### PR TITLE
Fix MiniMax Token Plan usage from new remaining-percent fields

### DIFF
--- a/Sources/VibeBarCore/Adapters/MiniMaxQuotaAdapter.swift
+++ b/Sources/VibeBarCore/Adapters/MiniMaxQuotaAdapter.swift
@@ -283,7 +283,11 @@ enum MiniMaxResponseParser {
         var buckets: [QuotaBucket] = []
         var addedWeekly = false
         for (index, row) in rows.enumerated() {
-            guard (row.currentIntervalTotalCount ?? 0) > 0 else { continue }
+            // A row counts if it has either a count-based interval quota
+            // or the newer percentage-based one. The old `> 0` gate alone
+            // dropped TokenPlanMax's percentage-metered "general" model
+            // (whose count fields are zeroed) — the core of this bug.
+            guard (row.currentIntervalTotalCount ?? 0) > 0 || row.currentIntervalRemainingPercent != nil else { continue }
             buckets.append(modelBucket(from: row, index: index, now: now))
             if !addedWeekly, let weekly = weeklyBucket(from: row, now: now) {
                 buckets.append(weekly)
@@ -295,44 +299,74 @@ enum MiniMaxResponseParser {
 
     private static func modelBucket(from row: MiniMaxModelRemains, index: Int = 0, now: Date) -> QuotaBucket {
         let total = row.currentIntervalTotalCount ?? 0
-        let used = max(0, row.currentIntervalUsageCount ?? 0)
-        let remaining = max(0, total - used)
         let windowLabel = windowLabel(startTime: row.startTime, endTime: row.endTime) ?? "5 hours"
         let title = serviceTitle(displayName: row.displayName, modelName: row.modelName) ?? "5 Hours"
+        let usage = usage(total: total, usageCount: row.currentIntervalUsageCount, remainingPercent: row.currentIntervalRemainingPercent, windowLabel: windowLabel)
         return quotaBucket(
             id: "minimax.coding.\(index).\(slug(row.modelName ?? title))",
             title: title,
             shortLabel: "5h",
-            used: used,
+            used: usage.used,
             total: total,
             percent: nil,
+            usedPercentOverride: usage.usedPercent,
             startTime: row.startTime,
             endTime: row.endTime,
             remainsTime: row.remainsTime,
             windowSeconds: 5 * 3600,
             now: now,
-            groupTitle: "\(remaining)/\(total) · \(windowLabel)"
+            groupTitle: usage.groupTitle
         )
     }
 
-    private static func weeklyBucket(from row: MiniMaxModelRemains, now: Date) -> QuotaBucket? {
-        guard (row.currentWeeklyTotalCount ?? 0) > 0 else { return nil }
-        let total = row.currentWeeklyTotalCount ?? 0
-        let used = max(0, row.currentWeeklyUsageCount ?? 0)
+    /// Resolve a window's usage. The newer TokenPlanMax shape carries the
+    /// real figure in `*_remaining_percent` (counts are zeroed for the
+    /// percentage-metered "general" model, and for count-metered bonus
+    /// rows the raw `usage_count` is *not* the used count) — so when a
+    /// remaining-percent is present it is authoritative: used% = 100 - it,
+    /// and any count display is derived from it. Older count-only shapes
+    /// fall back to `usage_count` as the used count.
+    private static func usage(
+        total: Int,
+        usageCount: Int?,
+        remainingPercent: Int?,
+        windowLabel: String
+    ) -> (used: Int, usedPercent: Double?, groupTitle: String?) {
+        if let remainingPercent {
+            let remainingFraction = max(0, min(100, Double(remainingPercent))) / 100
+            let usedPercent = max(0, min(100, 100 - Double(remainingPercent)))
+            if total > 0 {
+                let remainingCount = Int((Double(total) * remainingFraction).rounded())
+                let used = max(0, total - remainingCount)
+                return (used, usedPercent, "\(remainingCount)/\(total) · \(windowLabel)")
+            }
+            return (0, usedPercent, "\(remainingPercent)% left · \(windowLabel)")
+        }
+        let used = max(0, usageCount ?? 0)
         let remaining = max(0, total - used)
+        return (used, nil, "\(remaining)/\(total) · \(windowLabel)")
+    }
+
+    private static func weeklyBucket(from row: MiniMaxModelRemains, now: Date) -> QuotaBucket? {
+        let total = row.currentWeeklyTotalCount ?? 0
+        // Newer plans zero the weekly count and report only a percentage,
+        // so a present `current_weekly_remaining_percent` also qualifies.
+        guard total > 0 || row.currentWeeklyRemainingPercent != nil else { return nil }
+        let usage = usage(total: total, usageCount: row.currentWeeklyUsageCount, remainingPercent: row.currentWeeklyRemainingPercent, windowLabel: "weekly")
         return quotaBucket(
             id: "minimax.weekly",
             title: "Weekly",
             shortLabel: "Wk",
-            used: used,
+            used: usage.used,
             total: total,
             percent: nil,
+            usedPercentOverride: usage.usedPercent,
             startTime: row.weeklyStartTime,
             endTime: row.weeklyEndTime,
             remainsTime: row.weeklyRemainsTime,
             windowSeconds: 7 * 86_400,
             now: now,
-            groupTitle: "\(remaining)/\(total) · weekly"
+            groupTitle: usage.groupTitle
         )
     }
 
@@ -367,6 +401,7 @@ enum MiniMaxResponseParser {
         used: Int,
         total: Int,
         percent: Double?,
+        usedPercentOverride: Double? = nil,
         startTime: Int?,
         endTime: Int?,
         remainsTime: Int?,
@@ -375,7 +410,11 @@ enum MiniMaxResponseParser {
         groupTitle: String? = nil
     ) -> QuotaBucket {
         let usedPercent: Double
-        if let percent {
+        if let usedPercentOverride {
+            // Authoritative 0–100 value (e.g. derived from the API's own
+            // `*_remaining_percent`); skip the count / fraction heuristics.
+            usedPercent = usedPercentOverride
+        } else if let percent {
             usedPercent = percent <= 1 ? percent * 100 : percent
         } else if total > 0 {
             usedPercent = Double(max(0, used)) / Double(total) * 100
@@ -686,6 +725,10 @@ private struct MiniMaxModelRemains: Decodable {
     let weeklyStartTime: Int?
     let weeklyEndTime: Int?
     let weeklyRemainsTime: Int?
+    /// TokenPlanMax-era fields: the percentage of the window's allowance
+    /// still available (0–100). Authoritative when present.
+    let currentIntervalRemainingPercent: Int?
+    let currentWeeklyRemainingPercent: Int?
 
     enum CodingKeys: String, CodingKey {
         case modelName = "model_name"
@@ -705,6 +748,8 @@ private struct MiniMaxModelRemains: Decodable {
         case weeklyStartTime = "weekly_start_time"
         case weeklyEndTime = "weekly_end_time"
         case weeklyRemainsTime = "weekly_remains_time"
+        case currentIntervalRemainingPercent = "current_interval_remaining_percent"
+        case currentWeeklyRemainingPercent = "current_weekly_remaining_percent"
     }
 
     init(from decoder: Decoder) throws {
@@ -729,6 +774,8 @@ private struct MiniMaxModelRemains: Decodable {
         weeklyStartTime = MiniMaxQuotaDecoding.int(c, forKey: .weeklyStartTime)
         weeklyEndTime = MiniMaxQuotaDecoding.int(c, forKey: .weeklyEndTime)
         weeklyRemainsTime = MiniMaxQuotaDecoding.int(c, forKey: .weeklyRemainsTime)
+        currentIntervalRemainingPercent = MiniMaxQuotaDecoding.int(c, forKey: .currentIntervalRemainingPercent)
+        currentWeeklyRemainingPercent = MiniMaxQuotaDecoding.int(c, forKey: .currentWeeklyRemainingPercent)
     }
 }
 

--- a/Tests/VibeBarCoreTests/KimiMiniMaxParserTests.swift
+++ b/Tests/VibeBarCoreTests/KimiMiniMaxParserTests.swift
@@ -200,6 +200,64 @@ final class MiniMaxParserTests: XCTestCase {
         XCTAssertEqual(snap.buckets[0].rawWindowSeconds, 5 * 3600)
     }
 
+    /// New TokenPlanMax shape (captured live from coding_plan/remains).
+    /// The primary "general" model reports usage via
+    /// `current_*_remaining_percent`, with the legacy `*_count` fields
+    /// zeroed. A bonus "video" row keeps count fields but its real usage
+    /// also lives in `remaining_percent` (100 = nothing used) — the raw
+    /// `usage_count` is NOT "used" here. The old parser skipped the
+    /// zero-count general row and rendered the video row at 100%.
+    func testNewTokenPlanMaxRemainingPercentShape() throws {
+        let json = """
+        {
+          "model_remains": [
+            {
+              "start_time": 1781697600000, "end_time": 1781712000000, "remains_time": 6989144,
+              "current_interval_total_count": 0, "current_interval_usage_count": 0,
+              "model_name": "general",
+              "current_weekly_total_count": 0, "current_weekly_usage_count": 0,
+              "weekly_start_time": 1781452800000, "weekly_end_time": 1782057600000, "weekly_remains_time": 352589144,
+              "current_interval_status": 1, "current_interval_remaining_percent": 88,
+              "current_weekly_status": 1, "current_weekly_remaining_percent": 82,
+              "weekly_boost_permille": 1500
+            },
+            {
+              "start_time": 1781625600000, "end_time": 1781712000000, "remains_time": 6989144,
+              "current_interval_total_count": 3, "current_interval_usage_count": 3,
+              "model_name": "video",
+              "current_weekly_total_count": 21, "current_weekly_usage_count": 21,
+              "weekly_start_time": 1781452800000, "weekly_end_time": 1782057600000,
+              "current_interval_status": 1, "current_interval_remaining_percent": 100,
+              "current_weekly_status": 1, "current_weekly_remaining_percent": 100
+            }
+          ],
+          "base_resp": {"status_code": 0, "status_msg": "success"}
+        }
+        """
+        let snap = try MiniMaxResponseParser.parse(data: Data(json.utf8), now: now)
+
+        // The general row must NOT be skipped, and nothing should render
+        // as ~100% (the old bug surfaced the video count row at 100%).
+        XCTAssertFalse(
+            snap.buckets.contains { $0.usedPercent >= 99 },
+            "no window is near-exhausted; got \(snap.buckets.map(\.usedPercent))"
+        )
+
+        // Weekly = 100 - current_weekly_remaining_percent (82) = 18%.
+        let weekly = snap.buckets.first { $0.rawWindowSeconds == 7 * 86_400 }
+        XCTAssertNotNil(weekly, "weekly bucket should come from the general row")
+        XCTAssertEqual(weekly?.usedPercent ?? -1, 18, accuracy: 0.5)
+
+        // Two 5-hour buckets: general text (100-88 = 12%) and video bonus (0%).
+        let fiveHourUsed = snap.buckets
+            .filter { $0.rawWindowSeconds == 5 * 3600 }
+            .map(\.usedPercent)
+            .sorted()
+        XCTAssertEqual(fiveHourUsed.count, 2)
+        XCTAssertEqual(fiveHourUsed.first ?? -1, 0, accuracy: 0.5)   // video: 100% remaining
+        XCTAssertEqual(fiveHourUsed.last ?? -1, 12, accuracy: 0.5)   // general text: 12% used
+    }
+
     func testPrefersChatModelRemainsOverMediaRows() throws {
         let json = """
         {


### PR DESCRIPTION
## Symptom

The MiniMax (Token Plan) card showed **clearly wrong** data: a maxed-out bar with the real text-token usage missing.

## Root cause (captured live from the console via Chrome)

MiniMax's newer **TokenPlanMax** subscription changed the `coding_plan/remains` response. The real per-window usage of the primary `"general"` (text) model now lives **only** in new percentage fields, with the legacy count fields zeroed:

```jsonc
"model_remains": [
  { "model_name": "general",
    "current_interval_total_count": 0, "current_interval_usage_count": 0,   // zeroed
    "current_interval_remaining_percent": 88,    // ← real: 12% used
    "current_weekly_remaining_percent": 82,      // ← real: 18% used / 82% left
    "weekly_boost_permille": 1500 },
  { "model_name": "video",
    "current_interval_total_count": 3, "current_interval_usage_count": 3,
    "current_interval_remaining_percent": 100 }  // ← actually 0 used (3/3 available)
]
```

The old parser:
1. **Skipped** any row with `current_interval_total_count == 0` → dropped the real `general` text usage entirely.
2. Treated `current_interval_usage_count` as *used* → the `video` bonus row (`3/3`) rendered as **100% used**.

Net: the card displayed a full "video" bar and hid the actual text-token quota.

## Fix

Treat `current_interval_remaining_percent` / `current_weekly_remaining_percent` as authoritative when present:
- `usedPercent = 100 - remaining_percent`
- count display derived from it (`remaining = round(total * remaining_percent / 100)`)
- rows now also qualify when they carry a remaining-percent even with zero counts

The count-only path is untouched, so older Coding Plan responses and all existing fixtures keep working. With live data this matches the official dashboard: **5h 12% used, weekly 18% used / 82% left, video 0%**.

## Tests

- New `testNewTokenPlanMaxRemainingPercentShape` using the captured live shape — fails on `main` (`[100.0, 100.0]`), passes after the fix.
- All 16 MiniMax parser tests + full suite (552) green.

## Validation

`swift build` ✅ · `swift test` ✅ (552) · `./Scripts/build_app.sh release` ✅ · `codesign -d --entitlements` → empty `<dict/>`, no `app-sandbox`; `--verify --deep --strict` ✅

Fixture is numbers + generic model names only (no account data).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>