### PR TITLE
Bill fast-tier usage and follow LiteLLM pricing upstream

### DIFF
--- a/Sources/VibeBarCore/Resources/pricing.json
+++ b/Sources/VibeBarCore/Resources/pricing.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
-  "updatedAt": "2026-05-29",
-  "calculationVersion": 5,
+  "updatedAt": "2026-06-08",
+  "calculationVersion": 6,
   "providers": {
     "codex": {
       "displayName": "OpenAI",
@@ -18,14 +18,14 @@
         "gpt-5.2":             { "input": 1.75e-6, "output": 1.4e-5,  "cacheRead": 1.75e-7 },
         "gpt-5.2-codex":       { "input": 1.75e-6, "output": 1.4e-5,  "cacheRead": 1.75e-7 },
         "gpt-5.2-pro":         { "input": 2.1e-5,  "output": 1.68e-4, "cacheRead": null },
-        "gpt-5.3-codex":       { "input": 1.75e-6, "output": 1.4e-5,  "cacheRead": 1.75e-7 },
+        "gpt-5.3-codex":       { "input": 1.75e-6, "output": 1.4e-5,  "cacheRead": 1.75e-7, "fastMultiplier": 2.0 },
         "gpt-5.3-codex-spark": { "input": 0,       "output": 0,       "cacheRead": 0,
                                  "displayLabel": "Research Preview" },
-        "gpt-5.4":             { "input": 2.5e-6,  "output": 1.5e-5,  "cacheRead": 2.5e-7 },
+        "gpt-5.4":             { "input": 2.5e-6,  "output": 1.5e-5,  "cacheRead": 2.5e-7, "fastMultiplier": 2.0 },
         "gpt-5.4-mini":        { "input": 7.5e-7,  "output": 4.5e-6,  "cacheRead": 7.5e-8 },
         "gpt-5.4-nano":        { "input": 2e-7,    "output": 1.25e-6, "cacheRead": 2e-8 },
         "gpt-5.4-pro":         { "input": 3e-5,    "output": 1.8e-4,  "cacheRead": null },
-        "gpt-5.5":             { "input": 5e-6,    "output": 3e-5,    "cacheRead": 5e-7 },
+        "gpt-5.5":             { "input": 5e-6,    "output": 3e-5,    "cacheRead": 5e-7, "fastMultiplier": 2.5 },
         "gpt-5.5-pro":         { "input": 3e-5,    "output": 1.8e-4,  "cacheRead": null }
       }
     },
@@ -50,19 +50,23 @@
         },
         "claude-opus-4-6-20260205": {
           "input": 5e-6, "output": 2.5e-5,
-          "cacheCreation": 6.25e-6, "cacheRead": 5e-7
+          "cacheCreation": 6.25e-6, "cacheRead": 5e-7,
+          "fastMultiplier": 6.0
         },
         "claude-opus-4-6": {
           "input": 5e-6, "output": 2.5e-5,
-          "cacheCreation": 6.25e-6, "cacheRead": 5e-7
+          "cacheCreation": 6.25e-6, "cacheRead": 5e-7,
+          "fastMultiplier": 6.0
         },
         "claude-opus-4-7": {
           "input": 5e-6, "output": 2.5e-5,
-          "cacheCreation": 6.25e-6, "cacheRead": 5e-7
+          "cacheCreation": 6.25e-6, "cacheRead": 5e-7,
+          "fastMultiplier": 6.0
         },
         "claude-opus-4-8": {
           "input": 5e-6, "output": 2.5e-5,
-          "cacheCreation": 6.25e-6, "cacheRead": 5e-7
+          "cacheCreation": 6.25e-6, "cacheRead": 5e-7,
+          "fastMultiplier": 2.0
         },
         "claude-sonnet-4-5": {
           "input": 3e-6, "output": 1.5e-5,

--- a/Sources/VibeBarCore/Services/CostUsageScanner.swift
+++ b/Sources/VibeBarCore/Services/CostUsageScanner.swift
@@ -52,6 +52,10 @@ public enum CostUsageScanner {
             URL(fileURLWithPath: homeDirectory).appendingPathComponent(".codex/archived_sessions")
         ]
         let files = roots.flatMap { collectJSONL(under: $0) }
+        // Codex bills the whole install at one service tier; it isn't
+        // stamped on each token event, so resolve it once and apply it
+        // to every codex event in this scan (mirrors ccusage).
+        let codexFastTier = codexFastServiceTier(homeDirectory: homeDirectory)
         var aggregator = CostAggregator(tool: .codex, now: now)
         var cache = CostUsageScanCache.load(homeDirectory: homeDirectory, tool: .codex, retentionDays: retentionDays)
         let cutoff = retentionCutoff(now: now, retentionDays: retentionDays)
@@ -64,7 +68,7 @@ public enum CostUsageScanner {
                     cache.store(retained, for: file.path, mtime: mtime, size: size)
                 }
                 for event in retained {
-                    let cost = costUSD(tool: .codex, event: event)
+                    let cost = costUSD(tool: .codex, event: event, codexFastTier: codexFastTier)
                     aggregator.add(at: event.date, model: event.model, input: event.input,
                                    output: event.output, cache: event.cache, costUSD: cost)
                 }
@@ -93,7 +97,8 @@ public enum CostUsageScanner {
                     model: event.model,
                     inputTokens: delta.input,
                     cachedInputTokens: delta.cached,
-                    outputTokens: delta.output
+                    outputTokens: delta.output,
+                    isFast: codexFastTier
                 ) ?? 0
                 let parsedEvent = CostUsageScanCache.ParsedEvent(
                     date: event.date,
@@ -222,6 +227,11 @@ public enum CostUsageScanner {
                 let cacheCreation = anyInt(usage["cache_creation_input_tokens"])
                 let output = anyInt(usage["output_tokens"])
                 if input == 0, cacheRead == 0, cacheCreation == 0, output == 0 { return }
+                // Per-message billing tier. Claude Code writes
+                // `usage.speed` ("standard"/"fast"); `service_tier` is a
+                // fallback. A fast/priority value applies the model's
+                // fast-tier multiplier at costing time.
+                let serviceTier = (usage["speed"] as? String) ?? (usage["service_tier"] as? String)
                 let date = (obj["timestamp"] as? String).flatMap(parseISO) ?? fileMTime(file) ?? Date()
                 let messageId = message["id"] as? String
                 let requestId = obj["requestId"] as? String
@@ -241,7 +251,8 @@ public enum CostUsageScanner {
                     requestId: requestId,
                     isSidechain: anyBool(obj["isSidechain"]),
                     pathRole: pathRole,
-                    sourceKey: sourceKey
+                    sourceKey: sourceKey,
+                    serviceTier: serviceTier
                 )
                 guard isRetained(parsedEvent.date, cutoff: cutoff) else { return }
                 if let messageId, let requestId {
@@ -990,14 +1001,46 @@ public enum CostUsageScanner {
         return events.filter { $0.date >= cutoff }
     }
 
-    private static func costUSD(tool: ToolType, event: CostUsageScanCache.ParsedEvent) -> Double {
+    /// Whether this Codex install is configured for the "fast" /
+    /// "priority" service tier. Codex doesn't stamp the tier on each
+    /// token event, so — like ccusage — we read it once from
+    /// `~/.codex/config.toml` and apply it to every codex event in the
+    /// scan. The flat scan for any `service_tier = "fast" | "priority"`
+    /// line mirrors Codex's own precedence-free reading of the key.
+    static func codexFastServiceTier(homeDirectory: String) -> Bool {
+        let url = URL(fileURLWithPath: homeDirectory)
+            .appendingPathComponent(".codex/config.toml")
+        guard let content = try? String(contentsOf: url, encoding: .utf8) else { return false }
+        for rawLine in content.split(whereSeparator: { $0 == "\n" || $0 == "\r" }) {
+            // Drop trailing `# comment`, then split on the first `=`.
+            let setting = rawLine.split(separator: "#", maxSplits: 1, omittingEmptySubsequences: false)[0]
+            guard let eq = setting.firstIndex(of: "=") else { continue }
+            let key = setting[..<eq].trimmingCharacters(in: .whitespaces)
+            guard key == "service_tier" else { continue }
+            let value = setting[setting.index(after: eq)...]
+                .trimmingCharacters(in: .whitespaces)
+                .trimmingCharacters(in: CharacterSet(charactersIn: "\"'"))
+            if value == "fast" || value == "priority" { return true }
+        }
+        return false
+    }
+
+    /// A per-event `"fast"`/`"priority"` tier (Claude `usage.speed` /
+    /// `service_tier`) selects the model's fast-tier multiplier.
+    static func eventIsFast(_ event: CostUsageScanCache.ParsedEvent) -> Bool {
+        guard let tier = event.serviceTier else { return false }
+        return tier == "fast" || tier == "priority"
+    }
+
+    private static func costUSD(tool: ToolType, event: CostUsageScanCache.ParsedEvent, codexFastTier: Bool = false) -> Double {
         switch tool {
         case .codex:
             return CostUsagePricing.codexCostUSD(
                 model: event.model,
                 inputTokens: event.input + event.cache,
                 cachedInputTokens: event.cache,
-                outputTokens: event.output
+                outputTokens: event.output,
+                isFast: codexFastTier
             ) ?? 0
         case .claude:
             let cacheCreation = max(0, event.cacheCreation ?? 0)
@@ -1007,7 +1050,8 @@ public enum CostUsageScanner {
                 inputTokens: event.input,
                 cacheReadInputTokens: cacheRead,
                 cacheCreationInputTokens: cacheCreation,
-                outputTokens: event.output
+                outputTokens: event.output,
+                isFast: eventIsFast(event)
             ) ?? 0
         case .gemini:
             return CostUsagePricing.geminiCostUSD(

--- a/Sources/VibeBarCore/Services/PricingRefresher.swift
+++ b/Sources/VibeBarCore/Services/PricingRefresher.swift
@@ -1,27 +1,38 @@
 import Foundation
 
-/// Periodically pulls `pricing.json` from the canonical GitHub raw
-/// URL and writes it to `~/.vibebar/pricing_cache.json` so the
-/// `PricingResolver` picks up new model rates without a rebuild.
+/// Periodically pulls LiteLLM's community-maintained model price map,
+/// transforms it into our schema (overlaid on the bundled floor via
+/// `LiteLLMPricingTransformer`), and writes the result to
+/// `~/.vibebar/pricing_cache.json` so `PricingResolver` picks up new
+/// model rates without a rebuild — and without anyone hand-editing
+/// `pricing.json` for every new model.
 ///
 /// Refresh policy: best-effort, never blocking. The cache file's
 /// mtime gates whether a fresh fetch is worth attempting — the
 /// default 24-hour window keeps quiet machines off GitHub's rate
 /// limits without pinning to a stale snapshot for weeks. The remote
-/// fetch is HTTPS-only, size-capped (`PricingDataSet.maxBytes`), and
-/// schema-validated; any failure leaves the previous cache in place
-/// instead of replacing it with garbage.
+/// fetch is HTTPS-only and size-capped (`maxFetchBytes`); the
+/// transformed payload we persist is re-capped at
+/// `PricingDataSet.maxBytes`. Any failure leaves the previous cache in
+/// place instead of replacing it with garbage.
 ///
 /// Because `PricingResolver.cachedActive` snapshots on first read,
 /// a successful refresh only takes effect on the *next* app launch.
 /// That keeps cost calculations stable mid-process and avoids
 /// re-aggregating today's data with mid-flight rate changes.
 public enum PricingRefresher {
-    /// Bundled JSON is the floor; the remote pulls from the same
-    /// repository so updates ship by editing one file and merging.
+    /// Upstream source of truth: LiteLLM's
+    /// `model_prices_and_context_window.json`. The bundled
+    /// `pricing.json` is only the offline floor that this overlays.
     public static let remoteURL = URL(
-        string: "https://raw.githubusercontent.com/AstroQore/vibe-bar/main/Sources/VibeBarCore/Resources/pricing.json"
+        string: "https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json"
     )!
+
+    /// Cap for the raw LiteLLM download (~1.5 MB today). Generous
+    /// headroom for upstream growth while still rejecting a runaway or
+    /// garbage response. The transformed cache we actually persist stays
+    /// small and is re-checked against `PricingDataSet.maxBytes`.
+    public static let maxFetchBytes = 8 * 1024 * 1024
 
     /// Minimum time between fetches — equivalent to "refresh at most
     /// once per app session per day". Override in tests.
@@ -103,24 +114,36 @@ public enum PricingRefresher {
         guard http.statusCode == 200 else {
             return .networkFailure
         }
-        guard data.count > 0, data.count <= PricingDataSet.maxBytes else {
+        guard data.count > 0, data.count <= Self.maxFetchBytes else {
             return .oversized
         }
-        let decoded: PricingDataSet
-        do {
-            decoded = try JSONDecoder().decode(PricingDataSet.self, from: data)
-        } catch {
-            SafeLog.warn("PricingRefresher decode: \(SafeLog.sanitize(error.localizedDescription))")
+        // Transform LiteLLM's flat price map into our schema, overlaid on
+        // the bundled floor so models LiteLLM omits (AntiGravity, anything
+        // it prices as null) survive.
+        let base = PricingResolver.loadBundled() ?? PricingHardcoded.fallback
+        guard let dataSet = LiteLLMPricingTransformer.transform(
+            data,
+            base: base,
+            updatedAt: Self.updatedAtString(for: now)
+        ) else {
+            SafeLog.warn("PricingRefresher transform: LiteLLM payload not usable")
             return .parseFailure
         }
-        guard decoded.schemaVersion == PricingDataSet.currentSchemaVersion else {
-            return .schemaMismatch
+        let encoded: Data
+        do {
+            encoded = try JSONEncoder().encode(dataSet)
+        } catch {
+            SafeLog.warn("PricingRefresher encode: \(SafeLog.sanitize(error.localizedDescription))")
+            return .parseFailure
+        }
+        guard encoded.count <= PricingDataSet.maxBytes else {
+            return .oversized
         }
 
         do {
             let parent = cacheURL.deletingLastPathComponent()
             try FileManager.default.createDirectory(at: parent, withIntermediateDirectories: true)
-            try data.write(to: cacheURL, options: .atomic)
+            try encoded.write(to: cacheURL, options: .atomic)
             try FileManager.default.setAttributes(
                 [.posixPermissions: NSNumber(value: Int16(0o600))],
                 ofItemAtPath: cacheURL.path
@@ -130,5 +153,13 @@ public enum PricingRefresher {
             return .networkFailure
         }
         return .fetched
+    }
+
+    private static func updatedAtString(for date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(identifier: "GMT")
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter.string(from: date)
     }
 }

--- a/Sources/VibeBarCore/Storage/CostUsageScanCache.swift
+++ b/Sources/VibeBarCore/Storage/CostUsageScanCache.swift
@@ -34,6 +34,13 @@ public struct CostUsageScanCache: Codable, Sendable {
         public let isSidechain: Bool?
         public let pathRole: PathRole?
         public let sourceKey: String?
+        /// Billing tier the message ran on when the source log records
+        /// it per-event — Claude writes `message.usage.speed`
+        /// (`"standard"` / `"fast"`). A `"fast"`/`"priority"` value
+        /// triggers the model's fast-tier cost multiplier. Codex resolves
+        /// its tier globally from `~/.codex/config.toml` at scan time, so
+        /// codex events leave this `nil`.
+        public let serviceTier: String?
 
         public init(
             date: Date,
@@ -47,7 +54,8 @@ public struct CostUsageScanCache: Codable, Sendable {
             requestId: String? = nil,
             isSidechain: Bool? = nil,
             pathRole: PathRole? = nil,
-            sourceKey: String? = nil
+            sourceKey: String? = nil,
+            serviceTier: String? = nil
         ) {
             self.date = date
             self.model = model
@@ -61,6 +69,7 @@ public struct CostUsageScanCache: Codable, Sendable {
             self.isSidechain = isSidechain
             self.pathRole = pathRole
             self.sourceKey = sourceKey
+            self.serviceTier = serviceTier
         }
     }
 
@@ -128,7 +137,10 @@ public struct CostUsageScanCache: Codable, Sendable {
     /// 64 MB safety cap. The cache for a heavy user with several years of
     /// Codex / Claude history is usually under 10 MB.
     private static let maxFileBytes: Int = 64 * 1024 * 1024
-    public static let currentSchemaVersion = 2
+    /// v3 adds `ParsedEvent.serviceTier` (Claude fast-tier billing) and
+    /// fast-multiplier cost semantics; bumping forces a one-time
+    /// re-parse so historical events pick up the new field.
+    public static let currentSchemaVersion = 3
 
     public static func fileURL(homeDirectory: String, tool: ToolType) -> URL {
         URL(fileURLWithPath: homeDirectory)

--- a/Sources/VibeBarCore/Vendored/CostUsage/CostUsagePricing.swift
+++ b/Sources/VibeBarCore/Vendored/CostUsage/CostUsagePricing.swift
@@ -26,6 +26,17 @@ public enum CostUsagePricing {
         PricingResolver.active.calculationVersion
     }
 
+    /// Resolves the cost multiplier for a request: `1.0` unless it ran
+    /// on the fast/priority tier, in which case the model's
+    /// `fastMultiplier` applies (defaulting to `1.0` when the model has
+    /// no published premium). Mirrors ccusage's `fast_multiplier`
+    /// semantics so cost totals line up on fast-tier usage.
+    static func fastFactor(_ isFast: Bool, _ fastMultiplier: Double?) -> Double {
+        guard isFast else { return 1.0 }
+        let multiplier = fastMultiplier ?? 1.0
+        return multiplier > 0 ? multiplier : 1.0
+    }
+
     // MARK: - Codex
 
     static func normalizeCodexModel(_ raw: String) -> String {
@@ -51,16 +62,18 @@ public enum CostUsagePricing {
         model: String,
         inputTokens: Int,
         cachedInputTokens: Int,
-        outputTokens: Int
+        outputTokens: Int,
+        isFast: Bool = false
     ) -> Double? {
         let codex = PricingResolver.active.providers.codex.models
         guard let pricing = codex[normalizeCodexModel(model)] else { return nil }
         let cached = min(max(0, cachedInputTokens), max(0, inputTokens))
         let nonCached = max(0, inputTokens - cached)
         let cachedRate = pricing.cacheRead ?? pricing.input
-        return Double(nonCached) * pricing.input
+        let base = Double(nonCached) * pricing.input
             + Double(cached) * cachedRate
             + Double(max(0, outputTokens)) * pricing.output
+        return base * fastFactor(isFast, pricing.fastMultiplier)
     }
 
     // MARK: - Claude
@@ -94,7 +107,8 @@ public enum CostUsagePricing {
         inputTokens: Int,
         cacheReadInputTokens: Int,
         cacheCreationInputTokens: Int,
-        outputTokens: Int
+        outputTokens: Int,
+        isFast: Bool = false
     ) -> Double? {
         let claude = PricingResolver.active.providers.claude.models
         guard let pricing = claude[normalizeClaudeModel(model)] else { return nil }
@@ -106,7 +120,7 @@ public enum CostUsagePricing {
             return Double(below) * base + Double(over) * above
         }
 
-        return tiered(
+        let base = tiered(
             max(0, inputTokens),
             base: pricing.input,
             above: pricing.inputAboveThreshold,
@@ -126,6 +140,7 @@ public enum CostUsagePricing {
                 base: pricing.output,
                 above: pricing.outputAboveThreshold,
                 threshold: pricing.thresholdTokens)
+        return base * fastFactor(isFast, pricing.fastMultiplier)
     }
 
     // MARK: - Gemini

--- a/Sources/VibeBarCore/Vendored/CostUsage/LiteLLMPricingTransformer.swift
+++ b/Sources/VibeBarCore/Vendored/CostUsage/LiteLLMPricingTransformer.swift
@@ -1,0 +1,169 @@
+import Foundation
+
+/// Transforms LiteLLM's community-maintained
+/// `model_prices_and_context_window.json` into Vibe Bar's
+/// `PricingDataSet`, **overlaid on a base set** so curated entries that
+/// LiteLLM doesn't cover survive (AntiGravity shadow rates, models
+/// LiteLLM prices as `null`, display labels). This is what lets
+/// `PricingRefresher` follow upstream pricing automatically instead of
+/// hand-editing `pricing.json` for every new model.
+///
+/// Overlay semantics: every LiteLLM model that classifies into a known
+/// provider family updates (or adds) that entry; everything else in the
+/// base set is left untouched. LiteLLM is therefore authoritative for
+/// the models it prices, and the bundled floor covers the rest.
+///
+/// Only the canonical, bare model keys are kept (`gpt-…`, `claude-…`,
+/// `gemini-…`, `grok-…`, plus `xai/grok-…` with the vendor prefix
+/// stripped). The thousands of `vertex_ai/…`, `azure/…`, `bedrock`,
+/// `openrouter/…` aliases are dropped: Codex / Claude / Gemini / Grok
+/// CLIs log the bare names, and the alias explosion would blow the
+/// cache size cap for no benefit.
+public enum LiteLLMPricingTransformer {
+    /// Fast/priority multipliers LiteLLM does not publish in
+    /// `provider_specific_entry.fast` (the Codex tiers). Mirrors
+    /// ccusage's `fast-multiplier-overrides.json`; looked up by the
+    /// canonical model key and used only when LiteLLM omits `fast`.
+    static let fastMultiplierOverrides: [String: Double] = [
+        "gpt-5.5": 2.5,
+        "gpt-5.4": 2.0,
+        "gpt-5.3-codex": 2.0,
+        "claude-opus-4-6": 6.0,
+        "claude-opus-4-7": 6.0,
+        "claude-opus-4-8": 2.0
+    ]
+
+    /// Decoded subset of one LiteLLM model record. Unknown keys are
+    /// ignored; a record missing `input`/`output` cost is skipped by
+    /// the caller.
+    struct RawEntry: Decodable {
+        let inputCostPerToken: Double?
+        let outputCostPerToken: Double?
+        let cacheCreationInputTokenCost: Double?
+        let cacheReadInputTokenCost: Double?
+        let inputCostPerTokenAbove200k: Double?
+        let outputCostPerTokenAbove200k: Double?
+        let cacheCreationInputTokenCostAbove200k: Double?
+        let cacheReadInputTokenCostAbove200k: Double?
+        let providerSpecificEntry: ProviderSpecific?
+
+        struct ProviderSpecific: Decodable {
+            let fast: Double?
+        }
+
+        enum CodingKeys: String, CodingKey {
+            case inputCostPerToken = "input_cost_per_token"
+            case outputCostPerToken = "output_cost_per_token"
+            case cacheCreationInputTokenCost = "cache_creation_input_token_cost"
+            case cacheReadInputTokenCost = "cache_read_input_token_cost"
+            case inputCostPerTokenAbove200k = "input_cost_per_token_above_200k_tokens"
+            case outputCostPerTokenAbove200k = "output_cost_per_token_above_200k_tokens"
+            case cacheCreationInputTokenCostAbove200k = "cache_creation_input_token_cost_above_200k_tokens"
+            case cacheReadInputTokenCostAbove200k = "cache_read_input_token_cost_above_200k_tokens"
+            case providerSpecificEntry = "provider_specific_entry"
+        }
+    }
+
+    private enum Family {
+        case codex, claude, gemini, grok
+    }
+
+    /// Classifies a LiteLLM key into a provider family and the canonical
+    /// model key Vibe Bar's normalizers expect, or `nil` to drop it.
+    private static func classify(_ rawKey: String) -> (Family, String)? {
+        if rawKey.contains("/") {
+            // The only prefixed family Vibe Bar normalizes back to a bare
+            // key is xAI Grok (`xai/grok-…`). Everything else (vertex_ai,
+            // azure, bedrock, openrouter, anthropic.) is an alias we drop.
+            guard rawKey.hasPrefix("xai/grok-") else { return nil }
+            return (.grok, String(rawKey.dropFirst("xai/".count)))
+        }
+        if rawKey.hasPrefix("gpt-") { return (.codex, rawKey) }
+        if rawKey.hasPrefix("claude-") { return (.claude, rawKey) }
+        if rawKey.hasPrefix("gemini-") { return (.gemini, rawKey) }
+        if rawKey.hasPrefix("grok-") { return (.grok, rawKey) }
+        return nil
+    }
+
+    /// Parses the LiteLLM JSON and overlays it on `base`. Returns `nil`
+    /// when the payload isn't a usable LiteLLM map (so the caller keeps
+    /// the previous cache / bundled floor rather than caching garbage).
+    public static func transform(_ data: Data, base: PricingDataSet, updatedAt: String) -> PricingDataSet? {
+        guard let raw = try? JSONDecoder().decode([String: RawEntry].self, from: data) else {
+            return nil
+        }
+
+        var codex = base.providers.codex.models
+        var claude = base.providers.claude.models
+        var gemini = base.providers.gemini.models
+        var grok = base.providers.grok.models
+        var loaded = 0
+
+        for (rawKey, entry) in raw {
+            guard let input = entry.inputCostPerToken,
+                  let output = entry.outputCostPerToken,
+                  let (family, key) = classify(rawKey)
+            else { continue }
+
+            let fast = entry.providerSpecificEntry?.fast ?? fastMultiplierOverrides[key]
+            let threshold: Int? = (entry.inputCostPerTokenAbove200k != nil
+                || entry.outputCostPerTokenAbove200k != nil
+                || entry.cacheReadInputTokenCostAbove200k != nil) ? 200_000 : nil
+
+            switch family {
+            case .codex:
+                codex[key] = PricingDataSet.CodexEntry(
+                    input: input,
+                    output: output,
+                    cacheRead: entry.cacheReadInputTokenCost,
+                    fastMultiplier: fast,
+                    displayLabel: codex[key]?.displayLabel)
+            case .claude:
+                claude[key] = PricingDataSet.ClaudeEntry(
+                    input: input,
+                    output: output,
+                    cacheCreation: entry.cacheCreationInputTokenCost ?? input * 1.25,
+                    cacheRead: entry.cacheReadInputTokenCost ?? input * 0.1,
+                    thresholdTokens: threshold,
+                    inputAboveThreshold: entry.inputCostPerTokenAbove200k,
+                    outputAboveThreshold: entry.outputCostPerTokenAbove200k,
+                    cacheCreationAboveThreshold: entry.cacheCreationInputTokenCostAbove200k,
+                    cacheReadAboveThreshold: entry.cacheReadInputTokenCostAbove200k,
+                    fastMultiplier: fast)
+            case .gemini:
+                gemini[key] = PricingDataSet.GeminiEntry(
+                    input: input,
+                    output: output,
+                    cacheRead: entry.cacheReadInputTokenCost,
+                    thresholdTokens: threshold,
+                    inputAboveThreshold: entry.inputCostPerTokenAbove200k,
+                    outputAboveThreshold: entry.outputCostPerTokenAbove200k,
+                    cacheReadAboveThreshold: entry.cacheReadInputTokenCostAbove200k,
+                    displayLabel: gemini[key]?.displayLabel)
+            case .grok:
+                grok[key] = PricingDataSet.GrokEntry(
+                    input: input,
+                    output: output,
+                    cacheRead: entry.cacheReadInputTokenCost,
+                    displayLabel: grok[key]?.displayLabel)
+            }
+            loaded += 1
+        }
+
+        // A valid LiteLLM file always carries the frontier Claude/GPT
+        // models. Zero matches means we fetched something else (an error
+        // page, a renamed schema) — refuse it so the caller falls back.
+        guard loaded > 0 else { return nil }
+
+        return PricingDataSet(
+            schemaVersion: PricingDataSet.currentSchemaVersion,
+            updatedAt: updatedAt,
+            calculationVersion: base.calculationVersion,
+            providers: PricingDataSet.Providers(
+                codex: .init(displayName: base.providers.codex.displayName, models: codex),
+                claude: .init(displayName: base.providers.claude.displayName, models: claude),
+                gemini: .init(displayName: base.providers.gemini.displayName, models: gemini),
+                grok: .init(displayName: base.providers.grok.displayName, models: grok),
+                antigravity: base.providers.antigravity))
+    }
+}

--- a/Sources/VibeBarCore/Vendored/CostUsage/PricingDataSet.swift
+++ b/Sources/VibeBarCore/Vendored/CostUsage/PricingDataSet.swift
@@ -14,9 +14,12 @@ import Foundation
 /// of every other provider's quirks.
 public struct PricingDataSet: Codable, Sendable, Equatable {
     public static let currentSchemaVersion = 1
-    /// Hard cap so a corrupt remote file can't blow up the loader.
-    /// 64 KB is ~150× the current bundled JSON's size.
-    public static let maxBytes = 64 * 1024
+    /// Hard cap on a cached / bundled `PricingDataSet` so a corrupt
+    /// file can't blow up the loader. The LiteLLM-overlaid cache the
+    /// refresher writes is ~40 KB; 256 KB leaves room for upstream
+    /// growth. The raw LiteLLM download is capped separately by
+    /// `PricingRefresher.maxFetchBytes`.
+    public static let maxBytes = 256 * 1024
 
     public let schemaVersion: Int
     public let updatedAt: String

--- a/Sources/VibeBarCore/Vendored/CostUsage/PricingDataSet.swift
+++ b/Sources/VibeBarCore/Vendored/CostUsage/PricingDataSet.swift
@@ -71,12 +71,17 @@ public struct PricingDataSet: Codable, Sendable, Equatable {
         public let input: Double
         public let output: Double
         public let cacheRead: Double?
+        /// Multiplier applied to the whole cost when the request ran on
+        /// the "fast"/"priority" Codex service tier (resolved once per
+        /// scan from `~/.codex/config.toml`). `nil` means no premium (×1).
+        public let fastMultiplier: Double?
         public let displayLabel: String?
 
-        public init(input: Double, output: Double, cacheRead: Double?, displayLabel: String? = nil) {
+        public init(input: Double, output: Double, cacheRead: Double?, fastMultiplier: Double? = nil, displayLabel: String? = nil) {
             self.input = input
             self.output = output
             self.cacheRead = cacheRead
+            self.fastMultiplier = fastMultiplier
             self.displayLabel = displayLabel
         }
     }
@@ -91,6 +96,10 @@ public struct PricingDataSet: Codable, Sendable, Equatable {
         public let outputAboveThreshold: Double?
         public let cacheCreationAboveThreshold: Double?
         public let cacheReadAboveThreshold: Double?
+        /// Multiplier applied to the whole cost when the assistant
+        /// message was billed on the "fast"/"priority" tier
+        /// (`message.usage.speed == "fast"`). `nil` means no premium (×1).
+        public let fastMultiplier: Double?
 
         public init(
             input: Double, output: Double,
@@ -99,7 +108,8 @@ public struct PricingDataSet: Codable, Sendable, Equatable {
             inputAboveThreshold: Double? = nil,
             outputAboveThreshold: Double? = nil,
             cacheCreationAboveThreshold: Double? = nil,
-            cacheReadAboveThreshold: Double? = nil
+            cacheReadAboveThreshold: Double? = nil,
+            fastMultiplier: Double? = nil
         ) {
             self.input = input
             self.output = output
@@ -110,6 +120,7 @@ public struct PricingDataSet: Codable, Sendable, Equatable {
             self.outputAboveThreshold = outputAboveThreshold
             self.cacheCreationAboveThreshold = cacheCreationAboveThreshold
             self.cacheReadAboveThreshold = cacheReadAboveThreshold
+            self.fastMultiplier = fastMultiplier
         }
     }
 

--- a/Sources/VibeBarCore/Vendored/CostUsage/PricingHardcoded.swift
+++ b/Sources/VibeBarCore/Vendored/CostUsage/PricingHardcoded.swift
@@ -14,8 +14,8 @@ import Foundation
 enum PricingHardcoded {
     static let fallback: PricingDataSet = PricingDataSet(
         schemaVersion: 1,
-        updatedAt: "2026-05-29",
-        calculationVersion: 5,
+        updatedAt: "2026-06-08",
+        calculationVersion: 6,
         providers: PricingDataSet.Providers(
             codex: codex,
             claude: claude,
@@ -40,14 +40,14 @@ enum PricingHardcoded {
             "gpt-5.2":             .init(input: 1.75e-6, output: 1.4e-5,  cacheRead: 1.75e-7),
             "gpt-5.2-codex":       .init(input: 1.75e-6, output: 1.4e-5,  cacheRead: 1.75e-7),
             "gpt-5.2-pro":         .init(input: 2.1e-5,  output: 1.68e-4, cacheRead: nil),
-            "gpt-5.3-codex":       .init(input: 1.75e-6, output: 1.4e-5,  cacheRead: 1.75e-7),
+            "gpt-5.3-codex":       .init(input: 1.75e-6, output: 1.4e-5,  cacheRead: 1.75e-7, fastMultiplier: 2.0),
             "gpt-5.3-codex-spark": .init(input: 0,       output: 0,       cacheRead: 0,
                                          displayLabel: "Research Preview"),
-            "gpt-5.4":             .init(input: 2.5e-6,  output: 1.5e-5,  cacheRead: 2.5e-7),
+            "gpt-5.4":             .init(input: 2.5e-6,  output: 1.5e-5,  cacheRead: 2.5e-7, fastMultiplier: 2.0),
             "gpt-5.4-mini":        .init(input: 7.5e-7,  output: 4.5e-6,  cacheRead: 7.5e-8),
             "gpt-5.4-nano":        .init(input: 2e-7,    output: 1.25e-6, cacheRead: 2e-8),
             "gpt-5.4-pro":         .init(input: 3e-5,    output: 1.8e-4,  cacheRead: nil),
-            "gpt-5.5":             .init(input: 5e-6,    output: 3e-5,    cacheRead: 5e-7),
+            "gpt-5.5":             .init(input: 5e-6,    output: 3e-5,    cacheRead: 5e-7, fastMultiplier: 2.5),
             "gpt-5.5-pro":         .init(input: 3e-5,    output: 1.8e-4,  cacheRead: nil)
         ]
     )
@@ -69,16 +69,20 @@ enum PricingHardcoded {
                 cacheCreation: 6.25e-6, cacheRead: 5e-7),
             "claude-opus-4-6-20260205": .init(
                 input: 5e-6, output: 2.5e-5,
-                cacheCreation: 6.25e-6, cacheRead: 5e-7),
+                cacheCreation: 6.25e-6, cacheRead: 5e-7,
+                fastMultiplier: 6.0),
             "claude-opus-4-6": .init(
                 input: 5e-6, output: 2.5e-5,
-                cacheCreation: 6.25e-6, cacheRead: 5e-7),
+                cacheCreation: 6.25e-6, cacheRead: 5e-7,
+                fastMultiplier: 6.0),
             "claude-opus-4-7": .init(
                 input: 5e-6, output: 2.5e-5,
-                cacheCreation: 6.25e-6, cacheRead: 5e-7),
+                cacheCreation: 6.25e-6, cacheRead: 5e-7,
+                fastMultiplier: 6.0),
             "claude-opus-4-8": .init(
                 input: 5e-6, output: 2.5e-5,
-                cacheCreation: 6.25e-6, cacheRead: 5e-7),
+                cacheCreation: 6.25e-6, cacheRead: 5e-7,
+                fastMultiplier: 2.0),
             "claude-sonnet-4-5": .init(
                 input: 3e-6, output: 1.5e-5,
                 cacheCreation: 3.75e-6, cacheRead: 3e-7,

--- a/Tests/VibeBarCoreTests/CostUsagePricingTests.swift
+++ b/Tests/VibeBarCoreTests/CostUsagePricingTests.swift
@@ -132,4 +132,61 @@ final class CostUsagePricingTests: XCTestCase {
     func testPricingDataDateAvailable() {
         XCTAssertFalse(CostUsagePricing.pricingDataUpdatedAt.isEmpty)
     }
+
+    // MARK: - Fast / priority service-tier multiplier
+
+    func testCodexFastTierMultipliesWholeCost() {
+        PricingResolver.testOverride = PricingHardcoded.fallback
+        defer { PricingResolver.testOverride = nil }
+
+        // gpt-5.5: input $5/MTok, output $30/MTok, fast multiplier ×2.5.
+        // 1M input + 100k output = 5.0 + 3.0 = 8.0 base; ×2.5 = 20.0 fast.
+        let base = CostUsagePricing.codexCostUSD(
+            model: "gpt-5.5", inputTokens: 1_000_000, cachedInputTokens: 0, outputTokens: 100_000)
+        let fast = CostUsagePricing.codexCostUSD(
+            model: "gpt-5.5", inputTokens: 1_000_000, cachedInputTokens: 0, outputTokens: 100_000, isFast: true)
+        XCTAssertEqual(base ?? -1, 8.0, accuracy: 0.001)
+        XCTAssertEqual(fast ?? -1, 20.0, accuracy: 0.001)
+    }
+
+    func testClaudeFastTierMultipliesWholeCost() {
+        PricingResolver.testOverride = PricingHardcoded.fallback
+        defer { PricingResolver.testOverride = nil }
+
+        // base = 1M input + 100k output = 5.0 + 2.5 = 7.5.
+        // opus-4-7 fast ×6 = 45.0; opus-4-8 fast ×2 = 15.0.
+        let opus47 = CostUsagePricing.claudeCostUSD(
+            model: "claude-opus-4-7", inputTokens: 1_000_000, cacheReadInputTokens: 0,
+            cacheCreationInputTokens: 0, outputTokens: 100_000, isFast: true)
+        let opus48 = CostUsagePricing.claudeCostUSD(
+            model: "claude-opus-4-8", inputTokens: 1_000_000, cacheReadInputTokens: 0,
+            cacheCreationInputTokens: 0, outputTokens: 100_000, isFast: true)
+        XCTAssertEqual(opus47 ?? -1, 45.0, accuracy: 0.001)
+        XCTAssertEqual(opus48 ?? -1, 15.0, accuracy: 0.001)
+    }
+
+    func testFastTierDefaultsOffSoStandardUsageIsUnchanged() {
+        PricingResolver.testOverride = PricingHardcoded.fallback
+        defer { PricingResolver.testOverride = nil }
+
+        // Regression guard: the new `isFast` parameter defaults to false,
+        // so every existing call site keeps standard-tier pricing.
+        let opus47 = CostUsagePricing.claudeCostUSD(
+            model: "claude-opus-4-7", inputTokens: 1_000_000, cacheReadInputTokens: 0,
+            cacheCreationInputTokens: 0, outputTokens: 100_000)
+        XCTAssertEqual(opus47 ?? -1, 7.5, accuracy: 0.001)
+    }
+
+    func testFastTierIsNoOpForModelWithoutPublishedPremium() {
+        PricingResolver.testOverride = PricingHardcoded.fallback
+        defer { PricingResolver.testOverride = nil }
+
+        // gpt-5 has no fast multiplier, so the fast flag must not change
+        // its cost (multiplier resolves to ×1).
+        let base = CostUsagePricing.codexCostUSD(
+            model: "gpt-5", inputTokens: 1_000_000, cachedInputTokens: 0, outputTokens: 100_000)
+        let fast = CostUsagePricing.codexCostUSD(
+            model: "gpt-5", inputTokens: 1_000_000, cachedInputTokens: 0, outputTokens: 100_000, isFast: true)
+        XCTAssertEqual(fast ?? -1, base ?? -2, accuracy: 0.0001)
+    }
 }

--- a/Tests/VibeBarCoreTests/CostUsageScannerTests.swift
+++ b/Tests/VibeBarCoreTests/CostUsageScannerTests.swift
@@ -236,6 +236,96 @@ final class CostUsageScannerTests: XCTestCase {
         XCTAssertEqual(snapshot?.jsonlFilesFound, 2)
     }
 
+    // MARK: - Fast / priority service tier
+
+    func testCodexFastServiceTierParsesConfigToml() throws {
+        let fileManager = FileManager.default
+        func tierIsFast(_ toml: String) throws -> Bool {
+            let home = fileManager.temporaryDirectory
+                .appendingPathComponent("VibeBarCodexTier-\(UUID().uuidString)", isDirectory: true)
+            defer { try? fileManager.removeItem(at: home) }
+            let codex = home.appendingPathComponent(".codex", isDirectory: true)
+            try fileManager.createDirectory(at: codex, withIntermediateDirectories: true)
+            try toml.write(to: codex.appendingPathComponent("config.toml"), atomically: true, encoding: .utf8)
+            return CostUsageScanner.codexFastServiceTier(homeDirectory: home.path)
+        }
+
+        XCTAssertTrue(try tierIsFast(#"service_tier = "fast""#))
+        XCTAssertTrue(try tierIsFast(#"service_tier = 'priority'  # higher tier"#))
+        XCTAssertFalse(try tierIsFast(#"service_tier = "standard""#))
+        XCTAssertFalse(try tierIsFast(##"# service_tier = "fast""##))
+        XCTAssertFalse(try tierIsFast("model = \"gpt-5.5\"\n"))
+    }
+
+    func testCodexFastServiceTierMissingConfigIsStandard() {
+        let fileManager = FileManager.default
+        let home = fileManager.temporaryDirectory
+            .appendingPathComponent("VibeBarCodexNoTier-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fileManager.removeItem(at: home) }
+        XCTAssertFalse(CostUsageScanner.codexFastServiceTier(homeDirectory: home.path))
+    }
+
+    func testCodexScanAppliesConfiguredFastTierMultiplier() async throws {
+        PricingResolver.testOverride = PricingHardcoded.fallback
+        defer { PricingResolver.testOverride = nil }
+        let fileManager = FileManager.default
+        let now = Date(timeIntervalSince1970: 1_762_339_200)
+
+        func scanCost(fast: Bool) async throws -> Double {
+            let home = fileManager.temporaryDirectory
+                .appendingPathComponent("VibeBarCodexFastScan-\(UUID().uuidString)", isDirectory: true)
+            defer { try? fileManager.removeItem(at: home) }
+            let codex = home.appendingPathComponent(".codex", isDirectory: true)
+            let sessions = codex.appendingPathComponent("sessions", isDirectory: true)
+            try fileManager.createDirectory(at: sessions, withIntermediateDirectories: true)
+            if fast {
+                try #"service_tier = "fast""#
+                    .write(to: codex.appendingPathComponent("config.toml"), atomically: true, encoding: .utf8)
+            }
+            try codexTokenCountLine(timestamp: now, model: "gpt-5.5", input: 1_000_000, cached: 0, output: 100_000)
+                .write(to: sessions.appendingPathComponent("session.jsonl"), atomically: true, encoding: .utf8)
+            let snapshot = await CostUsageScanner.scan(tool: .codex, homeDirectory: home.path, now: now)
+            return try XCTUnwrap(snapshot?.modelBreakdowns.first?.costUSD)
+        }
+
+        // gpt-5.5: 1M input + 100k output = 8.0 base; fast tier ×2.5 = 20.0.
+        let standard = try await scanCost(fast: false)
+        let fast = try await scanCost(fast: true)
+        XCTAssertEqual(standard, 8.0, accuracy: 0.001)
+        XCTAssertEqual(fast, 20.0, accuracy: 0.001)
+    }
+
+    func testClaudeScanAppliesPerMessageFastSpeedMultiplier() async throws {
+        PricingResolver.testOverride = PricingHardcoded.fallback
+        defer { PricingResolver.testOverride = nil }
+        let fileManager = FileManager.default
+        let now = Date(timeIntervalSince1970: 1_762_339_200)
+
+        func scanCost(speed: String) async throws -> Double {
+            let home = fileManager.temporaryDirectory
+                .appendingPathComponent("VibeBarClaudeFastScan-\(UUID().uuidString)", isDirectory: true)
+            defer { try? fileManager.removeItem(at: home) }
+            let projects = home
+                .appendingPathComponent(".claude", isDirectory: true)
+                .appendingPathComponent("projects", isDirectory: true)
+                .appendingPathComponent("project-a", isDirectory: true)
+            try fileManager.createDirectory(at: projects, withIntermediateDirectories: true)
+            try claudeAssistantLine(
+                timestamp: now, sessionId: "s", messageId: "m", requestId: "r",
+                model: "claude-opus-4-7", input: 1_000_000, cacheRead: 0, cacheCreation: 0,
+                output: 100_000, speed: speed
+            ).write(to: projects.appendingPathComponent("session.jsonl"), atomically: true, encoding: .utf8)
+            let snapshot = await CostUsageScanner.scan(tool: .claude, homeDirectory: home.path, now: now)
+            return try XCTUnwrap(snapshot?.modelBreakdowns.first?.costUSD)
+        }
+
+        // opus-4-7: 1M input + 100k output = 7.5 base; fast speed ×6 = 45.0.
+        let standard = try await scanCost(speed: "standard")
+        let fast = try await scanCost(speed: "fast")
+        XCTAssertEqual(standard, 7.5, accuracy: 0.001)
+        XCTAssertEqual(fast, 45.0, accuracy: 0.001)
+    }
+
     private func codexTokenCountLine(
         timestamp: Date,
         model: String,
@@ -259,11 +349,13 @@ final class CostUsageScannerTests: XCTestCase {
         cacheRead: Int,
         cacheCreation: Int,
         output: Int,
-        isSidechain: Bool = false
+        isSidechain: Bool = false,
+        speed: String? = nil
     ) -> String {
         let timestampString = Self.isoFormatter.string(from: timestamp)
+        let speedField = speed.map { ",\"speed\":\"\($0)\"" } ?? ""
         return """
-        {"timestamp":"\(timestampString)","type":"assistant","sessionId":"\(sessionId)","requestId":"\(requestId)","isSidechain":\(isSidechain),"message":{"id":"\(messageId)","model":"\(model)","usage":{"input_tokens":\(input),"cache_read_input_tokens":\(cacheRead),"cache_creation_input_tokens":\(cacheCreation),"output_tokens":\(output)}}}
+        {"timestamp":"\(timestampString)","type":"assistant","sessionId":"\(sessionId)","requestId":"\(requestId)","isSidechain":\(isSidechain),"message":{"id":"\(messageId)","model":"\(model)","usage":{"input_tokens":\(input),"cache_read_input_tokens":\(cacheRead),"cache_creation_input_tokens":\(cacheCreation),"output_tokens":\(output)\(speedField)}}}
         """
     }
 

--- a/Tests/VibeBarCoreTests/LiteLLMPricingTransformerTests.swift
+++ b/Tests/VibeBarCoreTests/LiteLLMPricingTransformerTests.swift
@@ -1,0 +1,110 @@
+import XCTest
+@testable import VibeBarCore
+
+/// Validates the LiteLLM → `PricingDataSet` overlay that lets
+/// `PricingRefresher` follow upstream pricing automatically.
+final class LiteLLMPricingTransformerTests: XCTestCase {
+    private func transform(_ json: String) -> PricingDataSet? {
+        LiteLLMPricingTransformer.transform(
+            Data(json.utf8),
+            base: PricingHardcoded.fallback,
+            updatedAt: "2026-06-08"
+        )
+    }
+
+    func testRoutesEachFamilyToItsProviderWithRatesAndFastTier() throws {
+        let set = try XCTUnwrap(transform("""
+        {
+          "claude-opus-4-8": {
+            "input_cost_per_token": 5e-6, "output_cost_per_token": 2.5e-5,
+            "cache_creation_input_token_cost": 6.25e-6, "cache_read_input_token_cost": 5e-7,
+            "provider_specific_entry": {"fast": 2.0}
+          },
+          "gpt-5.5": {"input_cost_per_token": 5e-6, "output_cost_per_token": 3e-5, "cache_read_input_token_cost": 5e-7},
+          "gemini-2.5-pro": {
+            "input_cost_per_token": 1.25e-6, "output_cost_per_token": 1e-5, "cache_read_input_token_cost": 3.1e-7,
+            "input_cost_per_token_above_200k_tokens": 2.5e-6, "output_cost_per_token_above_200k_tokens": 1.5e-5,
+            "cache_read_input_token_cost_above_200k_tokens": 6.25e-7
+          },
+          "xai/grok-4.3": {"input_cost_per_token": 1.25e-6, "output_cost_per_token": 2.5e-6, "cache_read_input_token_cost": 3.1e-7}
+        }
+        """))
+
+        let opus = try XCTUnwrap(set.providers.claude.models["claude-opus-4-8"])
+        XCTAssertEqual(opus.input, 5e-6, accuracy: 1e-12)
+        XCTAssertEqual(opus.fastMultiplier, 2.0)
+
+        // gpt-5.5 carries no `fast` in LiteLLM → filled from the override table.
+        XCTAssertEqual(set.providers.codex.models["gpt-5.5"]?.fastMultiplier, 2.5)
+
+        let gemini = try XCTUnwrap(set.providers.gemini.models["gemini-2.5-pro"])
+        XCTAssertEqual(gemini.thresholdTokens, 200_000)
+        XCTAssertEqual(gemini.inputAboveThreshold ?? 0, 2.5e-6, accuracy: 1e-12)
+
+        // xAI grok is stored under the bare key Vibe Bar normalizes to.
+        XCTAssertEqual(set.providers.grok.models["grok-4.3"]?.input ?? 0, 1.25e-6, accuracy: 1e-12)
+        XCTAssertNil(set.providers.grok.models["xai/grok-4.3"])
+    }
+
+    func testFillsClaudeCacheRatesFromInputWhenLiteLLMOmitsThem() throws {
+        let set = try XCTUnwrap(transform("""
+        {"claude-fictional-1": {"input_cost_per_token": 1e-5, "output_cost_per_token": 5e-5}}
+        """))
+        let entry = try XCTUnwrap(set.providers.claude.models["claude-fictional-1"])
+        XCTAssertEqual(entry.cacheCreation, 1.25e-5, accuracy: 1e-15) // input × 1.25
+        XCTAssertEqual(entry.cacheRead, 1e-6, accuracy: 1e-15)        // input × 0.10
+    }
+
+    func testDropsVendorPrefixedAliases() throws {
+        let set = try XCTUnwrap(transform("""
+        {
+          "vertex_ai/claude-opus-4-8": {"input_cost_per_token": 9e-6, "output_cost_per_token": 9e-5},
+          "openrouter/anthropic/claude-opus-4-8": {"input_cost_per_token": 9e-6, "output_cost_per_token": 9e-5},
+          "claude-opus-4-8": {"input_cost_per_token": 5e-6, "output_cost_per_token": 2.5e-5}
+        }
+        """))
+        // Only the bare key is kept; the $9 aliases never landed.
+        XCTAssertEqual(set.providers.claude.models["claude-opus-4-8"]?.input ?? 0, 5e-6, accuracy: 1e-12)
+        XCTAssertNil(set.providers.claude.models["vertex_ai/claude-opus-4-8"])
+        XCTAssertNil(set.providers.claude.models["openrouter/anthropic/claude-opus-4-8"])
+    }
+
+    func testPreservesBaseModelsLiteLLMDoesNotPrice() throws {
+        // gpt-5.5 keeps loaded > 0; gemini-3-pro is priced null upstream and
+        // absent here, so the curated base entry must survive the overlay.
+        let set = try XCTUnwrap(transform("""
+        {
+          "gpt-5.5": {"input_cost_per_token": 5e-6, "output_cost_per_token": 3e-5},
+          "gemini-3-pro": {"input_cost_per_token": null, "output_cost_per_token": null}
+        }
+        """))
+        XCTAssertEqual(set.providers.gemini.models["gemini-3-pro"]?.input ?? 0, 2e-6, accuracy: 1e-12)
+        // AntiGravity shadow rates are never in LiteLLM; they must persist.
+        XCTAssertNotNil(set.providers.antigravity.models["antigravity-default"])
+    }
+
+    func testAddsNewUpstreamModelWithoutEditingBundledTable() throws {
+        // The whole point of the overlay: a model nobody hand-added shows up.
+        let set = try XCTUnwrap(transform("""
+        {"gpt-9-hypothetical": {"input_cost_per_token": 1e-6, "output_cost_per_token": 2e-6, "cache_read_input_token_cost": 1e-7}}
+        """))
+        XCTAssertNil(PricingHardcoded.fallback.providers.codex.models["gpt-9-hypothetical"])
+        XCTAssertEqual(set.providers.codex.models["gpt-9-hypothetical"]?.input ?? 0, 1e-6, accuracy: 1e-12)
+        XCTAssertEqual(set.providers.codex.models["gpt-9-hypothetical"]?.cacheRead ?? 0, 1e-7, accuracy: 1e-13)
+    }
+
+    func testRejectsPayloadsThatAreNotLiteLLMMaps() {
+        XCTAssertNil(transform("not json at all"))
+        XCTAssertNil(transform(#"{"hello":"world"}"#))      // values aren't model objects
+        XCTAssertNil(transform(#"{"sample_spec":{}}"#))     // no priceable models → unusable
+    }
+
+    func testCarriesSchemaAndCalculationVersionForTheLoader() throws {
+        let set = try XCTUnwrap(transform("""
+        {"gpt-5.5": {"input_cost_per_token": 5e-6, "output_cost_per_token": 3e-5}}
+        """))
+        XCTAssertEqual(set.schemaVersion, PricingDataSet.currentSchemaVersion)
+        XCTAssertEqual(set.calculationVersion, PricingHardcoded.fallback.calculationVersion)
+        XCTAssertEqual(set.updatedAt, "2026-06-08")
+    }
+}

--- a/Tests/VibeBarCoreTests/PricingRefresherTests.swift
+++ b/Tests/VibeBarCoreTests/PricingRefresherTests.swift
@@ -2,10 +2,10 @@ import XCTest
 @testable import VibeBarCore
 
 /// Exercises `PricingRefresher` against a stubbed URLProtocol so we
-/// can assert behavior on the happy path (200 → cache written),
-/// freshness short-circuit (cache present + within window → skipped),
-/// schema mismatch (unknown version → rejected), and network failure
-/// (left cache untouched).
+/// can assert behavior on the happy path (200 → LiteLLM transformed →
+/// cache written), freshness short-circuit (cache present + within
+/// window → skipped), unusable payload (not LiteLLM → rejected),
+/// oversized download, and network failure (left cache untouched).
 final class PricingRefresherTests: XCTestCase {
     private final class StubURLProtocol: URLProtocol {
         nonisolated(unsafe) static var responder: (@Sendable (URLRequest) -> (HTTPURLResponse, Data?))?
@@ -75,17 +75,29 @@ final class PricingRefresherTests: XCTestCase {
         XCTAssertEqual(outcome, .skippedFresh)
     }
 
-    func testSuccessfulFetchWritesCache() async throws {
+    func testSuccessfulFetchTransformsLiteLLMAndWritesCache() async throws {
         let home = try makeTempHome()
         defer { cleanup(home) }
 
-        let dataSet = PricingDataSet(
-            schemaVersion: 1,
-            updatedAt: "2026-06-01",
-            calculationVersion: 5,
-            providers: PricingHardcoded.fallback.providers
-        )
-        let body = try JSONEncoder().encode(dataSet)
+        // A trimmed LiteLLM-shaped payload: a frontier Claude model with
+        // an explicit fast multiplier, a Codex model whose fast tier comes
+        // from our override table, and a spec stub with no cost fields.
+        let body = Data("""
+        {
+          "claude-opus-4-8": {
+            "input_cost_per_token": 5e-6, "output_cost_per_token": 2.5e-5,
+            "cache_creation_input_token_cost": 6.25e-6,
+            "cache_read_input_token_cost": 5e-7,
+            "max_input_tokens": 1000000,
+            "provider_specific_entry": {"fast": 2.0}
+          },
+          "gpt-5.5": {
+            "input_cost_per_token": 5e-6, "output_cost_per_token": 3e-5,
+            "cache_read_input_token_cost": 5e-7
+          },
+          "sample_spec": {"max_input_tokens": "max input tokens, if the provider specifies it"}
+        }
+        """.utf8)
 
         StubURLProtocol.responder = { request in
             let response = HTTPURLResponse(
@@ -97,30 +109,43 @@ final class PricingRefresherTests: XCTestCase {
             return (response, body)
         }
 
+        let now = Date(timeIntervalSince1970: 1_762_339_200)
+        let expectedDate: String = {
+            let formatter = DateFormatter()
+            formatter.locale = Locale(identifier: "en_US_POSIX")
+            formatter.timeZone = TimeZone(identifier: "GMT")
+            formatter.dateFormat = "yyyy-MM-dd"
+            return formatter.string(from: now)
+        }()
+
         let outcome = await PricingRefresher.refresh(
             homeDirectory: home.path,
             session: makeStubbedSession(),
-            force: true
+            force: true,
+            now: now
         )
         XCTAssertEqual(outcome, .fetched)
 
         let cacheURL = PricingResolver.cacheFileURL(homeDirectory: home.path)
-        let read = try Data(contentsOf: cacheURL)
-        let decoded = try JSONDecoder().decode(PricingDataSet.self, from: read)
-        XCTAssertEqual(decoded.updatedAt, "2026-06-01")
+        let decoded = try JSONDecoder().decode(PricingDataSet.self, from: Data(contentsOf: cacheURL))
+        XCTAssertEqual(decoded.schemaVersion, PricingDataSet.currentSchemaVersion)
+        XCTAssertEqual(decoded.updatedAt, expectedDate)
+        XCTAssertEqual(decoded.calculationVersion, PricingHardcoded.fallback.calculationVersion)
+        // LiteLLM's fast multiplier survives the round-trip…
+        XCTAssertEqual(decoded.providers.claude.models["claude-opus-4-8"]?.fastMultiplier, 2.0)
+        XCTAssertEqual(decoded.providers.claude.models["claude-opus-4-8"]?.input ?? 0, 5e-6, accuracy: 1e-12)
+        // …and the Codex fast multiplier is filled from the override table.
+        XCTAssertEqual(decoded.providers.codex.models["gpt-5.5"]?.fastMultiplier, 2.5)
+        // Overlay preserves base-only providers LiteLLM never ships.
+        XCTAssertNotNil(decoded.providers.antigravity.models["antigravity-default"])
     }
 
-    func testSchemaMismatchRejectsBadPayload() async throws {
+    func testUnusablePayloadIsRejected() async throws {
         let home = try makeTempHome()
         defer { cleanup(home) }
 
-        let bad = PricingDataSet(
-            schemaVersion: 999,
-            updatedAt: "future",
-            calculationVersion: 5,
-            providers: PricingHardcoded.fallback.providers
-        )
-        let body = try JSONEncoder().encode(bad)
+        // Valid JSON, but not a LiteLLM price map (no priceable models).
+        let body = Data(#"{"note":"this is not litellm","models":[]}"#.utf8)
         StubURLProtocol.responder = { request in
             let response = HTTPURLResponse(url: request.url!,
                                            statusCode: 200,
@@ -134,18 +159,18 @@ final class PricingRefresherTests: XCTestCase {
             session: makeStubbedSession(),
             force: true
         )
-        XCTAssertEqual(outcome, .schemaMismatch)
+        XCTAssertEqual(outcome, .parseFailure)
         XCTAssertFalse(
             FileManager.default.fileExists(atPath: PricingResolver.cacheFileURL(homeDirectory: home.path).path),
-            "Cache should not be written when schemaVersion mismatches"
+            "Cache should not be written when the payload isn't usable LiteLLM data"
         )
     }
 
-    func testOversizedPayloadIsRejected() async throws {
+    func testOversizedDownloadIsRejected() async throws {
         let home = try makeTempHome()
         defer { cleanup(home) }
 
-        let oversize = Data(repeating: 0x20, count: PricingDataSet.maxBytes + 1)
+        let oversize = Data(repeating: 0x20, count: PricingRefresher.maxFetchBytes + 1)
         StubURLProtocol.responder = { request in
             let response = HTTPURLResponse(url: request.url!,
                                            statusCode: 200,


### PR DESCRIPTION
## Why

Vibe Bar's cost totals drifted noticeably from [ccusage](https://github.com/ryoppippi/ccusage) for the same logs. Two root causes (base per-token rates were already correct):

1. **Fast / priority tier usage was billed at the standard rate.** Codex (`service_tier = "fast"` / `"priority"` in `~/.codex/config.toml`) and Claude (`message.usage.speed == "fast"`) can run on a premium tier that costs a multiple of the standard rate. The scanner only charged `tokens × rate`, so it under-counted fast-tier usage versus the real bill and versus ccusage.
2. **Pricing was a hand-maintained table.** `PricingRefresher` pulled this repo's own `pricing.json`, so every new model meant a manual edit — which is exactly how `claude-opus-4-8` briefly shipped unpriced (it counted as $0 until #65).

## What

### 1. Fast/priority service-tier multiplier (`d69e373`)
- Adds an optional `fastMultiplier` to the Claude/Codex pricing entries (opus-4-6/4-7 ×6, opus-4-8 ×2, gpt-5.5 ×2.5, gpt-5.4 / gpt-5.3-codex ×2 — matching ccusage's LiteLLM-derived multipliers) and applies it **only** when the request ran on the fast tier.
- Claude carries the tier per message (persisted on `ParsedEvent.serviceTier`); Codex has no per-event signal, so it's resolved once per scan from `config.toml` and applied to every codex event (same approach ccusage takes).
- Bumps pricing `calculationVersion` 5→6 and scan-cache `schemaVersion` 2→3 so persisted totals recompute under the new semantics.

### 2. Follow LiteLLM upstream pricing (`a005ba4`)
- Points `PricingRefresher` at LiteLLM's community-maintained [`model_prices_and_context_window.json`](https://github.com/BerriAI/litellm/blob/main/model_prices_and_context_window.json) (the source ccusage uses) and transforms it into our schema, **overlaid on the bundled floor** so curated entries LiteLLM doesn't ship (AntiGravity shadow rates, models it prices as `null`, display labels) survive. New upstream models now appear automatically; bundled `pricing.json` is just the offline fallback.
- The transformer keeps only the bare canonical keys the CLIs log (`gpt-*`, `claude-*`, `gemini-*`, `grok-*`, plus `xai/grok-*` with the prefix stripped), drops the `vertex_ai`/`azure`/`bedrock`/`openrouter` alias explosion, and applies LiteLLM's cache-rate fallbacks. The real upstream map (202 matched models) overlays to ~18 KB.

## Validation
- `swift build`, `swift test` — **533 tests, 0 failures** (19 new across pricing, scanner, transformer, refresher).
- `./Scripts/build_app.sh release` → `codesign -d --entitlements -` is an empty dict (no `app-sandbox`); `codesign --verify --deep --strict` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
