### PR TITLE
Add Claude Opus 4.8 to the pricing table

### DIFF
--- a/Sources/VibeBarCore/Resources/pricing.json
+++ b/Sources/VibeBarCore/Resources/pricing.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "updatedAt": "2026-05-22",
+  "updatedAt": "2026-05-29",
   "calculationVersion": 5,
   "providers": {
     "codex": {
@@ -57,6 +57,10 @@
           "cacheCreation": 6.25e-6, "cacheRead": 5e-7
         },
         "claude-opus-4-7": {
+          "input": 5e-6, "output": 2.5e-5,
+          "cacheCreation": 6.25e-6, "cacheRead": 5e-7
+        },
+        "claude-opus-4-8": {
           "input": 5e-6, "output": 2.5e-5,
           "cacheCreation": 6.25e-6, "cacheRead": 5e-7
         },

--- a/Sources/VibeBarCore/Vendored/CostUsage/PricingHardcoded.swift
+++ b/Sources/VibeBarCore/Vendored/CostUsage/PricingHardcoded.swift
@@ -14,7 +14,7 @@ import Foundation
 enum PricingHardcoded {
     static let fallback: PricingDataSet = PricingDataSet(
         schemaVersion: 1,
-        updatedAt: "2026-05-22",
+        updatedAt: "2026-05-29",
         calculationVersion: 5,
         providers: PricingDataSet.Providers(
             codex: codex,
@@ -74,6 +74,9 @@ enum PricingHardcoded {
                 input: 5e-6, output: 2.5e-5,
                 cacheCreation: 6.25e-6, cacheRead: 5e-7),
             "claude-opus-4-7": .init(
+                input: 5e-6, output: 2.5e-5,
+                cacheCreation: 6.25e-6, cacheRead: 5e-7),
+            "claude-opus-4-8": .init(
                 input: 5e-6, output: 2.5e-5,
                 cacheCreation: 6.25e-6, cacheRead: 5e-7),
             "claude-sonnet-4-5": .init(

--- a/Tests/VibeBarCoreTests/CostUsagePricingTests.swift
+++ b/Tests/VibeBarCoreTests/CostUsagePricingTests.swift
@@ -96,6 +96,28 @@ final class CostUsagePricingTests: XCTestCase {
         XCTAssertEqual(cost ?? -1, 0.9, accuracy: 0.01)
     }
 
+    func testClaudeOpus48CostNormalizesDatedSnapshot() {
+        // Pin the in-code table so the assertion validates the data we
+        // ship, not a stale ~/.vibebar/pricing_cache.json that may
+        // predate this model on the developer's machine.
+        PricingResolver.testOverride = PricingHardcoded.fallback
+        defer { PricingResolver.testOverride = nil }
+
+        // claude-opus-4-8: input $5/MTok, cache write $6.25/MTok,
+        // cache read $0.50/MTok, output $25/MTok. The dated snapshot
+        // must normalize down to the undated entry.
+        // 1M input + 200k cache read + 100k cache write + 50k output
+        // = 5.0 + 0.1 + 0.625 + 1.25 = 6.975
+        let cost = CostUsagePricing.claudeCostUSD(
+            model: "claude-opus-4-8-20260515",
+            inputTokens: 1_000_000,
+            cacheReadInputTokens: 200_000,
+            cacheCreationInputTokens: 100_000,
+            outputTokens: 50_000
+        )
+        XCTAssertEqual(cost ?? -1, 6.975, accuracy: 0.001)
+    }
+
     func testClaudeNormalizesAnthropicPrefix() {
         let cost = CostUsagePricing.claudeCostUSD(
             model: "anthropic.claude-opus-4-1",

--- a/Tests/VibeBarCoreTests/PricingResolverTests.swift
+++ b/Tests/VibeBarCoreTests/PricingResolverTests.swift
@@ -104,7 +104,7 @@ final class PricingResolverTests: XCTestCase {
 
         XCTAssertEqual(bundled.calculationVersion, hardcoded.calculationVersion)
 
-        let claudeSentinel = "claude-opus-4-7"
+        let claudeSentinel = "claude-opus-4-8"
         XCTAssertEqual(
             bundled.providers.claude.models[claudeSentinel],
             hardcoded.providers.claude.models[claudeSentinel],


### PR DESCRIPTION
## What

Adds **`claude-opus-4-8`** to the Anthropic pricing table — the only model in the [official Claude API pricing docs](https://platform.claude.com/docs/en/about-claude/pricing) that was missing from vibe-bar (Sonnet's newest is still 4.6, Haiku's still 4.5, both already present).

Opus 4.8 ships at the same Opus tier as 4.5/4.6/4.7:

| | per MTok |
|---|---|
| Input | $5 → `5e-6` |
| Output | $25 → `2.5e-5` |
| 5-min cache write | $6.25 → `6.25e-6` |
| Cache read | $0.50 → `5e-7` |

## Changes

- `Sources/VibeBarCore/Resources/pricing.json` — add `claude-opus-4-8`, bump `updatedAt` to `2026-05-29`.
- `Sources/VibeBarCore/Vendored/CostUsage/PricingHardcoded.swift` — same entry + date, kept in lockstep with the JSON.
- Tests — bump the drift sentinel to `claude-opus-4-8` and add a hermetic cost test.

Notes:
- No `calculationVersion` bump: this is purely additive, so a fresh scan can only price *more* than before and max-merge with persisted totals stays safe.
- The Claude normalizer strips a trailing `-YYYYMMDD`, so the single undated entry also covers dated snapshots (matching the `claude-opus-4-7` precedent). 1M-context usage is billed at standard rates per the docs, so no separate entry.
- Once merged to `main`, `PricingRefresher` pulls the updated `pricing.json` from GitHub raw and refreshes `~/.vibebar/pricing_cache.json` on next launch (24h window) — no manual cache reset needed.

## Verification

- ✅ `swift build`
- ✅ `swift test` — 519 tests, 0 failures
- ✅ `./Scripts/build_app.sh release`
- ✅ `codesign -d --entitlements` → empty `<dict/>`, no `app-sandbox` key
- ✅ `codesign --verify --deep --strict` → exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)