### PR TITLE
Track Volcengine Agent Plan AFP usage alongside Coding Plan

### DIFF
--- a/Sources/VibeBarApp/HiddenCookieRefresher.swift
+++ b/Sources/VibeBarApp/HiddenCookieRefresher.swift
@@ -60,9 +60,11 @@ final class HiddenCookieRefresher {
                     requiredCookieNames: [],
                     postLoadWait: 8
                 )
-            case .volcengine:
+            case .volcengine, .volcengineAgentPlan:
+                // Both Volcengine cards share one console session, so the
+                // same IAM keepalive refreshes either slot.
                 return Config(
-                    tool: .volcengine,
+                    tool: tool,
                     refreshURL: URL(string: "https://console.volcengine.com/iam/")!,
                     cookieDomainSuffixes: ["volcengine.com"],
                     requiredCookieNames: [],
@@ -131,7 +133,7 @@ final class HiddenCookieRefresher {
             }
         }
 
-        static let supportedTools: [ToolType] = [.tencentHunyuan, .tencentTokenPlan, .volcengine, .alibaba, .alibabaTokenPlan, .baiduQianfan]
+        static let supportedTools: [ToolType] = [.tencentHunyuan, .tencentTokenPlan, .volcengine, .volcengineAgentPlan, .alibaba, .alibabaTokenPlan, .baiduQianfan]
     }
 
     private var inflight: [ToolType: Task<Bool, Never>] = [:]

--- a/Sources/VibeBarApp/MiscWebLoginController.swift
+++ b/Sources/VibeBarApp/MiscWebLoginController.swift
@@ -674,6 +674,26 @@ final class MiscWebLoginRegistry {
                 savedConfirmation: "Doubao cookies saved.",
                 setupHint: "Sign in to Volcengine console (sub-user works), then click Save Cookies."
             )
+        case .volcengineAgentPlan:
+            // Same Volcengine console login as the Coding Plan card; we
+            // just land on the Agent Plan tab and stash the captured jar
+            // under the Agent Plan slot.
+            return MiscWebLoginController.Config(
+                tool: .volcengineAgentPlan,
+                loginURL: URL(string: "https://console.volcengine.com/ark/region:ark+cn-beijing/openManagement?advancedActiveKey=agentPlan")!,
+                cookieDomainSuffixes: ["volcengine.com"],
+                requiredCookieNames: [],  // ship full jar
+                trustedAuthHostSuffixes: [
+                    "volcengine.com",
+                    "volccdn.com",
+                    "zijieapi.com",       // Bytedance internal monitoring CDN
+                    "douyincdn.com",
+                    "bytedance.com"
+                ],
+                windowTitle: "Volcengine Doubao Login",
+                savedConfirmation: "Doubao cookies saved.",
+                setupHint: "Sign in to Volcengine console (sub-user works), then click Save Cookies."
+            )
         case .tencentHunyuan:
             return MiscWebLoginController.Config(
                 tool: .tencentHunyuan,

--- a/Sources/VibeBarApp/ProviderBrandIcon.swift
+++ b/Sources/VibeBarApp/ProviderBrandIcon.swift
@@ -62,7 +62,7 @@ enum ProviderBrandIcon {
         switch tool {
         case .codex:  return fallbackSystemImage(for: MenuBarItemKind.codex)
         case .claude: return fallbackSystemImage(for: MenuBarItemKind.claude)
-        case .alibaba, .alibabaTokenPlan, .gemini, .antigravity, .grok, .copilot, .zai, .minimax, .kimi, .cursor, .mimo, .iflytek, .tencentHunyuan, .tencentTokenPlan, .volcengine, .baiduQianfan, .openCodeGo, .kilo, .kiro, .ollama, .openRouter, .warp:
+        case .alibaba, .alibabaTokenPlan, .gemini, .antigravity, .grok, .copilot, .zai, .minimax, .kimi, .cursor, .mimo, .iflytek, .tencentHunyuan, .tencentTokenPlan, .volcengine, .volcengineAgentPlan, .baiduQianfan, .openCodeGo, .kilo, .kiro, .ollama, .openRouter, .warp:
             return tool.miscFallbackSymbol
         }
     }
@@ -162,7 +162,7 @@ enum ProviderBrandIcon {
         let svg: String? = switch tool {
         case .codex: openAISVG
         case .claude: claudeSVG
-        case .alibaba, .alibabaTokenPlan, .gemini, .antigravity, .grok, .copilot, .zai, .minimax, .kimi, .cursor, .mimo, .iflytek, .tencentHunyuan, .tencentTokenPlan, .volcengine, .baiduQianfan, .openCodeGo, .kilo, .kiro, .ollama, .openRouter, .warp:
+        case .alibaba, .alibabaTokenPlan, .gemini, .antigravity, .grok, .copilot, .zai, .minimax, .kimi, .cursor, .mimo, .iflytek, .tencentHunyuan, .tencentTokenPlan, .volcengine, .volcengineAgentPlan, .baiduQianfan, .openCodeGo, .kilo, .kiro, .ollama, .openRouter, .warp:
             nil
         }
         guard let svg, let image = NSImage(data: Data(svg.utf8)) else { return nil }
@@ -369,6 +369,7 @@ extension ToolType {
         case .tencentHunyuan:   return "ProviderIcon-tencentHunyuan"
         case .tencentTokenPlan: return "ProviderIcon-tencentHunyuan"
         case .volcengine:  return "ProviderIcon-volcengine"
+        case .volcengineAgentPlan: return "ProviderIcon-volcengine"
         case .baiduQianfan: return "ProviderIcon-baiduQianfan"
         case .openCodeGo:  return "ProviderIcon-opencodego"
         case .kilo:        return "ProviderIcon-kilo"
@@ -390,7 +391,7 @@ extension ToolType {
         // no halo on either pair.
         case .codex, .claude, .gemini, .antigravity, .grok, .copilot, .cursor:
             return 1.25
-        case .alibaba, .alibabaTokenPlan, .minimax, .kimi, .mimo, .iflytek, .tencentHunyuan, .tencentTokenPlan, .volcengine, .baiduQianfan, .openCodeGo, .kilo, .kiro, .ollama, .openRouter, .warp:
+        case .alibaba, .alibabaTokenPlan, .minimax, .kimi, .mimo, .iflytek, .tencentHunyuan, .tencentTokenPlan, .volcengine, .volcengineAgentPlan, .baiduQianfan, .openCodeGo, .kilo, .kiro, .ollama, .openRouter, .warp:
             return 1.36
         case .zai:
             return 1.5
@@ -420,6 +421,7 @@ extension ToolType {
         case .tencentHunyuan:   return "globe.asia.australia"
         case .tencentTokenPlan: return "creditcard.circle"
         case .volcengine:  return "flame.fill"
+        case .volcengineAgentPlan: return "flame.circle.fill"
         case .baiduQianfan: return "pawprint.fill"
         case .openCodeGo:  return "terminal"
         case .kilo:        return "k.circle.fill"

--- a/Sources/VibeBarApp/Views/MiniQuotaWindowView.swift
+++ b/Sources/VibeBarApp/Views/MiniQuotaWindowView.swift
@@ -388,6 +388,7 @@ private func providerAccent(for tool: ToolType) -> Color {
     case .tencentHunyuan:   return Color(red: 0.00, green: 0.49, blue: 0.91)  // tencent blue
     case .tencentTokenPlan: return Color(red: 0.18, green: 0.62, blue: 0.96)  // tencent token blue
     case .volcengine:  return Color(red: 0.92, green: 0.30, blue: 0.30)  // doubao red
+    case .volcengineAgentPlan: return Color(red: 0.96, green: 0.45, blue: 0.22)  // doubao agent amber
     case .baiduQianfan: return Color(red: 0.16, green: 0.40, blue: 0.93)  // baidu blue
     case .openCodeGo:  return Color(red: 0.22, green: 0.66, blue: 0.50)  // green
     case .kilo:        return Color(red: 0.47, green: 0.37, blue: 0.93)  // purple
@@ -417,6 +418,7 @@ private func providerTitle(for tool: ToolType) -> String {
     case .tencentHunyuan:   return "HUNYUAN"
     case .tencentTokenPlan: return "HUNYUAN TP"
     case .volcengine:  return "DOUBAO"
+    case .volcengineAgentPlan: return "DOUBAO AP"
     case .baiduQianfan: return "QIANFAN"
     case .openCodeGo:  return "OPENCODE"
     case .kilo:        return "KILO"

--- a/Sources/VibeBarApp/Views/MiscProviderSettingsSection.swift
+++ b/Sources/VibeBarApp/Views/MiscProviderSettingsSection.swift
@@ -236,6 +236,20 @@ struct MiscProviderSettingsSection: View {
                     helpText: "Volcengine console session cookies expire after a few hours. When the card flips to \"Needs re-login\", click here to refresh."
                 )
             }
+        case .volcengineAgentPlan:
+            VStack(alignment: .leading, spacing: 4) {
+                CookieSourceControls(
+                    tool: .volcengineAgentPlan,
+                    instanceID: instanceID,
+                    spec: VolcengineAgentPlanQuotaAdapter.cookieSpec,
+                    manualPrompt: "Paste console.volcengine.com Cookie header (csrfToken=…; AccountID=…; …)"
+                )
+                MiscWebLoginRow(
+                    tool: .volcengineAgentPlan,
+                    instanceID: instanceID,
+                    helpText: "Same Volcengine console login as the Coding Plan card. With browser auto-import on, signing in once covers both cards."
+                )
+            }
         case .baiduQianfan:
             VStack(alignment: .leading, spacing: 4) {
                 CookieSourceControls(

--- a/Sources/VibeBarApp/Views/PopoverRoot.swift
+++ b/Sources/VibeBarApp/Views/PopoverRoot.swift
@@ -1324,7 +1324,7 @@ private struct OverviewCostCard: View {
         case .gemini: return "No Gemini CLI or chat-history usage found yet."
         case .antigravity: return "No Antigravity conversation token metadata found yet."
         case .grok: return "No Grok Build session usage found yet."
-        case .alibaba, .alibabaTokenPlan, .copilot, .zai, .minimax, .kimi, .cursor, .mimo, .iflytek, .tencentHunyuan, .tencentTokenPlan, .volcengine, .baiduQianfan, .openCodeGo, .kilo, .kiro, .ollama, .openRouter, .warp:
+        case .alibaba, .alibabaTokenPlan, .copilot, .zai, .minimax, .kimi, .cursor, .mimo, .iflytek, .tencentHunyuan, .tencentTokenPlan, .volcengine, .volcengineAgentPlan, .baiduQianfan, .openCodeGo, .kilo, .kiro, .ollama, .openRouter, .warp:
             // Misc providers' empty cost-history view shouldn't be
             // reachable (cost cards are gated on
             // `tool.supportsTokenCost`), but render a graceful
@@ -1714,7 +1714,7 @@ struct ProviderQuotaCard: View {
         switch tool {
         case .codex:  return "Run codex login, then refresh."
         case .claude: return "Run claude login, then refresh."
-        case .alibaba, .alibabaTokenPlan, .gemini, .antigravity, .grok, .copilot, .zai, .minimax, .kimi, .cursor, .mimo, .iflytek, .tencentHunyuan, .tencentTokenPlan, .volcengine, .baiduQianfan, .openCodeGo, .kilo, .kiro, .ollama, .openRouter, .warp:
+        case .alibaba, .alibabaTokenPlan, .gemini, .antigravity, .grok, .copilot, .zai, .minimax, .kimi, .cursor, .mimo, .iflytek, .tencentHunyuan, .tencentTokenPlan, .volcengine, .volcengineAgentPlan, .baiduQianfan, .openCodeGo, .kilo, .kiro, .ollama, .openRouter, .warp:
             // Misc providers route through the Misc page's per-card
             // setup CTA. This empty-message path is only reachable from
             // a primary-provider detail view, but cover misc cases

--- a/Sources/VibeBarApp/Views/UsageActivityView.swift
+++ b/Sources/VibeBarApp/Views/UsageActivityView.swift
@@ -59,7 +59,7 @@ struct UsageActivityView: View {
         switch heatmap.tool {
         case .codex:  return "Codex"
         case .claude: return "Claude"
-        case .alibaba, .alibabaTokenPlan, .gemini, .antigravity, .grok, .copilot, .zai, .minimax, .kimi, .cursor, .mimo, .iflytek, .tencentHunyuan, .tencentTokenPlan, .volcengine, .baiduQianfan, .openCodeGo, .kilo, .kiro, .ollama, .openRouter, .warp:
+        case .alibaba, .alibabaTokenPlan, .gemini, .antigravity, .grok, .copilot, .zai, .minimax, .kimi, .cursor, .mimo, .iflytek, .tencentHunyuan, .tencentTokenPlan, .volcengine, .volcengineAgentPlan, .baiduQianfan, .openCodeGo, .kilo, .kiro, .ollama, .openRouter, .warp:
             return heatmap.tool.menuTitle
         }
     }

--- a/Sources/VibeBarCore/Adapters/VolcengineAgentPlanQuotaAdapter.swift
+++ b/Sources/VibeBarCore/Adapters/VolcengineAgentPlanQuotaAdapter.swift
@@ -1,0 +1,333 @@
+import Foundation
+
+/// Volcengine / Doubao **Agent Plan** usage adapter.
+///
+/// Lives alongside `VolcengineQuotaAdapter` (the Coding Plan flavour).
+/// Agent Plan is a separate Ark subscription, sold and metered in its
+/// own "AFP" unit (Agent燃料值 / Agent Fuel Points). The console renders
+/// it under a dedicated tab next to Coding Plan:
+/// `console.volcengine.com/ark/region:ark+cn-beijing/openManagement?advancedActiveKey=agentPlan`.
+///
+/// Auth: identical to the Coding Plan card — the full `*.volcengine.com`
+/// console jar with the `csrfToken` cookie mirrored into `X-Csrf-Token`.
+/// Both cards therefore ride the same Volcengine login; the default
+/// browser-cookie auto-import (keyed by domain) populates both at once,
+/// so the user signs in once and both refresh.
+///
+/// Endpoint:
+/// `POST .../2024-01-01/GetAgentPlanAFPUsage` returns one richer block
+/// than Coding Plan's percent-only `GetCodingPlanUsage`:
+///
+///     Result.PlanType            "medium" / "small" / "large" / …
+///     Result.AFPFiveHour         { Quota, Used, SubscribeTime, ResetTime }
+///     Result.AFPWeekly           { … }
+///     Result.AFPMonthly          { … }
+///     Result.AFPDaily            { … }
+///
+/// Each window carries an absolute `Used` / `Quota` pair (so we compute
+/// the percent ourselves) plus `ResetTime` in **milliseconds** — unlike
+/// the Coding Plan endpoint, whose `ResetTimestamp` is in seconds.
+///
+/// We surface the same three windows the console shows (5-hour, weekly,
+/// monthly). `AFPDaily` is returned by the API but hidden by the console
+/// for the observed tiers — its quota (e.g. 50000) sits *above* the
+/// weekly cap (35000), which only makes sense as a vestigial default,
+/// not an enforced limit — so we mirror the console and skip it.
+///
+/// `PlanType` doubles as the plan badge ("Agent Plan Medium"), so unlike
+/// the Coding Plan adapter there is no companion `ListSubscribeTrade`
+/// call to fetch the plan name.
+public struct VolcengineAgentPlanQuotaAdapter: QuotaAdapter {
+    public let tool: ToolType = .volcengineAgentPlan
+
+    private let session: URLSession
+    private let now: @Sendable () -> Date
+
+    public static let cookieSpec = MiscCookieResolver.Spec(
+        tool: .volcengineAgentPlan,
+        domains: [
+            "console.volcengine.com",
+            "volcengine.com",
+            ".volcengine.com"
+        ],
+        // Same trade-off as the Coding Plan jar: Volcengine's BFF stitches
+        // identity from HttpOnly session keys we can't enumerate from JS,
+        // so we ship the entire `*.volcengine.com` jar.
+        requiredNames: []
+    )
+
+    public init(
+        session: URLSession = .shared,
+        now: @escaping @Sendable () -> Date = { Date() }
+    ) {
+        self.session = session
+        self.now = now
+    }
+
+    public func fetch(for account: AccountIdentity) async throws -> AccountQuota {
+        let resolutions = MiscCookieResolver.resolveAll(for: VolcengineAgentPlanQuotaAdapter.cookieSpec, account: account)
+        guard !resolutions.isEmpty else { throw QuotaError.noCredential }
+
+        let queriedAt = now()
+        let results = await MiscQuotaAggregator.gatherSlotResults(resolutions) { resolution in
+            try await self.fetchOneSlot(resolution, account: account, queriedAt: queriedAt)
+        }
+        return MiscQuotaAggregator.aggregate(
+            tool: .volcengineAgentPlan,
+            account: account,
+            results: results,
+            queriedAt: queriedAt
+        )
+    }
+
+    private func fetchOneSlot(
+        _ resolution: MiscCookieResolver.Resolution,
+        account: AccountIdentity,
+        queriedAt: Date
+    ) async throws -> AccountQuota {
+        let pairs = CookieHeaderNormalizer.pairs(from: resolution.header)
+        guard let csrfToken = pairs.first(where: { $0.name == "csrfToken" })?.value, !csrfToken.isEmpty else {
+            // No `csrfToken` means the user logged in at the
+            // volcengine.com website level but never opened the console
+            // (the cookie is set by the first console request).
+            throw QuotaError.needsLogin
+        }
+
+        let data = try await callBFF(cookieHeader: resolution.header, csrfToken: csrfToken)
+        let parsed = try VolcengineAgentPlanResponseParser.parseUsage(data: data)
+        return AccountQuota(
+            accountId: account.id,
+            tool: .volcengineAgentPlan,
+            buckets: parsed.buckets,
+            plan: parsed.planName,
+            email: account.email,
+            queriedAt: queriedAt,
+            error: nil
+        )
+    }
+
+    private func callBFF(cookieHeader: String, csrfToken: String) async throws -> Data {
+        var request = URLRequest(url: Self.getAgentPlanAFPUsageURL)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("application/json, text/plain, */*", forHTTPHeaderField: "Accept")
+        request.setValue(csrfToken, forHTTPHeaderField: "X-Csrf-Token")
+        request.setValue(cookieHeader, forHTTPHeaderField: "Cookie")
+        request.setValue("zh", forHTTPHeaderField: "Accept-Language")
+        request.setValue("https://console.volcengine.com", forHTTPHeaderField: "Origin")
+        request.setValue("https://console.volcengine.com/", forHTTPHeaderField: "Referer")
+        request.setValue(
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Safari/537.36",
+            forHTTPHeaderField: "User-Agent"
+        )
+        request.httpBody = try JSONSerialization.data(withJSONObject: [:])
+
+        let (data, response): (Data, URLResponse)
+        do {
+            (data, response) = try await self.session.data(for: request)
+        } catch {
+            throw QuotaError.network("Volcengine Agent Plan network error: \(error.localizedDescription)")
+        }
+        guard let http = response as? HTTPURLResponse else {
+            throw QuotaError.network("Volcengine Agent Plan: invalid response object")
+        }
+        guard http.statusCode == 200 else {
+            if http.statusCode == 401 || http.statusCode == 403 {
+                throw QuotaError.needsLogin
+            }
+            if http.statusCode == 429 {
+                throw QuotaError.rateLimited
+            }
+            throw QuotaError.network("Volcengine Agent Plan returned HTTP \(http.statusCode).")
+        }
+        return data
+    }
+
+    private static let getAgentPlanAFPUsageURL = URL(string:
+        "https://console.volcengine.com/api/top/ark/cn-beijing/2024-01-01/GetAgentPlanAFPUsage"
+    )!
+}
+
+// MARK: - Response parsing
+
+enum VolcengineAgentPlanResponseParser {
+    struct UsageSnapshot {
+        var buckets: [QuotaBucket]
+        var planName: String?
+    }
+
+    static func parseUsage(data: Data) throws -> UsageSnapshot {
+        guard !data.isEmpty else {
+            throw QuotaError.parseFailure("Volcengine Agent Plan returned an empty body.")
+        }
+        let envelope: AgentPlanUsageEnvelope
+        do {
+            envelope = try JSONDecoder().decode(AgentPlanUsageEnvelope.self, from: data)
+        } catch {
+            throw QuotaError.parseFailure("Volcengine Agent Plan usage response not parseable: \(error.localizedDescription)")
+        }
+
+        if let err = envelope.responseMetadata?.error {
+            let code = err.code?.lowercased() ?? ""
+            let message = err.message?.trimmedNonEmpty ?? "code \(err.code ?? "?")"
+            if isAuthCode(code) || message.lowercased().contains("login") {
+                throw QuotaError.needsLogin
+            }
+            if code.contains("requestlimit") || code.contains("ratelimit") {
+                throw QuotaError.rateLimited
+            }
+            throw QuotaError.network("Volcengine Agent Plan: \(message)")
+        }
+
+        guard let result = envelope.result else {
+            throw QuotaError.parseFailure("Volcengine Agent Plan response had no Result block.")
+        }
+
+        // The console shows 5-hour / weekly / monthly; `AFPDaily` is
+        // returned but intentionally not surfaced (see the type doc).
+        let windows: [(AgentPlanWindow?, AgentPlanBucketKind)] = [
+            (result.afpFiveHour, .session),
+            (result.afpWeekly, .weekly),
+            (result.afpMonthly, .monthly)
+        ]
+
+        var buckets: [QuotaBucket] = []
+        for (window, kind) in windows {
+            guard let bucket = bucket(from: window, kind: kind) else { continue }
+            buckets.append(bucket)
+        }
+        guard !buckets.isEmpty else {
+            throw QuotaError.parseFailure("Volcengine Agent Plan response had no usable AFP windows.")
+        }
+
+        return UsageSnapshot(buckets: buckets, planName: planName(from: result.planType))
+    }
+
+    private enum AgentPlanBucketKind {
+        case session, weekly, monthly
+
+        var id: String {
+            switch self {
+            case .session: return "volcengineAgentPlan.session"
+            case .weekly:  return "volcengineAgentPlan.weekly"
+            case .monthly: return "volcengineAgentPlan.monthly"
+            }
+        }
+        var title: String {
+            switch self {
+            case .session: return "5 Hours"
+            case .weekly:  return "Weekly"
+            case .monthly: return "Monthly"
+            }
+        }
+        var shortLabel: String {
+            switch self {
+            case .session: return "5h"
+            case .weekly:  return "Wk"
+            case .monthly: return "Mo"
+            }
+        }
+        var windowSeconds: Int {
+            switch self {
+            case .session: return 5 * 3600
+            case .weekly:  return 7 * 86_400
+            case .monthly: return 30 * 86_400
+            }
+        }
+    }
+
+    private static func bucket(from window: AgentPlanWindow?, kind: AgentPlanBucketKind) -> QuotaBucket? {
+        guard let window, let quota = window.quota, quota > 0 else { return nil }
+        let used = window.used ?? 0
+        let percent = max(0, min(100, used / quota * 100))
+        // `ResetTime` is epoch milliseconds here (Coding Plan uses seconds).
+        let resetAt = window.resetTime.map { Date(timeIntervalSince1970: TimeInterval($0) / 1000) }
+        return QuotaBucket(
+            id: kind.id,
+            title: kind.title,
+            shortLabel: kind.shortLabel,
+            usedPercent: percent,
+            resetAt: resetAt,
+            rawWindowSeconds: kind.windowSeconds
+        )
+    }
+
+    static func planName(from planType: String?) -> String? {
+        guard let raw = planType?.trimmingCharacters(in: .whitespacesAndNewlines), !raw.isEmpty else {
+            return nil
+        }
+        return "Agent Plan " + raw.prefix(1).uppercased() + raw.dropFirst()
+    }
+
+    private static func isAuthCode(_ code: String) -> Bool {
+        code.contains("login") ||
+            code.contains("auth") ||
+            code.contains("invalidstate") ||
+            code.contains("unauthenticated")
+    }
+}
+
+// MARK: - Wire types
+
+private struct AgentPlanUsageEnvelope: Decodable {
+    let responseMetadata: AgentPlanResponseMetadata?
+    let result: AgentPlanUsageResult?
+
+    enum CodingKeys: String, CodingKey {
+        case responseMetadata = "ResponseMetadata"
+        case result = "Result"
+    }
+}
+
+private struct AgentPlanResponseMetadata: Decodable {
+    let error: AgentPlanMetadataError?
+
+    enum CodingKeys: String, CodingKey { case error = "Error" }
+}
+
+private struct AgentPlanMetadataError: Decodable {
+    let code: String?
+    let message: String?
+
+    enum CodingKeys: String, CodingKey {
+        case code = "Code"
+        case message = "Message"
+    }
+}
+
+private struct AgentPlanUsageResult: Decodable {
+    let planType: String?
+    let afpFiveHour: AgentPlanWindow?
+    let afpWeekly: AgentPlanWindow?
+    let afpMonthly: AgentPlanWindow?
+    let afpDaily: AgentPlanWindow?
+
+    enum CodingKeys: String, CodingKey {
+        case planType = "PlanType"
+        case afpFiveHour = "AFPFiveHour"
+        case afpWeekly = "AFPWeekly"
+        case afpMonthly = "AFPMonthly"
+        case afpDaily = "AFPDaily"
+    }
+}
+
+struct AgentPlanWindow: Decodable {
+    let quota: Double?
+    let used: Double?
+    let resetTime: Int?
+    let subscribeTime: Int?
+
+    enum CodingKeys: String, CodingKey {
+        case quota = "Quota"
+        case used = "Used"
+        case resetTime = "ResetTime"
+        case subscribeTime = "SubscribeTime"
+    }
+}
+
+private extension String {
+    var trimmedNonEmpty: String? {
+        let t = trimmingCharacters(in: .whitespacesAndNewlines)
+        return t.isEmpty ? nil : t
+    }
+}

--- a/Sources/VibeBarCore/Credentials/VibeBarKeychainAccessAuthorizer.swift
+++ b/Sources/VibeBarCore/Credentials/VibeBarKeychainAccessAuthorizer.swift
@@ -70,14 +70,14 @@ public enum VibeBarKeychainAccessAuthorizer {
     /// plus Alibaba (cookie path is one of two auth modes).
     private static let currentCookieBackedMiscTools: [ToolType] = [
         .alibaba, .alibabaTokenPlan, .kimi, .cursor, .mimo, .iflytek,
-        .tencentHunyuan, .tencentTokenPlan, .volcengine, .baiduQianfan, .openCodeGo, .ollama
+        .tencentHunyuan, .tencentTokenPlan, .volcengine, .volcengineAgentPlan, .baiduQianfan, .openCodeGo, .ollama
     ]
     /// Misc tools with an in-app WKWebView login flow where
     /// `WebFormCredentialStore` may persist a username/password pair.
     /// Keeping the list explicit lets the preflight pre-authorize the
     /// Keychain accounts so users don't see a prompt on first save.
     private static let currentWebFormBackedMiscTools: [ToolType] = [
-        .mimo, .volcengine, .tencentHunyuan, .tencentTokenPlan, .alibaba, .alibabaTokenPlan, .baiduQianfan
+        .mimo, .volcengine, .volcengineAgentPlan, .tencentHunyuan, .tencentTokenPlan, .alibaba, .alibabaTokenPlan, .baiduQianfan
     ]
     private static let currentSecretKindsByTool: [ToolType: [MiscCredentialStore.Kind]] = [
         .alibaba: [.apiKey],

--- a/Sources/VibeBarCore/Models/ProviderHierarchy.swift
+++ b/Sources/VibeBarCore/Models/ProviderHierarchy.swift
@@ -65,6 +65,7 @@ public enum ProviderHierarchyCatalog {
     public static let tencentHunyuan   = ProviderHierarchy(vendor: "Tencent",    product: "Hunyuan",     tool: "Hunyuan Coding Plan")
     public static let tencentTokenPlan = ProviderHierarchy(vendor: "Tencent",    product: "Hunyuan",     tool: "Hunyuan Token Plan")
     public static let volcengine       = ProviderHierarchy(vendor: "ByteDance",  product: "Doubao",      tool: "Doubao Coding Plan")
+    public static let volcengineAgentPlan = ProviderHierarchy(vendor: "ByteDance",  product: "Doubao",   tool: "Doubao Agent Plan")
     public static let baiduQianfan     = ProviderHierarchy(vendor: "Baidu",      product: "Qianfan",     tool: "Qianfan Coding Plan")
     public static let openCodeGo       = ProviderHierarchy(vendor: "OpenCode",   product: "OpenCode Go", tool: "OpenCode Go")
     public static let kilo             = ProviderHierarchy(vendor: "Kilo",       product: "Kilo",        tool: "Kilo")

--- a/Sources/VibeBarCore/Models/ProviderPlanDisplay.swift
+++ b/Sources/VibeBarCore/Models/ProviderPlanDisplay.swift
@@ -7,7 +7,7 @@ public enum ProviderPlanDisplay {
             return codexDisplayName(rawPlan)
         case .claude:
             return claudeDisplayName(rawPlan)
-        case .alibaba, .alibabaTokenPlan, .gemini, .antigravity, .grok, .copilot, .zai, .minimax, .kimi, .cursor, .mimo, .iflytek, .tencentHunyuan, .tencentTokenPlan, .volcengine, .baiduQianfan, .openCodeGo, .kilo, .kiro, .ollama, .openRouter, .warp:
+        case .alibaba, .alibabaTokenPlan, .gemini, .antigravity, .grok, .copilot, .zai, .minimax, .kimi, .cursor, .mimo, .iflytek, .tencentHunyuan, .tencentTokenPlan, .volcengine, .volcengineAgentPlan, .baiduQianfan, .openCodeGo, .kilo, .kiro, .ollama, .openRouter, .warp:
             // Misc providers feed `plan` straight through. Each adapter
             // is responsible for normalizing the raw API response
             // (e.g. `Pro Coding` → `Pro`) before it reaches this map.

--- a/Sources/VibeBarCore/Models/ToolType.swift
+++ b/Sources/VibeBarCore/Models/ToolType.swift
@@ -29,7 +29,8 @@ import Foundation
 ///   token-cost scanning and status polling as provider data becomes known.
 /// - **Misc** (`.alibaba`, `.alibabaTokenPlan`, `.copilot`, `.zai`,
 ///   `.minimax`, `.kimi`, `.cursor`, `.mimo`, `.iflytek`,
-///   `.tencentHunyuan`, `.tencentTokenPlan`, `.volcengine`, `.baiduQianfan`,
+///   `.tencentHunyuan`, `.tencentTokenPlan`, `.volcengine`,
+///   `.volcengineAgentPlan`, `.baiduQianfan`,
 ///   `.openCodeGo`, `.kilo`, `.kiro`, `.ollama`, `.openRouter`, `.warp`) —
 ///   usage-only cards on the Misc tab.
 ///
@@ -59,6 +60,7 @@ public enum ToolType: String, Codable, CaseIterable, Hashable, Sendable {
     case tencentHunyuan
     case tencentTokenPlan
     case volcengine
+    case volcengineAgentPlan
     case baiduQianfan
     case openCodeGo
     case kilo
@@ -72,7 +74,7 @@ public enum ToolType: String, Codable, CaseIterable, Hashable, Sendable {
     public var isPrimary: Bool {
         switch self {
         case .codex, .claude: return true
-        case .alibaba, .alibabaTokenPlan, .gemini, .antigravity, .grok, .copilot, .zai, .minimax, .kimi, .cursor, .mimo, .iflytek, .tencentHunyuan, .tencentTokenPlan, .volcengine, .baiduQianfan, .openCodeGo, .kilo, .kiro, .ollama, .openRouter, .warp:
+        case .alibaba, .alibabaTokenPlan, .gemini, .antigravity, .grok, .copilot, .zai, .minimax, .kimi, .cursor, .mimo, .iflytek, .tencentHunyuan, .tencentTokenPlan, .volcengine, .volcengineAgentPlan, .baiduQianfan, .openCodeGo, .kilo, .kiro, .ollama, .openRouter, .warp:
             return false
         }
     }
@@ -86,7 +88,7 @@ public enum ToolType: String, Codable, CaseIterable, Hashable, Sendable {
     public var supportsDedicatedCard: Bool {
         switch self {
         case .codex, .claude, .gemini, .antigravity, .grok: return true
-        case .alibaba, .alibabaTokenPlan, .copilot, .zai, .minimax, .kimi, .cursor, .mimo, .iflytek, .tencentHunyuan, .tencentTokenPlan, .volcengine, .baiduQianfan, .openCodeGo, .kilo, .kiro, .ollama, .openRouter, .warp:
+        case .alibaba, .alibabaTokenPlan, .copilot, .zai, .minimax, .kimi, .cursor, .mimo, .iflytek, .tencentHunyuan, .tencentTokenPlan, .volcengine, .volcengineAgentPlan, .baiduQianfan, .openCodeGo, .kilo, .kiro, .ollama, .openRouter, .warp:
             return false
         }
     }
@@ -164,7 +166,7 @@ public enum ToolType: String, Codable, CaseIterable, Hashable, Sendable {
     public var supportsTokenCost: Bool {
         switch self {
         case .codex, .claude, .gemini, .antigravity, .grok: return true
-        case .alibaba, .alibabaTokenPlan, .copilot, .zai, .minimax, .kimi, .cursor, .mimo, .iflytek, .tencentHunyuan, .tencentTokenPlan, .volcengine, .baiduQianfan, .openCodeGo, .kilo, .kiro, .ollama, .openRouter, .warp:
+        case .alibaba, .alibabaTokenPlan, .copilot, .zai, .minimax, .kimi, .cursor, .mimo, .iflytek, .tencentHunyuan, .tencentTokenPlan, .volcengine, .volcengineAgentPlan, .baiduQianfan, .openCodeGo, .kilo, .kiro, .ollama, .openRouter, .warp:
             return false
         }
     }
@@ -178,7 +180,7 @@ public enum ToolType: String, Codable, CaseIterable, Hashable, Sendable {
     public var supportsStatusPage: Bool {
         switch self {
         case .codex, .claude, .gemini, .antigravity, .grok: return true
-        case .alibaba, .alibabaTokenPlan, .copilot, .zai, .minimax, .kimi, .cursor, .mimo, .iflytek, .tencentHunyuan, .tencentTokenPlan, .volcengine, .baiduQianfan, .openCodeGo, .kilo, .kiro, .ollama, .openRouter, .warp:
+        case .alibaba, .alibabaTokenPlan, .copilot, .zai, .minimax, .kimi, .cursor, .mimo, .iflytek, .tencentHunyuan, .tencentTokenPlan, .volcengine, .volcengineAgentPlan, .baiduQianfan, .openCodeGo, .kilo, .kiro, .ollama, .openRouter, .warp:
             return false
         }
     }
@@ -223,6 +225,7 @@ public enum ToolType: String, Codable, CaseIterable, Hashable, Sendable {
         case .tencentHunyuan:   return ProviderHierarchyCatalog.tencentHunyuan
         case .tencentTokenPlan: return ProviderHierarchyCatalog.tencentTokenPlan
         case .volcengine:       return ProviderHierarchyCatalog.volcengine
+        case .volcengineAgentPlan: return ProviderHierarchyCatalog.volcengineAgentPlan
         case .baiduQianfan:     return ProviderHierarchyCatalog.baiduQianfan
         case .openCodeGo:       return ProviderHierarchyCatalog.openCodeGo
         case .kilo:             return ProviderHierarchyCatalog.kilo
@@ -263,6 +266,7 @@ public enum ToolType: String, Codable, CaseIterable, Hashable, Sendable {
         case .tencentHunyuan:   return "Tencent Hunyuan Coding Plan"
         case .tencentTokenPlan: return "Tencent Hunyuan Token Plan"
         case .volcengine:       return "Volcengine Coding Plan"
+        case .volcengineAgentPlan: return "Volcengine Agent Plan"
         case .baiduQianfan:     return "Baidu Qianfan Coding Plan"
         case .openCodeGo:       return "OpenCode Go"
         case .kilo:             return "Kilo"
@@ -296,6 +300,7 @@ public enum ToolType: String, Codable, CaseIterable, Hashable, Sendable {
         case .tencentHunyuan:   return "Coding Plan"
         case .tencentTokenPlan: return "Token Plan"
         case .volcengine:       return "Coding Plan"
+        case .volcengineAgentPlan: return "Agent Plan"
         case .baiduQianfan:     return "Coding Plan"
         case .openCodeGo:       return "Workspace"
         case .kilo:             return "Credits"
@@ -326,7 +331,7 @@ public enum ToolType: String, Codable, CaseIterable, Hashable, Sendable {
         case .mimo:             return "Xiaomi MiMo"
         case .iflytek:          return "iFlytek Spark"
         case .tencentHunyuan, .tencentTokenPlan: return "Tencent Hunyuan"
-        case .volcengine:       return "Volcengine"
+        case .volcengine, .volcengineAgentPlan: return "Volcengine"
         case .baiduQianfan:     return "Baidu Qianfan"
         case .openCodeGo:       return "OpenCode Go"
         case .kilo:             return "Kilo"
@@ -355,7 +360,7 @@ public enum ToolType: String, Codable, CaseIterable, Hashable, Sendable {
         case .mimo:             return "Xiaomi"
         case .iflytek:          return "iFlytek"
         case .tencentHunyuan, .tencentTokenPlan: return "Tencent Cloud"
-        case .volcengine:       return "Volcengine"
+        case .volcengine, .volcengineAgentPlan: return "Volcengine"
         case .baiduQianfan:     return "Baidu Qianfan"
         case .openCodeGo:       return "OpenCode"
         case .kilo:             return "Kilo"
@@ -389,6 +394,7 @@ public enum ToolType: String, Codable, CaseIterable, Hashable, Sendable {
         case .tencentHunyuan:   return URL(string: "https://console.cloud.tencent.com/tokenhub/codingplan")!
         case .tencentTokenPlan: return URL(string: "https://console.cloud.tencent.com/tokenhub/tokenplan")!
         case .volcengine:  return URL(string: "https://console.volcengine.com/ark")!
+        case .volcengineAgentPlan: return URL(string: "https://console.volcengine.com/ark/region:ark+cn-beijing/openManagement?advancedActiveKey=agentPlan")!
         case .baiduQianfan: return URL(string: "https://console.bce.baidu.com/qianfan/resource/subscribe")!
         case .openCodeGo:  return URL(string: "https://opencode.ai/")!
         case .kilo:        return URL(string: "https://app.kilo.ai/")!

--- a/Sources/VibeBarCore/Services/CostUsageScanner.swift
+++ b/Sources/VibeBarCore/Services/CostUsageScanner.swift
@@ -30,7 +30,7 @@ public enum CostUsageScanner {
             return await scanGrok(homeDirectory: homeDirectory, now: now, retentionDays: retentionDays)
         case .antigravity:
             return await scanAntigravity(homeDirectory: homeDirectory, now: now, retentionDays: retentionDays)
-        case .alibaba, .alibabaTokenPlan, .copilot, .zai, .minimax, .kimi, .cursor, .mimo, .iflytek, .tencentHunyuan, .tencentTokenPlan, .volcengine, .baiduQianfan, .openCodeGo, .kilo, .kiro, .ollama, .openRouter, .warp:
+        case .alibaba, .alibabaTokenPlan, .copilot, .zai, .minimax, .kimi, .cursor, .mimo, .iflytek, .tencentHunyuan, .tencentTokenPlan, .volcengine, .volcengineAgentPlan, .baiduQianfan, .openCodeGo, .kilo, .kiro, .ollama, .openRouter, .warp:
             // Misc providers don't expose token-level cost data through
             // any documented public protocol. The cost-history pipeline
             // is gated by `tool.supportsTokenCost` upstream. Returning
@@ -1240,7 +1240,7 @@ public enum CostUsageScanner {
                 cacheCreationInputTokens: cacheCreation,
                 outputTokens: event.output
             ) ?? 0
-        case .alibaba, .alibabaTokenPlan, .copilot, .zai, .minimax, .kimi, .cursor, .mimo, .iflytek, .tencentHunyuan, .tencentTokenPlan, .volcengine, .baiduQianfan, .openCodeGo, .kilo, .kiro, .ollama, .openRouter, .warp:
+        case .alibaba, .alibabaTokenPlan, .copilot, .zai, .minimax, .kimi, .cursor, .mimo, .iflytek, .tencentHunyuan, .tencentTokenPlan, .volcengine, .volcengineAgentPlan, .baiduQianfan, .openCodeGo, .kilo, .kiro, .ollama, .openRouter, .warp:
             return 0
         }
     }

--- a/Sources/VibeBarCore/Services/MockDataProvider.swift
+++ b/Sources/VibeBarCore/Services/MockDataProvider.swift
@@ -171,7 +171,7 @@ public enum MockDataProvider {
                 extraUsageEnabled: true,
                 updatedAt: now
             )
-        case .alibaba, .alibabaTokenPlan, .gemini, .antigravity, .grok, .copilot, .zai, .minimax, .kimi, .cursor, .mimo, .iflytek, .tencentHunyuan, .tencentTokenPlan, .volcengine, .baiduQianfan, .openCodeGo, .kilo, .kiro, .ollama, .openRouter, .warp:
+        case .alibaba, .alibabaTokenPlan, .gemini, .antigravity, .grok, .copilot, .zai, .minimax, .kimi, .cursor, .mimo, .iflytek, .tencentHunyuan, .tencentTokenPlan, .volcengine, .volcengineAgentPlan, .baiduQianfan, .openCodeGo, .kilo, .kiro, .ollama, .openRouter, .warp:
             // Misc / partial-primary providers don't carry credits or
             // overage extras in the mock. The Cursor card surfaces
             // on-demand budget through a different field on
@@ -257,7 +257,7 @@ public enum MockDataProvider {
                     rawWindowSeconds: nil
                 )
             ]
-        case .alibaba, .alibabaTokenPlan, .copilot, .zai, .minimax, .kimi, .cursor, .mimo, .iflytek, .tencentHunyuan, .tencentTokenPlan, .volcengine, .baiduQianfan, .openCodeGo, .kilo, .kiro, .ollama, .openRouter, .warp:
+        case .alibaba, .alibabaTokenPlan, .copilot, .zai, .minimax, .kimi, .cursor, .mimo, .iflytek, .tencentHunyuan, .tencentTokenPlan, .volcengine, .volcengineAgentPlan, .baiduQianfan, .openCodeGo, .kilo, .kiro, .ollama, .openRouter, .warp:
             // Misc providers' mock data lands in subsequent phases as
             // each adapter is wired up. For now return a single
             // illustrative bucket so the card renders something during

--- a/Sources/VibeBarCore/Services/QuotaService.swift
+++ b/Sources/VibeBarCore/Services/QuotaService.swift
@@ -66,6 +66,7 @@ public final class QuotaService: ObservableObject {
                 .tencentHunyuan: TencentHunyuanQuotaAdapter(),
                 .tencentTokenPlan: TencentTokenPlanQuotaAdapter(),
                 .volcengine: VolcengineQuotaAdapter(),
+                .volcengineAgentPlan: VolcengineAgentPlanQuotaAdapter(),
                 .baiduQianfan: BaiduQianfanQuotaAdapter(),
                 .openCodeGo: OpenCodeGoQuotaAdapter(),
                 .kilo: KiloQuotaAdapter(),

--- a/Sources/VibeBarCore/Services/ServiceStatusClient.swift
+++ b/Sources/VibeBarCore/Services/ServiceStatusClient.swift
@@ -26,7 +26,7 @@ public actor ServiceStatusClient {
             return try await fetchGoogleAppsStatus(tool: tool, dayCount: dayCount, now: now)
         case .grok:
             return try await fetchXAIStatus(dayCount: dayCount, now: now)
-        case .alibaba, .alibabaTokenPlan, .copilot, .zai, .minimax, .kimi, .cursor, .mimo, .iflytek, .tencentHunyuan, .tencentTokenPlan, .volcengine, .baiduQianfan, .openCodeGo, .kilo, .kiro, .ollama, .openRouter, .warp:
+        case .alibaba, .alibabaTokenPlan, .copilot, .zai, .minimax, .kimi, .cursor, .mimo, .iflytek, .tencentHunyuan, .tencentTokenPlan, .volcengine, .volcengineAgentPlan, .baiduQianfan, .openCodeGo, .kilo, .kiro, .ollama, .openRouter, .warp:
             // Misc providers don't expose known machine-readable status APIs.
             // `tool.supportsStatusPage` is `false` for all of them, and
             // upstream callers should already be filtering to primary

--- a/Tests/VibeBarCoreTests/VolcengineAgentPlanParserTests.swift
+++ b/Tests/VibeBarCoreTests/VolcengineAgentPlanParserTests.swift
@@ -1,0 +1,151 @@
+import XCTest
+@testable import VibeBarCore
+
+final class VolcengineAgentPlanParserTests: XCTestCase {
+    /// Captured live from `GetAgentPlanAFPUsage` (numbers only, no PII).
+    private let liveBody = """
+    {
+      "ResponseMetadata": {"RequestId": "req-1", "Action": "GetAgentPlanAFPUsage"},
+      "Result": {
+        "PlanType": "medium",
+        "AFPFiveHour": {"Quota": 10000, "Used": 411.0225, "SubscribeTime": 1781701260000, "ResetTime": 1781719260000},
+        "AFPWeekly":   {"Quota": 35000, "Used": 411.0718, "SubscribeTime": 1781452800000, "ResetTime": 1782057600000},
+        "AFPMonthly":  {"Quota": 100000, "Used": 411.0718, "SubscribeTime": 1781591283000, "ResetTime": 1784217599000},
+        "AFPDaily":    {"Quota": 50000, "Used": 0, "SubscribeTime": 1781625600000, "ResetTime": 1781712000000}
+      }
+    }
+    """
+
+    func testParsesThreeWindowsAndSkipsDaily() throws {
+        let snap = try VolcengineAgentPlanResponseParser.parseUsage(data: Data(liveBody.utf8))
+        // AFPDaily is present in the payload but intentionally not surfaced.
+        XCTAssertEqual(snap.buckets.count, 3)
+
+        XCTAssertEqual(snap.buckets[0].id, "volcengineAgentPlan.session")
+        XCTAssertEqual(snap.buckets[0].title, "5 Hours")
+        XCTAssertEqual(snap.buckets[0].shortLabel, "5h")
+        XCTAssertEqual(snap.buckets[0].rawWindowSeconds, 5 * 3600)
+        // 411.0225 / 10000 * 100 = 4.110225
+        XCTAssertEqual(snap.buckets[0].usedPercent, 4.110225, accuracy: 0.0001)
+        // ResetTime is in milliseconds → seconds.
+        XCTAssertEqual(snap.buckets[0].resetAt?.timeIntervalSince1970 ?? 0, 1781719260, accuracy: 1)
+
+        XCTAssertEqual(snap.buckets[1].id, "volcengineAgentPlan.weekly")
+        XCTAssertEqual(snap.buckets[1].rawWindowSeconds, 7 * 86_400)
+        XCTAssertEqual(snap.buckets[1].usedPercent, 411.0718 / 35000 * 100, accuracy: 0.0001)
+
+        XCTAssertEqual(snap.buckets[2].id, "volcengineAgentPlan.monthly")
+        XCTAssertEqual(snap.buckets[2].rawWindowSeconds, 30 * 86_400)
+        XCTAssertEqual(snap.buckets[2].usedPercent, 411.0718 / 100000 * 100, accuracy: 0.0001)
+    }
+
+    func testPlanTypeBecomesCapitalizedBadge() throws {
+        let snap = try VolcengineAgentPlanResponseParser.parseUsage(data: Data(liveBody.utf8))
+        XCTAssertEqual(snap.planName, "Agent Plan Medium")
+    }
+
+    func testMissingPlanTypeLeavesPlanNameNil() throws {
+        let json = """
+        {"Result": {"AFPFiveHour": {"Quota": 10000, "Used": 100, "ResetTime": 1781719260000}}}
+        """
+        let snap = try VolcengineAgentPlanResponseParser.parseUsage(data: Data(json.utf8))
+        XCTAssertNil(snap.planName)
+        XCTAssertEqual(snap.buckets.count, 1)
+        XCTAssertEqual(snap.buckets[0].id, "volcengineAgentPlan.session")
+    }
+
+    func testZeroQuotaWindowIsSkipped() throws {
+        let json = """
+        {
+          "Result": {
+            "PlanType": "small",
+            "AFPFiveHour": {"Quota": 0, "Used": 0, "ResetTime": 1781719260000},
+            "AFPWeekly":   {"Quota": 35000, "Used": 350, "ResetTime": 1782057600000}
+          }
+        }
+        """
+        let snap = try VolcengineAgentPlanResponseParser.parseUsage(data: Data(json.utf8))
+        XCTAssertEqual(snap.buckets.count, 1)
+        XCTAssertEqual(snap.buckets[0].id, "volcengineAgentPlan.weekly")
+        XCTAssertEqual(snap.buckets[0].usedPercent, 1.0, accuracy: 0.0001)
+    }
+
+    func testZeroUsageIsAValidZeroPercentBucket() throws {
+        let json = """
+        {"Result": {"PlanType": "large", "AFPMonthly": {"Quota": 100000, "Used": 0, "ResetTime": 1784217599000}}}
+        """
+        let snap = try VolcengineAgentPlanResponseParser.parseUsage(data: Data(json.utf8))
+        XCTAssertEqual(snap.buckets.count, 1)
+        XCTAssertEqual(snap.buckets[0].id, "volcengineAgentPlan.monthly")
+        XCTAssertEqual(snap.buckets[0].usedPercent, 0, accuracy: 0.0001)
+    }
+
+    func testInvalidStateMapsToNeedsLogin() {
+        let json = """
+        {"ResponseMetadata": {"Error": {"Code": "InvalidState", "Message": "登录态已更新"}}}
+        """
+        XCTAssertThrowsError(try VolcengineAgentPlanResponseParser.parseUsage(data: Data(json.utf8))) { error in
+            guard let qe = error as? QuotaError, case .needsLogin = qe else {
+                XCTFail("Expected needsLogin, got \(error)")
+                return
+            }
+        }
+    }
+
+    func testRequestLimitMapsToRateLimited() {
+        let json = """
+        {"ResponseMetadata": {"Error": {"Code": "RequestLimitExceeded", "Message": "rate"}}}
+        """
+        XCTAssertThrowsError(try VolcengineAgentPlanResponseParser.parseUsage(data: Data(json.utf8))) { error in
+            guard let qe = error as? QuotaError, case .rateLimited = qe else {
+                XCTFail("Expected rateLimited, got \(error)")
+                return
+            }
+        }
+    }
+
+    func testGenericErrorMapsToNetworkError() {
+        let json = """
+        {"ResponseMetadata": {"Error": {"Code": "InternalError", "Message": "boom"}}}
+        """
+        XCTAssertThrowsError(try VolcengineAgentPlanResponseParser.parseUsage(data: Data(json.utf8))) { error in
+            guard let qe = error as? QuotaError, case .network = qe else {
+                XCTFail("Expected network error, got \(error)")
+                return
+            }
+        }
+    }
+
+    func testMissingResultBlockThrowsParseFailure() {
+        let json = """
+        {"ResponseMetadata": {"RequestId": "x"}}
+        """
+        XCTAssertThrowsError(try VolcengineAgentPlanResponseParser.parseUsage(data: Data(json.utf8))) { error in
+            guard let qe = error as? QuotaError, case .parseFailure = qe else {
+                XCTFail("Expected parseFailure, got \(error)")
+                return
+            }
+        }
+    }
+
+    func testResultWithNoWindowsThrowsParseFailure() {
+        let json = """
+        {"Result": {"PlanType": "medium"}}
+        """
+        XCTAssertThrowsError(try VolcengineAgentPlanResponseParser.parseUsage(data: Data(json.utf8))) { error in
+            guard let qe = error as? QuotaError, case .parseFailure = qe else {
+                XCTFail("Expected parseFailure, got \(error)")
+                return
+            }
+        }
+    }
+
+    func testEmptyBodyThrowsParseFailure() {
+        XCTAssertThrowsError(try VolcengineAgentPlanResponseParser.parseUsage(data: Data())) { error in
+            guard let qe = error as? QuotaError, case .parseFailure = qe else {
+                XCTFail("Expected parseFailure, got \(error)")
+                return
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What

Volcengine recently split its Ark subscription into two products: the existing **Coding Plan** (percent-only) and a new **Agent Plan** metered in *AFP* units (Agent 燃料值 / Agent Fuel Points). This adds a sibling misc-provider card for the Agent Plan, mirroring the Tencent / Alibaba dual-plan split (`.tencentHunyuan`/`.tencentTokenPlan`, `.alibaba`/`.alibabaTokenPlan`).

## How

- New `.volcengineAgentPlan` ToolType + `VolcengineAgentPlanQuotaAdapter`.
- Endpoint (captured live from the console via Chrome devtools): `POST .../2024-01-01/GetAgentPlanAFPUsage`. One call returns everything the card needs:
  - `Result.PlanType` → plan badge (`"Agent Plan Medium"`).
  - `Result.AFPFiveHour` / `AFPWeekly` / `AFPMonthly` → each `{ Quota, Used, SubscribeTime, ResetTime }`.
- So, unlike the Coding Plan adapter, there is **no** companion `ListSubscribeTrade` call — `PlanType` already carries the plan name.
- Percent is computed ourselves (`Used / Quota * 100`).
- We surface the three windows the console shows (5-hour / weekly / monthly). The API also returns `AFPDaily`, but the console hides it for the observed tiers (its quota sits *above* the weekly cap — a vestigial default, not an enforced limit), so we skip it too.
- ⚠️ `ResetTime` here is **epoch milliseconds**, whereas the Coding Plan endpoint's `ResetTimestamp` is seconds. Handled + unit-tested.

## Shared login

Both Volcengine cards ride one console session: identical `*.volcengine.com` cookie jar with `csrfToken` mirrored into `X-Csrf-Token`, the same IAM keepalive refresh, and the same in-app WKWebView login (it just lands on the Agent Plan tab). With browser-cookie auto-import on (the default), signing in once populates both cards.

## Validation

- `swift build` ✅
- `swift test` ✅ — 562 existing + **11 new** `VolcengineAgentPlanParserTests` (3-window parse, AFPDaily skip, ms→s reset, PlanType badge, zero-quota skip, auth/rate-limit/parse-failure mapping).
- `./Scripts/build_app.sh release` ✅
- `codesign -d --entitlements -` → empty `<dict/>`, no `app-sandbox`; `--verify --deep --strict` ✅

Fixtures are numbers-only (no account IDs / cookies / personal paths); the status-page deep link carries no `projectName`.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>