### PR TITLE
Refine forecast interval contact geometry

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -666,14 +666,18 @@ Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
 - **Forecast overlays need one coherent visual vocabulary.** The current quota
   remains the primary summary-bar layer. The elapsed-time-only pace uses the
   substantial neutral inset tick established by `PaceMarkerCapsule`; the
-  forecast-at-reset median is a verdict-colored vertical tick; the confidence
-  interval is a context-aware solid capsule through exactly the bar's original
-  full height. Use verdict color over the unfilled track, a solid mixed bridge
-  over the actual fill, and a narrow curved background seam at the bridge's
-  trailing cap. Keep that seam visible even when the forecast interval is
-  fully contained by the actual fill; it may overflow horizontally by a few
-  pixels, but never vertically. Do not use a translucent wash, gradient, or
-  square color cut, and never make the quota bar look thicker. Legends
+  forecast-at-reset median is a verdict-colored vertical tick. The confidence
+  interval always stays within the bar's original full height and follows four
+  explicit geometries. Ordinary intervals use an opaque solid overlay. In Used
+  mode, an interval that starts exactly at the actual endpoint overlaps it by
+  one rounded cap radius with no dark seam; when the actual endpoint falls
+  strictly inside the interval, keep the interval's rounded lower cap laid over
+  the complete actual fill and draw the curved background seam only at that
+  actual endpoint. When actual, interval, and median all crowd the lower axis,
+  both Used and Remaining modes use the same translucent full-height tint with
+  a complete rounded outline and emphasized far edge. Do not expose the track
+  through the lower rounded cap, use gradients or square color cuts, or make
+  the quota bar look thicker. Legends
   must use the same marker shapes as the bar — never show a solid sample for a
   dashed mark, reduce the wall-clock reference to a hairline, or turn the
   forecast into a dot. Used/Remaining projection must be performed through one

--- a/Sources/VibeBarApp/Views/PaceMarkerCapsule.swift
+++ b/Sources/VibeBarApp/Views/PaceMarkerCapsule.swift
@@ -67,10 +67,10 @@ struct PaceMarkerCapsule: View {
 /// The actual fill remains the dominant layer. A substantial neutral tick
 /// marks where usage should be *now* under a time-only pace. A
 /// status-colored tick marks the projected usage *at reset*. The confidence
-/// interval is a full-height, context-aware solid capsule: forecast color over
-/// the unfilled track, a mixed bridge over the actual fill, and a narrow curved
-/// seam where those two regions meet. It is intentionally not a second bar or
-/// a gradient.
+/// interval is a full-height capsule. It is opaque in ordinary geometry, uses
+/// a soft overlap or curved endpoint seam for the two Used-mode contact cases,
+/// and switches to an outlined tint when every mark crowds the lower axis. It
+/// is intentionally not a second bar or a gradient.
 struct ForecastQuotaBar: View {
     let percent: Double
     let mode: DisplayMode
@@ -85,21 +85,26 @@ struct ForecastQuotaBar: View {
         GeometryReader { proxy in
             let width = proxy.size.width
             let fillFraction = clamp(percent, 0, 100) / 100
-            let lower = forecastProjection.lowerPercent / 100
-            let upper = forecastProjection.upperPercent / 100
             let median = forecastProjection.medianPercent / 100
             let timePace = timePacePercent.map { clamp($0, 0, 100) / 100 }
             let forecastLineWidth = max(3.2, min(4.2, height * 0.30))
             let paceMarkerWidth = max(4.5, min(5.5, height * 0.42))
             let minimumBandWidth = forecastLineWidth + 6
-            let band = confidenceBandLayout(
-                width: width,
-                lower: lower,
-                upper: upper,
-                minimumWidth: minimumBandWidth
+            let band = forecastProjection.confidenceBandLayout(
+                actualDisplayedPercent: clamp(percent, 0, 100),
+                minimumVisibleWidthPercent: width > 0 ? minimumBandWidth / width * 100 : 100,
+                contactTolerancePercent: width > 0 ? 0.5 / width * 100 : 100
             )
-            let actualFillWidth = min(width, max(height, width * fillFraction))
-            let bandOverlapWidth = max(0, min(band.width, actualFillWidth - band.x))
+            let naturalBandX = width * band.startPercent / 100
+            let naturalBandWidth = width * band.widthPercent / 100
+            let softJoinOverlap = band.style == .softJoin
+                ? min(height / 2, naturalBandX)
+                : 0
+            let bandX = naturalBandX - softJoinOverlap
+            let bandWidth = naturalBandWidth + softJoinOverlap
+            let bandOverlapWidth = band.style == .softJoin
+                ? softJoinOverlap
+                : width * band.overlapPercent / 100
             let seamWidth = min(3, max(2, height * 0.25))
             let actualColor = Theme.barColor(percent: percent, mode: mode)
             let visibleForecastColor = colorScheme == .dark
@@ -118,13 +123,14 @@ struct ForecastQuotaBar: View {
 
                 if forecastProjection.hasUncertainty {
                     confidenceBand(
+                        style: band.style,
                         actualColor: actualColor,
                         overlapWidth: bandOverlapWidth,
                         seamWidth: seamWidth,
                         visibleForecastColor: visibleForecastColor
                     )
-                    .frame(width: band.width, height: height, alignment: .leading)
-                    .offset(x: band.x)
+                    .frame(width: bandWidth, height: height, alignment: .leading)
+                    .offset(x: bandX)
                 }
 
                 if let timePace, timePacePercent.map({ $0 > 2 && $0 < 98 }) == true {
@@ -151,20 +157,67 @@ struct ForecastQuotaBar: View {
 
     @ViewBuilder
     private func confidenceBand(
+        style: QuotaForecastBandStyle,
         actualColor: Color,
         overlapWidth: CGFloat,
         seamWidth: CGFloat,
+        visibleForecastColor: Color
+    ) -> some View {
+        switch style {
+        case .outlinedTint:
+            ZStack(alignment: .trailing) {
+                Capsule(style: .continuous)
+                    .fill(visibleForecastColor.opacity(colorScheme == .dark ? 0.30 : 0.18))
+                Capsule(style: .continuous)
+                    .strokeBorder(visibleForecastColor.opacity(0.88), lineWidth: 1)
+                RoundedRectangle(cornerRadius: 1, style: .continuous)
+                    .fill(visibleForecastColor.opacity(0.95))
+                    .frame(width: 2, height: max(4, height - 4))
+                    .padding(.trailing, 1)
+            }
+
+        case .softJoin:
+            Capsule(style: .continuous)
+                .fill(visibleForecastColor)
+
+        case .opaque:
+            solidConfidenceBand(
+                actualColor: actualColor,
+                overlapWidth: overlapWidth,
+                seamWidth: seamWidth,
+                showsCurvedSeam: false,
+                visibleForecastColor: visibleForecastColor
+            )
+
+        case .curvedSeam:
+            solidConfidenceBand(
+                actualColor: actualColor,
+                overlapWidth: overlapWidth,
+                seamWidth: seamWidth,
+                showsCurvedSeam: true,
+                visibleForecastColor: visibleForecastColor
+            )
+        }
+    }
+
+    private func solidConfidenceBand(
+        actualColor: Color,
+        overlapWidth: CGFloat,
+        seamWidth: CGFloat,
+        showsCurvedSeam: Bool,
         visibleForecastColor: Color
     ) -> some View {
         ZStack(alignment: .leading) {
             Capsule(style: .continuous)
                 .fill(visibleForecastColor)
 
-            if overlapWidth > 0.5 {
+            if showsCurvedSeam {
                 Capsule(style: .continuous)
                     .fill(confidenceSeamColor)
                     .frame(width: overlapWidth + seamWidth)
+            }
 
+            if overlapWidth > 0.5 {
                 Capsule(style: .continuous)
                     .fill(actualColor.mix(with: visibleForecastColor, by: 0.42))
                     .frame(width: overlapWidth)
@@ -182,30 +235,6 @@ struct ForecastQuotaBar: View {
 
     private func markerOffset(width: CGFloat, fraction: Double, markerWidth: CGFloat) -> CGFloat {
         max(0, min(width - markerWidth, width * fraction - markerWidth / 2))
-    }
-
-    private func confidenceBandLayout(
-        width: CGFloat,
-        lower: Double,
-        upper: Double,
-        minimumWidth: CGFloat
-    ) -> (x: CGFloat, width: CGFloat) {
-        let naturalStart = width * lower
-        let naturalEnd = width * upper
-        let naturalWidth = max(0, naturalEnd - naturalStart)
-        guard naturalWidth < minimumWidth else {
-            return (naturalStart, naturalWidth)
-        }
-        if lower <= 0 {
-            return (0, min(width, minimumWidth))
-        }
-        if upper >= 1 {
-            let bandWidth = min(width, minimumWidth)
-            return (max(0, width - bandWidth), bandWidth)
-        }
-        let bandWidth = min(width, minimumWidth)
-        let center = (naturalStart + naturalEnd) / 2
-        return (max(0, min(width - bandWidth, center - bandWidth / 2)), bandWidth)
     }
 
     private func neutralPaceMarker(width: CGFloat) -> some View {

--- a/Sources/VibeBarCore/Adapters/GeminiWebResponseParser.swift
+++ b/Sources/VibeBarCore/Adapters/GeminiWebResponseParser.swift
@@ -145,6 +145,16 @@ enum GeminiWebResponseParser {
         guard !buckets.isEmpty else {
             throw QuotaError.parseFailure("Gemini Web jSf9Qc returned no buckets.")
         }
+        // Google's bucket array is not stable across refreshes: live
+        // responses may list the weekly window before the shorter current
+        // window. Every Gemini surface renders this array directly, so lock
+        // the user-facing cadence to 5 Hours -> Weekly and keep any future
+        // unknown buckets after the two known windows.
+        buckets.sort { lhs, rhs in
+            let lhsRank = displayRank(forBucketId: lhs.id)
+            let rhsRank = displayRank(forBucketId: rhs.id)
+            return lhsRank == rhsRank ? lhs.id < rhs.id : lhsRank < rhsRank
+        }
         return GeminiResponseParser.Snapshot(buckets: buckets, planName: planName, email: email)
     }
 
@@ -186,6 +196,14 @@ enum GeminiWebResponseParser {
                 shortLabel: "B\(type)",
                 windowSeconds: nil
             )
+        }
+    }
+
+    private static func displayRank(forBucketId id: String) -> Int {
+        switch id {
+        case currentUsageBucketId: return 0
+        case weeklyUsageBucketId: return 1
+        default: return 2
         }
     }
 

--- a/Sources/VibeBarCore/Models/QuotaForecastBarProjection.swift
+++ b/Sources/VibeBarCore/Models/QuotaForecastBarProjection.swift
@@ -6,6 +6,7 @@ import Foundation
 /// overflow information while guaranteeing the visible marker stays inside
 /// the visible confidence band in both Used and Remaining display modes.
 public struct QuotaForecastBarProjection: Sendable, Equatable {
+    public let displayMode: DisplayMode
     public let lowerPercent: Double
     public let upperPercent: Double
     public let medianPercent: Double
@@ -19,6 +20,7 @@ public struct QuotaForecastBarProjection: Sendable, Equatable {
         projectedUsedMedianPercent: Double,
         displayMode: DisplayMode
     ) {
+        self.displayMode = displayMode
         let usedLower = min(projectedUsedLowerPercent, projectedUsedUpperPercent)
         let usedUpper = max(projectedUsedLowerPercent, projectedUsedUpperPercent)
 
@@ -54,5 +56,102 @@ public struct QuotaForecastBarProjection: Sendable, Equatable {
     private static func clamp(_ value: Double) -> Double {
         guard value.isFinite else { return 0 }
         return min(max(value, 0), 100)
+    }
+
+    /// Resolves the visible interval independently from the current fill.
+    /// `overlapPercent` is only the portion that receives the mixed bridge;
+    /// it never shortens `widthPercent`, so the interval may extend freely
+    /// beyond the actual-fill endpoint.
+    public func confidenceBandLayout(
+        actualDisplayedPercent: Double,
+        minimumVisibleWidthPercent: Double,
+        contactTolerancePercent: Double = 0.1,
+        axisPileupThresholdPercent: Double = 12
+    ) -> QuotaForecastBandLayout {
+        let minimumWidth = min(max(minimumVisibleWidthPercent, 0), 100)
+        let naturalWidth = max(0, upperPercent - lowerPercent)
+        let bandWidth: Double
+        let start: Double
+
+        if naturalWidth >= minimumWidth {
+            bandWidth = naturalWidth
+            start = lowerPercent
+        } else {
+            bandWidth = minimumWidth
+            if lowerPercent <= 0 {
+                start = 0
+            } else if upperPercent >= 100 {
+                start = max(0, 100 - bandWidth)
+            } else {
+                let center = (lowerPercent + upperPercent) / 2
+                start = min(max(center - bandWidth / 2, 0), 100 - bandWidth)
+            }
+        }
+
+        let actualEnd = min(max(actualDisplayedPercent, 0), 100)
+        let overlap = max(0, min(bandWidth, actualEnd - start))
+        let tolerance = max(0, contactTolerancePercent)
+        let pileupThreshold = min(max(axisPileupThresholdPercent, 0), 100)
+        let style: QuotaForecastBandStyle
+
+        if actualEnd <= pileupThreshold,
+           upperPercent <= pileupThreshold,
+           medianPercent <= pileupThreshold
+        {
+            // Near the lower axis, the current fill, interval and median can
+            // collapse into only a handful of pixels. Use one translucent,
+            // fully outlined pill in both display modes so all boundaries
+            // remain legible without adding an artificial gap.
+            style = .outlinedTint
+        } else if displayMode == .used,
+                  abs(actualEnd - lowerPercent) <= tolerance
+        {
+            // The interval starts exactly where observed usage ends. A small
+            // visual cap overlap is cleaner than a dark contact seam.
+            style = .softJoin
+        } else if displayMode == .used,
+                  actualEnd > lowerPercent + tolerance,
+                  actualEnd < upperPercent - tolerance
+        {
+            // Observed usage ends inside the interval. Preserve the interval's
+            // rounded lower bound and mark only the actual endpoint with the
+            // curved seam.
+            style = .curvedSeam
+        } else {
+            style = .opaque
+        }
+
+        return QuotaForecastBandLayout(
+            startPercent: start,
+            widthPercent: bandWidth,
+            overlapPercent: overlap,
+            style: style
+        )
+    }
+}
+
+public enum QuotaForecastBandStyle: Sendable, Equatable {
+    case opaque
+    case softJoin
+    case curvedSeam
+    case outlinedTint
+}
+
+public struct QuotaForecastBandLayout: Sendable, Equatable {
+    public let startPercent: Double
+    public let widthPercent: Double
+    public let overlapPercent: Double
+    public let style: QuotaForecastBandStyle
+
+    public init(
+        startPercent: Double,
+        widthPercent: Double,
+        overlapPercent: Double,
+        style: QuotaForecastBandStyle
+    ) {
+        self.startPercent = startPercent
+        self.widthPercent = widthPercent
+        self.overlapPercent = overlapPercent
+        self.style = style
     }
 }

--- a/Tests/VibeBarCoreTests/GeminiWebResponseParserTests.swift
+++ b/Tests/VibeBarCoreTests/GeminiWebResponseParserTests.swift
@@ -110,8 +110,9 @@ final class GeminiWebResponseParserTests: XCTestCase {
     }
 
     func testParseTolerantOfBucketOrderingInResponse() throws {
-        // Same buckets but listed weekly-then-current. UI-side aggregation
-        // looks up by id, so ordering inside the array must not matter.
+        // Same buckets but listed weekly-then-current. The parser must
+        // canonicalize them because Gemini quota cards render this array
+        // directly and otherwise flip after refreshes.
         let inner =
             "[2,[" +
             "[4500,0.1,2,[[1779815111,884621000]]]," +
@@ -119,8 +120,10 @@ final class GeminiWebResponseParserTests: XCTestCase {
             "],false]"
         let snapshot = try GeminiWebResponseParser.parse(data: Self.wireFormat(inner: inner))
         XCTAssertEqual(snapshot.buckets.count, 2)
-        XCTAssertNotNil(snapshot.buckets.first(where: { $0.id == GeminiWebResponseParser.currentUsageBucketId }))
-        XCTAssertNotNil(snapshot.buckets.first(where: { $0.id == GeminiWebResponseParser.weeklyUsageBucketId }))
+        XCTAssertEqual(snapshot.buckets.map(\.id), [
+            GeminiWebResponseParser.currentUsageBucketId,
+            GeminiWebResponseParser.weeklyUsageBucketId
+        ])
     }
 
     func testCurrentUltraPayloadMapsTierSixAndDropsInternalSentinel() throws {

--- a/Tests/VibeBarCoreTests/QuotaForecastBarProjectionTests.swift
+++ b/Tests/VibeBarCoreTests/QuotaForecastBarProjectionTests.swift
@@ -46,4 +46,155 @@ final class QuotaForecastBarProjectionTests: XCTestCase {
         XCTAssertEqual(projection.medianPercent, 75)
         XCTAssertTrue(projection.lowerPercent...projection.upperPercent ~= projection.medianPercent)
     }
+
+    func testUsedBandFullyInsideActualFillUsesOrdinaryOpaqueOverlay() {
+        let projection = QuotaForecastBarProjection(
+            projectedUsedLowerPercent: 40,
+            projectedUsedUpperPercent: 60,
+            projectedUsedMedianPercent: 50,
+            displayMode: .used
+        )
+
+        let layout = projection.confidenceBandLayout(
+            actualDisplayedPercent: 80,
+            minimumVisibleWidthPercent: 2
+        )
+
+        XCTAssertEqual(layout.startPercent, 40)
+        XCTAssertEqual(layout.widthPercent, 20)
+        XCTAssertEqual(layout.overlapPercent, 20)
+        XCTAssertEqual(layout.style, .opaque)
+    }
+
+    func testUsedBandWithActualEndpointInsideIntervalUsesCurvedSeam() {
+        let projection = QuotaForecastBarProjection(
+            projectedUsedLowerPercent: 40,
+            projectedUsedUpperPercent: 80,
+            projectedUsedMedianPercent: 65,
+            displayMode: .used
+        )
+
+        let layout = projection.confidenceBandLayout(
+            actualDisplayedPercent: 60,
+            minimumVisibleWidthPercent: 2
+        )
+
+        XCTAssertEqual(layout.startPercent, 40)
+        XCTAssertEqual(layout.widthPercent, 40)
+        XCTAssertEqual(layout.overlapPercent, 20)
+        XCTAssertEqual(layout.style, .curvedSeam)
+        XCTAssertEqual(layout.startPercent + layout.widthPercent, 80)
+        XCTAssertGreaterThan(layout.startPercent + layout.widthPercent, 60)
+    }
+
+    func testUsedBandOutsideActualFillRemainsFullyVisibleAndOpaque() {
+        let projection = QuotaForecastBarProjection(
+            projectedUsedLowerPercent: 70,
+            projectedUsedUpperPercent: 90,
+            projectedUsedMedianPercent: 80,
+            displayMode: .used
+        )
+
+        let layout = projection.confidenceBandLayout(
+            actualDisplayedPercent: 50,
+            minimumVisibleWidthPercent: 2
+        )
+
+        XCTAssertEqual(layout.startPercent, 70)
+        XCTAssertEqual(layout.widthPercent, 20)
+        XCTAssertEqual(layout.overlapPercent, 0)
+        XCTAssertEqual(layout.style, .opaque)
+    }
+
+    func testUsedBandStartingAtActualEndpointUsesSoftJoin() {
+        let projection = QuotaForecastBarProjection(
+            projectedUsedLowerPercent: 40,
+            projectedUsedUpperPercent: 60,
+            projectedUsedMedianPercent: 50,
+            displayMode: .used
+        )
+
+        let layout = projection.confidenceBandLayout(
+            actualDisplayedPercent: 40,
+            minimumVisibleWidthPercent: 2
+        )
+
+        XCTAssertEqual(layout.startPercent, 40)
+        XCTAssertEqual(layout.overlapPercent, 0)
+        XCTAssertEqual(layout.style, .softJoin)
+    }
+
+    func testUsedBandPileupAtLowerAxisUsesOutlinedTint() {
+        let projection = QuotaForecastBarProjection(
+            projectedUsedLowerPercent: 0,
+            projectedUsedUpperPercent: 10,
+            projectedUsedMedianPercent: 2,
+            displayMode: .used
+        )
+
+        let layout = projection.confidenceBandLayout(
+            actualDisplayedPercent: 0,
+            minimumVisibleWidthPercent: 2
+        )
+
+        XCTAssertEqual(layout.overlapPercent, 0)
+        XCTAssertEqual(layout.style, .outlinedTint)
+    }
+
+    func testRemainingBandPileupAtLowerAxisUsesSameOutlinedTint() {
+        let projection = QuotaForecastBarProjection(
+            projectedUsedLowerPercent: 95,
+            projectedUsedUpperPercent: 100,
+            projectedUsedMedianPercent: 98,
+            displayMode: .remaining
+        )
+
+        let layout = projection.confidenceBandLayout(
+            actualDisplayedPercent: 5,
+            minimumVisibleWidthPercent: 2
+        )
+
+        XCTAssertEqual(layout.startPercent, 0)
+        XCTAssertEqual(layout.widthPercent, 5)
+        XCTAssertEqual(layout.overlapPercent, 5)
+        XCTAssertEqual(layout.style, .outlinedTint)
+    }
+
+    func testRemainingBandReachingActualEndpointStaysOpaque() {
+        let projection = QuotaForecastBarProjection(
+            projectedUsedLowerPercent: 42,
+            projectedUsedUpperPercent: 53,
+            projectedUsedMedianPercent: 46,
+            displayMode: .remaining
+        )
+
+        let layout = projection.confidenceBandLayout(
+            actualDisplayedPercent: 58,
+            minimumVisibleWidthPercent: 2
+        )
+
+        XCTAssertEqual(layout.startPercent, 47)
+        XCTAssertEqual(layout.widthPercent, 11)
+        XCTAssertEqual(layout.overlapPercent, 11)
+        XCTAssertEqual(layout.style, .opaque)
+    }
+
+    func testCurvedSeamKeepsRoundedLowerBoundInsideActualFill() {
+        let projection = QuotaForecastBarProjection(
+            projectedUsedLowerPercent: 36,
+            projectedUsedUpperPercent: 60,
+            projectedUsedMedianPercent: 51,
+            displayMode: .used
+        )
+
+        let layout = projection.confidenceBandLayout(
+            actualDisplayedPercent: 42,
+            minimumVisibleWidthPercent: 2
+        )
+
+        XCTAssertEqual(layout.startPercent, 36)
+        XCTAssertEqual(layout.widthPercent, 24)
+        XCTAssertEqual(layout.overlapPercent, 6)
+        XCTAssertEqual(layout.style, .curvedSeam)
+    }
 }


### PR DESCRIPTION
## Summary
- render ordinary, exact-touch, endpoint-inside, and lower-axis pileup forecast intervals with distinct verified geometries
- use the selected transparent outlined treatment for R3 and U4 without changing bar height
- keep Gemini Web quota buckets in stable 5 Hours then Weekly order across refreshes
- document the forecast overlay rules in AGENTS.md

## Test plan
- [x] swift build
- [x] swift test (664 tests, 0 failures)
- [x] ./Scripts/build_app.sh release
- [x] codesign --verify --deep --strict .build/Vibe Bar.app
- [x] verified empty entitlements dictionary