### PR TITLE
Track Gemini usage via AntiGravity .db scan and language-server RPC

### DIFF
--- a/Sources/VibeBarApp/Views/PopoverRoot.swift
+++ b/Sources/VibeBarApp/Views/PopoverRoot.swift
@@ -443,16 +443,24 @@ private struct OverviewWaterfall: View {
                 // (`GeminiCombinedCard`). Grok stays on its own card.
                 GeminiCombinedCard(density: density)
                 ProviderQuotaCard(tool: .grok, density: density, compact: false)
-                // Google AI (Gemini + Antigravity) cost is intentionally
-                // omitted while the IDE/CLI cost story is incomplete
-                // (`~/.gemini/antigravity-cli/conversations/*.pb` is
-                // encrypted and the IDE side mixes Google-vs-third-party
-                // model rates that we haven't validated end-to-end). The
-                // dedicated Google AI sub-page surfaces a placeholder
-                // explaining the gap.
                 ForEach(overviewCostProviders, id: \.self) { tool in
                     OverviewCostCard(tool: tool, density: density)
                 }
+                // Google AI (Gemini + AntiGravity) cost, surfaced as the
+                // single "Gemini" platform aligned with the other three.
+                // AntiGravity is now the only live Google/Gemini usage
+                // source (Gemini CLI no longer writes local telemetry);
+                // its `.pb`-only cascades are filled via the
+                // language-server RPC in CostUsageScanner.scanAntigravity.
+                OverviewCostCard(
+                    tool: .antigravity,
+                    density: density,
+                    snapshotOverride: googleAICostSnapshot,
+                    titleOverride: "Gemini Cost",
+                    emptyMessageOverride: "No Gemini / AntiGravity usage yet — open AntiGravity once so Vibe Bar can sync it.",
+                    toolNameOverride: "Gemini",
+                    heatmapTitleOverride: "When you use Gemini"
+                )
                 if hasCostData {
                     ModelRankingList(
                         breakdowns: combinedModels,
@@ -474,19 +482,33 @@ private struct OverviewWaterfall: View {
         }
     }
 
-    /// Cost providers that contribute to the overview totals and the
-    /// per-provider OverviewCostCard. Google AI (Gemini + Antigravity)
-    /// is deliberately excluded while the local cost story is
-    /// incomplete — see the GoogleAIDualPage right column for the
-    /// user-facing explanation.
+    /// Cost providers rendered as their own per-provider
+    /// `OverviewCostCard` in the grid. Google AI is rendered separately
+    /// (combined Gemini + AntiGravity) via `googleAICostSnapshot`, so it
+    /// isn't listed here.
     private var overviewCostProviders: [ToolType] {
         [.codex, .claude, .grok]
     }
 
+    /// Combined Gemini + AntiGravity cost, surfaced as the single
+    /// "Gemini" (Google AI) platform. Gemini CLI no longer writes local
+    /// usage, so in practice this is the AntiGravity IDE/CLI data; the
+    /// combine keeps any residual Gemini telemetry counted too. Returns
+    /// an empty snapshot (no files) when neither has data, which the
+    /// card renders as an empty state.
+    private var googleAICostSnapshot: CostSnapshot {
+        let parts = ToolType.googleAIPair.compactMap { environment.costService.snapshot(for: $0) }
+        return CostSnapshotAggregator.combinedSnapshot(tool: .antigravity, snapshots: parts)
+    }
+
+    /// Snapshots feeding the "All providers" rollups (model ranking,
+    /// heatmaps). Includes the combined Google AI snapshot when it has
+    /// data so Gemini / AntiGravity usage shows up there too.
     private var overviewCostSnapshots: [CostSnapshot] {
-        overviewCostProviders.compactMap { tool in
-            environment.costService.snapshot(for: tool)
-        }
+        var snaps = overviewCostProviders.compactMap { environment.costService.snapshot(for: $0) }
+        let googleAI = googleAICostSnapshot
+        if googleAI.jsonlFilesFound > 0 { snaps.append(googleAI) }
+        return snaps
     }
 }
 
@@ -689,7 +711,7 @@ private struct GeminiTabPage: View {
                 alignment: .topLeading
             )
 
-            GeminiComingSoonCard(density: density)
+            GeminiCostColumn(density: density)
                 .frame(minWidth: geminiRightColumnMinWidth, maxWidth: .infinity, alignment: .topLeading)
         }
     }
@@ -711,13 +733,40 @@ private struct GeminiTabPage: View {
     }
 }
 
-/// Right-column placeholder on the Gemini sub-page. Mirrors the
-/// shape of the OpenAI/Claude cost panels (rounded card, padded
-/// section title) so the dedicated Gemini page reads the same as
-/// the other primary sub-pages while the cost story is still
-/// blocked on the encrypted `.pb` conversation files and unverified
-/// IDE-side rates.
-private struct GeminiComingSoonCard: View {
+/// Right-column cost panel on the Gemini sub-page: the combined
+/// Gemini + AntiGravity cost, presented as one "Gemini" surface so the
+/// page matches the OpenAI / Claude sub-page cost columns. AntiGravity
+/// is the live Google/Gemini usage source today; the data comes from
+/// `CostUsageScanner.scanAntigravity` (offline `.db` + language-server
+/// RPC for the encrypted `.pb` cascades).
+private struct GeminiCostColumn: View {
+    let density: Theme.Density
+
+    @EnvironmentObject var environment: AppEnvironment
+
+    var body: some View {
+        let parts = ToolType.googleAIPair.compactMap { environment.costService.snapshot(for: $0) }
+        let snapshot = CostSnapshotAggregator.combinedSnapshot(tool: .antigravity, snapshots: parts)
+        if snapshot.jsonlFilesFound > 0 {
+            ProviderCostStack(
+                tool: .antigravity,
+                snapshot: snapshot,
+                density: density,
+                titleOverride: "Gemini Cost",
+                toolNameOverride: "Gemini",
+                heatmapTitleOverride: "When you use Gemini"
+            )
+        } else {
+            GeminiCostEmptyCard(density: density)
+        }
+    }
+}
+
+/// Empty state for the Gemini sub-page cost column. AntiGravity's
+/// `.pb`-only cascades are fetched from the running language server, so
+/// the first sync needs AntiGravity open; the result is then cached and
+/// survives Antigravity quitting.
+private struct GeminiCostEmptyCard: View {
     let density: Theme.Density
 
     var body: some View {
@@ -726,7 +775,7 @@ private struct GeminiComingSoonCard: View {
                 ProviderSectionTitle(
                     tool: .gemini,
                     title: "\(ToolType.gemini.productName) Cost",
-                    subtitle: "Coming soon",
+                    subtitle: "No usage yet",
                     titleFontSize: density.titleFontSize,
                     subtitleFontSize: density.subtitleFontSize,
                     iconSize: 16,
@@ -735,10 +784,10 @@ private struct GeminiComingSoonCard: View {
                 Spacer(minLength: 4)
             }
             VStack(alignment: .leading, spacing: 6) {
-                Text("Cost tracking for Gemini Web + AntiGravity is on the roadmap but not yet accurate enough to surface.")
+                Text("No Gemini or AntiGravity usage found yet.")
                     .font(.system(size: density.subtitleFontSize))
                     .foregroundStyle(.secondary)
-                Text("AntiGravity CLI conversations live in encrypted `.pb` files we can't yet parse, and the IDE-side pricing mixes Google-owned and third-party model rates we haven't validated end-to-end. Quota readings on the left are unaffected.")
+                Text("AntiGravity is the live Google/Gemini source. Open AntiGravity at least once while Vibe Bar is running so it can sync cascade usage from the language server; cached results then persist after you quit it.")
                     .font(.system(size: max(10, density.subtitleFontSize - 1)))
                     .foregroundStyle(.tertiary)
                     .lineLimit(nil)
@@ -805,12 +854,11 @@ private struct CombinedTotalsRow: View {
     private let summaryHeight: CGFloat = 178
 
     var body: some View {
-        // Skip Google AI snapshots here so the headline totals don't
-        // get polluted by unreliable Gemini/Antigravity cost numbers.
-        // See OverviewWaterfall.overviewCostProviders for the parallel
-        // exclusion in the per-provider cost grid.
+        // Headline totals span every cost-aware provider, including
+        // Google AI (Gemini + AntiGravity): AntiGravity usage is now
+        // captured offline (`.db`) and via the language-server RPC
+        // (`.pb`), so it's reliable enough to roll up here.
         let snapshots = ToolType.costAwareProviders
-            .filter { !ToolType.googleAIPair.contains($0) }
             .compactMap { environment.costService.snapshot(for: $0) }
         let dailyHistory = CostSnapshotAggregator.combinedDailyHistory(snapshots)
         let totalCost = snapshots.reduce(0.0) { $0 + $1.allTimeCostUSD }

--- a/Sources/VibeBarCore/Adapters/AntigravityLanguageServerClient.swift
+++ b/Sources/VibeBarCore/Adapters/AntigravityLanguageServerClient.swift
@@ -1,0 +1,313 @@
+import Foundation
+
+/// Shared client for talking to a locally-running AntiGravity language
+/// server.
+///
+/// Discovers the server process (`/bin/ps`), parses its CSRF token and
+/// extension flags out of the command line, finds its listening TCP
+/// ports (`/usr/sbin/lsof`), builds candidate endpoints, and POSTs
+/// ConnectRPC-style JSON to a localhost path guarded by
+/// `X-Codeium-Csrf-Token`.
+///
+/// Extracted from `AntigravityQuotaAdapter` so two callers can share one
+/// probe + transport:
+///   1. live quota — `GetUserStatus` (`AntigravityQuotaAdapter`)
+///   2. historical cost — `GetCascadeTrajectoryGeneratorMetadata`
+///      (`AntigravityCascadeUsageFetcher`, used by `CostUsageScanner`
+///      for the encrypted `.pb` conversations we can't decode offline)
+///
+/// The self-signed language-server cert is trusted only for
+/// `127.0.0.1` / `localhost` (`AntigravityLocalhostTrustPolicy`).
+struct AntigravityLanguageServerClient {
+    let timeout: TimeInterval
+
+    init(timeout: TimeInterval = 8) {
+        self.timeout = timeout
+    }
+
+    struct ProcessInfo {
+        let pid: Int
+        let csrfToken: String
+        let extensionPort: Int?
+        let extensionCSRFToken: String?
+    }
+
+    struct Endpoint: Equatable {
+        let scheme: String
+        let port: Int
+        let csrfToken: String
+    }
+
+    /// Substring that every AntiGravity language-server process name
+    /// must contain. AntiGravity IDE 1.x shipped the binary as
+    /// `language_server_macos`; v2.0.x renamed it to plain
+    /// `language_server`. The loose substring works for both — the
+    /// `isAntigravityCommand` filter below narrows it to the right
+    /// process when other vendors ship a `language_server` of their own.
+    private static let processNameSubstring = "language_server"
+
+    // MARK: - High-level
+
+    /// Detect the running server and return its candidate endpoints.
+    /// Throws `QuotaError.noCredential` when Antigravity isn't running.
+    func connectedEndpoints() async throws -> [Endpoint] {
+        let process = try await detectProcessInfo()
+        let ports = try await listeningPorts(pid: process.pid)
+        return endpointCandidates(for: process, ports: ports)
+    }
+
+    // MARK: - Process detection
+
+    func detectProcessInfo() async throws -> ProcessInfo {
+        let result: ProcessRunner.Result
+        do {
+            result = try await ProcessRunner.run(
+                binary: "/bin/ps",
+                arguments: ["-ax", "-o", "pid=,command="],
+                timeout: timeout,
+                label: "antigravity-ps"
+            )
+        } catch {
+            throw QuotaError.unknown("Could not list processes: \(error.localizedDescription)")
+        }
+
+        var foundAntigravity = false
+        for line in result.stdout.split(separator: "\n") {
+            guard let match = AntigravityProcessLine.parse(String(line)) else { continue }
+            let lower = match.command.lowercased()
+            guard Self.matchesAntigravityProcess(lowercasedCommand: lower) else { continue }
+            foundAntigravity = true
+            guard let csrf = extractFlag("--csrf_token", from: match.command) else { continue }
+            return ProcessInfo(
+                pid: match.pid,
+                csrfToken: csrf,
+                extensionPort: extractFlag("--extension_server_port", from: match.command).flatMap { Int($0) },
+                extensionCSRFToken: extractFlag("--extension_server_csrf_token", from: match.command)
+            )
+        }
+        if foundAntigravity {
+            throw QuotaError.parseFailure("Antigravity is running but its CSRF token is missing — restart Antigravity and retry.")
+        }
+        throw QuotaError.noCredential
+    }
+
+    /// Whether a process-list line looks like an AntiGravity language
+    /// server. Combines the loose `language_server` binary-name match
+    /// with the AntiGravity-specific path or flag check so unrelated
+    /// vendors that also ship a `language_server` binary don't get
+    /// picked up.
+    static func matchesAntigravityProcess(lowercasedCommand command: String) -> Bool {
+        guard command.contains(processNameSubstring) else { return false }
+        return isAntigravityCommand(command)
+    }
+
+    static func isAntigravityCommand(_ command: String) -> Bool {
+        if command.contains("--app_data_dir") && command.contains("antigravity") { return true }
+        if command.contains("/antigravity/") || command.contains("\\antigravity\\") { return true }
+        return false
+    }
+
+    private func extractFlag(_ flag: String, from command: String) -> String? {
+        let pattern = "\(NSRegularExpression.escapedPattern(for: flag))[=\\s]+([^\\s]+)"
+        guard let regex = try? NSRegularExpression(pattern: pattern, options: .caseInsensitive) else {
+            return nil
+        }
+        let range = NSRange(command.startIndex..<command.endIndex, in: command)
+        guard let match = regex.firstMatch(in: command, options: [], range: range),
+              let captured = Range(match.range(at: 1), in: command) else {
+            return nil
+        }
+        return String(command[captured])
+    }
+
+    // MARK: - Port detection
+
+    func listeningPorts(pid: Int) async throws -> [Int] {
+        let lsof = ["/usr/sbin/lsof", "/usr/bin/lsof"]
+            .first(where: { FileManager.default.isExecutableFile(atPath: $0) })
+        guard let lsof else {
+            throw QuotaError.unknown("`lsof` not available; cannot probe Antigravity ports.")
+        }
+        let result: ProcessRunner.Result
+        do {
+            result = try await ProcessRunner.run(
+                binary: lsof,
+                arguments: ["-nP", "-iTCP", "-sTCP:LISTEN", "-a", "-p", String(pid)],
+                timeout: timeout,
+                label: "antigravity-lsof"
+            )
+        } catch {
+            throw QuotaError.unknown("lsof failed: \(error.localizedDescription)")
+        }
+        let ports = parseListeningPorts(result.stdout)
+        guard !ports.isEmpty else {
+            throw QuotaError.parseFailure("Antigravity is running but no listening ports found yet — wait a few seconds and retry.")
+        }
+        return ports
+    }
+
+    func parseListeningPorts(_ output: String) -> [Int] {
+        guard let regex = try? NSRegularExpression(pattern: #":(\d+)\s+\(LISTEN\)"#) else { return [] }
+        let range = NSRange(output.startIndex..<output.endIndex, in: output)
+        var ports: Set<Int> = []
+        regex.enumerateMatches(in: output, options: [], range: range) { match, _, _ in
+            guard let match,
+                  let captured = Range(match.range(at: 1), in: output),
+                  let port = Int(output[captured]) else { return }
+            ports.insert(port)
+        }
+        return ports.sorted()
+    }
+
+    // MARK: - Endpoint candidates
+
+    func endpointCandidates(for info: ProcessInfo, ports: [Int]) -> [Endpoint] {
+        var endpoints: [Endpoint] = ports.map {
+            Endpoint(scheme: "https", port: $0, csrfToken: info.csrfToken)
+        }
+        // Extension server is plain HTTP and may be on a separate port
+        // with its own CSRF token. Append both shapes if we have them.
+        if let extPort = info.extensionPort {
+            if let extCSRF = info.extensionCSRFToken,
+               !endpoints.contains(where: { $0.port == extPort && $0.csrfToken == extCSRF }) {
+                endpoints.append(Endpoint(scheme: "http", port: extPort, csrfToken: extCSRF))
+            }
+            if !endpoints.contains(where: { $0.port == extPort && $0.csrfToken == info.csrfToken }) {
+                endpoints.append(Endpoint(scheme: "http", port: extPort, csrfToken: info.csrfToken))
+            }
+        }
+        return endpoints
+    }
+
+    // MARK: - HTTP
+
+    func postLocal(
+        endpoint: Endpoint,
+        path: String,
+        body: Data
+    ) async throws -> Data {
+        guard let url = URL(string: "\(endpoint.scheme)://127.0.0.1:\(endpoint.port)\(path)") else {
+            throw QuotaError.unknown("Antigravity: invalid URL")
+        }
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.httpBody = body
+        request.timeoutInterval = timeout
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue(String(body.count), forHTTPHeaderField: "Content-Length")
+        request.setValue("1", forHTTPHeaderField: "Connect-Protocol-Version")
+        request.setValue(endpoint.csrfToken, forHTTPHeaderField: "X-Codeium-Csrf-Token")
+
+        let config = URLSessionConfiguration.ephemeral
+        config.timeoutIntervalForRequest = timeout
+        config.timeoutIntervalForResource = timeout
+        config.waitsForConnectivity = false
+
+        let delegate = AntigravityLocalhostSessionDelegate()
+        let session = URLSession(configuration: config, delegate: delegate, delegateQueue: nil)
+        defer { session.invalidateAndCancel() }
+
+        let (data, response) = try await delegate.data(for: request, session: session)
+        guard let http = response as? HTTPURLResponse else {
+            throw QuotaError.network("Antigravity: invalid response object")
+        }
+        guard http.statusCode == 200 else {
+            if http.statusCode == 401 || http.statusCode == 403 {
+                throw QuotaError.needsLogin
+            }
+            // The language server returns HTTP 500 with `code: unknown`
+            // + `error getting token source` when the user is signed out
+            // of AntiGravity itself. Surface that as needsLogin so the
+            // card shows a sign-in hint instead of a generic error.
+            if let body = String(data: data, encoding: .utf8),
+               body.contains("token source") || body.contains("not authenticated") {
+                throw QuotaError.needsLogin
+            }
+            throw QuotaError.network("Antigravity HTTP \(http.statusCode)")
+        }
+        return data
+    }
+}
+
+// MARK: - Process line parser
+
+struct AntigravityProcessLine {
+    let pid: Int
+    let command: String
+
+    static func parse(_ line: String) -> AntigravityProcessLine? {
+        let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        let parts = trimmed.split(separator: " ", maxSplits: 1, omittingEmptySubsequences: true)
+        guard parts.count == 2, let pid = Int(parts[0]) else { return nil }
+        return AntigravityProcessLine(pid: pid, command: String(parts[1]))
+    }
+}
+
+// MARK: - Localhost trust policy
+
+enum AntigravityLocalhostTrustPolicy {
+    /// Returns `true` only for localhost / 127.0.0.1 + ServerTrust.
+    /// Codexbar's policy verbatim.
+    static func shouldAcceptServerTrust(
+        host: String,
+        authenticationMethod: String,
+        hasServerTrust: Bool
+    ) -> Bool {
+        guard authenticationMethod == NSURLAuthenticationMethodServerTrust else { return false }
+        let normalised = host.lowercased()
+        guard normalised == "127.0.0.1" || normalised == "localhost" else { return false }
+        return hasServerTrust
+    }
+}
+
+private final class AntigravityLocalhostSessionDelegate: NSObject, URLSessionDelegate, URLSessionTaskDelegate {
+    func data(
+        for request: URLRequest,
+        session: URLSession
+    ) async throws -> (Data, URLResponse) {
+        try await withCheckedThrowingContinuation { continuation in
+            let task = session.dataTask(with: request) { data, response, error in
+                if let error {
+                    continuation.resume(throwing: error)
+                    return
+                }
+                guard let data, let response else {
+                    continuation.resume(throwing: QuotaError.network("Antigravity: empty response"))
+                    return
+                }
+                continuation.resume(returning: (data, response))
+            }
+            task.resume()
+        }
+    }
+
+    private func challengeResult(
+        _ challenge: URLAuthenticationChallenge
+    ) -> (URLSession.AuthChallengeDisposition, URLCredential?) {
+        let space = challenge.protectionSpace
+        guard AntigravityLocalhostTrustPolicy.shouldAcceptServerTrust(
+            host: space.host,
+            authenticationMethod: space.authenticationMethod,
+            hasServerTrust: space.serverTrust != nil
+        ), let trust = space.serverTrust else {
+            return (.performDefaultHandling, nil)
+        }
+        return (.useCredential, URLCredential(trust: trust))
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        didReceive challenge: URLAuthenticationChallenge
+    ) async -> (URLSession.AuthChallengeDisposition, URLCredential?) {
+        challengeResult(challenge)
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        task: URLSessionTask,
+        didReceive challenge: URLAuthenticationChallenge
+    ) async -> (URLSession.AuthChallengeDisposition, URLCredential?) {
+        challengeResult(challenge)
+    }
+}

--- a/Sources/VibeBarCore/Adapters/AntigravityQuotaAdapter.swift
+++ b/Sources/VibeBarCore/Adapters/AntigravityQuotaAdapter.swift
@@ -1,38 +1,16 @@
 import Foundation
 
-/// Google AntiGravity (local language-server) usage adapter.
+/// Google AntiGravity (local language-server) live-quota adapter.
 ///
-/// Auth flow has no remote credential — we discover the locally
-/// running AntiGravity language-server process, parse its CSRF
-/// tokens out of the command line, find its listening TCP ports
-/// via lsof, then POST to a localhost HTTPS endpoint protected by
-/// `X-Codeium-Csrf-Token`.
-///
-/// Step-by-step:
-/// 1. `/bin/ps -ax -o pid=,command=` → look for any `language_server`
-///    process with `--app_data_dir` containing `antigravity` (or
-///    path contains `antigravity`). AntiGravity IDE 1.x shipped the
-///    binary as `language_server_macos`; v2.0.x renamed it to plain
-///    `language_server`. The substring match here covers both.
-/// 2. From that command line, extract `--csrf_token`,
-///    `--extension_server_port`, `--extension_server_csrf_token`.
-/// 3. `/usr/sbin/lsof -nP -iTCP -sTCP:LISTEN -a -p <pid>` → set
-///    of listening ports.
-/// 4. Try the language-server endpoints first
-///    (`https://127.0.0.1:<port>` with the language-server CSRF),
-///    fall back to the extension-server endpoint
-///    (`http://127.0.0.1:<extension_port>` with the extension CSRF
-///    when present).
-/// 5. POST `/exa.language_server_pb.LanguageServerService/GetUserStatus`
-///    with `{}` body, `Content-Type: application/json`,
-///    `Connect-Protocol-Version: 1`, `X-Codeium-Csrf-Token: <token>`.
-/// 6. Parse the response into per-model `QuotaBucket`s and the
-///    plan name from `userTier.name` or `planStatus.planInfo`.
-///
-/// `URLSessionDelegate` accepts the language server's self-signed
-/// cert, but only when the protection-space host is exactly
-/// `127.0.0.1` or `localhost` — codexbar's
-/// `LocalhostTrustPolicy.shouldAcceptServerTrust` is the same.
+/// Auth flow has no remote credential — it discovers the locally
+/// running AntiGravity language-server process, parses its CSRF tokens
+/// and ports, then POSTs to a localhost HTTPS endpoint protected by
+/// `X-Codeium-Csrf-Token`. The discovery + transport now live in the
+/// shared `AntigravityLanguageServerClient`; this adapter only adds the
+/// `GetUserStatus` call and maps the response into `QuotaBucket`s and
+/// the plan name (`userTier.name` / `planStatus.planInfo`). The
+/// cost-scanner reuses the same client for the
+/// `GetCascadeTrajectoryGeneratorMetadata` call.
 public struct AntigravityQuotaAdapter: QuotaAdapter {
     public let tool: ToolType = .antigravity
 
@@ -50,14 +28,6 @@ public struct AntigravityQuotaAdapter: QuotaAdapter {
         self.usageModeProvider = usageMode ?? { Self.resolveUsageMode() }
     }
 
-    /// Substring that every AntiGravity language-server process name
-    /// must contain. AntiGravity IDE 1.x shipped the binary as
-    /// `language_server_macos`; v2.0.x renamed it to plain
-    /// `language_server`. The loose substring works for both — the
-    /// `isAntigravityCommand` filter below narrows it to the right
-    /// process when other vendors ship a `language_server` of their
-    /// own.
-    private static let processNameSubstring = "language_server"
     private static let userStatusPath =
         "/exa.language_server_pb.LanguageServerService/GetUserStatus"
 
@@ -93,15 +63,14 @@ public struct AntigravityQuotaAdapter: QuotaAdapter {
     }
 
     private func fetchWithLocalProbe(for account: AccountIdentity) async throws -> AccountQuota {
-        let process = try await detectProcessInfo()
-        let ports = try await listeningPorts(pid: process.pid)
-        let endpoints = endpointCandidates(for: process, ports: ports)
+        let client = AntigravityLanguageServerClient(timeout: timeout)
+        let endpoints = try await client.connectedEndpoints()
         let body = Data("{}".utf8)
 
         var lastError: Error?
         for endpoint in endpoints {
             do {
-                let data = try await postLocal(
+                let data = try await client.postLocal(
                     endpoint: endpoint,
                     path: AntigravityQuotaAdapter.userStatusPath,
                     body: body
@@ -135,281 +104,17 @@ public struct AntigravityQuotaAdapter: QuotaAdapter {
         return appSettings.antigravityUsageMode
     }
 
-    // MARK: - Process detection
-
-    struct ProcessInfo {
-        let pid: Int
-        let csrfToken: String
-        let extensionPort: Int?
-        let extensionCSRFToken: String?
-    }
-
-    private func detectProcessInfo() async throws -> ProcessInfo {
-        let result: ProcessRunner.Result
-        do {
-            result = try await ProcessRunner.run(
-                binary: "/bin/ps",
-                arguments: ["-ax", "-o", "pid=,command="],
-                timeout: timeout,
-                label: "antigravity-ps"
-            )
-        } catch {
-            throw QuotaError.unknown("Could not list processes: \(error.localizedDescription)")
-        }
-
-        var foundAntigravity = false
-        for line in result.stdout.split(separator: "\n") {
-            guard let match = AntigravityProcessLine.parse(String(line)) else { continue }
-            let lower = match.command.lowercased()
-            guard Self.matchesAntigravityProcess(lowercasedCommand: lower) else { continue }
-            foundAntigravity = true
-            guard let csrf = extractFlag("--csrf_token", from: match.command) else { continue }
-            return ProcessInfo(
-                pid: match.pid,
-                csrfToken: csrf,
-                extensionPort: extractFlag("--extension_server_port", from: match.command).flatMap { Int($0) },
-                extensionCSRFToken: extractFlag("--extension_server_csrf_token", from: match.command)
-            )
-        }
-        if foundAntigravity {
-            throw QuotaError.parseFailure("Antigravity is running but its CSRF token is missing — restart Antigravity and retry.")
-        }
-        throw QuotaError.noCredential
-    }
-
     /// Whether a process-list line looks like an AntiGravity language
-    /// server. Combines the loose `language_server` binary-name match
-    /// with the AntiGravity-specific path or flag check so unrelated
-    /// vendors that also ship a `language_server` binary don't get
-    /// picked up. Exposed at the package level so the parser tests can
-    /// lock in v1.x → v2.0.x process-name compatibility without going
-    /// through `ProcessRunner`.
+    /// server. Thin delegate to `AntigravityLanguageServerClient` so the
+    /// parser tests keep their original `AntigravityQuotaAdapter` entry
+    /// point now that the probe logic lives in the shared client.
     static func matchesAntigravityProcess(lowercasedCommand command: String) -> Bool {
-        guard command.contains(processNameSubstring) else { return false }
-        return isAntigravityCommand(command)
-    }
-
-    static func isAntigravityCommand(_ command: String) -> Bool {
-        if command.contains("--app_data_dir") && command.contains("antigravity") { return true }
-        if command.contains("/antigravity/") || command.contains("\\antigravity\\") { return true }
-        return false
-    }
-
-    private func extractFlag(_ flag: String, from command: String) -> String? {
-        let pattern = "\(NSRegularExpression.escapedPattern(for: flag))[=\\s]+([^\\s]+)"
-        guard let regex = try? NSRegularExpression(pattern: pattern, options: .caseInsensitive) else {
-            return nil
-        }
-        let range = NSRange(command.startIndex..<command.endIndex, in: command)
-        guard let match = regex.firstMatch(in: command, options: [], range: range),
-              let captured = Range(match.range(at: 1), in: command) else {
-            return nil
-        }
-        return String(command[captured])
-    }
-
-    // MARK: - Port detection
-
-    private func listeningPorts(pid: Int) async throws -> [Int] {
-        let lsof = ["/usr/sbin/lsof", "/usr/bin/lsof"]
-            .first(where: { FileManager.default.isExecutableFile(atPath: $0) })
-        guard let lsof else {
-            throw QuotaError.unknown("`lsof` not available; cannot probe Antigravity ports.")
-        }
-        let result: ProcessRunner.Result
-        do {
-            result = try await ProcessRunner.run(
-                binary: lsof,
-                arguments: ["-nP", "-iTCP", "-sTCP:LISTEN", "-a", "-p", String(pid)],
-                timeout: timeout,
-                label: "antigravity-lsof"
-            )
-        } catch {
-            throw QuotaError.unknown("lsof failed: \(error.localizedDescription)")
-        }
-        let ports = parseListeningPorts(result.stdout)
-        guard !ports.isEmpty else {
-            throw QuotaError.parseFailure("Antigravity is running but no listening ports found yet — wait a few seconds and retry.")
-        }
-        return ports
-    }
-
-    private func parseListeningPorts(_ output: String) -> [Int] {
-        guard let regex = try? NSRegularExpression(pattern: #":(\d+)\s+\(LISTEN\)"#) else { return [] }
-        let range = NSRange(output.startIndex..<output.endIndex, in: output)
-        var ports: Set<Int> = []
-        regex.enumerateMatches(in: output, options: [], range: range) { match, _, _ in
-            guard let match,
-                  let captured = Range(match.range(at: 1), in: output),
-                  let port = Int(output[captured]) else { return }
-            ports.insert(port)
-        }
-        return ports.sorted()
-    }
-
-    // MARK: - Endpoint candidates
-
-    struct Endpoint: Equatable {
-        let scheme: String
-        let port: Int
-        let csrfToken: String
-    }
-
-    private func endpointCandidates(for info: ProcessInfo, ports: [Int]) -> [Endpoint] {
-        var endpoints: [Endpoint] = ports.map {
-            Endpoint(scheme: "https", port: $0, csrfToken: info.csrfToken)
-        }
-        // Extension server is plain HTTP and may be on a separate
-        // port with its own CSRF token. Append both shapes if we
-        // have them.
-        if let extPort = info.extensionPort {
-            if let extCSRF = info.extensionCSRFToken,
-               !endpoints.contains(where: { $0.port == extPort && $0.csrfToken == extCSRF }) {
-                endpoints.append(Endpoint(scheme: "http", port: extPort, csrfToken: extCSRF))
-            }
-            if !endpoints.contains(where: { $0.port == extPort && $0.csrfToken == info.csrfToken }) {
-                endpoints.append(Endpoint(scheme: "http", port: extPort, csrfToken: info.csrfToken))
-            }
-        }
-        return endpoints
-    }
-
-    // MARK: - HTTP
-
-    private func postLocal(
-        endpoint: Endpoint,
-        path: String,
-        body: Data
-    ) async throws -> Data {
-        guard let url = URL(string: "\(endpoint.scheme)://127.0.0.1:\(endpoint.port)\(path)") else {
-            throw QuotaError.unknown("Antigravity: invalid URL")
-        }
-        var request = URLRequest(url: url)
-        request.httpMethod = "POST"
-        request.httpBody = body
-        request.timeoutInterval = timeout
-        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.setValue(String(body.count), forHTTPHeaderField: "Content-Length")
-        request.setValue("1", forHTTPHeaderField: "Connect-Protocol-Version")
-        request.setValue(endpoint.csrfToken, forHTTPHeaderField: "X-Codeium-Csrf-Token")
-
-        let config = URLSessionConfiguration.ephemeral
-        config.timeoutIntervalForRequest = timeout
-        config.timeoutIntervalForResource = timeout
-        config.waitsForConnectivity = false
-
-        let delegate = LocalhostSessionDelegate()
-        let session = URLSession(configuration: config, delegate: delegate, delegateQueue: nil)
-        defer { session.invalidateAndCancel() }
-
-        let (data, response) = try await delegate.data(for: request, session: session)
-        guard let http = response as? HTTPURLResponse else {
-            throw QuotaError.network("Antigravity: invalid response object")
-        }
-        guard http.statusCode == 200 else {
-            if http.statusCode == 401 || http.statusCode == 403 {
-                throw QuotaError.needsLogin
-            }
-            // The language server returns HTTP 500 with
-            // `code: unknown` + `error getting token source` when
-            // the user is signed out of AntiGravity itself. Surface
-            // that as needsLogin so the misc card shows a sign-in
-            // hint instead of a generic network error.
-            if let body = String(data: data, encoding: .utf8),
-               body.contains("token source") || body.contains("not authenticated") {
-                throw QuotaError.needsLogin
-            }
-            throw QuotaError.network("Antigravity HTTP \(http.statusCode)")
-        }
-        return data
+        AntigravityLanguageServerClient.matchesAntigravityProcess(lowercasedCommand: command)
     }
 
     private func mapError(_ error: Error?) -> QuotaError {
         if let qe = error as? QuotaError { return qe }
         return QuotaError.network(error?.localizedDescription ?? "Antigravity unreachable.")
-    }
-}
-
-// MARK: - Process line parser
-
-struct AntigravityProcessLine {
-    let pid: Int
-    let command: String
-
-    static func parse(_ line: String) -> AntigravityProcessLine? {
-        let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return nil }
-        let parts = trimmed.split(separator: " ", maxSplits: 1, omittingEmptySubsequences: true)
-        guard parts.count == 2, let pid = Int(parts[0]) else { return nil }
-        return AntigravityProcessLine(pid: pid, command: String(parts[1]))
-    }
-}
-
-// MARK: - Localhost trust policy
-
-enum AntigravityLocalhostTrustPolicy {
-    /// Returns `true` only for localhost / 127.0.0.1 + ServerTrust.
-    /// Codexbar's policy verbatim.
-    static func shouldAcceptServerTrust(
-        host: String,
-        authenticationMethod: String,
-        hasServerTrust: Bool
-    ) -> Bool {
-        guard authenticationMethod == NSURLAuthenticationMethodServerTrust else { return false }
-        let normalised = host.lowercased()
-        guard normalised == "127.0.0.1" || normalised == "localhost" else { return false }
-        return hasServerTrust
-    }
-}
-
-private final class LocalhostSessionDelegate: NSObject, URLSessionDelegate, URLSessionTaskDelegate {
-    func data(
-        for request: URLRequest,
-        session: URLSession
-    ) async throws -> (Data, URLResponse) {
-        try await withCheckedThrowingContinuation { continuation in
-            let task = session.dataTask(with: request) { data, response, error in
-                if let error {
-                    continuation.resume(throwing: error)
-                    return
-                }
-                guard let data, let response else {
-                    continuation.resume(throwing: QuotaError.network("Antigravity: empty response"))
-                    return
-                }
-                continuation.resume(returning: (data, response))
-            }
-            task.resume()
-        }
-    }
-
-    private func challengeResult(
-        _ challenge: URLAuthenticationChallenge
-    ) -> (URLSession.AuthChallengeDisposition, URLCredential?) {
-        let space = challenge.protectionSpace
-        guard AntigravityLocalhostTrustPolicy.shouldAcceptServerTrust(
-            host: space.host,
-            authenticationMethod: space.authenticationMethod,
-            hasServerTrust: space.serverTrust != nil
-        ), let trust = space.serverTrust else {
-            return (.performDefaultHandling, nil)
-        }
-        return (.useCredential, URLCredential(trust: trust))
-    }
-
-    func urlSession(
-        _ session: URLSession,
-        didReceive challenge: URLAuthenticationChallenge
-    ) async -> (URLSession.AuthChallengeDisposition, URLCredential?) {
-        challengeResult(challenge)
-    }
-
-    func urlSession(
-        _ session: URLSession,
-        task: URLSessionTask,
-        didReceive challenge: URLAuthenticationChallenge
-    ) async -> (URLSession.AuthChallengeDisposition, URLCredential?) {
-        challengeResult(challenge)
     }
 }
 

--- a/Sources/VibeBarCore/Services/AntigravityCascadeUsageFetcher.swift
+++ b/Sources/VibeBarCore/Services/AntigravityCascadeUsageFetcher.swift
@@ -1,0 +1,169 @@
+import Foundation
+
+/// Fetches per-turn token usage for an AntiGravity *cascade*
+/// (conversation) from the locally-running language server.
+///
+/// Used by `CostUsageScanner` for the conversations whose only on-disk
+/// form is the encrypted `.pb` container we can't decode offline —
+/// unlike the `.db` SQLite blobs, which `AntigravitySessionReader`
+/// reads directly. Mirrors codeburn's approach: the `.pb`/`.db` files
+/// only yield the cascade id (their `<UUID>` filename); the
+/// authoritative token numbers come from a ConnectRPC call to
+/// `GetCascadeTrajectoryGeneratorMetadata` on the running server.
+///
+/// Results are cached by the scanner (keyed on the `.pb` file
+/// fingerprint), so a cascade fetched once while Antigravity is running
+/// keeps showing up after it quits.
+enum AntigravityCascadeUsageFetcher {
+    static let methodPath =
+        "/exa.language_server_pb.LanguageServerService/GetCascadeTrajectoryGeneratorMetadata"
+
+    /// One model turn pulled from the RPC response. `output` already
+    /// folds the thinking tokens in (Gemini / Claude bill reasoning at
+    /// the output rate), matching the `.db` decode path. The RPC does
+    /// not expose cache tokens, so the scanner records `cache = 0`.
+    struct Turn: Equatable {
+        let date: Date?
+        let model: String?
+        let input: Int
+        let output: Int
+        let responseId: String?
+    }
+
+    /// POST the cascade id to the running server (trying each candidate
+    /// endpoint) and parse the turns out of the response. Throws on
+    /// transport / parse failure so the scanner can fall back to its
+    /// cache.
+    static func fetchTurns(
+        cascadeId: String,
+        client: AntigravityLanguageServerClient,
+        endpoints: [AntigravityLanguageServerClient.Endpoint]
+    ) async throws -> [Turn] {
+        let body = try JSONSerialization.data(withJSONObject: ["cascadeId": cascadeId])
+        var lastError: Error?
+        for endpoint in endpoints {
+            do {
+                let data = try await client.postLocal(endpoint: endpoint, path: methodPath, body: body)
+                return parse(data: data)
+            } catch {
+                lastError = error
+                continue
+            }
+        }
+        throw lastError ?? QuotaError.network("Antigravity cascade RPC unreachable.")
+    }
+
+    // MARK: - Parsing
+    //
+    // The response is ConnectRPC JSON. The exact envelope key for the
+    // metadata array isn't documented, so the parser is deliberately
+    // lenient: it unwraps common wrappers, then takes the first
+    // array-of-objects whose elements look like generator metadata
+    // (carry `chatModel` / `usage`). Every field read is optional —
+    // a short or renamed payload yields fewer turns, never a throw.
+    // int64 fields arrive as JSON strings, so token values are parsed
+    // from strings as well as numbers.
+
+    static func parse(data: Data) -> [Turn] {
+        guard let root = try? JSONSerialization.jsonObject(with: data) else { return [] }
+        let entries = extractMetadataEntries(root)
+        var turns: [Turn] = []
+        var seenResponseIds: Set<String> = []
+        for entry in entries {
+            let chatModel = (entry["chatModel"] as? [String: Any])
+                ?? (entry["chat_model"] as? [String: Any])
+            let usage = (chatModel?["usage"] as? [String: Any])
+                ?? (entry["usage"] as? [String: Any])
+            guard let usage else { continue }
+
+            let input = asInt(usage["inputTokens"] ?? usage["input_tokens"]) ?? 0
+            let thinking = asInt(usage["thinkingOutputTokens"] ?? usage["thinking_output_tokens"]) ?? 0
+            let output: Int
+            if let response = asInt(usage["responseOutputTokens"] ?? usage["response_output_tokens"]) {
+                // Response + thinking are both billed at the output rate.
+                output = response + thinking
+            } else {
+                // No response/thinking split — `outputTokens` already is
+                // the full output for the turn.
+                output = asInt(usage["outputTokens"] ?? usage["output_tokens"]) ?? 0
+            }
+            guard input > 0 || output > 0 else { continue }
+
+            let responseId = (usage["responseId"] as? String) ?? (usage["response_id"] as? String)
+            if let responseId, !responseId.isEmpty {
+                if seenResponseIds.contains(responseId) { continue }
+                seenResponseIds.insert(responseId)
+            }
+
+            let model = normalized(usage["model"] as? String) ?? normalized(chatModel?["model"] as? String)
+            let date = startDate(from: chatModel)
+
+            turns.append(Turn(date: date, model: model, input: input, output: output, responseId: responseId))
+        }
+        return turns
+    }
+
+    /// Locate the array of generator-metadata objects inside an
+    /// arbitrary decoded JSON value.
+    static func extractMetadataEntries(_ node: Any) -> [[String: Any]] {
+        if let arr = node as? [[String: Any]] {
+            return arr
+        }
+        guard let dict = node as? [String: Any] else { return [] }
+
+        for key in ["generatorMetadata", "generator_metadata", "trajectoryGeneratorMetadata", "metadata"] {
+            if let arr = dict[key] as? [[String: Any]] { return arr }
+        }
+        for key in ["response", "result", "data"] {
+            if let inner = dict[key] {
+                let nested = extractMetadataEntries(inner)
+                if !nested.isEmpty { return nested }
+            }
+        }
+        // Last resort: first array-of-objects that looks like metadata.
+        for value in dict.values {
+            if let arr = value as? [[String: Any]],
+               arr.contains(where: { $0["chatModel"] != nil || $0["chat_model"] != nil || $0["usage"] != nil }) {
+                return arr
+            }
+        }
+        return []
+    }
+
+    private static func startDate(from chatModel: [String: Any]?) -> Date? {
+        let meta = (chatModel?["chatStartMetadata"] as? [String: Any])
+            ?? (chatModel?["chat_start_metadata"] as? [String: Any])
+        guard let raw = (meta?["createdAt"] as? String) ?? (meta?["created_at"] as? String) else {
+            return nil
+        }
+        return parseDate(raw)
+    }
+
+    private static func asInt(_ value: Any?) -> Int? {
+        if let n = value as? NSNumber { return n.intValue }
+        if let s = value as? String {
+            let trimmed = s.trimmingCharacters(in: .whitespaces)
+            if let i = Int(trimmed) { return i }
+            if let d = Double(trimmed) { return Int(d) }
+        }
+        return nil
+    }
+
+    private static func normalized(_ raw: String?) -> String? {
+        guard let value = raw?.trimmingCharacters(in: .whitespacesAndNewlines), !value.isEmpty else {
+            return nil
+        }
+        return value
+    }
+
+    private static func parseDate(_ raw: String) -> Date? {
+        let withFractional = ISO8601DateFormatter()
+        withFractional.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        if let d = withFractional.date(from: raw) { return d }
+        let plain = ISO8601DateFormatter()
+        plain.formatOptions = [.withInternetDateTime]
+        if let d = plain.date(from: raw) { return d }
+        if let seconds = Double(raw) { return Date(timeIntervalSince1970: seconds) }
+        return nil
+    }
+}

--- a/Sources/VibeBarCore/Services/CostUsageScanner.swift
+++ b/Sources/VibeBarCore/Services/CostUsageScanner.swift
@@ -875,92 +875,156 @@ public enum CostUsageScanner {
         return current ?? timeline.first?.model ?? fallback
     }
 
-    // MARK: - AntiGravity (per-trajectory SQLite + protobuf blobs)
+    // MARK: - AntiGravity (per-trajectory SQLite + protobuf blobs / live RPC)
     //
-    // The AntiGravity IDE writes one SQLite database per conversation
-    // under `~/.gemini/antigravity/conversations/<UUID>.db`. The
-    // `gen_metadata` table holds one row per model call; its `data`
-    // BLOB is a protobuf message we read with a raw varint scanner
-    // (no SwiftProtobuf dependency). Per-row token fields under path
-    // `1.4`:
+    // The AntiGravity IDE / CLI write one conversation file per cascade
+    // under `~/.gemini/antigravity{,-cli,-ide}/conversations/<UUID>.{db,pb}`.
+    //
+    // `.db` is a SQLite store whose `gen_metadata.data` BLOB is a
+    // protobuf message we decode offline with a raw varint scanner
+    // (`AntigravitySessionReader`, no SwiftProtobuf dependency). Per-row
+    // token fields under path `1.4`:
     //   - field 1: constant system-prompt size (cached after turn 1)
     //   - field 2: non-cached input tokens this turn
     //   - field 3: output tokens this turn
     //   - field 5: cumulative cache-read pool size
     //   - field 9: reasoning / thinking tokens (counted as output)
     //   - field 10: tool tokens (counted as output)
-    // Model id lives at path `1.19`.
-    // Timestamp lives at path `1.9.4` (seconds + nanos).
+    // Model id lives at path `1.19`, timestamp at `1.9.4` (sec + nanos).
     //
-    // The CLI-only `~/.gemini/antigravity-cli/conversations/*.pb`
-    // container is an unidentified binary format, and the companion
-    // transcript/history JSONL files do not carry token counts. CLI-only
-    // AntiGravity usage stays dark until that format is reverse-engineered.
+    // `.pb` is an encrypted / opaque container we can't decode offline
+    // (neither can codeburn). For those cascades we fall back to the
+    // running language server's `GetCascadeTrajectoryGeneratorMetadata`
+    // RPC (`AntigravityCascadeUsageFetcher`) and cache the result so it
+    // survives Antigravity being closed. `.db` is always preferred when
+    // it yields turns — it's authoritative and carries cache tokens the
+    // RPC doesn't expose.
+
+    /// Conversation roots scanned for AntiGravity usage. All three may
+    /// coexist on one machine (IDE, CLI, and the legacy `-ide` layout).
+    private static let antigravityConversationDirs = [
+        ".gemini/antigravity/conversations",
+        ".gemini/antigravity-cli/conversations",
+        ".gemini/antigravity-ide/conversations"
+    ]
 
     private static func scanAntigravity(
         homeDirectory: String,
         now: Date,
         retentionDays: Int?
     ) async -> CostSnapshot {
-        let root = URL(fileURLWithPath: homeDirectory)
-            .appendingPathComponent(".gemini/antigravity/conversations")
-        let dbFiles = collectAntigravityConversationFiles(under: root)
+        let roots = antigravityConversationDirs.map {
+            URL(fileURLWithPath: homeDirectory).appendingPathComponent($0)
+        }
+        let cascades = collectAntigravityCascades(under: roots)
         var aggregator = CostAggregator(tool: .antigravity, now: now)
         var cache = CostUsageScanCache.load(homeDirectory: homeDirectory, tool: .antigravity, retentionDays: retentionDays)
         let cutoff = retentionCutoff(now: now, retentionDays: retentionDays)
 
-        for file in dbFiles {
-            let (mtime, size) = fileFingerprint(file)
-            if let cached = cache.reusable(for: file.path, mtime: mtime, size: size) {
-                let retained = retainedEvents(cached, cutoff: cutoff)
-                if retained.count != cached.count {
-                    cache.store(retained, for: file.path, mtime: mtime, size: size)
-                }
-                for event in retained {
-                    let cost = costUSD(tool: .antigravity, event: event)
-                    aggregator.add(at: event.date, model: event.model, input: event.input,
-                                   output: event.output, cache: event.cache, costUSD: cost)
-                }
-                continue
-            }
+        // The language server is probed lazily — only if a `.pb`-only
+        // cascade actually needs an RPC, and at most once per scan.
+        let lsClient = AntigravityLanguageServerClient()
+        var endpoints: [AntigravityLanguageServerClient.Endpoint]?
+        var serverUnavailable = false
 
-            let turns = AntigravitySessionReader.readGenMetadata(at: file)
-            var parsed: [CostUsageScanCache.ParsedEvent] = []
-            parsed.reserveCapacity(turns.count)
-            var previousCacheCumulative = 0
-            let sessionId = file.deletingPathExtension().lastPathComponent
-            for turn in turns {
-                let cacheCreation = max(0, turn.cumulativeCacheReadTokens - previousCacheCumulative)
-                let cacheRead = max(0, previousCacheCumulative)
-                previousCacheCumulative = turn.cumulativeCacheReadTokens
-                let input = turn.inputTokens
-                // Reasoning + tool tokens are billed at output rates by
-                // Claude / Gemini, so fold them into output here.
-                let output = turn.outputTokens + turn.thoughtsTokens + turn.toolTokens
-                guard input > 0 || output > 0 || cacheRead > 0 || cacheCreation > 0 else { continue }
-                let model = normalizedNonEmpty(turn.model) ?? "antigravity-default"
-                let parsedEvent = CostUsageScanCache.ParsedEvent(
-                    date: turn.date,
-                    model: model,
-                    input: input,
-                    output: output,
-                    cache: cacheRead + cacheCreation,
-                    cacheCreation: cacheCreation,
-                    sessionId: sessionId,
-                    messageId: turn.requestId
-                )
-                guard isRetained(parsedEvent.date, cutoff: cutoff) else { continue }
-                parsed.append(parsedEvent)
-                let cost = costUSD(tool: .antigravity, event: parsedEvent)
-                aggregator.add(at: parsedEvent.date, model: parsedEvent.model,
-                               input: parsedEvent.input, output: parsedEvent.output,
-                               cache: parsedEvent.cache, costUSD: cost)
+        var knownPaths: Set<String> = []
+        var fileCount = 0
+
+        for cascade in cascades {
+            // 1. Prefer the offline `.db` decode.
+            var handledByDB = false
+            for dbFile in cascade.dbFiles {
+                fileCount += 1
+                knownPaths.insert(dbFile.path)
+                let (mtime, size) = fileFingerprint(dbFile)
+                if let cached = cache.reusable(for: dbFile.path, mtime: mtime, size: size) {
+                    let retained = retainedEvents(cached, cutoff: cutoff)
+                    if retained.count != cached.count {
+                        cache.store(retained, for: dbFile.path, mtime: mtime, size: size)
+                    }
+                    aggregateAntigravity(retained, into: &aggregator)
+                    if !cached.isEmpty { handledByDB = true }
+                    continue
+                }
+                let turns = AntigravitySessionReader.readGenMetadata(at: dbFile)
+                let parsed = antigravityEvents(fromDB: turns, sessionId: cascade.id, cutoff: cutoff)
+                cache.store(parsed, for: dbFile.path, mtime: mtime, size: size)
+                aggregateAntigravity(parsed, into: &aggregator)
+                if !turns.isEmpty { handledByDB = true }
             }
-            cache.store(parsed, for: file.path, mtime: mtime, size: size)
+            if handledByDB { continue }
+
+            // 2. `.pb`-only (or empty `.db`): live-RPC fallback, cached
+            //    so it persists across Antigravity restarts.
+            for pbFile in cascade.pbFiles {
+                fileCount += 1
+                knownPaths.insert(pbFile.path)
+                let (mtime, size) = fileFingerprint(pbFile)
+                if let cached = cache.reusable(for: pbFile.path, mtime: mtime, size: size) {
+                    let retained = retainedEvents(cached, cutoff: cutoff)
+                    if retained.count != cached.count {
+                        cache.store(retained, for: pbFile.path, mtime: mtime, size: size)
+                    }
+                    aggregateAntigravity(retained, into: &aggregator)
+                    continue
+                }
+                if endpoints == nil && !serverUnavailable {
+                    do { endpoints = try await lsClient.connectedEndpoints() }
+                    catch { serverUnavailable = true }
+                }
+                if let endpoints, !serverUnavailable,
+                   let turns = try? await AntigravityCascadeUsageFetcher.fetchTurns(
+                       cascadeId: cascade.id, client: lsClient, endpoints: endpoints
+                   ) {
+                    let parsed = antigravityEvents(
+                        fromRPC: turns,
+                        sessionId: cascade.id,
+                        fallbackDate: fileMTime(pbFile) ?? now,
+                        cutoff: cutoff
+                    )
+                    cache.store(parsed, for: pbFile.path, mtime: mtime, size: size)
+                    aggregateAntigravity(parsed, into: &aggregator)
+                    continue
+                }
+                // 3. RPC unavailable / failed → reuse the last good fetch
+                //    (ignoring the fingerprint) so usage doesn't vanish
+                //    while Antigravity is closed.
+                if let stale = cache.lastKnownEvents(for: pbFile.path) {
+                    aggregateAntigravity(retainedEvents(stale, cutoff: cutoff), into: &aggregator)
+                }
+            }
         }
-        cache.prune(known: Set(dbFiles.map(\.path)))
+        cache.prune(known: knownPaths)
         cache.save(homeDirectory: homeDirectory, tool: .antigravity)
-        return aggregator.snapshot(jsonlFilesFound: dbFiles.count)
+        return aggregator.snapshot(jsonlFilesFound: fileCount)
+    }
+
+    /// One cascade (conversation), grouping the `.db` and `.pb` files
+    /// that share a `<UUID>` filename across the AntiGravity roots.
+    private struct AntigravityCascade {
+        let id: String
+        var dbFiles: [URL]
+        var pbFiles: [URL]
+    }
+
+    private static func collectAntigravityCascades(under roots: [URL]) -> [AntigravityCascade] {
+        var byID: [String: AntigravityCascade] = [:]
+        var order: [String] = []
+        for root in roots {
+            for file in collectAntigravityConversationFiles(under: root) {
+                let id = file.deletingPathExtension().lastPathComponent
+                if byID[id] == nil {
+                    byID[id] = AntigravityCascade(id: id, dbFiles: [], pbFiles: [])
+                    order.append(id)
+                }
+                if file.pathExtension == "db" {
+                    byID[id]?.dbFiles.append(file)
+                } else {
+                    byID[id]?.pbFiles.append(file)
+                }
+            }
+        }
+        return order.compactMap { byID[$0] }
     }
 
     private static func collectAntigravityConversationFiles(under root: URL) -> [URL] {
@@ -971,11 +1035,90 @@ public enum CostUsageScanner {
             options: [.skipsHiddenFiles]
         ) else { return [] }
         return entries.filter { url in
-            guard url.pathExtension == "db" else { return false }
+            guard url.pathExtension == "db" || url.pathExtension == "pb" else { return false }
             let values = try? url.resourceValues(forKeys: [.isSymbolicLinkKey, .isRegularFileKey])
             if values?.isSymbolicLink == true { return false }
             if values?.isRegularFile == false { return false }
             return true
+        }
+    }
+
+    /// Convert decoded `.db` turns into cache events, resolving the
+    /// cumulative cache-read pool into per-turn cache-read /
+    /// cache-creation splits.
+    private static func antigravityEvents(
+        fromDB turns: [AntigravitySessionReader.Turn],
+        sessionId: String,
+        cutoff: Date?
+    ) -> [CostUsageScanCache.ParsedEvent] {
+        var parsed: [CostUsageScanCache.ParsedEvent] = []
+        parsed.reserveCapacity(turns.count)
+        var previousCacheCumulative = 0
+        for turn in turns {
+            let cacheCreation = max(0, turn.cumulativeCacheReadTokens - previousCacheCumulative)
+            let cacheRead = max(0, previousCacheCumulative)
+            previousCacheCumulative = turn.cumulativeCacheReadTokens
+            let input = turn.inputTokens
+            // Reasoning + tool tokens are billed at output rates by
+            // Claude / Gemini, so fold them into output here.
+            let output = turn.outputTokens + turn.thoughtsTokens + turn.toolTokens
+            guard input > 0 || output > 0 || cacheRead > 0 || cacheCreation > 0 else { continue }
+            let model = normalizedNonEmpty(turn.model) ?? "antigravity-default"
+            let event = CostUsageScanCache.ParsedEvent(
+                date: turn.date,
+                model: model,
+                input: input,
+                output: output,
+                cache: cacheRead + cacheCreation,
+                cacheCreation: cacheCreation,
+                sessionId: sessionId,
+                messageId: turn.requestId
+            )
+            guard isRetained(event.date, cutoff: cutoff) else { continue }
+            parsed.append(event)
+        }
+        return parsed
+    }
+
+    /// Convert RPC-fetched turns into cache events. The RPC exposes no
+    /// cache tokens (`cache = 0`) and already folds thinking into
+    /// `output`. A turn with no timestamp falls back to the `.pb` file's
+    /// mtime so it still lands on a real day.
+    private static func antigravityEvents(
+        fromRPC turns: [AntigravityCascadeUsageFetcher.Turn],
+        sessionId: String,
+        fallbackDate: Date,
+        cutoff: Date?
+    ) -> [CostUsageScanCache.ParsedEvent] {
+        var parsed: [CostUsageScanCache.ParsedEvent] = []
+        parsed.reserveCapacity(turns.count)
+        for turn in turns {
+            guard turn.input > 0 || turn.output > 0 else { continue }
+            let model = normalizedNonEmpty(turn.model) ?? "antigravity-default"
+            let event = CostUsageScanCache.ParsedEvent(
+                date: turn.date ?? fallbackDate,
+                model: model,
+                input: turn.input,
+                output: turn.output,
+                cache: 0,
+                cacheCreation: nil,
+                sessionId: sessionId,
+                messageId: turn.responseId
+            )
+            guard isRetained(event.date, cutoff: cutoff) else { continue }
+            parsed.append(event)
+        }
+        return parsed
+    }
+
+    private static func aggregateAntigravity(
+        _ events: [CostUsageScanCache.ParsedEvent],
+        into aggregator: inout CostAggregator
+    ) {
+        for event in events {
+            let cost = costUSD(tool: .antigravity, event: event)
+            aggregator.add(at: event.date, model: event.model, input: event.input,
+                           output: event.output, cache: event.cache, costUSD: cost)
         }
     }
 

--- a/Sources/VibeBarCore/Storage/CostUsageScanCache.swift
+++ b/Sources/VibeBarCore/Storage/CostUsageScanCache.swift
@@ -115,6 +115,16 @@ public struct CostUsageScanCache: Codable, Sendable {
         return entry.events
     }
 
+    /// Last cached events for `path`, ignoring the file fingerprint.
+    /// Used as a stale-data fallback when a fresh parse / RPC is
+    /// impossible — e.g. an AntiGravity `.pb` cascade whose tokens can
+    /// only be re-fetched from the language server, which isn't running
+    /// right now. Returns whatever was cached on a previous successful
+    /// fetch so usage doesn't blink out while Antigravity is closed.
+    public func lastKnownEvents(for path: String) -> [ParsedEvent]? {
+        entries[Self.entryKey(for: path)]?.events
+    }
+
     public mutating func store(_ events: [ParsedEvent], for path: String, mtime: Date, size: Int64) {
         entries[entryKey(for: path)] = FileEntry(mtime: mtime, size: size, events: events)
     }

--- a/Tests/VibeBarCoreTests/AntigravityCascadeUsageFetcherTests.swift
+++ b/Tests/VibeBarCoreTests/AntigravityCascadeUsageFetcherTests.swift
@@ -1,0 +1,88 @@
+import XCTest
+@testable import VibeBarCore
+
+/// Exercises the pure response parser behind the AntiGravity cascade
+/// usage RPC. The network call itself isn't unit-tested (it needs a live
+/// language server), but the JSON → `Turn` mapping is, so the token math
+/// and envelope tolerance stay locked in.
+final class AntigravityCascadeUsageFetcherTests: XCTestCase {
+    private func parse(_ json: String) -> [AntigravityCascadeUsageFetcher.Turn] {
+        AntigravityCascadeUsageFetcher.parse(data: Data(json.utf8))
+    }
+
+    func testParsesGeneratorMetadataArray() throws {
+        let json = """
+        {"generatorMetadata":[
+          {"chatModel":{"model":"gemini-3-pro",
+            "usage":{"model":"gemini-3-pro","inputTokens":"1200","outputTokens":"500",
+                     "thinkingOutputTokens":"100","responseOutputTokens":"400","responseId":"r1"},
+            "chatStartMetadata":{"createdAt":"2026-06-11T13:53:00Z"}}}
+        ]}
+        """
+        let turns = parse(json)
+        XCTAssertEqual(turns.count, 1)
+        let turn = try XCTUnwrap(turns.first)
+        XCTAssertEqual(turn.input, 1200)
+        // response (400) + thinking (100), both billed at the output rate.
+        XCTAssertEqual(turn.output, 500)
+        XCTAssertEqual(turn.model, "gemini-3-pro")
+        XCTAssertEqual(turn.responseId, "r1")
+        XCTAssertNotNil(turn.date)
+    }
+
+    func testFallsBackToOutputTokensWhenNoResponseSplit() {
+        let json = """
+        {"generatorMetadata":[
+          {"chatModel":{"usage":{"model":"gemini-3-flash","inputTokens":"10","outputTokens":"42"}}}
+        ]}
+        """
+        let turns = parse(json)
+        XCTAssertEqual(turns.count, 1)
+        XCTAssertEqual(turns.first?.input, 10)
+        XCTAssertEqual(turns.first?.output, 42)
+    }
+
+    func testSkipsZeroTokenTurns() {
+        let json = """
+        {"generatorMetadata":[
+          {"chatModel":{"usage":{"inputTokens":"0","outputTokens":"0"}}},
+          {"chatModel":{"usage":{"inputTokens":"5","outputTokens":"0"}}}
+        ]}
+        """
+        let turns = parse(json)
+        XCTAssertEqual(turns.count, 1)
+        XCTAssertEqual(turns.first?.input, 5)
+    }
+
+    func testDedupesByResponseId() {
+        let json = """
+        {"generatorMetadata":[
+          {"chatModel":{"usage":{"inputTokens":"5","outputTokens":"1","responseId":"dup"}}},
+          {"chatModel":{"usage":{"inputTokens":"7","outputTokens":"2","responseId":"dup"}}}
+        ]}
+        """
+        let turns = parse(json)
+        XCTAssertEqual(turns.count, 1)
+        XCTAssertEqual(turns.first?.input, 5)
+    }
+
+    func testToleratesWrappedEnvelopeAndNumericTokens() {
+        // A wrapper key around the array + numeric (non-string) token
+        // values — both shapes the parser must absorb.
+        let json = """
+        {"response":{"trajectoryGeneratorMetadata":[
+          {"chatModel":{"usage":{"model":"gemini-3-pro","inputTokens":3,"outputTokens":9}}}
+        ]}}
+        """
+        let turns = parse(json)
+        XCTAssertEqual(turns.count, 1)
+        XCTAssertEqual(turns.first?.input, 3)
+        XCTAssertEqual(turns.first?.output, 9)
+    }
+
+    func testReturnsEmptyForUnrelatedOrInvalidJSON() {
+        XCTAssertTrue(parse("{}").isEmpty)
+        XCTAssertTrue(parse(#"{"foo":42}"#).isEmpty)
+        XCTAssertTrue(parse("not json at all").isEmpty)
+    }
+}

--- a/Tests/VibeBarCoreTests/AntigravityCostScannerTests.swift
+++ b/Tests/VibeBarCoreTests/AntigravityCostScannerTests.swift
@@ -240,15 +240,19 @@ final class AntigravityCostScannerTests: XCTestCase {
         XCTAssertGreaterThan(snap.allTimeCostUSD, 0)
     }
 
-    func testScannerSkipsNonDatabaseFiles() async throws {
+    func testScannerIgnoresUnrelatedExtensions() async throws {
+        // Only `.db` and `.pb` conversation files are recognized; other
+        // files in the conversations directory (transcripts, SQLite
+        // sidecars) are ignored and contribute nothing.
         let home = try makeTempHome()
         defer { cleanup(home) }
         let convDir = home
             .appendingPathComponent(".gemini/antigravity/conversations", isDirectory: true)
         try FileManager.default.createDirectory(at: convDir, withIntermediateDirectories: true)
 
-        try Data([0x00, 0x01, 0x02]).write(to: convDir.appendingPathComponent("foo.pb"))
         try Data().write(to: convDir.appendingPathComponent("bar.txt"))
+        try Data("{}".utf8).write(to: convDir.appendingPathComponent("notes.json"))
+        try Data().write(to: convDir.appendingPathComponent("trajectory.db-wal"))
 
         let snapshot = await CostUsageScanner.scan(
             tool: .antigravity,
@@ -258,6 +262,65 @@ final class AntigravityCostScannerTests: XCTestCase {
         let snap = try XCTUnwrap(snapshot)
         XCTAssertEqual(snap.jsonlFilesFound, 0)
         XCTAssertEqual(snap.allTimeTokens, 0)
+    }
+
+    func testScansDatabaseInCliConversationsDir() async throws {
+        // CLI conversations live under `antigravity-cli/conversations`,
+        // which the scanner now covers alongside the IDE directory.
+        let home = try makeTempHome()
+        defer { cleanup(home) }
+        let convDir = home
+            .appendingPathComponent(".gemini/antigravity-cli/conversations", isDirectory: true)
+        try FileManager.default.createDirectory(at: convDir, withIntermediateDirectories: true)
+
+        let now = Date(timeIntervalSince1970: 1_779_434_500)
+        let base = UInt64(now.addingTimeInterval(-600).timeIntervalSince1970)
+        try writeAntigravityDB(at: convDir.appendingPathComponent("cli-trajectory.db"), turns: [
+            TurnSpec(idx: 0, blob: encodeTurnBlob(
+                seconds: base, input: 1_000, output: 200, cumulativeCache: 0
+            ))
+        ])
+
+        let snapshot = await CostUsageScanner.scan(
+            tool: .antigravity,
+            homeDirectory: home.path,
+            now: now
+        )
+        let snap = try XCTUnwrap(snapshot)
+        XCTAssertEqual(snap.jsonlFilesFound, 1)
+        XCTAssertEqual(snap.allTimeTokens, 1_200)
+        XCTAssertGreaterThan(snap.allTimeCostUSD, 0)
+    }
+
+    func testPrefersDatabaseOverProtobufSibling() async throws {
+        // When a cascade has both a populated `.db` and a `.pb` sibling
+        // (the 0-byte-db / large-pb shape never happens here because the
+        // db has turns), the offline decode wins and the `.pb` is not
+        // probed — no double counting, no language-server round trip.
+        let home = try makeTempHome()
+        defer { cleanup(home) }
+        let convDir = home
+            .appendingPathComponent(".gemini/antigravity/conversations", isDirectory: true)
+        try FileManager.default.createDirectory(at: convDir, withIntermediateDirectories: true)
+
+        let now = Date(timeIntervalSince1970: 1_779_434_500)
+        let base = UInt64(now.addingTimeInterval(-600).timeIntervalSince1970)
+        try writeAntigravityDB(at: convDir.appendingPathComponent("paired.db"), turns: [
+            TurnSpec(idx: 0, blob: encodeTurnBlob(
+                seconds: base, input: 4_000, output: 600, cumulativeCache: 0
+            ))
+        ])
+        try Data([0x00, 0x01, 0x02]).write(to: convDir.appendingPathComponent("paired.pb"))
+
+        let snapshot = await CostUsageScanner.scan(
+            tool: .antigravity,
+            homeDirectory: home.path,
+            now: now
+        )
+        let snap = try XCTUnwrap(snapshot)
+        // Only the `.db` is counted; the `.pb` sibling is skipped.
+        XCTAssertEqual(snap.jsonlFilesFound, 1)
+        XCTAssertEqual(snap.allTimeTokens, 4_600)
     }
 
     func testAntigravityCostUsesSonnetRatesForDefault() throws {


### PR DESCRIPTION
## Why

The Overview's four platforms are OpenAI, Anthropic, **Google AI (Gemini)**, and Grok — but only Google AI showed **no** cost/usage. Two root causes:

- Gemini CLI no longer writes local telemetry here (`~/.gemini/telemetry.log` absent, chat history stale), so **AntiGravity is now the only live Google/Gemini usage source**.
- The cost scanner read only `~/.gemini/antigravity/conversations/*.db` — it skipped the entire `antigravity-cli/` directory and **every encrypted `.pb` cascade**, and the Overview deliberately excluded Google AI from the cost totals while that gap existed.

This ports the technique [`getagentseal/codeburn`](https://github.com/getagentseal/codeburn) uses for AntiGravity. (codeburn doesn't decode the `.pb`/`.db` files either — the `.pb` container is encrypted — it reads token data from the running language server over RPC.)

## What changed

**Data (`VibeBarCore`)**
- Scan all three conversation roots — `antigravity/`, `antigravity-cli/`, `antigravity-ide/` — for `.db`, decoded offline by the existing `AntigravitySessionReader`.
- For `.pb`-only cascades, fall back to the running language server's `GetCascadeTrajectoryGeneratorMetadata` RPC (mirrors codeburn). Results are cached by file fingerprint so they **persist after AntiGravity quits**; a stale cache is reused when the server is unreachable. `.db` is always preferred when it yields turns (authoritative, has cache tokens) — no double counting.
- Extracted the `ps`/`lsof`/CSRF probe + localhost transport out of `AntigravityQuotaAdapter` into a shared `AntigravityLanguageServerClient`, so `GetUserStatus` (live quota) and the cascade RPC share one path.

**UI (`VibeBarApp`)**
- Surface combined Gemini + AntiGravity cost as a single **"Gemini"** platform aligned with the other three: an Overview cost card, inclusion in the headline totals + all-provider rollups, and a real cost panel on the Gemini sub-page (replacing the "Coming soon" placeholder).

## Testing

- `swift build`, `swift test` (544 tests, 0 failures), `./Scripts/build_app.sh release` all pass.
- `codesign -d --entitlements` is an empty dict (no `app-sandbox`); `codesign --verify --deep --strict` OK.
- New tests: cascade RPC parser (token math, envelope tolerance, dedupe, zero-skip), the widened `antigravity-cli/` directory scan, and `.db`-preferred-over-`.pb` selection.

## Note for reviewers / first run

The `.pb` cascades are fetched from the **running** language server, so the first sync needs AntiGravity open; after that the result is cached and survives quitting it. `.db` conversations (incl. the now-covered CLI dir) work fully offline. The RPC response envelope key is parsed leniently — worth a glance against a live capture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)