### PR TITLE
Rebalance provider detail pages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -661,6 +661,12 @@ Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
   recent activity trend, forecast interval, safety target, evidence counts,
   coverage, and confidence. The Overview may stay concise; this detail view
   must show why a verdict was produced.
+- **Core-provider use-up ETA comes from the personal forecast.** Under each
+  core quota, preserve the scannable "runs out in" conclusion, but derive it
+  from `QuotaPaceForecast.runOutAt`, not the legacy elapsed-time burn rate.
+  When the model does not predict exhaustion before reset, say that the quota
+  is projected to last until reset instead of extrapolating a meaningless time
+  beyond the refill boundary. A `Watch` ETA is explicitly possible, not certain.
 - **Reset history belongs to its quota.** Render each independently resettable
   bucket's cycle history immediately under that bucket in Subscription
   Utilization. Do not restore a shared selector at the bottom of the card;

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -648,17 +648,34 @@ Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
   `PaceMarkerCapsule`; do not route Misc through the personal forecast model
   unless AQ explicitly asks to change that product boundary.
 - **Forecast overlays need one coherent visual vocabulary.** The current quota
-  remains the primary summary-bar layer. If a personal forecast is overlaid,
-  use one integrated uncertainty band plus one color-matched endpoint tied to
-  the labeled status row below. Do not stack unrelated plan, range, and median
-  micro-lines; they look like rendering defects without a legend. Detailed
-  utilization views may carry additional labeled planning marks.
+  remains the primary summary-bar layer. The elapsed-time-only pace is a thin
+  solid gray vertical tick; the forecast-at-reset median is a taller
+  verdict-colored vertical tick; the confidence interval is a matching bottom
+  gradient band. Legends must use the same vertical-tick shapes as the bar —
+  never show a solid sample for a dashed mark or turn the forecast into a dot.
+  Keep forecast semantics in the labeled status row below the Overview bar;
+  detailed utilization views may carry the explicit reference legend.
 - **Subscription Utilization is the forecast explainability surface.** Keep
-  the legacy wall-clock pace visible alongside the personal plan, then expose
+  the legacy wall-clock pace visible alongside the forecast at reset, then expose
   recent burn, reset-history comparison, weekday/hour activity weighting,
   recent activity trend, forecast interval, safety target, evidence counts,
   coverage, and confidence. The Overview may stay concise; this detail view
   must show why a verdict was produced.
+- **Reset history belongs to its quota.** Render each independently resettable
+  bucket's cycle history immediately under that bucket in Subscription
+  Utilization. Do not restore a shared selector at the bottom of the card;
+  model-scoped limits such as Spark, Fable, Gemini Web, and AntiGravity must
+  remain visible at the same time.
+- **Provider detail pages share one asymmetric layout.** Preserve the existing
+  column ratio but put the wide primary flow on the left in this order: quota,
+  cost, cost history, service status, model ranking, past year, when-you-use.
+  The narrow right column contains Subscription Utilization only. ChatGPT,
+  Claude, Gemini, and Grok must use the same framework.
+- **Dense status history is one drawing surface, not hundreds of views.** Use
+  `Canvas` (or an equivalent batched renderer) for uptime strips and avoid one
+  Swift Charts instance per quota. These detail pages can display many status
+  components and quota dimensions simultaneously, so per-cell view trees make
+  scrolling visibly stutter.
 - **`Surplus` is a robust likely-waste verdict, not a synonym for high current
   remaining quota.** Keep `Learning` while confidence is low. Only surface
   `Surplus` with at least medium confidence, a materially large median surplus

--- a/Sources/VibeBarApp/Views/FillTimelineChart.swift
+++ b/Sources/VibeBarApp/Views/FillTimelineChart.swift
@@ -16,14 +16,12 @@ struct FillTimelineSeries: Identifiable {
 /// answers the useful question: how much quota was still unused when the
 /// provider refilled it? The final outlined bar is the active cycle.
 struct FillTimelineChart: View {
-    let series: [FillTimelineSeries]
+    let series: FillTimelineSeries
     let mode: DisplayMode
     let density: Theme.Density
-    let now: Date
+    let targetPercent: Double?
 
     @EnvironmentObject var quotaService: QuotaService
-    @EnvironmentObject var environment: AppEnvironment
-    @State private var selectedBucketId: String?
     @State private var hoveredIndex: Int?
 
     private static let maxCycles = 12
@@ -44,122 +42,26 @@ struct FillTimelineChart: View {
         }
     }
 
-    private var tabHeight: CGFloat {
-        switch density.profile {
-        case .compact: 20
-        case .regular: 24
-        case .spacious: 28
-        }
-    }
-
     var body: some View {
-        let tabs = availableTabs
-        if tabs.isEmpty {
-            EmptyView()
-        } else {
-            let activeSeriesId = selectedBucketId.flatMap { id in
-                tabs.contains(where: { $0.id == id }) ? id : nil
-            } ?? tabs[0].id
-            let activeSeries = tabs.first(where: { $0.id == activeSeriesId })!.series
-            let cycles = visibleCycles(series: activeSeries)
-            let target = displayedTarget(for: activeSeries)
-            VStack(alignment: .leading, spacing: 4) {
-                HStack(alignment: .firstTextBaseline, spacing: 8) {
-                    Text("Utilization by reset")
-                        .font(.system(size: max(9, density.subtitleFontSize - 2)))
-                        .foregroundStyle(.tertiary)
-                    Spacer(minLength: 8)
-                    Text("Each bar is one quota cycle")
-                        .font(.system(size: max(7.5, density.subtitleFontSize - 4)))
-                        .foregroundStyle(.quaternary)
-                }
-                if tabs.count > 1 {
-                    GeometryReader { geometry in
-                        let tabFontSize = max(8.5, density.subtitleFontSize - 2)
-                        let minimumContentWidth = tabs.reduce(CGFloat.zero) { width, tab in
-                            width + max(64, CGFloat(tab.label.count) * tabFontSize * 0.58 + 24)
-                        } + CGFloat(max(0, tabs.count - 1)) * 2 + 4
-                        let contentWidth = max(geometry.size.width, minimumContentWidth)
-
-                        ScrollView(.horizontal, showsIndicators: false) {
-                            HStack(spacing: 2) {
-                                ForEach(tabs, id: \.id) { tab in
-                                    let isSelected = tab.id == activeSeriesId
-                                    Button {
-                                        selectedBucketId = tab.id
-                                        hoveredIndex = nil
-                                    } label: {
-                                        Text(tab.label)
-                                            .font(.system(
-                                                size: tabFontSize,
-                                                weight: .semibold,
-                                                design: .rounded
-                                            ))
-                                            .foregroundStyle(isSelected ? Color.white : Color.secondary)
-                                            .lineLimit(1)
-                                            .fixedSize(horizontal: true, vertical: false)
-                                            .padding(.horizontal, 9)
-                                            .frame(maxWidth: .infinity, minHeight: tabHeight, maxHeight: tabHeight)
-                                            .background {
-                                                if isSelected {
-                                                    RoundedRectangle(cornerRadius: 6, style: .continuous)
-                                                        .fill(Color.accentColor)
-                                                }
-                                            }
-                                            .contentShape(Rectangle())
-                                    }
-                                    .buttonStyle(.plain)
-                                    .focusable(false)
-                                    .accessibilityLabel("Show \(tab.label) utilization history")
-                                }
-                            }
-                            .padding(2)
-                            .frame(width: contentWidth)
-                        }
-                    }
-                    .frame(height: tabHeight + 4)
-                    .background(
-                        RoundedRectangle(cornerRadius: 7, style: .continuous)
-                            .fill(Color.primary.opacity(0.08))
-                    )
-                }
-                cycleStrip(cycles, tool: activeSeries.tool, targetPercent: target)
-                Text(caption(cycles))
-                    .font(.system(size: max(8, density.subtitleFontSize - 3), design: .rounded).monospacedDigit())
-                    .foregroundStyle(.secondary)
-                    .lineLimit(1)
-                    .truncationMode(.tail)
-                axis(cycles)
+        let cycles = visibleCycles(series: series)
+        VStack(alignment: .leading, spacing: 4) {
+            HStack(alignment: .firstTextBaseline, spacing: 8) {
+                Text("Reset history")
+                    .font(.system(size: max(9, density.subtitleFontSize - 2), weight: .medium))
+                    .foregroundStyle(.tertiary)
+                Spacer(minLength: 8)
+                Text("Each bar is one quota cycle")
+                    .font(.system(size: max(7.5, density.subtitleFontSize - 4)))
+                    .foregroundStyle(.quaternary)
             }
-            .padding(.top, 2)
+            cycleStrip(cycles, tool: series.tool, targetPercent: targetPercent)
+            Text(caption(cycles))
+                .font(.system(size: max(8, density.subtitleFontSize - 3), design: .rounded).monospacedDigit())
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+            axis(cycles)
         }
-    }
-
-    private var availableTabs: [(id: String, label: String, series: FillTimelineSeries)] {
-        let toolCount = Set(series.map(\.tool)).count
-        return series.map { item in
-            (item.id, Self.tabLabel(for: item, includeTool: toolCount > 1), item)
-        }
-    }
-
-    private static func tabLabel(for series: FillTimelineSeries, includeTool: Bool) -> String {
-        let bucket = series.bucket
-        let window: String
-        switch bucket.rawWindowSeconds {
-        case 18_000: window = "5 Hours"
-        case 604_800: window = "Weekly"
-        case 2_592_000: window = "Monthly"
-        default:
-            switch bucket.shortLabel.lowercased() {
-            case "5h", "5 hr", "5 hrs": window = "5 Hours"
-            case "wk", "1w": window = "Weekly"
-            case "mo", "1m": window = "Monthly"
-            default: window = bucket.title
-            }
-        }
-        let group = bucket.groupTitle?.replacingOccurrences(of: " Models", with: "")
-        let owner = group ?? (includeTool ? series.tool.toolName : nil)
-        return owner.map { "\($0) · \(window)" } ?? window
+        .padding(.top, 4)
     }
 
     private func visibleCycles(series: FillTimelineSeries) -> [SubscriptionWindowSample] {
@@ -281,21 +183,6 @@ struct FillTimelineChart: View {
         switch mode {
         case .used: cycle.peakUsedPercent
         case .remaining: cycle.remainingPercentAtReset
-        }
-    }
-
-    private func displayedTarget(for series: FillTimelineSeries) -> Double? {
-        let snapshot = environment.costService.snapshot(for: series.tool)
-        guard let forecast = quotaService.paceForecast(
-            accountId: series.accountId,
-            bucket: series.bucket,
-            activityHeatmap: snapshot?.heatmap,
-            dailyActivity: snapshot?.dailyHistory ?? [],
-            now: now
-        ) else { return nil }
-        switch mode {
-        case .used: return 100 - forecast.targetRemainingPercent
-        case .remaining: return forecast.targetRemainingPercent
         }
     }
 

--- a/Sources/VibeBarApp/Views/MiniQuotaWindowView.swift
+++ b/Sources/VibeBarApp/Views/MiniQuotaWindowView.swift
@@ -474,10 +474,9 @@ private func miniForecastPlan(_ forecast: QuotaPaceForecast, mode: DisplayMode) 
 }
 
 private func miniForecastLine(_ forecast: QuotaPaceForecast, now: Date, compact: Bool = false) -> String {
-    if forecast.verdict == .atRisk,
-       let runOutAt = forecast.runOutAt,
+    if let runOutAt = forecast.runOutAt,
        let countdown = ResetCountdownFormatter.string(from: runOutAt, now: now) {
-        return "out \(countdown)"
+        return forecast.verdict == .watch ? "may run out \(countdown)" : "out \(countdown)"
     }
     let left = Int(forecast.projectedRemainingPercent.rounded())
     switch forecast.verdict {

--- a/Sources/VibeBarApp/Views/PaceMarkerCapsule.swift
+++ b/Sources/VibeBarApp/Views/PaceMarkerCapsule.swift
@@ -61,14 +61,17 @@ struct PaceMarkerCapsule: View {
     }
 }
 
-/// Current quota with a forecast interval integrated into the same capsule.
+/// Current quota with wall-clock pace and reset forecast integrated into the
+/// same capsule.
 ///
-/// The actual fill remains the dominant layer. The forecast uses one coherent
-/// visual vocabulary: a soft, full-height interval band plus one color-matched
-/// endpoint. The matching labeled row directly below supplies the meaning.
+/// The actual fill remains the dominant layer. A short gray tick marks where
+/// usage should be *now* under a time-only pace. A taller status-colored tick
+/// marks the projected usage *at reset*. The matching color gradient hugs the
+/// bottom edge and expresses the forecast interval without obscuring the fill.
 struct ForecastQuotaBar: View {
     let percent: Double
     let mode: DisplayMode
+    let timePacePercent: Double?
     let forecastLowerPercent: Double
     let forecastUpperPercent: Double
     let forecastMedianPercent: Double
@@ -82,10 +85,12 @@ struct ForecastQuotaBar: View {
             let lower = clamp(min(forecastLowerPercent, forecastUpperPercent), 0, 100) / 100
             let upper = clamp(max(forecastLowerPercent, forecastUpperPercent), 0, 100) / 100
             let median = clamp(forecastMedianPercent, 0, 100) / 100
-            let inset = max(1.5, height * 0.14)
-            let endpointSize = min(7, max(5, height * 0.52))
+            let timePace = timePacePercent.map { clamp($0, 0, 100) / 100 }
+            let intervalHeight = max(2.5, height * 0.28)
+            let forecastLineWidth = max(2, min(3, height * 0.22))
+            let paceLineWidth = max(1, min(1.5, height * 0.11))
 
-            ZStack(alignment: .leading) {
+            ZStack(alignment: .bottomLeading) {
                 Capsule(style: .continuous)
                     .fill(Theme.barTrack)
                 Capsule(style: .continuous)
@@ -93,46 +98,38 @@ struct ForecastQuotaBar: View {
                     .frame(width: max(height, width * fillFraction))
 
                 if upper > lower {
-                    RoundedRectangle(
-                        cornerRadius: max(2, (height - inset * 2) / 2),
-                        style: .continuous
-                    )
+                    RoundedRectangle(cornerRadius: intervalHeight / 2, style: .continuous)
                     .fill(
                         LinearGradient(
                             colors: [
-                                forecastColor.opacity(0.10),
-                                forecastColor.opacity(0.28),
-                                forecastColor.opacity(0.10),
+                                forecastColor.opacity(0.08),
+                                forecastColor.opacity(0.48),
+                                forecastColor.opacity(0.20),
                             ],
                             startPoint: .leading,
                             endPoint: .trailing
                         )
                     )
-                    .overlay {
-                        RoundedRectangle(
-                            cornerRadius: max(2, (height - inset * 2) / 2),
-                            style: .continuous
-                        )
-                        .stroke(forecastColor.opacity(0.24), lineWidth: 0.75)
-                    }
                     .frame(
-                        width: max(endpointSize, width * (upper - lower)),
-                        height: max(3, height - inset * 2)
+                        width: max(forecastLineWidth * 2, width * (upper - lower)),
+                        height: intervalHeight
                     )
                     .offset(x: width * lower)
                 }
 
-                Circle()
+                if let timePace, timePacePercent.map({ $0 > 2 && $0 < 98 }) == true {
+                    RoundedRectangle(cornerRadius: paceLineWidth / 2, style: .continuous)
+                        .fill(Color.secondary.opacity(0.78))
+                        .frame(width: paceLineWidth, height: max(4, height * 0.62))
+                        .offset(x: markerOffset(width: width, fraction: timePace, markerWidth: paceLineWidth))
+                        .padding(.bottom, max(1, height * 0.18))
+                }
+
+                RoundedRectangle(cornerRadius: forecastLineWidth / 2, style: .continuous)
                     .fill(forecastColor)
-                    .overlay {
-                        Circle()
-                            .stroke(Color.white.opacity(0.72), lineWidth: 1)
-                    }
-                    .shadow(color: Color.black.opacity(0.18), radius: 1.5, y: 0.5)
-                    .frame(width: endpointSize, height: endpointSize)
-                    .offset(
-                        x: max(1, min(width - endpointSize - 1, width * median - endpointSize / 2))
-                    )
+                    .frame(width: forecastLineWidth, height: max(5, height * 0.90))
+                    .offset(x: markerOffset(width: width, fraction: median, markerWidth: forecastLineWidth))
+                    .padding(.bottom, max(0.5, height * 0.05))
             }
             .clipShape(Capsule(style: .continuous))
         }
@@ -141,5 +138,9 @@ struct ForecastQuotaBar: View {
 
     private func clamp(_ value: Double, _ lower: Double, _ upper: Double) -> Double {
         min(max(value, lower), upper)
+    }
+
+    private func markerOffset(width: CGFloat, fraction: Double, markerWidth: CGFloat) -> CGFloat {
+        max(0, min(width - markerWidth, width * fraction - markerWidth / 2))
     }
 }

--- a/Sources/VibeBarApp/Views/PopoverRoot.swift
+++ b/Sources/VibeBarApp/Views/PopoverRoot.swift
@@ -658,11 +658,10 @@ private struct GeminiCombinedCard: View {
 
 /// The dedicated Gemini sub-page (still routed through `OverviewPage.googleAI`
 /// for backwards-compat with the menu-bar settings, but labelled "Gemini" at
-/// every user-facing surface). Two-column layout matching the OpenAI / Claude
-/// sub-pages: quota + pace + status on the left, a "Cost · Coming soon"
-/// placeholder on the right so the page width stays consistent with the
-/// other Overview sub-pages while the IDE/CLI cost story is still being
-/// validated.
+/// every user-facing surface). Provider detail pages share one asymmetric
+/// layout: the wider primary column carries the live quota, cost, status and
+/// analytics flow; the narrower secondary column is dedicated to the deeper
+/// subscription forecast and reset-cycle history.
 private struct GeminiTabPage: View {
     let density: Theme.Density
 
@@ -680,86 +679,89 @@ private struct GeminiTabPage: View {
                 FillTimelineSeries(tool: .antigravity, accountId: account.id, bucket: $0)
             }
         } ?? []
+        let costParts = ToolType.googleAIPair.compactMap { environment.costService.snapshot(for: $0) }
+        let costSnapshot = CostSnapshotAggregator.combinedSnapshot(tool: .antigravity, snapshots: costParts)
+        let hasCostData = costSnapshot.jsonlFilesFound > 0
 
         HStack(alignment: .top, spacing: density.interSectionSpacing) {
-            VStack(alignment: .leading, spacing: density.interSectionSpacing) {
+            LazyVStack(alignment: .leading, spacing: density.interSectionSpacing) {
                 GeminiCombinedCard(density: density)
-                TimelineView(.periodic(from: .now, by: 30)) { context in
-                    SubscriptionUtilizationView(
-                        tool: .gemini,
-                        buckets: geminiAccounts.first.flatMap {
-                            quotaService.cachedQuota(for: $0.id)?.buckets
-                        } ?? [],
-                        mode: settingsStore.displayMode,
+                if hasCostData {
+                    CostHeaderCard(
+                        tool: .antigravity,
+                        snapshot: costSnapshot,
                         density: density,
-                        now: context.date,
-                        additionalQuotaSeries: antigravityQuotaSeries
+                        titleOverride: "Gemini Cost",
+                        toolNameOverride: "Gemini"
                     )
+                    CostHistoryView(
+                        tool: .antigravity,
+                        snapshot: costSnapshot,
+                        density: density,
+                        chartHeight: density.detailCostChartHeight
+                    )
+                } else {
+                    GeminiCostEmptyCard(density: density)
                 }
                 ServiceStatusCard(tools: [.gemini], density: density)
+                if hasCostData {
+                    ModelRankingList(snapshot: costSnapshot, density: density)
+                    YearlyContributionHeatmapView(
+                        history: costSnapshot.dailyHistory,
+                        density: density,
+                        toolName: "Gemini"
+                    )
+                    UsageActivityView(
+                        heatmap: costSnapshot.heatmap,
+                        density: density,
+                        titleOverride: "When you use Gemini"
+                    )
+                }
+            }
+            .frame(minWidth: primaryColumnMinWidth, maxWidth: .infinity, alignment: .topLeading)
+
+            TimelineView(.periodic(from: .now, by: 30)) { context in
+                SubscriptionUtilizationView(
+                    tool: .gemini,
+                    buckets: geminiAccounts.first.flatMap {
+                        quotaService.cachedQuota(for: $0.id)?.buckets
+                    } ?? [],
+                    mode: settingsStore.displayMode,
+                    density: density,
+                    now: context.date,
+                    additionalQuotaSeries: antigravityQuotaSeries
+                )
             }
             .frame(
-                minWidth: geminiLeftColumnMinWidth,
-                idealWidth: geminiLeftColumnIdealWidth,
-                maxWidth: geminiLeftColumnMaxWidth,
+                minWidth: utilizationColumnMinWidth,
+                idealWidth: utilizationColumnIdealWidth,
+                maxWidth: utilizationColumnMaxWidth,
                 alignment: .topLeading
             )
-
-            GeminiCostColumn(density: density)
-                .frame(minWidth: geminiRightColumnMinWidth, maxWidth: .infinity, alignment: .topLeading)
         }
     }
 
-    private var geminiLeftColumnMinWidth: CGFloat {
+    private var utilizationColumnMinWidth: CGFloat {
         density.detailLeftColumnRange.lowerBound
     }
 
-    private var geminiLeftColumnIdealWidth: CGFloat {
+    private var utilizationColumnIdealWidth: CGFloat {
         min(
             density.detailLeftColumnRange.upperBound,
-            max(geminiLeftColumnMinWidth, density.popoverWidth * density.detailLeftColumnFraction)
+            max(utilizationColumnMinWidth, density.popoverWidth * density.detailLeftColumnFraction)
         )
     }
 
-    private var geminiLeftColumnMaxWidth: CGFloat {
+    private var utilizationColumnMaxWidth: CGFloat {
         density.detailLeftColumnRange.upperBound
     }
 
-    private var geminiRightColumnMinWidth: CGFloat {
+    private var primaryColumnMinWidth: CGFloat {
         density.detailRightColumnMinimum
     }
 }
 
-/// Right-column cost panel on the Gemini sub-page: the combined
-/// Gemini + AntiGravity cost, presented as one "Gemini" surface so the
-/// page matches the OpenAI / Claude sub-page cost columns. AntiGravity
-/// is the live Google/Gemini usage source today; the data comes from
-/// `CostUsageScanner.scanAntigravity` (offline `.db` + language-server
-/// RPC for the encrypted `.pb` cascades).
-private struct GeminiCostColumn: View {
-    let density: Theme.Density
-
-    @EnvironmentObject var environment: AppEnvironment
-
-    var body: some View {
-        let parts = ToolType.googleAIPair.compactMap { environment.costService.snapshot(for: $0) }
-        let snapshot = CostSnapshotAggregator.combinedSnapshot(tool: .antigravity, snapshots: parts)
-        if snapshot.jsonlFilesFound > 0 {
-            ProviderCostStack(
-                tool: .antigravity,
-                snapshot: snapshot,
-                density: density,
-                titleOverride: "Gemini Cost",
-                toolNameOverride: "Gemini",
-                heatmapTitleOverride: "When you use Gemini"
-            )
-        } else {
-            GeminiCostEmptyCard(density: density)
-        }
-    }
-}
-
-/// Empty state for the Gemini sub-page cost column. AntiGravity's
+/// Empty state for the Gemini sub-page cost section. AntiGravity's
 /// `.pb`-only cascades are fetched from the running language server, so
 /// the first sync needs AntiGravity open; the result is then cached and
 /// survives Antigravity quitting.
@@ -801,40 +803,6 @@ private struct GeminiCostEmptyCard: View {
             RoundedRectangle(cornerRadius: density.cardCornerRadius, style: .continuous)
                 .stroke(.separator.opacity(0.4), lineWidth: 0.5)
         )
-    }
-}
-
-private struct ProviderCostStack: View {
-    let tool: ToolType
-    let snapshot: CostSnapshot
-    let density: Theme.Density
-    var titleOverride: String? = nil
-    var toolNameOverride: String? = nil
-    var heatmapTitleOverride: String? = nil
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: density.interSectionSpacing) {
-            CostHeaderCard(
-                tool: tool,
-                snapshot: snapshot,
-                density: density,
-                titleOverride: titleOverride,
-                toolNameOverride: toolNameOverride
-            )
-            CostHistoryView(
-                tool: tool,
-                snapshot: snapshot,
-                density: density,
-                chartHeight: density.detailCostChartHeight
-            )
-            ModelRankingList(snapshot: snapshot, density: density)
-            YearlyContributionHeatmapView(
-                history: snapshot.dailyHistory,
-                density: density,
-                toolName: toolNameOverride ?? tool.menuTitle
-            )
-            UsageActivityView(heatmap: snapshot.heatmap, density: density, titleOverride: heatmapTitleOverride)
-        }
     }
 }
 
@@ -1437,22 +1405,21 @@ private struct CostDetailPopoverContent: View {
 
 // MARK: - Single-provider detail (two-column waterfall)
 
-/// Single-provider popover content. Two-column layout — narrow left for the
-/// live subscription panels, wider right for cost charts and heatmaps. The
+/// Single-provider popover content. Two-column layout — wider left for the
+/// primary quota, cost, status and analytics flow; narrow right for the deeper
+/// subscription forecast and its per-quota reset history. The
 /// two columns size independently and do NOT have to match in height.
 ///
-/// Left column (fixed order, narrow):
+/// Left column (fixed order, wide):
 ///   1. Quota / Usage bar
-///   2. Subscription Utilization
-///   3. Service Status
+///   2. Cost summary
+///   3. Cost history
+///   4. Service Status
+///   5. Model Ranking
+///   6. Past Year
+///   7. When You Use
 ///
-/// Right column (wide): Cost summary card (TODAY / 7D / 30D / ALL + Top
-/// Model) → Cost History → Model Ranking → yearly contribution heatmap →
-/// weekday-hour heatmap → hourly burn rate.
-///
-/// AQ tried the cost summary on the left and decided it looked off there;
-/// the entire cost section now lives on the right with the rest of the
-/// charts, where the wider column suits its grid of metrics.
+/// Right column (narrow): Subscription Utilization only.
 private struct ProviderDetailView: View {
     let tool: ToolType
     let density: Theme.Density
@@ -1465,27 +1432,8 @@ private struct ProviderDetailView: View {
         let snapshot = environment.costService.snapshot(for: tool)
         let hasCostData = (snapshot?.jsonlFilesFound ?? 0) > 0
         HStack(alignment: .top, spacing: density.interSectionSpacing) {
-            VStack(alignment: .leading, spacing: density.interSectionSpacing) {
+            LazyVStack(alignment: .leading, spacing: density.interSectionSpacing) {
                 ProviderQuotaCard(tool: tool, density: density, compact: false)
-                TimelineView(.periodic(from: .now, by: 30)) { context in
-                    SubscriptionUtilizationView(
-                        tool: tool,
-                        buckets: environment.quota(for: tool)?.buckets ?? [],
-                        mode: settingsStore.displayMode,
-                        density: density,
-                        now: context.date
-                    )
-                }
-                ServiceStatusCard(tools: [tool], density: density)
-            }
-            .frame(
-                minWidth: leftColumnMinWidth,
-                idealWidth: leftColumnIdealWidth,
-                maxWidth: leftColumnMaxWidth,
-                alignment: .topLeading
-            )
-
-            VStack(alignment: .leading, spacing: density.interSectionSpacing) {
                 if let snapshot, hasCostData {
                     CostHeaderCard(tool: tool, snapshot: snapshot, density: density)
                     CostHistoryView(
@@ -1494,9 +1442,6 @@ private struct ProviderDetailView: View {
                         density: density,
                         chartHeight: density.detailCostChartHeight
                     )
-                    ModelRankingList(snapshot: snapshot, density: density)
-                    YearlyContributionHeatmapView(history: snapshot.dailyHistory, density: density, toolName: tool.menuTitle)
-                    UsageActivityView(heatmap: snapshot.heatmap, density: density)
                 } else {
                     Text("No \(tool.menuTitle) CLI sessions found yet.")
                         .font(.system(size: density.subtitleFontSize))
@@ -1504,34 +1449,60 @@ private struct ProviderDetailView: View {
                         .padding(.vertical, 24)
                         .frame(maxWidth: .infinity)
                 }
+                ServiceStatusCard(tools: [tool], density: density)
+                if let snapshot, hasCostData {
+                    ModelRankingList(snapshot: snapshot, density: density)
+                    YearlyContributionHeatmapView(
+                        history: snapshot.dailyHistory,
+                        density: density,
+                        toolName: tool.menuTitle
+                    )
+                    UsageActivityView(heatmap: snapshot.heatmap, density: density)
+                }
             }
-            .frame(minWidth: rightColumnMinWidth, maxWidth: .infinity, alignment: .topLeading)
+            .frame(minWidth: primaryColumnMinWidth, maxWidth: .infinity, alignment: .topLeading)
+
+            TimelineView(.periodic(from: .now, by: 30)) { context in
+                SubscriptionUtilizationView(
+                    tool: tool,
+                    buckets: environment.quota(for: tool)?.buckets ?? [],
+                    mode: settingsStore.displayMode,
+                    density: density,
+                    now: context.date
+                )
+            }
+            .frame(
+                minWidth: utilizationColumnMinWidth,
+                idealWidth: utilizationColumnIdealWidth,
+                maxWidth: utilizationColumnMaxWidth,
+                alignment: .topLeading
+            )
         }
     }
 
-    private var leftColumnMinWidth: CGFloat {
+    private var utilizationColumnMinWidth: CGFloat {
         density.detailLeftColumnRange.lowerBound
     }
 
-    private var leftColumnIdealWidth: CGFloat {
+    private var utilizationColumnIdealWidth: CGFloat {
         min(
             density.detailLeftColumnRange.upperBound,
-            max(leftColumnMinWidth, density.popoverWidth * density.detailLeftColumnFraction)
+            max(utilizationColumnMinWidth, density.popoverWidth * density.detailLeftColumnFraction)
         )
     }
 
-    private var leftColumnMaxWidth: CGFloat {
+    private var utilizationColumnMaxWidth: CGFloat {
         density.detailLeftColumnRange.upperBound
     }
 
-    private var rightColumnMinWidth: CGFloat {
+    private var primaryColumnMinWidth: CGFloat {
         density.detailRightColumnMinimum
     }
 }
 
-/// Composite Cost header for the right column: 4-cell summary row + Top Model.
-/// Bundled so the right column has clear "this is the cost section" framing
-/// before the chart starts.
+/// Composite Cost header for the provider's primary column: 4-cell summary
+/// row + Top Model. Bundled so the cost section has clear framing before the
+/// chart starts.
 private struct CostHeaderCard: View {
     let tool: ToolType
     let snapshot: CostSnapshot
@@ -1887,9 +1858,7 @@ private struct ProviderBucketRow: View {
         let forecast = paceForecast(now: now)
         let forecastRange = forecast.map { displayedRange($0) }
         let forecastMedian = forecast.map { displayedForecast($0) }
-        let legacyExpectedDisplayed = forecast == nil
-            ? pace.map { expectedDisplay(for: $0, mode: mode) }
-            : nil
+        let timePaceDisplayed = pace.map { expectedDisplay(for: $0, mode: mode) }
         VStack(alignment: .leading, spacing: density.bucketRowSpacing) {
             HStack(alignment: .firstTextBaseline) {
                 Text(bucket.title)
@@ -1909,16 +1878,17 @@ private struct ProviderBucketRow: View {
                 ForecastQuotaBar(
                     percent: percent,
                     mode: mode,
+                    timePacePercent: timePaceDisplayed,
                     forecastLowerPercent: forecastRange.lowerBound,
                     forecastUpperPercent: forecastRange.upperBound,
                     forecastMedianPercent: forecastMedian,
                     forecastColor: QuotaForecastPalette.color(for: forecast.verdict),
                     height: density.bucketBarHeight
                 )
-            } else if let legacyExpectedDisplayed {
+            } else if let timePaceDisplayed {
                 PaceMarkerCapsule(
                     usedPercent: percent,
-                    expectedPercent: legacyExpectedDisplayed,
+                    expectedPercent: timePaceDisplayed,
                     mode: mode,
                     height: density.bucketBarHeight
                 )

--- a/Sources/VibeBarApp/Views/QuotaForecastRow.swift
+++ b/Sources/VibeBarApp/Views/QuotaForecastRow.swift
@@ -11,31 +11,47 @@ struct QuotaForecastRow: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: showGuidance ? 3 : 0) {
-            HStack(spacing: 6) {
-                Circle()
-                    .fill(QuotaForecastPalette.color(for: forecast.verdict))
-                    .frame(width: 5, height: 5)
-                Text(primaryText)
-                    .font(.system(size: fontSize, weight: .medium))
-                    .foregroundStyle(QuotaForecastPalette.color(for: forecast.verdict))
-                    .lineLimit(1)
-                    .truncationMode(.tail)
-                Spacer(minLength: 4)
-                if showGuidance {
-                    Text(forecast.confidenceLabel)
-                        .font(.system(size: max(8, fontSize - 1)))
-                        .foregroundStyle(.tertiary)
-                        .lineLimit(1)
+            if showGuidance {
+                ViewThatFits(in: .horizontal) {
+                    HStack(alignment: .firstTextBaseline, spacing: 8) {
+                        statusLabel
+                        Spacer(minLength: 4)
+                        confidenceLabel
+                    }
+                    VStack(alignment: .leading, spacing: 2) {
+                        statusLabel
+                        confidenceLabel
+                    }
                 }
+            } else {
+                statusLabel
             }
             if showGuidance {
                 Text(forecast.guidanceSummary)
                     .font(.system(size: max(8, fontSize - 1)))
                     .foregroundStyle(.secondary)
-                    .lineLimit(1)
-                    .truncationMode(.tail)
+                    .fixedSize(horizontal: false, vertical: true)
             }
         }
+    }
+
+    private var statusLabel: some View {
+        HStack(spacing: 6) {
+            Circle()
+                .fill(QuotaForecastPalette.color(for: forecast.verdict))
+                .frame(width: 5, height: 5)
+            Text(primaryText)
+                .font(.system(size: fontSize, weight: .medium))
+                .foregroundStyle(QuotaForecastPalette.color(for: forecast.verdict))
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    private var confidenceLabel: some View {
+        Text(forecast.confidenceLabel)
+            .font(.system(size: max(8, fontSize - 1)))
+            .foregroundStyle(.tertiary)
+            .fixedSize(horizontal: true, vertical: false)
     }
 
     private var primaryText: String {

--- a/Sources/VibeBarApp/Views/QuotaForecastRow.swift
+++ b/Sources/VibeBarApp/Views/QuotaForecastRow.swift
@@ -10,7 +10,7 @@ struct QuotaForecastRow: View {
     var showGuidance = false
 
     var body: some View {
-        VStack(alignment: .leading, spacing: showGuidance ? 3 : 0) {
+        VStack(alignment: .leading, spacing: 3) {
             if showGuidance {
                 ViewThatFits(in: .horizontal) {
                     HStack(alignment: .firstTextBaseline, spacing: 8) {
@@ -26,6 +26,10 @@ struct QuotaForecastRow: View {
             } else {
                 statusLabel
             }
+            Text(useUpText)
+                .font(.system(size: max(8, fontSize - 1), weight: .medium))
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
             if showGuidance {
                 Text(forecast.guidanceSummary)
                     .font(.system(size: max(8, fontSize - 1)))
@@ -55,10 +59,6 @@ struct QuotaForecastRow: View {
     }
 
     private var primaryText: String {
-        if forecast.verdict == .atRisk, let runOutAt = forecast.runOutAt,
-           let countdown = ResetCountdownFormatter.string(from: runOutAt, now: now) {
-            return "At risk · runs out in \(countdown)"
-        }
         let left = Int(forecast.projectedRemainingPercent.rounded())
         switch forecast.verdict {
         case .enough:
@@ -71,6 +71,23 @@ struct QuotaForecastRow: View {
             return "At risk · likely to run out before reset"
         case .learning:
             return "Learning · about \(left)% left at reset"
+        }
+    }
+
+    private var useUpText: String {
+        if let runOutAt = forecast.runOutAt,
+           let countdown = ResetCountdownFormatter.string(from: runOutAt, now: now) {
+            return forecast.verdict == .watch
+                ? "Could run out in \(countdown)"
+                : "Estimated to run out in \(countdown)"
+        }
+        switch forecast.verdict {
+        case .watch:
+            return "Use-up time uncertain · may run short before reset"
+        case .atRisk:
+            return "Expected to run out before reset"
+        case .enough, .surplus, .learning:
+            return "Projected to last until reset"
         }
     }
 

--- a/Sources/VibeBarApp/Views/ServiceStatusCard.swift
+++ b/Sources/VibeBarApp/Views/ServiceStatusCard.swift
@@ -454,20 +454,30 @@ private struct UptimeStrip: View {
     let currentImpact: IncidentImpact?
 
     var body: some View {
-        GeometryReader { proxy in
-            let count = max(days.count, 1)
-            let totalGap = CGFloat(count - 1) * 1
-            let cellWidth = max((proxy.size.width - totalGap) / CGFloat(count), 1)
-            HStack(spacing: 1) {
-                ForEach(Array(days.enumerated()), id: \.element.id) { index, day in
-                    let isToday = index == count - 1
-                    let impact = isToday ? (currentImpact ?? day.worstImpact) : day.worstImpact
-                    RoundedRectangle(cornerRadius: 1.2, style: .continuous)
-                        .fill(uptimeColor(for: impact))
-                        .frame(width: cellWidth)
-                }
+        Canvas { context, size in
+            guard !days.isEmpty else { return }
+            let gap: CGFloat = 1
+            let count = days.count
+            let totalGap = CGFloat(count - 1) * gap
+            let cellWidth = max((size.width - totalGap) / CGFloat(count), 1)
+
+            for (index, day) in days.enumerated() {
+                let isToday = index == count - 1
+                let impact = isToday ? (currentImpact ?? day.worstImpact) : day.worstImpact
+                let rect = CGRect(
+                    x: CGFloat(index) * (cellWidth + gap),
+                    y: 0,
+                    width: cellWidth,
+                    height: size.height
+                )
+                context.fill(
+                    Path(roundedRect: rect, cornerRadius: 1.2),
+                    with: .color(uptimeColor(for: impact))
+                )
             }
         }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("Service uptime over the last \(days.count) days")
     }
 }
 

--- a/Sources/VibeBarApp/Views/SubscriptionUtilizationView.swift
+++ b/Sources/VibeBarApp/Views/SubscriptionUtilizationView.swift
@@ -1,5 +1,4 @@
 import SwiftUI
-import Charts
 import VibeBarCore
 
 /// Subscription Utilization sub-page. Every independently resettable quota
@@ -35,7 +34,7 @@ struct SubscriptionUtilizationView: View {
                     }
                 }
             }
-            if utilizationBuckets.isEmpty && historySeries.isEmpty {
+            if utilizationBuckets.isEmpty {
                 Text("No utilization data — try refreshing.")
                     .font(.system(size: density.subtitleFontSize))
                     .foregroundStyle(.tertiary)
@@ -43,14 +42,6 @@ struct SubscriptionUtilizationView: View {
             } else {
                 ForEach(utilizationBuckets) { item in
                     row(for: item)
-                }
-                if !historySeries.isEmpty {
-                    FillTimelineChart(
-                        series: historySeries,
-                        mode: mode,
-                        density: density,
-                        now: now
-                    )
                 }
             }
         }
@@ -93,18 +84,6 @@ struct SubscriptionUtilizationView: View {
         return primary + additional
     }
 
-    /// Every bucket participates in reset-cycle history, including per-model
-    /// dimensions and additional accounts combined into the same product page.
-    private var historySeries: [FillTimelineSeries] {
-        let primary: [FillTimelineSeries]
-        if let accountId = environment.account(for: tool)?.id {
-            primary = buckets.map { FillTimelineSeries(tool: tool, accountId: accountId, bucket: $0) }
-        } else {
-            primary = []
-        }
-        return primary + additionalQuotaSeries
-    }
-
     private var isRefreshing: Bool {
         refreshTools.contains { refreshTool in
             guard let id = environment.account(for: refreshTool)?.id else { return false }
@@ -125,55 +104,25 @@ struct SubscriptionUtilizationView: View {
         let forecast = paceForecast(for: item)
         let used = bucket.usedPercent
         let timeExpected = pace?.expectedUsedPercent
-        let personalExpected = forecast?.plannedUsedPercent
+        let forecastExpected = forecast?.projectedUsedPercent
         VStack(alignment: .leading, spacing: density.bucketRowSpacing) {
             HStack(alignment: .firstTextBaseline) {
                 Text(rowTitle(for: item))
                     .font(.system(size: density.bucketTitleFontSize, weight: .semibold))
-                    .lineLimit(1)
-                    .truncationMode(.tail)
+                    .lineLimit(2)
+                    .fixedSize(horizontal: false, vertical: true)
                 Spacer(minLength: 6)
                 Text(percentLabel(used: used))
                     .font(.system(size: density.bucketPercentFontSize, weight: .semibold, design: .rounded).monospacedDigit())
                     .lineLimit(1)
                     .fixedSize(horizontal: true, vertical: false)
             }
-            Chart {
-                BarMark(
-                    xStart: .value("Start", 0),
-                    xEnd: .value("Used", min(100, used)),
-                    y: .value("Bucket", bucket.title)
-                )
-                .foregroundStyle(Theme.barColor(percent: used, mode: .used))
-                .cornerRadius(3)
-                if let timeExpected, timeExpected > 0 {
-                    RuleMark(x: .value("Time-only pace", timeExpected))
-                        .foregroundStyle(.secondary.opacity(0.7))
-                        .lineStyle(StrokeStyle(lineWidth: 1.25, dash: [3, 3]))
-                }
-                if let personalExpected, personalExpected > 0 {
-                    RuleMark(x: .value("Personal plan", personalExpected))
-                        .foregroundStyle(Color.accentColor.opacity(0.9))
-                        .lineStyle(StrokeStyle(lineWidth: 2))
-                }
-            }
-            .chartXScale(domain: 0...100)
-            .chartXAxis {
-                AxisMarks(values: [0, 25, 50, 75, 100]) { value in
-                    AxisGridLine().foregroundStyle(.secondary.opacity(0.1))
-                    AxisValueLabel {
-                        if let raw = value.as(Int.self) {
-                            Text("\(raw)%")
-                                .font(.system(size: 9, design: .rounded).monospacedDigit())
-                        }
-                    }
-                }
-            }
-            .chartYAxis(.hidden)
-            .frame(height: density.utilizationBarHeight)
+            quotaReferenceBar(used: used, pace: pace, forecast: forecast)
+            percentageAxis
             referenceLegend(
                 timeExpected: timeExpected,
-                personalExpected: personalExpected
+                forecastExpected: forecastExpected,
+                forecastColor: forecast.map { QuotaForecastPalette.color(for: $0.verdict) }
             )
             Text(SubscriptionWindowProgress.summary(
                 usedPercent: bucket.usedPercent,
@@ -183,8 +132,7 @@ struct SubscriptionUtilizationView: View {
             ))
                 .font(.system(size: density.subtitleFontSize, weight: .semibold))
                 .foregroundStyle(.primary)
-                .lineLimit(1)
-                .truncationMode(.tail)
+                .fixedSize(horizontal: false, vertical: true)
             if let forecast {
                 QuotaForecastRow(
                     forecast: forecast,
@@ -192,7 +140,6 @@ struct SubscriptionUtilizationView: View {
                     fontSize: density.subtitleFontSize,
                     showGuidance: true
                 )
-                forecastExplanation(forecast: forecast, pace: pace)
             } else if let pace {
                 HStack(spacing: 6) {
                     Text(pace.stageSummary)
@@ -202,6 +149,61 @@ struct SubscriptionUtilizationView: View {
                     Text(etaText(pace: pace))
                         .font(.system(size: density.subtitleFontSize))
                         .foregroundStyle(.secondary)
+                }
+            }
+            if let series = historySeries(for: item) {
+                FillTimelineChart(
+                    series: series,
+                    mode: mode,
+                    density: density,
+                    targetPercent: forecast.map(displayedTarget)
+                )
+            }
+            if let forecast {
+                forecastExplanation(forecast: forecast, pace: pace)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func quotaReferenceBar(
+        used: Double,
+        pace: UsagePace?,
+        forecast: QuotaPaceForecast?
+    ) -> some View {
+        let barHeight = max(10, density.bucketBarHeight)
+        if let forecast {
+            ForecastQuotaBar(
+                percent: used,
+                mode: .used,
+                timePacePercent: pace?.expectedUsedPercent,
+                forecastLowerPercent: forecast.projectedUsedLowerPercent,
+                forecastUpperPercent: forecast.projectedUsedUpperPercent,
+                forecastMedianPercent: forecast.projectedUsedPercent,
+                forecastColor: QuotaForecastPalette.color(for: forecast.verdict),
+                height: barHeight
+            )
+        } else if let pace {
+            PaceMarkerCapsule(
+                usedPercent: used,
+                expectedPercent: pace.expectedUsedPercent,
+                mode: .used,
+                height: barHeight
+            )
+        } else {
+            QuotaBarShape(percent: used, mode: .used, height: barHeight)
+        }
+    }
+
+    private var percentageAxis: some View {
+        HStack(spacing: 0) {
+            ForEach([0, 25, 50, 75, 100], id: \.self) { value in
+                Text("\(value)%")
+                    .font(.system(size: max(8, density.subtitleFontSize - 3), design: .rounded).monospacedDigit())
+                    .foregroundStyle(.tertiary)
+                    .fixedSize(horizontal: true, vertical: false)
+                if value < 100 {
+                    Spacer(minLength: 0)
                 }
             }
         }
@@ -220,38 +222,88 @@ struct SubscriptionUtilizationView: View {
     }
 
     @ViewBuilder
-    private func referenceLegend(timeExpected: Double?, personalExpected: Double?) -> some View {
-        HStack(spacing: 14) {
-            if let timeExpected {
-                referenceLegendItem(
-                    color: .secondary,
-                    label: "Time-only pace",
-                    value: "\(Int(timeExpected.rounded()))%"
+    private func referenceLegend(
+        timeExpected: Double?,
+        forecastExpected: Double?,
+        forecastColor: Color?
+    ) -> some View {
+        ViewThatFits(in: .horizontal) {
+            HStack(spacing: 14) {
+                referenceItems(
+                    timeExpected: timeExpected,
+                    forecastExpected: forecastExpected,
+                    forecastColor: forecastColor
                 )
+                Spacer(minLength: 4)
+                actualUsedLegend
             }
-            if let personalExpected {
-                referenceLegendItem(
-                    color: .accentColor,
-                    label: "Personal plan",
-                    value: "\(Int(personalExpected.rounded()))%"
-                )
+            VStack(alignment: .leading, spacing: 4) {
+                ViewThatFits(in: .horizontal) {
+                    HStack(spacing: 14) {
+                        referenceItems(
+                            timeExpected: timeExpected,
+                            forecastExpected: forecastExpected,
+                            forecastColor: forecastColor
+                        )
+                    }
+                    VStack(alignment: .leading, spacing: 4) {
+                        referenceItems(
+                            timeExpected: timeExpected,
+                            forecastExpected: forecastExpected,
+                            forecastColor: forecastColor
+                        )
+                    }
+                }
+                actualUsedLegend
             }
-            Spacer(minLength: 4)
-            Text("bar = actual used")
-                .font(.system(size: max(8, density.subtitleFontSize - 1)))
-                .foregroundStyle(.tertiary)
         }
-        .lineLimit(1)
     }
 
-    private func referenceLegendItem(color: Color, label: String, value: String) -> some View {
+    @ViewBuilder
+    private func referenceItems(
+        timeExpected: Double?,
+        forecastExpected: Double?,
+        forecastColor: Color?
+    ) -> some View {
+        if let timeExpected {
+            referenceLegendItem(
+                color: .secondary,
+                lineWidth: 1.25,
+                label: "Time-only pace",
+                value: "\(Int(timeExpected.rounded()))%"
+            )
+        }
+        if let forecastExpected, let forecastColor {
+            referenceLegendItem(
+                color: forecastColor,
+                lineWidth: 2.5,
+                label: "Forecast at reset",
+                value: "\(Int(forecastExpected.rounded()))%"
+            )
+        }
+    }
+
+    private var actualUsedLegend: some View {
+        Text("bar = actual used")
+            .font(.system(size: max(8, density.subtitleFontSize - 1)))
+            .foregroundStyle(.tertiary)
+            .fixedSize(horizontal: true, vertical: false)
+    }
+
+    private func referenceLegendItem(
+        color: Color,
+        lineWidth: CGFloat,
+        label: String,
+        value: String
+    ) -> some View {
         HStack(spacing: 5) {
-            Capsule(style: .continuous)
+            RoundedRectangle(cornerRadius: lineWidth / 2, style: .continuous)
                 .fill(color)
-                .frame(width: 14, height: 2)
+                .frame(width: lineWidth, height: 12)
             Text("\(label) \(value)")
                 .font(.system(size: max(8, density.subtitleFontSize - 1), weight: .medium))
                 .foregroundStyle(color)
+                .fixedSize(horizontal: true, vertical: false)
         }
     }
 
@@ -272,7 +324,7 @@ struct SubscriptionUtilizationView: View {
                 .font(.system(size: density.subtitleFontSize, weight: .semibold))
                 .foregroundStyle(.secondary)
             LazyVGrid(
-                columns: [GridItem(.flexible()), GridItem(.flexible())],
+                columns: [GridItem(.adaptive(minimum: 126), spacing: 7)],
                 alignment: .leading,
                 spacing: 7
             ) {
@@ -281,17 +333,15 @@ struct SubscriptionUtilizationView: View {
                         Text(metric.label.uppercased())
                             .font(.system(size: max(8, density.subtitleFontSize - 2), weight: .semibold))
                             .foregroundStyle(.tertiary)
-                            .lineLimit(1)
+                            .fixedSize(horizontal: false, vertical: true)
                         Text(metric.value)
                             .font(.system(size: density.subtitleFontSize, weight: .semibold, design: .rounded))
                             .foregroundStyle(.primary)
-                            .lineLimit(1)
-                            .minimumScaleFactor(0.82)
+                            .fixedSize(horizontal: false, vertical: true)
                         Text(metric.detail)
                             .font(.system(size: max(8, density.subtitleFontSize - 1)))
                             .foregroundStyle(.secondary)
-                            .lineLimit(1)
-                            .minimumScaleFactor(0.78)
+                            .fixedSize(horizontal: false, vertical: true)
                     }
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .padding(.horizontal, 8)
@@ -430,6 +480,18 @@ struct SubscriptionUtilizationView: View {
         }
         parts.append(item.bucket.title)
         return parts.joined(separator: " · ")
+    }
+
+    private func historySeries(for item: UtilizationBucket) -> FillTimelineSeries? {
+        guard let accountId = item.accountId else { return nil }
+        return FillTimelineSeries(tool: item.tool, accountId: accountId, bucket: item.bucket)
+    }
+
+    private func displayedTarget(_ forecast: QuotaPaceForecast) -> Double {
+        switch mode {
+        case .used: 100 - forecast.targetRemainingPercent
+        case .remaining: forecast.targetRemainingPercent
+        }
     }
 
     private func percentLabel(used: Double) -> String {


### PR DESCRIPTION
## Summary
- swap the existing asymmetric provider-detail columns so quota, cost, status, and analytics form the wide left flow while Subscription Utilization owns the narrow right column
- embed reset history directly under every independent quota and remove the shared history selector
- make time-only pace a solid gray tick, reset forecast a colored tick, and confidence a bottom gradient band with matching legends
- restore the scannable run-out ETA below every core quota using the new forecast model; surviving quotas explicitly say they last until reset
- reduce long-page view count by replacing per-quota Swift Charts and per-day uptime views with lightweight drawing
- document the layout, forecast marker, ETA, reset-history, Misc boundary, and performance rules in AGENTS.md

## Test plan
- [x] swift build
- [x] swift test --quiet (641 tests)
- [x] ./Scripts/build_app.sh release
- [x] codesign -d --entitlements - ".build/Vibe Bar.app" (empty Dict)
- [x] codesign --verify --deep --strict ".build/Vibe Bar.app"
- [ ] manual smoke test (not launched, per user request)