### PR TITLE
Align Google AI and Grok parity

### DIFF
--- a/Sources/VibeBarApp/AppEnvironment.swift
+++ b/Sources/VibeBarApp/AppEnvironment.swift
@@ -76,7 +76,7 @@ final class AppEnvironment: ObservableObject {
                     return MockDataProvider.sampleAccounts()
                 }
                 var visibleAccounts: [AccountIdentity] = []
-                for tool in ToolType.primaryProviders {
+                for tool in ToolType.dedicatedCardProviders {
                     if let account = accounts.accounts(for: tool).first {
                         visibleAccounts.append(account)
                     }
@@ -139,6 +139,8 @@ final class AppEnvironment: ObservableObject {
                 $0.mockEnabled == $1.mockEnabled
                     && $0.claudeUsageMode == $1.claudeUsageMode
                     && $0.codexUsageMode == $1.codexUsageMode
+                    && $0.geminiUsageMode == $1.geminiUsageMode
+                    && $0.antigravityUsageMode == $1.antigravityUsageMode
             }
             .debounce(for: .milliseconds(300), scheduler: RunLoop.main)
             .sink { [weak self] _ in
@@ -186,6 +188,8 @@ final class AppEnvironment: ObservableObject {
         importClaudeBrowserCookiesAndRefreshIfNeeded()
         importPersistentOpenAICookiesAndRefreshIfNeeded()
         importOpenAIBrowserCookiesAndRefreshIfNeeded()
+        importGeminiBrowserCookiesAndRefreshIfNeeded()
+        importGrokBrowserCookiesAndRefreshIfNeeded()
 
         // Push Claude/Codex extras parsed by adapters into CostUsageService.
         service.$lastSuccessByAccount
@@ -229,11 +233,15 @@ final class AppEnvironment: ObservableObject {
     func reloadProviderCredentialsAndRefresh() {
         hasClaudeWebCookies = ClaudeWebCookieStore.hasCookieHeader()
         hasOpenAIWebCookies = OpenAIWebCookieStore.hasCookieHeader()
+        hasGeminiWebCookies = GeminiWebCookieStore.hasCookieHeader()
+        hasGrokWebCookies = GrokWebCookieStore.hasCookieHeader()
         recheckPrimaryRouteHealth()
         importPersistentOpenAICookiesAndRefreshIfNeeded()
         importOpenAIBrowserCookiesAndRefreshIfNeeded()
         importPersistentClaudeCookiesAndRefreshIfNeeded()
         importClaudeBrowserCookiesAndRefreshIfNeeded()
+        importGeminiBrowserCookiesAndRefreshIfNeeded()
+        importGrokBrowserCookiesAndRefreshIfNeeded()
         accountStore.reload(
             codexUsageMode: settingsStore.settings.codexUsageMode,
             claudeUsageMode: settingsStore.claudeUsageMode,
@@ -268,6 +276,8 @@ final class AppEnvironment: ObservableObject {
     func refresh(_ tool: ToolType) {
         hasClaudeWebCookies = ClaudeWebCookieStore.hasCookieHeader()
         hasOpenAIWebCookies = OpenAIWebCookieStore.hasCookieHeader()
+        hasGeminiWebCookies = GeminiWebCookieStore.hasCookieHeader()
+        hasGrokWebCookies = GrokWebCookieStore.hasCookieHeader()
         recheckPrimaryRouteHealth(provider: tool)
         accountStore.reload(
             codexUsageMode: settingsStore.settings.codexUsageMode,
@@ -391,6 +401,7 @@ final class AppEnvironment: ObservableObject {
                 self.isImportingGrokBrowserCookies = false
             }
             self.hasGrokWebCookies = GrokWebCookieStore.hasCookieHeader()
+            self.recheckPrimaryRouteHealth(provider: .grok)
             guard let result else {
                 if userInitiated {
                     self.grokBrowserCookieImportStatus = "No Grok cookies found in readable browser stores."
@@ -438,6 +449,7 @@ final class AppEnvironment: ObservableObject {
                 self.isImportingGeminiBrowserCookies = false
             }
             self.hasGeminiWebCookies = GeminiWebCookieStore.hasCookieHeader()
+            self.recheckPrimaryRouteHealth(provider: .gemini)
             guard let result else {
                 if userInitiated {
                     self.geminiBrowserCookieImportStatus = "No Gemini cookies found in readable browser stores."
@@ -658,6 +670,7 @@ final class AppEnvironment: ObservableObject {
             try GeminiWebCookieStore.deleteCookieHeader()
             geminiBrowserCookieImportStatus = nil
             hasGeminiWebCookies = false
+            recheckPrimaryRouteHealth(provider: .gemini)
             for account in accountStore.accounts(for: .gemini) {
                 quotaService.clear(accountId: account.id)
             }
@@ -683,6 +696,7 @@ final class AppEnvironment: ObservableObject {
             try GrokWebCookieStore.deleteCookieHeader()
             grokBrowserCookieImportStatus = nil
             hasGrokWebCookies = false
+            recheckPrimaryRouteHealth(provider: .grok)
             for account in accountStore.accounts(for: .grok) {
                 quotaService.clear(accountId: account.id)
             }

--- a/Sources/VibeBarApp/StatusItemController.swift
+++ b/Sources/VibeBarApp/StatusItemController.swift
@@ -319,17 +319,14 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
         }
         menu.addItem(.separator())
         menu.addItem(disabledMenuItem("Usage"))
-        // Tray context menu only summarises primary providers — misc
-        // tools are surfaced through the Misc tab in the Overview
-        // popover, not as menu lines here.
-        for tool in ToolType.primaryProviders {
+        for tool in ToolType.dedicatedCardProviders {
             for line in usageMenuLines(for: tool) {
                 menu.addItem(disabledMenuItem(line))
             }
         }
         menu.addItem(.separator())
         menu.addItem(disabledMenuItem("Service Status"))
-        for tool in ToolType.primaryProviders {
+        for tool in ToolType.statusPageProviders {
             menu.addItem(disabledMenuItem(statusSummaryLine(for: tool)))
         }
         menu.addItem(.separator())
@@ -342,7 +339,7 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
     }
 
     private func contextTools(for kind: MenuBarItemKind) -> [ToolType] {
-        ToolType.primaryProviders
+        ToolType.dedicatedCardProviders
     }
 
     private func contextUpdatedLine(for kind: MenuBarItemKind) -> String? {

--- a/Sources/VibeBarApp/Views/MiniQuotaWindowView.swift
+++ b/Sources/VibeBarApp/Views/MiniQuotaWindowView.swift
@@ -17,9 +17,7 @@ struct MiniQuotaWindowView: View {
         let contentByTool = miniContentByTool
         // Mini window only surfaces dedicated-card providers — misc
         // cards live on the Misc tab inside the Overview popover, not
-        // in this floating panel. Today the field catalog only has
-        // Codex / Claude entries, so Gemini / Antigravity stay invisible
-        // here until / unless they grow their own catalog rows.
+        // in this floating panel.
         let visibleTools = ToolType.dedicatedCardProviders.filter { tool in
             contentByTool[tool]?.isEmpty == false
         }
@@ -89,6 +87,9 @@ struct MiniQuotaWindowView: View {
     }
 
     private func isBranchField(_ field: MenuBarFieldOption) -> Bool {
+        if field.tool == .gemini || field.tool == .antigravity {
+            return true
+        }
         switch field.bucketId {
         case "gpt_5_3_codex_spark_five_hour",
              "gpt_5_3_codex_spark_weekly",
@@ -235,6 +236,20 @@ private struct MiniBranchCell: Identifiable {
             return "claude.opus"
         case "weekly_oauth_apps":
             return "claude.oauth"
+        case let id where tool == .gemini && id.contains("flash-lite"):
+            return "gemini.flash-lite"
+        case let id where tool == .gemini && id.contains("flash"):
+            return "gemini.flash"
+        case let id where tool == .gemini && id.contains("pro"):
+            return "gemini.pro"
+        case let id where tool == .antigravity && id.contains("claude"):
+            return "antigravity.claude"
+        case let id where tool == .antigravity && id.contains("flash-lite"):
+            return "antigravity.gemini-flash-lite"
+        case let id where tool == .antigravity && id.contains("flash"):
+            return "antigravity.gemini-flash"
+        case let id where tool == .antigravity && id.contains("gemini") && id.contains("pro"):
+            return "antigravity.gemini-pro"
         default:
             return "\(tool.rawValue).\(field.bucketId)"
         }
@@ -257,6 +272,20 @@ private struct MiniBranchCell: Identifiable {
             return "Opus"
         case "weekly_oauth_apps":
             return "OAuth"
+        case let id where tool == .gemini && id.contains("flash-lite"):
+            return "Lite"
+        case let id where tool == .gemini && id.contains("flash"):
+            return "Flash"
+        case let id where tool == .gemini && id.contains("pro"):
+            return "Pro"
+        case let id where tool == .antigravity && id.contains("claude"):
+            return "Claude"
+        case let id where tool == .antigravity && id.contains("flash-lite"):
+            return "G Lite"
+        case let id where tool == .antigravity && id.contains("flash"):
+            return "G Flash"
+        case let id where tool == .antigravity && id.contains("gemini") && id.contains("pro"):
+            return "G Pro"
         default:
             return (bucket.groupTitle ?? bucket.shortLabel)
                 .replacingOccurrences(of: "GPT-5.3 Codex Spark", with: "Spark")

--- a/Sources/VibeBarApp/Views/MiniWindowGroupLabelCatalog.swift
+++ b/Sources/VibeBarApp/Views/MiniWindowGroupLabelCatalog.swift
@@ -13,7 +13,14 @@ enum MiniWindowGroupLabelCatalog {
         .init(id: "claude.design", title: "CLAUDE · Design", defaultLabel: "Design"),
         .init(id: "claude.routine", title: "CLAUDE · Routine", defaultLabel: "Routine"),
         .init(id: "claude.opus", title: "CLAUDE · Opus", defaultLabel: "Opus"),
-        .init(id: "claude.oauth", title: "CLAUDE · OAuth", defaultLabel: "OAuth")
+        .init(id: "claude.oauth", title: "CLAUDE · OAuth", defaultLabel: "OAuth"),
+        .init(id: "gemini.pro", title: "GEMINI · Pro", defaultLabel: "Pro"),
+        .init(id: "gemini.flash", title: "GEMINI · Flash", defaultLabel: "Flash"),
+        .init(id: "gemini.flash-lite", title: "GEMINI · Flash Lite", defaultLabel: "Lite"),
+        .init(id: "antigravity.claude", title: "ANTIGRAVITY · Claude", defaultLabel: "Claude"),
+        .init(id: "antigravity.gemini-pro", title: "ANTIGRAVITY · Gemini Pro", defaultLabel: "G Pro"),
+        .init(id: "antigravity.gemini-flash", title: "ANTIGRAVITY · Gemini Flash", defaultLabel: "G Flash"),
+        .init(id: "antigravity.gemini-flash-lite", title: "ANTIGRAVITY · Gemini Flash Lite", defaultLabel: "G Lite")
     ]
 
     static func defaultLabel(for id: String) -> String? {

--- a/Sources/VibeBarApp/Views/PopoverRoot.swift
+++ b/Sources/VibeBarApp/Views/PopoverRoot.swift
@@ -119,9 +119,7 @@ struct PopoverRoot: View {
         case .claude:
             ProviderDetailView(tool: .claude, density: density)
         case .status:
-            // Status card only renders providers that actually publish
-            // an Atlassian-style status feed — misc providers don't.
-            ServiceStatusCard(tools: ToolType.primaryProviders)
+            ServiceStatusCard(tools: ToolType.statusPageProviders)
         }
     }
 
@@ -148,10 +146,10 @@ struct PopoverRoot: View {
             return "Usage-only · sign in or paste a key"
         }
         if kind == .compact, overviewPage == .googleAI {
-            return "Gemini + Antigravity · quota only"
+            return "Gemini + Antigravity · quota, cost & status"
         }
         if kind == .compact, overviewPage == .grok {
-            return "xAI · monthly credits"
+            return "xAI · monthly credits, cost & status"
         }
         switch effectiveKind {
         case .compact: return "All providers · quota & cost"
@@ -179,9 +177,7 @@ struct PopoverRoot: View {
         // Header timestamps and refresh state aggregate the providers
         // visible in the current popover. The Misc subpage owns its
         // usage-only integrations; the Google AI subpage aggregates the
-        // partial-primary pair; the Grok subpage shows just `.grok`;
-        // the Overview and Status surfaces stick to the two primary
-        // providers.
+        // partial-primary pair; the Grok subpage shows just `.grok`.
         if kind == .compact, overviewPage == .misc {
             return settingsStore.settings.visibleMiscProviderList
         }
@@ -192,7 +188,8 @@ struct PopoverRoot: View {
             return [.grok]
         }
         switch effectiveKind {
-        case .compact, .status: return ToolType.primaryProviders
+        case .compact:          return ToolType.dedicatedCardProviders
+        case .status:           return ToolType.statusPageProviders
         case .codex:            return [.codex]
         case .claude:           return [.claude]
         }
@@ -411,7 +408,7 @@ private struct OverviewWaterfall: View {
     @EnvironmentObject var environment: AppEnvironment
 
     var body: some View {
-        let snapshots = ToolType.primaryProviders.compactMap { environment.costService.snapshot(for: $0) }
+        let snapshots = ToolType.costAwareProviders.compactMap { environment.costService.snapshot(for: $0) }
         let combinedHistory = CostSnapshotAggregator.combinedDailyHistory(snapshots)
         let combinedHeatmap = CostSnapshotAggregator.combinedHeatmap(snapshots)
         let combinedModels = CostSnapshotAggregator.combinedModelBreakdowns(snapshots)
@@ -426,7 +423,10 @@ private struct OverviewWaterfall: View {
             ) {
                 ProviderQuotaCard(tool: .codex, density: density, compact: false)
                 ProviderQuotaCard(tool: .claude, density: density, compact: false)
-                ForEach(ToolType.primaryProviders, id: \.self) { tool in
+                ForEach(ToolType.partialPrimaryProviders, id: \.self) { tool in
+                    ProviderQuotaCard(tool: tool, density: density, compact: false)
+                }
+                ForEach(ToolType.costAwareProviders, id: \.self) { tool in
                     OverviewCostCard(tool: tool, density: density)
                 }
                 if hasCostData {
@@ -455,21 +455,11 @@ private struct OverviewWaterfall: View {
     }
 }
 
-/// The "Grok" overview sub-page. A single `ProviderQuotaCard` for
-/// `.grok` with no cost / heatmap rails — Grok ships per-month credit
-/// usage only, mirroring the partial-primary contract that Gemini
-/// and Antigravity use.
 private struct GrokPage: View {
     let density: Theme.Density
 
     var body: some View {
-        ColumnMasonryLayout(
-            columns: 1,
-            spacing: density.interSectionSpacing,
-            anchoredItems: 1
-        ) {
-            ProviderQuotaCard(tool: .grok, density: density, compact: false)
-        }
+        ProviderDetailView(tool: .grok, density: density)
     }
 }
 
@@ -477,16 +467,9 @@ private struct GrokPage: View {
 /// **structurally different** bucket shapes — Code Assist returns
 /// per-model fractions, gemini.google.com returns aggregate Current /
 /// Weekly — so each source becomes its own card. Antigravity gets
-/// its own quota card (local-LSP probe), and the page also surfaces
-/// Gemini CLI's full cost panel + service-status feed via the same
-/// detail-view layout the OpenAI / Claude tabs use.
-///
-/// Cost data only lights up if the user has opted into Gemini CLI
-/// telemetry (`~/.gemini/settings.json` → `telemetry.enabled=true`).
-/// Antigravity has no cost data source (its conversation database
-/// is Electron-encrypted protobuf with no public schema). Service
-/// status is shared — Google publishes one feed for the whole
-/// "Gemini" product family covering both CLI and Antigravity.
+/// its own quota card (local-LSP probe), and the page surfaces the
+/// Gemini + Antigravity local cost panels plus the shared Google status
+/// feed.
 private struct GoogleAIDualPage: View {
     let density: Theme.Density
 
@@ -500,8 +483,12 @@ private struct GoogleAIDualPage: View {
         let geminiAccounts = environment.accountStore
             .accounts(for: .gemini)
             .sorted { $0.id < $1.id }
-        let snapshot = environment.costService.snapshot(for: .gemini)
-        let hasCostData = (snapshot?.jsonlFilesFound ?? 0) > 0
+        let costTools = ToolType.googleAIPair
+        let costSnapshots = costTools.compactMap { tool -> (ToolType, CostSnapshot)? in
+            guard let snapshot = environment.costService.snapshot(for: tool),
+                  snapshot.jsonlFilesFound > 0 else { return nil }
+            return (tool, snapshot)
+        }
 
         HStack(alignment: .top, spacing: density.interSectionSpacing) {
             VStack(alignment: .leading, spacing: density.interSectionSpacing) {
@@ -529,7 +516,7 @@ private struct GoogleAIDualPage: View {
                         )
                     }
                 }
-                ServiceStatusCard(tools: [.gemini])
+                ServiceStatusCard(tools: ToolType.googleAIPair)
             }
             .frame(
                 minWidth: googleAILeftColumnMinWidth,
@@ -539,24 +526,16 @@ private struct GoogleAIDualPage: View {
             )
 
             VStack(alignment: .leading, spacing: density.interSectionSpacing) {
-                if let snapshot, hasCostData {
-                    CostHeaderCard(tool: .gemini, snapshot: snapshot, density: density)
-                    CostHistoryView(
-                        tool: .gemini,
-                        snapshot: snapshot,
-                        density: density,
-                        chartHeight: 160
-                    )
-                    ModelRankingList(snapshot: snapshot, density: density)
-                    YearlyContributionHeatmapView(history: snapshot.dailyHistory, density: density, toolName: ToolType.gemini.menuTitle)
-                    UsageHeatmapView(heatmap: snapshot.heatmap, density: density)
-                    UsageRateView(heatmap: snapshot.heatmap, density: density)
+                if !costSnapshots.isEmpty {
+                    ForEach(costSnapshots, id: \.0) { tool, snapshot in
+                        ProviderCostStack(tool: tool, snapshot: snapshot, density: density)
+                    }
                 } else {
                     VStack(alignment: .leading, spacing: 6) {
-                        Text("No Gemini CLI cost data yet.")
+                        Text("No Google AI local cost data yet.")
                             .font(.system(size: density.subtitleFontSize))
                             .foregroundStyle(.secondary)
-                        Text("Enable telemetry to populate this panel: edit ~/.gemini/settings.json and add `\"telemetry\":{\"enabled\":true,\"target\":\"local\",\"outfile\":\".gemini/telemetry.log\"}`, then re-run a `gemini` command.")
+                        Text("Gemini reads ~/.gemini telemetry and chat-history logs; Antigravity reads local conversation databases when they contain token metadata.")
                             .font(.system(size: max(10, density.subtitleFontSize - 1)))
                             .foregroundStyle(.tertiary)
                             .lineLimit(nil)
@@ -586,6 +565,32 @@ private struct GoogleAIDualPage: View {
     }
 }
 
+private struct ProviderCostStack: View {
+    let tool: ToolType
+    let snapshot: CostSnapshot
+    let density: Theme.Density
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: density.interSectionSpacing) {
+            CostHeaderCard(tool: tool, snapshot: snapshot, density: density)
+            CostHistoryView(
+                tool: tool,
+                snapshot: snapshot,
+                density: density,
+                chartHeight: 160
+            )
+            ModelRankingList(snapshot: snapshot, density: density)
+            YearlyContributionHeatmapView(
+                history: snapshot.dailyHistory,
+                density: density,
+                toolName: tool.menuTitle
+            )
+            UsageHeatmapView(heatmap: snapshot.heatmap, density: density)
+            UsageRateView(heatmap: snapshot.heatmap, density: density)
+        }
+    }
+}
+
 /// Sits above the per-provider columns: eight usage metrics in two rows on the
 /// left and current provider status on the right. Both halves get their own
 /// refresh button so the user can pull just-this-card data without firing the
@@ -598,7 +603,7 @@ private struct CombinedTotalsRow: View {
     private let summaryHeight: CGFloat = 134
 
     var body: some View {
-        let snapshots = ToolType.primaryProviders.compactMap { environment.costService.snapshot(for: $0) }
+        let snapshots = ToolType.costAwareProviders.compactMap { environment.costService.snapshot(for: $0) }
         let totalCost = snapshots.reduce(0.0) { $0 + $1.allTimeCostUSD }
         let todayCost = snapshots.reduce(0.0) { $0 + $1.todayCostUSD }
         let weekCost = snapshots.reduce(0.0) { $0 + $1.last7DaysCostUSD }
@@ -729,10 +734,12 @@ private struct OverviewStatusSummaryCard: View {
                 }
                 .disabled(!serviceStatus.inFlight.isEmpty)
             }
-            HStack(spacing: 8) {
-                // Only providers with an Atlassian-style status feed
-                // belong here — misc providers don't publish one.
-                ForEach(ToolType.primaryProviders, id: \.self) { tool in
+            LazyVGrid(
+                columns: [GridItem(.adaptive(minimum: 150), spacing: 8, alignment: .top)],
+                alignment: .leading,
+                spacing: 8
+            ) {
+                ForEach(ToolType.statusPageProviders, id: \.self) { tool in
                     providerStatusTile(tool)
                         .frame(maxWidth: .infinity, alignment: .leading)
                 }
@@ -967,7 +974,10 @@ private struct OverviewCostCard: View {
         switch tool {
         case .codex:  return "No Codex CLI sessions found yet."
         case .claude: return "No Claude CLI sessions found yet."
-        case .alibaba, .alibabaTokenPlan, .gemini, .antigravity, .grok, .copilot, .zai, .minimax, .kimi, .cursor, .mimo, .iflytek, .tencentHunyuan, .tencentTokenPlan, .volcengine, .baiduQianfan, .openCodeGo, .kilo, .kiro, .ollama, .openRouter, .warp:
+        case .gemini: return "No Gemini CLI or chat-history usage found yet."
+        case .antigravity: return "No Antigravity conversation token metadata found yet."
+        case .grok: return "No Grok Build session usage found yet."
+        case .alibaba, .alibabaTokenPlan, .copilot, .zai, .minimax, .kimi, .cursor, .mimo, .iflytek, .tencentHunyuan, .tencentTokenPlan, .volcengine, .baiduQianfan, .openCodeGo, .kilo, .kiro, .ollama, .openRouter, .warp:
             // Misc providers' empty cost-history view shouldn't be
             // reachable (cost cards are gated on
             // `tool.supportsTokenCost`), but render a graceful

--- a/Sources/VibeBarApp/Views/SettingsView.swift
+++ b/Sources/VibeBarApp/Views/SettingsView.swift
@@ -56,10 +56,7 @@ struct SettingsView: View {
                             .font(.caption)
                             .foregroundStyle(.secondary)
                         VStack(alignment: .leading, spacing: 8) {
-                            // Plan badges only meaningful for primary
-                            // providers (Codex, Claude). Misc providers
-                            // expose their plan inline on the misc card.
-                            ForEach(ToolType.primaryProviders, id: \.self) { tool in
+                            ForEach(ToolType.dedicatedCardProviders, id: \.self) { tool in
                                 providerBadgeRow(tool)
                             }
                         }
@@ -242,6 +239,14 @@ struct SettingsView: View {
                             Text("Could not delete saved Gemini cookies.")
                                 .font(.caption2).foregroundStyle(.orange)
                         }
+                        Divider()
+                            .padding(.vertical, 2)
+                        connectionHealthRows(provider: .gemini)
+                        Button {
+                            environment.recheckPrimaryRouteHealth(provider: .gemini)
+                        } label: {
+                            Label("Check Gemini connections", systemImage: "checkmark.circle")
+                        }
 
                         Divider()
                             .padding(.vertical, 2)
@@ -266,6 +271,14 @@ struct SettingsView: View {
                             Text("Antigravity reads the locally running language server. Cookie import is deferred until the Antigravity Cloud endpoint ships.")
                                 .font(.caption2)
                                 .foregroundStyle(.tertiary)
+                        }
+                        Divider()
+                            .padding(.vertical, 2)
+                        connectionHealthRows(provider: .antigravity)
+                        Button {
+                            environment.recheckPrimaryRouteHealth(provider: .antigravity)
+                        } label: {
+                            Label("Check Antigravity connection", systemImage: "checkmark.circle")
                         }
                     }
 
@@ -313,7 +326,16 @@ struct SettingsView: View {
                                 .font(.caption2).foregroundStyle(.orange)
                         }
 
-                        Link("Open grok.com usage dashboard",
+                        Divider()
+                            .padding(.vertical, 2)
+                        connectionHealthRows(provider: .grok)
+                        Button {
+                            environment.recheckPrimaryRouteHealth(provider: .grok)
+                        } label: {
+                            Label("Check Grok connections", systemImage: "checkmark.circle")
+                        }
+
+                        Link("Open xAI status page",
                              destination: ToolType.grok.statusPageURL)
                             .font(.caption2)
                     }

--- a/Sources/VibeBarCore/Adapters/AntigravityQuotaAdapter.swift
+++ b/Sources/VibeBarCore/Adapters/AntigravityQuotaAdapter.swift
@@ -424,7 +424,7 @@ enum AntigravityResponseParser {
             let resetAt = quota.resetTime.flatMap(parseDate)
             let modelId = config.modelOrAlias?.model ?? config.label
             var bucket = QuotaBucket(
-                id: "antigravity.\(modelId)",
+                id: modelId,
                 title: config.label,
                 shortLabel: AntigravityResponseParser.shortLabel(for: modelId),
                 usedPercent: max(0, min(100, (1 - fraction) * 100)),

--- a/Sources/VibeBarCore/Adapters/GeminiQuotaAdapter.swift
+++ b/Sources/VibeBarCore/Adapters/GeminiQuotaAdapter.swift
@@ -263,7 +263,7 @@ enum GeminiResponseParser {
                     withFractional.date(from: raw) ?? plainISO.date(from: raw)
                 }
                 return QuotaBucket(
-                    id: "gemini.\(modelId)",
+                    id: modelId,
                     title: prettyModelName(modelId),
                     shortLabel: shortLabel(for: modelId),
                     usedPercent: max(0, min(100, (1 - info.fraction) * 100)),

--- a/Sources/VibeBarCore/Models/MenuBarSettings.swift
+++ b/Sources/VibeBarCore/Models/MenuBarSettings.swift
@@ -146,7 +146,30 @@ public enum MenuBarFieldCatalog {
         option(.claude, "weekly_oauth_apps", "OAuth Apps · Weekly", "OAuth wk")
     ]
 
-    public static let allFields: [MenuBarFieldOption] = codexFields + claudeFields
+    public static let geminiFields: [MenuBarFieldOption] = [
+        option(.gemini, "gemini-2.5-pro", "Gemini 2.5 Pro", "Pro"),
+        option(.gemini, "gemini-2.5-flash", "Gemini 2.5 Flash", "Flash"),
+        option(.gemini, "gemini-2.5-flash-lite", "Gemini 2.5 Flash Lite", "Lite"),
+        option(.gemini, "gemini-3-pro", "Gemini 3 Pro", "3 Pro"),
+        option(.gemini, "gemini-3-flash", "Gemini 3 Flash", "3 Flash")
+    ]
+
+    public static let antigravityFields: [MenuBarFieldOption] = [
+        option(.antigravity, "claude-sonnet-4-20250514", "Claude Sonnet 4", "Sonnet"),
+        option(.antigravity, "claude-sonnet-4-5", "Claude Sonnet 4.5", "Sonnet"),
+        option(.antigravity, "gemini-2.5-pro", "Gemini 2.5 Pro", "Pro"),
+        option(.antigravity, "gemini-2.5-flash", "Gemini 2.5 Flash", "Flash"),
+        option(.antigravity, "gemini-2.5-flash-lite", "Gemini 2.5 Flash Lite", "Lite"),
+        option(.antigravity, "gemini-3-pro", "Gemini 3 Pro", "3 Pro"),
+        option(.antigravity, "gemini-3-flash", "Gemini 3 Flash", "3 Flash")
+    ]
+
+    public static let grokFields: [MenuBarFieldOption] = [
+        option(.grok, "monthly", "Monthly Credits", "Mo")
+    ]
+
+    public static let allFields: [MenuBarFieldOption] =
+        codexFields + claudeFields + geminiFields + antigravityFields + grokFields
 
     public static func fields(for kind: MenuBarItemKind) -> [MenuBarFieldOption] {
         switch kind {

--- a/Sources/VibeBarCore/Models/PrimaryProviderRouteHealth.swift
+++ b/Sources/VibeBarCore/Models/PrimaryProviderRouteHealth.swift
@@ -9,6 +9,11 @@ public enum PrimaryProviderRoute: String, CaseIterable, Identifiable, Sendable {
     case claudeWebViewCookies
     case claudeOAuth
     case claudeCLI
+    case geminiOAuth
+    case geminiBrowserCookies
+    case antigravityLocalProbe
+    case grokAuthJSON
+    case grokBrowserCookies
 
     public var id: String { rawValue }
 
@@ -18,6 +23,12 @@ public enum PrimaryProviderRoute: String, CaseIterable, Identifiable, Sendable {
             return .codex
         case .claudeBrowserCookies, .claudeWebViewCookies, .claudeOAuth, .claudeCLI:
             return .claude
+        case .geminiOAuth, .geminiBrowserCookies:
+            return .gemini
+        case .antigravityLocalProbe:
+            return .antigravity
+        case .grokAuthJSON, .grokBrowserCookies:
+            return .grok
         }
     }
 
@@ -31,6 +42,11 @@ public enum PrimaryProviderRoute: String, CaseIterable, Identifiable, Sendable {
         case .claudeWebViewCookies: return "WebView cookies"
         case .claudeOAuth: return "OAuth"
         case .claudeCLI: return "CLI"
+        case .geminiOAuth: return "OAuth"
+        case .geminiBrowserCookies: return "Chrome/Safari cookies"
+        case .antigravityLocalProbe: return "Local language server"
+        case .grokAuthJSON: return "~/.grok/auth.json"
+        case .grokBrowserCookies: return "Chrome/Safari cookies"
         }
     }
 
@@ -120,6 +136,160 @@ public enum PrimaryProviderRouteHealthChecker {
             return credentialHealth(route: route, now: now) {
                 _ = try ClaudeCredentialReader.loadFromCLI()
             }
+        case .geminiOAuth:
+            return geminiOAuthHealth(route: route, now: now)
+        case .geminiBrowserCookies:
+            return cookieHealth(
+                route: route,
+                result: GeminiWebCookieStore.storageState(source: .browser),
+                now: now
+            )
+        case .antigravityLocalProbe:
+            return antigravityLocalProbeHealth(route: route, now: now)
+        case .grokAuthJSON:
+            return grokAuthJSONHealth(route: route, now: now)
+        case .grokBrowserCookies:
+            return cookieHealth(
+                route: route,
+                result: GrokWebCookieStore.storageState(source: .browser),
+                now: now
+            )
+        }
+    }
+
+    private static func geminiOAuthHealth(
+        route: PrimaryProviderRoute,
+        now: Date
+    ) -> PrimaryProviderRouteHealth {
+        let url = URL(fileURLWithPath: RealHomeDirectory.path)
+            .appendingPathComponent(".gemini/oauth_creds.json")
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            return PrimaryProviderRouteHealth(
+                route: route,
+                status: .missing,
+                detail: "No oauth_creds.json",
+                checkedAt: now
+            )
+        }
+        do {
+            let credentials = try GeminiCredentials.load(from: url)
+            let hasAccess = credentials.accessToken?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
+            let hasRefresh = credentials.refreshToken?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
+            guard hasAccess || hasRefresh else {
+                return PrimaryProviderRouteHealth(
+                    route: route,
+                    status: .missing,
+                    detail: "Token fields missing",
+                    checkedAt: now
+                )
+            }
+            if let expiry = credentials.expiry, expiry <= now, !hasRefresh {
+                return PrimaryProviderRouteHealth(
+                    route: route,
+                    status: .failed,
+                    detail: "Access token expired",
+                    checkedAt: now
+                )
+            }
+            return PrimaryProviderRouteHealth(
+                route: route,
+                status: .ok,
+                detail: hasRefresh ? "Refresh token available" : "Access token available",
+                checkedAt: now
+            )
+        } catch {
+            return PrimaryProviderRouteHealth(
+                route: route,
+                status: .failed,
+                detail: "Could not read OAuth file",
+                checkedAt: now
+            )
+        }
+    }
+
+    private static func antigravityLocalProbeHealth(
+        route: PrimaryProviderRoute,
+        now: Date
+    ) -> PrimaryProviderRouteHealth {
+        if antigravityLanguageServerIsRunning() {
+            return PrimaryProviderRouteHealth(
+                route: route,
+                status: .ok,
+                detail: "Local LSP running",
+                checkedAt: now
+            )
+        }
+        let dataRoot = URL(fileURLWithPath: RealHomeDirectory.path)
+            .appendingPathComponent(".gemini/antigravity")
+        if FileManager.default.fileExists(atPath: dataRoot.path) {
+            return PrimaryProviderRouteHealth(
+                route: route,
+                status: .missing,
+                detail: "Local data found; LSP not running",
+                checkedAt: now
+            )
+        }
+        return PrimaryProviderRouteHealth(
+            route: route,
+            status: .missing,
+            detail: "No local Antigravity data",
+            checkedAt: now
+        )
+    }
+
+    private static func grokAuthJSONHealth(
+        route: PrimaryProviderRoute,
+        now: Date
+    ) -> PrimaryProviderRouteHealth {
+        do {
+            let credentials = try GrokCredentialsStore.load()
+            if let expiresAt = credentials.expiresAt, expiresAt <= now {
+                return PrimaryProviderRouteHealth(
+                    route: route,
+                    status: .failed,
+                    detail: "auth.json expired",
+                    checkedAt: now
+                )
+            }
+            return PrimaryProviderRouteHealth(
+                route: route,
+                status: .ok,
+                detail: credentials.planLabel ?? "Credentials available",
+                checkedAt: now
+            )
+        } catch let error as QuotaError where error == .noCredential || error == .needsLogin {
+            return PrimaryProviderRouteHealth(
+                route: route,
+                status: .missing,
+                detail: "No auth.json",
+                checkedAt: now
+            )
+        } catch {
+            return PrimaryProviderRouteHealth(
+                route: route,
+                status: .failed,
+                detail: "Could not read auth.json",
+                checkedAt: now
+            )
+        }
+    }
+
+    private static func antigravityLanguageServerIsRunning() -> Bool {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/ps")
+        process.arguments = ["-ax", "-o", "command="]
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = Pipe()
+        do {
+            try process.run()
+            process.waitUntilExit()
+            guard process.terminationStatus == 0 else { return false }
+            let data = pipe.fileHandleForReading.readDataToEndOfFile()
+            guard let output = String(data: data, encoding: .utf8)?.lowercased() else { return false }
+            return output.contains("language_server_macos") && output.contains("antigravity")
+        } catch {
+            return false
         }
     }
 

--- a/Sources/VibeBarCore/Models/ToolType.swift
+++ b/Sources/VibeBarCore/Models/ToolType.swift
@@ -13,8 +13,8 @@ import Foundation
 /// - MiniQuotaWindowView.swift: providerAccent / providerTitle
 /// - ProviderBrandIcon.swift: SF symbol + brand SVG mapping
 ///
-/// Adding a *partial-primary* case (dedicated card without token cost or
-/// status integration) also requires:
+/// Adding a *partial-primary* case (dedicated card outside the two
+/// historical primary menu-bar items) also requires:
 /// - PrimaryProviderSourcePlanner.swift: a per-provider UsageMode + planner
 /// - AccountStore.swift: autoDetect<Provider> helper
 /// - AppSettings.swift: dedicated settings struct + lossy migration from
@@ -25,9 +25,8 @@ import Foundation
 ///   integration, dedicated popover pages, mini-window slots.
 /// - **Partial-Primary** (`.gemini`, `.antigravity`, `.grok`) — dedicated
 ///   popover sub-page (Google AI dual page for Gemini+Antigravity, single
-///   provider page for Grok) + SettingsView panel, but no token-cost
-///   scanning and no Atlassian-style status polling. Share
-///   `supportsDedicatedCard == true` with primary.
+///   provider page for Grok) + SettingsView panel. These can still opt into
+///   token-cost scanning and status polling as provider data becomes known.
 /// - **Misc** (`.alibaba`, `.alibabaTokenPlan`, `.copilot`, `.zai`,
 ///   `.minimax`, `.kimi`, `.cursor`, `.mimo`, `.iflytek`,
 ///   `.tencentHunyuan`, `.tencentTokenPlan`, `.volcengine`, `.baiduQianfan`,
@@ -83,7 +82,7 @@ public enum ToolType: String, Codable, CaseIterable, Hashable, Sendable {
     /// True for providers that get a dedicated popover card, a SettingsView
     /// panel, and multi-source credential fallback. Primary providers are a
     /// proper subset of this set; partial-primary providers (Gemini,
-    /// Antigravity) live here without the cost / status integrations.
+    /// Antigravity, Grok) live here without dedicated menu-bar item kinds.
     public var supportsDedicatedCard: Bool {
         switch self {
         case .codex, .claude, .gemini, .antigravity, .grok: return true
@@ -92,8 +91,8 @@ public enum ToolType: String, Codable, CaseIterable, Hashable, Sendable {
         }
     }
 
-    /// True for the Google AI pair — dedicated card, multi-source
-    /// credentials, no token cost, no status page integration.
+    /// True for dedicated-card providers that do not have their own
+    /// `MenuBarItemKind`.
     public var isPartialPrimary: Bool {
         supportsDedicatedCard && !isPrimary
     }
@@ -120,6 +119,14 @@ public enum ToolType: String, Codable, CaseIterable, Hashable, Sendable {
 
     public static var partialPrimaryProviders: [ToolType] {
         allCases.filter { $0.isPartialPrimary }
+    }
+
+    public static var costAwareProviders: [ToolType] {
+        allCases.filter { $0.supportsTokenCost }
+    }
+
+    public static var statusPageProviders: [ToolType] {
+        allCases.filter { $0.supportsStatusPage }
     }
 
     public static var miscPageProviders: [ToolType] {
@@ -162,11 +169,12 @@ public enum ToolType: String, Codable, CaseIterable, Hashable, Sendable {
     /// `.antigravity` share the Google Apps Status dashboard feed
     /// (`https://www.google.com/appsstatus/dashboard/incidents.json`,
     /// filtered to product id `npdyhgECDJ6tB66MxXyo` = "Gemini").
+    /// Grok reads the xAI service-status HTML at `https://status.x.ai/`.
     /// Codex / Claude use their own Atlassian / incident.io feeds.
     public var supportsStatusPage: Bool {
         switch self {
-        case .codex, .claude, .gemini, .antigravity: return true
-        case .alibaba, .alibabaTokenPlan, .grok, .copilot, .zai, .minimax, .kimi, .cursor, .mimo, .iflytek, .tencentHunyuan, .tencentTokenPlan, .volcengine, .baiduQianfan, .openCodeGo, .kilo, .kiro, .ollama, .openRouter, .warp:
+        case .codex, .claude, .gemini, .antigravity, .grok: return true
+        case .alibaba, .alibabaTokenPlan, .copilot, .zai, .minimax, .kimi, .cursor, .mimo, .iflytek, .tencentHunyuan, .tencentTokenPlan, .volcengine, .baiduQianfan, .openCodeGo, .kilo, .kiro, .ollama, .openRouter, .warp:
             return false
         }
     }
@@ -290,8 +298,9 @@ public enum ToolType: String, Codable, CaseIterable, Hashable, Sendable {
     }
 
     /// Click-through URL for the provider's status / dashboard page.
-    /// The Atlassian-style API endpoints (`statusSummaryAPI` etc.) are
-    /// only meaningful when `supportsStatusPage` is true.
+    /// The Statuspage-style API endpoints (`statusSummaryAPI` etc.) are
+    /// meaningful only for providers backed by those APIs; xAI/Grok is
+    /// scraped from HTML at this URL instead.
     public var statusPageURL: URL {
         switch self {
         case .codex:       return URL(string: "https://status.openai.com/")!
@@ -300,7 +309,7 @@ public enum ToolType: String, Codable, CaseIterable, Hashable, Sendable {
         case .alibabaTokenPlan: return URL(string: "https://bailian.console.aliyun.com/cn-beijing?tab=plan#/efm/subscription/token-plan")!
         case .gemini:      return URL(string: "https://status.cloud.google.com/")!
         case .antigravity: return URL(string: "https://antigravity.google/")!
-        case .grok:        return URL(string: "https://grok.com/?_s=usage")!
+        case .grok:        return URL(string: "https://status.x.ai/")!
         case .copilot:     return URL(string: "https://www.githubstatus.com/")!
         case .zai:         return URL(string: "https://www.z.ai/")!
         case .minimax:     return URL(string: "https://platform.minimax.io/")!

--- a/Sources/VibeBarCore/Services/CostUsageScanner.swift
+++ b/Sources/VibeBarCore/Services/CostUsageScanner.swift
@@ -746,9 +746,9 @@ public enum CostUsageScanner {
     // Timestamp lives at path `1.9.4` (seconds + nanos).
     //
     // The CLI-only `~/.gemini/antigravity-cli/conversations/*.pb`
-    // container uses an unidentified compressed format (magic bytes
-    // `4f fc 3f 34 …`) and stays unparsed — we accept that CLI-only
-    // AntiGravity usage is dark until that format is reverse-engineered.
+    // container is an unidentified binary format, and the companion
+    // transcript/history JSONL files do not carry token counts. CLI-only
+    // AntiGravity usage stays dark until that format is reverse-engineered.
 
     private static func scanAntigravity(
         homeDirectory: String,

--- a/Sources/VibeBarCore/Services/MockDataProvider.swift
+++ b/Sources/VibeBarCore/Services/MockDataProvider.swift
@@ -221,24 +221,24 @@ public enum MockDataProvider {
             // shape Gemini CLI / Web returns. Reset times are arbitrary —
             // the live data overrides whichever fields are present.
             buckets = [
-                QuotaBucket(id: "gemini.pro", title: "Pro", shortLabel: "Pro",
+                QuotaBucket(id: "gemini-2.5-pro", title: "Pro", shortLabel: "Pro",
                             usedPercent: 78, resetAt: weeklyReset, rawWindowSeconds: nil, groupTitle: "Pro"),
-                QuotaBucket(id: "gemini.flash", title: "Flash", shortLabel: "Flash",
+                QuotaBucket(id: "gemini-2.5-flash", title: "Flash", shortLabel: "Flash",
                             usedPercent: 33, resetAt: weeklyReset, rawWindowSeconds: nil, groupTitle: "Flash"),
-                QuotaBucket(id: "gemini.flash-lite", title: "Flash Lite", shortLabel: "Lite",
+                QuotaBucket(id: "gemini-2.5-flash-lite", title: "Flash Lite", shortLabel: "Lite",
                             usedPercent: 9, resetAt: weeklyReset, rawWindowSeconds: nil, groupTitle: "Flash Lite")
             ]
         case .antigravity:
             // Partial-primary mock: the live Antigravity LSP groups
             // buckets by Gemini Pro / Flash / Claude variants.
             buckets = [
-                QuotaBucket(id: "antigravity.gemini-3-pro", title: "Gemini Pro",
+                QuotaBucket(id: "gemini-3-pro", title: "Gemini Pro",
                             shortLabel: "Pro", usedPercent: 41, resetAt: fiveHourReset,
                             rawWindowSeconds: nil, groupTitle: "Gemini Pro"),
-                QuotaBucket(id: "antigravity.gemini-3-flash", title: "Gemini Flash",
+                QuotaBucket(id: "gemini-3-flash", title: "Gemini Flash",
                             shortLabel: "Flash", usedPercent: 17, resetAt: fiveHourReset,
                             rawWindowSeconds: nil, groupTitle: "Gemini Flash"),
-                QuotaBucket(id: "antigravity.claude-sonnet-4-5", title: "Claude Sonnet 4.5",
+                QuotaBucket(id: "claude-sonnet-4-5", title: "Claude Sonnet 4.5",
                             shortLabel: "Sonnet", usedPercent: 71, resetAt: fiveHourReset,
                             rawWindowSeconds: nil, groupTitle: "Claude")
             ]

--- a/Sources/VibeBarCore/Services/ServiceStatusClient.swift
+++ b/Sources/VibeBarCore/Services/ServiceStatusClient.swift
@@ -24,8 +24,10 @@ public actor ServiceStatusClient {
             // Apps Status product (id `npdyhgECDJ6tB66MxXyo` =
             // "Gemini"), so they share one feed.
             return try await fetchGoogleAppsStatus(tool: tool, dayCount: dayCount, now: now)
-        case .alibaba, .alibabaTokenPlan, .grok, .copilot, .zai, .minimax, .kimi, .cursor, .mimo, .iflytek, .tencentHunyuan, .tencentTokenPlan, .volcengine, .baiduQianfan, .openCodeGo, .kilo, .kiro, .ollama, .openRouter, .warp:
-            // Misc providers don't expose Atlassian-style status APIs.
+        case .grok:
+            return try await fetchXAIStatus(dayCount: dayCount, now: now)
+        case .alibaba, .alibabaTokenPlan, .copilot, .zai, .minimax, .kimi, .cursor, .mimo, .iflytek, .tencentHunyuan, .tencentTokenPlan, .volcengine, .baiduQianfan, .openCodeGo, .kilo, .kiro, .ollama, .openRouter, .warp:
+            // Misc providers don't expose known machine-readable status APIs.
             // `tool.supportsStatusPage` is `false` for all of them, and
             // upstream callers should already be filtering to primary
             // tools via `tool.supportsStatusPage` before reaching here.
@@ -42,6 +44,329 @@ public actor ServiceStatusClient {
                 recentIncidents: []
             )
         }
+    }
+
+    // MARK: - xAI Status (HTML status.x.ai)
+
+    private static let xAIComponentPageSpecs: [(id: String, name: String, path: String)] = [
+        ("grok-com", "Grok (Web)", "grok-com"),
+        ("ios-app", "Grok (iOS)", "ios-app"),
+        ("android-app", "Grok (Android)", "android-app"),
+        ("grok-in-x", "Grok in X", "grok-in-x"),
+        ("api-us-east-1", "API (us-east-1.api.x.ai)", "api-us-east-1"),
+        ("api-eu-west-1", "API (eu-west-1.api.x.ai)", "api-eu-west-1"),
+        ("api-console", "API Console", "api-console")
+    ]
+
+    private func fetchXAIStatus(dayCount: Int, now: Date) async throws -> ServiceStatusSnapshot {
+        let overviewHTML = try await fetchHTML(url: ToolType.grok.statusPageURL)
+        var componentPages: [(id: String, name: String, url: URL, html: String)] = []
+        for spec in Self.xAIComponentPageSpecs {
+            guard let url = URL(string: spec.path, relativeTo: ToolType.grok.statusPageURL)?.absoluteURL else {
+                continue
+            }
+            if let html = try? await fetchHTML(url: url) {
+                componentPages.append((id: spec.id, name: spec.name, url: url, html: html))
+            }
+        }
+        return Self.parseXAIStatusPages(
+            tool: .grok,
+            overviewHTML: overviewHTML,
+            componentPages: componentPages,
+            dayCount: dayCount,
+            now: now
+        )
+    }
+
+    nonisolated static func parseXAIStatusPages(
+        tool: ToolType,
+        overviewHTML: String,
+        componentPages: [(id: String, name: String, url: URL, html: String)],
+        dayCount: Int,
+        now: Date
+    ) -> ServiceStatusSnapshot {
+        let parsedComponents = componentPages.map { page in
+            parseXAIComponentPage(
+                id: page.id,
+                name: page.name,
+                url: page.url,
+                html: page.html,
+                dayCount: dayCount,
+                now: now
+            )
+        }
+        let components: [ServiceComponentSummary]
+        if parsedComponents.isEmpty {
+            components = parseXAIOverviewComponents(
+                overviewHTML,
+                dayCount: dayCount,
+                now: now
+            )
+        } else {
+            components = parsedComponents.map(\.component)
+        }
+
+        let recentIncidents = parsedComponents
+            .flatMap(\.incidents)
+            .sorted { $0.createdAt > $1.createdAt }
+            .prefix(4)
+            .map { $0 }
+
+        let worstStatus = components.map(\.status).max { $0.severity < $1.severity } ?? .operational
+        let indicator = xAIIndicator(for: worstStatus)
+        let overviewText = visibleTextLines(fromHTML: overviewHTML).joined(separator: " ").lowercased()
+        let description: String
+        if overviewText.contains("no incidents declared") && indicator == .none {
+            description = "All services operational"
+        } else {
+            description = xAIDescription(for: indicator)
+        }
+
+        let updatedAt = recentIncidents.compactMap(\.resolvedAt).max()
+            ?? recentIncidents.map(\.createdAt).max()
+            ?? now
+
+        return ServiceStatusSnapshot(
+            tool: tool,
+            indicator: indicator,
+            description: description,
+            updatedAt: updatedAt,
+            groups: [],
+            components: components,
+            recentIncidents: Array(recentIncidents)
+        )
+    }
+
+    private nonisolated static func parseXAIComponentPage(
+        id: String,
+        name: String,
+        url: URL,
+        html: String,
+        dayCount: Int,
+        now: Date
+    ) -> (component: ServiceComponentSummary, incidents: [IncidentSummary]) {
+        let lines = visibleTextLines(fromHTML: html)
+        let status = xAIComponentStatus(from: lines)
+        let incidents = parseXAIIncidents(
+            text: lines.joined(separator: " "),
+            componentId: id,
+            url: url
+        )
+        let dayBuckets = buildXAIDayBuckets(
+            from: incidents.map { incident in
+                (start: incident.createdAt, end: incident.resolvedAt ?? now, impact: incident.impact)
+            },
+            dayCount: dayCount,
+            now: now
+        )
+        let component = ServiceComponentSummary(
+            id: id,
+            name: name,
+            status: status,
+            groupId: nil,
+            uptimePercent: xAIUptime(dayBuckets),
+            recentDays: dayBuckets
+        )
+        return (component, incidents)
+    }
+
+    private nonisolated static func parseXAIOverviewComponents(
+        _ html: String,
+        dayCount: Int,
+        now: Date
+    ) -> [ServiceComponentSummary] {
+        let lines = visibleTextLines(fromHTML: html)
+        let statusWords = ["available", "degraded", "unavailable", "maintenance"]
+        let services = lines.compactMap { line -> (name: String, status: ComponentStatusLevel)? in
+            let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard let word = statusWords.first(where: { trimmed.lowercased().hasSuffix(" \($0)") }) else {
+                return nil
+            }
+            let name = String(trimmed.dropLast(word.count))
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !name.isEmpty else { return nil }
+            return (name, xAIComponentStatus(fromAvailabilityWord: word))
+        }
+        return services.map { service in
+            ServiceComponentSummary(
+                id: xAISlug(service.name),
+                name: service.name,
+                status: service.status,
+                groupId: nil,
+                uptimePercent: service.status == .operational ? 100 : nil,
+                recentDays: buildXAIDayBuckets(from: [], dayCount: dayCount, now: now)
+            )
+        }
+    }
+
+    private nonisolated static func parseXAIIncidents(
+        text: String,
+        componentId: String,
+        url: URL
+    ) -> [IncidentSummary] {
+        let normalized = text.replacingOccurrences(of: "\\s+", with: " ", options: .regularExpression)
+        let pattern = #"([A-Z][a-z]{2} \d{1,2}, \d{4}, \d{2}:\d{2} [AP]M UTC)\s+(.+?)\s+Resolved\s+·\s+Duration:\s+(.+?)\s+·\s+(info|disruption|outage)"#
+        guard let regex = try? NSRegularExpression(pattern: pattern, options: []) else { return [] }
+        let range = NSRange(normalized.startIndex..<normalized.endIndex, in: normalized)
+        var incidents: [IncidentSummary] = []
+        regex.enumerateMatches(in: normalized, options: [], range: range) { match, _, _ in
+            guard let match,
+                  let dateRange = Range(match.range(at: 1), in: normalized),
+                  let nameRange = Range(match.range(at: 2), in: normalized),
+                  let impactRange = Range(match.range(at: 4), in: normalized),
+                  let createdAt = parseXAIStatusDate(String(normalized[dateRange]))
+            else { return }
+            let name = String(normalized[nameRange]).trimmingCharacters(in: .whitespacesAndNewlines)
+            let impact = xAIIncidentImpact(String(normalized[impactRange]))
+            incidents.append(
+                IncidentSummary(
+                    id: "\(componentId)-\(Int(createdAt.timeIntervalSince1970))-\(xAISlug(name))",
+                    name: name,
+                    impact: impact,
+                    createdAt: createdAt,
+                    resolvedAt: createdAt,
+                    url: url
+                )
+            )
+        }
+        return incidents
+    }
+
+    nonisolated static func parseXAIStatusDate(_ raw: String) -> Date? {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(identifier: "UTC")
+        formatter.dateFormat = "MMM d, yyyy, hh:mm a 'UTC'"
+        return formatter.date(from: raw)
+    }
+
+    private nonisolated static func xAIComponentStatus(from lines: [String]) -> ComponentStatusLevel {
+        let head = lines.prefix(12).joined(separator: " ").lowercased()
+        if head.contains("service fully operational")
+            || head.contains("not aware of any issues")
+            || head.contains("available") {
+            return .operational
+        }
+        if head.contains("major outage") || head.contains("unavailable") {
+            return .majorOutage
+        }
+        if head.contains("partial outage") {
+            return .partialOutage
+        }
+        if head.contains("maintenance") {
+            return .underMaintenance
+        }
+        if head.contains("degraded") || head.contains("disruption") {
+            return .degradedPerformance
+        }
+        return .operational
+    }
+
+    private nonisolated static func xAIComponentStatus(fromAvailabilityWord word: String) -> ComponentStatusLevel {
+        switch word.lowercased() {
+        case "available": return .operational
+        case "maintenance": return .underMaintenance
+        case "degraded": return .degradedPerformance
+        case "unavailable": return .majorOutage
+        default: return .operational
+        }
+    }
+
+    private nonisolated static func xAIIncidentImpact(_ raw: String) -> IncidentImpact {
+        switch raw.lowercased() {
+        case "outage": return .critical
+        case "disruption": return .minor
+        case "info": return .minor
+        default: return .minor
+        }
+    }
+
+    private nonisolated static func xAIIndicator(for status: ComponentStatusLevel) -> StatusIndicator {
+        switch status {
+        case .operational: return .none
+        case .underMaintenance: return .maintenance
+        case .degradedPerformance: return .minor
+        case .partialOutage: return .major
+        case .majorOutage: return .critical
+        }
+    }
+
+    private nonisolated static func xAIDescription(for indicator: StatusIndicator) -> String {
+        switch indicator {
+        case .none: return "All services operational"
+        case .maintenance: return "Under maintenance"
+        case .minor: return "Service issue"
+        case .major: return "Partial outage"
+        case .critical: return "Major outage"
+        }
+    }
+
+    private nonisolated static func visibleTextLines(fromHTML html: String) -> [String] {
+        var text = html
+            .replacingOccurrences(of: "(?is)<script.*?</script>", with: "\n", options: .regularExpression)
+            .replacingOccurrences(of: "(?is)<style.*?</style>", with: "\n", options: .regularExpression)
+            .replacingOccurrences(of: "<[^>]+>", with: "\n", options: .regularExpression)
+            .replacingOccurrences(of: "&amp;", with: "&")
+            .replacingOccurrences(of: "&nbsp;", with: " ")
+            .replacingOccurrences(of: "&middot;", with: "·")
+            .replacingOccurrences(of: "&#183;", with: "·")
+            .replacingOccurrences(of: "&quot;", with: "\"")
+            .replacingOccurrences(of: "&#39;", with: "'")
+        text = text.replacingOccurrences(of: "\\s*\\n\\s*", with: "\n", options: .regularExpression)
+        return text
+            .split(separator: "\n")
+            .map { String($0).trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+    }
+
+    private nonisolated static func buildXAIDayBuckets(
+        from impacts: [(start: Date, end: Date, impact: IncidentImpact)],
+        dayCount: Int,
+        now: Date
+    ) -> [DayUptime] {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "UTC")!
+        let today = calendar.startOfDay(for: now)
+        var bucket: [Date: IncidentImpact] = [:]
+        for entry in impacts {
+            let start = calendar.startOfDay(for: entry.start)
+            let end = calendar.startOfDay(for: entry.end)
+            var date = start
+            while date <= end {
+                if let existing = bucket[date] {
+                    if entry.impact.severity > existing.severity {
+                        bucket[date] = entry.impact
+                    }
+                } else {
+                    bucket[date] = entry.impact
+                }
+                guard let next = calendar.date(byAdding: .day, value: 1, to: date) else { break }
+                date = next
+                if date > today { break }
+            }
+        }
+        return stride(from: dayCount - 1, through: 0, by: -1).compactMap { offset in
+            guard let date = calendar.date(byAdding: .day, value: -offset, to: today) else { return nil }
+            return DayUptime(date: date, worstImpact: bucket[date])
+        }
+    }
+
+    private nonisolated static func xAIUptime(_ days: [DayUptime]) -> Double {
+        guard !days.isEmpty else { return 0 }
+        let clean = days.filter { $0.worstImpact == nil }.count
+        return Double(clean) / Double(days.count) * 100
+    }
+
+    private nonisolated static func xAISlug(_ raw: String) -> String {
+        let allowed = CharacterSet.alphanumerics
+        return raw.lowercased().unicodeScalars.map { scalar in
+            allowed.contains(scalar) ? Character(scalar) : "-"
+        }
+        .reduce(into: "") { result, ch in
+            if ch == "-", result.last == "-" { return }
+            result.append(ch)
+        }
+        .trimmingCharacters(in: CharacterSet(charactersIn: "-"))
     }
 
     // MARK: - Google Apps Status (incidents.json + products.json)

--- a/Tests/VibeBarCoreTests/MenuBarFieldCatalogTests.swift
+++ b/Tests/VibeBarCoreTests/MenuBarFieldCatalogTests.swift
@@ -1,0 +1,27 @@
+import XCTest
+@testable import VibeBarCore
+
+final class MenuBarFieldCatalogTests: XCTestCase {
+    func testDedicatedProviderMiniFieldsAreCatalogued() {
+        let expected = [
+            "gemini.gemini-2.5-pro",
+            "gemini.gemini-2.5-flash",
+            "gemini.gemini-2.5-flash-lite",
+            "antigravity.claude-sonnet-4-20250514",
+            "antigravity.gemini-2.5-pro",
+            "antigravity.gemini-2.5-flash-lite",
+            "grok.monthly"
+        ]
+
+        for id in expected {
+            XCTAssertNotNil(MenuBarFieldCatalog.field(id: id), "\(id) should be selectable in the mini window")
+        }
+    }
+
+    func testDefaultMiniWindowIncludesDedicatedProviderFields() {
+        let selected = Set(AppSettings.defaultMiniWindow.selectedFieldIds)
+        XCTAssertTrue(selected.contains("gemini.gemini-2.5-pro"))
+        XCTAssertTrue(selected.contains("antigravity.gemini-2.5-pro"))
+        XCTAssertTrue(selected.contains("grok.monthly"))
+    }
+}

--- a/Tests/VibeBarCoreTests/PartialPrimaryToolTypeTests.swift
+++ b/Tests/VibeBarCoreTests/PartialPrimaryToolTypeTests.swift
@@ -30,7 +30,8 @@ final class PartialPrimaryToolTypeTests: XCTestCase {
         XCTAssertFalse(ToolType.grok.isPrimary)
         XCTAssertTrue(ToolType.grok.supportsTokenCost,
                       "Grok joined the cost-aware club: ~/.grok/sessions/**/updates.jsonl carries per-session running totals")
-        XCTAssertFalse(ToolType.grok.supportsStatusPage)
+        XCTAssertTrue(ToolType.grok.supportsStatusPage)
+        XCTAssertEqual(ToolType.grok.statusPageURL.absoluteString, "https://status.x.ai/")
         XCTAssertFalse(ToolType.grok.isMiscPageProvider)
     }
 
@@ -53,6 +54,20 @@ final class PartialPrimaryToolTypeTests: XCTestCase {
             XCTAssertTrue(tool.supportsStatusPage,
                           "\(tool) should support status page via Google Apps Status feed")
         }
+    }
+
+    func testDedicatedStatusProvidersIncludeGrok() {
+        XCTAssertEqual(
+            ToolType.statusPageProviders,
+            [.codex, .claude, .gemini, .antigravity, .grok]
+        )
+    }
+
+    func testCostAwareProvidersIncludeGoogleAIAndGrok() {
+        XCTAssertEqual(
+            ToolType.costAwareProviders,
+            [.codex, .claude, .gemini, .antigravity, .grok]
+        )
     }
 
     func testGoogleAIPairSupportsDedicatedCard() {

--- a/Tests/VibeBarCoreTests/PrimaryProviderRouteHealthTests.swift
+++ b/Tests/VibeBarCoreTests/PrimaryProviderRouteHealthTests.swift
@@ -1,0 +1,19 @@
+import XCTest
+@testable import VibeBarCore
+
+final class PrimaryProviderRouteHealthTests: XCTestCase {
+    func testRoutesCoverDedicatedGoogleAndGrokProviders() {
+        XCTAssertEqual(
+            PrimaryProviderRoute.routes(for: .gemini),
+            [.geminiOAuth, .geminiBrowserCookies]
+        )
+        XCTAssertEqual(
+            PrimaryProviderRoute.routes(for: .antigravity),
+            [.antigravityLocalProbe]
+        )
+        XCTAssertEqual(
+            PrimaryProviderRoute.routes(for: .grok),
+            [.grokAuthJSON, .grokBrowserCookies]
+        )
+    }
+}

--- a/Tests/VibeBarCoreTests/XAIServiceStatusTests.swift
+++ b/Tests/VibeBarCoreTests/XAIServiceStatusTests.swift
@@ -1,0 +1,45 @@
+import XCTest
+@testable import VibeBarCore
+
+final class XAIServiceStatusTests: XCTestCase {
+    func testParsesOverviewAndComponentHistory() throws {
+        let overview = """
+        <html>
+          <body>
+            <h1>Service Status</h1>
+            <h3>No incidents declared</h3>
+            <a>Grok (Web) available</a>
+            <a>API (us-east-1.api.x.ai) available</a>
+          </body>
+        </html>
+        """
+        let component = """
+        <html>
+          <body>
+            <h1>API (us-east-1.api.x.ai)</h1>
+            <h3>Service fully operational</h3>
+            <h2>Past Issues</h2>
+            <a>May 13, 2026, 03:50 PM UTC Requests Using grok-imagine Models have Reduced Success Rate Resolved · Duration: 47 minutes · disruption</a>
+          </body>
+        </html>
+        """
+        let now = try XCTUnwrap(ServiceStatusClient.parseXAIStatusDate("May 22, 2026, 12:00 PM UTC"))
+        let snapshot = ServiceStatusClient.parseXAIStatusPages(
+            tool: .grok,
+            overviewHTML: overview,
+            componentPages: [
+                (id: "api-us-east-1", name: "API (us-east-1.api.x.ai)", url: URL(string: "https://status.x.ai/api-us-east-1")!, html: component)
+            ],
+            dayCount: 30,
+            now: now
+        )
+
+        XCTAssertEqual(snapshot.tool, .grok)
+        XCTAssertEqual(snapshot.indicator, .none)
+        XCTAssertEqual(snapshot.description, "All services operational")
+        XCTAssertEqual(snapshot.components.count, 1)
+        XCTAssertEqual(snapshot.components[0].status, .operational)
+        XCTAssertEqual(snapshot.recentIncidents.first?.name, "Requests Using grok-imagine Models have Reduced Success Rate")
+        XCTAssertEqual(snapshot.recentIncidents.first?.impact, .minor)
+    }
+}


### PR DESCRIPTION
## Summary
- Add Google AI and Grok provider parity across the overview dashboard, detail pages, mini window, field catalog, and settings health UI.
- Add xAI/Grok service-status fetching from status.x.ai and expose Grok status alongside existing provider status surfaces.
- Expand connection-health modeling for Gemini, Antigravity, and Grok, with focused tests for field catalogs, route health, and xAI status parsing.

## Test plan
- [x] git diff --check
- [x] swift test
- [x] swift build
- [x] ./Scripts/build_app.sh release
- [x] codesign -d --entitlements - ".build/Vibe Bar.app"
- [x] codesign --verify --deep --strict ".build/Vibe Bar.app"