### PR TITLE
Unify Gemini surfaces under one provider hierarchy

### DIFF
--- a/Sources/VibeBarApp/Views/PopoverRoot.swift
+++ b/Sources/VibeBarApp/Views/PopoverRoot.swift
@@ -108,7 +108,7 @@ struct PopoverRoot: View {
             case .openAI:
                 ProviderDetailView(tool: .codex, density: density)
             case .googleAI:
-                GoogleAIDualPage(density: density)
+                GeminiTabPage(density: density)
             case .grok:
                 GrokPage(density: density)
             case .misc:
@@ -128,14 +128,14 @@ struct PopoverRoot: View {
             return "Misc Providers"
         }
         if kind == .compact, overviewPage == .googleAI {
-            return "Google AI"
+            return "Gemini"
         }
         if kind == .compact, overviewPage == .grok {
             return "Grok"
         }
         switch effectiveKind {
         case .compact: return "Overview"
-        case .codex:   return "OpenAI"
+        case .codex:   return "ChatGPT"
         case .claude:  return "Claude"
         case .status:  return "Service Status"
         }
@@ -146,7 +146,7 @@ struct PopoverRoot: View {
             return "Usage-only · sign in or paste a key"
         }
         if kind == .compact, overviewPage == .googleAI {
-            return "Gemini + Antigravity · quota, cost & status"
+            return "Gemini Web + AntiGravity · quota & status"
         }
         if kind == .compact, overviewPage == .grok {
             return "xAI · monthly credits, cost & status"
@@ -292,12 +292,18 @@ private enum OverviewPage: String, CaseIterable, Identifiable {
 
     var id: String { rawValue }
 
+    /// L2 product-family labels. The tab strip used to mix L1 vendor
+    /// names (OpenAI, Google AI) with L2 product names (Claude, Grok);
+    /// pinning every tab to L2 means the tab strip reads "ChatGPT ·
+    /// Claude · Gemini · Grok" — what the user calls the AI, not how
+    /// they're billed. Gemini's tab covers both Gemini Web and the
+    /// AntiGravity IDE since both roll up to the Gemini product.
     var label: String {
         switch self {
         case .overview: return "Overview"
-        case .openAI:   return "OpenAI"
+        case .openAI:   return "ChatGPT"
         case .claude:   return "Claude"
-        case .googleAI: return "Google AI"
+        case .googleAI: return "Gemini"
         case .grok:     return "Grok"
         case .misc:     return "Misc"
         }
@@ -423,9 +429,12 @@ private struct OverviewWaterfall: View {
             ) {
                 ProviderQuotaCard(tool: .codex, density: density, compact: false)
                 ProviderQuotaCard(tool: .claude, density: density, compact: false)
-                ForEach(ToolType.partialPrimaryProviders, id: \.self) { tool in
-                    ProviderQuotaCard(tool: tool, density: density, compact: false)
-                }
+                // Gemini Web and AntiGravity both roll up to the
+                // Gemini product, so the Overview surface shows them
+                // as a single L2 "Gemini" card with two L3 sub-sections
+                // (`GeminiCombinedCard`). Grok stays on its own card.
+                GeminiCombinedCard(density: density, compact: true)
+                ProviderQuotaCard(tool: .grok, density: density, compact: false)
                 // Google AI (Gemini + Antigravity) cost is intentionally
                 // omitted while the IDE/CLI cost story is incomplete
                 // (`~/.gemini/antigravity-cli/conversations/*.pb` is
@@ -481,11 +490,114 @@ private struct GrokPage: View {
     }
 }
 
-/// The "Google AI" overview sub-page. Gemini live quota comes from
-/// gemini.google.com cookies, Antigravity gets its own local-LSP quota
-/// card, and the page surfaces the combined Gemini + Antigravity local
-/// cost panels plus the shared Google status feed.
-private struct GoogleAIDualPage: View {
+/// Overview popover card that merges Gemini Web + AntiGravity into a
+/// single L2 "Gemini" surface, with each tool as an L3 sub-section.
+/// Replaces the previous side-by-side ProviderQuotaCard pair so the
+/// two surfaces under the Gemini product no longer look like
+/// unrelated tools to the user.
+///
+/// The card itself owns the outer card chrome; the inner
+/// `ProviderQuotaCard`s render with `embedded: true` so they
+/// contribute only the per-tool header + bucket list, not their
+/// own rounded-rectangle background.
+private struct GeminiCombinedCard: View {
+    let density: Theme.Density
+    /// Compact buckets-only rendering for the dense Overview grid;
+    /// dedicated Gemini tab passes `false` so every per-model bucket
+    /// shows.
+    var compact: Bool = true
+
+    @EnvironmentObject var environment: AppEnvironment
+    @EnvironmentObject var quotaService: QuotaService
+
+    var body: some View {
+        let geminiAccounts = environment.accountStore
+            .accounts(for: .gemini)
+            .sorted { $0.id < $1.id }
+        let anyGeminiInFlight = geminiAccounts.contains {
+            quotaService.inFlightAccountIds.contains($0.id)
+        }
+        let antigravityAccount = environment.account(for: .antigravity)
+        let antigravityInFlight = antigravityAccount.map {
+            quotaService.inFlightAccountIds.contains($0.id)
+        } ?? false
+        let anyInFlight = anyGeminiInFlight || antigravityInFlight
+
+        VStack(alignment: .leading, spacing: density.cardSpacing) {
+            HStack(alignment: .center, spacing: 8) {
+                ProviderSectionTitle(
+                    tool: .gemini,
+                    title: ToolType.gemini.productName,
+                    subtitle: "\(ToolType.gemini.toolName) + \(ToolType.antigravity.toolName)",
+                    titleFontSize: density.titleFontSize,
+                    subtitleFontSize: density.subtitleFontSize,
+                    iconSize: 16,
+                    badgeSize: 24
+                )
+                Spacer(minLength: 4)
+                BorderlessIconButton(
+                    systemImage: "arrow.clockwise",
+                    help: "Refresh Gemini Web + AntiGravity"
+                ) {
+                    environment.refresh(.gemini)
+                    environment.refresh(.antigravity)
+                }
+                .disabled(anyInFlight)
+                if anyInFlight {
+                    ProgressView()
+                        .controlSize(.small)
+                        .frame(width: 16, height: 16)
+                }
+            }
+
+            ForEach(Array(geminiAccounts.enumerated()), id: \.element.id) { index, account in
+                if index > 0 {
+                    Divider().opacity(0.18).padding(.vertical, 1)
+                }
+                ProviderQuotaCard(
+                    tool: .gemini,
+                    accountId: account.id,
+                    density: density,
+                    compact: compact,
+                    embedded: true
+                )
+            }
+            if geminiAccounts.isEmpty {
+                ProviderQuotaCard(
+                    tool: .gemini,
+                    density: density,
+                    compact: compact,
+                    embedded: true
+                )
+            }
+
+            Divider().opacity(0.18).padding(.vertical, 1)
+
+            ProviderQuotaCard(
+                tool: .antigravity,
+                density: density,
+                compact: compact,
+                embedded: true
+            )
+        }
+        .padding(density.cardPadding)
+        .background(
+            RoundedRectangle(cornerRadius: density.cardCornerRadius, style: .continuous)
+                .fill(.background.tertiary.opacity(0.6))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: density.cardCornerRadius, style: .continuous)
+                .stroke(.separator.opacity(0.4), lineWidth: 0.5)
+        )
+    }
+}
+
+/// The dedicated Gemini sub-page (still routed through `OverviewPage.googleAI`
+/// for backwards-compat with the menu-bar settings, but labelled "Gemini" at
+/// every user-facing surface). Renders the unified Gemini card with full
+/// bucket detail, plus the shared subscription pace chart and the
+/// Google service-status feed.
+private struct GeminiTabPage: View {
     let density: Theme.Density
 
     @EnvironmentObject var environment: AppEnvironment
@@ -497,65 +609,21 @@ private struct GoogleAIDualPage: View {
             .accounts(for: .gemini)
             .sorted { $0.id < $1.id }
 
-        HStack(alignment: .top, spacing: density.interSectionSpacing) {
-            VStack(alignment: .leading, spacing: density.interSectionSpacing) {
-                ForEach(geminiAccounts, id: \.id) { account in
-                    ProviderQuotaCard(
+        VStack(alignment: .leading, spacing: density.interSectionSpacing) {
+            GeminiCombinedCard(density: density, compact: false)
+            if let geminiAccount = geminiAccounts.first {
+                TimelineView(.periodic(from: .now, by: 30)) { context in
+                    SubscriptionUtilizationView(
                         tool: .gemini,
-                        accountId: account.id,
+                        buckets: quotaService.cachedQuota(for: geminiAccount.id)?.buckets ?? [],
+                        mode: settingsStore.displayMode,
                         density: density,
-                        compact: false
+                        now: context.date
                     )
                 }
-                ProviderQuotaCard(tool: .antigravity, density: density, compact: false)
-                if let geminiAccount = geminiAccounts.first {
-                    TimelineView(.periodic(from: .now, by: 30)) { context in
-                        SubscriptionUtilizationView(
-                            tool: .gemini,
-                            buckets: quotaService.cachedQuota(for: geminiAccount.id)?.buckets ?? [],
-                            mode: settingsStore.displayMode,
-                            density: density,
-                            now: context.date
-                        )
-                    }
-                }
-                ServiceStatusCard(tools: [.gemini])
             }
-            .frame(
-                minWidth: googleAILeftColumnMinWidth,
-                idealWidth: googleAILeftColumnIdealWidth,
-                maxWidth: googleAILeftColumnMaxWidth,
-                alignment: .topLeading
-            )
-
-            VStack(alignment: .leading, spacing: 6) {
-                Text("Cost tracking hidden for Google AI")
-                    .font(.system(size: density.subtitleFontSize, weight: .medium))
-                    .foregroundStyle(.secondary)
-                Text("Antigravity CLI conversations live in encrypted `.pb` files that we can't yet parse, and the IDE-side rates mix Google-owned and third-party model pricing in ways we haven't verified end-to-end. The cost numbers were giving misleading totals, so the section is hidden until accuracy improves. Quota readings above are unaffected.")
-                    .font(.system(size: max(10, density.subtitleFontSize - 1)))
-                    .foregroundStyle(.tertiary)
-                    .lineLimit(nil)
-            }
-            .padding(.vertical, 24)
-            .frame(minWidth: googleAIRightColumnMinWidth, maxWidth: .infinity, alignment: .topLeading)
+            ServiceStatusCard(tools: [.gemini])
         }
-    }
-
-    private var googleAILeftColumnMinWidth: CGFloat {
-        max(320, min(380, density.popoverWidth * 0.34))
-    }
-
-    private var googleAILeftColumnIdealWidth: CGFloat {
-        max(googleAILeftColumnMinWidth, min(410, density.popoverWidth * 0.38))
-    }
-
-    private var googleAILeftColumnMaxWidth: CGFloat {
-        max(googleAILeftColumnIdealWidth, min(440, density.popoverWidth * 0.42))
-    }
-
-    private var googleAIRightColumnMinWidth: CGFloat {
-        500
     }
 }
 
@@ -622,7 +690,15 @@ private struct CombinedTotalsRow: View {
         let weekTokens = snapshots.reduce(0) { $0 + $1.last7DaysTokens }
         let monthTokens = snapshots.reduce(0) { $0 + $1.last30DaysTokens }
         let todayRequests = snapshots.reduce(0) { $0 + $1.todayRequests }
-        let peakDayCost = dailyHistory.map(\.costUSD).max() ?? 0
+        // Pick the single day with the highest cost across all
+        // providers, then surface both its cost and token totals so
+        // the user sees what they spent *and* burned on their worst
+        // day. Using `.max(by:)` rather than two separate `.max()`
+        // calls keeps the two numbers from drifting onto different
+        // days when token-heavy and dollar-heavy days disagree.
+        let peakDayPoint = dailyHistory.max(by: { $0.costUSD < $1.costUSD })
+        let peakDayCost = peakDayPoint?.costUSD ?? 0
+        let peakDayTokens = peakDayPoint?.totalTokens ?? 0
         // TPM / RPM are today-so-far rates: tokens (or requests)
         // divided by the elapsed minutes since local midnight. We
         // floor the divisor to 1 so a 00:00:05 launch can't divide
@@ -676,6 +752,8 @@ private struct CombinedTotalsRow: View {
                 }
                 HStack(alignment: .top, spacing: 0) {
                     metric(label: "PEAK DAY", value: formatCost(peakDayCost))
+                    divider
+                    metric(label: "PEAK DAY TOK", value: formatTokens(peakDayTokens))
                     divider
                     metric(label: "TPM", value: formatTokens(tokensPerMinute))
                     divider
@@ -1309,6 +1387,11 @@ struct ProviderQuotaCard: View {
     /// Overview where 3 cards are stacked. Single-provider popovers pass `false`
     /// so every bucket appears (Sonnet, Designs, Daily Routines, …).
     var compact: Bool = false
+    /// When true, drop the outer rounded-rectangle chrome so the card can
+    /// be nested inside a larger container (the unified Gemini card uses
+    /// this to host Gemini Web + AntiGravity as L3 sub-sections inside a
+    /// single L2 Gemini surface).
+    var embedded: Bool = false
 
     @EnvironmentObject var environment: AppEnvironment
     @EnvironmentObject var settingsStore: SettingsStore
@@ -1385,14 +1468,22 @@ struct ProviderQuotaCard: View {
                 messageRow(text: emptyMessage, color: .secondary)
             }
         }
-        .padding(density.cardPadding)
+        .padding(embedded ? 0 : density.cardPadding)
         .background(
-            RoundedRectangle(cornerRadius: density.cardCornerRadius, style: .continuous)
-                .fill(.background.tertiary.opacity(0.6))
+            embedded
+                ? AnyView(Color.clear)
+                : AnyView(
+                    RoundedRectangle(cornerRadius: density.cardCornerRadius, style: .continuous)
+                        .fill(.background.tertiary.opacity(0.6))
+                )
         )
         .overlay(
-            RoundedRectangle(cornerRadius: density.cardCornerRadius, style: .continuous)
-                .stroke(.separator.opacity(0.4), lineWidth: 0.5)
+            embedded
+                ? AnyView(EmptyView())
+                : AnyView(
+                    RoundedRectangle(cornerRadius: density.cardCornerRadius, style: .continuous)
+                        .stroke(.separator.opacity(0.4), lineWidth: 0.5)
+                )
         )
     }
 

--- a/Sources/VibeBarCore/Models/ProviderHierarchy.swift
+++ b/Sources/VibeBarCore/Models/ProviderHierarchy.swift
@@ -1,0 +1,75 @@
+import Foundation
+
+/// Three-level vendor / product / tool hierarchy used everywhere the
+/// UI needs to identify a provider at a single, consistent level.
+///
+/// - `vendor` (L1) — who issues the plan / bills the account
+///   (OpenAI, Anthropic, Google, xAI).
+/// - `product` (L2) — what users call the AI brand
+///   (ChatGPT, Claude, Gemini, Grok). Both Gemini Web and the
+///   AntiGravity IDE share the Gemini product because that's how
+///   Google brands them.
+/// - `tool` (L3) — the specific surface Vibe Bar tracks
+///   (Codex, Claude Code, Gemini Web, AntiGravity, Grok Build).
+///
+/// `ToolType` derives its `vendorName` / `productName` / `toolName`
+/// from a single entry per case in `ProviderHierarchyCatalog`, so
+/// every UI surface — tabs, card titles, mini-window headers,
+/// service-status rows — pulls from the same source of truth.
+public struct ProviderHierarchy: Sendable, Equatable, Hashable {
+    public let vendor: String
+    public let product: String
+    public let tool: String
+
+    public init(vendor: String, product: String, tool: String) {
+        self.vendor = vendor
+        self.product = product
+        self.tool = tool
+    }
+}
+
+/// Canonical lookup table for the five primary tools and every misc
+/// provider Vibe Bar tracks. Each `ToolType` maps to exactly one
+/// entry; the constants below double as the public spec — adding or
+/// renaming a provider is a single edit here, not a hunt across
+/// five `switch` statements.
+public enum ProviderHierarchyCatalog {
+    // MARK: - Primary five-tool hierarchy
+    //
+    //   L1 vendor   : OpenAI    | Anthropic   | Google    | Google      | xAI
+    //   L2 product  : ChatGPT   | Claude      | Gemini    | Gemini      | Grok
+    //   L3 tool     : Codex     | Claude Code | Gemini Web| AntiGravity | Grok Build
+
+    public static let codex       = ProviderHierarchy(vendor: "OpenAI",    product: "ChatGPT", tool: "Codex")
+    public static let claude      = ProviderHierarchy(vendor: "Anthropic", product: "Claude",  tool: "Claude Code")
+    public static let gemini      = ProviderHierarchy(vendor: "Google",    product: "Gemini",  tool: "Gemini Web")
+    public static let antigravity = ProviderHierarchy(vendor: "Google",    product: "Gemini",  tool: "AntiGravity")
+    public static let grok        = ProviderHierarchy(vendor: "xAI",       product: "Grok",    tool: "Grok Build")
+
+    // MARK: - Misc providers
+    //
+    // Misc tools don't slot cleanly into a vendor → product → tool
+    // split because most of them are single-product vendors with
+    // one tracked surface. Keep the same shape so callers don't have
+    // to special-case the misc tab.
+
+    public static let copilot          = ProviderHierarchy(vendor: "GitHub",     product: "Copilot",     tool: "GitHub Copilot")
+    public static let alibaba          = ProviderHierarchy(vendor: "Alibaba",    product: "Bailian",     tool: "Coding Plan")
+    public static let alibabaTokenPlan = ProviderHierarchy(vendor: "Alibaba",    product: "Bailian",     tool: "Token Plan")
+    public static let zai              = ProviderHierarchy(vendor: "Zhipu",      product: "GLM",         tool: "GLM Coding Plan")
+    public static let minimax          = ProviderHierarchy(vendor: "MiniMax",    product: "MiniMax",     tool: "MiniMax Token Plan")
+    public static let kimi             = ProviderHierarchy(vendor: "Moonshot",   product: "Kimi",        tool: "Kimi Coding Plan")
+    public static let cursor           = ProviderHierarchy(vendor: "Cursor",     product: "Cursor",      tool: "Cursor")
+    public static let mimo             = ProviderHierarchy(vendor: "Xiaomi",     product: "MiMo",        tool: "MiMo Token Plan")
+    public static let iflytek          = ProviderHierarchy(vendor: "iFlytek",    product: "Spark",       tool: "Spark Coding Plan")
+    public static let tencentHunyuan   = ProviderHierarchy(vendor: "Tencent",    product: "Hunyuan",     tool: "Hunyuan Coding Plan")
+    public static let tencentTokenPlan = ProviderHierarchy(vendor: "Tencent",    product: "Hunyuan",     tool: "Hunyuan Token Plan")
+    public static let volcengine       = ProviderHierarchy(vendor: "ByteDance",  product: "Doubao",      tool: "Doubao Coding Plan")
+    public static let baiduQianfan     = ProviderHierarchy(vendor: "Baidu",      product: "Qianfan",     tool: "Qianfan Coding Plan")
+    public static let openCodeGo       = ProviderHierarchy(vendor: "OpenCode",   product: "OpenCode Go", tool: "OpenCode Go")
+    public static let kilo             = ProviderHierarchy(vendor: "Kilo",       product: "Kilo",        tool: "Kilo")
+    public static let kiro             = ProviderHierarchy(vendor: "Kiro",       product: "Kiro",        tool: "Kiro")
+    public static let ollama           = ProviderHierarchy(vendor: "Ollama",     product: "Ollama",      tool: "Ollama")
+    public static let openRouter       = ProviderHierarchy(vendor: "OpenRouter", product: "OpenRouter",  tool: "OpenRouter")
+    public static let warp             = ProviderHierarchy(vendor: "Warp",       product: "Warp",        tool: "Warp")
+}

--- a/Sources/VibeBarCore/Models/ToolType.swift
+++ b/Sources/VibeBarCore/Models/ToolType.swift
@@ -185,195 +185,155 @@ public enum ToolType: String, Codable, CaseIterable, Hashable, Sendable {
 
     // MARK: - Display
     //
-    // Three explicit levels of the user-facing hierarchy. The legacy
-    // `displayName` / `menuTitle` / `statusProviderName` properties
-    // now delegate to these so each surface uses one level
-    // consistently:
+    // Every UI surface that needs to identify a provider picks one of
+    // three explicit levels from `hierarchy` and stays at that level:
     //
-    //   L1 vendorName  → who bills you (OpenAI / Anthropic / Google / xAI)
-    //   L2 productName → what users call the AI (ChatGPT / Claude / Gemini / Grok)
-    //   L3 toolName    → the specific surface Vibe Bar tracks (Codex CLI,
-    //                    Claude Code, Gemini Web, AntiGravity, Grok Build)
+    //   L1 vendor  → who bills you (OpenAI / Anthropic / Google / xAI)
+    //   L2 product → what users call the AI (ChatGPT / Claude / Gemini / Grok)
+    //   L3 tool    → the specific surface Vibe Bar tracks (Codex,
+    //                Claude Code, Gemini Web, AntiGravity, Grok Build)
     //
-    // Misc-provider tools (Alibaba / Tencent / Volcengine / etc.)
-    // don't slot cleanly into the hierarchy, so their L1/L2/L3 are
-    // best-effort mirrors of the existing label — the consistency
-    // requirement applies to the five primary tools listed in
-    // `ToolType.partialPrimaryProviders + [.codex, .claude]`.
+    // The catalog in `ProviderHierarchyCatalog` is the single source of
+    // truth — renaming a provider is one edit there, not a hunt across
+    // five `switch` statements. The legacy `displayName` / `menuTitle`
+    // / `statusProviderName` accessors all derive from the same entry.
+    // Misc-provider tools (Alibaba / Tencent / Volcengine / etc.) get
+    // best-effort hierarchy entries too so callers don't have to
+    // special-case them, but the consistency contract only applies to
+    // the five primary tools (`[.codex, .claude] +
+    // ToolType.partialPrimaryProviders`).
+
+    /// The single hierarchy entry every L1/L2/L3 accessor reads from.
+    public var hierarchy: ProviderHierarchy {
+        switch self {
+        case .codex:            return ProviderHierarchyCatalog.codex
+        case .claude:           return ProviderHierarchyCatalog.claude
+        case .gemini:           return ProviderHierarchyCatalog.gemini
+        case .antigravity:      return ProviderHierarchyCatalog.antigravity
+        case .grok:             return ProviderHierarchyCatalog.grok
+        case .copilot:          return ProviderHierarchyCatalog.copilot
+        case .alibaba:          return ProviderHierarchyCatalog.alibaba
+        case .alibabaTokenPlan: return ProviderHierarchyCatalog.alibabaTokenPlan
+        case .zai:              return ProviderHierarchyCatalog.zai
+        case .minimax:          return ProviderHierarchyCatalog.minimax
+        case .kimi:             return ProviderHierarchyCatalog.kimi
+        case .cursor:           return ProviderHierarchyCatalog.cursor
+        case .mimo:             return ProviderHierarchyCatalog.mimo
+        case .iflytek:          return ProviderHierarchyCatalog.iflytek
+        case .tencentHunyuan:   return ProviderHierarchyCatalog.tencentHunyuan
+        case .tencentTokenPlan: return ProviderHierarchyCatalog.tencentTokenPlan
+        case .volcengine:       return ProviderHierarchyCatalog.volcengine
+        case .baiduQianfan:     return ProviderHierarchyCatalog.baiduQianfan
+        case .openCodeGo:       return ProviderHierarchyCatalog.openCodeGo
+        case .kilo:             return ProviderHierarchyCatalog.kilo
+        case .kiro:             return ProviderHierarchyCatalog.kiro
+        case .ollama:           return ProviderHierarchyCatalog.ollama
+        case .openRouter:       return ProviderHierarchyCatalog.openRouter
+        case .warp:             return ProviderHierarchyCatalog.warp
+        }
+    }
 
     /// Level 1 — the vendor that issues the plan / bills the account.
-    public var vendorName: String {
-        switch self {
-        case .codex:       return "OpenAI"
-        case .claude:      return "Anthropic"
-        case .gemini:      return "Google"
-        case .antigravity: return "Google"
-        case .grok:        return "xAI"
-        case .copilot:     return "GitHub"
-        case .alibaba, .alibabaTokenPlan: return "Alibaba"
-        case .zai:         return "Zhipu"
-        case .minimax:     return "MiniMax"
-        case .kimi:        return "Moonshot"
-        case .cursor:      return "Cursor"
-        case .mimo:        return "Xiaomi"
-        case .iflytek:     return "iFlytek"
-        case .tencentHunyuan, .tencentTokenPlan: return "Tencent"
-        case .volcengine:  return "ByteDance"
-        case .baiduQianfan: return "Baidu"
-        case .openCodeGo:  return "OpenCode"
-        case .kilo:        return "Kilo"
-        case .kiro:        return "Kiro"
-        case .ollama:      return "Ollama"
-        case .openRouter:  return "OpenRouter"
-        case .warp:        return "Warp"
-        }
-    }
+    public var vendorName: String { hierarchy.vendor }
 
     /// Level 2 — the product brand a user identifies with.
-    public var productName: String {
-        switch self {
-        case .codex:       return "ChatGPT"
-        case .claude:      return "Claude"
-        case .gemini:      return "Gemini"
-        case .antigravity: return "Gemini"
-        case .grok:        return "Grok"
-        case .copilot:     return "Copilot"
-        case .alibaba, .alibabaTokenPlan: return "Bailian"
-        case .zai:         return "GLM"
-        case .minimax:     return "MiniMax"
-        case .kimi:        return "Kimi"
-        case .cursor:      return "Cursor"
-        case .mimo:        return "MiMo"
-        case .iflytek:     return "Spark"
-        case .tencentHunyuan, .tencentTokenPlan: return "Hunyuan"
-        case .volcengine:  return "Doubao"
-        case .baiduQianfan: return "Qianfan"
-        case .openCodeGo:  return "OpenCode Go"
-        case .kilo:        return "Kilo"
-        case .kiro:        return "Kiro"
-        case .ollama:      return "Ollama"
-        case .openRouter:  return "OpenRouter"
-        case .warp:        return "Warp"
-        }
-    }
+    public var productName: String { hierarchy.product }
 
     /// Level 3 — the specific surface Vibe Bar tracks usage for.
-    public var toolName: String {
-        switch self {
-        case .codex:       return "Codex CLI"
-        case .claude:      return "Claude Code"
-        case .gemini:      return "Gemini Web"
-        case .antigravity: return "AntiGravity"
-        case .grok:        return "Grok Build"
-        case .copilot:     return "GitHub Copilot"
-        case .alibaba:     return "Coding Plan"
-        case .alibabaTokenPlan: return "Token Plan"
-        case .zai:         return "GLM Coding Plan"
-        case .minimax:     return "MiniMax Token Plan"
-        case .kimi:        return "Kimi Coding Plan"
-        case .cursor:      return "Cursor"
-        case .mimo:        return "MiMo Token Plan"
-        case .iflytek:     return "Spark Coding Plan"
-        case .tencentHunyuan:   return "Hunyuan Coding Plan"
-        case .tencentTokenPlan: return "Hunyuan Token Plan"
-        case .volcengine:  return "Doubao Coding Plan"
-        case .baiduQianfan: return "Qianfan Coding Plan"
-        case .openCodeGo:  return "OpenCode Go"
-        case .kilo:        return "Kilo"
-        case .kiro:        return "Kiro"
-        case .ollama:      return "Ollama"
-        case .openRouter:  return "OpenRouter"
-        case .warp:        return "Warp"
-        }
-    }
+    public var toolName: String { hierarchy.tool }
 
+    /// Long-form name used by Spotlight-y surfaces (system menu items,
+    /// account-list aliases). Primary tools use the L3 tool name from
+    /// `hierarchy` directly; misc tools keep their curated long form
+    /// because the hierarchy can't capture distinctions like
+    /// "Alibaba Bailian Coding Plan" vs "Alibaba Bailian Token Plan".
     public var displayName: String {
         switch self {
-        case .codex:       return "Codex CLI"
-        case .claude:      return "Claude Code"
-        case .alibaba:     return "Alibaba Bailian Coding Plan"
+        case .codex, .claude, .gemini, .antigravity, .grok:
+            return hierarchy.tool
+        case .alibaba:          return "Alibaba Bailian Coding Plan"
         case .alibabaTokenPlan: return "Alibaba Bailian Token Plan"
-        case .gemini:      return "Gemini Web"
-        case .antigravity: return "AntiGravity"
-        case .grok:        return "Grok Build"
-        case .copilot:     return "GitHub - Copilot"
-        case .zai:         return "Zhipu GLM Coding Plan"
-        case .minimax:     return "MiniMax Token Plan"
-        case .kimi:        return "Kimi Coding Plan"
-        case .cursor:      return "Cursor"
-        case .mimo:        return "Xiaomi MiMo Token Plan"
-        case .iflytek:     return "iFlytek Spark Coding Plan"
+        case .copilot:          return "GitHub - Copilot"
+        case .zai:              return "Zhipu GLM Coding Plan"
+        case .minimax:          return "MiniMax Token Plan"
+        case .kimi:             return "Kimi Coding Plan"
+        case .cursor:           return "Cursor"
+        case .mimo:             return "Xiaomi MiMo Token Plan"
+        case .iflytek:          return "iFlytek Spark Coding Plan"
         case .tencentHunyuan:   return "Tencent Hunyuan Coding Plan"
         case .tencentTokenPlan: return "Tencent Hunyuan Token Plan"
-        case .volcengine:  return "Volcengine Coding Plan"
-        case .baiduQianfan: return "Baidu Qianfan Coding Plan"
-        case .openCodeGo:  return "OpenCode Go"
-        case .kilo:        return "Kilo"
-        case .kiro:        return "Kiro"
-        case .ollama:      return "Ollama"
-        case .openRouter:  return "OpenRouter"
-        case .warp:        return "Warp"
+        case .volcengine:       return "Volcengine Coding Plan"
+        case .baiduQianfan:     return "Baidu Qianfan Coding Plan"
+        case .openCodeGo:       return "OpenCode Go"
+        case .kilo:             return "Kilo"
+        case .kiro:             return "Kiro"
+        case .ollama:           return "Ollama"
+        case .openRouter:       return "OpenRouter"
+        case .warp:             return "Warp"
         }
     }
 
+    /// Card subtitle rendered under the L2 product title. For the
+    /// primary five tools this is the L3 tool name from `hierarchy`
+    /// so the Overview popover reads "Gemini · Gemini Web" / "Gemini ·
+    /// AntiGravity" instead of the old ad-hoc "Usage" / "Local LSP"
+    /// labels. Misc tools keep their plan-flavour descriptor since
+    /// they distinguish multiple plans inside one product (Coding
+    /// Plan vs Token Plan).
     public var subtitle: String {
         switch self {
-        case .codex:       return "CodeX"
-        case .claude:      return "Claude Code"
-        case .alibaba:     return "Coding Plan"
+        case .codex, .claude, .gemini, .antigravity, .grok:
+            return hierarchy.tool
+        case .alibaba:          return "Coding Plan"
         case .alibabaTokenPlan: return "Token Plan"
-        case .gemini:      return "Usage"
-        case .antigravity: return "Local LSP"
-        case .grok:        return "Monthly"
-        case .copilot:     return "GitHub Copilot"
-        case .zai:         return "Coding Plan"
-        case .minimax:     return "Token Plan"
-        case .kimi:        return "Coding Plan"
-        case .cursor:      return "Cursor"
-        case .mimo:        return "Token Plan"
-        case .iflytek:     return "Coding Plan"
+        case .copilot:          return "GitHub Copilot"
+        case .zai:              return "Coding Plan"
+        case .minimax:          return "Token Plan"
+        case .kimi:             return "Coding Plan"
+        case .cursor:           return "Cursor"
+        case .mimo:             return "Token Plan"
+        case .iflytek:          return "Coding Plan"
         case .tencentHunyuan:   return "Coding Plan"
         case .tencentTokenPlan: return "Token Plan"
-        case .volcengine:  return "Coding Plan"
-        case .baiduQianfan: return "Coding Plan"
-        case .openCodeGo:  return "Workspace"
-        case .kilo:        return "Credits"
-        case .kiro:        return "CLI Usage"
-        case .ollama:      return "Cloud"
-        case .openRouter:  return "Credits"
-        case .warp:        return "Warp AI Credits"
+        case .volcengine:       return "Coding Plan"
+        case .baiduQianfan:     return "Coding Plan"
+        case .openCodeGo:       return "Workspace"
+        case .kilo:             return "Credits"
+        case .kiro:             return "CLI Usage"
+        case .ollama:           return "Cloud"
+        case .openRouter:       return "Credits"
+        case .warp:             return "Warp AI Credits"
         }
     }
 
     /// L2 product family — what users call the AI brand. Used by
     /// menu-bar tile titles, popover sub-page headers, and anywhere
     /// the surface should pick one consistent level across all tools.
+    /// Primary tools take their L2 product directly from `hierarchy`;
+    /// misc tools keep curated forms that prefix the vendor for
+    /// disambiguation (e.g. "Tencent Hunyuan" rather than bare
+    /// "Hunyuan", which would clash with other Tencent surfaces).
     public var menuTitle: String {
         switch self {
-        case .codex:       return "ChatGPT"
-        case .claude:      return "Claude"
-        case .alibaba:     return "Bailian"
-        case .alibabaTokenPlan: return "Bailian"
-        case .gemini:      return "Gemini"
-        case .antigravity: return "Gemini"
-        case .grok:        return "Grok"
-        case .copilot:     return "Copilot"
-        case .zai:         return "Zhipu GLM"
-        case .minimax:     return "MiniMax"
-        case .kimi:        return "Kimi"
-        case .cursor:      return "Cursor"
-        case .mimo:        return "Xiaomi MiMo"
-        case .iflytek:     return "iFlytek Spark"
-        case .tencentHunyuan:   return "Tencent Hunyuan"
-        case .tencentTokenPlan: return "Tencent Hunyuan"
-        case .volcengine:  return "Volcengine"
-        case .baiduQianfan: return "Baidu Qianfan"
-        case .openCodeGo:  return "OpenCode Go"
-        case .kilo:        return "Kilo"
-        case .kiro:        return "Kiro"
-        case .ollama:      return "Ollama"
-        case .openRouter:  return "OpenRouter"
-        case .warp:        return "Warp"
+        case .codex, .claude, .gemini, .antigravity, .grok:
+            return hierarchy.product
+        case .alibaba, .alibabaTokenPlan: return "Bailian"
+        case .copilot:          return "Copilot"
+        case .zai:              return "Zhipu GLM"
+        case .minimax:          return "MiniMax"
+        case .kimi:             return "Kimi"
+        case .cursor:           return "Cursor"
+        case .mimo:             return "Xiaomi MiMo"
+        case .iflytek:          return "iFlytek Spark"
+        case .tencentHunyuan, .tencentTokenPlan: return "Tencent Hunyuan"
+        case .volcengine:       return "Volcengine"
+        case .baiduQianfan:     return "Baidu Qianfan"
+        case .openCodeGo:       return "OpenCode Go"
+        case .kilo:             return "Kilo"
+        case .kiro:             return "Kiro"
+        case .ollama:           return "Ollama"
+        case .openRouter:       return "OpenRouter"
+        case .warp:             return "Warp"
         }
     }
 
@@ -384,30 +344,25 @@ public enum ToolType: String, Codable, CaseIterable, Hashable, Sendable {
     /// status feed with `.gemini` for the same reason.
     public var statusProviderName: String {
         switch self {
-        case .codex:       return "OpenAI"
-        case .claude:      return "Anthropic"
-        case .alibaba:     return "Alibaba"
-        case .alibabaTokenPlan: return "Alibaba"
-        case .gemini:      return "Google"
-        case .antigravity: return "Google"
-        case .grok:        return "xAI"
-        case .copilot:     return "GitHub"
-        case .zai:         return "Z.ai"
-        case .minimax:     return "MiniMax"
-        case .kimi:        return "Moonshot"
-        case .cursor:      return "Cursor"
-        case .mimo:        return "Xiaomi"
-        case .iflytek:     return "iFlytek"
-        case .tencentHunyuan:   return "Tencent Cloud"
-        case .tencentTokenPlan: return "Tencent Cloud"
-        case .volcengine:  return "Volcengine"
-        case .baiduQianfan: return "Baidu Qianfan"
-        case .openCodeGo:  return "OpenCode"
-        case .kilo:        return "Kilo"
-        case .kiro:        return "Kiro"
-        case .ollama:      return "Ollama"
-        case .openRouter:  return "OpenRouter"
-        case .warp:        return "Warp"
+        case .codex, .claude, .gemini, .antigravity, .grok:
+            return hierarchy.vendor
+        case .alibaba, .alibabaTokenPlan: return "Alibaba"
+        case .copilot:          return "GitHub"
+        case .zai:              return "Z.ai"
+        case .minimax:          return "MiniMax"
+        case .kimi:             return "Moonshot"
+        case .cursor:           return "Cursor"
+        case .mimo:             return "Xiaomi"
+        case .iflytek:          return "iFlytek"
+        case .tencentHunyuan, .tencentTokenPlan: return "Tencent Cloud"
+        case .volcengine:       return "Volcengine"
+        case .baiduQianfan:     return "Baidu Qianfan"
+        case .openCodeGo:       return "OpenCode"
+        case .kilo:             return "Kilo"
+        case .kiro:             return "Kiro"
+        case .ollama:           return "Ollama"
+        case .openRouter:       return "OpenRouter"
+        case .warp:             return "Warp"
         }
     }
 


### PR DESCRIPTION
## Summary
- Single L1/L2/L3 catalog (`ProviderHierarchy.swift`) — every provider name on every UI surface derives from one entry per tool, so renames stop being a five-switch hunt.
- Overview tab strip pinned to L2 product names: **ChatGPT · Claude · Gemini · Grok** (was a mix of L1 vendor and L2 product).
- Gemini Web + AntiGravity now render as one **Gemini** card with two L3 sub-sections on both the Overview waterfall and the dedicated Gemini sub-page.
- Card subtitles for the five primary tools surface the L3 tool name (Codex, Claude Code, Gemini Web, AntiGravity, Grok Build) instead of the old "Usage" / "Local LSP" ad-hoc strings.
- `PEAK DAY TOK` joins `PEAK DAY $` in the Cost summary row — token count for the worst-spending day is now visible without opening the per-provider chart. Both pull from the same day so they describe one event.

## Hierarchy
- **L1 vendor** — OpenAI · Anthropic · Google · xAI
- **L2 product** — ChatGPT · Claude · Gemini · Grok
- **L3 tool** — Codex · Claude Code · Gemini Web · AntiGravity · Grok Build (AntiGravity sits under the Gemini product because that's how Google brands it.)

## Test plan
- [x] swift build
- [x] swift test (492/492)
- [x] ./Scripts/build_app.sh release
- [x] codesign -d --entitlements - ".build/Vibe Bar.app" → empty plist (no app-sandbox)
- [x] codesign --verify --deep --strict ".build/Vibe Bar.app"
- [ ] Open .build/Vibe Bar.app and verify:
  - Tabs read ChatGPT · Claude · Gemini · Grok
  - Gemini card shows one L2 header with Gemini Web + AntiGravity stacked inside
  - PEAK DAY row shows two values (cost + token)

🤖 Generated with [Claude Code](https://claude.com/claude-code)