### PR TITLE
Document branch worktree PR workflow

### DIFF
--- a/AGENT-PR.md
+++ b/AGENT-PR.md
@@ -12,13 +12,47 @@ human-facing version of the same rules.
 - Default branch: `main`.
 - License: AGPL-3.0-only. Any contribution is licensed under AGPL-3.0.
 
+## Branch and worktree rules
+
+Start every change from a current `main`, then create a topic branch.
+Do not commit directly on `main`, and do not push directly to `main`
+unless AQ explicitly asks for an emergency direct push.
+
+Use short, descriptive branch names with conventional prefixes:
+
+- `feat/<short-topic>` for new user-facing behavior.
+- `fix/<short-topic>` for bug fixes.
+- `docs/<short-topic>` for documentation-only changes.
+- `test/<short-topic>` for test-only changes.
+- `refactor/<short-topic>` for behavior-preserving restructuring.
+- `release/<version-or-topic>` for release-prep branches.
+
+These prefixes are for branch names only. Commit subjects still match
+the repo style below: imperative, plain-English, and no `feat:` / `fix:`
+/ `chore:` prefix.
+
+Because multiple local AI agents may work in this checkout at once,
+prefer a separate Git worktree for non-trivial changes:
+
+```sh
+git checkout main
+git pull --ff-only origin main
+git worktree add ../vibe-bar-<short-topic> -b <prefix>/<short-topic> main
+cd ../vibe-bar-<short-topic>
+```
+
+If the user did not explicitly mention worktrees, do not stop just to
+ask. Pick the safer path and keep moving: use a worktree for parallel
+work, dirty checkouts, or longer-running branches; use an in-place topic
+branch only when the current checkout is clean and the change is small.
+
 ## End-to-end PR workflow
 
 ```sh
 # 1. Branch from main
 git checkout main
-git pull --ff-only
-git checkout -b <short-topic-branch-name>
+git pull --ff-only origin main
+git checkout -b <prefix>/<short-topic>
 
 # 2. Make your change. Keep edits scoped to the topic.
 
@@ -33,7 +67,7 @@ git add <files>
 git commit -m "<imperative subject line>"
 
 # 5. Push the branch.
-git push -u origin <short-topic-branch-name>
+git push -u origin <prefix>/<short-topic>
 
 # 6. Open the PR.
 gh pr create --base main \
@@ -50,6 +84,9 @@ gh pr create --base main \
 EOF
 )"
 ```
+
+The default publishing path is always a PR against `main`, not a direct
+push to `main`.
 
 ## Commit identity
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -478,13 +478,48 @@ more than one human or agent shaped a commit.
 The repository is `AstroQore/vibe-bar` on GitHub. Default branch is
 `main`. Any contribution is licensed under AGPL-3.0.
 
-### 9.1 End-to-end PR flow
+### 9.1 Branch and worktree rules
+
+All maintenance work starts from an up-to-date `main`, then moves onto a
+topic branch. Do not commit directly on `main`, and do not push directly
+to `main` unless AQ explicitly asks for an emergency direct push.
+
+Use short, descriptive branch names with a conventional prefix:
+
+- `feat/<short-topic>` for new user-facing behavior.
+- `fix/<short-topic>` for bug fixes.
+- `docs/<short-topic>` for documentation-only changes.
+- `test/<short-topic>` for test-only changes.
+- `refactor/<short-topic>` for behavior-preserving restructuring.
+- `release/<version-or-topic>` for release-prep branches.
+
+Commit subjects still follow this repo's normal style: imperative,
+plain-English, and no `feat:` / `fix:` / `chore:` prefix. The prefix is
+for branch organization only.
+
+Because multiple local AI agents may work in this checkout at once,
+prefer creating a separate Git worktree for non-trivial changes:
+
+```sh
+git checkout main
+git pull --ff-only origin main
+git worktree add ../vibe-bar-<short-topic> -b <prefix>/<short-topic> main
+cd ../vibe-bar-<short-topic>
+```
+
+If the user did not explicitly mention worktrees, do not stop just to
+ask. Pick the safer path and keep moving: use a worktree when parallel
+work, a dirty checkout, or a long-running branch would make isolation
+useful; for tiny single-agent changes on a clean checkout, an in-place
+topic branch is acceptable.
+
+### 9.2 End-to-end PR flow
 
 ```sh
 # 1. Branch from main
 git checkout main
-git pull --ff-only
-git checkout -b <short-topic-branch-name>
+git pull --ff-only origin main
+git checkout -b <prefix>/<short-topic>
 
 # 2. Make your change. Keep edits scoped to the topic.
 
@@ -499,7 +534,7 @@ git add <files>
 git commit -m "<imperative subject line>"
 
 # 5. Push the branch.
-git push -u origin <short-topic-branch-name>
+git push -u origin <prefix>/<short-topic>
 
 # 6. Open the PR.
 gh pr create --base main \
@@ -517,7 +552,10 @@ EOF
 )"
 ```
 
-### 9.2 Required local checks before pushing
+Do not replace the PR flow with a direct push to `main`. Push the topic
+branch and open a PR against `main`.
+
+### 9.3 Required local checks before pushing
 
 | Check                                                         | Why it must pass                                              |
 | ------------------------------------------------------------- | ------------------------------------------------------------- |
@@ -529,7 +567,7 @@ EOF
 If you cannot run one of these (no macOS host, no Xcode, etc.), say so
 explicitly in the PR description instead of skipping the checkbox.
 
-### 9.3 Commit message style
+### 9.4 Commit message style
 
 Match what `git log` shows on `main`:
 
@@ -552,7 +590,7 @@ be current when the off-screen NSImage rendered. Forward the matching
 Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
 ```
 
-### 9.4 After the PR is open
+### 9.5 After the PR is open
 
 - CI may run additional checks. Address any failures.
 - A maintainer may request changes. Push follow-up commits to the same

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,7 @@ default to.
 
 ## Critical rules for Claude
 
-These five rules cause silent failures or public-repo accidents if
+These rules cause silent failures or public-repo accidents if
 ignored. The full reasoning and grep recipes live in `AGENTS.md`.
 
 1. **Real-home routing.** Any path under the user's real home
@@ -86,13 +86,24 @@ ignored. The full reasoning and grep recipes live in `AGENTS.md`.
    config is already set; do not overwrite it with a personal mailbox.
    Match the existing log style: imperative subject ≤ 70 chars, no
    `feat:`/`fix:`/`chore:` prefixes, optional `Co-Authored-By:`
-   trailer. Never force-push `main`.
+   trailer. Put conventional prefixes such as `feat/`, `fix/`, or
+   `docs/` on branch names, not commit subjects. Never force-push
+   `main`.
+
+6. **Branch first, PR always.** Start from current `main`, create a
+   topic branch, and submit changes through a PR against `main`. Do not
+   push directly to `main` unless AQ explicitly asks for an emergency
+   direct push. Because multiple local agents may work here at once,
+   prefer a separate Git worktree for non-trivial changes; if the user
+   did not mention worktrees, decide and proceed instead of stopping to
+   ask.
 
 ## Heavy lifting
 
-For maintenance flows that AQ owns on his Mac (sync → change → build →
-test → sign → smoke-test → optional install → commit → push to
-`AstroQore/vibe-bar`), there is a dedicated maintainer skill
-`vibe-bar-maintainer`. Invoke it whenever the work is "AQ asked me to
-maintain Vibe Bar." For one-off contributor work (e.g. a guest agent
-opening a PR), `AGENTS.md` plus this file are sufficient.
+For maintenance flows that AQ owns on his Mac (sync → branch/worktree →
+change → build → test → sign → smoke-test → optional install → commit →
+push branch → open PR against `AstroQore/vibe-bar`), there is a
+dedicated maintainer skill `vibe-bar-maintainer`. Invoke it whenever
+the work is "AQ asked me to maintain Vibe Bar." For one-off contributor
+work (e.g. a guest agent opening a PR), `AGENTS.md` plus this file are
+sufficient.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,24 @@ Do not commit personal emails, machine hostnames, internal handles, or
 `/Users/<name>` paths inside source files, fixtures, or logs — that's a
 source-content rule, not a commit-author rule.
 
+## Branch and PR Workflow
+
+Start from an up-to-date `main`, then create a topic branch. Use short,
+descriptive branch names with conventional prefixes such as
+`feat/<topic>`, `fix/<topic>`, `docs/<topic>`, `test/<topic>`,
+`refactor/<topic>`, or `release/<topic>`. These prefixes are for branch
+names only; commit subjects should stay imperative and should not use
+`feat:` / `fix:` / `chore:` prefixes.
+
+If multiple local agents may be working at once, prefer a separate Git
+worktree so each branch has its own checkout. If the user has not
+explicitly asked about worktrees, choose the safer path and proceed
+instead of stopping for confirmation.
+
+Submit changes through a pull request against `main`. Do not push
+directly to `main` unless AQ explicitly asks for an emergency direct
+push.
+
 ## Development Setup
 
 Vibe Bar is a Swift package with two main targets:


### PR DESCRIPTION
## Summary
- Document the conventional branch-prefix workflow for Vibe Bar maintenance.
- Clarify when agents should prefer Git worktrees without stopping to ask.
- Reinforce that publishing should go through PRs instead of direct main pushes.

## Test plan
- [x] git diff --check
- [x] swift build
- [x] swift test
- [x] ./Scripts/build_app.sh release
- [x] codesign -d --entitlements - ".build/Vibe Bar.app"
- [x] codesign --verify --deep --strict ".build/Vibe Bar.app"