### PR TITLE
Finish TokenHub rebrand in popover console link and login UI

### DIFF
--- a/Sources/VibeBarApp/MiscWebLoginController.swift
+++ b/Sources/VibeBarApp/MiscWebLoginController.swift
@@ -691,7 +691,7 @@ final class MiscWebLoginRegistry {
                 // enumerate from JS.
                 requiredCookieNames: [],
                 trustedAuthHostSuffixes: [
-                    // Tencent Cloud console + Hunyuan console.
+                    // Tencent Cloud console + TokenHub / legacy Hunyuan console.
                     "cloud.tencent.com",
                     "tencent.com",
                     "qq.com",                     // QQ login + assets
@@ -701,9 +701,9 @@ final class MiscWebLoginRegistry {
                     "captcha.qcloud.com",         // Tencent captcha
                     "captcha.gtimg.com"           // captcha assets
                 ],
-                windowTitle: "Tencent Hunyuan Login",
-                savedConfirmation: "Hunyuan cookies saved.",
-                setupHint: "Sign in to Tencent Cloud (sub-user works), then click Save Cookies."
+                windowTitle: "Tencent Coding Plan Login",
+                savedConfirmation: "Coding Plan cookies saved.",
+                setupHint: "Sign in to Tencent Cloud TokenHub Coding Plan (sub-user works), then click Save Cookies."
             )
         case .alibaba:
             return MiscWebLoginController.Config(

--- a/Sources/VibeBarCore/Models/ToolType.swift
+++ b/Sources/VibeBarCore/Models/ToolType.swift
@@ -196,7 +196,7 @@ public enum ToolType: String, Codable, CaseIterable, Hashable, Sendable {
         case .cursor:      return URL(string: "https://status.cursor.com/")!
         case .mimo:        return URL(string: "https://platform.xiaomimimo.com/")!
         case .iflytek:     return URL(string: "https://maas.xfyun.cn/")!
-        case .tencentHunyuan: return URL(string: "https://hunyuan.cloud.tencent.com/")!
+        case .tencentHunyuan: return URL(string: "https://console.cloud.tencent.com/tokenhub/codingplan")!
         case .volcengine:  return URL(string: "https://console.volcengine.com/ark")!
         case .openCodeGo:  return URL(string: "https://opencode.ai/")!
         case .kilo:        return URL(string: "https://app.kilo.ai/")!


### PR DESCRIPTION
## Summary

[apps#16](https://github.com/AstroQore/vibe-bar/pull/16) migrated the
Tencent adapter to the TokenHub BFF and switched the misc-providers
login flow to `console.cloud.tencent.com/tokenhub/codingplan`. Two
surface-level references still pointed at the old
`hunyuan.cloud.tencent.com` console, which goes dark on **2026-09-30**:

- `ToolType.consoleURL[.tencentHunyuan]` — the deep link the popover
  and mini-window tiles use to send users "to your console" — landed
  on the legacy marketing page.
- The login window title, saved-confirmation string, and setup hint
  still said "Hunyuan" even though the WKWebView now opens
  TokenHub Coding Plan.

This PR finishes the rebrand on both. Credit to the parallel Codex
attempt in a local worktree for catching them; only the URL +
wording fixes from that branch were folded in (the actual BFF
migration is already on `main` from #16).

## Test plan

- [x] `swift build`
- [x] `swift test` — 304 / 304
- [x] `./Scripts/build_app.sh release`
- [x] `codesign -d --entitlements - ".build/Vibe Bar.app"` — empty
      `<dict/>` plist
- [x] `codesign --verify --deep --strict ".build/Vibe Bar.app"` — OK
- [ ] Manual: open the popover, click the Tencent tile, confirm it
      opens `console.cloud.tencent.com/tokenhub/codingplan` in the
      browser; re-capture cookies via the login window and confirm
      title/hint read "Tencent Coding Plan Login".

🤖 Generated with [Claude Code](https://claude.com/claude-code)