### PR TITLE
Move startup credential detection off the main thread

### DIFF
--- a/Sources/VibeBarApp/AppEnvironment.swift
+++ b/Sources/VibeBarApp/AppEnvironment.swift
@@ -38,16 +38,12 @@ final class AppEnvironment: ObservableObject {
     private var browserOpenAICookieImportInFlight = false
     private var browserGeminiCookieImportInFlight = false
     private var browserGrokCookieImportInFlight = false
+    private var webCookiePresence: AccountStore.WebCookiePresence = .none
 
     init() {
         let settings = SettingsStore()
-        let accounts = AccountStore(
-            codexUsageMode: settings.codexUsageMode,
-            claudeUsageMode: settings.claudeUsageMode,
-            geminiUsageMode: settings.geminiUsageMode,
-            antigravityUsageMode: settings.antigravityUsageMode,
-            miscProviderInstances: settings.settings.miscProviderInstances
-        )
+        let initialWebCookiePresence = AccountStore.WebCookiePresence.none
+        let accounts = AccountStore(initialAccounts: [])
         let service = QuotaService.makeDefault(mockProvider: { [weak settings] in
             settings?.mockEnabled ?? false
         }, initialAccountIds: accounts.accounts.map(\.id))
@@ -62,10 +58,10 @@ final class AppEnvironment: ObservableObject {
             settings?.settings.costData ?? .default
         })
         self.costService = costService
-        self.hasClaudeWebCookies = ClaudeWebCookieStore.hasCookieHeader()
-        self.hasOpenAIWebCookies = OpenAIWebCookieStore.hasCookieHeader()
-        self.hasGeminiWebCookies = GeminiWebCookieStore.hasCookieHeader()
-        self.hasGrokWebCookies = GrokWebCookieStore.hasCookieHeader()
+        self.hasClaudeWebCookies = initialWebCookiePresence.claude
+        self.hasOpenAIWebCookies = initialWebCookiePresence.openAI
+        self.hasGeminiWebCookies = initialWebCookiePresence.gemini
+        self.hasGrokWebCookies = initialWebCookiePresence.grok
         self.routeHealth = PrimaryProviderRouteHealthChecker.checkAll()
 
         let scheduler = QuotaRefreshScheduler(
@@ -114,16 +110,9 @@ final class AppEnvironment: ObservableObject {
                     && $0.miscProviderInstances == $1.miscProviderInstances
             }
             .sink { [weak self] settings in
-                self?.accountStore.reload(
-                    codexUsageMode: settings.codexUsageMode,
-                    claudeUsageMode: settings.claudeUsageMode,
-                    geminiUsageMode: settings.geminiUsageMode,
-                    antigravityUsageMode: settings.antigravityUsageMode,
-                    miscProviderInstances: settings.miscProviderInstances
-                )
                 self?.recheckPrimaryRouteHealth()
                 self?.scheduler.reschedule()
-                self?.scheduler.triggerRefresh()
+                self?.reloadAccountsInBackground(from: settings, triggerRefresh: true)
             }
             .store(in: &cancellables)
 
@@ -190,6 +179,7 @@ final class AppEnvironment: ObservableObject {
         importOpenAIBrowserCookiesAndRefreshIfNeeded()
         importGeminiBrowserCookiesAndRefreshIfNeeded()
         importGrokBrowserCookiesAndRefreshIfNeeded()
+        refreshWebCookiePresence(reloadAccounts: true, triggerRefresh: true)
 
         // Push Claude/Codex extras parsed by adapters into CostUsageService.
         service.$lastSuccessByAccount
@@ -231,10 +221,6 @@ final class AppEnvironment: ObservableObject {
     }
 
     func reloadProviderCredentialsAndRefresh() {
-        hasClaudeWebCookies = ClaudeWebCookieStore.hasCookieHeader()
-        hasOpenAIWebCookies = OpenAIWebCookieStore.hasCookieHeader()
-        hasGeminiWebCookies = GeminiWebCookieStore.hasCookieHeader()
-        hasGrokWebCookies = GrokWebCookieStore.hasCookieHeader()
         recheckPrimaryRouteHealth()
         importPersistentOpenAICookiesAndRefreshIfNeeded()
         importOpenAIBrowserCookiesAndRefreshIfNeeded()
@@ -242,18 +228,11 @@ final class AppEnvironment: ObservableObject {
         importClaudeBrowserCookiesAndRefreshIfNeeded()
         importGeminiBrowserCookiesAndRefreshIfNeeded()
         importGrokBrowserCookiesAndRefreshIfNeeded()
-        accountStore.reload(
-            codexUsageMode: settingsStore.settings.codexUsageMode,
-            claudeUsageMode: settingsStore.claudeUsageMode,
-            geminiUsageMode: settingsStore.geminiUsageMode,
-            antigravityUsageMode: settingsStore.antigravityUsageMode,
-            miscProviderInstances: settingsStore.settings.miscProviderInstances
-        )
         // Cookies may have changed (login / re-login) — drop any stale
         // 1h failure cooldowns so the routine WebView probe gets a fresh
         // chance on the very next quota refresh.
         lastRoutineBudgetAttemptByAccount.removeAll()
-        scheduler.triggerRefresh()
+        refreshWebCookiePresence(reloadAccounts: true, triggerRefresh: true)
         serviceStatus.refreshAll()
     }
 
@@ -273,23 +252,82 @@ final class AppEnvironment: ObservableObject {
         }
     }
 
+    private func refreshWebCookiePresence(
+        reloadAccounts: Bool = false,
+        triggerRefresh: Bool = false,
+        completion: (() -> Void)? = nil
+    ) {
+        let settingsSnapshot = settingsStore.settings
+        DispatchQueue.global(qos: .utility).async {
+            let presence = AccountStore.WebCookiePresence(
+                openAI: OpenAIWebCookieStore.hasCookieHeader(),
+                claude: ClaudeWebCookieStore.hasCookieHeader(),
+                gemini: GeminiWebCookieStore.hasCookieHeader(),
+                grok: GrokWebCookieStore.hasCookieHeader()
+            )
+            let detectedAccounts = reloadAccounts
+                ? AccountStore.detectedAccounts(
+                    codexUsageMode: settingsSnapshot.codexUsageMode,
+                    claudeUsageMode: settingsSnapshot.claudeUsageMode,
+                    geminiUsageMode: settingsSnapshot.geminiUsageMode,
+                    antigravityUsageMode: settingsSnapshot.antigravityUsageMode,
+                    miscProviderInstances: settingsSnapshot.miscProviderInstances,
+                    webCookiePresence: presence
+                )
+                : nil
+            DispatchQueue.main.async { [weak self] in
+                guard let self else { return }
+                self.webCookiePresence = presence
+                self.hasOpenAIWebCookies = presence.openAI
+                self.hasClaudeWebCookies = presence.claude
+                self.hasGeminiWebCookies = presence.gemini
+                self.hasGrokWebCookies = presence.grok
+                if let detectedAccounts {
+                    self.accountStore.replaceAccounts(detectedAccounts)
+                }
+                if triggerRefresh {
+                    self.scheduler.triggerRefresh()
+                }
+                completion?()
+            }
+        }
+    }
+
+    private func reloadAccountsInBackground(
+        from settings: AppSettings,
+        triggerRefresh: Bool = false,
+        completion: (() -> Void)? = nil
+    ) {
+        let presence = webCookiePresence
+        DispatchQueue.global(qos: .utility).async {
+            let detectedAccounts = AccountStore.detectedAccounts(
+                codexUsageMode: settings.codexUsageMode,
+                claudeUsageMode: settings.claudeUsageMode,
+                geminiUsageMode: settings.geminiUsageMode,
+                antigravityUsageMode: settings.antigravityUsageMode,
+                miscProviderInstances: settings.miscProviderInstances,
+                webCookiePresence: presence
+            )
+            DispatchQueue.main.async { [weak self] in
+                guard let self else { return }
+                self.accountStore.replaceAccounts(detectedAccounts)
+                if triggerRefresh {
+                    self.scheduler.triggerRefresh()
+                }
+                completion?()
+            }
+        }
+    }
+
     func refresh(_ tool: ToolType) {
-        hasClaudeWebCookies = ClaudeWebCookieStore.hasCookieHeader()
-        hasOpenAIWebCookies = OpenAIWebCookieStore.hasCookieHeader()
-        hasGeminiWebCookies = GeminiWebCookieStore.hasCookieHeader()
-        hasGrokWebCookies = GrokWebCookieStore.hasCookieHeader()
         recheckPrimaryRouteHealth(provider: tool)
-        accountStore.reload(
-            codexUsageMode: settingsStore.settings.codexUsageMode,
-            claudeUsageMode: settingsStore.claudeUsageMode,
-            geminiUsageMode: settingsStore.geminiUsageMode,
-            antigravityUsageMode: settingsStore.antigravityUsageMode,
-            miscProviderInstances: settingsStore.settings.miscProviderInstances
-        )
-        let account = account(for: tool)
-        Task { @MainActor in
+        refreshWebCookiePresence(reloadAccounts: true) { [weak self] in
+            guard let self else { return }
+            let account = self.account(for: tool)
             if let account {
-                _ = await quotaService.refresh(account)
+                Task { @MainActor in
+                    _ = await self.quotaService.refresh(account)
+                }
             }
         }
     }
@@ -317,14 +355,12 @@ final class AppEnvironment: ObservableObject {
 
     func openClaudeWebLogin() {
         claudeWebLoginController.open { [weak self] in
-            self?.hasClaudeWebCookies = ClaudeWebCookieStore.hasCookieHeader()
             self?.reloadProviderCredentialsAndRefresh()
         }
     }
 
     func openOpenAIWebLogin() {
         openAIWebLoginController.open { [weak self] in
-            self?.hasOpenAIWebCookies = OpenAIWebCookieStore.hasCookieHeader()
             self?.reloadProviderCredentialsAndRefresh()
         }
     }
@@ -378,7 +414,7 @@ final class AppEnvironment: ObservableObject {
         allowKeychainPrompt: Bool = false,
         userInitiated: Bool = false
     ) {
-        if !allowKeychainPrompt, GrokWebCookieStore.hasCookieHeader() {
+        if !allowKeychainPrompt, hasGrokWebCookies {
             return
         }
         guard !browserGrokCookieImportInFlight else { return }
@@ -400,25 +436,18 @@ final class AppEnvironment: ObservableObject {
             if userInitiated {
                 self.isImportingGrokBrowserCookies = false
             }
-            self.hasGrokWebCookies = GrokWebCookieStore.hasCookieHeader()
             self.recheckPrimaryRouteHealth(provider: .grok)
             guard let result else {
                 if userInitiated {
                     self.grokBrowserCookieImportStatus = "No Grok cookies found in readable browser stores."
                 }
+                self.refreshWebCookiePresence()
                 return
             }
             if userInitiated {
                 self.grokBrowserCookieImportStatus = "Imported from \(result.sourceLabel)."
             }
-            self.accountStore.reload(
-                codexUsageMode: self.settingsStore.settings.codexUsageMode,
-                claudeUsageMode: self.settingsStore.claudeUsageMode,
-                geminiUsageMode: self.settingsStore.geminiUsageMode,
-                antigravityUsageMode: self.settingsStore.antigravityUsageMode,
-                miscProviderInstances: self.settingsStore.settings.miscProviderInstances
-            )
-            self.scheduler.triggerRefresh()
+            self.refreshWebCookiePresence(reloadAccounts: true, triggerRefresh: true)
         }
     }
 
@@ -426,7 +455,7 @@ final class AppEnvironment: ObservableObject {
         allowKeychainPrompt: Bool = false,
         userInitiated: Bool = false
     ) {
-        if !allowKeychainPrompt, GeminiWebCookieStore.hasCookieHeader() {
+        if !allowKeychainPrompt, hasGeminiWebCookies {
             return
         }
         guard !browserGeminiCookieImportInFlight else { return }
@@ -448,25 +477,18 @@ final class AppEnvironment: ObservableObject {
             if userInitiated {
                 self.isImportingGeminiBrowserCookies = false
             }
-            self.hasGeminiWebCookies = GeminiWebCookieStore.hasCookieHeader()
             self.recheckPrimaryRouteHealth(provider: .gemini)
             guard let result else {
                 if userInitiated {
                     self.geminiBrowserCookieImportStatus = "No Gemini cookies found in readable browser stores."
                 }
+                self.refreshWebCookiePresence()
                 return
             }
             if userInitiated {
                 self.geminiBrowserCookieImportStatus = "Imported from \(result.sourceLabel)."
             }
-            self.accountStore.reload(
-                codexUsageMode: self.settingsStore.settings.codexUsageMode,
-                claudeUsageMode: self.settingsStore.claudeUsageMode,
-                geminiUsageMode: self.settingsStore.geminiUsageMode,
-                antigravityUsageMode: self.settingsStore.antigravityUsageMode,
-                miscProviderInstances: self.settingsStore.settings.miscProviderInstances
-            )
-            self.scheduler.triggerRefresh()
+            self.refreshWebCookiePresence(reloadAccounts: true, triggerRefresh: true)
         }
     }
 
@@ -477,18 +499,15 @@ final class AppEnvironment: ObservableObject {
         ClaudeWebLoginController.importPersistentClaudeCookiesIfAvailable { [weak self] didImport in
             guard let self else { return }
             self.persistentClaudeCookieImportInFlight = false
-            self.hasClaudeWebCookies = ClaudeWebCookieStore.hasCookieHeader()
             self.recheckPrimaryRouteHealth(provider: .claude)
-            guard didImport, !hadCookies else { return }
-            self.accountStore.reload(
-                codexUsageMode: self.settingsStore.settings.codexUsageMode,
-                claudeUsageMode: self.settingsStore.claudeUsageMode,
-                geminiUsageMode: self.settingsStore.geminiUsageMode,
-                antigravityUsageMode: self.settingsStore.antigravityUsageMode,
-                miscProviderInstances: self.settingsStore.settings.miscProviderInstances
-            )
-            self.lastRoutineBudgetAttemptByAccount.removeAll()
-            self.scheduler.triggerRefresh()
+            let shouldRefreshQuota = didImport && !hadCookies
+            self.refreshWebCookiePresence(
+                reloadAccounts: shouldRefreshQuota,
+                triggerRefresh: shouldRefreshQuota
+            ) { [weak self] in
+                guard shouldRefreshQuota else { return }
+                self?.lastRoutineBudgetAttemptByAccount.removeAll()
+            }
         }
     }
 
@@ -496,7 +515,7 @@ final class AppEnvironment: ObservableObject {
         allowKeychainPrompt: Bool = false,
         userInitiated: Bool = false
     ) {
-        if !allowKeychainPrompt, ClaudeWebCookieStore.hasCookieHeader() {
+        if !allowKeychainPrompt, hasClaudeWebCookies {
             return
         }
         guard !browserClaudeCookieImportInFlight else { return }
@@ -518,26 +537,20 @@ final class AppEnvironment: ObservableObject {
             if userInitiated {
                 self.isImportingClaudeBrowserCookies = false
             }
-            self.hasClaudeWebCookies = ClaudeWebCookieStore.hasCookieHeader()
             self.recheckPrimaryRouteHealth(provider: .claude)
             guard let result else {
                 if userInitiated {
                     self.claudeBrowserCookieImportStatus = "No Claude sessionKey found in readable browser cookies."
                 }
+                self.refreshWebCookiePresence()
                 return
             }
             if userInitiated {
                 self.claudeBrowserCookieImportStatus = "Imported from \(result.sourceLabel)."
             }
-            self.accountStore.reload(
-                codexUsageMode: self.settingsStore.settings.codexUsageMode,
-                claudeUsageMode: self.settingsStore.claudeUsageMode,
-                geminiUsageMode: self.settingsStore.geminiUsageMode,
-                antigravityUsageMode: self.settingsStore.antigravityUsageMode,
-                miscProviderInstances: self.settingsStore.settings.miscProviderInstances
-            )
-            self.lastRoutineBudgetAttemptByAccount.removeAll()
-            self.scheduler.triggerRefresh()
+            self.refreshWebCookiePresence(reloadAccounts: true, triggerRefresh: true) { [weak self] in
+                self?.lastRoutineBudgetAttemptByAccount.removeAll()
+            }
         }
     }
 
@@ -548,17 +561,12 @@ final class AppEnvironment: ObservableObject {
         OpenAIWebLoginController.importPersistentOpenAICookiesIfAvailable { [weak self] didImport in
             guard let self else { return }
             self.persistentOpenAICookieImportInFlight = false
-            self.hasOpenAIWebCookies = OpenAIWebCookieStore.hasCookieHeader()
             self.recheckPrimaryRouteHealth(provider: .codex)
-            guard didImport, !hadCookies else { return }
-            self.accountStore.reload(
-                codexUsageMode: self.settingsStore.settings.codexUsageMode,
-                claudeUsageMode: self.settingsStore.claudeUsageMode,
-                geminiUsageMode: self.settingsStore.geminiUsageMode,
-                antigravityUsageMode: self.settingsStore.antigravityUsageMode,
-                miscProviderInstances: self.settingsStore.settings.miscProviderInstances
+            let shouldRefreshQuota = didImport && !hadCookies
+            self.refreshWebCookiePresence(
+                reloadAccounts: shouldRefreshQuota,
+                triggerRefresh: shouldRefreshQuota
             )
-            self.scheduler.triggerRefresh()
         }
     }
 
@@ -566,7 +574,7 @@ final class AppEnvironment: ObservableObject {
         allowKeychainPrompt: Bool = false,
         userInitiated: Bool = false
     ) {
-        if !allowKeychainPrompt, OpenAIWebCookieStore.hasCookieHeader() {
+        if !allowKeychainPrompt, hasOpenAIWebCookies {
             return
         }
         guard !browserOpenAICookieImportInFlight else { return }
@@ -588,25 +596,18 @@ final class AppEnvironment: ObservableObject {
             if userInitiated {
                 self.isImportingOpenAIBrowserCookies = false
             }
-            self.hasOpenAIWebCookies = OpenAIWebCookieStore.hasCookieHeader()
             self.recheckPrimaryRouteHealth(provider: .codex)
             guard let result else {
                 if userInitiated {
                     self.openAIBrowserCookieImportStatus = "No ChatGPT session cookies found in readable browser cookies."
                 }
+                self.refreshWebCookiePresence()
                 return
             }
             if userInitiated {
                 self.openAIBrowserCookieImportStatus = "Imported from \(result.sourceLabel)."
             }
-            self.accountStore.reload(
-                codexUsageMode: self.settingsStore.settings.codexUsageMode,
-                claudeUsageMode: self.settingsStore.claudeUsageMode,
-                geminiUsageMode: self.settingsStore.geminiUsageMode,
-                antigravityUsageMode: self.settingsStore.antigravityUsageMode,
-                miscProviderInstances: self.settingsStore.settings.miscProviderInstances
-            )
-            self.scheduler.triggerRefresh()
+            self.refreshWebCookiePresence(reloadAccounts: true, triggerRefresh: true)
         }
     }
 
@@ -617,22 +618,16 @@ final class AppEnvironment: ObservableObject {
             try ClaudeWebCookieStore.deleteCookieHeader()
             claudeBrowserCookieImportStatus = nil
             hasClaudeWebCookies = false
+            webCookiePresence.claude = false
             recheckPrimaryRouteHealth(provider: .claude)
             for account in accountStore.accounts(for: .claude) {
                 quotaService.clear(accountId: account.id)
             }
-            accountStore.reload(
-                codexUsageMode: settingsStore.settings.codexUsageMode,
-                claudeUsageMode: settingsStore.claudeUsageMode,
-                geminiUsageMode: settingsStore.geminiUsageMode,
-                antigravityUsageMode: settingsStore.antigravityUsageMode,
-                miscProviderInstances: settingsStore.settings.miscProviderInstances
-            )
-            scheduler.triggerRefresh()
+            reloadAccountsInBackground(from: settingsStore.settings, triggerRefresh: true)
             return true
         } catch {
             SafeLog.warn("Deleting Claude web cookies failed: \(SafeLog.sanitize(error.localizedDescription))")
-            hasClaudeWebCookies = ClaudeWebCookieStore.hasCookieHeader()
+            refreshWebCookiePresence()
             return false
         }
     }
@@ -644,22 +639,16 @@ final class AppEnvironment: ObservableObject {
             try OpenAIWebCookieStore.deleteCookieHeader()
             openAIBrowserCookieImportStatus = nil
             hasOpenAIWebCookies = false
+            webCookiePresence.openAI = false
             recheckPrimaryRouteHealth(provider: .codex)
             for account in accountStore.accounts(for: .codex) {
                 quotaService.clear(accountId: account.id)
             }
-            accountStore.reload(
-                codexUsageMode: settingsStore.settings.codexUsageMode,
-                claudeUsageMode: settingsStore.claudeUsageMode,
-                geminiUsageMode: settingsStore.geminiUsageMode,
-                antigravityUsageMode: settingsStore.antigravityUsageMode,
-                miscProviderInstances: settingsStore.settings.miscProviderInstances
-            )
-            scheduler.triggerRefresh()
+            reloadAccountsInBackground(from: settingsStore.settings, triggerRefresh: true)
             return true
         } catch {
             SafeLog.warn("Deleting OpenAI web cookies failed: \(SafeLog.sanitize(error.localizedDescription))")
-            hasOpenAIWebCookies = OpenAIWebCookieStore.hasCookieHeader()
+            refreshWebCookiePresence()
             return false
         }
     }
@@ -670,22 +659,16 @@ final class AppEnvironment: ObservableObject {
             try GeminiWebCookieStore.deleteCookieHeader()
             geminiBrowserCookieImportStatus = nil
             hasGeminiWebCookies = false
+            webCookiePresence.gemini = false
             recheckPrimaryRouteHealth(provider: .gemini)
             for account in accountStore.accounts(for: .gemini) {
                 quotaService.clear(accountId: account.id)
             }
-            accountStore.reload(
-                codexUsageMode: settingsStore.settings.codexUsageMode,
-                claudeUsageMode: settingsStore.claudeUsageMode,
-                geminiUsageMode: settingsStore.geminiUsageMode,
-                antigravityUsageMode: settingsStore.antigravityUsageMode,
-                miscProviderInstances: settingsStore.settings.miscProviderInstances
-            )
-            scheduler.triggerRefresh()
+            reloadAccountsInBackground(from: settingsStore.settings, triggerRefresh: true)
             return true
         } catch {
             SafeLog.warn("Deleting Gemini web cookies failed: \(SafeLog.sanitize(error.localizedDescription))")
-            hasGeminiWebCookies = GeminiWebCookieStore.hasCookieHeader()
+            refreshWebCookiePresence()
             return false
         }
     }
@@ -696,22 +679,16 @@ final class AppEnvironment: ObservableObject {
             try GrokWebCookieStore.deleteCookieHeader()
             grokBrowserCookieImportStatus = nil
             hasGrokWebCookies = false
+            webCookiePresence.grok = false
             recheckPrimaryRouteHealth(provider: .grok)
             for account in accountStore.accounts(for: .grok) {
                 quotaService.clear(accountId: account.id)
             }
-            accountStore.reload(
-                codexUsageMode: settingsStore.settings.codexUsageMode,
-                claudeUsageMode: settingsStore.claudeUsageMode,
-                geminiUsageMode: settingsStore.geminiUsageMode,
-                antigravityUsageMode: settingsStore.antigravityUsageMode,
-                miscProviderInstances: settingsStore.settings.miscProviderInstances
-            )
-            scheduler.triggerRefresh()
+            reloadAccountsInBackground(from: settingsStore.settings, triggerRefresh: true)
             return true
         } catch {
             SafeLog.warn("Deleting Grok web cookies failed: \(SafeLog.sanitize(error.localizedDescription))")
-            hasGrokWebCookies = GrokWebCookieStore.hasCookieHeader()
+            refreshWebCookiePresence()
             return false
         }
     }
@@ -734,7 +711,7 @@ final class AppEnvironment: ObservableObject {
         // No cookies → the WebView would just load the login page and the
         // parser would never see a budget JSON. Spinning it up costs CPU
         // for no chance of success.
-        guard !ClaudeWebCookieStore.candidateCookieHeaders().isEmpty else { return }
+        guard hasClaudeWebCookies else { return }
         let now = Date()
         if let last = lastRoutineBudgetAttemptByAccount[quota.accountId],
            now.timeIntervalSince(last) < Self.routineBudgetFailureCooldown {

--- a/Sources/VibeBarCore/Storage/AccountStore.swift
+++ b/Sources/VibeBarCore/Storage/AccountStore.swift
@@ -15,21 +15,48 @@ import Combine
 /// lands the same id is reused so cached snapshots survive.
 @MainActor
 public final class AccountStore: ObservableObject {
+    public struct WebCookiePresence: Equatable, Sendable {
+        public var openAI: Bool
+        public var claude: Bool
+        public var gemini: Bool
+        public var grok: Bool
+
+        public init(openAI: Bool, claude: Bool, gemini: Bool, grok: Bool) {
+            self.openAI = openAI
+            self.claude = claude
+            self.gemini = gemini
+            self.grok = grok
+        }
+
+        public static let none = WebCookiePresence(
+            openAI: false,
+            claude: false,
+            gemini: false,
+            grok: false
+        )
+    }
+
     @Published public private(set) var accounts: [AccountIdentity] = []
+
+    public init(initialAccounts: [AccountIdentity]) {
+        self.accounts = initialAccounts
+    }
 
     public init(
         codexUsageMode: CodexUsageMode = .auto,
         claudeUsageMode: ClaudeUsageMode = .auto,
         geminiUsageMode: GeminiUsageMode = .auto,
         antigravityUsageMode: AntigravityUsageMode = .auto,
-        miscProviderInstances: [MiscProviderInstance] = AppSettings.defaultMiscProviderInstances
+        miscProviderInstances: [MiscProviderInstance] = AppSettings.defaultMiscProviderInstances,
+        webCookiePresence: WebCookiePresence? = nil
     ) {
         reload(
             codexUsageMode: codexUsageMode,
             claudeUsageMode: claudeUsageMode,
             geminiUsageMode: geminiUsageMode,
             antigravityUsageMode: antigravityUsageMode,
-            miscProviderInstances: miscProviderInstances
+            miscProviderInstances: miscProviderInstances,
+            webCookiePresence: webCookiePresence
         )
     }
 
@@ -39,30 +66,53 @@ public final class AccountStore: ObservableObject {
         claudeUsageMode: ClaudeUsageMode = .auto,
         geminiUsageMode: GeminiUsageMode = .auto,
         antigravityUsageMode: AntigravityUsageMode = .auto,
-        miscProviderInstances: [MiscProviderInstance] = AppSettings.defaultMiscProviderInstances
+        miscProviderInstances: [MiscProviderInstance] = AppSettings.defaultMiscProviderInstances,
+        webCookiePresence: WebCookiePresence? = nil
     ) {
+        self.accounts = Self.detectedAccounts(
+            codexUsageMode: codexUsageMode,
+            claudeUsageMode: claudeUsageMode,
+            geminiUsageMode: geminiUsageMode,
+            antigravityUsageMode: antigravityUsageMode,
+            miscProviderInstances: miscProviderInstances,
+            webCookiePresence: webCookiePresence
+        )
+    }
+
+    nonisolated public static func detectedAccounts(
+        codexUsageMode: CodexUsageMode = .auto,
+        claudeUsageMode: ClaudeUsageMode = .auto,
+        geminiUsageMode: GeminiUsageMode = .auto,
+        antigravityUsageMode: AntigravityUsageMode = .auto,
+        miscProviderInstances: [MiscProviderInstance] = AppSettings.defaultMiscProviderInstances,
+        webCookiePresence: WebCookiePresence? = nil
+    ) -> [AccountIdentity] {
         var detected: [AccountIdentity] = []
 
-        if let codex = autoDetectCodex(mode: codexUsageMode) {
+        if let codex = Self.autoDetectCodex(mode: codexUsageMode, webCookiePresence: webCookiePresence) {
             detected.append(codex)
         }
-        if let claude = autoDetectClaude(mode: claudeUsageMode) {
+        if let claude = Self.autoDetectClaude(mode: claudeUsageMode, webCookiePresence: webCookiePresence) {
             detected.append(claude)
         }
-        detected.append(contentsOf: autoDetectGemini(mode: geminiUsageMode))
-        if let antigravity = autoDetectAntigravity(mode: antigravityUsageMode) {
+        detected.append(contentsOf: Self.autoDetectGemini(mode: geminiUsageMode, webCookiePresence: webCookiePresence))
+        if let antigravity = Self.autoDetectAntigravity(mode: antigravityUsageMode) {
             detected.append(antigravity)
         }
-        if let grok = autoDetectGrok() {
+        if let grok = Self.autoDetectGrok(webCookiePresence: webCookiePresence) {
             detected.append(grok)
         }
 
         // Misc provider instances always present, regardless of credentials.
         for instance in miscProviderInstances {
-            detected.append(miscPlaceholder(for: instance))
+            detected.append(Self.miscPlaceholder(for: instance))
         }
 
-        self.accounts = detected
+        return detected
+    }
+
+    public func replaceAccounts(_ accounts: [AccountIdentity]) {
+        self.accounts = accounts
     }
 
     public func accounts(for tool: ToolType) -> [AccountIdentity] {
@@ -92,7 +142,7 @@ public final class AccountStore: ObservableObject {
 
     // MARK: - CLI auto detection
 
-    private func autoDetectCodex(mode: CodexUsageMode) -> AccountIdentity? {
+    nonisolated private static func autoDetectCodex(mode: CodexUsageMode, webCookiePresence: WebCookiePresence?) -> AccountIdentity? {
         let order = CodexSourcePlanner.resolve(mode: mode)
         let lookupOrder = order + (CodexSourcePlanner.allowsWebFallback(mode: mode) ? [.webCookie] : [])
         var selected: (source: CredentialSource, credential: CodexCredential?)?
@@ -107,7 +157,7 @@ public final class AccountStore: ObservableObject {
                     selected = (source, credential)
                 }
             case .webCookie:
-                if OpenAIWebCookieStore.hasCookieHeader() {
+                if Self.hasOpenAIWebCookie(webCookiePresence) {
                     selected = (source, nil)
                 }
             case .apiToken, .browserCookie, .manualCookie, .localProbe, .notConfigured:
@@ -117,7 +167,7 @@ public final class AccountStore: ObservableObject {
         }
         guard let selected else { return nil }
         let cred = selected.credential
-        let remaining = remainingSources(after: selected.source, in: order)
+        let remaining = Self.remainingSources(after: selected.source, in: order)
         let id = cred?.accountId ?? (selected.source == .oauthCLI ? "oauth-codex" : selected.source == .webCookie ? "web-codex" : "cli-codex")
         return AccountIdentity(
             id: id,
@@ -129,7 +179,7 @@ public final class AccountStore: ObservableObject {
             source: selected.source,
             allowsWebFallback: selected.source == .webCookie
                 ? false
-                : CodexSourcePlanner.allowsWebFallback(mode: mode) && OpenAIWebCookieStore.hasCookieHeader(),
+                : CodexSourcePlanner.allowsWebFallback(mode: mode) && Self.hasOpenAIWebCookie(webCookiePresence),
             allowsCLIFallback: remaining.contains(.cliDetected),
             allowsOAuthFallback: remaining.contains(.oauthCLI),
             createdAt: Date(),
@@ -137,7 +187,7 @@ public final class AccountStore: ObservableObject {
         )
     }
 
-    private func autoDetectClaude(mode: ClaudeUsageMode) -> AccountIdentity? {
+    nonisolated private static func autoDetectClaude(mode: ClaudeUsageMode, webCookiePresence: WebCookiePresence?) -> AccountIdentity? {
         let order = ClaudeSourcePlanner.resolve(mode: mode)
         var selected: (source: CredentialSource, credential: ClaudeCredential?)?
         for source in order {
@@ -151,7 +201,7 @@ public final class AccountStore: ObservableObject {
                     selected = (source, credential)
                 }
             case .webCookie:
-                if ClaudeWebCookieStore.hasCookieHeader() {
+                if Self.hasClaudeWebCookie(webCookiePresence) {
                     selected = (source, nil)
                 }
             case .apiToken, .browserCookie, .manualCookie, .localProbe, .notConfigured:
@@ -177,7 +227,7 @@ public final class AccountStore: ObservableObject {
             id = "claude"
             alias = "Claude"
         }
-        let remaining = remainingSources(after: selected.source, in: order)
+        let remaining = Self.remainingSources(after: selected.source, in: order)
         return AccountIdentity(
             id: id,
             tool: .claude,
@@ -203,13 +253,13 @@ public final class AccountStore: ObservableObject {
     /// are present. `.oauthOnly` / `.webOnly` register at most one.
     /// Stable account ids let `QuotaCacheStore` keep snapshots across
     /// restarts.
-    private func autoDetectGemini(mode: GeminiUsageMode) -> [AccountIdentity] {
+    nonisolated private static func autoDetectGemini(mode: GeminiUsageMode, webCookiePresence: WebCookiePresence?) -> [AccountIdentity] {
         let enabled = GeminiSourcePlanner.enabledSources(mode: mode)
         let homeDir = RealHomeDirectory.path
         let geminiOAuthPath = URL(fileURLWithPath: homeDir)
             .appendingPathComponent(".gemini/oauth_creds.json").path
         let hasOAuth = enabled.contains(.oauthCLI) && FileManager.default.fileExists(atPath: geminiOAuthPath)
-        let hasWeb = enabled.contains(.webCookie) && GeminiWebCookieStore.hasCookieHeader()
+        let hasWeb = enabled.contains(.webCookie) && Self.hasGeminiWebCookie(webCookiePresence)
 
         var out: [AccountIdentity] = []
         if hasOAuth {
@@ -246,7 +296,7 @@ public final class AccountStore: ObservableObject {
     /// or no cookies have been imported yet. The adapter's `fetch`
     /// surfaces the real "open Antigravity" / "import cookies" error
     /// once the user opens the popover.
-    private func autoDetectAntigravity(mode: AntigravityUsageMode) -> AccountIdentity? {
+    nonisolated private static func autoDetectAntigravity(mode: AntigravityUsageMode) -> AccountIdentity? {
         let order = AntigravitySourcePlanner.resolve(mode: mode)
         let primarySource: CredentialSource = order.first ?? .localProbe
         let id: String
@@ -278,9 +328,9 @@ public final class AccountStore: ObservableObject {
     /// The dominant source determines the account id / alias; the
     /// adapter still falls back internally if its preferred source
     /// trips at fetch time.
-    private func autoDetectGrok() -> AccountIdentity? {
+    nonisolated private static func autoDetectGrok(webCookiePresence: WebCookiePresence?) -> AccountIdentity? {
         let hasAuthJson = GrokCredentialsStore.hasCredentials()
-        let hasCookies = GrokWebCookieStore.hasCookieHeader()
+        let hasCookies = Self.hasGrokWebCookie(webCookiePresence)
         guard hasAuthJson || hasCookies else { return nil }
 
         if hasAuthJson {
@@ -320,15 +370,15 @@ public final class AccountStore: ObservableObject {
         )
     }
 
-    private func remainingSources(after source: CredentialSource, in order: [CredentialSource]) -> [CredentialSource] {
+    nonisolated private static func remainingSources(after source: CredentialSource, in order: [CredentialSource]) -> [CredentialSource] {
         guard let index = order.firstIndex(of: source) else { return [] }
         let next = order.index(after: index)
         guard next < order.endIndex else { return [] }
         return Array(order[next...])
     }
 
-    private func webClaudeAccount(allowsCLIFallback: Bool = false) -> AccountIdentity? {
-        guard ClaudeWebCookieStore.hasCookieHeader() else { return nil }
+    nonisolated private static func webClaudeAccount(allowsCLIFallback: Bool = false) -> AccountIdentity? {
+        guard Self.hasClaudeWebCookie(nil) else { return nil }
         return AccountIdentity(
             id: "web-claude",
             tool: .claude,
@@ -345,7 +395,7 @@ public final class AccountStore: ObservableObject {
     /// adapter actually fetches successfully, `QuotaService` updates
     /// the snapshot's metadata — the placeholder identity is mainly a
     /// hook for the UI to render a card and route to Settings.
-    private func miscPlaceholder(for instance: MiscProviderInstance) -> AccountIdentity {
+    nonisolated private static func miscPlaceholder(for instance: MiscProviderInstance) -> AccountIdentity {
         AccountIdentity(
             id: AccountStore.miscAccountId(forInstanceID: instance.id),
             tool: instance.tool,
@@ -354,5 +404,21 @@ public final class AccountStore: ObservableObject {
             createdAt: Date(),
             updatedAt: Date()
         )
+    }
+
+    nonisolated private static func hasOpenAIWebCookie(_ presence: WebCookiePresence?) -> Bool {
+        presence?.openAI ?? OpenAIWebCookieStore.hasCookieHeader()
+    }
+
+    nonisolated private static func hasClaudeWebCookie(_ presence: WebCookiePresence?) -> Bool {
+        presence?.claude ?? ClaudeWebCookieStore.hasCookieHeader()
+    }
+
+    nonisolated private static func hasGeminiWebCookie(_ presence: WebCookiePresence?) -> Bool {
+        presence?.gemini ?? GeminiWebCookieStore.hasCookieHeader()
+    }
+
+    nonisolated private static func hasGrokWebCookie(_ presence: WebCookiePresence?) -> Bool {
+        presence?.grok ?? GrokWebCookieStore.hasCookieHeader()
     }
 }

--- a/Tests/VibeBarCoreTests/AccountStoreWebCookiePresenceTests.swift
+++ b/Tests/VibeBarCoreTests/AccountStoreWebCookiePresenceTests.swift
@@ -1,0 +1,34 @@
+import XCTest
+@testable import VibeBarCore
+
+@MainActor
+final class AccountStoreWebCookiePresenceTests: XCTestCase {
+    func testExplicitWebCookiePresenceRegistersWebOnlyAccounts() {
+        let accounts = AccountStore(
+            claudeUsageMode: .webOnly,
+            geminiUsageMode: .webOnly,
+            miscProviderInstances: [],
+            webCookiePresence: AccountStore.WebCookiePresence(
+                openAI: false,
+                claude: true,
+                gemini: true,
+                grok: false
+            )
+        )
+
+        XCTAssertEqual(accounts.accounts(for: .claude).map(\.id), ["web-claude"])
+        XCTAssertEqual(accounts.accounts(for: .gemini).map(\.id), ["web-gemini"])
+    }
+
+    func testExplicitEmptyWebCookiePresenceSuppressesWebOnlyAccounts() {
+        let accounts = AccountStore(
+            claudeUsageMode: .webOnly,
+            geminiUsageMode: .webOnly,
+            miscProviderInstances: [],
+            webCookiePresence: AccountStore.WebCookiePresence.none
+        )
+
+        XCTAssertTrue(accounts.accounts(for: .claude).isEmpty)
+        XCTAssertTrue(accounts.accounts(for: .gemini).isEmpty)
+    }
+}


### PR DESCRIPTION
## Summary
- Initialize `AccountStore` without doing synchronous credential detection on the main thread.
- Load web-cookie presence and provider account identities on background queues, then publish the detected accounts back on the main actor.
- Keep refresh, login import, delete, and settings-change flows from synchronously calling Keychain-backed `hasCookieHeader()` / account reload paths on the UI thread.
- Add tests covering explicit web-cookie presence for Web-only account registration without falling back to live Keychain reads.

## Test plan
- [x] `git diff --check`
- [x] `swift build`
- [x] `swift test --filter AccountStoreWebCookiePresenceTests`
- [x] `swift test`
- [x] `./Scripts/build_app.sh release`
- [x] `codesign --verify --deep --strict ".build/Vibe Bar.app"`
- [x] `codesign -d --entitlements - ".build/Vibe Bar.app"`
- [x] Launched and sampled the fixed bundle; main thread is in AppKit run loop/rendering rather than AccountStore, Keychain, MiscCookieSlotStore, or process wait stacks.