### PR TITLE
Unify primary brand icon render scale to remove halo

### DIFF
--- a/Sources/VibeBarApp/ProviderBrandIcon.swift
+++ b/Sources/VibeBarApp/ProviderBrandIcon.swift
@@ -381,9 +381,14 @@ extension ToolType {
 
     var providerIconDrawScale: CGFloat {
         switch self {
-        case .codex, .claude:
-            return 1.0
-        case .gemini, .antigravity, .grok, .copilot, .cursor:
+        // All five primary tools render at the same overshoot scale.
+        // The previous 1.0 for codex/claude let the SVG paths reach
+        // the canvas edge — the anti-aliased boundary that produced
+        // read as a "细线" (thin line / halo) around the glyph, while
+        // the 1.25 brands (gemini/grok) overshot the canvas and got
+        // clipped to crisp edges. Same scale → same edge treatment →
+        // no halo on either pair.
+        case .codex, .claude, .gemini, .antigravity, .grok, .copilot, .cursor:
             return 1.25
         case .alibaba, .alibabaTokenPlan, .minimax, .kimi, .mimo, .iflytek, .tencentHunyuan, .tencentTokenPlan, .volcengine, .baiduQianfan, .openCodeGo, .kilo, .kiro, .ollama, .openRouter, .warp:
             return 1.36


### PR DESCRIPTION
## Summary
\`providerIconDrawScale\` previously split the five primary tools into two camps:
- \`codex\`, \`claude\` → **1.0** (no overshoot — SVG path touches the canvas edge → anti-aliased boundary shows as a faint outline / "细线")
- \`gemini\`, \`antigravity\`, \`grok\` → **1.25** (path overshoots the canvas → edges clip cleanly)

Same icon row, two edge treatments → ChatGPT/Claude looked ringed by a thin line while Gemini/Grok looked native. Move all primaries to **1.25**.

## Test plan
- [x] swift build / swift test (492/492)
- [x] build_app.sh release + codesign verify
- [ ] Open app → Overview, all five primary brand icons render with the same edge crispness

🤖 Generated with [Claude Code](https://claude.com/claude-code)