### PR TITLE
Normalize Antigravity quota models

### DIFF
--- a/Sources/VibeBarApp/Views/MiniQuotaWindowView.swift
+++ b/Sources/VibeBarApp/Views/MiniQuotaWindowView.swift
@@ -221,6 +221,18 @@ private struct MiniBranchCell: Identifiable {
         case "daily_routines": return "Daily"
         case "weekly_opus": return "Opus"
         case "weekly_oauth_apps": return "OAuth"
+        case let id where tool == .antigravity && id.contains("gpt-oss"):
+            return "GPT"
+        case let id where tool == .antigravity && id.contains("sonnet"):
+            return "Sonnet"
+        case let id where tool == .antigravity && id.contains("opus"):
+            return "Opus"
+        case let id where tool == .antigravity && id.contains("high"):
+            return "High"
+        case let id where tool == .antigravity && id.contains("medium"):
+            return "Med"
+        case let id where tool == .antigravity && id.contains("low"):
+            return "Low"
         default:
             let group = bucket.groupTitle ?? bucket.shortLabel
             return group
@@ -249,6 +261,8 @@ private struct MiniBranchCell: Identifiable {
             return "gemini.flash"
         case let id where tool == .gemini && id.contains("pro"):
             return "gemini.pro"
+        case let id where tool == .antigravity && id.contains("gpt-oss"):
+            return "antigravity.gpt-oss"
         case let id where tool == .antigravity && id.contains("claude"):
             return "antigravity.claude"
         case let id where tool == .antigravity && id.contains("flash-lite"):
@@ -285,6 +299,8 @@ private struct MiniBranchCell: Identifiable {
             return "Flash"
         case let id where tool == .gemini && id.contains("pro"):
             return "Pro"
+        case let id where tool == .antigravity && id.contains("gpt-oss"):
+            return "GPT-OSS"
         case let id where tool == .antigravity && id.contains("claude"):
             return "Claude"
         case let id where tool == .antigravity && id.contains("flash-lite"):

--- a/Sources/VibeBarCore/Adapters/AntigravityQuotaAdapter.swift
+++ b/Sources/VibeBarCore/Adapters/AntigravityQuotaAdapter.swift
@@ -422,16 +422,16 @@ enum AntigravityResponseParser {
             guard let quota = config.quotaInfo,
                   let fraction = quota.remainingFraction else { continue }
             let resetAt = quota.resetTime.flatMap(parseDate)
-            let modelId = config.modelOrAlias?.model ?? config.label
+            let modelId = normalizedModelID(label: config.label, rawModelID: config.modelOrAlias?.model)
             var bucket = QuotaBucket(
                 id: modelId,
                 title: config.label,
-                shortLabel: AntigravityResponseParser.shortLabel(for: modelId),
+                shortLabel: AntigravityResponseParser.shortLabel(for: config.label, modelId: modelId),
                 usedPercent: max(0, min(100, (1 - fraction) * 100)),
                 resetAt: resetAt,
                 rawWindowSeconds: nil
             )
-            bucket.groupTitle = AntigravityResponseParser.groupTitle(for: modelId)
+            bucket.groupTitle = AntigravityResponseParser.groupTitle(for: config.label, modelId: modelId)
             buckets.append(bucket)
         }
 
@@ -452,17 +452,53 @@ enum AntigravityResponseParser {
         return nil
     }
 
-    private static func shortLabel(for modelId: String) -> String {
-        let lower = modelId.lowercased()
+    private static func normalizedModelID(label: String, rawModelID: String?) -> String {
+        let trimmedRaw = rawModelID?.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let trimmedRaw, !trimmedRaw.isEmpty, !isPlaceholderModelID(trimmedRaw) {
+            return trimmedRaw
+        }
+        let slug = slugModelLabel(label)
+        return slug.isEmpty ? (trimmedRaw ?? "model") : slug
+    }
+
+    private static func isPlaceholderModelID(_ value: String) -> Bool {
+        value.lowercased().hasPrefix("model_")
+    }
+
+    private static func slugModelLabel(_ label: String) -> String {
+        let lower = label.lowercased()
+        var scalars = String.UnicodeScalarView()
+        var lastWasSeparator = false
+        for scalar in lower.unicodeScalars {
+            if CharacterSet.alphanumerics.contains(scalar) || scalar.value == 46 {
+                scalars.append(scalar)
+                lastWasSeparator = false
+            } else if !lastWasSeparator {
+                scalars.append("-")
+                lastWasSeparator = true
+            }
+        }
+        return String(scalars).trimmingCharacters(in: CharacterSet(charactersIn: "-"))
+    }
+
+    private static func shortLabel(for label: String, modelId: String) -> String {
+        let lower = "\(label) \(modelId)".lowercased()
+        if lower.contains("gpt-oss") { return "GPT-OSS" }
+        if lower.contains("sonnet") { return "Sonnet" }
+        if lower.contains("opus") { return "Opus" }
         if lower.contains("claude") { return "Claude" }
+        if lower.contains("high") { return "High" }
+        if lower.contains("medium") { return "Med" }
+        if lower.contains("low") { return "Low" }
         if lower.contains("flash-lite") { return "Lite" }
         if lower.contains("flash") { return "Flash" }
         if lower.contains("pro") { return "Pro" }
         return modelId
     }
 
-    private static func groupTitle(for modelId: String) -> String? {
-        let lower = modelId.lowercased()
+    private static func groupTitle(for label: String, modelId: String) -> String? {
+        let lower = "\(label) \(modelId)".lowercased()
+        if lower.contains("gpt-oss") { return "GPT-OSS" }
         if lower.contains("claude") { return "Claude" }
         if lower.contains("gemini") {
             if lower.contains("flash-lite") { return "Gemini Flash Lite" }

--- a/Sources/VibeBarCore/Models/AppSettings.swift
+++ b/Sources/VibeBarCore/Models/AppSettings.swift
@@ -669,7 +669,11 @@ public struct AppSettings: Codable, Equatable, Sendable {
     }
 
     private static func migratedMenuBarItem(_ item: MenuBarItemSettings) -> MenuBarItemSettings {
-        guard item.kind == .compact else { return item }
+        var migrated = item
+        migrated.selectedFieldIds = MenuBarFieldCatalog.migratedFieldIds(migrated.selectedFieldIds)
+        migrated.customLabels = MenuBarFieldCatalog.migratedCustomLabels(migrated.customLabels)
+
+        guard migrated.kind == .compact else { return migrated }
         let oldDefaultFieldIds = [
             "codex.five_hour",
             "codex.weekly",
@@ -682,12 +686,12 @@ public struct AppSettings: Codable, Equatable, Sendable {
             "claude.five_hour": "C5h",
             "claude.weekly": "Cwk"
         ]
-        if item.showTitle == true,
-           item.selectedFieldIds == oldDefaultFieldIds,
-           item.customLabels == oldDefaultLabels {
+        if migrated.showTitle == true,
+           migrated.selectedFieldIds == oldDefaultFieldIds,
+           migrated.customLabels == oldDefaultLabels {
             return defaultMenuBarItems.first { $0.kind == .compact }!
         }
-        return item
+        return migrated
     }
 }
 
@@ -763,10 +767,15 @@ public struct MiniWindowSettings: Codable, Equatable, Sendable {
     public init(from decoder: Decoder) throws {
         let c = try decoder.container(keyedBy: CodingKeys.self)
         self.displayMode = try c.decodeIfPresent(MiniWindowDisplayMode.self, forKey: .displayMode) ?? .regular
-        self.selectedFieldIds = try c.decodeIfPresent([String].self, forKey: .selectedFieldIds) ?? []
-        self.compactSelectedFieldIds = try c.decodeIfPresent([String].self, forKey: .compactSelectedFieldIds)
-            ?? self.selectedFieldIds
-        self.customLabels = try c.decodeIfPresent([String: String].self, forKey: .customLabels) ?? [:]
+        let decodedSelected = try c.decodeIfPresent([String].self, forKey: .selectedFieldIds) ?? []
+        self.selectedFieldIds = MenuBarFieldCatalog.migratedFieldIds(decodedSelected)
+        if let decodedCompact = try c.decodeIfPresent([String].self, forKey: .compactSelectedFieldIds) {
+            self.compactSelectedFieldIds = MenuBarFieldCatalog.migratedFieldIds(decodedCompact)
+        } else {
+            self.compactSelectedFieldIds = self.selectedFieldIds
+        }
+        let decodedLabels = try c.decodeIfPresent([String: String].self, forKey: .customLabels) ?? [:]
+        self.customLabels = MenuBarFieldCatalog.migratedCustomLabels(decodedLabels)
         self.groupLabels = try c.decodeIfPresent([String: String].self, forKey: .groupLabels) ?? [:]
         self.wasOpen = try c.decodeIfPresent(Bool.self, forKey: .wasOpen) ?? false
         self.savedOriginX = try c.decodeIfPresent(Double.self, forKey: .savedOriginX)

--- a/Sources/VibeBarCore/Models/MenuBarSettings.swift
+++ b/Sources/VibeBarCore/Models/MenuBarSettings.swift
@@ -155,13 +155,13 @@ public enum MenuBarFieldCatalog {
     ]
 
     public static let antigravityFields: [MenuBarFieldOption] = [
-        option(.antigravity, "claude-sonnet-4-20250514", "Claude Sonnet 4", "Sonnet"),
-        option(.antigravity, "claude-sonnet-4-5", "Claude Sonnet 4.5", "Sonnet"),
-        option(.antigravity, "gemini-2.5-pro", "Gemini 2.5 Pro", "Pro"),
-        option(.antigravity, "gemini-2.5-flash", "Gemini 2.5 Flash", "Flash"),
-        option(.antigravity, "gemini-2.5-flash-lite", "Gemini 2.5 Flash Lite", "Lite"),
-        option(.antigravity, "gemini-3-pro", "Gemini 3 Pro", "3 Pro"),
-        option(.antigravity, "gemini-3-flash", "Gemini 3 Flash", "3 Flash")
+        option(.antigravity, "claude-sonnet-4.6-thinking", "Claude Sonnet 4.6 Thinking", "Sonnet"),
+        option(.antigravity, "claude-opus-4.6-thinking", "Claude Opus 4.6 Thinking", "Opus"),
+        option(.antigravity, "gpt-oss-120b-medium", "GPT-OSS 120B Medium", "GPT"),
+        option(.antigravity, "gemini-3.5-flash-high", "Gemini 3.5 Flash High", "Flash H"),
+        option(.antigravity, "gemini-3.5-flash-medium", "Gemini 3.5 Flash Medium", "Flash M"),
+        option(.antigravity, "gemini-3.1-pro-high", "Gemini 3.1 Pro High", "Pro H"),
+        option(.antigravity, "gemini-3.1-pro-low", "Gemini 3.1 Pro Low", "Pro L")
     ]
 
     public static let grokFields: [MenuBarFieldOption] = [
@@ -188,6 +188,28 @@ public enum MenuBarFieldCatalog {
         "\(tool.rawValue).\(bucketId)"
     }
 
+    public static func migratedFieldIds(_ ids: [String]) -> [String] {
+        var seen: Set<String> = []
+        var out: [String] = []
+        for id in ids {
+            let resolved = fieldIdMigrations[id] ?? [id]
+            for candidate in resolved where seen.insert(candidate).inserted {
+                out.append(candidate)
+            }
+        }
+        return out
+    }
+
+    public static func migratedCustomLabels(_ labels: [String: String]) -> [String: String] {
+        var out: [String: String] = [:]
+        for (id, label) in labels {
+            let resolved = fieldIdMigrations[id] ?? [id]
+            guard resolved.count == 1, let migratedId = resolved.first else { continue }
+            out[migratedId] = label
+        }
+        return out
+    }
+
     private static func option(
         _ tool: ToolType,
         _ bucketId: String,
@@ -202,4 +224,29 @@ public enum MenuBarFieldCatalog {
             defaultLabel: defaultLabel
         )
     }
+
+    private static let fieldIdMigrations: [String: [String]] = [
+        "gemini.gemini_pro": ["gemini.gemini-2.5-pro"],
+        "gemini.gemini_flash": ["gemini.gemini-2.5-flash"],
+        "gemini.gemini_flash_lite": ["gemini.gemini-2.5-flash-lite"],
+        "antigravity.claude-sonnet-4-20250514": ["antigravity.claude-sonnet-4.6-thinking"],
+        "antigravity.claude-sonnet-4-5": ["antigravity.claude-sonnet-4.6-thinking"],
+        "antigravity.gemini-2.5-pro": [
+            "antigravity.gemini-3.1-pro-high",
+            "antigravity.gemini-3.1-pro-low"
+        ],
+        "antigravity.gemini-3-pro": [
+            "antigravity.gemini-3.1-pro-high",
+            "antigravity.gemini-3.1-pro-low"
+        ],
+        "antigravity.gemini-2.5-flash": [
+            "antigravity.gemini-3.5-flash-high",
+            "antigravity.gemini-3.5-flash-medium"
+        ],
+        "antigravity.gemini-3-flash": [
+            "antigravity.gemini-3.5-flash-high",
+            "antigravity.gemini-3.5-flash-medium"
+        ],
+        "antigravity.gemini-2.5-flash-lite": []
+    ]
 }

--- a/Tests/VibeBarCoreTests/AntigravityParserTests.swift
+++ b/Tests/VibeBarCoreTests/AntigravityParserTests.swift
@@ -70,6 +70,47 @@ final class AntigravityParserTests: XCTestCase {
         XCTAssertEqual(snap.buckets[0].usedPercent, 0.0, accuracy: 0.01)
     }
 
+    func testNormalizesCurrentPlaceholderModelsFromLabels() throws {
+        let json = """
+        {
+          "code": 0,
+          "userStatus": {
+            "cascadeModelConfigData": {
+              "clientModelConfigs": [
+                {
+                  "label": "Gemini 3.5 Flash (High)",
+                  "modelOrAlias": {"model": "MODEL_PLACEHOLDER_M132"},
+                  "quotaInfo": {"remainingFraction": 0.0}
+                },
+                {
+                  "label": "Claude Sonnet 4.6 (Thinking)",
+                  "modelOrAlias": {"model": "MODEL_PLACEHOLDER_M35"},
+                  "quotaInfo": {"remainingFraction": 1.0}
+                },
+                {
+                  "label": "GPT-OSS 120B (Medium)",
+                  "modelOrAlias": {"model": "MODEL_OPENAI_GPT_OSS_120B_MEDIUM"},
+                  "quotaInfo": {"remainingFraction": 0.25}
+                }
+              ]
+            }
+          }
+        }
+        """
+        let snap = try AntigravityResponseParser.parseUserStatus(data: Data(json.utf8))
+
+        XCTAssertEqual(snap.buckets.map(\.id), [
+            "gemini-3.5-flash-high",
+            "claude-sonnet-4.6-thinking",
+            "gpt-oss-120b-medium"
+        ])
+        XCTAssertEqual(snap.buckets[0].usedPercent, 100.0, accuracy: 0.01)
+        XCTAssertEqual(snap.buckets[0].remainingPercent, 0.0, accuracy: 0.01)
+        XCTAssertEqual(snap.buckets[0].groupTitle, "Gemini Flash")
+        XCTAssertEqual(snap.buckets[1].shortLabel, "Sonnet")
+        XCTAssertEqual(snap.buckets[2].groupTitle, "GPT-OSS")
+    }
+
     func testMissingUserStatusThrowsParseFailure() {
         let json = """
         { "code": 0 }

--- a/Tests/VibeBarCoreTests/AppSettingsTests.swift
+++ b/Tests/VibeBarCoreTests/AppSettingsTests.swift
@@ -140,6 +140,72 @@ final class AppSettingsTests: XCTestCase {
         XCTAssertNil(decoded.savedScreenScale)
     }
 
+    func testMiniWindowMigratesLegacyAntigravityFields() throws {
+        let json = """
+        {
+          "selectedFieldIds": [
+            "antigravity.gemini-3-flash",
+            "antigravity.gemini-2.5-flash",
+            "antigravity.gemini-3-pro",
+            "antigravity.claude-sonnet-4-5",
+            "antigravity.gemini-2.5-flash-lite"
+          ],
+          "compactSelectedFieldIds": [
+            "antigravity.claude-sonnet-4-20250514",
+            "antigravity.gemini-2.5-pro"
+          ],
+          "customLabels": {}
+        }
+        """
+        let decoded = try JSONDecoder().decode(MiniWindowSettings.self, from: Data(json.utf8))
+
+        XCTAssertEqual(decoded.selectedFieldIds, [
+            "antigravity.gemini-3.5-flash-high",
+            "antigravity.gemini-3.5-flash-medium",
+            "antigravity.gemini-3.1-pro-high",
+            "antigravity.gemini-3.1-pro-low",
+            "antigravity.claude-sonnet-4.6-thinking"
+        ])
+        XCTAssertEqual(decoded.compactSelectedFieldIds, [
+            "antigravity.claude-sonnet-4.6-thinking",
+            "antigravity.gemini-3.1-pro-high",
+            "antigravity.gemini-3.1-pro-low"
+        ])
+    }
+
+    func testMenuBarItemMigratesLegacyAntigravityFields() throws {
+        let json = """
+        {
+          "displayMode": "remaining",
+          "refreshIntervalSeconds": 600,
+          "launchAtLogin": false,
+          "menuBarTextEnabled": true,
+          "mockEnabled": false,
+          "menuBarItems": [
+            {
+              "kind": "compact",
+              "isVisible": true,
+              "showTitle": false,
+              "layout": "twoRows",
+              "selectedFieldIds": [
+                "antigravity.gemini-3-flash",
+                "antigravity.claude-sonnet-4-20250514"
+              ],
+              "customLabels": {}
+            }
+          ]
+        }
+        """
+        let settings = try JSONDecoder().decode(AppSettings.self, from: Data(json.utf8))
+        let compact = settings.menuBarItem(.compact)
+
+        XCTAssertEqual(compact.selectedFieldIds, [
+            "antigravity.gemini-3.5-flash-high",
+            "antigravity.gemini-3.5-flash-medium",
+            "antigravity.claude-sonnet-4.6-thinking"
+        ])
+    }
+
     func testOldCompactDefaultMigratesToOverviewIconOnly() throws {
         let json = """
         {

--- a/Tests/VibeBarCoreTests/MenuBarFieldCatalogTests.swift
+++ b/Tests/VibeBarCoreTests/MenuBarFieldCatalogTests.swift
@@ -7,9 +7,13 @@ final class MenuBarFieldCatalogTests: XCTestCase {
             "gemini.gemini-2.5-pro",
             "gemini.gemini-2.5-flash",
             "gemini.gemini-2.5-flash-lite",
-            "antigravity.claude-sonnet-4-20250514",
-            "antigravity.gemini-2.5-pro",
-            "antigravity.gemini-2.5-flash-lite",
+            "antigravity.claude-sonnet-4.6-thinking",
+            "antigravity.claude-opus-4.6-thinking",
+            "antigravity.gpt-oss-120b-medium",
+            "antigravity.gemini-3.5-flash-high",
+            "antigravity.gemini-3.5-flash-medium",
+            "antigravity.gemini-3.1-pro-high",
+            "antigravity.gemini-3.1-pro-low",
             "grok.monthly"
         ]
 
@@ -21,7 +25,8 @@ final class MenuBarFieldCatalogTests: XCTestCase {
     func testDefaultMiniWindowIncludesDedicatedProviderFields() {
         let selected = Set(AppSettings.defaultMiniWindow.selectedFieldIds)
         XCTAssertTrue(selected.contains("gemini.gemini-2.5-pro"))
-        XCTAssertTrue(selected.contains("antigravity.gemini-2.5-pro"))
+        XCTAssertTrue(selected.contains("antigravity.gemini-3.5-flash-high"))
+        XCTAssertTrue(selected.contains("antigravity.claude-sonnet-4.6-thinking"))
         XCTAssertTrue(selected.contains("grok.monthly"))
     }
 }


### PR DESCRIPTION
## Summary
- Normalize current Antigravity placeholder model IDs from their readable labels so quota buckets remain stable.
- Refresh Antigravity mini/menu field catalog and migrate stale Gemini/Antigravity selections.
- Preserve zero remaining quota rows by testing remainingFraction 0.0 through parser and display selection flow.

## Test plan
- [x] swift build
- [x] swift test
- [x] ./Scripts/build_app.sh release
- [x] codesign -d --entitlements - ".build/Vibe Bar.app"
- [x] codesign --verify --deep --strict ".build/Vibe Bar.app"