### PR TITLE
Add subscription fill-rate history with per-bucket sparklines

### DIFF
--- a/Sources/VibeBarApp/AppEnvironment.swift
+++ b/Sources/VibeBarApp/AppEnvironment.swift
@@ -48,9 +48,15 @@ final class AppEnvironment: ObservableObject {
             antigravityUsageMode: settings.antigravityUsageMode,
             miscProviderInstances: settings.settings.miscProviderInstances
         )
-        let service = QuotaService.makeDefault(mockProvider: { [weak settings] in
-            settings?.mockEnabled ?? false
-        }, initialAccountIds: accounts.accounts.map(\.id))
+        let service = QuotaService.makeDefault(
+            mockProvider: { [weak settings] in
+                settings?.mockEnabled ?? false
+            },
+            retentionProvider: { [weak settings] in
+                settings?.settings.costData.retentionDays ?? CostDataSettings.defaultRetentionDays
+            },
+            initialAccountIds: accounts.accounts.map(\.id)
+        )
 
         self.settingsStore = settings
         self.accountStore = accounts

--- a/Sources/VibeBarApp/Views/SettingsView.swift
+++ b/Sources/VibeBarApp/Views/SettingsView.swift
@@ -410,6 +410,9 @@ struct SettingsView: View {
                                 Text(costRetentionLabel(days)).tag(days)
                             }
                         }
+                        Text("Applies to cost history and subscription fill history.")
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
                         Toggle("Privacy mode", isOn: $settingsStore.settings.costData.privacyModeEnabled)
                         HStack {
                             Button {

--- a/Sources/VibeBarApp/Views/SubscriptionUtilizationView.swift
+++ b/Sources/VibeBarApp/Views/SubscriptionUtilizationView.swift
@@ -132,6 +132,24 @@ struct SubscriptionUtilizationView: View {
                         .truncationMode(.tail)
                 }
             }
+            sparkline(for: bucket)
+        }
+    }
+
+    @ViewBuilder
+    private func sparkline(for bucket: QuotaBucket) -> some View {
+        if let accountId = environment.account(for: tool)?.id {
+            let key = SubscriptionHistoryKey(accountId: accountId, bucketId: bucket.id)
+            let samples = quotaService.historyByAccountBucket[key] ?? []
+            if bucket.resetAt != nil || !samples.isEmpty {
+                SubscriptionWindowSparkline(
+                    samples: samples,
+                    currentResetAt: bucket.resetAt,
+                    currentUsedPercent: bucket.usedPercent,
+                    mode: mode,
+                    density: density
+                )
+            }
         }
     }
 

--- a/Sources/VibeBarApp/Views/SubscriptionWindowSparkline.swift
+++ b/Sources/VibeBarApp/Views/SubscriptionWindowSparkline.swift
@@ -1,0 +1,314 @@
+import SwiftUI
+import VibeBarCore
+
+/// Compact horizontal strip showing the fill rate of past reset
+/// windows for one quota bucket. Each bar is a `SubscriptionWindowSample`;
+/// the rightmost bar is the in-progress window when `currentResetAt`
+/// matches a sample, or a synthesized faded bar built from
+/// `currentUsedPercent` when no live sample exists yet.
+///
+/// Reads its data from `QuotaService.historyByAccountBucket` through
+/// the parent view; this view is purely visual.
+struct SubscriptionWindowSparkline: View {
+    /// Newest-first samples for the bucket (already sorted by
+    /// `windowEnd`).
+    let samples: [SubscriptionWindowSample]
+    let currentResetAt: Date?
+    let currentUsedPercent: Double
+    let mode: DisplayMode
+    let density: Theme.Density
+
+    private static let barWidth: CGFloat = 6
+    private static let barSpacing: CGFloat = 2
+    private static let maxBars: Int = 24
+    private static let minVisibleHeight: CGFloat = 2
+
+    var body: some View {
+        let bars = renderableBars()
+        if bars.isEmpty { EmptyView() } else {
+            HStack(spacing: Self.barSpacing) {
+                ForEach(bars) { bar in
+                    SparklineBar(bar: bar, mode: mode, barWidth: Self.barWidth)
+                }
+            }
+            .frame(height: barHeight, alignment: .bottom)
+            .accessibilityLabel(accessibilitySummary(bars: bars))
+        }
+    }
+
+    private var barHeight: CGFloat {
+        max(16, density.bucketBarHeight * 0.6)
+    }
+
+    private func renderableBars() -> [BarSlot] {
+        var slots: [BarSlot] = []
+        // Track which samples we already promoted into the "current"
+        // slot so we don't double-render them.
+        var consumedCurrentSampleID: String?
+
+        if let currentResetAt {
+            // Prefer a live sample matching the in-progress windowEnd
+            // (so the bar inherits real peak/last numbers and hover
+            // shows accurate counts). Fall back to a synthesized bar
+            // from currentUsedPercent when no sample exists yet.
+            if let liveSample = samples.first(where: { $0.windowEnd == currentResetAt }) {
+                slots.append(BarSlot(
+                    id: liveSample.id,
+                    windowEnd: liveSample.windowEnd,
+                    windowStart: liveSample.windowStart,
+                    rawWindowSeconds: liveSample.rawWindowSeconds,
+                    peak: liveSample.peakUsedPercent,
+                    last: liveSample.lastUsedPercent,
+                    observationCount: liveSample.observationCount,
+                    isCurrent: true
+                ))
+                consumedCurrentSampleID = liveSample.id
+            } else {
+                slots.append(BarSlot(
+                    id: "synthetic-current-\(currentResetAt.timeIntervalSinceReferenceDate)",
+                    windowEnd: currentResetAt,
+                    windowStart: nil,
+                    rawWindowSeconds: nil,
+                    peak: currentUsedPercent,
+                    last: currentUsedPercent,
+                    observationCount: 0,
+                    isCurrent: true
+                ))
+            }
+        }
+
+        for sample in samples where sample.id != consumedCurrentSampleID {
+            slots.append(BarSlot(
+                id: sample.id,
+                windowEnd: sample.windowEnd,
+                windowStart: sample.windowStart,
+                rawWindowSeconds: sample.rawWindowSeconds,
+                peak: sample.peakUsedPercent,
+                last: sample.lastUsedPercent,
+                observationCount: sample.observationCount,
+                isCurrent: false
+            ))
+        }
+
+        if slots.count > Self.maxBars {
+            slots = Array(slots.prefix(Self.maxBars))
+        }
+        return slots.reversed()  // oldest left, newest (current) right
+    }
+
+    private func accessibilitySummary(bars: [BarSlot]) -> String {
+        guard let newest = bars.last else { return "Subscription fill history" }
+        let percent = displayValue(for: newest)
+        let label = mode == .remaining ? "left" : "used"
+        return "Subscription fill history. Current window \(Int(percent.rounded()))% \(label)."
+    }
+
+    private func displayValue(for bar: BarSlot) -> Double {
+        switch mode {
+        case .used:      return bar.peak
+        case .remaining: return max(0, 100 - bar.peak)
+        }
+    }
+}
+
+// MARK: - Bar slot
+
+extension SubscriptionWindowSparkline {
+    fileprivate struct BarSlot: Identifiable, Hashable {
+        let id: String
+        let windowEnd: Date
+        let windowStart: Date?
+        let rawWindowSeconds: Int?
+        let peak: Double
+        let last: Double
+        let observationCount: Int
+        let isCurrent: Bool
+    }
+}
+
+private extension SubscriptionWindowSample {
+    /// Stable identifier used by the sparkline ForEach. Bucket id + the
+    /// window end timestamp fully identifies a window across runs.
+    var id: String {
+        "\(accountId)|\(bucketId)|\(Int(windowEnd.timeIntervalSinceReferenceDate))"
+    }
+}
+
+// MARK: - Single bar with hover popover
+
+private struct SparklineBar: View {
+    let bar: SubscriptionWindowSparkline.BarSlot
+    let mode: DisplayMode
+    let barWidth: CGFloat
+
+    @State private var hovering = false
+
+    private static let minVisibleHeight: CGFloat = 2
+
+    var body: some View {
+        let percent = displayValue
+        GeometryReader { geo in
+            VStack(spacing: 0) {
+                Spacer(minLength: 0)
+                RoundedRectangle(cornerRadius: 1.5, style: .continuous)
+                    .fill(Theme.barColor(percent: bar.peak, mode: mode))
+                    .opacity(bar.isCurrent ? 0.5 : 1.0)
+                    .frame(height: barFillHeight(in: geo.size.height, percent: percent))
+            }
+        }
+        .frame(width: barWidth)
+        .background(
+            RoundedRectangle(cornerRadius: 1.5, style: .continuous)
+                .fill(Theme.barTrack)
+                .opacity(0.6)
+        )
+        .contentShape(Rectangle())
+        .onHover { hovering = $0 }
+        .popover(isPresented: $hovering, arrowEdge: .top) {
+            tooltip
+                .padding(.vertical, 8)
+                .padding(.horizontal, 10)
+        }
+    }
+
+    private var displayValue: Double {
+        switch mode {
+        case .used:      return bar.peak
+        case .remaining: return max(0, 100 - bar.peak)
+        }
+    }
+
+    private func barFillHeight(in total: CGFloat, percent: Double) -> CGFloat {
+        guard total > 0 else { return Self.minVisibleHeight }
+        let raw = total * CGFloat(percent / 100)
+        return max(Self.minVisibleHeight, min(total, raw))
+    }
+
+    @ViewBuilder
+    private var tooltip: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack(spacing: 8) {
+                Text("peak")
+                    .font(.caption2).foregroundStyle(.secondary)
+                Text(formatPercent(bar.peak))
+                    .font(.caption.monospacedDigit())
+                    .fontWeight(.semibold)
+            }
+            HStack(spacing: 8) {
+                Text("last")
+                    .font(.caption2).foregroundStyle(.secondary)
+                Text(formatPercent(bar.last))
+                    .font(.caption.monospacedDigit())
+            }
+            Divider()
+            Text(windowSummary)
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+            if bar.observationCount > 0 {
+                Text("observed \(bar.observationCount)×")
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+            } else if bar.isCurrent {
+                Text("in progress")
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+            }
+        }
+    }
+
+    private func formatPercent(_ value: Double) -> String {
+        switch mode {
+        case .used:      return "\(Int(value.rounded()))%"
+        case .remaining: return "\(Int((100 - value).rounded()))% left"
+        }
+    }
+
+    private var windowSummary: String {
+        let endStr = SparklineBar.dateFormatter.string(from: bar.windowEnd)
+        if let start = bar.windowStart {
+            let startStr = SparklineBar.dateFormatter.string(from: start)
+            return "\(startStr) → \(endStr)"
+        }
+        return "ends \(endStr)"
+    }
+
+    private static let dateFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.locale = Locale(identifier: "en_US_POSIX")
+        f.dateFormat = "MM-dd HH:mm"
+        return f
+    }()
+}
+
+// MARK: - Previews
+
+private enum SubscriptionWindowSparklinePreviewFixtures {
+    static func samples(
+        tool: ToolType,
+        peaks: [Double],
+        lasts: [Double]
+    ) -> [SubscriptionWindowSample] {
+        let now = Date()
+        return zip(peaks, lasts).enumerated().map { (offset, pair) in
+            let (peak, last) = pair
+            let i = offset + 1
+            return SubscriptionWindowSample(
+                accountId: "acct",
+                tool: tool,
+                bucketId: "weekly",
+                windowEnd: now.addingTimeInterval(-Double(i) * 7 * 86_400),
+                windowStart: now.addingTimeInterval(-Double(i + 1) * 7 * 86_400),
+                rawWindowSeconds: 604_800,
+                peakUsedPercent: peak,
+                lastUsedPercent: last,
+                observationCount: 30,
+                firstSeenAt: now,
+                lastSeenAt: now
+            )
+        }
+    }
+}
+
+#Preview("Mixed history") {
+    SubscriptionWindowSparkline(
+        samples: SubscriptionWindowSparklinePreviewFixtures.samples(
+            tool: .claude,
+            peaks: [80, 100, 5, 55, 90],
+            lasts: [78, 100, 5, 50, 88]
+        ),
+        currentResetAt: Date().addingTimeInterval(3 * 86_400),
+        currentUsedPercent: 32,
+        mode: .used,
+        density: Theme.density(for: .regular)
+    )
+    .padding()
+    .frame(width: 240)
+}
+
+#Preview("Empty + current only") {
+    SubscriptionWindowSparkline(
+        samples: [],
+        currentResetAt: Date().addingTimeInterval(3 * 86_400),
+        currentUsedPercent: 18,
+        mode: .used,
+        density: Theme.density(for: .regular)
+    )
+    .padding()
+    .frame(width: 240)
+}
+
+#Preview("Remaining mode") {
+    SubscriptionWindowSparkline(
+        samples: SubscriptionWindowSparklinePreviewFixtures.samples(
+            tool: .codex,
+            peaks: [70, 95, 40, 60],
+            lasts: [70, 95, 40, 60]
+        ),
+        currentResetAt: Date().addingTimeInterval(2 * 86_400),
+        currentUsedPercent: 22,
+        mode: .remaining,
+        density: Theme.density(for: .regular)
+    )
+    .padding()
+    .frame(width: 240)
+}

--- a/Sources/VibeBarCore/Models/SubscriptionWindowSample.swift
+++ b/Sources/VibeBarCore/Models/SubscriptionWindowSample.swift
@@ -1,0 +1,70 @@
+import Foundation
+
+/// One observed reset window for a single quota bucket of a single
+/// account. The store keeps a rolling history of these per (account,
+/// bucket) so the UI can render a sparkline of "how full did I get in
+/// each of the last N windows."
+///
+/// Identity for max-merge is `(accountId, bucketId, windowEnd)`. A
+/// window is uniquely identified by its `resetAt` — every observation
+/// of the same bucket within the same window converges to one sample,
+/// with `peakUsedPercent` rising monotonically as new observations
+/// arrive and `lastUsedPercent` tracking the time-newest value.
+public struct SubscriptionWindowSample: Codable, Hashable, Sendable {
+    public var accountId: String
+    public var tool: ToolType
+    public var bucketId: String
+    public var windowEnd: Date
+    public var windowStart: Date?
+    public var rawWindowSeconds: Int?
+    public var peakUsedPercent: Double
+    public var lastUsedPercent: Double
+    public var observationCount: Int
+    public var firstSeenAt: Date
+    public var lastSeenAt: Date
+
+    public init(
+        accountId: String,
+        tool: ToolType,
+        bucketId: String,
+        windowEnd: Date,
+        windowStart: Date? = nil,
+        rawWindowSeconds: Int? = nil,
+        peakUsedPercent: Double,
+        lastUsedPercent: Double,
+        observationCount: Int = 1,
+        firstSeenAt: Date,
+        lastSeenAt: Date
+    ) {
+        self.accountId = accountId
+        self.tool = tool
+        self.bucketId = bucketId
+        self.windowEnd = windowEnd
+        self.windowStart = windowStart
+        self.rawWindowSeconds = rawWindowSeconds
+        self.peakUsedPercent = Self.clamp(peakUsedPercent)
+        self.lastUsedPercent = Self.clamp(lastUsedPercent)
+        self.observationCount = max(0, observationCount)
+        self.firstSeenAt = firstSeenAt
+        self.lastSeenAt = lastSeenAt
+    }
+
+    private static func clamp(_ value: Double) -> Double {
+        guard value.isFinite else { return 0 }
+        return min(100, max(0, value))
+    }
+}
+
+/// Composite key (accountId + bucketId) used by `QuotaService` to
+/// expose subscription-history samples to SwiftUI views as one
+/// dictionary. Bucket ids are stable across refreshes; account ids
+/// are already privacy-preserving hashes.
+public struct SubscriptionHistoryKey: Hashable, Sendable {
+    public var accountId: String
+    public var bucketId: String
+
+    public init(accountId: String, bucketId: String) {
+        self.accountId = accountId
+        self.bucketId = bucketId
+    }
+}

--- a/Sources/VibeBarCore/Services/QuotaService.swift
+++ b/Sources/VibeBarCore/Services/QuotaService.swift
@@ -9,24 +9,42 @@ public final class QuotaService: ObservableObject {
     @Published public private(set) var lastErrorByAccount: [String: QuotaError] = [:]
     @Published public private(set) var lastUpdatedByAccount: [String: Date] = [:]
     @Published public private(set) var inFlightAccountIds: Set<String> = []
+    /// Per-(accountId, bucketId) subscription fill history loaded from
+    /// `SubscriptionHistoryStore`. Hydrated asynchronously on init and
+    /// kept in sync as each `refresh` succeeds; views read this
+    /// dictionary directly via the `@Published` projection.
+    @Published public private(set) var historyByAccountBucket: [SubscriptionHistoryKey: [SubscriptionWindowSample]] = [:]
 
     private let adapters: [ToolType: any QuotaAdapter]
     private let mockProvider: () -> Bool
+    private let retentionProvider: () -> Int
 
     public init(
         adapters: [ToolType: any QuotaAdapter],
         mockProvider: @escaping () -> Bool,
+        retentionProvider: @escaping () -> Int = { CostDataSettings.defaultRetentionDays },
         initialAccountIds: [String] = []
     ) {
         self.adapters = adapters
         self.mockProvider = mockProvider
+        self.retentionProvider = retentionProvider
         let cached = QuotaCacheStore.loadAll(accountIds: initialAccountIds)
         self.lastSuccessByAccount = cached
         self.lastUpdatedByAccount = cached.mapValues(\.queriedAt)
+
+        // Hydrate the subscription history dictionary from disk. The
+        // store is an actor, so this has to be deferred — the popover
+        // and mini window won't render samples until this Task resolves,
+        // but neither is open at launch so the brief flicker is invisible.
+        Task { @MainActor [weak self] in
+            let samples = await SubscriptionHistoryStore.shared.allSamples()
+            self?.applyInitialSubscriptionHistory(samples)
+        }
     }
 
     public static func makeDefault(
         mockProvider: @escaping () -> Bool,
+        retentionProvider: @escaping () -> Int = { CostDataSettings.defaultRetentionDays },
         initialAccountIds: [String] = []
     ) -> QuotaService {
         QuotaService(
@@ -57,6 +75,7 @@ public final class QuotaService: ObservableObject {
                 .warp: WarpQuotaAdapter()
             ],
             mockProvider: mockProvider,
+            retentionProvider: retentionProvider,
             initialAccountIds: initialAccountIds
         )
     }
@@ -130,6 +149,45 @@ public final class QuotaService: ObservableObject {
             try QuotaCacheStore.save(success)
         } catch {
             SafeLog.warn("Saving quota cache failed: \(SafeLog.sanitize(error.localizedDescription))")
+        }
+
+        // Fold this snapshot into the subscription fill-history store
+        // and republish the affected keys so views can repaint
+        // sparklines. The store's provider and window gates drop
+        // anything outside the four primary providers and 5-hour
+        // buckets, so this is a no-op for misc-provider refreshes.
+        let retention = retentionProvider()
+        let quota = success
+        Task { [weak self] in
+            await SubscriptionHistoryStore.shared.observe(quota, retentionDays: retention)
+            await self?.refreshSubscriptionHistory(for: quota)
+        }
+    }
+
+    private func applyInitialSubscriptionHistory(_ samples: [SubscriptionWindowSample]) {
+        var grouped: [SubscriptionHistoryKey: [SubscriptionWindowSample]] = [:]
+        for sample in samples {
+            let key = SubscriptionHistoryKey(accountId: sample.accountId, bucketId: sample.bucketId)
+            grouped[key, default: []].append(sample)
+        }
+        for key in grouped.keys {
+            grouped[key]?.sort { $0.windowEnd > $1.windowEnd }
+        }
+        historyByAccountBucket = grouped
+    }
+
+    private func refreshSubscriptionHistory(for quota: AccountQuota) async {
+        var updates: [SubscriptionHistoryKey: [SubscriptionWindowSample]] = [:]
+        for bucket in quota.buckets {
+            let samples = await SubscriptionHistoryStore.shared.samples(
+                accountId: quota.accountId,
+                bucketId: bucket.id
+            )
+            let key = SubscriptionHistoryKey(accountId: quota.accountId, bucketId: bucket.id)
+            updates[key] = samples
+        }
+        for (key, samples) in updates {
+            historyByAccountBucket[key] = samples
         }
     }
 

--- a/Sources/VibeBarCore/Services/SubscriptionHistoryStore.swift
+++ b/Sources/VibeBarCore/Services/SubscriptionHistoryStore.swift
@@ -1,0 +1,251 @@
+import Foundation
+
+/// Persists per-bucket subscription fill history so the UI can render
+/// a sparkline of "how full did I get in each of the last N reset
+/// windows" alongside the live quota bar.
+///
+/// Scope is intentionally narrow:
+///
+/// - **Provider gate.** Only the four primary providers (`codex`,
+///   `claude`, `gemini`, `grok`) are recorded. Misc providers are not
+///   subscription plans in the same sense and are silently dropped.
+/// - **Window gate.** Only buckets whose window is fixed-clock and
+///   monotonic within the window — concretely
+///   `rawWindowSeconds == nil || rawWindowSeconds >= 86_400` — are
+///   recorded. The 5-hour on-demand rolling windows on Claude/Codex
+///   are excluded because the clock doesn't tick when idle, so the
+///   peak-per-window series is non-monotonic in a way that would
+///   invert "used more" into "sparkline goes down".
+///
+/// File: `~/.vibebar/subscription_history.json` (mode 0600). Retention
+/// is driven by callers passing `retentionDays`, matching how
+/// `CostHistoryStore` consumes `CostDataSettings.retentionDays`.
+public actor SubscriptionHistoryStore {
+    public static let shared = SubscriptionHistoryStore()
+
+    private struct Storage: Codable {
+        var schemaVersion: Int
+        var samples: [SubscriptionWindowSample]
+
+        init(
+            schemaVersion: Int = SubscriptionHistoryStore.storageSchemaVersion,
+            samples: [SubscriptionWindowSample] = []
+        ) {
+            self.schemaVersion = schemaVersion
+            self.samples = samples
+        }
+    }
+
+    private let fileURL: URL
+    private var cachedStorage: Storage?
+    private var lastSavedAt: Date?
+    private var pendingFlushTask: Task<Void, Never>?
+    private var pendingStorage: Storage?
+
+    private static let storageSchemaVersion = 1
+    private static let saveThrottleInterval: TimeInterval = 30
+    private static let maxFileBytes = 16 * 1024 * 1024
+
+    private static let supportedTools: Set<ToolType> = [.codex, .claude, .gemini, .grok]
+    /// Buckets with a `rawWindowSeconds` smaller than this threshold are
+    /// dropped at observe time — they're on-demand rolling windows and
+    /// don't have a monotonic peak-per-window series.
+    private static let minimumTrackedWindowSeconds = 86_400
+
+    public init(fileURL: URL = SubscriptionHistoryStore.defaultFileURL()) {
+        self.fileURL = fileURL
+    }
+
+    public static func defaultFileURL() -> URL {
+        try? VibeBarLocalStore.ensureBaseDirectory()
+        return VibeBarLocalStore.subscriptionHistoryURL
+    }
+
+    // MARK: - Public API
+
+    public func observe(
+        _ quota: AccountQuota,
+        now: Date = Date(),
+        retentionDays: Int = CostDataSettings.defaultRetentionDays
+    ) {
+        guard Self.supportedTools.contains(quota.tool) else { return }
+
+        var storage = load()
+        var dirty = false
+        for bucket in quota.buckets {
+            guard let windowEnd = bucket.resetAt else { continue }
+            guard bucket.usedPercent.isFinite else { continue }
+            if let secs = bucket.rawWindowSeconds, secs < Self.minimumTrackedWindowSeconds {
+                continue
+            }
+            let windowStart = bucket.rawWindowSeconds.map {
+                windowEnd.addingTimeInterval(-TimeInterval($0))
+            }
+            if let idx = storage.samples.firstIndex(where: {
+                $0.accountId == quota.accountId
+                    && $0.bucketId == bucket.id
+                    && $0.windowEnd == windowEnd
+            }) {
+                var sample = storage.samples[idx]
+                sample.peakUsedPercent = max(sample.peakUsedPercent, clamp(bucket.usedPercent))
+                sample.lastUsedPercent = clamp(bucket.usedPercent)
+                sample.observationCount += 1
+                sample.lastSeenAt = max(sample.lastSeenAt, now)
+                // windowStart and rawWindowSeconds might tighten across
+                // refreshes (e.g. an adapter learning the window size
+                // later); accept the latest non-nil value.
+                if sample.windowStart == nil, windowStart != nil {
+                    sample.windowStart = windowStart
+                }
+                if sample.rawWindowSeconds == nil, let s = bucket.rawWindowSeconds {
+                    sample.rawWindowSeconds = s
+                }
+                storage.samples[idx] = sample
+                dirty = true
+            } else {
+                let sample = SubscriptionWindowSample(
+                    accountId: quota.accountId,
+                    tool: quota.tool,
+                    bucketId: bucket.id,
+                    windowEnd: windowEnd,
+                    windowStart: windowStart,
+                    rawWindowSeconds: bucket.rawWindowSeconds,
+                    peakUsedPercent: bucket.usedPercent,
+                    lastUsedPercent: bucket.usedPercent,
+                    observationCount: 1,
+                    firstSeenAt: now,
+                    lastSeenAt: now
+                )
+                storage.samples.append(sample)
+                dirty = true
+            }
+        }
+        guard dirty else { return }
+        pruneInPlace(&storage, retentionDays: retentionDays, now: now)
+        save(storage)
+    }
+
+    public func samples(
+        accountId: String,
+        bucketId: String,
+        now: Date = Date(),
+        includeCurrent: Bool = true,
+        limit: Int? = nil
+    ) -> [SubscriptionWindowSample] {
+        let storage = load()
+        var matching = storage.samples.filter {
+            $0.accountId == accountId && $0.bucketId == bucketId
+        }
+        if !includeCurrent {
+            matching.removeAll { $0.windowEnd > now }
+        }
+        matching.sort { $0.windowEnd > $1.windowEnd }
+        if let limit, matching.count > limit {
+            matching = Array(matching.prefix(limit))
+        }
+        return matching
+    }
+
+    public func allSamples() -> [SubscriptionWindowSample] {
+        load().samples
+    }
+
+    public func prune(retentionDays: Int, now: Date = Date()) {
+        var storage = load()
+        pruneInPlace(&storage, retentionDays: retentionDays, now: now)
+        save(storage)
+    }
+
+    public func eraseAll() {
+        cachedStorage = Storage(samples: [])
+        pendingStorage = nil
+        pendingFlushTask?.cancel()
+        pendingFlushTask = nil
+        lastSavedAt = nil
+        try? FileManager.default.removeItem(at: fileURL)
+    }
+
+    public func flushPendingWrites() async {
+        if let storage = pendingStorage {
+            persist(storage)
+            pendingStorage = nil
+            lastSavedAt = Date()
+        }
+        pendingFlushTask?.cancel()
+        pendingFlushTask = nil
+    }
+
+    // MARK: - Private
+
+    private func clamp(_ value: Double) -> Double {
+        guard value.isFinite else { return 0 }
+        return min(100, max(0, value))
+    }
+
+    private func load() -> Storage {
+        if let cached = cachedStorage { return cached }
+        if let attrs = try? FileManager.default.attributesOfItem(atPath: fileURL.path),
+           let size = (attrs[.size] as? NSNumber)?.intValue,
+           size > Self.maxFileBytes {
+            let empty = Storage()
+            cachedStorage = empty
+            return empty
+        }
+        guard let data = try? Data(contentsOf: fileURL),
+              let storage = try? JSONDecoder().decode(Storage.self, from: data)
+        else {
+            let empty = Storage()
+            cachedStorage = empty
+            return empty
+        }
+        if storage.schemaVersion > Self.storageSchemaVersion {
+            // Future schema we don't understand — drop and start fresh
+            // rather than risk corrupting the user's newer data.
+            let empty = Storage()
+            persist(empty)
+            cachedStorage = empty
+            return empty
+        }
+        cachedStorage = storage
+        return storage
+    }
+
+    private func save(_ storage: Storage) {
+        cachedStorage = storage
+        let now = Date()
+        if let last = lastSavedAt, now.timeIntervalSince(last) < Self.saveThrottleInterval {
+            pendingStorage = storage
+            scheduleFlush(after: Self.saveThrottleInterval - now.timeIntervalSince(last))
+            return
+        }
+        persist(storage)
+        pendingStorage = nil
+        pendingFlushTask?.cancel()
+        pendingFlushTask = nil
+        lastSavedAt = now
+    }
+
+    private func persist(_ storage: Storage) {
+        guard let data = try? JSONEncoder().encode(storage) else { return }
+        try? data.write(to: fileURL, options: .atomic)
+        try? FileManager.default.setAttributes(
+            [.posixPermissions: NSNumber(value: Int16(0o600))],
+            ofItemAtPath: fileURL.path
+        )
+    }
+
+    private func scheduleFlush(after delay: TimeInterval) {
+        if pendingFlushTask != nil { return }
+        let nanoseconds = UInt64(max(0.05, delay) * 1_000_000_000)
+        pendingFlushTask = Task { [weak self] in
+            try? await Task.sleep(nanoseconds: nanoseconds)
+            await self?.flushPendingWrites()
+        }
+    }
+
+    private func pruneInPlace(_ storage: inout Storage, retentionDays: Int, now: Date) {
+        if CostDataSettings.isUnlimitedRetention(retentionDays) { return }
+        let cutoff = now.addingTimeInterval(-TimeInterval(retentionDays) * 86_400)
+        storage.samples.removeAll { $0.windowEnd < cutoff }
+    }
+}

--- a/Sources/VibeBarCore/Storage/VibeBarLocalStore.swift
+++ b/Sources/VibeBarCore/Storage/VibeBarLocalStore.swift
@@ -63,6 +63,10 @@ public enum VibeBarLocalStore {
         baseDirectory.appendingPathComponent("cost_history.json")
     }
 
+    public static var subscriptionHistoryURL: URL {
+        baseDirectory.appendingPathComponent("subscription_history.json")
+    }
+
     /// Mini-window geometry is persisted out-of-band from `AppSettings` so a
     /// drag-to-move (which fires didMove repeatedly) doesn't rewrite the
     /// whole settings JSON or fan out through every Combine subscriber on

--- a/Tests/VibeBarCoreTests/SubscriptionHistoryStoreTests.swift
+++ b/Tests/VibeBarCoreTests/SubscriptionHistoryStoreTests.swift
@@ -1,0 +1,214 @@
+import XCTest
+@testable import VibeBarCore
+
+final class SubscriptionHistoryStoreTests: XCTestCase {
+    // MARK: - Fixture helpers
+
+    private func makeTempStore() throws -> (store: SubscriptionHistoryStore, fileURL: URL, cleanup: () -> Void) {
+        let fileManager = FileManager.default
+        let directory = fileManager.temporaryDirectory
+            .appendingPathComponent("VibeBarSubscriptionHistoryTests-\(UUID().uuidString)", isDirectory: true)
+        try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+        let url = directory.appendingPathComponent("subscription_history.json")
+        let store = SubscriptionHistoryStore(fileURL: url)
+        return (store, url, { try? fileManager.removeItem(at: directory) })
+    }
+
+    private func bucket(
+        id: String,
+        usedPercent: Double,
+        resetAt: Date?,
+        rawWindowSeconds: Int?,
+        groupTitle: String? = nil
+    ) -> QuotaBucket {
+        QuotaBucket(
+            id: id,
+            title: id,
+            shortLabel: id,
+            usedPercent: usedPercent,
+            resetAt: resetAt,
+            rawWindowSeconds: rawWindowSeconds,
+            groupTitle: groupTitle
+        )
+    }
+
+    private func quota(
+        accountId: String = "acct-test",
+        tool: ToolType,
+        buckets: [QuotaBucket],
+        queriedAt: Date = Date()
+    ) -> AccountQuota {
+        AccountQuota(
+            accountId: accountId,
+            tool: tool,
+            buckets: buckets,
+            queriedAt: queriedAt
+        )
+    }
+
+    // MARK: - Tests
+
+    func testObserveCreatesOneSamplePerEligibleBucket() async throws {
+        let (store, _, cleanup) = try makeTempStore()
+        defer { cleanup() }
+        let now = Date()
+        let weeklyReset = now.addingTimeInterval(3 * 86_400)
+        let fiveHourReset = now.addingTimeInterval(2 * 3_600)
+
+        let q = quota(tool: .claude, buckets: [
+            bucket(id: "five_hour", usedPercent: 80, resetAt: fiveHourReset, rawWindowSeconds: 18_000),
+            bucket(id: "weekly", usedPercent: 40, resetAt: weeklyReset, rawWindowSeconds: 604_800),
+            bucket(id: "weekly_sonnet", usedPercent: 25, resetAt: weeklyReset, rawWindowSeconds: 604_800, groupTitle: "Sonnet")
+        ])
+        await store.observe(q, now: now, retentionDays: 30)
+        let all = await store.allSamples()
+        XCTAssertEqual(Set(all.map(\.bucketId)), ["weekly", "weekly_sonnet"])
+        XCTAssertFalse(all.contains { $0.bucketId == "five_hour" })
+    }
+
+    func testTwoObservationsSameWindowMaxMerge() async throws {
+        let (store, _, cleanup) = try makeTempStore()
+        defer { cleanup() }
+        let now = Date()
+        let resetAt = now.addingTimeInterval(3 * 86_400)
+
+        let first = quota(tool: .codex, buckets: [
+            bucket(id: "weekly", usedPercent: 88, resetAt: resetAt, rawWindowSeconds: 604_800)
+        ])
+        let second = quota(tool: .codex, buckets: [
+            bucket(id: "weekly", usedPercent: 30, resetAt: resetAt, rawWindowSeconds: 604_800)
+        ])
+        await store.observe(first, now: now, retentionDays: 30)
+        await store.observe(second, now: now.addingTimeInterval(60), retentionDays: 30)
+        let samples = await store.samples(accountId: "acct-test", bucketId: "weekly")
+        XCTAssertEqual(samples.count, 1)
+        let sample = try XCTUnwrap(samples.first)
+        XCTAssertEqual(sample.peakUsedPercent, 88, accuracy: 0.001)
+        XCTAssertEqual(sample.lastUsedPercent, 30, accuracy: 0.001)
+        XCTAssertEqual(sample.observationCount, 2)
+    }
+
+    func testNewResetAtCreatesNewSample() async throws {
+        let (store, _, cleanup) = try makeTempStore()
+        defer { cleanup() }
+        let now = Date()
+        let firstReset = now.addingTimeInterval(1 * 86_400)
+        let secondReset = firstReset.addingTimeInterval(7 * 86_400)
+
+        let first = quota(tool: .claude, buckets: [
+            bucket(id: "weekly", usedPercent: 95, resetAt: firstReset, rawWindowSeconds: 604_800)
+        ])
+        let second = quota(tool: .claude, buckets: [
+            bucket(id: "weekly", usedPercent: 10, resetAt: secondReset, rawWindowSeconds: 604_800)
+        ])
+        await store.observe(first, now: now, retentionDays: 30)
+        await store.observe(second, now: firstReset.addingTimeInterval(60), retentionDays: 30)
+        let samples = await store.samples(accountId: "acct-test", bucketId: "weekly")
+        XCTAssertEqual(samples.count, 2)
+        XCTAssertEqual(samples.map(\.windowEnd), [secondReset, firstReset])
+        // Old window's peak must not be touched by the new window.
+        let old = try XCTUnwrap(samples.first { $0.windowEnd == firstReset })
+        XCTAssertEqual(old.peakUsedPercent, 95, accuracy: 0.001)
+        XCTAssertEqual(old.observationCount, 1)
+    }
+
+    func testRetentionPruneDropsOldSamples() async throws {
+        let (store, _, cleanup) = try makeTempStore()
+        defer { cleanup() }
+        let now = Date()
+        let oldReset = now.addingTimeInterval(-60 * 86_400)
+        let recentReset = now.addingTimeInterval(3 * 86_400)
+
+        await store.observe(
+            quota(tool: .claude, buckets: [
+                bucket(id: "weekly", usedPercent: 50, resetAt: oldReset, rawWindowSeconds: 604_800)
+            ]),
+            now: oldReset.addingTimeInterval(-60),
+            retentionDays: 0  // unlimited — write succeeds
+        )
+        await store.observe(
+            quota(tool: .claude, buckets: [
+                bucket(id: "weekly", usedPercent: 70, resetAt: recentReset, rawWindowSeconds: 604_800)
+            ]),
+            now: now,
+            retentionDays: 0
+        )
+        await store.prune(retentionDays: 30, now: now)
+        let samples = await store.samples(accountId: "acct-test", bucketId: "weekly")
+        XCTAssertEqual(samples.count, 1)
+        XCTAssertEqual(samples.first?.windowEnd, recentReset)
+    }
+
+    func testRoundTripPersistence() async throws {
+        let (store, fileURL, cleanup) = try makeTempStore()
+        defer { cleanup() }
+        let now = Date()
+        let reset = now.addingTimeInterval(3 * 86_400)
+        await store.observe(
+            quota(tool: .claude, buckets: [
+                bucket(id: "weekly", usedPercent: 60, resetAt: reset, rawWindowSeconds: 604_800)
+            ]),
+            now: now,
+            retentionDays: 30
+        )
+        await store.flushPendingWrites()
+
+        let reopened = SubscriptionHistoryStore(fileURL: fileURL)
+        let samples = await reopened.samples(accountId: "acct-test", bucketId: "weekly")
+        XCTAssertEqual(samples.count, 1)
+        let sample = try XCTUnwrap(samples.first)
+        XCTAssertEqual(sample.peakUsedPercent, 60, accuracy: 0.001)
+    }
+
+    func testProviderGatingDropsMiscTools() async throws {
+        let (store, _, cleanup) = try makeTempStore()
+        defer { cleanup() }
+        let now = Date()
+        let reset = now.addingTimeInterval(3 * 86_400)
+        await store.observe(
+            quota(tool: .kimi, buckets: [
+                bucket(id: "weekly", usedPercent: 60, resetAt: reset, rawWindowSeconds: 604_800)
+            ]),
+            now: now,
+            retentionDays: 30
+        )
+        let all = await store.allSamples()
+        XCTAssertTrue(all.isEmpty, "Misc tool quotas should not be recorded")
+    }
+
+    func testWindowGatingDropsFiveHourBuckets() async throws {
+        let (store, _, cleanup) = try makeTempStore()
+        defer { cleanup() }
+        let now = Date()
+        let reset = now.addingTimeInterval(2 * 3_600)
+        await store.observe(
+            quota(tool: .claude, buckets: [
+                bucket(id: "five_hour", usedPercent: 90, resetAt: reset, rawWindowSeconds: 18_000)
+            ]),
+            now: now,
+            retentionDays: 30
+        )
+        let all = await store.allSamples()
+        XCTAssertTrue(all.isEmpty, "5h buckets should be ignored")
+    }
+
+    func testGrokMonthlyWithoutWindowSecondsAllowed() async throws {
+        let (store, _, cleanup) = try makeTempStore()
+        defer { cleanup() }
+        let now = Date()
+        let reset = now.addingTimeInterval(20 * 86_400)
+        await store.observe(
+            quota(tool: .grok, buckets: [
+                bucket(id: "monthly", usedPercent: 55, resetAt: reset, rawWindowSeconds: nil)
+            ]),
+            now: now,
+            retentionDays: 30
+        )
+        let samples = await store.samples(accountId: "acct-test", bucketId: "monthly")
+        XCTAssertEqual(samples.count, 1)
+        let sample = try XCTUnwrap(samples.first)
+        XCTAssertEqual(sample.peakUsedPercent, 55, accuracy: 0.001)
+        XCTAssertEqual(sample.lastUsedPercent, 55, accuracy: 0.001)
+        XCTAssertNil(sample.windowStart, "windowStart should be nil when rawWindowSeconds is nil")
+    }
+}

--- a/docs/superpowers/specs/2026-05-25-subscription-fill-history-design.md
+++ b/docs/superpowers/specs/2026-05-25-subscription-fill-history-design.md
@@ -1,0 +1,319 @@
+# Subscription Fill History — Design
+
+## Motivation
+
+`SubscriptionUtilizationView` shows the **current** state of each quota
+bucket (used % + linear "expected" reference + ETA). It does not retain
+anything once a window resets. AQ wants to see, per bucket, how the
+last several windows ended — "did I burn through my weekly plan, or
+leave headroom?" — so a 30-day trend is visible at a glance.
+
+## Scope
+
+### In scope
+
+- Four primary providers only: `codex`, `claude`, `gemini`, `grok`.
+  Misc providers (`MiscQuotaAggregator` and everything routed through
+  it) are excluded entirely from both write and display paths.
+- Bucket scope inside those four: **only buckets whose window is
+  fixed-clock and monotonic within the window.** Concretely, a bucket
+  is recorded iff `rawWindowSeconds == nil || rawWindowSeconds >= 86_400`.
+  Hits:
+  - Claude — `weekly` (and sub-buckets `weekly_sonnet`, `weekly_opus`,
+    `weekly_design`, `weekly_oauth_apps`), `daily_routines`.
+  - Codex — `weekly`.
+  - Grok — `monthly` (`rawWindowSeconds = nil`; the monthly reset
+    timestamp from xAI's billing endpoint anchors the window).
+  - Gemini Web — per-model daily buckets (one bucket per model id;
+    `rawWindowSeconds = nil`, anchored on the per-model `resetAt`).
+
+### Out of scope
+
+- **`five_hour` buckets** (Claude + Codex). These are on-demand rolling
+  windows: the 5h clock doesn't tick when idle. Recording per-window
+  peaks across many such windows produces a series in which "I used
+  more" can look like "the bar went down" — exactly the failure mode
+  AQ flagged. The 5-hour view remains in the existing live bar + pace
+  ETA; we just do not historize it.
+- Cost/tokens history. That's `CostHistoryStore`'s job; this store
+  only deals with quota fill %.
+- Cross-bucket aggregation ("show me Claude's combined Sonnet+Opus
+  weekly utilization"). Possible later; data will be there.
+
+## User-facing change
+
+Inside each row of `SubscriptionUtilizationView`, below the existing
+`pace` legend line, add a 16–20 pt sparkline strip showing past
+windows for that bucket. Each tick:
+
+- **Bar height** encodes the fill metric for that window
+  (`peakUsedPercent`, transformed by current `DisplayMode`).
+- **Bar color** reuses `Theme.barColor(percent:mode:)`.
+- **Rightmost bar** is the **in-progress** window (current `resetAt`),
+  rendered at 0.5 opacity to read as "this week, so far".
+- **Bars to its left** are completed windows, newest-right to
+  oldest-left, capped to whatever fits the row width (~8 bars in the
+  narrow popover, ~20 in the wide mini-window layout).
+
+Hover/tooltip on a bar shows:
+
+```
+peak  87%       (or "13% left" in remaining mode)
+last  85%
+window  05-19 12:00 → 05-26 12:00     (omits left side if windowStart is nil)
+observed 312×
+```
+
+Bars older than `AppSettings.costData.retentionDays` (default 30) are
+pruned from disk and never reach the view.
+
+## Architecture
+
+### New model — `SubscriptionWindowSample`
+
+In `Sources/VibeBarCore/Models/`:
+
+```swift
+public struct SubscriptionWindowSample: Codable, Hashable, Sendable {
+    public var accountId: String        // matches QuotaCacheStore key
+    public var tool: ToolType
+    public var bucketId: String         // "weekly" / "daily_routines" / "monthly" / model id
+    public var windowEnd: Date          // == resetAt at the time of observation
+    public var windowStart: Date?       // resetAt - rawWindowSeconds when available
+    public var rawWindowSeconds: Int?   // mirror of QuotaBucket.rawWindowSeconds
+    public var peakUsedPercent: Double  // max(usedPercent) observed in this window
+    public var lastUsedPercent: Double  // latest observation's usedPercent
+    public var observationCount: Int
+    public var firstSeenAt: Date
+    public var lastSeenAt: Date
+}
+```
+
+Identity for max-merge is `(accountId, bucketId, windowEnd)`. A window
+is uniquely identified by its `resetAt`; if the API later reports a
+different `resetAt` for the same bucket, that's a new window (new
+sample).
+
+**Stability assumption.** All four primary providers report `resetAt`
+as an absolute server-side timestamp (Claude/Codex/Gemini: ISO8601 or
+epoch from the API payload; Grok: the billing endpoint's monthly
+`resetsAt`). The value is therefore deterministic across refreshes
+within one window, and exact equality is a safe merge key. If a future
+provider drifts (e.g., reports "seconds remaining" that we'd convert
+to `now + Δ`), the fix is a `±5 min` tolerance match inside `observe`
+— intentionally deferred until we see such a case.
+
+### New service — `SubscriptionHistoryStore`
+
+In `Sources/VibeBarCore/Services/SubscriptionHistoryStore.swift`,
+following `CostHistoryStore` 1-for-1:
+
+- Swift `actor`.
+- Backing file `~/.vibebar/subscription_history.json`, mode 0600,
+  schema-versioned.
+- In-memory cached storage, throttled write (~30 s coalesce window).
+- `flushPendingWrites()` for shutdown / tests.
+- Retention pruning by `AppSettings.costData.retentionDays` — a
+  sample is dropped when `windowEnd < now - retentionDays` (consistent
+  with how cost history treats `date < cutoff`).
+- Defensive 16 MB file-size guard mirrors cost history.
+
+Public API:
+
+```swift
+public actor SubscriptionHistoryStore {
+    public static let shared = SubscriptionHistoryStore()
+
+    /// Fold one `AccountQuota` into the store. No-op for any tool
+    /// not in the primary-four allow-list, and for any bucket where
+    /// `resetAt == nil`, `usedPercent` is NaN, or
+    /// `rawWindowSeconds != nil && rawWindowSeconds < 86_400`.
+    public func observe(_ quota: AccountQuota, now: Date = Date())
+
+    /// All samples for one (accountId, bucketId), newest windowEnd
+    /// first. `includeCurrent` controls whether the in-progress window
+    /// (resetAt in the future) is included.
+    public func samples(
+        accountId: String,
+        bucketId: String,
+        now: Date = Date(),
+        includeCurrent: Bool = true,
+        limit: Int? = nil
+    ) -> [SubscriptionWindowSample]
+
+    public func prune(retentionDays: Int)
+    public func eraseAll()
+    public func flushPendingWrites() async
+}
+```
+
+Merge rule inside `observe`:
+
+```
+key = (accountId, bucketId, windowEnd = bucket.resetAt)
+if existing for key:
+    existing.peakUsedPercent  = max(existing.peakUsedPercent, fresh)
+    existing.lastUsedPercent  = fresh                 // overwrite by time
+    existing.observationCount += 1
+    existing.lastSeenAt       = max(existing.lastSeenAt, now)
+else:
+    create with peak = last = fresh, count = 1,
+                firstSeenAt = lastSeenAt = now
+prune by retention
+schedule throttled save
+```
+
+### Write path
+
+```
+QuotaService.refresh
+  → adapter.fetch
+  → store(success: AccountQuota)          (existing)
+        ├─ QuotaCacheStore.save           (existing, current snapshot)
+        └─ Task { SubscriptionHistoryStore.shared.observe(quota) }   (new)
+```
+
+The hook lives in `QuotaService.store(success:)`. It dispatches into
+the actor with a detached `Task` so the synchronous refresh path
+doesn't await disk I/O. The provider gating
+(`quota.tool ∈ {codex,claude,gemini,grok}`) is enforced inside
+`observe` rather than at the call site, so the call site stays one
+line and future provider additions only touch one file.
+
+### Read path / View integration
+
+- `QuotaService` gains a `@Published var historyByAccountBucket:
+  [HistoryKey: [SubscriptionWindowSample]]` (struct key
+  `{accountId, bucketId}`). Populated on launch from
+  `SubscriptionHistoryStore.shared` and refreshed after each
+  `observe(_)` call.
+- `SubscriptionUtilizationView.row(for:)` reads the samples for the
+  current `(account.id, bucket.id)` from `quotaService` (already in
+  `@EnvironmentObject`), passes them into a new
+  `SubscriptionWindowSparkline` view.
+- New `Sources/VibeBarApp/Views/SubscriptionWindowSparkline.swift`:
+
+```swift
+struct SubscriptionWindowSparkline: View {
+    let samples: [SubscriptionWindowSample]   // newest first
+    let mode: DisplayMode
+    let density: Theme.Density
+    let bucketResetAt: Date?                  // current in-progress windowEnd
+
+    // Renders an HStack of fixed-width rounded bars; the bar whose
+    // windowEnd == bucketResetAt is treated as in-progress.
+}
+```
+
+**Empty-history case.** When `samples` is empty and the bucket has a
+`resetAt`, the sparkline renders a single faded "current" bar at the
+current `usedPercent` (read from the bucket itself, not the store).
+When `samples` is empty and the bucket has no `resetAt` either, the
+sparkline renders nothing (no row underneath the main bar). This keeps
+the row visually stable as the first window starts filling.
+
+Hover handled with a `.popover(isPresented:)` driven by a per-bar
+`HoverableBar` wrapper — same pattern the existing tooltip code uses
+for the heatmap legend.
+
+### Configuration / settings surface
+
+No new user settings. Retention follows the existing
+`AppSettings.costData.retentionDays` slider in the Settings view's
+"Cost Data" section.
+
+Because the slider lives under "Cost Data" but now affects both
+stores, this work adds a one-line caption under the existing
+"Keep history" Picker:
+
+> Applies to cost history and subscription fill history.
+
+No new section, no new toggle. If subscription history later needs
+its own independent retention, splitting this into a second slider
+is a self-contained follow-up.
+
+## Data scale
+
+Worst-case 30-day retention, one account per primary tool, all
+buckets covered:
+
+| Bucket                       | Samples / 30 d |
+|------------------------------|----------------|
+| Claude weekly + 4 sub-buckets| ~5 × 5 = 25    |
+| Claude daily_routines        | 30             |
+| Codex weekly                 | 5              |
+| Grok monthly                 | 1–2            |
+| Gemini per-model daily × ~6  | ~180           |
+| **Total**                    | **~240**       |
+
+~240 samples × ~250 bytes JSON each ≈ 60 KB. Well under the 16 MB
+guard.
+
+## Privacy
+
+- `accountId` is already a privacy-preserving hash
+  (`PrivacyPreservingHash`); we don't store anything beyond what
+  `QuotaCacheStore` already keeps.
+- No email, plan label, cookies, or tokens leave `QuotaService`.
+- File mode 0600, same as the other `.vibebar` artifacts.
+
+## Migration / versioning
+
+- `Storage.schemaVersion = 1` from day one.
+- No legacy file to migrate.
+- If a future schema bump is incompatible with the on-disk version,
+  the store falls back to empty (cost-history's pattern) — losing
+  history is acceptable because it's purely observational.
+
+## Testing
+
+`Tests/VibeBarCoreTests/SubscriptionHistoryStoreTests.swift`:
+
+1. **Empty store, then observe one quota** → one sample per eligible
+   bucket; ineligible buckets (`five_hour`, misc tools) are skipped.
+2. **Two observations in same window** → one sample, peak = max,
+   last = latest, count = 2.
+3. **Observation with smaller `usedPercent` than the stored peak**
+   → peak retained, last updated.
+4. **`resetAt` advances** (new window) → new sample appears, previous
+   sample untouched.
+5. **Retention prune** at 7 days drops samples whose `windowEnd <
+   now - 7 days`.
+6. **Restart round-trip** — write, instantiate a new store on the
+   same file URL, samples match.
+7. **Provider gating** — observing a `codex` quota writes; observing a
+   misc-provider quota is a no-op.
+8. **Window-gating** — `five_hour` bucket is a no-op; `weekly` and
+   `daily_routines` write.
+
+For the UI, a SwiftUI preview in `SubscriptionWindowSparkline.swift`
+that exercises:
+
+- One full bar at 100%, one at 80%, one at 5%, current at 20%.
+- Empty history (current-only).
+- Remaining-mode rendering.
+
+## Verification checklist (before claiming done)
+
+Same four commands `CLAUDE.md` requires:
+
+```sh
+swift build
+swift test
+./Scripts/build_app.sh release
+codesign -d --entitlements - ".build/Vibe Bar.app"
+```
+
+Then `open ".build/Vibe Bar.app"` and confirm:
+
+- A sparkline strip renders under each eligible bucket row.
+- The 5-hour row has **no** sparkline (only the live bar + pace).
+- Hovering a bar pops the tooltip with peak/last/window/count.
+- Killing and relaunching the app preserves the strip (samples reload
+  from disk).
+- Toggling `DisplayMode` flips the bars between used / remaining
+  encoding without re-querying.
+
+## Open questions
+
+None at this stage — proceed to writing-plans.


### PR DESCRIPTION
## Summary

Adds a per-bucket "fill-rate" history sparkline beneath each row of `SubscriptionUtilizationView`. Each bar = the peak utilization of one past reset window, sourced from a new persistent `SubscriptionHistoryStore`. Hover a bar to see peak / last / window range / observation count.

Spec: [`docs/superpowers/specs/2026-05-25-subscription-fill-history-design.md`](docs/superpowers/specs/2026-05-25-subscription-fill-history-design.md).

## Scope

- **Providers:** codex, claude, gemini, grok only. Misc providers are silently dropped at the store boundary.
- **Buckets:** only fixed-clock monotonic windows enter the store — `rawWindowSeconds == nil || rawWindowSeconds >= 86_400`. Concretely Claude `weekly` (+ Sonnet/Opus/Design/OAuth sub-buckets) + `daily_routines`, Codex `weekly`, Grok `monthly`, Gemini per-model daily.
- **Excluded:** Claude/Codex `five_hour`. The 5-hour clock doesn't tick when idle, so peak-per-window across many on-demand windows would invert into "I used more, the sparkline goes down". The live 5h bar and pace ETA are untouched.

## Storage

`~/.vibebar/subscription_history.json`, mode 0600. Same actor + max-merge + throttled write + retention-prune pattern as `CostHistoryStore`. Retention follows the existing `costData.retentionDays` slider (caption added so users discover the dual usage).

## Test plan

- [x] `swift build` — clean
- [x] `swift test` — 501 tests, 0 failures (includes 8 new tests covering provider gating, window gating, max-merge, new-window creation, round-trip persistence, retention prune, and `rawWindowSeconds == nil`)
- [x] `./Scripts/build_app.sh release` — build + ad-hoc sign succeed
- [x] `codesign -d --entitlements - ".build/Vibe Bar.app"` — empty `[Dict]`, no `app-sandbox` key
- [x] No new hits on the forbidden home-directory APIs (`grep` per `AGENTS.md` § 6)
- [ ] Smoke in app: confirm sparkline strip renders under Claude weekly / daily_routines / Codex weekly / Grok monthly / Gemini per-model rows, and that the 5h row stays sparkline-less
- [ ] Quit + relaunch — sparklines repaint from `~/.vibebar/subscription_history.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)