### PR TITLE
Don't bump pricing calculationVersion (it wipes cost history)

### DIFF
--- a/Sources/VibeBarCore/Resources/pricing.json
+++ b/Sources/VibeBarCore/Resources/pricing.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "updatedAt": "2026-06-08",
-  "calculationVersion": 6,
+  "calculationVersion": 5,
   "providers": {
     "codex": {
       "displayName": "OpenAI",

--- a/Sources/VibeBarCore/Vendored/CostUsage/PricingHardcoded.swift
+++ b/Sources/VibeBarCore/Vendored/CostUsage/PricingHardcoded.swift
@@ -12,10 +12,20 @@ import Foundation
 /// because the loaded data set won't match the hardcoded one for
 /// known models.
 enum PricingHardcoded {
+    // calculationVersion gates `CostHistoryStore`: changing it WIPES the
+    // user's entire accumulated daily history — including days whose
+    // session files have since rotated off disk and can never be
+    // re-scanned. The fast-tier multiplier only ever *raises* a day's
+    // cost, and `CostHistoryStore.mergeSeries` max-merges fresh scans
+    // over stored days, so on-disk days self-correct upward without a
+    // bump. Do NOT bump this for additive / re-derivable pricing changes
+    // (new models, higher multipliers); reserve it for changes where a
+    // day's cost could legitimately *decrease* and stale higher values
+    // must be discarded.
     static let fallback: PricingDataSet = PricingDataSet(
         schemaVersion: 1,
         updatedAt: "2026-06-08",
-        calculationVersion: 6,
+        calculationVersion: 5,
         providers: PricingDataSet.Providers(
             codex: codex,
             claude: claude,


### PR DESCRIPTION
## The regression

`CostHistoryStore.load()` wipes the **entire** accumulated daily history whenever the stored `calculationVersion` changes — and overwrites the on-disk `cost_history.json` with an empty one. Most of that history is days whose Codex/Claude session files have already rotated off disk, so they **cannot be re-scanned**.

[#66](https://github.com/AstroQore/vibe-bar/pull/66) bumped `calculationVersion` 5→6 for the fast-tier multiplier. On this maintainer's machine `cost_history.json` holds **246 days / ~8 months** (2025‑09‑24 → today). The first launch of a v6 build would have discarded all of it.

## The fix

Revert `calculationVersion` to 5 (both `pricing.json` and `PricingHardcoded`), with an inline comment documenting the hazard. This is safe because:

- The fast multiplier only ever **raises** a day's cost, and `mergeSeries` **max-merges** fresh scans over stored days — so on-disk days self-correct upward to the fast-adjusted cost *without* a version bump.
- Rotated days keep their prior (1×) cost instead of vanishing.

The scan-cache `schemaVersion` bump (v2→v3) from #66 stays: it only forces a cheap re-parse of on-disk files and never touches the history store.

## Diagnosis context (why the totals differed from ccusage)

Measured against ground truth (ccusage on the same machine, ~$19.5k):

| Tool | Vibe Bar (stored, 1×) | Vibe Bar (live, this fix) | ccusage |
|---|---|---|---|
| Codex | $5,585 / 12.2B | **$11,703 / 12.2B** | $14,953 / 18.2B |
| Claude | $5,751 / 8.0B | $5,392 / 7.4B | ~$4,606 / 6.3B |

- The dominant gap was the **fast multiplier** (Codex runs `service_tier = "fast"`); #66 + this fix close it (~$11.4k → ~$17.5k, ≈89% of ccusage).
- The remaining Codex **token** gap is a methodology difference: Codex logs each turn's `token_count` event **twice**, identically. Vibe Bar deltas the cumulative `total_token_usage` (duplicates → 0 delta, counted once); ccusage sums per-turn `last_token_usage` (appears to count both). For the largest session, ccusage's cache total is exactly **2×** Vibe Bar's — i.e. Vibe Bar may be **more** correct here, pending a check against the real OpenAI bill. Not changed in this PR.

## Validation
`swift build`, `swift test` (533 pass), `./Scripts/build_app.sh release`, `codesign -d` empty dict / `--verify --deep --strict` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
