### PR TITLE
Stabilize mini window sizing

### DIFF
--- a/Sources/VibeBarApp/MiniQuotaWindowController.swift
+++ b/Sources/VibeBarApp/MiniQuotaWindowController.swift
@@ -52,6 +52,7 @@ final class MiniQuotaWindowController: NSObject, NSWindowDelegate {
         self.environment = environment
         let panel = panel ?? makePanel(environment: environment)
         self.panel = panel
+        applyStableContentSize(to: panel, settings: environment.settingsStore.settings, preserveTopRight: false)
         applySavedPositionOrDefault(to: panel, settings: environment.settingsStore.settings)
         panel.orderFrontRegardless()
         markWasOpen(true)
@@ -84,8 +85,9 @@ final class MiniQuotaWindowController: NSObject, NSWindowDelegate {
     }
 
     private func makePanel(environment: AppEnvironment) -> NSPanel {
+        let contentSize = Self.stableContentSize(for: environment.settingsStore.settings)
         let panel = NSPanel(
-            contentRect: NSRect(x: 0, y: 0, width: 200, height: 120),
+            contentRect: NSRect(origin: .zero, size: contentSize),
             styleMask: [.borderless, .nonactivatingPanel],
             backing: .buffered,
             defer: false
@@ -110,7 +112,6 @@ final class MiniQuotaWindowController: NSObject, NSWindowDelegate {
                 .environmentObject(environment.settingsStore)
                 .environmentObject(environment.quotaService)
         )
-        host.sizingOptions = [.preferredContentSize]
         panel.contentViewController = host
 
         // Persist the panel's origin whenever the user drags it. We hook
@@ -125,6 +126,103 @@ final class MiniQuotaWindowController: NSObject, NSWindowDelegate {
             Task { @MainActor in self?.scheduleOriginPersist() }
         }
         return panel
+    }
+
+    private func applyStableContentSize(to panel: NSPanel, settings: AppSettings, preserveTopRight: Bool) {
+        let contentSize = Self.stableContentSize(for: settings)
+        let current = panel.contentView?.bounds.size ?? panel.frame.size
+        guard abs(current.width - contentSize.width) > 0.5 || abs(current.height - contentSize.height) > 0.5 else {
+            return
+        }
+        if preserveTopRight {
+            let oldFrame = panel.frame
+            let resized = NSRect(
+                x: oldFrame.maxX - contentSize.width,
+                y: oldFrame.maxY - contentSize.height,
+                width: contentSize.width,
+                height: contentSize.height
+            )
+            panel.setFrame(Self.clampedFrame(resized, preferredScreen: panel.screen), display: false)
+        } else {
+            panel.setContentSize(contentSize)
+        }
+    }
+
+    private static func stableContentSize(for settings: AppSettings) -> NSSize {
+        let mini = settings.miniWindow
+        let displayMode = mini.displayMode
+        let cellWidth: CGFloat
+        let cellSpacing: CGFloat
+        let groupDividerReserve: CGFloat
+        let providerSpacing: CGFloat
+        let horizontalPadding: CGFloat
+        let closeButtonReserve: CGFloat
+        let minWidth: CGFloat
+        let height: CGFloat
+        switch displayMode {
+        case .regular:
+            cellWidth = 62
+            cellSpacing = 8
+            groupDividerReserve = 16.5
+            providerSpacing = 14.75
+            horizontalPadding = 28
+            closeButtonReserve = 24
+            minWidth = 240
+            height = 166
+        case .compact:
+            cellWidth = 40
+            cellSpacing = 4
+            groupDividerReserve = 10
+            providerSpacing = 8.75
+            horizontalPadding = 16
+            closeButtonReserve = 20
+            minWidth = 156
+            height = 134
+        }
+
+        let selected = mini.fieldIds(for: displayMode)
+        var countsByTool: [ToolType: Int] = [:]
+        for fieldId in selected {
+            guard
+                let field = MenuBarFieldCatalog.field(id: fieldId),
+                field.tool.supportsDedicatedCard
+            else { continue }
+            countsByTool[field.tool, default: 0] += 1
+        }
+
+        var width: CGFloat = 0
+        var visibleToolCount = 0
+        for tool in ToolType.dedicatedCardProviders {
+            guard let count = countsByTool[tool], count > 0 else { continue }
+            let cellCount = CGFloat(count)
+            width += cellCount * cellWidth
+            width += CGFloat(max(0, count - 1)) * cellSpacing
+            width += CGFloat(max(0, min(count - 1, 4))) * groupDividerReserve
+            visibleToolCount += 1
+        }
+        if visibleToolCount > 1 {
+            width += CGFloat(visibleToolCount - 1) * providerSpacing
+        }
+        width += horizontalPadding + closeButtonReserve
+
+        let screenMaxWidth = (NSScreen.main?.visibleFrame.width ?? 900) - 48
+        return NSSize(
+            width: max(minWidth, min(width, max(screenMaxWidth, minWidth))),
+            height: height
+        )
+    }
+
+    private static func clampedFrame(_ frame: NSRect, preferredScreen: NSScreen?) -> NSRect {
+        guard let visibleFrame = preferredScreen?.visibleFrame ?? NSScreen.main?.visibleFrame else {
+            return frame
+        }
+        let margin: CGFloat = 8
+        var origin = frame.origin
+        let maxX = visibleFrame.maxX - margin - frame.width
+        let maxY = visibleFrame.maxY - margin - frame.height
+        origin.x = min(max(origin.x, visibleFrame.minX + margin), maxX)
+        origin.y = min(max(origin.y, visibleFrame.minY + margin), maxY)
+        return NSRect(origin: origin, size: frame.size)
     }
 
     private func scheduleOriginPersist() {
@@ -201,6 +299,10 @@ final class MiniQuotaWindowController: NSObject, NSWindowDelegate {
         var settings = environment.settingsStore.settings
         settings.miniWindow.toggleDisplayMode()
         environment.settingsStore.settings = settings
+        if let panel {
+            applyStableContentSize(to: panel, settings: settings, preserveTopRight: true)
+            persistOrigin()
+        }
     }
 
     private func markWasOpen(_ open: Bool) {

--- a/Sources/VibeBarApp/Views/MiniQuotaWindowView.swift
+++ b/Sources/VibeBarApp/Views/MiniQuotaWindowView.swift
@@ -45,17 +45,15 @@ struct MiniQuotaWindowView: View {
             .padding(.top, 6)
             .padding(.trailing, 8)
         }
-        .fixedSize(horizontal: true, vertical: true)
-        .background(
-            RoundedRectangle(cornerRadius: Theme.miniCornerRadius, style: .continuous)
-                .fill(.ultraThinMaterial)
+        .frame(
+            minWidth: displayMode == .compact ? 156 : 240,
+            minHeight: displayMode == .compact ? 134 : 166,
+            alignment: .center
         )
-        .overlay(
-            RoundedRectangle(cornerRadius: Theme.miniCornerRadius, style: .continuous)
-                .stroke(.separator.opacity(0.35), lineWidth: 0.6)
+        .glassEffect(
+            .regular.interactive(),
+            in: .rect(cornerRadius: Theme.miniCornerRadius)
         )
-        .clipShape(RoundedRectangle(cornerRadius: Theme.miniCornerRadius, style: .continuous))
-        .shadow(color: .black.opacity(0.16), radius: 18, x: 0, y: 8)
     }
 
     private var miniContentByTool: [ToolType: MiniToolContent] {

--- a/Sources/VibeBarApp/Views/PopoverRoot.swift
+++ b/Sources/VibeBarApp/Views/PopoverRoot.swift
@@ -642,7 +642,6 @@ private struct CombinedTotalsRow: View {
         let snapshots = ToolType.costAwareProviders.compactMap { environment.costService.snapshot(for: $0) }
         let dailyHistory = CostSnapshotAggregator.combinedDailyHistory(snapshots)
         let activeDays = dailyHistory.filter { $0.costUSD > 0 || $0.totalTokens > 0 }
-        let activeTools = snapshots.filter { $0.allTimeCostUSD > 0 || $0.allTimeTokens > 0 || $0.jsonlFilesFound > 0 }.count
         let totalCost = snapshots.reduce(0.0) { $0 + $1.allTimeCostUSD }
         let todayCost = snapshots.reduce(0.0) { $0 + $1.todayCostUSD }
         let weekCost = snapshots.reduce(0.0) { $0 + $1.last7DaysCostUSD }
@@ -650,8 +649,8 @@ private struct CombinedTotalsRow: View {
         let totalTokens = snapshots.reduce(0) { $0 + $1.allTimeTokens }
         let todayTokens = snapshots.reduce(0) { $0 + $1.todayTokens }
         let weekTokens = snapshots.reduce(0) { $0 + $1.last7DaysTokens }
+        let monthTokens = snapshots.reduce(0) { $0 + $1.last30DaysTokens }
         let totalFiles = snapshots.reduce(0) { $0 + $1.jsonlFilesFound }
-        let topModel7D = CostSnapshotAggregator.combinedLast7DaysModelBreakdowns(snapshots).first
         let peakDayCost = dailyHistory.map(\.costUSD).max() ?? 0
         let averageDayCost = activeDays.isEmpty
             ? 0
@@ -697,13 +696,13 @@ private struct CombinedTotalsRow: View {
                     metric(label: "SESSIONS", value: "\(totalFiles)")
                 }
                 HStack(alignment: .top, spacing: 0) {
-                    metric(label: "TOP 7D", value: formatModelName(topModel7D?.modelName))
+                    metric(label: "30-DAY TOK", value: formatTokens(monthTokens))
                     divider
                     metric(label: "PEAK DAY", value: formatCost(peakDayCost))
                     divider
                     metric(label: "AVG/DAY", value: formatCost(averageDayCost))
                     divider
-                    metric(label: "ACTIVE", value: "\(activeTools)/\(ToolType.costAwareProviders.count)")
+                    metric(label: "DAYS USED", value: "\(activeDays.count)")
                 }
             }
             .padding(density.cardPadding)


### PR DESCRIPTION
## Summary
- Keep the mini window on the official SwiftUI Liquid Glass surface while removing the AppKit preferred-size resize loop that caused stack-overflow crashes.
- Size the mini panel explicitly from the selected fields and preserve the top-right anchor when toggling compact/regular mode.
- Replace Overview Cost's TOP 7D and ACTIVE cells with 30-DAY TOK and DAYS USED.

## Test plan
- [x] swift build
- [x] swift test
- [x] ./Scripts/build_app.sh release
- [x] codesign -d --entitlements - ".build/Vibe Bar.app"
- [x] codesign --verify --deep --strict ".build/Vibe Bar.app"
- [x] Opened the release bundle and waited 75 seconds with no new VibeBar crash report; process stayed alive.