### PR TITLE
Hot-reload refreshed pricing without an app relaunch

### DIFF
--- a/Sources/VibeBarApp/AppEnvironment.swift
+++ b/Sources/VibeBarApp/AppEnvironment.swift
@@ -38,6 +38,7 @@ final class AppEnvironment: ObservableObject {
     private var browserOpenAICookieImportInFlight = false
     private var browserGeminiCookieImportInFlight = false
     private var browserGrokCookieImportInFlight = false
+    private var pricingRefreshTask: Task<Void, Never>?
 
     init() {
         let settings = SettingsStore()
@@ -181,14 +182,28 @@ final class AppEnvironment: ObservableObject {
             await costService.refreshAll()
         }
 
-        // Best-effort pricing refresh: fetches the latest pricing.json from
-        // GitHub raw and updates ~/.vibebar/pricing_cache.json so the *next*
-        // launch picks up new model rates without a rebuild. Failures are
-        // silent — the bundled fallback keeps the current session usable.
-        // The 24-hour freshness window inside PricingRefresher short-circuits
-        // the network call when the cache is still recent.
-        Task.detached(priority: .utility) {
-            await PricingRefresher.refresh()
+        // Best-effort pricing refresh loop: polls LiteLLM's pricing map on
+        // GitHub raw and rewrites ~/.vibebar/pricing_cache.json when it
+        // changes. The 24-hour freshness window inside PricingRefresher
+        // reduces most wake-ups to a stat() call, so the loop can re-check
+        // every few hours and a menu-bar app that stays up for weeks still
+        // follows new model rates. After a fetch lands a new table, nudge a
+        // re-scan — refreshAll() adopts the table at the start of its next
+        // pass, so a brand-new model stops pricing at $0 without an app
+        // relaunch. Failures stay silent: the previous cache (or the
+        // bundled fallback) keeps the session usable.
+        pricingRefreshTask = Task.detached(priority: .utility) {
+            while !Task.isCancelled {
+                let outcome = await PricingRefresher.refresh()
+                if outcome == .fetched {
+                    await costService.refreshAll()
+                }
+                do {
+                    try await Task.sleep(for: .seconds(6 * 60 * 60))
+                } catch {
+                    break
+                }
+            }
         }
         importPersistentClaudeCookiesAndRefreshIfNeeded()
         importClaudeBrowserCookiesAndRefreshIfNeeded()
@@ -210,6 +225,10 @@ final class AppEnvironment: ObservableObject {
                 }
             }
             .store(in: &cancellables)
+    }
+
+    deinit {
+        pricingRefreshTask?.cancel()
     }
 
     func account(for tool: ToolType) -> AccountIdentity? {

--- a/Sources/VibeBarCore/Services/CostUsageService.swift
+++ b/Sources/VibeBarCore/Services/CostUsageService.swift
@@ -92,6 +92,12 @@ public final class CostUsageService: ObservableObject {
             return
         }
 
+        // Adopt any pricing table PricingRefresher has written since the
+        // last pass. Swapping here — at the pass boundary, before any scan
+        // starts — keeps every scan below on one consistent table while
+        // letting new model rates land without an app relaunch.
+        PricingResolver.reloadIfChanged()
+
         var results: [ToolType: CostSnapshot] = [:]
         let home = homeDirectory
         for tool in ToolType.allCases where tool.supportsTokenCost {

--- a/Sources/VibeBarCore/Services/PricingRefresher.swift
+++ b/Sources/VibeBarCore/Services/PricingRefresher.swift
@@ -16,10 +16,11 @@ import Foundation
 /// `PricingDataSet.maxBytes`. Any failure leaves the previous cache in
 /// place instead of replacing it with garbage.
 ///
-/// Because `PricingResolver.cachedActive` snapshots on first read,
-/// a successful refresh only takes effect on the *next* app launch.
-/// That keeps cost calculations stable mid-process and avoids
-/// re-aggregating today's data with mid-flight rate changes.
+/// A successful refresh takes effect at the next cost re-scan:
+/// `CostUsageService.refreshAll()` re-adopts the rewritten cache via
+/// `PricingResolver.reloadIfChanged()` at the start of each pass — a
+/// pass boundary — so new rates land without an app relaunch while any
+/// single aggregation still runs against one consistent table.
 public enum PricingRefresher {
     /// Upstream source of truth: LiteLLM's
     /// `model_prices_and_context_window.json`. The bundled

--- a/Sources/VibeBarCore/Vendored/CostUsage/PricingResolver.swift
+++ b/Sources/VibeBarCore/Vendored/CostUsage/PricingResolver.swift
@@ -11,26 +11,35 @@ import Foundation
 ///     pathological case where the bundle resource is missing on
 ///     disk at runtime.
 ///
-/// The resolved data set is computed exactly once per process. The
-/// refresher mutates the on-disk cache asynchronously, but those
-/// updates only take effect on the *next* launch — keeps the
-/// in-memory pricing table immutable for the rest of the process
-/// lifetime and avoids re-running `CostUsageScanner` aggregations
-/// with mid-flight rate changes.
+/// The resolved data set is loaded lazily on first read and then held
+/// stable until `reloadIfChanged()` swaps it. The refresher mutates
+/// the on-disk cache asynchronously; `CostUsageService` re-adopts it
+/// at the start of each `refreshAll()` pass — a pass boundary, before
+/// any scan begins — so the table never changes inside a single
+/// `CostUsageScanner` aggregation but new model rates still land
+/// without an app relaunch.
 public enum PricingResolver {
     /// Override hook for tests. When set, `active` returns this
     /// instead of reading the cache / bundle. Reset to `nil` in the
     /// `tearDown` of any suite that touches it.
     public static var testOverride: PricingDataSet?
 
+    /// Guards `loadedState`. `active` is read from detached cost-scan
+    /// tasks while `reloadIfChanged` swaps on the main actor — the
+    /// previous `static let` got its thread safety from the runtime's
+    /// one-time initialization, a mutable table needs a real lock.
+    private static let stateLock = NSLock()
+    private static var loadedState: PricingDataSet?
+
     public static var active: PricingDataSet {
         if let testOverride { return testOverride }
-        return cachedActive
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        if let loadedState { return loadedState }
+        let resolved = resolve(homeDirectory: RealHomeDirectory.path)
+        loadedState = resolved
+        return resolved
     }
-
-    private static let cachedActive: PricingDataSet = resolve(
-        homeDirectory: RealHomeDirectory.path
-    )
 
     /// Test-friendly entry point. Production code path goes through
     /// `active` which uses the real home directory.
@@ -42,6 +51,34 @@ public enum PricingResolver {
             return bundled
         }
         return PricingHardcoded.fallback
+    }
+
+    /// Re-runs the cache → bundle → hardcoded resolution and swaps the
+    /// active table when the result differs from the one currently
+    /// loaded. Returns `true` only on a content swap (the first load of
+    /// the process is not a change). Call at aggregation-pass
+    /// boundaries only — `CostUsageService.refreshAll()` does — so any
+    /// single cost scan computes against one consistent table. No-op
+    /// while `testOverride` is set, keeping service-level tests pinned
+    /// to their injected rates.
+    @discardableResult
+    public static func reloadIfChanged(homeDirectory: String = RealHomeDirectory.path) -> Bool {
+        guard testOverride == nil else { return false }
+        let fresh = resolve(homeDirectory: homeDirectory)
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        let changed = loadedState != nil && loadedState != fresh
+        loadedState = fresh
+        return changed
+    }
+
+    /// Test hook: drop the loaded table so the next `active` read
+    /// re-resolves from disk. Keeps reload tests from leaking a temp
+    /// home's pricing into later suites.
+    static func forgetCachedStateForTests() {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        loadedState = nil
     }
 
     public static func cacheFileURL(homeDirectory: String) -> URL {

--- a/Tests/VibeBarCoreTests/PricingResolverTests.swift
+++ b/Tests/VibeBarCoreTests/PricingResolverTests.swift
@@ -151,4 +151,98 @@ final class PricingResolverTests: XCTestCase {
         defer { PricingResolver.testOverride = nil }
         XCTAssertEqual(PricingResolver.active.updatedAt, "test-override")
     }
+
+    // MARK: - reloadIfChanged (hot reload without relaunch)
+
+    /// A data set distinguishable from anything the real machine or the
+    /// bundle could provide: a sentinel Claude model whose output rate
+    /// varies per call site.
+    private func hotReloadDataSet(updatedAt: String, sentinelOutput: Double) -> PricingDataSet {
+        let base = PricingHardcoded.fallback
+        var claudeModels = base.providers.claude.models
+        claudeModels["test-hot-reload-sentinel"] = PricingDataSet.ClaudeEntry(
+            input: 0.000001,
+            output: sentinelOutput,
+            cacheCreation: 0.00000125,
+            cacheRead: 0.0000001
+        )
+        return PricingDataSet(
+            schemaVersion: PricingDataSet.currentSchemaVersion,
+            updatedAt: updatedAt,
+            calculationVersion: base.calculationVersion,
+            providers: PricingDataSet.Providers(
+                codex: base.providers.codex,
+                claude: PricingDataSet.ProviderTable(
+                    displayName: base.providers.claude.displayName,
+                    models: claudeModels
+                ),
+                gemini: base.providers.gemini,
+                grok: base.providers.grok,
+                antigravity: base.providers.antigravity
+            )
+        )
+    }
+
+    func testReloadIfChangedAdoptsRewrittenCacheWithoutRelaunch() throws {
+        let home = try makeTempHome()
+        PricingResolver.forgetCachedStateForTests()
+        defer {
+            PricingResolver.forgetCachedStateForTests()
+            cleanup(home)
+        }
+
+        try writeCache(to: home, dataSet: hotReloadDataSet(updatedAt: "2099-01-01", sentinelOutput: 0.00005))
+        // First load primes the table; nothing was loaded before, so it
+        // does not count as a change.
+        XCTAssertFalse(PricingResolver.reloadIfChanged(homeDirectory: home.path))
+        XCTAssertEqual(PricingResolver.active.updatedAt, "2099-01-01")
+
+        // Simulate PricingRefresher rewriting the cache mid-process.
+        try writeCache(to: home, dataSet: hotReloadDataSet(updatedAt: "2099-01-02", sentinelOutput: 0.0001))
+        XCTAssertTrue(PricingResolver.reloadIfChanged(homeDirectory: home.path))
+        XCTAssertEqual(PricingResolver.active.updatedAt, "2099-01-02")
+        XCTAssertEqual(
+            PricingResolver.active.providers.claude.models["test-hot-reload-sentinel"]?.output,
+            0.0001
+        )
+    }
+
+    func testReloadIfChangedReportsNoChangeForIdenticalCache() throws {
+        let home = try makeTempHome()
+        PricingResolver.forgetCachedStateForTests()
+        defer {
+            PricingResolver.forgetCachedStateForTests()
+            cleanup(home)
+        }
+
+        try writeCache(to: home, dataSet: hotReloadDataSet(updatedAt: "2099-01-01", sentinelOutput: 0.00005))
+        _ = PricingResolver.reloadIfChanged(homeDirectory: home.path)
+        XCTAssertFalse(PricingResolver.reloadIfChanged(homeDirectory: home.path))
+        // The already-loaded table stays active either way.
+        XCTAssertEqual(PricingResolver.active.updatedAt, "2099-01-01")
+    }
+
+    func testReloadIfChangedIsNoOpUnderTestOverride() throws {
+        let home = try makeTempHome()
+        PricingResolver.forgetCachedStateForTests()
+        defer {
+            PricingResolver.testOverride = nil
+            PricingResolver.forgetCachedStateForTests()
+            cleanup(home)
+        }
+
+        PricingResolver.testOverride = PricingDataSet(
+            schemaVersion: 1,
+            updatedAt: "test-override",
+            calculationVersion: 1,
+            providers: PricingHardcoded.fallback.providers
+        )
+        try writeCache(to: home, dataSet: hotReloadDataSet(updatedAt: "2099-01-03", sentinelOutput: 0.00005))
+        XCTAssertFalse(PricingResolver.reloadIfChanged(homeDirectory: home.path))
+        XCTAssertEqual(PricingResolver.active.updatedAt, "test-override")
+
+        // Dropping the override must not reveal a leaked temp-home table.
+        PricingResolver.testOverride = nil
+        XCTAssertNotEqual(PricingResolver.active.updatedAt, "2099-01-03")
+    }
 }


### PR DESCRIPTION
## Why

When a brand-new model ships (e.g. `claude-fable-5` on 2026-06-10), its usage showed **$0** in the Claude Cost card until Vibe Bar was relaunched **twice**:

1. `PricingRefresher.refresh()` ran once per process at startup, so a menu-bar app that stays up for days never re-fetched — `~/.vibebar/pricing_cache.json` was observed stuck at Jun 8 while the app ran through Jun 10.
2. `PricingResolver` snapshotted the pricing table once per process, so even a successful fetch only took effect on the *next* launch.
3. Unknown models silently fall back to `?? 0` in `CostUsageScanner`.

## What

- **PricingResolver**: hold the loaded table behind an `NSLock` and add `reloadIfChanged()`, which re-runs the cache → bundle → hardcoded resolution and swaps the table when the content differs. Plus an internal test hook to drop the loaded state.
- **CostUsageService.refreshAll()**: re-adopt the on-disk cache at the start of each pass.
- **AppEnvironment**: turn the one-shot startup refresh into a long-lived utility loop — re-check every 6 hours (the 24-hour mtime window inside `PricingRefresher` reduces most wake-ups to a `stat()` call) and nudge a re-scan when a fetch lands a new table. Cancelled in `deinit`.

End-to-end: fetch loop rewrites the cache → next `refreshAll()` pass (pricing-nudged, scheduler tick, wake, or manual rescan) adopts it → new model prices correctly, no relaunch.

## Invariants kept

- **One consistent table per aggregation pass.** The swap happens only at the pass boundary on the main actor; scans only run inside `refreshAll()`, which is non-reentrant (`isRefreshing` guard). This preserves the property the old snapshot-once design existed to protect, at pass granularity instead of process granularity.
- **`calculationVersion` untouched** — routine price updates must not wipe cost history (see 346dc42). The scan cache stores raw tokens only, so the next pass recomputes costs with new rates, and `CostHistoryStore`'s per-day max-merge backfills upward automatically.
- **`testOverride` still wins everywhere**; `reloadIfChanged()` is a no-op under it so service-level tests stay pinned to injected rates.

## Not included

Surfacing "unpriced model" in the UI instead of a silent $0 row — possible follow-up; with this change the unpriced window shrinks from "until two relaunches" to at most one fetch-poll + one re-scan cycle.

## Validation

- `swift build` ✓
- `swift test` — 536 tests, 0 failures (3 new `PricingResolverTests`, written red→green)
- `./Scripts/build_app.sh release` ✓
- `codesign -d --entitlements -` → empty `<dict/>`, no `app-sandbox` key ✓
- `codesign --verify --deep --strict` ✓
- home-API grep guard: hits only inside `RealHomeDirectory.swift` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)