### PR TITLE
Recognize proportional quota reset signals

### DIFF
--- a/Sources/VibeBarCore/Models/SubscriptionWindowSample.swift
+++ b/Sources/VibeBarCore/Models/SubscriptionWindowSample.swift
@@ -1,8 +1,8 @@
 import Foundation
 
 /// One inferred subscription cycle for a quota bucket. The active cycle is
-/// updated in place; it becomes a historical sample only after a refill is
-/// observed (usage falls materially) or a scheduled reset is crossed.
+/// updated in place; it becomes a historical sample after a refill is inferred
+/// from usage, a proportional reset-time advance, or both signals together.
 public struct SubscriptionWindowSample: Codable, Hashable, Sendable {
     public enum CompletionReason: String, Codable, Hashable, Sendable {
         case refillDetected

--- a/Sources/VibeBarCore/Services/SubscriptionHistoryStore.swift
+++ b/Sources/VibeBarCore/Services/SubscriptionHistoryStore.swift
@@ -136,9 +136,10 @@ public actor SubscriptionHistoryStore {
         save(storage)
     }
 
-    /// One-time best-effort migration from the old hourly fill timeline. Only
-    /// material downward jumps become completed cycles; ordinary samples are
-    /// intentionally discarded so the new chart starts truthful.
+    /// One-time best-effort migration from the old hourly fill timeline.
+    /// Material downward jumps and proportional reset-time advances become
+    /// completed cycles; ordinary samples are intentionally discarded so the
+    /// new chart starts truthful.
     public func importLegacyTimeline(
         _ points: [FillTimelinePoint],
         retentionDays: Int = CostDataSettings.defaultRetentionDays

--- a/Sources/VibeBarCore/Services/SubscriptionHistoryStore.swift
+++ b/Sources/VibeBarCore/Services/SubscriptionHistoryStore.swift
@@ -2,26 +2,33 @@ import Foundation
 
 /// Persists inferred subscription cycles, not point-in-time samples.
 ///
-/// A changing `resetAt` is only a forecast and is never used as cycle
-/// identity. The active cycle is finalized when usage materially drops (the
-/// provider refilled the quota), with crossing the previous reset boundary as
-/// a secondary signal. This avoids the old failure mode where a few seconds of
-/// reset-time drift created thousands of fake weekly cycles.
+/// Small `resetAt` changes remain forecast drift, but a move of at least ten
+/// percent of the quota window is independent reset evidence. The active cycle
+/// is finalized when usage materially drops, reset time clearly advances, or
+/// concordant weak usage/reset signals jointly cross the evidence threshold.
+/// This catches low-use and between-poll refills without turning a few seconds
+/// of reset-time drift into thousands of fake weekly cycles.
 public actor SubscriptionHistoryStore {
     public static let shared = SubscriptionHistoryStore()
 
     private struct Storage: Codable {
         var schemaVersion: Int
         var legacyTimelineImported: Bool
+        /// One-time repair pass for reset transitions that older builds missed
+        /// because they required a five-point usage drop. Optional keeps
+        /// schema-v2 files backward compatible.
+        var resetSignalRepairVersion: Int?
         var samples: [SubscriptionWindowSample]
 
         init(
             schemaVersion: Int = SubscriptionHistoryStore.storageSchemaVersion,
             legacyTimelineImported: Bool = false,
+            resetSignalRepairVersion: Int? = nil,
             samples: [SubscriptionWindowSample] = []
         ) {
             self.schemaVersion = schemaVersion
             self.legacyTimelineImported = legacyTimelineImported
+            self.resetSignalRepairVersion = resetSignalRepairVersion
             self.samples = samples
         }
     }
@@ -37,6 +44,11 @@ public actor SubscriptionHistoryStore {
     private static let storageSchemaVersion = 2
     private static let saveThrottleInterval: TimeInterval = 30
     private static let maxFileBytes = 16 * 1024 * 1024
+    private static let currentResetSignalRepairVersion = 1
+    private static let strongResetAdvanceFraction = 0.10
+    private static let weakResetAdvanceFraction = 0.01
+    private static let minimumStrongUsageDrop = 0.5
+    private static let minimumWeakUsageDrop = 0.25
     private static let supportedTools: Set<ToolType> = [
         .codex, .claude, .gemini, .antigravity, .grok
     ]
@@ -132,9 +144,25 @@ public actor SubscriptionHistoryStore {
         retentionDays: Int = CostDataSettings.defaultRetentionDays
     ) {
         var storage = load()
-        guard !storage.legacyTimelineImported else { return }
-        storage.legacyTimelineImported = true
+        let needsLegacyImport = !storage.legacyTimelineImported
+        let needsResetSignalRepair = (storage.resetSignalRepairVersion ?? 0)
+            < Self.currentResetSignalRepairVersion
+        guard needsLegacyImport || needsResetSignalRepair else { return }
 
+        if needsLegacyImport {
+            storage.legacyTimelineImported = true
+            importMaterialRefills(points, into: &storage)
+        }
+
+        if needsResetSignalRepair {
+            repairMissedResetSignals(points, in: &storage)
+            storage.resetSignalRepairVersion = Self.currentResetSignalRepairVersion
+        }
+        pruneInPlace(&storage, retentionDays: retentionDays, now: Date())
+        save(storage)
+    }
+
+    private func importMaterialRefills(_ points: [FillTimelinePoint], into storage: inout Storage) {
         let grouped = Dictionary(grouping: points) {
             SubscriptionHistoryKey(accountId: $0.accountId, bucketId: $0.bucketId)
         }
@@ -170,8 +198,151 @@ public actor SubscriptionHistoryStore {
                 previous = point
             }
         }
-        pruneInPlace(&storage, retentionDays: retentionDays, now: Date())
-        save(storage)
+    }
+
+    /// Replays retained point observations once with the current reset-signal
+    /// model. This repairs low-utilization and reset-time-only transitions
+    /// missed by older builds without manufacturing cycles from ordinary
+    /// reset forecast drift.
+    private func repairMissedResetSignals(
+        _ points: [FillTimelinePoint],
+        in storage: inout Storage
+    ) {
+        let grouped = Dictionary(grouping: points) {
+            SubscriptionHistoryKey(accountId: $0.accountId, bucketId: $0.bucketId)
+        }
+        for (_, rawPoints) in grouped {
+            let sorted = rawPoints.sorted { $0.sampledAt < $1.sampledAt }
+            guard let first = sorted.first,
+                  sorted.count > 1,
+                  Self.supportedTools.contains(first.tool)
+            else { continue }
+
+            var previous = first
+            var segmentStart = first.sampledAt
+            var segmentPeak = clamp(first.usedPercent)
+            var segmentObservationCount = 1
+            var addedRepair = false
+
+            for point in sorted.dropFirst() {
+                let currentUsed = clamp(point.usedPercent)
+                let windowSeconds = previous.rawWindowSeconds ?? point.rawWindowSeconds
+                let previousResetAt = previous.resetAt ?? previous.sampledAt
+                let provisional = SubscriptionWindowSample(
+                    accountId: first.accountId,
+                    tool: first.tool,
+                    bucketId: first.bucketId,
+                    windowEnd: previousResetAt,
+                    windowStart: segmentStart,
+                    rawWindowSeconds: windowSeconds,
+                    peakUsedPercent: segmentPeak,
+                    lastUsedPercent: clamp(previous.usedPercent),
+                    observationCount: segmentObservationCount,
+                    firstSeenAt: segmentStart,
+                    lastSeenAt: previous.sampledAt
+                )
+                let newResetAt = point.resetAt ?? previousResetAt
+                let reason = completionReason(
+                    for: provisional,
+                    newUsedPercent: currentUsed,
+                    newResetAt: newResetAt,
+                    now: point.sampledAt
+                )
+
+                if let reason {
+                    if !hasNearbyCompletedSample(
+                        accountId: first.accountId,
+                        bucketId: first.bucketId,
+                        completedAt: point.sampledAt,
+                        windowSeconds: windowSeconds,
+                        in: storage.samples
+                    ) {
+                        storage.samples.append(SubscriptionWindowSample(
+                            accountId: first.accountId,
+                            tool: first.tool,
+                            bucketId: first.bucketId,
+                            windowEnd: point.sampledAt,
+                            windowStart: segmentStart,
+                            rawWindowSeconds: windowSeconds,
+                            peakUsedPercent: segmentPeak,
+                            lastUsedPercent: clamp(previous.usedPercent),
+                            observationCount: segmentObservationCount,
+                            firstSeenAt: segmentStart,
+                            lastSeenAt: previous.sampledAt,
+                            completedAt: point.sampledAt,
+                            completionReason: reason
+                        ))
+                        addedRepair = true
+                    }
+                    segmentStart = point.sampledAt
+                    segmentPeak = currentUsed
+                    segmentObservationCount = 1
+                } else {
+                    segmentPeak = max(segmentPeak, currentUsed)
+                    segmentObservationCount += 1
+                }
+                previous = point
+            }
+
+            guard addedRepair else { continue }
+            let activeIndex = storage.samples.indices
+                .filter {
+                    storage.samples[$0].accountId == first.accountId
+                        && storage.samples[$0].bucketId == first.bucketId
+                        && !storage.samples[$0].isCompleted
+                }
+                .max { storage.samples[$0].lastSeenAt < storage.samples[$1].lastSeenAt }
+            guard let activeIndex,
+                  storage.samples[activeIndex].firstSeenAt < segmentStart
+            else { continue }
+
+            let currentResetAt = previous.resetAt ?? storage.samples[activeIndex].windowEnd
+            let currentWindowSeconds = previous.rawWindowSeconds
+                ?? storage.samples[activeIndex].rawWindowSeconds
+            storage.samples[activeIndex] = SubscriptionWindowSample(
+                accountId: first.accountId,
+                tool: first.tool,
+                bucketId: first.bucketId,
+                windowEnd: currentResetAt,
+                windowStart: currentWindowSeconds.map {
+                    currentResetAt.addingTimeInterval(-TimeInterval($0))
+                } ?? segmentStart,
+                rawWindowSeconds: currentWindowSeconds,
+                peakUsedPercent: segmentPeak,
+                lastUsedPercent: clamp(previous.usedPercent),
+                observationCount: segmentObservationCount,
+                firstSeenAt: segmentStart,
+                lastSeenAt: previous.sampledAt
+            )
+        }
+    }
+
+    private func hasNearbyCompletedSample(
+        accountId: String,
+        bucketId: String,
+        completedAt: Date,
+        windowSeconds: Int?,
+        in samples: [SubscriptionWindowSample]
+    ) -> Bool {
+        let tolerance = Self.repairDuplicateTolerance(windowSeconds: windowSeconds)
+        return samples.contains {
+            $0.accountId == accountId
+                && $0.bucketId == bucketId
+                && $0.completedAt.map { abs($0.timeIntervalSince(completedAt)) <= tolerance } == true
+        }
+    }
+
+    private static func repairDuplicateTolerance(windowSeconds: Int?) -> TimeInterval {
+        switch windowSeconds {
+        case let seconds? where seconds <= 6 * 3_600:
+            return 10 * 60
+        case let seconds? where seconds <= 8 * 86_400:
+            return 2 * 3_600
+        case let seconds? where seconds <= 45 * 86_400:
+            return 12 * 3_600
+        default:
+            return 2 * 3_600
+        }
     }
 
     public func samples(
@@ -237,10 +408,28 @@ public actor SubscriptionHistoryStore {
         }
 
         let window = TimeInterval(current.rawWindowSeconds ?? 86_400)
-        let meaningfulAdvance = max(300, window * 0.2)
+        let resetAdvance = max(0, newResetAt.timeIntervalSince(current.windowEnd))
+        let meaningfulAdvance = max(300, window * Self.strongResetAdvanceFraction)
+        if resetAdvance >= meaningfulAdvance {
+            // A provider can refill and consume again between polls, so a
+            // clear move into the next reset window is sufficient even when
+            // the newly observed usage is equal to or above the old value.
+            return .scheduledReset
+        }
+
+        let weakAdvance = max(300, window * Self.weakResetAdvanceFraction)
         let crossedOldBoundary = now >= current.windowEnd.addingTimeInterval(-120)
-        let resetForecastAdvanced = newResetAt.timeIntervalSince(current.windowEnd) >= meaningfulAdvance
-        if crossedOldBoundary && resetForecastAdvanced {
+        if crossedOldBoundary && resetAdvance >= weakAdvance {
+            return .scheduledReset
+        }
+
+        let usageDrop = max(0, current.lastUsedPercent - newUsedPercent)
+        let usageThreshold = Self.materialRefillThreshold(previous: current.lastUsedPercent)
+        if usageDrop >= Self.minimumWeakUsageDrop,
+           resetAdvance >= weakAdvance,
+           usageDrop / usageThreshold + resetAdvance / meaningfulAdvance >= 1 {
+            // Two concordant weak signals can identify a refill even though
+            // neither clears its standalone threshold.
             return .scheduledReset
         }
         return nil
@@ -250,9 +439,13 @@ public actor SubscriptionHistoryStore {
         let normalizedPrevious = min(100, max(0, previous))
         let normalizedPeak = min(100, max(0, peak))
         let normalizedCurrent = min(100, max(0, current))
-        let threshold = max(5, min(15, normalizedPeak * 0.2))
+        let threshold = materialRefillThreshold(previous: normalizedPrevious)
         return normalizedPrevious - normalizedCurrent >= threshold
             && normalizedPeak - normalizedCurrent >= threshold
+    }
+
+    private static func materialRefillThreshold(previous: Double) -> Double {
+        max(minimumStrongUsageDrop, min(15, previous * 0.2))
     }
 
     private func makeCurrentSample(

--- a/Tests/VibeBarCoreTests/SubscriptionHistoryStoreTests.swift
+++ b/Tests/VibeBarCoreTests/SubscriptionHistoryStoreTests.swift
@@ -286,6 +286,260 @@ final class SubscriptionHistoryStoreTests: XCTestCase {
         XCTAssertFalse(samples[0].isCompleted)
     }
 
+    func testOnePercentToZeroCompletesLowUsageCycle() async throws {
+        let (store, _, cleanup) = try makeTempStore()
+        defer { cleanup() }
+        let now = Date()
+        let reset = now.addingTimeInterval(3 * 86_400)
+
+        await store.observe(
+            quota(tool: .codex, buckets: [
+                bucket(
+                    id: "gpt_5_3_codex_spark_weekly",
+                    usedPercent: 1,
+                    resetAt: reset,
+                    rawWindowSeconds: 604_800,
+                    groupTitle: "GPT-5.3 Codex Spark"
+                )
+            ]),
+            now: now,
+            retentionDays: 30
+        )
+        await store.observe(
+            quota(tool: .codex, buckets: [
+                bucket(
+                    id: "gpt_5_3_codex_spark_weekly",
+                    usedPercent: 0,
+                    resetAt: reset,
+                    rawWindowSeconds: 604_800,
+                    groupTitle: "GPT-5.3 Codex Spark"
+                )
+            ]),
+            now: now.addingTimeInterval(60),
+            retentionDays: 30
+        )
+
+        let samples = await store.samples(
+            accountId: "acct-test",
+            bucketId: "gpt_5_3_codex_spark_weekly"
+        )
+        XCTAssertEqual(samples.count, 2)
+        XCTAssertEqual(samples.filter(\.isCompleted).count, 1)
+        XCTAssertEqual(samples.first(where: \.isCompleted)?.peakUsedPercent, 1)
+        XCTAssertEqual(samples.first(where: \.isCompleted)?.completionReason, .refillDetected)
+    }
+
+    func testFiveHourTwoHourResetAdvanceCompletesEvenWhenUsageIncreases() async throws {
+        let (store, _, cleanup) = try makeTempStore()
+        defer { cleanup() }
+        let now = Date()
+        let reset = now.addingTimeInterval(3 * 3_600)
+
+        await store.observe(
+            quota(tool: .claude, buckets: [
+                bucket(id: "five_hour", usedPercent: 20, resetAt: reset, rawWindowSeconds: 18_000)
+            ]),
+            now: now,
+            retentionDays: 30
+        )
+        await store.observe(
+            quota(tool: .claude, buckets: [
+                bucket(
+                    id: "five_hour",
+                    usedPercent: 35,
+                    resetAt: reset.addingTimeInterval(2 * 3_600),
+                    rawWindowSeconds: 18_000
+                )
+            ]),
+            now: now.addingTimeInterval(60),
+            retentionDays: 30
+        )
+
+        let samples = await store.samples(accountId: "acct-test", bucketId: "five_hour")
+        XCTAssertEqual(samples.count, 2)
+        XCTAssertEqual(samples.filter(\.isCompleted).count, 1)
+        XCTAssertEqual(samples.first(where: \.isCompleted)?.completionReason, .scheduledReset)
+        XCTAssertEqual(samples.first(where: { !$0.isCompleted })?.lastUsedPercent, 35)
+    }
+
+    func testWeeklyThreeDayResetAdvanceCompletesEvenWhenUsageIncreases() async throws {
+        let (store, _, cleanup) = try makeTempStore()
+        defer { cleanup() }
+        let now = Date()
+        let reset = now.addingTimeInterval(3 * 86_400)
+
+        await store.observe(
+            quota(tool: .claude, buckets: [
+                bucket(id: "weekly", usedPercent: 20, resetAt: reset, rawWindowSeconds: 604_800)
+            ]),
+            now: now,
+            retentionDays: 30
+        )
+        await store.observe(
+            quota(tool: .claude, buckets: [
+                bucket(
+                    id: "weekly",
+                    usedPercent: 35,
+                    resetAt: reset.addingTimeInterval(3 * 86_400),
+                    rawWindowSeconds: 604_800
+                )
+            ]),
+            now: now.addingTimeInterval(60),
+            retentionDays: 30
+        )
+
+        let samples = await store.samples(accountId: "acct-test", bucketId: "weekly")
+        XCTAssertEqual(samples.count, 2)
+        XCTAssertEqual(samples.filter(\.isCompleted).count, 1)
+        XCTAssertEqual(samples.first(where: \.isCompleted)?.completionReason, .scheduledReset)
+    }
+
+    func testResetAdvanceBelowTenPercentDoesNotCompleteByItself() async throws {
+        let (store, _, cleanup) = try makeTempStore()
+        defer { cleanup() }
+        let now = Date()
+        let reset = now.addingTimeInterval(3 * 3_600)
+
+        await store.observe(
+            quota(tool: .claude, buckets: [
+                bucket(id: "five_hour", usedPercent: 20, resetAt: reset, rawWindowSeconds: 18_000)
+            ]),
+            now: now,
+            retentionDays: 30
+        )
+        await store.observe(
+            quota(tool: .claude, buckets: [
+                bucket(
+                    id: "five_hour",
+                    usedPercent: 21,
+                    resetAt: reset.addingTimeInterval(20 * 60),
+                    rawWindowSeconds: 18_000
+                )
+            ]),
+            now: now.addingTimeInterval(60),
+            retentionDays: 30
+        )
+
+        let samples = await store.samples(accountId: "acct-test", bucketId: "five_hour")
+        XCTAssertEqual(samples.count, 1)
+        XCTAssertFalse(samples[0].isCompleted)
+    }
+
+    func testWeakUsageDropAndWeakResetAdvanceCombineIntoReset() async throws {
+        let (store, _, cleanup) = try makeTempStore()
+        defer { cleanup() }
+        let now = Date()
+        let reset = now.addingTimeInterval(3 * 86_400)
+
+        await store.observe(
+            quota(tool: .claude, buckets: [
+                bucket(id: "weekly", usedPercent: 10, resetAt: reset, rawWindowSeconds: 604_800)
+            ]),
+            now: now,
+            retentionDays: 30
+        )
+        await store.observe(
+            quota(tool: .claude, buckets: [
+                bucket(
+                    id: "weekly",
+                    usedPercent: 9,
+                    resetAt: reset.addingTimeInterval(604_800 * 0.05),
+                    rawWindowSeconds: 604_800
+                )
+            ]),
+            now: now.addingTimeInterval(60),
+            retentionDays: 30
+        )
+
+        let samples = await store.samples(accountId: "acct-test", bucketId: "weekly")
+        XCTAssertEqual(samples.count, 2)
+        XCTAssertEqual(samples.filter(\.isCompleted).count, 1)
+        XCTAssertEqual(samples.first(where: \.isCompleted)?.completionReason, .scheduledReset)
+    }
+
+    func testOneTimeRepairSplitsMissedLowUsageResetFromRetainedTimeline() async throws {
+        struct ExistingStorage: Codable {
+            let schemaVersion: Int
+            let legacyTimelineImported: Bool
+            let samples: [SubscriptionWindowSample]
+        }
+
+        let (store, fileURL, cleanup) = try makeTempStore()
+        defer { cleanup() }
+        let now = Date()
+        let oldReset = now.addingTimeInterval(3 * 86_400)
+        let transition = now.addingTimeInterval(3_600)
+        let newReset = oldReset.addingTimeInterval(3 * 86_400)
+        let active = SubscriptionWindowSample(
+            accountId: "acct-test",
+            tool: .codex,
+            bucketId: "gpt_5_3_codex_spark_weekly",
+            windowEnd: newReset,
+            windowStart: now,
+            rawWindowSeconds: 604_800,
+            peakUsedPercent: 1,
+            lastUsedPercent: 0,
+            observationCount: 20,
+            firstSeenAt: now,
+            lastSeenAt: transition.addingTimeInterval(3_600)
+        )
+        let encoded = try JSONEncoder().encode(ExistingStorage(
+            schemaVersion: 2,
+            legacyTimelineImported: true,
+            samples: [active]
+        ))
+        try encoded.write(to: fileURL, options: .atomic)
+
+        let points = [
+            FillTimelinePoint(
+                accountId: "acct-test",
+                tool: .codex,
+                bucketId: "gpt_5_3_codex_spark_weekly",
+                slotStart: now,
+                usedPercent: 1,
+                sampledAt: now,
+                resetAt: oldReset,
+                rawWindowSeconds: 604_800
+            ),
+            FillTimelinePoint(
+                accountId: "acct-test",
+                tool: .codex,
+                bucketId: "gpt_5_3_codex_spark_weekly",
+                slotStart: transition,
+                usedPercent: 0,
+                sampledAt: transition,
+                resetAt: newReset,
+                rawWindowSeconds: 604_800
+            ),
+            FillTimelinePoint(
+                accountId: "acct-test",
+                tool: .codex,
+                bucketId: "gpt_5_3_codex_spark_weekly",
+                slotStart: transition.addingTimeInterval(3_600),
+                usedPercent: 0,
+                sampledAt: transition.addingTimeInterval(3_600),
+                resetAt: newReset,
+                rawWindowSeconds: 604_800
+            )
+        ]
+
+        await store.importLegacyTimeline(points, retentionDays: 30)
+        await store.importLegacyTimeline(points, retentionDays: 30)
+
+        let samples = await store.samples(
+            accountId: "acct-test",
+            bucketId: "gpt_5_3_codex_spark_weekly"
+        )
+        XCTAssertEqual(samples.count, 2)
+        let completed = try XCTUnwrap(samples.first(where: \.isCompleted))
+        XCTAssertEqual(completed.peakUsedPercent, 1)
+        XCTAssertEqual(completed.lastUsedPercent, 1)
+        let current = try XCTUnwrap(samples.first(where: { !$0.isCompleted }))
+        XCTAssertEqual(current.peakUsedPercent, 0)
+        XCTAssertEqual(current.lastUsedPercent, 0)
+        XCTAssertEqual(current.firstSeenAt, transition)
+    }
+
     func testLegacyTimelineImportsOnlyDetectedRefills() async throws {
         let (store, _, cleanup) = try makeTempStore()
         defer { cleanup() }


### PR DESCRIPTION
## Summary
- infer quota resets from material usage drops, reset-time advances of at least 10% of the quota window, or concordant weak signals
- recognize resets even when usage rises between polls, while ignoring ordinary reset forecast drift
- run a one-time repair over retained fill timeline data so missed low-use Spark-style cycles become visible without duplicating history

## Test plan
- [x] `swift test --filter SubscriptionHistoryStoreTests` (17 tests)
- [x] `swift test` (672 tests)
- [x] `swift build`
- [x] `./Scripts/build_app.sh release`
- [x] `codesign -d --entitlements - ".build/Vibe Bar.app"` (empty dictionary)
- [x] `codesign --verify --deep --strict ".build/Vibe Bar.app"`

## Covered cases
- Weekly reset advances by 3 days while usage increases
- 5 Hours reset advances by 2 hours while usage increases
- Spark usage falls from 1% to 0%
- sub-10% reset drift alone does not create a cycle
- weak usage and reset evidence can jointly identify a reset