### PR TITLE
Relabel Grok quota bucket as weekly

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -576,6 +576,14 @@ Match what `git log` shows on `main`:
 - Body wraps at ~72 chars, explains *why* and any non-obvious *how*.
   Skip the body for trivial changes.
 - Mention `Co-Authored-By:` trailers at the end if you collaborated.
+  Use the **runtime agent's** trailer — detect from your harness, don't
+  guess a model name from product branding or stale examples:
+
+  | Agent | Trailer |
+  | --- | --- |
+  | Claude Code | `Co-Authored-By: Claude <runtime model name> <noreply@anthropic.com>` — e.g. `Claude Opus 4.8 <noreply@anthropic.com>` |
+  | Codex | `Co-Authored-By: Codex <noreply@openai.com>` (read `commit_attribution` from `~/.codex/config.toml` if present) |
+  | Grok Build (Cursor) | `Co-Authored-By: Grok Composer 2.5 Fast (xAI) <noreply@x.ai>` |
 
 Example:
 
@@ -587,7 +595,7 @@ so the dynamic color resolved against whatever appearance happened to
 be current when the off-screen NSImage rendered. Forward the matching
 .darkAqua / .aqua appearance so labelColor resolves correctly.
 
-Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
 ```
 
 ### 9.5 After the PR is open

--- a/Sources/VibeBarCore/Adapters/GrokQuotaAdapter.swift
+++ b/Sources/VibeBarCore/Adapters/GrokQuotaAdapter.swift
@@ -14,9 +14,9 @@ import Foundation
 ///    user signed in to grok.com on the web but never ran
 ///    `grok login` — the case that Codex Bar already handles.
 ///
-/// The response is a tiny protobuf payload carrying the monthly
+/// The response is a tiny protobuf payload carrying the weekly
 /// used-percent and the next reset timestamp; both fields surface as
-/// a single `QuotaBucket(id: "monthly", ...)` on the card.
+/// a single `QuotaBucket(id: "weekly", ...)` on the card.
 public struct GrokQuotaAdapter: QuotaAdapter {
     public let tool: ToolType = .grok
 
@@ -99,16 +99,15 @@ public struct GrokQuotaAdapter: QuotaAdapter {
         email: String?
     ) -> AccountQuota {
         let bucket = QuotaBucket(
-            id: "monthly",
-            title: "Monthly",
-            shortLabel: "Monthly",
+            id: "weekly",
+            title: "Weekly",
+            shortLabel: "Weekly",
             usedPercent: snapshot.usedPercent,
             resetAt: snapshot.resetsAt,
-            // Calendar-month credits window. 31 days covers the longest
-            // month so `UsagePace` never rejects a fresh cycle
-            // (its guard requires time-until-reset <= window); short
-            // months just skew the expected line slightly early.
-            rawWindowSeconds: 2_678_400
+            // Seven-day credits window. Matches xAI's weekly reset cadence
+            // and keeps `UsagePace` from rejecting a fresh cycle (its guard
+            // requires time-until-reset <= window).
+            rawWindowSeconds: 604_800
         )
         return AccountQuota(
             accountId: account.id,

--- a/Sources/VibeBarCore/Adapters/GrokWebBillingFetcher.swift
+++ b/Sources/VibeBarCore/Adapters/GrokWebBillingFetcher.swift
@@ -3,7 +3,7 @@ import Foundation
 /// Decoded usage snapshot from grok.com's billing endpoint. The wire
 /// format is a gRPC-web `connect-es` response carrying a protobuf
 /// payload. We don't depend on a generated proto stub — instead a
-/// best-effort scanner pulls the monthly used-percent (`fixed32` field)
+/// best-effort scanner pulls the weekly used-percent (`fixed32` field)
 /// and the next reset timestamp (`varint` seconds since epoch) out of
 /// the bytes.
 public struct GrokWebBillingSnapshot: Sendable, Equatable {
@@ -227,7 +227,7 @@ public enum GrokWebBillingFetcher {
         }
 
         // The smallest "field number 1" fixed32 in the payload is the
-        // monthly used-percent. Picking the shallowest path keeps us
+        // weekly used-percent. Picking the shallowest path keeps us
         // pointed at the top-level usage object instead of a nested
         // sub-bucket that happens to share field=1.
         let parsedPercent = scan.fixed32Fields

--- a/Sources/VibeBarCore/Models/MenuBarSettings.swift
+++ b/Sources/VibeBarCore/Models/MenuBarSettings.swift
@@ -183,7 +183,7 @@ public enum MenuBarFieldCatalog {
     ]
 
     public static let grokFields: [MenuBarFieldOption] = [
-        option(.grok, "monthly", "Monthly Credits", "Mo")
+        option(.grok, "weekly", "Weekly Credits", "wk")
     ]
 
     public static let allFields: [MenuBarFieldOption] =
@@ -275,6 +275,7 @@ public enum MenuBarFieldCatalog {
             "antigravity.gemini-3.5-flash-high",
             "antigravity.gemini-3.5-flash-medium"
         ],
-        "antigravity.gemini-2.5-flash-lite": []
+        "antigravity.gemini-2.5-flash-lite": [],
+        "grok.monthly": ["grok.weekly"]
     ]
 }

--- a/Sources/VibeBarCore/Services/MockDataProvider.swift
+++ b/Sources/VibeBarCore/Services/MockDataProvider.swift
@@ -245,18 +245,18 @@ public enum MockDataProvider {
                             rawWindowSeconds: nil, groupTitle: "Claude")
             ]
         case .grok:
-            // Partial-primary mock: single monthly bucket so the
+            // Partial-primary mock: single weekly bucket so the
             // dedicated Grok sub-page renders the expected card
             // during mock mode.
-            let monthlyReset = now.addingTimeInterval(18 * 24 * 3600)
+            let weeklyReset = now.addingTimeInterval(4 * 24 * 3600)
             buckets = [
                 QuotaBucket(
-                    id: "monthly",
-                    title: "Monthly",
-                    shortLabel: "Monthly",
+                    id: "weekly",
+                    title: "Weekly",
+                    shortLabel: "Weekly",
                     usedPercent: 45,
-                    resetAt: monthlyReset,
-                    rawWindowSeconds: nil
+                    resetAt: weeklyReset,
+                    rawWindowSeconds: 604_800
                 )
             ]
         case .alibaba, .alibabaTokenPlan, .copilot, .zai, .minimax, .kimi, .cursor, .mimo, .iflytek, .tencentHunyuan, .tencentTokenPlan, .volcengine, .volcengineAgentPlan, .baiduQianfan, .openCodeGo, .kilo, .kiro, .ollama, .openRouter, .warp:

--- a/Sources/VibeBarCore/Services/OverallFillRate.swift
+++ b/Sources/VibeBarCore/Services/OverallFillRate.swift
@@ -9,7 +9,7 @@ import Foundation
 ///               like weekly_sonnet/weekly_opus are ignored to avoid
 ///               double-counting Claude's plan).
 ///   - Codex   → bucket id "weekly".
-///   - Grok    → bucket id "monthly".
+///   - Grok    → bucket id "weekly".
 ///   - Gemini  → arithmetic mean of all of that account's buckets
 ///               (per-model dailies).
 ///
@@ -45,7 +45,7 @@ public enum OverallFillRate {
                 .flatMap { $0.usedPercent.isFinite ? $0.usedPercent : nil }
         case .grok:
             return quota.buckets
-                .first(where: { $0.id == "monthly" })
+                .first(where: { $0.id == "weekly" })
                 .flatMap { $0.usedPercent.isFinite ? $0.usedPercent : nil }
         case .gemini:
             let valid = quota.buckets.filter { $0.usedPercent.isFinite }

--- a/Sources/VibeBarCore/Services/SubscriptionWindowProgress.swift
+++ b/Sources/VibeBarCore/Services/SubscriptionWindowProgress.swift
@@ -9,8 +9,8 @@ import Foundation
 ///   - "2h 35m of 5h · 7% used"           — sub-day windows (5-hour)
 ///   - "Resets soon · 99% used"           — reset has technically passed
 ///   - "42% used"                         — no resetAt or no
-///                                          rawWindowSeconds (Grok
-///                                          monthly, Gemini per-model)
+///                                          rawWindowSeconds (Gemini
+///                                          per-model when unset)
 public enum SubscriptionWindowProgress {
     public static func summary(
         usedPercent: Double,

--- a/Sources/VibeBarCore/Storage/SettingsStore.swift
+++ b/Sources/VibeBarCore/Storage/SettingsStore.swift
@@ -50,7 +50,8 @@ public final class SettingsStore: ObservableObject {
         let bucketIdMigrations: [String: String?] = [
             "claude.weekly_cowork":      "claude.daily_routines",
             "claude.design_promotional": nil,    // dropped — never showed up in real responses
-            "claude.extra_usage":        nil     // promoted out of buckets, surfaced as ProviderExtras now
+            "claude.extra_usage":        nil,    // promoted out of buckets, surfaced as ProviderExtras now
+            "grok.monthly":              "grok.weekly"
         ]
         var menuItems = migrated.menuBarItems
         for index in menuItems.indices {

--- a/Tests/VibeBarCoreTests/GrokWebBillingCookieFetchTests.swift
+++ b/Tests/VibeBarCoreTests/GrokWebBillingCookieFetchTests.swift
@@ -125,7 +125,7 @@ final class GrokWebBillingCookieFetchTests: XCTestCase {
         let quota = try await adapter.fetch(for: account)
 
         XCTAssertEqual(quota.buckets.count, 1)
-        XCTAssertEqual(quota.buckets[0].id, "monthly")
+        XCTAssertEqual(quota.buckets[0].id, "weekly")
         XCTAssertNil(quota.buckets[0].groupTitle)
     }
 

--- a/Tests/VibeBarCoreTests/GrokWebBillingFetcherTests.swift
+++ b/Tests/VibeBarCoreTests/GrokWebBillingFetcherTests.swift
@@ -25,7 +25,7 @@ final class GrokWebBillingFetcherTests: XCTestCase {
         payload.append(0x4D)
         var unrelated = Float(7).bitPattern.littleEndian
         withUnsafeBytes(of: &unrelated) { payload.append(contentsOf: $0) }
-        // Field 1, fixed32 — the real monthly used-percent.
+        // Field 1, fixed32 — the real weekly used-percent.
         payload.append(0x0D)
         var usage = Float(42).bitPattern.littleEndian
         withUnsafeBytes(of: &usage) { payload.append(contentsOf: $0) }
@@ -66,7 +66,7 @@ final class GrokWebBillingFetcherTests: XCTestCase {
         // Golden bytes captured from a brand-new SuperGrok account — no
         // fixed32 usage field, but a future-dated reset timestamp and
         // the `[1, 6, ...]` "future allotments" marker xAI sends to
-        // signal "monthly budget known but not consumed yet".
+        // signal "weekly budget known but not consumed yet".
         let data = Data([
             0x00, 0x00, 0x00, 0x00, 0x37, 0x0A, 0x35, 0x12,
             0x00, 0x1A, 0x00, 0x22, 0x06, 0x08, 0x80, 0xDA,

--- a/Tests/VibeBarCoreTests/MenuBarFieldCatalogTests.swift
+++ b/Tests/VibeBarCoreTests/MenuBarFieldCatalogTests.swift
@@ -17,7 +17,7 @@ final class MenuBarFieldCatalogTests: XCTestCase {
             "antigravity.gemini-3.5-flash-medium",
             "antigravity.gemini-3.1-pro-high",
             "antigravity.gemini-3.1-pro-low",
-            "grok.monthly"
+            "grok.weekly"
         ]
 
         for id in expected {
@@ -31,7 +31,7 @@ final class MenuBarFieldCatalogTests: XCTestCase {
         XCTAssertTrue(selected.contains("gemini.weekly"))
         XCTAssertTrue(selected.contains("antigravity.gemini-3.5-flash-high"))
         XCTAssertTrue(selected.contains("antigravity.claude-sonnet-4.6-thinking"))
-        XCTAssertTrue(selected.contains("grok.monthly"))
+        XCTAssertTrue(selected.contains("grok.weekly"))
     }
 
     func testGeminiCLIModelIdsMigrateToWebBuckets() {

--- a/Tests/VibeBarCoreTests/OverallFillRateTests.swift
+++ b/Tests/VibeBarCoreTests/OverallFillRateTests.swift
@@ -28,7 +28,7 @@ final class OverallFillRateTests: XCTestCase {
                 bucket(id: "weekly", usedPercent: 70)
             ]),
             "acct-grok": quota(accountId: "acct-grok", tool: .grok, buckets: [
-                bucket(id: "monthly", usedPercent: 30)
+                bucket(id: "weekly", usedPercent: 30)
             ]),
             "acct-gemini": quota(accountId: "acct-gemini", tool: .gemini, buckets: [
                 bucket(id: "gemini-2.5-pro", usedPercent: 60),
@@ -38,7 +38,7 @@ final class OverallFillRateTests: XCTestCase {
         let mean = try? XCTUnwrap(OverallFillRate.average(quotas))
         // Claude weekly headline = 50, sub-buckets ignored.
         // Codex weekly = 70.
-        // Grok monthly = 30.
+        // Grok weekly = 30.
         // Gemini = (60 + 40) / 2 = 50.
         // Overall = (50 + 70 + 30 + 50) / 4 = 50.
         XCTAssertEqual(mean ?? -1, 50, accuracy: 0.001)
@@ -54,7 +54,7 @@ final class OverallFillRateTests: XCTestCase {
                 bucket(id: "weekly", usedPercent: 80)
             ]),
             "acct-grok": quota(accountId: "acct-grok", tool: .grok, buckets: [
-                bucket(id: "monthly", usedPercent: 20)
+                bucket(id: "weekly", usedPercent: 20)
             ])
         ]
         let mean = try? XCTUnwrap(OverallFillRate.average(quotas))
@@ -68,7 +68,7 @@ final class OverallFillRateTests: XCTestCase {
                 bucket(id: "weekly_sonnet", usedPercent: 90, groupTitle: "Sonnet")
             ]),
             "acct-grok": quota(accountId: "acct-grok", tool: .grok, buckets: [
-                bucket(id: "monthly", usedPercent: 20)
+                bucket(id: "weekly", usedPercent: 20)
             ])
         ]
         let mean = try? XCTUnwrap(OverallFillRate.average(quotas))

--- a/Tests/VibeBarCoreTests/SubscriptionHistoryStoreTests.swift
+++ b/Tests/VibeBarCoreTests/SubscriptionHistoryStoreTests.swift
@@ -192,23 +192,23 @@ final class SubscriptionHistoryStoreTests: XCTestCase {
         XCTAssertTrue(all.isEmpty, "5h buckets should be ignored")
     }
 
-    func testGrokMonthlyWithoutWindowSecondsAllowed() async throws {
+    func testGrokWeeklyBucketIsTracked() async throws {
         let (store, _, cleanup) = try makeTempStore()
         defer { cleanup() }
         let now = Date()
-        let reset = now.addingTimeInterval(20 * 86_400)
+        let reset = now.addingTimeInterval(4 * 86_400)
         await store.observe(
             quota(tool: .grok, buckets: [
-                bucket(id: "monthly", usedPercent: 55, resetAt: reset, rawWindowSeconds: nil)
+                bucket(id: "weekly", usedPercent: 55, resetAt: reset, rawWindowSeconds: 604_800)
             ]),
             now: now,
             retentionDays: 30
         )
-        let samples = await store.samples(accountId: "acct-test", bucketId: "monthly")
+        let samples = await store.samples(accountId: "acct-test", bucketId: "weekly")
         XCTAssertEqual(samples.count, 1)
         let sample = try XCTUnwrap(samples.first)
         XCTAssertEqual(sample.peakUsedPercent, 55, accuracy: 0.001)
         XCTAssertEqual(sample.lastUsedPercent, 55, accuracy: 0.001)
-        XCTAssertNil(sample.windowStart, "windowStart should be nil when rawWindowSeconds is nil")
+        XCTAssertNotNil(sample.windowStart)
     }
 }


### PR DESCRIPTION
## Summary

- Rename Grok's quota bucket from `monthly` to `weekly` to match xAI's new seven-day reset cadence.
- Set `rawWindowSeconds` to 604800 so UsagePace and window progress render correctly.
- Migrate saved `grok.monthly` menu-bar / mini-window field selections to `grok.weekly`.
- Document Grok Build `Co-Authored-By` trailer in `AGENTS.md`.

## Validation

- [x] `swift build`
- [x] `swift test`
- [x] `./Scripts/build_app.sh release`
- [x] `codesign -d --entitlements - ".build/Vibe Bar.app"`

## Privacy Checklist

- [x] No raw tokens, cookies, JWTs, organization IDs, account IDs, or real email addresses.
- [x] No personal `/Users/<name>` paths or machine-specific identifiers.
- [x] New persistent data, if any, uses `VibeBarLocalStore` / `~/.vibebar/`.
- [x] Logs and diagnostics use `SafeLog.sanitize` / `EmailMasker` where needed.

## Target Workflow

- [ ] Codex/OpenAI
- [ ] Claude Code/Anthropic
- [x] Shared menu-bar, mini-window, or cost-history surface
- [ ] Build, packaging, or release metadata

Co-Authored-By: Grok Composer 2.5 Fast (xAI) <noreply@x.ai>