### PR TITLE
Stabilize primary provider auth and cost scanning

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -292,10 +292,13 @@ Vibe Bar persists derived data under the user's **real** home directory:
 If you are debugging odd behavior, that directory is the place to look.
 Deleting it resets the app to first-run state.
 
-Keychain stores Claude session cookies and the resolved Claude
-organization ID — those are not in `~/.vibebar/`. The app reads (never
-writes) Codex and Claude CLI credential files and their session JSONL
-logs. Treat those as read-only inputs.
+Keychain stores Vibe Bar-owned OpenAI / Claude Web cookies, split by
+source (`browser` vs `WebView`), plus the resolved Claude organization
+ID — those are not in `~/.vibebar/`. Legacy plaintext cookie files under
+`~/.vibebar/cookies/` may be read once for migration and must be deleted
+immediately afterward. The app reads (never writes) Codex and Claude CLI
+credential files and their session JSONL logs. Treat those as read-only
+inputs.
 
 ## 6. Home Directory (and why we no longer sandbox)
 
@@ -329,7 +332,10 @@ plist. The trade-offs:
   today and was never on MAS, so this is a no-op.
 - **Wider local file access.** Vibe Bar can technically read anything
   the user can read. The privacy rules (§ 8) and `SafeLog` /
-  `EmailMasker` discipline still apply — *don't* abuse this.
+  `EmailMasker` discipline still apply — *don't* abuse this. Browser
+  cookies imported for OpenAI / Claude must be minimized to the smallest
+  useful header and stored only in Keychain, never as new plaintext files
+  in `~/.vibebar/`.
 - **Re-enabling the sandbox is a one-PR change.** If a future
   requirement (e.g. someone wants a sandboxed fork for MAS) makes
   this worthwhile, restore the sandbox key + the four
@@ -437,6 +443,9 @@ What is **not** allowed in any commit:
   output. Use `/Users/example/...` and synthetic JWTs.
 - Logging raw credentials or email addresses. Route through
   `SafeLog.sanitize` and `EmailMasker`.
+- Persisting OpenAI / Claude Web cookies, session keys, or resolved
+  organization IDs in plaintext. Use the Vibe Bar-owned Keychain service;
+  `~/.vibebar/cookies/` is migration-only.
 - Re-enabling the app sandbox in `Resources/VibeBar.entitlements`
   *without coordinating the misc-providers feature first*. Vibe Bar is
   unsandboxed on purpose (see § 6) so the browser-cookie importer and

--- a/Sources/VibeBarApp/AppEnvironment.swift
+++ b/Sources/VibeBarApp/AppEnvironment.swift
@@ -12,9 +12,14 @@ final class AppEnvironment: ObservableObject {
     let costService: CostUsageService
 
     @Published private(set) var hasClaudeWebCookies: Bool
+    @Published private(set) var hasOpenAIWebCookies: Bool
+    @Published private(set) var isImportingOpenAIBrowserCookies = false
     @Published private(set) var isImportingClaudeBrowserCookies = false
+    @Published private(set) var openAIBrowserCookieImportStatus: String?
     @Published private(set) var claudeBrowserCookieImportStatus: String?
+    @Published private(set) var routeHealth: [PrimaryProviderRoute: PrimaryProviderRouteHealth]
 
+    private let openAIWebLoginController = OpenAIWebLoginController()
     private let claudeWebLoginController = ClaudeWebLoginController()
     private let settingsWindowController = SettingsWindowController()
     private var cancellables: Set<AnyCancellable> = []
@@ -22,10 +27,15 @@ final class AppEnvironment: ObservableObject {
     private var lastRoutineBudgetAttemptByAccount: [String: Date] = [:]
     private var persistentClaudeCookieImportInFlight = false
     private var browserClaudeCookieImportInFlight = false
+    private var persistentOpenAICookieImportInFlight = false
+    private var browserOpenAICookieImportInFlight = false
 
     init() {
         let settings = SettingsStore()
-        let accounts = AccountStore(claudeUsageMode: settings.claudeUsageMode)
+        let accounts = AccountStore(
+            codexUsageMode: settings.codexUsageMode,
+            claudeUsageMode: settings.claudeUsageMode
+        )
         let service = QuotaService.makeDefault(mockProvider: { [weak settings] in
             settings?.mockEnabled ?? false
         }, initialAccountIds: accounts.accounts.map(\.id))
@@ -41,6 +51,8 @@ final class AppEnvironment: ObservableObject {
         })
         self.costService = costService
         self.hasClaudeWebCookies = ClaudeWebCookieStore.hasCookieHeader()
+        self.hasOpenAIWebCookies = OpenAIWebCookieStore.hasCookieHeader()
+        self.routeHealth = PrimaryProviderRouteHealthChecker.checkAll()
 
         let scheduler = QuotaRefreshScheduler(
             service: service,
@@ -70,10 +82,15 @@ final class AppEnvironment: ObservableObject {
             .removeDuplicates {
                 $0.refreshIntervalSeconds == $1.refreshIntervalSeconds
                     && $0.mockEnabled == $1.mockEnabled
+                    && $0.codexUsageMode == $1.codexUsageMode
                     && $0.claudeUsageMode == $1.claudeUsageMode
             }
             .sink { [weak self] settings in
-                self?.accountStore.reload(claudeUsageMode: settings.claudeUsageMode)
+                self?.accountStore.reload(
+                    codexUsageMode: settings.codexUsageMode,
+                    claudeUsageMode: settings.claudeUsageMode
+                )
+                self?.recheckPrimaryRouteHealth()
                 self?.scheduler.reschedule()
                 self?.scheduler.triggerRefresh()
             }
@@ -90,6 +107,7 @@ final class AppEnvironment: ObservableObject {
             .removeDuplicates {
                 $0.mockEnabled == $1.mockEnabled
                     && $0.claudeUsageMode == $1.claudeUsageMode
+                    && $0.codexUsageMode == $1.codexUsageMode
             }
             .debounce(for: .milliseconds(300), scheduler: RunLoop.main)
             .sink { [weak self] _ in
@@ -125,6 +143,8 @@ final class AppEnvironment: ObservableObject {
         }
         importPersistentClaudeCookiesAndRefreshIfNeeded()
         importClaudeBrowserCookiesAndRefreshIfNeeded()
+        importPersistentOpenAICookiesAndRefreshIfNeeded()
+        importOpenAIBrowserCookiesAndRefreshIfNeeded()
 
         // Push Claude/Codex extras parsed by adapters into CostUsageService.
         service.$lastSuccessByAccount
@@ -155,9 +175,16 @@ final class AppEnvironment: ObservableObject {
 
     func reloadProviderCredentialsAndRefresh() {
         hasClaudeWebCookies = ClaudeWebCookieStore.hasCookieHeader()
+        hasOpenAIWebCookies = OpenAIWebCookieStore.hasCookieHeader()
+        recheckPrimaryRouteHealth()
+        importPersistentOpenAICookiesAndRefreshIfNeeded()
+        importOpenAIBrowserCookiesAndRefreshIfNeeded()
         importPersistentClaudeCookiesAndRefreshIfNeeded()
         importClaudeBrowserCookiesAndRefreshIfNeeded()
-        accountStore.reload(claudeUsageMode: settingsStore.claudeUsageMode)
+        accountStore.reload(
+            codexUsageMode: settingsStore.settings.codexUsageMode,
+            claudeUsageMode: settingsStore.claudeUsageMode
+        )
         // Cookies may have changed (login / re-login) — drop any stale
         // 1h failure cooldowns so the routine WebView probe gets a fresh
         // chance on the very next quota refresh.
@@ -184,18 +211,28 @@ final class AppEnvironment: ObservableObject {
 
     func refresh(_ tool: ToolType) {
         hasClaudeWebCookies = ClaudeWebCookieStore.hasCookieHeader()
-        if tool == .claude {
-            importPersistentClaudeCookiesAndRefreshIfNeeded()
-            importClaudeBrowserCookiesAndRefreshIfNeeded()
-        }
-        accountStore.reload(claudeUsageMode: settingsStore.claudeUsageMode)
+        hasOpenAIWebCookies = OpenAIWebCookieStore.hasCookieHeader()
+        recheckPrimaryRouteHealth(provider: tool)
+        accountStore.reload(
+            codexUsageMode: settingsStore.settings.codexUsageMode,
+            claudeUsageMode: settingsStore.claudeUsageMode
+        )
         let account = account(for: tool)
         Task { @MainActor in
             if let account {
                 _ = await quotaService.refresh(account)
             }
-            await costService.refreshAll()
         }
+    }
+
+    func recheckPrimaryRouteHealth(provider: ToolType? = nil) {
+        let routes = provider.map(PrimaryProviderRoute.routes(for:)) ?? PrimaryProviderRoute.allCases
+        var next = routeHealth
+        let now = Date()
+        for route in routes {
+            next[route] = PrimaryProviderRouteHealthChecker.check(route, now: now)
+        }
+        routeHealth = next
     }
 
     func showSettingsWindow() {
@@ -207,6 +244,20 @@ final class AppEnvironment: ObservableObject {
             self?.hasClaudeWebCookies = ClaudeWebCookieStore.hasCookieHeader()
             self?.reloadProviderCredentialsAndRefresh()
         }
+    }
+
+    func openOpenAIWebLogin() {
+        openAIWebLoginController.open { [weak self] in
+            self?.hasOpenAIWebCookies = OpenAIWebCookieStore.hasCookieHeader()
+            self?.reloadProviderCredentialsAndRefresh()
+        }
+    }
+
+    func importOpenAIBrowserCookies() {
+        importOpenAIBrowserCookiesAndRefreshIfNeeded(
+            allowKeychainPrompt: true,
+            userInitiated: true
+        )
     }
 
     func importClaudeBrowserCookies() {
@@ -224,8 +275,12 @@ final class AppEnvironment: ObservableObject {
             guard let self else { return }
             self.persistentClaudeCookieImportInFlight = false
             self.hasClaudeWebCookies = ClaudeWebCookieStore.hasCookieHeader()
+            self.recheckPrimaryRouteHealth(provider: .claude)
             guard didImport, !hadCookies else { return }
-            self.accountStore.reload(claudeUsageMode: self.settingsStore.claudeUsageMode)
+            self.accountStore.reload(
+                codexUsageMode: self.settingsStore.settings.codexUsageMode,
+                claudeUsageMode: self.settingsStore.claudeUsageMode
+            )
             self.lastRoutineBudgetAttemptByAccount.removeAll()
             self.scheduler.triggerRefresh()
         }
@@ -258,6 +313,7 @@ final class AppEnvironment: ObservableObject {
                 self.isImportingClaudeBrowserCookies = false
             }
             self.hasClaudeWebCookies = ClaudeWebCookieStore.hasCookieHeader()
+            self.recheckPrimaryRouteHealth(provider: .claude)
             guard let result else {
                 if userInitiated {
                     self.claudeBrowserCookieImportStatus = "No Claude sessionKey found in readable browser cookies."
@@ -267,8 +323,74 @@ final class AppEnvironment: ObservableObject {
             if userInitiated {
                 self.claudeBrowserCookieImportStatus = "Imported from \(result.sourceLabel)."
             }
-            self.accountStore.reload(claudeUsageMode: self.settingsStore.claudeUsageMode)
+            self.accountStore.reload(
+                codexUsageMode: self.settingsStore.settings.codexUsageMode,
+                claudeUsageMode: self.settingsStore.claudeUsageMode
+            )
             self.lastRoutineBudgetAttemptByAccount.removeAll()
+            self.scheduler.triggerRefresh()
+        }
+    }
+
+    private func importPersistentOpenAICookiesAndRefreshIfNeeded() {
+        guard !persistentOpenAICookieImportInFlight else { return }
+        persistentOpenAICookieImportInFlight = true
+        let hadCookies = hasOpenAIWebCookies
+        OpenAIWebLoginController.importPersistentOpenAICookiesIfAvailable { [weak self] didImport in
+            guard let self else { return }
+            self.persistentOpenAICookieImportInFlight = false
+            self.hasOpenAIWebCookies = OpenAIWebCookieStore.hasCookieHeader()
+            self.recheckPrimaryRouteHealth(provider: .codex)
+            guard didImport, !hadCookies else { return }
+            self.accountStore.reload(
+                codexUsageMode: self.settingsStore.settings.codexUsageMode,
+                claudeUsageMode: self.settingsStore.claudeUsageMode
+            )
+            self.scheduler.triggerRefresh()
+        }
+    }
+
+    private func importOpenAIBrowserCookiesAndRefreshIfNeeded(
+        allowKeychainPrompt: Bool = false,
+        userInitiated: Bool = false
+    ) {
+        if !allowKeychainPrompt, OpenAIWebCookieStore.hasCookieHeader() {
+            return
+        }
+        guard !browserOpenAICookieImportInFlight else { return }
+        browserOpenAICookieImportInFlight = true
+        if userInitiated {
+            isImportingOpenAIBrowserCookies = true
+            openAIBrowserCookieImportStatus = "Importing from browser..."
+        }
+
+        let importTask = Task.detached(priority: userInitiated ? .userInitiated : .utility) {
+            try? OpenAIBrowserCookieImporter.importAndStoreFromBrowsers(
+                allowKeychainPrompt: allowKeychainPrompt
+            )
+        }
+        Task { @MainActor [weak self] in
+            let result = await importTask.value
+            guard let self else { return }
+            self.browserOpenAICookieImportInFlight = false
+            if userInitiated {
+                self.isImportingOpenAIBrowserCookies = false
+            }
+            self.hasOpenAIWebCookies = OpenAIWebCookieStore.hasCookieHeader()
+            self.recheckPrimaryRouteHealth(provider: .codex)
+            guard let result else {
+                if userInitiated {
+                    self.openAIBrowserCookieImportStatus = "No ChatGPT session cookies found in readable browser cookies."
+                }
+                return
+            }
+            if userInitiated {
+                self.openAIBrowserCookieImportStatus = "Imported from \(result.sourceLabel)."
+            }
+            self.accountStore.reload(
+                codexUsageMode: self.settingsStore.settings.codexUsageMode,
+                claudeUsageMode: self.settingsStore.claudeUsageMode
+            )
             self.scheduler.triggerRefresh()
         }
     }
@@ -280,15 +402,43 @@ final class AppEnvironment: ObservableObject {
             try ClaudeWebCookieStore.deleteCookieHeader()
             claudeBrowserCookieImportStatus = nil
             hasClaudeWebCookies = false
+            recheckPrimaryRouteHealth(provider: .claude)
             for account in accountStore.accounts(for: .claude) {
                 quotaService.clear(accountId: account.id)
             }
-            accountStore.reload(claudeUsageMode: settingsStore.claudeUsageMode)
+            accountStore.reload(
+                codexUsageMode: settingsStore.settings.codexUsageMode,
+                claudeUsageMode: settingsStore.claudeUsageMode
+            )
             scheduler.triggerRefresh()
             return true
         } catch {
             SafeLog.warn("Deleting Claude web cookies failed: \(SafeLog.sanitize(error.localizedDescription))")
             hasClaudeWebCookies = ClaudeWebCookieStore.hasCookieHeader()
+            return false
+        }
+    }
+
+    @discardableResult
+    func deleteOpenAIWebCookies() -> Bool {
+        do {
+            OpenAIWebLoginController.clearPersistentOpenAIWebsiteData()
+            try OpenAIWebCookieStore.deleteCookieHeader()
+            openAIBrowserCookieImportStatus = nil
+            hasOpenAIWebCookies = false
+            recheckPrimaryRouteHealth(provider: .codex)
+            for account in accountStore.accounts(for: .codex) {
+                quotaService.clear(accountId: account.id)
+            }
+            accountStore.reload(
+                codexUsageMode: settingsStore.settings.codexUsageMode,
+                claudeUsageMode: settingsStore.claudeUsageMode
+            )
+            scheduler.triggerRefresh()
+            return true
+        } catch {
+            SafeLog.warn("Deleting OpenAI web cookies failed: \(SafeLog.sanitize(error.localizedDescription))")
+            hasOpenAIWebCookies = OpenAIWebCookieStore.hasCookieHeader()
             return false
         }
     }

--- a/Sources/VibeBarApp/ClaudeWebLoginController.swift
+++ b/Sources/VibeBarApp/ClaudeWebLoginController.swift
@@ -151,7 +151,7 @@ final class ClaudeWebLoginController: NSObject, NSWindowDelegate, WKNavigationDe
             return false
         }
         do {
-            try ClaudeWebCookieStore.writeCookieHeader(minimizedHeader)
+            try ClaudeWebCookieStore.writeCookieHeader(minimizedHeader, source: .webView)
             cacheClaudeOrganizationID(from: minimizedHeader)
             return true
         } catch {

--- a/Sources/VibeBarApp/OpenAIWebLoginController.swift
+++ b/Sources/VibeBarApp/OpenAIWebLoginController.swift
@@ -1,0 +1,219 @@
+import AppKit
+import WebKit
+import VibeBarCore
+
+@MainActor
+final class OpenAIWebLoginController: NSObject, NSWindowDelegate, WKNavigationDelegate {
+    private static let loginURL = URL(string: "https://chatgpt.com/")!
+
+    private var window: NSWindow?
+    private var webView: WKWebView?
+    private var statusLabel: NSTextField?
+    private var onSaved: (() -> Void)?
+    private var didSaveCookiesForCurrentWindow = false
+    private let websiteDataStore = WKWebsiteDataStore.default()
+
+    func open(onSaved: @escaping () -> Void) {
+        self.onSaved = onSaved
+
+        if let window {
+            window.makeKeyAndOrderFront(nil)
+            NSApp.activate(ignoringOtherApps: true)
+            return
+        }
+
+        let configuration = WKWebViewConfiguration()
+        configuration.websiteDataStore = websiteDataStore
+        configuration.defaultWebpagePreferences.allowsContentJavaScript = true
+
+        let webView = WKWebView(frame: .zero, configuration: configuration)
+        webView.navigationDelegate = self
+        webView.customUserAgent = safariUserAgent
+        webView.allowsBackForwardNavigationGestures = true
+        webView.translatesAutoresizingMaskIntoConstraints = false
+        self.webView = webView
+
+        let saveButton = NSButton(title: "Save OpenAI Cookies", target: self, action: #selector(saveCookies(_:)))
+        saveButton.bezelStyle = .rounded
+        let reloadButton = NSButton(title: "Reload", target: self, action: #selector(reloadPage(_:)))
+        reloadButton.bezelStyle = .rounded
+        let browserButton = NSButton(title: "Open in Browser", target: self, action: #selector(openInBrowser(_:)))
+        browserButton.bezelStyle = .rounded
+
+        let statusLabel = NSTextField(labelWithString: "Loading ChatGPT...")
+        statusLabel.textColor = .secondaryLabelColor
+        statusLabel.font = .systemFont(ofSize: NSFont.smallSystemFontSize)
+        self.statusLabel = statusLabel
+
+        let buttonRow = NSStackView(views: [statusLabel, NSView(), browserButton, reloadButton, saveButton])
+        buttonRow.orientation = .horizontal
+        buttonRow.alignment = .centerY
+        buttonRow.spacing = 10
+        buttonRow.edgeInsets = NSEdgeInsets(top: 10, left: 12, bottom: 10, right: 12)
+
+        let root = NSStackView(views: [webView, buttonRow])
+        root.orientation = .vertical
+        root.spacing = 0
+        root.translatesAutoresizingMaskIntoConstraints = false
+
+        let contentView = NSView()
+        contentView.addSubview(root)
+        NSLayoutConstraint.activate([
+            root.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+            root.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+            root.topAnchor.constraint(equalTo: contentView.topAnchor),
+            root.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
+            webView.heightAnchor.constraint(greaterThanOrEqualToConstant: 560)
+        ])
+
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 980, height: 680),
+            styleMask: [.titled, .closable, .resizable],
+            backing: .buffered,
+            defer: false
+        )
+        window.title = "OpenAI Web Login"
+        window.contentView = contentView
+        window.delegate = self
+        window.center()
+        window.isReleasedWhenClosed = false
+        window.makeKeyAndOrderFront(nil)
+        self.window = window
+        NSApp.activate(ignoringOtherApps: true)
+
+        loadLogin()
+    }
+
+    @objc private func saveCookies(_ sender: Any?) {
+        websiteDataStore.httpCookieStore.getAllCookies { [weak self] cookies in
+            Task { @MainActor in
+                self?.persistOpenAICookies(cookies, alertOnFailure: true)
+            }
+        }
+    }
+
+    @objc private func reloadPage(_ sender: Any?) {
+        loadLogin(ignoringCache: true)
+    }
+
+    @objc private func openInBrowser(_ sender: Any?) {
+        NSWorkspace.shared.open(Self.loginURL)
+        statusLabel?.stringValue = "Use your browser if WebView login is blocked, then import from browser."
+    }
+
+    static func importPersistentOpenAICookiesIfAvailable(completion: @escaping @MainActor (Bool) -> Void) {
+        WKWebsiteDataStore.default().httpCookieStore.getAllCookies { cookies in
+            let didImport = persistOpenAICookiesToStore(cookies)
+            Task { @MainActor in
+                completion(didImport)
+            }
+        }
+    }
+
+    static func clearPersistentOpenAIWebsiteData() {
+        let store = WKWebsiteDataStore.default()
+        let types = WKWebsiteDataStore.allWebsiteDataTypes()
+        store.fetchDataRecords(ofTypes: types) { records in
+            let openAIRecords = records.filter { record in
+                record.displayName == "chatgpt.com"
+                    || record.displayName == "openai.com"
+                    || record.displayName.hasSuffix(".chatgpt.com")
+                    || record.displayName.hasSuffix(".openai.com")
+            }
+            guard !openAIRecords.isEmpty else { return }
+            store.removeData(ofTypes: types, for: openAIRecords) {}
+        }
+    }
+
+    private func loadLogin(ignoringCache: Bool = false) {
+        var request = URLRequest(url: Self.loginURL)
+        if ignoringCache {
+            request.cachePolicy = .reloadIgnoringLocalAndRemoteCacheData
+        }
+        request.setValue("text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8", forHTTPHeaderField: "Accept")
+        webView?.load(request)
+        statusLabel?.stringValue = "Loading ChatGPT..."
+    }
+
+    private func persistOpenAICookies(_ cookies: [HTTPCookie], alertOnFailure: Bool) {
+        guard Self.persistOpenAICookiesToStore(cookies) else {
+            if alertOnFailure {
+                showAlert(message: "No ChatGPT session cookies found yet. Finish login first.")
+            }
+            return
+        }
+        didSaveCookiesForCurrentWindow = true
+        statusLabel?.stringValue = "OpenAI cookies saved."
+        if alertOnFailure {
+            showAlert(message: "OpenAI cookies saved.")
+        }
+        onSaved?()
+    }
+
+    private static func persistOpenAICookiesToStore(_ cookies: [HTTPCookie]) -> Bool {
+        let relevant = cookies
+            .filter { cookie in
+                cookie.domain == "chatgpt.com"
+                    || cookie.domain.hasSuffix(".chatgpt.com")
+                    || cookie.domain == "openai.com"
+                    || cookie.domain.hasSuffix(".openai.com")
+            }
+            .sorted { $0.name < $1.name }
+            .map { (name: $0.name, value: $0.value) }
+        guard let header = OpenAIWebCookieStore.cookieHeader(from: relevant) else { return false }
+        do {
+            try OpenAIWebCookieStore.writeCookieHeader(header, source: .webView)
+            return true
+        } catch {
+            SafeLog.warn("Saving OpenAI web cookies failed: \(SafeLog.sanitize(error.localizedDescription))")
+            return false
+        }
+    }
+
+    private func showAlert(message: String) {
+        let alert = NSAlert()
+        alert.messageText = message
+        alert.addButton(withTitle: "OK")
+        if let window {
+            alert.beginSheetModal(for: window) { _ in }
+        } else {
+            alert.runModal()
+        }
+    }
+
+    nonisolated private var safariUserAgent: String {
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.0 Safari/605.1.15"
+    }
+
+    func webView(_ webView: WKWebView, didStartProvisionalNavigation navigation: WKNavigation!) {
+        statusLabel?.stringValue = "Loading \(webView.url?.host ?? "ChatGPT")..."
+    }
+
+    func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+        statusLabel?.stringValue = "Log in to ChatGPT, then save cookies."
+        guard !didSaveCookiesForCurrentWindow else { return }
+        websiteDataStore.httpCookieStore.getAllCookies { [weak self] cookies in
+            Task { @MainActor in
+                guard let self, !self.didSaveCookiesForCurrentWindow else { return }
+                self.persistOpenAICookies(cookies, alertOnFailure: false)
+            }
+        }
+    }
+
+    func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
+        statusLabel?.stringValue = "Load failed: \(SafeLog.sanitize(error.localizedDescription))"
+    }
+
+    func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
+        statusLabel?.stringValue = "Load failed: \(SafeLog.sanitize(error.localizedDescription))"
+    }
+
+    func windowWillClose(_ notification: Notification) {
+        webView?.stopLoading()
+        webView?.navigationDelegate = nil
+        webView = nil
+        statusLabel = nil
+        window = nil
+        onSaved = nil
+    }
+}

--- a/Sources/VibeBarApp/Views/SettingsView.swift
+++ b/Sources/VibeBarApp/Views/SettingsView.swift
@@ -8,6 +8,7 @@ struct SettingsView: View {
 
     private let intervalOptions: [Int] = [60, 180, 300, 600, 1800]
     private let costRetentionOptions = CostDataSettings.retentionOptions
+    @State private var openAICookieDeleteFailed: Bool = false
     @State private var claudeCookieDeleteFailed: Bool = false
     @State private var costDataClearStatus: String?
     @State private var launchAtLoginStatusText: String = LoginItemController.statusText
@@ -91,6 +92,57 @@ struct SettingsView: View {
                         }
                     }
 
+                    settingsSection("OpenAI Account") {
+                        Picker("Usage source", selection: $settingsStore.settings.codexUsageMode) {
+                            ForEach(CodexUsageMode.allCases) { mode in
+                                Text(mode.label).tag(mode)
+                            }
+                        }
+                        Text(settingsStore.settings.codexUsageMode.detail)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                        HStack {
+                            Button {
+                                environment.importOpenAIBrowserCookies()
+                            } label: {
+                                Label("Import from browser", systemImage: "safari")
+                            }
+                            .disabled(environment.isImportingOpenAIBrowserCookies)
+                            Button {
+                                environment.openOpenAIWebLogin()
+                            } label: {
+                                Label("Open WebView login", systemImage: "person.crop.circle.badge.key")
+                            }
+                            Button(role: .destructive) {
+                                openAICookieDeleteFailed = !environment.deleteOpenAIWebCookies()
+                            } label: {
+                                Label("Delete cookies", systemImage: "trash")
+                            }
+                            .disabled(!environment.hasOpenAIWebCookies)
+                        }
+                        if environment.hasOpenAIWebCookies {
+                            Text("Cookies saved.")
+                                .font(.caption2).foregroundStyle(.green)
+                        }
+                        if let status = environment.openAIBrowserCookieImportStatus {
+                            Text(status)
+                                .font(.caption2)
+                                .foregroundStyle(status.hasPrefix("Imported") ? .green : .secondary)
+                        }
+                        if openAICookieDeleteFailed {
+                            Text("Could not delete saved cookies.")
+                                .font(.caption2).foregroundStyle(.orange)
+                        }
+                        Divider()
+                            .padding(.vertical, 2)
+                        connectionHealthRows(provider: .codex)
+                        Button {
+                            environment.recheckPrimaryRouteHealth(provider: .codex)
+                        } label: {
+                            Label("Check connections", systemImage: "checkmark.circle")
+                        }
+                    }
+
                     settingsSection("Claude Account") {
                         Picker("Usage source", selection: $settingsStore.settings.claudeUsageMode) {
                             ForEach(ClaudeUsageMode.allCases) { mode in
@@ -131,6 +183,14 @@ struct SettingsView: View {
                         if claudeCookieDeleteFailed {
                             Text("Could not delete saved cookies.")
                                 .font(.caption2).foregroundStyle(.orange)
+                        }
+                        Divider()
+                            .padding(.vertical, 2)
+                        connectionHealthRows(provider: .claude)
+                        Button {
+                            environment.recheckPrimaryRouteHealth(provider: .claude)
+                        } label: {
+                            Label("Check connections", systemImage: "checkmark.circle")
                         }
                     }
 
@@ -198,7 +258,7 @@ struct SettingsView: View {
                     }
 
                     settingsSection("Privacy") {
-                        Text("Tokens are read from local CLI credentials. Claude Web cookies are stored in Keychain. Settings, quota cache, and cost summaries are stored under ~/.vibebar.")
+                        Text("Tokens are read from local CLI credentials. Saved OpenAI and Claude Web cookies are stored in macOS Keychain, split by browser and WebView source. Legacy plaintext cookie files under ~/.vibebar/cookies are migrated once and deleted. Settings, quota cache, and cost summaries stay under ~/.vibebar.")
                             .font(.caption)
                             .foregroundStyle(.secondary)
                     }
@@ -231,6 +291,45 @@ struct SettingsView: View {
                 RoundedRectangle(cornerRadius: 8, style: .continuous)
                     .stroke(Color.primary.opacity(0.08), lineWidth: 0.6)
             )
+        }
+    }
+
+    private func connectionHealthRows(provider: ToolType) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("Connection health")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            ForEach(PrimaryProviderRoute.routes(for: provider)) { route in
+                let health = environment.routeHealth[route]
+                    ?? PrimaryProviderRouteHealth(
+                        route: route,
+                        status: .missing,
+                        detail: "Not checked"
+                    )
+                HStack(spacing: 8) {
+                    Circle()
+                        .fill(healthColor(health.status))
+                        .frame(width: 8, height: 8)
+                    Text(route.label)
+                        .font(.caption2)
+                        .fontWeight(.medium)
+                    Spacer(minLength: 12)
+                    Text(health.detail)
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                    Text(health.checkedAt, style: .time)
+                        .font(.caption2)
+                        .foregroundStyle(.tertiary)
+                }
+            }
+        }
+    }
+
+    private func healthColor(_ status: PrimaryProviderRouteHealthStatus) -> Color {
+        switch status {
+        case .ok: return .green
+        case .missing: return .red
+        case .blocked, .failed: return .orange
         }
     }
 

--- a/Sources/VibeBarCore/Adapters/ClaudeQuotaAdapter.swift
+++ b/Sources/VibeBarCore/Adapters/ClaudeQuotaAdapter.swift
@@ -5,46 +5,39 @@ public struct ClaudeQuotaAdapter: QuotaAdapter {
 
     private let endpoint = URL(string: "https://api.anthropic.com/api/oauth/usage")!
     private let session: URLSession
-    private let credentialResolver: @Sendable (AccountIdentity) throws -> ClaudeCredential
+    private let credentialResolver: @Sendable (CredentialSource, AccountIdentity) throws -> ClaudeCredential
 
     public init(
         session: URLSession = .shared,
-        credentialResolver: (@Sendable (AccountIdentity) throws -> ClaudeCredential)? = nil
+        credentialResolver: (@Sendable (CredentialSource, AccountIdentity) throws -> ClaudeCredential)? = nil
     ) {
         self.session = session
         self.credentialResolver = credentialResolver ?? Self.defaultResolver
     }
 
     public func fetch(for account: AccountIdentity) async throws -> AccountQuota {
-        if account.source == .webCookie {
+        var firstError: Error?
+        for source in sourceOrder(for: account) {
             do {
-                return try await fetchWithWebCookies(for: account)
-            } catch let qe as QuotaError {
-                return try await fetchWithCLIOrThrow(original: qe, account: account)
+                switch source {
+                case .webCookie:
+                    return try await fetchWithWebCookies(for: account)
+                case .oauthCLI, .cliDetected:
+                    return try await fetchWithOAuthCredential(for: account, source: source)
+                case .apiToken, .browserCookie, .manualCookie, .localProbe, .notConfigured:
+                    continue
+                }
             } catch {
-                return try await fetchWithCLIOrThrow(
-                    original: QuotaError.unknown(SafeLog.sanitize(error.localizedDescription)),
-                    account: account
-                )
+                if firstError == nil { firstError = error }
             }
         }
-
-        do {
-            return try await fetchWithCLI(for: account)
-        } catch let qe as QuotaError {
-            return try await fetchWithWebCookiesOrThrow(original: qe, account: account)
-        } catch {
-            return try await fetchWithWebCookiesOrThrow(
-                original: QuotaError.unknown(SafeLog.sanitize(error.localizedDescription)),
-                account: account
-            )
-        }
+        throw firstError ?? QuotaError.noCredential
     }
 
-    private func fetchWithCLI(for account: AccountIdentity) async throws -> AccountQuota {
+    private func fetchWithOAuthCredential(for account: AccountIdentity, source: CredentialSource) async throws -> AccountQuota {
         let credential: ClaudeCredential
         do {
-            credential = try credentialResolver(account)
+            credential = try credentialResolver(source, account)
         } catch let qe as QuotaError {
             throw qe
         } catch {
@@ -109,24 +102,6 @@ public struct ClaudeQuotaAdapter: QuotaAdapter {
             error: nil,
             providerExtras: extras
         )
-    }
-
-    private func fetchWithCLIOrThrow(original: QuotaError, account: AccountIdentity) async throws -> AccountQuota {
-        guard account.allowsCLIFallback else { throw original }
-        do {
-            return try await fetchWithCLI(for: account)
-        } catch {
-            throw original
-        }
-    }
-
-    private func fetchWithWebCookiesOrThrow(original: QuotaError, account: AccountIdentity) async throws -> AccountQuota {
-        guard account.allowsWebFallback else { throw original }
-        do {
-            return try await fetchWithWebCookies(for: account)
-        } catch {
-            throw original
-        }
     }
 
     /// Build a QuotaBucket from a Daily Routines budget snapshot. The slot is
@@ -305,9 +280,38 @@ public struct ClaudeQuotaAdapter: QuotaAdapter {
     }
 
     @Sendable
-    private static func defaultResolver(_ account: AccountIdentity) throws -> ClaudeCredential {
-        guard account.source == .cliDetected || account.allowsCLIFallback else { throw QuotaError.noCredential }
-        return try ClaudeCredentialReader.loadFromCLI()
+    private static func defaultResolver(_ source: CredentialSource, _ account: AccountIdentity) throws -> ClaudeCredential {
+        switch source {
+        case .oauthCLI:
+            return try ClaudeCredentialReader.loadFromOAuth()
+        case .cliDetected:
+            return try ClaudeCredentialReader.loadFromCLI()
+        case .webCookie, .apiToken, .browserCookie, .manualCookie, .localProbe, .notConfigured:
+            guard account.source == .cliDetected || account.allowsCLIFallback else { throw QuotaError.noCredential }
+            return try ClaudeCredentialReader.loadFromCLI()
+        }
+    }
+
+    private func sourceOrder(for account: AccountIdentity) -> [CredentialSource] {
+        let raw: [CredentialSource]
+        switch account.source {
+        case .oauthCLI:
+            raw = [.oauthCLI]
+                + (account.allowsCLIFallback ? [.cliDetected] : [])
+                + (account.allowsWebFallback ? [.webCookie] : [])
+        case .cliDetected:
+            raw = [.cliDetected]
+                + (account.allowsWebFallback ? [.webCookie] : [])
+                + (account.allowsOAuthFallback ? [.oauthCLI] : [])
+        case .webCookie:
+            raw = [.webCookie]
+                + (account.allowsCLIFallback ? [.cliDetected] : [])
+                + (account.allowsOAuthFallback ? [.oauthCLI] : [])
+        case .apiToken, .browserCookie, .manualCookie, .localProbe, .notConfigured:
+            raw = ClaudeSourcePlanner.resolve(mode: .auto)
+        }
+        var seen: Set<CredentialSource> = []
+        return raw.filter { seen.insert($0).inserted }
     }
 
     private static func nextRoutineResetDate(now: Date = Date()) -> Date? {

--- a/Sources/VibeBarCore/Adapters/CodexOAuthTokenRefresher.swift
+++ b/Sources/VibeBarCore/Adapters/CodexOAuthTokenRefresher.swift
@@ -1,0 +1,68 @@
+import Foundation
+
+enum CodexOAuthTokenRefresher {
+    private static let refreshEndpoint = URL(string: "https://auth.openai.com/oauth/token")!
+    private static let clientID = "app_EMoamEEZ73f0CkXaXp7hrann"
+
+    enum RefreshError: Error {
+        case noRefreshToken
+        case invalidResponse
+        case unauthorized
+        case network(Error)
+    }
+
+    static func refresh(_ credential: CodexCredential, session: URLSession = .shared) async throws -> CodexCredential {
+        guard let refreshToken = credential.refreshToken?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !refreshToken.isEmpty else {
+            throw RefreshError.noRefreshToken
+        }
+
+        var request = URLRequest(url: refreshEndpoint)
+        request.httpMethod = "POST"
+        request.timeoutInterval = 30
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try JSONSerialization.data(withJSONObject: [
+            "client_id": clientID,
+            "grant_type": "refresh_token",
+            "refresh_token": refreshToken,
+            "scope": "openid profile email"
+        ])
+
+        do {
+            let (data, response) = try await session.data(for: request)
+            guard let http = response as? HTTPURLResponse else {
+                throw RefreshError.invalidResponse
+            }
+            switch http.statusCode {
+            case 200:
+                break
+            case 401, 403:
+                throw RefreshError.unauthorized
+            default:
+                throw RefreshError.invalidResponse
+            }
+            guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+                throw RefreshError.invalidResponse
+            }
+            let accessToken = (json["access_token"] as? String) ?? credential.accessToken
+            let nextRefreshToken = (json["refresh_token"] as? String) ?? refreshToken
+            let idToken = (json["id_token"] as? String) ?? credential.idToken
+            return CodexCredential(
+                accessToken: accessToken,
+                refreshToken: nextRefreshToken,
+                accountId: credential.accountId,
+                idToken: idToken,
+                email: credential.email,
+                plan: credential.plan,
+                authMode: credential.authMode,
+                lastRefresh: ISO8601DateFormatter().string(from: Date()),
+                lastRefreshDate: Date(),
+                source: credential.source
+            )
+        } catch let error as RefreshError {
+            throw error
+        } catch {
+            throw RefreshError.network(error)
+        }
+    }
+}

--- a/Sources/VibeBarCore/Adapters/CodexQuotaAdapter.swift
+++ b/Sources/VibeBarCore/Adapters/CodexQuotaAdapter.swift
@@ -5,20 +5,39 @@ public struct CodexQuotaAdapter: QuotaAdapter {
 
     private let endpoint = URL(string: "https://chatgpt.com/backend-api/wham/usage")!
     private let session: URLSession
-    private let credentialResolver: @Sendable (AccountIdentity) throws -> CodexCredential
+    private let credentialResolver: @Sendable (CredentialSource, AccountIdentity) throws -> CodexCredential
 
     public init(
         session: URLSession = .shared,
-        credentialResolver: (@Sendable (AccountIdentity) throws -> CodexCredential)? = nil
+        credentialResolver: (@Sendable (CredentialSource, AccountIdentity) throws -> CodexCredential)? = nil
     ) {
         self.session = session
         self.credentialResolver = credentialResolver ?? Self.defaultResolver
     }
 
     public func fetch(for account: AccountIdentity) async throws -> AccountQuota {
-        let credential: CodexCredential
+        var firstError: Error?
+        for source in sourceOrder(for: account) {
+            do {
+                if source == .webCookie {
+                    return try await fetchWithWebCookies(for: account)
+                }
+                return try await fetch(for: account, source: source)
+            } catch {
+                if firstError == nil { firstError = error }
+            }
+        }
+        throw firstError ?? QuotaError.noCredential
+    }
+
+    private func fetch(for account: AccountIdentity, source: CredentialSource) async throws -> AccountQuota {
+        var credential: CodexCredential
         do {
-            credential = try credentialResolver(account)
+            credential = try credentialResolver(source, account)
+            if source == .oauthCLI, credential.needsRefresh {
+                credential = try await CodexOAuthTokenRefresher.refresh(credential, session: session)
+                try? CodexCredentialReader.saveOAuth(credential)
+            }
         } catch let qe as QuotaError {
             throw qe
         } catch {
@@ -78,9 +97,92 @@ public struct CodexQuotaAdapter: QuotaAdapter {
         )
     }
 
+    private func fetchWithWebCookies(for account: AccountIdentity) async throws -> AccountQuota {
+        let cookieHeader = try OpenAIWebCookieStore.readCookieHeader()
+        var request = URLRequest(url: endpoint)
+        request.httpMethod = "GET"
+        request.setValue(cookieHeader, forHTTPHeaderField: "Cookie")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.setValue("https://chatgpt.com/codex/settings/usage", forHTTPHeaderField: "Referer")
+        request.setValue("chatgpt.com", forHTTPHeaderField: "Origin")
+        request.setValue("VibeBar", forHTTPHeaderField: "User-Agent")
+        request.timeoutInterval = 15
+
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await session.data(for: request)
+        } catch {
+            SafeLog.net("OpenAI web quota fetch failed: \(SafeLog.sanitize(error.localizedDescription))")
+            throw mapURLError(error)
+        }
+
+        let http = response as? HTTPURLResponse
+        switch http?.statusCode {
+        case .some(200), .none:
+            break
+        case .some(401), .some(403):
+            throw QuotaError.needsLogin
+        case .some(429):
+            throw QuotaError.rateLimited
+        case .some(let code) where code >= 500:
+            throw QuotaError.network("server \(code)")
+        case .some(let code):
+            throw QuotaError.unknown("HTTP \(code)")
+        }
+
+        let buckets: [QuotaBucket]
+        do {
+            buckets = try CodexResponseParser.parse(data: data)
+        } catch let qe as QuotaError {
+            throw qe
+        } catch {
+            throw QuotaError.parseFailure(String(describing: error))
+        }
+
+        return AccountQuota(
+            accountId: account.id,
+            tool: .codex,
+            buckets: buckets,
+            plan: CodexResponseParser.planType(data: data) ?? account.plan,
+            email: account.email,
+            queriedAt: Date(),
+            error: nil
+        )
+    }
+
     @Sendable
-    private static func defaultResolver(_ account: AccountIdentity) throws -> CodexCredential {
-        guard account.source == .cliDetected else { throw QuotaError.noCredential }
-        return try CodexCredentialReader.loadFromCLI()
+    private static func defaultResolver(_ source: CredentialSource, _ account: AccountIdentity) throws -> CodexCredential {
+        switch source {
+        case .oauthCLI:
+            return try CodexCredentialReader.loadFromOAuth()
+        case .cliDetected:
+            return try CodexCredentialReader.loadFromCLI()
+        case .webCookie, .apiToken, .browserCookie, .manualCookie, .localProbe, .notConfigured:
+            guard account.source == .cliDetected else { throw QuotaError.noCredential }
+            return try CodexCredentialReader.loadFromCLI()
+        }
+    }
+
+    private func sourceOrder(for account: AccountIdentity) -> [CredentialSource] {
+        let raw: [CredentialSource]
+        switch account.source {
+        case .oauthCLI:
+            raw = [.oauthCLI]
+                + (account.allowsCLIFallback ? [.cliDetected] : [])
+                + (account.allowsWebFallback ? [.webCookie] : [])
+        case .cliDetected:
+            raw = [.cliDetected]
+                + (account.allowsOAuthFallback ? [.oauthCLI] : [])
+                + (account.allowsWebFallback ? [.webCookie] : [])
+        case .webCookie:
+            raw = [.webCookie]
+                + (account.allowsOAuthFallback ? [.oauthCLI] : [])
+                + (account.allowsCLIFallback ? [.cliDetected] : [])
+        case .apiToken, .browserCookie, .manualCookie, .localProbe, .notConfigured:
+            raw = CodexSourcePlanner.resolve(mode: .auto)
+        }
+        var seen: Set<CredentialSource> = []
+        return raw.filter { seen.insert($0).inserted }
     }
 }

--- a/Sources/VibeBarCore/BrowserCookies/BrowserCookieImportOrder.swift
+++ b/Sources/VibeBarCore/BrowserCookies/BrowserCookieImportOrder.swift
@@ -23,7 +23,18 @@ extension Array where Element == Browser {
             }
             return detection.isCookieSourceAvailable(browser)
         }
-        guard !allowKeychainPrompt else { return candidates }
+        if allowKeychainPrompt {
+            // Manual imports may need the login-keychain password for
+            // Chromium's "Safe Storage" secret. Try non-Keychain browsers
+            // freely, but cap Chromium-style attempts at one browser per
+            // click so a single import cannot fan out into a stack of
+            // password prompts.
+            var scoped = candidates.filter { !$0.usesKeychainForCookieDecryption }
+            if let firstKeychainBrowser = candidates.first(where: \.usesKeychainForCookieDecryption) {
+                scoped.append(firstKeychainBrowser)
+            }
+            return scoped
+        }
         return candidates.filter { BrowserCookieAccessGate.shouldAttempt($0) }
     }
 

--- a/Sources/VibeBarCore/BrowserCookies/OpenAIBrowserCookieImporter.swift
+++ b/Sources/VibeBarCore/BrowserCookies/OpenAIBrowserCookieImporter.swift
@@ -1,18 +1,14 @@
 import Foundation
 import SweetCookieKit
 
-/// Imports the minimum Claude web session cookie from the user's
-/// installed browsers. This is the reliable fallback for the Claude
-/// card when the in-app WebView login flow hits SSO / blank-page
-/// trouble.
-public enum ClaudeBrowserCookieImporter {
+public enum OpenAIBrowserCookieImporter {
     public struct Result: Sendable {
         public let header: String
         public let sourceLabel: String
         public let cookieCount: Int
     }
 
-    public static let cookieDomains = ["claude.ai"]
+    public static let cookieDomains = ["chatgpt.com", "chat.openai.com", "openai.com"]
 
     public static func importAndStoreFromBrowsers(
         allowKeychainPrompt: Bool = false,
@@ -30,7 +26,7 @@ public enum ClaudeBrowserCookieImporter {
         ) else {
             return nil
         }
-        try ClaudeWebCookieStore.writeCookieHeader(result.header, source: .browser)
+        try OpenAIWebCookieStore.writeCookieHeader(result.header, source: .browser)
         return result
     }
 
@@ -60,7 +56,7 @@ public enum ClaudeBrowserCookieImporter {
                 )
             } catch {
                 BrowserCookieAccessGate.recordIfNeeded(error)
-                logger?("\(browser.displayName) Claude cookie import failed: \(SafeLog.sanitize(error.localizedDescription))")
+                logger?("\(browser.displayName) OpenAI cookie import failed: \(SafeLog.sanitize(error.localizedDescription))")
                 continue
             }
 
@@ -68,25 +64,12 @@ public enum ClaudeBrowserCookieImporter {
                 let pairs = store.records.map { record in
                     (name: record.name, value: record.value)
                 }
-                guard let header = sessionHeader(from: pairs) else { continue }
+                guard let header = OpenAIWebCookieStore.cookieHeader(from: pairs) else { continue }
                 let label = "\(browser.displayName) (\(store.store.profile.name))"
-                return Result(
-                    header: header,
-                    sourceLabel: label,
-                    cookieCount: store.records.count
-                )
+                return Result(header: header, sourceLabel: label, cookieCount: store.records.count)
             }
         }
 
-        return nil
-    }
-
-    public static func sessionHeader(from cookies: [(name: String, value: String)]) -> String? {
-        for cookie in cookies where cookie.name == "sessionKey" {
-            let value = cookie.value.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard value.hasPrefix("sk-ant-") else { continue }
-            return ClaudeWebCookieStore.minimizedCookieHeader(from: "sessionKey=\(value)")
-        }
         return nil
     }
 }

--- a/Sources/VibeBarCore/Credentials/ClaudeCredentialReader.swift
+++ b/Sources/VibeBarCore/Credentials/ClaudeCredentialReader.swift
@@ -17,6 +17,16 @@ public enum ClaudeCredentialReader {
         return try readFromCredentialsJSON()
     }
 
+    public static func loadFromOAuth() throws -> ClaudeCredential {
+        if let fromFile = try? readFromCredentialsJSON(source: .oauthCLI) {
+            return fromFile
+        }
+        if let fromKeychain = try? readFromKeychain(source: .oauthCLI) {
+            return fromKeychain
+        }
+        throw QuotaError.noCredential
+    }
+
     public static func decode(jsonString: String, source: CredentialSource) throws -> ClaudeCredential {
         guard let data = jsonString.data(using: .utf8) else {
             throw QuotaError.parseFailure("credentials json is not utf8")
@@ -53,19 +63,19 @@ public enum ClaudeCredentialReader {
         )
     }
 
-    private static func readFromKeychain() throws -> ClaudeCredential {
+    private static func readFromKeychain(source: CredentialSource = .cliDetected) throws -> ClaudeCredential {
         let raw = try KeychainStore.readString(service: keychainService)
-        return try decode(jsonString: raw, source: .cliDetected)
+        return try decode(jsonString: raw, source: source)
     }
 
-    private static func readFromCredentialsJSON() throws -> ClaudeCredential {
+    private static func readFromCredentialsJSON(source: CredentialSource = .cliDetected) throws -> ClaudeCredential {
         let url = RealHomeDirectory.url
             .appendingPathComponent(".claude/.credentials.json")
         guard FileManager.default.fileExists(atPath: url.path) else {
             throw QuotaError.noCredential
         }
         let data = try Data(contentsOf: url)
-        return try decode(data: data, source: .cliDetected)
+        return try decode(data: data, source: source)
     }
 
     private static func parseExpiresAt(_ any: Any?) -> Date? {

--- a/Sources/VibeBarCore/Credentials/ClaudeWebCookieStore.swift
+++ b/Sources/VibeBarCore/Credentials/ClaudeWebCookieStore.swift
@@ -2,13 +2,21 @@ import Foundation
 
 /// Storage for the minimum Claude web session cookie needed by Vibe Bar.
 ///
-/// Cookies are stored in Keychain. Older builds wrote
-/// `~/.vibebar/cookies/claude-web.txt`; reads still migrate that legacy file
-/// into Keychain and then remove it.
+/// Cookies are stored in the user's Keychain, split by source: one
+/// captured from Vibe Bar's WebView, one imported from browser cookies.
+/// Older plaintext files under `~/.vibebar/cookies` are migrated once and
+/// deleted immediately.
 public enum ClaudeWebCookieStore {
-    private static let service = "Vibe Bar Claude Web Cookies"
-    private static let account = "claude.ai"
-    private static let organizationAccount = "claude.ai.organization"
+    public enum CookieSource: Sendable {
+        case webView
+        case browser
+        case legacy
+    }
+
+    private static let legacyService = "Vibe Bar Claude Web Cookies"
+    private static let legacyAccount = "claude.ai"
+    private static let legacyOrganizationAccount = "claude.ai.organization"
+    private static let organizationAccount = "claude.organization-id"
 
     public static func readCookieHeader() throws -> String {
         if let header = candidateCookieHeaders().first {
@@ -17,34 +25,31 @@ public enum ClaudeWebCookieStore {
         throw QuotaError.noCredential
     }
 
+    public static func readCookieHeader(source: CookieSource) throws -> String {
+        migrateLegacyPlaintextCookiesIfNeeded()
+        if let header = storedCookieHeader(source: source) {
+            return header
+        }
+        throw QuotaError.noCredential
+    }
+
     public static func candidateCookieHeaders() -> [String] {
+        migrateLegacyPlaintextCookiesIfNeeded()
         var headers: [String] = []
-        let rawKeychainHeader = readKeychainStringWithLegacyMigration(account: account)
-        let keychainHeader = rawKeychainHeader
-            .map { normalizedCookieHeader(from: $0) }
-            .flatMap { $0.isEmpty ? nil : $0 }
-            .flatMap { minimizedCookieHeader(from: $0) }
-        if let rawKeychainHeader,
-           let keychainHeader,
-           normalizedCookieHeader(from: rawKeychainHeader) != keychainHeader {
-            try? KeychainStore.writeString(service: service, account: account, value: keychainHeader, useDataProtectionKeychain: true)
-        }
-        appendCookieHeader(keychainHeader, to: &headers)
-        if let legacy = try? VibeBarLocalStore.readString(from: VibeBarLocalStore.claudeCookieURL) {
-            let legacyHeader = minimizedCookieHeader(from: legacy)
-            if keychainHeader == nil, let legacyHeader {
-                appendCookieHeader(legacyHeader, to: &headers)
-                try? writeCookieHeader(legacyHeader)
-            }
-            try? VibeBarLocalStore.deleteFile(at: VibeBarLocalStore.claudeCookieURL)
-        }
+        appendStoredCookieHeader(source: .browser, to: &headers)
+        appendStoredCookieHeader(source: .webView, to: &headers)
         return unique(headers)
     }
 
-    public static func writeCookieHeader(_ header: String) throws {
+    public static func writeCookieHeader(_ header: String, source: CookieSource = .legacy) throws {
         guard let minimized = minimizedCookieHeader(from: header) else { throw QuotaError.noCredential }
-        try KeychainStore.writeString(service: service, account: account, value: minimized, useDataProtectionKeychain: true)
+        try SecureCookieHeaderStore.store(
+            minimized,
+            provider: .claude,
+            source: secureSource(for: source)
+        )
         try? VibeBarLocalStore.deleteFile(at: VibeBarLocalStore.claudeCookieURL)
+        try? VibeBarLocalStore.deleteFile(at: legacyURL(for: source))
     }
 
     public static func hasCookieHeader() -> Bool {
@@ -52,42 +57,60 @@ public enum ClaudeWebCookieStore {
     }
 
     public static func deleteCookieHeader() throws {
+        try SecureCookieHeaderStore.deleteAll(provider: .claude)
         try VibeBarLocalStore.deleteFile(at: VibeBarLocalStore.claudeCookieURL)
+        try VibeBarLocalStore.deleteFile(at: VibeBarLocalStore.claudeWebViewCookieURL)
+        try VibeBarLocalStore.deleteFile(at: VibeBarLocalStore.claudeBrowserCookieURL)
         try VibeBarLocalStore.deleteFile(at: VibeBarLocalStore.claudeOrganizationIDURL)
-        try? KeychainStore.deleteItem(service: service, account: account, useDataProtectionKeychain: true)
-        try? KeychainStore.deleteItem(service: service, account: organizationAccount, useDataProtectionKeychain: true)
+        try? KeychainStore.deleteItem(
+            service: SecureCookieHeaderStore.keychainService,
+            account: organizationAccount,
+            useDataProtectionKeychain: true
+        )
+        try? KeychainStore.deleteItem(service: legacyService, account: legacyAccount, useDataProtectionKeychain: true)
+        try? KeychainStore.deleteItem(service: legacyService, account: legacyOrganizationAccount, useDataProtectionKeychain: true)
     }
 
     public static func readOrganizationID() -> String? {
-        if let raw = readKeychainStringWithLegacyMigration(account: organizationAccount),
-           let normalized = normalizedOrganizationID(raw) {
-            try? VibeBarLocalStore.deleteFile(at: VibeBarLocalStore.claudeOrganizationIDURL)
+        if let raw = try? KeychainStore.readString(
+            service: SecureCookieHeaderStore.keychainService,
+            account: organizationAccount,
+            useDataProtectionKeychain: true
+        ), let normalized = normalizedOrganizationID(raw) {
             return normalized
         }
-        if let legacy = try? VibeBarLocalStore.readString(from: VibeBarLocalStore.claudeOrganizationIDURL),
-           let normalized = normalizedOrganizationID(legacy) {
-            try? writeOrganizationID(normalized)
+
+        if let local = try? VibeBarLocalStore.readString(from: VibeBarLocalStore.claudeOrganizationIDURL),
+           let normalized = normalizedOrganizationID(local) {
+            try? KeychainStore.writeString(
+                service: SecureCookieHeaderStore.keychainService,
+                account: organizationAccount,
+                value: normalized,
+                useDataProtectionKeychain: true
+            )
+            try? VibeBarLocalStore.deleteFile(at: VibeBarLocalStore.claudeOrganizationIDURL)
             return normalized
         }
         return nil
     }
 
-    /// Read the Codex Bar-style login-keychain item, with a
-    /// best-effort migration fallback for short-lived builds that
-    /// attempted to store Claude web state in the data-protection
-    /// keychain.
-    private static func readKeychainStringWithLegacyMigration(account: String) -> String? {
-        return try? KeychainStore.readString(
-            service: service,
-            account: account,
-            useDataProtectionKeychain: true
-        )
-    }
-
     public static func writeOrganizationID(_ organizationID: String) throws {
         guard let trimmed = normalizedOrganizationID(organizationID) else { return }
-        try KeychainStore.writeString(service: service, account: organizationAccount, value: trimmed, useDataProtectionKeychain: true)
+        try KeychainStore.writeString(
+            service: SecureCookieHeaderStore.keychainService,
+            account: organizationAccount,
+            value: trimmed,
+            useDataProtectionKeychain: true
+        )
         try? VibeBarLocalStore.deleteFile(at: VibeBarLocalStore.claudeOrganizationIDURL)
+    }
+
+    public static func storageState(source: CookieSource) -> SecureCookieHeaderStore.LoadResult {
+        migrateLegacyPlaintextCookiesIfNeeded()
+        return SecureCookieHeaderStore.load(
+            provider: .claude,
+            source: secureSource(for: source)
+        )
     }
 
     public static func sessionKeyHeader(from header: String) -> String? {
@@ -118,6 +141,51 @@ public enum ClaudeWebCookieStore {
         guard let raw else { return }
         guard let header = minimizedCookieHeader(from: raw) else { return }
         headers.append(header)
+    }
+
+    private static func appendStoredCookieHeader(source: CookieSource, to headers: inout [String]) {
+        appendCookieHeader(storedCookieHeader(source: source), to: &headers)
+    }
+
+    private static func storedCookieHeader(source: CookieSource) -> String? {
+        switch SecureCookieHeaderStore.load(provider: .claude, source: secureSource(for: source)) {
+        case .found(let raw):
+            return minimizedCookieHeader(from: raw)
+        case .missing, .temporarilyUnavailable, .invalid:
+            return nil
+        }
+    }
+
+    private static func migrateLegacyPlaintextCookiesIfNeeded() {
+        migrateLegacyPlaintextCookieIfNeeded(from: VibeBarLocalStore.claudeBrowserCookieURL, source: .browser)
+        migrateLegacyPlaintextCookieIfNeeded(from: VibeBarLocalStore.claudeWebViewCookieURL, source: .webView)
+        migrateLegacyPlaintextCookieIfNeeded(from: VibeBarLocalStore.claudeCookieURL, source: .webView)
+    }
+
+    private static func migrateLegacyPlaintextCookieIfNeeded(from url: URL, source: CookieSource) {
+        guard let raw = try? VibeBarLocalStore.readString(from: url) else { return }
+        defer { try? VibeBarLocalStore.deleteFile(at: url) }
+        guard let header = minimizedCookieHeader(from: raw) else { return }
+        try? SecureCookieHeaderStore.store(
+            header,
+            provider: .claude,
+            source: secureSource(for: source)
+        )
+    }
+
+    private static func secureSource(for source: CookieSource) -> SecureCookieHeaderStore.Source {
+        switch source {
+        case .webView, .legacy: return .webView
+        case .browser: return .browser
+        }
+    }
+
+    private static func legacyURL(for source: CookieSource) -> URL {
+        switch source {
+        case .webView: return VibeBarLocalStore.claudeWebViewCookieURL
+        case .browser: return VibeBarLocalStore.claudeBrowserCookieURL
+        case .legacy: return VibeBarLocalStore.claudeCookieURL
+        }
     }
 
     private static func normalizedOrganizationID(_ raw: String) -> String? {

--- a/Sources/VibeBarCore/Credentials/CodexCredentialReader.swift
+++ b/Sources/VibeBarCore/Credentials/CodexCredentialReader.swift
@@ -4,13 +4,23 @@ import Foundation
 /// `accessToken` is sensitive — never log it, never persist outside Keychain.
 public struct CodexCredential: Sendable {
     public let accessToken: String
+    public let refreshToken: String?
     public let accountId: String?
     public let idToken: String?
     public let email: String?
     public let plan: String?
     public let authMode: String
     public let lastRefresh: String?
+    public let lastRefreshDate: Date?
     public let source: CredentialSource
+
+    public var needsRefresh: Bool {
+        guard refreshToken?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false else {
+            return false
+        }
+        guard let lastRefreshDate else { return true }
+        return Date().timeIntervalSince(lastRefreshDate) > 8 * 24 * 60 * 60
+    }
 }
 
 public enum CodexCredentialReader {
@@ -23,6 +33,45 @@ public enum CodexCredentialReader {
             return fromKeychain
         }
         return try readFromAuthJSON()
+    }
+
+    /// OAuth-priority reader. This deliberately reads `auth.json`
+    /// first because it is the Codex CLI's durable OAuth material and
+    /// includes refresh metadata that the Keychain mirror may not expose.
+    public static func loadFromOAuth() throws -> CodexCredential {
+        try readFromAuthJSON(source: .oauthCLI)
+    }
+
+    public static func saveOAuth(_ credential: CodexCredential) throws {
+        let url = authJSONURL()
+        var root: [String: Any] = [:]
+        if let data = try? Data(contentsOf: url),
+           let existing = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
+            root = existing
+        }
+
+        var tokens = (root["tokens"] as? [String: Any]) ?? [:]
+        tokens["access_token"] = credential.accessToken
+        if let refreshToken = credential.refreshToken {
+            tokens["refresh_token"] = refreshToken
+        }
+        if let idToken = credential.idToken {
+            tokens["id_token"] = idToken
+        }
+        if let accountId = credential.accountId {
+            tokens["account_id"] = accountId
+        }
+        root["tokens"] = tokens
+        root["auth_mode"] = credential.authMode
+        root["last_refresh"] = ISO8601DateFormatter().string(from: Date())
+
+        let data = try JSONSerialization.data(withJSONObject: root, options: [.prettyPrinted, .sortedKeys])
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try data.write(to: url, options: [.atomic])
+        try? FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: url.path)
     }
 
     /// Decode a Codex credential JSON blob.
@@ -44,6 +93,8 @@ public enum CodexCredentialReader {
         let accessToken = stringValue(in: tokens, snakeCaseKey: "access_token", camelCaseKey: "accessToken")
             ?? stringValue(in: root, snakeCaseKey: "access_token", camelCaseKey: "accessToken")
             ?? ""
+        let refreshToken = stringValue(in: tokens, snakeCaseKey: "refresh_token", camelCaseKey: "refreshToken")
+            ?? stringValue(in: root, snakeCaseKey: "refresh_token", camelCaseKey: "refreshToken")
         let idToken = stringValue(in: tokens, snakeCaseKey: "id_token", camelCaseKey: "idToken")
             ?? stringValue(in: root, snakeCaseKey: "id_token", camelCaseKey: "idToken")
         let payload = JWTClaims.parse(idToken)
@@ -69,12 +120,14 @@ public enum CodexCredentialReader {
 
         return CodexCredential(
             accessToken: accessToken,
+            refreshToken: refreshToken,
             accountId: accountId,
             idToken: idToken,
             email: email,
             plan: plan,
             authMode: authMode.isEmpty ? "chatgpt" : authMode,
             lastRefresh: lastRefresh,
+            lastRefreshDate: parseLastRefresh(lastRefresh),
             source: source
         )
     }
@@ -84,14 +137,27 @@ public enum CodexCredentialReader {
         return try decode(jsonString: raw, source: .cliDetected)
     }
 
-    private static func readFromAuthJSON() throws -> CodexCredential {
-        let url = RealHomeDirectory.url
-            .appendingPathComponent(".codex/auth.json")
+    private static func readFromAuthJSON(source: CredentialSource = .cliDetected) throws -> CodexCredential {
+        let url = authJSONURL()
         guard FileManager.default.fileExists(atPath: url.path) else {
             throw QuotaError.noCredential
         }
         let data = try Data(contentsOf: url)
-        return try decode(data: data, source: .cliDetected)
+        return try decode(data: data, source: source)
+    }
+
+    private static func parseLastRefresh(_ raw: String?) -> Date? {
+        guard let raw, !raw.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return nil }
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        if let date = f.date(from: raw) { return date }
+        f.formatOptions = [.withInternetDateTime]
+        return f.date(from: raw)
+    }
+
+    private static func authJSONURL() -> URL {
+        RealHomeDirectory.url
+            .appendingPathComponent(".codex/auth.json")
     }
 
     private static func stringValue(

--- a/Sources/VibeBarCore/Credentials/KeychainStore.swift
+++ b/Sources/VibeBarCore/Credentials/KeychainStore.swift
@@ -89,6 +89,7 @@ public enum KeychainStore {
         } else {
             query[kSecMatchLimit as String] = kSecMatchLimitAll
         }
+        KeychainNoUIQuery.apply(to: &query)
 
         var result: AnyObject?
         let status = SecItemCopyMatching(query as CFDictionary, &result)

--- a/Sources/VibeBarCore/Credentials/OpenAIWebCookieStore.swift
+++ b/Sources/VibeBarCore/Credentials/OpenAIWebCookieStore.swift
@@ -1,0 +1,158 @@
+import Foundation
+
+public enum OpenAIWebCookieStore {
+    public enum CookieSource: Sendable, CaseIterable {
+        case webView
+        case browser
+    }
+
+    private static let usefulCookieNames: Set<String> = [
+        "__Secure-next-auth.session-token",
+        "__Host-next-auth.csrf-token",
+        "oai-did",
+        "oai-nav-state",
+        "cf_clearance",
+        "__cf_bm",
+        "_cfuvid"
+    ]
+
+    public static func readCookieHeader() throws -> String {
+        if let header = candidateCookieHeaders().first {
+            return header
+        }
+        throw QuotaError.noCredential
+    }
+
+    public static func readCookieHeader(source: CookieSource) throws -> String {
+        migrateLegacyPlaintextCookiesIfNeeded()
+        if let header = storedCookieHeader(source: source) {
+            return header
+        }
+        throw QuotaError.noCredential
+    }
+
+    public static func candidateCookieHeaders() -> [String] {
+        migrateLegacyPlaintextCookiesIfNeeded()
+        var headers: [String] = []
+        appendStoredCookieHeader(source: .browser, to: &headers)
+        appendStoredCookieHeader(source: .webView, to: &headers)
+        return unique(headers)
+    }
+
+    public static func writeCookieHeader(_ header: String, source: CookieSource) throws {
+        guard let normalized = normalizedCookieHeader(from: header) else { throw QuotaError.noCredential }
+        try SecureCookieHeaderStore.store(
+            normalized,
+            provider: .openAI,
+            source: secureSource(for: source)
+        )
+        try? VibeBarLocalStore.deleteFile(at: legacyURL(for: source))
+    }
+
+    public static func hasCookieHeader() -> Bool {
+        !candidateCookieHeaders().isEmpty
+    }
+
+    public static func deleteCookieHeader() throws {
+        try SecureCookieHeaderStore.deleteAll(provider: .openAI)
+        try VibeBarLocalStore.deleteFile(at: VibeBarLocalStore.openAIWebViewCookieURL)
+        try VibeBarLocalStore.deleteFile(at: VibeBarLocalStore.openAIBrowserCookieURL)
+    }
+
+    public static func storageState(source: CookieSource) -> SecureCookieHeaderStore.LoadResult {
+        migrateLegacyPlaintextCookiesIfNeeded()
+        return SecureCookieHeaderStore.load(
+            provider: .openAI,
+            source: secureSource(for: source)
+        )
+    }
+
+    public static func normalizedCookieHeader(from raw: String) -> String? {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        let withoutPrefix = trimmed.localizedCaseInsensitiveContains("Cookie:")
+            ? trimmed.replacingOccurrences(of: "Cookie:", with: "", options: [.caseInsensitive])
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            : trimmed
+        return cookieHeader(from: cookiePairs(from: withoutPrefix))
+    }
+
+    public static func cookieHeader(from cookies: [(name: String, value: String)]) -> String? {
+        let parts = cookies.compactMap { cookie -> String? in
+            let name = cookie.name.trimmingCharacters(in: .whitespacesAndNewlines)
+            let value = cookie.value.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !name.isEmpty, !value.isEmpty, usefulCookieNames.contains(name) else { return nil }
+            return "\(name)=\(value)"
+        }
+        guard !parts.isEmpty else { return nil }
+        return parts.joined(separator: "; ")
+    }
+
+    private static func appendStoredCookieHeader(source: CookieSource, to headers: inout [String]) {
+        guard let header = storedCookieHeader(source: source) else { return }
+        headers.append(header)
+    }
+
+    private static func storedCookieHeader(source: CookieSource) -> String? {
+        switch SecureCookieHeaderStore.load(provider: .openAI, source: secureSource(for: source)) {
+        case .found(let raw):
+            return normalizedCookieHeader(from: raw)
+        case .missing, .temporarilyUnavailable, .invalid:
+            return nil
+        }
+    }
+
+    private static func migrateLegacyPlaintextCookiesIfNeeded() {
+        for source in CookieSource.allCases {
+            migrateLegacyPlaintextCookieIfNeeded(source: source)
+        }
+    }
+
+    private static func migrateLegacyPlaintextCookieIfNeeded(source: CookieSource) {
+        let url = legacyURL(for: source)
+        guard let raw = try? VibeBarLocalStore.readString(from: url) else { return }
+        defer { try? VibeBarLocalStore.deleteFile(at: url) }
+        guard let header = normalizedCookieHeader(from: raw) else { return }
+        try? SecureCookieHeaderStore.store(
+            header,
+            provider: .openAI,
+            source: secureSource(for: source)
+        )
+    }
+
+    private static func secureSource(for source: CookieSource) -> SecureCookieHeaderStore.Source {
+        switch source {
+        case .webView: return .webView
+        case .browser: return .browser
+        }
+    }
+
+    private static func legacyURL(for source: CookieSource) -> URL {
+        switch source {
+        case .webView: return VibeBarLocalStore.openAIWebViewCookieURL
+        case .browser: return VibeBarLocalStore.openAIBrowserCookieURL
+        }
+    }
+
+    private static func cookiePairs(from header: String) -> [(name: String, value: String)] {
+        header
+            .split(separator: ";")
+            .compactMap { part in
+                let pieces = part.split(separator: "=", maxSplits: 1, omittingEmptySubsequences: false)
+                guard pieces.count == 2 else { return nil }
+                return (
+                    name: pieces[0].trimmingCharacters(in: .whitespacesAndNewlines),
+                    value: pieces[1].trimmingCharacters(in: .whitespacesAndNewlines)
+                )
+            }
+    }
+
+    private static func unique(_ headers: [String]) -> [String] {
+        var seen: Set<String> = []
+        var out: [String] = []
+        for header in headers where seen.insert(header).inserted {
+            out.append(header)
+        }
+        return out
+    }
+}

--- a/Sources/VibeBarCore/Credentials/SecureCookieHeaderStore.swift
+++ b/Sources/VibeBarCore/Credentials/SecureCookieHeaderStore.swift
@@ -1,0 +1,210 @@
+import Foundation
+
+/// Keychain-backed storage for web session cookie headers owned by Vibe Bar.
+///
+/// Browser/WebView cookies are secrets. They must not be persisted in
+/// `~/.vibebar`; that directory is only used for non-secret derived app state
+/// and for one-time migration of older plaintext files.
+public enum SecureCookieHeaderStore {
+    public enum Provider: String, Sendable {
+        case openAI = "openai"
+        case claude
+    }
+
+    public enum Source: String, Sendable, CaseIterable {
+        case browser
+        case webView
+    }
+
+    public struct Entry: Codable, Sendable, Equatable {
+        public let cookieHeader: String
+        public let storedAt: Date
+
+        public init(cookieHeader: String, storedAt: Date = Date()) {
+            self.cookieHeader = cookieHeader
+            self.storedAt = storedAt
+        }
+    }
+
+    public enum LoadResult: Sendable, Equatable {
+        case found(String)
+        case missing
+        case temporarilyUnavailable
+        case invalid
+    }
+
+    public static let keychainService = "com.astroqore.VibeBar.web-cookies"
+
+    private static let cacheLock = NSLock()
+    private nonisolated(unsafe) static var cache: [String: Entry?] = [:]
+    private nonisolated(unsafe) static var unavailableUntilByAccount: [String: Date] = [:]
+    private static let unavailableCooldown: TimeInterval = 60 * 60
+
+    private static let testStoreLock = NSLock()
+    private nonisolated(unsafe) static var testStore: [String: Data]?
+
+    public static func account(provider: Provider, source: Source) -> String {
+        "\(provider.rawValue).\(source.rawValue).cookie"
+    }
+
+    public static func load(provider: Provider, source: Source, now: Date = Date()) -> LoadResult {
+        load(account: account(provider: provider, source: source), now: now)
+    }
+
+    public static func store(_ header: String, provider: Provider, source: Source, now: Date = Date()) throws {
+        try store(Entry(cookieHeader: header, storedAt: now), account: account(provider: provider, source: source))
+    }
+
+    public static func delete(provider: Provider, source: Source) throws {
+        try delete(account: account(provider: provider, source: source))
+    }
+
+    public static func deleteAll(provider: Provider) throws {
+        for source in Source.allCases {
+            try delete(provider: provider, source: source)
+        }
+    }
+
+    public static func withInMemoryStoreForTesting<T>(_ operation: () throws -> T) throws -> T {
+        testStoreLock.lock()
+        let previous = testStore
+        testStore = [:]
+        testStoreLock.unlock()
+
+        cacheLock.lock()
+        let previousCache = cache
+        let previousUnavailable = unavailableUntilByAccount
+        cache = [:]
+        unavailableUntilByAccount = [:]
+        cacheLock.unlock()
+
+        defer {
+            testStoreLock.lock()
+            testStore = previous
+            testStoreLock.unlock()
+
+            cacheLock.lock()
+            cache = previousCache
+            unavailableUntilByAccount = previousUnavailable
+            cacheLock.unlock()
+        }
+
+        return try operation()
+    }
+
+    private static func load(account: String, now: Date) -> LoadResult {
+        if let testResult = loadFromTestStore(account: account) {
+            return testResult
+        }
+
+        cacheLock.lock()
+        if let blockedUntil = unavailableUntilByAccount[account], blockedUntil > now {
+            cacheLock.unlock()
+            return .temporarilyUnavailable
+        }
+        let cached = cache[account]
+        cacheLock.unlock()
+
+        switch cached {
+        case .some(.some(let entry)):
+            return .found(entry.cookieHeader)
+        case .some(.none):
+            return .missing
+        case .none:
+            break
+        }
+
+        do {
+            let data = try KeychainStore.readData(
+                service: keychainService,
+                account: account,
+                useDataProtectionKeychain: true
+            )
+            let entry = try JSONDecoder().decode(Entry.self, from: data)
+            cacheLock.lock()
+            cache[account] = entry
+            unavailableUntilByAccount.removeValue(forKey: account)
+            cacheLock.unlock()
+            return entry.cookieHeader.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                ? .invalid
+                : .found(entry.cookieHeader)
+        } catch KeychainStore.KeychainError.itemNotFound {
+            cacheLock.lock()
+            cache[account] = nil
+            cacheLock.unlock()
+            return .missing
+        } catch KeychainStore.KeychainError.interactionNotAllowed {
+            cacheLock.lock()
+            unavailableUntilByAccount[account] = now.addingTimeInterval(unavailableCooldown)
+            cacheLock.unlock()
+            return .temporarilyUnavailable
+        } catch {
+            return .invalid
+        }
+    }
+
+    private static func store(_ entry: Entry, account: String) throws {
+        let data = try JSONEncoder().encode(entry)
+        if storeInTestStore(data, account: account) {
+            return
+        }
+        try KeychainStore.writeData(
+            service: keychainService,
+            account: account,
+            data: data,
+            useDataProtectionKeychain: true
+        )
+        cacheLock.lock()
+        cache[account] = entry
+        unavailableUntilByAccount.removeValue(forKey: account)
+        cacheLock.unlock()
+    }
+
+    private static func delete(account: String) throws {
+        if deleteFromTestStore(account: account) {
+            return
+        }
+        try KeychainStore.deleteItem(
+            service: keychainService,
+            account: account,
+            useDataProtectionKeychain: true
+        )
+        cacheLock.lock()
+        cache.removeValue(forKey: account)
+        unavailableUntilByAccount.removeValue(forKey: account)
+        cacheLock.unlock()
+    }
+
+    private static func loadFromTestStore(account: String) -> LoadResult? {
+        testStoreLock.lock()
+        guard let store = testStore else {
+            testStoreLock.unlock()
+            return nil
+        }
+        guard let data = store[account] else {
+            testStoreLock.unlock()
+            return .missing
+        }
+        testStoreLock.unlock()
+        guard let entry = try? JSONDecoder().decode(Entry.self, from: data) else {
+            return .invalid
+        }
+        return .found(entry.cookieHeader)
+    }
+
+    private static func storeInTestStore(_ data: Data, account: String) -> Bool {
+        testStoreLock.lock()
+        defer { testStoreLock.unlock() }
+        guard testStore != nil else { return false }
+        testStore?[account] = data
+        return true
+    }
+
+    private static func deleteFromTestStore(account: String) -> Bool {
+        testStoreLock.lock()
+        defer { testStoreLock.unlock() }
+        guard testStore != nil else { return false }
+        testStore?.removeValue(forKey: account)
+        return true
+    }
+}

--- a/Sources/VibeBarCore/Models/AccountIdentity.swift
+++ b/Sources/VibeBarCore/Models/AccountIdentity.swift
@@ -10,6 +10,7 @@ public struct AccountIdentity: Codable, Identifiable, Hashable, Sendable {
     public var source: CredentialSource
     public var allowsWebFallback: Bool
     public var allowsCLIFallback: Bool
+    public var allowsOAuthFallback: Bool
     public var createdAt: Date
     public var updatedAt: Date
 
@@ -23,6 +24,7 @@ public struct AccountIdentity: Codable, Identifiable, Hashable, Sendable {
         source: CredentialSource,
         allowsWebFallback: Bool = false,
         allowsCLIFallback: Bool = false,
+        allowsOAuthFallback: Bool = false,
         createdAt: Date = Date(),
         updatedAt: Date = Date()
     ) {
@@ -35,6 +37,7 @@ public struct AccountIdentity: Codable, Identifiable, Hashable, Sendable {
         self.source = source
         self.allowsWebFallback = allowsWebFallback
         self.allowsCLIFallback = allowsCLIFallback
+        self.allowsOAuthFallback = allowsOAuthFallback
         self.createdAt = createdAt
         self.updatedAt = updatedAt
     }
@@ -56,6 +59,7 @@ public struct AccountIdentity: Codable, Identifiable, Hashable, Sendable {
         case source
         case allowsWebFallback
         case allowsCLIFallback
+        case allowsOAuthFallback
         case createdAt
         case updatedAt
     }
@@ -71,6 +75,7 @@ public struct AccountIdentity: Codable, Identifiable, Hashable, Sendable {
         self.source = try c.decode(CredentialSource.self, forKey: .source)
         self.allowsWebFallback = try c.decodeIfPresent(Bool.self, forKey: .allowsWebFallback) ?? false
         self.allowsCLIFallback = try c.decodeIfPresent(Bool.self, forKey: .allowsCLIFallback) ?? false
+        self.allowsOAuthFallback = try c.decodeIfPresent(Bool.self, forKey: .allowsOAuthFallback) ?? false
         self.createdAt = try c.decodeIfPresent(Date.self, forKey: .createdAt) ?? Date()
         self.updatedAt = try c.decodeIfPresent(Date.self, forKey: .updatedAt) ?? Date()
     }
@@ -86,6 +91,7 @@ public struct AccountIdentity: Codable, Identifiable, Hashable, Sendable {
         try c.encode(source, forKey: .source)
         try c.encode(allowsWebFallback, forKey: .allowsWebFallback)
         try c.encode(allowsCLIFallback, forKey: .allowsCLIFallback)
+        try c.encode(allowsOAuthFallback, forKey: .allowsOAuthFallback)
         try c.encode(createdAt, forKey: .createdAt)
         try c.encode(updatedAt, forKey: .updatedAt)
     }

--- a/Sources/VibeBarCore/Models/AppSettings.swift
+++ b/Sources/VibeBarCore/Models/AppSettings.swift
@@ -6,6 +6,7 @@ public struct AppSettings: Codable, Equatable, Sendable {
     public var launchAtLogin: Bool
     public var menuBarTextEnabled: Bool
     public var mockEnabled: Bool
+    public var codexUsageMode: CodexUsageMode
     public var claudeUsageMode: ClaudeUsageMode
     public var menuBarItems: [MenuBarItemSettings]
     public var miniWindow: MiniWindowSettings
@@ -28,7 +29,8 @@ public struct AppSettings: Codable, Equatable, Sendable {
         launchAtLogin: false,
         menuBarTextEnabled: true,
         mockEnabled: false,
-        claudeUsageMode: .cliThenWeb,
+        codexUsageMode: .auto,
+        claudeUsageMode: .auto,
         menuBarItems: Self.defaultMenuBarItems,
         miniWindow: Self.defaultMiniWindow,
         popoverDensities: Self.defaultPopoverDensities,
@@ -109,7 +111,8 @@ public struct AppSettings: Codable, Equatable, Sendable {
         launchAtLogin: Bool,
         menuBarTextEnabled: Bool,
         mockEnabled: Bool,
-        claudeUsageMode: ClaudeUsageMode = .cliThenWeb,
+        codexUsageMode: CodexUsageMode = .auto,
+        claudeUsageMode: ClaudeUsageMode = .auto,
         menuBarItems: [MenuBarItemSettings] = AppSettings.defaultMenuBarItems,
         miniWindow: MiniWindowSettings = AppSettings.defaultMiniWindow,
         popoverDensities: [MenuBarItemKind: PopoverDensity] = AppSettings.defaultPopoverDensities,
@@ -122,6 +125,7 @@ public struct AppSettings: Codable, Equatable, Sendable {
         self.launchAtLogin = launchAtLogin
         self.menuBarTextEnabled = menuBarTextEnabled
         self.mockEnabled = false
+        self.codexUsageMode = codexUsageMode
         self.claudeUsageMode = claudeUsageMode
         self.menuBarItems = Self.normalizedMenuBarItems(menuBarItems)
         self.miniWindow = miniWindow
@@ -137,6 +141,7 @@ public struct AppSettings: Codable, Equatable, Sendable {
         case launchAtLogin
         case menuBarTextEnabled
         case mockEnabled
+        case codexUsageMode
         case claudeUsageMode
         case menuBarItems
         case miniWindow
@@ -154,6 +159,7 @@ public struct AppSettings: Codable, Equatable, Sendable {
         self.launchAtLogin = try c.decodeIfPresent(Bool.self, forKey: .launchAtLogin) ?? Self.default.launchAtLogin
         self.menuBarTextEnabled = try c.decodeIfPresent(Bool.self, forKey: .menuBarTextEnabled) ?? Self.default.menuBarTextEnabled
         self.mockEnabled = false
+        self.codexUsageMode = try c.decodeIfPresent(CodexUsageMode.self, forKey: .codexUsageMode) ?? Self.default.codexUsageMode
         self.claudeUsageMode = try c.decodeIfPresent(ClaudeUsageMode.self, forKey: .claudeUsageMode) ?? Self.default.claudeUsageMode
 
         // Gemini support was removed; old persisted configs may contain
@@ -214,6 +220,7 @@ public struct AppSettings: Codable, Equatable, Sendable {
         try c.encode(launchAtLogin, forKey: .launchAtLogin)
         try c.encode(menuBarTextEnabled, forKey: .menuBarTextEnabled)
         try c.encode(mockEnabled, forKey: .mockEnabled)
+        try c.encode(codexUsageMode, forKey: .codexUsageMode)
         try c.encode(claudeUsageMode, forKey: .claudeUsageMode)
         try c.encode(menuBarItems, forKey: .menuBarItems)
         try c.encode(miniWindow, forKey: .miniWindow)
@@ -485,8 +492,11 @@ public enum PopoverDensity: String, Codable, CaseIterable, Identifiable, Sendabl
 }
 
 public enum ClaudeUsageMode: String, Codable, CaseIterable, Identifiable, Sendable {
+    case auto
+    case oauthThenCliThenWeb
     case cliThenWeb
     case webThenCli
+    case oauthOnly
     case cliOnly
     case webOnly
 
@@ -494,8 +504,11 @@ public enum ClaudeUsageMode: String, Codable, CaseIterable, Identifiable, Sendab
 
     public var label: String {
         switch self {
+        case .auto: return "Auto"
+        case .oauthThenCliThenWeb: return "OAuth, then Claude Code, then Web"
         case .cliThenWeb: return "Claude Code, then Web"
         case .webThenCli: return "Claude Web, then Claude Code"
+        case .oauthOnly: return "OAuth only"
         case .cliOnly: return "Claude Code only"
         case .webOnly: return "Claude Web only"
         }
@@ -503,8 +516,11 @@ public enum ClaudeUsageMode: String, Codable, CaseIterable, Identifiable, Sendab
 
     public var detail: String {
         switch self {
+        case .auto: return "Use saved claude.ai cookies first; fall back to Claude OAuth and Claude Code."
+        case .oauthThenCliThenWeb: return "Use Claude OAuth first; fall back to Claude Code and saved claude.ai cookies."
         case .cliThenWeb: return "Use Claude Code first; fall back to saved claude.ai cookies."
-        case .webThenCli: return "Use saved claude.ai cookies first; fall back to local Claude Code credentials."
+        case .webThenCli: return "Use saved claude.ai cookies first; fall back to Claude Code and OAuth."
+        case .oauthOnly: return "Use only Claude OAuth credentials."
         case .cliOnly: return "Use only local Claude Code OAuth credentials."
         case .webOnly: return "Use only saved claude.ai cookies."
         }

--- a/Sources/VibeBarCore/Models/CredentialSource.swift
+++ b/Sources/VibeBarCore/Models/CredentialSource.swift
@@ -10,8 +10,10 @@ import Foundation
 /// - `browserCookie` — auto-imported from Chrome / Edge / Brave / Arc /
 ///   Safari / Firefox via SweetCookieKit.
 /// - `manualCookie` — user pasted a `Cookie:` header in Settings.
-/// - `oauthCLI` — read from a sibling CLI's OAuth credential file
-///   (e.g. `~/.gemini/oauth_creds.json`).
+/// - `oauthCLI` — primary-provider OAuth credentials sourced from
+///   provider CLI auth material. For OpenAI this is Codex
+///   `auth.json`; for Claude/Gemini this is the provider's local
+///   OAuth credential file.
 /// - `localProbe` — discovered by probing a locally running process
 ///   (e.g. AntiGravity language server via `lsof`).
 /// - `notConfigured` — placeholder used by `AccountStore` so a misc
@@ -21,10 +23,10 @@ import Foundation
 public enum CredentialSource: String, Codable, Sendable {
     case cliDetected
     case webCookie
+    case oauthCLI
     case apiToken
     case browserCookie
     case manualCookie
-    case oauthCLI
     case localProbe
     case notConfigured
 }

--- a/Sources/VibeBarCore/Models/PrimaryProviderRouteHealth.swift
+++ b/Sources/VibeBarCore/Models/PrimaryProviderRouteHealth.swift
@@ -1,0 +1,199 @@
+import Foundation
+
+public enum PrimaryProviderRoute: String, CaseIterable, Identifiable, Sendable {
+    case openAICLI
+    case openAIOAuth
+    case openAIBrowserCookies
+    case openAIWebViewCookies
+    case claudeBrowserCookies
+    case claudeWebViewCookies
+    case claudeOAuth
+    case claudeCLI
+
+    public var id: String { rawValue }
+
+    public var provider: ToolType {
+        switch self {
+        case .openAICLI, .openAIOAuth, .openAIBrowserCookies, .openAIWebViewCookies:
+            return .codex
+        case .claudeBrowserCookies, .claudeWebViewCookies, .claudeOAuth, .claudeCLI:
+            return .claude
+        }
+    }
+
+    public var label: String {
+        switch self {
+        case .openAICLI: return "CLI"
+        case .openAIOAuth: return "OAuth"
+        case .openAIBrowserCookies: return "Chrome/Safari cookies"
+        case .openAIWebViewCookies: return "WebView cookies"
+        case .claudeBrowserCookies: return "Chrome/Safari cookies"
+        case .claudeWebViewCookies: return "WebView cookies"
+        case .claudeOAuth: return "OAuth"
+        case .claudeCLI: return "CLI"
+        }
+    }
+
+    public static func routes(for provider: ToolType) -> [PrimaryProviderRoute] {
+        allCases.filter { $0.provider == provider }
+    }
+}
+
+public enum PrimaryProviderRouteHealthStatus: String, Sendable, Equatable {
+    case ok
+    case missing
+    case blocked
+    case failed
+
+    public var isHealthy: Bool { self == .ok }
+}
+
+public struct PrimaryProviderRouteHealth: Identifiable, Sendable, Equatable {
+    public let route: PrimaryProviderRoute
+    public let status: PrimaryProviderRouteHealthStatus
+    public let detail: String
+    public let checkedAt: Date
+
+    public var id: PrimaryProviderRoute { route }
+
+    public init(
+        route: PrimaryProviderRoute,
+        status: PrimaryProviderRouteHealthStatus,
+        detail: String,
+        checkedAt: Date = Date()
+    ) {
+        self.route = route
+        self.status = status
+        self.detail = detail
+        self.checkedAt = checkedAt
+    }
+}
+
+public enum PrimaryProviderRouteHealthChecker {
+    public static func checkAll(now: Date = Date()) -> [PrimaryProviderRoute: PrimaryProviderRouteHealth] {
+        Dictionary(
+            uniqueKeysWithValues: PrimaryProviderRoute.allCases.map { route in
+                (route, check(route, now: now))
+            }
+        )
+    }
+
+    public static func check(_ route: PrimaryProviderRoute, now: Date = Date()) -> PrimaryProviderRouteHealth {
+        switch route {
+        case .openAICLI:
+            return credentialHealth(route: route, now: now) {
+                _ = try CodexCredentialReader.loadFromCLI()
+            }
+        case .openAIOAuth:
+            return credentialHealth(route: route, now: now) {
+                _ = try CodexCredentialReader.loadFromOAuth()
+            }
+        case .openAIBrowserCookies:
+            return cookieHealth(
+                route: route,
+                result: OpenAIWebCookieStore.storageState(source: .browser),
+                now: now
+            )
+        case .openAIWebViewCookies:
+            return cookieHealth(
+                route: route,
+                result: OpenAIWebCookieStore.storageState(source: .webView),
+                now: now
+            )
+        case .claudeBrowserCookies:
+            return cookieHealth(
+                route: route,
+                result: ClaudeWebCookieStore.storageState(source: .browser),
+                now: now
+            )
+        case .claudeWebViewCookies:
+            return cookieHealth(
+                route: route,
+                result: ClaudeWebCookieStore.storageState(source: .webView),
+                now: now
+            )
+        case .claudeOAuth:
+            return credentialHealth(route: route, now: now) {
+                _ = try ClaudeCredentialReader.loadFromOAuth()
+            }
+        case .claudeCLI:
+            return credentialHealth(route: route, now: now) {
+                _ = try ClaudeCredentialReader.loadFromCLI()
+            }
+        }
+    }
+
+    private static func credentialHealth(
+        route: PrimaryProviderRoute,
+        now: Date,
+        _ load: () throws -> Void
+    ) -> PrimaryProviderRouteHealth {
+        do {
+            try load()
+            return PrimaryProviderRouteHealth(
+                route: route,
+                status: .ok,
+                detail: "Credentials available",
+                checkedAt: now
+            )
+        } catch KeychainStore.KeychainError.interactionNotAllowed {
+            return PrimaryProviderRouteHealth(
+                route: route,
+                status: .blocked,
+                detail: "Keychain locked",
+                checkedAt: now
+            )
+        } catch let error as QuotaError where error == .noCredential || error == .needsLogin {
+            return PrimaryProviderRouteHealth(
+                route: route,
+                status: .missing,
+                detail: "No credential found",
+                checkedAt: now
+            )
+        } catch {
+            return PrimaryProviderRouteHealth(
+                route: route,
+                status: .failed,
+                detail: "Could not read credential",
+                checkedAt: now
+            )
+        }
+    }
+
+    private static func cookieHealth(
+        route: PrimaryProviderRoute,
+        result: SecureCookieHeaderStore.LoadResult,
+        now: Date
+    ) -> PrimaryProviderRouteHealth {
+        switch result {
+        case .found:
+            return PrimaryProviderRouteHealth(
+                route: route,
+                status: .ok,
+                detail: "Saved in Keychain",
+                checkedAt: now
+            )
+        case .missing:
+            return PrimaryProviderRouteHealth(
+                route: route,
+                status: .missing,
+                detail: "No saved cookie",
+                checkedAt: now
+            )
+        case .temporarilyUnavailable:
+            return PrimaryProviderRouteHealth(
+                route: route,
+                status: .blocked,
+                detail: "Keychain locked",
+                checkedAt: now
+            )
+        case .invalid:
+            return PrimaryProviderRouteHealth(
+                route: route,
+                status: .failed,
+                detail: "Invalid cookie data",
+                checkedAt: now
+            )
+        }
+    }
+}

--- a/Sources/VibeBarCore/Models/PrimaryProviderSourcePlanner.swift
+++ b/Sources/VibeBarCore/Models/PrimaryProviderSourcePlanner.swift
@@ -1,0 +1,81 @@
+import Foundation
+
+public enum CodexUsageMode: String, Codable, CaseIterable, Identifiable, Sendable {
+    case auto
+    case oauthThenCLI
+    case cliThenOAuth
+    case oauthOnly
+    case cliOnly
+
+    public var id: String { rawValue }
+
+    public var label: String {
+        switch self {
+        case .auto: return "Auto"
+        case .oauthThenCLI: return "OAuth, then CLI"
+        case .cliThenOAuth: return "CLI, then OAuth"
+        case .oauthOnly: return "OAuth only"
+        case .cliOnly: return "CLI only"
+        }
+    }
+
+    public var detail: String {
+        switch self {
+        case .auto:
+            return "Use local Codex CLI credentials first; fall back to Codex OAuth and saved OpenAI web cookies."
+        case .oauthThenCLI:
+            return "Use Codex OAuth first; fall back to local Codex CLI credentials and saved OpenAI web cookies."
+        case .cliThenOAuth:
+            return "Use local Codex CLI credentials first; fall back to Codex OAuth and saved OpenAI web cookies."
+        case .oauthOnly:
+            return "Use only Codex OAuth credentials from auth.json."
+        case .cliOnly:
+            return "Use only local Codex CLI credentials."
+        }
+    }
+}
+
+public enum CodexSourcePlanner {
+    public static func resolve(mode: CodexUsageMode) -> [CredentialSource] {
+        switch mode {
+        case .auto, .cliThenOAuth:
+            return [.cliDetected, .oauthCLI]
+        case .oauthThenCLI:
+            return [.oauthCLI, .cliDetected]
+        case .oauthOnly:
+            return [.oauthCLI]
+        case .cliOnly:
+            return [.cliDetected]
+        }
+    }
+
+    public static func allowsWebFallback(mode: CodexUsageMode) -> Bool {
+        switch mode {
+        case .auto, .oauthThenCLI, .cliThenOAuth:
+            return true
+        case .oauthOnly, .cliOnly:
+            return false
+        }
+    }
+}
+
+public enum ClaudeSourcePlanner {
+    public static func resolve(mode: ClaudeUsageMode) -> [CredentialSource] {
+        switch mode {
+        case .auto:
+            return [.webCookie, .oauthCLI, .cliDetected]
+        case .oauthThenCliThenWeb:
+            return [.oauthCLI, .cliDetected, .webCookie]
+        case .cliThenWeb:
+            return [.cliDetected, .webCookie, .oauthCLI]
+        case .webThenCli:
+            return [.webCookie, .cliDetected, .oauthCLI]
+        case .oauthOnly:
+            return [.oauthCLI]
+        case .cliOnly:
+            return [.cliDetected]
+        case .webOnly:
+            return [.webCookie]
+        }
+    }
+}

--- a/Sources/VibeBarCore/Services/ClaudeOrganizationIDFetcher.swift
+++ b/Sources/VibeBarCore/Services/ClaudeOrganizationIDFetcher.swift
@@ -61,25 +61,60 @@ public enum ClaudeOrganizationIDFetcher {
     }
 
     private static func organizationID(from object: Any?) -> String? {
+        let candidates = organizationCandidates(from: object)
+        return candidates.first(where: \.hasChatCapability)?.id
+            ?? candidates.first(where: { !$0.isApiOnly })?.id
+            ?? candidates.first?.id
+    }
+
+    private struct OrganizationCandidate {
+        let id: String
+        let capabilities: Set<String>
+
+        var hasChatCapability: Bool {
+            capabilities.contains("chat")
+        }
+
+        var isApiOnly: Bool {
+            !capabilities.isEmpty && capabilities == ["api"]
+        }
+    }
+
+    private static func organizationCandidates(from object: Any?) -> [OrganizationCandidate] {
         if let dict = object as? [String: Any] {
+            var candidates: [OrganizationCandidate] = []
             for key in ["uuid", "id", "organization_uuid", "organizationId"] {
                 if let raw = dict[key] as? String {
                     let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
-                    if !trimmed.isEmpty { return trimmed }
+                    if !trimmed.isEmpty {
+                        candidates.append(OrganizationCandidate(
+                            id: trimmed,
+                            capabilities: capabilities(from: dict["capabilities"])
+                        ))
+                        break
+                    }
                 }
             }
             for key in ["organization", "current_organization"] {
-                if let id = organizationID(from: dict[key]) { return id }
+                candidates.append(contentsOf: organizationCandidates(from: dict[key]))
             }
             for key in ["organizations", "data", "results"] {
-                if let id = organizationID(from: dict[key]) { return id }
+                candidates.append(contentsOf: organizationCandidates(from: dict[key]))
             }
+            return candidates
         }
         if let array = object as? [Any] {
-            for entry in array {
-                if let id = organizationID(from: entry) { return id }
-            }
+            return array.flatMap { organizationCandidates(from: $0) }
         }
-        return nil
+        return []
+    }
+
+    private static func capabilities(from object: Any?) -> Set<String> {
+        guard let values = object as? [Any] else { return [] }
+        return Set(values.compactMap { raw in
+            guard let string = raw as? String else { return nil }
+            let normalized = string.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+            return normalized.isEmpty ? nil : normalized
+        })
     }
 }

--- a/Sources/VibeBarCore/Services/CostHistoryStore.swift
+++ b/Sources/VibeBarCore/Services/CostHistoryStore.swift
@@ -25,20 +25,27 @@ public actor CostHistoryStore {
     }
     private struct Storage: Codable {
         var schemaVersion: Int
+        var calculationVersion: Int?
         var entries: [Entry]
 
-        init(schemaVersion: Int = CostHistoryStore.storageSchemaVersion, entries: [Entry]) {
+        init(
+            schemaVersion: Int = CostHistoryStore.storageSchemaVersion,
+            calculationVersion: Int? = CostUsagePricing.calculationVersion,
+            entries: [Entry]
+        ) {
             self.schemaVersion = schemaVersion
+            self.calculationVersion = calculationVersion
             self.entries = entries
         }
 
         private enum CodingKeys: String, CodingKey {
-            case schemaVersion, entries
+            case schemaVersion, calculationVersion, entries
         }
 
         init(from decoder: Decoder) throws {
             let c = try decoder.container(keyedBy: CodingKeys.self)
             self.schemaVersion = try c.decodeIfPresent(Int.self, forKey: .schemaVersion) ?? 1
+            self.calculationVersion = try c.decodeIfPresent(Int.self, forKey: .calculationVersion)
             self.entries = try c.decode([Entry].self, forKey: .entries)
         }
     }
@@ -273,6 +280,13 @@ public actor CostHistoryStore {
             cachedStorage = empty
             return empty
         }
+        if storage.schemaVersion >= Self.storageSchemaVersion,
+           storage.calculationVersion != CostUsagePricing.calculationVersion {
+            let empty = Storage(entries: [])
+            persist(empty)
+            cachedStorage = empty
+            return empty
+        }
         if migrateLegacyStorageIfNeeded(&storage) {
             persist(storage)
         }
@@ -352,6 +366,7 @@ public actor CostHistoryStore {
         }
         storage.entries = Array(byKey.values)
         storage.schemaVersion = Self.storageSchemaVersion
+        storage.calculationVersion = CostUsagePricing.calculationVersion
         return true
     }
 

--- a/Sources/VibeBarCore/Services/CostUsageScanner.swift
+++ b/Sources/VibeBarCore/Services/CostUsageScanner.swift
@@ -58,8 +58,9 @@ public enum CostUsageScanner {
                     cache.store(retained, for: file.path, mtime: mtime, size: size)
                 }
                 for event in retained {
+                    let cost = costUSD(tool: .codex, event: event)
                     aggregator.add(at: event.date, model: event.model, input: event.input,
-                                   output: event.output, cache: event.cache, costUSD: event.costUSD)
+                                   output: event.output, cache: event.cache, costUSD: cost)
                 }
                 continue
             }
@@ -93,14 +94,13 @@ public enum CostUsageScanner {
                     model: event.model,
                     input: max(0, delta.input - delta.cached),
                     output: delta.output,
-                    cache: delta.cached,
-                    costUSD: cost
+                    cache: delta.cached
                 )
                 guard isRetained(parsedEvent.date, cutoff: cutoff) else { continue }
                 parsed.append(parsedEvent)
                 aggregator.add(at: parsedEvent.date, model: parsedEvent.model,
                                input: parsedEvent.input, output: parsedEvent.output,
-                               cache: parsedEvent.cache, costUSD: parsedEvent.costUSD)
+                               cache: parsedEvent.cache, costUSD: cost)
             }
             cache.store(parsed, for: file.path, mtime: mtime, size: size)
         }
@@ -124,6 +124,7 @@ public enum CostUsageScanner {
     private static func parseCodexFile(file: URL) -> [CodexEvent] {
         var events: [CodexEvent] = []
         var currentModel = "gpt-5"
+        var runningTotals = CodexEvent.Totals(input: 0, cached: 0, output: 0)
         let didRead = forEachJSONLLine(in: file) { lineData in
             guard !lineData.isEmpty else { return }
             guard lineData.contains(asciiSequence: "token_count") ||
@@ -132,6 +133,10 @@ public enum CostUsageScanner {
 
             if let payload = obj["payload"] as? [String: Any] {
                 if let m = payload["model"] as? String { currentModel = m }
+                if let info = payload["info"] as? [String: Any],
+                   let m = info["model"] as? String ?? info["model_name"] as? String {
+                    currentModel = m
+                }
             }
             if let m = obj["model"] as? String { currentModel = m }
 
@@ -140,12 +145,24 @@ public enum CostUsageScanner {
                   payload["type"] as? String == "token_count",
                   let info = payload["info"] as? [String: Any]
             else { return }
-            guard let total = info["total_token_usage"] as? [String: Any] else { return }
-            let totals = CodexEvent.Totals(
-                input: anyInt(total["input_tokens"]),
-                cached: anyInt(total["cached_input_tokens"] ?? total["cache_read_input_tokens"]),
-                output: anyInt(total["output_tokens"])
-            )
+            let totals: CodexEvent.Totals
+            if let total = info["total_token_usage"] as? [String: Any] {
+                totals = CodexEvent.Totals(
+                    input: anyInt(total["input_tokens"]),
+                    cached: anyInt(total["cached_input_tokens"] ?? total["cache_read_input_tokens"]),
+                    output: anyInt(total["output_tokens"])
+                )
+                runningTotals = totals
+            } else if let last = info["last_token_usage"] as? [String: Any] {
+                runningTotals = CodexEvent.Totals(
+                    input: runningTotals.input + max(0, anyInt(last["input_tokens"])),
+                    cached: runningTotals.cached + max(0, anyInt(last["cached_input_tokens"] ?? last["cache_read_input_tokens"])),
+                    output: runningTotals.output + max(0, anyInt(last["output_tokens"]))
+                )
+                totals = runningTotals
+            } else {
+                return
+            }
             let timestamp = (obj["timestamp"] as? String).flatMap(parseISO) ?? fileMTime(file) ?? Date()
             events.append(CodexEvent(date: timestamp, model: currentModel, totals: totals))
         }
@@ -165,6 +182,7 @@ public enum CostUsageScanner {
         var aggregator = CostAggregator(tool: .claude, now: now)
         var cache = CostUsageScanCache.load(homeDirectory: homeDirectory, tool: .claude, retentionDays: retentionDays)
         let cutoff = retentionCutoff(now: now, retentionDays: retentionDays)
+        var allEvents: [CostUsageScanCache.ParsedEvent] = []
 
         for file in files {
             let (mtime, size) = fileFingerprint(file)
@@ -173,14 +191,14 @@ public enum CostUsageScanner {
                 if retained.count != cached.count {
                     cache.store(retained, for: file.path, mtime: mtime, size: size)
                 }
-                for event in retained {
-                    aggregator.add(at: event.date, model: event.model, input: event.input,
-                                   output: event.output, cache: event.cache, costUSD: event.costUSD)
-                }
+                allEvents.append(contentsOf: retained)
                 continue
             }
 
-            var parsed: [CostUsageScanCache.ParsedEvent] = []
+            let sourceKey = CostUsageScanCache.entryKey(for: file.path)
+            let pathRole = claudePathRole(file: file)
+            var keyedRows: [String: CostUsageScanCache.ParsedEvent] = [:]
+            var unkeyedRows: [CostUsageScanCache.ParsedEvent] = []
             let didRead = forEachJSONLLine(in: file) { lineData in
                 guard !lineData.isEmpty,
                       lineData.contains(asciiSequence: "assistant"),
@@ -197,41 +215,57 @@ public enum CostUsageScanner {
                 let cacheRead = anyInt(usage["cache_read_input_tokens"])
                 let cacheCreation = anyInt(usage["cache_creation_input_tokens"])
                 let output = anyInt(usage["output_tokens"])
-                let cost = CostUsagePricing.claudeCostUSD(
-                    model: model,
-                    inputTokens: input,
-                    cacheReadInputTokens: cacheRead,
-                    cacheCreationInputTokens: cacheCreation,
-                    outputTokens: output
-                ) ?? 0
+                if input == 0, cacheRead == 0, cacheCreation == 0, output == 0 { return }
                 let date = (obj["timestamp"] as? String).flatMap(parseISO) ?? fileMTime(file) ?? Date()
+                let messageId = message["id"] as? String
+                let requestId = obj["requestId"] as? String
+                let sessionId = obj["sessionId"] as? String
+                    ?? obj["session_id"] as? String
+                    ?? (obj["metadata"] as? [String: Any])?["sessionId"] as? String
+                    ?? (message["metadata"] as? [String: Any])?["sessionId"] as? String
                 let parsedEvent = CostUsageScanCache.ParsedEvent(
                     date: date,
                     model: model,
                     input: input,
                     output: output,
                     cache: cacheRead + cacheCreation,
-                    costUSD: cost
+                    cacheCreation: cacheCreation,
+                    sessionId: sessionId,
+                    messageId: messageId,
+                    requestId: requestId,
+                    isSidechain: anyBool(obj["isSidechain"]),
+                    pathRole: pathRole,
+                    sourceKey: sourceKey
                 )
                 guard isRetained(parsedEvent.date, cutoff: cutoff) else { return }
-                parsed.append(parsedEvent)
-                aggregator.add(
-                    at: parsedEvent.date,
-                    model: parsedEvent.model,
-                    input: parsedEvent.input,
-                    output: parsedEvent.output,
-                    cache: parsedEvent.cache,
-                    costUSD: parsedEvent.costUSD
-                )
+                if let messageId, let requestId {
+                    keyedRows["\(messageId)\u{0}\(requestId)"] = parsedEvent
+                } else {
+                    unkeyedRows.append(parsedEvent)
+                }
             }
             guard didRead else {
                 cache.store([], for: file.path, mtime: mtime, size: size)
                 continue
             }
+            let parsed = keyedRows.keys.sorted().compactMap { keyedRows[$0] } + unkeyedRows
             cache.store(parsed, for: file.path, mtime: mtime, size: size)
+            allEvents.append(contentsOf: parsed)
         }
         cache.prune(known: Set(files.map(\.path)))
         cache.save(homeDirectory: homeDirectory, tool: .claude)
+        let deduped = deduplicateClaudeEvents(allEvents)
+        for event in deduped {
+            let cost = costUSD(tool: .claude, event: event)
+            aggregator.add(
+                at: event.date,
+                model: event.model,
+                input: event.input,
+                output: event.output,
+                cache: event.cache,
+                costUSD: cost
+            )
+        }
         return aggregator.snapshot(jsonlFilesFound: files.count)
     }
 
@@ -255,6 +289,80 @@ public enum CostUsageScanner {
     ) -> [CostUsageScanCache.ParsedEvent] {
         guard let cutoff else { return events }
         return events.filter { $0.date >= cutoff }
+    }
+
+    private static func costUSD(tool: ToolType, event: CostUsageScanCache.ParsedEvent) -> Double {
+        switch tool {
+        case .codex:
+            return CostUsagePricing.codexCostUSD(
+                model: event.model,
+                inputTokens: event.input + event.cache,
+                cachedInputTokens: event.cache,
+                outputTokens: event.output
+            ) ?? 0
+        case .claude:
+            let cacheCreation = max(0, event.cacheCreation ?? 0)
+            let cacheRead = max(0, event.cache - cacheCreation)
+            return CostUsagePricing.claudeCostUSD(
+                model: event.model,
+                inputTokens: event.input,
+                cacheReadInputTokens: cacheRead,
+                cacheCreationInputTokens: cacheCreation,
+                outputTokens: event.output
+            ) ?? 0
+        case .alibaba, .gemini, .antigravity, .copilot, .zai, .minimax, .kimi, .cursor:
+            return 0
+        }
+    }
+
+    private static func claudePathRole(file: URL) -> CostUsageScanCache.PathRole {
+        file.path.contains("/subagents/") ? .subagent : .parent
+    }
+
+    private static func deduplicateClaudeEvents(
+        _ events: [CostUsageScanCache.ParsedEvent]
+    ) -> [CostUsageScanCache.ParsedEvent] {
+        var keyed: [String: CostUsageScanCache.ParsedEvent] = [:]
+        var unkeyed: [CostUsageScanCache.ParsedEvent] = []
+
+        for event in events {
+            guard let sessionId = event.sessionId,
+                  let messageId = event.messageId,
+                  let requestId = event.requestId
+            else {
+                unkeyed.append(event)
+                continue
+            }
+            let key = "\(sessionId)\u{0}\(messageId)\u{0}\(requestId)"
+            if let existing = keyed[key] {
+                if claudeEventWins(candidate: event, existing: existing) {
+                    keyed[key] = event
+                }
+            } else {
+                keyed[key] = event
+            }
+        }
+
+        return keyed.keys.sorted().compactMap { keyed[$0] } + unkeyed
+    }
+
+    private static func claudeEventWins(
+        candidate: CostUsageScanCache.ParsedEvent,
+        existing: CostUsageScanCache.ParsedEvent
+    ) -> Bool {
+        let candidateSidechain = candidate.isSidechain ?? false
+        let existingSidechain = existing.isSidechain ?? false
+        if candidateSidechain != existingSidechain {
+            return !candidateSidechain
+        }
+
+        let candidateRole = candidate.pathRole ?? .parent
+        let existingRole = existing.pathRole ?? .parent
+        if candidateRole != existingRole {
+            return candidateRole == .parent
+        }
+
+        return (candidate.sourceKey ?? "") < (existing.sourceKey ?? "")
     }
 
     // MARK: - Aggregator
@@ -503,6 +611,12 @@ public enum CostUsageScanner {
         if let n = value as? NSNumber { return n.intValue }
         if let i = value as? Int { return i }
         return 0
+    }
+
+    private static func anyBool(_ value: Any?) -> Bool {
+        if let b = value as? Bool { return b }
+        if let n = value as? NSNumber { return n.boolValue }
+        return false
     }
 }
 

--- a/Sources/VibeBarCore/Services/QuotaService.swift
+++ b/Sources/VibeBarCore/Services/QuotaService.swift
@@ -120,12 +120,22 @@ public final class QuotaService: ObservableObject {
     }
 
     private func store(error: QuotaError, for account: AccountIdentity) {
+        if error.isCredentialState,
+           let cached = lastSuccessByAccount[account.id],
+           !cached.buckets.isEmpty {
+            lastErrorByAccount.removeValue(forKey: account.id)
+            return
+        }
         lastErrorByAccount[account.id] = error
         lastUpdatedByAccount[account.id] = Date()
     }
 
     private func cachedOrEmpty(for account: AccountIdentity, error: QuotaError) -> AccountQuota {
         if var cached = lastSuccessByAccount[account.id] {
+            if error.isCredentialState, !cached.buckets.isEmpty {
+                cached.error = nil
+                return cached
+            }
             cached.error = error
             return cached
         }

--- a/Sources/VibeBarCore/Storage/AccountStore.swift
+++ b/Sources/VibeBarCore/Storage/AccountStore.swift
@@ -17,15 +17,21 @@ import Combine
 public final class AccountStore: ObservableObject {
     @Published public private(set) var accounts: [AccountIdentity] = []
 
-    public init(claudeUsageMode: ClaudeUsageMode = .cliThenWeb) {
-        reload(claudeUsageMode: claudeUsageMode)
+    public init(
+        codexUsageMode: CodexUsageMode = .auto,
+        claudeUsageMode: ClaudeUsageMode = .auto
+    ) {
+        reload(codexUsageMode: codexUsageMode, claudeUsageMode: claudeUsageMode)
     }
 
     /// Re-scan CLI keychain/files for auto-detected provider identities.
-    public func reload(claudeUsageMode: ClaudeUsageMode = .cliThenWeb) {
+    public func reload(
+        codexUsageMode: CodexUsageMode = .auto,
+        claudeUsageMode: ClaudeUsageMode = .auto
+    ) {
         var detected: [AccountIdentity] = []
 
-        if let codex = autoDetectCodex() {
+        if let codex = autoDetectCodex(mode: codexUsageMode) {
             detected.append(codex)
         }
         if let claude = autoDetectClaude(mode: claudeUsageMode) {
@@ -51,66 +57,111 @@ public final class AccountStore: ObservableObject {
 
     // MARK: - CLI auto detection
 
-    private func autoDetectCodex() -> AccountIdentity? {
-        guard let cred = try? CodexCredentialReader.loadFromCLI() else { return nil }
-        let id = cred.accountId ?? "cli-codex"
+    private func autoDetectCodex(mode: CodexUsageMode) -> AccountIdentity? {
+        let order = CodexSourcePlanner.resolve(mode: mode)
+        let lookupOrder = order + (CodexSourcePlanner.allowsWebFallback(mode: mode) ? [.webCookie] : [])
+        var selected: (source: CredentialSource, credential: CodexCredential?)?
+        for source in lookupOrder {
+            switch source {
+            case .oauthCLI:
+                if let credential = try? CodexCredentialReader.loadFromOAuth() {
+                    selected = (source, credential)
+                }
+            case .cliDetected:
+                if let credential = try? CodexCredentialReader.loadFromCLI() {
+                    selected = (source, credential)
+                }
+            case .webCookie:
+                if OpenAIWebCookieStore.hasCookieHeader() {
+                    selected = (source, nil)
+                }
+            case .apiToken, .browserCookie, .manualCookie, .localProbe, .notConfigured:
+                break
+            }
+            if selected != nil { break }
+        }
+        guard let selected else { return nil }
+        let cred = selected.credential
+        let remaining = remainingSources(after: selected.source, in: order)
+        let id = cred?.accountId ?? (selected.source == .oauthCLI ? "oauth-codex" : selected.source == .webCookie ? "web-codex" : "cli-codex")
         return AccountIdentity(
             id: id,
             tool: .codex,
-            email: cred.email,
-            alias: "Codex CLI",
-            plan: cred.plan,
-            accountId: cred.accountId,
-            source: .cliDetected,
+            email: cred?.email,
+            alias: selected.source == .oauthCLI ? "Codex OAuth" : selected.source == .webCookie ? "OpenAI Web" : "Codex CLI",
+            plan: cred?.plan,
+            accountId: cred?.accountId,
+            source: selected.source,
+            allowsWebFallback: selected.source == .webCookie
+                ? false
+                : CodexSourcePlanner.allowsWebFallback(mode: mode) && OpenAIWebCookieStore.hasCookieHeader(),
+            allowsCLIFallback: remaining.contains(.cliDetected),
+            allowsOAuthFallback: remaining.contains(.oauthCLI),
             createdAt: Date(),
             updatedAt: Date()
         )
     }
 
     private func autoDetectClaude(mode: ClaudeUsageMode) -> AccountIdentity? {
-        switch mode {
-        case .cliThenWeb:
-            if let credential = try? ClaudeCredentialReader.loadFromCLI() {
-                return AccountIdentity(
-                    id: "cli-claude",
-                    tool: .claude,
-                    alias: "Claude Code",
-                    plan: ProviderPlanDisplay.claudeDisplayName(rateLimitTier: credential.rateLimitTier),
-                    source: .cliDetected,
-                    allowsWebFallback: true,
-                    createdAt: Date(),
-                    updatedAt: Date()
-                )
+        let order = ClaudeSourcePlanner.resolve(mode: mode)
+        var selected: (source: CredentialSource, credential: ClaudeCredential?)?
+        for source in order {
+            switch source {
+            case .oauthCLI:
+                if let credential = try? ClaudeCredentialReader.loadFromOAuth() {
+                    selected = (source, credential)
+                }
+            case .cliDetected:
+                if let credential = try? ClaudeCredentialReader.loadFromCLI() {
+                    selected = (source, credential)
+                }
+            case .webCookie:
+                if ClaudeWebCookieStore.hasCookieHeader() {
+                    selected = (source, nil)
+                }
+            case .apiToken, .browserCookie, .manualCookie, .localProbe, .notConfigured:
+                break
             }
-            return webClaudeAccount()
-        case .webThenCli:
-            if let web = webClaudeAccount(allowsCLIFallback: true) {
-                return web
-            }
-            guard let credential = try? ClaudeCredentialReader.loadFromCLI() else { return nil }
-            return AccountIdentity(
-                id: "cli-claude",
-                tool: .claude,
-                alias: "Claude Code",
-                plan: ProviderPlanDisplay.claudeDisplayName(rateLimitTier: credential.rateLimitTier),
-                source: .cliDetected,
-                createdAt: Date(),
-                updatedAt: Date()
-            )
-        case .cliOnly:
-            guard let credential = try? ClaudeCredentialReader.loadFromCLI() else { return nil }
-            return AccountIdentity(
-                id: "cli-claude",
-                tool: .claude,
-                alias: "Claude Code",
-                plan: ProviderPlanDisplay.claudeDisplayName(rateLimitTier: credential.rateLimitTier),
-                source: .cliDetected,
-                createdAt: Date(),
-                updatedAt: Date()
-            )
-        case .webOnly:
-            return webClaudeAccount()
+            if selected != nil { break }
         }
+        guard let selected else { return nil }
+        let credential = selected.credential
+        let id: String
+        let alias: String
+        switch selected.source {
+        case .oauthCLI:
+            id = "oauth-claude"
+            alias = "Claude OAuth"
+        case .cliDetected:
+            id = "cli-claude"
+            alias = "Claude Code"
+        case .webCookie:
+            id = "web-claude"
+            alias = "Claude Web"
+        case .apiToken, .browserCookie, .manualCookie, .localProbe, .notConfigured:
+            id = "claude"
+            alias = "Claude"
+        }
+        let remaining = remainingSources(after: selected.source, in: order)
+        return AccountIdentity(
+            id: id,
+            tool: .claude,
+            alias: alias,
+            plan: ProviderPlanDisplay.claudeDisplayName(rateLimitTier: credential?.rateLimitTier),
+            source: selected.source,
+            allowsWebFallback: remaining.contains(.webCookie),
+            allowsCLIFallback: remaining.contains(.cliDetected),
+            allowsOAuthFallback: remaining.contains(.oauthCLI),
+            createdAt: Date(),
+            updatedAt: Date()
+        )
+    }
+
+    private func remainingSources(after source: CredentialSource, in order: [CredentialSource]) -> [CredentialSource] {
+        guard let index = order.firstIndex(of: source) else { return [] }
+        let next = order.index(after: index)
+        guard next < order.endIndex else { return [] }
+        return Array(order[next...])
     }
 
     private func webClaudeAccount(allowsCLIFallback: Bool = false) -> AccountIdentity? {

--- a/Sources/VibeBarCore/Storage/CostSnapshotCache.swift
+++ b/Sources/VibeBarCore/Storage/CostSnapshotCache.swift
@@ -15,6 +15,7 @@ public actor CostSnapshotCache {
     private let directory: URL
     private struct StoredSnapshot: Codable {
         let retentionDays: Int
+        let calculationVersion: Int?
         let snapshot: CostSnapshot
     }
 
@@ -39,6 +40,7 @@ public actor CostSnapshotCache {
         do {
             let stored = StoredSnapshot(
                 retentionDays: CostDataSettings.normalizedRetentionDays(retentionDays),
+                calculationVersion: CostUsagePricing.calculationVersion,
                 snapshot: snapshot
             )
             let data = try JSONEncoder().encode(stored)
@@ -65,12 +67,15 @@ public actor CostSnapshotCache {
                 try? FileManager.default.removeItem(at: url)
                 return nil
             }
+            guard stored.calculationVersion == CostUsagePricing.calculationVersion else {
+                try? FileManager.default.removeItem(at: url)
+                return nil
+            }
             return stored.snapshot.rebasedForCurrentDay(now: now)
         }
-        if (normalizedRetentionDays == CostDataSettings.defaultRetentionDays
-            || normalizedRetentionDays == CostDataSettings.maximumRetentionDays),
-           let legacy = try? JSONDecoder().decode(CostSnapshot.self, from: data) {
-            return legacy.rebasedForCurrentDay(now: now)
+        if (try? JSONDecoder().decode(CostSnapshot.self, from: data)) != nil {
+            try? FileManager.default.removeItem(at: url)
+            return nil
         }
         try? FileManager.default.removeItem(at: url)
         return nil

--- a/Sources/VibeBarCore/Storage/CostUsageScanCache.swift
+++ b/Sources/VibeBarCore/Storage/CostUsageScanCache.swift
@@ -13,6 +13,11 @@ import Foundation
 /// The cache is stored at `<homeDirectory>/.vibebar/scan_cache/<tool>.json`,
 /// so tests pointing the scanner at a temp directory get an isolated cache.
 public struct CostUsageScanCache: Codable, Sendable {
+    public enum PathRole: String, Codable, Sendable {
+        case parent
+        case subagent
+    }
+
     /// One scanned event, ready to feed straight into the aggregator.
     /// For Codex this is a delta-resolved record; for Claude it's a per
     /// assistant-message usage line.
@@ -22,7 +27,41 @@ public struct CostUsageScanCache: Codable, Sendable {
         public let input: Int
         public let output: Int
         public let cache: Int
-        public let costUSD: Double
+        public let cacheCreation: Int?
+        public let sessionId: String?
+        public let messageId: String?
+        public let requestId: String?
+        public let isSidechain: Bool?
+        public let pathRole: PathRole?
+        public let sourceKey: String?
+
+        public init(
+            date: Date,
+            model: String,
+            input: Int,
+            output: Int,
+            cache: Int,
+            cacheCreation: Int? = nil,
+            sessionId: String? = nil,
+            messageId: String? = nil,
+            requestId: String? = nil,
+            isSidechain: Bool? = nil,
+            pathRole: PathRole? = nil,
+            sourceKey: String? = nil
+        ) {
+            self.date = date
+            self.model = model
+            self.input = input
+            self.output = output
+            self.cache = cache
+            self.cacheCreation = cacheCreation
+            self.sessionId = sessionId
+            self.messageId = messageId
+            self.requestId = requestId
+            self.isSidechain = isSidechain
+            self.pathRole = pathRole
+            self.sourceKey = sourceKey
+        }
     }
 
     public struct FileEntry: Codable, Sendable {
@@ -31,12 +70,25 @@ public struct CostUsageScanCache: Codable, Sendable {
         public let events: [ParsedEvent]
     }
 
+    public var schemaVersion: Int
     public var retentionDays: Int?
     public var entries: [String: FileEntry]
 
-    public init(entries: [String: FileEntry] = [:], retentionDays: Int? = nil) {
+    public init(entries: [String: FileEntry] = [:], retentionDays: Int? = nil, schemaVersion: Int = Self.currentSchemaVersion) {
+        self.schemaVersion = schemaVersion
         self.retentionDays = retentionDays.map(CostDataSettings.normalizedRetentionDays)
         self.entries = entries
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case schemaVersion, retentionDays, entries
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        self.schemaVersion = try c.decodeIfPresent(Int.self, forKey: .schemaVersion) ?? 1
+        self.retentionDays = try c.decodeIfPresent(Int.self, forKey: .retentionDays)
+        self.entries = try c.decode([String: FileEntry].self, forKey: .entries)
     }
 
     /// Returns cached events if the on-disk fingerprint still matches; nil
@@ -76,6 +128,7 @@ public struct CostUsageScanCache: Codable, Sendable {
     /// 64 MB safety cap. The cache for a heavy user with several years of
     /// Codex / Claude history is usually under 10 MB.
     private static let maxFileBytes: Int = 64 * 1024 * 1024
+    public static let currentSchemaVersion = 2
 
     public static func fileURL(homeDirectory: String, tool: ToolType) -> URL {
         URL(fileURLWithPath: homeDirectory)
@@ -99,6 +152,10 @@ public struct CostUsageScanCache: Codable, Sendable {
         guard let data = try? Data(contentsOf: url),
               let cache = try? JSONDecoder().decode(CostUsageScanCache.self, from: data)
         else {
+            return CostUsageScanCache(retentionDays: normalizedRetentionDays)
+        }
+        guard cache.schemaVersion == currentSchemaVersion else {
+            try? FileManager.default.removeItem(at: url)
             return CostUsageScanCache(retentionDays: normalizedRetentionDays)
         }
         guard cache.retentionDays == normalizedRetentionDays else {

--- a/Sources/VibeBarCore/Storage/SettingsStore.swift
+++ b/Sources/VibeBarCore/Storage/SettingsStore.swift
@@ -121,6 +121,10 @@ public final class SettingsStore: ObservableObject {
         get { settings.mockEnabled }
         set { settings.mockEnabled = false }
     }
+    public var codexUsageMode: CodexUsageMode {
+        get { settings.codexUsageMode }
+        set { settings.codexUsageMode = newValue }
+    }
     public var claudeUsageMode: ClaudeUsageMode {
         get { settings.claudeUsageMode }
         set { settings.claudeUsageMode = newValue }

--- a/Sources/VibeBarCore/Storage/VibeBarLocalStore.swift
+++ b/Sources/VibeBarCore/Storage/VibeBarLocalStore.swift
@@ -12,10 +12,37 @@ public enum VibeBarLocalStore {
         baseDirectory.appendingPathComponent("settings.json")
     }
 
+    // Legacy plaintext cookie paths from short-lived builds. Current code
+    // migrates these into Keychain and deletes them; do not write new cookies
+    // here.
     public static var claudeCookieURL: URL {
         baseDirectory
             .appendingPathComponent("cookies", isDirectory: true)
             .appendingPathComponent("claude-web.txt")
+    }
+
+    public static var claudeWebViewCookieURL: URL {
+        baseDirectory
+            .appendingPathComponent("cookies", isDirectory: true)
+            .appendingPathComponent("claude-webview.txt")
+    }
+
+    public static var claudeBrowserCookieURL: URL {
+        baseDirectory
+            .appendingPathComponent("cookies", isDirectory: true)
+            .appendingPathComponent("claude-browser.txt")
+    }
+
+    public static var openAIWebViewCookieURL: URL {
+        baseDirectory
+            .appendingPathComponent("cookies", isDirectory: true)
+            .appendingPathComponent("openai-webview.txt")
+    }
+
+    public static var openAIBrowserCookieURL: URL {
+        baseDirectory
+            .appendingPathComponent("cookies", isDirectory: true)
+            .appendingPathComponent("openai-browser.txt")
     }
 
     public static var claudeOrganizationIDURL: URL {

--- a/Sources/VibeBarCore/Vendored/CostUsage/CostUsagePricing.swift
+++ b/Sources/VibeBarCore/Vendored/CostUsage/CostUsagePricing.swift
@@ -5,7 +5,11 @@ import Foundation
 // so users can see freshness in Settings.
 public enum CostUsagePricing {
     /// ISO date the pricing tables were last refreshed against upstream provider docs.
-    public static let pricingDataUpdatedAt: String = "2026-01-15"
+    public static let pricingDataUpdatedAt: String = "2026-05-09"
+
+    /// Bump when local cost parsing or pricing semantics change in a way that
+    /// makes persisted cost totals unsafe to max-merge with fresh scans.
+    public static let calculationVersion: Int = 3
 
     struct CodexPricing {
         let inputCostPerToken: Double
@@ -216,11 +220,11 @@ public enum CostUsagePricing {
             outputCostPerToken: 1.5e-5,
             cacheCreationInputCostPerToken: 3.75e-6,
             cacheReadInputCostPerToken: 3e-7,
-            thresholdTokens: 200_000,
-            inputCostPerTokenAboveThreshold: 6e-6,
-            outputCostPerTokenAboveThreshold: 2.25e-5,
-            cacheCreationInputCostPerTokenAboveThreshold: 7.5e-6,
-            cacheReadInputCostPerTokenAboveThreshold: 6e-7),
+            thresholdTokens: nil,
+            inputCostPerTokenAboveThreshold: nil,
+            outputCostPerTokenAboveThreshold: nil,
+            cacheCreationInputCostPerTokenAboveThreshold: nil,
+            cacheReadInputCostPerTokenAboveThreshold: nil),
         "claude-sonnet-4-5-20250929": ClaudePricing(
             inputCostPerToken: 3e-6,
             outputCostPerToken: 1.5e-5,

--- a/Tests/VibeBarCoreTests/AppSettingsTests.swift
+++ b/Tests/VibeBarCoreTests/AppSettingsTests.swift
@@ -15,7 +15,8 @@ final class AppSettingsTests: XCTestCase {
         """
 
         let settings = try JSONDecoder().decode(AppSettings.self, from: Data(json.utf8))
-        XCTAssertEqual(settings.claudeUsageMode, .cliThenWeb)
+        XCTAssertEqual(settings.codexUsageMode, .auto)
+        XCTAssertEqual(settings.claudeUsageMode, .auto)
         XCTAssertEqual(settings.menuBarItems.count, MenuBarItemKind.allCases.count)
         XCTAssertEqual(settings.menuBarItem(.compact).layout, .iconOnly)
         XCTAssertFalse(settings.menuBarItem(.status).isVisible)

--- a/Tests/VibeBarCoreTests/ClaudeParserTests.swift
+++ b/Tests/VibeBarCoreTests/ClaudeParserTests.swift
@@ -159,6 +159,19 @@ final class ClaudeParserTests: XCTestCase {
         )
     }
 
+    func testClaudeOrganizationIDPrefersChatCapableOrganization() throws {
+        let json = """
+        [
+          {"uuid":"org-api","name":"API","capabilities":["api"]},
+          {"uuid":"org-chat","name":"Claude","capabilities":["chat","api"]}
+        ]
+        """
+        XCTAssertEqual(
+            try ClaudeQuotaAdapter.parseOrganizationID(data: Data(json.utf8)),
+            "org-chat"
+        )
+    }
+
     func testClaudeOrganizationIDParsesNestedResponse() throws {
         let json = """
         {"organizations":[{"id":"org-456"}]}

--- a/Tests/VibeBarCoreTests/CostHistoryStoreTests.swift
+++ b/Tests/VibeBarCoreTests/CostHistoryStoreTests.swift
@@ -122,6 +122,54 @@ final class CostHistoryStoreTests: XCTestCase {
         XCTAssertTrue(history.days.contains { $0.costUSD == 3 })
     }
 
+    func testMergeAndAugmentRebuildsCurrentSchemaHistoryWithoutCalculationVersion() async throws {
+        let fileManager = FileManager.default
+        let directory = fileManager.temporaryDirectory
+            .appendingPathComponent("VibeBarCostHistoryCalculationVersionTests-\(UUID().uuidString)", isDirectory: true)
+        try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: directory) }
+
+        let previousTimeZone = NSTimeZone.default
+        let utc = TimeZone(secondsFromGMT: 0)!
+        NSTimeZone.default = utc
+        defer { NSTimeZone.default = previousTimeZone }
+
+        let url = directory.appendingPathComponent("cost_history.json")
+        let legacyCurrentSchemaJSON = """
+        {"schemaVersion":2,"entries":[{"tool":"claude","date":"2026-05-06","costUSD":999,"totalTokens":999999}]}
+        """
+        try legacyCurrentSchemaJSON.write(to: url, atomically: true, encoding: .utf8)
+
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = utc
+        let now = try XCTUnwrap(calendar.date(from: DateComponents(year: 2026, month: 5, day: 6, hour: 12)))
+        let today = calendar.startOfDay(for: now)
+        let store = CostHistoryStore(fileURL: url)
+        let fresh = CostSnapshot(
+            tool: .claude,
+            todayCostUSD: 1,
+            last7DaysCostUSD: 1,
+            last30DaysCostUSD: 1,
+            allTimeCostUSD: 1,
+            todayTokens: 100,
+            last7DaysTokens: 100,
+            last30DaysTokens: 100,
+            allTimeTokens: 100,
+            dailyHistory: [DailyCostPoint(date: today, costUSD: 1, totalTokens: 100)],
+            heatmap: .empty(tool: .claude),
+            modelBreakdowns: [],
+            last7DaysModelBreakdowns: [],
+            dailyModelBreakdown: [:],
+            jsonlFilesFound: 1,
+            updatedAt: now
+        )
+
+        let merged = await store.mergeAndAugment(fresh, retentionDays: CostDataSettings.unlimitedRetentionDays)
+
+        XCTAssertEqual(merged.todayCostUSD, 1, accuracy: 0.001)
+        XCTAssertEqual(merged.todayTokens, 100)
+    }
+
     func testUnlimitedRetentionKeepsAllStoredHistory() async throws {
         let fileManager = FileManager.default
         let directory = fileManager.temporaryDirectory

--- a/Tests/VibeBarCoreTests/CostUsagePricingTests.swift
+++ b/Tests/VibeBarCoreTests/CostUsagePricingTests.swift
@@ -84,6 +84,18 @@ final class CostUsagePricingTests: XCTestCase {
         XCTAssertEqual(cost ?? -1, 1.2, accuracy: 0.01)
     }
 
+    func testClaudeSonnet46UsesStandardPricingAcrossLongContext() {
+        let cost = CostUsagePricing.claudeCostUSD(
+            model: "claude-sonnet-4-6",
+            inputTokens: 300_000,
+            cacheReadInputTokens: 0,
+            cacheCreationInputTokens: 0,
+            outputTokens: 0
+        )
+
+        XCTAssertEqual(cost ?? -1, 0.9, accuracy: 0.01)
+    }
+
     func testClaudeNormalizesAnthropicPrefix() {
         let cost = CostUsagePricing.claudeCostUSD(
             model: "anthropic.claude-opus-4-1",

--- a/Tests/VibeBarCoreTests/CostUsageScannerTests.swift
+++ b/Tests/VibeBarCoreTests/CostUsageScannerTests.swift
@@ -100,6 +100,142 @@ final class CostUsageScannerTests: XCTestCase {
         XCTAssertEqual(snapshot.todayHourlyHistory.reduce(0) { $0 + $1.totalTokens }, 300_000)
     }
 
+    func testCodexScanUsesLastTokenUsageWhenTotalsAreMissing() async throws {
+        let fileManager = FileManager.default
+        let home = fileManager.temporaryDirectory
+            .appendingPathComponent("VibeBarCostUsageLastTokenTests-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fileManager.removeItem(at: home) }
+
+        let sessions = home
+            .appendingPathComponent(".codex", isDirectory: true)
+            .appendingPathComponent("sessions", isDirectory: true)
+        try fileManager.createDirectory(at: sessions, withIntermediateDirectories: true)
+
+        let now = Date(timeIntervalSince1970: 1_762_339_200)
+        let logURL = sessions.appendingPathComponent("session.jsonl")
+        let timestamp = Self.isoFormatter.string(from: now)
+        let lines = [
+            #"{"timestamp":"\#(timestamp)","type":"turn_context","payload":{"info":{"model":"gpt-5.4"}}}"#,
+            #"{"timestamp":"\#(timestamp)","type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":1000,"cached_input_tokens":400,"output_tokens":50}}}}"#
+        ]
+        try lines.joined(separator: "\n").write(to: logURL, atomically: true, encoding: .utf8)
+
+        let snapshot = await CostUsageScanner.scan(tool: .codex, homeDirectory: home.path, now: now)
+
+        XCTAssertEqual(snapshot?.allTimeTokens, 1_050)
+        XCTAssertEqual(snapshot?.modelBreakdowns.first?.modelName, "gpt-5.4")
+    }
+
+    func testClaudeScanKeepsLastStreamingChunkAcrossCache() async throws {
+        let fileManager = FileManager.default
+        let home = fileManager.temporaryDirectory
+            .appendingPathComponent("VibeBarClaudeStreamingCostTests-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fileManager.removeItem(at: home) }
+
+        let projects = home
+            .appendingPathComponent(".claude", isDirectory: true)
+            .appendingPathComponent("projects", isDirectory: true)
+            .appendingPathComponent("project-a", isDirectory: true)
+        try fileManager.createDirectory(at: projects, withIntermediateDirectories: true)
+
+        let now = Date(timeIntervalSince1970: 1_762_339_200)
+        let logURL = projects.appendingPathComponent("session.jsonl")
+        let lines = [
+            claudeAssistantLine(
+                timestamp: now,
+                sessionId: "session-stream",
+                messageId: "msg-stream",
+                requestId: "req-stream",
+                model: "claude-haiku-4-5",
+                input: 100,
+                cacheRead: 0,
+                cacheCreation: 0,
+                output: 10
+            ),
+            claudeAssistantLine(
+                timestamp: now,
+                sessionId: "session-stream",
+                messageId: "msg-stream",
+                requestId: "req-stream",
+                model: "claude-haiku-4-5",
+                input: 150,
+                cacheRead: 20,
+                cacheCreation: 30,
+                output: 15
+            )
+        ]
+        try lines.joined(separator: "\n").write(to: logURL, atomically: true, encoding: .utf8)
+
+        let first = await CostUsageScanner.scan(tool: .claude, homeDirectory: home.path, now: now)
+        let second = await CostUsageScanner.scan(tool: .claude, homeDirectory: home.path, now: now)
+
+        XCTAssertEqual(first?.allTimeTokens, 215)
+        XCTAssertEqual(second?.allTimeTokens, 215)
+        XCTAssertEqual(first?.jsonlFilesFound, 1)
+    }
+
+    func testClaudeScanDeduplicatesCrossFileSubagentRows() async throws {
+        let fileManager = FileManager.default
+        let home = fileManager.temporaryDirectory
+            .appendingPathComponent("VibeBarClaudeCrossFileCostTests-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fileManager.removeItem(at: home) }
+
+        let sessionRoot = home
+            .appendingPathComponent(".claude", isDirectory: true)
+            .appendingPathComponent("projects", isDirectory: true)
+            .appendingPathComponent("project-a", isDirectory: true)
+            .appendingPathComponent("session-cross-file", isDirectory: true)
+        let subagents = sessionRoot.appendingPathComponent("subagents", isDirectory: true)
+        try fileManager.createDirectory(at: subagents, withIntermediateDirectories: true)
+
+        let now = Date(timeIntervalSince1970: 1_762_339_200)
+        let parentURL = sessionRoot.appendingPathComponent("parent.jsonl")
+        let subagentURL = subagents.appendingPathComponent("agent.jsonl")
+        try claudeAssistantLine(
+            timestamp: now,
+            sessionId: "session-cross-file",
+            messageId: "msg-overlap",
+            requestId: "req-overlap",
+            model: "claude-haiku-4-5",
+            input: 100,
+            cacheRead: 0,
+            cacheCreation: 0,
+            output: 11
+        ).write(to: parentURL, atomically: true, encoding: .utf8)
+        let subagentLines = [
+            claudeAssistantLine(
+                timestamp: now,
+                sessionId: "session-cross-file",
+                messageId: "msg-overlap",
+                requestId: "req-overlap",
+                model: "claude-haiku-4-5",
+                input: 900,
+                cacheRead: 0,
+                cacheCreation: 0,
+                output: 99,
+                isSidechain: true
+            ),
+            claudeAssistantLine(
+                timestamp: now,
+                sessionId: "session-cross-file",
+                messageId: "msg-unique",
+                requestId: "req-unique",
+                model: "claude-haiku-4-5",
+                input: 5,
+                cacheRead: 0,
+                cacheCreation: 0,
+                output: 2,
+                isSidechain: true
+            )
+        ]
+        try subagentLines.joined(separator: "\n").write(to: subagentURL, atomically: true, encoding: .utf8)
+
+        let snapshot = await CostUsageScanner.scan(tool: .claude, homeDirectory: home.path, now: now)
+
+        XCTAssertEqual(snapshot?.allTimeTokens, 118)
+        XCTAssertEqual(snapshot?.jsonlFilesFound, 2)
+    }
+
     private func codexTokenCountLine(
         timestamp: Date,
         model: String,
@@ -110,6 +246,24 @@ final class CostUsageScannerTests: XCTestCase {
         let timestampString = Self.isoFormatter.string(from: timestamp)
         return """
         {"timestamp":"\(timestampString)","type":"event_msg","payload":{"type":"token_count","model":"\(model)","info":{"total_token_usage":{"input_tokens":\(input),"cached_input_tokens":\(cached),"output_tokens":\(output)}}}}
+        """
+    }
+
+    private func claudeAssistantLine(
+        timestamp: Date,
+        sessionId: String,
+        messageId: String,
+        requestId: String,
+        model: String,
+        input: Int,
+        cacheRead: Int,
+        cacheCreation: Int,
+        output: Int,
+        isSidechain: Bool = false
+    ) -> String {
+        let timestampString = Self.isoFormatter.string(from: timestamp)
+        return """
+        {"timestamp":"\(timestampString)","type":"assistant","sessionId":"\(sessionId)","requestId":"\(requestId)","isSidechain":\(isSidechain),"message":{"id":"\(messageId)","model":"\(model)","usage":{"input_tokens":\(input),"cache_read_input_tokens":\(cacheRead),"cache_creation_input_tokens":\(cacheCreation),"output_tokens":\(output)}}}
         """
     }
 

--- a/Tests/VibeBarCoreTests/OpenAIWebCookieStoreTests.swift
+++ b/Tests/VibeBarCoreTests/OpenAIWebCookieStoreTests.swift
@@ -1,0 +1,44 @@
+import XCTest
+@testable import VibeBarCore
+
+final class OpenAIWebCookieStoreTests: XCTestCase {
+    func testCookieHeaderKeepsChatGPTSessionCookies() {
+        let header = OpenAIWebCookieStore.cookieHeader(from: [
+            (name: "__Secure-next-auth.session-token", value: "session"),
+            (name: "oai-did", value: "device")
+        ])
+
+        XCTAssertEqual(header, "__Secure-next-auth.session-token=session; oai-did=device")
+    }
+
+    func testCookieHeaderReturnsNilWithoutUsefulCookies() {
+        XCTAssertNil(OpenAIWebCookieStore.cookieHeader(from: [
+            (name: "unrelated", value: "value")
+        ]))
+    }
+
+    func testStoredHeadersUseBrowserBeforeWebView() throws {
+        try SecureCookieHeaderStore.withInMemoryStoreForTesting {
+            try OpenAIWebCookieStore.writeCookieHeader(
+                "__Secure-next-auth.session-token=webview",
+                source: .webView
+            )
+            try OpenAIWebCookieStore.writeCookieHeader(
+                "__Secure-next-auth.session-token=browser",
+                source: .browser
+            )
+
+            XCTAssertEqual(
+                try OpenAIWebCookieStore.readCookieHeader(source: .browser),
+                "__Secure-next-auth.session-token=browser"
+            )
+            XCTAssertEqual(
+                OpenAIWebCookieStore.candidateCookieHeaders(),
+                [
+                    "__Secure-next-auth.session-token=browser",
+                    "__Secure-next-auth.session-token=webview"
+                ]
+            )
+        }
+    }
+}

--- a/Tests/VibeBarCoreTests/PrimaryProviderSourcePlannerTests.swift
+++ b/Tests/VibeBarCoreTests/PrimaryProviderSourcePlannerTests.swift
@@ -1,0 +1,28 @@
+import XCTest
+@testable import VibeBarCore
+
+final class PrimaryProviderSourcePlannerTests: XCTestCase {
+    func testCodexAutoPrefersCLIThenOAuth() {
+        let plan = CodexSourcePlanner.resolve(mode: .auto)
+
+        XCTAssertEqual(plan, [.cliDetected, .oauthCLI])
+    }
+
+    func testCodexExplicitCLIOnlyDoesNotFallback() {
+        let plan = CodexSourcePlanner.resolve(mode: .cliOnly)
+
+        XCTAssertEqual(plan, [.cliDetected])
+    }
+
+    func testClaudeAutoPrefersWebThenOAuthThenCLI() {
+        let plan = ClaudeSourcePlanner.resolve(mode: .auto)
+
+        XCTAssertEqual(plan, [.webCookie, .oauthCLI, .cliDetected])
+    }
+
+    func testClaudeWebThenCLIThenOAuthOrder() {
+        let plan = ClaudeSourcePlanner.resolve(mode: .webThenCli)
+
+        XCTAssertEqual(plan, [.webCookie, .cliDetected, .oauthCLI])
+    }
+}

--- a/Tests/VibeBarCoreTests/PrivacyPersistenceTests.swift
+++ b/Tests/VibeBarCoreTests/PrivacyPersistenceTests.swift
@@ -14,6 +14,31 @@ final class PrivacyPersistenceTests: XCTestCase {
         XCTAssertNil(ClaudeWebCookieStore.minimizedCookieHeader(from: "sessionKey=not-claude"))
     }
 
+    func testClaudeStoredHeadersUseKeychainBackedSources() throws {
+        try SecureCookieHeaderStore.withInMemoryStoreForTesting {
+            try ClaudeWebCookieStore.writeCookieHeader(
+                "sessionKey=sk-ant-webview",
+                source: .webView
+            )
+            try ClaudeWebCookieStore.writeCookieHeader(
+                "sessionKey=sk-ant-browser",
+                source: .browser
+            )
+
+            XCTAssertEqual(
+                try ClaudeWebCookieStore.readCookieHeader(source: .browser),
+                "sessionKey=sk-ant-browser"
+            )
+            XCTAssertEqual(
+                ClaudeWebCookieStore.candidateCookieHeaders(),
+                [
+                    "sessionKey=sk-ant-browser",
+                    "sessionKey=sk-ant-webview"
+                ]
+            )
+        }
+    }
+
     func testQuotaStoredPayloadOmitsAccountIdentifiers() throws {
         let quota = AccountQuota(
             accountId: "acct_real_codex",
@@ -65,8 +90,7 @@ final class PrivacyPersistenceTests: XCTestCase {
             model: "gpt-5",
             input: 1,
             output: 2,
-            cache: 3,
-            costUSD: 0.04
+            cache: 3
         )
 
         cache.store([event], for: path, mtime: mtime, size: 123)

--- a/Tests/VibeBarCoreTests/QuotaRefreshSchedulerTests.swift
+++ b/Tests/VibeBarCoreTests/QuotaRefreshSchedulerTests.swift
@@ -19,4 +19,50 @@ final class QuotaRefreshSchedulerTests: XCTestCase {
 
         XCTAssertEqual(supplementalRefreshCount, 1)
     }
+
+    func testCredentialFailureDoesNotPoisonVisibleCachedQuota() async {
+        let account = AccountIdentity(id: "cached-claude", tool: .claude, source: .oauthCLI)
+        let service = QuotaService(
+            adapters: [.claude: SequenceAdapter(results: [
+                .success(AccountQuota(
+                    accountId: account.id,
+                    tool: .claude,
+                    buckets: [
+                        QuotaBucket(id: "five_hour", title: "5 Hours", shortLabel: "5h", usedPercent: 10)
+                    ],
+                    queriedAt: Date()
+                )),
+                .failure(.needsLogin)
+            ])],
+            mockProvider: { false }
+        )
+
+        let first = await service.refresh(account)
+        XCTAssertNil(first.error)
+        XCTAssertNil(service.lastErrorByAccount[account.id])
+
+        let second = await service.refresh(account)
+        XCTAssertEqual(second.buckets.count, 1)
+        XCTAssertNil(second.error)
+        XCTAssertNil(service.lastErrorByAccount[account.id])
+    }
+}
+
+private final class SequenceAdapter: QuotaAdapter, @unchecked Sendable {
+    let tool: ToolType = .claude
+    private var results: [Result<AccountQuota, QuotaError>]
+
+    init(results: [Result<AccountQuota, QuotaError>]) {
+        self.results = results
+    }
+
+    func fetch(for account: AccountIdentity) async throws -> AccountQuota {
+        guard !results.isEmpty else { throw QuotaError.unknown("empty sequence") }
+        switch results.removeFirst() {
+        case .success(let quota):
+            return quota
+        case .failure(let error):
+            throw error
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- add prioritized OpenAI/Claude source planning, provider route health, and Keychain-backed browser/webview cookie storage
- add OpenAI web cookie import/login support and Codex OAuth refresh fallback while keeping CLI first
- fix cost scanner edge cases for Codex last_token_usage, Claude streaming/subagent duplicate rows, stale cost caches, and Sonnet 4.6 pricing

## Test plan
- swift test
- ./Scripts/build_app.sh release
- codesign -d --entitlements - ".build/Vibe Bar.app"
- codesign --verify --deep --strict ".build/Vibe Bar.app"
- git diff --check