### PR TITLE
Show Codex limit reset credits in the Codex card

### DIFF
--- a/Sources/VibeBarApp/Views/PopoverRoot.swift
+++ b/Sources/VibeBarApp/Views/PopoverRoot.swift
@@ -1645,6 +1645,9 @@ struct ProviderQuotaCard: View {
 
             if let quota, !quota.buckets.isEmpty {
                 bucketContent(quota.buckets)
+                if tool == .codex, let credits = quota.resetCredits, credits.availableCount > 0 {
+                    ResetCreditsRow(credits: credits, density: density)
+                }
                 if let liveError {
                     messageRow(text: "Update failed: \(liveError.userFacingMessage)", color: .orange)
                 }
@@ -1744,6 +1747,42 @@ struct ProviderQuotaCard: View {
             return error
         }
         return nil
+    }
+}
+
+/// Codex "Limit reset credits" — manual rate-limit resets the user can spend,
+/// with the next expiry when the dedicated endpoint surfaced it. Only rendered
+/// when at least one reset is available.
+private struct ResetCreditsRow: View {
+    let credits: CodexResetCredits
+    let density: Theme.Density
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            HStack(alignment: .firstTextBaseline, spacing: 5) {
+                Image(systemName: "clock.arrow.circlepath")
+                    .font(.system(size: density.resetCountdownFontSize))
+                    .foregroundStyle(.secondary)
+                Text("Limit reset credits")
+                    .font(.system(size: density.bucketTitleFontSize, weight: .semibold))
+                Spacer(minLength: 6)
+                Text("\(credits.availableCount)")
+                    .font(.system(size: density.bucketPercentFontSize, weight: .semibold, design: .rounded).monospacedDigit())
+                    .foregroundStyle(Color.green)
+            }
+            Text(subtitle)
+                .font(.system(size: density.resetCountdownFontSize))
+                .foregroundStyle(.tertiary)
+        }
+    }
+
+    private var subtitle: String {
+        let noun = credits.availableCount == 1 ? "manual reset available" : "manual resets available"
+        if let expiry = credits.nextExpiresAt,
+           let countdown = ResetCountdownFormatter.string(from: expiry, now: Date()) {
+            return "\(credits.availableCount) \(noun) · next expires in \(countdown)"
+        }
+        return "\(credits.availableCount) \(noun)"
     }
 }
 

--- a/Sources/VibeBarCore/Adapters/CodexQuotaAdapter.swift
+++ b/Sources/VibeBarCore/Adapters/CodexQuotaAdapter.swift
@@ -86,6 +86,12 @@ public struct CodexQuotaAdapter: QuotaAdapter {
             throw QuotaError.parseFailure(String(describing: error))
         }
 
+        let resetCredits = await resolveResetCredits(
+            usageData: data,
+            accessToken: credential.accessToken,
+            accountId: credential.accountId
+        )
+
         return AccountQuota(
             accountId: account.id,
             tool: .codex,
@@ -93,8 +99,32 @@ public struct CodexQuotaAdapter: QuotaAdapter {
             plan: CodexResponseParser.planType(data: data) ?? credential.plan ?? account.plan,
             email: credential.email ?? account.email,
             queriedAt: Date(),
-            error: nil
+            error: nil,
+            resetCredits: resetCredits
         )
+    }
+
+    /// Resolve Codex manual reset credits. The inline `available_count` from the
+    /// usage payload is free; when it's >= 1 we make a best-effort call to the
+    /// dedicated endpoint to learn the next expiry. Returns nil when there's no
+    /// reset-credit data at all, so the UI simply omits the row.
+    private func resolveResetCredits(
+        usageData: Data,
+        accessToken: String,
+        accountId: String?
+    ) async -> CodexResetCredits? {
+        guard let inlineCount = CodexResponseParser.parseResetCreditsAvailableCount(data: usageData) else {
+            return nil
+        }
+        guard inlineCount > 0 else { return CodexResetCredits(availableCount: 0) }
+        if let enriched = await CodexResetCreditsFetcher.fetch(
+            accessToken: accessToken,
+            accountId: accountId,
+            session: session
+        ) {
+            return enriched
+        }
+        return CodexResetCredits(availableCount: inlineCount)
     }
 
     private func fetchWithWebCookies(for account: AccountIdentity) async throws -> AccountQuota {
@@ -140,6 +170,12 @@ public struct CodexQuotaAdapter: QuotaAdapter {
             throw QuotaError.parseFailure(String(describing: error))
         }
 
+        // Web-cookie path has no Bearer token for the dedicated reset-credits
+        // endpoint, so surface just the inline count when the usage payload
+        // carries it.
+        let resetCredits = CodexResponseParser.parseResetCreditsAvailableCount(data: data)
+            .map { CodexResetCredits(availableCount: $0) }
+
         return AccountQuota(
             accountId: account.id,
             tool: .codex,
@@ -147,7 +183,8 @@ public struct CodexQuotaAdapter: QuotaAdapter {
             plan: CodexResponseParser.planType(data: data) ?? account.plan,
             email: account.email,
             queriedAt: Date(),
-            error: nil
+            error: nil,
+            resetCredits: resetCredits
         )
     }
 

--- a/Sources/VibeBarCore/Adapters/CodexResponseParser.swift
+++ b/Sources/VibeBarCore/Adapters/CodexResponseParser.swift
@@ -64,6 +64,23 @@ public enum CodexResponseParser {
         return buckets
     }
 
+    /// Available manual rate-limit reset count inlined in the `/wham/usage`
+    /// payload under `rate_limit_reset_credits.available_count`. This is the
+    /// free, no-extra-request source for the headline number; the dedicated
+    /// `CodexResetCreditsFetcher` enriches it with the next expiry. Returns nil
+    /// when the block is absent (older API or web-cookie payloads).
+    public static func parseResetCreditsAvailableCount(data: Data) -> Int? {
+        guard
+            let root = try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any],
+            let block = root["rate_limit_reset_credits"] as? [String: Any],
+            let count = numberValue(block["available_count"]),
+            count >= 0
+        else {
+            return nil
+        }
+        return Int(count)
+    }
+
     public static func planType(data: Data) -> String? {
         guard
             let root = try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any],

--- a/Sources/VibeBarCore/Models/AccountQuota.swift
+++ b/Sources/VibeBarCore/Models/AccountQuota.swift
@@ -9,6 +9,9 @@ public struct AccountQuota: Codable, Hashable, Sendable {
     public var queriedAt: Date
     public var error: QuotaError?
     public var providerExtras: ProviderExtras?
+    /// Codex manual rate-limit reset credits (count + next expiry). Nil for
+    /// non-Codex tools and when the account has no reset-credit data.
+    public var resetCredits: CodexResetCredits?
 
     public init(
         accountId: String,
@@ -18,7 +21,8 @@ public struct AccountQuota: Codable, Hashable, Sendable {
         email: String? = nil,
         queriedAt: Date = Date(),
         error: QuotaError? = nil,
-        providerExtras: ProviderExtras? = nil
+        providerExtras: ProviderExtras? = nil,
+        resetCredits: CodexResetCredits? = nil
     ) {
         self.accountId = accountId
         self.tool = tool
@@ -28,6 +32,7 @@ public struct AccountQuota: Codable, Hashable, Sendable {
         self.queriedAt = queriedAt
         self.error = error
         self.providerExtras = providerExtras
+        self.resetCredits = resetCredits
     }
 
     public func bucket(id: String) -> QuotaBucket? {
@@ -43,7 +48,7 @@ public struct AccountQuota: Codable, Hashable, Sendable {
     }
 
     enum CodingKeys: String, CodingKey {
-        case accountId, tool, buckets, plan, email, queriedAt, error, providerExtras
+        case accountId, tool, buckets, plan, email, queriedAt, error, providerExtras, resetCredits
     }
 
     public init(from decoder: Decoder) throws {
@@ -55,6 +60,7 @@ public struct AccountQuota: Codable, Hashable, Sendable {
         email = try c.decodeIfPresent(String.self, forKey: .email)
         queriedAt = try c.decode(Date.self, forKey: .queriedAt)
         providerExtras = try c.decodeIfPresent(ProviderExtras.self, forKey: .providerExtras)
+        resetCredits = try c.decodeIfPresent(CodexResetCredits.self, forKey: .resetCredits)
         error = nil
     }
 
@@ -67,5 +73,6 @@ public struct AccountQuota: Codable, Hashable, Sendable {
         try c.encodeIfPresent(email, forKey: .email)
         try c.encode(queriedAt, forKey: .queriedAt)
         try c.encodeIfPresent(providerExtras, forKey: .providerExtras)
+        try c.encodeIfPresent(resetCredits, forKey: .resetCredits)
     }
 }

--- a/Sources/VibeBarCore/Models/CodexResetCredits.swift
+++ b/Sources/VibeBarCore/Models/CodexResetCredits.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+/// Codex "rate-limit reset credits" — manual reset grants the user can spend to
+/// reset a rate-limit window early (Codex CLI `/reset`). Surfaced in the Codex
+/// card as "N manual resets available · next expires in …".
+///
+/// `availableCount` is authoritative. It comes either from the inline
+/// `rate_limit_reset_credits.available_count` in the `/wham/usage` payload or
+/// from the dedicated `/wham/rate-limit-reset-credits` endpoint. `nextExpiresAt`
+/// is the earliest expiry among still-available, non-expired credits and is only
+/// populated when the dedicated endpoint is reachable.
+public struct CodexResetCredits: Codable, Hashable, Sendable {
+    public var availableCount: Int
+    public var nextExpiresAt: Date?
+
+    public init(availableCount: Int, nextExpiresAt: Date? = nil) {
+        self.availableCount = availableCount
+        self.nextExpiresAt = nextExpiresAt
+    }
+
+    /// Whether there is at least one reset to spend (the gate the UI uses to
+    /// decide whether to render the row at all).
+    public var hasAvailable: Bool { availableCount > 0 }
+}

--- a/Sources/VibeBarCore/Services/CodexResetCreditsFetcher.swift
+++ b/Sources/VibeBarCore/Services/CodexResetCreditsFetcher.swift
@@ -1,0 +1,100 @@
+import Foundation
+
+/// Fetches Codex manual rate-limit reset credits from
+/// `https://chatgpt.com/backend-api/wham/rate-limit-reset-credits`.
+///
+/// Response shape:
+/// ```
+/// {
+///   "credits": [
+///     { "status": "available", "granted_at": "…", "expires_at": "…" },
+///     …
+///   ],
+///   "available_count": 2
+/// }
+/// ```
+/// `available_count` is authoritative for the headline number. `nextExpiresAt`
+/// is the earliest `expires_at` among credits whose `status` is `available` and
+/// whose expiry is still in the future (mirroring CodexBar's
+/// "next expiring available credit").
+///
+/// Auth mirrors `CodexQuotaAdapter`: a Bearer access token (OAuth / CLI) plus
+/// the optional `ChatGPT-Account-Id` header. Returns `nil` silently on any
+/// network / decode failure so the caller can fall back to the inline count or
+/// simply omit the row.
+public enum CodexResetCreditsFetcher {
+    private static let endpoint = URL(string: "https://chatgpt.com/backend-api/wham/rate-limit-reset-credits")!
+
+    public static func fetch(
+        accessToken: String,
+        accountId: String?,
+        session: URLSession = .shared
+    ) async -> CodexResetCredits? {
+        var request = URLRequest(url: endpoint)
+        request.httpMethod = "GET"
+        request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+        request.setValue("codex-cli", forHTTPHeaderField: "User-Agent")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        if let accountId, !accountId.isEmpty {
+            request.setValue(accountId, forHTTPHeaderField: "ChatGPT-Account-Id")
+        }
+        request.timeoutInterval = 12
+
+        do {
+            let (data, response) = try await session.data(for: request)
+            guard let http = response as? HTTPURLResponse, http.statusCode == 200 else { return nil }
+            return parse(data: data)
+        } catch {
+            return nil
+        }
+    }
+
+    /// Internal entry point usable from tests with raw payload bytes. `now` is
+    /// injectable so the "skip stale available expiry" filter is deterministic.
+    public static func parse(data: Data, now: Date = Date()) -> CodexResetCredits? {
+        guard let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return nil
+        }
+        guard let count = anyInt(root["available_count"]), count >= 0 else { return nil }
+
+        let credits = (root["credits"] as? [[String: Any]]) ?? []
+        let nextExpiry = credits
+            .filter { isAvailable($0["status"]) }
+            .compactMap { parseDate($0["expires_at"]) }
+            .filter { $0 > now }
+            .min()
+
+        return CodexResetCredits(availableCount: count, nextExpiresAt: nextExpiry)
+    }
+
+    private static func isAvailable(_ raw: Any?) -> Bool {
+        (raw as? String)?.caseInsensitiveCompare("available") == .orderedSame
+    }
+
+    private static func anyInt(_ raw: Any?) -> Int? {
+        switch raw {
+        case let n as NSNumber: return n.intValue
+        case let i as Int:      return i
+        case let d as Double:   return Int(d)
+        case let s as String:   return Int(s)
+        default:                return nil
+        }
+    }
+
+    private static let isoFractional: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return f
+    }()
+
+    private static let isoPlain: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime]
+        return f
+    }()
+
+    private static func parseDate(_ raw: Any?) -> Date? {
+        guard let s = raw as? String else { return nil }
+        return isoFractional.date(from: s) ?? isoPlain.date(from: s)
+    }
+}

--- a/Tests/VibeBarCoreTests/CodexResetCreditsTests.swift
+++ b/Tests/VibeBarCoreTests/CodexResetCreditsTests.swift
@@ -1,0 +1,80 @@
+import XCTest
+@testable import VibeBarCore
+
+final class CodexResetCreditsTests: XCTestCase {
+    // MARK: Inline count from /wham/usage
+
+    func testInlineAvailableCountFromUsagePayload() {
+        let json = """
+        {
+          "rate_limit": {"primary_window": {"used_percent": 10, "limit_window_seconds": 18000}},
+          "rate_limit_reset_credits": {"available_count": 2}
+        }
+        """
+        XCTAssertEqual(CodexResponseParser.parseResetCreditsAvailableCount(data: Data(json.utf8)), 2)
+    }
+
+    func testInlineAvailableCountAbsentReturnsNil() {
+        let json = """
+        {"rate_limit": {"primary_window": {"used_percent": 10, "limit_window_seconds": 18000}}}
+        """
+        XCTAssertNil(CodexResponseParser.parseResetCreditsAvailableCount(data: Data(json.utf8)))
+    }
+
+    // MARK: Dedicated /wham/rate-limit-reset-credits endpoint
+
+    func testDedicatedEndpointDecodesCountAndSkipsStaleOrUnavailableExpiry() {
+        let now = ISO8601DateFormatter().date(from: "2026-06-22T00:00:00Z")!
+        // Four credits: one available-but-already-expired, two available in the
+        // future, and one future-dated but not "available". Next expiry must be
+        // the earliest *available, non-expired* one ("earlier", 2026-07-12) —
+        // NOT the earlier-but-unavailable "future_status" (2026-07-10).
+        let json = """
+        {
+          "credits": [
+            {"id": "expired", "reset_type": "codex_rate_limits", "status": "available",
+             "granted_at": "2026-05-18T00:39:53Z", "expires_at": "2026-06-17T00:39:53Z"},
+            {"id": "later", "reset_type": "codex_rate_limits", "status": "available",
+             "granted_at": "2026-06-18T00:39:53.731630Z", "expires_at": "2026-07-18T00:39:53.731630Z"},
+            {"id": "earlier", "reset_type": "codex_rate_limits", "status": "available",
+             "granted_at": "2026-06-12T04:03:43.263391Z", "expires_at": "2026-07-12T04:03:43.263391Z"},
+            {"id": "future_status", "reset_type": "codex_rate_limits", "status": "future_status",
+             "granted_at": "2026-06-12T04:03:43Z", "expires_at": "2026-07-10T04:03:43Z"}
+          ],
+          "available_count": 2
+        }
+        """
+        let snapshot = CodexResetCreditsFetcher.parse(data: Data(json.utf8), now: now)
+        XCTAssertEqual(snapshot?.availableCount, 2)
+
+        let fractional = ISO8601DateFormatter()
+        fractional.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        XCTAssertEqual(snapshot?.nextExpiresAt, fractional.date(from: "2026-07-12T04:03:43.263391Z"))
+    }
+
+    func testDedicatedEndpointEmptyCreditsGivesZeroCountNoExpiry() {
+        let snapshot = CodexResetCreditsFetcher.parse(data: Data(#"{"credits":[],"available_count":0}"#.utf8))
+        XCTAssertEqual(snapshot?.availableCount, 0)
+        XCTAssertNil(snapshot?.nextExpiresAt)
+    }
+
+    func testDedicatedEndpointRejectsNegativeCount() {
+        XCTAssertNil(CodexResetCreditsFetcher.parse(data: Data(#"{"credits":[],"available_count":-1}"#.utf8)))
+    }
+
+    // MARK: AccountQuota persistence
+
+    func testAccountQuotaRoundTripsResetCredits() throws {
+        let expiry = ISO8601DateFormatter().date(from: "2026-07-12T04:03:43Z")!
+        let quota = AccountQuota(
+            accountId: "codex",
+            tool: .codex,
+            buckets: [],
+            resetCredits: CodexResetCredits(availableCount: 2, nextExpiresAt: expiry)
+        )
+        let data = try JSONEncoder().encode(quota)
+        let decoded = try JSONDecoder().decode(AccountQuota.self, from: data)
+        XCTAssertEqual(decoded.resetCredits?.availableCount, 2)
+        XCTAssertEqual(decoded.resetCredits?.nextExpiresAt, expiry)
+    }
+}


### PR DESCRIPTION
## What

Codex banks manual rate-limit resets (one free at launch for Plus/Pro, plus earned ones — usable via `codex /reset`). This surfaces them in the Codex card the way CodexBar does:

> **Limit reset credits**  `2`
> 2 manual resets available · next expires in 19d 15h

## How

- `/wham/usage` already inlines `rate_limit_reset_credits.available_count` (verified live), so the headline number costs no extra request. `CodexResponseParser.parseResetCreditsAvailableCount` reads it.
- When the count is **≥ 1**, a best-effort call to the dedicated `/wham/rate-limit-reset-credits` endpoint (`CodexResetCreditsFetcher`) enriches it with the **next expiry** — the earliest `expires_at` among credits whose `status == "available"` and that haven't already expired (mirrors CodexBar's "next expiring available credit"). Count 0 / no data → no extra call, no row.
- New `CodexResetCredits` value carried on `AccountQuota` (Codable round-trips). The web-cookie Codex path surfaces just the inline count, since it has no Bearer token for the dedicated endpoint.
- `ProviderQuotaCard` renders the row only when `availableCount > 0`.

## Validation

- `swift build` ✅
- `swift test` ✅ (585 tests; +6 new in `CodexResetCreditsTests` covering inline count, the dedicated endpoint's stale/unavailable-expiry skipping, zero/negative counts, and `AccountQuota` round-trip)
- `./Scripts/build_app.sh release` ✅
- `codesign -d --entitlements -` → empty `<dict/>`, no `app-sandbox` ✅ · `codesign --verify --deep --strict` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)