### PR TITLE
Handle zero-use Grok weekly billing responses

### DIFF
--- a/Sources/VibeBarCore/Adapters/GrokWebBillingFetcher.swift
+++ b/Sources/VibeBarCore/Adapters/GrokWebBillingFetcher.swift
@@ -260,12 +260,22 @@ public enum GrokWebBillingFetcher {
             .map(\.date)
             .min()
 
-        // Brand-new accounts have no usage yet — the percent fixed32 is
-        // missing but a reset timestamp is present. Treat that as 0%.
+        // Accounts at exactly 0% omit the default-valued percent fixed32.
+        // xAI's older payloads carried allotments under field 6; current
+        // payloads repeat the weekly reset under `[1, 8, 3, 1]`. Require one
+        // of those known billing markers plus a future reset so an unrelated
+        // reset-only protobuf is not mistaken for zero usage.
+        let hasLegacyAllotmentMarker = scan.varintFields.contains {
+            $0.path.starts(with: [1, 6])
+        }
+        let hasWeeklyWindowMarker = scan.varintFields.contains { field in
+            guard field.path == [1, 8, 3, 1], let reset else { return false }
+            return reset == Date(timeIntervalSince1970: TimeInterval(field.value))
+        }
         let noUsageYet = parsedPercent == nil
             && scan.fixed32Fields.isEmpty
             && reset != nil
-            && scan.varintFields.contains { $0.path.starts(with: [1, 6]) }
+            && (hasLegacyAllotmentMarker || hasWeeklyWindowMarker)
         guard let percent = parsedPercent ?? (noUsageYet ? 0 : nil) else {
             throw QuotaError.parseFailure("Grok billing protobuf had no usage field.")
         }

--- a/Tests/VibeBarCoreTests/GrokWebBillingFetcherTests.swift
+++ b/Tests/VibeBarCoreTests/GrokWebBillingFetcherTests.swift
@@ -88,9 +88,53 @@ final class GrokWebBillingFetcherTests: XCTestCase {
         XCTAssertEqual(snapshot.resetsAt, Date(timeIntervalSince1970: 1_780_272_000))
     }
 
+    func testParsesNoUsageResponseWithWeeklyWindowMetadataAsZeroPercent() throws {
+        // Current xAI responses omit the default-valued fixed32 percent at
+        // 0% usage and describe the active weekly window under field 8.
+        // Older responses used repeated field 6 allotment entries instead.
+        let windowStart: UInt64 = 1_800_000_000
+        let windowEnd: UInt64 = 1_800_604_800
+
+        var billing = Data()
+        billing.append(Self.lengthDelimitedField(number: 2, payload: Data()))
+        billing.append(Self.lengthDelimitedField(number: 3, payload: Data()))
+        billing.append(Self.lengthDelimitedField(
+            number: 4,
+            payload: Self.varintField(number: 1, value: windowStart)
+        ))
+        billing.append(Self.lengthDelimitedField(
+            number: 5,
+            payload: Self.varintField(number: 1, value: windowEnd)
+        ))
+
+        var weeklyWindow = Data()
+        weeklyWindow.append(Self.varintField(number: 1, value: 2))
+        weeklyWindow.append(Self.lengthDelimitedField(
+            number: 2,
+            payload: Self.varintField(number: 1, value: windowStart)
+        ))
+        weeklyWindow.append(Self.lengthDelimitedField(
+            number: 3,
+            payload: Self.varintField(number: 1, value: windowEnd)
+        ))
+        billing.append(Self.lengthDelimitedField(number: 8, payload: weeklyWindow))
+        billing.append(Self.varintField(number: 11, value: 1))
+        billing.append(Self.lengthDelimitedField(number: 12, payload: Data()))
+        billing.append(Self.varintField(number: 13, value: 1))
+
+        let payload = Self.lengthDelimitedField(number: 1, payload: billing)
+        let snapshot = try GrokWebBillingFetcher.parseGRPCWebResponse(
+            Self.grpcFrame(payload),
+            now: now
+        )
+
+        XCTAssertEqual(snapshot.usedPercent, 0)
+        XCTAssertEqual(snapshot.resetsAt, Date(timeIntervalSince1970: TimeInterval(windowEnd)))
+    }
+
     func testRejectsResetOnlyPayloadThatLacksUsageAndNoUsageMarker() {
         var payload = Data()
-        // Only a reset timestamp — no usage field, no `[1, 6]` marker.
+        // Only a reset timestamp — no usage field or known zero-usage marker.
         payload.append(0x10)
         payload.append(contentsOf: Self.varint(1_800_000_001))
 
@@ -142,6 +186,19 @@ final class GrokWebBillingFetcherTests: XCTestCase {
         var data = Data([flags])
         let length = UInt32(payload.count).bigEndian
         withUnsafeBytes(of: length) { data.append(contentsOf: $0) }
+        data.append(payload)
+        return data
+    }
+
+    private static func varintField(number: UInt64, value: UInt64) -> Data {
+        var data = Data(varint(number << 3))
+        data.append(contentsOf: varint(value))
+        return data
+    }
+
+    private static func lengthDelimitedField(number: UInt64, payload: Data) -> Data {
+        var data = Data(varint((number << 3) | 2))
+        data.append(contentsOf: varint(UInt64(payload.count)))
         data.append(payload)
         return data
     }


### PR DESCRIPTION
## Summary
- accept the current xAI [1, 8, 3, 1] weekly-window reset marker when a valid 0% response omits the default fixed32 usage value
- keep the legacy field 6 fallback and continue rejecting unrelated reset-only protobuf payloads
- add a regression fixture matching the current weekly-window response structure

## Test plan
- [x] swift build
- [x] swift test (607 tests)
- [x] ./Scripts/build_app.sh release
- [x] codesign entitlement dump is an empty dictionary
- [x] codesign --verify --deep --strict
- [x] live current-account fetch returns 0% usage with a reset timestamp

Co-Authored-By: Codex <noreply@openai.com>