### PR TITLE
Dark-mode logo fix and agent-facing docs

### DIFF
--- a/AGENT-DEPLOY.md
+++ b/AGENT-DEPLOY.md
@@ -1,0 +1,136 @@
+# Deployment Guide for Agents
+
+Read this first if you are an AI coding agent (Claude Code, Codex, Cursor,
+Aider, etc.) and you have been asked to build, run, or package Vibe Bar
+locally. It is intentionally short and command-oriented.
+
+## What Vibe Bar is
+
+A native macOS menu-bar app for Codex and Claude Code users. Pure Swift
+package, no Xcode workspace required. The package produces:
+
+- `VibeBar` — executable target, the actual app binary.
+- `VibeBarApp` — AppKit/SwiftUI menu-bar UI module.
+- `VibeBarCore` — testable library for parsers, storage, privacy helpers,
+  cost/usage logic.
+- `VibeBarCoreTests` — `swift test` target.
+
+There is no installer and no notarized release in this repo. Distribution is
+"build from source, ad-hoc sign, run locally."
+
+## Prerequisites
+
+- macOS 26 (Tahoe) or newer.
+- Xcode 26 with the Swift 6.2 toolchain installed (`xcode-select -p` should
+  point at a working Xcode, not just CommandLineTools).
+- `swift --version` should report 6.2 or higher.
+- `git`, `codesign`, and `gh` (only needed if you also open a PR).
+
+You do **not** need an Apple Developer account. The packaging script ad-hoc
+signs the bundle so it runs on the local machine.
+
+## Build, package, run
+
+The canonical end-to-end sequence:
+
+```sh
+swift test                    # ~90 unit tests, must all pass
+./Scripts/build_app.sh        # default target = release
+open ".build/Vibe Bar.app"
+```
+
+The script accepts an explicit configuration:
+
+```sh
+./Scripts/build_app.sh debug      # faster compile, slower runtime
+./Scripts/build_app.sh release    # what users get
+```
+
+It builds the SwiftPM executable, assembles `.build/Vibe Bar.app`, copies
+`Resources/Info.plist` and `Resources/AppIcon.icns`, embeds the entitlements
+in `Resources/VibeBar.entitlements`, then runs `codesign --sign -` against
+the bundle.
+
+If you only need a fast compile-check (no bundle, no signing):
+
+```sh
+swift build
+```
+
+## Verifying a build
+
+After packaging, the bundle should report the expected entitlements:
+
+```sh
+codesign -d --entitlements - ".build/Vibe Bar.app"
+```
+
+Expected entitlements include the app sandbox, network client access, and
+the home-relative-path entries the app needs to read CLI session logs. If
+any of those go missing, something in `Resources/VibeBar.entitlements` or
+`Scripts/build_app.sh` regressed.
+
+## Running tests
+
+```sh
+swift test
+```
+
+Tests cover JSONL scanning, pricing, settings, privacy persistence, the
+parsers, and small UI helpers. Add new tests under
+`Tests/VibeBarCoreTests/` next to the area you changed. UI code in
+`VibeBarApp` is mostly not unit-tested; manual smoke testing is fine for
+SwiftUI tweaks but log what you tested.
+
+## Local runtime state (where the app writes)
+
+Vibe Bar persists derived data under the user's home directory:
+
+```text
+~/.vibebar/
+├── settings.json
+├── quotas/
+├── cost_snapshots/
+├── scan_cache/
+├── service_status.json
+├── cost_history.json
+└── mini_window_geometry.json
+```
+
+If you are debugging weird behavior, that directory is the place to look.
+Deleting it resets the app to first-run state. Keychain stores Claude
+session cookies and the resolved Claude organization ID — those are not in
+`~/.vibebar/`.
+
+The app reads (never writes) Codex and Claude CLI credential files and
+their session JSONL logs. Treat those as read-only inputs.
+
+## Common build/run failures
+
+- **`error: unable to find Xcode-select`** — Xcode isn't installed or
+  `xcode-select` points at CommandLineTools. Run
+  `sudo xcode-select -s /Applications/Xcode.app`.
+- **`Vibe Bar.app is damaged and can't be opened`** — Gatekeeper rejected
+  the ad-hoc signature. Right-click → Open the first time, or
+  `xattr -d com.apple.quarantine ".build/Vibe Bar.app"`.
+- **`The application can't be opened because the macOS version is too old`**
+  — the deployment target is macOS 26. Older systems are not supported.
+- **`swift test` failures referencing fixtures** — fixtures live under
+  `Tests/VibeBarCoreTests/Fixtures/`. They use `/Users/example/...` paths
+  on purpose; do not "fix" them to your own home path.
+
+## What you should not change without explicit instruction
+
+- The license. AGPL-3.0-only is a board decision, not a code style choice.
+- The bundle ID `com.astroqore.VibeBar`.
+- The sandbox state in `Resources/VibeBar.entitlements`. If a file path
+  needs new access, add a narrow temporary exception, do not drop the
+  sandbox.
+- The persistence root `~/.vibebar/`. New persistent state goes through
+  `VibeBarLocalStore`.
+
+## When in doubt
+
+`README.md` and `CONTRIBUTING.md` are the human-facing references. This
+file is the agent-facing distillation of them. If they conflict, the
+human-facing docs win and this file should be updated.

--- a/AGENT-PR.md
+++ b/AGENT-PR.md
@@ -1,0 +1,162 @@
+# Pull Request Guide for Agents
+
+Read this if you are an AI coding agent (Claude Code, Codex, Cursor, Aider,
+etc.) and you have been asked to contribute changes back to Vibe Bar via a
+pull request. Pair this with [AGENT-DEPLOY.md](AGENT-DEPLOY.md) for the
+build commands and with [CONTRIBUTING.md](CONTRIBUTING.md) for the
+human-facing version of the same rules.
+
+## Repository
+
+- Upstream: `AstroQore/vibe-bar` on GitHub.
+- Default branch: `main`.
+- License: AGPL-3.0-only. Any contribution is licensed under AGPL-3.0.
+
+## End-to-end PR workflow
+
+```sh
+# 1. Branch from main
+git checkout main
+git pull --ff-only
+git checkout -b <short-topic-branch-name>
+
+# 2. Make your change. Keep edits scoped to the topic.
+
+# 3. Verify locally — all of these must pass before pushing.
+swift build
+swift test
+./Scripts/build_app.sh release
+codesign -d --entitlements - ".build/Vibe Bar.app"
+
+# 4. Commit with your own identity.
+git add <files>
+git commit -m "<imperative subject line>"
+
+# 5. Push the branch.
+git push -u origin <short-topic-branch-name>
+
+# 6. Open the PR.
+gh pr create --base main \
+  --title "<imperative subject line>" \
+  --body  "$(cat <<'EOF'
+## Summary
+- <one-line bullet>
+- <another bullet>
+
+## Test plan
+- [ ] swift test
+- [ ] ./Scripts/build_app.sh release
+- [ ] manual smoke test (describe what you clicked / observed)
+EOF
+)"
+```
+
+## Commit identity
+
+Use your own git identity. There is no shared maintainer alias.
+
+If you do not want your personal email in the public log, configure
+GitHub's privacy email (`<id>+<login>@users.noreply.github.com`) for this
+repo only:
+
+```sh
+git config --local user.name  "Your GitHub Name"
+git config --local user.email "<id>+<login>@users.noreply.github.com"
+```
+
+`Co-Authored-By:` trailers are welcome when more than one human or agent
+contributed materially to a commit.
+
+## Commit message style
+
+Match what `git log` shows on `main`:
+
+- Subject line is imperative, ≤ 70 characters, no trailing period.
+- No type prefixes (`feat:`, `fix:`, `chore:`). Just write the change.
+- Body wraps at ~72 chars, explains *why* and any non-obvious *how*. Skip
+  the body for trivial changes.
+- Mention `Co-Authored-By:` trailers at the end if you collaborated.
+
+Example:
+
+```
+Tint provider brand icons via SwiftUI color scheme
+
+ProviderBrandIconView passed NSColor.labelColor without an NSAppearance,
+so the dynamic color resolved against whatever appearance happened to
+be current when the off-screen NSImage rendered. Forward the matching
+.darkAqua / .aqua appearance so labelColor resolves correctly.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+```
+
+## Required local checks before pushing
+
+| Check                                                         | Why it must pass                                  |
+| ------------------------------------------------------------- | ------------------------------------------------- |
+| `swift build`                                                 | Compiles cleanly under Swift 6.2 / macOS 26.      |
+| `swift test`                                                  | Core logic regressions are blocked.               |
+| `./Scripts/build_app.sh release`                              | The user-facing bundle still assembles.           |
+| `codesign -d --entitlements - ".build/Vibe Bar.app"`          | Sandbox + network + home-relative entitlements still present. |
+
+If you cannot run one of these (no macOS host, no Xcode, etc.), say so
+explicitly in the PR description instead of skipping the checkbox.
+
+## What is not allowed in commits
+
+These are source-content rules. They apply regardless of who you commit
+as.
+
+- Real OAuth tokens, real session cookies, real organization UUIDs, real
+  account IDs, real email addresses anywhere in source, tests, fixtures,
+  or log strings.
+- `/Users/<name>` paths or machine hostnames in fixtures, examples, or
+  output. Use `/Users/example/...` and synthetic JWTs.
+- Logging raw credentials or email addresses. Route through
+  `SafeLog.sanitize` and `EmailMasker`.
+- Dropping the app sandbox in `Resources/VibeBar.entitlements`. If you
+  need new file access, add a narrow temporary exception.
+- Folding `mini_window_geometry.json` back into `AppSettings`. The split
+  is intentional — every settings write fans out to every Combine
+  subscriber.
+
+## Code organization (so your PR lands in the right place)
+
+- `Sources/VibeBarCore/` — heavy logic. Parsers, storage, privacy
+  helpers, adapters, cost/usage scanners, pricing. Pure Swift, testable,
+  no AppKit/SwiftUI imports.
+- `Sources/VibeBarApp/` — AppKit/SwiftUI glue. Status item, popover,
+  mini window, settings UI. Thin layer over Core.
+- `Tests/VibeBarCoreTests/` — `swift test` target. Add a test next to the
+  area you changed.
+- `Resources/` — `Info.plist`, entitlements, app icon, README assets.
+- `Scripts/build_app.sh` — release packaging.
+
+If your change adds heavy logic in `VibeBarApp`, that's usually a sign it
+should live in `VibeBarCore` instead.
+
+## Implementation rules that have bitten people
+
+- **JSONL scanning must be O(n).** See
+  `CostUsageScanner.forEachJSONLLine`. Use a moving cursor, not
+  `removeSubrange`.
+- **Avoid `TimelineView(.periodic(...))` in deep view trees** that may be
+  eagerly instantiated. Scope live timers to the visible surface.
+- **New persistent state** goes through `VibeBarLocalStore` and lives
+  under `~/.vibebar/`. Do not write to `~/` directly from new code.
+- **Bundle ID** is `com.astroqore.VibeBar`. For a release, bump
+  `CFBundleShortVersionString` and `CFBundleVersion` in
+  `Resources/Info.plist`.
+
+## After the PR is open
+
+- CI may run additional checks. Address any failures.
+- A maintainer may request changes. Push follow-up commits to the same
+  branch — do not force-push unless asked, and never force-push `main`.
+- Squash vs. merge is the maintainer's call; structure your commits so
+  either works.
+
+## When in doubt
+
+`CONTRIBUTING.md` is the human-facing version of this guide and wins on
+any conflict. Update this file if you find it has drifted.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,16 +6,18 @@ private, and fast.
 
 ## Commit Identity
 
-Direct commits in this repository must use the shared maintainer identity:
+Use your own git identity — there is no shared maintainer alias. If you want
+to keep your personal email out of the public log, configure GitHub's
+privacy email (`<id>+<login>@users.noreply.github.com`) for this repo:
 
 ```sh
-git config --local user.name  "Vibe Bar Maintainers"
-git config --local user.email "noreply@github.com"
+git config --local user.name  "Your GitHub Name"
+git config --local user.email "<id>+<login>@users.noreply.github.com"
 ```
 
-Use `Co-Authored-By:` trailers in commit messages if you want explicit personal
-attribution. Do not publish personal emails, machine hostnames, internal handles,
-or local user paths through commit metadata or fixtures.
+Do not commit personal emails, machine hostnames, internal handles, or
+`/Users/<name>` paths inside source files, fixtures, or logs — that's a
+source-content rule, not a commit-author rule.
 
 ## Development Setup
 

--- a/Sources/VibeBarApp/ProviderBrandIcon.swift
+++ b/Sources/VibeBarApp/ProviderBrandIcon.swift
@@ -177,6 +177,7 @@ enum ProviderBrandIcon {
 }
 
 struct ProviderBrandIconView: View {
+    @Environment(\.colorScheme) private var colorScheme
     let kind: MenuBarItemKind
     var size: CGFloat = 16
 
@@ -185,7 +186,8 @@ struct ProviderBrandIconView: View {
             if let image = ProviderBrandIcon.image(
                 for: kind,
                 size: NSSize(width: size, height: size),
-                tint: NSColor.labelColor
+                tint: NSColor.labelColor,
+                appearance: nsAppearance(for: colorScheme)
             ) {
                 Image(nsImage: image)
                     .resizable()
@@ -199,6 +201,14 @@ struct ProviderBrandIconView: View {
         .frame(width: size, height: size)
         .foregroundStyle(.primary)
         .accessibilityHidden(true)
+    }
+
+    private func nsAppearance(for colorScheme: ColorScheme) -> NSAppearance? {
+        switch colorScheme {
+        case .dark:  return NSAppearance(named: .darkAqua)
+        case .light: return NSAppearance(named: .aqua)
+        @unknown default: return nil
+        }
     }
 }
 

--- a/Sources/VibeBarCore/Credentials/ClaudeCredentialReader.swift
+++ b/Sources/VibeBarCore/Credentials/ClaudeCredentialReader.swift
@@ -59,7 +59,7 @@ public enum ClaudeCredentialReader {
     }
 
     private static func readFromCredentialsJSON() throws -> ClaudeCredential {
-        let url = FileManager.default.homeDirectoryForCurrentUser
+        let url = RealHomeDirectory.url
             .appendingPathComponent(".claude/.credentials.json")
         guard FileManager.default.fileExists(atPath: url.path) else {
             throw QuotaError.noCredential

--- a/Sources/VibeBarCore/Credentials/CodexCredentialReader.swift
+++ b/Sources/VibeBarCore/Credentials/CodexCredentialReader.swift
@@ -85,7 +85,7 @@ public enum CodexCredentialReader {
     }
 
     private static func readFromAuthJSON() throws -> CodexCredential {
-        let url = FileManager.default.homeDirectoryForCurrentUser
+        let url = RealHomeDirectory.url
             .appendingPathComponent(".codex/auth.json")
         guard FileManager.default.fileExists(atPath: url.path) else {
             throw QuotaError.noCredential

--- a/Sources/VibeBarCore/Services/CostUsageScanner.swift
+++ b/Sources/VibeBarCore/Services/CostUsageScanner.swift
@@ -15,7 +15,7 @@ import Foundation
 public enum CostUsageScanner {
     public static func scan(
         tool: ToolType,
-        homeDirectory: String = NSHomeDirectory(),
+        homeDirectory: String = RealHomeDirectory.path,
         now: Date = Date(),
         retentionDays: Int? = nil
     ) async -> CostSnapshot? {

--- a/Sources/VibeBarCore/Services/CostUsageService.swift
+++ b/Sources/VibeBarCore/Services/CostUsageService.swift
@@ -26,7 +26,7 @@ public final class CostUsageService: ObservableObject {
     private let costDataSettingsProvider: () -> CostDataSettings
 
     public init(
-        homeDirectory: String = NSHomeDirectory(),
+        homeDirectory: String = RealHomeDirectory.path,
         mockProvider: @escaping () -> Bool = { false },
         costDataSettingsProvider: @escaping () -> CostDataSettings = { .default }
     ) {

--- a/Sources/VibeBarCore/Storage/VibeBarLocalStore.swift
+++ b/Sources/VibeBarCore/Storage/VibeBarLocalStore.swift
@@ -4,7 +4,7 @@ public enum VibeBarLocalStore {
     public static let directoryName = ".vibebar"
 
     public static var baseDirectory: URL {
-        FileManager.default.homeDirectoryForCurrentUser
+        RealHomeDirectory.url
             .appendingPathComponent(directoryName, isDirectory: true)
     }
 

--- a/Sources/VibeBarCore/Utilities/RealHomeDirectory.swift
+++ b/Sources/VibeBarCore/Utilities/RealHomeDirectory.swift
@@ -1,0 +1,36 @@
+import Darwin
+import Foundation
+
+/// Resolves the *real* user home directory, even when the app is sandboxed.
+///
+/// Inside the macOS app sandbox, every Foundation "home" API returns the
+/// container path (`~/Library/Containers/<bundle-id>/Data`):
+/// `NSHomeDirectory()`, `FileManager.default.homeDirectoryForCurrentUser`,
+/// and — despite Apple's docs implying otherwise — `NSHomeDirectoryForUser`.
+/// The `HOME` environment variable is also rewritten to the container.
+/// Only `getpwuid(getuid()).pw_dir` is left untouched, because passwd
+/// lookups go through an XPC service that does not honor the sandbox
+/// home redirect.
+///
+/// The temp-exception `home-relative-path` entitlements in
+/// `Resources/VibeBar.entitlements` grant *permission* to read/write
+/// real-home subpaths like `~/.codex/`, `~/.claude/`, `~/.config/claude/`,
+/// and `~/.vibebar/`. They do not redirect path resolution — the code
+/// has to pass the real absolute path to Foundation. This helper is the
+/// single place that knows how.
+///
+/// See AGENTS.md → "Sandbox & home directory" for the full rule and the
+/// diagnostic for spotting the regression.
+public enum RealHomeDirectory {
+    public static var path: String {
+        if let pw = getpwuid(getuid()) {
+            let dir = String(cString: pw.pointee.pw_dir)
+            if !dir.isEmpty { return dir }
+        }
+        return NSHomeDirectory()
+    }
+
+    public static var url: URL {
+        URL(fileURLWithPath: path, isDirectory: true)
+    }
+}


### PR DESCRIPTION
## Summary

Four changes from one session:

- **Fix:** `ProviderBrandIconView` rendered Codex/Claude logos with a hard-coded `NSColor.labelColor` tint but no `NSAppearance`, so the dynamic color resolved against whatever `NSAppearance.currentDrawing` happened to be when the off-screen NSImage drew. In dark mode the icons baked at near-black against the dark popover. Now the view reads `@Environment(\.colorScheme)` and forwards the matching `.darkAqua` / `.aqua` appearance into `image(for:size:tint:appearance:)`. The status-bar code path is unaffected — it still uses the template-image branch.
- **Fix:** the sandboxed app was reading the container's home (`~/Library/Containers/com.astroqore.VibeBar/Data/.codex/...`) instead of the real user home, leaving Codex/Claude data blank even though the temp-exception `home-relative-path` entitlements grant access. Add `VibeBarCore/Utilities/RealHomeDirectory` (uses `NSHomeDirectoryForUser(NSUserName())`) and route `CodexCredentialReader`, `ClaudeCredentialReader`, `CostUsageService`, `CostUsageScanner`, and `VibeBarLocalStore.baseDirectory` through it. Tests still pass `homeDirectory:` explicitly so they're unaffected.
- **Docs:** drop the forced \"Vibe Bar Maintainers <noreply@github.com>\" rule from `CONTRIBUTING.md`. Contributors now use their own git identity (with the GitHub privacy email if they want to keep their personal mailbox out of the public log). The privacy rule that actually mattered — no personal emails or `/Users/<name>` paths inside source content — is now stated as a source-content rule, not a committer rule.
- **Docs:** add `AGENT-DEPLOY.md` and `AGENT-PR.md` — short, command-oriented guides distilled from `README.md`, `CONTRIBUTING.md`, and `Scripts/build_app.sh`, intended for AI coding agents (Claude Code, Codex, Cursor, etc.) that are asked to build/run the project or open a PR against it.

## Test plan

- [x] `swift build`
- [x] `swift test` — 90/90 pass
- [x] `./Scripts/build_app.sh release` — bundle assembles and ad-hoc signs
- [x] `codesign -d --entitlements - ".build/Vibe Bar.app"` — sandbox + network.client + the four home-relative-path entitlements still present
- [ ] Manual smoke test: open the rebuilt `.build/Vibe Bar.app` in dark mode and confirm Codex / Claude data loads (logo color also correct). Reviewer to confirm visually.

## After merging

The sandbox container at `~/Library/Containers/com.astroqore.VibeBar/Data/.vibebar/` is no longer the live state directory — the app now reads and writes the real `~/.vibebar/`. The container's stale copy can be deleted; nothing references it.