### PR TITLE
Retire standalone tiles, align Gemini bucket labels

### DIFF
--- a/Sources/VibeBarApp/Views/SettingsView.swift
+++ b/Sources/VibeBarApp/Views/SettingsView.swift
@@ -64,7 +64,7 @@ struct SettingsView: View {
 
                     settingsSection("Menu Bar Items") {
                         VStack(alignment: .leading, spacing: 8) {
-                            ForEach(MenuBarItemKind.allCases) { kind in
+                            ForEach(MenuBarItemKind.userVisibleCases) { kind in
                                 menuBarItemEditor(kind)
                             }
                         }

--- a/Sources/VibeBarCore/Adapters/GeminiWebResponseParser.swift
+++ b/Sources/VibeBarCore/Adapters/GeminiWebResponseParser.swift
@@ -21,9 +21,16 @@ import Foundation
 ///   user-visible plan name (`2 = Pro` confirmed; `1 = Free` and
 ///   `3 = Ultra` inferred from Google's published tier names).
 enum GeminiWebResponseParser {
-    /// Bucket ids the parser emits. Surfaces in `QuotaBucket.id`.
-    static let currentUsageBucketId = "gemini.web.current"
-    static let weeklyUsageBucketId  = "gemini.web.weekly"
+    /// Bucket ids the parser emits. Aligned with Codex's
+    /// `five_hour` / `weekly` naming so the Overview/MiniWindow
+    /// label catalog can share field-id conventions across providers
+    /// instead of per-tool quirks. The label "5 Hours" matches the
+    /// shorter-window bucket regardless of the exact reset cadence
+    /// Google ships — Gemini's type=1 quota refreshes roughly every
+    /// 4-6 hours in practice, close enough to Codex's 5h primary
+    /// that the shared label is more useful than a brand-new one.
+    static let currentUsageBucketId = "gemini.five_hour"
+    static let weeklyUsageBucketId  = "gemini.weekly"
 
     /// Strip Google's anti-hijacking prefix `)]}'` (with or without a
     /// trailing newline) that fronts most internal JSON RPCs.
@@ -150,12 +157,12 @@ enum GeminiWebResponseParser {
     private static func bucketDescriptor(forType type: Int) -> BucketDescriptor {
         switch type {
         case 1:
-            return BucketDescriptor(id: currentUsageBucketId, title: "Current usage", shortLabel: "Current")
+            return BucketDescriptor(id: currentUsageBucketId, title: "5 Hours", shortLabel: "5h")
         case 2:
-            return BucketDescriptor(id: weeklyUsageBucketId,  title: "Weekly limit",  shortLabel: "Weekly")
+            return BucketDescriptor(id: weeklyUsageBucketId,  title: "Weekly",  shortLabel: "Wk")
         default:
             return BucketDescriptor(
-                id: "gemini.web.bucket\(type)",
+                id: "gemini.bucket\(type)",
                 title: "Bucket \(type)",
                 shortLabel: "B\(type)"
             )

--- a/Sources/VibeBarCore/Models/AppSettings.swift
+++ b/Sources/VibeBarCore/Models/AppSettings.swift
@@ -389,8 +389,18 @@ public struct AppSettings: Codable, Equatable, Sendable {
 
     private static func normalizedMenuBarItems(_ items: [MenuBarItemSettings]) -> [MenuBarItemSettings] {
         MenuBarItemKind.allCases.map { kind in
-            items.first { $0.kind == kind }.map(migratedMenuBarItem)
+            var item = items.first { $0.kind == kind }.map(migratedMenuBarItem)
                 ?? defaultMenuBarItems.first { $0.kind == kind }!
+            // Standalone menu bar tiles for non-user-visible kinds were
+            // retired in favour of the unified Overview tile. Force
+            // their isVisible=false on every normalize pass so legacy
+            // settings that had Codex/Claude/Status tiles enabled don't
+            // come back after the upgrade. The stored settings still
+            // round-trip — they just don't surface in the menu bar.
+            if !kind.isUserVisibleStandalone {
+                item.isVisible = false
+            }
+            return item
         }
     }
 

--- a/Sources/VibeBarCore/Models/MenuBarSettings.swift
+++ b/Sources/VibeBarCore/Models/MenuBarSettings.swift
@@ -8,6 +8,19 @@ public enum MenuBarItemKind: String, Codable, CaseIterable, Identifiable, Sendab
 
     public var id: String { rawValue }
 
+    /// Cases that the Settings page is allowed to surface as
+    /// independently togglable menu bar items. The other cases
+    /// (`.codex` / `.claude` / `.status`) remain in the enum for
+    /// stored-settings backward compatibility and for sub-page
+    /// routing inside the Overview popover, but the standalone
+    /// menu-bar entry is intentionally retired in favour of the
+    /// single Overview tile.
+    public static let userVisibleCases: [MenuBarItemKind] = [.compact]
+
+    public var isUserVisibleStandalone: Bool {
+        Self.userVisibleCases.contains(self)
+    }
+
     public var label: String {
         switch self {
         case .compact: return "Overview"

--- a/Tests/VibeBarCoreTests/GeminiWebResponseParserTests.swift
+++ b/Tests/VibeBarCoreTests/GeminiWebResponseParserTests.swift
@@ -93,15 +93,15 @@ final class GeminiWebResponseParserTests: XCTestCase {
         XCTAssertEqual(snapshot.buckets.count, 2)
 
         let current = try XCTUnwrap(snapshot.buckets.first(where: { $0.id == GeminiWebResponseParser.currentUsageBucketId }))
-        XCTAssertEqual(current.title, "Current usage")
-        XCTAssertEqual(current.shortLabel, "Current")
+        XCTAssertEqual(current.title, "5 Hours")
+        XCTAssertEqual(current.shortLabel, "5h")
         XCTAssertEqual(current.usedPercent, 25.0, accuracy: 0.0001)
         XCTAssertEqual(current.resetAt?.timeIntervalSince1970 ?? 0, 1779469511.884512, accuracy: 0.001)
         XCTAssertNil(current.rawWindowSeconds)
 
         let weekly = try XCTUnwrap(snapshot.buckets.first(where: { $0.id == GeminiWebResponseParser.weeklyUsageBucketId }))
-        XCTAssertEqual(weekly.title, "Weekly limit")
-        XCTAssertEqual(weekly.shortLabel, "Weekly")
+        XCTAssertEqual(weekly.title, "Weekly")
+        XCTAssertEqual(weekly.shortLabel, "Wk")
         XCTAssertEqual(weekly.usedPercent, 10.0, accuracy: 0.0001)
         XCTAssertEqual(weekly.resetAt?.timeIntervalSince1970 ?? 0, 1779815111.884621, accuracy: 0.001)
     }
@@ -140,7 +140,7 @@ final class GeminiWebResponseParserTests: XCTestCase {
         let inner = "[2,[[1,0.05,7,[[1779469511,884512000]]]],false]"
         let snapshot = try GeminiWebResponseParser.parse(data: Self.wireFormat(inner: inner))
         XCTAssertEqual(snapshot.buckets.count, 1)
-        XCTAssertEqual(snapshot.buckets[0].id, "gemini.web.bucket7")
+        XCTAssertEqual(snapshot.buckets[0].id, "gemini.bucket7")
         XCTAssertEqual(snapshot.buckets[0].title, "Bucket 7")
         XCTAssertEqual(snapshot.buckets[0].shortLabel, "B7")
     }


### PR DESCRIPTION
## Summary

Two threads of the UI cleanup round, packaged together because both are small Settings/parser polish.

### 1. Menu Bar Items → Overview only

The OpenAI / Claude / Status tiles were each their own \`NSStatusItem\` + popover sub-page + Settings editor, but the Overview tile already hosts the Codex/Claude/Service Status content with identical layout. Standalone tiles added menu-bar clutter without giving users anything new.

- \`MenuBarItemKind\` keeps all four cases (settings serialization + Overview sub-page routing reference them).
- New static \`MenuBarItemKind.userVisibleCases = [.compact]\` drives the Settings ForEach and the normalization pass.
- \`AppSettings.normalizedMenuBarItems\` now force-sets \`isVisible=false\` for non-user-visible kinds on every load — legacy settings with Codex/Claude/Status tiles enabled get cleaned up on the next launch without user action.
- \`StatusItemController\` still spawns four NSStatusItem slots (no structural change), but \`renderMenuBar\` reads the normalized \`isVisible=false\` and keeps them hidden.

### 2. Gemini bucket labels align with Codex/Claude

\"Current usage\" / \"Weekly limit\" was a Gemini-only wording that broke the mental model users built up on Codex (5 Hours / Weekly) and Claude (5 Hours / 7 Days). Folded to the shared convention:

| Gemini bucket type | Before | After |
|--------------------|--------|-------|
| type=1 (shorter window) | id \`gemini.web.current\`, title \"Current usage\", shortLabel \"Current\" | id \`gemini.five_hour\`, title \"5 Hours\", shortLabel \"5h\" |
| type=2 (weekly window)  | id \`gemini.web.weekly\`, title \"Weekly limit\", shortLabel \"Weekly\" | id \`gemini.weekly\`, title \"Weekly\", shortLabel \"Wk\" |
| unknown type | id \`gemini.web.bucket<N>\` | id \`gemini.bucket<N>\` |

No external migration needed — these IDs are only emitted by the parser and consumed by code that uses them via the static constants, never as string literals.

## Test plan

- [x] \`swift build\` — clean
- [x] \`swift test\` — 481 / 481 green (3 existing GeminiWebResponseParserTests cases updated to the new labels + IDs)
- [x] \`./Scripts/build_app.sh release\` — packages \`.build/Vibe Bar.app\`
- [x] \`codesign -d --entitlements -\` shows empty \`[Dict]\` (no app-sandbox)
- [x] \`codesign --verify --deep --strict\` silent pass
- [ ] (Manual, after install) Settings shows only the Overview menu-bar item editor. Gemini Web card shows \`5 Hours\` / \`Weekly\` instead of \`Current usage\` / \`Weekly limit\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)