### PR TITLE
Allow independent misc provider copies

### DIFF
--- a/Sources/VibeBarApp/AppDelegate.swift
+++ b/Sources/VibeBarApp/AppDelegate.swift
@@ -30,11 +30,19 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             object: nil,
             queue: .main
         ) { [weak environment] notification in
-            guard let environment,
-                  let raw = notification.userInfo?["tool"] as? String,
-                  let tool = ToolType(rawValue: raw),
-                  let account = environment.account(for: tool) else { return }
-            Task { _ = await environment.quotaService.refresh(account) }
+            Task { @MainActor [weak environment] in
+                guard let environment,
+                      let raw = notification.userInfo?["tool"] as? String,
+                      let tool = ToolType(rawValue: raw)
+                else { return }
+
+                if let instanceID = notification.userInfo?["instanceID"] as? String,
+                   let account = environment.accountStore.account(forMiscProviderInstanceID: instanceID) {
+                    _ = await environment.quotaService.refresh(account)
+                } else if let account = environment.account(for: tool) {
+                    _ = await environment.quotaService.refresh(account)
+                }
+            }
         }
     }
 

--- a/Sources/VibeBarApp/AppEnvironment.swift
+++ b/Sources/VibeBarApp/AppEnvironment.swift
@@ -35,7 +35,8 @@ final class AppEnvironment: ObservableObject {
         let settings = SettingsStore()
         let accounts = AccountStore(
             codexUsageMode: settings.codexUsageMode,
-            claudeUsageMode: settings.claudeUsageMode
+            claudeUsageMode: settings.claudeUsageMode,
+            miscProviderInstances: settings.settings.miscProviderInstances
         )
         let service = QuotaService.makeDefault(mockProvider: { [weak settings] in
             settings?.mockEnabled ?? false
@@ -62,10 +63,18 @@ final class AppEnvironment: ObservableObject {
                 if settings.mockEnabled {
                     return MockDataProvider.sampleAccounts()
                 }
-                let visibleTools = ToolType.allCases.filter { tool in
-                    tool.isPrimary || settings.settings.visibleMiscProviders.contains(tool)
+                var visibleAccounts: [AccountIdentity] = []
+                for tool in ToolType.primaryProviders {
+                    if let account = accounts.accounts(for: tool).first {
+                        visibleAccounts.append(account)
+                    }
                 }
-                return visibleTools.compactMap { accounts.accounts(for: $0).first }
+                for instance in settings.settings.visibleMiscProviderInstances {
+                    if let account = accounts.account(forMiscProviderInstanceID: instance.id) {
+                        visibleAccounts.append(account)
+                    }
+                }
+                return visibleAccounts
             },
             intervalProvider: { [weak settings] in
                 settings?.refreshIntervalSeconds ?? AppSettings.default.refreshIntervalSeconds
@@ -88,12 +97,13 @@ final class AppEnvironment: ObservableObject {
                     && $0.mockEnabled == $1.mockEnabled
                     && $0.codexUsageMode == $1.codexUsageMode
                     && $0.claudeUsageMode == $1.claudeUsageMode
-                    && $0.visibleMiscProviders == $1.visibleMiscProviders
+                    && $0.miscProviderInstances == $1.miscProviderInstances
             }
             .sink { [weak self] settings in
                 self?.accountStore.reload(
                     codexUsageMode: settings.codexUsageMode,
-                    claudeUsageMode: settings.claudeUsageMode
+                    claudeUsageMode: settings.claudeUsageMode,
+                    miscProviderInstances: settings.miscProviderInstances
                 )
                 self?.recheckPrimaryRouteHealth()
                 self?.scheduler.reschedule()
@@ -173,8 +183,20 @@ final class AppEnvironment: ObservableObject {
         return accountStore.accounts(for: tool).first
     }
 
+    func account(for instance: MiscProviderInstance) -> AccountIdentity? {
+        if settingsStore.mockEnabled {
+            return MockDataProvider.sampleAccounts().first { $0.tool == instance.tool }
+        }
+        return accountStore.account(forMiscProviderInstanceID: instance.id)
+    }
+
     func quota(for tool: ToolType) -> AccountQuota? {
         guard let account = account(for: tool) else { return nil }
+        return quotaService.cachedQuota(for: account.id)
+    }
+
+    func quota(for instance: MiscProviderInstance) -> AccountQuota? {
+        guard let account = account(for: instance) else { return nil }
         return quotaService.cachedQuota(for: account.id)
     }
 
@@ -188,7 +210,8 @@ final class AppEnvironment: ObservableObject {
         importClaudeBrowserCookiesAndRefreshIfNeeded()
         accountStore.reload(
             codexUsageMode: settingsStore.settings.codexUsageMode,
-            claudeUsageMode: settingsStore.claudeUsageMode
+            claudeUsageMode: settingsStore.claudeUsageMode,
+            miscProviderInstances: settingsStore.settings.miscProviderInstances
         )
         // Cookies may have changed (login / re-login) — drop any stale
         // 1h failure cooldowns so the routine WebView probe gets a fresh
@@ -220,13 +243,21 @@ final class AppEnvironment: ObservableObject {
         recheckPrimaryRouteHealth(provider: tool)
         accountStore.reload(
             codexUsageMode: settingsStore.settings.codexUsageMode,
-            claudeUsageMode: settingsStore.claudeUsageMode
+            claudeUsageMode: settingsStore.claudeUsageMode,
+            miscProviderInstances: settingsStore.settings.miscProviderInstances
         )
         let account = account(for: tool)
         Task { @MainActor in
             if let account {
                 _ = await quotaService.refresh(account)
             }
+        }
+    }
+
+    func refresh(_ instance: MiscProviderInstance) {
+        guard let account = account(for: instance) else { return }
+        Task { @MainActor in
+            _ = await quotaService.refresh(account)
         }
     }
 
@@ -264,8 +295,12 @@ final class AppEnvironment: ObservableObject {
     /// which SweetCookieKit doesn't read). After save, kicks a one-shot
     /// quota refresh so the misc card flips out of "Set up" state.
     func openMiscWebLogin(for tool: ToolType) {
-        guard let account = account(for: tool) else { return }
-        miscWebLoginRegistry.openLogin(for: tool) { [weak self] in
+        openMiscWebLogin(for: tool, instanceID: tool.rawValue)
+    }
+
+    func openMiscWebLogin(for tool: ToolType, instanceID: String) {
+        guard let account = accountStore.account(forMiscProviderInstanceID: instanceID) else { return }
+        miscWebLoginRegistry.openLogin(for: tool, instanceID: instanceID) { [weak self] in
             guard let self else { return }
             Task { _ = await self.quotaService.refresh(account) }
         }
@@ -297,7 +332,8 @@ final class AppEnvironment: ObservableObject {
             guard didImport, !hadCookies else { return }
             self.accountStore.reload(
                 codexUsageMode: self.settingsStore.settings.codexUsageMode,
-                claudeUsageMode: self.settingsStore.claudeUsageMode
+                claudeUsageMode: self.settingsStore.claudeUsageMode,
+                miscProviderInstances: self.settingsStore.settings.miscProviderInstances
             )
             self.lastRoutineBudgetAttemptByAccount.removeAll()
             self.scheduler.triggerRefresh()
@@ -343,7 +379,8 @@ final class AppEnvironment: ObservableObject {
             }
             self.accountStore.reload(
                 codexUsageMode: self.settingsStore.settings.codexUsageMode,
-                claudeUsageMode: self.settingsStore.claudeUsageMode
+                claudeUsageMode: self.settingsStore.claudeUsageMode,
+                miscProviderInstances: self.settingsStore.settings.miscProviderInstances
             )
             self.lastRoutineBudgetAttemptByAccount.removeAll()
             self.scheduler.triggerRefresh()
@@ -362,7 +399,8 @@ final class AppEnvironment: ObservableObject {
             guard didImport, !hadCookies else { return }
             self.accountStore.reload(
                 codexUsageMode: self.settingsStore.settings.codexUsageMode,
-                claudeUsageMode: self.settingsStore.claudeUsageMode
+                claudeUsageMode: self.settingsStore.claudeUsageMode,
+                miscProviderInstances: self.settingsStore.settings.miscProviderInstances
             )
             self.scheduler.triggerRefresh()
         }
@@ -407,7 +445,8 @@ final class AppEnvironment: ObservableObject {
             }
             self.accountStore.reload(
                 codexUsageMode: self.settingsStore.settings.codexUsageMode,
-                claudeUsageMode: self.settingsStore.claudeUsageMode
+                claudeUsageMode: self.settingsStore.claudeUsageMode,
+                miscProviderInstances: self.settingsStore.settings.miscProviderInstances
             )
             self.scheduler.triggerRefresh()
         }
@@ -426,7 +465,8 @@ final class AppEnvironment: ObservableObject {
             }
             accountStore.reload(
                 codexUsageMode: settingsStore.settings.codexUsageMode,
-                claudeUsageMode: settingsStore.claudeUsageMode
+                claudeUsageMode: settingsStore.claudeUsageMode,
+                miscProviderInstances: settingsStore.settings.miscProviderInstances
             )
             scheduler.triggerRefresh()
             return true
@@ -450,7 +490,8 @@ final class AppEnvironment: ObservableObject {
             }
             accountStore.reload(
                 codexUsageMode: settingsStore.settings.codexUsageMode,
-                claudeUsageMode: settingsStore.claudeUsageMode
+                claudeUsageMode: settingsStore.claudeUsageMode,
+                miscProviderInstances: settingsStore.settings.miscProviderInstances
             )
             scheduler.triggerRefresh()
             return true

--- a/Sources/VibeBarApp/HiddenCookieRefresher.swift
+++ b/Sources/VibeBarApp/HiddenCookieRefresher.swift
@@ -116,30 +116,46 @@ final class HiddenCookieRefresher {
     }
 
     private func performRefresh(_ config: Config) async -> Bool {
-        let slots = MiscCookieSlotStore.slots(for: config.tool)
-            .filter { $0.origin != .manual }
-        guard !slots.isEmpty else {
+        let settings = (try? VibeBarLocalStore.readJSON(
+            AppSettings.self,
+            from: VibeBarLocalStore.settingsURL
+        )) ?? .default
+        let targets = settings.miscProviderInstances
+            .filter { $0.tool == config.tool }
+            .flatMap { instance in
+                MiscCookieSlotStore.slots(for: config.tool, instanceID: instance.id)
+                    .filter { $0.origin != .manual }
+                    .map { RefreshTarget(instanceID: instance.id, slot: $0) }
+            }
+        guard !targets.isEmpty else {
             SafeLog.info("HiddenCookieRefresher skip tool=\(config.tool.rawValue) — no browser-origin slots")
             return false
         }
 
         var anyChanged = false
-        for slot in slots {
-            if await performRefreshForSlot(config, slot: slot) {
+        var changedInstanceIDs: Set<String> = []
+        for target in targets {
+            if await performRefreshForSlot(config, instanceID: target.instanceID, slot: target.slot) {
                 anyChanged = true
+                changedInstanceIDs.insert(target.instanceID)
             }
         }
-        if anyChanged {
+        for instanceID in changedInstanceIDs {
             NotificationCenter.default.post(
                 name: .cookiesRefreshed,
                 object: nil,
-                userInfo: ["tool": config.tool.rawValue]
+                userInfo: ["tool": config.tool.rawValue, "instanceID": instanceID]
             )
         }
         return anyChanged
     }
 
-    private func performRefreshForSlot(_ config: Config, slot: MiscCookieSlot) async -> Bool {
+    private struct RefreshTarget {
+        var instanceID: String
+        var slot: MiscCookieSlot
+    }
+
+    private func performRefreshForSlot(_ config: Config, instanceID: String, slot: MiscCookieSlot) async -> Bool {
         let beforeHeader = slot.cookieHeader
         let beforeFingerprint = headerFingerprint(beforeHeader)
         SafeLog.info(
@@ -186,6 +202,7 @@ final class HiddenCookieRefresher {
                         try? await Task.sleep(nanoseconds: UInt64(config.postLoadWait * 1_000_000_000))
                         let captured = await self.captureAndUpdateSlot(
                             config,
+                            instanceID: instanceID,
                             slot: slot,
                             store: dataStore.httpCookieStore,
                             beforeFingerprint: beforeFingerprint
@@ -211,6 +228,7 @@ final class HiddenCookieRefresher {
     }
 
     private func captureAndUpdateSlot(_ config: Config,
+                                      instanceID: String,
                                       slot: MiscCookieSlot,
                                       store: WKHTTPCookieStore,
                                       beforeFingerprint: String) async -> Bool {
@@ -235,6 +253,7 @@ final class HiddenCookieRefresher {
         return MiscCookieSlotStore.updateHeader(
             slotID: slot.id,
             for: config.tool,
+            instanceID: instanceID,
             header: header,
             sourceLabel: "Auto-refresh",
             origin: .autoRefresh

--- a/Sources/VibeBarApp/MiscWebLoginController.swift
+++ b/Sources/VibeBarApp/MiscWebLoginController.swift
@@ -40,6 +40,7 @@ final class MiscWebLoginController: NSObject, NSWindowDelegate, WKNavigationDele
     }
 
     private let config: Config
+    private let instanceID: String
     private var window: NSWindow?
     private var webView: WKWebView?
     private var popupWindow: NSWindow?
@@ -50,8 +51,9 @@ final class MiscWebLoginController: NSObject, NSWindowDelegate, WKNavigationDele
     private let websiteDataStore = WKWebsiteDataStore.default()
     private var autofillBridges: [MiscWebLoginAutofillBridge] = []
 
-    init(config: Config) {
+    init(config: Config, instanceID: String) {
         self.config = config
+        self.instanceID = instanceID
         super.init()
     }
 
@@ -166,7 +168,7 @@ final class MiscWebLoginController: NSObject, NSWindowDelegate, WKNavigationDele
             importedAt: Date(),
             origin: .browserImport
         )
-        let stored = MiscCookieSlotStore.append(slot, for: config.tool)
+        let stored = MiscCookieSlotStore.append(slot, for: config.tool, instanceID: instanceID)
         guard stored else {
             if manual {
                 showAlert(message: "Could not save \(config.tool.menuTitle) cookies to Keychain.")
@@ -617,7 +619,7 @@ final class MiscWebLoginAutofillBridge: NSObject, WKScriptMessageHandler {
 /// SwiftUI view re-renders.
 @MainActor
 final class MiscWebLoginRegistry {
-    private var controllers: [ToolType: MiscWebLoginController] = [:]
+    private var controllers: [String: MiscWebLoginController] = [:]
 
     /// Returns `true` if a webview-login flow is configured for `tool`.
     /// Used by the Settings UI to decide whether to render a "Sign in
@@ -626,10 +628,10 @@ final class MiscWebLoginRegistry {
         config(for: tool) != nil
     }
 
-    func openLogin(for tool: ToolType, onSaved: @escaping () -> Void) {
+    func openLogin(for tool: ToolType, instanceID: String, onSaved: @escaping () -> Void) {
         guard let config = Self.config(for: tool) else { return }
-        let controller = controllers[tool] ?? MiscWebLoginController(config: config)
-        controllers[tool] = controller
+        let controller = controllers[instanceID] ?? MiscWebLoginController(config: config, instanceID: instanceID)
+        controllers[instanceID] = controller
         controller.open(onSaved: onSaved)
     }
 

--- a/Sources/VibeBarApp/Views/MiscProviderSettingsSection.swift
+++ b/Sources/VibeBarApp/Views/MiscProviderSettingsSection.swift
@@ -8,13 +8,22 @@ import VibeBarCore
 /// provider's current integration path (API key, device login, local
 /// CLI/OAuth status, browser-cookie import, or local process probe).
 struct MiscProviderSettingsSection: View {
-    let tool: ToolType
+    let instance: MiscProviderInstance
 
+    @EnvironmentObject var environment: AppEnvironment
     @EnvironmentObject var settingsStore: SettingsStore
+
+    private var tool: ToolType { instance.tool }
+    private var instanceID: String { instance.id }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
             HStack(alignment: .center, spacing: 8) {
+                Image(systemName: "line.3.horizontal")
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(.tertiary)
+                    .frame(width: 14)
+                    .help("Drag to reorder")
                 Toggle(isOn: visibilityBinding) {
                     EmptyView()
                 }
@@ -24,26 +33,32 @@ struct MiscProviderSettingsSection: View {
                 ToolBrandBadge(tool: tool, iconSize: 17, containerSize: 24)
                 Text(tool.menuTitle)
                     .font(.system(size: 13, weight: .semibold))
+                if copyCount > 1 {
+                    CopyNameField(
+                        instanceID: instanceID,
+                        fallback: "Copy \(copyIndex)"
+                    )
+                }
                 Text(tool.subtitle)
                     .font(.caption)
                     .foregroundStyle(.tertiary)
                 Spacer(minLength: 8)
                 BorderlessIconButton(
-                    systemImage: "chevron.up",
-                    help: "Move \(tool.menuTitle) up",
+                    systemImage: "doc.on.doc",
+                    help: "Clone \(tool.menuTitle)",
                     size: 10
                 ) {
-                    settingsStore.settings.moveMiscProvider(tool, offset: -1)
+                    _ = settingsStore.settings.cloneMiscProviderInstance(id: instanceID)
                 }
-                .disabled(isFirst)
-                BorderlessIconButton(
-                    systemImage: "chevron.down",
-                    help: "Move \(tool.menuTitle) down",
-                    size: 10
-                ) {
-                    settingsStore.settings.moveMiscProvider(tool, offset: 1)
+                if !instance.isDefault {
+                    BorderlessIconButton(
+                        systemImage: "trash",
+                        help: "Remove this \(tool.menuTitle) copy",
+                        size: 10
+                    ) {
+                        removeClone()
+                    }
                 }
-                .disabled(isLast)
             }
             placeholderRow
         }
@@ -57,24 +72,29 @@ struct MiscProviderSettingsSection: View {
 
     private var visibilityBinding: Binding<Bool> {
         Binding(
-            get: { settingsStore.settings.isMiscProviderVisible(tool) },
+            get: { settingsStore.settings.miscProviderInstance(id: instanceID)?.isVisible ?? false },
             set: { value in
-                settingsStore.settings.setMiscProviderVisible(value, for: tool)
+                settingsStore.settings.setMiscProviderInstanceVisible(value, forID: instanceID)
             }
         )
     }
 
-    private var orderIndex: Int? {
-        settingsStore.settings.miscProviderOrderIndex(tool)
+    private var copyCount: Int {
+        settingsStore.settings.miscProviderInstances.filter { $0.tool == tool }.count
     }
 
-    private var isFirst: Bool {
-        orderIndex == 0
+    private var copyIndex: Int {
+        let sameTool = settingsStore.settings.miscProviderInstances.filter { $0.tool == tool }
+        return (sameTool.firstIndex { $0.id == instanceID } ?? 0) + 1
     }
 
-    private var isLast: Bool {
-        guard let orderIndex else { return true }
-        return orderIndex >= settingsStore.settings.miscProviderOrder.count - 1
+    private func removeClone() {
+        guard let removed = settingsStore.settings.removeMiscProviderInstance(id: instanceID) else { return }
+        MiscCookieSlotStore.deleteAll(for: removed.tool, instanceID: removed.id)
+        MiscCredentialStore.clearAll(for: removed.tool, instanceID: removed.id)
+        if let account = environment.accountStore.account(forMiscProviderInstanceID: removed.id) {
+            environment.quotaService.clear(accountId: account.id)
+        }
     }
 
     @ViewBuilder
@@ -82,31 +102,34 @@ struct MiscProviderSettingsSection: View {
         switch tool {
         case .zai:
             VStack(alignment: .leading, spacing: 4) {
-                ApiKeyField(tool: .zai, prompt: "Paste Z.ai API key (zai-...)", helpText: "Find it under z.ai → API Keys. Stored in macOS Keychain.")
-                ZaiRegionPicker()
+                ApiKeyField(tool: .zai, instanceID: instanceID, prompt: "Paste Z.ai API key (zai-...)", helpText: "Find it under z.ai → API Keys. Stored in macOS Keychain.")
+                ZaiRegionPicker(instanceID: instanceID)
             }
         case .copilot:
             VStack(alignment: .leading, spacing: 4) {
-                CopilotDeviceLoginRow()
-                EnterpriseHostField(tool: .copilot, prompt: "GitHub Enterprise host (optional, e.g. github.example.com)")
+                CopilotDeviceLoginRow(instanceID: instanceID)
+                EnterpriseHostField(tool: .copilot, instanceID: instanceID, prompt: "GitHub Enterprise host (optional, e.g. github.example.com)")
             }
         case .gemini:
-            GeminiCredentialStatusRow()
+            GeminiCredentialStatusRow(instanceID: instanceID)
         case .alibaba:
             VStack(alignment: .leading, spacing: 4) {
                 ApiKeyField(
                     tool: .alibaba,
+                    instanceID: instanceID,
                     prompt: "Paste DashScope API key (sk-...) — optional",
                     helpText: "If you have a DashScope key, paste it here. Otherwise sign in via Web below to use console cookies. Stored in macOS Keychain."
                 )
-                AlibabaRegionPicker()
+                AlibabaRegionPicker(instanceID: instanceID)
                 CookieSourceControls(
                     tool: .alibaba,
+                    instanceID: instanceID,
                     spec: AlibabaQuotaAdapter.cookieSpec,
                     manualPrompt: "Paste console.aliyun.com Cookie header (login_aliyunid_csrf=…; cna=…; …)"
                 )
                 MiscWebLoginRow(
                     tool: .alibaba,
+                    instanceID: instanceID,
                     helpText: "No DashScope key? Sign in to bailian.console.aliyun.com or modelstudio.console.alibabacloud.com once via Web; Vibe Bar refreshes the console session in the background after that."
                 )
             }
@@ -114,20 +137,23 @@ struct MiscProviderSettingsSection: View {
             VStack(alignment: .leading, spacing: 4) {
                 ApiKeyField(
                     tool: .minimax,
+                    instanceID: instanceID,
                     prompt: "Paste MiniMax Token Plan API key (sk-cp-... or MINIMAX_CODING_API_KEY)",
                     helpText: "Find it under Billing → Token Plan. Stored in macOS Keychain. Env fallback: MINIMAX_CODING_API_KEY, then MINIMAX_API_KEY."
                 )
-                MiniMaxRegionPicker()
+                MiniMaxRegionPicker(instanceID: instanceID)
             }
         case .kimi:
             CookieSourceControls(
                 tool: .kimi,
+                instanceID: instanceID,
                 spec: KimiQuotaAdapter.cookieSpec,
                 manualPrompt: "Paste www.kimi.com Cookie header (kimi-auth=eyJ...)"
             )
         case .cursor:
             CookieSourceControls(
                 tool: .cursor,
+                instanceID: instanceID,
                 spec: CursorQuotaAdapter.cookieSpec,
                 manualPrompt: "Paste cursor.com Cookie header (WorkosCursorSessionToken=...)"
             )
@@ -135,17 +161,20 @@ struct MiscProviderSettingsSection: View {
             VStack(alignment: .leading, spacing: 4) {
                 CookieSourceControls(
                     tool: .mimo,
+                    instanceID: instanceID,
                     spec: MimoQuotaAdapter.cookieSpec,
                     manualPrompt: "Paste platform.xiaomimimo.com Cookie header (userId=...; api-platform_slh=...; api-platform_ph=...; api-platform_serviceToken=...)"
                 )
                 MiscWebLoginRow(
                     tool: .mimo,
+                    instanceID: instanceID,
                     helpText: "Chrome's newer cookie encryption blocks the browser-import path on macOS. Sign in via the in-app webview to capture cookies cleanly."
                 )
             }
         case .iflytek:
             CookieSourceControls(
                 tool: .iflytek,
+                instanceID: instanceID,
                 spec: IFlyTekQuotaAdapter.cookieSpec,
                 manualPrompt: "Paste maas.xfyun.cn Cookie header (atp-auth-token=…; account_id=…; ssoSessionId=…; tenantToken=…)"
             )
@@ -153,11 +182,13 @@ struct MiscProviderSettingsSection: View {
             VStack(alignment: .leading, spacing: 4) {
                 CookieSourceControls(
                     tool: .tencentHunyuan,
+                    instanceID: instanceID,
                     spec: TencentHunyuanQuotaAdapter.cookieSpec,
                     manualPrompt: "Paste cloud.tencent.com Cookie header (skey=…; uin=…; …)"
                 )
                 MiscWebLoginRow(
                     tool: .tencentHunyuan,
+                    instanceID: instanceID,
                     helpText: "Tencent's `skey` cookie expires within hours. When the card flips to \"Needs re-login\", click here to refresh the session."
                 )
             }
@@ -165,11 +196,13 @@ struct MiscProviderSettingsSection: View {
             VStack(alignment: .leading, spacing: 4) {
                 CookieSourceControls(
                     tool: .volcengine,
+                    instanceID: instanceID,
                     spec: VolcengineQuotaAdapter.cookieSpec,
                     manualPrompt: "Paste console.volcengine.com Cookie header (csrfToken=…; AccountID=…; …)"
                 )
                 MiscWebLoginRow(
                     tool: .volcengine,
+                    instanceID: instanceID,
                     helpText: "Volcengine console session cookies expire after a few hours. When the card flips to \"Needs re-login\", click here to refresh."
                 )
             }
@@ -177,25 +210,29 @@ struct MiscProviderSettingsSection: View {
             VStack(alignment: .leading, spacing: 4) {
                 CookieSourceControls(
                     tool: .openCodeGo,
+                    instanceID: instanceID,
                     spec: OpenCodeGoQuotaAdapter.cookieSpec,
                     manualPrompt: "Paste opencode.ai Cookie header (__Host-auth=... or auth=...)"
                 )
                 WorkspaceIDField(
                     tool: .openCodeGo,
+                    instanceID: instanceID,
                     prompt: "Workspace ID or URL (optional, wrk_... or /workspace/wrk_.../go)"
                 )
             }
         case .kilo:
             ApiKeyField(
                 tool: .kilo,
+                instanceID: instanceID,
                 prompt: "Paste Kilo API key (optional)",
                 helpText: "Optional. Vibe Bar also reads ~/.local/share/kilo/auth.json after `kilo login`. Env fallback: KILO_API_KEY."
             )
         case .kiro:
-            KiroStatusRow()
+            KiroStatusRow(instanceID: instanceID)
         case .ollama:
             CookieSourceControls(
                 tool: .ollama,
+                instanceID: instanceID,
                 spec: OllamaQuotaAdapter.cookieSpec,
                 manualPrompt: "Paste ollama.com Cookie header (session=... or next-auth.session-token=...)"
             )
@@ -203,16 +240,18 @@ struct MiscProviderSettingsSection: View {
             VStack(alignment: .leading, spacing: 4) {
                 ApiKeyField(
                     tool: .openRouter,
+                    instanceID: instanceID,
                     prompt: "Paste OpenRouter API key (sk-or-v1-...)",
                     helpText: "Stored in macOS Keychain. Env fallback: OPENROUTER_API_KEY."
                 )
-                EnterpriseHostField(tool: .openRouter, prompt: "OpenRouter API URL (optional, defaults to https://openrouter.ai/api/v1)")
+                EnterpriseHostField(tool: .openRouter, instanceID: instanceID, prompt: "OpenRouter API URL (optional, defaults to https://openrouter.ai/api/v1)")
             }
         case .antigravity:
-            AntigravityStatusRow()
+            AntigravityStatusRow(instanceID: instanceID)
         case .warp:
             ApiKeyField(
                 tool: .warp,
+                instanceID: instanceID,
                 prompt: "Paste Warp API key (wk-...)",
                 helpText: "Open Warp → Settings → AI → API Keys to mint one. Stored in macOS Keychain. Env fallback: WARP_API_KEY, then WARP_TOKEN."
             )
@@ -223,6 +262,46 @@ struct MiscProviderSettingsSection: View {
 
 }
 
+private struct CopyNameField: View {
+    let instanceID: String
+    let fallback: String
+
+    @EnvironmentObject var settingsStore: SettingsStore
+    @FocusState private var isFocused: Bool
+    @State private var draft: String = ""
+
+    var body: some View {
+        TextField(fallback, text: $draft)
+            .textFieldStyle(.roundedBorder)
+            .controlSize(.small)
+            .font(.caption2)
+            .frame(width: 120)
+            .focused($isFocused)
+            .help("Rename this copy")
+            .onAppear(perform: syncDraft)
+            .onSubmit(save)
+            .onChange(of: isFocused) { _, focused in
+                if !focused { save() }
+            }
+            .onChange(of: currentDisplayName) { _, _ in
+                if !isFocused { syncDraft() }
+            }
+    }
+
+    private var currentDisplayName: String {
+        settingsStore.settings.miscProviderInstance(id: instanceID)?.displayName ?? ""
+    }
+
+    private func syncDraft() {
+        draft = currentDisplayName
+    }
+
+    private func save() {
+        settingsStore.settings.setMiscProviderInstanceDisplayName(draft, forID: instanceID)
+        syncDraft()
+    }
+}
+
 /// Secure-text input for misc-provider API keys / PATs.
 ///
 /// Reads/writes through `MiscCredentialStore` (Keychain) — the
@@ -231,6 +310,7 @@ struct MiscProviderSettingsSection: View {
 /// the misc card flips out of "Set up" state immediately.
 struct ApiKeyField: View {
     let tool: ToolType
+    let instanceID: String
     let prompt: String
     let helpText: String
 
@@ -269,13 +349,13 @@ struct ApiKeyField: View {
                     .foregroundStyle(.orange)
             }
         }
-        .onAppear { hasStored = MiscCredentialStore.hasValue(tool: tool, kind: .apiKey) }
+        .onAppear { hasStored = MiscCredentialStore.hasValue(tool: tool, kind: .apiKey, instanceID: instanceID) }
     }
 
     private func save() {
         let trimmed = draft.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return }
-        let ok = MiscCredentialStore.writeString(trimmed, tool: tool, kind: .apiKey)
+        let ok = MiscCredentialStore.writeString(trimmed, tool: tool, kind: .apiKey, instanceID: instanceID)
         if ok {
             saveError = nil
             hasStored = true
@@ -287,13 +367,13 @@ struct ApiKeyField: View {
     }
 
     private func clear() {
-        MiscCredentialStore.delete(tool: tool, kind: .apiKey)
+        MiscCredentialStore.delete(tool: tool, kind: .apiKey, instanceID: instanceID)
         hasStored = false
         triggerRefresh()
     }
 
     private func triggerRefresh() {
-        guard let account = environment.account(for: tool) else { return }
+        guard let account = environment.accountStore.account(forMiscProviderInstanceID: instanceID) else { return }
         Task { _ = await quotaService.refresh(account) }
     }
 }
@@ -302,6 +382,8 @@ struct ApiKeyField: View {
 /// old PAT-first setup while keeping legacy PATs readable in Core as
 /// a migration fallback.
 struct CopilotDeviceLoginRow: View {
+    let instanceID: String
+
     @EnvironmentObject var environment: AppEnvironment
     @EnvironmentObject var quotaService: QuotaService
     @EnvironmentObject var settingsStore: SettingsStore
@@ -359,7 +441,7 @@ struct CopilotDeviceLoginRow: View {
                 reloadStoredToken()
             }
 
-            let host = settingsStore.settings.miscProvider(.copilot).enterpriseHost?.absoluteString
+            let host = settingsStore.settings.miscProviderSettings(forInstanceID: instanceID).enterpriseHost?.absoluteString
             let flow = CopilotDeviceFlow(enterpriseHost: host)
             do {
                 let code = try await flow.requestDeviceCode()
@@ -378,18 +460,19 @@ struct CopilotDeviceLoginRow: View {
                 guard MiscCredentialStore.writeString(
                     token,
                     tool: .copilot,
-                    kind: .oauthAccessToken
+                    kind: .oauthAccessToken,
+                    instanceID: instanceID
                 ) else {
                     status = "GitHub login succeeded, but Vibe Bar could not save the token."
                     return
                 }
-                guard MiscCredentialStore.hasValue(tool: .copilot, kind: .oauthAccessToken) else {
+                guard MiscCredentialStore.hasValue(tool: .copilot, kind: .oauthAccessToken, instanceID: instanceID) else {
                     status = "GitHub login succeeded, but saved token could not be read back."
                     return
                 }
 
                 // Hide the old PAT path once device auth succeeds.
-                MiscCredentialStore.delete(tool: .copilot, kind: .apiKey)
+                MiscCredentialStore.delete(tool: .copilot, kind: .apiKey, instanceID: instanceID)
                 status = "GitHub signed in."
                 triggerRefresh()
             } catch is CancellationError {
@@ -401,8 +484,8 @@ struct CopilotDeviceLoginRow: View {
     }
 
     private func clearToken() {
-        MiscCredentialStore.delete(tool: .copilot, kind: .oauthAccessToken)
-        MiscCredentialStore.delete(tool: .copilot, kind: .apiKey)
+        MiscCredentialStore.delete(tool: .copilot, kind: .oauthAccessToken, instanceID: instanceID)
+        MiscCredentialStore.delete(tool: .copilot, kind: .apiKey, instanceID: instanceID)
         hasStoredToken = false
         status = "GitHub token cleared."
         triggerRefresh()
@@ -410,12 +493,12 @@ struct CopilotDeviceLoginRow: View {
 
     private func reloadStoredToken() {
         hasStoredToken =
-            MiscCredentialStore.hasValue(tool: .copilot, kind: .oauthAccessToken) ||
-            MiscCredentialStore.hasValue(tool: .copilot, kind: .apiKey)
+            MiscCredentialStore.hasValue(tool: .copilot, kind: .oauthAccessToken, instanceID: instanceID) ||
+            MiscCredentialStore.hasValue(tool: .copilot, kind: .apiKey, instanceID: instanceID)
     }
 
     private func triggerRefresh() {
-        guard let account = environment.account(for: .copilot) else { return }
+        guard let account = environment.accountStore.account(forMiscProviderInstanceID: instanceID) else { return }
         Task { _ = await quotaService.refresh(account) }
     }
 }
@@ -427,6 +510,8 @@ struct CopilotDeviceLoginRow: View {
 /// `cloudcode-pa.googleapis.com` — there's no value to enter here,
 /// just a status indicator and a "re-check" button.
 struct GeminiCredentialStatusRow: View {
+    let instanceID: String
+
     @EnvironmentObject var environment: AppEnvironment
     @EnvironmentObject var quotaService: QuotaService
     @State private var status: Status = .unknown
@@ -502,7 +587,7 @@ struct GeminiCredentialStatusRow: View {
 
     private func refresh() {
         reload()
-        guard let account = environment.account(for: .gemini) else { return }
+        guard let account = environment.accountStore.account(forMiscProviderInstanceID: instanceID) else { return }
         Task { _ = await quotaService.refresh(account) }
     }
 
@@ -520,6 +605,8 @@ struct GeminiCredentialStatusRow: View {
 /// indicator + manual refresh; the real action happens on the misc
 /// card itself.
 struct AntigravityStatusRow: View {
+    let instanceID: String
+
     @EnvironmentObject var environment: AppEnvironment
     @EnvironmentObject var quotaService: QuotaService
 
@@ -539,7 +626,7 @@ struct AntigravityStatusRow: View {
     }
 
     private func probe() {
-        guard let account = environment.account(for: .antigravity) else { return }
+        guard let account = environment.accountStore.account(forMiscProviderInstanceID: instanceID) else { return }
         Task { _ = await quotaService.refresh(account) }
     }
 }
@@ -548,6 +635,8 @@ struct AntigravityStatusRow: View {
 /// but points users at the login command that creates the usable
 /// session.
 struct KiroStatusRow: View {
+    let instanceID: String
+
     @EnvironmentObject var environment: AppEnvironment
     @EnvironmentObject var quotaService: QuotaService
 
@@ -567,7 +656,7 @@ struct KiroStatusRow: View {
     }
 
     private func probe() {
-        guard let account = environment.account(for: .kiro) else { return }
+        guard let account = environment.accountStore.account(forMiscProviderInstanceID: instanceID) else { return }
         Task { _ = await quotaService.refresh(account) }
     }
 }
@@ -582,6 +671,7 @@ struct KiroStatusRow: View {
 /// averaged; see `MiscQuotaAggregator`.
 struct CookieSourceControls: View {
     let tool: ToolType
+    let instanceID: String
     let spec: MiscCookieResolver.Spec
     let manualPrompt: String
 
@@ -630,20 +720,23 @@ struct CookieSourceControls: View {
             for: MiscCookieSlotStore.didChangeNotification
         )) { note in
             guard let raw = note.userInfo?["tool"] as? String,
-                  raw == tool.rawValue else { return }
+                  raw == tool.rawValue,
+                  let changedInstanceID = note.userInfo?["instanceID"] as? String,
+                  changedInstanceID == instanceID else { return }
             reloadSlots()
         }
     }
 
     private func reloadSlots() {
-        slots = MiscCookieSlotStore.slots(for: tool)
+        slots = MiscCookieSlotStore.slots(for: tool, instanceID: instanceID)
     }
 
     private func importNow() {
         importStatus = "Importing…"
         let snapshotSpec = spec
+        let snapshotInstanceID = instanceID
         DispatchQueue.global(qos: .userInitiated).async {
-            let result = MiscCookieResolver.appendBrowserImport(for: snapshotSpec)
+            let result = MiscCookieResolver.appendBrowserImport(for: snapshotSpec, instanceID: snapshotInstanceID)
             DispatchQueue.main.async {
                 if let result {
                     importStatus = "Imported from \(result.sourceLabel)."
@@ -669,7 +762,7 @@ struct CookieSourceControls: View {
             importedAt: Date(),
             origin: .manual
         )
-        guard MiscCookieSlotStore.append(slot, for: tool) else {
+        guard MiscCookieSlotStore.append(slot, for: tool, instanceID: instanceID) else {
             importStatus = "Could not save to Keychain."
             return
         }
@@ -680,7 +773,7 @@ struct CookieSourceControls: View {
     }
 
     private func deleteSlot(_ slot: MiscCookieSlot) {
-        guard MiscCookieSlotStore.delete(slotID: slot.id, for: tool) else { return }
+        guard MiscCookieSlotStore.delete(slotID: slot.id, for: tool, instanceID: instanceID) else { return }
         importStatus = "Removed \(slot.sourceLabel)."
         reloadSlots()
         triggerRefresh()
@@ -701,7 +794,7 @@ struct CookieSourceControls: View {
     }
 
     private func triggerRefresh() {
-        guard let account = environment.account(for: tool) else { return }
+        guard let account = environment.accountStore.account(forMiscProviderInstanceID: instanceID) else { return }
         Task { _ = await quotaService.refresh(account) }
     }
 }
@@ -759,6 +852,8 @@ private struct CookieSlotRow: View {
 /// china-mainland (cn-beijing). "Auto" lets the adapter try both
 /// in order on each refresh.
 struct AlibabaRegionPicker: View {
+    let instanceID: String
+
     @EnvironmentObject var settingsStore: SettingsStore
 
     enum Choice: String, CaseIterable, Identifiable {
@@ -788,13 +883,13 @@ struct AlibabaRegionPicker: View {
     private var choiceBinding: Binding<Choice> {
         Binding(
             get: {
-                let raw = settingsStore.settings.miscProvider(.alibaba).region ?? ""
+                let raw = settingsStore.settings.miscProviderSettings(forInstanceID: instanceID).region ?? ""
                 return Choice(rawValue: raw) ?? .auto
             },
             set: { newValue in
-                var current = settingsStore.settings.miscProvider(.alibaba)
+                var current = settingsStore.settings.miscProviderSettings(forInstanceID: instanceID)
                 current.region = newValue == .auto ? nil : newValue.rawValue
-                settingsStore.settings.setMiscProvider(current, for: .alibaba)
+                settingsStore.settings.setMiscProviderInstanceSettings(current, forID: instanceID)
             }
         )
     }
@@ -802,6 +897,8 @@ struct AlibabaRegionPicker: View {
 
 /// Z.ai has separate international and mainland China quota hosts.
 struct ZaiRegionPicker: View {
+    let instanceID: String
+
     @EnvironmentObject var settingsStore: SettingsStore
 
     enum Choice: String, CaseIterable, Identifiable {
@@ -829,13 +926,13 @@ struct ZaiRegionPicker: View {
     private var choiceBinding: Binding<Choice> {
         Binding(
             get: {
-                let raw = settingsStore.settings.miscProvider(.zai).region ?? Choice.global.rawValue
+                let raw = settingsStore.settings.miscProviderSettings(forInstanceID: instanceID).region ?? Choice.global.rawValue
                 return Choice(rawValue: raw) ?? .global
             },
             set: { newValue in
-                var current = settingsStore.settings.miscProvider(.zai)
+                var current = settingsStore.settings.miscProviderSettings(forInstanceID: instanceID)
                 current.region = newValue.rawValue
-                settingsStore.settings.setMiscProvider(current, for: .zai)
+                settingsStore.settings.setMiscProviderInstanceSettings(current, forID: instanceID)
             }
         )
     }
@@ -845,6 +942,8 @@ struct ZaiRegionPicker: View {
 /// The adapter still falls back across both, but this picker controls
 /// the preferred region tried first.
 struct MiniMaxRegionPicker: View {
+    let instanceID: String
+
     @EnvironmentObject var settingsStore: SettingsStore
 
     enum Choice: String, CaseIterable, Identifiable {
@@ -872,13 +971,13 @@ struct MiniMaxRegionPicker: View {
     private var choiceBinding: Binding<Choice> {
         Binding(
             get: {
-                let raw = settingsStore.settings.miscProvider(.minimax).region ?? Choice.global.rawValue
+                let raw = settingsStore.settings.miscProviderSettings(forInstanceID: instanceID).region ?? Choice.global.rawValue
                 return Choice(rawValue: raw) ?? .global
             },
             set: { newValue in
-                var current = settingsStore.settings.miscProvider(.minimax)
+                var current = settingsStore.settings.miscProviderSettings(forInstanceID: instanceID)
                 current.region = newValue.rawValue
-                settingsStore.settings.setMiscProvider(current, for: .minimax)
+                settingsStore.settings.setMiscProviderInstanceSettings(current, forID: instanceID)
             }
         )
     }
@@ -890,6 +989,7 @@ struct MiniMaxRegionPicker: View {
 /// it through `AppSettings.miscProvider(...).enterpriseHost`.
 struct EnterpriseHostField: View {
     let tool: ToolType
+    let instanceID: String
     let prompt: String
 
     @EnvironmentObject var settingsStore: SettingsStore
@@ -906,11 +1006,11 @@ struct EnterpriseHostField: View {
     }
 
     private var currentRaw: String {
-        settingsStore.settings.miscProvider(tool).enterpriseHost?.absoluteString ?? ""
+        settingsStore.settings.miscProviderSettings(forInstanceID: instanceID).enterpriseHost?.absoluteString ?? ""
     }
 
     private func save() {
-        var current = settingsStore.settings.miscProvider(tool)
+        var current = settingsStore.settings.miscProviderSettings(forInstanceID: instanceID)
         let trimmed = draft.trimmingCharacters(in: .whitespacesAndNewlines)
         if trimmed.isEmpty {
             current.enterpriseHost = nil
@@ -919,7 +1019,7 @@ struct EnterpriseHostField: View {
         } else {
             return
         }
-        settingsStore.settings.setMiscProvider(current, for: tool)
+        settingsStore.settings.setMiscProviderInstanceSettings(current, forID: instanceID)
     }
 }
 
@@ -928,6 +1028,7 @@ struct EnterpriseHostField: View {
 /// URL; the adapter normalizes it at fetch time.
 struct WorkspaceIDField: View {
     let tool: ToolType
+    let instanceID: String
     let prompt: String
 
     @EnvironmentObject var settingsStore: SettingsStore
@@ -953,14 +1054,14 @@ struct WorkspaceIDField: View {
     }
 
     private var currentRaw: String {
-        settingsStore.settings.miscProvider(tool).workspaceID ?? ""
+        settingsStore.settings.miscProviderSettings(forInstanceID: instanceID).workspaceID ?? ""
     }
 
     private func save() {
-        var current = settingsStore.settings.miscProvider(tool)
+        var current = settingsStore.settings.miscProviderSettings(forInstanceID: instanceID)
         let trimmed = draft.trimmingCharacters(in: .whitespacesAndNewlines)
         current.workspaceID = trimmed.isEmpty ? nil : trimmed
-        settingsStore.settings.setMiscProvider(current, for: tool)
+        settingsStore.settings.setMiscProviderInstanceSettings(current, forID: instanceID)
         triggerRefresh()
     }
 
@@ -970,7 +1071,7 @@ struct WorkspaceIDField: View {
     }
 
     private func triggerRefresh() {
-        guard let account = environment.account(for: tool) else { return }
+        guard let account = environment.accountStore.account(forMiscProviderInstanceID: instanceID) else { return }
         Task { _ = await quotaService.refresh(account) }
     }
 }
@@ -980,6 +1081,7 @@ struct WorkspaceIDField: View {
 /// renders for any tool that `MiscWebLoginRegistry` knows how to drive.
 struct MiscWebLoginRow: View {
     let tool: ToolType
+    let instanceID: String
     let helpText: String
 
     @EnvironmentObject var environment: AppEnvironment
@@ -999,7 +1101,7 @@ struct MiscWebLoginRow: View {
                     .fixedSize(horizontal: false, vertical: true)
                 Spacer(minLength: 4)
                 Button("Sign in via Web") {
-                    environment.openMiscWebLogin(for: tool)
+                    environment.openMiscWebLogin(for: tool, instanceID: instanceID)
                 }
                 .buttonStyle(.bordered)
                 .controlSize(.small)

--- a/Sources/VibeBarApp/Views/MiscProvidersPage.swift
+++ b/Sources/VibeBarApp/Views/MiscProvidersPage.swift
@@ -3,59 +3,70 @@ import AppKit
 import VibeBarCore
 
 /// The Misc tab inside the Overview popover. Renders a card for each
-/// provider checked in Misc settings. Hidden providers keep their
-/// credentials/config but don't render cards.
+/// visible provider instance. Multiple visible instances for the same
+/// provider collapse into one provider card with an aggregate state
+/// followed by per-copy states.
 struct MiscProvidersPage: View {
     let density: Theme.Density
 
-    @EnvironmentObject var environment: AppEnvironment
-    @EnvironmentObject var quotaService: QuotaService
     @EnvironmentObject var settingsStore: SettingsStore
 
     var body: some View {
-        // The Misc page is intentionally denser than the primary
-        // overview: every card is reorderable and receives the same
-        // third-width column treatment.
         ColumnMasonryLayout(columns: 3, spacing: density.interSectionSpacing, anchoredItems: 0) {
-            ForEach(settingsStore.settings.visibleMiscProviderList, id: \.self) { tool in
-                MiscProviderCard(tool: tool, density: density)
+            ForEach(providerGroups) { group in
+                if group.instances.count == 1, let instance = group.instances.first {
+                    MiscProviderCard(instance: instance, density: density)
+                } else {
+                    MiscProviderGroupCard(group: group, density: density)
+                }
             }
         }
     }
+
+    private var providerGroups: [MiscProviderInstanceGroup] {
+        var groups: [MiscProviderInstanceGroup] = []
+        for instance in settingsStore.settings.visibleMiscProviderInstances {
+            if let index = groups.firstIndex(where: { $0.tool == instance.tool }) {
+                groups[index].instances.append(instance)
+            } else {
+                groups.append(MiscProviderInstanceGroup(tool: instance.tool, instances: [instance]))
+            }
+        }
+        return groups
+    }
 }
 
-/// Single-provider card on the Misc page. Three states:
-/// - **Set up** — no credential configured. CTA opens Settings.
-/// - **Loaded** — `AccountQuota` carries usage buckets; render them.
-/// - **Error** — adapter returned a `QuotaError`; render its message
-///   as a soft tint.
-struct MiscProviderCard: View {
-    let tool: ToolType
+private struct MiscProviderInstanceGroup: Identifiable {
+    var tool: ToolType
+    var instances: [MiscProviderInstance]
+
+    var id: String { tool.rawValue }
+}
+
+private struct MiscProviderCard: View {
+    let instance: MiscProviderInstance
     let density: Theme.Density
 
     @EnvironmentObject var environment: AppEnvironment
     @EnvironmentObject var quotaService: QuotaService
-    @EnvironmentObject var settingsStore: SettingsStore
+
+    private var tool: ToolType { instance.tool }
+    private var accountID: String { AccountStore.miscAccountId(forInstanceID: instance.id) }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: density.cardSpacing) {
+        MiscProviderCardShell(density: density) {
             header
             Divider().opacity(0.25)
-            content
+            MiscQuotaBody(
+                tool: tool,
+                density: density,
+                quota: environment.quota(for: instance),
+                liveError: quotaService.lastErrorByAccount[accountID],
+                lastUpdated: quotaService.lastUpdatedByAccount[accountID],
+                isCompact: false
+            )
         }
-        .padding(density.cardPadding)
-        .frame(maxWidth: .infinity, alignment: .topLeading)
-        .background(
-            RoundedRectangle(cornerRadius: density.cardCornerRadius, style: .continuous)
-                .fill(.background.tertiary.opacity(0.6))
-        )
-        .overlay(
-            RoundedRectangle(cornerRadius: density.cardCornerRadius, style: .continuous)
-                .stroke(.separator.opacity(0.4), lineWidth: 0.5)
-        )
     }
-
-    // MARK: - Header
 
     private var header: some View {
         HStack(alignment: .center, spacing: 10) {
@@ -68,15 +79,10 @@ struct MiscProviderCard: View {
                 Text(tool.menuTitle)
                     .font(.system(size: density.bucketTitleFontSize, weight: .semibold))
                     .lineLimit(1)
-                if let plan = quota?.plan, !plan.isEmpty {
-                    Text(plan)
+                if let subtitle = headerSubtitle {
+                    Text(subtitle.text)
                         .font(.system(size: density.subtitleFontSize))
-                        .foregroundStyle(.secondary)
-                        .lineLimit(1)
-                } else {
-                    Text(tool.subtitle)
-                        .font(.system(size: density.subtitleFontSize))
-                        .foregroundStyle(.tertiary)
+                        .foregroundStyle(subtitle.isPrimary ? .secondary : .tertiary)
                         .lineLimit(1)
                 }
             }
@@ -86,34 +92,224 @@ struct MiscProviderCard: View {
                 help: "Refresh \(tool.menuTitle)",
                 size: density.subtitleFontSize
             ) {
-                guard let account = environment.account(for: tool) else { return }
-                Task { _ = await quotaService.refresh(account) }
+                environment.refresh(instance)
+            }
+            .disabled(quotaService.inFlightAccountIds.contains(accountID))
+        }
+    }
+
+    private var headerSubtitle: (text: String, isPrimary: Bool)? {
+        if let displayName = instance.displayName {
+            if let plan = environment.quota(for: instance)?.plan, !plan.isEmpty {
+                return ("\(displayName) · \(plan)", true)
+            }
+            return (displayName, true)
+        }
+        if let plan = environment.quota(for: instance)?.plan, !plan.isEmpty {
+            return (plan, true)
+        }
+        return (tool.subtitle, false)
+    }
+}
+
+private struct MiscProviderGroupCard: View {
+    let group: MiscProviderInstanceGroup
+    let density: Theme.Density
+
+    @EnvironmentObject var environment: AppEnvironment
+    @EnvironmentObject var quotaService: QuotaService
+
+    var body: some View {
+        MiscProviderCardShell(density: density) {
+            header
+            Divider().opacity(0.25)
+            MiscQuotaBody(
+                tool: group.tool,
+                density: density,
+                quota: aggregateQuota,
+                liveError: aggregateQuota?.error,
+                lastUpdated: latestUpdated,
+                isCompact: false
+            )
+            Divider().opacity(0.2)
+            VStack(alignment: .leading, spacing: max(6, density.bucketRowSpacing)) {
+                ForEach(Array(group.instances.enumerated()), id: \.element.id) { index, instance in
+                    MiscProviderInstanceStatusRow(
+                        instance: instance,
+                        ordinal: index + 1,
+                        density: density
+                    )
+                    if index < group.instances.count - 1 {
+                        Divider().opacity(0.16)
+                    }
+                }
+            }
+        }
+    }
+
+    private var header: some View {
+        HStack(alignment: .center, spacing: 10) {
+            ToolBrandBadge(
+                tool: group.tool,
+                iconSize: max(17, density.bucketTitleFontSize + 1),
+                containerSize: 26
+            )
+            VStack(alignment: .leading, spacing: 2) {
+                Text(group.tool.menuTitle)
+                    .font(.system(size: density.bucketTitleFontSize, weight: .semibold))
+                    .lineLimit(1)
+                Text("\(group.instances.count) independent copies")
+                    .font(.system(size: density.subtitleFontSize))
+                    .foregroundStyle(.tertiary)
+                    .lineLimit(1)
+            }
+            Spacer(minLength: 4)
+            BorderlessIconButton(
+                systemImage: "arrow.clockwise",
+                help: "Refresh \(group.tool.menuTitle) copies",
+                size: density.subtitleFontSize
+            ) {
+                for instance in group.instances {
+                    environment.refresh(instance)
+                }
             }
             .disabled(isRefreshing)
         }
     }
 
-    // MARK: - Content
+    private var isRefreshing: Bool {
+        group.instances.contains { instance in
+            quotaService.inFlightAccountIds.contains(AccountStore.miscAccountId(forInstanceID: instance.id))
+        }
+    }
 
-    @ViewBuilder
-    private var content: some View {
-        let liveError = displayableError(quotaService.lastErrorByAccount[accountId], with: quota)
+    private var latestUpdated: Date? {
+        group.instances
+            .compactMap { quotaService.lastUpdatedByAccount[AccountStore.miscAccountId(forInstanceID: $0.id)] }
+            .max()
+    }
+
+    private var aggregateQuota: AccountQuota? {
+        let queriedAt = group.instances
+            .compactMap { environment.quota(for: $0)?.queriedAt }
+            .max() ?? Date()
+        let results: [MiscQuotaAggregator.SlotResult] = group.instances.enumerated().map { index, instance in
+            let accountID = AccountStore.miscAccountId(forInstanceID: instance.id)
+            let label = instance.displayTitle(fallback: "Copy \(index + 1)")
+            if let quota = environment.quota(for: instance), !quota.buckets.isEmpty {
+                return .init(slotID: nil, sourceLabel: label, outcome: .success(quota))
+            }
+            let error = quotaService.lastErrorByAccount[accountID]
+                ?? environment.quota(for: instance)?.error
+                ?? .noCredential
+            return .init(slotID: nil, sourceLabel: label, outcome: .failure(error))
+        }
+        let account = AccountIdentity(
+            id: "misc-\(group.tool.rawValue)-aggregate",
+            tool: group.tool,
+            alias: group.tool.menuTitle,
+            source: .notConfigured
+        )
+        return MiscQuotaAggregator.aggregate(
+            tool: group.tool,
+            account: account,
+            results: results,
+            queriedAt: queriedAt
+        )
+    }
+}
+
+private struct MiscProviderInstanceStatusRow: View {
+    let instance: MiscProviderInstance
+    let ordinal: Int
+    let density: Theme.Density
+
+    @EnvironmentObject var environment: AppEnvironment
+    @EnvironmentObject var quotaService: QuotaService
+
+    private var accountID: String { AccountStore.miscAccountId(forInstanceID: instance.id) }
+    private var title: String { instance.displayTitle(fallback: "Copy \(ordinal)") }
+    private var refreshTitle: String { instance.displayTitle(fallback: "copy \(ordinal)") }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 5) {
+            HStack(alignment: .center, spacing: 6) {
+                Text(title)
+                    .font(.system(size: density.subtitleFontSize, weight: .semibold))
+                    .foregroundStyle(.secondary)
+                Spacer(minLength: 4)
+                BorderlessIconButton(
+                    systemImage: "arrow.clockwise",
+                    help: "Refresh \(refreshTitle)",
+                    size: max(9, density.subtitleFontSize - 1)
+                ) {
+                    environment.refresh(instance)
+                }
+                .disabled(quotaService.inFlightAccountIds.contains(accountID))
+            }
+            MiscQuotaBody(
+                tool: instance.tool,
+                density: density,
+                quota: environment.quota(for: instance),
+                liveError: quotaService.lastErrorByAccount[accountID],
+                lastUpdated: quotaService.lastUpdatedByAccount[accountID],
+                isCompact: true
+            )
+        }
+        .padding(.leading, 6)
+    }
+}
+
+private struct MiscProviderCardShell<Content: View>: View {
+    let density: Theme.Density
+    @ViewBuilder var content: () -> Content
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: density.cardSpacing) {
+            content()
+        }
+        .padding(density.cardPadding)
+        .frame(maxWidth: .infinity, alignment: .topLeading)
+        .background(
+            RoundedRectangle(cornerRadius: density.cardCornerRadius, style: .continuous)
+                .fill(.background.tertiary.opacity(0.6))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: density.cardCornerRadius, style: .continuous)
+                .stroke(.separator.opacity(0.4), lineWidth: 0.5)
+        )
+    }
+}
+
+private struct MiscQuotaBody: View {
+    let tool: ToolType
+    let density: Theme.Density
+    let quota: AccountQuota?
+    let liveError: QuotaError?
+    let lastUpdated: Date?
+    let isCompact: Bool
+
+    @EnvironmentObject var environment: AppEnvironment
+    @EnvironmentObject var settingsStore: SettingsStore
+
+    var body: some View {
+        let visibleError = displayableError(liveError, with: quota)
         if let buckets = quota?.buckets, !buckets.isEmpty {
-            VStack(alignment: .leading, spacing: density.bucketRowSpacing) {
+            VStack(alignment: .leading, spacing: max(4, density.bucketRowSpacing - (isCompact ? 2 : 0))) {
                 ForEach(buckets) { bucket in
                     miscBucketRow(bucket)
                 }
-                if let updated = quotaService.lastUpdatedByAccount[accountId] {
-                    Text(ResetCountdownFormatter.updatedAgo(from: updated, now: Date()))
+                if let lastUpdated {
+                    Text(ResetCountdownFormatter.updatedAgo(from: lastUpdated, now: Date()))
                         .font(.system(size: density.resetCountdownFontSize))
                         .foregroundStyle(.tertiary)
                 }
-                if let liveError {
-                    compactErrorText("Update failed: \(liveError.userFacingMessage)")
+                if let visibleError {
+                    compactErrorText("Update failed: \(visibleError.userFacingMessage)")
                 }
             }
-        } else if let liveError, liveError != .noCredential {
-            errorState(liveError)
+        } else if let visibleError, visibleError != .noCredential {
+            errorState(visibleError)
         } else {
             setupState
         }
@@ -132,28 +328,29 @@ struct MiscProviderCard: View {
     }
 
     private func miscBucketRow(_ bucket: QuotaBucket) -> some View {
-        // Honour the user's `displayMode` (used vs remaining) the same
-        // way the primary `ProviderBucketRow` does. With the default
-        // `.remaining` setting, "92%" means "92% remaining" and the
-        // bar fills toward "full". Without this conversion the misc
-        // cards always rendered used%, which read inverted next to
-        // the OpenAI / Claude cards.
         let mode = settingsStore.settings.displayMode
         let percent = bucket.displayPercent(mode)
         return VStack(alignment: .leading, spacing: 4) {
             HStack(alignment: .firstTextBaseline) {
                 Text(bucket.title)
-                    .font(.system(size: density.bucketTitleFontSize - 1, weight: .medium))
+                    .font(.system(
+                        size: density.bucketTitleFontSize - (isCompact ? 2 : 1),
+                        weight: .medium
+                    ))
                 Spacer()
                 Text("\(Int(percent.rounded()))%")
-                    .font(.system(size: density.bucketPercentFontSize, weight: .semibold))
+                    .font(.system(
+                        size: density.bucketPercentFontSize - (isCompact ? 2 : 0),
+                        weight: .semibold
+                    ))
                     .monospacedDigit()
                     .foregroundStyle(Theme.barColor(percent: percent, mode: mode))
             }
-            QuotaBarShape(percent: percent, mode: mode, height: density.bucketBarHeight)
-            // groupTitle is used by Cursor's on-demand bucket and
-            // similar adapters to surface a short dollar / count
-            // summary alongside the percent bar.
+            QuotaBarShape(
+                percent: percent,
+                mode: mode,
+                height: max(3, density.bucketBarHeight - (isCompact ? 1 : 0))
+            )
             if let group = bucket.groupTitle, !group.isEmpty, group != bucket.title {
                 Text(group)
                     .font(.system(size: density.resetCountdownFontSize))
@@ -219,19 +416,5 @@ struct MiscProviderCard: View {
         }
         .font(.system(size: density.resetCountdownFontSize))
         .foregroundStyle(.orange)
-    }
-
-    // MARK: - State helpers
-
-    private var accountId: String {
-        AccountStore.miscAccountId(for: tool)
-    }
-
-    private var quota: AccountQuota? {
-        environment.quota(for: tool)
-    }
-
-    private var isRefreshing: Bool {
-        quotaService.inFlightAccountIds.contains(accountId)
     }
 }

--- a/Sources/VibeBarApp/Views/PopoverRoot.swift
+++ b/Sources/VibeBarApp/Views/PopoverRoot.swift
@@ -173,16 +173,22 @@ struct PopoverRoot: View {
     }
 
     private var latestUpdated: Date? {
-        visibleTools
-            .compactMap { environment.account(for: $0) }
+        visibleAccounts
             .compactMap { quotaService.lastUpdatedByAccount[$0.id] }
             .max()
     }
 
     private var isRefreshing: Bool {
-        let ids = visibleTools
-            .compactMap { environment.account(for: $0)?.id }
+        let ids = visibleAccounts.map(\.id)
         return ids.contains { quotaService.inFlightAccountIds.contains($0) }
+    }
+
+    private var visibleAccounts: [AccountIdentity] {
+        if kind == .compact, overviewPage == .misc {
+            return settingsStore.settings.visibleMiscProviderInstances
+                .compactMap { environment.account(for: $0) }
+        }
+        return visibleTools.compactMap { environment.account(for: $0) }
     }
 
     private func planBadgeLabel(for tool: ToolType) -> String? {
@@ -200,7 +206,7 @@ struct PopoverRoot: View {
     private func refreshVisibleProvidersIfNeeded() {
         let key = autoRefreshKey
         guard !autoRefreshedPageKeys.contains(key) else { return }
-        let accounts = visibleTools.compactMap { environment.account(for: $0) }
+        let accounts = visibleAccounts
         let missing = accounts.filter { account in
             quotaService.cachedQuota(for: account.id) == nil
                 && quotaService.lastErrorByAccount[account.id] == nil

--- a/Sources/VibeBarApp/Views/SettingsView.swift
+++ b/Sources/VibeBarApp/Views/SettingsView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UniformTypeIdentifiers
 import VibeBarCore
 
 struct SettingsView: View {
@@ -17,6 +18,7 @@ struct SettingsView: View {
     @State private var isAuthorizingKeychain: Bool = false
     @State private var keychainAuthorizationStatus: String?
     @State private var keychainAuthorizationSucceeded: Bool = false
+    @State private var draggedMiscProviderInstanceID: String?
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -203,9 +205,31 @@ struct SettingsView: View {
                             .font(.caption)
                             .foregroundStyle(.secondary)
                         VStack(alignment: .leading, spacing: 10) {
-                            ForEach(settingsStore.settings.miscProviderOrder, id: \.self) { tool in
-                                MiscProviderSettingsSection(tool: tool)
+                            ForEach(settingsStore.settings.miscProviderInstances) { instance in
+                                MiscProviderSettingsSection(instance: instance)
+                                    .onDrag {
+                                        draggedMiscProviderInstanceID = instance.id
+                                        return NSItemProvider(object: instance.id as NSString)
+                                    }
+                                    .onDrop(
+                                        of: [UTType.text],
+                                        delegate: MiscProviderInstanceDropDelegate(
+                                            targetID: instance.id,
+                                            draggedID: $draggedMiscProviderInstanceID,
+                                            settingsStore: settingsStore
+                                        )
+                                    )
                             }
+                            Color.clear
+                                .frame(height: 8)
+                                .onDrop(
+                                    of: [UTType.text],
+                                    delegate: MiscProviderInstanceDropDelegate(
+                                        targetID: nil,
+                                        draggedID: $draggedMiscProviderInstanceID,
+                                        settingsStore: settingsStore
+                                    )
+                                )
                         }
                     }
 
@@ -795,5 +819,30 @@ struct SettingsView: View {
         case 365 * 3: return "3 years"
         default: return "\(days) days"
         }
+    }
+}
+
+private struct MiscProviderInstanceDropDelegate: DropDelegate {
+    let targetID: String?
+    @Binding var draggedID: String?
+    let settingsStore: SettingsStore
+
+    func dropEntered(info: DropInfo) {
+        guard let draggedID else { return }
+        if let targetID {
+            guard draggedID != targetID else { return }
+            settingsStore.settings.moveMiscProviderInstance(id: draggedID, before: targetID)
+        } else {
+            settingsStore.settings.moveMiscProviderInstanceToEnd(id: draggedID)
+        }
+    }
+
+    func dropUpdated(info: DropInfo) -> DropProposal? {
+        DropProposal(operation: .move)
+    }
+
+    func performDrop(info: DropInfo) -> Bool {
+        draggedID = nil
+        return true
     }
 }

--- a/Sources/VibeBarCore/Adapters/AlibabaQuotaAdapter.swift
+++ b/Sources/VibeBarCore/Adapters/AlibabaQuotaAdapter.swift
@@ -54,7 +54,8 @@ public struct AlibabaQuotaAdapter: QuotaAdapter {
     }
 
     public func fetch(for account: AccountIdentity) async throws -> AccountQuota {
-        let settings = MiscProviderSettings.current(for: .alibaba)
+        let instanceID = AccountStore.miscInstanceID(fromAccountID: account.id, fallbackTool: .alibaba)
+        let settings = MiscProviderSettings.current(for: .alibaba, instanceID: instanceID)
 
         let preferred: [AlibabaRegion]
         switch settings.region {
@@ -68,11 +69,11 @@ public struct AlibabaQuotaAdapter: QuotaAdapter {
 
         let queriedAt = now()
         let hasAPIKey = settings.allowsAPIOrOAuthAccess && {
-            guard let key = MiscCredentialStore.readString(tool: .alibaba, kind: .apiKey),
+            guard let key = MiscCredentialStore.readString(tool: .alibaba, kind: .apiKey, instanceID: instanceID),
                   !key.isEmpty else { return false }
             return true
         }()
-        let cookieResolutions = MiscCookieResolver.resolveAll(for: AlibabaQuotaAdapter.cookieSpec)
+        let cookieResolutions = MiscCookieResolver.resolveAll(for: AlibabaQuotaAdapter.cookieSpec, account: account)
 
         // Path 1: API key (preferred when present — fewer round-trips,
         // no SEC_TOKEN scrape). Fall through to the cookie path on
@@ -80,7 +81,7 @@ public struct AlibabaQuotaAdapter: QuotaAdapter {
         // black-hole users who also have a console session. The API
         // key returns a single account; aggregation is a no-op there.
         if hasAPIKey,
-           let apiKey = MiscCredentialStore.readString(tool: .alibaba, kind: .apiKey),
+           let apiKey = MiscCredentialStore.readString(tool: .alibaba, kind: .apiKey, instanceID: instanceID),
            !apiKey.isEmpty {
             do {
                 return try await fetchViaAPIKey(

--- a/Sources/VibeBarCore/Adapters/AntigravityQuotaAdapter.swift
+++ b/Sources/VibeBarCore/Adapters/AntigravityQuotaAdapter.swift
@@ -50,7 +50,8 @@ public struct AntigravityQuotaAdapter: QuotaAdapter {
         "/exa.language_server_pb.LanguageServerService/GetUserStatus"
 
     public func fetch(for account: AccountIdentity) async throws -> AccountQuota {
-        guard MiscProviderSettings.current(for: .antigravity).allowsLocalProbeAccess else {
+        let instanceID = AccountStore.miscInstanceID(fromAccountID: account.id, fallbackTool: .antigravity)
+        guard MiscProviderSettings.current(for: .antigravity, instanceID: instanceID).allowsLocalProbeAccess else {
             throw QuotaError.noCredential
         }
 

--- a/Sources/VibeBarCore/Adapters/CopilotQuotaAdapter.swift
+++ b/Sources/VibeBarCore/Adapters/CopilotQuotaAdapter.swift
@@ -30,11 +30,12 @@ public struct CopilotQuotaAdapter: QuotaAdapter {
     }
 
     public func fetch(for account: AccountIdentity) async throws -> AccountQuota {
-        let providerSettings = MiscProviderSettings.current(for: .copilot)
+        let instanceID = AccountStore.miscInstanceID(fromAccountID: account.id, fallbackTool: .copilot)
+        let providerSettings = MiscProviderSettings.current(for: .copilot, instanceID: instanceID)
         guard providerSettings.allowsAPIOrOAuthAccess else {
             throw QuotaError.noCredential
         }
-        let token = resolveToken()
+        let token = resolveToken(instanceID: instanceID)
         guard let token, !token.isEmpty else {
             throw QuotaError.noCredential
         }
@@ -88,16 +89,16 @@ public struct CopilotQuotaAdapter: QuotaAdapter {
         )
     }
 
-    private func resolveToken() -> String? {
+    private func resolveToken(instanceID: String) -> String? {
         if let env = environment["COPILOT_TOKEN"]?
             .trimmingCharacters(in: .whitespacesAndNewlines), !env.isEmpty {
             return env
         }
-        if let deviceToken = MiscCredentialStore.readString(tool: .copilot, kind: .oauthAccessToken),
+        if let deviceToken = MiscCredentialStore.readString(tool: .copilot, kind: .oauthAccessToken, instanceID: instanceID),
            !deviceToken.isEmpty {
             return deviceToken
         }
-        return MiscCredentialStore.readString(tool: .copilot, kind: .apiKey)
+        return MiscCredentialStore.readString(tool: .copilot, kind: .apiKey, instanceID: instanceID)
     }
 
     private func enterpriseHost(from settings: MiscProviderSettings) -> String? {

--- a/Sources/VibeBarCore/Adapters/CursorQuotaAdapter.swift
+++ b/Sources/VibeBarCore/Adapters/CursorQuotaAdapter.swift
@@ -61,7 +61,7 @@ public struct CursorQuotaAdapter: QuotaAdapter {
     }
 
     public func fetch(for account: AccountIdentity) async throws -> AccountQuota {
-        let resolutions = MiscCookieResolver.resolveAll(for: CursorQuotaAdapter.cookieSpec)
+        let resolutions = MiscCookieResolver.resolveAll(for: CursorQuotaAdapter.cookieSpec, account: account)
         guard !resolutions.isEmpty else { throw QuotaError.noCredential }
 
         let queriedAt = now()

--- a/Sources/VibeBarCore/Adapters/GeminiQuotaAdapter.swift
+++ b/Sources/VibeBarCore/Adapters/GeminiQuotaAdapter.swift
@@ -42,7 +42,8 @@ public struct GeminiQuotaAdapter: QuotaAdapter {
     }
 
     public func fetch(for account: AccountIdentity) async throws -> AccountQuota {
-        guard MiscProviderSettings.current(for: .gemini).allowsAPIOrOAuthAccess else {
+        let instanceID = AccountStore.miscInstanceID(fromAccountID: account.id, fallbackTool: .gemini)
+        guard MiscProviderSettings.current(for: .gemini, instanceID: instanceID).allowsAPIOrOAuthAccess else {
             throw QuotaError.noCredential
         }
 

--- a/Sources/VibeBarCore/Adapters/IFlyTekQuotaAdapter.swift
+++ b/Sources/VibeBarCore/Adapters/IFlyTekQuotaAdapter.swift
@@ -59,7 +59,7 @@ public struct IFlyTekQuotaAdapter: QuotaAdapter {
     }
 
     public func fetch(for account: AccountIdentity) async throws -> AccountQuota {
-        let resolutions = MiscCookieResolver.resolveAll(for: IFlyTekQuotaAdapter.cookieSpec)
+        let resolutions = MiscCookieResolver.resolveAll(for: IFlyTekQuotaAdapter.cookieSpec, account: account)
         guard !resolutions.isEmpty else { throw QuotaError.noCredential }
 
         let queriedAt = now()

--- a/Sources/VibeBarCore/Adapters/KiloQuotaAdapter.swift
+++ b/Sources/VibeBarCore/Adapters/KiloQuotaAdapter.swift
@@ -27,12 +27,14 @@ public struct KiloQuotaAdapter: QuotaAdapter {
     }
 
     public func fetch(for account: AccountIdentity) async throws -> AccountQuota {
-        let settings = MiscProviderSettings.current(for: .kilo)
+        let instanceID = AccountStore.miscInstanceID(fromAccountID: account.id, fallbackTool: .kilo)
+        let settings = MiscProviderSettings.current(for: .kilo, instanceID: instanceID)
         guard settings.allowsAPIOrOAuthAccess,
               let token = Self.resolveAuthToken(
                 environment: environment,
                 homeDirectory: homeDirectory,
-                allowCLI: settings.allowsLocalProbeAccess
+                allowCLI: settings.allowsLocalProbeAccess,
+                instanceID: instanceID
               ) else {
             throw QuotaError.noCredential
         }
@@ -90,9 +92,10 @@ public struct KiloQuotaAdapter: QuotaAdapter {
     private static func resolveAuthToken(
         environment: [String: String],
         homeDirectory: String,
-        allowCLI: Bool
+        allowCLI: Bool,
+        instanceID: String
     ) -> String? {
-        if let stored = MiscCredentialStore.readString(tool: .kilo, kind: .apiKey),
+        if let stored = MiscCredentialStore.readString(tool: .kilo, kind: .apiKey, instanceID: instanceID),
            !stored.isEmpty {
             return stored
         }

--- a/Sources/VibeBarCore/Adapters/KimiQuotaAdapter.swift
+++ b/Sources/VibeBarCore/Adapters/KimiQuotaAdapter.swift
@@ -41,7 +41,7 @@ public struct KimiQuotaAdapter: QuotaAdapter {
     }
 
     public func fetch(for account: AccountIdentity) async throws -> AccountQuota {
-        let resolutions = MiscCookieResolver.resolveAll(for: KimiQuotaAdapter.cookieSpec)
+        let resolutions = MiscCookieResolver.resolveAll(for: KimiQuotaAdapter.cookieSpec, account: account)
         guard !resolutions.isEmpty else { throw QuotaError.noCredential }
 
         let queriedAt = now()

--- a/Sources/VibeBarCore/Adapters/KiroQuotaAdapter.swift
+++ b/Sources/VibeBarCore/Adapters/KiroQuotaAdapter.swift
@@ -15,7 +15,8 @@ public struct KiroQuotaAdapter: QuotaAdapter {
     }
 
     public func fetch(for account: AccountIdentity) async throws -> AccountQuota {
-        let settings = MiscProviderSettings.current(for: .kiro)
+        let instanceID = AccountStore.miscInstanceID(fromAccountID: account.id, fallbackTool: .kiro)
+        let settings = MiscProviderSettings.current(for: .kiro, instanceID: instanceID)
         guard settings.allowsLocalProbeAccess else {
             throw QuotaError.noCredential
         }

--- a/Sources/VibeBarCore/Adapters/MimoQuotaAdapter.swift
+++ b/Sources/VibeBarCore/Adapters/MimoQuotaAdapter.swift
@@ -54,7 +54,7 @@ public struct MimoQuotaAdapter: QuotaAdapter {
     }
 
     public func fetch(for account: AccountIdentity) async throws -> AccountQuota {
-        let resolutions = MiscCookieResolver.resolveAll(for: MimoQuotaAdapter.cookieSpec)
+        let resolutions = MiscCookieResolver.resolveAll(for: MimoQuotaAdapter.cookieSpec, account: account)
         guard !resolutions.isEmpty else { throw QuotaError.noCredential }
 
         let queriedAt = now()

--- a/Sources/VibeBarCore/Adapters/MiniMaxQuotaAdapter.swift
+++ b/Sources/VibeBarCore/Adapters/MiniMaxQuotaAdapter.swift
@@ -34,12 +34,13 @@ public struct MiniMaxQuotaAdapter: QuotaAdapter {
     }
 
     public func fetch(for account: AccountIdentity) async throws -> AccountQuota {
-        let settings = MiscProviderSettings.current(for: .minimax)
+        let instanceID = AccountStore.miscInstanceID(fromAccountID: account.id, fallbackTool: .minimax)
+        let settings = MiscProviderSettings.current(for: .minimax, instanceID: instanceID)
         var lastError: QuotaError?
         let regions = MiniMaxRegion.resolve(settings: settings)
 
         guard settings.allowsAPIOrOAuthAccess,
-              let apiKey = MiniMaxSettings.resolveAPIKey(environment: environment),
+              let apiKey = MiniMaxSettings.resolveAPIKey(environment: environment, instanceID: instanceID),
               !apiKey.isEmpty else {
             throw QuotaError.noCredential
         }
@@ -199,8 +200,8 @@ enum MiniMaxRegion: String, CaseIterable {
 }
 
 private enum MiniMaxSettings {
-    static func resolveAPIKey(environment: [String: String]) -> String? {
-        if let stored = MiscCredentialStore.readString(tool: .minimax, kind: .apiKey),
+    static func resolveAPIKey(environment: [String: String], instanceID: String) -> String? {
+        if let stored = MiscCredentialStore.readString(tool: .minimax, kind: .apiKey, instanceID: instanceID),
            !stored.isEmpty {
             return stored
         }

--- a/Sources/VibeBarCore/Adapters/OllamaQuotaAdapter.swift
+++ b/Sources/VibeBarCore/Adapters/OllamaQuotaAdapter.swift
@@ -26,7 +26,7 @@ public struct OllamaQuotaAdapter: QuotaAdapter {
     }
 
     public func fetch(for account: AccountIdentity) async throws -> AccountQuota {
-        let resolutions = MiscCookieResolver.resolveAll(for: Self.cookieSpec)
+        let resolutions = MiscCookieResolver.resolveAll(for: Self.cookieSpec, account: account)
             .filter { Self.hasRecognizedSessionCookie($0.header) }
         guard !resolutions.isEmpty else { throw QuotaError.noCredential }
 

--- a/Sources/VibeBarCore/Adapters/OpenCodeGoQuotaAdapter.swift
+++ b/Sources/VibeBarCore/Adapters/OpenCodeGoQuotaAdapter.swift
@@ -31,7 +31,7 @@ public struct OpenCodeGoQuotaAdapter: QuotaAdapter {
     }
 
     public func fetch(for account: AccountIdentity) async throws -> AccountQuota {
-        let resolutions = MiscCookieResolver.resolveAll(for: Self.cookieSpec)
+        let resolutions = MiscCookieResolver.resolveAll(for: Self.cookieSpec, account: account)
         guard !resolutions.isEmpty else { throw QuotaError.noCredential }
 
         let queriedAt = now()
@@ -51,7 +51,8 @@ public struct OpenCodeGoQuotaAdapter: QuotaAdapter {
         account: AccountIdentity,
         queriedAt: Date
     ) async throws -> AccountQuota {
-        let settings = MiscProviderSettings.current(for: .openCodeGo)
+        let instanceID = AccountStore.miscInstanceID(fromAccountID: account.id, fallbackTool: .openCodeGo)
+        let settings = MiscProviderSettings.current(for: .openCodeGo, instanceID: instanceID)
         let workspaceID = try await resolveWorkspaceID(
             cookieHeader: resolution.header,
             configured: settings.workspaceID ?? environment["CODEXBAR_OPENCODEGO_WORKSPACE_ID"]

--- a/Sources/VibeBarCore/Adapters/OpenRouterQuotaAdapter.swift
+++ b/Sources/VibeBarCore/Adapters/OpenRouterQuotaAdapter.swift
@@ -24,9 +24,10 @@ public struct OpenRouterQuotaAdapter: QuotaAdapter {
     }
 
     public func fetch(for account: AccountIdentity) async throws -> AccountQuota {
-        let settings = MiscProviderSettings.current(for: .openRouter)
+        let instanceID = AccountStore.miscInstanceID(fromAccountID: account.id, fallbackTool: .openRouter)
+        let settings = MiscProviderSettings.current(for: .openRouter, instanceID: instanceID)
         guard settings.allowsAPIOrOAuthAccess,
-              let apiKey = Self.resolveAPIKey(environment: environment) else {
+              let apiKey = Self.resolveAPIKey(environment: environment, instanceID: instanceID) else {
             throw QuotaError.noCredential
         }
 
@@ -107,8 +108,8 @@ public struct OpenRouterQuotaAdapter: QuotaAdapter {
         return data
     }
 
-    private static func resolveAPIKey(environment: [String: String]) -> String? {
-        if let stored = MiscCredentialStore.readString(tool: .openRouter, kind: .apiKey),
+    private static func resolveAPIKey(environment: [String: String], instanceID: String) -> String? {
+        if let stored = MiscCredentialStore.readString(tool: .openRouter, kind: .apiKey, instanceID: instanceID),
            !stored.isEmpty {
             return stored
         }

--- a/Sources/VibeBarCore/Adapters/TencentHunyuanQuotaAdapter.swift
+++ b/Sources/VibeBarCore/Adapters/TencentHunyuanQuotaAdapter.swift
@@ -62,7 +62,7 @@ public struct TencentHunyuanQuotaAdapter: QuotaAdapter {
     }
 
     public func fetch(for account: AccountIdentity) async throws -> AccountQuota {
-        let resolutions = MiscCookieResolver.resolveAll(for: TencentHunyuanQuotaAdapter.cookieSpec)
+        let resolutions = MiscCookieResolver.resolveAll(for: TencentHunyuanQuotaAdapter.cookieSpec, account: account)
         guard !resolutions.isEmpty else { throw QuotaError.noCredential }
 
         let queriedAt = now()

--- a/Sources/VibeBarCore/Adapters/VolcengineQuotaAdapter.swift
+++ b/Sources/VibeBarCore/Adapters/VolcengineQuotaAdapter.swift
@@ -56,7 +56,7 @@ public struct VolcengineQuotaAdapter: QuotaAdapter {
     }
 
     public func fetch(for account: AccountIdentity) async throws -> AccountQuota {
-        let resolutions = MiscCookieResolver.resolveAll(for: VolcengineQuotaAdapter.cookieSpec)
+        let resolutions = MiscCookieResolver.resolveAll(for: VolcengineQuotaAdapter.cookieSpec, account: account)
         guard !resolutions.isEmpty else { throw QuotaError.noCredential }
 
         let queriedAt = now()

--- a/Sources/VibeBarCore/Adapters/WarpQuotaAdapter.swift
+++ b/Sources/VibeBarCore/Adapters/WarpQuotaAdapter.swift
@@ -48,9 +48,10 @@ public struct WarpQuotaAdapter: QuotaAdapter {
     }
 
     public func fetch(for account: AccountIdentity) async throws -> AccountQuota {
-        let settings = MiscProviderSettings.current(for: .warp)
+        let instanceID = AccountStore.miscInstanceID(fromAccountID: account.id, fallbackTool: .warp)
+        let settings = MiscProviderSettings.current(for: .warp, instanceID: instanceID)
         guard settings.allowsAPIOrOAuthAccess,
-              let apiKey = WarpQuotaAdapter.resolveAPIKey(environment: environment) else {
+              let apiKey = WarpQuotaAdapter.resolveAPIKey(environment: environment, instanceID: instanceID) else {
             throw QuotaError.noCredential
         }
 
@@ -122,8 +123,8 @@ public struct WarpQuotaAdapter: QuotaAdapter {
         return data
     }
 
-    public static func resolveAPIKey(environment: [String: String]) -> String? {
-        if let stored = MiscCredentialStore.readString(tool: .warp, kind: .apiKey),
+    public static func resolveAPIKey(environment: [String: String], instanceID: String = ToolType.warp.rawValue) -> String? {
+        if let stored = MiscCredentialStore.readString(tool: .warp, kind: .apiKey, instanceID: instanceID),
            !stored.isEmpty {
             return stored
         }

--- a/Sources/VibeBarCore/Adapters/ZaiQuotaAdapter.swift
+++ b/Sources/VibeBarCore/Adapters/ZaiQuotaAdapter.swift
@@ -32,7 +32,8 @@ public struct ZaiQuotaAdapter: QuotaAdapter {
     }
 
     public func fetch(for account: AccountIdentity) async throws -> AccountQuota {
-        let providerSettings = MiscProviderSettings.current(for: .zai)
+        let instanceID = AccountStore.miscInstanceID(fromAccountID: account.id, fallbackTool: .zai)
+        let providerSettings = MiscProviderSettings.current(for: .zai, instanceID: instanceID)
         guard providerSettings.allowsAPIOrOAuthAccess else {
             throw QuotaError.noCredential
         }
@@ -41,7 +42,7 @@ public struct ZaiQuotaAdapter: QuotaAdapter {
             providerSettings: providerSettings
         )
 
-        guard let apiKey = MiscCredentialStore.readString(tool: .zai, kind: .apiKey),
+        guard let apiKey = MiscCredentialStore.readString(tool: .zai, kind: .apiKey, instanceID: instanceID),
               !apiKey.isEmpty
         else {
             throw QuotaError.noCredential

--- a/Sources/VibeBarCore/BrowserCookies/MiscCookieResolver.swift
+++ b/Sources/VibeBarCore/BrowserCookies/MiscCookieResolver.swift
@@ -126,11 +126,22 @@ public enum MiscCookieResolver {
     /// slots, or when the source mode bans cookies entirely
     /// (`apiOnly` / `off`).
     public static func resolveAll(for spec: Spec) -> [Resolution] {
-        let settings = currentSettings(for: spec.tool)
+        resolveAll(for: spec, instanceID: spec.tool.rawValue)
+    }
+
+    public static func resolveAll(for spec: Spec, account: AccountIdentity) -> [Resolution] {
+        resolveAll(
+            for: spec,
+            instanceID: AccountStore.miscInstanceID(fromAccountID: account.id, fallbackTool: spec.tool)
+        )
+    }
+
+    public static func resolveAll(for spec: Spec, instanceID: String) -> [Resolution] {
+        let settings = currentSettings(for: spec.tool, instanceID: instanceID)
         let filter = SlotFilter(settings: settings)
         guard filter != .none else { return [] }
 
-        return MiscCookieSlotStore.slots(for: spec.tool).compactMap { slot in
+        return MiscCookieSlotStore.slots(for: spec.tool, instanceID: instanceID).compactMap { slot in
             guard filter.allows(slot) else { return nil }
             guard let header = spec.minimizedHeader(from: slot.cookieHeader),
                   !header.isEmpty else { return nil }
@@ -148,12 +159,20 @@ public enum MiscCookieResolver {
         resolveAll(for: spec).first
     }
 
+    public static func resolve(for spec: Spec, account: AccountIdentity) -> Resolution? {
+        resolveAll(for: spec, account: account).first
+    }
+
     /// Run the SweetCookieKit browser-import dance and append the
     /// captured header as a new slot. Returns the appended slot's
     /// Resolution on success, or `nil` if no browser session was
     /// found (or the source mode bans cookies).
     public static func appendBrowserImport(for spec: Spec) -> Resolution? {
-        let settings = currentSettings(for: spec.tool)
+        appendBrowserImport(for: spec, instanceID: spec.tool.rawValue)
+    }
+
+    public static func appendBrowserImport(for spec: Spec, instanceID: String) -> Resolution? {
+        let settings = currentSettings(for: spec.tool, instanceID: instanceID)
         guard SlotFilter(settings: settings) != .none else { return nil }
         guard let imported = importFromBrowsers(
             spec: spec,
@@ -168,7 +187,7 @@ public enum MiscCookieResolver {
             importedAt: Date(),
             origin: .browserImport
         )
-        guard MiscCookieSlotStore.append(slot, for: spec.tool) else { return nil }
+        guard MiscCookieSlotStore.append(slot, for: spec.tool, instanceID: instanceID) else { return nil }
         return Resolution(
             slotID: slot.id,
             header: imported.header,
@@ -181,6 +200,10 @@ public enum MiscCookieResolver {
     /// invocation appends a new slot rather than replacing one.
     public static func forceBrowserImport(for spec: Spec) -> Resolution? {
         appendBrowserImport(for: spec)
+    }
+
+    public static func forceBrowserImport(for spec: Spec, instanceID: String) -> Resolution? {
+        appendBrowserImport(for: spec, instanceID: instanceID)
     }
 
     // MARK: - Internals
@@ -309,7 +332,7 @@ public enum MiscCookieResolver {
         }
     }
 
-    private static func currentSettings(for tool: ToolType) -> MiscProviderSettings {
-        MiscProviderSettings.current(for: tool)
+    private static func currentSettings(for tool: ToolType, instanceID: String) -> MiscProviderSettings {
+        MiscProviderSettings.current(for: tool, instanceID: instanceID)
     }
 }

--- a/Sources/VibeBarCore/Credentials/MiscCookieSlotStore.swift
+++ b/Sources/VibeBarCore/Credentials/MiscCookieSlotStore.swift
@@ -42,9 +42,10 @@ public struct MiscCookieSlot: Codable, Equatable, Sendable, Identifiable {
 
 /// Keychain-backed list-of-cookies storage for misc providers.
 ///
-/// Each tool maps to one Keychain entry: service
+/// Each provider instance maps to one Keychain entry: service
 /// `com.astroqore.VibeBar.misc-secrets`, account
-/// `<tool.rawValue>.cookieSlots`. The value is a JSON-encoded
+/// `<tool.rawValue>.cookieSlots` for the default instance and
+/// `<instanceID>.cookieSlots` for clones. The value is a JSON-encoded
 /// `[MiscCookieSlot]`.
 ///
 /// The store is mutable — append, update, delete — but each
@@ -62,7 +63,14 @@ public enum MiscCookieSlotStore {
     public static let slotsAccountSuffix = "cookieSlots"
 
     public static func keychainAccount(for tool: ToolType) -> String {
+        keychainAccount(for: tool, instanceID: tool.rawValue)
+    }
+
+    public static func keychainAccount(for tool: ToolType, instanceID: String) -> String {
         precondition(tool.isMisc, "MiscCookieSlotStore is misc-only; got \(tool)")
+        if instanceID != tool.rawValue {
+            return "\(instanceID).\(slotsAccountSuffix)"
+        }
         return "\(tool.rawValue).\(slotsAccountSuffix)"
     }
 
@@ -70,13 +78,18 @@ public enum MiscCookieSlotStore {
     /// state on first read. Returns an empty array if no cookies are
     /// configured.
     public static func slots(for tool: ToolType) -> [MiscCookieSlot] {
+        slots(for: tool, instanceID: tool.rawValue)
+    }
+
+    public static func slots(for tool: ToolType, instanceID: String) -> [MiscCookieSlot] {
         guard tool.isMisc else { return [] }
-        if let stored = readRaw(for: tool) {
+        if let stored = readRaw(for: tool, instanceID: instanceID) {
             return stored
         }
+        guard instanceID == tool.rawValue else { return [] }
         let migrated = LegacyCookieMigration.collectSlots(for: tool)
         if !migrated.isEmpty {
-            _ = writeRaw(migrated, for: tool)
+            _ = writeRaw(migrated, for: tool, instanceID: instanceID)
             LegacyCookieMigration.clearLegacy(for: tool)
         }
         return migrated
@@ -84,8 +97,13 @@ public enum MiscCookieSlotStore {
 
     @discardableResult
     public static func append(_ slot: MiscCookieSlot, for tool: ToolType) -> Bool {
+        append(slot, for: tool, instanceID: tool.rawValue)
+    }
+
+    @discardableResult
+    public static func append(_ slot: MiscCookieSlot, for tool: ToolType, instanceID: String) -> Bool {
         guard tool.isMisc else { return false }
-        var list = slots(for: tool)
+        var list = slots(for: tool, instanceID: instanceID)
         if let existing = list.firstIndex(where: { $0.cookieHeader == slot.cookieHeader }) {
             // Refresh the timestamp/source so the user can see they're
             // pasting the same cookie they had before.
@@ -95,7 +113,7 @@ public enum MiscCookieSlotStore {
         } else {
             list.append(slot)
         }
-        return writeRaw(list, for: tool)
+        return writeRaw(list, for: tool, instanceID: instanceID)
     }
 
     @discardableResult
@@ -107,8 +125,29 @@ public enum MiscCookieSlotStore {
         importedAt: Date? = nil,
         origin: MiscCookieSlot.Origin? = nil
     ) -> Bool {
+        updateHeader(
+            slotID: slotID,
+            for: tool,
+            instanceID: tool.rawValue,
+            header: header,
+            sourceLabel: sourceLabel,
+            importedAt: importedAt,
+            origin: origin
+        )
+    }
+
+    @discardableResult
+    public static func updateHeader(
+        slotID: UUID,
+        for tool: ToolType,
+        instanceID: String,
+        header: String,
+        sourceLabel: String? = nil,
+        importedAt: Date? = nil,
+        origin: MiscCookieSlot.Origin? = nil
+    ) -> Bool {
         guard tool.isMisc else { return false }
-        var list = slots(for: tool)
+        var list = slots(for: tool, instanceID: instanceID)
         guard let idx = list.firstIndex(where: { $0.id == slotID }) else { return false }
         let trimmed = header.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return false }
@@ -116,30 +155,44 @@ public enum MiscCookieSlotStore {
         if let sourceLabel { list[idx].sourceLabel = sourceLabel }
         if let importedAt { list[idx].importedAt = importedAt }
         if let origin { list[idx].origin = origin }
-        return writeRaw(list, for: tool)
+        return writeRaw(list, for: tool, instanceID: instanceID)
     }
 
     @discardableResult
     public static func delete(slotID: UUID, for tool: ToolType) -> Bool {
+        delete(slotID: slotID, for: tool, instanceID: tool.rawValue)
+    }
+
+    @discardableResult
+    public static func delete(slotID: UUID, for tool: ToolType, instanceID: String) -> Bool {
         guard tool.isMisc else { return false }
-        var list = slots(for: tool)
+        var list = slots(for: tool, instanceID: instanceID)
         let before = list.count
         list.removeAll { $0.id == slotID }
         guard list.count != before else { return false }
         if list.isEmpty {
-            return deleteRaw(for: tool)
+            return deleteRaw(for: tool, instanceID: instanceID)
         }
-        return writeRaw(list, for: tool)
+        return writeRaw(list, for: tool, instanceID: instanceID)
     }
 
     @discardableResult
     public static func deleteAll(for tool: ToolType) -> Bool {
+        deleteAll(for: tool, instanceID: tool.rawValue)
+    }
+
+    @discardableResult
+    public static func deleteAll(for tool: ToolType, instanceID: String) -> Bool {
         guard tool.isMisc else { return false }
-        return deleteRaw(for: tool)
+        return deleteRaw(for: tool, instanceID: instanceID)
     }
 
     public static func hasAnySlot(for tool: ToolType) -> Bool {
         !slots(for: tool).isEmpty
+    }
+
+    public static func hasAnySlot(for tool: ToolType, instanceID: String) -> Bool {
+        !slots(for: tool, instanceID: instanceID).isEmpty
     }
 
     // MARK: - Notifications
@@ -152,18 +205,18 @@ public enum MiscCookieSlotStore {
         "com.astroqore.VibeBar.miscCookieSlotsChanged"
     )
 
-    private static func postChangeNotification(for tool: ToolType) {
+    private static func postChangeNotification(for tool: ToolType, instanceID: String) {
         NotificationCenter.default.post(
             name: didChangeNotification,
             object: nil,
-            userInfo: ["tool": tool.rawValue]
+            userInfo: ["tool": tool.rawValue, "instanceID": instanceID]
         )
     }
 
     // MARK: - Keychain plumbing
 
-    private static func readRaw(for tool: ToolType) -> [MiscCookieSlot]? {
-        let account = keychainAccount(for: tool)
+    private static func readRaw(for tool: ToolType, instanceID: String) -> [MiscCookieSlot]? {
+        let account = keychainAccount(for: tool, instanceID: instanceID)
         do {
             let data = try KeychainStore.readData(
                 service: keychainService,
@@ -183,10 +236,10 @@ public enum MiscCookieSlotStore {
     }
 
     @discardableResult
-    private static func writeRaw(_ slots: [MiscCookieSlot], for tool: ToolType) -> Bool {
-        let account = keychainAccount(for: tool)
+    private static func writeRaw(_ slots: [MiscCookieSlot], for tool: ToolType, instanceID: String) -> Bool {
+        let account = keychainAccount(for: tool, instanceID: instanceID)
         guard !slots.isEmpty else {
-            return deleteRaw(for: tool)
+            return deleteRaw(for: tool, instanceID: instanceID)
         }
         do {
             let data = try Self.encoder().encode(slots)
@@ -196,7 +249,7 @@ public enum MiscCookieSlotStore {
                 data: data,
                 useDataProtectionKeychain: true
             )
-            postChangeNotification(for: tool)
+            postChangeNotification(for: tool, instanceID: instanceID)
             return true
         } catch {
             SafeLog.error("MiscCookieSlotStore write failed for \(tool.rawValue): \(error)")
@@ -205,15 +258,15 @@ public enum MiscCookieSlotStore {
     }
 
     @discardableResult
-    private static func deleteRaw(for tool: ToolType) -> Bool {
-        let account = keychainAccount(for: tool)
+    private static func deleteRaw(for tool: ToolType, instanceID: String) -> Bool {
+        let account = keychainAccount(for: tool, instanceID: instanceID)
         do {
             try KeychainStore.deleteItem(
                 service: keychainService,
                 account: account,
                 useDataProtectionKeychain: true
             )
-            postChangeNotification(for: tool)
+            postChangeNotification(for: tool, instanceID: instanceID)
             return true
         } catch KeychainStore.KeychainError.itemNotFound {
             return false

--- a/Sources/VibeBarCore/Credentials/MiscCredentialStore.swift
+++ b/Sources/VibeBarCore/Credentials/MiscCredentialStore.swift
@@ -24,13 +24,24 @@ public enum MiscCredentialStore {
     }
 
     public static func keychainAccount(tool: ToolType, kind: Kind) -> String {
+        keychainAccount(tool: tool, kind: kind, instanceID: tool.rawValue)
+    }
+
+    public static func keychainAccount(tool: ToolType, kind: Kind, instanceID: String) -> String {
         precondition(tool.isMisc, "MiscCredentialStore is misc-only; got \(tool)")
-        return "\(tool.rawValue).\(kind.rawValue)"
+        if instanceID == tool.rawValue {
+            return "\(tool.rawValue).\(kind.rawValue)"
+        }
+        return "\(instanceID).\(kind.rawValue)"
     }
 
     public static func readString(tool: ToolType, kind: Kind) -> String? {
+        readString(tool: tool, kind: kind, instanceID: tool.rawValue)
+    }
+
+    public static func readString(tool: ToolType, kind: Kind, instanceID: String) -> String? {
         guard tool.isMisc else { return nil }
-        let account = keychainAccount(tool: tool, kind: kind)
+        let account = keychainAccount(tool: tool, kind: kind, instanceID: instanceID)
         if let value = try? KeychainStore.readString(
             service: keychainService,
             account: account,
@@ -39,20 +50,26 @@ public enum MiscCredentialStore {
             return value
         }
 
+        guard instanceID == tool.rawValue else { return nil }
         return readLegacyString(tool: tool, kind: kind, account: account)
     }
 
     @discardableResult
     public static func writeString(_ value: String, tool: ToolType, kind: Kind) -> Bool {
+        writeString(value, tool: tool, kind: kind, instanceID: tool.rawValue)
+    }
+
+    @discardableResult
+    public static func writeString(_ value: String, tool: ToolType, kind: Kind, instanceID: String) -> Bool {
         guard tool.isMisc else { return false }
         let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else {
-            return delete(tool: tool, kind: kind)
+            return delete(tool: tool, kind: kind, instanceID: instanceID)
         }
         do {
             try KeychainStore.writeString(
                 service: keychainService,
-                account: keychainAccount(tool: tool, kind: kind),
+                account: keychainAccount(tool: tool, kind: kind, instanceID: instanceID),
                 value: trimmed,
                 useDataProtectionKeychain: true
             )
@@ -65,17 +82,26 @@ public enum MiscCredentialStore {
 
     @discardableResult
     public static func delete(tool: ToolType, kind: Kind) -> Bool {
+        delete(tool: tool, kind: kind, instanceID: tool.rawValue)
+    }
+
+    @discardableResult
+    public static func delete(tool: ToolType, kind: Kind, instanceID: String) -> Bool {
         guard tool.isMisc else { return false }
         do {
             try KeychainStore.deleteItem(
                 service: keychainService,
-                account: keychainAccount(tool: tool, kind: kind),
+                account: keychainAccount(tool: tool, kind: kind, instanceID: instanceID),
                 useDataProtectionKeychain: true
             )
-            deleteLegacyMigratedValue(tool: tool, kind: kind)
+            if instanceID == tool.rawValue {
+                deleteLegacyMigratedValue(tool: tool, kind: kind)
+            }
             return true
         } catch KeychainStore.KeychainError.itemNotFound {
-            deleteLegacyMigratedValue(tool: tool, kind: kind)
+            if instanceID == tool.rawValue {
+                deleteLegacyMigratedValue(tool: tool, kind: kind)
+            }
             return false
         } catch {
             SafeLog.warn("Misc keychain delete failed for \(tool.rawValue).\(kind.rawValue): \(error)")
@@ -87,12 +113,20 @@ public enum MiscCredentialStore {
         readString(tool: tool, kind: kind) != nil
     }
 
+    public static func hasValue(tool: ToolType, kind: Kind, instanceID: String) -> Bool {
+        readString(tool: tool, kind: kind, instanceID: instanceID) != nil
+    }
+
     /// Wipe every Keychain entry vibe-bar holds for one misc tool.
     /// Used by Settings → "Clear stored credentials".
     public static func clearAll(for tool: ToolType) {
+        clearAll(for: tool, instanceID: tool.rawValue)
+    }
+
+    public static func clearAll(for tool: ToolType, instanceID: String) {
         guard tool.isMisc else { return }
         for kind in Kind.allCases {
-            delete(tool: tool, kind: kind)
+            delete(tool: tool, kind: kind, instanceID: instanceID)
         }
     }
 

--- a/Sources/VibeBarCore/Models/AppSettings.swift
+++ b/Sources/VibeBarCore/Models/AppSettings.swift
@@ -28,6 +28,10 @@ public struct AppSettings: Codable, Equatable, Sendable {
     /// used by Settings and the Misc page; missing providers are appended so
     /// older settings files pick up new integrations automatically.
     public var miscProviderOrder: [ToolType]
+    /// User-controlled misc provider instances. Multiple instances may share
+    /// one `ToolType`, but each gets independent credentials, cookie slots,
+    /// quota cache, and settings.
+    public var miscProviderInstances: [MiscProviderInstance]
     public var costData: CostDataSettings
 
     public static let `default` = AppSettings(
@@ -45,6 +49,7 @@ public struct AppSettings: Codable, Equatable, Sendable {
         miscProviders: Self.defaultMiscProviders,
         visibleMiscProviders: Self.defaultVisibleMiscProviders,
         miscProviderOrder: Self.defaultMiscProviderOrder,
+        miscProviderInstances: Self.defaultMiscProviderInstances,
         costData: .default
     )
 
@@ -121,6 +126,10 @@ public struct AppSettings: Codable, Equatable, Sendable {
         ToolType.miscProviders
     }
 
+    public static var defaultMiscProviderInstances: [MiscProviderInstance] {
+        ToolType.miscProviders.map { .defaultInstance(for: $0) }
+    }
+
     public init(
         displayMode: DisplayMode,
         refreshIntervalSeconds: Int,
@@ -136,6 +145,7 @@ public struct AppSettings: Codable, Equatable, Sendable {
         miscProviders: [ToolType: MiscProviderSettings] = AppSettings.defaultMiscProviders,
         visibleMiscProviders: Set<ToolType> = AppSettings.defaultVisibleMiscProviders,
         miscProviderOrder: [ToolType] = AppSettings.defaultMiscProviderOrder,
+        miscProviderInstances: [MiscProviderInstance]? = nil,
         costData: CostDataSettings = .default
     ) {
         self.displayMode = displayMode
@@ -149,9 +159,18 @@ public struct AppSettings: Codable, Equatable, Sendable {
         self.miniWindow = miniWindow
         self.popoverDensities = popoverDensities
         self.providerPlanLabels = Self.normalizedProviderPlanLabels(providerPlanLabels)
-        self.miscProviders = Self.normalizedMiscProviders(miscProviders)
-        self.visibleMiscProviders = Self.normalizedVisibleMiscProviders(visibleMiscProviders)
-        self.miscProviderOrder = Self.normalizedMiscProviderOrder(miscProviderOrder)
+        let normalizedLegacyProviders = Self.normalizedMiscProviders(miscProviders)
+        let normalizedVisibleProviders = Self.normalizedVisibleMiscProviders(visibleMiscProviders)
+        let normalizedProviderOrder = Self.normalizedMiscProviderOrder(miscProviderOrder)
+        self.miscProviderInstances = Self.normalizedMiscProviderInstances(
+            miscProviderInstances,
+            legacyProviders: normalizedLegacyProviders,
+            legacyVisible: normalizedVisibleProviders,
+            legacyOrder: normalizedProviderOrder
+        )
+        self.miscProviders = Self.legacyMiscProviders(from: self.miscProviderInstances)
+        self.visibleMiscProviders = Self.legacyVisibleMiscProviders(from: self.miscProviderInstances)
+        self.miscProviderOrder = Self.legacyMiscProviderOrder(from: self.miscProviderInstances)
         self.costData = costData
     }
 
@@ -171,6 +190,7 @@ public struct AppSettings: Codable, Equatable, Sendable {
         case miscProviders
         case visibleMiscProviders
         case miscProviderOrder
+        case miscProviderInstances
         case costData
     }
 
@@ -222,35 +242,49 @@ public struct AppSettings: Codable, Equatable, Sendable {
         // dropped. `MiscProviderSettings`' own decoder rejects fields
         // whose names look like secrets — together they keep
         // settings.json minimal and credential-free.
+        let decodedLegacyProviders: [ToolType: MiscProviderSettings]
         if let raw = try c.decodeIfPresent([String: MiscProviderSettings].self, forKey: .miscProviders) {
             var map: [ToolType: MiscProviderSettings] = [:]
             for (key, value) in raw {
                 if let tool = ToolType(rawValue: key), tool.isMisc { map[tool] = value }
             }
-            self.miscProviders = Self.normalizedMiscProviders(map)
+            decodedLegacyProviders = Self.normalizedMiscProviders(map)
         } else {
-            self.miscProviders = Self.defaultMiscProviders
+            decodedLegacyProviders = Self.defaultMiscProviders
         }
 
+        let decodedLegacyVisible: Set<ToolType>
         if let rawVisible = try c.decodeIfPresent([String].self, forKey: .visibleMiscProviders) {
             var set: Set<ToolType> = []
             for raw in rawVisible {
                 if let tool = ToolType(rawValue: raw), tool.isMisc { set.insert(tool) }
             }
-            self.visibleMiscProviders = Self.normalizedVisibleMiscProviders(set)
+            decodedLegacyVisible = Self.normalizedVisibleMiscProviders(set)
         } else {
-            self.visibleMiscProviders = Self.defaultVisibleMiscProviders
+            decodedLegacyVisible = Self.defaultVisibleMiscProviders
         }
 
+        let decodedLegacyOrder: [ToolType]
         if let rawOrder = try c.decodeIfPresent([String].self, forKey: .miscProviderOrder) {
             let order = rawOrder.compactMap { raw -> ToolType? in
                 guard let tool = ToolType(rawValue: raw), tool.isMisc else { return nil }
                 return tool
             }
-            self.miscProviderOrder = Self.normalizedMiscProviderOrder(order)
+            decodedLegacyOrder = Self.normalizedMiscProviderOrder(order)
         } else {
-            self.miscProviderOrder = Self.defaultMiscProviderOrder
+            decodedLegacyOrder = Self.defaultMiscProviderOrder
         }
+
+        let decodedInstances = try c.decodeIfPresent([MiscProviderInstance].self, forKey: .miscProviderInstances)
+        self.miscProviderInstances = Self.normalizedMiscProviderInstances(
+            decodedInstances,
+            legacyProviders: decodedLegacyProviders,
+            legacyVisible: decodedLegacyVisible,
+            legacyOrder: decodedLegacyOrder
+        )
+        self.miscProviders = Self.legacyMiscProviders(from: self.miscProviderInstances)
+        self.visibleMiscProviders = Self.legacyVisibleMiscProviders(from: self.miscProviderInstances)
+        self.miscProviderOrder = Self.legacyMiscProviderOrder(from: self.miscProviderInstances)
 
         self.costData = try c.decodeIfPresent(CostDataSettings.self, forKey: .costData) ?? .default
     }
@@ -277,6 +311,7 @@ public struct AppSettings: Codable, Equatable, Sendable {
             .map(\.rawValue)
         try c.encode(visibleRaw, forKey: .visibleMiscProviders)
         try c.encode(miscProviderOrder.map(\.rawValue), forKey: .miscProviderOrder)
+        try c.encode(miscProviderInstances, forKey: .miscProviderInstances)
         try c.encode(costData, forKey: .costData)
     }
 
@@ -378,15 +413,98 @@ public struct AppSettings: Codable, Equatable, Sendable {
         return out
     }
 
+    private static func normalizedMiscProviderInstances(
+        _ instances: [MiscProviderInstance]?,
+        legacyProviders: [ToolType: MiscProviderSettings],
+        legacyVisible: Set<ToolType>,
+        legacyOrder: [ToolType]
+    ) -> [MiscProviderInstance] {
+        var seenIDs: Set<String> = []
+        var out: [MiscProviderInstance] = []
+
+        if let instances, !instances.isEmpty {
+            for raw in instances {
+                guard raw.tool.isMisc else { continue }
+                let trimmedID = raw.id.trimmingCharacters(in: .whitespacesAndNewlines)
+                guard !trimmedID.isEmpty, seenIDs.insert(trimmedID).inserted else { continue }
+                out.append(MiscProviderInstance(
+                    id: trimmedID,
+                    tool: raw.tool,
+                    settings: raw.settings,
+                    isVisible: raw.isVisible,
+                    displayName: raw.displayName
+                ))
+            }
+        } else {
+            for tool in legacyOrder {
+                out.append(.defaultInstance(
+                    for: tool,
+                    settings: legacyProviders[tool] ?? .default,
+                    isVisible: legacyVisible.contains(tool)
+                ))
+                seenIDs.insert(tool.rawValue)
+            }
+        }
+
+        for tool in ToolType.miscProviders where !seenIDs.contains(tool.rawValue) {
+            out.append(.defaultInstance(
+                for: tool,
+                settings: legacyProviders[tool] ?? .default,
+                isVisible: legacyVisible.contains(tool)
+            ))
+            seenIDs.insert(tool.rawValue)
+        }
+        return out
+    }
+
+    private static func legacyMiscProviders(from instances: [MiscProviderInstance]) -> [ToolType: MiscProviderSettings] {
+        var out: [ToolType: MiscProviderSettings] = [:]
+        for tool in ToolType.miscProviders {
+            let preferred = instances.first { $0.tool == tool && $0.isDefault }
+                ?? instances.first { $0.tool == tool }
+            out[tool] = preferred?.settings ?? .default
+        }
+        return out
+    }
+
+    private static func legacyVisibleMiscProviders(from instances: [MiscProviderInstance]) -> Set<ToolType> {
+        Set(instances.filter(\.isVisible).map(\.tool))
+    }
+
+    private static func legacyMiscProviderOrder(from instances: [MiscProviderInstance]) -> [ToolType] {
+        var seen: Set<ToolType> = []
+        var out: [ToolType] = []
+        for instance in instances where seen.insert(instance.tool).inserted {
+            out.append(instance.tool)
+        }
+        for tool in ToolType.miscProviders where seen.insert(tool).inserted {
+            out.append(tool)
+        }
+        return out
+    }
+
+    private mutating func syncLegacyMiscProviderFields() {
+        miscProviderInstances = Self.normalizedMiscProviderInstances(
+            miscProviderInstances,
+            legacyProviders: miscProviders,
+            legacyVisible: visibleMiscProviders,
+            legacyOrder: miscProviderOrder
+        )
+        miscProviders = Self.legacyMiscProviders(from: miscProviderInstances)
+        visibleMiscProviders = Self.legacyVisibleMiscProviders(from: miscProviderInstances)
+        miscProviderOrder = Self.legacyMiscProviderOrder(from: miscProviderInstances)
+    }
+
     public func miscProvider(_ tool: ToolType) -> MiscProviderSettings {
         precondition(tool.isMisc, "miscProvider lookup requested for primary tool: \(tool)")
-        return miscProviders[tool] ?? .default
+        return miscProviderInstance(id: tool.rawValue)?.settings
+            ?? miscProviders[tool]
+            ?? .default
     }
 
     public mutating func setMiscProvider(_ settings: MiscProviderSettings, for tool: ToolType) {
         precondition(tool.isMisc, "setMiscProvider lookup requested for primary tool: \(tool)")
-        miscProviders[tool] = settings
-        miscProviders = Self.normalizedMiscProviders(miscProviders)
+        setMiscProviderInstanceSettings(settings, forID: tool.rawValue)
     }
 
     public func isMiscProviderVisible(_ tool: ToolType) -> Bool {
@@ -395,17 +513,12 @@ public struct AppSettings: Codable, Equatable, Sendable {
     }
 
     public var visibleMiscProviderList: [ToolType] {
-        Self.normalizedMiscProviderOrder(miscProviderOrder).filter { isMiscProviderVisible($0) }
+        visibleMiscProviderInstances.map(\.tool)
     }
 
     public mutating func setMiscProviderVisible(_ visible: Bool, for tool: ToolType) {
         precondition(tool.isMisc, "visibility update requested for primary tool: \(tool)")
-        if visible {
-            visibleMiscProviders.insert(tool)
-        } else {
-            visibleMiscProviders.remove(tool)
-        }
-        visibleMiscProviders = Self.normalizedVisibleMiscProviders(visibleMiscProviders)
+        setMiscProviderInstanceVisible(visible, forID: tool.rawValue)
     }
 
     public func miscProviderOrderIndex(_ tool: ToolType) -> Int? {
@@ -415,13 +528,115 @@ public struct AppSettings: Codable, Equatable, Sendable {
 
     public mutating func moveMiscProvider(_ tool: ToolType, offset: Int) {
         precondition(tool.isMisc, "order update requested for primary tool: \(tool)")
-        var order = Self.normalizedMiscProviderOrder(miscProviderOrder)
-        guard let from = order.firstIndex(of: tool) else { return }
+        var order = miscProviderInstances
+        guard let from = order.firstIndex(where: { $0.id == tool.rawValue }) else { return }
         let to = max(0, min(order.count - 1, from + offset))
         guard from != to else { return }
         let item = order.remove(at: from)
         order.insert(item, at: to)
-        miscProviderOrder = Self.normalizedMiscProviderOrder(order)
+        miscProviderInstances = order
+        syncLegacyMiscProviderFields()
+    }
+
+    public var visibleMiscProviderInstances: [MiscProviderInstance] {
+        miscProviderInstances.filter(\.isVisible)
+    }
+
+    public func miscProviderInstance(id: String) -> MiscProviderInstance? {
+        miscProviderInstances.first { $0.id == id }
+    }
+
+    public func miscProviderSettings(forInstanceID id: String) -> MiscProviderSettings {
+        miscProviderInstance(id: id)?.settings ?? .default
+    }
+
+    public mutating func setMiscProviderInstanceSettings(_ settings: MiscProviderSettings, forID id: String) {
+        guard let index = miscProviderInstances.firstIndex(where: { $0.id == id }) else { return }
+        miscProviderInstances[index].settings = settings.automaticSourceSelection
+        syncLegacyMiscProviderFields()
+    }
+
+    public mutating func setMiscProviderInstanceVisible(_ visible: Bool, forID id: String) {
+        guard let index = miscProviderInstances.firstIndex(where: { $0.id == id }) else { return }
+        miscProviderInstances[index].isVisible = visible
+        syncLegacyMiscProviderFields()
+    }
+
+    public mutating func setMiscProviderInstanceDisplayName(_ displayName: String?, forID id: String) {
+        guard let index = miscProviderInstances.firstIndex(where: { $0.id == id }) else { return }
+        miscProviderInstances[index].displayName = MiscProviderInstance.normalizedDisplayName(displayName)
+        syncLegacyMiscProviderFields()
+    }
+
+    @discardableResult
+    public mutating func cloneMiscProviderInstance(id: String) -> MiscProviderInstance? {
+        guard let index = miscProviderInstances.firstIndex(where: { $0.id == id }) else { return nil }
+        let original = miscProviderInstances[index]
+        let existingIDs = Set(miscProviderInstances.map(\.id))
+        var cloneID: String
+        repeat {
+            cloneID = "\(original.tool.rawValue)-\(UUID().uuidString.lowercased())"
+        } while existingIDs.contains(cloneID)
+
+        let clone = MiscProviderInstance(
+            id: cloneID,
+            tool: original.tool,
+            settings: original.settings,
+            isVisible: true
+        )
+        miscProviderInstances.insert(clone, at: miscProviderInstances.index(after: index))
+        syncLegacyMiscProviderFields()
+        return clone
+    }
+
+    @discardableResult
+    public mutating func removeMiscProviderInstance(id: String) -> MiscProviderInstance? {
+        guard let index = miscProviderInstances.firstIndex(where: { $0.id == id }) else { return nil }
+        let instance = miscProviderInstances[index]
+        guard !instance.isDefault else { return nil }
+        miscProviderInstances.remove(at: index)
+        syncLegacyMiscProviderFields()
+        return instance
+    }
+
+    public mutating func moveMiscProviderInstance(id: String, before targetID: String) {
+        guard id != targetID,
+              let from = miscProviderInstances.firstIndex(where: { $0.id == id }),
+              let target = miscProviderInstances.firstIndex(where: { $0.id == targetID })
+        else { return }
+        let item = miscProviderInstances.remove(at: from)
+        let adjustedTarget = from < target ? target - 1 : target
+        miscProviderInstances.insert(item, at: adjustedTarget)
+        syncLegacyMiscProviderFields()
+    }
+
+    public mutating func moveMiscProviderInstanceToEnd(id: String) {
+        guard let from = miscProviderInstances.firstIndex(where: { $0.id == id }) else { return }
+        let item = miscProviderInstances.remove(at: from)
+        miscProviderInstances.append(item)
+        syncLegacyMiscProviderFields()
+    }
+
+    public mutating func moveMiscProviderInstance(fromOffsets offsets: IndexSet, toOffset: Int) {
+        let sortedOffsets = offsets.sorted()
+        guard !sortedOffsets.isEmpty else { return }
+        let moving = sortedOffsets.compactMap { index -> MiscProviderInstance? in
+            guard miscProviderInstances.indices.contains(index) else { return nil }
+            return miscProviderInstances[index]
+        }
+        guard moving.count == sortedOffsets.count else { return }
+
+        var remaining = miscProviderInstances.enumerated()
+            .filter { !offsets.contains($0.offset) }
+            .map(\.element)
+        var destination = toOffset
+        for offset in sortedOffsets where offset < toOffset {
+            destination -= 1
+        }
+        destination = max(0, min(destination, remaining.count))
+        remaining.insert(contentsOf: moving, at: destination)
+        miscProviderInstances = remaining
+        syncLegacyMiscProviderFields()
     }
 
     private static func migratedMenuBarItem(_ item: MenuBarItemSettings) -> MenuBarItemSettings {

--- a/Sources/VibeBarCore/Models/MiscProviderInstance.swift
+++ b/Sources/VibeBarCore/Models/MiscProviderInstance.swift
@@ -1,0 +1,60 @@
+import Foundation
+
+/// User-facing copy of a misc provider.
+///
+/// The default instance keeps `id == tool.rawValue`, which preserves
+/// existing settings and Keychain account names. Cloned instances get
+/// their own stable id, account id, quota cache, and Keychain slots.
+public struct MiscProviderInstance: Codable, Equatable, Identifiable, Sendable {
+    public var id: String
+    public var tool: ToolType
+    public var settings: MiscProviderSettings
+    public var isVisible: Bool
+    public var displayName: String?
+
+    public init(
+        id: String,
+        tool: ToolType,
+        settings: MiscProviderSettings = .default,
+        isVisible: Bool = true,
+        displayName: String? = nil
+    ) {
+        self.id = id
+        self.tool = tool
+        self.settings = settings.automaticSourceSelection
+        self.isVisible = isVisible
+        self.displayName = Self.normalizedDisplayName(displayName)
+    }
+
+    public static func defaultInstance(
+        for tool: ToolType,
+        settings: MiscProviderSettings = .default,
+        isVisible: Bool = true,
+        displayName: String? = nil
+    ) -> MiscProviderInstance {
+        MiscProviderInstance(
+            id: tool.rawValue,
+            tool: tool,
+            settings: settings,
+            isVisible: isVisible,
+            displayName: displayName
+        )
+    }
+
+    public var isDefault: Bool {
+        id == tool.rawValue
+    }
+
+    public var title: String {
+        tool.menuTitle
+    }
+
+    public func displayTitle(fallback: String) -> String {
+        displayName ?? fallback
+    }
+
+    public static func normalizedDisplayName(_ value: String?) -> String? {
+        let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return trimmed.isEmpty ? nil : trimmed
+    }
+}

--- a/Sources/VibeBarCore/Models/MiscProviderSettings.swift
+++ b/Sources/VibeBarCore/Models/MiscProviderSettings.swift
@@ -3,7 +3,7 @@ import Foundation
 /// Non-sensitive per-misc-provider configuration that lives in
 /// `~/.vibebar/settings.json`. Sensitive values (API keys, cookie
 /// headers, OAuth tokens) live in Keychain — see
-/// `MiscCredentialStore` and `CookieHeaderCache`.
+/// `MiscCredentialStore` and `MiscCookieSlotStore`.
 ///
 /// The Codable round-trip rejects any field whose name contains a
 /// secret-looking key (`apiKey`, `cookie`, `token`, `password`, etc.).
@@ -145,12 +145,16 @@ public struct MiscProviderSettings: Codable, Equatable, Sendable {
     }
 
     public static func current(for tool: ToolType) -> MiscProviderSettings {
+        current(for: tool, instanceID: tool.rawValue)
+    }
+
+    public static func current(for tool: ToolType, instanceID: String) -> MiscProviderSettings {
         guard tool.isMisc else { return .default }
         let appSettings = (try? VibeBarLocalStore.readJSON(
             AppSettings.self,
             from: VibeBarLocalStore.settingsURL
         )) ?? .default
-        return appSettings.miscProvider(tool).automaticSourceSelection
+        return appSettings.miscProviderSettings(forInstanceID: instanceID).automaticSourceSelection
     }
 
     public var allowsAPIOrOAuthAccess: Bool {

--- a/Sources/VibeBarCore/Storage/AccountStore.swift
+++ b/Sources/VibeBarCore/Storage/AccountStore.swift
@@ -8,9 +8,9 @@ import Combine
 /// credential is found, no account is registered, and the popover shows
 /// a "logged out" placeholder for that tool.
 ///
-/// Misc providers (`ToolType.miscProviders`) follow the opposite rule:
-/// every misc provider always has a stable account id of the form
-/// `"misc-<rawValue>"`, even when no credential is configured. The
+/// Misc provider instances follow the opposite rule: every visible or
+/// hidden instance always has a stable account id of the form
+/// `"misc-<instanceID>"`, even when no credential is configured. The
 /// resulting card shows a "Set up" call-to-action; once a credential
 /// lands the same id is reused so cached snapshots survive.
 @MainActor
@@ -19,15 +19,21 @@ public final class AccountStore: ObservableObject {
 
     public init(
         codexUsageMode: CodexUsageMode = .auto,
-        claudeUsageMode: ClaudeUsageMode = .auto
+        claudeUsageMode: ClaudeUsageMode = .auto,
+        miscProviderInstances: [MiscProviderInstance] = AppSettings.defaultMiscProviderInstances
     ) {
-        reload(codexUsageMode: codexUsageMode, claudeUsageMode: claudeUsageMode)
+        reload(
+            codexUsageMode: codexUsageMode,
+            claudeUsageMode: claudeUsageMode,
+            miscProviderInstances: miscProviderInstances
+        )
     }
 
     /// Re-scan CLI keychain/files for auto-detected provider identities.
     public func reload(
         codexUsageMode: CodexUsageMode = .auto,
-        claudeUsageMode: ClaudeUsageMode = .auto
+        claudeUsageMode: ClaudeUsageMode = .auto,
+        miscProviderInstances: [MiscProviderInstance] = AppSettings.defaultMiscProviderInstances
     ) {
         var detected: [AccountIdentity] = []
 
@@ -38,9 +44,9 @@ public final class AccountStore: ObservableObject {
             detected.append(claude)
         }
 
-        // Misc providers always present, regardless of credentials.
-        for tool in ToolType.miscProviders {
-            detected.append(miscPlaceholder(for: tool))
+        // Misc provider instances always present, regardless of credentials.
+        for instance in miscProviderInstances {
+            detected.append(miscPlaceholder(for: instance))
         }
 
         self.accounts = detected
@@ -50,9 +56,25 @@ public final class AccountStore: ObservableObject {
         accounts.filter { $0.tool == tool }
     }
 
-    public static func miscAccountId(for tool: ToolType) -> String {
+    public func account(forMiscProviderInstanceID instanceID: String) -> AccountIdentity? {
+        accounts.first { $0.id == Self.miscAccountId(forInstanceID: instanceID) }
+    }
+
+    nonisolated public static func miscAccountId(for tool: ToolType) -> String {
         precondition(tool.isMisc, "miscAccountId requested for primary tool: \(tool)")
-        return "misc-\(tool.rawValue)"
+        return miscAccountId(forInstanceID: tool.rawValue)
+    }
+
+    nonisolated public static func miscAccountId(forInstanceID instanceID: String) -> String {
+        "misc-\(instanceID)"
+    }
+
+    nonisolated public static func miscInstanceID(fromAccountID accountID: String, fallbackTool: ToolType) -> String {
+        let prefix = "misc-"
+        guard accountID.hasPrefix(prefix), accountID.count > prefix.count else {
+            return fallbackTool.rawValue
+        }
+        return String(accountID.dropFirst(prefix.count))
     }
 
     // MARK: - CLI auto detection
@@ -182,11 +204,11 @@ public final class AccountStore: ObservableObject {
     /// adapter actually fetches successfully, `QuotaService` updates
     /// the snapshot's metadata — the placeholder identity is mainly a
     /// hook for the UI to render a card and route to Settings.
-    private func miscPlaceholder(for tool: ToolType) -> AccountIdentity {
+    private func miscPlaceholder(for instance: MiscProviderInstance) -> AccountIdentity {
         AccountIdentity(
-            id: AccountStore.miscAccountId(for: tool),
-            tool: tool,
-            alias: tool.menuTitle,
+            id: AccountStore.miscAccountId(forInstanceID: instance.id),
+            tool: instance.tool,
+            alias: instance.displayName ?? instance.tool.menuTitle,
             source: .notConfigured,
             createdAt: Date(),
             updatedAt: Date()

--- a/Tests/VibeBarCoreTests/MiscProviderSettingsTests.swift
+++ b/Tests/VibeBarCoreTests/MiscProviderSettingsTests.swift
@@ -204,6 +204,97 @@ final class AppSettingsMiscProviderTests: XCTestCase {
         XCTAssertEqual(object["miscProviderOrder"] as? [String], settings.miscProviderOrder.map(\.rawValue))
     }
 
+    func testClonedMiscProviderInstancesAreIndependentAndReorderable() {
+        var settings = AppSettings.default
+        let originalID = ToolType.volcengine.rawValue
+
+        guard let clone = settings.cloneMiscProviderInstance(id: originalID) else {
+            return XCTFail("expected Volcengine clone")
+        }
+
+        XCTAssertNotEqual(clone.id, originalID)
+        XCTAssertEqual(clone.tool, .volcengine)
+        XCTAssertEqual(settings.visibleMiscProviderInstances.filter { $0.tool == .volcengine }.count, 2)
+
+        var cloneSettings = settings.miscProviderInstance(id: clone.id)?.settings ?? .default
+        cloneSettings.region = "cn-beijing"
+        settings.setMiscProviderInstanceSettings(cloneSettings, forID: clone.id)
+
+        XCTAssertNil(settings.miscProviderInstance(id: originalID)?.settings.region)
+        XCTAssertEqual(settings.miscProviderInstance(id: clone.id)?.settings.region, "cn-beijing")
+
+        settings.moveMiscProviderInstance(id: clone.id, before: originalID)
+        let ids = settings.miscProviderInstances.map(\.id)
+        XCTAssertLessThan(
+            try XCTUnwrap(ids.firstIndex(of: clone.id)),
+            try XCTUnwrap(ids.firstIndex(of: originalID))
+        )
+        settings.moveMiscProviderInstanceToEnd(id: clone.id)
+        XCTAssertEqual(settings.miscProviderInstances.last?.id, clone.id)
+
+        settings.setMiscProviderInstanceVisible(false, forID: clone.id)
+        XCTAssertEqual(settings.visibleMiscProviderInstances.filter { $0.tool == .volcengine }.map(\.id), [originalID])
+    }
+
+    func testMiscProviderInstanceDisplayNamesAreIndependentAndRoundTrip() throws {
+        var settings = AppSettings.default
+        let originalID = ToolType.volcengine.rawValue
+
+        guard let clone = settings.cloneMiscProviderInstance(id: originalID) else {
+            return XCTFail("expected Volcengine clone")
+        }
+
+        settings.setMiscProviderInstanceDisplayName("  Work account  ", forID: clone.id)
+
+        XCTAssertNil(settings.miscProviderInstance(id: originalID)?.displayName)
+        XCTAssertEqual(settings.miscProviderInstance(id: clone.id)?.displayName, "Work account")
+
+        let decoded = try JSONDecoder().decode(
+            AppSettings.self,
+            from: try JSONEncoder().encode(settings)
+        )
+        XCTAssertEqual(decoded.miscProviderInstance(id: clone.id)?.displayName, "Work account")
+
+        var mutable = decoded
+        mutable.setMiscProviderInstanceDisplayName("   ", forID: clone.id)
+        XCTAssertNil(mutable.miscProviderInstance(id: clone.id)?.displayName)
+    }
+
+    func testLegacyMiscProviderFieldsMigrateToDefaultInstances() throws {
+        let json = """
+        {
+          "visibleMiscProviders": ["openRouter", "minimax"],
+          "miscProviderOrder": ["openRouter", "removedProvider", "codex", "minimax"],
+          "miscProviders": {
+            "minimax": { "region": "global" }
+          }
+        }
+        """
+
+        let settings = try JSONDecoder().decode(AppSettings.self, from: Data(json.utf8))
+
+        XCTAssertEqual(settings.miscProviderInstances.prefix(2).map(\.tool), [.openRouter, .minimax])
+        XCTAssertEqual(settings.visibleMiscProviderInstances.map(\.tool), [.openRouter, .minimax])
+        XCTAssertEqual(settings.miscProviderInstance(id: ToolType.minimax.rawValue)?.settings.region, "global")
+    }
+
+    @MainActor
+    func testAccountStoreCreatesSeparateAccountsForMiscProviderInstances() {
+        var settings = AppSettings.default
+        guard let clone = settings.cloneMiscProviderInstance(id: ToolType.volcengine.rawValue) else {
+            return XCTFail("expected Volcengine clone")
+        }
+
+        let accounts = AccountStore(miscProviderInstances: settings.miscProviderInstances)
+        let volcengineAccounts = accounts.accounts(for: .volcengine)
+
+        XCTAssertEqual(volcengineAccounts.map(\.id), [
+            AccountStore.miscAccountId(forInstanceID: ToolType.volcengine.rawValue),
+            AccountStore.miscAccountId(forInstanceID: clone.id)
+        ])
+        XCTAssertEqual(Set(volcengineAccounts.map(\.id)).count, 2)
+    }
+
     func testUnknownMiscProviderKeysAreDropped() throws {
         let json = """
         {


### PR DESCRIPTION
## Summary
- Add persistent misc provider instances so cloned providers keep independent settings, credentials, cookie slots, quota cache, and display names.
- Replace arrow-only misc provider ordering with drag reordering in Settings.
- Show aggregate Misc-page status for same-provider copies, with per-copy detail rows and refresh controls.

## Test plan
- [x] swift test --filter AppSettingsMiscProviderTests/testMiscProviderInstanceDisplayNamesAreIndependentAndRoundTrip
- [x] swift test
- [x] swift build
- [x] ./Scripts/build_app.sh release
- [x] codesign -d --entitlements - ".build/Vibe Bar.app"
- [x] codesign --verify --deep --strict ".build/Vibe Bar.app"