### PR TITLE
Probe all AntiGravity language servers and resolve real model names

### DIFF
--- a/Sources/VibeBarCore/Adapters/AntigravityLanguageServerClient.swift
+++ b/Sources/VibeBarCore/Adapters/AntigravityLanguageServerClient.swift
@@ -48,17 +48,30 @@ struct AntigravityLanguageServerClient {
 
     // MARK: - High-level
 
-    /// Detect the running server and return its candidate endpoints.
-    /// Throws `QuotaError.noCredential` when Antigravity isn't running.
+    /// Detect ALL running AntiGravity language servers and return every
+    /// server's candidate endpoints. A machine commonly runs more than
+    /// one — the IDE's `antigravity` / `antigravity-ide` servers, and,
+    /// while a CLI session is live, an `antigravity-cli` one. Each owns a
+    /// different set of conversations (a cascade fetched from the wrong
+    /// server returns "trajectory not found"), so callers must try a
+    /// cascade against every endpoint. Throws `QuotaError.noCredential`
+    /// when none is running.
     func connectedEndpoints() async throws -> [Endpoint] {
-        let process = try await detectProcessInfo()
-        let ports = try await listeningPorts(pid: process.pid)
-        return endpointCandidates(for: process, ports: ports)
+        let infos = try await detectAllProcessInfos()
+        var endpoints: [Endpoint] = []
+        for info in infos {
+            let ports = (try? await listeningPorts(pid: info.pid)) ?? []
+            endpoints.append(contentsOf: endpointCandidates(for: info, ports: ports))
+        }
+        if endpoints.isEmpty {
+            throw QuotaError.parseFailure("Antigravity is running but no listening ports found yet — wait a few seconds and retry.")
+        }
+        return endpoints
     }
 
     // MARK: - Process detection
 
-    func detectProcessInfo() async throws -> ProcessInfo {
+    func detectAllProcessInfos() async throws -> [ProcessInfo] {
         let result: ProcessRunner.Result
         do {
             result = try await ProcessRunner.run(
@@ -70,25 +83,45 @@ struct AntigravityLanguageServerClient {
         } catch {
             throw QuotaError.unknown("Could not list processes: \(error.localizedDescription)")
         }
+        let infos = Self.parseProcessInfos(psOutput: result.stdout)
+        if infos.isEmpty {
+            if Self.sawAntigravityProcess(psOutput: result.stdout) {
+                throw QuotaError.parseFailure("Antigravity is running but its CSRF token is missing — restart Antigravity and retry.")
+            }
+            throw QuotaError.noCredential
+        }
+        return infos
+    }
 
-        var foundAntigravity = false
-        for line in result.stdout.split(separator: "\n") {
+    /// Pure parse of `ps -ax -o pid=,command=` output into one
+    /// `ProcessInfo` per AntiGravity language server that exposes a CSRF
+    /// token. Split out so multi-server detection is unit-testable
+    /// without shelling out.
+    static func parseProcessInfos(psOutput: String) -> [ProcessInfo] {
+        var infos: [ProcessInfo] = []
+        for line in psOutput.split(separator: "\n") {
             guard let match = AntigravityProcessLine.parse(String(line)) else { continue }
-            let lower = match.command.lowercased()
-            guard Self.matchesAntigravityProcess(lowercasedCommand: lower) else { continue }
-            foundAntigravity = true
+            guard matchesAntigravityProcess(lowercasedCommand: match.command.lowercased()) else { continue }
             guard let csrf = extractFlag("--csrf_token", from: match.command) else { continue }
-            return ProcessInfo(
+            infos.append(ProcessInfo(
                 pid: match.pid,
                 csrfToken: csrf,
                 extensionPort: extractFlag("--extension_server_port", from: match.command).flatMap { Int($0) },
                 extensionCSRFToken: extractFlag("--extension_server_csrf_token", from: match.command)
-            )
+            ))
         }
-        if foundAntigravity {
-            throw QuotaError.parseFailure("Antigravity is running but its CSRF token is missing — restart Antigravity and retry.")
+        return infos
+    }
+
+    /// Whether any AntiGravity language server is present at all (even
+    /// without a readable CSRF token) — drives the "running but no CSRF"
+    /// vs "not running" error distinction.
+    static func sawAntigravityProcess(psOutput: String) -> Bool {
+        for line in psOutput.split(separator: "\n") {
+            guard let match = AntigravityProcessLine.parse(String(line)) else { continue }
+            if matchesAntigravityProcess(lowercasedCommand: match.command.lowercased()) { return true }
         }
-        throw QuotaError.noCredential
+        return false
     }
 
     /// Whether a process-list line looks like an AntiGravity language
@@ -107,7 +140,7 @@ struct AntigravityLanguageServerClient {
         return false
     }
 
-    private func extractFlag(_ flag: String, from command: String) -> String? {
+    private static func extractFlag(_ flag: String, from command: String) -> String? {
         let pattern = "\(NSRegularExpression.escapedPattern(for: flag))[=\\s]+([^\\s]+)"
         guard let regex = try? NSRegularExpression(pattern: pattern, options: .caseInsensitive) else {
             return nil

--- a/Sources/VibeBarCore/Adapters/AntigravityQuotaAdapter.swift
+++ b/Sources/VibeBarCore/Adapters/AntigravityQuotaAdapter.swift
@@ -76,6 +76,9 @@ public struct AntigravityQuotaAdapter: QuotaAdapter {
                     body: body
                 )
                 let snapshot = try AntigravityResponseParser.parseUserStatus(data: data)
+                // Keep the id → label map fresh so the cost scanner can
+                // resolve placeholder model ids to real names and rates.
+                AntigravityModelLabelStore.merge(snapshot.modelLabels)
                 return AccountQuota(
                     accountId: account.id,
                     tool: .antigravity,
@@ -125,6 +128,12 @@ enum AntigravityResponseParser {
         var buckets: [QuotaBucket]
         var planName: String?
         var email: String?
+        /// `modelOrAlias.model → label` for every config (e.g.
+        /// `MODEL_PLACEHOLDER_M132 → "Gemini 3.5 Flash (High)"`),
+        /// regardless of whether the config carried quota. Fed into
+        /// `AntigravityModelLabelStore` so the cost scanner can resolve
+        /// real model names and rates.
+        var modelLabels: [String: String] = [:]
     }
 
     static func parseUserStatus(data: Data) throws -> Snapshot {
@@ -143,7 +152,15 @@ enum AntigravityResponseParser {
 
         let modelConfigs = userStatus.cascadeModelConfigData?.clientModelConfigs ?? []
         var buckets: [QuotaBucket] = []
+        var modelLabels: [String: String] = [:]
         for config in modelConfigs {
+            // Capture the id → label mapping for every config (even ones
+            // without quota), so placeholder model ids in the cost data
+            // can later be resolved to real names / rates.
+            if let rawModel = config.modelOrAlias?.model {
+                let trimmed = rawModel.trimmingCharacters(in: .whitespacesAndNewlines)
+                if !trimmed.isEmpty { modelLabels[trimmed] = config.label }
+            }
             guard let quota = config.quotaInfo else { continue }
             // Google's wire format omits `remainingFraction` when the
             // model's quota is fully spent (proto3 zero-default). The
@@ -169,7 +186,7 @@ enum AntigravityResponseParser {
         }
 
         let plan = userStatus.userTier?.preferredName ?? userStatus.planStatus?.planInfo?.preferredName
-        return Snapshot(buckets: buckets, planName: plan, email: userStatus.email)
+        return Snapshot(buckets: buckets, planName: plan, email: userStatus.email, modelLabels: modelLabels)
     }
 
     private static func parseDate(_ raw: String) -> Date? {

--- a/Sources/VibeBarCore/Services/AntigravityCascadeUsageFetcher.swift
+++ b/Sources/VibeBarCore/Services/AntigravityCascadeUsageFetcher.swift
@@ -41,15 +41,25 @@ enum AntigravityCascadeUsageFetcher {
     ) async throws -> [Turn] {
         let body = try JSONSerialization.data(withJSONObject: ["cascadeId": cascadeId])
         var lastError: Error?
+        var sawSuccess = false
+        // Only one server owns a given cascade; the others answer HTTP
+        // 500 "trajectory not found" (→ caught, continue). Try them all
+        // and take the first non-empty result. A 200-but-empty response
+        // (cascade genuinely has no turns) is remembered so we return []
+        // rather than throwing — only an all-errors sweep throws, so the
+        // scanner falls back to its cache.
         for endpoint in endpoints {
             do {
                 let data = try await client.postLocal(endpoint: endpoint, path: methodPath, body: body)
-                return parse(data: data)
+                sawSuccess = true
+                let turns = parse(data: data)
+                if !turns.isEmpty { return turns }
             } catch {
                 lastError = error
                 continue
             }
         }
+        if sawSuccess { return [] }
         throw lastError ?? QuotaError.network("Antigravity cascade RPC unreachable.")
     }
 

--- a/Sources/VibeBarCore/Services/CostUsageScanner.swift
+++ b/Sources/VibeBarCore/Services/CostUsageScanner.swift
@@ -920,6 +920,9 @@ public enum CostUsageScanner {
         var aggregator = CostAggregator(tool: .antigravity, now: now)
         var cache = CostUsageScanCache.load(homeDirectory: homeDirectory, tool: .antigravity, retentionDays: retentionDays)
         let cutoff = retentionCutoff(now: now, retentionDays: retentionDays)
+        // Resolve placeholder model ids (e.g. MODEL_PLACEHOLDER_M132) to
+        // real names + rates using labels learned from GetUserStatus.
+        let labels = AntigravityModelLabelStore.load(homeDirectory: homeDirectory)
 
         // The language server is probed lazily — only if a `.pb`-only
         // cascade actually needs an RPC, and at most once per scan.
@@ -942,14 +945,14 @@ public enum CostUsageScanner {
                     if retained.count != cached.count {
                         cache.store(retained, for: dbFile.path, mtime: mtime, size: size)
                     }
-                    aggregateAntigravity(retained, into: &aggregator)
+                    aggregateAntigravity(retained, labels: labels, into: &aggregator)
                     if !cached.isEmpty { handledByDB = true }
                     continue
                 }
                 let turns = AntigravitySessionReader.readGenMetadata(at: dbFile)
                 let parsed = antigravityEvents(fromDB: turns, sessionId: cascade.id, cutoff: cutoff)
                 cache.store(parsed, for: dbFile.path, mtime: mtime, size: size)
-                aggregateAntigravity(parsed, into: &aggregator)
+                aggregateAntigravity(parsed, labels: labels, into: &aggregator)
                 if !turns.isEmpty { handledByDB = true }
             }
             if handledByDB { continue }
@@ -965,7 +968,7 @@ public enum CostUsageScanner {
                     if retained.count != cached.count {
                         cache.store(retained, for: pbFile.path, mtime: mtime, size: size)
                     }
-                    aggregateAntigravity(retained, into: &aggregator)
+                    aggregateAntigravity(retained, labels: labels, into: &aggregator)
                     continue
                 }
                 if endpoints == nil && !serverUnavailable {
@@ -983,14 +986,14 @@ public enum CostUsageScanner {
                         cutoff: cutoff
                     )
                     cache.store(parsed, for: pbFile.path, mtime: mtime, size: size)
-                    aggregateAntigravity(parsed, into: &aggregator)
+                    aggregateAntigravity(parsed, labels: labels, into: &aggregator)
                     continue
                 }
                 // 3. RPC unavailable / failed → reuse the last good fetch
                 //    (ignoring the fingerprint) so usage doesn't vanish
                 //    while Antigravity is closed.
                 if let stale = cache.lastKnownEvents(for: pbFile.path) {
-                    aggregateAntigravity(retainedEvents(stale, cutoff: cutoff), into: &aggregator)
+                    aggregateAntigravity(retainedEvents(stale, cutoff: cutoff), labels: labels, into: &aggregator)
                 }
             }
         }
@@ -1113,12 +1116,29 @@ public enum CostUsageScanner {
 
     private static func aggregateAntigravity(
         _ events: [CostUsageScanCache.ParsedEvent],
+        labels: AntigravityModelLabelStore,
         into aggregator: inout CostAggregator
     ) {
         for event in events {
-            let cost = costUSD(tool: .antigravity, event: event)
-            aggregator.add(at: event.date, model: event.model, input: event.input,
-                           output: event.output, cache: event.cache, costUSD: cost)
+            // Resolve the raw model id to its real label (when known),
+            // then price + group under that name. A placeholder id
+            // normalizes to `antigravity-default` (Sonnet rate); the
+            // resolved label (e.g. "Gemini 3.5 Flash") normalizes to the
+            // correct — usually much cheaper — rate.
+            let name = labels.resolve(event.model)
+            let resolved = name == event.model ? event : CostUsageScanCache.ParsedEvent(
+                date: event.date,
+                model: name,
+                input: event.input,
+                output: event.output,
+                cache: event.cache,
+                cacheCreation: event.cacheCreation,
+                sessionId: event.sessionId,
+                messageId: event.messageId
+            )
+            let cost = costUSD(tool: .antigravity, event: resolved)
+            aggregator.add(at: resolved.date, model: resolved.model, input: resolved.input,
+                           output: resolved.output, cache: resolved.cache, costUSD: cost)
         }
     }
 

--- a/Sources/VibeBarCore/Storage/AntigravityModelLabelStore.swift
+++ b/Sources/VibeBarCore/Storage/AntigravityModelLabelStore.swift
@@ -1,0 +1,87 @@
+import Foundation
+
+/// Maps AntiGravity's internal model ids to human labels.
+///
+/// AntiGravity reports usage under opaque ids — `MODEL_PLACEHOLDER_M132`,
+/// `MODEL_PLACEHOLDER_M20`, … — both in the cost trajectories and in the
+/// `GetUserStatus` model config. `GetUserStatus`'s `clientModelConfigs`
+/// is the one place that also carries the label (`Gemini 3.5 Flash
+/// (High)`), so the quota adapter feeds those `id → label` pairs in here
+/// each time it refreshes, and the cost scanner reads them back to:
+///   1. show real model names instead of placeholders, and
+///   2. price placeholder models at their real rate — a bare
+///      `MODEL_PLACEHOLDER_*` normalizes to `antigravity-default`
+///      (Sonnet rate), but the resolved label normalizes correctly
+///      (e.g. "…Flash…" → the much cheaper Gemini Flash rate).
+///
+/// Stored at `<homeDirectory>/.vibebar/antigravity_model_labels.json`
+/// and merged across sessions, since a single `GetUserStatus` only lists
+/// the currently-available models.
+public struct AntigravityModelLabelStore: Codable, Sendable, Equatable {
+    public var labels: [String: String]
+
+    public init(labels: [String: String] = [:]) {
+        self.labels = labels
+    }
+
+    /// Resolve a raw model id to its label, or return the id unchanged
+    /// when no label is known.
+    public func resolve(_ modelId: String) -> String {
+        labels[modelId] ?? modelId
+    }
+
+    // MARK: - Disk I/O
+
+    public static func fileURL(homeDirectory: String) -> URL {
+        URL(fileURLWithPath: homeDirectory)
+            .appendingPathComponent(VibeBarLocalStore.directoryName, isDirectory: true)
+            .appendingPathComponent("antigravity_model_labels.json")
+    }
+
+    public static func load(homeDirectory: String = RealHomeDirectory.path) -> AntigravityModelLabelStore {
+        let url = fileURL(homeDirectory: homeDirectory)
+        guard let data = try? Data(contentsOf: url),
+              let store = try? JSONDecoder().decode(AntigravityModelLabelStore.self, from: data)
+        else {
+            return AntigravityModelLabelStore()
+        }
+        return store
+    }
+
+    public func save(homeDirectory: String = RealHomeDirectory.path) {
+        let url = Self.fileURL(homeDirectory: homeDirectory)
+        let parent = url.deletingLastPathComponent()
+        let fm = FileManager.default
+        try? fm.createDirectory(at: parent, withIntermediateDirectories: true)
+        guard let data = try? JSONEncoder().encode(self) else { return }
+        try? data.write(to: url, options: .atomic)
+        try? fm.setAttributes(
+            [.posixPermissions: NSNumber(value: Int16(0o600))],
+            ofItemAtPath: url.path
+        )
+    }
+
+    /// Merge new `id → label` pairs into the persisted store. Empty
+    /// keys/values are dropped; the file is only rewritten when a value
+    /// actually changes, so a steady-state refresh does no disk I/O.
+    @discardableResult
+    public static func merge(
+        _ newLabels: [String: String],
+        homeDirectory: String = RealHomeDirectory.path
+    ) -> AntigravityModelLabelStore {
+        let cleaned = newLabels.reduce(into: [String: String]()) { acc, pair in
+            let id = pair.key.trimmingCharacters(in: .whitespacesAndNewlines)
+            let label = pair.value.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !id.isEmpty && !label.isEmpty { acc[id] = label }
+        }
+        var store = load(homeDirectory: homeDirectory)
+        guard !cleaned.isEmpty else { return store }
+        var changed = false
+        for (id, label) in cleaned where store.labels[id] != label {
+            store.labels[id] = label
+            changed = true
+        }
+        if changed { store.save(homeDirectory: homeDirectory) }
+        return store
+    }
+}

--- a/Tests/VibeBarCoreTests/AntigravityCostScannerTests.swift
+++ b/Tests/VibeBarCoreTests/AntigravityCostScannerTests.swift
@@ -335,4 +335,52 @@ final class AntigravityCostScannerTests: XCTestCase {
         ))
         XCTAssertEqual(cost, 3.0, accuracy: 1e-9)
     }
+
+    func testResolvesPlaceholderModelNameAndReprices() async throws {
+        let home = try makeTempHome()
+        defer { cleanup(home) }
+        // Seed the label store: placeholder id -> real Flash label.
+        AntigravityModelLabelStore(labels: ["MODEL_PLACEHOLDER_M132": "Gemini 3.5 Flash (High)"])
+            .save(homeDirectory: home.path)
+
+        let convDir = home
+            .appendingPathComponent(".gemini/antigravity/conversations", isDirectory: true)
+        try FileManager.default.createDirectory(at: convDir, withIntermediateDirectories: true)
+        let now = Date(timeIntervalSince1970: 1_779_434_500)
+        let base = UInt64(now.addingTimeInterval(-600).timeIntervalSince1970)
+        try writeAntigravityDB(at: convDir.appendingPathComponent("conv.db"), turns: [
+            TurnSpec(idx: 0, blob: encodeTurnBlob(
+                seconds: base, input: 1_000_000, output: 0, cumulativeCache: 0,
+                model: "MODEL_PLACEHOLDER_M132"
+            ))
+        ])
+
+        let snapshot = await CostUsageScanner.scan(tool: .antigravity, homeDirectory: home.path, now: now)
+        let snap = try XCTUnwrap(snapshot)
+        // Name resolved to the real label, not the raw placeholder.
+        XCTAssertEqual(snap.modelBreakdowns.map(\.modelName), ["Gemini 3.5 Flash (High)"])
+        // Re-priced at the Flash rate — strictly cheaper than the
+        // antigravity-default ($3 / Mtok) the bare placeholder would hit.
+        XCTAssertGreaterThan(snap.allTimeCostUSD, 0)
+        XCTAssertLessThan(snap.allTimeCostUSD, 3.0)
+    }
+
+    func testKeepsRawModelIdWhenNoLabelKnown() async throws {
+        let home = try makeTempHome()
+        defer { cleanup(home) }
+        let convDir = home
+            .appendingPathComponent(".gemini/antigravity/conversations", isDirectory: true)
+        try FileManager.default.createDirectory(at: convDir, withIntermediateDirectories: true)
+        let now = Date(timeIntervalSince1970: 1_779_434_500)
+        let base = UInt64(now.addingTimeInterval(-600).timeIntervalSince1970)
+        try writeAntigravityDB(at: convDir.appendingPathComponent("conv.db"), turns: [
+            TurnSpec(idx: 0, blob: encodeTurnBlob(
+                seconds: base, input: 1_000, output: 100, cumulativeCache: 0,
+                model: "MODEL_PLACEHOLDER_M999"
+            ))
+        ])
+        let snapshot = await CostUsageScanner.scan(tool: .antigravity, homeDirectory: home.path, now: now)
+        let snap = try XCTUnwrap(snapshot)
+        XCTAssertEqual(snap.modelBreakdowns.map(\.modelName), ["MODEL_PLACEHOLDER_M999"])
+    }
 }

--- a/Tests/VibeBarCoreTests/AntigravityModelLabelStoreTests.swift
+++ b/Tests/VibeBarCoreTests/AntigravityModelLabelStoreTests.swift
@@ -1,0 +1,47 @@
+import XCTest
+@testable import VibeBarCore
+
+final class AntigravityModelLabelStoreTests: XCTestCase {
+    private func tempHome() throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("VibeBarLabelStoreTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    func testEmptyStoreResolvesToRawId() throws {
+        let home = try tempHome()
+        defer { try? FileManager.default.removeItem(at: home) }
+        let store = AntigravityModelLabelStore.load(homeDirectory: home.path)
+        XCTAssertEqual(store.resolve("MODEL_PLACEHOLDER_M132"), "MODEL_PLACEHOLDER_M132")
+    }
+
+    func testMergePersistsAndDropsEmpties() throws {
+        let home = try tempHome()
+        defer { try? FileManager.default.removeItem(at: home) }
+
+        AntigravityModelLabelStore.merge([
+            "MODEL_PLACEHOLDER_M132": "Gemini 3.5 Flash (High)",
+            "   ": "ignored-empty-key",
+            "MODEL_EMPTY": "   "
+        ], homeDirectory: home.path)
+
+        let store = AntigravityModelLabelStore.load(homeDirectory: home.path)
+        XCTAssertEqual(store.labels.count, 1)
+        XCTAssertEqual(store.resolve("MODEL_PLACEHOLDER_M132"), "Gemini 3.5 Flash (High)")
+        XCTAssertEqual(store.resolve("MODEL_EMPTY"), "MODEL_EMPTY")
+    }
+
+    func testMergeAccumulatesAcrossCalls() throws {
+        let home = try tempHome()
+        defer { try? FileManager.default.removeItem(at: home) }
+
+        AntigravityModelLabelStore.merge(["MODEL_PLACEHOLDER_M132": "Gemini 3.5 Flash (High)"], homeDirectory: home.path)
+        AntigravityModelLabelStore.merge(["MODEL_PLACEHOLDER_M20": "Gemini 3.5 Flash (Medium)"], homeDirectory: home.path)
+
+        let store = AntigravityModelLabelStore.load(homeDirectory: home.path)
+        XCTAssertEqual(store.labels.count, 2)
+        XCTAssertEqual(store.resolve("MODEL_PLACEHOLDER_M132"), "Gemini 3.5 Flash (High)")
+        XCTAssertEqual(store.resolve("MODEL_PLACEHOLDER_M20"), "Gemini 3.5 Flash (Medium)")
+    }
+}

--- a/Tests/VibeBarCoreTests/AntigravityParserTests.swift
+++ b/Tests/VibeBarCoreTests/AntigravityParserTests.swift
@@ -306,4 +306,33 @@ final class AntigravityParserTests: XCTestCase {
             )
         )
     }
+
+    // MARK: - Multi-server process parsing
+
+    func testParseProcessInfosFindsEveryAntigravityServer() {
+        let ps = """
+        83055 /Applications/Antigravity.app/Contents/Resources/bin/language_server --app_data_dir antigravity --csrf_token AAA --extension_server_port 1234 --extension_server_csrf_token EXT
+        83474 /Applications/Antigravity IDE.app/Contents/Resources/app/extensions/antigravity/bin/language_server_macos_arm --app_data_dir antigravity-ide --csrf_token BBB
+        99999 /Users/example/.local/bin/agy-language_server --app_data_dir antigravity-cli --csrf_token CCC
+        42 /usr/bin/some_other_language_server --not-antigravity
+        7 /usr/bin/unrelated
+        """
+        let infos = AntigravityLanguageServerClient.parseProcessInfos(psOutput: ps)
+        XCTAssertEqual(infos.count, 3)
+        XCTAssertEqual(Set(infos.map(\.csrfToken)), ["AAA", "BBB", "CCC"])
+        XCTAssertEqual(Set(infos.map(\.pid)), [83055, 83474, 99999])
+        let hub = infos.first { $0.pid == 83055 }
+        XCTAssertEqual(hub?.extensionPort, 1234)
+        XCTAssertEqual(hub?.extensionCSRFToken, "EXT")
+        XCTAssertTrue(AntigravityLanguageServerClient.sawAntigravityProcess(psOutput: ps))
+    }
+
+    func testParseProcessInfosEmptyWhenNoAntigravityServer() {
+        let ps = """
+        1 /usr/bin/foo
+        2 /usr/bin/language_server --app_data_dir somethingelse --csrf_token X
+        """
+        XCTAssertTrue(AntigravityLanguageServerClient.parseProcessInfos(psOutput: ps).isEmpty)
+        XCTAssertFalse(AntigravityLanguageServerClient.sawAntigravityProcess(psOutput: ps))
+    }
 }


### PR DESCRIPTION
Two follow-ups to [#69](https://github.com/AstroQore/vibe-bar/pull/69), driven by live testing on a real machine.

## 1. Multi-server probe → CLI usage gets captured

`AntigravityLanguageServerClient` previously probed only the **first** running language server. But a machine runs several (`--app_data_dir antigravity`, `antigravity-ide`, and — while a CLI `agy` session is live — `antigravity-cli`), and a cascade is owned by exactly one of them; the others answer `HTTP 500 "trajectory not found"` (verified live).

Now it discovers **every** server and aggregates all their endpoints, and the cascade fetcher tries a cascade across all endpoints, taking the first non-empty result. So whenever a logged-in CLI session is running, its conversations get captured like any other — open `agy` once and the next scan caches them permanently.

**Why not auto-spawn `agy`?** Investigated and proven infeasible: a vibebar-spawned (headless) `agy` comes up **logged out** (`You are not logged into Antigravity`), its language server lives ~5s and can't serve trajectory data. Only a real, logged-in session works — hence the multi-server approach instead.

## 2. Real model names + pricing fix

AntiGravity reports usage under opaque ids like `MODEL_PLACEHOLDER_M132`. `GetUserStatus`'s `clientModelConfigs` is the one place that also carries the label, verified live:

```
MODEL_PLACEHOLDER_M132 -> Gemini 3.5 Flash (High)
MODEL_PLACEHOLDER_M20  -> Gemini 3.5 Flash (Medium)
MODEL_PLACEHOLDER_M35  -> Claude Sonnet 4.6 (Thinking)
```

The quota adapter now feeds those `id → label` pairs into a new `AntigravityModelLabelStore` (`~/.vibebar/antigravity_model_labels.json`, merged across refreshes), and the cost scanner resolves each model id to its label for **both display and pricing**.

Resolving before pricing also fixes a **latent over-charge**: a bare `MODEL_PLACEHOLDER_*` normalizes to `antigravity-default` (Sonnet rate), but the resolved label normalizes to the correct, usually much cheaper rate (e.g. Gemini Flash). So those Flash placeholders stop being billed at the Sonnet rate — totals will drop a bit, more accurately.

## Testing

- `swift build`, `swift test` (551 tests, 0 failures), `./Scripts/build_app.sh release` pass.
- `codesign -d --entitlements` is an empty dict (no `app-sandbox`); `--verify --deep --strict` OK.
- New tests: multi-server `ps` parsing (3 servers, extension flags), the label store (merge/accumulate/drop-empties), and the scanner's placeholder → label resolution + re-pricing (asserts a resolved Flash prices below the Sonnet default).

🤖 Generated with [Claude Code](https://claude.com/claude-code)