### PR TITLE
Show AntiGravity shared quota windows

### DIFF
--- a/Sources/VibeBarApp/MiniQuotaWindowController.swift
+++ b/Sources/VibeBarApp/MiniQuotaWindowController.swift
@@ -235,6 +235,12 @@ final class MiniQuotaWindowController: NSObject, NSWindowDelegate {
         }
         guard tool == .antigravity else { return nil }
         let lower = bucketId.lowercased()
+        if lower == "gemini_five_hour" || lower == "gemini_weekly" {
+            return "antigravity.gemini-models"
+        }
+        if lower == "claude_gpt_five_hour" || lower == "claude_gpt_weekly" {
+            return "antigravity.claude-gpt-models"
+        }
         if lower.contains("gpt-oss") { return "antigravity.gpt-oss" }
         if lower.contains("claude")  { return "antigravity.claude" }
         if lower.contains("flash-lite") { return "antigravity.gemini-flash-lite" }

--- a/Sources/VibeBarApp/Views/MiniQuotaWindowView.swift
+++ b/Sources/VibeBarApp/Views/MiniQuotaWindowView.swift
@@ -94,9 +94,9 @@ struct MiniQuotaWindowView: View {
     }
 
     private func isBranchField(_ field: MenuBarFieldOption) -> Bool {
-        // AntiGravity rows are always branch-style (one ring per
-        // per-model bucket, each carrying a `groupTitle` set by the
-        // parser). Gemini USED to be in this carve-out too — that
+        // Antigravity rows are branch-style because its four quota
+        // lanes are split across the Gemini and Claude/GPT groups.
+        // Gemini USED to be in this carve-out too — that
         // was a leftover from the per-model CLI adapter. After
         // PR #57 the Gemini Web parser emits two flat primary
         // buckets (`five_hour` / `weekly`) with `groupTitle == nil`,
@@ -269,6 +269,10 @@ private struct MiniBranchCell: Identifiable {
         switch bucket.id {
         case "gpt_5_3_codex_spark_five_hour": return "5h"
         case "gpt_5_3_codex_spark_weekly": return "wk"
+        case "gemini_five_hour", "claude_gpt_five_hour" where tool == .antigravity:
+            return "5h"
+        case "gemini_weekly", "claude_gpt_weekly" where tool == .antigravity:
+            return "wk"
         case "weekly_sonnet": return "wk"
         case "weekly_design": return "wk"
         case "daily_routines": return "Daily"
@@ -311,6 +315,10 @@ private struct MiniBranchCell: Identifiable {
             return "claude.fable"
         case "weekly_oauth_apps":
             return "claude.oauth"
+        case "gemini_five_hour", "gemini_weekly" where tool == .antigravity:
+            return "antigravity.gemini-models"
+        case "claude_gpt_five_hour", "claude_gpt_weekly" where tool == .antigravity:
+            return "antigravity.claude-gpt-models"
         case let id where tool == .gemini && id.contains("flash-lite"):
             return "gemini.flash-lite"
         case let id where tool == .gemini && id.contains("flash"):
@@ -351,6 +359,10 @@ private struct MiniBranchCell: Identifiable {
             return "Fable"
         case "weekly_oauth_apps":
             return "OAuth"
+        case "gemini_five_hour", "gemini_weekly" where tool == .antigravity:
+            return "Gemini"
+        case "claude_gpt_five_hour", "claude_gpt_weekly" where tool == .antigravity:
+            return "C+G"
         case let id where tool == .gemini && id.contains("flash-lite"):
             return "Lite"
         case let id where tool == .gemini && id.contains("flash"):

--- a/Sources/VibeBarApp/Views/MiniWindowGroupLabelCatalog.swift
+++ b/Sources/VibeBarApp/Views/MiniWindowGroupLabelCatalog.swift
@@ -18,10 +18,8 @@ enum MiniWindowGroupLabelCatalog {
         .init(id: "gemini.pro", title: "GEMINI · Pro", defaultLabel: "Pro"),
         .init(id: "gemini.flash", title: "GEMINI · Flash", defaultLabel: "Flash"),
         .init(id: "gemini.flash-lite", title: "GEMINI · Flash Lite", defaultLabel: "Lite"),
-        .init(id: "antigravity.claude", title: "ANTIGRAVITY · Claude", defaultLabel: "Claude"),
-        .init(id: "antigravity.gemini-pro", title: "ANTIGRAVITY · Gemini Pro", defaultLabel: "G Pro"),
-        .init(id: "antigravity.gemini-flash", title: "ANTIGRAVITY · Gemini Flash", defaultLabel: "G Flash"),
-        .init(id: "antigravity.gemini-flash-lite", title: "ANTIGRAVITY · Gemini Flash Lite", defaultLabel: "G Lite")
+        .init(id: "antigravity.gemini-models", title: "ANTIGRAVITY · Gemini Models", defaultLabel: "Gemini"),
+        .init(id: "antigravity.claude-gpt-models", title: "ANTIGRAVITY · Claude + GPT Models", defaultLabel: "C+G")
     ]
 
     static func defaultLabel(for id: String) -> String? {

--- a/Sources/VibeBarCore/Adapters/AntigravityLanguageServerClient.swift
+++ b/Sources/VibeBarCore/Adapters/AntigravityLanguageServerClient.swift
@@ -11,7 +11,8 @@ import Foundation
 ///
 /// Extracted from `AntigravityQuotaAdapter` so two callers can share one
 /// probe + transport:
-///   1. live quota — `GetUserStatus` (`AntigravityQuotaAdapter`)
+///   1. live quota — `RetrieveUserQuotaSummary`, plus `GetUserStatus`
+///      for identity metadata (`AntigravityQuotaAdapter`)
 ///   2. historical cost — `GetCascadeTrajectoryGeneratorMetadata`
 ///      (`AntigravityCascadeUsageFetcher`, used by `CostUsageScanner`
 ///      for the encrypted `.pb` conversations we can't decode offline)

--- a/Sources/VibeBarCore/Adapters/AntigravityQuotaAdapter.swift
+++ b/Sources/VibeBarCore/Adapters/AntigravityQuotaAdapter.swift
@@ -6,11 +6,11 @@ import Foundation
 /// running AntiGravity language-server process, parses its CSRF tokens
 /// and ports, then POSTs to a localhost HTTPS endpoint protected by
 /// `X-Codeium-Csrf-Token`. The discovery + transport now live in the
-/// shared `AntigravityLanguageServerClient`; this adapter only adds the
-/// `GetUserStatus` call and maps the response into `QuotaBucket`s and
-/// the plan name (`userTier.name` / `planStatus.planInfo`). The
-/// cost-scanner reuses the same client for the
-/// `GetCascadeTrajectoryGeneratorMetadata` call.
+/// shared `AntigravityLanguageServerClient`; this adapter reads the
+/// grouped `RetrieveUserQuotaSummary` payload for the four real quota
+/// lanes and uses `GetUserStatus` only to attach account identity and
+/// keep the model-label cache fresh. The cost-scanner reuses the client
+/// for the `GetCascadeTrajectoryGeneratorMetadata` call.
 public struct AntigravityQuotaAdapter: QuotaAdapter {
     public let tool: ToolType = .antigravity
 
@@ -30,6 +30,8 @@ public struct AntigravityQuotaAdapter: QuotaAdapter {
 
     private static let userStatusPath =
         "/exa.language_server_pb.LanguageServerService/GetUserStatus"
+    private static let quotaSummaryPath =
+        "/exa.language_server_pb.LanguageServerService/RetrieveUserQuotaSummary"
 
     public func fetch(for account: AccountIdentity) async throws -> AccountQuota {
         let order = AntigravitySourcePlanner.resolve(mode: usageModeProvider())
@@ -65,17 +67,12 @@ public struct AntigravityQuotaAdapter: QuotaAdapter {
     private func fetchWithLocalProbe(for account: AccountIdentity) async throws -> AccountQuota {
         let client = AntigravityLanguageServerClient(timeout: timeout)
         let endpoints = try await client.connectedEndpoints()
-        let body = Data("{}".utf8)
-
         var lastError: Error?
         for endpoint in endpoints {
             do {
-                let data = try await client.postLocal(
-                    endpoint: endpoint,
-                    path: AntigravityQuotaAdapter.userStatusPath,
-                    body: body
-                )
-                let snapshot = try AntigravityResponseParser.parseUserStatus(data: data)
+                let snapshot = try await Self.fetchLocalSnapshot { path, body in
+                    try await client.postLocal(endpoint: endpoint, path: path, body: body)
+                }
                 // Keep the id → label map fresh so the cost scanner can
                 // resolve placeholder model ids to real names and rates.
                 AntigravityModelLabelStore.merge(snapshot.modelLabels)
@@ -94,6 +91,29 @@ public struct AntigravityQuotaAdapter: QuotaAdapter {
             }
         }
         throw mapError(lastError)
+    }
+
+    /// Fetch the grouped quota payload first, then attach identity on a
+    /// best-effort basis. Keeping this seam independent from process discovery
+    /// makes the endpoint contract and request order unit-testable.
+    static func fetchLocalSnapshot(
+        request: (_ path: String, _ body: Data) async throws -> Data
+    ) async throws -> AntigravityResponseParser.Snapshot {
+        let quotaData = try await request(
+            Self.quotaSummaryPath,
+            Data(#"{"forceRefresh":true}"#.utf8)
+        )
+        let quotaSnapshot = try AntigravityResponseParser.parseQuotaSummary(data: quotaData)
+
+        let identitySnapshot: AntigravityResponseParser.Snapshot?
+        do {
+            let identityData = try await request(Self.userStatusPath, Data("{}".utf8))
+            identitySnapshot = try AntigravityResponseParser.parseUserStatus(data: identityData)
+        } catch {
+            // Quotas remain useful when this older endpoint is unavailable.
+            identitySnapshot = nil
+        }
+        return quotaSnapshot.mergingIdentity(identitySnapshot)
     }
 
     /// Reads the persisted `antigravityUsageMode` setting from disk.
@@ -134,6 +154,67 @@ enum AntigravityResponseParser {
         /// `AntigravityModelLabelStore` so the cost scanner can resolve
         /// real model names and rates.
         var modelLabels: [String: String] = [:]
+
+        func mergingIdentity(_ identity: Snapshot?) -> Snapshot {
+            guard let identity else { return self }
+            return Snapshot(
+                buckets: buckets,
+                planName: identity.planName ?? planName,
+                email: identity.email ?? email,
+                modelLabels: identity.modelLabels.isEmpty ? modelLabels : identity.modelLabels
+            )
+        }
+    }
+
+    /// Parse Antigravity 2.x's grouped quota summary into the four stable
+    /// Vibe Bar lanes. Unknown cadences/groups and buckets without a usable
+    /// remaining fraction are deliberately omitted instead of being reported
+    /// as exhausted.
+    static func parseQuotaSummary(data: Data) throws -> Snapshot {
+        let response: AntigravityQuotaSummaryResponse
+        do {
+            let decoder = JSONDecoder()
+            decoder.keyDecodingStrategy = .convertFromSnakeCase
+            response = try decoder.decode(AntigravityQuotaSummaryResponse.self, from: data)
+        } catch {
+            throw QuotaError.parseFailure("Antigravity quota summary not parseable: \(error.localizedDescription)")
+        }
+        if let code = response.code, code.isError {
+            throw QuotaError.network("Antigravity: \(response.message ?? code.label)")
+        }
+
+        guard let groups = response.resolvedGroups, !groups.isEmpty else {
+            throw QuotaError.parseFailure("Antigravity quota summary had no groups.")
+        }
+
+        var bucketsBySlot: [QuotaSummarySlot: QuotaBucket] = [:]
+        for group in groups {
+            for payload in group.buckets ?? [] {
+                guard payload.disabled != true,
+                      let groupKind = quotaGroupKind(groupName: group.displayName, bucketId: payload.bucketId),
+                      let cadence = quotaCadence(for: payload),
+                      let remainingFraction = payload.resolvedRemainingFraction,
+                      remainingFraction.isFinite
+                else { continue }
+
+                let slot = QuotaSummarySlot(group: groupKind, cadence: cadence)
+                let candidate = quotaBucket(
+                    slot: slot,
+                    remainingFraction: remainingFraction,
+                    resetAt: payload.resetTime.flatMap(parseDate)
+                )
+                if let current = bucketsBySlot[slot], current.usedPercent >= candidate.usedPercent {
+                    continue
+                }
+                bucketsBySlot[slot] = candidate
+            }
+        }
+
+        let buckets = QuotaSummarySlot.displayOrder.compactMap { bucketsBySlot[$0] }
+        guard !buckets.isEmpty else {
+            throw QuotaError.parseFailure("Antigravity quota summary had no usable 5-hour or weekly buckets.")
+        }
+        return Snapshot(buckets: buckets, planName: nil, email: nil)
     }
 
     static func parseUserStatus(data: Data) throws -> Snapshot {
@@ -150,50 +231,19 @@ enum AntigravityResponseParser {
             throw QuotaError.parseFailure("Antigravity response had no userStatus envelope.")
         }
 
-        let modelConfigs = userStatus.cascadeModelConfigData?.clientModelConfigs ?? []
-        var buckets: [QuotaBucket] = []
         var modelLabels: [String: String] = [:]
-        for config in modelConfigs {
-            // Capture the id → label mapping for every config (even ones
-            // without quota), so placeholder model ids in the cost data
-            // can later be resolved to real names / rates.
+        for config in userStatus.cascadeModelConfigData?.clientModelConfigs ?? [] {
             if let rawModel = config.modelOrAlias?.model {
                 let trimmed = rawModel.trimmingCharacters(in: .whitespacesAndNewlines)
                 if !trimmed.isEmpty { modelLabels[trimmed] = config.label }
             }
-            guard let quota = config.quotaInfo else { continue }
-            // Google's wire format omits `remainingFraction` when the
-            // model's quota is fully spent (proto3 zero-default). The
-            // older guard dropped depleted models entirely, hiding the
-            // exhausted state from the user. Treat a missing fraction
-            // as 0 so the bucket still shows up (at 100% used) with
-            // the reset countdown that Google does send. See the live
-            // AntigravityQuotaWatcher-v2 panel — depleted models stay
-            // visible there for exactly the same reason.
-            let fraction = quota.remainingFraction ?? 0.0
-            let resetAt = quota.resetTime.flatMap(parseDate)
-            let modelId = normalizedModelID(label: config.label, rawModelID: config.modelOrAlias?.model)
-            var bucket = QuotaBucket(
-                id: modelId,
-                title: config.label,
-                shortLabel: AntigravityResponseParser.shortLabel(for: config.label, modelId: modelId),
-                usedPercent: max(0, min(100, (1 - fraction) * 100)),
-                resetAt: resetAt,
-                // Antigravity's per-model quotas run on the same 5-hour
-                // rolling window as the rest of Google's Gemini plans;
-                // the protobuf only exposes the reset timestamp, so the
-                // window length is assumed. Enables `UsagePace` captions.
-                rawWindowSeconds: 18_000
-            )
-            bucket.groupTitle = AntigravityResponseParser.groupTitle(for: config.label, modelId: modelId)
-            buckets.append(bucket)
         }
 
         let plan = userStatus.userTier?.preferredName ?? userStatus.planStatus?.planInfo?.preferredName
-        return Snapshot(buckets: buckets, planName: plan, email: userStatus.email, modelLabels: modelLabels)
+        return Snapshot(buckets: [], planName: plan, email: userStatus.email, modelLabels: modelLabels)
     }
 
-    private static func parseDate(_ raw: String) -> Date? {
+    static func parseDate(_ raw: String) -> Date? {
         let withFractional = ISO8601DateFormatter()
         withFractional.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
         if let d = withFractional.date(from: raw) { return d }
@@ -206,64 +256,166 @@ enum AntigravityResponseParser {
         return nil
     }
 
-    private static func normalizedModelID(label: String, rawModelID: String?) -> String {
-        let trimmedRaw = rawModelID?.trimmingCharacters(in: .whitespacesAndNewlines)
-        if let trimmedRaw, !trimmedRaw.isEmpty, !isPlaceholderModelID(trimmedRaw) {
-            return trimmedRaw
-        }
-        let slug = slugModelLabel(label)
-        return slug.isEmpty ? (trimmedRaw ?? "model") : slug
-    }
-
-    private static func isPlaceholderModelID(_ value: String) -> Bool {
-        value.lowercased().hasPrefix("model_")
-    }
-
-    private static func slugModelLabel(_ label: String) -> String {
-        let lower = label.lowercased()
-        var scalars = String.UnicodeScalarView()
-        var lastWasSeparator = false
-        for scalar in lower.unicodeScalars {
-            if CharacterSet.alphanumerics.contains(scalar) || scalar.value == 46 {
-                scalars.append(scalar)
-                lastWasSeparator = false
-            } else if !lastWasSeparator {
-                scalars.append("-")
-                lastWasSeparator = true
-            }
-        }
-        return String(scalars).trimmingCharacters(in: CharacterSet(charactersIn: "-"))
-    }
-
-    private static func shortLabel(for label: String, modelId: String) -> String {
-        let lower = "\(label) \(modelId)".lowercased()
-        if lower.contains("gpt-oss") { return "GPT-OSS" }
-        if lower.contains("sonnet") { return "Sonnet" }
-        if lower.contains("opus") { return "Opus" }
-        if lower.contains("claude") { return "Claude" }
-        if lower.contains("high") { return "High" }
-        if lower.contains("medium") { return "Med" }
-        if lower.contains("low") { return "Low" }
-        if lower.contains("flash-lite") { return "Lite" }
-        if lower.contains("flash") { return "Flash" }
-        if lower.contains("pro") { return "Pro" }
-        return modelId
-    }
-
-    private static func groupTitle(for label: String, modelId: String) -> String? {
-        let lower = "\(label) \(modelId)".lowercased()
-        if lower.contains("gpt-oss") { return "GPT-OSS" }
-        if lower.contains("claude") { return "Claude" }
-        if lower.contains("gemini") {
-            if lower.contains("flash-lite") { return "Gemini Flash Lite" }
-            if lower.contains("flash") { return "Gemini Flash" }
-            return "Gemini Pro"
+    private static func quotaGroupKind(groupName: String?, bucketId: String?) -> QuotaSummaryGroupKind? {
+        let value = "\(groupName ?? "") \(bucketId ?? "")".lowercased()
+        if value.contains("gemini") { return .gemini }
+        if value.contains("claude") || value.contains("gpt") || value.contains("3p-") {
+            return .claudeGPT
         }
         return nil
+    }
+
+    private static func quotaCadence(for bucket: AntigravityQuotaSummaryBucket) -> QuotaSummaryCadence? {
+        var candidates: Set<String> = []
+        for rawValue in [bucket.bucketId, bucket.displayName, bucket.window].compactMap({ $0 }) {
+            let normalized = rawValue
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+                .lowercased()
+                .replacingOccurrences(of: "_", with: "-")
+            guard !normalized.isEmpty else { continue }
+            candidates.insert(normalized)
+            if normalized.hasSuffix(" limit") {
+                candidates.insert(String(normalized.dropLast(" limit".count)))
+            }
+        }
+        let expanded = candidates.reduce(into: candidates) { result, candidate in
+            for alias in sessionCadenceAliases.union(["weekly"])
+                where candidate.hasSuffix("-\(alias)")
+            {
+                result.insert(alias)
+            }
+        }
+        if !expanded.isDisjoint(with: sessionCadenceAliases) { return .fiveHour }
+        if expanded.contains("weekly") { return .weekly }
+        return nil
+    }
+
+    private static let sessionCadenceAliases: Set<String> = [
+        "session", "5h", "5-hour", "five hour", "five-hour"
+    ]
+
+    private static func quotaBucket(
+        slot: QuotaSummarySlot,
+        remainingFraction: Double,
+        resetAt: Date?
+    ) -> QuotaBucket {
+        let remaining = max(0, min(1, remainingFraction))
+        return QuotaBucket(
+            id: slot.id,
+            title: slot.cadence == .fiveHour ? "5 Hours" : "Weekly",
+            shortLabel: slot.shortLabel,
+            usedPercent: (1 - remaining) * 100,
+            resetAt: resetAt,
+            rawWindowSeconds: slot.cadence == .fiveHour ? 18_000 : 604_800,
+            groupTitle: slot.group.title
+        )
+    }
+}
+
+private enum QuotaSummaryGroupKind: Int, Hashable {
+    case gemini
+    case claudeGPT
+
+    var title: String {
+        switch self {
+        case .gemini: return "Gemini Models"
+        case .claudeGPT: return "Claude and GPT Models"
+        }
+    }
+}
+
+private enum QuotaSummaryCadence: Int, Hashable {
+    case fiveHour
+    case weekly
+}
+
+private struct QuotaSummarySlot: Hashable {
+    let group: QuotaSummaryGroupKind
+    let cadence: QuotaSummaryCadence
+
+    static let displayOrder: [QuotaSummarySlot] = [
+        QuotaSummarySlot(group: .gemini, cadence: .fiveHour),
+        QuotaSummarySlot(group: .gemini, cadence: .weekly),
+        QuotaSummarySlot(group: .claudeGPT, cadence: .fiveHour),
+        QuotaSummarySlot(group: .claudeGPT, cadence: .weekly)
+    ]
+
+    var id: String {
+        switch (group, cadence) {
+        case (.gemini, .fiveHour): return "gemini_five_hour"
+        case (.gemini, .weekly): return "gemini_weekly"
+        case (.claudeGPT, .fiveHour): return "claude_gpt_five_hour"
+        case (.claudeGPT, .weekly): return "claude_gpt_weekly"
+        }
+    }
+
+    var shortLabel: String {
+        switch (group, cadence) {
+        case (.gemini, .fiveHour): return "G 5h"
+        case (.gemini, .weekly): return "G wk"
+        case (.claudeGPT, .fiveHour): return "C+G 5h"
+        case (.claudeGPT, .weekly): return "C+G wk"
+        }
     }
 }
 
 // MARK: - Wire types
+
+private struct AntigravityQuotaSummaryResponse: Decodable {
+    let code: AntigravityCodeValue?
+    let message: String?
+    let response: AntigravityQuotaSummaryPayload?
+    let summary: AntigravityQuotaSummaryPayload?
+    let groups: [AntigravityQuotaSummaryGroup]?
+
+    var resolvedGroups: [AntigravityQuotaSummaryGroup]? {
+        response?.groups ?? summary?.groups ?? groups
+    }
+}
+
+private struct AntigravityQuotaSummaryPayload: Decodable {
+    let groups: [AntigravityQuotaSummaryGroup]?
+}
+
+private struct AntigravityQuotaSummaryGroup: Decodable {
+    let displayName: String?
+    let buckets: [AntigravityQuotaSummaryBucket]?
+}
+
+private struct AntigravityQuotaSummaryBucket: Decodable {
+    let bucketId: String?
+    let displayName: String?
+    let window: String?
+    let remainingFraction: Double?
+    let remaining: AntigravityQuotaSummaryRemaining?
+    let resetTime: String?
+    let disabled: Bool?
+
+    var resolvedRemainingFraction: Double? {
+        remainingFraction ?? remaining?.remainingFraction
+    }
+}
+
+private struct AntigravityQuotaSummaryRemaining: Decodable {
+    let remainingFraction: Double?
+
+    private enum CodingKeys: String, CodingKey {
+        case remainingFraction
+        case oneofCase = "case"
+        case value
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        if let value = try container.decodeIfPresent(Double.self, forKey: .remainingFraction) {
+            remainingFraction = value
+        } else if try container.decodeIfPresent(String.self, forKey: .oneofCase) == "remainingFraction" {
+            remainingFraction = try container.decodeIfPresent(Double.self, forKey: .value)
+        } else {
+            remainingFraction = nil
+        }
+    }
+}
 
 private struct AntigravityAPIResponse: Decodable {
     let code: AntigravityCodeValue?
@@ -317,16 +469,10 @@ private struct AntigravityModelConfigData: Decodable {
 private struct AntigravityModelConfig: Decodable {
     let label: String
     let modelOrAlias: AntigravityModelAlias?
-    let quotaInfo: AntigravityQuotaInfo?
 }
 
 private struct AntigravityModelAlias: Decodable {
     let model: String
-}
-
-private struct AntigravityQuotaInfo: Decodable {
-    let remainingFraction: Double?
-    let resetTime: String?
 }
 
 /// AntiGravity's `code` field can be either a number or a string —

--- a/Sources/VibeBarCore/Models/MenuBarSettings.swift
+++ b/Sources/VibeBarCore/Models/MenuBarSettings.swift
@@ -173,13 +173,10 @@ public enum MenuBarFieldCatalog {
     ]
 
     public static let antigravityFields: [MenuBarFieldOption] = [
-        option(.antigravity, "claude-sonnet-4.6-thinking", "Claude Sonnet 4.6 Thinking", "Sonnet"),
-        option(.antigravity, "claude-opus-4.6-thinking", "Claude Opus 4.6 Thinking", "Opus"),
-        option(.antigravity, "gpt-oss-120b-medium", "GPT-OSS 120B Medium", "GPT"),
-        option(.antigravity, "gemini-3.5-flash-high", "Gemini 3.5 Flash High", "Flash H"),
-        option(.antigravity, "gemini-3.5-flash-medium", "Gemini 3.5 Flash Medium", "Flash M"),
-        option(.antigravity, "gemini-3.1-pro-high", "Gemini 3.1 Pro High", "Pro H"),
-        option(.antigravity, "gemini-3.1-pro-low", "Gemini 3.1 Pro Low", "Pro L")
+        option(.antigravity, "gemini_five_hour", "Gemini Models · 5 Hours", "G 5h"),
+        option(.antigravity, "gemini_weekly", "Gemini Models · Weekly", "G wk"),
+        option(.antigravity, "claude_gpt_five_hour", "Claude and GPT Models · 5 Hours", "C+G 5h"),
+        option(.antigravity, "claude_gpt_weekly", "Claude and GPT Models · Weekly", "C+G wk")
     ]
 
     public static let grokFields: [MenuBarFieldOption] = [
@@ -257,25 +254,24 @@ public enum MenuBarFieldCatalog {
         "gemini.gemini-2.5-flash-lite":  ["gemini.five_hour"],
         "gemini.gemini-3-pro":           ["gemini.five_hour"],
         "gemini.gemini-3-flash":         ["gemini.five_hour"],
-        "antigravity.claude-sonnet-4-20250514": ["antigravity.claude-sonnet-4.6-thinking"],
-        "antigravity.claude-sonnet-4-5": ["antigravity.claude-sonnet-4.6-thinking"],
-        "antigravity.gemini-2.5-pro": [
-            "antigravity.gemini-3.1-pro-high",
-            "antigravity.gemini-3.1-pro-low"
-        ],
-        "antigravity.gemini-3-pro": [
-            "antigravity.gemini-3.1-pro-high",
-            "antigravity.gemini-3.1-pro-low"
-        ],
-        "antigravity.gemini-2.5-flash": [
-            "antigravity.gemini-3.5-flash-high",
-            "antigravity.gemini-3.5-flash-medium"
-        ],
-        "antigravity.gemini-3-flash": [
-            "antigravity.gemini-3.5-flash-high",
-            "antigravity.gemini-3.5-flash-medium"
-        ],
-        "antigravity.gemini-2.5-flash-lite": [],
+        // Antigravity 2.x reports two shared pools, each with a 5-hour
+        // and weekly lane. Every legacy per-model selection therefore
+        // migrates to the matching pool's 5-hour lane; the weekly lane
+        // remains independently selectable beside it.
+        "antigravity.claude-sonnet-4-20250514": ["antigravity.claude_gpt_five_hour"],
+        "antigravity.claude-sonnet-4-5": ["antigravity.claude_gpt_five_hour"],
+        "antigravity.claude-sonnet-4.6-thinking": ["antigravity.claude_gpt_five_hour"],
+        "antigravity.claude-opus-4.6-thinking": ["antigravity.claude_gpt_five_hour"],
+        "antigravity.gpt-oss-120b-medium": ["antigravity.claude_gpt_five_hour"],
+        "antigravity.gemini-2.5-pro": ["antigravity.gemini_five_hour"],
+        "antigravity.gemini-3-pro": ["antigravity.gemini_five_hour"],
+        "antigravity.gemini-3.1-pro-high": ["antigravity.gemini_five_hour"],
+        "antigravity.gemini-3.1-pro-low": ["antigravity.gemini_five_hour"],
+        "antigravity.gemini-2.5-flash": ["antigravity.gemini_five_hour"],
+        "antigravity.gemini-3-flash": ["antigravity.gemini_five_hour"],
+        "antigravity.gemini-3.5-flash-high": ["antigravity.gemini_five_hour"],
+        "antigravity.gemini-3.5-flash-medium": ["antigravity.gemini_five_hour"],
+        "antigravity.gemini-2.5-flash-lite": ["antigravity.gemini_five_hour"],
         "grok.monthly": ["grok.weekly"]
     ]
 }

--- a/Sources/VibeBarCore/Services/MockDataProvider.swift
+++ b/Sources/VibeBarCore/Services/MockDataProvider.swift
@@ -231,18 +231,21 @@ public enum MockDataProvider {
                             usedPercent: 9, resetAt: weeklyReset, rawWindowSeconds: nil, groupTitle: "Flash Lite")
             ]
         case .antigravity:
-            // Partial-primary mock: the live Antigravity LSP groups
-            // buckets by Gemini Pro / Flash / Claude variants.
+            // Antigravity 2.x exposes two shared pools, each with a
+            // 5-hour and weekly lane.
             buckets = [
-                QuotaBucket(id: "gemini-3-pro", title: "Gemini Pro",
-                            shortLabel: "Pro", usedPercent: 41, resetAt: fiveHourReset,
-                            rawWindowSeconds: nil, groupTitle: "Gemini Pro"),
-                QuotaBucket(id: "gemini-3-flash", title: "Gemini Flash",
-                            shortLabel: "Flash", usedPercent: 17, resetAt: fiveHourReset,
-                            rawWindowSeconds: nil, groupTitle: "Gemini Flash"),
-                QuotaBucket(id: "claude-sonnet-4-5", title: "Claude Sonnet 4.5",
-                            shortLabel: "Sonnet", usedPercent: 71, resetAt: fiveHourReset,
-                            rawWindowSeconds: nil, groupTitle: "Claude")
+                QuotaBucket(id: "gemini_five_hour", title: "5 Hours",
+                            shortLabel: "G 5h", usedPercent: 41, resetAt: fiveHourReset,
+                            rawWindowSeconds: 18_000, groupTitle: "Gemini Models"),
+                QuotaBucket(id: "gemini_weekly", title: "Weekly",
+                            shortLabel: "G wk", usedPercent: 17, resetAt: weeklyReset,
+                            rawWindowSeconds: 604_800, groupTitle: "Gemini Models"),
+                QuotaBucket(id: "claude_gpt_five_hour", title: "5 Hours",
+                            shortLabel: "C+G 5h", usedPercent: 71, resetAt: fiveHourReset,
+                            rawWindowSeconds: 18_000, groupTitle: "Claude and GPT Models"),
+                QuotaBucket(id: "claude_gpt_weekly", title: "Weekly",
+                            shortLabel: "C+G wk", usedPercent: 28, resetAt: weeklyReset,
+                            rawWindowSeconds: 604_800, groupTitle: "Claude and GPT Models")
             ]
         case .grok:
             // Partial-primary mock: single weekly bucket so the

--- a/Tests/VibeBarCoreTests/AntigravityParserTests.swift
+++ b/Tests/VibeBarCoreTests/AntigravityParserTests.swift
@@ -2,7 +2,202 @@ import XCTest
 @testable import VibeBarCore
 
 final class AntigravityParserTests: XCTestCase {
-    func testParsesUserStatusWithModelQuotas() throws {
+    func testParsesQuotaSummaryIntoFourStableBuckets() throws {
+        let json = """
+        {
+          "response": {
+            "groups": [
+              {
+                "displayName": "Claude and GPT models",
+                "buckets": [
+                  {
+                    "bucketId": "3p-weekly",
+                    "displayName": "Weekly Limit",
+                    "remaining": {"remainingFraction": 0.64},
+                    "resetTime": "2026-06-20T00:39:54Z"
+                  },
+                  {
+                    "bucketId": "3p-5h",
+                    "displayName": "Five Hour Limit",
+                    "remaining": {"remainingFraction": 0.73},
+                    "resetTime": "2026-06-15T12:52:10Z"
+                  }
+                ]
+              },
+              {
+                "displayName": "Gemini Models",
+                "buckets": [
+                  {
+                    "bucketId": "gemini-weekly",
+                    "displayName": "Weekly Limit",
+                    "remaining": {"remainingFraction": 0.82},
+                    "resetTime": "2026-06-19T08:45:39Z"
+                  },
+                  {
+                    "bucketId": "gemini-5h",
+                    "displayName": "Five Hour Limit",
+                    "remaining": {"remainingFraction": 0.91},
+                    "resetTime": "2026-06-15T11:39:34Z"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+        """
+        let snap = try AntigravityResponseParser.parseQuotaSummary(data: Data(json.utf8))
+
+        XCTAssertEqual(snap.buckets.map(\.id), [
+            "gemini_five_hour",
+            "gemini_weekly",
+            "claude_gpt_five_hour",
+            "claude_gpt_weekly"
+        ])
+        XCTAssertEqual(snap.buckets.map(\.title), ["5 Hours", "Weekly", "5 Hours", "Weekly"])
+        XCTAssertEqual(snap.buckets.map(\.shortLabel), ["G 5h", "G wk", "C+G 5h", "C+G wk"])
+        XCTAssertEqual(snap.buckets.map(\.groupTitle), [
+            "Gemini Models",
+            "Gemini Models",
+            "Claude and GPT Models",
+            "Claude and GPT Models"
+        ])
+        XCTAssertEqual(snap.buckets.map(\.rawWindowSeconds), [18_000, 604_800, 18_000, 604_800])
+        XCTAssertEqual(snap.buckets[0].remainingPercent, 91, accuracy: 0.01)
+        XCTAssertEqual(snap.buckets[1].remainingPercent, 82, accuracy: 0.01)
+        XCTAssertEqual(snap.buckets[2].remainingPercent, 73, accuracy: 0.01)
+        XCTAssertEqual(snap.buckets[3].remainingPercent, 64, accuracy: 0.01)
+        XCTAssertTrue(snap.buckets.allSatisfy { $0.resetAt != nil })
+    }
+
+    func testParsesSupportedRemainingFractionShapesAndSnakeCase() throws {
+        let json = """
+        {
+          "groups": [
+            {
+              "display_name": "Gemini Models",
+              "buckets": [
+                {
+                  "bucket_id": "gemini_session",
+                  "display_name": "Session",
+                  "remaining_fraction": 0.5
+                },
+                {
+                  "bucketId": "gemini-weekly",
+                  "displayName": "Weekly Limit",
+                  "remaining": {"case": "remainingFraction", "value": 0.25}
+                }
+              ]
+            },
+            {
+              "displayName": "Claude and GPT models",
+              "buckets": [
+                {
+                  "bucketId": "3p-five-hour",
+                  "displayName": "Five Hour Limit",
+                  "remaining": {"remainingFraction": 0.75}
+                },
+                {
+                  "bucketId": "3p-weekly",
+                  "displayName": "Weekly Limit",
+                  "remainingFraction": 0.0
+                }
+              ]
+            }
+          ]
+        }
+        """
+        let snap = try AntigravityResponseParser.parseQuotaSummary(data: Data(json.utf8))
+        XCTAssertEqual(snap.buckets.map(\.remainingPercent), [50, 25, 75, 0])
+    }
+
+    func testSkipsUnknownDisabledAndFractionlessQuotaSummaryBuckets() throws {
+        let json = """
+        {
+          "groups": [
+            {
+              "displayName": "Gemini Models",
+              "buckets": [
+                {
+                  "bucketId": "gemini-5h",
+                  "displayName": "Five Hour Limit",
+                  "remaining": {"remainingFraction": 0.9}
+                },
+                {
+                  "bucketId": "gemini-weekly",
+                  "displayName": "Weekly Limit"
+                },
+                {
+                  "bucketId": "gemini-monthly",
+                  "displayName": "Monthly Limit",
+                  "remaining": {"remainingFraction": 0.8}
+                },
+                {
+                  "bucketId": "gemini-session-disabled",
+                  "displayName": "Session",
+                  "disabled": true,
+                  "remaining": {"remainingFraction": 0.7}
+                }
+              ]
+            }
+          ]
+        }
+        """
+        let snap = try AntigravityResponseParser.parseQuotaSummary(data: Data(json.utf8))
+        XCTAssertEqual(snap.buckets.map(\.id), ["gemini_five_hour"])
+    }
+
+    func testQuotaSummaryWithoutUsableKnownBucketsThrows() {
+        let json = """
+        {
+          "groups": [
+            {
+              "displayName": "Gemini Models",
+              "buckets": [
+                {"bucketId": "gemini-weekly", "displayName": "Weekly Limit"}
+              ]
+            }
+          ]
+        }
+        """
+        XCTAssertThrowsError(try AntigravityResponseParser.parseQuotaSummary(data: Data(json.utf8)))
+    }
+
+    func testFetchLocalSnapshotUsesSummaryThenMergesIdentity() async throws {
+        var paths: [String] = []
+        var bodies: [String] = []
+        let snapshot = try await AntigravityQuotaAdapter.fetchLocalSnapshot { path, body in
+            paths.append(path)
+            bodies.append(String(decoding: body, as: UTF8.self))
+            if path.contains("RetrieveUserQuotaSummary") {
+                return Data(Self.fourBucketQuotaSummaryJSON.utf8)
+            }
+            return Data(Self.userStatusIdentityJSON.utf8)
+        }
+
+        XCTAssertEqual(paths, [
+            "/exa.language_server_pb.LanguageServerService/RetrieveUserQuotaSummary",
+            "/exa.language_server_pb.LanguageServerService/GetUserStatus"
+        ])
+        XCTAssertEqual(bodies, [#"{"forceRefresh":true}"#, "{}"])
+        XCTAssertEqual(snapshot.buckets.count, 4)
+        XCTAssertEqual(snapshot.email, "user@example.com")
+        XCTAssertEqual(snapshot.planName, "Ultra Lite")
+        XCTAssertEqual(snapshot.modelLabels["MODEL_PLACEHOLDER_M132"], "Gemini Flash")
+    }
+
+    func testFetchLocalSnapshotKeepsFourBucketsWhenIdentityFails() async throws {
+        let snapshot = try await AntigravityQuotaAdapter.fetchLocalSnapshot { path, _ in
+            if path.contains("RetrieveUserQuotaSummary") {
+                return Data(Self.fourBucketQuotaSummaryJSON.utf8)
+            }
+            throw QuotaError.network("identity unavailable")
+        }
+        XCTAssertEqual(snapshot.buckets.count, 4)
+        XCTAssertNil(snapshot.email)
+        XCTAssertNil(snapshot.planName)
+    }
+
+    func testUserStatusProvidesIdentityAndLabelsButNoLegacyQuotaRows() throws {
         let json = """
         {
           "code": 0,
@@ -12,19 +207,9 @@ final class AntigravityParserTests: XCTestCase {
             "cascadeModelConfigData": {
               "clientModelConfigs": [
                 {
-                  "label": "Claude Sonnet 4",
-                  "modelOrAlias": {"model": "claude-sonnet-4-20250514"},
-                  "quotaInfo": {"remainingFraction": 0.42, "resetTime": "2026-06-01T00:00:00Z"}
-                },
-                {
-                  "label": "Gemini 2.5 Pro",
-                  "modelOrAlias": {"model": "gemini-2.5-pro"},
-                  "quotaInfo": {"remainingFraction": 0.78}
-                },
-                {
-                  "label": "Gemini Flash Lite",
-                  "modelOrAlias": {"model": "gemini-2.5-flash-lite"},
-                  "quotaInfo": {"remainingFraction": 0.95}
+                  "label": "Gemini Flash",
+                  "modelOrAlias": {"model": "MODEL_PLACEHOLDER_M132"},
+                  "quotaInfo": {"remainingFraction": 0.42}
                 }
               ]
             }
@@ -34,152 +219,8 @@ final class AntigravityParserTests: XCTestCase {
         let snap = try AntigravityResponseParser.parseUserStatus(data: Data(json.utf8))
         XCTAssertEqual(snap.email, "user@example.com")
         XCTAssertEqual(snap.planName, "Pro")
-        XCTAssertEqual(snap.buckets.count, 3)
-        XCTAssertEqual(snap.buckets[0].title, "Claude Sonnet 4")
-        XCTAssertEqual(snap.buckets[0].usedPercent, 58.0, accuracy: 0.01)
-        XCTAssertNotNil(snap.buckets[0].resetAt)
-        XCTAssertEqual(snap.buckets[0].groupTitle, "Claude")
-
-        XCTAssertEqual(snap.buckets[1].usedPercent, 22.0, accuracy: 0.01)
-        XCTAssertEqual(snap.buckets[1].groupTitle, "Gemini Pro")
-
-        XCTAssertEqual(snap.buckets[2].usedPercent, 5.0, accuracy: 0.01)
-        XCTAssertEqual(snap.buckets[2].groupTitle, "Gemini Flash Lite")
-    }
-
-    /// Google's wire format omits `remainingFraction` (proto3 zero
-    /// default) when a model's per-window quota is fully spent. The
-    /// older parser dropped those entries entirely, hiding the
-    /// exhausted state from the user — they would just stop seeing
-    /// the affected model in Vibe Bar's card while still seeing the
-    /// reset countdown in the official Antigravity dashboard.
-    /// Treat a missing fraction as 0 so the bucket stays visible.
-    func testKeepsDepletedModelsWithMissingRemainingFraction() throws {
-        let json = """
-        {
-          "code": 0,
-          "userStatus": {
-            "cascadeModelConfigData": {
-              "clientModelConfigs": [
-                {
-                  "label": "Gemini 3.5 Flash (High)",
-                  "modelOrAlias": {"model": "gemini-3.5-flash-high"},
-                  "quotaInfo": {"resetTime": "2026-05-23T01:05:00Z"}
-                },
-                {
-                  "label": "Gemini 3.5 Flash (Medium)",
-                  "modelOrAlias": {"model": "gemini-3.5-flash-medium"},
-                  "quotaInfo": {"remainingFraction": 0.0, "resetTime": "2026-05-23T01:05:00Z"}
-                },
-                {
-                  "label": "Claude Sonnet 4.6 (Thinking)",
-                  "modelOrAlias": {"model": "claude-sonnet-4-6"},
-                  "quotaInfo": {"remainingFraction": 0.42, "resetTime": "2026-05-23T05:55:00Z"}
-                }
-              ]
-            }
-          }
-        }
-        """
-        let snap = try AntigravityResponseParser.parseUserStatus(data: Data(json.utf8))
-        XCTAssertEqual(snap.buckets.count, 3, "All three models must surface — including the two depleted Gemini variants.")
-
-        let flashHigh = try XCTUnwrap(snap.buckets.first { $0.title == "Gemini 3.5 Flash (High)" })
-        XCTAssertEqual(flashHigh.usedPercent, 100.0, accuracy: 0.01, "Missing remainingFraction should map to 100% used.")
-        XCTAssertNotNil(flashHigh.resetAt, "Reset countdown should still surface.")
-
-        let flashMed = try XCTUnwrap(snap.buckets.first { $0.title == "Gemini 3.5 Flash (Medium)" })
-        XCTAssertEqual(flashMed.usedPercent, 100.0, accuracy: 0.01, "Explicit zero fraction should also be 100% used.")
-
-        let sonnet = try XCTUnwrap(snap.buckets.first { $0.title == "Claude Sonnet 4.6 (Thinking)" })
-        XCTAssertEqual(sonnet.usedPercent, 58.0, accuracy: 0.01, "Non-depleted models continue to compute as before.")
-    }
-
-    /// Entries with no quotaInfo at all stay filtered out — without
-    /// any quota object, we can't say anything meaningful about the
-    /// model's usage and dragging a "no data" pill into the card is
-    /// worse than omitting it.
-    func testStillSkipsModelsWithoutQuotaInfo() throws {
-        let json = """
-        {
-          "code": 0,
-          "userStatus": {
-            "cascadeModelConfigData": {
-              "clientModelConfigs": [
-                {"label": "Unknown Model A", "modelOrAlias": {"model": "unknown-a"}},
-                {"label": "Claude Sonnet 4.6 (Thinking)", "modelOrAlias": {"model": "claude-sonnet"}, "quotaInfo": {"remainingFraction": 0.5}}
-              ]
-            }
-          }
-        }
-        """
-        let snap = try AntigravityResponseParser.parseUserStatus(data: Data(json.utf8))
-        XCTAssertEqual(snap.buckets.count, 1)
-        XCTAssertEqual(snap.buckets[0].title, "Claude Sonnet 4.6 (Thinking)")
-    }
-
-    func testFallsBackToPlanInfoWhenUserTierMissing() throws {
-        let json = """
-        {
-          "code": 0,
-          "userStatus": {
-            "email": null,
-            "planStatus": {
-              "planInfo": {"planDisplayName": "Pro Trial", "productName": "AntiGravity"}
-            },
-            "cascadeModelConfigData": {
-              "clientModelConfigs": [
-                {"label": "x", "modelOrAlias": {"model": "x"}, "quotaInfo": {"remainingFraction": 1.0}}
-              ]
-            }
-          }
-        }
-        """
-        let snap = try AntigravityResponseParser.parseUserStatus(data: Data(json.utf8))
-        XCTAssertEqual(snap.planName, "Pro Trial")
-        XCTAssertEqual(snap.buckets.count, 1)
-        XCTAssertEqual(snap.buckets[0].usedPercent, 0.0, accuracy: 0.01)
-    }
-
-    func testNormalizesCurrentPlaceholderModelsFromLabels() throws {
-        let json = """
-        {
-          "code": 0,
-          "userStatus": {
-            "cascadeModelConfigData": {
-              "clientModelConfigs": [
-                {
-                  "label": "Gemini 3.5 Flash (High)",
-                  "modelOrAlias": {"model": "MODEL_PLACEHOLDER_M132"},
-                  "quotaInfo": {"remainingFraction": 0.0}
-                },
-                {
-                  "label": "Claude Sonnet 4.6 (Thinking)",
-                  "modelOrAlias": {"model": "MODEL_PLACEHOLDER_M35"},
-                  "quotaInfo": {"remainingFraction": 1.0}
-                },
-                {
-                  "label": "GPT-OSS 120B (Medium)",
-                  "modelOrAlias": {"model": "MODEL_OPENAI_GPT_OSS_120B_MEDIUM"},
-                  "quotaInfo": {"remainingFraction": 0.25}
-                }
-              ]
-            }
-          }
-        }
-        """
-        let snap = try AntigravityResponseParser.parseUserStatus(data: Data(json.utf8))
-
-        XCTAssertEqual(snap.buckets.map(\.id), [
-            "gemini-3.5-flash-high",
-            "claude-sonnet-4.6-thinking",
-            "gpt-oss-120b-medium"
-        ])
-        XCTAssertEqual(snap.buckets[0].usedPercent, 100.0, accuracy: 0.01)
-        XCTAssertEqual(snap.buckets[0].remainingPercent, 0.0, accuracy: 0.01)
-        XCTAssertEqual(snap.buckets[0].groupTitle, "Gemini Flash")
-        XCTAssertEqual(snap.buckets[1].shortLabel, "Sonnet")
-        XCTAssertEqual(snap.buckets[2].groupTitle, "GPT-OSS")
+        XCTAssertTrue(snap.buckets.isEmpty, "GetUserStatus must no longer restore per-model quota rows.")
+        XCTAssertEqual(snap.modelLabels["MODEL_PLACEHOLDER_M132"], "Gemini Flash")
     }
 
     func testMissingUserStatusThrowsParseFailure() {
@@ -213,23 +254,43 @@ final class AntigravityParserTests: XCTestCase {
         }
     }
 
-    func testCodeOKStringIsAcceptedAsSuccess() throws {
-        let json = """
-        {
-          "code": "OK",
-          "userStatus": {
-            "cascadeModelConfigData": {
-              "clientModelConfigs": [
-                {"label": "Pro", "modelOrAlias": {"model": "x"}, "quotaInfo": {"remainingFraction": 0.6}}
-              ]
-            }
+    private static let fourBucketQuotaSummaryJSON = """
+    {
+      "response": {
+        "groups": [
+          {
+            "displayName": "Gemini Models",
+            "buckets": [
+              {"bucketId": "gemini-5h", "displayName": "Five Hour Limit", "remaining": {"remainingFraction": 0.91}},
+              {"bucketId": "gemini-weekly", "displayName": "Weekly Limit", "remaining": {"remainingFraction": 0.82}}
+            ]
+          },
+          {
+            "displayName": "Claude and GPT models",
+            "buckets": [
+              {"bucketId": "3p-5h", "displayName": "Five Hour Limit", "remaining": {"remainingFraction": 0.73}},
+              {"bucketId": "3p-weekly", "displayName": "Weekly Limit", "remaining": {"remainingFraction": 0.64}}
+            ]
           }
-        }
-        """
-        let snap = try AntigravityResponseParser.parseUserStatus(data: Data(json.utf8))
-        XCTAssertEqual(snap.buckets.count, 1)
-        XCTAssertEqual(snap.buckets[0].usedPercent, 40.0, accuracy: 0.01)
+        ]
+      }
     }
+    """
+
+    private static let userStatusIdentityJSON = """
+    {
+      "code": "OK",
+      "userStatus": {
+        "email": "user@example.com",
+        "userTier": {"id": "g1-ultra-lite-tier", "name": "Ultra Lite"},
+        "cascadeModelConfigData": {
+          "clientModelConfigs": [
+            {"label": "Gemini Flash", "modelOrAlias": {"model": "MODEL_PLACEHOLDER_M132"}}
+          ]
+        }
+      }
+    }
+    """
 
     func testProcessLineParse() {
         let line = "  12345 /Applications/Antigravity/Resources/.../language_server_macos --csrf_token=abc --extension_server_port=44567"

--- a/Tests/VibeBarCoreTests/AppSettingsTests.swift
+++ b/Tests/VibeBarCoreTests/AppSettingsTests.swift
@@ -160,16 +160,12 @@ final class AppSettingsTests: XCTestCase {
         let decoded = try JSONDecoder().decode(MiniWindowSettings.self, from: Data(json.utf8))
 
         XCTAssertEqual(decoded.selectedFieldIds, [
-            "antigravity.gemini-3.5-flash-high",
-            "antigravity.gemini-3.5-flash-medium",
-            "antigravity.gemini-3.1-pro-high",
-            "antigravity.gemini-3.1-pro-low",
-            "antigravity.claude-sonnet-4.6-thinking"
+            "antigravity.gemini_five_hour",
+            "antigravity.claude_gpt_five_hour"
         ])
         XCTAssertEqual(decoded.compactSelectedFieldIds, [
-            "antigravity.claude-sonnet-4.6-thinking",
-            "antigravity.gemini-3.1-pro-high",
-            "antigravity.gemini-3.1-pro-low"
+            "antigravity.claude_gpt_five_hour",
+            "antigravity.gemini_five_hour"
         ])
     }
 
@@ -200,9 +196,8 @@ final class AppSettingsTests: XCTestCase {
         let compact = settings.menuBarItem(.compact)
 
         XCTAssertEqual(compact.selectedFieldIds, [
-            "antigravity.gemini-3.5-flash-high",
-            "antigravity.gemini-3.5-flash-medium",
-            "antigravity.claude-sonnet-4.6-thinking"
+            "antigravity.gemini_five_hour",
+            "antigravity.claude_gpt_five_hour"
         ])
     }
 

--- a/Tests/VibeBarCoreTests/MenuBarFieldCatalogTests.swift
+++ b/Tests/VibeBarCoreTests/MenuBarFieldCatalogTests.swift
@@ -10,13 +10,10 @@ final class MenuBarFieldCatalogTests: XCTestCase {
         let expected = [
             "gemini.five_hour",
             "gemini.weekly",
-            "antigravity.claude-sonnet-4.6-thinking",
-            "antigravity.claude-opus-4.6-thinking",
-            "antigravity.gpt-oss-120b-medium",
-            "antigravity.gemini-3.5-flash-high",
-            "antigravity.gemini-3.5-flash-medium",
-            "antigravity.gemini-3.1-pro-high",
-            "antigravity.gemini-3.1-pro-low",
+            "antigravity.gemini_five_hour",
+            "antigravity.gemini_weekly",
+            "antigravity.claude_gpt_five_hour",
+            "antigravity.claude_gpt_weekly",
             "grok.weekly"
         ]
 
@@ -29,8 +26,10 @@ final class MenuBarFieldCatalogTests: XCTestCase {
         let selected = Set(AppSettings.defaultMiniWindow.selectedFieldIds)
         XCTAssertTrue(selected.contains("gemini.five_hour"))
         XCTAssertTrue(selected.contains("gemini.weekly"))
-        XCTAssertTrue(selected.contains("antigravity.gemini-3.5-flash-high"))
-        XCTAssertTrue(selected.contains("antigravity.claude-sonnet-4.6-thinking"))
+        XCTAssertTrue(selected.contains("antigravity.gemini_five_hour"))
+        XCTAssertTrue(selected.contains("antigravity.gemini_weekly"))
+        XCTAssertTrue(selected.contains("antigravity.claude_gpt_five_hour"))
+        XCTAssertTrue(selected.contains("antigravity.claude_gpt_weekly"))
         XCTAssertTrue(selected.contains("grok.weekly"))
     }
 
@@ -51,5 +50,18 @@ final class MenuBarFieldCatalogTests: XCTestCase {
         ]
         let migrated = MenuBarFieldCatalog.migratedFieldIds(legacy)
         XCTAssertEqual(migrated, ["gemini.five_hour"])
+    }
+
+    func testAntigravityPerModelIdsMigrateToSharedFiveHourPools() {
+        let legacy = [
+            "antigravity.gemini-3.5-flash-high",
+            "antigravity.gemini-3.1-pro-low",
+            "antigravity.claude-sonnet-4.6-thinking",
+            "antigravity.gpt-oss-120b-medium"
+        ]
+        XCTAssertEqual(MenuBarFieldCatalog.migratedFieldIds(legacy), [
+            "antigravity.gemini_five_hour",
+            "antigravity.claude_gpt_five_hour"
+        ])
     }
 }


### PR DESCRIPTION
## Summary
- read AntiGravity grouped quota summary from the local language server
- expose Gemini and Claude/GPT five-hour and weekly pools as four stable rows
- migrate legacy per-model selections while preserving Gemini Web quota fields

## Test plan
- [x] swift build
- [x] swift test (615 tests)
- [x] ./Scripts/build_app.sh release
- [x] codesign entitlements and strict signature verification
- [x] launch packaged app and confirm it remains running without an immediate crash