### PR TITLE
Add Fable to Claude usage limits and enforce model-bucket parity

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -637,6 +637,65 @@ Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
   `CFBundleShortVersionString` and `CFBundleVersion` in
   `Resources/Info.plist`.
 
+### 11.1 Adding a new Claude usage-limit model
+
+Anthropic periodically adds a per-model dimension to the
+`/api/oauth/usage` payload (a new `seven_day_<model>` key — this is how
+Sonnet, Opus, and Fable each arrived). When you see one — in the API
+response, in logs, or because AQ points it out — add it end-to-end
+using this checklist. Do **not** stop at the parser; a half-added model
+parses but never becomes selectable.
+
+Use consistent ids for a model `<x>` (e.g. `fable`):
+
+| Layer | Value |
+|-------|-------|
+| API payload key | `seven_day_<x>` |
+| `QuotaBucket.id` | `weekly_<x>` |
+| Mini-window group key | `claude.<x>` |
+| Menu-bar field id | `claude.weekly_<x>` (built from the two above) |
+
+**Required (correctness — without these the model is invisible):**
+
+1. `Sources/VibeBarCore/Adapters/ClaudeResponseParser.swift` —
+   add a `BucketSpec` to `knownBuckets`
+   (`key: "seven_day_<x>", id: "weekly_<x>", …, groupTitle: "<X>"`) and
+   the doc-comment line. Unknown payload keys are silently dropped, so
+   this is the one edit that actually surfaces the data.
+2. `Sources/VibeBarCore/Models/MenuBarSettings.swift` —
+   add `option(.claude, "weekly_<x>", "<X> · Weekly", "<X> wk")` to
+   `claudeFields` so the bucket is selectable in the menu bar / mini
+   window. The `ClaudeModelBucketParityTests` suite **fails `swift test`**
+   if you skip this, so it's the backstop for the required half of this
+   list.
+
+**Mini-window polish (degrades gracefully via `groupTitle` fallbacks,
+but add for parity so the labels look hand-tuned):**
+
+3. `Sources/VibeBarApp/Views/MiniWindowGroupLabelCatalog.swift` —
+   add `.init(id: "claude.<x>", title: "CLAUDE · <X>", defaultLabel: "<X>")`.
+4. `Sources/VibeBarApp/Views/MiniQuotaWindowView.swift` — four switches:
+   `isBranchField`, `MiniBranchCell.defaultTitle` (use `"wk"`),
+   `.groupKey` (→ `"claude.<x>"`), `.defaultGroupTitle` (→ `"<X>"`).
+5. `Sources/VibeBarApp/MiniQuotaWindowController.swift` —
+   `miniBranchGroupKey` (→ `"claude.<x>"`), keeps AppKit panel sizing in
+   sync with the SwiftUI layout.
+
+**Nice to have:**
+
+6. `Sources/VibeBarCore/Services/MockDataProvider.swift` — add a sample
+   `weekly_<x>` bucket to the `.claude` branch so mock mode is
+   representative.
+7. `Tests/VibeBarCoreTests/ClaudeParserTests.swift` — extend
+   `testEachModelGetsItsOwnGroup` (present) and
+   `testWebUsageBucketsIncludeDesignWhenPresent` (null) fixtures.
+
+**Already automatic — do not add per-model code here:** the main popover
+(`PopoverRoot`), the status item, `OverallFillRate`,
+`SubscriptionUtilizationView`, and the Misc page all group Claude
+buckets by `QuotaBucket.groupTitle`, so a new model appears there the
+moment step 1 lands.
+
 ## 12. Releases
 
 - Bundle ID is `com.astroqore.VibeBar`. Bump

--- a/Sources/VibeBarApp/MiniQuotaWindowController.swift
+++ b/Sources/VibeBarApp/MiniQuotaWindowController.swift
@@ -226,6 +226,8 @@ final class MiniQuotaWindowController: NSObject, NSWindowDelegate {
             return "claude.routine"
         case "weekly_opus":
             return "claude.opus"
+        case "weekly_fable":
+            return "claude.fable"
         case "weekly_oauth_apps":
             return "claude.oauth"
         default:

--- a/Sources/VibeBarApp/Views/MiniQuotaWindowView.swift
+++ b/Sources/VibeBarApp/Views/MiniQuotaWindowView.swift
@@ -112,6 +112,7 @@ struct MiniQuotaWindowView: View {
              "weekly_design",
              "daily_routines",
              "weekly_opus",
+             "weekly_fable",
              "weekly_oauth_apps":
             return true
         default:
@@ -272,6 +273,7 @@ private struct MiniBranchCell: Identifiable {
         case "weekly_design": return "wk"
         case "daily_routines": return "Daily"
         case "weekly_opus": return "Opus"
+        case "weekly_fable": return "wk"
         case "weekly_oauth_apps": return "OAuth"
         case let id where tool == .antigravity && id.contains("gpt-oss"):
             return "GPT"
@@ -305,6 +307,8 @@ private struct MiniBranchCell: Identifiable {
             return "claude.routine"
         case "weekly_opus":
             return "claude.opus"
+        case "weekly_fable":
+            return "claude.fable"
         case "weekly_oauth_apps":
             return "claude.oauth"
         case let id where tool == .gemini && id.contains("flash-lite"):
@@ -343,6 +347,8 @@ private struct MiniBranchCell: Identifiable {
             return "Routine"
         case "weekly_opus":
             return "Opus"
+        case "weekly_fable":
+            return "Fable"
         case "weekly_oauth_apps":
             return "OAuth"
         case let id where tool == .gemini && id.contains("flash-lite"):

--- a/Sources/VibeBarApp/Views/MiniWindowGroupLabelCatalog.swift
+++ b/Sources/VibeBarApp/Views/MiniWindowGroupLabelCatalog.swift
@@ -13,6 +13,7 @@ enum MiniWindowGroupLabelCatalog {
         .init(id: "claude.design", title: "CLAUDE · Design", defaultLabel: "Design"),
         .init(id: "claude.routine", title: "CLAUDE · Routine", defaultLabel: "Routine"),
         .init(id: "claude.opus", title: "CLAUDE · Opus", defaultLabel: "Opus"),
+        .init(id: "claude.fable", title: "CLAUDE · Fable", defaultLabel: "Fable"),
         .init(id: "claude.oauth", title: "CLAUDE · OAuth", defaultLabel: "OAuth"),
         .init(id: "gemini.pro", title: "GEMINI · Pro", defaultLabel: "Pro"),
         .init(id: "gemini.flash", title: "GEMINI · Flash", defaultLabel: "Flash"),

--- a/Sources/VibeBarCore/Adapters/ClaudeResponseParser.swift
+++ b/Sources/VibeBarCore/Adapters/ClaudeResponseParser.swift
@@ -10,7 +10,14 @@ import Foundation
 ///   - `seven_day_sonnet`       → "Sonnet" (own section)
 ///   - `seven_day_omelette`     → "Designs" (own section)
 ///   - `seven_day_opus`         → "Opus" (own section, when present)
+///   - `seven_day_fable`        → "Fable" (own section, when present)
 ///   - `seven_day_oauth_apps`   → "OAuth Apps" (own section, when present)
+///
+/// Adding a new per-model dimension is a checklist, not a one-liner: see
+/// `AGENTS.md` § "Adding a new Claude usage-limit model". The
+/// `ClaudeModelBucketParityTests` suite fails `swift test` if a `knownBuckets`
+/// entry with a `groupTitle` has no matching menu-bar field, so the
+/// correctness-critical half of that checklist is self-enforcing.
 ///
 /// Daily Routines has a dedicated endpoint — see `ClaudeRoutinesFetcher` and
 /// `ClaudeQuotaAdapter` — but the OAuth/Web usage payload also exposes a set of
@@ -41,8 +48,18 @@ public enum ClaudeResponseParser {
         .init(key: "seven_day_sonnet", id: "weekly_sonnet", title: "Weekly", shortLabel: "Sonnet wk", windowSeconds: 604_800, groupTitle: "Sonnet"),
         .init(key: "seven_day_omelette", id: "weekly_design", title: "Weekly", shortLabel: "Designs", windowSeconds: 604_800, groupTitle: "Designs"),
         .init(key: "seven_day_opus", id: "weekly_opus", title: "Weekly", shortLabel: "Opus wk", windowSeconds: 604_800, groupTitle: "Opus"),
+        .init(key: "seven_day_fable", id: "weekly_fable", title: "Weekly", shortLabel: "Fable wk", windowSeconds: 604_800, groupTitle: "Fable"),
         .init(key: "seven_day_oauth_apps", id: "weekly_oauth_apps", title: "Weekly", shortLabel: "OAuth wk", windowSeconds: 604_800, groupTitle: "OAuth Apps")
     ]
+
+    /// Bucket ids for Claude's per-model weekly dimensions — every
+    /// `knownBuckets` entry that carries a `groupTitle`. Exposed read-only so
+    /// `ClaudeModelBucketParityTests` can assert the menu-bar field catalog
+    /// stays in lockstep with the parser: adding a model here without a
+    /// matching `MenuBarFieldCatalog.claudeFields` entry fails the suite.
+    public static var perModelBucketIDs: [String] {
+        knownBuckets.compactMap { $0.groupTitle == nil ? nil : $0.id }
+    }
 
     /// Aliases the API may use for the same logical key. Tried in order.
     private static let bucketAliases: [String: [String]] = [

--- a/Sources/VibeBarCore/Models/MenuBarSettings.swift
+++ b/Sources/VibeBarCore/Models/MenuBarSettings.swift
@@ -156,6 +156,7 @@ public enum MenuBarFieldCatalog {
         option(.claude, "weekly_design", "Designs · Weekly", "Design wk"),
         option(.claude, "daily_routines", "Daily Routines", "Routines"),
         option(.claude, "weekly_opus", "Opus · Weekly", "Opus wk"),
+        option(.claude, "weekly_fable", "Fable · Weekly", "Fable wk"),
         option(.claude, "weekly_oauth_apps", "OAuth Apps · Weekly", "OAuth wk")
     ]
 

--- a/Sources/VibeBarCore/Services/MockDataProvider.swift
+++ b/Sources/VibeBarCore/Services/MockDataProvider.swift
@@ -214,7 +214,9 @@ public enum MockDataProvider {
                 QuotaBucket(id: "daily_routines", title: "Today", shortLabel: "Routines",
                             usedPercent: 47, resetAt: dayReset, rawWindowSeconds: 86_400, groupTitle: "Daily Routines"),
                 QuotaBucket(id: "weekly_opus", title: "Weekly", shortLabel: "Opus wk",
-                            usedPercent: 18, resetAt: weeklyReset, rawWindowSeconds: 604_800, groupTitle: "Opus")
+                            usedPercent: 18, resetAt: weeklyReset, rawWindowSeconds: 604_800, groupTitle: "Opus"),
+                QuotaBucket(id: "weekly_fable", title: "Weekly", shortLabel: "Fable wk",
+                            usedPercent: 15, resetAt: weeklyReset, rawWindowSeconds: 604_800, groupTitle: "Fable")
             ]
         case .gemini:
             // Partial-primary mock: per-model buckets keep the Google

--- a/Tests/VibeBarCoreTests/ClaudeModelBucketParityTests.swift
+++ b/Tests/VibeBarCoreTests/ClaudeModelBucketParityTests.swift
@@ -1,0 +1,37 @@
+import XCTest
+@testable import VibeBarCore
+
+/// Parity guardrail for Claude's per-model usage limits — the self-enforcing
+/// half of the "Adding a new Claude usage-limit model" checklist in
+/// `AGENTS.md` § 11.1.
+///
+/// `ClaudeResponseParser.knownBuckets` is the single source of truth for which
+/// Claude usage dimensions become `QuotaBucket`s. Every per-model dimension
+/// (a `knownBuckets` entry carrying a `groupTitle`) must also have a
+/// `MenuBarFieldCatalog.claudeFields` entry, or it can never be selected for
+/// the menu bar / mini window. This suite fails `swift test` when the two
+/// drift, so adding a new Claude usage limit to the parser without wiring the
+/// menu-bar field is caught here instead of silently shipping a half-added
+/// model.
+final class ClaudeModelBucketParityTests: XCTestCase {
+    func testEveryPerModelBucketHasMenuBarField() {
+        let fieldBucketIDs = Set(MenuBarFieldCatalog.claudeFields.map { $0.bucketId })
+        for bucketID in ClaudeResponseParser.perModelBucketIDs {
+            XCTAssertTrue(
+                fieldBucketIDs.contains(bucketID),
+                """
+                Claude per-model bucket '\(bucketID)' from \
+                ClaudeResponseParser.knownBuckets has no matching \
+                MenuBarFieldCatalog.claudeFields entry. Add \
+                `option(.claude, "\(bucketID)", ...)` plus the mini-window \
+                label sites listed in AGENTS.md § 11.1 when introducing a new \
+                Claude usage limit.
+                """
+            )
+        }
+    }
+
+    func testFableBucketIsRegisteredAsPerModel() {
+        XCTAssertTrue(ClaudeResponseParser.perModelBucketIDs.contains("weekly_fable"))
+    }
+}

--- a/Tests/VibeBarCoreTests/ClaudeParserTests.swift
+++ b/Tests/VibeBarCoreTests/ClaudeParserTests.swift
@@ -53,7 +53,8 @@ final class ClaudeParserTests: XCTestCase {
           "seven_day": {"utilization": 20},
           "seven_day_opus": {"utilization": 30, "resets_at": "2026-05-01T00:00:00Z"},
           "seven_day_sonnet": {"utilization": 40, "resets_at": "2026-05-01T00:00:00Z"},
-          "seven_day_omelette": {"utilization": 50, "resets_at": "2026-05-01T00:00:00Z"}
+          "seven_day_omelette": {"utilization": 50, "resets_at": "2026-05-01T00:00:00Z"},
+          "seven_day_fable": {"utilization": 60, "resets_at": "2026-05-01T00:00:00Z"}
         }
         """
         let buckets = try ClaudeResponseParser.parse(data: Data(json.utf8))
@@ -69,6 +70,12 @@ final class ClaudeParserTests: XCTestCase {
         let opus = buckets.first { $0.id == "weekly_opus" }!
         XCTAssertEqual(opus.usedPercent, 30)
         XCTAssertEqual(opus.groupTitle, "Opus")
+
+        let fable = buckets.first { $0.id == "weekly_fable" }!
+        XCTAssertEqual(fable.usedPercent, 60)
+        XCTAssertEqual(fable.groupTitle, "Fable")
+        XCTAssertEqual(fable.shortLabel, "Fable wk")
+        XCTAssertEqual(fable.rawWindowSeconds, 604_800)
     }
 
     /// `seven_day_cowork` is kept as a visible fallback for Daily Routines
@@ -194,6 +201,7 @@ final class ClaudeParserTests: XCTestCase {
           },
           "seven_day_oauth_apps": null,
           "seven_day_opus": null,
+          "seven_day_fable": null,
           "seven_day_sonnet": {
             "utilization": 1.0,
             "resets_at": "2026-04-30T20:00:00.765522+00:00"
@@ -230,6 +238,10 @@ final class ClaudeParserTests: XCTestCase {
         // synthesize a placeholder Daily Routines section — only a real
         // utilization number surfaces the group.
         XCTAssertNil(buckets.first { $0.id == "daily_routines" })
+
+        // A present-but-null `seven_day_fable` (model exists in the schema but
+        // is unused on this account) must not synthesize a bogus 0% section.
+        XCTAssertNil(buckets.first { $0.id == "weekly_fable" })
     }
 
     func testParseExtraUsageDecodesCentToDollar() {


### PR DESCRIPTION
## Summary

Anthropic's `/api/oauth/usage` payload started returning a new per-model
`seven_day_fable` dimension, but `ClaudeResponseParser` drops any key that
isn't in `knownBuckets`, so the Fable weekly limit was silently thrown away
and never appeared in the popover, menu bar, or mini window.

This PR:

- **Surfaces Fable.** Adds the `seven_day_fable → weekly_fable` bucket spec
  (its own "Fable" section) and threads it through every per-model site that
  Sonnet/Opus already use: the menu-bar field catalog (`claudeFields`), the
  mini-window label catalog, the four `MiniQuotaWindowView` branch switches
  (`isBranchField`, `defaultTitle`, `groupKey`, `defaultGroupTitle`), the
  AppKit panel-sizing `miniBranchGroupKey`, and the mock provider. The main
  popover, status item, `OverallFillRate`, and `SubscriptionUtilizationView`
  already group by `QuotaBucket.groupTitle`, so they pick Fable up
  automatically once the parser emits it.

- **Adds a mechanism so the next model can't be half-added.** New
  `ClaudeResponseParser.perModelBucketIDs` + the `ClaudeModelBucketParityTests`
  suite fail `swift test` whenever a parser bucket that carries a `groupTitle`
  has no matching menu-bar field. `AGENTS.md` § 11.1 documents the full
  end-to-end checklist (required vs. mini-window polish vs. already-automatic
  sites) for adding a Claude usage-limit model.

Adding `weekly_fable` to `claudeFields` only makes it *available*; the default
selection stays `claude.five_hour` + `claude.weekly`, so existing users see no
change unless they opt in.

## Test plan

- `swift build` — clean (VibeBarApp + VibeBarCore).
- `swift test` — 587 tests pass, including the new `ClaudeModelBucketParityTests`
  and the extended `ClaudeParserTests` (present-Fable and null-Fable fixtures).
- `./Scripts/build_app.sh release` — packages + ad-hoc signs the bundle.
- `codesign -d --entitlements - ".build/Vibe Bar.app"` → empty `<dict/>`, no
  `app-sandbox` key.
- `codesign --verify --deep --strict ".build/Vibe Bar.app"` → OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
