### PR TITLE
Restore SweetCookieKit 0.4 compatibility

### DIFF
--- a/Sources/VibeBarCore/BrowserCookies/BrowserCookieAccessGate.swift
+++ b/Sources/VibeBarCore/BrowserCookies/BrowserCookieAccessGate.swift
@@ -153,9 +153,7 @@ extension BrowserCookieClient {
 extension Browser {
     var usesKeychainForCookieDecryption: Bool {
         switch self {
-        case .safari,
-             .firefox, .firefoxBeta, .firefoxDeveloperEdition, .firefoxNightly,
-             .zen:
+        case .safari, .firefox, .zen:
             return false
         case .chrome, .chromeBeta, .chromeCanary,
              .arc, .arcBeta, .arcCanary,
@@ -165,9 +163,7 @@ extension Browser {
              .edge, .edgeBeta, .edgeCanary,
              .helium,
              .vivaldi,
-             .dia,
-             .yandex,
-             .comet:
+             .dia:
             return true
         @unknown default:
             // Treat unknown future browsers conservatively: assume


### PR DESCRIPTION
## Summary
- restore compatibility with the SweetCookieKit 0.4.0 revision locked by the main worktree
- keep the Gemini Web quota and Cost/Fill UI fixes from #87 unchanged

## Test plan
- [x] swift test with SweetCookieKit 0.4.0 (623 tests)
- [x] main build failure reproduced before the compatibility change

Co-Authored-By: Codex <noreply@openai.com>