### PR TITLE
Reflow Overview into a 2-column masonry with combined summary cards

### DIFF
--- a/Sources/VibeBarApp/Views/ColumnMasonryLayout.swift
+++ b/Sources/VibeBarApp/Views/ColumnMasonryLayout.swift
@@ -1,0 +1,101 @@
+import SwiftUI
+
+/// Two-column "shortest column wins" masonry. Used by the Overview to lay out
+/// cost cards plus the four combined summary cards (Model Ranking, Past Year,
+/// When You Use, Hourly Burn Rate) without one column ending up dramatically
+/// taller than the other.
+///
+/// Each column is the same width (`(totalWidth - spacing) / columns`). For
+/// each subview we measure the height it would take at that width, then place
+/// it in whichever column currently has the shortest stack. Ties always
+/// resolve to the leftmost shorter column, which keeps the layout
+/// deterministic across redraws.
+struct ColumnMasonryLayout: Layout {
+    var columns: Int = 2
+    var spacing: CGFloat = 12
+    /// The first `anchoredItems` subviews are pinned to columns 0…N-1 in
+    /// declaration order, regardless of column height. Everything after
+    /// fills whichever column is currently shortest. This lets the Overview
+    /// keep OpenAI Quota / Claude Quota locked to their respective columns
+    /// while the cost + summary cards below flow into the empty space under
+    /// whichever provider's quota came up shorter.
+    var anchoredItems: Int = 0
+
+    func sizeThatFits(
+        proposal: ProposedViewSize,
+        subviews: Subviews,
+        cache: inout Void
+    ) -> CGSize {
+        let totalWidth = proposal.width ?? 0
+        let columnWidth = columnWidth(for: totalWidth)
+        let placement = placements(for: subviews, columnWidth: columnWidth)
+        let totalHeight = placement.columnHeights.max() ?? 0
+        return CGSize(width: totalWidth, height: totalHeight)
+    }
+
+    func placeSubviews(
+        in bounds: CGRect,
+        proposal: ProposedViewSize,
+        subviews: Subviews,
+        cache: inout Void
+    ) {
+        let columnWidth = columnWidth(for: bounds.width)
+        let placement = placements(for: subviews, columnWidth: columnWidth)
+        for (index, slot) in placement.slots.enumerated() {
+            subviews[index].place(
+                at: CGPoint(x: bounds.minX + slot.x, y: bounds.minY + slot.y),
+                anchor: .topLeading,
+                proposal: ProposedViewSize(width: columnWidth, height: slot.height)
+            )
+        }
+    }
+
+    private struct Slot {
+        let x: CGFloat
+        let y: CGFloat
+        let height: CGFloat
+    }
+
+    private struct Placement {
+        let slots: [Slot]
+        let columnHeights: [CGFloat]
+    }
+
+    private func placements(for subviews: Subviews, columnWidth: CGFloat) -> Placement {
+        let columnCount = max(1, columns)
+        let anchorLimit = max(0, min(anchoredItems, columnCount))
+        var heights = Array(repeating: CGFloat(0), count: columnCount)
+        var slots: [Slot] = []
+        slots.reserveCapacity(subviews.count)
+        for (index, subview) in subviews.enumerated() {
+            let proposed = ProposedViewSize(width: columnWidth, height: nil)
+            let size = subview.sizeThatFits(proposed)
+            let column = index < anchorLimit ? index : shortestColumn(in: heights)
+            let needsLeadingSpacing = heights[column] > 0
+            let y = heights[column] + (needsLeadingSpacing ? spacing : 0)
+            let x = CGFloat(column) * (columnWidth + spacing)
+            slots.append(Slot(x: x, y: y, height: size.height))
+            heights[column] = y + size.height
+        }
+        return Placement(slots: slots, columnHeights: heights)
+    }
+
+    /// Leftmost column whose running height is the smallest. Ties prefer the
+    /// earlier index — important so re-runs of `sizeThatFits` and
+    /// `placeSubviews` agree on placement when several columns are at zero.
+    private func shortestColumn(in heights: [CGFloat]) -> Int {
+        var bestIndex = 0
+        var bestHeight = heights[0]
+        for index in 1..<heights.count where heights[index] < bestHeight {
+            bestHeight = heights[index]
+            bestIndex = index
+        }
+        return bestIndex
+    }
+
+    private func columnWidth(for totalWidth: CGFloat) -> CGFloat {
+        let columnCount = max(1, columns)
+        let totalSpacing = spacing * CGFloat(columnCount - 1)
+        return max(0, (totalWidth - totalSpacing) / CGFloat(columnCount))
+    }
+}

--- a/Sources/VibeBarApp/Views/ModelRankingList.swift
+++ b/Sources/VibeBarApp/Views/ModelRankingList.swift
@@ -9,42 +9,63 @@ import VibeBarCore
 /// Default shows 5 entries; the embedded ScrollView lets the user see more
 /// if the user has been across many models.
 struct ModelRankingList: View {
-    let snapshot: CostSnapshot?
+    let breakdowns: [CostSnapshot.ModelBreakdown]
     let density: Theme.Density
     var maxHeight: CGFloat = 180
+    /// Right-hand subtitle next to "Model ranking". Defaults to "All time"; the
+    /// Overview's combined card overrides to "All providers · all time" so the
+    /// scope is unambiguous.
+    var subtitle: String = "All time"
+
+    init(snapshot: CostSnapshot?, density: Theme.Density, maxHeight: CGFloat = 180, subtitle: String = "All time") {
+        self.breakdowns = snapshot?.modelBreakdowns ?? []
+        self.density = density
+        self.maxHeight = maxHeight
+        self.subtitle = subtitle
+    }
+
+    init(
+        breakdowns: [CostSnapshot.ModelBreakdown],
+        density: Theme.Density,
+        maxHeight: CGFloat = 180,
+        subtitle: String = "All time"
+    ) {
+        self.breakdowns = breakdowns
+        self.density = density
+        self.maxHeight = maxHeight
+        self.subtitle = subtitle
+    }
 
     var body: some View {
-        if let snapshot {
-            let models = filteredModels(snapshot.modelBreakdowns)
-            if !models.isEmpty {
-                VStack(alignment: .leading, spacing: density.bucketRowSpacing) {
-                    HStack(alignment: .firstTextBaseline) {
-                        Text("Model ranking")
-                            .font(.system(size: density.bucketTitleFontSize, weight: .semibold))
-                        Spacer()
-                        Text("All time")
-                            .font(.system(size: density.resetCountdownFontSize))
-                            .foregroundStyle(.tertiary)
-                    }
-                    ScrollView(.vertical, showsIndicators: false) {
-                        VStack(alignment: .leading, spacing: 4) {
-                            ForEach(Array(models.enumerated()), id: \.element.id) { index, model in
-                                row(rank: index + 1, model: model, total: total(models))
-                            }
+        let models = filteredModels(breakdowns)
+        if !models.isEmpty {
+            VStack(alignment: .leading, spacing: density.bucketRowSpacing) {
+                HStack(alignment: .firstTextBaseline) {
+                    Text("Model ranking")
+                        .font(.system(size: density.bucketTitleFontSize, weight: .semibold))
+                    Spacer()
+                    Text(subtitle)
+                        .font(.system(size: density.resetCountdownFontSize))
+                        .foregroundStyle(.tertiary)
+                }
+                ScrollView(.vertical, showsIndicators: false) {
+                    VStack(alignment: .leading, spacing: 4) {
+                        ForEach(Array(models.enumerated()), id: \.element.id) { index, model in
+                            row(rank: index + 1, model: model, total: total(models))
                         }
                     }
-                    .frame(maxHeight: maxHeight)
                 }
-                .padding(density.cardPadding)
-                .background(
-                    RoundedRectangle(cornerRadius: density.cardCornerRadius, style: .continuous)
-                        .fill(.background.tertiary.opacity(0.6))
-                )
-                .overlay(
-                    RoundedRectangle(cornerRadius: density.cardCornerRadius, style: .continuous)
-                        .stroke(.separator.opacity(0.4), lineWidth: 0.5)
-                )
+                .frame(maxHeight: maxHeight)
             }
+            .padding(density.cardPadding)
+            .background(
+                RoundedRectangle(cornerRadius: density.cardCornerRadius, style: .continuous)
+                    .fill(.background.tertiary.opacity(0.6))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: density.cardCornerRadius, style: .continuous)
+                    .stroke(.separator.opacity(0.4), lineWidth: 0.5)
+            )
         }
     }
 

--- a/Sources/VibeBarApp/Views/PopoverRoot.swift
+++ b/Sources/VibeBarApp/Views/PopoverRoot.swift
@@ -265,29 +265,62 @@ private struct OverviewSwitchIcon: View {
     }
 }
 
-/// Overview popover content:
-///   1. A compact cost summary plus live service status.
-///   2. Two provider columns, each with quota followed by cost.
-///
-/// The columns are per-provider so OpenAI's quota and OpenAI's cost align
-/// vertically — same for Claude on the right. No tabs, no sub-pages.
+/// Overview popover content, top-to-bottom:
+///   1. `CombinedTotalsRow` — cost+token grid plus live service status.
+///   2. A `ColumnMasonryLayout` covering everything else. The first two
+///      subviews — OpenAI Quota and Claude Quota — are anchored to the top
+///      of columns 0 and 1 respectively (AQ wants the quota cards locked in
+///      place). Every subsequent card flows into whichever column is
+///      currently shorter, so the empty space below the shorter quota card
+///      gets filled by Cost / Model Ranking / heatmap cards instead of left
+///      blank. The cost and summary cards therefore drift between columns
+///      based on how the heights work out — this is intentional.
 private struct OverviewWaterfall: View {
     let density: Theme.Density
 
     @EnvironmentObject var environment: AppEnvironment
 
     var body: some View {
+        let snapshots = ToolType.allCases.compactMap { environment.costService.snapshot(for: $0) }
+        let combinedHistory = CostSnapshotAggregator.combinedDailyHistory(snapshots)
+        let combinedHeatmap = CostSnapshotAggregator.combinedHeatmap(snapshots)
+        let combinedModels = CostSnapshotAggregator.combinedModelBreakdowns(snapshots)
+        let hasCostData = snapshots.contains { $0.jsonlFilesFound > 0 }
+
         VStack(alignment: .leading, spacing: density.interSectionSpacing) {
             CombinedTotalsRow(density: density)
-            HStack(alignment: .top, spacing: density.interSectionSpacing) {
+            ColumnMasonryLayout(
+                columns: 2,
+                spacing: density.interSectionSpacing,
+                anchoredItems: 2
+            ) {
+                ProviderQuotaCard(tool: .codex, density: density, compact: false)
+                ProviderQuotaCard(tool: .claude, density: density, compact: false)
                 ForEach(ToolType.allCases, id: \.self) { tool in
-                    VStack(alignment: .leading, spacing: density.interSectionSpacing) {
-                        ProviderQuotaCard(tool: tool, density: density, compact: false)
-                        if tool.supportsTokenCost {
-                            OverviewCostCard(tool: tool, density: density)
-                        }
+                    if tool.supportsTokenCost {
+                        OverviewCostCard(tool: tool, density: density)
                     }
-                    .frame(maxWidth: .infinity, alignment: .topLeading)
+                }
+                if hasCostData {
+                    ModelRankingList(
+                        breakdowns: combinedModels,
+                        density: density,
+                        subtitle: "All providers · all time"
+                    )
+                    YearlyContributionHeatmapView(
+                        history: combinedHistory,
+                        density: density,
+                        toolName: "All providers"
+                    )
+                    UsageHeatmapView(
+                        heatmap: combinedHeatmap,
+                        density: density,
+                        titleOverride: "When you use everything"
+                    )
+                    UsageRateView(
+                        heatmap: combinedHeatmap,
+                        density: density
+                    )
                 }
             }
         }

--- a/Sources/VibeBarApp/Views/UsageHeatmapView.swift
+++ b/Sources/VibeBarApp/Views/UsageHeatmapView.swift
@@ -7,6 +7,10 @@ import VibeBarCore
 struct UsageHeatmapView: View {
     let heatmap: UsageHeatmap
     let density: Theme.Density
+    /// Optional title override. The Overview's "all providers" version of this
+    /// card needs "When you use everything" instead of the default
+    /// `When you use \(toolName)` derived from `heatmap.tool`.
+    var titleOverride: String? = nil
 
     private let weekdayLabels = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"]
     @State private var measuredGridWidth: CGFloat = 0
@@ -14,7 +18,7 @@ struct UsageHeatmapView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: density.cardSpacing) {
             HStack(alignment: .firstTextBaseline) {
-                Text("When you use \(toolName)")
+                Text(titleOverride ?? "When you use \(toolName)")
                     .font(.system(size: density.bucketTitleFontSize, weight: .semibold))
                 Spacer()
                 if heatmap.totalTokens > 0 {

--- a/Sources/VibeBarCore/Models/CostSnapshot.swift
+++ b/Sources/VibeBarCore/Models/CostSnapshot.swift
@@ -243,6 +243,78 @@ public struct CostSnapshot: Sendable, Equatable, Codable {
     }
 }
 
+/// Combine multiple `CostSnapshot`s into the aggregate inputs the Overview's
+/// "all providers" cards need (Model Ranking, Past Year heatmap, When You Use
+/// heatmap, Hourly Burn Rate). Lives in Core so the math is testable and the
+/// view layer just plumbs values through.
+///
+/// Notes
+/// - Daily history is summed by start-of-day in the supplied calendar so a
+///   Codex day and a Claude day at the same wall-clock date land in the same
+///   bucket.
+/// - The 7×24 heatmap is summed cell-by-cell. The returned heatmap's `tool`
+///   field is irrelevant for the combined view; callers should pass an
+///   explicit title to `UsageHeatmapView` instead of relying on it.
+/// - Models from different providers don't normally collide, but if they do
+///   we sum costs/tokens under the shared name. The output is sorted by cost
+///   desc to match the existing single-provider rendering.
+public enum CostSnapshotAggregator {
+    public static func combinedDailyHistory(
+        _ snapshots: [CostSnapshot],
+        calendar: Calendar = .current
+    ) -> [DailyCostPoint] {
+        var totals: [Date: (cost: Double, tokens: Int)] = [:]
+        for snapshot in snapshots {
+            for point in snapshot.dailyHistory {
+                let day = calendar.startOfDay(for: point.date)
+                let current = totals[day] ?? (0, 0)
+                totals[day] = (current.cost + point.costUSD, current.tokens + point.totalTokens)
+            }
+        }
+        return totals
+            .map { DailyCostPoint(date: $0.key, costUSD: $0.value.cost, totalTokens: $0.value.tokens) }
+            .sorted { $0.date < $1.date }
+    }
+
+    public static func combinedHeatmap(_ snapshots: [CostSnapshot]) -> UsageHeatmap {
+        let zeroes = Array(repeating: Array(repeating: 0, count: 24), count: 7)
+        guard !snapshots.isEmpty else {
+            return UsageHeatmap(tool: .codex, cells: zeroes, totalTokens: 0)
+        }
+        var combined = zeroes
+        var total = 0
+        for snapshot in snapshots {
+            let cells = snapshot.heatmap.cells
+            for weekday in 0..<7 where weekday < cells.count {
+                let row = cells[weekday]
+                for hour in 0..<24 where hour < row.count {
+                    combined[weekday][hour] += row[hour]
+                }
+            }
+            total += snapshot.heatmap.totalTokens
+        }
+        return UsageHeatmap(tool: snapshots.first?.tool ?? .codex, cells: combined, totalTokens: total)
+    }
+
+    public static func combinedModelBreakdowns(
+        _ snapshots: [CostSnapshot]
+    ) -> [CostSnapshot.ModelBreakdown] {
+        var totals: [String: (cost: Double, tokens: Int)] = [:]
+        for snapshot in snapshots {
+            for breakdown in snapshot.modelBreakdowns {
+                let current = totals[breakdown.modelName] ?? (0, 0)
+                totals[breakdown.modelName] = (
+                    current.cost + breakdown.costUSD,
+                    current.tokens + breakdown.totalTokens
+                )
+            }
+        }
+        return totals
+            .map { CostSnapshot.ModelBreakdown(modelName: $0.key, costUSD: $0.value.cost, totalTokens: $0.value.tokens) }
+            .sorted { $0.costUSD > $1.costUSD }
+    }
+}
+
 public enum CostTimeframe: String, CaseIterable, Identifiable, Sendable {
     case today
     case week

--- a/Tests/VibeBarCoreTests/CostSnapshotAggregatorTests.swift
+++ b/Tests/VibeBarCoreTests/CostSnapshotAggregatorTests.swift
@@ -1,0 +1,122 @@
+import XCTest
+@testable import VibeBarCore
+
+final class CostSnapshotAggregatorTests: XCTestCase {
+    private func calendar() -> Calendar {
+        var cal = Calendar(identifier: .gregorian)
+        cal.locale = Locale(identifier: "en_US_POSIX")
+        cal.timeZone = TimeZone(secondsFromGMT: 0)!
+        return cal
+    }
+
+    private func makeSnapshot(
+        tool: ToolType,
+        days: [(Date, Double, Int)],
+        heatmap: [[Int]],
+        models: [(String, Double, Int)]
+    ) -> CostSnapshot {
+        CostSnapshot(
+            tool: tool,
+            todayCostUSD: 0,
+            last7DaysCostUSD: 0,
+            last30DaysCostUSD: 0,
+            allTimeCostUSD: 0,
+            todayTokens: 0,
+            last7DaysTokens: 0,
+            last30DaysTokens: 0,
+            allTimeTokens: 0,
+            dailyHistory: days.map { DailyCostPoint(date: $0.0, costUSD: $0.1, totalTokens: $0.2) },
+            heatmap: UsageHeatmap(tool: tool, cells: heatmap, totalTokens: heatmap.flatMap { $0 }.reduce(0, +)),
+            modelBreakdowns: models.map { CostSnapshot.ModelBreakdown(modelName: $0.0, costUSD: $0.1, totalTokens: $0.2) },
+            jsonlFilesFound: 1,
+            updatedAt: Date(timeIntervalSince1970: 0)
+        )
+    }
+
+    func testCombinedDailyHistorySumsByCalendarDay() throws {
+        let cal = calendar()
+        let day1 = try XCTUnwrap(cal.date(from: DateComponents(year: 2026, month: 5, day: 1)))
+        let day2 = try XCTUnwrap(cal.date(from: DateComponents(year: 2026, month: 5, day: 2)))
+        let day1Afternoon = try XCTUnwrap(cal.date(byAdding: .hour, value: 14, to: day1))
+
+        let codex = makeSnapshot(
+            tool: .codex,
+            days: [(day1, 1.50, 1_000), (day2, 0.50, 500)],
+            heatmap: Array(repeating: Array(repeating: 0, count: 24), count: 7),
+            models: []
+        )
+        let claude = makeSnapshot(
+            tool: .claude,
+            days: [(day1Afternoon, 2.00, 2_000), (day2, 0.25, 250)],
+            heatmap: Array(repeating: Array(repeating: 0, count: 24), count: 7),
+            models: []
+        )
+
+        let combined = CostSnapshotAggregator.combinedDailyHistory([codex, claude], calendar: cal)
+        XCTAssertEqual(combined.count, 2)
+        XCTAssertEqual(combined[0].date, day1)
+        XCTAssertEqual(combined[0].costUSD, 3.50, accuracy: 0.0001)
+        XCTAssertEqual(combined[0].totalTokens, 3_000)
+        XCTAssertEqual(combined[1].date, day2)
+        XCTAssertEqual(combined[1].costUSD, 0.75, accuracy: 0.0001)
+        XCTAssertEqual(combined[1].totalTokens, 750)
+    }
+
+    func testCombinedHeatmapAddsCellsAndTotalsAcrossProviders() {
+        var codexCells = Array(repeating: Array(repeating: 0, count: 24), count: 7)
+        codexCells[1][9] = 100
+        codexCells[3][14] = 50
+        var claudeCells = Array(repeating: Array(repeating: 0, count: 24), count: 7)
+        claudeCells[1][9] = 25
+        claudeCells[5][22] = 200
+
+        let codex = makeSnapshot(tool: .codex, days: [], heatmap: codexCells, models: [])
+        let claude = makeSnapshot(tool: .claude, days: [], heatmap: claudeCells, models: [])
+
+        let combined = CostSnapshotAggregator.combinedHeatmap([codex, claude])
+        XCTAssertEqual(combined.cells[1][9], 125)
+        XCTAssertEqual(combined.cells[3][14], 50)
+        XCTAssertEqual(combined.cells[5][22], 200)
+        XCTAssertEqual(combined.totalTokens, 375)
+    }
+
+    func testCombinedHeatmapWithNoSnapshotsReturnsZeroes() {
+        let combined = CostSnapshotAggregator.combinedHeatmap([])
+        XCTAssertEqual(combined.cells.count, 7)
+        XCTAssertEqual(combined.cells.first?.count, 24)
+        XCTAssertEqual(combined.totalTokens, 0)
+    }
+
+    func testCombinedModelBreakdownsSortByCostDescending() throws {
+        let codex = makeSnapshot(
+            tool: .codex,
+            days: [],
+            heatmap: Array(repeating: Array(repeating: 0, count: 24), count: 7),
+            models: [
+                ("gpt-5", 3.00, 30_000),
+                ("o4-mini", 0.40, 4_000)
+            ]
+        )
+        let claude = makeSnapshot(
+            tool: .claude,
+            days: [],
+            heatmap: Array(repeating: Array(repeating: 0, count: 24), count: 7),
+            models: [
+                ("claude-sonnet-4-5", 5.00, 50_000),
+                ("claude-haiku-4-5", 0.10, 1_000),
+                ("gpt-5", 1.00, 10_000)   // simulate a name collision
+            ]
+        )
+
+        let combined = CostSnapshotAggregator.combinedModelBreakdowns([codex, claude])
+        XCTAssertEqual(combined.map(\.modelName), [
+            "claude-sonnet-4-5",
+            "gpt-5",
+            "o4-mini",
+            "claude-haiku-4-5"
+        ])
+        let merged = try XCTUnwrap(combined.first { $0.modelName == "gpt-5" })
+        XCTAssertEqual(merged.costUSD, 4.00, accuracy: 0.0001)
+        XCTAssertEqual(merged.totalTokens, 40_000)
+    }
+}


### PR DESCRIPTION
## Summary

- Replace the Overview's hand-rolled two-column layout with a `ColumnMasonryLayout`. The two provider Quota cards are anchored to the top of columns 0/1; everything below — the per-provider Cost cards and the new "all providers" summary cards — flows into whichever column is currently shortest, so the empty space under the shorter quota is filled instead of left blank.
- Add four combined cards to the Overview: Model Ranking, Past Year (yearly contribution heatmap), When You Use (weekday × hour heatmap), and Hourly Burn Rate. Each one aggregates Codex + Claude data so the Overview is a real all-providers view instead of two single-provider stacks side-by-side.
- New `CostSnapshotAggregator` in `VibeBarCore` does the math (sum daily history by calendar day, element-wise heatmap merge, model breakdowns merged by name and sorted by cost desc), with unit tests covering each path.
- `UsageHeatmapView` gained a `titleOverride` and `ModelRankingList` now also accepts a `[ModelBreakdown]` directly so the combined cards reuse the existing rendering instead of duplicating it.

## Why

Before this change the Overview had two rigid columns: OpenAI Quota → OpenAI Cost on the left and Claude Quota → Claude Cost on the right. Because Claude's quota card is taller (Sonnet, Designs, Daily Routines extras), the OpenAI side picked up a noticeable empty band under its quota — visually awkward and complained about specifically.

The new masonry pins the quota cards in their familiar positions but lets every other card waterfall by height, so neither column runs noticeably longer than the other.

## Test plan

- [x] `swift build`
- [x] `swift test` — 96/96 tests pass, including 4 new `CostSnapshotAggregatorTests` cases
- [x] `./Scripts/build_app.sh release`
- [x] `codesign -d --entitlements - ".build/Vibe Bar.app"` shows app-sandbox + network.client + the four home-relative path exceptions
- [x] `codesign --verify --deep --strict ".build/Vibe Bar.app"`
- [x] Smoke-test: `~/Library/Containers/com.astroqore.VibeBar/Data/` contains only the standard symlinks; no shadow `.codex/.claude/.vibebar` tree
- [x] Visually confirmed in the popover that the empty band under the shorter quota card now gets filled by the next masonry card

🤖 Generated with [Claude Code](https://claude.com/claude-code)