### PR TITLE
Wire Gemini Web fields, group settings, restore badges

### DIFF
--- a/Sources/VibeBarApp/Views/PopoverRoot.swift
+++ b/Sources/VibeBarApp/Views/PopoverRoot.swift
@@ -512,6 +512,7 @@ private struct GeminiCombinedCard: View {
     let density: Theme.Density
 
     @EnvironmentObject var environment: AppEnvironment
+    @EnvironmentObject var settingsStore: SettingsStore
     @EnvironmentObject var quotaService: QuotaService
 
     var body: some View {
@@ -526,6 +527,11 @@ private struct GeminiCombinedCard: View {
             quotaService.inFlightAccountIds.contains($0.id)
         } ?? false
         let anyInFlight = anyGeminiInFlight || antigravityInFlight
+        let geminiPlanBadge = planBadge(for: .gemini, accountIds: geminiAccounts.map(\.id))
+        let antigravityPlanBadge = planBadge(
+            for: .antigravity,
+            accountIds: antigravityAccount.map { [$0.id] } ?? []
+        )
 
         VStack(alignment: .leading, spacing: density.cardSpacing) {
             HStack(alignment: .center, spacing: 8) {
@@ -539,6 +545,12 @@ private struct GeminiCombinedCard: View {
                     badgeSize: 24
                 )
                 Spacer(minLength: 4)
+                if let label = geminiPlanBadge {
+                    PlanBadgeView(
+                        text: label,
+                        fontSize: max(9, density.subtitleFontSize - 1)
+                    )
+                }
                 BorderlessIconButton(
                     systemImage: "arrow.clockwise",
                     help: "Refresh Gemini Web + AntiGravity"
@@ -558,9 +570,9 @@ private struct GeminiCombinedCard: View {
             // header — no second sub-header needed because the card
             // title already reads "Gemini · Google" and the Web
             // surface is the primary one. AntiGravity gets its own
-            // L3 sub-header below (logo + name) so the IDE-side
-            // model buckets are visibly separated from the Web
-            // quota even though both live in the same card.
+            // L3 sub-header below (logo + name + plan badge) so the
+            // IDE-side model buckets are visibly separated from the
+            // Web quota even though both live in the same card.
             ForEach(geminiAccounts, id: \.id) { account in
                 ProviderQuotaCard(
                     tool: .gemini,
@@ -579,11 +591,6 @@ private struct GeminiCombinedCard: View {
                 )
             }
 
-            // L3 sub-section header — AntiGravity logo + tool name
-            // before the model bucket list. AQ asked to surface the
-            // "IDE 关系" (which tool the per-model buckets actually
-            // belong to) so the seven AntiGravity rows don't look
-            // like extra Gemini Web buckets.
             HStack(alignment: .center, spacing: 6) {
                 ToolBrandIconView(tool: .antigravity, size: 13)
                     .opacity(0.85)
@@ -591,6 +598,12 @@ private struct GeminiCombinedCard: View {
                     .font(.system(size: max(10, density.subtitleFontSize), weight: .semibold))
                     .foregroundStyle(.secondary)
                 Spacer(minLength: 4)
+                if let label = antigravityPlanBadge {
+                    PlanBadgeView(
+                        text: label,
+                        fontSize: max(8, density.subtitleFontSize - 2)
+                    )
+                }
             }
             .padding(.top, 4)
 
@@ -610,6 +623,27 @@ private struct GeminiCombinedCard: View {
             RoundedRectangle(cornerRadius: density.cardCornerRadius, style: .continuous)
                 .stroke(.separator.opacity(0.4), lineWidth: 0.5)
         )
+    }
+
+    /// Resolve the plan-badge text for a Gemini-family sub-tool. Looks
+    /// at the cached quota first (jSf9Qc returns "Pro" / "Ultra" /
+    /// "Free") and falls back to the account-level plan string. nil
+    /// when nothing meaningful is set so the caller suppresses the
+    /// badge instead of drawing an empty pill.
+    private func planBadge(for tool: ToolType, accountIds: [String]) -> String? {
+        let quotaPlan = accountIds
+            .compactMap { quotaService.cachedQuota(for: $0)?.plan }
+            .first
+        let accountPlan = accountIds
+            .compactMap { id in environment.accountStore.accounts.first(where: { $0.id == id })?.plan }
+            .first
+        let label = settingsStore.settings.planBadgeLabel(
+            for: tool,
+            quotaPlan: quotaPlan,
+            accountPlan: accountPlan
+        )
+        let trimmed = label?.trimmingCharacters(in: .whitespacesAndNewlines)
+        return (trimmed?.isEmpty == false) ? trimmed : nil
     }
 }
 

--- a/Sources/VibeBarApp/Views/SettingsView.swift
+++ b/Sources/VibeBarApp/Views/SettingsView.swift
@@ -80,9 +80,30 @@ struct SettingsView: View {
                         Text("Pick which fields appear in the selected mini mode.")
                             .font(.caption)
                             .foregroundStyle(.secondary)
-                        VStack(alignment: .leading, spacing: 8) {
-                            ForEach(MenuBarFieldCatalog.allFields) { field in
-                                miniFieldRow(field)
+                        // The flat `allFields` list had two "5 Hours" rows
+                        // and two "Weekly" rows (one for Codex, one for
+                        // Claude) with no provider context — easy to
+                        // mis-tick. Group by L2 product so each row sits
+                        // under the brand it belongs to.
+                        VStack(alignment: .leading, spacing: 12) {
+                            ForEach(MiniWindowFieldProviderSection.all, id: \.tool) { section in
+                                VStack(alignment: .leading, spacing: 8) {
+                                    HStack(spacing: 6) {
+                                        ToolBrandIconView(tool: section.tool, size: 13)
+                                            .opacity(0.85)
+                                        Text(section.title)
+                                            .font(.caption)
+                                            .fontWeight(.semibold)
+                                            .foregroundStyle(.secondary)
+                                            .textCase(.uppercase)
+                                            .tracking(0.4)
+                                    }
+                                    VStack(alignment: .leading, spacing: 6) {
+                                        ForEach(section.fields) { field in
+                                            miniFieldRow(field)
+                                        }
+                                    }
+                                }
                             }
                         }
                         Divider()
@@ -980,4 +1001,23 @@ private struct MiscProviderInstanceDropDelegate: DropDelegate {
         draggedID = nil
         return true
     }
+}
+
+/// Provider-grouped slice of `MenuBarFieldCatalog.allFields` used by
+/// the Mini Window field picker. Each section shows a brand icon
+/// + L2 product name above its rows so a flat 20-row checklist
+/// stops asking the user to remember which "5 Hours" belongs to
+/// Codex and which to Claude.
+private struct MiniWindowFieldProviderSection {
+    let tool: ToolType
+    let title: String
+    let fields: [MenuBarFieldOption]
+
+    static let all: [MiniWindowFieldProviderSection] = [
+        .init(tool: .codex,       title: ToolType.codex.productName,       fields: MenuBarFieldCatalog.codexFields),
+        .init(tool: .claude,      title: ToolType.claude.productName,      fields: MenuBarFieldCatalog.claudeFields),
+        .init(tool: .gemini,      title: ToolType.gemini.productName + " Web", fields: MenuBarFieldCatalog.geminiFields),
+        .init(tool: .antigravity, title: ToolType.antigravity.toolName,    fields: MenuBarFieldCatalog.antigravityFields),
+        .init(tool: .grok,        title: ToolType.grok.productName,        fields: MenuBarFieldCatalog.grokFields)
+    ]
 }

--- a/Sources/VibeBarCore/Adapters/GeminiWebResponseParser.swift
+++ b/Sources/VibeBarCore/Adapters/GeminiWebResponseParser.swift
@@ -29,8 +29,17 @@ enum GeminiWebResponseParser {
     /// Google ships — Gemini's type=1 quota refreshes roughly every
     /// 4-6 hours in practice, close enough to Codex's 5h primary
     /// that the shared label is more useful than a brand-new one.
-    static let currentUsageBucketId = "gemini.five_hour"
-    static let weeklyUsageBucketId  = "gemini.weekly"
+    // Bucket IDs follow the Codex / Claude convention — plain
+    // `"five_hour"` / `"weekly"` strings, no `gemini.` prefix. The
+    // tool namespace is implicit (these buckets only live on a
+    // `.gemini` quota) and `MenuBarFieldCatalog.fieldId(tool:bucketId:)`
+    // adds the prefix back when composing field ids, so the catalog
+    // entry `option(.gemini, "five_hour", ...)` ends up with the
+    // same `gemini.five_hour` field id user settings already store
+    // — which is what `MiniQuotaWindowView` looks up against
+    // `field.bucketId` on the live quota.
+    static let currentUsageBucketId = "five_hour"
+    static let weeklyUsageBucketId  = "weekly"
 
     /// Strip Google's anti-hijacking prefix `)]}'` (with or without a
     /// trailing newline) that fronts most internal JSON RPCs.

--- a/Sources/VibeBarCore/Models/MenuBarSettings.swift
+++ b/Sources/VibeBarCore/Models/MenuBarSettings.swift
@@ -159,12 +159,16 @@ public enum MenuBarFieldCatalog {
         option(.claude, "weekly_oauth_apps", "OAuth Apps · Weekly", "OAuth wk")
     ]
 
+    // Gemini Web (`gemini.google.com`) exposes a 5-hour rolling
+    // window and a weekly bucket — that's the entire quota surface
+    // the jSf9Qc parser returns, regardless of model. Earlier
+    // entries here were per-model CLI ids (Gemini 2.5 Pro / Flash /
+    // Lite, Gemini 3 Pro / Flash) from the pre-PR-#45 telemetry
+    // adapter the Web parser no longer produces; those ids get
+    // migrated to the new pair in `fieldIdMigrations` below.
     public static let geminiFields: [MenuBarFieldOption] = [
-        option(.gemini, "gemini-2.5-pro", "Gemini 2.5 Pro", "Pro"),
-        option(.gemini, "gemini-2.5-flash", "Gemini 2.5 Flash", "Flash"),
-        option(.gemini, "gemini-2.5-flash-lite", "Gemini 2.5 Flash Lite", "Lite"),
-        option(.gemini, "gemini-3-pro", "Gemini 3 Pro", "3 Pro"),
-        option(.gemini, "gemini-3-flash", "Gemini 3 Flash", "3 Flash")
+        option(.gemini, "five_hour", "5 Hours", "5h"),
+        option(.gemini, "weekly", "Weekly", "wk")
     ]
 
     public static let antigravityFields: [MenuBarFieldOption] = [
@@ -239,9 +243,19 @@ public enum MenuBarFieldCatalog {
     }
 
     private static let fieldIdMigrations: [String: [String]] = [
-        "gemini.gemini_pro": ["gemini.gemini-2.5-pro"],
-        "gemini.gemini_flash": ["gemini.gemini-2.5-flash"],
-        "gemini.gemini_flash_lite": ["gemini.gemini-2.5-flash-lite"],
+        // Old Gemini CLI per-model fields all roll up to the Web
+        // parser's two-bucket pair. We collapse them to a single
+        // `gemini.five_hour` since users selecting one model
+        // generally cared about a primary quota indicator; the
+        // Weekly bucket is right next to it in the catalog.
+        "gemini.gemini_pro":             ["gemini.five_hour"],
+        "gemini.gemini_flash":           ["gemini.five_hour"],
+        "gemini.gemini_flash_lite":      ["gemini.five_hour"],
+        "gemini.gemini-2.5-pro":         ["gemini.five_hour"],
+        "gemini.gemini-2.5-flash":       ["gemini.five_hour"],
+        "gemini.gemini-2.5-flash-lite":  ["gemini.five_hour"],
+        "gemini.gemini-3-pro":           ["gemini.five_hour"],
+        "gemini.gemini-3-flash":         ["gemini.five_hour"],
         "antigravity.claude-sonnet-4-20250514": ["antigravity.claude-sonnet-4.6-thinking"],
         "antigravity.claude-sonnet-4-5": ["antigravity.claude-sonnet-4.6-thinking"],
         "antigravity.gemini-2.5-pro": [

--- a/Tests/VibeBarCoreTests/MenuBarFieldCatalogTests.swift
+++ b/Tests/VibeBarCoreTests/MenuBarFieldCatalogTests.swift
@@ -3,10 +3,13 @@ import XCTest
 
 final class MenuBarFieldCatalogTests: XCTestCase {
     func testDedicatedProviderMiniFieldsAreCatalogued() {
+        // Gemini Web (jSf9Qc parser) only emits 5-hour and weekly
+        // buckets — the per-model CLI ids the catalog used to carry
+        // (gemini.gemini-2.5-pro etc.) are migrated to `gemini.five_hour`
+        // via `fieldIdMigrations`.
         let expected = [
-            "gemini.gemini-2.5-pro",
-            "gemini.gemini-2.5-flash",
-            "gemini.gemini-2.5-flash-lite",
+            "gemini.five_hour",
+            "gemini.weekly",
             "antigravity.claude-sonnet-4.6-thinking",
             "antigravity.claude-opus-4.6-thinking",
             "antigravity.gpt-oss-120b-medium",
@@ -24,9 +27,29 @@ final class MenuBarFieldCatalogTests: XCTestCase {
 
     func testDefaultMiniWindowIncludesDedicatedProviderFields() {
         let selected = Set(AppSettings.defaultMiniWindow.selectedFieldIds)
-        XCTAssertTrue(selected.contains("gemini.gemini-2.5-pro"))
+        XCTAssertTrue(selected.contains("gemini.five_hour"))
+        XCTAssertTrue(selected.contains("gemini.weekly"))
         XCTAssertTrue(selected.contains("antigravity.gemini-3.5-flash-high"))
         XCTAssertTrue(selected.contains("antigravity.claude-sonnet-4.6-thinking"))
         XCTAssertTrue(selected.contains("grok.monthly"))
+    }
+
+    func testGeminiCLIModelIdsMigrateToWebBuckets() {
+        // Old Gemini CLI fields no longer have catalog entries; all of
+        // them must migrate to the Web parser's `gemini.five_hour`
+        // bucket so users upgrading from <= 0.1 builds don't lose
+        // their Gemini quota cells.
+        let legacy = [
+            "gemini.gemini_pro",
+            "gemini.gemini_flash",
+            "gemini.gemini_flash_lite",
+            "gemini.gemini-2.5-pro",
+            "gemini.gemini-2.5-flash",
+            "gemini.gemini-2.5-flash-lite",
+            "gemini.gemini-3-pro",
+            "gemini.gemini-3-flash"
+        ]
+        let migrated = MenuBarFieldCatalog.migratedFieldIds(legacy)
+        XCTAssertEqual(migrated, ["gemini.five_hour"])
     }
 }


### PR DESCRIPTION
## Summary
- **Gemini Web is now configurable in Mini Window settings.** Catalog's \`geminiFields\` carried pre-PR-#45 CLI model ids (\`gemini.gemini-2.5-pro\` etc.) the jSf9Qc Web parser never produces. Replaced with the two real Web buckets (\`gemini.five_hour\` / \`gemini.weekly\`). Legacy ids migrate to \`gemini.five_hour\` so upgrading users keep one Gemini cell instead of zero.
- **Mini Window field picker grouped by L2 product**. CHATGPT / CLAUDE / GEMINI / ANTIGRAVITY / GROK section headers with brand icons; no more guessing which "5 Hours" belongs to which provider.
- **Plan badges restored** on Gemini (L2 header) and AntiGravity (L3 sub-section header) inside \`GeminiCombinedCard\`. PR #54 dropped them; this resolves them via the existing \`planBadgeLabel\` helper.

Also drops the \`gemini.\` prefix from parser bucket ids so they share the Codex/Claude convention. Field id composition still lands on \`gemini.five_hour\` for storage and lookup.

## Test plan
- [x] swift build / swift test (493/493 incl. new migration test)
- [x] build_app.sh release + codesign verify
- [ ] Open Settings → Mini Window, confirm fields are grouped under CHATGPT / CLAUDE / GEMINI / ANTIGRAVITY / GROK headers with icons
- [ ] Check "5 Hours" and "Weekly" under GEMINI group; cells appear in mini window after Gemini refresh
- [ ] Overview Gemini card shows plan badges next to "Gemini" title and "AntiGravity" sub-header

🤖 Generated with [Claude Code](https://claude.com/claude-code)