### PR TITLE
Improve quota utilization and cost history

### DIFF
--- a/Sources/VibeBarApp/Views/ColumnMasonryLayout.swift
+++ b/Sources/VibeBarApp/Views/ColumnMasonryLayout.swift
@@ -1,25 +1,40 @@
 import SwiftUI
+import VibeBarCore
 
-/// Two-column "shortest column wins" masonry. Used by the Overview to lay out
-/// cost cards plus the four combined summary cards (Model Ranking, Past Year,
-/// When You Use, Hourly Burn Rate) without one column ending up dramatically
-/// taller than the other.
-///
-/// Each column is the same width (`(totalWidth - spacing) / columns`). For
-/// each subview we measure the height it would take at that width, then place
-/// it in whichever column currently has the shortest stack. Ties always
-/// resolve to the leftmost shorter column, which keeps the layout
-/// deterministic across redraws.
+enum OverviewMasonryPhase: Int {
+    case quota
+    case cost
+    case auxiliary
+
+    var corePhase: OverviewMasonryPlanner.Phase {
+        switch self {
+        case .quota: .quota
+        case .cost: .cost
+        case .auxiliary: .auxiliary
+        }
+    }
+}
+
+private struct OverviewMasonryPhaseKey: LayoutValueKey {
+    static let defaultValue = OverviewMasonryPhase.auxiliary
+}
+
+private struct OverviewMasonryIDKey: LayoutValueKey {
+    static let defaultValue = ""
+}
+
+extension View {
+    func overviewMasonryItem(id: String, phase: OverviewMasonryPhase) -> some View {
+        layoutValue(key: OverviewMasonryIDKey.self, value: id)
+            .layoutValue(key: OverviewMasonryPhaseKey.self, value: phase)
+    }
+}
+
+/// A live-measured waterfall whose policy is quota-first, then Cost, then
+/// supporting analytics. See `OverviewMasonryPlanner` for the tested optimizer.
 struct ColumnMasonryLayout: Layout {
     var columns: Int = 2
     var spacing: CGFloat = 12
-    /// The first `anchoredItems` subviews are pinned to columns 0…N-1 in
-    /// declaration order, regardless of column height. Everything after
-    /// fills whichever column is currently shortest. This lets the Overview
-    /// keep OpenAI Quota / Claude Quota locked to their respective columns
-    /// while the cost + summary cards below flow into the empty space under
-    /// whichever provider's quota came up shorter.
-    var anchoredItems: Int = 0
 
     func sizeThatFits(
         proposal: ProposedViewSize,
@@ -27,10 +42,8 @@ struct ColumnMasonryLayout: Layout {
         cache: inout Void
     ) -> CGSize {
         let totalWidth = proposal.width ?? 0
-        let columnWidth = columnWidth(for: totalWidth)
-        let placement = placements(for: subviews, columnWidth: columnWidth)
-        let totalHeight = placement.columnHeights.max() ?? 0
-        return CGSize(width: totalWidth, height: totalHeight)
+        let plan = placementPlan(for: subviews, columnWidth: columnWidth(for: totalWidth))
+        return CGSize(width: totalWidth, height: CGFloat(plan.columnHeights.max() ?? 0))
     }
 
     func placeSubviews(
@@ -39,63 +52,46 @@ struct ColumnMasonryLayout: Layout {
         subviews: Subviews,
         cache: inout Void
     ) {
-        let columnWidth = columnWidth(for: bounds.width)
-        let placement = placements(for: subviews, columnWidth: columnWidth)
-        for (index, slot) in placement.slots.enumerated() {
-            subviews[index].place(
-                at: CGPoint(x: bounds.minX + slot.x, y: bounds.minY + slot.y),
+        let width = columnWidth(for: bounds.width)
+        let plan = placementPlan(for: subviews, columnWidth: width)
+        for (index, subview) in subviews.enumerated() {
+            let id = stableID(for: subview, index: index)
+            guard let position = plan.positions[id] else { continue }
+            let size = subview.sizeThatFits(ProposedViewSize(width: width, height: nil))
+            subview.place(
+                at: CGPoint(
+                    x: bounds.minX + CGFloat(position.column) * (width + spacing),
+                    y: bounds.minY + CGFloat(position.y)
+                ),
                 anchor: .topLeading,
-                proposal: ProposedViewSize(width: columnWidth, height: slot.height)
+                proposal: ProposedViewSize(width: width, height: size.height)
             )
         }
     }
 
-    private struct Slot {
-        let x: CGFloat
-        let y: CGFloat
-        let height: CGFloat
-    }
-
-    private struct Placement {
-        let slots: [Slot]
-        let columnHeights: [CGFloat]
-    }
-
-    private func placements(for subviews: Subviews, columnWidth: CGFloat) -> Placement {
-        let columnCount = max(1, columns)
-        let anchorLimit = max(0, min(anchoredItems, columnCount))
-        var heights = Array(repeating: CGFloat(0), count: columnCount)
-        var slots: [Slot] = []
-        slots.reserveCapacity(subviews.count)
-        for (index, subview) in subviews.enumerated() {
-            let proposed = ProposedViewSize(width: columnWidth, height: nil)
-            let size = subview.sizeThatFits(proposed)
-            let column = index < anchorLimit ? index : shortestColumn(in: heights)
-            let needsLeadingSpacing = heights[column] > 0
-            let y = heights[column] + (needsLeadingSpacing ? spacing : 0)
-            let x = CGFloat(column) * (columnWidth + spacing)
-            slots.append(Slot(x: x, y: y, height: size.height))
-            heights[column] = y + size.height
+    private func placementPlan(for subviews: Subviews, columnWidth: CGFloat) -> OverviewMasonryPlanner.Plan {
+        let proposal = ProposedViewSize(width: columnWidth, height: nil)
+        let items = subviews.enumerated().map { index, subview in
+            OverviewMasonryPlanner.Item(
+                id: stableID(for: subview, index: index),
+                height: Double(subview.sizeThatFits(proposal).height),
+                phase: subview[OverviewMasonryPhaseKey.self].corePhase
+            )
         }
-        return Placement(slots: slots, columnHeights: heights)
+        return OverviewMasonryPlanner.plan(
+            items: items,
+            columns: columns,
+            spacing: Double(spacing)
+        )
     }
 
-    /// Leftmost column whose running height is the smallest. Ties prefer the
-    /// earlier index — important so re-runs of `sizeThatFits` and
-    /// `placeSubviews` agree on placement when several columns are at zero.
-    private func shortestColumn(in heights: [CGFloat]) -> Int {
-        var bestIndex = 0
-        var bestHeight = heights[0]
-        for index in 1..<heights.count where heights[index] < bestHeight {
-            bestHeight = heights[index]
-            bestIndex = index
-        }
-        return bestIndex
+    private func stableID(for subview: Subviews.Element, index: Int) -> String {
+        let supplied = subview[OverviewMasonryIDKey.self]
+        return supplied.isEmpty ? "overview-item-\(index)" : supplied
     }
 
     private func columnWidth(for totalWidth: CGFloat) -> CGFloat {
         let columnCount = max(1, columns)
-        let totalSpacing = spacing * CGFloat(columnCount - 1)
-        return max(0, (totalWidth - totalSpacing) / CGFloat(columnCount))
+        return max(0, (totalWidth - spacing * CGFloat(columnCount - 1)) / CGFloat(columnCount))
     }
 }

--- a/Sources/VibeBarApp/Views/CostHistoryView.swift
+++ b/Sources/VibeBarApp/Views/CostHistoryView.swift
@@ -2,59 +2,88 @@ import SwiftUI
 import Charts
 import VibeBarCore
 
-/// Cost history chart with selectable timeframe (Today / 7d / 30d / All).
-/// Bars taller than the average get a warmer color; a dashed RuleMark shows
-/// the daily average so anomalies are obvious at a glance.
-///
-/// Hovering / clicking a bar reveals that day's top models and totals — fed
-/// from `CostSnapshot.dailyModelBreakdown`.
+private enum CostHistoryGranularity: String, CaseIterable, Identifiable {
+    case hour = "Hour"
+    case day = "Day"
+    case week = "Week"
+    case month = "Month"
+    var id: String { rawValue }
+}
+
+private struct CostChartPoint: Identifiable, Equatable {
+    let date: Date
+    let costUSD: Double
+    let totalTokens: Int
+    let models: [CostSnapshot.ModelBreakdown]
+    var id: Date { date }
+}
+
+/// Cost history with hour/day/week/month grouping, model-aware hover detail,
+/// and a click-to-pin model inspector that stays out of the plot area.
 struct CostHistoryView: View {
     let tool: ToolType
     let snapshot: CostSnapshot?
     let density: Theme.Density
-    /// Plot area height. Overview uses a taller value to roughly match the
-    /// height of the left-column quota cards; provider detail tabs pass the
-    /// default.
     var chartHeight: CGFloat = 130
+    var titleOverride: String? = nil
+
     @State private var timeframe: CostTimeframe = .month
-    @State private var hoveredDay: Date?
-    @State private var hoveredHour: Date?
+    @State private var granularity: CostHistoryGranularity = .day
+    @State private var hoveredDate: Date?
+    @State private var pinnedDate: Date?
 
     @EnvironmentObject var environment: AppEnvironment
 
     var body: some View {
-        // Hoist the timeframe-derived values once per body. These were
-        // previously computed properties that re-filtered & re-reduced the
-        // entire daily history every time SwiftUI accessed them — once for
-        // the chart, three times for the metric row, plus per-bar via
-        // `barColor`. With ~1000 daily points (3-year retention) and a
-        // periodic TimelineView upstream, that adds up.
-        let days = filteredDays
-        let hourlyPoints = todayHourlyPoints
-        let hasHourlyDetail = timeframe == .today && (snapshot?.todayHourlyHistory.isEmpty == false)
-        let total = hasHourlyDetail ? hourlyPoints.reduce(0) { $0 + $1.costUSD } : days.reduce(0) { $0 + $1.costUSD }
-        let sampleCount = hasHourlyDetail ? hourlyPoints.count : days.count
-        let avg = sampleCount == 0 ? 0 : total / Double(sampleCount)
-        let peakValue = hasHourlyDetail ? (hourlyPoints.map(\.costUSD).max() ?? 0) : (days.map(\.costUSD).max() ?? 0)
+        let points = chartPoints
+        let total = points.reduce(0) { $0 + $1.costUSD }
+        let average = points.isEmpty ? 0 : total / Double(points.count)
+        let peak = points.map(\.costUSD).max() ?? 0
 
         VStack(alignment: .leading, spacing: density.cardSpacing) {
-            HStack(alignment: .firstTextBaseline) {
-                Text("Cost History")
+            HStack(alignment: .firstTextBaseline, spacing: 6) {
+                Text(titleOverride ?? "Cost History")
                     .font(.system(size: density.bucketTitleFontSize, weight: .semibold))
-                Spacer()
+                Spacer(minLength: 4)
                 CostTimeframeSelector(selection: $timeframe, density: density)
+                if availableGranularities.count > 1 {
+                    Menu {
+                        ForEach(availableGranularities) { option in
+                            Button {
+                                granularity = option
+                                clearSelection()
+                            } label: {
+                                if option == granularity {
+                                    Label(option.rawValue, systemImage: "checkmark")
+                                } else {
+                                    Text(option.rawValue)
+                                }
+                            }
+                        }
+                    } label: {
+                        Text("By \(granularity.rawValue)")
+                            .font(.system(size: max(9, density.segmentedFontSize - 1), weight: .semibold))
+                    }
+                    .menuStyle(.borderlessButton)
+                    .fixedSize()
+                }
                 SectionRefreshButton(isRefreshing: false) {
                     environment.refreshCostUsage()
                 }
-                .padding(.leading, 4)
             }
-            chart(points: days, hourlyPoints: hourlyPoints, hasHourlyDetail: hasHourlyDetail, average: avg)
+
+            chart(points: points, average: average)
+
+            if let pinned = pinnedPoint(in: points) {
+                pinnedModelPanel(pinned)
+            }
+
             HStack(spacing: 16) {
                 metric(label: "Total", value: formatCost(total))
-                metric(label: timeframe == .today ? "Avg/hour" : "Avg/day", value: formatCost(avg))
-                metric(label: timeframe == .today ? "Peak hr" : "Peak", value: formatCost(peakValue))
+                metric(label: "Avg/\(granularity.rawValue.lowercased())", value: formatCost(average))
+                metric(label: "Peak", value: formatCost(peak))
                 Spacer()
-                Text(timeframeNote(sampleCount: sampleCount))
+                Text(timeframeNote(pointCount: points.count))
                     .font(.system(size: density.resetCountdownFontSize))
                     .foregroundStyle(.tertiary)
             }
@@ -68,23 +97,22 @@ struct CostHistoryView: View {
             RoundedRectangle(cornerRadius: density.cardCornerRadius, style: .continuous)
                 .stroke(.separator.opacity(0.4), lineWidth: 0.5)
         )
+        .onChange(of: timeframe) { _, _ in
+            if !availableGranularities.contains(granularity) {
+                granularity = availableGranularities.first ?? .day
+            }
+            clearSelection()
+        }
     }
 
     @ViewBuilder
-    private func chart(
-        points: [DailyCostPoint],
-        hourlyPoints: [HourlyCostPoint],
-        hasHourlyDetail: Bool,
-        average: Double
-    ) -> some View {
-        if timeframe == .today {
-            todayChart(points: hourlyPoints, hasHourlyDetail: hasHourlyDetail, average: average)
-        } else if points.isEmpty {
-            VStack {
-                Text("Building history…")
+    private func chart(points: [CostChartPoint], average: Double) -> some View {
+        if points.isEmpty {
+            VStack(spacing: 4) {
+                Text(granularity == .hour ? "Building hourly detail…" : "Building history…")
                     .font(.system(size: density.subtitleFontSize))
                     .foregroundStyle(.tertiary)
-                Text("Cost samples accumulate as you use Codex/Claude CLI.")
+                Text("Cost samples appear after the next local scan.")
                     .font(.system(size: density.resetCountdownFontSize))
                     .foregroundStyle(.tertiary)
             }
@@ -92,37 +120,55 @@ struct CostHistoryView: View {
             .padding(.vertical, 24)
         } else {
             Chart {
-                ForEach(points) { day in
-                    BarMark(
-                        x: .value("Day", day.date, unit: .day),
-                        y: .value("Cost", day.costUSD)
-                    )
-                    .foregroundStyle(barColor(for: day, average: average))
-                    .cornerRadius(2)
-                    .opacity(opacity(for: day))
+                if granularity == .hour {
+                    ForEach(points) { point in
+                        AreaMark(
+                            x: .value("Hour", point.date, unit: .hour),
+                            y: .value("Cost", point.costUSD)
+                        )
+                        .interpolationMethod(.monotone)
+                        .foregroundStyle(
+                            LinearGradient(
+                                colors: [Color.accentColor.opacity(0.22), Color.accentColor.opacity(0.04)],
+                                startPoint: .top,
+                                endPoint: .bottom
+                            )
+                        )
+                        LineMark(
+                            x: .value("Hour", point.date, unit: .hour),
+                            y: .value("Cost", point.costUSD)
+                        )
+                        .interpolationMethod(.monotone)
+                        .foregroundStyle(Color.accentColor)
+                        .lineStyle(StrokeStyle(lineWidth: 2, lineCap: .round, lineJoin: .round))
+                        .opacity(pointOpacity(point))
+                        if point.costUSD > 0 {
+                            PointMark(
+                                x: .value("Hour", point.date, unit: .hour),
+                                y: .value("Cost", point.costUSD)
+                            )
+                            .symbolSize(24)
+                            .foregroundStyle(point.costUSD > average * 1.5 ? Color.orange : Color.accentColor)
+                        }
+                    }
+                } else {
+                    ForEach(points) { point in
+                        BarMark(
+                            x: .value("Period", point.date, unit: chartCalendarComponent),
+                            y: .value("Cost", point.costUSD)
+                        )
+                        .foregroundStyle(point.costUSD > average * 1.5 ? Color.orange : Color.accentColor)
+                        .cornerRadius(2)
+                        .opacity(pointOpacity(point))
+                    }
                 }
                 if average > 0 {
                     RuleMark(y: .value("Avg", average))
-                        .foregroundStyle(Color.accentColor.opacity(0.55))
+                        .foregroundStyle(Color.accentColor.opacity(0.5))
                         .lineStyle(StrokeStyle(lineWidth: 1.2, dash: [4, 3]))
-                        .annotation(position: .top, alignment: .trailing, spacing: 3) {
-                            Text("avg \(formatCost(average))")
-                                .font(.system(size: 9, weight: .semibold, design: .rounded).monospacedDigit())
-                                .foregroundStyle(.primary.opacity(0.82))
-                                .padding(.horizontal, 5)
-                                .padding(.vertical, 2)
-                                .background(
-                                    Capsule(style: .continuous)
-                                        .fill(Color(nsColor: .controlBackgroundColor).opacity(0.92))
-                                )
-                                .overlay(
-                                    Capsule(style: .continuous)
-                                        .stroke(.separator.opacity(0.35), lineWidth: 0.5)
-                                )
-                                .shadow(color: .black.opacity(0.18), radius: 2, x: 0, y: 1)
-                        }
                 }
             }
+            .chartXScale(domain: chartDomain(points))
             .chartYAxis {
                 AxisMarks(position: .leading, values: .automatic(desiredCount: 3)) { value in
                     AxisGridLine().foregroundStyle(.secondary.opacity(0.15))
@@ -135,8 +181,8 @@ struct CostHistoryView: View {
                 }
             }
             .chartXAxis {
-                AxisMarks(values: .stride(by: stride.calendarComponent, count: stride.count)) { value in
-                    AxisValueLabel(format: stride.format)
+                AxisMarks(values: .stride(by: axisStride.component, count: axisStride.count)) { value in
+                    AxisValueLabel(format: axisStride.format)
                         .font(.system(size: 9))
                 }
             }
@@ -144,113 +190,11 @@ struct CostHistoryView: View {
                 hoverOverlay(proxy: proxy, points: points)
             }
             .frame(height: chartHeight)
-            // Tooltip is an overlay on top of the chart bars — no padding
-            // reservation. It auto-clamps horizontally inside `tooltipX(...)`
-            // and floats above the bar at the top of the chart area.
         }
     }
 
-    @ViewBuilder
-    private func todayChart(points: [HourlyCostPoint], hasHourlyDetail: Bool, average: Double) -> some View {
-        if !hasHourlyDetail {
-            VStack(spacing: 4) {
-                Text("Building hourly detail…")
-                    .font(.system(size: density.subtitleFontSize))
-                    .foregroundStyle(.tertiary)
-                Text("Hourly samples appear after the next local scan.")
-                    .font(.system(size: density.resetCountdownFontSize))
-                    .foregroundStyle(.tertiary)
-            }
-            .frame(maxWidth: .infinity)
-            .padding(.vertical, 24)
-        } else {
-            Chart {
-                ForEach(points) { hour in
-                    AreaMark(
-                        x: .value("Hour", hour.date, unit: .hour),
-                        y: .value("Cost", hour.costUSD)
-                    )
-                    .interpolationMethod(.monotone)
-                    .foregroundStyle(
-                        LinearGradient(
-                            colors: [
-                                Color.accentColor.opacity(0.22),
-                                Color.accentColor.opacity(0.04)
-                            ],
-                            startPoint: .top,
-                            endPoint: .bottom
-                        )
-                    )
-
-                    LineMark(
-                        x: .value("Hour", hour.date, unit: .hour),
-                        y: .value("Cost", hour.costUSD)
-                    )
-                    .interpolationMethod(.monotone)
-                    .foregroundStyle(Color.accentColor)
-                    .lineStyle(StrokeStyle(lineWidth: 2, lineCap: .round, lineJoin: .round))
-                    .opacity(hourlyOpacity(for: hour))
-
-                    if hour.costUSD > 0 {
-                        PointMark(
-                            x: .value("Hour", hour.date, unit: .hour),
-                            y: .value("Cost", hour.costUSD)
-                        )
-                        .symbolSize(24)
-                        .foregroundStyle(hour.costUSD > average * 1.5 ? Color.orange : Color.accentColor)
-                    }
-                }
-                if average > 0 {
-                    RuleMark(y: .value("Avg", average))
-                        .foregroundStyle(Color.accentColor.opacity(0.5))
-                        .lineStyle(StrokeStyle(lineWidth: 1.2, dash: [4, 3]))
-                        .annotation(position: .top, alignment: .trailing, spacing: 3) {
-                            Text("avg \(formatCost(average))")
-                                .font(.system(size: 9, weight: .semibold, design: .rounded).monospacedDigit())
-                                .foregroundStyle(.primary.opacity(0.82))
-                                .padding(.horizontal, 5)
-                                .padding(.vertical, 2)
-                                .background(
-                                    Capsule(style: .continuous)
-                                        .fill(Color(nsColor: .controlBackgroundColor).opacity(0.92))
-                                )
-                                .overlay(
-                                    Capsule(style: .continuous)
-                                        .stroke(.separator.opacity(0.35), lineWidth: 0.5)
-                                )
-                                .shadow(color: .black.opacity(0.18), radius: 2, x: 0, y: 1)
-                        }
-                }
-            }
-            .chartXScale(domain: todayDomain)
-            .chartYAxis {
-                AxisMarks(position: .leading, values: .automatic(desiredCount: 3)) { value in
-                    AxisGridLine().foregroundStyle(.secondary.opacity(0.15))
-                    AxisValueLabel {
-                        if let raw = value.as(Double.self) {
-                            Text(formatAxisCost(raw))
-                                .font(.system(size: 9, design: .rounded).monospacedDigit())
-                        }
-                    }
-                }
-            }
-            .chartXAxis {
-                AxisMarks(values: .stride(by: .hour, count: 4)) { value in
-                    AxisValueLabel(format: .dateTime.hour())
-                        .font(.system(size: 9))
-                }
-            }
-            .chartOverlay { proxy in
-                hourlyHoverOverlay(proxy: proxy, points: points)
-            }
-            .frame(height: chartHeight)
-        }
-    }
-
-    /// Track the cursor X position and resolve it to the closest day so we can
-    /// surface a tooltip with model breakdown.
-    private func hoverOverlay(proxy: ChartProxy, points: [DailyCostPoint]) -> some View {
-        GeometryReader { geo in
+    private func hoverOverlay(proxy: ChartProxy, points: [CostChartPoint]) -> some View {
+        GeometryReader { geometry in
             ZStack(alignment: .topLeading) {
                 Rectangle()
                     .fill(Color.clear)
@@ -258,31 +202,31 @@ struct CostHistoryView: View {
                     .onContinuousHover { phase in
                         switch phase {
                         case .active(let location):
-                            // proxy.plotFrame is the modern API but optional; fall back to 0
-                            // when it isn't ready yet (first frame of layout).
-                            let plotMinX = proxy.plotFrame.map { geo[$0].minX } ?? 0
+                            let plotMinX = proxy.plotFrame.map { geometry[$0].minX } ?? 0
                             if let date: Date = proxy.value(atX: location.x - plotMinX, as: Date.self) {
-                                hoveredDay = nearestDay(to: date, in: points)
+                                hoveredDate = nearestPoint(to: date, in: points)?.date
                             }
                         case .ended:
-                            hoveredDay = nil
+                            hoveredDate = nil
                         }
                     }
-                if let day = hoveredDay,
-                   let point = points.first(where: { Calendar.current.isDate($0.date, inSameDayAs: day) }) {
-                    tooltipView(for: point)
-                        .offset(x: tooltipX(for: point.date, proxy: proxy, geo: geo, in: points))
+                    .onTapGesture {
+                        guard let hoveredDate else { return }
+                        pinnedDate = pinnedDate == hoveredDate ? nil : hoveredDate
+                    }
+
+                if let hovered = hoveredPoint(in: points), pinnedDate == nil {
+                    compactTooltip(hovered)
+                        .offset(x: tooltipX(for: hovered.date, proxy: proxy, geometry: geometry))
                 }
             }
         }
     }
 
-    @ViewBuilder
-    private func tooltipView(for point: DailyCostPoint) -> some View {
-        let models = snapshot?.topModels(for: point.date) ?? []
+    private func compactTooltip(_ point: CostChartPoint) -> some View {
         VStack(alignment: .leading, spacing: 4) {
             HStack {
-                Text(formatTooltipDate(point.date))
+                Text(tooltipDate(point.date))
                     .font(.system(size: 10, weight: .semibold))
                 Spacer(minLength: 8)
                 Text(formatCost(point.costUSD))
@@ -291,168 +235,254 @@ struct CostHistoryView: View {
             Text(formatTokens(point.totalTokens))
                 .font(.system(size: 9, design: .rounded).monospacedDigit())
                 .foregroundStyle(.secondary)
-            if !models.isEmpty {
-                Divider().opacity(0.3)
-                ForEach(models) { model in
-                    HStack(alignment: .firstTextBaseline) {
-                        Text(model.modelName)
-                            .font(.system(size: 9, weight: .medium))
-                            .lineLimit(1)
-                            .truncationMode(.middle)
-                        Spacer(minLength: 8)
-                        Text(formatCost(model.costUSD))
-                            .font(.system(size: 9, design: .rounded).monospacedDigit())
-                            .foregroundStyle(.secondary)
-                    }
-                }
+            ForEach(point.models.prefix(3)) { model in
+                modelRow(model)
+            }
+            if point.models.count > 3 {
+                Text("+\(point.models.count - 3) more · click to inspect")
+                    .font(.system(size: 8, weight: .medium))
+                    .foregroundStyle(.secondary)
             }
         }
         .padding(.horizontal, 8)
         .padding(.vertical, 6)
-        .background(
-            RoundedRectangle(cornerRadius: 6, style: .continuous)
-                .fill(Color.black.opacity(0.85))
-        )
+        .background(RoundedRectangle(cornerRadius: 6).fill(Color.black.opacity(0.87)))
         .foregroundStyle(.white)
-        .frame(width: tooltipWidth)
+        .frame(width: 190)
         .allowsHitTesting(false)
     }
 
-    private let tooltipWidth: CGFloat = 180
-
-    private func tooltipX(for date: Date, proxy: ChartProxy, geo: GeometryProxy, in points: [DailyCostPoint]) -> CGFloat {
-        guard let xValue = proxy.position(forX: date) else { return 0 }
-        let plotMinX = proxy.plotFrame.map { geo[$0].minX } ?? 0
-        let centerX = plotMinX + xValue
-        // Keep the tooltip on-screen even at the chart edges.
-        let halfWidth = tooltipWidth / 2
-        let clamped = min(max(centerX - halfWidth, 0), max(0, geo.size.width - tooltipWidth))
-        return clamped
-    }
-
-    private func nearestDay(to date: Date, in points: [DailyCostPoint]) -> Date? {
-        guard !points.isEmpty else { return nil }
-        return points.min(by: { abs($0.date.timeIntervalSince(date)) < abs($1.date.timeIntervalSince(date)) })?.date
-    }
-
-    private func hourlyHoverOverlay(proxy: ChartProxy, points: [HourlyCostPoint]) -> some View {
-        GeometryReader { geo in
-            ZStack(alignment: .topLeading) {
-                Rectangle()
-                    .fill(Color.clear)
-                    .contentShape(Rectangle())
-                    .onContinuousHover { phase in
-                        switch phase {
-                        case .active(let location):
-                            let plotMinX = proxy.plotFrame.map { geo[$0].minX } ?? 0
-                            if let date: Date = proxy.value(atX: location.x - plotMinX, as: Date.self) {
-                                hoveredHour = nearestHour(to: date, in: points)
+    private func pinnedModelPanel(_ point: CostChartPoint) -> some View {
+        VStack(alignment: .leading, spacing: 5) {
+            HStack {
+                Text("Models · \(tooltipDate(point.date))")
+                    .font(.system(size: 10, weight: .semibold))
+                Spacer()
+                Text("Top \(min(10, point.models.count)) of \(point.models.count)")
+                    .font(.system(size: 9))
+                    .foregroundStyle(.secondary)
+                Button {
+                    pinnedDate = nil
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                }
+                .buttonStyle(.plain)
+                .foregroundStyle(.secondary)
+            }
+            if point.models.isEmpty {
+                Text("Model detail is unavailable for this historical period.")
+                    .font(.system(size: 9))
+                    .foregroundStyle(.secondary)
+            } else {
+                ScrollView {
+                    VStack(spacing: 4) {
+                        ForEach(point.models.prefix(10)) { model in
+                            HStack {
+                                Text(model.modelName)
+                                    .font(.system(size: 9, weight: .medium))
+                                    .lineLimit(1)
+                                    .truncationMode(.middle)
+                                Spacer()
+                                Text(formatCost(model.costUSD))
+                                    .font(.system(size: 9, design: .rounded).monospacedDigit())
+                                Text(formatTokens(model.totalTokens))
+                                    .font(.system(size: 8, design: .rounded).monospacedDigit())
+                                    .foregroundStyle(.secondary)
                             }
-                        case .ended:
-                            hoveredHour = nil
                         }
                     }
-                if let hour = hoveredHour,
-                   let point = points.first(where: { $0.date == hour }) {
-                    tooltipView(for: point)
-                        .offset(x: tooltipX(for: point.date, proxy: proxy, geo: geo, in: points))
                 }
+                .frame(maxHeight: 112)
             }
         }
+        .padding(8)
+        .background(RoundedRectangle(cornerRadius: 7).fill(Color.primary.opacity(0.06)))
+        .overlay(RoundedRectangle(cornerRadius: 7).stroke(.separator.opacity(0.35), lineWidth: 0.5))
     }
 
-    @ViewBuilder
-    private func tooltipView(for point: HourlyCostPoint) -> some View {
-        VStack(alignment: .leading, spacing: 4) {
-            HStack {
-                Text(formatTooltipHour(point.date))
-                    .font(.system(size: 10, weight: .semibold))
-                Spacer(minLength: 8)
-                Text(formatCost(point.costUSD))
-                    .font(.system(size: 10, weight: .semibold, design: .rounded).monospacedDigit())
-            }
-            Text(formatTokens(point.totalTokens))
+    private func modelRow(_ model: CostSnapshot.ModelBreakdown) -> some View {
+        HStack(alignment: .firstTextBaseline) {
+            Text(model.modelName)
+                .font(.system(size: 9, weight: .medium))
+                .lineLimit(1)
+                .truncationMode(.middle)
+            Spacer(minLength: 8)
+            Text(formatCost(model.costUSD))
                 .font(.system(size: 9, design: .rounded).monospacedDigit())
                 .foregroundStyle(.secondary)
         }
-        .padding(.horizontal, 8)
-        .padding(.vertical, 6)
-        .background(
-            RoundedRectangle(cornerRadius: 6, style: .continuous)
-                .fill(Color.black.opacity(0.85))
-        )
-        .foregroundStyle(.white)
-        .frame(width: tooltipWidth)
-        .allowsHitTesting(false)
     }
 
-    private func tooltipX(for date: Date, proxy: ChartProxy, geo: GeometryProxy, in points: [HourlyCostPoint]) -> CGFloat {
-        guard let xValue = proxy.position(forX: date) else { return 0 }
-        let plotMinX = proxy.plotFrame.map { geo[$0].minX } ?? 0
-        let centerX = plotMinX + xValue
-        let halfWidth = tooltipWidth / 2
-        let clamped = min(max(centerX - halfWidth, 0), max(0, geo.size.width - tooltipWidth))
-        return clamped
-    }
+    // MARK: - Data shaping
 
-    private func nearestHour(to date: Date, in points: [HourlyCostPoint]) -> Date? {
-        guard !points.isEmpty else { return nil }
-        return points.min(by: { abs($0.date.timeIntervalSince(date)) < abs($1.date.timeIntervalSince(date)) })?.date
-    }
-
-    private struct StrideSpec {
-        let calendarComponent: Calendar.Component
-        let count: Int
-        let format: Date.FormatStyle
-    }
-
-    private var stride: StrideSpec {
+    private var availableGranularities: [CostHistoryGranularity] {
         switch timeframe {
-        case .today: return .init(calendarComponent: .hour, count: 4, format: .dateTime.hour())
-        case .week:  return .init(calendarComponent: .day, count: 1, format: .dateTime.day().month(.abbreviated))
-        case .month: return .init(calendarComponent: .day, count: 5, format: .dateTime.day().month(.abbreviated))
-        case .all:   return .init(calendarComponent: .month, count: 1, format: .dateTime.month(.abbreviated).year(.twoDigits))
+        case .today, .yesterday: [.hour]
+        case .week: [.day]
+        case .month, .all: [.day, .week, .month]
         }
     }
 
-    private var filteredDays: [DailyCostPoint] {
-        guard let history = snapshot?.dailyHistory else { return [] }
+    private var chartPoints: [CostChartPoint] {
+        guard let snapshot else { return [] }
+        if timeframe == .today || timeframe == .yesterday {
+            let history = timeframe == .today ? snapshot.todayHourlyHistory : snapshot.yesterdayHourlyHistory
+            return history.map { point in
+                CostChartPoint(
+                    date: point.date,
+                    costUSD: point.costUSD,
+                    totalTokens: point.totalTokens,
+                    models: snapshot.topModels(forHour: point.date, limit: 20)
+                )
+            }
+        }
+
+        let filtered = filteredDailyHistory(snapshot)
+        guard granularity != .day else {
+            return filtered.map { point in
+                CostChartPoint(
+                    date: point.date,
+                    costUSD: point.costUSD,
+                    totalTokens: point.totalTokens,
+                    models: snapshot.topModels(for: point.date, limit: 20)
+                )
+            }
+        }
+        return aggregate(filtered, snapshot: snapshot, by: granularity)
+    }
+
+    private func filteredDailyHistory(_ snapshot: CostSnapshot) -> [DailyCostPoint] {
+        let calendar = Calendar.current
+        let today = calendar.startOfDay(for: Date())
         let cutoff: Date?
         switch timeframe {
-        case .today: cutoff = Calendar.current.startOfDay(for: Date())
-        case .week:  cutoff = Calendar.current.date(byAdding: .day, value: -6, to: Calendar.current.startOfDay(for: Date()))
-        case .month: cutoff = Calendar.current.date(byAdding: .day, value: -29, to: Calendar.current.startOfDay(for: Date()))
-        case .all:   cutoff = nil
+        case .today: cutoff = today
+        case .yesterday: cutoff = calendar.date(byAdding: .day, value: -1, to: today)
+        case .week: cutoff = calendar.date(byAdding: .day, value: -6, to: today)
+        case .month: cutoff = calendar.date(byAdding: .day, value: -29, to: today)
+        case .all: cutoff = nil
         }
-        guard let cutoff else { return history }
-        return history.filter { $0.date >= cutoff }
+        guard let cutoff else { return snapshot.dailyHistory }
+        return snapshot.dailyHistory.filter { $0.date >= cutoff && $0.date <= today }
     }
 
-    private var todayHourlyPoints: [HourlyCostPoint] {
-        guard let snapshot else { return [] }
+    private func aggregate(
+        _ days: [DailyCostPoint],
+        snapshot: CostSnapshot,
+        by grouping: CostHistoryGranularity
+    ) -> [CostChartPoint] {
         let calendar = Calendar.current
-        let start = calendar.startOfDay(for: Date())
-        let currentHour = calendar.component(.hour, from: Date())
-        let byHour = Dictionary(uniqueKeysWithValues: snapshot.todayHourlyHistory.map { ($0.date, $0) })
-        return (0...max(0, currentHour)).compactMap { offset -> HourlyCostPoint? in
-            guard let hour = calendar.date(byAdding: .hour, value: offset, to: start) else { return nil }
-            return byHour[hour] ?? HourlyCostPoint(date: hour, costUSD: 0, totalTokens: 0)
+        var totals: [Date: (cost: Double, tokens: Int, models: [String: (Double, Int)])] = [:]
+        for day in days {
+            let component: Calendar.Component = grouping == .week ? .weekOfYear : .month
+            guard let key = calendar.dateInterval(of: component, for: day.date)?.start else { continue }
+            var value = totals[key] ?? (0, 0, [:])
+            value.cost += day.costUSD
+            value.tokens += day.totalTokens
+            for model in snapshot.topModels(for: day.date, limit: 20) {
+                let current = value.models[model.modelName] ?? (0, 0)
+                value.models[model.modelName] = (current.0 + model.costUSD, current.1 + model.totalTokens)
+            }
+            totals[key] = value
+        }
+        return totals.map { date, value in
+            CostChartPoint(
+                date: date,
+                costUSD: value.cost,
+                totalTokens: value.tokens,
+                models: value.models.map {
+                    CostSnapshot.ModelBreakdown(modelName: $0.key, costUSD: $0.value.0, totalTokens: $0.value.1)
+                }.sorted { $0.costUSD > $1.costUSD }
+            )
+        }.sorted { $0.date < $1.date }
+    }
+
+    // MARK: - Presentation helpers
+
+    private var chartCalendarComponent: Calendar.Component {
+        switch granularity {
+        case .hour: .hour
+        case .day: .day
+        case .week: .weekOfYear
+        case .month: .month
         }
     }
 
-    private var todayDomain: ClosedRange<Date> {
+    private var hourlyDomain: ClosedRange<Date> {
         let calendar = Calendar.current
-        let start = calendar.startOfDay(for: Date())
+        let today = calendar.startOfDay(for: Date())
+        let start = timeframe == .yesterday
+            ? (calendar.date(byAdding: .day, value: -1, to: today) ?? today)
+            : today
         let end = calendar.date(byAdding: .day, value: 1, to: start) ?? start.addingTimeInterval(86_400)
         return start...end
     }
 
-    private func timeframeNote(sampleCount: Int) -> String {
+    private func chartDomain(_ points: [CostChartPoint]) -> ClosedRange<Date> {
+        if granularity == .hour { return hourlyDomain }
+        let start = points.first?.date ?? Date()
+        let fallbackSpan: TimeInterval
+        switch granularity {
+        case .hour: fallbackSpan = 86_400
+        case .day: fallbackSpan = 86_400
+        case .week: fallbackSpan = 7 * 86_400
+        case .month: fallbackSpan = 31 * 86_400
+        }
+        let end = (points.last?.date ?? start).addingTimeInterval(fallbackSpan)
+        return start...max(end, start.addingTimeInterval(fallbackSpan))
+    }
+
+    private struct AxisStride {
+        let component: Calendar.Component
+        let count: Int
+        let format: Date.FormatStyle
+    }
+
+    private var axisStride: AxisStride {
+        switch granularity {
+        case .hour: .init(component: .hour, count: 4, format: .dateTime.hour())
+        case .day:
+            .init(component: .day, count: timeframe == .month ? 5 : 1, format: .dateTime.day().month(.abbreviated))
+        case .week: .init(component: .weekOfYear, count: 1, format: .dateTime.day().month(.abbreviated))
+        case .month: .init(component: .month, count: 1, format: .dateTime.month(.abbreviated).year(.twoDigits))
+        }
+    }
+
+    private func hoveredPoint(in points: [CostChartPoint]) -> CostChartPoint? {
+        hoveredDate.flatMap { date in points.first { $0.date == date } }
+    }
+
+    private func pinnedPoint(in points: [CostChartPoint]) -> CostChartPoint? {
+        pinnedDate.flatMap { date in points.first { $0.date == date } }
+    }
+
+    private func nearestPoint(to date: Date, in points: [CostChartPoint]) -> CostChartPoint? {
+        points.min { abs($0.date.timeIntervalSince(date)) < abs($1.date.timeIntervalSince(date)) }
+    }
+
+    private func pointOpacity(_ point: CostChartPoint) -> Double {
+        guard let selected = pinnedDate ?? hoveredDate else { return 1 }
+        return point.date == selected ? 1 : 0.55
+    }
+
+    private func tooltipX(for date: Date, proxy: ChartProxy, geometry: GeometryProxy) -> CGFloat {
+        guard let x = proxy.position(forX: date) else { return 0 }
+        let plotMinX = proxy.plotFrame.map { geometry[$0].minX } ?? 0
+        return min(max(plotMinX + x - 95, 0), max(0, geometry.size.width - 190))
+    }
+
+    private func clearSelection() {
+        hoveredDate = nil
+        pinnedDate = nil
+    }
+
+    private func timeframeNote(pointCount: Int) -> String {
         switch timeframe {
-        case .today: return sampleCount > 0 ? "\(sampleCount) hours" : "today"
-        case .week:  return "7 days"
-        case .month: return "30 days"
-        case .all:   return sampleCount == 0 ? "" : "\(sampleCount) days"
+        case .today: "today"
+        case .yesterday: "yesterday"
+        case .week: "7 days"
+        case .month: "30 days"
+        case .all: pointCount == 0 ? "" : "\(pointCount) \(granularity.rawValue.lowercased())s"
         }
     }
 
@@ -473,43 +503,23 @@ struct CostHistoryView: View {
         if value < 100 { return String(format: "$%.2f", value) }
         return String(format: "$%.0f", value)
     }
+
     private func formatAxisCost(_ value: Double) -> String {
-        if value < 1 { return String(format: "$%.2f", value) }
-        return String(format: "$%.0f", value)
+        value < 1 ? String(format: "$%.2f", value) : String(format: "$%.0f", value)
     }
+
     private func formatTokens(_ tokens: Int) -> String {
         if tokens < 1_000 { return "\(tokens) tok" }
         if tokens < 1_000_000 { return String(format: "%.1fk tok", Double(tokens) / 1_000) }
         if tokens < 1_000_000_000 { return String(format: "%.2fM tok", Double(tokens) / 1_000_000) }
         return String(format: "%.2fB tok", Double(tokens) / 1_000_000_000)
     }
-    private func formatTooltipDate(_ date: Date) -> String {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "MMM d, yyyy"
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        return formatter.string(from: date)
-    }
-    private func formatTooltipHour(_ date: Date) -> String {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "HH:00"
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        return formatter.string(from: date)
-    }
 
-    private func barColor(for day: DailyCostPoint, average: Double) -> Color {
-        if average > 0, day.costUSD > average * 1.5 {
-            return Color(red: 0.97, green: 0.55, blue: 0.20)
-        }
-        return Color(red: 0.42, green: 0.60, blue: 0.97)
-    }
-
-    private func opacity(for day: DailyCostPoint) -> Double {
-        guard let hovered = hoveredDay else { return 1.0 }
-        return Calendar.current.isDate(day.date, inSameDayAs: hovered) ? 1.0 : 0.55
-    }
-    private func hourlyOpacity(for hour: HourlyCostPoint) -> Double {
-        guard let hovered = hoveredHour else { return 1.0 }
-        return hour.date == hovered ? 1.0 : 0.72
+    private func tooltipDate(_ date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = granularity == .hour ? "MMM d · HH:00" : "MMM d, yyyy"
+        return formatter.string(from: date)
     }
 }
 
@@ -518,17 +528,17 @@ private struct CostTimeframeSelector: View {
     let density: Theme.Density
 
     var body: some View {
-        HStack(spacing: 2) {
+        HStack(spacing: 1) {
             ForEach(CostTimeframe.allCases) { timeframe in
                 Button {
                     selection = timeframe
                 } label: {
                     Text(timeframe.shortLabel)
-                        .font(.system(size: density.segmentedFontSize, weight: .semibold, design: .rounded))
+                        .font(.system(size: max(9, density.segmentedFontSize - 1), weight: .semibold, design: .rounded))
                         .foregroundStyle(selection == timeframe ? .primary : .secondary)
                         .lineLimit(1)
-                        .minimumScaleFactor(0.8)
-                        .padding(.horizontal, 14)
+                        .minimumScaleFactor(0.75)
+                        .padding(.horizontal, 8)
                         .frame(minHeight: 22)
                         .contentShape(Rectangle())
                 }
@@ -538,19 +548,12 @@ private struct CostTimeframeSelector: View {
                     if selection == timeframe {
                         RoundedRectangle(cornerRadius: 6, style: .continuous)
                             .fill(Color.primary.opacity(0.12))
-                            .overlay(
-                                RoundedRectangle(cornerRadius: 6, style: .continuous)
-                                    .stroke(Color.primary.opacity(0.08), lineWidth: 0.5)
-                            )
                     }
                 }
                 .accessibilityLabel(timeframe.label)
             }
         }
         .padding(2)
-        .background(
-            RoundedRectangle(cornerRadius: 7, style: .continuous)
-                .fill(Color.primary.opacity(0.08))
-        )
+        .background(RoundedRectangle(cornerRadius: 7).fill(Color.primary.opacity(0.08)))
     }
 }

--- a/Sources/VibeBarApp/Views/CostSummaryRow.swift
+++ b/Sources/VibeBarApp/Views/CostSummaryRow.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 import VibeBarCore
 
-/// 4-column timeframe summary: Today / 7d / 30d / All. Hidden when no JSONL
+/// 5-column timeframe summary: Today / Yesterday / 7d / 30d / All.
 /// session logs were found (otherwise we'd mislead web-only users into
 /// thinking they spent $0 this month).
 struct CostSummaryRow: View {

--- a/Sources/VibeBarApp/Views/FillTimelineChart.swift
+++ b/Sources/VibeBarApp/Views/FillTimelineChart.swift
@@ -1,253 +1,256 @@
 import SwiftUI
 import VibeBarCore
 
-/// CodexBar-style fill history: a Session | Weekly segmented control, a
-/// strip of thin per-slot bars (light track, accent fill proportional to
-/// used%), date ticks along the bottom, and a caption line that follows the
-/// hovered bar ("Jul 2 at 16:23: 24% used").
-///
-/// Data comes from `QuotaService.fillTimelineByAccountBucket` — hourly
-/// point-in-time samples recorded on every quota refresh. The chart shows
-/// the last 7 days; slots without a sample render as an empty track, which
-/// is also how a fresh install looks until history accumulates.
-struct FillTimelineChart: View {
+/// One independently resettable quota shown in Fill History. The account id
+/// is part of the identity because the Gemini page combines Gemini Web and
+/// AntiGravity, whose bucket ids can otherwise overlap.
+struct FillTimelineSeries: Identifiable {
     let tool: ToolType
-    /// Headline buckets of the account (groupTitle == nil), in display order.
-    let buckets: [QuotaBucket]
     let accountId: String
+    let bucket: QuotaBucket
+
+    var id: String { "\(tool.rawValue):\(accountId):\(bucket.id)" }
+}
+
+/// Reset-cycle utilization history. Each bar is one subscription cycle and
+/// answers the useful question: how much quota was still unused when the
+/// provider refilled it? The final outlined bar is the active cycle.
+struct FillTimelineChart: View {
+    let series: [FillTimelineSeries]
     let mode: DisplayMode
     let density: Theme.Density
     let now: Date
 
     @EnvironmentObject var quotaService: QuotaService
     @State private var selectedBucketId: String?
-    /// Resolved at hover time inside the strip, where the live slot grid is
-    /// in scope — keeps the caption pinned to the exact bar under the cursor
-    /// regardless of the rendered width.
-    @State private var hovered: HoveredSlot?
+    @State private var hoveredIndex: Int?
 
-    private struct HoveredSlot: Equatable {
-        let index: Int
-        let start: Date
-        let point: FillTimelinePoint?
-    }
-
-    private static let spanDays: Double = 7
-    private static let barSpacing: CGFloat = 2
-    private static let minBarWidth: CGFloat = 2.5
-    private static let maxSlots = 84   // 2h slots over 7 days
-    private static let chartHeight: CGFloat = 40
+    private static let barSpacing: CGFloat = 3
+    private static let maxCycles = 12
+    private static let chartHeight: CGFloat = 48
 
     var body: some View {
         let tabs = availableTabs
         if tabs.isEmpty {
             EmptyView()
         } else {
-            let activeBucketId = selectedBucketId.flatMap { id in
-                tabs.contains(where: { $0.bucketId == id }) ? id : nil
-            } ?? tabs.first!.bucketId
+            let activeSeriesId = selectedBucketId.flatMap { id in
+                tabs.contains(where: { $0.id == id }) ? id : nil
+            } ?? tabs[0].id
+            let activeSeries = tabs.first(where: { $0.id == activeSeriesId })!.series
+            let cycles = visibleCycles(series: activeSeries)
             VStack(alignment: .leading, spacing: 4) {
                 HStack(spacing: 8) {
-                    Text("Fill history")
-                        .font(.system(size: max(9, density.subtitleFontSize - 2)))
-                        .foregroundStyle(.tertiary)
+                    VStack(alignment: .leading, spacing: 0) {
+                        Text("Utilization by reset")
+                            .font(.system(size: max(9, density.subtitleFontSize - 2)))
+                            .foregroundStyle(.tertiary)
+                        Text("Each bar is one quota cycle")
+                            .font(.system(size: max(7.5, density.subtitleFontSize - 4)))
+                            .foregroundStyle(.quaternary)
+                    }
                     Spacer(minLength: 4)
                     if tabs.count > 1 {
-                        Picker("", selection: Binding(
-                            get: { activeBucketId },
-                            set: { selectedBucketId = $0; hovered = nil }
-                        )) {
-                            ForEach(tabs, id: \.bucketId) { tab in
-                                Text(tab.label).tag(tab.bucketId)
+                        if tabs.count <= 3 {
+                            Picker("", selection: Binding(
+                                get: { activeSeriesId },
+                                set: { selectedBucketId = $0; hoveredIndex = nil }
+                            )) {
+                                ForEach(tabs, id: \.id) { tab in
+                                    Text(tab.label).tag(tab.id)
+                                }
                             }
+                            .pickerStyle(.segmented)
+                            .controlSize(.mini)
+                            .labelsHidden()
+                            .fixedSize()
+                        } else {
+                            Menu {
+                                ForEach(tabs, id: \.id) { tab in
+                                    Button {
+                                        selectedBucketId = tab.id
+                                        hoveredIndex = nil
+                                    } label: {
+                                        if tab.id == activeSeriesId {
+                                            Label(tab.label, systemImage: "checkmark")
+                                        } else {
+                                            Text(tab.label)
+                                        }
+                                    }
+                                }
+                            } label: {
+                                HStack(spacing: 4) {
+                                    Text(tabs.first(where: { $0.id == activeSeriesId })?.label ?? "Quota")
+                                        .lineLimit(1)
+                                    Image(systemName: "chevron.up.chevron.down")
+                                        .font(.system(size: 8, weight: .semibold))
+                                }
+                                .font(.system(size: max(9, density.subtitleFontSize - 2), weight: .medium))
+                            }
+                            .menuStyle(.borderlessButton)
+                            .fixedSize()
                         }
-                        .pickerStyle(.segmented)
-                        .controlSize(.mini)
-                        .labelsHidden()
-                        .fixedSize()
                     }
                 }
-                strip(bucketId: activeBucketId)
-                caption(bucketId: activeBucketId)
-                axisLabels
+                cycleStrip(cycles, tool: activeSeries.tool)
+                Text(caption(cycles))
+                    .font(.system(size: max(8, density.subtitleFontSize - 3), design: .rounded).monospacedDigit())
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+                axis(cycles)
             }
             .padding(.top, 2)
         }
     }
 
-    // MARK: - Tabs
-
-    private var availableTabs: [(bucketId: String, label: String)] {
-        buckets.map { bucket in
-            (bucketId: bucket.id, label: Self.tabLabel(for: bucket))
+    private var availableTabs: [(id: String, label: String, series: FillTimelineSeries)] {
+        let toolCount = Set(series.map(\.tool)).count
+        return series.map { item in
+            (item.id, Self.tabLabel(for: item, includeTool: toolCount > 1), item)
         }
     }
 
-    private static func tabLabel(for bucket: QuotaBucket) -> String {
-        switch bucket.id {
-        case "five_hour": return "Session"
-        case "weekly":    return "Weekly"
-        case "monthly":   return "Monthly"
-        default:          return bucket.title
+    private static func tabLabel(for series: FillTimelineSeries, includeTool: Bool) -> String {
+        let bucket = series.bucket
+        let window: String
+        switch bucket.rawWindowSeconds {
+        case 18_000: window = "5h"
+        case 604_800: window = "Wk"
+        case 2_592_000: window = "Mo"
+        default: window = bucket.shortLabel
         }
+        let group = bucket.groupTitle?.replacingOccurrences(of: " Models", with: "")
+        let owner = group ?? (includeTool ? series.tool.toolName : nil)
+        return owner.map { "\($0) · \(window)" } ?? window
     }
 
-    // MARK: - Slots
-
-    private struct Slot: Identifiable {
-        let index: Int
-        let start: Date
-        let point: FillTimelinePoint?
-        var id: Int { index }
-    }
-
-    private func slots(bucketId: String, count: Int) -> [Slot] {
-        let key = SubscriptionHistoryKey(accountId: accountId, bucketId: bucketId)
-        let points = quotaService.fillTimelineByAccountBucket[key] ?? []
-        let spanSeconds = Self.spanDays * 86_400
-        let slotSeconds = spanSeconds / Double(count)
-        let windowStart = now.addingTimeInterval(-spanSeconds)
-        var slots: [Slot] = []
-        for index in 0..<count {
-            let start = windowStart.addingTimeInterval(Double(index) * slotSeconds)
-            let end = start.addingTimeInterval(slotSeconds)
-            // Latest sample inside the slot wins — matches the store's
-            // last-in-hour-wins semantics at coarser granularity.
-            let point = points.last { $0.sampledAt >= start && $0.sampledAt < end }
-            slots.append(Slot(index: index, start: start, point: point))
-        }
-        return slots
-    }
-
-    private func slotCount(for width: CGFloat) -> Int {
-        let per = Self.minBarWidth + Self.barSpacing
-        guard width > per else { return 1 }
-        return max(12, min(Self.maxSlots, Int(width / per)))
+    private func visibleCycles(series: FillTimelineSeries) -> [SubscriptionWindowSample] {
+        let key = SubscriptionHistoryKey(accountId: series.accountId, bucketId: series.bucket.id)
+        let samples = quotaService.historyByAccountBucket[key] ?? []
+        return Array(samples.sorted { cycleDate($0) < cycleDate($1) }.suffix(Self.maxCycles))
     }
 
     @ViewBuilder
-    private func strip(bucketId: String) -> some View {
-        GeometryReader { geo in
-            let count = slotCount(for: geo.size.width)
-            let slots = slots(bucketId: bucketId, count: count)
-            let barWidth = max(
-                Self.minBarWidth,
-                (geo.size.width - CGFloat(count - 1) * Self.barSpacing) / CGFloat(count)
-            )
-            HStack(alignment: .bottom, spacing: Self.barSpacing) {
-                ForEach(slots) { slot in
-                    slotBar(slot: slot, width: barWidth, height: geo.size.height)
+    private func cycleStrip(_ cycles: [SubscriptionWindowSample], tool: ToolType) -> some View {
+        if cycles.isEmpty {
+            RoundedRectangle(cornerRadius: 4, style: .continuous)
+                .fill(Theme.barTrack.opacity(0.45))
+                .overlay {
+                    Text("Waiting for the first quota observation")
+                        .font(.system(size: max(8, density.subtitleFontSize - 3)))
+                        .foregroundStyle(.tertiary)
+                }
+                .frame(height: Self.chartHeight)
+        } else {
+            GeometryReader { geo in
+                let count = cycles.count
+                let barWidth = max(5, (geo.size.width - CGFloat(count - 1) * Self.barSpacing) / CGFloat(count))
+                HStack(alignment: .bottom, spacing: Self.barSpacing) {
+                    ForEach(Array(cycles.enumerated()), id: \.offset) { index, cycle in
+                        cycleBar(cycle, tool: tool, isHovered: hoveredIndex == index)
+                            .frame(width: barWidth, height: geo.size.height)
+                    }
+                }
+                .contentShape(Rectangle())
+                .onContinuousHover { phase in
+                    switch phase {
+                    case .active(let location):
+                        hoveredIndex = min(max(0, Int(location.x / (barWidth + Self.barSpacing))), count - 1)
+                    case .ended:
+                        hoveredIndex = nil
+                    }
                 }
             }
-            .contentShape(Rectangle())
-            .onContinuousHover { phase in
-                switch phase {
-                case .active(let location):
-                    let index = min(max(0, Int(location.x / (barWidth + Self.barSpacing))), count - 1)
-                    let slot = slots[index]
-                    hovered = HoveredSlot(index: index, start: slot.start, point: slot.point)
-                case .ended:
-                    hovered = nil
-                }
+            .frame(height: Self.chartHeight)
+        }
+    }
+
+    private func cycleBar(_ cycle: SubscriptionWindowSample, tool: ToolType, isHovered: Bool) -> some View {
+        let percent = displayedPercent(cycle)
+        return ZStack(alignment: .bottom) {
+            RoundedRectangle(cornerRadius: 3, style: .continuous)
+                .fill(Theme.barTrack.opacity(isHovered ? 0.95 : 0.62))
+            RoundedRectangle(cornerRadius: 3, style: .continuous)
+                .fill(Self.accent(for: tool).opacity(isHovered ? 1 : 0.86))
+                .frame(maxHeight: .infinity)
+                .scaleEffect(x: 1, y: max(0.04, percent / 100), anchor: .bottom)
+        }
+        .overlay {
+            if !cycle.isCompleted {
+                RoundedRectangle(cornerRadius: 3, style: .continuous)
+                    .stroke(Self.accent(for: tool).opacity(0.9), style: StrokeStyle(lineWidth: 1, dash: [3, 2]))
             }
         }
-        .frame(height: Self.chartHeight)
+    }
+
+    private func caption(_ cycles: [SubscriptionWindowSample]) -> String {
+        guard !cycles.isEmpty else {
+            return "A cycle is recorded when the quota refills"
+        }
+        let index = hoveredIndex.map { min(max(0, $0), cycles.count - 1) } ?? cycles.count - 1
+        let cycle = cycles[index]
+        let used = Int(cycle.peakUsedPercent.rounded())
+        let left = Int(cycle.remainingPercentAtReset.rounded())
+        if let completedAt = cycle.completedAt {
+            return "\(Self.timestampFormatter.string(from: completedAt)) reset · \(used)% used · \(left)% left"
+        }
+        return "Current cycle · \(used)% used so far · \(left)% left"
     }
 
     @ViewBuilder
-    private func slotBar(slot: Slot, width: CGFloat, height: CGFloat) -> some View {
-        let isHovered = hovered?.index == slot.index
-        ZStack(alignment: .bottom) {
-            RoundedRectangle(cornerRadius: width / 2, style: .continuous)
-                .fill(Theme.barTrack)
-                .opacity(isHovered ? 0.9 : 0.55)
-            if let point = slot.point {
-                let percent = displayPercent(point.usedPercent)
-                RoundedRectangle(cornerRadius: width / 2, style: .continuous)
-                    .fill(Self.accent(for: tool))
-                    .opacity(isHovered ? 1.0 : 0.85)
-                    .frame(height: max(2, height * CGFloat(percent / 100)))
+    private func axis(_ cycles: [SubscriptionWindowSample]) -> some View {
+        if !cycles.isEmpty {
+            HStack {
+                Text(axisLabel(cycles[0]))
+                Spacer()
+                if cycles.count > 2 {
+                    Text(axisLabel(cycles[cycles.count / 2]))
+                    Spacer()
+                }
+                Text(cycles.last?.isCompleted == false ? "Current" : axisLabel(cycles[cycles.count - 1]))
             }
-        }
-        .frame(width: width, height: height)
-    }
-
-    // MARK: - Caption & axis
-
-    private func caption(bucketId: String) -> some View {
-        Text(captionString(bucketId: bucketId))
-            .font(.system(size: max(8, density.subtitleFontSize - 3), design: .rounded).monospacedDigit())
-            .foregroundStyle(.secondary)
-            .lineLimit(1)
-            .truncationMode(.tail)
-    }
-
-    private func captionString(bucketId: String) -> String {
-        if let hovered {
-            if let point = hovered.point {
-                return Self.captionText(point: point, mode: mode)
-            }
-            return Self.dayFormatter.string(from: hovered.start) + ": no data"
-        }
-        let key = SubscriptionHistoryKey(accountId: accountId, bucketId: bucketId)
-        let points = quotaService.fillTimelineByAccountBucket[key] ?? []
-        if let latest = points.max(by: { $0.sampledAt < $1.sampledAt }) {
-            return Self.captionText(point: latest, mode: mode)
-        }
-        return "No samples yet — fills in as Vibe Bar refreshes"
-    }
-
-    private var axisLabels: some View {
-        HStack {
-            ForEach(0..<4, id: \.self) { index in
-                if index > 0 { Spacer(minLength: 4) }
-                Text(Self.dayFormatter.string(
-                    from: now.addingTimeInterval((-Self.spanDays + Double(index) * Self.spanDays / 3) * 86_400)
-                ))
-                .font(.system(size: max(7.5, density.subtitleFontSize - 4), design: .rounded))
-                .foregroundStyle(.tertiary)
-            }
+            .font(.system(size: max(7.5, density.subtitleFontSize - 4), design: .rounded))
+            .foregroundStyle(.tertiary)
         }
     }
 
-    private func displayPercent(_ used: Double) -> Double {
+    private func displayedPercent(_ cycle: SubscriptionWindowSample) -> Double {
         switch mode {
-        case .used:      return used
-        case .remaining: return max(0, 100 - used)
+        case .used: cycle.peakUsedPercent
+        case .remaining: cycle.remainingPercentAtReset
         }
     }
 
-    private static func captionText(point: FillTimelinePoint, mode: DisplayMode) -> String {
-        let stamp = timestampFormatter.string(from: point.sampledAt)
-        switch mode {
-        case .used:
-            return "\(stamp): \(Int(point.usedPercent.rounded()))% used"
-        case .remaining:
-            return "\(stamp): \(Int((100 - point.usedPercent).rounded()))% left"
-        }
+    private func cycleDate(_ cycle: SubscriptionWindowSample) -> Date {
+        cycle.completedAt ?? cycle.lastSeenAt
+    }
+
+    private func axisLabel(_ cycle: SubscriptionWindowSample) -> String {
+        Self.dayFormatter.string(from: cycleDate(cycle))
     }
 
     private static func accent(for tool: ToolType) -> Color {
         switch tool {
-        case .codex:  return Color(red: 0.30, green: 0.78, blue: 0.74)
-        case .claude: return Color(red: 0.93, green: 0.40, blue: 0.40)
-        case .gemini: return Color(red: 0.34, green: 0.62, blue: 0.96)
-        case .grok:   return Color(red: 0.45, green: 0.45, blue: 0.50)
-        default:      return Color(red: 0.45, green: 0.55, blue: 0.65)
+        case .codex: Color(red: 0.30, green: 0.78, blue: 0.74)
+        case .claude: Color(red: 0.93, green: 0.40, blue: 0.40)
+        case .gemini, .antigravity: Color(red: 0.34, green: 0.62, blue: 0.96)
+        case .grok: Color(red: 0.45, green: 0.45, blue: 0.50)
+        default: Color(red: 0.45, green: 0.55, blue: 0.65)
         }
     }
 
     private static let timestampFormatter: DateFormatter = {
-        let f = DateFormatter()
-        f.locale = Locale(identifier: "en_US_POSIX")
-        f.dateFormat = "MMM d 'at' HH:mm"
-        return f
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "MMM d 'at' HH:mm"
+        return formatter
     }()
 
     private static let dayFormatter: DateFormatter = {
-        let f = DateFormatter()
-        f.locale = Locale(identifier: "en_US_POSIX")
-        f.dateFormat = "MMM d"
-        return f
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "MMM d"
+        return formatter
     }()
 }

--- a/Sources/VibeBarApp/Views/MiniQuotaWindowView.swift
+++ b/Sources/VibeBarApp/Views/MiniQuotaWindowView.swift
@@ -269,9 +269,9 @@ private struct MiniBranchCell: Identifiable {
         switch bucket.id {
         case "gpt_5_3_codex_spark_five_hour": return "5h"
         case "gpt_5_3_codex_spark_weekly": return "wk"
-        case "gemini_five_hour", "claude_gpt_five_hour" where tool == .antigravity:
+        case let id where tool == .antigravity && ["gemini_five_hour", "claude_gpt_five_hour"].contains(id):
             return "5h"
-        case "gemini_weekly", "claude_gpt_weekly" where tool == .antigravity:
+        case let id where tool == .antigravity && ["gemini_weekly", "claude_gpt_weekly"].contains(id):
             return "wk"
         case "weekly_sonnet": return "wk"
         case "weekly_design": return "wk"
@@ -315,9 +315,9 @@ private struct MiniBranchCell: Identifiable {
             return "claude.fable"
         case "weekly_oauth_apps":
             return "claude.oauth"
-        case "gemini_five_hour", "gemini_weekly" where tool == .antigravity:
+        case let id where tool == .antigravity && ["gemini_five_hour", "gemini_weekly"].contains(id):
             return "antigravity.gemini-models"
-        case "claude_gpt_five_hour", "claude_gpt_weekly" where tool == .antigravity:
+        case let id where tool == .antigravity && ["claude_gpt_five_hour", "claude_gpt_weekly"].contains(id):
             return "antigravity.claude-gpt-models"
         case let id where tool == .gemini && id.contains("flash-lite"):
             return "gemini.flash-lite"
@@ -359,9 +359,9 @@ private struct MiniBranchCell: Identifiable {
             return "Fable"
         case "weekly_oauth_apps":
             return "OAuth"
-        case "gemini_five_hour", "gemini_weekly" where tool == .antigravity:
+        case let id where tool == .antigravity && ["gemini_five_hour", "gemini_weekly"].contains(id):
             return "Gemini"
-        case "claude_gpt_five_hour", "claude_gpt_weekly" where tool == .antigravity:
+        case let id where tool == .antigravity && ["claude_gpt_five_hour", "claude_gpt_weekly"].contains(id):
             return "C+G"
         case let id where tool == .gemini && id.contains("flash-lite"):
             return "Lite"

--- a/Sources/VibeBarApp/Views/MiscProvidersPage.swift
+++ b/Sources/VibeBarApp/Views/MiscProvidersPage.swift
@@ -12,7 +12,7 @@ struct MiscProvidersPage: View {
     @EnvironmentObject var settingsStore: SettingsStore
 
     var body: some View {
-        ColumnMasonryLayout(columns: 3, spacing: density.interSectionSpacing, anchoredItems: 0) {
+        ColumnMasonryLayout(columns: 3, spacing: density.interSectionSpacing) {
             ForEach(providerGroups) { group in
                 if group.instances.count == 1, let instance = group.instances.first {
                     MiscProviderCard(instance: instance, density: density)

--- a/Sources/VibeBarApp/Views/PopoverRoot.swift
+++ b/Sources/VibeBarApp/Views/PopoverRoot.swift
@@ -230,9 +230,9 @@ struct PopoverRoot: View {
         let key = autoRefreshKey
         guard !autoRefreshedPageKeys.contains(key) else { return }
         let accounts = visibleAccounts
+        let refreshAge = TimeInterval(max(60, settingsStore.settings.refreshIntervalSeconds))
         let missing = accounts.filter { account in
-            quotaService.cachedQuota(for: account.id) == nil
-                && quotaService.lastErrorByAccount[account.id] == nil
+            quotaService.needsRefresh(accountId: account.id, maxAge: refreshAge)
                 && !quotaService.inFlightAccountIds.contains(account.id)
         }
         guard !missing.isEmpty else { return }
@@ -408,14 +408,11 @@ private struct OverviewSwitchIcon: View {
 
 /// Overview popover content, top-to-bottom:
 ///   1. `CombinedTotalsRow` — cost+token grid plus live service status.
-///   2. A `ColumnMasonryLayout` covering everything else. The first two
-///      subviews — OpenAI Quota and Claude Quota — are anchored to the top
-///      of columns 0 and 1 respectively (AQ wants the quota cards locked in
-///      place). Every subsequent card flows into whichever column is
-///      currently shorter, so the empty space below the shorter quota card
-///      gets filled by Cost / Model Ranking / heatmap cards instead of left
-///      blank. The cost and summary cards therefore drift between columns
-///      based on how the heights work out — this is intentional.
+///   2. A live-measured `ColumnMasonryLayout` covering everything else. It
+///      globally balances the four quota cards first, then places Cost cards
+///      from those seeded column heights, and finally fills the shorter side
+///      with supporting analytics. Quota rows can grow or shrink after every
+///      refresh without leaving a permanently sparse column.
 private struct OverviewWaterfall: View {
     let density: Theme.Density
 
@@ -427,24 +424,42 @@ private struct OverviewWaterfall: View {
         let combinedHeatmap = CostSnapshotAggregator.combinedHeatmap(snapshots)
         let combinedModels = CostSnapshotAggregator.combinedModelBreakdowns(snapshots)
         let hasCostData = snapshots.contains { $0.jsonlFilesFound > 0 }
+        let combinedCostSnapshot = CostSnapshotAggregator.combinedSnapshot(
+            tool: .codex,
+            snapshots: snapshots
+        )
 
         VStack(alignment: .leading, spacing: density.interSectionSpacing) {
             CombinedTotalsRow(density: density)
             ColumnMasonryLayout(
                 columns: 2,
-                spacing: density.interSectionSpacing,
-                anchoredItems: 2
+                spacing: density.interSectionSpacing
             ) {
                 ProviderQuotaCard(tool: .codex, density: density, compact: false)
+                    .overviewMasonryItem(id: "quota-codex", phase: .quota)
                 ProviderQuotaCard(tool: .claude, density: density, compact: false)
+                    .overviewMasonryItem(id: "quota-claude", phase: .quota)
                 // Gemini Web and AntiGravity both roll up to the
                 // Gemini product, so the Overview surface shows them
                 // as a single L2 "Gemini" card with two L3 sub-sections
                 // (`GeminiCombinedCard`). Grok stays on its own card.
                 GeminiCombinedCard(density: density)
+                    .overviewMasonryItem(id: "quota-gemini", phase: .quota)
                 ProviderQuotaCard(tool: .grok, density: density, compact: false)
+                    .overviewMasonryItem(id: "quota-grok", phase: .quota)
+                if hasCostData {
+                    CostHistoryView(
+                        tool: .codex,
+                        snapshot: combinedCostSnapshot,
+                        density: density,
+                        chartHeight: 190,
+                        titleOverride: "All Providers Cost History"
+                    )
+                    .overviewMasonryItem(id: "cost-all-providers", phase: .cost)
+                }
                 ForEach(overviewCostProviders, id: \.self) { tool in
                     OverviewCostCard(tool: tool, density: density)
+                        .overviewMasonryItem(id: "cost-\(tool.rawValue)", phase: .cost)
                 }
                 // Google AI (Gemini + AntiGravity) cost, surfaced as the
                 // single "Gemini" platform aligned with the other three.
@@ -461,22 +476,26 @@ private struct OverviewWaterfall: View {
                     toolNameOverride: "Gemini",
                     heatmapTitleOverride: "When you use Gemini"
                 )
+                .overviewMasonryItem(id: "cost-gemini", phase: .cost)
                 if hasCostData {
                     ModelRankingList(
                         breakdowns: combinedModels,
                         density: density,
                         subtitle: "All providers · all time"
                     )
+                    .overviewMasonryItem(id: "analytics-model-ranking", phase: .auxiliary)
                     YearlyContributionHeatmapView(
                         history: combinedHistory,
                         density: density,
                         toolName: "All providers"
                     )
+                    .overviewMasonryItem(id: "analytics-year", phase: .auxiliary)
                     UsageActivityView(
                         heatmap: combinedHeatmap,
                         density: density,
                         titleOverride: "When you use everything"
                     )
+                    .overviewMasonryItem(id: "analytics-activity", phase: .auxiliary)
                 }
             }
         }
@@ -687,20 +706,27 @@ private struct GeminiTabPage: View {
         let geminiAccounts = environment.accountStore
             .accounts(for: .gemini)
             .sorted { $0.id < $1.id }
+        let antigravityAccount = environment.account(for: .antigravity)
+        let antigravityHistorySeries: [FillTimelineSeries] = antigravityAccount.map { account in
+            (quotaService.cachedQuota(for: account.id)?.buckets ?? []).map {
+                FillTimelineSeries(tool: .antigravity, accountId: account.id, bucket: $0)
+            }
+        } ?? []
 
         HStack(alignment: .top, spacing: density.interSectionSpacing) {
             VStack(alignment: .leading, spacing: density.interSectionSpacing) {
                 GeminiCombinedCard(density: density)
-                if let geminiAccount = geminiAccounts.first {
-                    TimelineView(.periodic(from: .now, by: 30)) { context in
-                        SubscriptionUtilizationView(
-                            tool: .gemini,
-                            buckets: quotaService.cachedQuota(for: geminiAccount.id)?.buckets ?? [],
-                            mode: settingsStore.displayMode,
-                            density: density,
-                            now: context.date
-                        )
-                    }
+                TimelineView(.periodic(from: .now, by: 30)) { context in
+                    SubscriptionUtilizationView(
+                        tool: .gemini,
+                        buckets: geminiAccounts.first.flatMap {
+                            quotaService.cachedQuota(for: $0.id)?.buckets
+                        } ?? [],
+                        mode: settingsStore.displayMode,
+                        density: density,
+                        now: context.date,
+                        additionalHistorySeries: antigravityHistorySeries
+                    )
                 }
                 ServiceStatusCard(tools: [.gemini])
             }

--- a/Sources/VibeBarApp/Views/ServiceStatusCard.swift
+++ b/Sources/VibeBarApp/Views/ServiceStatusCard.swift
@@ -126,9 +126,7 @@ private struct ServiceStatusRow: View {
             ComponentGroupBlock(
                 title: "Components",
                 components: snapshot.components,
-                defaultExpanded: true,
-                incidentDays: snapshot.incidentDays,
-                incidentAdjustedUptime: snapshot.incidentAdjustedUptimePercent
+                defaultExpanded: true
             )
         } else {
             VStack(alignment: .leading, spacing: 12) {

--- a/Sources/VibeBarApp/Views/SubscriptionUtilizationView.swift
+++ b/Sources/VibeBarApp/Views/SubscriptionUtilizationView.swift
@@ -12,6 +12,7 @@ struct SubscriptionUtilizationView: View {
     let mode: DisplayMode
     let density: Theme.Density
     let now: Date
+    var additionalHistorySeries: [FillTimelineSeries] = []
 
     @EnvironmentObject var environment: AppEnvironment
     @EnvironmentObject var quotaService: QuotaService
@@ -29,20 +30,18 @@ struct SubscriptionUtilizationView: View {
                     environment.refresh(tool)
                 }
             }
-            if relevantBuckets.isEmpty {
+            if paceBuckets.isEmpty && historySeries.isEmpty {
                 Text("No utilization data — try refreshing.")
                     .font(.system(size: density.subtitleFontSize))
                     .foregroundStyle(.tertiary)
                     .padding(.vertical, 8)
             } else {
-                ForEach(relevantBuckets) { bucket in
+                ForEach(paceBuckets) { bucket in
                     row(for: bucket)
                 }
-                if let accountId = environment.account(for: tool)?.id {
+                if !historySeries.isEmpty {
                     FillTimelineChart(
-                        tool: tool,
-                        buckets: relevantBuckets,
-                        accountId: accountId,
+                        series: historySeries,
                         mode: mode,
                         density: density,
                         now: now
@@ -62,8 +61,20 @@ struct SubscriptionUtilizationView: View {
     }
 
     /// Pick the headline buckets only (no per-model groups).
-    private var relevantBuckets: [QuotaBucket] {
+    private var paceBuckets: [QuotaBucket] {
         buckets.filter { $0.groupTitle == nil }
+    }
+
+    /// Every bucket participates in reset-cycle history, including per-model
+    /// dimensions and additional accounts combined into the same product page.
+    private var historySeries: [FillTimelineSeries] {
+        let primary: [FillTimelineSeries]
+        if let accountId = environment.account(for: tool)?.id {
+            primary = buckets.map { FillTimelineSeries(tool: tool, accountId: accountId, bucket: $0) }
+        } else {
+            primary = []
+        }
+        return primary + additionalHistorySeries
     }
 
     private var isRefreshing: Bool {

--- a/Sources/VibeBarCore/Adapters/AlibabaTokenPlanQuotaAdapter.swift
+++ b/Sources/VibeBarCore/Adapters/AlibabaTokenPlanQuotaAdapter.swift
@@ -662,14 +662,15 @@ enum AlibabaTokenPlanResponseParser {
         let nextFlush = parseDate(group["NextCycleFlushTime"] ?? group["nextCycleFlushTime"])
 
         let specLabel = displaySpecLabel(specType)
+        let groupLabel = productCode.contains("teams") ? "Team · \(specLabel)" : specLabel
         return QuotaBucket(
             id: "alibabaTokenPlan.\(productCode).\(specType)",
-            title: "\(specLabel) Credits",
-            shortLabel: "\(specLabel) credits",
+            title: "Monthly",
+            shortLabel: "Month",
             usedPercent: percent,
             resetAt: nextFlush,
-            rawWindowSeconds: nil,
-            groupTitle: specLabel
+            rawWindowSeconds: 30 * 86_400,
+            groupTitle: groupLabel
         )
     }
 
@@ -682,11 +683,12 @@ enum AlibabaTokenPlanResponseParser {
         let reset = parseDate(summary["NearestExpireDate"] ?? summary["nearestExpireDate"])
         return QuotaBucket(
             id: "alibabaTokenPlan.\(productCode).summary",
-            title: "Token Plan Credits",
-            shortLabel: "Credits",
+            title: "Monthly",
+            shortLabel: "Month",
             usedPercent: percent,
             resetAt: reset,
-            rawWindowSeconds: nil
+            rawWindowSeconds: 30 * 86_400,
+            groupTitle: productCode.contains("teams") ? "Team" : "Token Plan"
         )
     }
 
@@ -712,7 +714,14 @@ enum AlibabaTokenPlanResponseParser {
 
     private static func bucketGroupName(for productCode: String, suffix: String?) -> String? {
         guard let suffix, !suffix.isEmpty else { return nil }
-        return "\(familyDisplayName(for: productCode)) · \(suffix)"
+        let family = familyDisplayName(for: productCode)
+        let normalizedSuffix: String
+        if productCode.contains("teams"), suffix.hasPrefix("Team · ") {
+            normalizedSuffix = String(suffix.dropFirst("Team · ".count))
+        } else {
+            normalizedSuffix = suffix
+        }
+        return "\(family) · \(normalizedSuffix)"
     }
 
     // MARK: - Tree helpers

--- a/Sources/VibeBarCore/Adapters/GeminiQuotaAdapter.swift
+++ b/Sources/VibeBarCore/Adapters/GeminiQuotaAdapter.swift
@@ -33,7 +33,23 @@ public struct GeminiQuotaAdapter: QuotaAdapter {
             throw QuotaError.noCredential
         }
         let fetcher = GeminiWebQuotaFetcher(session: session, now: now)
-        let snapshot = try await fetcher.fetch(cookieHeader: header)
+        let snapshot: GeminiResponseParser.Snapshot
+        do {
+            snapshot = try await fetcher.fetch(cookieHeader: header)
+        } catch let initialError as QuotaError {
+            // Google rotates the browser session more often than Vibe Bar's
+            // persisted Keychain copy. Refresh it directly from an installed
+            // browser once before surfacing a login error; this keeps the
+            // source purely gemini.google.com and never falls back to CLI
+            // OAuth quota.
+            guard let imported = GeminiBrowserCookieImporter.importFromBrowsers(
+                allowKeychainPrompt: false
+            ), imported.header != header else {
+                throw initialError
+            }
+            snapshot = try await fetcher.fetch(cookieHeader: imported.header)
+            try? GeminiWebCookieStore.writeCookieHeader(imported.header, source: .browser)
+        }
         return AccountQuota(
             accountId: account.id,
             tool: .gemini,
@@ -44,7 +60,6 @@ public struct GeminiQuotaAdapter: QuotaAdapter {
             error: nil
         )
     }
-
 }
 
 // MARK: - Response parsing

--- a/Sources/VibeBarCore/Adapters/GeminiWebResponseParser.swift
+++ b/Sources/VibeBarCore/Adapters/GeminiWebResponseParser.swift
@@ -124,6 +124,13 @@ enum GeminiWebResponseParser {
             let bucketType = intValue(entry[2])
             let resetAt = extractResetDate(from: entry[3])
             let descriptor = bucketDescriptor(forType: bucketType)
+            // The live Ultra payload currently includes an internal type-4
+            // sentinel with no reset timestamp. It is not rendered on the
+            // Gemini Usage page and is not a resettable user quota, so don't
+            // turn it into a misleading "Bucket 4" meter. Future unknown
+            // buckets with a real reset remain visible through the generic
+            // fallback below.
+            if descriptor.windowSeconds == nil, resetAt == nil { continue }
             let usedPercent = min(100, max(0, usedFraction * 100))
             buckets.append(QuotaBucket(
                 id: descriptor.id,
@@ -142,15 +149,13 @@ enum GeminiWebResponseParser {
     }
 
     /// Map Google's `planTier` integer to the user-visible plan label.
-    /// Confirmed `2 = "Pro"` (Google AI Pro). `1 = Free` / `3 = Ultra`
-    /// are inferred from Google's published tier names and the
-    /// "20x more usage than AI Pro" upgrade banner — adjust when a
-    /// real Ultra or Free account becomes available for verification.
+    /// `2 = Pro`; the current live Ultra response uses tier id `6`.
+    /// Older captures used `3` for Ultra, so retain that alias.
     static func planLabel(forTierId id: Int) -> String? {
         switch id {
         case 1: return "Free"
         case 2: return "Pro"
-        case 3: return "Ultra"
+        case 3, 6: return "Ultra"
         default: return nil
         }
     }

--- a/Sources/VibeBarCore/Adapters/MiniMaxQuotaAdapter.swift
+++ b/Sources/VibeBarCore/Adapters/MiniMaxQuotaAdapter.swift
@@ -489,6 +489,13 @@ enum MiniMaxResponseParser {
     }
 
     private static func serviceTitle(displayName: String?, modelName: String?) -> String? {
+        // TokenPlanMax calls its primary rolling quota row `general`.
+        // That is a window name rather than a user-facing model name, so
+        // align it with the other providers' duration-based quota labels.
+        if modelName?.trimmingCharacters(in: .whitespacesAndNewlines)
+            .localizedCaseInsensitiveCompare("general") == .orderedSame {
+            return "5 Hours"
+        }
         if let displayTitle = englishServiceTitle(fromDisplayName: displayName, modelName: modelName) {
             return displayTitle
         }

--- a/Sources/VibeBarCore/Adapters/TencentTokenPlanQuotaAdapter.swift
+++ b/Sources/VibeBarCore/Adapters/TencentTokenPlanQuotaAdapter.swift
@@ -346,11 +346,11 @@ enum TencentTokenPlanResponseParser {
         let displayLabel = humanPlanName(plan)
         return QuotaBucket(
             id: "tencentTokenPlan.\(variant.rawValue).\(stableSuffix)",
-            title: "Credits",
-            shortLabel: "Credits",
+            title: "Monthly",
+            shortLabel: "Month",
             usedPercent: percent,
             resetAt: resetAt,
-            rawWindowSeconds: nil,
+            rawWindowSeconds: 30 * 86_400,
             groupTitle: displayLabel
         )
     }

--- a/Sources/VibeBarCore/Models/CostSnapshot.swift
+++ b/Sources/VibeBarCore/Models/CostSnapshot.swift
@@ -33,6 +33,9 @@ public struct CostSnapshot: Sendable, Equatable, Codable {
     /// derived from live JSONL events so the Today chart can show hourly shape
     /// instead of rendering one whole-day bar.
     public let todayHourlyHistory: [HourlyCostPoint]
+    /// Per-hour series for the previous local day. Kept separately so the
+    /// Yesterday range can retain the same line-chart detail as Today.
+    public let yesterdayHourlyHistory: [HourlyCostPoint]
     /// 7×24 cells: weekday (1-7, Sunday=1) × hour (0-23) → token total.
     public let heatmap: UsageHeatmap
     /// Top models in the all-time window.
@@ -44,6 +47,9 @@ public struct CostSnapshot: Sendable, Equatable, Codable {
     /// Not persisted to disk: when CostHistoryStore preserves a day from a
     /// rotated session, the model split is lost — but the totals are kept.
     public let dailyModelBreakdown: [Date: [ModelBreakdown]]
+    /// Per-hour model breakdown for Today and Yesterday. This powers the
+    /// hourly hover detail without inflating the long-term history file.
+    public let hourlyModelBreakdown: [Date: [ModelBreakdown]]
     public let jsonlFilesFound: Int
     public let updatedAt: Date
 
@@ -76,10 +82,12 @@ public struct CostSnapshot: Sendable, Equatable, Codable {
         allTimeRequests: Int = 0,
         dailyHistory: [DailyCostPoint],
         todayHourlyHistory: [HourlyCostPoint] = [],
+        yesterdayHourlyHistory: [HourlyCostPoint] = [],
         heatmap: UsageHeatmap,
         modelBreakdowns: [ModelBreakdown],
         last7DaysModelBreakdowns: [ModelBreakdown] = [],
         dailyModelBreakdown: [Date: [ModelBreakdown]] = [:],
+        hourlyModelBreakdown: [Date: [ModelBreakdown]] = [:],
         jsonlFilesFound: Int,
         updatedAt: Date
     ) {
@@ -98,10 +106,12 @@ public struct CostSnapshot: Sendable, Equatable, Codable {
         self.allTimeRequests = allTimeRequests
         self.dailyHistory = dailyHistory
         self.todayHourlyHistory = todayHourlyHistory
+        self.yesterdayHourlyHistory = yesterdayHourlyHistory
         self.heatmap = heatmap
         self.modelBreakdowns = modelBreakdowns
         self.last7DaysModelBreakdowns = last7DaysModelBreakdowns
         self.dailyModelBreakdown = dailyModelBreakdown
+        self.hourlyModelBreakdown = hourlyModelBreakdown
         self.jsonlFilesFound = jsonlFilesFound
         self.updatedAt = updatedAt
     }
@@ -112,8 +122,8 @@ public struct CostSnapshot: Sendable, Equatable, Codable {
             todayCostUSD: 0, last7DaysCostUSD: 0, last30DaysCostUSD: 0, allTimeCostUSD: 0,
             todayTokens: 0, last7DaysTokens: 0, last30DaysTokens: 0, allTimeTokens: 0,
             todayRequests: 0, last7DaysRequests: 0, last30DaysRequests: 0, allTimeRequests: 0,
-            dailyHistory: [], todayHourlyHistory: [], heatmap: .empty(tool: tool),
-            modelBreakdowns: [], last7DaysModelBreakdowns: [], dailyModelBreakdown: [:], jsonlFilesFound: 0, updatedAt: now
+            dailyHistory: [], todayHourlyHistory: [], yesterdayHourlyHistory: [], heatmap: .empty(tool: tool),
+            modelBreakdowns: [], last7DaysModelBreakdowns: [], dailyModelBreakdown: [:], hourlyModelBreakdown: [:], jsonlFilesFound: 0, updatedAt: now
         )
     }
 
@@ -153,6 +163,10 @@ public struct CostSnapshot: Sendable, Equatable, Codable {
         let hourlyToday = todayHourlyHistory.filter {
             calendar.isDate($0.date, inSameDayAs: now)
         }
+        let yesterday = calendar.date(byAdding: .day, value: -1, to: today) ?? today
+        let hourlyYesterday = yesterdayHourlyHistory.filter {
+            calendar.isDate($0.date, inSameDayAs: yesterday)
+        }
 
         // Request counts have no daily history — they pass through
         // verbatim except for the today bucket, which we zero out
@@ -175,10 +189,12 @@ public struct CostSnapshot: Sendable, Equatable, Codable {
             allTimeRequests: allTimeRequests,
             dailyHistory: dailyHistory,
             todayHourlyHistory: hourlyToday,
+            yesterdayHourlyHistory: hourlyYesterday,
             heatmap: heatmap,
             modelBreakdowns: modelBreakdowns,
             last7DaysModelBreakdowns: last7DaysModelBreakdowns,
             dailyModelBreakdown: dailyModelBreakdown,
+            hourlyModelBreakdown: hourlyModelBreakdown,
             jsonlFilesFound: jsonlFilesFound,
             updatedAt: updatedAt
         )
@@ -192,6 +208,12 @@ public struct CostSnapshot: Sendable, Equatable, Codable {
         return Array((dailyModelBreakdown[key] ?? []).prefix(limit))
     }
 
+    public func topModels(forHour hour: Date, limit: Int = 3, calendar: Calendar = .current) -> [ModelBreakdown] {
+        let components = calendar.dateComponents([.year, .month, .day, .hour], from: hour)
+        guard let key = calendar.date(from: components) else { return [] }
+        return Array((hourlyModelBreakdown[key] ?? []).prefix(limit))
+    }
+
     // MARK: - Codable
     //
     // The default synthesis can't encode `[Date: [ModelBreakdown]]` as JSON
@@ -203,7 +225,8 @@ public struct CostSnapshot: Sendable, Equatable, Codable {
         case tool, todayCostUSD, last7DaysCostUSD, last30DaysCostUSD, allTimeCostUSD
         case todayTokens, last7DaysTokens, last30DaysTokens, allTimeTokens
         case todayRequests, last7DaysRequests, last30DaysRequests, allTimeRequests
-        case dailyHistory, todayHourlyHistory, heatmap, modelBreakdowns, last7DaysModelBreakdowns, dailyModelBreakdown
+        case dailyHistory, todayHourlyHistory, yesterdayHourlyHistory, heatmap, modelBreakdowns, last7DaysModelBreakdowns
+        case dailyModelBreakdown, hourlyModelBreakdown
         case jsonlFilesFound, updatedAt
     }
 
@@ -233,6 +256,7 @@ public struct CostSnapshot: Sendable, Equatable, Codable {
         self.allTimeRequests = try c.decodeIfPresent(Int.self, forKey: .allTimeRequests) ?? 0
         self.dailyHistory = try c.decode([DailyCostPoint].self, forKey: .dailyHistory)
         self.todayHourlyHistory = try c.decodeIfPresent([HourlyCostPoint].self, forKey: .todayHourlyHistory) ?? []
+        self.yesterdayHourlyHistory = try c.decodeIfPresent([HourlyCostPoint].self, forKey: .yesterdayHourlyHistory) ?? []
         self.heatmap = try c.decode(UsageHeatmap.self, forKey: .heatmap)
         self.modelBreakdowns = try c.decode([ModelBreakdown].self, forKey: .modelBreakdowns)
         self.last7DaysModelBreakdowns = try c.decodeIfPresent(
@@ -250,6 +274,15 @@ public struct CostSnapshot: Sendable, Equatable, Codable {
             }
         }
         self.dailyModelBreakdown = rebuilt
+
+        let hourlyStringKeyed = try c.decodeIfPresent([String: [ModelBreakdown]].self, forKey: .hourlyModelBreakdown) ?? [:]
+        var hourlyRebuilt: [Date: [ModelBreakdown]] = [:]
+        for (raw, value) in hourlyStringKeyed {
+            if let date = Self.dateKeyFormatter.date(from: raw) {
+                hourlyRebuilt[date] = value
+            }
+        }
+        self.hourlyModelBreakdown = hourlyRebuilt
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -269,6 +302,7 @@ public struct CostSnapshot: Sendable, Equatable, Codable {
         try c.encode(allTimeRequests, forKey: .allTimeRequests)
         try c.encode(dailyHistory, forKey: .dailyHistory)
         try c.encode(todayHourlyHistory, forKey: .todayHourlyHistory)
+        try c.encode(yesterdayHourlyHistory, forKey: .yesterdayHourlyHistory)
         try c.encode(heatmap, forKey: .heatmap)
         try c.encode(modelBreakdowns, forKey: .modelBreakdowns)
         try c.encode(last7DaysModelBreakdowns, forKey: .last7DaysModelBreakdowns)
@@ -279,6 +313,10 @@ public struct CostSnapshot: Sendable, Equatable, Codable {
             uniqueKeysWithValues: dailyModelBreakdown.map { (Self.dateKeyFormatter.string(from: $0.key), $0.value) }
         )
         try c.encode(stringKeyed, forKey: .dailyModelBreakdown)
+        let hourlyStringKeyed = Dictionary(
+            uniqueKeysWithValues: hourlyModelBreakdown.map { (Self.dateKeyFormatter.string(from: $0.key), $0.value) }
+        )
+        try c.encode(hourlyStringKeyed, forKey: .hourlyModelBreakdown)
     }
 }
 
@@ -331,6 +369,40 @@ public enum CostSnapshotAggregator {
         return totals
             .map { HourlyCostPoint(date: $0.key, costUSD: $0.value.cost, totalTokens: $0.value.tokens) }
             .sorted { $0.date < $1.date }
+    }
+
+    public static func combinedYesterdayHourlyHistory(
+        _ snapshots: [CostSnapshot],
+        calendar: Calendar = .current
+    ) -> [HourlyCostPoint] {
+        combineHourlyPoints(snapshots.flatMap(\.yesterdayHourlyHistory), calendar: calendar)
+    }
+
+    public static func combinedHourlyModelBreakdown(
+        _ snapshots: [CostSnapshot],
+        calendar: Calendar = .current
+    ) -> [Date: [CostSnapshot.ModelBreakdown]] {
+        var totals: [Date: [String: (cost: Double, tokens: Int)]] = [:]
+        for snapshot in snapshots {
+            for (rawHour, breakdowns) in snapshot.hourlyModelBreakdown {
+                let components = calendar.dateComponents([.year, .month, .day, .hour], from: rawHour)
+                guard let hour = calendar.date(from: components) else { continue }
+                var hourTotals = totals[hour] ?? [:]
+                for breakdown in breakdowns {
+                    let current = hourTotals[breakdown.modelName] ?? (0, 0)
+                    hourTotals[breakdown.modelName] = (
+                        current.cost + breakdown.costUSD,
+                        current.tokens + breakdown.totalTokens
+                    )
+                }
+                totals[hour] = hourTotals
+            }
+        }
+        return totals.mapValues { models in
+            models.map {
+                CostSnapshot.ModelBreakdown(modelName: $0.key, costUSD: $0.value.cost, totalTokens: $0.value.tokens)
+            }.sorted { $0.costUSD > $1.costUSD }
+        }
     }
 
     public static func combinedHeatmap(
@@ -421,10 +493,12 @@ public enum CostSnapshotAggregator {
             allTimeRequests: rebased.reduce(0) { $0 + $1.allTimeRequests },
             dailyHistory: combinedDailyHistory(rebased, calendar: calendar),
             todayHourlyHistory: combinedHourlyHistory(rebased, calendar: calendar),
+            yesterdayHourlyHistory: combinedYesterdayHourlyHistory(rebased, calendar: calendar),
             heatmap: combinedHeatmap(rebased, tool: tool),
             modelBreakdowns: combinedModelBreakdowns(rebased),
             last7DaysModelBreakdowns: combinedLast7DaysModelBreakdowns(rebased),
             dailyModelBreakdown: combinedDailyModelBreakdown(rebased, calendar: calendar),
+            hourlyModelBreakdown: combinedHourlyModelBreakdown(rebased, calendar: calendar),
             jsonlFilesFound: rebased.reduce(0) { $0 + $1.jsonlFilesFound },
             updatedAt: rebased.map(\.updatedAt).max() ?? now
         )
@@ -445,10 +519,27 @@ public enum CostSnapshotAggregator {
             .map { CostSnapshot.ModelBreakdown(modelName: $0.key, costUSD: $0.value.cost, totalTokens: $0.value.tokens) }
             .sorted { $0.costUSD > $1.costUSD }
     }
+
+    private static func combineHourlyPoints(
+        _ points: [HourlyCostPoint],
+        calendar: Calendar
+    ) -> [HourlyCostPoint] {
+        var totals: [Date: (cost: Double, tokens: Int)] = [:]
+        for point in points {
+            let components = calendar.dateComponents([.year, .month, .day, .hour], from: point.date)
+            guard let hour = calendar.date(from: components) else { continue }
+            let current = totals[hour] ?? (0, 0)
+            totals[hour] = (current.cost + point.costUSD, current.tokens + point.totalTokens)
+        }
+        return totals.map {
+            HourlyCostPoint(date: $0.key, costUSD: $0.value.cost, totalTokens: $0.value.tokens)
+        }.sorted { $0.date < $1.date }
+    }
 }
 
 public enum CostTimeframe: String, CaseIterable, Identifiable, Sendable {
     case today
+    case yesterday
     case week
     case month
     case all
@@ -458,6 +549,7 @@ public enum CostTimeframe: String, CaseIterable, Identifiable, Sendable {
     public var label: String {
         switch self {
         case .today: return "Today"
+        case .yesterday: return "Yesterday"
         case .week:  return "7 days"
         case .month: return "30 days"
         case .all:   return "All"
@@ -467,6 +559,7 @@ public enum CostTimeframe: String, CaseIterable, Identifiable, Sendable {
     public var shortLabel: String {
         switch self {
         case .today: return "Today"
+        case .yesterday: return "Yday"
         case .week:  return "7d"
         case .month: return "30d"
         case .all:   return "All"
@@ -476,6 +569,10 @@ public enum CostTimeframe: String, CaseIterable, Identifiable, Sendable {
     public func cost(in snapshot: CostSnapshot) -> Double {
         switch self {
         case .today: return snapshot.todayCostUSD
+        case .yesterday:
+            return snapshot.dailyHistory.first {
+                Calendar.current.isDate($0.date, inSameDayAs: Calendar.current.date(byAdding: .day, value: -1, to: Date()) ?? Date())
+            }?.costUSD ?? 0
         case .week:  return snapshot.last7DaysCostUSD
         case .month: return snapshot.last30DaysCostUSD
         case .all:   return snapshot.allTimeCostUSD
@@ -485,6 +582,10 @@ public enum CostTimeframe: String, CaseIterable, Identifiable, Sendable {
     public func tokens(in snapshot: CostSnapshot) -> Int {
         switch self {
         case .today: return snapshot.todayTokens
+        case .yesterday:
+            return snapshot.dailyHistory.first {
+                Calendar.current.isDate($0.date, inSameDayAs: Calendar.current.date(byAdding: .day, value: -1, to: Date()) ?? Date())
+            }?.totalTokens ?? 0
         case .week:  return snapshot.last7DaysTokens
         case .month: return snapshot.last30DaysTokens
         case .all:   return snapshot.allTimeTokens

--- a/Sources/VibeBarCore/Models/ServiceStatus.swift
+++ b/Sources/VibeBarCore/Models/ServiceStatus.swift
@@ -173,11 +173,11 @@ public struct ServiceStatusSnapshot: Sendable, Hashable, Codable {
         return values.reduce(0, +) / Double(values.count)
     }
 
-    /// Uptime the card should display: the incident-adjusted number when the
-    /// provider's incident feed dented it, otherwise the official aggregate.
+    /// Uptime shown by the card comes only from the provider's published
+    /// component uptime. Incident tickets are not continuous downtime
+    /// intervals: some stay open across intermittent degradation for days.
     public var displayUptimePercent: Double {
-        guard let adjusted = incidentAdjustedUptimePercent else { return aggregateUptimePercent }
-        return min(adjusted, aggregateUptimePercent)
+        aggregateUptimePercent
     }
 
     /// Indicator with unresolved incidents folded in. Anthropic sometimes

--- a/Sources/VibeBarCore/Models/SubscriptionWindowSample.swift
+++ b/Sources/VibeBarCore/Models/SubscriptionWindowSample.swift
@@ -1,16 +1,15 @@
 import Foundation
 
-/// One observed reset window for a single quota bucket of a single
-/// account. The store keeps a rolling history of these per (account,
-/// bucket) so the UI can render a sparkline of "how full did I get in
-/// each of the last N windows."
-///
-/// Identity for max-merge is `(accountId, bucketId, windowEnd)`. A
-/// window is uniquely identified by its `resetAt` — every observation
-/// of the same bucket within the same window converges to one sample,
-/// with `peakUsedPercent` rising monotonically as new observations
-/// arrive and `lastUsedPercent` tracking the time-newest value.
+/// One inferred subscription cycle for a quota bucket. The active cycle is
+/// updated in place; it becomes a historical sample only after a refill is
+/// observed (usage falls materially) or a scheduled reset is crossed.
 public struct SubscriptionWindowSample: Codable, Hashable, Sendable {
+    public enum CompletionReason: String, Codable, Hashable, Sendable {
+        case refillDetected
+        case scheduledReset
+        case legacyTimelineMigration
+    }
+
     public var accountId: String
     public var tool: ToolType
     public var bucketId: String
@@ -22,6 +21,13 @@ public struct SubscriptionWindowSample: Codable, Hashable, Sendable {
     public var observationCount: Int
     public var firstSeenAt: Date
     public var lastSeenAt: Date
+    public var completedAt: Date?
+    public var completionReason: CompletionReason?
+
+    public var isCompleted: Bool { completedAt != nil }
+    public var remainingPercentAtReset: Double {
+        max(0, 100 - peakUsedPercent)
+    }
 
     public init(
         accountId: String,
@@ -34,7 +40,9 @@ public struct SubscriptionWindowSample: Codable, Hashable, Sendable {
         lastUsedPercent: Double,
         observationCount: Int = 1,
         firstSeenAt: Date,
-        lastSeenAt: Date
+        lastSeenAt: Date,
+        completedAt: Date? = nil,
+        completionReason: CompletionReason? = nil
     ) {
         self.accountId = accountId
         self.tool = tool
@@ -47,6 +55,8 @@ public struct SubscriptionWindowSample: Codable, Hashable, Sendable {
         self.observationCount = max(0, observationCount)
         self.firstSeenAt = firstSeenAt
         self.lastSeenAt = lastSeenAt
+        self.completedAt = completedAt
+        self.completionReason = completionReason
     }
 
     private static func clamp(_ value: Double) -> Double {

--- a/Sources/VibeBarCore/Services/CostUsageScanner.swift
+++ b/Sources/VibeBarCore/Services/CostUsageScanner.swift
@@ -1309,6 +1309,7 @@ public enum CostUsageScanner {
         let now: Date
         let calendar: Calendar
         let startOfToday: Date
+        let startOfYesterday: Date
         let weekCutoff: Date
         let monthCutoff: Date
 
@@ -1318,6 +1319,7 @@ public enum CostUsageScanner {
         var monthCost: Double = 0, monthTokens: Int = 0, monthRequests: Int = 0
         var byDay: [Date: (cost: Double, tokens: Int)] = [:]
         var byHourToday: [Date: (cost: Double, tokens: Int)] = [:]
+        var byHourYesterday: [Date: (cost: Double, tokens: Int)] = [:]
         var heatmap: [[Int]] = Array(repeating: Array(repeating: 0, count: 24), count: 7)
         /// Model ranking across every scanned session.
         var byModelAllTime: [String: (cost: Double, tokens: Int)] = [:]
@@ -1326,6 +1328,7 @@ public enum CostUsageScanner {
         /// Per-day per-model breakdown. Keyed by `startOfDay` of the event so
         /// chart tooltips can show "On Mar 5: gpt-5 $1.20 · sonnet $0.40".
         var byDayModel: [Date: [String: (cost: Double, tokens: Int)]] = [:]
+        var byHourModel: [Date: [String: (cost: Double, tokens: Int)]] = [:]
 
         init(tool: ToolType, now: Date) {
             self.tool = tool
@@ -1334,6 +1337,7 @@ public enum CostUsageScanner {
             cal.locale = Locale(identifier: "en_US_POSIX")
             self.calendar = cal
             self.startOfToday = cal.startOfDay(for: now)
+            self.startOfYesterday = cal.date(byAdding: .day, value: -1, to: startOfToday) ?? startOfToday
             self.weekCutoff = cal.date(byAdding: .day, value: -6, to: startOfToday) ?? now
             self.monthCutoff = cal.date(byAdding: .day, value: -29, to: startOfToday) ?? now
         }
@@ -1353,6 +1357,13 @@ public enum CostUsageScanner {
                     hourBucket.tokens += tokens
                     byHourToday[hourKey] = hourBucket
                 }
+            }
+            if date >= startOfYesterday, date < startOfToday,
+               let hourKey = calendar.dateInterval(of: .hour, for: date)?.start {
+                var hourBucket = byHourYesterday[hourKey] ?? (0, 0)
+                hourBucket.cost += costUSD
+                hourBucket.tokens += tokens
+                byHourYesterday[hourKey] = hourBucket
             }
             if date >= weekCutoff {
                 weekCost += costUSD
@@ -1394,6 +1405,16 @@ public enum CostUsageScanner {
             dayModelEntry.tokens += tokens
             dayModels[model] = dayModelEntry
             byDayModel[dayKey] = dayModels
+
+            if date >= startOfYesterday,
+               let hourKey = calendar.dateInterval(of: .hour, for: date)?.start {
+                var hourModels = byHourModel[hourKey] ?? [:]
+                var hourModelEntry = hourModels[model] ?? (0, 0)
+                hourModelEntry.cost += costUSD
+                hourModelEntry.tokens += tokens
+                hourModels[model] = hourModelEntry
+                byHourModel[hourKey] = hourModels
+            }
         }
 
         func snapshot(jsonlFilesFound: Int) -> CostSnapshot {
@@ -1406,6 +1427,11 @@ public enum CostUsageScanner {
                 let value = byHourToday[hour] ?? (0, 0)
                 return HourlyCostPoint(date: hour, costUSD: value.cost, totalTokens: value.tokens)
             }
+            let hourlyYesterday = (0..<24).compactMap { offset -> HourlyCostPoint? in
+                guard let hour = calendar.date(byAdding: .hour, value: offset, to: startOfYesterday) else { return nil }
+                let value = byHourYesterday[hour] ?? (0, 0)
+                return HourlyCostPoint(date: hour, costUSD: value.cost, totalTokens: value.tokens)
+            }
             let sevenDayBreakdowns = byModel7d
                 .sorted { $0.value.cost > $1.value.cost }
                 .prefix(20)
@@ -1415,13 +1441,20 @@ public enum CostUsageScanner {
                 .sorted { $0.value.cost > $1.value.cost }
                 .prefix(20)
                 .map { CostSnapshot.ModelBreakdown(modelName: $0.key, costUSD: $0.value.cost, totalTokens: $0.value.tokens) }
-            // Reduce per-day model maps to sorted top-N arrays. Tooltip caps
-            // at 3 entries; we keep up to 5 here in case the UI wants more.
+            // Keep enough entries for the compact top-three hover plus the
+            // click-to-pin expanded list (up to ten models).
             var perDayModels: [Date: [CostSnapshot.ModelBreakdown]] = [:]
             for (day, models) in byDayModel {
                 perDayModels[day] = models
                     .sorted { $0.value.cost > $1.value.cost }
-                    .prefix(5)
+                    .prefix(20)
+                    .map { CostSnapshot.ModelBreakdown(modelName: $0.key, costUSD: $0.value.cost, totalTokens: $0.value.tokens) }
+            }
+            var perHourModels: [Date: [CostSnapshot.ModelBreakdown]] = [:]
+            for (hour, models) in byHourModel {
+                perHourModels[hour] = models
+                    .sorted { $0.value.cost > $1.value.cost }
+                    .prefix(20)
                     .map { CostSnapshot.ModelBreakdown(modelName: $0.key, costUSD: $0.value.cost, totalTokens: $0.value.tokens) }
             }
             return CostSnapshot(
@@ -1440,10 +1473,12 @@ public enum CostUsageScanner {
                 allTimeRequests: totalRequests,
                 dailyHistory: sortedDays,
                 todayHourlyHistory: hourlyToday,
+                yesterdayHourlyHistory: hourlyYesterday,
                 heatmap: UsageHeatmap(tool: tool, cells: heatmap, totalTokens: totalTokens),
                 modelBreakdowns: Array(allTimeBreakdowns),
                 last7DaysModelBreakdowns: Array(sevenDayBreakdowns),
                 dailyModelBreakdown: perDayModels,
+                hourlyModelBreakdown: perHourModels,
                 jsonlFilesFound: jsonlFilesFound,
                 updatedAt: now
             )

--- a/Sources/VibeBarCore/Services/CostUsageService.swift
+++ b/Sources/VibeBarCore/Services/CostUsageService.swift
@@ -172,14 +172,23 @@ public final class CostUsageService: ObservableObject {
         let dayCount: Int?
         switch timeframe {
         case .today: dayCount = 1
+        case .yesterday: dayCount = 2
         case .week:  dayCount = 7
         case .month: dayCount = 30
         case .all:   dayCount = nil
         }
-        return await CostHistoryStore.shared.history(
+        let history = await CostHistoryStore.shared.history(
             for: tool,
             days: dayCount,
             retentionDays: costData.retentionDays
+        )
+        guard timeframe == .yesterday else { return history }
+        let calendar = Calendar.current
+        let yesterday = calendar.date(byAdding: .day, value: -1, to: calendar.startOfDay(for: Date())) ?? Date()
+        return CostHistory(
+            tool: history.tool,
+            days: history.days.filter { calendar.isDate($0.date, inSameDayAs: yesterday) },
+            updatedAt: history.updatedAt
         )
     }
 

--- a/Sources/VibeBarCore/Services/MockDataProvider.swift
+++ b/Sources/VibeBarCore/Services/MockDataProvider.swift
@@ -28,6 +28,7 @@ public enum MockDataProvider {
         let days: Int
         switch timeframe {
         case .today: days = 1
+        case .yesterday: days = 1
         case .week:  days = 7
         case .month: days = 30
         case .all:   days = 120
@@ -37,7 +38,8 @@ public enum MockDataProvider {
         let baseCost: Double = (tool == .codex) ? 0.7 : 1.1
         var points: [DailyCostPoint] = []
         for offset in stride(from: days - 1, through: 0, by: -1) {
-            guard let day = calendar.date(byAdding: .day, value: -offset, to: today) else { continue }
+            let adjustedOffset = timeframe == .yesterday ? offset + 1 : offset
+            guard let day = calendar.date(byAdding: .day, value: -adjustedOffset, to: today) else { continue }
             let weekday = calendar.component(.weekday, from: day)
             let weekendDip = (weekday == 1 || weekday == 7) ? 0.45 : 1.0
             let oscillation = 0.6 + 0.5 * Double((offset * 7) % 13) / 13.0

--- a/Sources/VibeBarCore/Services/OverviewMasonryPlanner.swift
+++ b/Sources/VibeBarCore/Services/OverviewMasonryPlanner.swift
@@ -1,0 +1,211 @@
+import Foundation
+
+/// Pure layout planner for the Overview's two-column waterfall.
+///
+/// Placement is deliberately phased: quota cards are balanced first without
+/// considering anything below them, cost cards are then balanced from those
+/// seeded column heights, and auxiliary cards finally fill the shorter column.
+/// Keeping this policy in Core makes the behavior deterministic and testable
+/// while SwiftUI remains responsible only for live height measurement.
+public enum OverviewMasonryPlanner {
+    public enum Phase: Int, Sendable, Comparable {
+        case quota
+        case cost
+        case auxiliary
+
+        public static func < (lhs: Phase, rhs: Phase) -> Bool {
+            lhs.rawValue < rhs.rawValue
+        }
+    }
+
+    public struct Item: Sendable, Equatable {
+        public let id: String
+        public let height: Double
+        public let phase: Phase
+
+        public init(id: String, height: Double, phase: Phase) {
+            self.id = id
+            self.height = max(0, height)
+            self.phase = phase
+        }
+    }
+
+    public struct Position: Sendable, Equatable {
+        public let column: Int
+        public let y: Double
+
+        public init(column: Int, y: Double) {
+            self.column = column
+            self.y = y
+        }
+    }
+
+    public struct Plan: Sendable, Equatable {
+        public let positions: [String: Position]
+        public let columnHeights: [Double]
+
+        public init(positions: [String: Position], columnHeights: [Double]) {
+            self.positions = positions
+            self.columnHeights = columnHeights
+        }
+    }
+
+    public static func plan(
+        items: [Item],
+        columns: Int = 2,
+        spacing: Double
+    ) -> Plan {
+        let columnCount = max(1, columns)
+        guard columnCount == 2 else {
+            return greedyPlan(items: items, columns: columnCount, spacing: spacing)
+        }
+
+        let quotas = items.filter { $0.phase == .quota }
+        let costs = items.filter { $0.phase == .cost }
+        let auxiliary = items.filter { $0.phase == .auxiliary }
+        var positions: [String: Position] = [:]
+        var heights = Array(repeating: 0.0, count: columnCount)
+
+        // AQ's Overview has four quota cards. Enumerating all 24 orders lets
+        // either pair occupy either column while preserving the invariant of
+        // two quota cards per column. For any other count, use deterministic
+        // shortest-column placement rather than making brittle assumptions.
+        if quotas.count == 4 {
+            let order = bestQuotaOrder(quotas, spacing: spacing)
+            for (offset, item) in order.enumerated() {
+                let column = offset < 2 ? 0 : 1
+                append(item, to: column, spacing: spacing, heights: &heights, positions: &positions)
+            }
+        } else {
+            for item in quotas {
+                let column = shortestColumn(heights)
+                append(item, to: column, spacing: spacing, heights: &heights, positions: &positions)
+            }
+        }
+
+        // There are only five Cost cards, so exhaustive assignment is both
+        // cheaper and more accurate than greedy placement. Declaration order
+        // remains the vertical order within each column.
+        if !costs.isEmpty {
+            let columns = bestCostColumns(costs, seededBy: heights, spacing: spacing)
+            for (item, column) in zip(costs, columns) {
+                append(item, to: column, spacing: spacing, heights: &heights, positions: &positions)
+            }
+        }
+
+        for item in auxiliary {
+            let column = shortestColumn(heights)
+            append(item, to: column, spacing: spacing, heights: &heights, positions: &positions)
+        }
+        return Plan(positions: positions, columnHeights: heights)
+    }
+
+    private static func bestQuotaOrder(_ items: [Item], spacing: Double) -> [Item] {
+        var best = items
+        var bestScore = quotaScore(items, spacing: spacing)
+        for permutation in permutations(items) {
+            let score = quotaScore(permutation, spacing: spacing)
+            if score.lexicographicallyPrecedes(bestScore) {
+                best = permutation
+                bestScore = score
+            }
+        }
+        return best
+    }
+
+    /// Balance the quota block itself first. The lexicographic tail is a
+    /// stable tie-breaker that favors original declaration order.
+    private static func quotaScore(_ order: [Item], spacing: Double) -> [Double] {
+        let left = stackedHeight(Array(order.prefix(2)), spacing: spacing)
+        let right = stackedHeight(Array(order.dropFirst(2)), spacing: spacing)
+        return [abs(left - right), max(left, right)]
+    }
+
+    private static func bestCostColumns(
+        _ items: [Item],
+        seededBy seed: [Double],
+        spacing: Double
+    ) -> [Int] {
+        var bestColumns = Array(repeating: 0, count: items.count)
+        var bestScore = [Double.infinity, Double.infinity, Double.infinity]
+        let combinations = 1 << items.count
+        for mask in 0..<combinations {
+            var heights = seed
+            var columns: [Int] = []
+            columns.reserveCapacity(items.count)
+            for (index, item) in items.enumerated() {
+                let column = (mask >> index) & 1
+                columns.append(column)
+                heights[column] = appendedHeight(heights[column], item.height, spacing: spacing)
+            }
+            // Minimize the total waterfall height first, then its ragged
+            // bottom edge. The last term makes ties prefer fewer right-column
+            // moves, which prevents arbitrary flipping between redraws.
+            let score = [
+                max(heights[0], heights[1]),
+                abs(heights[0] - heights[1]),
+                Double(columns.reduce(0, +))
+            ]
+            if score.lexicographicallyPrecedes(bestScore) {
+                bestScore = score
+                bestColumns = columns
+            }
+        }
+        return bestColumns
+    }
+
+    private static func greedyPlan(items: [Item], columns: Int, spacing: Double) -> Plan {
+        var heights = Array(repeating: 0.0, count: columns)
+        var positions: [String: Position] = [:]
+        for item in items.sorted(by: { $0.phase < $1.phase }) {
+            let column = shortestColumn(heights)
+            append(item, to: column, spacing: spacing, heights: &heights, positions: &positions)
+        }
+        return Plan(positions: positions, columnHeights: heights)
+    }
+
+    private static func append(
+        _ item: Item,
+        to column: Int,
+        spacing: Double,
+        heights: inout [Double],
+        positions: inout [String: Position]
+    ) {
+        let y = heights[column] + (heights[column] > 0 ? spacing : 0)
+        positions[item.id] = Position(column: column, y: y)
+        heights[column] = y + item.height
+    }
+
+    private static func appendedHeight(_ current: Double, _ item: Double, spacing: Double) -> Double {
+        current + (current > 0 ? spacing : 0) + item
+    }
+
+    private static func stackedHeight(_ items: [Item], spacing: Double) -> Double {
+        guard !items.isEmpty else { return 0 }
+        return items.reduce(0) { appendedHeight($0, $1.height, spacing: spacing) }
+    }
+
+    private static func shortestColumn(_ heights: [Double]) -> Int {
+        heights.indices.min { lhs, rhs in
+            heights[lhs] == heights[rhs] ? lhs < rhs : heights[lhs] < heights[rhs]
+        } ?? 0
+    }
+
+    private static func permutations<T>(_ values: [T]) -> [[T]] {
+        guard values.count > 1 else { return [values] }
+        return values.indices.flatMap { index -> [[T]] in
+            var remainder = values
+            let head = remainder.remove(at: index)
+            return permutations(remainder).map { [head] + $0 }
+        }
+    }
+}
+
+private extension Array where Element == Double {
+    func lexicographicallyPrecedes(_ other: [Double]) -> Bool {
+        for (lhs, rhs) in zip(self, other) where lhs != rhs {
+            return lhs < rhs
+        }
+        return count < other.count
+    }
+}

--- a/Sources/VibeBarCore/Services/QuotaService.swift
+++ b/Sources/VibeBarCore/Services/QuotaService.swift
@@ -5,6 +5,7 @@ import Foundation
 /// failures, and supports a global mock-mode override.
 @MainActor
 public final class QuotaService: ObservableObject {
+    public static let credentialFallbackMaxAge: TimeInterval = 30 * 60
     @Published public private(set) var lastSuccessByAccount: [String: AccountQuota] = [:]
     @Published public private(set) var lastErrorByAccount: [String: QuotaError] = [:]
     @Published public private(set) var lastUpdatedByAccount: [String: Date] = [:]
@@ -14,10 +15,6 @@ public final class QuotaService: ObservableObject {
     /// kept in sync as each `refresh` succeeds; views read this
     /// dictionary directly via the `@Published` projection.
     @Published public private(set) var historyByAccountBucket: [SubscriptionHistoryKey: [SubscriptionWindowSample]] = [:]
-    /// Per-(accountId, bucketId) fill timeline (hourly point-in-time samples)
-    /// from `UsageFillTimelineStore`, powering the CodexBar-style fill chart.
-    /// Points are oldest-first.
-    @Published public private(set) var fillTimelineByAccountBucket: [SubscriptionHistoryKey: [FillTimelinePoint]] = [:]
 
     private let adapters: [ToolType: any QuotaAdapter]
     private let mockProvider: () -> Bool
@@ -41,10 +38,15 @@ public final class QuotaService: ObservableObject {
         // and mini window won't render samples until this Task resolves,
         // but neither is open at launch so the brief flicker is invisible.
         Task { @MainActor [weak self] in
+            // Salvage only genuine refill jumps from the retired hourly
+            // timeline before hydrating the cycle-based history UI.
+            let points = await UsageFillTimelineStore.shared.allPoints()
+            await SubscriptionHistoryStore.shared.importLegacyTimeline(
+                points,
+                retentionDays: retentionProvider()
+            )
             let samples = await SubscriptionHistoryStore.shared.allSamples()
             self?.applyInitialSubscriptionHistory(samples)
-            let points = await UsageFillTimelineStore.shared.allPoints()
-            self?.applyInitialFillTimeline(points)
         }
     }
 
@@ -131,6 +133,18 @@ public final class QuotaService: ObservableObject {
         lastSuccessByAccount[accountId]
     }
 
+    /// Opening a provider page should refresh both missing and stale cache.
+    /// Previously any cache entry — even one from months ago — suppressed the
+    /// page refresh indefinitely.
+    public func needsRefresh(
+        accountId: String,
+        now: Date = Date(),
+        maxAge: TimeInterval
+    ) -> Bool {
+        guard let cached = lastSuccessByAccount[accountId] else { return true }
+        return now.timeIntervalSince(cached.queriedAt) >= max(0, maxAge)
+    }
+
     public func clear(accountId: String) {
         lastSuccessByAccount.removeValue(forKey: accountId)
         lastErrorByAccount.removeValue(forKey: accountId)
@@ -158,45 +172,15 @@ public final class QuotaService: ObservableObject {
             SafeLog.warn("Saving quota cache failed: \(SafeLog.sanitize(error.localizedDescription))")
         }
 
-        // Fold this snapshot into the subscription fill-history store
-        // and republish the affected keys so views can repaint
-        // sparklines. The store's provider and window gates drop
-        // anything outside the four primary providers and 5-hour
-        // buckets, so this is a no-op for misc-provider refreshes.
+        // Fold this snapshot into the reset-cycle store and republish the
+        // affected keys. Point-in-time hourly sampling is intentionally no
+        // longer updated: it measured "what remained at refresh time", not
+        // "what remained when the subscription reset".
         let retention = retentionProvider()
         let quota = success
         Task { [weak self] in
             await SubscriptionHistoryStore.shared.observe(quota, retentionDays: retention)
             await self?.refreshSubscriptionHistory(for: quota)
-            await UsageFillTimelineStore.shared.observe(quota, retentionDays: retention)
-            await self?.refreshFillTimeline(for: quota)
-        }
-    }
-
-    private func applyInitialFillTimeline(_ points: [FillTimelinePoint]) {
-        var grouped: [SubscriptionHistoryKey: [FillTimelinePoint]] = [:]
-        for point in points {
-            let key = SubscriptionHistoryKey(accountId: point.accountId, bucketId: point.bucketId)
-            grouped[key, default: []].append(point)
-        }
-        for key in grouped.keys {
-            grouped[key]?.sort { $0.slotStart < $1.slotStart }
-        }
-        fillTimelineByAccountBucket = grouped
-    }
-
-    private func refreshFillTimeline(for quota: AccountQuota) async {
-        var updates: [SubscriptionHistoryKey: [FillTimelinePoint]] = [:]
-        for bucket in quota.buckets where bucket.groupTitle == nil {
-            let points = await UsageFillTimelineStore.shared.points(
-                accountId: quota.accountId,
-                bucketId: bucket.id
-            )
-            let key = SubscriptionHistoryKey(accountId: quota.accountId, bucketId: bucket.id)
-            updates[key] = points
-        }
-        for (key, points) in updates {
-            fillTimelineByAccountBucket[key] = points
         }
     }
 
@@ -230,7 +214,8 @@ public final class QuotaService: ObservableObject {
     private func store(error: QuotaError, for account: AccountIdentity) {
         if error.isCredentialState,
            let cached = lastSuccessByAccount[account.id],
-           !cached.buckets.isEmpty {
+           !cached.buckets.isEmpty,
+           Date().timeIntervalSince(cached.queriedAt) < Self.credentialFallbackMaxAge {
             lastErrorByAccount.removeValue(forKey: account.id)
             return
         }
@@ -240,7 +225,9 @@ public final class QuotaService: ObservableObject {
 
     private func cachedOrEmpty(for account: AccountIdentity, error: QuotaError) -> AccountQuota {
         if var cached = lastSuccessByAccount[account.id] {
-            if error.isCredentialState, !cached.buckets.isEmpty {
+            if error.isCredentialState,
+               !cached.buckets.isEmpty,
+               Date().timeIntervalSince(cached.queriedAt) < Self.credentialFallbackMaxAge {
                 cached.error = nil
                 return cached
             }

--- a/Sources/VibeBarCore/Services/ServiceStatusClient.swift
+++ b/Sources/VibeBarCore/Services/ServiceStatusClient.swift
@@ -542,30 +542,6 @@ public actor ServiceStatusClient {
                 )
             }
 
-        // Anthropic posts incidents ("Elevated errors on …") without ever
-        // flipping a component to degraded, so the scraped uptimeData stays
-        // 100% green wall-to-wall. Fold the incident feed into a
-        // provider-level day overlay + an incident-aware uptime so the card
-        // reflects the week's incidents instead of contradicting its own
-        // incident footer. Uses the full incidents feed, not the 4-item
-        // `recent` slice, so older incidents inside the window still count.
-        let incidentIntervals: [(start: Date, end: Date, impact: IncidentImpact)] =
-            incidentsDTO.incidents.compactMap { incident in
-                guard incident.impact.severity > IncidentImpact.none.severity else { return nil }
-                return (
-                    start: incident.created_at,
-                    end: incident.resolved_at ?? now,
-                    impact: incident.impact
-                )
-            }
-        let incidentDays = buildDayBuckets(from: incidentIntervals, dayCount: dayCount, now: now)
-        let adjustedUptime = Self.incidentAdjustedUptime(
-            officialPercent: components.compactMap(\.uptimePercent).min(),
-            intervals: incidentIntervals.map { (start: $0.start, end: $0.end) },
-            dayCount: dayCount,
-            now: now
-        )
-
         return ServiceStatusSnapshot(
             tool: .claude,
             indicator: summary.status.indicator,
@@ -573,48 +549,8 @@ public actor ServiceStatusClient {
             updatedAt: summary.page.updated_at,
             groups: groups,
             components: components,
-            recentIncidents: Array(recent),
-            incidentDays: incidentDays.contains(where: { $0.worstImpact != nil }) ? incidentDays : nil,
-            incidentAdjustedUptimePercent: adjustedUptime
+            recentIncidents: Array(recent)
         )
-    }
-
-    /// 100% minus the merged (union) incident downtime over the window,
-    /// capped by the official component uptime when that is lower. Overlap
-    /// between concurrent incidents is only counted once.
-    nonisolated static func incidentAdjustedUptime(
-        officialPercent: Double?,
-        intervals: [(start: Date, end: Date)],
-        dayCount: Int,
-        now: Date
-    ) -> Double? {
-        let windowSeconds = Double(dayCount) * 86_400
-        guard windowSeconds > 0 else { return nil }
-        let windowStart = now.addingTimeInterval(-windowSeconds)
-        let clamped = intervals.compactMap { interval -> (Date, Date)? in
-            let start = max(interval.start, windowStart)
-            let end = min(interval.end, now)
-            guard end > start else { return nil }
-            return (start, end)
-        }
-        .sorted { $0.0 < $1.0 }
-        guard !clamped.isEmpty else { return nil }
-        var downtime: TimeInterval = 0
-        var currentStart = clamped[0].0
-        var currentEnd = clamped[0].1
-        for (start, end) in clamped.dropFirst() {
-            if start <= currentEnd {
-                currentEnd = max(currentEnd, end)
-            } else {
-                downtime += currentEnd.timeIntervalSince(currentStart)
-                currentStart = start
-                currentEnd = end
-            }
-        }
-        downtime += currentEnd.timeIntervalSince(currentStart)
-        let incidentUptime = max(0, min(100, (1 - downtime / windowSeconds) * 100))
-        guard let officialPercent else { return incidentUptime }
-        return min(officialPercent, incidentUptime)
     }
 
     // MARK: - OpenAI (incident.io with embedded streaming chunks)

--- a/Sources/VibeBarCore/Services/SubscriptionHistoryStore.swift
+++ b/Sources/VibeBarCore/Services/SubscriptionHistoryStore.swift
@@ -1,40 +1,32 @@
 import Foundation
 
-/// Persists per-bucket subscription fill history so the UI can render
-/// a sparkline of "how full did I get in each of the last N reset
-/// windows" alongside the live quota bar.
+/// Persists inferred subscription cycles, not point-in-time samples.
 ///
-/// Scope is intentionally narrow:
-///
-/// - **Provider gate.** Only the four primary providers (`codex`,
-///   `claude`, `gemini`, `grok`) are recorded. Misc providers are not
-///   subscription plans in the same sense and are silently dropped.
-/// - **Window gate.** Only buckets whose window is fixed-clock and
-///   monotonic within the window — concretely
-///   `rawWindowSeconds == nil || rawWindowSeconds >= 86_400` — are
-///   recorded. The 5-hour on-demand rolling windows on Claude/Codex
-///   are excluded because the clock doesn't tick when idle, so the
-///   peak-per-window series is non-monotonic in a way that would
-///   invert "used more" into "sparkline goes down".
-///
-/// File: `~/.vibebar/subscription_history.json` (mode 0600). Retention
-/// is driven by callers passing `retentionDays`, matching how
-/// `CostHistoryStore` consumes `CostDataSettings.retentionDays`.
+/// A changing `resetAt` is only a forecast and is never used as cycle
+/// identity. The active cycle is finalized when usage materially drops (the
+/// provider refilled the quota), with crossing the previous reset boundary as
+/// a secondary signal. This avoids the old failure mode where a few seconds of
+/// reset-time drift created thousands of fake weekly cycles.
 public actor SubscriptionHistoryStore {
     public static let shared = SubscriptionHistoryStore()
 
     private struct Storage: Codable {
         var schemaVersion: Int
+        var legacyTimelineImported: Bool
         var samples: [SubscriptionWindowSample]
 
         init(
             schemaVersion: Int = SubscriptionHistoryStore.storageSchemaVersion,
+            legacyTimelineImported: Bool = false,
             samples: [SubscriptionWindowSample] = []
         ) {
             self.schemaVersion = schemaVersion
+            self.legacyTimelineImported = legacyTimelineImported
             self.samples = samples
         }
     }
+
+    private struct VersionHeader: Decodable { let schemaVersion: Int }
 
     private let fileURL: URL
     private var cachedStorage: Storage?
@@ -42,15 +34,12 @@ public actor SubscriptionHistoryStore {
     private var pendingFlushTask: Task<Void, Never>?
     private var pendingStorage: Storage?
 
-    private static let storageSchemaVersion = 1
+    private static let storageSchemaVersion = 2
     private static let saveThrottleInterval: TimeInterval = 30
     private static let maxFileBytes = 16 * 1024 * 1024
-
-    private static let supportedTools: Set<ToolType> = [.codex, .claude, .gemini, .grok]
-    /// Buckets with a `rawWindowSeconds` smaller than this threshold are
-    /// dropped at observe time — they're on-demand rolling windows and
-    /// don't have a monotonic peak-per-window series.
-    private static let minimumTrackedWindowSeconds = 86_400
+    private static let supportedTools: Set<ToolType> = [
+        .codex, .claude, .gemini, .antigravity, .grok
+    ]
 
     public init(fileURL: URL = SubscriptionHistoryStore.defaultFileURL()) {
         self.fileURL = fileURL
@@ -73,55 +62,115 @@ public actor SubscriptionHistoryStore {
         var storage = load()
         var dirty = false
         for bucket in quota.buckets {
-            guard let windowEnd = bucket.resetAt else { continue }
-            guard bucket.usedPercent.isFinite else { continue }
-            if let secs = bucket.rawWindowSeconds, secs < Self.minimumTrackedWindowSeconds {
+            guard let resetAt = bucket.resetAt, bucket.usedPercent.isFinite else { continue }
+            let used = clamp(bucket.usedPercent)
+            let currentIndex = storage.samples.indices
+                .filter {
+                    storage.samples[$0].accountId == quota.accountId
+                        && storage.samples[$0].bucketId == bucket.id
+                        && !storage.samples[$0].isCompleted
+                }
+                .max { storage.samples[$0].lastSeenAt < storage.samples[$1].lastSeenAt }
+
+            guard let currentIndex else {
+                storage.samples.append(makeCurrentSample(
+                    quota: quota,
+                    bucket: bucket,
+                    used: used,
+                    resetAt: resetAt,
+                    now: now
+                ))
+                dirty = true
                 continue
             }
-            let windowStart = bucket.rawWindowSeconds.map {
-                windowEnd.addingTimeInterval(-TimeInterval($0))
-            }
-            if let idx = storage.samples.firstIndex(where: {
-                $0.accountId == quota.accountId
-                    && $0.bucketId == bucket.id
-                    && $0.windowEnd == windowEnd
-            }) {
-                var sample = storage.samples[idx]
-                sample.peakUsedPercent = max(sample.peakUsedPercent, clamp(bucket.usedPercent))
-                sample.lastUsedPercent = clamp(bucket.usedPercent)
-                sample.observationCount += 1
-                sample.lastSeenAt = max(sample.lastSeenAt, now)
-                // windowStart and rawWindowSeconds might tighten across
-                // refreshes (e.g. an adapter learning the window size
-                // later); accept the latest non-nil value.
-                if sample.windowStart == nil, windowStart != nil {
-                    sample.windowStart = windowStart
-                }
-                if sample.rawWindowSeconds == nil, let s = bucket.rawWindowSeconds {
-                    sample.rawWindowSeconds = s
-                }
-                storage.samples[idx] = sample
-                dirty = true
+
+            var current = storage.samples[currentIndex]
+            if let reason = completionReason(
+                for: current,
+                newUsedPercent: used,
+                newResetAt: resetAt,
+                now: now
+            ) {
+                current.completedAt = now
+                current.completionReason = reason
+                // The observed refill time is more useful than a stale reset
+                // forecast when providers reset early or late.
+                current.windowEnd = now
+                storage.samples[currentIndex] = current
+                storage.samples.append(makeCurrentSample(
+                    quota: quota,
+                    bucket: bucket,
+                    used: used,
+                    resetAt: resetAt,
+                    now: now
+                ))
             } else {
-                let sample = SubscriptionWindowSample(
-                    accountId: quota.accountId,
-                    tool: quota.tool,
-                    bucketId: bucket.id,
-                    windowEnd: windowEnd,
-                    windowStart: windowStart,
-                    rawWindowSeconds: bucket.rawWindowSeconds,
-                    peakUsedPercent: bucket.usedPercent,
-                    lastUsedPercent: bucket.usedPercent,
-                    observationCount: 1,
-                    firstSeenAt: now,
-                    lastSeenAt: now
-                )
-                storage.samples.append(sample)
-                dirty = true
+                current.windowEnd = resetAt
+                current.windowStart = bucket.rawWindowSeconds.map {
+                    resetAt.addingTimeInterval(-TimeInterval($0))
+                } ?? current.windowStart
+                current.rawWindowSeconds = bucket.rawWindowSeconds ?? current.rawWindowSeconds
+                current.peakUsedPercent = max(current.peakUsedPercent, used)
+                current.lastUsedPercent = used
+                current.observationCount += 1
+                current.lastSeenAt = max(current.lastSeenAt, now)
+                storage.samples[currentIndex] = current
             }
+            dirty = true
         }
+
         guard dirty else { return }
         pruneInPlace(&storage, retentionDays: retentionDays, now: now)
+        save(storage)
+    }
+
+    /// One-time best-effort migration from the old hourly fill timeline. Only
+    /// material downward jumps become completed cycles; ordinary samples are
+    /// intentionally discarded so the new chart starts truthful.
+    public func importLegacyTimeline(
+        _ points: [FillTimelinePoint],
+        retentionDays: Int = CostDataSettings.defaultRetentionDays
+    ) {
+        var storage = load()
+        guard !storage.legacyTimelineImported else { return }
+        storage.legacyTimelineImported = true
+
+        let grouped = Dictionary(grouping: points) {
+            SubscriptionHistoryKey(accountId: $0.accountId, bucketId: $0.bucketId)
+        }
+        for (_, rawPoints) in grouped {
+            let sorted = rawPoints.sorted { $0.sampledAt < $1.sampledAt }
+            guard let first = sorted.first, Self.supportedTools.contains(first.tool) else { continue }
+            var peak = clamp(first.usedPercent)
+            var previous = first
+            var segmentStart = first.sampledAt
+            for point in sorted.dropFirst() {
+                let currentUsed = clamp(point.usedPercent)
+                if Self.isMaterialRefill(previous: previous.usedPercent, peak: peak, current: currentUsed) {
+                    storage.samples.append(SubscriptionWindowSample(
+                        accountId: first.accountId,
+                        tool: first.tool,
+                        bucketId: first.bucketId,
+                        windowEnd: point.sampledAt,
+                        windowStart: segmentStart,
+                        rawWindowSeconds: nil,
+                        peakUsedPercent: peak,
+                        lastUsedPercent: clamp(previous.usedPercent),
+                        observationCount: 1,
+                        firstSeenAt: segmentStart,
+                        lastSeenAt: previous.sampledAt,
+                        completedAt: point.sampledAt,
+                        completionReason: .legacyTimelineMigration
+                    ))
+                    segmentStart = point.sampledAt
+                    peak = currentUsed
+                } else {
+                    peak = max(peak, currentUsed)
+                }
+                previous = point
+            }
+        }
+        pruneInPlace(&storage, retentionDays: retentionDays, now: Date())
         save(storage)
     }
 
@@ -132,23 +181,19 @@ public actor SubscriptionHistoryStore {
         includeCurrent: Bool = true,
         limit: Int? = nil
     ) -> [SubscriptionWindowSample] {
-        let storage = load()
-        var matching = storage.samples.filter {
-            $0.accountId == accountId && $0.bucketId == bucketId
+        var matching = load().samples.filter {
+            $0.accountId == accountId
+                && $0.bucketId == bucketId
+                && (includeCurrent || $0.isCompleted)
         }
-        if !includeCurrent {
-            matching.removeAll { $0.windowEnd > now }
-        }
-        matching.sort { $0.windowEnd > $1.windowEnd }
+        matching.sort { sampleSortDate($0) > sampleSortDate($1) }
         if let limit, matching.count > limit {
             matching = Array(matching.prefix(limit))
         }
         return matching
     }
 
-    public func allSamples() -> [SubscriptionWindowSample] {
-        load().samples
-    }
+    public func allSamples() -> [SubscriptionWindowSample] { load().samples }
 
     public func prune(retentionDays: Int, now: Date = Date()) {
         var storage = load()
@@ -157,7 +202,7 @@ public actor SubscriptionHistoryStore {
     }
 
     public func eraseAll() {
-        cachedStorage = Storage(samples: [])
+        cachedStorage = Storage()
         pendingStorage = nil
         pendingFlushTask?.cancel()
         pendingFlushTask = nil
@@ -175,15 +220,78 @@ public actor SubscriptionHistoryStore {
         pendingFlushTask = nil
     }
 
-    // MARK: - Private
+    // MARK: - Reset inference
+
+    private func completionReason(
+        for current: SubscriptionWindowSample,
+        newUsedPercent: Double,
+        newResetAt: Date,
+        now: Date
+    ) -> SubscriptionWindowSample.CompletionReason? {
+        if Self.isMaterialRefill(
+            previous: current.lastUsedPercent,
+            peak: current.peakUsedPercent,
+            current: newUsedPercent
+        ) {
+            return .refillDetected
+        }
+
+        let window = TimeInterval(current.rawWindowSeconds ?? 86_400)
+        let meaningfulAdvance = max(300, window * 0.2)
+        let crossedOldBoundary = now >= current.windowEnd.addingTimeInterval(-120)
+        let resetForecastAdvanced = newResetAt.timeIntervalSince(current.windowEnd) >= meaningfulAdvance
+        if crossedOldBoundary && resetForecastAdvanced {
+            return .scheduledReset
+        }
+        return nil
+    }
+
+    private static func isMaterialRefill(previous: Double, peak: Double, current: Double) -> Bool {
+        let normalizedPrevious = min(100, max(0, previous))
+        let normalizedPeak = min(100, max(0, peak))
+        let normalizedCurrent = min(100, max(0, current))
+        let threshold = max(5, min(15, normalizedPeak * 0.2))
+        return normalizedPrevious - normalizedCurrent >= threshold
+            && normalizedPeak - normalizedCurrent >= threshold
+    }
+
+    private func makeCurrentSample(
+        quota: AccountQuota,
+        bucket: QuotaBucket,
+        used: Double,
+        resetAt: Date,
+        now: Date
+    ) -> SubscriptionWindowSample {
+        SubscriptionWindowSample(
+            accountId: quota.accountId,
+            tool: quota.tool,
+            bucketId: bucket.id,
+            windowEnd: resetAt,
+            windowStart: bucket.rawWindowSeconds.map {
+                resetAt.addingTimeInterval(-TimeInterval($0))
+            },
+            rawWindowSeconds: bucket.rawWindowSeconds,
+            peakUsedPercent: used,
+            lastUsedPercent: used,
+            observationCount: 1,
+            firstSeenAt: now,
+            lastSeenAt: now
+        )
+    }
+
+    // MARK: - Persistence
 
     private func clamp(_ value: Double) -> Double {
         guard value.isFinite else { return 0 }
         return min(100, max(0, value))
     }
 
+    private func sampleSortDate(_ sample: SubscriptionWindowSample) -> Date {
+        sample.completedAt ?? sample.lastSeenAt
+    }
+
     private func load() -> Storage {
-        if let cached = cachedStorage { return cached }
+        if let cachedStorage { return cachedStorage }
         if let attrs = try? FileManager.default.attributesOfItem(atPath: fileURL.path),
            let size = (attrs[.size] as? NSNumber)?.intValue,
            size > Self.maxFileBytes {
@@ -192,17 +300,11 @@ public actor SubscriptionHistoryStore {
             return empty
         }
         guard let data = try? Data(contentsOf: fileURL),
+              let header = try? JSONDecoder().decode(VersionHeader.self, from: data),
+              header.schemaVersion == Self.storageSchemaVersion,
               let storage = try? JSONDecoder().decode(Storage.self, from: data)
         else {
             let empty = Storage()
-            cachedStorage = empty
-            return empty
-        }
-        if storage.schemaVersion > Self.storageSchemaVersion {
-            // Future schema we don't understand — drop and start fresh
-            // rather than risk corrupting the user's newer data.
-            let empty = Storage()
-            persist(empty)
             cachedStorage = empty
             return empty
         }
@@ -235,17 +337,19 @@ public actor SubscriptionHistoryStore {
     }
 
     private func scheduleFlush(after delay: TimeInterval) {
-        if pendingFlushTask != nil { return }
-        let nanoseconds = UInt64(max(0.05, delay) * 1_000_000_000)
+        guard pendingFlushTask == nil else { return }
         pendingFlushTask = Task { [weak self] in
-            try? await Task.sleep(nanoseconds: nanoseconds)
+            try? await Task.sleep(nanoseconds: UInt64(max(0.05, delay) * 1_000_000_000))
             await self?.flushPendingWrites()
         }
     }
 
     private func pruneInPlace(_ storage: inout Storage, retentionDays: Int, now: Date) {
-        if CostDataSettings.isUnlimitedRetention(retentionDays) { return }
+        guard !CostDataSettings.isUnlimitedRetention(retentionDays) else { return }
         let cutoff = now.addingTimeInterval(-TimeInterval(retentionDays) * 86_400)
-        storage.samples.removeAll { $0.windowEnd < cutoff }
+        storage.samples.removeAll {
+            let relevantDate = $0.completedAt ?? $0.lastSeenAt
+            return relevantDate < cutoff
+        }
     }
 }

--- a/Tests/VibeBarCoreTests/AlibabaTokenPlanParserTests.swift
+++ b/Tests/VibeBarCoreTests/AlibabaTokenPlanParserTests.swift
@@ -62,7 +62,10 @@ final class AlibabaTokenPlanParserTests: XCTestCase {
         XCTAssertEqual(snap.buckets.count, 1)
         let bucket = snap.buckets[0]
         XCTAssertEqual(bucket.id, "alibabaTokenPlan.\(cnProductCode).standard")
-        XCTAssertEqual(bucket.groupTitle, "Standard")
+        XCTAssertEqual(bucket.title, "Monthly")
+        XCTAssertEqual(bucket.shortLabel, "Month")
+        XCTAssertEqual(bucket.rawWindowSeconds, 30 * 86_400)
+        XCTAssertEqual(bucket.groupTitle, "Team · Standard")
         XCTAssertEqual(snap.planName, "Token Plan · Team · Standard")
         // (25000 - 24999.5534) / 25000 * 100 ≈ 0.001786
         XCTAssertEqual(bucket.usedPercent, 0.001786, accuracy: 0.001)
@@ -112,8 +115,8 @@ final class AlibabaTokenPlanParserTests: XCTestCase {
         XCTAssertEqual(snap.buckets.count, 2)
         XCTAssertEqual(snap.buckets[0].usedPercent, 25.0, accuracy: 0.01)
         XCTAssertEqual(snap.buckets[1].usedPercent, 75.0, accuracy: 0.01)
-        XCTAssertEqual(snap.buckets[0].groupTitle, "Standard")
-        XCTAssertEqual(snap.buckets[1].groupTitle, "Advanced")
+        XCTAssertEqual(snap.buckets[0].groupTitle, "Team · Standard")
+        XCTAssertEqual(snap.buckets[1].groupTitle, "Team · Advanced")
     }
 
     func testFallsBackToFlatTotalValueWhenNoGroupList() throws {

--- a/Tests/VibeBarCoreTests/GeminiWebResponseParserTests.swift
+++ b/Tests/VibeBarCoreTests/GeminiWebResponseParserTests.swift
@@ -123,6 +123,18 @@ final class GeminiWebResponseParserTests: XCTestCase {
         XCTAssertNotNil(snapshot.buckets.first(where: { $0.id == GeminiWebResponseParser.weeklyUsageBucketId }))
     }
 
+    func testCurrentUltraPayloadMapsTierSixAndDropsInternalSentinel() throws {
+        let inner =
+            "[6,[" +
+            "[9999,0,4,null,null,[[[2,0]],4]]," +
+            "[238022,0.01611225,2,[[1784689500,0]]]," +
+            "[8187,0.32,1,[[1784557500,0]]]" +
+            "],false]"
+        let snapshot = try GeminiWebResponseParser.parse(data: Self.wireFormat(inner: inner))
+        XCTAssertEqual(snapshot.planName, "Ultra")
+        XCTAssertEqual(snapshot.buckets.map(\.id).sorted(), ["five_hour", "weekly"])
+    }
+
     func testParseClampsUsedPercentToZeroToHundred() throws {
         // Bogus fractions outside 0..1 should clamp to 0..100.
         let inner =

--- a/Tests/VibeBarCoreTests/KimiMiniMaxParserTests.swift
+++ b/Tests/VibeBarCoreTests/KimiMiniMaxParserTests.swift
@@ -254,6 +254,10 @@ final class MiniMaxParserTests: XCTestCase {
             .map(\.usedPercent)
             .sorted()
         XCTAssertEqual(fiveHourUsed.count, 2)
+        XCTAssertEqual(
+            snap.buckets.first { $0.id.hasSuffix(".general") }?.title,
+            "5 Hours"
+        )
         XCTAssertEqual(fiveHourUsed.first ?? -1, 0, accuracy: 0.5)   // video: 100% remaining
         XCTAssertEqual(fiveHourUsed.last ?? -1, 12, accuracy: 0.5)   // general text: 12% used
     }

--- a/Tests/VibeBarCoreTests/OverviewMasonryPlannerTests.swift
+++ b/Tests/VibeBarCoreTests/OverviewMasonryPlannerTests.swift
@@ -1,0 +1,58 @@
+import XCTest
+@testable import VibeBarCore
+
+final class OverviewMasonryPlannerTests: XCTestCase {
+    func testQuotaCardsBalanceBeforeCostCardsAreConsidered() {
+        let items: [OverviewMasonryPlanner.Item] = [
+            .init(id: "chatgpt", height: 300, phase: .quota),
+            .init(id: "claude", height: 280, phase: .quota),
+            .init(id: "gemini", height: 120, phase: .quota),
+            .init(id: "grok", height: 100, phase: .quota),
+            .init(id: "huge-cost", height: 900, phase: .cost)
+        ]
+
+        let plan = OverviewMasonryPlanner.plan(items: items, spacing: 12)
+        let leftQuota = Set(plan.positions.compactMap { id, position in
+            position.column == 0 && id != "huge-cost" ? id : nil
+        })
+        let rightQuota = Set(plan.positions.compactMap { id, position in
+            position.column == 1 && id != "huge-cost" ? id : nil
+        })
+
+        XCTAssertEqual(leftQuota.count, 2)
+        XCTAssertEqual(rightQuota.count, 2)
+        XCTAssertTrue(leftQuota == ["chatgpt", "grok"] || leftQuota == ["claude", "gemini"])
+    }
+
+    func testCostAssignmentStartsFromQuotaColumnHeights() {
+        let items: [OverviewMasonryPlanner.Item] = [
+            .init(id: "q1", height: 300, phase: .quota),
+            .init(id: "q2", height: 300, phase: .quota),
+            .init(id: "q3", height: 100, phase: .quota),
+            .init(id: "q4", height: 100, phase: .quota),
+            .init(id: "cost1", height: 220, phase: .cost),
+            .init(id: "cost2", height: 180, phase: .cost),
+            .init(id: "cost3", height: 140, phase: .cost)
+        ]
+
+        let plan = OverviewMasonryPlanner.plan(items: items, spacing: 10)
+        XCTAssertLessThan(abs(plan.columnHeights[0] - plan.columnHeights[1]), 200)
+    }
+
+    func testAuxiliaryCardsGreedilyFillTheShorterFinishedColumn() {
+        let items: [OverviewMasonryPlanner.Item] = [
+            .init(id: "q1", height: 200, phase: .quota),
+            .init(id: "q2", height: 190, phase: .quota),
+            .init(id: "q3", height: 180, phase: .quota),
+            .init(id: "q4", height: 170, phase: .quota),
+            .init(id: "cost", height: 300, phase: .cost),
+            .init(id: "aux1", height: 80, phase: .auxiliary),
+            .init(id: "aux2", height: 60, phase: .auxiliary)
+        ]
+
+        let plan = OverviewMasonryPlanner.plan(items: items, spacing: 10)
+        XCTAssertNotNil(plan.positions["aux1"])
+        XCTAssertNotNil(plan.positions["aux2"])
+        XCTAssertGreaterThan(plan.positions["aux1"]?.y ?? 0, 0)
+    }
+}

--- a/Tests/VibeBarCoreTests/QuotaRefreshSchedulerTests.swift
+++ b/Tests/VibeBarCoreTests/QuotaRefreshSchedulerTests.swift
@@ -46,13 +46,41 @@ final class QuotaRefreshSchedulerTests: XCTestCase {
         XCTAssertNil(second.error)
         XCTAssertNil(service.lastErrorByAccount[account.id])
     }
+
+    func testCredentialFailureSurfacesWhenCachedQuotaIsStale() async {
+        let account = AccountIdentity(id: "stale-gemini", tool: .gemini, source: .webCookie)
+        let staleDate = Date().addingTimeInterval(-2 * 3_600)
+        let service = QuotaService(
+            adapters: [.gemini: SequenceAdapter(tool: .gemini, results: [
+                .success(AccountQuota(
+                    accountId: account.id,
+                    tool: .gemini,
+                    buckets: [
+                        QuotaBucket(id: "weekly", title: "Weekly", shortLabel: "Wk", usedPercent: 1)
+                    ],
+                    queriedAt: staleDate
+                )),
+                .failure(.needsLogin)
+            ])],
+            mockProvider: { false }
+        )
+
+        _ = await service.refresh(account)
+        XCTAssertTrue(service.needsRefresh(accountId: account.id, maxAge: 600))
+        let fallback = await service.refresh(account)
+
+        XCTAssertEqual(fallback.error, .needsLogin)
+        XCTAssertEqual(service.lastErrorByAccount[account.id], .needsLogin)
+        XCTAssertEqual(fallback.buckets.count, 1)
+    }
 }
 
 private final class SequenceAdapter: QuotaAdapter, @unchecked Sendable {
-    let tool: ToolType = .claude
+    let tool: ToolType
     private var results: [Result<AccountQuota, QuotaError>]
 
-    init(results: [Result<AccountQuota, QuotaError>]) {
+    init(tool: ToolType = .claude, results: [Result<AccountQuota, QuotaError>]) {
+        self.tool = tool
         self.results = results
     }
 

--- a/Tests/VibeBarCoreTests/ServiceStatusIncidentTests.swift
+++ b/Tests/VibeBarCoreTests/ServiceStatusIncidentTests.swift
@@ -70,50 +70,11 @@ final class ServiceStatusIncidentTests: XCTestCase {
         XCTAssertEqual(snap.effectiveDescription, "All Systems Operational")
     }
 
-    func testDisplayUptimePrefersAdjustedWhenLower() {
+    func testDisplayUptimeIgnoresSyntheticIncidentDuration() {
         let dented = snapshot(indicator: .none, incidents: [], adjustedUptime: 99.83)
-        XCTAssertEqual(dented.displayUptimePercent, 99.83, accuracy: 0.001)
+        XCTAssertEqual(dented.displayUptimePercent, 100, accuracy: 0.001)
         let clean = snapshot(indicator: .none, incidents: [], adjustedUptime: nil)
         XCTAssertEqual(clean.displayUptimePercent, 100, accuracy: 0.001)
-    }
-
-    func testIncidentAdjustedUptimeMergesOverlaps() {
-        // Two incidents: 60min and an overlapping 30min inside it, plus a
-        // separate 30min — union is 90min of downtime over a 90-day window.
-        let intervals: [(start: Date, end: Date)] = [
-            (now.addingTimeInterval(-7_200), now.addingTimeInterval(-3_600)),   // 60 min
-            (now.addingTimeInterval(-5_400), now.addingTimeInterval(-4_500)),   // inside previous
-            (now.addingTimeInterval(-90_000), now.addingTimeInterval(-88_200))  // separate 30 min
-        ]
-        let uptime = ServiceStatusClient.incidentAdjustedUptime(
-            officialPercent: 100,
-            intervals: intervals,
-            dayCount: 90,
-            now: now
-        )
-        let expected = (1.0 - (5_400.0 / (90.0 * 86_400.0))) * 100
-        XCTAssertEqual(uptime ?? -1, expected, accuracy: 0.0001)
-    }
-
-    func testIncidentAdjustedUptimeClampsToWindowAndTakesOfficialMin() {
-        // Interval mostly before the window — only the in-window slice counts.
-        let intervals: [(start: Date, end: Date)] = [
-            (now.addingTimeInterval(-91 * 86_400), now.addingTimeInterval(-90 * 86_400 + 3_600))
-        ]
-        let uptime = ServiceStatusClient.incidentAdjustedUptime(
-            officialPercent: 99.0,
-            intervals: intervals,
-            dayCount: 90,
-            now: now
-        )
-        XCTAssertEqual(uptime ?? -1, 99.0, accuracy: 0.0001)
-
-        XCTAssertNil(ServiceStatusClient.incidentAdjustedUptime(
-            officialPercent: 100,
-            intervals: [],
-            dayCount: 90,
-            now: now
-        ))
     }
 
     /// Cached snapshots from before the incident-overlay schema must still

--- a/Tests/VibeBarCoreTests/SubscriptionHistoryStoreTests.swift
+++ b/Tests/VibeBarCoreTests/SubscriptionHistoryStoreTests.swift
@@ -62,8 +62,39 @@ final class SubscriptionHistoryStoreTests: XCTestCase {
         ])
         await store.observe(q, now: now, retentionDays: 30)
         let all = await store.allSamples()
-        XCTAssertEqual(Set(all.map(\.bucketId)), ["weekly", "weekly_sonnet"])
-        XCTAssertFalse(all.contains { $0.bucketId == "five_hour" })
+        XCTAssertEqual(Set(all.map(\.bucketId)), ["five_hour", "weekly", "weekly_sonnet"])
+    }
+
+    func testGeminiProductTracksAllThreeFiveHourAndWeeklySeries() async throws {
+        let (store, _, cleanup) = try makeTempStore()
+        defer { cleanup() }
+        let now = Date()
+        let fiveHourReset = now.addingTimeInterval(12_000)
+        let weeklyReset = now.addingTimeInterval(400_000)
+
+        await store.observe(quota(
+            accountId: "web-gemini",
+            tool: .gemini,
+            buckets: [
+                bucket(id: "five_hour", usedPercent: 1, resetAt: fiveHourReset, rawWindowSeconds: 18_000),
+                bucket(id: "weekly", usedPercent: 2, resetAt: weeklyReset, rawWindowSeconds: 604_800)
+            ]
+        ), now: now, retentionDays: 30)
+        await store.observe(quota(
+            accountId: "local-antigravity",
+            tool: .antigravity,
+            buckets: [
+                bucket(id: "gemini_five_hour", usedPercent: 3, resetAt: fiveHourReset, rawWindowSeconds: 18_000, groupTitle: "Gemini Models"),
+                bucket(id: "gemini_weekly", usedPercent: 4, resetAt: weeklyReset, rawWindowSeconds: 604_800, groupTitle: "Gemini Models"),
+                bucket(id: "claude_gpt_five_hour", usedPercent: 5, resetAt: fiveHourReset, rawWindowSeconds: 18_000, groupTitle: "Claude and GPT Models"),
+                bucket(id: "claude_gpt_weekly", usedPercent: 6, resetAt: weeklyReset, rawWindowSeconds: 604_800, groupTitle: "Claude and GPT Models")
+            ]
+        ), now: now, retentionDays: 30)
+
+        let all = await store.allSamples()
+        XCTAssertEqual(all.count, 6)
+        XCTAssertEqual(all.filter { $0.rawWindowSeconds == 18_000 }.count, 3)
+        XCTAssertEqual(all.filter { $0.rawWindowSeconds == 604_800 }.count, 3)
     }
 
     func testTwoObservationsSameWindowMaxMerge() async throws {
@@ -73,19 +104,20 @@ final class SubscriptionHistoryStoreTests: XCTestCase {
         let resetAt = now.addingTimeInterval(3 * 86_400)
 
         let first = quota(tool: .codex, buckets: [
-            bucket(id: "weekly", usedPercent: 88, resetAt: resetAt, rawWindowSeconds: 604_800)
+            bucket(id: "weekly", usedPercent: 30, resetAt: resetAt, rawWindowSeconds: 604_800)
         ])
         let second = quota(tool: .codex, buckets: [
-            bucket(id: "weekly", usedPercent: 30, resetAt: resetAt, rawWindowSeconds: 604_800)
+            bucket(id: "weekly", usedPercent: 44, resetAt: resetAt.addingTimeInterval(90), rawWindowSeconds: 604_800)
         ])
         await store.observe(first, now: now, retentionDays: 30)
         await store.observe(second, now: now.addingTimeInterval(60), retentionDays: 30)
         let samples = await store.samples(accountId: "acct-test", bucketId: "weekly")
         XCTAssertEqual(samples.count, 1)
         let sample = try XCTUnwrap(samples.first)
-        XCTAssertEqual(sample.peakUsedPercent, 88, accuracy: 0.001)
-        XCTAssertEqual(sample.lastUsedPercent, 30, accuracy: 0.001)
+        XCTAssertEqual(sample.peakUsedPercent, 44, accuracy: 0.001)
+        XCTAssertEqual(sample.lastUsedPercent, 44, accuracy: 0.001)
         XCTAssertEqual(sample.observationCount, 2)
+        XCTAssertFalse(sample.isCompleted)
     }
 
     func testNewResetAtCreatesNewSample() async throws {
@@ -105,11 +137,12 @@ final class SubscriptionHistoryStoreTests: XCTestCase {
         await store.observe(second, now: firstReset.addingTimeInterval(60), retentionDays: 30)
         let samples = await store.samples(accountId: "acct-test", bucketId: "weekly")
         XCTAssertEqual(samples.count, 2)
-        XCTAssertEqual(samples.map(\.windowEnd), [secondReset, firstReset])
-        // Old window's peak must not be touched by the new window.
-        let old = try XCTUnwrap(samples.first { $0.windowEnd == firstReset })
+        let old = try XCTUnwrap(samples.first { $0.isCompleted })
         XCTAssertEqual(old.peakUsedPercent, 95, accuracy: 0.001)
         XCTAssertEqual(old.observationCount, 1)
+        XCTAssertEqual(old.completionReason, .refillDetected)
+        XCTAssertEqual(old.remainingPercentAtReset, 5, accuracy: 0.001)
+        XCTAssertEqual(samples.filter { !$0.isCompleted }.count, 1)
     }
 
     func testRetentionPruneDropsOldSamples() async throws {
@@ -128,6 +161,13 @@ final class SubscriptionHistoryStoreTests: XCTestCase {
         )
         await store.observe(
             quota(tool: .claude, buckets: [
+                bucket(id: "weekly", usedPercent: 0, resetAt: oldReset.addingTimeInterval(7 * 86_400), rawWindowSeconds: 604_800)
+            ]),
+            now: oldReset,
+            retentionDays: 0
+        )
+        await store.observe(
+            quota(tool: .claude, buckets: [
                 bucket(id: "weekly", usedPercent: 70, resetAt: recentReset, rawWindowSeconds: 604_800)
             ]),
             now: now,
@@ -135,8 +175,8 @@ final class SubscriptionHistoryStoreTests: XCTestCase {
         )
         await store.prune(retentionDays: 30, now: now)
         let samples = await store.samples(accountId: "acct-test", bucketId: "weekly")
-        XCTAssertEqual(samples.count, 1)
-        XCTAssertEqual(samples.first?.windowEnd, recentReset)
+        XCTAssertFalse(samples.contains { $0.peakUsedPercent == 50 })
+        XCTAssertEqual(samples.filter { !$0.isCompleted }.count, 1)
     }
 
     func testRoundTripPersistence() async throws {
@@ -176,7 +216,7 @@ final class SubscriptionHistoryStoreTests: XCTestCase {
         XCTAssertTrue(all.isEmpty, "Misc tool quotas should not be recorded")
     }
 
-    func testWindowGatingDropsFiveHourBuckets() async throws {
+    func testFiveHourBucketsAreTrackedByRefill() async throws {
         let (store, _, cleanup) = try makeTempStore()
         defer { cleanup() }
         let now = Date()
@@ -188,8 +228,16 @@ final class SubscriptionHistoryStoreTests: XCTestCase {
             now: now,
             retentionDays: 30
         )
+        await store.observe(
+            quota(tool: .claude, buckets: [
+                bucket(id: "five_hour", usedPercent: 5, resetAt: reset.addingTimeInterval(5 * 3_600), rawWindowSeconds: 18_000)
+            ]),
+            now: now.addingTimeInterval(60),
+            retentionDays: 30
+        )
         let all = await store.allSamples()
-        XCTAssertTrue(all.isEmpty, "5h buckets should be ignored")
+        XCTAssertEqual(all.count, 2)
+        XCTAssertEqual(all.filter(\.isCompleted).count, 1)
     }
 
     func testGrokWeeklyBucketIsTracked() async throws {
@@ -210,5 +258,49 @@ final class SubscriptionHistoryStoreTests: XCTestCase {
         XCTAssertEqual(sample.peakUsedPercent, 55, accuracy: 0.001)
         XCTAssertEqual(sample.lastUsedPercent, 55, accuracy: 0.001)
         XCTAssertNotNil(sample.windowStart)
+    }
+
+    func testResetAtDriftDoesNotCreateFakeCycles() async throws {
+        let (store, _, cleanup) = try makeTempStore()
+        defer { cleanup() }
+        let now = Date()
+        let reset = now.addingTimeInterval(4 * 86_400)
+        await store.observe(
+            quota(tool: .claude, buckets: [
+                bucket(id: "weekly", usedPercent: 20, resetAt: reset, rawWindowSeconds: 604_800)
+            ]),
+            now: now,
+            retentionDays: 30
+        )
+        await store.observe(
+            quota(tool: .claude, buckets: [
+                bucket(id: "weekly", usedPercent: 21, resetAt: reset.addingTimeInterval(180), rawWindowSeconds: 604_800)
+            ]),
+            now: now.addingTimeInterval(60),
+            retentionDays: 30
+        )
+
+        let samples = await store.samples(accountId: "acct-test", bucketId: "weekly")
+        XCTAssertEqual(samples.count, 1)
+        XCTAssertEqual(samples[0].observationCount, 2)
+        XCTAssertFalse(samples[0].isCompleted)
+    }
+
+    func testLegacyTimelineImportsOnlyDetectedRefills() async throws {
+        let (store, _, cleanup) = try makeTempStore()
+        defer { cleanup() }
+        let now = Date()
+        let points = [
+            FillTimelinePoint(accountId: "acct-test", tool: .claude, bucketId: "weekly", slotStart: now, usedPercent: 20, sampledAt: now),
+            FillTimelinePoint(accountId: "acct-test", tool: .claude, bucketId: "weekly", slotStart: now.addingTimeInterval(3_600), usedPercent: 75, sampledAt: now.addingTimeInterval(3_600)),
+            FillTimelinePoint(accountId: "acct-test", tool: .claude, bucketId: "weekly", slotStart: now.addingTimeInterval(7_200), usedPercent: 4, sampledAt: now.addingTimeInterval(7_200))
+        ]
+        await store.importLegacyTimeline(points, retentionDays: 30)
+        await store.importLegacyTimeline(points, retentionDays: 30)
+
+        let samples = await store.samples(accountId: "acct-test", bucketId: "weekly")
+        XCTAssertEqual(samples.count, 1)
+        XCTAssertEqual(samples[0].peakUsedPercent, 75, accuracy: 0.001)
+        XCTAssertEqual(samples[0].completionReason, .legacyTimelineMigration)
     }
 }

--- a/Tests/VibeBarCoreTests/TencentTokenPlanParserTests.swift
+++ b/Tests/VibeBarCoreTests/TencentTokenPlanParserTests.swift
@@ -74,6 +74,9 @@ final class TencentTokenPlanParserTests: XCTestCase {
         XCTAssertEqual(snap.buckets.count, 1)
         let bucket = snap.buckets[0]
         XCTAssertEqual(bucket.id, "tencentTokenPlan.generic.tp_standard")
+        XCTAssertEqual(bucket.title, "Monthly")
+        XCTAssertEqual(bucket.shortLabel, "Month")
+        XCTAssertEqual(bucket.rawWindowSeconds, 30 * 86_400)
         XCTAssertEqual(bucket.groupTitle, "Standard")
         // 51 / 100_000_000 * 100 ≈ 0.000051
         XCTAssertEqual(bucket.usedPercent, 0.000051, accuracy: 0.00001)


### PR DESCRIPTION
## Summary
- balance the four quota cards first from live measured heights, then place Cost and analytics cards into the shortest layout
- replace point-sample Fill History with reset-cycle utilization and track every Codex, Claude, Gemini Web, and AntiGravity quota bucket
- add global and yesterday Cost History, day/week/month granularity, and expandable model detail
- make Gemini quota strictly gemini.google.com Web-only, refresh stale caches, and retry fresh browser cookies without CLI/OAuth fallback
- correct Anthropic incident history rendering and normalize MiniMax, Alibaba, and Tencent period labels

## Test plan
- [x] swift test (621 tests)
- [x] ./Scripts/build_app.sh release
- [x] codesign --verify --deep --strict ".build/Vibe Bar.app"
- [x] confirm empty entitlements and no app sandbox

Co-Authored-By: Codex <noreply@openai.com>