### PR TITLE
Auto-refresh console cookies + Alibaba console-cookie path

### DIFF
--- a/Sources/VibeBarApp/AppDelegate.swift
+++ b/Sources/VibeBarApp/AppDelegate.swift
@@ -18,13 +18,31 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         self.environment = env
         self.statusItem = StatusItemController(environment: env)
 
+        CookieRefreshScheduler.shared.start()
+        observeCookieRefreshes(environment: env)
+
         SafeLog.info("Vibe Bar started")
+    }
+
+    private func observeCookieRefreshes(environment: AppEnvironment) {
+        NotificationCenter.default.addObserver(
+            forName: .cookiesRefreshed,
+            object: nil,
+            queue: .main
+        ) { [weak environment] notification in
+            guard let environment,
+                  let raw = notification.userInfo?["tool"] as? String,
+                  let tool = ToolType(rawValue: raw),
+                  let account = environment.account(for: tool) else { return }
+            Task { _ = await environment.quotaService.refresh(account) }
+        }
     }
 
     func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
         statusItem?.applicationWillTerminate()
         environment?.scheduler.stop()
         environment?.serviceStatus.stop()
+        CookieRefreshScheduler.shared.stop()
         return .terminateNow
     }
 }

--- a/Sources/VibeBarApp/HiddenCookieRefresher.swift
+++ b/Sources/VibeBarApp/HiddenCookieRefresher.swift
@@ -1,0 +1,362 @@
+import AppKit
+import WebKit
+import VibeBarCore
+
+/// Background cookie refresher for misc providers whose console
+/// session cookies expire within hours (Tencent `skey`, Volcengine
+/// `csrfToken` + sso tickets, …).
+///
+/// Pattern: load the provider's authenticated console homepage in a
+/// hidden `WKWebView`, let the page's own JS run its silent
+/// session-refresh / keepalive flow, then snapshot the freshened
+/// cookies and persist them via `CookieHeaderCache`. The user never
+/// sees a window — the WebView is offscreen and discarded after each
+/// refresh.
+///
+/// Why this works without reverse-engineering `/touch` or
+/// `/refresh`-style endpoints: the page bring-up itself triggers the
+/// keepalive (which is exactly what keeps a regular user logged in
+/// for weeks at a time). We just borrow the browser engine.
+///
+/// The data store is shared with `MiscWebLoginController`, so the
+/// user's first-time login (skey + long-lived ticket cookies) acts
+/// as the bootstrap state. We additionally inject anything cached in
+/// `CookieHeaderCache` in case the user came in via SweetCookieKit
+/// auto-import rather than the in-app webview.
+@MainActor
+final class HiddenCookieRefresher {
+    static let shared = HiddenCookieRefresher()
+
+    struct Config {
+        let tool: ToolType
+        let refreshURL: URL
+        /// Domain suffixes whose cookies are considered relevant for
+        /// the captured header. Matches both bare domain and
+        /// subdomains (`tencent.com` matches `cloud.tencent.com`).
+        let cookieDomainSuffixes: [String]
+        /// Cookie names to retain in the captured header. Empty set
+        /// keeps the entire matching jar (used for Tencent/Volcengine
+        /// because their HttpOnly session helpers can't be enumerated
+        /// from JS).
+        let requiredCookieNames: Set<String>
+        /// Seconds to wait after `didFinish` before snapshotting
+        /// cookies. Console JS typically fires its silent refresh in
+        /// the first 1-3s of bring-up; some sites kick a second
+        /// /idle ping after a beat.
+        let postLoadWait: TimeInterval
+    }
+
+    /// Resolve a Config for each tool that needs background refresh.
+    /// Tools not listed here are skipped (e.g. MiMo, iFlytek — their
+    /// cookies live for days and don't need this).
+    enum Registry {
+        static func config(for tool: ToolType) -> Config? {
+            switch tool {
+            case .tencentHunyuan:
+                return Config(
+                    tool: .tencentHunyuan,
+                    refreshURL: URL(string: "https://cloud.tencent.com/account/info")!,
+                    cookieDomainSuffixes: ["tencent.com", "qq.com", "qcloud.com"],
+                    requiredCookieNames: [],
+                    postLoadWait: 8
+                )
+            case .volcengine:
+                return Config(
+                    tool: .volcengine,
+                    refreshURL: URL(string: "https://console.volcengine.com/iam/")!,
+                    cookieDomainSuffixes: ["volcengine.com"],
+                    requiredCookieNames: [],
+                    postLoadWait: 8
+                )
+            case .alibaba:
+                // Alibaba's bailian/modelstudio console keeps the
+                // login ticket alive only when the SPA loads — its
+                // /tool/user/info.json keepalive fires inside the
+                // Coding Plan widget bring-up. Loading the cn-beijing
+                // dashboard URL covers most users; the cookie path
+                // adapter falls back to the intl host on its own.
+                return Config(
+                    tool: .alibaba,
+                    refreshURL: URL(string: "https://bailian.console.aliyun.com/cn-beijing/?tab=model#/efm/coding_plan")!,
+                    cookieDomainSuffixes: ["aliyun.com", "alibabacloud.com"],
+                    requiredCookieNames: [],
+                    postLoadWait: 10
+                )
+            default:
+                return nil
+            }
+        }
+
+        static let supportedTools: [ToolType] = [.tencentHunyuan, .volcengine, .alibaba]
+    }
+
+    private let websiteDataStore = WKWebsiteDataStore.default()
+    private var inflight: [ToolType: Task<Bool, Never>] = [:]
+    private var pinnedDelegates: [ObjectIdentifier: NavDelegate] = [:]
+    private var pinnedWebViews: [ObjectIdentifier: WKWebView] = [:]
+
+    /// Trigger a silent refresh for `tool`. Returns true if the
+    /// captured header changed (i.e. cookies were freshened).
+    /// Concurrent refreshes for the same tool are coalesced.
+    @discardableResult
+    func refresh(_ tool: ToolType) async -> Bool {
+        if let task = inflight[tool] { return await task.value }
+        guard let config = Registry.config(for: tool) else { return false }
+        let task = Task { [weak self] () -> Bool in
+            guard let self else { return false }
+            return await self.performRefresh(config)
+        }
+        inflight[tool] = task
+        let result = await task.value
+        inflight[tool] = nil
+        return result
+    }
+
+    private func performRefresh(_ config: Config) async -> Bool {
+        let beforeHeader = CookieHeaderCache.load(for: config.tool)?.cookieHeader ?? ""
+        let beforeFingerprint = headerFingerprint(beforeHeader)
+        SafeLog.info("HiddenCookieRefresher start tool=\(config.tool.rawValue) beforeLen=\(beforeHeader.count) fp=\(beforeFingerprint)")
+
+        // Inject any cached header into the WebView cookie store so a
+        // user who arrived via SweetCookieKit auto-import (i.e. their
+        // cookies live in Keychain but have never touched WKWebView)
+        // can still bootstrap a refresh.
+        if !beforeHeader.isEmpty {
+            await injectCookies(beforeHeader, into: websiteDataStore.httpCookieStore, config: config)
+        }
+
+        return await withCheckedContinuation { (continuation: CheckedContinuation<Bool, Never>) in
+            let webViewConfig = WKWebViewConfiguration()
+            webViewConfig.websiteDataStore = self.websiteDataStore
+            webViewConfig.preferences.javaScriptCanOpenWindowsAutomatically = false
+            webViewConfig.defaultWebpagePreferences.allowsContentJavaScript = true
+
+            let webView = WKWebView(frame: CGRect(x: 0, y: 0, width: 1024, height: 768),
+                                    configuration: webViewConfig)
+            webView.customUserAgent = Self.safariUserAgent
+            let key = ObjectIdentifier(webView)
+
+            let delegate = NavDelegate { [weak self] result in
+                Task { @MainActor in
+                    guard let self else {
+                        continuation.resume(returning: false)
+                        return
+                    }
+                    defer {
+                        self.pinnedDelegates.removeValue(forKey: key)
+                        self.pinnedWebViews.removeValue(forKey: key)
+                    }
+                    switch result {
+                    case .finished:
+                        // Sleep on the actor so we don't block the
+                        // continuation; the inflight task keeps the
+                        // WebView retained until we're done.
+                        try? await Task.sleep(nanoseconds: UInt64(config.postLoadWait * 1_000_000_000))
+                        let captured = await self.captureAndStore(
+                            config,
+                            store: self.websiteDataStore.httpCookieStore,
+                            beforeFingerprint: beforeFingerprint
+                        )
+                        continuation.resume(returning: captured)
+                    case .failed(let err):
+                        SafeLog.warn("HiddenCookieRefresher load-failed tool=\(config.tool.rawValue) err=\(err.localizedDescription)")
+                        continuation.resume(returning: false)
+                    }
+                }
+            }
+            webView.navigationDelegate = delegate
+            self.pinnedDelegates[key] = delegate
+            self.pinnedWebViews[key] = webView
+
+            var request = URLRequest(url: config.refreshURL)
+            request.cachePolicy = .reloadIgnoringLocalAndRemoteCacheData
+            webView.load(request)
+        }
+    }
+
+    private func captureAndStore(_ config: Config,
+                                 store: WKHTTPCookieStore,
+                                 beforeFingerprint: String) async -> Bool {
+        let cookies: [HTTPCookie] = await withCheckedContinuation { cont in
+            store.getAllCookies { cont.resume(returning: $0) }
+        }
+
+        let header = minimizedHeader(cookies: cookies, config: config)
+        guard !header.isEmpty else {
+            SafeLog.warn("HiddenCookieRefresher no-cookies tool=\(config.tool.rawValue) — page likely redirected to login")
+            return false
+        }
+        let afterFingerprint = headerFingerprint(header)
+        let changed = afterFingerprint != beforeFingerprint
+        SafeLog.info("HiddenCookieRefresher done tool=\(config.tool.rawValue) afterLen=\(header.count) fp=\(afterFingerprint) changed=\(changed)")
+        guard changed else { return false }
+
+        CookieHeaderCache.store(
+            for: config.tool,
+            cookieHeader: header,
+            sourceLabel: "Auto-refresh"
+        )
+        NotificationCenter.default.post(
+            name: .cookiesRefreshed,
+            object: nil,
+            userInfo: ["tool": config.tool.rawValue]
+        )
+        return true
+    }
+
+    private func minimizedHeader(cookies: [HTTPCookie], config: Config) -> String {
+        let kept = cookies
+            .filter { cookie in
+                let domain = cookie.domain.lowercased()
+                let stripped = domain.hasPrefix(".") ? String(domain.dropFirst()) : domain
+                let domainOK = config.cookieDomainSuffixes.contains { suffix in
+                    let lowered = suffix.lowercased()
+                    let normalized = lowered.hasPrefix(".") ? String(lowered.dropFirst()) : lowered
+                    return stripped == normalized || stripped.hasSuffix("." + normalized)
+                }
+                guard domainOK else { return false }
+                if config.requiredCookieNames.isEmpty { return true }
+                return config.requiredCookieNames.contains(cookie.name)
+            }
+            .sorted { $0.name < $1.name }
+
+        var seen = Set<String>()
+        var pairs: [String] = []
+        for cookie in kept where seen.insert(cookie.name).inserted {
+            pairs.append("\(cookie.name)=\(cookie.value)")
+        }
+        return pairs.joined(separator: "; ")
+    }
+
+    private func injectCookies(_ header: String,
+                               into store: WKHTTPCookieStore,
+                               config: Config) async {
+        // Use the first listed suffix as the inject domain. WKHTTPCookieStore
+        // is forgiving here — once the WebView navigates to the matching host
+        // the engine re-keys cookies onto the right exact domain.
+        guard let primarySuffix = config.cookieDomainSuffixes.first else { return }
+        let domain = primarySuffix.hasPrefix(".") ? primarySuffix : "." + primarySuffix
+
+        for pair in header.split(separator: ";") {
+            let trimmed = pair.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard let eq = trimmed.firstIndex(of: "="), eq != trimmed.startIndex else { continue }
+            let name = String(trimmed[..<eq])
+            let value = String(trimmed[trimmed.index(after: eq)...])
+            guard let cookie = HTTPCookie(properties: [
+                .name: name,
+                .value: value,
+                .domain: domain,
+                .path: "/",
+                .secure: true
+            ]) else { continue }
+            await withCheckedContinuation { cont in
+                store.setCookie(cookie) { cont.resume() }
+            }
+        }
+    }
+
+    /// Hash the cookie header so we can log "did this refresh actually
+    /// change anything?" without writing the secret to logs.
+    nonisolated private func headerFingerprint(_ header: String) -> String {
+        guard !header.isEmpty else { return "empty" }
+        var hash: UInt64 = 5381
+        for byte in header.utf8 {
+            hash = ((hash << 5) &+ hash) &+ UInt64(byte)
+        }
+        return String(hash, radix: 16)
+    }
+
+    nonisolated private static var safariUserAgent: String {
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.0 Safari/605.1.15"
+    }
+}
+
+extension Notification.Name {
+    /// Posted when `HiddenCookieRefresher` writes a freshened cookie
+    /// header to `CookieHeaderCache`. `userInfo["tool"]` carries the
+    /// `ToolType.rawValue`. AppDelegate listens and kicks an
+    /// out-of-band `QuotaService.refresh` so the misc card flips
+    /// from "Needs re-login" to live data within seconds, instead of
+    /// waiting for the next `QuotaRefreshScheduler` tick.
+    static let cookiesRefreshed = Notification.Name("com.astroqore.VibeBar.cookiesRefreshed")
+}
+
+private final class NavDelegate: NSObject, WKNavigationDelegate {
+    enum Outcome { case finished, failed(Error) }
+    private let onComplete: (Outcome) -> Void
+    private var resolved = false
+
+    init(onComplete: @escaping (Outcome) -> Void) {
+        self.onComplete = onComplete
+        super.init()
+    }
+
+    func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+        guard !resolved else { return }
+        resolved = true
+        onComplete(.finished)
+    }
+
+    func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
+        guard !resolved else { return }
+        resolved = true
+        onComplete(.failed(error))
+    }
+
+    func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
+        guard !resolved else { return }
+        resolved = true
+        onComplete(.failed(error))
+    }
+}
+
+/// Periodic driver for `HiddenCookieRefresher`. Kicks an initial
+/// refresh shortly after launch, then re-runs on a jittered ~30
+/// minute cadence per tool.
+@MainActor
+final class CookieRefreshScheduler {
+    static let shared = CookieRefreshScheduler()
+
+    /// Minutes between background refreshes. Jittered ±20 % to avoid a
+    /// detectable beat pattern.
+    private static let basePeriodSeconds: TimeInterval = 30 * 60
+    /// First refresh after launch. Long enough that StatusItemController
+    /// has finished bringing up the popover, short enough that the
+    /// initial misc-card render still gets fresh cookies.
+    private static let firstRefreshDelaySeconds: TimeInterval = 60
+
+    private var tasks: [ToolType: Task<Void, Never>] = [:]
+
+    func start() {
+        for tool in HiddenCookieRefresher.Registry.supportedTools {
+            scheduleNext(for: tool, after: Self.firstRefreshDelaySeconds)
+        }
+    }
+
+    func stop() {
+        for task in tasks.values { task.cancel() }
+        tasks.removeAll()
+    }
+
+    /// Force an out-of-band refresh (e.g. when an adapter reports
+    /// `needsLogin` and we want to retry once before surfacing the
+    /// error to the user). Runs synchronously through the in-flight
+    /// coalescer so two adapter retries don't fire two refreshes.
+    @discardableResult
+    func refreshNow(_ tool: ToolType) async -> Bool {
+        await HiddenCookieRefresher.shared.refresh(tool)
+    }
+
+    private func scheduleNext(for tool: ToolType, after delay: TimeInterval) {
+        tasks[tool]?.cancel()
+        let jitter = Self.basePeriodSeconds * Double.random(in: -0.2...0.2)
+        let next = max(60, Self.basePeriodSeconds + jitter)
+        tasks[tool] = Task { [weak self] in
+            try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+            guard !Task.isCancelled else { return }
+            _ = await HiddenCookieRefresher.shared.refresh(tool)
+            guard !Task.isCancelled else { return }
+            self?.scheduleNext(for: tool, after: next)
+        }
+    }
+}

--- a/Sources/VibeBarApp/MiscWebLoginController.swift
+++ b/Sources/VibeBarApp/MiscWebLoginController.swift
@@ -190,19 +190,23 @@ final class MiscWebLoginController: NSObject, NSWindowDelegate, WKNavigationDele
 
     private func minimizedCookieHeader(from cookies: [HTTPCookie]) -> String? {
         // Filter to cookies whose domain matches one of the spec's
-        // suffix patterns AND whose name is in the required set. Sort
-        // for stability so identical sessions produce identical
-        // headers in Keychain.
+        // suffix patterns. If `requiredCookieNames` is non-empty, also
+        // restrict to those names; an empty set means "ship the full
+        // jar" (used for Tencent/Volcengine, whose HttpOnly session
+        // helpers can't be enumerated up front). Sort for stability so
+        // identical sessions produce identical headers in Keychain.
         let kept = cookies
             .filter { cookie in
-                guard config.requiredCookieNames.contains(cookie.name) else { return false }
                 let domain = cookie.domain.lowercased()
                 let stripped = domain.hasPrefix(".") ? String(domain.dropFirst()) : domain
-                return config.cookieDomainSuffixes.contains { suffix in
+                let domainOK = config.cookieDomainSuffixes.contains { suffix in
                     let lowered = suffix.lowercased()
                     let normalized = lowered.hasPrefix(".") ? String(lowered.dropFirst()) : lowered
                     return stripped == normalized || stripped.hasSuffix("." + normalized)
                 }
+                guard domainOK else { return false }
+                if config.requiredCookieNames.isEmpty { return true }
+                return config.requiredCookieNames.contains(cookie.name)
             }
             .sorted { $0.name < $1.name }
 
@@ -476,6 +480,26 @@ final class MiscWebLoginRegistry {
                 windowTitle: "Tencent Hunyuan Login",
                 savedConfirmation: "Hunyuan cookies saved.",
                 setupHint: "Sign in to Tencent Cloud (sub-user works), then click Save Cookies."
+            )
+        case .alibaba:
+            return MiscWebLoginController.Config(
+                tool: .alibaba,
+                loginURL: URL(string: "https://bailian.console.aliyun.com/cn-beijing/?tab=model#/efm/coding_plan")!,
+                cookieDomainSuffixes: ["aliyun.com", "alibabacloud.com"],
+                requiredCookieNames: [],  // ship full jar (HttpOnly login tickets)
+                trustedAuthHostSuffixes: [
+                    "aliyun.com",
+                    "alibabacloud.com",
+                    "alibaba.com",
+                    "alibaba-inc.com",
+                    "alicdn.com",
+                    "alipay.com",
+                    "taobao.com",
+                    "alibabausercontent.com"
+                ],
+                windowTitle: "Alibaba Bailian / ModelStudio Login",
+                savedConfirmation: "Alibaba console cookies saved.",
+                setupHint: "Sign in to Bailian (CN) or ModelStudio (Intl); use the same console where your Coding Plan lives. Then click Save Cookies."
             )
         default:
             return nil

--- a/Sources/VibeBarApp/Views/MiscProviderSettingsSection.swift
+++ b/Sources/VibeBarApp/Views/MiscProviderSettingsSection.swift
@@ -50,10 +50,19 @@ struct MiscProviderSettingsSection: View {
             VStack(alignment: .leading, spacing: 4) {
                 ApiKeyField(
                     tool: .alibaba,
-                    prompt: "Paste DashScope API key (sk-...)",
-                    helpText: "Find it at bailian.console.aliyun.com → API-KEY. Stored in macOS Keychain. (Console-cookie fallback coming later.)"
+                    prompt: "Paste DashScope API key (sk-...) — optional",
+                    helpText: "If you have a DashScope key, paste it here. Otherwise sign in via Web below to use console cookies. Stored in macOS Keychain."
                 )
                 AlibabaRegionPicker()
+                CookieSourceControls(
+                    tool: .alibaba,
+                    spec: AlibabaQuotaAdapter.cookieSpec,
+                    manualPrompt: "Paste console.aliyun.com Cookie header (login_aliyunid_csrf=…; cna=…; …)"
+                )
+                MiscWebLoginRow(
+                    tool: .alibaba,
+                    helpText: "No DashScope key? Sign in to bailian.console.aliyun.com or modelstudio.console.alibabacloud.com once via Web; Vibe Bar refreshes the console session in the background after that."
+                )
             }
         case .minimax:
             VStack(alignment: .leading, spacing: 4) {

--- a/Sources/VibeBarCore/Adapters/AlibabaQuotaAdapter.swift
+++ b/Sources/VibeBarCore/Adapters/AlibabaQuotaAdapter.swift
@@ -2,17 +2,22 @@ import Foundation
 
 /// Alibaba Qwen / Bailian Coding Plan usage adapter.
 ///
-/// Auth: API key (DashScope key) pasted in Settings. The user picks
-/// a region — international (`ap-southeast-1`, dashscope-intl) or
-/// china-mainland (`cn-beijing`, dashscope) — or leaves it blank
-/// for auto-failover.
+/// Two auth paths, tried in order:
+/// 1. **API key** (DashScope `sk-…`) — pasted in Settings, hits the
+///    public gateway directly. Cleanest path; only Coding Plan users
+///    who explicitly minted an API key have this.
+/// 2. **Console cookie** — the `*.aliyun.com` / `*.alibabacloud.com`
+///    session jar. Adapter scrapes `SEC_TOKEN` from the dashboard
+///    HTML, then POSTs the console RPC with `sec_token` + a
+///    `cornerstoneParam` blob the same way the Bailian / ModelStudio
+///    page does in the browser. This is what most Coding Plan
+///    customers end up using, since they signed up via the console
+///    rather than DashScope.
 ///
-/// Cookie fallback (codexbar's web-session path with sec_token /
-/// x-csrf-token / x-xsrf-token header dance) is **deliberately
-/// dropped** in this v1 port. It's ~600 lines of console-RPC-shape
-/// reverse engineering and depends on a live SweetCookieKit import
-/// chain. Users who only have a console session, no API key, see a
-/// "paste an API key" hint until that path lands as a follow-up.
+/// The user picks a region — international (`ap-southeast-1`,
+/// modelstudio.console.alibabacloud.com) or china-mainland
+/// (`cn-beijing`, bailian.console.aliyun.com) — or leaves it blank
+/// for auto-failover.
 ///
 /// Output: up to three `QuotaBucket`s — 5-hour (primary), weekly
 /// (secondary), monthly (tertiary). Each is built from used / total
@@ -24,6 +29,22 @@ public struct AlibabaQuotaAdapter: QuotaAdapter {
     private let session: URLSession
     private let now: @Sendable () -> Date
 
+    public static let cookieSpec = MiscCookieResolver.Spec(
+        tool: .alibaba,
+        domains: [
+            "bailian.console.aliyun.com",
+            "modelstudio.console.alibabacloud.com",
+            ".aliyun.com",
+            ".alibabacloud.com"
+        ],
+        // Empty `requiredNames` ships the entire jar — Alibaba's
+        // console identity stitches together `login_aliyunid_csrf`,
+        // `cna`, plus a handful of HttpOnly login tickets we can't
+        // enumerate from JS. Same approach as the iFlytek / Tencent
+        // / Volcengine adapters.
+        requiredNames: []
+    )
+
     public init(
         session: URLSession = .shared,
         now: @escaping @Sendable () -> Date = { Date() }
@@ -34,14 +55,6 @@ public struct AlibabaQuotaAdapter: QuotaAdapter {
 
     public func fetch(for account: AccountIdentity) async throws -> AccountQuota {
         let settings = MiscProviderSettings.current(for: .alibaba)
-        guard settings.allowsAPIOrOAuthAccess else {
-            throw QuotaError.noCredential
-        }
-        guard let apiKey = MiscCredentialStore.readString(tool: .alibaba, kind: .apiKey),
-              !apiKey.isEmpty
-        else {
-            throw QuotaError.noCredential
-        }
 
         let preferred: [AlibabaRegion]
         switch settings.region {
@@ -53,8 +66,46 @@ public struct AlibabaQuotaAdapter: QuotaAdapter {
             preferred = [.international, .chinaMainland]
         }
 
+        let hasAPIKey = settings.allowsAPIOrOAuthAccess && {
+            guard let key = MiscCredentialStore.readString(tool: .alibaba, kind: .apiKey),
+                  !key.isEmpty else { return false }
+            return true
+        }()
+        let cookieResolution = MiscCookieResolver.resolve(for: AlibabaQuotaAdapter.cookieSpec)
+
+        // Path 1: API key (preferred when present — fewer round-trips,
+        // no SEC_TOKEN scrape). Fall through to the cookie path on
+        // auth-style failures so a stale `sk-…` doesn't permanently
+        // black-hole users who also have a console session.
+        if hasAPIKey,
+           let apiKey = MiscCredentialStore.readString(tool: .alibaba, kind: .apiKey),
+           !apiKey.isEmpty {
+            do {
+                return try await fetchViaAPIKey(apiKey: apiKey, regions: preferred, account: account)
+            } catch let qe as QuotaError {
+                switch qe {
+                case .needsLogin, .noCredential:
+                    if cookieResolution == nil { throw qe }
+                    // else fall through to cookie path
+                default:
+                    throw qe
+                }
+            }
+        }
+
+        // Path 2: console cookie.
+        if let resolution = cookieResolution {
+            return try await fetchViaCookie(header: resolution.header, regions: preferred, account: account)
+        }
+
+        throw QuotaError.noCredential
+    }
+
+    private func fetchViaAPIKey(apiKey: String,
+                                regions: [AlibabaRegion],
+                                account: AccountIdentity) async throws -> AccountQuota {
         var lastError: QuotaError?
-        for region in preferred {
+        for region in regions {
             do {
                 let snapshot = try await fetchOnce(apiKey: apiKey, region: region)
                 return AccountQuota(
@@ -72,6 +123,40 @@ public struct AlibabaQuotaAdapter: QuotaAdapter {
                 // "log in"). Real network failures shouldn't roll
                 // through to the next region — they're more useful as
                 // a single error message.
+                switch qe {
+                case .needsLogin, .noCredential:
+                    continue
+                default:
+                    throw qe
+                }
+            }
+        }
+        throw lastError ?? QuotaError.unknown("Alibaba: no usable region.")
+    }
+
+    private func fetchViaCookie(header: String,
+                                regions: [AlibabaRegion],
+                                account: AccountIdentity) async throws -> AccountQuota {
+        var lastError: QuotaError?
+        for region in regions {
+            do {
+                let secToken = try await resolveSECToken(cookieHeader: header, region: region)
+                let snapshot = try await fetchConsoleOnce(
+                    cookieHeader: header,
+                    secToken: secToken,
+                    region: region
+                )
+                return AccountQuota(
+                    accountId: account.id,
+                    tool: .alibaba,
+                    buckets: snapshot.buckets,
+                    plan: snapshot.planName,
+                    email: account.email,
+                    queriedAt: now(),
+                    error: nil
+                )
+            } catch let qe as QuotaError {
+                lastError = qe
                 switch qe {
                 case .needsLogin, .noCredential:
                     continue
@@ -122,6 +207,174 @@ public struct AlibabaQuotaAdapter: QuotaAdapter {
 
         return try AlibabaResponseParser.parse(data: data, now: now())
     }
+
+    // MARK: Console-cookie path
+
+    /// GET the dashboard HTML and pull out the inline `SEC_TOKEN` JS
+    /// constant that the console RPC requires alongside the cookie
+    /// header. Falls back to a `sec_token` cookie if the page didn't
+    /// embed one.
+    private func resolveSECToken(cookieHeader: String,
+                                 region: AlibabaRegion) async throws -> String {
+        var request = URLRequest(url: region.dashboardURL)
+        request.httpMethod = "GET"
+        request.setValue(cookieHeader, forHTTPHeaderField: "Cookie")
+        request.setValue(Self.safariUA, forHTTPHeaderField: "User-Agent")
+        request.setValue(
+            "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+            forHTTPHeaderField: "Accept"
+        )
+
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await session.data(for: request)
+        } catch {
+            throw QuotaError.network("Alibaba dashboard fetch error: \(error.localizedDescription)")
+        }
+
+        if let http = response as? HTTPURLResponse,
+           http.statusCode == 200,
+           let html = String(data: data, encoding: .utf8) {
+            let patterns = [
+                #"SEC_TOKEN\s*:\s*\"([^\"]+)\""#,
+                #"SEC_TOKEN\s*:\s*'([^']+)'"#,
+                #"secToken\s*:\s*\"([^\"]+)\""#,
+                #"sec_token\s*:\s*\"([^\"]+)\""#,
+                #"\"SEC_TOKEN\"\s*:\s*\"([^\"]+)\""#,
+                #"\"sec_token\"\s*:\s*\"([^\"]+)\""#
+            ]
+            for pattern in patterns {
+                if let token = Self.matchFirstGroup(pattern: pattern, in: html), !token.isEmpty {
+                    return token
+                }
+            }
+        }
+
+        if let cookieToken = Self.extractCookieValue(name: "sec_token", from: cookieHeader),
+           !cookieToken.isEmpty {
+            return cookieToken
+        }
+
+        throw QuotaError.needsLogin
+    }
+
+    /// POST the form-urlencoded console RPC body the Bailian /
+    /// ModelStudio dashboard fires from the browser. Body shape:
+    /// `params=<json>&region=<id>&sec_token=<sec>`. Headers carry
+    /// the cookie + `x-csrf-token` / `x-xsrf-token` lifted from the
+    /// `login_aliyunid_csrf` (or `csrf`) cookie value.
+    private func fetchConsoleOnce(cookieHeader: String,
+                                  secToken: String,
+                                  region: AlibabaRegion) async throws -> AlibabaResponseParser.Snapshot {
+        let traceID = UUID().uuidString.lowercased()
+        var cornerstone: [String: Any] = [
+            "feTraceId": traceID,
+            "feURL": region.dashboardURL.absoluteString,
+            "protocol": "V2",
+            "console": "ONE_CONSOLE",
+            "productCode": "p_efm",
+            "domain": region.consoleDomain,
+            "consoleSite": region.consoleSite,
+            "userNickName": "",
+            "userPrincipalName": "",
+            "xsp_lang": "en-US"
+        ]
+        if let cna = Self.extractCookieValue(name: "cna", from: cookieHeader), !cna.isEmpty {
+            cornerstone["X-Anonymous-Id"] = cna
+        }
+
+        let paramsObject: [String: Any] = [
+            "Api": region.consoleQuotaAPIName,
+            "V": "1.0",
+            "Data": [
+                "queryCodingPlanInstanceInfoRequest": [
+                    "commodityCode": region.commodityCode,
+                    "onlyLatestOne": true
+                ],
+                "cornerstoneParam": cornerstone
+            ]
+        ]
+
+        guard let paramsData = try? JSONSerialization.data(withJSONObject: paramsObject),
+              let paramsString = String(data: paramsData, encoding: .utf8) else {
+            throw QuotaError.parseFailure("Alibaba: failed to encode console params")
+        }
+
+        var components = URLComponents()
+        components.queryItems = [
+            URLQueryItem(name: "params", value: paramsString),
+            URLQueryItem(name: "region", value: region.currentRegionID),
+            URLQueryItem(name: "sec_token", value: secToken)
+        ]
+        let body = (components.percentEncodedQuery ?? "").data(using: .utf8) ?? Data()
+
+        var request = URLRequest(url: region.consoleRPCURL)
+        request.httpMethod = "POST"
+        request.httpBody = body
+        request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+        request.setValue("*/*", forHTTPHeaderField: "Accept")
+        request.setValue(cookieHeader, forHTTPHeaderField: "Cookie")
+        if let csrf = Self.extractCookieValue(name: "login_aliyunid_csrf", from: cookieHeader)
+            ?? Self.extractCookieValue(name: "csrf", from: cookieHeader) {
+            request.setValue(csrf, forHTTPHeaderField: "x-xsrf-token")
+            request.setValue(csrf, forHTTPHeaderField: "x-csrf-token")
+        }
+        request.setValue("XMLHttpRequest", forHTTPHeaderField: "X-Requested-With")
+        request.setValue(Self.safariUA, forHTTPHeaderField: "User-Agent")
+        request.setValue(region.gatewayBaseURL.absoluteString, forHTTPHeaderField: "Origin")
+        request.setValue(region.consoleRefererURL.absoluteString, forHTTPHeaderField: "Referer")
+
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await session.data(for: request)
+        } catch {
+            throw QuotaError.network("Alibaba console error: \(error.localizedDescription)")
+        }
+        guard let http = response as? HTTPURLResponse else {
+            throw QuotaError.network("Alibaba console: invalid response object")
+        }
+        guard http.statusCode == 200 else {
+            if http.statusCode == 401 || http.statusCode == 403 {
+                throw QuotaError.needsLogin
+            }
+            if http.statusCode == 429 {
+                throw QuotaError.rateLimited
+            }
+            throw QuotaError.network("Alibaba console returned HTTP \(http.statusCode).")
+        }
+
+        return try AlibabaResponseParser.parse(data: data, now: now())
+    }
+
+    // MARK: Helpers
+
+    nonisolated private static var safariUA: String {
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.0 Safari/605.1.15"
+    }
+
+    nonisolated private static func matchFirstGroup(pattern: String, in text: String) -> String? {
+        guard let regex = try? NSRegularExpression(pattern: pattern, options: []) else { return nil }
+        let range = NSRange(text.startIndex..<text.endIndex, in: text)
+        guard let match = regex.firstMatch(in: text, options: [], range: range),
+              match.numberOfRanges > 1,
+              let valueRange = Range(match.range(at: 1), in: text) else { return nil }
+        let value = String(text[valueRange]).trimmingCharacters(in: .whitespacesAndNewlines)
+        return value.isEmpty ? nil : value
+    }
+
+    nonisolated private static func extractCookieValue(name: String, from header: String) -> String? {
+        for segment in header.split(separator: ";") {
+            let part = segment.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard let eq = part.firstIndex(of: "=") else { continue }
+            let key = String(part[..<eq]).trimmingCharacters(in: .whitespacesAndNewlines)
+            guard key == name else { continue }
+            let value = String(part[part.index(after: eq)...]).trimmingCharacters(in: .whitespacesAndNewlines)
+            return value.isEmpty ? nil : value
+        }
+        return nil
+    }
 }
 
 // MARK: - Region
@@ -162,6 +415,73 @@ enum AlibabaRegion: String {
             URLQueryItem(name: "currentRegionId", value: currentRegionID)
         ]
         return components.url!
+    }
+
+    // MARK: Console-cookie path
+
+    var dashboardURL: URL {
+        switch self {
+        case .international:
+            return URL(string: "https://modelstudio.console.alibabacloud.com/ap-southeast-1/?tab=coding-plan#/efm/detail")!
+        case .chinaMainland:
+            return URL(string: "https://bailian.console.aliyun.com/cn-beijing/?tab=model#/efm/coding_plan")!
+        }
+    }
+
+    var consoleRefererURL: URL {
+        switch self {
+        case .international:
+            return URL(string: "https://modelstudio.console.alibabacloud.com/ap-southeast-1/?tab=coding-plan")!
+        case .chinaMainland:
+            return URL(string: "https://bailian.console.aliyun.com/cn-beijing/?tab=model")!
+        }
+    }
+
+    var consoleDomain: String {
+        switch self {
+        case .international: return "modelstudio.console.alibabacloud.com"
+        case .chinaMainland: return "bailian.console.aliyun.com"
+        }
+    }
+
+    var consoleSite: String {
+        switch self {
+        case .international: return "MODELSTUDIO_ALIBABACLOUD"
+        case .chinaMainland: return "BAILIAN_ALIYUN"
+        }
+    }
+
+    var consoleRPCBaseURL: URL {
+        switch self {
+        case .international: return URL(string: "https://bailian-singapore-cs.alibabacloud.com")!
+        case .chinaMainland: return URL(string: "https://bailian-cs.console.aliyun.com")!
+        }
+    }
+
+    /// Console BFF endpoint used by the cookie path. Matches what the
+    /// Bailian / ModelStudio dashboard issues from the browser when
+    /// loading the coding-plan widget.
+    var consoleRPCURL: URL {
+        var components = URLComponents(url: consoleRPCBaseURL, resolvingAgainstBaseURL: false)!
+        components.path = "/data/api.json"
+        components.queryItems = [
+            URLQueryItem(name: "action", value: consoleRPCAction),
+            URLQueryItem(name: "product", value: "sfm_bailian"),
+            URLQueryItem(name: "api", value: consoleQuotaAPIName),
+            URLQueryItem(name: "_v", value: "undefined")
+        ]
+        return components.url!
+    }
+
+    var consoleRPCAction: String {
+        switch self {
+        case .international: return "IntlBroadScopeAspnGateway"
+        case .chinaMainland: return "BroadScopeAspnGateway"
+        }
+    }
+
+    var consoleQuotaAPIName: String {
+        "zeldaEasy.broadscope-bailian.codingPlan.queryCodingPlanInstanceInfoV2"
     }
 }
 


### PR DESCRIPTION
## Summary
- Hidden-WKWebView background refresher silently re-issues `skey` / sso ticket cookies for Tencent, Volcengine, and Alibaba every ~30 min (jittered), eliminating manual "Sign in via Web" round-trips.
- Successful refreshes post `cookiesRefreshed` so `QuotaService` re-fetches immediately — cards flip from "Needs re-login" to live data within seconds.
- Adds the Alibaba console-cookie path that PR #9 deferred: SEC_TOKEN scrape + console-RPC POST, with API-key → cookie fall-through.
- Fixes a `MiscWebLoginController` bug where empty `requiredCookieNames` dropped every cookie at save time (broke Tencent + Volcengine in-app webview saves).

## Test plan
- [x] `swift build && swift test` (264 tests, 0 failures)
- [x] `./Scripts/build_app.sh release` + `codesign --verify --deep --strict` (empty entitlements, exit 0)
- [x] Smoke test: launch unsandboxed; container dir absent
- [x] Tencent silent refresh: `HiddenCookieRefresher done changed=true` every tick, `cloud.tencent.com refresh failed` logs disappear
- [x] Alibaba: API-key path fails (stale `sk-…`) → cookie path → console RPC 200 → parser yields 3 buckets ("Coding Plan Pro")
- [x] Volcengine webview save: empty-required-names bug fix verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)