### PR TITLE
Fix Gemini web quota and cost history layout

### DIFF
--- a/Sources/VibeBarApp/Views/CostHistoryView.swift
+++ b/Sources/VibeBarApp/Views/CostHistoryView.swift
@@ -19,7 +19,8 @@ private struct CostChartPoint: Identifiable, Equatable {
 }
 
 /// Cost history with hour/day/week/month grouping, model-aware hover detail,
-/// and a click-to-pin model inspector that stays out of the plot area.
+/// and a click-to-pin model inspector presented in a fixed-size popover so
+/// inspecting a bar never changes the card height or reflows the masonry.
 struct CostHistoryView: View {
     let tool: ToolType
     let snapshot: CostSnapshot?
@@ -41,42 +42,52 @@ struct CostHistoryView: View {
         let peak = points.map(\.costUSD).max() ?? 0
 
         VStack(alignment: .leading, spacing: density.cardSpacing) {
-            HStack(alignment: .firstTextBaseline, spacing: 6) {
-                Text(titleOverride ?? "Cost History")
-                    .font(.system(size: density.bucketTitleFontSize, weight: .semibold))
-                Spacer(minLength: 4)
-                CostTimeframeSelector(selection: $timeframe, density: density)
-                if availableGranularities.count > 1 {
-                    Menu {
-                        ForEach(availableGranularities) { option in
-                            Button {
-                                granularity = option
-                                clearSelection()
-                            } label: {
-                                if option == granularity {
-                                    Label(option.rawValue, systemImage: "checkmark")
-                                } else {
-                                    Text(option.rawValue)
+            VStack(alignment: .trailing, spacing: 4) {
+                HStack(alignment: .firstTextBaseline, spacing: 6) {
+                    Text(titleOverride ?? "Cost History")
+                        .font(.system(size: density.bucketTitleFontSize, weight: .semibold))
+                    Spacer(minLength: 8)
+                    SectionRefreshButton(isRefreshing: false) {
+                        environment.refreshCostUsage()
+                    }
+                }
+                HStack(spacing: 6) {
+                    Spacer(minLength: 0)
+                    CostTimeframeSelector(selection: $timeframe, density: density)
+                        .fixedSize(horizontal: true, vertical: false)
+                    if availableGranularities.count > 1 {
+                        Menu {
+                            ForEach(availableGranularities) { option in
+                                Button {
+                                    granularity = option
+                                    clearSelection()
+                                } label: {
+                                    if option == granularity {
+                                        Label(option.rawValue, systemImage: "checkmark")
+                                    } else {
+                                        Text(option.rawValue)
+                                    }
                                 }
                             }
+                        } label: {
+                            Text("By \(granularity.rawValue)")
+                                .font(.system(size: max(9, density.segmentedFontSize - 1), weight: .semibold))
                         }
-                    } label: {
-                        Text("By \(granularity.rawValue)")
-                            .font(.system(size: max(9, density.segmentedFontSize - 1), weight: .semibold))
+                        .menuStyle(.borderlessButton)
+                        .focusable(false)
+                        .fixedSize()
                     }
-                    .menuStyle(.borderlessButton)
-                    .fixedSize()
-                }
-                SectionRefreshButton(isRefreshing: false) {
-                    environment.refreshCostUsage()
                 }
             }
 
             chart(points: points, average: average)
-
-            if let pinned = pinnedPoint(in: points) {
-                pinnedModelPanel(pinned)
-            }
+                .popover(isPresented: pinnedPopoverBinding(points: points), arrowEdge: .top) {
+                    if let pinned = pinnedPoint(in: points) {
+                        pinnedModelPanel(pinned)
+                            .frame(width: 300)
+                            .padding(10)
+                    }
+                }
 
             HStack(spacing: 16) {
                 metric(label: "Total", value: formatCost(total))
@@ -98,9 +109,7 @@ struct CostHistoryView: View {
                 .stroke(.separator.opacity(0.4), lineWidth: 0.5)
         )
         .onChange(of: timeframe) { _, _ in
-            if !availableGranularities.contains(granularity) {
-                granularity = availableGranularities.first ?? .day
-            }
+            granularity = preferredGranularity(for: timeframe)
             clearSelection()
         }
     }
@@ -181,8 +190,9 @@ struct CostHistoryView: View {
                 }
             }
             .chartXAxis {
-                AxisMarks(values: .stride(by: axisStride.component, count: axisStride.count)) { value in
-                    AxisValueLabel(format: axisStride.format)
+                let stride = axisStride(for: points)
+                AxisMarks(values: .stride(by: stride.component, count: stride.count)) { value in
+                    AxisValueLabel(format: stride.format)
                         .font(.system(size: 9))
                 }
             }
@@ -323,6 +333,14 @@ struct CostHistoryView: View {
         }
     }
 
+    private func preferredGranularity(for timeframe: CostTimeframe) -> CostHistoryGranularity {
+        switch timeframe {
+        case .today, .yesterday: .hour
+        case .week, .month: .day
+        case .all: .month
+        }
+    }
+
     private var chartPoints: [CostChartPoint] {
         guard let snapshot else { return [] }
         if timeframe == .today || timeframe == .yesterday {
@@ -438,13 +456,30 @@ struct CostHistoryView: View {
         let format: Date.FormatStyle
     }
 
-    private var axisStride: AxisStride {
+    private func axisStride(for points: [CostChartPoint]) -> AxisStride {
+        let desiredLabels = 6
+        let adaptiveCount = max(1, Int(ceil(Double(max(1, points.count)) / Double(desiredLabels))))
         switch granularity {
-        case .hour: .init(component: .hour, count: 4, format: .dateTime.hour())
+        case .hour:
+            return AxisStride(component: .hour, count: 4, format: .dateTime.hour())
         case .day:
-            .init(component: .day, count: timeframe == .month ? 5 : 1, format: .dateTime.day().month(.abbreviated))
-        case .week: .init(component: .weekOfYear, count: 1, format: .dateTime.day().month(.abbreviated))
-        case .month: .init(component: .month, count: 1, format: .dateTime.month(.abbreviated).year(.twoDigits))
+            return AxisStride(
+                component: .day,
+                count: timeframe == .all ? adaptiveCount : (timeframe == .month ? 5 : 1),
+                format: .dateTime.day().month(.abbreviated)
+            )
+        case .week:
+            return AxisStride(
+                component: .weekOfYear,
+                count: timeframe == .all ? adaptiveCount : 1,
+                format: .dateTime.day().month(.abbreviated)
+            )
+        case .month:
+            return AxisStride(
+                component: .month,
+                count: timeframe == .all ? adaptiveCount : 1,
+                format: .dateTime.month(.abbreviated).year(.twoDigits)
+            )
         }
     }
 
@@ -454,6 +489,15 @@ struct CostHistoryView: View {
 
     private func pinnedPoint(in points: [CostChartPoint]) -> CostChartPoint? {
         pinnedDate.flatMap { date in points.first { $0.date == date } }
+    }
+
+    private func pinnedPopoverBinding(points: [CostChartPoint]) -> Binding<Bool> {
+        Binding(
+            get: { pinnedPoint(in: points) != nil },
+            set: { isPresented in
+                if !isPresented { pinnedDate = nil }
+            }
+        )
     }
 
     private func nearestPoint(to date: Date, in points: [CostChartPoint]) -> CostChartPoint? {

--- a/Sources/VibeBarApp/Views/FillTimelineChart.swift
+++ b/Sources/VibeBarApp/Views/FillTimelineChart.swift
@@ -115,10 +115,16 @@ struct FillTimelineChart: View {
         let bucket = series.bucket
         let window: String
         switch bucket.rawWindowSeconds {
-        case 18_000: window = "5h"
-        case 604_800: window = "Wk"
-        case 2_592_000: window = "Mo"
-        default: window = bucket.shortLabel
+        case 18_000: window = "5 Hours"
+        case 604_800: window = "Weekly"
+        case 2_592_000: window = "Monthly"
+        default:
+            switch bucket.shortLabel.lowercased() {
+            case "5h", "5 hr", "5 hrs": window = "5 Hours"
+            case "wk", "1w": window = "Weekly"
+            case "mo", "1m": window = "Monthly"
+            default: window = bucket.title
+            }
         }
         let group = bucket.groupTitle?.replacingOccurrences(of: " Models", with: "")
         let owner = group ?? (includeTool ? series.tool.toolName : nil)

--- a/Sources/VibeBarApp/Views/PopoverRoot.swift
+++ b/Sources/VibeBarApp/Views/PopoverRoot.swift
@@ -867,10 +867,10 @@ private struct ProviderCostStack: View {
     }
 }
 
-/// Sits above the per-provider columns: eight usage metrics in two rows on the
-/// left and current provider status on the right. Both halves get their own
-/// refresh button so the user can pull just-this-card data without firing the
-/// global header refresh.
+/// Sits above the per-provider columns: cost and token summary on the left,
+/// current provider status on the right. Cost intentionally gets more width
+/// because its metrics are denser while the four compact status tiles fit in
+/// the narrower column.
 private struct CombinedTotalsRow: View {
     let density: Theme.Density
 
@@ -889,10 +889,12 @@ private struct CombinedTotalsRow: View {
         let dailyHistory = CostSnapshotAggregator.combinedDailyHistory(snapshots)
         let totalCost = snapshots.reduce(0.0) { $0 + $1.allTimeCostUSD }
         let todayCost = snapshots.reduce(0.0) { $0 + $1.todayCostUSD }
+        let yesterdayCost = snapshots.reduce(0.0) { $0 + CostTimeframe.yesterday.cost(in: $1) }
         let weekCost = snapshots.reduce(0.0) { $0 + $1.last7DaysCostUSD }
         let monthCost = snapshots.reduce(0.0) { $0 + $1.last30DaysCostUSD }
         let totalTokens = snapshots.reduce(0) { $0 + $1.allTimeTokens }
         let todayTokens = snapshots.reduce(0) { $0 + $1.todayTokens }
+        let yesterdayTokens = snapshots.reduce(0) { $0 + CostTimeframe.yesterday.tokens(in: $1) }
         let weekTokens = snapshots.reduce(0) { $0 + $1.last7DaysTokens }
         let monthTokens = snapshots.reduce(0) { $0 + $1.last30DaysTokens }
         let overallFill = OverallFillRate.average(quotaService.lastSuccessByAccount)
@@ -919,8 +921,13 @@ private struct CombinedTotalsRow: View {
         }()
         let tokensPerMinute = Int((Double(todayTokens) / elapsedMinutesToday).rounded())
 
-        HStack(alignment: .top, spacing: density.interSectionSpacing) {
-            VStack(alignment: .leading, spacing: 8) {
+        GeometryReader { geometry in
+            let spacing = density.interSectionSpacing
+            let availableWidth = max(0, geometry.size.width - spacing)
+            let costWidth = availableWidth * 0.62
+
+            HStack(alignment: .top, spacing: spacing) {
+                VStack(alignment: .leading, spacing: 8) {
                 HStack(alignment: .firstTextBaseline) {
                     Text("Cost")
                         .font(.system(size: density.bucketTitleFontSize, weight: .semibold))
@@ -940,48 +947,66 @@ private struct CombinedTotalsRow: View {
                     }
                     .disabled(costService.isRefreshing)
                 }
-                HStack(alignment: .top, spacing: 0) {
-                    metric(label: "TOTAL COST", value: formatCost(totalCost), highlight: true)
-                    divider
-                    metric(label: "TODAY", value: formatCost(todayCost))
-                    divider
-                    metric(label: "7-DAY", value: formatCost(weekCost))
-                    divider
-                    metric(label: "30-DAY", value: formatCost(monthCost))
+                    HStack(alignment: .top, spacing: 0) {
+                        metric(label: "TOTAL COST", value: formatCost(totalCost), highlight: true)
+                        divider
+                        metric(label: "TODAY", value: formatCost(todayCost))
+                        divider
+                        metric(label: "YESTERDAY", value: formatCost(yesterdayCost))
+                        divider
+                        metric(label: "7-DAY", value: formatCost(weekCost))
+                        divider
+                        metric(label: "30-DAY", value: formatCost(monthCost))
+                    }
+                    HStack(alignment: .top, spacing: 0) {
+                        metric(label: "TOTAL TOK", value: formatTokens(totalTokens), highlight: true)
+                        divider
+                        metric(label: "TODAY TOK", value: formatTokens(todayTokens))
+                        divider
+                        metric(label: "YESTERDAY TOK", value: formatTokens(yesterdayTokens))
+                        divider
+                        metric(label: "7-DAY TOK", value: formatTokens(weekTokens))
+                        divider
+                        metric(label: "30-DAY TOK", value: formatTokens(monthTokens))
+                    }
+                    HStack(alignment: .top, spacing: 0) {
+                        metric(label: "PEAK DAY", value: formatCost(peakDayCost))
+                        divider
+                        metric(label: "PEAK DAY TOK", value: formatTokens(peakDayTokens))
+                        divider
+                        metric(label: "TPM", value: formatTokens(tokensPerMinute))
+                        divider
+                        metric(label: "FILL", value: formatFillPercent(overallFill))
+                    }
                 }
-                HStack(alignment: .top, spacing: 0) {
-                    metric(label: "TOTAL TOK", value: formatTokens(totalTokens), highlight: true)
-                    divider
-                    metric(label: "TODAY TOK", value: formatTokens(todayTokens))
-                    divider
-                    metric(label: "7-DAY TOK", value: formatTokens(weekTokens))
-                    divider
-                    metric(label: "30-DAY TOK", value: formatTokens(monthTokens))
-                }
-                HStack(alignment: .top, spacing: 0) {
-                    metric(label: "PEAK DAY", value: formatCost(peakDayCost))
-                    divider
-                    metric(label: "PEAK DAY TOK", value: formatTokens(peakDayTokens))
-                    divider
-                    metric(label: "TPM", value: formatTokens(tokensPerMinute))
-                    divider
-                    metric(label: "FILL", value: formatFillPercent(overallFill))
-                }
-            }
-            .padding(density.cardPadding)
-            .frame(maxWidth: .infinity, minHeight: summaryHeight, alignment: .topLeading)
-            .background(
-                RoundedRectangle(cornerRadius: density.cardCornerRadius, style: .continuous)
-                    .fill(.background.tertiary.opacity(0.6))
-            )
-            .overlay(
-                RoundedRectangle(cornerRadius: density.cardCornerRadius, style: .continuous)
-                    .stroke(.separator.opacity(0.4), lineWidth: 0.5)
-            )
+                .padding(density.cardPadding)
+                .frame(
+                    minWidth: costWidth,
+                    idealWidth: costWidth,
+                    maxWidth: costWidth,
+                    minHeight: summaryHeight,
+                    alignment: .topLeading
+                )
+                .background(
+                    RoundedRectangle(cornerRadius: density.cardCornerRadius, style: .continuous)
+                        .fill(.background.tertiary.opacity(0.6))
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: density.cardCornerRadius, style: .continuous)
+                        .stroke(.separator.opacity(0.4), lineWidth: 0.5)
+                )
 
-            OverviewStatusSummaryCard(density: density)
-                .frame(maxWidth: .infinity, minHeight: summaryHeight, alignment: .topLeading)
+                OverviewStatusSummaryCard(density: density)
+                    .frame(
+                        minWidth: availableWidth - costWidth,
+                        idealWidth: availableWidth - costWidth,
+                        maxWidth: availableWidth - costWidth,
+                        minHeight: summaryHeight,
+                        alignment: .topLeading
+                    )
+            }
         }
+        .frame(height: summaryHeight)
     }
 
     private var divider: some View {

--- a/Sources/VibeBarCore/BrowserCookies/BrowserCookieAccessGate.swift
+++ b/Sources/VibeBarCore/BrowserCookies/BrowserCookieAccessGate.swift
@@ -153,7 +153,9 @@ extension BrowserCookieClient {
 extension Browser {
     var usesKeychainForCookieDecryption: Bool {
         switch self {
-        case .safari, .firefox, .zen:
+        case .safari,
+             .firefox, .firefoxBeta, .firefoxDeveloperEdition, .firefoxNightly,
+             .zen:
             return false
         case .chrome, .chromeBeta, .chromeCanary,
              .arc, .arcBeta, .arcCanary,
@@ -163,7 +165,9 @@ extension Browser {
              .edge, .edgeBeta, .edgeCanary,
              .helium,
              .vivaldi,
-             .dia:
+             .dia,
+             .yandex,
+             .comet:
             return true
         @unknown default:
             // Treat unknown future browsers conservatively: assume

--- a/Sources/VibeBarCore/BrowserCookies/GeminiBrowserCookieImporter.swift
+++ b/Sources/VibeBarCore/BrowserCookies/GeminiBrowserCookieImporter.swift
@@ -73,8 +73,7 @@ public enum GeminiBrowserCookieImporter {
             }
 
             for store in stores {
-                let pairs = store.records.map { (name: $0.name, value: $0.value) }
-                guard let header = sessionHeader(from: pairs) else { continue }
+                guard let header = sessionHeader(from: store.records) else { continue }
                 let label = "\(browser.displayName) (\(store.store.profile.name))"
                 return Result(
                     header: header,
@@ -95,5 +94,38 @@ public enum GeminiBrowserCookieImporter {
             .map { "\($0.name)=\($0.value)" }
             .joined(separator: "; ")
         return GeminiWebCookieStore.minimizedCookieHeader(from: raw)
+    }
+
+    /// Builds the exact Cookie header a browser would send to Gemini's Usage
+    /// page. A flat name/value projection is not sufficient because Chrome
+    /// may contain the same cookie name for the host, parent domain, and
+    /// multiple paths. Choosing the most-specific matching record first is
+    /// what made the live Web quota request authenticate reliably.
+    static func sessionHeader(
+        from records: [BrowserCookieRecord],
+        host: String = "gemini.google.com",
+        path: String = "/usage"
+    ) -> String? {
+        let matching = records.filter { record in
+            let domain = record.domain.trimmingCharacters(in: CharacterSet(charactersIn: "."))
+            let cookiePath = record.path.isEmpty ? "/" : record.path
+            return (host == domain || host.hasSuffix(".\(domain)"))
+                && path.hasPrefix(cookiePath)
+                && !record.value.isEmpty
+        }
+        let ordered = matching.sorted { lhs, rhs in
+            let lhsPath = lhs.path.isEmpty ? "/" : lhs.path
+            let rhsPath = rhs.path.isEmpty ? "/" : rhs.path
+            if lhsPath.count != rhsPath.count { return lhsPath.count > rhsPath.count }
+            if lhs.domain.count != rhs.domain.count { return lhs.domain.count > rhs.domain.count }
+            return lhs.name < rhs.name
+        }
+
+        var names: Set<String> = []
+        let pairs = ordered.compactMap { record -> (name: String, value: String)? in
+            guard names.insert(record.name).inserted else { return nil }
+            return (record.name, record.value)
+        }
+        return sessionHeader(from: pairs)
     }
 }

--- a/Sources/VibeBarCore/Credentials/GeminiWebCookieStore.swift
+++ b/Sources/VibeBarCore/Credentials/GeminiWebCookieStore.swift
@@ -15,10 +15,11 @@ import Foundation
 /// The set of cookies that are kept after `minimizedCookieHeader(from:)`
 /// runs is intentionally conservative for now: until the spike against
 /// `gemini.google.com/usage` confirms the exact authentication contract,
-/// the store keeps every `__Secure-1PSID*` cookie plus the Google SAPISID
-/// family. Spike outcomes that prove a smaller set is sufficient should
-/// shrink `keptCookieNamePrefixes` accordingly and document why each
-/// remaining cookie is required.
+/// the store keeps the Google SID/PSID/PAPISID authentication family. A
+/// July 2026 live `gemini.google.com/usage` verification confirmed that
+/// `SIDCC` and both secure PAPISID cookies are required in addition to the
+/// older PSID set; omitting them returns a logged-out HTML shell even while
+/// the same Chrome profile is visibly signed in.
 public enum GeminiWebCookieStore {
     public enum CookieSource: Sendable {
         case webView
@@ -34,10 +35,13 @@ public enum GeminiWebCookieStore {
         "__Secure-1PSID",
         "__Secure-1PSIDTS",
         "__Secure-1PSIDCC",
+        "__Secure-1PAPISID",
         "__Secure-3PSID",
         "__Secure-3PSIDTS",
         "__Secure-3PSIDCC",
+        "__Secure-3PAPISID",
         "SID",
+        "SIDCC",
         "HSID",
         "SSID",
         "APISID",

--- a/Sources/VibeBarCore/Models/CostSnapshot.swift
+++ b/Sources/VibeBarCore/Models/CostSnapshot.swift
@@ -559,7 +559,7 @@ public enum CostTimeframe: String, CaseIterable, Identifiable, Sendable {
     public var shortLabel: String {
         switch self {
         case .today: return "Today"
-        case .yesterday: return "Yday"
+        case .yesterday: return "Yesterday"
         case .week:  return "7d"
         case .month: return "30d"
         case .all:   return "All"

--- a/Tests/VibeBarCoreTests/CostSnapshotTests.swift
+++ b/Tests/VibeBarCoreTests/CostSnapshotTests.swift
@@ -2,6 +2,11 @@ import XCTest
 @testable import VibeBarCore
 
 final class CostSnapshotTests: XCTestCase {
+    func testYesterdayUsesFullDisplayLabel() {
+        XCTAssertEqual(CostTimeframe.yesterday.label, "Yesterday")
+        XCTAssertEqual(CostTimeframe.yesterday.shortLabel, "Yesterday")
+    }
+
     func testRebasedForCurrentDayClearsStaleTodayTotalsAndHours() throws {
         let shanghai = try XCTUnwrap(TimeZone(secondsFromGMT: 8 * 3600))
         var calendar = Calendar(identifier: .gregorian)

--- a/Tests/VibeBarCoreTests/GeminiWebCookieStoreTests.swift
+++ b/Tests/VibeBarCoreTests/GeminiWebCookieStoreTests.swift
@@ -1,3 +1,4 @@
+import SweetCookieKit
 import XCTest
 @testable import VibeBarCore
 
@@ -6,11 +7,14 @@ import XCTest
 /// analytics cookies and require the authoritative `__Secure-1PSID`.
 final class GeminiWebCookieStoreTests: XCTestCase {
     func testMinimizedHeaderKeepsAuthCookies() {
-        let raw = "_ga=GA1.example; __Secure-1PSID=abc.synthetic-jwt; SAPISID=def-token; pref=light"
+        let raw = "_ga=GA1.example; __Secure-1PSID=abc.synthetic-jwt; SAPISID=def-token; SIDCC=sidcc; __Secure-1PAPISID=papi1; __Secure-3PAPISID=papi3; pref=light"
         let minimized = GeminiWebCookieStore.minimizedCookieHeader(from: raw)
         XCTAssertNotNil(minimized)
         XCTAssertTrue(minimized!.contains("__Secure-1PSID=abc.synthetic-jwt"))
         XCTAssertTrue(minimized!.contains("SAPISID=def-token"))
+        XCTAssertTrue(minimized!.contains("SIDCC=sidcc"))
+        XCTAssertTrue(minimized!.contains("__Secure-1PAPISID=papi1"))
+        XCTAssertTrue(minimized!.contains("__Secure-3PAPISID=papi3"))
         XCTAssertFalse(minimized!.contains("_ga"))
         XCTAssertFalse(minimized!.contains("pref="))
     }
@@ -83,5 +87,43 @@ final class GeminiWebCookieStoreTests: XCTestCase {
         let raw = "Cookie: __Secure-1PSID=abc; SAPISID=def"
         let normalized = GeminiWebCookieStore.normalizedCookieHeader(from: raw)
         XCTAssertEqual(normalized, "__Secure-1PSID=abc; SAPISID=def")
+    }
+
+    func testBrowserImporterUsesMostSpecificMatchingCookieRecord() throws {
+        let records = [
+            record(domain: "google.com", name: "__Secure-1PSID", path: "/", value: "parent"),
+            record(domain: "gemini.google.com", name: "__Secure-1PSID", path: "/", value: "host"),
+            record(domain: "google.com", name: "SIDCC", path: "/", value: "sidcc"),
+            record(domain: "google.com", name: "__Secure-1PAPISID", path: "/", value: "papi1"),
+            record(domain: "google.com", name: "__Secure-3PAPISID", path: "/", value: "papi3"),
+            record(domain: "other.google.com", name: "SAPISID", path: "/", value: "wrong-host"),
+            record(domain: "gemini.google.com", name: "SSID", path: "/other", value: "wrong-path")
+        ]
+
+        let header = try XCTUnwrap(GeminiBrowserCookieImporter.sessionHeader(from: records))
+        XCTAssertTrue(header.contains("__Secure-1PSID=host"))
+        XCTAssertFalse(header.contains("__Secure-1PSID=parent"))
+        XCTAssertTrue(header.contains("SIDCC=sidcc"))
+        XCTAssertTrue(header.contains("__Secure-1PAPISID=papi1"))
+        XCTAssertTrue(header.contains("__Secure-3PAPISID=papi3"))
+        XCTAssertFalse(header.contains("wrong-host"))
+        XCTAssertFalse(header.contains("wrong-path"))
+    }
+
+    private func record(
+        domain: String,
+        name: String,
+        path: String,
+        value: String
+    ) -> BrowserCookieRecord {
+        BrowserCookieRecord(
+            domain: domain,
+            name: name,
+            path: path,
+            value: value,
+            expires: nil,
+            isSecure: true,
+            isHTTPOnly: true
+        )
     }
 }


### PR DESCRIPTION
## Summary
- authenticate Gemini quota with the current gemini.google.com browser Cookie contract, including domain/path-specific selection and the minimal SIDCC/PAPISID set
- replace Fill History abbreviations with full period names
- keep Cost History card height stable by moving clicked model detail into a popover, prevent compressed controls/focus rings, and choose sensible All granularity and axis ticks
- spell out Yesterday everywhere, add it to the top Cost summary, and give Cost more width than Status

## Test plan
- [x] live Chrome Web quota request returned Ultra with 2 buckets
- [x] swift test (623 tests)
- [x] ./Scripts/build_app.sh release
- [x] codesign --verify --deep --strict ".build/Vibe Bar.app"
- [x] confirm empty entitlements and no app sandbox

Co-Authored-By: Codex <noreply@openai.com>