### PR TITLE
Add grok.com cookie fallback for users without grok login

### DIFF
--- a/Sources/VibeBarApp/AppEnvironment.swift
+++ b/Sources/VibeBarApp/AppEnvironment.swift
@@ -14,12 +14,15 @@ final class AppEnvironment: ObservableObject {
     @Published private(set) var hasClaudeWebCookies: Bool
     @Published private(set) var hasOpenAIWebCookies: Bool
     @Published private(set) var hasGeminiWebCookies: Bool
+    @Published private(set) var hasGrokWebCookies: Bool
     @Published private(set) var isImportingOpenAIBrowserCookies = false
     @Published private(set) var isImportingClaudeBrowserCookies = false
     @Published private(set) var isImportingGeminiBrowserCookies = false
+    @Published private(set) var isImportingGrokBrowserCookies = false
     @Published private(set) var openAIBrowserCookieImportStatus: String?
     @Published private(set) var claudeBrowserCookieImportStatus: String?
     @Published private(set) var geminiBrowserCookieImportStatus: String?
+    @Published private(set) var grokBrowserCookieImportStatus: String?
     @Published private(set) var routeHealth: [PrimaryProviderRoute: PrimaryProviderRouteHealth]
 
     private let openAIWebLoginController = OpenAIWebLoginController()
@@ -34,6 +37,7 @@ final class AppEnvironment: ObservableObject {
     private var persistentOpenAICookieImportInFlight = false
     private var browserOpenAICookieImportInFlight = false
     private var browserGeminiCookieImportInFlight = false
+    private var browserGrokCookieImportInFlight = false
 
     init() {
         let settings = SettingsStore()
@@ -61,6 +65,7 @@ final class AppEnvironment: ObservableObject {
         self.hasClaudeWebCookies = ClaudeWebCookieStore.hasCookieHeader()
         self.hasOpenAIWebCookies = OpenAIWebCookieStore.hasCookieHeader()
         self.hasGeminiWebCookies = GeminiWebCookieStore.hasCookieHeader()
+        self.hasGrokWebCookies = GrokWebCookieStore.hasCookieHeader()
         self.routeHealth = PrimaryProviderRouteHealthChecker.checkAll()
 
         let scheduler = QuotaRefreshScheduler(
@@ -342,6 +347,60 @@ final class AppEnvironment: ObservableObject {
         )
     }
 
+    func importGrokBrowserCookies() {
+        importGrokBrowserCookiesAndRefreshIfNeeded(
+            allowKeychainPrompt: true,
+            userInitiated: true
+        )
+    }
+
+    private func importGrokBrowserCookiesAndRefreshIfNeeded(
+        allowKeychainPrompt: Bool = false,
+        userInitiated: Bool = false
+    ) {
+        if !allowKeychainPrompt, GrokWebCookieStore.hasCookieHeader() {
+            return
+        }
+        guard !browserGrokCookieImportInFlight else { return }
+        browserGrokCookieImportInFlight = true
+        if userInitiated {
+            isImportingGrokBrowserCookies = true
+            grokBrowserCookieImportStatus = "Importing from browser..."
+        }
+
+        let importTask = Task.detached(priority: userInitiated ? .userInitiated : .utility) {
+            try? GrokBrowserCookieImporter.importAndStoreFromBrowsers(
+                allowKeychainPrompt: allowKeychainPrompt
+            )
+        }
+        Task { @MainActor [weak self] in
+            let result = await importTask.value
+            guard let self else { return }
+            self.browserGrokCookieImportInFlight = false
+            if userInitiated {
+                self.isImportingGrokBrowserCookies = false
+            }
+            self.hasGrokWebCookies = GrokWebCookieStore.hasCookieHeader()
+            guard let result else {
+                if userInitiated {
+                    self.grokBrowserCookieImportStatus = "No Grok cookies found in readable browser stores."
+                }
+                return
+            }
+            if userInitiated {
+                self.grokBrowserCookieImportStatus = "Imported from \(result.sourceLabel)."
+            }
+            self.accountStore.reload(
+                codexUsageMode: self.settingsStore.settings.codexUsageMode,
+                claudeUsageMode: self.settingsStore.claudeUsageMode,
+                geminiUsageMode: self.settingsStore.geminiUsageMode,
+                antigravityUsageMode: self.settingsStore.antigravityUsageMode,
+                miscProviderInstances: self.settingsStore.settings.miscProviderInstances
+            )
+            self.scheduler.triggerRefresh()
+        }
+    }
+
     private func importGeminiBrowserCookiesAndRefreshIfNeeded(
         allowKeychainPrompt: Bool = false,
         userInitiated: Bool = false
@@ -604,6 +663,31 @@ final class AppEnvironment: ObservableObject {
         } catch {
             SafeLog.warn("Deleting Gemini web cookies failed: \(SafeLog.sanitize(error.localizedDescription))")
             hasGeminiWebCookies = GeminiWebCookieStore.hasCookieHeader()
+            return false
+        }
+    }
+
+    @discardableResult
+    func deleteGrokWebCookies() -> Bool {
+        do {
+            try GrokWebCookieStore.deleteCookieHeader()
+            grokBrowserCookieImportStatus = nil
+            hasGrokWebCookies = false
+            for account in accountStore.accounts(for: .grok) {
+                quotaService.clear(accountId: account.id)
+            }
+            accountStore.reload(
+                codexUsageMode: settingsStore.settings.codexUsageMode,
+                claudeUsageMode: settingsStore.claudeUsageMode,
+                geminiUsageMode: settingsStore.geminiUsageMode,
+                antigravityUsageMode: settingsStore.antigravityUsageMode,
+                miscProviderInstances: settingsStore.settings.miscProviderInstances
+            )
+            scheduler.triggerRefresh()
+            return true
+        } catch {
+            SafeLog.warn("Deleting Grok web cookies failed: \(SafeLog.sanitize(error.localizedDescription))")
+            hasGrokWebCookies = GrokWebCookieStore.hasCookieHeader()
             return false
         }
     }

--- a/Sources/VibeBarApp/Views/SettingsView.swift
+++ b/Sources/VibeBarApp/Views/SettingsView.swift
@@ -12,6 +12,7 @@ struct SettingsView: View {
     @State private var openAICookieDeleteFailed: Bool = false
     @State private var claudeCookieDeleteFailed: Bool = false
     @State private var geminiCookieDeleteFailed: Bool = false
+    @State private var grokCookieDeleteFailed: Bool = false
     @State private var costDataClearStatus: String?
     @State private var launchAtLoginStatusText: String = LoginItemController.statusText
     @State private var launchAtLoginError: String?
@@ -269,19 +270,49 @@ struct SettingsView: View {
                     }
 
                     settingsSection("Grok Account") {
-                        Text("Vibe Bar reads ~/.grok/auth.json and queries grok.com for the monthly credit usage. Run `grok login` once in a terminal to sign in.")
+                        Text("Vibe Bar can read Grok usage from `~/.grok/auth.json` (preferred — written by `grok login`) or from a signed-in grok.com browser session. Either source is enough.")
                             .font(.caption)
                             .foregroundStyle(.secondary)
+
                         if GrokCredentialsStore.hasCredentials() {
                             Label("~/.grok/auth.json detected", systemImage: "checkmark.circle")
                                 .font(.caption2)
                                 .foregroundStyle(.green)
                         } else {
-                            Label("No ~/.grok/auth.json yet — run `grok login` to authenticate.",
+                            Label("No ~/.grok/auth.json yet — run `grok login` to authenticate, or import cookies below.",
                                   systemImage: "exclamationmark.circle")
                                 .font(.caption2)
                                 .foregroundStyle(.secondary)
                         }
+
+                        HStack {
+                            Button {
+                                environment.importGrokBrowserCookies()
+                            } label: {
+                                Label("Import Grok cookies from browser", systemImage: "safari")
+                            }
+                            .disabled(environment.isImportingGrokBrowserCookies)
+                            Button(role: .destructive) {
+                                grokCookieDeleteFailed = !environment.deleteGrokWebCookies()
+                            } label: {
+                                Label("Delete Grok cookies", systemImage: "trash")
+                            }
+                            .disabled(!environment.hasGrokWebCookies)
+                        }
+                        if environment.hasGrokWebCookies {
+                            Text("Grok cookies saved.")
+                                .font(.caption2).foregroundStyle(.green)
+                        }
+                        if let status = environment.grokBrowserCookieImportStatus {
+                            Text(status)
+                                .font(.caption2)
+                                .foregroundStyle(status.hasPrefix("Imported") ? .green : .secondary)
+                        }
+                        if grokCookieDeleteFailed {
+                            Text("Could not delete saved Grok cookies.")
+                                .font(.caption2).foregroundStyle(.orange)
+                        }
+
                         Link("Open grok.com usage dashboard",
                              destination: ToolType.grok.statusPageURL)
                             .font(.caption2)

--- a/Sources/VibeBarCore/Adapters/GrokQuotaAdapter.swift
+++ b/Sources/VibeBarCore/Adapters/GrokQuotaAdapter.swift
@@ -2,19 +2,21 @@ import Foundation
 
 /// xAI Grok partial-primary usage adapter.
 ///
-/// Reads `~/.grok/auth.json` (written by `grok login`) and posts an
-/// empty gRPC-web frame to
-/// `https://grok.com/grok_api_v2.GrokBuildBilling/GetGrokCreditsConfig`
-/// using the bearer token from that file. The response is a tiny
-/// protobuf payload carrying the monthly used-percent and the next
-/// reset timestamp; both fields surface as a single
-/// `QuotaBucket(id: "monthly", ...)` on the card.
+/// Hits `https://grok.com/grok_api_v2.GrokBuildBilling/GetGrokCreditsConfig`
+/// with one of two credentials:
 ///
-/// The cookie-based fallback that Codex Bar maintains is intentionally
-/// deferred — `grok login` is the documented entry point for
-/// SuperGrok subscribers, and the cookie path adds a sizeable
-/// SweetCookieKit + browser-import surface that doesn't pay off until
-/// users without `grok login` show up.
+/// 1. **`~/.grok/auth.json` bearer** (preferred). Written by
+///    `grok login`. Carries the SuperGrok email and plan label so the
+///    card chrome is rich.
+/// 2. **grok.com browser cookies** (fallback). Imported via
+///    `GrokBrowserCookieImporter` from Chrome / Safari / etc., stored
+///    minimised in Keychain by `GrokWebCookieStore`. Used when the
+///    user signed in to grok.com on the web but never ran
+///    `grok login` — the case that Codex Bar already handles.
+///
+/// The response is a tiny protobuf payload carrying the monthly
+/// used-percent and the next reset timestamp; both fields surface as
+/// a single `QuotaBucket(id: "monthly", ...)` on the card.
 public struct GrokQuotaAdapter: QuotaAdapter {
     public let tool: ToolType = .grok
 
@@ -33,25 +35,69 @@ public struct GrokQuotaAdapter: QuotaAdapter {
     }
 
     public func fetch(for account: AccountIdentity) async throws -> AccountQuota {
-        let credentials: GrokCredentials
-        do {
-            credentials = try GrokCredentialsStore.load(homeDirectory: homeDirectory)
-        } catch let error as QuotaError {
-            throw error
-        } catch {
-            throw QuotaError.parseFailure("Could not load ~/.grok/auth.json: \(error.localizedDescription)")
+        let credentials = (try? GrokCredentialsStore.load(homeDirectory: homeDirectory)).flatMap { creds in
+            creds.isExpired ? nil : creds
         }
 
-        if credentials.isExpired {
-            throw QuotaError.needsLogin
+        if let credentials {
+            return try await fetchWithBearer(credentials: credentials, account: account)
         }
 
+        if let header = try? GrokWebCookieStore.readCookieHeader() {
+            return try await fetchWithCookies(header: header, account: account)
+        }
+
+        // Neither source available. Prefer the auth.json error message
+        // because it's actionable (`grok login` is the canonical
+        // documented path) and tells the user exactly what to do.
+        throw QuotaError.noCredential
+    }
+
+    private func fetchWithBearer(
+        credentials: GrokCredentials,
+        account: AccountIdentity
+    ) async throws -> AccountQuota {
         let snapshot = try await GrokWebBillingFetcher.fetch(
             credentials: credentials,
             session: session,
             now: now
         )
+        return makeQuota(
+            snapshot: snapshot,
+            account: account,
+            plan: credentials.planLabel,
+            email: credentials.email
+        )
+    }
 
+    private func fetchWithCookies(
+        header: String,
+        account: AccountIdentity
+    ) async throws -> AccountQuota {
+        let snapshot = try await GrokWebBillingFetcher.fetch(
+            cookieHeader: header,
+            session: session,
+            now: now
+        )
+        return makeQuota(
+            snapshot: snapshot,
+            account: account,
+            // Cookie-only sessions don't carry email / plan metadata —
+            // grok.com's billing payload only reports the percent +
+            // reset. Re-use whatever the account identity already
+            // knows so the card chrome doesn't flicker between
+            // "Grok" and "user@example.com" on each refresh.
+            plan: account.plan,
+            email: account.email
+        )
+    }
+
+    private func makeQuota(
+        snapshot: GrokWebBillingSnapshot,
+        account: AccountIdentity,
+        plan: String?,
+        email: String?
+    ) -> AccountQuota {
         let bucket = QuotaBucket(
             id: "monthly",
             title: "Monthly",
@@ -61,13 +107,12 @@ public struct GrokQuotaAdapter: QuotaAdapter {
             rawWindowSeconds: nil,
             groupTitle: "Grok"
         )
-
         return AccountQuota(
             accountId: account.id,
             tool: .grok,
             buckets: [bucket],
-            plan: credentials.planLabel,
-            email: credentials.email,
+            plan: plan,
+            email: email,
             queriedAt: now(),
             error: nil
         )

--- a/Sources/VibeBarCore/Adapters/GrokWebBillingFetcher.swift
+++ b/Sources/VibeBarCore/Adapters/GrokWebBillingFetcher.swift
@@ -34,13 +34,61 @@ public enum GrokWebBillingFetcher {
         endpoint: URL = Self.defaultEndpoint,
         now: @Sendable () -> Date = { Date() }
     ) async throws -> GrokWebBillingSnapshot {
+        try await Self.fetch(
+            authorizationHeader: "Bearer \(credentials.accessToken)",
+            cookieHeader: nil,
+            session: session,
+            endpoint: endpoint,
+            now: now
+        )
+    }
+
+    /// Cookie-authenticated overload. Used when `~/.grok/auth.json` is
+    /// absent and the user has imported grok.com cookies from a
+    /// signed-in browser session. xAI's billing endpoint accepts
+    /// either Bearer or Cookie auth — Codex Bar exercises both paths
+    /// in parallel; Vibe Bar picks one based on which credential the
+    /// adapter found.
+    public static func fetch(
+        cookieHeader: String,
+        session: URLSession = .shared,
+        endpoint: URL = Self.defaultEndpoint,
+        now: @Sendable () -> Date = { Date() }
+    ) async throws -> GrokWebBillingSnapshot {
+        try await Self.fetch(
+            authorizationHeader: nil,
+            cookieHeader: cookieHeader,
+            session: session,
+            endpoint: endpoint,
+            now: now
+        )
+    }
+
+    private static func fetch(
+        authorizationHeader: String?,
+        cookieHeader: String?,
+        session: URLSession,
+        endpoint: URL,
+        now: @Sendable () -> Date
+    ) async throws -> GrokWebBillingSnapshot {
         var request = URLRequest(url: endpoint)
         request.httpMethod = "POST"
         request.timeoutInterval = Self.requestTimeoutSeconds
+        // URLSession.shared shares the system HTTP cookie jar — that
+        // can quietly inject stale grok.com cookies on every request,
+        // which conflicts with the bearer header and trips xAI's auth
+        // gate. We pass the cookie header ourselves (or nothing) and
+        // tell URLSession to stay out of it.
+        request.httpShouldHandleCookies = false
         // Empty gRPC-web message frame: 1-byte flags + 4-byte big-endian
         // length (zero). Matches what xAI's web UI sends.
         request.httpBody = Data([0x00, 0x00, 0x00, 0x00, 0x00])
-        request.setValue("Bearer \(credentials.accessToken)", forHTTPHeaderField: "Authorization")
+        if let authorizationHeader {
+            request.setValue(authorizationHeader, forHTTPHeaderField: "Authorization")
+        }
+        if let cookieHeader {
+            request.setValue(cookieHeader, forHTTPHeaderField: "Cookie")
+        }
         request.setValue("https://grok.com", forHTTPHeaderField: "Origin")
         request.setValue("https://grok.com/?_s=usage", forHTTPHeaderField: "Referer")
         request.setValue("*/*", forHTTPHeaderField: "Accept")

--- a/Sources/VibeBarCore/BrowserCookies/GrokBrowserCookieImporter.swift
+++ b/Sources/VibeBarCore/BrowserCookies/GrokBrowserCookieImporter.swift
@@ -1,0 +1,95 @@
+import Foundation
+import SweetCookieKit
+
+/// Imports the minimum grok.com web session cookie set from the
+/// user's installed browsers. Mirrors `GeminiBrowserCookieImporter`:
+/// queries every browser profile via SweetCookieKit, then funnels the
+/// raw name/value pairs through `GrokWebCookieStore.minimizedCookieHeader`
+/// before persisting to Keychain.
+///
+/// Codex Bar's importer accepts a session as soon as it sees `sso` or
+/// `sso-rw`; we apply the same gate here so Vibe Bar and Codex Bar
+/// recognise the same browser session as "signed in to grok.com".
+public enum GrokBrowserCookieImporter {
+    public struct Result: Sendable {
+        public let header: String
+        public let sourceLabel: String
+        public let cookieCount: Int
+    }
+
+    public static let cookieDomains = ["grok.com"]
+
+    public static func importAndStoreFromBrowsers(
+        allowKeychainPrompt: Bool = false,
+        importOrder: BrowserCookieImportOrder = BrowserCookieDefaults.importOrder,
+        detection: BrowserDetection = BrowserDetection(),
+        client: BrowserCookieClient = BrowserCookieClient(),
+        logger: ((String) -> Void)? = nil
+    ) throws -> Result? {
+        guard let result = importFromBrowsers(
+            allowKeychainPrompt: allowKeychainPrompt,
+            importOrder: importOrder,
+            detection: detection,
+            client: client,
+            logger: logger
+        ) else {
+            return nil
+        }
+        try GrokWebCookieStore.writeCookieHeader(result.header, source: .browser)
+        return result
+    }
+
+    public static func importFromBrowsers(
+        allowKeychainPrompt: Bool = false,
+        importOrder: BrowserCookieImportOrder = BrowserCookieDefaults.importOrder,
+        detection: BrowserDetection = BrowserDetection(),
+        client: BrowserCookieClient = BrowserCookieClient(),
+        logger: ((String) -> Void)? = nil
+    ) -> Result? {
+        let candidates = importOrder.cookieImportCandidates(
+            using: detection,
+            allowKeychainPrompt: allowKeychainPrompt
+        )
+        guard !candidates.isEmpty else { return nil }
+
+        let query = BrowserCookieQuery(domains: cookieDomains)
+
+        for browser in candidates {
+            let stores: [BrowserCookieStoreRecords]
+            do {
+                stores = try client.vibeBarRecords(
+                    matching: query,
+                    in: browser,
+                    allowKeychainPrompt: allowKeychainPrompt,
+                    logger: logger
+                )
+            } catch {
+                BrowserCookieAccessGate.recordIfNeeded(error)
+                logger?("\(browser.displayName) Grok cookie import failed: \(SafeLog.sanitize(error.localizedDescription))")
+                continue
+            }
+
+            for store in stores {
+                let pairs = store.records.map { (name: $0.name, value: $0.value) }
+                guard let header = sessionHeader(from: pairs) else { continue }
+                let label = "\(browser.displayName) (\(store.store.profile.name))"
+                return Result(
+                    header: header,
+                    sourceLabel: label,
+                    cookieCount: store.records.count
+                )
+            }
+        }
+        return nil
+    }
+
+    /// Builds a minimised Cookie header from a flat list of name/value
+    /// pairs. The kept-list and auth-cookie gate live in
+    /// `GrokWebCookieStore` so this importer stays a thin shim.
+    public static func sessionHeader(from cookies: [(name: String, value: String)]) -> String? {
+        let raw = cookies
+            .map { "\($0.name)=\($0.value)" }
+            .joined(separator: "; ")
+        return GrokWebCookieStore.minimizedCookieHeader(from: raw)
+    }
+}

--- a/Sources/VibeBarCore/Credentials/GrokWebCookieStore.swift
+++ b/Sources/VibeBarCore/Credentials/GrokWebCookieStore.swift
@@ -1,0 +1,156 @@
+import Foundation
+
+/// Storage for the grok.com web session cookies imported from a
+/// signed-in browser. Mirrors `GeminiWebCookieStore`: cookies live in
+/// the user's Keychain via `SecureCookieHeaderStore` under the `grok`
+/// provider namespace; nothing is persisted to `~/.vibebar/`.
+///
+/// The minimisation step keeps `sso`, `sso-rw`, and the
+/// `cf_clearance` cookie that Cloudflare's challenge-passed gate
+/// stamps on the grok.com origin. xAI's gRPC-web billing endpoint
+/// rejects requests that don't carry the Cloudflare cookie even when
+/// the bearer / session pair is valid, so dropping it silently breaks
+/// the fetcher.
+///
+/// At least one of `sso` / `sso-rw` must be present; otherwise the
+/// browser is treated as "signed out for grok.com" and the
+/// minimisation returns `nil` so the caller can surface a "no
+/// credentials" state.
+public enum GrokWebCookieStore {
+    public enum CookieSource: Sendable {
+        case webView
+        case browser
+        case legacy
+    }
+
+    /// Cookie names kept by the minimisation step. Anything outside
+    /// this list is dropped before the header reaches the Keychain.
+    /// The Cloudflare clearance cookie is required for grok.com's
+    /// gRPC-web gate to let the request through, so it stays even
+    /// though it's not strictly an auth cookie.
+    static let keptCookieNames: Set<String> = [
+        "sso",
+        "sso-rw",
+        "cf_clearance"
+    ]
+
+    /// The two cookies that actually authenticate the session. At
+    /// least one of these has to land in the minimised header for the
+    /// browser session to count as "signed in to grok.com".
+    static let authCookieNames: Set<String> = [
+        "sso",
+        "sso-rw"
+    ]
+
+    public static func readCookieHeader() throws -> String {
+        if let header = candidateCookieHeaders().first {
+            return header
+        }
+        throw QuotaError.noCredential
+    }
+
+    public static func readCookieHeader(source: CookieSource) throws -> String {
+        if let header = storedCookieHeader(source: source) {
+            return header
+        }
+        throw QuotaError.noCredential
+    }
+
+    public static func candidateCookieHeaders() -> [String] {
+        var headers: [String] = []
+        appendStoredCookieHeader(source: .browser, to: &headers)
+        appendStoredCookieHeader(source: .webView, to: &headers)
+        return unique(headers)
+    }
+
+    public static func writeCookieHeader(_ header: String, source: CookieSource = .legacy) throws {
+        guard let minimized = minimizedCookieHeader(from: header) else { throw QuotaError.noCredential }
+        try SecureCookieHeaderStore.store(
+            minimized,
+            provider: .grok,
+            source: secureSource(for: source)
+        )
+    }
+
+    public static func hasCookieHeader() -> Bool {
+        (try? readCookieHeader()) != nil
+    }
+
+    public static func deleteCookieHeader() throws {
+        try SecureCookieHeaderStore.deleteAll(provider: .grok)
+    }
+
+    public static func storageState(source: CookieSource) -> SecureCookieHeaderStore.LoadResult {
+        SecureCookieHeaderStore.load(
+            provider: .grok,
+            source: secureSource(for: source)
+        )
+    }
+
+    public static func minimizedCookieHeader(from raw: String) -> String? {
+        let pairs = cookiePairs(from: raw)
+        let kept = pairs.filter { keptCookieNames.contains($0.name) }
+        // Require at least one of the auth cookies. Without them the
+        // header carries no useful session and the fetcher's first call
+        // would just bounce off Cloudflare or grok.com's auth gate.
+        guard kept.contains(where: { authCookieNames.contains($0.name) && !$0.value.isEmpty }) else {
+            return nil
+        }
+        let header = kept.map { "\($0.name)=\($0.value)" }.joined(separator: "; ")
+        return header.isEmpty ? nil : header
+    }
+
+    public static func normalizedCookieHeader(from raw: String) -> String {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return "" }
+        if trimmed.localizedCaseInsensitiveContains("Cookie:") {
+            return trimmed
+                .replacingOccurrences(of: "Cookie:", with: "", options: [.caseInsensitive])
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+        return trimmed
+    }
+
+    private static func appendStoredCookieHeader(source: CookieSource, to headers: inout [String]) {
+        guard let raw = storedCookieHeader(source: source) else { return }
+        headers.append(raw)
+    }
+
+    private static func storedCookieHeader(source: CookieSource) -> String? {
+        switch SecureCookieHeaderStore.load(provider: .grok, source: secureSource(for: source)) {
+        case .found(let raw):
+            return minimizedCookieHeader(from: raw)
+        case .missing, .temporarilyUnavailable, .invalid:
+            return nil
+        }
+    }
+
+    private static func secureSource(for source: CookieSource) -> SecureCookieHeaderStore.Source {
+        switch source {
+        case .webView, .legacy: return .webView
+        case .browser: return .browser
+        }
+    }
+
+    private static func cookiePairs(from header: String) -> [(name: String, value: String)] {
+        normalizedCookieHeader(from: header)
+            .split(separator: ";")
+            .compactMap { part in
+                let pieces = part.split(separator: "=", maxSplits: 1, omittingEmptySubsequences: false)
+                guard pieces.count == 2 else { return nil }
+                return (
+                    name: pieces[0].trimmingCharacters(in: .whitespacesAndNewlines),
+                    value: pieces[1].trimmingCharacters(in: .whitespacesAndNewlines)
+                )
+            }
+    }
+
+    private static func unique(_ headers: [String]) -> [String] {
+        var seen: Set<String> = []
+        var out: [String] = []
+        for header in headers where seen.insert(header).inserted {
+            out.append(header)
+        }
+        return out
+    }
+}

--- a/Sources/VibeBarCore/Credentials/SecureCookieHeaderStore.swift
+++ b/Sources/VibeBarCore/Credentials/SecureCookieHeaderStore.swift
@@ -10,6 +10,7 @@ public enum SecureCookieHeaderStore {
         case openAI = "openai"
         case claude
         case gemini
+        case grok
         // Antigravity is intentionally absent until
         // `AntigravitySourcePlanner.antigravityWebSourceAvailable` flips
         // to true. Once the spike confirms a cloud endpoint, add

--- a/Sources/VibeBarCore/Storage/AccountStore.swift
+++ b/Sources/VibeBarCore/Storage/AccountStore.swift
@@ -272,28 +272,49 @@ public final class AccountStore: ObservableObject {
         )
     }
 
-    /// Grok registers only when `~/.grok/auth.json` is present — the
-    /// current adapter has no cookie-based fallback, so a missing
-    /// auth.json means there is no usable credential to surface. Once
-    /// the file lands the popover starts showing the live monthly
-    /// usage card on the dedicated Grok sub-page.
+    /// Grok registers when EITHER `~/.grok/auth.json` is present
+    /// (preferred — carries email + plan label) OR a signed-in
+    /// grok.com browser session has been imported into the Keychain.
+    /// The dominant source determines the account id / alias; the
+    /// adapter still falls back internally if its preferred source
+    /// trips at fetch time.
     private func autoDetectGrok() -> AccountIdentity? {
-        guard GrokCredentialsStore.hasCredentials() else { return nil }
-        // Best-effort identity enrichment: surface the account's email
-        // and SuperGrok plan badge when auth.json parses cleanly. If
-        // parsing fails we still register the account so the adapter
-        // can run and report a fetch error in the popover.
-        let credentials = try? GrokCredentialsStore.load()
+        let hasAuthJson = GrokCredentialsStore.hasCredentials()
+        let hasCookies = GrokWebCookieStore.hasCookieHeader()
+        guard hasAuthJson || hasCookies else { return nil }
+
+        if hasAuthJson {
+            // Best-effort identity enrichment: surface the account's
+            // email and SuperGrok plan badge when auth.json parses
+            // cleanly. If parsing fails we still register the account
+            // so the adapter can run and report a fetch error.
+            let credentials = try? GrokCredentialsStore.load()
+            return AccountIdentity(
+                id: "oauth-grok",
+                tool: .grok,
+                email: credentials?.email,
+                alias: "Grok",
+                plan: credentials?.planLabel,
+                source: .oauthCLI,
+                allowsWebFallback: hasCookies,
+                allowsCLIFallback: false,
+                allowsOAuthFallback: true,
+                createdAt: Date(),
+                updatedAt: Date()
+            )
+        }
+
+        // Cookie-only session. The web payload doesn't carry email or
+        // plan tier, so the card shows just "Grok Web" until/unless
+        // the user also runs `grok login`.
         return AccountIdentity(
-            id: "oauth-grok",
+            id: "web-grok",
             tool: .grok,
-            email: credentials?.email,
-            alias: "Grok",
-            plan: credentials?.planLabel,
-            source: .oauthCLI,
-            allowsWebFallback: false,
+            alias: "Grok Web",
+            source: .webCookie,
+            allowsWebFallback: true,
             allowsCLIFallback: false,
-            allowsOAuthFallback: true,
+            allowsOAuthFallback: false,
             createdAt: Date(),
             updatedAt: Date()
         )

--- a/Tests/VibeBarCoreTests/GrokWebBillingCookieFetchTests.swift
+++ b/Tests/VibeBarCoreTests/GrokWebBillingCookieFetchTests.swift
@@ -1,0 +1,135 @@
+import XCTest
+@testable import VibeBarCore
+
+/// Covers the cookie-authenticated overload of
+/// `GrokWebBillingFetcher.fetch(cookieHeader:)`. The bearer-based
+/// overload's framing/protobuf tests live in
+/// `GrokWebBillingFetcherTests`; this file focuses on the request
+/// shape and on the cookie-jar isolation that lets a cookie-only
+/// session reach grok.com cleanly.
+final class GrokWebBillingCookieFetchTests: XCTestCase {
+    func testCookieOverloadSendsCookieHeaderAndNoBearer() async throws {
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [GrokCookieStubURLProtocol.self]
+        let session = URLSession(configuration: config)
+        let endpoint = URL(string: "https://grok.test/grok_api_v2.GrokBuildBilling/GetGrokCreditsConfig")!
+
+        GrokCookieStubURLProtocol.reset()
+        GrokCookieStubURLProtocol.handler = { request in
+            XCTAssertEqual(request.value(forHTTPHeaderField: "Cookie"), "sso=session; cf_clearance=cf789")
+            XCTAssertNil(request.value(forHTTPHeaderField: "Authorization"))
+            XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "application/grpc-web+proto")
+            XCTAssertEqual(request.value(forHTTPHeaderField: "x-grpc-web"), "1")
+            XCTAssertEqual(request.httpShouldHandleCookies, false)
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "application/grpc-web+proto"]
+            )!
+            let payload = Self.protobufPayload(usedPercent: 67.5, resetEpoch: 1_800_000_000)
+            return (response, Self.grpcFrame(payload))
+        }
+
+        let snapshot = try await GrokWebBillingFetcher.fetch(
+            cookieHeader: "sso=session; cf_clearance=cf789",
+            session: session,
+            endpoint: endpoint
+        )
+        XCTAssertEqual(snapshot.usedPercent, 67.5, accuracy: 0.001)
+        XCTAssertEqual(snapshot.resetsAt, Date(timeIntervalSince1970: 1_800_000_000))
+    }
+
+    func testCookieOverloadRejectsStaleCookiesAsNeedsLogin() async throws {
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [GrokCookieStubURLProtocol.self]
+        let session = URLSession(configuration: config)
+        let endpoint = URL(string: "https://grok.test/grok_api_v2.GrokBuildBilling/GetGrokCreditsConfig")!
+
+        GrokCookieStubURLProtocol.reset()
+        GrokCookieStubURLProtocol.handler = { request in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 401,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "text/plain"]
+            )!
+            return (response, Data("unauthorized".utf8))
+        }
+
+        do {
+            _ = try await GrokWebBillingFetcher.fetch(
+                cookieHeader: "sso=stale",
+                session: session,
+                endpoint: endpoint
+            )
+            XCTFail("Expected needsLogin")
+        } catch let error as QuotaError {
+            guard case .needsLogin = error else {
+                return XCTFail("Expected .needsLogin, got \(error)")
+            }
+        } catch {
+            XCTFail("Expected QuotaError, got \(error)")
+        }
+    }
+
+    // MARK: - Helpers
+
+    private static func protobufPayload(usedPercent: Float, resetEpoch: UInt64) -> Data {
+        var data = Data()
+        data.append(0x0D)
+        var percentBits = usedPercent.bitPattern.littleEndian
+        withUnsafeBytes(of: &percentBits) { data.append(contentsOf: $0) }
+        data.append(0x10)
+        data.append(contentsOf: varint(resetEpoch))
+        return data
+    }
+
+    private static func grpcFrame(_ payload: Data, flags: UInt8 = 0x00) -> Data {
+        var data = Data([flags])
+        let length = UInt32(payload.count).bigEndian
+        withUnsafeBytes(of: length) { data.append(contentsOf: $0) }
+        data.append(payload)
+        return data
+    }
+
+    private static func varint(_ value: UInt64) -> [UInt8] {
+        var remaining = value
+        var bytes: [UInt8] = []
+        repeat {
+            var byte = UInt8(remaining & 0x7F)
+            remaining >>= 7
+            if remaining != 0 { byte |= 0x80 }
+            bytes.append(byte)
+        } while remaining != 0
+        return bytes
+    }
+}
+
+private final class GrokCookieStubURLProtocol: URLProtocol {
+    nonisolated(unsafe) static var handler: (@Sendable (URLRequest) throws -> (HTTPURLResponse, Data))?
+
+    static func reset() {
+        handler = nil
+    }
+
+    override class func canInit(with _: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        guard let handler = Self.handler else {
+            client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
+            return
+        }
+        do {
+            let (response, data) = try handler(request)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
+}

--- a/Tests/VibeBarCoreTests/GrokWebCookieStoreTests.swift
+++ b/Tests/VibeBarCoreTests/GrokWebCookieStoreTests.swift
@@ -1,0 +1,90 @@
+import XCTest
+@testable import VibeBarCore
+
+final class GrokWebCookieStoreTests: XCTestCase {
+    func testMinimizationKeepsAuthCookiesAndDropsTrackers() {
+        let raw = "sso=auth123; _ga=GA1.2.foo; sso-rw=rw456; _intercom_session=baz; cf_clearance=cf789; foo=bar"
+        let minimized = GrokWebCookieStore.minimizedCookieHeader(from: raw)
+        XCTAssertNotNil(minimized)
+        let header = minimized ?? ""
+        XCTAssertTrue(header.contains("sso=auth123"))
+        XCTAssertTrue(header.contains("sso-rw=rw456"))
+        XCTAssertTrue(header.contains("cf_clearance=cf789"))
+        XCTAssertFalse(header.contains("_ga"))
+        XCTAssertFalse(header.contains("_intercom_session"))
+        XCTAssertFalse(header.contains("foo=bar"))
+    }
+
+    func testMinimizationAcceptsSsoOnly() {
+        let raw = "sso=auth123; _ga=GA1.2.foo"
+        let minimized = GrokWebCookieStore.minimizedCookieHeader(from: raw)
+        XCTAssertEqual(minimized, "sso=auth123")
+    }
+
+    func testMinimizationAcceptsSsoRwOnly() {
+        let raw = "sso-rw=rw456; cf_clearance=cf789"
+        let minimized = GrokWebCookieStore.minimizedCookieHeader(from: raw)
+        XCTAssertNotNil(minimized)
+        let header = minimized ?? ""
+        XCTAssertTrue(header.contains("sso-rw=rw456"))
+        XCTAssertTrue(header.contains("cf_clearance=cf789"))
+    }
+
+    func testMinimizationRejectsHeaderWithoutAuthCookies() {
+        // No sso / sso-rw — without an auth cookie the header is
+        // useless even if cf_clearance happens to be present.
+        let raw = "cf_clearance=cf789; _ga=GA1.2.foo"
+        XCTAssertNil(GrokWebCookieStore.minimizedCookieHeader(from: raw))
+    }
+
+    func testMinimizationRejectsEmptyAuthCookieValue() {
+        // An auth cookie has to actually carry a value — an empty
+        // sso= pair is the shape we'd see when the user is signed out.
+        let raw = "sso=; sso-rw=; cf_clearance=cf789"
+        XCTAssertNil(GrokWebCookieStore.minimizedCookieHeader(from: raw))
+    }
+
+    func testNormalizedCookieHeaderStripsLeadingCookieLabel() {
+        XCTAssertEqual(
+            GrokWebCookieStore.normalizedCookieHeader(from: "Cookie: sso=auth"),
+            "sso=auth"
+        )
+        XCTAssertEqual(
+            GrokWebCookieStore.normalizedCookieHeader(from: "  Cookie: sso=auth  "),
+            "sso=auth"
+        )
+    }
+
+    func testWriteThenReadRoundTripsViaInMemoryStore() throws {
+        try SecureCookieHeaderStore.withInMemoryStoreForTesting {
+            XCTAssertFalse(GrokWebCookieStore.hasCookieHeader())
+            try GrokWebCookieStore.writeCookieHeader(
+                "sso=auth123; cf_clearance=cf789",
+                source: .browser
+            )
+            XCTAssertTrue(GrokWebCookieStore.hasCookieHeader())
+            let header = try GrokWebCookieStore.readCookieHeader()
+            XCTAssertTrue(header.contains("sso=auth123"))
+            XCTAssertTrue(header.contains("cf_clearance=cf789"))
+        }
+    }
+
+    func testWriteRejectsHeaderWithoutAuthCookies() throws {
+        try SecureCookieHeaderStore.withInMemoryStoreForTesting {
+            XCTAssertThrowsError(
+                try GrokWebCookieStore.writeCookieHeader(
+                    "cf_clearance=cf789; _ga=GA1.2.foo",
+                    source: .browser
+                )
+            ) { error in
+                guard let qe = error as? QuotaError else {
+                    return XCTFail("Expected QuotaError, got \(error)")
+                }
+                guard case .noCredential = qe else {
+                    return XCTFail("Expected .noCredential, got \(qe)")
+                }
+            }
+            XCTAssertFalse(GrokWebCookieStore.hasCookieHeader())
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Closes the gap reported on AQ's machine: the first Grok pass shipped only the `~/.grok/auth.json` bearer path, so users who signed in to grok.com on the web but never ran `grok login` see an empty Grok sub-page while Codex Bar's parallel cookie scraper has data. This patch mirrors the existing Gemini cookie pipeline so Vibe Bar can read the same browser session.
- New `GrokWebCookieStore` keeps `sso`, `sso-rw`, and `cf_clearance` through the Keychain via `SecureCookieHeaderStore` (new `.grok` provider namespace); the auth gate requires at least one of the `sso` cookies to carry a value. `GrokBrowserCookieImporter` walks every detected browser profile for `grok.com` cookies via SweetCookieKit and writes the minimised header.
- `GrokWebBillingFetcher` gains a `fetch(cookieHeader:)` overload. Both overloads now set `httpShouldHandleCookies = false` so URLSession's shared cookie jar can't quietly inject stale grok.com cookies on top of the bearer (a latent bug that would have bitten the auth.json path too).
- `GrokQuotaAdapter` prefers auth.json (richer metadata — email + plan label) and falls back to the cookie source when no usable bearer is present. `AccountStore.autoDetectGrok` registers a `web-grok` identity when cookies are the only source so the Overview sub-page renders immediately after import.
- `SettingsView` Grok Account section gains Import / Delete browser cookie buttons + status text, matching the Gemini section.

## Why now

PR #28 deferred the cookie fallback to a follow-up to keep the initial Grok PR scoped. Real-world bug report on AQ's machine shows the deferral isn't tenable: `grok login` is not the only path people sign in. Codex Bar handles both, and Vibe Bar's "first-class Grok provider" claim only holds if it handles both too.

## Test plan

- [x] `swift build` — clean
- [x] `swift test` — 426 tests, 0 failures (was 416 on post-#29 main + 10 new cookie tests)
- [x] `./Scripts/build_app.sh release` + `codesign -d --entitlements - ".build/Vibe Bar.app"` returns empty `[Dict]`
- [x] `codesign --verify --deep --strict ".build/Vibe Bar.app"` passes
- [x] No new `NSHomeDirectory()` / `homeDirectoryForCurrentUser` / `URL.homeDirectory` hits in product code
- [ ] Manual smoke (AQ): open built `.app`, click Settings → Grok Account → "Import Grok cookies from browser", confirm the Overview "Grok" sub-page populates with a Monthly card

🤖 Generated with [Claude Code](https://claude.com/claude-code)