### PR TITLE
Add Alibaba Token Plan misc provider alongside Coding Plan

### DIFF
--- a/Sources/VibeBarApp/HiddenCookieRefresher.swift
+++ b/Sources/VibeBarApp/HiddenCookieRefresher.swift
@@ -82,12 +82,26 @@ final class HiddenCookieRefresher {
                     requiredCookieNames: [],
                     postLoadWait: 10
                 )
+            case .alibabaTokenPlan:
+                // Same console family as Alibaba Coding Plan — the
+                // cookies are interchangeable since they're issued
+                // by `*.aliyun.com`. We still refresh through the
+                // Token Plan dashboard URL so the page's own keepalive
+                // touches the BSS-side session helpers the Token Plan
+                // BFF (`GetSeatSubscriptionSummary`) cares about.
+                return Config(
+                    tool: .alibabaTokenPlan,
+                    refreshURL: URL(string: "https://bailian.console.aliyun.com/cn-beijing/?tab=plan#/efm/subscription/token-plan")!,
+                    cookieDomainSuffixes: ["aliyun.com", "alibabacloud.com"],
+                    requiredCookieNames: [],
+                    postLoadWait: 10
+                )
             default:
                 return nil
             }
         }
 
-        static let supportedTools: [ToolType] = [.tencentHunyuan, .volcengine, .alibaba]
+        static let supportedTools: [ToolType] = [.tencentHunyuan, .volcengine, .alibaba, .alibabaTokenPlan]
     }
 
     private var inflight: [ToolType: Task<Bool, Never>] = [:]

--- a/Sources/VibeBarApp/MiscWebLoginController.swift
+++ b/Sources/VibeBarApp/MiscWebLoginController.swift
@@ -727,6 +727,31 @@ final class MiscWebLoginRegistry {
                 savedConfirmation: "Alibaba console cookies saved.",
                 setupHint: "Sign in to Bailian (CN) or ModelStudio (Intl); use the same console where your Coding Plan lives. Then click Save Cookies."
             )
+        case .alibabaTokenPlan:
+            return MiscWebLoginController.Config(
+                tool: .alibabaTokenPlan,
+                // Open the Token Plan dashboard directly so the user
+                // can confirm their subscription is active before
+                // saving cookies. The auth jar is identical to the
+                // Coding Plan login — same Aliyun ID, same *.aliyun.com
+                // ticket cookies.
+                loginURL: URL(string: "https://bailian.console.aliyun.com/cn-beijing/?tab=plan#/efm/subscription/token-plan")!,
+                cookieDomainSuffixes: ["aliyun.com", "alibabacloud.com"],
+                requiredCookieNames: [],
+                trustedAuthHostSuffixes: [
+                    "aliyun.com",
+                    "alibabacloud.com",
+                    "alibaba.com",
+                    "alibaba-inc.com",
+                    "alicdn.com",
+                    "alipay.com",
+                    "taobao.com",
+                    "alibabausercontent.com"
+                ],
+                windowTitle: "Alibaba Bailian Token Plan Login",
+                savedConfirmation: "Alibaba Token Plan cookies saved.",
+                setupHint: "Sign in to Bailian (CN) or ModelStudio (Intl) on the same Aliyun account that owns the Token Plan. Then click Save Cookies."
+            )
         default:
             return nil
         }

--- a/Sources/VibeBarApp/ProviderBrandIcon.swift
+++ b/Sources/VibeBarApp/ProviderBrandIcon.swift
@@ -62,7 +62,7 @@ enum ProviderBrandIcon {
         switch tool {
         case .codex:  return fallbackSystemImage(for: MenuBarItemKind.codex)
         case .claude: return fallbackSystemImage(for: MenuBarItemKind.claude)
-        case .alibaba, .gemini, .antigravity, .copilot, .zai, .minimax, .kimi, .cursor, .mimo, .iflytek, .tencentHunyuan, .volcengine, .openCodeGo, .kilo, .kiro, .ollama, .openRouter, .warp:
+        case .alibaba, .alibabaTokenPlan, .gemini, .antigravity, .copilot, .zai, .minimax, .kimi, .cursor, .mimo, .iflytek, .tencentHunyuan, .volcengine, .openCodeGo, .kilo, .kiro, .ollama, .openRouter, .warp:
             return tool.miscFallbackSymbol
         }
     }
@@ -162,7 +162,7 @@ enum ProviderBrandIcon {
         let svg: String? = switch tool {
         case .codex: openAISVG
         case .claude: claudeSVG
-        case .alibaba, .gemini, .antigravity, .copilot, .zai, .minimax, .kimi, .cursor, .mimo, .iflytek, .tencentHunyuan, .volcengine, .openCodeGo, .kilo, .kiro, .ollama, .openRouter, .warp:
+        case .alibaba, .alibabaTokenPlan, .gemini, .antigravity, .copilot, .zai, .minimax, .kimi, .cursor, .mimo, .iflytek, .tencentHunyuan, .volcengine, .openCodeGo, .kilo, .kiro, .ollama, .openRouter, .warp:
             nil
         }
         guard let svg, let image = NSImage(data: Data(svg.utf8)) else { return nil }
@@ -359,6 +359,7 @@ extension ToolType {
         case .codex:       return "ProviderIcon-codex"
         case .claude:      return "ProviderIcon-claude"
         case .alibaba:     return "ProviderIcon-alibaba"
+        case .alibabaTokenPlan: return "ProviderIcon-alibaba"
         case .gemini:      return "ProviderIcon-gemini"
         case .antigravity: return "ProviderIcon-antigravity"
         case .copilot:     return "ProviderIcon-copilot"
@@ -385,7 +386,7 @@ extension ToolType {
             return 1.0
         case .gemini, .antigravity, .copilot, .cursor:
             return 1.25
-        case .alibaba, .minimax, .kimi, .mimo, .iflytek, .tencentHunyuan, .volcengine, .openCodeGo, .kilo, .kiro, .ollama, .openRouter, .warp:
+        case .alibaba, .alibabaTokenPlan, .minimax, .kimi, .mimo, .iflytek, .tencentHunyuan, .volcengine, .openCodeGo, .kilo, .kiro, .ollama, .openRouter, .warp:
             return 1.36
         case .zai:
             return 1.5
@@ -401,6 +402,7 @@ extension ToolType {
         case .codex, .claude:
             return "sparkles"
         case .alibaba:     return "cube.transparent"
+        case .alibabaTokenPlan: return "creditcard"
         case .gemini:      return "sparkle"
         case .antigravity: return "arrow.up.forward.app"
         case .copilot:     return "chevron.left.forward.slash.chevron.right"

--- a/Sources/VibeBarApp/Views/MiniQuotaWindowView.swift
+++ b/Sources/VibeBarApp/Views/MiniQuotaWindowView.swift
@@ -268,6 +268,7 @@ private func providerAccent(for tool: ToolType) -> Color {
     case .codex:       return Color(red: 0.30, green: 0.78, blue: 0.74)  // teal
     case .claude:      return Color(red: 0.93, green: 0.40, blue: 0.40)  // coral
     case .alibaba:     return Color(red: 1.00, green: 0.62, blue: 0.20)  // amber
+    case .alibabaTokenPlan: return Color(red: 1.00, green: 0.48, blue: 0.18)  // deeper amber
     case .gemini:      return Color(red: 0.34, green: 0.62, blue: 0.96)  // google blue
     case .antigravity: return Color(red: 0.55, green: 0.40, blue: 0.92)  // violet
     case .copilot:     return Color(red: 0.46, green: 0.46, blue: 0.46)  // graphite
@@ -293,6 +294,7 @@ private func providerTitle(for tool: ToolType) -> String {
     case .codex:       return "CODEX"
     case .claude:      return "CLAUDE"
     case .alibaba:     return "QWEN"
+    case .alibabaTokenPlan: return "QWEN TP"
     case .gemini:      return "GEMINI"
     case .antigravity: return "ANTIGRAVITY"
     case .copilot:     return "COPILOT"

--- a/Sources/VibeBarApp/Views/MiscProviderSettingsSection.swift
+++ b/Sources/VibeBarApp/Views/MiscProviderSettingsSection.swift
@@ -133,6 +133,21 @@ struct MiscProviderSettingsSection: View {
                     helpText: "No DashScope key? Sign in to bailian.console.aliyun.com or modelstudio.console.alibabacloud.com once via Web; Vibe Bar refreshes the console session in the background after that."
                 )
             }
+        case .alibabaTokenPlan:
+            VStack(alignment: .leading, spacing: 4) {
+                AlibabaRegionPicker(instanceID: instanceID)
+                CookieSourceControls(
+                    tool: .alibabaTokenPlan,
+                    instanceID: instanceID,
+                    spec: AlibabaTokenPlanQuotaAdapter.cookieSpec,
+                    manualPrompt: "Paste console.aliyun.com Cookie header (login_aliyunid_csrf=…; cna=…; …)"
+                )
+                MiscWebLoginRow(
+                    tool: .alibabaTokenPlan,
+                    instanceID: instanceID,
+                    helpText: "Sign in to bailian.console.aliyun.com once on the Aliyun account that owns the Token Plan. Same login as the Coding Plan card — you can sign in on either."
+                )
+            }
         case .minimax:
             VStack(alignment: .leading, spacing: 4) {
                 ApiKeyField(

--- a/Sources/VibeBarApp/Views/PopoverRoot.swift
+++ b/Sources/VibeBarApp/Views/PopoverRoot.swift
@@ -795,7 +795,7 @@ private struct OverviewCostCard: View {
         switch tool {
         case .codex:  return "No Codex CLI sessions found yet."
         case .claude: return "No Claude CLI sessions found yet."
-        case .alibaba, .gemini, .antigravity, .copilot, .zai, .minimax, .kimi, .cursor, .mimo, .iflytek, .tencentHunyuan, .volcengine, .openCodeGo, .kilo, .kiro, .ollama, .openRouter, .warp:
+        case .alibaba, .alibabaTokenPlan, .gemini, .antigravity, .copilot, .zai, .minimax, .kimi, .cursor, .mimo, .iflytek, .tencentHunyuan, .volcengine, .openCodeGo, .kilo, .kiro, .ollama, .openRouter, .warp:
             // Misc providers' empty cost-history view shouldn't be
             // reachable (cost cards are gated on
             // `tool.supportsTokenCost`), but render a graceful
@@ -1131,7 +1131,7 @@ struct ProviderQuotaCard: View {
         switch tool {
         case .codex:  return "Run codex login, then refresh."
         case .claude: return "Run claude login, then refresh."
-        case .alibaba, .gemini, .antigravity, .copilot, .zai, .minimax, .kimi, .cursor, .mimo, .iflytek, .tencentHunyuan, .volcengine, .openCodeGo, .kilo, .kiro, .ollama, .openRouter, .warp:
+        case .alibaba, .alibabaTokenPlan, .gemini, .antigravity, .copilot, .zai, .minimax, .kimi, .cursor, .mimo, .iflytek, .tencentHunyuan, .volcengine, .openCodeGo, .kilo, .kiro, .ollama, .openRouter, .warp:
             // Misc providers route through the Misc page's per-card
             // setup CTA. This empty-message path is only reachable from
             // a primary-provider detail view, but cover misc cases

--- a/Sources/VibeBarApp/Views/UsageHeatmapView.swift
+++ b/Sources/VibeBarApp/Views/UsageHeatmapView.swift
@@ -66,7 +66,7 @@ struct UsageHeatmapView: View {
         switch heatmap.tool {
         case .codex:  return "Codex"
         case .claude: return "Claude"
-        case .alibaba, .gemini, .antigravity, .copilot, .zai, .minimax, .kimi, .cursor, .mimo, .iflytek, .tencentHunyuan, .volcengine, .openCodeGo, .kilo, .kiro, .ollama, .openRouter, .warp:
+        case .alibaba, .alibabaTokenPlan, .gemini, .antigravity, .copilot, .zai, .minimax, .kimi, .cursor, .mimo, .iflytek, .tencentHunyuan, .volcengine, .openCodeGo, .kilo, .kiro, .ollama, .openRouter, .warp:
             return heatmap.tool.menuTitle
         }
     }

--- a/Sources/VibeBarCore/Adapters/AlibabaTokenPlanQuotaAdapter.swift
+++ b/Sources/VibeBarCore/Adapters/AlibabaTokenPlanQuotaAdapter.swift
@@ -1,0 +1,644 @@
+import Foundation
+
+/// Alibaba Qwen / Bailian **Token Plan** usage adapter.
+///
+/// Lives alongside `AlibabaQuotaAdapter` (the Coding Plan flavour).
+/// Token Plan is a different commercial product with credit-based
+/// quotas — sold separately, lives on a different BFF, has its own
+/// console URL, and the dashboard renders under a separate tab:
+/// `https://bailian.console.aliyun.com/cn-beijing?tab=plan#/efm/subscription/token-plan`.
+///
+/// Auth: console cookies only (`*.aliyun.com` / `*.alibabacloud.com`).
+/// DashScope API keys are not used for the Token Plan BFF — that
+/// endpoint is BSS-backed (BssOpenAPI-V3) and authenticates the user
+/// via the regular Aliyun console session jar, just like the buy /
+/// renew flow in the browser.
+///
+/// Request shape captured from the live console:
+///
+///     POST https://bailian.console.aliyun.com/data/api.json
+///        ?action=GetSeatSubscriptionSummary
+///        &product=BssOpenAPI-V3
+///        &_tag=
+///     Body (form-urlencoded):
+///        product=BssOpenAPI-V3
+///        action=GetSeatSubscriptionSummary
+///        params={"ProductCode":"sfm_tokenplanteams_dp_cn"}
+///        sec_token=<scraped>
+///        region=cn-qingdao
+///
+/// Response payload contains `SubscriptionGroupList[]` with one entry
+/// per seat tier (standard / advanced / exclusive). Each entry carries
+/// an `EquityList[]` with the `credit_value` totals and surplus, plus a
+/// `NextCycleFlushTime` reset stamp. We surface one quota bucket per
+/// non-empty seat tier so the misc card mirrors what the user sees in
+/// the browser dashboard.
+public struct AlibabaTokenPlanQuotaAdapter: QuotaAdapter {
+    public let tool: ToolType = .alibabaTokenPlan
+
+    private let session: URLSession
+    private let now: @Sendable () -> Date
+
+    public static let cookieSpec = MiscCookieResolver.Spec(
+        tool: .alibabaTokenPlan,
+        domains: [
+            "bailian.console.aliyun.com",
+            "modelstudio.console.alibabacloud.com",
+            ".aliyun.com",
+            ".alibabacloud.com"
+        ],
+        // Same trade-off as the Coding Plan jar: console identity is
+        // stitched together from `login_aliyunid_csrf`, `cna`, plus
+        // HttpOnly login tickets we can't enumerate from JS, so we
+        // ship the full jar.
+        requiredNames: []
+    )
+
+    public init(
+        session: URLSession = .shared,
+        now: @escaping @Sendable () -> Date = { Date() }
+    ) {
+        self.session = session
+        self.now = now
+    }
+
+    public func fetch(for account: AccountIdentity) async throws -> AccountQuota {
+        let instanceID = AccountStore.miscInstanceID(fromAccountID: account.id, fallbackTool: .alibabaTokenPlan)
+        let settings = MiscProviderSettings.current(for: .alibabaTokenPlan, instanceID: instanceID)
+
+        let preferred: [AlibabaTokenPlanRegion]
+        switch settings.region {
+        case "ap-southeast-1", "intl", "international":
+            preferred = [.international]
+        case "cn-beijing", "cn", "china":
+            preferred = [.chinaMainland]
+        default:
+            preferred = [.chinaMainland, .international]
+        }
+
+        let queriedAt = now()
+        let cookieResolutions = MiscCookieResolver.resolveAll(for: AlibabaTokenPlanQuotaAdapter.cookieSpec, account: account)
+        guard !cookieResolutions.isEmpty else {
+            throw QuotaError.noCredential
+        }
+
+        let results = await MiscQuotaAggregator.gatherSlotResults(cookieResolutions) { resolution in
+            try await self.fetchViaCookieSlot(
+                resolution: resolution,
+                regions: preferred,
+                account: account,
+                queriedAt: queriedAt
+            )
+        }
+        return MiscQuotaAggregator.aggregate(
+            tool: .alibabaTokenPlan,
+            account: account,
+            results: results,
+            queriedAt: queriedAt
+        )
+    }
+
+    private func fetchViaCookieSlot(resolution: MiscCookieResolver.Resolution,
+                                    regions: [AlibabaTokenPlanRegion],
+                                    account: AccountIdentity,
+                                    queriedAt: Date) async throws -> AccountQuota {
+        var lastError: QuotaError?
+        for region in regions {
+            do {
+                let secToken = try await resolveSECToken(cookieHeader: resolution.header, region: region)
+                let snapshot = try await fetchSeatSummary(
+                    cookieHeader: resolution.header,
+                    secToken: secToken,
+                    region: region,
+                    now: queriedAt
+                )
+                return AccountQuota(
+                    accountId: account.id,
+                    tool: .alibabaTokenPlan,
+                    buckets: snapshot.buckets,
+                    plan: snapshot.planName,
+                    email: account.email,
+                    queriedAt: queriedAt,
+                    error: nil
+                )
+            } catch let qe as QuotaError {
+                lastError = qe
+                switch qe {
+                case .needsLogin, .noCredential:
+                    continue
+                default:
+                    throw qe
+                }
+            }
+        }
+        throw lastError ?? QuotaError.unknown("Alibaba Token Plan: no usable region.")
+    }
+
+    /// GET the Token Plan dashboard HTML and pull the inline
+    /// `SEC_TOKEN` constant. Same scrape pattern as the Coding Plan
+    /// adapter (the page reuses the Bailian console shell), with a
+    /// `sec_token` cookie fallback for layouts that hoist the token
+    /// onto the jar instead of the inline JS.
+    private func resolveSECToken(cookieHeader: String,
+                                 region: AlibabaTokenPlanRegion) async throws -> String {
+        var request = URLRequest(url: region.dashboardURL)
+        request.httpMethod = "GET"
+        request.setValue(cookieHeader, forHTTPHeaderField: "Cookie")
+        request.setValue(Self.safariUA, forHTTPHeaderField: "User-Agent")
+        request.setValue(
+            "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+            forHTTPHeaderField: "Accept"
+        )
+
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await session.data(for: request)
+        } catch {
+            throw QuotaError.network("Alibaba Token Plan dashboard fetch error: \(error.localizedDescription)")
+        }
+
+        if let http = response as? HTTPURLResponse,
+           http.statusCode == 200,
+           let html = String(data: data, encoding: .utf8) {
+            let patterns = [
+                #"SEC_TOKEN\s*:\s*\"([^\"]+)\""#,
+                #"SEC_TOKEN\s*:\s*'([^']+)'"#,
+                #"secToken\s*:\s*\"([^\"]+)\""#,
+                #"sec_token\s*:\s*\"([^\"]+)\""#,
+                #"\"SEC_TOKEN\"\s*:\s*\"([^\"]+)\""#,
+                #"\"sec_token\"\s*:\s*\"([^\"]+)\""#
+            ]
+            for pattern in patterns {
+                if let token = Self.matchFirstGroup(pattern: pattern, in: html), !token.isEmpty {
+                    return token
+                }
+            }
+        }
+
+        if let cookieToken = Self.extractCookieValue(name: "sec_token", from: cookieHeader),
+           !cookieToken.isEmpty {
+            return cookieToken
+        }
+
+        throw QuotaError.needsLogin
+    }
+
+    /// POST the form-urlencoded BSS RPC body the Token Plan dashboard
+    /// fires from the browser. Body layout:
+    ///   `product=…&action=…&params=<json>&sec_token=…&region=cn-qingdao`
+    /// The `region` body parameter is the BSS-backend region
+    /// (`cn-qingdao` for the China site, `ap-southeast-1` for intl)
+    /// and is not derived from the user-facing region setting.
+    private func fetchSeatSummary(cookieHeader: String,
+                                  secToken: String,
+                                  region: AlibabaTokenPlanRegion,
+                                  now referenceTime: Date) async throws -> AlibabaTokenPlanResponseParser.Snapshot {
+        let paramsObject: [String: Any] = [
+            "ProductCode": region.productCode
+        ]
+
+        guard let paramsData = try? JSONSerialization.data(withJSONObject: paramsObject),
+              let paramsString = String(data: paramsData, encoding: .utf8) else {
+            throw QuotaError.parseFailure("Alibaba Token Plan: failed to encode params")
+        }
+
+        var components = URLComponents()
+        components.queryItems = [
+            URLQueryItem(name: "product", value: "BssOpenAPI-V3"),
+            URLQueryItem(name: "action", value: "GetSeatSubscriptionSummary"),
+            URLQueryItem(name: "params", value: paramsString),
+            URLQueryItem(name: "sec_token", value: secToken),
+            URLQueryItem(name: "region", value: region.bssRegion)
+        ]
+        let body = (components.percentEncodedQuery ?? "").data(using: .utf8) ?? Data()
+
+        var request = URLRequest(url: region.consoleRPCURL)
+        request.httpMethod = "POST"
+        request.httpBody = body
+        request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+        request.setValue("application/json, text/plain, */*", forHTTPHeaderField: "Accept")
+        request.setValue(cookieHeader, forHTTPHeaderField: "Cookie")
+        if let csrf = Self.extractCookieValue(name: "login_aliyunid_csrf", from: cookieHeader)
+            ?? Self.extractCookieValue(name: "csrf", from: cookieHeader) {
+            request.setValue(csrf, forHTTPHeaderField: "x-xsrf-token")
+            request.setValue(csrf, forHTTPHeaderField: "x-csrf-token")
+        }
+        request.setValue("XMLHttpRequest", forHTTPHeaderField: "X-Requested-With")
+        request.setValue(Self.safariUA, forHTTPHeaderField: "User-Agent")
+        request.setValue(region.consoleBaseURL.absoluteString, forHTTPHeaderField: "Origin")
+        request.setValue(region.dashboardURL.absoluteString, forHTTPHeaderField: "Referer")
+
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await session.data(for: request)
+        } catch {
+            throw QuotaError.network("Alibaba Token Plan console error: \(error.localizedDescription)")
+        }
+        guard let http = response as? HTTPURLResponse else {
+            throw QuotaError.network("Alibaba Token Plan: invalid response object")
+        }
+        guard http.statusCode == 200 else {
+            if http.statusCode == 401 || http.statusCode == 403 {
+                throw QuotaError.needsLogin
+            }
+            if http.statusCode == 429 {
+                throw QuotaError.rateLimited
+            }
+            throw QuotaError.network("Alibaba Token Plan returned HTTP \(http.statusCode).")
+        }
+
+        return try AlibabaTokenPlanResponseParser.parse(data: data, productCode: region.productCode, now: referenceTime)
+    }
+
+    // MARK: Helpers
+
+    nonisolated private static var safariUA: String {
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.0 Safari/605.1.15"
+    }
+
+    nonisolated private static func matchFirstGroup(pattern: String, in text: String) -> String? {
+        guard let regex = try? NSRegularExpression(pattern: pattern, options: []) else { return nil }
+        let range = NSRange(text.startIndex..<text.endIndex, in: text)
+        guard let match = regex.firstMatch(in: text, options: [], range: range),
+              match.numberOfRanges > 1,
+              let valueRange = Range(match.range(at: 1), in: text) else { return nil }
+        let value = String(text[valueRange]).trimmingCharacters(in: .whitespacesAndNewlines)
+        return value.isEmpty ? nil : value
+    }
+
+    nonisolated private static func extractCookieValue(name: String, from header: String) -> String? {
+        for segment in header.split(separator: ";") {
+            let part = segment.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard let eq = part.firstIndex(of: "=") else { continue }
+            let key = String(part[..<eq]).trimmingCharacters(in: .whitespacesAndNewlines)
+            guard key == name else { continue }
+            let value = String(part[part.index(after: eq)...]).trimmingCharacters(in: .whitespacesAndNewlines)
+            return value.isEmpty ? nil : value
+        }
+        return nil
+    }
+}
+
+// MARK: - Region
+
+enum AlibabaTokenPlanRegion: String {
+    case international
+    case chinaMainland
+
+    /// User-visible region IDs in `MiscProviderSettings.region`.
+    var settingsRegionID: String {
+        switch self {
+        case .international: return "ap-southeast-1"
+        case .chinaMainland: return "cn-beijing"
+        }
+    }
+
+    /// BSS calls live in the China-wide billing region (`cn-qingdao`)
+    /// or its international counterpart, regardless of which console
+    /// site the page is loaded under.
+    var bssRegion: String {
+        switch self {
+        case .international: return "ap-southeast-1"
+        case .chinaMainland: return "cn-qingdao"
+        }
+    }
+
+    /// `sfm_tokenplanteams_dp_cn` was captured live; `_dp_intl` is
+    /// the standard Aliyun pattern for the international BSS variant
+    /// and matches the Coding Plan naming (`_public_cn` /
+    /// `_public_intl`). If a future expansion adds an individual
+    /// Token Plan we'll layer another `try-per-product` loop in.
+    var productCode: String {
+        switch self {
+        case .international: return "sfm_tokenplanteams_dp_intl"
+        case .chinaMainland: return "sfm_tokenplanteams_dp_cn"
+        }
+    }
+
+    var consoleBaseURL: URL {
+        switch self {
+        case .international: return URL(string: "https://modelstudio.console.alibabacloud.com")!
+        case .chinaMainland: return URL(string: "https://bailian.console.aliyun.com")!
+        }
+    }
+
+    /// Dashboard URL the console shell uses to bootstrap the Token
+    /// Plan page. Visiting this URL with a valid session embeds
+    /// `SEC_TOKEN` inline.
+    var dashboardURL: URL {
+        switch self {
+        case .international:
+            return URL(string: "https://modelstudio.console.alibabacloud.com/ap-southeast-1/?tab=plan#/efm/subscription/token-plan")!
+        case .chinaMainland:
+            return URL(string: "https://bailian.console.aliyun.com/cn-beijing/?tab=plan#/efm/subscription/token-plan")!
+        }
+    }
+
+    /// BSS RPC endpoint. Token Plan rides on the regular console BFF
+    /// (`bailian.console.aliyun.com/data/api.json`), not the BroadScope
+    /// `bailian-cs.console.aliyun.com` BFF the Coding Plan uses.
+    var consoleRPCURL: URL {
+        var components = URLComponents(url: consoleBaseURL, resolvingAgainstBaseURL: false)!
+        components.path = "/data/api.json"
+        components.queryItems = [
+            URLQueryItem(name: "action", value: "GetSeatSubscriptionSummary"),
+            URLQueryItem(name: "product", value: "BssOpenAPI-V3"),
+            URLQueryItem(name: "_tag", value: "")
+        ]
+        return components.url!
+    }
+}
+
+// MARK: - Response parsing
+
+enum AlibabaTokenPlanResponseParser {
+    struct Snapshot {
+        var buckets: [QuotaBucket]
+        var planName: String?
+    }
+
+    static func parse(data: Data, productCode: String, now: Date) throws -> Snapshot {
+        guard !data.isEmpty else {
+            throw QuotaError.parseFailure("Alibaba Token Plan returned an empty body.")
+        }
+        let raw = try JSONSerialization.jsonObject(with: data, options: [])
+        guard let dict = expandedJSON(raw) as? [String: Any] else {
+            throw QuotaError.parseFailure("Alibaba Token Plan response was not a JSON object.")
+        }
+
+        // String-coded login failures (mirrors the Coding Plan parser).
+        if let codeText = findFirstString(["code", "status", "statusCode", "Code"], in: dict) {
+            let lower = codeText.lowercased()
+            if lower.contains("needlogin") ||
+               lower.contains("notlogin") ||
+               lower.contains("unauthenticated") ||
+               lower == "login" {
+                throw QuotaError.needsLogin
+            }
+        }
+        if let success = dict["successResponse"] as? Bool, !success {
+            let msg = findFirstString(["message", "msg", "Message"], in: dict) ?? "Alibaba Token Plan request failed."
+            throw QuotaError.network("Alibaba Token Plan: \(msg)")
+        }
+
+        // Numeric error envelope (rare on this BFF — most failures
+        // come through as `Code: "ConsoleNeedLogin"`).
+        if let numeric = findFirstInt(["statusCode", "status_code", "httpStatusCode"], in: dict),
+           numeric != 0, numeric != 200 {
+            let msg = findFirstString(["statusMessage", "status_msg", "message", "msg", "Message"], in: dict)
+                ?? "status code \(numeric)"
+            if numeric == 401 || numeric == 403 {
+                throw QuotaError.needsLogin
+            }
+            throw QuotaError.network("Alibaba Token Plan: \(msg)")
+        }
+
+        // `SubscriptionGroupList` is the canonical shape. Some BFF
+        // variants nest the payload under `data.Data` / `Data`; the
+        // recursive helpers below let us pull from either.
+        var buckets: [QuotaBucket] = []
+
+        if let groups = findFirstArray(["SubscriptionGroupList", "subscriptionGroupList"], in: dict) {
+            for raw in groups {
+                guard let group = raw as? [String: Any] else { continue }
+                guard let bucket = bucketForGroup(group, productCode: productCode) else { continue }
+                buckets.append(bucket)
+            }
+        }
+
+        // Fallback: some responses (the simpler `GetSubscriptionSummary`
+        // variant) collapse the equity into top-level
+        // `TotalValue`/`TotalSurplusValue` without a group list. We
+        // still surface a single aggregate bucket so the card shows
+        // *something* instead of failing.
+        if buckets.isEmpty {
+            if let summary = findFirstDictionary(matchingAnyKey: [
+                "TotalValue", "TotalSurplusValue"
+            ], in: dict),
+               let bucket = bucketForFlatSummary(summary, productCode: productCode) {
+                buckets.append(bucket)
+            }
+        }
+
+        guard !buckets.isEmpty else {
+            throw QuotaError.parseFailure("Alibaba Token Plan response had no usable subscription data.")
+        }
+
+        // Plan name: combine the human label (Team / Individual based
+        // on the product code) with the spec tier if all buckets share
+        // one, otherwise stick to the family name.
+        let familyName = familyDisplayName(for: productCode)
+        let planName: String
+        if buckets.count == 1, let group = bucketGroupName(for: productCode, suffix: buckets[0].groupTitle) {
+            planName = group
+        } else {
+            planName = familyName
+        }
+
+        return Snapshot(buckets: buckets, planName: planName)
+    }
+
+    private static func bucketForGroup(_ group: [String: Any], productCode: String) -> QuotaBucket? {
+        let specType = (anyString(["SpecType", "specType"], in: group) ?? "standard").lowercased()
+        let equityList = (group["EquityList"] as? [Any])
+            ?? (group["equityList"] as? [Any])
+            ?? []
+
+        // Pick the credit_value equity — that's the "总额度" / "用量
+        // 消耗" bar the dashboard renders for the seat tier. Other
+        // equity codes can be added later if Aliyun expands the
+        // schema (e.g. a separate "cache" or "tool-call" equity).
+        let credit = equityList.compactMap { $0 as? [String: Any] }.first {
+            let code = (anyString(["EquityCode", "equityCode"], in: $0) ?? "").lowercased()
+            return code == "credit_value" || code.contains("credit")
+        }
+
+        let total = parseDouble(credit?["TotalValue"] ?? credit?["totalValue"]) ?? 0
+        let surplus = parseDouble(credit?["SurplusValue"] ?? credit?["surplusValue"]) ?? 0
+        guard total > 0 else { return nil }
+        let used = max(0, total - surplus)
+        let percent = max(0, min(100, used / total * 100))
+
+        let nextFlush = parseDate(group["NextCycleFlushTime"] ?? group["nextCycleFlushTime"])
+
+        let specLabel = displaySpecLabel(specType)
+        return QuotaBucket(
+            id: "alibabaTokenPlan.\(productCode).\(specType)",
+            title: "\(specLabel) Credits",
+            shortLabel: "\(specLabel) credits",
+            usedPercent: percent,
+            resetAt: nextFlush,
+            rawWindowSeconds: nil,
+            groupTitle: specLabel
+        )
+    }
+
+    private static func bucketForFlatSummary(_ summary: [String: Any], productCode: String) -> QuotaBucket? {
+        let total = parseDouble(summary["TotalValue"] ?? summary["totalValue"]) ?? 0
+        let surplus = parseDouble(summary["TotalSurplusValue"] ?? summary["totalSurplusValue"]) ?? 0
+        guard total > 0 else { return nil }
+        let used = max(0, total - surplus)
+        let percent = max(0, min(100, used / total * 100))
+        let reset = parseDate(summary["NearestExpireDate"] ?? summary["nearestExpireDate"])
+        return QuotaBucket(
+            id: "alibabaTokenPlan.\(productCode).summary",
+            title: "Token Plan Credits",
+            shortLabel: "Credits",
+            usedPercent: percent,
+            resetAt: reset,
+            rawWindowSeconds: nil
+        )
+    }
+
+    private static func displaySpecLabel(_ specType: String) -> String {
+        switch specType {
+        case "standard": return "Standard"
+        case "advanced": return "Advanced"
+        case "exclusive": return "Exclusive"
+        default:
+            // Title-case anything else so we don't surface the raw
+            // `enterprise_v2` style strings.
+            return specType
+                .split(separator: "_")
+                .map { $0.prefix(1).uppercased() + $0.dropFirst() }
+                .joined(separator: " ")
+        }
+    }
+
+    private static func familyDisplayName(for productCode: String) -> String {
+        if productCode.contains("teams") { return "Token Plan · Team" }
+        return "Token Plan"
+    }
+
+    private static func bucketGroupName(for productCode: String, suffix: String?) -> String? {
+        guard let suffix, !suffix.isEmpty else { return nil }
+        return "\(familyDisplayName(for: productCode)) · \(suffix)"
+    }
+
+    // MARK: - Tree helpers
+
+    static func expandedJSON(_ value: Any) -> Any {
+        if let dict = value as? [String: Any] {
+            var out: [String: Any] = [:]
+            out.reserveCapacity(dict.count)
+            for (k, v) in dict { out[k] = expandedJSON(v) }
+            return out
+        }
+        if let arr = value as? [Any] { return arr.map { expandedJSON($0) } }
+        if let s = value as? String,
+           let data = s.data(using: .utf8),
+           let nested = try? JSONSerialization.jsonObject(with: data),
+           nested is [String: Any] || nested is [Any] {
+            return expandedJSON(nested)
+        }
+        return value
+    }
+
+    static func findFirstDictionary(matchingAnyKey keys: [String], in value: Any) -> [String: Any]? {
+        if let dict = value as? [String: Any] {
+            if keys.contains(where: { dict[$0] != nil }) { return dict }
+            for nested in dict.values {
+                if let found = findFirstDictionary(matchingAnyKey: keys, in: nested) { return found }
+            }
+            return nil
+        }
+        if let arr = value as? [Any] {
+            for item in arr {
+                if let found = findFirstDictionary(matchingAnyKey: keys, in: item) { return found }
+            }
+        }
+        return nil
+    }
+
+    static func findFirstArray(_ keys: [String], in value: Any) -> [Any]? {
+        if let dict = value as? [String: Any] {
+            for key in keys { if let arr = dict[key] as? [Any] { return arr } }
+            for nested in dict.values {
+                if let found = findFirstArray(keys, in: nested) { return found }
+            }
+        }
+        if let arr = value as? [Any] {
+            for item in arr {
+                if let found = findFirstArray(keys, in: item) { return found }
+            }
+        }
+        return nil
+    }
+
+    static func findFirstInt(_ keys: [String], in value: Any) -> Int? {
+        if let dict = value as? [String: Any] {
+            for key in keys { if let v = parseInt(dict[key]) { return v } }
+            for nested in dict.values {
+                if let v = findFirstInt(keys, in: nested) { return v }
+            }
+        }
+        if let arr = value as? [Any] {
+            for item in arr {
+                if let v = findFirstInt(keys, in: item) { return v }
+            }
+        }
+        return nil
+    }
+
+    static func findFirstString(_ keys: [String], in value: Any) -> String? {
+        if let dict = value as? [String: Any] {
+            for key in keys { if let v = parseString(dict[key]) { return v } }
+            for nested in dict.values {
+                if let v = findFirstString(keys, in: nested) { return v }
+            }
+        }
+        if let arr = value as? [Any] {
+            for item in arr {
+                if let v = findFirstString(keys, in: item) { return v }
+            }
+        }
+        return nil
+    }
+
+    static func anyString(_ keys: [String], in dict: [String: Any]) -> String? {
+        for key in keys { if let v = parseString(dict[key]) { return v } }
+        return nil
+    }
+
+    static func parseInt(_ value: Any?) -> Int? {
+        switch value {
+        case let v as Int:    return v
+        case let v as Double: return Int(v)
+        case let v as String: return Int(v)
+        case let v as NSNumber: return v.intValue
+        default: return nil
+        }
+    }
+
+    static func parseDouble(_ value: Any?) -> Double? {
+        switch value {
+        case let v as Double: return v
+        case let v as Int:    return Double(v)
+        case let v as NSNumber: return v.doubleValue
+        case let v as String: return Double(v)
+        default: return nil
+        }
+    }
+
+    static func parseString(_ value: Any?) -> String? {
+        guard let s = (value as? String)?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !s.isEmpty else { return nil }
+        return s
+    }
+
+    static func parseDate(_ value: Any?) -> Date? {
+        if let ms = parseInt(value), ms > 0 {
+            return Date(timeIntervalSince1970: TimeInterval(ms) / 1000)
+        }
+        if let str = parseString(value) {
+            let f = ISO8601DateFormatter()
+            f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+            if let d = f.date(from: str) { return d }
+            f.formatOptions = [.withInternetDateTime]
+            if let d = f.date(from: str) { return d }
+        }
+        return nil
+    }
+}

--- a/Sources/VibeBarCore/Credentials/VibeBarKeychainAccessAuthorizer.swift
+++ b/Sources/VibeBarCore/Credentials/VibeBarKeychainAccessAuthorizer.swift
@@ -69,7 +69,7 @@ public enum VibeBarKeychainAccessAuthorizer {
     /// `MiscCookieSlotStore`. The list mirrors every cookie-only adapter
     /// plus Alibaba (cookie path is one of two auth modes).
     private static let currentCookieBackedMiscTools: [ToolType] = [
-        .alibaba, .kimi, .cursor, .mimo, .iflytek,
+        .alibaba, .alibabaTokenPlan, .kimi, .cursor, .mimo, .iflytek,
         .tencentHunyuan, .volcengine, .openCodeGo, .ollama
     ]
     /// Misc tools with an in-app WKWebView login flow where
@@ -77,7 +77,7 @@ public enum VibeBarKeychainAccessAuthorizer {
     /// Keeping the list explicit lets the preflight pre-authorize the
     /// Keychain accounts so users don't see a prompt on first save.
     private static let currentWebFormBackedMiscTools: [ToolType] = [
-        .mimo, .volcengine, .tencentHunyuan, .alibaba
+        .mimo, .volcengine, .tencentHunyuan, .alibaba, .alibabaTokenPlan
     ]
     private static let currentSecretKindsByTool: [ToolType: [MiscCredentialStore.Kind]] = [
         .alibaba: [.apiKey],

--- a/Sources/VibeBarCore/Models/ProviderPlanDisplay.swift
+++ b/Sources/VibeBarCore/Models/ProviderPlanDisplay.swift
@@ -7,7 +7,7 @@ public enum ProviderPlanDisplay {
             return codexDisplayName(rawPlan)
         case .claude:
             return claudeDisplayName(rawPlan)
-        case .alibaba, .gemini, .antigravity, .copilot, .zai, .minimax, .kimi, .cursor, .mimo, .iflytek, .tencentHunyuan, .volcengine, .openCodeGo, .kilo, .kiro, .ollama, .openRouter, .warp:
+        case .alibaba, .alibabaTokenPlan, .gemini, .antigravity, .copilot, .zai, .minimax, .kimi, .cursor, .mimo, .iflytek, .tencentHunyuan, .volcengine, .openCodeGo, .kilo, .kiro, .ollama, .openRouter, .warp:
             // Misc providers feed `plan` straight through. Each adapter
             // is responsible for normalizing the raw API response
             // (e.g. `Pro Coding` → `Pro`) before it reaches this map.

--- a/Sources/VibeBarCore/Models/ToolType.swift
+++ b/Sources/VibeBarCore/Models/ToolType.swift
@@ -16,8 +16,8 @@ import Foundation
 /// Tools split into two tiers:
 /// - **Primary** (`.codex`, `.claude`) — full quota + cost + service-status
 ///   integration, dedicated popover pages, mini-window slots.
-/// - **Misc** (`.alibaba`, `.gemini`, `.antigravity`, `.copilot`, `.zai`,
-///   `.minimax`, `.kimi`, `.cursor`, `.mimo`, `.iflytek`,
+/// - **Misc** (`.alibaba`, `.alibabaTokenPlan`, `.gemini`, `.antigravity`,
+///   `.copilot`, `.zai`, `.minimax`, `.kimi`, `.cursor`, `.mimo`, `.iflytek`,
 ///   `.tencentHunyuan`, `.volcengine`, `.openCodeGo`, `.kilo`, `.kiro`,
 ///   `.ollama`, `.openRouter`, `.warp`) — usage-only cards on the Misc tab.
 ///   No token-cost scanning, no Atlassian-style status polling.
@@ -31,6 +31,7 @@ public enum ToolType: String, Codable, CaseIterable, Hashable, Sendable {
     case claude
     // Misc — usage-only, no cost / status integration.
     case alibaba
+    case alibabaTokenPlan
     case gemini
     case antigravity
     case copilot
@@ -54,7 +55,7 @@ public enum ToolType: String, Codable, CaseIterable, Hashable, Sendable {
     public var isPrimary: Bool {
         switch self {
         case .codex, .claude: return true
-        case .alibaba, .gemini, .antigravity, .copilot, .zai, .minimax, .kimi, .cursor, .mimo, .iflytek, .tencentHunyuan, .volcengine, .openCodeGo, .kilo, .kiro, .ollama, .openRouter, .warp:
+        case .alibaba, .alibabaTokenPlan, .gemini, .antigravity, .copilot, .zai, .minimax, .kimi, .cursor, .mimo, .iflytek, .tencentHunyuan, .volcengine, .openCodeGo, .kilo, .kiro, .ollama, .openRouter, .warp:
             return false
         }
     }
@@ -84,6 +85,7 @@ public enum ToolType: String, Codable, CaseIterable, Hashable, Sendable {
         case .codex:       return "OpenAI - ChatGPT"
         case .claude:      return "Anthropic - Claude"
         case .alibaba:     return "Alibaba Qwen"
+        case .alibabaTokenPlan: return "Alibaba Qwen"
         case .gemini:      return "Gemini"
         case .antigravity: return "Google - Antigravity"
         case .copilot:     return "GitHub - Copilot"
@@ -109,6 +111,7 @@ public enum ToolType: String, Codable, CaseIterable, Hashable, Sendable {
         case .codex:       return "CodeX"
         case .claude:      return "Claude Code"
         case .alibaba:     return "Coding Plan"
+        case .alibabaTokenPlan: return "Token Plan"
         case .gemini:      return "Usage"
         case .antigravity: return "Local LSP"
         case .copilot:     return "GitHub Copilot"
@@ -134,6 +137,7 @@ public enum ToolType: String, Codable, CaseIterable, Hashable, Sendable {
         case .codex:       return "OpenAI"
         case .claude:      return "Claude"
         case .alibaba:     return "Alibaba Qwen"
+        case .alibabaTokenPlan: return "Qwen Token Plan"
         case .gemini:      return "Gemini"
         case .antigravity: return "Antigravity"
         case .copilot:     return "Copilot"
@@ -159,6 +163,7 @@ public enum ToolType: String, Codable, CaseIterable, Hashable, Sendable {
         case .codex:       return "OpenAI"
         case .claude:      return "Anthropic"
         case .alibaba:     return "Alibaba Qwen"
+        case .alibabaTokenPlan: return "Alibaba Qwen"
         case .gemini:      return "Gemini"
         case .antigravity: return "Antigravity"
         case .copilot:     return "GitHub"
@@ -187,6 +192,7 @@ public enum ToolType: String, Codable, CaseIterable, Hashable, Sendable {
         case .codex:       return URL(string: "https://status.openai.com/")!
         case .claude:      return URL(string: "https://status.claude.com/")!
         case .alibaba:     return URL(string: "https://bailian.console.aliyun.com/")!
+        case .alibabaTokenPlan: return URL(string: "https://bailian.console.aliyun.com/cn-beijing?tab=plan#/efm/subscription/token-plan")!
         case .gemini:      return URL(string: "https://status.cloud.google.com/")!
         case .antigravity: return URL(string: "https://antigravity.google/")!
         case .copilot:     return URL(string: "https://www.githubstatus.com/")!

--- a/Sources/VibeBarCore/Services/CostUsageScanner.swift
+++ b/Sources/VibeBarCore/Services/CostUsageScanner.swift
@@ -24,7 +24,7 @@ public enum CostUsageScanner {
             return await scanCodex(homeDirectory: homeDirectory, now: now, retentionDays: retentionDays)
         case .claude:
             return await scanClaude(homeDirectory: homeDirectory, now: now, retentionDays: retentionDays)
-        case .alibaba, .gemini, .antigravity, .copilot, .zai, .minimax, .kimi, .cursor, .mimo, .iflytek, .tencentHunyuan, .volcengine, .openCodeGo, .kilo, .kiro, .ollama, .openRouter, .warp:
+        case .alibaba, .alibabaTokenPlan, .gemini, .antigravity, .copilot, .zai, .minimax, .kimi, .cursor, .mimo, .iflytek, .tencentHunyuan, .volcengine, .openCodeGo, .kilo, .kiro, .ollama, .openRouter, .warp:
             // Misc providers don't expose token-level cost data; the
             // cost-history pipeline is gated by `tool.supportsTokenCost`
             // upstream. Returning `nil` here is a defensive belt:
@@ -310,7 +310,7 @@ public enum CostUsageScanner {
                 cacheCreationInputTokens: cacheCreation,
                 outputTokens: event.output
             ) ?? 0
-        case .alibaba, .gemini, .antigravity, .copilot, .zai, .minimax, .kimi, .cursor, .mimo, .iflytek, .tencentHunyuan, .volcengine, .openCodeGo, .kilo, .kiro, .ollama, .openRouter, .warp:
+        case .alibaba, .alibabaTokenPlan, .gemini, .antigravity, .copilot, .zai, .minimax, .kimi, .cursor, .mimo, .iflytek, .tencentHunyuan, .volcengine, .openCodeGo, .kilo, .kiro, .ollama, .openRouter, .warp:
             return 0
         }
     }

--- a/Sources/VibeBarCore/Services/MockDataProvider.swift
+++ b/Sources/VibeBarCore/Services/MockDataProvider.swift
@@ -171,7 +171,7 @@ public enum MockDataProvider {
                 extraUsageEnabled: true,
                 updatedAt: now
             )
-        case .alibaba, .gemini, .antigravity, .copilot, .zai, .minimax, .kimi, .cursor, .mimo, .iflytek, .tencentHunyuan, .volcengine, .openCodeGo, .kilo, .kiro, .ollama, .openRouter, .warp:
+        case .alibaba, .alibabaTokenPlan, .gemini, .antigravity, .copilot, .zai, .minimax, .kimi, .cursor, .mimo, .iflytek, .tencentHunyuan, .volcengine, .openCodeGo, .kilo, .kiro, .ollama, .openRouter, .warp:
             // Misc providers don't carry credits / overage extras in the
             // mock. The Cursor card surfaces on-demand budget through a
             // different field on `AccountQuota`, not `ProviderExtras`.
@@ -215,7 +215,7 @@ public enum MockDataProvider {
                 QuotaBucket(id: "weekly_opus", title: "Weekly", shortLabel: "Opus wk",
                             usedPercent: 18, resetAt: weeklyReset, rawWindowSeconds: 604_800, groupTitle: "Opus")
             ]
-        case .alibaba, .gemini, .antigravity, .copilot, .zai, .minimax, .kimi, .cursor, .mimo, .iflytek, .tencentHunyuan, .volcengine, .openCodeGo, .kilo, .kiro, .ollama, .openRouter, .warp:
+        case .alibaba, .alibabaTokenPlan, .gemini, .antigravity, .copilot, .zai, .minimax, .kimi, .cursor, .mimo, .iflytek, .tencentHunyuan, .volcengine, .openCodeGo, .kilo, .kiro, .ollama, .openRouter, .warp:
             // Misc providers' mock data lands in subsequent phases as
             // each adapter is wired up. For now return a single
             // illustrative bucket so the card renders something during

--- a/Sources/VibeBarCore/Services/QuotaService.swift
+++ b/Sources/VibeBarCore/Services/QuotaService.swift
@@ -37,6 +37,7 @@ public final class QuotaService: ObservableObject {
                 .copilot: CopilotQuotaAdapter(),
                 .gemini: GeminiQuotaAdapter(),
                 .alibaba: AlibabaQuotaAdapter(),
+                .alibabaTokenPlan: AlibabaTokenPlanQuotaAdapter(),
                 .minimax: MiniMaxQuotaAdapter(),
                 .kimi: KimiQuotaAdapter(),
                 .cursor: CursorQuotaAdapter(),

--- a/Sources/VibeBarCore/Services/ServiceStatusClient.swift
+++ b/Sources/VibeBarCore/Services/ServiceStatusClient.swift
@@ -19,7 +19,7 @@ public actor ServiceStatusClient {
         switch tool {
         case .codex:  return try await fetchOpenAI(dayCount: dayCount, now: now)
         case .claude: return try await fetchClaude(dayCount: dayCount, now: now)
-        case .alibaba, .gemini, .antigravity, .copilot, .zai, .minimax, .kimi, .cursor, .mimo, .iflytek, .tencentHunyuan, .volcengine, .openCodeGo, .kilo, .kiro, .ollama, .openRouter, .warp:
+        case .alibaba, .alibabaTokenPlan, .gemini, .antigravity, .copilot, .zai, .minimax, .kimi, .cursor, .mimo, .iflytek, .tencentHunyuan, .volcengine, .openCodeGo, .kilo, .kiro, .ollama, .openRouter, .warp:
             // Misc providers don't expose Atlassian-style status APIs.
             // `tool.supportsStatusPage` is `false` for all of them, and
             // upstream callers should already be filtering to primary

--- a/Tests/VibeBarCoreTests/AlibabaTokenPlanParserTests.swift
+++ b/Tests/VibeBarCoreTests/AlibabaTokenPlanParserTests.swift
@@ -1,0 +1,242 @@
+import XCTest
+@testable import VibeBarCore
+
+final class AlibabaTokenPlanParserTests: XCTestCase {
+    private let now = Date(timeIntervalSince1970: 1_715_000_000)
+    private let cnProductCode = "sfm_tokenplanteams_dp_cn"
+
+    // MARK: - Happy path (captured from the live console)
+
+    func testParsesSeatSubscriptionSummaryWithStandardCredits() throws {
+        // This is the live shape captured from the Token Plan dashboard
+        // (with the BSS request id swapped out for a synthetic value).
+        let json = """
+        {
+          "code": "200",
+          "data": {
+            "RequestId": "00000000-0000-0000-0000-000000000000",
+            "Message": "Successful!",
+            "Data": {
+              "Uid": 1234567890,
+              "EndTime": 1781769600000,
+              "ProductCode": "sfm_tokenplanteams_dp_cn",
+              "StartTime": 1779091200000,
+              "RemainingDays": "30",
+              "SubscriptionGroupList": [
+                {
+                  "SubscriptionAssignedNumber": 1,
+                  "EquityList": [
+                    {
+                      "EquityCode": "credit_value",
+                      "TotalValue": "25000.00000000",
+                      "EquityType": "CREDITS",
+                      "SurplusValue": "24999.55340000"
+                    }
+                  ],
+                  "SpecType": "standard",
+                  "SubscriptionTotalNumber": 1,
+                  "NextCycleFlushTime": 1781769600000
+                }
+              ]
+            },
+            "Code": "Success",
+            "Success": true
+          },
+          "httpStatusCode": "200",
+          "successResponse": true
+        }
+        """
+        let snap = try AlibabaTokenPlanResponseParser.parse(
+            data: Data(json.utf8),
+            productCode: cnProductCode,
+            now: now
+        )
+        XCTAssertEqual(snap.buckets.count, 1)
+        let bucket = snap.buckets[0]
+        XCTAssertEqual(bucket.id, "alibabaTokenPlan.\(cnProductCode).standard")
+        XCTAssertEqual(bucket.groupTitle, "Standard")
+        // (25000 - 24999.5534) / 25000 * 100 ≈ 0.001786
+        XCTAssertEqual(bucket.usedPercent, 0.001786, accuracy: 0.001)
+        XCTAssertNotNil(bucket.resetAt)
+        XCTAssertEqual(
+            bucket.resetAt?.timeIntervalSince1970 ?? 0,
+            1781769600,
+            accuracy: 0.5
+        )
+    }
+
+    func testMultipleSpecTiersBecomeMultipleBuckets() throws {
+        let json = """
+        {
+          "code": "200",
+          "data": {
+            "Data": {
+              "SubscriptionGroupList": [
+                {
+                  "SpecType": "standard",
+                  "EquityList": [{
+                    "EquityCode": "credit_value",
+                    "TotalValue": "100",
+                    "SurplusValue": "75"
+                  }],
+                  "NextCycleFlushTime": 1781769600000
+                },
+                {
+                  "SpecType": "advanced",
+                  "EquityList": [{
+                    "EquityCode": "credit_value",
+                    "TotalValue": "200",
+                    "SurplusValue": "50"
+                  }]
+                }
+              ]
+            },
+            "Success": true
+          }
+        }
+        """
+        let snap = try AlibabaTokenPlanResponseParser.parse(
+            data: Data(json.utf8),
+            productCode: cnProductCode,
+            now: now
+        )
+        XCTAssertEqual(snap.buckets.count, 2)
+        XCTAssertEqual(snap.buckets[0].usedPercent, 25.0, accuracy: 0.01)
+        XCTAssertEqual(snap.buckets[1].usedPercent, 75.0, accuracy: 0.01)
+        XCTAssertEqual(snap.buckets[0].groupTitle, "Standard")
+        XCTAssertEqual(snap.buckets[1].groupTitle, "Advanced")
+    }
+
+    func testFallsBackToFlatTotalValueWhenNoGroupList() throws {
+        // The simpler GetSubscriptionSummary response shape carries the
+        // aggregate in `TotalValue` / `TotalSurplusValue` without a
+        // SubscriptionGroupList. The parser surfaces a single
+        // aggregate bucket in that case.
+        let json = """
+        {
+          "code": "200",
+          "data": {
+            "Data": {
+              "TotalSurplusValue": "8000",
+              "TotalValue": "10000",
+              "ProductCode": "sfm_tokenplanteams_dp_cn",
+              "NearestExpireDate": 1781769600000
+            },
+            "Success": true
+          }
+        }
+        """
+        let snap = try AlibabaTokenPlanResponseParser.parse(
+            data: Data(json.utf8),
+            productCode: cnProductCode,
+            now: now
+        )
+        XCTAssertEqual(snap.buckets.count, 1)
+        XCTAssertEqual(snap.buckets[0].id, "alibabaTokenPlan.\(cnProductCode).summary")
+        XCTAssertEqual(snap.buckets[0].usedPercent, 20.0, accuracy: 0.01)
+        XCTAssertNotNil(snap.buckets[0].resetAt)
+    }
+
+    // MARK: - Error envelopes
+
+    func testConsoleNeedLoginStringCodeThrowsNeedsLogin() {
+        let json = """
+        {"code":"ConsoleNeedLogin","message":"请登录","successResponse":false}
+        """
+        XCTAssertThrowsError(try AlibabaTokenPlanResponseParser.parse(
+            data: Data(json.utf8),
+            productCode: cnProductCode,
+            now: now
+        )) { error in
+            guard let qe = error as? QuotaError, case .needsLogin = qe else {
+                XCTFail("Expected QuotaError.needsLogin, got \(error)")
+                return
+            }
+        }
+    }
+
+    func testSuccessFalseMapsToNetwork() {
+        let json = """
+        {"code":"InvalidParameter","message":"bad input","successResponse":false}
+        """
+        XCTAssertThrowsError(try AlibabaTokenPlanResponseParser.parse(
+            data: Data(json.utf8),
+            productCode: cnProductCode,
+            now: now
+        )) { error in
+            guard let qe = error as? QuotaError, case .network = qe else {
+                XCTFail("Expected QuotaError.network, got \(error)")
+                return
+            }
+        }
+    }
+
+    func testEmptyBodyThrowsParseFailure() {
+        XCTAssertThrowsError(try AlibabaTokenPlanResponseParser.parse(
+            data: Data(),
+            productCode: cnProductCode,
+            now: now
+        ))
+    }
+
+    func testEmptySubscriptionGroupListThrowsParseFailure() {
+        // User signed in to a console session that lacks a Token Plan
+        // subscription — the BFF still returns a 200/Success envelope
+        // but with an empty group list and no flat totals.
+        let json = """
+        {
+          "code": "200",
+          "data": {
+            "Data": {
+              "SubscriptionGroupList": []
+            },
+            "Success": true
+          }
+        }
+        """
+        XCTAssertThrowsError(try AlibabaTokenPlanResponseParser.parse(
+            data: Data(json.utf8),
+            productCode: cnProductCode,
+            now: now
+        )) { error in
+            guard let qe = error as? QuotaError, case .parseFailure = qe else {
+                XCTFail("Expected QuotaError.parseFailure, got \(error)")
+                return
+            }
+        }
+    }
+
+    // MARK: - Region wiring
+
+    func testRegionURLs() {
+        XCTAssertEqual(
+            AlibabaTokenPlanRegion.chinaMainland.consoleRPCURL.host,
+            "bailian.console.aliyun.com"
+        )
+        XCTAssertEqual(
+            AlibabaTokenPlanRegion.international.consoleRPCURL.host,
+            "modelstudio.console.alibabacloud.com"
+        )
+        // RPC URL carries the action + product as query parameters so
+        // gateway-side routing sees the same shape the browser uses.
+        let cnQuery = AlibabaTokenPlanRegion.chinaMainland.consoleRPCURL.query ?? ""
+        XCTAssertTrue(cnQuery.contains("action=GetSeatSubscriptionSummary"))
+        XCTAssertTrue(cnQuery.contains("product=BssOpenAPI-V3"))
+
+        // BSS body-region is independent of the user-facing region ID
+        // — China site billing lives in cn-qingdao.
+        XCTAssertEqual(AlibabaTokenPlanRegion.chinaMainland.bssRegion, "cn-qingdao")
+        XCTAssertEqual(AlibabaTokenPlanRegion.international.bssRegion, "ap-southeast-1")
+
+        // Product codes follow the `_dp_cn` / `_dp_intl` Aliyun
+        // convention used by the Coding Plan adapter as well.
+        XCTAssertEqual(
+            AlibabaTokenPlanRegion.chinaMainland.productCode,
+            "sfm_tokenplanteams_dp_cn"
+        )
+        XCTAssertEqual(
+            AlibabaTokenPlanRegion.international.productCode,
+            "sfm_tokenplanteams_dp_intl"
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a new misc provider `ToolType.alibabaTokenPlan` that surfaces Aliyun Bailian **Token Plan** credit usage on its own card, sitting next to the existing Coding Plan card.
- `AlibabaTokenPlanQuotaAdapter` POSTs `bailian.console.aliyun.com/data/api.json?action=GetSeatSubscriptionSummary&product=BssOpenAPI-V3` with `params={\"ProductCode\":\"sfm_tokenplanteams_dp_cn\"}` and `region=cn-qingdao`, scraping `SEC_TOKEN` from the Token Plan dashboard HTML the same way the Coding Plan adapter does, and parses `SubscriptionGroupList[].EquityList[]` (`credit_value`) into one bucket per spec tier (standard / advanced / exclusive) with `NextCycleFlushTime` as the reset stamp.
- Token Plan and Coding Plan share the `*.aliyun.com` console session jar but are otherwise independent: separate ToolType, separate cookie slots, separate `MiscWebLoginController` config (Token Plan dashboard URL) and `HiddenCookieRefresher` config (Token Plan dashboard URL), so users can keep both cards if they have both subscriptions.
- Wires the new tool through every `ToolType` switch site (display strings, status page URL, mock data, cost-scanner short-circuit, brand icon — same Aliyun SVG, mini-window accent / title, Settings UI).

## Why this lives on a different BFF

- **Coding Plan** uses `bailian-cs.console.aliyun.com/data/api.json` with a BroadScope `cornerstoneParam` blob and product `sfm_bailian` / action `BroadScopeAspnGateway`.
- **Token Plan** uses the regular console BFF `bailian.console.aliyun.com/data/api.json` with product `BssOpenAPI-V3` / action `GetSeatSubscriptionSummary` and a flat `{ProductCode}` params blob — no cornerstone, no `bailian-cs`. The Token Plan adapter is therefore standalone rather than a sub-mode of the Coding Plan adapter.

## Test plan

- [x] `swift build` — clean
- [x] `swift test` — 316 tests pass (8 new `AlibabaTokenPlanParserTests` cover the live response shape, the multi-tier fan-out, the flat `TotalValue` fallback, login-required envelopes, empty-subscription handling, and region wiring)
- [x] `./Scripts/build_app.sh release` — packages `.build/Vibe Bar.app`
- [x] `codesign -d --entitlements - ".build/Vibe Bar.app"` — empty `[Dict]`, no `app-sandbox` regression
- [x] `codesign --verify --deep --strict ".build/Vibe Bar.app"` — verifies
- [x] Live request shape confirmed against the production Bailian console: `GetSeatSubscriptionSummary` returns `standard:24999.20140000/25000.00000000` with the exact URL / form body / SEC_TOKEN scrape pattern this adapter generates

🤖 Generated with [Claude Code](https://claude.com/claude-code)