### PR TITLE
Make subscription fill rate readable and replace empty RPM cell

### DIFF
--- a/Sources/VibeBarApp/Views/PopoverRoot.swift
+++ b/Sources/VibeBarApp/Views/PopoverRoot.swift
@@ -801,6 +801,7 @@ private struct CombinedTotalsRow: View {
 
     @EnvironmentObject var environment: AppEnvironment
     @EnvironmentObject var costService: CostUsageService
+    @EnvironmentObject var quotaService: QuotaService
     private let summaryHeight: CGFloat = 178
 
     var body: some View {
@@ -820,7 +821,7 @@ private struct CombinedTotalsRow: View {
         let todayTokens = snapshots.reduce(0) { $0 + $1.todayTokens }
         let weekTokens = snapshots.reduce(0) { $0 + $1.last7DaysTokens }
         let monthTokens = snapshots.reduce(0) { $0 + $1.last30DaysTokens }
-        let todayRequests = snapshots.reduce(0) { $0 + $1.todayRequests }
+        let overallFill = OverallFillRate.average(quotaService.lastSuccessByAccount)
         // Pick the single day with the highest cost across all
         // providers, then surface both its cost and token totals so
         // the user sees what they spent *and* burned on their worst
@@ -830,17 +831,19 @@ private struct CombinedTotalsRow: View {
         let peakDayPoint = dailyHistory.max(by: { $0.costUSD < $1.costUSD })
         let peakDayCost = peakDayPoint?.costUSD ?? 0
         let peakDayTokens = peakDayPoint?.totalTokens ?? 0
-        // TPM / RPM are today-so-far rates: tokens (or requests)
-        // divided by the elapsed minutes since local midnight. We
-        // floor the divisor to 1 so a 00:00:05 launch can't divide
-        // by zero, and clamp the result on the display side.
+        // TPM is today-so-far tokens divided by elapsed minutes since
+        // local midnight. We floor the divisor to 1 so a 00:00:05
+        // launch can't divide by zero. RPM previously sat next to it
+        // but request counts aren't available across providers; the
+        // cell now surfaces the overall subscription fill rate
+        // instead, which is the more useful "are my plans burning
+        // hot?" indicator.
         let elapsedMinutesToday: Double = {
             let cal = Calendar.current
             let start = cal.startOfDay(for: Date())
             return max(1, Date().timeIntervalSince(start) / 60)
         }()
         let tokensPerMinute = Int((Double(todayTokens) / elapsedMinutesToday).rounded())
-        let requestsPerMinute = Double(todayRequests) / elapsedMinutesToday
 
         HStack(alignment: .top, spacing: density.interSectionSpacing) {
             VStack(alignment: .leading, spacing: 8) {
@@ -888,7 +891,7 @@ private struct CombinedTotalsRow: View {
                     divider
                     metric(label: "TPM", value: formatTokens(tokensPerMinute))
                     divider
-                    metric(label: "RPM", value: formatRate(requestsPerMinute))
+                    metric(label: "FILL", value: formatFillPercent(overallFill))
                 }
             }
             .padding(density.cardPadding)
@@ -946,13 +949,9 @@ private struct CombinedTotalsRow: View {
         return "\(tokens)"
     }
 
-    private func formatRate(_ value: Double) -> String {
-        if value <= 0 { return "0" }
-        if value < 0.1 { return String(format: "%.2f", value) }
-        if value < 10 { return String(format: "%.1f", value) }
-        if value >= 1_000_000 { return String(format: "%.2fM", value / 1_000_000) }
-        if value >= 1_000 { return String(format: "%.1fk", value / 1_000) }
-        return String(format: "%.0f", value)
+    private func formatFillPercent(_ value: Double?) -> String {
+        guard let value, value.isFinite else { return "—" }
+        return "\(Int(value.rounded()))%"
     }
 
     private func formatModelName(_ modelName: String?) -> String {

--- a/Sources/VibeBarApp/Views/SubscriptionUtilizationView.swift
+++ b/Sources/VibeBarApp/Views/SubscriptionUtilizationView.swift
@@ -109,11 +109,21 @@ struct SubscriptionUtilizationView: View {
             }
             .chartYAxis(.hidden)
             .frame(height: 36)
+            Text(SubscriptionWindowProgress.summary(
+                usedPercent: bucket.usedPercent,
+                resetAt: bucket.resetAt,
+                rawWindowSeconds: bucket.rawWindowSeconds,
+                now: now
+            ))
+                .font(.system(size: density.subtitleFontSize, weight: .semibold))
+                .foregroundStyle(.primary)
+                .lineLimit(1)
+                .truncationMode(.tail)
             if let pace {
                 HStack(spacing: 6) {
                     Text(pace.stageSummary)
                         .font(.system(size: density.subtitleFontSize, weight: .medium))
-                        .foregroundStyle(.primary)
+                        .foregroundStyle(.secondary)
                         .lineLimit(1)
                     if expected > 0 {
                         Text("·")

--- a/Sources/VibeBarApp/Views/SubscriptionWindowSparkline.swift
+++ b/Sources/VibeBarApp/Views/SubscriptionWindowSparkline.swift
@@ -18,26 +18,33 @@ struct SubscriptionWindowSparkline: View {
     let mode: DisplayMode
     let density: Theme.Density
 
-    private static let barWidth: CGFloat = 6
-    private static let barSpacing: CGFloat = 2
-    private static let maxBars: Int = 24
+    private static let barWidth: CGFloat = 8
+    private static let barSpacing: CGFloat = 3
+    private static let maxBars: Int = 20
     private static let minVisibleHeight: CGFloat = 2
 
     var body: some View {
         let bars = renderableBars()
         if bars.isEmpty { EmptyView() } else {
-            HStack(spacing: Self.barSpacing) {
-                ForEach(bars) { bar in
-                    SparklineBar(bar: bar, mode: mode, barWidth: Self.barWidth)
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Fill history")
+                    .font(.system(size: max(9, density.subtitleFontSize - 2)))
+                    .foregroundStyle(.tertiary)
+                HStack(spacing: Self.barSpacing) {
+                    ForEach(bars) { bar in
+                        SparklineBar(bar: bar, mode: mode, barWidth: Self.barWidth)
+                    }
+                    Spacer(minLength: 0)
                 }
+                .frame(height: barHeight, alignment: .bottom)
             }
-            .frame(height: barHeight, alignment: .bottom)
+            .padding(.top, 2)
             .accessibilityLabel(accessibilitySummary(bars: bars))
         }
     }
 
     private var barHeight: CGFloat {
-        max(16, density.bucketBarHeight * 0.6)
+        max(26, density.bucketBarHeight * 1.4)
     }
 
     private func renderableBars() -> [BarSlot] {

--- a/Sources/VibeBarCore/Models/QuotaBucket.swift
+++ b/Sources/VibeBarCore/Models/QuotaBucket.swift
@@ -21,7 +21,12 @@ public struct QuotaBucket: Codable, Identifiable, Hashable, Sendable {
         self.id = id
         self.title = VisibleSecretRedactor.redact(title) ?? ""
         self.shortLabel = VisibleSecretRedactor.redact(shortLabel) ?? ""
-        self.usedPercent = max(0.0, min(100.0, usedPercent))
+        // Swift's `min/max` on Double pass NaN through unchanged in
+        // one ordering and trap it in the other, so a non-finite
+        // value here would silently end up as 100% — a much louder
+        // bug than treating it as zero (the parser shouldn't have
+        // produced a non-finite percent in the first place).
+        self.usedPercent = usedPercent.isFinite ? max(0.0, min(100.0, usedPercent)) : 0
         self.resetAt = resetAt
         self.rawWindowSeconds = rawWindowSeconds
         self.groupTitle = VisibleSecretRedactor.redact(groupTitle)

--- a/Sources/VibeBarCore/Services/OverallFillRate.swift
+++ b/Sources/VibeBarCore/Services/OverallFillRate.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+/// Aggregate "how full are my subscription plans, overall" across the
+/// four primary providers. Used by the Cost summary card to replace
+/// the empty RPM cell with a meaningful single number.
+///
+/// Aggregation rules:
+///   - Claude  → bucket id "weekly" with no `groupTitle` (sub-buckets
+///               like weekly_sonnet/weekly_opus are ignored to avoid
+///               double-counting Claude's plan).
+///   - Codex   → bucket id "weekly".
+///   - Grok    → bucket id "monthly".
+///   - Gemini  → arithmetic mean of all of that account's buckets
+///               (per-model dailies).
+///
+/// Multiple accounts of the same tool are averaged within the tool
+/// first; tool-level averages then contribute equally to the overall
+/// mean. Tools without data are skipped. Returns nil when no tool
+/// contributes a finite value.
+public enum OverallFillRate {
+    public static func average(_ quotas: [String: AccountQuota]) -> Double? {
+        var perTool: [ToolType: [Double]] = [:]
+        for (_, quota) in quotas {
+            guard let value = headlineValue(for: quota) else { continue }
+            perTool[quota.tool, default: []].append(value)
+        }
+        let toolMeans: [Double] = perTool.values.compactMap { values in
+            let finite = values.filter { $0.isFinite }
+            guard !finite.isEmpty else { return nil }
+            return finite.reduce(0, +) / Double(finite.count)
+        }
+        guard !toolMeans.isEmpty else { return nil }
+        return toolMeans.reduce(0, +) / Double(toolMeans.count)
+    }
+
+    private static func headlineValue(for quota: AccountQuota) -> Double? {
+        switch quota.tool {
+        case .claude:
+            return quota.buckets
+                .first(where: { $0.id == "weekly" && $0.groupTitle == nil })
+                .flatMap { $0.usedPercent.isFinite ? $0.usedPercent : nil }
+        case .codex:
+            return quota.buckets
+                .first(where: { $0.id == "weekly" })
+                .flatMap { $0.usedPercent.isFinite ? $0.usedPercent : nil }
+        case .grok:
+            return quota.buckets
+                .first(where: { $0.id == "monthly" })
+                .flatMap { $0.usedPercent.isFinite ? $0.usedPercent : nil }
+        case .gemini:
+            let valid = quota.buckets.filter { $0.usedPercent.isFinite }
+            guard !valid.isEmpty else { return nil }
+            return valid.reduce(0.0) { $0 + $1.usedPercent } / Double(valid.count)
+        default:
+            return nil
+        }
+    }
+}

--- a/Sources/VibeBarCore/Services/SubscriptionWindowProgress.swift
+++ b/Sources/VibeBarCore/Services/SubscriptionWindowProgress.swift
@@ -1,0 +1,61 @@
+import Foundation
+
+/// Short one-line summary describing how far into the current reset
+/// window a bucket is plus the live used%. Used by
+/// `SubscriptionUtilizationView` above the pace line.
+///
+/// Examples:
+///   - "Day 6 of 7 · 56% used"            — windows with full-day grain
+///   - "2h 35m of 5h · 7% used"           — sub-day windows (5-hour)
+///   - "Resets soon · 99% used"           — reset has technically passed
+///   - "42% used"                         — no resetAt or no
+///                                          rawWindowSeconds (Grok
+///                                          monthly, Gemini per-model)
+public enum SubscriptionWindowProgress {
+    public static func summary(
+        usedPercent: Double,
+        resetAt: Date?,
+        rawWindowSeconds: Int?,
+        now: Date = Date()
+    ) -> String {
+        let pct = formatPercent(usedPercent)
+        guard let resetAt, let rawWindowSeconds, rawWindowSeconds > 0 else {
+            return "\(pct) used"
+        }
+
+        let windowSeconds = TimeInterval(rawWindowSeconds)
+        let remaining = resetAt.timeIntervalSince(now)
+        if remaining <= 0 {
+            return "Resets soon · \(pct) used"
+        }
+        let elapsed = max(0, min(windowSeconds, windowSeconds - remaining))
+
+        if rawWindowSeconds >= 86_400 {
+            let totalDays = max(1, Int((windowSeconds / 86_400).rounded()))
+            let dayNumber = clamp(Int(elapsed / 86_400) + 1, lower: 1, upper: totalDays)
+            return "Day \(dayNumber) of \(totalDays) · \(pct) used"
+        }
+
+        let totalLabel = formatShortDuration(windowSeconds)
+        let elapsedLabel = formatShortDuration(elapsed)
+        return "\(elapsedLabel) of \(totalLabel) · \(pct) used"
+    }
+
+    private static func clamp(_ value: Int, lower: Int, upper: Int) -> Int {
+        min(max(value, lower), upper)
+    }
+
+    private static func formatPercent(_ value: Double) -> String {
+        let v = value.isFinite ? max(0, min(100, value)) : 0
+        return "\(Int(v.rounded()))%"
+    }
+
+    private static func formatShortDuration(_ seconds: TimeInterval) -> String {
+        let total = max(0, Int(seconds.rounded()))
+        let hours = total / 3_600
+        let minutes = (total % 3_600) / 60
+        if hours == 0 { return "\(minutes)m" }
+        if minutes == 0 { return "\(hours)h" }
+        return "\(hours)h \(minutes)m"
+    }
+}

--- a/Tests/VibeBarCoreTests/OverallFillRateTests.swift
+++ b/Tests/VibeBarCoreTests/OverallFillRateTests.swift
@@ -1,0 +1,106 @@
+import XCTest
+@testable import VibeBarCore
+
+final class OverallFillRateTests: XCTestCase {
+    private func bucket(id: String, usedPercent: Double, groupTitle: String? = nil) -> QuotaBucket {
+        QuotaBucket(
+            id: id,
+            title: id,
+            shortLabel: id,
+            usedPercent: usedPercent,
+            resetAt: Date(),
+            rawWindowSeconds: nil,
+            groupTitle: groupTitle
+        )
+    }
+
+    private func quota(accountId: String, tool: ToolType, buckets: [QuotaBucket]) -> AccountQuota {
+        AccountQuota(accountId: accountId, tool: tool, buckets: buckets)
+    }
+
+    func testFourProvidersFullCoverage() {
+        let quotas: [String: AccountQuota] = [
+            "acct-claude": quota(accountId: "acct-claude", tool: .claude, buckets: [
+                bucket(id: "weekly", usedPercent: 50),
+                bucket(id: "weekly_sonnet", usedPercent: 80, groupTitle: "Sonnet")
+            ]),
+            "acct-codex": quota(accountId: "acct-codex", tool: .codex, buckets: [
+                bucket(id: "weekly", usedPercent: 70)
+            ]),
+            "acct-grok": quota(accountId: "acct-grok", tool: .grok, buckets: [
+                bucket(id: "monthly", usedPercent: 30)
+            ]),
+            "acct-gemini": quota(accountId: "acct-gemini", tool: .gemini, buckets: [
+                bucket(id: "gemini-2.5-pro", usedPercent: 60),
+                bucket(id: "gemini-2.5-flash", usedPercent: 40)
+            ])
+        ]
+        let mean = try? XCTUnwrap(OverallFillRate.average(quotas))
+        // Claude weekly headline = 50, sub-buckets ignored.
+        // Codex weekly = 70.
+        // Grok monthly = 30.
+        // Gemini = (60 + 40) / 2 = 50.
+        // Overall = (50 + 70 + 30 + 50) / 4 = 50.
+        XCTAssertEqual(mean ?? -1, 50, accuracy: 0.001)
+    }
+
+    func testEmptyQuotasReturnsNil() {
+        XCTAssertNil(OverallFillRate.average([:]))
+    }
+
+    func testTwoProvidersOnly() {
+        let quotas: [String: AccountQuota] = [
+            "acct-claude": quota(accountId: "acct-claude", tool: .claude, buckets: [
+                bucket(id: "weekly", usedPercent: 80)
+            ]),
+            "acct-grok": quota(accountId: "acct-grok", tool: .grok, buckets: [
+                bucket(id: "monthly", usedPercent: 20)
+            ])
+        ]
+        let mean = try? XCTUnwrap(OverallFillRate.average(quotas))
+        XCTAssertEqual(mean ?? -1, 50, accuracy: 0.001)
+    }
+
+    func testClaudeMissingHeadlineWeeklyIsSkipped() {
+        let quotas: [String: AccountQuota] = [
+            "acct-claude": quota(accountId: "acct-claude", tool: .claude, buckets: [
+                bucket(id: "five_hour", usedPercent: 30),
+                bucket(id: "weekly_sonnet", usedPercent: 90, groupTitle: "Sonnet")
+            ]),
+            "acct-grok": quota(accountId: "acct-grok", tool: .grok, buckets: [
+                bucket(id: "monthly", usedPercent: 20)
+            ])
+        ]
+        let mean = try? XCTUnwrap(OverallFillRate.average(quotas))
+        // Claude contributes nothing (no headline weekly), so only Grok.
+        XCTAssertEqual(mean ?? -1, 20, accuracy: 0.001)
+    }
+
+    func testMiscProvidersIgnored() {
+        let quotas: [String: AccountQuota] = [
+            "acct-kimi": quota(accountId: "acct-kimi", tool: .kimi, buckets: [
+                bucket(id: "weekly", usedPercent: 99)
+            ]),
+            "acct-claude": quota(accountId: "acct-claude", tool: .claude, buckets: [
+                bucket(id: "weekly", usedPercent: 40)
+            ])
+        ]
+        let mean = try? XCTUnwrap(OverallFillRate.average(quotas))
+        XCTAssertEqual(mean ?? -1, 40, accuracy: 0.001)
+    }
+
+    func testMultipleAccountsPerToolAverageWithinTool() {
+        let quotas: [String: AccountQuota] = [
+            "acct-claude-a": quota(accountId: "acct-claude-a", tool: .claude, buckets: [
+                bucket(id: "weekly", usedPercent: 30)
+            ]),
+            "acct-claude-b": quota(accountId: "acct-claude-b", tool: .claude, buckets: [
+                bucket(id: "weekly", usedPercent: 70)
+            ])
+        ]
+        let mean = try? XCTUnwrap(OverallFillRate.average(quotas))
+        // Two claude accounts average inside the tool to (30+70)/2 = 50,
+        // and that's the only tool, so overall = 50.
+        XCTAssertEqual(mean ?? -1, 50, accuracy: 0.001)
+    }
+}

--- a/Tests/VibeBarCoreTests/QuotaBucketTests.swift
+++ b/Tests/VibeBarCoreTests/QuotaBucketTests.swift
@@ -1,0 +1,25 @@
+import XCTest
+@testable import VibeBarCore
+
+final class QuotaBucketTests: XCTestCase {
+    /// `min/max` over Doubles passes NaN through in one ordering and
+    /// silently turns it into the bound in the other. Without an
+    /// explicit isFinite gate, a non-finite percent from a buggy
+    /// parser would surface as 100% used. The init clamps to 0 instead.
+    func testNonFiniteUsedPercentClampsToZero() {
+        let nanBucket = QuotaBucket(id: "x", title: "x", shortLabel: "x", usedPercent: .nan)
+        XCTAssertEqual(nanBucket.usedPercent, 0, accuracy: 0.001)
+
+        let positiveInfBucket = QuotaBucket(id: "y", title: "y", shortLabel: "y", usedPercent: .infinity)
+        XCTAssertEqual(positiveInfBucket.usedPercent, 0, accuracy: 0.001)
+
+        let negativeInfBucket = QuotaBucket(id: "z", title: "z", shortLabel: "z", usedPercent: -.infinity)
+        XCTAssertEqual(negativeInfBucket.usedPercent, 0, accuracy: 0.001)
+    }
+
+    func testFiniteUsedPercentClampsToZeroOneHundred() {
+        XCTAssertEqual(QuotaBucket(id: "a", title: "a", shortLabel: "a", usedPercent: -5).usedPercent, 0, accuracy: 0.001)
+        XCTAssertEqual(QuotaBucket(id: "b", title: "b", shortLabel: "b", usedPercent: 150).usedPercent, 100, accuracy: 0.001)
+        XCTAssertEqual(QuotaBucket(id: "c", title: "c", shortLabel: "c", usedPercent: 42.5).usedPercent, 42.5, accuracy: 0.001)
+    }
+}

--- a/Tests/VibeBarCoreTests/SubscriptionWindowProgressTests.swift
+++ b/Tests/VibeBarCoreTests/SubscriptionWindowProgressTests.swift
@@ -1,0 +1,95 @@
+import XCTest
+@testable import VibeBarCore
+
+final class SubscriptionWindowProgressTests: XCTestCase {
+    func testWeeklyWindowMidweek() {
+        let now = Date(timeIntervalSinceReferenceDate: 800_000_000)
+        let reset = now.addingTimeInterval(2 * 86_400)  // 2 days remaining of 7
+        let summary = SubscriptionWindowProgress.summary(
+            usedPercent: 56,
+            resetAt: reset,
+            rawWindowSeconds: 604_800,
+            now: now
+        )
+        XCTAssertEqual(summary, "Day 6 of 7 · 56% used")
+    }
+
+    func testWeeklyWindowJustStarted() {
+        let now = Date(timeIntervalSinceReferenceDate: 800_000_000)
+        let reset = now.addingTimeInterval(7 * 86_400 - 60)  // basically the full window left
+        let summary = SubscriptionWindowProgress.summary(
+            usedPercent: 1,
+            resetAt: reset,
+            rawWindowSeconds: 604_800,
+            now: now
+        )
+        XCTAssertEqual(summary, "Day 1 of 7 · 1% used")
+    }
+
+    func testWeeklyWindowAboutToReset() {
+        let now = Date(timeIntervalSinceReferenceDate: 800_000_000)
+        let reset = now.addingTimeInterval(60)  // a minute remaining of 7-day window
+        let summary = SubscriptionWindowProgress.summary(
+            usedPercent: 92,
+            resetAt: reset,
+            rawWindowSeconds: 604_800,
+            now: now
+        )
+        XCTAssertEqual(summary, "Day 7 of 7 · 92% used")
+    }
+
+    func testFiveHourWindowMidway() {
+        let now = Date(timeIntervalSinceReferenceDate: 800_000_000)
+        let reset = now.addingTimeInterval(2 * 3_600 + 25 * 60)  // 2h 25m remaining
+        let summary = SubscriptionWindowProgress.summary(
+            usedPercent: 7,
+            resetAt: reset,
+            rawWindowSeconds: 18_000,
+            now: now
+        )
+        XCTAssertEqual(summary, "2h 35m of 5h · 7% used")
+    }
+
+    func testFiveHourWindowSubHourElapsed() {
+        let now = Date(timeIntervalSinceReferenceDate: 800_000_000)
+        let reset = now.addingTimeInterval(4 * 3_600 + 30 * 60)  // 4h 30m remaining
+        let summary = SubscriptionWindowProgress.summary(
+            usedPercent: 12,
+            resetAt: reset,
+            rawWindowSeconds: 18_000,
+            now: now
+        )
+        XCTAssertEqual(summary, "30m of 5h · 12% used")
+    }
+
+    func testMissingResetAtFallsBackToPercentOnly() {
+        let summary = SubscriptionWindowProgress.summary(
+            usedPercent: 33,
+            resetAt: nil,
+            rawWindowSeconds: nil
+        )
+        XCTAssertEqual(summary, "33% used")
+    }
+
+    func testWindowSecondsNilStillFallsBackToPercent() {
+        let now = Date(timeIntervalSinceReferenceDate: 800_000_000)
+        let summary = SubscriptionWindowProgress.summary(
+            usedPercent: 42,
+            resetAt: now.addingTimeInterval(20 * 86_400),
+            rawWindowSeconds: nil,
+            now: now
+        )
+        XCTAssertEqual(summary, "42% used")
+    }
+
+    func testResetInThePastReportsResetsSoon() {
+        let now = Date(timeIntervalSinceReferenceDate: 800_000_000)
+        let summary = SubscriptionWindowProgress.summary(
+            usedPercent: 99,
+            resetAt: now.addingTimeInterval(-60),
+            rawWindowSeconds: 604_800,
+            now: now
+        )
+        XCTAssertEqual(summary, "Resets soon · 99% used")
+    }
+}


### PR DESCRIPTION
## Summary

AQ flagged that PR #60's sparkline was hard to read and asked for an explicit "how far in / how much used" sentence per row. Also: the Cost summary's RPM cell has always been empty because no provider gives us request counts — replace it with a real signal.

## Changes

1. **Lead each bucket row with a plain-English sentence.** New `SubscriptionWindowProgress` Core helper renders `"Day 6 of 7 · 56% used"`, `"2h 35m of 5h · 7% used"`, or just `"42% used"` when window timing is unknown. Added above the existing pace line in `SubscriptionUtilizationView`; the pace line ("7% in deficit · expected 49% · runs out in 2d 16h") demotes to a secondary subtitle.
2. **Beef up the fill-history sparkline.** Wider/taller bars, a `"Fill history"` caption, small top inset. Reads as an intentional second-class chart instead of a stray glyph.
3. **Replace RPM with FILL.** New `OverallFillRate` Core helper averages the headline buckets across the four primary providers (Claude weekly, Codex weekly, Grok monthly, Gemini per-model mean; multiple accounts per tool average within the tool first). Cell label shifts RPM → FILL; value is `XX%` or `—` when no quota has loaded.
4. **Harden `QuotaBucket.init`** against non-finite `usedPercent`. Surfaced via the aggregator tests: Swift's `min/max` over Doubles silently turned NaN into 100, which would have made a malformed parser bucket look maxed-out instead of dropped.

## Test plan

- [x] `swift build` — clean
- [x] `swift test` — 517 tests, 0 failures (adds 8 `SubscriptionWindowProgress` + 6 `OverallFillRate` + 2 `QuotaBucket` tests)
- [x] `./Scripts/build_app.sh release` — build + ad-hoc sign succeed
- [x] `codesign -d --entitlements - ".build/Vibe Bar.app"` — empty `[Dict]`, no `app-sandbox`
- [x] No new hits on forbidden home-directory APIs
- [ ] Smoke in app: confirm each row's first subtitle line is "Day X of Y · Z% used" (or 5h equivalent), sparkline is visibly bigger with "Fill history" caption, and the Cost summary's last cell shows `FILL XX%`

🤖 Generated with [Claude Code](https://claude.com/claude-code)