### PR TITLE
Merge Google AI usage and fix Grok scanning

### DIFF
--- a/Sources/VibeBarApp/Views/PopoverRoot.swift
+++ b/Sources/VibeBarApp/Views/PopoverRoot.swift
@@ -119,7 +119,7 @@ struct PopoverRoot: View {
         case .claude:
             ProviderDetailView(tool: .claude, density: density)
         case .status:
-            ServiceStatusCard(tools: ToolType.statusPageProviders)
+            ServiceStatusCard(tools: ToolType.combinedStatusPageProviders)
         }
     }
 
@@ -189,7 +189,7 @@ struct PopoverRoot: View {
         }
         switch effectiveKind {
         case .compact:          return ToolType.dedicatedCardProviders
-        case .status:           return ToolType.statusPageProviders
+        case .status:           return ToolType.combinedStatusPageProviders
         case .codex:            return [.codex]
         case .claude:           return [.claude]
         }
@@ -408,11 +408,12 @@ private struct OverviewWaterfall: View {
     @EnvironmentObject var environment: AppEnvironment
 
     var body: some View {
-        let snapshots = ToolType.costAwareProviders.compactMap { environment.costService.snapshot(for: $0) }
+        let snapshots = overviewCostSnapshots
         let combinedHistory = CostSnapshotAggregator.combinedDailyHistory(snapshots)
         let combinedHeatmap = CostSnapshotAggregator.combinedHeatmap(snapshots)
         let combinedModels = CostSnapshotAggregator.combinedModelBreakdowns(snapshots)
         let hasCostData = snapshots.contains { $0.jsonlFilesFound > 0 }
+        let googleAISnapshot = googleAICombinedSnapshot
 
         VStack(alignment: .leading, spacing: density.interSectionSpacing) {
             CombinedTotalsRow(density: density)
@@ -426,8 +427,20 @@ private struct OverviewWaterfall: View {
                 ForEach(ToolType.partialPrimaryProviders, id: \.self) { tool in
                     ProviderQuotaCard(tool: tool, density: density, compact: false)
                 }
-                ForEach(ToolType.costAwareProviders, id: \.self) { tool in
-                    OverviewCostCard(tool: tool, density: density)
+                ForEach(overviewCostProviders, id: \.self) { tool in
+                    if tool == .gemini {
+                        OverviewCostCard(
+                            tool: .gemini,
+                            density: density,
+                            snapshotOverride: googleAISnapshot,
+                            titleOverride: "Google AI Cost",
+                            emptyMessageOverride: "No Google AI local cost data yet.",
+                            toolNameOverride: "Google AI",
+                            heatmapTitleOverride: "When you use Google AI"
+                        )
+                    } else {
+                        OverviewCostCard(tool: tool, density: density)
+                    }
                 }
                 if hasCostData {
                     ModelRankingList(
@@ -452,6 +465,25 @@ private struct OverviewWaterfall: View {
                 }
             }
         }
+    }
+
+    private var overviewCostProviders: [ToolType] {
+        [.codex, .claude, .gemini, .grok]
+    }
+
+    private var overviewCostSnapshots: [CostSnapshot] {
+        overviewCostProviders.compactMap { tool in
+            if tool == .gemini {
+                return googleAICombinedSnapshot
+            }
+            return environment.costService.snapshot(for: tool)
+        }
+    }
+
+    private var googleAICombinedSnapshot: CostSnapshot? {
+        let snapshots = ToolType.googleAIPair.compactMap { environment.costService.snapshot(for: $0) }
+        guard !snapshots.isEmpty else { return nil }
+        return CostSnapshotAggregator.combinedSnapshot(tool: .gemini, snapshots: snapshots)
     }
 }
 
@@ -483,12 +515,11 @@ private struct GoogleAIDualPage: View {
         let geminiAccounts = environment.accountStore
             .accounts(for: .gemini)
             .sorted { $0.id < $1.id }
-        let costTools = ToolType.googleAIPair
-        let costSnapshots = costTools.compactMap { tool -> (ToolType, CostSnapshot)? in
-            guard let snapshot = environment.costService.snapshot(for: tool),
-                  snapshot.jsonlFilesFound > 0 else { return nil }
-            return (tool, snapshot)
-        }
+        let googleAICostSnapshot: CostSnapshot? = {
+            let snapshots = ToolType.googleAIPair.compactMap { environment.costService.snapshot(for: $0) }
+            guard !snapshots.isEmpty else { return nil }
+            return CostSnapshotAggregator.combinedSnapshot(tool: .gemini, snapshots: snapshots)
+        }()
 
         HStack(alignment: .top, spacing: density.interSectionSpacing) {
             VStack(alignment: .leading, spacing: density.interSectionSpacing) {
@@ -516,7 +547,7 @@ private struct GoogleAIDualPage: View {
                         )
                     }
                 }
-                ServiceStatusCard(tools: ToolType.googleAIPair)
+                ServiceStatusCard(tools: [.gemini])
             }
             .frame(
                 minWidth: googleAILeftColumnMinWidth,
@@ -526,10 +557,15 @@ private struct GoogleAIDualPage: View {
             )
 
             VStack(alignment: .leading, spacing: density.interSectionSpacing) {
-                if !costSnapshots.isEmpty {
-                    ForEach(costSnapshots, id: \.0) { tool, snapshot in
-                        ProviderCostStack(tool: tool, snapshot: snapshot, density: density)
-                    }
+                if let snapshot = googleAICostSnapshot, snapshot.jsonlFilesFound > 0 {
+                    ProviderCostStack(
+                        tool: .gemini,
+                        snapshot: snapshot,
+                        density: density,
+                        titleOverride: "Google AI Cost",
+                        toolNameOverride: "Google AI",
+                        heatmapTitleOverride: "When you use Google AI"
+                    )
                 } else {
                     VStack(alignment: .leading, spacing: 6) {
                         Text("No Google AI local cost data yet.")
@@ -569,10 +605,19 @@ private struct ProviderCostStack: View {
     let tool: ToolType
     let snapshot: CostSnapshot
     let density: Theme.Density
+    var titleOverride: String? = nil
+    var toolNameOverride: String? = nil
+    var heatmapTitleOverride: String? = nil
 
     var body: some View {
         VStack(alignment: .leading, spacing: density.interSectionSpacing) {
-            CostHeaderCard(tool: tool, snapshot: snapshot, density: density)
+            CostHeaderCard(
+                tool: tool,
+                snapshot: snapshot,
+                density: density,
+                titleOverride: titleOverride,
+                toolNameOverride: toolNameOverride
+            )
             CostHistoryView(
                 tool: tool,
                 snapshot: snapshot,
@@ -583,9 +628,9 @@ private struct ProviderCostStack: View {
             YearlyContributionHeatmapView(
                 history: snapshot.dailyHistory,
                 density: density,
-                toolName: tool.menuTitle
+                toolName: toolNameOverride ?? tool.menuTitle
             )
-            UsageHeatmapView(heatmap: snapshot.heatmap, density: density)
+            UsageHeatmapView(heatmap: snapshot.heatmap, density: density, titleOverride: heatmapTitleOverride)
             UsageRateView(heatmap: snapshot.heatmap, density: density)
         }
     }
@@ -739,7 +784,7 @@ private struct OverviewStatusSummaryCard: View {
                 alignment: .leading,
                 spacing: 8
             ) {
-                ForEach(ToolType.statusPageProviders, id: \.self) { tool in
+                ForEach(ToolType.combinedStatusPageProviders, id: \.self) { tool in
                     providerStatusTile(tool)
                         .frame(maxWidth: .infinity, alignment: .leading)
                 }
@@ -759,7 +804,7 @@ private struct OverviewStatusSummaryCard: View {
 
     private func providerStatusTile(_ tool: ToolType) -> some View {
         let state = statusState(for: tool)
-        let snapshot = serviceStatus.snapshotByTool[tool]
+        let snapshot = statusSnapshot(for: tool)
         return VStack(alignment: .leading, spacing: 7) {
             HStack(spacing: 6) {
                 Image(systemName: state.iconName)
@@ -768,7 +813,7 @@ private struct OverviewStatusSummaryCard: View {
                 ToolBrandIconView(tool: tool, size: 16)
                     .opacity(0.9)
                     .frame(width: 18, height: 18)
-                Text(tool.statusProviderName)
+                Text(statusTitle(for: tool))
                     .font(.system(size: density.subtitleFontSize, weight: .semibold, design: .rounded))
                     .foregroundStyle(.primary)
                     .lineLimit(1)
@@ -810,8 +855,8 @@ private struct OverviewStatusSummaryCard: View {
         snapshot: ServiceStatusSnapshot?,
         state: OverviewStatusState
     ) -> String {
-        if serviceStatus.inFlight.contains(tool) { return "Refreshing" }
-        if serviceStatus.errorByTool[tool] != nil { return "Fetch failed" }
+        if statusInFlight(for: tool) { return "Refreshing" }
+        if statusError(for: tool) != nil { return "Fetch failed" }
         if let incident = snapshot?.recentIncidents.first, !incident.isResolved {
             return incident.name
         }
@@ -819,13 +864,13 @@ private struct OverviewStatusSummaryCard: View {
     }
 
     private func statusState(for tool: ToolType) -> OverviewStatusState {
-        if serviceStatus.inFlight.contains(tool) {
+        if statusInFlight(for: tool) {
             return .checking
         }
-        if serviceStatus.errorByTool[tool] != nil {
+        if statusError(for: tool) != nil {
             return .down
         }
-        guard let indicator = serviceStatus.snapshotByTool[tool]?.indicator else {
+        guard let indicator = statusSnapshot(for: tool)?.indicator else {
             return .checking
         }
         switch indicator {
@@ -842,6 +887,35 @@ private struct OverviewStatusSummaryCard: View {
         case .critical:
             return .down
         }
+    }
+
+    private func statusTitle(for tool: ToolType) -> String {
+        tool == .gemini ? "Google AI" : tool.statusProviderName
+    }
+
+    private func statusSnapshot(for tool: ToolType) -> ServiceStatusSnapshot? {
+        if tool == .gemini {
+            return serviceStatus.snapshotByTool[.gemini]
+                ?? serviceStatus.snapshotByTool[.antigravity]
+        }
+        return serviceStatus.snapshotByTool[tool]
+    }
+
+    private func statusInFlight(for tool: ToolType) -> Bool {
+        if tool == .gemini {
+            return serviceStatus.inFlight.contains(.gemini)
+                || serviceStatus.inFlight.contains(.antigravity)
+        }
+        return serviceStatus.inFlight.contains(tool)
+    }
+
+    private func statusError(for tool: ToolType) -> String? {
+        if tool == .gemini {
+            if statusSnapshot(for: tool) != nil { return nil }
+            return serviceStatus.errorByTool[.gemini]
+                ?? serviceStatus.errorByTool[.antigravity]
+        }
+        return serviceStatus.errorByTool[tool]
     }
 }
 
@@ -902,18 +976,25 @@ private enum OverviewStatusState {
 private struct OverviewCostCard: View {
     let tool: ToolType
     let density: Theme.Density
+    var snapshotOverride: CostSnapshot? = nil
+    var titleOverride: String? = nil
+    var emptyMessageOverride: String? = nil
+    var toolNameOverride: String? = nil
+    var heatmapTitleOverride: String? = nil
 
     @EnvironmentObject var environment: AppEnvironment
     @EnvironmentObject var costService: CostUsageService
     @State private var detailPresented: Bool = false
 
     var body: some View {
-        let snapshot = environment.costService.snapshot(for: tool)
+        let snapshot = snapshotOverride ?? environment.costService.snapshot(for: tool)
+        let title = titleOverride ?? "\(tool.menuTitle) Cost"
+        let toolName = toolNameOverride ?? tool.menuTitle
         VStack(alignment: .leading, spacing: density.cardSpacing) {
             HStack(alignment: .center) {
                 ProviderSectionTitle(
                     tool: tool,
-                    title: "\(tool.menuTitle) Cost",
+                    title: title,
                     titleFontSize: density.titleFontSize,
                     subtitleFontSize: density.subtitleFontSize,
                     iconSize: 15,
@@ -925,7 +1006,7 @@ private struct OverviewCostCard: View {
                         .controlSize(.small)
                         .frame(width: 12, height: 12)
                 }
-                BorderlessIconButton(systemImage: "arrow.clockwise", help: "Refresh \(tool.menuTitle) cost") {
+                BorderlessIconButton(systemImage: "arrow.clockwise", help: "Refresh \(toolName) cost") {
                     environment.refreshCostUsage()
                 }
                 .disabled(costService.isRefreshing)
@@ -941,7 +1022,14 @@ private struct OverviewCostCard: View {
                     .foregroundStyle(.secondary)
                     .help("Open full charts")
                     .popover(isPresented: $detailPresented, arrowEdge: .trailing) {
-                        CostDetailPopoverContent(tool: tool, density: density)
+                        CostDetailPopoverContent(
+                            tool: tool,
+                            density: density,
+                            snapshotOverride: snapshot,
+                            titleOverride: "\(title) — Full Charts",
+                            toolNameOverride: toolName,
+                            heatmapTitleOverride: heatmapTitleOverride
+                        )
                             .frame(width: max(660, density.popoverWidth * 0.70), height: 660)
                     }
                 }
@@ -952,7 +1040,7 @@ private struct OverviewCostCard: View {
                 CostHistoryView(tool: tool, snapshot: snapshot, density: density, chartHeight: 160)
                     .padding(.top, 2)
             } else {
-                Text(emptyMessage)
+                Text(emptyMessageOverride ?? emptyMessage)
                     .font(.system(size: density.subtitleFontSize))
                     .foregroundStyle(.tertiary)
                     .padding(.vertical, 24)
@@ -993,17 +1081,21 @@ private struct OverviewCostCard: View {
 private struct CostDetailPopoverContent: View {
     let tool: ToolType
     let density: Theme.Density
+    var snapshotOverride: CostSnapshot? = nil
+    var titleOverride: String? = nil
+    var toolNameOverride: String? = nil
+    var heatmapTitleOverride: String? = nil
 
     @EnvironmentObject var environment: AppEnvironment
 
     var body: some View {
-        let snapshot = environment.costService.snapshot(for: tool)
+        let snapshot = snapshotOverride ?? environment.costService.snapshot(for: tool)
         ScrollView(.vertical) {
             VStack(alignment: .leading, spacing: density.interSectionSpacing) {
                 HStack(alignment: .center) {
                     ProviderSectionTitle(
                         tool: tool,
-                        title: "\(tool.menuTitle) Cost — Full Charts",
+                        title: titleOverride ?? "\(tool.menuTitle) Cost — Full Charts",
                         titleFontSize: density.titleFontSize,
                         subtitleFontSize: density.subtitleFontSize,
                         iconSize: 15,
@@ -1017,8 +1109,12 @@ private struct CostDetailPopoverContent: View {
                     }
                 }
                 if let snap = snapshot {
-                    YearlyContributionHeatmapView(history: snap.dailyHistory, density: density, toolName: tool.menuTitle)
-                    UsageHeatmapView(heatmap: snap.heatmap, density: density)
+                    YearlyContributionHeatmapView(
+                        history: snap.dailyHistory,
+                        density: density,
+                        toolName: toolNameOverride ?? tool.menuTitle
+                    )
+                    UsageHeatmapView(heatmap: snap.heatmap, density: density, titleOverride: heatmapTitleOverride)
                     UsageRateView(heatmap: snap.heatmap, density: density)
                 }
             }
@@ -1126,6 +1222,8 @@ private struct CostHeaderCard: View {
     let tool: ToolType
     let snapshot: CostSnapshot
     let density: Theme.Density
+    var titleOverride: String? = nil
+    var toolNameOverride: String? = nil
 
     @EnvironmentObject var environment: AppEnvironment
     @EnvironmentObject var costService: CostUsageService
@@ -1135,7 +1233,7 @@ private struct CostHeaderCard: View {
             HStack(alignment: .center) {
                 ProviderSectionTitle(
                     tool: tool,
-                    title: "\(tool.menuTitle) Cost",
+                    title: titleOverride ?? "\(tool.menuTitle) Cost",
                     titleFontSize: density.titleFontSize,
                     subtitleFontSize: density.subtitleFontSize,
                     iconSize: 15,
@@ -1150,7 +1248,7 @@ private struct CostHeaderCard: View {
                         .controlSize(.small)
                         .frame(width: 12, height: 12)
                 }
-                BorderlessIconButton(systemImage: "arrow.clockwise", help: "Refresh \(tool.menuTitle) cost") {
+                BorderlessIconButton(systemImage: "arrow.clockwise", help: "Refresh \(toolNameOverride ?? tool.menuTitle) cost") {
                     environment.refreshCostUsage()
                 }
                 .disabled(costService.isRefreshing)

--- a/Sources/VibeBarApp/Views/ServiceStatusCard.swift
+++ b/Sources/VibeBarApp/Views/ServiceStatusCard.swift
@@ -70,7 +70,7 @@ private struct ServiceStatusRow: View {
         VStack(alignment: .leading, spacing: 10) {
             HStack(alignment: .center, spacing: 8) {
                 ToolBrandBadge(tool: tool, iconSize: 17, containerSize: 24)
-                Text(tool.statusProviderName)
+                Text(displayName)
                     .font(.system(size: 13, weight: .semibold))
                 StatusPill(indicator: snapshot?.indicator, description: snapshot?.description)
                 Spacer(minLength: 6)
@@ -142,11 +142,15 @@ private struct ServiceStatusRow: View {
     }
 
     private var shouldExpandFlatComponents: Bool {
-        tool == .claude
+        tool == .claude || tool == .grok
     }
 
     private func shouldExpand(_ group: ServiceComponentGroup) -> Bool {
         tool == .codex && group.name.localizedCaseInsensitiveContains("codex")
+    }
+
+    private var displayName: String {
+        tool == .gemini ? "Google AI" : tool.statusProviderName
     }
 }
 

--- a/Sources/VibeBarCore/Models/CostSnapshot.swift
+++ b/Sources/VibeBarCore/Models/CostSnapshot.swift
@@ -276,10 +276,31 @@ public enum CostSnapshotAggregator {
             .sorted { $0.date < $1.date }
     }
 
-    public static func combinedHeatmap(_ snapshots: [CostSnapshot]) -> UsageHeatmap {
+    public static func combinedHourlyHistory(
+        _ snapshots: [CostSnapshot],
+        calendar: Calendar = .current
+    ) -> [HourlyCostPoint] {
+        var totals: [Date: (cost: Double, tokens: Int)] = [:]
+        for snapshot in snapshots {
+            for point in snapshot.todayHourlyHistory {
+                let components = calendar.dateComponents([.year, .month, .day, .hour], from: point.date)
+                guard let hour = calendar.date(from: components) else { continue }
+                let current = totals[hour] ?? (0, 0)
+                totals[hour] = (current.cost + point.costUSD, current.tokens + point.totalTokens)
+            }
+        }
+        return totals
+            .map { HourlyCostPoint(date: $0.key, costUSD: $0.value.cost, totalTokens: $0.value.tokens) }
+            .sorted { $0.date < $1.date }
+    }
+
+    public static func combinedHeatmap(
+        _ snapshots: [CostSnapshot],
+        tool: ToolType? = nil
+    ) -> UsageHeatmap {
         let zeroes = Array(repeating: Array(repeating: 0, count: 24), count: 7)
         guard !snapshots.isEmpty else {
-            return UsageHeatmap(tool: .codex, cells: zeroes, totalTokens: 0)
+            return UsageHeatmap(tool: tool ?? .codex, cells: zeroes, totalTokens: 0)
         }
         var combined = zeroes
         var total = 0
@@ -293,21 +314,89 @@ public enum CostSnapshotAggregator {
             }
             total += snapshot.heatmap.totalTokens
         }
-        return UsageHeatmap(tool: snapshots.first?.tool ?? .codex, cells: combined, totalTokens: total)
+        return UsageHeatmap(tool: tool ?? snapshots.first?.tool ?? .codex, cells: combined, totalTokens: total)
     }
 
     public static func combinedModelBreakdowns(
         _ snapshots: [CostSnapshot]
     ) -> [CostSnapshot.ModelBreakdown] {
-        var totals: [String: (cost: Double, tokens: Int)] = [:]
+        combineBreakdowns(snapshots.flatMap(\.modelBreakdowns))
+    }
+
+    public static func combinedLast7DaysModelBreakdowns(
+        _ snapshots: [CostSnapshot]
+    ) -> [CostSnapshot.ModelBreakdown] {
+        combineBreakdowns(snapshots.flatMap(\.last7DaysModelBreakdowns))
+    }
+
+    public static func combinedDailyModelBreakdown(
+        _ snapshots: [CostSnapshot],
+        calendar: Calendar = .current
+    ) -> [Date: [CostSnapshot.ModelBreakdown]] {
+        var totals: [Date: [String: (cost: Double, tokens: Int)]] = [:]
         for snapshot in snapshots {
-            for breakdown in snapshot.modelBreakdowns {
-                let current = totals[breakdown.modelName] ?? (0, 0)
-                totals[breakdown.modelName] = (
-                    current.cost + breakdown.costUSD,
-                    current.tokens + breakdown.totalTokens
-                )
+            for (day, breakdowns) in snapshot.dailyModelBreakdown {
+                let key = calendar.startOfDay(for: day)
+                var dayTotals = totals[key] ?? [:]
+                for breakdown in breakdowns {
+                    let current = dayTotals[breakdown.modelName] ?? (0, 0)
+                    dayTotals[breakdown.modelName] = (
+                        current.cost + breakdown.costUSD,
+                        current.tokens + breakdown.totalTokens
+                    )
+                }
+                totals[key] = dayTotals
             }
+        }
+        return totals.mapValues { models in
+            models
+                .map { CostSnapshot.ModelBreakdown(modelName: $0.key, costUSD: $0.value.cost, totalTokens: $0.value.tokens) }
+                .sorted { $0.costUSD > $1.costUSD }
+        }
+    }
+
+    public static func combinedSnapshot(
+        tool: ToolType,
+        snapshots: [CostSnapshot],
+        now: Date = Date(),
+        calendar: Calendar = .current
+    ) -> CostSnapshot {
+        guard !snapshots.isEmpty else {
+            return .empty(tool: tool, now: now)
+        }
+
+        let rebased = snapshots.map { $0.rebasedForCurrentDay(now: now, calendar: calendar) }
+        return CostSnapshot(
+            tool: tool,
+            todayCostUSD: rebased.reduce(0) { $0 + $1.todayCostUSD },
+            last7DaysCostUSD: rebased.reduce(0) { $0 + $1.last7DaysCostUSD },
+            last30DaysCostUSD: rebased.reduce(0) { $0 + $1.last30DaysCostUSD },
+            allTimeCostUSD: rebased.reduce(0) { $0 + $1.allTimeCostUSD },
+            todayTokens: rebased.reduce(0) { $0 + $1.todayTokens },
+            last7DaysTokens: rebased.reduce(0) { $0 + $1.last7DaysTokens },
+            last30DaysTokens: rebased.reduce(0) { $0 + $1.last30DaysTokens },
+            allTimeTokens: rebased.reduce(0) { $0 + $1.allTimeTokens },
+            dailyHistory: combinedDailyHistory(rebased, calendar: calendar),
+            todayHourlyHistory: combinedHourlyHistory(rebased, calendar: calendar),
+            heatmap: combinedHeatmap(rebased, tool: tool),
+            modelBreakdowns: combinedModelBreakdowns(rebased),
+            last7DaysModelBreakdowns: combinedLast7DaysModelBreakdowns(rebased),
+            dailyModelBreakdown: combinedDailyModelBreakdown(rebased, calendar: calendar),
+            jsonlFilesFound: rebased.reduce(0) { $0 + $1.jsonlFilesFound },
+            updatedAt: rebased.map(\.updatedAt).max() ?? now
+        )
+    }
+
+    private static func combineBreakdowns(
+        _ breakdowns: [CostSnapshot.ModelBreakdown]
+    ) -> [CostSnapshot.ModelBreakdown] {
+        var totals: [String: (cost: Double, tokens: Int)] = [:]
+        for breakdown in breakdowns {
+            let current = totals[breakdown.modelName] ?? (0, 0)
+            totals[breakdown.modelName] = (
+                current.cost + breakdown.costUSD,
+                current.tokens + breakdown.totalTokens
+            )
         }
         return totals
             .map { CostSnapshot.ModelBreakdown(modelName: $0.key, costUSD: $0.value.cost, totalTokens: $0.value.tokens) }

--- a/Sources/VibeBarCore/Models/ToolType.swift
+++ b/Sources/VibeBarCore/Models/ToolType.swift
@@ -129,6 +129,10 @@ public enum ToolType: String, Codable, CaseIterable, Hashable, Sendable {
         allCases.filter { $0.supportsStatusPage }
     }
 
+    public static var combinedStatusPageProviders: [ToolType] {
+        [.codex, .claude, .gemini, .grok]
+    }
+
     public static var miscPageProviders: [ToolType] {
         allCases.filter { $0.isMiscPageProvider }
     }
@@ -148,12 +152,12 @@ public enum ToolType: String, Codable, CaseIterable, Hashable, Sendable {
     /// - `.antigravity` reads the AntiGravity IDE's per-conversation
     ///   SQLite databases under `~/.gemini/antigravity/conversations/*.db`;
     ///   the `gen_metadata.data` protobuf blob exposes per-turn
-    ///   input / output / cumulative cache-read counts. The
+    ///   input / output / cumulative cache-read counts and model id. The
     ///   `~/.gemini/antigravity-cli/conversations/*.pb` files use an
     ///   unidentified container format and are skipped — accept that
     ///   CLI-only AntiGravity usage stays dark for now.
     /// - `.grok` reads `~/.grok/sessions/**/updates.jsonl` and takes
-    ///   per-session deltas of the cumulative `_meta.totalTokens`
+    ///   per-session deltas of the cumulative `params._meta.totalTokens`
     ///   field. Grok exposes only a session-level total (no per-call
     ///   input / output split), so the USD figure is a blended
     ///   approximation against the published `grok-build` rate.

--- a/Sources/VibeBarCore/Services/AntigravitySessionReader.swift
+++ b/Sources/VibeBarCore/Services/AntigravitySessionReader.swift
@@ -22,6 +22,7 @@ import SQLite3
 ///     dedupe key in the scan cache
 ///   - `1.9.4.1` / `1.9.4.2` — seconds + nanoseconds of the wall
 ///     clock when the turn started
+///   - `1.19` — model id, e.g. `gemini-3-flash-a`
 ///
 /// Unknown fields are ignored. Missing fields default to 0 / nil so
 /// callers never have to special-case a turn whose blob is short on
@@ -35,6 +36,7 @@ public enum AntigravitySessionReader {
         public let thoughtsTokens: Int
         public let toolTokens: Int
         public let requestId: String?
+        public let model: String?
 
         public init(
             date: Date,
@@ -43,7 +45,8 @@ public enum AntigravitySessionReader {
             cumulativeCacheReadTokens: Int,
             thoughtsTokens: Int,
             toolTokens: Int,
-            requestId: String?
+            requestId: String?,
+            model: String? = nil
         ) {
             self.date = date
             self.inputTokens = inputTokens
@@ -52,6 +55,7 @@ public enum AntigravitySessionReader {
             self.thoughtsTokens = thoughtsTokens
             self.toolTokens = toolTokens
             self.requestId = requestId
+            self.model = model
         }
     }
 
@@ -108,6 +112,7 @@ public enum AntigravitySessionReader {
         let thoughts = Int(extractVarint(bytes: usage, fieldNumber: 9) ?? 0)
         let tool = Int(extractVarint(bytes: usage, fieldNumber: 10) ?? 0)
         let requestId = extractString(bytes: usage, fieldNumber: 11)
+        let model = extractString(bytes: outer, fieldNumber: 19)
 
         let date: Date
         if let seconds = extractVarint(bytes: timeBlock, fieldNumber: 1) {
@@ -124,7 +129,8 @@ public enum AntigravitySessionReader {
             cumulativeCacheReadTokens: cache,
             thoughtsTokens: thoughts,
             toolTokens: tool,
-            requestId: requestId
+            requestId: requestId,
+            model: model
         )
     }
 

--- a/Sources/VibeBarCore/Services/CostUsageScanner.swift
+++ b/Sources/VibeBarCore/Services/CostUsageScanner.swift
@@ -610,7 +610,7 @@ public enum CostUsageScanner {
         let cutoff = retentionCutoff(now: now, retentionDays: retentionDays)
 
         for file in files {
-            let (mtime, size) = fileFingerprint(file)
+            let (mtime, size) = grokFingerprint(file)
             if let cached = cache.reusable(for: file.path, mtime: mtime, size: size) {
                 let retained = retainedEvents(cached, cutoff: cutoff)
                 if retained.count != cached.count {
@@ -668,6 +668,11 @@ public enum CostUsageScanner {
         let sessionId: String?
     }
 
+    private struct GrokModelChange {
+        let date: Date
+        let model: String
+    }
+
     private static func collectGrokUpdatesFiles(under root: URL) -> [URL] {
         guard FileManager.default.fileExists(atPath: root.path) else { return [] }
         guard let enumerator = FileManager.default.enumerator(
@@ -696,13 +701,19 @@ public enum CostUsageScanner {
 
     private static func parseGrokUpdatesFile(file: URL) -> [GrokSnapshot] {
         var events: [GrokSnapshot] = []
-        let sessionId = file.deletingLastPathComponent().lastPathComponent
+        let sessionDirectory = file.deletingLastPathComponent()
+        let fallbackSessionId = sessionDirectory.lastPathComponent
+        let modelTimeline = grokModelTimeline(in: sessionDirectory)
+        let fallbackModel = grokSessionModel(in: sessionDirectory) ?? "grok-build"
         let didRead = forEachJSONLLine(in: file) { lineData in
             guard !lineData.isEmpty,
                   lineData.contains(asciiSequence: "totalTokens")
             else { return }
             guard let obj = (try? JSONSerialization.jsonObject(with: lineData)) as? [String: Any] else { return }
-            guard let meta = obj["_meta"] as? [String: Any] else { return }
+            let params = obj["params"] as? [String: Any]
+            let meta = (obj["_meta"] as? [String: Any])
+                ?? (params?["_meta"] as? [String: Any])
+            guard let meta else { return }
             let total = anyInt(meta["totalTokens"])
             guard total >= 0 else { return }
             let timestamp: Date
@@ -717,9 +728,24 @@ public enum CostUsageScanner {
             } else {
                 timestamp = fileMTime(file) ?? Date()
             }
+            let sessionId = firstNonEmptyString(
+                params?["sessionId"],
+                obj["sessionId"],
+                meta["sessionId"]
+            ) ?? fallbackSessionId
+            let model = grokModel(
+                at: timestamp,
+                timeline: modelTimeline,
+                fallback: firstNonEmptyString(
+                    meta["model_id"],
+                    meta["modelId"],
+                    obj["model_id"],
+                    obj["modelId"]
+                ) ?? fallbackModel
+            )
             events.append(GrokSnapshot(
                 date: timestamp,
-                model: "grok-build",
+                model: model,
                 totalTokens: total,
                 sessionId: sessionId
             ))
@@ -727,6 +753,115 @@ public enum CostUsageScanner {
         // Stable order: sessions written by Grok CLI are append-only but we
         // still sort by timestamp to absorb out-of-order writes.
         return didRead ? events.sorted { $0.date < $1.date } : []
+    }
+
+    private static func grokFingerprint(_ file: URL) -> (Date, Int64) {
+        let sessionDirectory = file.deletingLastPathComponent()
+        let siblings = [
+            file,
+            sessionDirectory.appendingPathComponent("events.jsonl"),
+            sessionDirectory.appendingPathComponent("summary.json"),
+            sessionDirectory.appendingPathComponent("signals.json")
+        ]
+        var latest = Date.distantPast
+        var totalSize: Int64 = 0
+        var seen: Set<String> = []
+        for sibling in siblings where !seen.contains(sibling.path) {
+            seen.insert(sibling.path)
+            guard FileManager.default.fileExists(atPath: sibling.path) else { continue }
+            let (mtime, size) = fileFingerprint(sibling)
+            if mtime > latest { latest = mtime }
+            totalSize += size
+        }
+        return (latest, totalSize)
+    }
+
+    private static func grokModelTimeline(in sessionDirectory: URL) -> [GrokModelChange] {
+        let eventsFile = sessionDirectory.appendingPathComponent("events.jsonl")
+        guard FileManager.default.fileExists(atPath: eventsFile.path) else { return [] }
+        var changes: [GrokModelChange] = []
+        _ = forEachJSONLLine(in: eventsFile) { lineData in
+            guard !lineData.isEmpty,
+                  lineData.contains(asciiSequence: "model")
+            else { return }
+            guard let obj = (try? JSONSerialization.jsonObject(with: lineData)) as? [String: Any],
+                  let model = firstNonEmptyString(
+                    obj["model_id"],
+                    obj["modelId"],
+                    obj["current_model_id"],
+                    obj["currentModelId"]
+                  )
+            else { return }
+            guard let date = firstDate(from: obj["ts"], obj["timestamp"], obj["createdAt"]) else {
+                return
+            }
+            changes.append(GrokModelChange(date: date, model: model))
+        }
+        return changes.sorted { $0.date < $1.date }
+    }
+
+    private static func grokSessionModel(in sessionDirectory: URL) -> String? {
+        if let model = grokModelFromJSON(
+            sessionDirectory.appendingPathComponent("summary.json"),
+            keys: ["current_model_id", "currentModelId", "model_id", "modelId"]
+        ) {
+            return model
+        }
+        if let model = grokModelFromJSON(
+            sessionDirectory.appendingPathComponent("signals.json"),
+            keys: ["primaryModelId", "primary_model_id", "current_model_id", "currentModelId"]
+        ) {
+            return model
+        }
+        if let model = grokModelFromJSONArray(
+            sessionDirectory.appendingPathComponent("signals.json"),
+            key: "modelsUsed"
+        ) {
+            return model
+        }
+        return grokModelTimeline(in: sessionDirectory).last?.model
+    }
+
+    private static func grokModelFromJSON(_ file: URL, keys: [String]) -> String? {
+        guard let data = try? Data(contentsOf: file),
+              let obj = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any]
+        else { return nil }
+        for key in keys {
+            if let value = firstNonEmptyString(obj[key]) {
+                return value
+            }
+        }
+        return nil
+    }
+
+    private static func grokModelFromJSONArray(_ file: URL, key: String) -> String? {
+        guard let data = try? Data(contentsOf: file),
+              let obj = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any],
+              let values = obj[key] as? [Any]
+        else { return nil }
+        for value in values {
+            if let model = firstNonEmptyString(value) {
+                return model
+            }
+        }
+        return nil
+    }
+
+    private static func grokModel(
+        at date: Date,
+        timeline: [GrokModelChange],
+        fallback: String
+    ) -> String {
+        guard !timeline.isEmpty else { return fallback }
+        var current: String?
+        for change in timeline {
+            if change.date <= date {
+                current = change.model
+            } else {
+                break
+            }
+        }
+        return current ?? timeline.first?.model ?? fallback
     }
 
     // MARK: - AntiGravity (per-trajectory SQLite + protobuf blobs)
@@ -743,6 +878,7 @@ public enum CostUsageScanner {
     //   - field 5: cumulative cache-read pool size
     //   - field 9: reasoning / thinking tokens (counted as output)
     //   - field 10: tool tokens (counted as output)
+    // Model id lives at path `1.19`.
     // Timestamp lives at path `1.9.4` (seconds + nanos).
     //
     // The CLI-only `~/.gemini/antigravity-cli/conversations/*.pb`
@@ -791,9 +927,10 @@ public enum CostUsageScanner {
                 // Claude / Gemini, so fold them into output here.
                 let output = turn.outputTokens + turn.thoughtsTokens + turn.toolTokens
                 guard input > 0 || output > 0 || cacheRead > 0 || cacheCreation > 0 else { continue }
+                let model = normalizedNonEmpty(turn.model) ?? "antigravity-default"
                 let parsedEvent = CostUsageScanCache.ParsedEvent(
                     date: turn.date,
-                    model: "antigravity-default",
+                    model: model,
                     input: input,
                     output: output,
                     cache: cacheRead + cacheCreation,
@@ -1191,6 +1328,41 @@ public enum CostUsageScanner {
 
     private static func parseISO(_ raw: String) -> Date? {
         isoWithFraction.date(from: raw) ?? isoStandard.date(from: raw)
+    }
+
+    private static func normalizedNonEmpty(_ raw: String?) -> String? {
+        guard let value = raw?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !value.isEmpty
+        else { return nil }
+        return value
+    }
+
+    private static func firstNonEmptyString(_ values: Any?...) -> String? {
+        for value in values {
+            if let string = value as? String,
+               let normalized = normalizedNonEmpty(string) {
+                return normalized
+            }
+            if let number = value as? NSNumber {
+                let string = number.stringValue
+                if let normalized = normalizedNonEmpty(string) {
+                    return normalized
+                }
+            }
+        }
+        return nil
+    }
+
+    private static func firstDate(from values: Any?...) -> Date? {
+        for value in values {
+            if let string = value as? String, let date = parseISO(string) {
+                return date
+            }
+            if let number = value as? NSNumber {
+                return Date(timeIntervalSince1970: number.doubleValue)
+            }
+        }
+        return nil
     }
 
     private static func anyInt(_ value: Any?) -> Int {

--- a/Tests/VibeBarCoreTests/AntigravityCostScannerTests.swift
+++ b/Tests/VibeBarCoreTests/AntigravityCostScannerTests.swift
@@ -51,7 +51,8 @@ final class AntigravityCostScannerTests: XCTestCase {
         cumulativeCache: UInt64,
         thoughts: UInt64 = 0,
         tool: UInt64 = 0,
-        requestId: String = "test-request"
+        requestId: String = "test-request",
+        model: String? = "gemini-3-flash-a"
     ) -> Data {
         var usage: [UInt8] = []
         usage += encodeVarintField(1, systemPrompt)
@@ -66,7 +67,10 @@ final class AntigravityCostScannerTests: XCTestCase {
         let timeBlock = encodeVarintField(1, seconds) + encodeVarintField(2, nanos)
         let systemBlock = encodeLengthDelimited(4, timeBlock)
 
-        let outer = encodeLengthDelimited(4, usage) + encodeLengthDelimited(9, systemBlock)
+        var outer = encodeLengthDelimited(4, usage) + encodeLengthDelimited(9, systemBlock)
+        if let model {
+            outer += encodeString(19, model)
+        }
         let blob = encodeLengthDelimited(1, outer)
         return Data(blob)
     }
@@ -139,6 +143,7 @@ final class AntigravityCostScannerTests: XCTestCase {
         XCTAssertEqual(turn.thoughtsTokens, 158)
         XCTAssertEqual(turn.toolTokens, 87)
         XCTAssertEqual(turn.requestId, "req-001")
+        XCTAssertEqual(turn.model, "gemini-3-flash-a")
         XCTAssertEqual(turn.date.timeIntervalSince1970,
                        1_779_434_426 + 571_722_000.0 / 1_000_000_000,
                        accuracy: 1e-6)
@@ -160,6 +165,21 @@ final class AntigravityCostScannerTests: XCTestCase {
         XCTAssertEqual(turn.cumulativeCacheReadTokens, 0)
         XCTAssertEqual(turn.thoughtsTokens, 0)
         XCTAssertEqual(turn.toolTokens, 0)
+        XCTAssertEqual(turn.model, "gemini-3-flash-a")
+    }
+
+    func testDecoderKeepsLegacyBlobsWithoutModelReadable() throws {
+        let blob = encodeTurnBlob(
+            seconds: 1_779_434_426,
+            input: 16_738,
+            output: 780,
+            cumulativeCache: 0,
+            requestId: "req-legacy",
+            model: nil
+        )
+        let turn = try XCTUnwrap(AntigravitySessionReader.decodeTurn(blob: blob))
+        XCTAssertNil(turn.model)
+        XCTAssertEqual(turn.requestId, "req-legacy")
     }
 
     func testDecoderRejectsTruncatedBlobs() {
@@ -216,7 +236,7 @@ final class AntigravityCostScannerTests: XCTestCase {
         XCTAssertEqual(snap.allTimeTokens, 63_137)
         // All turns are within the last 7 days from `now`.
         XCTAssertEqual(snap.last7DaysTokens, 63_137)
-        XCTAssertEqual(snap.modelBreakdowns.map(\.modelName), ["antigravity-default"])
+        XCTAssertEqual(snap.modelBreakdowns.map(\.modelName), ["gemini-3-flash-a"])
         XCTAssertGreaterThan(snap.allTimeCostUSD, 0)
     }
 

--- a/Tests/VibeBarCoreTests/CostSnapshotAggregatorTests.swift
+++ b/Tests/VibeBarCoreTests/CostSnapshotAggregatorTests.swift
@@ -12,24 +12,33 @@ final class CostSnapshotAggregatorTests: XCTestCase {
     private func makeSnapshot(
         tool: ToolType,
         days: [(Date, Double, Int)],
+        hours: [(Date, Double, Int)] = [],
         heatmap: [[Int]],
-        models: [(String, Double, Int)]
+        models: [(String, Double, Int)],
+        last7Models: [(String, Double, Int)] = [],
+        dailyModels: [Date: [(String, Double, Int)]] = [:],
+        updatedAt: Date = Date(timeIntervalSince1970: 0)
     ) -> CostSnapshot {
         CostSnapshot(
             tool: tool,
-            todayCostUSD: 0,
-            last7DaysCostUSD: 0,
-            last30DaysCostUSD: 0,
-            allTimeCostUSD: 0,
-            todayTokens: 0,
-            last7DaysTokens: 0,
-            last30DaysTokens: 0,
-            allTimeTokens: 0,
+            todayCostUSD: hours.reduce(0) { $0 + $1.1 },
+            last7DaysCostUSD: days.reduce(0) { $0 + $1.1 },
+            last30DaysCostUSD: days.reduce(0) { $0 + $1.1 },
+            allTimeCostUSD: days.reduce(0) { $0 + $1.1 },
+            todayTokens: hours.reduce(0) { $0 + $1.2 },
+            last7DaysTokens: days.reduce(0) { $0 + $1.2 },
+            last30DaysTokens: days.reduce(0) { $0 + $1.2 },
+            allTimeTokens: days.reduce(0) { $0 + $1.2 },
             dailyHistory: days.map { DailyCostPoint(date: $0.0, costUSD: $0.1, totalTokens: $0.2) },
+            todayHourlyHistory: hours.map { HourlyCostPoint(date: $0.0, costUSD: $0.1, totalTokens: $0.2) },
             heatmap: UsageHeatmap(tool: tool, cells: heatmap, totalTokens: heatmap.flatMap { $0 }.reduce(0, +)),
             modelBreakdowns: models.map { CostSnapshot.ModelBreakdown(modelName: $0.0, costUSD: $0.1, totalTokens: $0.2) },
+            last7DaysModelBreakdowns: last7Models.map { CostSnapshot.ModelBreakdown(modelName: $0.0, costUSD: $0.1, totalTokens: $0.2) },
+            dailyModelBreakdown: dailyModels.mapValues { values in
+                values.map { CostSnapshot.ModelBreakdown(modelName: $0.0, costUSD: $0.1, totalTokens: $0.2) }
+            },
             jsonlFilesFound: 1,
-            updatedAt: Date(timeIntervalSince1970: 0)
+            updatedAt: updatedAt
         )
     }
 
@@ -118,5 +127,52 @@ final class CostSnapshotAggregatorTests: XCTestCase {
         let merged = try XCTUnwrap(combined.first { $0.modelName == "gpt-5" })
         XCTAssertEqual(merged.costUSD, 4.00, accuracy: 0.0001)
         XCTAssertEqual(merged.totalTokens, 40_000)
+    }
+
+    func testCombinedSnapshotMergesGoogleAICostAndUsage() throws {
+        let cal = calendar()
+        let day = try XCTUnwrap(cal.date(from: DateComponents(year: 2026, month: 5, day: 22)))
+        let hour = try XCTUnwrap(cal.date(from: DateComponents(year: 2026, month: 5, day: 22, hour: 8)))
+        var geminiCells = Array(repeating: Array(repeating: 0, count: 24), count: 7)
+        geminiCells[5][8] = 1_000
+        var antigravityCells = Array(repeating: Array(repeating: 0, count: 24), count: 7)
+        antigravityCells[5][8] = 2_000
+
+        let gemini = makeSnapshot(
+            tool: .gemini,
+            days: [(day, 1.50, 10_000)],
+            hours: [(hour, 0.50, 3_000)],
+            heatmap: geminiCells,
+            models: [("gemini-3-flash", 1.50, 10_000)],
+            last7Models: [("gemini-3-flash", 1.50, 10_000)],
+            dailyModels: [day: [("gemini-3-flash", 1.50, 10_000)]],
+            updatedAt: day
+        )
+        let antigravity = makeSnapshot(
+            tool: .antigravity,
+            days: [(day, 2.00, 20_000)],
+            hours: [(hour, 0.75, 4_000)],
+            heatmap: antigravityCells,
+            models: [("gemini-3-flash-a", 2.00, 20_000)],
+            last7Models: [("gemini-3-flash-a", 2.00, 20_000)],
+            dailyModels: [day: [("gemini-3-flash-a", 2.00, 20_000)]],
+            updatedAt: hour
+        )
+
+        let combined = CostSnapshotAggregator.combinedSnapshot(
+            tool: .gemini,
+            snapshots: [gemini, antigravity],
+            now: day,
+            calendar: cal
+        )
+        XCTAssertEqual(combined.tool, .gemini)
+        XCTAssertEqual(combined.allTimeCostUSD, 3.50, accuracy: 0.0001)
+        XCTAssertEqual(combined.allTimeTokens, 30_000)
+        let combinedHour = try XCTUnwrap(combined.todayHourlyHistory.first)
+        XCTAssertEqual(combinedHour.costUSD, 1.25, accuracy: 0.0001)
+        XCTAssertEqual(combined.heatmap.cells[5][8], 3_000)
+        XCTAssertEqual(combined.modelBreakdowns.map(\.modelName), ["gemini-3-flash-a", "gemini-3-flash"])
+        XCTAssertEqual(combined.jsonlFilesFound, 2)
+        XCTAssertEqual(combined.updatedAt, hour)
     }
 }

--- a/Tests/VibeBarCoreTests/GrokCostScannerTests.swift
+++ b/Tests/VibeBarCoreTests/GrokCostScannerTests.swift
@@ -2,8 +2,8 @@ import XCTest
 @testable import VibeBarCore
 
 /// Grok stores each session as `~/.grok/sessions/<urlEncodedCwd>/
-/// <sessionUUID>/updates.jsonl`. Every record carries a cumulative
-/// `_meta.totalTokens` plus `_meta.agentTimestampMs` — per-turn token
+/// <sessionUUID>/updates.jsonl`. Modern records carry a cumulative
+/// `params._meta.totalTokens` plus `params._meta.agentTimestampMs` — per-turn token
 /// delta is the only "what did this turn cost" signal Grok hands us,
 /// so the scanner deltas the running total and 70 / 30 splits the
 /// number across input vs output for cost.
@@ -30,8 +30,9 @@ final class GrokCostScannerTests: XCTestCase {
         home: URL,
         cwdLabel: String,
         sessionId: String,
-        records: [(date: Date, total: Int)]
-    ) throws {
+        records: [(date: Date, total: Int)],
+        nestedMeta: Bool = false
+    ) throws -> URL {
         let dir = home
             .appendingPathComponent(".grok", isDirectory: true)
             .appendingPathComponent("sessions", isDirectory: true)
@@ -41,8 +42,27 @@ final class GrokCostScannerTests: XCTestCase {
         let file = dir.appendingPathComponent("updates.jsonl")
         let lines = records.map { record -> String in
             let ms = Int64(record.date.timeIntervalSince1970 * 1000)
+            if nestedMeta {
+                return """
+                {"method":"session/update","params":{"sessionId":"\(sessionId)","_meta":{"totalTokens":\(record.total),"agentTimestampMs":\(ms),"updateType":"AvailableCommandsUpdate"}}}
+                """
+            }
             return """
             {"_meta":{"totalTokens":\(record.total),"agentTimestampMs":\(ms),"updateType":"AvailableCommandsUpdate"},"payload":{}}
+            """
+        }
+        try lines.joined(separator: "\n").write(to: file, atomically: true, encoding: .utf8)
+        return dir
+    }
+
+    private func writeEventsFile(
+        sessionDirectory: URL,
+        records: [(date: Date, model: String)]
+    ) throws {
+        let file = sessionDirectory.appendingPathComponent("events.jsonl")
+        let lines = records.map { record -> String in
+            """
+            {"ts":"\(Self.isoFormatter.string(from: record.date))","type":"turn_started","model_id":"\(record.model)"}
             """
         }
         try lines.joined(separator: "\n").write(to: file, atomically: true, encoding: .utf8)
@@ -97,6 +117,41 @@ final class GrokCostScannerTests: XCTestCase {
         // 11_000 tokens * $1.30/Mtok = $0.01430
         XCTAssertEqual(snap.allTimeCostUSD, 0.0143, accuracy: 0.0001)
         XCTAssertEqual(snap.modelBreakdowns.map(\.modelName), ["grok-build"])
+    }
+
+    func testNestedSessionUpdateMetaAndSiblingModelAreParsed() async throws {
+        let home = try makeTempHome()
+        defer { cleanup(home) }
+
+        let now = Date(timeIntervalSince1970: 1_779_434_500)
+        let t0 = now.addingTimeInterval(-240)
+        let t1 = now.addingTimeInterval(-120)
+        let sessionDirectory = try writeUpdatesFile(
+            home: home,
+            cwdLabel: "%2FUsers%2Fexample%2Fproject",
+            sessionId: "session-model",
+            records: [
+                (t0, 2_000),
+                (t1, 7_000)
+            ],
+            nestedMeta: true
+        )
+        try writeEventsFile(
+            sessionDirectory: sessionDirectory,
+            records: [(t0.addingTimeInterval(-1), "grok-4-fast")]
+        )
+
+        let snapshot = await CostUsageScanner.scan(
+            tool: .grok,
+            homeDirectory: home.path,
+            now: now
+        )
+        let snap = try XCTUnwrap(snapshot)
+        XCTAssertEqual(snap.jsonlFilesFound, 1)
+        XCTAssertEqual(snap.allTimeTokens, 7_000)
+        XCTAssertEqual(snap.modelBreakdowns.map(\.modelName), ["grok-4-fast"])
+        // 7000 tokens split 70 / 30 at grok-4-fast's $0.20 / $0.50 per Mtok.
+        XCTAssertEqual(snap.allTimeCostUSD, 0.00203, accuracy: 0.00001)
     }
 
     func testMultipleSessionsAggregateAcrossWorkingDirectories() async throws {

--- a/Tests/VibeBarCoreTests/PartialPrimaryToolTypeTests.swift
+++ b/Tests/VibeBarCoreTests/PartialPrimaryToolTypeTests.swift
@@ -63,6 +63,13 @@ final class PartialPrimaryToolTypeTests: XCTestCase {
         )
     }
 
+    func testCombinedStatusDisplayProvidersMergeGoogleAI() {
+        XCTAssertEqual(
+            ToolType.combinedStatusPageProviders,
+            [.codex, .claude, .gemini, .grok]
+        )
+    }
+
     func testCostAwareProvidersIncludeGoogleAIAndGrok() {
         XCTAssertEqual(
             ToolType.costAwareProviders,


### PR DESCRIPTION
## Summary
- Merge Gemini and AntiGravity cost/usage displays into one Google AI cost stack while keeping quota cards separate.
- Read AntiGravity model ids from local gen_metadata protobuf data instead of showing antigravity-default.
- Parse Grok nested params._meta usage totals and sibling model metadata, and default-expand Grok service components.

## Test plan
- [x] swift build
- [x] swift test
- [x] ./Scripts/build_app.sh release
- [x] codesign -d --entitlements - ".build/Vibe Bar.app"
- [x] codesign --verify --deep --strict ".build/Vibe Bar.app"