### PR TITLE
Add personal quota forecasts and refine density layouts

### DIFF
--- a/Sources/VibeBarApp/ProviderBrandIcon.swift
+++ b/Sources/VibeBarApp/ProviderBrandIcon.swift
@@ -10,16 +10,7 @@ enum ProviderBrandIcon {
         tint: NSColor? = nil,
         appearance: NSAppearance? = nil
     ) -> NSImage? {
-        switch kind {
-        case .compact:
-            return vibeBarGlyphImage(size: size, tint: tint, appearance: appearance, includeStatusDot: false)
-        case .codex:
-            return image(for: ToolType.codex, size: size, tint: tint, appearance: appearance)
-        case .claude:
-            return image(for: ToolType.claude, size: size, tint: tint, appearance: appearance)
-        case .status:
-            return vibeBarGlyphImage(size: size, tint: tint, appearance: appearance, includeStatusDot: true)
-        }
+        vibeBarGlyphImage(size: size, tint: tint, appearance: appearance, includeStatusDot: false)
     }
 
     static func image(
@@ -50,18 +41,13 @@ enum ProviderBrandIcon {
     }
 
     static func fallbackSystemImage(for kind: MenuBarItemKind) -> String {
-        switch kind {
-        case .compact: return "chart.bar"
-        case .codex:   return "sparkle.magnifyingglass"
-        case .claude:  return "sparkles"
-        case .status:  return "chart.bar.xaxis"
-        }
+        "chart.bar"
     }
 
     static func fallbackSystemImage(for tool: ToolType) -> String {
         switch tool {
-        case .codex:  return fallbackSystemImage(for: MenuBarItemKind.codex)
-        case .claude: return fallbackSystemImage(for: MenuBarItemKind.claude)
+        case .codex:  return "sparkle.magnifyingglass"
+        case .claude: return "sparkles"
         case .alibaba, .alibabaTokenPlan, .gemini, .antigravity, .grok, .copilot, .zai, .minimax, .kimi, .cursor, .mimo, .iflytek, .tencentHunyuan, .tencentTokenPlan, .volcengine, .volcengineAgentPlan, .baiduQianfan, .openCodeGo, .kilo, .kiro, .ollama, .openRouter, .warp:
             return tool.miscFallbackSymbol
         }

--- a/Sources/VibeBarApp/StatusItemController.swift
+++ b/Sources/VibeBarApp/StatusItemController.swift
@@ -31,9 +31,6 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
     private static let popoverReopenSuppressionWindow: TimeInterval = 0.2
 
     private let compactStatusItem: NSStatusItem
-    private let codexStatusItem: NSStatusItem
-    private let claudeStatusItem: NSStatusItem
-    private let statusStatusItem: NSStatusItem
     private var popovers: [MenuBarItemKind: NSPopover] = [:]
     private let environment: AppEnvironment
     private let miniWindowController: MiniQuotaWindowController
@@ -48,23 +45,15 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
         self.miniWindowController = MiniQuotaWindowController()
         self.lastObservedDensities = Self.snapshotDensities(environment.settingsStore.settings)
         self.compactStatusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
-        self.codexStatusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
-        self.claudeStatusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
-        self.statusStatusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
         super.init()
 
         configureButton(for: .compact, item: compactStatusItem)
-        configureButton(for: .codex, item: codexStatusItem)
-        configureButton(for: .claude, item: claudeStatusItem)
-        configureButton(for: .status, item: statusStatusItem)
         observeChanges()
         renderMenuBar()
         // Restore mini window if the user had it open last session.
         miniWindowController.restoreIfNeeded(environment: environment)
-        // Pre-build only the compact popover's SwiftUI tree at launch. The
-        // others build on first click (still fast in practice). Eagerly
-        // warming all four left N copies of TimelineView(.periodic(by: 30))
-        // running for popovers the user might never open.
+        // Warm the one unified popover after launch so the first open is
+        // immediate without keeping retired standalone trees alive.
         DispatchQueue.main.async { [weak self] in
             _ = self?.popover(for: .compact)
         }
@@ -72,32 +61,16 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
 
     private func currentPopoverWidth(for kind: MenuBarItemKind) -> CGFloat {
         let settings = environment.settingsStore.settings
-        switch kind {
-        case .compact:
-            // The compact popover hosts three pages (Overview / Claude / OpenAI)
-            // and the user expects every sub-page to render identically to the
-            // matching dedicated menu bar item. Size the container to whichever
-            // of those is widest so switching pages never reflows the popover
-            // and the Claude/OpenAI sub-pages get exactly the same width as
-            // their stand-alone counterparts.
-            return max(
-                Theme.overviewDensity(for: settings.popoverDensity(for: .compact)).popoverWidth,
-                Theme.detailDensity(for: settings.popoverDensity(for: .claude)).popoverWidth,
-                Theme.detailDensity(for: settings.popoverDensity(for: .codex)).popoverWidth
-            )
-        case .codex, .claude:
-            return Theme.detailDensity(for: settings.popoverDensity(for: kind)).popoverWidth
-        case .status:
-            return Theme.density(for: settings.popoverDensity(for: kind)).popoverWidth
-        }
+        // Every tab uses the same density profile and the same stable window
+        // width. Page switches therefore never reflow the popover.
+        return max(
+            Theme.overviewDensity(for: settings.popoverDensity).popoverWidth,
+            Theme.detailDensity(for: settings.popoverDensity).popoverWidth
+        )
     }
 
     private static func snapshotDensities(_ settings: AppSettings) -> [MenuBarItemKind: PopoverDensity] {
-        var out: [MenuBarItemKind: PopoverDensity] = [:]
-        for kind in MenuBarItemKind.allCases {
-            out[kind] = settings.popoverDensity(for: kind)
-        }
-        return out
+        [.compact: settings.popoverDensity]
     }
 
     private static func makePopover(
@@ -113,9 +86,7 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
         popover.contentSize = NSSize(width: width, height: initialPopoverHeight)
         popover.contentViewController = NSHostingController(
             rootView: PopoverRoot(
-                kind: kind,
                 width: width,
-                closePopover: { [weak controller] in controller?.closePopover(kind: kind) },
                 onContentHeightChange: { [weak controller] height in controller?.resizePopover(kind: kind, toContentHeight: height) },
                 onToggleMiniWindow: { [weak controller] in controller?.toggleMiniWindow() }
             )
@@ -154,11 +125,8 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
             }
             .store(in: &cancellables)
 
-        // Coalesce all five render triggers into one throttled pipeline.
-        // Five separate sinks each calling renderMenuBar() (which lockFocus's
-        // four NSImages) was the most expensive hot path on settings or
-        // quota updates that fire several @Published values in quick
-        // succession.
+        // Coalesce all render triggers into one throttled pipeline so a burst
+        // of quota, settings, account, and status updates only redraws once.
         let renderTriggers: [AnyPublisher<Void, Never>] = [
             environment.settingsStore.$settings.map { _ in () }.eraseToAnyPublisher(),
             environment.quotaService.$lastSuccessByAccount.map { _ in () }.eraseToAnyPublisher(),
@@ -235,26 +203,11 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
         }
         guard !changed.isEmpty else { return }
         lastObservedDensities = newDensities
-        var toInvalidate = Set(changed)
-        // The compact popover renders Overview + Claude/OpenAI sub-pages and
-        // sizes itself to fit the widest of the three. A change to claude's
-        // or codex's density preference therefore needs to invalidate compact
-        // too, so the next open picks up the new max width.
-        if changed.contains(.claude) || changed.contains(.codex) {
-            toInvalidate.insert(.compact)
-        }
-        for kind in toInvalidate {
+        for kind in changed {
             if let popover = popovers[kind], popover.isShown {
                 popover.performClose(nil)
             }
             popovers.removeValue(forKey: kind)
-        }
-    }
-
-    private func closePopover(kind: MenuBarItemKind) {
-        guard let popover = popovers[kind] else { return }
-        if popover.isShown {
-            popover.performClose(nil)
         }
     }
 
@@ -279,13 +232,7 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
     }
 
     private func kindForTag(_ tag: Int) -> MenuBarItemKind {
-        switch tag {
-        case 1: return .compact
-        case 2: return .codex
-        case 3: return .claude
-        case 4: return .status
-        default: return .compact
-        }
+        .compact
     }
 
     private func toggleMiniWindow() {
@@ -450,15 +397,6 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
             button.image = nil
             button.imagePosition = .noImage
             removeTwoRowStatusContent(from: button)
-            if kind == .status && itemSettings.layout != .iconOnly {
-                installTwoRowImageContent(
-                    in: button,
-                    item: item,
-                    columns: serviceStatusTwoRowColumns(),
-                    kind: kind
-                )
-                continue
-            }
             switch itemSettings.layout {
             case .iconOnly:
                 installIconOnlyContent(in: button, item: item, kind: kind)
@@ -476,43 +414,6 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
                 button.attributedTitle = compactMenuTitle(for: itemSettings, settings: settings)
                 item.length = NSStatusItem.variableLength
             }
-        }
-    }
-
-    private func serviceStatusTwoRowColumns() -> [TwoRowMenuColumn] {
-        let top = providerStatusLine(tool: .codex, name: ToolType.codex.statusProviderName)
-        let bottom = providerStatusLine(tool: .claude, name: ToolType.claude.statusProviderName)
-        return [TwoRowMenuColumn(top: top, bottom: bottom)]
-    }
-
-    private func providerStatusLine(tool: ToolType, name: String) -> NSAttributedString {
-        let result = NSMutableAttributedString()
-        result.append(NSAttributedString(
-            string: "\(name) ",
-            attributes: [
-                .foregroundColor: NSColor.labelColor,
-                .font: NSFont.systemFont(ofSize: MenuBarStatusMetrics.twoRowFontSize, weight: .medium)
-            ]
-        ))
-        let snapshot = environment.serviceStatus.snapshotByTool[tool]
-        result.append(NSAttributedString(
-            string: "●",
-            attributes: [
-                .foregroundColor: providerStatusColor(snapshot?.indicator),
-                .font: NSFont.systemFont(ofSize: MenuBarStatusMetrics.twoRowFontSize, weight: .bold)
-            ]
-        ))
-        return result
-    }
-
-    private func providerStatusColor(_ indicator: StatusIndicator?) -> NSColor {
-        guard let indicator else { return NSColor.tertiaryLabelColor }
-        switch indicator {
-        case .none:         return NSColor.systemGreen
-        case .maintenance:  return NSColor.systemBlue
-        case .minor:        return NSColor.systemYellow
-        case .major:        return NSColor.systemOrange
-        case .critical:     return NSColor.systemRed
         }
     }
 
@@ -838,21 +739,11 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
     }
 
     private func statusItemTag(for kind: MenuBarItemKind) -> Int {
-        switch kind {
-        case .compact: return 1
-        case .codex:   return 2
-        case .claude:  return 3
-        case .status:  return 4
-        }
+        1
     }
 
     private func statusItem(for kind: MenuBarItemKind) -> NSStatusItem {
-        switch kind {
-        case .compact: return compactStatusItem
-        case .codex:   return codexStatusItem
-        case .claude:  return claudeStatusItem
-        case .status:  return statusStatusItem
-        }
+        compactStatusItem
     }
 
     private func barColor(for percent: Double, mode: DisplayMode) -> NSColor {

--- a/Sources/VibeBarApp/Views/ColumnMasonryLayout.swift
+++ b/Sources/VibeBarApp/Views/ColumnMasonryLayout.swift
@@ -31,18 +31,34 @@ extension View {
 }
 
 /// A live-measured waterfall whose policy is quota-first, then Cost, then
-/// supporting analytics. See `OverviewMasonryPlanner` for the tested optimizer.
+/// supporting analytics. Quota height changes trigger a fresh optimization;
+/// transient height changes below the quota block keep the current columns and
+/// only move later cards down within their existing column. This lets inline
+/// Cost History inspection expand naturally without reshuffling the Overview.
 struct ColumnMasonryLayout: Layout {
     var columns: Int = 2
     var spacing: CGFloat = 12
 
+    struct Cache {
+        var columnsByID: [String: Int] = [:]
+        var structureKey: [String] = []
+        var quotaHeightKey: [String: Int] = [:]
+        var columnWidthKey: Int?
+    }
+
+    func makeCache(subviews: Subviews) -> Cache { Cache() }
+
     func sizeThatFits(
         proposal: ProposedViewSize,
         subviews: Subviews,
-        cache: inout Void
+        cache: inout Cache
     ) -> CGSize {
         let totalWidth = proposal.width ?? 0
-        let plan = placementPlan(for: subviews, columnWidth: columnWidth(for: totalWidth))
+        let plan = placementPlan(
+            for: subviews,
+            columnWidth: columnWidth(for: totalWidth),
+            cache: &cache
+        )
         return CGSize(width: totalWidth, height: CGFloat(plan.columnHeights.max() ?? 0))
     }
 
@@ -50,10 +66,10 @@ struct ColumnMasonryLayout: Layout {
         in bounds: CGRect,
         proposal: ProposedViewSize,
         subviews: Subviews,
-        cache: inout Void
+        cache: inout Cache
     ) {
         let width = columnWidth(for: bounds.width)
-        let plan = placementPlan(for: subviews, columnWidth: width)
+        let plan = placementPlan(for: subviews, columnWidth: width, cache: &cache)
         for (index, subview) in subviews.enumerated() {
             let id = stableID(for: subview, index: index)
             guard let position = plan.positions[id] else { continue }
@@ -69,7 +85,11 @@ struct ColumnMasonryLayout: Layout {
         }
     }
 
-    private func placementPlan(for subviews: Subviews, columnWidth: CGFloat) -> OverviewMasonryPlanner.Plan {
+    private func placementPlan(
+        for subviews: Subviews,
+        columnWidth: CGFloat,
+        cache: inout Cache
+    ) -> OverviewMasonryPlanner.Plan {
         let proposal = ProposedViewSize(width: columnWidth, height: nil)
         let items = subviews.enumerated().map { index, subview in
             OverviewMasonryPlanner.Item(
@@ -78,8 +98,31 @@ struct ColumnMasonryLayout: Layout {
                 phase: subview[OverviewMasonryPhaseKey.self].corePhase
             )
         }
+        let structureKey = items.map { "\($0.phase.rawValue):\($0.id)" }
+        let quotaHeightKey = Dictionary(uniqueKeysWithValues:
+            items.filter { $0.phase == .quota }.map { item in
+                (item.id, Int((item.height * 2).rounded()))
+            }
+        )
+        let columnWidthKey = Int((columnWidth * 2).rounded())
+        if cache.columnsByID.isEmpty
+            || cache.structureKey != structureKey
+            || cache.quotaHeightKey != quotaHeightKey
+            || cache.columnWidthKey != columnWidthKey
+        {
+            let optimized = OverviewMasonryPlanner.plan(
+                items: items,
+                columns: columns,
+                spacing: Double(spacing)
+            )
+            cache.columnsByID = optimized.positions.mapValues(\.column)
+            cache.structureKey = structureKey
+            cache.quotaHeightKey = quotaHeightKey
+            cache.columnWidthKey = columnWidthKey
+        }
         return OverviewMasonryPlanner.plan(
             items: items,
+            fixedColumns: cache.columnsByID,
             columns: columns,
             spacing: Double(spacing)
         )

--- a/Sources/VibeBarApp/Views/ColumnMasonryLayout.swift
+++ b/Sources/VibeBarApp/Views/ColumnMasonryLayout.swift
@@ -31,27 +31,32 @@ extension View {
 }
 
 /// A live-measured waterfall whose policy is quota-first, then Cost, then
-/// supporting analytics. Quota height changes trigger a fresh optimization;
-/// transient height changes below the quota block keep the current columns and
-/// only move later cards down within their existing column. This lets inline
-/// Cost History inspection expand naturally without reshuffling the Overview.
+/// supporting analytics. It optimizes column assignment once for this layout
+/// lifetime, then keeps every existing card on that side until the Overview is
+/// entered again. Refreshes and inline expansion may move later cards down,
+/// but never reshuffle the visible dashboard.
 struct ColumnMasonryLayout: Layout {
-    var columns: Int = 2
-    var spacing: CGFloat = 12
-
-    struct Cache {
+    /// Owned by `OverviewWaterfall` for exactly one visible Overview session.
+    /// Keeping assignments outside SwiftUI's disposable Layout cache prevents
+    /// a live subview-set change from silently triggering a second shuffle.
+    final class Session {
         var columnsByID: [String: Int] = [:]
-        var structureKey: [String] = []
-        var quotaHeightKey: [String: Int] = [:]
-        var columnWidthKey: Int?
     }
 
-    func makeCache(subviews: Subviews) -> Cache { Cache() }
+    var columns: Int = 2
+    var spacing: CGFloat = 12
+    let session: Session
+
+    init(columns: Int = 2, spacing: CGFloat = 12, session: Session = Session()) {
+        self.columns = columns
+        self.spacing = spacing
+        self.session = session
+    }
 
     func sizeThatFits(
         proposal: ProposedViewSize,
         subviews: Subviews,
-        cache: inout Cache
+        cache: inout Void
     ) -> CGSize {
         let totalWidth = proposal.width ?? 0
         let plan = placementPlan(
@@ -66,7 +71,7 @@ struct ColumnMasonryLayout: Layout {
         in bounds: CGRect,
         proposal: ProposedViewSize,
         subviews: Subviews,
-        cache: inout Cache
+        cache: inout Void
     ) {
         let width = columnWidth(for: bounds.width)
         let plan = placementPlan(for: subviews, columnWidth: width, cache: &cache)
@@ -88,7 +93,7 @@ struct ColumnMasonryLayout: Layout {
     private func placementPlan(
         for subviews: Subviews,
         columnWidth: CGFloat,
-        cache: inout Cache
+        cache: inout Void
     ) -> OverviewMasonryPlanner.Plan {
         let proposal = ProposedViewSize(width: columnWidth, height: nil)
         let items = subviews.enumerated().map { index, subview in
@@ -98,31 +103,27 @@ struct ColumnMasonryLayout: Layout {
                 phase: subview[OverviewMasonryPhaseKey.self].corePhase
             )
         }
-        let structureKey = items.map { "\($0.phase.rawValue):\($0.id)" }
-        let quotaHeightKey = Dictionary(uniqueKeysWithValues:
-            items.filter { $0.phase == .quota }.map { item in
-                (item.id, Int((item.height * 2).rounded()))
-            }
-        )
-        let columnWidthKey = Int((columnWidth * 2).rounded())
-        if cache.columnsByID.isEmpty
-            || cache.structureKey != structureKey
-            || cache.quotaHeightKey != quotaHeightKey
-            || cache.columnWidthKey != columnWidthKey
-        {
+        // A zero-width speculative pass is not a real Overview placement.
+        // Wait for the first usable proposal, optimize once, then lock the
+        // assignment for the lifetime of this visible Overview session.
+        if session.columnsByID.isEmpty, columnWidth > 0, !items.isEmpty {
             let optimized = OverviewMasonryPlanner.plan(
                 items: items,
                 columns: columns,
                 spacing: Double(spacing)
             )
-            cache.columnsByID = optimized.positions.mapValues(\.column)
-            cache.structureKey = structureKey
-            cache.quotaHeightKey = quotaHeightKey
-            cache.columnWidthKey = columnWidthKey
+            session.columnsByID = optimized.positions.mapValues(\.column)
+        }
+        if session.columnsByID.isEmpty {
+            return OverviewMasonryPlanner.plan(
+                items: items,
+                columns: columns,
+                spacing: Double(spacing)
+            )
         }
         return OverviewMasonryPlanner.plan(
             items: items,
-            fixedColumns: cache.columnsByID,
+            fixedColumns: session.columnsByID,
             columns: columns,
             spacing: Double(spacing)
         )

--- a/Sources/VibeBarApp/Views/CostHistoryView.swift
+++ b/Sources/VibeBarApp/Views/CostHistoryView.swift
@@ -19,8 +19,10 @@ private struct CostChartPoint: Identifiable, Equatable {
 }
 
 /// Cost history with hour/day/week/month grouping, model-aware hover detail,
-/// and a click-to-pin model inspector drawn inside the card so inspecting a
-/// bar never creates a separate AppKit popover or reflows the masonry.
+/// and an inline model inspector. The inspector is absent until a point is
+/// selected, then expands as part of the card; `ColumnMasonryLayout` keeps the
+/// current column assignments stable while live item heights change so the
+/// expanded card does not jump across the Overview.
 struct CostHistoryView: View {
     let tool: ToolType
     let snapshot: CostSnapshot?
@@ -59,15 +61,10 @@ struct CostHistoryView: View {
                 }
             }
 
-            ZStack(alignment: .topTrailing) {
-                chart(points: points, average: average)
-                if let inspectedPoint {
-                    inspectedModelPanel(inspectedPoint)
-                        .frame(width: 300)
-                        .padding(.top, 4)
-                        .padding(.trailing, 4)
-                        .zIndex(2)
-                }
+            chart(points: points, average: average)
+
+            if inspectedPoint != nil {
+                inlineModelInspector
             }
 
             HStack(spacing: 16) {
@@ -243,53 +240,67 @@ struct CostHistoryView: View {
         .allowsHitTesting(false)
     }
 
-    private func inspectedModelPanel(_ point: CostChartPoint) -> some View {
-        VStack(alignment: .leading, spacing: 5) {
-            HStack {
-                Text("Models · \(tooltipDate(point.date))")
-                    .font(.system(size: 10, weight: .semibold))
-                Spacer()
-                Text("Top \(min(10, point.models.count)) of \(point.models.count)")
-                    .font(.system(size: 9))
+    @ViewBuilder
+    private var inlineModelInspector: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Divider()
+                .opacity(0.35)
+
+            if let point = inspectedPoint {
+                HStack(spacing: 8) {
+                    Text("Models · \(tooltipDate(point.date))")
+                        .font(.system(size: 10, weight: .semibold))
+                    Spacer(minLength: 8)
+                    Text("Top \(min(10, point.models.count)) of \(point.models.count)")
+                        .font(.system(size: 9))
+                        .foregroundStyle(.secondary)
+                    Button {
+                        inspectedPoint = nil
+                    } label: {
+                        Image(systemName: "xmark.circle.fill")
+                    }
+                    .buttonStyle(.plain)
                     .foregroundStyle(.secondary)
-                Button {
-                    inspectedPoint = nil
-                } label: {
-                    Image(systemName: "xmark.circle.fill")
+                    .help("Clear model selection")
                 }
-                .buttonStyle(.plain)
-                .foregroundStyle(.secondary)
-            }
-            if point.models.isEmpty {
-                Text("Model detail is unavailable for this historical period.")
-                    .font(.system(size: 9))
-                    .foregroundStyle(.secondary)
-            } else {
-                ScrollView {
-                    VStack(spacing: 4) {
+
+                if point.models.isEmpty {
+                    Text("Model detail is unavailable for this historical period.")
+                        .font(.system(size: 9))
+                        .foregroundStyle(.secondary)
+                        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
+                } else {
+                    LazyVGrid(
+                        columns: [
+                            GridItem(.flexible(), spacing: 16, alignment: .leading),
+                            GridItem(.flexible(), spacing: 0, alignment: .leading)
+                        ],
+                        alignment: .leading,
+                        spacing: 4
+                    ) {
                         ForEach(point.models.prefix(10)) { model in
-                            HStack {
-                                Text(model.modelName)
-                                    .font(.system(size: 9, weight: .medium))
-                                    .lineLimit(1)
-                                    .truncationMode(.middle)
-                                Spacer()
-                                Text(formatCost(model.costUSD))
-                                    .font(.system(size: 9, design: .rounded).monospacedDigit())
-                                Text(formatTokens(model.totalTokens))
-                                    .font(.system(size: 8, design: .rounded).monospacedDigit())
-                                    .foregroundStyle(.secondary)
-                            }
+                            inspectedModelRow(model)
                         }
                     }
                 }
-                .frame(maxHeight: 112)
             }
         }
-        .padding(8)
-        .background(RoundedRectangle(cornerRadius: 7).fill(.background))
-        .overlay(RoundedRectangle(cornerRadius: 7).stroke(.separator.opacity(0.35), lineWidth: 0.5))
-        .shadow(color: .black.opacity(0.16), radius: 8, y: 3)
+    }
+
+    private func inspectedModelRow(_ model: CostSnapshot.ModelBreakdown) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: 6) {
+            Text(model.modelName)
+                .font(.system(size: 9, weight: .medium))
+                .lineLimit(1)
+                .truncationMode(.middle)
+            Spacer(minLength: 4)
+            Text(formatCost(model.costUSD))
+                .font(.system(size: 9, design: .rounded).monospacedDigit())
+            Text(formatTokens(model.totalTokens))
+                .font(.system(size: 8, design: .rounded).monospacedDigit())
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+        }
     }
 
     private func modelRow(_ model: CostSnapshot.ModelBreakdown) -> some View {
@@ -419,6 +430,7 @@ struct CostHistoryView: View {
                 granularityLabel
             }
             .menuStyle(.borderlessButton)
+            .menuIndicator(.hidden)
             .focusable(false)
             .accessibilityLabel("Group cost history by \(granularity.rawValue.lowercased())")
         } else {

--- a/Sources/VibeBarApp/Views/CostHistoryView.swift
+++ b/Sources/VibeBarApp/Views/CostHistoryView.swift
@@ -251,9 +251,6 @@ struct CostHistoryView: View {
                     Text("Models · \(tooltipDate(point.date))")
                         .font(.system(size: 10, weight: .semibold))
                     Spacer(minLength: 8)
-                    Text("Top \(min(10, point.models.count)) of \(point.models.count)")
-                        .font(.system(size: 9))
-                        .foregroundStyle(.secondary)
                     Button {
                         inspectedPoint = nil
                     } label: {
@@ -278,7 +275,7 @@ struct CostHistoryView: View {
                         alignment: .leading,
                         spacing: 4
                     ) {
-                        ForEach(point.models.prefix(10)) { model in
+                        ForEach(point.models) { model in
                             inspectedModelRow(model)
                         }
                     }
@@ -343,7 +340,7 @@ struct CostHistoryView: View {
                     date: point.date,
                     costUSD: point.costUSD,
                     totalTokens: point.totalTokens,
-                    models: snapshot.topModels(forHour: point.date, limit: 20)
+                    models: snapshot.topModels(forHour: point.date, limit: .max)
                 )
             }
         }
@@ -355,7 +352,7 @@ struct CostHistoryView: View {
                     date: point.date,
                     costUSD: point.costUSD,
                     totalTokens: point.totalTokens,
-                    models: snapshot.topModels(for: point.date, limit: 20)
+                    models: snapshot.topModels(for: point.date, limit: .max)
                 )
             }
         }
@@ -390,7 +387,7 @@ struct CostHistoryView: View {
             var value = totals[key] ?? (0, 0, [:])
             value.cost += day.costUSD
             value.tokens += day.totalTokens
-            for model in snapshot.topModels(for: day.date, limit: 20) {
+            for model in snapshot.topModels(for: day.date, limit: .max) {
                 let current = value.models[model.modelName] ?? (0, 0)
                 value.models[model.modelName] = (current.0 + model.costUSD, current.1 + model.totalTokens)
             }

--- a/Sources/VibeBarApp/Views/CostHistoryView.swift
+++ b/Sources/VibeBarApp/Views/CostHistoryView.swift
@@ -19,8 +19,8 @@ private struct CostChartPoint: Identifiable, Equatable {
 }
 
 /// Cost history with hour/day/week/month grouping, model-aware hover detail,
-/// and a click-to-pin model inspector presented in a fixed-size popover so
-/// inspecting a bar never changes the card height or reflows the masonry.
+/// and a click-to-pin model inspector drawn inside the card so inspecting a
+/// bar never creates a separate AppKit popover or reflows the masonry.
 struct CostHistoryView: View {
     let tool: ToolType
     let snapshot: CostSnapshot?
@@ -31,7 +31,7 @@ struct CostHistoryView: View {
     @State private var timeframe: CostTimeframe = .month
     @State private var granularity: CostHistoryGranularity = .day
     @State private var hoveredDate: Date?
-    @State private var pinnedDate: Date?
+    @State private var inspectedPoint: CostChartPoint?
 
     @EnvironmentObject var environment: AppEnvironment
 
@@ -55,39 +55,20 @@ struct CostHistoryView: View {
                     Spacer(minLength: 0)
                     CostTimeframeSelector(selection: $timeframe, density: density)
                         .fixedSize(horizontal: true, vertical: false)
-                    if availableGranularities.count > 1 {
-                        Menu {
-                            ForEach(availableGranularities) { option in
-                                Button {
-                                    granularity = option
-                                    clearSelection()
-                                } label: {
-                                    if option == granularity {
-                                        Label(option.rawValue, systemImage: "checkmark")
-                                    } else {
-                                        Text(option.rawValue)
-                                    }
-                                }
-                            }
-                        } label: {
-                            Text("By \(granularity.rawValue)")
-                                .font(.system(size: max(9, density.segmentedFontSize - 1), weight: .semibold))
-                        }
-                        .menuStyle(.borderlessButton)
-                        .focusable(false)
-                        .fixedSize()
-                    }
+                    granularityControl
                 }
             }
 
-            chart(points: points, average: average)
-                .popover(isPresented: pinnedPopoverBinding(points: points), arrowEdge: .top) {
-                    if let pinned = pinnedPoint(in: points) {
-                        pinnedModelPanel(pinned)
-                            .frame(width: 300)
-                            .padding(10)
-                    }
+            ZStack(alignment: .topTrailing) {
+                chart(points: points, average: average)
+                if let inspectedPoint {
+                    inspectedModelPanel(inspectedPoint)
+                        .frame(width: 300)
+                        .padding(.top, 4)
+                        .padding(.trailing, 4)
+                        .zIndex(2)
                 }
+            }
 
             HStack(spacing: 16) {
                 metric(label: "Total", value: formatCost(total))
@@ -221,11 +202,11 @@ struct CostHistoryView: View {
                         }
                     }
                     .onTapGesture {
-                        guard let hoveredDate else { return }
-                        pinnedDate = pinnedDate == hoveredDate ? nil : hoveredDate
+                        guard let hovered = hoveredPoint(in: points) else { return }
+                        inspectedPoint = inspectedPoint?.date == hovered.date ? nil : hovered
                     }
 
-                if let hovered = hoveredPoint(in: points), pinnedDate == nil {
+                if let hovered = hoveredPoint(in: points), inspectedPoint == nil {
                     compactTooltip(hovered)
                         .offset(x: tooltipX(for: hovered.date, proxy: proxy, geometry: geometry))
                 }
@@ -262,7 +243,7 @@ struct CostHistoryView: View {
         .allowsHitTesting(false)
     }
 
-    private func pinnedModelPanel(_ point: CostChartPoint) -> some View {
+    private func inspectedModelPanel(_ point: CostChartPoint) -> some View {
         VStack(alignment: .leading, spacing: 5) {
             HStack {
                 Text("Models · \(tooltipDate(point.date))")
@@ -272,7 +253,7 @@ struct CostHistoryView: View {
                     .font(.system(size: 9))
                     .foregroundStyle(.secondary)
                 Button {
-                    pinnedDate = nil
+                    inspectedPoint = nil
                 } label: {
                     Image(systemName: "xmark.circle.fill")
                 }
@@ -306,8 +287,9 @@ struct CostHistoryView: View {
             }
         }
         .padding(8)
-        .background(RoundedRectangle(cornerRadius: 7).fill(Color.primary.opacity(0.06)))
+        .background(RoundedRectangle(cornerRadius: 7).fill(.background))
         .overlay(RoundedRectangle(cornerRadius: 7).stroke(.separator.opacity(0.35), lineWidth: 0.5))
+        .shadow(color: .black.opacity(0.16), radius: 8, y: 3)
     }
 
     private func modelRow(_ model: CostSnapshot.ModelBreakdown) -> some View {
@@ -417,6 +399,50 @@ struct CostHistoryView: View {
 
     // MARK: - Presentation helpers
 
+    @ViewBuilder
+    private var granularityControl: some View {
+        if availableGranularities.count > 1 {
+            Menu {
+                ForEach(availableGranularities) { option in
+                    Button {
+                        granularity = option
+                        clearSelection()
+                    } label: {
+                        if option == granularity {
+                            Label(option.rawValue, systemImage: "checkmark")
+                        } else {
+                            Text(option.rawValue)
+                        }
+                    }
+                }
+            } label: {
+                granularityLabel
+            }
+            .menuStyle(.borderlessButton)
+            .focusable(false)
+            .accessibilityLabel("Group cost history by \(granularity.rawValue.lowercased())")
+        } else {
+            granularityLabel
+                .foregroundStyle(.secondary)
+                .accessibilityLabel("Cost history grouped by \(granularity.rawValue.lowercased())")
+        }
+    }
+
+    private var granularityLabel: some View {
+        HStack(spacing: 3) {
+            Text("By \(granularity.rawValue)")
+                .lineLimit(1)
+            Image(systemName: "chevron.down")
+                .font(.system(size: 7, weight: .bold))
+                .opacity(availableGranularities.count > 1 ? 1 : 0)
+        }
+        .font(.system(size: max(9, density.segmentedFontSize - 1), weight: .semibold))
+        .frame(width: 72, height: 22)
+        .padding(2)
+        .background(RoundedRectangle(cornerRadius: 7).fill(Color.primary.opacity(0.08)))
+        .contentShape(Rectangle())
+    }
+
     private var chartCalendarComponent: Calendar.Component {
         switch granularity {
         case .hour: .hour
@@ -487,25 +513,12 @@ struct CostHistoryView: View {
         hoveredDate.flatMap { date in points.first { $0.date == date } }
     }
 
-    private func pinnedPoint(in points: [CostChartPoint]) -> CostChartPoint? {
-        pinnedDate.flatMap { date in points.first { $0.date == date } }
-    }
-
-    private func pinnedPopoverBinding(points: [CostChartPoint]) -> Binding<Bool> {
-        Binding(
-            get: { pinnedPoint(in: points) != nil },
-            set: { isPresented in
-                if !isPresented { pinnedDate = nil }
-            }
-        )
-    }
-
     private func nearestPoint(to date: Date, in points: [CostChartPoint]) -> CostChartPoint? {
         points.min { abs($0.date.timeIntervalSince(date)) < abs($1.date.timeIntervalSince(date)) }
     }
 
     private func pointOpacity(_ point: CostChartPoint) -> Double {
-        guard let selected = pinnedDate ?? hoveredDate else { return 1 }
+        guard let selected = inspectedPoint?.date ?? hoveredDate else { return 1 }
         return point.date == selected ? 1 : 0.55
     }
 
@@ -517,7 +530,7 @@ struct CostHistoryView: View {
 
     private func clearSelection() {
         hoveredDate = nil
-        pinnedDate = nil
+        inspectedPoint = nil
     }
 
     private func timeframeNote(pointCount: Int) -> String {

--- a/Sources/VibeBarApp/Views/CostHistoryView.swift
+++ b/Sources/VibeBarApp/Views/CostHistoryView.swift
@@ -412,47 +412,54 @@ struct CostHistoryView: View {
 
     @ViewBuilder
     private var granularityControl: some View {
-        if availableGranularities.count > 1 {
-            Menu {
-                ForEach(availableGranularities) { option in
-                    Button {
-                        granularity = option
-                        clearSelection()
-                    } label: {
-                        if option == granularity {
-                            Label(option.rawValue, systemImage: "checkmark")
-                        } else {
-                            Text(option.rawValue)
+        Group {
+            if availableGranularities.count > 1 {
+                HStack(spacing: 1) {
+                    ForEach(availableGranularities) { option in
+                        Button {
+                            granularity = option
+                            clearSelection()
+                        } label: {
+                            granularityOptionLabel(option, selected: option == granularity)
                         }
+                        .buttonStyle(.plain)
+                        .focusable(false)
+                        .accessibilityLabel("Group cost history by \(option.rawValue.lowercased())")
                     }
                 }
-            } label: {
-                granularityLabel
+            } else {
+                Text(granularity.rawValue)
+                    .font(.system(size: max(9, density.segmentedFontSize - 1), weight: .semibold, design: .rounded))
+                    .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity, minHeight: 22)
+                    .accessibilityLabel("Cost history grouped by \(granularity.rawValue.lowercased())")
             }
-            .menuStyle(.borderlessButton)
-            .menuIndicator(.hidden)
-            .focusable(false)
-            .accessibilityLabel("Group cost history by \(granularity.rawValue.lowercased())")
-        } else {
-            granularityLabel
-                .foregroundStyle(.secondary)
-                .accessibilityLabel("Cost history grouped by \(granularity.rawValue.lowercased())")
         }
+        .padding(2)
+        .frame(width: 132)
+        .background(
+            RoundedRectangle(cornerRadius: 7, style: .continuous)
+                .fill(Color.primary.opacity(0.08))
+        )
     }
 
-    private var granularityLabel: some View {
-        HStack(spacing: 3) {
-            Text("By \(granularity.rawValue)")
-                .lineLimit(1)
-            Image(systemName: "chevron.down")
-                .font(.system(size: 7, weight: .bold))
-                .opacity(availableGranularities.count > 1 ? 1 : 0)
-        }
-        .font(.system(size: max(9, density.segmentedFontSize - 1), weight: .semibold))
-        .frame(width: 72, height: 22)
-        .padding(2)
-        .background(RoundedRectangle(cornerRadius: 7).fill(Color.primary.opacity(0.08)))
-        .contentShape(Rectangle())
+    private func granularityOptionLabel(
+        _ option: CostHistoryGranularity,
+        selected: Bool
+    ) -> some View {
+        Text(option.rawValue)
+            .font(.system(size: max(9, density.segmentedFontSize - 1), weight: .semibold, design: .rounded))
+            .foregroundStyle(selected ? Color.primary : Color.secondary)
+            .lineLimit(1)
+            .minimumScaleFactor(0.8)
+            .frame(maxWidth: .infinity, minHeight: 22)
+            .contentShape(Rectangle())
+            .background {
+                if selected {
+                    RoundedRectangle(cornerRadius: 6, style: .continuous)
+                        .fill(Color.primary.opacity(0.12))
+                }
+            }
     }
 
     private var chartCalendarComponent: Calendar.Component {

--- a/Sources/VibeBarApp/Views/FillTimelineChart.swift
+++ b/Sources/VibeBarApp/Views/FillTimelineChart.swift
@@ -50,48 +50,43 @@ struct FillTimelineChart: View {
                         .foregroundStyle(.quaternary)
                 }
                 if tabs.count > 1 {
-                    if tabs.count <= 3 {
-                        Picker("", selection: Binding(
-                            get: { activeSeriesId },
-                            set: { selectedBucketId = $0; hoveredIndex = nil }
-                        )) {
+                    ScrollView(.horizontal, showsIndicators: false) {
+                        HStack(spacing: 2) {
                             ForEach(tabs, id: \.id) { tab in
-                                Text(tab.label).tag(tab.id)
-                            }
-                        }
-                        .pickerStyle(.segmented)
-                        .controlSize(.mini)
-                        .labelsHidden()
-                        .frame(maxWidth: .infinity)
-                    } else {
-                        HStack {
-                            Spacer(minLength: 0)
-                            Menu {
-                                ForEach(tabs, id: \.id) { tab in
-                                    Button {
-                                        selectedBucketId = tab.id
-                                        hoveredIndex = nil
-                                    } label: {
-                                        if tab.id == activeSeriesId {
-                                            Label(tab.label, systemImage: "checkmark")
-                                        } else {
-                                            Text(tab.label)
-                                        }
-                                    }
-                                }
-                            } label: {
-                                HStack(spacing: 4) {
-                                    Text(tabs.first(where: { $0.id == activeSeriesId })?.label ?? "Quota")
+                                let isSelected = tab.id == activeSeriesId
+                                Button {
+                                    selectedBucketId = tab.id
+                                    hoveredIndex = nil
+                                } label: {
+                                    Text(tab.label)
+                                        .font(.system(
+                                            size: max(8.5, density.subtitleFontSize - 2),
+                                            weight: .semibold,
+                                            design: .rounded
+                                        ))
+                                        .foregroundStyle(isSelected ? Color.white : Color.secondary)
                                         .lineLimit(1)
-                                    Image(systemName: "chevron.up.chevron.down")
-                                        .font(.system(size: 8, weight: .semibold))
+                                        .padding(.horizontal, 9)
+                                        .frame(height: 22)
+                                        .background {
+                                            if isSelected {
+                                                RoundedRectangle(cornerRadius: 6, style: .continuous)
+                                                    .fill(Color.accentColor)
+                                            }
+                                        }
+                                        .contentShape(Rectangle())
                                 }
-                                .font(.system(size: max(9, density.subtitleFontSize - 2), weight: .medium))
+                                .buttonStyle(.plain)
+                                .focusable(false)
+                                .accessibilityLabel("Show \(tab.label) utilization history")
                             }
-                            .menuStyle(.borderlessButton)
-                            .fixedSize()
                         }
+                        .padding(2)
                     }
+                    .background(
+                        RoundedRectangle(cornerRadius: 7, style: .continuous)
+                            .fill(Color.primary.opacity(0.08))
+                    )
                 }
                 cycleStrip(cycles, tool: activeSeries.tool)
                 Text(caption(cycles))

--- a/Sources/VibeBarApp/Views/FillTimelineChart.swift
+++ b/Sources/VibeBarApp/Views/FillTimelineChart.swift
@@ -50,39 +50,44 @@ struct FillTimelineChart: View {
                         .foregroundStyle(.quaternary)
                 }
                 if tabs.count > 1 {
-                    ScrollView(.horizontal, showsIndicators: false) {
-                        HStack(spacing: 2) {
-                            ForEach(tabs, id: \.id) { tab in
-                                let isSelected = tab.id == activeSeriesId
-                                Button {
-                                    selectedBucketId = tab.id
-                                    hoveredIndex = nil
-                                } label: {
-                                    Text(tab.label)
-                                        .font(.system(
-                                            size: max(8.5, density.subtitleFontSize - 2),
-                                            weight: .semibold,
-                                            design: .rounded
-                                        ))
-                                        .foregroundStyle(isSelected ? Color.white : Color.secondary)
-                                        .lineLimit(1)
-                                        .padding(.horizontal, 9)
-                                        .frame(height: 22)
-                                        .background {
-                                            if isSelected {
-                                                RoundedRectangle(cornerRadius: 6, style: .continuous)
-                                                    .fill(Color.accentColor)
+                    GeometryReader { geometry in
+                        ScrollView(.horizontal, showsIndicators: false) {
+                            HStack(spacing: 2) {
+                                ForEach(tabs, id: \.id) { tab in
+                                    let isSelected = tab.id == activeSeriesId
+                                    Button {
+                                        selectedBucketId = tab.id
+                                        hoveredIndex = nil
+                                    } label: {
+                                        Text(tab.label)
+                                            .font(.system(
+                                                size: max(8.5, density.subtitleFontSize - 2),
+                                                weight: .semibold,
+                                                design: .rounded
+                                            ))
+                                            .foregroundStyle(isSelected ? Color.white : Color.secondary)
+                                            .lineLimit(1)
+                                            .padding(.horizontal, 9)
+                                            .frame(height: 22)
+                                            .background {
+                                                if isSelected {
+                                                    RoundedRectangle(cornerRadius: 6, style: .continuous)
+                                                        .fill(Color.accentColor)
+                                                }
                                             }
-                                        }
-                                        .contentShape(Rectangle())
+                                            .contentShape(Rectangle())
+                                    }
+                                    .buttonStyle(.plain)
+                                    .focusable(false)
+                                    .accessibilityLabel("Show \(tab.label) utilization history")
                                 }
-                                .buttonStyle(.plain)
-                                .focusable(false)
-                                .accessibilityLabel("Show \(tab.label) utilization history")
                             }
+                            .padding(2)
+                            .fixedSize(horizontal: true, vertical: false)
+                            .frame(minWidth: geometry.size.width, alignment: .trailing)
                         }
-                        .padding(2)
                     }
+                    .frame(height: 26)
                     .background(
                         RoundedRectangle(cornerRadius: 7, style: .continuous)
                             .fill(Color.primary.opacity(0.08))

--- a/Sources/VibeBarApp/Views/FillTimelineChart.swift
+++ b/Sources/VibeBarApp/Views/FillTimelineChart.swift
@@ -40,31 +40,32 @@ struct FillTimelineChart: View {
             let activeSeries = tabs.first(where: { $0.id == activeSeriesId })!.series
             let cycles = visibleCycles(series: activeSeries)
             VStack(alignment: .leading, spacing: 4) {
-                HStack(spacing: 8) {
-                    VStack(alignment: .leading, spacing: 0) {
-                        Text("Utilization by reset")
-                            .font(.system(size: max(9, density.subtitleFontSize - 2)))
-                            .foregroundStyle(.tertiary)
-                        Text("Each bar is one quota cycle")
-                            .font(.system(size: max(7.5, density.subtitleFontSize - 4)))
-                            .foregroundStyle(.quaternary)
-                    }
-                    Spacer(minLength: 4)
-                    if tabs.count > 1 {
-                        if tabs.count <= 3 {
-                            Picker("", selection: Binding(
-                                get: { activeSeriesId },
-                                set: { selectedBucketId = $0; hoveredIndex = nil }
-                            )) {
-                                ForEach(tabs, id: \.id) { tab in
-                                    Text(tab.label).tag(tab.id)
-                                }
+                HStack(alignment: .firstTextBaseline, spacing: 8) {
+                    Text("Utilization by reset")
+                        .font(.system(size: max(9, density.subtitleFontSize - 2)))
+                        .foregroundStyle(.tertiary)
+                    Spacer(minLength: 8)
+                    Text("Each bar is one quota cycle")
+                        .font(.system(size: max(7.5, density.subtitleFontSize - 4)))
+                        .foregroundStyle(.quaternary)
+                }
+                if tabs.count > 1 {
+                    if tabs.count <= 3 {
+                        Picker("", selection: Binding(
+                            get: { activeSeriesId },
+                            set: { selectedBucketId = $0; hoveredIndex = nil }
+                        )) {
+                            ForEach(tabs, id: \.id) { tab in
+                                Text(tab.label).tag(tab.id)
                             }
-                            .pickerStyle(.segmented)
-                            .controlSize(.mini)
-                            .labelsHidden()
-                            .fixedSize()
-                        } else {
+                        }
+                        .pickerStyle(.segmented)
+                        .controlSize(.mini)
+                        .labelsHidden()
+                        .frame(maxWidth: .infinity)
+                    } else {
+                        HStack {
+                            Spacer(minLength: 0)
                             Menu {
                                 ForEach(tabs, id: \.id) { tab in
                                     Button {

--- a/Sources/VibeBarApp/Views/FillTimelineChart.swift
+++ b/Sources/VibeBarApp/Views/FillTimelineChart.swift
@@ -22,12 +22,35 @@ struct FillTimelineChart: View {
     let now: Date
 
     @EnvironmentObject var quotaService: QuotaService
+    @EnvironmentObject var environment: AppEnvironment
     @State private var selectedBucketId: String?
     @State private var hoveredIndex: Int?
 
-    private static let barSpacing: CGFloat = 3
     private static let maxCycles = 12
-    private static let chartHeight: CGFloat = 48
+
+    private var barSpacing: CGFloat {
+        switch density.profile {
+        case .compact: 2
+        case .regular: 3
+        case .spacious: 4
+        }
+    }
+
+    private var chartHeight: CGFloat {
+        switch density.profile {
+        case .compact: 40
+        case .regular: 52
+        case .spacious: 66
+        }
+    }
+
+    private var tabHeight: CGFloat {
+        switch density.profile {
+        case .compact: 20
+        case .regular: 24
+        case .spacious: 28
+        }
+    }
 
     var body: some View {
         let tabs = availableTabs
@@ -39,6 +62,7 @@ struct FillTimelineChart: View {
             } ?? tabs[0].id
             let activeSeries = tabs.first(where: { $0.id == activeSeriesId })!.series
             let cycles = visibleCycles(series: activeSeries)
+            let target = displayedTarget(for: activeSeries)
             VStack(alignment: .leading, spacing: 4) {
                 HStack(alignment: .firstTextBaseline, spacing: 8) {
                     Text("Utilization by reset")
@@ -75,7 +99,7 @@ struct FillTimelineChart: View {
                                             .lineLimit(1)
                                             .fixedSize(horizontal: true, vertical: false)
                                             .padding(.horizontal, 9)
-                                            .frame(maxWidth: .infinity, minHeight: 22, maxHeight: 22)
+                                            .frame(maxWidth: .infinity, minHeight: tabHeight, maxHeight: tabHeight)
                                             .background {
                                                 if isSelected {
                                                     RoundedRectangle(cornerRadius: 6, style: .continuous)
@@ -93,13 +117,13 @@ struct FillTimelineChart: View {
                             .frame(width: contentWidth)
                         }
                     }
-                    .frame(height: 26)
+                    .frame(height: tabHeight + 4)
                     .background(
                         RoundedRectangle(cornerRadius: 7, style: .continuous)
                             .fill(Color.primary.opacity(0.08))
                     )
                 }
-                cycleStrip(cycles, tool: activeSeries.tool)
+                cycleStrip(cycles, tool: activeSeries.tool, targetPercent: target)
                 Text(caption(cycles))
                     .font(.system(size: max(8, density.subtitleFontSize - 3), design: .rounded).monospacedDigit())
                     .foregroundStyle(.secondary)
@@ -145,7 +169,11 @@ struct FillTimelineChart: View {
     }
 
     @ViewBuilder
-    private func cycleStrip(_ cycles: [SubscriptionWindowSample], tool: ToolType) -> some View {
+    private func cycleStrip(
+        _ cycles: [SubscriptionWindowSample],
+        tool: ToolType,
+        targetPercent: Double?
+    ) -> some View {
         if cycles.isEmpty {
             RoundedRectangle(cornerRadius: 4, style: .continuous)
                 .fill(Theme.barTrack.opacity(0.45))
@@ -154,28 +182,41 @@ struct FillTimelineChart: View {
                         .font(.system(size: max(8, density.subtitleFontSize - 3)))
                         .foregroundStyle(.tertiary)
                 }
-                .frame(height: Self.chartHeight)
+                .frame(height: chartHeight)
         } else {
             GeometryReader { geo in
                 let count = cycles.count
-                let barWidth = max(5, (geo.size.width - CGFloat(count - 1) * Self.barSpacing) / CGFloat(count))
-                HStack(alignment: .bottom, spacing: Self.barSpacing) {
-                    ForEach(Array(cycles.enumerated()), id: \.offset) { index, cycle in
-                        cycleBar(cycle, tool: tool, isHovered: hoveredIndex == index)
-                            .frame(width: barWidth, height: geo.size.height)
+                let barWidth = max(5, (geo.size.width - CGFloat(count - 1) * barSpacing) / CGFloat(count))
+                ZStack(alignment: .topLeading) {
+                    HStack(alignment: .bottom, spacing: barSpacing) {
+                        ForEach(Array(cycles.enumerated()), id: \.offset) { index, cycle in
+                            cycleBar(cycle, tool: tool, isHovered: hoveredIndex == index)
+                                .frame(width: barWidth, height: geo.size.height)
+                        }
+                    }
+                    if let targetPercent, targetPercent > 3, targetPercent < 97 {
+                        Path { path in
+                            let y = geo.size.height * (1 - targetPercent / 100)
+                            path.move(to: CGPoint(x: 0, y: y))
+                            path.addLine(to: CGPoint(x: geo.size.width, y: y))
+                        }
+                        .stroke(
+                            Color.primary.opacity(0.34),
+                            style: StrokeStyle(lineWidth: 1, dash: [4, 3])
+                        )
                     }
                 }
                 .contentShape(Rectangle())
                 .onContinuousHover { phase in
                     switch phase {
                     case .active(let location):
-                        hoveredIndex = min(max(0, Int(location.x / (barWidth + Self.barSpacing))), count - 1)
+                        hoveredIndex = min(max(0, Int(location.x / (barWidth + barSpacing))), count - 1)
                     case .ended:
                         hoveredIndex = nil
                     }
                 }
             }
-            .frame(height: Self.chartHeight)
+            .frame(height: chartHeight)
         }
     }
 
@@ -206,7 +247,15 @@ struct FillTimelineChart: View {
         let used = Int(cycle.peakUsedPercent.rounded())
         let left = Int(cycle.remainingPercentAtReset.rounded())
         if let completedAt = cycle.completedAt {
-            return "\(Self.timestampFormatter.string(from: completedAt)) reset · \(used)% used · \(left)% left"
+            let samplingGap = completedAt.timeIntervalSince(cycle.lastSeenAt)
+            let gapText: String
+            if samplingGap >= 60,
+               let duration = ResetCountdownFormatter.string(from: completedAt, now: cycle.lastSeenAt) {
+                gapText = " · last seen \(duration) before reset"
+            } else {
+                gapText = ""
+            }
+            return "\(Self.timestampFormatter.string(from: completedAt)) reset · \(used)% used · \(left)% left\(gapText)"
         }
         return "Current cycle · \(used)% used so far · \(left)% left"
     }
@@ -232,6 +281,21 @@ struct FillTimelineChart: View {
         switch mode {
         case .used: cycle.peakUsedPercent
         case .remaining: cycle.remainingPercentAtReset
+        }
+    }
+
+    private func displayedTarget(for series: FillTimelineSeries) -> Double? {
+        let snapshot = environment.costService.snapshot(for: series.tool)
+        guard let forecast = quotaService.paceForecast(
+            accountId: series.accountId,
+            bucket: series.bucket,
+            activityHeatmap: snapshot?.heatmap,
+            dailyActivity: snapshot?.dailyHistory ?? [],
+            now: now
+        ) else { return nil }
+        switch mode {
+        case .used: return 100 - forecast.targetRemainingPercent
+        case .remaining: return forecast.targetRemainingPercent
         }
     }
 

--- a/Sources/VibeBarApp/Views/FillTimelineChart.swift
+++ b/Sources/VibeBarApp/Views/FillTimelineChart.swift
@@ -51,6 +51,12 @@ struct FillTimelineChart: View {
                 }
                 if tabs.count > 1 {
                     GeometryReader { geometry in
+                        let tabFontSize = max(8.5, density.subtitleFontSize - 2)
+                        let minimumContentWidth = tabs.reduce(CGFloat.zero) { width, tab in
+                            width + max(64, CGFloat(tab.label.count) * tabFontSize * 0.58 + 24)
+                        } + CGFloat(max(0, tabs.count - 1)) * 2 + 4
+                        let contentWidth = max(geometry.size.width, minimumContentWidth)
+
                         ScrollView(.horizontal, showsIndicators: false) {
                             HStack(spacing: 2) {
                                 ForEach(tabs, id: \.id) { tab in
@@ -61,14 +67,15 @@ struct FillTimelineChart: View {
                                     } label: {
                                         Text(tab.label)
                                             .font(.system(
-                                                size: max(8.5, density.subtitleFontSize - 2),
+                                                size: tabFontSize,
                                                 weight: .semibold,
                                                 design: .rounded
                                             ))
                                             .foregroundStyle(isSelected ? Color.white : Color.secondary)
                                             .lineLimit(1)
+                                            .fixedSize(horizontal: true, vertical: false)
                                             .padding(.horizontal, 9)
-                                            .frame(height: 22)
+                                            .frame(maxWidth: .infinity, minHeight: 22, maxHeight: 22)
                                             .background {
                                                 if isSelected {
                                                     RoundedRectangle(cornerRadius: 6, style: .continuous)
@@ -83,8 +90,7 @@ struct FillTimelineChart: View {
                                 }
                             }
                             .padding(2)
-                            .fixedSize(horizontal: true, vertical: false)
-                            .frame(minWidth: geometry.size.width, alignment: .trailing)
+                            .frame(width: contentWidth)
                         }
                     }
                     .frame(height: 26)

--- a/Sources/VibeBarApp/Views/MiniQuotaWindowView.swift
+++ b/Sources/VibeBarApp/Views/MiniQuotaWindowView.swift
@@ -267,18 +267,18 @@ private struct MiniBranchCell: Identifiable {
 
     private var defaultTitle: String {
         switch bucket.id {
-        case "gpt_5_3_codex_spark_five_hour": return "5h"
-        case "gpt_5_3_codex_spark_weekly": return "wk"
+        case "gpt_5_3_codex_spark_five_hour": return "5 Hours"
+        case "gpt_5_3_codex_spark_weekly": return "Weekly"
         case let id where tool == .antigravity && ["gemini_five_hour", "claude_gpt_five_hour"].contains(id):
-            return "5h"
+            return "5 Hours"
         case let id where tool == .antigravity && ["gemini_weekly", "claude_gpt_weekly"].contains(id):
-            return "wk"
-        case "weekly_sonnet": return "wk"
-        case "weekly_design": return "wk"
+            return "Weekly"
+        case "weekly_sonnet": return "Weekly"
+        case "weekly_design": return "Weekly"
         case "daily_routines": return "Daily"
-        case "weekly_opus": return "Opus"
-        case "weekly_fable": return "wk"
-        case "weekly_oauth_apps": return "OAuth"
+        case "weekly_opus": return "Weekly"
+        case "weekly_fable": return "Weekly"
+        case "weekly_oauth_apps": return "Weekly"
         case let id where tool == .antigravity && id.contains("gpt-oss"):
             return "GPT"
         case let id where tool == .antigravity && id.contains("sonnet"):
@@ -572,9 +572,11 @@ private struct MiniMemberStack: View {
                 if !member.content.primaryCells.isEmpty {
                     MiniPrimaryRingGroup(cells: member.content.primaryCells)
                 }
-                ForEach(branchGroups) { group in
-                    MiniGroupDivider()
-                        .padding(.top, 15)
+                ForEach(Array(branchGroups.enumerated()), id: \.element.id) { index, group in
+                    if !member.content.primaryCells.isEmpty || index > 0 {
+                        MiniGroupDivider()
+                            .padding(.top, 15)
+                    }
                     MiniBranchRingGroup(group: group)
                 }
             }
@@ -987,9 +989,11 @@ private struct MiniCompactMemberStack: View {
                 if !member.content.primaryCells.isEmpty {
                     MiniCompactPrimaryGroup(cells: member.content.primaryCells)
                 }
-                ForEach(branchGroups) { group in
-                    MiniGroupDivider(height: 66)
-                        .padding(.top, 12)
+                ForEach(Array(branchGroups.enumerated()), id: \.element.id) { index, group in
+                    if !member.content.primaryCells.isEmpty || index > 0 {
+                        MiniGroupDivider(height: 66)
+                            .padding(.top, 12)
+                    }
                     MiniCompactBranchGroup(group: group)
                 }
             }

--- a/Sources/VibeBarApp/Views/MiniQuotaWindowView.swift
+++ b/Sources/VibeBarApp/Views/MiniQuotaWindowView.swift
@@ -501,6 +501,19 @@ private func miniGroupTitle(for cell: MiniBranchCell, settings: MiniWindowSettin
     return cell.defaultGroupTitle
 }
 
+private func miniPrimaryGroupTitle(
+    for tool: ToolType,
+    settings: MiniWindowSettings
+) -> String? {
+    guard tool == .gemini else { return nil }
+    let key = "gemini.chat"
+    let custom = settings.groupLabels[key]?.trimmingCharacters(in: .whitespacesAndNewlines)
+    if let custom, !custom.isEmpty {
+        return custom
+    }
+    return MiniWindowGroupLabelCatalog.defaultLabel(for: key)
+}
+
 /// Renders one L2 product super-column in the regular (ring) layout.
 /// Single-tool groups (ChatGPT / Claude / Grok) get a compact L2
 /// header + bucket rings. Multi-tool groups (Gemini = Gemini Web +
@@ -555,13 +568,9 @@ private struct MiniL2GroupColumn: View {
     }
 }
 
-/// One L3 member inside an L2 super-column. Renders only the bucket
-/// rings — AQ asked to drop the per-L3 sub-label ("Gemini Web" /
-/// "AntiGravity") under the GEMINI column. The branch-group titles
-/// the parser already emits (G PRO, G FLASH, CLAUDE, GPT-OSS) still
-/// distinguish the two surfaces visually, so an explicit L3 label
-/// on top was redundant and made the mini window look like a third
-/// hierarchy level when only two are wanted.
+/// One L3 member inside an L2 super-column. Primary Gemini Web quotas use a
+/// compact "Gemini Chat" group heading so the two leftmost rings are clearly
+/// distinguished from AntiGravity's Gemini and Claude + GPT quota groups.
 private struct MiniMemberStack: View {
     let member: MiniL2Member
     let settings: MiniWindowSettings
@@ -570,7 +579,10 @@ private struct MiniMemberStack: View {
         VStack(alignment: .center, spacing: 0) {
             HStack(alignment: .top, spacing: 8) {
                 if !member.content.primaryCells.isEmpty {
-                    MiniPrimaryRingGroup(cells: member.content.primaryCells)
+                    MiniPrimaryRingGroup(
+                        cells: member.content.primaryCells,
+                        title: primaryGroupTitle
+                    )
                 }
                 ForEach(Array(branchGroups.enumerated()), id: \.element.id) { index, group in
                     if !member.content.primaryCells.isEmpty || index > 0 {
@@ -585,6 +597,10 @@ private struct MiniMemberStack: View {
 
     private var branchGroups: [MiniBranchGroup] {
         miniBranchGroups(from: member.content.branchCells, settings: settings)
+    }
+
+    private var primaryGroupTitle: String? {
+        miniPrimaryGroupTitle(for: member.tool, settings: settings)
     }
 
     static func width(
@@ -613,9 +629,10 @@ private struct MiniMemberStack: View {
 
 private struct MiniPrimaryRingGroup: View {
     let cells: [MiniCell]
+    let title: String?
 
     var body: some View {
-        MiniRingGroupShell(title: nil, width: groupWidth) {
+        MiniRingGroupShell(title: title, width: groupWidth) {
             HStack(alignment: .top, spacing: MiniRingMetrics.ringSpacing) {
                 ForEach(cells) { cell in
                     MiniRingCell(cell: cell)
@@ -987,7 +1004,10 @@ private struct MiniCompactMemberStack: View {
         VStack(alignment: .center, spacing: 0) {
             HStack(alignment: .top, spacing: 5) {
                 if !member.content.primaryCells.isEmpty {
-                    MiniCompactPrimaryGroup(cells: member.content.primaryCells)
+                    MiniCompactPrimaryGroup(
+                        cells: member.content.primaryCells,
+                        title: primaryGroupTitle
+                    )
                 }
                 ForEach(Array(branchGroups.enumerated()), id: \.element.id) { index, group in
                     if !member.content.primaryCells.isEmpty || index > 0 {
@@ -1002,6 +1022,10 @@ private struct MiniCompactMemberStack: View {
 
     private var branchGroups: [MiniBranchGroup] {
         miniBranchGroups(from: member.content.branchCells, settings: settings)
+    }
+
+    private var primaryGroupTitle: String? {
+        miniPrimaryGroupTitle(for: member.tool, settings: settings)
     }
 
     static func width(
@@ -1030,9 +1054,10 @@ private struct MiniCompactMemberStack: View {
 
 private struct MiniCompactPrimaryGroup: View {
     let cells: [MiniCell]
+    let title: String?
 
     var body: some View {
-        MiniCompactGroupShell(title: nil, width: groupWidth) {
+        MiniCompactGroupShell(title: title, width: groupWidth) {
             HStack(alignment: .top, spacing: MiniCompactMetrics.ringSpacing) {
                 ForEach(cells) { cell in
                     MiniCompactBarCell(

--- a/Sources/VibeBarApp/Views/MiniQuotaWindowView.swift
+++ b/Sources/VibeBarApp/Views/MiniQuotaWindowView.swift
@@ -447,6 +447,57 @@ private func providerTitle(for tool: ToolType) -> String {
     }
 }
 
+@MainActor
+private func miniQuotaForecast(
+    tool: ToolType,
+    bucket: QuotaBucket,
+    environment: AppEnvironment,
+    quotaService: QuotaService,
+    now: Date
+) -> QuotaPaceForecast? {
+    guard let accountId = environment.account(for: tool)?.id else { return nil }
+    let snapshot = environment.costService.snapshot(for: tool)
+    return quotaService.paceForecast(
+        accountId: accountId,
+        bucket: bucket,
+        activityHeatmap: snapshot?.heatmap,
+        dailyActivity: snapshot?.dailyHistory ?? [],
+        now: now
+    )
+}
+
+private func miniForecastPlan(_ forecast: QuotaPaceForecast, mode: DisplayMode) -> Double {
+    switch mode {
+    case .used: forecast.plannedUsedPercent
+    case .remaining: 100 - forecast.plannedUsedPercent
+    }
+}
+
+private func miniForecastLine(_ forecast: QuotaPaceForecast, now: Date, compact: Bool = false) -> String {
+    if forecast.verdict == .atRisk,
+       let runOutAt = forecast.runOutAt,
+       let countdown = ResetCountdownFormatter.string(from: runOutAt, now: now) {
+        return "out \(countdown)"
+    }
+    let left = Int(forecast.projectedRemainingPercent.rounded())
+    switch forecast.verdict {
+    case .enough: return compact ? "left \(left)%" : "\(left)% left"
+    case .watch: return "watch"
+    case .atRisk: return "risk"
+    case .learning: return compact ? "~\(left)% left" : "learning · \(left)% left"
+    }
+}
+
+private func miniForecastColor(_ forecast: QuotaPaceForecast?) -> Color {
+    guard let forecast else { return Color.secondary.opacity(0.5) }
+    switch forecast.verdict {
+    case .enough: return Color(red: 0.20, green: 0.70, blue: 0.48)
+    case .watch: return Color(red: 0.96, green: 0.62, blue: 0.20)
+    case .atRisk: return Color(red: 0.95, green: 0.32, blue: 0.32)
+    case .learning: return .secondary
+    }
+}
+
 private struct MiniProviderDivider: View {
     var height: CGFloat
 
@@ -697,6 +748,8 @@ private struct MiniBranchRingCell: View {
     let cell: MiniBranchCell
 
     @EnvironmentObject var settingsStore: SettingsStore
+    @EnvironmentObject var environment: AppEnvironment
+    @EnvironmentObject var quotaService: QuotaService
 
     var body: some View {
         TimelineView(.periodic(from: .now, by: 30)) { context in
@@ -708,10 +761,17 @@ private struct MiniBranchRingCell: View {
     @ViewBuilder
     private func content(now: Date) -> some View {
         let pace = UsagePace.compute(bucket: cell.bucket, now: now)
+        let forecast = miniQuotaForecast(
+            tool: cell.tool,
+            bucket: cell.bucket,
+            environment: environment,
+            quotaService: quotaService,
+            now: now
+        )
         let percent = cell.bucket.displayPercent(settingsStore.displayMode)
         let color = Theme.barColor(percent: percent, mode: settingsStore.displayMode)
         VStack(spacing: 3) {
-            let expected: Double? = pace.map { p in
+            let expected: Double? = forecast.map { miniForecastPlan($0, mode: settingsStore.displayMode) } ?? pace.map { p in
                 switch settingsStore.displayMode {
                 case .used:      return p.expectedUsedPercent
                 case .remaining: return 100 - p.expectedUsedPercent
@@ -721,7 +781,7 @@ private struct MiniBranchRingCell: View {
                 percent: percent,
                 expected: expected,
                 color: color,
-                markerColor: paceColor(pace: pace),
+                markerColor: forecast.map { miniForecastColor($0) } ?? paceColor(pace: pace),
                 size: MiniRingMetrics.ringSize,
                 lineWidth: MiniRingMetrics.ringLineWidth
             ) {
@@ -737,9 +797,9 @@ private struct MiniBranchRingCell: View {
                 .lineLimit(1)
                 .minimumScaleFactor(0.7)
                 .frame(height: MiniRingMetrics.labelHeight, alignment: .center)
-            Text(paceLine(pace: pace, now: now))
+            Text(forecast.map { miniForecastLine($0, now: now) } ?? paceLine(pace: pace, now: now))
                 .font(.system(size: 8, weight: .medium, design: .rounded).monospacedDigit())
-                .foregroundStyle(paceColor(pace: pace))
+                .foregroundStyle(forecast.map { miniForecastColor($0) } ?? paceColor(pace: pace))
                 .lineLimit(1)
                 .minimumScaleFactor(0.62)
                 .frame(height: MiniRingMetrics.paceHeight, alignment: .center)
@@ -810,6 +870,8 @@ private struct MiniRingCell: View {
     let cell: MiniCell
 
     @EnvironmentObject var settingsStore: SettingsStore
+    @EnvironmentObject var environment: AppEnvironment
+    @EnvironmentObject var quotaService: QuotaService
 
     var body: some View {
         TimelineView(.periodic(from: .now, by: 30)) { context in
@@ -821,17 +883,26 @@ private struct MiniRingCell: View {
     @ViewBuilder
     private func content(now: Date) -> some View {
         let pace = cell.bucket.flatMap { UsagePace.compute(bucket: $0, now: now) }
+        let forecast = cell.bucket.flatMap {
+            miniQuotaForecast(
+                tool: cell.tool,
+                bucket: $0,
+                environment: environment,
+                quotaService: quotaService,
+                now: now
+            )
+        }
         VStack(spacing: 3) {
-            ringGauge(pace: pace, now: now)
+            ringGauge(pace: pace, forecast: forecast, now: now)
             Text(cell.resolvedLabel)
                 .font(.system(size: 9, weight: .medium, design: .rounded))
                 .foregroundStyle(.secondary)
                 .lineLimit(1)
                 .minimumScaleFactor(0.7)
                 .frame(height: MiniRingMetrics.labelHeight, alignment: .center)
-            Text(paceLine(pace: pace, now: now))
+            Text(forecast.map { miniForecastLine($0, now: now) } ?? paceLine(pace: pace, now: now))
                 .font(.system(size: 8, weight: .medium, design: .rounded).monospacedDigit())
-                .foregroundStyle(paceColor(pace: pace))
+                .foregroundStyle(forecast.map { miniForecastColor($0) } ?? paceColor(pace: pace))
                 .lineLimit(1)
                 .minimumScaleFactor(0.65)
                 .frame(height: MiniRingMetrics.paceHeight, alignment: .center)
@@ -894,10 +965,10 @@ private struct MiniRingCell: View {
     }
 
     @ViewBuilder
-    private func ringGauge(pace: UsagePace?, now: Date) -> some View {
+    private func ringGauge(pace: UsagePace?, forecast: QuotaPaceForecast?, now: Date) -> some View {
         if let bucket = cell.bucket {
             let percent = bucket.displayPercent(settingsStore.displayMode)
-            let expected: Double? = pace.map { p in
+            let expected: Double? = forecast.map { miniForecastPlan($0, mode: settingsStore.displayMode) } ?? pace.map { p in
                 switch settingsStore.displayMode {
                 case .used:      return p.expectedUsedPercent
                 case .remaining: return 100 - p.expectedUsedPercent
@@ -908,7 +979,7 @@ private struct MiniRingCell: View {
                 percent: percent,
                 expected: expected,
                 color: color,
-                markerColor: paceColor(pace: pace),
+                markerColor: forecast.map { miniForecastColor($0) } ?? paceColor(pace: pace),
                 size: MiniRingMetrics.ringSize,
                 lineWidth: MiniRingMetrics.ringLineWidth
             ) {
@@ -1146,6 +1217,8 @@ private struct MiniCompactBarCell: View {
     let data: MiniCompactCellData
 
     @EnvironmentObject var settingsStore: SettingsStore
+    @EnvironmentObject var environment: AppEnvironment
+    @EnvironmentObject var quotaService: QuotaService
 
     var body: some View {
         TimelineView(.periodic(from: .now, by: 30)) { context in
@@ -1157,8 +1230,17 @@ private struct MiniCompactBarCell: View {
     @ViewBuilder
     private func content(now: Date) -> some View {
         let pace = data.bucket.flatMap { UsagePace.compute(bucket: $0, now: now) }
+        let forecast = data.bucket.flatMap {
+            miniQuotaForecast(
+                tool: data.tool,
+                bucket: $0,
+                environment: environment,
+                quotaService: quotaService,
+                now: now
+            )
+        }
         let percent = data.bucket?.displayPercent(settingsStore.displayMode) ?? 0
-        let expected: Double? = pace.map { p in
+        let expected: Double? = forecast.map { miniForecastPlan($0, mode: settingsStore.displayMode) } ?? pace.map { p in
             switch settingsStore.displayMode {
             case .used:      return p.expectedUsedPercent
             case .remaining: return 100 - p.expectedUsedPercent
@@ -1178,7 +1260,7 @@ private struct MiniCompactBarCell: View {
                 percent: percent,
                 expected: expected,
                 color: color,
-                markerColor: compactPaceColor(pace)
+                markerColor: forecast.map { miniForecastColor($0) } ?? compactPaceColor(pace)
             )
             Text(centerText(percent: percent))
                 .font(.system(size: 10.5, weight: .bold, design: .rounded).monospacedDigit())
@@ -1186,9 +1268,9 @@ private struct MiniCompactBarCell: View {
                 .lineLimit(1)
                 .minimumScaleFactor(0.68)
                 .frame(height: MiniCompactMetrics.percentHeight, alignment: .center)
-            Text(compactPaceLine(pace: pace, now: now))
+            Text(forecast.map { miniForecastLine($0, now: now, compact: true) } ?? compactPaceLine(pace: pace, now: now))
                 .font(.system(size: 6.8, weight: .medium, design: .rounded).monospacedDigit())
-                .foregroundStyle(compactPaceColor(pace))
+                .foregroundStyle(forecast.map { miniForecastColor($0) } ?? compactPaceColor(pace))
                 .lineLimit(1)
                 .minimumScaleFactor(0.48)
                 .frame(height: MiniCompactMetrics.paceHeight, alignment: .center)

--- a/Sources/VibeBarApp/Views/MiniWindowGroupLabelCatalog.swift
+++ b/Sources/VibeBarApp/Views/MiniWindowGroupLabelCatalog.swift
@@ -15,6 +15,7 @@ enum MiniWindowGroupLabelCatalog {
         .init(id: "claude.opus", title: "CLAUDE · Opus", defaultLabel: "Opus"),
         .init(id: "claude.fable", title: "CLAUDE · Fable", defaultLabel: "Fable"),
         .init(id: "claude.oauth", title: "CLAUDE · OAuth", defaultLabel: "OAuth"),
+        .init(id: "gemini.chat", title: "GEMINI · Gemini Chat", defaultLabel: "Gemini Chat"),
         .init(id: "gemini.pro", title: "GEMINI · Pro", defaultLabel: "Pro"),
         .init(id: "gemini.flash", title: "GEMINI · Flash", defaultLabel: "Flash"),
         .init(id: "gemini.flash-lite", title: "GEMINI · Flash Lite", defaultLabel: "Lite"),

--- a/Sources/VibeBarApp/Views/MiscProvidersPage.swift
+++ b/Sources/VibeBarApp/Views/MiscProvidersPage.swift
@@ -12,7 +12,7 @@ struct MiscProvidersPage: View {
     @EnvironmentObject var settingsStore: SettingsStore
 
     var body: some View {
-        ColumnMasonryLayout(columns: 3, spacing: density.interSectionSpacing) {
+        ColumnMasonryLayout(columns: density.miscColumnCount, spacing: density.interSectionSpacing) {
             ForEach(providerGroups) { group in
                 if group.instances.count == 1, let instance = group.instances.first {
                     MiscProviderCard(instance: instance, density: density)

--- a/Sources/VibeBarApp/Views/PaceMarkerCapsule.swift
+++ b/Sources/VibeBarApp/Views/PaceMarkerCapsule.swift
@@ -12,6 +12,9 @@ struct PaceMarkerCapsule: View {
     let expectedPercent: Double  // 0..100 in displayed terms (already mode-adjusted)
     let mode: DisplayMode
     var height: CGFloat = 12
+    var forecastLowerPercent: Double? = nil
+    var forecastUpperPercent: Double? = nil
+    var forecastMedianPercent: Double? = nil
 
     var body: some View {
         GeometryReader { proxy in
@@ -30,6 +33,24 @@ struct PaceMarkerCapsule: View {
                 Capsule(style: .continuous)
                     .fill(Theme.barColor(percent: usedPercent, mode: mode))
                     .frame(width: max(height, width * pct))
+                if let lower = forecastLowerPercent,
+                   let upper = forecastUpperPercent,
+                   upper > lower {
+                    let start = clamp(lower, 0, 100) / 100
+                    let end = clamp(upper, 0, 100) / 100
+                    RoundedRectangle(cornerRadius: 1.5, style: .continuous)
+                        .fill(Color.primary.opacity(0.24))
+                        .frame(width: max(2, width * (end - start)), height: max(2, height * 0.24))
+                        .offset(x: width * start, y: -height * 0.28)
+                }
+                if let median = forecastMedianPercent,
+                   median > 2,
+                   median < 98 {
+                    RoundedRectangle(cornerRadius: 1, style: .continuous)
+                        .fill(Color.primary.opacity(0.48))
+                        .frame(width: 1.5, height: max(3, height * 0.42))
+                        .offset(x: max(0, min(width - 1.5, width * clamp(median, 0, 100) / 100 - 0.75)), y: -height * 0.27)
+                }
                 if showMarker {
                     paceMarker
                         .offset(x: max(0, min(width - 7, width * markerPos - 3.5)))

--- a/Sources/VibeBarApp/Views/PopoverRoot.swift
+++ b/Sources/VibeBarApp/Views/PopoverRoot.swift
@@ -914,9 +914,8 @@ private struct ProviderCostStack: View {
 }
 
 /// Sits above the per-provider columns: cost and token summary on the left,
-/// current provider status on the right. Cost intentionally gets more width
-/// because its metrics are denser while the four compact status tiles fit in
-/// the narrower column.
+/// current provider status on the right. The two cards use equal columns so
+/// the Overview header aligns with the waterfall below it.
 private struct CombinedTotalsRow: View {
     let density: Theme.Density
 
@@ -924,7 +923,7 @@ private struct CombinedTotalsRow: View {
     @EnvironmentObject var costService: CostUsageService
     @EnvironmentObject var quotaService: QuotaService
     @EnvironmentObject var settingsStore: SettingsStore
-    private let summaryHeight: CGFloat = 178
+    private let summaryHeight: CGFloat = 220
 
     var body: some View {
         // Headline totals span every cost-aware provider, including
@@ -948,6 +947,9 @@ private struct CombinedTotalsRow: View {
         let weekTokens = snapshots.reduce(0) { $0 + $1.last7DaysTokens }
         let monthTokens = snapshots.reduce(0) { $0 + $1.last30DaysTokens }
         let monthAverageCost = monthCost / 30
+        let monthCostPerMillionTokens = monthTokens > 0
+            ? monthCost * 1_000_000 / Double(monthTokens)
+            : nil
         let visibleAccountIDs = Set(
             ToolType.dedicatedCardProviders
                 .filter { settingsStore.settings.isCoreProviderVisible($0) }
@@ -985,9 +987,7 @@ private struct CombinedTotalsRow: View {
         GeometryReader { geometry in
             let spacing = density.interSectionSpacing
             let availableWidth = max(0, geometry.size.width - spacing)
-            // Five cost columns next to the status card's four logical
-            // columns: enough room for Yesterday without over-expanding Cost.
-            let costWidth = availableWidth * (5.0 / 9.0)
+            let columnWidth = availableWidth / 2
 
             HStack(alignment: .top, spacing: spacing) {
                 VStack(alignment: .leading, spacing: 8) {
@@ -1010,9 +1010,19 @@ private struct CombinedTotalsRow: View {
                     }
                     .disabled(costService.isRefreshing)
                 }
+                    // 4 × 4 summary: durable all-time/peak context first,
+                    // matching cost and token timeframes next, then four
+                    // operational efficiency indicators.
                     HStack(alignment: .top, spacing: 0) {
                         metric(label: "TOTAL COST", value: formatCost(totalCost), highlight: true)
                         divider
+                        metric(label: "TOTAL TOK", value: formatTokens(totalTokens), highlight: true)
+                        divider
+                        metric(label: "PEAK DAY", value: formatCost(peakDayCost))
+                        divider
+                        metric(label: "PEAK DAY TOK", value: formatTokens(peakDayTokens))
+                    }
+                    HStack(alignment: .top, spacing: 0) {
                         metric(label: "TODAY", value: formatCost(todayCost))
                         divider
                         metric(label: "YESTERDAY", value: formatCost(yesterdayCost))
@@ -1022,8 +1032,6 @@ private struct CombinedTotalsRow: View {
                         metric(label: "30-DAY", value: formatCost(monthCost))
                     }
                     HStack(alignment: .top, spacing: 0) {
-                        metric(label: "TOTAL TOK", value: formatTokens(totalTokens), highlight: true)
-                        divider
                         metric(label: "TODAY TOK", value: formatTokens(todayTokens))
                         divider
                         metric(label: "YESTERDAY TOK", value: formatTokens(yesterdayTokens))
@@ -1033,11 +1041,9 @@ private struct CombinedTotalsRow: View {
                         metric(label: "30-DAY TOK", value: formatTokens(monthTokens))
                     }
                     HStack(alignment: .top, spacing: 0) {
-                        metric(label: "PEAK DAY", value: formatCost(peakDayCost))
-                        divider
-                        metric(label: "PEAK DAY TOK", value: formatTokens(peakDayTokens))
-                        divider
                         metric(label: "30D AVG/DAY", value: formatCost(monthAverageCost))
+                        divider
+                        metric(label: "30D $/1M TOK", value: formatCost(monthCostPerMillionTokens))
                         divider
                         metric(label: "TPM", value: formatTokens(tokensPerMinute))
                         divider
@@ -1046,9 +1052,9 @@ private struct CombinedTotalsRow: View {
                 }
                 .padding(density.cardPadding)
                 .frame(
-                    minWidth: costWidth,
-                    idealWidth: costWidth,
-                    maxWidth: costWidth,
+                    minWidth: columnWidth,
+                    idealWidth: columnWidth,
+                    maxWidth: columnWidth,
                     minHeight: summaryHeight,
                     alignment: .topLeading
                 )
@@ -1063,15 +1069,15 @@ private struct CombinedTotalsRow: View {
 
                 OverviewStatusSummaryCard(
                     density: density,
+                    minHeight: summaryHeight,
                     tools: ToolType.combinedStatusPageProviders.filter {
                         settingsStore.settings.isCoreProviderVisible($0)
                     }
                 )
                     .frame(
-                        minWidth: availableWidth - costWidth,
-                        idealWidth: availableWidth - costWidth,
-                        maxWidth: availableWidth - costWidth,
-                        minHeight: summaryHeight,
+                        minWidth: columnWidth,
+                        idealWidth: columnWidth,
+                        maxWidth: columnWidth,
                         alignment: .topLeading
                     )
             }
@@ -1105,7 +1111,8 @@ private struct CombinedTotalsRow: View {
         .frame(maxWidth: .infinity, alignment: .leading)
     }
 
-    private func formatCost(_ value: Double) -> String {
+    private func formatCost(_ value: Double?) -> String {
+        guard let value, value.isFinite else { return "—" }
         if value < 0.01 { return "$0.00" }
         if value < 100  { return String(format: "$%.2f", value) }
         return String(format: "$%.0f", value)
@@ -1132,6 +1139,7 @@ private struct CombinedTotalsRow: View {
 
 private struct OverviewStatusSummaryCard: View {
     let density: Theme.Density
+    let minHeight: CGFloat
     let tools: [ToolType]
 
     @EnvironmentObject var serviceStatus: ServiceStatusController
@@ -1176,7 +1184,7 @@ private struct OverviewStatusSummaryCard: View {
             }
         }
         .padding(density.cardPadding)
-        .frame(maxWidth: .infinity, minHeight: 134, alignment: .topLeading)
+        .frame(maxWidth: .infinity, minHeight: minHeight, alignment: .topLeading)
         .background(
             RoundedRectangle(cornerRadius: density.cardCornerRadius, style: .continuous)
                 .fill(.background.tertiary.opacity(0.6))

--- a/Sources/VibeBarApp/Views/PopoverRoot.swift
+++ b/Sources/VibeBarApp/Views/PopoverRoot.swift
@@ -753,7 +753,7 @@ private struct GeminiTabPage: View {
             .accounts(for: .gemini)
             .sorted { $0.id < $1.id }
         let antigravityAccount = environment.account(for: .antigravity)
-        let antigravityHistorySeries: [FillTimelineSeries] = antigravityAccount.map { account in
+        let antigravityQuotaSeries: [FillTimelineSeries] = antigravityAccount.map { account in
             (quotaService.cachedQuota(for: account.id)?.buckets ?? []).map {
                 FillTimelineSeries(tool: .antigravity, accountId: account.id, bucket: $0)
             }
@@ -771,7 +771,7 @@ private struct GeminiTabPage: View {
                         mode: settingsStore.displayMode,
                         density: density,
                         now: context.date,
-                        additionalHistorySeries: antigravityHistorySeries
+                        additionalQuotaSeries: antigravityQuotaSeries
                     )
                 }
                 ServiceStatusCard(tools: [.gemini])

--- a/Sources/VibeBarApp/Views/PopoverRoot.swift
+++ b/Sources/VibeBarApp/Views/PopoverRoot.swift
@@ -490,7 +490,7 @@ private struct OverviewWaterfall: View {
                         tool: .codex,
                         snapshot: combinedCostSnapshot,
                         density: density,
-                        chartHeight: overviewCostHistoryHeight,
+                        chartHeight: 190,
                         titleOverride: "All Providers Cost History"
                     )
                     .overviewMasonryItem(id: "cost-all-providers", phase: .cost)
@@ -547,13 +547,6 @@ private struct OverviewWaterfall: View {
     /// isn't listed here.
     private var overviewCostProviders: [ToolType] {
         [.codex, .claude, .grok].filter(isVisible)
-    }
-
-    /// Compact Overview already exposes one all-provider chart, so it should
-    /// stay useful without consuming the height of a full analytics card.
-    /// Regular and spacious layouts retain the established chart height.
-    private var overviewCostHistoryHeight: CGFloat {
-        density.popoverDensity == .compact ? 140 : 190
     }
 
     private func isVisible(_ tool: ToolType) -> Bool {
@@ -988,34 +981,41 @@ private struct CombinedTotalsRow: View {
                     .disabled(costService.isRefreshing)
                 }
                     // 4 × 3 summary: durable all-time/peak context first,
-                    // followed by matching cost and token timeframes.
-                    HStack(alignment: .top, spacing: 0) {
-                        metric(label: "TOTAL COST", value: formatCost(totalCost), highlight: true)
-                        divider
-                        metric(label: "TOTAL TOK", value: formatTokens(totalTokens), highlight: true)
-                        divider
-                        metric(label: "PEAK DAY", value: formatCost(peakDayCost))
-                        divider
-                        metric(label: "PEAK DAY TOK", value: formatTokens(peakDayTokens))
+                    // followed by matching cost and token timeframes. The
+                    // flexible gaps use the full height shared with Status,
+                    // instead of leaving one empty band below the third row.
+                    VStack(alignment: .leading, spacing: 0) {
+                        HStack(alignment: .top, spacing: 0) {
+                            metric(label: "TOTAL COST", value: formatCost(totalCost), highlight: true)
+                            divider
+                            metric(label: "TOTAL TOK", value: formatTokens(totalTokens), highlight: true)
+                            divider
+                            metric(label: "PEAK DAY", value: formatCost(peakDayCost))
+                            divider
+                            metric(label: "PEAK DAY TOK", value: formatTokens(peakDayTokens))
+                        }
+                        Spacer(minLength: 8)
+                        HStack(alignment: .top, spacing: 0) {
+                            metric(label: "TODAY", value: formatCost(todayCost))
+                            divider
+                            metric(label: "YESTERDAY", value: formatCost(yesterdayCost))
+                            divider
+                            metric(label: "7-DAY", value: formatCost(weekCost))
+                            divider
+                            metric(label: "30-DAY", value: formatCost(monthCost))
+                        }
+                        Spacer(minLength: 8)
+                        HStack(alignment: .top, spacing: 0) {
+                            metric(label: "TODAY TOK", value: formatTokens(todayTokens))
+                            divider
+                            metric(label: "YESTERDAY TOK", value: formatTokens(yesterdayTokens))
+                            divider
+                            metric(label: "7-DAY TOK", value: formatTokens(weekTokens))
+                            divider
+                            metric(label: "30-DAY TOK", value: formatTokens(monthTokens))
+                        }
                     }
-                    HStack(alignment: .top, spacing: 0) {
-                        metric(label: "TODAY", value: formatCost(todayCost))
-                        divider
-                        metric(label: "YESTERDAY", value: formatCost(yesterdayCost))
-                        divider
-                        metric(label: "7-DAY", value: formatCost(weekCost))
-                        divider
-                        metric(label: "30-DAY", value: formatCost(monthCost))
-                    }
-                    HStack(alignment: .top, spacing: 0) {
-                        metric(label: "TODAY TOK", value: formatTokens(todayTokens))
-                        divider
-                        metric(label: "YESTERDAY TOK", value: formatTokens(yesterdayTokens))
-                        divider
-                        metric(label: "7-DAY TOK", value: formatTokens(weekTokens))
-                        divider
-                        metric(label: "30-DAY TOK", value: formatTokens(monthTokens))
-                    }
+                    .frame(maxHeight: .infinity)
                 }
                 .padding(density.cardPadding)
                 .frame(
@@ -1023,6 +1023,8 @@ private struct CombinedTotalsRow: View {
                     idealWidth: columnWidth,
                     maxWidth: columnWidth,
                     minHeight: summaryHeight,
+                    idealHeight: summaryHeight,
+                    maxHeight: summaryHeight,
                     alignment: .topLeading
                 )
                 .background(
@@ -1347,10 +1349,9 @@ private enum OverviewStatusState {
     }
 }
 
-/// Cost card for the Overview waterfall. Compact density keeps these as
-/// summary cards because the same surface already has the all-provider Cost
-/// History chart; the expand action exposes the provider's full charts.
-/// Regular and spacious densities retain the inline provider history.
+/// Cost card for the Overview right column — full Cost History bar chart with
+/// timeframe picker, plus a 4-column summary header. Tall enough to roughly
+/// match the height of the left-column quota cards (~280pt by default).
 private struct OverviewCostCard: View {
     let tool: ToolType
     let density: Theme.Density
@@ -1415,10 +1416,8 @@ private struct OverviewCostCard: View {
             if let snapshot, snapshot.jsonlFilesFound > 0 {
                 CostSummaryRow(snapshot: snapshot, density: density)
                 TopModelTile(snapshot: snapshot, density: density)
-                if density.popoverDensity != .compact {
-                    CostHistoryView(tool: tool, snapshot: snapshot, density: density, chartHeight: 160)
-                        .padding(.top, 2)
-                }
+                CostHistoryView(tool: tool, snapshot: snapshot, density: density, chartHeight: 160)
+                    .padding(.top, 2)
             } else {
                 Text(emptyMessageOverride ?? emptyMessage)
                     .font(.system(size: density.subtitleFontSize))
@@ -1456,8 +1455,8 @@ private struct OverviewCostCard: View {
 }
 
 /// Detail popover surfaced when the user clicks the expand button on an
-/// Overview cost card. Compact Overview moves the provider-specific Cost
-/// History here; the same popover also contains the longer-range analytics.
+/// Overview cost card. Contains the yearly contribution heatmap + weekday-hour
+/// heatmap + hourly burn rate.
 private struct CostDetailPopoverContent: View {
     let tool: ToolType
     let density: Theme.Density
@@ -1489,12 +1488,6 @@ private struct CostDetailPopoverContent: View {
                     }
                 }
                 if let snap = snapshot {
-                    CostHistoryView(
-                        tool: tool,
-                        snapshot: snap,
-                        density: density,
-                        chartHeight: 180
-                    )
                     YearlyContributionHeatmapView(
                         history: snap.dailyHistory,
                         density: density,

--- a/Sources/VibeBarApp/Views/PopoverRoot.swift
+++ b/Sources/VibeBarApp/Views/PopoverRoot.swift
@@ -445,6 +445,7 @@ private struct OverviewWaterfall: View {
 
     @EnvironmentObject var environment: AppEnvironment
     @EnvironmentObject var settingsStore: SettingsStore
+    @State private var masonrySession = ColumnMasonryLayout.Session()
 
     var body: some View {
         let snapshots = overviewCostSnapshots
@@ -461,7 +462,8 @@ private struct OverviewWaterfall: View {
             CombinedTotalsRow(density: density)
             ColumnMasonryLayout(
                 columns: 2,
-                spacing: density.interSectionSpacing
+                spacing: density.interSectionSpacing,
+                session: masonrySession
             ) {
                 if isVisible(.codex) {
                     ProviderQuotaCard(tool: .codex, density: density, compact: false)

--- a/Sources/VibeBarApp/Views/PopoverRoot.swift
+++ b/Sources/VibeBarApp/Views/PopoverRoot.swift
@@ -2,16 +2,9 @@ import SwiftUI
 import AppKit
 import VibeBarCore
 
-/// Top-level popover content. Each menu bar item kind opens its own popover.
-///
-/// - `.compact` → Overview: a wide provider-column waterfall with a small
-///   page switcher for all-provider and single-provider views.
-/// - `.codex` / `.claude` → single-provider detail waterfall.
-/// - `.status` → service status only.
+/// Top-level content for Vibe Bar's single tabbed popover workspace.
 struct PopoverRoot: View {
-    let kind: MenuBarItemKind
     let width: CGFloat
-    let closePopover: () -> Void
     let onContentHeightChange: (CGFloat) -> Void
     let onToggleMiniWindow: () -> Void
 
@@ -22,32 +15,32 @@ struct PopoverRoot: View {
     @State private var autoRefreshedPageKeys: Set<String> = []
 
     var body: some View {
-        let density = activeDensity
-        VStack(alignment: .leading, spacing: density.interSectionSpacing) {
+        let shellDensity = shellDensity
+        let contentDensity = activeDensity
+        VStack(alignment: .leading, spacing: shellDensity.interSectionSpacing) {
             HeaderView(
                 title: headerTitle,
                 subtitle: headerSubtitle,
-                plan: headerPlan,
+                plan: nil,
                 lastUpdated: latestUpdated,
                 isRefreshing: isRefreshing,
-                titleFontSize: density.titleFontSize + 2,
-                subtitleFontSize: density.subtitleFontSize,
-                accessory: kind == .compact
-                    ? AnyView(OverviewPageSwitch(selection: $overviewPage, density: density))
-                    : nil,
+                titleFontSize: shellDensity.titleFontSize + 2,
+                subtitleFontSize: shellDensity.subtitleFontSize,
+                accessory: AnyView(OverviewPageSwitch(selection: $overviewPage, density: shellDensity)),
                 onRefresh: { environment.refreshAll() },
                 onToggleMiniWindow: onToggleMiniWindow,
                 onShowSettings: { environment.showSettingsWindow() }
             )
+            .frame(height: shellDensity.headerHeight, alignment: .center)
             Divider().opacity(0.3)
             ScrollView(.vertical, showsIndicators: false) {
-                content(density: density)
+                content(density: contentDensity)
                     .padding(.bottom, 4)
             }
             .frame(maxHeight: maxScrollHeight)
         }
-        .padding(.horizontal, density.popoverPaddingH)
-        .padding(.vertical, density.popoverPaddingV)
+        .padding(.horizontal, shellDensity.popoverPaddingH)
+        .padding(.vertical, shellDensity.popoverPaddingV)
         .frame(width: width)
         .fixedSize(horizontal: false, vertical: true)
         .readHeight(onContentHeightChange)
@@ -57,37 +50,20 @@ struct PopoverRoot: View {
         }
     }
 
-    /// Resolves the "logical" menu bar kind for the current view. When the
-    /// overview popover sits on a sub-page (Claude / OpenAI), every kind-keyed
-    /// piece of state — density preference, header title/subtitle/plan,
-    /// `visibleTools` — is taken from the matching dedicated kind so the
-    /// rendering is byte-for-byte consistent with what the user would see if
-    /// they had opened that provider's menu bar item directly.
-    private var effectiveKind: MenuBarItemKind {
-        switch kind {
-        case .compact:
-            switch overviewPage {
-            case .overview: return .compact
-            case .claude:   return .claude
-            case .openAI:   return .codex
-            case .googleAI: return .compact
-            case .grok:     return .compact
-            case .misc:     return .compact
-            }
-        default:
-            return kind
-        }
+    /// The tabbed popover is one shared shell. Provider pages may use their
+    /// own content metrics, but the title band and outer margins must never
+    /// shift when the selected tab changes.
+    private var shellDensity: Theme.Density {
+        Theme.overviewDensity(for: settingsStore.settings.popoverDensity)
     }
 
     private var activeDensity: Theme.Density {
-        let popDens = settingsStore.settings.popoverDensity(for: effectiveKind)
-        switch effectiveKind {
-        case .compact:
-            return Theme.overviewDensity(for: popDens)
-        case .codex, .claude:
-            return Theme.detailDensity(for: popDens)
-        case .status:
-            return Theme.density(for: popDens)
+        let profile = settingsStore.settings.popoverDensity
+        switch overviewPage {
+        case .overview, .misc:
+            return Theme.overviewDensity(for: profile)
+        case .openAI, .claude, .googleAI, .grok:
+            return Theme.detailDensity(for: profile)
         }
     }
 
@@ -98,78 +74,41 @@ struct PopoverRoot: View {
 
     @ViewBuilder
     private func content(density: Theme.Density) -> some View {
-        switch kind {
-        case .compact:
-            switch overviewPage {
-            case .overview:
-                OverviewWaterfall(density: density)
-            case .claude:
-                ProviderDetailView(tool: .claude, density: density)
-            case .openAI:
-                ProviderDetailView(tool: .codex, density: density)
-            case .googleAI:
-                GeminiTabPage(density: density)
-            case .grok:
-                GrokPage(density: density)
-            case .misc:
-                MiscProvidersPage(density: density)
-            }
-        case .codex:
-            ProviderDetailView(tool: .codex, density: density)
+        switch overviewPage {
+        case .overview:
+            OverviewWaterfall(density: density)
         case .claude:
             ProviderDetailView(tool: .claude, density: density)
-        case .status:
-            ServiceStatusCard(tools: ToolType.combinedStatusPageProviders)
+        case .openAI:
+            ProviderDetailView(tool: .codex, density: density)
+        case .googleAI:
+            GeminiTabPage(density: density)
+        case .grok:
+            GrokPage(density: density)
+        case .misc:
+            MiscProvidersPage(density: density)
         }
     }
 
     private var headerTitle: String {
-        if kind == .compact, overviewPage == .misc {
-            return "Misc Providers"
-        }
-        if kind == .compact, overviewPage == .googleAI {
-            return "Gemini"
-        }
-        if kind == .compact, overviewPage == .grok {
-            return "Grok"
-        }
-        switch effectiveKind {
-        case .compact: return "Overview"
-        case .codex:   return "ChatGPT"
-        case .claude:  return "Claude"
-        case .status:  return "Service Status"
+        switch overviewPage {
+        case .overview: return "Overview"
+        case .openAI: return "ChatGPT"
+        case .claude: return "Claude"
+        case .googleAI: return "Gemini"
+        case .grok: return "Grok"
+        case .misc: return "Misc Providers"
         }
     }
 
     private var headerSubtitle: String? {
-        if kind == .compact, overviewPage == .misc {
-            return "Usage-only · sign in or paste a key"
-        }
-        if kind == .compact, overviewPage == .googleAI {
-            return "Gemini Web + AntiGravity · quota & status"
-        }
-        if kind == .compact, overviewPage == .grok {
-            return "xAI · monthly credits, cost & status"
-        }
-        switch effectiveKind {
-        case .compact: return "All providers · quota & cost"
-        case .codex:   return ToolType.codex.subtitle
-        case .claude:  return ToolType.claude.subtitle
-        case .status:  return "Live status pages"
-        }
-    }
-
-    private var headerPlan: String? {
-        // Always check `kind` here (not `effectiveKind`). The Overview popover
-        // sits between the page switcher and the refresh / settings buttons,
-        // so any extra accessory in that header band gets in the user's way
-        // when they're trying to switch tabs. AQ explicitly does not want a
-        // plan badge to appear in Overview, even when the active sub-page is
-        // Claude or OpenAI. Dedicated provider popovers still show it.
-        switch kind {
-        case .compact, .status: return nil
-        case .codex:   return planBadgeLabel(for: .codex)
-        case .claude:  return planBadgeLabel(for: .claude)
+        switch overviewPage {
+        case .overview: return "All providers · quota & cost"
+        case .openAI: return ToolType.codex.subtitle
+        case .claude: return ToolType.claude.subtitle
+        case .googleAI: return "Gemini Web + AntiGravity · quota & status"
+        case .grok: return "xAI · monthly credits, cost & status"
+        case .misc: return "Usage-only · sign in or paste a key"
         }
     }
 
@@ -178,23 +117,25 @@ struct PopoverRoot: View {
         // visible in the current popover. The Misc subpage owns its
         // usage-only integrations; the Google AI subpage aggregates the
         // partial-primary pair; the Grok subpage shows just `.grok`.
-        if kind == .compact, overviewPage == .misc {
+        if overviewPage == .misc {
             return settingsStore.settings.visibleMiscProviderList
         }
-        if kind == .compact, overviewPage == .googleAI {
+        if overviewPage == .googleAI {
             return ToolType.googleAIPair
         }
-        if kind == .compact, overviewPage == .grok {
+        if overviewPage == .grok {
             return [.grok]
         }
-        switch effectiveKind {
-        case .compact:
+        switch overviewPage {
+        case .overview:
             return ToolType.dedicatedCardProviders.filter {
                 settingsStore.settings.isCoreProviderVisible($0)
             }
-        case .status:           return ToolType.combinedStatusPageProviders
-        case .codex:            return [.codex]
-        case .claude:           return [.claude]
+        case .openAI: return [.codex]
+        case .claude: return [.claude]
+        case .googleAI: return ToolType.googleAIPair
+        case .grok: return [.grok]
+        case .misc: return settingsStore.settings.visibleMiscProviderList
         }
     }
 
@@ -210,23 +151,15 @@ struct PopoverRoot: View {
     }
 
     private var visibleAccounts: [AccountIdentity] {
-        if kind == .compact, overviewPage == .misc {
+        if overviewPage == .misc {
             return settingsStore.settings.visibleMiscProviderInstances
                 .compactMap { environment.account(for: $0) }
         }
         return visibleTools.compactMap { environment.account(for: $0) }
     }
 
-    private func planBadgeLabel(for tool: ToolType) -> String? {
-        settingsStore.settings.planBadgeLabel(
-            for: tool,
-            quotaPlan: environment.quota(for: tool)?.plan,
-            accountPlan: environment.account(for: tool)?.plan
-        )
-    }
-
     private var autoRefreshKey: String {
-        "\(kind.rawValue):\(overviewPage.rawValue)"
+        overviewPage.rawValue
     }
 
     private func refreshVisibleProvidersIfNeeded() {
@@ -309,17 +242,6 @@ private enum OverviewPage: String, CaseIterable, Identifiable {
         case .googleAI: return "Gemini"
         case .grok:     return "Grok"
         case .misc:     return "Misc"
-        }
-    }
-
-    var menuBarKind: MenuBarItemKind {
-        switch self {
-        case .overview: return .compact
-        case .openAI:   return .codex
-        case .claude:   return .claude
-        case .googleAI: return .compact
-        case .grok:     return .compact
-        case .misc:     return .compact
         }
     }
 
@@ -490,7 +412,7 @@ private struct OverviewWaterfall: View {
                         tool: .codex,
                         snapshot: combinedCostSnapshot,
                         density: density,
-                        chartHeight: 190,
+                        chartHeight: density.overviewCostChartHeight,
                         titleOverride: "All Providers Cost History"
                     )
                     .overviewMasonryItem(id: "cost-all-providers", phase: .cost)
@@ -774,7 +696,7 @@ private struct GeminiTabPage: View {
                         additionalQuotaSeries: antigravityQuotaSeries
                     )
                 }
-                ServiceStatusCard(tools: [.gemini])
+                ServiceStatusCard(tools: [.gemini], density: density)
             }
             .frame(
                 minWidth: geminiLeftColumnMinWidth,
@@ -789,19 +711,22 @@ private struct GeminiTabPage: View {
     }
 
     private var geminiLeftColumnMinWidth: CGFloat {
-        max(320, min(380, density.popoverWidth * 0.34))
+        density.detailLeftColumnRange.lowerBound
     }
 
     private var geminiLeftColumnIdealWidth: CGFloat {
-        max(geminiLeftColumnMinWidth, min(410, density.popoverWidth * 0.38))
+        min(
+            density.detailLeftColumnRange.upperBound,
+            max(geminiLeftColumnMinWidth, density.popoverWidth * density.detailLeftColumnFraction)
+        )
     }
 
     private var geminiLeftColumnMaxWidth: CGFloat {
-        max(geminiLeftColumnIdealWidth, min(440, density.popoverWidth * 0.42))
+        density.detailLeftColumnRange.upperBound
     }
 
     private var geminiRightColumnMinWidth: CGFloat {
-        500
+        density.detailRightColumnMinimum
     }
 }
 
@@ -900,7 +825,7 @@ private struct ProviderCostStack: View {
                 tool: tool,
                 snapshot: snapshot,
                 density: density,
-                chartHeight: 160
+                chartHeight: density.detailCostChartHeight
             )
             ModelRankingList(snapshot: snapshot, density: density)
             YearlyContributionHeatmapView(
@@ -922,8 +847,6 @@ private struct CombinedTotalsRow: View {
     @EnvironmentObject var environment: AppEnvironment
     @EnvironmentObject var costService: CostUsageService
     @EnvironmentObject var settingsStore: SettingsStore
-    private let summaryHeight: CGFloat = 178
-
     var body: some View {
         // Headline totals span every cost-aware provider, including
         // Google AI (Gemini + AntiGravity): AntiGravity usage is now
@@ -1022,9 +945,9 @@ private struct CombinedTotalsRow: View {
                     minWidth: columnWidth,
                     idealWidth: columnWidth,
                     maxWidth: columnWidth,
-                    minHeight: summaryHeight,
-                    idealHeight: summaryHeight,
-                    maxHeight: summaryHeight,
+                    minHeight: density.overviewSummaryHeight,
+                    idealHeight: density.overviewSummaryHeight,
+                    maxHeight: density.overviewSummaryHeight,
                     alignment: .topLeading
                 )
                 .background(
@@ -1038,7 +961,7 @@ private struct CombinedTotalsRow: View {
 
                 OverviewStatusSummaryCard(
                     density: density,
-                    minHeight: summaryHeight,
+                    minHeight: density.overviewSummaryHeight,
                     tools: ToolType.combinedStatusPageProviders.filter {
                         settingsStore.settings.isCoreProviderVisible($0)
                     }
@@ -1051,7 +974,7 @@ private struct CombinedTotalsRow: View {
                     )
             }
         }
-        .frame(height: summaryHeight)
+        .frame(height: density.overviewSummaryHeight)
     }
 
     private var divider: some View {
@@ -1109,7 +1032,7 @@ private struct OverviewStatusSummaryCard: View {
     @EnvironmentObject var serviceStatus: ServiceStatusController
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
+        VStack(alignment: .leading, spacing: density.cardSpacing) {
             HStack(alignment: .firstTextBaseline) {
                 Text("Status")
                     .font(.system(size: density.bucketTitleFontSize, weight: .semibold))
@@ -1140,11 +1063,11 @@ private struct OverviewStatusSummaryCard: View {
                 let tileHeight = statusTileHeight(rowCount: rowCount)
                 LazyVGrid(
                     columns: Array(
-                        repeating: GridItem(.flexible(), spacing: 8, alignment: .top),
+                        repeating: GridItem(.flexible(), spacing: density.cardSpacing, alignment: .top),
                         count: columnCount
                     ),
                     alignment: .leading,
-                    spacing: 8
+                    spacing: density.cardSpacing
                 ) {
                     ForEach(tools, id: \.self) { tool in
                         providerStatusTile(tool, height: tileHeight)
@@ -1168,25 +1091,31 @@ private struct OverviewStatusSummaryCard: View {
     private func statusTileHeight(rowCount: Int) -> CGFloat {
         let rows = max(1, rowCount)
         let headerHeight = max(18, density.bucketTitleFontSize + 6)
-        let gridSpacing = CGFloat(max(0, rows - 1)) * 8
+        let gridSpacing = CGFloat(max(0, rows - 1)) * density.cardSpacing
         let available = minHeight
             - density.cardPadding * 2
             - headerHeight
-            - 8
+            - density.cardSpacing
             - gridSpacing
-        return max(58, available / CGFloat(rows))
+        let minimum: CGFloat
+        switch density.profile {
+        case .compact: minimum = 46
+        case .regular: minimum = 58
+        case .spacious: minimum = 70
+        }
+        return max(minimum, available / CGFloat(rows))
     }
 
     private func providerStatusTile(_ tool: ToolType, height: CGFloat) -> some View {
         let state = statusState(for: tool)
         let snapshot = statusSnapshot(for: tool)
-        return VStack(alignment: .leading, spacing: 9) {
+        return VStack(alignment: .leading, spacing: density.bucketRowSpacing) {
             HStack(spacing: 7) {
                 Image(systemName: state.iconName)
-                    .font(.system(size: 15, weight: .semibold))
+                    .font(.system(size: density.bucketTitleFontSize + 1, weight: .semibold))
                     .foregroundStyle(state.color)
                     .frame(width: 17, height: 17)
-                ToolBrandIconView(tool: tool, size: 20)
+                ToolBrandIconView(tool: tool, size: density.bucketTitleFontSize + 6)
                     .opacity(0.9)
                     .frame(width: 22, height: 22)
                 Text(statusTitle(for: tool))
@@ -1213,8 +1142,8 @@ private struct OverviewStatusSummaryCard: View {
                 }
             }
         }
-        .padding(.horizontal, 12)
-        .padding(.vertical, 10)
+        .padding(.horizontal, density.cardPadding - 2)
+        .padding(.vertical, max(6, density.cardPadding - 4))
         .frame(minHeight: height, maxHeight: height, alignment: .center)
         .background(
             RoundedRectangle(cornerRadius: 9, style: .continuous)
@@ -1416,7 +1345,12 @@ private struct OverviewCostCard: View {
             if let snapshot, snapshot.jsonlFilesFound > 0 {
                 CostSummaryRow(snapshot: snapshot, density: density)
                 TopModelTile(snapshot: snapshot, density: density)
-                CostHistoryView(tool: tool, snapshot: snapshot, density: density, chartHeight: 160)
+                CostHistoryView(
+                    tool: tool,
+                    snapshot: snapshot,
+                    density: density,
+                    chartHeight: density.detailCostChartHeight
+                )
                     .padding(.top, 2)
             } else {
                 Text(emptyMessageOverride ?? emptyMessage)
@@ -1542,7 +1476,7 @@ private struct ProviderDetailView: View {
                         now: context.date
                     )
                 }
-                ServiceStatusCard(tools: [tool])
+                ServiceStatusCard(tools: [tool], density: density)
             }
             .frame(
                 minWidth: leftColumnMinWidth,
@@ -1558,7 +1492,7 @@ private struct ProviderDetailView: View {
                         tool: tool,
                         snapshot: snapshot,
                         density: density,
-                        chartHeight: 160
+                        chartHeight: density.detailCostChartHeight
                     )
                     ModelRankingList(snapshot: snapshot, density: density)
                     YearlyContributionHeatmapView(history: snapshot.dailyHistory, density: density, toolName: tool.menuTitle)
@@ -1576,19 +1510,22 @@ private struct ProviderDetailView: View {
     }
 
     private var leftColumnMinWidth: CGFloat {
-        max(320, min(380, density.popoverWidth * 0.34))
+        density.detailLeftColumnRange.lowerBound
     }
 
     private var leftColumnIdealWidth: CGFloat {
-        max(leftColumnMinWidth, min(410, density.popoverWidth * 0.38))
+        min(
+            density.detailLeftColumnRange.upperBound,
+            max(leftColumnMinWidth, density.popoverWidth * density.detailLeftColumnFraction)
+        )
     }
 
     private var leftColumnMaxWidth: CGFloat {
-        max(leftColumnIdealWidth, min(440, density.popoverWidth * 0.42))
+        density.detailLeftColumnRange.upperBound
     }
 
     private var rightColumnMinWidth: CGFloat {
-        500
+        density.detailRightColumnMinimum
     }
 }
 
@@ -1764,7 +1701,7 @@ struct ProviderQuotaCard: View {
             }
 
             if let quota, !quota.buckets.isEmpty {
-                bucketContent(quota.buckets)
+                bucketContent(quota.buckets, accountId: account?.id)
                 if tool == .codex, let credits = quota.resetCredits, credits.availableCount > 0 {
                     ResetCreditsRow(credits: credits, density: density)
                 }
@@ -1796,13 +1733,19 @@ struct ProviderQuotaCard: View {
         )
     }
 
-    private func bucketContent(_ buckets: [QuotaBucket]) -> some View {
+    private func bucketContent(_ buckets: [QuotaBucket], accountId: String?) -> some View {
         let primary = buckets.filter { $0.groupTitle == nil }
         let extras = buckets.filter { $0.groupTitle != nil }
         return VStack(alignment: .leading, spacing: density.bucketGroupSpacing) {
             if !primary.isEmpty {
                 ForEach(primary) { bucket in
-                    ProviderBucketRow(bucket: bucket, mode: settingsStore.displayMode, density: density)
+                    ProviderBucketRow(
+                        tool: tool,
+                        accountId: accountId,
+                        bucket: bucket,
+                        mode: settingsStore.displayMode,
+                        density: density
+                    )
                 }
             }
             if !compact, !extras.isEmpty {
@@ -1821,7 +1764,13 @@ struct ProviderQuotaCard: View {
                             .textCase(.uppercase)
                             .tracking(0.4)
                         ForEach(group.buckets) { bucket in
-                            ProviderBucketRow(bucket: bucket, mode: settingsStore.displayMode, density: density)
+                            ProviderBucketRow(
+                                tool: tool,
+                                accountId: accountId,
+                                bucket: bucket,
+                                mode: settingsStore.displayMode,
+                                density: density
+                            )
                         }
                     }
                 }
@@ -1912,9 +1861,14 @@ private struct ResetCreditsRow: View {
 }
 
 private struct ProviderBucketRow: View {
+    let tool: ToolType
+    let accountId: String?
     let bucket: QuotaBucket
     let mode: DisplayMode
     let density: Theme.Density
+
+    @EnvironmentObject var environment: AppEnvironment
+    @EnvironmentObject var quotaService: QuotaService
 
     var body: some View {
         // We only refresh "resets in …" periodically, but we don't repaint
@@ -1930,7 +1884,11 @@ private struct ProviderBucketRow: View {
     private func content(now: Date) -> some View {
         let percent = bucket.displayPercent(mode)
         let pace = UsagePace.compute(bucket: bucket, now: now)
-        let expectedDisplayed = pace.map { expectedDisplay(for: $0, mode: mode) }
+        let forecast = paceForecast(now: now)
+        let expectedDisplayed = forecast.map { displayedPlan($0) }
+            ?? pace.map { expectedDisplay(for: $0, mode: mode) }
+        let forecastRange = forecast.map { displayedRange($0) }
+        let forecastMedian = forecast.map { displayedForecast($0) }
         VStack(alignment: .leading, spacing: density.bucketRowSpacing) {
             HStack(alignment: .firstTextBaseline) {
                 Text(bucket.title)
@@ -1951,14 +1909,58 @@ private struct ProviderBucketRow: View {
                     usedPercent: percent,
                     expectedPercent: expectedDisplayed,
                     mode: mode,
-                    height: density.bucketBarHeight
+                    height: density.bucketBarHeight,
+                    forecastLowerPercent: forecastRange?.lowerBound,
+                    forecastUpperPercent: forecastRange?.upperBound,
+                    forecastMedianPercent: forecastMedian
                 )
             } else {
                 QuotaBarShape(percent: percent, mode: mode, height: density.bucketBarHeight)
             }
-            if let pace {
+            if let forecast {
+                QuotaForecastRow(
+                    forecast: forecast,
+                    now: now,
+                    fontSize: density.resetCountdownFontSize
+                )
+            } else if let pace {
                 UsagePaceRow(pace: pace, now: now, fontSize: density.resetCountdownFontSize)
             }
+        }
+    }
+
+    private func paceForecast(now: Date) -> QuotaPaceForecast? {
+        guard let resolvedAccountId = accountId ?? environment.account(for: tool)?.id else { return nil }
+        let snapshot = environment.costService.snapshot(for: tool)
+        return quotaService.paceForecast(
+            accountId: resolvedAccountId,
+            bucket: bucket,
+            activityHeatmap: snapshot?.heatmap,
+            dailyActivity: snapshot?.dailyHistory ?? [],
+            now: now
+        )
+    }
+
+    private func displayedPlan(_ forecast: QuotaPaceForecast) -> Double {
+        switch mode {
+        case .used: forecast.plannedUsedPercent
+        case .remaining: 100 - forecast.plannedUsedPercent
+        }
+    }
+
+    private func displayedForecast(_ forecast: QuotaPaceForecast) -> Double {
+        switch mode {
+        case .used: forecast.projectedUsedPercent
+        case .remaining: 100 - forecast.projectedUsedPercent
+        }
+    }
+
+    private func displayedRange(_ forecast: QuotaPaceForecast) -> ClosedRange<Double> {
+        switch mode {
+        case .used:
+            return forecast.projectedUsedLowerPercent...forecast.projectedUsedUpperPercent
+        case .remaining:
+            return (100 - forecast.projectedUsedUpperPercent)...(100 - forecast.projectedUsedLowerPercent)
         }
     }
 

--- a/Sources/VibeBarApp/Views/PopoverRoot.swift
+++ b/Sources/VibeBarApp/Views/PopoverRoot.swift
@@ -188,7 +188,10 @@ struct PopoverRoot: View {
             return [.grok]
         }
         switch effectiveKind {
-        case .compact:          return ToolType.dedicatedCardProviders
+        case .compact:
+            return ToolType.dedicatedCardProviders.filter {
+                settingsStore.settings.isCoreProviderVisible($0)
+            }
         case .status:           return ToolType.combinedStatusPageProviders
         case .codex:            return [.codex]
         case .claude:           return [.claude]
@@ -319,15 +322,34 @@ private enum OverviewPage: String, CaseIterable, Identifiable {
         case .misc:     return .compact
         }
     }
+
+    var coreProvider: ToolType? {
+        switch self {
+        case .openAI: return .codex
+        case .claude: return .claude
+        case .googleAI: return .gemini
+        case .grok: return .grok
+        case .overview, .misc: return nil
+        }
+    }
 }
 
 private struct OverviewPageSwitch: View {
     @Binding var selection: OverviewPage
     let density: Theme.Density
 
+    @EnvironmentObject var settingsStore: SettingsStore
+
+    private var visiblePages: [OverviewPage] {
+        OverviewPage.allCases.filter { page in
+            guard let provider = page.coreProvider else { return true }
+            return settingsStore.settings.isCoreProviderVisible(provider)
+        }
+    }
+
     var body: some View {
         HStack(spacing: 3) {
-            ForEach(OverviewPage.allCases) { page in
+            ForEach(visiblePages) { page in
                 let isSelected = selection == page
                 BorderlessRowButton(action: {
                     selection = page
@@ -365,6 +387,11 @@ private struct OverviewPageSwitch: View {
                         .stroke(Color.primary.opacity(0.075), lineWidth: 0.7)
                 )
         )
+        .onChange(of: settingsStore.settings.visibleCoreProviders) { _, _ in
+            if !visiblePages.contains(selection) {
+                selection = .overview
+            }
+        }
     }
 }
 
@@ -417,6 +444,7 @@ private struct OverviewWaterfall: View {
     let density: Theme.Density
 
     @EnvironmentObject var environment: AppEnvironment
+    @EnvironmentObject var settingsStore: SettingsStore
 
     var body: some View {
         let snapshots = overviewCostSnapshots
@@ -435,18 +463,26 @@ private struct OverviewWaterfall: View {
                 columns: 2,
                 spacing: density.interSectionSpacing
             ) {
-                ProviderQuotaCard(tool: .codex, density: density, compact: false)
-                    .overviewMasonryItem(id: "quota-codex", phase: .quota)
-                ProviderQuotaCard(tool: .claude, density: density, compact: false)
-                    .overviewMasonryItem(id: "quota-claude", phase: .quota)
+                if isVisible(.codex) {
+                    ProviderQuotaCard(tool: .codex, density: density, compact: false)
+                        .overviewMasonryItem(id: "quota-codex", phase: .quota)
+                }
+                if isVisible(.claude) {
+                    ProviderQuotaCard(tool: .claude, density: density, compact: false)
+                        .overviewMasonryItem(id: "quota-claude", phase: .quota)
+                }
                 // Gemini Web and AntiGravity both roll up to the
                 // Gemini product, so the Overview surface shows them
                 // as a single L2 "Gemini" card with two L3 sub-sections
                 // (`GeminiCombinedCard`). Grok stays on its own card.
-                GeminiCombinedCard(density: density)
-                    .overviewMasonryItem(id: "quota-gemini", phase: .quota)
-                ProviderQuotaCard(tool: .grok, density: density, compact: false)
-                    .overviewMasonryItem(id: "quota-grok", phase: .quota)
+                if isVisible(.gemini) {
+                    GeminiCombinedCard(density: density)
+                        .overviewMasonryItem(id: "quota-gemini", phase: .quota)
+                }
+                if isVisible(.grok) {
+                    ProviderQuotaCard(tool: .grok, density: density, compact: false)
+                        .overviewMasonryItem(id: "quota-grok", phase: .quota)
+                }
                 if hasCostData {
                     CostHistoryView(
                         tool: .codex,
@@ -467,16 +503,18 @@ private struct OverviewWaterfall: View {
                 // source (Gemini CLI no longer writes local telemetry);
                 // its `.pb`-only cascades are filled via the
                 // language-server RPC in CostUsageScanner.scanAntigravity.
-                OverviewCostCard(
-                    tool: .antigravity,
-                    density: density,
-                    snapshotOverride: googleAICostSnapshot,
-                    titleOverride: "Gemini Cost",
-                    emptyMessageOverride: "No Gemini / AntiGravity usage yet — open AntiGravity once so Vibe Bar can sync it.",
-                    toolNameOverride: "Gemini",
-                    heatmapTitleOverride: "When you use Gemini"
-                )
-                .overviewMasonryItem(id: "cost-gemini", phase: .cost)
+                if isVisible(.gemini) {
+                    OverviewCostCard(
+                        tool: .antigravity,
+                        density: density,
+                        snapshotOverride: googleAICostSnapshot,
+                        titleOverride: "Gemini Cost",
+                        emptyMessageOverride: "No Gemini / AntiGravity usage yet — open AntiGravity once so Vibe Bar can sync it.",
+                        toolNameOverride: "Gemini",
+                        heatmapTitleOverride: "When you use Gemini"
+                    )
+                    .overviewMasonryItem(id: "cost-gemini", phase: .cost)
+                }
                 if hasCostData {
                     ModelRankingList(
                         breakdowns: combinedModels,
@@ -506,7 +544,11 @@ private struct OverviewWaterfall: View {
     /// (combined Gemini + AntiGravity) via `googleAICostSnapshot`, so it
     /// isn't listed here.
     private var overviewCostProviders: [ToolType] {
-        [.codex, .claude, .grok]
+        [.codex, .claude, .grok].filter(isVisible)
+    }
+
+    private func isVisible(_ tool: ToolType) -> Bool {
+        settingsStore.settings.isCoreProviderVisible(tool)
     }
 
     /// Combined Gemini + AntiGravity cost, surfaced as the single
@@ -525,8 +567,10 @@ private struct OverviewWaterfall: View {
     /// data so Gemini / AntiGravity usage shows up there too.
     private var overviewCostSnapshots: [CostSnapshot] {
         var snaps = overviewCostProviders.compactMap { environment.costService.snapshot(for: $0) }
-        let googleAI = googleAICostSnapshot
-        if googleAI.jsonlFilesFound > 0 { snaps.append(googleAI) }
+        if isVisible(.gemini) {
+            let googleAI = googleAICostSnapshot
+            if googleAI.jsonlFilesFound > 0 { snaps.append(googleAI) }
+        }
         return snaps
     }
 }
@@ -877,6 +921,7 @@ private struct CombinedTotalsRow: View {
     @EnvironmentObject var environment: AppEnvironment
     @EnvironmentObject var costService: CostUsageService
     @EnvironmentObject var quotaService: QuotaService
+    @EnvironmentObject var settingsStore: SettingsStore
     private let summaryHeight: CGFloat = 178
 
     var body: some View {
@@ -884,7 +929,10 @@ private struct CombinedTotalsRow: View {
         // Google AI (Gemini + AntiGravity): AntiGravity usage is now
         // captured offline (`.db`) and via the language-server RPC
         // (`.pb`), so it's reliable enough to roll up here.
-        let snapshots = ToolType.costAwareProviders
+        let visibleCostProviders = ToolType.costAwareProviders.filter {
+            settingsStore.settings.isCoreProviderVisible($0)
+        }
+        let snapshots = visibleCostProviders
             .compactMap { environment.costService.snapshot(for: $0) }
         let dailyHistory = CostSnapshotAggregator.combinedDailyHistory(snapshots)
         let totalCost = snapshots.reduce(0.0) { $0 + $1.allTimeCostUSD }
@@ -898,7 +946,17 @@ private struct CombinedTotalsRow: View {
         let weekTokens = snapshots.reduce(0) { $0 + $1.last7DaysTokens }
         let monthTokens = snapshots.reduce(0) { $0 + $1.last30DaysTokens }
         let monthAverageCost = monthCost / 30
-        let overallFill = OverallFillRate.average(quotaService.lastSuccessByAccount)
+        let visibleAccountIDs = Set(
+            ToolType.dedicatedCardProviders
+                .filter { settingsStore.settings.isCoreProviderVisible($0) }
+                .compactMap { environment.account(for: $0)?.id }
+        )
+        let visibleQuotas = Dictionary(uniqueKeysWithValues:
+            quotaService.lastSuccessByAccount.compactMap { accountID, quota in
+                visibleAccountIDs.contains(accountID) ? (accountID, quota) : nil
+            }
+        )
+        let overallFill = OverallFillRate.average(visibleQuotas)
         // Pick the single day with the highest cost across all
         // providers, then surface both its cost and token totals so
         // the user sees what they spent *and* burned on their worst
@@ -1001,7 +1059,12 @@ private struct CombinedTotalsRow: View {
                         .stroke(.separator.opacity(0.4), lineWidth: 0.5)
                 )
 
-                OverviewStatusSummaryCard(density: density)
+                OverviewStatusSummaryCard(
+                    density: density,
+                    tools: ToolType.combinedStatusPageProviders.filter {
+                        settingsStore.settings.isCoreProviderVisible($0)
+                    }
+                )
                     .frame(
                         minWidth: availableWidth - costWidth,
                         idealWidth: availableWidth - costWidth,
@@ -1067,6 +1130,7 @@ private struct CombinedTotalsRow: View {
 
 private struct OverviewStatusSummaryCard: View {
     let density: Theme.Density
+    let tools: [ToolType]
 
     @EnvironmentObject var serviceStatus: ServiceStatusController
 
@@ -1091,14 +1155,21 @@ private struct OverviewStatusSummaryCard: View {
                 }
                 .disabled(!serviceStatus.inFlight.isEmpty)
             }
-            LazyVGrid(
-                columns: [GridItem(.adaptive(minimum: 150), spacing: 8, alignment: .top)],
-                alignment: .leading,
-                spacing: 8
-            ) {
-                ForEach(ToolType.combinedStatusPageProviders, id: \.self) { tool in
-                    providerStatusTile(tool)
-                        .frame(maxWidth: .infinity, alignment: .leading)
+            if tools.isEmpty {
+                Text("Enable a core provider in Settings to show service status.")
+                    .font(.system(size: max(9, density.subtitleFontSize - 1)))
+                    .foregroundStyle(.tertiary)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
+            } else {
+                LazyVGrid(
+                    columns: [GridItem(.adaptive(minimum: 150), spacing: 8, alignment: .top)],
+                    alignment: .leading,
+                    spacing: 8
+                ) {
+                    ForEach(tools, id: \.self) { tool in
+                        providerStatusTile(tool)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
                 }
             }
         }
@@ -1795,10 +1866,15 @@ struct ProviderQuotaCard: View {
 
     private func displayableError(_ error: QuotaError?, with quota: AccountQuota?) -> QuotaError? {
         guard let error else { return nil }
+        // A credential route can disappear temporarily when an account source
+        // reloads, even though the last successful quota remains complete and
+        // usable until its next reset. Do not turn that transient routing state
+        // into a large orange error inside an otherwise healthy quota card.
+        // Settings still exposes the live route-health result, while network
+        // and response-format failures continue to surface here.
         guard error.isCredentialState,
               let quota,
-              !quota.buckets.isEmpty,
-              Date().timeIntervalSince(quota.queriedAt) < 30 * 60
+              !quota.buckets.isEmpty
         else {
             return error
         }

--- a/Sources/VibeBarApp/Views/PopoverRoot.swift
+++ b/Sources/VibeBarApp/Views/PopoverRoot.swift
@@ -1171,13 +1171,19 @@ private struct OverviewStatusSummaryCard: View {
                     .foregroundStyle(.tertiary)
                     .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
             } else {
+                let columnCount = min(2, max(1, tools.count))
+                let rowCount = Int(ceil(Double(tools.count) / Double(columnCount)))
+                let tileHeight = statusTileHeight(rowCount: rowCount)
                 LazyVGrid(
-                    columns: [GridItem(.adaptive(minimum: 150), spacing: 8, alignment: .top)],
+                    columns: Array(
+                        repeating: GridItem(.flexible(), spacing: 8, alignment: .top),
+                        count: columnCount
+                    ),
                     alignment: .leading,
                     spacing: 8
                 ) {
                     ForEach(tools, id: \.self) { tool in
-                        providerStatusTile(tool)
+                        providerStatusTile(tool, height: tileHeight)
                             .frame(maxWidth: .infinity, alignment: .leading)
                     }
                 }
@@ -1195,19 +1201,32 @@ private struct OverviewStatusSummaryCard: View {
         )
     }
 
-    private func providerStatusTile(_ tool: ToolType) -> some View {
+    private func statusTileHeight(rowCount: Int) -> CGFloat {
+        let rows = max(1, rowCount)
+        let headerHeight = max(18, density.bucketTitleFontSize + 6)
+        let gridSpacing = CGFloat(max(0, rows - 1)) * 8
+        let available = minHeight
+            - density.cardPadding * 2
+            - headerHeight
+            - 8
+            - gridSpacing
+        return max(58, available / CGFloat(rows))
+    }
+
+    private func providerStatusTile(_ tool: ToolType, height: CGFloat) -> some View {
         let state = statusState(for: tool)
         let snapshot = statusSnapshot(for: tool)
-        return VStack(alignment: .leading, spacing: 7) {
-            HStack(spacing: 6) {
+        return VStack(alignment: .leading, spacing: 9) {
+            HStack(spacing: 7) {
                 Image(systemName: state.iconName)
-                    .font(.system(size: 13, weight: .semibold))
+                    .font(.system(size: 15, weight: .semibold))
                     .foregroundStyle(state.color)
-                ToolBrandIconView(tool: tool, size: 16)
+                    .frame(width: 17, height: 17)
+                ToolBrandIconView(tool: tool, size: 20)
                     .opacity(0.9)
-                    .frame(width: 18, height: 18)
+                    .frame(width: 22, height: 22)
                 Text(statusTitle(for: tool))
-                    .font(.system(size: density.subtitleFontSize, weight: .semibold, design: .rounded))
+                    .font(.system(size: density.subtitleFontSize + 1, weight: .semibold, design: .rounded))
                     .foregroundStyle(.primary)
                     .lineLimit(1)
                 Spacer(minLength: 4)
@@ -1230,9 +1249,9 @@ private struct OverviewStatusSummaryCard: View {
                 }
             }
         }
-        .padding(.horizontal, 10)
-        .padding(.vertical, 8)
-        .frame(minHeight: 54, alignment: .center)
+        .padding(.horizontal, 12)
+        .padding(.vertical, 10)
+        .frame(minHeight: height, maxHeight: height, alignment: .center)
         .background(
             RoundedRectangle(cornerRadius: 9, style: .continuous)
                 .fill(state.color.opacity(0.12))

--- a/Sources/VibeBarApp/Views/PopoverRoot.swift
+++ b/Sources/VibeBarApp/Views/PopoverRoot.swift
@@ -921,9 +921,8 @@ private struct CombinedTotalsRow: View {
 
     @EnvironmentObject var environment: AppEnvironment
     @EnvironmentObject var costService: CostUsageService
-    @EnvironmentObject var quotaService: QuotaService
     @EnvironmentObject var settingsStore: SettingsStore
-    private let summaryHeight: CGFloat = 220
+    private let summaryHeight: CGFloat = 178
 
     var body: some View {
         // Headline totals span every cost-aware provider, including
@@ -946,21 +945,6 @@ private struct CombinedTotalsRow: View {
         let yesterdayTokens = snapshots.reduce(0) { $0 + CostTimeframe.yesterday.tokens(in: $1) }
         let weekTokens = snapshots.reduce(0) { $0 + $1.last7DaysTokens }
         let monthTokens = snapshots.reduce(0) { $0 + $1.last30DaysTokens }
-        let monthAverageCost = monthCost / 30
-        let monthCostPerMillionTokens = monthTokens > 0
-            ? monthCost * 1_000_000 / Double(monthTokens)
-            : nil
-        let visibleAccountIDs = Set(
-            ToolType.dedicatedCardProviders
-                .filter { settingsStore.settings.isCoreProviderVisible($0) }
-                .compactMap { environment.account(for: $0)?.id }
-        )
-        let visibleQuotas = Dictionary(uniqueKeysWithValues:
-            quotaService.lastSuccessByAccount.compactMap { accountID, quota in
-                visibleAccountIDs.contains(accountID) ? (accountID, quota) : nil
-            }
-        )
-        let overallFill = OverallFillRate.average(visibleQuotas)
         // Pick the single day with the highest cost across all
         // providers, then surface both its cost and token totals so
         // the user sees what they spent *and* burned on their worst
@@ -970,20 +954,6 @@ private struct CombinedTotalsRow: View {
         let peakDayPoint = dailyHistory.max(by: { $0.costUSD < $1.costUSD })
         let peakDayCost = peakDayPoint?.costUSD ?? 0
         let peakDayTokens = peakDayPoint?.totalTokens ?? 0
-        // TPM is today-so-far tokens divided by elapsed minutes since
-        // local midnight. We floor the divisor to 1 so a 00:00:05
-        // launch can't divide by zero. RPM previously sat next to it
-        // but request counts aren't available across providers; the
-        // cell now surfaces the overall subscription fill rate
-        // instead, which is the more useful "are my plans burning
-        // hot?" indicator.
-        let elapsedMinutesToday: Double = {
-            let cal = Calendar.current
-            let start = cal.startOfDay(for: Date())
-            return max(1, Date().timeIntervalSince(start) / 60)
-        }()
-        let tokensPerMinute = Int((Double(todayTokens) / elapsedMinutesToday).rounded())
-
         GeometryReader { geometry in
             let spacing = density.interSectionSpacing
             let availableWidth = max(0, geometry.size.width - spacing)
@@ -1010,9 +980,8 @@ private struct CombinedTotalsRow: View {
                     }
                     .disabled(costService.isRefreshing)
                 }
-                    // 4 × 4 summary: durable all-time/peak context first,
-                    // matching cost and token timeframes next, then four
-                    // operational efficiency indicators.
+                    // 4 × 3 summary: durable all-time/peak context first,
+                    // followed by matching cost and token timeframes.
                     HStack(alignment: .top, spacing: 0) {
                         metric(label: "TOTAL COST", value: formatCost(totalCost), highlight: true)
                         divider
@@ -1039,15 +1008,6 @@ private struct CombinedTotalsRow: View {
                         metric(label: "7-DAY TOK", value: formatTokens(weekTokens))
                         divider
                         metric(label: "30-DAY TOK", value: formatTokens(monthTokens))
-                    }
-                    HStack(alignment: .top, spacing: 0) {
-                        metric(label: "30D AVG/DAY", value: formatCost(monthAverageCost))
-                        divider
-                        metric(label: "30D $/1M TOK", value: formatCost(monthCostPerMillionTokens))
-                        divider
-                        metric(label: "TPM", value: formatTokens(tokensPerMinute))
-                        divider
-                        metric(label: "FILL", value: formatFillPercent(overallFill))
                     }
                 }
                 .padding(density.cardPadding)
@@ -1123,11 +1083,6 @@ private struct CombinedTotalsRow: View {
         if tokens >= 1_000_000 { return String(format: "%.2fM", Double(tokens) / 1_000_000) }
         if tokens >= 1_000 { return String(format: "%.1fk", Double(tokens) / 1_000) }
         return "\(tokens)"
-    }
-
-    private func formatFillPercent(_ value: Double?) -> String {
-        guard let value, value.isFinite else { return "—" }
-        return "\(Int(value.rounded()))%"
     }
 
     private func formatModelName(_ modelName: String?) -> String {

--- a/Sources/VibeBarApp/Views/PopoverRoot.swift
+++ b/Sources/VibeBarApp/Views/PopoverRoot.swift
@@ -490,7 +490,7 @@ private struct OverviewWaterfall: View {
                         tool: .codex,
                         snapshot: combinedCostSnapshot,
                         density: density,
-                        chartHeight: 190,
+                        chartHeight: overviewCostHistoryHeight,
                         titleOverride: "All Providers Cost History"
                     )
                     .overviewMasonryItem(id: "cost-all-providers", phase: .cost)
@@ -547,6 +547,13 @@ private struct OverviewWaterfall: View {
     /// isn't listed here.
     private var overviewCostProviders: [ToolType] {
         [.codex, .claude, .grok].filter(isVisible)
+    }
+
+    /// Compact Overview already exposes one all-provider chart, so it should
+    /// stay useful without consuming the height of a full analytics card.
+    /// Regular and spacious layouts retain the established chart height.
+    private var overviewCostHistoryHeight: CGFloat {
+        density.popoverDensity == .compact ? 140 : 190
     }
 
     private func isVisible(_ tool: ToolType) -> Bool {
@@ -1340,9 +1347,10 @@ private enum OverviewStatusState {
     }
 }
 
-/// Cost card for the Overview right column — full Cost History bar chart with
-/// timeframe picker, plus a 4-column summary header. Tall enough to roughly
-/// match the height of the left-column quota cards (~280pt by default).
+/// Cost card for the Overview waterfall. Compact density keeps these as
+/// summary cards because the same surface already has the all-provider Cost
+/// History chart; the expand action exposes the provider's full charts.
+/// Regular and spacious densities retain the inline provider history.
 private struct OverviewCostCard: View {
     let tool: ToolType
     let density: Theme.Density
@@ -1407,8 +1415,10 @@ private struct OverviewCostCard: View {
             if let snapshot, snapshot.jsonlFilesFound > 0 {
                 CostSummaryRow(snapshot: snapshot, density: density)
                 TopModelTile(snapshot: snapshot, density: density)
-                CostHistoryView(tool: tool, snapshot: snapshot, density: density, chartHeight: 160)
-                    .padding(.top, 2)
+                if density.popoverDensity != .compact {
+                    CostHistoryView(tool: tool, snapshot: snapshot, density: density, chartHeight: 160)
+                        .padding(.top, 2)
+                }
             } else {
                 Text(emptyMessageOverride ?? emptyMessage)
                     .font(.system(size: density.subtitleFontSize))
@@ -1446,8 +1456,8 @@ private struct OverviewCostCard: View {
 }
 
 /// Detail popover surfaced when the user clicks the expand button on an
-/// Overview cost card. Contains the yearly contribution heatmap + weekday-hour
-/// heatmap + hourly burn rate.
+/// Overview cost card. Compact Overview moves the provider-specific Cost
+/// History here; the same popover also contains the longer-range analytics.
 private struct CostDetailPopoverContent: View {
     let tool: ToolType
     let density: Theme.Density
@@ -1479,6 +1489,12 @@ private struct CostDetailPopoverContent: View {
                     }
                 }
                 if let snap = snapshot {
+                    CostHistoryView(
+                        tool: tool,
+                        snapshot: snap,
+                        density: density,
+                        chartHeight: 180
+                    )
                     YearlyContributionHeatmapView(
                         history: snap.dailyHistory,
                         density: density,

--- a/Sources/VibeBarApp/Views/PopoverRoot.swift
+++ b/Sources/VibeBarApp/Views/PopoverRoot.swift
@@ -897,6 +897,7 @@ private struct CombinedTotalsRow: View {
         let yesterdayTokens = snapshots.reduce(0) { $0 + CostTimeframe.yesterday.tokens(in: $1) }
         let weekTokens = snapshots.reduce(0) { $0 + $1.last7DaysTokens }
         let monthTokens = snapshots.reduce(0) { $0 + $1.last30DaysTokens }
+        let monthAverageCost = monthCost / 30
         let overallFill = OverallFillRate.average(quotaService.lastSuccessByAccount)
         // Pick the single day with the highest cost across all
         // providers, then surface both its cost and token totals so
@@ -924,7 +925,9 @@ private struct CombinedTotalsRow: View {
         GeometryReader { geometry in
             let spacing = density.interSectionSpacing
             let availableWidth = max(0, geometry.size.width - spacing)
-            let costWidth = availableWidth * 0.62
+            // Five cost columns next to the status card's four logical
+            // columns: enough room for Yesterday without over-expanding Cost.
+            let costWidth = availableWidth * (5.0 / 9.0)
 
             HStack(alignment: .top, spacing: spacing) {
                 VStack(alignment: .leading, spacing: 8) {
@@ -973,6 +976,8 @@ private struct CombinedTotalsRow: View {
                         metric(label: "PEAK DAY", value: formatCost(peakDayCost))
                         divider
                         metric(label: "PEAK DAY TOK", value: formatTokens(peakDayTokens))
+                        divider
+                        metric(label: "30D AVG/DAY", value: formatCost(monthAverageCost))
                         divider
                         metric(label: "TPM", value: formatTokens(tokensPerMinute))
                         divider

--- a/Sources/VibeBarApp/Views/QuotaForecastRow.swift
+++ b/Sources/VibeBarApp/Views/QuotaForecastRow.swift
@@ -1,0 +1,67 @@
+import SwiftUI
+import VibeBarCore
+
+/// Compact, stable-height expression of the two forecast goals: survive the
+/// reset window and avoid leaving materially more than the safety target.
+struct QuotaForecastRow: View {
+    let forecast: QuotaPaceForecast
+    let now: Date
+    let fontSize: CGFloat
+    var showGuidance = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: showGuidance ? 3 : 0) {
+            HStack(spacing: 6) {
+                Circle()
+                    .fill(verdictColor)
+                    .frame(width: 5, height: 5)
+                Text(primaryText)
+                    .font(.system(size: fontSize, weight: .medium))
+                    .foregroundStyle(verdictColor)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+                Spacer(minLength: 4)
+                if showGuidance {
+                    Text(forecast.confidenceLabel)
+                        .font(.system(size: max(8, fontSize - 1)))
+                        .foregroundStyle(.tertiary)
+                        .lineLimit(1)
+                }
+            }
+            if showGuidance {
+                Text(forecast.guidanceSummary)
+                    .font(.system(size: max(8, fontSize - 1)))
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+        }
+    }
+
+    private var primaryText: String {
+        if forecast.verdict == .atRisk, let runOutAt = forecast.runOutAt,
+           let countdown = ResetCountdownFormatter.string(from: runOutAt, now: now) {
+            return "At risk · runs out in \(countdown)"
+        }
+        let left = Int(forecast.projectedRemainingPercent.rounded())
+        switch forecast.verdict {
+        case .enough:
+            return "Enough · forecast \(left)% left at reset"
+        case .watch:
+            return "Watch · forecast \(left)% left at reset"
+        case .atRisk:
+            return "At risk · likely to run out before reset"
+        case .learning:
+            return "Learning · about \(left)% left at reset"
+        }
+    }
+
+    private var verdictColor: Color {
+        switch forecast.verdict {
+        case .enough: Color(red: 0.20, green: 0.70, blue: 0.48)
+        case .watch: Color(red: 0.96, green: 0.62, blue: 0.20)
+        case .atRisk: Color(red: 0.95, green: 0.32, blue: 0.32)
+        case .learning: .secondary
+        }
+    }
+}

--- a/Sources/VibeBarApp/Views/ServiceStatusCard.swift
+++ b/Sources/VibeBarApp/Views/ServiceStatusCard.swift
@@ -4,27 +4,32 @@ import VibeBarCore
 
 struct ServiceStatusCard: View {
     let tools: [ToolType]
+    let density: Theme.Density
 
     @EnvironmentObject var environment: AppEnvironment
     @EnvironmentObject var serviceStatus: ServiceStatusController
 
-    init(tools: [ToolType] = ToolType.allCases.filter(\.supportsStatusPage)) {
+    init(
+        tools: [ToolType] = ToolType.allCases.filter(\.supportsStatusPage),
+        density: Theme.Density
+    ) {
         // Misc providers don't expose Atlassian-style status pages, so
         // they never belong in this card. Default to the providers
         // that actually publish a status feed; callers can still pass
         // an explicit subset (e.g. just `.codex` or `.claude`).
         self.tools = tools.filter(\.supportsStatusPage)
+        self.density = density
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 12) {
+        VStack(alignment: .leading, spacing: density.statusGroupSpacing) {
             HStack(alignment: .firstTextBaseline) {
                 Text("Service Status")
-                    .font(.system(size: 13, weight: .semibold))
+                    .font(.system(size: density.bucketTitleFontSize, weight: .semibold))
                 Spacer()
                 if let last = serviceStatus.lastFetched {
                     Text(timeAgo(last))
-                        .font(.system(size: 10))
+                        .font(.system(size: density.resetCountdownFontSize))
                         .foregroundStyle(.tertiary)
                 }
                 BorderlessIconButton(systemImage: "arrow.clockwise", help: "Refresh service status") {
@@ -32,19 +37,19 @@ struct ServiceStatusCard: View {
                 }
             }
 
-            VStack(spacing: 16) {
+            VStack(spacing: density.statusGroupSpacing + 4) {
                 ForEach(tools, id: \.self) { tool in
-                    ServiceStatusRow(tool: tool)
+                    ServiceStatusRow(tool: tool, density: density)
                 }
             }
         }
-        .padding(12)
+        .padding(density.cardPadding)
         .background(
-            RoundedRectangle(cornerRadius: Theme.sectionCornerRadius, style: .continuous)
+            RoundedRectangle(cornerRadius: density.cardCornerRadius, style: .continuous)
                 .fill(.background.tertiary.opacity(0.6))
         )
         .overlay(
-            RoundedRectangle(cornerRadius: Theme.sectionCornerRadius, style: .continuous)
+            RoundedRectangle(cornerRadius: density.cardCornerRadius, style: .continuous)
                 .stroke(.separator.opacity(0.5), lineWidth: 0.5)
         )
     }
@@ -59,6 +64,7 @@ struct ServiceStatusCard: View {
 
 private struct ServiceStatusRow: View {
     let tool: ToolType
+    let density: Theme.Density
 
     @EnvironmentObject var serviceStatus: ServiceStatusController
 
@@ -67,12 +73,20 @@ private struct ServiceStatusRow: View {
         let inFlight = serviceStatus.inFlight.contains(tool)
         let error = serviceStatus.errorByTool[tool]
 
-        VStack(alignment: .leading, spacing: 10) {
+        VStack(alignment: .leading, spacing: density.statusComponentSpacing + 2) {
             HStack(alignment: .center, spacing: 8) {
-                ToolBrandBadge(tool: tool, iconSize: 17, containerSize: 24)
+                ToolBrandBadge(
+                    tool: tool,
+                    iconSize: density.bucketTitleFontSize + 3,
+                    containerSize: density.bucketTitleFontSize + 10
+                )
                 Text(displayName)
-                    .font(.system(size: 13, weight: .semibold))
-                StatusPill(indicator: snapshot?.effectiveIndicator, description: snapshot?.effectiveDescription)
+                    .font(.system(size: density.bucketTitleFontSize, weight: .semibold))
+                StatusPill(
+                    indicator: snapshot?.effectiveIndicator,
+                    description: snapshot?.effectiveDescription,
+                    density: density
+                )
                 Spacer(minLength: 6)
                 if inFlight {
                     ProgressView().controlSize(.mini)
@@ -81,7 +95,7 @@ private struct ServiceStatusRow: View {
                     let agg = snapshot.displayUptimePercent
                     if agg > 0 {
                         Text(String(format: "%.2f%% uptime", agg))
-                            .font(.system(size: 10, weight: .medium, design: .rounded).monospacedDigit())
+                            .font(.system(size: density.resetCountdownFontSize, weight: .medium, design: .rounded).monospacedDigit())
                             .foregroundStyle(.secondary)
                     }
                 }
@@ -100,14 +114,14 @@ private struct ServiceStatusRow: View {
 
             if let error {
                 Text(error)
-                    .font(.system(size: 10))
+                    .font(.system(size: density.resetCountdownFontSize))
                     .foregroundStyle(.orange)
                     .lineLimit(2)
             } else if let snapshot, let latest = snapshot.recentIncidents.first {
-                IncidentRow(incident: latest)
+                IncidentRow(incident: latest, density: density)
             } else if snapshot != nil {
                 Text("No incidents in the last 90 days")
-                    .font(.system(size: 10))
+                    .font(.system(size: density.resetCountdownFontSize))
                     .foregroundStyle(.tertiary)
             }
         }
@@ -126,16 +140,18 @@ private struct ServiceStatusRow: View {
             ComponentGroupBlock(
                 title: "Components",
                 components: snapshot.components,
-                defaultExpanded: true
+                density: density,
+                defaultExpanded: defaultExpanded(forGroupName: "Components")
             )
         } else {
-            VStack(alignment: .leading, spacing: 12) {
+            VStack(alignment: .leading, spacing: density.statusGroupSpacing) {
                 ForEach(snapshot.groups) { group in
                     let comps = snapshot.components(in: group)
                     if !comps.isEmpty {
                         ComponentGroupBlock(
                             title: group.name,
                             components: comps,
+                            density: density,
                             defaultExpanded: defaultExpanded(forGroupName: group.name)
                         )
                     }
@@ -150,6 +166,7 @@ private struct ServiceStatusRow: View {
                     ComponentGroupBlock(
                         title: "Other",
                         components: ungrouped,
+                        density: density,
                         defaultExpanded: false
                     )
                 }
@@ -160,6 +177,8 @@ private struct ServiceStatusRow: View {
     /// Per-tool selective default-expand rule. Codex page opens only
     /// the "Codex" group; everything else opens every group.
     private func defaultExpanded(forGroupName name: String) -> Bool {
+        if density.profile == .compact { return false }
+        if density.profile == .spacious { return true }
         if tool == .codex {
             return name.localizedCaseInsensitiveContains("codex")
         }
@@ -178,6 +197,7 @@ private struct ServiceStatusRow: View {
 private struct ComponentGroupBlock: View {
     let title: String
     let components: [ServiceComponentSummary]
+    let density: Theme.Density
     /// Provider-level incident overlay (see `ServiceStatusSnapshot.incidentDays`)
     /// — merged into the summary strip so incident-only providers
     /// (Anthropic) don't render an all-green wall next to their own
@@ -189,31 +209,33 @@ private struct ComponentGroupBlock: View {
     init(
         title: String,
         components: [ServiceComponentSummary],
+        density: Theme.Density,
         defaultExpanded: Bool = false,
         incidentDays: [DayUptime]? = nil,
         incidentAdjustedUptime: Double? = nil
     ) {
         self.title = title
         self.components = components
+        self.density = density
         self.incidentDays = incidentDays
         self.incidentAdjustedUptime = incidentAdjustedUptime
         self._expanded = State(initialValue: defaultExpanded)
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
+        VStack(alignment: .leading, spacing: density.statusComponentSpacing) {
             BorderlessRowButton(action: {
                 withAnimation(.easeInOut(duration: 0.18)) { expanded.toggle() }
             }) {
                 HStack(spacing: 6) {
                     Image(systemName: statusIcon)
-                        .font(.system(size: 10, weight: .semibold))
+                        .font(.system(size: density.resetCountdownFontSize, weight: .semibold))
                         .foregroundStyle(componentColor(aggregateStatus))
                     Text(title)
-                        .font(.system(size: 11, weight: .semibold))
+                        .font(.system(size: density.subtitleFontSize, weight: .semibold))
                         .foregroundStyle(.primary)
                     Text("\(components.count) component\(components.count == 1 ? "" : "s")")
-                        .font(.system(size: 10))
+                        .font(.system(size: density.resetCountdownFontSize))
                         .foregroundStyle(.secondary)
                     Image(systemName: expanded ? "chevron.up" : "chevron.down")
                         .font(.system(size: 8, weight: .semibold))
@@ -221,7 +243,7 @@ private struct ComponentGroupBlock: View {
                     Spacer(minLength: 6)
                     if let uptime = aggregateUptime {
                         Text(String(format: "%.2f%% uptime", uptime))
-                            .font(.system(size: 10, weight: .medium, design: .rounded).monospacedDigit())
+                            .font(.system(size: density.resetCountdownFontSize, weight: .medium, design: .rounded).monospacedDigit())
                             .foregroundStyle(.secondary)
                     }
                 }
@@ -229,7 +251,7 @@ private struct ComponentGroupBlock: View {
 
             if !summaryDays.isEmpty {
                 UptimeStrip(days: summaryDays, currentImpact: impact(for: aggregateStatus))
-                    .frame(height: 12)
+                    .frame(height: density.statusStripHeight)
             } else {
                 Capsule()
                     .fill(Color.primary.opacity(0.05))
@@ -237,9 +259,9 @@ private struct ComponentGroupBlock: View {
             }
 
             if expanded {
-                VStack(alignment: .leading, spacing: 8) {
+                VStack(alignment: .leading, spacing: density.statusComponentSpacing) {
                     ForEach(components) { component in
-                        ComponentBar(component: component)
+                        ComponentBar(component: component, density: density)
                     }
                 }
                 .padding(.leading, 4)
@@ -298,33 +320,34 @@ private struct ComponentGroupBlock: View {
 
 private struct ComponentBar: View {
     let component: ServiceComponentSummary
+    let density: Theme.Density
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 4) {
+        VStack(alignment: .leading, spacing: max(3, density.statusComponentSpacing - 2)) {
             HStack(alignment: .firstTextBaseline, spacing: 6) {
                 Image(systemName: statusIcon)
-                    .font(.system(size: 10, weight: .semibold))
+                    .font(.system(size: density.resetCountdownFontSize, weight: .semibold))
                     .foregroundStyle(componentColor(component.status))
                 Text(component.name)
-                    .font(.system(size: 11, weight: .medium))
+                    .font(.system(size: density.subtitleFontSize, weight: .medium))
                     .foregroundStyle(.primary)
                     .lineLimit(1)
                     .truncationMode(.tail)
                 Spacer(minLength: 4)
                 if component.status != .operational {
                     Text(componentLabel(component.status))
-                        .font(.system(size: 9, weight: .semibold))
+                        .font(.system(size: max(8, density.resetCountdownFontSize - 1), weight: .semibold))
                         .foregroundStyle(componentColor(component.status))
                 }
                 if let uptime = component.uptimePercent {
                     Text(String(format: "%.2f%% uptime", uptime))
-                        .font(.system(size: 9, weight: .medium, design: .rounded).monospacedDigit())
+                        .font(.system(size: max(8, density.resetCountdownFontSize - 1), weight: .medium, design: .rounded).monospacedDigit())
                         .foregroundStyle(.tertiary)
                 }
             }
             if !component.recentDays.isEmpty {
                 UptimeStrip(days: component.recentDays, currentImpact: currentImpact)
-                    .frame(height: 12)
+                    .frame(height: density.statusStripHeight)
             } else {
                 Capsule()
                     .fill(Color.primary.opacity(0.05))
@@ -385,6 +408,7 @@ private func componentLabel(_ status: ComponentStatusLevel) -> String {
 private struct StatusPill: View {
     let indicator: StatusIndicator?
     let description: String?
+    let density: Theme.Density
 
     var body: some View {
         HStack(spacing: 5) {
@@ -392,7 +416,7 @@ private struct StatusPill: View {
                 .fill(color)
                 .frame(width: 6, height: 6)
             Text(text)
-                .font(.system(size: 10, weight: .medium))
+                .font(.system(size: density.resetCountdownFontSize, weight: .medium))
                 .foregroundStyle(.secondary)
                 .lineLimit(1)
         }
@@ -460,14 +484,15 @@ private func uptimeColor(for impact: IncidentImpact?) -> Color {
 
 private struct IncidentRow: View {
     let incident: IncidentSummary
+    let density: Theme.Density
 
     var body: some View {
         HStack(alignment: .firstTextBaseline, spacing: 6) {
             Image(systemName: incident.isResolved ? "checkmark.circle.fill" : "exclamationmark.triangle.fill")
-                .font(.system(size: 10, weight: .semibold))
+                .font(.system(size: density.resetCountdownFontSize, weight: .semibold))
                 .foregroundStyle(incident.isResolved ? .secondary : impactColor(incident.impact))
             Text(incident.name)
-                .font(.system(size: 10))
+                .font(.system(size: density.resetCountdownFontSize))
                 .foregroundStyle(.secondary)
                 .lineLimit(2)
             Spacer(minLength: 4)

--- a/Sources/VibeBarApp/Views/SettingsView.swift
+++ b/Sources/VibeBarApp/Views/SettingsView.swift
@@ -64,7 +64,7 @@ struct SettingsView: View {
 
                     settingsSection("Menu Bar Items") {
                         VStack(alignment: .leading, spacing: 8) {
-                            ForEach(MenuBarItemKind.userVisibleCases) { kind in
+                            ForEach(MenuBarItemKind.allCases) { kind in
                                 menuBarItemEditor(kind)
                             }
                         }
@@ -644,11 +644,11 @@ struct SettingsView: View {
                     }
                 }
                 .pickerStyle(.segmented)
-                Picker("Popover density", selection: popoverDensityBinding(kind)) {
+                Picker("Display density", selection: popoverDensityBinding()) {
                     ForEach(PopoverDensity.allCases) { Text($0.label).tag($0) }
                 }
                 .pickerStyle(.segmented)
-                Text(settingsStore.settings.popoverDensity(for: kind).detail)
+                Text(settingsStore.settings.popoverDensity.detail)
                     .font(.caption2)
                     .foregroundStyle(.tertiary)
                 if !MenuBarFieldCatalog.fields(for: kind).isEmpty {
@@ -890,12 +890,10 @@ struct SettingsView: View {
         )
     }
 
-    private func popoverDensityBinding(_ kind: MenuBarItemKind) -> Binding<PopoverDensity> {
+    private func popoverDensityBinding() -> Binding<PopoverDensity> {
         Binding(
-            get: { settingsStore.settings.popoverDensity(for: kind) },
-            set: { value in
-                settingsStore.settings.setPopoverDensity(value, for: kind)
-            }
+            get: { settingsStore.settings.popoverDensity },
+            set: { settingsStore.settings.popoverDensity = $0 }
         )
     }
 

--- a/Sources/VibeBarApp/Views/SettingsView.swift
+++ b/Sources/VibeBarApp/Views/SettingsView.swift
@@ -118,7 +118,13 @@ struct SettingsView: View {
                         }
                     }
 
-                    settingsSection("OpenAI Account") {
+                    settingsSection("OpenAI") {
+                        coreProviderSummary(
+                            representative: .codex,
+                            healthProviders: [.codex]
+                        )
+                        Divider()
+                            .padding(.vertical, 2)
                         Picker("Usage source", selection: $settingsStore.settings.codexUsageMode) {
                             ForEach(CodexUsageMode.allCases) { mode in
                                 Text(mode.label).tag(mode)
@@ -165,11 +171,17 @@ struct SettingsView: View {
                         Button {
                             environment.recheckPrimaryRouteHealth(provider: .codex)
                         } label: {
-                            Label("Check connections", systemImage: "checkmark.circle")
+                            Label("Check OpenAI connections", systemImage: "checkmark.circle")
                         }
                     }
 
-                    settingsSection("Claude Account") {
+                    settingsSection("Anthropic") {
+                        coreProviderSummary(
+                            representative: .claude,
+                            healthProviders: [.claude]
+                        )
+                        Divider()
+                            .padding(.vertical, 2)
                         Picker("Usage source", selection: $settingsStore.settings.claudeUsageMode) {
                             ForEach(ClaudeUsageMode.allCases) { mode in
                                 Text(mode.label).tag(mode)
@@ -216,15 +228,22 @@ struct SettingsView: View {
                         Button {
                             environment.recheckPrimaryRouteHealth(provider: .claude)
                         } label: {
-                            Label("Check connections", systemImage: "checkmark.circle")
+                            Label("Check Anthropic connections", systemImage: "checkmark.circle")
                         }
                     }
 
-                    settingsSection("Google AI Account") {
+                    settingsSection("Google AI") {
+                        coreProviderSummary(
+                            representative: .gemini,
+                            healthProviders: [.gemini, .antigravity]
+                        )
+                        Divider()
+                            .padding(.vertical, 2)
                         Text("Gemini and Antigravity share the same Google AI subscription quota. Cookie import is the only supported web path — there is no WebView login.")
                             .font(.caption)
                             .foregroundStyle(.secondary)
 
+                        sourceSummary(label: "Gemini source", value: "Web quota")
                         Text(GeminiUsageMode.webOnly.detail)
                             .font(.caption)
                             .foregroundStyle(.secondary)
@@ -258,11 +277,6 @@ struct SettingsView: View {
                         Divider()
                             .padding(.vertical, 2)
                         connectionHealthRows(provider: .gemini)
-                        Button {
-                            environment.recheckPrimaryRouteHealth(provider: .gemini)
-                        } label: {
-                            Label("Check Gemini connections", systemImage: "checkmark.circle")
-                        }
 
                         Divider()
                             .padding(.vertical, 2)
@@ -292,16 +306,25 @@ struct SettingsView: View {
                             .padding(.vertical, 2)
                         connectionHealthRows(provider: .antigravity)
                         Button {
+                            environment.recheckPrimaryRouteHealth(provider: .gemini)
                             environment.recheckPrimaryRouteHealth(provider: .antigravity)
                         } label: {
-                            Label("Check Antigravity connection", systemImage: "checkmark.circle")
+                            Label("Check Google AI connections", systemImage: "checkmark.circle")
                         }
                     }
 
-                    settingsSection("Grok Account") {
+                    settingsSection("xAI") {
+                        coreProviderSummary(
+                            representative: .grok,
+                            healthProviders: [.grok]
+                        )
+                        Divider()
+                            .padding(.vertical, 2)
                         Text("Vibe Bar can read Grok usage from `~/.grok/auth.json` (preferred — written by `grok login`) or from a signed-in grok.com browser session. Either source is enough.")
                             .font(.caption)
                             .foregroundStyle(.secondary)
+
+                        sourceSummary(label: "Usage source", value: "Auto")
 
                         if GrokCredentialsStore.hasCredentials() {
                             Label("~/.grok/auth.json detected", systemImage: "checkmark.circle")
@@ -348,7 +371,7 @@ struct SettingsView: View {
                         Button {
                             environment.recheckPrimaryRouteHealth(provider: .grok)
                         } label: {
-                            Label("Check Grok connections", systemImage: "checkmark.circle")
+                            Label("Check xAI connections", systemImage: "checkmark.circle")
                         }
 
                         Link("Open xAI status page",
@@ -512,8 +535,62 @@ struct SettingsView: View {
                         .font(.caption2)
                         .foregroundStyle(.tertiary)
                 }
+                .padding(.horizontal, 8)
+                .frame(minHeight: 28)
+                .background(
+                    RoundedRectangle(cornerRadius: 6, style: .continuous)
+                        .fill(healthColor(health.status).opacity(health.status == .ok ? 0.08 : 0.04))
+                )
             }
         }
+    }
+
+    private func coreProviderSummary(
+        representative: ToolType,
+        healthProviders: [ToolType]
+    ) -> some View {
+        let routes = healthProviders.flatMap(PrimaryProviderRoute.routes(for:))
+        let ready = routes.contains { route in
+            environment.routeHealth[route]?.status == .ok
+        }
+        return HStack(spacing: 10) {
+            ToolBrandIconView(tool: representative, size: 20)
+                .frame(width: 24, height: 24)
+            VStack(alignment: .leading, spacing: 1) {
+                Text(representative.statusProviderName)
+                    .font(.system(size: 13, weight: .semibold))
+                HStack(spacing: 5) {
+                    Circle()
+                        .fill(ready ? Color.green : Color.red)
+                        .frame(width: 7, height: 7)
+                    Text(ready ? "Ready" : "Needs setup")
+                        .font(.caption2)
+                        .foregroundStyle(ready ? Color.green : Color.red)
+                }
+            }
+            Spacer(minLength: 12)
+            Toggle("Show in Overview", isOn: coreProviderVisibilityBinding(representative))
+                .toggleStyle(.switch)
+                .controlSize(.small)
+                .font(.caption)
+        }
+    }
+
+    private func sourceSummary(label: String, value: String) -> some View {
+        HStack(alignment: .firstTextBaseline) {
+            Text(label)
+            Spacer(minLength: 12)
+            Text(value)
+                .foregroundStyle(.secondary)
+        }
+        .font(.body)
+    }
+
+    private func coreProviderVisibilityBinding(_ tool: ToolType) -> Binding<Bool> {
+        Binding(
+            get: { settingsStore.settings.isCoreProviderVisible(tool) },
+            set: { settingsStore.settings.setCoreProviderVisible($0, for: tool) }
+        )
     }
 
     private var keychainAuthorizationControls: some View {
@@ -551,8 +628,8 @@ struct SettingsView: View {
     private func healthColor(_ status: PrimaryProviderRouteHealthStatus) -> Color {
         switch status {
         case .ok: return .green
-        case .missing: return .red
-        case .blocked, .failed: return .orange
+        case .missing: return .secondary
+        case .blocked, .failed: return .red
         }
     }
 

--- a/Sources/VibeBarApp/Views/SubscriptionUtilizationView.swift
+++ b/Sources/VibeBarApp/Views/SubscriptionUtilizationView.swift
@@ -69,6 +69,7 @@ struct SubscriptionUtilizationView: View {
     private struct UtilizationBucket: Identifiable {
         let id: String
         let tool: ToolType
+        let accountId: String?
         let bucket: QuotaBucket
     }
 
@@ -81,11 +82,12 @@ struct SubscriptionUtilizationView: View {
             UtilizationBucket(
                 id: "primary:\(tool.rawValue):\($0.id)",
                 tool: tool,
+                accountId: environment.account(for: tool)?.id,
                 bucket: $0
             )
         }
         let additional = additionalQuotaSeries.map {
-            UtilizationBucket(id: $0.id, tool: $0.tool, bucket: $0.bucket)
+            UtilizationBucket(id: $0.id, tool: $0.tool, accountId: $0.accountId, bucket: $0.bucket)
         }
         return primary + additional
     }
@@ -119,8 +121,9 @@ struct SubscriptionUtilizationView: View {
     private func row(for item: UtilizationBucket) -> some View {
         let bucket = item.bucket
         let pace = UsagePace.compute(bucket: bucket, now: now)
+        let forecast = paceForecast(for: item)
         let used = bucket.usedPercent
-        let expected = pace?.expectedUsedPercent ?? 0
+        let expected = forecast?.plannedUsedPercent ?? pace?.expectedUsedPercent ?? 0
         VStack(alignment: .leading, spacing: density.bucketRowSpacing) {
             HStack(alignment: .firstTextBaseline) {
                 Text(rowTitle(for: item))
@@ -163,7 +166,7 @@ struct SubscriptionUtilizationView: View {
                 }
             }
             .chartYAxis(.hidden)
-            .frame(height: 36)
+            .frame(height: density.utilizationBarHeight)
             Text(SubscriptionWindowProgress.summary(
                 usedPercent: bucket.usedPercent,
                 resetAt: bucket.resetAt,
@@ -174,30 +177,37 @@ struct SubscriptionUtilizationView: View {
                 .foregroundStyle(.primary)
                 .lineLimit(1)
                 .truncationMode(.tail)
-            if let pace {
+            if let forecast {
+                QuotaForecastRow(
+                    forecast: forecast,
+                    now: now,
+                    fontSize: density.subtitleFontSize,
+                    showGuidance: true
+                )
+            } else if let pace {
                 HStack(spacing: 6) {
                     Text(pace.stageSummary)
                         .font(.system(size: density.subtitleFontSize, weight: .medium))
                         .foregroundStyle(.secondary)
-                        .lineLimit(1)
-                    if expected > 0 {
-                        Text("·")
-                            .font(.system(size: density.subtitleFontSize))
-                            .foregroundStyle(.tertiary)
-                        Text("expected \(Int(expected.rounded()))%")
-                            .font(.system(size: density.subtitleFontSize))
-                            .foregroundStyle(.secondary)
-                            .lineLimit(1)
-                    }
                     Spacer(minLength: 4)
                     Text(etaText(pace: pace))
                         .font(.system(size: density.subtitleFontSize))
                         .foregroundStyle(.secondary)
-                        .lineLimit(1)
-                        .truncationMode(.tail)
                 }
             }
         }
+    }
+
+    private func paceForecast(for item: UtilizationBucket) -> QuotaPaceForecast? {
+        guard let accountId = item.accountId else { return nil }
+        let snapshot = environment.costService.snapshot(for: item.tool)
+        return quotaService.paceForecast(
+            accountId: accountId,
+            bucket: item.bucket,
+            activityHeatmap: snapshot?.heatmap,
+            dailyActivity: snapshot?.dailyHistory ?? [],
+            now: now
+        )
     }
 
     private func rowTitle(for item: UtilizationBucket) -> String {

--- a/Sources/VibeBarApp/Views/SubscriptionUtilizationView.swift
+++ b/Sources/VibeBarApp/Views/SubscriptionUtilizationView.swift
@@ -2,9 +2,11 @@ import SwiftUI
 import Charts
 import VibeBarCore
 
-/// Subscription Utilization sub-page. For each main bucket (5h / weekly),
-/// shows the absolute time-since-reset on a horizontal Swift Charts bar
-/// alongside the linear "expected" reference line — making it obvious
+/// Subscription Utilization sub-page. Every independently resettable quota
+/// gets its own pace row — including model-scoped buckets such as Codex Spark
+/// and Claude Fable, plus linked product tools such as AntiGravity on Gemini.
+/// Each row shows the absolute time-since-reset on a horizontal Swift Charts
+/// bar alongside the linear "expected" reference line, making it obvious
 /// whether the user is burning faster or slower than the linear pace.
 struct SubscriptionUtilizationView: View {
     let tool: ToolType
@@ -12,7 +14,7 @@ struct SubscriptionUtilizationView: View {
     let mode: DisplayMode
     let density: Theme.Density
     let now: Date
-    var additionalHistorySeries: [FillTimelineSeries] = []
+    var additionalQuotaSeries: [FillTimelineSeries] = []
 
     @EnvironmentObject var environment: AppEnvironment
     @EnvironmentObject var quotaService: QuotaService
@@ -27,17 +29,19 @@ struct SubscriptionUtilizationView: View {
                     .font(.system(size: density.subtitleFontSize))
                     .foregroundStyle(.secondary)
                 SectionRefreshButton(isRefreshing: isRefreshing) {
-                    environment.refresh(tool)
+                    for refreshTool in refreshTools {
+                        environment.refresh(refreshTool)
+                    }
                 }
             }
-            if paceBuckets.isEmpty && historySeries.isEmpty {
+            if utilizationBuckets.isEmpty && historySeries.isEmpty {
                 Text("No utilization data — try refreshing.")
                     .font(.system(size: density.subtitleFontSize))
                     .foregroundStyle(.tertiary)
                     .padding(.vertical, 8)
             } else {
-                ForEach(paceBuckets) { bucket in
-                    row(for: bucket)
+                ForEach(utilizationBuckets) { item in
+                    row(for: item)
                 }
                 if !historySeries.isEmpty {
                     FillTimelineChart(
@@ -60,9 +64,30 @@ struct SubscriptionUtilizationView: View {
         )
     }
 
-    /// Pick the headline buckets only (no per-model groups).
-    private var paceBuckets: [QuotaBucket] {
-        buckets.filter { $0.groupTitle == nil }
+    /// One live quota row. The tool is retained so linked-product quotas can
+    /// be labelled and refreshed independently (Gemini Web + AntiGravity).
+    private struct UtilizationBucket: Identifiable {
+        let id: String
+        let tool: ToolType
+        let bucket: QuotaBucket
+    }
+
+    /// Keep live utilization and reset-cycle history on the same complete
+    /// quota set. Previously this path discarded every bucket with a
+    /// `groupTitle`, which made Spark and Fable disappear even though their
+    /// history tabs were already present.
+    private var utilizationBuckets: [UtilizationBucket] {
+        let primary = buckets.map {
+            UtilizationBucket(
+                id: "primary:\(tool.rawValue):\($0.id)",
+                tool: tool,
+                bucket: $0
+            )
+        }
+        let additional = additionalQuotaSeries.map {
+            UtilizationBucket(id: $0.id, tool: $0.tool, bucket: $0.bucket)
+        }
+        return primary + additional
     }
 
     /// Every bucket participates in reset-cycle history, including per-model
@@ -74,22 +99,31 @@ struct SubscriptionUtilizationView: View {
         } else {
             primary = []
         }
-        return primary + additionalHistorySeries
+        return primary + additionalQuotaSeries
     }
 
     private var isRefreshing: Bool {
-        guard let id = environment.account(for: tool)?.id else { return false }
-        return quotaService.inFlightAccountIds.contains(id)
+        refreshTools.contains { refreshTool in
+            guard let id = environment.account(for: refreshTool)?.id else { return false }
+            return quotaService.inFlightAccountIds.contains(id)
+        }
+    }
+
+    private var refreshTools: [ToolType] {
+        var seen: Set<ToolType> = []
+        let productTools = tool == .gemini ? ToolType.googleAIPair : [tool]
+        return (productTools + additionalQuotaSeries.map(\.tool)).filter { seen.insert($0).inserted }
     }
 
     @ViewBuilder
-    private func row(for bucket: QuotaBucket) -> some View {
+    private func row(for item: UtilizationBucket) -> some View {
+        let bucket = item.bucket
         let pace = UsagePace.compute(bucket: bucket, now: now)
         let used = bucket.usedPercent
         let expected = pace?.expectedUsedPercent ?? 0
         VStack(alignment: .leading, spacing: density.bucketRowSpacing) {
             HStack(alignment: .firstTextBaseline) {
-                Text(bucket.title)
+                Text(rowTitle(for: item))
                     .font(.system(size: density.bucketTitleFontSize, weight: .semibold))
                     .lineLimit(1)
                     .truncationMode(.tail)
@@ -164,6 +198,19 @@ struct SubscriptionUtilizationView: View {
                 }
             }
         }
+    }
+
+    private func rowTitle(for item: UtilizationBucket) -> String {
+        var parts: [String] = []
+        if item.tool != tool {
+            parts.append(item.tool.toolName)
+        }
+        if let groupTitle = item.bucket.groupTitle?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !groupTitle.isEmpty {
+            parts.append(groupTitle)
+        }
+        parts.append(item.bucket.title)
+        return parts.joined(separator: " · ")
     }
 
     private func percentLabel(used: Double) -> String {

--- a/Sources/VibeBarApp/Views/Theme.swift
+++ b/Sources/VibeBarApp/Views/Theme.swift
@@ -14,6 +14,7 @@ enum Theme {
     /// Per-density spacing/sizing for the popover. Returned by `Theme.density(for:)`.
     /// Each menu bar item kind picks its own density via Settings.
     struct Density {
+        let popoverDensity: PopoverDensity
         let popoverPaddingH: CGFloat
         let popoverPaddingV: CGFloat
         let interSectionSpacing: CGFloat
@@ -37,6 +38,7 @@ enum Theme {
         switch popover {
         case .compact:
             return Density(
+                popoverDensity: popover,
                 popoverPaddingH: 12, popoverPaddingV: 10,
                 interSectionSpacing: 10, cardPadding: 10, cardSpacing: 8,
                 bucketRowSpacing: 5, bucketGroupSpacing: 8,
@@ -48,6 +50,7 @@ enum Theme {
             )
         case .regular:
             return Density(
+                popoverDensity: popover,
                 popoverPaddingH: 16, popoverPaddingV: 14,
                 interSectionSpacing: 14, cardPadding: 14, cardSpacing: 10,
                 bucketRowSpacing: 6, bucketGroupSpacing: 12,
@@ -59,6 +62,7 @@ enum Theme {
             )
         case .spacious:
             return Density(
+                popoverDensity: popover,
                 popoverPaddingH: 20, popoverPaddingV: 18,
                 interSectionSpacing: 18, cardPadding: 16, cardSpacing: 12,
                 bucketRowSpacing: 8, bucketGroupSpacing: 14,
@@ -84,6 +88,7 @@ enum Theme {
         case .spacious: extraWidth = 560
         }
         return Density(
+            popoverDensity: base.popoverDensity,
             popoverPaddingH: base.popoverPaddingH,
             popoverPaddingV: base.popoverPaddingV,
             interSectionSpacing: base.interSectionSpacing,
@@ -115,6 +120,7 @@ enum Theme {
         case .spacious: extraWidth = 580
         }
         return Density(
+            popoverDensity: base.popoverDensity,
             popoverPaddingH: base.popoverPaddingH,
             popoverPaddingV: base.popoverPaddingV,
             interSectionSpacing: base.interSectionSpacing,

--- a/Sources/VibeBarApp/Views/Theme.swift
+++ b/Sources/VibeBarApp/Views/Theme.swift
@@ -12,8 +12,11 @@ enum Theme {
     static let glassPillCornerRadius: CGFloat = 12
 
     /// Per-density spacing/sizing for the popover. Returned by `Theme.density(for:)`.
-    /// Each menu bar item kind picks its own density via Settings.
+    /// One profile drives the full tabbed workspace. The semantic tokens below
+    /// deliberately change layout, chart presence, and information rhythm —
+    /// not just every number by the same scale factor.
     struct Density {
+        let profile: PopoverDensity
         let popoverPaddingH: CGFloat
         let popoverPaddingV: CGFloat
         let interSectionSpacing: CGFloat
@@ -30,6 +33,110 @@ enum Theme {
         let resetCountdownFontSize: CGFloat
         let bucketBarHeight: CGFloat
         let segmentedFontSize: CGFloat
+
+        var headerHeight: CGFloat {
+            switch profile {
+            case .compact: 34
+            case .regular: 40
+            case .spacious: 48
+            }
+        }
+
+        var overviewSummaryHeight: CGFloat {
+            switch profile {
+            case .compact: 148
+            case .regular: 178
+            case .spacious: 210
+            }
+        }
+
+        var overviewCostChartHeight: CGFloat {
+            switch profile {
+            case .compact: 154
+            case .regular: 190
+            case .spacious: 230
+            }
+        }
+
+        var detailCostChartHeight: CGFloat {
+            switch profile {
+            case .compact: 136
+            case .regular: 168
+            case .spacious: 208
+            }
+        }
+
+        var utilizationBarHeight: CGFloat {
+            switch profile {
+            case .compact: 28
+            case .regular: 36
+            case .spacious: 46
+            }
+        }
+
+        var activityBarHeight: CGFloat {
+            switch profile {
+            case .compact: 48
+            case .regular: 64
+            case .spacious: 82
+            }
+        }
+
+        var detailLeftColumnFraction: CGFloat {
+            switch profile {
+            case .compact: 0.38
+            case .regular: 0.37
+            case .spacious: 0.35
+            }
+        }
+
+        var detailLeftColumnRange: ClosedRange<CGFloat> {
+            switch profile {
+            case .compact: 300...350
+            case .regular: 350...410
+            case .spacious: 390...455
+            }
+        }
+
+        var detailRightColumnMinimum: CGFloat {
+            switch profile {
+            case .compact: 460
+            case .regular: 520
+            case .spacious: 620
+            }
+        }
+
+        var miscColumnCount: Int {
+            switch profile {
+            case .compact: 3
+            case .regular: 3
+            case .spacious: 3
+            }
+        }
+
+        var statusGroupSpacing: CGFloat {
+            switch profile {
+            case .compact: 8
+            case .regular: 12
+            case .spacious: 16
+            }
+        }
+
+        var statusComponentSpacing: CGFloat {
+            switch profile {
+            case .compact: 5
+            case .regular: 8
+            case .spacious: 11
+            }
+        }
+
+        var statusStripHeight: CGFloat {
+            switch profile {
+            case .compact: 9
+            case .regular: 12
+            case .spacious: 14
+            }
+        }
     }
 
     /// Standard popover density for single-provider popovers and detail views.
@@ -37,17 +144,19 @@ enum Theme {
         switch popover {
         case .compact:
             return Density(
+                profile: .compact,
                 popoverPaddingH: 12, popoverPaddingV: 10,
                 interSectionSpacing: 10, cardPadding: 10, cardSpacing: 8,
                 bucketRowSpacing: 5, bucketGroupSpacing: 8,
                 popoverWidth: 360, cardCornerRadius: 12,
                 titleFontSize: 14, subtitleFontSize: 11,
                 bucketTitleFontSize: 12, bucketPercentFontSize: 12,
-                resetCountdownFontSize: 10, bucketBarHeight: 12,
+                resetCountdownFontSize: 10, bucketBarHeight: 10,
                 segmentedFontSize: 11
             )
         case .regular:
             return Density(
+                profile: .regular,
                 popoverPaddingH: 16, popoverPaddingV: 14,
                 interSectionSpacing: 14, cardPadding: 14, cardSpacing: 10,
                 bucketRowSpacing: 6, bucketGroupSpacing: 12,
@@ -59,13 +168,14 @@ enum Theme {
             )
         case .spacious:
             return Density(
+                profile: .spacious,
                 popoverPaddingH: 20, popoverPaddingV: 18,
                 interSectionSpacing: 18, cardPadding: 16, cardSpacing: 12,
                 bucketRowSpacing: 8, bucketGroupSpacing: 14,
                 popoverWidth: 500, cardCornerRadius: 16,
                 titleFontSize: 18, subtitleFontSize: 13,
                 bucketTitleFontSize: 14, bucketPercentFontSize: 14,
-                resetCountdownFontSize: 12, bucketBarHeight: 12,
+                resetCountdownFontSize: 12, bucketBarHeight: 14,
                 segmentedFontSize: 13
             )
         }
@@ -77,13 +187,14 @@ enum Theme {
     /// per-density preset but the popoverWidth is roughly doubled.
     static func overviewDensity(for popover: PopoverDensity) -> Density {
         let base = density(for: popover)
-        let extraWidth: CGFloat
+        let workspaceWidth: CGFloat
         switch popover {
-        case .compact:  extraWidth = 500
-        case .regular:  extraWidth = 520
-        case .spacious: extraWidth = 560
+        case .compact:  workspaceWidth = 860
+        case .regular:  workspaceWidth = 960
+        case .spacious: workspaceWidth = 1120
         }
         return Density(
+            profile: base.profile,
             popoverPaddingH: base.popoverPaddingH,
             popoverPaddingV: base.popoverPaddingV,
             interSectionSpacing: base.interSectionSpacing,
@@ -91,7 +202,7 @@ enum Theme {
             cardSpacing: base.cardSpacing,
             bucketRowSpacing: base.bucketRowSpacing,
             bucketGroupSpacing: base.bucketGroupSpacing,
-            popoverWidth: base.popoverWidth + extraWidth,
+            popoverWidth: workspaceWidth,
             cardCornerRadius: base.cardCornerRadius,
             titleFontSize: base.titleFontSize,
             subtitleFontSize: base.subtitleFontSize,
@@ -108,13 +219,14 @@ enum Theme {
     /// width while the chart column still has enough space for both heatmaps.
     static func detailDensity(for popover: PopoverDensity) -> Density {
         let base = density(for: popover)
-        let extraWidth: CGFloat
+        let workspaceWidth: CGFloat
         switch popover {
-        case .compact:  extraWidth = 500
-        case .regular:  extraWidth = 540
-        case .spacious: extraWidth = 580
+        case .compact:  workspaceWidth = 860
+        case .regular:  workspaceWidth = 960
+        case .spacious: workspaceWidth = 1120
         }
         return Density(
+            profile: base.profile,
             popoverPaddingH: base.popoverPaddingH,
             popoverPaddingV: base.popoverPaddingV,
             interSectionSpacing: base.interSectionSpacing,
@@ -122,7 +234,7 @@ enum Theme {
             cardSpacing: base.cardSpacing,
             bucketRowSpacing: base.bucketRowSpacing,
             bucketGroupSpacing: base.bucketGroupSpacing,
-            popoverWidth: base.popoverWidth + extraWidth,
+            popoverWidth: workspaceWidth,
             cardCornerRadius: base.cardCornerRadius,
             titleFontSize: base.titleFontSize,
             subtitleFontSize: base.subtitleFontSize,

--- a/Sources/VibeBarApp/Views/Theme.swift
+++ b/Sources/VibeBarApp/Views/Theme.swift
@@ -14,7 +14,6 @@ enum Theme {
     /// Per-density spacing/sizing for the popover. Returned by `Theme.density(for:)`.
     /// Each menu bar item kind picks its own density via Settings.
     struct Density {
-        let popoverDensity: PopoverDensity
         let popoverPaddingH: CGFloat
         let popoverPaddingV: CGFloat
         let interSectionSpacing: CGFloat
@@ -38,7 +37,6 @@ enum Theme {
         switch popover {
         case .compact:
             return Density(
-                popoverDensity: popover,
                 popoverPaddingH: 12, popoverPaddingV: 10,
                 interSectionSpacing: 10, cardPadding: 10, cardSpacing: 8,
                 bucketRowSpacing: 5, bucketGroupSpacing: 8,
@@ -50,7 +48,6 @@ enum Theme {
             )
         case .regular:
             return Density(
-                popoverDensity: popover,
                 popoverPaddingH: 16, popoverPaddingV: 14,
                 interSectionSpacing: 14, cardPadding: 14, cardSpacing: 10,
                 bucketRowSpacing: 6, bucketGroupSpacing: 12,
@@ -62,7 +59,6 @@ enum Theme {
             )
         case .spacious:
             return Density(
-                popoverDensity: popover,
                 popoverPaddingH: 20, popoverPaddingV: 18,
                 interSectionSpacing: 18, cardPadding: 16, cardSpacing: 12,
                 bucketRowSpacing: 8, bucketGroupSpacing: 14,
@@ -88,7 +84,6 @@ enum Theme {
         case .spacious: extraWidth = 560
         }
         return Density(
-            popoverDensity: base.popoverDensity,
             popoverPaddingH: base.popoverPaddingH,
             popoverPaddingV: base.popoverPaddingV,
             interSectionSpacing: base.interSectionSpacing,
@@ -120,7 +115,6 @@ enum Theme {
         case .spacious: extraWidth = 580
         }
         return Density(
-            popoverDensity: base.popoverDensity,
             popoverPaddingH: base.popoverPaddingH,
             popoverPaddingV: base.popoverPaddingV,
             interSectionSpacing: base.interSectionSpacing,

--- a/Sources/VibeBarApp/Views/TopModelTile.swift
+++ b/Sources/VibeBarApp/Views/TopModelTile.swift
@@ -56,7 +56,7 @@ struct TopModelTile: View {
                 }
             }
             .padding(.horizontal, density.cardPadding - 2)
-            .padding(.vertical, 8)
+            .padding(.vertical, density.popoverDensity == .compact ? 6 : 8)
             .frame(maxWidth: .infinity, alignment: .leading)
             .background(
                 RoundedRectangle(cornerRadius: 8, style: .continuous)

--- a/Sources/VibeBarApp/Views/TopModelTile.swift
+++ b/Sources/VibeBarApp/Views/TopModelTile.swift
@@ -56,7 +56,7 @@ struct TopModelTile: View {
                 }
             }
             .padding(.horizontal, density.cardPadding - 2)
-            .padding(.vertical, density.popoverDensity == .compact ? 6 : 8)
+            .padding(.vertical, 8)
             .frame(maxWidth: .infinity, alignment: .leading)
             .background(
                 RoundedRectangle(cornerRadius: 8, style: .continuous)

--- a/Sources/VibeBarApp/Views/UsageActivityView.swift
+++ b/Sources/VibeBarApp/Views/UsageActivityView.swift
@@ -14,7 +14,7 @@ struct UsageActivityView: View {
     var titleOverride: String? = nil
 
     private let weekdayLabels = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"]
-    private let barRowHeight: CGFloat = 64
+    private var barRowHeight: CGFloat { density.activityBarHeight }
 
     @State private var measuredGridWidth: CGFloat = 0
     @EnvironmentObject var environment: AppEnvironment

--- a/Sources/VibeBarApp/Views/YearlyContributionHeatmapView.swift
+++ b/Sources/VibeBarApp/Views/YearlyContributionHeatmapView.swift
@@ -12,7 +12,13 @@ struct YearlyContributionHeatmapView: View {
     let density: Theme.Density
     let toolName: String
 
-    private let cellSpacing: CGFloat = 2
+    private var cellSpacing: CGFloat {
+        switch density.profile {
+        case .compact: 1.5
+        case .regular: 2
+        case .spacious: 2.5
+        }
+    }
     private let weekdayLabels = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"]
     @State private var measuredGridWidth: CGFloat = 0
     @EnvironmentObject var environment: AppEnvironment
@@ -102,7 +108,7 @@ struct YearlyContributionHeatmapView: View {
                         .frame(width: metrics.gridWidth, height: 12)
                     ForEach(monthMarkers, id: \.column) { marker in
                         Text(marker.label)
-                            .font(.system(size: 8, design: .rounded))
+                            .font(.system(size: max(7, density.resetCountdownFontSize - 2), design: .rounded))
                             .foregroundStyle(.tertiary)
                             .offset(x: CGFloat(marker.column) * (metrics.cellSize + metrics.cellSpacing))
                     }
@@ -116,11 +122,11 @@ struct YearlyContributionHeatmapView: View {
                         Group {
                             if weekday % 2 == 1 {
                                 Text(weekdayLabels[weekday])
-                                    .font(.system(size: 8, design: .rounded))
+                                    .font(.system(size: max(7, density.resetCountdownFontSize - 2), design: .rounded))
                                     .foregroundStyle(.tertiary)
                             } else {
                                 Text(" ")
-                                    .font(.system(size: 8))
+                                    .font(.system(size: max(7, density.resetCountdownFontSize - 2)))
                             }
                         }
                         .frame(width: metrics.labelWidth, height: metrics.cellSize)
@@ -153,12 +159,18 @@ struct YearlyContributionHeatmapView: View {
     private func gridMetrics(columnCount: Int, measuredWidth: CGFloat) -> YearlyGridMetrics {
         let labelWidth: CGFloat = 28
         let labelGap: CGFloat = 4
-        let fallbackWidth: CGFloat = 560
+        let fallbackWidth = density.detailRightColumnMinimum
         let availableWidth = measuredWidth > 1 ? measuredWidth : fallbackWidth
         let interCellSpacing = CGFloat(max(0, columnCount - 1)) * cellSpacing
         let usableWidth = max(0, availableWidth - labelWidth - labelGap - interCellSpacing)
         let rawSide = usableWidth / CGFloat(max(1, columnCount))
-        let cellSize = min(max(rawSide, 5), 13)
+        let cellBounds: ClosedRange<CGFloat>
+        switch density.profile {
+        case .compact: cellBounds = 4...11
+        case .regular: cellBounds = 5...13
+        case .spacious: cellBounds = 6...15
+        }
+        let cellSize = min(max(rawSide, cellBounds.lowerBound), cellBounds.upperBound)
         return YearlyGridMetrics(
             labelWidth: labelWidth,
             labelGap: labelGap,

--- a/Sources/VibeBarCore/Adapters/GeminiQuotaAdapter.swift
+++ b/Sources/VibeBarCore/Adapters/GeminiQuotaAdapter.swift
@@ -12,14 +12,19 @@ public struct GeminiQuotaAdapter: QuotaAdapter {
 
     private let session: URLSession
     private let now: @Sendable () -> Date
+    private let cookieHeader: @Sendable () throws -> String
 
     public init(
         session: URLSession = .shared,
         homeDirectory _: String = RealHomeDirectory.path,
-        now: @escaping @Sendable () -> Date = { Date() }
+        now: @escaping @Sendable () -> Date = { Date() },
+        cookieHeader: @escaping @Sendable () throws -> String = {
+            try GeminiWebCookieStore.readCookieHeader()
+        }
     ) {
         self.session = session
         self.now = now
+        self.cookieHeader = cookieHeader
     }
 
     public func fetch(for account: AccountIdentity) async throws -> AccountQuota {
@@ -28,7 +33,7 @@ public struct GeminiQuotaAdapter: QuotaAdapter {
         }
         let header: String
         do {
-            header = try GeminiWebCookieStore.readCookieHeader()
+            header = try cookieHeader()
         } catch {
             throw QuotaError.noCredential
         }

--- a/Sources/VibeBarCore/Models/AppSettings.swift
+++ b/Sources/VibeBarCore/Models/AppSettings.swift
@@ -12,9 +12,8 @@ public struct AppSettings: Codable, Equatable, Sendable {
     public var antigravityUsageMode: AntigravityUsageMode
     public var menuBarItems: [MenuBarItemSettings]
     public var miniWindow: MiniWindowSettings
-    /// Per-popover density. Each menu bar item kind has its own density so the
-    /// user can keep one popover roomy and another tight.
-    public var popoverDensities: [MenuBarItemKind: PopoverDensity]
+    /// One density profile controls the entire tabbed popover workspace.
+    public var popoverDensity: PopoverDensity
     /// Optional user-visible plan badge overrides. Empty means "Auto".
     public var providerPlanLabels: [ToolType: String]
     /// L1 providers shown on the Overview surface. Hiding one keeps its
@@ -52,7 +51,7 @@ public struct AppSettings: Codable, Equatable, Sendable {
         antigravityUsageMode: .auto,
         menuBarItems: Self.defaultMenuBarItems,
         miniWindow: Self.defaultMiniWindow,
-        popoverDensities: Self.defaultPopoverDensities,
+        popoverDensity: .regular,
         providerPlanLabels: Self.defaultProviderPlanLabels,
         visibleCoreProviders: Self.defaultVisibleCoreProviders,
         miscProviders: Self.defaultMiscProviders,
@@ -76,27 +75,6 @@ public struct AppSettings: Codable, Equatable, Sendable {
             ],
             customLabels: [:]
         ),
-        MenuBarItemSettings(
-            kind: .codex,
-            isVisible: false,
-            showTitle: true,
-            layout: .singleLine,
-            selectedFieldIds: MenuBarFieldCatalog.codexFields.map(\.id)
-        ),
-        MenuBarItemSettings(
-            kind: .claude,
-            isVisible: false,
-            showTitle: true,
-            layout: .singleLine,
-            selectedFieldIds: MenuBarFieldCatalog.claudeFields.map(\.id)
-        ),
-        MenuBarItemSettings(
-            kind: .status,
-            isVisible: false,
-            showTitle: false,
-            layout: .iconOnly,
-            selectedFieldIds: []
-        )
     ]
 
     public static let defaultMiniWindow = MiniWindowSettings(
@@ -104,15 +82,6 @@ public struct AppSettings: Codable, Equatable, Sendable {
         compactSelectedFieldIds: MenuBarFieldCatalog.allFields.map(\.id),
         customLabels: [:]
     )
-
-    /// New defaults: Overview is roomy (it shows 2 providers stacked), individual
-    /// provider popovers are also roomy (only one provider per popover now).
-    public static let defaultPopoverDensities: [MenuBarItemKind: PopoverDensity] = [
-        .compact: .regular,
-        .codex: .regular,
-        .claude: .regular,
-        .status: .regular
-    ]
 
     public static let defaultProviderPlanLabels: [ToolType: String] = [:]
 
@@ -157,7 +126,7 @@ public struct AppSettings: Codable, Equatable, Sendable {
         antigravityUsageMode: AntigravityUsageMode = .auto,
         menuBarItems: [MenuBarItemSettings] = AppSettings.defaultMenuBarItems,
         miniWindow: MiniWindowSettings = AppSettings.defaultMiniWindow,
-        popoverDensities: [MenuBarItemKind: PopoverDensity] = AppSettings.defaultPopoverDensities,
+        popoverDensity: PopoverDensity = .regular,
         providerPlanLabels: [ToolType: String] = AppSettings.defaultProviderPlanLabels,
         visibleCoreProviders: Set<ToolType> = AppSettings.defaultVisibleCoreProviders,
         miscProviders: [ToolType: MiscProviderSettings] = AppSettings.defaultMiscProviders,
@@ -177,7 +146,7 @@ public struct AppSettings: Codable, Equatable, Sendable {
         self.antigravityUsageMode = antigravityUsageMode
         self.menuBarItems = Self.normalizedMenuBarItems(menuBarItems)
         self.miniWindow = miniWindow
-        self.popoverDensities = popoverDensities
+        self.popoverDensity = popoverDensity
         self.providerPlanLabels = Self.normalizedProviderPlanLabels(providerPlanLabels)
         self.visibleCoreProviders = Self.normalizedVisibleCoreProviders(visibleCoreProviders)
         let normalizedLegacyProviders = Self.normalizedMiscProviders(miscProviders)
@@ -243,18 +212,15 @@ public struct AppSettings: Codable, Equatable, Sendable {
         self.menuBarItems = Self.normalizedMenuBarItems(decodedItems)
         self.miniWindow = try c.decodeIfPresent(MiniWindowSettings.self, forKey: .miniWindow) ?? Self.defaultMiniWindow
 
-        if let perKind = try c.decodeIfPresent([String: PopoverDensity].self, forKey: .popoverDensities) {
-            var map: [MenuBarItemKind: PopoverDensity] = [:]
-            for (raw, value) in perKind {
-                if let kind = MenuBarItemKind(rawValue: raw) { map[kind] = value }
-            }
-            self.popoverDensities = Self.normalizedPopoverDensities(map)
-        } else if let legacy = try c.decodeIfPresent(PopoverDensity.self, forKey: .popoverDensity) {
-            var map: [MenuBarItemKind: PopoverDensity] = [:]
-            for kind in MenuBarItemKind.allCases { map[kind] = legacy }
-            self.popoverDensities = map
+        if let density = try c.decodeIfPresent(PopoverDensity.self, forKey: .popoverDensity) {
+            self.popoverDensity = density
+        } else if let legacy = try c.decodeIfPresent([String: PopoverDensity].self, forKey: .popoverDensities) {
+            // The retired standalone Codex / Claude / Status popovers once
+            // persisted independent values. Only the Overview value belongs
+            // to the current tabbed workspace.
+            self.popoverDensity = legacy[MenuBarItemKind.compact.rawValue] ?? .regular
         } else {
-            self.popoverDensities = Self.defaultPopoverDensities
+            self.popoverDensity = .regular
         }
 
         if let labels = try c.decodeIfPresent([String: String].self, forKey: .providerPlanLabels) {
@@ -343,8 +309,7 @@ public struct AppSettings: Codable, Equatable, Sendable {
         try c.encode(antigravityUsageMode, forKey: .antigravityUsageMode)
         try c.encode(menuBarItems, forKey: .menuBarItems)
         try c.encode(miniWindow, forKey: .miniWindow)
-        let stringKeyed = Dictionary(uniqueKeysWithValues: popoverDensities.map { ($0.key.rawValue, $0.value) })
-        try c.encode(stringKeyed, forKey: .popoverDensities)
+        try c.encode(popoverDensity, forKey: .popoverDensity)
         let planLabels = Dictionary(uniqueKeysWithValues: providerPlanLabels.map { ($0.key.rawValue, $0.value) })
         try c.encode(planLabels, forKey: .providerPlanLabels)
         let normalizedVisibleCore = Self.normalizedVisibleCoreProviders(visibleCoreProviders)
@@ -376,14 +341,6 @@ public struct AppSettings: Codable, Equatable, Sendable {
             normalized.append(item)
         }
         menuBarItems = Self.normalizedMenuBarItems(normalized)
-    }
-
-    public func popoverDensity(for kind: MenuBarItemKind) -> PopoverDensity {
-        popoverDensities[kind] ?? Self.defaultPopoverDensities[kind] ?? .regular
-    }
-
-    public mutating func setPopoverDensity(_ density: PopoverDensity, for kind: MenuBarItemKind) {
-        popoverDensities[kind] = density
     }
 
     public func planBadgeLabel(
@@ -427,26 +384,10 @@ public struct AppSettings: Codable, Equatable, Sendable {
     }
 
     private static func normalizedMenuBarItems(_ items: [MenuBarItemSettings]) -> [MenuBarItemSettings] {
-        MenuBarItemKind.allCases.map { kind in
-            var item = items.first { $0.kind == kind }.map(migratedMenuBarItem)
-                ?? defaultMenuBarItems.first { $0.kind == kind }!
-            // Standalone menu bar tiles for non-user-visible kinds were
-            // retired in favour of the unified Overview tile. Force
-            // their isVisible=false on every normalize pass so legacy
-            // settings that had Codex/Claude/Status tiles enabled don't
-            // come back after the upgrade. The stored settings still
-            // round-trip — they just don't surface in the menu bar.
-            if !kind.isUserVisibleStandalone {
-                item.isVisible = false
-            }
-            return item
-        }
-    }
-
-    private static func normalizedPopoverDensities(_ map: [MenuBarItemKind: PopoverDensity]) -> [MenuBarItemKind: PopoverDensity] {
-        var out = defaultPopoverDensities
-        for (k, v) in map { out[k] = v }
-        return out
+        [
+            items.first { $0.kind == .compact }.map(migratedMenuBarItem)
+                ?? defaultMenuBarItems[0]
+        ]
     }
 
     private static func normalizedProviderPlanLabels(_ labels: [ToolType: String]) -> [ToolType: String] {

--- a/Sources/VibeBarCore/Models/AppSettings.swift
+++ b/Sources/VibeBarCore/Models/AppSettings.swift
@@ -17,6 +17,10 @@ public struct AppSettings: Codable, Equatable, Sendable {
     public var popoverDensities: [MenuBarItemKind: PopoverDensity]
     /// Optional user-visible plan badge overrides. Empty means "Auto".
     public var providerPlanLabels: [ToolType: String]
+    /// L1 providers shown on the Overview surface. Hiding one keeps its
+    /// credentials, refresh schedule, and history intact; it only removes the
+    /// provider's Overview card, totals contribution, status tile, and tab.
+    public var visibleCoreProviders: Set<ToolType>
     /// Per-misc-provider non-sensitive config (source mode, region,
     /// enterprise host, etc.). Sensitive credentials live in Keychain
     /// (`MiscCredentialStore` / `CookieHeaderCache`), never in this map. The
@@ -50,6 +54,7 @@ public struct AppSettings: Codable, Equatable, Sendable {
         miniWindow: Self.defaultMiniWindow,
         popoverDensities: Self.defaultPopoverDensities,
         providerPlanLabels: Self.defaultProviderPlanLabels,
+        visibleCoreProviders: Self.defaultVisibleCoreProviders,
         miscProviders: Self.defaultMiscProviders,
         visibleMiscProviders: Self.defaultVisibleMiscProviders,
         miscProviderOrder: Self.defaultMiscProviderOrder,
@@ -111,6 +116,10 @@ public struct AppSettings: Codable, Equatable, Sendable {
 
     public static let defaultProviderPlanLabels: [ToolType: String] = [:]
 
+    public static var defaultVisibleCoreProviders: Set<ToolType> {
+        Set(ToolType.coreProviderRepresentatives)
+    }
+
     /// Default `MiscProviderSettings` for every misc-page provider. Source
     /// selection is intentionally automatic and not exposed in the UI;
     /// region / enterprise host remain as provider-specific knobs.
@@ -150,6 +159,7 @@ public struct AppSettings: Codable, Equatable, Sendable {
         miniWindow: MiniWindowSettings = AppSettings.defaultMiniWindow,
         popoverDensities: [MenuBarItemKind: PopoverDensity] = AppSettings.defaultPopoverDensities,
         providerPlanLabels: [ToolType: String] = AppSettings.defaultProviderPlanLabels,
+        visibleCoreProviders: Set<ToolType> = AppSettings.defaultVisibleCoreProviders,
         miscProviders: [ToolType: MiscProviderSettings] = AppSettings.defaultMiscProviders,
         visibleMiscProviders: Set<ToolType> = AppSettings.defaultVisibleMiscProviders,
         miscProviderOrder: [ToolType] = AppSettings.defaultMiscProviderOrder,
@@ -169,6 +179,7 @@ public struct AppSettings: Codable, Equatable, Sendable {
         self.miniWindow = miniWindow
         self.popoverDensities = popoverDensities
         self.providerPlanLabels = Self.normalizedProviderPlanLabels(providerPlanLabels)
+        self.visibleCoreProviders = Self.normalizedVisibleCoreProviders(visibleCoreProviders)
         let normalizedLegacyProviders = Self.normalizedMiscProviders(miscProviders)
         let normalizedVisibleProviders = Self.normalizedVisibleMiscProviders(visibleMiscProviders)
         let normalizedProviderOrder = Self.normalizedMiscProviderOrder(miscProviderOrder)
@@ -199,6 +210,7 @@ public struct AppSettings: Codable, Equatable, Sendable {
         case popoverDensities
         case popoverDensity   // legacy single-value form
         case providerPlanLabels
+        case visibleCoreProviders
         case miscProviders
         case visibleMiscProviders
         case miscProviderOrder
@@ -253,6 +265,13 @@ public struct AppSettings: Codable, Equatable, Sendable {
             self.providerPlanLabels = Self.normalizedProviderPlanLabels(map)
         } else {
             self.providerPlanLabels = Self.defaultProviderPlanLabels
+        }
+
+        if let rawVisible = try c.decodeIfPresent([String].self, forKey: .visibleCoreProviders) {
+            let decoded = Set(rawVisible.compactMap(ToolType.init(rawValue:)))
+            self.visibleCoreProviders = Self.normalizedVisibleCoreProviders(decoded)
+        } else {
+            self.visibleCoreProviders = Self.defaultVisibleCoreProviders
         }
 
         // Misc providers: lossy decode keyed by ToolType raw value.
@@ -328,6 +347,11 @@ public struct AppSettings: Codable, Equatable, Sendable {
         try c.encode(stringKeyed, forKey: .popoverDensities)
         let planLabels = Dictionary(uniqueKeysWithValues: providerPlanLabels.map { ($0.key.rawValue, $0.value) })
         try c.encode(planLabels, forKey: .providerPlanLabels)
+        let normalizedVisibleCore = Self.normalizedVisibleCoreProviders(visibleCoreProviders)
+        let visibleCoreRaw = ToolType.coreProviderRepresentatives
+            .filter { normalizedVisibleCore.contains($0) }
+            .map(\.rawValue)
+        try c.encode(visibleCoreRaw, forKey: .visibleCoreProviders)
         let miscRaw = Dictionary(uniqueKeysWithValues: miscProviders.map { ($0.key.rawValue, $0.value) })
         try c.encode(miscRaw, forKey: .miscProviders)
         let visibleRaw = ToolType.miscPageProviders
@@ -387,6 +411,21 @@ public struct AppSettings: Codable, Equatable, Sendable {
         providerPlanLabels = Self.normalizedProviderPlanLabels(labels)
     }
 
+    public func isCoreProviderVisible(_ tool: ToolType) -> Bool {
+        guard let representative = tool.coreProviderRepresentative else { return false }
+        return Self.normalizedVisibleCoreProviders(visibleCoreProviders).contains(representative)
+    }
+
+    public mutating func setCoreProviderVisible(_ visible: Bool, for tool: ToolType) {
+        guard let representative = tool.coreProviderRepresentative else { return }
+        if visible {
+            visibleCoreProviders.insert(representative)
+        } else {
+            visibleCoreProviders.remove(representative)
+        }
+        visibleCoreProviders = Self.normalizedVisibleCoreProviders(visibleCoreProviders)
+    }
+
     private static func normalizedMenuBarItems(_ items: [MenuBarItemSettings]) -> [MenuBarItemSettings] {
         MenuBarItemKind.allCases.map { kind in
             var item = items.first { $0.kind == kind }.map(migratedMenuBarItem)
@@ -419,6 +458,10 @@ public struct AppSettings: Codable, Equatable, Sendable {
             }
         }
         return out
+    }
+
+    private static func normalizedVisibleCoreProviders(_ providers: Set<ToolType>) -> Set<ToolType> {
+        Set(providers.compactMap(\.coreProviderRepresentative))
     }
 
     /// Fill in defaults for any misc-page provider missing from the

--- a/Sources/VibeBarCore/Models/FillTimelinePoint.swift
+++ b/Sources/VibeBarCore/Models/FillTimelinePoint.swift
@@ -1,11 +1,10 @@
 import Foundation
 
-/// One point-in-time usage sample for a quota bucket, bucketed to an hour
-/// slot. Powers the CodexBar-style fill timeline chart: unlike
-/// `SubscriptionWindowSample` (one aggregate per reset window), this is a
-/// short-horizon time series — "at 16:00 on Jul 2 the weekly bucket was 24%
-/// used" — so it can include the 5-hour rolling windows the window-peak
-/// store deliberately excludes.
+/// One point-in-time usage sample for a quota bucket. Slots are adaptive:
+/// five-hour windows use five-minute slots, weekly windows use hourly slots,
+/// and monthly windows use six-hour slots. The exact sample timestamp and the
+/// provider's reset forecast are retained so the forecasting engine can
+/// distinguish real burn from refills and reset-time drift.
 public struct FillTimelinePoint: Codable, Sendable, Hashable {
     public let accountId: String
     public let tool: ToolType
@@ -17,6 +16,12 @@ public struct FillTimelinePoint: Codable, Sendable, Hashable {
     /// Exact refresh timestamp of the winning sample — shown in the
     /// hover caption ("Jul 2 at 16:23: 24% used").
     public var sampledAt: Date
+    /// Provider-reported reset forecast at the time of this observation.
+    /// Optional for schema-v1 points migrated from older builds.
+    public var resetAt: Date?
+    /// Window length at the time of this observation. Optional for legacy
+    /// points whose original payload did not retain this field.
+    public var rawWindowSeconds: Int?
 
     public init(
         accountId: String,
@@ -24,7 +29,9 @@ public struct FillTimelinePoint: Codable, Sendable, Hashable {
         bucketId: String,
         slotStart: Date,
         usedPercent: Double,
-        sampledAt: Date
+        sampledAt: Date,
+        resetAt: Date? = nil,
+        rawWindowSeconds: Int? = nil
     ) {
         self.accountId = accountId
         self.tool = tool
@@ -32,5 +39,7 @@ public struct FillTimelinePoint: Codable, Sendable, Hashable {
         self.slotStart = slotStart
         self.usedPercent = usedPercent
         self.sampledAt = sampledAt
+        self.resetAt = resetAt
+        self.rawWindowSeconds = rawWindowSeconds
     }
 }

--- a/Sources/VibeBarCore/Models/MenuBarSettings.swift
+++ b/Sources/VibeBarCore/Models/MenuBarSettings.swift
@@ -2,41 +2,15 @@ import Foundation
 
 public enum MenuBarItemKind: String, Codable, CaseIterable, Identifiable, Sendable {
     case compact
-    case codex
-    case claude
-    case status
 
     public var id: String { rawValue }
 
-    /// Cases that the Settings page is allowed to surface as
-    /// independently togglable menu bar items. The other cases
-    /// (`.codex` / `.claude` / `.status`) remain in the enum for
-    /// stored-settings backward compatibility and for sub-page
-    /// routing inside the Overview popover, but the standalone
-    /// menu-bar entry is intentionally retired in favour of the
-    /// single Overview tile.
-    public static let userVisibleCases: [MenuBarItemKind] = [.compact]
-
-    public var isUserVisibleStandalone: Bool {
-        Self.userVisibleCases.contains(self)
-    }
-
     public var label: String {
-        switch self {
-        case .compact: return "Overview"
-        case .codex:   return "OpenAI"
-        case .claude:  return "Claude"
-        case .status:  return "Status"
-        }
+        "Overview"
     }
 
     public var title: String {
-        switch self {
-        case .compact: return "VB"
-        case .codex:   return "OpenAI"
-        case .claude:  return "Claude"
-        case .status:  return "●"
-        }
+        "VB"
     }
 }
 
@@ -187,12 +161,7 @@ public enum MenuBarFieldCatalog {
         codexFields + claudeFields + geminiFields + antigravityFields + grokFields
 
     public static func fields(for kind: MenuBarItemKind) -> [MenuBarFieldOption] {
-        switch kind {
-        case .compact: return allFields
-        case .codex:   return codexFields
-        case .claude:  return claudeFields
-        case .status:  return []
-        }
+        allFields
     }
 
     public static func field(id: String) -> MenuBarFieldOption? {

--- a/Sources/VibeBarCore/Models/MenuBarSettings.swift
+++ b/Sources/VibeBarCore/Models/MenuBarSettings.swift
@@ -143,21 +143,21 @@ public struct MenuBarFieldOption: Identifiable, Hashable, Sendable {
 
 public enum MenuBarFieldCatalog {
     public static let codexFields: [MenuBarFieldOption] = [
-        option(.codex, "five_hour", "5 Hours", "5h"),
-        option(.codex, "weekly", "Weekly", "wk"),
-        option(.codex, "gpt_5_3_codex_spark_five_hour", "GPT-5.3 Codex Spark · 5 Hours", "Spark 5h"),
-        option(.codex, "gpt_5_3_codex_spark_weekly", "GPT-5.3 Codex Spark · Weekly", "Spark wk")
+        option(.codex, "five_hour", "5 Hours", "5 Hours"),
+        option(.codex, "weekly", "Weekly", "Weekly"),
+        option(.codex, "gpt_5_3_codex_spark_five_hour", "GPT-5.3 Codex Spark · 5 Hours", "Spark 5 Hours"),
+        option(.codex, "gpt_5_3_codex_spark_weekly", "GPT-5.3 Codex Spark · Weekly", "Spark Weekly")
     ]
 
     public static let claudeFields: [MenuBarFieldOption] = [
-        option(.claude, "five_hour", "5 Hours", "5h"),
-        option(.claude, "weekly", "All Models · Weekly", "All wk"),
-        option(.claude, "weekly_sonnet", "Sonnet · Weekly", "Sonnet wk"),
-        option(.claude, "weekly_design", "Designs · Weekly", "Design wk"),
+        option(.claude, "five_hour", "5 Hours", "5 Hours"),
+        option(.claude, "weekly", "All Models · Weekly", "Weekly"),
+        option(.claude, "weekly_sonnet", "Sonnet · Weekly", "Sonnet Weekly"),
+        option(.claude, "weekly_design", "Designs · Weekly", "Design Weekly"),
         option(.claude, "daily_routines", "Daily Routines", "Routines"),
-        option(.claude, "weekly_opus", "Opus · Weekly", "Opus wk"),
-        option(.claude, "weekly_fable", "Fable · Weekly", "Fable wk"),
-        option(.claude, "weekly_oauth_apps", "OAuth Apps · Weekly", "OAuth wk")
+        option(.claude, "weekly_opus", "Opus · Weekly", "Opus Weekly"),
+        option(.claude, "weekly_fable", "Fable · Weekly", "Fable Weekly"),
+        option(.claude, "weekly_oauth_apps", "OAuth Apps · Weekly", "OAuth Weekly")
     ]
 
     // Gemini Web (`gemini.google.com`) exposes a 5-hour rolling
@@ -168,19 +168,19 @@ public enum MenuBarFieldCatalog {
     // adapter the Web parser no longer produces; those ids get
     // migrated to the new pair in `fieldIdMigrations` below.
     public static let geminiFields: [MenuBarFieldOption] = [
-        option(.gemini, "five_hour", "5 Hours", "5h"),
-        option(.gemini, "weekly", "Weekly", "wk")
+        option(.gemini, "five_hour", "5 Hours", "5 Hours"),
+        option(.gemini, "weekly", "Weekly", "Weekly")
     ]
 
     public static let antigravityFields: [MenuBarFieldOption] = [
-        option(.antigravity, "gemini_five_hour", "Gemini Models · 5 Hours", "G 5h"),
-        option(.antigravity, "gemini_weekly", "Gemini Models · Weekly", "G wk"),
-        option(.antigravity, "claude_gpt_five_hour", "Claude and GPT Models · 5 Hours", "C+G 5h"),
-        option(.antigravity, "claude_gpt_weekly", "Claude and GPT Models · Weekly", "C+G wk")
+        option(.antigravity, "gemini_five_hour", "Gemini Models · 5 Hours", "G 5 Hours"),
+        option(.antigravity, "gemini_weekly", "Gemini Models · Weekly", "G Weekly"),
+        option(.antigravity, "claude_gpt_five_hour", "Claude and GPT Models · 5 Hours", "C+G 5 Hours"),
+        option(.antigravity, "claude_gpt_weekly", "Claude and GPT Models · Weekly", "C+G Weekly")
     ]
 
     public static let grokFields: [MenuBarFieldOption] = [
-        option(.grok, "weekly", "Weekly Credits", "wk")
+        option(.grok, "weekly", "Weekly Credits", "Weekly")
     ]
 
     public static let allFields: [MenuBarFieldOption] =

--- a/Sources/VibeBarCore/Models/PrimaryProviderRouteHealth.swift
+++ b/Sources/VibeBarCore/Models/PrimaryProviderRouteHealth.swift
@@ -157,7 +157,28 @@ public enum PrimaryProviderRouteHealthChecker {
         route: PrimaryProviderRoute,
         now: Date
     ) -> PrimaryProviderRouteHealth {
-        if antigravityLanguageServerIsRunning() {
+        let dataRoot = URL(fileURLWithPath: RealHomeDirectory.path)
+            .appendingPathComponent(".gemini/antigravity")
+        return antigravityLocalProbeHealth(
+            route: route,
+            languageServerRunning: antigravityLanguageServerIsRunning(),
+            hasLocalData: FileManager.default.fileExists(atPath: dataRoot.path),
+            now: now
+        )
+    }
+
+    /// Separates the AntiGravity availability semantics from process and file
+    /// probing so the important cached-data fallback remains testable. A
+    /// stopped language server is not a broken connection when Vibe Bar still
+    /// has usable local AntiGravity data; it only means live synchronization is
+    /// paused until AntiGravity runs again.
+    static func antigravityLocalProbeHealth(
+        route: PrimaryProviderRoute = .antigravityLocalProbe,
+        languageServerRunning: Bool,
+        hasLocalData: Bool,
+        now: Date
+    ) -> PrimaryProviderRouteHealth {
+        if languageServerRunning {
             return PrimaryProviderRouteHealth(
                 route: route,
                 status: .ok,
@@ -165,13 +186,11 @@ public enum PrimaryProviderRouteHealthChecker {
                 checkedAt: now
             )
         }
-        let dataRoot = URL(fileURLWithPath: RealHomeDirectory.path)
-            .appendingPathComponent(".gemini/antigravity")
-        if FileManager.default.fileExists(atPath: dataRoot.path) {
+        if hasLocalData {
             return PrimaryProviderRouteHealth(
                 route: route,
-                status: .missing,
-                detail: "Local data found; LSP not running",
+                status: .ok,
+                detail: "Local data available; LSP offline",
                 checkedAt: now
             )
         }

--- a/Sources/VibeBarCore/Models/QuotaBucket.swift
+++ b/Sources/VibeBarCore/Models/QuotaBucket.swift
@@ -20,7 +20,10 @@ public struct QuotaBucket: Codable, Identifiable, Hashable, Sendable {
     ) {
         self.id = id
         self.title = VisibleSecretRedactor.redact(title) ?? ""
-        self.shortLabel = VisibleSecretRedactor.redact(shortLabel) ?? ""
+        self.shortLabel = Self.expandedWindowLabel(
+            VisibleSecretRedactor.redact(shortLabel) ?? "",
+            bucketId: id
+        )
         // Swift's `min/max` on Double pass NaN through unchanged in
         // one ordering and trap it in the other, so a non-finite
         // value here would silently end up as 100% — a much louder
@@ -30,6 +33,59 @@ public struct QuotaBucket: Codable, Identifiable, Hashable, Sendable {
         self.resetAt = resetAt
         self.rawWindowSeconds = rawWindowSeconds
         self.groupTitle = VisibleSecretRedactor.redact(groupTitle)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case title
+        case shortLabel
+        case usedPercent
+        case resetAt
+        case rawWindowSeconds
+        case groupTitle
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.init(
+            id: try container.decode(String.self, forKey: .id),
+            title: try container.decode(String.self, forKey: .title),
+            shortLabel: try container.decode(String.self, forKey: .shortLabel),
+            usedPercent: try container.decode(Double.self, forKey: .usedPercent),
+            resetAt: try container.decodeIfPresent(Date.self, forKey: .resetAt),
+            rawWindowSeconds: try container.decodeIfPresent(Int.self, forKey: .rawWindowSeconds),
+            groupTitle: try container.decodeIfPresent(String.self, forKey: .groupTitle)
+        )
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(id, forKey: .id)
+        try container.encode(title, forKey: .title)
+        try container.encode(shortLabel, forKey: .shortLabel)
+        try container.encode(usedPercent, forKey: .usedPercent)
+        try container.encodeIfPresent(resetAt, forKey: .resetAt)
+        try container.encodeIfPresent(rawWindowSeconds, forKey: .rawWindowSeconds)
+        try container.encodeIfPresent(groupTitle, forKey: .groupTitle)
+    }
+
+    /// Quota-window names are ordinary UI copy, not telemetry codes. Keep
+    /// provider/parser compatibility inside the adapters while guaranteeing
+    /// that every newly parsed or cache-restored bucket exposes full words to
+    /// the app surfaces.
+    private static func expandedWindowLabel(_ label: String, bucketId: String) -> String {
+        if bucketId == "five_hour" { return "5 Hours" }
+        if bucketId == "weekly" { return "Weekly" }
+        return label
+            .split(separator: " ", omittingEmptySubsequences: false)
+            .map { component in
+                switch component.lowercased() {
+                case "5h": return "5 Hours"
+                case "wk": return "Weekly"
+                default: return String(component)
+                }
+            }
+            .joined(separator: " ")
     }
 
     public var remainingPercent: Double {

--- a/Sources/VibeBarCore/Models/ToolType.swift
+++ b/Sources/VibeBarCore/Models/ToolType.swift
@@ -132,7 +132,28 @@ public enum ToolType: String, Codable, CaseIterable, Hashable, Sendable {
     }
 
     public static var combinedStatusPageProviders: [ToolType] {
+        coreProviderRepresentatives
+    }
+
+    /// One representative tool for each L1 provider shown in Overview and
+    /// Settings. Google AI is represented by Gemini; AntiGravity maps back to
+    /// the same provider so one visibility switch controls the combined card.
+    public static var coreProviderRepresentatives: [ToolType] {
         [.codex, .claude, .gemini, .grok]
+    }
+
+    public var coreProviderRepresentative: ToolType? {
+        switch self {
+        case .codex, .claude, .gemini, .grok:
+            return self
+        case .antigravity:
+            return .gemini
+        case .alibaba, .alibabaTokenPlan, .copilot, .zai, .minimax, .kimi,
+             .cursor, .mimo, .iflytek, .tencentHunyuan, .tencentTokenPlan,
+             .volcengine, .volcengineAgentPlan, .baiduQianfan, .openCodeGo,
+             .kilo, .kiro, .ollama, .openRouter, .warp:
+            return nil
+        }
     }
 
     public static var miscPageProviders: [ToolType] {

--- a/Sources/VibeBarCore/Services/CostHistoryStore.swift
+++ b/Sources/VibeBarCore/Services/CostHistoryStore.swift
@@ -191,12 +191,14 @@ public actor CostHistoryStore {
             allTimeTokens: allTokens,
             dailyHistory: dailyPoints,
             todayHourlyHistory: snapshot.todayHourlyHistory,
+            yesterdayHourlyHistory: snapshot.yesterdayHourlyHistory,
             heatmap: snapshot.heatmap,
             modelBreakdowns: snapshot.modelBreakdowns,
             last7DaysModelBreakdowns: snapshot.last7DaysModelBreakdowns,
             // Per-day model breakdown is in-memory only; preserve whatever
             // the live scan produced. Persisted historical days won't have it.
             dailyModelBreakdown: snapshot.dailyModelBreakdown,
+            hourlyModelBreakdown: snapshot.hourlyModelBreakdown,
             jsonlFilesFound: snapshot.jsonlFilesFound,
             updatedAt: snapshot.updatedAt
         )

--- a/Sources/VibeBarCore/Services/CostUsageScanner.swift
+++ b/Sources/VibeBarCore/Services/CostUsageScanner.swift
@@ -1441,20 +1441,18 @@ public enum CostUsageScanner {
                 .sorted { $0.value.cost > $1.value.cost }
                 .prefix(20)
                 .map { CostSnapshot.ModelBreakdown(modelName: $0.key, costUSD: $0.value.cost, totalTokens: $0.value.tokens) }
-            // Keep enough entries for the compact top-three hover plus the
-            // click-to-pin expanded list (up to ten models).
+            // Keep every per-period model. Hover remains intentionally compact,
+            // while the inline inspector can show the complete model mix.
             var perDayModels: [Date: [CostSnapshot.ModelBreakdown]] = [:]
             for (day, models) in byDayModel {
                 perDayModels[day] = models
                     .sorted { $0.value.cost > $1.value.cost }
-                    .prefix(20)
                     .map { CostSnapshot.ModelBreakdown(modelName: $0.key, costUSD: $0.value.cost, totalTokens: $0.value.tokens) }
             }
             var perHourModels: [Date: [CostSnapshot.ModelBreakdown]] = [:]
             for (hour, models) in byHourModel {
                 perHourModels[hour] = models
                     .sorted { $0.value.cost > $1.value.cost }
-                    .prefix(20)
                     .map { CostSnapshot.ModelBreakdown(modelName: $0.key, costUSD: $0.value.cost, totalTokens: $0.value.tokens) }
             }
             return CostSnapshot(

--- a/Sources/VibeBarCore/Services/OverviewMasonryPlanner.swift
+++ b/Sources/VibeBarCore/Services/OverviewMasonryPlanner.swift
@@ -100,6 +100,37 @@ public enum OverviewMasonryPlanner {
         return Plan(positions: positions, columnHeights: heights)
     }
 
+    /// Rebuild positions from a previously chosen column assignment while
+    /// honoring each item's current height. Interactive card expansion can
+    /// therefore push later cards down within the same column without making
+    /// any card jump to the other side. Declaration order remains the vertical
+    /// order within each phase.
+    public static func plan(
+        items: [Item],
+        fixedColumns: [String: Int],
+        columns: Int = 2,
+        spacing: Double
+    ) -> Plan {
+        let columnCount = max(1, columns)
+        var positions: [String: Position] = [:]
+        var heights = Array(repeating: 0.0, count: columnCount)
+
+        for phase in [Phase.quota, .cost, .auxiliary] {
+            for item in items where item.phase == phase {
+                let preferred = fixedColumns[item.id] ?? shortestColumn(heights)
+                let column = min(max(0, preferred), columnCount - 1)
+                append(
+                    item,
+                    to: column,
+                    spacing: spacing,
+                    heights: &heights,
+                    positions: &positions
+                )
+            }
+        }
+        return Plan(positions: positions, columnHeights: heights)
+    }
+
     private static func bestQuotaOrder(_ items: [Item], spacing: Double) -> [Item] {
         var best = items
         var bestScore = quotaScore(items, spacing: spacing)

--- a/Sources/VibeBarCore/Services/QuotaPaceForecast.swift
+++ b/Sources/VibeBarCore/Services/QuotaPaceForecast.swift
@@ -1,0 +1,385 @@
+import Foundation
+
+/// Personal quota forecast for one independently resettable bucket.
+///
+/// The forecast separates two questions that a linear elapsed-time marker
+/// cannot answer on its own:
+/// 1. Is the quota likely to survive until the provider refills it?
+/// 2. If it survives, how much useful capacity is likely to be left unused?
+///
+/// Quota observations are the only source used to estimate consumption.
+/// Token/cost history contributes calendar weights (when the user tends to be
+/// active), never a token-to-quota conversion.
+public struct QuotaPaceForecast: Sendable, Equatable {
+    public enum Verdict: String, Sendable, Equatable {
+        case enough
+        case watch
+        case atRisk
+        case learning
+    }
+
+    public enum Confidence: String, Sendable, Equatable {
+        case learning
+        case medium
+        case high
+    }
+
+    public let verdict: Verdict
+    public let confidence: Confidence
+    public let confidenceScore: Double
+    public let currentUsedPercent: Double
+    public let plannedUsedPercent: Double
+    /// Median projected demand at reset. May exceed 100 to preserve shortage
+    /// severity even though the visible quota itself is capped at 100%.
+    public let projectedUsedPercent: Double
+    public let projectedUsedLowerPercent: Double
+    public let projectedUsedUpperPercent: Double
+    public let targetRemainingPercent: Double
+    public let runOutAt: Date?
+    public let completedCycleCount: Int
+    public let currentObservationCount: Int
+
+    public var projectedRemainingPercent: Double {
+        max(0, 100 - projectedUsedPercent)
+    }
+
+    /// Remaining-at-reset interval, low first and high second.
+    public var projectedRemainingRange: ClosedRange<Double> {
+        max(0, 100 - projectedUsedUpperPercent)...max(0, 100 - projectedUsedLowerPercent)
+    }
+
+    /// Median capacity above the adaptive safety target. Positive values are
+    /// potential waste, not an instruction to manufacture unnecessary work.
+    public var potentialUnusedPercent: Double {
+        max(0, projectedRemainingPercent - targetRemainingPercent)
+    }
+
+    public var verdictLabel: String {
+        switch verdict {
+        case .enough: "Enough"
+        case .watch: "Watch"
+        case .atRisk: "At risk"
+        case .learning: "Learning"
+        }
+    }
+
+    public var confidenceLabel: String {
+        switch confidence {
+        case .learning: "Learning"
+        case .medium: "Medium confidence"
+        case .high: "High confidence"
+        }
+    }
+
+    public var resetSummary: String {
+        let left = Int(projectedRemainingPercent.rounded())
+        switch verdict {
+        case .enough:
+            return "Forecast \(left)% left at reset"
+        case .watch:
+            return "May run short · forecast \(left)% left"
+        case .atRisk:
+            return "Likely to run out before reset"
+        case .learning:
+            return "Learning your pattern · about \(left)% left"
+        }
+    }
+
+    public var guidanceSummary: String {
+        let target = Int(targetRemainingPercent.rounded())
+        let unused = Int(potentialUnusedPercent.rounded())
+        if verdict == .atRisk { return "Slow down or shift work to another quota" }
+        if verdict == .watch { return "Recent usage is above the safe range" }
+        if unused >= 3 {
+            return "Target \(target)% left · about \(unused)% available"
+        }
+        return "Within the \(target)% safety target"
+    }
+
+    public static func compute(
+        bucket: QuotaBucket,
+        observations: [FillTimelinePoint],
+        cycles: [SubscriptionWindowSample],
+        activityHeatmap: UsageHeatmap? = nil,
+        dailyActivity: [DailyCostPoint] = [],
+        now: Date = Date(),
+        calendar: Calendar = .current
+    ) -> QuotaPaceForecast? {
+        guard let resetAt = bucket.resetAt,
+              let rawWindowSeconds = bucket.rawWindowSeconds,
+              rawWindowSeconds > 0
+        else { return nil }
+
+        let duration = TimeInterval(rawWindowSeconds)
+        let remainingTime = resetAt.timeIntervalSince(now)
+        guard remainingTime > 0, remainingTime <= duration * 1.1 else { return nil }
+
+        let windowStart = resetAt.addingTimeInterval(-duration)
+        let actual = clamp(bucket.usedPercent, 0, 100)
+        let profile = ActivityProfile(heatmap: activityHeatmap, calendar: calendar)
+        let totalActivity = max(0.001, profile.weight(from: windowStart, to: resetAt))
+        let elapsedActivity = clamp(profile.weight(from: windowStart, to: now), 0, totalActivity)
+        let futureActivity = max(0, totalActivity - elapsedActivity)
+        let behavioralProgress = clamp(elapsedActivity / totalActivity, 0, 1)
+
+        let currentPoints = observations
+            .filter { $0.sampledAt >= windowStart.addingTimeInterval(-300) && $0.sampledAt <= now.addingTimeInterval(60) }
+            .sorted { $0.sampledAt < $1.sampledAt }
+
+        let recent = recentSlope(points: currentPoints, profile: profile)
+        let completed = cycles.filter(\.isCompleted)
+        let historicalAdditions = historicalRemainingUsage(
+            cycles: completed,
+            observations: observations,
+            currentProgress: behavioralProgress,
+            profile: profile
+        )
+        let trend = activityTrend(dailyActivity, now: now, calendar: calendar)
+
+        var candidates: [(value: Double, weight: Double)] = []
+        if let recentRate = recent.rate, recentRate > 0 {
+            let prediction = actual + recentRate * futureActivity
+            let reliability = min(1, Double(recent.sampleCount) / 6)
+            candidates.append((prediction, 0.52 * reliability))
+        }
+        if let historical = median(historicalAdditions) {
+            let reliability = min(1, Double(historicalAdditions.count) / 5)
+            candidates.append((actual + historical * trend, 0.34 * reliability))
+        }
+
+        // Always retain a low-weight behavioral-time fallback. It behaves like
+        // the old linear model when no activity profile exists, but switches to
+        // the user's actual weekday/hour shape as soon as a heatmap is present.
+        let fallback: Double
+        if behavioralProgress > 0.015 {
+            fallback = actual / behavioralProgress
+        } else {
+            fallback = actual
+        }
+        candidates.append((fallback * trend, 0.14))
+
+        let weightSum = candidates.reduce(0) { $0 + $1.weight }
+        let rawProjection = weightSum > 0
+            ? candidates.reduce(0) { $0 + $1.value * $1.weight } / weightSum
+            : actual
+        let projected = max(actual, rawProjection)
+
+        let observationCoverage: Double = {
+            guard let first = currentPoints.first, let last = currentPoints.last else { return 0 }
+            let span = max(0, last.sampledAt.timeIntervalSince(first.sampledAt))
+            let elapsed = max(1, now.timeIntervalSince(windowStart))
+            let countScore = min(1, Double(currentPoints.count) / 10)
+            let spanScore = min(1, span / elapsed)
+            return countScore * 0.65 + spanScore * 0.35
+        }()
+        let historyCoverage = min(1, Double(completed.count) / 5)
+        let freshness: Double = {
+            guard let last = currentPoints.last else { return 0 }
+            let naturalSlot: TimeInterval = rawWindowSeconds <= 6 * 3_600 ? 5 * 60 : 3_600
+            return clamp(1 - now.timeIntervalSince(last.sampledAt) / max(60, naturalSlot * 3), 0, 1)
+        }()
+        let activityCoverage = (activityHeatmap?.totalTokens ?? 0) > 0 ? 1.0 : 0.0
+        let confidenceScore = clamp(
+            observationCoverage * 0.38
+                + historyCoverage * 0.30
+                + freshness * 0.20
+                + activityCoverage * 0.12,
+            0,
+            1
+        )
+        let confidence: Confidence
+        if confidenceScore >= 0.72 { confidence = .high }
+        else if confidenceScore >= 0.35 { confidence = .medium }
+        else { confidence = .learning }
+
+        let targetRemaining = clamp(5 + (1 - confidenceScore) * 8, 5, 13)
+        let historicalSpread = medianAbsoluteDeviation(completed.map(\.peakUsedPercent)) * 1.4826
+        let recentSpread = recent.spread * futureActivity
+        let uncertainty = clamp(
+            max(4, 18 * (1 - confidenceScore)) + min(12, historicalSpread * 0.35 + recentSpread * 0.5),
+            4,
+            28
+        )
+        let lower = max(actual, projected - uncertainty)
+        let upper = projected + uncertainty
+
+        let verdict: Verdict
+        if projected >= 100 {
+            verdict = .atRisk
+        } else if upper >= 100 {
+            verdict = .watch
+        } else if confidence == .learning {
+            verdict = .learning
+        } else {
+            verdict = .enough
+        }
+
+        let targetUsed = 100 - targetRemaining
+        let planned = clamp(targetUsed * behavioralProgress, 0, targetUsed)
+        let runOutAt: Date? = {
+            guard upper >= 100, actual < 100 else { return actual >= 100 ? now : nil }
+            if let recentRate = recent.rate, recentRate > 0 {
+                let neededWeight = (100 - actual) / recentRate
+                return profile.date(after: now, accumulating: neededWeight, noLaterThan: resetAt)
+            }
+            let additional = projected - actual
+            guard additional > 0 else { return nil }
+            let fraction = clamp((100 - actual) / additional, 0, 1)
+            return profile.date(after: now, accumulating: futureActivity * fraction, noLaterThan: resetAt)
+        }()
+
+        return QuotaPaceForecast(
+            verdict: verdict,
+            confidence: confidence,
+            confidenceScore: confidenceScore,
+            currentUsedPercent: actual,
+            plannedUsedPercent: planned,
+            projectedUsedPercent: projected,
+            projectedUsedLowerPercent: lower,
+            projectedUsedUpperPercent: upper,
+            targetRemainingPercent: targetRemaining,
+            runOutAt: runOutAt,
+            completedCycleCount: completed.count,
+            currentObservationCount: currentPoints.count
+        )
+    }
+
+    private struct RecentSlope {
+        let rate: Double?
+        let spread: Double
+        let sampleCount: Int
+    }
+
+    private static func recentSlope(points: [FillTimelinePoint], profile: ActivityProfile) -> RecentSlope {
+        guard points.count >= 2 else { return RecentSlope(rate: nil, spread: 0, sampleCount: 0) }
+        let recentPoints = Array(points.suffix(18))
+        var slopes: [Double] = []
+        for pair in zip(recentPoints, recentPoints.dropFirst()) {
+            let delta = pair.1.usedPercent - pair.0.usedPercent
+            guard delta >= 0, delta <= 45 else { continue }
+            let activity = profile.weight(from: pair.0.sampledAt, to: pair.1.sampledAt)
+            guard activity > 0.002 else { continue }
+            slopes.append(delta / activity)
+        }
+        guard let rate = median(slopes) else { return RecentSlope(rate: nil, spread: 0, sampleCount: 0) }
+        return RecentSlope(
+            rate: rate,
+            spread: medianAbsoluteDeviation(slopes) * 1.4826,
+            sampleCount: slopes.count
+        )
+    }
+
+    private static func historicalRemainingUsage(
+        cycles: [SubscriptionWindowSample],
+        observations: [FillTimelinePoint],
+        currentProgress: Double,
+        profile: ActivityProfile
+    ) -> [Double] {
+        cycles.compactMap { cycle in
+            let cycleStart = cycle.windowStart ?? cycle.firstSeenAt
+            let cycleEnd = cycle.completedAt ?? cycle.windowEnd
+            guard cycleEnd > cycleStart else { return nil }
+            let total = max(0.001, profile.weight(from: cycleStart, to: cycleEnd))
+            let matching = observations
+                .filter { $0.sampledAt >= cycleStart && $0.sampledAt <= cycleEnd }
+                .map { point -> (distance: Double, used: Double) in
+                    let progress = clamp(profile.weight(from: cycleStart, to: point.sampledAt) / total, 0, 1)
+                    return (abs(progress - currentProgress), point.usedPercent)
+                }
+                .min { $0.distance < $1.distance }
+            if let matching, matching.distance <= 0.22 {
+                return max(0, cycle.peakUsedPercent - matching.used)
+            }
+            return max(0, cycle.peakUsedPercent * (1 - currentProgress))
+        }
+    }
+
+    private static func activityTrend(_ days: [DailyCostPoint], now: Date, calendar: Calendar) -> Double {
+        guard !days.isEmpty else { return 1 }
+        let today = calendar.startOfDay(for: now)
+        let recentStart = calendar.date(byAdding: .day, value: -6, to: today) ?? today
+        let baselineStart = calendar.date(byAdding: .day, value: -27, to: today) ?? today
+        let baselineEnd = calendar.date(byAdding: .day, value: -7, to: today) ?? today
+        let recentTotal = days.filter { $0.date >= recentStart && $0.date <= now }.reduce(0.0) { $0 + Double($1.totalTokens) }
+        let baselineTotal = days.filter { $0.date >= baselineStart && $0.date < baselineEnd }.reduce(0.0) { $0 + Double($1.totalTokens) }
+        guard baselineTotal > 0 else { return 1 }
+        let recentAverage = recentTotal / 7
+        let baselineAverage = baselineTotal / 21
+        return clamp(recentAverage / baselineAverage, 0.5, 1.8)
+    }
+
+    private struct ActivityProfile {
+        let heatmap: UsageHeatmap?
+        let calendar: Calendar
+        let maximumCell: Double
+
+        init(heatmap: UsageHeatmap?, calendar: Calendar) {
+            self.heatmap = heatmap
+            self.calendar = calendar
+            self.maximumCell = Double(heatmap?.cells.flatMap { $0 }.max() ?? 0)
+        }
+
+        func weight(from start: Date, to end: Date) -> Double {
+            guard end > start else { return 0 }
+            var cursor = start
+            var total = 0.0
+            while cursor < end {
+                let nextHour = calendar.date(byAdding: .hour, value: 1, to: calendar.dateInterval(of: .hour, for: cursor)?.start ?? cursor)
+                    ?? cursor.addingTimeInterval(3_600)
+                let next = min(end, max(cursor.addingTimeInterval(60), nextHour))
+                let hours = next.timeIntervalSince(cursor) / 3_600
+                total += hourWeight(at: cursor) * hours
+                cursor = next
+            }
+            return total
+        }
+
+        func date(after start: Date, accumulating targetWeight: Double, noLaterThan end: Date) -> Date? {
+            guard targetWeight > 0, end > start else { return nil }
+            let step: TimeInterval = end.timeIntervalSince(start) <= 6 * 3_600 ? 5 * 60 : 30 * 60
+            var cursor = start
+            var accumulated = 0.0
+            while cursor < end {
+                let next = min(end, cursor.addingTimeInterval(step))
+                let weight = hourWeight(at: cursor) * next.timeIntervalSince(cursor) / 3_600
+                if accumulated + weight >= targetWeight, weight > 0 {
+                    let fraction = (targetWeight - accumulated) / weight
+                    return cursor.addingTimeInterval(next.timeIntervalSince(cursor) * clamp(fraction, 0, 1))
+                }
+                accumulated += weight
+                cursor = next
+            }
+            return nil
+        }
+
+        private func hourWeight(at date: Date) -> Double {
+            guard let heatmap, heatmap.totalTokens > 0, maximumCell > 0 else { return 1 }
+            let weekday = max(0, min(6, calendar.component(.weekday, from: date) - 1))
+            let hour = max(0, min(23, calendar.component(.hour, from: date)))
+            guard heatmap.cells.indices.contains(weekday), heatmap.cells[weekday].indices.contains(hour) else { return 1 }
+            let normalized = sqrt(Double(heatmap.cells[weekday][hour]) / maximumCell)
+            // Laplace-like floor prevents an empty historical cell from
+            // asserting that future work there is impossible.
+            return 0.15 + normalized * 0.85
+        }
+    }
+
+    private static func median(_ values: [Double]) -> Double? {
+        guard !values.isEmpty else { return nil }
+        let sorted = values.sorted()
+        let middle = sorted.count / 2
+        if sorted.count.isMultiple(of: 2) {
+            return (sorted[middle - 1] + sorted[middle]) / 2
+        }
+        return sorted[middle]
+    }
+
+    private static func medianAbsoluteDeviation(_ values: [Double]) -> Double {
+        guard let center = median(values) else { return 0 }
+        return median(values.map { abs($0 - center) }) ?? 0
+    }
+
+    private static func clamp(_ value: Double, _ lower: Double, _ upper: Double) -> Double {
+        min(max(value, lower), upper)
+    }
+}

--- a/Sources/VibeBarCore/Services/QuotaRefreshScheduler.swift
+++ b/Sources/VibeBarCore/Services/QuotaRefreshScheduler.swift
@@ -18,9 +18,13 @@ public final class QuotaRefreshScheduler {
     private let intervalProvider: () -> Int
     private let onRefreshTriggered: @MainActor () -> Void
     private var timer: Timer?
+    private var boundaryTimer: Timer?
+    private var boundaryAccountIds: Set<String> = []
+    private var lastBoundaryRefreshByAccount: [String: Date] = [:]
     private var pathMonitor: NWPathMonitor?
     private var lastNetworkStatus: NWPath.Status = .satisfied
     private var observers: [NSObjectProtocol] = []
+    private var quotaObservation: AnyCancellable?
 
     public init(
         service: QuotaService,
@@ -32,16 +36,27 @@ public final class QuotaRefreshScheduler {
         self.accountsProvider = accountsProvider
         self.intervalProvider = intervalProvider
         self.onRefreshTriggered = onRefreshTriggered
+        self.quotaObservation = service.$lastSuccessByAccount
+            .dropFirst()
+            .sink { [weak self] _ in
+                Task { @MainActor in
+                    self?.scheduleBoundaryTimer()
+                }
+            }
     }
 
     public func start() {
         scheduleTimer()
+        scheduleBoundaryTimer()
         installSystemObservers()
     }
 
     public func stop() {
         timer?.invalidate()
         timer = nil
+        boundaryTimer?.invalidate()
+        boundaryTimer = nil
+        boundaryAccountIds = []
         pathMonitor?.cancel()
         pathMonitor = nil
         #if canImport(AppKit)
@@ -83,6 +98,69 @@ public final class QuotaRefreshScheduler {
         self.timer = timer
     }
 
+    /// When Vibe Bar is running, take one observation shortly before and one
+    /// shortly after the nearest provider-reported reset. Refill-drop
+    /// detection remains authoritative for early/late resets; these two
+    /// bounded reads simply tighten the "last seen before reset" gap without
+    /// turning the normal scheduler into aggressive polling.
+    private func scheduleBoundaryTimer(now: Date = Date()) {
+        boundaryTimer?.invalidate()
+        boundaryTimer = nil
+        boundaryAccountIds = []
+
+        let accounts = accountsProvider()
+        var candidates: [(date: Date, accountId: String)] = []
+        for account in accounts {
+            guard let quota = service.cachedQuota(for: account.id) else { continue }
+            for resetAt in quota.buckets.compactMap(\.resetAt) {
+                for offset in [-120.0, 120.0] {
+                    let candidate = resetAt.addingTimeInterval(offset)
+                    guard candidate.timeIntervalSince(now) >= 5,
+                          candidate.timeIntervalSince(now) <= 45 * 86_400
+                    else { continue }
+                    if let last = lastBoundaryRefreshByAccount[account.id],
+                       candidate.timeIntervalSince(last) < 90 {
+                        continue
+                    }
+                    candidates.append((candidate, account.id))
+                }
+            }
+        }
+        guard let nextDate = candidates.map(\.date).min() else { return }
+        boundaryAccountIds = Set(
+            candidates
+                .filter { abs($0.date.timeIntervalSince(nextDate)) <= 5 }
+                .map(\.accountId)
+        )
+        let delay = max(5, nextDate.timeIntervalSince(now))
+        let boundaryTimer = Timer.scheduledTimer(withTimeInterval: delay, repeats: false) { [weak self] _ in
+            Task { @MainActor in
+                self?.triggerBoundaryRefresh()
+            }
+        }
+        boundaryTimer.tolerance = min(5, delay * 0.02)
+        self.boundaryTimer = boundaryTimer
+    }
+
+    private func triggerBoundaryRefresh() {
+        let ids = boundaryAccountIds
+        boundaryAccountIds = []
+        boundaryTimer?.invalidate()
+        boundaryTimer = nil
+        let accounts = accountsProvider().filter { ids.contains($0.id) }
+        guard !accounts.isEmpty else {
+            scheduleBoundaryTimer()
+            return
+        }
+        Task { @MainActor in
+            for account in accounts {
+                lastBoundaryRefreshByAccount[account.id] = Date()
+                _ = await service.refresh(account)
+            }
+            scheduleBoundaryTimer()
+        }
+    }
+
     private func installSystemObservers() {
         #if canImport(AppKit)
         let wake = NSWorkspace.shared.notificationCenter.addObserver(
@@ -112,6 +190,7 @@ public final class QuotaRefreshScheduler {
 
     deinit {
         timer?.invalidate()
+        boundaryTimer?.invalidate()
         pathMonitor?.cancel()
         #if canImport(AppKit)
         for observer in observers {

--- a/Sources/VibeBarCore/Services/QuotaService.swift
+++ b/Sources/VibeBarCore/Services/QuotaService.swift
@@ -15,6 +15,10 @@ public final class QuotaService: ObservableObject {
     /// kept in sync as each `refresh` succeeds; views read this
     /// dictionary directly via the `@Published` projection.
     @Published public private(set) var historyByAccountBucket: [SubscriptionHistoryKey: [SubscriptionWindowSample]] = [:]
+    /// Adaptive point samples for every independently resettable quota. These
+    /// power personal pace forecasts; completed-cycle summaries remain in
+    /// `historyByAccountBucket` for Fill History and reset outcomes.
+    @Published public private(set) var observationsByAccountBucket: [SubscriptionHistoryKey: [FillTimelinePoint]] = [:]
 
     private let adapters: [ToolType: any QuotaAdapter]
     private let mockProvider: () -> Bool
@@ -41,6 +45,7 @@ public final class QuotaService: ObservableObject {
             // Salvage only genuine refill jumps from the retired hourly
             // timeline before hydrating the cycle-based history UI.
             let points = await UsageFillTimelineStore.shared.allPoints()
+            self?.applyInitialObservations(points)
             await SubscriptionHistoryStore.shared.importLegacyTimeline(
                 points,
                 retentionDays: retentionProvider()
@@ -160,6 +165,24 @@ public final class QuotaService: ObservableObject {
         store(success: quota)
     }
 
+    public func paceForecast(
+        accountId: String,
+        bucket: QuotaBucket,
+        activityHeatmap: UsageHeatmap? = nil,
+        dailyActivity: [DailyCostPoint] = [],
+        now: Date = Date()
+    ) -> QuotaPaceForecast? {
+        let key = SubscriptionHistoryKey(accountId: accountId, bucketId: bucket.id)
+        return QuotaPaceForecast.compute(
+            bucket: bucket,
+            observations: observationsByAccountBucket[key] ?? [],
+            cycles: historyByAccountBucket[key] ?? [],
+            activityHeatmap: activityHeatmap,
+            dailyActivity: dailyActivity,
+            now: now
+        )
+    }
+
     // MARK: - Private
 
     private func store(success: AccountQuota) {
@@ -172,15 +195,36 @@ public final class QuotaService: ObservableObject {
             SafeLog.warn("Saving quota cache failed: \(SafeLog.sanitize(error.localizedDescription))")
         }
 
-        // Fold this snapshot into the reset-cycle store and republish the
-        // affected keys. Point-in-time hourly sampling is intentionally no
-        // longer updated: it measured "what remained at refresh time", not
-        // "what remained when the subscription reset".
+        // Store both the point observations used by the personal forecast and
+        // the inferred completed cycles used by reset history. Both paths
+        // retain every bucket, including model-scoped limits.
         let retention = retentionProvider()
         let quota = success
         Task { [weak self] in
+            await UsageFillTimelineStore.shared.observe(quota, retentionDays: retention)
             await SubscriptionHistoryStore.shared.observe(quota, retentionDays: retention)
+            await self?.refreshObservations(for: quota)
             await self?.refreshSubscriptionHistory(for: quota)
+        }
+    }
+
+    private func applyInitialObservations(_ points: [FillTimelinePoint]) {
+        var grouped: [SubscriptionHistoryKey: [FillTimelinePoint]] = [:]
+        for point in points {
+            let key = SubscriptionHistoryKey(accountId: point.accountId, bucketId: point.bucketId)
+            grouped[key, default: []].append(point)
+        }
+        observationsByAccountBucket = grouped.mapValues { $0.sorted { $0.sampledAt < $1.sampledAt } }
+    }
+
+    private func refreshObservations(for quota: AccountQuota) async {
+        for bucket in quota.buckets {
+            let key = SubscriptionHistoryKey(accountId: quota.accountId, bucketId: bucket.id)
+            let points = await UsageFillTimelineStore.shared.points(
+                accountId: quota.accountId,
+                bucketId: bucket.id
+            )
+            observationsByAccountBucket[key] = points
         }
     }
 

--- a/Sources/VibeBarCore/Services/SubscriptionWindowProgress.swift
+++ b/Sources/VibeBarCore/Services/SubscriptionWindowProgress.swift
@@ -6,7 +6,7 @@ import Foundation
 ///
 /// Examples:
 ///   - "Day 6 of 7 · 56% used"            — windows with full-day grain
-///   - "2h 35m of 5h · 7% used"           — sub-day windows (5-hour)
+///   - "2h 35m of 5 Hours · 7% used"      — sub-day windows (5-hour)
 ///   - "Resets soon · 99% used"           — reset has technically passed
 ///   - "42% used"                         — no resetAt or no
 ///                                          rawWindowSeconds (Gemini
@@ -36,7 +36,9 @@ public enum SubscriptionWindowProgress {
             return "Day \(dayNumber) of \(totalDays) · \(pct) used"
         }
 
-        let totalLabel = formatShortDuration(windowSeconds)
+        let totalLabel = rawWindowSeconds == 18_000
+            ? "5 Hours"
+            : formatShortDuration(windowSeconds)
         let elapsedLabel = formatShortDuration(elapsed)
         return "\(elapsedLabel) of \(totalLabel) · \(pct) used"
     }

--- a/Sources/VibeBarCore/Services/UsageFillTimelineStore.swift
+++ b/Sources/VibeBarCore/Services/UsageFillTimelineStore.swift
@@ -1,19 +1,13 @@
 import Foundation
 
-/// Persists short-horizon fill samples (`FillTimelinePoint`) so the popover
-/// can render a CodexBar-style timeline — thin per-hour bars over the last
-/// week — for each headline quota bucket.
+/// Persists quota observations used by reset history and pace forecasting.
 ///
 /// Scope mirrors `SubscriptionHistoryStore` where it makes sense:
 ///
-/// - **Provider gate.** Only the four primary providers (`codex`, `claude`,
-///   `gemini`, `grok`).
-/// - **Bucket gate.** Headline buckets only (`groupTitle == nil`) — the
-///   five_hour / weekly / monthly rows the utilization panel shows. Unlike
-///   the window-peak store, 5-hour rolling buckets ARE recorded: a
-///   point-in-time series has no monotonicity requirement.
-/// - **Horizon.** Hour-slot samples, pruned past `maxHorizonDays` (8) — the
-///   chart shows 7 days; retention settings below that are respected.
+/// - Every quota for the five core providers is recorded, including Codex
+///   Spark, Claude Fable, and every Gemini Web / AntiGravity lane.
+/// - Slot size and retention follow the quota window so short rolling limits
+///   stay detailed without making weekly/monthly history unnecessarily large.
 ///
 /// File: `~/.vibebar/fill_timeline.json` (mode 0600).
 public actor UsageFillTimelineStore {
@@ -38,11 +32,10 @@ public actor UsageFillTimelineStore {
     private var pendingFlushTask: Task<Void, Never>?
     private var pendingStorage: Storage?
 
-    private static let storageSchemaVersion = 1
+    private static let storageSchemaVersion = 2
     private static let saveThrottleInterval: TimeInterval = 30
-    private static let maxFileBytes = 4 * 1024 * 1024
-    private static let maxHorizonDays = 8
-    private static let supportedTools: Set<ToolType> = [.codex, .claude, .gemini, .grok]
+    private static let maxFileBytes = 24 * 1024 * 1024
+    private static let supportedTools: Set<ToolType> = [.codex, .claude, .gemini, .antigravity, .grok]
 
     public init(fileURL: URL = UsageFillTimelineStore.defaultFileURL()) {
         self.fileURL = fileURL
@@ -64,11 +57,10 @@ public actor UsageFillTimelineStore {
 
         var storage = load()
         var dirty = false
-        let slotStart = Self.hourSlotStart(for: now)
         for bucket in quota.buckets {
-            guard bucket.groupTitle == nil else { continue }
             guard bucket.usedPercent.isFinite else { continue }
             let percent = min(100, max(0, bucket.usedPercent))
+            let slotStart = Self.slotStart(for: now, windowSeconds: bucket.rawWindowSeconds)
             if let idx = storage.points.firstIndex(where: {
                 $0.accountId == quota.accountId
                     && $0.bucketId == bucket.id
@@ -76,6 +68,8 @@ public actor UsageFillTimelineStore {
             }) {
                 storage.points[idx].usedPercent = percent
                 storage.points[idx].sampledAt = now
+                storage.points[idx].resetAt = bucket.resetAt
+                storage.points[idx].rawWindowSeconds = bucket.rawWindowSeconds
             } else {
                 storage.points.append(FillTimelinePoint(
                     accountId: quota.accountId,
@@ -83,7 +77,9 @@ public actor UsageFillTimelineStore {
                     bucketId: bucket.id,
                     slotStart: slotStart,
                     usedPercent: percent,
-                    sampledAt: now
+                    sampledAt: now,
+                    resetAt: bucket.resetAt,
+                    rawWindowSeconds: bucket.rawWindowSeconds
                 ))
             }
             dirty = true
@@ -129,6 +125,21 @@ public actor UsageFillTimelineStore {
         Date(timeIntervalSince1970: floor(date.timeIntervalSince1970 / 3_600) * 3_600)
     }
 
+    static func slotStart(for date: Date, windowSeconds: Int?) -> Date {
+        let slotSeconds: TimeInterval
+        switch windowSeconds {
+        case let seconds? where seconds <= 6 * 3_600:
+            slotSeconds = 5 * 60
+        case let seconds? where seconds <= 8 * 86_400:
+            slotSeconds = 3_600
+        case let seconds? where seconds <= 45 * 86_400:
+            slotSeconds = 6 * 3_600
+        default:
+            slotSeconds = 86_400
+        }
+        return Date(timeIntervalSince1970: floor(date.timeIntervalSince1970 / slotSeconds) * slotSeconds)
+    }
+
     private func load() -> Storage {
         if let cached = cachedStorage { return cached }
         if let attrs = try? FileManager.default.attributesOfItem(atPath: fileURL.path),
@@ -151,8 +162,13 @@ public actor UsageFillTimelineStore {
             cachedStorage = empty
             return empty
         }
-        cachedStorage = storage
-        return storage
+        var migrated = storage
+        if migrated.schemaVersion < Self.storageSchemaVersion {
+            migrated.schemaVersion = Self.storageSchemaVersion
+            persist(migrated)
+        }
+        cachedStorage = migrated
+        return migrated
     }
 
     private func save(_ storage: Storage) {
@@ -189,13 +205,22 @@ public actor UsageFillTimelineStore {
     }
 
     private func pruneInPlace(_ storage: inout Storage, retentionDays: Int, now: Date) {
-        let horizon: Int
-        if CostDataSettings.isUnlimitedRetention(retentionDays) {
-            horizon = Self.maxHorizonDays
-        } else {
-            horizon = max(0, min(Self.maxHorizonDays, retentionDays))
+        storage.points.removeAll { point in
+            let naturalHorizon: Int
+            switch point.rawWindowSeconds {
+            case let seconds? where seconds <= 6 * 3_600:
+                naturalHorizon = 30
+            case let seconds? where seconds <= 8 * 86_400:
+                naturalHorizon = 16 * 7
+            case let seconds? where seconds <= 45 * 86_400:
+                naturalHorizon = 18 * 31
+            default:
+                naturalHorizon = 16 * 7
+            }
+            let horizon = CostDataSettings.isUnlimitedRetention(retentionDays)
+                ? naturalHorizon
+                : min(naturalHorizon, max(1, retentionDays))
+            return point.slotStart < now.addingTimeInterval(-TimeInterval(horizon) * 86_400)
         }
-        let cutoff = now.addingTimeInterval(-TimeInterval(horizon) * 86_400)
-        storage.points.removeAll { $0.slotStart < cutoff }
     }
 }

--- a/Sources/VibeBarCore/Storage/AccountStore.swift
+++ b/Sources/VibeBarCore/Storage/AccountStore.swift
@@ -58,9 +58,7 @@ public final class AccountStore: ObservableObject {
         }
 
         // Misc provider instances always present, regardless of credentials.
-        for instance in miscProviderInstances {
-            detected.append(miscPlaceholder(for: instance))
-        }
+        detected.append(contentsOf: Self.miscAccounts(for: miscProviderInstances))
 
         self.accounts = detected
     }
@@ -88,6 +86,24 @@ public final class AccountStore: ObservableObject {
             return fallbackTool.rawValue
         }
         return String(accountID.dropFirst(prefix.count))
+    }
+
+    /// Builds the stable placeholder identities for misc-provider instances
+    /// without probing any primary-provider credentials or the Keychain.
+    nonisolated static func miscAccounts(
+        for instances: [MiscProviderInstance],
+        now: Date = Date()
+    ) -> [AccountIdentity] {
+        instances.map { instance in
+            AccountIdentity(
+                id: miscAccountId(forInstanceID: instance.id),
+                tool: instance.tool,
+                alias: instance.displayName ?? instance.tool.menuTitle,
+                source: .notConfigured,
+                createdAt: now,
+                updatedAt: now
+            )
+        }
     }
 
     // MARK: - CLI auto detection
@@ -315,19 +331,4 @@ public final class AccountStore: ObservableObject {
         )
     }
 
-    /// Stable placeholder for misc providers regardless of credential
-    /// presence. The `source` defaults to `.notConfigured`; once an
-    /// adapter actually fetches successfully, `QuotaService` updates
-    /// the snapshot's metadata — the placeholder identity is mainly a
-    /// hook for the UI to render a card and route to Settings.
-    private func miscPlaceholder(for instance: MiscProviderInstance) -> AccountIdentity {
-        AccountIdentity(
-            id: AccountStore.miscAccountId(forInstanceID: instance.id),
-            tool: instance.tool,
-            alias: instance.displayName ?? instance.tool.menuTitle,
-            source: .notConfigured,
-            createdAt: Date(),
-            updatedAt: Date()
-        )
-    }
 }

--- a/Tests/VibeBarCoreTests/AntigravityParserTests.swift
+++ b/Tests/VibeBarCoreTests/AntigravityParserTests.swift
@@ -54,7 +54,7 @@ final class AntigravityParserTests: XCTestCase {
             "claude_gpt_weekly"
         ])
         XCTAssertEqual(snap.buckets.map(\.title), ["5 Hours", "Weekly", "5 Hours", "Weekly"])
-        XCTAssertEqual(snap.buckets.map(\.shortLabel), ["G 5h", "G wk", "C+G 5h", "C+G wk"])
+        XCTAssertEqual(snap.buckets.map(\.shortLabel), ["G 5 Hours", "G Weekly", "C+G 5 Hours", "C+G Weekly"])
         XCTAssertEqual(snap.buckets.map(\.groupTitle), [
             "Gemini Models",
             "Gemini Models",

--- a/Tests/VibeBarCoreTests/AppSettingsTests.swift
+++ b/Tests/VibeBarCoreTests/AppSettingsTests.swift
@@ -19,13 +19,11 @@ final class AppSettingsTests: XCTestCase {
         XCTAssertEqual(settings.claudeUsageMode, .auto)
         XCTAssertEqual(settings.menuBarItems.count, MenuBarItemKind.allCases.count)
         XCTAssertEqual(settings.menuBarItem(.compact).layout, .iconOnly)
-        XCTAssertFalse(settings.menuBarItem(.status).isVisible)
         XCTAssertFalse(settings.menuBarItem(.compact).showTitle)
         XCTAssertTrue(settings.menuBarItem(.compact).selectedFieldIds.contains("codex.five_hour"))
-        XCTAssertTrue(settings.menuBarItem(.codex).selectedFieldIds.contains("codex.weekly"))
-        XCTAssertTrue(settings.menuBarItem(.claude).selectedFieldIds.contains("claude.weekly"))
-        XCTAssertEqual(settings.popoverDensity(for: .codex), .regular)
-        XCTAssertEqual(settings.popoverDensity(for: .claude), .regular)
+        XCTAssertTrue(settings.menuBarItem(.compact).selectedFieldIds.contains("codex.weekly"))
+        XCTAssertTrue(settings.menuBarItem(.compact).selectedFieldIds.contains("claude.weekly"))
+        XCTAssertEqual(settings.popoverDensity, .regular)
         XCTAssertEqual(settings.miniWindow.displayMode, .regular)
         XCTAssertTrue(settings.miniWindow.selectedFieldIds.contains("claude.weekly"))
         XCTAssertTrue(settings.miniWindow.compactSelectedFieldIds.contains("claude.weekly"))
@@ -72,10 +70,10 @@ final class AppSettingsTests: XCTestCase {
         }
         """
         let settings = try JSONDecoder().decode(AppSettings.self, from: Data(json.utf8))
-        // Claude is preserved; gemini is silently dropped (filled with default if any other kind missing).
-        XCTAssertTrue(settings.menuBarItem(.claude).selectedFieldIds.contains("claude.weekly"))
-        // Persisted file shouldn't surface a .gemini entry in the in-memory list either.
-        XCTAssertFalse(settings.menuBarItems.contains { $0.kind.rawValue == "gemini" })
+        // Retired standalone provider items are silently dropped and the
+        // single Overview item is restored from defaults.
+        XCTAssertEqual(settings.menuBarItems.map(\.kind), [.compact])
+        XCTAssertTrue(settings.menuBarItem(.compact).selectedFieldIds.contains("claude.weekly"))
     }
 
     func testClaudeWebThenCliModeRoundTrip() throws {
@@ -276,35 +274,61 @@ final class AppSettingsTests: XCTestCase {
         XCTAssertFalse(overview.showTitle)
 
         XCTAssertTrue(AppSettings.default.menuBarItem(.compact).isVisible)
-        XCTAssertFalse(AppSettings.default.menuBarItem(.codex).isVisible)
-        XCTAssertFalse(AppSettings.default.menuBarItem(.claude).isVisible)
-        XCTAssertFalse(AppSettings.default.menuBarItem(.status).isVisible)
+        XCTAssertEqual(MenuBarItemKind.allCases, [.compact])
+        XCTAssertEqual(AppSettings.default.menuBarItems.count, 1)
         XCTAssertEqual(AppSettings.default.menuBarItems.filter(\.isVisible).map(\.kind), [.compact])
         XCTAssertTrue(overview.customLabels.isEmpty)
     }
 
     func testMenuBarCompactLayoutRoundTrip() throws {
         var settings = AppSettings.default
-        var codex = settings.menuBarItem(.codex)
-        codex.layout = .compact
-        settings.setMenuBarItem(codex)
+        var overview = settings.menuBarItem(.compact)
+        overview.layout = .compact
+        settings.setMenuBarItem(overview)
 
         let data = try JSONEncoder().encode(settings)
         let decoded = try JSONDecoder().decode(AppSettings.self, from: data)
 
-        XCTAssertEqual(decoded.menuBarItem(.codex).layout, .compact)
+        XCTAssertEqual(decoded.menuBarItem(.compact).layout, .compact)
     }
 
     func testMenuBarIconOnlyLayoutRoundTrip() throws {
         var settings = AppSettings.default
-        var codex = settings.menuBarItem(.codex)
-        codex.layout = .iconOnly
-        settings.setMenuBarItem(codex)
+        var overview = settings.menuBarItem(.compact)
+        overview.layout = .iconOnly
+        settings.setMenuBarItem(overview)
 
         let data = try JSONEncoder().encode(settings)
         let decoded = try JSONDecoder().decode(AppSettings.self, from: data)
 
-        XCTAssertEqual(decoded.menuBarItem(.codex).layout, .iconOnly)
+        XCTAssertEqual(decoded.menuBarItem(.compact).layout, .iconOnly)
+    }
+
+    func testGlobalPopoverDensityRoundTrips() throws {
+        var settings = AppSettings.default
+        settings.popoverDensity = .spacious
+
+        let data = try JSONEncoder().encode(settings)
+        let decoded = try JSONDecoder().decode(AppSettings.self, from: data)
+
+        XCTAssertEqual(decoded.popoverDensity, .spacious)
+    }
+
+    func testLegacyPerItemDensitiesUseOverviewValue() throws {
+        let json = """
+        {
+          "popoverDensities": {
+            "compact": "compact",
+            "codex": "spacious",
+            "claude": "regular",
+            "status": "spacious"
+          }
+        }
+        """
+
+        let decoded = try JSONDecoder().decode(AppSettings.self, from: Data(json.utf8))
+
+        XCTAssertEqual(decoded.popoverDensity, .compact)
     }
 
     func testOnlyIconOnlyLayoutShowsMenuBarIcon() {

--- a/Tests/VibeBarCoreTests/AppSettingsTests.swift
+++ b/Tests/VibeBarCoreTests/AppSettingsTests.swift
@@ -31,6 +31,7 @@ final class AppSettingsTests: XCTestCase {
         XCTAssertTrue(settings.miniWindow.compactSelectedFieldIds.contains("claude.weekly"))
         XCTAssertTrue(settings.miniWindow.selectedFieldIds.contains("claude.daily_routines"))
         XCTAssertNil(settings.miniWindow.customLabels["codex.five_hour"])
+        XCTAssertEqual(settings.visibleCoreProviders, AppSettings.defaultVisibleCoreProviders)
         XCTAssertEqual(settings.costData.retentionDays, CostDataSettings.defaultRetentionDays)
         XCTAssertEqual(settings.costData.retentionDays, CostDataSettings.unlimitedRetentionDays)
         XCTAssertFalse(settings.costData.privacyModeEnabled)
@@ -340,5 +341,37 @@ final class AppSettingsTests: XCTestCase {
         settings.setProviderPlanLabel("sk-or-v1-abcdefghijklmnopqrstuvwxyz0123456789", for: .codex)
 
         XCTAssertNil(settings.planBadgeLabel(for: .codex))
+    }
+
+    func testCoreProviderVisibilityGroupsGeminiAndAntigravityAndRoundTrips() throws {
+        var settings = AppSettings.default
+
+        settings.setCoreProviderVisible(false, for: .antigravity)
+
+        XCTAssertFalse(settings.isCoreProviderVisible(.gemini))
+        XCTAssertFalse(settings.isCoreProviderVisible(.antigravity))
+        XCTAssertTrue(settings.isCoreProviderVisible(.codex))
+
+        let data = try JSONEncoder().encode(settings)
+        let decoded = try JSONDecoder().decode(AppSettings.self, from: data)
+
+        XCTAssertFalse(decoded.isCoreProviderVisible(.gemini))
+        XCTAssertFalse(decoded.isCoreProviderVisible(.antigravity))
+        XCTAssertEqual(
+            decoded.visibleCoreProviders,
+            Set([.codex, .claude, .grok])
+        )
+    }
+
+    func testCoreProviderVisibilityDropsNonCoreValues() throws {
+        let json = """
+        {
+          "visibleCoreProviders": ["codex", "antigravity", "minimax", "removedProvider"]
+        }
+        """
+
+        let settings = try JSONDecoder().decode(AppSettings.self, from: Data(json.utf8))
+
+        XCTAssertEqual(settings.visibleCoreProviders, Set([.codex, .gemini]))
     }
 }

--- a/Tests/VibeBarCoreTests/ClaudeParserTests.swift
+++ b/Tests/VibeBarCoreTests/ClaudeParserTests.swift
@@ -24,14 +24,14 @@ final class ClaudeParserTests: XCTestCase {
 
         let five = buckets.first { $0.id == "five_hour" }!
         XCTAssertEqual(five.title, "5 Hours")
-        XCTAssertEqual(five.shortLabel, "5h")
+        XCTAssertEqual(five.shortLabel, "5 Hours")
         XCTAssertEqual(five.usedPercent, 56)
         XCTAssertEqual(five.remainingPercent, 44)
         XCTAssertNil(five.groupTitle)
 
         let weekly = buckets.first { $0.id == "weekly" }!
         XCTAssertEqual(weekly.title, "Weekly")
-        XCTAssertEqual(weekly.shortLabel, "All models")
+        XCTAssertEqual(weekly.shortLabel, "Weekly")
         XCTAssertEqual(weekly.usedPercent, 13)
         XCTAssertEqual(weekly.remainingPercent, 87)
         XCTAssertNil(weekly.groupTitle)
@@ -74,7 +74,7 @@ final class ClaudeParserTests: XCTestCase {
         let fable = buckets.first { $0.id == "weekly_fable" }!
         XCTAssertEqual(fable.usedPercent, 60)
         XCTAssertEqual(fable.groupTitle, "Fable")
-        XCTAssertEqual(fable.shortLabel, "Fable wk")
+        XCTAssertEqual(fable.shortLabel, "Fable Weekly")
         XCTAssertEqual(fable.rawWindowSeconds, 604_800)
     }
 
@@ -111,7 +111,7 @@ final class ClaudeParserTests: XCTestCase {
         XCTAssertNotNil(fable)
         XCTAssertEqual(fable?.usedPercent, 1)
         XCTAssertEqual(fable?.groupTitle, "Fable")
-        XCTAssertEqual(fable?.shortLabel, "Fable wk")
+        XCTAssertEqual(fable?.shortLabel, "Fable Weekly")
         XCTAssertEqual(fable?.rawWindowSeconds, 604_800)
         XCTAssertNotNil(fable?.resetAt)
     }
@@ -134,7 +134,7 @@ final class ClaudeParserTests: XCTestCase {
         XCTAssertNil(five?.groupTitle)
         let weekly = buckets.first { $0.id == "weekly" }
         XCTAssertEqual(weekly?.usedPercent, 12)
-        XCTAssertEqual(weekly?.shortLabel, "All models")
+        XCTAssertEqual(weekly?.shortLabel, "Weekly")
     }
 
     /// A scoped model Vibe Bar has never heard of still surfaces with a
@@ -188,7 +188,7 @@ final class ClaudeParserTests: XCTestCase {
         let buckets = try ClaudeResponseParser.parse(data: Data(json.utf8))
         let routine = buckets.first { $0.id == "daily_routines" }!
         XCTAssertEqual(routine.groupTitle, "Daily Routines")
-        XCTAssertEqual(routine.shortLabel, "Routine wk")
+        XCTAssertEqual(routine.shortLabel, "Routine Weekly")
         XCTAssertEqual(routine.title, "Weekly")
         XCTAssertEqual(routine.usedPercent, 33.3)
         XCTAssertEqual(routine.rawWindowSeconds, 604_800)

--- a/Tests/VibeBarCoreTests/CodexParserTests.swift
+++ b/Tests/VibeBarCoreTests/CodexParserTests.swift
@@ -25,7 +25,7 @@ final class CodexParserTests: XCTestCase {
         let five = buckets[0]
         XCTAssertEqual(five.id, "five_hour")
         XCTAssertEqual(five.title, "5 Hours")
-        XCTAssertEqual(five.shortLabel, "5h")
+        XCTAssertEqual(five.shortLabel, "5 Hours")
         XCTAssertEqual(five.usedPercent, 56)
         XCTAssertEqual(five.remainingPercent, 44)
         XCTAssertEqual(five.rawWindowSeconds, 18000)
@@ -34,7 +34,7 @@ final class CodexParserTests: XCTestCase {
         let week = buckets[1]
         XCTAssertEqual(week.id, "weekly")
         XCTAssertEqual(week.title, "Weekly")
-        XCTAssertEqual(week.shortLabel, "wk")
+        XCTAssertEqual(week.shortLabel, "Weekly")
         XCTAssertEqual(week.usedPercent, 13)
         XCTAssertEqual(week.remainingPercent, 87)
         XCTAssertEqual(week.rawWindowSeconds, 604800)
@@ -81,14 +81,14 @@ final class CodexParserTests: XCTestCase {
         let sparkFive = buckets.first { $0.id == "gpt_5_3_codex_spark_five_hour" }
         XCTAssertEqual(sparkFive?.groupTitle, "GPT-5.3 Codex Spark")
         XCTAssertEqual(sparkFive?.title, "5 Hours")
-        XCTAssertEqual(sparkFive?.shortLabel, "Spark 5h")
+        XCTAssertEqual(sparkFive?.shortLabel, "Spark 5 Hours")
         XCTAssertEqual(sparkFive?.usedPercent, 0)
         XCTAssertEqual(sparkFive?.resetAt, Date(timeIntervalSince1970: 1_760_001_000))
 
         let sparkWeek = buckets.first { $0.id == "gpt_5_3_codex_spark_weekly" }
         XCTAssertEqual(sparkWeek?.groupTitle, "GPT-5.3 Codex Spark")
         XCTAssertEqual(sparkWeek?.title, "Weekly")
-        XCTAssertEqual(sparkWeek?.shortLabel, "Spark wk")
+        XCTAssertEqual(sparkWeek?.shortLabel, "Spark Weekly")
         XCTAssertEqual(sparkWeek?.usedPercent, 2)
         XCTAssertEqual(sparkWeek?.resetAt, Date(timeIntervalSince1970: 1_760_002_000))
     }

--- a/Tests/VibeBarCoreTests/CostHistoryStoreTests.swift
+++ b/Tests/VibeBarCoreTests/CostHistoryStoreTests.swift
@@ -2,6 +2,65 @@ import XCTest
 @testable import VibeBarCore
 
 final class CostHistoryStoreTests: XCTestCase {
+    func testMergeAndAugmentPreservesHourlyHistoryAndModelDetails() async throws {
+        let fileManager = FileManager.default
+        let directory = fileManager.temporaryDirectory
+            .appendingPathComponent("VibeBarCostHistoryHourlyDetails-\(UUID().uuidString)", isDirectory: true)
+        try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: directory) }
+
+        let calendar = Calendar.current
+        let now = Date()
+        let today = calendar.startOfDay(for: now)
+        let todayHour = try XCTUnwrap(calendar.date(byAdding: .hour, value: 10, to: today))
+        let yesterday = try XCTUnwrap(calendar.date(byAdding: .day, value: -1, to: today))
+        let yesterdayHour = try XCTUnwrap(calendar.date(byAdding: .hour, value: 17, to: yesterday))
+        let todayModels = [
+            CostSnapshot.ModelBreakdown(modelName: "gpt-today", costUSD: 1.5, totalTokens: 1_500)
+        ]
+        let yesterdayModels = [
+            CostSnapshot.ModelBreakdown(modelName: "gpt-yesterday", costUSD: 2.5, totalTokens: 2_500)
+        ]
+        let snapshot = CostSnapshot(
+            tool: .codex,
+            todayCostUSD: 1.5,
+            last7DaysCostUSD: 4,
+            last30DaysCostUSD: 4,
+            allTimeCostUSD: 4,
+            todayTokens: 1_500,
+            last7DaysTokens: 4_000,
+            last30DaysTokens: 4_000,
+            allTimeTokens: 4_000,
+            dailyHistory: [
+                DailyCostPoint(date: yesterday, costUSD: 2.5, totalTokens: 2_500),
+                DailyCostPoint(date: today, costUSD: 1.5, totalTokens: 1_500)
+            ],
+            todayHourlyHistory: [
+                HourlyCostPoint(date: todayHour, costUSD: 1.5, totalTokens: 1_500)
+            ],
+            yesterdayHourlyHistory: [
+                HourlyCostPoint(date: yesterdayHour, costUSD: 2.5, totalTokens: 2_500)
+            ],
+            heatmap: .empty(tool: .codex),
+            modelBreakdowns: todayModels + yesterdayModels,
+            dailyModelBreakdown: [today: todayModels, yesterday: yesterdayModels],
+            hourlyModelBreakdown: [todayHour: todayModels, yesterdayHour: yesterdayModels],
+            jsonlFilesFound: 1,
+            updatedAt: now
+        )
+        let store = CostHistoryStore(fileURL: directory.appendingPathComponent("cost_history.json"))
+
+        let merged = await store.mergeAndAugment(
+            snapshot,
+            retentionDays: CostDataSettings.unlimitedRetentionDays
+        )
+
+        XCTAssertEqual(merged.todayHourlyHistory, snapshot.todayHourlyHistory)
+        XCTAssertEqual(merged.yesterdayHourlyHistory, snapshot.yesterdayHourlyHistory)
+        XCTAssertEqual(merged.topModels(forHour: todayHour, limit: .max), todayModels)
+        XCTAssertEqual(merged.topModels(forHour: yesterdayHour, limit: .max), yesterdayModels)
+    }
+
     func testMergeAndAugmentKeepsLocalTodayWhenTimeZoneIsAheadOfUTC() async throws {
         let previousTimeZone = NSTimeZone.default
         let shanghai = TimeZone(secondsFromGMT: 8 * 3600)!

--- a/Tests/VibeBarCoreTests/CostUsageScannerTests.swift
+++ b/Tests/VibeBarCoreTests/CostUsageScannerTests.swift
@@ -100,6 +100,43 @@ final class CostUsageScannerTests: XCTestCase {
         XCTAssertEqual(snapshot.todayHourlyHistory.reduce(0) { $0 + $1.totalTokens }, 300_000)
     }
 
+    func testCodexScanKeepsEveryPerHourAndPerDayModel() async throws {
+        let fileManager = FileManager.default
+        let home = fileManager.temporaryDirectory
+            .appendingPathComponent("VibeBarCostUsageAllModels-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fileManager.removeItem(at: home) }
+
+        let sessions = home
+            .appendingPathComponent(".codex", isDirectory: true)
+            .appendingPathComponent("sessions", isDirectory: true)
+        try fileManager.createDirectory(at: sessions, withIntermediateDirectories: true)
+
+        let calendar = Calendar.current
+        let day = calendar.startOfDay(for: Date())
+        let hour = try XCTUnwrap(calendar.date(byAdding: .hour, value: 12, to: day))
+        let now = try XCTUnwrap(calendar.date(byAdding: .hour, value: 1, to: hour))
+        let lines = (0..<24).map { index in
+            codexTokenCountLine(
+                timestamp: hour.addingTimeInterval(Double(index)),
+                model: "gpt-model-\(index)",
+                input: (index + 1) * 1_000,
+                cached: 0,
+                output: 0
+            )
+        }
+        try lines.joined(separator: "\n").write(
+            to: sessions.appendingPathComponent("session.jsonl"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let scanned = await CostUsageScanner.scan(tool: .codex, homeDirectory: home.path, now: now)
+        let snapshot = try XCTUnwrap(scanned)
+
+        XCTAssertEqual(snapshot.topModels(forHour: hour, limit: .max).count, 24)
+        XCTAssertEqual(snapshot.topModels(for: day, limit: .max).count, 24)
+    }
+
     func testCodexScanUsesLastTokenUsageWhenTotalsAreMissing() async throws {
         let fileManager = FileManager.default
         let home = fileManager.temporaryDirectory

--- a/Tests/VibeBarCoreTests/GeminiDualFetchTests.swift
+++ b/Tests/VibeBarCoreTests/GeminiDualFetchTests.swift
@@ -12,7 +12,8 @@ final class GeminiDualFetchTests: XCTestCase {
         let adapter = GeminiQuotaAdapter(
             session: .shared,
             homeDirectory: temp.path,
-            now: { Date() }
+            now: { Date() },
+            cookieHeader: { throw QuotaError.noCredential }
         )
         return (adapter, temp)
     }
@@ -48,17 +49,14 @@ final class GeminiDualFetchTests: XCTestCase {
 
     func testWebAccountWithoutCookiesSurfacesNoCredential() async throws {
         // With no cookies imported, the adapter should surface a
-        // QuotaError without crashing. Most likely .noCredential
-        // from GeminiWebCookieStore; .network is acceptable if the
-        // test env happens to have a stale cookie in the keychain.
+        // QuotaError without crashing. The injected loader keeps this
+        // test isolated from the developer's real Gemini Keychain item.
         let (adapter, temp) = try makeEmptyHomeAdapter()
         defer { cleanup(temp) }
 
         do {
             _ = try await adapter.fetch(for: account(source: .webCookie))
-            // If this ever succeeds, the test env happens to have a
-            // live cookie in the keychain. Don't fail — but the
-            // smoke test scope still passes.
+            XCTFail("Expected noCredential without an injected cookie")
         } catch is QuotaError {
             // Pass — any QuotaError variant is acceptable here.
         } catch {

--- a/Tests/VibeBarCoreTests/GeminiWebResponseParserTests.swift
+++ b/Tests/VibeBarCoreTests/GeminiWebResponseParserTests.swift
@@ -94,7 +94,7 @@ final class GeminiWebResponseParserTests: XCTestCase {
 
         let current = try XCTUnwrap(snapshot.buckets.first(where: { $0.id == GeminiWebResponseParser.currentUsageBucketId }))
         XCTAssertEqual(current.title, "5 Hours")
-        XCTAssertEqual(current.shortLabel, "5h")
+        XCTAssertEqual(current.shortLabel, "5 Hours")
         XCTAssertEqual(current.usedPercent, 25.0, accuracy: 0.0001)
         XCTAssertEqual(current.resetAt?.timeIntervalSince1970 ?? 0, 1779469511.884512, accuracy: 0.001)
         // Fixed window lengths let `UsagePace` render reserve/deficit
@@ -103,7 +103,7 @@ final class GeminiWebResponseParserTests: XCTestCase {
 
         let weekly = try XCTUnwrap(snapshot.buckets.first(where: { $0.id == GeminiWebResponseParser.weeklyUsageBucketId }))
         XCTAssertEqual(weekly.title, "Weekly")
-        XCTAssertEqual(weekly.shortLabel, "Wk")
+        XCTAssertEqual(weekly.shortLabel, "Weekly")
         XCTAssertEqual(weekly.usedPercent, 10.0, accuracy: 0.0001)
         XCTAssertEqual(weekly.resetAt?.timeIntervalSince1970 ?? 0, 1779815111.884621, accuracy: 0.001)
         XCTAssertEqual(weekly.rawWindowSeconds, 604_800)

--- a/Tests/VibeBarCoreTests/KimiMiniMaxParserTests.swift
+++ b/Tests/VibeBarCoreTests/KimiMiniMaxParserTests.swift
@@ -70,7 +70,7 @@ final class KimiParserTests: XCTestCase {
         let snap = try KimiResponseParser.parse(data: Data(json.utf8), now: now)
 
         XCTAssertEqual(snap.buckets[1].title, "5 Hours")
-        XCTAssertEqual(snap.buckets[1].shortLabel, "5h")
+        XCTAssertEqual(snap.buckets[1].shortLabel, "5 Hours")
         XCTAssertEqual(snap.buckets[1].rawWindowSeconds, 5 * 3600)
     }
 
@@ -102,7 +102,7 @@ final class KimiParserTests: XCTestCase {
         let snap = try KimiResponseParser.parse(data: Data(json.utf8), now: now)
 
         XCTAssertEqual(snap.buckets[1].title, "5 Hours")
-        XCTAssertEqual(snap.buckets[1].shortLabel, "5h")
+        XCTAssertEqual(snap.buckets[1].shortLabel, "5 Hours")
         XCTAssertEqual(snap.buckets[1].rawWindowSeconds, 5 * 3600)
     }
 
@@ -166,7 +166,7 @@ final class MiniMaxParserTests: XCTestCase {
         // used=234, remaining=766.
         XCTAssertEqual(snap.buckets[0].usedPercent, 23.4, accuracy: 0.01)
         XCTAssertEqual(snap.buckets[0].title, "5 Hours")
-        XCTAssertEqual(snap.buckets[0].shortLabel, "5h")
+        XCTAssertEqual(snap.buckets[0].shortLabel, "5 Hours")
         XCTAssertEqual(snap.buckets[0].groupTitle, "766/1000 · 222 hours")
         XCTAssertNotNil(snap.buckets[0].resetAt)
         XCTAssertEqual(snap.buckets[0].rawWindowSeconds, 5 * 3600)
@@ -476,7 +476,7 @@ final class MiniMaxParserTests: XCTestCase {
                 "Web Search"
             ]
         )
-        XCTAssertEqual(snap.buckets.map(\.shortLabel), Array(repeating: "5h", count: 8))
+        XCTAssertEqual(snap.buckets.map(\.shortLabel), Array(repeating: "5 Hours", count: 8))
         XCTAssertEqual(snap.buckets.first?.usedPercent ?? -1, 0.222, accuracy: 0.001)
         XCTAssertEqual(snap.buckets.first?.groupTitle, "449/450 · 5 hours")
     }
@@ -526,7 +526,7 @@ final class MiniMaxParserTests: XCTestCase {
         """
         let snap = try MiniMaxResponseParser.parse(data: Data(json.utf8), now: now)
         XCTAssertEqual(snap.buckets[0].title, "5 Hours")
-        XCTAssertEqual(snap.buckets[0].shortLabel, "5h")
+        XCTAssertEqual(snap.buckets[0].shortLabel, "5 Hours")
         XCTAssertEqual(snap.buckets[0].rawWindowSeconds, 5 * 3600)
     }
 

--- a/Tests/VibeBarCoreTests/MenuBarFieldCatalogTests.swift
+++ b/Tests/VibeBarCoreTests/MenuBarFieldCatalogTests.swift
@@ -33,6 +33,16 @@ final class MenuBarFieldCatalogTests: XCTestCase {
         XCTAssertTrue(selected.contains("grok.weekly"))
     }
 
+    func testDefaultLabelsUseFullQuotaWindowNames() {
+        for field in MenuBarFieldCatalog.allFields {
+            let words = field.defaultLabel
+                .split(whereSeparator: { $0.isWhitespace })
+                .map { $0.lowercased() }
+            XCTAssertFalse(words.contains("5h"), "\(field.id) must spell out 5 Hours")
+            XCTAssertFalse(words.contains("wk"), "\(field.id) must spell out Weekly")
+        }
+    }
+
     func testGeminiCLIModelIdsMigrateToWebBuckets() {
         // Old Gemini CLI fields no longer have catalog entries; all of
         // them must migrate to the Web parser's `gemini.five_hour`

--- a/Tests/VibeBarCoreTests/MiscProviderParserTests.swift
+++ b/Tests/VibeBarCoreTests/MiscProviderParserTests.swift
@@ -128,7 +128,7 @@ final class MiscProviderParserTests: XCTestCase {
         XCTAssertEqual(snapshot.email, "dev@example.com")
         XCTAssertEqual(snapshot.buckets.map(\.id), ["ollama.fiveHour", "ollama.weekly"])
         XCTAssertEqual(snapshot.buckets[0].title, "5 Hours")
-        XCTAssertEqual(snapshot.buckets[0].shortLabel, "5h")
+        XCTAssertEqual(snapshot.buckets[0].shortLabel, "5 Hours")
         XCTAssertEqual(snapshot.buckets[0].usedPercent, 25.0, accuracy: 0.01)
         XCTAssertEqual(snapshot.buckets[1].usedPercent, 40.0, accuracy: 0.01)
         XCTAssertTrue(OllamaQuotaAdapter.hasRecognizedSessionCookie("__Secure-next-auth.session-token.0=abc; other=x"))
@@ -152,7 +152,7 @@ final class MiscProviderParserTests: XCTestCase {
 
         XCTAssertEqual(snapshot.buckets.map(\.id), ["ollama.fiveHour", "ollama.weekly"])
         XCTAssertEqual(snapshot.buckets[0].title, "5 Hours")
-        XCTAssertEqual(snapshot.buckets[0].shortLabel, "5h")
+        XCTAssertEqual(snapshot.buckets[0].shortLabel, "5 Hours")
         XCTAssertEqual(snapshot.buckets[0].usedPercent, 1.0, accuracy: 0.01)
         XCTAssertEqual(snapshot.buckets[0].rawWindowSeconds, 5 * 3600)
         XCTAssertEqual(snapshot.buckets[1].usedPercent, 0.5, accuracy: 0.01)

--- a/Tests/VibeBarCoreTests/MiscProviderSettingsTests.swift
+++ b/Tests/VibeBarCoreTests/MiscProviderSettingsTests.swift
@@ -285,15 +285,14 @@ final class AppSettingsMiscProviderTests: XCTestCase {
         XCTAssertEqual(settings.miscProviderInstance(id: ToolType.minimax.rawValue)?.settings.region, "global")
     }
 
-    @MainActor
     func testAccountStoreCreatesSeparateAccountsForMiscProviderInstances() {
         var settings = AppSettings.default
         guard let clone = settings.cloneMiscProviderInstance(id: ToolType.volcengine.rawValue) else {
             return XCTFail("expected Volcengine clone")
         }
 
-        let accounts = AccountStore(miscProviderInstances: settings.miscProviderInstances)
-        let volcengineAccounts = accounts.accounts(for: .volcengine)
+        let accounts = AccountStore.miscAccounts(for: settings.miscProviderInstances)
+        let volcengineAccounts = accounts.filter { $0.tool == .volcengine }
 
         XCTAssertEqual(volcengineAccounts.map(\.id), [
             AccountStore.miscAccountId(forInstanceID: ToolType.volcengine.rawValue),

--- a/Tests/VibeBarCoreTests/OverviewMasonryPlannerTests.swift
+++ b/Tests/VibeBarCoreTests/OverviewMasonryPlannerTests.swift
@@ -55,4 +55,36 @@ final class OverviewMasonryPlannerTests: XCTestCase {
         XCTAssertNotNil(plan.positions["aux2"])
         XCTAssertGreaterThan(plan.positions["aux1"]?.y ?? 0, 0)
     }
+
+    func testFixedColumnsKeepExpandedCostCardOnTheSameSide() throws {
+        let collapsed: [OverviewMasonryPlanner.Item] = [
+            .init(id: "quota-left", height: 200, phase: .quota),
+            .init(id: "quota-right", height: 180, phase: .quota),
+            .init(id: "cost-detail", height: 220, phase: .cost),
+            .init(id: "cost-following", height: 160, phase: .cost),
+            .init(id: "aux", height: 80, phase: .auxiliary)
+        ]
+        let initial = OverviewMasonryPlanner.plan(items: collapsed, spacing: 10)
+        let fixedColumns = initial.positions.mapValues(\.column)
+        let expanded = collapsed.map { item in
+            item.id == "cost-detail"
+                ? .init(id: item.id, height: 420, phase: item.phase)
+                : item
+        }
+
+        let locked = OverviewMasonryPlanner.plan(
+            items: expanded,
+            fixedColumns: fixedColumns,
+            spacing: 10
+        )
+
+        for item in expanded {
+            XCTAssertEqual(locked.positions[item.id]?.column, fixedColumns[item.id])
+        }
+        let detail = try XCTUnwrap(locked.positions["cost-detail"])
+        let following = try XCTUnwrap(locked.positions["cost-following"])
+        if detail.column == following.column {
+            XCTAssertGreaterThan(following.y, detail.y + 420)
+        }
+    }
 }

--- a/Tests/VibeBarCoreTests/PrimaryProviderRouteHealthTests.swift
+++ b/Tests/VibeBarCoreTests/PrimaryProviderRouteHealthTests.swift
@@ -30,4 +30,29 @@ final class PrimaryProviderRouteHealthTests: XCTestCase {
         XCTAssertEqual(result.terminationStatus, 0)
         XCTAssertTrue(result.output.contains("antigravity language_server_macos"))
     }
+
+    func testAntigravityCachedDataIsHealthyWhileLSPIsOffline() {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let health = PrimaryProviderRouteHealthChecker.antigravityLocalProbeHealth(
+            languageServerRunning: false,
+            hasLocalData: true,
+            now: now
+        )
+
+        XCTAssertEqual(health.status, .ok)
+        XCTAssertEqual(health.detail, "Local data available; LSP offline")
+        XCTAssertEqual(health.checkedAt, now)
+    }
+
+    func testAntigravityWithoutLSPOrLocalDataNeedsSetup() {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let health = PrimaryProviderRouteHealthChecker.antigravityLocalProbeHealth(
+            languageServerRunning: false,
+            hasLocalData: false,
+            now: now
+        )
+
+        XCTAssertEqual(health.status, .missing)
+        XCTAssertEqual(health.detail, "No local Antigravity data")
+    }
 }

--- a/Tests/VibeBarCoreTests/QuotaBucketTests.swift
+++ b/Tests/VibeBarCoreTests/QuotaBucketTests.swift
@@ -22,4 +22,16 @@ final class QuotaBucketTests: XCTestCase {
         XCTAssertEqual(QuotaBucket(id: "b", title: "b", shortLabel: "b", usedPercent: 150).usedPercent, 100, accuracy: 0.001)
         XCTAssertEqual(QuotaBucket(id: "c", title: "c", shortLabel: "c", usedPercent: 42.5).usedPercent, 42.5, accuracy: 0.001)
     }
+
+    func testQuotaWindowLabelsAlwaysUseFullWords() throws {
+        XCTAssertEqual(QuotaBucket(id: "a", title: "a", shortLabel: "5h", usedPercent: 0).shortLabel, "5 Hours")
+        XCTAssertEqual(QuotaBucket(id: "b", title: "b", shortLabel: "Wk", usedPercent: 0).shortLabel, "Weekly")
+        XCTAssertEqual(QuotaBucket(id: "c", title: "c", shortLabel: "Spark 5h", usedPercent: 0).shortLabel, "Spark 5 Hours")
+        XCTAssertEqual(QuotaBucket(id: "d", title: "d", shortLabel: "Fable wk", usedPercent: 0).shortLabel, "Fable Weekly")
+        XCTAssertEqual(QuotaBucket(id: "weekly", title: "Weekly", shortLabel: "All models", usedPercent: 0).shortLabel, "Weekly")
+
+        let cachedJSON = #"{"id":"cached","title":"Weekly","shortLabel":"wk","usedPercent":20}"#.data(using: .utf8)!
+        let restored = try JSONDecoder().decode(QuotaBucket.self, from: cachedJSON)
+        XCTAssertEqual(restored.shortLabel, "Weekly")
+    }
 }

--- a/Tests/VibeBarCoreTests/QuotaPaceForecastTests.swift
+++ b/Tests/VibeBarCoreTests/QuotaPaceForecastTests.swift
@@ -1,0 +1,161 @@
+import XCTest
+@testable import VibeBarCore
+
+final class QuotaPaceForecastTests: XCTestCase {
+    private let week = 7 * 86_400
+
+    private func bucket(used: Double, resetAt: Date) -> QuotaBucket {
+        QuotaBucket(
+            id: "weekly",
+            title: "Weekly",
+            shortLabel: "Weekly",
+            usedPercent: used,
+            resetAt: resetAt,
+            rawWindowSeconds: week
+        )
+    }
+
+    private func point(_ used: Double, at date: Date, resetAt: Date) -> FillTimelinePoint {
+        FillTimelinePoint(
+            accountId: "account",
+            tool: .codex,
+            bucketId: "weekly",
+            slotStart: UsageFillTimelineStore.hourSlotStart(for: date),
+            usedPercent: used,
+            sampledAt: date,
+            resetAt: resetAt,
+            rawWindowSeconds: week
+        )
+    }
+
+    func testColdStartFallsBackToBehavioralLinearAndLabelsLearning() throws {
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let reset = now.addingTimeInterval(TimeInterval(week) / 2)
+        let forecast = try XCTUnwrap(QuotaPaceForecast.compute(
+            bucket: bucket(used: 30, resetAt: reset),
+            observations: [],
+            cycles: [],
+            now: now
+        ))
+        XCTAssertEqual(forecast.confidence, .learning)
+        XCTAssertEqual(forecast.verdict, .learning)
+        XCTAssertEqual(forecast.projectedUsedPercent, 60, accuracy: 0.5)
+        XCTAssertGreaterThan(forecast.targetRemainingPercent, 10)
+    }
+
+    func testRecentAccelerationPredictsRunOutBeforeReset() throws {
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let reset = now.addingTimeInterval(2 * 86_400)
+        let observations = (0..<10).map { index in
+            point(
+                44 + Double(index) * 4,
+                at: now.addingTimeInterval(TimeInterval(index - 9) * 3_600),
+                resetAt: reset
+            )
+        }
+        let forecast = try XCTUnwrap(QuotaPaceForecast.compute(
+            bucket: bucket(used: 80, resetAt: reset),
+            observations: observations,
+            cycles: [],
+            now: now
+        ))
+        XCTAssertEqual(forecast.verdict, .atRisk)
+        XCTAssertGreaterThanOrEqual(forecast.projectedUsedPercent, 100)
+        XCTAssertNotNil(forecast.runOutAt)
+        XCTAssertLessThan(try XCTUnwrap(forecast.runOutAt), reset)
+    }
+
+    func testHistoricalLowUtilizationSurfacesPotentialWaste() throws {
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let reset = now.addingTimeInterval(TimeInterval(week) / 2)
+        let start = reset.addingTimeInterval(-TimeInterval(week))
+        let currentPoints = (0..<12).map { index in
+            point(
+                Double(index) * 10 / 11,
+                at: start.addingTimeInterval(TimeInterval(index) * (TimeInterval(week) / 24)),
+                resetAt: reset
+            )
+        }
+        let cycles = (0..<6).map { index in
+            let end = start.addingTimeInterval(-TimeInterval(index + 1) * TimeInterval(week))
+            return SubscriptionWindowSample(
+                accountId: "account",
+                tool: .codex,
+                bucketId: "weekly",
+                windowEnd: end,
+                windowStart: end.addingTimeInterval(-TimeInterval(week)),
+                rawWindowSeconds: week,
+                peakUsedPercent: 28 + Double(index % 3),
+                lastUsedPercent: 28 + Double(index % 3),
+                observationCount: 12,
+                firstSeenAt: end.addingTimeInterval(-TimeInterval(week)),
+                lastSeenAt: end.addingTimeInterval(-60),
+                completedAt: end,
+                completionReason: .scheduledReset
+            )
+        }
+        let forecast = try XCTUnwrap(QuotaPaceForecast.compute(
+            bucket: bucket(used: 10, resetAt: reset),
+            observations: currentPoints,
+            cycles: cycles,
+            now: now
+        ))
+        XCTAssertNotEqual(forecast.verdict, .atRisk)
+        XCTAssertGreaterThan(forecast.potentialUnusedPercent, 30)
+        XCTAssertGreaterThan(forecast.projectedRemainingPercent, forecast.targetRemainingPercent)
+    }
+
+    func testForecastKeepsEveryBucketIndependent() throws {
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let reset = now.addingTimeInterval(2 * 86_400)
+        let first = try XCTUnwrap(QuotaPaceForecast.compute(
+            bucket: bucket(used: 20, resetAt: reset),
+            observations: [point(20, at: now, resetAt: reset)],
+            cycles: [],
+            now: now
+        ))
+        var secondBucket = bucket(used: 70, resetAt: reset)
+        secondBucket.id = "weekly_spark"
+        let second = try XCTUnwrap(QuotaPaceForecast.compute(
+            bucket: secondBucket,
+            observations: [],
+            cycles: [],
+            now: now
+        ))
+        XCTAssertNotEqual(first.projectedUsedPercent, second.projectedUsedPercent)
+    }
+
+    func testPlanUsesWeekdayAndHourActivityShapeInsteadOfWallClockOnly() throws {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+        let start = calendar.date(from: DateComponents(
+            year: 2026, month: 7, day: 20, hour: 0
+        ))! // Monday
+        let now = start.addingTimeInterval(2 * 86_400)
+        let reset = start.addingTimeInterval(TimeInterval(week))
+        var cells = Array(repeating: Array(repeating: 0, count: 24), count: 7)
+        cells[1] = Array(repeating: 100, count: 24) // Monday
+        cells[2] = Array(repeating: 100, count: 24) // Tuesday
+        let heatmap = UsageHeatmap(
+            tool: .codex,
+            cells: cells,
+            totalTokens: cells.flatMap { $0 }.reduce(0, +)
+        )
+        let uniform = try XCTUnwrap(QuotaPaceForecast.compute(
+            bucket: bucket(used: 20, resetAt: reset),
+            observations: [],
+            cycles: [],
+            now: now,
+            calendar: calendar
+        ))
+        let habitual = try XCTUnwrap(QuotaPaceForecast.compute(
+            bucket: bucket(used: 20, resetAt: reset),
+            observations: [],
+            cycles: [],
+            activityHeatmap: heatmap,
+            now: now,
+            calendar: calendar
+        ))
+        XCTAssertGreaterThan(habitual.plannedUsedPercent, uniform.plannedUsedPercent + 20)
+    }
+}

--- a/Tests/VibeBarCoreTests/SubscriptionWindowProgressTests.swift
+++ b/Tests/VibeBarCoreTests/SubscriptionWindowProgressTests.swift
@@ -47,7 +47,7 @@ final class SubscriptionWindowProgressTests: XCTestCase {
             rawWindowSeconds: 18_000,
             now: now
         )
-        XCTAssertEqual(summary, "2h 35m of 5h · 7% used")
+        XCTAssertEqual(summary, "2h 35m of 5 Hours · 7% used")
     }
 
     func testFiveHourWindowSubHourElapsed() {
@@ -59,7 +59,7 @@ final class SubscriptionWindowProgressTests: XCTestCase {
             rawWindowSeconds: 18_000,
             now: now
         )
-        XCTAssertEqual(summary, "30m of 5h · 12% used")
+        XCTAssertEqual(summary, "30m of 5 Hours · 12% used")
     }
 
     func testMissingResetAtFallsBackToPercentOnly() {

--- a/Tests/VibeBarCoreTests/UsageFillTimelineStoreTests.swift
+++ b/Tests/VibeBarCoreTests/UsageFillTimelineStoreTests.swift
@@ -47,7 +47,7 @@ final class UsageFillTimelineStoreTests: XCTestCase {
         )
     }
 
-    func testRecordsHeadlineBucketsIncludingFiveHour() async {
+    func testRecordsEveryBucketWithAdaptiveSlots() async {
         let store = UsageFillTimelineStore(fileURL: tempURL)
         let now = Date(timeIntervalSince1970: 1_780_000_123)
         await store.observe(quota(buckets: [
@@ -59,14 +59,18 @@ final class UsageFillTimelineStoreTests: XCTestCase {
         let five = await store.points(accountId: "acct-1", bucketId: "five_hour")
         XCTAssertEqual(five.count, 1)
         XCTAssertEqual(five.first?.usedPercent, 41)
-        XCTAssertEqual(five.first?.slotStart, UsageFillTimelineStore.hourSlotStart(for: now))
+        XCTAssertEqual(
+            five.first?.slotStart,
+            UsageFillTimelineStore.slotStart(for: now, windowSeconds: 18_000)
+        )
 
         let weekly = await store.points(accountId: "acct-1", bucketId: "weekly")
         XCTAssertEqual(weekly.count, 1)
 
-        // Per-model branch buckets are not part of the timeline chart.
         let fable = await store.points(accountId: "acct-1", bucketId: "weekly_fable")
-        XCTAssertTrue(fable.isEmpty)
+        XCTAssertEqual(fable.count, 1)
+        XCTAssertNotNil(fable.first?.resetAt)
+        XCTAssertEqual(fable.first?.rawWindowSeconds, 604_800)
     }
 
     func testLastSampleInHourWinsAndNewHourAppends() async {
@@ -94,13 +98,32 @@ final class UsageFillTimelineStoreTests: XCTestCase {
         let store = UsageFillTimelineStore(fileURL: tempURL)
         let old = Date(timeIntervalSince1970: 1_780_000_000)
         await store.observe(quota(buckets: [bucket(id: "weekly", used: 5)]), now: old)
-        // 10 days later: the old point is past the 8-day horizon and pruned
-        // by the next observe.
-        let later = old.addingTimeInterval(10 * 86_400)
+        // Weekly observations retain sixteen weeks.
+        let later = old.addingTimeInterval(120 * 86_400)
         await store.observe(quota(buckets: [bucket(id: "weekly", used: 9)]), now: later)
         let points = await store.points(accountId: "acct-1", bucketId: "weekly")
         XCTAssertEqual(points.count, 1)
         XCTAssertEqual(points.first?.usedPercent, 9)
+    }
+
+    func testAntigravityStoresEveryFiveHourAndWeeklyLane() async {
+        let store = UsageFillTimelineStore(fileURL: tempURL)
+        await store.observe(quota(
+            tool: .antigravity,
+            accountId: "ag-account",
+            buckets: [
+                bucket(id: "gemini_five_hour", used: 8, groupTitle: "Gemini Models", windowSeconds: 18_000),
+                bucket(id: "gemini_weekly", used: 12, groupTitle: "Gemini Models"),
+                bucket(id: "claude_gpt_five_hour", used: 5, groupTitle: "Claude and GPT Models", windowSeconds: 18_000),
+                bucket(id: "claude_gpt_weekly", used: 22, groupTitle: "Claude and GPT Models")
+            ]
+        ))
+        let points = await store.allPoints()
+        XCTAssertEqual(points.count, 4)
+        XCTAssertEqual(Set(points.map(\.bucketId)), [
+            "gemini_five_hour", "gemini_weekly",
+            "claude_gpt_five_hour", "claude_gpt_weekly"
+        ])
     }
 
     func testPersistenceRoundTrip() async {
@@ -114,5 +137,29 @@ final class UsageFillTimelineStoreTests: XCTestCase {
         XCTAssertEqual(points.count, 1)
         XCTAssertEqual(points.first?.usedPercent, 33)
         XCTAssertEqual(points.first?.tool, .claude)
+    }
+
+    func testSchemaOnePointsMigrateWithoutResetMetadata() async throws {
+        let sampledAt = Date(timeIntervalSince1970: 1_780_000_000)
+        let point = FillTimelinePoint(
+            accountId: "acct-legacy",
+            tool: .codex,
+            bucketId: "weekly",
+            slotStart: sampledAt,
+            usedPercent: 42,
+            sampledAt: sampledAt
+        )
+        struct LegacyStorage: Encodable {
+            let schemaVersion = 1
+            let points: [FillTimelinePoint]
+        }
+        try JSONEncoder().encode(LegacyStorage(points: [point])).write(to: tempURL, options: .atomic)
+
+        let store = UsageFillTimelineStore(fileURL: tempURL)
+        let migrated = await store.points(accountId: "acct-legacy", bucketId: "weekly")
+        XCTAssertEqual(migrated.count, 1)
+        XCTAssertEqual(migrated.first?.usedPercent, 42)
+        XCTAssertNil(migrated.first?.resetAt)
+        XCTAssertNil(migrated.first?.rawWindowSeconds)
     }
 }

--- a/Tests/VibeBarCoreTests/VolcengineAgentPlanParserTests.swift
+++ b/Tests/VibeBarCoreTests/VolcengineAgentPlanParserTests.swift
@@ -23,7 +23,7 @@ final class VolcengineAgentPlanParserTests: XCTestCase {
 
         XCTAssertEqual(snap.buckets[0].id, "volcengineAgentPlan.session")
         XCTAssertEqual(snap.buckets[0].title, "5 Hours")
-        XCTAssertEqual(snap.buckets[0].shortLabel, "5h")
+        XCTAssertEqual(snap.buckets[0].shortLabel, "5 Hours")
         XCTAssertEqual(snap.buckets[0].rawWindowSeconds, 5 * 3600)
         // 411.0225 / 10000 * 100 = 4.110225
         XCTAssertEqual(snap.buckets[0].usedPercent, 4.110225, accuracy: 0.0001)

--- a/Tests/VibeBarCoreTests/ZaiParserTests.swift
+++ b/Tests/VibeBarCoreTests/ZaiParserTests.swift
@@ -32,7 +32,7 @@ final class ZaiParserTests: XCTestCase {
         XCTAssertEqual(snap.buckets.count, 1)
         let bucket = snap.buckets[0]
         XCTAssertEqual(bucket.title, "Weekly")
-        XCTAssertEqual(bucket.shortLabel, "Wk")
+        XCTAssertEqual(bucket.shortLabel, "Weekly")
         // (10_000_000 - 6_500_000) / 10_000_000 * 100 = 35.0
         XCTAssertEqual(bucket.usedPercent, 35.0, accuracy: 0.01)
         XCTAssertEqual(bucket.rawWindowSeconds, 7 * 86_400)


### PR DESCRIPTION
## Summary
- capture all core-provider quota lanes and preserve completed reset cycles
- forecast whether each quota will last until reset using recent burn, historical cycles, activity habits, and confidence-aware reserve targets
- add reset-boundary refreshes and surface forecasts across overview, provider pages, fill history, and the mini window
- unify popover density behavior and retain stable provider-specific page headers
- include the accumulated Overview, Cost History, quota grouping, and compact layout fixes already completed locally

## Test plan
- [x] swift build
- [x] swift test (641 tests, 0 failures)
- [x] ./Scripts/build_app.sh release
- [x] codesign entitlements are empty
- [x] codesign --verify --deep --strict