### PR TITLE
Migrate Tencent Coding Plan adapter to TokenHub BFF

### DIFF
--- a/Sources/VibeBarApp/MiscWebLoginController.swift
+++ b/Sources/VibeBarApp/MiscWebLoginController.swift
@@ -675,7 +675,14 @@ final class MiscWebLoginRegistry {
         case .tencentHunyuan:
             return MiscWebLoginController.Config(
                 tool: .tencentHunyuan,
-                loginURL: URL(string: "https://hunyuan.cloud.tencent.com/")!,
+                // The standalone `hunyuan.cloud.tencent.com` console is
+                // scheduled for full shutdown on 2026-09-30; Tencent has
+                // rebranded the Coding Plan product under TokenHub at
+                // `console.cloud.tencent.com/tokenhub/codingplan`. Send
+                // users straight to the new console so the cookies they
+                // capture come from the platform that will still exist
+                // after the migration window.
+                loginURL: URL(string: "https://console.cloud.tencent.com/tokenhub/codingplan")!,
                 cookieDomainSuffixes: ["cloud.tencent.com", "tencent.com"],
                 // Empty set tells the controller to ship every cookie
                 // for the matching domains, mirroring the adapter's

--- a/Sources/VibeBarCore/Adapters/TencentHunyuanQuotaAdapter.swift
+++ b/Sources/VibeBarCore/Adapters/TencentHunyuanQuotaAdapter.swift
@@ -5,9 +5,8 @@ import Foundation
 /// Auth: cookies captured from a Tencent Cloud console login. The user
 /// signs in once via `MiscWebLoginController` (or pastes a Cookie
 /// header in Settings); we ship the full `*.cloud.tencent.com` jar to
-/// `console-hc.cloud.tencent.com` and derive the per-request
-/// `csrfCode` URL parameter locally from the `skey` cookie via
-/// `TencentCsrfCode`.
+/// the console BFF and derive the per-request `csrfCode` URL parameter
+/// locally from the `skey` cookie via `TencentCsrfCode`.
 ///
 /// We previously ran a sub-account password login via
 /// `TencentSessionManager`, but Tencent's `auth-api/login/submit` now
@@ -16,9 +15,20 @@ import Foundation
 /// generates. The cookie path mirrors what MiMo / Kimi / Cursor do
 /// and avoids the captcha treadmill.
 ///
-/// Endpoint: `POST https://console-hc.cloud.tencent.com/_api/hunyuan/DescribePkg`
-/// with the standard Tencent console BFF envelope. Returns the
-/// PerFiveHour / PerWeek / PerMonth windows for the user's plan.
+/// Endpoint: `POST https://console.cloud.tencent.com/cgi/capi` with
+/// `?cmd=DescribePkg&action=delegate&serviceType=hunyuan` plus the
+/// usual `t`/`uin`/`csrfCode` console params. Returns the PerFiveHour /
+/// PerWeek / PerMonth windows for the user's plan, wrapped in the CGI
+/// router envelope (`{code:0, data:{code:0, cgwerrorCode:0, data:{Response:...}}}`).
+///
+/// Migrated 2026-05 from the legacy `console-hc.cloud.tencent.com/_api/hunyuan/DescribePkg`
+/// path, which Tencent announced will be fully shut down on 2026-09-30
+/// alongside the rest of the standalone `hunyuan.cloud.tencent.com`
+/// console. The new console lives at `console.cloud.tencent.com/tokenhub/codingplan`
+/// (TokenHub-branded) and routes through the same `cgi/capi` BFF as
+/// the rest of the Tencent Cloud console; `serviceType=hunyuan` is
+/// still the backend identifier on Tencent's side, so the response
+/// shape inside the new wrapper is byte-identical to the legacy one.
 public struct TencentHunyuanQuotaAdapter: QuotaAdapter {
     public let tool: ToolType = .tencentHunyuan
 
@@ -106,8 +116,15 @@ public struct TencentHunyuanQuotaAdapter: QuotaAdapter {
         }
 
         let csrfCode = TencentCsrfCode.compute(from: skey)
-        let urlString = "https://console-hc.cloud.tencent.com/_api/hunyuan/DescribePkg" +
-            "?t=\(Self.epochMillis())&uin=\(uin)&csrfCode=\(csrfCode)"
+        // The TokenHub console routes Coding Plan reads through the
+        // shared `/cgi/capi` BFF. `cmd`, `action=delegate`, and
+        // `serviceType=hunyuan` are required by the router; `t`, `uin`,
+        // and `csrfCode` are the standard console session params. The
+        // page also sends `secure=1&version=3&json=1&dictId=...&sts=1&ownerUin=...`
+        // but those are all optional — the call still 200s without them.
+        let urlString = "https://console.cloud.tencent.com/cgi/capi" +
+            "?cmd=DescribePkg&action=delegate&serviceType=hunyuan" +
+            "&t=\(Self.epochMillis())&uin=\(uin)&csrfCode=\(csrfCode)"
         guard let url = URL(string: urlString) else {
             throw QuotaError.network("Tencent Hunyuan: could not build BFF URL.")
         }
@@ -116,8 +133,8 @@ public struct TencentHunyuanQuotaAdapter: QuotaAdapter {
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.setValue(resolution.header, forHTTPHeaderField: "Cookie")
-        request.setValue("https://hunyuan.cloud.tencent.com", forHTTPHeaderField: "Origin")
-        request.setValue("https://hunyuan.cloud.tencent.com/", forHTTPHeaderField: "Referer")
+        request.setValue("https://console.cloud.tencent.com", forHTTPHeaderField: "Origin")
+        request.setValue("https://console.cloud.tencent.com/tokenhub/codingplan", forHTTPHeaderField: "Referer")
         request.setValue("application/json, text/plain, */*", forHTTPHeaderField: "Accept")
         request.setValue(
             "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Safari/537.36",
@@ -172,9 +189,17 @@ enum TencentHunyuanResponseParser {
         guard !data.isEmpty else {
             throw QuotaError.parseFailure("Tencent Hunyuan returned an empty body.")
         }
+        // Tencent serves the same payload through two transports today.
+        // The legacy `console-hc.cloud.tencent.com/_api/hunyuan/DescribePkg`
+        // path returns `{Response: {...}}` directly. The new TokenHub
+        // path on `console.cloud.tencent.com/cgi/capi` wraps the same
+        // envelope twice: `{code, data: {code, cgwerrorCode, data: {Response: ...}}}`.
+        // Peel the CGI wrapper transparently so the rest of the parser
+        // (and every existing test fixture) stays oblivious.
+        let envelopeData = try Self.unwrapCgiBffEnvelopeIfPresent(data)
         let envelope: TencentHunyuanEnvelope
         do {
-            envelope = try JSONDecoder().decode(TencentHunyuanEnvelope.self, from: data)
+            envelope = try JSONDecoder().decode(TencentHunyuanEnvelope.self, from: envelopeData)
         } catch {
             throw QuotaError.parseFailure(
                 "Tencent Hunyuan response not parseable: \(error.localizedDescription)"
@@ -270,6 +295,57 @@ enum TencentHunyuanResponseParser {
             resetAt: parseShanghaiDate(window.endTime),
             rawWindowSeconds: windowSeconds
         )
+    }
+
+    /// If `data` is wrapped in the `console.cloud.tencent.com/cgi/capi`
+    /// router envelope, walk two `data.data` hops to the inner
+    /// `{Response: ...}` payload. Otherwise return `data` untouched so
+    /// the existing direct-shape fixtures and the legacy
+    /// `console-hc...` host both still parse.
+    ///
+    /// Non-zero outer / middle `code` values are treated as auth or
+    /// rate-limit failures where the code is recognisable, and as a
+    /// generic network error otherwise — we don't want to confuse a
+    /// router-level rejection with a parse failure inside the inner
+    /// `Response.Error` channel.
+    private static func unwrapCgiBffEnvelopeIfPresent(_ data: Data) throws -> Data {
+        guard let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return data
+        }
+        // The new wrapper has a top-level numeric `code` and no
+        // top-level `Response` key. Anything else is the legacy shape.
+        guard root["Response"] == nil,
+              let outerCode = (root["code"] as? NSNumber)?.intValue else {
+            return data
+        }
+        // Always check outer code first — when the router rejects the
+        // request (e.g. 401), `data` is usually `null` and we don't
+        // want to misreport that as a missing inner payload.
+        if outerCode != 0 {
+            throw cgiBffError(code: outerCode, layer: "outer", payload: root)
+        }
+        guard let middle = root["data"] as? [String: Any] else {
+            throw QuotaError.parseFailure("Tencent CGI BFF envelope had no middle data block.")
+        }
+        if let middleCode = (middle["code"] as? NSNumber)?.intValue, middleCode != 0 {
+            throw cgiBffError(code: middleCode, layer: "middle", payload: middle)
+        }
+        guard let inner = middle["data"] as? [String: Any] else {
+            // Recognisable wrapper, both codes zero, but no inner
+            // payload — surface this as a parse failure rather than
+            // silently handing the wrapper itself to the Response decoder.
+            throw QuotaError.parseFailure("Tencent CGI BFF envelope had no inner data block.")
+        }
+        return try JSONSerialization.data(withJSONObject: inner)
+    }
+
+    private static func cgiBffError(code: Int, layer: String, payload: [String: Any]) -> Error {
+        if code == 401 || code == 403 { return QuotaError.needsLogin }
+        if code == 429 { return QuotaError.rateLimited }
+        let message = (payload["message"] as? String)
+            ?? (payload["msg"] as? String)
+            ?? "code \(code)"
+        return QuotaError.network("Tencent CGI BFF \(layer) error: \(message)")
     }
 
     private static func isAuthError(_ error: TencentHunyuanError) -> Bool {

--- a/Tests/VibeBarCoreTests/TencentHunyuanParserTests.swift
+++ b/Tests/VibeBarCoreTests/TencentHunyuanParserTests.swift
@@ -207,4 +207,78 @@ final class TencentHunyuanParserTests: XCTestCase {
             }
         }
     }
+
+    func testParsesCgiBffEnvelope() throws {
+        // TokenHub-era `console.cloud.tencent.com/cgi/capi?cmd=DescribePkg`
+        // wraps the legacy `{Response: ...}` payload in
+        // `{code, data: {code, cgwerrorCode, data: <inner>}}`. The parser
+        // must peel both wrappers transparently and still surface the
+        // same three windows.
+        let json = """
+        {
+          "code": 0,
+          "data": {
+            "code": 0,
+            "cgwerrorCode": 0,
+            "data": {
+              "Response": {
+                "RequestId": "req-cgi-1",
+                "PkgList": [
+                  {
+                    "PkgName": "Coding Plan Pro",
+                    "PkgType": "pro",
+                    "UsageDetail": {
+                      "PerFiveHour": {
+                        "Total": 6000, "Used": 0, "UsagePercent": 0,
+                        "EndTime": "2026-05-18 14:14:55"
+                      },
+                      "PerWeek": {
+                        "Total": 45000, "Used": 0, "UsagePercent": 0,
+                        "EndTime": "2026-05-25 00:00:00"
+                      },
+                      "PerMonth": {
+                        "Total": 90000, "Used": 23830, "UsagePercent": 26.48,
+                        "EndTime": "2026-05-24 00:00:42"
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+        """
+        let snap = try TencentHunyuanResponseParser.parse(data: Data(json.utf8))
+        XCTAssertEqual(snap.planName, "Coding Plan Pro")
+        XCTAssertEqual(snap.buckets.count, 3)
+        XCTAssertEqual(snap.buckets[2].id, "tencentHunyuan.monthly")
+        XCTAssertEqual(snap.buckets[2].usedPercent, 26.48, accuracy: 0.01)
+    }
+
+    func testCgiBffOuter401MapsToNeedsLogin() {
+        let json = """
+        {"code": 401, "message": "session expired", "data": null}
+        """
+        XCTAssertThrowsError(try TencentHunyuanResponseParser.parse(data: Data(json.utf8))) { error in
+            guard let qe = error as? QuotaError, case .needsLogin = qe else {
+                XCTFail("Expected needsLogin, got \(error)")
+                return
+            }
+        }
+    }
+
+    func testCgiBffMiddleNonZeroMapsToNetworkError() {
+        // Outer code 0 but middle (CGW) code non-zero — typically a
+        // backend gateway hiccup, surface as network error so the UI
+        // shows a retry rather than dragging the user back to login.
+        let json = """
+        {"code": 0, "data": {"code": 9999, "cgwerrorCode": 9999, "msg": "upstream timeout", "data": null}}
+        """
+        XCTAssertThrowsError(try TencentHunyuanResponseParser.parse(data: Data(json.utf8))) { error in
+            guard let qe = error as? QuotaError, case .network = qe else {
+                XCTFail("Expected network error, got \(error)")
+                return
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Summary

- Switch the Tencent Hunyuan / Coding Plan adapter from the legacy
  `console-hc.cloud.tencent.com/_api/hunyuan/DescribePkg` host to the
  new TokenHub-era `console.cloud.tencent.com/cgi/capi?cmd=DescribePkg`
  router. Same cookie jar, same `csrfCode` derivation, same inner
  response body — just wrapped twice in `{code, data}` by the new
  router. The parser peels that wrapper transparently so every
  existing fixture keeps passing.
- Point the misc-providers login flow at the new
  `console.cloud.tencent.com/tokenhub/codingplan` console so the
  cookies users capture come from the platform that will still exist
  after the migration window.

## Background

The `hunyuan.cloud.tencent.com` console (and its dedicated BFF host)
now displays an in-app banner announcing:

- **2026-06-30 00:00** — stop selling: new subscriptions and API key
  creation disabled on the old platform.
- **2026-09-30 00:00** — full shutdown: old console AND API endpoints
  go dark.

I captured the new console's traffic via the in-browser MCP — the new
BFF call is `POST console.cloud.tencent.com/cgi/capi?cmd=DescribePkg&action=delegate&serviceType=hunyuan`
with the same request body shape and the same `Response.PkgList[…]`
payload nested inside `{code:0, data:{code:0, cgwerrorCode:0, data:{Response:…}}}`.
The legacy endpoint still returns 200 today, so this is a safe
ahead-of-deadline migration — no flag-day rush.

## Test plan

- [x] `swift build` — clean
- [x] `swift test` — 304 / 304 (including 2 new tests covering the
      wrapped happy path and outer / middle non-zero code mapping to
      `needsLogin` / `network`)
- [x] `./Scripts/build_app.sh release` — bundles + ad-hoc signs
- [x] `codesign -d --entitlements - ".build/Vibe Bar.app"` — empty
      `<dict/>` plist (sandbox stays off as required)
- [x] `codesign --verify --deep --strict ".build/Vibe Bar.app"` — OK
- [ ] Manual: capture cookies via the new TokenHub login flow on a
      live account and confirm the popover shows the same 5h / week /
      month buckets the console shows (best done by AQ from a live
      Tencent sub-user).

🤖 Generated with [Claude Code](https://claude.com/claude-code)