### PR TITLE
Promote agent guides in README and add Chinese mirror

### DIFF
--- a/AGENT-DEPLOY.md
+++ b/AGENT-DEPLOY.md
@@ -2,7 +2,9 @@
 
 Read this first if you are an AI coding agent (Claude Code, Codex, Cursor,
 Aider, etc.) and you have been asked to build, run, or package Vibe Bar
-locally. It is intentionally short and command-oriented.
+locally. This document is **self-contained**: an agent with no prior
+knowledge of this project should be able to follow it top-to-bottom and
+end with a working app.
 
 ## What Vibe Bar is
 
@@ -15,41 +17,169 @@ package, no Xcode workspace required. The package produces:
   cost/usage logic.
 - `VibeBarCoreTests` — `swift test` target.
 
-There is no installer and no notarized release in this repo. Distribution is
-"build from source, ad-hoc sign, run locally."
+There is no installer and no notarized release in this repo. Distribution
+is "build from source, ad-hoc sign, run locally."
 
 ## Prerequisites
 
-- macOS 26 (Tahoe) or newer.
-- Xcode 26 with the Swift 6.2 toolchain installed (`xcode-select -p` should
-  point at a working Xcode, not just CommandLineTools).
-- `swift --version` should report 6.2 or higher.
-- `git`, `codesign`, and `gh` (only needed if you also open a PR).
+All of the following must be true on the target Mac before you start:
+
+- **macOS 26 (Tahoe) or newer.** Check with `sw_vers -productVersion`.
+- **Xcode 26 with the Swift 6.2 toolchain installed.** Check with:
+  - `xcode-select -p` — must point at a working Xcode app, not just
+    `CommandLineTools`. If it points at CommandLineTools, fix with
+    `sudo xcode-select -s /Applications/Xcode.app`.
+  - `swift --version` — must report Swift 6.2 or newer.
+- **`git`, `codesign`, and (only if you will also open a PR) `gh`** all
+  available on `PATH`.
 
 You do **not** need an Apple Developer account. The packaging script ad-hoc
 signs the bundle so it runs on the local machine.
 
-## Build, package, run
+## Build, package, and install (zero-to-running)
 
-The canonical end-to-end sequence:
+Follow these steps in order. An agent with no prior context should be
+able to execute them end-to-end and finish with a running, optionally
+installed Vibe Bar. If anything fails, see **Common build/run failures**
+below.
+
+### 1. Get the source
+
+If the repository is not already on disk:
 
 ```sh
-swift test                    # ~90 unit tests, must all pass
-./Scripts/build_app.sh        # default target = release
+git clone https://github.com/AstroQore/vibe-bar.git
+cd vibe-bar
+```
+
+If you already have a clone, switch into it and confirm it is on the
+branch you intend to build:
+
+```sh
+cd /path/to/vibe-bar
+git status
+git rev-parse --abbrev-ref HEAD
+```
+
+### 2. Verify the toolchain
+
+```sh
+sw_vers -productVersion        # must be 26.x or newer
+xcode-select -p                # must point at /Applications/Xcode.app/...
+swift --version                # must be 6.2.x or newer
+```
+
+If any of these are wrong, stop and tell the user — the build will fail
+later in a more confusing way.
+
+### 3. Run unit tests
+
+```sh
+swift test
+```
+
+About 90 tests run; all must pass. If any fail, stop and surface the
+failure to the user before continuing. Packaging on top of broken core
+logic produces a broken app.
+
+### 4. Build and package the `.app` bundle
+
+```sh
+./Scripts/build_app.sh           # default configuration = release
+```
+
+Or pick a configuration explicitly:
+
+```sh
+./Scripts/build_app.sh debug     # faster compile, slower runtime
+./Scripts/build_app.sh release   # what end users get
+```
+
+What the script does (so you can recognize each phase in its output):
+
+1. Runs `swift build -c <config>`.
+2. Resolves the executable path with
+   `swift build -c <config> --show-bin-path`.
+3. Deletes any old `.build/Vibe Bar.app` and creates a fresh bundle
+   skeleton at `.build/Vibe Bar.app/Contents/{MacOS,Resources}`.
+4. Copies the freshly built `VibeBar` executable into
+   `Contents/MacOS/VibeBar`.
+5. Copies `Resources/Info.plist` and `Resources/AppIcon.icns` into the
+   bundle.
+6. Writes `Contents/PkgInfo`.
+7. Runs `codesign --force --deep --sign - --entitlements
+   Resources/VibeBar.entitlements ".build/Vibe Bar.app"`.
+
+The output bundle is `.build/Vibe Bar.app` (the bundle name has a literal
+space).
+
+### 5. Verify the bundle's entitlements
+
+```sh
+codesign -d --entitlements - ".build/Vibe Bar.app"
+```
+
+The output must include all of:
+
+- `com.apple.security.app-sandbox`
+- `com.apple.security.network.client`
+- `com.apple.security.temporary-exception.files.home-relative-path.read-only`
+  with at least `/.codex/`, `/.claude/`, `/.config/claude/`.
+- `com.apple.security.temporary-exception.files.home-relative-path.read-write`
+  with at least `/.vibebar/`.
+
+If anything is missing, something in `Resources/VibeBar.entitlements` or
+`Scripts/build_app.sh` has regressed. Stop and surface the regression
+rather than shipping a broken bundle.
+
+### 6. Launch the app for a smoke test
+
+```sh
 open ".build/Vibe Bar.app"
 ```
 
-The script accepts an explicit configuration:
+A menu-bar item should appear on the right-hand side of the macOS menu
+bar. If macOS reports the bundle as damaged, see **Common build/run
+failures**.
+
+### 7. Offer to install into `/Applications`
+
+After step 6 succeeds, **ask the user whether to install Vibe Bar into
+the macOS Applications folder.** Do not move the bundle without asking —
+the user may prefer to keep the build output inside the repo (for
+example, while iterating on the build).
+
+A suggested prompt:
+
+> Build succeeded and Vibe Bar launched from `.build/Vibe Bar.app`. Want
+> me to install it to `/Applications/Vibe Bar.app` so it shows up in
+> Launchpad and Spotlight?
+
+If the user agrees, install with:
 
 ```sh
-./Scripts/build_app.sh debug      # faster compile, slower runtime
-./Scripts/build_app.sh release    # what users get
+# Quit any running instance first
+osascript -e 'tell application "Vibe Bar" to quit' 2>/dev/null || true
+
+# Remove any previously installed copy
+rm -rf "/Applications/Vibe Bar.app"
+
+# Move the freshly built bundle into /Applications
+mv ".build/Vibe Bar.app" "/Applications/Vibe Bar.app"
+
+# Launch from its new home
+open "/Applications/Vibe Bar.app"
 ```
 
-It builds the SwiftPM executable, assembles `.build/Vibe Bar.app`, copies
-`Resources/Info.plist` and `Resources/AppIcon.icns`, embeds the entitlements
-in `Resources/VibeBar.entitlements`, then runs `codesign --sign -` against
-the bundle.
+If the user declines, leave the bundle at `.build/Vibe Bar.app` and tell
+them how to launch it from there
+(`open ".build/Vibe Bar.app"`).
+
+This step is macOS-only (Vibe Bar does not build for any other
+platform), so `/Applications` is always the right destination when the
+user says yes.
+
+## Quick reference
 
 If you only need a fast compile-check (no bundle, no signing):
 
@@ -57,18 +187,12 @@ If you only need a fast compile-check (no bundle, no signing):
 swift build
 ```
 
-## Verifying a build
-
-After packaging, the bundle should report the expected entitlements:
+If you only want to re-verify an existing bundle:
 
 ```sh
 codesign -d --entitlements - ".build/Vibe Bar.app"
+codesign --verify --deep --strict ".build/Vibe Bar.app"
 ```
-
-Expected entitlements include the app sandbox, network client access, and
-the home-relative-path entries the app needs to read CLI session logs. If
-any of those go missing, something in `Resources/VibeBar.entitlements` or
-`Scripts/build_app.sh` regressed.
 
 ## Running tests
 
@@ -97,31 +221,38 @@ Vibe Bar persists derived data under the user's home directory:
 └── mini_window_geometry.json
 ```
 
-If you are debugging weird behavior, that directory is the place to look.
-Deleting it resets the app to first-run state. Keychain stores Claude
-session cookies and the resolved Claude organization ID — those are not in
-`~/.vibebar/`.
+If you are debugging weird behavior, that directory is the place to
+look. Deleting it resets the app to first-run state. Keychain stores
+Claude session cookies and the resolved Claude organization ID — those
+are not in `~/.vibebar/`.
 
 The app reads (never writes) Codex and Claude CLI credential files and
 their session JSONL logs. Treat those as read-only inputs.
 
 ## Common build/run failures
 
-- **`error: unable to find Xcode-select`** — Xcode isn't installed or
+- **`error: unable to find Xcode-select`** — Xcode is not installed or
   `xcode-select` points at CommandLineTools. Run
   `sudo xcode-select -s /Applications/Xcode.app`.
-- **`Vibe Bar.app is damaged and can't be opened`** — Gatekeeper rejected
-  the ad-hoc signature. Right-click → Open the first time, or
+- **`Vibe Bar.app is damaged and can't be opened`** — Gatekeeper
+  rejected the ad-hoc signature. Right-click → Open the first time, or
   `xattr -d com.apple.quarantine ".build/Vibe Bar.app"`.
-- **`The application can't be opened because the macOS version is too old`**
-  — the deployment target is macOS 26. Older systems are not supported.
+- **`The application can't be opened because the macOS version is too
+  old`** — the deployment target is macOS 26. Older systems are not
+  supported.
 - **`swift test` failures referencing fixtures** — fixtures live under
-  `Tests/VibeBarCoreTests/Fixtures/`. They use `/Users/example/...` paths
-  on purpose; do not "fix" them to your own home path.
+  `Tests/VibeBarCoreTests/Fixtures/`. They use `/Users/example/...`
+  paths on purpose; do not "fix" them to your own home path.
+- **The `.app` launches but Codex/Claude show as logged out and all
+  numbers are zero** — the build is reading from the sandbox container
+  home instead of the real user home. See `AGENTS.md` →
+  "Sandbox & home directory" for the rule and the grep recipe to find
+  the offending call site.
 
 ## What you should not change without explicit instruction
 
-- The license. AGPL-3.0-only is a board decision, not a code style choice.
+- The license. AGPL-3.0-only is a board decision, not a code style
+  choice.
 - The bundle ID `com.astroqore.VibeBar`.
 - The sandbox state in `Resources/VibeBar.entitlements`. If a file path
   needs new access, add a narrow temporary exception, do not drop the

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Vibe Bar
 
+**Read this in:** **English** · [中文](README.zh-CN.md)
+
 Vibe Bar is a native macOS menu-bar app for Codex and Claude Code users who
 want subscription quota, usage pace, local token cost, and service status in one
 quiet desktop surface. It is built for developers who run OpenAI/Codex and
@@ -9,6 +11,20 @@ without opening multiple dashboards.
 <p align="center">
   <img src="Resources/README/overview-dashboard.png" alt="Vibe Bar overview dashboard" width="760">
 </p>
+
+> ### Working with an AI coding agent?
+>
+> Two zero-context guides are written for AI agents (Claude Code, Codex,
+> Cursor, Aider, …). Hand either one to your agent and it can take over
+> from there:
+>
+> - **[AGENT-DEPLOY.md](AGENT-DEPLOY.md)** — clone, build, package, smoke-test,
+>   and (with your confirmation) install into `/Applications`.
+> - **[AGENT-PR.md](AGENT-PR.md)** — branch, verify locally, and open a
+>   pull request that matches this repo's conventions.
+>
+> Both files are designed to be self-contained — an agent with no prior
+> knowledge of the project can follow them top-to-bottom.
 
 ## Highlights
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,0 +1,159 @@
+# Vibe Bar
+
+**Read this in:** [English](README.md) · **中文**
+
+Vibe Bar 是一款面向 Codex 和 Claude Code 用户的原生 macOS 菜单栏应用，
+把订阅配额、用量节奏、本地 Token 成本和服务状态收拢到一个安静的桌面入口。
+它专为同时使用 OpenAI/Codex 与 Anthropic/Claude Code 的开发者设计，
+让关键数据不再需要打开多个面板就能一眼看到。
+
+<p align="center">
+  <img src="Resources/README/overview-dashboard.png" alt="Vibe Bar overview dashboard" width="760">
+</p>
+
+> ### 在使用 AI 编码 Agent？
+>
+> 仓库内为 AI Agent（Claude Code、Codex、Cursor、Aider 等）准备了两份
+> **零背景**说明文档。把其中任意一份交给你的 Agent，它就能自行接管：
+>
+> - **[AGENT-DEPLOY.md](AGENT-DEPLOY.md)** —— 拉取代码、构建、打包、冒烟测试，
+>   并在征得你同意后安装到 `/Applications`。
+> - **[AGENT-PR.md](AGENT-PR.md)** —— 切分支、本地校验，并按本仓库约定提交
+>   Pull Request。
+>
+> 两份文档都设计为自包含 —— 即便 Agent 对项目毫无背景，也能逐步跟着完成。
+
+## 功能亮点
+
+- 菜单栏配额指示器，分别覆盖 OpenAI/Codex 与 Anthropic/Claude Code。
+- 总览仪表盘：配额节奏、状态、成本历史、Token 累计。
+- 服务商详情页：订阅利用率、模型排行、热力图、小时燃烧速率、实时服务状态。
+- 迷你浮窗：常规与紧凑两种布局。
+- 本地优先的成本统计，全部来自 CLI 会话日志。
+- 隐私控制：可设置保留期限、清除衍生成本数据，或直接关闭成本历史持久化。
+
+## 适用人群
+
+Vibe Bar 关注本仓库唯一在意的两类编码 Agent 工作流：
+
+- **Codex/OpenAI 用量**：订阅时间窗、重置时间、服务状态，以及本地 Codex 会话
+  的成本/Token 历史。
+- **Claude Code/Anthropic 用量**：配额/Routine 预算可视化、服务状态，以及
+  本地 Claude Code 会话的成本/Token 历史。
+- **混合日常**：菜单栏与迷你窗的紧凑视图，让你不用切换厂商面板就能对比节奏、
+  剩余配额和近期开销。
+
+## 截图
+
+### 服务商详情
+
+<p align="center">
+  <img src="Resources/README/openai-detail.png" alt="OpenAI detail page" width="420">
+  <img src="Resources/README/claude-detail.png" alt="Claude detail page" width="420">
+</p>
+
+### 迷你窗口
+
+<p align="center">
+  <img src="Resources/README/mini-window-regular.png" alt="Regular mini window" width="520">
+</p>
+
+<p align="center">
+  <img src="Resources/README/mini-window-compact.png" alt="Compact mini window" width="180">
+</p>
+
+### 设置
+
+<p align="center">
+  <img src="Resources/README/settings-mini-window.png" alt="Mini window settings" width="420">
+</p>
+
+## 它能展示什么
+
+Vibe Bar 把实时配额和本地用量分析合并到同一处：
+
+- 当前配额时间窗、重置时间、剩余百分比和节奏标记。
+- 今日、近 7 天、近 30 天和总计的成本数字。
+- Top 模型用量与模型排名。
+- 每日成本历史，以及当日的小时燃烧速率。
+- 类似 GitHub 贡献图的年度用量热力图。
+- OpenAI 与 Anthropic 服务状态。
+
+菜单栏图标也支持右键上下文菜单，包含完整用量行、服务商状态、刷新、迷你窗、
+设置和退出操作。
+
+## 隐私与本地数据
+
+运行时状态保存在当前用户的家目录下：
+
+```text
+~/.vibebar/
+├── settings.json
+├── quotas/
+├── cost_snapshots/
+├── scan_cache/
+├── service_status.json
+└── cost_history.json
+```
+
+Vibe Bar 会读取本地 CLI 凭据和 Claude/Codex 会话 JSONL 日志，但**不会**写入
+这些 CLI 凭据或会话文件。衍生出的成本和 Token 历史只保留在你的 Mac 上，
+除非你自己选择导出或公开。
+
+Claude 网页 Cookie 会被收窄到必要的 `sessionKey`，统一存放在 Keychain 里；
+解析得到的 Claude 组织 ID 也存在 Keychain。`~/.vibebar/cookies/` 下的旧版
+明文 Cookie 文件会在首次读取时迁移到 Keychain 并被清理。
+
+成本历史保留期限可在「设置」中配置，默认是「永久」。隐私模式会清空本地成本
+历史、快照和扫描缓存，并在启用期间不再把成本数据写入磁盘。「Cost Data」设置
+还提供手动「Clear Cost Data」操作。
+
+## 系统要求
+
+- macOS 26 或更高版本。
+- Xcode 26 / Swift 6.2 工具链。
+- 想看实时配额，需要本地 OpenAI/Codex 和/或 Claude 凭据。
+- 想看成本和 Token 历史，需要本地 CLI 会话日志。
+
+## 从源码构建
+
+```bash
+swift test
+./Scripts/build_app.sh
+open ".build/Vibe Bar.app"
+```
+
+SwiftPM 的可执行产物名是 `VibeBar`。打包脚本会构建可执行文件、生成
+`.build/Vibe Bar.app`、复制 App 图标和 Info.plist，并对 Bundle 做 ad-hoc
+签名以便本地运行。
+
+Debug 构建：
+
+```bash
+./Scripts/build_app.sh debug
+```
+
+Release 构建：
+
+```bash
+./Scripts/build_app.sh release
+```
+
+## 开发说明
+
+- `Package.swift` 定义了 `VibeBar` 可执行目标和 `VibeBarCore` 库。
+- `Sources/VibeBarApp` 存放 SwiftUI/AppKit 菜单栏应用。
+- `Sources/VibeBarCore` 存放解析器、存储、隐私辅助器和用量计算逻辑。
+- `Scripts/build_app.sh` 负责生成并 ad-hoc 签名 App Bundle。
+- 打包时会把 `Resources/AppIcon.icns` 复制进 Bundle。
+- `swift test` 覆盖解析器、设置、计费、隐私持久化以及通用工具。
+
+## 项目状态
+
+Vibe Bar 处于早期公开发布阶段。围绕厂商 API、模型计费、打包流程和 macOS 设计
+细节会有较快的迭代节奏。
+
+## 许可证
+
+Vibe Bar 采用 GNU Affero General Public License v3.0 only（AGPL-3.0-only）
+许可。完整许可证文本见 [LICENSE](LICENSE)。


### PR DESCRIPTION
## Summary
- Add a callout panel near the top of `README.md` that surfaces the two agent-targeted guides (`AGENT-DEPLOY.md`, `AGENT-PR.md`) so anyone handing this repo to an AI coding agent sees them immediately.
- Rewrite `AGENT-DEPLOY.md` as a self-contained zero-context build guide: numbered steps from `git clone` through toolchain checks, `swift test`, `Scripts/build_app.sh`, entitlements verification, and a smoke launch — plus an explicit step that asks the user for permission before moving the bundle to `/Applications`.
- Add `README.zh-CN.md` as a Chinese mirror of the README. Both READMEs carry a small `English · 中文` language switcher; English remains the default landing.

## Why
- The deploy and PR guides were already in the repo (since e9fc75d) but invisible from the README, so they went unread when humans drove the workflow.
- The deploy guide previously assumed the agent already had the source and toolchain wired up; making it strictly self-contained means a fresh agent can run it end-to-end.
- The Chinese README serves Chinese-speaking users without burying English readers.

## Notes for the reviewer
- No code changes — docs only. `swift build` / `swift test` not re-run for this PR.
- `AGENT-PR.md` is unchanged. It already links to `AGENT-DEPLOY.md` for build commands; duplicating the detail there would have made them drift.
- The `/Applications` install step is gated on explicit user confirmation, in line with `AGENTS.md` and the safe-actions rules.

## Test plan
- [x] Visual check of `README.md` and `README.zh-CN.md` for broken links and switcher targets.
- [x] Confirm `[AGENT-DEPLOY.md](AGENT-DEPLOY.md)` / `[AGENT-PR.md](AGENT-PR.md)` resolve from both READMEs.
- [ ] Optional: have an AI agent execute `AGENT-DEPLOY.md` top-to-bottom on a clean checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)