### PR TITLE
Split Gemini CLI and Web into separate dedicated cards

### DIFF
--- a/Sources/VibeBarApp/Views/PopoverRoot.swift
+++ b/Sources/VibeBarApp/Views/PopoverRoot.swift
@@ -435,21 +435,38 @@ private struct OverviewWaterfall: View {
     }
 }
 
-/// The "Google AI" overview sub-page. Two `ProviderQuotaCard`s side
-/// by side — Gemini on the left, Antigravity on the right — with no
-/// cost / model-ranking / heatmap rails. Per the design decision in
-/// the partial-primary plan, Google AI providers expose quota only
-/// (`supportsTokenCost == false`).
+/// The "Google AI" overview sub-page. Gemini's two sources expose
+/// **structurally different** bucket shapes — Code Assist returns
+/// per-model fractions, gemini.google.com returns aggregate Current /
+/// Weekly — so each source becomes its own card. Antigravity rounds
+/// out the page with its local-LSP probe. All three are quota-only
+/// (`supportsTokenCost == false`); cost data isn't available from any
+/// of these endpoints today.
 private struct GoogleAIDualPage: View {
     let density: Theme.Density
 
+    @EnvironmentObject var environment: AppEnvironment
+
     var body: some View {
+        // Order is deterministic: CLI before Web (Account id
+        // "oauth-gemini" sorts before "web-gemini"); then Antigravity.
+        let geminiAccounts = environment.accountStore
+            .accounts(for: .gemini)
+            .sorted { $0.id < $1.id }
+
         ColumnMasonryLayout(
             columns: 2,
             spacing: density.interSectionSpacing,
-            anchoredItems: 2
+            anchoredItems: max(2, geminiAccounts.count + 1)
         ) {
-            ProviderQuotaCard(tool: .gemini, density: density, compact: false)
+            ForEach(geminiAccounts, id: \.id) { account in
+                ProviderQuotaCard(
+                    tool: .gemini,
+                    accountId: account.id,
+                    density: density,
+                    compact: false
+                )
+            }
             ProviderQuotaCard(tool: .antigravity, density: density, compact: false)
         }
     }
@@ -1055,8 +1072,15 @@ private func groupExtraBuckets(_ buckets: [QuotaBucket]) -> [ExtraGroup] {
 /// Provider quota card. Renders all top-level buckets, then any grouped
 /// (Additional Features) buckets, then live extras (credits / overage) at the
 /// bottom — Extras is no longer its own tab.
+///
+/// When `accountId` is non-nil the card targets that specific account
+/// (used by the Gemini split, where `.gemini` has both an `oauth-gemini`
+/// and a `web-gemini` account). The default — `accountId == nil` — falls
+/// back to "first account for this tool", which is the single-account
+/// behaviour every other provider uses today.
 struct ProviderQuotaCard: View {
     let tool: ToolType
+    var accountId: String?
     let density: Theme.Density
     /// When true, only the headline (no-group) buckets are rendered. Used in
     /// Overview where 3 cards are stacked. Single-provider popovers pass `false`
@@ -1068,8 +1092,18 @@ struct ProviderQuotaCard: View {
     @EnvironmentObject var quotaService: QuotaService
 
     var body: some View {
-        let account = environment.account(for: tool)
-        let quota = environment.quota(for: tool)
+        let account: AccountIdentity? = {
+            if let accountId {
+                return environment.accountStore.accounts.first { $0.id == accountId }
+            }
+            return environment.account(for: tool)
+        }()
+        let quota: AccountQuota? = {
+            if let account, let cached = quotaService.cachedQuota(for: account.id) {
+                return cached
+            }
+            return accountId == nil ? environment.quota(for: tool) : nil
+        }()
         let liveError = displayableError(
             account.flatMap { quotaService.lastErrorByAccount[$0.id] },
             with: quota
@@ -1080,13 +1114,22 @@ struct ProviderQuotaCard: View {
             quotaPlan: quota?.plan,
             accountPlan: account?.plan
         )
+        let cardTitle = (accountId != nil ? account?.alias : nil) ?? tool.menuTitle
+        let cardSubtitle: String = {
+            guard accountId != nil else { return tool.subtitle }
+            switch account?.source {
+            case .oauthCLI: return "Code Assist · per-model"
+            case .webCookie: return "gemini.google.com · current + weekly"
+            default: return tool.subtitle
+            }
+        }()
 
         VStack(alignment: .leading, spacing: density.cardSpacing) {
             HStack(alignment: .center, spacing: 8) {
                 ProviderSectionTitle(
                     tool: tool,
-                    title: tool.menuTitle,
-                    subtitle: tool.subtitle,
+                    title: cardTitle,
+                    subtitle: cardSubtitle,
                     titleFontSize: density.titleFontSize,
                     subtitleFontSize: density.subtitleFontSize,
                     iconSize: 16,

--- a/Sources/VibeBarCore/Adapters/GeminiQuotaAdapter.swift
+++ b/Sources/VibeBarCore/Adapters/GeminiQuotaAdapter.swift
@@ -1,137 +1,56 @@
 import Foundation
 
-/// Google Gemini partial-primary usage adapter.
-///
-/// `.auto` mode runs both sources **in parallel** and merges the
-/// resulting buckets so the user sees CLI and Web data on one card.
-/// `.oauthOnly` / `.webOnly` are explicit single-source escape hatches.
+/// Google Gemini partial-primary usage adapter. Gemini exposes two
+/// sources with structurally **different** bucket shapes, so each
+/// gets its own `AccountIdentity` and renders as a separate card —
+/// this adapter just dispatches by `account.source`, it does not
+/// merge.
 ///
 /// Sources:
-/// - **OAuth CLI** — read `~/.gemini/oauth_creds.json`, reuse
-///   `access_token`, call
-///   `cloudcode-pa.googleapis.com/v1internal:retrieveUserQuota`. This is
-///   the Gemini Code Assist protocol the official CLI uses.
-///   `GeminiTokenRefreshHelper` shells out to `gemini` itself to refresh
-///   expired tokens.
-/// - **Web cookie** — use cookies imported from `gemini.google.com`
-///   (Chrome Safe Storage via SweetCookieKit). Routed through
-///   `GeminiWebQuotaFetcher`; the live endpoint and parser are
-///   spike-pending. While the spike is incomplete this source returns
-///   a parse failure and the dual-fetch merger drops it silently —
-///   the OAuth half still shows up.
+/// - **OAuth CLI** (`account.source == .oauthCLI`, id `oauth-gemini`)
+///   — read `~/.gemini/oauth_creds.json`, reuse `access_token`, call
+///   `cloudcode-pa.googleapis.com/v1internal:retrieveUserQuota`.
+///   Returns per-model `remainingFraction` (Pro / Flash / Flash Lite).
+///   `GeminiTokenRefreshHelper` shells out to `gemini` itself to
+///   refresh expired tokens.
+/// - **Web cookie** (`account.source == .webCookie`, id `web-gemini`)
+///   — use cookies imported from `gemini.google.com` (Chrome Safe
+///   Storage via SweetCookieKit). Routed through
+///   `GeminiWebQuotaFetcher`; the page shows aggregate Current usage
+///   + Weekly limit (the same data `gemini.google.com/usage` displays),
+///   not per-model.
 ///
-/// Output: one `QuotaBucket` per model with
-/// `usedPercent = (1 - remainingFraction) * 100`. In dual-fetch mode
-/// buckets from each source carry a `"CLI · "` / `"Web · "` groupTitle
-/// prefix so the popover renders distinct sections.
+/// Account selection happens in `AccountStore.autoDetectGemini`,
+/// which returns one identity per configured-and-enabled source.
 public struct GeminiQuotaAdapter: QuotaAdapter {
     public let tool: ToolType = .gemini
 
     private let session: URLSession
     private let homeDirectory: String
     private let now: @Sendable () -> Date
-    private let usageModeProvider: @Sendable () -> GeminiUsageMode
 
     public init(
         session: URLSession = .shared,
         homeDirectory: String = RealHomeDirectory.path,
-        now: @escaping @Sendable () -> Date = { Date() },
-        usageMode: (@Sendable () -> GeminiUsageMode)? = nil
+        now: @escaping @Sendable () -> Date = { Date() }
     ) {
         self.session = session
         self.homeDirectory = homeDirectory
         self.now = now
-        // Default to reading the persisted setting on every fetch. The
-        // closure indirection lets tests inject a fixed mode without
-        // touching disk, and keeps the public default expression free
-        // of any internal references (Swift forbids those).
-        self.usageModeProvider = usageMode ?? { Self.resolveUsageMode() }
     }
 
     public func fetch(for account: AccountIdentity) async throws -> AccountQuota {
-        switch usageModeProvider() {
-        case .oauthOnly:
+        switch account.source {
+        case .oauthCLI:
             return try await fetchWithOAuth(for: account)
-        case .webOnly:
+        case .webCookie:
             return try await fetchWithWebCookies(for: account)
-        case .auto:
-            return try await fetchDual(for: account)
+        default:
+            // Shouldn't happen — AccountStore only registers Gemini
+            // accounts with these two sources. Surface a clear error
+            // if it ever does (e.g. a stale persisted source value).
+            throw QuotaError.unknown("Gemini adapter received unsupported source \(account.source)")
         }
-    }
-
-    /// Run OAuth and Web in parallel, merge their buckets. When both
-    /// fail, surface the OAuth error (the Web side currently throws a
-    /// spike-pending parseFailure, which is less informative). When
-    /// either succeeds, the failed half is silently dropped — partial
-    /// data beats a "needs login" placeholder on the dedicated card.
-    private func fetchDual(for account: AccountIdentity) async throws -> AccountQuota {
-        async let oauthResult = tryFetchOAuth(for: account)
-        async let webResult = tryFetchWeb(for: account)
-        let oauth = await oauthResult
-        let web = await webResult
-
-        if oauth.quota == nil && web.quota == nil {
-            throw mapURLError(oauth.error ?? web.error ?? QuotaError.noCredential)
-        }
-
-        var buckets: [QuotaBucket] = []
-        if let q = oauth.quota {
-            buckets.append(contentsOf: q.buckets.map { Self.tagBucket($0, source: .oauthCLI) })
-        }
-        if let q = web.quota {
-            buckets.append(contentsOf: q.buckets.map { Self.tagBucket($0, source: .webCookie) })
-        }
-
-        return AccountQuota(
-            accountId: account.id,
-            tool: .gemini,
-            buckets: buckets,
-            plan: oauth.quota?.plan ?? web.quota?.plan,
-            email: oauth.quota?.email ?? web.quota?.email,
-            queriedAt: now(),
-            error: nil
-        )
-    }
-
-    private func tryFetchOAuth(for account: AccountIdentity) async -> (quota: AccountQuota?, error: QuotaError?) {
-        do {
-            return (try await fetchWithOAuth(for: account), nil)
-        } catch let error as QuotaError {
-            return (nil, error)
-        } catch {
-            return (nil, .unknown(String(describing: error)))
-        }
-    }
-
-    private func tryFetchWeb(for account: AccountIdentity) async -> (quota: AccountQuota?, error: QuotaError?) {
-        do {
-            return (try await fetchWithWebCookies(for: account), nil)
-        } catch let error as QuotaError {
-            return (nil, error)
-        } catch {
-            return (nil, .unknown(String(describing: error)))
-        }
-    }
-
-    /// Prefix a bucket's `id` and `groupTitle` with `"CLI"` / `"Web"`
-    /// so the popover card renders the two source's bucket lists as
-    /// distinct sections (rather than letting them visually overlap
-    /// when `groupTitle` collides — e.g. CLI's "Pro" and Web's "Pro").
-    private static func tagBucket(_ bucket: QuotaBucket, source: CredentialSource) -> QuotaBucket {
-        let prefix: String
-        switch source {
-        case .oauthCLI:  prefix = "CLI"
-        case .webCookie: prefix = "Web"
-        default:         return bucket
-        }
-        var copy = bucket
-        copy.id = "\(prefix.lowercased()).\(bucket.id)"
-        if let group = bucket.groupTitle, !group.isEmpty {
-            copy.groupTitle = "\(prefix) · \(group)"
-        } else {
-            copy.groupTitle = prefix
-        }
-        return copy
     }
 
     private func fetchWithOAuth(for account: AccountIdentity) async throws -> AccountQuota {
@@ -230,18 +149,6 @@ public struct GeminiQuotaAdapter: QuotaAdapter {
         )
     }
 
-    /// Reads the persisted `geminiUsageMode` setting from disk.
-    /// Matches how the Codex / Claude adapters resolve their modes
-    /// without threading `AppSettings` through every call site.
-    /// Internal (not `private`) so the public init's default argument
-    /// can reference it.
-    static func resolveUsageMode() -> GeminiUsageMode {
-        let appSettings = (try? VibeBarLocalStore.readJSON(
-            AppSettings.self,
-            from: VibeBarLocalStore.settingsURL
-        )) ?? .default
-        return appSettings.geminiUsageMode
-    }
 }
 
 // MARK: - Endpoints

--- a/Sources/VibeBarCore/Adapters/GeminiWebAdapter.swift
+++ b/Sources/VibeBarCore/Adapters/GeminiWebAdapter.swift
@@ -3,18 +3,43 @@ import Foundation
 /// Fetches Gemini usage data from the signed-in `gemini.google.com`
 /// web session via imported browser cookies.
 ///
-/// **Spike-pending**: the exact endpoint, request body, anti-hijacking
-/// envelope, and required `Authorization: SAPISIDHASH` header are not
-/// covered by public Google documentation. The placeholder
-/// implementation here intentionally fails fast with `.needsLogin`
-/// when the cookie store is empty (so the UI shows "Import cookies"),
-/// and otherwise throws `.parseFailure` with a developer-facing hint
-/// to flip `GeminiWebQuotaFetcher.spikeComplete` and fill in the
-/// real request once the spike (see plan §9) is done. This keeps the
-/// dedicated-card UI shippable today without forging protocol details.
+/// **Spike-pending — endpoint not yet identified.**
+///
+/// Investigation summary (2026-05-22, against a live PRO account):
+/// - Loading `/usage?pli=1` triggers **eight** `batchexecute` POST
+///   requests with rpcids `MaZiqc`, `L5adhe`, `Bsxleb`, `GPRiHf`,
+///   `maGuAc`, `Te6DCf`, `CNgdBe`, plus a repeat `MaZiqc`. **None**
+///   of them returned the per-usage quota numbers — they cover
+///   chats list, bootstrap flags, feature flags, an upgrade promo
+///   banner, and the Gems library. So `gemini.google.com/usage`
+///   does NOT lay its quota data through batchexecute.
+/// - The SSR HTML response (≈ 690 KB) contains no `"% used"`
+///   literal, no `AF_initDataCallback` chunk with quota fields, and
+///   no quota numbers in `WIZ_global_data` either.
+/// - The two visible buckets ("Current usage" + "Weekly limit",
+///   percentage + reset timestamps) are rendered by the
+///   `<usage-metrics-window>` Angular component into
+///   `.gxu-currently-luminous` / `.gxu-items-container` divs. The
+///   data source has to be either a non-batchexecute endpoint or
+///   an inlined-but-encoded blob that the spike has not yet
+///   recovered.
+///
+/// Until the real endpoint is identified, this fetcher throws a
+/// `.parseFailure` with a clear maintenance hint. The dedicated
+/// "Gemini Web" card stays visible (so the cookie import + delete
+/// flow is exercisable) but shows the error message until the
+/// spike lands and `spikeComplete` flips.
+///
+/// XSRF: replays observed `at=AOOh0P...` tokens 400 with `xsrf`
+/// errors that *include* the right token in the response — the
+/// server hands back a usable XSRF on every error, so the future
+/// fetch path can probe `L5adhe` once, grab the token from the
+/// error envelope, and retry. The anti-hijacking prefix `)]}'\n`
+/// is consistent across all responses observed.
 struct GeminiWebQuotaFetcher: Sendable {
-    /// Flip to `true` once `gemini.google.com/usage` reverse-engineering
-    /// is complete and the wire shape is locked in.
+    /// Flip to `true` once `gemini.google.com/usage`
+    /// reverse-engineering identifies the real quota endpoint and
+    /// `GeminiWebResponseParser.parse(_:)` can decode it.
     static let spikeComplete = false
 
     private let session: URLSession
@@ -33,19 +58,18 @@ struct GeminiWebQuotaFetcher: Sendable {
             throw QuotaError.noCredential
         }
         guard Self.spikeComplete else {
-            // Surface a clear maintenance-time hint instead of a
-            // generic network error. The dedicated card will fall
-            // through to the OAuth source when the planner allows.
             throw QuotaError.parseFailure(
-                "Gemini Web source is awaiting the gemini.google.com/usage spike. See plan §9."
+                "Gemini Web spike incomplete: gemini.google.com/usage quota endpoint not yet identified. See GeminiWebAdapter.swift header for the 2026-05-22 investigation summary."
             )
         }
         // Spike-completed implementation lives here. Expected shape:
-        //   1. Build URLRequest against the confirmed endpoint
-        //      (likely under gemini.google.com/_/...).
+        //   1. Build URLRequest against the confirmed endpoint.
         //   2. Apply minimum cookie header + SAPISIDHASH if required.
-        //   3. Strip `)]}'\n` anti-hijacking prefix from the response.
-        //   4. Delegate JSON parsing to GeminiWebResponseParser.parse(_:).
+        //   3. Strip `)]}'\n` anti-hijacking prefix from the response
+        //      (helper already in GeminiWebResponseParser).
+        //   4. Delegate JSON parsing to GeminiWebResponseParser.parse(_:)
+        //      — expected to emit exactly two buckets, "current" and
+        //      "weekly", matching the page UI 1:1.
         throw QuotaError.parseFailure("Gemini Web fetch not implemented yet.")
     }
 }

--- a/Sources/VibeBarCore/Adapters/GeminiWebResponseParser.swift
+++ b/Sources/VibeBarCore/Adapters/GeminiWebResponseParser.swift
@@ -1,14 +1,28 @@
 import Foundation
 
 /// Parses the JSON envelope returned by Gemini's signed-in web usage
-/// endpoint into the shared `GeminiResponseParser.Snapshot` shape so the
-/// `GeminiQuotaAdapter` produces an identical `AccountQuota` regardless
-/// of which credential source won.
+/// endpoint into the shared `GeminiResponseParser.Snapshot` shape.
 ///
-/// **Spike-pending**: the exact field names and per-model layout are
-/// not covered by public Google documentation. Treat this file as the
-/// home for the wire-shape decoder once the spike is complete.
+/// **Spike-pending — wire shape not yet captured.**
+///
+/// What the live page renders (confirmed by direct DOM inspection
+/// of a PRO account, 2026-05-22):
+/// - One "Current usage" bar — a single percentage + a "Resets at HH:MM AM/PM" line.
+/// - One "Weekly limit" bar — same shape, "Resets <Date> at HH:MM AM/PM".
+/// - A plan badge in the page header — "PRO" / "FREE" / etc.
+/// So whenever the spike yields a real response, this parser is
+/// expected to emit exactly two `QuotaBucket`s (ids `gemini.web.current`
+/// and `gemini.web.weekly`), plus the plan name on `Snapshot.planName`.
+///
+/// `stripAntiHijackingPrefix` is ready to use — every observed
+/// `gemini.google.com` response starts with `)]}'\n` followed by a
+/// length-prefixed chunked JSON stream. See the file-level docs on
+/// `GeminiWebQuotaFetcher` for the investigation notes.
 enum GeminiWebResponseParser {
+    /// Bucket ids the parser will emit once the spike is complete.
+    static let currentUsageBucketId = "gemini.web.current"
+    static let weeklyUsageBucketId  = "gemini.web.weekly"
+
     /// Strip Google's anti-hijacking prefix `)]}'` (with or without a
     /// trailing newline) that fronts most internal JSON RPCs.
     static func stripAntiHijackingPrefix(_ data: Data) -> Data {
@@ -35,18 +49,9 @@ enum GeminiWebResponseParser {
         guard !stripped.isEmpty else {
             throw QuotaError.parseFailure("Gemini Web response was empty after stripping anti-hijacking prefix.")
         }
-        // Spike-completed shape decoding goes here. Expect either:
-        //   * per-model buckets (Pro / Flash / Flash-Lite / Deep
-        //     Research / Veo), each with `usedPercent` + `resetTime`;
-        //   * or a single aggregate "compute usage" percentage — emit
-        //     one bucket with id `gemini.web.compute` and no
-        //     `groupTitle` in that case.
-        // For now, signal a clear parse failure so the adapter falls
-        // through to the OAuth source and the UI shows a maintenance
-        // hint rather than a misleading "everything is fine" card.
         _ = stripped
         throw QuotaError.parseFailure(
-            "Gemini Web response parser not implemented yet (awaiting spike, see plan §9)."
+            "Gemini Web response parser not implemented yet — expected two buckets (current + weekly) once the spike completes. See GeminiWebAdapter.swift for investigation notes."
         )
     }
 }

--- a/Sources/VibeBarCore/Storage/AccountStore.swift
+++ b/Sources/VibeBarCore/Storage/AccountStore.swift
@@ -49,9 +49,7 @@ public final class AccountStore: ObservableObject {
         if let claude = autoDetectClaude(mode: claudeUsageMode) {
             detected.append(claude)
         }
-        if let gemini = autoDetectGemini(mode: geminiUsageMode) {
-            detected.append(gemini)
-        }
+        detected.append(contentsOf: autoDetectGemini(mode: geminiUsageMode))
         if let antigravity = autoDetectAntigravity(mode: antigravityUsageMode) {
             detected.append(antigravity)
         }
@@ -191,49 +189,53 @@ public final class AccountStore: ObservableObject {
         )
     }
 
-    /// Gemini in `.auto` mode runs both sources in parallel and merges
-    /// their buckets — so the account is registered if *either* source
-    /// has credentials. The `source` field reflects the dominant route
-    /// (OAuth wins when present because it carries email + plan info).
-    /// `.oauthOnly` / `.webOnly` register the account only when that
-    /// one source is configured.
-    private func autoDetectGemini(mode: GeminiUsageMode) -> AccountIdentity? {
+    /// Gemini exposes two sources with structurally different bucket
+    /// shapes — CLI returns per-model `remainingFraction`, Web returns
+    /// the aggregate `Current usage` + `Weekly limit` pair shown on
+    /// `gemini.google.com/usage`. They render as **two separate
+    /// cards** on the Google AI page, so this helper returns one
+    /// `AccountIdentity` per enabled-and-configured source.
+    ///
+    /// `.auto` registers either or both depending on which credentials
+    /// are present. `.oauthOnly` / `.webOnly` register at most one.
+    /// Stable account ids let `QuotaCacheStore` keep snapshots across
+    /// restarts.
+    private func autoDetectGemini(mode: GeminiUsageMode) -> [AccountIdentity] {
         let enabled = GeminiSourcePlanner.enabledSources(mode: mode)
         let homeDir = RealHomeDirectory.path
         let geminiOAuthPath = URL(fileURLWithPath: homeDir)
             .appendingPathComponent(".gemini/oauth_creds.json").path
         let hasOAuth = enabled.contains(.oauthCLI) && FileManager.default.fileExists(atPath: geminiOAuthPath)
         let hasWeb = enabled.contains(.webCookie) && GeminiWebCookieStore.hasCookieHeader()
-        guard hasOAuth || hasWeb else { return nil }
 
-        // Dominant source: OAuth (richer metadata) > Web. The
-        // `source` field is mostly informational on the card — the
-        // adapter still decides which paths to actually fetch.
-        let primarySource: CredentialSource = hasOAuth ? .oauthCLI : .webCookie
-        let id: String
-        let alias: String
-        switch mode {
-        case .auto:
-            id = hasOAuth && hasWeb ? "dual-gemini" : (hasOAuth ? "oauth-gemini" : "web-gemini")
-            alias = hasOAuth && hasWeb ? "Gemini CLI + Web" : (hasOAuth ? "Gemini CLI" : "Gemini Web")
-        case .oauthOnly:
-            id = "oauth-gemini"
-            alias = "Gemini CLI"
-        case .webOnly:
-            id = "web-gemini"
-            alias = "Gemini Web"
+        var out: [AccountIdentity] = []
+        if hasOAuth {
+            out.append(AccountIdentity(
+                id: "oauth-gemini",
+                tool: .gemini,
+                alias: "Gemini CLI",
+                source: .oauthCLI,
+                allowsWebFallback: false,
+                allowsCLIFallback: false,
+                allowsOAuthFallback: false,
+                createdAt: Date(),
+                updatedAt: Date()
+            ))
         }
-        return AccountIdentity(
-            id: id,
-            tool: .gemini,
-            alias: alias,
-            source: primarySource,
-            allowsWebFallback: mode == .auto && hasWeb && !hasOAuth ? false : (mode != .oauthOnly && hasWeb),
-            allowsCLIFallback: false,
-            allowsOAuthFallback: mode != .webOnly && hasOAuth,
-            createdAt: Date(),
-            updatedAt: Date()
-        )
+        if hasWeb {
+            out.append(AccountIdentity(
+                id: "web-gemini",
+                tool: .gemini,
+                alias: "Gemini Web",
+                source: .webCookie,
+                allowsWebFallback: false,
+                allowsCLIFallback: false,
+                allowsOAuthFallback: false,
+                createdAt: Date(),
+                updatedAt: Date()
+            ))
+        }
+        return out
     }
 
     /// Antigravity always registers a placeholder identity so its

--- a/Tests/VibeBarCoreTests/GeminiDualFetchTests.swift
+++ b/Tests/VibeBarCoreTests/GeminiDualFetchTests.swift
@@ -1,25 +1,19 @@
 import XCTest
 @testable import VibeBarCore
 
-/// Smoke tests for the dual-fetch dispatch in `GeminiQuotaAdapter`.
-/// The adapter's helpers are private, so these tests focus on the
-/// observable behaviour: which sources get attempted for each mode,
-/// and how failures from both halves are surfaced.
-///
-/// The Web parser is currently spike-pending and always throws
-/// `parseFailure`; in `.auto` mode that side is silently dropped when
-/// OAuth succeeds, and is the dominant error only when OAuth also
-/// fails.
+/// Smoke tests for `GeminiQuotaAdapter`'s account-source dispatch.
+/// After the split-cards refactor each Gemini source has its own
+/// `AccountIdentity`, and the adapter routes by `account.source` —
+/// no fallback chain, no bucket merging.
 final class GeminiDualFetchTests: XCTestCase {
-    private func makeEmptyHomeAdapter(mode: GeminiUsageMode) throws -> (GeminiQuotaAdapter, URL) {
+    private func makeEmptyHomeAdapter() throws -> (GeminiQuotaAdapter, URL) {
         let temp = FileManager.default.temporaryDirectory
             .appendingPathComponent("vibebar-gemini-tests-\(UUID().uuidString)")
         try FileManager.default.createDirectory(at: temp, withIntermediateDirectories: true)
         let adapter = GeminiQuotaAdapter(
             session: .shared,
             homeDirectory: temp.path,
-            now: { Date() },
-            usageMode: { mode }
+            now: { Date() }
         )
         return (adapter, temp)
     }
@@ -28,23 +22,23 @@ final class GeminiDualFetchTests: XCTestCase {
         try? FileManager.default.removeItem(at: url)
     }
 
-    private var fixtureAccount: AccountIdentity {
+    private func account(source: CredentialSource) -> AccountIdentity {
         AccountIdentity(
-            id: "test-gemini",
+            id: source == .oauthCLI ? "oauth-gemini" : "web-gemini",
             tool: .gemini,
-            alias: "Gemini Test",
-            source: .oauthCLI,
+            alias: source == .oauthCLI ? "Gemini CLI" : "Gemini Web",
+            source: source,
             createdAt: Date(),
             updatedAt: Date()
         )
     }
 
-    func testOAuthOnlyModeThrowsNoCredentialWhenCredsMissing() async throws {
-        let (adapter, temp) = try makeEmptyHomeAdapter(mode: .oauthOnly)
+    func testOAuthAccountThrowsNoCredentialWhenCredsMissing() async throws {
+        let (adapter, temp) = try makeEmptyHomeAdapter()
         defer { cleanup(temp) }
 
         do {
-            _ = try await adapter.fetch(for: fixtureAccount)
+            _ = try await adapter.fetch(for: account(source: .oauthCLI))
             XCTFail("Expected throw with no oauth_creds.json present")
         } catch QuotaError.noCredential {
             // Pass
@@ -53,48 +47,48 @@ final class GeminiDualFetchTests: XCTestCase {
         }
     }
 
-    func testAutoModeThrowsWhenBothSourcesUnconfigured() async throws {
-        // With no `~/.gemini/oauth_creds.json` and no imported cookies,
-        // the adapter should surface an error rather than returning an
-        // empty bucket list. The Web side always parseFailures while
-        // the spike is incomplete, so the merged error is OAuth's
-        // .noCredential (the more diagnostic of the two).
-        let (adapter, temp) = try makeEmptyHomeAdapter(mode: .auto)
+    func testWebAccountSurfacesSpikePendingError() async throws {
+        // The Web fetcher is spike-pending and always throws either
+        // .noCredential (no cookies imported) or .parseFailure
+        // (cookies present, but the wire shape isn't decoded yet).
+        // The adapter must propagate whichever happens — never crash.
+        let (adapter, temp) = try makeEmptyHomeAdapter()
         defer { cleanup(temp) }
 
         do {
-            _ = try await adapter.fetch(for: fixtureAccount)
-            XCTFail("Expected throw with no sources configured")
-        } catch QuotaError.noCredential {
-            // Pass — OAuth's noCredential dominates the merger.
-        } catch QuotaError.parseFailure {
-            // Acceptable fallback if the local keychain still has
-            // imported cookies from a previous session: the Web
-            // side then surfaces its spike-pending parseFailure.
-        } catch QuotaError.network {
-            // Acceptable if the spike Web fetcher made a real call.
+            _ = try await adapter.fetch(for: account(source: .webCookie))
+            // If this ever succeeds, the spike has landed —
+            // tighten the assertion in a follow-up PR to verify the
+            // expected current/weekly bucket pair.
+        } catch is QuotaError {
+            // Pass — any QuotaError variant is acceptable here.
         } catch {
-            XCTFail("Unexpected error: \(error)")
+            XCTFail("Expected a QuotaError, got \(error)")
         }
     }
 
-    func testWebOnlyModeSurfacesSpikePendingError() async throws {
-        // `.webOnly` always exercises the Web path. With the spike
-        // incomplete the fetcher returns `parseFailure` (or
-        // `noCredential` if no cookies are imported). Either is
-        // acceptable here — the test guarantees no crash and a
-        // QuotaError reaching the caller.
-        let (adapter, temp) = try makeEmptyHomeAdapter(mode: .webOnly)
+    func testUnsupportedSourceThrowsUnknown() async throws {
+        let (adapter, temp) = try makeEmptyHomeAdapter()
         defer { cleanup(temp) }
 
+        // A Gemini account that somehow got registered with the wrong
+        // source (e.g. a stale persisted snapshot) must surface a
+        // clear error instead of silently doing nothing.
+        let oddAccount = AccountIdentity(
+            id: "stale-gemini",
+            tool: .gemini,
+            alias: "Stale",
+            source: .cliDetected,
+            createdAt: Date(),
+            updatedAt: Date()
+        )
         do {
-            _ = try await adapter.fetch(for: fixtureAccount)
-            // If this ever succeeds it means the spike landed —
-            // tighten the assertion to verify bucket shape.
-        } catch is QuotaError {
-            // Pass — any QuotaError is fine for this smoke test.
+            _ = try await adapter.fetch(for: oddAccount)
+            XCTFail("Expected throw for unsupported source")
+        } catch QuotaError.unknown {
+            // Pass
         } catch {
-            XCTFail("Expected a QuotaError, got \(error)")
+            XCTFail("Expected .unknown, got \(error)")
         }
     }
 }


### PR DESCRIPTION
## Summary

Gemini's two sources expose structurally different bucket shapes, so they now render as **two separate dedicated cards** instead of being merged onto one:

- **Gemini CLI** card — per-model `remainingFraction` (Pro / Flash / Flash Lite, with version suffix), pulled from `cloudcode-pa.googleapis.com/v1internal:retrieveUserQuota`.
- **Gemini Web** card — aggregate "Current usage" + "Weekly limit", pulled from `gemini.google.com` (spike-pending — see below).

The Google AI overview tab now lays out 1-3 cards (CLI ∪ Web ∪ Antigravity) using the existing masonry layout.

## Why

PR [#26](https://github.com/AstroQore/vibe-bar/pull/26) wired both sources to fetch in parallel and merge into a single card. Inspecting `gemini.google.com/usage` directly (see spike notes below) made it clear the two sources show genuinely different things — CLI is developer per-model usage; Web is the user-facing "how much of my Pro subscription have I burned this rolling window / this week" view. Merging the two felt like jamming two unrelated dashboards onto one panel.

## What changed

- **`AccountStore.autoDetectGemini` → `[AccountIdentity]`**. Each enabled-and-configured source gets its own identity (`oauth-gemini` with `source: .oauthCLI`, `web-gemini` with `source: .webCookie`). `.auto` may register zero, one, or both depending on credentials. `QuotaCacheStore` snapshots survive restarts via the stable ids.
- **`GeminiQuotaAdapter.fetch` dispatches by `account.source`** — no `usageMode` lookup, no fallback chain, no bucket merging. The dual-fetch helpers (`fetchDual` / `tryFetchOAuth` / `tryFetchWeb` / `tagBucket`) and the static `resolveUsageMode` are removed.
- **`ProviderQuotaCard` gains optional `accountId`**. When set the card pins to a specific account (used by the Gemini split); when `nil` it keeps the existing "first account for this tool" behaviour every other provider uses. The card pulls its title from `account.alias` and a source-specific subtitle (`Code Assist · per-model` / `gemini.google.com · current + weekly`).
- **`GoogleAIDualPage`** iterates `accountStore.accounts(for: .gemini)` with deterministic ordering (`oauth-gemini` before `web-gemini`) and renders one `ProviderQuotaCard` per identity, followed by Antigravity.

## Spike status — Gemini Web wire shape

Investigation against a live signed-in PRO account on 2026-05-22:

- Eight `batchexecute` rpcids fire on `/usage?pli=1`: `L5adhe`, `MaZiqc`, `Bsxleb`, `GPRiHf`, `maGuAc`, `Te6DCf`, `CNgdBe`, and a repeat `MaZiqc`. All eight were replayed manually with a valid XSRF token; **none** returned the visible quota numbers. They cover bootstrap flags, chats list, feature flags, an upgrade promo banner, and the Gems library.
- The SSR HTML response (~690 KB) does not include the literal `"% used"` string, no `AF_initDataCallback` chunk with quota fields, and `WIZ_global_data` has no quota keys either.
- DOM inspection of the rendered page confirms the structure: one "Current usage" bar + one "Weekly limit" bar + a plan-badge in the page header (PRO / FREE / etc). The `<usage-metrics-window>` Angular component is doing the rendering; the underlying data source isn't yet pinned down.

`GeminiWebQuotaFetcher.spikeComplete` stays `false`. The dedicated Web card appears as soon as cookies are imported, but for now displays the spike-pending parse-failure message in the card body. When the endpoint is found, only the fetcher + `GeminiWebResponseParser.parse(_:)` need updating; the rest of the architecture is ready (bucket-id constants for `gemini.web.current` / `gemini.web.weekly` are already reserved). The investigation findings are baked into the `GeminiWebAdapter.swift` and `GeminiWebResponseParser.swift` header comments.

## Test plan

- [x] `swift build` clean.
- [x] `swift test` — 387 / 387 pass.
- [x] `./Scripts/build_app.sh release` succeeds.
- [x] `codesign -d --entitlements -` prints empty `[Dict]` (no `app-sandbox` key).
- [x] `codesign --verify --deep --strict` passes.
- [ ] Manual: with only `~/.gemini/oauth_creds.json` present, Google AI tab shows 2 cards (Gemini CLI + Antigravity). With only Gemini Web cookies imported, 2 cards (Gemini Web + Antigravity). With both, 3 cards (CLI + Web + Antigravity).
- [ ] Manual: clicking "Refresh" on either Gemini card refreshes both accounts (current implementation: `environment.refresh(.gemini)` reloads all `.gemini` accounts together); the spinner only shows on the card whose account is mid-fetch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)