### PR TITLE
Align MiniMax and Z.ai quota labels

### DIFF
--- a/Sources/VibeBarCore/Adapters/MiniMaxQuotaAdapter.swift
+++ b/Sources/VibeBarCore/Adapters/MiniMaxQuotaAdapter.swift
@@ -298,7 +298,7 @@ enum MiniMaxResponseParser {
         let used = max(0, row.currentIntervalUsageCount ?? 0)
         let remaining = max(0, total - used)
         let windowLabel = windowLabel(startTime: row.startTime, endTime: row.endTime) ?? "5 hours"
-        let title = serviceTitle(for: row.modelName) ?? "5 Hours"
+        let title = serviceTitle(displayName: row.displayName, modelName: row.modelName) ?? "5 Hours"
         return quotaBucket(
             id: "minimax.coding.\(index).\(slug(row.modelName ?? title))",
             title: title,
@@ -449,19 +449,94 @@ enum MiniMaxResponseParser {
         return hours > 0 ? "\(hours) hours" : nil
     }
 
-    private static func serviceTitle(for modelName: String?) -> String? {
+    private static func serviceTitle(displayName: String?, modelName: String?) -> String? {
+        if let displayTitle = englishServiceTitle(fromDisplayName: displayName, modelName: modelName) {
+            return displayTitle
+        }
+        if let displayName = displayName?.trimmed, displayName.isMostlyASCII {
+            return formattedDisplayName(displayName)
+        }
         guard let modelName = modelName?.trimmingCharacters(in: .whitespacesAndNewlines),
               !modelName.isEmpty else {
             return nil
         }
         let lower = modelName.lowercased()
         if lower.contains("minimax-m") { return "Text Generation" }
+        if lower.contains("speech"), lower.contains("hd") { return "Text to Speech HD" }
         if lower.contains("speech") { return "Text to Speech" }
-        if lower.contains("hailuo"), lower.contains("fast") { return "Image to Video" }
-        if lower.contains("hailuo") { return "Text to Video" }
+        if lower.contains("hailuo"), lower.contains("fast") { return "Video Generation Fast" }
+        if lower.contains("hailuo") { return "Video Generation Standard" }
+        if lower == "music-cover" { return "Music Cover" }
+        if lower.hasPrefix("music-") {
+            return musicGenerationTitle(suffix: formattedVersionSuffix(from: modelName))
+        }
+        if lower.contains("lyrics") { return "Lyrics Generation" }
         if lower.hasPrefix("image-") { return "Image Generation" }
-        if lower.contains("music") { return "Music Generation" }
+        if lower == "coding-plan-vlm" { return "Image Understanding" }
+        if lower == "coding-plan-search" { return "Web Search" }
         return formattedModelName(modelName)
+    }
+
+    private static func englishServiceTitle(fromDisplayName displayName: String?, modelName: String?) -> String? {
+        guard let raw = displayName?.trimmed else { return nil }
+        let lower = raw.lowercased()
+        let normalized = raw
+            .replacingOccurrences(of: "（", with: "(")
+            .replacingOccurrences(of: "）", with: ")")
+        let model = modelName?.lowercased() ?? ""
+        if normalized.contains("文本生成") { return "Text Generation" }
+        if normalized.contains("语音合成") {
+            if normalized.localizedCaseInsensitiveContains("HD") || normalized.contains("高保真") {
+                return "Text to Speech HD"
+            }
+            return "Text to Speech"
+        }
+        if normalized.contains("视频生成") {
+            if normalized.contains("高速版") || lower.contains("fast") || model.contains("fast") {
+                return "Video Generation Fast"
+            }
+            if normalized.contains("标准版") || model.contains("hailuo") {
+                return "Video Generation Standard"
+            }
+            return "Video Generation"
+        }
+        if normalized.contains("音乐生成") {
+            let suffix = versionSuffix(from: normalized) ?? formattedVersionSuffix(from: modelName)
+            return musicGenerationTitle(suffix: suffix)
+        }
+        if normalized.contains("音乐翻唱") { return "Music Cover" }
+        if normalized.contains("歌词生成") { return "Lyrics Generation" }
+        if normalized.contains("图像生成") { return "Image Generation" }
+        if normalized.contains("图片理解") { return "Image Understanding" }
+        if normalized.contains("网络搜索") { return "Web Search" }
+        return nil
+    }
+
+    private static func formattedVersionSuffix(from modelName: String?) -> String {
+        guard let raw = modelName?.trimmed,
+              let suffix = versionSuffix(from: raw) else {
+            return ""
+        }
+        return suffix
+    }
+
+    private static func musicGenerationTitle(suffix: String) -> String {
+        suffix.isEmpty ? "Music Generation" : "Music Generation \(suffix)"
+    }
+
+    private static func versionSuffix(from raw: String) -> String? {
+        if let match = raw.range(of: #"[vV]?\d+(?:\.\d+)+"#, options: .regularExpression) {
+            let value = String(raw[match])
+            return value.lowercased().hasPrefix("v") ? value : "v\(value)"
+        }
+        return nil
+    }
+
+    private static func formattedDisplayName(_ displayName: String) -> String {
+        let cleaned = displayName
+            .replacingOccurrences(of: "·", with: " ")
+            .replacingOccurrences(of: #"[\(\)]"#, with: " ", options: .regularExpression)
+        return formattedModelName(cleaned)
     }
 
     private static func formattedModelName(_ modelName: String) -> String {
@@ -600,6 +675,7 @@ private struct MiniMaxComboCard: Decodable {
 
 private struct MiniMaxModelRemains: Decodable {
     let modelName: String?
+    let displayName: String?
     let currentIntervalTotalCount: Int?
     let currentIntervalUsageCount: Int?
     let startTime: Int?
@@ -613,6 +689,12 @@ private struct MiniMaxModelRemains: Decodable {
 
     enum CodingKeys: String, CodingKey {
         case modelName = "model_name"
+        case displayName = "display_name"
+        case displayTitle = "display_title"
+        case resourceName = "resource_name"
+        case serviceName = "service_name"
+        case name
+        case title
         case currentIntervalTotalCount = "current_interval_total_count"
         case currentIntervalUsageCount = "current_interval_usage_count"
         case startTime = "start_time"
@@ -628,6 +710,15 @@ private struct MiniMaxModelRemains: Decodable {
     init(from decoder: Decoder) throws {
         let c = try decoder.container(keyedBy: CodingKeys.self)
         modelName = try? c.decodeIfPresent(String.self, forKey: .modelName)
+        let displayCandidates: [String?] = [
+            (try? c.decodeIfPresent(String.self, forKey: .displayName)) ?? nil,
+            (try? c.decodeIfPresent(String.self, forKey: .displayTitle)) ?? nil,
+            (try? c.decodeIfPresent(String.self, forKey: .resourceName)) ?? nil,
+            (try? c.decodeIfPresent(String.self, forKey: .serviceName)) ?? nil,
+            (try? c.decodeIfPresent(String.self, forKey: .name)) ?? nil,
+            (try? c.decodeIfPresent(String.self, forKey: .title)) ?? nil
+        ]
+        displayName = displayCandidates.compactMap(\.self).compactMap { $0.trimmed }.first
         currentIntervalTotalCount = MiniMaxQuotaDecoding.int(c, forKey: .currentIntervalTotalCount)
         currentIntervalUsageCount = MiniMaxQuotaDecoding.int(c, forKey: .currentIntervalUsageCount)
         startTime = MiniMaxQuotaDecoding.int(c, forKey: .startTime)
@@ -728,5 +819,12 @@ private extension String {
     var trimmed: String? {
         let t = trimmingCharacters(in: .whitespacesAndNewlines)
         return t.isEmpty ? nil : t
+    }
+
+    var isMostlyASCII: Bool {
+        let scalars = unicodeScalars.filter { !$0.properties.isWhitespace }
+        guard !scalars.isEmpty else { return false }
+        let asciiCount = scalars.filter { $0.isASCII }.count
+        return Double(asciiCount) / Double(scalars.count) >= 0.8
     }
 }

--- a/Sources/VibeBarCore/Adapters/ZaiQuotaAdapter.swift
+++ b/Sources/VibeBarCore/Adapters/ZaiQuotaAdapter.swift
@@ -264,7 +264,7 @@ private struct ZaiRawLimit: Decodable {
         switch unit {
         case 1: return number * 86_400        // days
         case 3: return number * 3_600         // hours
-        case 5: return number * 60            // minutes
+        case 5: return number * 30 * 86_400   // months
         case 6: return number * 7 * 86_400    // weeks
         default: return nil
         }
@@ -283,8 +283,12 @@ private struct ZaiRawLimit: Decodable {
             title = "\(number) Hour\(number == 1 ? "" : "s")"
             shortLabel = "\(number)h"
         case 5:
-            title = "\(number) Minute\(number == 1 ? "" : "s")"
-            shortLabel = "\(number)m"
+            if type == "TIME_LIMIT" {
+                title = number == 1 ? "MCP Monthly" : "MCP \(number) Months"
+            } else {
+                title = number == 1 ? "Monthly" : "\(number) Months"
+            }
+            shortLabel = number == 1 ? "Month" : "\(number)mo"
         case 6:
             title = number == 1 ? "Weekly" : "\(number) Weeks"
             shortLabel = number == 1 ? "Wk" : "\(number)w"

--- a/Tests/VibeBarCoreTests/KimiMiniMaxParserTests.swift
+++ b/Tests/VibeBarCoreTests/KimiMiniMaxParserTests.swift
@@ -342,13 +342,13 @@ final class MiniMaxParserTests: XCTestCase {
             snap.buckets.map(\.title),
             [
                 "Text Generation",
-                "Text to Speech",
-                "Image to Video",
-                "Text to Video",
+                "Text to Speech HD",
+                "Video Generation Fast",
+                "Video Generation Standard",
                 "Music Generation",
                 "Lyrics Generation",
                 "Image Generation",
-                "Coding Plan Search"
+                "Web Search"
             ]
         )
         XCTAssertEqual(snap.buckets.map(\.shortLabel), Array(repeating: "5h", count: 8))
@@ -403,5 +403,41 @@ final class MiniMaxParserTests: XCTestCase {
         XCTAssertEqual(snap.buckets[0].title, "5 Hours")
         XCTAssertEqual(snap.buckets[0].shortLabel, "5h")
         XCTAssertEqual(snap.buckets[0].rawWindowSeconds, 5 * 3600)
+    }
+
+    func testMiniMaxModelRemainNamesMatchTokenPlanDashboard() throws {
+        let json = """
+        {
+          "model_remains": [
+            {"current_interval_total_count": 19000, "current_interval_usage_count": 0, "model_name": "speech-hd", "display_name": "语音合成 · HD（高保真）"},
+            {"current_interval_total_count": 3, "current_interval_usage_count": 0, "model_name": "minimax-hailuo-2.3-fast-6s-768p", "display_name": "视频生成 · 高速版（768P / 6s）"},
+            {"current_interval_total_count": 3, "current_interval_usage_count": 0, "model_name": "minimax-hailuo-2.3-6s-768p", "display_name": "视频生成 · 标准版（768P / 6s）"},
+            {"current_interval_total_count": 7, "current_interval_usage_count": 0, "model_name": "music-2.5", "display_name": "音乐生成 · v2.5"},
+            {"current_interval_total_count": 100, "current_interval_usage_count": 0, "model_name": "music-2.6", "display_name": "音乐生成 · v2.6"},
+            {"current_interval_total_count": 100, "current_interval_usage_count": 0, "model_name": "music-cover", "display_name": "音乐翻唱"},
+            {"current_interval_total_count": 100, "current_interval_usage_count": 0, "model_name": "lyrics-generation", "display_name": "歌词生成"},
+            {"current_interval_total_count": 200, "current_interval_usage_count": 0, "model_name": "image-01", "display_name": "图像生成"},
+            {"current_interval_total_count": 450, "current_interval_usage_count": 0, "model_name": "coding-plan-vlm", "display_name": "图片理解"},
+            {"current_interval_total_count": 450, "current_interval_usage_count": 0, "model_name": "coding-plan-search", "display_name": "网络搜索"}
+          ],
+          "base_resp": {"status_code": 0}
+        }
+        """
+        let snap = try MiniMaxResponseParser.parse(data: Data(json.utf8), now: now)
+        XCTAssertEqual(
+            snap.buckets.map(\.title),
+            [
+                "Text to Speech HD",
+                "Video Generation Fast",
+                "Video Generation Standard",
+                "Music Generation v2.5",
+                "Music Generation v2.6",
+                "Music Cover",
+                "Lyrics Generation",
+                "Image Generation",
+                "Image Understanding",
+                "Web Search"
+            ]
+        )
     }
 }

--- a/Tests/VibeBarCoreTests/ZaiParserTests.swift
+++ b/Tests/VibeBarCoreTests/ZaiParserTests.swift
@@ -84,6 +84,31 @@ final class ZaiParserTests: XCTestCase {
         XCTAssertEqual(snap.buckets.last?.rawWindowSeconds, 30 * 86_400)
     }
 
+    func testMCPMonthlyLimitUsesMonthUnit() throws {
+        let json = """
+        {
+          "code": 200,
+          "msg": "OK",
+          "success": true,
+          "data": {
+            "limits": [
+              {"type": "TOKENS_LIMIT", "unit": 6, "number": 1, "usage": 100, "remaining": 80, "currentValue": 20, "percentage": 20, "nextResetTime": 801108004990},
+              {"type": "TOKENS_LIMIT", "unit": 3, "number": 5, "usage": 100, "remaining": 97, "currentValue": 3, "percentage": 3, "nextResetTime": 800818660450},
+              {"type": "TIME_LIMIT", "unit": 5, "number": 1, "usage": 100, "remaining": 100, "currentValue": 0, "percentage": 0, "nextResetTime": 803181604993}
+            ]
+          }
+        }
+        """
+        let snap = try ZaiResponseParser.parse(data: Data(json.utf8), now: now)
+        XCTAssertEqual(snap.buckets.count, 3)
+        let mcp = snap.buckets[2]
+        XCTAssertEqual(mcp.id, "zai.time")
+        XCTAssertEqual(mcp.title, "MCP Monthly")
+        XCTAssertEqual(mcp.shortLabel, "Month")
+        XCTAssertEqual(mcp.rawWindowSeconds, 30 * 86_400)
+        XCTAssertEqual(mcp.usedPercent, 0.0, accuracy: 0.01)
+    }
+
     func testNonSuccessThrowsNetwork() {
         let json = """
         { "code": 500, "msg": "internal error", "success": false }


### PR DESCRIPTION
## Summary
- Read MiniMax service display names from API rows and normalize dashboard labels into English.
- Treat the Z.ai MCP time limit as monthly instead of one minute.

## Test plan
- [x] swift test --filter 'MiniMaxParserTests|ZaiParserTests'
- [x] swift test
- [x] ./Scripts/build_app.sh release
- [x] codesign -d --entitlements - ".build/Vibe Bar.app"
- [x] codesign --verify --deep --strict ".build/Vibe Bar.app"