### PR TITLE
Unify popover shell and provider settings

### DIFF
--- a/Sources/VibeBarApp/Controllers/SettingsWindowController.swift
+++ b/Sources/VibeBarApp/Controllers/SettingsWindowController.swift
@@ -26,7 +26,7 @@ final class SettingsWindowController: NSObject {
                 .environmentObject(environment.quotaService)
                 .environmentObject(environment.serviceStatus)
         )
-        let initialSize = NSSize(width: 980, height: 760)
+        let initialSize = NSSize(width: 1040, height: 780)
         let win = NSWindow(
             contentRect: NSRect(origin: .zero, size: initialSize),
             styleMask: [.titled, .closable, .resizable, .miniaturizable, .fullSizeContentView],
@@ -39,7 +39,7 @@ final class SettingsWindowController: NSObject {
         win.isReleasedWhenClosed = false
         win.contentViewController = hosting
         win.center()
-        win.minSize = NSSize(width: 820, height: 600)
+        win.minSize = NSSize(width: 900, height: 620)
         win.delegate = self
         self.window = win
 

--- a/Sources/VibeBarApp/Views/MiscProvidersPage.swift
+++ b/Sources/VibeBarApp/Views/MiscProvidersPage.swift
@@ -418,7 +418,7 @@ private struct MiscQuotaBody: View {
                     .font(.system(size: density.resetCountdownFontSize))
                     .foregroundStyle(.tertiary)
             }
-            if let countdown = ResetCountdownFormatter.string(from: bucket.resetAt) {
+            if let countdown = ResetCountdownFormatter.stringWithAbsoluteTime(from: bucket.resetAt) {
                 Text("Resets \(countdown)")
                     .font(.system(size: density.resetCountdownFontSize))
                     .foregroundStyle(.tertiary)

--- a/Sources/VibeBarApp/Views/PaceMarkerCapsule.swift
+++ b/Sources/VibeBarApp/Views/PaceMarkerCapsule.swift
@@ -66,9 +66,9 @@ struct PaceMarkerCapsule: View {
 ///
 /// The actual fill remains the dominant layer. A substantial neutral tick
 /// marks where usage should be *now* under a time-only pace. A
-/// status-colored tick marks the projected usage *at reset*. A soft,
-/// full-height gradient expresses the confidence interval as one integrated
-/// layer rather than looking like a second progress bar below the quota.
+/// status-colored tick marks the projected usage *at reset*. A quiet,
+/// full-height flat tint expresses the confidence interval behind both the
+/// fill and markers; it is intentionally not a second bar or a gradient.
 struct ForecastQuotaBar: View {
     let percent: Double
     let mode: DisplayMode
@@ -76,6 +76,8 @@ struct ForecastQuotaBar: View {
     let forecastProjection: QuotaForecastBarProjection
     let forecastColor: Color
     var height: CGFloat = 12
+
+    @Environment(\.colorScheme) private var colorScheme
 
     var body: some View {
         GeometryReader { proxy in
@@ -85,7 +87,7 @@ struct ForecastQuotaBar: View {
             let upper = forecastProjection.upperPercent / 100
             let median = forecastProjection.medianPercent / 100
             let timePace = timePacePercent.map { clamp($0, 0, 100) / 100 }
-            let forecastLineWidth = max(2.5, min(3.5, height * 0.25))
+            let forecastLineWidth = max(3.2, min(4.2, height * 0.30))
             let paceMarkerWidth = max(4.5, min(5.5, height * 0.42))
             let minimumBandWidth = forecastLineWidth + 6
             let band = confidenceBandLayout(
@@ -104,9 +106,7 @@ struct ForecastQuotaBar: View {
 
                 if forecastProjection.hasUncertainty {
                     Rectangle()
-                        .fill(
-                            confidenceGradient(lower: lower, upper: upper, median: median)
-                        )
+                        .fill(forecastColor.opacity(colorScheme == .dark ? 0.28 : 0.20))
                         .frame(width: band.width, height: height)
                         .offset(x: band.x)
                 }
@@ -119,14 +119,15 @@ struct ForecastQuotaBar: View {
 
                 ZStack {
                     RoundedRectangle(cornerRadius: 2, style: .continuous)
-                        .fill(Color.black.opacity(0.12))
-                        .frame(width: forecastLineWidth + 2, height: height)
+                        .fill(colorScheme == .dark ? Color.black.opacity(0.82) : Color.white.opacity(0.92))
+                        .frame(width: forecastLineWidth + 3, height: height)
                     RoundedRectangle(cornerRadius: forecastLineWidth / 2, style: .continuous)
                         .fill(forecastColor)
-                        .frame(width: forecastLineWidth, height: max(4, height - 1))
+                        .frame(width: forecastLineWidth, height: height)
+                        .shadow(color: Color.black.opacity(0.30), radius: 0.7)
                 }
-                .frame(width: forecastLineWidth + 2, height: height)
-                .offset(x: markerOffset(width: width, fraction: median, markerWidth: forecastLineWidth + 2))
+                .frame(width: forecastLineWidth + 3, height: height)
+                .offset(x: markerOffset(width: width, fraction: median, markerWidth: forecastLineWidth + 3))
             }
             .clipShape(Capsule(style: .continuous))
         }
@@ -163,25 +164,6 @@ struct ForecastQuotaBar: View {
         let bandWidth = min(width, minimumWidth)
         let center = (naturalStart + naturalEnd) / 2
         return (max(0, min(width - bandWidth, center - bandWidth / 2)), bandWidth)
-    }
-
-    private func confidenceGradient(lower: Double, upper: Double, median: Double) -> LinearGradient {
-        let visibleSpan = upper - lower
-        let medianLocation = visibleSpan > 0
-            ? clamp((median - lower) / visibleSpan, 0, 1)
-            : (forecastProjection.clipsLowerBound ? 0 : 1)
-        let leadingOpacity = forecastProjection.clipsLowerBound ? 0.44 : 0.10
-        let trailingOpacity = forecastProjection.clipsUpperBound ? 0.44 : 0.10
-        let peakLocation = min(max(medianLocation, 0.001), 0.999)
-        return LinearGradient(
-            gradient: Gradient(stops: [
-                .init(color: forecastColor.opacity(leadingOpacity), location: 0),
-                .init(color: forecastColor.opacity(0.48), location: peakLocation),
-                .init(color: forecastColor.opacity(trailingOpacity), location: 1),
-            ]),
-            startPoint: .leading,
-            endPoint: .trailing
-        )
     }
 
     private func neutralPaceMarker(width: CGFloat) -> some View {

--- a/Sources/VibeBarApp/Views/PopoverRoot.swift
+++ b/Sources/VibeBarApp/Views/PopoverRoot.swift
@@ -31,7 +31,6 @@ struct PopoverRoot: View {
                 onShowSettings: { environment.showSettingsWindow() }
             )
             .frame(height: shellDensity.headerHeight, alignment: .center)
-            .padding(.horizontal, shellDensity.cardPadding)
             .padding(.bottom, max(4, shellDensity.interSectionSpacing * 0.45))
             Divider()
                 .opacity(0.3)
@@ -50,21 +49,15 @@ struct PopoverRoot: View {
         .readHeight(onContentHeightChange)
     }
 
-    /// The tabbed popover is one shared shell. Provider pages may use their
-    /// own content metrics, but the title band and outer margins must never
-    /// shift when the selected tab changes.
+    /// The tabbed popover is one shared shell. The title band, content cards,
+    /// and outer margins all use the same density so switching pages never
+    /// shifts the left edge or changes the apparent workspace padding.
     private var shellDensity: Theme.Density {
         Theme.overviewDensity(for: settingsStore.settings.popoverDensity)
     }
 
     private var activeDensity: Theme.Density {
-        let profile = settingsStore.settings.popoverDensity
-        switch overviewPage {
-        case .overview, .misc:
-            return Theme.overviewDensity(for: profile)
-        case .openAI, .claude, .googleAI, .grok:
-            return Theme.detailDensity(for: profile)
-        }
+        shellDensity
     }
 
     private var maxScrollHeight: CGFloat {
@@ -128,9 +121,7 @@ struct PopoverRoot: View {
         }
         switch overviewPage {
         case .overview:
-            return ToolType.dedicatedCardProviders.filter {
-                settingsStore.settings.isCoreProviderVisible($0)
-            }
+            return settingsStore.settings.visibleCoreProviderList
         case .openAI: return [.codex]
         case .claude: return [.claude]
         case .googleAI: return ToolType.googleAIPair
@@ -233,6 +224,16 @@ private enum OverviewPage: String, CaseIterable, Identifiable {
         case .overview, .misc: return nil
         }
     }
+
+    static func page(for tool: ToolType) -> OverviewPage? {
+        switch tool.coreProviderRepresentative {
+        case .codex: return .openAI
+        case .claude: return .claude
+        case .gemini: return .googleAI
+        case .grok: return .grok
+        default: return nil
+        }
+    }
 }
 
 private struct OverviewPageSwitch: View {
@@ -242,10 +243,9 @@ private struct OverviewPageSwitch: View {
     @EnvironmentObject var settingsStore: SettingsStore
 
     private var visiblePages: [OverviewPage] {
-        OverviewPage.allCases.filter { page in
-            guard let provider = page.coreProvider else { return true }
-            return settingsStore.settings.isCoreProviderVisible(provider)
-        }
+        [.overview]
+            + settingsStore.settings.visibleCoreProviderList.compactMap(OverviewPage.page(for:))
+            + [.misc]
     }
 
     var body: some View {
@@ -366,25 +366,8 @@ private struct OverviewWaterfall: View {
                 spacing: density.interSectionSpacing,
                 session: masonrySession
             ) {
-                if isVisible(.codex) {
-                    ProviderQuotaCard(tool: .codex, density: density, compact: false)
-                        .overviewMasonryItem(id: "quota-codex", phase: .quota)
-                }
-                if isVisible(.claude) {
-                    ProviderQuotaCard(tool: .claude, density: density, compact: false)
-                        .overviewMasonryItem(id: "quota-claude", phase: .quota)
-                }
-                // Gemini Web and AntiGravity both roll up to the
-                // Gemini product, so the Overview surface shows them
-                // as a single L2 "Gemini" card with two L3 sub-sections
-                // (`GeminiCombinedCard`). Grok stays on its own card.
-                if isVisible(.gemini) {
-                    GeminiCombinedCard(density: density)
-                        .overviewMasonryItem(id: "quota-gemini", phase: .quota)
-                }
-                if isVisible(.grok) {
-                    ProviderQuotaCard(tool: .grok, density: density, compact: false)
-                        .overviewMasonryItem(id: "quota-grok", phase: .quota)
+                ForEach(settingsStore.settings.visibleCoreProviderList, id: \.self) { tool in
+                    overviewQuotaCard(for: tool)
                 }
                 if hasCostData {
                     CostHistoryView(
@@ -447,7 +430,21 @@ private struct OverviewWaterfall: View {
     /// (combined Gemini + AntiGravity) via `googleAICostSnapshot`, so it
     /// isn't listed here.
     private var overviewCostProviders: [ToolType] {
-        [.codex, .claude, .grok].filter(isVisible)
+        settingsStore.settings.visibleCoreProviderList.filter { tool in
+            tool == .codex || tool == .claude || tool == .grok
+        }
+    }
+
+    @ViewBuilder
+    private func overviewQuotaCard(for tool: ToolType) -> some View {
+        if tool == .gemini {
+            // Gemini Web and AntiGravity roll up to one Google AI product.
+            GeminiCombinedCard(density: density)
+                .overviewMasonryItem(id: "quota-gemini", phase: .quota)
+        } else {
+            ProviderQuotaCard(tool: tool, density: density, compact: false)
+                .overviewMasonryItem(id: "quota-\(tool.rawValue)", phase: .quota)
+        }
     }
 
     private func isVisible(_ tool: ToolType) -> Bool {
@@ -937,9 +934,7 @@ private struct CombinedTotalsRow: View {
                 OverviewStatusSummaryCard(
                     density: density,
                     minHeight: density.overviewSummaryHeight,
-                    tools: ToolType.combinedStatusPageProviders.filter {
-                        settingsStore.settings.isCoreProviderVisible($0)
-                    }
+                    tools: settingsStore.settings.visibleCoreProviderList
                 )
                     .frame(
                         minWidth: columnWidth,
@@ -1862,15 +1857,18 @@ private struct ProviderBucketRow: View {
                 Text(bucket.title)
                     .font(.system(size: density.bucketTitleFontSize, weight: .semibold))
                 if let resetAt = bucket.resetAt,
-                   let reset = ResetCountdownFormatter.string(from: resetAt, now: now) {
+                   let reset = ResetCountdownFormatter.stringWithAbsoluteTime(from: resetAt, now: now) {
                     Text("resets in \(reset)")
                         .font(.system(size: density.resetCountdownFontSize))
                         .foregroundStyle(.tertiary)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.72)
                 }
                 Spacer(minLength: 6)
                 Text("\(Int(percent.rounded()))%")
                     .font(.system(size: density.bucketPercentFontSize, weight: .semibold, design: .rounded).monospacedDigit())
                     .foregroundStyle(Theme.barColor(percent: percent, mode: mode))
+                    .fixedSize(horizontal: true, vertical: false)
             }
             if let forecast {
                 ForecastQuotaBar(

--- a/Sources/VibeBarApp/Views/QuotaBucketView.swift
+++ b/Sources/VibeBarApp/Views/QuotaBucketView.swift
@@ -20,7 +20,7 @@ struct QuotaBucketView: View {
             }
             QuotaBarShape(percent: percent, mode: mode, height: 12)
             HStack {
-                if let s = ResetCountdownFormatter.string(from: bucket.resetAt, now: now) {
+                if let s = ResetCountdownFormatter.stringWithAbsoluteTime(from: bucket.resetAt, now: now) {
                     Text("Resets in \(s)")
                         .font(.system(size: 11))
                         .foregroundStyle(.secondary)

--- a/Sources/VibeBarApp/Views/SettingsSidebarView.swift
+++ b/Sources/VibeBarApp/Views/SettingsSidebarView.swift
@@ -1,0 +1,331 @@
+import SwiftUI
+import UniformTypeIdentifiers
+import VibeBarCore
+
+/// One settings navigator for both static preferences and provider-specific
+/// configuration. Provider ordering is edited directly where it is consumed,
+/// rather than in a second, disconnected ordering screen.
+struct SettingsSidebarView: View {
+    static let width: CGFloat = 236
+
+    @EnvironmentObject private var settingsStore: SettingsStore
+    @Binding var selection: SettingsDestination
+
+    @State private var searchText = ""
+    @State private var draggedCoreProvider: ToolType?
+    @State private var draggedMiscProviderID: String?
+
+    private let basicPages: [SettingsSectionID] = [
+        .system,
+        .costData,
+        .keychain,
+        .privacy,
+        .menuBar,
+        .miniWindow,
+    ]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Text("Vibe Bar")
+                .font(.system(size: 22, weight: .bold, design: .rounded))
+                .padding(.horizontal, 18)
+                .padding(.top, 18)
+                .padding(.bottom, 12)
+
+            HStack(spacing: 7) {
+                Image(systemName: "magnifyingglass")
+                    .foregroundStyle(.secondary)
+                TextField("Search settings", text: $searchText)
+                    .textFieldStyle(.plain)
+            }
+            .padding(.horizontal, 10)
+            .frame(height: 31)
+            .background(
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .fill(Color.primary.opacity(0.055))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 8, style: .continuous)
+                            .stroke(Color.primary.opacity(0.08), lineWidth: 0.6)
+                    )
+            )
+            .padding(.horizontal, 14)
+            .padding(.bottom, 12)
+
+            ScrollView(.vertical, showsIndicators: false) {
+                VStack(alignment: .leading, spacing: 14) {
+                    if searchText.isEmpty || !filteredBasicPages.isEmpty {
+                        sidebarGroup("Settings") {
+                            ForEach(filteredBasicPages, id: \.rawValue) { page in
+                                staticRow(page)
+                            }
+                        }
+                    }
+
+                    if searchText.isEmpty || !filteredCoreProviders.isEmpty {
+                        sidebarGroup("Core Providers") {
+                            ForEach(filteredCoreProviders, id: \.self) { tool in
+                                coreProviderRow(tool)
+                                    .onDrag {
+                                        draggedCoreProvider = tool
+                                        return NSItemProvider(object: tool.rawValue as NSString)
+                                    }
+                                    .onDrop(
+                                        of: [.text],
+                                        delegate: SettingsCoreProviderDropDelegate(
+                                            target: tool,
+                                            dragged: $draggedCoreProvider,
+                                            settingsStore: settingsStore
+                                        )
+                                    )
+                            }
+                            if searchText.isEmpty {
+                                Color.clear
+                                    .frame(height: 6)
+                                    .contentShape(Rectangle())
+                                    .onDrop(
+                                        of: [.text],
+                                        delegate: SettingsCoreProviderDropDelegate(
+                                            target: nil,
+                                            dragged: $draggedCoreProvider,
+                                            settingsStore: settingsStore
+                                        )
+                                    )
+                            }
+                        }
+                    }
+
+                    if searchText.isEmpty || !filteredMiscProviders.isEmpty {
+                        sidebarGroup("Misc Providers") {
+                            ForEach(filteredMiscProviders) { instance in
+                                miscProviderRow(instance)
+                                    .onDrag {
+                                        draggedMiscProviderID = instance.id
+                                        return NSItemProvider(object: instance.id as NSString)
+                                    }
+                                    .onDrop(
+                                        of: [.text],
+                                        delegate: SettingsMiscProviderDropDelegate(
+                                            targetID: instance.id,
+                                            draggedID: $draggedMiscProviderID,
+                                            settingsStore: settingsStore
+                                        )
+                                    )
+                            }
+                            if searchText.isEmpty {
+                                Color.clear
+                                    .frame(height: 8)
+                                    .contentShape(Rectangle())
+                                    .onDrop(
+                                        of: [.text],
+                                        delegate: SettingsMiscProviderDropDelegate(
+                                            targetID: nil,
+                                            draggedID: $draggedMiscProviderID,
+                                            settingsStore: settingsStore
+                                        )
+                                    )
+                            }
+                        }
+                    }
+                }
+                .padding(.horizontal, 10)
+                .padding(.bottom, 18)
+            }
+        }
+        .frame(width: Self.width)
+        .background(Color.primary.opacity(0.035))
+    }
+
+    private var filteredBasicPages: [SettingsSectionID] {
+        guard !searchText.isEmpty else { return basicPages }
+        return basicPages.filter { $0.title.localizedCaseInsensitiveContains(searchText) }
+    }
+
+    private var filteredCoreProviders: [ToolType] {
+        settingsStore.settings.orderedCoreProviders.filter { tool in
+            searchText.isEmpty
+                || coreProviderTitle(tool).localizedCaseInsensitiveContains(searchText)
+        }
+    }
+
+    private var filteredMiscProviders: [MiscProviderInstance] {
+        settingsStore.settings.miscProviderInstances.filter { instance in
+            let title = instance.displayTitle(fallback: instance.tool.menuTitle)
+            return searchText.isEmpty
+                || title.localizedCaseInsensitiveContains(searchText)
+                || instance.tool.vendorName.localizedCaseInsensitiveContains(searchText)
+        }
+    }
+
+    private func sidebarGroup<Content: View>(
+        _ title: String,
+        @ViewBuilder content: () -> Content
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(title)
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundStyle(.tertiary)
+                .textCase(.uppercase)
+                .tracking(0.55)
+                .padding(.horizontal, 9)
+                .padding(.bottom, 2)
+            content()
+        }
+    }
+
+    private func staticRow(_ page: SettingsSectionID) -> some View {
+        sidebarRow(
+            destination: .page(page),
+            title: page.title,
+            icon: AnyView(
+                Image(systemName: page.systemImage)
+                    .font(.system(size: 14, weight: .medium))
+                    .frame(width: 20, height: 20)
+            ),
+            enabled: true,
+            showsStatusDot: false,
+            showsDragHandle: false
+        )
+    }
+
+    private func coreProviderRow(_ tool: ToolType) -> some View {
+        let enabled = settingsStore.settings.isCoreProviderVisible(tool)
+        return sidebarRow(
+            destination: .coreProvider(tool),
+            title: coreProviderTitle(tool),
+            icon: AnyView(ToolBrandIconView(tool: tool, size: 17).frame(width: 20, height: 20)),
+            enabled: enabled,
+            showsStatusDot: true,
+            showsDragHandle: true
+        )
+        .contextMenu {
+            Button(enabled ? "Hide from Overview" : "Show in Overview") {
+                settingsStore.settings.setCoreProviderVisible(!enabled, for: tool)
+            }
+        }
+    }
+
+    private func miscProviderRow(_ instance: MiscProviderInstance) -> some View {
+        let enabled = instance.isVisible
+        return sidebarRow(
+            destination: .miscProvider(instance.id),
+            title: instance.displayTitle(fallback: instance.tool.menuTitle),
+            icon: AnyView(ToolBrandIconView(tool: instance.tool, size: 17).frame(width: 20, height: 20)),
+            enabled: enabled,
+            showsStatusDot: true,
+            showsDragHandle: true
+        )
+        .contextMenu {
+            Button(enabled ? "Disable Provider" : "Enable Provider") {
+                settingsStore.settings.setMiscProviderInstanceVisible(!enabled, forID: instance.id)
+            }
+        }
+    }
+
+    private func sidebarRow(
+        destination: SettingsDestination,
+        title: String,
+        icon: AnyView,
+        enabled: Bool,
+        showsStatusDot: Bool,
+        showsDragHandle: Bool
+    ) -> some View {
+        let selected = selection == destination
+        return Button {
+            selection = destination
+        } label: {
+            HStack(spacing: 9) {
+                icon
+                    .opacity(enabled || selected ? 1 : 0.48)
+                Text(title)
+                    .font(.system(size: 13, weight: selected ? .semibold : .medium))
+                    .lineLimit(1)
+                Spacer(minLength: 4)
+                if showsStatusDot {
+                    Circle()
+                        .fill(enabled ? Color.green : Color.secondary.opacity(0.42))
+                        .frame(width: 6, height: 6)
+                }
+                if showsDragHandle {
+                    Image(systemName: "line.3.horizontal")
+                        .font(.system(size: 10, weight: .medium))
+                        .foregroundStyle(.tertiary)
+                }
+            }
+            .foregroundStyle(selected ? Color.primary : (enabled ? Color.primary : Color.secondary))
+            .padding(.horizontal, 9)
+            .frame(height: 33)
+            .background {
+                if selected {
+                    RoundedRectangle(cornerRadius: 7, style: .continuous)
+                        .fill(Color.accentColor.opacity(0.20))
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 7, style: .continuous)
+                                .stroke(Color.accentColor.opacity(0.32), lineWidth: 0.6)
+                        )
+                }
+            }
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .focusable(false)
+        .opacity(enabled || selected ? 1 : 0.62)
+    }
+
+    private func coreProviderTitle(_ tool: ToolType) -> String {
+        switch tool.coreProviderRepresentative {
+        case .codex: "OpenAI"
+        case .claude: "Anthropic"
+        case .gemini: "Google AI"
+        case .grok: "xAI"
+        default: tool.vendorName
+        }
+    }
+}
+
+private struct SettingsCoreProviderDropDelegate: DropDelegate {
+    let target: ToolType?
+    @Binding var dragged: ToolType?
+    let settingsStore: SettingsStore
+
+    func dropEntered(info: DropInfo) {
+        guard let dragged else { return }
+        if let target {
+            settingsStore.settings.moveCoreProvider(dragged, before: target)
+        } else {
+            settingsStore.settings.moveCoreProviderToEnd(dragged)
+        }
+    }
+
+    func performDrop(info: DropInfo) -> Bool {
+        dragged = nil
+        return true
+    }
+
+    func dropUpdated(info: DropInfo) -> DropProposal? {
+        DropProposal(operation: .move)
+    }
+}
+
+private struct SettingsMiscProviderDropDelegate: DropDelegate {
+    let targetID: String?
+    @Binding var draggedID: String?
+    let settingsStore: SettingsStore
+
+    func dropEntered(info: DropInfo) {
+        guard let draggedID else { return }
+        if let targetID {
+            settingsStore.settings.moveMiscProviderInstance(id: draggedID, before: targetID)
+        } else {
+            settingsStore.settings.moveMiscProviderInstanceToEnd(id: draggedID)
+        }
+    }
+
+    func performDrop(info: DropInfo) -> Bool {
+        draggedID = nil
+        return true
+    }
+
+    func dropUpdated(info: DropInfo) -> DropProposal? {
+        DropProposal(operation: .move)
+    }
+}

--- a/Sources/VibeBarApp/Views/SettingsView.swift
+++ b/Sources/VibeBarApp/Views/SettingsView.swift
@@ -1,10 +1,7 @@
 import SwiftUI
-import UniformTypeIdentifiers
 import VibeBarCore
 
-private enum SettingsSectionID: String, CaseIterable, Identifiable {
-    case general
-    case providerBadges
+enum SettingsSectionID: String {
     case menuBar
     case miniWindow
     case openAI
@@ -21,8 +18,6 @@ private enum SettingsSectionID: String, CaseIterable, Identifiable {
 
     var title: String {
         switch self {
-        case .general: "General"
-        case .providerBadges: "Provider Badges"
         case .menuBar: "Menu Bar"
         case .miniWindow: "Mini Window"
         case .openAI: "OpenAI"
@@ -39,8 +34,6 @@ private enum SettingsSectionID: String, CaseIterable, Identifiable {
 
     var systemImage: String {
         switch self {
-        case .general: "gearshape"
-        case .providerBadges: "person.text.rectangle"
         case .menuBar: "menubar.rectangle"
         case .miniWindow: "rectangle.on.rectangle"
         case .openAI: "brain.head.profile"
@@ -52,6 +45,44 @@ private enum SettingsSectionID: String, CaseIterable, Identifiable {
         case .costData: "chart.bar.xaxis"
         case .keychain: "key.fill"
         case .privacy: "hand.raised.fill"
+        }
+    }
+}
+
+enum SettingsDestination: Hashable {
+    case page(SettingsSectionID)
+    case coreProvider(ToolType)
+    case miscProvider(String)
+
+    var sectionID: SettingsSectionID {
+        switch self {
+        case let .page(section): section
+        case let .coreProvider(tool):
+            switch tool.coreProviderRepresentative {
+            case .codex: .openAI
+            case .claude: .anthropic
+            case .gemini: .googleAI
+            case .grok: .xAI
+            default: .openAI
+            }
+        case .miscProvider: .miscProviders
+        }
+    }
+
+    func title(settings: AppSettings) -> String {
+        switch self {
+        case let .page(section): return section.title
+        case let .coreProvider(tool):
+            switch tool.coreProviderRepresentative {
+            case .codex: return "OpenAI"
+            case .claude: return "Anthropic"
+            case .gemini: return "Google AI"
+            case .grok: return "xAI"
+            default: return tool.vendorName
+            }
+        case let .miscProvider(id):
+            guard let instance = settings.miscProviderInstance(id: id) else { return "Misc Provider" }
+            return instance.displayTitle(fallback: instance.tool.menuTitle)
         }
     }
 }
@@ -75,27 +106,27 @@ struct SettingsView: View {
     @State private var isAuthorizingKeychain: Bool = false
     @State private var keychainAuthorizationStatus: String?
     @State private var keychainAuthorizationSucceeded: Bool = false
-    @State private var draggedMiscProviderInstanceID: String?
-    @State private var selectedSection: SettingsSectionID = .general
+    @State private var selectedDestination: SettingsDestination = .page(.system)
+
+    private var selectedSection: SettingsSectionID {
+        selectedDestination.sectionID
+    }
 
     var body: some View {
         HStack(spacing: 0) {
-            settingsSidebar { section in
-                selectedSection = section
-            }
-            Divider()
+            SettingsSidebarView(selection: $selectedDestination)
 
             VStack(alignment: .leading, spacing: 0) {
                     HStack {
-                        Text(selectedSection.title)
+                        Text(selectedDestination.title(settings: settingsStore.settings))
                             .font(.system(size: 20, weight: .semibold))
                         Spacer()
-                        Button(action: dismiss) {
-                            Image(systemName: "xmark.circle.fill")
-                                .font(.system(size: 18))
-                                .foregroundStyle(.secondary)
-                        }
-                        .buttonStyle(.plain)
+                        BorderlessIconButton(
+                            systemImage: "xmark.circle.fill",
+                            help: "Close Settings",
+                            size: 15,
+                            action: dismiss
+                        )
                     }
                     .padding(.horizontal, 22)
                     .padding(.vertical, 16)
@@ -104,8 +135,21 @@ struct SettingsView: View {
 
                     ScrollView(.vertical, showsIndicators: true) {
                         VStack(alignment: .leading, spacing: 18) {
-                    if selectedSection == .general {
-                    settingsSection("General") {
+                    if selectedSection == .system {
+                    settingsSection("System") {
+                        Toggle("Launch at login", isOn: launchAtLoginBinding())
+                        Text(launchAtLoginStatusText)
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                        if let launchAtLoginError {
+                            Text(launchAtLoginError)
+                                .font(.caption2)
+                                .foregroundStyle(.orange)
+                        }
+                    }
+                    .id(SettingsSectionID.system.rawValue)
+
+                    settingsSection("Refreshing") {
                         Picker("Percent shows", selection: $settingsStore.settings.displayMode) {
                             ForEach(DisplayMode.allCases, id: \.self) { Text($0.label).tag($0) }
                         }
@@ -133,32 +177,14 @@ struct SettingsView: View {
                                 .foregroundStyle(.secondary)
                         }
                     }
-                    .id(SettingsSectionID.general.id)
-                    }
-
-                    if selectedSection == .providerBadges {
-                    settingsSection("Provider Badges") {
-                        Text("Leave a badge blank to use the detected account plan.")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                        VStack(alignment: .leading, spacing: 8) {
-                            ForEach(ToolType.dedicatedCardProviders, id: \.self) { tool in
-                                providerBadgeRow(tool)
-                            }
-                        }
-                    }
-                    .id(SettingsSectionID.providerBadges.id)
+                    .id("refreshing")
                     }
 
                     if selectedSection == .menuBar {
-                    settingsSection("Menu Bar Items") {
-                        VStack(alignment: .leading, spacing: 8) {
-                            ForEach(MenuBarItemKind.allCases) { kind in
-                                menuBarItemEditor(kind)
-                            }
-                        }
+                    settingsSection("Overview") {
+                        menuBarOverviewEditor()
                     }
-                    .id(SettingsSectionID.menuBar.id)
+                    .id(SettingsSectionID.menuBar.rawValue)
                     }
 
                     if selectedSection == .miniWindow {
@@ -209,7 +235,7 @@ struct SettingsView: View {
                             }
                         }
                     }
-                    .id(SettingsSectionID.miniWindow.id)
+                    .id(SettingsSectionID.miniWindow.rawValue)
                     }
 
                     if selectedSection == .openAI {
@@ -218,6 +244,7 @@ struct SettingsView: View {
                             representative: .codex,
                             healthProviders: [.codex]
                         )
+                        coreProviderPlanBadgeRows(for: [.codex])
                         Divider()
                             .padding(.vertical, 2)
                         Picker("Usage source", selection: $settingsStore.settings.codexUsageMode) {
@@ -278,6 +305,7 @@ struct SettingsView: View {
                             representative: .claude,
                             healthProviders: [.claude]
                         )
+                        coreProviderPlanBadgeRows(for: [.claude])
                         Divider()
                             .padding(.vertical, 2)
                         Picker("Usage source", selection: $settingsStore.settings.claudeUsageMode) {
@@ -338,6 +366,7 @@ struct SettingsView: View {
                             representative: .gemini,
                             healthProviders: [.gemini, .antigravity]
                         )
+                        coreProviderPlanBadgeRows(for: [.gemini, .antigravity])
                         Divider()
                             .padding(.vertical, 2)
                         Text("Gemini and Antigravity share the same Google AI subscription quota. Cookie import is the only supported web path — there is no WebView login.")
@@ -422,6 +451,7 @@ struct SettingsView: View {
                             representative: .grok,
                             healthProviders: [.grok]
                         )
+                        coreProviderPlanBadgeRows(for: [.grok])
                         Divider()
                             .padding(.vertical, 2)
                         Text("Vibe Bar can read Grok usage from `~/.grok/auth.json` (preferred — written by `grok login`) or from a signed-in grok.com browser session. Either source is enough.")
@@ -486,54 +516,16 @@ struct SettingsView: View {
                     }
 
                     if selectedSection == .miscProviders {
-                    settingsSection("Misc Providers") {
-                        Text("Usage-only integrations. Check providers to show them on the Misc page; hidden providers keep their saved setup.")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                        VStack(alignment: .leading, spacing: 10) {
-                            ForEach(settingsStore.settings.miscProviderInstances) { instance in
-                                MiscProviderSettingsSection(instance: instance)
-                                    .onDrag {
-                                        draggedMiscProviderInstanceID = instance.id
-                                        return NSItemProvider(object: instance.id as NSString)
-                                    }
-                                    .onDrop(
-                                        of: [UTType.text],
-                                        delegate: MiscProviderInstanceDropDelegate(
-                                            targetID: instance.id,
-                                            draggedID: $draggedMiscProviderInstanceID,
-                                            settingsStore: settingsStore
-                                        )
-                                    )
-                            }
-                            Color.clear
-                                .frame(height: 8)
-                                .onDrop(
-                                    of: [UTType.text],
-                                    delegate: MiscProviderInstanceDropDelegate(
-                                        targetID: nil,
-                                        draggedID: $draggedMiscProviderInstanceID,
-                                        settingsStore: settingsStore
-                                    )
-                                )
+                    if case let .miscProvider(instanceID) = selectedDestination,
+                       let instance = settingsStore.settings.miscProviderInstance(id: instanceID) {
+                        MiscProviderSettingsSection(instance: instance)
+                    } else {
+                        settingsSection("Misc Provider") {
+                            Text("Select a provider from the sidebar. Hidden providers keep their saved setup and credentials.")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
                         }
                     }
-                    .id(SettingsSectionID.miscProviders.id)
-                    }
-
-                    if selectedSection == .system {
-                    settingsSection("System") {
-                        Toggle("Launch at login", isOn: launchAtLoginBinding())
-                        Text(launchAtLoginStatusText)
-                            .font(.caption2)
-                            .foregroundStyle(.secondary)
-                        if let launchAtLoginError {
-                            Text(launchAtLoginError)
-                                .font(.caption2)
-                                .foregroundStyle(.orange)
-                        }
-                    }
-                    .id(SettingsSectionID.system.id)
                     }
 
                     if selectedSection == .costData {
@@ -606,43 +598,6 @@ struct SettingsView: View {
         .onAppear(perform: refreshLaunchAtLoginState)
     }
 
-    private func settingsSidebar(onSelect: @escaping (SettingsSectionID) -> Void) -> some View {
-        ScrollView(.vertical, showsIndicators: false) {
-            VStack(alignment: .leading, spacing: 4) {
-                Text("Vibe Bar")
-                    .font(.system(size: 17, weight: .semibold))
-                    .padding(.horizontal, 12)
-                    .padding(.bottom, 10)
-                ForEach(SettingsSectionID.allCases) { section in
-                    Button {
-                        onSelect(section)
-                    } label: {
-                        HStack(spacing: 9) {
-                            Image(systemName: section.systemImage)
-                                .frame(width: 18)
-                            Text(section.title)
-                                .lineLimit(1)
-                            Spacer(minLength: 0)
-                        }
-                        .font(.system(size: 13, weight: selectedSection == section ? .semibold : .regular))
-                        .foregroundStyle(selectedSection == section ? Color.white : Color.primary)
-                        .padding(.horizontal, 10)
-                        .frame(height: 34)
-                        .background(
-                            RoundedRectangle(cornerRadius: 7, style: .continuous)
-                                .fill(selectedSection == section ? Color.accentColor : Color.clear)
-                        )
-                        .contentShape(Rectangle())
-                    }
-                    .buttonStyle(.plain)
-                }
-            }
-            .padding(14)
-        }
-        .frame(width: 205)
-        .background(Color.primary.opacity(0.035))
-    }
-
     private func settingsSection<Content: View>(
         _ title: String,
         @ViewBuilder content: () -> Content
@@ -702,6 +657,14 @@ struct SettingsView: View {
                 )
             }
         }
+        .overlay(alignment: .leading) {
+            Rectangle()
+                .fill(Color(nsColor: .separatorColor).opacity(0.72))
+                .frame(width: 1)
+                .offset(x: SettingsSidebarView.width)
+                .ignoresSafeArea(.container, edges: .vertical)
+                .allowsHitTesting(false)
+        }
     }
 
     private func coreProviderSummary(
@@ -732,6 +695,20 @@ struct SettingsView: View {
                 .toggleStyle(.switch)
                 .controlSize(.small)
                 .font(.caption)
+        }
+    }
+
+    private func coreProviderPlanBadgeRows(for tools: [ToolType]) -> some View {
+        VStack(alignment: .leading, spacing: 7) {
+            Text("Plan badge")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            ForEach(tools, id: \.self) { tool in
+                providerBadgeRow(tool)
+            }
+            Text("Leave blank to use the detected account plan.")
+                .font(.caption2)
+                .foregroundStyle(.tertiary)
         }
     }
 
@@ -792,51 +769,32 @@ struct SettingsView: View {
         }
     }
 
-    private func menuBarItemEditor(_ kind: MenuBarItemKind) -> some View {
-        DisclosureGroup {
-            VStack(alignment: .leading, spacing: 10) {
-                Toggle("Show in menu bar", isOn: menuItemVisibleBinding(kind))
-                Toggle("Show title text", isOn: menuItemTitleBinding(kind))
-                Picker("Layout", selection: menuItemLayoutBinding(kind)) {
-                    ForEach(MenuBarLayout.allCases) { layout in
-                        Text(layout.label).tag(layout)
-                    }
-                }
-                .pickerStyle(.segmented)
-                Picker("Display density", selection: popoverDensityBinding()) {
-                    ForEach(PopoverDensity.allCases) { Text($0.label).tag($0) }
-                }
-                .pickerStyle(.segmented)
-                Text(settingsStore.settings.popoverDensity.detail)
-                    .font(.caption2)
-                    .foregroundStyle(.tertiary)
-                if !MenuBarFieldCatalog.fields(for: kind).isEmpty {
-                    Text("Fields")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                        .padding(.top, 2)
-                    menuItemFieldList(for: kind)
+    private func menuBarOverviewEditor() -> some View {
+        let kind = MenuBarItemKind.compact
+        return VStack(alignment: .leading, spacing: 10) {
+            Toggle("Show in menu bar", isOn: menuItemVisibleBinding(kind))
+            Toggle("Show title text", isOn: menuItemTitleBinding(kind))
+            Picker("Layout", selection: menuItemLayoutBinding(kind)) {
+                ForEach(MenuBarLayout.allCases) { layout in
+                    Text(layout.label).tag(layout)
                 }
             }
-            .padding(.top, 8)
-        } label: {
-            HStack(spacing: 8) {
-                if settingsStore.settings.menuBarItem(kind).layout.showsMenuBarIcon {
-                    ProviderBrandIconView(kind: kind, size: 16)
-                }
-                Text(kind.label)
-                    .font(.system(size: 13, weight: .semibold))
-                Spacer(minLength: 8)
-                Text(settingsStore.settings.menuBarItem(kind).layout.label)
-                    .font(.caption2)
-                    .foregroundStyle(.tertiary)
+            .pickerStyle(.segmented)
+            Picker("Display density", selection: popoverDensityBinding()) {
+                ForEach(PopoverDensity.allCases) { Text($0.label).tag($0) }
+            }
+            .pickerStyle(.segmented)
+            Text(settingsStore.settings.popoverDensity.detail)
+                .font(.caption2)
+                .foregroundStyle(.tertiary)
+            if !MenuBarFieldCatalog.fields(for: kind).isEmpty {
+                Text("Fields")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .padding(.top, 2)
+                menuItemFieldList(for: kind)
             }
         }
-        .padding(10)
-        .background(
-            RoundedRectangle(cornerRadius: 7, style: .continuous)
-                .fill(Color.primary.opacity(0.035))
-        )
     }
 
     private func launchAtLoginBinding() -> Binding<Bool> {
@@ -1258,31 +1216,6 @@ struct SettingsView: View {
         case 365 * 3: return "3 years"
         default: return "\(days) days"
         }
-    }
-}
-
-private struct MiscProviderInstanceDropDelegate: DropDelegate {
-    let targetID: String?
-    @Binding var draggedID: String?
-    let settingsStore: SettingsStore
-
-    func dropEntered(info: DropInfo) {
-        guard let draggedID else { return }
-        if let targetID {
-            guard draggedID != targetID else { return }
-            settingsStore.settings.moveMiscProviderInstance(id: draggedID, before: targetID)
-        } else {
-            settingsStore.settings.moveMiscProviderInstanceToEnd(id: draggedID)
-        }
-    }
-
-    func dropUpdated(info: DropInfo) -> DropProposal? {
-        DropProposal(operation: .move)
-    }
-
-    func performDrop(info: DropInfo) -> Bool {
-        draggedID = nil
-        return true
     }
 }
 

--- a/Sources/VibeBarApp/Views/SubscriptionUtilizationView.swift
+++ b/Sources/VibeBarApp/Views/SubscriptionUtilizationView.swift
@@ -176,11 +176,12 @@ struct SubscriptionUtilizationView: View {
                     .font(.system(size: density.bucketTitleFontSize, weight: .semibold))
                     .lineLimit(1)
                 if let resetAt = bucket.resetAt,
-                   let reset = ResetCountdownFormatter.string(from: resetAt, now: now) {
+                   let reset = ResetCountdownFormatter.stringWithAbsoluteTime(from: resetAt, now: now) {
                     Text("resets in \(reset)")
                         .font(.system(size: density.resetCountdownFontSize))
                         .foregroundStyle(.tertiary)
                         .lineLimit(1)
+                        .minimumScaleFactor(0.72)
                 }
                 Spacer(minLength: 6)
                 Text(percentLabel(used: used))

--- a/Sources/VibeBarCore/Models/AppSettings.swift
+++ b/Sources/VibeBarCore/Models/AppSettings.swift
@@ -22,6 +22,11 @@ public struct AppSettings: Codable, Equatable, Sendable {
     /// credentials, refresh schedule, and history intact; it only removes the
     /// provider's Overview card, totals contribution, status tile, and tab.
     public var visibleCoreProviders: Set<ToolType>
+    /// User-controlled order for the four core provider families. The same
+    /// order drives Settings, the popover switcher, and Overview quota cards.
+    /// Missing providers are appended so older settings files automatically
+    /// pick up newly introduced core providers.
+    public var coreProviderOrder: [ToolType]
     /// Per-misc-provider non-sensitive config (source mode, region,
     /// enterprise host, etc.). Sensitive credentials live in Keychain
     /// (`MiscCredentialStore` / `CookieHeaderCache`), never in this map. The
@@ -58,6 +63,7 @@ public struct AppSettings: Codable, Equatable, Sendable {
         popoverDensity: .regular,
         providerPlanLabels: Self.defaultProviderPlanLabels,
         visibleCoreProviders: Self.defaultVisibleCoreProviders,
+        coreProviderOrder: Self.defaultCoreProviderOrder,
         miscProviders: Self.defaultMiscProviders,
         visibleMiscProviders: Self.defaultVisibleMiscProviders,
         miscProviderOrder: Self.defaultMiscProviderOrder,
@@ -91,6 +97,10 @@ public struct AppSettings: Codable, Equatable, Sendable {
 
     public static var defaultVisibleCoreProviders: Set<ToolType> {
         Set(ToolType.coreProviderRepresentatives)
+    }
+
+    public static var defaultCoreProviderOrder: [ToolType] {
+        ToolType.coreProviderRepresentatives
     }
 
     /// Default `MiscProviderSettings` for every misc-page provider. Source
@@ -135,6 +145,7 @@ public struct AppSettings: Codable, Equatable, Sendable {
         popoverDensity: PopoverDensity = .regular,
         providerPlanLabels: [ToolType: String] = AppSettings.defaultProviderPlanLabels,
         visibleCoreProviders: Set<ToolType> = AppSettings.defaultVisibleCoreProviders,
+        coreProviderOrder: [ToolType] = AppSettings.defaultCoreProviderOrder,
         miscProviders: [ToolType: MiscProviderSettings] = AppSettings.defaultMiscProviders,
         visibleMiscProviders: Set<ToolType> = AppSettings.defaultVisibleMiscProviders,
         miscProviderOrder: [ToolType] = AppSettings.defaultMiscProviderOrder,
@@ -157,6 +168,7 @@ public struct AppSettings: Codable, Equatable, Sendable {
         self.popoverDensity = popoverDensity
         self.providerPlanLabels = Self.normalizedProviderPlanLabels(providerPlanLabels)
         self.visibleCoreProviders = Self.normalizedVisibleCoreProviders(visibleCoreProviders)
+        self.coreProviderOrder = Self.normalizedCoreProviderOrder(coreProviderOrder)
         let normalizedLegacyProviders = Self.normalizedMiscProviders(miscProviders)
         let normalizedVisibleProviders = Self.normalizedVisibleMiscProviders(visibleMiscProviders)
         let normalizedProviderOrder = Self.normalizedMiscProviderOrder(miscProviderOrder)
@@ -190,6 +202,7 @@ public struct AppSettings: Codable, Equatable, Sendable {
         case popoverDensity   // legacy single-value form
         case providerPlanLabels
         case visibleCoreProviders
+        case coreProviderOrder
         case miscProviders
         case visibleMiscProviders
         case miscProviderOrder
@@ -254,6 +267,14 @@ public struct AppSettings: Codable, Equatable, Sendable {
             self.visibleCoreProviders = Self.normalizedVisibleCoreProviders(decoded)
         } else {
             self.visibleCoreProviders = Self.defaultVisibleCoreProviders
+        }
+
+        if let rawOrder = try c.decodeIfPresent([String].self, forKey: .coreProviderOrder) {
+            self.coreProviderOrder = Self.normalizedCoreProviderOrder(
+                rawOrder.compactMap(ToolType.init(rawValue:))
+            )
+        } else {
+            self.coreProviderOrder = Self.defaultCoreProviderOrder
         }
 
         // Misc providers: lossy decode keyed by ToolType raw value.
@@ -335,6 +356,7 @@ public struct AppSettings: Codable, Equatable, Sendable {
             .filter { normalizedVisibleCore.contains($0) }
             .map(\.rawValue)
         try c.encode(visibleCoreRaw, forKey: .visibleCoreProviders)
+        try c.encode(coreProviderOrder.map(\.rawValue), forKey: .coreProviderOrder)
         let miscRaw = Dictionary(uniqueKeysWithValues: miscProviders.map { ($0.key.rawValue, $0.value) })
         try c.encode(miscRaw, forKey: .miscProviders)
         let visibleRaw = ToolType.miscPageProviders
@@ -401,6 +423,35 @@ public struct AppSettings: Codable, Equatable, Sendable {
         visibleCoreProviders = Self.normalizedVisibleCoreProviders(visibleCoreProviders)
     }
 
+    public var orderedCoreProviders: [ToolType] {
+        Self.normalizedCoreProviderOrder(coreProviderOrder)
+    }
+
+    public var visibleCoreProviderList: [ToolType] {
+        orderedCoreProviders.filter(isCoreProviderVisible)
+    }
+
+    public mutating func moveCoreProvider(_ tool: ToolType, before target: ToolType) {
+        let source = tool.coreProviderRepresentative
+        let destination = target.coreProviderRepresentative
+        guard let source, let destination, source != destination else { return }
+        var order = orderedCoreProviders
+        guard let from = order.firstIndex(of: source),
+              let targetIndex = order.firstIndex(of: destination) else { return }
+        let item = order.remove(at: from)
+        let adjustedTarget = from < targetIndex ? targetIndex - 1 : targetIndex
+        order.insert(item, at: adjustedTarget)
+        coreProviderOrder = Self.normalizedCoreProviderOrder(order)
+    }
+
+    public mutating func moveCoreProviderToEnd(_ tool: ToolType) {
+        guard let representative = tool.coreProviderRepresentative else { return }
+        var order = orderedCoreProviders
+        guard let from = order.firstIndex(of: representative) else { return }
+        order.append(order.remove(at: from))
+        coreProviderOrder = Self.normalizedCoreProviderOrder(order)
+    }
+
     private static func normalizedMenuBarItems(_ items: [MenuBarItemSettings]) -> [MenuBarItemSettings] {
         [
             items.first { $0.kind == .compact }.map(migratedMenuBarItem)
@@ -421,6 +472,20 @@ public struct AppSettings: Codable, Equatable, Sendable {
 
     private static func normalizedVisibleCoreProviders(_ providers: Set<ToolType>) -> Set<ToolType> {
         Set(providers.compactMap(\.coreProviderRepresentative))
+    }
+
+    private static func normalizedCoreProviderOrder(_ order: [ToolType]) -> [ToolType] {
+        var seen = Set<ToolType>()
+        var normalized: [ToolType] = []
+        for tool in order {
+            guard let representative = tool.coreProviderRepresentative,
+                  seen.insert(representative).inserted else { continue }
+            normalized.append(representative)
+        }
+        for tool in ToolType.coreProviderRepresentatives where seen.insert(tool).inserted {
+            normalized.append(tool)
+        }
+        return normalized
     }
 
     /// Fill in defaults for any misc-page provider missing from the

--- a/Sources/VibeBarCore/Utilities/ResetCountdownFormatter.swift
+++ b/Sources/VibeBarCore/Utilities/ResetCountdownFormatter.swift
@@ -1,6 +1,11 @@
 import Foundation
 
 public enum ResetCountdownFormatter {
+    private static let shortMonthNames = [
+        "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+        "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+    ]
+
     /// Formats a future reset date as a compact human countdown:
     /// "5d", "2d 4h", "3h 16m", "12m", "<1m", "now".
     /// Returns nil if `resetAt` is nil.
@@ -26,6 +31,36 @@ public enum ResetCountdownFormatter {
             return "\(minutes)m"
         }
         return "<1m"
+    }
+
+    /// Combines the compact countdown with the concrete local reset time.
+    /// Same-day resets stay compact ("3h 16m · 18:30"); later resets include
+    /// the calendar date ("2d 4h · Jul 24, 09:00") so the user never has to
+    /// mentally derive the exact reset from a relative duration.
+    public static func stringWithAbsoluteTime(
+        from resetAt: Date?,
+        now: Date = Date(),
+        calendar: Calendar = .current,
+        timeZone: TimeZone = .current
+    ) -> String? {
+        guard let resetAt, let countdown = string(from: resetAt, now: now) else { return nil }
+        var calendar = calendar
+        calendar.timeZone = timeZone
+
+        let components = calendar.dateComponents([.year, .month, .day, .hour, .minute], from: resetAt)
+        guard let year = components.year,
+              let month = components.month,
+              let day = components.day,
+              let hour = components.hour,
+              let minute = components.minute,
+              shortMonthNames.indices.contains(month - 1) else { return countdown }
+        let time = String(format: "%02d:%02d", hour, minute)
+        if calendar.isDate(resetAt, inSameDayAs: now) {
+            return "\(countdown) · \(time)"
+        } else if calendar.component(.year, from: resetAt) == calendar.component(.year, from: now) {
+            return "\(countdown) · \(shortMonthNames[month - 1]) \(day), \(time)"
+        }
+        return "\(countdown) · \(shortMonthNames[month - 1]) \(day), \(year), \(time)"
     }
 
     /// "Updated 10 seconds ago", "Updated 3 minutes ago", "Updated just now",

--- a/Tests/VibeBarCoreTests/AppSettingsTests.swift
+++ b/Tests/VibeBarCoreTests/AppSettingsTests.swift
@@ -30,6 +30,7 @@ final class AppSettingsTests: XCTestCase {
         XCTAssertTrue(settings.miniWindow.selectedFieldIds.contains("claude.daily_routines"))
         XCTAssertNil(settings.miniWindow.customLabels["codex.five_hour"])
         XCTAssertEqual(settings.visibleCoreProviders, AppSettings.defaultVisibleCoreProviders)
+        XCTAssertEqual(settings.coreProviderOrder, AppSettings.defaultCoreProviderOrder)
         XCTAssertEqual(settings.costData.retentionDays, CostDataSettings.defaultRetentionDays)
         XCTAssertEqual(settings.costData.retentionDays, CostDataSettings.unlimitedRetentionDays)
         XCTAssertFalse(settings.costData.privacyModeEnabled)
@@ -397,6 +398,34 @@ final class AppSettingsTests: XCTestCase {
         let settings = try JSONDecoder().decode(AppSettings.self, from: Data(json.utf8))
 
         XCTAssertEqual(settings.visibleCoreProviders, Set([.codex, .gemini]))
+    }
+
+    func testCoreProviderOrderNormalizesAliasesDuplicatesAndUnknownValues() throws {
+        let json = """
+        {
+          "coreProviderOrder": ["grok", "antigravity", "minimax", "grok"]
+        }
+        """
+
+        let settings = try JSONDecoder().decode(AppSettings.self, from: Data(json.utf8))
+
+        XCTAssertEqual(settings.orderedCoreProviders, [.grok, .gemini, .codex, .claude])
+    }
+
+    func testCoreProviderOrderMovesAndRoundTrips() throws {
+        var settings = AppSettings.default
+        settings.moveCoreProvider(.grok, before: .codex)
+        settings.moveCoreProvider(.claude, before: .gemini)
+        settings.setCoreProviderVisible(false, for: .codex)
+
+        XCTAssertEqual(settings.orderedCoreProviders, [.grok, .codex, .claude, .gemini])
+        XCTAssertEqual(settings.visibleCoreProviderList, [.grok, .claude, .gemini])
+
+        let data = try JSONEncoder().encode(settings)
+        let decoded = try JSONDecoder().decode(AppSettings.self, from: data)
+
+        XCTAssertEqual(decoded.orderedCoreProviders, settings.orderedCoreProviders)
+        XCTAssertEqual(decoded.visibleCoreProviderList, settings.visibleCoreProviderList)
     }
 
     func testRefreshPreferencesRoundTrip() throws {

--- a/Tests/VibeBarCoreTests/ResetCountdownFormatterTests.swift
+++ b/Tests/VibeBarCoreTests/ResetCountdownFormatterTests.swift
@@ -1,0 +1,69 @@
+import Foundation
+import XCTest
+@testable import VibeBarCore
+
+final class ResetCountdownFormatterTests: XCTestCase {
+    private let timeZone = TimeZone(secondsFromGMT: 0)!
+
+    func testAbsoluteResetTimeUsesTimeOnlyForSameDay() {
+        let now = date(2026, 7, 21, 8, 0)
+        let reset = date(2026, 7, 21, 12, 30)
+
+        XCTAssertEqual(
+            ResetCountdownFormatter.stringWithAbsoluteTime(
+                from: reset,
+                now: now,
+                calendar: calendar,
+                timeZone: timeZone
+            ),
+            "4h 30m · 12:30"
+        )
+    }
+
+    func testAbsoluteResetTimeIncludesDateAcrossDays() {
+        let now = date(2026, 7, 21, 8, 0)
+        let reset = date(2026, 7, 24, 12, 0)
+
+        XCTAssertEqual(
+            ResetCountdownFormatter.stringWithAbsoluteTime(
+                from: reset,
+                now: now,
+                calendar: calendar,
+                timeZone: timeZone
+            ),
+            "3d 4h · Jul 24, 12:00"
+        )
+    }
+
+    func testAbsoluteResetTimeIncludesYearAcrossYears() {
+        let now = date(2026, 12, 31, 23, 0)
+        let reset = date(2027, 1, 1, 1, 0)
+
+        XCTAssertEqual(
+            ResetCountdownFormatter.stringWithAbsoluteTime(
+                from: reset,
+                now: now,
+                calendar: calendar,
+                timeZone: timeZone
+            ),
+            "2h · Jan 1, 2027, 01:00"
+        )
+    }
+
+    private var calendar: Calendar {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = timeZone
+        return calendar
+    }
+
+    private func date(_ year: Int, _ month: Int, _ day: Int, _ hour: Int, _ minute: Int) -> Date {
+        calendar.date(from: DateComponents(
+            timeZone: timeZone,
+            year: year,
+            month: month,
+            day: day,
+            hour: hour,
+            minute: minute
+        ))!
+    }
+}


### PR DESCRIPTION
## Summary
- unify Overview, provider, and Misc pages under one popover inset and density shell
- replace the Settings category maze with ordered Core and Misc provider sidebars using official brand icons
- simplify Overview menu-bar settings, remove close-button focus chrome, and restore the full-height sidebar divider
- replace the forecast gradient with a full-height flat confidence band and stronger forecast marker
- append exact local reset timestamps to relative quota countdowns

## Test plan
- [x] swift build
- [x] swift test (653 tests)
- [x] ./Scripts/build_app.sh release
- [x] codesign --verify --deep --strict ".build/Vibe Bar.app"
- [x] verified empty entitlements (no app sandbox)