### PR TITLE
Consolidate credentials and polish quota displays

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -292,9 +292,15 @@ Vibe Bar persists derived data under the user's **real** home directory:
 If you are debugging odd behavior, that directory is the place to look.
 Deleting it resets the app to first-run state.
 
-Keychain stores Vibe Bar-owned OpenAI / Claude Web cookies, split by
-source (`browser` vs `WebView`), plus the resolved Claude organization
-ID — those are not in `~/.vibebar/`. Legacy plaintext cookie files under
+Keychain stores one Vibe Bar credential Vault
+(`com.astroqore.VibeBar.credential-vault` / `vault-v1`). Its versioned
+JSON payload keeps OpenAI / Claude / Gemini / Grok Web cookies logically
+split by source (`browser` vs `WebView`), plus the resolved Claude
+organization ID and misc-provider secrets. The single-item design is
+intentional: ad-hoc rebuilds change the app's Keychain ACL identity, so
+Settings can repair one Vault instead of triggering one authorization per
+secret. Never put external CLI credentials or browser Safe Storage keys in
+this Vault. Legacy plaintext cookie files under
 `~/.vibebar/cookies/` may be read once for migration and must be deleted
 immediately afterward. The app reads (never writes) Codex and Claude CLI
 credential files and their session JSONL logs. Treat those as read-only
@@ -444,7 +450,9 @@ What is **not** allowed in any commit:
 - Logging raw credentials or email addresses. Route through
   `SafeLog.sanitize` and `EmailMasker`.
 - Persisting OpenAI / Claude Web cookies, session keys, or resolved
-  organization IDs in plaintext. Use the Vibe Bar-owned Keychain service;
+  organization IDs in plaintext. Use the single Vibe Bar-owned credential
+  Vault; keep logical service/account keys inside its payload and do not
+  create a new physical Keychain item per secret;
   `~/.vibebar/cookies/` is migration-only.
 - Re-enabling the app sandbox in `Resources/VibeBar.entitlements`
   *without coordinating the misc-providers feature first*. Vibe Bar is

--- a/Sources/VibeBarApp/Views/PaceMarkerCapsule.swift
+++ b/Sources/VibeBarApp/Views/PaceMarkerCapsule.swift
@@ -98,17 +98,27 @@ struct ForecastQuotaBar: View {
             )
 
             ZStack(alignment: .leading) {
-                Capsule(style: .continuous)
-                    .fill(Theme.barTrack)
-                Capsule(style: .continuous)
-                    .fill(Theme.barColor(percent: percent, mode: mode))
-                    .frame(width: max(height, width * fillFraction))
+                ZStack(alignment: .leading) {
+                    Capsule(style: .continuous)
+                        .fill(Theme.barTrack)
+                    Capsule(style: .continuous)
+                        .fill(Theme.barColor(percent: percent, mode: mode))
+                        .frame(width: max(height, width * fillFraction))
+                }
+                .clipShape(Capsule(style: .continuous))
 
                 if forecastProjection.hasUncertainty {
-                    Rectangle()
-                        .fill(forecastColor.opacity(colorScheme == .dark ? 0.28 : 0.20))
-                        .frame(width: band.width, height: height)
-                        .offset(x: band.x)
+                    RoundedRectangle(cornerRadius: (height + 6) / 2, style: .continuous)
+                        .fill(forecastColor.opacity(colorScheme == .dark ? 0.22 : 0.15))
+                        .overlay {
+                            RoundedRectangle(cornerRadius: (height + 6) / 2, style: .continuous)
+                                .stroke(
+                                    forecastColor.opacity(colorScheme == .dark ? 0.30 : 0.22),
+                                    lineWidth: 0.8
+                                )
+                        }
+                        .frame(width: band.width, height: height + 6)
+                        .offset(x: band.x, y: -3)
                 }
 
                 if let timePace, timePacePercent.map({ $0 > 2 && $0 < 98 }) == true {
@@ -129,7 +139,6 @@ struct ForecastQuotaBar: View {
                 .frame(width: forecastLineWidth + 3, height: height)
                 .offset(x: markerOffset(width: width, fraction: median, markerWidth: forecastLineWidth + 3))
             }
-            .clipShape(Capsule(style: .continuous))
         }
         .frame(height: height)
     }

--- a/Sources/VibeBarApp/Views/PopoverRoot.swift
+++ b/Sources/VibeBarApp/Views/PopoverRoot.swift
@@ -16,6 +16,7 @@ struct PopoverRoot: View {
     var body: some View {
         let shellDensity = shellDensity
         let contentDensity = activeDensity
+        let shellContentWidth = max(0, width - shellDensity.popoverPaddingH * 2)
         VStack(alignment: .leading, spacing: 0) {
             HeaderView(
                 title: headerTitle,
@@ -42,9 +43,13 @@ struct PopoverRoot: View {
             }
             .frame(maxHeight: maxScrollHeight)
         }
+        // Provider pages have a narrower intrinsic HStack than Overview and
+        // Misc. Pin the shared shell's inner width before adding padding so
+        // SwiftUI never centers those pages inside the outer frame.
+        .frame(width: shellContentWidth, alignment: .topLeading)
         .padding(.horizontal, shellDensity.popoverPaddingH)
         .padding(.vertical, shellDensity.popoverPaddingV)
-        .frame(width: width)
+        .frame(width: width, alignment: .topLeading)
         .fixedSize(horizontal: false, vertical: true)
         .readHeight(onContentHeightChange)
     }
@@ -1859,10 +1864,11 @@ private struct ProviderBucketRow: View {
                 if let resetAt = bucket.resetAt,
                    let reset = ResetCountdownFormatter.stringWithAbsoluteTime(from: resetAt, now: now) {
                     Text("resets in \(reset)")
-                        .font(.system(size: density.resetCountdownFontSize))
+                        .font(.system(size: resetCountdownFontSize))
                         .foregroundStyle(.tertiary)
                         .lineLimit(1)
-                        .minimumScaleFactor(0.72)
+                        .minimumScaleFactor(tool == .antigravity ? 0.92 : 0.80)
+                        .layoutPriority(tool == .antigravity ? 1 : 0)
                 }
                 Spacer(minLength: 6)
                 Text("\(Int(percent.rounded()))%")
@@ -1905,6 +1911,12 @@ private struct ProviderBucketRow: View {
                 UsagePaceRow(pace: pace, now: now, fontSize: density.resetCountdownFontSize)
             }
         }
+    }
+
+    private var resetCountdownFontSize: CGFloat {
+        tool == .antigravity
+            ? max(density.subtitleFontSize, density.resetCountdownFontSize + 1)
+            : density.resetCountdownFontSize
     }
 
     private func paceForecast(now: Date) -> QuotaPaceForecast? {

--- a/Sources/VibeBarApp/Views/SettingsView.swift
+++ b/Sources/VibeBarApp/Views/SettingsView.swift
@@ -731,7 +731,7 @@ struct SettingsView: View {
 
     private var keychainAuthorizationControls: some View {
         VStack(alignment: .leading, spacing: 8) {
-            Text("If macOS repeatedly asks for Vibe Bar's Keychain items after a rebuild, enter the login keychain password once to re-authorize Vibe Bar-owned cookies and misc-provider secrets. The password is used only for this operation.")
+            Text("Vibe Bar keeps its cookies and provider secrets inside one Keychain Vault. After an ad-hoc rebuild, enter the login keychain password once to migrate old entries and repair access to that single Vault. Browser and CLI-owned Keychain items are never included. The password is used only for this operation.")
                 .font(.caption)
                 .foregroundStyle(.secondary)
                 .fixedSize(horizontal: false, vertical: true)
@@ -744,7 +744,7 @@ struct SettingsView: View {
                     authorizeKeychainAccess()
                 } label: {
                     Label(
-                        isAuthorizingKeychain ? "Authorizing..." : "Authorize",
+                        isAuthorizingKeychain ? "Repairing..." : "Repair Vault",
                         systemImage: "key.fill"
                     )
                 }
@@ -920,7 +920,7 @@ struct SettingsView: View {
             ToolBrandIconView(tool: tool, size: 16)
                 .frame(width: 18, height: 18)
             VStack(alignment: .leading, spacing: 2) {
-                Text(tool.menuTitle)
+                Text(providerBadgeTitle(for: tool))
                     .font(.system(size: 12, weight: .medium))
                 Text(autoPlanLabel(for: tool))
                     .font(.caption2)
@@ -930,6 +930,17 @@ struct SettingsView: View {
             TextField("Auto", text: providerPlanLabelBinding(tool))
                 .textFieldStyle(.roundedBorder)
                 .frame(width: 130)
+        }
+    }
+
+    private func providerBadgeTitle(for tool: ToolType) -> String {
+        switch tool {
+        case .codex: return "ChatGPT"
+        case .claude: return "Claude"
+        case .gemini: return "Gemini Web"
+        case .antigravity: return "AntiGravity"
+        case .grok: return "Grok"
+        default: return tool.menuTitle
         }
     }
 
@@ -1145,7 +1156,7 @@ struct SettingsView: View {
         let password = keychainPassword
         keychainPassword = ""
         keychainAuthorizationSucceeded = false
-        keychainAuthorizationStatus = "Authorizing Keychain access..."
+        keychainAuthorizationStatus = "Consolidating secrets into one Keychain Vault..."
         isAuthorizingKeychain = true
 
         Task.detached {
@@ -1172,10 +1183,13 @@ struct SettingsView: View {
         for report: VibeBarKeychainAccessAuthorizer.Report
     ) -> String {
         if report.failureCount == 0 {
-            return "Authorized \(report.authorizedCount) existing Keychain item(s). \(report.missingCount) item(s) have not been created yet."
+            if report.migratedItemCount > 0 {
+                return "Migrated \(report.migratedItemCount) old item(s) into one Vault containing \(report.vaultEntryCount) secret(s). Future rebuilds need one repair only."
+            }
+            return "Keychain Vault repaired. It currently contains \(report.vaultEntryCount) secret(s)."
         }
         let firstStatus = report.failures.first.map { String($0.status) } ?? "unknown"
-        return "Partially authorized \(report.authorizedCount) item(s); \(report.failureCount) failed with OSStatus \(firstStatus)."
+        return "Vault saved with \(report.vaultEntryCount) secret(s), but \(report.failureCount) old item(s) could not be migrated or removed (status \(firstStatus))."
     }
 
     private func keychainAuthorizationFailureMessage(_ error: Error) -> String {
@@ -1186,9 +1200,13 @@ struct SettingsView: View {
             case .unlockFailed(let status):
                 return "Could not unlock the login keychain. OSStatus \(status)."
             case .trustedApplicationFailed(let status):
-                return "Could not identify the current Vibe Bar app for Keychain access. OSStatus \(status)."
+                return "Could not identify this Vibe Bar build. OSStatus \(status)."
             case .accessCreateFailed(let status):
-                return "Could not create the Keychain access rule. OSStatus \(status)."
+                return "Could not create Keychain access for this Vibe Bar build. OSStatus \(status)."
+            case .invalidVault:
+                return "The existing Vault could not be decoded, so no old Keychain item was deleted."
+            case .vaultWriteFailed:
+                return "Could not write the new Vault. No old Keychain item was deleted."
             }
         }
         return "Could not authorize Keychain access: \(error)"

--- a/Sources/VibeBarApp/Views/SubscriptionUtilizationView.swift
+++ b/Sources/VibeBarApp/Views/SubscriptionUtilizationView.swift
@@ -178,10 +178,11 @@ struct SubscriptionUtilizationView: View {
                 if let resetAt = bucket.resetAt,
                    let reset = ResetCountdownFormatter.stringWithAbsoluteTime(from: resetAt, now: now) {
                     Text("resets in \(reset)")
-                        .font(.system(size: density.resetCountdownFontSize))
+                        .font(.system(size: resetCountdownFontSize(for: item.tool)))
                         .foregroundStyle(.tertiary)
                         .lineLimit(1)
-                        .minimumScaleFactor(0.72)
+                        .minimumScaleFactor(item.tool == .antigravity ? 0.92 : 0.80)
+                        .layoutPriority(item.tool == .antigravity ? 1 : 0)
                 }
                 Spacer(minLength: 6)
                 Text(percentLabel(used: used))
@@ -237,6 +238,12 @@ struct SubscriptionUtilizationView: View {
                 forecastExplanation(itemID: item.id, forecast: forecast, pace: pace)
             }
         }
+    }
+
+    private func resetCountdownFontSize(for tool: ToolType) -> CGFloat {
+        tool == .antigravity
+            ? max(density.subtitleFontSize, density.resetCountdownFontSize + 1)
+            : density.resetCountdownFontSize
     }
 
     @ViewBuilder
@@ -312,7 +319,6 @@ struct SubscriptionUtilizationView: View {
                     forecastColor: forecastColor
                 )
                 Spacer(minLength: 4)
-                actualValueLegend
             }
             VStack(alignment: .leading, spacing: 4) {
                 ViewThatFits(in: .horizontal) {
@@ -331,7 +337,6 @@ struct SubscriptionUtilizationView: View {
                         )
                     }
                 }
-                actualValueLegend
             }
         }
     }
@@ -358,13 +363,6 @@ struct SubscriptionUtilizationView: View {
                 value: "\(Int(forecastExpected.rounded()))% \(mode == .remaining ? "left" : "used")"
             )
         }
-    }
-
-    private var actualValueLegend: some View {
-        Text("bar = actual \(mode == .remaining ? "left" : "used")")
-            .font(.system(size: max(8, density.subtitleFontSize - 1)))
-            .foregroundStyle(.tertiary)
-            .fixedSize(horizontal: true, vertical: false)
     }
 
     private enum ReferenceMarkerStyle {

--- a/Sources/VibeBarCore/BrowserCookies/BrowserCookieAccessGate.swift
+++ b/Sources/VibeBarCore/BrowserCookies/BrowserCookieAccessGate.swift
@@ -165,12 +165,13 @@ extension Browser {
              .vivaldi,
              .dia:
             return true
-        @unknown default:
+        default:
             // Treat unknown future browsers conservatively: assume
-            // they're Chromium-derived and gate them. False positive
+            // they're Chromium-derived unless their enum label clearly says
+            // Firefox. False positive
             // here just means we run an extra preflight; false
             // negative would mean a Keychain prompt loop.
-            return true
+            return !String(describing: self).localizedCaseInsensitiveContains("firefox")
         }
     }
 }

--- a/Sources/VibeBarCore/BrowserCookies/CookieHeaderCache.swift
+++ b/Sources/VibeBarCore/BrowserCookies/CookieHeaderCache.swift
@@ -99,11 +99,10 @@ public enum CookieHeaderCache {
             let encoder = JSONEncoder()
             encoder.dateEncodingStrategy = .iso8601
             let data = try encoder.encode(entry)
-            try KeychainStore.writeData(
+            try VibeBarCredentialVault.writeData(
                 service: keychainService,
                 account: keychainAccount(for: tool),
-                data: data,
-                useDataProtectionKeychain: true
+                data: data
             )
             return true
         } catch {
@@ -116,10 +115,9 @@ public enum CookieHeaderCache {
     public static func clear(for tool: ToolType) -> Bool {
         guard tool.isMisc else { return false }
         do {
-            try KeychainStore.deleteItem(
+            try VibeBarCredentialVault.delete(
                 service: keychainService,
-                account: keychainAccount(for: tool),
-                useDataProtectionKeychain: true
+                account: keychainAccount(for: tool)
             )
             try? KeychainStore.deleteItemFromDataProtectionKeychainOnly(
                 service: legacyKeychainService,
@@ -161,10 +159,9 @@ public enum CookieHeaderCache {
                     service: service,
                     account: account
                 )
-                : try KeychainStore.readData(
+                : try VibeBarCredentialVault.readData(
                     service: service,
-                    account: account,
-                    useDataProtectionKeychain: true
+                    account: account
                 )
             let decoder = JSONDecoder()
             decoder.dateDecodingStrategy = .iso8601

--- a/Sources/VibeBarCore/Credentials/ClaudeWebCookieStore.swift
+++ b/Sources/VibeBarCore/Credentials/ClaudeWebCookieStore.swift
@@ -62,31 +62,28 @@ public enum ClaudeWebCookieStore {
         try VibeBarLocalStore.deleteFile(at: VibeBarLocalStore.claudeWebViewCookieURL)
         try VibeBarLocalStore.deleteFile(at: VibeBarLocalStore.claudeBrowserCookieURL)
         try VibeBarLocalStore.deleteFile(at: VibeBarLocalStore.claudeOrganizationIDURL)
-        try? KeychainStore.deleteItem(
+        try? VibeBarCredentialVault.delete(
             service: SecureCookieHeaderStore.keychainService,
-            account: organizationAccount,
-            useDataProtectionKeychain: true
+            account: organizationAccount
         )
         try? KeychainStore.deleteItemFromDataProtectionKeychainOnly(service: legacyService, account: legacyAccount)
         try? KeychainStore.deleteItemFromDataProtectionKeychainOnly(service: legacyService, account: legacyOrganizationAccount)
     }
 
     public static func readOrganizationID() -> String? {
-        if let raw = try? KeychainStore.readString(
+        if let raw = try? VibeBarCredentialVault.readString(
             service: SecureCookieHeaderStore.keychainService,
-            account: organizationAccount,
-            useDataProtectionKeychain: true
+            account: organizationAccount
         ), let normalized = normalizedOrganizationID(raw) {
             return normalized
         }
 
         if let local = try? VibeBarLocalStore.readString(from: VibeBarLocalStore.claudeOrganizationIDURL),
            let normalized = normalizedOrganizationID(local) {
-            try? KeychainStore.writeString(
+            try? VibeBarCredentialVault.writeString(
                 service: SecureCookieHeaderStore.keychainService,
                 account: organizationAccount,
-                value: normalized,
-                useDataProtectionKeychain: true
+                value: normalized
             )
             try? VibeBarLocalStore.deleteFile(at: VibeBarLocalStore.claudeOrganizationIDURL)
             return normalized
@@ -96,11 +93,10 @@ public enum ClaudeWebCookieStore {
 
     public static func writeOrganizationID(_ organizationID: String) throws {
         guard let trimmed = normalizedOrganizationID(organizationID) else { return }
-        try KeychainStore.writeString(
+        try VibeBarCredentialVault.writeString(
             service: SecureCookieHeaderStore.keychainService,
             account: organizationAccount,
-            value: trimmed,
-            useDataProtectionKeychain: true
+            value: trimmed
         )
         try? VibeBarLocalStore.deleteFile(at: VibeBarLocalStore.claudeOrganizationIDURL)
     }

--- a/Sources/VibeBarCore/Credentials/GrokCredentialsStore.swift
+++ b/Sources/VibeBarCore/Credentials/GrokCredentialsStore.swift
@@ -12,6 +12,7 @@ public struct GrokCredentials: Sendable, Equatable {
     public let firstName: String?
     public let lastName: String?
     public let teamId: String?
+    public let subscriptionTier: String?
     public let expiresAt: Date?
 
     public init(
@@ -22,6 +23,7 @@ public struct GrokCredentials: Sendable, Equatable {
         firstName: String?,
         lastName: String?,
         teamId: String?,
+        subscriptionTier: String?,
         expiresAt: Date?
     ) {
         self.accessToken = accessToken
@@ -31,6 +33,7 @@ public struct GrokCredentials: Sendable, Equatable {
         self.firstName = firstName
         self.lastName = lastName
         self.teamId = teamId
+        self.subscriptionTier = subscriptionTier
         self.expiresAt = expiresAt
     }
 
@@ -43,6 +46,10 @@ public struct GrokCredentials: Sendable, Equatable {
     /// session logins surface as "session" so the user can tell them
     /// apart in the popover badge.
     public var planLabel: String? {
+        if let subscriptionTier,
+           let normalized = ProviderPlanDisplay.grokDisplayName(subscriptionTier) {
+            return normalized
+        }
         switch authMode?.lowercased() {
         case "oidc":    return "SuperGrok"
         case "session": return "Session"
@@ -118,8 +125,18 @@ public enum GrokCredentialsStore {
             firstName: (entry["first_name"] as? String)?.trimmed.nilIfEmpty,
             lastName: (entry["last_name"] as? String)?.trimmed.nilIfEmpty,
             teamId: (entry["team_id"] as? String)?.trimmed.nilIfEmpty,
+            subscriptionTier: firstNonEmptyString(
+                entry["subscription_tier"],
+                entry["plan_name"],
+                entry["plan"],
+                entry["tier"]
+            ),
             expiresAt: parseDate(entry["expires_at"])
         )
+    }
+
+    private static func firstNonEmptyString(_ values: Any?...) -> String? {
+        values.lazy.compactMap { ($0 as? String)?.trimmed.nilIfEmpty }.first
     }
 
     private static func selectPreferredEntry(in root: [String: Any]) -> (scope: String, entry: [String: Any])? {

--- a/Sources/VibeBarCore/Credentials/MiscCookieSlotStore.swift
+++ b/Sources/VibeBarCore/Credentials/MiscCookieSlotStore.swift
@@ -218,10 +218,9 @@ public enum MiscCookieSlotStore {
     private static func readRaw(for tool: ToolType, instanceID: String) -> [MiscCookieSlot]? {
         let account = keychainAccount(for: tool, instanceID: instanceID)
         do {
-            let data = try KeychainStore.readData(
+            let data = try VibeBarCredentialVault.readData(
                 service: keychainService,
-                account: account,
-                useDataProtectionKeychain: true
+                account: account
             )
             return try Self.decoder().decode([MiscCookieSlot].self, from: data)
         } catch KeychainStore.KeychainError.itemNotFound {
@@ -243,11 +242,10 @@ public enum MiscCookieSlotStore {
         }
         do {
             let data = try Self.encoder().encode(slots)
-            try KeychainStore.writeData(
+            try VibeBarCredentialVault.writeData(
                 service: keychainService,
                 account: account,
-                data: data,
-                useDataProtectionKeychain: true
+                data: data
             )
             postChangeNotification(for: tool, instanceID: instanceID)
             return true
@@ -261,10 +259,9 @@ public enum MiscCookieSlotStore {
     private static func deleteRaw(for tool: ToolType, instanceID: String) -> Bool {
         let account = keychainAccount(for: tool, instanceID: instanceID)
         do {
-            try KeychainStore.deleteItem(
+            try VibeBarCredentialVault.delete(
                 service: keychainService,
-                account: account,
-                useDataProtectionKeychain: true
+                account: account
             )
             postChangeNotification(for: tool, instanceID: instanceID)
             return true

--- a/Sources/VibeBarCore/Credentials/MiscCredentialStore.swift
+++ b/Sources/VibeBarCore/Credentials/MiscCredentialStore.swift
@@ -47,10 +47,9 @@ public enum MiscCredentialStore {
     public static func readString(tool: ToolType, kind: Kind, instanceID: String) -> String? {
         guard tool.isMisc else { return nil }
         let account = keychainAccount(tool: tool, kind: kind, instanceID: instanceID)
-        if let value = try? KeychainStore.readString(
+        if let value = try? VibeBarCredentialVault.readString(
             service: keychainService,
-            account: account,
-            useDataProtectionKeychain: true
+            account: account
         ) {
             return value
         }
@@ -72,11 +71,10 @@ public enum MiscCredentialStore {
             return delete(tool: tool, kind: kind, instanceID: instanceID)
         }
         do {
-            try KeychainStore.writeString(
+            try VibeBarCredentialVault.writeString(
                 service: keychainService,
                 account: keychainAccount(tool: tool, kind: kind, instanceID: instanceID),
-                value: trimmed,
-                useDataProtectionKeychain: true
+                value: trimmed
             )
             return true
         } catch {
@@ -94,10 +92,9 @@ public enum MiscCredentialStore {
     public static func delete(tool: ToolType, kind: Kind, instanceID: String) -> Bool {
         guard tool.isMisc else { return false }
         do {
-            try KeychainStore.deleteItem(
+            try VibeBarCredentialVault.delete(
                 service: keychainService,
-                account: keychainAccount(tool: tool, kind: kind, instanceID: instanceID),
-                useDataProtectionKeychain: true
+                account: keychainAccount(tool: tool, kind: kind, instanceID: instanceID)
             )
             if instanceID == tool.rawValue {
                 deleteLegacyMigratedValue(tool: tool, kind: kind)

--- a/Sources/VibeBarCore/Credentials/SecureCookieHeaderStore.swift
+++ b/Sources/VibeBarCore/Credentials/SecureCookieHeaderStore.swift
@@ -121,10 +121,9 @@ public enum SecureCookieHeaderStore {
         }
 
         do {
-            let data = try KeychainStore.readData(
+            let data = try VibeBarCredentialVault.readData(
                 service: keychainService,
-                account: account,
-                useDataProtectionKeychain: true
+                account: account
             )
             let entry = try JSONDecoder().decode(Entry.self, from: data)
             cacheLock.lock()
@@ -154,11 +153,10 @@ public enum SecureCookieHeaderStore {
         if storeInTestStore(data, account: account) {
             return
         }
-        try KeychainStore.writeData(
+        try VibeBarCredentialVault.writeData(
             service: keychainService,
             account: account,
-            data: data,
-            useDataProtectionKeychain: true
+            data: data
         )
         cacheLock.lock()
         cache[account] = entry
@@ -170,10 +168,9 @@ public enum SecureCookieHeaderStore {
         if deleteFromTestStore(account: account) {
             return
         }
-        try KeychainStore.deleteItem(
+        try VibeBarCredentialVault.delete(
             service: keychainService,
-            account: account,
-            useDataProtectionKeychain: true
+            account: account
         )
         cacheLock.lock()
         cache.removeValue(forKey: account)

--- a/Sources/VibeBarCore/Credentials/VibeBarCredentialVault.swift
+++ b/Sources/VibeBarCore/Credentials/VibeBarCredentialVault.swift
@@ -1,0 +1,175 @@
+import Foundation
+import Security
+
+/// A single Keychain item containing every secret owned by Vibe Bar.
+///
+/// Source builds are ad-hoc signed, so their Keychain ACL identity changes on
+/// every rebuild. Keeping Vibe Bar-owned values inside one versioned vault
+/// means a rebuild has one item to repair instead of one prompt per cookie,
+/// provider, or account. External items (CLI credentials and browser Safe
+/// Storage keys) are deliberately excluded.
+public enum VibeBarCredentialVault {
+    public static let keychainService = "com.astroqore.VibeBar.credential-vault"
+    public static let keychainAccount = "vault-v1"
+    public static let stagingKeychainAccountPrefix = "vault-v1.migration-staging"
+
+    public struct Entry: Codable, Sendable, Equatable {
+        public let service: String
+        public let account: String
+        public var data: Data
+
+        public init(service: String, account: String, data: Data) {
+            self.service = service
+            self.account = account
+            self.data = data
+        }
+    }
+
+    public struct Payload: Codable, Sendable, Equatable {
+        public var version: Int
+        public var entries: [Entry]
+
+        public init(version: Int = 1, entries: [Entry] = []) {
+            self.version = version
+            self.entries = Self.normalized(entries)
+        }
+
+        public func data(service: String, account: String) -> Data? {
+            entries.first { $0.service == service && $0.account == account }?.data
+        }
+
+        public mutating func set(_ data: Data, service: String, account: String) {
+            entries.removeAll { $0.service == service && $0.account == account }
+            entries.append(Entry(service: service, account: account, data: data))
+            entries = Self.normalized(entries)
+        }
+
+        @discardableResult
+        public mutating func remove(service: String, account: String) -> Bool {
+            let originalCount = entries.count
+            entries.removeAll { $0.service == service && $0.account == account }
+            return entries.count != originalCount
+        }
+
+        private static func normalized(_ entries: [Entry]) -> [Entry] {
+            var unique: [String: Entry] = [:]
+            for entry in entries {
+                unique[entry.service + "\u{0}" + entry.account] = entry
+            }
+            return unique.values.sorted {
+                $0.service == $1.service ? $0.account < $1.account : $0.service < $1.service
+            }
+        }
+    }
+
+    private static let lock = NSLock()
+
+    public static func readData(service: String, account: String) throws -> Data {
+        lock.lock()
+        defer { lock.unlock() }
+        var payload = try loadPayloadOrEmpty()
+        if let data = payload.data(service: service, account: account) {
+            return data
+        }
+
+        // Seamless transition for an already-authorized build: import the
+        // historical per-secret item on first read. Queries stay non-
+        // interactive, so a newly signed build never brings back the prompt
+        // storm; Settings → Keychain Access handles inaccessible old items.
+        let legacy = try KeychainStore.readData(
+            service: service,
+            account: account,
+            useDataProtectionKeychain: true
+        )
+        payload.set(legacy, service: service, account: account)
+        try persist(payload)
+        try? KeychainStore.deleteItem(
+            service: service,
+            account: account,
+            useDataProtectionKeychain: true
+        )
+        return legacy
+    }
+
+    public static func readString(service: String, account: String) throws -> String {
+        let data = try readData(service: service, account: account)
+        guard let value = String(data: data, encoding: .utf8) else {
+            throw KeychainStore.KeychainError.itemNotFound
+        }
+        return value
+    }
+
+    public static func writeData(service: String, account: String, data: Data) throws {
+        lock.lock()
+        defer { lock.unlock() }
+        var payload = try loadPayloadOrEmpty()
+        payload.set(data, service: service, account: account)
+        try persist(payload)
+    }
+
+    public static func writeString(service: String, account: String, value: String) throws {
+        guard let data = value.data(using: .utf8) else {
+            throw KeychainStore.KeychainError.unhandledStatus(errSecParam)
+        }
+        try writeData(service: service, account: account, data: data)
+    }
+
+    public static func delete(service: String, account: String) throws {
+        lock.lock()
+        defer { lock.unlock() }
+        var payload = try loadPayload()
+        guard payload.remove(service: service, account: account) else {
+            throw KeychainStore.KeychainError.itemNotFound
+        }
+        try persist(payload)
+    }
+
+    /// Replaces the complete payload after the explicit password-assisted
+    /// migration in Settings. This is intentionally public so the authorizer
+    /// can make migration transactional: old items are deleted only after
+    /// this write succeeds.
+    public static func replacePayload(_ payload: Payload) throws {
+        lock.lock()
+        defer { lock.unlock() }
+        try persist(Payload(version: payload.version, entries: payload.entries))
+    }
+
+    public static func decodePayload(_ data: Data) throws -> Payload {
+        let decoded = try JSONDecoder().decode(Payload.self, from: data)
+        guard decoded.version == 1 else {
+            throw KeychainStore.KeychainError.unhandledStatus(errSecDecode)
+        }
+        return Payload(version: decoded.version, entries: decoded.entries)
+    }
+
+    public static func encodePayload(_ payload: Payload) throws -> Data {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        return try encoder.encode(payload)
+    }
+
+    private static func loadPayload() throws -> Payload {
+        let data = try KeychainStore.readData(
+            service: keychainService,
+            account: keychainAccount
+        )
+        return try decodePayload(data)
+    }
+
+    private static func loadPayloadOrEmpty() throws -> Payload {
+        do {
+            return try loadPayload()
+        } catch KeychainStore.KeychainError.itemNotFound {
+            return Payload()
+        }
+    }
+
+    private static func persist(_ payload: Payload) throws {
+        let data = try encodePayload(payload)
+        try KeychainStore.writeData(
+            service: keychainService,
+            account: keychainAccount,
+            data: data
+        )
+    }
+}

--- a/Sources/VibeBarCore/Credentials/VibeBarKeychainAccessAuthorizer.swift
+++ b/Sources/VibeBarCore/Credentials/VibeBarKeychainAccessAuthorizer.swift
@@ -2,13 +2,10 @@ import Darwin
 import Foundation
 import Security
 
-/// User-initiated repair for Vibe Bar-owned login-keychain items.
-///
-/// Source builds are usually ad-hoc signed, so every rebuild can look like
-/// a different app to macOS Keychain ACLs. Background refreshes stay
-/// non-interactive; this helper is called only from Settings after the
-/// user explicitly provides the login-keychain password for this one
-/// operation.
+/// Password-assisted migration and repair for Vibe Bar's single credential
+/// vault. The password stays in memory and is used only to unlock the login
+/// keychain through Security.framework; it is never persisted or passed to a
+/// child process.
 public enum VibeBarKeychainAccessAuthorizer {
     public struct Target: Hashable, Sendable, Equatable {
         public let service: String
@@ -35,6 +32,8 @@ public enum VibeBarKeychainAccessAuthorizer {
         public let authorized: [Target]
         public let missing: [Target]
         public let failures: [Failure]
+        public let vaultEntryCount: Int
+        public let migratedItemCount: Int
 
         public var authorizedCount: Int { authorized.count }
         public var missingCount: Int { missing.count }
@@ -44,12 +43,16 @@ public enum VibeBarKeychainAccessAuthorizer {
             targetCount: Int,
             authorized: [Target],
             missing: [Target],
-            failures: [Failure]
+            failures: [Failure],
+            vaultEntryCount: Int = 0,
+            migratedItemCount: Int = 0
         ) {
             self.targetCount = targetCount
             self.authorized = authorized
             self.missing = missing
             self.failures = failures
+            self.vaultEntryCount = vaultEntryCount
+            self.migratedItemCount = migratedItemCount
         }
     }
 
@@ -58,117 +61,26 @@ public enum VibeBarKeychainAccessAuthorizer {
         case unlockFailed(Int)
         case trustedApplicationFailed(Int)
         case accessCreateFailed(Int)
+        case invalidVault
+        case vaultWriteFailed
     }
 
     private static let legacyMiscService = "com.astroqore.VibeBar.misc"
     private static let legacyClaudeWebService = "Vibe Bar Claude Web Cookies"
-    private static let legacyClaudeCookieAccount = "claude.ai"
-    private static let legacyClaudeOrganizationAccount = "claude.ai.organization"
-    private static let claudeOrganizationAccount = "claude.organization-id"
-    /// Misc providers that stack their cookie sessions through
-    /// `MiscCookieSlotStore`. The list mirrors every cookie-only adapter
-    /// plus Alibaba (cookie path is one of two auth modes).
-    private static let currentCookieBackedMiscTools: [ToolType] = [
-        .alibaba, .alibabaTokenPlan, .kimi, .cursor, .mimo, .iflytek,
-        .tencentHunyuan, .tencentTokenPlan, .volcengine, .volcengineAgentPlan, .baiduQianfan, .openCodeGo, .ollama
-    ]
-    /// Misc tools with an in-app WKWebView login flow where
-    /// `WebFormCredentialStore` may persist a username/password pair.
-    /// Keeping the list explicit lets the preflight pre-authorize the
-    /// Keychain accounts so users don't see a prompt on first save.
-    private static let currentWebFormBackedMiscTools: [ToolType] = [
-        .mimo, .volcengine, .volcengineAgentPlan, .tencentHunyuan, .tencentTokenPlan, .alibaba, .alibabaTokenPlan, .baiduQianfan
-    ]
-    private static let currentSecretKindsByTool: [ToolType: [MiscCredentialStore.Kind]] = [
-        .alibaba: [.apiKey],
-        .copilot: [.apiKey, .oauthAccessToken, .oauthRefreshToken, .oauthExpiry],
-        .kilo: [.apiKey],
-        .minimax: [.apiKey],
-        .openRouter: [.apiKey],
-        .warp: [.apiKey],
-        .zai: [.apiKey]
-    ]
+
+    /// The only current Keychain item owned by Vibe Bar.
+    public static var currentOwnedTargets: [Target] {
+        [vaultTarget]
+    }
+
+    /// Historical stores that are scanned only during explicit migration.
+    /// They are never pre-created and no longer contribute placeholder rows.
+    public static var legacyOwnedTargets: [Target] {
+        knownMigrationTargets
+    }
 
     public static var ownedTargets: [Target] {
-        uniqueSortedTargets(currentOwnedTargets + legacyOwnedTargets)
-    }
-
-    public static var currentOwnedTargets: [Target] {
-        var targets: [Target] = []
-
-        for provider in [SecureCookieHeaderStore.Provider.openAI, .claude] {
-            for source in SecureCookieHeaderStore.Source.allCases {
-                targets.append(
-                    Target(
-                        service: SecureCookieHeaderStore.keychainService,
-                        account: SecureCookieHeaderStore.account(provider: provider, source: source)
-                    )
-                )
-            }
-        }
-        targets.append(
-            Target(
-                service: SecureCookieHeaderStore.keychainService,
-                account: claudeOrganizationAccount
-            )
-        )
-
-        for tool in currentCookieBackedMiscTools {
-            targets.append(
-                Target(
-                    service: MiscCookieSlotStore.keychainService,
-                    account: MiscCookieSlotStore.keychainAccount(for: tool)
-                )
-            )
-        }
-
-        for (tool, kinds) in currentSecretKindsByTool {
-            for kind in kinds {
-                targets.append(
-                    Target(
-                        service: MiscCredentialStore.keychainService,
-                        account: MiscCredentialStore.keychainAccount(tool: tool, kind: kind)
-                    )
-                )
-            }
-        }
-
-        for tool in currentWebFormBackedMiscTools {
-            targets.append(
-                Target(
-                    service: WebFormCredentialStore.keychainService,
-                    account: WebFormCredentialStore.keychainAccount(tool: tool)
-                )
-            )
-        }
-
-        return uniqueSortedTargets(targets)
-    }
-
-    public static var legacyOwnedTargets: [Target] {
-        var targets: [Target] = [
-            Target(service: legacyClaudeWebService, account: legacyClaudeCookieAccount),
-            Target(service: legacyClaudeWebService, account: legacyClaudeOrganizationAccount)
-        ]
-
-        for tool in ToolType.miscProviders {
-            targets.append(
-                Target(
-                    service: legacyMiscService,
-                    account: "cookie.\(tool.rawValue)"
-                )
-            )
-            for kind in MiscCredentialStore.Kind.allCases {
-                targets.append(
-                    Target(
-                        service: legacyMiscService,
-                        account: MiscCredentialStore.keychainAccount(tool: tool, kind: kind)
-                    )
-                )
-            }
-        }
-
-        return uniqueSortedTargets(targets)
+        [vaultTarget]
     }
 
     public static func authorizeExistingOwnedItems(
@@ -192,41 +104,231 @@ public enum VibeBarKeychainAccessAuthorizer {
         guard unlockStatus == errSecSuccess else {
             throw AuthorizationError.unlockFailed(Int(unlockStatus))
         }
-
         let access = try currentApplicationAccess()
 
-        var authorized: [Target] = []
-        var missing: [Target] = []
+        let discovered = discoverExistingTargets()
+        let existingVault = discovered.contains(vaultTarget)
+        let existingStagingVaults = discovered.filter(isStagingVault)
+        let migrationTargets = discovered.filter { $0 != vaultTarget && !isStagingVault($0) }
+        var payload = VibeBarCredentialVault.Payload()
+        var migrated: [Target] = []
         var failures: [Failure] = []
 
-        for target in ownedTargets {
-            let lookup = findGenericPasswordItem(target)
-            switch lookup.status {
-            case errSecSuccess:
-                guard let item = lookup.item else {
-                    failures.append(Failure(target: target, status: Int(errSecInternalComponent)))
-                    continue
+        for stagingTarget in existingStagingVaults {
+            do {
+                let data = try extractSecret(for: stagingTarget, access: access)
+                let staged = try VibeBarCredentialVault.decodePayload(data)
+                for entry in staged.entries {
+                    payload.set(entry.data, service: entry.service, account: entry.account)
                 }
+                migrated.append(stagingTarget)
+            } catch let error as KeychainOperationError {
+                failures.append(Failure(target: stagingTarget, status: Int(error.status)))
+            } catch {
+                throw AuthorizationError.invalidVault
+            }
+        }
 
-                let setStatus = SecKeychainItemSetAccess(item, access)
-                if setStatus == errSecSuccess {
-                    authorized.append(target)
-                } else {
-                    failures.append(Failure(target: target, status: Int(setStatus)))
+        if existingVault {
+            do {
+                let data = try extractSecret(for: vaultTarget, access: access)
+                let existing = try VibeBarCredentialVault.decodePayload(data)
+                for entry in existing.entries {
+                    payload.set(entry.data, service: entry.service, account: entry.account)
                 }
-            case errSecItemNotFound:
-                missing.append(target)
-            default:
-                failures.append(Failure(target: target, status: Int(lookup.status)))
+                migrated.append(vaultTarget)
+            } catch let error as KeychainOperationError {
+                failures.append(Failure(target: vaultTarget, status: Int(error.status)))
+            } catch {
+                throw AuthorizationError.invalidVault
+            }
+        }
+
+        for target in migrationTargets {
+            do {
+                let data = try extractSecret(for: target, access: access)
+                payload.set(data, service: target.service, account: target.account)
+                migrated.append(target)
+            } catch let error as KeychainOperationError {
+                failures.append(Failure(target: target, status: Int(error.status)))
+            }
+        }
+
+        // Never replace an unreadable vault: that would discard secrets which
+        // the current build could not decrypt.
+        if existingVault,
+           !migrated.contains(vaultTarget),
+           !existingStagingVaults.contains(where: { migrated.contains($0) }) {
+            return Report(
+                targetCount: discovered.count,
+                authorized: migrated,
+                missing: [],
+                failures: failures,
+                vaultEntryCount: 0,
+                migratedItemCount: max(0, migrated.count)
+            )
+        }
+
+        // Write a recovery copy with the current app identity before touching
+        // the old vault. If the final add fails, the next repair can recover
+        // every entry from this staging item.
+        let recoveryTarget = Target(
+            service: VibeBarCredentialVault.keychainService,
+            account: VibeBarCredentialVault.stagingKeychainAccountPrefix + "." + UUID().uuidString
+        )
+        do {
+            try KeychainStore.writeData(
+                service: recoveryTarget.service,
+                account: recoveryTarget.account,
+                data: try VibeBarCredentialVault.encodePayload(payload)
+            )
+        } catch {
+            throw AuthorizationError.vaultWriteFailed
+        }
+
+        if existingVault {
+            do {
+                try deleteKeychainItem(vaultTarget)
+            } catch let error as KeychainOperationError {
+                failures.append(Failure(target: vaultTarget, status: Int(error.status)))
+                throw AuthorizationError.vaultWriteFailed
+            }
+        }
+
+        do {
+            try VibeBarCredentialVault.replacePayload(payload)
+        } catch {
+            throw AuthorizationError.vaultWriteFailed
+        }
+
+        try? KeychainStore.deleteItem(
+            service: recoveryTarget.service,
+            account: recoveryTarget.account
+        )
+
+        for stagingTarget in existingStagingVaults where migrated.contains(stagingTarget) {
+            do {
+                try deleteKeychainItem(stagingTarget)
+            } catch let error as KeychainOperationError {
+                failures.append(Failure(target: stagingTarget, status: Int(error.status)))
+            }
+        }
+
+        // Transaction boundary: old entries are removed only after the new
+        // single-item vault is safely written.
+        for target in migrationTargets where migrated.contains(target) {
+            do {
+                try deleteKeychainItem(target)
+            } catch let error as KeychainOperationError {
+                failures.append(Failure(target: target, status: Int(error.status)))
             }
         }
 
         return Report(
-            targetCount: ownedTargets.count,
-            authorized: authorized,
-            missing: missing,
-            failures: failures
+            targetCount: discovered.count,
+            authorized: migrated,
+            missing: [],
+            failures: failures,
+            vaultEntryCount: payload.entries.count,
+            migratedItemCount: migrationTargets.filter { migrated.contains($0) }.count
         )
+    }
+
+    private struct KeychainOperationError: Error {
+        let status: OSStatus
+    }
+
+    private static var vaultTarget: Target {
+        Target(
+            service: VibeBarCredentialVault.keychainService,
+            account: VibeBarCredentialVault.keychainAccount
+        )
+    }
+
+    private static var ownedServiceNames: [String] {
+        [
+            VibeBarCredentialVault.keychainService,
+            SecureCookieHeaderStore.keychainService,
+            MiscCredentialStore.keychainService,
+            WebFormCredentialStore.keychainService,
+            legacyMiscService,
+            legacyClaudeWebService
+        ]
+    }
+
+    private static func discoverExistingTargets() -> [Target] {
+        var targets = Set<Target>()
+        for service in ownedServiceNames {
+            var query: [String: Any] = [
+                kSecClass as String: kSecClassGenericPassword,
+                kSecAttrService as String: service,
+                kSecReturnAttributes as String: true,
+                kSecMatchLimit as String: kSecMatchLimitAll
+            ]
+            KeychainNoUIQuery.apply(to: &query, uiPolicy: .skip)
+            var result: AnyObject?
+            guard SecItemCopyMatching(query as CFDictionary, &result) == errSecSuccess else {
+                continue
+            }
+            let dictionaries: [[String: Any]]
+            if let list = result as? [[String: Any]] {
+                dictionaries = list
+            } else if let one = result as? [String: Any] {
+                dictionaries = [one]
+            } else {
+                dictionaries = []
+            }
+            for attributes in dictionaries {
+                if let account = attributes[kSecAttrAccount as String] as? String {
+                    targets.insert(Target(service: service, account: account))
+                }
+            }
+        }
+
+        // Attribute enumeration varies between older macOS Keychain formats;
+        // direct lookups make the known historical accounts deterministic.
+        for target in [vaultTarget] + knownMigrationTargets {
+            if findGenericPasswordItem(target).status == errSecSuccess {
+                targets.insert(target)
+            }
+        }
+        return targets.sorted(by: targetSort)
+    }
+
+    private static func extractSecret(for target: Target, access: SecAccess) throws -> Data {
+        let lookup = findGenericPasswordItem(target)
+        guard lookup.status == errSecSuccess, let item = lookup.item else {
+            throw KeychainOperationError(status: lookup.status)
+        }
+
+        // Reset the ACL only after the user explicitly unlocks the login
+        // keychain in Settings. The read below is then non-interactive, so a
+        // rebuild never fans out into one system prompt per old secret.
+        let accessStatus = SecKeychainItemSetAccess(item, access)
+        guard accessStatus == errSecSuccess else {
+            throw KeychainOperationError(status: accessStatus)
+        }
+
+        do {
+            return try KeychainStore.readData(service: target.service, account: target.account)
+        } catch let KeychainStore.KeychainError.unhandledStatus(status) {
+            throw KeychainOperationError(status: status)
+        } catch KeychainStore.KeychainError.interactionNotAllowed {
+            throw KeychainOperationError(status: errSecInteractionNotAllowed)
+        } catch {
+            throw KeychainOperationError(status: errSecItemNotFound)
+        }
+    }
+
+    private static func deleteKeychainItem(_ target: Target) throws {
+        let lookup = findGenericPasswordItem(target)
+        guard lookup.status == errSecSuccess, let item = lookup.item else {
+            throw KeychainOperationError(status: lookup.status)
+        }
+        let status = SecKeychainItemDelete(item)
+        guard status == errSecSuccess else {
+            throw KeychainOperationError(status: status)
+        }
     }
 
     private static func currentApplicationAccess() throws -> SecAccess {
@@ -239,7 +341,7 @@ public enum VibeBarKeychainAccessAuthorizer {
         let trustedList = [trustedApplication] as CFArray
         var access: SecAccess?
         let accessStatus = SecAccessCreate(
-            "Vibe Bar Keychain Access" as CFString,
+            "Vibe Bar Credential Vault" as CFString,
             trustedList,
             &access
         )
@@ -268,12 +370,55 @@ public enum VibeBarKeychainAccessAuthorizer {
         return (item, status)
     }
 
-    private static func uniqueSortedTargets(_ targets: [Target]) -> [Target] {
-        Array(Set(targets)).sorted {
-            if $0.service == $1.service {
-                return $0.account < $1.account
+    private static func targetSort(_ lhs: Target, _ rhs: Target) -> Bool {
+        lhs.service == rhs.service ? lhs.account < rhs.account : lhs.service < rhs.service
+    }
+
+    private static func isStagingVault(_ target: Target) -> Bool {
+        target.service == VibeBarCredentialVault.keychainService &&
+            target.account.hasPrefix(VibeBarCredentialVault.stagingKeychainAccountPrefix + ".")
+    }
+
+    private static var knownMigrationTargets: [Target] {
+        var targets: [Target] = [
+            Target(service: legacyClaudeWebService, account: "claude.ai"),
+            Target(service: legacyClaudeWebService, account: "claude.ai.organization"),
+            Target(service: SecureCookieHeaderStore.keychainService, account: "claude.organization-id")
+        ]
+        for provider in [
+            SecureCookieHeaderStore.Provider.openAI,
+            .claude,
+            .gemini,
+            .grok
+        ] {
+            for source in SecureCookieHeaderStore.Source.allCases {
+                targets.append(Target(
+                    service: SecureCookieHeaderStore.keychainService,
+                    account: SecureCookieHeaderStore.account(provider: provider, source: source)
+                ))
             }
-            return $0.service < $1.service
         }
+        for tool in ToolType.miscProviders {
+            targets.append(Target(
+                service: MiscCookieSlotStore.keychainService,
+                account: MiscCookieSlotStore.keychainAccount(for: tool)
+            ))
+            targets.append(Target(service: legacyMiscService, account: "cookie.\(tool.rawValue)"))
+            for kind in MiscCredentialStore.Kind.allCases {
+                targets.append(Target(
+                    service: MiscCredentialStore.keychainService,
+                    account: MiscCredentialStore.keychainAccount(tool: tool, kind: kind)
+                ))
+                targets.append(Target(
+                    service: legacyMiscService,
+                    account: MiscCredentialStore.keychainAccount(tool: tool, kind: kind)
+                ))
+            }
+            targets.append(Target(
+                service: WebFormCredentialStore.keychainService,
+                account: WebFormCredentialStore.keychainAccount(tool: tool)
+            ))
+        }
+        return Array(Set(targets)).sorted(by: targetSort)
     }
 }

--- a/Sources/VibeBarCore/Credentials/WebFormCredentialStore.swift
+++ b/Sources/VibeBarCore/Credentials/WebFormCredentialStore.swift
@@ -31,10 +31,9 @@ public enum WebFormCredentialStore {
     public static func read(for tool: ToolType) -> [WebFormCredential] {
         guard tool.isMisc else { return [] }
         do {
-            let data = try KeychainStore.readData(
+            let data = try VibeBarCredentialVault.readData(
                 service: keychainService,
-                account: keychainAccount(tool: tool),
-                useDataProtectionKeychain: true
+                account: keychainAccount(tool: tool)
             )
             return decode(data)
         } catch {
@@ -99,10 +98,9 @@ public enum WebFormCredentialStore {
         let account = keychainAccount(tool: tool)
         if credentials.isEmpty {
             do {
-                try KeychainStore.deleteItem(
+                try VibeBarCredentialVault.delete(
                     service: keychainService,
-                    account: account,
-                    useDataProtectionKeychain: true
+                    account: account
                 )
                 return true
             } catch KeychainStore.KeychainError.itemNotFound {
@@ -114,11 +112,10 @@ public enum WebFormCredentialStore {
         }
         do {
             let data = try JSONEncoder().encode(credentials)
-            try KeychainStore.writeData(
+            try VibeBarCredentialVault.writeData(
                 service: keychainService,
                 account: account,
-                data: data,
-                useDataProtectionKeychain: true
+                data: data
             )
             return true
         } catch {

--- a/Sources/VibeBarCore/Models/ProviderPlanDisplay.swift
+++ b/Sources/VibeBarCore/Models/ProviderPlanDisplay.swift
@@ -4,10 +4,14 @@ public enum ProviderPlanDisplay {
     public static func displayName(for tool: ToolType, rawPlan: String?) -> String? {
         switch tool {
         case .codex:
-            return codexDisplayName(rawPlan)
+            return prefixed(codexDisplayName(rawPlan), brand: "ChatGPT")
         case .claude:
-            return claudeDisplayName(rawPlan)
-        case .alibaba, .alibabaTokenPlan, .gemini, .antigravity, .grok, .copilot, .zai, .minimax, .kimi, .cursor, .mimo, .iflytek, .tencentHunyuan, .tencentTokenPlan, .volcengine, .volcengineAgentPlan, .baiduQianfan, .openCodeGo, .kilo, .kiro, .ollama, .openRouter, .warp:
+            return prefixed(claudeDisplayName(rawPlan), brand: "Claude")
+        case .gemini, .antigravity:
+            return prefixed(codexDisplayName(rawPlan), brand: "Google AI")
+        case .grok:
+            return grokDisplayName(rawPlan)
+        case .alibaba, .alibabaTokenPlan, .copilot, .zai, .minimax, .kimi, .cursor, .mimo, .iflytek, .tencentHunyuan, .tencentTokenPlan, .volcengine, .volcengineAgentPlan, .baiduQianfan, .openCodeGo, .kilo, .kiro, .ollama, .openRouter, .warp:
             // Misc providers feed `plan` straight through. Each adapter
             // is responsible for normalizing the raw API response
             // (e.g. `Pro Coding` → `Pro`) before it reaches this map.
@@ -43,6 +47,26 @@ public enum ProviderPlanDisplay {
 
     public static func claudeDisplayName(rateLimitTier: String?, billingType: String? = nil) -> String? {
         ClaudePlan.webPlan(rateLimitTier: rateLimitTier, billingType: billingType)?.compactLoginMethod
+    }
+
+    public static func grokDisplayName(_ rawPlan: String?) -> String? {
+        guard let display = codexDisplayName(rawPlan) else { return nil }
+        let compact = display.replacingOccurrences(of: " ", with: "").lowercased()
+        switch compact {
+        case "supergrokheavy": return "SuperGrok Heavy"
+        case "supergrok": return "SuperGrok"
+        case "supergroklite": return "SuperGrok Lite"
+        default: return display
+        }
+    }
+
+    private static func prefixed(_ plan: String?, brand: String) -> String? {
+        guard let plan else { return nil }
+        if plan.lowercased().hasPrefix(brand.lowercased() + " ") ||
+            plan.caseInsensitiveCompare(brand) == .orderedSame {
+            return plan
+        }
+        return "\(brand) \(plan)"
     }
 
     private static let codexExactDisplayNames: [String: String] = [

--- a/Tests/VibeBarCoreTests/AppSettingsTests.swift
+++ b/Tests/VibeBarCoreTests/AppSettingsTests.swift
@@ -343,10 +343,10 @@ final class AppSettingsTests: XCTestCase {
         let settings = AppSettings.default
 
         XCTAssertNil(settings.planBadgeLabel(for: .codex))
-        XCTAssertEqual(settings.planBadgeLabel(for: .codex, quotaPlan: "prolite"), "Pro Lite")
-        XCTAssertEqual(settings.planBadgeLabel(for: .codex, accountPlan: "self_serve_business_usage_based"), "Self Serve Business Usage Based")
-        XCTAssertEqual(settings.planBadgeLabel(for: .claude, quotaPlan: "default_claude_max_20x"), "Max")
-        XCTAssertEqual(settings.planBadgeLabel(for: .claude, accountPlan: "Claude Pro Account"), "Pro")
+        XCTAssertEqual(settings.planBadgeLabel(for: .codex, quotaPlan: "prolite"), "ChatGPT Pro Lite")
+        XCTAssertEqual(settings.planBadgeLabel(for: .codex, accountPlan: "self_serve_business_usage_based"), "ChatGPT Self Serve Business Usage Based")
+        XCTAssertEqual(settings.planBadgeLabel(for: .claude, quotaPlan: "default_claude_max_20x"), "Claude Max")
+        XCTAssertEqual(settings.planBadgeLabel(for: .claude, accountPlan: "Claude Pro Account"), "Claude Pro")
     }
 
     func testProviderPlanLabelOverrideWinsAndRoundTrips() throws {

--- a/Tests/VibeBarCoreTests/GrokCredentialsStoreTests.swift
+++ b/Tests/VibeBarCoreTests/GrokCredentialsStoreTests.swift
@@ -43,6 +43,20 @@ final class GrokCredentialsStoreTests: XCTestCase {
         XCTAssertEqual(creds.planLabel, "Session")
     }
 
+    func testExplicitSubscriptionTierDistinguishesHeavy() throws {
+        let json = """
+        {
+          "https://auth.x.ai::client-id": {
+            "key": "token",
+            "auth_mode": "oidc",
+            "subscription_tier": "supergrok_heavy"
+          }
+        }
+        """
+        let creds = try GrokCredentialsStore.parse(data: Data(json.utf8))
+        XCTAssertEqual(creds.planLabel, "SuperGrok Heavy")
+    }
+
     func testPrefersOIDCWhenBothPresent() throws {
         let json = """
         {

--- a/Tests/VibeBarCoreTests/KeychainMigrationPolicyTests.swift
+++ b/Tests/VibeBarCoreTests/KeychainMigrationPolicyTests.swift
@@ -9,94 +9,51 @@ final class KeychainMigrationPolicyTests: XCTestCase {
         )
     }
 
-    func testAuthorizationTargetsCoverVibeBarOwnedStores() {
-        let targets = Set(VibeBarKeychainAccessAuthorizer.ownedTargets)
-
-        XCTAssertTrue(targets.contains(.init(
-            service: "com.astroqore.VibeBar.web-cookies",
-            account: "openai.browser.cookie"
-        )))
-        XCTAssertTrue(targets.contains(.init(
-            service: "com.astroqore.VibeBar.web-cookies",
-            account: "claude.webView.cookie"
-        )))
-        XCTAssertTrue(targets.contains(.init(
-            service: "com.astroqore.VibeBar.web-cookies",
-            account: "claude.organization-id"
-        )))
-        // Cookie-backed misc providers now stack their sessions through
-        // `MiscCookieSlotStore` (one Keychain entry per tool, holding a
-        // JSON-encoded list of slots). The authorizer needs to cover
-        // every cookie-backed tool's slot list.
-        XCTAssertTrue(targets.contains(.init(
-            service: "com.astroqore.VibeBar.misc-secrets",
-            account: "kimi.cookieSlots"
-        )))
-        XCTAssertTrue(targets.contains(.init(
-            service: "com.astroqore.VibeBar.misc-secrets",
-            account: "cursor.cookieSlots"
-        )))
-        XCTAssertTrue(targets.contains(.init(
-            service: "com.astroqore.VibeBar.misc-secrets",
-            account: "volcengine.cookieSlots"
-        )))
-        XCTAssertTrue(targets.contains(.init(
-            service: "com.astroqore.VibeBar.misc-secrets",
-            account: "alibaba.cookieSlots"
-        )))
-        XCTAssertTrue(targets.contains(.init(
-            service: "com.astroqore.VibeBar.misc-secrets",
-            account: "copilot.oauthAccessToken"
-        )))
-        XCTAssertTrue(targets.contains(.init(
-            service: "com.astroqore.VibeBar.misc-secrets",
-            account: "zai.apiKey"
-        )))
-        XCTAssertTrue(targets.contains(.init(
-            service: "com.astroqore.VibeBar.misc-secrets",
-            account: "minimax.apiKey"
-        )))
-        // The single-cookie `CookieHeaderCache` entries are no longer the
-        // authoritative storage (their contents migrate into slots on
-        // first read) and should not appear in the current target list.
-        XCTAssertFalse(targets.contains(.init(
-            service: CookieHeaderCache.keychainService,
-            account: CookieHeaderCache.keychainAccount(for: .minimax)
-        )))
-        XCTAssertFalse(targets.contains(.init(
-            service: "com.astroqore.VibeBar.web-cookies",
-            account: "misc.kimi.cookie"
-        )))
+    func testCurrentAuthorizationTargetIsOnlyTheVault() {
+        XCTAssertEqual(
+            VibeBarKeychainAccessAuthorizer.currentOwnedTargets,
+            [.init(
+                service: VibeBarCredentialVault.keychainService,
+                account: VibeBarCredentialVault.keychainAccount
+            )]
+        )
+        XCTAssertEqual(
+            VibeBarKeychainAccessAuthorizer.ownedTargets,
+            VibeBarKeychainAccessAuthorizer.currentOwnedTargets
+        )
     }
 
-    func testAuthorizationTargetsIncludeLegacyOwnedStores() {
-        let targets = Set(VibeBarKeychainAccessAuthorizer.ownedTargets)
-
-        XCTAssertTrue(targets.contains(.init(
-            service: "com.astroqore.VibeBar.misc",
-            account: "cookie.antigravity"
-        )))
-        XCTAssertTrue(targets.contains(.init(
-            service: "com.astroqore.VibeBar.misc",
-            account: "antigravity.importedCookieHeader"
-        )))
-        XCTAssertTrue(targets.contains(.init(
-            service: "Vibe Bar Claude Web Cookies",
-            account: "claude.ai"
-        )))
-        XCTAssertTrue(targets.contains(.init(
-            service: "Vibe Bar Claude Web Cookies",
-            account: "claude.ai.organization"
-        )))
-    }
-
-    func testAuthorizationTargetsExcludeExternalCredentialStores() {
-        let targets = VibeBarKeychainAccessAuthorizer.ownedTargets
-        let pairs = Set(targets.map { "\($0.service)|\($0.account)" })
-
-        XCTAssertEqual(targets.count, pairs.count)
+    func testMigrationSourcesExcludeExternalCredentialStores() {
+        let targets = VibeBarKeychainAccessAuthorizer.legacyOwnedTargets
         XCTAssertFalse(targets.contains { $0.service == "Codex Auth" })
         XCTAssertFalse(targets.contains { $0.service == "Claude Code-credentials" })
         XCTAssertFalse(targets.contains { $0.service.localizedCaseInsensitiveContains("Chrome Safe Storage") })
+    }
+
+    func testVaultPayloadDeduplicatesAndRoundTripsBinaryData() throws {
+        var payload = VibeBarCredentialVault.Payload(entries: [
+            .init(service: "service-b", account: "account", data: Data([0, 1, 2])),
+            .init(service: "service-a", account: "account", data: Data("old".utf8))
+        ])
+        payload.set(Data("new".utf8), service: "service-a", account: "account")
+        payload.set(Data("second".utf8), service: "service-a", account: "other")
+
+        let encoded = try VibeBarCredentialVault.encodePayload(payload)
+        let decoded = try VibeBarCredentialVault.decodePayload(encoded)
+
+        XCTAssertEqual(decoded.entries.count, 3)
+        XCTAssertEqual(decoded.data(service: "service-a", account: "account"), Data("new".utf8))
+        XCTAssertEqual(decoded.data(service: "service-b", account: "account"), Data([0, 1, 2]))
+    }
+
+    func testVaultPayloadDeleteDoesNotAffectSiblingAccount() {
+        var payload = VibeBarCredentialVault.Payload(entries: [
+            .init(service: "service", account: "one", data: Data("1".utf8)),
+            .init(service: "service", account: "two", data: Data("2".utf8))
+        ])
+
+        XCTAssertTrue(payload.remove(service: "service", account: "one"))
+        XCTAssertNil(payload.data(service: "service", account: "one"))
+        XCTAssertEqual(payload.data(service: "service", account: "two"), Data("2".utf8))
     }
 }

--- a/Tests/VibeBarCoreTests/ProviderPlanDisplayTests.swift
+++ b/Tests/VibeBarCoreTests/ProviderPlanDisplayTests.swift
@@ -3,19 +3,22 @@ import XCTest
 
 final class ProviderPlanDisplayTests: XCTestCase {
     func testCodexPlanDisplayHumanizesKnownMachineValues() {
-        XCTAssertEqual(ProviderPlanDisplay.displayName(for: .codex, rawPlan: "pro"), "Pro")
-        XCTAssertEqual(ProviderPlanDisplay.displayName(for: .codex, rawPlan: "prolite"), "Pro Lite")
+        XCTAssertEqual(ProviderPlanDisplay.displayName(for: .codex, rawPlan: "pro"), "ChatGPT Pro")
+        XCTAssertEqual(ProviderPlanDisplay.displayName(for: .codex, rawPlan: "prolite"), "ChatGPT Pro Lite")
         XCTAssertEqual(
             ProviderPlanDisplay.displayName(for: .codex, rawPlan: "enterprise_cbp_usage_based"),
-            "Enterprise CBP Usage Based"
+            "ChatGPT Enterprise CBP Usage Based"
         )
     }
 
     func testClaudePlanDisplayRecognizesRateLimitTiers() {
-        XCTAssertEqual(ProviderPlanDisplay.displayName(for: .claude, rawPlan: "default_claude_max_20x"), "Max")
-        XCTAssertEqual(ProviderPlanDisplay.displayName(for: .claude, rawPlan: "claude_pro"), "Pro")
-        XCTAssertEqual(ProviderPlanDisplay.displayName(for: .claude, rawPlan: "Claude Enterprise Account"), "Enterprise")
-        XCTAssertEqual(ProviderPlanDisplay.displayName(for: .claude, rawPlan: "Experimental"), "Experimental")
+        XCTAssertEqual(ProviderPlanDisplay.displayName(for: .claude, rawPlan: "default_claude_max_20x"), "Claude Max")
+        XCTAssertEqual(ProviderPlanDisplay.displayName(for: .claude, rawPlan: "claude_pro"), "Claude Pro")
+        XCTAssertEqual(ProviderPlanDisplay.displayName(for: .claude, rawPlan: "Claude Enterprise Account"), "Claude Enterprise")
+        XCTAssertEqual(ProviderPlanDisplay.displayName(for: .claude, rawPlan: "Experimental"), "Claude Experimental")
+        XCTAssertEqual(ProviderPlanDisplay.displayName(for: .gemini, rawPlan: "Ultra"), "Google AI Ultra")
+        XCTAssertEqual(ProviderPlanDisplay.displayName(for: .antigravity, rawPlan: "Google AI Ultra"), "Google AI Ultra")
+        XCTAssertEqual(ProviderPlanDisplay.displayName(for: .grok, rawPlan: "supergrok_heavy"), "SuperGrok Heavy")
     }
 
     func testCodexCredentialDecodesPlanAndEmailFromIDToken() throws {
@@ -56,7 +59,7 @@ final class ProviderPlanDisplayTests: XCTestCase {
         let credential = try ClaudeCredentialReader.decode(jsonString: json, source: .cliDetected)
 
         XCTAssertEqual(credential.rateLimitTier, "default_claude_max_20x")
-        XCTAssertEqual(ProviderPlanDisplay.displayName(for: .claude, rawPlan: credential.rateLimitTier), "Max")
+        XCTAssertEqual(ProviderPlanDisplay.displayName(for: .claude, rawPlan: credential.rateLimitTier), "Claude Max")
     }
 
     func testMiscProviderDisplayNamesUseNormalizedPlanNames() {


### PR DESCRIPTION
## Summary
- consolidate all Vibe Bar-owned credentials into one versioned Keychain Vault with password-assisted, non-interactive migration
- align provider-page padding, improve the full-height forecast confidence band, and remove the redundant actual-bar legend
- standardize provider plan badges and distinguish Gemini Web from AntiGravity; detect explicit SuperGrok Heavy tiers
- enlarge AntiGravity reset timing text and document the single-Vault repository rule

## Test plan
- [x] swift test (655 tests)
- [x] ./Scripts/build_app.sh release
- [x] codesign -d --entitlements - ".build/Vibe Bar.app" (empty dict)
- [x] codesign --verify --deep --strict ".build/Vibe Bar.app"
- [x] git diff --check

Co-Authored-By: Codex <noreply@openai.com>