### PR TITLE
Fix Antigravity health probe launch hang

### DIFF
--- a/Sources/VibeBarCore/Models/PrimaryProviderRouteHealth.swift
+++ b/Sources/VibeBarCore/Models/PrimaryProviderRouteHealth.swift
@@ -275,21 +275,34 @@ public enum PrimaryProviderRouteHealthChecker {
     }
 
     private static func antigravityLanguageServerIsRunning() -> Bool {
+        guard let result = captureProcessOutput(
+            executablePath: "/bin/ps",
+            arguments: ["-ax", "-o", "command="]
+        ), result.terminationStatus == 0 else {
+            return false
+        }
+        let output = result.output.lowercased()
+        return output.contains("language_server_macos") && output.contains("antigravity")
+    }
+
+    static func captureProcessOutput(
+        executablePath: String,
+        arguments: [String]
+    ) -> (terminationStatus: Int32, output: String)? {
         let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/bin/ps")
-        process.arguments = ["-ax", "-o", "command="]
+        process.executableURL = URL(fileURLWithPath: executablePath)
+        process.arguments = arguments
         let pipe = Pipe()
         process.standardOutput = pipe
-        process.standardError = Pipe()
+        process.standardError = FileHandle.nullDevice
         do {
             try process.run()
-            process.waitUntilExit()
-            guard process.terminationStatus == 0 else { return false }
             let data = pipe.fileHandleForReading.readDataToEndOfFile()
-            guard let output = String(data: data, encoding: .utf8)?.lowercased() else { return false }
-            return output.contains("language_server_macos") && output.contains("antigravity")
+            process.waitUntilExit()
+            guard let output = String(data: data, encoding: .utf8) else { return nil }
+            return (process.terminationStatus, output)
         } catch {
-            return false
+            return nil
         }
     }
 

--- a/Tests/VibeBarCoreTests/PrimaryProviderRouteHealthTests.swift
+++ b/Tests/VibeBarCoreTests/PrimaryProviderRouteHealthTests.swift
@@ -16,4 +16,18 @@ final class PrimaryProviderRouteHealthTests: XCTestCase {
             [.grokAuthJSON, .grokBrowserCookies]
         )
     }
+
+    func testProcessOutputDrainsLargeStdoutBeforeWaiting() throws {
+        let result = try XCTUnwrap(
+            PrimaryProviderRouteHealthChecker.captureProcessOutput(
+                executablePath: "/usr/bin/awk",
+                arguments: [
+                    #"BEGIN { for (i = 0; i < 20000; i++) print "antigravity language_server_macos" }"#
+                ]
+            )
+        )
+
+        XCTAssertEqual(result.terminationStatus, 0)
+        XCTAssertTrue(result.output.contains("antigravity language_server_macos"))
+    }
 }


### PR DESCRIPTION
## Summary
- Fix the Antigravity connection-health process probe so it drains stdout before waiting for `ps` to exit.
- Add a regression test that captures large child-process output without deadlocking.

## Root cause
- The startup health check ran `ps -ax -o command=` on the main thread, called `waitUntilExit()` first, and only read stdout afterward.
- On machines with a large process list, the stdout pipe fills; `ps` blocks writing while Vibe Bar blocks waiting, freezing launch.

## Test plan
- [x] `swift test --filter PrimaryProviderRouteHealthTests`
- [x] `swift test`
- [x] `./Scripts/build_app.sh release`
- [x] `codesign --verify --deep --strict ".build/Vibe Bar.app"`
- [x] `codesign -d --entitlements - ".build/Vibe Bar.app"`
- [x] Launch repaired bundle and sample process to confirm main thread is no longer stuck in `waitUntilExit()`