### PR TITLE
Detect AntiGravity v2.0.x language_server binary

### DIFF
--- a/Sources/VibeBarCore/Adapters/AntigravityQuotaAdapter.swift
+++ b/Sources/VibeBarCore/Adapters/AntigravityQuotaAdapter.swift
@@ -9,9 +9,11 @@ import Foundation
 /// `X-Codeium-Csrf-Token`.
 ///
 /// Step-by-step:
-/// 1. `/bin/ps -ax -o pid=,command=` → look for `language_server_macos`
-///    with `--app_data_dir` containing `antigravity` (or path
-///    contains `antigravity`).
+/// 1. `/bin/ps -ax -o pid=,command=` → look for any `language_server`
+///    process with `--app_data_dir` containing `antigravity` (or
+///    path contains `antigravity`). AntiGravity IDE 1.x shipped the
+///    binary as `language_server_macos`; v2.0.x renamed it to plain
+///    `language_server`. The substring match here covers both.
 /// 2. From that command line, extract `--csrf_token`,
 ///    `--extension_server_port`, `--extension_server_csrf_token`.
 /// 3. `/usr/sbin/lsof -nP -iTCP -sTCP:LISTEN -a -p <pid>` → set
@@ -48,7 +50,14 @@ public struct AntigravityQuotaAdapter: QuotaAdapter {
         self.usageModeProvider = usageMode ?? { Self.resolveUsageMode() }
     }
 
-    private static let processName = "language_server_macos"
+    /// Substring that every AntiGravity language-server process name
+    /// must contain. AntiGravity IDE 1.x shipped the binary as
+    /// `language_server_macos`; v2.0.x renamed it to plain
+    /// `language_server`. The loose substring works for both — the
+    /// `isAntigravityCommand` filter below narrows it to the right
+    /// process when other vendors ship a `language_server` of their
+    /// own.
+    private static let processNameSubstring = "language_server"
     private static let userStatusPath =
         "/exa.language_server_pb.LanguageServerService/GetUserStatus"
 
@@ -152,8 +161,7 @@ public struct AntigravityQuotaAdapter: QuotaAdapter {
         for line in result.stdout.split(separator: "\n") {
             guard let match = AntigravityProcessLine.parse(String(line)) else { continue }
             let lower = match.command.lowercased()
-            guard lower.contains(AntigravityQuotaAdapter.processName) else { continue }
-            guard isAntigravityCommand(lower) else { continue }
+            guard Self.matchesAntigravityProcess(lowercasedCommand: lower) else { continue }
             foundAntigravity = true
             guard let csrf = extractFlag("--csrf_token", from: match.command) else { continue }
             return ProcessInfo(
@@ -169,7 +177,19 @@ public struct AntigravityQuotaAdapter: QuotaAdapter {
         throw QuotaError.noCredential
     }
 
-    private func isAntigravityCommand(_ command: String) -> Bool {
+    /// Whether a process-list line looks like an AntiGravity language
+    /// server. Combines the loose `language_server` binary-name match
+    /// with the AntiGravity-specific path or flag check so unrelated
+    /// vendors that also ship a `language_server` binary don't get
+    /// picked up. Exposed at the package level so the parser tests can
+    /// lock in v1.x → v2.0.x process-name compatibility without going
+    /// through `ProcessRunner`.
+    static func matchesAntigravityProcess(lowercasedCommand command: String) -> Bool {
+        guard command.contains(processNameSubstring) else { return false }
+        return isAntigravityCommand(command)
+    }
+
+    static func isAntigravityCommand(_ command: String) -> Bool {
         if command.contains("--app_data_dir") && command.contains("antigravity") { return true }
         if command.contains("/antigravity/") || command.contains("\\antigravity\\") { return true }
         return false

--- a/Tests/VibeBarCoreTests/AntigravityParserTests.swift
+++ b/Tests/VibeBarCoreTests/AntigravityParserTests.swift
@@ -167,6 +167,44 @@ final class AntigravityParserTests: XCTestCase {
         XCTAssertTrue(parsed?.command.contains("language_server_macos") ?? false)
     }
 
+    /// AntiGravity IDE 1.x shipped its language server as
+    /// `language_server_macos`. The adapter must still recognise that
+    /// older naming so users on legacy builds aren't broken when we
+    /// loosen the substring match for v2.0.x.
+    func testMatchesLegacyLanguageServerMacosBinary() {
+        let command = "/Applications/Antigravity.app/Contents/Resources/bin/language_server_macos --app_data_dir antigravity --csrf_token 00000000-0000-0000-0000-000000000000"
+        XCTAssertTrue(AntigravityQuotaAdapter.matchesAntigravityProcess(lowercasedCommand: command.lowercased()))
+    }
+
+    /// AntiGravity IDE v2.0.x renamed the binary to plain
+    /// `language_server` (without the `_macos` suffix). The previous
+    /// hard-coded `processName = "language_server_macos"` regressed
+    /// detection for this build — this test pins the v2.0.x command
+    /// shape (mirrored from a live AQ session, with the CSRF
+    /// token scrubbed to a synthetic UUID).
+    func testMatchesV2LanguageServerBinary() {
+        let command = "/Applications/Antigravity.app/Contents/Resources/bin/language_server --standalone --override_ide_name antigravity --subclient_type hub --override_ide_version 2.0.1 --override_user_agent_name antigravity --https_server_port 0 --csrf_token 00000000-0000-0000-0000-000000000000 --app_data_dir antigravity --api_server_url https://generativelanguage.googleapis.com --cloud_code_endpoint https://daily-cloudcode-pa.googleapis.com --enable_sidecars"
+        XCTAssertTrue(AntigravityQuotaAdapter.matchesAntigravityProcess(lowercasedCommand: command.lowercased()))
+    }
+
+    /// Other vendors ship binaries called `language_server` too
+    /// (e.g. Codeium, Cursor, Sourcegraph). Without an AntiGravity
+    /// path or `--app_data_dir antigravity` flag, the match must
+    /// reject — otherwise we'd dispatch CSRF tokens to the wrong LSP.
+    func testRejectsForeignLanguageServer() {
+        let command = "/Applications/Codeium.app/.../language_server --csrf_token=other"
+        XCTAssertFalse(AntigravityQuotaAdapter.matchesAntigravityProcess(lowercasedCommand: command.lowercased()))
+    }
+
+    /// Conversely, a non-language-server process running inside an
+    /// AntiGravity directory (e.g. a helper) must not get picked up —
+    /// the language-server binary substring is the load-bearing
+    /// filter for "this is the RPC endpoint we want."
+    func testRejectsNonLanguageServerInAntigravityDir() {
+        let command = "/Applications/Antigravity.app/Contents/Frameworks/Antigravity Helper.app/.../some-other-binary --app_data_dir antigravity"
+        XCTAssertFalse(AntigravityQuotaAdapter.matchesAntigravityProcess(lowercasedCommand: command.lowercased()))
+    }
+
     func testLocalhostTrustPolicyAcceptsLocalhostOnly() {
         XCTAssertTrue(
             AntigravityLocalhostTrustPolicy.shouldAcceptServerTrust(


### PR DESCRIPTION
## Summary

- Fixes a process-name regression that prevents the AntiGravity card from showing live quota on AntiGravity IDE **v2.0.x** (the binary was renamed from `language_server_macos` to plain `language_server`). The adapter's hard-coded substring match was never updated, so `AntigravityQuotaAdapter.detectProcessInfo()` returned `noCredential` even though AntiGravity was running.
- Loosens the binary-name substring from `"language_server_macos"` → `"language_server"` (covers both v1.x and v2.0.x). `isAntigravityCommand` (matches `--app_data_dir antigravity` or `/antigravity/` path) remains the load-bearing filter, so unrelated vendors that ship a `language_server` binary (Codeium, Cursor) don't get picked up.
- Promotes the combined match to a package-internal static helper `AntigravityQuotaAdapter.matchesAntigravityProcess(lowercasedCommand:)` so the parser tests can lock the regression without going through `ProcessRunner`.

## Investigation summary

Local probe pass against AQ's running AntiGravity IDE v2.0.1 (cross-checked against `Yinuo0602/AntigravityQuotaWatcher-v2` OSS project — explicit v2.0.1 compatibility fixes):

- IDE process command line: `/Applications/Antigravity.app/Contents/Resources/bin/language_server --standalone --override_ide_name antigravity --subclient_type hub --override_ide_version 2.0.1 ... --csrf_token <UUID> --app_data_dir antigravity --api_server_url https://generativelanguage.googleapis.com --cloud_code_endpoint https://daily-cloudcode-pa.googleapis.com --enable_sidecars`
- Binary name has dropped the `_macos` suffix; everything else in the adapter (CSRF extraction, lsof port discovery, `/exa.language_server_pb.LanguageServerService/GetUserStatus` POST, localhost trust policy) still works as-is.
- `Yinuo0602/AntigravityQuotaWatcher-v2`'s own detector also matches by `--app_data_dir antigravity` rather than a hard-coded binary name, confirming the fix direction.

## Out of scope (deliberately, documented for future)

- **CLI `.pb` conversation file decryption.** `~/.gemini/antigravity-cli/conversations/*.pb` files have ~max entropy (7.997 / 8.0) and `protoc --decode_raw` fails on them — they're encrypted, not raw protobuf. The OSS community (Antigravity-Database-Manager, antigravity-chat-recovery, resurrect) recovers conversation visibility by rebuilding the IDE's *index* (in `state.vscdb`), not by reading the encrypted content. We need this for CLI-only users' cost.
- **CLI-only live-quota path.** `antigravity-cli` doesn't expose a local RPC server (the language server is in-process). The Google Cloud Code REST endpoints (`https://daily-cloudcode-pa.{sandbox.,}googleapis.com/v1internal:fetchAvailableModels`) would work with a keychain-resident OAuth token, but that's a larger refactor — left for a follow-up.

## Test plan

- [x] `swift build` — clean
- [x] `swift test` — 464/464 green (4 new `AntigravityParserTests` cases: legacy binary still matches, v2.0.x binary matches, foreign `language_server` rejected, non-language-server helper rejected; CSRF tokens in fixtures are synthetic UUIDs per the no-secrets-in-source rule)
- [x] `./Scripts/build_app.sh release` — packages `.build/Vibe Bar.app`
- [x] `codesign -d --entitlements -` shows empty `[Dict]` (no `app-sandbox` key)
- [x] `codesign --verify --deep --strict` silent pass
- [ ] (Manual, after AQ installs from `.build/`) Launch the bundle on a Mac running AntiGravity IDE v2.0.x, confirm the Antigravity card now shows live `userTier` + per-model `QuotaBucket`s instead of "no credential".

🤖 Generated with [Claude Code](https://claude.com/claude-code)