### PR TITLE
Lift Gemini and Antigravity to dedicated-card partial-primary tier

### DIFF
--- a/Sources/VibeBarApp/AppEnvironment.swift
+++ b/Sources/VibeBarApp/AppEnvironment.swift
@@ -13,10 +13,13 @@ final class AppEnvironment: ObservableObject {
 
     @Published private(set) var hasClaudeWebCookies: Bool
     @Published private(set) var hasOpenAIWebCookies: Bool
+    @Published private(set) var hasGeminiWebCookies: Bool
     @Published private(set) var isImportingOpenAIBrowserCookies = false
     @Published private(set) var isImportingClaudeBrowserCookies = false
+    @Published private(set) var isImportingGeminiBrowserCookies = false
     @Published private(set) var openAIBrowserCookieImportStatus: String?
     @Published private(set) var claudeBrowserCookieImportStatus: String?
+    @Published private(set) var geminiBrowserCookieImportStatus: String?
     @Published private(set) var routeHealth: [PrimaryProviderRoute: PrimaryProviderRouteHealth]
 
     private let openAIWebLoginController = OpenAIWebLoginController()
@@ -30,12 +33,15 @@ final class AppEnvironment: ObservableObject {
     private var browserClaudeCookieImportInFlight = false
     private var persistentOpenAICookieImportInFlight = false
     private var browserOpenAICookieImportInFlight = false
+    private var browserGeminiCookieImportInFlight = false
 
     init() {
         let settings = SettingsStore()
         let accounts = AccountStore(
             codexUsageMode: settings.codexUsageMode,
             claudeUsageMode: settings.claudeUsageMode,
+            geminiUsageMode: settings.geminiUsageMode,
+            antigravityUsageMode: settings.antigravityUsageMode,
             miscProviderInstances: settings.settings.miscProviderInstances
         )
         let service = QuotaService.makeDefault(mockProvider: { [weak settings] in
@@ -54,6 +60,7 @@ final class AppEnvironment: ObservableObject {
         self.costService = costService
         self.hasClaudeWebCookies = ClaudeWebCookieStore.hasCookieHeader()
         self.hasOpenAIWebCookies = OpenAIWebCookieStore.hasCookieHeader()
+        self.hasGeminiWebCookies = GeminiWebCookieStore.hasCookieHeader()
         self.routeHealth = PrimaryProviderRouteHealthChecker.checkAll()
 
         let scheduler = QuotaRefreshScheduler(
@@ -97,12 +104,16 @@ final class AppEnvironment: ObservableObject {
                     && $0.mockEnabled == $1.mockEnabled
                     && $0.codexUsageMode == $1.codexUsageMode
                     && $0.claudeUsageMode == $1.claudeUsageMode
+                    && $0.geminiUsageMode == $1.geminiUsageMode
+                    && $0.antigravityUsageMode == $1.antigravityUsageMode
                     && $0.miscProviderInstances == $1.miscProviderInstances
             }
             .sink { [weak self] settings in
                 self?.accountStore.reload(
                     codexUsageMode: settings.codexUsageMode,
                     claudeUsageMode: settings.claudeUsageMode,
+                    geminiUsageMode: settings.geminiUsageMode,
+                    antigravityUsageMode: settings.antigravityUsageMode,
                     miscProviderInstances: settings.miscProviderInstances
                 )
                 self?.recheckPrimaryRouteHealth()
@@ -211,6 +222,8 @@ final class AppEnvironment: ObservableObject {
         accountStore.reload(
             codexUsageMode: settingsStore.settings.codexUsageMode,
             claudeUsageMode: settingsStore.claudeUsageMode,
+            geminiUsageMode: settingsStore.geminiUsageMode,
+            antigravityUsageMode: settingsStore.antigravityUsageMode,
             miscProviderInstances: settingsStore.settings.miscProviderInstances
         )
         // Cookies may have changed (login / re-login) — drop any stale
@@ -244,6 +257,8 @@ final class AppEnvironment: ObservableObject {
         accountStore.reload(
             codexUsageMode: settingsStore.settings.codexUsageMode,
             claudeUsageMode: settingsStore.claudeUsageMode,
+            geminiUsageMode: settingsStore.geminiUsageMode,
+            antigravityUsageMode: settingsStore.antigravityUsageMode,
             miscProviderInstances: settingsStore.settings.miscProviderInstances
         )
         let account = account(for: tool)
@@ -320,6 +335,60 @@ final class AppEnvironment: ObservableObject {
         )
     }
 
+    func importGeminiBrowserCookies() {
+        importGeminiBrowserCookiesAndRefreshIfNeeded(
+            allowKeychainPrompt: true,
+            userInitiated: true
+        )
+    }
+
+    private func importGeminiBrowserCookiesAndRefreshIfNeeded(
+        allowKeychainPrompt: Bool = false,
+        userInitiated: Bool = false
+    ) {
+        if !allowKeychainPrompt, GeminiWebCookieStore.hasCookieHeader() {
+            return
+        }
+        guard !browserGeminiCookieImportInFlight else { return }
+        browserGeminiCookieImportInFlight = true
+        if userInitiated {
+            isImportingGeminiBrowserCookies = true
+            geminiBrowserCookieImportStatus = "Importing from browser..."
+        }
+
+        let importTask = Task.detached(priority: userInitiated ? .userInitiated : .utility) {
+            try? GeminiBrowserCookieImporter.importAndStoreFromBrowsers(
+                allowKeychainPrompt: allowKeychainPrompt
+            )
+        }
+        Task { @MainActor [weak self] in
+            let result = await importTask.value
+            guard let self else { return }
+            self.browserGeminiCookieImportInFlight = false
+            if userInitiated {
+                self.isImportingGeminiBrowserCookies = false
+            }
+            self.hasGeminiWebCookies = GeminiWebCookieStore.hasCookieHeader()
+            guard let result else {
+                if userInitiated {
+                    self.geminiBrowserCookieImportStatus = "No Gemini cookies found in readable browser stores."
+                }
+                return
+            }
+            if userInitiated {
+                self.geminiBrowserCookieImportStatus = "Imported from \(result.sourceLabel)."
+            }
+            self.accountStore.reload(
+                codexUsageMode: self.settingsStore.settings.codexUsageMode,
+                claudeUsageMode: self.settingsStore.claudeUsageMode,
+                geminiUsageMode: self.settingsStore.geminiUsageMode,
+                antigravityUsageMode: self.settingsStore.antigravityUsageMode,
+                miscProviderInstances: self.settingsStore.settings.miscProviderInstances
+            )
+            self.scheduler.triggerRefresh()
+        }
+    }
+
     private func importPersistentClaudeCookiesAndRefreshIfNeeded() {
         guard !persistentClaudeCookieImportInFlight else { return }
         persistentClaudeCookieImportInFlight = true
@@ -333,6 +402,8 @@ final class AppEnvironment: ObservableObject {
             self.accountStore.reload(
                 codexUsageMode: self.settingsStore.settings.codexUsageMode,
                 claudeUsageMode: self.settingsStore.claudeUsageMode,
+                geminiUsageMode: self.settingsStore.geminiUsageMode,
+                antigravityUsageMode: self.settingsStore.antigravityUsageMode,
                 miscProviderInstances: self.settingsStore.settings.miscProviderInstances
             )
             self.lastRoutineBudgetAttemptByAccount.removeAll()
@@ -380,6 +451,8 @@ final class AppEnvironment: ObservableObject {
             self.accountStore.reload(
                 codexUsageMode: self.settingsStore.settings.codexUsageMode,
                 claudeUsageMode: self.settingsStore.claudeUsageMode,
+                geminiUsageMode: self.settingsStore.geminiUsageMode,
+                antigravityUsageMode: self.settingsStore.antigravityUsageMode,
                 miscProviderInstances: self.settingsStore.settings.miscProviderInstances
             )
             self.lastRoutineBudgetAttemptByAccount.removeAll()
@@ -400,6 +473,8 @@ final class AppEnvironment: ObservableObject {
             self.accountStore.reload(
                 codexUsageMode: self.settingsStore.settings.codexUsageMode,
                 claudeUsageMode: self.settingsStore.claudeUsageMode,
+                geminiUsageMode: self.settingsStore.geminiUsageMode,
+                antigravityUsageMode: self.settingsStore.antigravityUsageMode,
                 miscProviderInstances: self.settingsStore.settings.miscProviderInstances
             )
             self.scheduler.triggerRefresh()
@@ -446,6 +521,8 @@ final class AppEnvironment: ObservableObject {
             self.accountStore.reload(
                 codexUsageMode: self.settingsStore.settings.codexUsageMode,
                 claudeUsageMode: self.settingsStore.claudeUsageMode,
+                geminiUsageMode: self.settingsStore.geminiUsageMode,
+                antigravityUsageMode: self.settingsStore.antigravityUsageMode,
                 miscProviderInstances: self.settingsStore.settings.miscProviderInstances
             )
             self.scheduler.triggerRefresh()
@@ -466,6 +543,8 @@ final class AppEnvironment: ObservableObject {
             accountStore.reload(
                 codexUsageMode: settingsStore.settings.codexUsageMode,
                 claudeUsageMode: settingsStore.claudeUsageMode,
+                geminiUsageMode: settingsStore.geminiUsageMode,
+                antigravityUsageMode: settingsStore.antigravityUsageMode,
                 miscProviderInstances: settingsStore.settings.miscProviderInstances
             )
             scheduler.triggerRefresh()
@@ -491,6 +570,8 @@ final class AppEnvironment: ObservableObject {
             accountStore.reload(
                 codexUsageMode: settingsStore.settings.codexUsageMode,
                 claudeUsageMode: settingsStore.claudeUsageMode,
+                geminiUsageMode: settingsStore.geminiUsageMode,
+                antigravityUsageMode: settingsStore.antigravityUsageMode,
                 miscProviderInstances: settingsStore.settings.miscProviderInstances
             )
             scheduler.triggerRefresh()
@@ -498,6 +579,31 @@ final class AppEnvironment: ObservableObject {
         } catch {
             SafeLog.warn("Deleting OpenAI web cookies failed: \(SafeLog.sanitize(error.localizedDescription))")
             hasOpenAIWebCookies = OpenAIWebCookieStore.hasCookieHeader()
+            return false
+        }
+    }
+
+    @discardableResult
+    func deleteGeminiWebCookies() -> Bool {
+        do {
+            try GeminiWebCookieStore.deleteCookieHeader()
+            geminiBrowserCookieImportStatus = nil
+            hasGeminiWebCookies = false
+            for account in accountStore.accounts(for: .gemini) {
+                quotaService.clear(accountId: account.id)
+            }
+            accountStore.reload(
+                codexUsageMode: settingsStore.settings.codexUsageMode,
+                claudeUsageMode: settingsStore.claudeUsageMode,
+                geminiUsageMode: settingsStore.geminiUsageMode,
+                antigravityUsageMode: settingsStore.antigravityUsageMode,
+                miscProviderInstances: settingsStore.settings.miscProviderInstances
+            )
+            scheduler.triggerRefresh()
+            return true
+        } catch {
+            SafeLog.warn("Deleting Gemini web cookies failed: \(SafeLog.sanitize(error.localizedDescription))")
+            hasGeminiWebCookies = GeminiWebCookieStore.hasCookieHeader()
             return false
         }
     }

--- a/Sources/VibeBarApp/Views/MiniQuotaWindowView.swift
+++ b/Sources/VibeBarApp/Views/MiniQuotaWindowView.swift
@@ -15,10 +15,12 @@ struct MiniQuotaWindowView: View {
 
     var body: some View {
         let contentByTool = miniContentByTool
-        // Mini window only surfaces primary providers — misc cards
-        // live on the Misc tab inside the Overview popover, not in
-        // this floating panel.
-        let visibleTools = ToolType.primaryProviders.filter { tool in
+        // Mini window only surfaces dedicated-card providers — misc
+        // cards live on the Misc tab inside the Overview popover, not
+        // in this floating panel. Today the field catalog only has
+        // Codex / Claude entries, so Gemini / Antigravity stay invisible
+        // here until / unless they grow their own catalog rows.
+        let visibleTools = ToolType.dedicatedCardProviders.filter { tool in
             contentByTool[tool]?.isEmpty == false
         }
         let displayMode = settingsStore.settings.miniWindow.displayMode
@@ -54,7 +56,7 @@ struct MiniQuotaWindowView: View {
         let selected = mini.fieldIds(for: mini.displayMode)
         let selectedFieldIds = Set(selected)
         var contentByTool: [ToolType: MiniToolContent] = [:]
-        for tool in ToolType.primaryProviders {
+        for tool in ToolType.dedicatedCardProviders {
             var cells: [MiniCell] = []
             for fieldId in selected {
                 guard

--- a/Sources/VibeBarApp/Views/PopoverRoot.swift
+++ b/Sources/VibeBarApp/Views/PopoverRoot.swift
@@ -70,6 +70,7 @@ struct PopoverRoot: View {
             case .overview: return .compact
             case .claude:   return .claude
             case .openAI:   return .codex
+            case .googleAI: return .compact
             case .misc:     return .compact
             }
         default:
@@ -105,6 +106,8 @@ struct PopoverRoot: View {
                 ProviderDetailView(tool: .claude, density: density)
             case .openAI:
                 ProviderDetailView(tool: .codex, density: density)
+            case .googleAI:
+                GoogleAIDualPage(density: density)
             case .misc:
                 MiscProvidersPage(density: density)
             }
@@ -123,6 +126,9 @@ struct PopoverRoot: View {
         if kind == .compact, overviewPage == .misc {
             return "Misc Providers"
         }
+        if kind == .compact, overviewPage == .googleAI {
+            return "Google AI"
+        }
         switch effectiveKind {
         case .compact: return "Overview"
         case .codex:   return "OpenAI"
@@ -134,6 +140,9 @@ struct PopoverRoot: View {
     private var headerSubtitle: String? {
         if kind == .compact, overviewPage == .misc {
             return "Usage-only · sign in or paste a key"
+        }
+        if kind == .compact, overviewPage == .googleAI {
+            return "Gemini + Antigravity · quota only"
         }
         switch effectiveKind {
         case .compact: return "All providers · quota & cost"
@@ -160,10 +169,14 @@ struct PopoverRoot: View {
     private var visibleTools: [ToolType] {
         // Header timestamps and refresh state aggregate the providers
         // visible in the current popover. The Misc subpage owns its
-        // usage-only integrations; the normal Overview and Status
-        // surfaces continue to aggregate just the primary providers.
+        // usage-only integrations; the Google AI subpage aggregates the
+        // partial-primary pair; the Overview and Status surfaces stick
+        // to the two primary providers.
         if kind == .compact, overviewPage == .misc {
             return settingsStore.settings.visibleMiscProviderList
+        }
+        if kind == .compact, overviewPage == .googleAI {
+            return ToolType.googleAIPair
         }
         switch effectiveKind {
         case .compact, .status: return ToolType.primaryProviders
@@ -263,6 +276,7 @@ private enum OverviewPage: String, CaseIterable, Identifiable {
     case overview
     case openAI
     case claude
+    case googleAI
     case misc
 
     var id: String { rawValue }
@@ -272,6 +286,7 @@ private enum OverviewPage: String, CaseIterable, Identifiable {
         case .overview: return "Overview"
         case .openAI:   return "OpenAI"
         case .claude:   return "Claude"
+        case .googleAI: return "Google AI"
         case .misc:     return "Misc"
         }
     }
@@ -281,6 +296,7 @@ private enum OverviewPage: String, CaseIterable, Identifiable {
         case .overview: return .compact
         case .openAI:   return .codex
         case .claude:   return .claude
+        case .googleAI: return .compact
         case .misc:     return .compact
         }
     }
@@ -341,10 +357,15 @@ private struct OverviewSwitchIcon: View {
         Group {
             if page == .misc {
                 // Misc gets a generic "more" glyph — the misc tab
-                // covers eight providers so no single brand icon is
+                // covers many providers so no single brand icon is
                 // a fair representative.
                 Image(systemName: "square.grid.2x2")
                     .font(.system(size: 11, weight: .medium))
+            } else if page == .googleAI {
+                // The Google AI tab pairs Gemini + Antigravity. Use the
+                // Gemini brand icon as the visual anchor; the label
+                // already says "Google AI".
+                ToolBrandIconView(tool: .gemini, size: 13)
             } else {
                 ProviderBrandIconView(kind: page.menuBarKind, size: page == .overview ? 14 : 13)
             }
@@ -410,6 +431,26 @@ private struct OverviewWaterfall: View {
                     )
                 }
             }
+        }
+    }
+}
+
+/// The "Google AI" overview sub-page. Two `ProviderQuotaCard`s side
+/// by side — Gemini on the left, Antigravity on the right — with no
+/// cost / model-ranking / heatmap rails. Per the design decision in
+/// the partial-primary plan, Google AI providers expose quota only
+/// (`supportsTokenCost == false`).
+private struct GoogleAIDualPage: View {
+    let density: Theme.Density
+
+    var body: some View {
+        ColumnMasonryLayout(
+            columns: 2,
+            spacing: density.interSectionSpacing,
+            anchoredItems: 2
+        ) {
+            ProviderQuotaCard(tool: .gemini, density: density, compact: false)
+            ProviderQuotaCard(tool: .antigravity, density: density, compact: false)
         }
     }
 }

--- a/Sources/VibeBarApp/Views/SettingsView.swift
+++ b/Sources/VibeBarApp/Views/SettingsView.swift
@@ -11,6 +11,7 @@ struct SettingsView: View {
     private let costRetentionOptions = CostDataSettings.retentionOptions
     @State private var openAICookieDeleteFailed: Bool = false
     @State private var claudeCookieDeleteFailed: Bool = false
+    @State private var geminiCookieDeleteFailed: Bool = false
     @State private var costDataClearStatus: String?
     @State private var launchAtLoginStatusText: String = LoginItemController.statusText
     @State private var launchAtLoginError: String?
@@ -197,6 +198,73 @@ struct SettingsView: View {
                             environment.recheckPrimaryRouteHealth(provider: .claude)
                         } label: {
                             Label("Check connections", systemImage: "checkmark.circle")
+                        }
+                    }
+
+                    settingsSection("Google AI Account") {
+                        Text("Gemini and Antigravity share the same Google AI subscription quota. Cookie import is the only supported web path — there is no WebView login.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+
+                        Picker("Gemini source", selection: $settingsStore.settings.geminiUsageMode) {
+                            ForEach(GeminiUsageMode.allCases) { mode in
+                                Text(mode.label).tag(mode)
+                            }
+                        }
+                        Text(settingsStore.settings.geminiUsageMode.detail)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                        HStack {
+                            Button {
+                                environment.importGeminiBrowserCookies()
+                            } label: {
+                                Label("Import Gemini cookies from browser", systemImage: "safari")
+                            }
+                            .disabled(environment.isImportingGeminiBrowserCookies)
+                            Button(role: .destructive) {
+                                geminiCookieDeleteFailed = !environment.deleteGeminiWebCookies()
+                            } label: {
+                                Label("Delete Gemini cookies", systemImage: "trash")
+                            }
+                            .disabled(!environment.hasGeminiWebCookies)
+                        }
+                        if environment.hasGeminiWebCookies {
+                            Text("Gemini cookies saved.")
+                                .font(.caption2).foregroundStyle(.green)
+                        }
+                        if let status = environment.geminiBrowserCookieImportStatus {
+                            Text(status)
+                                .font(.caption2)
+                                .foregroundStyle(status.hasPrefix("Imported") ? .green : .secondary)
+                        }
+                        if geminiCookieDeleteFailed {
+                            Text("Could not delete saved Gemini cookies.")
+                                .font(.caption2).foregroundStyle(.orange)
+                        }
+
+                        Divider()
+                            .padding(.vertical, 2)
+
+                        Picker("Antigravity source", selection: $settingsStore.settings.antigravityUsageMode) {
+                            ForEach(AntigravityUsageMode.allCases) { mode in
+                                Text(mode.label).tag(mode)
+                            }
+                        }
+                        Text(settingsStore.settings.antigravityUsageMode.detail)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                        // Antigravity web-cookie controls are gated on the
+                        // spike outcome (plan §9). When the planner has the
+                        // flag off, only the local LSP probe runs and the
+                        // cookie controls would be dead UI.
+                        if AntigravitySourcePlanner.antigravityWebSourceAvailable {
+                            Text("Antigravity cookie import is enabled — sign in at antigravity.google first.")
+                                .font(.caption2)
+                                .foregroundStyle(.secondary)
+                        } else {
+                            Text("Antigravity reads the locally running language server. Cookie import is deferred until the Antigravity Cloud endpoint ships.")
+                                .font(.caption2)
+                                .foregroundStyle(.tertiary)
                         }
                     }
 

--- a/Sources/VibeBarCore/Adapters/AntigravityQuotaAdapter.swift
+++ b/Sources/VibeBarCore/Adapters/AntigravityQuotaAdapter.swift
@@ -36,13 +36,16 @@ public struct AntigravityQuotaAdapter: QuotaAdapter {
 
     private let timeout: TimeInterval
     private let now: @Sendable () -> Date
+    private let usageModeProvider: @Sendable () -> AntigravityUsageMode
 
     public init(
         timeout: TimeInterval = 8,
-        now: @escaping @Sendable () -> Date = { Date() }
+        now: @escaping @Sendable () -> Date = { Date() },
+        usageMode: (@Sendable () -> AntigravityUsageMode)? = nil
     ) {
         self.timeout = timeout
         self.now = now
+        self.usageModeProvider = usageMode ?? { Self.resolveUsageMode() }
     }
 
     private static let processName = "language_server_macos"
@@ -50,11 +53,37 @@ public struct AntigravityQuotaAdapter: QuotaAdapter {
         "/exa.language_server_pb.LanguageServerService/GetUserStatus"
 
     public func fetch(for account: AccountIdentity) async throws -> AccountQuota {
-        let instanceID = AccountStore.miscInstanceID(fromAccountID: account.id, fallbackTool: .antigravity)
-        guard MiscProviderSettings.current(for: .antigravity, instanceID: instanceID).allowsLocalProbeAccess else {
-            throw QuotaError.noCredential
+        let order = AntigravitySourcePlanner.resolve(mode: usageModeProvider())
+        var lastError: Error?
+        for source in order {
+            do {
+                switch source {
+                case .localProbe:
+                    return try await fetchWithLocalProbe(for: account)
+                case .webCookie:
+                    // Spike-gated: returns `.noCredential` until the
+                    // Antigravity Cloud endpoint is reverse-engineered
+                    // and `antigravityWebSourceAvailable` flips. See
+                    // plan §9. The planner already collapses
+                    // `webOnly` / `webThenLocal` to `[.localProbe]`
+                    // while the flag is off, so this arm is unreachable
+                    // in practice until the spike lands.
+                    throw QuotaError.noCredential
+                default:
+                    continue
+                }
+            } catch QuotaError.noCredential {
+                lastError = QuotaError.noCredential
+                continue
+            } catch {
+                lastError = error
+                continue
+            }
         }
+        throw mapURLError(lastError ?? QuotaError.noCredential)
+    }
 
+    private func fetchWithLocalProbe(for account: AccountIdentity) async throws -> AccountQuota {
         let process = try await detectProcessInfo()
         let ports = try await listeningPorts(pid: process.pid)
         let endpoints = endpointCandidates(for: process, ports: ports)
@@ -84,6 +113,17 @@ public struct AntigravityQuotaAdapter: QuotaAdapter {
             }
         }
         throw mapError(lastError)
+    }
+
+    /// Reads the persisted `antigravityUsageMode` setting from disk.
+    /// Internal (not `private`) so the public init's default argument
+    /// can reference it.
+    static func resolveUsageMode() -> AntigravityUsageMode {
+        let appSettings = (try? VibeBarLocalStore.readJSON(
+            AppSettings.self,
+            from: VibeBarLocalStore.settingsURL
+        )) ?? .default
+        return appSettings.antigravityUsageMode
     }
 
     // MARK: - Process detection

--- a/Sources/VibeBarCore/Adapters/GeminiQuotaAdapter.swift
+++ b/Sources/VibeBarCore/Adapters/GeminiQuotaAdapter.swift
@@ -1,52 +1,76 @@
 import Foundation
 
-/// Google Gemini (Code Assist) usage adapter.
+/// Google Gemini partial-primary usage adapter.
 ///
-/// Auth flow vs. codexbar's reference:
+/// Source order (driven by `GeminiSourcePlanner.resolve(mode:)`):
 ///
-/// - **Read** the user's Gemini CLI OAuth file at
-///   `~/.gemini/oauth_creds.json` and reuse `access_token`. We
-///   surface a friendly "re-run `gemini`" error when the token is
-///   expired rather than re-implementing codexbar's
-///   binary-discovery + npm-package-walk + Google OAuth refresh
-///   pipeline. That's a meaningful simplification — codexbar's
-///   refresh path is ~600 lines because Google distributes the
-///   OAuth client credentials inside the Gemini CLI npm package
-///   itself; reading them requires resolving the binary, walking
-///   `node_modules`, and parsing source files. Vibe Bar's first
-///   port pushes that complexity to a follow-up.
-/// - **Skip** `loadCodeAssist` and the project-ID discovery hop.
-///   `retrieveUserQuota` accepts an empty body and returns the
-///   per-model buckets we render. Tier detection (Free / Workspace
-///   / Paid / Legacy) is dropped for now — same follow-up.
+/// - **OAuth CLI** — read `~/.gemini/oauth_creds.json`, reuse
+///   `access_token`, call
+///   `cloudcode-pa.googleapis.com/v1internal:retrieveUserQuota`. This is
+///   the Gemini Code Assist protocol the official CLI uses. Tier
+///   detection (Free / Workspace / Paid / Legacy) is still deferred,
+///   matching codexbar's port. `GeminiTokenRefreshHelper` shells out
+///   to `gemini` itself to refresh expired tokens.
+/// - **Web cookie** — use cookies imported from `gemini.google.com`
+///   (Chrome Safe Storage via SweetCookieKit). Routed through
+///   `GeminiWebQuotaFetcher`; the live endpoint and parser are
+///   spike-pending (see plan §9).
 ///
-/// Output: one `QuotaBucket` per model (Pro / Flash / Flash-Lite).
-/// `usedPercent = (1 - remainingFraction) * 100`. The bucket
-/// `groupTitle` carries the model id so the misc card can group
-/// related models if they ever land.
+/// Output: one `QuotaBucket` per model with
+/// `usedPercent = (1 - remainingFraction) * 100`. The `groupTitle`
+/// carries the prettified model name so the popover card can group
+/// related variants.
 public struct GeminiQuotaAdapter: QuotaAdapter {
     public let tool: ToolType = .gemini
 
     private let session: URLSession
     private let homeDirectory: String
     private let now: @Sendable () -> Date
+    private let usageModeProvider: @Sendable () -> GeminiUsageMode
 
     public init(
         session: URLSession = .shared,
         homeDirectory: String = RealHomeDirectory.path,
-        now: @escaping @Sendable () -> Date = { Date() }
+        now: @escaping @Sendable () -> Date = { Date() },
+        usageMode: (@Sendable () -> GeminiUsageMode)? = nil
     ) {
         self.session = session
         self.homeDirectory = homeDirectory
         self.now = now
+        // Default to reading the persisted setting on every fetch. The
+        // closure indirection lets tests inject a fixed mode without
+        // touching disk, and keeps the public default expression free
+        // of any internal references (Swift forbids those).
+        self.usageModeProvider = usageMode ?? { Self.resolveUsageMode() }
     }
 
     public func fetch(for account: AccountIdentity) async throws -> AccountQuota {
-        let instanceID = AccountStore.miscInstanceID(fromAccountID: account.id, fallbackTool: .gemini)
-        guard MiscProviderSettings.current(for: .gemini, instanceID: instanceID).allowsAPIOrOAuthAccess else {
-            throw QuotaError.noCredential
+        let order = GeminiSourcePlanner.resolve(mode: usageModeProvider())
+        var lastError: Error?
+        for source in order {
+            do {
+                switch source {
+                case .oauthCLI:
+                    return try await fetchWithOAuth(for: account)
+                case .webCookie:
+                    return try await fetchWithWebCookies(for: account)
+                default:
+                    continue
+                }
+            } catch QuotaError.noCredential {
+                // Try the next source; only surface "no credential"
+                // if every source agreed there is nothing to use.
+                lastError = QuotaError.noCredential
+                continue
+            } catch {
+                lastError = error
+                continue
+            }
         }
+        throw mapURLError(lastError ?? QuotaError.noCredential)
+    }
 
+    private func fetchWithOAuth(for account: AccountIdentity) async throws -> AccountQuota {
         let credsURL = URL(fileURLWithPath: homeDirectory)
             .appendingPathComponent(".gemini/oauth_creds.json")
 
@@ -73,9 +97,10 @@ public struct GeminiQuotaAdapter: QuotaAdapter {
         }
 
         if let expiry = credentials.expiry, expiry < now() {
-            // Vibe Bar's first port doesn't refresh tokens. The user
-            // can run any `gemini` command to refresh in-place; we
-            // surface a clear hint instead of silently failing.
+            // The keepalive in `GeminiTokenRefreshHelper` is best-effort
+            // and cooldown-throttled. A stale token reaching this point
+            // means the keepalive failed or is on cooldown; hint the
+            // user to refresh in a terminal instead of silently failing.
             throw QuotaError.needsLogin
         }
 
@@ -119,6 +144,39 @@ public struct GeminiQuotaAdapter: QuotaAdapter {
             queriedAt: now(),
             error: nil
         )
+    }
+
+    private func fetchWithWebCookies(for account: AccountIdentity) async throws -> AccountQuota {
+        let header: String
+        do {
+            header = try GeminiWebCookieStore.readCookieHeader()
+        } catch {
+            throw QuotaError.noCredential
+        }
+        let fetcher = GeminiWebQuotaFetcher(session: session, now: now)
+        let snapshot = try await fetcher.fetch(cookieHeader: header)
+        return AccountQuota(
+            accountId: account.id,
+            tool: .gemini,
+            buckets: snapshot.buckets,
+            plan: snapshot.planName,
+            email: snapshot.email,
+            queriedAt: now(),
+            error: nil
+        )
+    }
+
+    /// Reads the persisted `geminiUsageMode` setting from disk.
+    /// Matches how the Codex / Claude adapters resolve their modes
+    /// without threading `AppSettings` through every call site.
+    /// Internal (not `private`) so the public init's default argument
+    /// can reference it.
+    static func resolveUsageMode() -> GeminiUsageMode {
+        let appSettings = (try? VibeBarLocalStore.readJSON(
+            AppSettings.self,
+            from: VibeBarLocalStore.settingsURL
+        )) ?? .default
+        return appSettings.geminiUsageMode
     }
 }
 

--- a/Sources/VibeBarCore/Adapters/GeminiWebAdapter.swift
+++ b/Sources/VibeBarCore/Adapters/GeminiWebAdapter.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+/// Fetches Gemini usage data from the signed-in `gemini.google.com`
+/// web session via imported browser cookies.
+///
+/// **Spike-pending**: the exact endpoint, request body, anti-hijacking
+/// envelope, and required `Authorization: SAPISIDHASH` header are not
+/// covered by public Google documentation. The placeholder
+/// implementation here intentionally fails fast with `.needsLogin`
+/// when the cookie store is empty (so the UI shows "Import cookies"),
+/// and otherwise throws `.parseFailure` with a developer-facing hint
+/// to flip `GeminiWebQuotaFetcher.spikeComplete` and fill in the
+/// real request once the spike (see plan §9) is done. This keeps the
+/// dedicated-card UI shippable today without forging protocol details.
+struct GeminiWebQuotaFetcher: Sendable {
+    /// Flip to `true` once `gemini.google.com/usage` reverse-engineering
+    /// is complete and the wire shape is locked in.
+    static let spikeComplete = false
+
+    private let session: URLSession
+    private let now: @Sendable () -> Date
+
+    init(
+        session: URLSession = .shared,
+        now: @escaping @Sendable () -> Date = { Date() }
+    ) {
+        self.session = session
+        self.now = now
+    }
+
+    func fetch(cookieHeader: String, email: String? = nil) async throws -> GeminiResponseParser.Snapshot {
+        guard !cookieHeader.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw QuotaError.noCredential
+        }
+        guard Self.spikeComplete else {
+            // Surface a clear maintenance-time hint instead of a
+            // generic network error. The dedicated card will fall
+            // through to the OAuth source when the planner allows.
+            throw QuotaError.parseFailure(
+                "Gemini Web source is awaiting the gemini.google.com/usage spike. See plan §9."
+            )
+        }
+        // Spike-completed implementation lives here. Expected shape:
+        //   1. Build URLRequest against the confirmed endpoint
+        //      (likely under gemini.google.com/_/...).
+        //   2. Apply minimum cookie header + SAPISIDHASH if required.
+        //   3. Strip `)]}'\n` anti-hijacking prefix from the response.
+        //   4. Delegate JSON parsing to GeminiWebResponseParser.parse(_:).
+        throw QuotaError.parseFailure("Gemini Web fetch not implemented yet.")
+    }
+}

--- a/Sources/VibeBarCore/Adapters/GeminiWebResponseParser.swift
+++ b/Sources/VibeBarCore/Adapters/GeminiWebResponseParser.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+/// Parses the JSON envelope returned by Gemini's signed-in web usage
+/// endpoint into the shared `GeminiResponseParser.Snapshot` shape so the
+/// `GeminiQuotaAdapter` produces an identical `AccountQuota` regardless
+/// of which credential source won.
+///
+/// **Spike-pending**: the exact field names and per-model layout are
+/// not covered by public Google documentation. Treat this file as the
+/// home for the wire-shape decoder once the spike is complete.
+enum GeminiWebResponseParser {
+    /// Strip Google's anti-hijacking prefix `)]}'` (with or without a
+    /// trailing newline) that fronts most internal JSON RPCs.
+    static func stripAntiHijackingPrefix(_ data: Data) -> Data {
+        let prefix = Data(")]}'".utf8)
+        guard data.starts(with: prefix) else { return data }
+        var idx = data.index(data.startIndex, offsetBy: prefix.count)
+        while idx < data.endIndex {
+            let byte = data[idx]
+            if byte == 0x0A || byte == 0x0D { // \n or \r
+                idx = data.index(after: idx)
+            } else {
+                break
+            }
+        }
+        return data.subdata(in: idx..<data.endIndex)
+    }
+
+    static func parse(
+        data: Data,
+        email: String? = nil,
+        now: Date = Date()
+    ) throws -> GeminiResponseParser.Snapshot {
+        let stripped = stripAntiHijackingPrefix(data)
+        guard !stripped.isEmpty else {
+            throw QuotaError.parseFailure("Gemini Web response was empty after stripping anti-hijacking prefix.")
+        }
+        // Spike-completed shape decoding goes here. Expect either:
+        //   * per-model buckets (Pro / Flash / Flash-Lite / Deep
+        //     Research / Veo), each with `usedPercent` + `resetTime`;
+        //   * or a single aggregate "compute usage" percentage — emit
+        //     one bucket with id `gemini.web.compute` and no
+        //     `groupTitle` in that case.
+        // For now, signal a clear parse failure so the adapter falls
+        // through to the OAuth source and the UI shows a maintenance
+        // hint rather than a misleading "everything is fine" card.
+        _ = stripped
+        throw QuotaError.parseFailure(
+            "Gemini Web response parser not implemented yet (awaiting spike, see plan §9)."
+        )
+    }
+}

--- a/Sources/VibeBarCore/BrowserCookies/GeminiBrowserCookieImporter.swift
+++ b/Sources/VibeBarCore/BrowserCookies/GeminiBrowserCookieImporter.swift
@@ -1,0 +1,99 @@
+import Foundation
+import SweetCookieKit
+
+/// Imports the minimum Gemini web session cookie set from the user's
+/// installed browsers. Vibe Bar does not offer a WKWebView login flow
+/// for Gemini (user decision: cookie-import-only), so this importer is
+/// the sole on-ramp for the Gemini web credential source.
+///
+/// Cookies live on `gemini.google.com` and on the parent `.google.com`
+/// domain (the `__Secure-1PSID*` family lives on the parent so a single
+/// Google login covers Gemini, Antigravity, AI Studio, and other
+/// Google AI products). Both domains are queried; the resulting cookie
+/// jar is then minimised through `GeminiWebCookieStore` to drop
+/// analytics / preference cookies before the header reaches the
+/// Keychain.
+public enum GeminiBrowserCookieImporter {
+    public struct Result: Sendable {
+        public let header: String
+        public let sourceLabel: String
+        public let cookieCount: Int
+    }
+
+    public static let cookieDomains = ["gemini.google.com", ".google.com"]
+
+    public static func importAndStoreFromBrowsers(
+        allowKeychainPrompt: Bool = false,
+        importOrder: BrowserCookieImportOrder = BrowserCookieDefaults.importOrder,
+        detection: BrowserDetection = BrowserDetection(),
+        client: BrowserCookieClient = BrowserCookieClient(),
+        logger: ((String) -> Void)? = nil
+    ) throws -> Result? {
+        guard let result = importFromBrowsers(
+            allowKeychainPrompt: allowKeychainPrompt,
+            importOrder: importOrder,
+            detection: detection,
+            client: client,
+            logger: logger
+        ) else {
+            return nil
+        }
+        try GeminiWebCookieStore.writeCookieHeader(result.header, source: .browser)
+        return result
+    }
+
+    public static func importFromBrowsers(
+        allowKeychainPrompt: Bool = false,
+        importOrder: BrowserCookieImportOrder = BrowserCookieDefaults.importOrder,
+        detection: BrowserDetection = BrowserDetection(),
+        client: BrowserCookieClient = BrowserCookieClient(),
+        logger: ((String) -> Void)? = nil
+    ) -> Result? {
+        let candidates = importOrder.cookieImportCandidates(
+            using: detection,
+            allowKeychainPrompt: allowKeychainPrompt
+        )
+        guard !candidates.isEmpty else { return nil }
+
+        let query = BrowserCookieQuery(domains: cookieDomains)
+
+        for browser in candidates {
+            let stores: [BrowserCookieStoreRecords]
+            do {
+                stores = try client.vibeBarRecords(
+                    matching: query,
+                    in: browser,
+                    allowKeychainPrompt: allowKeychainPrompt,
+                    logger: logger
+                )
+            } catch {
+                BrowserCookieAccessGate.recordIfNeeded(error)
+                logger?("\(browser.displayName) Gemini cookie import failed: \(SafeLog.sanitize(error.localizedDescription))")
+                continue
+            }
+
+            for store in stores {
+                let pairs = store.records.map { (name: $0.name, value: $0.value) }
+                guard let header = sessionHeader(from: pairs) else { continue }
+                let label = "\(browser.displayName) (\(store.store.profile.name))"
+                return Result(
+                    header: header,
+                    sourceLabel: label,
+                    cookieCount: store.records.count
+                )
+            }
+        }
+        return nil
+    }
+
+    /// Builds a minimised Cookie header from a flat list of name/value
+    /// pairs. The minimisation rule lives in `GeminiWebCookieStore` so
+    /// the importer stays a thin shim — when the spike (plan §9)
+    /// finalises the required cookie set, only the store needs updating.
+    public static func sessionHeader(from cookies: [(name: String, value: String)]) -> String? {
+        let raw = cookies
+            .map { "\($0.name)=\($0.value)" }
+            .joined(separator: "; ")
+        return GeminiWebCookieStore.minimizedCookieHeader(from: raw)
+    }
+}

--- a/Sources/VibeBarCore/Credentials/GeminiWebCookieStore.swift
+++ b/Sources/VibeBarCore/Credentials/GeminiWebCookieStore.swift
@@ -1,0 +1,158 @@
+import Foundation
+
+/// Storage for the minimum Gemini web session cookie set imported from a
+/// signed-in browser.
+///
+/// Vibe Bar does not expose a WKWebView login flow for Gemini (user
+/// decision: cookie-import-only). The `webView` cookie source is kept
+/// in the API surface for parity with `ClaudeWebCookieStore` and for
+/// possible future use, but no code path currently writes to it.
+///
+/// Cookies are stored in the user's Keychain via `SecureCookieHeaderStore`
+/// under the `gemini` provider namespace. Nothing is persisted to
+/// `~/.vibebar/`.
+///
+/// The set of cookies that are kept after `minimizedCookieHeader(from:)`
+/// runs is intentionally conservative for now: until the spike against
+/// `gemini.google.com/usage` confirms the exact authentication contract,
+/// the store keeps every `__Secure-1PSID*` cookie plus the Google SAPISID
+/// family. Spike outcomes that prove a smaller set is sufficient should
+/// shrink `keptCookieNamePrefixes` accordingly and document why each
+/// remaining cookie is required.
+public enum GeminiWebCookieStore {
+    public enum CookieSource: Sendable {
+        case webView
+        case browser
+        case legacy
+    }
+
+    /// Cookie names kept by the minimization step. The list is a
+    /// superset of what is likely to be required — the spike will
+    /// trim it down. Any cookie *not* in this list is dropped before
+    /// the header reaches the Keychain.
+    static let keptCookieNames: Set<String> = [
+        "__Secure-1PSID",
+        "__Secure-1PSIDTS",
+        "__Secure-1PSIDCC",
+        "__Secure-3PSID",
+        "__Secure-3PSIDTS",
+        "__Secure-3PSIDCC",
+        "SID",
+        "HSID",
+        "SSID",
+        "APISID",
+        "SAPISID"
+    ]
+
+    public static func readCookieHeader() throws -> String {
+        if let header = candidateCookieHeaders().first {
+            return header
+        }
+        throw QuotaError.noCredential
+    }
+
+    public static func readCookieHeader(source: CookieSource) throws -> String {
+        if let header = storedCookieHeader(source: source) {
+            return header
+        }
+        throw QuotaError.noCredential
+    }
+
+    public static func candidateCookieHeaders() -> [String] {
+        var headers: [String] = []
+        appendStoredCookieHeader(source: .browser, to: &headers)
+        appendStoredCookieHeader(source: .webView, to: &headers)
+        return unique(headers)
+    }
+
+    public static func writeCookieHeader(_ header: String, source: CookieSource = .legacy) throws {
+        guard let minimized = minimizedCookieHeader(from: header) else { throw QuotaError.noCredential }
+        try SecureCookieHeaderStore.store(
+            minimized,
+            provider: .gemini,
+            source: secureSource(for: source)
+        )
+    }
+
+    public static func hasCookieHeader() -> Bool {
+        (try? readCookieHeader()) != nil
+    }
+
+    public static func deleteCookieHeader() throws {
+        try SecureCookieHeaderStore.deleteAll(provider: .gemini)
+    }
+
+    public static func storageState(source: CookieSource) -> SecureCookieHeaderStore.LoadResult {
+        SecureCookieHeaderStore.load(
+            provider: .gemini,
+            source: secureSource(for: source)
+        )
+    }
+
+    public static func minimizedCookieHeader(from raw: String) -> String? {
+        let pairs = cookiePairs(from: raw)
+        let kept = pairs.filter { keptCookieNames.contains($0.name) }
+        // The authoritative auth cookie is `__Secure-1PSID`. Without it
+        // there is no point storing the rest — bail and signal "no
+        // credential" to callers.
+        guard kept.contains(where: { $0.name == "__Secure-1PSID" && !$0.value.isEmpty }) else {
+            return nil
+        }
+        let header = kept.map { "\($0.name)=\($0.value)" }.joined(separator: "; ")
+        return header.isEmpty ? nil : header
+    }
+
+    public static func normalizedCookieHeader(from raw: String) -> String {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return "" }
+        if trimmed.localizedCaseInsensitiveContains("Cookie:") {
+            return trimmed
+                .replacingOccurrences(of: "Cookie:", with: "", options: [.caseInsensitive])
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+        return trimmed
+    }
+
+    private static func appendStoredCookieHeader(source: CookieSource, to headers: inout [String]) {
+        guard let raw = storedCookieHeader(source: source) else { return }
+        headers.append(raw)
+    }
+
+    private static func storedCookieHeader(source: CookieSource) -> String? {
+        switch SecureCookieHeaderStore.load(provider: .gemini, source: secureSource(for: source)) {
+        case .found(let raw):
+            return minimizedCookieHeader(from: raw)
+        case .missing, .temporarilyUnavailable, .invalid:
+            return nil
+        }
+    }
+
+    private static func secureSource(for source: CookieSource) -> SecureCookieHeaderStore.Source {
+        switch source {
+        case .webView, .legacy: return .webView
+        case .browser: return .browser
+        }
+    }
+
+    private static func cookiePairs(from header: String) -> [(name: String, value: String)] {
+        normalizedCookieHeader(from: header)
+            .split(separator: ";")
+            .compactMap { part in
+                let pieces = part.split(separator: "=", maxSplits: 1, omittingEmptySubsequences: false)
+                guard pieces.count == 2 else { return nil }
+                return (
+                    name: pieces[0].trimmingCharacters(in: .whitespacesAndNewlines),
+                    value: pieces[1].trimmingCharacters(in: .whitespacesAndNewlines)
+                )
+            }
+    }
+
+    private static func unique(_ headers: [String]) -> [String] {
+        var seen: Set<String> = []
+        var out: [String] = []
+        for header in headers where seen.insert(header).inserted {
+            out.append(header)
+        }
+        return out
+    }
+}

--- a/Sources/VibeBarCore/Credentials/SecureCookieHeaderStore.swift
+++ b/Sources/VibeBarCore/Credentials/SecureCookieHeaderStore.swift
@@ -9,6 +9,11 @@ public enum SecureCookieHeaderStore {
     public enum Provider: String, Sendable {
         case openAI = "openai"
         case claude
+        case gemini
+        // Antigravity is intentionally absent until
+        // `AntigravitySourcePlanner.antigravityWebSourceAvailable` flips
+        // to true. Once the spike confirms a cloud endpoint, add
+        // `case antigravity` and the matching cookie store.
     }
 
     public enum Source: String, Sendable, CaseIterable {

--- a/Sources/VibeBarCore/Models/AppSettings.swift
+++ b/Sources/VibeBarCore/Models/AppSettings.swift
@@ -8,6 +8,8 @@ public struct AppSettings: Codable, Equatable, Sendable {
     public var mockEnabled: Bool
     public var codexUsageMode: CodexUsageMode
     public var claudeUsageMode: ClaudeUsageMode
+    public var geminiUsageMode: GeminiUsageMode
+    public var antigravityUsageMode: AntigravityUsageMode
     public var menuBarItems: [MenuBarItemSettings]
     public var miniWindow: MiniWindowSettings
     /// Per-popover density. Each menu bar item kind has its own density so the
@@ -42,6 +44,8 @@ public struct AppSettings: Codable, Equatable, Sendable {
         mockEnabled: false,
         codexUsageMode: .auto,
         claudeUsageMode: .auto,
+        geminiUsageMode: .auto,
+        antigravityUsageMode: .auto,
         menuBarItems: Self.defaultMenuBarItems,
         miniWindow: Self.defaultMiniWindow,
         popoverDensities: Self.defaultPopoverDensities,
@@ -107,27 +111,29 @@ public struct AppSettings: Codable, Equatable, Sendable {
 
     public static let defaultProviderPlanLabels: [ToolType: String] = [:]
 
-    /// Default `MiscProviderSettings` for every misc provider. Source
+    /// Default `MiscProviderSettings` for every misc-page provider. Source
     /// selection is intentionally automatic and not exposed in the UI;
     /// region / enterprise host remain as provider-specific knobs.
+    /// Partial-primary providers (`.gemini`, `.antigravity`) are excluded —
+    /// they have dedicated `*UsageMode` top-level fields instead.
     public static var defaultMiscProviders: [ToolType: MiscProviderSettings] {
         var out: [ToolType: MiscProviderSettings] = [:]
-        for tool in ToolType.miscProviders {
+        for tool in ToolType.miscPageProviders {
             out[tool] = .default
         }
         return out
     }
 
     public static var defaultVisibleMiscProviders: Set<ToolType> {
-        Set(ToolType.miscProviders)
+        Set(ToolType.miscPageProviders)
     }
 
     public static var defaultMiscProviderOrder: [ToolType] {
-        ToolType.miscProviders
+        ToolType.miscPageProviders
     }
 
     public static var defaultMiscProviderInstances: [MiscProviderInstance] {
-        ToolType.miscProviders.map { .defaultInstance(for: $0) }
+        ToolType.miscPageProviders.map { .defaultInstance(for: $0) }
     }
 
     public init(
@@ -138,6 +144,8 @@ public struct AppSettings: Codable, Equatable, Sendable {
         mockEnabled: Bool,
         codexUsageMode: CodexUsageMode = .auto,
         claudeUsageMode: ClaudeUsageMode = .auto,
+        geminiUsageMode: GeminiUsageMode = .auto,
+        antigravityUsageMode: AntigravityUsageMode = .auto,
         menuBarItems: [MenuBarItemSettings] = AppSettings.defaultMenuBarItems,
         miniWindow: MiniWindowSettings = AppSettings.defaultMiniWindow,
         popoverDensities: [MenuBarItemKind: PopoverDensity] = AppSettings.defaultPopoverDensities,
@@ -155,6 +163,8 @@ public struct AppSettings: Codable, Equatable, Sendable {
         self.mockEnabled = false
         self.codexUsageMode = codexUsageMode
         self.claudeUsageMode = claudeUsageMode
+        self.geminiUsageMode = geminiUsageMode
+        self.antigravityUsageMode = antigravityUsageMode
         self.menuBarItems = Self.normalizedMenuBarItems(menuBarItems)
         self.miniWindow = miniWindow
         self.popoverDensities = popoverDensities
@@ -182,6 +192,8 @@ public struct AppSettings: Codable, Equatable, Sendable {
         case mockEnabled
         case codexUsageMode
         case claudeUsageMode
+        case geminiUsageMode
+        case antigravityUsageMode
         case menuBarItems
         case miniWindow
         case popoverDensities
@@ -203,6 +215,8 @@ public struct AppSettings: Codable, Equatable, Sendable {
         self.mockEnabled = false
         self.codexUsageMode = try c.decodeIfPresent(CodexUsageMode.self, forKey: .codexUsageMode) ?? Self.default.codexUsageMode
         self.claudeUsageMode = try c.decodeIfPresent(ClaudeUsageMode.self, forKey: .claudeUsageMode) ?? Self.default.claudeUsageMode
+        self.geminiUsageMode = try c.decodeIfPresent(GeminiUsageMode.self, forKey: .geminiUsageMode) ?? Self.default.geminiUsageMode
+        self.antigravityUsageMode = try c.decodeIfPresent(AntigravityUsageMode.self, forKey: .antigravityUsageMode) ?? Self.default.antigravityUsageMode
 
         // Gemini support was removed; old persisted configs may contain
         // {"kind":"gemini",...} entries that no longer match a known case.
@@ -241,12 +255,16 @@ public struct AppSettings: Codable, Equatable, Sendable {
         // Unknown ToolType keys (typo, removed provider) are silently
         // dropped. `MiscProviderSettings`' own decoder rejects fields
         // whose names look like secrets — together they keep
-        // settings.json minimal and credential-free.
+        // settings.json minimal and credential-free. Partial-primary
+        // providers (`.gemini`, `.antigravity`) are also dropped here:
+        // their settings have been lifted into top-level
+        // `geminiUsageMode` / `antigravityUsageMode` fields and any
+        // legacy entries in `settings.json` are stale.
         let decodedLegacyProviders: [ToolType: MiscProviderSettings]
         if let raw = try c.decodeIfPresent([String: MiscProviderSettings].self, forKey: .miscProviders) {
             var map: [ToolType: MiscProviderSettings] = [:]
             for (key, value) in raw {
-                if let tool = ToolType(rawValue: key), tool.isMisc { map[tool] = value }
+                if let tool = ToolType(rawValue: key), tool.isMiscPageProvider { map[tool] = value }
             }
             decodedLegacyProviders = Self.normalizedMiscProviders(map)
         } else {
@@ -257,7 +275,7 @@ public struct AppSettings: Codable, Equatable, Sendable {
         if let rawVisible = try c.decodeIfPresent([String].self, forKey: .visibleMiscProviders) {
             var set: Set<ToolType> = []
             for raw in rawVisible {
-                if let tool = ToolType(rawValue: raw), tool.isMisc { set.insert(tool) }
+                if let tool = ToolType(rawValue: raw), tool.isMiscPageProvider { set.insert(tool) }
             }
             decodedLegacyVisible = Self.normalizedVisibleMiscProviders(set)
         } else {
@@ -267,7 +285,7 @@ public struct AppSettings: Codable, Equatable, Sendable {
         let decodedLegacyOrder: [ToolType]
         if let rawOrder = try c.decodeIfPresent([String].self, forKey: .miscProviderOrder) {
             let order = rawOrder.compactMap { raw -> ToolType? in
-                guard let tool = ToolType(rawValue: raw), tool.isMisc else { return nil }
+                guard let tool = ToolType(rawValue: raw), tool.isMiscPageProvider else { return nil }
                 return tool
             }
             decodedLegacyOrder = Self.normalizedMiscProviderOrder(order)
@@ -298,6 +316,8 @@ public struct AppSettings: Codable, Equatable, Sendable {
         try c.encode(mockEnabled, forKey: .mockEnabled)
         try c.encode(codexUsageMode, forKey: .codexUsageMode)
         try c.encode(claudeUsageMode, forKey: .claudeUsageMode)
+        try c.encode(geminiUsageMode, forKey: .geminiUsageMode)
+        try c.encode(antigravityUsageMode, forKey: .antigravityUsageMode)
         try c.encode(menuBarItems, forKey: .menuBarItems)
         try c.encode(miniWindow, forKey: .miniWindow)
         let stringKeyed = Dictionary(uniqueKeysWithValues: popoverDensities.map { ($0.key.rawValue, $0.value) })
@@ -306,7 +326,7 @@ public struct AppSettings: Codable, Equatable, Sendable {
         try c.encode(planLabels, forKey: .providerPlanLabels)
         let miscRaw = Dictionary(uniqueKeysWithValues: miscProviders.map { ($0.key.rawValue, $0.value) })
         try c.encode(miscRaw, forKey: .miscProviders)
-        let visibleRaw = ToolType.miscProviders
+        let visibleRaw = ToolType.miscPageProviders
             .filter { visibleMiscProviders.contains($0) }
             .map(\.rawValue)
         try c.encode(visibleRaw, forKey: .visibleMiscProviders)
@@ -387,27 +407,28 @@ public struct AppSettings: Codable, Equatable, Sendable {
         return out
     }
 
-    /// Fill in defaults for any misc provider missing from the
-    /// incoming map, and drop entries for non-misc tools.
+    /// Fill in defaults for any misc-page provider missing from the
+    /// incoming map, and drop entries for non-misc-page tools
+    /// (including partial-primary providers).
     private static func normalizedMiscProviders(_ map: [ToolType: MiscProviderSettings]) -> [ToolType: MiscProviderSettings] {
         var out: [ToolType: MiscProviderSettings] = [:]
-        for tool in ToolType.miscProviders {
+        for tool in ToolType.miscPageProviders {
             out[tool] = (map[tool] ?? .default).automaticSourceSelection
         }
         return out
     }
 
     private static func normalizedVisibleMiscProviders(_ providers: Set<ToolType>) -> Set<ToolType> {
-        Set(providers.filter(\.isMisc))
+        Set(providers.filter(\.isMiscPageProvider))
     }
 
     private static func normalizedMiscProviderOrder(_ order: [ToolType]) -> [ToolType] {
         var seen: Set<ToolType> = []
         var out: [ToolType] = []
-        for tool in order where tool.isMisc && seen.insert(tool).inserted {
+        for tool in order where tool.isMiscPageProvider && seen.insert(tool).inserted {
             out.append(tool)
         }
-        for tool in ToolType.miscProviders where seen.insert(tool).inserted {
+        for tool in ToolType.miscPageProviders where seen.insert(tool).inserted {
             out.append(tool)
         }
         return out
@@ -424,7 +445,11 @@ public struct AppSettings: Codable, Equatable, Sendable {
 
         if let instances, !instances.isEmpty {
             for raw in instances {
-                guard raw.tool.isMisc else { continue }
+                // Partial-primary providers (`.gemini`, `.antigravity`)
+                // are silently dropped: any legacy instances from older
+                // `settings.json` files belong to top-level
+                // `*UsageMode` fields now.
+                guard raw.tool.isMiscPageProvider else { continue }
                 let trimmedID = raw.id.trimmingCharacters(in: .whitespacesAndNewlines)
                 guard !trimmedID.isEmpty, seenIDs.insert(trimmedID).inserted else { continue }
                 out.append(MiscProviderInstance(
@@ -446,7 +471,7 @@ public struct AppSettings: Codable, Equatable, Sendable {
             }
         }
 
-        for tool in ToolType.miscProviders where !seenIDs.contains(tool.rawValue) {
+        for tool in ToolType.miscPageProviders where !seenIDs.contains(tool.rawValue) {
             out.append(.defaultInstance(
                 for: tool,
                 settings: legacyProviders[tool] ?? .default,
@@ -459,7 +484,7 @@ public struct AppSettings: Codable, Equatable, Sendable {
 
     private static func legacyMiscProviders(from instances: [MiscProviderInstance]) -> [ToolType: MiscProviderSettings] {
         var out: [ToolType: MiscProviderSettings] = [:]
-        for tool in ToolType.miscProviders {
+        for tool in ToolType.miscPageProviders {
             let preferred = instances.first { $0.tool == tool && $0.isDefault }
                 ?? instances.first { $0.tool == tool }
             out[tool] = preferred?.settings ?? .default
@@ -477,7 +502,7 @@ public struct AppSettings: Codable, Equatable, Sendable {
         for instance in instances where seen.insert(instance.tool).inserted {
             out.append(instance.tool)
         }
-        for tool in ToolType.miscProviders where seen.insert(tool).inserted {
+        for tool in ToolType.miscPageProviders where seen.insert(tool).inserted {
             out.append(tool)
         }
         return out
@@ -838,6 +863,66 @@ public enum ClaudeUsageMode: String, Codable, CaseIterable, Identifiable, Sendab
         case .oauthOnly: return "Use only Claude OAuth credentials."
         case .cliOnly: return "Use only local Claude Code OAuth credentials."
         case .webOnly: return "Use only saved claude.ai cookies."
+        }
+    }
+}
+
+public enum GeminiUsageMode: String, Codable, CaseIterable, Identifiable, Sendable {
+    case auto
+    case oauthThenWeb
+    case webThenOAuth
+    case oauthOnly
+    case webOnly
+
+    public var id: String { rawValue }
+
+    public var label: String {
+        switch self {
+        case .auto: return "Auto"
+        case .oauthThenWeb: return "Gemini CLI, then Web"
+        case .webThenOAuth: return "Gemini Web, then CLI"
+        case .oauthOnly: return "Gemini CLI only"
+        case .webOnly: return "Gemini Web only"
+        }
+    }
+
+    public var detail: String {
+        switch self {
+        case .auto: return "Use local Gemini CLI credentials first; fall back to imported gemini.google.com cookies."
+        case .oauthThenWeb: return "Use local Gemini CLI credentials first; fall back to imported gemini.google.com cookies."
+        case .webThenOAuth: return "Use imported gemini.google.com cookies first; fall back to local Gemini CLI credentials."
+        case .oauthOnly: return "Use only the Gemini CLI OAuth credentials at ~/.gemini/oauth_creds.json."
+        case .webOnly: return "Use only imported gemini.google.com cookies."
+        }
+    }
+}
+
+public enum AntigravityUsageMode: String, Codable, CaseIterable, Identifiable, Sendable {
+    case auto
+    case localThenWeb
+    case webThenLocal
+    case localOnly
+    case webOnly
+
+    public var id: String { rawValue }
+
+    public var label: String {
+        switch self {
+        case .auto: return "Auto"
+        case .localThenWeb: return "Local LSP, then Web"
+        case .webThenLocal: return "Web, then Local LSP"
+        case .localOnly: return "Local LSP only"
+        case .webOnly: return "Web only"
+        }
+    }
+
+    public var detail: String {
+        switch self {
+        case .auto: return "Probe the running Antigravity language server first; fall back to imported cookies when the web source is available."
+        case .localThenWeb: return "Probe the running Antigravity language server first; fall back to imported cookies."
+        case .webThenLocal: return "Use imported cookies first; fall back to the running Antigravity language server."
+        case .localOnly: return "Only probe the running Antigravity language server."
+        case .webOnly: return "Only use imported cookies. Falls back to the local probe until the Antigravity Cloud endpoint ships."
         }
     }
 }

--- a/Sources/VibeBarCore/Models/PrimaryProviderSourcePlanner.swift
+++ b/Sources/VibeBarCore/Models/PrimaryProviderSourcePlanner.swift
@@ -79,3 +79,41 @@ public enum ClaudeSourcePlanner {
         }
     }
 }
+
+public enum GeminiSourcePlanner {
+    public static func resolve(mode: GeminiUsageMode) -> [CredentialSource] {
+        switch mode {
+        case .auto, .oauthThenWeb:
+            return [.oauthCLI, .webCookie]
+        case .webThenOAuth:
+            return [.webCookie, .oauthCLI]
+        case .oauthOnly:
+            return [.oauthCLI]
+        case .webOnly:
+            return [.webCookie]
+        }
+    }
+}
+
+public enum AntigravitySourcePlanner {
+    /// Compile-time flag controlling whether the web-cookie path is
+    /// exposed. Flip to `true` only after the Antigravity Cloud endpoint
+    /// spike succeeds (see plan §9). Until then, `webOnly` collapses to
+    /// `[.localProbe]` and the Settings UI hides the Antigravity cookie
+    /// controls. Centralised here so the follow-up patch is a one-line
+    /// flip instead of a multi-file churn.
+    public static let antigravityWebSourceAvailable = false
+
+    public static func resolve(mode: AntigravityUsageMode) -> [CredentialSource] {
+        switch mode {
+        case .auto, .localThenWeb:
+            return antigravityWebSourceAvailable ? [.localProbe, .webCookie] : [.localProbe]
+        case .webThenLocal:
+            return antigravityWebSourceAvailable ? [.webCookie, .localProbe] : [.localProbe]
+        case .localOnly:
+            return [.localProbe]
+        case .webOnly:
+            return antigravityWebSourceAvailable ? [.webCookie] : [.localProbe]
+        }
+    }
+}

--- a/Sources/VibeBarCore/Models/ToolType.swift
+++ b/Sources/VibeBarCore/Models/ToolType.swift
@@ -13,20 +13,33 @@ import Foundation
 /// - MiniQuotaWindowView.swift: providerAccent / providerTitle
 /// - ProviderBrandIcon.swift: SF symbol + brand SVG mapping
 ///
-/// Tools split into two tiers:
+/// Adding a *partial-primary* case (dedicated card without token cost or
+/// status integration) also requires:
+/// - PrimaryProviderSourcePlanner.swift: a per-provider UsageMode + planner
+/// - AccountStore.swift: autoDetect<Provider> helper
+/// - AppSettings.swift: dedicated settings struct + lossy migration from
+///   `miscProviderInstances`
+///
+/// Tools split into three tiers:
 /// - **Primary** (`.codex`, `.claude`) — full quota + cost + service-status
 ///   integration, dedicated popover pages, mini-window slots.
-/// - **Misc** (`.alibaba`, `.alibabaTokenPlan`, `.gemini`, `.antigravity`,
-///   `.copilot`, `.zai`, `.minimax`, `.kimi`, `.cursor`, `.mimo`, `.iflytek`,
+/// - **Partial-Primary** (`.gemini`, `.antigravity`) — dedicated popover
+///   card (Google AI dual page) + SettingsView panel + multi-source
+///   credential fallback, but no token-cost scanning and no Atlassian-style
+///   status polling. Share `supportsDedicatedCard == true` with primary.
+/// - **Misc** (`.alibaba`, `.alibabaTokenPlan`, `.copilot`, `.zai`,
+///   `.minimax`, `.kimi`, `.cursor`, `.mimo`, `.iflytek`,
 ///   `.tencentHunyuan`, `.tencentTokenPlan`, `.volcengine`, `.baiduQianfan`,
 ///   `.openCodeGo`, `.kilo`, `.kiro`, `.ollama`, `.openRouter`, `.warp`) —
 ///   usage-only cards on the Misc tab.
-///   No token-cost scanning, no Atlassian-style status polling.
 ///
 /// `supportsTokenCost` and `supportsStatusPage` short-circuit the cost
-/// scanner and the status-page poller for misc providers; most other
-/// switch sites only need to add a `default:` arm or guard with
-/// `tool.isPrimary`.
+/// scanner and the status-page poller; `supportsDedicatedCard` is the
+/// predicate the dedicated-card UI uses; `isMiscPageProvider` is the
+/// filter the Misc tab and `defaultMiscProviderInstances` use. Note
+/// `isMisc` still reports true for the partial-primary pair so legacy
+/// `tool.isMisc` callers keep their original semantics — new misc-only
+/// code paths should switch to `isMiscPageProvider`.
 public enum ToolType: String, Codable, CaseIterable, Hashable, Sendable {
     case codex
     case claude
@@ -65,12 +78,56 @@ public enum ToolType: String, Codable, CaseIterable, Hashable, Sendable {
 
     public var isMisc: Bool { !isPrimary }
 
+    /// True for providers that get a dedicated popover card, a SettingsView
+    /// panel, and multi-source credential fallback. Primary providers are a
+    /// proper subset of this set; partial-primary providers (Gemini,
+    /// Antigravity) live here without the cost / status integrations.
+    public var supportsDedicatedCard: Bool {
+        switch self {
+        case .codex, .claude, .gemini, .antigravity: return true
+        case .alibaba, .alibabaTokenPlan, .copilot, .zai, .minimax, .kimi, .cursor, .mimo, .iflytek, .tencentHunyuan, .tencentTokenPlan, .volcengine, .baiduQianfan, .openCodeGo, .kilo, .kiro, .ollama, .openRouter, .warp:
+            return false
+        }
+    }
+
+    /// True for the Google AI pair — dedicated card, multi-source
+    /// credentials, no token cost, no status page integration.
+    public var isPartialPrimary: Bool {
+        supportsDedicatedCard && !isPrimary
+    }
+
+    /// True for providers that show up on the Misc settings tab and in
+    /// `defaultMiscProviderInstances`. Equivalent to "no dedicated card" —
+    /// narrower than `isMisc`, which still reports true for the
+    /// partial-primary pair so legacy `tool.isMisc` callers keep working.
+    public var isMiscPageProvider: Bool {
+        !supportsDedicatedCard
+    }
+
     public static var primaryProviders: [ToolType] {
         allCases.filter { $0.isPrimary }
     }
 
     public static var miscProviders: [ToolType] {
         allCases.filter { $0.isMisc }
+    }
+
+    public static var dedicatedCardProviders: [ToolType] {
+        allCases.filter { $0.supportsDedicatedCard }
+    }
+
+    public static var partialPrimaryProviders: [ToolType] {
+        allCases.filter { $0.isPartialPrimary }
+    }
+
+    public static var miscPageProviders: [ToolType] {
+        allCases.filter { $0.isMiscPageProvider }
+    }
+
+    /// The two Google AI providers that render side-by-side in the
+    /// Overview popover's "Google AI" page.
+    public static var googleAIPair: [ToolType] {
+        [.gemini, .antigravity]
     }
 
     public var supportsTokenCost: Bool {

--- a/Sources/VibeBarCore/Services/MockDataProvider.swift
+++ b/Sources/VibeBarCore/Services/MockDataProvider.swift
@@ -215,7 +215,33 @@ public enum MockDataProvider {
                 QuotaBucket(id: "weekly_opus", title: "Weekly", shortLabel: "Opus wk",
                             usedPercent: 18, resetAt: weeklyReset, rawWindowSeconds: 604_800, groupTitle: "Opus")
             ]
-        case .alibaba, .alibabaTokenPlan, .gemini, .antigravity, .copilot, .zai, .minimax, .kimi, .cursor, .mimo, .iflytek, .tencentHunyuan, .tencentTokenPlan, .volcengine, .baiduQianfan, .openCodeGo, .kilo, .kiro, .ollama, .openRouter, .warp:
+        case .gemini:
+            // Partial-primary mock: per-model buckets matching the
+            // shape Gemini CLI / Web returns. Reset times are arbitrary —
+            // the live data overrides whichever fields are present.
+            buckets = [
+                QuotaBucket(id: "gemini.pro", title: "Pro", shortLabel: "Pro",
+                            usedPercent: 78, resetAt: weeklyReset, rawWindowSeconds: nil, groupTitle: "Pro"),
+                QuotaBucket(id: "gemini.flash", title: "Flash", shortLabel: "Flash",
+                            usedPercent: 33, resetAt: weeklyReset, rawWindowSeconds: nil, groupTitle: "Flash"),
+                QuotaBucket(id: "gemini.flash-lite", title: "Flash Lite", shortLabel: "Lite",
+                            usedPercent: 9, resetAt: weeklyReset, rawWindowSeconds: nil, groupTitle: "Flash Lite")
+            ]
+        case .antigravity:
+            // Partial-primary mock: the live Antigravity LSP groups
+            // buckets by Gemini Pro / Flash / Claude variants.
+            buckets = [
+                QuotaBucket(id: "antigravity.gemini-3-pro", title: "Gemini Pro",
+                            shortLabel: "Pro", usedPercent: 41, resetAt: fiveHourReset,
+                            rawWindowSeconds: nil, groupTitle: "Gemini Pro"),
+                QuotaBucket(id: "antigravity.gemini-3-flash", title: "Gemini Flash",
+                            shortLabel: "Flash", usedPercent: 17, resetAt: fiveHourReset,
+                            rawWindowSeconds: nil, groupTitle: "Gemini Flash"),
+                QuotaBucket(id: "antigravity.claude-sonnet-4-5", title: "Claude Sonnet 4.5",
+                            shortLabel: "Sonnet", usedPercent: 71, resetAt: fiveHourReset,
+                            rawWindowSeconds: nil, groupTitle: "Claude")
+            ]
+        case .alibaba, .alibabaTokenPlan, .copilot, .zai, .minimax, .kimi, .cursor, .mimo, .iflytek, .tencentHunyuan, .tencentTokenPlan, .volcengine, .baiduQianfan, .openCodeGo, .kilo, .kiro, .ollama, .openRouter, .warp:
             // Misc providers' mock data lands in subsequent phases as
             // each adapter is wired up. For now return a single
             // illustrative bucket so the card renders something during

--- a/Sources/VibeBarCore/Storage/AccountStore.swift
+++ b/Sources/VibeBarCore/Storage/AccountStore.swift
@@ -20,11 +20,15 @@ public final class AccountStore: ObservableObject {
     public init(
         codexUsageMode: CodexUsageMode = .auto,
         claudeUsageMode: ClaudeUsageMode = .auto,
+        geminiUsageMode: GeminiUsageMode = .auto,
+        antigravityUsageMode: AntigravityUsageMode = .auto,
         miscProviderInstances: [MiscProviderInstance] = AppSettings.defaultMiscProviderInstances
     ) {
         reload(
             codexUsageMode: codexUsageMode,
             claudeUsageMode: claudeUsageMode,
+            geminiUsageMode: geminiUsageMode,
+            antigravityUsageMode: antigravityUsageMode,
             miscProviderInstances: miscProviderInstances
         )
     }
@@ -33,6 +37,8 @@ public final class AccountStore: ObservableObject {
     public func reload(
         codexUsageMode: CodexUsageMode = .auto,
         claudeUsageMode: ClaudeUsageMode = .auto,
+        geminiUsageMode: GeminiUsageMode = .auto,
+        antigravityUsageMode: AntigravityUsageMode = .auto,
         miscProviderInstances: [MiscProviderInstance] = AppSettings.defaultMiscProviderInstances
     ) {
         var detected: [AccountIdentity] = []
@@ -42,6 +48,12 @@ public final class AccountStore: ObservableObject {
         }
         if let claude = autoDetectClaude(mode: claudeUsageMode) {
             detected.append(claude)
+        }
+        if let gemini = autoDetectGemini(mode: geminiUsageMode) {
+            detected.append(gemini)
+        }
+        if let antigravity = autoDetectAntigravity(mode: antigravityUsageMode) {
+            detected.append(antigravity)
         }
 
         // Misc provider instances always present, regardless of credentials.
@@ -174,6 +186,86 @@ public final class AccountStore: ObservableObject {
             allowsWebFallback: remaining.contains(.webCookie),
             allowsCLIFallback: remaining.contains(.cliDetected),
             allowsOAuthFallback: remaining.contains(.oauthCLI),
+            createdAt: Date(),
+            updatedAt: Date()
+        )
+    }
+
+    private func autoDetectGemini(mode: GeminiUsageMode) -> AccountIdentity? {
+        let order = GeminiSourcePlanner.resolve(mode: mode)
+        let homeDir = RealHomeDirectory.path
+        let geminiOAuthPath = URL(fileURLWithPath: homeDir)
+            .appendingPathComponent(".gemini/oauth_creds.json").path
+        var selected: CredentialSource?
+        for source in order {
+            switch source {
+            case .oauthCLI:
+                if FileManager.default.fileExists(atPath: geminiOAuthPath) {
+                    selected = .oauthCLI
+                }
+            case .webCookie:
+                if GeminiWebCookieStore.hasCookieHeader() {
+                    selected = .webCookie
+                }
+            case .cliDetected, .apiToken, .browserCookie, .manualCookie, .localProbe, .notConfigured:
+                break
+            }
+            if selected != nil { break }
+        }
+        guard let selectedSource = selected else { return nil }
+        let id: String
+        let alias: String
+        switch selectedSource {
+        case .oauthCLI:
+            id = "oauth-gemini"
+            alias = "Gemini CLI"
+        case .webCookie:
+            id = "web-gemini"
+            alias = "Gemini Web"
+        default:
+            id = "gemini"
+            alias = "Gemini"
+        }
+        let remaining = remainingSources(after: selectedSource, in: order)
+        return AccountIdentity(
+            id: id,
+            tool: .gemini,
+            alias: alias,
+            source: selectedSource,
+            allowsWebFallback: remaining.contains(.webCookie),
+            allowsCLIFallback: false,
+            allowsOAuthFallback: remaining.contains(.oauthCLI),
+            createdAt: Date(),
+            updatedAt: Date()
+        )
+    }
+
+    /// Antigravity always registers a placeholder identity so its
+    /// dedicated card shows up even when the desktop app isn't running
+    /// or no cookies have been imported yet. The adapter's `fetch`
+    /// surfaces the real "open Antigravity" / "import cookies" error
+    /// once the user opens the popover.
+    private func autoDetectAntigravity(mode: AntigravityUsageMode) -> AccountIdentity? {
+        let order = AntigravitySourcePlanner.resolve(mode: mode)
+        let primarySource: CredentialSource = order.first ?? .localProbe
+        let id: String
+        let alias: String
+        switch primarySource {
+        case .webCookie:
+            id = "web-antigravity"
+            alias = "Antigravity Web"
+        default:
+            id = "local-antigravity"
+            alias = "Antigravity"
+        }
+        return AccountIdentity(
+            id: id,
+            tool: .antigravity,
+            alias: alias,
+            source: primarySource,
+            allowsWebFallback: order.contains(.webCookie),
+            allowsCLIFallback: false,
+            allowsOAuthFallback: false,
             createdAt: Date(),
             updatedAt: Date()
         )

--- a/Sources/VibeBarCore/Storage/SettingsStore.swift
+++ b/Sources/VibeBarCore/Storage/SettingsStore.swift
@@ -129,6 +129,14 @@ public final class SettingsStore: ObservableObject {
         get { settings.claudeUsageMode }
         set { settings.claudeUsageMode = newValue }
     }
+    public var geminiUsageMode: GeminiUsageMode {
+        get { settings.geminiUsageMode }
+        set { settings.geminiUsageMode = newValue }
+    }
+    public var antigravityUsageMode: AntigravityUsageMode {
+        get { settings.antigravityUsageMode }
+        set { settings.antigravityUsageMode = newValue }
+    }
     public var launchAtLogin: Bool {
         get { settings.launchAtLogin }
         set { settings.launchAtLogin = newValue }

--- a/Tests/VibeBarCoreTests/AppSettingsGoogleAIMigrationTests.swift
+++ b/Tests/VibeBarCoreTests/AppSettingsGoogleAIMigrationTests.swift
@@ -1,0 +1,102 @@
+import XCTest
+@testable import VibeBarCore
+
+/// Locks the one-way migration from "Gemini / Antigravity were misc
+/// providers" to "they're partial-primary, have top-level
+/// `*UsageMode` fields, and are excluded from `miscProviderInstances`."
+///
+/// The migration runs on every `init(from:)` because both the decode
+/// path and the normalisation helpers now filter by `isMiscPageProvider`.
+final class AppSettingsGoogleAIMigrationTests: XCTestCase {
+    func testDefaultIncludesNewGoogleAIUsageModes() {
+        XCTAssertEqual(AppSettings.default.geminiUsageMode, .auto)
+        XCTAssertEqual(AppSettings.default.antigravityUsageMode, .auto)
+    }
+
+    func testGeminiUsageModeRoundTrip() throws {
+        var settings = AppSettings.default
+        settings.geminiUsageMode = .webThenOAuth
+        settings.antigravityUsageMode = .localOnly
+
+        let data = try JSONEncoder().encode(settings)
+        let decoded = try JSONDecoder().decode(AppSettings.self, from: data)
+
+        XCTAssertEqual(decoded.geminiUsageMode, .webThenOAuth)
+        XCTAssertEqual(decoded.antigravityUsageMode, .localOnly)
+    }
+
+    func testLegacyGeminiMiscInstanceIsDroppedOnDecode() throws {
+        // Older settings files include `.gemini` / `.antigravity` in
+        // `miscProviderInstances`. After the partial-primary upgrade
+        // those entries are stale and must not survive a decode.
+        let json = """
+        {
+          "displayMode": "remaining",
+          "refreshIntervalSeconds": 600,
+          "launchAtLogin": false,
+          "menuBarTextEnabled": true,
+          "mockEnabled": false,
+          "miscProviderInstances": [
+            { "id": "gemini", "tool": "gemini", "isVisible": true, "isDefault": true, "settings": {} },
+            { "id": "antigravity", "tool": "antigravity", "isVisible": true, "isDefault": true, "settings": {} },
+            { "id": "cursor", "tool": "cursor", "isVisible": true, "isDefault": true, "settings": {} }
+          ]
+        }
+        """
+        let settings = try JSONDecoder().decode(AppSettings.self, from: Data(json.utf8))
+
+        XCTAssertFalse(settings.miscProviderInstances.contains { $0.tool == .gemini },
+                       "legacy .gemini misc instance must be filtered out")
+        XCTAssertFalse(settings.miscProviderInstances.contains { $0.tool == .antigravity },
+                       "legacy .antigravity misc instance must be filtered out")
+        XCTAssertTrue(settings.miscProviderInstances.contains { $0.tool == .cursor },
+                      "unrelated misc instances must survive the migration")
+    }
+
+    func testLegacyGeminiMiscEntryInMiscProvidersDictIsDroppedOnDecode() throws {
+        // The decode path also reads the legacy `miscProviders` dictionary
+        // (the pre-instance shape). Same migration rule applies there.
+        let json = """
+        {
+          "displayMode": "remaining",
+          "refreshIntervalSeconds": 600,
+          "launchAtLogin": false,
+          "menuBarTextEnabled": true,
+          "mockEnabled": false,
+          "miscProviders": {
+            "gemini": {},
+            "antigravity": {},
+            "cursor": {}
+          }
+        }
+        """
+        let settings = try JSONDecoder().decode(AppSettings.self, from: Data(json.utf8))
+
+        XCTAssertNil(settings.miscProviders[.gemini])
+        XCTAssertNil(settings.miscProviders[.antigravity])
+        XCTAssertNotNil(settings.miscProviders[.cursor])
+    }
+
+    func testMigrationIsIdempotent() throws {
+        // Encoding then decoding a freshly-migrated AppSettings must
+        // not resurrect partial-primary misc entries.
+        let initialJSON = """
+        {
+          "displayMode": "remaining",
+          "refreshIntervalSeconds": 600,
+          "launchAtLogin": false,
+          "menuBarTextEnabled": true,
+          "mockEnabled": false,
+          "miscProviderInstances": [
+            { "id": "gemini", "tool": "gemini", "isVisible": true, "isDefault": true, "settings": {} }
+          ]
+        }
+        """
+        let firstPass = try JSONDecoder().decode(AppSettings.self, from: Data(initialJSON.utf8))
+        let reencoded = try JSONEncoder().encode(firstPass)
+        let secondPass = try JSONDecoder().decode(AppSettings.self, from: reencoded)
+
+        XCTAssertFalse(secondPass.miscProviderInstances.contains { $0.tool == .gemini })
+        XCTAssertFalse(secondPass.miscProviderInstances.contains { $0.tool == .antigravity })
+    }
+}

--- a/Tests/VibeBarCoreTests/GeminiWebCookieStoreTests.swift
+++ b/Tests/VibeBarCoreTests/GeminiWebCookieStoreTests.swift
@@ -1,0 +1,37 @@
+import XCTest
+@testable import VibeBarCore
+
+/// Locks the cookie minimisation contract — the importer leans on
+/// `GeminiWebCookieStore.minimizedCookieHeader(from:)` to drop
+/// analytics cookies and require the authoritative `__Secure-1PSID`.
+final class GeminiWebCookieStoreTests: XCTestCase {
+    func testMinimizedHeaderKeepsAuthCookies() {
+        let raw = "_ga=GA1.example; __Secure-1PSID=abc.synthetic-jwt; SAPISID=def-token; pref=light"
+        let minimized = GeminiWebCookieStore.minimizedCookieHeader(from: raw)
+        XCTAssertNotNil(minimized)
+        XCTAssertTrue(minimized!.contains("__Secure-1PSID=abc.synthetic-jwt"))
+        XCTAssertTrue(minimized!.contains("SAPISID=def-token"))
+        XCTAssertFalse(minimized!.contains("_ga"))
+        XCTAssertFalse(minimized!.contains("pref="))
+    }
+
+    func testMinimizedHeaderRequiresPSID() {
+        // Without `__Secure-1PSID` the rest of the cookie set is
+        // useless for the usage RPCs — the helper must bail out.
+        let raw = "SAPISID=def-token; HSID=ghi; SSID=jkl"
+        let minimized = GeminiWebCookieStore.minimizedCookieHeader(from: raw)
+        XCTAssertNil(minimized)
+    }
+
+    func testMinimizedHeaderRejectsBlankPSID() {
+        let raw = "__Secure-1PSID=; SAPISID=def-token"
+        let minimized = GeminiWebCookieStore.minimizedCookieHeader(from: raw)
+        XCTAssertNil(minimized)
+    }
+
+    func testNormalizedHeaderStripsCookiePrefix() {
+        let raw = "Cookie: __Secure-1PSID=abc; SAPISID=def"
+        let normalized = GeminiWebCookieStore.normalizedCookieHeader(from: raw)
+        XCTAssertEqual(normalized, "__Secure-1PSID=abc; SAPISID=def")
+    }
+}

--- a/Tests/VibeBarCoreTests/GeminiWebResponseParserTests.swift
+++ b/Tests/VibeBarCoreTests/GeminiWebResponseParserTests.swift
@@ -1,0 +1,51 @@
+import XCTest
+@testable import VibeBarCore
+
+/// Behavioural tests for the parts of `GeminiWebResponseParser` that
+/// are decided independently of the spike outcome. The full per-shape
+/// decoding lands once the `gemini.google.com/usage` spike (plan §9)
+/// completes; until then we lock in the anti-hijacking prefix logic
+/// and the explicit "not implemented yet" parse-failure contract.
+final class GeminiWebResponseParserTests: XCTestCase {
+    func testStripAntiHijackingPrefixRemovesProperPrefix() {
+        let raw = Data(")]}'\n[{\"x\":1}]".utf8)
+        let stripped = GeminiWebResponseParser.stripAntiHijackingPrefix(raw)
+        XCTAssertEqual(String(data: stripped, encoding: .utf8), "[{\"x\":1}]")
+    }
+
+    func testStripAntiHijackingPrefixWithoutTrailingNewlineStillStripsPrefix() {
+        let raw = Data(")]}'[1,2,3]".utf8)
+        let stripped = GeminiWebResponseParser.stripAntiHijackingPrefix(raw)
+        XCTAssertEqual(String(data: stripped, encoding: .utf8), "[1,2,3]")
+    }
+
+    func testStripAntiHijackingPrefixIsNoopWhenAbsent() {
+        let raw = Data("{\"clean\":true}".utf8)
+        let stripped = GeminiWebResponseParser.stripAntiHijackingPrefix(raw)
+        XCTAssertEqual(String(data: stripped, encoding: .utf8), "{\"clean\":true}")
+    }
+
+    func testParseEmptyDataThrowsParseFailure() {
+        XCTAssertThrowsError(try GeminiWebResponseParser.parse(data: Data())) { error in
+            guard case QuotaError.parseFailure = error else {
+                XCTFail("Expected parseFailure, got \(error)")
+                return
+            }
+        }
+    }
+
+    func testParseUntilSpikeReturnsParseFailureWithSpikeHint() {
+        // Until the spike completes the parser is intentionally a
+        // parseFailure so the adapter falls through to the OAuth source
+        // and the dedicated card surfaces the maintenance hint instead
+        // of a misleading "everything is fine" panel.
+        let payload = Data(")]}'\n{\"buckets\":[]}".utf8)
+        XCTAssertThrowsError(try GeminiWebResponseParser.parse(data: payload)) { error in
+            guard case QuotaError.parseFailure(let message) = error else {
+                XCTFail("Expected parseFailure, got \(error)")
+                return
+            }
+            XCTAssertTrue(message.contains("spike"), "Message should reference the spike: \(message)")
+        }
+    }
+}

--- a/Tests/VibeBarCoreTests/MiscProviderSettingsTests.swift
+++ b/Tests/VibeBarCoreTests/MiscProviderSettingsTests.swift
@@ -133,9 +133,12 @@ final class MiscProviderSettingsTests: XCTestCase {
 }
 
 final class AppSettingsMiscProviderTests: XCTestCase {
-    func testDefaultsIncludeEveryMiscProvider() {
+    func testDefaultsIncludeEveryMiscPageProvider() {
+        // Partial-primary providers (`.gemini`, `.antigravity`) live in
+        // top-level `*UsageMode` fields after the dedicated-card upgrade
+        // and are intentionally absent from `miscProviders` defaults.
         let settings = AppSettings.default
-        for tool in ToolType.miscProviders {
+        for tool in ToolType.miscPageProviders {
             XCTAssertNotNil(settings.miscProviders[tool], "default settings missing entry for \(tool)")
             XCTAssertEqual(settings.miscProviders[tool], .default)
             XCTAssertTrue(settings.isMiscProviderVisible(tool), "default settings should show \(tool)")
@@ -144,7 +147,8 @@ final class AppSettingsMiscProviderTests: XCTestCase {
 
     func testMissingMiscProvidersFieldFillsDefaults() throws {
         // Old settings.json from before this PR had no miscProviders
-        // key. Decoding should still produce a complete map.
+        // key. Decoding should still produce a complete map for every
+        // misc-page provider.
         let json = """
         {
           "displayMode": "remaining",
@@ -155,7 +159,7 @@ final class AppSettingsMiscProviderTests: XCTestCase {
         }
         """
         let settings = try JSONDecoder().decode(AppSettings.self, from: Data(json.utf8))
-        XCTAssertEqual(settings.miscProviders.count, ToolType.miscProviders.count)
+        XCTAssertEqual(settings.miscProviders.count, ToolType.miscPageProviders.count)
         XCTAssertEqual(settings.visibleMiscProviders, AppSettings.defaultVisibleMiscProviders)
     }
 
@@ -306,8 +310,9 @@ final class AppSettingsMiscProviderTests: XCTestCase {
         """
         let settings = try JSONDecoder().decode(AppSettings.self, from: Data(json.utf8))
         XCTAssertEqual(settings.miscProviders[.alibaba]?.sourceMode, .auto)
-        // Every other misc tool falls back to default.
-        for tool in ToolType.miscProviders where tool != .alibaba {
+        // Every other misc-page tool falls back to default. Partial-primary
+        // providers no longer live in this dictionary.
+        for tool in ToolType.miscPageProviders where tool != .alibaba {
             XCTAssertEqual(settings.miscProviders[tool], .default, "expected default for \(tool)")
         }
     }

--- a/Tests/VibeBarCoreTests/PartialPrimaryToolTypeTests.swift
+++ b/Tests/VibeBarCoreTests/PartialPrimaryToolTypeTests.swift
@@ -1,0 +1,61 @@
+import XCTest
+@testable import VibeBarCore
+
+/// Locks the capability-flag taxonomy for the dedicated-card tier.
+/// Without these tests it's easy to regress `isMisc` semantics or
+/// silently drop the Google AI pair out of the dedicated-card filter.
+final class PartialPrimaryToolTypeTests: XCTestCase {
+    func testPrimaryProvidersUnchanged() {
+        XCTAssertEqual(ToolType.primaryProviders, [.codex, .claude])
+    }
+
+    func testGoogleAIPairIsExactlyGeminiAndAntigravity() {
+        XCTAssertEqual(ToolType.googleAIPair, [.gemini, .antigravity])
+    }
+
+    func testPartialPrimaryProvidersAreGeminiAndAntigravity() {
+        XCTAssertEqual(ToolType.partialPrimaryProviders, [.gemini, .antigravity])
+    }
+
+    func testDedicatedCardProvidersIncludePrimaryAndPartialPrimary() {
+        XCTAssertEqual(ToolType.dedicatedCardProviders, [.codex, .claude, .gemini, .antigravity])
+    }
+
+    func testGoogleAIPairDoesNotSupportTokenCost() {
+        for tool in ToolType.googleAIPair {
+            XCTAssertFalse(tool.supportsTokenCost, "\(tool) should not support token cost")
+        }
+    }
+
+    func testGoogleAIPairDoesNotSupportStatusPage() {
+        for tool in ToolType.googleAIPair {
+            XCTAssertFalse(tool.supportsStatusPage, "\(tool) should not support status page")
+        }
+    }
+
+    func testGoogleAIPairSupportsDedicatedCard() {
+        for tool in ToolType.googleAIPair {
+            XCTAssertTrue(tool.supportsDedicatedCard, "\(tool) should support a dedicated card")
+            XCTAssertTrue(tool.isPartialPrimary, "\(tool) should be partial-primary")
+            XCTAssertFalse(tool.isPrimary, "\(tool) should not be `isPrimary`")
+            XCTAssertFalse(tool.isMiscPageProvider, "\(tool) should not show on the Misc page")
+        }
+    }
+
+    func testIsMiscStaysTrueForPartialPrimaryForBackwardCompat() {
+        // The plan keeps `isMisc` true for Gemini/Antigravity so legacy
+        // misc-only call sites (MiscCookieSlotStore, etc.) keep working.
+        // Code that wants to filter the Misc page should use the new
+        // `isMiscPageProvider`.
+        for tool in ToolType.googleAIPair {
+            XCTAssertTrue(tool.isMisc, "\(tool).isMisc must stay true for legacy compat")
+        }
+    }
+
+    func testMiscPageProvidersExcludesPartialPrimary() {
+        XCTAssertFalse(ToolType.miscPageProviders.contains(.gemini))
+        XCTAssertFalse(ToolType.miscPageProviders.contains(.antigravity))
+        XCTAssertTrue(ToolType.miscPageProviders.contains(.copilot))
+        XCTAssertTrue(ToolType.miscPageProviders.contains(.cursor))
+    }
+}

--- a/Tests/VibeBarCoreTests/PrimaryProviderSourcePlannerTests.swift
+++ b/Tests/VibeBarCoreTests/PrimaryProviderSourcePlannerTests.swift
@@ -25,4 +25,66 @@ final class PrimaryProviderSourcePlannerTests: XCTestCase {
 
         XCTAssertEqual(plan, [.webCookie, .cliDetected, .oauthCLI])
     }
+
+    // MARK: - Gemini
+
+    func testGeminiAutoPrefersOAuthThenWeb() {
+        let plan = GeminiSourcePlanner.resolve(mode: .auto)
+
+        XCTAssertEqual(plan, [.oauthCLI, .webCookie])
+    }
+
+    func testGeminiWebThenOAuthOrder() {
+        let plan = GeminiSourcePlanner.resolve(mode: .webThenOAuth)
+
+        XCTAssertEqual(plan, [.webCookie, .oauthCLI])
+    }
+
+    func testGeminiOAuthOnlyDoesNotIncludeWeb() {
+        let plan = GeminiSourcePlanner.resolve(mode: .oauthOnly)
+
+        XCTAssertEqual(plan, [.oauthCLI])
+    }
+
+    func testGeminiWebOnlyDoesNotIncludeOAuth() {
+        let plan = GeminiSourcePlanner.resolve(mode: .webOnly)
+
+        XCTAssertEqual(plan, [.webCookie])
+    }
+
+    // MARK: - Antigravity
+
+    func testAntigravityAutoCollapsesToLocalProbeWhileWebFlagOff() {
+        // `antigravityWebSourceAvailable` is `false` until the
+        // Antigravity Cloud endpoint spike completes (plan §9).
+        // Until then, every mode that would include `.webCookie`
+        // must degrade gracefully to local-probe-only.
+        XCTAssertFalse(AntigravitySourcePlanner.antigravityWebSourceAvailable,
+                       "Flip this test once antigravityWebSourceAvailable goes true.")
+
+        let plan = AntigravitySourcePlanner.resolve(mode: .auto)
+
+        XCTAssertEqual(plan, [.localProbe])
+    }
+
+    func testAntigravityLocalOnlyAlwaysReturnsLocal() {
+        let plan = AntigravitySourcePlanner.resolve(mode: .localOnly)
+
+        XCTAssertEqual(plan, [.localProbe])
+    }
+
+    func testAntigravityWebOnlyCollapsesToLocalWhileWebFlagOff() {
+        // `.webOnly` is a user-visible option; planner must still
+        // degrade rather than return an empty source list, otherwise
+        // the dedicated card would show "no credential" forever.
+        let plan = AntigravitySourcePlanner.resolve(mode: .webOnly)
+
+        XCTAssertEqual(plan, [.localProbe])
+    }
+
+    func testAntigravityWebThenLocalCollapsesWhileWebFlagOff() {
+        let plan = AntigravitySourcePlanner.resolve(mode: .webThenLocal)
+
+        XCTAssertEqual(plan, [.localProbe])
+    }
 }


### PR DESCRIPTION
## Summary

- Promote `.gemini` and `.antigravity` from misc-provider to a new **partial-primary** tier — dedicated popover card + SettingsView panel + multi-source credential fallback, but no token-cost scanning and no Atlassian-style status polling.
- New "Google AI" Overview page renders both cards side-by-side via `GoogleAIDualPage` so the Gemini + Antigravity shared quota lives next to Codex / Claude rather than buried on the Misc tab.
- Add the `gemini.google.com` browser-cookie source as a fallback on top of the existing `~/.gemini/oauth_creds.json` Code Assist path; cookie minimisation keeps the `__Secure-1PSID*` and SAPISID families.

## Scope & decisions

- **Three capability flags** on `ToolType`: `supportsDedicatedCard`, `isPartialPrimary`, `isMiscPageProvider`. `isMisc` semantics are deliberately preserved so legacy `MiscCookieSlotStore` / `MiscCredentialStore` call sites keep working through the dual-storage slot path.
- **No WebView login** for Gemini (user decision: cookie-import-only). `GeminiBrowserCookieImporter` is the sole on-ramp; the importer is a thin shim over the existing `MiscCookieResolver.Spec` infrastructure.
- **Antigravity web source is gated** behind `AntigravitySourcePlanner.antigravityWebSourceAvailable = false`. `webOnly` / `webThenLocal` modes collapse to `[.localProbe]` so the dedicated card never goes dark. The Antigravity Cloud endpoint is not publicly documented yet — the flag flip is a follow-up after the spike below lands.
- **`gemini.google.com/usage` is spike-pending.** `GeminiWebQuotaFetcher` and `GeminiWebResponseParser` throw `.parseFailure` with a clear maintenance hint so the adapter falls through to OAuth and the dedicated card keeps working today. The wire-shape decoder needs a DevTools spike before it can be filled in (see plan §9 in the planning doc).

## Migration

- `AppSettings` gains top-level `geminiUsageMode` / `antigravityUsageMode`.
- Legacy `.gemini` / `.antigravity` entries in `miscProviderInstances` and the older `miscProviders` dictionary are silently dropped on decode. The migration is idempotent — round-tripping settings.json after the first migrated load doesn't resurrect them.
- `MiscCookieSlotStore` keychain entries for `.gemini` / `.antigravity` stay reachable via the dual-storage cookie path described in plan §5.

## Spike step needed before the web source is live

The `gemini.google.com/usage` endpoint is gated and not publicly documented. To turn the web source from "scaffold" into "live":

1. Sign in to `gemini.google.com` in Chrome, open DevTools → Network on `/usage?pli=1`.
2. Capture any XHR/Fetch that returns quota data (likely `gemini.google.com/_/...` or a `batchexecute` RPC).
3. Identify whether `Authorization: SAPISIDHASH` is required (the Google internal `SHA1(<ts>_<SAPISID>_<origin>)` flavour) or whether cookies alone suffice.
4. Strip down the cookie set to the minimal authenticated subset.
5. Fill in `GeminiWebQuotaFetcher.fetch(cookieHeader:)` and the per-shape decoder in `GeminiWebResponseParser.parse(data:)`, then flip `GeminiWebQuotaFetcher.spikeComplete = true`.

The same approach applies to a potential Antigravity Cloud endpoint — if a domain shows up in `strings` of `Antigravity.app` and survives a DevTools capture, flip `AntigravitySourcePlanner.antigravityWebSourceAvailable` and ship the matching `AntigravityWebAdapter`.

## Test plan

- [x] `swift build` clean (release).
- [x] `swift test --parallel` — 378 / 378 pass.
- [x] `./Scripts/build_app.sh release` succeeds.
- [x] `codesign -d --entitlements - ".build/Vibe Bar.app"` prints the empty `[Dict]` (no `app-sandbox` key).
- [x] `codesign --verify --deep --strict ".build/Vibe Bar.app"` passes.
- [ ] Manual: launch the app, confirm the new "Google AI" Overview tab shows up between "Claude" and "Misc"; Gemini card shows per-model buckets from `~/.gemini/oauth_creds.json`; Antigravity card shows the local LSP probe when the desktop app is running.
- [ ] Manual: Settings → Google AI Account → "Import Gemini cookies from browser" — confirm a single Chrome Safe Storage Keychain prompt; afterwards `hasGeminiWebCookies` flips green. (Live data still requires the spike.)
- [ ] Manual: confirm legacy users see no `.gemini` / `.antigravity` entries on the Misc tab after the first launch (migration kicks in on settings.json decode).

🤖 Generated with [Claude Code](https://claude.com/claude-code)