### PR TITLE
Restructure Overview Cost row + add TPM/RPM tiles

### DIFF
--- a/Sources/VibeBarApp/Views/CostHistoryView.swift
+++ b/Sources/VibeBarApp/Views/CostHistoryView.swift
@@ -480,7 +480,8 @@ struct CostHistoryView: View {
     private func formatTokens(_ tokens: Int) -> String {
         if tokens < 1_000 { return "\(tokens) tok" }
         if tokens < 1_000_000 { return String(format: "%.1fk tok", Double(tokens) / 1_000) }
-        return String(format: "%.2fM tok", Double(tokens) / 1_000_000)
+        if tokens < 1_000_000_000 { return String(format: "%.2fM tok", Double(tokens) / 1_000_000) }
+        return String(format: "%.2fB tok", Double(tokens) / 1_000_000_000)
     }
     private func formatTooltipDate(_ date: Date) -> String {
         let formatter = DateFormatter()

--- a/Sources/VibeBarApp/Views/CostSummaryRow.swift
+++ b/Sources/VibeBarApp/Views/CostSummaryRow.swift
@@ -53,6 +53,7 @@ struct CostSummaryRow: View {
     private func formatTokens(_ tokens: Int) -> String {
         if tokens < 1_000 { return "\(tokens) tok" }
         if tokens < 1_000_000 { return String(format: "%.1fk tok", Double(tokens) / 1_000) }
-        return String(format: "%.2fM tok", Double(tokens) / 1_000_000)
+        if tokens < 1_000_000_000 { return String(format: "%.2fM tok", Double(tokens) / 1_000_000) }
+        return String(format: "%.2fB tok", Double(tokens) / 1_000_000_000)
     }
 }

--- a/Sources/VibeBarApp/Views/PopoverRoot.swift
+++ b/Sources/VibeBarApp/Views/PopoverRoot.swift
@@ -618,7 +618,6 @@ private struct CombinedTotalsRow: View {
             .filter { !ToolType.googleAIPair.contains($0) }
             .compactMap { environment.costService.snapshot(for: $0) }
         let dailyHistory = CostSnapshotAggregator.combinedDailyHistory(snapshots)
-        let activeDays = dailyHistory.filter { $0.costUSD > 0 || $0.totalTokens > 0 }
         let totalCost = snapshots.reduce(0.0) { $0 + $1.allTimeCostUSD }
         let todayCost = snapshots.reduce(0.0) { $0 + $1.todayCostUSD }
         let weekCost = snapshots.reduce(0.0) { $0 + $1.last7DaysCostUSD }
@@ -627,11 +626,19 @@ private struct CombinedTotalsRow: View {
         let todayTokens = snapshots.reduce(0) { $0 + $1.todayTokens }
         let weekTokens = snapshots.reduce(0) { $0 + $1.last7DaysTokens }
         let monthTokens = snapshots.reduce(0) { $0 + $1.last30DaysTokens }
-        let totalFiles = snapshots.reduce(0) { $0 + $1.jsonlFilesFound }
+        let todayRequests = snapshots.reduce(0) { $0 + $1.todayRequests }
         let peakDayCost = dailyHistory.map(\.costUSD).max() ?? 0
-        let averageDayCost = activeDays.isEmpty
-            ? 0
-            : activeDays.reduce(0.0) { $0 + $1.costUSD } / Double(activeDays.count)
+        // TPM / RPM are today-so-far rates: tokens (or requests)
+        // divided by the elapsed minutes since local midnight. We
+        // floor the divisor to 1 so a 00:00:05 launch can't divide
+        // by zero, and clamp the result on the display side.
+        let elapsedMinutesToday: Double = {
+            let cal = Calendar.current
+            let start = cal.startOfDay(for: Date())
+            return max(1, Date().timeIntervalSince(start) / 60)
+        }()
+        let tokensPerMinute = Int((Double(todayTokens) / elapsedMinutesToday).rounded())
+        let requestsPerMinute = Double(todayRequests) / elapsedMinutesToday
 
         HStack(alignment: .top, spacing: density.interSectionSpacing) {
             VStack(alignment: .leading, spacing: 8) {
@@ -670,16 +677,14 @@ private struct CombinedTotalsRow: View {
                     divider
                     metric(label: "7-DAY TOK", value: formatTokens(weekTokens))
                     divider
-                    metric(label: "SESSIONS", value: "\(totalFiles)")
+                    metric(label: "30-DAY TOK", value: formatTokens(monthTokens))
                 }
                 HStack(alignment: .top, spacing: 0) {
-                    metric(label: "30-DAY TOK", value: formatTokens(monthTokens))
-                    divider
                     metric(label: "PEAK DAY", value: formatCost(peakDayCost))
                     divider
-                    metric(label: "AVG/DAY", value: formatCost(averageDayCost))
+                    metric(label: "TPM", value: formatTokens(tokensPerMinute))
                     divider
-                    metric(label: "DAYS USED", value: "\(activeDays.count)")
+                    metric(label: "RPM", value: formatRate(requestsPerMinute))
                 }
             }
             .padding(density.cardPadding)
@@ -731,9 +736,19 @@ private struct CombinedTotalsRow: View {
     }
 
     private func formatTokens(_ tokens: Int) -> String {
+        if tokens >= 1_000_000_000 { return String(format: "%.2fB", Double(tokens) / 1_000_000_000) }
         if tokens >= 1_000_000 { return String(format: "%.2fM", Double(tokens) / 1_000_000) }
         if tokens >= 1_000 { return String(format: "%.1fk", Double(tokens) / 1_000) }
         return "\(tokens)"
+    }
+
+    private func formatRate(_ value: Double) -> String {
+        if value <= 0 { return "0" }
+        if value < 0.1 { return String(format: "%.2f", value) }
+        if value < 10 { return String(format: "%.1f", value) }
+        if value >= 1_000_000 { return String(format: "%.2fM", value / 1_000_000) }
+        if value >= 1_000 { return String(format: "%.1fk", value / 1_000) }
+        return String(format: "%.0f", value)
     }
 
     private func formatModelName(_ modelName: String?) -> String {

--- a/Sources/VibeBarApp/Views/TopModelTile.swift
+++ b/Sources/VibeBarApp/Views/TopModelTile.swift
@@ -78,6 +78,7 @@ struct TopModelTile: View {
     private func formatTokens(_ tokens: Int) -> String {
         if tokens < 1_000 { return "\(tokens) tok" }
         if tokens < 1_000_000 { return String(format: "%.1fk tok", Double(tokens) / 1_000) }
-        return String(format: "%.2fM tok", Double(tokens) / 1_000_000)
+        if tokens < 1_000_000_000 { return String(format: "%.2fM tok", Double(tokens) / 1_000_000) }
+        return String(format: "%.2fB tok", Double(tokens) / 1_000_000_000)
     }
 }

--- a/Sources/VibeBarApp/Views/UsageHeatmapView.swift
+++ b/Sources/VibeBarApp/Views/UsageHeatmapView.swift
@@ -172,7 +172,8 @@ struct UsageHeatmapView: View {
         let label: String
         if value < 1_000 { label = "\(value) tok" }
         else if value < 1_000_000 { label = String(format: "%.1fk tok", Double(value) / 1_000) }
-        else { label = String(format: "%.2fM tok", Double(value) / 1_000_000) }
+        else if value < 1_000_000_000 { label = String(format: "%.2fM tok", Double(value) / 1_000_000) }
+        else { label = String(format: "%.2fB tok", Double(value) / 1_000_000_000) }
         return "\(day) \(hourLabel(hour)) · \(label)"
     }
 

--- a/Sources/VibeBarApp/Views/UsageRateView.swift
+++ b/Sources/VibeBarApp/Views/UsageRateView.swift
@@ -127,6 +127,7 @@ struct UsageRateView: View {
     private func formatTokens(_ tokens: Int) -> String {
         if tokens < 1_000 { return "\(tokens)" }
         if tokens < 1_000_000 { return String(format: "%.1fk", Double(tokens) / 1_000) }
-        return String(format: "%.1fM", Double(tokens) / 1_000_000)
+        if tokens < 1_000_000_000 { return String(format: "%.1fM", Double(tokens) / 1_000_000) }
+        return String(format: "%.2fB", Double(tokens) / 1_000_000_000)
     }
 }

--- a/Sources/VibeBarCore/Models/CostSnapshot.swift
+++ b/Sources/VibeBarCore/Models/CostSnapshot.swift
@@ -18,6 +18,15 @@ public struct CostSnapshot: Sendable, Equatable, Codable {
     public let last30DaysTokens: Int
     public let allTimeTokens: Int
 
+    /// Request count per window. Each event the CostAggregator sees
+    /// (one JSONL line ≈ one assistant turn ≈ one provider request)
+    /// increments these. Powers the RPM (Requests Per Minute) tile
+    /// in the Overview cost row.
+    public let todayRequests: Int
+    public let last7DaysRequests: Int
+    public let last30DaysRequests: Int
+    public let allTimeRequests: Int
+
     /// Per-day series since `dayHistoryStart`, ordered ascending.
     public let dailyHistory: [DailyCostPoint]
     /// Per-hour series for the current local day, ordered ascending. This is
@@ -61,6 +70,10 @@ public struct CostSnapshot: Sendable, Equatable, Codable {
         last7DaysTokens: Int,
         last30DaysTokens: Int,
         allTimeTokens: Int,
+        todayRequests: Int = 0,
+        last7DaysRequests: Int = 0,
+        last30DaysRequests: Int = 0,
+        allTimeRequests: Int = 0,
         dailyHistory: [DailyCostPoint],
         todayHourlyHistory: [HourlyCostPoint] = [],
         heatmap: UsageHeatmap,
@@ -79,6 +92,10 @@ public struct CostSnapshot: Sendable, Equatable, Codable {
         self.last7DaysTokens = last7DaysTokens
         self.last30DaysTokens = last30DaysTokens
         self.allTimeTokens = allTimeTokens
+        self.todayRequests = todayRequests
+        self.last7DaysRequests = last7DaysRequests
+        self.last30DaysRequests = last30DaysRequests
+        self.allTimeRequests = allTimeRequests
         self.dailyHistory = dailyHistory
         self.todayHourlyHistory = todayHourlyHistory
         self.heatmap = heatmap
@@ -94,6 +111,7 @@ public struct CostSnapshot: Sendable, Equatable, Codable {
             tool: tool,
             todayCostUSD: 0, last7DaysCostUSD: 0, last30DaysCostUSD: 0, allTimeCostUSD: 0,
             todayTokens: 0, last7DaysTokens: 0, last30DaysTokens: 0, allTimeTokens: 0,
+            todayRequests: 0, last7DaysRequests: 0, last30DaysRequests: 0, allTimeRequests: 0,
             dailyHistory: [], todayHourlyHistory: [], heatmap: .empty(tool: tool),
             modelBreakdowns: [], last7DaysModelBreakdowns: [], dailyModelBreakdown: [:], jsonlFilesFound: 0, updatedAt: now
         )
@@ -136,16 +154,25 @@ public struct CostSnapshot: Sendable, Equatable, Codable {
             calendar.isDate($0.date, inSameDayAs: now)
         }
 
+        // Request counts have no daily history — they pass through
+        // verbatim except for the today bucket, which we zero out
+        // when the cached snapshot's `updatedAt` is from a previous
+        // day (otherwise yesterday's TPM/RPM bleed into "today").
+        let todayIsFresh = calendar.isDate(updatedAt, inSameDayAs: now)
         return CostSnapshot(
             tool: tool,
-            todayCostUSD: hasDailyHistory ? todayCost : (calendar.isDate(updatedAt, inSameDayAs: now) ? todayCostUSD : 0),
+            todayCostUSD: hasDailyHistory ? todayCost : (todayIsFresh ? todayCostUSD : 0),
             last7DaysCostUSD: hasDailyHistory ? weekCost : last7DaysCostUSD,
             last30DaysCostUSD: hasDailyHistory ? monthCost : last30DaysCostUSD,
             allTimeCostUSD: hasDailyHistory ? allCost : allTimeCostUSD,
-            todayTokens: hasDailyHistory ? todayTokenCount : (calendar.isDate(updatedAt, inSameDayAs: now) ? todayTokens : 0),
+            todayTokens: hasDailyHistory ? todayTokenCount : (todayIsFresh ? todayTokens : 0),
             last7DaysTokens: hasDailyHistory ? weekTokenCount : last7DaysTokens,
             last30DaysTokens: hasDailyHistory ? monthTokenCount : last30DaysTokens,
             allTimeTokens: hasDailyHistory ? allTokenCount : allTimeTokens,
+            todayRequests: todayIsFresh ? todayRequests : 0,
+            last7DaysRequests: last7DaysRequests,
+            last30DaysRequests: last30DaysRequests,
+            allTimeRequests: allTimeRequests,
             dailyHistory: dailyHistory,
             todayHourlyHistory: hourlyToday,
             heatmap: heatmap,
@@ -175,6 +202,7 @@ public struct CostSnapshot: Sendable, Equatable, Codable {
     private enum CodingKeys: String, CodingKey {
         case tool, todayCostUSD, last7DaysCostUSD, last30DaysCostUSD, allTimeCostUSD
         case todayTokens, last7DaysTokens, last30DaysTokens, allTimeTokens
+        case todayRequests, last7DaysRequests, last30DaysRequests, allTimeRequests
         case dailyHistory, todayHourlyHistory, heatmap, modelBreakdowns, last7DaysModelBreakdowns, dailyModelBreakdown
         case jsonlFilesFound, updatedAt
     }
@@ -196,6 +224,13 @@ public struct CostSnapshot: Sendable, Equatable, Codable {
         self.last7DaysTokens = try c.decode(Int.self, forKey: .last7DaysTokens)
         self.last30DaysTokens = try c.decode(Int.self, forKey: .last30DaysTokens)
         self.allTimeTokens = try c.decode(Int.self, forKey: .allTimeTokens)
+        // Request counts are new — cached snapshots from older builds
+        // omit them; default to 0 so the TPM/RPM tiles render as 0
+        // until the next scan lands.
+        self.todayRequests = try c.decodeIfPresent(Int.self, forKey: .todayRequests) ?? 0
+        self.last7DaysRequests = try c.decodeIfPresent(Int.self, forKey: .last7DaysRequests) ?? 0
+        self.last30DaysRequests = try c.decodeIfPresent(Int.self, forKey: .last30DaysRequests) ?? 0
+        self.allTimeRequests = try c.decodeIfPresent(Int.self, forKey: .allTimeRequests) ?? 0
         self.dailyHistory = try c.decode([DailyCostPoint].self, forKey: .dailyHistory)
         self.todayHourlyHistory = try c.decodeIfPresent([HourlyCostPoint].self, forKey: .todayHourlyHistory) ?? []
         self.heatmap = try c.decode(UsageHeatmap.self, forKey: .heatmap)
@@ -228,6 +263,10 @@ public struct CostSnapshot: Sendable, Equatable, Codable {
         try c.encode(last7DaysTokens, forKey: .last7DaysTokens)
         try c.encode(last30DaysTokens, forKey: .last30DaysTokens)
         try c.encode(allTimeTokens, forKey: .allTimeTokens)
+        try c.encode(todayRequests, forKey: .todayRequests)
+        try c.encode(last7DaysRequests, forKey: .last7DaysRequests)
+        try c.encode(last30DaysRequests, forKey: .last30DaysRequests)
+        try c.encode(allTimeRequests, forKey: .allTimeRequests)
         try c.encode(dailyHistory, forKey: .dailyHistory)
         try c.encode(todayHourlyHistory, forKey: .todayHourlyHistory)
         try c.encode(heatmap, forKey: .heatmap)
@@ -376,6 +415,10 @@ public enum CostSnapshotAggregator {
             last7DaysTokens: rebased.reduce(0) { $0 + $1.last7DaysTokens },
             last30DaysTokens: rebased.reduce(0) { $0 + $1.last30DaysTokens },
             allTimeTokens: rebased.reduce(0) { $0 + $1.allTimeTokens },
+            todayRequests: rebased.reduce(0) { $0 + $1.todayRequests },
+            last7DaysRequests: rebased.reduce(0) { $0 + $1.last7DaysRequests },
+            last30DaysRequests: rebased.reduce(0) { $0 + $1.last30DaysRequests },
+            allTimeRequests: rebased.reduce(0) { $0 + $1.allTimeRequests },
             dailyHistory: combinedDailyHistory(rebased, calendar: calendar),
             todayHourlyHistory: combinedHourlyHistory(rebased, calendar: calendar),
             heatmap: combinedHeatmap(rebased, tool: tool),

--- a/Sources/VibeBarCore/Services/CostUsageScanner.swift
+++ b/Sources/VibeBarCore/Services/CostUsageScanner.swift
@@ -1098,10 +1098,10 @@ public enum CostUsageScanner {
         let weekCutoff: Date
         let monthCutoff: Date
 
-        var totalCost: Double = 0, totalTokens: Int = 0
-        var todayCost: Double = 0, todayTokens: Int = 0
-        var weekCost: Double = 0, weekTokens: Int = 0
-        var monthCost: Double = 0, monthTokens: Int = 0
+        var totalCost: Double = 0, totalTokens: Int = 0, totalRequests: Int = 0
+        var todayCost: Double = 0, todayTokens: Int = 0, todayRequests: Int = 0
+        var weekCost: Double = 0, weekTokens: Int = 0, weekRequests: Int = 0
+        var monthCost: Double = 0, monthTokens: Int = 0, monthRequests: Int = 0
         var byDay: [Date: (cost: Double, tokens: Int)] = [:]
         var byHourToday: [Date: (cost: Double, tokens: Int)] = [:]
         var heatmap: [[Int]] = Array(repeating: Array(repeating: 0, count: 24), count: 7)
@@ -1128,9 +1128,11 @@ public enum CostUsageScanner {
             let tokens = input + output + cache
             totalCost += costUSD
             totalTokens += tokens
+            totalRequests += 1
             if date >= startOfToday {
                 todayCost += costUSD
                 todayTokens += tokens
+                todayRequests += 1
                 if let hourKey = calendar.dateInterval(of: .hour, for: date)?.start {
                     var hourBucket = byHourToday[hourKey] ?? (0, 0)
                     hourBucket.cost += costUSD
@@ -1141,10 +1143,12 @@ public enum CostUsageScanner {
             if date >= weekCutoff {
                 weekCost += costUSD
                 weekTokens += tokens
+                weekRequests += 1
             }
             if date >= monthCutoff {
                 monthCost += costUSD
                 monthTokens += tokens
+                monthRequests += 1
             }
             let dayKey = calendar.startOfDay(for: date)
             var bucket = byDay[dayKey] ?? (0, 0)
@@ -1216,6 +1220,10 @@ public enum CostUsageScanner {
                 last7DaysTokens: weekTokens,
                 last30DaysTokens: monthTokens,
                 allTimeTokens: totalTokens,
+                todayRequests: todayRequests,
+                last7DaysRequests: weekRequests,
+                last30DaysRequests: monthRequests,
+                allTimeRequests: totalRequests,
                 dailyHistory: sortedDays,
                 todayHourlyHistory: hourlyToday,
                 heatmap: UsageHeatmap(tool: tool, cells: heatmap, totalTokens: totalTokens),


### PR DESCRIPTION
Three threads in the Overview cost card:

1. **Slot 8 is now 30-Day Tokens** (was SESSIONS). The top two rows now mirror each other: row 1 = cost columns, row 2 = token columns.
2. **Row 3 drops AVG/DAY, DAYS USED, SESSIONS** and keeps PEAK DAY. Adds **TPM** (Tokens Per Minute) and **RPM** (Requests Per Minute) — both computed against today's elapsed minutes since local midnight.
3. **Token formatter learns B (billions)** across all views (PopoverRoot / TopModelTile / CostSummaryRow / CostHistoryView / UsageRateView / UsageHeatmapView).

To power RPM, \`CostSnapshot\` grows four new fields (\`todayRequests\` / \`last7DaysRequests\` / \`last30DaysRequests\` / \`allTimeRequests\`) populated by \`CostAggregator\` — each \`add()\` call (≈ one assistant turn ≈ one provider request) bumps the counters. New fields decode as 0 from older cached snapshots so no migration is needed.

481/481 tests green; \`./Scripts/build_app.sh release\` + codesign verify pass with empty entitlements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)