### PR TITLE
Cost-aware tier parity for Grok / AntiGravity + JSON-driven pricing

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -31,6 +31,15 @@ let package = Package(
             dependencies: [
                 .product(name: "SweetCookieKit", package: "SweetCookieKit")
             ],
+            resources: [
+                // Pricing tables: shipped as a bundled JSON so model
+                // rate updates can be merged without a code change.
+                // `PricingResolver` loads this via `Bundle.module` and
+                // a runtime cache under ~/.vibebar/pricing_cache.json
+                // can override it when `PricingRefresher` fetches a
+                // newer copy from the project's GitHub raw URL.
+                .copy("Resources/pricing.json")
+            ],
             swiftSettings: [.swiftLanguageMode(.v5)]
         ),
         .testTarget(

--- a/Sources/VibeBarApp/AppEnvironment.swift
+++ b/Sources/VibeBarApp/AppEnvironment.swift
@@ -167,6 +167,16 @@ final class AppEnvironment: ObservableObject {
             await costService.applyCostDataSettings()
             await costService.refreshAll()
         }
+
+        // Best-effort pricing refresh: fetches the latest pricing.json from
+        // GitHub raw and updates ~/.vibebar/pricing_cache.json so the *next*
+        // launch picks up new model rates without a rebuild. Failures are
+        // silent — the bundled fallback keeps the current session usable.
+        // The 24-hour freshness window inside PricingRefresher short-circuits
+        // the network call when the cache is still recent.
+        Task.detached(priority: .utility) {
+            await PricingRefresher.refresh()
+        }
         importPersistentClaudeCookiesAndRefreshIfNeeded()
         importClaudeBrowserCookiesAndRefreshIfNeeded()
         importPersistentOpenAICookiesAndRefreshIfNeeded()

--- a/Sources/VibeBarCore/Models/ToolType.swift
+++ b/Sources/VibeBarCore/Models/ToolType.swift
@@ -133,17 +133,27 @@ public enum ToolType: String, Codable, CaseIterable, Hashable, Sendable {
     }
 
     /// True for providers we can build a per-token cost panel for.
-    /// `.gemini` joins Codex / Claude because Gemini CLI's
-    /// OpenTelemetry log (`~/.gemini/telemetry.log`) carries
-    /// `input_token_count` / `output_token_count` per
-    /// `gemini_cli.api_response` event. Antigravity has no comparable
-    /// public protocol (LS quotas are remainingFraction only;
-    /// `~/.gemini/antigravity/conversations/*.db` is Electron-encrypted
-    /// protobuf), so it stays false.
+    /// - `.gemini` reads Gemini CLI's OpenTelemetry log
+    ///   (`~/.gemini/telemetry.log` / per-project OTLP collector log)
+    ///   *and* the persistent chat-history JSONL files under
+    ///   `~/.gemini/tmp/*/chats/session-*.jsonl` (each `type:gemini`
+    ///   message carries `tokens.{input,output,cached,thoughts}`).
+    /// - `.antigravity` reads the AntiGravity IDE's per-conversation
+    ///   SQLite databases under `~/.gemini/antigravity/conversations/*.db`;
+    ///   the `gen_metadata.data` protobuf blob exposes per-turn
+    ///   input / output / cumulative cache-read counts. The
+    ///   `~/.gemini/antigravity-cli/conversations/*.pb` files use an
+    ///   unidentified container format and are skipped — accept that
+    ///   CLI-only AntiGravity usage stays dark for now.
+    /// - `.grok` reads `~/.grok/sessions/**/updates.jsonl` and takes
+    ///   per-session deltas of the cumulative `_meta.totalTokens`
+    ///   field. Grok exposes only a session-level total (no per-call
+    ///   input / output split), so the USD figure is a blended
+    ///   approximation against the published `grok-build` rate.
     public var supportsTokenCost: Bool {
         switch self {
-        case .codex, .claude, .gemini: return true
-        case .alibaba, .alibabaTokenPlan, .antigravity, .grok, .copilot, .zai, .minimax, .kimi, .cursor, .mimo, .iflytek, .tencentHunyuan, .tencentTokenPlan, .volcengine, .baiduQianfan, .openCodeGo, .kilo, .kiro, .ollama, .openRouter, .warp:
+        case .codex, .claude, .gemini, .antigravity, .grok: return true
+        case .alibaba, .alibabaTokenPlan, .copilot, .zai, .minimax, .kimi, .cursor, .mimo, .iflytek, .tencentHunyuan, .tencentTokenPlan, .volcengine, .baiduQianfan, .openCodeGo, .kilo, .kiro, .ollama, .openRouter, .warp:
             return false
         }
     }

--- a/Sources/VibeBarCore/Resources/pricing.json
+++ b/Sources/VibeBarCore/Resources/pricing.json
@@ -1,0 +1,179 @@
+{
+  "schemaVersion": 1,
+  "updatedAt": "2026-05-22",
+  "calculationVersion": 5,
+  "providers": {
+    "codex": {
+      "displayName": "OpenAI",
+      "models": {
+        "gpt-5":               { "input": 1.25e-6, "output": 1e-5,    "cacheRead": 1.25e-7 },
+        "gpt-5-codex":         { "input": 1.25e-6, "output": 1e-5,    "cacheRead": 1.25e-7 },
+        "gpt-5-mini":          { "input": 2.5e-7,  "output": 2e-6,    "cacheRead": 2.5e-8 },
+        "gpt-5-nano":          { "input": 5e-8,    "output": 4e-7,    "cacheRead": 5e-9 },
+        "gpt-5-pro":           { "input": 1.5e-5,  "output": 1.2e-4,  "cacheRead": null },
+        "gpt-5.1":             { "input": 1.25e-6, "output": 1e-5,    "cacheRead": 1.25e-7 },
+        "gpt-5.1-codex":       { "input": 1.25e-6, "output": 1e-5,    "cacheRead": 1.25e-7 },
+        "gpt-5.1-codex-max":   { "input": 1.25e-6, "output": 1e-5,    "cacheRead": 1.25e-7 },
+        "gpt-5.1-codex-mini":  { "input": 2.5e-7,  "output": 2e-6,    "cacheRead": 2.5e-8 },
+        "gpt-5.2":             { "input": 1.75e-6, "output": 1.4e-5,  "cacheRead": 1.75e-7 },
+        "gpt-5.2-codex":       { "input": 1.75e-6, "output": 1.4e-5,  "cacheRead": 1.75e-7 },
+        "gpt-5.2-pro":         { "input": 2.1e-5,  "output": 1.68e-4, "cacheRead": null },
+        "gpt-5.3-codex":       { "input": 1.75e-6, "output": 1.4e-5,  "cacheRead": 1.75e-7 },
+        "gpt-5.3-codex-spark": { "input": 0,       "output": 0,       "cacheRead": 0,
+                                 "displayLabel": "Research Preview" },
+        "gpt-5.4":             { "input": 2.5e-6,  "output": 1.5e-5,  "cacheRead": 2.5e-7 },
+        "gpt-5.4-mini":        { "input": 7.5e-7,  "output": 4.5e-6,  "cacheRead": 7.5e-8 },
+        "gpt-5.4-nano":        { "input": 2e-7,    "output": 1.25e-6, "cacheRead": 2e-8 },
+        "gpt-5.4-pro":         { "input": 3e-5,    "output": 1.8e-4,  "cacheRead": null },
+        "gpt-5.5":             { "input": 5e-6,    "output": 3e-5,    "cacheRead": 5e-7 },
+        "gpt-5.5-pro":         { "input": 3e-5,    "output": 1.8e-4,  "cacheRead": null }
+      }
+    },
+    "claude": {
+      "displayName": "Anthropic",
+      "models": {
+        "claude-haiku-4-5-20251001": {
+          "input": 1e-6, "output": 5e-6,
+          "cacheCreation": 1.25e-6, "cacheRead": 1e-7
+        },
+        "claude-haiku-4-5": {
+          "input": 1e-6, "output": 5e-6,
+          "cacheCreation": 1.25e-6, "cacheRead": 1e-7
+        },
+        "claude-opus-4-5-20251101": {
+          "input": 5e-6, "output": 2.5e-5,
+          "cacheCreation": 6.25e-6, "cacheRead": 5e-7
+        },
+        "claude-opus-4-5": {
+          "input": 5e-6, "output": 2.5e-5,
+          "cacheCreation": 6.25e-6, "cacheRead": 5e-7
+        },
+        "claude-opus-4-6-20260205": {
+          "input": 5e-6, "output": 2.5e-5,
+          "cacheCreation": 6.25e-6, "cacheRead": 5e-7
+        },
+        "claude-opus-4-6": {
+          "input": 5e-6, "output": 2.5e-5,
+          "cacheCreation": 6.25e-6, "cacheRead": 5e-7
+        },
+        "claude-opus-4-7": {
+          "input": 5e-6, "output": 2.5e-5,
+          "cacheCreation": 6.25e-6, "cacheRead": 5e-7
+        },
+        "claude-sonnet-4-5": {
+          "input": 3e-6, "output": 1.5e-5,
+          "cacheCreation": 3.75e-6, "cacheRead": 3e-7,
+          "thresholdTokens": 200000,
+          "inputAboveThreshold": 6e-6, "outputAboveThreshold": 2.25e-5,
+          "cacheCreationAboveThreshold": 7.5e-6, "cacheReadAboveThreshold": 6e-7
+        },
+        "claude-sonnet-4-6": {
+          "input": 3e-6, "output": 1.5e-5,
+          "cacheCreation": 3.75e-6, "cacheRead": 3e-7
+        },
+        "claude-sonnet-4-5-20250929": {
+          "input": 3e-6, "output": 1.5e-5,
+          "cacheCreation": 3.75e-6, "cacheRead": 3e-7,
+          "thresholdTokens": 200000,
+          "inputAboveThreshold": 6e-6, "outputAboveThreshold": 2.25e-5,
+          "cacheCreationAboveThreshold": 7.5e-6, "cacheReadAboveThreshold": 6e-7
+        },
+        "claude-opus-4-20250514": {
+          "input": 1.5e-5, "output": 7.5e-5,
+          "cacheCreation": 1.875e-5, "cacheRead": 1.5e-6
+        },
+        "claude-opus-4-1": {
+          "input": 1.5e-5, "output": 7.5e-5,
+          "cacheCreation": 1.875e-5, "cacheRead": 1.5e-6
+        },
+        "claude-sonnet-4-20250514": {
+          "input": 3e-6, "output": 1.5e-5,
+          "cacheCreation": 3.75e-6, "cacheRead": 3e-7,
+          "thresholdTokens": 200000,
+          "inputAboveThreshold": 6e-6, "outputAboveThreshold": 2.25e-5,
+          "cacheCreationAboveThreshold": 7.5e-6, "cacheReadAboveThreshold": 6e-7
+        }
+      }
+    },
+    "gemini": {
+      "displayName": "Google Gemini",
+      "models": {
+        "gemini-2.5-pro": {
+          "input": 1.25e-6, "output": 1e-5, "cacheRead": 3.1e-7,
+          "thresholdTokens": 200000,
+          "inputAboveThreshold": 2.5e-6, "outputAboveThreshold": 1.5e-5,
+          "cacheReadAboveThreshold": 6.25e-7
+        },
+        "gemini-2.5-flash": {
+          "input": 3e-7, "output": 2.5e-6, "cacheRead": 7.5e-8
+        },
+        "gemini-2.5-flash-lite": {
+          "input": 1e-7, "output": 4e-7, "cacheRead": 2.5e-8
+        },
+        "gemini-3-pro": {
+          "input": 2e-6, "output": 1.2e-5, "cacheRead": 5e-7,
+          "thresholdTokens": 200000,
+          "inputAboveThreshold": 4e-6, "outputAboveThreshold": 1.8e-5,
+          "cacheReadAboveThreshold": 1e-6
+        },
+        "gemini-3-pro-preview": {
+          "input": 2e-6, "output": 1.2e-5, "cacheRead": 5e-7,
+          "thresholdTokens": 200000,
+          "inputAboveThreshold": 4e-6, "outputAboveThreshold": 1.8e-5,
+          "cacheReadAboveThreshold": 1e-6
+        },
+        "gemini-3-flash": {
+          "input": 3.5e-7, "output": 2.8e-6, "cacheRead": 8.75e-8
+        },
+        "gemini-3-flash-lite": {
+          "input": 1.25e-7, "output": 5e-7, "cacheRead": 3.1e-8
+        }
+      }
+    },
+    "grok": {
+      "displayName": "xAI Grok",
+      "models": {
+        "grok-build":        { "input": 1e-6,    "output": 2e-6,    "cacheRead": null },
+        "grok-build-0.1":    { "input": 1e-6,    "output": 2e-6,    "cacheRead": null },
+        "grok-4":            { "input": 3e-6,    "output": 1.5e-5,  "cacheRead": 7.5e-7 },
+        "grok-4-fast":       { "input": 2e-7,    "output": 5e-7,    "cacheRead": 5e-8 },
+        "grok-4.1-fast":     { "input": 2e-7,    "output": 5e-7,    "cacheRead": 5e-8 },
+        "grok-4.3":          { "input": 1.25e-6, "output": 2.5e-6,  "cacheRead": 3.1e-7 },
+        "grok-4.20":         { "input": 2e-6,    "output": 6e-6,    "cacheRead": 2e-7 },
+        "grok-3":            { "input": 3e-6,    "output": 1.5e-5,  "cacheRead": 7.5e-7 },
+        "grok-3-mini":       { "input": 3e-7,    "output": 5e-7,    "cacheRead": 7.5e-8 },
+        "grok-code-fast-1":  { "input": 2e-7,    "output": 1.5e-6,  "cacheRead": 2e-8 }
+      }
+    },
+    "antigravity": {
+      "displayName": "Google AntiGravity (shadow rates)",
+      "models": {
+        "antigravity-default": {
+          "input": 3e-6, "output": 1.5e-5,
+          "cacheRead": 3e-7, "cacheCreation": 3.75e-6,
+          "displayLabel": "Sonnet-rate est."
+        },
+        "antigravity-claude-sonnet": {
+          "input": 3e-6, "output": 1.5e-5,
+          "cacheRead": 3e-7, "cacheCreation": 3.75e-6
+        },
+        "antigravity-claude-opus": {
+          "input": 5e-6, "output": 2.5e-5,
+          "cacheRead": 5e-7, "cacheCreation": 6.25e-6
+        },
+        "antigravity-claude-haiku": {
+          "input": 1e-6, "output": 5e-6,
+          "cacheRead": 1e-7, "cacheCreation": 1.25e-6
+        },
+        "antigravity-gemini-pro": {
+          "input": 1.25e-6, "output": 1e-5,
+          "cacheRead": 3.1e-7, "cacheCreation": 0
+        },
+        "antigravity-gemini-flash": {
+          "input": 3e-7, "output": 2.5e-6,
+          "cacheRead": 7.5e-8, "cacheCreation": 0
+        }
+      }
+    }
+  }
+}

--- a/Sources/VibeBarCore/Services/AntigravitySessionReader.swift
+++ b/Sources/VibeBarCore/Services/AntigravitySessionReader.swift
@@ -1,0 +1,215 @@
+import Foundation
+import SQLite3
+
+/// Reads token-usage records out of an AntiGravity IDE conversation
+/// database. Each `.db` file under `~/.gemini/antigravity/conversations/`
+/// is a tiny SQLite store with one row per model turn in
+/// `gen_metadata.data` — a protobuf blob.
+///
+/// The blob's shape was reverse-engineered against AntiGravity 2025
+/// builds with `protoc --decode_raw`; the fields we read live at:
+///
+///   - `1.4.1` — constant system-prompt token count (1132 today),
+///     cached after the first turn
+///   - `1.4.2` — non-cached input tokens for this turn
+///   - `1.4.3` — output tokens for this turn
+///   - `1.4.5` — cumulative cache-read pool size (monotonically
+///     non-decreasing within a trajectory)
+///   - `1.4.9` — reasoning / "thinking" tokens — billed at output
+///     rate by Claude / Gemini, so callers fold into output
+///   - `1.4.10` — tool tokens — same as above
+///   - `1.4.11` — the upstream request id (string), useful as a
+///     dedupe key in the scan cache
+///   - `1.9.4.1` / `1.9.4.2` — seconds + nanoseconds of the wall
+///     clock when the turn started
+///
+/// Unknown fields are ignored. Missing fields default to 0 / nil so
+/// callers never have to special-case a turn whose blob is short on
+/// detail.
+public enum AntigravitySessionReader {
+    public struct Turn: Sendable, Equatable {
+        public let date: Date
+        public let inputTokens: Int
+        public let outputTokens: Int
+        public let cumulativeCacheReadTokens: Int
+        public let thoughtsTokens: Int
+        public let toolTokens: Int
+        public let requestId: String?
+
+        public init(
+            date: Date,
+            inputTokens: Int,
+            outputTokens: Int,
+            cumulativeCacheReadTokens: Int,
+            thoughtsTokens: Int,
+            toolTokens: Int,
+            requestId: String?
+        ) {
+            self.date = date
+            self.inputTokens = inputTokens
+            self.outputTokens = outputTokens
+            self.cumulativeCacheReadTokens = cumulativeCacheReadTokens
+            self.thoughtsTokens = thoughtsTokens
+            self.toolTokens = toolTokens
+            self.requestId = requestId
+        }
+    }
+
+    /// Open the SQLite database in read-only mode, walk the
+    /// `gen_metadata` table in row-order, and decode each blob's
+    /// turn-usage fields. Errors at any step return an empty array
+    /// rather than throwing — a malformed database shouldn't sink
+    /// the rest of the scan.
+    public static func readGenMetadata(at file: URL) -> [Turn] {
+        let path = file.path
+        var db: OpaquePointer? = nil
+        let openFlags = SQLITE_OPEN_READONLY | SQLITE_OPEN_NOMUTEX | SQLITE_OPEN_URI
+        let uri = "file:\(path)?immutable=1"
+        guard sqlite3_open_v2(uri, &db, openFlags, nil) == SQLITE_OK, let db else {
+            if db != nil { sqlite3_close_v2(db) }
+            return []
+        }
+        defer { sqlite3_close_v2(db) }
+
+        var statement: OpaquePointer? = nil
+        let sql = "SELECT idx, data FROM gen_metadata ORDER BY idx"
+        guard sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK, let statement else {
+            if statement != nil { sqlite3_finalize(statement) }
+            return []
+        }
+        defer { sqlite3_finalize(statement) }
+
+        var turns: [Turn] = []
+        while sqlite3_step(statement) == SQLITE_ROW {
+            guard let raw = sqlite3_column_blob(statement, 1) else { continue }
+            let length = Int(sqlite3_column_bytes(statement, 1))
+            guard length > 0 else { continue }
+            let blob = Data(bytes: raw, count: length)
+            if let turn = decodeTurn(blob: blob) {
+                turns.append(turn)
+            }
+        }
+        return turns
+    }
+
+    // MARK: - Blob decoding
+
+    static func decodeTurn(blob: Data) -> Turn? {
+        let bytes = [UInt8](blob)
+        guard let outer = extractLengthDelimited(bytes: bytes, fieldNumber: 1) else { return nil }
+
+        let usage = extractLengthDelimited(bytes: outer, fieldNumber: 4) ?? []
+        let system = extractLengthDelimited(bytes: outer, fieldNumber: 9) ?? []
+        let timeBlock = extractLengthDelimited(bytes: system, fieldNumber: 4) ?? []
+
+        let input = Int(extractVarint(bytes: usage, fieldNumber: 2) ?? 0)
+        let output = Int(extractVarint(bytes: usage, fieldNumber: 3) ?? 0)
+        let cache = Int(extractVarint(bytes: usage, fieldNumber: 5) ?? 0)
+        let thoughts = Int(extractVarint(bytes: usage, fieldNumber: 9) ?? 0)
+        let tool = Int(extractVarint(bytes: usage, fieldNumber: 10) ?? 0)
+        let requestId = extractString(bytes: usage, fieldNumber: 11)
+
+        let date: Date
+        if let seconds = extractVarint(bytes: timeBlock, fieldNumber: 1) {
+            let nanos = extractVarint(bytes: timeBlock, fieldNumber: 2) ?? 0
+            date = Date(timeIntervalSince1970: TimeInterval(seconds) + TimeInterval(nanos) / 1_000_000_000)
+        } else {
+            return nil
+        }
+
+        return Turn(
+            date: date,
+            inputTokens: input,
+            outputTokens: output,
+            cumulativeCacheReadTokens: cache,
+            thoughtsTokens: thoughts,
+            toolTokens: tool,
+            requestId: requestId
+        )
+    }
+
+    // MARK: - Protobuf raw scanner
+    //
+    // Path-based readers. Each `extract…` walks the byte stream
+    // looking for the requested field number and returns the
+    // *first* value of the matching wire type. AntiGravity's
+    // schema doesn't repeat the fields we care about, so first-match
+    // is the right semantics.
+
+    static func extractLengthDelimited(bytes: [UInt8], fieldNumber: UInt64) -> [UInt8]? {
+        var index = 0
+        while let (number, wireType) = readTag(bytes: bytes, index: &index) {
+            switch wireType {
+            case 0:
+                _ = readVarint(bytes: bytes, index: &index)
+            case 1:
+                guard index + 8 <= bytes.count else { return nil }
+                index += 8
+            case 2:
+                guard let length = readVarint(bytes: bytes, index: &index) else { return nil }
+                let end = index + Int(length)
+                guard end <= bytes.count else { return nil }
+                if number == fieldNumber {
+                    return Array(bytes[index..<end])
+                }
+                index = end
+            case 5:
+                guard index + 4 <= bytes.count else { return nil }
+                index += 4
+            default:
+                return nil
+            }
+        }
+        return nil
+    }
+
+    static func extractVarint(bytes: [UInt8], fieldNumber: UInt64) -> UInt64? {
+        var index = 0
+        while let (number, wireType) = readTag(bytes: bytes, index: &index) {
+            switch wireType {
+            case 0:
+                let value = readVarint(bytes: bytes, index: &index)
+                if number == fieldNumber { return value }
+            case 1:
+                guard index + 8 <= bytes.count else { return nil }
+                index += 8
+            case 2:
+                guard let length = readVarint(bytes: bytes, index: &index) else { return nil }
+                let end = index + Int(length)
+                guard end <= bytes.count else { return nil }
+                index = end
+            case 5:
+                guard index + 4 <= bytes.count else { return nil }
+                index += 4
+            default:
+                return nil
+            }
+        }
+        return nil
+    }
+
+    static func extractString(bytes: [UInt8], fieldNumber: UInt64) -> String? {
+        guard let payload = extractLengthDelimited(bytes: bytes, fieldNumber: fieldNumber) else {
+            return nil
+        }
+        return String(bytes: payload, encoding: .utf8)
+    }
+
+    private static func readTag(bytes: [UInt8], index: inout Int) -> (UInt64, UInt64)? {
+        guard let key = readVarint(bytes: bytes, index: &index), key != 0 else { return nil }
+        return (key >> 3, key & 0x07)
+    }
+
+    private static func readVarint(bytes: [UInt8], index: inout Int) -> UInt64? {
+        var value: UInt64 = 0
+        var shift: UInt64 = 0
+        while index < bytes.count, shift < 64 {
+            let byte = bytes[index]
+            index += 1
+            value |= UInt64(byte & 0x7F) << shift
+            if byte & 0x80 == 0 { return value }
+            shift += 7
+        }
+        return nil
+    }
+}

--- a/Sources/VibeBarCore/Services/CostUsageScanner.swift
+++ b/Sources/VibeBarCore/Services/CostUsageScanner.swift
@@ -26,14 +26,16 @@ public enum CostUsageScanner {
             return await scanClaude(homeDirectory: homeDirectory, now: now, retentionDays: retentionDays)
         case .gemini:
             return await scanGemini(homeDirectory: homeDirectory, now: now, retentionDays: retentionDays)
-        case .alibaba, .alibabaTokenPlan, .antigravity, .grok, .copilot, .zai, .minimax, .kimi, .cursor, .mimo, .iflytek, .tencentHunyuan, .tencentTokenPlan, .volcengine, .baiduQianfan, .openCodeGo, .kilo, .kiro, .ollama, .openRouter, .warp:
-            // Antigravity, Grok, and misc providers don't expose
-            // token-level cost data through any documented public
-            // protocol. The
-            // cost-history pipeline is gated by `tool.supportsTokenCost`
-            // upstream. Returning `nil` here is a defensive belt:
-            // anything that does call us by accident gets an empty
-            // snapshot, not a crash.
+        case .grok:
+            return await scanGrok(homeDirectory: homeDirectory, now: now, retentionDays: retentionDays)
+        case .antigravity:
+            return await scanAntigravity(homeDirectory: homeDirectory, now: now, retentionDays: retentionDays)
+        case .alibaba, .alibabaTokenPlan, .copilot, .zai, .minimax, .kimi, .cursor, .mimo, .iflytek, .tencentHunyuan, .tencentTokenPlan, .volcengine, .baiduQianfan, .openCodeGo, .kilo, .kiro, .ollama, .openRouter, .warp:
+            // Misc providers don't expose token-level cost data through
+            // any documented public protocol. The cost-history pipeline
+            // is gated by `tool.supportsTokenCost` upstream. Returning
+            // `nil` here is a defensive belt: anything that does call
+            // us by accident gets an empty snapshot, not a crash.
             return nil
         }
     }
@@ -305,13 +307,16 @@ public enum CostUsageScanner {
         now: Date,
         retentionDays: Int?
     ) async -> CostSnapshot {
-        let candidates = geminiTelemetryFileCandidates(homeDirectory: homeDirectory)
-        let files = candidates.filter { FileManager.default.fileExists(atPath: $0.path) }
+        let telemetryCandidates = geminiTelemetryFileCandidates(homeDirectory: homeDirectory)
+        let chatCandidates = geminiChatFileCandidates(homeDirectory: homeDirectory)
+        let telemetryFiles = telemetryCandidates.filter { FileManager.default.fileExists(atPath: $0.path) }
+        let chatFiles = chatCandidates // chat enumerator only returns existing files
+        let allFiles = telemetryFiles + chatFiles
         var aggregator = CostAggregator(tool: .gemini, now: now)
         var cache = CostUsageScanCache.load(homeDirectory: homeDirectory, tool: .gemini, retentionDays: retentionDays)
         let cutoff = retentionCutoff(now: now, retentionDays: retentionDays)
 
-        for file in files {
+        for file in allFiles {
             let (mtime, size) = fileFingerprint(file)
             if let cached = cache.reusable(for: file.path, mtime: mtime, size: size) {
                 let retained = retainedEvents(cached, cutoff: cutoff)
@@ -326,62 +331,177 @@ public enum CostUsageScanner {
                 continue
             }
 
-            var parsed: [CostUsageScanCache.ParsedEvent] = []
-            let fileMTimeFallback = fileMTime(file) ?? now
-            let didRead = forEachJSONLLine(in: file) { lineData in
-                guard !lineData.isEmpty,
-                      lineData.contains(asciiSequence: "gemini_cli")
-                else { return }
-                guard let raw = (try? JSONSerialization.jsonObject(with: lineData)) as? [String: Any] else { return }
-                guard isGeminiApiResponse(raw) else { return }
-                let attributes = geminiAttributes(raw)
-                let model = (attributes["model"] as? String)
-                    ?? (attributes["gen_ai.request.model"] as? String)
-                    ?? (attributes["gen_ai.response.model"] as? String)
-                    ?? "gemini-unknown"
-                let input = anyInt(attributes["input_token_count"]
-                                   ?? attributes["gen_ai.usage.input_tokens"]
-                                   ?? attributes["prompt_token_count"])
-                let cached = anyInt(attributes["cached_content_token_count"]
-                                    ?? attributes["gen_ai.usage.cached_tokens"])
-                let output = anyInt(attributes["output_token_count"]
-                                    ?? attributes["gen_ai.usage.output_tokens"]
-                                    ?? attributes["candidates_token_count"])
-                if input == 0, cached == 0, output == 0 { return }
-                let timestamp = geminiTimestamp(raw) ?? fileMTimeFallback
-                let promptId = attributes["prompt_id"] as? String
-                    ?? attributes["gen_ai.prompt_id"] as? String
-                let sessionId = attributes["session.id"] as? String
-                    ?? attributes["session_id"] as? String
-                let inputNonCached = max(0, input - cached)
-                let parsedEvent = CostUsageScanCache.ParsedEvent(
-                    date: timestamp,
-                    model: model,
-                    input: inputNonCached,
-                    output: output,
-                    cache: cached,
-                    sessionId: sessionId,
-                    messageId: promptId
-                )
-                guard isRetained(parsedEvent.date, cutoff: cutoff) else { return }
-                parsed.append(parsedEvent)
-                let cost = CostUsagePricing.geminiCostUSD(
-                    model: model,
-                    inputTokens: input,
-                    cacheReadInputTokens: cached,
-                    outputTokens: output
-                ) ?? 0
-                aggregator.add(at: parsedEvent.date, model: parsedEvent.model,
-                               input: parsedEvent.input, output: parsedEvent.output,
-                               cache: parsedEvent.cache, costUSD: cost)
+            let isChatFile = file.path.contains("/chats/")
+            let parsed: [CostUsageScanCache.ParsedEvent]
+            let didRead: Bool
+            if isChatFile {
+                (parsed, didRead) = parseGeminiChatFile(file: file, cutoff: cutoff, aggregator: &aggregator)
+            } else {
+                (parsed, didRead) = parseGeminiTelemetryFile(file: file, now: now, cutoff: cutoff, aggregator: &aggregator)
             }
             if didRead {
                 cache.store(parsed, for: file.path, mtime: mtime, size: size)
             }
         }
-        cache.prune(known: Set(files.map(\.path)))
+        cache.prune(known: Set(allFiles.map(\.path)))
         cache.save(homeDirectory: homeDirectory, tool: .gemini)
-        return aggregator.snapshot(jsonlFilesFound: files.count)
+        return aggregator.snapshot(jsonlFilesFound: allFiles.count)
+    }
+
+    /// Parse the original Gemini CLI OpenTelemetry telemetry-log
+    /// format — `gemini_cli.api_response` events whose attributes
+    /// carry per-call token counts. Returns the cached events
+    /// (still subject to retention) plus a `didRead` bool the
+    /// caller uses to decide whether to update the per-file cache.
+    private static func parseGeminiTelemetryFile(
+        file: URL,
+        now: Date,
+        cutoff: Date?,
+        aggregator: inout CostAggregator
+    ) -> ([CostUsageScanCache.ParsedEvent], Bool) {
+        var parsed: [CostUsageScanCache.ParsedEvent] = []
+        let fileMTimeFallback = fileMTime(file) ?? now
+        let didRead = forEachJSONLLine(in: file) { lineData in
+            guard !lineData.isEmpty,
+                  lineData.contains(asciiSequence: "gemini_cli")
+            else { return }
+            guard let raw = (try? JSONSerialization.jsonObject(with: lineData)) as? [String: Any] else { return }
+            guard isGeminiApiResponse(raw) else { return }
+            let attributes = geminiAttributes(raw)
+            let model = (attributes["model"] as? String)
+                ?? (attributes["gen_ai.request.model"] as? String)
+                ?? (attributes["gen_ai.response.model"] as? String)
+                ?? "gemini-unknown"
+            let input = anyInt(attributes["input_token_count"]
+                               ?? attributes["gen_ai.usage.input_tokens"]
+                               ?? attributes["prompt_token_count"])
+            let cached = anyInt(attributes["cached_content_token_count"]
+                                ?? attributes["gen_ai.usage.cached_tokens"])
+            let output = anyInt(attributes["output_token_count"]
+                                ?? attributes["gen_ai.usage.output_tokens"]
+                                ?? attributes["candidates_token_count"])
+            if input == 0, cached == 0, output == 0 { return }
+            let timestamp = geminiTimestamp(raw) ?? fileMTimeFallback
+            let promptId = attributes["prompt_id"] as? String
+                ?? attributes["gen_ai.prompt_id"] as? String
+            let sessionId = attributes["session.id"] as? String
+                ?? attributes["session_id"] as? String
+            let inputNonCached = max(0, input - cached)
+            let parsedEvent = CostUsageScanCache.ParsedEvent(
+                date: timestamp,
+                model: model,
+                input: inputNonCached,
+                output: output,
+                cache: cached,
+                sessionId: sessionId,
+                messageId: promptId
+            )
+            guard isRetained(parsedEvent.date, cutoff: cutoff) else { return }
+            parsed.append(parsedEvent)
+            let cost = CostUsagePricing.geminiCostUSD(
+                model: model,
+                inputTokens: input,
+                cacheReadInputTokens: cached,
+                outputTokens: output
+            ) ?? 0
+            aggregator.add(at: parsedEvent.date, model: parsedEvent.model,
+                           input: parsedEvent.input, output: parsedEvent.output,
+                           cache: parsedEvent.cache, costUSD: cost)
+        }
+        return (parsed, didRead)
+    }
+
+    /// Parse a Gemini CLI chat-history JSONL file from
+    /// `~/.gemini/tmp/<project>/chats/session-*.jsonl`. Each line is
+    /// one chat message; the `type: "gemini"` records carry a
+    /// `tokens` object with `input` / `output` / `cached` / `thoughts`
+    /// / `tool` / `total`. This is the format AQ's installation uses
+    /// instead of the OpenTelemetry log; once a project enables
+    /// telemetry the OTLP path takes over again.
+    private static func parseGeminiChatFile(
+        file: URL,
+        cutoff: Date?,
+        aggregator: inout CostAggregator
+    ) -> ([CostUsageScanCache.ParsedEvent], Bool) {
+        var parsed: [CostUsageScanCache.ParsedEvent] = []
+        var sessionIdFromHeader: String? = nil
+        let didRead = forEachJSONLLine(in: file) { lineData in
+            guard !lineData.isEmpty,
+                  lineData.contains(asciiSequence: "\"tokens\"")
+                    || lineData.contains(asciiSequence: "\"sessionId\"")
+            else { return }
+            guard let raw = (try? JSONSerialization.jsonObject(with: lineData)) as? [String: Any] else { return }
+            if let sid = raw["sessionId"] as? String, sessionIdFromHeader == nil {
+                sessionIdFromHeader = sid
+            }
+            guard raw["type"] as? String == "gemini",
+                  let tokens = raw["tokens"] as? [String: Any]
+            else { return }
+            let model = (raw["model"] as? String) ?? "gemini-unknown"
+            let inputTotal = anyInt(tokens["input"])
+            let cached = anyInt(tokens["cached"])
+            let output = anyInt(tokens["output"])
+            let thoughts = anyInt(tokens["thoughts"])
+            let tool = anyInt(tokens["tool"])
+            if inputTotal == 0, cached == 0, output == 0, thoughts == 0, tool == 0 { return }
+            let timestamp = (raw["timestamp"] as? String).flatMap(parseISO)
+                ?? fileMTime(file) ?? Date()
+            let inputNonCached = max(0, inputTotal - cached)
+            // Gemini bills reasoning ("thoughts") and tool tokens at
+            // output rates, so fold them into output for cost — matches
+            // the CLI's own usage page totals.
+            let outputBilled = output + thoughts + tool
+            let parsedEvent = CostUsageScanCache.ParsedEvent(
+                date: timestamp,
+                model: model,
+                input: inputNonCached,
+                output: outputBilled,
+                cache: cached,
+                sessionId: sessionIdFromHeader,
+                messageId: raw["id"] as? String
+            )
+            guard isRetained(parsedEvent.date, cutoff: cutoff) else { return }
+            parsed.append(parsedEvent)
+            let cost = CostUsagePricing.geminiCostUSD(
+                model: model,
+                inputTokens: inputTotal,
+                cacheReadInputTokens: cached,
+                outputTokens: outputBilled
+            ) ?? 0
+            aggregator.add(at: parsedEvent.date, model: parsedEvent.model,
+                           input: parsedEvent.input, output: parsedEvent.output,
+                           cache: parsedEvent.cache, costUSD: cost)
+        }
+        return (parsed, didRead)
+    }
+
+    /// Gather all `~/.gemini/tmp/<project>/chats/session-*.jsonl`
+    /// files. Each chat file is one conversation; an installation
+    /// can have hundreds across multiple project hashes.
+    private static func geminiChatFileCandidates(homeDirectory: String) -> [URL] {
+        let tmp = URL(fileURLWithPath: homeDirectory)
+            .appendingPathComponent(".gemini/tmp")
+        guard let projects = try? FileManager.default.contentsOfDirectory(atPath: tmp.path) else {
+            return []
+        }
+        var out: [URL] = []
+        for project in projects {
+            let chats = tmp.appendingPathComponent(project).appendingPathComponent("chats")
+            guard let entries = try? FileManager.default.contentsOfDirectory(
+                at: chats,
+                includingPropertiesForKeys: [.isRegularFileKey, .isSymbolicLinkKey],
+                options: [.skipsHiddenFiles]
+            ) else { continue }
+            for url in entries
+            where url.pathExtension == "jsonl" && url.lastPathComponent.hasPrefix("session-")
+            {
+                let values = try? url.resourceValues(forKeys: [.isSymbolicLinkKey, .isRegularFileKey])
+                if values?.isSymbolicLink == true { continue }
+                if values?.isRegularFile == false { continue }
+                out.append(url)
+            }
+        }
+        return out
     }
 
     private static func geminiTelemetryFileCandidates(homeDirectory: String) -> [URL] {
@@ -459,6 +579,258 @@ public enum CostUsageScanner {
         return nil
     }
 
+    // MARK: - Grok (per-session updates.jsonl)
+    //
+    // Grok CLI stores each session as a directory under
+    // `~/.grok/sessions/<urlEncodedCwd>/<sessionUUID>/` and writes
+    // three JSONL streams (chat_history, events, updates). Per-call
+    // token counts are not exposed — what we get is a cumulative
+    // `_meta.totalTokens` on every `updates.jsonl` record, paired
+    // with an `_meta.agentTimestampMs`. Per-turn deltas of that
+    // running total tell us how many tokens the turn cost; the
+    // first row's value is the floor.
+    //
+    // We split each delta 70 / 30 between input and output before
+    // costing — Grok's pricing tables charge input and output at
+    // different rates and a session-total figure can't be billed
+    // precisely without the split. 70 / 30 is the rough chat-assistant
+    // average and lines up with how Grok's own dashboard summarises
+    // sessions.
+
+    private static func scanGrok(
+        homeDirectory: String,
+        now: Date,
+        retentionDays: Int?
+    ) async -> CostSnapshot {
+        let root = URL(fileURLWithPath: homeDirectory)
+            .appendingPathComponent(".grok/sessions")
+        let files = collectGrokUpdatesFiles(under: root)
+        var aggregator = CostAggregator(tool: .grok, now: now)
+        var cache = CostUsageScanCache.load(homeDirectory: homeDirectory, tool: .grok, retentionDays: retentionDays)
+        let cutoff = retentionCutoff(now: now, retentionDays: retentionDays)
+
+        for file in files {
+            let (mtime, size) = fileFingerprint(file)
+            if let cached = cache.reusable(for: file.path, mtime: mtime, size: size) {
+                let retained = retainedEvents(cached, cutoff: cutoff)
+                if retained.count != cached.count {
+                    cache.store(retained, for: file.path, mtime: mtime, size: size)
+                }
+                for event in retained {
+                    let cost = costUSD(tool: .grok, event: event)
+                    aggregator.add(at: event.date, model: event.model, input: event.input,
+                                   output: event.output, cache: event.cache, costUSD: cost)
+                }
+                continue
+            }
+
+            let raw = parseGrokUpdatesFile(file: file)
+            var parsed: [CostUsageScanCache.ParsedEvent] = []
+            parsed.reserveCapacity(raw.count)
+            var previousTotal: Int? = nil
+            for snapshot in raw {
+                let delta: Int
+                if let previousTotal {
+                    delta = max(0, snapshot.totalTokens - previousTotal)
+                } else {
+                    delta = max(0, snapshot.totalTokens)
+                }
+                previousTotal = snapshot.totalTokens
+                guard delta > 0 else { continue }
+                let inputTokens = Int((Double(delta) * 0.7).rounded())
+                let outputTokens = max(0, delta - inputTokens)
+                let parsedEvent = CostUsageScanCache.ParsedEvent(
+                    date: snapshot.date,
+                    model: snapshot.model,
+                    input: inputTokens,
+                    output: outputTokens,
+                    cache: 0,
+                    sessionId: snapshot.sessionId
+                )
+                guard isRetained(parsedEvent.date, cutoff: cutoff) else { continue }
+                parsed.append(parsedEvent)
+                let cost = costUSD(tool: .grok, event: parsedEvent)
+                aggregator.add(at: parsedEvent.date, model: parsedEvent.model,
+                               input: parsedEvent.input, output: parsedEvent.output,
+                               cache: parsedEvent.cache, costUSD: cost)
+            }
+            cache.store(parsed, for: file.path, mtime: mtime, size: size)
+        }
+        cache.prune(known: Set(files.map(\.path)))
+        cache.save(homeDirectory: homeDirectory, tool: .grok)
+        return aggregator.snapshot(jsonlFilesFound: files.count)
+    }
+
+    private struct GrokSnapshot {
+        let date: Date
+        let model: String
+        let totalTokens: Int
+        let sessionId: String?
+    }
+
+    private static func collectGrokUpdatesFiles(under root: URL) -> [URL] {
+        guard FileManager.default.fileExists(atPath: root.path) else { return [] }
+        guard let enumerator = FileManager.default.enumerator(
+            at: root,
+            includingPropertiesForKeys: [.isRegularFileKey, .isSymbolicLinkKey],
+            options: [.skipsHiddenFiles]
+        ) else { return [] }
+        var out: [URL] = []
+        for case let url as URL in enumerator
+        where url.lastPathComponent == "updates.jsonl"
+            || url.lastPathComponent == "events.jsonl"
+        {
+            let values = try? url.resourceValues(forKeys: [.isSymbolicLinkKey, .isRegularFileKey])
+            if values?.isSymbolicLink == true { continue }
+            if values?.isRegularFile == false { continue }
+            // Prefer updates.jsonl when both exist for the same session.
+            if url.lastPathComponent == "events.jsonl" {
+                let sibling = url.deletingLastPathComponent()
+                    .appendingPathComponent("updates.jsonl")
+                if FileManager.default.fileExists(atPath: sibling.path) { continue }
+            }
+            out.append(url)
+        }
+        return out
+    }
+
+    private static func parseGrokUpdatesFile(file: URL) -> [GrokSnapshot] {
+        var events: [GrokSnapshot] = []
+        let sessionId = file.deletingLastPathComponent().lastPathComponent
+        let didRead = forEachJSONLLine(in: file) { lineData in
+            guard !lineData.isEmpty,
+                  lineData.contains(asciiSequence: "totalTokens")
+            else { return }
+            guard let obj = (try? JSONSerialization.jsonObject(with: lineData)) as? [String: Any] else { return }
+            guard let meta = obj["_meta"] as? [String: Any] else { return }
+            let total = anyInt(meta["totalTokens"])
+            guard total >= 0 else { return }
+            let timestamp: Date
+            if let ms = meta["agentTimestampMs"] as? Double {
+                timestamp = Date(timeIntervalSince1970: ms / 1000)
+            } else if let ms = meta["agentTimestampMs"] as? Int {
+                timestamp = Date(timeIntervalSince1970: TimeInterval(ms) / 1000)
+            } else if let s = meta["agentTimestampMs"] as? String, let ms = Double(s) {
+                timestamp = Date(timeIntervalSince1970: ms / 1000)
+            } else if let iso = obj["timestamp"] as? String, let d = parseISO(iso) {
+                timestamp = d
+            } else {
+                timestamp = fileMTime(file) ?? Date()
+            }
+            events.append(GrokSnapshot(
+                date: timestamp,
+                model: "grok-build",
+                totalTokens: total,
+                sessionId: sessionId
+            ))
+        }
+        // Stable order: sessions written by Grok CLI are append-only but we
+        // still sort by timestamp to absorb out-of-order writes.
+        return didRead ? events.sorted { $0.date < $1.date } : []
+    }
+
+    // MARK: - AntiGravity (per-trajectory SQLite + protobuf blobs)
+    //
+    // The AntiGravity IDE writes one SQLite database per conversation
+    // under `~/.gemini/antigravity/conversations/<UUID>.db`. The
+    // `gen_metadata` table holds one row per model call; its `data`
+    // BLOB is a protobuf message we read with a raw varint scanner
+    // (no SwiftProtobuf dependency). Per-row token fields under path
+    // `1.4`:
+    //   - field 1: constant system-prompt size (cached after turn 1)
+    //   - field 2: non-cached input tokens this turn
+    //   - field 3: output tokens this turn
+    //   - field 5: cumulative cache-read pool size
+    //   - field 9: reasoning / thinking tokens (counted as output)
+    //   - field 10: tool tokens (counted as output)
+    // Timestamp lives at path `1.9.4` (seconds + nanos).
+    //
+    // The CLI-only `~/.gemini/antigravity-cli/conversations/*.pb`
+    // container uses an unidentified compressed format (magic bytes
+    // `4f fc 3f 34 …`) and stays unparsed — we accept that CLI-only
+    // AntiGravity usage is dark until that format is reverse-engineered.
+
+    private static func scanAntigravity(
+        homeDirectory: String,
+        now: Date,
+        retentionDays: Int?
+    ) async -> CostSnapshot {
+        let root = URL(fileURLWithPath: homeDirectory)
+            .appendingPathComponent(".gemini/antigravity/conversations")
+        let dbFiles = collectAntigravityConversationFiles(under: root)
+        var aggregator = CostAggregator(tool: .antigravity, now: now)
+        var cache = CostUsageScanCache.load(homeDirectory: homeDirectory, tool: .antigravity, retentionDays: retentionDays)
+        let cutoff = retentionCutoff(now: now, retentionDays: retentionDays)
+
+        for file in dbFiles {
+            let (mtime, size) = fileFingerprint(file)
+            if let cached = cache.reusable(for: file.path, mtime: mtime, size: size) {
+                let retained = retainedEvents(cached, cutoff: cutoff)
+                if retained.count != cached.count {
+                    cache.store(retained, for: file.path, mtime: mtime, size: size)
+                }
+                for event in retained {
+                    let cost = costUSD(tool: .antigravity, event: event)
+                    aggregator.add(at: event.date, model: event.model, input: event.input,
+                                   output: event.output, cache: event.cache, costUSD: cost)
+                }
+                continue
+            }
+
+            let turns = AntigravitySessionReader.readGenMetadata(at: file)
+            var parsed: [CostUsageScanCache.ParsedEvent] = []
+            parsed.reserveCapacity(turns.count)
+            var previousCacheCumulative = 0
+            let sessionId = file.deletingPathExtension().lastPathComponent
+            for turn in turns {
+                let cacheCreation = max(0, turn.cumulativeCacheReadTokens - previousCacheCumulative)
+                let cacheRead = max(0, previousCacheCumulative)
+                previousCacheCumulative = turn.cumulativeCacheReadTokens
+                let input = turn.inputTokens
+                // Reasoning + tool tokens are billed at output rates by
+                // Claude / Gemini, so fold them into output here.
+                let output = turn.outputTokens + turn.thoughtsTokens + turn.toolTokens
+                guard input > 0 || output > 0 || cacheRead > 0 || cacheCreation > 0 else { continue }
+                let parsedEvent = CostUsageScanCache.ParsedEvent(
+                    date: turn.date,
+                    model: "antigravity-default",
+                    input: input,
+                    output: output,
+                    cache: cacheRead + cacheCreation,
+                    cacheCreation: cacheCreation,
+                    sessionId: sessionId,
+                    messageId: turn.requestId
+                )
+                guard isRetained(parsedEvent.date, cutoff: cutoff) else { continue }
+                parsed.append(parsedEvent)
+                let cost = costUSD(tool: .antigravity, event: parsedEvent)
+                aggregator.add(at: parsedEvent.date, model: parsedEvent.model,
+                               input: parsedEvent.input, output: parsedEvent.output,
+                               cache: parsedEvent.cache, costUSD: cost)
+            }
+            cache.store(parsed, for: file.path, mtime: mtime, size: size)
+        }
+        cache.prune(known: Set(dbFiles.map(\.path)))
+        cache.save(homeDirectory: homeDirectory, tool: .antigravity)
+        return aggregator.snapshot(jsonlFilesFound: dbFiles.count)
+    }
+
+    private static func collectAntigravityConversationFiles(under root: URL) -> [URL] {
+        guard FileManager.default.fileExists(atPath: root.path) else { return [] }
+        guard let entries = try? FileManager.default.contentsOfDirectory(
+            at: root,
+            includingPropertiesForKeys: [.isRegularFileKey, .isSymbolicLinkKey],
+            options: [.skipsHiddenFiles]
+        ) else { return [] }
+        return entries.filter { url in
+            guard url.pathExtension == "db" else { return false }
+            let values = try? url.resourceValues(forKeys: [.isSymbolicLinkKey, .isRegularFileKey])
+            if values?.isSymbolicLink == true { return false }
+            if values?.isRegularFile == false { return false }
+            return true
+        }
+    }
+
     private static func retentionCutoff(now: Date, retentionDays: Int?) -> Date? {
         guard let retentionDays else { return nil }
         let normalized = CostDataSettings.normalizedRetentionDays(retentionDays)
@@ -507,7 +879,24 @@ public enum CostUsageScanner {
                 cacheReadInputTokens: event.cache,
                 outputTokens: event.output
             ) ?? 0
-        case .alibaba, .alibabaTokenPlan, .antigravity, .grok, .copilot, .zai, .minimax, .kimi, .cursor, .mimo, .iflytek, .tencentHunyuan, .tencentTokenPlan, .volcengine, .baiduQianfan, .openCodeGo, .kilo, .kiro, .ollama, .openRouter, .warp:
+        case .grok:
+            return CostUsagePricing.grokCostUSD(
+                model: event.model,
+                inputTokens: event.input + event.cache,
+                cachedInputTokens: event.cache,
+                outputTokens: event.output
+            ) ?? 0
+        case .antigravity:
+            let cacheCreation = max(0, event.cacheCreation ?? 0)
+            let cacheRead = max(0, event.cache - cacheCreation)
+            return CostUsagePricing.antigravityCostUSD(
+                model: event.model,
+                inputTokens: event.input,
+                cacheReadInputTokens: cacheRead,
+                cacheCreationInputTokens: cacheCreation,
+                outputTokens: event.output
+            ) ?? 0
+        case .alibaba, .alibabaTokenPlan, .copilot, .zai, .minimax, .kimi, .cursor, .mimo, .iflytek, .tencentHunyuan, .tencentTokenPlan, .volcengine, .baiduQianfan, .openCodeGo, .kilo, .kiro, .ollama, .openRouter, .warp:
             return 0
         }
     }

--- a/Sources/VibeBarCore/Services/PricingRefresher.swift
+++ b/Sources/VibeBarCore/Services/PricingRefresher.swift
@@ -1,0 +1,134 @@
+import Foundation
+
+/// Periodically pulls `pricing.json` from the canonical GitHub raw
+/// URL and writes it to `~/.vibebar/pricing_cache.json` so the
+/// `PricingResolver` picks up new model rates without a rebuild.
+///
+/// Refresh policy: best-effort, never blocking. The cache file's
+/// mtime gates whether a fresh fetch is worth attempting — the
+/// default 24-hour window keeps quiet machines off GitHub's rate
+/// limits without pinning to a stale snapshot for weeks. The remote
+/// fetch is HTTPS-only, size-capped (`PricingDataSet.maxBytes`), and
+/// schema-validated; any failure leaves the previous cache in place
+/// instead of replacing it with garbage.
+///
+/// Because `PricingResolver.cachedActive` snapshots on first read,
+/// a successful refresh only takes effect on the *next* app launch.
+/// That keeps cost calculations stable mid-process and avoids
+/// re-aggregating today's data with mid-flight rate changes.
+public enum PricingRefresher {
+    /// Bundled JSON is the floor; the remote pulls from the same
+    /// repository so updates ship by editing one file and merging.
+    public static let remoteURL = URL(
+        string: "https://raw.githubusercontent.com/AstroQore/vibe-bar/main/Sources/VibeBarCore/Resources/pricing.json"
+    )!
+
+    /// Minimum time between fetches — equivalent to "refresh at most
+    /// once per app session per day". Override in tests.
+    public static let defaultRefreshInterval: TimeInterval = 24 * 3600
+
+    /// Short network timeout — the resolver's already loaded a value
+    /// by the time this runs, so we shouldn't hold the run loop on a
+    /// hung GitHub edge node.
+    public static let defaultRequestTimeout: TimeInterval = 10
+
+    public enum Outcome: Equatable, Sendable {
+        case skippedFresh
+        case fetched
+        case unchanged
+        case networkFailure
+        case parseFailure
+        case schemaMismatch
+        case oversized
+    }
+
+    /// Refresh the on-disk cache if the existing copy is older than
+    /// `interval`. Pass `force: true` to bypass the freshness check
+    /// (used by tests and by an explicit user-triggered refresh).
+    @discardableResult
+    public static func refresh(
+        homeDirectory: String = RealHomeDirectory.path,
+        session: URLSession = .shared,
+        endpoint: URL = Self.remoteURL,
+        interval: TimeInterval = Self.defaultRefreshInterval,
+        requestTimeout: TimeInterval = Self.defaultRequestTimeout,
+        force: Bool = false,
+        now: Date = Date()
+    ) async -> Outcome {
+        let cacheURL = PricingResolver.cacheFileURL(homeDirectory: homeDirectory)
+
+        if !force,
+           let attrs = try? FileManager.default.attributesOfItem(atPath: cacheURL.path),
+           let modDate = attrs[.modificationDate] as? Date,
+           now.timeIntervalSince(modDate) < interval
+        {
+            return .skippedFresh
+        }
+
+        var request = URLRequest(url: endpoint)
+        request.httpMethod = "GET"
+        request.timeoutInterval = requestTimeout
+        request.setValue("VibeBar/pricing-refresh", forHTTPHeaderField: "User-Agent")
+        // Conditional GET: tell GitHub raw to short-circuit if the
+        // file hasn't changed since the cached copy.
+        if let attrs = try? FileManager.default.attributesOfItem(atPath: cacheURL.path),
+           let modDate = attrs[.modificationDate] as? Date
+        {
+            let formatter = DateFormatter()
+            formatter.locale = Locale(identifier: "en_US_POSIX")
+            formatter.timeZone = TimeZone(identifier: "GMT")
+            formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss 'GMT'"
+            request.setValue(formatter.string(from: modDate),
+                             forHTTPHeaderField: "If-Modified-Since")
+        }
+
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await session.data(for: request)
+        } catch {
+            SafeLog.warn("PricingRefresher network: \(SafeLog.sanitize(error.localizedDescription))")
+            return .networkFailure
+        }
+        guard let http = response as? HTTPURLResponse else { return .networkFailure }
+        if http.statusCode == 304 {
+            // Touch the cache mtime so the freshness window resets
+            // without rewriting identical bytes.
+            try? FileManager.default.setAttributes(
+                [.modificationDate: now],
+                ofItemAtPath: cacheURL.path
+            )
+            return .unchanged
+        }
+        guard http.statusCode == 200 else {
+            return .networkFailure
+        }
+        guard data.count > 0, data.count <= PricingDataSet.maxBytes else {
+            return .oversized
+        }
+        let decoded: PricingDataSet
+        do {
+            decoded = try JSONDecoder().decode(PricingDataSet.self, from: data)
+        } catch {
+            SafeLog.warn("PricingRefresher decode: \(SafeLog.sanitize(error.localizedDescription))")
+            return .parseFailure
+        }
+        guard decoded.schemaVersion == PricingDataSet.currentSchemaVersion else {
+            return .schemaMismatch
+        }
+
+        do {
+            let parent = cacheURL.deletingLastPathComponent()
+            try FileManager.default.createDirectory(at: parent, withIntermediateDirectories: true)
+            try data.write(to: cacheURL, options: .atomic)
+            try FileManager.default.setAttributes(
+                [.posixPermissions: NSNumber(value: Int16(0o600))],
+                ofItemAtPath: cacheURL.path
+            )
+        } catch {
+            SafeLog.warn("PricingRefresher cache write: \(SafeLog.sanitize(error.localizedDescription))")
+            return .networkFailure
+        }
+        return .fetched
+    }
+}

--- a/Sources/VibeBarCore/Vendored/CostUsage/CostUsagePricing.swift
+++ b/Sources/VibeBarCore/Vendored/CostUsage/CostUsagePricing.swift
@@ -9,7 +9,9 @@ public enum CostUsagePricing {
 
     /// Bump when local cost parsing or pricing semantics change in a way that
     /// makes persisted cost totals unsafe to max-merge with fresh scans.
-    public static let calculationVersion: Int = 4
+    /// v5: add Grok + AntiGravity adapters with their own pricing tables;
+    /// existing Codex / Claude / Gemini totals stay byte-identical.
+    public static let calculationVersion: Int = 5
 
     struct CodexPricing {
         let inputCostPerToken: Double
@@ -29,6 +31,25 @@ public enum CostUsagePricing {
         let inputCostPerTokenAboveThreshold: Double?
         let outputCostPerTokenAboveThreshold: Double?
         let cacheReadInputCostPerTokenAboveThreshold: Double?
+        let displayLabel: String?
+    }
+
+    struct GrokPricing {
+        let inputCostPerToken: Double
+        let outputCostPerToken: Double
+        let cacheReadInputCostPerToken: Double?
+        let displayLabel: String?
+    }
+
+    struct AntigravityPricing {
+        let inputCostPerToken: Double
+        let outputCostPerToken: Double
+        /// AntiGravity bills by plan quota, not per-token. These rates
+        /// shadow the corresponding upstream model (Sonnet, Opus,
+        /// Gemini Pro, etc.) so the dollar number is interpretable as
+        /// "the API-equivalent of this session would have cost ~$X".
+        let cacheReadInputCostPerToken: Double
+        let cacheCreationInputCostPerToken: Double
         let displayLabel: String?
     }
 
@@ -354,6 +375,151 @@ public enum CostUsagePricing {
             displayLabel: nil)
     ]
 
+    /// xAI Grok API pricing, USD per token, as of `pricingDataUpdatedAt`.
+    /// Source: docs.x.ai/docs/models and pricepertoken.com cross-checks.
+    /// Cached-input rates that aren't published explicitly stay `nil`
+    /// and fall back to the regular input rate in `grokCostUSD`.
+    private static let grok: [String: GrokPricing] = [
+        "grok-build": GrokPricing(
+            inputCostPerToken: 1e-6,
+            outputCostPerToken: 2e-6,
+            cacheReadInputCostPerToken: nil,
+            displayLabel: nil),
+        "grok-build-0.1": GrokPricing(
+            inputCostPerToken: 1e-6,
+            outputCostPerToken: 2e-6,
+            cacheReadInputCostPerToken: nil,
+            displayLabel: nil),
+        "grok-4": GrokPricing(
+            inputCostPerToken: 3e-6,
+            outputCostPerToken: 1.5e-5,
+            cacheReadInputCostPerToken: 7.5e-7,
+            displayLabel: nil),
+        "grok-4-fast": GrokPricing(
+            inputCostPerToken: 2e-7,
+            outputCostPerToken: 5e-7,
+            cacheReadInputCostPerToken: 5e-8,
+            displayLabel: nil),
+        "grok-4.1-fast": GrokPricing(
+            inputCostPerToken: 2e-7,
+            outputCostPerToken: 5e-7,
+            cacheReadInputCostPerToken: 5e-8,
+            displayLabel: nil),
+        "grok-4.3": GrokPricing(
+            inputCostPerToken: 1.25e-6,
+            outputCostPerToken: 2.5e-6,
+            cacheReadInputCostPerToken: 3.1e-7,
+            displayLabel: nil),
+        "grok-4.20": GrokPricing(
+            inputCostPerToken: 2e-6,
+            outputCostPerToken: 6e-6,
+            cacheReadInputCostPerToken: 2e-7,
+            displayLabel: nil),
+        "grok-3": GrokPricing(
+            inputCostPerToken: 3e-6,
+            outputCostPerToken: 1.5e-5,
+            cacheReadInputCostPerToken: 7.5e-7,
+            displayLabel: nil),
+        "grok-3-mini": GrokPricing(
+            inputCostPerToken: 3e-7,
+            outputCostPerToken: 5e-7,
+            cacheReadInputCostPerToken: 7.5e-8,
+            displayLabel: nil),
+        "grok-code-fast-1": GrokPricing(
+            inputCostPerToken: 2e-7,
+            outputCostPerToken: 1.5e-6,
+            cacheReadInputCostPerToken: 2e-8,
+            displayLabel: nil)
+    ]
+
+    /// AntiGravity is a managed product, not a pay-per-token API.
+    /// These rates shadow Claude Sonnet 4.6 (the default) / Opus /
+    /// Haiku / Gemini Pro / Gemini Flash so the dollar number is
+    /// interpretable as "if this session had hit the API directly,
+    /// it would have cost approximately $X". The `-default` key is
+    /// the fallback when the scanner can't pin the underlying model.
+    private static let antigravity: [String: AntigravityPricing] = [
+        "antigravity-default": AntigravityPricing(
+            inputCostPerToken: 3e-6,
+            outputCostPerToken: 1.5e-5,
+            cacheReadInputCostPerToken: 3e-7,
+            cacheCreationInputCostPerToken: 3.75e-6,
+            displayLabel: "Sonnet-rate est."),
+        "antigravity-claude-sonnet": AntigravityPricing(
+            inputCostPerToken: 3e-6,
+            outputCostPerToken: 1.5e-5,
+            cacheReadInputCostPerToken: 3e-7,
+            cacheCreationInputCostPerToken: 3.75e-6,
+            displayLabel: nil),
+        "antigravity-claude-opus": AntigravityPricing(
+            inputCostPerToken: 5e-6,
+            outputCostPerToken: 2.5e-5,
+            cacheReadInputCostPerToken: 5e-7,
+            cacheCreationInputCostPerToken: 6.25e-6,
+            displayLabel: nil),
+        "antigravity-claude-haiku": AntigravityPricing(
+            inputCostPerToken: 1e-6,
+            outputCostPerToken: 5e-6,
+            cacheReadInputCostPerToken: 1e-7,
+            cacheCreationInputCostPerToken: 1.25e-6,
+            displayLabel: nil),
+        "antigravity-gemini-pro": AntigravityPricing(
+            inputCostPerToken: 1.25e-6,
+            outputCostPerToken: 1e-5,
+            cacheReadInputCostPerToken: 3.1e-7,
+            cacheCreationInputCostPerToken: 0,
+            displayLabel: nil),
+        "antigravity-gemini-flash": AntigravityPricing(
+            inputCostPerToken: 3e-7,
+            outputCostPerToken: 2.5e-6,
+            cacheReadInputCostPerToken: 7.5e-8,
+            cacheCreationInputCostPerToken: 0,
+            displayLabel: nil)
+    ]
+
+    static func normalizeGrokModel(_ raw: String) -> String {
+        var trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        if trimmed.hasPrefix("xai/") {
+            trimmed = String(trimmed.dropFirst("xai/".count))
+        }
+        if self.grok[trimmed] != nil { return trimmed }
+        if let datedRange = trimmed.range(of: #"-(beta|preview|\d{4}-\d{2}-\d{2}|\d{4}-\d{2})$"#, options: .regularExpression) {
+            let base = String(trimmed[..<datedRange.lowerBound])
+            if self.grok[base] != nil { return base }
+        }
+        let segments = trimmed.split(separator: "-")
+        for end in stride(from: segments.count, through: 1, by: -1) {
+            let candidate = segments.prefix(end).joined(separator: "-")
+            if self.grok[candidate] != nil { return candidate }
+        }
+        return trimmed
+    }
+
+    static func grokDisplayLabel(model: String) -> String? {
+        self.grok[self.normalizeGrokModel(model)]?.displayLabel
+    }
+
+    static func normalizeAntigravityModel(_ raw: String) -> String {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        if self.antigravity[trimmed] != nil { return trimmed }
+        if trimmed.contains("opus") { return "antigravity-claude-opus" }
+        if trimmed.contains("haiku") { return "antigravity-claude-haiku" }
+        if trimmed.contains("sonnet") || trimmed.contains("claude") {
+            return "antigravity-claude-sonnet"
+        }
+        if trimmed.contains("flash-lite") || trimmed.contains("flash") {
+            return "antigravity-gemini-flash"
+        }
+        if trimmed.contains("pro") || trimmed.contains("gemini") {
+            return "antigravity-gemini-pro"
+        }
+        return "antigravity-default"
+    }
+
+    static func antigravityDisplayLabel(model: String) -> String? {
+        self.antigravity[self.normalizeAntigravityModel(model)]?.displayLabel
+    }
+
     static func normalizeGeminiModel(_ raw: String) -> String {
         var trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         // Drop the common `models/` prefix used by the Gemini API.
@@ -498,6 +664,48 @@ public enum CostUsagePricing {
                    base: pricing.outputCostPerToken,
                    above: pricing.outputCostPerTokenAboveThreshold,
                    threshold: pricing.thresholdTokens)
+    }
+
+    /// Compute USD cost for a Grok call. xAI publishes per-model input
+    /// and output rates; cached-input is sometimes ~10% of input on
+    /// newer models. The caller passes pre-split tokens — when the
+    /// upstream source only has a session-level total, the Grok
+    /// scanner splits it ~70 / 30 input vs output before calling us.
+    /// Returns `nil` for unknown models.
+    static func grokCostUSD(
+        model: String,
+        inputTokens: Int,
+        cachedInputTokens: Int,
+        outputTokens: Int
+    ) -> Double? {
+        let key = self.normalizeGrokModel(model)
+        guard let pricing = self.grok[key] else { return nil }
+        let cached = min(max(0, cachedInputTokens), max(0, inputTokens))
+        let nonCached = max(0, inputTokens - cached)
+        let cachedRate = pricing.cacheReadInputCostPerToken ?? pricing.inputCostPerToken
+        return Double(nonCached) * pricing.inputCostPerToken
+            + Double(cached) * cachedRate
+            + Double(max(0, outputTokens)) * pricing.outputCostPerToken
+    }
+
+    /// Compute USD cost for an AntiGravity-mediated call. AntiGravity
+    /// bills by plan quota, so this number is an "if this same volume
+    /// hit the underlying API directly" estimate, not a real invoice
+    /// figure. Default key (`antigravity-default`) shadows Claude
+    /// Sonnet 4.6 rates.
+    static func antigravityCostUSD(
+        model: String,
+        inputTokens: Int,
+        cacheReadInputTokens: Int,
+        cacheCreationInputTokens: Int,
+        outputTokens: Int
+    ) -> Double? {
+        let key = self.normalizeAntigravityModel(model)
+        guard let pricing = self.antigravity[key] else { return nil }
+        return Double(max(0, inputTokens)) * pricing.inputCostPerToken
+            + Double(max(0, cacheReadInputTokens)) * pricing.cacheReadInputCostPerToken
+            + Double(max(0, cacheCreationInputTokens)) * pricing.cacheCreationInputCostPerToken
+            + Double(max(0, outputTokens)) * pricing.outputCostPerToken
     }
 
     static func claudeCostUSD(

--- a/Sources/VibeBarCore/Vendored/CostUsage/CostUsagePricing.swift
+++ b/Sources/VibeBarCore/Vendored/CostUsage/CostUsagePricing.swift
@@ -1,507 +1,247 @@
 import Foundation
 
-// Vendored pricing data — pure data, no external dependencies.
-// USD per token. Update `pricingDataUpdatedAt` whenever the rate tables change
-// so users can see freshness in Settings.
+/// Thin facade over `PricingResolver.active`. The price tables
+/// themselves live in `Resources/pricing.json` (bundled), an
+/// optional cache at `~/.vibebar/pricing_cache.json` (refreshed by
+/// `PricingRefresher`), and `PricingHardcoded.fallback` (used when
+/// neither file is loadable — e.g. tests, or a corrupt cache).
+///
+/// Function signatures and return semantics are preserved verbatim
+/// from the earlier hardcoded-dict implementation so every caller
+/// (CostUsageScanner, the cost UI surfaces, tests) keeps working
+/// without modification.
 public enum CostUsagePricing {
-    /// ISO date the pricing tables were last refreshed against upstream provider docs.
-    public static let pricingDataUpdatedAt: String = "2026-05-22"
-
-    /// Bump when local cost parsing or pricing semantics change in a way that
-    /// makes persisted cost totals unsafe to max-merge with fresh scans.
-    /// v5: add Grok + AntiGravity adapters with their own pricing tables;
-    /// existing Codex / Claude / Gemini totals stay byte-identical.
-    public static let calculationVersion: Int = 5
-
-    struct CodexPricing {
-        let inputCostPerToken: Double
-        let outputCostPerToken: Double
-        let cacheReadInputCostPerToken: Double?
-        let displayLabel: String?
+    /// ISO date the pricing tables were last refreshed against
+    /// upstream provider docs. Reflects the *currently loaded* data
+    /// set (cache → bundle → hardcoded), so a stale cache is visible
+    /// in Settings as a stale date.
+    public static var pricingDataUpdatedAt: String {
+        PricingResolver.active.updatedAt
     }
 
-    struct GeminiPricing {
-        let inputCostPerToken: Double
-        let outputCostPerToken: Double
-        let cacheReadInputCostPerToken: Double?
-        /// Tiered: when total input tokens exceed `thresholdTokens`, rates
-        /// flip to the `*AboveThreshold` values. Gemini 2.5 Pro & Pro
-        /// Preview have a 200K threshold; smaller / earlier models are flat.
-        let thresholdTokens: Int?
-        let inputCostPerTokenAboveThreshold: Double?
-        let outputCostPerTokenAboveThreshold: Double?
-        let cacheReadInputCostPerTokenAboveThreshold: Double?
-        let displayLabel: String?
+    /// Bump in `Resources/pricing.json` (and `PricingHardcoded`) when
+    /// cost parsing or pricing semantics change in a way that makes
+    /// persisted cost totals unsafe to max-merge with fresh scans.
+    public static var calculationVersion: Int {
+        PricingResolver.active.calculationVersion
     }
 
-    struct GrokPricing {
-        let inputCostPerToken: Double
-        let outputCostPerToken: Double
-        let cacheReadInputCostPerToken: Double?
-        let displayLabel: String?
+    // MARK: - Codex
+
+    static func normalizeCodexModel(_ raw: String) -> String {
+        let codex = PricingResolver.active.providers.codex.models
+        var trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.hasPrefix("openai/") {
+            trimmed = String(trimmed.dropFirst("openai/".count))
+        }
+        if codex[trimmed] != nil { return trimmed }
+        if let datedSuffix = trimmed.range(of: #"-\d{4}-\d{2}-\d{2}$"#, options: .regularExpression) {
+            let base = String(trimmed[..<datedSuffix.lowerBound])
+            if codex[base] != nil { return base }
+        }
+        return trimmed
     }
 
-    struct AntigravityPricing {
-        let inputCostPerToken: Double
-        let outputCostPerToken: Double
-        /// AntiGravity bills by plan quota, not per-token. These rates
-        /// shadow the corresponding upstream model (Sonnet, Opus,
-        /// Gemini Pro, etc.) so the dollar number is interpretable as
-        /// "the API-equivalent of this session would have cost ~$X".
-        let cacheReadInputCostPerToken: Double
-        let cacheCreationInputCostPerToken: Double
-        let displayLabel: String?
+    static func codexDisplayLabel(model: String) -> String? {
+        let codex = PricingResolver.active.providers.codex.models
+        return codex[normalizeCodexModel(model)]?.displayLabel
     }
 
-    struct ClaudePricing {
-        let inputCostPerToken: Double
-        let outputCostPerToken: Double
-        let cacheCreationInputCostPerToken: Double
-        let cacheReadInputCostPerToken: Double
-
-        let thresholdTokens: Int?
-        let inputCostPerTokenAboveThreshold: Double?
-        let outputCostPerTokenAboveThreshold: Double?
-        let cacheCreationInputCostPerTokenAboveThreshold: Double?
-        let cacheReadInputCostPerTokenAboveThreshold: Double?
+    static func codexCostUSD(
+        model: String,
+        inputTokens: Int,
+        cachedInputTokens: Int,
+        outputTokens: Int
+    ) -> Double? {
+        let codex = PricingResolver.active.providers.codex.models
+        guard let pricing = codex[normalizeCodexModel(model)] else { return nil }
+        let cached = min(max(0, cachedInputTokens), max(0, inputTokens))
+        let nonCached = max(0, inputTokens - cached)
+        let cachedRate = pricing.cacheRead ?? pricing.input
+        return Double(nonCached) * pricing.input
+            + Double(cached) * cachedRate
+            + Double(max(0, outputTokens)) * pricing.output
     }
 
-    private static let codex: [String: CodexPricing] = [
-        "gpt-5": CodexPricing(
-            inputCostPerToken: 1.25e-6,
-            outputCostPerToken: 1e-5,
-            cacheReadInputCostPerToken: 1.25e-7,
-            displayLabel: nil),
-        "gpt-5-codex": CodexPricing(
-            inputCostPerToken: 1.25e-6,
-            outputCostPerToken: 1e-5,
-            cacheReadInputCostPerToken: 1.25e-7,
-            displayLabel: nil),
-        "gpt-5-mini": CodexPricing(
-            inputCostPerToken: 2.5e-7,
-            outputCostPerToken: 2e-6,
-            cacheReadInputCostPerToken: 2.5e-8,
-            displayLabel: nil),
-        "gpt-5-nano": CodexPricing(
-            inputCostPerToken: 5e-8,
-            outputCostPerToken: 4e-7,
-            cacheReadInputCostPerToken: 5e-9,
-            displayLabel: nil),
-        "gpt-5-pro": CodexPricing(
-            inputCostPerToken: 1.5e-5,
-            outputCostPerToken: 1.2e-4,
-            cacheReadInputCostPerToken: nil,
-            displayLabel: nil),
-        "gpt-5.1": CodexPricing(
-            inputCostPerToken: 1.25e-6,
-            outputCostPerToken: 1e-5,
-            cacheReadInputCostPerToken: 1.25e-7,
-            displayLabel: nil),
-        "gpt-5.1-codex": CodexPricing(
-            inputCostPerToken: 1.25e-6,
-            outputCostPerToken: 1e-5,
-            cacheReadInputCostPerToken: 1.25e-7,
-            displayLabel: nil),
-        "gpt-5.1-codex-max": CodexPricing(
-            inputCostPerToken: 1.25e-6,
-            outputCostPerToken: 1e-5,
-            cacheReadInputCostPerToken: 1.25e-7,
-            displayLabel: nil),
-        "gpt-5.1-codex-mini": CodexPricing(
-            inputCostPerToken: 2.5e-7,
-            outputCostPerToken: 2e-6,
-            cacheReadInputCostPerToken: 2.5e-8,
-            displayLabel: nil),
-        "gpt-5.2": CodexPricing(
-            inputCostPerToken: 1.75e-6,
-            outputCostPerToken: 1.4e-5,
-            cacheReadInputCostPerToken: 1.75e-7,
-            displayLabel: nil),
-        "gpt-5.2-codex": CodexPricing(
-            inputCostPerToken: 1.75e-6,
-            outputCostPerToken: 1.4e-5,
-            cacheReadInputCostPerToken: 1.75e-7,
-            displayLabel: nil),
-        "gpt-5.2-pro": CodexPricing(
-            inputCostPerToken: 2.1e-5,
-            outputCostPerToken: 1.68e-4,
-            cacheReadInputCostPerToken: nil,
-            displayLabel: nil),
-        "gpt-5.3-codex": CodexPricing(
-            inputCostPerToken: 1.75e-6,
-            outputCostPerToken: 1.4e-5,
-            cacheReadInputCostPerToken: 1.75e-7,
-            displayLabel: nil),
-        "gpt-5.3-codex-spark": CodexPricing(
-            inputCostPerToken: 0,
-            outputCostPerToken: 0,
-            cacheReadInputCostPerToken: 0,
-            displayLabel: "Research Preview"),
-        "gpt-5.4": CodexPricing(
-            inputCostPerToken: 2.5e-6,
-            outputCostPerToken: 1.5e-5,
-            cacheReadInputCostPerToken: 2.5e-7,
-            displayLabel: nil),
-        "gpt-5.4-mini": CodexPricing(
-            inputCostPerToken: 7.5e-7,
-            outputCostPerToken: 4.5e-6,
-            cacheReadInputCostPerToken: 7.5e-8,
-            displayLabel: nil),
-        "gpt-5.4-nano": CodexPricing(
-            inputCostPerToken: 2e-7,
-            outputCostPerToken: 1.25e-6,
-            cacheReadInputCostPerToken: 2e-8,
-            displayLabel: nil),
-        "gpt-5.4-pro": CodexPricing(
-            inputCostPerToken: 3e-5,
-            outputCostPerToken: 1.8e-4,
-            cacheReadInputCostPerToken: nil,
-            displayLabel: nil),
-        "gpt-5.5": CodexPricing(
-            inputCostPerToken: 5e-6,
-            outputCostPerToken: 3e-5,
-            cacheReadInputCostPerToken: 5e-7,
-            displayLabel: nil),
-        "gpt-5.5-pro": CodexPricing(
-            inputCostPerToken: 3e-5,
-            outputCostPerToken: 1.8e-4,
-            cacheReadInputCostPerToken: nil,
-            displayLabel: nil),
-    ]
+    // MARK: - Claude
 
-    private static let claude: [String: ClaudePricing] = [
-        "claude-haiku-4-5-20251001": ClaudePricing(
-            inputCostPerToken: 1e-6,
-            outputCostPerToken: 5e-6,
-            cacheCreationInputCostPerToken: 1.25e-6,
-            cacheReadInputCostPerToken: 1e-7,
-            thresholdTokens: nil,
-            inputCostPerTokenAboveThreshold: nil,
-            outputCostPerTokenAboveThreshold: nil,
-            cacheCreationInputCostPerTokenAboveThreshold: nil,
-            cacheReadInputCostPerTokenAboveThreshold: nil),
-        "claude-haiku-4-5": ClaudePricing(
-            inputCostPerToken: 1e-6,
-            outputCostPerToken: 5e-6,
-            cacheCreationInputCostPerToken: 1.25e-6,
-            cacheReadInputCostPerToken: 1e-7,
-            thresholdTokens: nil,
-            inputCostPerTokenAboveThreshold: nil,
-            outputCostPerTokenAboveThreshold: nil,
-            cacheCreationInputCostPerTokenAboveThreshold: nil,
-            cacheReadInputCostPerTokenAboveThreshold: nil),
-        "claude-opus-4-5-20251101": ClaudePricing(
-            inputCostPerToken: 5e-6,
-            outputCostPerToken: 2.5e-5,
-            cacheCreationInputCostPerToken: 6.25e-6,
-            cacheReadInputCostPerToken: 5e-7,
-            thresholdTokens: nil,
-            inputCostPerTokenAboveThreshold: nil,
-            outputCostPerTokenAboveThreshold: nil,
-            cacheCreationInputCostPerTokenAboveThreshold: nil,
-            cacheReadInputCostPerTokenAboveThreshold: nil),
-        "claude-opus-4-5": ClaudePricing(
-            inputCostPerToken: 5e-6,
-            outputCostPerToken: 2.5e-5,
-            cacheCreationInputCostPerToken: 6.25e-6,
-            cacheReadInputCostPerToken: 5e-7,
-            thresholdTokens: nil,
-            inputCostPerTokenAboveThreshold: nil,
-            outputCostPerTokenAboveThreshold: nil,
-            cacheCreationInputCostPerTokenAboveThreshold: nil,
-            cacheReadInputCostPerTokenAboveThreshold: nil),
-        "claude-opus-4-6-20260205": ClaudePricing(
-            inputCostPerToken: 5e-6,
-            outputCostPerToken: 2.5e-5,
-            cacheCreationInputCostPerToken: 6.25e-6,
-            cacheReadInputCostPerToken: 5e-7,
-            thresholdTokens: nil,
-            inputCostPerTokenAboveThreshold: nil,
-            outputCostPerTokenAboveThreshold: nil,
-            cacheCreationInputCostPerTokenAboveThreshold: nil,
-            cacheReadInputCostPerTokenAboveThreshold: nil),
-        "claude-opus-4-6": ClaudePricing(
-            inputCostPerToken: 5e-6,
-            outputCostPerToken: 2.5e-5,
-            cacheCreationInputCostPerToken: 6.25e-6,
-            cacheReadInputCostPerToken: 5e-7,
-            thresholdTokens: nil,
-            inputCostPerTokenAboveThreshold: nil,
-            outputCostPerTokenAboveThreshold: nil,
-            cacheCreationInputCostPerTokenAboveThreshold: nil,
-            cacheReadInputCostPerTokenAboveThreshold: nil),
-        "claude-opus-4-7": ClaudePricing(
-            inputCostPerToken: 5e-6,
-            outputCostPerToken: 2.5e-5,
-            cacheCreationInputCostPerToken: 6.25e-6,
-            cacheReadInputCostPerToken: 5e-7,
-            thresholdTokens: nil,
-            inputCostPerTokenAboveThreshold: nil,
-            outputCostPerTokenAboveThreshold: nil,
-            cacheCreationInputCostPerTokenAboveThreshold: nil,
-            cacheReadInputCostPerTokenAboveThreshold: nil),
-        "claude-sonnet-4-5": ClaudePricing(
-            inputCostPerToken: 3e-6,
-            outputCostPerToken: 1.5e-5,
-            cacheCreationInputCostPerToken: 3.75e-6,
-            cacheReadInputCostPerToken: 3e-7,
-            thresholdTokens: 200_000,
-            inputCostPerTokenAboveThreshold: 6e-6,
-            outputCostPerTokenAboveThreshold: 2.25e-5,
-            cacheCreationInputCostPerTokenAboveThreshold: 7.5e-6,
-            cacheReadInputCostPerTokenAboveThreshold: 6e-7),
-        "claude-sonnet-4-6": ClaudePricing(
-            inputCostPerToken: 3e-6,
-            outputCostPerToken: 1.5e-5,
-            cacheCreationInputCostPerToken: 3.75e-6,
-            cacheReadInputCostPerToken: 3e-7,
-            thresholdTokens: nil,
-            inputCostPerTokenAboveThreshold: nil,
-            outputCostPerTokenAboveThreshold: nil,
-            cacheCreationInputCostPerTokenAboveThreshold: nil,
-            cacheReadInputCostPerTokenAboveThreshold: nil),
-        "claude-sonnet-4-5-20250929": ClaudePricing(
-            inputCostPerToken: 3e-6,
-            outputCostPerToken: 1.5e-5,
-            cacheCreationInputCostPerToken: 3.75e-6,
-            cacheReadInputCostPerToken: 3e-7,
-            thresholdTokens: 200_000,
-            inputCostPerTokenAboveThreshold: 6e-6,
-            outputCostPerTokenAboveThreshold: 2.25e-5,
-            cacheCreationInputCostPerTokenAboveThreshold: 7.5e-6,
-            cacheReadInputCostPerTokenAboveThreshold: 6e-7),
-        "claude-opus-4-20250514": ClaudePricing(
-            inputCostPerToken: 1.5e-5,
-            outputCostPerToken: 7.5e-5,
-            cacheCreationInputCostPerToken: 1.875e-5,
-            cacheReadInputCostPerToken: 1.5e-6,
-            thresholdTokens: nil,
-            inputCostPerTokenAboveThreshold: nil,
-            outputCostPerTokenAboveThreshold: nil,
-            cacheCreationInputCostPerTokenAboveThreshold: nil,
-            cacheReadInputCostPerTokenAboveThreshold: nil),
-        "claude-opus-4-1": ClaudePricing(
-            inputCostPerToken: 1.5e-5,
-            outputCostPerToken: 7.5e-5,
-            cacheCreationInputCostPerToken: 1.875e-5,
-            cacheReadInputCostPerToken: 1.5e-6,
-            thresholdTokens: nil,
-            inputCostPerTokenAboveThreshold: nil,
-            outputCostPerTokenAboveThreshold: nil,
-            cacheCreationInputCostPerTokenAboveThreshold: nil,
-            cacheReadInputCostPerTokenAboveThreshold: nil),
-        "claude-sonnet-4-20250514": ClaudePricing(
-            inputCostPerToken: 3e-6,
-            outputCostPerToken: 1.5e-5,
-            cacheCreationInputCostPerToken: 3.75e-6,
-            cacheReadInputCostPerToken: 3e-7,
-            thresholdTokens: 200_000,
-            inputCostPerTokenAboveThreshold: 6e-6,
-            outputCostPerTokenAboveThreshold: 2.25e-5,
-            cacheCreationInputCostPerTokenAboveThreshold: 7.5e-6,
-            cacheReadInputCostPerTokenAboveThreshold: 6e-7),
-    ]
+    static func normalizeClaudeModel(_ raw: String) -> String {
+        let claude = PricingResolver.active.providers.claude.models
+        var trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.hasPrefix("anthropic.") {
+            trimmed = String(trimmed.dropFirst("anthropic.".count))
+        }
+        if let lastDot = trimmed.lastIndex(of: "."),
+           trimmed.contains("claude-")
+        {
+            let tail = String(trimmed[trimmed.index(after: lastDot)...])
+            if tail.hasPrefix("claude-") {
+                trimmed = tail
+            }
+        }
+        if let vRange = trimmed.range(of: #"-v\d+:\d+$"#, options: .regularExpression) {
+            trimmed.removeSubrange(vRange)
+        }
+        if let baseRange = trimmed.range(of: #"-\d{8}$"#, options: .regularExpression) {
+            let base = String(trimmed[..<baseRange.lowerBound])
+            if claude[base] != nil { return base }
+        }
+        return trimmed
+    }
 
-    /// Gemini API pricing, USD per token, as of `pricingDataUpdatedAt`.
-    /// Source: ai.google.dev/gemini-api/docs/pricing. Free-tier rows
-    /// have zero cost so the cost chart stays at $0 for AI-Studio-only
-    /// users. Paid tier rates are tiered for Pro models (≤200K and
-    /// >200K input-token prompts use different rates).
-    private static let gemini: [String: GeminiPricing] = [
-        // === Gemini 2.5 family ===
-        "gemini-2.5-pro": GeminiPricing(
-            inputCostPerToken: 1.25e-6,
-            outputCostPerToken: 1e-5,
-            cacheReadInputCostPerToken: 3.1e-7,
-            thresholdTokens: 200_000,
-            inputCostPerTokenAboveThreshold: 2.5e-6,
-            outputCostPerTokenAboveThreshold: 1.5e-5,
-            cacheReadInputCostPerTokenAboveThreshold: 6.25e-7,
-            displayLabel: nil),
-        "gemini-2.5-flash": GeminiPricing(
-            inputCostPerToken: 3e-7,
-            outputCostPerToken: 2.5e-6,
-            cacheReadInputCostPerToken: 7.5e-8,
-            thresholdTokens: nil,
-            inputCostPerTokenAboveThreshold: nil,
-            outputCostPerTokenAboveThreshold: nil,
-            cacheReadInputCostPerTokenAboveThreshold: nil,
-            displayLabel: nil),
-        "gemini-2.5-flash-lite": GeminiPricing(
-            inputCostPerToken: 1e-7,
-            outputCostPerToken: 4e-7,
-            cacheReadInputCostPerToken: 2.5e-8,
-            thresholdTokens: nil,
-            inputCostPerTokenAboveThreshold: nil,
-            outputCostPerTokenAboveThreshold: nil,
-            cacheReadInputCostPerTokenAboveThreshold: nil,
-            displayLabel: nil),
-        // === Gemini 3 family (post-I/O 2026) ===
-        "gemini-3-pro": GeminiPricing(
-            inputCostPerToken: 2e-6,
-            outputCostPerToken: 1.2e-5,
-            cacheReadInputCostPerToken: 5e-7,
-            thresholdTokens: 200_000,
-            inputCostPerTokenAboveThreshold: 4e-6,
-            outputCostPerTokenAboveThreshold: 1.8e-5,
-            cacheReadInputCostPerTokenAboveThreshold: 1e-6,
-            displayLabel: nil),
-        "gemini-3-pro-preview": GeminiPricing(
-            inputCostPerToken: 2e-6,
-            outputCostPerToken: 1.2e-5,
-            cacheReadInputCostPerToken: 5e-7,
-            thresholdTokens: 200_000,
-            inputCostPerTokenAboveThreshold: 4e-6,
-            outputCostPerTokenAboveThreshold: 1.8e-5,
-            cacheReadInputCostPerTokenAboveThreshold: 1e-6,
-            displayLabel: nil),
-        "gemini-3-flash": GeminiPricing(
-            inputCostPerToken: 3.5e-7,
-            outputCostPerToken: 2.8e-6,
-            cacheReadInputCostPerToken: 8.75e-8,
-            thresholdTokens: nil,
-            inputCostPerTokenAboveThreshold: nil,
-            outputCostPerTokenAboveThreshold: nil,
-            cacheReadInputCostPerTokenAboveThreshold: nil,
-            displayLabel: nil),
-        "gemini-3-flash-lite": GeminiPricing(
-            inputCostPerToken: 1.25e-7,
-            outputCostPerToken: 5e-7,
-            cacheReadInputCostPerToken: 3.1e-8,
-            thresholdTokens: nil,
-            inputCostPerTokenAboveThreshold: nil,
-            outputCostPerTokenAboveThreshold: nil,
-            cacheReadInputCostPerTokenAboveThreshold: nil,
-            displayLabel: nil)
-    ]
+    static func claudeCostUSD(
+        model: String,
+        inputTokens: Int,
+        cacheReadInputTokens: Int,
+        cacheCreationInputTokens: Int,
+        outputTokens: Int
+    ) -> Double? {
+        let claude = PricingResolver.active.providers.claude.models
+        guard let pricing = claude[normalizeClaudeModel(model)] else { return nil }
 
-    /// xAI Grok API pricing, USD per token, as of `pricingDataUpdatedAt`.
-    /// Source: docs.x.ai/docs/models and pricepertoken.com cross-checks.
-    /// Cached-input rates that aren't published explicitly stay `nil`
-    /// and fall back to the regular input rate in `grokCostUSD`.
-    private static let grok: [String: GrokPricing] = [
-        "grok-build": GrokPricing(
-            inputCostPerToken: 1e-6,
-            outputCostPerToken: 2e-6,
-            cacheReadInputCostPerToken: nil,
-            displayLabel: nil),
-        "grok-build-0.1": GrokPricing(
-            inputCostPerToken: 1e-6,
-            outputCostPerToken: 2e-6,
-            cacheReadInputCostPerToken: nil,
-            displayLabel: nil),
-        "grok-4": GrokPricing(
-            inputCostPerToken: 3e-6,
-            outputCostPerToken: 1.5e-5,
-            cacheReadInputCostPerToken: 7.5e-7,
-            displayLabel: nil),
-        "grok-4-fast": GrokPricing(
-            inputCostPerToken: 2e-7,
-            outputCostPerToken: 5e-7,
-            cacheReadInputCostPerToken: 5e-8,
-            displayLabel: nil),
-        "grok-4.1-fast": GrokPricing(
-            inputCostPerToken: 2e-7,
-            outputCostPerToken: 5e-7,
-            cacheReadInputCostPerToken: 5e-8,
-            displayLabel: nil),
-        "grok-4.3": GrokPricing(
-            inputCostPerToken: 1.25e-6,
-            outputCostPerToken: 2.5e-6,
-            cacheReadInputCostPerToken: 3.1e-7,
-            displayLabel: nil),
-        "grok-4.20": GrokPricing(
-            inputCostPerToken: 2e-6,
-            outputCostPerToken: 6e-6,
-            cacheReadInputCostPerToken: 2e-7,
-            displayLabel: nil),
-        "grok-3": GrokPricing(
-            inputCostPerToken: 3e-6,
-            outputCostPerToken: 1.5e-5,
-            cacheReadInputCostPerToken: 7.5e-7,
-            displayLabel: nil),
-        "grok-3-mini": GrokPricing(
-            inputCostPerToken: 3e-7,
-            outputCostPerToken: 5e-7,
-            cacheReadInputCostPerToken: 7.5e-8,
-            displayLabel: nil),
-        "grok-code-fast-1": GrokPricing(
-            inputCostPerToken: 2e-7,
-            outputCostPerToken: 1.5e-6,
-            cacheReadInputCostPerToken: 2e-8,
-            displayLabel: nil)
-    ]
+        func tiered(_ tokens: Int, base: Double, above: Double?, threshold: Int?) -> Double {
+            guard let threshold, let above else { return Double(tokens) * base }
+            let below = min(tokens, threshold)
+            let over = max(tokens - threshold, 0)
+            return Double(below) * base + Double(over) * above
+        }
 
-    /// AntiGravity is a managed product, not a pay-per-token API.
-    /// These rates shadow Claude Sonnet 4.6 (the default) / Opus /
-    /// Haiku / Gemini Pro / Gemini Flash so the dollar number is
-    /// interpretable as "if this session had hit the API directly,
-    /// it would have cost approximately $X". The `-default` key is
-    /// the fallback when the scanner can't pin the underlying model.
-    private static let antigravity: [String: AntigravityPricing] = [
-        "antigravity-default": AntigravityPricing(
-            inputCostPerToken: 3e-6,
-            outputCostPerToken: 1.5e-5,
-            cacheReadInputCostPerToken: 3e-7,
-            cacheCreationInputCostPerToken: 3.75e-6,
-            displayLabel: "Sonnet-rate est."),
-        "antigravity-claude-sonnet": AntigravityPricing(
-            inputCostPerToken: 3e-6,
-            outputCostPerToken: 1.5e-5,
-            cacheReadInputCostPerToken: 3e-7,
-            cacheCreationInputCostPerToken: 3.75e-6,
-            displayLabel: nil),
-        "antigravity-claude-opus": AntigravityPricing(
-            inputCostPerToken: 5e-6,
-            outputCostPerToken: 2.5e-5,
-            cacheReadInputCostPerToken: 5e-7,
-            cacheCreationInputCostPerToken: 6.25e-6,
-            displayLabel: nil),
-        "antigravity-claude-haiku": AntigravityPricing(
-            inputCostPerToken: 1e-6,
-            outputCostPerToken: 5e-6,
-            cacheReadInputCostPerToken: 1e-7,
-            cacheCreationInputCostPerToken: 1.25e-6,
-            displayLabel: nil),
-        "antigravity-gemini-pro": AntigravityPricing(
-            inputCostPerToken: 1.25e-6,
-            outputCostPerToken: 1e-5,
-            cacheReadInputCostPerToken: 3.1e-7,
-            cacheCreationInputCostPerToken: 0,
-            displayLabel: nil),
-        "antigravity-gemini-flash": AntigravityPricing(
-            inputCostPerToken: 3e-7,
-            outputCostPerToken: 2.5e-6,
-            cacheReadInputCostPerToken: 7.5e-8,
-            cacheCreationInputCostPerToken: 0,
-            displayLabel: nil)
-    ]
+        return tiered(
+            max(0, inputTokens),
+            base: pricing.input,
+            above: pricing.inputAboveThreshold,
+            threshold: pricing.thresholdTokens)
+            + tiered(
+                max(0, cacheReadInputTokens),
+                base: pricing.cacheRead,
+                above: pricing.cacheReadAboveThreshold,
+                threshold: pricing.thresholdTokens)
+            + tiered(
+                max(0, cacheCreationInputTokens),
+                base: pricing.cacheCreation,
+                above: pricing.cacheCreationAboveThreshold,
+                threshold: pricing.thresholdTokens)
+            + tiered(
+                max(0, outputTokens),
+                base: pricing.output,
+                above: pricing.outputAboveThreshold,
+                threshold: pricing.thresholdTokens)
+    }
+
+    // MARK: - Gemini
+
+    static func normalizeGeminiModel(_ raw: String) -> String {
+        let gemini = PricingResolver.active.providers.gemini.models
+        var trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        if trimmed.hasPrefix("models/") {
+            trimmed = String(trimmed.dropFirst("models/".count))
+        }
+        if gemini[trimmed] != nil { return trimmed }
+        if let datedSuffix = trimmed.range(of: #"-(preview-)?\d{2,4}-\d{2}(-\d{2})?$"#, options: .regularExpression) {
+            let base = String(trimmed[..<datedSuffix.lowerBound])
+            if gemini[base] != nil { return base }
+        }
+        if let revSuffix = trimmed.range(of: #"-\d{3}$"#, options: .regularExpression) {
+            let base = String(trimmed[..<revSuffix.lowerBound])
+            if gemini[base] != nil { return base }
+        }
+        let segments = trimmed.split(separator: "-")
+        for end in stride(from: segments.count, through: 3, by: -1) {
+            let candidate = segments.prefix(end).joined(separator: "-")
+            if gemini[candidate] != nil { return candidate }
+        }
+        return trimmed
+    }
+
+    static func geminiDisplayLabel(model: String) -> String? {
+        let gemini = PricingResolver.active.providers.gemini.models
+        return gemini[normalizeGeminiModel(model)]?.displayLabel
+    }
+
+    static func geminiCostUSD(
+        model: String,
+        inputTokens: Int,
+        cacheReadInputTokens: Int,
+        outputTokens: Int
+    ) -> Double? {
+        let gemini = PricingResolver.active.providers.gemini.models
+        guard let pricing = gemini[normalizeGeminiModel(model)] else { return nil }
+
+        let cached = min(max(0, cacheReadInputTokens), max(0, inputTokens))
+        let nonCached = max(0, inputTokens - cached)
+        let output = max(0, outputTokens)
+
+        func tier(_ tokens: Int, base: Double, above: Double?, threshold: Int?) -> Double {
+            guard let threshold, let above else { return Double(tokens) * base }
+            let below = min(tokens, threshold)
+            let over = max(tokens - threshold, 0)
+            return Double(below) * base + Double(over) * above
+        }
+
+        let cachedRate = pricing.cacheRead ?? pricing.input
+        let cachedRateAbove = pricing.cacheReadAboveThreshold ?? pricing.inputAboveThreshold
+        return tier(nonCached,
+                    base: pricing.input,
+                    above: pricing.inputAboveThreshold,
+                    threshold: pricing.thresholdTokens)
+            + tier(cached,
+                   base: cachedRate,
+                   above: cachedRateAbove,
+                   threshold: pricing.thresholdTokens)
+            + tier(output,
+                   base: pricing.output,
+                   above: pricing.outputAboveThreshold,
+                   threshold: pricing.thresholdTokens)
+    }
+
+    // MARK: - Grok
 
     static func normalizeGrokModel(_ raw: String) -> String {
+        let grok = PricingResolver.active.providers.grok.models
         var trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         if trimmed.hasPrefix("xai/") {
             trimmed = String(trimmed.dropFirst("xai/".count))
         }
-        if self.grok[trimmed] != nil { return trimmed }
+        if grok[trimmed] != nil { return trimmed }
         if let datedRange = trimmed.range(of: #"-(beta|preview|\d{4}-\d{2}-\d{2}|\d{4}-\d{2})$"#, options: .regularExpression) {
             let base = String(trimmed[..<datedRange.lowerBound])
-            if self.grok[base] != nil { return base }
+            if grok[base] != nil { return base }
         }
         let segments = trimmed.split(separator: "-")
         for end in stride(from: segments.count, through: 1, by: -1) {
             let candidate = segments.prefix(end).joined(separator: "-")
-            if self.grok[candidate] != nil { return candidate }
+            if grok[candidate] != nil { return candidate }
         }
         return trimmed
     }
 
     static func grokDisplayLabel(model: String) -> String? {
-        self.grok[self.normalizeGrokModel(model)]?.displayLabel
+        let grok = PricingResolver.active.providers.grok.models
+        return grok[normalizeGrokModel(model)]?.displayLabel
     }
 
+    static func grokCostUSD(
+        model: String,
+        inputTokens: Int,
+        cachedInputTokens: Int,
+        outputTokens: Int
+    ) -> Double? {
+        let grok = PricingResolver.active.providers.grok.models
+        guard let pricing = grok[normalizeGrokModel(model)] else { return nil }
+        let cached = min(max(0, cachedInputTokens), max(0, inputTokens))
+        let nonCached = max(0, inputTokens - cached)
+        let cachedRate = pricing.cacheRead ?? pricing.input
+        return Double(nonCached) * pricing.input
+            + Double(cached) * cachedRate
+            + Double(max(0, outputTokens)) * pricing.output
+    }
+
+    // MARK: - AntiGravity
+
     static func normalizeAntigravityModel(_ raw: String) -> String {
+        let antigravity = PricingResolver.active.providers.antigravity.models
         let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-        if self.antigravity[trimmed] != nil { return trimmed }
+        if antigravity[trimmed] != nil { return trimmed }
         if trimmed.contains("opus") { return "antigravity-claude-opus" }
         if trimmed.contains("haiku") { return "antigravity-claude-haiku" }
         if trimmed.contains("sonnet") || trimmed.contains("claude") {
@@ -517,182 +257,10 @@ public enum CostUsagePricing {
     }
 
     static func antigravityDisplayLabel(model: String) -> String? {
-        self.antigravity[self.normalizeAntigravityModel(model)]?.displayLabel
+        let antigravity = PricingResolver.active.providers.antigravity.models
+        return antigravity[normalizeAntigravityModel(model)]?.displayLabel
     }
 
-    static func normalizeGeminiModel(_ raw: String) -> String {
-        var trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-        // Drop the common `models/` prefix used by the Gemini API.
-        if trimmed.hasPrefix("models/") {
-            trimmed = String(trimmed.dropFirst("models/".count))
-        }
-
-        if self.gemini[trimmed] != nil {
-            return trimmed
-        }
-
-        // Strip `-001`, `-002`, `-preview-04-09` style suffixes — they
-        // share pricing with the bare base name.
-        if let datedSuffix = trimmed.range(of: #"-(preview-)?\d{2,4}-\d{2}(-\d{2})?$"#, options: .regularExpression) {
-            let base = String(trimmed[..<datedSuffix.lowerBound])
-            if self.gemini[base] != nil {
-                return base
-            }
-        }
-        if let revSuffix = trimmed.range(of: #"-\d{3}$"#, options: .regularExpression) {
-            let base = String(trimmed[..<revSuffix.lowerBound])
-            if self.gemini[base] != nil {
-                return base
-            }
-        }
-        // Best-effort family fallback: "gemini-2.5-pro-exp" → "gemini-2.5-pro".
-        let segments = trimmed.split(separator: "-")
-        for end in stride(from: segments.count, through: 3, by: -1) {
-            let candidate = segments.prefix(end).joined(separator: "-")
-            if self.gemini[candidate] != nil {
-                return candidate
-            }
-        }
-        return trimmed
-    }
-
-    static func geminiDisplayLabel(model: String) -> String? {
-        let key = self.normalizeGeminiModel(model)
-        return self.gemini[key]?.displayLabel
-    }
-
-    static func normalizeCodexModel(_ raw: String) -> String {
-        var trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
-        if trimmed.hasPrefix("openai/") {
-            trimmed = String(trimmed.dropFirst("openai/".count))
-        }
-
-        if self.codex[trimmed] != nil {
-            return trimmed
-        }
-
-        if let datedSuffix = trimmed.range(of: #"-\d{4}-\d{2}-\d{2}$"#, options: .regularExpression) {
-            let base = String(trimmed[..<datedSuffix.lowerBound])
-            if self.codex[base] != nil {
-                return base
-            }
-        }
-        return trimmed
-    }
-
-    static func codexDisplayLabel(model: String) -> String? {
-        let key = self.normalizeCodexModel(model)
-        return self.codex[key]?.displayLabel
-    }
-
-    static func normalizeClaudeModel(_ raw: String) -> String {
-        var trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
-        if trimmed.hasPrefix("anthropic.") {
-            trimmed = String(trimmed.dropFirst("anthropic.".count))
-        }
-
-        if let lastDot = trimmed.lastIndex(of: "."),
-           trimmed.contains("claude-")
-        {
-            let tail = String(trimmed[trimmed.index(after: lastDot)...])
-            if tail.hasPrefix("claude-") {
-                trimmed = tail
-            }
-        }
-
-        if let vRange = trimmed.range(of: #"-v\d+:\d+$"#, options: .regularExpression) {
-            trimmed.removeSubrange(vRange)
-        }
-
-        if let baseRange = trimmed.range(of: #"-\d{8}$"#, options: .regularExpression) {
-            let base = String(trimmed[..<baseRange.lowerBound])
-            if self.claude[base] != nil {
-                return base
-            }
-        }
-
-        return trimmed
-    }
-
-    static func codexCostUSD(model: String, inputTokens: Int, cachedInputTokens: Int, outputTokens: Int) -> Double? {
-        let key = self.normalizeCodexModel(model)
-        guard let pricing = self.codex[key] else { return nil }
-        let cached = min(max(0, cachedInputTokens), max(0, inputTokens))
-        let nonCached = max(0, inputTokens - cached)
-        let cachedRate = pricing.cacheReadInputCostPerToken ?? pricing.inputCostPerToken
-        return Double(nonCached) * pricing.inputCostPerToken
-            + Double(cached) * cachedRate
-            + Double(max(0, outputTokens)) * pricing.outputCostPerToken
-    }
-
-    /// Compute USD cost for a Gemini API call. `cacheReadInputTokens`
-    /// is the slice of `inputTokens` that hit context cache — same
-    /// shape as `codexCostUSD`. Returns `nil` when the model is
-    /// unknown so the scanner can skip the row instead of charging
-    /// $0 (which would silently under-count cost on a new model).
-    static func geminiCostUSD(
-        model: String,
-        inputTokens: Int,
-        cacheReadInputTokens: Int,
-        outputTokens: Int
-    ) -> Double? {
-        let key = self.normalizeGeminiModel(model)
-        guard let pricing = self.gemini[key] else { return nil }
-
-        let cached = min(max(0, cacheReadInputTokens), max(0, inputTokens))
-        let nonCached = max(0, inputTokens - cached)
-        let output = max(0, outputTokens)
-
-        func tier(_ tokens: Int, base: Double, above: Double?, threshold: Int?) -> Double {
-            guard let threshold, let above else { return Double(tokens) * base }
-            let below = min(tokens, threshold)
-            let over = max(tokens - threshold, 0)
-            return Double(below) * base + Double(over) * above
-        }
-
-        let cachedRate = pricing.cacheReadInputCostPerToken ?? pricing.inputCostPerToken
-        let cachedRateAbove = pricing.cacheReadInputCostPerTokenAboveThreshold ?? pricing.inputCostPerTokenAboveThreshold
-        return tier(nonCached,
-                    base: pricing.inputCostPerToken,
-                    above: pricing.inputCostPerTokenAboveThreshold,
-                    threshold: pricing.thresholdTokens)
-            + tier(cached,
-                   base: cachedRate,
-                   above: cachedRateAbove,
-                   threshold: pricing.thresholdTokens)
-            + tier(output,
-                   base: pricing.outputCostPerToken,
-                   above: pricing.outputCostPerTokenAboveThreshold,
-                   threshold: pricing.thresholdTokens)
-    }
-
-    /// Compute USD cost for a Grok call. xAI publishes per-model input
-    /// and output rates; cached-input is sometimes ~10% of input on
-    /// newer models. The caller passes pre-split tokens — when the
-    /// upstream source only has a session-level total, the Grok
-    /// scanner splits it ~70 / 30 input vs output before calling us.
-    /// Returns `nil` for unknown models.
-    static func grokCostUSD(
-        model: String,
-        inputTokens: Int,
-        cachedInputTokens: Int,
-        outputTokens: Int
-    ) -> Double? {
-        let key = self.normalizeGrokModel(model)
-        guard let pricing = self.grok[key] else { return nil }
-        let cached = min(max(0, cachedInputTokens), max(0, inputTokens))
-        let nonCached = max(0, inputTokens - cached)
-        let cachedRate = pricing.cacheReadInputCostPerToken ?? pricing.inputCostPerToken
-        return Double(nonCached) * pricing.inputCostPerToken
-            + Double(cached) * cachedRate
-            + Double(max(0, outputTokens)) * pricing.outputCostPerToken
-    }
-
-    /// Compute USD cost for an AntiGravity-mediated call. AntiGravity
-    /// bills by plan quota, so this number is an "if this same volume
-    /// hit the underlying API directly" estimate, not a real invoice
-    /// figure. Default key (`antigravity-default`) shadows Claude
-    /// Sonnet 4.6 rates.
     static func antigravityCostUSD(
         model: String,
         inputTokens: Int,
@@ -700,50 +268,11 @@ public enum CostUsagePricing {
         cacheCreationInputTokens: Int,
         outputTokens: Int
     ) -> Double? {
-        let key = self.normalizeAntigravityModel(model)
-        guard let pricing = self.antigravity[key] else { return nil }
-        return Double(max(0, inputTokens)) * pricing.inputCostPerToken
-            + Double(max(0, cacheReadInputTokens)) * pricing.cacheReadInputCostPerToken
-            + Double(max(0, cacheCreationInputTokens)) * pricing.cacheCreationInputCostPerToken
-            + Double(max(0, outputTokens)) * pricing.outputCostPerToken
-    }
-
-    static func claudeCostUSD(
-        model: String,
-        inputTokens: Int,
-        cacheReadInputTokens: Int,
-        cacheCreationInputTokens: Int,
-        outputTokens: Int) -> Double?
-    {
-        let key = self.normalizeClaudeModel(model)
-        guard let pricing = self.claude[key] else { return nil }
-
-        func tiered(_ tokens: Int, base: Double, above: Double?, threshold: Int?) -> Double {
-            guard let threshold, let above else { return Double(tokens) * base }
-            let below = min(tokens, threshold)
-            let over = max(tokens - threshold, 0)
-            return Double(below) * base + Double(over) * above
-        }
-
-        return tiered(
-            max(0, inputTokens),
-            base: pricing.inputCostPerToken,
-            above: pricing.inputCostPerTokenAboveThreshold,
-            threshold: pricing.thresholdTokens)
-            + tiered(
-                max(0, cacheReadInputTokens),
-                base: pricing.cacheReadInputCostPerToken,
-                above: pricing.cacheReadInputCostPerTokenAboveThreshold,
-                threshold: pricing.thresholdTokens)
-            + tiered(
-                max(0, cacheCreationInputTokens),
-                base: pricing.cacheCreationInputCostPerToken,
-                above: pricing.cacheCreationInputCostPerTokenAboveThreshold,
-                threshold: pricing.thresholdTokens)
-            + tiered(
-                max(0, outputTokens),
-                base: pricing.outputCostPerToken,
-                above: pricing.outputCostPerTokenAboveThreshold,
-                threshold: pricing.thresholdTokens)
+        let antigravity = PricingResolver.active.providers.antigravity.models
+        guard let pricing = antigravity[normalizeAntigravityModel(model)] else { return nil }
+        return Double(max(0, inputTokens)) * pricing.input
+            + Double(max(0, cacheReadInputTokens)) * pricing.cacheRead
+            + Double(max(0, cacheCreationInputTokens)) * pricing.cacheCreation
+            + Double(max(0, outputTokens)) * pricing.output
     }
 }

--- a/Sources/VibeBarCore/Vendored/CostUsage/PricingDataSet.swift
+++ b/Sources/VibeBarCore/Vendored/CostUsage/PricingDataSet.swift
@@ -1,0 +1,178 @@
+import Foundation
+
+/// Codable shape of the bundled / fetched `pricing.json`.
+///
+/// The schema version gates "is this file safe to load with this
+/// build of the app"? When the loader sees a newer version it falls
+/// back to the bundled copy (or the in-code fallback when the bundle
+/// resource is missing — e.g. inside a test target).
+///
+/// Every per-model entry uses a separate struct because the provider
+/// pricing shapes diverge (tiered Gemini / Claude rates, Anthropic
+/// cache-creation rate, Grok / Codex flat-rate). Single-rate code
+/// would either lose fidelity or force every model to model the union
+/// of every other provider's quirks.
+public struct PricingDataSet: Codable, Sendable, Equatable {
+    public static let currentSchemaVersion = 1
+    /// Hard cap so a corrupt remote file can't blow up the loader.
+    /// 64 KB is ~150× the current bundled JSON's size.
+    public static let maxBytes = 64 * 1024
+
+    public let schemaVersion: Int
+    public let updatedAt: String
+    public let calculationVersion: Int
+    public let providers: Providers
+
+    public init(
+        schemaVersion: Int,
+        updatedAt: String,
+        calculationVersion: Int,
+        providers: Providers
+    ) {
+        self.schemaVersion = schemaVersion
+        self.updatedAt = updatedAt
+        self.calculationVersion = calculationVersion
+        self.providers = providers
+    }
+
+    public struct Providers: Codable, Sendable, Equatable {
+        public let codex: ProviderTable<CodexEntry>
+        public let claude: ProviderTable<ClaudeEntry>
+        public let gemini: ProviderTable<GeminiEntry>
+        public let grok: ProviderTable<GrokEntry>
+        public let antigravity: ProviderTable<AntigravityEntry>
+
+        public init(
+            codex: ProviderTable<CodexEntry>,
+            claude: ProviderTable<ClaudeEntry>,
+            gemini: ProviderTable<GeminiEntry>,
+            grok: ProviderTable<GrokEntry>,
+            antigravity: ProviderTable<AntigravityEntry>
+        ) {
+            self.codex = codex
+            self.claude = claude
+            self.gemini = gemini
+            self.grok = grok
+            self.antigravity = antigravity
+        }
+    }
+
+    public struct ProviderTable<Entry: Codable & Sendable & Equatable>: Codable, Sendable, Equatable {
+        public let displayName: String?
+        public let models: [String: Entry]
+
+        public init(displayName: String? = nil, models: [String: Entry]) {
+            self.displayName = displayName
+            self.models = models
+        }
+    }
+
+    public struct CodexEntry: Codable, Sendable, Equatable {
+        public let input: Double
+        public let output: Double
+        public let cacheRead: Double?
+        public let displayLabel: String?
+
+        public init(input: Double, output: Double, cacheRead: Double?, displayLabel: String? = nil) {
+            self.input = input
+            self.output = output
+            self.cacheRead = cacheRead
+            self.displayLabel = displayLabel
+        }
+    }
+
+    public struct ClaudeEntry: Codable, Sendable, Equatable {
+        public let input: Double
+        public let output: Double
+        public let cacheCreation: Double
+        public let cacheRead: Double
+        public let thresholdTokens: Int?
+        public let inputAboveThreshold: Double?
+        public let outputAboveThreshold: Double?
+        public let cacheCreationAboveThreshold: Double?
+        public let cacheReadAboveThreshold: Double?
+
+        public init(
+            input: Double, output: Double,
+            cacheCreation: Double, cacheRead: Double,
+            thresholdTokens: Int? = nil,
+            inputAboveThreshold: Double? = nil,
+            outputAboveThreshold: Double? = nil,
+            cacheCreationAboveThreshold: Double? = nil,
+            cacheReadAboveThreshold: Double? = nil
+        ) {
+            self.input = input
+            self.output = output
+            self.cacheCreation = cacheCreation
+            self.cacheRead = cacheRead
+            self.thresholdTokens = thresholdTokens
+            self.inputAboveThreshold = inputAboveThreshold
+            self.outputAboveThreshold = outputAboveThreshold
+            self.cacheCreationAboveThreshold = cacheCreationAboveThreshold
+            self.cacheReadAboveThreshold = cacheReadAboveThreshold
+        }
+    }
+
+    public struct GeminiEntry: Codable, Sendable, Equatable {
+        public let input: Double
+        public let output: Double
+        public let cacheRead: Double?
+        public let thresholdTokens: Int?
+        public let inputAboveThreshold: Double?
+        public let outputAboveThreshold: Double?
+        public let cacheReadAboveThreshold: Double?
+        public let displayLabel: String?
+
+        public init(
+            input: Double, output: Double, cacheRead: Double?,
+            thresholdTokens: Int? = nil,
+            inputAboveThreshold: Double? = nil,
+            outputAboveThreshold: Double? = nil,
+            cacheReadAboveThreshold: Double? = nil,
+            displayLabel: String? = nil
+        ) {
+            self.input = input
+            self.output = output
+            self.cacheRead = cacheRead
+            self.thresholdTokens = thresholdTokens
+            self.inputAboveThreshold = inputAboveThreshold
+            self.outputAboveThreshold = outputAboveThreshold
+            self.cacheReadAboveThreshold = cacheReadAboveThreshold
+            self.displayLabel = displayLabel
+        }
+    }
+
+    public struct GrokEntry: Codable, Sendable, Equatable {
+        public let input: Double
+        public let output: Double
+        public let cacheRead: Double?
+        public let displayLabel: String?
+
+        public init(input: Double, output: Double, cacheRead: Double?, displayLabel: String? = nil) {
+            self.input = input
+            self.output = output
+            self.cacheRead = cacheRead
+            self.displayLabel = displayLabel
+        }
+    }
+
+    public struct AntigravityEntry: Codable, Sendable, Equatable {
+        public let input: Double
+        public let output: Double
+        public let cacheRead: Double
+        public let cacheCreation: Double
+        public let displayLabel: String?
+
+        public init(
+            input: Double, output: Double,
+            cacheRead: Double, cacheCreation: Double,
+            displayLabel: String? = nil
+        ) {
+            self.input = input
+            self.output = output
+            self.cacheRead = cacheRead
+            self.cacheCreation = cacheCreation
+            self.displayLabel = displayLabel
+        }
+    }
+}

--- a/Sources/VibeBarCore/Vendored/CostUsage/PricingHardcoded.swift
+++ b/Sources/VibeBarCore/Vendored/CostUsage/PricingHardcoded.swift
@@ -1,0 +1,174 @@
+import Foundation
+
+/// Hardcoded floor for `PricingResolver`. The bundled `pricing.json`
+/// is the *real* source of truth in production builds, but tests
+/// (and any pathological "bundle resource missing at runtime" case)
+/// need a viable fallback so cost calculations don't silently start
+/// returning `nil` for every model.
+///
+/// Keep this in sync with `Resources/pricing.json` when adding new
+/// models. The PR template review checklist covers this; if a future
+/// agent forgets, the new tests in `PricingResolverTests` will fail
+/// because the loaded data set won't match the hardcoded one for
+/// known models.
+enum PricingHardcoded {
+    static let fallback: PricingDataSet = PricingDataSet(
+        schemaVersion: 1,
+        updatedAt: "2026-05-22",
+        calculationVersion: 5,
+        providers: PricingDataSet.Providers(
+            codex: codex,
+            claude: claude,
+            gemini: gemini,
+            grok: grok,
+            antigravity: antigravity
+        )
+    )
+
+    private static let codex = PricingDataSet.ProviderTable<PricingDataSet.CodexEntry>(
+        displayName: "OpenAI",
+        models: [
+            "gpt-5":               .init(input: 1.25e-6, output: 1e-5,    cacheRead: 1.25e-7),
+            "gpt-5-codex":         .init(input: 1.25e-6, output: 1e-5,    cacheRead: 1.25e-7),
+            "gpt-5-mini":          .init(input: 2.5e-7,  output: 2e-6,    cacheRead: 2.5e-8),
+            "gpt-5-nano":          .init(input: 5e-8,    output: 4e-7,    cacheRead: 5e-9),
+            "gpt-5-pro":           .init(input: 1.5e-5,  output: 1.2e-4,  cacheRead: nil),
+            "gpt-5.1":             .init(input: 1.25e-6, output: 1e-5,    cacheRead: 1.25e-7),
+            "gpt-5.1-codex":       .init(input: 1.25e-6, output: 1e-5,    cacheRead: 1.25e-7),
+            "gpt-5.1-codex-max":   .init(input: 1.25e-6, output: 1e-5,    cacheRead: 1.25e-7),
+            "gpt-5.1-codex-mini":  .init(input: 2.5e-7,  output: 2e-6,    cacheRead: 2.5e-8),
+            "gpt-5.2":             .init(input: 1.75e-6, output: 1.4e-5,  cacheRead: 1.75e-7),
+            "gpt-5.2-codex":       .init(input: 1.75e-6, output: 1.4e-5,  cacheRead: 1.75e-7),
+            "gpt-5.2-pro":         .init(input: 2.1e-5,  output: 1.68e-4, cacheRead: nil),
+            "gpt-5.3-codex":       .init(input: 1.75e-6, output: 1.4e-5,  cacheRead: 1.75e-7),
+            "gpt-5.3-codex-spark": .init(input: 0,       output: 0,       cacheRead: 0,
+                                         displayLabel: "Research Preview"),
+            "gpt-5.4":             .init(input: 2.5e-6,  output: 1.5e-5,  cacheRead: 2.5e-7),
+            "gpt-5.4-mini":        .init(input: 7.5e-7,  output: 4.5e-6,  cacheRead: 7.5e-8),
+            "gpt-5.4-nano":        .init(input: 2e-7,    output: 1.25e-6, cacheRead: 2e-8),
+            "gpt-5.4-pro":         .init(input: 3e-5,    output: 1.8e-4,  cacheRead: nil),
+            "gpt-5.5":             .init(input: 5e-6,    output: 3e-5,    cacheRead: 5e-7),
+            "gpt-5.5-pro":         .init(input: 3e-5,    output: 1.8e-4,  cacheRead: nil)
+        ]
+    )
+
+    private static let claude = PricingDataSet.ProviderTable<PricingDataSet.ClaudeEntry>(
+        displayName: "Anthropic",
+        models: [
+            "claude-haiku-4-5-20251001": .init(
+                input: 1e-6, output: 5e-6,
+                cacheCreation: 1.25e-6, cacheRead: 1e-7),
+            "claude-haiku-4-5": .init(
+                input: 1e-6, output: 5e-6,
+                cacheCreation: 1.25e-6, cacheRead: 1e-7),
+            "claude-opus-4-5-20251101": .init(
+                input: 5e-6, output: 2.5e-5,
+                cacheCreation: 6.25e-6, cacheRead: 5e-7),
+            "claude-opus-4-5": .init(
+                input: 5e-6, output: 2.5e-5,
+                cacheCreation: 6.25e-6, cacheRead: 5e-7),
+            "claude-opus-4-6-20260205": .init(
+                input: 5e-6, output: 2.5e-5,
+                cacheCreation: 6.25e-6, cacheRead: 5e-7),
+            "claude-opus-4-6": .init(
+                input: 5e-6, output: 2.5e-5,
+                cacheCreation: 6.25e-6, cacheRead: 5e-7),
+            "claude-opus-4-7": .init(
+                input: 5e-6, output: 2.5e-5,
+                cacheCreation: 6.25e-6, cacheRead: 5e-7),
+            "claude-sonnet-4-5": .init(
+                input: 3e-6, output: 1.5e-5,
+                cacheCreation: 3.75e-6, cacheRead: 3e-7,
+                thresholdTokens: 200_000,
+                inputAboveThreshold: 6e-6, outputAboveThreshold: 2.25e-5,
+                cacheCreationAboveThreshold: 7.5e-6, cacheReadAboveThreshold: 6e-7),
+            "claude-sonnet-4-6": .init(
+                input: 3e-6, output: 1.5e-5,
+                cacheCreation: 3.75e-6, cacheRead: 3e-7),
+            "claude-sonnet-4-5-20250929": .init(
+                input: 3e-6, output: 1.5e-5,
+                cacheCreation: 3.75e-6, cacheRead: 3e-7,
+                thresholdTokens: 200_000,
+                inputAboveThreshold: 6e-6, outputAboveThreshold: 2.25e-5,
+                cacheCreationAboveThreshold: 7.5e-6, cacheReadAboveThreshold: 6e-7),
+            "claude-opus-4-20250514": .init(
+                input: 1.5e-5, output: 7.5e-5,
+                cacheCreation: 1.875e-5, cacheRead: 1.5e-6),
+            "claude-opus-4-1": .init(
+                input: 1.5e-5, output: 7.5e-5,
+                cacheCreation: 1.875e-5, cacheRead: 1.5e-6),
+            "claude-sonnet-4-20250514": .init(
+                input: 3e-6, output: 1.5e-5,
+                cacheCreation: 3.75e-6, cacheRead: 3e-7,
+                thresholdTokens: 200_000,
+                inputAboveThreshold: 6e-6, outputAboveThreshold: 2.25e-5,
+                cacheCreationAboveThreshold: 7.5e-6, cacheReadAboveThreshold: 6e-7)
+        ]
+    )
+
+    private static let gemini = PricingDataSet.ProviderTable<PricingDataSet.GeminiEntry>(
+        displayName: "Google Gemini",
+        models: [
+            "gemini-2.5-pro": .init(
+                input: 1.25e-6, output: 1e-5, cacheRead: 3.1e-7,
+                thresholdTokens: 200_000,
+                inputAboveThreshold: 2.5e-6, outputAboveThreshold: 1.5e-5,
+                cacheReadAboveThreshold: 6.25e-7),
+            "gemini-2.5-flash": .init(input: 3e-7,  output: 2.5e-6, cacheRead: 7.5e-8),
+            "gemini-2.5-flash-lite": .init(input: 1e-7,  output: 4e-7,  cacheRead: 2.5e-8),
+            "gemini-3-pro": .init(
+                input: 2e-6, output: 1.2e-5, cacheRead: 5e-7,
+                thresholdTokens: 200_000,
+                inputAboveThreshold: 4e-6, outputAboveThreshold: 1.8e-5,
+                cacheReadAboveThreshold: 1e-6),
+            "gemini-3-pro-preview": .init(
+                input: 2e-6, output: 1.2e-5, cacheRead: 5e-7,
+                thresholdTokens: 200_000,
+                inputAboveThreshold: 4e-6, outputAboveThreshold: 1.8e-5,
+                cacheReadAboveThreshold: 1e-6),
+            "gemini-3-flash": .init(input: 3.5e-7, output: 2.8e-6, cacheRead: 8.75e-8),
+            "gemini-3-flash-lite": .init(input: 1.25e-7, output: 5e-7, cacheRead: 3.1e-8)
+        ]
+    )
+
+    private static let grok = PricingDataSet.ProviderTable<PricingDataSet.GrokEntry>(
+        displayName: "xAI Grok",
+        models: [
+            "grok-build":       .init(input: 1e-6,    output: 2e-6,    cacheRead: nil),
+            "grok-build-0.1":   .init(input: 1e-6,    output: 2e-6,    cacheRead: nil),
+            "grok-4":           .init(input: 3e-6,    output: 1.5e-5,  cacheRead: 7.5e-7),
+            "grok-4-fast":      .init(input: 2e-7,    output: 5e-7,    cacheRead: 5e-8),
+            "grok-4.1-fast":    .init(input: 2e-7,    output: 5e-7,    cacheRead: 5e-8),
+            "grok-4.3":         .init(input: 1.25e-6, output: 2.5e-6,  cacheRead: 3.1e-7),
+            "grok-4.20":        .init(input: 2e-6,    output: 6e-6,    cacheRead: 2e-7),
+            "grok-3":           .init(input: 3e-6,    output: 1.5e-5,  cacheRead: 7.5e-7),
+            "grok-3-mini":      .init(input: 3e-7,    output: 5e-7,    cacheRead: 7.5e-8),
+            "grok-code-fast-1": .init(input: 2e-7,    output: 1.5e-6,  cacheRead: 2e-8)
+        ]
+    )
+
+    private static let antigravity = PricingDataSet.ProviderTable<PricingDataSet.AntigravityEntry>(
+        displayName: "Google AntiGravity (shadow rates)",
+        models: [
+            "antigravity-default": .init(
+                input: 3e-6, output: 1.5e-5,
+                cacheRead: 3e-7, cacheCreation: 3.75e-6,
+                displayLabel: "Sonnet-rate est."),
+            "antigravity-claude-sonnet": .init(
+                input: 3e-6, output: 1.5e-5,
+                cacheRead: 3e-7, cacheCreation: 3.75e-6),
+            "antigravity-claude-opus": .init(
+                input: 5e-6, output: 2.5e-5,
+                cacheRead: 5e-7, cacheCreation: 6.25e-6),
+            "antigravity-claude-haiku": .init(
+                input: 1e-6, output: 5e-6,
+                cacheRead: 1e-7, cacheCreation: 1.25e-6),
+            "antigravity-gemini-pro": .init(
+                input: 1.25e-6, output: 1e-5,
+                cacheRead: 3.1e-7, cacheCreation: 0),
+            "antigravity-gemini-flash": .init(
+                input: 3e-7, output: 2.5e-6,
+                cacheRead: 7.5e-8, cacheCreation: 0)
+        ]
+    )
+}

--- a/Sources/VibeBarCore/Vendored/CostUsage/PricingResolver.swift
+++ b/Sources/VibeBarCore/Vendored/CostUsage/PricingResolver.swift
@@ -1,0 +1,73 @@
+import Foundation
+
+/// Resolves the active pricing data set with a strict precedence:
+///
+///  1. **Cache** at `~/.vibebar/pricing_cache.json` — populated by
+///     `PricingRefresher` when a fresh remote fetch succeeds.
+///  2. **Bundled** `pricing.json` shipped in `Bundle.module` (the
+///     copy that lives alongside the source).
+///  3. **Hardcoded** in-code fallback (`PricingHardcoded.fallback`) —
+///     covers test targets that don't ship `Bundle.module` and the
+///     pathological case where the bundle resource is missing on
+///     disk at runtime.
+///
+/// The resolved data set is computed exactly once per process. The
+/// refresher mutates the on-disk cache asynchronously, but those
+/// updates only take effect on the *next* launch — keeps the
+/// in-memory pricing table immutable for the rest of the process
+/// lifetime and avoids re-running `CostUsageScanner` aggregations
+/// with mid-flight rate changes.
+public enum PricingResolver {
+    /// Override hook for tests. When set, `active` returns this
+    /// instead of reading the cache / bundle. Reset to `nil` in the
+    /// `tearDown` of any suite that touches it.
+    public static var testOverride: PricingDataSet?
+
+    public static var active: PricingDataSet {
+        if let testOverride { return testOverride }
+        return cachedActive
+    }
+
+    private static let cachedActive: PricingDataSet = resolve(
+        homeDirectory: RealHomeDirectory.path
+    )
+
+    /// Test-friendly entry point. Production code path goes through
+    /// `active` which uses the real home directory.
+    public static func resolve(homeDirectory: String) -> PricingDataSet {
+        if let cached = loadCache(homeDirectory: homeDirectory) {
+            return cached
+        }
+        if let bundled = loadBundled() {
+            return bundled
+        }
+        return PricingHardcoded.fallback
+    }
+
+    public static func cacheFileURL(homeDirectory: String) -> URL {
+        URL(fileURLWithPath: homeDirectory)
+            .appendingPathComponent(VibeBarLocalStore.directoryName, isDirectory: true)
+            .appendingPathComponent("pricing_cache.json")
+    }
+
+    static func loadCache(homeDirectory: String) -> PricingDataSet? {
+        let url = cacheFileURL(homeDirectory: homeDirectory)
+        guard let attrs = try? FileManager.default.attributesOfItem(atPath: url.path),
+              let size = (attrs[.size] as? NSNumber)?.intValue,
+              size > 0, size <= PricingDataSet.maxBytes,
+              let data = try? Data(contentsOf: url),
+              let decoded = try? JSONDecoder().decode(PricingDataSet.self, from: data),
+              decoded.schemaVersion == PricingDataSet.currentSchemaVersion
+        else { return nil }
+        return decoded
+    }
+
+    static func loadBundled() -> PricingDataSet? {
+        guard let url = Bundle.module.url(forResource: "pricing", withExtension: "json"),
+              let data = try? Data(contentsOf: url),
+              let decoded = try? JSONDecoder().decode(PricingDataSet.self, from: data),
+              decoded.schemaVersion == PricingDataSet.currentSchemaVersion
+        else { return nil }
+        return decoded
+    }
+}

--- a/Tests/VibeBarCoreTests/AntigravityCostScannerTests.swift
+++ b/Tests/VibeBarCoreTests/AntigravityCostScannerTests.swift
@@ -1,0 +1,255 @@
+import XCTest
+import SQLite3
+@testable import VibeBarCore
+
+/// AntiGravity IDE sessions ship as one SQLite database per
+/// conversation under `~/.gemini/antigravity/conversations/<UUID>.db`.
+/// The `gen_metadata.data` BLOB is a protobuf message whose schema
+/// was reverse-engineered with `protoc --decode_raw`; this suite
+/// exercises both the raw decoder (`AntigravitySessionReader`) and
+/// the end-to-end scanner against synthetic databases.
+final class AntigravityCostScannerTests: XCTestCase {
+    // MARK: - Protobuf encoder helpers (test-only, mirrors xAI / Google wire format)
+
+    private func encodeVarint(_ value: UInt64) -> [UInt8] {
+        var bytes: [UInt8] = []
+        var v = value
+        while v > 0x7F {
+            bytes.append(UInt8(v & 0x7F) | 0x80)
+            v >>= 7
+        }
+        bytes.append(UInt8(v & 0x7F))
+        return bytes
+    }
+
+    private func encodeTag(field: UInt64, wire: UInt64) -> [UInt8] {
+        encodeVarint((field << 3) | wire)
+    }
+
+    private func encodeVarintField(_ field: UInt64, _ value: UInt64) -> [UInt8] {
+        encodeTag(field: field, wire: 0) + encodeVarint(value)
+    }
+
+    private func encodeLengthDelimited(_ field: UInt64, _ payload: [UInt8]) -> [UInt8] {
+        encodeTag(field: field, wire: 2) + encodeVarint(UInt64(payload.count)) + payload
+    }
+
+    private func encodeString(_ field: UInt64, _ value: String) -> [UInt8] {
+        encodeLengthDelimited(field, [UInt8](value.utf8))
+    }
+
+    /// Build a `gen_metadata.data` blob matching AntiGravity's schema:
+    ///   `1` (outer message)
+    ///     `4` (usage): per-turn token counts
+    ///     `9` (system): wall-clock timestamp under `4`
+    private func encodeTurnBlob(
+        seconds: UInt64,
+        nanos: UInt64 = 0,
+        systemPrompt: UInt64 = 1132,
+        input: UInt64,
+        output: UInt64,
+        cumulativeCache: UInt64,
+        thoughts: UInt64 = 0,
+        tool: UInt64 = 0,
+        requestId: String = "test-request"
+    ) -> Data {
+        var usage: [UInt8] = []
+        usage += encodeVarintField(1, systemPrompt)
+        usage += encodeVarintField(2, input)
+        usage += encodeVarintField(3, output)
+        if cumulativeCache > 0 { usage += encodeVarintField(5, cumulativeCache) }
+        usage += encodeVarintField(6, 24)
+        if thoughts > 0 { usage += encodeVarintField(9, thoughts) }
+        if tool > 0 { usage += encodeVarintField(10, tool) }
+        usage += encodeString(11, requestId)
+
+        let timeBlock = encodeVarintField(1, seconds) + encodeVarintField(2, nanos)
+        let systemBlock = encodeLengthDelimited(4, timeBlock)
+
+        let outer = encodeLengthDelimited(4, usage) + encodeLengthDelimited(9, systemBlock)
+        let blob = encodeLengthDelimited(1, outer)
+        return Data(blob)
+    }
+
+    // MARK: - SQLite synthesis
+
+    private struct TurnSpec {
+        let idx: Int
+        let blob: Data
+    }
+
+    /// Create a minimal AntiGravity-shaped database with just the
+    /// columns the scanner reads.
+    private func writeAntigravityDB(at url: URL, turns: [TurnSpec]) throws {
+        var db: OpaquePointer?
+        XCTAssertEqual(
+            sqlite3_open_v2(url.path, &db, SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE, nil),
+            SQLITE_OK
+        )
+        defer { sqlite3_close_v2(db) }
+        let create = "CREATE TABLE gen_metadata(idx integer PRIMARY KEY, data blob, size integer NOT NULL DEFAULT 0)"
+        XCTAssertEqual(sqlite3_exec(db, create, nil, nil, nil), SQLITE_OK)
+
+        for spec in turns {
+            var statement: OpaquePointer?
+            let insert = "INSERT INTO gen_metadata(idx, data, size) VALUES (?, ?, ?)"
+            XCTAssertEqual(sqlite3_prepare_v2(db, insert, -1, &statement, nil), SQLITE_OK)
+            sqlite3_bind_int(statement, 1, Int32(spec.idx))
+            spec.blob.withUnsafeBytes { raw in
+                sqlite3_bind_blob(statement, 2,
+                                  raw.baseAddress, Int32(spec.blob.count),
+                                  unsafeBitCast(-1, to: sqlite3_destructor_type.self))
+            }
+            sqlite3_bind_int64(statement, 3, sqlite3_int64(spec.blob.count))
+            XCTAssertEqual(sqlite3_step(statement), SQLITE_DONE)
+            sqlite3_finalize(statement)
+        }
+    }
+
+    private func makeTempHome() throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("VibeBarAntigravityScannerTests-\(UUID().uuidString)",
+                                    isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    private func cleanup(_ url: URL) {
+        try? FileManager.default.removeItem(at: url)
+    }
+
+    // MARK: - Decoder unit tests
+
+    func testDecoderExtractsAllFields() throws {
+        let blob = encodeTurnBlob(
+            seconds: 1_779_434_426,
+            nanos: 571_722_000,
+            systemPrompt: 1132,
+            input: 2056,
+            output: 245,
+            cumulativeCache: 16_284,
+            thoughts: 158,
+            tool: 87,
+            requestId: "req-001"
+        )
+        let turn = try XCTUnwrap(AntigravitySessionReader.decodeTurn(blob: blob))
+        XCTAssertEqual(turn.inputTokens, 2056)
+        XCTAssertEqual(turn.outputTokens, 245)
+        XCTAssertEqual(turn.cumulativeCacheReadTokens, 16_284)
+        XCTAssertEqual(turn.thoughtsTokens, 158)
+        XCTAssertEqual(turn.toolTokens, 87)
+        XCTAssertEqual(turn.requestId, "req-001")
+        XCTAssertEqual(turn.date.timeIntervalSince1970,
+                       1_779_434_426 + 571_722_000.0 / 1_000_000_000,
+                       accuracy: 1e-6)
+    }
+
+    func testDecoderHandlesMissingOptionalFields() throws {
+        // First-turn blobs typically omit the cumulative cache field
+        // and the optional thoughts / tool fields.
+        let blob = encodeTurnBlob(
+            seconds: 1_779_434_426,
+            input: 16_738,
+            output: 780,
+            cumulativeCache: 0,
+            requestId: "req-first"
+        )
+        let turn = try XCTUnwrap(AntigravitySessionReader.decodeTurn(blob: blob))
+        XCTAssertEqual(turn.inputTokens, 16_738)
+        XCTAssertEqual(turn.outputTokens, 780)
+        XCTAssertEqual(turn.cumulativeCacheReadTokens, 0)
+        XCTAssertEqual(turn.thoughtsTokens, 0)
+        XCTAssertEqual(turn.toolTokens, 0)
+    }
+
+    func testDecoderRejectsTruncatedBlobs() {
+        let truncated = Data([0x0A]) // tag with no length
+        XCTAssertNil(AntigravitySessionReader.decodeTurn(blob: truncated))
+    }
+
+    // MARK: - End-to-end scanner tests
+
+    func testSingleConversationFlowsThroughScanner() async throws {
+        let home = try makeTempHome()
+        defer { cleanup(home) }
+
+        let convDir = home
+            .appendingPathComponent(".gemini", isDirectory: true)
+            .appendingPathComponent("antigravity", isDirectory: true)
+            .appendingPathComponent("conversations", isDirectory: true)
+        try FileManager.default.createDirectory(at: convDir, withIntermediateDirectories: true)
+
+        let now = Date(timeIntervalSince1970: 1_779_434_500)
+        let dbURL = convDir.appendingPathComponent("synthetic-trajectory.db")
+        let base = UInt64(now.addingTimeInterval(-600).timeIntervalSince1970)
+
+        try writeAntigravityDB(at: dbURL, turns: [
+            TurnSpec(idx: 0, blob: encodeTurnBlob(
+                seconds: base + 0,
+                input: 16_738, output: 780,
+                cumulativeCache: 0, thoughts: 705, tool: 75
+            )),
+            TurnSpec(idx: 1, blob: encodeTurnBlob(
+                seconds: base + 5,
+                input: 2056, output: 245,
+                cumulativeCache: 16_284, thoughts: 158, tool: 87
+            )),
+            TurnSpec(idx: 2, blob: encodeTurnBlob(
+                seconds: base + 10,
+                input: 9_203, output: 250,
+                cumulativeCache: 16_306, thoughts: 175, tool: 75
+            ))
+        ])
+
+        let snapshot = await CostUsageScanner.scan(
+            tool: .antigravity,
+            homeDirectory: home.path,
+            now: now
+        )
+        let snap = try XCTUnwrap(snapshot)
+        XCTAssertEqual(snap.jsonlFilesFound, 1)
+        // Per-turn token totals fed to aggregator:
+        //   idx 0: input 16738, output 780+705+75 = 1560, cache 0
+        //   idx 1: input  2056, output 245+158+87 =  490, cache 16284 (15284 creation + 0 read)
+        //   idx 2: input  9203, output 250+175+75 =  500, cache 16306 (   22 creation + 16284 read)
+        // Total tokens (input+output+cache): 16738+1560 + 2056+490+16284 + 9203+500+16306 = 63137
+        XCTAssertEqual(snap.allTimeTokens, 63_137)
+        // All turns are within the last 7 days from `now`.
+        XCTAssertEqual(snap.last7DaysTokens, 63_137)
+        XCTAssertEqual(snap.modelBreakdowns.map(\.modelName), ["antigravity-default"])
+        XCTAssertGreaterThan(snap.allTimeCostUSD, 0)
+    }
+
+    func testScannerSkipsNonDatabaseFiles() async throws {
+        let home = try makeTempHome()
+        defer { cleanup(home) }
+        let convDir = home
+            .appendingPathComponent(".gemini/antigravity/conversations", isDirectory: true)
+        try FileManager.default.createDirectory(at: convDir, withIntermediateDirectories: true)
+
+        try Data([0x00, 0x01, 0x02]).write(to: convDir.appendingPathComponent("foo.pb"))
+        try Data().write(to: convDir.appendingPathComponent("bar.txt"))
+
+        let snapshot = await CostUsageScanner.scan(
+            tool: .antigravity,
+            homeDirectory: home.path,
+            now: Date()
+        )
+        let snap = try XCTUnwrap(snapshot)
+        XCTAssertEqual(snap.jsonlFilesFound, 0)
+        XCTAssertEqual(snap.allTimeTokens, 0)
+    }
+
+    func testAntigravityCostUsesSonnetRatesForDefault() throws {
+        // `antigravity-default` shadows Claude Sonnet 4.6:
+        //   $3 / Mtok input, $0.30 / Mtok cache read, $3.75 / Mtok cache creation, $15 / Mtok output.
+        let cost = try XCTUnwrap(CostUsagePricing.antigravityCostUSD(
+            model: "antigravity-default",
+            inputTokens: 1_000_000,
+            cacheReadInputTokens: 0,
+            cacheCreationInputTokens: 0,
+            outputTokens: 0
+        ))
+        XCTAssertEqual(cost, 3.0, accuracy: 1e-9)
+    }
+}

--- a/Tests/VibeBarCoreTests/GeminiChatCostScannerTests.swift
+++ b/Tests/VibeBarCoreTests/GeminiChatCostScannerTests.swift
@@ -1,0 +1,111 @@
+import XCTest
+@testable import VibeBarCore
+
+/// AQ's installation stores Gemini CLI usage in chat-history JSONL
+/// files under `~/.gemini/tmp/<project>/chats/session-*.jsonl`, NOT
+/// the OpenTelemetry log the scanner originally only knew how to
+/// read. This suite locks in the chat-history branch: per-message
+/// `tokens.{input,output,cached,thoughts,tool}` records aggregate
+/// into the same CostSnapshot shape Codex / Claude produce.
+final class GeminiChatCostScannerTests: XCTestCase {
+    private func makeTempHome() throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("VibeBarGeminiChatScannerTests-\(UUID().uuidString)",
+                                    isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    private func cleanup(_ url: URL) {
+        try? FileManager.default.removeItem(at: url)
+    }
+
+    private func writeChatSession(
+        home: URL,
+        project: String,
+        sessionFileName: String,
+        startTime: String,
+        sessionId: String,
+        records: [String]
+    ) throws {
+        let chats = home
+            .appendingPathComponent(".gemini", isDirectory: true)
+            .appendingPathComponent("tmp", isDirectory: true)
+            .appendingPathComponent(project, isDirectory: true)
+            .appendingPathComponent("chats", isDirectory: true)
+        try FileManager.default.createDirectory(at: chats, withIntermediateDirectories: true)
+        let header = """
+        {"sessionId":"\(sessionId)","projectHash":"0000","startTime":"\(startTime)","lastUpdated":"\(startTime)","kind":"main"}
+        """
+        let lines = [header] + records
+        try lines.joined(separator: "\n").write(
+            to: chats.appendingPathComponent(sessionFileName),
+            atomically: true,
+            encoding: .utf8
+        )
+    }
+
+    func testChatHistoryGeminiTurnsAggregateIntoSnapshot() async throws {
+        let home = try makeTempHome()
+        defer { cleanup(home) }
+
+        let now = Date(timeIntervalSince1970: 1_779_434_500)
+        try writeChatSession(
+            home: home,
+            project: "example-project",
+            sessionFileName: "session-2026-05-22T10-00-aaaaaaaa.jsonl",
+            startTime: "2026-05-22T10:00:00.000Z",
+            sessionId: "aaaaaaaa-1111-2222-3333-444444444444",
+            records: [
+                #"{"id":"u1","timestamp":"2026-05-22T10:00:00.000Z","type":"user","content":[{"text":"hi"}]}"#,
+                #"{"id":"g1","timestamp":"2026-05-22T10:00:05.000Z","type":"gemini","model":"gemini-2.5-pro","tokens":{"input":1000,"output":100,"cached":0,"thoughts":50,"tool":0,"total":1150}}"#,
+                #"{"id":"u2","timestamp":"2026-05-22T10:00:10.000Z","type":"user","content":[{"text":"and again"}]}"#,
+                #"{"id":"g2","timestamp":"2026-05-22T10:00:15.000Z","type":"gemini","model":"gemini-2.5-pro","tokens":{"input":2000,"output":200,"cached":500,"thoughts":25,"tool":10,"total":2735}}"#
+            ]
+        )
+
+        let snapshot = await CostUsageScanner.scan(
+            tool: .gemini,
+            homeDirectory: home.path,
+            now: now
+        )
+        let snap = try XCTUnwrap(snapshot)
+        XCTAssertEqual(snap.jsonlFilesFound, 1)
+        // Sum:
+        //   g1: input 1000 (cached 0 → non-cached 1000), output 100+50 = 150
+        //   g2: input 2000 (cached 500 → non-cached 1500), output 200+25+10 = 235, cache 500
+        //   Aggregator sums input + output + cache = 1000 + 150 + 1500 + 235 + 500 = 3385
+        XCTAssertEqual(snap.allTimeTokens, 3_385)
+        XCTAssertEqual(snap.modelBreakdowns.map(\.modelName), ["gemini-2.5-pro"])
+        XCTAssertGreaterThan(snap.allTimeCostUSD, 0)
+    }
+
+    func testChatHistorySkipsNonGeminiMessages() async throws {
+        let home = try makeTempHome()
+        defer { cleanup(home) }
+
+        let now = Date(timeIntervalSince1970: 1_779_434_500)
+        try writeChatSession(
+            home: home,
+            project: "example",
+            sessionFileName: "session-2026-05-22T11-00-bbbbbbbb.jsonl",
+            startTime: "2026-05-22T11:00:00.000Z",
+            sessionId: "bbbbbbbb",
+            records: [
+                #"{"id":"u","timestamp":"2026-05-22T11:00:00.000Z","type":"user","content":[{"text":"hi"}]}"#,
+                #"{"id":"t","timestamp":"2026-05-22T11:00:02.000Z","type":"tool","content":[{"text":"ran"}]}"#,
+                #"{"id":"g","timestamp":"2026-05-22T11:00:05.000Z","type":"gemini","model":"gemini-2.5-flash","tokens":{"input":500,"output":50,"cached":0,"thoughts":0,"tool":0,"total":550}}"#
+            ]
+        )
+
+        let snapshot = await CostUsageScanner.scan(
+            tool: .gemini,
+            homeDirectory: home.path,
+            now: now
+        )
+        let snap = try XCTUnwrap(snapshot)
+        // Only the gemini record contributes: input 500 + output 50 = 550 tokens.
+        XCTAssertEqual(snap.allTimeTokens, 550)
+        XCTAssertEqual(snap.modelBreakdowns.map(\.modelName), ["gemini-2.5-flash"])
+    }
+}

--- a/Tests/VibeBarCoreTests/GeminiCostScannerTests.swift
+++ b/Tests/VibeBarCoreTests/GeminiCostScannerTests.swift
@@ -104,9 +104,21 @@ final class GeminiCostScannerTests: XCTestCase {
     }
 
     func testNonGeminiToolsStillBehave() async throws {
-        // Defensive — Antigravity remains cost-blind even though it's
-        // partial-primary; misc providers stay nil.
-        let snapshot = await CostUsageScanner.scan(tool: .antigravity, homeDirectory: NSTemporaryDirectory())
-        XCTAssertNil(snapshot)
+        // Misc providers stay nil; partial-primary cost-aware tools
+        // now return an empty snapshot instead (zero files found, all
+        // counters at zero) — confirms `scan` dispatches by tool but
+        // doesn't fabricate data when nothing is on disk.
+        let miscSnapshot = await CostUsageScanner.scan(tool: .cursor, homeDirectory: NSTemporaryDirectory())
+        XCTAssertNil(miscSnapshot)
+
+        let antigravitySnapshot = await CostUsageScanner.scan(tool: .antigravity, homeDirectory: NSTemporaryDirectory())
+        let antigravitySnap = try XCTUnwrap(antigravitySnapshot)
+        XCTAssertEqual(antigravitySnap.jsonlFilesFound, 0)
+        XCTAssertEqual(antigravitySnap.allTimeTokens, 0)
+
+        let grokSnapshot = await CostUsageScanner.scan(tool: .grok, homeDirectory: NSTemporaryDirectory())
+        let grokSnap = try XCTUnwrap(grokSnapshot)
+        XCTAssertEqual(grokSnap.jsonlFilesFound, 0)
+        XCTAssertEqual(grokSnap.allTimeTokens, 0)
     }
 }

--- a/Tests/VibeBarCoreTests/GrokCostScannerTests.swift
+++ b/Tests/VibeBarCoreTests/GrokCostScannerTests.swift
@@ -1,0 +1,197 @@
+import XCTest
+@testable import VibeBarCore
+
+/// Grok stores each session as `~/.grok/sessions/<urlEncodedCwd>/
+/// <sessionUUID>/updates.jsonl`. Every record carries a cumulative
+/// `_meta.totalTokens` plus `_meta.agentTimestampMs` — per-turn token
+/// delta is the only "what did this turn cost" signal Grok hands us,
+/// so the scanner deltas the running total and 70 / 30 splits the
+/// number across input vs output for cost.
+final class GrokCostScannerTests: XCTestCase {
+    private static let isoFormatter: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime]
+        return f
+    }()
+
+    private func makeTempHome() throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("VibeBarGrokScannerTests-\(UUID().uuidString)",
+                                    isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    private func cleanup(_ url: URL) {
+        try? FileManager.default.removeItem(at: url)
+    }
+
+    private func writeUpdatesFile(
+        home: URL,
+        cwdLabel: String,
+        sessionId: String,
+        records: [(date: Date, total: Int)]
+    ) throws {
+        let dir = home
+            .appendingPathComponent(".grok", isDirectory: true)
+            .appendingPathComponent("sessions", isDirectory: true)
+            .appendingPathComponent(cwdLabel, isDirectory: true)
+            .appendingPathComponent(sessionId, isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let file = dir.appendingPathComponent("updates.jsonl")
+        let lines = records.map { record -> String in
+            let ms = Int64(record.date.timeIntervalSince1970 * 1000)
+            return """
+            {"_meta":{"totalTokens":\(record.total),"agentTimestampMs":\(ms),"updateType":"AvailableCommandsUpdate"},"payload":{}}
+            """
+        }
+        try lines.joined(separator: "\n").write(to: file, atomically: true, encoding: .utf8)
+    }
+
+    func testEmptyHomeProducesEmptySnapshot() async throws {
+        let home = try makeTempHome()
+        defer { cleanup(home) }
+
+        let snapshot = await CostUsageScanner.scan(
+            tool: .grok,
+            homeDirectory: home.path,
+            now: Date()
+        )
+        let snap = try XCTUnwrap(snapshot)
+        XCTAssertEqual(snap.jsonlFilesFound, 0)
+        XCTAssertEqual(snap.allTimeTokens, 0)
+        XCTAssertEqual(snap.allTimeCostUSD, 0)
+    }
+
+    func testSingleSessionDeltaSplitsInputOutputAndCostsAtGrokBuildRate() async throws {
+        let home = try makeTempHome()
+        defer { cleanup(home) }
+
+        let now = Date(timeIntervalSince1970: 1_779_434_500)
+        let t0 = now.addingTimeInterval(-200)
+        let t1 = now.addingTimeInterval(-100)
+        let t2 = now
+        try writeUpdatesFile(
+            home: home,
+            cwdLabel: "%2FUsers%2Fexample%2Fproject",
+            sessionId: "019e4e90-f8b7-7473-9f42-4eba2e254caf",
+            records: [
+                (t0, 1_000),
+                (t1, 6_000),
+                (t2, 11_000)
+            ]
+        )
+
+        let snapshot = await CostUsageScanner.scan(
+            tool: .grok,
+            homeDirectory: home.path,
+            now: now
+        )
+        let snap = try XCTUnwrap(snapshot)
+        XCTAssertEqual(snap.jsonlFilesFound, 1)
+        XCTAssertEqual(snap.allTimeTokens, 11_000,
+                       "First-row floor (1000) + two 5000 deltas should equal the latest cumulative")
+
+        // 70 / 30 split → per-Mtok blended cost for grok-build:
+        //   0.7 * $1 + 0.3 * $2 = $1.30 per million tokens
+        // 11_000 tokens * $1.30/Mtok = $0.01430
+        XCTAssertEqual(snap.allTimeCostUSD, 0.0143, accuracy: 0.0001)
+        XCTAssertEqual(snap.modelBreakdowns.map(\.modelName), ["grok-build"])
+    }
+
+    func testMultipleSessionsAggregateAcrossWorkingDirectories() async throws {
+        let home = try makeTempHome()
+        defer { cleanup(home) }
+
+        let now = Date(timeIntervalSince1970: 1_779_434_500)
+        try writeUpdatesFile(
+            home: home,
+            cwdLabel: "%2FUsers%2Fexample%2Fa",
+            sessionId: "session-a",
+            records: [
+                (now.addingTimeInterval(-3 * 86_400), 2_000),
+                (now.addingTimeInterval(-3 * 86_400 + 60), 4_500)
+            ]
+        )
+        try writeUpdatesFile(
+            home: home,
+            cwdLabel: "%2FUsers%2Fexample%2Fb",
+            sessionId: "session-b",
+            records: [
+                (now.addingTimeInterval(-1 * 86_400), 1_000),
+                (now.addingTimeInterval(-1 * 86_400 + 60), 3_000)
+            ]
+        )
+
+        let snapshot = await CostUsageScanner.scan(
+            tool: .grok,
+            homeDirectory: home.path,
+            now: now
+        )
+        let snap = try XCTUnwrap(snapshot)
+        XCTAssertEqual(snap.jsonlFilesFound, 2)
+        // session-a: 2000 + (4500 - 2000) = 4500
+        // session-b: 1000 + (3000 - 1000) = 3000
+        XCTAssertEqual(snap.allTimeTokens, 7_500)
+        XCTAssertGreaterThan(snap.dailyHistory.count, 1)
+    }
+
+    func testCacheReusesEventsWhenFingerprintMatches() async throws {
+        let home = try makeTempHome()
+        defer { cleanup(home) }
+
+        let now = Date(timeIntervalSince1970: 1_779_434_500)
+        try writeUpdatesFile(
+            home: home,
+            cwdLabel: "%2FUsers%2Fexample%2Fc",
+            sessionId: "session-c",
+            records: [
+                (now.addingTimeInterval(-300), 1_000),
+                (now.addingTimeInterval(-200), 5_000)
+            ]
+        )
+
+        let firstScan = await CostUsageScanner.scan(
+            tool: .grok,
+            homeDirectory: home.path,
+            now: now
+        )
+        let firstSnap = try XCTUnwrap(firstScan)
+        let secondScan = await CostUsageScanner.scan(
+            tool: .grok,
+            homeDirectory: home.path,
+            now: now
+        )
+        let secondSnap = try XCTUnwrap(secondScan)
+        XCTAssertEqual(firstSnap.allTimeTokens, secondSnap.allTimeTokens)
+        XCTAssertEqual(firstSnap.allTimeCostUSD, secondSnap.allTimeCostUSD, accuracy: 1e-9)
+    }
+
+    func testGrokPricingAtPublishedRates() throws {
+        // grok-build is published at $1 / $2 per million tokens.
+        let oneMillionInput = try XCTUnwrap(CostUsagePricing.grokCostUSD(
+            model: "grok-build",
+            inputTokens: 1_000_000,
+            cachedInputTokens: 0,
+            outputTokens: 0
+        ))
+        XCTAssertEqual(oneMillionInput, 1.0, accuracy: 1e-9)
+
+        let oneMillionOutput = try XCTUnwrap(CostUsagePricing.grokCostUSD(
+            model: "grok-build",
+            inputTokens: 0,
+            cachedInputTokens: 0,
+            outputTokens: 1_000_000
+        ))
+        XCTAssertEqual(oneMillionOutput, 2.0, accuracy: 1e-9)
+
+        // grok-4 fast variant: $0.20 / $0.50 per Mtok.
+        let fastInput = try XCTUnwrap(CostUsagePricing.grokCostUSD(
+            model: "grok-4-fast",
+            inputTokens: 1_000_000,
+            cachedInputTokens: 0,
+            outputTokens: 0
+        ))
+        XCTAssertEqual(fastInput, 0.2, accuracy: 1e-9)
+    }
+}

--- a/Tests/VibeBarCoreTests/PartialPrimaryToolTypeTests.swift
+++ b/Tests/VibeBarCoreTests/PartialPrimaryToolTypeTests.swift
@@ -28,20 +28,22 @@ final class PartialPrimaryToolTypeTests: XCTestCase {
         XCTAssertTrue(ToolType.grok.isPartialPrimary)
         XCTAssertTrue(ToolType.grok.supportsDedicatedCard)
         XCTAssertFalse(ToolType.grok.isPrimary)
-        XCTAssertFalse(ToolType.grok.supportsTokenCost)
+        XCTAssertTrue(ToolType.grok.supportsTokenCost,
+                      "Grok joined the cost-aware club: ~/.grok/sessions/**/updates.jsonl carries per-session running totals")
         XCTAssertFalse(ToolType.grok.supportsStatusPage)
         XCTAssertFalse(ToolType.grok.isMiscPageProvider)
     }
 
-    func testGeminiSupportsTokenCostAntigravityDoesNot() {
-        // Gemini joined the cost-aware club: the OpenTelemetry log
-        // (~/.gemini/telemetry.log, when telemetry is enabled) carries
-        // per-call token counts. Antigravity has no public protocol
-        // exposing token-level data, so it stays cost-blind.
+    func testGoogleAIPairSupportsTokenCost() {
+        // Gemini reads the OpenTelemetry log + chat-history JSONL;
+        // AntiGravity reads the per-conversation SQLite stores under
+        // ~/.gemini/antigravity/conversations/*.db. Both join Codex /
+        // Claude in the cost-aware tier, even though they're
+        // partial-primary in every other respect.
         XCTAssertTrue(ToolType.gemini.supportsTokenCost,
-                      "Gemini should support token cost via OpenTelemetry log scanning")
-        XCTAssertFalse(ToolType.antigravity.supportsTokenCost,
-                       "Antigravity has no public token-count protocol")
+                      "Gemini should support token cost via telemetry + chat-history scanning")
+        XCTAssertTrue(ToolType.antigravity.supportsTokenCost,
+                      "AntiGravity should support token cost via per-conversation SQLite scanning")
     }
 
     func testGoogleAIPairSupportsStatusPage() {

--- a/Tests/VibeBarCoreTests/PricingRefresherTests.swift
+++ b/Tests/VibeBarCoreTests/PricingRefresherTests.swift
@@ -1,0 +1,239 @@
+import XCTest
+@testable import VibeBarCore
+
+/// Exercises `PricingRefresher` against a stubbed URLProtocol so we
+/// can assert behavior on the happy path (200 → cache written),
+/// freshness short-circuit (cache present + within window → skipped),
+/// schema mismatch (unknown version → rejected), and network failure
+/// (left cache untouched).
+final class PricingRefresherTests: XCTestCase {
+    private final class StubURLProtocol: URLProtocol {
+        nonisolated(unsafe) static var responder: (@Sendable (URLRequest) -> (HTTPURLResponse, Data?))?
+        override class func canInit(with request: URLRequest) -> Bool { true }
+        override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+        override func startLoading() {
+            guard let responder = StubURLProtocol.responder else {
+                client?.urlProtocol(self, didFailWithError: URLError(.notConnectedToInternet))
+                return
+            }
+            let (response, data) = responder(request)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            if let data {
+                client?.urlProtocol(self, didLoad: data)
+            }
+            client?.urlProtocolDidFinishLoading(self)
+        }
+        override func stopLoading() {}
+    }
+
+    private func makeStubbedSession() -> URLSession {
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [StubURLProtocol.self]
+        return URLSession(configuration: config)
+    }
+
+    private func makeTempHome() throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("VibeBarPricingRefresherTests-\(UUID().uuidString)",
+                                    isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    private func cleanup(_ url: URL) {
+        try? FileManager.default.removeItem(at: url)
+    }
+
+    override func tearDown() {
+        StubURLProtocol.responder = nil
+        super.tearDown()
+    }
+
+    func testFreshCacheSkipsNetwork() async throws {
+        let home = try makeTempHome()
+        defer { cleanup(home) }
+
+        // Write a fresh cache.
+        let cacheURL = PricingResolver.cacheFileURL(homeDirectory: home.path)
+        try FileManager.default.createDirectory(
+            at: cacheURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        let dataSet = PricingHardcoded.fallback
+        try JSONEncoder().encode(dataSet).write(to: cacheURL)
+
+        StubURLProtocol.responder = { _ in
+            XCTFail("Network should not be hit when cache is fresh")
+            return (HTTPURLResponse(), nil)
+        }
+
+        let outcome = await PricingRefresher.refresh(
+            homeDirectory: home.path,
+            session: makeStubbedSession(),
+            interval: 86_400
+        )
+        XCTAssertEqual(outcome, .skippedFresh)
+    }
+
+    func testSuccessfulFetchWritesCache() async throws {
+        let home = try makeTempHome()
+        defer { cleanup(home) }
+
+        let dataSet = PricingDataSet(
+            schemaVersion: 1,
+            updatedAt: "2026-06-01",
+            calculationVersion: 5,
+            providers: PricingHardcoded.fallback.providers
+        )
+        let body = try JSONEncoder().encode(dataSet)
+
+        StubURLProtocol.responder = { request in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: "HTTP/1.1",
+                headerFields: nil
+            )!
+            return (response, body)
+        }
+
+        let outcome = await PricingRefresher.refresh(
+            homeDirectory: home.path,
+            session: makeStubbedSession(),
+            force: true
+        )
+        XCTAssertEqual(outcome, .fetched)
+
+        let cacheURL = PricingResolver.cacheFileURL(homeDirectory: home.path)
+        let read = try Data(contentsOf: cacheURL)
+        let decoded = try JSONDecoder().decode(PricingDataSet.self, from: read)
+        XCTAssertEqual(decoded.updatedAt, "2026-06-01")
+    }
+
+    func testSchemaMismatchRejectsBadPayload() async throws {
+        let home = try makeTempHome()
+        defer { cleanup(home) }
+
+        let bad = PricingDataSet(
+            schemaVersion: 999,
+            updatedAt: "future",
+            calculationVersion: 5,
+            providers: PricingHardcoded.fallback.providers
+        )
+        let body = try JSONEncoder().encode(bad)
+        StubURLProtocol.responder = { request in
+            let response = HTTPURLResponse(url: request.url!,
+                                           statusCode: 200,
+                                           httpVersion: "HTTP/1.1",
+                                           headerFields: nil)!
+            return (response, body)
+        }
+
+        let outcome = await PricingRefresher.refresh(
+            homeDirectory: home.path,
+            session: makeStubbedSession(),
+            force: true
+        )
+        XCTAssertEqual(outcome, .schemaMismatch)
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: PricingResolver.cacheFileURL(homeDirectory: home.path).path),
+            "Cache should not be written when schemaVersion mismatches"
+        )
+    }
+
+    func testOversizedPayloadIsRejected() async throws {
+        let home = try makeTempHome()
+        defer { cleanup(home) }
+
+        let oversize = Data(repeating: 0x20, count: PricingDataSet.maxBytes + 1)
+        StubURLProtocol.responder = { request in
+            let response = HTTPURLResponse(url: request.url!,
+                                           statusCode: 200,
+                                           httpVersion: "HTTP/1.1",
+                                           headerFields: nil)!
+            return (response, oversize)
+        }
+
+        let outcome = await PricingRefresher.refresh(
+            homeDirectory: home.path,
+            session: makeStubbedSession(),
+            force: true
+        )
+        XCTAssertEqual(outcome, .oversized)
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: PricingResolver.cacheFileURL(homeDirectory: home.path).path)
+        )
+    }
+
+    func testNetworkFailureLeavesCacheIntact() async throws {
+        let home = try makeTempHome()
+        defer { cleanup(home) }
+
+        // Seed existing cache.
+        let cacheURL = PricingResolver.cacheFileURL(homeDirectory: home.path)
+        try FileManager.default.createDirectory(
+            at: cacheURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        let seed = try JSONEncoder().encode(PricingHardcoded.fallback)
+        try seed.write(to: cacheURL)
+
+        StubURLProtocol.responder = { request in
+            let response = HTTPURLResponse(url: request.url!,
+                                           statusCode: 500,
+                                           httpVersion: "HTTP/1.1",
+                                           headerFields: nil)!
+            return (response, nil)
+        }
+
+        let outcome = await PricingRefresher.refresh(
+            homeDirectory: home.path,
+            session: makeStubbedSession(),
+            force: true
+        )
+        XCTAssertEqual(outcome, .networkFailure)
+
+        // Cache file is untouched.
+        let read = try Data(contentsOf: cacheURL)
+        XCTAssertEqual(read, seed)
+    }
+
+    func testNotModifiedTouchesCacheMtime() async throws {
+        let home = try makeTempHome()
+        defer { cleanup(home) }
+
+        let cacheURL = PricingResolver.cacheFileURL(homeDirectory: home.path)
+        try FileManager.default.createDirectory(
+            at: cacheURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        let seed = try JSONEncoder().encode(PricingHardcoded.fallback)
+        try seed.write(to: cacheURL)
+        let oldDate = Date(timeIntervalSince1970: 1_700_000_000)
+        try FileManager.default.setAttributes(
+            [.modificationDate: oldDate],
+            ofItemAtPath: cacheURL.path
+        )
+
+        StubURLProtocol.responder = { request in
+            let response = HTTPURLResponse(url: request.url!,
+                                           statusCode: 304,
+                                           httpVersion: "HTTP/1.1",
+                                           headerFields: nil)!
+            return (response, nil)
+        }
+
+        let now = Date()
+        let outcome = await PricingRefresher.refresh(
+            homeDirectory: home.path,
+            session: makeStubbedSession(),
+            force: true,
+            now: now
+        )
+        XCTAssertEqual(outcome, .unchanged)
+
+        let attrs = try FileManager.default.attributesOfItem(atPath: cacheURL.path)
+        let newModDate = try XCTUnwrap(attrs[.modificationDate] as? Date)
+        XCTAssertGreaterThan(newModDate, oldDate)
+    }
+}

--- a/Tests/VibeBarCoreTests/PricingResolverTests.swift
+++ b/Tests/VibeBarCoreTests/PricingResolverTests.swift
@@ -1,0 +1,154 @@
+import XCTest
+@testable import VibeBarCore
+
+/// Locks the three-tier resolution chain:
+///   cache (~/.vibebar/pricing_cache.json)
+///     → bundled (Resources/pricing.json via Bundle.module)
+///       → hardcoded (PricingHardcoded.fallback)
+final class PricingResolverTests: XCTestCase {
+    private func makeTempHome() throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("VibeBarPricingResolverTests-\(UUID().uuidString)",
+                                    isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    private func cleanup(_ url: URL) {
+        try? FileManager.default.removeItem(at: url)
+    }
+
+    private func writeCache(to home: URL, dataSet: PricingDataSet) throws {
+        let cacheDir = home.appendingPathComponent(".vibebar", isDirectory: true)
+        try FileManager.default.createDirectory(at: cacheDir, withIntermediateDirectories: true)
+        let cacheFile = cacheDir.appendingPathComponent("pricing_cache.json")
+        let data = try JSONEncoder().encode(dataSet)
+        try data.write(to: cacheFile)
+    }
+
+    func testBundledResourceLoads() {
+        // No cache present, so resolver must hit the bundled JSON
+        // and return a valid data set with all five providers.
+        let bundled = try? XCTUnwrap(PricingResolver.loadBundled())
+        XCTAssertNotNil(bundled)
+        XCTAssertEqual(bundled?.schemaVersion, PricingDataSet.currentSchemaVersion)
+        XCTAssertGreaterThan(bundled?.providers.codex.models.count ?? 0, 0)
+        XCTAssertGreaterThan(bundled?.providers.claude.models.count ?? 0, 0)
+        XCTAssertGreaterThan(bundled?.providers.gemini.models.count ?? 0, 0)
+        XCTAssertGreaterThan(bundled?.providers.grok.models.count ?? 0, 0)
+        XCTAssertGreaterThan(bundled?.providers.antigravity.models.count ?? 0, 0)
+    }
+
+    func testCacheOverridesBundle() throws {
+        let home = try makeTempHome()
+        defer { cleanup(home) }
+
+        let cacheDataSet = PricingDataSet(
+            schemaVersion: 1,
+            updatedAt: "2099-01-01",
+            calculationVersion: 99,
+            providers: PricingDataSet.Providers(
+                codex: PricingHardcoded.fallback.providers.codex,
+                claude: PricingHardcoded.fallback.providers.claude,
+                gemini: PricingHardcoded.fallback.providers.gemini,
+                grok: PricingHardcoded.fallback.providers.grok,
+                antigravity: PricingHardcoded.fallback.providers.antigravity
+            )
+        )
+        try writeCache(to: home, dataSet: cacheDataSet)
+
+        let resolved = PricingResolver.resolve(homeDirectory: home.path)
+        XCTAssertEqual(resolved.updatedAt, "2099-01-01")
+        XCTAssertEqual(resolved.calculationVersion, 99)
+    }
+
+    func testCorruptCacheFallsBackToBundle() throws {
+        let home = try makeTempHome()
+        defer { cleanup(home) }
+        let cacheDir = home.appendingPathComponent(".vibebar", isDirectory: true)
+        try FileManager.default.createDirectory(at: cacheDir, withIntermediateDirectories: true)
+        try Data("not json".utf8).write(to: cacheDir.appendingPathComponent("pricing_cache.json"))
+
+        let resolved = PricingResolver.resolve(homeDirectory: home.path)
+        XCTAssertEqual(resolved.schemaVersion, PricingDataSet.currentSchemaVersion)
+        // Bundle ships a real updatedAt, not the corrupt placeholder.
+        XCTAssertFalse(resolved.updatedAt.isEmpty)
+    }
+
+    func testSchemaMismatchCacheIgnored() throws {
+        let home = try makeTempHome()
+        defer { cleanup(home) }
+
+        let wrongSchema = PricingDataSet(
+            schemaVersion: 99,
+            updatedAt: "future-format",
+            calculationVersion: 0,
+            providers: PricingHardcoded.fallback.providers
+        )
+        try writeCache(to: home, dataSet: wrongSchema)
+
+        let resolved = PricingResolver.resolve(homeDirectory: home.path)
+        XCTAssertEqual(resolved.schemaVersion, PricingDataSet.currentSchemaVersion)
+        XCTAssertNotEqual(resolved.updatedAt, "future-format")
+    }
+
+    func testBundledMatchesHardcodedForSentinelModels() throws {
+        // The bundled JSON is generated alongside `PricingHardcoded`
+        // and must stay in lockstep. Drift between the two would
+        // produce different cost numbers depending on whether the
+        // bundle resource is loadable at runtime — never acceptable
+        // for a production install. Sample a few sentinel models per
+        // provider; if any of these miss, audit the full table.
+        let bundled = try XCTUnwrap(PricingResolver.loadBundled())
+        let hardcoded = PricingHardcoded.fallback
+
+        XCTAssertEqual(bundled.calculationVersion, hardcoded.calculationVersion)
+
+        let claudeSentinel = "claude-opus-4-7"
+        XCTAssertEqual(
+            bundled.providers.claude.models[claudeSentinel],
+            hardcoded.providers.claude.models[claudeSentinel],
+            "Claude \(claudeSentinel) drift between bundled JSON and hardcoded fallback"
+        )
+
+        let codexSentinel = "gpt-5"
+        XCTAssertEqual(
+            bundled.providers.codex.models[codexSentinel],
+            hardcoded.providers.codex.models[codexSentinel],
+            "Codex \(codexSentinel) drift between bundled JSON and hardcoded fallback"
+        )
+
+        let geminiSentinel = "gemini-2.5-pro"
+        XCTAssertEqual(
+            bundled.providers.gemini.models[geminiSentinel],
+            hardcoded.providers.gemini.models[geminiSentinel],
+            "Gemini \(geminiSentinel) drift between bundled JSON and hardcoded fallback"
+        )
+
+        let grokSentinel = "grok-build"
+        XCTAssertEqual(
+            bundled.providers.grok.models[grokSentinel],
+            hardcoded.providers.grok.models[grokSentinel],
+            "Grok \(grokSentinel) drift between bundled JSON and hardcoded fallback"
+        )
+
+        let antigravitySentinel = "antigravity-default"
+        XCTAssertEqual(
+            bundled.providers.antigravity.models[antigravitySentinel],
+            hardcoded.providers.antigravity.models[antigravitySentinel],
+            "AntiGravity \(antigravitySentinel) drift between bundled JSON and hardcoded fallback"
+        )
+    }
+
+    func testTestOverrideTakesPrecedence() {
+        let override = PricingDataSet(
+            schemaVersion: 1,
+            updatedAt: "test-override",
+            calculationVersion: 1,
+            providers: PricingHardcoded.fallback.providers
+        )
+        PricingResolver.testOverride = override
+        defer { PricingResolver.testOverride = nil }
+        XCTAssertEqual(PricingResolver.active.updatedAt, "test-override")
+    }
+}


### PR DESCRIPTION
## Summary

Two related bodies of work shipped together — both unlock easier maintenance of the cost layer.

### Part 1 — Grok and AntiGravity join the cost-aware tier

- **Grok** cost scanning by deltaing the cumulative `_meta.totalTokens` field in `~/.grok/sessions/<cwd>/<uuid>/updates.jsonl`. Each per-turn delta is 70 / 30 split between input and output, then priced against published `grok-build` (and friends) rates.
- **AntiGravity** cost scanning by opening the per-conversation SQLite databases under `~/.gemini/antigravity/conversations/*.db` and decoding the `gen_metadata.data` protobuf blob (raw varint scanner, no SwiftProtobuf dependency). Fields recovered per turn: input, output, cumulative cache-read pool, reasoning tokens, tool tokens, timestamp.
- **Gemini** fixed for the common no-telemetry case: also reads the chat-history JSONL files under `~/.gemini/tmp/<project>/chats/session-*.jsonl`. Previously only the OpenTelemetry log path was scanned, which leaves AQ's installation (and most users who haven't enabled telemetry) showing zeros.
- `ToolType.supportsTokenCost` now returns true for `.grok` and `.antigravity`; `CostUsagePricing.calculationVersion` bumps to 5.
- Grok pricing entries (grok-build, grok-4, grok-4-fast, grok-4.3, grok-4.20, grok-3, grok-3-mini, grok-code-fast-1) and AntiGravity shadow rates (Claude Sonnet 4.6 by default, with `-claude-opus` / `-haiku` / `-gemini-pro` / `-flash` overrides).

### Part 2 — Pricing tables move to bundled JSON + periodic remote refresh

- `Sources/VibeBarCore/Resources/pricing.json` is now the single source of truth for production builds, shipped as a `Bundle.module` resource.
- `PricingResolver` resolves the active data set with strict precedence: `~/.vibebar/pricing_cache.json` → bundled JSON → `PricingHardcoded.fallback`. Snapshotted on first read so rates stay stable mid-process.
- `PricingRefresher` pulls `https://raw.githubusercontent.com/AstroQore/vibe-bar/main/Sources/VibeBarCore/Resources/pricing.json` on launch (best-effort, non-blocking, 24h freshness window, 10s timeout, 64KB cap, schema-validated). Conditional GET via `If-Modified-Since` keeps the request cheap.
- `CostUsagePricing` public signatures unchanged — every caller still goes through `*CostUSD` / `normalize*Model` / `*DisplayLabel`, just reading through `PricingResolver.active` instead of static dicts.

**Update flow after merge:** edit `Sources/VibeBarCore/Resources/pricing.json` on main → push. Every running install picks up the new rates within 24 hours (or instantly on next launch) without a rebuild.

## Out of scope

- `~/.gemini/antigravity-cli/conversations/*.pb` uses an unidentified compressed container format (magic `4f fc 3f 34 …`) and stays unparsed; CLI-only AntiGravity usage will keep showing zero until that format is reverse-engineered. The scanner's comment block calls this out so the next agent doesn't re-investigate.
- Per-turn model identification inside AntiGravity sqlite (only the default Sonnet shadow rate is applied today — explicit `-claude-opus` / `-gemini-flash` etc. keys exist but aren't yet selected per row).

## Test plan

- [x] `swift build` — clean
- [x] `swift test` — 441 tests pass, including new suites:
  - `GrokCostScannerTests` (5 tests)
  - `AntigravityCostScannerTests` (6 tests, 3 protobuf decoder + 2 end-to-end SQLite + 1 pricing rate)
  - `GeminiChatCostScannerTests` (2 tests)
  - `PricingResolverTests` (6 tests covering bundle load, cache precedence, corrupt cache fallback, schema mismatch rejection, bundled-vs-hardcoded drift check, test override hook)
  - `PricingRefresherTests` (6 tests with stubbed URLProtocol: fresh-cache skip, 200 fetch, schema mismatch reject, oversized reject, network failure leaves cache intact, 304 touches mtime)
- [x] `./Scripts/build_app.sh release` — clean
- [x] `codesign -d --entitlements - \".build/Vibe Bar.app\"` — empty plist, no `app-sandbox`
- [x] `codesign --verify --deep --strict \".build/Vibe Bar.app\"` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)