### PR TITLE
Dedupe Gemini cookies to avoid Google CookieMismatch 302

### DIFF
--- a/Sources/VibeBarCore/Credentials/GeminiWebCookieStore.swift
+++ b/Sources/VibeBarCore/Credentials/GeminiWebCookieStore.swift
@@ -98,7 +98,22 @@ public enum GeminiWebCookieStore {
         guard kept.contains(where: { $0.name == "__Secure-1PSID" && !$0.value.isEmpty }) else {
             return nil
         }
-        let header = kept.map { "\($0.name)=\($0.value)" }.joined(separator: "; ")
+        // De-duplicate by cookie name (keeping the first occurrence).
+        // GeminiBrowserCookieImporter queries both `gemini.google.com`
+        // and `.google.com` in a single cookie scan, and Chrome's cookie
+        // store returns the same `.google.com`-scoped cookie once per
+        // matching domain. The unfiltered output therefore contains 2-3
+        // copies of every SID-family cookie, and shipping that as a
+        // single `Cookie:` header trips Google's `CookieMismatch`
+        // protection (HTTP 302 → accounts.google.com/CookieMismatch
+        // before any quota request lands). Folding to one value per
+        // name restores the canonical browser-sent shape.
+        var deduped: [(name: String, value: String)] = []
+        var seenNames: Set<String> = []
+        for pair in kept where seenNames.insert(pair.name).inserted {
+            deduped.append(pair)
+        }
+        let header = deduped.map { "\($0.name)=\($0.value)" }.joined(separator: "; ")
         return header.isEmpty ? nil : header
     }
 

--- a/Tests/VibeBarCoreTests/GeminiWebCookieStoreTests.swift
+++ b/Tests/VibeBarCoreTests/GeminiWebCookieStoreTests.swift
@@ -29,6 +29,56 @@ final class GeminiWebCookieStoreTests: XCTestCase {
         XCTAssertNil(minimized)
     }
 
+    /// Locks the de-duplication fix that resolves the live "Needs
+    /// re-login" bug. `GeminiBrowserCookieImporter` queries both
+    /// `gemini.google.com` and `.google.com` in a single Chrome scan,
+    /// so each `.google.com`-scoped cookie is returned 2-3 times.
+    /// Without de-duplication the resulting header carries multiple
+    /// values per name and Google's `CookieMismatch` protection
+    /// 302s every quota request to `accounts.google.com/CookieMismatch`
+    /// before any user code runs.
+    func testMinimizedHeaderDeduplicatesByCookieName() throws {
+        // Simulates the unfiltered importer output: each name appears
+        // 3 times (host-only + parent-domain × 2 query passes) except
+        // the rotating PSIDTS/PSIDCC family which is only ever
+        // host-only on the parent and therefore appears once.
+        let raw = [
+            "APISID=apisid-v1", "HSID=hsid-v1", "SAPISID=sapisid-v1",
+            "SID=sid-v1", "SSID=ssid-v1",
+            "__Secure-1PSID=psid-v1.synthetic", "__Secure-3PSID=psid3-v1.synthetic",
+            "APISID=apisid-v1", "HSID=hsid-v1", "SAPISID=sapisid-v1",
+            "SID=sid-v1", "SSID=ssid-v1",
+            "__Secure-1PSID=psid-v1.synthetic", "__Secure-3PSID=psid3-v1.synthetic",
+            "APISID=apisid-v1", "HSID=hsid-v1", "SAPISID=sapisid-v1",
+            "SID=sid-v1", "SSID=ssid-v1",
+            "__Secure-1PSID=psid-v1.synthetic", "__Secure-3PSID=psid3-v1.synthetic",
+            "__Secure-1PSIDTS=psidts-v1.rotating", "__Secure-3PSIDTS=psidts3-v1.rotating",
+            "__Secure-1PSIDCC=psidcc-v1.rotating", "__Secure-3PSIDCC=psidcc3-v1.rotating"
+        ].joined(separator: "; ")
+        let minimized = try XCTUnwrap(GeminiWebCookieStore.minimizedCookieHeader(from: raw))
+        let names = minimized
+            .split(separator: ";")
+            .map { $0.trimmingCharacters(in: .whitespaces).split(separator: "=", maxSplits: 1).first.map(String.init) ?? "" }
+        XCTAssertEqual(names.count, Set(names).count, "Each cookie name must appear at most once in the minimised header — duplicates trigger Google CookieMismatch.")
+        // Spot-check the must-have rotating cookies are still present.
+        XCTAssertTrue(minimized.contains("__Secure-1PSIDTS=psidts-v1.rotating"))
+        XCTAssertTrue(minimized.contains("__Secure-3PSIDTS=psidts3-v1.rotating"))
+        // And the dedup keeps the first occurrence intact.
+        XCTAssertTrue(minimized.contains("__Secure-1PSID=psid-v1.synthetic"))
+    }
+
+    /// If the importer's later duplicate happens to carry a fresher
+    /// value (e.g. host-only PSID rotated mid-scan), the dedup still
+    /// keeps the FIRST occurrence — that matches how browsers order
+    /// cookies in the Cookie header (more-specific first). Locks the
+    /// "first wins" tie-break in case someone later flips it to last.
+    func testMinimizedHeaderDeduplicationKeepsFirstOccurrence() throws {
+        let raw = "__Secure-1PSID=first.value; SAPISID=sapi; __Secure-1PSID=second.value"
+        let minimized = try XCTUnwrap(GeminiWebCookieStore.minimizedCookieHeader(from: raw))
+        XCTAssertTrue(minimized.contains("__Secure-1PSID=first.value"))
+        XCTAssertFalse(minimized.contains("__Secure-1PSID=second.value"))
+    }
+
     func testNormalizedHeaderStripsCookiePrefix() {
         let raw = "Cookie: __Secure-1PSID=abc; SAPISID=def"
         let normalized = GeminiWebCookieStore.normalizedCookieHeader(from: raw)


### PR DESCRIPTION
## Summary

Resolves the "Needs re-login" state that surfaced on the Gemini Web card immediately after PR #41 landed, even on freshly-imported cookies.

**Root cause**: `GeminiBrowserCookieImporter` runs `BrowserCookieQuery(domains: ["gemini.google.com", ".google.com"])` as a single Chrome scan. Chrome returns each `.google.com`-scoped SID-family cookie once per matching domain (so APISID / HSID / SAPISID / SID / SSID / __Secure-1PSID / __Secure-3PSID each show up 3 times; the host-only rotating __Secure-{1,3}PSIDTS/PSIDCC quartet shows up once). `GeminiWebCookieStore.minimizedCookieHeader` emitted all of those duplicates verbatim — Vibe Bar shipped a 2.3 KB Cookie header with 25 entries (11 unique names) on every request.

Google's session-stability protection 302-redirects `gemini.google.com/usage` → `https://accounts.google.com/CookieMismatch` when the same Cookie name carries multiple values (looks like session-hijack). The fetcher sees the redirect-stripped 41-byte body, finds no `SNlM0e`, throws `needsLogin`, and the UI prints "Needs re-login".

**Diagnostic, end-to-end**:

```text
Original stored header  (2283 chars, 25 entries) → HTTP 302 → accounts.google.com/CookieMismatch
Same header deduped     (1015 chars, 11 entries) → HTTP 200 with live SNlM0e + WIZ_global_data
```

**Fix**: one extra loop at the bottom of `GeminiWebCookieStore.minimizedCookieHeader` — after the keptCookieNames filter, fold the list to one entry per name with first-occurrence-wins (insertion order preserved so the browser-canonical "more-specific first" ordering holds). `storedCookieHeader` already runs `minimizedCookieHeader` on read, so existing Keychain entries get sanitised the next time the adapter fetches. **No user-side re-import needed.**

## Test plan

- [x] `swift build` — clean
- [x] `swift test` — 481/481 green
- [x] Two new `GeminiWebCookieStoreTests`:
  - `testMinimizedHeaderDeduplicatesByCookieName` — 25-entry repro fixture (matches the live importer output) collapses to 11 unique names; PSIDTS/PSIDCC quartet survives.
  - `testMinimizedHeaderDeduplicationKeepsFirstOccurrence` — pins the "first wins" tie-break.
- [x] `./Scripts/build_app.sh release` — packages `.build/Vibe Bar.app`
- [x] `codesign -d --entitlements -` shows empty `[Dict]` (no `app-sandbox` key)
- [x] `codesign --verify --deep --strict` silent pass
- [ ] (Manual, after install) Open the bundle — the Gemini Web card should flip from "Needs re-login" → live quota numbers using the existing imported cookies, without any user action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)