### PR TITLE
Stack multiple cookie sessions per misc provider

### DIFF
--- a/Sources/VibeBarApp/HiddenCookieRefresher.swift
+++ b/Sources/VibeBarApp/HiddenCookieRefresher.swift
@@ -90,13 +90,16 @@ final class HiddenCookieRefresher {
         static let supportedTools: [ToolType] = [.tencentHunyuan, .volcengine, .alibaba]
     }
 
-    private let websiteDataStore = WKWebsiteDataStore.default()
     private var inflight: [ToolType: Task<Bool, Never>] = [:]
     private var pinnedDelegates: [ObjectIdentifier: NavDelegate] = [:]
     private var pinnedWebViews: [ObjectIdentifier: WKWebView] = [:]
+    private var pinnedDataStores: [ObjectIdentifier: WKWebsiteDataStore] = [:]
 
-    /// Trigger a silent refresh for `tool`. Returns true if the
-    /// captured header changed (i.e. cookies were freshened).
+    /// Trigger a silent refresh for `tool`. Iterates the user's
+    /// browser-origin cookie slots and refreshes each one. Manual
+    /// slots are skipped — auto-refresh only re-runs a session the
+    /// user originally captured via browser import or the in-app web
+    /// login. Returns true if at least one slot's header changed.
     /// Concurrent refreshes for the same tool are coalesced.
     @discardableResult
     func refresh(_ tool: ToolType) async -> Bool {
@@ -113,21 +116,49 @@ final class HiddenCookieRefresher {
     }
 
     private func performRefresh(_ config: Config) async -> Bool {
-        let beforeHeader = CookieHeaderCache.load(for: config.tool)?.cookieHeader ?? ""
-        let beforeFingerprint = headerFingerprint(beforeHeader)
-        SafeLog.info("HiddenCookieRefresher start tool=\(config.tool.rawValue) beforeLen=\(beforeHeader.count) fp=\(beforeFingerprint)")
+        let slots = MiscCookieSlotStore.slots(for: config.tool)
+            .filter { $0.origin != .manual }
+        guard !slots.isEmpty else {
+            SafeLog.info("HiddenCookieRefresher skip tool=\(config.tool.rawValue) — no browser-origin slots")
+            return false
+        }
 
-        // Inject any cached header into the WebView cookie store so a
-        // user who arrived via SweetCookieKit auto-import (i.e. their
-        // cookies live in Keychain but have never touched WKWebView)
-        // can still bootstrap a refresh.
+        var anyChanged = false
+        for slot in slots {
+            if await performRefreshForSlot(config, slot: slot) {
+                anyChanged = true
+            }
+        }
+        if anyChanged {
+            NotificationCenter.default.post(
+                name: .cookiesRefreshed,
+                object: nil,
+                userInfo: ["tool": config.tool.rawValue]
+            )
+        }
+        return anyChanged
+    }
+
+    private func performRefreshForSlot(_ config: Config, slot: MiscCookieSlot) async -> Bool {
+        let beforeHeader = slot.cookieHeader
+        let beforeFingerprint = headerFingerprint(beforeHeader)
+        SafeLog.info(
+            "HiddenCookieRefresher start tool=\(config.tool.rawValue) slot=\(slot.id.uuidString.prefix(8)) beforeLen=\(beforeHeader.count) fp=\(beforeFingerprint)"
+        )
+
+        // Fresh ephemeral data store per slot so cookies from one
+        // session can't leak into another. The default
+        // `WKWebsiteDataStore` is process-shared, which is the wrong
+        // shape once we have multiple stacked sessions per provider.
+        let dataStore = WKWebsiteDataStore.nonPersistent()
+
         if !beforeHeader.isEmpty {
-            await injectCookies(beforeHeader, into: websiteDataStore.httpCookieStore, config: config)
+            await injectCookies(beforeHeader, into: dataStore.httpCookieStore, config: config)
         }
 
         return await withCheckedContinuation { (continuation: CheckedContinuation<Bool, Never>) in
             let webViewConfig = WKWebViewConfiguration()
-            webViewConfig.websiteDataStore = self.websiteDataStore
+            webViewConfig.websiteDataStore = dataStore
             webViewConfig.preferences.javaScriptCanOpenWindowsAutomatically = false
             webViewConfig.defaultWebpagePreferences.allowsContentJavaScript = true
 
@@ -145,6 +176,7 @@ final class HiddenCookieRefresher {
                     defer {
                         self.pinnedDelegates.removeValue(forKey: key)
                         self.pinnedWebViews.removeValue(forKey: key)
+                        self.pinnedDataStores.removeValue(forKey: key)
                     }
                     switch result {
                     case .finished:
@@ -152,14 +184,17 @@ final class HiddenCookieRefresher {
                         // continuation; the inflight task keeps the
                         // WebView retained until we're done.
                         try? await Task.sleep(nanoseconds: UInt64(config.postLoadWait * 1_000_000_000))
-                        let captured = await self.captureAndStore(
+                        let captured = await self.captureAndUpdateSlot(
                             config,
-                            store: self.websiteDataStore.httpCookieStore,
+                            slot: slot,
+                            store: dataStore.httpCookieStore,
                             beforeFingerprint: beforeFingerprint
                         )
                         continuation.resume(returning: captured)
                     case .failed(let err):
-                        SafeLog.warn("HiddenCookieRefresher load-failed tool=\(config.tool.rawValue) err=\(err.localizedDescription)")
+                        SafeLog.warn(
+                            "HiddenCookieRefresher load-failed tool=\(config.tool.rawValue) slot=\(slot.id.uuidString.prefix(8)) err=\(err.localizedDescription)"
+                        )
                         continuation.resume(returning: false)
                     }
                 }
@@ -167,6 +202,7 @@ final class HiddenCookieRefresher {
             webView.navigationDelegate = delegate
             self.pinnedDelegates[key] = delegate
             self.pinnedWebViews[key] = webView
+            self.pinnedDataStores[key] = dataStore
 
             var request = URLRequest(url: config.refreshURL)
             request.cachePolicy = .reloadIgnoringLocalAndRemoteCacheData
@@ -174,34 +210,35 @@ final class HiddenCookieRefresher {
         }
     }
 
-    private func captureAndStore(_ config: Config,
-                                 store: WKHTTPCookieStore,
-                                 beforeFingerprint: String) async -> Bool {
+    private func captureAndUpdateSlot(_ config: Config,
+                                      slot: MiscCookieSlot,
+                                      store: WKHTTPCookieStore,
+                                      beforeFingerprint: String) async -> Bool {
         let cookies: [HTTPCookie] = await withCheckedContinuation { cont in
             store.getAllCookies { cont.resume(returning: $0) }
         }
 
         let header = minimizedHeader(cookies: cookies, config: config)
         guard !header.isEmpty else {
-            SafeLog.warn("HiddenCookieRefresher no-cookies tool=\(config.tool.rawValue) — page likely redirected to login")
+            SafeLog.warn(
+                "HiddenCookieRefresher no-cookies tool=\(config.tool.rawValue) slot=\(slot.id.uuidString.prefix(8)) — page likely redirected to login"
+            )
             return false
         }
         let afterFingerprint = headerFingerprint(header)
         let changed = afterFingerprint != beforeFingerprint
-        SafeLog.info("HiddenCookieRefresher done tool=\(config.tool.rawValue) afterLen=\(header.count) fp=\(afterFingerprint) changed=\(changed)")
+        SafeLog.info(
+            "HiddenCookieRefresher done tool=\(config.tool.rawValue) slot=\(slot.id.uuidString.prefix(8)) afterLen=\(header.count) fp=\(afterFingerprint) changed=\(changed)"
+        )
         guard changed else { return false }
 
-        CookieHeaderCache.store(
+        return MiscCookieSlotStore.updateHeader(
+            slotID: slot.id,
             for: config.tool,
-            cookieHeader: header,
-            sourceLabel: "Auto-refresh"
+            header: header,
+            sourceLabel: "Auto-refresh",
+            origin: .autoRefresh
         )
-        NotificationCenter.default.post(
-            name: .cookiesRefreshed,
-            object: nil,
-            userInfo: ["tool": config.tool.rawValue]
-        )
-        return true
     }
 
     private func minimizedHeader(cookies: [HTTPCookie], config: Config) -> String {

--- a/Sources/VibeBarApp/MiscWebLoginController.swift
+++ b/Sources/VibeBarApp/MiscWebLoginController.swift
@@ -12,8 +12,8 @@ import VibeBarCore
 ///    login URL.
 /// 2. Let the user sign in (handles password + SSO + popup flows).
 /// 3. Watch the cookie store; once the spec's required cookies are
-///    present, minimise them to `name=value; …` form and persist via
-///    `CookieHeaderCache.store(for:cookieHeader:sourceLabel:)`.
+///    present, minimise them to `name=value; …` form and append a new
+///    slot to `MiscCookieSlotStore`.
 /// 4. Fire the `onSaved` callback so the caller can kick a refresh.
 ///
 /// Generic on `ToolType` via `Config` — one instance per tool. Use
@@ -29,7 +29,7 @@ final class MiscWebLoginController: NSObject, NSWindowDelegate, WKNavigationDele
         /// `xiaomimimo.com` and `platform.xiaomimimo.com`).
         let cookieDomainSuffixes: [String]
         /// Cookie names to retain from the WebView store. Anything not
-        /// in this set is dropped before `CookieHeaderCache.store`.
+        /// in this set is dropped before the slot is persisted.
         let requiredCookieNames: Set<String>
         /// Hosts the in-app browser is allowed to navigate to. Anything
         /// outside this allowlist opens in the system browser instead.
@@ -159,11 +159,13 @@ final class MiscWebLoginController: NSObject, NSWindowDelegate, WKNavigationDele
             }
             return
         }
-        let stored = CookieHeaderCache.store(
-            for: config.tool,
+        let slot = MiscCookieSlot(
             cookieHeader: header,
-            sourceLabel: "WebView login"
+            sourceLabel: "WebView login",
+            importedAt: Date(),
+            origin: .browserImport
         )
+        let stored = MiscCookieSlotStore.append(slot, for: config.tool)
         guard stored else {
             if manual {
                 showAlert(message: "Could not save \(config.tool.menuTitle) cookies to Keychain.")

--- a/Sources/VibeBarApp/Views/MiscProviderSettingsSection.swift
+++ b/Sources/VibeBarApp/Views/MiscProviderSettingsSection.swift
@@ -566,8 +566,14 @@ struct KiroStatusRow: View {
     }
 }
 
-/// Browser-cookie controls for the misc providers. Import/manual source
-/// selection is automatic; the UI only exposes recovery actions.
+/// Browser-cookie controls for the misc providers.
+///
+/// Each provider can stack multiple cookie sessions — one per account.
+/// The section shows the current list of imported slots (with source
+/// label, import time, and a delete button) plus two additive entry
+/// points: "Import from browser" and a manual paste field. Quota
+/// queries fan out across every slot and the bucket percentages are
+/// averaged; see `MiscQuotaAggregator`.
 struct CookieSourceControls: View {
     let tool: ToolType
     let spec: MiscCookieResolver.Spec
@@ -576,30 +582,36 @@ struct CookieSourceControls: View {
     @EnvironmentObject var environment: AppEnvironment
     @EnvironmentObject var quotaService: QuotaService
 
+    @State private var slots: [MiscCookieSlot] = []
     @State private var manualDraft: String = ""
     @State private var importStatus: String?
 
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
+            if slots.isEmpty {
+                Text("No cookies imported yet — import from your browser or paste below.")
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+            } else {
+                VStack(alignment: .leading, spacing: 4) {
+                    ForEach(slots) { slot in
+                        CookieSlotRow(slot: slot) { deleteSlot(slot) }
+                    }
+                }
+            }
             HStack(spacing: 6) {
-                Button("Import now", action: importNow)
+                Button("Import from browser", action: importNow)
                     .buttonStyle(.bordered)
                     .controlSize(.small)
-                Text("Vibe Bar tries cached, browser, then pasted cookies automatically.")
+                Text("Adds a new slot. Existing cookies stay; quotas are averaged across all slots.")
                     .font(.caption)
                     .foregroundStyle(.tertiary)
             }
             HStack(spacing: 6) {
                 SecureField(manualPrompt, text: $manualDraft)
                     .textFieldStyle(.roundedBorder)
-                Button("Save", action: saveManual)
+                Button("Add", action: saveManual)
                     .disabled(manualDraft.isEmpty)
-                if hasManualValue {
-                    Button(role: .destructive, action: clearManual) {
-                        Image(systemName: "trash")
-                    }
-                    .help("Remove pasted cookie")
-                }
             }
             if let importStatus {
                 Text(importStatus)
@@ -607,19 +619,29 @@ struct CookieSourceControls: View {
                     .foregroundStyle(.secondary)
             }
         }
+        .onAppear(perform: reloadSlots)
+        .onReceive(NotificationCenter.default.publisher(
+            for: MiscCookieSlotStore.didChangeNotification
+        )) { note in
+            guard let raw = note.userInfo?["tool"] as? String,
+                  raw == tool.rawValue else { return }
+            reloadSlots()
+        }
     }
 
-    private var hasManualValue: Bool {
-        MiscCredentialStore.hasValue(tool: tool, kind: .manualCookieHeader)
+    private func reloadSlots() {
+        slots = MiscCookieSlotStore.slots(for: tool)
     }
 
     private func importNow() {
         importStatus = "Importing…"
+        let snapshotSpec = spec
         DispatchQueue.global(qos: .userInitiated).async {
-            let result = MiscCookieResolver.forceBrowserImport(for: spec)
+            let result = MiscCookieResolver.appendBrowserImport(for: snapshotSpec)
             DispatchQueue.main.async {
                 if let result {
                     importStatus = "Imported from \(result.sourceLabel)."
+                    reloadSlots()
                     triggerRefresh()
                 } else {
                     importStatus = "No cookies found. Sign in at the provider in your browser, then retry."
@@ -635,17 +657,26 @@ struct CookieSourceControls: View {
             importStatus = missingCookieMessage
             return
         }
-        MiscCredentialStore.writeString(normalised, tool: tool, kind: .manualCookieHeader)
-        CookieHeaderCache.clear(for: tool)
-        importStatus = "Manual cookie saved."
+        let slot = MiscCookieSlot(
+            cookieHeader: normalised,
+            sourceLabel: "Manual paste",
+            importedAt: Date(),
+            origin: .manual
+        )
+        guard MiscCookieSlotStore.append(slot, for: tool) else {
+            importStatus = "Could not save to Keychain."
+            return
+        }
+        importStatus = "Pasted cookie saved."
         manualDraft = ""
+        reloadSlots()
         triggerRefresh()
     }
 
-    private func clearManual() {
-        MiscCredentialStore.delete(tool: tool, kind: .manualCookieHeader)
-        CookieHeaderCache.clear(for: tool)
-        importStatus = "Manual cookie cleared."
+    private func deleteSlot(_ slot: MiscCookieSlot) {
+        guard MiscCookieSlotStore.delete(slotID: slot.id, for: tool) else { return }
+        importStatus = "Removed \(slot.sourceLabel)."
+        reloadSlots()
         triggerRefresh()
     }
 
@@ -667,6 +698,55 @@ struct CookieSourceControls: View {
         guard let account = environment.account(for: tool) else { return }
         Task { _ = await quotaService.refresh(account) }
     }
+}
+
+/// One row in the cookie slot list. Shows the source label + import
+/// time and a trash button.
+private struct CookieSlotRow: View {
+    let slot: MiscCookieSlot
+    let onDelete: () -> Void
+
+    var body: some View {
+        HStack(spacing: 6) {
+            Image(systemName: icon)
+                .foregroundStyle(.secondary)
+                .font(.caption)
+                .frame(width: 14)
+            Text(slot.sourceLabel)
+                .font(.caption)
+                .foregroundStyle(.primary)
+            Spacer(minLength: 4)
+            Text(Self.dateFormatter.string(from: slot.importedAt))
+                .font(.caption2)
+                .foregroundStyle(.tertiary)
+            Button(role: .destructive, action: onDelete) {
+                Image(systemName: "trash")
+            }
+            .buttonStyle(.borderless)
+            .help("Remove this cookie slot")
+        }
+        .padding(.vertical, 2)
+        .padding(.horizontal, 6)
+        .background(
+            RoundedRectangle(cornerRadius: 6, style: .continuous)
+                .fill(Color.primary.opacity(0.05))
+        )
+    }
+
+    private var icon: String {
+        switch slot.origin {
+        case .manual:         return "doc.on.clipboard"
+        case .browserImport:  return "safari"
+        case .autoRefresh:    return "arrow.clockwise.circle"
+        }
+    }
+
+    private static let dateFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateStyle = .short
+        f.timeStyle = .short
+        return f
+    }()
 }
 
 /// Region picker for Alibaba — international (ap-southeast-1) vs.

--- a/Sources/VibeBarCore/Adapters/AlibabaQuotaAdapter.swift
+++ b/Sources/VibeBarCore/Adapters/AlibabaQuotaAdapter.swift
@@ -66,26 +66,33 @@ public struct AlibabaQuotaAdapter: QuotaAdapter {
             preferred = [.international, .chinaMainland]
         }
 
+        let queriedAt = now()
         let hasAPIKey = settings.allowsAPIOrOAuthAccess && {
             guard let key = MiscCredentialStore.readString(tool: .alibaba, kind: .apiKey),
                   !key.isEmpty else { return false }
             return true
         }()
-        let cookieResolution = MiscCookieResolver.resolve(for: AlibabaQuotaAdapter.cookieSpec)
+        let cookieResolutions = MiscCookieResolver.resolveAll(for: AlibabaQuotaAdapter.cookieSpec)
 
         // Path 1: API key (preferred when present — fewer round-trips,
         // no SEC_TOKEN scrape). Fall through to the cookie path on
         // auth-style failures so a stale `sk-…` doesn't permanently
-        // black-hole users who also have a console session.
+        // black-hole users who also have a console session. The API
+        // key returns a single account; aggregation is a no-op there.
         if hasAPIKey,
            let apiKey = MiscCredentialStore.readString(tool: .alibaba, kind: .apiKey),
            !apiKey.isEmpty {
             do {
-                return try await fetchViaAPIKey(apiKey: apiKey, regions: preferred, account: account)
+                return try await fetchViaAPIKey(
+                    apiKey: apiKey,
+                    regions: preferred,
+                    account: account,
+                    queriedAt: queriedAt
+                )
             } catch let qe as QuotaError {
                 switch qe {
                 case .needsLogin, .noCredential:
-                    if cookieResolution == nil { throw qe }
+                    if cookieResolutions.isEmpty { throw qe }
                     // else fall through to cookie path
                 default:
                     throw qe
@@ -93,28 +100,42 @@ public struct AlibabaQuotaAdapter: QuotaAdapter {
             }
         }
 
-        // Path 2: console cookie.
-        if let resolution = cookieResolution {
-            return try await fetchViaCookie(header: resolution.header, regions: preferred, account: account)
+        // Path 2: console cookies. Average buckets across every
+        // imported cookie slot.
+        guard !cookieResolutions.isEmpty else {
+            throw QuotaError.noCredential
         }
-
-        throw QuotaError.noCredential
+        let results = await MiscQuotaAggregator.gatherSlotResults(cookieResolutions) { resolution in
+            try await self.fetchViaCookieSlot(
+                resolution: resolution,
+                regions: preferred,
+                account: account,
+                queriedAt: queriedAt
+            )
+        }
+        return MiscQuotaAggregator.aggregate(
+            tool: .alibaba,
+            account: account,
+            results: results,
+            queriedAt: queriedAt
+        )
     }
 
     private func fetchViaAPIKey(apiKey: String,
                                 regions: [AlibabaRegion],
-                                account: AccountIdentity) async throws -> AccountQuota {
+                                account: AccountIdentity,
+                                queriedAt: Date) async throws -> AccountQuota {
         var lastError: QuotaError?
         for region in regions {
             do {
-                let snapshot = try await fetchOnce(apiKey: apiKey, region: region)
+                let snapshot = try await fetchOnce(apiKey: apiKey, region: region, now: queriedAt)
                 return AccountQuota(
                     accountId: account.id,
                     tool: .alibaba,
                     buckets: snapshot.buckets,
                     plan: snapshot.planName,
                     email: account.email,
-                    queriedAt: now(),
+                    queriedAt: queriedAt,
                     error: nil
                 )
             } catch let qe as QuotaError {
@@ -134,17 +155,19 @@ public struct AlibabaQuotaAdapter: QuotaAdapter {
         throw lastError ?? QuotaError.unknown("Alibaba: no usable region.")
     }
 
-    private func fetchViaCookie(header: String,
-                                regions: [AlibabaRegion],
-                                account: AccountIdentity) async throws -> AccountQuota {
+    private func fetchViaCookieSlot(resolution: MiscCookieResolver.Resolution,
+                                    regions: [AlibabaRegion],
+                                    account: AccountIdentity,
+                                    queriedAt: Date) async throws -> AccountQuota {
         var lastError: QuotaError?
         for region in regions {
             do {
-                let secToken = try await resolveSECToken(cookieHeader: header, region: region)
+                let secToken = try await resolveSECToken(cookieHeader: resolution.header, region: region)
                 let snapshot = try await fetchConsoleOnce(
-                    cookieHeader: header,
+                    cookieHeader: resolution.header,
                     secToken: secToken,
-                    region: region
+                    region: region,
+                    now: queriedAt
                 )
                 return AccountQuota(
                     accountId: account.id,
@@ -152,7 +175,7 @@ public struct AlibabaQuotaAdapter: QuotaAdapter {
                     buckets: snapshot.buckets,
                     plan: snapshot.planName,
                     email: account.email,
-                    queriedAt: now(),
+                    queriedAt: queriedAt,
                     error: nil
                 )
             } catch let qe as QuotaError {
@@ -168,7 +191,7 @@ public struct AlibabaQuotaAdapter: QuotaAdapter {
         throw lastError ?? QuotaError.unknown("Alibaba: no usable region.")
     }
 
-    private func fetchOnce(apiKey: String, region: AlibabaRegion) async throws -> AlibabaResponseParser.Snapshot {
+    private func fetchOnce(apiKey: String, region: AlibabaRegion, now referenceTime: Date) async throws -> AlibabaResponseParser.Snapshot {
         var request = URLRequest(url: region.apiKeyQuotaURL)
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
@@ -205,7 +228,7 @@ public struct AlibabaQuotaAdapter: QuotaAdapter {
             throw QuotaError.network("Alibaba returned HTTP \(http.statusCode).")
         }
 
-        return try AlibabaResponseParser.parse(data: data, now: now())
+        return try AlibabaResponseParser.parse(data: data, now: referenceTime)
     }
 
     // MARK: Console-cookie path
@@ -266,7 +289,8 @@ public struct AlibabaQuotaAdapter: QuotaAdapter {
     /// `login_aliyunid_csrf` (or `csrf`) cookie value.
     private func fetchConsoleOnce(cookieHeader: String,
                                   secToken: String,
-                                  region: AlibabaRegion) async throws -> AlibabaResponseParser.Snapshot {
+                                  region: AlibabaRegion,
+                                  now referenceTime: Date) async throws -> AlibabaResponseParser.Snapshot {
         let traceID = UUID().uuidString.lowercased()
         var cornerstone: [String: Any] = [
             "feTraceId": traceID,
@@ -345,7 +369,7 @@ public struct AlibabaQuotaAdapter: QuotaAdapter {
             throw QuotaError.network("Alibaba console returned HTTP \(http.statusCode).")
         }
 
-        return try AlibabaResponseParser.parse(data: data, now: now())
+        return try AlibabaResponseParser.parse(data: data, now: referenceTime)
     }
 
     // MARK: Helpers

--- a/Sources/VibeBarCore/Adapters/CursorQuotaAdapter.swift
+++ b/Sources/VibeBarCore/Adapters/CursorQuotaAdapter.swift
@@ -61,10 +61,26 @@ public struct CursorQuotaAdapter: QuotaAdapter {
     }
 
     public func fetch(for account: AccountIdentity) async throws -> AccountQuota {
-        guard let resolution = MiscCookieResolver.resolve(for: CursorQuotaAdapter.cookieSpec) else {
-            throw QuotaError.noCredential
-        }
+        let resolutions = MiscCookieResolver.resolveAll(for: CursorQuotaAdapter.cookieSpec)
+        guard !resolutions.isEmpty else { throw QuotaError.noCredential }
 
+        let queriedAt = now()
+        let results = await MiscQuotaAggregator.gatherSlotResults(resolutions) { resolution in
+            try await self.fetchOneSlot(resolution, account: account, queriedAt: queriedAt)
+        }
+        return MiscQuotaAggregator.aggregate(
+            tool: .cursor,
+            account: account,
+            results: results,
+            queriedAt: queriedAt
+        )
+    }
+
+    private func fetchOneSlot(
+        _ resolution: MiscCookieResolver.Resolution,
+        account: AccountIdentity,
+        queriedAt: Date
+    ) async throws -> AccountQuota {
         let summaryData = try await get(path: "/api/usage-summary", cookieHeader: resolution.header)
         let summary = try CursorResponseParser.decodeUsageSummary(data: summaryData)
 
@@ -84,7 +100,7 @@ public struct CursorQuotaAdapter: QuotaAdapter {
             summary: summary,
             userInfo: userInfo,
             requestUsage: requestUsage,
-            now: now()
+            now: queriedAt
         )
 
         return AccountQuota(
@@ -92,8 +108,8 @@ public struct CursorQuotaAdapter: QuotaAdapter {
             tool: .cursor,
             buckets: snapshot.buckets,
             plan: snapshot.planName,
-            email: userInfo?.email,
-            queriedAt: now(),
+            email: userInfo?.email ?? account.email,
+            queriedAt: queriedAt,
             error: nil
         )
     }
@@ -119,7 +135,6 @@ public struct CursorQuotaAdapter: QuotaAdapter {
         }
         guard http.statusCode == 200 else {
             if http.statusCode == 401 || http.statusCode == 403 {
-                CookieHeaderCache.clear(for: .cursor)
                 throw QuotaError.needsLogin
             }
             if http.statusCode == 429 {

--- a/Sources/VibeBarCore/Adapters/IFlyTekQuotaAdapter.swift
+++ b/Sources/VibeBarCore/Adapters/IFlyTekQuotaAdapter.swift
@@ -59,10 +59,26 @@ public struct IFlyTekQuotaAdapter: QuotaAdapter {
     }
 
     public func fetch(for account: AccountIdentity) async throws -> AccountQuota {
-        guard let resolution = MiscCookieResolver.resolve(for: IFlyTekQuotaAdapter.cookieSpec) else {
-            throw QuotaError.noCredential
-        }
+        let resolutions = MiscCookieResolver.resolveAll(for: IFlyTekQuotaAdapter.cookieSpec)
+        guard !resolutions.isEmpty else { throw QuotaError.noCredential }
 
+        let queriedAt = now()
+        let results = await MiscQuotaAggregator.gatherSlotResults(resolutions) { resolution in
+            try await self.fetchOneSlot(resolution, account: account, queriedAt: queriedAt)
+        }
+        return MiscQuotaAggregator.aggregate(
+            tool: .iflytek,
+            account: account,
+            results: results,
+            queriedAt: queriedAt
+        )
+    }
+
+    private func fetchOneSlot(
+        _ resolution: MiscCookieResolver.Resolution,
+        account: AccountIdentity,
+        queriedAt: Date
+    ) async throws -> AccountQuota {
         var request = URLRequest(url: IFlyTekQuotaAdapter.endpoint)
         request.httpMethod = "GET"
         request.setValue(resolution.header, forHTTPHeaderField: "Cookie")
@@ -88,7 +104,6 @@ public struct IFlyTekQuotaAdapter: QuotaAdapter {
             // iFlytek normally returns 200 even for auth failures (see parser),
             // but a non-200 still happens on infrastructure errors.
             if http.statusCode == 401 || http.statusCode == 403 {
-                CookieHeaderCache.clear(for: .iflytek)
                 throw QuotaError.needsLogin
             }
             if http.statusCode == 429 {
@@ -97,22 +112,14 @@ public struct IFlyTekQuotaAdapter: QuotaAdapter {
             throw QuotaError.network("iFlytek returned HTTP \(http.statusCode).")
         }
 
-        let snapshot: IFlyTekResponseParser.Snapshot
-        do {
-            snapshot = try IFlyTekResponseParser.parse(data: data, now: now())
-        } catch let qe as QuotaError {
-            if case .needsLogin = qe {
-                CookieHeaderCache.clear(for: .iflytek)
-            }
-            throw qe
-        }
+        let snapshot = try IFlyTekResponseParser.parse(data: data, now: queriedAt)
         return AccountQuota(
             accountId: account.id,
             tool: .iflytek,
             buckets: snapshot.buckets,
             plan: snapshot.planName,
             email: account.email,
-            queriedAt: now(),
+            queriedAt: queriedAt,
             error: nil
         )
     }

--- a/Sources/VibeBarCore/Adapters/KimiQuotaAdapter.swift
+++ b/Sources/VibeBarCore/Adapters/KimiQuotaAdapter.swift
@@ -41,10 +41,26 @@ public struct KimiQuotaAdapter: QuotaAdapter {
     }
 
     public func fetch(for account: AccountIdentity) async throws -> AccountQuota {
-        guard let resolution = MiscCookieResolver.resolve(for: KimiQuotaAdapter.cookieSpec) else {
-            throw QuotaError.noCredential
-        }
+        let resolutions = MiscCookieResolver.resolveAll(for: KimiQuotaAdapter.cookieSpec)
+        guard !resolutions.isEmpty else { throw QuotaError.noCredential }
 
+        let queriedAt = now()
+        let results = await MiscQuotaAggregator.gatherSlotResults(resolutions) { resolution in
+            try await self.fetchOneSlot(resolution, account: account, queriedAt: queriedAt)
+        }
+        return MiscQuotaAggregator.aggregate(
+            tool: .kimi,
+            account: account,
+            results: results,
+            queriedAt: queriedAt
+        )
+    }
+
+    private func fetchOneSlot(
+        _ resolution: MiscCookieResolver.Resolution,
+        account: AccountIdentity,
+        queriedAt: Date
+    ) async throws -> AccountQuota {
         // Pull the kimi-auth cookie value out of the resolved header.
         let pairs = CookieHeaderNormalizer.pairs(from: resolution.header)
         guard let authToken = pairs.first(where: { $0.name == "kimi-auth" })?.value,
@@ -91,10 +107,6 @@ public struct KimiQuotaAdapter: QuotaAdapter {
         }
         guard http.statusCode == 200 else {
             if http.statusCode == 401 || http.statusCode == 403 {
-                // Stale cookie: clear cache so the next refresh
-                // re-imports rather than retrying with the same
-                // bad token.
-                CookieHeaderCache.clear(for: .kimi)
                 throw QuotaError.needsLogin
             }
             if http.statusCode == 429 {
@@ -103,14 +115,14 @@ public struct KimiQuotaAdapter: QuotaAdapter {
             throw QuotaError.network("Kimi returned HTTP \(http.statusCode).")
         }
 
-        let snapshot = try KimiResponseParser.parse(data: data, now: now())
+        let snapshot = try KimiResponseParser.parse(data: data, now: queriedAt)
         return AccountQuota(
             accountId: account.id,
             tool: .kimi,
             buckets: snapshot.buckets,
             plan: nil,
             email: account.email,
-            queriedAt: now(),
+            queriedAt: queriedAt,
             error: nil
         )
     }

--- a/Sources/VibeBarCore/Adapters/MimoQuotaAdapter.swift
+++ b/Sources/VibeBarCore/Adapters/MimoQuotaAdapter.swift
@@ -54,10 +54,26 @@ public struct MimoQuotaAdapter: QuotaAdapter {
     }
 
     public func fetch(for account: AccountIdentity) async throws -> AccountQuota {
-        guard let resolution = MiscCookieResolver.resolve(for: MimoQuotaAdapter.cookieSpec) else {
-            throw QuotaError.noCredential
-        }
+        let resolutions = MiscCookieResolver.resolveAll(for: MimoQuotaAdapter.cookieSpec)
+        guard !resolutions.isEmpty else { throw QuotaError.noCredential }
 
+        let queriedAt = now()
+        let results = await MiscQuotaAggregator.gatherSlotResults(resolutions) { resolution in
+            try await self.fetchOneSlot(resolution, account: account, queriedAt: queriedAt)
+        }
+        return MiscQuotaAggregator.aggregate(
+            tool: .mimo,
+            account: account,
+            results: results,
+            queriedAt: queriedAt
+        )
+    }
+
+    private func fetchOneSlot(
+        _ resolution: MiscCookieResolver.Resolution,
+        account: AccountIdentity,
+        queriedAt: Date
+    ) async throws -> AccountQuota {
         var request = URLRequest(url: MimoQuotaAdapter.endpoint)
         request.httpMethod = "GET"
         request.setValue(resolution.header, forHTTPHeaderField: "Cookie")
@@ -80,11 +96,7 @@ public struct MimoQuotaAdapter: QuotaAdapter {
             throw QuotaError.network("MiMo: invalid response object")
         }
         guard http.statusCode == 200 else {
-            // Removing any one of the three required cookies returns HTTP 401
-            // with body `{"code":401,...}`. Drop the cached header so the next
-            // refresh re-imports rather than retrying with the stale cookies.
             if http.statusCode == 401 || http.statusCode == 403 {
-                CookieHeaderCache.clear(for: .mimo)
                 throw QuotaError.needsLogin
             }
             if http.statusCode == 429 {
@@ -93,14 +105,14 @@ public struct MimoQuotaAdapter: QuotaAdapter {
             throw QuotaError.network("MiMo returned HTTP \(http.statusCode).")
         }
 
-        let snapshot = try MimoResponseParser.parse(data: data, now: now())
+        let snapshot = try MimoResponseParser.parse(data: data, now: queriedAt)
         return AccountQuota(
             accountId: account.id,
             tool: .mimo,
             buckets: snapshot.buckets,
             plan: snapshot.planName,
             email: account.email,
-            queriedAt: now(),
+            queriedAt: queriedAt,
             error: nil
         )
     }

--- a/Sources/VibeBarCore/Adapters/OllamaQuotaAdapter.swift
+++ b/Sources/VibeBarCore/Adapters/OllamaQuotaAdapter.swift
@@ -26,11 +26,27 @@ public struct OllamaQuotaAdapter: QuotaAdapter {
     }
 
     public func fetch(for account: AccountIdentity) async throws -> AccountQuota {
-        guard let resolution = MiscCookieResolver.resolve(for: Self.cookieSpec),
-              Self.hasRecognizedSessionCookie(resolution.header) else {
-            throw QuotaError.noCredential
-        }
+        let resolutions = MiscCookieResolver.resolveAll(for: Self.cookieSpec)
+            .filter { Self.hasRecognizedSessionCookie($0.header) }
+        guard !resolutions.isEmpty else { throw QuotaError.noCredential }
 
+        let queriedAt = now()
+        let results = await MiscQuotaAggregator.gatherSlotResults(resolutions) { resolution in
+            try await self.fetchOneSlot(resolution, account: account, queriedAt: queriedAt)
+        }
+        return MiscQuotaAggregator.aggregate(
+            tool: .ollama,
+            account: account,
+            results: results,
+            queriedAt: queriedAt
+        )
+    }
+
+    private func fetchOneSlot(
+        _ resolution: MiscCookieResolver.Resolution,
+        account: AccountIdentity,
+        queriedAt: Date
+    ) async throws -> AccountQuota {
         var request = URLRequest(url: URL(string: "https://ollama.com/settings")!)
         request.httpMethod = "GET"
         request.timeoutInterval = 15
@@ -53,7 +69,6 @@ public struct OllamaQuotaAdapter: QuotaAdapter {
         let text = String(data: data, encoding: .utf8) ?? ""
         guard http.statusCode == 200 else {
             if http.statusCode == 401 || http.statusCode == 403 {
-                CookieHeaderCache.clear(for: .ollama)
                 throw QuotaError.needsLogin
             }
             if http.statusCode == 429 {
@@ -62,18 +77,17 @@ public struct OllamaQuotaAdapter: QuotaAdapter {
             throw QuotaError.network("Ollama returned HTTP \(http.statusCode).")
         }
         if OllamaResponseParser.looksSignedOut(text) {
-            CookieHeaderCache.clear(for: .ollama)
             throw QuotaError.needsLogin
         }
 
-        let snapshot = try OllamaResponseParser.parse(html: text, now: now())
+        let snapshot = try OllamaResponseParser.parse(html: text, now: queriedAt)
         return AccountQuota(
             accountId: account.id,
             tool: .ollama,
             buckets: snapshot.buckets,
             plan: snapshot.planName,
             email: snapshot.email ?? account.email,
-            queriedAt: now(),
+            queriedAt: queriedAt,
             error: nil
         )
     }

--- a/Sources/VibeBarCore/Adapters/OpenCodeGoQuotaAdapter.swift
+++ b/Sources/VibeBarCore/Adapters/OpenCodeGoQuotaAdapter.swift
@@ -31,9 +31,26 @@ public struct OpenCodeGoQuotaAdapter: QuotaAdapter {
     }
 
     public func fetch(for account: AccountIdentity) async throws -> AccountQuota {
-        guard let resolution = MiscCookieResolver.resolve(for: Self.cookieSpec) else {
-            throw QuotaError.noCredential
+        let resolutions = MiscCookieResolver.resolveAll(for: Self.cookieSpec)
+        guard !resolutions.isEmpty else { throw QuotaError.noCredential }
+
+        let queriedAt = now()
+        let results = await MiscQuotaAggregator.gatherSlotResults(resolutions) { resolution in
+            try await self.fetchOneSlot(resolution, account: account, queriedAt: queriedAt)
         }
+        return MiscQuotaAggregator.aggregate(
+            tool: .openCodeGo,
+            account: account,
+            results: results,
+            queriedAt: queriedAt
+        )
+    }
+
+    private func fetchOneSlot(
+        _ resolution: MiscCookieResolver.Resolution,
+        account: AccountIdentity,
+        queriedAt: Date
+    ) async throws -> AccountQuota {
         let settings = MiscProviderSettings.current(for: .openCodeGo)
         let workspaceID = try await resolveWorkspaceID(
             cookieHeader: resolution.header,
@@ -44,17 +61,16 @@ public struct OpenCodeGoQuotaAdapter: QuotaAdapter {
             cookieHeader: resolution.header
         )
         if OpenCodeGoResponseParser.looksSignedOut(text) {
-            CookieHeaderCache.clear(for: .openCodeGo)
             throw QuotaError.needsLogin
         }
-        let snapshot = try OpenCodeGoResponseParser.parse(text: text, now: now())
+        let snapshot = try OpenCodeGoResponseParser.parse(text: text, now: queriedAt)
         return AccountQuota(
             accountId: account.id,
             tool: .openCodeGo,
             buckets: snapshot.buckets,
             plan: nil,
             email: account.email,
-            queriedAt: now(),
+            queriedAt: queriedAt,
             error: nil
         )
     }
@@ -70,7 +86,6 @@ public struct OpenCodeGoQuotaAdapter: QuotaAdapter {
             args: nil
         )
         if OpenCodeGoResponseParser.looksSignedOut(getText) {
-            CookieHeaderCache.clear(for: .openCodeGo)
             throw QuotaError.needsLogin
         }
         if let id = OpenCodeGoResponseParser.workspaceIDs(from: getText).first {
@@ -83,7 +98,6 @@ public struct OpenCodeGoQuotaAdapter: QuotaAdapter {
             args: "[]"
         )
         if OpenCodeGoResponseParser.looksSignedOut(postText) {
-            CookieHeaderCache.clear(for: .openCodeGo)
             throw QuotaError.needsLogin
         }
         if let id = OpenCodeGoResponseParser.workspaceIDs(from: postText).first {
@@ -144,7 +158,6 @@ public struct OpenCodeGoQuotaAdapter: QuotaAdapter {
         let text = String(data: data, encoding: .utf8) ?? ""
         guard http.statusCode == 200 else {
             if http.statusCode == 401 || http.statusCode == 403 || OpenCodeGoResponseParser.looksSignedOut(text) {
-                CookieHeaderCache.clear(for: .openCodeGo)
                 throw QuotaError.needsLogin
             }
             if http.statusCode == 429 {

--- a/Sources/VibeBarCore/Adapters/TencentHunyuanQuotaAdapter.swift
+++ b/Sources/VibeBarCore/Adapters/TencentHunyuanQuotaAdapter.swift
@@ -52,33 +52,48 @@ public struct TencentHunyuanQuotaAdapter: QuotaAdapter {
     }
 
     public func fetch(for account: AccountIdentity) async throws -> AccountQuota {
-        let snapshot = try await fetchSnapshot()
+        let resolutions = MiscCookieResolver.resolveAll(for: TencentHunyuanQuotaAdapter.cookieSpec)
+        guard !resolutions.isEmpty else { throw QuotaError.noCredential }
+
+        let queriedAt = now()
+        let results = await MiscQuotaAggregator.gatherSlotResults(resolutions) { resolution in
+            try await self.fetchOneSlot(resolution, account: account, queriedAt: queriedAt)
+        }
+        return MiscQuotaAggregator.aggregate(
+            tool: .tencentHunyuan,
+            account: account,
+            results: results,
+            queriedAt: queriedAt
+        )
+    }
+
+    private func fetchOneSlot(
+        _ resolution: MiscCookieResolver.Resolution,
+        account: AccountIdentity,
+        queriedAt: Date
+    ) async throws -> AccountQuota {
+        let snapshot = try await fetchSnapshot(using: resolution)
         return AccountQuota(
             accountId: account.id,
             tool: .tencentHunyuan,
             buckets: snapshot.buckets,
             plan: snapshot.planName,
             email: account.email,
-            queriedAt: now(),
+            queriedAt: queriedAt,
             error: nil
         )
     }
 
-    private func fetchSnapshot() async throws -> TencentHunyuanResponseParser.Snapshot {
-        guard let resolution = MiscCookieResolver.resolve(for: TencentHunyuanQuotaAdapter.cookieSpec) else {
-            throw QuotaError.noCredential
-        }
+    private func fetchSnapshot(using resolution: MiscCookieResolver.Resolution) async throws -> TencentHunyuanResponseParser.Snapshot {
         let pairs = CookieHeaderNormalizer.pairs(from: resolution.header)
         guard let skey = pairs.first(where: { $0.name == "skey" })?.value, !skey.isEmpty else {
             // No `skey` means the user signed in to Tencent at the
             // domain level (`tencent.com`) but never opened the Cloud
             // console — that's the cookie that proves a console
             // session. Tell them to retry.
-            CookieHeaderCache.clear(for: .tencentHunyuan)
             throw QuotaError.needsLogin
         }
         guard let rawUin = pairs.first(where: { $0.name == "uin" })?.value, !rawUin.isEmpty else {
-            CookieHeaderCache.clear(for: .tencentHunyuan)
             throw QuotaError.needsLogin
         }
         // Tencent's `uin` cookie value comes prefixed with `o`
@@ -87,7 +102,6 @@ public struct TencentHunyuanQuotaAdapter: QuotaAdapter {
         // the BFF response from `Code 21 登录态冲突` to a normal 200.
         let uin = String(rawUin.drop(while: { !$0.isNumber }))
         guard !uin.isEmpty else {
-            CookieHeaderCache.clear(for: .tencentHunyuan)
             throw QuotaError.needsLogin
         }
 
@@ -130,7 +144,6 @@ public struct TencentHunyuanQuotaAdapter: QuotaAdapter {
         }
         guard http.statusCode == 200 else {
             if http.statusCode == 401 || http.statusCode == 403 {
-                CookieHeaderCache.clear(for: .tencentHunyuan)
                 throw QuotaError.needsLogin
             }
             if http.statusCode == 429 {

--- a/Sources/VibeBarCore/Adapters/VolcengineQuotaAdapter.swift
+++ b/Sources/VibeBarCore/Adapters/VolcengineQuotaAdapter.swift
@@ -56,29 +56,45 @@ public struct VolcengineQuotaAdapter: QuotaAdapter {
     }
 
     public func fetch(for account: AccountIdentity) async throws -> AccountQuota {
-        let snapshot = try await fetchSnapshot()
+        let resolutions = MiscCookieResolver.resolveAll(for: VolcengineQuotaAdapter.cookieSpec)
+        guard !resolutions.isEmpty else { throw QuotaError.noCredential }
+
+        let queriedAt = now()
+        let results = await MiscQuotaAggregator.gatherSlotResults(resolutions) { resolution in
+            try await self.fetchOneSlot(resolution, account: account, queriedAt: queriedAt)
+        }
+        return MiscQuotaAggregator.aggregate(
+            tool: .volcengine,
+            account: account,
+            results: results,
+            queriedAt: queriedAt
+        )
+    }
+
+    private func fetchOneSlot(
+        _ resolution: MiscCookieResolver.Resolution,
+        account: AccountIdentity,
+        queriedAt: Date
+    ) async throws -> AccountQuota {
+        let snapshot = try await fetchSnapshot(using: resolution)
         return AccountQuota(
             accountId: account.id,
             tool: .volcengine,
             buckets: snapshot.buckets,
             plan: snapshot.planName,
             email: account.email,
-            queriedAt: now(),
+            queriedAt: queriedAt,
             error: nil
         )
     }
 
-    private func fetchSnapshot() async throws -> VolcengineQuotaSnapshot {
-        guard let resolution = MiscCookieResolver.resolve(for: VolcengineQuotaAdapter.cookieSpec) else {
-            throw QuotaError.noCredential
-        }
+    private func fetchSnapshot(using resolution: MiscCookieResolver.Resolution) async throws -> VolcengineQuotaSnapshot {
         let pairs = CookieHeaderNormalizer.pairs(from: resolution.header)
         guard let csrfToken = pairs.first(where: { $0.name == "csrfToken" })?.value, !csrfToken.isEmpty else {
             // No `csrfToken` means the user signed in to volcengine.com
             // at the public-website level but never opened the console
             // — the cookie is set by the first console request after
             // login.
-            CookieHeaderCache.clear(for: .volcengine)
             throw QuotaError.needsLogin
         }
 
@@ -142,7 +158,6 @@ public struct VolcengineQuotaAdapter: QuotaAdapter {
         }
         guard http.statusCode == 200 else {
             if http.statusCode == 401 || http.statusCode == 403 {
-                CookieHeaderCache.clear(for: .volcengine)
                 throw QuotaError.needsLogin
             }
             if http.statusCode == 429 {

--- a/Sources/VibeBarCore/BrowserCookies/MiscCookieResolver.swift
+++ b/Sources/VibeBarCore/BrowserCookies/MiscCookieResolver.swift
@@ -1,25 +1,19 @@
 import Foundation
 import SweetCookieKit
 
-/// Picks a `Cookie:` header for a misc-provider adapter at fetch time.
+/// Picks `Cookie:` headers for a misc-provider adapter at fetch time.
 ///
-/// Resolution order (skipped per `MiscProviderSettings.cookieSource`):
+/// Vibe Bar lets the user stack multiple cookie sessions per provider
+/// (work + personal + trial accounts) and aggregates their quotas. The
+/// resolver returns every slot the user has imported for `spec.tool`,
+/// filtered by the current `MiscProviderSettings` source mode and the
+/// spec's required-credential gate. Adapters fan out a quota query per
+/// slot and average the buckets via `MiscQuotaAggregator`.
 ///
-/// 1. **Cached** — Keychain entry from a prior successful import.
-///    Returned immediately if present.
-/// 2. **Browser auto-import** (when source mode permits browser cookies) —
-///    SweetCookieKit reads cookies for the provider's domains from
-///    every browser in the configured order. Records from the same
-///    browser profile are merged across cookie stores before the
-///    auth-cookie set is minimized and cached, matching Codex Bar's
-///    Kimi/MiniMax/Cursor importers.
-/// 3. **Manual paste** (when source mode permits manual cookies) —
-///    the value the user pasted in Settings, normalised through
-///    `CookieHeaderNormalizer`.
-///
-/// Adapters call `resolve(for:)` and translate "no header" into a
-/// `QuotaError.noCredential` that surfaces a "Sign in" CTA on the
-/// misc card.
+/// Slots live in `MiscCookieSlotStore` (Keychain). The resolver no
+/// longer keeps a separate `CookieHeaderCache` layer — slots *are* the
+/// cache. The legacy single-cookie state is migrated into slots on
+/// first read; see `LegacyCookieMigration`.
 public enum MiscCookieResolver {
     /// Per-provider description of which cookies matter and where
     /// to look for them. Adapters declare this as a constant.
@@ -75,63 +69,92 @@ public enum MiscCookieResolver {
     }
 
     public struct Resolution {
+        public let slotID: UUID?
         public let header: String
         public let sourceLabel: String
+
+        public init(slotID: UUID?, header: String, sourceLabel: String) {
+            self.slotID = slotID
+            self.header = header
+            self.sourceLabel = sourceLabel
+        }
     }
 
-    /// Resolve a cookie header for `spec.tool`. Returns `nil` if the
-    /// configured sources all came up empty — adapters surface
-    /// `noCredential` in that case.
-    public static func resolve(for spec: Spec) -> Resolution? {
-        let settings = currentSettings(for: spec.tool)
-        guard let plan = CookieSourcePlan(settings: settings) else {
-            return nil
-        }
+    /// Slot filter derived from the user's source-mode settings.
+    enum SlotFilter: Equatable {
+        case all
+        case browserOnly
+        case manualOnly
+        case none
 
-        // 1. Cached header from a prior import or manual paste.
-        let cached = CookieHeaderCache.load(for: spec.tool)
-        if let cached, plan.acceptsCached(cached) {
-            if spec.hasRequiredCredential(in: cached.cookieHeader) {
-                return Resolution(header: cached.cookieHeader, sourceLabel: cached.sourceLabel)
+        init(settings: MiscProviderSettings) {
+            switch settings.sourceMode {
+            case .off, .apiOnly:
+                self = .none
+            case .browserOnly:
+                self = .browserOnly
+            case .manualOnly:
+                self = .manualOnly
+            case .auto:
+                switch settings.cookieSource {
+                case .off:
+                    self = .none
+                case .manual:
+                    self = .manualOnly
+                case .auto:
+                    self = .all
+                }
             }
-            CookieHeaderCache.clear(for: spec.tool)
         }
 
-        // 2. Browser auto-import (skipped in `.manual` mode).
-        if plan.allowsBrowser,
-           let imported = importFromBrowsers(spec: spec, settings: settings) {
-            CookieHeaderCache.store(
-                for: spec.tool,
-                cookieHeader: imported.header,
-                sourceLabel: imported.sourceLabel
-            )
-            return imported
+        func allows(_ slot: MiscCookieSlot) -> Bool {
+            switch self {
+            case .all:
+                return true
+            case .browserOnly:
+                return slot.origin != .manual
+            case .manualOnly:
+                return slot.origin == .manual
+            case .none:
+                return false
+            }
         }
-
-        // 3. Manual paste fallback.
-        if plan.allowsManual,
-           let manual = MiscCredentialStore.readString(tool: spec.tool, kind: .manualCookieHeader),
-           let normalised = spec.minimizedHeader(from: manual),
-           !normalised.isEmpty {
-            CookieHeaderCache.store(
-                for: spec.tool,
-                cookieHeader: normalised,
-                sourceLabel: "Manual paste"
-            )
-            return Resolution(header: normalised, sourceLabel: "Manual paste")
-        }
-        return nil
     }
 
-    /// Force a fresh browser import, ignoring the cache. Settings UI
-    /// uses this for the "Import now" button so the user can recover
-    /// without waiting for a stale cache to expire.
-    public static func forceBrowserImport(for spec: Spec) -> Resolution? {
-        CookieHeaderCache.clear(for: spec.tool)
+    /// Resolve every cookie slot that's eligible for `spec.tool`.
+    /// Returns slots in insertion order. Empty when the user has no
+    /// slots, or when the source mode bans cookies entirely
+    /// (`apiOnly` / `off`).
+    public static func resolveAll(for spec: Spec) -> [Resolution] {
         let settings = currentSettings(for: spec.tool)
-        guard CookieSourcePlan(settings: settings)?.allowsBrowser == true else {
-            return nil
+        let filter = SlotFilter(settings: settings)
+        guard filter != .none else { return [] }
+
+        return MiscCookieSlotStore.slots(for: spec.tool).compactMap { slot in
+            guard filter.allows(slot) else { return nil }
+            guard let header = spec.minimizedHeader(from: slot.cookieHeader),
+                  !header.isEmpty else { return nil }
+            return Resolution(
+                slotID: slot.id,
+                header: header,
+                sourceLabel: slot.sourceLabel
+            )
         }
+    }
+
+    /// Resolve the first eligible slot. Kept for callers that haven't
+    /// migrated to `resolveAll` yet.
+    public static func resolve(for spec: Spec) -> Resolution? {
+        resolveAll(for: spec).first
+    }
+
+    /// Run the SweetCookieKit browser-import dance and append the
+    /// captured header as a new slot. Returns the appended slot's
+    /// Resolution on success, or `nil` if no browser session was
+    /// found (or the source mode bans cookies).
+    public static func appendBrowserImport(for spec: Spec) -> Resolution? {
+        let settings = currentSettings(for: spec.tool)
+        guard SlotFilter(settings: settings) != .none else { return nil }
         guard let imported = importFromBrowsers(
             spec: spec,
             settings: settings,
@@ -139,21 +162,39 @@ public enum MiscCookieResolver {
         ) else {
             return nil
         }
-        CookieHeaderCache.store(
-            for: spec.tool,
+        let slot = MiscCookieSlot(
             cookieHeader: imported.header,
+            sourceLabel: imported.sourceLabel,
+            importedAt: Date(),
+            origin: .browserImport
+        )
+        guard MiscCookieSlotStore.append(slot, for: spec.tool) else { return nil }
+        return Resolution(
+            slotID: slot.id,
+            header: imported.header,
             sourceLabel: imported.sourceLabel
         )
-        return imported
+    }
+
+    /// Legacy alias for callers that haven't migrated to
+    /// `appendBrowserImport`. Slot semantics are identical — every
+    /// invocation appends a new slot rather than replacing one.
+    public static func forceBrowserImport(for spec: Spec) -> Resolution? {
+        appendBrowserImport(for: spec)
     }
 
     // MARK: - Internals
+
+    private struct BrowserImportResult {
+        let header: String
+        let sourceLabel: String
+    }
 
     private static func importFromBrowsers(
         spec: Spec,
         settings: MiscProviderSettings,
         allowKeychainPrompt: Bool = false
-    ) -> Resolution? {
+    ) -> BrowserImportResult? {
         let detection = BrowserDetection()
         let preferred: [Browser]
         if let kind = settings.preferredBrowser {
@@ -193,7 +234,7 @@ public enum MiscCookieResolver {
                 guard spec.requiredNames.isEmpty || !pairs.isEmpty else { continue }
                 let header = pairs.joined(separator: "; ")
                 guard !header.isEmpty, spec.hasRequiredCredential(in: header) else { continue }
-                return Resolution(header: header, sourceLabel: session.label)
+                return BrowserImportResult(header: header, sourceLabel: session.label)
             }
         }
         return nil
@@ -202,62 +243,6 @@ public enum MiscCookieResolver {
     private struct BrowserSession {
         let label: String
         let records: [BrowserCookieRecord]
-    }
-
-    private struct CookieSourcePlan {
-        let allowsBrowser: Bool
-        let allowsManual: Bool
-        let cachePolicy: CachePolicy
-
-        enum CachePolicy {
-            case any
-            case browserOnly
-            case manualOnly
-        }
-
-        init?(settings: MiscProviderSettings) {
-            switch settings.sourceMode {
-            case .off, .apiOnly:
-                return nil
-            case .browserOnly:
-                self.allowsBrowser = true
-                self.allowsManual = false
-                self.cachePolicy = .browserOnly
-                return
-            case .manualOnly:
-                self.allowsBrowser = false
-                self.allowsManual = true
-                self.cachePolicy = .manualOnly
-                return
-            case .auto:
-                switch settings.cookieSource {
-                case .off:
-                    return nil
-                case .manual:
-                    self.allowsBrowser = false
-                    self.allowsManual = true
-                    self.cachePolicy = .manualOnly
-                    return
-                case .auto:
-                    self.allowsBrowser = true
-                    self.allowsManual = true
-                    self.cachePolicy = .any
-                    return
-                }
-            }
-        }
-
-        func acceptsCached(_ entry: CookieHeaderCache.Entry) -> Bool {
-            let isManual = entry.sourceLabel == "Manual paste"
-            switch cachePolicy {
-            case .any:
-                return true
-            case .browserOnly:
-                return !isManual
-            case .manualOnly:
-                return isManual
-            }
-        }
     }
 
     private static func mergedSessions(from sources: [BrowserCookieStoreRecords]) -> [BrowserSession] {

--- a/Sources/VibeBarCore/Credentials/MiscCookieSlotStore.swift
+++ b/Sources/VibeBarCore/Credentials/MiscCookieSlotStore.swift
@@ -1,0 +1,301 @@
+import Foundation
+
+/// A single cookie session a user has imported for a misc provider.
+///
+/// Each slot stands on its own — adapters fan out a quota query per
+/// slot and average the results, so users can stack multiple accounts
+/// (work + personal + trial) under one provider card. Slots are stored
+/// as a JSON array in Keychain alongside the rest of the misc-provider
+/// secrets.
+public struct MiscCookieSlot: Codable, Equatable, Sendable, Identifiable {
+    public enum Origin: String, Codable, Sendable, Equatable {
+        /// Pasted by the user via the Settings cookie field.
+        case manual
+        /// Snapshotted from a browser's cookie store (SweetCookieKit) or
+        /// captured by the in-app `MiscWebLoginController` web view.
+        case browserImport
+        /// Replaced in place by `HiddenCookieRefresher` after a silent
+        /// console keepalive load.
+        case autoRefresh
+    }
+
+    public let id: UUID
+    public var cookieHeader: String
+    public var sourceLabel: String
+    public var importedAt: Date
+    public var origin: Origin
+
+    public init(
+        id: UUID = UUID(),
+        cookieHeader: String,
+        sourceLabel: String,
+        importedAt: Date = Date(),
+        origin: Origin
+    ) {
+        self.id = id
+        self.cookieHeader = cookieHeader
+        self.sourceLabel = sourceLabel
+        self.importedAt = importedAt
+        self.origin = origin
+    }
+}
+
+/// Keychain-backed list-of-cookies storage for misc providers.
+///
+/// Each tool maps to one Keychain entry: service
+/// `com.astroqore.VibeBar.misc-secrets`, account
+/// `<tool.rawValue>.cookieSlots`. The value is a JSON-encoded
+/// `[MiscCookieSlot]`.
+///
+/// The store is mutable — append, update, delete — but each
+/// mutation rewrites the whole list. List sizes are tiny (< 10
+/// realistic upper bound), so the simplicity wins over per-slot
+/// keychain entries.
+///
+/// Legacy single-cookie state (`MiscCredentialStore.manualCookieHeader`
+/// and the old per-tool `CookieHeaderCache` entry) is migrated lazily
+/// into slots on the first read, then the legacy locations are
+/// cleared.
+public enum MiscCookieSlotStore {
+    public static let keychainService = MiscCredentialStore.keychainService
+
+    public static let slotsAccountSuffix = "cookieSlots"
+
+    public static func keychainAccount(for tool: ToolType) -> String {
+        precondition(tool.isMisc, "MiscCookieSlotStore is misc-only; got \(tool)")
+        return "\(tool.rawValue).\(slotsAccountSuffix)"
+    }
+
+    /// Read the slot list for `tool`, migrating legacy single-cookie
+    /// state on first read. Returns an empty array if no cookies are
+    /// configured.
+    public static func slots(for tool: ToolType) -> [MiscCookieSlot] {
+        guard tool.isMisc else { return [] }
+        if let stored = readRaw(for: tool) {
+            return stored
+        }
+        let migrated = LegacyCookieMigration.collectSlots(for: tool)
+        if !migrated.isEmpty {
+            _ = writeRaw(migrated, for: tool)
+            LegacyCookieMigration.clearLegacy(for: tool)
+        }
+        return migrated
+    }
+
+    @discardableResult
+    public static func append(_ slot: MiscCookieSlot, for tool: ToolType) -> Bool {
+        guard tool.isMisc else { return false }
+        var list = slots(for: tool)
+        if let existing = list.firstIndex(where: { $0.cookieHeader == slot.cookieHeader }) {
+            // Refresh the timestamp/source so the user can see they're
+            // pasting the same cookie they had before.
+            list[existing].importedAt = slot.importedAt
+            list[existing].sourceLabel = slot.sourceLabel
+            list[existing].origin = slot.origin
+        } else {
+            list.append(slot)
+        }
+        return writeRaw(list, for: tool)
+    }
+
+    @discardableResult
+    public static func updateHeader(
+        slotID: UUID,
+        for tool: ToolType,
+        header: String,
+        sourceLabel: String? = nil,
+        importedAt: Date? = nil,
+        origin: MiscCookieSlot.Origin? = nil
+    ) -> Bool {
+        guard tool.isMisc else { return false }
+        var list = slots(for: tool)
+        guard let idx = list.firstIndex(where: { $0.id == slotID }) else { return false }
+        let trimmed = header.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return false }
+        list[idx].cookieHeader = trimmed
+        if let sourceLabel { list[idx].sourceLabel = sourceLabel }
+        if let importedAt { list[idx].importedAt = importedAt }
+        if let origin { list[idx].origin = origin }
+        return writeRaw(list, for: tool)
+    }
+
+    @discardableResult
+    public static func delete(slotID: UUID, for tool: ToolType) -> Bool {
+        guard tool.isMisc else { return false }
+        var list = slots(for: tool)
+        let before = list.count
+        list.removeAll { $0.id == slotID }
+        guard list.count != before else { return false }
+        if list.isEmpty {
+            return deleteRaw(for: tool)
+        }
+        return writeRaw(list, for: tool)
+    }
+
+    @discardableResult
+    public static func deleteAll(for tool: ToolType) -> Bool {
+        guard tool.isMisc else { return false }
+        return deleteRaw(for: tool)
+    }
+
+    public static func hasAnySlot(for tool: ToolType) -> Bool {
+        !slots(for: tool).isEmpty
+    }
+
+    // MARK: - Notifications
+
+    /// Posted on every mutation (append / update / delete). The
+    /// `userInfo["tool"]` carries the affected `ToolType.rawValue`.
+    /// Settings UI subscribes to this so the slot list redraws when
+    /// `HiddenCookieRefresher` updates a slot in the background.
+    public static let didChangeNotification = Notification.Name(
+        "com.astroqore.VibeBar.miscCookieSlotsChanged"
+    )
+
+    private static func postChangeNotification(for tool: ToolType) {
+        NotificationCenter.default.post(
+            name: didChangeNotification,
+            object: nil,
+            userInfo: ["tool": tool.rawValue]
+        )
+    }
+
+    // MARK: - Keychain plumbing
+
+    private static func readRaw(for tool: ToolType) -> [MiscCookieSlot]? {
+        let account = keychainAccount(for: tool)
+        do {
+            let data = try KeychainStore.readData(
+                service: keychainService,
+                account: account,
+                useDataProtectionKeychain: true
+            )
+            return try Self.decoder().decode([MiscCookieSlot].self, from: data)
+        } catch KeychainStore.KeychainError.itemNotFound {
+            return nil
+        } catch KeychainStore.KeychainError.interactionNotAllowed {
+            SafeLog.info("MiscCookieSlotStore temporarily unavailable for \(tool.rawValue)")
+            return nil
+        } catch {
+            SafeLog.warn("MiscCookieSlotStore read failed for \(tool.rawValue): \(error)")
+            return nil
+        }
+    }
+
+    @discardableResult
+    private static func writeRaw(_ slots: [MiscCookieSlot], for tool: ToolType) -> Bool {
+        let account = keychainAccount(for: tool)
+        guard !slots.isEmpty else {
+            return deleteRaw(for: tool)
+        }
+        do {
+            let data = try Self.encoder().encode(slots)
+            try KeychainStore.writeData(
+                service: keychainService,
+                account: account,
+                data: data,
+                useDataProtectionKeychain: true
+            )
+            postChangeNotification(for: tool)
+            return true
+        } catch {
+            SafeLog.error("MiscCookieSlotStore write failed for \(tool.rawValue): \(error)")
+            return false
+        }
+    }
+
+    @discardableResult
+    private static func deleteRaw(for tool: ToolType) -> Bool {
+        let account = keychainAccount(for: tool)
+        do {
+            try KeychainStore.deleteItem(
+                service: keychainService,
+                account: account,
+                useDataProtectionKeychain: true
+            )
+            postChangeNotification(for: tool)
+            return true
+        } catch KeychainStore.KeychainError.itemNotFound {
+            return false
+        } catch {
+            SafeLog.warn("MiscCookieSlotStore delete failed for \(tool.rawValue): \(error)")
+            return false
+        }
+    }
+
+    private static func encoder() -> JSONEncoder {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.sortedKeys]
+        return encoder
+    }
+
+    private static func decoder() -> JSONDecoder {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return decoder
+    }
+}
+
+/// Migrates legacy single-cookie storage into the new slot list on
+/// first read.
+///
+/// Two legacy sources exist:
+///
+/// 1. `MiscCredentialStore.Kind.manualCookieHeader` — the cookie the
+///    user pasted in Settings.
+/// 2. `CookieHeaderCache` — the cached resolved header from the last
+///    successful import (browser auto-import, web login, or
+///    `HiddenCookieRefresher`).
+///
+/// They are not mutually exclusive — a user who pasted once and then
+/// also signed in via the web view will have both. The two carry
+/// distinct semantics so we surface both as separate slots and let
+/// the user pick which to keep.
+enum LegacyCookieMigration {
+    /// Collect slots from legacy storage without mutating it. Returns
+    /// an empty list when nothing legacy is present. Call
+    /// `clearLegacy` after the new list is durably stored.
+    static func collectSlots(for tool: ToolType) -> [MiscCookieSlot] {
+        guard tool.isMisc else { return [] }
+        var collected: [MiscCookieSlot] = []
+        var seenHeaders: Set<String> = []
+
+        if let manual = MiscCredentialStore.readString(tool: tool, kind: .manualCookieHeader),
+           !manual.isEmpty {
+            collected.append(
+                MiscCookieSlot(
+                    cookieHeader: manual,
+                    sourceLabel: "Manual paste",
+                    importedAt: Date(),
+                    origin: .manual
+                )
+            )
+            seenHeaders.insert(manual)
+        }
+
+        if let cached = CookieHeaderCache.load(for: tool), !cached.cookieHeader.isEmpty {
+            let header = cached.cookieHeader
+            if !seenHeaders.contains(header) {
+                let isAutoRefresh = cached.sourceLabel.lowercased().contains("refresh")
+                collected.append(
+                    MiscCookieSlot(
+                        cookieHeader: header,
+                        sourceLabel: cached.sourceLabel,
+                        importedAt: cached.storedAt,
+                        origin: isAutoRefresh ? .autoRefresh : .browserImport
+                    )
+                )
+                seenHeaders.insert(header)
+            }
+        }
+
+        return collected
+    }
+
+    static func clearLegacy(for tool: ToolType) {
+        guard tool.isMisc else { return }
+        MiscCredentialStore.delete(tool: tool, kind: .manualCookieHeader)
+        CookieHeaderCache.clear(for: tool)
+    }
+}

--- a/Sources/VibeBarCore/Credentials/VibeBarKeychainAccessAuthorizer.swift
+++ b/Sources/VibeBarCore/Credentials/VibeBarKeychainAccessAuthorizer.swift
@@ -65,16 +65,18 @@ public enum VibeBarKeychainAccessAuthorizer {
     private static let legacyClaudeCookieAccount = "claude.ai"
     private static let legacyClaudeOrganizationAccount = "claude.ai.organization"
     private static let claudeOrganizationAccount = "claude.organization-id"
-    private static let currentCookieBackedMiscTools: [ToolType] = [.kimi, .cursor, .openCodeGo, .ollama]
+    /// Misc providers that stack their cookie sessions through
+    /// `MiscCookieSlotStore`. The list mirrors every cookie-only adapter
+    /// plus Alibaba (cookie path is one of two auth modes).
+    private static let currentCookieBackedMiscTools: [ToolType] = [
+        .alibaba, .kimi, .cursor, .mimo, .iflytek,
+        .tencentHunyuan, .volcengine, .openCodeGo, .ollama
+    ]
     private static let currentSecretKindsByTool: [ToolType: [MiscCredentialStore.Kind]] = [
         .alibaba: [.apiKey],
         .copilot: [.apiKey, .oauthAccessToken, .oauthRefreshToken, .oauthExpiry],
-        .cursor: [.manualCookieHeader],
-        .kimi: [.manualCookieHeader],
         .kilo: [.apiKey],
         .minimax: [.apiKey],
-        .ollama: [.manualCookieHeader],
-        .openCodeGo: [.manualCookieHeader],
         .openRouter: [.apiKey],
         .zai: [.apiKey]
     ]
@@ -106,8 +108,8 @@ public enum VibeBarKeychainAccessAuthorizer {
         for tool in currentCookieBackedMiscTools {
             targets.append(
                 Target(
-                    service: CookieHeaderCache.keychainService,
-                    account: CookieHeaderCache.keychainAccount(for: tool)
+                    service: MiscCookieSlotStore.keychainService,
+                    account: MiscCookieSlotStore.keychainAccount(for: tool)
                 )
             )
         }

--- a/Sources/VibeBarCore/Services/MiscQuotaAggregator.swift
+++ b/Sources/VibeBarCore/Services/MiscQuotaAggregator.swift
@@ -1,0 +1,192 @@
+import Foundation
+
+/// Combines per-slot quota fetches into a single `AccountQuota`.
+///
+/// Each cookie slot a user has imported for a misc provider is queried
+/// independently (see `MiscCookieResolver.resolveAll`). The aggregator
+/// then averages the percent-used across all successful slots for each
+/// bucket id — "0% + 100% → 50%", "20% + 80% → 50%". Failed slots are
+/// excluded from the average; if every slot fails the surfaced error
+/// is the first failure (so the card flips to "Needs re-login" /
+/// "Network error" exactly as it did under the single-cookie flow).
+///
+/// The aggregator is pure — it doesn't touch Keychain, networking, or
+/// the slot store. Adapters wrap their per-slot fetch in a
+/// `do/catch`, hand the resulting `SlotResult`s to `aggregate(...)`,
+/// and return whatever comes back.
+public enum MiscQuotaAggregator {
+    public struct SlotResult: Sendable {
+        public let slotID: UUID?
+        public let sourceLabel: String
+        public let outcome: Result<AccountQuota, QuotaError>
+
+        public init(
+            slotID: UUID?,
+            sourceLabel: String,
+            outcome: Result<AccountQuota, QuotaError>
+        ) {
+            self.slotID = slotID
+            self.sourceLabel = sourceLabel
+            self.outcome = outcome
+        }
+    }
+
+    /// Combine `results` into one quota row.
+    ///
+    /// - When at least one slot succeeded: average `usedPercent` for
+    ///   each observed bucket id. The bucket's display metadata
+    ///   (`title`, `shortLabel`, `rawWindowSeconds`, `groupTitle`) and
+    ///   plan / email come from the first successful slot that
+    ///   contained that bucket / field. `resetAt` is the earliest
+    ///   non-nil reset across successful slots (most pessimistic). The
+    ///   returned `error` is `nil`.
+    /// - When every slot failed: the returned quota has empty buckets
+    ///   and carries the first failure as `error`, so the existing
+    ///   card-error rendering keeps working.
+    public static func aggregate(
+        tool: ToolType,
+        account: AccountIdentity,
+        results: [SlotResult],
+        queriedAt: Date
+    ) -> AccountQuota {
+        let successes: [AccountQuota] = results.compactMap { result in
+            if case let .success(quota) = result.outcome { return quota }
+            return nil
+        }
+
+        guard !successes.isEmpty else {
+            let firstError: QuotaError = results.compactMap {
+                if case let .failure(err) = $0.outcome { return err }
+                return nil
+            }.first ?? .noCredential
+            return AccountQuota(
+                accountId: account.id,
+                tool: tool,
+                buckets: [],
+                plan: nil,
+                email: account.email,
+                queriedAt: queriedAt,
+                error: firstError
+            )
+        }
+
+        let aggregatedBuckets = mergeBuckets(from: successes)
+        let plan = successes.compactMap(\.plan).first
+        let email = successes.compactMap(\.email).first ?? account.email
+        let providerExtras = successes.compactMap(\.providerExtras).first
+
+        return AccountQuota(
+            accountId: account.id,
+            tool: tool,
+            buckets: aggregatedBuckets,
+            plan: plan,
+            email: email,
+            queriedAt: queriedAt,
+            error: nil,
+            providerExtras: providerExtras
+        )
+    }
+
+    /// Fan a per-slot fetch out concurrently, then box each outcome
+    /// into a `SlotResult`. Adapters call this with their per-slot
+    /// fetcher and pass the result straight into `aggregate(...)`.
+    public static func gatherSlotResults(
+        _ resolutions: [MiscCookieResolver.Resolution],
+        fetch: @Sendable @escaping (MiscCookieResolver.Resolution) async throws -> AccountQuota
+    ) async -> [SlotResult] {
+        await withTaskGroup(of: SlotResult.self, returning: [SlotResult].self) { group in
+            for resolution in resolutions {
+                group.addTask {
+                    do {
+                        let quota = try await fetch(resolution)
+                        return SlotResult(
+                            slotID: resolution.slotID,
+                            sourceLabel: resolution.sourceLabel,
+                            outcome: .success(quota)
+                        )
+                    } catch let err as QuotaError {
+                        return SlotResult(
+                            slotID: resolution.slotID,
+                            sourceLabel: resolution.sourceLabel,
+                            outcome: .failure(err)
+                        )
+                    } catch {
+                        return SlotResult(
+                            slotID: resolution.slotID,
+                            sourceLabel: resolution.sourceLabel,
+                            outcome: .failure(.network(error.localizedDescription))
+                        )
+                    }
+                }
+            }
+            var collected: [SlotResult] = []
+            for await result in group {
+                collected.append(result)
+            }
+            return collected
+        }
+    }
+
+    /// Convenience for single-slot adapters / callers that haven't
+    /// migrated to slot-aware fetching yet — wraps a `Result` so the
+    /// adapter doesn't need to re-implement the aggregation branch.
+    public static func passthrough(
+        tool: ToolType,
+        account: AccountIdentity,
+        result: Result<AccountQuota, QuotaError>,
+        queriedAt: Date,
+        sourceLabel: String = ""
+    ) -> AccountQuota {
+        aggregate(
+            tool: tool,
+            account: account,
+            results: [
+                SlotResult(slotID: nil, sourceLabel: sourceLabel, outcome: result)
+            ],
+            queriedAt: queriedAt
+        )
+    }
+
+    private static func mergeBuckets(from successes: [AccountQuota]) -> [QuotaBucket] {
+        var firstAppearance: [String: (order: Int, bucket: QuotaBucket)] = [:]
+        var orderCounter = 0
+        var percentSums: [String: Double] = [:]
+        var percentCounts: [String: Int] = [:]
+        var earliestReset: [String: Date] = [:]
+
+        for quota in successes {
+            for bucket in quota.buckets {
+                if firstAppearance[bucket.id] == nil {
+                    firstAppearance[bucket.id] = (orderCounter, bucket)
+                    orderCounter += 1
+                }
+                percentSums[bucket.id, default: 0] += bucket.usedPercent
+                percentCounts[bucket.id, default: 0] += 1
+                if let reset = bucket.resetAt {
+                    if let current = earliestReset[bucket.id] {
+                        if reset < current { earliestReset[bucket.id] = reset }
+                    } else {
+                        earliestReset[bucket.id] = reset
+                    }
+                }
+            }
+        }
+
+        return firstAppearance.values
+            .sorted { $0.order < $1.order }
+            .map { entry in
+                let template = entry.bucket
+                let count = max(percentCounts[template.id] ?? 1, 1)
+                let avg = (percentSums[template.id] ?? template.usedPercent) / Double(count)
+                return QuotaBucket(
+                    id: template.id,
+                    title: template.title,
+                    shortLabel: template.shortLabel,
+                    usedPercent: avg,
+                    resetAt: earliestReset[template.id] ?? template.resetAt,
+                    rawWindowSeconds: template.rawWindowSeconds,
+                    groupTitle: template.groupTitle
+                )
+            }
+    }
+}

--- a/Tests/VibeBarCoreTests/KeychainMigrationPolicyTests.swift
+++ b/Tests/VibeBarCoreTests/KeychainMigrationPolicyTests.swift
@@ -24,13 +24,25 @@ final class KeychainMigrationPolicyTests: XCTestCase {
             service: "com.astroqore.VibeBar.web-cookies",
             account: "claude.organization-id"
         )))
+        // Cookie-backed misc providers now stack their sessions through
+        // `MiscCookieSlotStore` (one Keychain entry per tool, holding a
+        // JSON-encoded list of slots). The authorizer needs to cover
+        // every cookie-backed tool's slot list.
         XCTAssertTrue(targets.contains(.init(
-            service: "com.astroqore.VibeBar.web-cookies",
-            account: "misc.kimi.cookie"
+            service: "com.astroqore.VibeBar.misc-secrets",
+            account: "kimi.cookieSlots"
         )))
         XCTAssertTrue(targets.contains(.init(
-            service: "com.astroqore.VibeBar.web-cookies",
-            account: "misc.cursor.cookie"
+            service: "com.astroqore.VibeBar.misc-secrets",
+            account: "cursor.cookieSlots"
+        )))
+        XCTAssertTrue(targets.contains(.init(
+            service: "com.astroqore.VibeBar.misc-secrets",
+            account: "volcengine.cookieSlots"
+        )))
+        XCTAssertTrue(targets.contains(.init(
+            service: "com.astroqore.VibeBar.misc-secrets",
+            account: "alibaba.cookieSlots"
         )))
         XCTAssertTrue(targets.contains(.init(
             service: "com.astroqore.VibeBar.misc-secrets",
@@ -44,9 +56,16 @@ final class KeychainMigrationPolicyTests: XCTestCase {
             service: "com.astroqore.VibeBar.misc-secrets",
             account: "minimax.apiKey"
         )))
+        // The single-cookie `CookieHeaderCache` entries are no longer the
+        // authoritative storage (their contents migrate into slots on
+        // first read) and should not appear in the current target list.
         XCTAssertFalse(targets.contains(.init(
             service: CookieHeaderCache.keychainService,
             account: CookieHeaderCache.keychainAccount(for: .minimax)
+        )))
+        XCTAssertFalse(targets.contains(.init(
+            service: "com.astroqore.VibeBar.web-cookies",
+            account: "misc.kimi.cookie"
         )))
     }
 

--- a/Tests/VibeBarCoreTests/MiscCookieSlotTests.swift
+++ b/Tests/VibeBarCoreTests/MiscCookieSlotTests.swift
@@ -1,0 +1,89 @@
+import XCTest
+@testable import VibeBarCore
+
+final class MiscCookieSlotTests: XCTestCase {
+    func testRoundTripsThroughJSON() throws {
+        let original = MiscCookieSlot(
+            cookieHeader: "kimi-auth=eyJ.example; trace=abc",
+            sourceLabel: "Chrome (Default)",
+            importedAt: Date(timeIntervalSince1970: 1_700_000_000),
+            origin: .browserImport
+        )
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(original)
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let decoded = try decoder.decode(MiscCookieSlot.self, from: data)
+
+        XCTAssertEqual(decoded, original)
+    }
+
+    func testOriginDecodesFromString() throws {
+        let raw = """
+        {
+          "id": "11111111-1111-1111-1111-111111111111",
+          "cookieHeader": "foo=bar",
+          "sourceLabel": "Manual paste",
+          "importedAt": "2026-05-16T10:00:00Z",
+          "origin": "manual"
+        }
+        """
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let slot = try decoder.decode(MiscCookieSlot.self, from: Data(raw.utf8))
+        XCTAssertEqual(slot.origin, .manual)
+        XCTAssertEqual(slot.cookieHeader, "foo=bar")
+    }
+
+    func testSlotFilterFromSettings() {
+        // Auto mode: all origins pass.
+        let auto = MiscCookieResolver.SlotFilter(
+            settings: MiscProviderSettings(sourceMode: .auto, cookieSource: .auto)
+        )
+        XCTAssertEqual(auto, .all)
+        XCTAssertTrue(auto.allows(slot(origin: .manual)))
+        XCTAssertTrue(auto.allows(slot(origin: .browserImport)))
+        XCTAssertTrue(auto.allows(slot(origin: .autoRefresh)))
+
+        // Auto with cookieSource = manual collapses to manualOnly.
+        let manualViaCookieSource = MiscCookieResolver.SlotFilter(
+            settings: MiscProviderSettings(sourceMode: .auto, cookieSource: .manual)
+        )
+        XCTAssertEqual(manualViaCookieSource, .manualOnly)
+        XCTAssertTrue(manualViaCookieSource.allows(slot(origin: .manual)))
+        XCTAssertFalse(manualViaCookieSource.allows(slot(origin: .browserImport)))
+
+        // Explicit browserOnly source mode.
+        let browser = MiscCookieResolver.SlotFilter(
+            settings: MiscProviderSettings(sourceMode: .browserOnly)
+        )
+        XCTAssertEqual(browser, .browserOnly)
+        XCTAssertFalse(browser.allows(slot(origin: .manual)))
+        XCTAssertTrue(browser.allows(slot(origin: .browserImport)))
+        XCTAssertTrue(browser.allows(slot(origin: .autoRefresh)))
+
+        // apiOnly / off shut every slot out.
+        let api = MiscCookieResolver.SlotFilter(
+            settings: MiscProviderSettings(sourceMode: .apiOnly)
+        )
+        XCTAssertEqual(api, .none)
+        XCTAssertFalse(api.allows(slot(origin: .browserImport)))
+
+        let off = MiscCookieResolver.SlotFilter(
+            settings: MiscProviderSettings(sourceMode: .off)
+        )
+        XCTAssertEqual(off, .none)
+    }
+
+    private func slot(origin: MiscCookieSlot.Origin) -> MiscCookieSlot {
+        MiscCookieSlot(
+            cookieHeader: "name=value",
+            sourceLabel: "test",
+            importedAt: Date(),
+            origin: origin
+        )
+    }
+}

--- a/Tests/VibeBarCoreTests/MiscQuotaAggregatorTests.swift
+++ b/Tests/VibeBarCoreTests/MiscQuotaAggregatorTests.swift
@@ -1,0 +1,196 @@
+import XCTest
+@testable import VibeBarCore
+
+final class MiscQuotaAggregatorTests: XCTestCase {
+    private let account = AccountIdentity(
+        id: "acct-1",
+        tool: .volcengine,
+        email: "user@example.com",
+        source: .browserCookie
+    )
+
+    private let queriedAt = Date(timeIntervalSince1970: 1_700_000_000)
+
+    func testTwoSlotsAverageZeroAndHundredToFifty() {
+        let resetA = queriedAt.addingTimeInterval(3600)
+        let resetB = queriedAt.addingTimeInterval(7200)
+
+        let quotaA = AccountQuota(
+            accountId: account.id,
+            tool: .volcengine,
+            buckets: [
+                QuotaBucket(
+                    id: "volcengine.session",
+                    title: "5 Hours",
+                    shortLabel: "5h",
+                    usedPercent: 0,
+                    resetAt: resetA,
+                    rawWindowSeconds: 5 * 3600
+                )
+            ],
+            plan: "Coding Plan Pro"
+        )
+        let quotaB = AccountQuota(
+            accountId: account.id,
+            tool: .volcengine,
+            buckets: [
+                QuotaBucket(
+                    id: "volcengine.session",
+                    title: "5 Hours",
+                    shortLabel: "5h",
+                    usedPercent: 100,
+                    resetAt: resetB,
+                    rawWindowSeconds: 5 * 3600
+                )
+            ],
+            plan: "Coding Plan Lite"
+        )
+
+        let aggregated = MiscQuotaAggregator.aggregate(
+            tool: .volcengine,
+            account: account,
+            results: [
+                .init(slotID: UUID(), sourceLabel: "Chrome (Default)", outcome: .success(quotaA)),
+                .init(slotID: UUID(), sourceLabel: "Manual paste", outcome: .success(quotaB))
+            ],
+            queriedAt: queriedAt
+        )
+
+        XCTAssertNil(aggregated.error)
+        XCTAssertEqual(aggregated.buckets.count, 1)
+        XCTAssertEqual(aggregated.buckets[0].usedPercent, 50, accuracy: 0.0001)
+        XCTAssertEqual(aggregated.buckets[0].resetAt, resetA)
+        XCTAssertEqual(aggregated.plan, "Coding Plan Pro")
+        XCTAssertEqual(aggregated.email, "user@example.com")
+    }
+
+    func testTwoSlotsAverageTwentyAndEightyToFifty() {
+        let bucketA = QuotaBucket(
+            id: "tencentHunyuan.weekly",
+            title: "Weekly",
+            shortLabel: "Wk",
+            usedPercent: 20
+        )
+        let bucketB = QuotaBucket(
+            id: "tencentHunyuan.weekly",
+            title: "Weekly",
+            shortLabel: "Wk",
+            usedPercent: 80
+        )
+
+        let aggregated = MiscQuotaAggregator.aggregate(
+            tool: .tencentHunyuan,
+            account: account,
+            results: [
+                .init(slotID: nil, sourceLabel: "A", outcome: .success(AccountQuota(
+                    accountId: account.id, tool: .tencentHunyuan, buckets: [bucketA]
+                ))),
+                .init(slotID: nil, sourceLabel: "B", outcome: .success(AccountQuota(
+                    accountId: account.id, tool: .tencentHunyuan, buckets: [bucketB]
+                )))
+            ],
+            queriedAt: queriedAt
+        )
+
+        XCTAssertEqual(aggregated.buckets.first?.usedPercent ?? 0, 50, accuracy: 0.0001)
+    }
+
+    func testNonOverlappingBucketIdsRetainBoth() {
+        let session = QuotaBucket(
+            id: "volcengine.session",
+            title: "5 Hours",
+            shortLabel: "5h",
+            usedPercent: 10
+        )
+        let weekly = QuotaBucket(
+            id: "volcengine.weekly",
+            title: "Weekly",
+            shortLabel: "Wk",
+            usedPercent: 75
+        )
+        let aggregated = MiscQuotaAggregator.aggregate(
+            tool: .volcengine,
+            account: account,
+            results: [
+                .init(slotID: nil, sourceLabel: "A", outcome: .success(AccountQuota(
+                    accountId: account.id, tool: .volcengine, buckets: [session]
+                ))),
+                .init(slotID: nil, sourceLabel: "B", outcome: .success(AccountQuota(
+                    accountId: account.id, tool: .volcengine, buckets: [weekly]
+                )))
+            ],
+            queriedAt: queriedAt
+        )
+
+        XCTAssertEqual(aggregated.buckets.count, 2)
+        let bySession = aggregated.buckets.first(where: { $0.id == "volcengine.session" })
+        let byWeekly = aggregated.buckets.first(where: { $0.id == "volcengine.weekly" })
+        XCTAssertEqual(bySession?.usedPercent ?? 0, 10, accuracy: 0.0001)
+        XCTAssertEqual(byWeekly?.usedPercent ?? 0, 75, accuracy: 0.0001)
+    }
+
+    func testOneSuccessAndOneFailureUsesOnlySuccess() {
+        let bucket = QuotaBucket(
+            id: "kimi.weekly",
+            title: "Weekly",
+            shortLabel: "Wk",
+            usedPercent: 42
+        )
+        let aggregated = MiscQuotaAggregator.aggregate(
+            tool: .kimi,
+            account: account,
+            results: [
+                .init(slotID: nil, sourceLabel: "Good", outcome: .success(AccountQuota(
+                    accountId: account.id, tool: .kimi, buckets: [bucket]
+                ))),
+                .init(slotID: nil, sourceLabel: "Stale", outcome: .failure(.needsLogin))
+            ],
+            queriedAt: queriedAt
+        )
+
+        XCTAssertNil(aggregated.error)
+        XCTAssertEqual(aggregated.buckets.count, 1)
+        XCTAssertEqual(aggregated.buckets[0].usedPercent, 42, accuracy: 0.0001)
+    }
+
+    func testAllFailuresSurfaceFirstError() {
+        let aggregated = MiscQuotaAggregator.aggregate(
+            tool: .volcengine,
+            account: account,
+            results: [
+                .init(slotID: nil, sourceLabel: "A", outcome: .failure(.needsLogin)),
+                .init(slotID: nil, sourceLabel: "B", outcome: .failure(.rateLimited))
+            ],
+            queriedAt: queriedAt
+        )
+
+        XCTAssertEqual(aggregated.error, QuotaError.needsLogin)
+        XCTAssertTrue(aggregated.buckets.isEmpty)
+    }
+
+    func testEarliestResetWins() {
+        let early = queriedAt.addingTimeInterval(60)
+        let late = queriedAt.addingTimeInterval(3600)
+
+        let aggregated = MiscQuotaAggregator.aggregate(
+            tool: .mimo,
+            account: account,
+            results: [
+                .init(slotID: nil, sourceLabel: "Late", outcome: .success(AccountQuota(
+                    accountId: account.id, tool: .mimo, buckets: [
+                        QuotaBucket(id: "mimo.month", title: "Monthly", shortLabel: "Mo", usedPercent: 30, resetAt: late)
+                    ]
+                ))),
+                .init(slotID: nil, sourceLabel: "Early", outcome: .success(AccountQuota(
+                    accountId: account.id, tool: .mimo, buckets: [
+                        QuotaBucket(id: "mimo.month", title: "Monthly", shortLabel: "Mo", usedPercent: 70, resetAt: early)
+                    ]
+                )))
+            ],
+            queriedAt: queriedAt
+        )
+
+        XCTAssertEqual(aggregated.buckets.first?.resetAt, early)
+        XCTAssertEqual(aggregated.buckets.first?.usedPercent ?? 0, 50, accuracy: 0.0001)
+    }
+}

--- a/docs/superpowers/specs/2026-05-16-misc-multi-cookie-design.md
+++ b/docs/superpowers/specs/2026-05-16-misc-multi-cookie-design.md
@@ -1,0 +1,301 @@
+# Multi-Cookie Misc Providers — Design
+
+## Motivation
+
+Cookie-based misc providers (Kimi, Cursor, Alibaba console, MiMo,
+iFlytek, Tencent Hunyuan, Volcengine, OpenCode Go, Ollama) currently
+hold a single cookie per tool. Power users have multiple accounts
+with the same provider — one team account, one personal account, a
+trial account — and want the Vibe Bar card to reflect the combined
+plan capacity across all of them.
+
+## User story
+
+1. **Additive import.** Importing a cookie never clobbers a previously
+   imported one. Each click of "Import from browser" or each manual
+   paste appends a new slot.
+2. **Managed list.** Settings shows the list of imported cookies for
+   the provider in insertion order, with the import time and source
+   label, and a delete button per row.
+3. **Aggregated query.** On refresh, every slot is queried in
+   parallel. For each bucket, `usedPercent` is averaged across
+   successful queries (0% + 100% → 50%; 20% + 80% → 50%). Failed
+   queries are excluded; if every slot fails, the surfaced error
+   matches the first failure.
+
+This applies to every cookie-based misc provider listed above. Misc
+providers that use API keys / OAuth / local probes are unchanged.
+
+## Architecture
+
+### Storage — `MiscCookieSlotStore`
+
+New core module `Sources/VibeBarCore/Credentials/MiscCookieSlotStore.swift`.
+
+```swift
+public struct MiscCookieSlot: Codable, Equatable, Sendable {
+    public let id: UUID
+    public var cookieHeader: String
+    public var sourceLabel: String   // "Manual paste", "Chrome (Default)", "Auto-refresh"
+    public var importedAt: Date
+    public var origin: Origin        // .manual | .browserImport | .autoRefresh
+
+    public enum Origin: String, Codable, Sendable {
+        case manual
+        case browserImport
+        case autoRefresh
+    }
+}
+
+public enum MiscCookieSlotStore {
+    public static func slots(for tool: ToolType) -> [MiscCookieSlot]
+    @discardableResult public static func append(_ slot: MiscCookieSlot, for tool: ToolType) -> Bool
+    @discardableResult public static func updateHeader(slotID: UUID, for tool: ToolType, header: String, sourceLabel: String? = nil) -> Bool
+    @discardableResult public static func delete(slotID: UUID, for tool: ToolType) -> Bool
+    @discardableResult public static func deleteAll(for tool: ToolType) -> Bool
+    public static func hasAnySlot(for tool: ToolType) -> Bool
+}
+```
+
+- Single Keychain entry per tool, service
+  `com.astroqore.VibeBar.misc-secrets`, account
+  `<tool.rawValue>.cookieSlots`. Value is a JSON-encoded
+  `[MiscCookieSlot]`.
+- Append is O(n) (decode → push → re-encode), which is fine: a
+  realistic upper bound is < 10 slots per tool.
+- Treats an empty list as "delete the keychain entry."
+
+### Migration — `MiscCookieSlotStore.migrateLegacyIfNeeded(_:)`
+
+On every slot read, lazily migrate single-cookie state into slots:
+
+1. If the slot list is empty:
+   - If `MiscCredentialStore.manualCookieHeader` exists →
+     append a `.manual` slot with `sourceLabel = "Manual paste"`,
+     `importedAt = now` (the original timestamp is unknown), then
+     delete `manualCookieHeader`.
+   - If `CookieHeaderCache.load(for:)` returns an entry whose label
+     is not `"Manual paste"` → append a `.browserImport` slot using
+     that entry's `sourceLabel` + `storedAt`, then clear the cache.
+2. The legacy `importedCookieHeader` Keychain kind is removed (it
+   was never populated by current code; verified by grep).
+
+After migration, single-cookie reads via `manualCookieHeader` and
+`CookieHeaderCache` are no longer authoritative. They are deleted
+during migration; any future writes to those locations are dead
+code that we also remove.
+
+### Resolution — `MiscCookieResolver`
+
+`MiscCookieResolver` gains `resolveAll(for:) -> [Resolution]`:
+
+```swift
+public struct Resolution {
+    public let slotID: UUID
+    public let header: String
+    public let sourceLabel: String
+}
+
+public static func resolveAll(for spec: Spec) -> [Resolution]
+```
+
+Behaviour:
+
+- Reads `MiscCookieSlotStore.slots(for: spec.tool)`.
+- Filters slots by the current `MiscProviderSettings.sourceMode`:
+  - `auto` → all slots
+  - `browserOnly` → only `.browserImport` / `.autoRefresh` slots
+  - `manualOnly` → only `.manual` slots
+  - `apiOnly` / `off` → empty
+- Filters out slots whose `cookieHeader` no longer has the
+  spec's required credential cookies (same gate as today).
+- Returns Resolutions in slot insertion order.
+
+`resolve(for:)` keeps its existing signature but is now a thin
+shim: `resolveAll(for:).first`. Adapters migrate off it.
+
+`forceBrowserImport(for:)` becomes `appendBrowserImport(for:)` —
+it always appends a new slot (or returns `nil` if no browser
+session is found). The button label in Settings changes to "Import
+from browser" to match.
+
+### Aggregation — `MiscQuotaAggregator`
+
+New module `Sources/VibeBarCore/Services/MiscQuotaAggregator.swift`:
+
+```swift
+public enum MiscQuotaAggregator {
+    public struct SlotResult {
+        public let slotID: UUID
+        public let outcome: Result<AccountQuota, QuotaError>
+    }
+
+    public static func aggregate(
+        tool: ToolType,
+        account: AccountIdentity,
+        results: [SlotResult],
+        queriedAt: Date
+    ) -> AccountQuota
+}
+```
+
+Semantics:
+
+- For each bucket id observed in any successful result:
+  - `usedPercent` = arithmetic mean across results that contained
+    that id (rounded to one decimal).
+  - `resetAt` = earliest non-nil `resetAt` (most pessimistic).
+  - `title`, `shortLabel`, `rawWindowSeconds`, `groupTitle` =
+    copied from the first result that contained the bucket.
+- `plan` = first non-nil plan among successful results.
+- `email` = first non-nil email.
+- `error` = nil if any result succeeded; otherwise the first
+  failure (so the card surfaces "Needs login" or "Network error"
+  exactly as it does today for a single failing cookie).
+- `queriedAt` = the caller's clock (single timestamp for the card,
+  not per slot).
+
+The aggregator is pure (no Keychain, no networking) — easy to test
+with hand-rolled `SlotResult`s.
+
+### Adapters
+
+Every cookie-based adapter currently follows this pattern:
+
+```swift
+guard let resolution = MiscCookieResolver.resolve(for: spec) else { ... }
+let data = try await fetch(using: resolution.header)
+let buckets = parse(data)
+return AccountQuota(... buckets ...)
+```
+
+The new pattern, applied uniformly to all 9 cookie adapters:
+
+```swift
+let resolutions = MiscCookieResolver.resolveAll(for: spec)
+guard !resolutions.isEmpty else { throw QuotaError.noCredential }
+
+let results = await withTaskGroup(of: MiscQuotaAggregator.SlotResult.self) { group in
+    for r in resolutions {
+        group.addTask { await fetchOneSlot(r) }
+    }
+    return await group.collect()
+}
+
+return MiscQuotaAggregator.aggregate(
+    tool: .volcengine,
+    account: account,
+    results: results,
+    queriedAt: now()
+)
+```
+
+`fetchOneSlot(_:)` wraps the existing per-cookie request in a
+`do/catch`, returning `.success(AccountQuota)` or `.failure(QuotaError)`.
+
+Per-slot stale-cookie handling: when a slot's fetch raises
+`.needsLogin`, we **mark** the slot as suspect (we don't delete it
+silently — the user must see it in Settings and decide). A
+follow-up improvement could carry a `lastError` field on the slot
+for UI display; the initial cut just logs a `SafeLog.warn` and lets
+the user re-import.
+
+### Auto-refresh — `HiddenCookieRefresher`
+
+`HiddenCookieRefresher` currently writes to
+`CookieHeaderCache`. After migration that path is gone. The new
+contract:
+
+- For each tool the refresher supports, iterate over its slots
+  in order.
+- For each slot, inject the slot's cookies into the
+  `WKWebsiteDataStore`, load `Config.refreshURL`, wait
+  `postLoadWait`, capture the resulting cookie header.
+- If the captured header differs from the slot's stored header,
+  call `MiscCookieSlotStore.updateHeader(slotID:for:header:sourceLabel:)`
+  with `sourceLabel = "Auto-refresh"`. Slot ID and `importedAt`
+  are preserved.
+- Between slots, clear the WebView cookie store so slots can't
+  leak into each other. Cheapest path: tear down the
+  `WKWebsiteDataStore` per slot. We accept slower refresh in
+  exchange for correctness.
+
+Manual slots (`origin == .manual`) are skipped — auto-refresh
+only revives sessions the user originally captured via the
+in-app web login or browser auto-import. The user's pasted
+session is their problem to maintain.
+
+### Settings UI — `CookieSourceControls`
+
+The current row exposes "Import now" + a single manual paste field.
+Replaces with:
+
+```
+┌──────────────────────────────────────────────────────────┐
+│ [trash] Chrome (Default)   imported 2026-05-16 10:14    │
+│ [trash] Manual paste       imported 2026-05-16 11:02    │
+│ [trash] Auto-refresh       refreshed 2026-05-16 11:30    │
+├──────────────────────────────────────────────────────────┤
+│ [ Import from browser ]                                  │
+│ [ Paste new cookie...        ] [Save]                    │
+└──────────────────────────────────────────────────────────┘
+```
+
+- Slot list shows `sourceLabel` + relative or absolute
+  `importedAt`. Each row has a trash button that calls
+  `MiscCookieSlotStore.delete(slotID:for:)` and triggers a
+  refresh.
+- "Import from browser" runs `MiscCookieResolver.appendBrowserImport(for:)`
+  off the main thread.
+- "Paste new cookie" saves into a new `.manual` slot on the same
+  store, then clears the textfield.
+
+Empty list shows the existing tertiary help text.
+
+The list uses a `@State`-tracked snapshot that's reloaded after every
+mutation, plus subscribes to a new `Notification.Name.miscCookieSlotsChanged`
+posted by the store on writes, so the UI updates when
+`HiddenCookieRefresher` mutates slots in the background.
+
+### Tests (`Tests/VibeBarCoreTests`)
+
+New files / cases:
+
+- `MiscCookieSlotStoreTests.swift`
+  - Append → list grows in order.
+  - Delete by id → list shrinks; deleting last clears the keychain entry.
+  - Update header preserves id + importedAt.
+  - Migration: pre-existing `manualCookieHeader` + cache entry produce
+    expected slots and clear legacy entries (mock the keychain via
+    a test-only protocol or by namespacing the service to the test bundle).
+- `MiscQuotaAggregatorTests.swift`
+  - Two successes (0% + 100%) → 50%.
+  - Two successes with non-overlapping bucket ids → both buckets
+    appear with their original percent.
+  - One success + one `needsLogin` → success bucket only, no error.
+  - All failures → carries the first failure as `error`.
+  - Earliest `resetAt` wins.
+- `MiscCookieResolverTests.swift` (extend)
+  - `resolveAll` filters by sourceMode.
+  - Slots missing required credentials are dropped.
+
+No existing tests need to change once the adapters are migrated;
+parser tests stay green because parsing is per-slot.
+
+## Migration safety
+
+- The migration is one-way (single → list). A user downgrading
+  the app loses multi-slot state; the first slot survives because
+  the legacy migration runs only when the list is empty.
+- All slot data is in Keychain, never in `~/.vibebar/settings.json`.
+- `MiscProviderSettings.sensitiveKeyMarkers` already rejects
+  `manualcookie` / `cookieheader`; no settings JSON change.
+
+## Out of scope (for this PR)
+
+- Per-slot `lastError` indicator on the Settings row.
+- Aggregation across **different** providers (still per-tool).
+- "Pause/disable" toggle for an individual slot — the user can
+  just delete and re-import.
+- Aggregating MiniMax / Z.ai API keys or Copilot device tokens
+  (this PR only touches cookie-based misc providers).


### PR DESCRIPTION
## Summary
- Cookie-based misc providers (Kimi, Cursor, Alibaba console, MiMo, iFlytek, Tencent Hunyuan, Volcengine, OpenCode Go, Ollama) now hold a **list of cookie slots** in Keychain instead of one session per tool. Imports are additive — each "Import from browser" click and each paste appends a new slot; existing slots are preserved.
- Settings shows a per-provider list of imported slots with source icon, import time, and per-slot delete. Empty state prompts an import.
- On refresh, each slot is queried in parallel. For every bucket id, `usedPercent` is averaged across successful slots (0%+100% → 50%, 20%+80% → 50%). `resetAt` becomes the earliest non-nil reset. If every slot fails, the card surfaces the first failure exactly as before.

## Implementation notes
- `MiscCookieSlot` + `MiscCookieSlotStore` (`Sources/VibeBarCore/Credentials/MiscCookieSlotStore.swift`) — one Keychain entry per tool (`<tool>.cookieSlots`), value is a JSON-encoded `[MiscCookieSlot]`. Posts a `didChangeNotification` on mutations so the Settings UI redraws when `HiddenCookieRefresher` updates a slot in the background.
- Lazy migration from `MiscCredentialStore.manualCookieHeader` + the legacy single-entry `CookieHeaderCache` on first read of the slot list; legacy entries are deleted after the new list is durably stored.
- `MiscCookieResolver.resolveAll` returns every slot eligible under the current source-mode/cookie-source filter; `appendBrowserImport` runs the SweetCookieKit dance and appends. `resolve` stays as a thin first-slot shim for callers that haven't migrated.
- `MiscQuotaAggregator` (`Sources/VibeBarCore/Services/MiscQuotaAggregator.swift`) is the pure aggregation function — adapters call `gatherSlotResults` (concurrent `withTaskGroup` fan-out) and pass the boxed `SlotResult`s into `aggregate`.
- Every cookie adapter migrates to `fetch → resolveAll → gather → aggregate`. The per-401 `CookieHeaderCache.clear` calls are gone — slots are user-owned now, not transparent cache.
- `HiddenCookieRefresher` iterates browser-origin slots, refreshes each one inside a fresh `WKWebsiteDataStore.nonPersistent()` (prevents cookie bleed across sessions), and writes the captured header back via `MiscCookieSlotStore.updateHeader`.
- `MiscWebLoginController` (in-app WebView login) now appends a `.browserImport` slot instead of clobbering a single cookie entry.
- `VibeBarKeychainAccessAuthorizer` lists the new `<tool>.cookieSlots` Keychain accounts for every cookie-backed misc tool. The existing test asserting the legacy `misc.<tool>.cookie` accounts now asserts the slot accounts instead.

Design doc: [`docs/superpowers/specs/2026-05-16-misc-multi-cookie-design.md`](docs/superpowers/specs/2026-05-16-misc-multi-cookie-design.md).

## Test plan
- [x] `swift build` — clean.
- [x] `swift test` — 291 tests pass (was 282; 9 new aggregator/slot tests).
- [x] `./Scripts/build_app.sh release` + `codesign -d --entitlements - ".build/Vibe Bar.app"` — entitlements stay empty `<dict/>`, no `app-sandbox` key.
- [x] `codesign --verify --deep --strict ".build/Vibe Bar.app"` — exit 0.
- [x] `open ".build/Vibe Bar.app"` launches; `ls ~/Library/Containers/com.astroqore.VibeBar/Data/` reports "No such file or directory" (unsandboxed).
- [ ] Manual UI smoke: open Settings → misc provider (e.g. Volcengine), confirm the slot list renders, import + paste both append (don't replace), delete removes a slot, and the card averages bucket percentages across imported slots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)