### PR TITLE
Polish quota forecasts and restore provider layout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -648,11 +648,13 @@ Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
   `PaceMarkerCapsule`; do not route Misc through the personal forecast model
   unless AQ explicitly asks to change that product boundary.
 - **Forecast overlays need one coherent visual vocabulary.** The current quota
-  remains the primary summary-bar layer. The elapsed-time-only pace is a thin
-  solid gray vertical tick; the forecast-at-reset median is a taller
-  verdict-colored vertical tick; the confidence interval is a matching bottom
-  gradient band. Legends must use the same vertical-tick shapes as the bar —
-  never show a solid sample for a dashed mark or turn the forecast into a dot.
+  remains the primary summary-bar layer. The elapsed-time-only pace uses the
+  substantial neutral inset tick established by `PaceMarkerCapsule`; the
+  forecast-at-reset median is a verdict-colored vertical tick; the confidence
+  interval is a soft matching gradient through the bar's full height. Legends
+  must use the same marker shapes as the bar — never show a solid sample for a
+  dashed mark, reduce the wall-clock reference to a hairline, or turn the
+  forecast into a dot.
   Keep forecast semantics in the labeled status row below the Overview bar;
   detailed utilization views may carry the explicit reference legend.
 - **Subscription Utilization is the forecast explainability surface.** Keep
@@ -660,7 +662,9 @@ Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
   recent burn, reset-history comparison, weekday/hour activity weighting,
   recent activity trend, forecast interval, safety target, evidence counts,
   coverage, and confidence. The Overview may stay concise; this detail view
-  must show why a verdict was produced.
+  must make the explanation available without dominating the page. Keep
+  "How this forecast was calculated" collapsed by default and expand it per
+  quota only when the user asks.
 - **Core-provider use-up ETA comes from the personal forecast.** Under each
   core quota, preserve the scannable "runs out in" conclusion, but derive it
   from `QuotaPaceForecast.runOutAt`, not the legacy elapsed-time burn rate.
@@ -673,10 +677,12 @@ Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
   model-scoped limits such as Spark, Fable, Gemini Web, and AntiGravity must
   remain visible at the same time.
 - **Provider detail pages share one asymmetric layout.** Preserve the existing
-  column ratio but put the wide primary flow on the left in this order: quota,
-  cost, cost history, service status, model ranking, past year, when-you-use.
-  The narrow right column contains Subscription Utilization only. ChatGPT,
-  Claude, Gemini, and Grok must use the same framework.
+  column ratio with quota, Subscription Utilization, and service status in the
+  narrow left column. Put cost, cost history, model ranking, past year, and
+  when-you-use in the wide right column. ChatGPT, Claude, Gemini, and Grok must
+  use the same framework. Overview and provider pages also share the popover
+  shell's exact horizontal content inset; page-specific layouts must not add a
+  second outer inset or shrink away from the scroll view's available width.
 - **Dense status history is one drawing surface, not hundreds of views.** Use
   `Canvas` (or an equivalent batched renderer) for uptime strips and avoid one
   Swift Charts instance per quota. These detail pages can display many status

--- a/Sources/VibeBarApp/Views/PaceMarkerCapsule.swift
+++ b/Sources/VibeBarApp/Views/PaceMarkerCapsule.swift
@@ -64,10 +64,11 @@ struct PaceMarkerCapsule: View {
 /// Current quota with wall-clock pace and reset forecast integrated into the
 /// same capsule.
 ///
-/// The actual fill remains the dominant layer. A short gray tick marks where
-/// usage should be *now* under a time-only pace. A taller status-colored tick
-/// marks the projected usage *at reset*. The matching color gradient hugs the
-/// bottom edge and expresses the forecast interval without obscuring the fill.
+/// The actual fill remains the dominant layer. A substantial neutral tick
+/// marks where usage should be *now* under a time-only pace. A
+/// status-colored tick marks the projected usage *at reset*. A soft,
+/// full-height gradient expresses the confidence interval as one integrated
+/// layer rather than looking like a second progress bar below the quota.
 struct ForecastQuotaBar: View {
     let percent: Double
     let mode: DisplayMode
@@ -86,11 +87,10 @@ struct ForecastQuotaBar: View {
             let upper = clamp(max(forecastLowerPercent, forecastUpperPercent), 0, 100) / 100
             let median = clamp(forecastMedianPercent, 0, 100) / 100
             let timePace = timePacePercent.map { clamp($0, 0, 100) / 100 }
-            let intervalHeight = max(2.5, height * 0.28)
-            let forecastLineWidth = max(2, min(3, height * 0.22))
-            let paceLineWidth = max(1, min(1.5, height * 0.11))
+            let forecastLineWidth = max(2.5, min(3.5, height * 0.25))
+            let paceMarkerWidth = max(4.5, min(5.5, height * 0.42))
 
-            ZStack(alignment: .bottomLeading) {
+            ZStack(alignment: .leading) {
                 Capsule(style: .continuous)
                     .fill(Theme.barTrack)
                 Capsule(style: .continuous)
@@ -98,13 +98,15 @@ struct ForecastQuotaBar: View {
                     .frame(width: max(height, width * fillFraction))
 
                 if upper > lower {
-                    RoundedRectangle(cornerRadius: intervalHeight / 2, style: .continuous)
-                    .fill(
+                    Rectangle()
+                        .fill(
                         LinearGradient(
                             colors: [
-                                forecastColor.opacity(0.08),
-                                forecastColor.opacity(0.48),
-                                forecastColor.opacity(0.20),
+                                forecastColor.opacity(0.06),
+                                forecastColor.opacity(0.26),
+                                forecastColor.opacity(0.42),
+                                forecastColor.opacity(0.26),
+                                forecastColor.opacity(0.06),
                             ],
                             startPoint: .leading,
                             endPoint: .trailing
@@ -112,24 +114,27 @@ struct ForecastQuotaBar: View {
                     )
                     .frame(
                         width: max(forecastLineWidth * 2, width * (upper - lower)),
-                        height: intervalHeight
+                        height: height
                     )
                     .offset(x: width * lower)
                 }
 
                 if let timePace, timePacePercent.map({ $0 > 2 && $0 < 98 }) == true {
-                    RoundedRectangle(cornerRadius: paceLineWidth / 2, style: .continuous)
-                        .fill(Color.secondary.opacity(0.78))
-                        .frame(width: paceLineWidth, height: max(4, height * 0.62))
-                        .offset(x: markerOffset(width: width, fraction: timePace, markerWidth: paceLineWidth))
-                        .padding(.bottom, max(1, height * 0.18))
+                    neutralPaceMarker(width: paceMarkerWidth)
+                        .frame(width: paceMarkerWidth, height: height)
+                        .offset(x: markerOffset(width: width, fraction: timePace, markerWidth: paceMarkerWidth))
                 }
 
-                RoundedRectangle(cornerRadius: forecastLineWidth / 2, style: .continuous)
-                    .fill(forecastColor)
-                    .frame(width: forecastLineWidth, height: max(5, height * 0.90))
-                    .offset(x: markerOffset(width: width, fraction: median, markerWidth: forecastLineWidth))
-                    .padding(.bottom, max(0.5, height * 0.05))
+                ZStack {
+                    RoundedRectangle(cornerRadius: 2, style: .continuous)
+                        .fill(Color.black.opacity(0.12))
+                        .frame(width: forecastLineWidth + 2, height: height)
+                    RoundedRectangle(cornerRadius: forecastLineWidth / 2, style: .continuous)
+                        .fill(forecastColor)
+                        .frame(width: forecastLineWidth, height: max(4, height - 1))
+                }
+                .frame(width: forecastLineWidth + 2, height: height)
+                .offset(x: markerOffset(width: width, fraction: median, markerWidth: forecastLineWidth + 2))
             }
             .clipShape(Capsule(style: .continuous))
         }
@@ -142,5 +147,16 @@ struct ForecastQuotaBar: View {
 
     private func markerOffset(width: CGFloat, fraction: Double, markerWidth: CGFloat) -> CGFloat {
         max(0, min(width - markerWidth, width * fraction - markerWidth / 2))
+    }
+
+    private func neutralPaceMarker(width: CGFloat) -> some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: 2, style: .continuous)
+                .fill(Color.black.opacity(0.16))
+                .frame(width: width, height: height)
+            RoundedRectangle(cornerRadius: 1.2, style: .continuous)
+                .fill(Color.primary.opacity(0.62))
+                .frame(width: max(2.2, width * 0.46), height: max(4, height - 1))
+        }
     }
 }

--- a/Sources/VibeBarApp/Views/PopoverRoot.swift
+++ b/Sources/VibeBarApp/Views/PopoverRoot.swift
@@ -35,6 +35,7 @@ struct PopoverRoot: View {
             Divider().opacity(0.3)
             ScrollView(.vertical, showsIndicators: false) {
                 content(density: contentDensity)
+                    .frame(maxWidth: .infinity, alignment: .topLeading)
                     .padding(.bottom, 4)
             }
             .frame(maxHeight: maxScrollHeight)
@@ -658,10 +659,9 @@ private struct GeminiCombinedCard: View {
 
 /// The dedicated Gemini sub-page (still routed through `OverviewPage.googleAI`
 /// for backwards-compat with the menu-bar settings, but labelled "Gemini" at
-/// every user-facing surface). Provider detail pages share one asymmetric
-/// layout: the wider primary column carries the live quota, cost, status and
-/// analytics flow; the narrower secondary column is dedicated to the deeper
-/// subscription forecast and reset-cycle history.
+/// every user-facing surface). Provider pages share one asymmetric layout:
+/// live quota, forecast and service status remain together in the narrow left
+/// column; cost and analytics use the wider right column.
 private struct GeminiTabPage: View {
     let density: Theme.Density
 
@@ -679,85 +679,77 @@ private struct GeminiTabPage: View {
                 FillTimelineSeries(tool: .antigravity, accountId: account.id, bucket: $0)
             }
         } ?? []
-        let costParts = ToolType.googleAIPair.compactMap { environment.costService.snapshot(for: $0) }
-        let costSnapshot = CostSnapshotAggregator.combinedSnapshot(tool: .antigravity, snapshots: costParts)
-        let hasCostData = costSnapshot.jsonlFilesFound > 0
 
         HStack(alignment: .top, spacing: density.interSectionSpacing) {
-            LazyVStack(alignment: .leading, spacing: density.interSectionSpacing) {
+            VStack(alignment: .leading, spacing: density.interSectionSpacing) {
                 GeminiCombinedCard(density: density)
-                if hasCostData {
-                    CostHeaderCard(
-                        tool: .antigravity,
-                        snapshot: costSnapshot,
+                TimelineView(.periodic(from: .now, by: 30)) { context in
+                    SubscriptionUtilizationView(
+                        tool: .gemini,
+                        buckets: geminiAccounts.first.flatMap {
+                            quotaService.cachedQuota(for: $0.id)?.buckets
+                        } ?? [],
+                        mode: settingsStore.displayMode,
                         density: density,
-                        titleOverride: "Gemini Cost",
-                        toolNameOverride: "Gemini"
+                        now: context.date,
+                        additionalQuotaSeries: antigravityQuotaSeries
                     )
-                    CostHistoryView(
-                        tool: .antigravity,
-                        snapshot: costSnapshot,
-                        density: density,
-                        chartHeight: density.detailCostChartHeight
-                    )
-                } else {
-                    GeminiCostEmptyCard(density: density)
                 }
                 ServiceStatusCard(tools: [.gemini], density: density)
-                if hasCostData {
-                    ModelRankingList(snapshot: costSnapshot, density: density)
-                    YearlyContributionHeatmapView(
-                        history: costSnapshot.dailyHistory,
-                        density: density,
-                        toolName: "Gemini"
-                    )
-                    UsageActivityView(
-                        heatmap: costSnapshot.heatmap,
-                        density: density,
-                        titleOverride: "When you use Gemini"
-                    )
-                }
-            }
-            .frame(minWidth: primaryColumnMinWidth, maxWidth: .infinity, alignment: .topLeading)
-
-            TimelineView(.periodic(from: .now, by: 30)) { context in
-                SubscriptionUtilizationView(
-                    tool: .gemini,
-                    buckets: geminiAccounts.first.flatMap {
-                        quotaService.cachedQuota(for: $0.id)?.buckets
-                    } ?? [],
-                    mode: settingsStore.displayMode,
-                    density: density,
-                    now: context.date,
-                    additionalQuotaSeries: antigravityQuotaSeries
-                )
             }
             .frame(
-                minWidth: utilizationColumnMinWidth,
-                idealWidth: utilizationColumnIdealWidth,
-                maxWidth: utilizationColumnMaxWidth,
+                minWidth: leftColumnMinWidth,
+                idealWidth: leftColumnIdealWidth,
+                maxWidth: leftColumnMaxWidth,
                 alignment: .topLeading
             )
+
+            GeminiCostColumn(density: density)
+                .frame(minWidth: rightColumnMinWidth, maxWidth: .infinity, alignment: .topLeading)
         }
     }
 
-    private var utilizationColumnMinWidth: CGFloat {
+    private var leftColumnMinWidth: CGFloat {
         density.detailLeftColumnRange.lowerBound
     }
 
-    private var utilizationColumnIdealWidth: CGFloat {
+    private var leftColumnIdealWidth: CGFloat {
         min(
             density.detailLeftColumnRange.upperBound,
-            max(utilizationColumnMinWidth, density.popoverWidth * density.detailLeftColumnFraction)
+            max(leftColumnMinWidth, density.popoverWidth * density.detailLeftColumnFraction)
         )
     }
 
-    private var utilizationColumnMaxWidth: CGFloat {
+    private var leftColumnMaxWidth: CGFloat {
         density.detailLeftColumnRange.upperBound
     }
 
-    private var primaryColumnMinWidth: CGFloat {
+    private var rightColumnMinWidth: CGFloat {
         density.detailRightColumnMinimum
+    }
+}
+
+/// Right-column cost and analytics flow for the combined Gemini surface.
+private struct GeminiCostColumn: View {
+    let density: Theme.Density
+
+    @EnvironmentObject var environment: AppEnvironment
+
+    var body: some View {
+        let parts = ToolType.googleAIPair.compactMap { environment.costService.snapshot(for: $0) }
+        let snapshot = CostSnapshotAggregator.combinedSnapshot(tool: .antigravity, snapshots: parts)
+        if snapshot.jsonlFilesFound > 0 {
+            ProviderCostStack(
+                tool: .antigravity,
+                snapshot: snapshot,
+                density: density,
+                titleOverride: "Gemini Cost",
+                toolNameOverride: "Gemini",
+                heatmapTitleOverride: "When you use Gemini"
+            )
+        } else {
+            GeminiCostEmptyCard(density: density)
+        }
     }
 }
 
@@ -803,6 +795,44 @@ private struct GeminiCostEmptyCard: View {
             RoundedRectangle(cornerRadius: density.cardCornerRadius, style: .continuous)
                 .stroke(.separator.opacity(0.4), lineWidth: 0.5)
         )
+    }
+}
+
+private struct ProviderCostStack: View {
+    let tool: ToolType
+    let snapshot: CostSnapshot
+    let density: Theme.Density
+    var titleOverride: String? = nil
+    var toolNameOverride: String? = nil
+    var heatmapTitleOverride: String? = nil
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: density.interSectionSpacing) {
+            CostHeaderCard(
+                tool: tool,
+                snapshot: snapshot,
+                density: density,
+                titleOverride: titleOverride,
+                toolNameOverride: toolNameOverride
+            )
+            CostHistoryView(
+                tool: tool,
+                snapshot: snapshot,
+                density: density,
+                chartHeight: density.detailCostChartHeight
+            )
+            ModelRankingList(snapshot: snapshot, density: density)
+            YearlyContributionHeatmapView(
+                history: snapshot.dailyHistory,
+                density: density,
+                toolName: toolNameOverride ?? tool.menuTitle
+            )
+            UsageActivityView(
+                heatmap: snapshot.heatmap,
+                density: density,
+                titleOverride: heatmapTitleOverride
+            )
+        }
     }
 }
 
@@ -1405,21 +1435,17 @@ private struct CostDetailPopoverContent: View {
 
 // MARK: - Single-provider detail (two-column waterfall)
 
-/// Single-provider popover content. Two-column layout — wider left for the
-/// primary quota, cost, status and analytics flow; narrow right for the deeper
-/// subscription forecast and its per-quota reset history. The
-/// two columns size independently and do NOT have to match in height.
+/// Single-provider popover content. Two-column layout — narrow left for the
+/// live subscription panels, wider right for cost charts and heatmaps. The two
+/// columns size independently and do NOT have to match in height.
 ///
-/// Left column (fixed order, wide):
+/// Left column (fixed order, narrow):
 ///   1. Quota / Usage bar
-///   2. Cost summary
-///   3. Cost history
-///   4. Service Status
-///   5. Model Ranking
-///   6. Past Year
-///   7. When You Use
+///   2. Subscription Utilization
+///   3. Service Status
 ///
-/// Right column (narrow): Subscription Utilization only.
+/// Right column (wide): Cost summary → Cost History → Model Ranking →
+/// yearly contribution heatmap → weekday-hour heatmap.
 private struct ProviderDetailView: View {
     let tool: ToolType
     let density: Theme.Density
@@ -1432,8 +1458,27 @@ private struct ProviderDetailView: View {
         let snapshot = environment.costService.snapshot(for: tool)
         let hasCostData = (snapshot?.jsonlFilesFound ?? 0) > 0
         HStack(alignment: .top, spacing: density.interSectionSpacing) {
-            LazyVStack(alignment: .leading, spacing: density.interSectionSpacing) {
+            VStack(alignment: .leading, spacing: density.interSectionSpacing) {
                 ProviderQuotaCard(tool: tool, density: density, compact: false)
+                TimelineView(.periodic(from: .now, by: 30)) { context in
+                    SubscriptionUtilizationView(
+                        tool: tool,
+                        buckets: environment.quota(for: tool)?.buckets ?? [],
+                        mode: settingsStore.displayMode,
+                        density: density,
+                        now: context.date
+                    )
+                }
+                ServiceStatusCard(tools: [tool], density: density)
+            }
+            .frame(
+                minWidth: leftColumnMinWidth,
+                idealWidth: leftColumnIdealWidth,
+                maxWidth: leftColumnMaxWidth,
+                alignment: .topLeading
+            )
+
+            VStack(alignment: .leading, spacing: density.interSectionSpacing) {
                 if let snapshot, hasCostData {
                     CostHeaderCard(tool: tool, snapshot: snapshot, density: density)
                     CostHistoryView(
@@ -1442,15 +1487,6 @@ private struct ProviderDetailView: View {
                         density: density,
                         chartHeight: density.detailCostChartHeight
                     )
-                } else {
-                    Text("No \(tool.menuTitle) CLI sessions found yet.")
-                        .font(.system(size: density.subtitleFontSize))
-                        .foregroundStyle(.tertiary)
-                        .padding(.vertical, 24)
-                        .frame(maxWidth: .infinity)
-                }
-                ServiceStatusCard(tools: [tool], density: density)
-                if let snapshot, hasCostData {
                     ModelRankingList(snapshot: snapshot, density: density)
                     YearlyContributionHeatmapView(
                         history: snapshot.dailyHistory,
@@ -1458,51 +1494,40 @@ private struct ProviderDetailView: View {
                         toolName: tool.menuTitle
                     )
                     UsageActivityView(heatmap: snapshot.heatmap, density: density)
+                } else {
+                    Text("No \(tool.menuTitle) CLI sessions found yet.")
+                        .font(.system(size: density.subtitleFontSize))
+                        .foregroundStyle(.tertiary)
+                        .padding(.vertical, 24)
+                        .frame(maxWidth: .infinity)
                 }
             }
-            .frame(minWidth: primaryColumnMinWidth, maxWidth: .infinity, alignment: .topLeading)
-
-            TimelineView(.periodic(from: .now, by: 30)) { context in
-                SubscriptionUtilizationView(
-                    tool: tool,
-                    buckets: environment.quota(for: tool)?.buckets ?? [],
-                    mode: settingsStore.displayMode,
-                    density: density,
-                    now: context.date
-                )
-            }
-            .frame(
-                minWidth: utilizationColumnMinWidth,
-                idealWidth: utilizationColumnIdealWidth,
-                maxWidth: utilizationColumnMaxWidth,
-                alignment: .topLeading
-            )
+            .frame(minWidth: rightColumnMinWidth, maxWidth: .infinity, alignment: .topLeading)
         }
     }
 
-    private var utilizationColumnMinWidth: CGFloat {
+    private var leftColumnMinWidth: CGFloat {
         density.detailLeftColumnRange.lowerBound
     }
 
-    private var utilizationColumnIdealWidth: CGFloat {
+    private var leftColumnIdealWidth: CGFloat {
         min(
             density.detailLeftColumnRange.upperBound,
-            max(utilizationColumnMinWidth, density.popoverWidth * density.detailLeftColumnFraction)
+            max(leftColumnMinWidth, density.popoverWidth * density.detailLeftColumnFraction)
         )
     }
 
-    private var utilizationColumnMaxWidth: CGFloat {
+    private var leftColumnMaxWidth: CGFloat {
         density.detailLeftColumnRange.upperBound
     }
 
-    private var primaryColumnMinWidth: CGFloat {
+    private var rightColumnMinWidth: CGFloat {
         density.detailRightColumnMinimum
     }
 }
 
-/// Composite Cost header for the provider's primary column: 4-cell summary
-/// row + Top Model. Bundled so the cost section has clear framing before the
-/// chart starts.
+/// Composite Cost header for the provider's wide analytics column: 4-cell
+/// summary row + Top Model.
 private struct CostHeaderCard: View {
     let tool: ToolType
     let snapshot: CostSnapshot

--- a/Sources/VibeBarApp/Views/SubscriptionUtilizationView.swift
+++ b/Sources/VibeBarApp/Views/SubscriptionUtilizationView.swift
@@ -18,6 +18,7 @@ struct SubscriptionUtilizationView: View {
 
     @EnvironmentObject var environment: AppEnvironment
     @EnvironmentObject var quotaService: QuotaService
+    @State private var expandedForecastIDs: Set<String> = []
 
     var body: some View {
         VStack(alignment: .leading, spacing: density.cardSpacing) {
@@ -160,7 +161,7 @@ struct SubscriptionUtilizationView: View {
                 )
             }
             if let forecast {
-                forecastExplanation(forecast: forecast, pace: pace)
+                forecastExplanation(itemID: item.id, forecast: forecast, pace: pace)
             }
         }
     }
@@ -268,7 +269,7 @@ struct SubscriptionUtilizationView: View {
         if let timeExpected {
             referenceLegendItem(
                 color: .secondary,
-                lineWidth: 1.25,
+                markerStyle: .timePace,
                 label: "Time-only pace",
                 value: "\(Int(timeExpected.rounded()))%"
             )
@@ -276,7 +277,7 @@ struct SubscriptionUtilizationView: View {
         if let forecastExpected, let forecastColor {
             referenceLegendItem(
                 color: forecastColor,
-                lineWidth: 2.5,
+                markerStyle: .forecast,
                 label: "Forecast at reset",
                 value: "\(Int(forecastExpected.rounded()))%"
             )
@@ -290,20 +291,49 @@ struct SubscriptionUtilizationView: View {
             .fixedSize(horizontal: true, vertical: false)
     }
 
+    private enum ReferenceMarkerStyle {
+        case timePace
+        case forecast
+    }
+
     private func referenceLegendItem(
         color: Color,
-        lineWidth: CGFloat,
+        markerStyle: ReferenceMarkerStyle,
         label: String,
         value: String
     ) -> some View {
         HStack(spacing: 5) {
-            RoundedRectangle(cornerRadius: lineWidth / 2, style: .continuous)
-                .fill(color)
-                .frame(width: lineWidth, height: 12)
+            referenceMarker(style: markerStyle, color: color)
             Text("\(label) \(value)")
                 .font(.system(size: max(8, density.subtitleFontSize - 1), weight: .medium))
                 .foregroundStyle(color)
                 .fixedSize(horizontal: true, vertical: false)
+        }
+    }
+
+    @ViewBuilder
+    private func referenceMarker(style: ReferenceMarkerStyle, color: Color) -> some View {
+        switch style {
+        case .timePace:
+            ZStack {
+                RoundedRectangle(cornerRadius: 2, style: .continuous)
+                    .fill(Color.black.opacity(0.16))
+                    .frame(width: 5, height: 12)
+                RoundedRectangle(cornerRadius: 1.2, style: .continuous)
+                    .fill(color.opacity(0.78))
+                    .frame(width: 2.4, height: 11)
+            }
+            .frame(width: 5, height: 12)
+        case .forecast:
+            ZStack {
+                RoundedRectangle(cornerRadius: 2, style: .continuous)
+                    .fill(Color.black.opacity(0.12))
+                    .frame(width: 5, height: 12)
+                RoundedRectangle(cornerRadius: 1.5, style: .continuous)
+                    .fill(color)
+                    .frame(width: 3, height: 11)
+            }
+            .frame(width: 5, height: 12)
         }
     }
 
@@ -315,47 +345,72 @@ struct SubscriptionUtilizationView: View {
     }
 
     private func forecastExplanation(
+        itemID: String,
         forecast: QuotaPaceForecast,
         pace: UsagePace?
     ) -> some View {
         let metrics = forecastMetrics(forecast: forecast, pace: pace)
+        let isExpanded = expandedForecastIDs.contains(itemID)
         return VStack(alignment: .leading, spacing: 7) {
-            Text("How this forecast was calculated")
-                .font(.system(size: density.subtitleFontSize, weight: .semibold))
-                .foregroundStyle(.secondary)
-            LazyVGrid(
-                columns: [GridItem(.adaptive(minimum: 126), spacing: 7)],
-                alignment: .leading,
-                spacing: 7
-            ) {
-                ForEach(metrics) { metric in
-                    VStack(alignment: .leading, spacing: 2) {
-                        Text(metric.label.uppercased())
-                            .font(.system(size: max(8, density.subtitleFontSize - 2), weight: .semibold))
-                            .foregroundStyle(.tertiary)
-                            .fixedSize(horizontal: false, vertical: true)
-                        Text(metric.value)
-                            .font(.system(size: density.subtitleFontSize, weight: .semibold, design: .rounded))
-                            .foregroundStyle(.primary)
-                            .fixedSize(horizontal: false, vertical: true)
-                        Text(metric.detail)
-                            .font(.system(size: max(8, density.subtitleFontSize - 1)))
-                            .foregroundStyle(.secondary)
-                            .fixedSize(horizontal: false, vertical: true)
+            Button {
+                withAnimation(.easeInOut(duration: 0.16)) {
+                    if isExpanded {
+                        expandedForecastIDs.remove(itemID)
+                    } else {
+                        expandedForecastIDs.insert(itemID)
                     }
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .padding(.horizontal, 8)
-                    .padding(.vertical, 7)
-                    .background(
-                        RoundedRectangle(cornerRadius: 7, style: .continuous)
-                            .fill(Color.primary.opacity(0.035))
-                    )
                 }
+            } label: {
+                HStack(spacing: 6) {
+                    Text("How this forecast was calculated")
+                        .font(.system(size: density.subtitleFontSize, weight: .semibold))
+                    Spacer(minLength: 6)
+                    Image(systemName: "chevron.right")
+                        .font(.system(size: max(8, density.subtitleFontSize - 2), weight: .semibold))
+                        .rotationEffect(.degrees(isExpanded ? 90 : 0))
+                }
+                .foregroundStyle(.secondary)
+                .contentShape(Rectangle())
             }
-            Text("Quota observations drive consumption. Token history only weights when you tend to work; it is never converted into quota usage.")
-                .font(.system(size: max(8, density.subtitleFontSize - 1)))
-                .foregroundStyle(.tertiary)
-                .fixedSize(horizontal: false, vertical: true)
+            .buttonStyle(.plain)
+            .accessibilityLabel(isExpanded ? "Hide forecast calculation" : "Show forecast calculation")
+
+            if isExpanded {
+                LazyVGrid(
+                    columns: [GridItem(.adaptive(minimum: 126), spacing: 7)],
+                    alignment: .leading,
+                    spacing: 7
+                ) {
+                    ForEach(metrics) { metric in
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(metric.label.uppercased())
+                                .font(.system(size: max(8, density.subtitleFontSize - 2), weight: .semibold))
+                                .foregroundStyle(.tertiary)
+                                .fixedSize(horizontal: false, vertical: true)
+                            Text(metric.value)
+                                .font(.system(size: density.subtitleFontSize, weight: .semibold, design: .rounded))
+                                .foregroundStyle(.primary)
+                                .fixedSize(horizontal: false, vertical: true)
+                            Text(metric.detail)
+                                .font(.system(size: max(8, density.subtitleFontSize - 1)))
+                                .foregroundStyle(.secondary)
+                                .fixedSize(horizontal: false, vertical: true)
+                        }
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 7)
+                        .background(
+                            RoundedRectangle(cornerRadius: 7, style: .continuous)
+                                .fill(Color.primary.opacity(0.035))
+                        )
+                    }
+                }
+                Text("Quota observations drive consumption. Token history only weights when you tend to work; it is never converted into quota usage.")
+                    .font(.system(size: max(8, density.subtitleFontSize - 1)))
+                    .foregroundStyle(.tertiary)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .transition(.opacity.combined(with: .move(edge: .top)))
+            }
         }
         .padding(.top, 2)
     }

--- a/Sources/VibeBarCore/Adapters/AlibabaTokenPlanQuotaAdapter.swift
+++ b/Sources/VibeBarCore/Adapters/AlibabaTokenPlanQuotaAdapter.swift
@@ -867,23 +867,27 @@ enum AlibabaTokenPlanPersonalResponseParser {
 
         var buckets: [QuotaBucket] = []
         if let fiveHour = findFirstDouble(["per5HourPercentage"], in: usage) {
+            let resetAt = findFirstDouble(["per5HourResetTime"], in: usage)
+                .flatMap(AlibabaTokenPlanResponseParser.parseDate)
             buckets.append(QuotaBucket(
                 id: "alibabaTokenPlan.personal.fiveHour",
                 title: "5 Hours",
                 shortLabel: "5h",
                 usedPercent: normalizedPercentage(fiveHour),
-                resetAt: nil,
+                resetAt: resetAt,
                 rawWindowSeconds: 5 * 3_600,
                 groupTitle: "Personal"
             ))
         }
         if let weekly = findFirstDouble(["per1WeekPercentage"], in: usage) {
+            let resetAt = findFirstDouble(["per1WeekResetTime"], in: usage)
+                .flatMap(AlibabaTokenPlanResponseParser.parseDate)
             buckets.append(QuotaBucket(
                 id: "alibabaTokenPlan.personal.weekly",
                 title: "Weekly",
                 shortLabel: "Wk",
                 usedPercent: normalizedPercentage(weekly),
-                resetAt: nil,
+                resetAt: resetAt,
                 rawWindowSeconds: 7 * 86_400,
                 groupTitle: "Personal"
             ))

--- a/Tests/VibeBarCoreTests/AlibabaTokenPlanParserTests.swift
+++ b/Tests/VibeBarCoreTests/AlibabaTokenPlanParserTests.swift
@@ -266,7 +266,7 @@ final class AlibabaTokenPlanParserTests: XCTestCase {
         let usage = #"""
         {
           "code": "200",
-          "DataV2": "{\"data\":{\"data\":{\"per5HourPercentage\":0.25,\"per1WeekPercentage\":37.5}}}",
+          "DataV2": "{\"data\":{\"data\":{\"per5HourPercentage\":0.25,\"per5HourResetTime\":1784622360000,\"per1WeekPercentage\":37.5,\"per1WeekResetTime\":1785134940000}}}",
           "httpStatusCode": "200",
           "successResponse": true
         }
@@ -284,9 +284,16 @@ final class AlibabaTokenPlanParserTests: XCTestCase {
         ])
         XCTAssertEqual(snap.buckets[0].usedPercent, 25, accuracy: 0.01)
         XCTAssertEqual(snap.buckets[0].rawWindowSeconds, 5 * 3_600)
+        XCTAssertEqual(
+            snap.buckets[0].resetAt,
+            Date(timeIntervalSince1970: 1_784_622_360)
+        )
         XCTAssertEqual(snap.buckets[1].usedPercent, 37.5, accuracy: 0.01)
         XCTAssertEqual(snap.buckets[1].rawWindowSeconds, 7 * 86_400)
-        XCTAssertNil(snap.buckets[0].resetAt)
+        XCTAssertEqual(
+            snap.buckets[1].resetAt,
+            Date(timeIntervalSince1970: 1_785_134_940)
+        )
     }
 
     func testPersonalUsageWithoutWindowsThrowsParseFailure() {


### PR DESCRIPTION
## Summary
- restore the narrow-left, wide-right provider detail layout and align every tab to the shared popover inset
- render forecast confidence as a full-height gradient, restore substantial time/forecast ticks, and collapse forecast details by default
- read Bailian Personal 5-hour and weekly reset timestamps from the authenticated usage response
- document the resulting layout and forecast presentation invariants

## Test plan
- [x] swift build
- [x] swift test (641 tests)
- [x] ./Scripts/build_app.sh release
- [x] codesign entitlements and strict verification
- [x] authenticated Bailian Personal response probe

Co-Authored-By: Codex <noreply@openai.com>