### PR TITLE
Unify tab strip icons and drop brand-badge chrome

### DIFF
--- a/Sources/VibeBarApp/ProviderBrandIcon.swift
+++ b/Sources/VibeBarApp/ProviderBrandIcon.swift
@@ -275,21 +275,17 @@ struct ProviderBrandBadge: View {
     var containerSize: CGFloat = 24
 
     var body: some View {
+        // Companion to `ToolBrandBadge` — same naked-glyph treatment
+        // so the menu-bar / overview kind icons match the per-tool
+        // brand marks instead of wearing the old rounded-rectangle
+        // wrapper.
         ProviderBrandIconView(kind: kind, size: effectiveIconSize)
             .frame(width: containerSize, height: containerSize, alignment: .center)
-            .background(
-                RoundedRectangle(cornerRadius: min(8, containerSize * 0.32), style: .continuous)
-                    .fill(Color.primary.opacity(0.055))
-            )
-            .overlay(
-                RoundedRectangle(cornerRadius: min(8, containerSize * 0.32), style: .continuous)
-                    .stroke(Color.primary.opacity(0.075), lineWidth: 0.7)
-            )
             .accessibilityHidden(true)
     }
 
     private var effectiveIconSize: CGFloat {
-        min(containerSize - 3, max(iconSize, containerSize * 0.78))
+        min(containerSize, max(iconSize, containerSize * 0.85))
     }
 }
 
@@ -335,21 +331,21 @@ struct ToolBrandBadge: View {
     var containerSize: CGFloat = 24
 
     var body: some View {
+        // Render the brand glyph naked — AQ flagged that the
+        // background fill + stroke on the outer rounded rectangle
+        // looked like the icon was "套了一层" (wrapped in an extra
+        // layer), especially for ChatGPT and Claude whose brand
+        // marks already have rounded silhouettes. The fixed
+        // `containerSize` frame is kept so call sites that align
+        // multiple badges horizontally don't shift after the
+        // chrome comes off.
         ToolBrandIconView(tool: tool, size: effectiveIconSize)
             .frame(width: containerSize, height: containerSize, alignment: .center)
-            .background(
-                RoundedRectangle(cornerRadius: min(8, containerSize * 0.32), style: .continuous)
-                    .fill(Color.primary.opacity(0.055))
-            )
-            .overlay(
-                RoundedRectangle(cornerRadius: min(8, containerSize * 0.32), style: .continuous)
-                    .stroke(Color.primary.opacity(0.075), lineWidth: 0.7)
-            )
             .accessibilityHidden(true)
     }
 
     private var effectiveIconSize: CGFloat {
-        min(containerSize - 3, max(iconSize, containerSize * 0.78))
+        min(containerSize, max(iconSize, containerSize * 0.85))
     }
 }
 

--- a/Sources/VibeBarApp/Views/PopoverRoot.swift
+++ b/Sources/VibeBarApp/Views/PopoverRoot.swift
@@ -372,25 +372,33 @@ private struct OverviewSwitchIcon: View {
     let page: OverviewPage
     let isSelected: Bool
 
+    private static let iconSize: CGFloat = 13
+
     var body: some View {
+        // Every tab uses the same 13pt icon canvas — mixing 14pt for
+        // Overview with 13pt for the rest, and ProviderBrandIconView
+        // for codex/claude with ToolBrandIconView for gemini/grok,
+        // made the row read "高低不齐" (uneven baselines / sizes).
+        // One renderer (`ToolBrandIconView` driven off the L2-
+        // representative ToolType) keeps every tab visually pinned to
+        // the same baseline. Overview and Misc still get SF symbols
+        // because they aren't single-provider tabs.
         Group {
-            if page == .misc {
-                // Misc gets a generic "more" glyph — the misc tab
-                // covers many providers so no single brand icon is
-                // a fair representative.
+            switch page {
+            case .overview:
+                Image(systemName: "chart.bar.fill")
+                    .font(.system(size: Self.iconSize, weight: .semibold))
+            case .misc:
                 Image(systemName: "square.grid.2x2")
-                    .font(.system(size: 11, weight: .medium))
-            } else if page == .googleAI {
-                // The Google AI tab pairs Gemini + Antigravity. Use the
-                // Gemini brand icon as the visual anchor; the label
-                // already says "Google AI".
-                ToolBrandIconView(tool: .gemini, size: 13)
-            } else if page == .grok {
-                // Grok has no dedicated MenuBarItemKind, so we render
-                // its brand icon directly off the ToolType.
-                ToolBrandIconView(tool: .grok, size: 13)
-            } else {
-                ProviderBrandIconView(kind: page.menuBarKind, size: page == .overview ? 14 : 13)
+                    .font(.system(size: Self.iconSize, weight: .medium))
+            case .openAI:
+                ToolBrandIconView(tool: .codex, size: Self.iconSize)
+            case .claude:
+                ToolBrandIconView(tool: .claude, size: Self.iconSize)
+            case .googleAI:
+                ToolBrandIconView(tool: .gemini, size: Self.iconSize)
+            case .grok:
+                ToolBrandIconView(tool: .grok, size: Self.iconSize)
             }
         }
         .opacity(isSelected ? 1 : 0.72)


### PR DESCRIPTION
## Summary
- Tab strip icons now use a single 13pt canvas + a single renderer (\`ToolBrandIconView\` for the four product tabs, SF symbols for Overview + Misc). Fixes the "高低不齐" (uneven baselines / sizes) AQ flagged.
- \`ToolBrandBadge\` and \`ProviderBrandBadge\` no longer paint a rounded-rectangle fill/stroke around the brand glyph — ChatGPT / Claude / Gemini / Grok marks were reading as "套了一层" (nested layer). Glyphs are naked inside the same fixed frame so neighboring views keep alignment.

## What's still outstanding
- App icon redesign (point 3b — bigger asset work, separate PR).
- Header framework unification (point 4) — investigating; current HeaderView is already shared, jitter likely comes from elsewhere.

## Test plan
- [x] swift build / swift test (492/492)
- [x] ./Scripts/build_app.sh release
- [x] codesign -d → empty plist; codesign --verify OK
- [ ] Open app, click each Overview tab — every icon sits on the same baseline at the same size
- [ ] Open any provider card, brand glyph is not boxed in a colored square

🤖 Generated with [Claude Code](https://claude.com/claude-code)