### PR TITLE
Surface depleted Antigravity models and hide Google AI cost

### DIFF
--- a/Sources/VibeBarApp/Views/PopoverRoot.swift
+++ b/Sources/VibeBarApp/Views/PopoverRoot.swift
@@ -413,7 +413,6 @@ private struct OverviewWaterfall: View {
         let combinedHeatmap = CostSnapshotAggregator.combinedHeatmap(snapshots)
         let combinedModels = CostSnapshotAggregator.combinedModelBreakdowns(snapshots)
         let hasCostData = snapshots.contains { $0.jsonlFilesFound > 0 }
-        let googleAISnapshot = googleAICombinedSnapshot
 
         VStack(alignment: .leading, spacing: density.interSectionSpacing) {
             CombinedTotalsRow(density: density)
@@ -427,20 +426,15 @@ private struct OverviewWaterfall: View {
                 ForEach(ToolType.partialPrimaryProviders, id: \.self) { tool in
                     ProviderQuotaCard(tool: tool, density: density, compact: false)
                 }
+                // Google AI (Gemini + Antigravity) cost is intentionally
+                // omitted while the IDE/CLI cost story is incomplete
+                // (`~/.gemini/antigravity-cli/conversations/*.pb` is
+                // encrypted and the IDE side mixes Google-vs-third-party
+                // model rates that we haven't validated end-to-end). The
+                // dedicated Google AI sub-page surfaces a placeholder
+                // explaining the gap.
                 ForEach(overviewCostProviders, id: \.self) { tool in
-                    if tool == .gemini {
-                        OverviewCostCard(
-                            tool: .gemini,
-                            density: density,
-                            snapshotOverride: googleAISnapshot,
-                            titleOverride: "Google AI Cost",
-                            emptyMessageOverride: "No Google AI local cost data yet.",
-                            toolNameOverride: "Google AI",
-                            heatmapTitleOverride: "When you use Google AI"
-                        )
-                    } else {
-                        OverviewCostCard(tool: tool, density: density)
-                    }
+                    OverviewCostCard(tool: tool, density: density)
                 }
                 if hasCostData {
                     ModelRankingList(
@@ -467,23 +461,19 @@ private struct OverviewWaterfall: View {
         }
     }
 
+    /// Cost providers that contribute to the overview totals and the
+    /// per-provider OverviewCostCard. Google AI (Gemini + Antigravity)
+    /// is deliberately excluded while the local cost story is
+    /// incomplete — see the GoogleAIDualPage right column for the
+    /// user-facing explanation.
     private var overviewCostProviders: [ToolType] {
-        [.codex, .claude, .gemini, .grok]
+        [.codex, .claude, .grok]
     }
 
     private var overviewCostSnapshots: [CostSnapshot] {
         overviewCostProviders.compactMap { tool in
-            if tool == .gemini {
-                return googleAICombinedSnapshot
-            }
-            return environment.costService.snapshot(for: tool)
+            environment.costService.snapshot(for: tool)
         }
-    }
-
-    private var googleAICombinedSnapshot: CostSnapshot? {
-        let snapshots = ToolType.googleAIPair.compactMap { environment.costService.snapshot(for: $0) }
-        guard !snapshots.isEmpty else { return nil }
-        return CostSnapshotAggregator.combinedSnapshot(tool: .gemini, snapshots: snapshots)
     }
 }
 
@@ -510,11 +500,6 @@ private struct GoogleAIDualPage: View {
         let geminiAccounts = environment.accountStore
             .accounts(for: .gemini)
             .sorted { $0.id < $1.id }
-        let googleAICostSnapshot: CostSnapshot? = {
-            let snapshots = ToolType.googleAIPair.compactMap { environment.costService.snapshot(for: $0) }
-            guard !snapshots.isEmpty else { return nil }
-            return CostSnapshotAggregator.combinedSnapshot(tool: .gemini, snapshots: snapshots)
-        }()
 
         HStack(alignment: .top, spacing: density.interSectionSpacing) {
             VStack(alignment: .leading, spacing: density.interSectionSpacing) {
@@ -547,30 +532,16 @@ private struct GoogleAIDualPage: View {
                 alignment: .topLeading
             )
 
-            VStack(alignment: .leading, spacing: density.interSectionSpacing) {
-                if let snapshot = googleAICostSnapshot, snapshot.jsonlFilesFound > 0 {
-                    ProviderCostStack(
-                        tool: .gemini,
-                        snapshot: snapshot,
-                        density: density,
-                        titleOverride: "Google AI Cost",
-                        toolNameOverride: "Google AI",
-                        heatmapTitleOverride: "When you use Google AI"
-                    )
-                } else {
-                    VStack(alignment: .leading, spacing: 6) {
-                        Text("No Google AI local cost data yet.")
-                            .font(.system(size: density.subtitleFontSize))
-                            .foregroundStyle(.secondary)
-                        Text("Gemini reads ~/.gemini telemetry and chat-history logs; Antigravity reads local conversation databases when they contain token metadata.")
-                            .font(.system(size: max(10, density.subtitleFontSize - 1)))
-                            .foregroundStyle(.tertiary)
-                            .lineLimit(nil)
-                    }
-                    .padding(.vertical, 24)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                }
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Cost tracking hidden for Google AI")
+                    .font(.system(size: density.subtitleFontSize, weight: .medium))
+                    .foregroundStyle(.secondary)
+                Text("Antigravity CLI conversations live in encrypted `.pb` files that we can't yet parse, and the IDE-side rates mix Google-owned and third-party model pricing in ways we haven't verified end-to-end. The cost numbers were giving misleading totals, so the section is hidden until accuracy improves. Quota readings above are unaffected.")
+                    .font(.system(size: max(10, density.subtitleFontSize - 1)))
+                    .foregroundStyle(.tertiary)
+                    .lineLimit(nil)
             }
+            .padding(.vertical, 24)
             .frame(minWidth: googleAIRightColumnMinWidth, maxWidth: .infinity, alignment: .topLeading)
         }
     }
@@ -639,7 +610,13 @@ private struct CombinedTotalsRow: View {
     private let summaryHeight: CGFloat = 178
 
     var body: some View {
-        let snapshots = ToolType.costAwareProviders.compactMap { environment.costService.snapshot(for: $0) }
+        // Skip Google AI snapshots here so the headline totals don't
+        // get polluted by unreliable Gemini/Antigravity cost numbers.
+        // See OverviewWaterfall.overviewCostProviders for the parallel
+        // exclusion in the per-provider cost grid.
+        let snapshots = ToolType.costAwareProviders
+            .filter { !ToolType.googleAIPair.contains($0) }
+            .compactMap { environment.costService.snapshot(for: $0) }
         let dailyHistory = CostSnapshotAggregator.combinedDailyHistory(snapshots)
         let activeDays = dailyHistory.filter { $0.costUSD > 0 || $0.totalTokens > 0 }
         let totalCost = snapshots.reduce(0.0) { $0 + $1.allTimeCostUSD }

--- a/Sources/VibeBarCore/Adapters/AntigravityQuotaAdapter.swift
+++ b/Sources/VibeBarCore/Adapters/AntigravityQuotaAdapter.swift
@@ -419,8 +419,16 @@ enum AntigravityResponseParser {
         let modelConfigs = userStatus.cascadeModelConfigData?.clientModelConfigs ?? []
         var buckets: [QuotaBucket] = []
         for config in modelConfigs {
-            guard let quota = config.quotaInfo,
-                  let fraction = quota.remainingFraction else { continue }
+            guard let quota = config.quotaInfo else { continue }
+            // Google's wire format omits `remainingFraction` when the
+            // model's quota is fully spent (proto3 zero-default). The
+            // older guard dropped depleted models entirely, hiding the
+            // exhausted state from the user. Treat a missing fraction
+            // as 0 so the bucket still shows up (at 100% used) with
+            // the reset countdown that Google does send. See the live
+            // AntigravityQuotaWatcher-v2 panel — depleted models stay
+            // visible there for exactly the same reason.
+            let fraction = quota.remainingFraction ?? 0.0
             let resetAt = quota.resetTime.flatMap(parseDate)
             let modelId = normalizedModelID(label: config.label, rawModelID: config.modelOrAlias?.model)
             var bucket = QuotaBucket(

--- a/Tests/VibeBarCoreTests/AntigravityParserTests.swift
+++ b/Tests/VibeBarCoreTests/AntigravityParserTests.swift
@@ -47,6 +47,77 @@ final class AntigravityParserTests: XCTestCase {
         XCTAssertEqual(snap.buckets[2].groupTitle, "Gemini Flash Lite")
     }
 
+    /// Google's wire format omits `remainingFraction` (proto3 zero
+    /// default) when a model's per-window quota is fully spent. The
+    /// older parser dropped those entries entirely, hiding the
+    /// exhausted state from the user — they would just stop seeing
+    /// the affected model in Vibe Bar's card while still seeing the
+    /// reset countdown in the official Antigravity dashboard.
+    /// Treat a missing fraction as 0 so the bucket stays visible.
+    func testKeepsDepletedModelsWithMissingRemainingFraction() throws {
+        let json = """
+        {
+          "code": 0,
+          "userStatus": {
+            "cascadeModelConfigData": {
+              "clientModelConfigs": [
+                {
+                  "label": "Gemini 3.5 Flash (High)",
+                  "modelOrAlias": {"model": "gemini-3.5-flash-high"},
+                  "quotaInfo": {"resetTime": "2026-05-23T01:05:00Z"}
+                },
+                {
+                  "label": "Gemini 3.5 Flash (Medium)",
+                  "modelOrAlias": {"model": "gemini-3.5-flash-medium"},
+                  "quotaInfo": {"remainingFraction": 0.0, "resetTime": "2026-05-23T01:05:00Z"}
+                },
+                {
+                  "label": "Claude Sonnet 4.6 (Thinking)",
+                  "modelOrAlias": {"model": "claude-sonnet-4-6"},
+                  "quotaInfo": {"remainingFraction": 0.42, "resetTime": "2026-05-23T05:55:00Z"}
+                }
+              ]
+            }
+          }
+        }
+        """
+        let snap = try AntigravityResponseParser.parseUserStatus(data: Data(json.utf8))
+        XCTAssertEqual(snap.buckets.count, 3, "All three models must surface — including the two depleted Gemini variants.")
+
+        let flashHigh = try XCTUnwrap(snap.buckets.first { $0.title == "Gemini 3.5 Flash (High)" })
+        XCTAssertEqual(flashHigh.usedPercent, 100.0, accuracy: 0.01, "Missing remainingFraction should map to 100% used.")
+        XCTAssertNotNil(flashHigh.resetAt, "Reset countdown should still surface.")
+
+        let flashMed = try XCTUnwrap(snap.buckets.first { $0.title == "Gemini 3.5 Flash (Medium)" })
+        XCTAssertEqual(flashMed.usedPercent, 100.0, accuracy: 0.01, "Explicit zero fraction should also be 100% used.")
+
+        let sonnet = try XCTUnwrap(snap.buckets.first { $0.title == "Claude Sonnet 4.6 (Thinking)" })
+        XCTAssertEqual(sonnet.usedPercent, 58.0, accuracy: 0.01, "Non-depleted models continue to compute as before.")
+    }
+
+    /// Entries with no quotaInfo at all stay filtered out — without
+    /// any quota object, we can't say anything meaningful about the
+    /// model's usage and dragging a "no data" pill into the card is
+    /// worse than omitting it.
+    func testStillSkipsModelsWithoutQuotaInfo() throws {
+        let json = """
+        {
+          "code": 0,
+          "userStatus": {
+            "cascadeModelConfigData": {
+              "clientModelConfigs": [
+                {"label": "Unknown Model A", "modelOrAlias": {"model": "unknown-a"}},
+                {"label": "Claude Sonnet 4.6 (Thinking)", "modelOrAlias": {"model": "claude-sonnet"}, "quotaInfo": {"remainingFraction": 0.5}}
+              ]
+            }
+          }
+        }
+        """
+        let snap = try AntigravityResponseParser.parseUserStatus(data: Data(json.utf8))
+        XCTAssertEqual(snap.buckets.count, 1)
+        XCTAssertEqual(snap.buckets[0].title, "Claude Sonnet 4.6 (Thinking)")
+    }
+
     func testFallsBackToPlanInfoWhenUserTierMissing() throws {
         let json = """
         {


### PR DESCRIPTION
## Summary

Two follow-up gaps surfaced after #42 wired the live language-server probe up for AntiGravity IDE v2.0.x:

- **Depleted models were silently dropped from the Antigravity card.** Google's wire format omits `quotaInfo.remainingFraction` when a per-window bucket is fully spent (proto3 zero-default). The parser guard `guard let fraction = quota.remainingFraction else { continue }` therefore hid exhausted Gemini variants entirely — the user saw 3 bars in the Vibe Bar card while AntigravityQuotaWatcher-v2 showed all 7 (with ⚠️ on the 4 depleted Gemini ones). Treat a missing fraction as 0 so depleted models stay visible with usedPercent=100 and their reset countdown.
- **Google AI cost numbers were misleading enough to pollute headline totals.** `~/.gemini/antigravity-cli/conversations/*.pb` is encrypted (entropy 7.997/8.0; OSS community has not solved decryption), so CLI conversations contribute zero cost even when the user is active there. IDE-side rates also mix Google-owned and third-party model pricing in ways we haven't validated end-to-end. Per AQ's request, hide Google AI cost everywhere until accuracy is back.

## Where the cost hide lands

- `OverviewWaterfall.overviewCostProviders` no longer includes `.gemini`. The per-provider Google AI Cost card disappears from the Overview grid.
- `CombinedTotalsRow` filters out `ToolType.googleAIPair`. The headline `TOTAL COST` / `TODAY` / `7-DAY` / `30-DAY` figures stop counting Gemini and Antigravity snapshots.
- `GoogleAIDualPage` right column is replaced with a `Cost tracking hidden for Google AI` placeholder that names the encrypted-CLI and unverified-rate-mix as reasons. The left column (quota cards, subscription utilization, status feed) is untouched.

## Test plan

- [x] `swift build` — clean
- [x] `swift test` — 462/462 green (2 new `AntigravityParserTests`: `testKeepsDepletedModelsWithMissingRemainingFraction`, `testStillSkipsModelsWithoutQuotaInfo`)
- [x] `./Scripts/build_app.sh release` — packages `.build/Vibe Bar.app`
- [x] `codesign -d --entitlements -` shows empty `[Dict]` (no `app-sandbox` key)
- [x] `codesign --verify --deep --strict` silent pass
- [ ] (Manual, after AQ installs from `.build/`) Confirm the Antigravity card now shows all 7 models, with the 4 depleted Gemini ones at 100% used + their `Refreshes in 58 minutes` countdown. Confirm Google AI Cost no longer appears in the Overview grid, the Google AI sub-page right column shows the placeholder, and headline COST totals drop by the Google AI contribution.

## Follow-ups not in scope

- **Decrypting `~/.gemini/antigravity-cli/conversations/*.pb`** — still dark; OSS community (Antigravity-Database-Manager, antigravity-chat-recovery) recovers visibility by rebuilding indices, not by reading content. Re-enable cost once decryption lands.
- **Per-provider cost rate validation** — Antigravity exposes a mix of Google AI Pro models (e.g. Gemini 3.1 Pro) and third-party LLMs (Claude Sonnet/Opus, GPT-OSS 120B). The current pricing.json `antigravity-*` entries are estimates; cross-check against AntiGravity's billing docs (when published) before re-enabling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)