### PR TITLE
Clarify quota forecast presentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -641,6 +641,17 @@ Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
 - **Mini-window geometry stays in `mini_window_geometry.json`.** Do not
   fold it back into `AppSettings` — every settings write fans out to
   every Combine subscriber.
+- **Keep the two pace systems intentionally separate.** The core-provider
+  surfaces (ChatGPT/Codex, Claude, Gemini Web, AntiGravity, and Grok) may use
+  `QuotaPaceForecast` and reset-cycle observations. Misc provider cards must
+  retain the legacy elapsed-time `UsagePace` reserve/deficit calculation and
+  `PaceMarkerCapsule`; do not route Misc through the personal forecast model
+  unless AQ explicitly asks to change that product boundary.
+- **Do not place unlabeled forecast micro-marks inside summary quota bars.** A
+  provider summary bar represents the current quota only. Put forecast status,
+  projected remaining quota, and uncertainty in a labeled row or a detailed
+  utilization view where their meaning is explicit. An unlabeled range line,
+  median tick, or plan tick in the summary bar looks like a rendering defect.
 - **Bundle ID is `com.astroqore.VibeBar`.** For a release, bump
   `CFBundleShortVersionString` and `CFBundleVersion` in
   `Resources/Info.plist`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -647,11 +647,18 @@ Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
   retain the legacy elapsed-time `UsagePace` reserve/deficit calculation and
   `PaceMarkerCapsule`; do not route Misc through the personal forecast model
   unless AQ explicitly asks to change that product boundary.
-- **Do not place unlabeled forecast micro-marks inside summary quota bars.** A
-  provider summary bar represents the current quota only. Put forecast status,
-  projected remaining quota, and uncertainty in a labeled row or a detailed
-  utilization view where their meaning is explicit. An unlabeled range line,
-  median tick, or plan tick in the summary bar looks like a rendering defect.
+- **Forecast overlays need one coherent visual vocabulary.** The current quota
+  remains the primary summary-bar layer. If a personal forecast is overlaid,
+  use one integrated uncertainty band plus one color-matched endpoint tied to
+  the labeled status row below. Do not stack unrelated plan, range, and median
+  micro-lines; they look like rendering defects without a legend. Detailed
+  utilization views may carry additional labeled planning marks.
+- **Subscription Utilization is the forecast explainability surface.** Keep
+  the legacy wall-clock pace visible alongside the personal plan, then expose
+  recent burn, reset-history comparison, weekday/hour activity weighting,
+  recent activity trend, forecast interval, safety target, evidence counts,
+  coverage, and confidence. The Overview may stay concise; this detail view
+  must show why a verdict was produced.
 - **Bundle ID is `com.astroqore.VibeBar`.** For a release, bump
   `CFBundleShortVersionString` and `CFBundleVersion` in
   `Resources/Info.plist`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -659,6 +659,11 @@ Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
   recent activity trend, forecast interval, safety target, evidence counts,
   coverage, and confidence. The Overview may stay concise; this detail view
   must show why a verdict was produced.
+- **`Surplus` is a robust likely-waste verdict, not a synonym for high current
+  remaining quota.** Keep `Learning` while confidence is low. Only surface
+  `Surplus` with at least medium confidence, a materially large median surplus
+  above the safety target, and a conservative forecast bound that still clears
+  that target. Risk verdicts always take precedence.
 - **Bundle ID is `com.astroqore.VibeBar`.** For a release, bump
   `CFBundleShortVersionString` and `CFBundleVersion` in
   `Resources/Info.plist`.

--- a/Sources/VibeBarApp/Views/MiniQuotaWindowView.swift
+++ b/Sources/VibeBarApp/Views/MiniQuotaWindowView.swift
@@ -482,6 +482,7 @@ private func miniForecastLine(_ forecast: QuotaPaceForecast, now: Date, compact:
     let left = Int(forecast.projectedRemainingPercent.rounded())
     switch forecast.verdict {
     case .enough: return compact ? "left \(left)%" : "\(left)% left"
+    case .surplus: return compact ? "surplus \(left)%" : "surplus · \(left)% left"
     case .watch: return "watch"
     case .atRisk: return "risk"
     case .learning: return compact ? "~\(left)% left" : "learning · \(left)% left"
@@ -492,6 +493,7 @@ private func miniForecastColor(_ forecast: QuotaPaceForecast?) -> Color {
     guard let forecast else { return Color.secondary.opacity(0.5) }
     switch forecast.verdict {
     case .enough: return Color(red: 0.20, green: 0.70, blue: 0.48)
+    case .surplus: return Color(red: 0.20, green: 0.56, blue: 0.88)
     case .watch: return Color(red: 0.96, green: 0.62, blue: 0.20)
     case .atRisk: return Color(red: 0.95, green: 0.32, blue: 0.32)
     case .learning: return .secondary

--- a/Sources/VibeBarApp/Views/MiniQuotaWindowView.swift
+++ b/Sources/VibeBarApp/Views/MiniQuotaWindowView.swift
@@ -556,8 +556,14 @@ private func miniPrimaryGroupTitle(
     for tool: ToolType,
     settings: MiniWindowSettings
 ) -> String? {
-    guard tool == .gemini else { return nil }
-    let key = "gemini.chat"
+    let key: String
+    switch tool {
+    case .codex: key = "codex.all-models"
+    case .claude: key = "claude.all-models"
+    case .gemini: key = "gemini.chat"
+    case .grok: key = "grok.all-models"
+    default: return nil
+    }
     let custom = settings.groupLabels[key]?.trimmingCharacters(in: .whitespacesAndNewlines)
     if let custom, !custom.isEmpty {
         return custom
@@ -619,9 +625,9 @@ private struct MiniL2GroupColumn: View {
     }
 }
 
-/// One L3 member inside an L2 super-column. Primary Gemini Web quotas use a
-/// compact "Gemini Chat" group heading so the two leftmost rings are clearly
-/// distinguished from AntiGravity's Gemini and Claude + GPT quota groups.
+/// One L3 member inside an L2 super-column. Primary provider quotas get an
+/// explicit group heading: "All Models" for ChatGPT, Claude, and Grok, and
+/// "Gemini Chat" for Gemini Web so it stays distinct from AntiGravity groups.
 private struct MiniMemberStack: View {
     let member: MiniL2Member
     let settings: MiniWindowSettings

--- a/Sources/VibeBarApp/Views/MiniWindowGroupLabelCatalog.swift
+++ b/Sources/VibeBarApp/Views/MiniWindowGroupLabelCatalog.swift
@@ -8,7 +8,9 @@ struct MiniWindowGroupLabelOption: Identifiable, Hashable {
 
 enum MiniWindowGroupLabelCatalog {
     static let all: [MiniWindowGroupLabelOption] = [
+        .init(id: "codex.all-models", title: "CHATGPT · All Models", defaultLabel: "All Models"),
         .init(id: "codex.spark", title: "CODEX · Spark", defaultLabel: "Spark"),
+        .init(id: "claude.all-models", title: "CLAUDE · All Models", defaultLabel: "All Models"),
         .init(id: "claude.sonnet", title: "CLAUDE · Sonnet", defaultLabel: "Sonnet"),
         .init(id: "claude.design", title: "CLAUDE · Design", defaultLabel: "Design"),
         .init(id: "claude.routine", title: "CLAUDE · Routine", defaultLabel: "Routine"),
@@ -20,7 +22,8 @@ enum MiniWindowGroupLabelCatalog {
         .init(id: "gemini.flash", title: "GEMINI · Flash", defaultLabel: "Flash"),
         .init(id: "gemini.flash-lite", title: "GEMINI · Flash Lite", defaultLabel: "Lite"),
         .init(id: "antigravity.gemini-models", title: "ANTIGRAVITY · Gemini Models", defaultLabel: "Gemini"),
-        .init(id: "antigravity.claude-gpt-models", title: "ANTIGRAVITY · Claude + GPT Models", defaultLabel: "C+G")
+        .init(id: "antigravity.claude-gpt-models", title: "ANTIGRAVITY · Claude + GPT Models", defaultLabel: "C+G"),
+        .init(id: "grok.all-models", title: "GROK · All Models", defaultLabel: "All Models")
     ]
 
     static func defaultLabel(for id: String) -> String? {

--- a/Sources/VibeBarApp/Views/PaceMarkerCapsule.swift
+++ b/Sources/VibeBarApp/Views/PaceMarkerCapsule.swift
@@ -60,3 +60,86 @@ struct PaceMarkerCapsule: View {
         min(max(value, lower), upper)
     }
 }
+
+/// Current quota with a forecast interval integrated into the same capsule.
+///
+/// The actual fill remains the dominant layer. The forecast uses one coherent
+/// visual vocabulary: a soft, full-height interval band plus one color-matched
+/// endpoint. The matching labeled row directly below supplies the meaning.
+struct ForecastQuotaBar: View {
+    let percent: Double
+    let mode: DisplayMode
+    let forecastLowerPercent: Double
+    let forecastUpperPercent: Double
+    let forecastMedianPercent: Double
+    let forecastColor: Color
+    var height: CGFloat = 12
+
+    var body: some View {
+        GeometryReader { proxy in
+            let width = proxy.size.width
+            let fillFraction = clamp(percent, 0, 100) / 100
+            let lower = clamp(min(forecastLowerPercent, forecastUpperPercent), 0, 100) / 100
+            let upper = clamp(max(forecastLowerPercent, forecastUpperPercent), 0, 100) / 100
+            let median = clamp(forecastMedianPercent, 0, 100) / 100
+            let inset = max(1.5, height * 0.14)
+            let endpointSize = min(7, max(5, height * 0.52))
+
+            ZStack(alignment: .leading) {
+                Capsule(style: .continuous)
+                    .fill(Theme.barTrack)
+                Capsule(style: .continuous)
+                    .fill(Theme.barColor(percent: percent, mode: mode))
+                    .frame(width: max(height, width * fillFraction))
+
+                if upper > lower {
+                    RoundedRectangle(
+                        cornerRadius: max(2, (height - inset * 2) / 2),
+                        style: .continuous
+                    )
+                    .fill(
+                        LinearGradient(
+                            colors: [
+                                forecastColor.opacity(0.10),
+                                forecastColor.opacity(0.28),
+                                forecastColor.opacity(0.10),
+                            ],
+                            startPoint: .leading,
+                            endPoint: .trailing
+                        )
+                    )
+                    .overlay {
+                        RoundedRectangle(
+                            cornerRadius: max(2, (height - inset * 2) / 2),
+                            style: .continuous
+                        )
+                        .stroke(forecastColor.opacity(0.24), lineWidth: 0.75)
+                    }
+                    .frame(
+                        width: max(endpointSize, width * (upper - lower)),
+                        height: max(3, height - inset * 2)
+                    )
+                    .offset(x: width * lower)
+                }
+
+                Circle()
+                    .fill(forecastColor)
+                    .overlay {
+                        Circle()
+                            .stroke(Color.white.opacity(0.72), lineWidth: 1)
+                    }
+                    .shadow(color: Color.black.opacity(0.18), radius: 1.5, y: 0.5)
+                    .frame(width: endpointSize, height: endpointSize)
+                    .offset(
+                        x: max(1, min(width - endpointSize - 1, width * median - endpointSize / 2))
+                    )
+            }
+            .clipShape(Capsule(style: .continuous))
+        }
+        .frame(height: height)
+    }
+
+    private func clamp(_ value: Double, _ lower: Double, _ upper: Double) -> Double {
+        min(max(value, lower), upper)
+    }
+}

--- a/Sources/VibeBarApp/Views/PaceMarkerCapsule.swift
+++ b/Sources/VibeBarApp/Views/PaceMarkerCapsule.swift
@@ -12,9 +12,6 @@ struct PaceMarkerCapsule: View {
     let expectedPercent: Double  // 0..100 in displayed terms (already mode-adjusted)
     let mode: DisplayMode
     var height: CGFloat = 12
-    var forecastLowerPercent: Double? = nil
-    var forecastUpperPercent: Double? = nil
-    var forecastMedianPercent: Double? = nil
 
     var body: some View {
         GeometryReader { proxy in
@@ -33,24 +30,6 @@ struct PaceMarkerCapsule: View {
                 Capsule(style: .continuous)
                     .fill(Theme.barColor(percent: usedPercent, mode: mode))
                     .frame(width: max(height, width * pct))
-                if let lower = forecastLowerPercent,
-                   let upper = forecastUpperPercent,
-                   upper > lower {
-                    let start = clamp(lower, 0, 100) / 100
-                    let end = clamp(upper, 0, 100) / 100
-                    RoundedRectangle(cornerRadius: 1.5, style: .continuous)
-                        .fill(Color.primary.opacity(0.24))
-                        .frame(width: max(2, width * (end - start)), height: max(2, height * 0.24))
-                        .offset(x: width * start, y: -height * 0.28)
-                }
-                if let median = forecastMedianPercent,
-                   median > 2,
-                   median < 98 {
-                    RoundedRectangle(cornerRadius: 1, style: .continuous)
-                        .fill(Color.primary.opacity(0.48))
-                        .frame(width: 1.5, height: max(3, height * 0.42))
-                        .offset(x: max(0, min(width - 1.5, width * clamp(median, 0, 100) / 100 - 0.75)), y: -height * 0.27)
-                }
                 if showMarker {
                     paceMarker
                         .offset(x: max(0, min(width - 7, width * markerPos - 3.5)))

--- a/Sources/VibeBarApp/Views/PopoverRoot.swift
+++ b/Sources/VibeBarApp/Views/PopoverRoot.swift
@@ -1885,6 +1885,8 @@ private struct ProviderBucketRow: View {
         let percent = bucket.displayPercent(mode)
         let pace = UsagePace.compute(bucket: bucket, now: now)
         let forecast = paceForecast(now: now)
+        let forecastRange = forecast.map { displayedRange($0) }
+        let forecastMedian = forecast.map { displayedForecast($0) }
         let legacyExpectedDisplayed = forecast == nil
             ? pace.map { expectedDisplay(for: $0, mode: mode) }
             : nil
@@ -1903,12 +1905,16 @@ private struct ProviderBucketRow: View {
                     .font(.system(size: density.bucketPercentFontSize, weight: .semibold, design: .rounded).monospacedDigit())
                     .foregroundStyle(Theme.barColor(percent: percent, mode: mode))
             }
-            // The provider summary bar represents only the quota that exists
-            // right now. Forecast ranges and plan markers need labels to be
-            // meaningful, so the personal forecast is expressed in the row
-            // below instead of as unexplained micro-marks inside the bar.
-            if forecast != nil {
-                QuotaBarShape(percent: percent, mode: mode, height: density.bucketBarHeight)
+            if let forecast, let forecastRange, let forecastMedian {
+                ForecastQuotaBar(
+                    percent: percent,
+                    mode: mode,
+                    forecastLowerPercent: forecastRange.lowerBound,
+                    forecastUpperPercent: forecastRange.upperBound,
+                    forecastMedianPercent: forecastMedian,
+                    forecastColor: QuotaForecastPalette.color(for: forecast.verdict),
+                    height: density.bucketBarHeight
+                )
             } else if let legacyExpectedDisplayed {
                 PaceMarkerCapsule(
                     usedPercent: percent,
@@ -1941,6 +1947,22 @@ private struct ProviderBucketRow: View {
             dailyActivity: snapshot?.dailyHistory ?? [],
             now: now
         )
+    }
+
+    private func displayedForecast(_ forecast: QuotaPaceForecast) -> Double {
+        switch mode {
+        case .used: forecast.projectedUsedPercent
+        case .remaining: 100 - forecast.projectedUsedPercent
+        }
+    }
+
+    private func displayedRange(_ forecast: QuotaPaceForecast) -> ClosedRange<Double> {
+        switch mode {
+        case .used:
+            return forecast.projectedUsedLowerPercent...forecast.projectedUsedUpperPercent
+        case .remaining:
+            return (100 - forecast.projectedUsedUpperPercent)...(100 - forecast.projectedUsedLowerPercent)
+        }
     }
 
     private func expectedDisplay(for pace: UsagePace, mode: DisplayMode) -> Double {

--- a/Sources/VibeBarApp/Views/PopoverRoot.swift
+++ b/Sources/VibeBarApp/Views/PopoverRoot.swift
@@ -1885,10 +1885,9 @@ private struct ProviderBucketRow: View {
         let percent = bucket.displayPercent(mode)
         let pace = UsagePace.compute(bucket: bucket, now: now)
         let forecast = paceForecast(now: now)
-        let expectedDisplayed = forecast.map { displayedPlan($0) }
-            ?? pace.map { expectedDisplay(for: $0, mode: mode) }
-        let forecastRange = forecast.map { displayedRange($0) }
-        let forecastMedian = forecast.map { displayedForecast($0) }
+        let legacyExpectedDisplayed = forecast == nil
+            ? pace.map { expectedDisplay(for: $0, mode: mode) }
+            : nil
         VStack(alignment: .leading, spacing: density.bucketRowSpacing) {
             HStack(alignment: .firstTextBaseline) {
                 Text(bucket.title)
@@ -1904,15 +1903,18 @@ private struct ProviderBucketRow: View {
                     .font(.system(size: density.bucketPercentFontSize, weight: .semibold, design: .rounded).monospacedDigit())
                     .foregroundStyle(Theme.barColor(percent: percent, mode: mode))
             }
-            if let expectedDisplayed {
+            // The provider summary bar represents only the quota that exists
+            // right now. Forecast ranges and plan markers need labels to be
+            // meaningful, so the personal forecast is expressed in the row
+            // below instead of as unexplained micro-marks inside the bar.
+            if forecast != nil {
+                QuotaBarShape(percent: percent, mode: mode, height: density.bucketBarHeight)
+            } else if let legacyExpectedDisplayed {
                 PaceMarkerCapsule(
                     usedPercent: percent,
-                    expectedPercent: expectedDisplayed,
+                    expectedPercent: legacyExpectedDisplayed,
                     mode: mode,
-                    height: density.bucketBarHeight,
-                    forecastLowerPercent: forecastRange?.lowerBound,
-                    forecastUpperPercent: forecastRange?.upperBound,
-                    forecastMedianPercent: forecastMedian
+                    height: density.bucketBarHeight
                 )
             } else {
                 QuotaBarShape(percent: percent, mode: mode, height: density.bucketBarHeight)
@@ -1939,29 +1941,6 @@ private struct ProviderBucketRow: View {
             dailyActivity: snapshot?.dailyHistory ?? [],
             now: now
         )
-    }
-
-    private func displayedPlan(_ forecast: QuotaPaceForecast) -> Double {
-        switch mode {
-        case .used: forecast.plannedUsedPercent
-        case .remaining: 100 - forecast.plannedUsedPercent
-        }
-    }
-
-    private func displayedForecast(_ forecast: QuotaPaceForecast) -> Double {
-        switch mode {
-        case .used: forecast.projectedUsedPercent
-        case .remaining: 100 - forecast.projectedUsedPercent
-        }
-    }
-
-    private func displayedRange(_ forecast: QuotaPaceForecast) -> ClosedRange<Double> {
-        switch mode {
-        case .used:
-            return forecast.projectedUsedLowerPercent...forecast.projectedUsedUpperPercent
-        case .remaining:
-            return (100 - forecast.projectedUsedUpperPercent)...(100 - forecast.projectedUsedLowerPercent)
-        }
     }
 
     private func expectedDisplay(for pace: UsagePace, mode: DisplayMode) -> Double {

--- a/Sources/VibeBarApp/Views/QuotaForecastRow.swift
+++ b/Sources/VibeBarApp/Views/QuotaForecastRow.swift
@@ -47,6 +47,8 @@ struct QuotaForecastRow: View {
         switch forecast.verdict {
         case .enough:
             return "Enough · forecast \(left)% left at reset"
+        case .surplus:
+            return "Surplus · forecast \(left)% left at reset"
         case .watch:
             return "Watch · forecast \(left)% left at reset"
         case .atRisk:
@@ -62,6 +64,7 @@ enum QuotaForecastPalette {
     static func color(for verdict: QuotaPaceForecast.Verdict) -> Color {
         switch verdict {
         case .enough: Color(red: 0.20, green: 0.70, blue: 0.48)
+        case .surplus: Color(red: 0.20, green: 0.56, blue: 0.88)
         case .watch: Color(red: 0.96, green: 0.62, blue: 0.20)
         case .atRisk: Color(red: 0.95, green: 0.32, blue: 0.32)
         case .learning: .secondary

--- a/Sources/VibeBarApp/Views/QuotaForecastRow.swift
+++ b/Sources/VibeBarApp/Views/QuotaForecastRow.swift
@@ -13,11 +13,11 @@ struct QuotaForecastRow: View {
         VStack(alignment: .leading, spacing: showGuidance ? 3 : 0) {
             HStack(spacing: 6) {
                 Circle()
-                    .fill(verdictColor)
+                    .fill(QuotaForecastPalette.color(for: forecast.verdict))
                     .frame(width: 5, height: 5)
                 Text(primaryText)
                     .font(.system(size: fontSize, weight: .medium))
-                    .foregroundStyle(verdictColor)
+                    .foregroundStyle(QuotaForecastPalette.color(for: forecast.verdict))
                     .lineLimit(1)
                     .truncationMode(.tail)
                 Spacer(minLength: 4)
@@ -56,8 +56,11 @@ struct QuotaForecastRow: View {
         }
     }
 
-    private var verdictColor: Color {
-        switch forecast.verdict {
+}
+
+enum QuotaForecastPalette {
+    static func color(for verdict: QuotaPaceForecast.Verdict) -> Color {
+        switch verdict {
         case .enough: Color(red: 0.20, green: 0.70, blue: 0.48)
         case .watch: Color(red: 0.96, green: 0.62, blue: 0.20)
         case .atRisk: Color(red: 0.95, green: 0.32, blue: 0.32)

--- a/Sources/VibeBarApp/Views/SubscriptionUtilizationView.swift
+++ b/Sources/VibeBarApp/Views/SubscriptionUtilizationView.swift
@@ -5,9 +5,10 @@ import VibeBarCore
 /// Subscription Utilization sub-page. Every independently resettable quota
 /// gets its own pace row — including model-scoped buckets such as Codex Spark
 /// and Claude Fable, plus linked product tools such as AntiGravity on Gemini.
-/// Each row shows the absolute time-since-reset on a horizontal Swift Charts
-/// bar alongside the linear "expected" reference line, making it obvious
-/// whether the user is burning faster or slower than the linear pace.
+/// The detailed view keeps both reference systems visible: the legacy
+/// wall-clock pace and the personal activity-aware plan. It also exposes the
+/// component projections, evidence coverage, confidence, target, and final
+/// forecast so the verdict is inspectable rather than a black box.
 struct SubscriptionUtilizationView: View {
     let tool: ToolType
     let buckets: [QuotaBucket]
@@ -123,7 +124,8 @@ struct SubscriptionUtilizationView: View {
         let pace = UsagePace.compute(bucket: bucket, now: now)
         let forecast = paceForecast(for: item)
         let used = bucket.usedPercent
-        let expected = forecast?.plannedUsedPercent ?? pace?.expectedUsedPercent ?? 0
+        let timeExpected = pace?.expectedUsedPercent
+        let personalExpected = forecast?.plannedUsedPercent
         VStack(alignment: .leading, spacing: density.bucketRowSpacing) {
             HStack(alignment: .firstTextBaseline) {
                 Text(rowTitle(for: item))
@@ -144,13 +146,15 @@ struct SubscriptionUtilizationView: View {
                 )
                 .foregroundStyle(Theme.barColor(percent: used, mode: .used))
                 .cornerRadius(3)
-                if expected > 0 {
-                    RuleMark(x: .value("Expected", expected))
-                        .foregroundStyle(.primary.opacity(0.55))
-                        .lineStyle(StrokeStyle(lineWidth: 1.5))
-                        // Annotation moved into the legend row below the chart
-                        // — placing it inside Charts caused the popover to clip
-                        // when the rule was near the chart edge (esp. at 100%).
+                if let timeExpected, timeExpected > 0 {
+                    RuleMark(x: .value("Time-only pace", timeExpected))
+                        .foregroundStyle(.secondary.opacity(0.7))
+                        .lineStyle(StrokeStyle(lineWidth: 1.25, dash: [3, 3]))
+                }
+                if let personalExpected, personalExpected > 0 {
+                    RuleMark(x: .value("Personal plan", personalExpected))
+                        .foregroundStyle(Color.accentColor.opacity(0.9))
+                        .lineStyle(StrokeStyle(lineWidth: 2))
                 }
             }
             .chartXScale(domain: 0...100)
@@ -167,6 +171,10 @@ struct SubscriptionUtilizationView: View {
             }
             .chartYAxis(.hidden)
             .frame(height: density.utilizationBarHeight)
+            referenceLegend(
+                timeExpected: timeExpected,
+                personalExpected: personalExpected
+            )
             Text(SubscriptionWindowProgress.summary(
                 usedPercent: bucket.usedPercent,
                 resetAt: bucket.resetAt,
@@ -184,6 +192,7 @@ struct SubscriptionUtilizationView: View {
                     fontSize: density.subtitleFontSize,
                     showGuidance: true
                 )
+                forecastExplanation(forecast: forecast, pace: pace)
             } else if let pace {
                 HStack(spacing: 6) {
                     Text(pace.stageSummary)
@@ -208,6 +217,206 @@ struct SubscriptionUtilizationView: View {
             dailyActivity: snapshot?.dailyHistory ?? [],
             now: now
         )
+    }
+
+    @ViewBuilder
+    private func referenceLegend(timeExpected: Double?, personalExpected: Double?) -> some View {
+        HStack(spacing: 14) {
+            if let timeExpected {
+                referenceLegendItem(
+                    color: .secondary,
+                    label: "Time-only pace",
+                    value: "\(Int(timeExpected.rounded()))%"
+                )
+            }
+            if let personalExpected {
+                referenceLegendItem(
+                    color: .accentColor,
+                    label: "Personal plan",
+                    value: "\(Int(personalExpected.rounded()))%"
+                )
+            }
+            Spacer(minLength: 4)
+            Text("bar = actual used")
+                .font(.system(size: max(8, density.subtitleFontSize - 1)))
+                .foregroundStyle(.tertiary)
+        }
+        .lineLimit(1)
+    }
+
+    private func referenceLegendItem(color: Color, label: String, value: String) -> some View {
+        HStack(spacing: 5) {
+            Capsule(style: .continuous)
+                .fill(color)
+                .frame(width: 14, height: 2)
+            Text("\(label) \(value)")
+                .font(.system(size: max(8, density.subtitleFontSize - 1), weight: .medium))
+                .foregroundStyle(color)
+        }
+    }
+
+    private struct ForecastMetric: Identifiable {
+        let id: String
+        let label: String
+        let value: String
+        let detail: String
+    }
+
+    private func forecastExplanation(
+        forecast: QuotaPaceForecast,
+        pace: UsagePace?
+    ) -> some View {
+        let metrics = forecastMetrics(forecast: forecast, pace: pace)
+        return VStack(alignment: .leading, spacing: 7) {
+            Text("How this forecast was calculated")
+                .font(.system(size: density.subtitleFontSize, weight: .semibold))
+                .foregroundStyle(.secondary)
+            LazyVGrid(
+                columns: [GridItem(.flexible()), GridItem(.flexible())],
+                alignment: .leading,
+                spacing: 7
+            ) {
+                ForEach(metrics) { metric in
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(metric.label.uppercased())
+                            .font(.system(size: max(8, density.subtitleFontSize - 2), weight: .semibold))
+                            .foregroundStyle(.tertiary)
+                            .lineLimit(1)
+                        Text(metric.value)
+                            .font(.system(size: density.subtitleFontSize, weight: .semibold, design: .rounded))
+                            .foregroundStyle(.primary)
+                            .lineLimit(1)
+                            .minimumScaleFactor(0.82)
+                        Text(metric.detail)
+                            .font(.system(size: max(8, density.subtitleFontSize - 1)))
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                            .minimumScaleFactor(0.78)
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 7)
+                    .background(
+                        RoundedRectangle(cornerRadius: 7, style: .continuous)
+                            .fill(Color.primary.opacity(0.035))
+                    )
+                }
+            }
+            Text("Quota observations drive consumption. Token history only weights when you tend to work; it is never converted into quota usage.")
+                .font(.system(size: max(8, density.subtitleFontSize - 1)))
+                .foregroundStyle(.tertiary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(.top, 2)
+    }
+
+    private func forecastMetrics(
+        forecast: QuotaPaceForecast,
+        pace: UsagePace?
+    ) -> [ForecastMetric] {
+        let diagnostics = forecast.diagnostics
+        let timePaceValue = pace.map { "\(whole($0.expectedUsedPercent))% expected now" } ?? "Unavailable"
+        let timePaceDetail = pace.map { "\($0.stageSummary) by wall clock" } ?? "Needs reset time and window length"
+        let recentValue = diagnostics.recentProjectionUsedPercent
+            .map { "\(whole($0))% used at reset" } ?? "Learning"
+        let recentDetail = diagnostics.recentSampleCount > 0
+            ? "\(diagnostics.recentSampleCount) recent intervals"
+            : "Needs at least two useful observations"
+        let historyValue = diagnostics.historicalProjectionUsedPercent
+            .map { "\(whole($0))% used at reset" } ?? "No comparison yet"
+        let historyDetail = diagnostics.comparableCycleCount > 0
+            ? "\(diagnostics.comparableCycleCount) comparable reset cycles"
+            : "Completed cycles will appear here"
+        let activityDetail = diagnostics.activityCoveragePercent > 0
+            ? "weekday and hour weighted"
+            : "wall-clock fallback until habits exist"
+        let trendValue = diagnostics.hasActivityTrendBaseline
+            ? String(format: "%.2f× activity", diagnostics.activityTrendMultiplier)
+            : "No baseline yet"
+        let trendDetail = diagnostics.hasActivityTrendBaseline
+            ? "last 7 days versus prior 21 days"
+            : "needs prior daily activity"
+        let range = forecast.projectedUsedLowerPercent...forecast.projectedUsedUpperPercent
+        let unused = whole(forecast.potentialUnusedPercent)
+
+        return [
+            ForecastMetric(
+                id: "time",
+                label: "Time-only pace",
+                value: timePaceValue,
+                detail: timePaceDetail
+            ),
+            ForecastMetric(
+                id: "plan",
+                label: "Personal plan now",
+                value: "\(whole(forecast.plannedUsedPercent))% used",
+                detail: "activity timing + \(whole(forecast.targetRemainingPercent))% safety target"
+            ),
+            ForecastMetric(
+                id: "recent",
+                label: "Recent burn",
+                value: recentValue,
+                detail: recentDetail
+            ),
+            ForecastMetric(
+                id: "history",
+                label: "Reset history",
+                value: historyValue,
+                detail: historyDetail
+            ),
+            ForecastMetric(
+                id: "activity",
+                label: "Activity timing",
+                value: "\(whole(diagnostics.behavioralProgressPercent))% elapsed",
+                detail: activityDetail
+            ),
+            ForecastMetric(
+                id: "trend",
+                label: "Recent trend",
+                value: trendValue,
+                detail: trendDetail
+            ),
+            ForecastMetric(
+                id: "forecast",
+                label: "Forecast at reset",
+                value: "\(whole(forecast.projectedUsedPercent))% used",
+                detail: "\(whole(forecast.projectedRemainingPercent))% expected left"
+            ),
+            ForecastMetric(
+                id: "range",
+                label: "Forecast range",
+                value: "\(whole(range.lowerBound))–\(whole(range.upperBound))% used",
+                detail: "uncertainty interval"
+            ),
+            ForecastMetric(
+                id: "target",
+                label: "Safety target",
+                value: "\(whole(forecast.targetRemainingPercent))% left",
+                detail: unused >= 3 ? "\(unused)% capacity above target" : "inside the target range"
+            ),
+            ForecastMetric(
+                id: "evidence",
+                label: "Evidence",
+                value: "\(forecast.currentObservationCount) obs · \(forecast.completedCycleCount) cycles",
+                detail: "\(forecast.confidenceLabel) · score \(whole(forecast.confidenceScore * 100))%"
+            ),
+            ForecastMetric(
+                id: "coverage",
+                label: "Coverage",
+                value: "obs \(whole(diagnostics.observationCoveragePercent))% · history \(whole(diagnostics.historyCoveragePercent))%",
+                detail: "fresh \(whole(diagnostics.freshnessPercent))% · habits \(whole(diagnostics.activityCoveragePercent))%"
+            ),
+            ForecastMetric(
+                id: "behavior",
+                label: "Behavior fallback",
+                value: "\(whole(diagnostics.behavioralProjectionUsedPercent))% used at reset",
+                detail: "used when stronger evidence is sparse"
+            ),
+        ]
+    }
+
+    private func whole(_ value: Double) -> Int {
+        Int(value.rounded())
     }
 
     private func rowTitle(for item: UtilizationBucket) -> String {

--- a/Sources/VibeBarCore/Services/QuotaPaceForecast.swift
+++ b/Sources/VibeBarCore/Services/QuotaPaceForecast.swift
@@ -24,6 +24,24 @@ public struct QuotaPaceForecast: Sendable, Equatable {
         case high
     }
 
+    /// Explainable inputs and component projections used by the blended
+    /// forecast. These values are intentionally retained so detailed product
+    /// surfaces can show their work instead of presenting a black-box verdict.
+    public struct Diagnostics: Sendable, Equatable {
+        public let recentProjectionUsedPercent: Double?
+        public let historicalProjectionUsedPercent: Double?
+        public let behavioralProjectionUsedPercent: Double
+        public let behavioralProgressPercent: Double
+        public let activityTrendMultiplier: Double
+        public let hasActivityTrendBaseline: Bool
+        public let observationCoveragePercent: Double
+        public let historyCoveragePercent: Double
+        public let freshnessPercent: Double
+        public let activityCoveragePercent: Double
+        public let recentSampleCount: Int
+        public let comparableCycleCount: Int
+    }
+
     public let verdict: Verdict
     public let confidence: Confidence
     public let confidenceScore: Double
@@ -38,6 +56,7 @@ public struct QuotaPaceForecast: Sendable, Equatable {
     public let runOutAt: Date?
     public let completedCycleCount: Int
     public let currentObservationCount: Int
+    public let diagnostics: Diagnostics
 
     public var projectedRemainingPercent: Double {
         max(0, 100 - projectedUsedPercent)
@@ -134,17 +153,24 @@ public struct QuotaPaceForecast: Sendable, Equatable {
             currentProgress: behavioralProgress,
             profile: profile
         )
-        let trend = activityTrend(dailyActivity, now: now, calendar: calendar)
+        let trendResult = activityTrend(dailyActivity, now: now, calendar: calendar)
+        let trend = trendResult.multiplier
+
+        let recentProjection = recent.rate.flatMap { recentRate in
+            recentRate > 0 ? actual + recentRate * futureActivity : nil
+        }
+        let historicalProjection = median(historicalAdditions).map {
+            actual + $0 * trend
+        }
 
         var candidates: [(value: Double, weight: Double)] = []
-        if let recentRate = recent.rate, recentRate > 0 {
-            let prediction = actual + recentRate * futureActivity
+        if let recentProjection {
             let reliability = min(1, Double(recent.sampleCount) / 6)
-            candidates.append((prediction, 0.52 * reliability))
+            candidates.append((recentProjection, 0.52 * reliability))
         }
-        if let historical = median(historicalAdditions) {
+        if let historicalProjection {
             let reliability = min(1, Double(historicalAdditions.count) / 5)
-            candidates.append((actual + historical * trend, 0.34 * reliability))
+            candidates.append((historicalProjection, 0.34 * reliability))
         }
 
         // Always retain a low-weight behavioral-time fallback. It behaves like
@@ -156,7 +182,8 @@ public struct QuotaPaceForecast: Sendable, Equatable {
         } else {
             fallback = actual
         }
-        candidates.append((fallback * trend, 0.14))
+        let behavioralProjection = fallback * trend
+        candidates.append((behavioralProjection, 0.14))
 
         let weightSum = candidates.reduce(0) { $0 + $1.weight }
         let rawProjection = weightSum > 0
@@ -240,7 +267,21 @@ public struct QuotaPaceForecast: Sendable, Equatable {
             targetRemainingPercent: targetRemaining,
             runOutAt: runOutAt,
             completedCycleCount: completed.count,
-            currentObservationCount: currentPoints.count
+            currentObservationCount: currentPoints.count,
+            diagnostics: Diagnostics(
+                recentProjectionUsedPercent: recentProjection,
+                historicalProjectionUsedPercent: historicalProjection,
+                behavioralProjectionUsedPercent: behavioralProjection,
+                behavioralProgressPercent: behavioralProgress * 100,
+                activityTrendMultiplier: trend,
+                hasActivityTrendBaseline: trendResult.hasBaseline,
+                observationCoveragePercent: observationCoverage * 100,
+                historyCoveragePercent: historyCoverage * 100,
+                freshnessPercent: freshness * 100,
+                activityCoveragePercent: activityCoverage * 100,
+                recentSampleCount: recent.sampleCount,
+                comparableCycleCount: historicalAdditions.count
+            )
         )
     }
 
@@ -294,18 +335,30 @@ public struct QuotaPaceForecast: Sendable, Equatable {
         }
     }
 
-    private static func activityTrend(_ days: [DailyCostPoint], now: Date, calendar: Calendar) -> Double {
-        guard !days.isEmpty else { return 1 }
+    private struct ActivityTrendResult {
+        let multiplier: Double
+        let hasBaseline: Bool
+    }
+
+    private static func activityTrend(
+        _ days: [DailyCostPoint],
+        now: Date,
+        calendar: Calendar
+    ) -> ActivityTrendResult {
+        guard !days.isEmpty else { return ActivityTrendResult(multiplier: 1, hasBaseline: false) }
         let today = calendar.startOfDay(for: now)
         let recentStart = calendar.date(byAdding: .day, value: -6, to: today) ?? today
         let baselineStart = calendar.date(byAdding: .day, value: -27, to: today) ?? today
         let baselineEnd = calendar.date(byAdding: .day, value: -7, to: today) ?? today
         let recentTotal = days.filter { $0.date >= recentStart && $0.date <= now }.reduce(0.0) { $0 + Double($1.totalTokens) }
         let baselineTotal = days.filter { $0.date >= baselineStart && $0.date < baselineEnd }.reduce(0.0) { $0 + Double($1.totalTokens) }
-        guard baselineTotal > 0 else { return 1 }
+        guard baselineTotal > 0 else { return ActivityTrendResult(multiplier: 1, hasBaseline: false) }
         let recentAverage = recentTotal / 7
         let baselineAverage = baselineTotal / 21
-        return clamp(recentAverage / baselineAverage, 0.5, 1.8)
+        return ActivityTrendResult(
+            multiplier: clamp(recentAverage / baselineAverage, 0.5, 1.8),
+            hasBaseline: true
+        )
     }
 
     private struct ActivityProfile {

--- a/Sources/VibeBarCore/Services/QuotaPaceForecast.swift
+++ b/Sources/VibeBarCore/Services/QuotaPaceForecast.swift
@@ -13,6 +13,7 @@ import Foundation
 public struct QuotaPaceForecast: Sendable, Equatable {
     public enum Verdict: String, Sendable, Equatable {
         case enough
+        case surplus
         case watch
         case atRisk
         case learning
@@ -76,6 +77,7 @@ public struct QuotaPaceForecast: Sendable, Equatable {
     public var verdictLabel: String {
         switch verdict {
         case .enough: "Enough"
+        case .surplus: "Surplus"
         case .watch: "Watch"
         case .atRisk: "At risk"
         case .learning: "Learning"
@@ -95,6 +97,8 @@ public struct QuotaPaceForecast: Sendable, Equatable {
         switch verdict {
         case .enough:
             return "Forecast \(left)% left at reset"
+        case .surplus:
+            return "Likely surplus · forecast \(left)% left"
         case .watch:
             return "May run short · forecast \(left)% left"
         case .atRisk:
@@ -109,6 +113,9 @@ public struct QuotaPaceForecast: Sendable, Equatable {
         let unused = Int(potentialUnusedPercent.rounded())
         if verdict == .atRisk { return "Slow down or shift work to another quota" }
         if verdict == .watch { return "Recent usage is above the safe range" }
+        if verdict == .surplus {
+            return "About \(unused)% likely unused beyond the \(target)% safety target"
+        }
         if unused >= 3 {
             return "Target \(target)% left · about \(unused)% available"
         }
@@ -229,6 +236,11 @@ public struct QuotaPaceForecast: Sendable, Equatable {
         )
         let lower = max(actual, projected - uncertainty)
         let upper = projected + uncertainty
+        // A high remaining estimate alone is not enough to call quota waste:
+        // require both a material median surplus and a pessimistic bound that
+        // still clears the adaptive safety target.
+        let medianSurplus = max(0, 100 - projected - targetRemaining)
+        let conservativeSurplus = max(0, 100 - upper - targetRemaining)
 
         let verdict: Verdict
         if projected >= 100 {
@@ -237,6 +249,8 @@ public struct QuotaPaceForecast: Sendable, Equatable {
             verdict = .watch
         } else if confidence == .learning {
             verdict = .learning
+        } else if medianSurplus >= 25, conservativeSurplus >= 10 {
+            verdict = .surplus
         } else {
             verdict = .enough
         }

--- a/Tests/VibeBarCoreTests/QuotaPaceForecastTests.swift
+++ b/Tests/VibeBarCoreTests/QuotaPaceForecastTests.swift
@@ -105,9 +105,16 @@ final class QuotaPaceForecastTests: XCTestCase {
             cycles: cycles,
             now: now
         ))
-        XCTAssertNotEqual(forecast.verdict, .atRisk)
+        XCTAssertEqual(forecast.verdict, .surplus)
+        XCTAssertEqual(forecast.verdictLabel, "Surplus")
+        XCTAssertTrue(forecast.resetSummary.hasPrefix("Likely surplus"))
+        XCTAssertTrue(forecast.guidanceSummary.contains("likely unused"))
         XCTAssertGreaterThan(forecast.potentialUnusedPercent, 30)
         XCTAssertGreaterThan(forecast.projectedRemainingPercent, forecast.targetRemainingPercent)
+        XCTAssertGreaterThanOrEqual(
+            forecast.projectedRemainingRange.lowerBound - forecast.targetRemainingPercent,
+            10
+        )
     }
 
     func testForecastKeepsEveryBucketIndependent() throws {

--- a/Tests/VibeBarCoreTests/QuotaPaceForecastTests.swift
+++ b/Tests/VibeBarCoreTests/QuotaPaceForecastTests.swift
@@ -41,6 +41,9 @@ final class QuotaPaceForecastTests: XCTestCase {
         XCTAssertEqual(forecast.verdict, .learning)
         XCTAssertEqual(forecast.projectedUsedPercent, 60, accuracy: 0.5)
         XCTAssertGreaterThan(forecast.targetRemainingPercent, 10)
+        XCTAssertEqual(forecast.diagnostics.behavioralProjectionUsedPercent, 60, accuracy: 0.5)
+        XCTAssertFalse(forecast.diagnostics.hasActivityTrendBaseline)
+        XCTAssertEqual(forecast.diagnostics.recentSampleCount, 0)
     }
 
     func testRecentAccelerationPredictsRunOutBeforeReset() throws {
@@ -61,6 +64,8 @@ final class QuotaPaceForecastTests: XCTestCase {
         ))
         XCTAssertEqual(forecast.verdict, .atRisk)
         XCTAssertGreaterThanOrEqual(forecast.projectedUsedPercent, 100)
+        XCTAssertNotNil(forecast.diagnostics.recentProjectionUsedPercent)
+        XCTAssertGreaterThan(forecast.diagnostics.recentSampleCount, 0)
         XCTAssertNotNil(forecast.runOutAt)
         XCTAssertLessThan(try XCTUnwrap(forecast.runOutAt), reset)
     }
@@ -157,5 +162,7 @@ final class QuotaPaceForecastTests: XCTestCase {
             calendar: calendar
         ))
         XCTAssertGreaterThan(habitual.plannedUsedPercent, uniform.plannedUsedPercent + 20)
+        XCTAssertEqual(habitual.diagnostics.activityCoveragePercent, 100)
+        XCTAssertGreaterThan(habitual.diagnostics.behavioralProgressPercent, 70)
     }
 }


### PR DESCRIPTION
## Summary
- replace conflicting plan/range/median micro-lines with one status-colored uncertainty band and one forecast endpoint
- keep the endpoint color tied to the labeled Enough, Surplus, Watch, At risk, or Learning row
- add a guarded Surplus verdict for likely pre-reset waste: medium-or-higher confidence, at least 25% median surplus, and at least 10% conservative surplus above the safety target
- expand Subscription Utilization with both legacy time-only pace and the personal activity-aware plan
- expose recent burn, reset history, activity timing, 7/21-day trend, forecast range, safety target, evidence, coverage, and confidence
- show All Models above the primary ChatGPT, Claude, and Grok mini-window quota groups in regular and compact layouts
- preserve the legacy elapsed-time pace implementation for Misc provider cards and document the product boundary in AGENTS.md

## Test plan
- [x] swift build
- [x] swift test (641 tests, 0 failures)
- [x] ./Scripts/build_app.sh release
- [x] empty entitlements verified
- [x] codesign --verify --deep --strict