### PR TITLE
Run Gemini CLI and Web sources in parallel, merge buckets

### DIFF
--- a/Sources/VibeBarCore/Adapters/GeminiQuotaAdapter.swift
+++ b/Sources/VibeBarCore/Adapters/GeminiQuotaAdapter.swift
@@ -2,24 +2,28 @@ import Foundation
 
 /// Google Gemini partial-primary usage adapter.
 ///
-/// Source order (driven by `GeminiSourcePlanner.resolve(mode:)`):
+/// `.auto` mode runs both sources **in parallel** and merges the
+/// resulting buckets so the user sees CLI and Web data on one card.
+/// `.oauthOnly` / `.webOnly` are explicit single-source escape hatches.
 ///
+/// Sources:
 /// - **OAuth CLI** — read `~/.gemini/oauth_creds.json`, reuse
 ///   `access_token`, call
 ///   `cloudcode-pa.googleapis.com/v1internal:retrieveUserQuota`. This is
-///   the Gemini Code Assist protocol the official CLI uses. Tier
-///   detection (Free / Workspace / Paid / Legacy) is still deferred,
-///   matching codexbar's port. `GeminiTokenRefreshHelper` shells out
-///   to `gemini` itself to refresh expired tokens.
+///   the Gemini Code Assist protocol the official CLI uses.
+///   `GeminiTokenRefreshHelper` shells out to `gemini` itself to refresh
+///   expired tokens.
 /// - **Web cookie** — use cookies imported from `gemini.google.com`
 ///   (Chrome Safe Storage via SweetCookieKit). Routed through
 ///   `GeminiWebQuotaFetcher`; the live endpoint and parser are
-///   spike-pending (see plan §9).
+///   spike-pending. While the spike is incomplete this source returns
+///   a parse failure and the dual-fetch merger drops it silently —
+///   the OAuth half still shows up.
 ///
 /// Output: one `QuotaBucket` per model with
-/// `usedPercent = (1 - remainingFraction) * 100`. The `groupTitle`
-/// carries the prettified model name so the popover card can group
-/// related variants.
+/// `usedPercent = (1 - remainingFraction) * 100`. In dual-fetch mode
+/// buckets from each source carry a `"CLI · "` / `"Web · "` groupTitle
+/// prefix so the popover renders distinct sections.
 public struct GeminiQuotaAdapter: QuotaAdapter {
     public let tool: ToolType = .gemini
 
@@ -45,29 +49,89 @@ public struct GeminiQuotaAdapter: QuotaAdapter {
     }
 
     public func fetch(for account: AccountIdentity) async throws -> AccountQuota {
-        let order = GeminiSourcePlanner.resolve(mode: usageModeProvider())
-        var lastError: Error?
-        for source in order {
-            do {
-                switch source {
-                case .oauthCLI:
-                    return try await fetchWithOAuth(for: account)
-                case .webCookie:
-                    return try await fetchWithWebCookies(for: account)
-                default:
-                    continue
-                }
-            } catch QuotaError.noCredential {
-                // Try the next source; only surface "no credential"
-                // if every source agreed there is nothing to use.
-                lastError = QuotaError.noCredential
-                continue
-            } catch {
-                lastError = error
-                continue
-            }
+        switch usageModeProvider() {
+        case .oauthOnly:
+            return try await fetchWithOAuth(for: account)
+        case .webOnly:
+            return try await fetchWithWebCookies(for: account)
+        case .auto:
+            return try await fetchDual(for: account)
         }
-        throw mapURLError(lastError ?? QuotaError.noCredential)
+    }
+
+    /// Run OAuth and Web in parallel, merge their buckets. When both
+    /// fail, surface the OAuth error (the Web side currently throws a
+    /// spike-pending parseFailure, which is less informative). When
+    /// either succeeds, the failed half is silently dropped — partial
+    /// data beats a "needs login" placeholder on the dedicated card.
+    private func fetchDual(for account: AccountIdentity) async throws -> AccountQuota {
+        async let oauthResult = tryFetchOAuth(for: account)
+        async let webResult = tryFetchWeb(for: account)
+        let oauth = await oauthResult
+        let web = await webResult
+
+        if oauth.quota == nil && web.quota == nil {
+            throw mapURLError(oauth.error ?? web.error ?? QuotaError.noCredential)
+        }
+
+        var buckets: [QuotaBucket] = []
+        if let q = oauth.quota {
+            buckets.append(contentsOf: q.buckets.map { Self.tagBucket($0, source: .oauthCLI) })
+        }
+        if let q = web.quota {
+            buckets.append(contentsOf: q.buckets.map { Self.tagBucket($0, source: .webCookie) })
+        }
+
+        return AccountQuota(
+            accountId: account.id,
+            tool: .gemini,
+            buckets: buckets,
+            plan: oauth.quota?.plan ?? web.quota?.plan,
+            email: oauth.quota?.email ?? web.quota?.email,
+            queriedAt: now(),
+            error: nil
+        )
+    }
+
+    private func tryFetchOAuth(for account: AccountIdentity) async -> (quota: AccountQuota?, error: QuotaError?) {
+        do {
+            return (try await fetchWithOAuth(for: account), nil)
+        } catch let error as QuotaError {
+            return (nil, error)
+        } catch {
+            return (nil, .unknown(String(describing: error)))
+        }
+    }
+
+    private func tryFetchWeb(for account: AccountIdentity) async -> (quota: AccountQuota?, error: QuotaError?) {
+        do {
+            return (try await fetchWithWebCookies(for: account), nil)
+        } catch let error as QuotaError {
+            return (nil, error)
+        } catch {
+            return (nil, .unknown(String(describing: error)))
+        }
+    }
+
+    /// Prefix a bucket's `id` and `groupTitle` with `"CLI"` / `"Web"`
+    /// so the popover card renders the two source's bucket lists as
+    /// distinct sections (rather than letting them visually overlap
+    /// when `groupTitle` collides — e.g. CLI's "Pro" and Web's "Pro").
+    private static func tagBucket(_ bucket: QuotaBucket, source: CredentialSource) -> QuotaBucket {
+        let prefix: String
+        switch source {
+        case .oauthCLI:  prefix = "CLI"
+        case .webCookie: prefix = "Web"
+        default:         return bucket
+        }
+        var copy = bucket
+        copy.id = "\(prefix.lowercased()).\(bucket.id)"
+        if let group = bucket.groupTitle, !group.isEmpty {
+            copy.groupTitle = "\(prefix) · \(group)"
+        } else {
+            copy.groupTitle = prefix
+        }
+        return copy
     }
 
     private func fetchWithOAuth(for account: AccountIdentity) async throws -> AccountQuota {
@@ -305,22 +369,41 @@ enum GeminiResponseParser {
         return Snapshot(buckets: buckets, planName: nil, email: email)
     }
 
-    private static func prettyModelName(_ id: String) -> String {
+    static func prettyModelName(_ id: String) -> String {
         let lower = id.lowercased()
-        if lower.contains("flash-lite") { return "Flash Lite" }
-        if lower.contains("flash")      { return "Flash" }
-        if lower.contains("pro")        { return "Pro" }
-        if lower.contains("ultra")      { return "Ultra" }
+        let version = extractGeminiVersion(from: lower)
+        let suffix = version.isEmpty ? "" : " \(version)"
+        if lower.contains("flash-lite") { return "Flash Lite\(suffix)" }
+        if lower.contains("flash")      { return "Flash\(suffix)" }
+        if lower.contains("pro")        { return "Pro\(suffix)" }
+        if lower.contains("ultra")      { return "Ultra\(suffix)" }
         return id
     }
 
-    private static func shortLabel(for id: String) -> String {
+    static func shortLabel(for id: String) -> String {
         let lower = id.lowercased()
-        if lower.contains("flash-lite") { return "Lite" }
-        if lower.contains("flash")      { return "Flash" }
-        if lower.contains("pro")        { return "Pro" }
-        if lower.contains("ultra")      { return "Ultra" }
+        let version = extractGeminiVersion(from: lower)
+        let suffix = version.isEmpty ? "" : " \(version)"
+        if lower.contains("flash-lite") { return "Lite\(suffix)" }
+        if lower.contains("flash")      { return "Flash\(suffix)" }
+        if lower.contains("pro")        { return "Pro\(suffix)" }
+        if lower.contains("ultra")      { return "Ultra\(suffix)" }
         return id
+    }
+
+    /// Best-effort version extractor for Gemini model identifiers.
+    /// Handles `"gemini-2.5-flash-lite"`, `"gemini-3-pro"`,
+    /// `"models/gemini-3.0-pro"` → `"2.5"` / `"3"` / `"3.0"`. Returns
+    /// `""` when no version segment is recognisable so callers can
+    /// fall back to the plain family name.
+    static func extractGeminiVersion(from id: String) -> String {
+        let pattern = #"gemini[-_/]?(\d+(?:\.\d+)?)"#
+        guard let regex = try? NSRegularExpression(pattern: pattern, options: .caseInsensitive),
+              let match = regex.firstMatch(in: id, range: NSRange(id.startIndex..., in: id)),
+              let range = Range(match.range(at: 1), in: id) else {
+            return ""
+        }
+        return String(id[range])
     }
 }
 

--- a/Sources/VibeBarCore/Models/AppSettings.swift
+++ b/Sources/VibeBarCore/Models/AppSettings.swift
@@ -215,8 +215,12 @@ public struct AppSettings: Codable, Equatable, Sendable {
         self.mockEnabled = false
         self.codexUsageMode = try c.decodeIfPresent(CodexUsageMode.self, forKey: .codexUsageMode) ?? Self.default.codexUsageMode
         self.claudeUsageMode = try c.decodeIfPresent(ClaudeUsageMode.self, forKey: .claudeUsageMode) ?? Self.default.claudeUsageMode
-        self.geminiUsageMode = try c.decodeIfPresent(GeminiUsageMode.self, forKey: .geminiUsageMode) ?? Self.default.geminiUsageMode
-        self.antigravityUsageMode = try c.decodeIfPresent(AntigravityUsageMode.self, forKey: .antigravityUsageMode) ?? Self.default.antigravityUsageMode
+        // `try?` (not `try`) so legacy raw values from older builds —
+        // e.g. the v1 `.oauthThenWeb` / `.webThenOAuth` Gemini cases —
+        // fall back to `.auto` instead of failing the whole AppSettings
+        // decode. Same robustness for AntigravityUsageMode.
+        self.geminiUsageMode = (try? c.decodeIfPresent(GeminiUsageMode.self, forKey: .geminiUsageMode)) ?? Self.default.geminiUsageMode
+        self.antigravityUsageMode = (try? c.decodeIfPresent(AntigravityUsageMode.self, forKey: .antigravityUsageMode)) ?? Self.default.antigravityUsageMode
 
         // Gemini support was removed; old persisted configs may contain
         // {"kind":"gemini",...} entries that no longer match a known case.
@@ -867,10 +871,14 @@ public enum ClaudeUsageMode: String, Codable, CaseIterable, Identifiable, Sendab
     }
 }
 
+/// Gemini exposes two complementary usage views (Code Assist quota via
+/// the CLI's OAuth credentials, and gemini.google.com's per-model
+/// compute usage). They surface different bucket sets — running both
+/// and merging is the default. The single-source modes exist for users
+/// who only sign in via one path or want to silence noisy errors from
+/// the other.
 public enum GeminiUsageMode: String, Codable, CaseIterable, Identifiable, Sendable {
     case auto
-    case oauthThenWeb
-    case webThenOAuth
     case oauthOnly
     case webOnly
 
@@ -878,9 +886,7 @@ public enum GeminiUsageMode: String, Codable, CaseIterable, Identifiable, Sendab
 
     public var label: String {
         switch self {
-        case .auto: return "Auto"
-        case .oauthThenWeb: return "Gemini CLI, then Web"
-        case .webThenOAuth: return "Gemini Web, then CLI"
+        case .auto: return "Auto (CLI + Web)"
         case .oauthOnly: return "Gemini CLI only"
         case .webOnly: return "Gemini Web only"
         }
@@ -888,11 +894,9 @@ public enum GeminiUsageMode: String, Codable, CaseIterable, Identifiable, Sendab
 
     public var detail: String {
         switch self {
-        case .auto: return "Use local Gemini CLI credentials first; fall back to imported gemini.google.com cookies."
-        case .oauthThenWeb: return "Use local Gemini CLI credentials first; fall back to imported gemini.google.com cookies."
-        case .webThenOAuth: return "Use imported gemini.google.com cookies first; fall back to local Gemini CLI credentials."
-        case .oauthOnly: return "Use only the Gemini CLI OAuth credentials at ~/.gemini/oauth_creds.json."
-        case .webOnly: return "Use only imported gemini.google.com cookies."
+        case .auto: return "Fetch both ~/.gemini/oauth_creds.json (Code Assist) and imported gemini.google.com cookies in parallel; merge whichever buckets each source returns."
+        case .oauthOnly: return "Only fetch the Gemini CLI OAuth credentials at ~/.gemini/oauth_creds.json."
+        case .webOnly: return "Only fetch imported gemini.google.com cookies."
         }
     }
 }

--- a/Sources/VibeBarCore/Models/PrimaryProviderSourcePlanner.swift
+++ b/Sources/VibeBarCore/Models/PrimaryProviderSourcePlanner.swift
@@ -80,18 +80,25 @@ public enum ClaudeSourcePlanner {
     }
 }
 
+/// Gemini's adapter does not walk a fallback chain — it runs the
+/// enabled sources in parallel and merges their buckets. Callers ask
+/// the planner which sources are enabled for the current mode; order
+/// within the returned array is informational only.
 public enum GeminiSourcePlanner {
-    public static func resolve(mode: GeminiUsageMode) -> [CredentialSource] {
+    public static func enabledSources(mode: GeminiUsageMode) -> [CredentialSource] {
         switch mode {
-        case .auto, .oauthThenWeb:
-            return [.oauthCLI, .webCookie]
-        case .webThenOAuth:
-            return [.webCookie, .oauthCLI]
-        case .oauthOnly:
-            return [.oauthCLI]
-        case .webOnly:
-            return [.webCookie]
+        case .auto:      return [.oauthCLI, .webCookie]
+        case .oauthOnly: return [.oauthCLI]
+        case .webOnly:   return [.webCookie]
         }
+    }
+
+    public static func runsOAuth(mode: GeminiUsageMode) -> Bool {
+        enabledSources(mode: mode).contains(.oauthCLI)
+    }
+
+    public static func runsWeb(mode: GeminiUsageMode) -> Bool {
+        enabledSources(mode: mode).contains(.webCookie)
     }
 }
 

--- a/Sources/VibeBarCore/Storage/AccountStore.swift
+++ b/Sources/VibeBarCore/Storage/AccountStore.swift
@@ -191,50 +191,46 @@ public final class AccountStore: ObservableObject {
         )
     }
 
+    /// Gemini in `.auto` mode runs both sources in parallel and merges
+    /// their buckets — so the account is registered if *either* source
+    /// has credentials. The `source` field reflects the dominant route
+    /// (OAuth wins when present because it carries email + plan info).
+    /// `.oauthOnly` / `.webOnly` register the account only when that
+    /// one source is configured.
     private func autoDetectGemini(mode: GeminiUsageMode) -> AccountIdentity? {
-        let order = GeminiSourcePlanner.resolve(mode: mode)
+        let enabled = GeminiSourcePlanner.enabledSources(mode: mode)
         let homeDir = RealHomeDirectory.path
         let geminiOAuthPath = URL(fileURLWithPath: homeDir)
             .appendingPathComponent(".gemini/oauth_creds.json").path
-        var selected: CredentialSource?
-        for source in order {
-            switch source {
-            case .oauthCLI:
-                if FileManager.default.fileExists(atPath: geminiOAuthPath) {
-                    selected = .oauthCLI
-                }
-            case .webCookie:
-                if GeminiWebCookieStore.hasCookieHeader() {
-                    selected = .webCookie
-                }
-            case .cliDetected, .apiToken, .browserCookie, .manualCookie, .localProbe, .notConfigured:
-                break
-            }
-            if selected != nil { break }
-        }
-        guard let selectedSource = selected else { return nil }
+        let hasOAuth = enabled.contains(.oauthCLI) && FileManager.default.fileExists(atPath: geminiOAuthPath)
+        let hasWeb = enabled.contains(.webCookie) && GeminiWebCookieStore.hasCookieHeader()
+        guard hasOAuth || hasWeb else { return nil }
+
+        // Dominant source: OAuth (richer metadata) > Web. The
+        // `source` field is mostly informational on the card — the
+        // adapter still decides which paths to actually fetch.
+        let primarySource: CredentialSource = hasOAuth ? .oauthCLI : .webCookie
         let id: String
         let alias: String
-        switch selectedSource {
-        case .oauthCLI:
+        switch mode {
+        case .auto:
+            id = hasOAuth && hasWeb ? "dual-gemini" : (hasOAuth ? "oauth-gemini" : "web-gemini")
+            alias = hasOAuth && hasWeb ? "Gemini CLI + Web" : (hasOAuth ? "Gemini CLI" : "Gemini Web")
+        case .oauthOnly:
             id = "oauth-gemini"
             alias = "Gemini CLI"
-        case .webCookie:
+        case .webOnly:
             id = "web-gemini"
             alias = "Gemini Web"
-        default:
-            id = "gemini"
-            alias = "Gemini"
         }
-        let remaining = remainingSources(after: selectedSource, in: order)
         return AccountIdentity(
             id: id,
             tool: .gemini,
             alias: alias,
-            source: selectedSource,
-            allowsWebFallback: remaining.contains(.webCookie),
+            source: primarySource,
+            allowsWebFallback: mode == .auto && hasWeb && !hasOAuth ? false : (mode != .oauthOnly && hasWeb),
             allowsCLIFallback: false,
-            allowsOAuthFallback: remaining.contains(.oauthCLI),
+            allowsOAuthFallback: mode != .webOnly && hasOAuth,
             createdAt: Date(),
             updatedAt: Date()
         )

--- a/Tests/VibeBarCoreTests/AppSettingsGoogleAIMigrationTests.swift
+++ b/Tests/VibeBarCoreTests/AppSettingsGoogleAIMigrationTests.swift
@@ -15,14 +15,34 @@ final class AppSettingsGoogleAIMigrationTests: XCTestCase {
 
     func testGeminiUsageModeRoundTrip() throws {
         var settings = AppSettings.default
-        settings.geminiUsageMode = .webThenOAuth
+        settings.geminiUsageMode = .webOnly
         settings.antigravityUsageMode = .localOnly
 
         let data = try JSONEncoder().encode(settings)
         let decoded = try JSONDecoder().decode(AppSettings.self, from: data)
 
-        XCTAssertEqual(decoded.geminiUsageMode, .webThenOAuth)
+        XCTAssertEqual(decoded.geminiUsageMode, .webOnly)
         XCTAssertEqual(decoded.antigravityUsageMode, .localOnly)
+    }
+
+    /// Old `settings.json` files persisted while the v1 enum was in
+    /// place may contain `.oauthThenWeb` or `.webThenOAuth`. The
+    /// `decodeIfPresent` fallback should drop the unknown value and
+    /// re-default to `.auto` (dual-fetch) — which is what the user
+    /// likely wanted anyway.
+    func testLegacyGeminiUsageModeFallsBackToAuto() throws {
+        let json = """
+        {
+          "displayMode": "remaining",
+          "refreshIntervalSeconds": 600,
+          "launchAtLogin": false,
+          "menuBarTextEnabled": true,
+          "mockEnabled": false,
+          "geminiUsageMode": "webThenOAuth"
+        }
+        """
+        let settings = try JSONDecoder().decode(AppSettings.self, from: Data(json.utf8))
+        XCTAssertEqual(settings.geminiUsageMode, .auto)
     }
 
     func testLegacyGeminiMiscInstanceIsDroppedOnDecode() throws {

--- a/Tests/VibeBarCoreTests/GeminiDualFetchTests.swift
+++ b/Tests/VibeBarCoreTests/GeminiDualFetchTests.swift
@@ -1,0 +1,100 @@
+import XCTest
+@testable import VibeBarCore
+
+/// Smoke tests for the dual-fetch dispatch in `GeminiQuotaAdapter`.
+/// The adapter's helpers are private, so these tests focus on the
+/// observable behaviour: which sources get attempted for each mode,
+/// and how failures from both halves are surfaced.
+///
+/// The Web parser is currently spike-pending and always throws
+/// `parseFailure`; in `.auto` mode that side is silently dropped when
+/// OAuth succeeds, and is the dominant error only when OAuth also
+/// fails.
+final class GeminiDualFetchTests: XCTestCase {
+    private func makeEmptyHomeAdapter(mode: GeminiUsageMode) throws -> (GeminiQuotaAdapter, URL) {
+        let temp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("vibebar-gemini-tests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: temp, withIntermediateDirectories: true)
+        let adapter = GeminiQuotaAdapter(
+            session: .shared,
+            homeDirectory: temp.path,
+            now: { Date() },
+            usageMode: { mode }
+        )
+        return (adapter, temp)
+    }
+
+    private func cleanup(_ url: URL) {
+        try? FileManager.default.removeItem(at: url)
+    }
+
+    private var fixtureAccount: AccountIdentity {
+        AccountIdentity(
+            id: "test-gemini",
+            tool: .gemini,
+            alias: "Gemini Test",
+            source: .oauthCLI,
+            createdAt: Date(),
+            updatedAt: Date()
+        )
+    }
+
+    func testOAuthOnlyModeThrowsNoCredentialWhenCredsMissing() async throws {
+        let (adapter, temp) = try makeEmptyHomeAdapter(mode: .oauthOnly)
+        defer { cleanup(temp) }
+
+        do {
+            _ = try await adapter.fetch(for: fixtureAccount)
+            XCTFail("Expected throw with no oauth_creds.json present")
+        } catch QuotaError.noCredential {
+            // Pass
+        } catch {
+            XCTFail("Expected .noCredential, got \(error)")
+        }
+    }
+
+    func testAutoModeThrowsWhenBothSourcesUnconfigured() async throws {
+        // With no `~/.gemini/oauth_creds.json` and no imported cookies,
+        // the adapter should surface an error rather than returning an
+        // empty bucket list. The Web side always parseFailures while
+        // the spike is incomplete, so the merged error is OAuth's
+        // .noCredential (the more diagnostic of the two).
+        let (adapter, temp) = try makeEmptyHomeAdapter(mode: .auto)
+        defer { cleanup(temp) }
+
+        do {
+            _ = try await adapter.fetch(for: fixtureAccount)
+            XCTFail("Expected throw with no sources configured")
+        } catch QuotaError.noCredential {
+            // Pass — OAuth's noCredential dominates the merger.
+        } catch QuotaError.parseFailure {
+            // Acceptable fallback if the local keychain still has
+            // imported cookies from a previous session: the Web
+            // side then surfaces its spike-pending parseFailure.
+        } catch QuotaError.network {
+            // Acceptable if the spike Web fetcher made a real call.
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func testWebOnlyModeSurfacesSpikePendingError() async throws {
+        // `.webOnly` always exercises the Web path. With the spike
+        // incomplete the fetcher returns `parseFailure` (or
+        // `noCredential` if no cookies are imported). Either is
+        // acceptable here — the test guarantees no crash and a
+        // QuotaError reaching the caller.
+        let (adapter, temp) = try makeEmptyHomeAdapter(mode: .webOnly)
+        defer { cleanup(temp) }
+
+        do {
+            _ = try await adapter.fetch(for: fixtureAccount)
+            // If this ever succeeds it means the spike landed —
+            // tighten the assertion to verify bucket shape.
+        } catch is QuotaError {
+            // Pass — any QuotaError is fine for this smoke test.
+        } catch {
+            XCTFail("Expected a QuotaError, got \(error)")
+        }
+    }
+}

--- a/Tests/VibeBarCoreTests/GeminiModelNameTests.swift
+++ b/Tests/VibeBarCoreTests/GeminiModelNameTests.swift
@@ -1,0 +1,60 @@
+import XCTest
+@testable import VibeBarCore
+
+/// `GeminiResponseParser` previously collapsed every Flash Lite variant
+/// onto the same display label, so two `gemini-*-flash-lite` buckets
+/// with distinct ids rendered as two identical-looking "Flash Lite"
+/// rows on the popover card. The version extractor disambiguates them.
+final class GeminiModelNameTests: XCTestCase {
+    func testExtractVersionHandlesDottedAndPlainVersions() {
+        XCTAssertEqual(GeminiResponseParser.extractGeminiVersion(from: "gemini-2.5-flash-lite"), "2.5")
+        XCTAssertEqual(GeminiResponseParser.extractGeminiVersion(from: "gemini-3-pro"), "3")
+        XCTAssertEqual(GeminiResponseParser.extractGeminiVersion(from: "gemini-3.0-pro"), "3.0")
+        XCTAssertEqual(GeminiResponseParser.extractGeminiVersion(from: "models/gemini-3.1-flash"), "3.1")
+    }
+
+    func testExtractVersionReturnsEmptyWhenAbsent() {
+        XCTAssertEqual(GeminiResponseParser.extractGeminiVersion(from: "gemini-pro"), "")
+        XCTAssertEqual(GeminiResponseParser.extractGeminiVersion(from: "some-other-model"), "")
+    }
+
+    func testPrettyModelNameCarriesVersion() {
+        XCTAssertEqual(GeminiResponseParser.prettyModelName("gemini-2.5-flash-lite"), "Flash Lite 2.5")
+        XCTAssertEqual(GeminiResponseParser.prettyModelName("gemini-3-pro"), "Pro 3")
+        XCTAssertEqual(GeminiResponseParser.prettyModelName("gemini-3.0-flash"), "Flash 3.0")
+    }
+
+    func testPrettyModelNameFallsBackWhenVersionMissing() {
+        XCTAssertEqual(GeminiResponseParser.prettyModelName("gemini-flash"), "Flash")
+        XCTAssertEqual(GeminiResponseParser.prettyModelName("unknown-foo"), "unknown-foo")
+    }
+
+    func testShortLabelCarriesVersion() {
+        XCTAssertEqual(GeminiResponseParser.shortLabel(for: "gemini-2.5-flash-lite"), "Lite 2.5")
+        XCTAssertEqual(GeminiResponseParser.shortLabel(for: "gemini-3-pro"), "Pro 3")
+    }
+
+    func testTwoFlashLiteVariantsRenderAsDistinctRows() throws {
+        // The actual bug: two different Flash Lite buckets came back
+        // from `retrieveUserQuota` and the popover rendered both with
+        // an identical "Flash Lite" header.
+        let json = """
+        {
+          "buckets": [
+            { "modelId": "gemini-2.5-flash-lite", "remainingFraction": 0.5, "resetTime": "2026-05-22T00:00:00Z", "tokenType": "input" },
+            { "modelId": "gemini-3.0-flash-lite", "remainingFraction": 0.8, "resetTime": "2026-05-22T00:00:00Z", "tokenType": "input" }
+          ]
+        }
+        """
+        let snapshot = try GeminiResponseParser.parse(
+            data: Data(json.utf8),
+            email: nil,
+            now: Date()
+        )
+        XCTAssertEqual(snapshot.buckets.count, 2)
+        let titles = Set(snapshot.buckets.map(\.title))
+        XCTAssertEqual(titles, ["Flash Lite 2.5", "Flash Lite 3.0"])
+        let groups = Set(snapshot.buckets.compactMap(\.groupTitle))
+        XCTAssertEqual(groups, ["Flash Lite 2.5", "Flash Lite 3.0"])
+    }
+}

--- a/Tests/VibeBarCoreTests/GeminiParserTests.swift
+++ b/Tests/VibeBarCoreTests/GeminiParserTests.swift
@@ -19,15 +19,17 @@ final class GeminiParserTests: XCTestCase {
         XCTAssertEqual(snap.email, "user@example.com")
         XCTAssertEqual(snap.buckets.count, 3)
 
-        // Sorted alphabetically by model id.
-        XCTAssertEqual(snap.buckets[0].title, "Flash")
+        // Sorted alphabetically by model id. Titles now carry the
+        // Gemini family version to disambiguate variants like
+        // gemini-2.5-flash-lite vs gemini-3.0-flash-lite.
+        XCTAssertEqual(snap.buckets[0].title, "Flash 2.5")
         XCTAssertEqual(snap.buckets[0].usedPercent, 45.0, accuracy: 0.01)
 
-        XCTAssertEqual(snap.buckets[1].title, "Flash Lite")
+        XCTAssertEqual(snap.buckets[1].title, "Flash Lite 2.5")
         XCTAssertEqual(snap.buckets[1].usedPercent, 5.0, accuracy: 0.01)
 
         // Pro keeps the LOWER fraction (input 30%, not output 85%) → 70% used.
-        XCTAssertEqual(snap.buckets[2].title, "Pro")
+        XCTAssertEqual(snap.buckets[2].title, "Pro 2.5")
         XCTAssertEqual(snap.buckets[2].usedPercent, 70.0, accuracy: 0.01)
         XCTAssertNotNil(snap.buckets[2].resetAt)
     }
@@ -50,7 +52,7 @@ final class GeminiParserTests: XCTestCase {
         """
         let snap = try GeminiResponseParser.parse(data: Data(json.utf8), email: nil, now: now)
         XCTAssertEqual(snap.buckets.count, 1)
-        XCTAssertEqual(snap.buckets[0].title, "Flash")
+        XCTAssertEqual(snap.buckets[0].title, "Flash 2.5")
     }
 
     func testCredentialFileLoadsAccessAndExpiry() throws {

--- a/Tests/VibeBarCoreTests/PrimaryProviderSourcePlannerTests.swift
+++ b/Tests/VibeBarCoreTests/PrimaryProviderSourcePlannerTests.swift
@@ -27,29 +27,27 @@ final class PrimaryProviderSourcePlannerTests: XCTestCase {
     }
 
     // MARK: - Gemini
+    //
+    // Gemini's adapter runs sources in parallel and merges buckets,
+    // so the planner exposes "which sources are enabled" rather than
+    // a fallback chain.
 
-    func testGeminiAutoPrefersOAuthThenWeb() {
-        let plan = GeminiSourcePlanner.resolve(mode: .auto)
-
-        XCTAssertEqual(plan, [.oauthCLI, .webCookie])
+    func testGeminiAutoEnablesBothSources() {
+        XCTAssertEqual(GeminiSourcePlanner.enabledSources(mode: .auto), [.oauthCLI, .webCookie])
+        XCTAssertTrue(GeminiSourcePlanner.runsOAuth(mode: .auto))
+        XCTAssertTrue(GeminiSourcePlanner.runsWeb(mode: .auto))
     }
 
-    func testGeminiWebThenOAuthOrder() {
-        let plan = GeminiSourcePlanner.resolve(mode: .webThenOAuth)
-
-        XCTAssertEqual(plan, [.webCookie, .oauthCLI])
+    func testGeminiOAuthOnlyEnablesOnlyOAuth() {
+        XCTAssertEqual(GeminiSourcePlanner.enabledSources(mode: .oauthOnly), [.oauthCLI])
+        XCTAssertTrue(GeminiSourcePlanner.runsOAuth(mode: .oauthOnly))
+        XCTAssertFalse(GeminiSourcePlanner.runsWeb(mode: .oauthOnly))
     }
 
-    func testGeminiOAuthOnlyDoesNotIncludeWeb() {
-        let plan = GeminiSourcePlanner.resolve(mode: .oauthOnly)
-
-        XCTAssertEqual(plan, [.oauthCLI])
-    }
-
-    func testGeminiWebOnlyDoesNotIncludeOAuth() {
-        let plan = GeminiSourcePlanner.resolve(mode: .webOnly)
-
-        XCTAssertEqual(plan, [.webCookie])
+    func testGeminiWebOnlyEnablesOnlyWeb() {
+        XCTAssertEqual(GeminiSourcePlanner.enabledSources(mode: .webOnly), [.webCookie])
+        XCTAssertFalse(GeminiSourcePlanner.runsOAuth(mode: .webOnly))
+        XCTAssertTrue(GeminiSourcePlanner.runsWeb(mode: .webOnly))
     }
 
     // MARK: - Antigravity


### PR DESCRIPTION
## Summary

- Gemini's `.auto` mode now runs the **Code Assist (OAuth CLI)** and **gemini.google.com (Web cookie)** sources **in parallel** and **merges** their bucket lists onto one dedicated card, instead of treating them as a fallback chain where the first hit short-circuited the other half.
- Bucket `groupTitle` is prefixed with `"CLI · …"` / `"Web · …"` so the two source's data renders as distinct sections under the same Gemini header.
- `prettyModelName` / `shortLabel` now include the Gemini family version (`Flash Lite 2.5`, `Pro 3`), fixing the popover showing two indistinguishable "Flash Lite" rows when different model versions came back from `retrieveUserQuota`.

## Why

Per the design discussion on PR #25: the OAuth (Code Assist) and Web (gemini.google.com/usage) endpoints expose **different** bucket sets — the CLI returns per-model `remainingFraction`, the Web page returns compute-usage windows. They're complementary, not redundant, so the previous "first one wins" fallback was hiding one of them every refresh. The new parallel-merge default surfaces both whenever both are configured.

## Notes

- **Web side is still spike-pending.** `GeminiWebQuotaFetcher.spikeComplete = false` still throws `parseFailure`, so today the visible behaviour is identical to before (only CLI buckets render). The dual-fetch dispatch is fully wired and waiting on the spike — once the wire shape is filled in, the new buckets show up automatically.
- **No cost yet.** Cost numbers aren't available from either Gemini source (Code Assist API and Web page both omit token counts), so the Google AI cards stay quota-only. Two open spike paths to revisit cost later: Antigravity LSP `GetUserStatus` may carry token usage in a field we don't currently parse, and `~/.gemini/antigravity/conversations/` could be a JSONL-shaped session log — both need a real spike on a live Antigravity install.
- **`GeminiUsageMode` enum was simplified** from five to three cases (`.auto` / `.oauthOnly` / `.webOnly`). Legacy persisted raw values (`.oauthThenWeb` / `.webThenOAuth`) decode cleanly back to `.auto` via a `try?` in `AppSettings.init(from:)`.
- **`AccountStore.autoDetectGemini`** registers the account whenever *either* source has credentials; alias reads `"Gemini CLI + Web"` when both are present.
- **`GeminiSourcePlanner.resolve(mode:)` is gone**, replaced by `enabledSources(mode:)` / `runsOAuth(mode:)` / `runsWeb(mode:)` — the planner no longer thinks in fallback-chain terms.

## Test plan

- [x] `swift build` clean.
- [x] `swift test --parallel` — 387 / 387 pass.
- [x] `./Scripts/build_app.sh release` succeeds.
- [x] `codesign -d --entitlements -` prints the empty `[Dict]` (no `app-sandbox` key).
- [x] `codesign --verify --deep --strict` passes.
- [ ] Manual: with `~/.gemini/oauth_creds.json` present and no Gemini cookies imported, Google AI card shows only the CLI buckets (today's behaviour). Once cookies are imported and the spike lands, both sets render as separate sections.
- [ ] Manual: confirm the two Flash Lite rows in the screenshot now read `Flash Lite 2.5` / `Flash Lite 3.0` (or whatever versions the API returns).
- [ ] Manual: legacy `~/.vibebar/settings.json` with `"geminiUsageMode": "webThenOAuth"` loads without errors and the picker shows `Auto (CLI + Web)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)