### PR TITLE
Add personal Alibaba Token Plan and MiMo expiry

### DIFF
--- a/Sources/VibeBarApp/Views/MiscProviderSettingsSection.swift
+++ b/Sources/VibeBarApp/Views/MiscProviderSettingsSection.swift
@@ -135,7 +135,18 @@ struct MiscProviderSettingsSection: View {
             }
         case .alibabaTokenPlan:
             VStack(alignment: .leading, spacing: 4) {
-                AlibabaRegionPicker(instanceID: instanceID)
+                AlibabaTokenPlanVariantPicker(instanceID: instanceID)
+                if AlibabaTokenPlanVariant.from(
+                    settingsValue: settingsStore.settings
+                        .miscProviderSettings(forInstanceID: instanceID)
+                        .planVariant
+                ) == .team {
+                    AlibabaRegionPicker(instanceID: instanceID)
+                } else {
+                    Text("Personal Token Plan is currently available only in China mainland (cn-beijing). Clone this row to track Team and Personal together.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
                 CookieSourceControls(
                     tool: .alibabaTokenPlan,
                     instanceID: instanceID,
@@ -145,7 +156,7 @@ struct MiscProviderSettingsSection: View {
                 MiscWebLoginRow(
                     tool: .alibabaTokenPlan,
                     instanceID: instanceID,
-                    helpText: "Sign in to bailian.console.aliyun.com once on the Aliyun account that owns the Token Plan. Same login as the Coding Plan card — you can sign in on either."
+                    helpText: "Sign in to bailian.console.aliyun.com once on the Aliyun account that owns this Token Plan. Existing cards default to Team; choose Personal above for the new rolling-window plan."
                 )
             }
         case .minimax:
@@ -316,6 +327,40 @@ struct MiscProviderSettingsSection: View {
         }
     }
 
+}
+
+/// Alibaba Token Plan commercial edition. This uses a dedicated
+/// settings field because Team also has its own independent region
+/// selector. Missing values map to Team for backward compatibility.
+struct AlibabaTokenPlanVariantPicker: View {
+    let instanceID: String
+
+    @EnvironmentObject var settingsStore: SettingsStore
+
+    var body: some View {
+        Picker("Edition", selection: choiceBinding) {
+            ForEach(AlibabaTokenPlanVariant.allCases, id: \.rawValue) { choice in
+                Text(choice.displayLabel).tag(choice)
+            }
+        }
+        .pickerStyle(.menu)
+    }
+
+    private var choiceBinding: Binding<AlibabaTokenPlanVariant> {
+        Binding(
+            get: {
+                let raw = settingsStore.settings
+                    .miscProviderSettings(forInstanceID: instanceID)
+                    .planVariant
+                return AlibabaTokenPlanVariant.from(settingsValue: raw)
+            },
+            set: { newValue in
+                var current = settingsStore.settings.miscProviderSettings(forInstanceID: instanceID)
+                current.planVariant = newValue.rawValue
+                settingsStore.settings.setMiscProviderInstanceSettings(current, forID: instanceID)
+            }
+        )
+    }
 }
 
 private struct CopyNameField: View {

--- a/Sources/VibeBarCore/Adapters/AlibabaTokenPlanQuotaAdapter.swift
+++ b/Sources/VibeBarCore/Adapters/AlibabaTokenPlanQuotaAdapter.swift
@@ -3,16 +3,19 @@ import Foundation
 /// Alibaba Qwen / Bailian **Token Plan** usage adapter.
 ///
 /// Lives alongside `AlibabaQuotaAdapter` (the Coding Plan flavour).
-/// Token Plan is a different commercial product with credit-based
-/// quotas — sold separately, lives on a different BFF, has its own
-/// console URL, and the dashboard renders under a separate tab:
-/// `https://bailian.console.aliyun.com/cn-beijing?tab=plan#/efm/subscription/token-plan`.
+/// Token Plan is a different commercial product sold separately from
+/// Coding Plan. It currently has two editions with independent console
+/// contracts:
+///
+/// - **Team** — the original credit-based BSS summary, available on the
+///   China-mainland and international consoles.
+/// - **Personal** — rolling 5-hour and 7-day utilization windows, only
+///   available in `cn-beijing` at launch.
 ///
 /// Auth: console cookies only (`*.aliyun.com` / `*.alibabacloud.com`).
 /// DashScope API keys are not used for the Token Plan BFF — that
-/// endpoint is BSS-backed (BssOpenAPI-V3) and authenticates the user
-/// via the regular Aliyun console session jar, just like the buy /
-/// renew flow in the browser.
+/// endpoints authenticate the user via the regular Aliyun console
+/// session jar, just like the buy / renew flow in the browser.
 ///
 /// Request shape captured from the live console:
 ///
@@ -27,12 +30,12 @@ import Foundation
 ///        sec_token=<scraped>
 ///        region=cn-qingdao
 ///
-/// Response payload contains `SubscriptionGroupList[]` with one entry
+/// The Team response contains `SubscriptionGroupList[]` with one entry
 /// per seat tier (standard / advanced / exclusive). Each entry carries
 /// an `EquityList[]` with the `credit_value` totals and surplus, plus a
 /// `NextCycleFlushTime` reset stamp. We surface one quota bucket per
-/// non-empty seat tier so the misc card mirrors what the user sees in
-/// the browser dashboard.
+/// non-empty seat tier. Personal uses two BroadScope endpoints: one for
+/// subscription metadata and one for the rolling utilization values.
 public struct AlibabaTokenPlanQuotaAdapter: QuotaAdapter {
     public let tool: ToolType = .alibabaTokenPlan
 
@@ -65,6 +68,7 @@ public struct AlibabaTokenPlanQuotaAdapter: QuotaAdapter {
     public func fetch(for account: AccountIdentity) async throws -> AccountQuota {
         let instanceID = AccountStore.miscInstanceID(fromAccountID: account.id, fallbackTool: .alibabaTokenPlan)
         let settings = MiscProviderSettings.current(for: .alibabaTokenPlan, instanceID: instanceID)
+        let variant = AlibabaTokenPlanVariant.from(settingsValue: settings.planVariant)
 
         let preferred: [AlibabaTokenPlanRegion]
         switch settings.region {
@@ -85,6 +89,7 @@ public struct AlibabaTokenPlanQuotaAdapter: QuotaAdapter {
         let results = await MiscQuotaAggregator.gatherSlotResults(cookieResolutions) { resolution in
             try await self.fetchViaCookieSlot(
                 resolution: resolution,
+                variant: variant,
                 regions: preferred,
                 account: account,
                 queriedAt: queriedAt
@@ -99,13 +104,38 @@ public struct AlibabaTokenPlanQuotaAdapter: QuotaAdapter {
     }
 
     private func fetchViaCookieSlot(resolution: MiscCookieResolver.Resolution,
+                                    variant: AlibabaTokenPlanVariant,
                                     regions: [AlibabaTokenPlanRegion],
                                     account: AccountIdentity,
                                     queriedAt: Date) async throws -> AccountQuota {
+        if variant == .personal {
+            let secToken = try await resolveSECToken(
+                cookieHeader: resolution.header,
+                dashboardURL: variant.dashboardURL
+            )
+            let snapshot = try await fetchPersonalSummary(
+                cookieHeader: resolution.header,
+                secToken: secToken,
+                now: queriedAt
+            )
+            return AccountQuota(
+                accountId: account.id,
+                tool: .alibabaTokenPlan,
+                buckets: snapshot.buckets,
+                plan: snapshot.planName,
+                email: account.email,
+                queriedAt: queriedAt,
+                error: nil
+            )
+        }
+
         var lastError: QuotaError?
         for region in regions {
             do {
-                let secToken = try await resolveSECToken(cookieHeader: resolution.header, region: region)
+                let secToken = try await resolveSECToken(
+                    cookieHeader: resolution.header,
+                    dashboardURL: region.dashboardURL
+                )
                 let snapshot = try await fetchSeatSummary(
                     cookieHeader: resolution.header,
                     secToken: secToken,
@@ -140,8 +170,8 @@ public struct AlibabaTokenPlanQuotaAdapter: QuotaAdapter {
     /// `sec_token` cookie fallback for layouts that hoist the token
     /// onto the jar instead of the inline JS.
     private func resolveSECToken(cookieHeader: String,
-                                 region: AlibabaTokenPlanRegion) async throws -> String {
-        var request = URLRequest(url: region.dashboardURL)
+                                 dashboardURL: URL) async throws -> String {
+        var request = URLRequest(url: dashboardURL)
         request.httpMethod = "GET"
         request.setValue(cookieHeader, forHTTPHeaderField: "Cookie")
         request.setValue(Self.safariUA, forHTTPHeaderField: "User-Agent")
@@ -252,6 +282,118 @@ public struct AlibabaTokenPlanQuotaAdapter: QuotaAdapter {
         return try AlibabaTokenPlanResponseParser.parse(data: data, productCode: region.productCode, now: referenceTime)
     }
 
+    /// Fetch the two requests emitted by the Personal Token Plan page:
+    /// subscription metadata identifies the tier, while usage carries
+    /// the independent rolling 5-hour and 7-day utilization values.
+    private func fetchPersonalSummary(
+        cookieHeader: String,
+        secToken: String,
+        now referenceTime: Date
+    ) async throws -> AlibabaTokenPlanResponseParser.Snapshot {
+        let traceID = UUID().uuidString.lowercased()
+        var cornerstone: [String: Any] = [
+            "feTraceId": traceID,
+            "feURL": AlibabaTokenPlanVariant.personal.dashboardURL.absoluteString,
+            "protocol": "V2",
+            "console": "ONE_CONSOLE",
+            "productCode": "p_efm",
+            "domain": "bailian.console.aliyun.com",
+            "consoleSite": "BAILIAN_ALIYUN",
+            "switchAgent": 10_087_432,
+            "switchUserType": 3,
+            "userNickName": "",
+            "userPrincipalName": "",
+            "xsp_lang": "en-US"
+        ]
+        if let cna = Self.extractCookieValue(name: "cna", from: cookieHeader), !cna.isEmpty {
+            cornerstone["X-Anonymous-Id"] = cna
+        }
+
+        let subscriptionData = try await fetchPersonalData(
+            endpoint: .subscription,
+            dataObject: [
+                "queryInstanceInfoRequest": [
+                    "commodityCode": "sfm_tokenplansolo_public_cn"
+                ],
+                "cornerstoneParam": cornerstone
+            ],
+            cookieHeader: cookieHeader,
+            secToken: secToken
+        )
+        let usageData = try await fetchPersonalData(
+            endpoint: .usage,
+            dataObject: ["cornerstoneParam": cornerstone],
+            cookieHeader: cookieHeader,
+            secToken: secToken
+        )
+
+        return try AlibabaTokenPlanPersonalResponseParser.parse(
+            subscriptionData: subscriptionData,
+            usageData: usageData,
+            now: referenceTime
+        )
+    }
+
+    private func fetchPersonalData(
+        endpoint: AlibabaTokenPlanPersonalEndpoint,
+        dataObject: [String: Any],
+        cookieHeader: String,
+        secToken: String
+    ) async throws -> Data {
+        let paramsObject: [String: Any] = [
+            "Api": endpoint.apiName,
+            "V": "1.0",
+            "Data": dataObject
+        ]
+        guard let paramsData = try? JSONSerialization.data(withJSONObject: paramsObject),
+              let paramsString = String(data: paramsData, encoding: .utf8) else {
+            throw QuotaError.parseFailure("Alibaba Personal Token Plan: failed to encode params")
+        }
+
+        var components = URLComponents()
+        components.queryItems = [
+            URLQueryItem(name: "params", value: paramsString),
+            URLQueryItem(name: "region", value: "cn-beijing"),
+            URLQueryItem(name: "sec_token", value: secToken)
+        ]
+
+        var request = URLRequest(url: endpoint.consoleRPCURL)
+        request.httpMethod = "POST"
+        request.httpBody = (components.percentEncodedQuery ?? "").data(using: .utf8) ?? Data()
+        request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+        request.setValue("*/*", forHTTPHeaderField: "Accept")
+        request.setValue(cookieHeader, forHTTPHeaderField: "Cookie")
+        if let csrf = Self.extractCookieValue(name: "login_aliyunid_csrf", from: cookieHeader)
+            ?? Self.extractCookieValue(name: "csrf", from: cookieHeader) {
+            request.setValue(csrf, forHTTPHeaderField: "x-xsrf-token")
+            request.setValue(csrf, forHTTPHeaderField: "x-csrf-token")
+        }
+        request.setValue("XMLHttpRequest", forHTTPHeaderField: "X-Requested-With")
+        request.setValue(Self.safariUA, forHTTPHeaderField: "User-Agent")
+        request.setValue("https://bailian.console.aliyun.com", forHTTPHeaderField: "Origin")
+        request.setValue(
+            AlibabaTokenPlanVariant.personal.dashboardURL.absoluteString,
+            forHTTPHeaderField: "Referer"
+        )
+
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await session.data(for: request)
+        } catch {
+            throw QuotaError.network("Alibaba Personal Token Plan console error: \(error.localizedDescription)")
+        }
+        guard let http = response as? HTTPURLResponse else {
+            throw QuotaError.network("Alibaba Personal Token Plan: invalid response object")
+        }
+        guard http.statusCode == 200 else {
+            if http.statusCode == 401 || http.statusCode == 403 { throw QuotaError.needsLogin }
+            if http.statusCode == 429 { throw QuotaError.rateLimited }
+            throw QuotaError.network("Alibaba Personal Token Plan returned HTTP \(http.statusCode).")
+        }
+        return data
+    }
+
     // MARK: Helpers
 
     nonisolated private static var safariUA: String {
@@ -278,6 +420,62 @@ public struct AlibabaTokenPlanQuotaAdapter: QuotaAdapter {
             return value.isEmpty ? nil : value
         }
         return nil
+    }
+}
+
+// MARK: - Plan variant
+
+/// Commercial edition selected for one Alibaba Token Plan misc card.
+/// Missing settings deliberately map to Team so existing installations
+/// keep monitoring the same product after Personal support is added.
+public enum AlibabaTokenPlanVariant: String, CaseIterable, Sendable {
+    case team
+    case personal
+
+    public static func from(settingsValue raw: String?) -> Self {
+        switch raw?.lowercased() {
+        case "personal", "individual", "solo": return .personal
+        default: return .team
+        }
+    }
+
+    public var displayLabel: String {
+        switch self {
+        case .team: return "Team"
+        case .personal: return "Personal"
+        }
+    }
+
+    var dashboardURL: URL {
+        switch self {
+        case .team:
+            return AlibabaTokenPlanRegion.chinaMainland.dashboardURL
+        case .personal:
+            return URL(string: "https://bailian.console.aliyun.com/cn-beijing/?tab=plan#/efm/subscription/token-plan/personal")!
+        }
+    }
+}
+
+enum AlibabaTokenPlanPersonalEndpoint: CaseIterable {
+    case subscription
+    case usage
+
+    var apiName: String {
+        switch self {
+        case .subscription: return "zeldaHttp.apikeyMgr./tokenplan/personal/api/v2/subscription"
+        case .usage: return "zeldaHttp.apikeyMgr./tokenplan/personal/api/v2/usage"
+        }
+    }
+
+    var consoleRPCURL: URL {
+        var components = URLComponents(string: "https://bailian-cs.console.aliyun.com/data/api.json")!
+        components.queryItems = [
+            URLQueryItem(name: "action", value: "BroadScopeAspnGateway"),
+            URLQueryItem(name: "product", value: "sfm_bailian"),
+            URLQueryItem(name: "api", value: apiName),
+            URLQueryItem(name: "_v", value: "undefined")
+        ]
+        return components.url!
     }
 }
 
@@ -639,6 +837,146 @@ enum AlibabaTokenPlanResponseParser {
             f.formatOptions = [.withInternetDateTime]
             if let d = f.date(from: str) { return d }
         }
+        return nil
+    }
+}
+
+/// Parser for the Personal Token Plan's split subscription + usage
+/// response. Both BroadScope responses may contain JSON serialized as
+/// strings under `DataV2`; the Team parser's tree expansion keeps the
+/// extraction tolerant of that console envelope.
+enum AlibabaTokenPlanPersonalResponseParser {
+    static func parse(
+        subscriptionData: Data,
+        usageData: Data,
+        now _: Date
+    ) throws -> AlibabaTokenPlanResponseParser.Snapshot {
+        let subscription = try root(from: subscriptionData, responseName: "subscription")
+        let usage = try root(from: usageData, responseName: "usage")
+        try validateEnvelope(subscription)
+        try validateEnvelope(usage)
+
+        var buckets: [QuotaBucket] = []
+        if let fiveHour = findFirstDouble(["per5HourPercentage"], in: usage) {
+            buckets.append(QuotaBucket(
+                id: "alibabaTokenPlan.personal.fiveHour",
+                title: "5 Hours",
+                shortLabel: "5h",
+                usedPercent: normalizedPercentage(fiveHour),
+                resetAt: nil,
+                rawWindowSeconds: 5 * 3_600,
+                groupTitle: "Personal"
+            ))
+        }
+        if let weekly = findFirstDouble(["per1WeekPercentage"], in: usage) {
+            buckets.append(QuotaBucket(
+                id: "alibabaTokenPlan.personal.weekly",
+                title: "Weekly",
+                shortLabel: "Wk",
+                usedPercent: normalizedPercentage(weekly),
+                resetAt: nil,
+                rawWindowSeconds: 7 * 86_400,
+                groupTitle: "Personal"
+            ))
+        }
+
+        guard !buckets.isEmpty else {
+            throw QuotaError.parseFailure(
+                "Alibaba Personal Token Plan response had no usable utilization windows."
+            )
+        }
+
+        let specCode = AlibabaTokenPlanResponseParser.findFirstString(["specCode"], in: subscription)
+        let tier = tierDisplayName(from: specCode)
+        let planName = tier.map { "Token Plan · Personal · \($0)" } ?? "Token Plan · Personal"
+        return AlibabaTokenPlanResponseParser.Snapshot(buckets: buckets, planName: planName)
+    }
+
+    private static func root(from data: Data, responseName: String) throws -> [String: Any] {
+        guard !data.isEmpty else {
+            throw QuotaError.parseFailure(
+                "Alibaba Personal Token Plan returned an empty \(responseName) body."
+            )
+        }
+        let raw: Any
+        do {
+            raw = try JSONSerialization.jsonObject(with: data, options: [])
+        } catch {
+            throw QuotaError.parseFailure(
+                "Alibaba Personal Token Plan \(responseName) response was not parseable."
+            )
+        }
+        guard let dict = AlibabaTokenPlanResponseParser.expandedJSON(raw) as? [String: Any] else {
+            throw QuotaError.parseFailure(
+                "Alibaba Personal Token Plan \(responseName) response was not a JSON object."
+            )
+        }
+        return dict
+    }
+
+    private static func validateEnvelope(_ dict: [String: Any]) throws {
+        if let code = AlibabaTokenPlanResponseParser.findFirstString(
+            ["code", "status", "statusCode", "Code"],
+            in: dict
+        ) {
+            let lower = code.lowercased()
+            if lower.contains("needlogin") || lower.contains("notlogin") ||
+                lower.contains("unauthenticated") || lower == "login" {
+                throw QuotaError.needsLogin
+            }
+        }
+        if let success = dict["successResponse"] as? Bool, !success {
+            let message = AlibabaTokenPlanResponseParser.findFirstString(
+                ["message", "msg", "Message"],
+                in: dict
+            ) ?? "request failed"
+            throw QuotaError.network("Alibaba Personal Token Plan: \(message)")
+        }
+        if let status = AlibabaTokenPlanResponseParser.findFirstInt(
+            ["httpStatusCode", "statusCode", "status_code"],
+            in: dict
+        ), status != 0, status != 200 {
+            if status == 401 || status == 403 { throw QuotaError.needsLogin }
+            throw QuotaError.network("Alibaba Personal Token Plan returned status \(status).")
+        }
+    }
+
+    private static func findFirstDouble(_ keys: [String], in value: Any) -> Double? {
+        if let dict = value as? [String: Any] {
+            for key in keys {
+                if let parsed = AlibabaTokenPlanResponseParser.parseDouble(dict[key]) { return parsed }
+            }
+            for nested in dict.values {
+                if let parsed = findFirstDouble(keys, in: nested) { return parsed }
+            }
+        }
+        if let array = value as? [Any] {
+            for nested in array {
+                if let parsed = findFirstDouble(keys, in: nested) { return parsed }
+            }
+        }
+        return nil
+    }
+
+    /// The live account currently reports zero, which cannot reveal
+    /// whether a non-zero deployment serializes 0...1 or 0...100.
+    /// Accept both shapes without misreading a whole-number 1% value,
+    /// then clamp malformed data to the UI's supported range.
+    private static func normalizedPercentage(_ raw: Double) -> Double {
+        let scaled: Double
+        if raw > 0, raw < 1, raw.rounded(.towardZero) != raw {
+            scaled = raw * 100
+        } else {
+            scaled = raw
+        }
+        return max(0, min(100, scaled))
+    }
+
+    private static func tierDisplayName(from specCode: String?) -> String? {
+        guard let lower = specCode?.lowercased() else { return nil }
+        if lower.contains("standard") { return "Standard" }
+        if lower.contains("pro") { return "Pro" }
+        if lower.contains("lite") { return "Lite" }
         return nil
     }
 }

--- a/Sources/VibeBarCore/Adapters/MimoQuotaAdapter.swift
+++ b/Sources/VibeBarCore/Adapters/MimoQuotaAdapter.swift
@@ -8,10 +8,11 @@ import Foundation
 /// miVerify slider captcha so headless username/password login is not viable;
 /// users sign in once in their browser and Vibe Bar imports the cookies.
 ///
-/// Endpoint:
-/// `GET https://platform.xiaomimimo.com/api/v1/tokenPlan/usage`
-/// returns the monthly Token Plan counter the console renders on its
-/// Subscription page. The `monthUsage.items[name=month_total_token]` entry is
+/// Endpoints:
+/// - `/api/v1/tokenPlan/usage` returns the monthly Token Plan counter.
+/// - `/api/v1/tokenPlan/detail` returns the plan name and current-period end.
+///
+/// The `monthUsage.items[name=month_total_token]` entry is
 /// preferred over the alternative `usage.items[name=plan_total_token]` because
 /// it matches the headline number on the console exactly.
 ///
@@ -41,8 +42,11 @@ public struct MimoQuotaAdapter: QuotaAdapter {
         requiredNames: ["userId", "api-platform_slh", "api-platform_ph", "api-platform_serviceToken"]
     )
 
-    private static let endpoint = URL(string:
+    private static let usageEndpoint = URL(string:
         "https://platform.xiaomimimo.com/api/v1/tokenPlan/usage"
+    )!
+    private static let detailEndpoint = URL(string:
+        "https://platform.xiaomimimo.com/api/v1/tokenPlan/detail"
     )!
 
     public init(
@@ -74,7 +78,39 @@ public struct MimoQuotaAdapter: QuotaAdapter {
         account: AccountIdentity,
         queriedAt: Date
     ) async throws -> AccountQuota {
-        var request = URLRequest(url: MimoQuotaAdapter.endpoint)
+        let usageData = try await fetchData(
+            from: MimoQuotaAdapter.usageEndpoint,
+            using: resolution
+        )
+        // Detail enriches the card with the subscription expiry and
+        // plan name. Keep usage available if Xiaomi temporarily rolls
+        // this newer endpoint back or changes its response envelope.
+        let detailData = try? await fetchData(
+            from: MimoQuotaAdapter.detailEndpoint,
+            using: resolution
+        )
+
+        let snapshot = try MimoResponseParser.parse(
+            usageData: usageData,
+            detailData: detailData,
+            now: queriedAt
+        )
+        return AccountQuota(
+            accountId: account.id,
+            tool: .mimo,
+            buckets: snapshot.buckets,
+            plan: snapshot.planName,
+            email: account.email,
+            queriedAt: queriedAt,
+            error: nil
+        )
+    }
+
+    private func fetchData(
+        from endpoint: URL,
+        using resolution: MiscCookieResolver.Resolution
+    ) async throws -> Data {
+        var request = URLRequest(url: endpoint)
         request.httpMethod = "GET"
         request.setValue(resolution.header, forHTTPHeaderField: "Cookie")
         request.setValue("application/json, text/plain, */*", forHTTPHeaderField: "Accept")
@@ -105,16 +141,7 @@ public struct MimoQuotaAdapter: QuotaAdapter {
             throw QuotaError.network("MiMo returned HTTP \(http.statusCode).")
         }
 
-        let snapshot = try MimoResponseParser.parse(data: data, now: queriedAt)
-        return AccountQuota(
-            accountId: account.id,
-            tool: .mimo,
-            buckets: snapshot.buckets,
-            plan: snapshot.planName,
-            email: account.email,
-            queriedAt: queriedAt,
-            error: nil
-        )
+        return data
     }
 }
 
@@ -127,12 +154,16 @@ enum MimoResponseParser {
     }
 
     static func parse(data: Data, now: Date) throws -> Snapshot {
-        guard !data.isEmpty else {
+        try parse(usageData: data, detailData: nil, now: now)
+    }
+
+    static func parse(usageData: Data, detailData: Data?, now: Date) throws -> Snapshot {
+        guard !usageData.isEmpty else {
             throw QuotaError.parseFailure("MiMo returned an empty body.")
         }
         let response: MimoAPIResponse
         do {
-            response = try JSONDecoder().decode(MimoAPIResponse.self, from: data)
+            response = try JSONDecoder().decode(MimoAPIResponse.self, from: usageData)
         } catch {
             throw QuotaError.parseFailure("MiMo response not parseable: \(error.localizedDescription)")
         }
@@ -175,20 +206,52 @@ enum MimoResponseParser {
             percent = 0
         }
 
+        let detail = detailData.flatMap(parseDetail)
         let bucket = QuotaBucket(
             id: "mimo.month",
             title: "Monthly",
             shortLabel: "Month",
             usedPercent: percent,
-            resetAt: nil,
+            resetAt: detail?.periodEnd,
             rawWindowSeconds: 30 * 86_400
         )
 
-        return Snapshot(buckets: [bucket], planName: nil)
+        return Snapshot(buckets: [bucket], planName: detail?.planName)
     }
 
     private static func pickItem(in items: [MimoAPIItem]?, name: String) -> MimoAPIItem? {
         items?.first(where: { $0.name == name })
+    }
+
+    private static func parseDetail(_ data: Data) -> (periodEnd: Date?, planName: String?)? {
+        guard !data.isEmpty,
+              let response = try? JSONDecoder().decode(MimoPlanDetailResponse.self, from: data),
+              response.code == nil || response.code == 0,
+              let detail = response.data else {
+            return nil
+        }
+        return (
+            periodEnd: parsePeriodEnd(detail.currentPeriodEnd),
+            planName: detail.planName?.trimmed
+        )
+    }
+
+    /// The MiMo console labels `currentPeriodEnd` as UTC even though
+    /// the server serializes it without an offset.
+    private static func parsePeriodEnd(_ raw: String?) -> Date? {
+        guard let value = raw?.trimmed else { return nil }
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.calendar = Calendar(identifier: .gregorian)
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        formatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
+        if let date = formatter.date(from: value) { return date }
+
+        let iso = ISO8601DateFormatter()
+        iso.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        if let date = iso.date(from: value) { return date }
+        iso.formatOptions = [.withInternetDateTime]
+        return iso.date(from: value)
     }
 }
 
@@ -212,6 +275,24 @@ private struct MimoAPIResponse: Decodable {
 private struct MimoAPIData: Decodable {
     let monthUsage: MimoAPIBucket?
     let usage: MimoAPIBucket?
+}
+
+private struct MimoPlanDetailResponse: Decodable {
+    let code: Int?
+    let data: MimoPlanDetail?
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        code = MimoQuotaDecoding.int(c, forKey: .code)
+        data = try c.decodeIfPresent(MimoPlanDetail.self, forKey: .data)
+    }
+
+    enum CodingKeys: String, CodingKey { case code, data }
+}
+
+private struct MimoPlanDetail: Decodable {
+    let planName: String?
+    let currentPeriodEnd: String?
 }
 
 private struct MimoAPIBucket: Decodable {

--- a/Sources/VibeBarCore/Models/MiscProviderSettings.swift
+++ b/Sources/VibeBarCore/Models/MiscProviderSettings.swift
@@ -36,6 +36,10 @@ public struct MiscProviderSettings: Codable, Equatable, Sendable {
     /// Optional region override (e.g. "ap-southeast-1", "cn-beijing"
     /// for Alibaba; provider-specific for others).
     public var region: String?
+    /// Optional commercial-plan variant for providers that expose
+    /// multiple products under one card (for example Alibaba Token
+    /// Plan's Team and Personal editions).
+    public var planVariant: String?
     /// Self-hosted endpoint override (e.g. GitHub Enterprise for
     /// Copilot, Z.ai self-hosted for Z.ai).
     public var enterpriseHost: URL?
@@ -54,6 +58,7 @@ public struct MiscProviderSettings: Codable, Equatable, Sendable {
         sourceMode: .auto,
         cookieSource: .auto,
         region: nil,
+        planVariant: nil,
         enterpriseHost: nil,
         workspaceID: nil,
         preferredBrowser: nil,
@@ -64,6 +69,7 @@ public struct MiscProviderSettings: Codable, Equatable, Sendable {
         sourceMode: SourceMode = .auto,
         cookieSource: ProviderCookieSource = .auto,
         region: String? = nil,
+        planVariant: String? = nil,
         enterpriseHost: URL? = nil,
         workspaceID: String? = nil,
         preferredBrowser: BrowserKind? = nil,
@@ -72,6 +78,7 @@ public struct MiscProviderSettings: Codable, Equatable, Sendable {
         self.sourceMode = sourceMode
         self.cookieSource = cookieSource
         self.region = region
+        self.planVariant = planVariant
         self.enterpriseHost = enterpriseHost
         self.workspaceID = workspaceID
         self.preferredBrowser = preferredBrowser
@@ -87,7 +94,7 @@ public struct MiscProviderSettings: Codable, Equatable, Sendable {
     }
 
     private enum CodingKeys: String, CodingKey {
-        case sourceMode, cookieSource, region, enterpriseHost, workspaceID
+        case sourceMode, cookieSource, region, planVariant, enterpriseHost, workspaceID
         case preferredBrowser, enabledOverride
     }
 
@@ -122,6 +129,7 @@ public struct MiscProviderSettings: Codable, Equatable, Sendable {
         self.sourceMode = try c.decodeIfPresent(SourceMode.self, forKey: .sourceMode) ?? .auto
         self.cookieSource = try c.decodeIfPresent(ProviderCookieSource.self, forKey: .cookieSource) ?? .auto
         self.region = try c.decodeIfPresent(String.self, forKey: .region)
+        self.planVariant = try c.decodeIfPresent(String.self, forKey: .planVariant)
         self.enterpriseHost = try c.decodeIfPresent(URL.self, forKey: .enterpriseHost)
         self.workspaceID = try c.decodeIfPresent(String.self, forKey: .workspaceID)
         self.preferredBrowser = try c.decodeIfPresent(BrowserKind.self, forKey: .preferredBrowser)
@@ -138,6 +146,7 @@ public struct MiscProviderSettings: Codable, Equatable, Sendable {
         try c.encode(sourceMode, forKey: .sourceMode)
         try c.encode(cookieSource, forKey: .cookieSource)
         try c.encodeIfPresent(region, forKey: .region)
+        try c.encodeIfPresent(planVariant, forKey: .planVariant)
         try c.encodeIfPresent(enterpriseHost, forKey: .enterpriseHost)
         try c.encodeIfPresent(workspaceID, forKey: .workspaceID)
         try c.encodeIfPresent(preferredBrowser, forKey: .preferredBrowser)

--- a/Tests/VibeBarCoreTests/AlibabaTokenPlanParserTests.swift
+++ b/Tests/VibeBarCoreTests/AlibabaTokenPlanParserTests.swift
@@ -5,6 +5,14 @@ final class AlibabaTokenPlanParserTests: XCTestCase {
     private let now = Date(timeIntervalSince1970: 1_715_000_000)
     private let cnProductCode = "sfm_tokenplanteams_dp_cn"
 
+    func testEditionDefaultsToTeamForExistingSettings() {
+        XCTAssertEqual(AlibabaTokenPlanVariant.from(settingsValue: nil), .team)
+        XCTAssertEqual(AlibabaTokenPlanVariant.from(settingsValue: ""), .team)
+        XCTAssertEqual(AlibabaTokenPlanVariant.from(settingsValue: "team"), .team)
+        XCTAssertEqual(AlibabaTokenPlanVariant.from(settingsValue: "personal"), .personal)
+        XCTAssertEqual(AlibabaTokenPlanVariant.from(settingsValue: "solo"), .personal)
+    }
+
     // MARK: - Happy path (captured from the live console)
 
     func testParsesSeatSubscriptionSummaryWithStandardCredits() throws {
@@ -55,6 +63,7 @@ final class AlibabaTokenPlanParserTests: XCTestCase {
         let bucket = snap.buckets[0]
         XCTAssertEqual(bucket.id, "alibabaTokenPlan.\(cnProductCode).standard")
         XCTAssertEqual(bucket.groupTitle, "Standard")
+        XCTAssertEqual(snap.planName, "Token Plan · Team · Standard")
         // (25000 - 24999.5534) / 25000 * 100 ≈ 0.001786
         XCTAssertEqual(bucket.usedPercent, 0.001786, accuracy: 0.001)
         XCTAssertNotNil(bucket.resetAt)
@@ -237,6 +246,86 @@ final class AlibabaTokenPlanParserTests: XCTestCase {
         XCTAssertEqual(
             AlibabaTokenPlanRegion.international.productCode,
             "sfm_tokenplanteams_dp_intl"
+        )
+    }
+
+    // MARK: - Personal edition
+
+    func testParsesPersonalRollingWindowsAndTier() throws {
+        let subscription = #"""
+        {
+          "code": "200",
+          "DataV2": "{\"data\":{\"data\":{\"specCode\":\"tokenplansolo_standard_cn\",\"remainingDays\":14,\"startTime\":1770000000000,\"endTime\":1771209600000,\"status\":\"ACTIVE\"}}}",
+          "httpStatusCode": "200",
+          "successResponse": true
+        }
+        """#
+        let usage = #"""
+        {
+          "code": "200",
+          "DataV2": "{\"data\":{\"data\":{\"per5HourPercentage\":0.25,\"per1WeekPercentage\":37.5}}}",
+          "httpStatusCode": "200",
+          "successResponse": true
+        }
+        """#
+
+        let snap = try AlibabaTokenPlanPersonalResponseParser.parse(
+            subscriptionData: Data(subscription.utf8),
+            usageData: Data(usage.utf8),
+            now: now
+        )
+        XCTAssertEqual(snap.planName, "Token Plan · Personal · Standard")
+        XCTAssertEqual(snap.buckets.map(\.id), [
+            "alibabaTokenPlan.personal.fiveHour",
+            "alibabaTokenPlan.personal.weekly"
+        ])
+        XCTAssertEqual(snap.buckets[0].usedPercent, 25, accuracy: 0.01)
+        XCTAssertEqual(snap.buckets[0].rawWindowSeconds, 5 * 3_600)
+        XCTAssertEqual(snap.buckets[1].usedPercent, 37.5, accuracy: 0.01)
+        XCTAssertEqual(snap.buckets[1].rawWindowSeconds, 7 * 86_400)
+        XCTAssertNil(snap.buckets[0].resetAt)
+    }
+
+    func testPersonalUsageWithoutWindowsThrowsParseFailure() {
+        let subscription = "{\"code\":\"200\",\"successResponse\":true}"
+        let usage = "{\"code\":\"200\",\"successResponse\":true,\"data\":{}}"
+        XCTAssertThrowsError(try AlibabaTokenPlanPersonalResponseParser.parse(
+            subscriptionData: Data(subscription.utf8),
+            usageData: Data(usage.utf8),
+            now: now
+        )) { error in
+            guard let quotaError = error as? QuotaError, case .parseFailure = quotaError else {
+                return XCTFail("Expected parseFailure, got \(error)")
+            }
+        }
+    }
+
+    func testPersonalEndpointWiringMatchesConsoleContract() {
+        let subscriptionURL = AlibabaTokenPlanPersonalEndpoint.subscription.consoleRPCURL
+        let usageURL = AlibabaTokenPlanPersonalEndpoint.usage.consoleRPCURL
+        XCTAssertEqual(subscriptionURL.host, "bailian-cs.console.aliyun.com")
+        XCTAssertEqual(usageURL.host, "bailian-cs.console.aliyun.com")
+        let subscriptionQuery = URLComponents(
+            url: subscriptionURL,
+            resolvingAgainstBaseURL: false
+        )?.queryItems ?? []
+        let usageQuery = URLComponents(
+            url: usageURL,
+            resolvingAgainstBaseURL: false
+        )?.queryItems ?? []
+        XCTAssertTrue(subscriptionQuery.contains {
+            $0.name == "action" && $0.value == "BroadScopeAspnGateway"
+        })
+        XCTAssertTrue(subscriptionQuery.contains {
+            $0.name == "api" && $0.value?.hasSuffix("/tokenplan/personal/api/v2/subscription") == true
+        })
+        XCTAssertTrue(usageQuery.contains {
+            $0.name == "api" && $0.value?.hasSuffix("/tokenplan/personal/api/v2/usage") == true
+        })
+        XCTAssertTrue(
+            AlibabaTokenPlanVariant.personal.dashboardURL.absoluteString.hasSuffix(
+                "/token-plan/personal"
+            )
         )
     }
 }

--- a/Tests/VibeBarCoreTests/MimoParserTests.swift
+++ b/Tests/VibeBarCoreTests/MimoParserTests.swift
@@ -90,6 +90,67 @@ final class MimoParserTests: XCTestCase {
         XCTAssertEqual(snap.buckets[0].usedPercent, 42.0, accuracy: 0.01)
     }
 
+    func testPlanDetailAddsUTCExpiryAndPlanName() throws {
+        let usage = """
+        {
+          "code": 0,
+          "data": {
+            "monthUsage": {
+              "items": [
+                {"name": "month_total_token", "used": 25, "limit": 100}
+              ]
+            }
+          }
+        }
+        """
+        let detail = """
+        {
+          "code": 0,
+          "data": {
+            "planCode": "pro",
+            "planName": "Pro",
+            "currentPeriodEnd": "2026-08-02 23:59:59",
+            "expired": false
+          }
+        }
+        """
+
+        let snap = try MimoResponseParser.parse(
+            usageData: Data(usage.utf8),
+            detailData: Data(detail.utf8),
+            now: now
+        )
+        XCTAssertEqual(snap.planName, "Pro")
+        XCTAssertEqual(
+            snap.buckets[0].resetAt?.timeIntervalSince1970 ?? 0,
+            1_785_715_199,
+            accuracy: 0.5
+        )
+    }
+
+    func testMalformedPlanDetailDoesNotHideUsage() throws {
+        let usage = """
+        {
+          "code": 0,
+          "data": {
+            "monthUsage": {
+              "items": [
+                {"name": "month_total_token", "used": 25, "limit": 100}
+              ]
+            }
+          }
+        }
+        """
+        let snap = try MimoResponseParser.parse(
+            usageData: Data(usage.utf8),
+            detailData: Data("not json".utf8),
+            now: now
+        )
+        XCTAssertEqual(snap.buckets[0].usedPercent, 25)
+        XCTAssertNil(snap.buckets[0].resetAt)
+        XCTAssertNil(snap.planName)
+    }
+
     func testMissingDataThrowsParseFailure() {
         let json = "{\"code\": 0}"
         XCTAssertThrowsError(try MimoResponseParser.parse(data: Data(json.utf8), now: now)) { error in

--- a/Tests/VibeBarCoreTests/MiscProviderSettingsTests.swift
+++ b/Tests/VibeBarCoreTests/MiscProviderSettingsTests.swift
@@ -16,6 +16,7 @@ final class MiscProviderSettingsTests: XCTestCase {
             sourceMode: .browserOnly,
             cookieSource: .manual,
             region: "cn-beijing",
+            planVariant: "personal",
             enterpriseHost: URL(string: "https://copilot.example.com/")!,
             workspaceID: "wrk_demo",
             preferredBrowser: .brave,
@@ -34,6 +35,7 @@ final class MiscProviderSettingsTests: XCTestCase {
         XCTAssertEqual(decoded.sourceMode, .auto)
         XCTAssertEqual(decoded.cookieSource, .auto)
         XCTAssertNil(decoded.region)
+        XCTAssertNil(decoded.planVariant)
         XCTAssertNil(decoded.enterpriseHost)
         XCTAssertNil(decoded.workspaceID)
         XCTAssertNil(decoded.preferredBrowser)
@@ -67,6 +69,7 @@ final class MiscProviderSettingsTests: XCTestCase {
         XCTAssertFalse(MiscProviderSettings.looksSensitive("sourceMode"))
         XCTAssertFalse(MiscProviderSettings.looksSensitive("cookieSource"))
         XCTAssertFalse(MiscProviderSettings.looksSensitive("region"))
+        XCTAssertFalse(MiscProviderSettings.looksSensitive("planVariant"))
         XCTAssertFalse(MiscProviderSettings.looksSensitive("enterpriseHost"))
         XCTAssertFalse(MiscProviderSettings.looksSensitive("workspaceID"))
         XCTAssertFalse(MiscProviderSettings.looksSensitive("preferredBrowser"))


### PR DESCRIPTION
## Summary
- split Alibaba Token Plan into backward-compatible Team and new Personal editions
- fetch Personal 5-hour and weekly usage from the live Bailian console contract
- enrich MiMo quota with plan tier and UTC subscription expiry

## Test plan
- [x] swift build
- [x] swift test (613 tests)
- [x] ./Scripts/build_app.sh release
- [x] codesign --verify --deep --strict
- [x] empty entitlements and no sandbox container
- [x] visually checked the Personal edition settings row
- [x] live-verified Alibaba Personal Standard 5-hour/weekly buckets and MiMo Pro expiry

Co-Authored-By: Codex <noreply@openai.com>