### PR TITLE
Fit mini window to Gemini Web, group Overview field picker

### DIFF
--- a/Sources/VibeBarApp/MiniQuotaWindowController.swift
+++ b/Sources/VibeBarApp/MiniQuotaWindowController.swift
@@ -193,6 +193,54 @@ final class MiniQuotaWindowController: NSObject, NSWindowDelegate {
         }
     }
 
+    /// Count of primary + branch groups the mini window will render
+    /// for `tool` given the selected bucket ids. Mirrors
+    /// `MiniBranchCell.groupKey` so a per-tool sizing decision in the
+    /// AppKit controller stays in sync with the SwiftUI layout
+    /// without having to query the live quota. A primary bucket
+    /// (anything that doesn't match a known branch-group prefix)
+    /// counts as one extra group. Used by `stableContentSize` to
+    /// reserve exactly the right number of `groupDividerReserve` gaps.
+    static func miniGroupCount(tool: ToolType, selectedBucketIds: [String]) -> Int {
+        var keys: Set<String> = []
+        var hasPrimary = false
+        for bucketId in selectedBucketIds {
+            if let key = miniBranchGroupKey(tool: tool, bucketId: bucketId) {
+                keys.insert(key)
+            } else {
+                hasPrimary = true
+            }
+        }
+        return keys.count + (hasPrimary ? 1 : 0)
+    }
+
+    private static func miniBranchGroupKey(tool: ToolType, bucketId: String) -> String? {
+        switch bucketId {
+        case "gpt_5_3_codex_spark_five_hour", "gpt_5_3_codex_spark_weekly":
+            return "codex.spark"
+        case "weekly_sonnet":
+            return "claude.sonnet"
+        case "weekly_design":
+            return "claude.design"
+        case "daily_routines":
+            return "claude.routine"
+        case "weekly_opus":
+            return "claude.opus"
+        case "weekly_oauth_apps":
+            return "claude.oauth"
+        default:
+            break
+        }
+        guard tool == .antigravity else { return nil }
+        let lower = bucketId.lowercased()
+        if lower.contains("gpt-oss") { return "antigravity.gpt-oss" }
+        if lower.contains("claude")  { return "antigravity.claude" }
+        if lower.contains("flash-lite") { return "antigravity.gemini-flash-lite" }
+        if lower.contains("flash")   { return "antigravity.gemini-flash" }
+        if lower.contains("pro")     { return "antigravity.gemini-pro" }
+        return "antigravity.\(bucketId)"
+    }
+
     private static func stableContentSize(for settings: AppSettings) -> NSSize {
         let mini = settings.miniWindow
         let displayMode = mini.displayMode
@@ -226,40 +274,42 @@ final class MiniQuotaWindowController: NSObject, NSWindowDelegate {
         }
 
         let selected = mini.fieldIds(for: displayMode)
-        var countsByTool: [ToolType: Int] = [:]
+        var bucketsByTool: [ToolType: [String]] = [:]
         for fieldId in selected {
             guard
                 let field = MenuBarFieldCatalog.field(id: fieldId),
                 field.tool.supportsDedicatedCard
             else { continue }
-            countsByTool[field.tool, default: 0] += 1
+            bucketsByTool[field.tool, default: []].append(field.bucketId)
         }
 
         // Sizing now mirrors the L2-grouped layout in
         // `MiniWindowProviderLayout`: consecutive tools sharing the
         // same L2 productName (Gemini Web + AntiGravity → "Gemini")
         // share one provider column with an internal divider between
-        // L3 sub-tools. The width calc treats each L2 group as one
-        // visible column for `providerSpacing` accounting, then adds
-        // an extra `groupDividerReserve` per intra-group L3 boundary.
+        // L3 sub-tools. Group dividers come from the actual primary +
+        // branch-group count derived from selected bucket ids; the
+        // old `min(count - 1, 4)` heuristic over-counted dividers for
+        // tools with many primary cells (Codex 4 cells reserved space
+        // for 3 dividers when there's really only 1), which left
+        // visible empty padding on the L/R edges of the panel.
         var width: CGFloat = 0
         var visibleProductGroupCount = 0
         var lastProductName: String? = nil
-        var toolsInCurrentGroup = 0
         for tool in ToolType.dedicatedCardProviders {
-            guard let count = countsByTool[tool], count > 0 else { continue }
-            let cellCount = CGFloat(count)
-            width += cellCount * cellWidth
-            width += CGFloat(max(0, count - 1)) * cellSpacing
-            width += CGFloat(max(0, min(count - 1, 4))) * groupDividerReserve
+            guard let bucketIds = bucketsByTool[tool], !bucketIds.isEmpty else { continue }
+            let cellCount = bucketIds.count
+            width += CGFloat(cellCount) * cellWidth
+            width += CGFloat(max(0, cellCount - 1)) * cellSpacing
+            let groupCount = Self.miniGroupCount(tool: tool, selectedBucketIds: bucketIds)
+            width += CGFloat(max(0, groupCount - 1)) * groupDividerReserve
             if lastProductName == tool.productName {
-                // Same L2 group as previous tool — count one intra-group divider.
+                // Same L2 product as the previous tool — adds one
+                // intra-group divider between L3 sub-columns.
                 width += groupDividerReserve
-                toolsInCurrentGroup += 1
             } else {
                 visibleProductGroupCount += 1
                 lastProductName = tool.productName
-                toolsInCurrentGroup = 1
             }
         }
         if visibleProductGroupCount > 1 {

--- a/Sources/VibeBarApp/Views/MiniQuotaWindowView.swift
+++ b/Sources/VibeBarApp/Views/MiniQuotaWindowView.swift
@@ -94,7 +94,15 @@ struct MiniQuotaWindowView: View {
     }
 
     private func isBranchField(_ field: MenuBarFieldOption) -> Bool {
-        if field.tool == .gemini || field.tool == .antigravity {
+        // AntiGravity rows are always branch-style (one ring per
+        // per-model bucket, each carrying a `groupTitle` set by the
+        // parser). Gemini USED to be in this carve-out too — that
+        // was a leftover from the per-model CLI adapter. After
+        // PR #57 the Gemini Web parser emits two flat primary
+        // buckets (`five_hour` / `weekly`) with `groupTitle == nil`,
+        // so they need to flow through the primary cell path or
+        // they never reach the mini window at all.
+        if field.tool == .antigravity {
             return true
         }
         switch field.bucketId {

--- a/Sources/VibeBarApp/Views/SettingsView.swift
+++ b/Sources/VibeBarApp/Views/SettingsView.swift
@@ -576,11 +576,7 @@ struct SettingsView: View {
                         .font(.caption)
                         .foregroundStyle(.secondary)
                         .padding(.top, 2)
-                    VStack(alignment: .leading, spacing: 6) {
-                        ForEach(MenuBarFieldCatalog.fields(for: kind)) { field in
-                            menuFieldRow(kind: kind, field: field)
-                        }
-                    }
+                    menuItemFieldList(for: kind)
                 }
             }
             .padding(.top, 8)
@@ -669,6 +665,46 @@ struct SettingsView: View {
                 field: field,
                 label: menuFieldLabelBinding(kind, field)
             )
+        }
+    }
+
+    /// Field-picker layout for a `MenuBarItemKind`. Overview lists
+    /// every provider's fields, which used to render as a flat 20-row
+    /// checklist with two unlabelled "5 Hours" rows and no Gemini Web
+    /// section — the same readability problem the Mini Window picker
+    /// already solved with L2-product section headers. Re-use that
+    /// grouping for Overview; the per-tool kinds (.codex / .claude)
+    /// already render a single provider, so they keep the flat list.
+    @ViewBuilder
+    private func menuItemFieldList(for kind: MenuBarItemKind) -> some View {
+        if kind == .compact {
+            VStack(alignment: .leading, spacing: 12) {
+                ForEach(MiniWindowFieldProviderSection.all, id: \.tool) { section in
+                    VStack(alignment: .leading, spacing: 8) {
+                        HStack(spacing: 6) {
+                            ToolBrandIconView(tool: section.tool, size: 13)
+                                .opacity(0.85)
+                            Text(section.title)
+                                .font(.caption)
+                                .fontWeight(.semibold)
+                                .foregroundStyle(.secondary)
+                                .textCase(.uppercase)
+                                .tracking(0.4)
+                        }
+                        VStack(alignment: .leading, spacing: 6) {
+                            ForEach(section.fields) { field in
+                                menuFieldRow(kind: kind, field: field)
+                            }
+                        }
+                    }
+                }
+            }
+        } else {
+            VStack(alignment: .leading, spacing: 6) {
+                ForEach(MenuBarFieldCatalog.fields(for: kind)) { field in
+                    menuFieldRow(kind: kind, field: field)
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
Three follow-ups to PR #57.

1. **Gemini Web 5h / Weekly now appear in mini window.** \`isBranchField\` blanket-treated every \`.gemini\` field as a branch (one ring per groupTitle) — a leftover from the per-model CLI adapter. The Web parser emits two primary buckets with \`groupTitle == nil\`, so the branch path's \`groupTitle != nil\` filter dropped them silently. Restrict the carve-out to \`.antigravity\`.
2. **Mini window L/R gaps tightened.** \`stableContentSize\` over-counted group dividers (\`min(count - 1, 4)\`) — reserved space for 3 dividers on Codex when there's really 1. Replace with an accurate primary+branch group count derived via \`miniGroupCount(tool:selectedBucketIds:)\`.
3. **Overview menu-bar item Fields list grouped by L2 product**, mirroring PR #57's Mini Window picker. Per-tool kinds (.codex / .claude) keep the flat list since they only show one provider.

## Test plan
- [x] swift build / swift test (493/493)
- [x] build_app.sh release + codesign verify
- [ ] Open mini window: Gemini's "5 Hours" / "Weekly" cells appear in the GEMINI column
- [ ] Mini window doesn't have visible L/R empty padding
- [ ] Settings → Overview menu bar item → Fields list shows CHATGPT / CLAUDE / GEMINI / ANTIGRAVITY / GROK section headers

🤖 Generated with [Claude Code](https://claude.com/claude-code)