### PR TITLE
Refresh stale Claude web cookie and drop routines placeholder

### DIFF
--- a/Sources/VibeBarCore/Adapters/ClaudeQuotaAdapter.swift
+++ b/Sources/VibeBarCore/Adapters/ClaudeQuotaAdapter.swift
@@ -6,13 +6,33 @@ public struct ClaudeQuotaAdapter: QuotaAdapter {
     private let endpoint = URL(string: "https://api.anthropic.com/api/oauth/usage")!
     private let session: URLSession
     private let credentialResolver: @Sendable (CredentialSource, AccountIdentity) throws -> ClaudeCredential
+    /// Best-effort refresh of the stored claude.ai cookie from the user's
+    /// browser, used to self-heal an expired sessionKey on the web path.
+    /// Returns true when a fresh cookie was imported. Injectable for tests.
+    private let reimportWebCookieOnStale: @Sendable () async -> Bool
 
     public init(
         session: URLSession = .shared,
-        credentialResolver: (@Sendable (CredentialSource, AccountIdentity) throws -> ClaudeCredential)? = nil
+        credentialResolver: (@Sendable (CredentialSource, AccountIdentity) throws -> ClaudeCredential)? = nil,
+        reimportWebCookieOnStale: (@Sendable () async -> Bool)? = nil
     ) {
         self.session = session
         self.credentialResolver = credentialResolver ?? Self.defaultResolver
+        self.reimportWebCookieOnStale = reimportWebCookieOnStale ?? Self.defaultWebCookieReimporter
+    }
+
+    /// Default cookie re-import: pull a fresh claude.ai sessionKey from the
+    /// user's browser into the keychain store. Gated by
+    /// `BrowserCookieAccessGate`, so it silently returns false (never prompts)
+    /// when keychain access isn't granted — a user-initiated import still
+    /// forces the prompt. Offloaded to a detached task to keep the SQLite /
+    /// Keychain reads off the fetch's executor.
+    @Sendable
+    private static func defaultWebCookieReimporter() async -> Bool {
+        await Task.detached(priority: .utility) {
+            let imported = (try? ClaudeBrowserCookieImporter.importAndStoreFromBrowsers()) ?? nil
+            return imported != nil
+        }.value
     }
 
     public func fetch(for account: AccountIdentity) async throws -> AccountQuota {
@@ -83,13 +103,12 @@ public struct ClaudeQuotaAdapter: QuotaAdapter {
             throw QuotaError.parseFailure(String(describing: error))
         }
         // Daily Routines lives on a different endpoint (claude.ai web cookie).
-        // Fold it in opportunistically. If the call fails or no cookies work,
-        // keep a visible placeholder so the Claude card still exposes the
-        // Daily Routines slot.
+        // Fold it in only when the budget call actually returns data — Claude
+        // dropped Daily Routines from the usage surface, so a forced placeholder
+        // would just show a misleading "100%".
         if let routines = await ClaudeRoutinesFetcher.fetch(session: session) {
             replaceRoutinesBucket(in: &buckets, with: routinesBucket(from: routines))
         }
-        ensureRoutinesBucketVisible(in: &buckets)
         let extras = ClaudeResponseParser.parseExtraUsage(data: data)
 
         return AccountQuota(
@@ -124,20 +143,20 @@ public struct ClaudeQuotaAdapter: QuotaAdapter {
         buckets.append(bucket)
     }
 
-    private func ensureRoutinesBucketVisible(in buckets: inout [QuotaBucket]) {
-        guard !buckets.contains(where: { $0.id == "daily_routines" }) else { return }
-        buckets.append(QuotaBucket(
-            id: "daily_routines",
-            title: "Today · -- / --",
-            shortLabel: "Routine",
-            usedPercent: 0,
-            resetAt: Self.nextRoutineResetDate(),
-            rawWindowSeconds: 86_400,
-            groupTitle: "Daily Routines"
-        ))
+    /// Preferred Claude path. On `needsLogin` (a stale / expired sessionKey) we
+    /// re-import a fresh cookie from the browser once and retry, so the web
+    /// path self-heals instead of silently falling through to the
+    /// rate-limited OAuth endpoint and pinning stale data.
+    private func fetchWithWebCookies(for account: AccountIdentity) async throws -> AccountQuota {
+        do {
+            return try await fetchWithWebCookiesOnce(for: account)
+        } catch QuotaError.needsLogin {
+            guard await reimportWebCookieOnStale() else { throw QuotaError.needsLogin }
+            return try await fetchWithWebCookiesOnce(for: account)
+        }
     }
 
-    private func fetchWithWebCookies(for account: AccountIdentity) async throws -> AccountQuota {
+    private func fetchWithWebCookiesOnce(for account: AccountIdentity) async throws -> AccountQuota {
         let cookieHeader = try ClaudeWebCookieStore.readCookieHeader()
         let organization = try await organizationID(cookieHeader: cookieHeader)
         let webAccount = await webAccountInfo(organizationID: organization.id, cookieHeader: cookieHeader)
@@ -168,7 +187,6 @@ public struct ClaudeQuotaAdapter: QuotaAdapter {
         if let routines {
             replaceRoutinesBucket(in: &buckets, with: routinesBucket(from: routines))
         }
-        ensureRoutinesBucketVisible(in: &buckets)
         let extras = ClaudeResponseParser.parseExtraUsage(data: data)
 
         return AccountQuota(

--- a/Sources/VibeBarCore/Adapters/ClaudeResponseParser.swift
+++ b/Sources/VibeBarCore/Adapters/ClaudeResponseParser.swift
@@ -156,13 +156,17 @@ public enum ClaudeResponseParser {
 
     private static func routineBucket(from root: [String: Any]) -> QuotaBucket? {
         for key in routineAliases {
-            guard root.keys.contains(key) else { continue }
-            let entry = root[key] as? [String: Any]
-            let utilization = numberValue(entry?["utilization"])
-                ?? numberValue(entry?["used_percent"])
-                ?? 0
-            let resetDate = parseDate(entry?["resets_at"])
-                ?? parseDate(entry?["reset_at"])
+            // Only surface Daily Routines when the alias carries a real
+            // utilization number. A present-but-null key (e.g.
+            // `"seven_day_cowork": null`) must not synthesize a misleading
+            // "0% used" routines section — Claude dropped Daily Routines from
+            // the usage payload, so absence means "don't show it".
+            guard let entry = root[key] as? [String: Any] else { continue }
+            guard let utilization = numberValue(entry["utilization"])
+                ?? numberValue(entry["used_percent"])
+            else { continue }
+            let resetDate = parseDate(entry["resets_at"])
+                ?? parseDate(entry["reset_at"])
             return QuotaBucket(
                 id: "daily_routines",
                 title: "Weekly",

--- a/Tests/VibeBarCoreTests/ClaudeParserTests.swift
+++ b/Tests/VibeBarCoreTests/ClaudeParserTests.swift
@@ -91,7 +91,10 @@ final class ClaudeParserTests: XCTestCase {
         XCTAssertEqual(buckets.count, 3)
     }
 
-    func testNullRoutineAliasStillShowsRoutineFallback() throws {
+    /// A present-but-null routine alias must NOT synthesize a misleading
+    /// "0% used" Daily Routines section. Claude dropped Daily Routines from the
+    /// usage payload, so absence of a real number means "don't show it".
+    func testNullRoutineAliasDoesNotShowRoutineFallback() throws {
         let json = """
         {
           "five_hour": {"utilization": 5},
@@ -100,12 +103,8 @@ final class ClaudeParserTests: XCTestCase {
         }
         """
         let buckets = try ClaudeResponseParser.parse(data: Data(json.utf8))
-        let routine = buckets.first { $0.id == "daily_routines" }!
-        XCTAssertEqual(routine.usedPercent, 0)
-        XCTAssertEqual(routine.title, "Weekly")
-        XCTAssertEqual(routine.shortLabel, "Routine wk")
-        XCTAssertEqual(routine.rawWindowSeconds, 604_800)
-        XCTAssertEqual(routine.groupTitle, "Daily Routines")
+        XCTAssertNil(buckets.first { $0.id == "daily_routines" })
+        XCTAssertEqual(buckets.count, 2)
     }
 
     func testRoutinesFetcherParsesStringFields() {
@@ -227,10 +226,10 @@ final class ClaudeParserTests: XCTestCase {
         XCTAssertEqual(design.usedPercent, 42)
         XCTAssertNotNil(design.resetAt)
 
-        // Null routine-like keys still keep the Daily Routines group visible.
-        let routine = buckets.first { $0.id == "daily_routines" }!
-        XCTAssertEqual(routine.usedPercent, 0)
-        XCTAssertEqual(routine.groupTitle, "Daily Routines")
+        // Null routine-like keys (e.g. `seven_day_cowork: null`) no longer
+        // synthesize a placeholder Daily Routines section — only a real
+        // utilization number surfaces the group.
+        XCTAssertNil(buckets.first { $0.id == "daily_routines" })
     }
 
     func testParseExtraUsageDecodesCentToDollar() {


### PR DESCRIPTION
## Why the Claude card went inaccurate

Claude usage in `auto` mode is **web-cookie first** (`ClaudeSourcePlanner.resolve(.auto) = [.webCookie, .oauthCLI, .cliDetected]`) and that path matches claude.ai exactly. But the automatic browser-cookie import bailed out whenever *any* cookie was already stored:

```swift
// AppEnvironment.importClaudeBrowserCookiesAndRefreshIfNeeded
if !allowKeychainPrompt, ClaudeWebCookieStore.hasCookieHeader() { return }
```

`hasCookieHeader()` checks **presence, not validity**. Once the stored `sessionKey` expired (claude.ai sessions roll over after a few weeks), the expired cookie still "existed", so the auto-import never refreshed it. The web path then `401`'d → fell through to the now-aggressively-rate-limited `/api/oauth/usage` (observed live: `429`, `retry-after: 1462`) → pinned the last cached snapshot. Result: the card silently drifts (e.g. a 5h window stuck at "resets in now") even though the user's *browser* cookie is perfectly valid. Classic "worked before, suddenly wrong" regression.

## Fix

1. **Self-heal the web path.** When `fetchWithWebCookies` hits `needsLogin`, re-import a fresh cookie from the browser **once** and retry, instead of dropping to OAuth. The re-import is gated by `BrowserCookieAccessGate`, so it silently no-ops (never spams Keychain prompts) when access isn't granted — a user-initiated "Import Claude cookies from browser" still forces the prompt. Injectable (`reimportWebCookieOnStale`) for tests.

2. **Drop the fake Daily Routines placeholder.** Claude removed Daily Routines from the usage surface. The adapter no longer synthesizes an empty `Today · -- / --` slot, and the parser no longer turns a present-but-null routine alias (`"seven_day_cowork": null`) into a misleading "0% used" section. Daily Routines now shows **only** when the run-budget endpoint or a real utilization number returns data.

## Immediate workaround for an already-stale install

Settings → **Import Claude cookies from browser** (one Keychain prompt → Allow), then refresh. After this PR an expired cookie re-imports itself on the next refresh.

## Validation

- `swift build` ✅
- `swift test` ✅ (579 tests; updated 2 parser tests that encoded the old placeholder behavior)
- `./Scripts/build_app.sh release` ✅
- `codesign -d --entitlements -` → empty `<dict/>`, no `app-sandbox` ✅ · `codesign --verify --deep --strict` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)