### PR TITLE
Collapse misc group card per-instance rows when buckets are distinct

### DIFF
--- a/Sources/VibeBarApp/Views/MiscProvidersPage.swift
+++ b/Sources/VibeBarApp/Views/MiscProvidersPage.swift
@@ -131,20 +131,54 @@ private struct MiscProviderGroupCard: View {
                 lastUpdated: latestUpdated,
                 isCompact: false
             )
-            Divider().opacity(0.2)
-            VStack(alignment: .leading, spacing: max(6, density.bucketRowSpacing)) {
-                ForEach(Array(group.instances.enumerated()), id: \.element.id) { index, instance in
-                    MiscProviderInstanceStatusRow(
-                        instance: instance,
-                        ordinal: index + 1,
-                        density: density
-                    )
-                    if index < group.instances.count - 1 {
-                        Divider().opacity(0.16)
+            if shouldShowPerInstanceRows {
+                Divider().opacity(0.2)
+                VStack(alignment: .leading, spacing: max(6, density.bucketRowSpacing)) {
+                    ForEach(Array(group.instances.enumerated()), id: \.element.id) { index, instance in
+                        MiscProviderInstanceStatusRow(
+                            instance: instance,
+                            ordinal: index + 1,
+                            density: density
+                        )
+                        if index < group.instances.count - 1 {
+                            Divider().opacity(0.16)
+                        }
                     }
                 }
             }
         }
+    }
+
+    /// True when the per-instance breakdown adds information the
+    /// aggregated top section can't show on its own.
+    ///
+    /// Hide the breakdown when every instance contributes distinct
+    /// buckets and is healthy — the aggregated body already lists
+    /// every bucket once, so the per-instance rows would just repeat
+    /// the same numbers (this is the common Tencent Token Plan case:
+    /// one generic + one HY3 clone, no bucket ids overlap).
+    ///
+    /// Show the breakdown when:
+    /// - Any bucket id is contributed by 2+ instances (the aggregator
+    ///   averages them, so per-instance rows are how the user sees
+    ///   each copy's real number).
+    /// - Any instance has no successful quota (`needs login`, network
+    ///   error, etc.) — the aggregate suppresses that error if even
+    ///   one sibling succeeded, so the per-instance row is the only
+    ///   place that failure surfaces.
+    private var shouldShowPerInstanceRows: Bool {
+        var seenBucketIDs = Set<String>()
+        for instance in group.instances {
+            guard let quota = environment.quota(for: instance),
+                  !quota.buckets.isEmpty,
+                  quota.error == nil else {
+                return true
+            }
+            for bucket in quota.buckets where !seenBucketIDs.insert(bucket.id).inserted {
+                return true
+            }
+        }
+        return false
     }
 
     private var header: some View {


### PR DESCRIPTION
## Summary

When a misc provider has 2+ visible clones (the canonical Tencent Token Plan case: one Personal + one HY3), the group card was always rendering both an aggregated quota section AND a per-instance breakdown below it. Because each variant fetches a distinct `Plan` (`tp_standard` vs `tp_hy_standard`), the aggregator already shows every bucket exactly once at the top, so the breakdown just restated the same numbers — adding a lot of vertical noise to a card that's normally three buckets tall (see screenshot below the discussion).

This PR hides the per-instance section when every clone is healthy AND no bucket id is contributed by more than one clone. It still appears whenever it actually adds information:

- A bucket id is contributed by 2+ instances (the aggregator averages them, so the breakdown is the only way to see each copy's real number — e.g. two clones of the *same* variant against different accounts).
- Any instance is errored or empty — the aggregator suppresses per-instance failures when at least one sibling succeeds, so the breakdown is the only surface that failure reaches.

## Test plan

- [x] `swift build`
- [x] `swift test` — 342 tests, no failures
- [x] `./Scripts/build_app.sh release`
- [x] `codesign -d --entitlements - ".build/Vibe Bar.app"` returns an empty `<dict/>`
- [x] `codesign --verify --deep --strict ".build/Vibe Bar.app"` clean
- [ ] Visually verify: Tencent Token Plan card with one Personal + one HY3 clone shows only the aggregated two-bucket view (no duplicate breakdown)
- [ ] Visually verify: cloning a *second* Personal copy brings the per-instance breakdown back

🤖 Generated with [Claude Code](https://claude.com/claude-code)