### PR TITLE
Refine forecast interval separation and pileup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -669,8 +669,10 @@ Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
   forecast-at-reset median is a verdict-colored vertical tick. The confidence
   interval always stays within the bar's original full height and follows four
   explicit geometries. Ordinary intervals use an opaque solid overlay. In Used
-  mode, an interval that starts exactly at the actual endpoint overlaps it by
-  one rounded cap radius with no dark seam; when the actual endpoint falls
+  mode, an interval separated from the actual endpoint stays opaque and uses a
+  quiet centerline connector whose ends tuck beneath both rounded caps. An
+  interval that starts exactly at the actual endpoint overlaps it by one
+  rounded cap radius with no dark seam; when the actual endpoint falls
   strictly inside the interval, keep the interval's rounded lower cap laid over
   the complete actual fill and draw the curved background seam only at that
   actual endpoint. When actual, interval, and median all crowd the lower axis,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -675,11 +675,14 @@ Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
   rounded cap radius with no dark seam; when the actual endpoint falls
   strictly inside the interval, keep the interval's rounded lower cap laid over
   the complete actual fill and draw the curved background seam only at that
-  actual endpoint. When actual, interval, and median all crowd the lower axis,
-  both Used and Remaining modes use the same translucent full-height tint with
-  a complete rounded outline and emphasized far edge. Do not expose the track
-  through the lower rounded cap, use gradients or square color cuts, or make
-  the quota bar look thicker. Legends
+  actual endpoint. When Used-mode actual, interval, and median all crowd the
+  lower axis, use a translucent full-height tint with a complete rounded
+  outline and emphasized far edge. In Remaining mode, forecasts stay inside
+  the current remaining fill; at 8% remaining or below, preserve that fill as
+  the capsule silhouette and render the confidence interval as a narrow,
+  borderless inset color core. Do not expose the track through the lower
+  rounded cap, use gradients or square color cuts, or make the quota bar look
+  thicker. Legends
   must use the same marker shapes as the bar — never show a solid sample for a
   dashed mark, reduce the wall-clock reference to a hairline, or turn the
   forecast into a dot. Used/Remaining projection must be performed through one

--- a/Sources/VibeBarApp/Views/PaceMarkerCapsule.swift
+++ b/Sources/VibeBarApp/Views/PaceMarkerCapsule.swift
@@ -105,6 +105,11 @@ struct ForecastQuotaBar: View {
             let bandOverlapWidth = band.style == .softJoin
                 ? softJoinOverlap
                 : width * band.overlapPercent / 100
+            let actualFillWidth = min(width, max(height, width * fillFraction))
+            let connectorCapOverlap = height / 2
+            let connectorStartX = max(0, actualFillWidth - connectorCapOverlap)
+            let connectorEndX = min(width, bandX + connectorCapOverlap)
+            let connectorWidth = max(0, connectorEndX - connectorStartX)
             let seamWidth = min(3, max(2, height * 0.25))
             let actualColor = Theme.barColor(percent: percent, mode: mode)
             let visibleForecastColor = colorScheme == .dark
@@ -115,9 +120,20 @@ struct ForecastQuotaBar: View {
                 ZStack(alignment: .leading) {
                     Capsule(style: .continuous)
                         .fill(Theme.barTrack)
+
+                    if forecastProjection.hasUncertainty,
+                       band.showsGapConnector,
+                       connectorWidth > 0.5
+                    {
+                        Capsule(style: .continuous)
+                            .fill(visibleForecastColor.opacity(colorScheme == .dark ? 0.34 : 0.24))
+                            .frame(width: connectorWidth, height: max(1.5, min(2.5, height * 0.18)))
+                            .offset(x: connectorStartX)
+                    }
+
                     Capsule(style: .continuous)
                         .fill(Theme.barColor(percent: percent, mode: mode))
-                        .frame(width: max(height, width * fillFraction))
+                        .frame(width: actualFillWidth)
                 }
                 .clipShape(Capsule(style: .continuous))
 

--- a/Sources/VibeBarApp/Views/PaceMarkerCapsule.swift
+++ b/Sources/VibeBarApp/Views/PaceMarkerCapsule.swift
@@ -69,8 +69,10 @@ struct PaceMarkerCapsule: View {
 /// status-colored tick marks the projected usage *at reset*. The confidence
 /// interval is a full-height capsule. It is opaque in ordinary geometry, uses
 /// a soft overlap or curved endpoint seam for the two Used-mode contact cases,
-/// and switches to an outlined tint when every mark crowds the lower axis. It
-/// is intentionally not a second bar or a gradient.
+/// and switches to an outlined tint when every Used-mode mark crowds the lower
+/// axis. In the equivalent Remaining-mode extreme, the interval becomes a
+/// narrow inset color core so the actual fill keeps one clean silhouette. It is
+/// intentionally not a second bar or a gradient.
 struct ForecastQuotaBar: View {
     let percent: Double
     let mode: DisplayMode
@@ -180,6 +182,11 @@ struct ForecastQuotaBar: View {
         visibleForecastColor: Color
     ) -> some View {
         switch style {
+        case .insetTint:
+            Capsule(style: .continuous)
+                .fill(visibleForecastColor.opacity(colorScheme == .dark ? 0.78 : 0.68))
+                .frame(height: max(3, height * 0.42))
+
         case .outlinedTint:
             ZStack(alignment: .trailing) {
                 Capsule(style: .continuous)

--- a/Sources/VibeBarCore/Models/QuotaForecastBarProjection.swift
+++ b/Sources/VibeBarCore/Models/QuotaForecastBarProjection.swift
@@ -121,11 +121,16 @@ public struct QuotaForecastBarProjection: Sendable, Equatable {
             style = .opaque
         }
 
+        let showsGapConnector = displayMode == .used
+            && style == .opaque
+            && start > actualEnd + tolerance
+
         return QuotaForecastBandLayout(
             startPercent: start,
             widthPercent: bandWidth,
             overlapPercent: overlap,
-            style: style
+            style: style,
+            showsGapConnector: showsGapConnector
         )
     }
 }
@@ -142,16 +147,19 @@ public struct QuotaForecastBandLayout: Sendable, Equatable {
     public let widthPercent: Double
     public let overlapPercent: Double
     public let style: QuotaForecastBandStyle
+    public let showsGapConnector: Bool
 
     public init(
         startPercent: Double,
         widthPercent: Double,
         overlapPercent: Double,
-        style: QuotaForecastBandStyle
+        style: QuotaForecastBandStyle,
+        showsGapConnector: Bool
     ) {
         self.startPercent = startPercent
         self.widthPercent = widthPercent
         self.overlapPercent = overlapPercent
         self.style = style
+        self.showsGapConnector = showsGapConnector
     }
 }

--- a/Sources/VibeBarCore/Models/QuotaForecastBarProjection.swift
+++ b/Sources/VibeBarCore/Models/QuotaForecastBarProjection.swift
@@ -66,11 +66,12 @@ public struct QuotaForecastBarProjection: Sendable, Equatable {
         actualDisplayedPercent: Double,
         minimumVisibleWidthPercent: Double,
         contactTolerancePercent: Double = 0.1,
-        axisPileupThresholdPercent: Double = 12
+        axisPileupThresholdPercent: Double = 12,
+        remainingInsetThresholdPercent: Double = 8
     ) -> QuotaForecastBandLayout {
         let minimumWidth = min(max(minimumVisibleWidthPercent, 0), 100)
         let naturalWidth = max(0, upperPercent - lowerPercent)
-        let bandWidth: Double
+        var bandWidth: Double
         let start: Double
 
         if naturalWidth >= minimumWidth {
@@ -89,19 +90,34 @@ public struct QuotaForecastBarProjection: Sendable, Equatable {
         }
 
         let actualEnd = min(max(actualDisplayedPercent, 0), 100)
-        let overlap = max(0, min(bandWidth, actualEnd - start))
+        var overlap = max(0, min(bandWidth, actualEnd - start))
         let tolerance = max(0, contactTolerancePercent)
         let pileupThreshold = min(max(axisPileupThresholdPercent, 0), 100)
+        let remainingInsetThreshold = min(max(remainingInsetThresholdPercent, 0), 100)
         let style: QuotaForecastBandStyle
 
-        if actualEnd <= pileupThreshold,
-           upperPercent <= pileupThreshold,
-           medianPercent <= pileupThreshold
+        if displayMode == .remaining,
+           actualEnd <= remainingInsetThreshold,
+           upperPercent <= actualEnd + tolerance,
+           medianPercent <= actualEnd + tolerance
+        {
+            // A Remaining-mode forecast cannot exceed the quota remaining now.
+            // When all of that geometry crowds the lower axis, keep the actual
+            // fill's capsule as the silhouette and render the interval as an
+            // inset color core inside it. The minimum-width expansion must not
+            // push that core beyond the current remaining endpoint.
+            bandWidth = min(bandWidth, max(0, actualEnd - start))
+            overlap = min(overlap, bandWidth)
+            style = .insetTint
+        } else if displayMode == .used,
+                  actualEnd <= pileupThreshold,
+                  upperPercent <= pileupThreshold,
+                  medianPercent <= pileupThreshold
         {
             // Near the lower axis, the current fill, interval and median can
-            // collapse into only a handful of pixels. Use one translucent,
-            // fully outlined pill in both display modes so all boundaries
-            // remain legible without adding an artificial gap.
+            // collapse into only a handful of pixels. Used mode can project
+            // beyond the current fill, so retain the outlined tint that keeps
+            // those coincident boundaries legible.
             style = .outlinedTint
         } else if displayMode == .used,
                   abs(actualEnd - lowerPercent) <= tolerance
@@ -140,6 +156,7 @@ public enum QuotaForecastBandStyle: Sendable, Equatable {
     case softJoin
     case curvedSeam
     case outlinedTint
+    case insetTint
 }
 
 public struct QuotaForecastBandLayout: Sendable, Equatable {

--- a/Tests/VibeBarCoreTests/QuotaForecastBarProjectionTests.swift
+++ b/Tests/VibeBarCoreTests/QuotaForecastBarProjectionTests.swift
@@ -144,7 +144,7 @@ final class QuotaForecastBarProjectionTests: XCTestCase {
         XCTAssertEqual(layout.style, .outlinedTint)
     }
 
-    func testRemainingBandPileupAtLowerAxisUsesSameOutlinedTint() {
+    func testRemainingBandPileupAtLowerAxisUsesInsetTint() {
         let projection = QuotaForecastBarProjection(
             projectedUsedLowerPercent: 95,
             projectedUsedUpperPercent: 100,
@@ -160,7 +160,47 @@ final class QuotaForecastBarProjectionTests: XCTestCase {
         XCTAssertEqual(layout.startPercent, 0)
         XCTAssertEqual(layout.widthPercent, 5)
         XCTAssertEqual(layout.overlapPercent, 5)
-        XCTAssertEqual(layout.style, .outlinedTint)
+        XCTAssertEqual(layout.style, .insetTint)
+        XCTAssertFalse(layout.showsGapConnector)
+    }
+
+    func testRemainingInsetTintNeverExtendsBeyondActualFill() {
+        let projection = QuotaForecastBarProjection(
+            projectedUsedLowerPercent: 99.7,
+            projectedUsedUpperPercent: 100,
+            projectedUsedMedianPercent: 99.9,
+            displayMode: .remaining
+        )
+
+        let layout = projection.confidenceBandLayout(
+            actualDisplayedPercent: 0.4,
+            minimumVisibleWidthPercent: 2
+        )
+
+        XCTAssertEqual(layout.style, .insetTint)
+        XCTAssertEqual(layout.startPercent, 0)
+        XCTAssertEqual(layout.widthPercent, 0.4, accuracy: 0.0001)
+        XCTAssertEqual(layout.overlapPercent, 0.4, accuracy: 0.0001)
+        XCTAssertLessThanOrEqual(layout.startPercent + layout.widthPercent, 0.4)
+    }
+
+    func testRemainingBandAboveExtremeThresholdUsesOrdinaryOpaqueOverlay() {
+        let projection = QuotaForecastBarProjection(
+            projectedUsedLowerPercent: 89,
+            projectedUsedUpperPercent: 94,
+            projectedUsedMedianPercent: 92,
+            displayMode: .remaining
+        )
+
+        let layout = projection.confidenceBandLayout(
+            actualDisplayedPercent: 11,
+            minimumVisibleWidthPercent: 2
+        )
+
+        XCTAssertEqual(layout.startPercent, 6)
+        XCTAssertEqual(layout.widthPercent, 5)
+        XCTAssertEqual(layout.style, .opaque)
+        XCTAssertFalse(layout.showsGapConnector)
     }
 
     func testRemainingBandReachingActualEndpointStaysOpaque() {

--- a/Tests/VibeBarCoreTests/QuotaForecastBarProjectionTests.swift
+++ b/Tests/VibeBarCoreTests/QuotaForecastBarProjectionTests.swift
@@ -64,6 +64,7 @@ final class QuotaForecastBarProjectionTests: XCTestCase {
         XCTAssertEqual(layout.widthPercent, 20)
         XCTAssertEqual(layout.overlapPercent, 20)
         XCTAssertEqual(layout.style, .opaque)
+        XCTAssertFalse(layout.showsGapConnector)
     }
 
     func testUsedBandWithActualEndpointInsideIntervalUsesCurvedSeam() {
@@ -104,6 +105,7 @@ final class QuotaForecastBarProjectionTests: XCTestCase {
         XCTAssertEqual(layout.widthPercent, 20)
         XCTAssertEqual(layout.overlapPercent, 0)
         XCTAssertEqual(layout.style, .opaque)
+        XCTAssertTrue(layout.showsGapConnector)
     }
 
     func testUsedBandStartingAtActualEndpointUsesSoftJoin() {
@@ -122,6 +124,7 @@ final class QuotaForecastBarProjectionTests: XCTestCase {
         XCTAssertEqual(layout.startPercent, 40)
         XCTAssertEqual(layout.overlapPercent, 0)
         XCTAssertEqual(layout.style, .softJoin)
+        XCTAssertFalse(layout.showsGapConnector)
     }
 
     func testUsedBandPileupAtLowerAxisUsesOutlinedTint() {
@@ -177,6 +180,7 @@ final class QuotaForecastBarProjectionTests: XCTestCase {
         XCTAssertEqual(layout.widthPercent, 11)
         XCTAssertEqual(layout.overlapPercent, 11)
         XCTAssertEqual(layout.style, .opaque)
+        XCTAssertFalse(layout.showsGapConnector)
     }
 
     func testCurvedSeamKeepsRoundedLowerBoundInsideActualFill() {


### PR DESCRIPTION
## Summary
- restore the quiet U3 connector between the actual Used bar and a detached forecast interval
- tuck the connector beneath both rounded caps so only the true gap is visible
- keep the current fill as the silhouette when Remaining quota falls to 8% or below
- render that crowded Remaining interval as a borderless inset color core and clamp it inside the actual fill
- document both forecast geometries in AGENTS.md

## Test plan
- [x] swift build
- [x] swift test (666 tests, 0 failures)
- [x] ./Scripts/build_app.sh release
- [x] empty entitlements verified
- [x] codesign --verify --deep --strict .build/Vibe Bar.app