### PR TITLE
Unify quota details and refresh settings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -638,6 +638,11 @@ Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
   be eagerly instantiated. Scope live timers to the visible surface.
 - **New persistent state** goes through `VibeBarLocalStore` and lives
   under `~/.vibebar/`. Do not write to `~/` directly from new code.
+- **Every user-facing Settings control must round-trip through
+  `AppSettings`.** Add its Codable key, a backward-compatible decode default,
+  and a round-trip test. Migrations must be one-time and evidence-based; never
+  rewrite a currently selectable value (such as a refresh interval) on every
+  launch.
 - **Mini-window geometry stays in `mini_window_geometry.json`.** Do not
   fold it back into `AppSettings` — every settings write fans out to
   every Combine subscriber.
@@ -654,9 +659,15 @@ Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
   interval is a soft matching gradient through the bar's full height. Legends
   must use the same marker shapes as the bar — never show a solid sample for a
   dashed mark, reduce the wall-clock reference to a hairline, or turn the
-  forecast into a dot.
+  forecast into a dot. Used/Remaining projection must be performed through one
+  shared coordinate transform; the visible median marker must stay inside its
+  confidence band, and a band clipped by the 0% or 100% boundary must remain
+  saturated at that boundary instead of fading as though it ended there.
   Keep forecast semantics in the labeled status row below the Overview bar;
   detailed utilization views may carry the explicit reference legend.
+- **Forecast diagnostic tiles use one stable height per density.** Long labels
+  may wrap within that shared height, but no individual tile may grow and leave
+  a ragged two-column grid.
 - **Subscription Utilization is the forecast explainability surface.** Keep
   the legacy wall-clock pace visible alongside the forecast at reset, then expose
   recent burn, reset-history comparison, weekday/hour activity weighting,

--- a/Sources/VibeBarApp/AppDelegate.swift
+++ b/Sources/VibeBarApp/AppDelegate.swift
@@ -16,6 +16,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         let env = AppEnvironment()
         self.environment = env
+        do {
+            try LoginItemController.reconcileDesiredState(env.settingsStore.settings.launchAtLogin)
+        } catch {
+            SafeLog.warn("Reconciling launch at login failed: \(SafeLog.sanitize(error.localizedDescription))")
+        }
         self.statusItem = StatusItemController(environment: env)
 
         CookieRefreshScheduler.shared.start()

--- a/Sources/VibeBarApp/Controllers/SettingsWindowController.swift
+++ b/Sources/VibeBarApp/Controllers/SettingsWindowController.swift
@@ -26,7 +26,7 @@ final class SettingsWindowController: NSObject {
                 .environmentObject(environment.quotaService)
                 .environmentObject(environment.serviceStatus)
         )
-        let initialSize = NSSize(width: 640, height: 720)
+        let initialSize = NSSize(width: 980, height: 760)
         let win = NSWindow(
             contentRect: NSRect(origin: .zero, size: initialSize),
             styleMask: [.titled, .closable, .resizable, .miniaturizable, .fullSizeContentView],
@@ -39,7 +39,7 @@ final class SettingsWindowController: NSObject {
         win.isReleasedWhenClosed = false
         win.contentViewController = hosting
         win.center()
-        win.minSize = NSSize(width: 560, height: 540)
+        win.minSize = NSSize(width: 820, height: 600)
         win.delegate = self
         self.window = win
 

--- a/Sources/VibeBarApp/LoginItemController.swift
+++ b/Sources/VibeBarApp/LoginItemController.swift
@@ -7,16 +7,28 @@ enum LoginItemController {
         SMAppService.mainApp.status
     }
 
-    static var isEnabled: Bool {
-        status == .enabled
+    /// `.requiresApproval` means the login item was successfully requested
+    /// and is waiting on the user in System Settings. Treat it as on in the
+    /// UI so opening Settings does not erase the saved request.
+    static var isRequestedOrEnabled: Bool {
+        status == .enabled || status == .requiresApproval
     }
 
     static func setEnabled(_ enabled: Bool) throws {
         if enabled {
+            guard status != .enabled, status != .requiresApproval else { return }
             try SMAppService.mainApp.register()
         } else {
+            guard status == .enabled || status == .requiresApproval else { return }
             try SMAppService.mainApp.unregister()
         }
+    }
+
+    /// Reconcile the persisted user choice with macOS on every launch. This
+    /// repairs registrations lost when a locally built app bundle is replaced
+    /// while keeping `.requiresApproval` intact for the user to approve.
+    static func reconcileDesiredState(_ enabled: Bool) throws {
+        try setEnabled(enabled)
     }
 
     static var statusText: String {

--- a/Sources/VibeBarApp/StatusItemController.swift
+++ b/Sources/VibeBarApp/StatusItemController.swift
@@ -165,6 +165,11 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
         for (otherKind, other) in popovers where otherKind != kind && other.isShown {
             other.performClose(nil)
         }
+        let settings = environment.settingsStore.settings
+        environment.scheduler.triggerRefreshForPopoverOpenIfNeeded(
+            enabled: settings.refreshOnPopoverOpen,
+            cooldownSeconds: settings.popoverOpenRefreshCooldownSeconds
+        )
         popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
         popover.contentViewController?.view.window?.makeKey()
     }

--- a/Sources/VibeBarApp/Views/PaceMarkerCapsule.swift
+++ b/Sources/VibeBarApp/Views/PaceMarkerCapsule.swift
@@ -73,9 +73,7 @@ struct ForecastQuotaBar: View {
     let percent: Double
     let mode: DisplayMode
     let timePacePercent: Double?
-    let forecastLowerPercent: Double
-    let forecastUpperPercent: Double
-    let forecastMedianPercent: Double
+    let forecastProjection: QuotaForecastBarProjection
     let forecastColor: Color
     var height: CGFloat = 12
 
@@ -83,12 +81,19 @@ struct ForecastQuotaBar: View {
         GeometryReader { proxy in
             let width = proxy.size.width
             let fillFraction = clamp(percent, 0, 100) / 100
-            let lower = clamp(min(forecastLowerPercent, forecastUpperPercent), 0, 100) / 100
-            let upper = clamp(max(forecastLowerPercent, forecastUpperPercent), 0, 100) / 100
-            let median = clamp(forecastMedianPercent, 0, 100) / 100
+            let lower = forecastProjection.lowerPercent / 100
+            let upper = forecastProjection.upperPercent / 100
+            let median = forecastProjection.medianPercent / 100
             let timePace = timePacePercent.map { clamp($0, 0, 100) / 100 }
             let forecastLineWidth = max(2.5, min(3.5, height * 0.25))
             let paceMarkerWidth = max(4.5, min(5.5, height * 0.42))
+            let minimumBandWidth = forecastLineWidth + 6
+            let band = confidenceBandLayout(
+                width: width,
+                lower: lower,
+                upper: upper,
+                minimumWidth: minimumBandWidth
+            )
 
             ZStack(alignment: .leading) {
                 Capsule(style: .continuous)
@@ -97,26 +102,13 @@ struct ForecastQuotaBar: View {
                     .fill(Theme.barColor(percent: percent, mode: mode))
                     .frame(width: max(height, width * fillFraction))
 
-                if upper > lower {
+                if forecastProjection.hasUncertainty {
                     Rectangle()
                         .fill(
-                        LinearGradient(
-                            colors: [
-                                forecastColor.opacity(0.06),
-                                forecastColor.opacity(0.26),
-                                forecastColor.opacity(0.42),
-                                forecastColor.opacity(0.26),
-                                forecastColor.opacity(0.06),
-                            ],
-                            startPoint: .leading,
-                            endPoint: .trailing
+                            confidenceGradient(lower: lower, upper: upper, median: median)
                         )
-                    )
-                    .frame(
-                        width: max(forecastLineWidth * 2, width * (upper - lower)),
-                        height: height
-                    )
-                    .offset(x: width * lower)
+                        .frame(width: band.width, height: height)
+                        .offset(x: band.x)
                 }
 
                 if let timePace, timePacePercent.map({ $0 > 2 && $0 < 98 }) == true {
@@ -147,6 +139,49 @@ struct ForecastQuotaBar: View {
 
     private func markerOffset(width: CGFloat, fraction: Double, markerWidth: CGFloat) -> CGFloat {
         max(0, min(width - markerWidth, width * fraction - markerWidth / 2))
+    }
+
+    private func confidenceBandLayout(
+        width: CGFloat,
+        lower: Double,
+        upper: Double,
+        minimumWidth: CGFloat
+    ) -> (x: CGFloat, width: CGFloat) {
+        let naturalStart = width * lower
+        let naturalEnd = width * upper
+        let naturalWidth = max(0, naturalEnd - naturalStart)
+        guard naturalWidth < minimumWidth else {
+            return (naturalStart, naturalWidth)
+        }
+        if lower <= 0 {
+            return (0, min(width, minimumWidth))
+        }
+        if upper >= 1 {
+            let bandWidth = min(width, minimumWidth)
+            return (max(0, width - bandWidth), bandWidth)
+        }
+        let bandWidth = min(width, minimumWidth)
+        let center = (naturalStart + naturalEnd) / 2
+        return (max(0, min(width - bandWidth, center - bandWidth / 2)), bandWidth)
+    }
+
+    private func confidenceGradient(lower: Double, upper: Double, median: Double) -> LinearGradient {
+        let visibleSpan = upper - lower
+        let medianLocation = visibleSpan > 0
+            ? clamp((median - lower) / visibleSpan, 0, 1)
+            : (forecastProjection.clipsLowerBound ? 0 : 1)
+        let leadingOpacity = forecastProjection.clipsLowerBound ? 0.44 : 0.10
+        let trailingOpacity = forecastProjection.clipsUpperBound ? 0.44 : 0.10
+        let peakLocation = min(max(medianLocation, 0.001), 0.999)
+        return LinearGradient(
+            gradient: Gradient(stops: [
+                .init(color: forecastColor.opacity(leadingOpacity), location: 0),
+                .init(color: forecastColor.opacity(0.48), location: peakLocation),
+                .init(color: forecastColor.opacity(trailingOpacity), location: 1),
+            ]),
+            startPoint: .leading,
+            endPoint: .trailing
+        )
     }
 
     private func neutralPaceMarker(width: CGFloat) -> some View {

--- a/Sources/VibeBarApp/Views/PopoverRoot.swift
+++ b/Sources/VibeBarApp/Views/PopoverRoot.swift
@@ -12,12 +12,11 @@ struct PopoverRoot: View {
     @EnvironmentObject var settingsStore: SettingsStore
     @EnvironmentObject var quotaService: QuotaService
     @State private var overviewPage: OverviewPage = .overview
-    @State private var autoRefreshedPageKeys: Set<String> = []
 
     var body: some View {
         let shellDensity = shellDensity
         let contentDensity = activeDensity
-        VStack(alignment: .leading, spacing: shellDensity.interSectionSpacing) {
+        VStack(alignment: .leading, spacing: 0) {
             HeaderView(
                 title: headerTitle,
                 subtitle: headerSubtitle,
@@ -32,7 +31,11 @@ struct PopoverRoot: View {
                 onShowSettings: { environment.showSettingsWindow() }
             )
             .frame(height: shellDensity.headerHeight, alignment: .center)
-            Divider().opacity(0.3)
+            .padding(.horizontal, shellDensity.cardPadding)
+            .padding(.bottom, max(4, shellDensity.interSectionSpacing * 0.45))
+            Divider()
+                .opacity(0.3)
+                .padding(.bottom, shellDensity.interSectionSpacing)
             ScrollView(.vertical, showsIndicators: false) {
                 content(density: contentDensity)
                     .frame(maxWidth: .infinity, alignment: .topLeading)
@@ -45,10 +48,6 @@ struct PopoverRoot: View {
         .frame(width: width)
         .fixedSize(horizontal: false, vertical: true)
         .readHeight(onContentHeightChange)
-        .onAppear(perform: refreshVisibleProvidersIfNeeded)
-        .onChange(of: overviewPage) { _, _ in
-            refreshVisibleProvidersIfNeeded()
-        }
     }
 
     /// The tabbed popover is one shared shell. Provider pages may use their
@@ -159,30 +158,9 @@ struct PopoverRoot: View {
         return visibleTools.compactMap { environment.account(for: $0) }
     }
 
-    private var autoRefreshKey: String {
-        overviewPage.rawValue
-    }
-
-    private func refreshVisibleProvidersIfNeeded() {
-        let key = autoRefreshKey
-        guard !autoRefreshedPageKeys.contains(key) else { return }
-        let accounts = visibleAccounts
-        let refreshAge = TimeInterval(max(60, settingsStore.settings.refreshIntervalSeconds))
-        let missing = accounts.filter { account in
-            quotaService.needsRefresh(accountId: account.id, maxAge: refreshAge)
-                && !quotaService.inFlightAccountIds.contains(account.id)
-        }
-        guard !missing.isEmpty else { return }
-        autoRefreshedPageKeys.insert(key)
-        Task { @MainActor in
-            for account in missing {
-                _ = await quotaService.refresh(account)
-            }
-        }
-    }
 }
 
-private struct ProviderSectionTitle: View {
+struct ProviderSectionTitle: View {
     let tool: ToolType
     let title: String
     var subtitle: String?
@@ -682,7 +660,6 @@ private struct GeminiTabPage: View {
 
         HStack(alignment: .top, spacing: density.interSectionSpacing) {
             VStack(alignment: .leading, spacing: density.interSectionSpacing) {
-                GeminiCombinedCard(density: density)
                 TimelineView(.periodic(from: .now, by: 30)) { context in
                     SubscriptionUtilizationView(
                         tool: .gemini,
@@ -1436,13 +1413,12 @@ private struct CostDetailPopoverContent: View {
 // MARK: - Single-provider detail (two-column waterfall)
 
 /// Single-provider popover content. Two-column layout — narrow left for the
-/// live subscription panels, wider right for cost charts and heatmaps. The two
+/// live subscription panel, wider right for cost charts and heatmaps. The two
 /// columns size independently and do NOT have to match in height.
 ///
 /// Left column (fixed order, narrow):
-///   1. Quota / Usage bar
-///   2. Subscription Utilization
-///   3. Service Status
+///   1. Subscription Utilization (provider header + all live quotas)
+///   2. Service Status
 ///
 /// Right column (wide): Cost summary → Cost History → Model Ranking →
 /// yearly contribution heatmap → weekday-hour heatmap.
@@ -1459,7 +1435,6 @@ private struct ProviderDetailView: View {
         let hasCostData = (snapshot?.jsonlFilesFound ?? 0) > 0
         HStack(alignment: .top, spacing: density.interSectionSpacing) {
             VStack(alignment: .leading, spacing: density.interSectionSpacing) {
-                ProviderQuotaCard(tool: tool, density: density, compact: false)
                 TimelineView(.periodic(from: .now, by: 30)) { context in
                     SubscriptionUtilizationView(
                         tool: tool,
@@ -1881,8 +1856,6 @@ private struct ProviderBucketRow: View {
         let percent = bucket.displayPercent(mode)
         let pace = UsagePace.compute(bucket: bucket, now: now)
         let forecast = paceForecast(now: now)
-        let forecastRange = forecast.map { displayedRange($0) }
-        let forecastMedian = forecast.map { displayedForecast($0) }
         let timePaceDisplayed = pace.map { expectedDisplay(for: $0, mode: mode) }
         VStack(alignment: .leading, spacing: density.bucketRowSpacing) {
             HStack(alignment: .firstTextBaseline) {
@@ -1899,14 +1872,17 @@ private struct ProviderBucketRow: View {
                     .font(.system(size: density.bucketPercentFontSize, weight: .semibold, design: .rounded).monospacedDigit())
                     .foregroundStyle(Theme.barColor(percent: percent, mode: mode))
             }
-            if let forecast, let forecastRange, let forecastMedian {
+            if let forecast {
                 ForecastQuotaBar(
                     percent: percent,
                     mode: mode,
                     timePacePercent: timePaceDisplayed,
-                    forecastLowerPercent: forecastRange.lowerBound,
-                    forecastUpperPercent: forecastRange.upperBound,
-                    forecastMedianPercent: forecastMedian,
+                    forecastProjection: QuotaForecastBarProjection(
+                        projectedUsedLowerPercent: forecast.projectedUsedLowerPercent,
+                        projectedUsedUpperPercent: forecast.projectedUsedUpperPercent,
+                        projectedUsedMedianPercent: forecast.projectedUsedPercent,
+                        displayMode: mode
+                    ),
                     forecastColor: QuotaForecastPalette.color(for: forecast.verdict),
                     height: density.bucketBarHeight
                 )
@@ -1924,7 +1900,8 @@ private struct ProviderBucketRow: View {
                 QuotaForecastRow(
                     forecast: forecast,
                     now: now,
-                    fontSize: density.resetCountdownFontSize
+                    fontSize: density.resetCountdownFontSize,
+                    displayMode: mode
                 )
             } else if let pace {
                 UsagePaceRow(pace: pace, now: now, fontSize: density.resetCountdownFontSize)
@@ -1942,22 +1919,6 @@ private struct ProviderBucketRow: View {
             dailyActivity: snapshot?.dailyHistory ?? [],
             now: now
         )
-    }
-
-    private func displayedForecast(_ forecast: QuotaPaceForecast) -> Double {
-        switch mode {
-        case .used: forecast.projectedUsedPercent
-        case .remaining: 100 - forecast.projectedUsedPercent
-        }
-    }
-
-    private func displayedRange(_ forecast: QuotaPaceForecast) -> ClosedRange<Double> {
-        switch mode {
-        case .used:
-            return forecast.projectedUsedLowerPercent...forecast.projectedUsedUpperPercent
-        case .remaining:
-            return (100 - forecast.projectedUsedUpperPercent)...(100 - forecast.projectedUsedLowerPercent)
-        }
     }
 
     private func expectedDisplay(for pace: UsagePace, mode: DisplayMode) -> Double {

--- a/Sources/VibeBarApp/Views/QuotaForecastRow.swift
+++ b/Sources/VibeBarApp/Views/QuotaForecastRow.swift
@@ -8,6 +8,7 @@ struct QuotaForecastRow: View {
     let now: Date
     let fontSize: CGFloat
     var showGuidance = false
+    var displayMode: DisplayMode = .remaining
 
     var body: some View {
         VStack(alignment: .leading, spacing: 3) {
@@ -31,7 +32,7 @@ struct QuotaForecastRow: View {
                 .foregroundStyle(.secondary)
                 .fixedSize(horizontal: false, vertical: true)
             if showGuidance {
-                Text(forecast.guidanceSummary)
+                Text(guidanceText)
                     .font(.system(size: max(8, fontSize - 1)))
                     .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)
@@ -60,17 +61,19 @@ struct QuotaForecastRow: View {
 
     private var primaryText: String {
         let left = Int(forecast.projectedRemainingPercent.rounded())
+        let used = Int(forecast.projectedUsedPercent.rounded())
+        let forecastValue = displayMode == .remaining ? "\(left)% left" : "\(used)% used"
         switch forecast.verdict {
         case .enough:
-            return "Enough · forecast \(left)% left at reset"
+            return "Enough · forecast \(forecastValue) at reset"
         case .surplus:
-            return "Surplus · forecast \(left)% left at reset"
+            return "Surplus · forecast \(forecastValue) at reset"
         case .watch:
-            return "Watch · forecast \(left)% left at reset"
+            return "Watch · forecast \(forecastValue) at reset"
         case .atRisk:
             return "At risk · likely to run out before reset"
         case .learning:
-            return "Learning · about \(left)% left at reset"
+            return "Learning · about \(forecastValue) at reset"
         }
     }
 
@@ -89,6 +92,21 @@ struct QuotaForecastRow: View {
         case .enough, .surplus, .learning:
             return "Projected to last until reset"
         }
+    }
+
+    private var guidanceText: String {
+        guard displayMode == .used else { return forecast.guidanceSummary }
+        let usedTarget = Int((100 - forecast.targetRemainingPercent).rounded())
+        let unused = Int(forecast.potentialUnusedPercent.rounded())
+        if forecast.verdict == .atRisk { return "Slow down or shift work to another quota" }
+        if forecast.verdict == .watch { return "Recent usage is above the safe range" }
+        if forecast.verdict == .surplus {
+            return "About \(unused)% capacity may remain beyond the \(usedTarget)% used target"
+        }
+        if unused >= 3 {
+            return "Target \(usedTarget)% used · about \(unused)% capacity available"
+        }
+        return "Within the \(usedTarget)% used target"
     }
 
 }

--- a/Sources/VibeBarApp/Views/SettingsView.swift
+++ b/Sources/VibeBarApp/Views/SettingsView.swift
@@ -2,12 +2,67 @@ import SwiftUI
 import UniformTypeIdentifiers
 import VibeBarCore
 
+private enum SettingsSectionID: String, CaseIterable, Identifiable {
+    case general
+    case providerBadges
+    case menuBar
+    case miniWindow
+    case openAI
+    case anthropic
+    case googleAI
+    case xAI
+    case miscProviders
+    case system
+    case costData
+    case keychain
+    case privacy
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .general: "General"
+        case .providerBadges: "Provider Badges"
+        case .menuBar: "Menu Bar"
+        case .miniWindow: "Mini Window"
+        case .openAI: "OpenAI"
+        case .anthropic: "Anthropic"
+        case .googleAI: "Google AI"
+        case .xAI: "xAI"
+        case .miscProviders: "Misc Providers"
+        case .system: "System"
+        case .costData: "Cost Data"
+        case .keychain: "Keychain Access"
+        case .privacy: "Privacy"
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .general: "gearshape"
+        case .providerBadges: "person.text.rectangle"
+        case .menuBar: "menubar.rectangle"
+        case .miniWindow: "rectangle.on.rectangle"
+        case .openAI: "brain.head.profile"
+        case .anthropic: "sparkles"
+        case .googleAI: "diamond"
+        case .xAI: "circle.hexagongrid"
+        case .miscProviders: "square.grid.2x2"
+        case .system: "desktopcomputer"
+        case .costData: "chart.bar.xaxis"
+        case .keychain: "key.fill"
+        case .privacy: "hand.raised.fill"
+        }
+    }
+}
+
 struct SettingsView: View {
     @EnvironmentObject var environment: AppEnvironment
     @EnvironmentObject var settingsStore: SettingsStore
     var dismiss: () -> Void
 
     private let intervalOptions: [Int] = [60, 180, 300, 600, 1800]
+    private let popoverRefreshCooldownOptions: [Int] = [60, 120, 300, 600]
     private let costRetentionOptions = CostDataSettings.retentionOptions
     @State private var openAICookieDeleteFailed: Bool = false
     @State private var claudeCookieDeleteFailed: Bool = false
@@ -21,24 +76,35 @@ struct SettingsView: View {
     @State private var keychainAuthorizationStatus: String?
     @State private var keychainAuthorizationSucceeded: Bool = false
     @State private var draggedMiscProviderInstanceID: String?
+    @State private var selectedSection: SettingsSectionID = .general
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            HStack {
-                Text("Settings")
-                    .font(.system(size: 18, weight: .semibold))
-                Spacer()
-                Button(action: dismiss) {
-                    Image(systemName: "xmark.circle.fill")
-                        .font(.system(size: 18))
-                        .foregroundStyle(.secondary)
-                }
-                .buttonStyle(.plain)
+        HStack(spacing: 0) {
+            settingsSidebar { section in
+                selectedSection = section
             }
-            .padding(.bottom, 12)
+            Divider()
 
-            ScrollView(.vertical, showsIndicators: true) {
-                VStack(alignment: .leading, spacing: 14) {
+            VStack(alignment: .leading, spacing: 0) {
+                    HStack {
+                        Text(selectedSection.title)
+                            .font(.system(size: 20, weight: .semibold))
+                        Spacer()
+                        Button(action: dismiss) {
+                            Image(systemName: "xmark.circle.fill")
+                                .font(.system(size: 18))
+                                .foregroundStyle(.secondary)
+                        }
+                        .buttonStyle(.plain)
+                    }
+                    .padding(.horizontal, 22)
+                    .padding(.vertical, 16)
+
+                    Divider()
+
+                    ScrollView(.vertical, showsIndicators: true) {
+                        VStack(alignment: .leading, spacing: 18) {
+                    if selectedSection == .general {
                     settingsSection("General") {
                         Picker("Percent shows", selection: $settingsStore.settings.displayMode) {
                             ForEach(DisplayMode.allCases, id: \.self) { Text($0.label).tag($0) }
@@ -49,8 +115,28 @@ struct SettingsView: View {
                                 Text(intervalLabel(secs)).tag(secs)
                             }
                         }
+                        Toggle(
+                            "Refresh when the popover opens",
+                            isOn: $settingsStore.settings.refreshOnPopoverOpen
+                        )
+                        if settingsStore.settings.refreshOnPopoverOpen {
+                            Picker(
+                                "Minimum open-refresh cooldown",
+                                selection: $settingsStore.settings.popoverOpenRefreshCooldownSeconds
+                            ) {
+                                ForEach(popoverRefreshCooldownOptions, id: \.self) { secs in
+                                    Text(intervalLabel(secs)).tag(secs)
+                                }
+                            }
+                            Text("Opening the popover refreshes all visible providers at most once per cooldown period.")
+                                .font(.caption2)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                    .id(SettingsSectionID.general.id)
                     }
 
+                    if selectedSection == .providerBadges {
                     settingsSection("Provider Badges") {
                         Text("Leave a badge blank to use the detected account plan.")
                             .font(.caption)
@@ -61,7 +147,10 @@ struct SettingsView: View {
                             }
                         }
                     }
+                    .id(SettingsSectionID.providerBadges.id)
+                    }
 
+                    if selectedSection == .menuBar {
                     settingsSection("Menu Bar Items") {
                         VStack(alignment: .leading, spacing: 8) {
                             ForEach(MenuBarItemKind.allCases) { kind in
@@ -69,7 +158,10 @@ struct SettingsView: View {
                             }
                         }
                     }
+                    .id(SettingsSectionID.menuBar.id)
+                    }
 
+                    if selectedSection == .miniWindow {
                     settingsSection("Mini Window") {
                         Picker("Display mode", selection: miniWindowDisplayModeBinding()) {
                             ForEach(MiniWindowDisplayMode.allCases) { mode in
@@ -117,7 +209,10 @@ struct SettingsView: View {
                             }
                         }
                     }
+                    .id(SettingsSectionID.miniWindow.id)
+                    }
 
+                    if selectedSection == .openAI {
                     settingsSection("OpenAI") {
                         coreProviderSummary(
                             representative: .codex,
@@ -174,7 +269,10 @@ struct SettingsView: View {
                             Label("Check OpenAI connections", systemImage: "checkmark.circle")
                         }
                     }
+                    .id(SettingsSectionID.openAI.id)
+                    }
 
+                    if selectedSection == .anthropic {
                     settingsSection("Anthropic") {
                         coreProviderSummary(
                             representative: .claude,
@@ -231,7 +329,10 @@ struct SettingsView: View {
                             Label("Check Anthropic connections", systemImage: "checkmark.circle")
                         }
                     }
+                    .id(SettingsSectionID.anthropic.id)
+                    }
 
+                    if selectedSection == .googleAI {
                     settingsSection("Google AI") {
                         coreProviderSummary(
                             representative: .gemini,
@@ -312,7 +413,10 @@ struct SettingsView: View {
                             Label("Check Google AI connections", systemImage: "checkmark.circle")
                         }
                     }
+                    .id(SettingsSectionID.googleAI.id)
+                    }
 
+                    if selectedSection == .xAI {
                     settingsSection("xAI") {
                         coreProviderSummary(
                             representative: .grok,
@@ -378,7 +482,10 @@ struct SettingsView: View {
                              destination: ToolType.grok.statusPageURL)
                             .font(.caption2)
                     }
+                    .id(SettingsSectionID.xAI.id)
+                    }
 
+                    if selectedSection == .miscProviders {
                     settingsSection("Misc Providers") {
                         Text("Usage-only integrations. Check providers to show them on the Misc page; hidden providers keep their saved setup.")
                             .font(.caption)
@@ -411,7 +518,10 @@ struct SettingsView: View {
                                 )
                         }
                     }
+                    .id(SettingsSectionID.miscProviders.id)
+                    }
 
+                    if selectedSection == .system {
                     settingsSection("System") {
                         Toggle("Launch at login", isOn: launchAtLoginBinding())
                         Text(launchAtLoginStatusText)
@@ -423,7 +533,10 @@ struct SettingsView: View {
                                 .foregroundStyle(.orange)
                         }
                     }
+                    .id(SettingsSectionID.system.id)
+                    }
 
+                    if selectedSection == .costData {
                     settingsSection("Cost Data") {
                         Text("Cost is computed from local CLI session JSONL logs at ~/.codex/sessions and ~/.claude/projects. Web/desktop usage is not tracked.")
                             .font(.caption)
@@ -466,22 +579,68 @@ struct SettingsView: View {
                             .font(.caption2)
                             .foregroundStyle(.tertiary)
                     }
+                    .id(SettingsSectionID.costData.id)
+                    }
 
+                    if selectedSection == .keychain {
                     settingsSection("Keychain Access") {
                         keychainAuthorizationControls
                     }
+                    .id(SettingsSectionID.keychain.id)
+                    }
 
+                    if selectedSection == .privacy {
                     settingsSection("Privacy") {
                         Text("Tokens are read from local CLI credentials. Saved OpenAI and Claude Web cookies are stored in macOS Keychain, split by browser and WebView source. Legacy plaintext cookie files under ~/.vibebar/cookies are migrated once and deleted. Settings, quota cache, and cost summaries stay under ~/.vibebar.")
                             .font(.caption)
                             .foregroundStyle(.secondary)
                     }
-                }
+                    .id(SettingsSectionID.privacy.id)
+                    }
+                        }
+                        .padding(22)
+                    }
             }
         }
-        .padding(20)
-        .frame(minWidth: 560, idealWidth: 640, minHeight: 560, idealHeight: 720)
+        .frame(minWidth: 820, idealWidth: 980, minHeight: 600, idealHeight: 760)
         .onAppear(perform: refreshLaunchAtLoginState)
+    }
+
+    private func settingsSidebar(onSelect: @escaping (SettingsSectionID) -> Void) -> some View {
+        ScrollView(.vertical, showsIndicators: false) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Vibe Bar")
+                    .font(.system(size: 17, weight: .semibold))
+                    .padding(.horizontal, 12)
+                    .padding(.bottom, 10)
+                ForEach(SettingsSectionID.allCases) { section in
+                    Button {
+                        onSelect(section)
+                    } label: {
+                        HStack(spacing: 9) {
+                            Image(systemName: section.systemImage)
+                                .frame(width: 18)
+                            Text(section.title)
+                                .lineLimit(1)
+                            Spacer(minLength: 0)
+                        }
+                        .font(.system(size: 13, weight: selectedSection == section ? .semibold : .regular))
+                        .foregroundStyle(selectedSection == section ? Color.white : Color.primary)
+                        .padding(.horizontal, 10)
+                        .frame(height: 34)
+                        .background(
+                            RoundedRectangle(cornerRadius: 7, style: .continuous)
+                                .fill(selectedSection == section ? Color.accentColor : Color.clear)
+                        )
+                        .contentShape(Rectangle())
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+            .padding(14)
+        }
+        .frame(width: 205)
+        .background(Color.primary.opacity(0.035))
     }
 
     private func settingsSection<Content: View>(
@@ -686,6 +845,7 @@ struct SettingsView: View {
             set: { enabled in
                 do {
                     try LoginItemController.setEnabled(enabled)
+                    settingsStore.settings.launchAtLogin = enabled
                     launchAtLoginError = nil
                 } catch {
                     launchAtLoginError = error.localizedDescription
@@ -696,7 +856,16 @@ struct SettingsView: View {
     }
 
     private func refreshLaunchAtLoginState() {
-        settingsStore.settings.launchAtLogin = LoginItemController.isEnabled
+        switch LoginItemController.status {
+        case .enabled, .requiresApproval:
+            settingsStore.settings.launchAtLogin = true
+        case .notRegistered:
+            settingsStore.settings.launchAtLogin = false
+        case .notFound:
+            break
+        @unknown default:
+            break
+        }
         launchAtLoginStatusText = LoginItemController.statusText
     }
 

--- a/Sources/VibeBarApp/Views/SubscriptionUtilizationView.swift
+++ b/Sources/VibeBarApp/Views/SubscriptionUtilizationView.swift
@@ -17,18 +17,29 @@ struct SubscriptionUtilizationView: View {
     var additionalQuotaSeries: [FillTimelineSeries] = []
 
     @EnvironmentObject var environment: AppEnvironment
+    @EnvironmentObject var settingsStore: SettingsStore
     @EnvironmentObject var quotaService: QuotaService
     @State private var expandedForecastIDs: Set<String> = []
 
     var body: some View {
         VStack(alignment: .leading, spacing: density.cardSpacing) {
-            HStack(alignment: .firstTextBaseline) {
-                Text("Subscription Utilization")
-                    .font(.system(size: density.bucketTitleFontSize, weight: .semibold))
-                Spacer()
-                Text(toolDisplayName)
-                    .font(.system(size: density.subtitleFontSize))
-                    .foregroundStyle(.secondary)
+            HStack(alignment: .center, spacing: 8) {
+                ProviderSectionTitle(
+                    tool: tool,
+                    title: tool.menuTitle,
+                    subtitle: providerSubtitle,
+                    titleFontSize: density.titleFontSize,
+                    subtitleFontSize: density.subtitleFontSize,
+                    iconSize: 16,
+                    badgeSize: 24
+                )
+                Spacer(minLength: 4)
+                if let providerPlanBadge {
+                    PlanBadgeView(
+                        text: providerPlanBadge,
+                        fontSize: max(9, density.subtitleFontSize - 1)
+                    )
+                }
                 SectionRefreshButton(isRefreshing: isRefreshing) {
                     for refreshTool in refreshTools {
                         environment.refresh(refreshTool)
@@ -64,6 +75,10 @@ struct SubscriptionUtilizationView: View {
         let tool: ToolType
         let accountId: String?
         let bucket: QuotaBucket
+        let sectionTitle: String?
+        let startsSection: Bool
+        let groupTitle: String?
+        let startsGroup: Bool
     }
 
     /// Keep live utilization and reset-cycle history on the same complete
@@ -71,8 +86,15 @@ struct SubscriptionUtilizationView: View {
     /// `groupTitle`, which made Spark and Fable disappear even though their
     /// history tabs were already present.
     private var utilizationBuckets: [UtilizationBucket] {
+        struct RawBucket {
+            let id: String
+            let tool: ToolType
+            let accountId: String?
+            let bucket: QuotaBucket
+        }
+
         let primary = buckets.map {
-            UtilizationBucket(
+            RawBucket(
                 id: "primary:\(tool.rawValue):\($0.id)",
                 tool: tool,
                 accountId: environment.account(for: tool)?.id,
@@ -80,9 +102,33 @@ struct SubscriptionUtilizationView: View {
             )
         }
         let additional = additionalQuotaSeries.map {
-            UtilizationBucket(id: $0.id, tool: $0.tool, accountId: $0.accountId, bucket: $0.bucket)
+            RawBucket(id: $0.id, tool: $0.tool, accountId: $0.accountId, bucket: $0.bucket)
         }
-        return primary + additional
+        var previousSectionKey: String?
+        var previousGroupKey: String?
+        return (primary + additional).map { item in
+            let sectionTitle = linkedSectionTitle(for: item.tool)
+            let sectionKey = sectionTitle.map { "\(item.tool.rawValue):\($0)" }
+            let startsSection = sectionKey != nil && sectionKey != previousSectionKey
+            if startsSection {
+                previousSectionKey = sectionKey
+                previousGroupKey = nil
+            }
+            let groupTitle = quotaGroupTitle(for: item.tool, bucket: item.bucket)
+            let groupKey = groupTitle.map { "\(item.tool.rawValue):\($0)" }
+            let startsGroup = groupKey != nil && groupKey != previousGroupKey
+            if groupKey != nil { previousGroupKey = groupKey }
+            return UtilizationBucket(
+                id: item.id,
+                tool: item.tool,
+                accountId: item.accountId,
+                bucket: item.bucket,
+                sectionTitle: sectionTitle,
+                startsSection: startsSection,
+                groupTitle: groupTitle,
+                startsGroup: startsGroup
+            )
+        }
     }
 
     private var isRefreshing: Bool {
@@ -104,14 +150,38 @@ struct SubscriptionUtilizationView: View {
         let pace = UsagePace.compute(bucket: bucket, now: now)
         let forecast = paceForecast(for: item)
         let used = bucket.usedPercent
-        let timeExpected = pace?.expectedUsedPercent
-        let forecastExpected = forecast?.projectedUsedPercent
+        let timeExpected = pace.map { displayedPercent(fromUsed: $0.expectedUsedPercent) }
+        let forecastProjection = forecast.map {
+            QuotaForecastBarProjection(
+                projectedUsedLowerPercent: $0.projectedUsedLowerPercent,
+                projectedUsedUpperPercent: $0.projectedUsedUpperPercent,
+                projectedUsedMedianPercent: $0.projectedUsedPercent,
+                displayMode: mode
+            )
+        }
         VStack(alignment: .leading, spacing: density.bucketRowSpacing) {
+            if item.startsSection, let sectionTitle = item.sectionTitle {
+                linkedProviderSection(tool: item.tool, title: sectionTitle)
+            }
+            if item.startsGroup, let groupTitle = item.groupTitle {
+                Text(groupTitle)
+                    .font(.system(size: max(9, density.subtitleFontSize - 1), weight: .semibold))
+                    .foregroundStyle(.tertiary)
+                    .textCase(.uppercase)
+                    .tracking(0.4)
+                    .padding(.top, item.startsSection ? 1 : 5)
+            }
             HStack(alignment: .firstTextBaseline) {
-                Text(rowTitle(for: item))
+                Text(bucket.title)
                     .font(.system(size: density.bucketTitleFontSize, weight: .semibold))
-                    .lineLimit(2)
-                    .fixedSize(horizontal: false, vertical: true)
+                    .lineLimit(1)
+                if let resetAt = bucket.resetAt,
+                   let reset = ResetCountdownFormatter.string(from: resetAt, now: now) {
+                    Text("resets in \(reset)")
+                        .font(.system(size: density.resetCountdownFontSize))
+                        .foregroundStyle(.tertiary)
+                        .lineLimit(1)
+                }
                 Spacer(minLength: 6)
                 Text(percentLabel(used: used))
                     .font(.system(size: density.bucketPercentFontSize, weight: .semibold, design: .rounded).monospacedDigit())
@@ -122,13 +192,14 @@ struct SubscriptionUtilizationView: View {
             percentageAxis
             referenceLegend(
                 timeExpected: timeExpected,
-                forecastExpected: forecastExpected,
+                forecastExpected: forecastProjection?.medianPercent,
                 forecastColor: forecast.map { QuotaForecastPalette.color(for: $0.verdict) }
             )
             Text(SubscriptionWindowProgress.summary(
                 usedPercent: bucket.usedPercent,
                 resetAt: bucket.resetAt,
                 rawWindowSeconds: bucket.rawWindowSeconds,
+                displayMode: mode,
                 now: now
             ))
                 .font(.system(size: density.subtitleFontSize, weight: .semibold))
@@ -139,7 +210,8 @@ struct SubscriptionUtilizationView: View {
                     forecast: forecast,
                     now: now,
                     fontSize: density.subtitleFontSize,
-                    showGuidance: true
+                    showGuidance: true,
+                    displayMode: mode
                 )
             } else if let pace {
                 HStack(spacing: 6) {
@@ -175,24 +247,27 @@ struct SubscriptionUtilizationView: View {
         let barHeight = max(10, density.bucketBarHeight)
         if let forecast {
             ForecastQuotaBar(
-                percent: used,
-                mode: .used,
-                timePacePercent: pace?.expectedUsedPercent,
-                forecastLowerPercent: forecast.projectedUsedLowerPercent,
-                forecastUpperPercent: forecast.projectedUsedUpperPercent,
-                forecastMedianPercent: forecast.projectedUsedPercent,
+                percent: displayedPercent(fromUsed: used),
+                mode: mode,
+                timePacePercent: pace.map { displayedPercent(fromUsed: $0.expectedUsedPercent) },
+                forecastProjection: QuotaForecastBarProjection(
+                    projectedUsedLowerPercent: forecast.projectedUsedLowerPercent,
+                    projectedUsedUpperPercent: forecast.projectedUsedUpperPercent,
+                    projectedUsedMedianPercent: forecast.projectedUsedPercent,
+                    displayMode: mode
+                ),
                 forecastColor: QuotaForecastPalette.color(for: forecast.verdict),
                 height: barHeight
             )
         } else if let pace {
             PaceMarkerCapsule(
-                usedPercent: used,
-                expectedPercent: pace.expectedUsedPercent,
-                mode: .used,
+                usedPercent: displayedPercent(fromUsed: used),
+                expectedPercent: displayedPercent(fromUsed: pace.expectedUsedPercent),
+                mode: mode,
                 height: barHeight
             )
         } else {
-            QuotaBarShape(percent: used, mode: .used, height: barHeight)
+            QuotaBarShape(percent: displayedPercent(fromUsed: used), mode: mode, height: barHeight)
         }
     }
 
@@ -236,7 +311,7 @@ struct SubscriptionUtilizationView: View {
                     forecastColor: forecastColor
                 )
                 Spacer(minLength: 4)
-                actualUsedLegend
+                actualValueLegend
             }
             VStack(alignment: .leading, spacing: 4) {
                 ViewThatFits(in: .horizontal) {
@@ -255,7 +330,7 @@ struct SubscriptionUtilizationView: View {
                         )
                     }
                 }
-                actualUsedLegend
+                actualValueLegend
             }
         }
     }
@@ -271,7 +346,7 @@ struct SubscriptionUtilizationView: View {
                 color: .secondary,
                 markerStyle: .timePace,
                 label: "Time-only pace",
-                value: "\(Int(timeExpected.rounded()))%"
+                value: "\(Int(timeExpected.rounded()))% \(mode == .remaining ? "left" : "used")"
             )
         }
         if let forecastExpected, let forecastColor {
@@ -279,13 +354,13 @@ struct SubscriptionUtilizationView: View {
                 color: forecastColor,
                 markerStyle: .forecast,
                 label: "Forecast at reset",
-                value: "\(Int(forecastExpected.rounded()))%"
+                value: "\(Int(forecastExpected.rounded()))% \(mode == .remaining ? "left" : "used")"
             )
         }
     }
 
-    private var actualUsedLegend: some View {
-        Text("bar = actual used")
+    private var actualValueLegend: some View {
+        Text("bar = actual \(mode == .remaining ? "left" : "used")")
             .font(.system(size: max(8, density.subtitleFontSize - 1)))
             .foregroundStyle(.tertiary)
             .fixedSize(horizontal: true, vertical: false)
@@ -386,19 +461,26 @@ struct SubscriptionUtilizationView: View {
                             Text(metric.label.uppercased())
                                 .font(.system(size: max(8, density.subtitleFontSize - 2), weight: .semibold))
                                 .foregroundStyle(.tertiary)
-                                .fixedSize(horizontal: false, vertical: true)
+                                .lineLimit(1)
                             Text(metric.value)
                                 .font(.system(size: density.subtitleFontSize, weight: .semibold, design: .rounded))
                                 .foregroundStyle(.primary)
-                                .fixedSize(horizontal: false, vertical: true)
+                                .lineLimit(2)
+                                .minimumScaleFactor(0.88)
                             Text(metric.detail)
                                 .font(.system(size: max(8, density.subtitleFontSize - 1)))
                                 .foregroundStyle(.secondary)
-                                .fixedSize(horizontal: false, vertical: true)
+                                .lineLimit(2)
+                            Spacer(minLength: 0)
                         }
-                        .frame(maxWidth: .infinity, alignment: .leading)
                         .padding(.horizontal, 8)
                         .padding(.vertical, 7)
+                        .frame(
+                            maxWidth: .infinity,
+                            minHeight: forecastMetricCardHeight,
+                            maxHeight: forecastMetricCardHeight,
+                            alignment: .topLeading
+                        )
                         .background(
                             RoundedRectangle(cornerRadius: 7, style: .continuous)
                                 .fill(Color.primary.opacity(0.035))
@@ -415,20 +497,28 @@ struct SubscriptionUtilizationView: View {
         .padding(.top, 2)
     }
 
+    private var forecastMetricCardHeight: CGFloat {
+        switch density.profile {
+        case .compact: 72
+        case .regular: 76
+        case .spacious: 84
+        }
+    }
+
     private func forecastMetrics(
         forecast: QuotaPaceForecast,
         pace: UsagePace?
     ) -> [ForecastMetric] {
         let diagnostics = forecast.diagnostics
-        let timePaceValue = pace.map { "\(whole($0.expectedUsedPercent))% expected now" } ?? "Unavailable"
+        let timePaceValue = pace.map { quotaValue(fromUsed: $0.expectedUsedPercent, suffix: "expected now") } ?? "Unavailable"
         let timePaceDetail = pace.map { "\($0.stageSummary) by wall clock" } ?? "Needs reset time and window length"
         let recentValue = diagnostics.recentProjectionUsedPercent
-            .map { "\(whole($0))% used at reset" } ?? "Learning"
+            .map { quotaValue(fromUsed: $0, suffix: "at reset") } ?? "Learning"
         let recentDetail = diagnostics.recentSampleCount > 0
             ? "\(diagnostics.recentSampleCount) recent intervals"
             : "Needs at least two useful observations"
         let historyValue = diagnostics.historicalProjectionUsedPercent
-            .map { "\(whole($0))% used at reset" } ?? "No comparison yet"
+            .map { quotaValue(fromUsed: $0, suffix: "at reset") } ?? "No comparison yet"
         let historyDetail = diagnostics.comparableCycleCount > 0
             ? "\(diagnostics.comparableCycleCount) comparable reset cycles"
             : "Completed cycles will appear here"
@@ -441,7 +531,9 @@ struct SubscriptionUtilizationView: View {
         let trendDetail = diagnostics.hasActivityTrendBaseline
             ? "last 7 days versus prior 21 days"
             : "needs prior daily activity"
-        let range = forecast.projectedUsedLowerPercent...forecast.projectedUsedUpperPercent
+        let range = mode == .used
+            ? forecast.projectedUsedLowerPercent...forecast.projectedUsedUpperPercent
+            : forecast.projectedRemainingRange
         let unused = whole(forecast.potentialUnusedPercent)
 
         return [
@@ -454,7 +546,7 @@ struct SubscriptionUtilizationView: View {
             ForecastMetric(
                 id: "plan",
                 label: "Personal plan now",
-                value: "\(whole(forecast.plannedUsedPercent))% used",
+                value: quotaValue(fromUsed: forecast.plannedUsedPercent),
                 detail: "activity timing + \(whole(forecast.targetRemainingPercent))% safety target"
             ),
             ForecastMetric(
@@ -484,19 +576,23 @@ struct SubscriptionUtilizationView: View {
             ForecastMetric(
                 id: "forecast",
                 label: "Forecast at reset",
-                value: "\(whole(forecast.projectedUsedPercent))% used",
-                detail: "\(whole(forecast.projectedRemainingPercent))% expected left"
+                value: quotaValue(fromUsed: forecast.projectedUsedPercent),
+                detail: mode == .used
+                    ? "\(whole(forecast.projectedRemainingPercent))% expected left"
+                    : "\(whole(forecast.projectedUsedPercent))% expected used"
             ),
             ForecastMetric(
                 id: "range",
                 label: "Forecast range",
-                value: "\(whole(range.lowerBound))–\(whole(range.upperBound))% used",
+                value: "\(whole(range.lowerBound))–\(whole(range.upperBound))% \(mode == .used ? "used" : "left")",
                 detail: "uncertainty interval"
             ),
             ForecastMetric(
                 id: "target",
                 label: "Safety target",
-                value: "\(whole(forecast.targetRemainingPercent))% left",
+                value: mode == .remaining
+                    ? "\(whole(forecast.targetRemainingPercent))% left"
+                    : "\(whole(100 - forecast.targetRemainingPercent))% used",
                 detail: unused >= 3 ? "\(unused)% capacity above target" : "inside the target range"
             ),
             ForecastMetric(
@@ -514,7 +610,7 @@ struct SubscriptionUtilizationView: View {
             ForecastMetric(
                 id: "behavior",
                 label: "Behavior fallback",
-                value: "\(whole(diagnostics.behavioralProjectionUsedPercent))% used at reset",
+                value: quotaValue(fromUsed: diagnostics.behavioralProjectionUsedPercent, suffix: "at reset"),
                 detail: "used when stronger evidence is sparse"
             ),
         ]
@@ -524,17 +620,17 @@ struct SubscriptionUtilizationView: View {
         Int(value.rounded())
     }
 
-    private func rowTitle(for item: UtilizationBucket) -> String {
-        var parts: [String] = []
-        if item.tool != tool {
-            parts.append(item.tool.toolName)
+    private func displayedPercent(fromUsed used: Double) -> Double {
+        switch mode {
+        case .used: used
+        case .remaining: max(0, 100 - used)
         }
-        if let groupTitle = item.bucket.groupTitle?.trimmingCharacters(in: .whitespacesAndNewlines),
-           !groupTitle.isEmpty {
-            parts.append(groupTitle)
-        }
-        parts.append(item.bucket.title)
-        return parts.joined(separator: " · ")
+    }
+
+    private func quotaValue(fromUsed used: Double, suffix: String? = nil) -> String {
+        let base = "\(whole(displayedPercent(fromUsed: used)))% \(mode == .used ? "used" : "left")"
+        guard let suffix else { return base }
+        return "\(base) \(suffix)"
     }
 
     private func historySeries(for item: UtilizationBucket) -> FillTimelineSeries? {
@@ -563,7 +659,51 @@ struct SubscriptionUtilizationView: View {
         return ResetCountdownFormatter.string(from: target, now: now).map { "runs out in \($0)" } ?? "—"
     }
 
-    private var toolDisplayName: String {
-        tool.displayName
+    private var providerSubtitle: String {
+        tool == .gemini ? tool.statusProviderName : tool.subtitle
+    }
+
+    private var providerPlanBadge: String? {
+        let account = environment.account(for: tool)
+        let quotaPlan = account.flatMap { quotaService.cachedQuota(for: $0.id)?.plan }
+            ?? environment.quota(for: tool)?.plan
+        let label = settingsStore.settings.planBadgeLabel(
+            for: tool,
+            quotaPlan: quotaPlan,
+            accountPlan: account?.plan
+        )?.trimmingCharacters(in: .whitespacesAndNewlines)
+        return label?.isEmpty == false ? label : nil
+    }
+
+    private func linkedSectionTitle(for itemTool: ToolType) -> String? {
+        guard itemTool != tool else { return nil }
+        return itemTool.toolName
+    }
+
+    private func quotaGroupTitle(for itemTool: ToolType, bucket: QuotaBucket) -> String? {
+        if let title = bucket.groupTitle?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !title.isEmpty {
+            return title
+        }
+        if tool == .gemini, itemTool == .gemini {
+            return "Gemini Chat"
+        }
+        return nil
+    }
+
+    private func linkedProviderSection(tool linkedTool: ToolType, title: String) -> some View {
+        VStack(alignment: .leading, spacing: 7) {
+            Divider()
+                .opacity(0.18)
+                .padding(.top, 3)
+            HStack(alignment: .center, spacing: 6) {
+                ToolBrandIconView(tool: linkedTool, size: 13)
+                    .opacity(0.85)
+                Text(title)
+                    .font(.system(size: max(10, density.subtitleFontSize), weight: .semibold))
+                    .foregroundStyle(.secondary)
+                Spacer(minLength: 4)
+            }
+        }
     }
 }

--- a/Sources/VibeBarCore/Models/AppSettings.swift
+++ b/Sources/VibeBarCore/Models/AppSettings.swift
@@ -3,6 +3,8 @@ import Foundation
 public struct AppSettings: Codable, Equatable, Sendable {
     public var displayMode: DisplayMode
     public var refreshIntervalSeconds: Int
+    public var refreshOnPopoverOpen: Bool
+    public var popoverOpenRefreshCooldownSeconds: Int
     public var launchAtLogin: Bool
     public var menuBarTextEnabled: Bool
     public var mockEnabled: Bool
@@ -42,6 +44,8 @@ public struct AppSettings: Codable, Equatable, Sendable {
     public static let `default` = AppSettings(
         displayMode: .remaining,
         refreshIntervalSeconds: 600,
+        refreshOnPopoverOpen: false,
+        popoverOpenRefreshCooldownSeconds: 60,
         launchAtLogin: false,
         menuBarTextEnabled: true,
         mockEnabled: false,
@@ -117,6 +121,8 @@ public struct AppSettings: Codable, Equatable, Sendable {
     public init(
         displayMode: DisplayMode,
         refreshIntervalSeconds: Int,
+        refreshOnPopoverOpen: Bool = false,
+        popoverOpenRefreshCooldownSeconds: Int = 60,
         launchAtLogin: Bool,
         menuBarTextEnabled: Bool,
         mockEnabled: Bool,
@@ -137,6 +143,8 @@ public struct AppSettings: Codable, Equatable, Sendable {
     ) {
         self.displayMode = displayMode
         self.refreshIntervalSeconds = refreshIntervalSeconds
+        self.refreshOnPopoverOpen = refreshOnPopoverOpen
+        self.popoverOpenRefreshCooldownSeconds = max(60, popoverOpenRefreshCooldownSeconds)
         self.launchAtLogin = launchAtLogin
         self.menuBarTextEnabled = menuBarTextEnabled
         self.mockEnabled = false
@@ -167,6 +175,8 @@ public struct AppSettings: Codable, Equatable, Sendable {
     private enum CodingKeys: String, CodingKey {
         case displayMode
         case refreshIntervalSeconds
+        case refreshOnPopoverOpen
+        case popoverOpenRefreshCooldownSeconds
         case launchAtLogin
         case menuBarTextEnabled
         case mockEnabled
@@ -191,6 +201,12 @@ public struct AppSettings: Codable, Equatable, Sendable {
         let c = try decoder.container(keyedBy: CodingKeys.self)
         self.displayMode = try c.decodeIfPresent(DisplayMode.self, forKey: .displayMode) ?? Self.default.displayMode
         self.refreshIntervalSeconds = try c.decodeIfPresent(Int.self, forKey: .refreshIntervalSeconds) ?? Self.default.refreshIntervalSeconds
+        self.refreshOnPopoverOpen = try c.decodeIfPresent(Bool.self, forKey: .refreshOnPopoverOpen) ?? Self.default.refreshOnPopoverOpen
+        self.popoverOpenRefreshCooldownSeconds = max(
+            60,
+            try c.decodeIfPresent(Int.self, forKey: .popoverOpenRefreshCooldownSeconds)
+                ?? Self.default.popoverOpenRefreshCooldownSeconds
+        )
         self.launchAtLogin = try c.decodeIfPresent(Bool.self, forKey: .launchAtLogin) ?? Self.default.launchAtLogin
         self.menuBarTextEnabled = try c.decodeIfPresent(Bool.self, forKey: .menuBarTextEnabled) ?? Self.default.menuBarTextEnabled
         self.mockEnabled = false
@@ -300,6 +316,8 @@ public struct AppSettings: Codable, Equatable, Sendable {
         var c = encoder.container(keyedBy: CodingKeys.self)
         try c.encode(displayMode, forKey: .displayMode)
         try c.encode(refreshIntervalSeconds, forKey: .refreshIntervalSeconds)
+        try c.encode(refreshOnPopoverOpen, forKey: .refreshOnPopoverOpen)
+        try c.encode(popoverOpenRefreshCooldownSeconds, forKey: .popoverOpenRefreshCooldownSeconds)
         try c.encode(launchAtLogin, forKey: .launchAtLogin)
         try c.encode(menuBarTextEnabled, forKey: .menuBarTextEnabled)
         try c.encode(mockEnabled, forKey: .mockEnabled)

--- a/Sources/VibeBarCore/Models/QuotaForecastBarProjection.swift
+++ b/Sources/VibeBarCore/Models/QuotaForecastBarProjection.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+/// A forecast interval projected onto the finite 0...100 quota-bar axis.
+///
+/// Forecast demand may legitimately exceed 100%. This type keeps that
+/// overflow information while guaranteeing the visible marker stays inside
+/// the visible confidence band in both Used and Remaining display modes.
+public struct QuotaForecastBarProjection: Sendable, Equatable {
+    public let lowerPercent: Double
+    public let upperPercent: Double
+    public let medianPercent: Double
+    public let clipsLowerBound: Bool
+    public let clipsUpperBound: Bool
+    public let hasUncertainty: Bool
+
+    public init(
+        projectedUsedLowerPercent: Double,
+        projectedUsedUpperPercent: Double,
+        projectedUsedMedianPercent: Double,
+        displayMode: DisplayMode
+    ) {
+        let usedLower = min(projectedUsedLowerPercent, projectedUsedUpperPercent)
+        let usedUpper = max(projectedUsedLowerPercent, projectedUsedUpperPercent)
+
+        let displayedLower: Double
+        let displayedUpper: Double
+        let displayedMedian: Double
+        switch displayMode {
+        case .used:
+            displayedLower = usedLower
+            displayedUpper = usedUpper
+            displayedMedian = projectedUsedMedianPercent
+        case .remaining:
+            displayedLower = 100 - usedUpper
+            displayedUpper = 100 - usedLower
+            displayedMedian = 100 - projectedUsedMedianPercent
+        }
+
+        // Defensive inclusion keeps a malformed or rounded provider interval
+        // from ever drawing its median marker outside the confidence band.
+        let rawLower = min(displayedLower, displayedUpper, displayedMedian)
+        let rawUpper = max(displayedLower, displayedUpper, displayedMedian)
+        let visibleLower = Self.clamp(rawLower)
+        let visibleUpper = Self.clamp(rawUpper)
+
+        lowerPercent = visibleLower
+        upperPercent = visibleUpper
+        medianPercent = min(max(Self.clamp(displayedMedian), visibleLower), visibleUpper)
+        clipsLowerBound = rawLower < 0
+        clipsUpperBound = rawUpper > 100
+        hasUncertainty = rawUpper > rawLower
+    }
+
+    private static func clamp(_ value: Double) -> Double {
+        guard value.isFinite else { return 0 }
+        return min(max(value, 0), 100)
+    }
+}

--- a/Sources/VibeBarCore/Services/QuotaRefreshScheduler.swift
+++ b/Sources/VibeBarCore/Services/QuotaRefreshScheduler.swift
@@ -21,6 +21,7 @@ public final class QuotaRefreshScheduler {
     private var boundaryTimer: Timer?
     private var boundaryAccountIds: Set<String> = []
     private var lastBoundaryRefreshByAccount: [String: Date] = [:]
+    private var lastPopoverOpenRefreshAt: Date?
     private var pathMonitor: NWPathMonitor?
     private var lastNetworkStatus: NWPath.Status = .satisfied
     private var observers: [NSObjectProtocol] = []
@@ -81,6 +82,27 @@ public final class QuotaRefreshScheduler {
                 _ = await service.refresh(account)
             }
         }
+    }
+
+    /// Refresh when the user explicitly opens the menu popover, subject to a
+    /// user-configured cooldown. Popover construction/warm-up does not call
+    /// this method; only an actual open gesture does, so launch-time eager
+    /// SwiftUI creation cannot accidentally consume the cooldown.
+    @discardableResult
+    public func triggerRefreshForPopoverOpenIfNeeded(
+        enabled: Bool,
+        cooldownSeconds: Int,
+        now: Date = Date()
+    ) -> Bool {
+        guard enabled else { return false }
+        let cooldown = TimeInterval(max(60, cooldownSeconds))
+        if let lastPopoverOpenRefreshAt,
+           now.timeIntervalSince(lastPopoverOpenRefreshAt) < cooldown {
+            return false
+        }
+        lastPopoverOpenRefreshAt = now
+        triggerRefresh()
+        return true
     }
 
     private func scheduleTimer() {

--- a/Sources/VibeBarCore/Services/SubscriptionWindowProgress.swift
+++ b/Sources/VibeBarCore/Services/SubscriptionWindowProgress.swift
@@ -16,31 +16,34 @@ public enum SubscriptionWindowProgress {
         usedPercent: Double,
         resetAt: Date?,
         rawWindowSeconds: Int?,
+        displayMode: DisplayMode = .used,
         now: Date = Date()
     ) -> String {
-        let pct = formatPercent(usedPercent)
+        let displayedPercent = displayMode == .used ? usedPercent : 100 - usedPercent
+        let pct = formatPercent(displayedPercent)
+        let unit = displayMode == .used ? "used" : "left"
         guard let resetAt, let rawWindowSeconds, rawWindowSeconds > 0 else {
-            return "\(pct) used"
+            return "\(pct) \(unit)"
         }
 
         let windowSeconds = TimeInterval(rawWindowSeconds)
         let remaining = resetAt.timeIntervalSince(now)
         if remaining <= 0 {
-            return "Resets soon · \(pct) used"
+            return "Resets soon · \(pct) \(unit)"
         }
         let elapsed = max(0, min(windowSeconds, windowSeconds - remaining))
 
         if rawWindowSeconds >= 86_400 {
             let totalDays = max(1, Int((windowSeconds / 86_400).rounded()))
             let dayNumber = clamp(Int(elapsed / 86_400) + 1, lower: 1, upper: totalDays)
-            return "Day \(dayNumber) of \(totalDays) · \(pct) used"
+            return "Day \(dayNumber) of \(totalDays) · \(pct) \(unit)"
         }
 
         let totalLabel = rawWindowSeconds == 18_000
             ? "5 Hours"
             : formatShortDuration(windowSeconds)
         let elapsedLabel = formatShortDuration(elapsed)
-        return "\(elapsedLabel) of \(totalLabel) · \(pct) used"
+        return "\(elapsedLabel) of \(totalLabel) · \(pct) \(unit)"
     }
 
     private static func clamp(_ value: Int, lower: Int, upper: Int) -> Int {

--- a/Sources/VibeBarCore/Storage/SettingsStore.swift
+++ b/Sources/VibeBarCore/Storage/SettingsStore.swift
@@ -38,12 +38,9 @@ public final class SettingsStore: ObservableObject {
         }
     }
 
-    private static func migrated(_ settings: AppSettings) -> AppSettings {
+    static func migrated(_ settings: AppSettings) -> AppSettings {
         var migrated = settings
         migrated.mockEnabled = false
-        if migrated.refreshIntervalSeconds == 300 {
-            migrated.refreshIntervalSeconds = AppSettings.default.refreshIntervalSeconds
-        }
         // Claude bucket IDs were renamed when Daily Routines moved out of the
         // headline weekly group. Rewrite stale field IDs in-place so the user
         // doesn't have to re-pick everything in Settings.
@@ -117,6 +114,14 @@ public final class SettingsStore: ObservableObject {
     public var refreshIntervalSeconds: Int {
         get { settings.refreshIntervalSeconds }
         set { settings.refreshIntervalSeconds = max(60, newValue) }
+    }
+    public var refreshOnPopoverOpen: Bool {
+        get { settings.refreshOnPopoverOpen }
+        set { settings.refreshOnPopoverOpen = newValue }
+    }
+    public var popoverOpenRefreshCooldownSeconds: Int {
+        get { settings.popoverOpenRefreshCooldownSeconds }
+        set { settings.popoverOpenRefreshCooldownSeconds = max(60, newValue) }
     }
     public var mockEnabled: Bool {
         get { settings.mockEnabled }

--- a/Tests/VibeBarCoreTests/AppSettingsTests.swift
+++ b/Tests/VibeBarCoreTests/AppSettingsTests.swift
@@ -398,4 +398,27 @@ final class AppSettingsTests: XCTestCase {
 
         XCTAssertEqual(settings.visibleCoreProviders, Set([.codex, .gemini]))
     }
+
+    func testRefreshPreferencesRoundTrip() throws {
+        var settings = AppSettings.default
+        settings.refreshIntervalSeconds = 300
+        settings.refreshOnPopoverOpen = true
+        settings.popoverOpenRefreshCooldownSeconds = 120
+
+        let data = try JSONEncoder().encode(settings)
+        let decoded = try JSONDecoder().decode(AppSettings.self, from: data)
+
+        XCTAssertEqual(decoded.refreshIntervalSeconds, 300)
+        XCTAssertTrue(decoded.refreshOnPopoverOpen)
+        XCTAssertEqual(decoded.popoverOpenRefreshCooldownSeconds, 120)
+    }
+
+    func testFiveMinuteRefreshIntervalIsNotRewrittenDuringMigration() async {
+        await MainActor.run {
+            var settings = AppSettings.default
+            settings.refreshIntervalSeconds = 300
+
+            XCTAssertEqual(SettingsStore.migrated(settings).refreshIntervalSeconds, 300)
+        }
+    }
 }

--- a/Tests/VibeBarCoreTests/QuotaForecastBarProjectionTests.swift
+++ b/Tests/VibeBarCoreTests/QuotaForecastBarProjectionTests.swift
@@ -1,0 +1,49 @@
+import XCTest
+
+@testable import VibeBarCore
+
+final class QuotaForecastBarProjectionTests: XCTestCase {
+    func testAtRiskIntervalKeepsUsedMarkerInsideVisibleBand() {
+        let projection = QuotaForecastBarProjection(
+            projectedUsedLowerPercent: 84,
+            projectedUsedUpperPercent: 116,
+            projectedUsedMedianPercent: 100,
+            displayMode: .used
+        )
+
+        XCTAssertEqual(projection.lowerPercent, 84)
+        XCTAssertEqual(projection.upperPercent, 100)
+        XCTAssertEqual(projection.medianPercent, 100)
+        XCTAssertTrue(projection.clipsUpperBound)
+        XCTAssertTrue(projection.lowerPercent...projection.upperPercent ~= projection.medianPercent)
+    }
+
+    func testAtRiskIntervalFlipsConsistentlyForRemainingMode() {
+        let projection = QuotaForecastBarProjection(
+            projectedUsedLowerPercent: 84,
+            projectedUsedUpperPercent: 116,
+            projectedUsedMedianPercent: 100,
+            displayMode: .remaining
+        )
+
+        XCTAssertEqual(projection.lowerPercent, 0)
+        XCTAssertEqual(projection.upperPercent, 16)
+        XCTAssertEqual(projection.medianPercent, 0)
+        XCTAssertTrue(projection.clipsLowerBound)
+        XCTAssertTrue(projection.lowerPercent...projection.upperPercent ~= projection.medianPercent)
+    }
+
+    func testProjectionDefensivelyIncludesMedianInMalformedInterval() {
+        let projection = QuotaForecastBarProjection(
+            projectedUsedLowerPercent: 40,
+            projectedUsedUpperPercent: 60,
+            projectedUsedMedianPercent: 75,
+            displayMode: .used
+        )
+
+        XCTAssertEqual(projection.lowerPercent, 40)
+        XCTAssertEqual(projection.upperPercent, 75)
+        XCTAssertEqual(projection.medianPercent, 75)
+        XCTAssertTrue(projection.lowerPercent...projection.upperPercent ~= projection.medianPercent)
+    }
+}

--- a/Tests/VibeBarCoreTests/QuotaRefreshSchedulerTests.swift
+++ b/Tests/VibeBarCoreTests/QuotaRefreshSchedulerTests.swift
@@ -20,6 +20,40 @@ final class QuotaRefreshSchedulerTests: XCTestCase {
         XCTAssertEqual(supplementalRefreshCount, 1)
     }
 
+    func testPopoverOpenRefreshHonorsToggleAndCooldown() {
+        var refreshCount = 0
+        let service = QuotaService(adapters: [:], mockProvider: { false })
+        let scheduler = QuotaRefreshScheduler(
+            service: service,
+            accountsProvider: { [] },
+            intervalProvider: { 600 },
+            onRefreshTriggered: { refreshCount += 1 }
+        )
+        let start = Date(timeIntervalSinceReferenceDate: 800_000_000)
+
+        XCTAssertFalse(scheduler.triggerRefreshForPopoverOpenIfNeeded(
+            enabled: false,
+            cooldownSeconds: 60,
+            now: start
+        ))
+        XCTAssertTrue(scheduler.triggerRefreshForPopoverOpenIfNeeded(
+            enabled: true,
+            cooldownSeconds: 60,
+            now: start
+        ))
+        XCTAssertFalse(scheduler.triggerRefreshForPopoverOpenIfNeeded(
+            enabled: true,
+            cooldownSeconds: 60,
+            now: start.addingTimeInterval(59)
+        ))
+        XCTAssertTrue(scheduler.triggerRefreshForPopoverOpenIfNeeded(
+            enabled: true,
+            cooldownSeconds: 60,
+            now: start.addingTimeInterval(60)
+        ))
+        XCTAssertEqual(refreshCount, 2)
+    }
+
     func testCredentialFailureDoesNotPoisonVisibleCachedQuota() async {
         let account = AccountIdentity(id: "cached-claude", tool: .claude, source: .oauthCLI)
         let service = QuotaService(

--- a/Tests/VibeBarCoreTests/SubscriptionWindowProgressTests.swift
+++ b/Tests/VibeBarCoreTests/SubscriptionWindowProgressTests.swift
@@ -92,4 +92,18 @@ final class SubscriptionWindowProgressTests: XCTestCase {
         )
         XCTAssertEqual(summary, "Resets soon · 99% used")
     }
+
+    func testRemainingModeUsesTheSameWindowWithRemainingPercent() {
+        let now = Date(timeIntervalSinceReferenceDate: 800_000_000)
+        let reset = now.addingTimeInterval(2 * 86_400)
+        let summary = SubscriptionWindowProgress.summary(
+            usedPercent: 56,
+            resetAt: reset,
+            rawWindowSeconds: 604_800,
+            displayMode: .remaining,
+            now: now
+        )
+
+        XCTAssertEqual(summary, "Day 6 of 7 · 44% left")
+    }
 }


### PR DESCRIPTION
## Summary
- replace duplicate provider quota cards with the forecast-aware Subscription Utilization surface while keeping Overview cards unchanged
- keep forecast bands, markers, labels, diagnostics, and reset summaries consistent with the Remaining/Used preference
- add a true sidebar settings layout, persisted popover-open refresh with configurable cooldown, and launch-at-login reconciliation
- document settings persistence and forecast coordinate rules in AGENTS.md

## Test plan
- [x] swift build
- [x] swift test (648 tests)
- [x] ./Scripts/build_app.sh release
- [x] codesign --verify --deep --strict ".build/Vibe Bar.app"
- [ ] manual visual capture (local uninstalled app launch was blocked by the execution environment)