### PR TITLE
Auto-calibrate Gemini Web quota refresh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -663,6 +663,15 @@ Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
   retain the legacy elapsed-time `UsagePace` reserve/deficit calculation and
   `PaceMarkerCapsule`; do not route Misc through the personal forecast model
   unless AQ explicitly asks to change that product boundary.
+- **Gemini Web quota requests are learned, not guessed.** Keep normal refresh
+  on the lightweight URLSession replay path using the persisted, non-secret
+  usage recipe. If Google rotates the private batchexecute rpcid or argument,
+  the App-layer hidden usage WebView must observe the page's own request,
+  verify the two-bucket payload against rendered percentages, persist only the
+  recipe, and immediately return that quota. Do not substitute an unrelated
+  Google rpcid from search results, persist response bodies/cookies, or route
+  Gemini live quota through Gemini CLI credentials. Always normalize the
+  resulting buckets to 5 Hours followed by Weekly.
 - **Forecast overlays need one coherent visual vocabulary.** The current quota
   remains the primary summary-bar layer. The elapsed-time-only pace uses the
   substantial neutral inset tick established by `PaceMarkerCapsule`; the

--- a/Sources/VibeBarApp/AppEnvironment.swift
+++ b/Sources/VibeBarApp/AppEnvironment.swift
@@ -56,7 +56,13 @@ final class AppEnvironment: ObservableObject {
             retentionProvider: { [weak settings] in
                 settings?.settings.costData.retentionDays ?? CostDataSettings.defaultRetentionDays
             },
-            initialAccountIds: accounts.accounts.map(\.id)
+            initialAccountIds: accounts.accounts.map(\.id),
+            geminiWebFallback: { account, cookieHeader in
+                try await GeminiWebQuotaCalibrator.shared.fetch(
+                    account: account,
+                    cookieHeader: cookieHeader
+                )
+            }
         )
 
         self.settingsStore = settings

--- a/Sources/VibeBarApp/GeminiWebQuotaCalibrator.swift
+++ b/Sources/VibeBarApp/GeminiWebQuotaCalibrator.swift
@@ -1,0 +1,344 @@
+import Foundation
+import WebKit
+import VibeBarCore
+
+/// Learns Gemini Web's current private usage request from the page itself.
+/// This is only entered after the lightweight URLSession replay fails.
+@MainActor
+final class GeminiWebQuotaCalibrator {
+    static let shared = GeminiWebQuotaCalibrator()
+
+    private var inflight: [String: Task<AccountQuota, Error>] = [:]
+    private var sessions: [ObjectIdentifier: GeminiCalibrationSession] = [:]
+
+    func fetch(account: AccountIdentity, cookieHeader: String) async throws -> AccountQuota {
+        if let task = inflight[account.id] {
+            return try await task.value
+        }
+        let task = Task { @MainActor [weak self] () throws -> AccountQuota in
+            guard let self else {
+                throw QuotaError.unknown("Gemini Web calibration was cancelled.")
+            }
+            return try await self.perform(account: account, cookieHeader: cookieHeader)
+        }
+        inflight[account.id] = task
+        defer { inflight[account.id] = nil }
+        return try await task.value
+    }
+
+    private func perform(account: AccountIdentity, cookieHeader: String) async throws -> AccountQuota {
+        let session = GeminiCalibrationSession(account: account, cookieHeader: cookieHeader)
+        let key = ObjectIdentifier(session)
+        sessions[key] = session
+        defer { sessions[key] = nil }
+        return try await session.start()
+    }
+}
+
+@MainActor
+private final class GeminiCalibrationSession: NSObject, WKNavigationDelegate, WKScriptMessageHandler {
+    private struct Candidate {
+        let recipe: GeminiWebUsageRecipe
+        let snapshot: GeminiWebQuotaSnapshot
+    }
+
+    private let account: AccountIdentity
+    private let cookieHeader: String
+    private var webView: WKWebView?
+    private var continuation: CheckedContinuation<AccountQuota, Error>?
+    private var timeoutTask: Task<Void, Never>?
+    private var candidate: Candidate?
+    private var resolved = false
+    private var didRetryUsageNavigation = false
+
+    init(account: AccountIdentity, cookieHeader: String) {
+        self.account = account
+        self.cookieHeader = cookieHeader
+        super.init()
+    }
+
+    func start() async throws -> AccountQuota {
+        let dataStore = WKWebsiteDataStore.nonPersistent()
+        await injectCookies(into: dataStore.httpCookieStore)
+
+        return try await withCheckedThrowingContinuation { continuation in
+            self.continuation = continuation
+
+            let controller = WKUserContentController()
+            controller.addUserScript(WKUserScript(
+                source: Self.observerScript,
+                injectionTime: .atDocumentStart,
+                forMainFrameOnly: false,
+                in: .page
+            ))
+            controller.add(self, name: Self.messageName)
+
+            let config = WKWebViewConfiguration()
+            config.websiteDataStore = dataStore
+            config.userContentController = controller
+            config.defaultWebpagePreferences.allowsContentJavaScript = true
+            config.preferences.javaScriptCanOpenWindowsAutomatically = false
+
+            let webView = WKWebView(
+                frame: CGRect(x: 0, y: 0, width: 1_024, height: 768),
+                configuration: config
+            )
+            webView.customUserAgent = Self.safariUserAgent
+            webView.navigationDelegate = self
+            self.webView = webView
+
+            let request = URLRequest(
+                url: URL(string: "https://gemini.google.com/usage?pli=1&hl=en")!,
+                cachePolicy: .reloadIgnoringLocalAndRemoteCacheData
+            )
+            webView.load(request)
+
+            timeoutTask = Task { @MainActor [weak self] in
+                try? await Task.sleep(nanoseconds: 18_000_000_000)
+                guard let self, !Task.isCancelled else { return }
+                if let candidate = self.candidate {
+                    self.finish(with: .success(self.quota(from: candidate)))
+                } else {
+                    self.finish(with: .failure(QuotaError.parseFailure(
+                        "Gemini usage page did not expose a recognizable quota request."
+                    )))
+                }
+            }
+        }
+    }
+
+    func userContentController(_ userContentController: WKUserContentController,
+                               didReceive message: WKScriptMessage) {
+        guard message.name == Self.messageName,
+              let payload = message.body as? [String: Any],
+              let rpcID = payload["rpcID"] as? String,
+              let argument = payload["argument"] as? String,
+              let response = payload["response"] as? String else {
+            return
+        }
+        let recipe = GeminiWebUsageRecipe(rpcID: rpcID, argument: argument)
+        guard recipe.isValid,
+              let data = response.data(using: .utf8),
+              let snapshot = try? GeminiWebResponseParser.parse(
+                data: data,
+                rpcID: rpcID,
+                now: Date()
+              ),
+              Self.hasCanonicalBuckets(snapshot) else {
+            return
+        }
+
+        let candidate = Candidate(recipe: recipe, snapshot: snapshot)
+        self.candidate = candidate
+        Task { @MainActor [weak self] in
+            // Give Angular one rendering turn so page text and network data
+            // describe the same response before cross-checking.
+            try? await Task.sleep(nanoseconds: 450_000_000)
+            await self?.validateAgainstRenderedPage(candidate, attempt: 0)
+        }
+    }
+
+    func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
+        finish(with: .failure(QuotaError.network(error.localizedDescription)))
+    }
+
+    func webView(_ webView: WKWebView,
+                 didFailProvisionalNavigation navigation: WKNavigation!,
+                 withError error: Error) {
+        finish(with: .failure(QuotaError.network(error.localizedDescription)))
+    }
+
+    func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+        guard !didRetryUsageNavigation else { return }
+        didRetryUsageNavigation = true
+        Task { @MainActor [weak self, weak webView] in
+            try? await Task.sleep(nanoseconds: 2_000_000_000)
+            guard let self, let webView, !self.resolved, self.candidate == nil else { return }
+            // Some Gemini builds fill the first usage visit from bootstrap
+            // data and only issue the quota RPC on the next entry.
+            var components = URLComponents(string: "https://gemini.google.com/usage")
+            components?.queryItems = [
+                URLQueryItem(name: "pli", value: "1"),
+                URLQueryItem(name: "hl", value: "en"),
+                URLQueryItem(name: "_vibebar_probe", value: UUID().uuidString)
+            ]
+            guard let url = components?.url else { return }
+            webView.load(URLRequest(url: url, cachePolicy: .reloadIgnoringLocalAndRemoteCacheData))
+        }
+    }
+
+    private func validateAgainstRenderedPage(_ candidate: Candidate, attempt: Int) async {
+        guard !resolved, self.candidate?.recipe == candidate.recipe, let webView else { return }
+        let text = (try? await webView.evaluateJavaScript(
+            "document.body ? document.body.innerText : ''"
+        )) as? String ?? ""
+        let rendered = Self.renderedUsedPercents(in: text)
+
+        if !rendered.isEmpty {
+            let expected = candidate.snapshot.buckets
+                .filter { $0.id == GeminiWebResponseParser.currentUsageBucketId
+                    || $0.id == GeminiWebResponseParser.weeklyUsageBucketId }
+                .map(\.usedPercent)
+            let matches = expected.allSatisfy { value in
+                rendered.contains { abs($0 - value) <= 2.0 }
+            }
+            guard matches else { return }
+            finish(with: .success(quota(from: candidate)))
+            return
+        }
+
+        // Localized or still-loading pages may not expose the English
+        // "% used" labels immediately. Retry twice; the semantic two-bucket
+        // validation remains the final fallback at the session timeout.
+        guard attempt < 2 else { return }
+        try? await Task.sleep(nanoseconds: 700_000_000)
+        await validateAgainstRenderedPage(candidate, attempt: attempt + 1)
+    }
+
+    private func quota(from candidate: Candidate) -> AccountQuota {
+        try? GeminiWebUsageRecipeStore.save(candidate.recipe)
+        return AccountQuota(
+            accountId: account.id,
+            tool: .gemini,
+            buckets: candidate.snapshot.buckets,
+            plan: candidate.snapshot.planName,
+            email: candidate.snapshot.email,
+            queriedAt: Date(),
+            error: nil
+        )
+    }
+
+    private func finish(with result: Result<AccountQuota, Error>) {
+        guard !resolved else { return }
+        resolved = true
+        timeoutTask?.cancel()
+        timeoutTask = nil
+        if let controller = webView?.configuration.userContentController as WKUserContentController? {
+            controller.removeScriptMessageHandler(forName: Self.messageName)
+        }
+        webView?.stopLoading()
+        webView?.navigationDelegate = nil
+        webView = nil
+        let continuation = self.continuation
+        self.continuation = nil
+        continuation?.resume(with: result)
+    }
+
+    private func injectCookies(into store: WKHTTPCookieStore) async {
+        for pair in cookieHeader.split(separator: ";") {
+            let trimmed = pair.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard let equals = trimmed.firstIndex(of: "="), equals != trimmed.startIndex else { continue }
+            let name = String(trimmed[..<equals])
+            let value = String(trimmed[trimmed.index(after: equals)...])
+            guard let cookie = HTTPCookie(properties: [
+                .name: name,
+                .value: value,
+                .domain: ".gemini.google.com",
+                .path: "/",
+                .secure: true
+            ]) else { continue }
+            await withCheckedContinuation { continuation in
+                store.setCookie(cookie) { continuation.resume() }
+            }
+        }
+    }
+
+    private static func hasCanonicalBuckets(_ snapshot: GeminiWebQuotaSnapshot) -> Bool {
+        let ids = Set(snapshot.buckets.map(\.id))
+        return ids.contains(GeminiWebResponseParser.currentUsageBucketId)
+            && ids.contains(GeminiWebResponseParser.weeklyUsageBucketId)
+    }
+
+    private static func renderedUsedPercents(in text: String) -> [Double] {
+        guard let regex = try? NSRegularExpression(
+            pattern: #"(\d{1,3}(?:\.\d+)?)\s*%\s*used"#,
+            options: [.caseInsensitive]
+        ) else { return [] }
+        let ns = text as NSString
+        return regex.matches(in: text, range: NSRange(location: 0, length: ns.length))
+            .compactMap { match -> Double? in
+                guard match.numberOfRanges > 1 else { return nil }
+                return Double(ns.substring(with: match.range(at: 1)))
+            }
+    }
+
+    private static let messageName = "vibeBarGeminiUsageCapture"
+
+    /// MAIN-world interception is required because isolated-world scripts
+    /// cannot wrap the page's own fetch/XMLHttpRequest functions.
+    private static let observerScript = #"""
+    (() => {
+      if (window.__vibeBarUsageObserverInstalled) return;
+      window.__vibeBarUsageObserverInstalled = true;
+      const handler = window.webkit?.messageHandlers?.vibeBarGeminiUsageCapture;
+      if (!handler) return;
+
+      const recipes = (url, body) => {
+        try {
+          if (!String(url || '').includes('/batchexecute')) return [];
+          const params = new URLSearchParams(typeof body === 'string' ? body : '');
+          const raw = params.get('f.req');
+          if (!raw) return [];
+          const parsed = JSON.parse(raw);
+          const found = [];
+          const visit = value => {
+            if (!Array.isArray(value)) return;
+            if (typeof value[0] === 'string' &&
+                typeof value[1] === 'string' &&
+                value.length >= 2) {
+              found.push({ rpcID: value[0], argument: value[1] });
+            }
+            for (const child of value) visit(child);
+          };
+          visit(parsed);
+          return found;
+        } catch (_) {
+          return [];
+        }
+      };
+
+      const publish = (url, body, response) => {
+        if (typeof response !== 'string' || response.length === 0) return;
+        for (const recipe of recipes(url, body)) {
+          try { handler.postMessage({ ...recipe, response }); } catch (_) {}
+        }
+      };
+
+      const nativeFetch = window.fetch;
+      window.fetch = async function(input, init) {
+        let url = typeof input === 'string'
+          ? input
+          : (input instanceof Request ? input.url : String(input || ''));
+        let body = init?.body;
+        if (body instanceof URLSearchParams) body = body.toString();
+        if (typeof body !== 'string' && input instanceof Request) {
+          try { body = await input.clone().text(); } catch (_) {}
+        }
+        const response = await nativeFetch.apply(this, arguments);
+        try {
+          const text = await response.clone().text();
+          publish(url, body, text);
+        } catch (_) {}
+        return response;
+      };
+
+      const nativeOpen = XMLHttpRequest.prototype.open;
+      const nativeSend = XMLHttpRequest.prototype.send;
+      XMLHttpRequest.prototype.open = function(method, url) {
+        this.__vibeBarURL = String(url || '');
+        return nativeOpen.apply(this, arguments);
+      };
+      XMLHttpRequest.prototype.send = function(body) {
+        this.__vibeBarBody = typeof body === 'string' ? body : '';
+        this.addEventListener('load', () => {
+          try { publish(this.__vibeBarURL, this.__vibeBarBody, this.responseText); } catch (_) {}
+        }, { once: true });
+        return nativeSend.apply(this, arguments);
+      };
+    })();
+    """#
+
+    private nonisolated static var safariUserAgent: String {
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.0 Safari/605.1.15"
+    }
+}

--- a/Sources/VibeBarApp/Views/PopoverRoot.swift
+++ b/Sources/VibeBarApp/Views/PopoverRoot.swift
@@ -616,7 +616,7 @@ private struct GeminiCombinedCard: View {
     }
 
     /// Resolve the plan-badge text for a Gemini-family sub-tool. Looks
-    /// at the cached quota first (jSf9Qc returns "Pro" / "Ultra" /
+    /// at the cached quota first (Gemini Web returns "Pro" / "Ultra" /
     /// "Free") and falls back to the account-level plan string. nil
     /// when nothing meaningful is set so the caller suppresses the
     /// badge instead of drawing an empty pill.

--- a/Sources/VibeBarCore/Adapters/GeminiQuotaAdapter.swift
+++ b/Sources/VibeBarCore/Adapters/GeminiQuotaAdapter.swift
@@ -13,6 +13,8 @@ public struct GeminiQuotaAdapter: QuotaAdapter {
     private let session: URLSession
     private let now: @Sendable () -> Date
     private let cookieHeader: @Sendable () throws -> String
+    private let browserCookieImporter: @Sendable () -> GeminiBrowserCookieImporter.Result?
+    private let webFallback: (@Sendable (AccountIdentity, String) async throws -> AccountQuota)?
 
     public init(
         session: URLSession = .shared,
@@ -20,11 +22,17 @@ public struct GeminiQuotaAdapter: QuotaAdapter {
         now: @escaping @Sendable () -> Date = { Date() },
         cookieHeader: @escaping @Sendable () throws -> String = {
             try GeminiWebCookieStore.readCookieHeader()
-        }
+        },
+        browserCookieImporter: @escaping @Sendable () -> GeminiBrowserCookieImporter.Result? = {
+            GeminiBrowserCookieImporter.importFromBrowsers(allowKeychainPrompt: false)
+        },
+        webFallback: (@Sendable (AccountIdentity, String) async throws -> AccountQuota)? = nil
     ) {
         self.session = session
         self.now = now
         self.cookieHeader = cookieHeader
+        self.browserCookieImporter = browserCookieImporter
+        self.webFallback = webFallback
     }
 
     public func fetch(for account: AccountIdentity) async throws -> AccountQuota {
@@ -38,23 +46,41 @@ public struct GeminiQuotaAdapter: QuotaAdapter {
             throw QuotaError.noCredential
         }
         let fetcher = GeminiWebQuotaFetcher(session: session, now: now)
-        let snapshot: GeminiResponseParser.Snapshot
+        let snapshot: GeminiWebQuotaSnapshot
         do {
             snapshot = try await fetcher.fetch(cookieHeader: header)
-        } catch let initialError as QuotaError {
+        } catch let initialError {
             // Google rotates the browser session more often than Vibe Bar's
             // persisted Keychain copy. Refresh it directly from an installed
             // browser once before surfacing a login error; this keeps the
             // source purely gemini.google.com and never falls back to CLI
             // OAuth quota.
-            guard let imported = GeminiBrowserCookieImporter.importFromBrowsers(
-                allowKeychainPrompt: false
-            ), imported.header != header else {
-                throw initialError
+            if let imported = browserCookieImporter(), imported.header != header {
+                do {
+                    let refreshed = try await fetcher.fetch(cookieHeader: imported.header)
+                    try? GeminiWebCookieStore.writeCookieHeader(imported.header, source: .browser)
+                    return quota(from: refreshed, for: account)
+                } catch {
+                    if shouldCalibrate(error), let webFallback {
+                        let calibrated = try await webFallback(account, imported.header)
+                        try? GeminiWebCookieStore.writeCookieHeader(imported.header, source: .browser)
+                        return calibrated
+                    }
+                    throw error
+                }
             }
-            snapshot = try await fetcher.fetch(cookieHeader: imported.header)
-            try? GeminiWebCookieStore.writeCookieHeader(imported.header, source: .browser)
+            if shouldCalibrate(initialError), let webFallback {
+                return try await webFallback(account, header)
+            }
+            throw initialError
         }
+        return quota(from: snapshot, for: account)
+    }
+
+    private func quota(
+        from snapshot: GeminiWebQuotaSnapshot,
+        for account: AccountIdentity
+    ) -> AccountQuota {
         return AccountQuota(
             accountId: account.id,
             tool: .gemini,
@@ -64,6 +90,21 @@ public struct GeminiQuotaAdapter: QuotaAdapter {
             queriedAt: now(),
             error: nil
         )
+    }
+
+    private func shouldCalibrate(_ error: Error) -> Bool {
+        guard let quotaError = error as? QuotaError else { return false }
+        switch quotaError {
+        case .parseFailure:
+            return true
+        case .network(let message):
+            // Transport failures should surface immediately. Only an HTTP
+            // response from the private RPC itself indicates a likely rotated
+            // route/argument that WebKit can learn.
+            return message.contains("Gemini Web batchexecute HTTP")
+        case .noCredential, .needsLogin, .rateLimited, .notImplemented, .unknown:
+            return false
+        }
     }
 }
 

--- a/Sources/VibeBarCore/Adapters/GeminiWebAdapter.swift
+++ b/Sources/VibeBarCore/Adapters/GeminiWebAdapter.swift
@@ -3,48 +3,87 @@ import Foundation
 /// Fetches Gemini usage data from the signed-in `gemini.google.com`
 /// web session via imported browser cookies.
 ///
-/// The live quota data rendered by Gemini's `<usage-metrics-window>`
-/// Angular component comes from a private batchexecute RPC. Google renamed
-/// that RPC from `jSf9Qc` to `ESY5D` in July 2026 and changed its request
-/// argument from `[]` to a `bard_activity_enabled` feature list. Keep the
-/// live contract centralized below so request construction and response
-/// parsing cannot drift independently the next time the identifier moves.
+/// The live quota data rendered by Gemini's usage component comes from a
+/// private batchexecute RPC. Its identifier and argument are runtime
+/// implementation details, so Vibe Bar replays a small learned recipe and
+/// lets the App-layer hidden `/usage` WebView calibrate a replacement when
+/// Google changes it.
 ///
 /// Wire format (cookie-authenticated, no SAPISIDHASH required):
 /// - URL: `https://gemini.google.com/_/BardChatUi/data/batchexecute`
-///   with query items `rpcids=ESY5D&source-path=/usage&hl=en&_reqid=<rand>&rt=c`.
+///   with query items `rpcids=<learned>&source-path=/usage&hl=en&_reqid=<rand>&rt=c`.
 /// - Method: POST, `Content-Type:
 ///   application/x-www-form-urlencoded;charset=UTF-8`.
-/// - Body: `f.req=[[["ESY5D","[[[\"bard_activity_enabled\"]]]",null,
+/// - Body: `f.req=[[["<learned>","<learned args>",null,
 ///   "generic"]]]&at=<XSRF>&`. `at=` carries the
 ///   `WIZ_global_data.SNlM0e` XSRF token extracted from the SSR
 ///   HTML of `https://gemini.google.com/usage?pli=1`.
 /// - Response: JSONP-prefixed (`)]}'\n`) chunked stream. The
-///   `["wrb.fr","ESY5D","<encoded JSON>",...]` entry carries the
+///   `["wrb.fr","<learned>","<encoded JSON>",...]` entry carries the
 ///   payload. See `GeminiWebResponseParser` for the decoded shape.
 struct GeminiWebQuotaFetcher: Sendable {
     /// Set to `true` now that the live quota endpoint is implemented.
     static let spikeComplete = true
-    static let quotaRPCId = "ESY5D"
-    static let quotaRPCArgument = #"[[[\"bard_activity_enabled\"]]]"#
+    static let quotaRPCId = GeminiWebUsageRecipe.fallback.rpcID
 
     private let session: URLSession
     private let now: @Sendable () -> Date
+    private let recipeProvider: @Sendable () -> GeminiWebUsageRecipe
 
     init(
         session: URLSession = .shared,
-        now: @escaping @Sendable () -> Date = { Date() }
+        now: @escaping @Sendable () -> Date = { Date() },
+        recipeProvider: @escaping @Sendable () -> GeminiWebUsageRecipe = {
+            GeminiWebUsageRecipeStore.load()
+        }
     ) {
         self.session = session
         self.now = now
+        self.recipeProvider = recipeProvider
     }
 
-    func fetch(cookieHeader: String, email: String? = nil) async throws -> GeminiResponseParser.Snapshot {
+    func fetch(cookieHeader: String, email: String? = nil) async throws -> GeminiWebQuotaSnapshot {
         let trimmed = cookieHeader.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { throw QuotaError.noCredential }
         let xsrf = try await fetchXsrfToken(cookieHeader: trimmed)
-        let payload = try await postQuotaRequest(cookieHeader: trimmed, xsrfToken: xsrf)
-        return try GeminiWebResponseParser.parse(data: payload, email: email, now: now())
+        let learned = recipeProvider()
+        do {
+            return try await fetch(
+                recipe: learned,
+                cookieHeader: trimmed,
+                xsrfToken: xsrf,
+                email: email
+            )
+        } catch {
+            // A learned recipe can become stale. Retry the last broadly known
+            // contract once before asking WebKit to calibrate a new one.
+            guard learned != .fallback else { throw error }
+            return try await fetch(
+                recipe: .fallback,
+                cookieHeader: trimmed,
+                xsrfToken: xsrf,
+                email: email
+            )
+        }
+    }
+
+    private func fetch(
+        recipe: GeminiWebUsageRecipe,
+        cookieHeader: String,
+        xsrfToken: String,
+        email: String?
+    ) async throws -> GeminiWebQuotaSnapshot {
+        let payload = try await postQuotaRequest(
+            cookieHeader: cookieHeader,
+            xsrfToken: xsrfToken,
+            recipe: recipe
+        )
+        return try GeminiWebResponseParser.parse(
+            data: payload,
+            rpcID: recipe.rpcID,
+            email: email,
+            now: now()
+        )
     }
 
     private func fetchXsrfToken(cookieHeader: String) async throws -> String {
@@ -84,13 +123,17 @@ struct GeminiWebQuotaFetcher: Sendable {
         return try Self.extractXsrfToken(from: body)
     }
 
-    private func postQuotaRequest(cookieHeader: String, xsrfToken: String) async throws -> Data {
+    private func postQuotaRequest(
+        cookieHeader: String,
+        xsrfToken: String,
+        recipe: GeminiWebUsageRecipe
+    ) async throws -> Data {
         let reqid = Int.random(in: 100_000...999_999)
         guard var components = URLComponents(string: "https://gemini.google.com/_/BardChatUi/data/batchexecute") else {
             throw QuotaError.unknown("Gemini Web batchexecute URL malformed.")
         }
         components.queryItems = [
-            URLQueryItem(name: "rpcids", value: Self.quotaRPCId),
+            URLQueryItem(name: "rpcids", value: recipe.rpcID),
             URLQueryItem(name: "source-path", value: "/usage"),
             URLQueryItem(name: "hl", value: "en"),
             URLQueryItem(name: "_reqid", value: String(reqid)),
@@ -110,7 +153,11 @@ struct GeminiWebQuotaFetcher: Sendable {
         request.setValue(Self.safariUA, forHTTPHeaderField: "User-Agent")
         request.httpShouldHandleCookies = false
 
-        let innerArgs = #"[[["\#(Self.quotaRPCId)","\#(Self.quotaRPCArgument)",null,"generic"]]]"#
+        let requestEnvelope: [Any] = [[[recipe.rpcID, recipe.argument, NSNull(), "generic"]]]
+        guard let envelopeData = try? JSONSerialization.data(withJSONObject: requestEnvelope),
+              let innerArgs = String(data: envelopeData, encoding: .utf8) else {
+            throw QuotaError.parseFailure("Gemini Web request recipe could not be encoded.")
+        }
         let bodyString = "f.req=" + Self.formEncode(innerArgs)
             + "&at=" + Self.formEncode(xsrfToken) + "&"
         request.httpBody = bodyString.data(using: .utf8)

--- a/Sources/VibeBarCore/Adapters/GeminiWebAdapter.swift
+++ b/Sources/VibeBarCore/Adapters/GeminiWebAdapter.swift
@@ -3,30 +3,30 @@ import Foundation
 /// Fetches Gemini usage data from the signed-in `gemini.google.com`
 /// web session via imported browser cookies.
 ///
-/// 2026-05-23 spike resolved: the live quota data rendered by the
-/// `<usage-metrics-window>` Angular component comes from a hidden
-/// `jSf9Qc` batchexecute rpcid, not from the initial-load rpcid set
-/// the 2026-05-22 pass inspected. `jSf9Qc` only fires on the SECOND
-/// entry to `/usage` within a session (initial loads cache the
-/// bucket array client-side), so a clean page-load capture missed
-/// it. SPA-navigating to `/app` and back exposed it.
+/// The live quota data rendered by Gemini's `<usage-metrics-window>`
+/// Angular component comes from a private batchexecute RPC. Google renamed
+/// that RPC from `jSf9Qc` to `ESY5D` in July 2026 and changed its request
+/// argument from `[]` to a `bard_activity_enabled` feature list. Keep the
+/// live contract centralized below so request construction and response
+/// parsing cannot drift independently the next time the identifier moves.
 ///
 /// Wire format (cookie-authenticated, no SAPISIDHASH required):
 /// - URL: `https://gemini.google.com/_/BardChatUi/data/batchexecute`
-///   with query items `rpcids=jSf9Qc&source-path=/usage&hl=en&_reqid=<rand>&rt=c`.
+///   with query items `rpcids=ESY5D&source-path=/usage&hl=en&_reqid=<rand>&rt=c`.
 /// - Method: POST, `Content-Type:
 ///   application/x-www-form-urlencoded;charset=UTF-8`.
-/// - Body: `f.req=[[["jSf9Qc","[]",null,"generic"]]]&at=<XSRF>&`.
-///   The inner args really are an empty array — the server scopes
-///   the response using the cookie identity. `at=` carries the
+/// - Body: `f.req=[[["ESY5D","[[[\"bard_activity_enabled\"]]]",null,
+///   "generic"]]]&at=<XSRF>&`. `at=` carries the
 ///   `WIZ_global_data.SNlM0e` XSRF token extracted from the SSR
 ///   HTML of `https://gemini.google.com/usage?pli=1`.
 /// - Response: JSONP-prefixed (`)]}'\n`) chunked stream. The
-///   `["wrb.fr","jSf9Qc","<encoded JSON>",...]` entry carries the
+///   `["wrb.fr","ESY5D","<encoded JSON>",...]` entry carries the
 ///   payload. See `GeminiWebResponseParser` for the decoded shape.
 struct GeminiWebQuotaFetcher: Sendable {
     /// Set to `true` now that the live quota endpoint is implemented.
     static let spikeComplete = true
+    static let quotaRPCId = "ESY5D"
+    static let quotaRPCArgument = #"[[[\"bard_activity_enabled\"]]]"#
 
     private let session: URLSession
     private let now: @Sendable () -> Date
@@ -90,7 +90,7 @@ struct GeminiWebQuotaFetcher: Sendable {
             throw QuotaError.unknown("Gemini Web batchexecute URL malformed.")
         }
         components.queryItems = [
-            URLQueryItem(name: "rpcids", value: "jSf9Qc"),
+            URLQueryItem(name: "rpcids", value: Self.quotaRPCId),
             URLQueryItem(name: "source-path", value: "/usage"),
             URLQueryItem(name: "hl", value: "en"),
             URLQueryItem(name: "_reqid", value: String(reqid)),
@@ -110,7 +110,7 @@ struct GeminiWebQuotaFetcher: Sendable {
         request.setValue(Self.safariUA, forHTTPHeaderField: "User-Agent")
         request.httpShouldHandleCookies = false
 
-        let innerArgs = #"[[["jSf9Qc","[]",null,"generic"]]]"#
+        let innerArgs = #"[[["\#(Self.quotaRPCId)","\#(Self.quotaRPCArgument)",null,"generic"]]]"#
         let bodyString = "f.req=" + Self.formEncode(innerArgs)
             + "&at=" + Self.formEncode(xsrfToken) + "&"
         request.httpBody = bodyString.data(using: .utf8)

--- a/Sources/VibeBarCore/Adapters/GeminiWebResponseParser.swift
+++ b/Sources/VibeBarCore/Adapters/GeminiWebResponseParser.swift
@@ -1,9 +1,23 @@
 import Foundation
 
+/// Parsed Gemini Web quota data shared with the App-layer WebView
+/// calibrator without exposing the internal wire envelope.
+public struct GeminiWebQuotaSnapshot: Sendable {
+    public var buckets: [QuotaBucket]
+    public var planName: String?
+    public var email: String?
+
+    public init(buckets: [QuotaBucket], planName: String?, email: String?) {
+        self.buckets = buckets
+        self.planName = planName
+        self.email = email
+    }
+}
+
 /// Parses the JSON envelope returned by Gemini's signed-in web
-/// quota endpoint (currently rpcid `ESY5D` on
+/// quota endpoint (a dynamically learned batchexecute rpcid on
 /// `gemini.google.com/_/BardChatUi/data/batchexecute`) into the
-/// shared `GeminiResponseParser.Snapshot` shape.
+/// shared `GeminiWebQuotaSnapshot` shape.
 ///
 /// Wire format (see the file-level docs on `GeminiWebQuotaFetcher`
 /// for the upstream investigation):
@@ -20,7 +34,7 @@ import Foundation
 ///   weekly window. `planTier` is an integer that maps to the
 ///   user-visible plan name (`2 = Pro` confirmed; `1 = Free` and
 ///   `3 = Ultra` inferred from Google's published tier names).
-enum GeminiWebResponseParser {
+public enum GeminiWebResponseParser {
     /// Bucket ids the parser emits. Aligned with Codex's
     /// `five_hour` / `weekly` naming so the Overview/MiniWindow
     /// label catalog can share field-id conventions across providers
@@ -38,8 +52,8 @@ enum GeminiWebResponseParser {
     // same `gemini.five_hour` field id user settings already store
     // — which is what `MiniQuotaWindowView` looks up against
     // `field.bucketId` on the live quota.
-    static let currentUsageBucketId = "five_hour"
-    static let weeklyUsageBucketId  = "weekly"
+    public static let currentUsageBucketId = "five_hour"
+    public static let weeklyUsageBucketId  = "weekly"
 
     /// Strip Google's anti-hijacking prefix `)]}'` (with or without a
     /// trailing newline) that fronts most internal JSON RPCs.
@@ -58,11 +72,12 @@ enum GeminiWebResponseParser {
         return data.subdata(in: idx..<data.endIndex)
     }
 
-    static func parse(
+    public static func parse(
         data: Data,
+        rpcID: String = GeminiWebUsageRecipe.fallback.rpcID,
         email: String? = nil,
         now: Date = Date()
-    ) throws -> GeminiResponseParser.Snapshot {
+    ) throws -> GeminiWebQuotaSnapshot {
         let stripped = stripAntiHijackingPrefix(data)
         guard !stripped.isEmpty else {
             throw QuotaError.parseFailure("Gemini Web response was empty after stripping anti-hijacking prefix.")
@@ -76,7 +91,7 @@ enum GeminiWebResponseParser {
         // `["wrb.fr","<rpcid>","` and the `"`-terminator immediately
         // before `,null` — handling escape sequences so a `\"` inside
         // the payload doesn't end the match early.
-        let escapedRPCId = NSRegularExpression.escapedPattern(for: GeminiWebQuotaFetcher.quotaRPCId)
+        let escapedRPCId = NSRegularExpression.escapedPattern(for: rpcID)
         let pattern = #"\["wrb\.fr","\#(escapedRPCId)","((?:[^"\\]|\\.)*)",null"#
         guard let regex = try? NSRegularExpression(
             pattern: pattern,
@@ -90,7 +105,7 @@ enum GeminiWebResponseParser {
             range: NSRange(location: 0, length: ns.length)
         ), match.numberOfRanges >= 2 else {
             throw QuotaError.parseFailure(
-                "Gemini Web response did not contain an \(GeminiWebQuotaFetcher.quotaRPCId) payload entry."
+                "Gemini Web response did not contain an \(rpcID) payload entry."
             )
         }
         let innerEscaped = ns.substring(with: match.range(at: 1))
@@ -154,7 +169,7 @@ enum GeminiWebResponseParser {
         // the user-facing cadence to 5 Hours -> Weekly and keep any future
         // unknown buckets after the two known windows.
         buckets = canonicalBucketOrder(buckets)
-        return GeminiResponseParser.Snapshot(buckets: buckets, planName: planName, email: email)
+        return GeminiWebQuotaSnapshot(buckets: buckets, planName: planName, email: email)
     }
 
     /// Normalize both fresh responses and persisted caches. Older cache files
@@ -187,7 +202,7 @@ enum GeminiWebResponseParser {
         let id: String
         let title: String
         let shortLabel: String
-        /// Fixed window length for `UsagePace`. Google's jSf9Qc payload
+        /// Fixed window length for `UsagePace`. Google's quota payload
         /// carries reset timestamps but no window duration, so the two
         /// known bucket types get the same 5h / 7d constants Codex and
         /// Claude use. Unknown types stay nil (no pace caption).

--- a/Sources/VibeBarCore/Adapters/GeminiWebResponseParser.swift
+++ b/Sources/VibeBarCore/Adapters/GeminiWebResponseParser.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// Parses the JSON envelope returned by Gemini's signed-in web
-/// quota endpoint (rpcid `jSf9Qc` on
+/// quota endpoint (currently rpcid `ESY5D` on
 /// `gemini.google.com/_/BardChatUi/data/batchexecute`) into the
 /// shared `GeminiResponseParser.Snapshot` shape.
 ///
@@ -73,10 +73,11 @@ enum GeminiWebResponseParser {
         // The chunked stream is `<len>\n<json>\n<len>\n<json>...`.
         // The `wrb.fr` entry we want sits inside one of those JSON
         // chunks. The regex captures the JSON-encoded string between
-        // `["wrb.fr","jSf9Qc","` and the `"`-terminator immediately
+        // `["wrb.fr","<rpcid>","` and the `"`-terminator immediately
         // before `,null` — handling escape sequences so a `\"` inside
         // the payload doesn't end the match early.
-        let pattern = #"\["wrb\.fr","jSf9Qc","((?:[^"\\]|\\.)*)",null"#
+        let escapedRPCId = NSRegularExpression.escapedPattern(for: GeminiWebQuotaFetcher.quotaRPCId)
+        let pattern = #"\["wrb\.fr","\#(escapedRPCId)","((?:[^"\\]|\\.)*)",null"#
         guard let regex = try? NSRegularExpression(
             pattern: pattern,
             options: [.dotMatchesLineSeparators]
@@ -88,7 +89,9 @@ enum GeminiWebResponseParser {
             in: text,
             range: NSRange(location: 0, length: ns.length)
         ), match.numberOfRanges >= 2 else {
-            throw QuotaError.parseFailure("Gemini Web response did not contain a jSf9Qc payload entry.")
+            throw QuotaError.parseFailure(
+                "Gemini Web response did not contain an \(GeminiWebQuotaFetcher.quotaRPCId) payload entry."
+            )
         }
         let innerEscaped = ns.substring(with: match.range(at: 1))
         // Captured string is JSON-encoded inside the outer JSON. Wrap
@@ -98,21 +101,21 @@ enum GeminiWebResponseParser {
               let innerJsonString = (try? JSONSerialization.jsonObject(
                 with: wrappedData, options: [.allowFragments])) as? String,
               let innerData = innerJsonString.data(using: .utf8) else {
-            throw QuotaError.parseFailure("Gemini Web jSf9Qc inner payload could not be unescaped.")
+            throw QuotaError.parseFailure("Gemini Web quota inner payload could not be unescaped.")
         }
         let outer: [Any]
         do {
             guard let arr = try JSONSerialization.jsonObject(with: innerData) as? [Any] else {
-                throw QuotaError.parseFailure("Gemini Web jSf9Qc inner payload not an array.")
+                throw QuotaError.parseFailure("Gemini Web quota inner payload not an array.")
             }
             outer = arr
         } catch let error as QuotaError {
             throw error
         } catch {
-            throw QuotaError.parseFailure("Gemini Web jSf9Qc inner payload not parseable: \(error.localizedDescription)")
+            throw QuotaError.parseFailure("Gemini Web quota inner payload not parseable: \(error.localizedDescription)")
         }
         guard outer.count >= 2, let bucketsRaw = outer[1] as? [[Any]] else {
-            throw QuotaError.parseFailure("Gemini Web jSf9Qc payload missing bucket array.")
+            throw QuotaError.parseFailure("Gemini Web quota payload missing bucket array.")
         }
         let planTier = intValue(outer.first ?? 0)
         let planName = planLabel(forTierId: planTier)
@@ -143,19 +146,27 @@ enum GeminiWebResponseParser {
             ))
         }
         guard !buckets.isEmpty else {
-            throw QuotaError.parseFailure("Gemini Web jSf9Qc returned no buckets.")
+            throw QuotaError.parseFailure("Gemini Web quota payload returned no buckets.")
         }
         // Google's bucket array is not stable across refreshes: live
         // responses may list the weekly window before the shorter current
         // window. Every Gemini surface renders this array directly, so lock
         // the user-facing cadence to 5 Hours -> Weekly and keep any future
         // unknown buckets after the two known windows.
-        buckets.sort { lhs, rhs in
+        buckets = canonicalBucketOrder(buckets)
+        return GeminiResponseParser.Snapshot(buckets: buckets, planName: planName, email: email)
+    }
+
+    /// Normalize both fresh responses and persisted caches. Older cache files
+    /// may retain the server's weekly-first order even after a protocol change
+    /// prevents an immediate refresh; every surface should still render the
+    /// shorter current window before Weekly.
+    static func canonicalBucketOrder(_ buckets: [QuotaBucket]) -> [QuotaBucket] {
+        buckets.sorted { lhs, rhs in
             let lhsRank = displayRank(forBucketId: lhs.id)
             let rhsRank = displayRank(forBucketId: rhs.id)
             return lhsRank == rhsRank ? lhs.id < rhs.id : lhsRank < rhsRank
         }
-        return GeminiResponseParser.Snapshot(buckets: buckets, planName: planName, email: email)
     }
 
     /// Map Google's `planTier` integer to the user-visible plan label.

--- a/Sources/VibeBarCore/Models/MenuBarSettings.swift
+++ b/Sources/VibeBarCore/Models/MenuBarSettings.swift
@@ -136,7 +136,7 @@ public enum MenuBarFieldCatalog {
 
     // Gemini Web (`gemini.google.com`) exposes a 5-hour rolling
     // window and a weekly bucket — that's the entire quota surface
-    // the jSf9Qc parser returns, regardless of model. Earlier
+    // the Gemini Web quota parser returns, regardless of model. Earlier
     // entries here were per-model CLI ids (Gemini 2.5 Pro / Flash /
     // Lite, Gemini 3 Pro / Flash) from the pre-PR-#45 telemetry
     // adapter the Web parser no longer produces; those ids get

--- a/Sources/VibeBarCore/Services/QuotaService.swift
+++ b/Sources/VibeBarCore/Services/QuotaService.swift
@@ -58,7 +58,8 @@ public final class QuotaService: ObservableObject {
     public static func makeDefault(
         mockProvider: @escaping () -> Bool,
         retentionProvider: @escaping () -> Int = { CostDataSettings.defaultRetentionDays },
-        initialAccountIds: [String] = []
+        initialAccountIds: [String] = [],
+        geminiWebFallback: (@Sendable (AccountIdentity, String) async throws -> AccountQuota)? = nil
     ) -> QuotaService {
         QuotaService(
             adapters: [
@@ -66,7 +67,7 @@ public final class QuotaService: ObservableObject {
                 .claude: ClaudeQuotaAdapter(),
                 .zai: ZaiQuotaAdapter(),
                 .copilot: CopilotQuotaAdapter(),
-                .gemini: GeminiQuotaAdapter(),
+                .gemini: GeminiQuotaAdapter(webFallback: geminiWebFallback),
                 .alibaba: AlibabaQuotaAdapter(),
                 .alibabaTokenPlan: AlibabaTokenPlanQuotaAdapter(),
                 .minimax: MiniMaxQuotaAdapter(),

--- a/Sources/VibeBarCore/Storage/GeminiWebUsageRecipeStore.swift
+++ b/Sources/VibeBarCore/Storage/GeminiWebUsageRecipeStore.swift
@@ -1,0 +1,63 @@
+import Foundation
+
+/// The minimum replayable description of Gemini Web's private usage request.
+/// It intentionally contains no cookies, XSRF token, response body, or account
+/// data; those remain ephemeral and are supplied by the current session.
+public struct GeminiWebUsageRecipe: Codable, Equatable, Sendable {
+    public static let fallback = GeminiWebUsageRecipe(
+        rpcID: "jSf9Qc",
+        argument: "[]",
+        learnedAt: nil
+    )
+
+    public let rpcID: String
+    public let argument: String
+    public let learnedAt: Date?
+
+    public init(rpcID: String, argument: String, learnedAt: Date? = Date()) {
+        self.rpcID = rpcID
+        self.argument = argument
+        self.learnedAt = learnedAt
+    }
+
+    public var isValid: Bool {
+        let allowed = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "_-"))
+        return !rpcID.isEmpty
+            && rpcID.count <= 64
+            && rpcID.unicodeScalars.allSatisfy(allowed.contains)
+            && !argument.isEmpty
+            && argument.utf8.count <= 65_536
+    }
+}
+
+/// Persists the learned request recipe under `~/.vibebar/`. The store is
+/// deliberately separate from AppSettings: protocol calibration is runtime
+/// cache state, not a user preference, and must not fan out UI updates.
+public enum GeminiWebUsageRecipeStore {
+    public static var defaultURL: URL {
+        VibeBarLocalStore.baseDirectory.appendingPathComponent("gemini_web_usage_recipe.json")
+    }
+
+    public static func load(from url: URL = defaultURL) -> GeminiWebUsageRecipe {
+        guard let recipe = try? VibeBarLocalStore.readJSON(GeminiWebUsageRecipe.self, from: url),
+              recipe.isValid else {
+            return .fallback
+        }
+        return recipe
+    }
+
+    public static func save(_ recipe: GeminiWebUsageRecipe, to url: URL = defaultURL) throws {
+        guard recipe.isValid else {
+            throw CocoaError(.fileWriteInvalidFileName)
+        }
+        if url.standardizedFileURL == defaultURL.standardizedFileURL {
+            try VibeBarLocalStore.writeJSON(recipe, to: url)
+            return
+        }
+        // Explicit URLs exist for test isolation; do not touch the real
+        // ~/.vibebar root when a synthetic destination is supplied.
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        try encoder.encode(recipe).write(to: url, options: .atomic)
+    }
+}

--- a/Sources/VibeBarCore/Storage/QuotaCacheStore.swift
+++ b/Sources/VibeBarCore/Storage/QuotaCacheStore.swift
@@ -9,7 +9,7 @@ public enum QuotaCacheStore {
 
         init(_ quota: AccountQuota) {
             self.tool = quota.tool
-            self.buckets = quota.buckets
+            self.buckets = Self.normalizedBuckets(quota.buckets, tool: quota.tool)
             self.plan = quota.plan
             self.queriedAt = quota.queriedAt
         }
@@ -18,13 +18,18 @@ public enum QuotaCacheStore {
             AccountQuota(
                 accountId: accountId,
                 tool: tool,
-                buckets: buckets,
+                buckets: Self.normalizedBuckets(buckets, tool: tool),
                 plan: plan,
                 email: nil,
                 queriedAt: queriedAt,
                 error: nil,
                 providerExtras: nil
             )
+        }
+
+        private static func normalizedBuckets(_ buckets: [QuotaBucket], tool: ToolType) -> [QuotaBucket] {
+            guard tool == .gemini else { return buckets }
+            return GeminiWebResponseParser.canonicalBucketOrder(buckets)
         }
     }
 

--- a/Tests/VibeBarCoreTests/GeminiDualFetchTests.swift
+++ b/Tests/VibeBarCoreTests/GeminiDualFetchTests.swift
@@ -5,6 +5,11 @@ import XCTest
 /// Gemini live quota is Web-only; CLI telemetry remains a cost-history
 /// input, not a quota account.
 final class GeminiDualFetchTests: XCTestCase {
+    override func tearDown() {
+        GeminiAdapterStubURLProtocol.handler = nil
+        super.tearDown()
+    }
+
     private func makeEmptyHomeAdapter() throws -> (GeminiQuotaAdapter, URL) {
         let temp = FileManager.default.temporaryDirectory
             .appendingPathComponent("vibebar-gemini-tests-\(UUID().uuidString)")
@@ -88,4 +93,86 @@ final class GeminiDualFetchTests: XCTestCase {
             XCTFail("Expected .unknown, got \(error)")
         }
     }
+
+    func testResponseShapeChangeUsesInjectedWebCalibrationImmediately() async throws {
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [GeminiAdapterStubURLProtocol.self]
+        let session = URLSession(configuration: config)
+        GeminiAdapterStubURLProtocol.handler = { request in
+            let response = HTTPURLResponse(
+                url: try XCTUnwrap(request.url),
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            if request.httpMethod == "GET" {
+                return (
+                    response,
+                    Data(#"<script>window.WIZ_global_data={"SNlM0e":"synthetic-xsrf"};</script>"#.utf8)
+                )
+            }
+            // A successful Google response that no longer contains the known
+            // quota rpcid must enter WebKit calibration in this same refresh.
+            return (response, Data(#")]}'\n[["wrb.fr","rotated","[]",null]]"#.utf8))
+        }
+
+        let adapter = GeminiQuotaAdapter(
+            session: session,
+            cookieHeader: { "__Secure-1PSID=synthetic" },
+            browserCookieImporter: { nil },
+            webFallback: { account, _ in
+                AccountQuota(
+                    accountId: account.id,
+                    tool: .gemini,
+                    buckets: [
+                        QuotaBucket(
+                            id: "five_hour",
+                            title: "5 Hours",
+                            shortLabel: "5 Hours",
+                            usedPercent: 12
+                        ),
+                        QuotaBucket(
+                            id: "weekly",
+                            title: "Weekly",
+                            shortLabel: "Weekly",
+                            usedPercent: 34
+                        )
+                    ],
+                    plan: "Ultra",
+                    queriedAt: Date(timeIntervalSince1970: 1_700_000_000)
+                )
+            }
+        )
+
+        let quota = try await adapter.fetch(for: account(source: .webCookie))
+
+        XCTAssertEqual(quota.plan, "Ultra")
+        XCTAssertEqual(quota.buckets.map(\.id), ["five_hour", "weekly"])
+        XCTAssertEqual(quota.buckets.map(\.usedPercent), [12, 34])
+    }
+}
+
+private final class GeminiAdapterStubURLProtocol: URLProtocol {
+    nonisolated(unsafe) static var handler:
+        (@Sendable (URLRequest) throws -> (HTTPURLResponse, Data))?
+
+    override class func canInit(with _: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        guard let handler = Self.handler else {
+            client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
+            return
+        }
+        do {
+            let (response, data) = try handler(request)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
 }

--- a/Tests/VibeBarCoreTests/GeminiWebResponseParserTests.swift
+++ b/Tests/VibeBarCoreTests/GeminiWebResponseParserTests.swift
@@ -131,6 +131,37 @@ final class GeminiWebResponseParserTests: XCTestCase {
         ])
     }
 
+    func testParseAcceptsDynamicallyLearnedRPCID() throws {
+        let rpcID = "rotatedQuotaRPC"
+        let inner =
+            "[6,[" +
+            "[1,0.12,2,[[1779815111,0]]]," +
+            "[1,0.34,1,[[1779469511,0]]]" +
+            "],false]"
+        let snapshot = try GeminiWebResponseParser.parse(
+            data: Self.wireFormat(inner: inner, rpcID: rpcID),
+            rpcID: rpcID
+        )
+
+        XCTAssertEqual(snapshot.planName, "Ultra")
+        XCTAssertEqual(snapshot.buckets.map(\.id), ["five_hour", "weekly"])
+        XCTAssertEqual(snapshot.buckets.map(\.usedPercent), [34, 12])
+    }
+
+    func testActivityPayloadCannotMasqueradeAsQuota() {
+        let rpcID = "ESY5D"
+        let activity = #"[[["bard_activity_enabled",true]],["history",[]]]"#
+        XCTAssertThrowsError(try GeminiWebResponseParser.parse(
+            data: Self.wireFormat(inner: activity, rpcID: rpcID),
+            rpcID: rpcID
+        )) { error in
+            guard case QuotaError.parseFailure = error else {
+                XCTFail("Expected parseFailure, got \(error)")
+                return
+            }
+        }
+    }
+
     func testCurrentUltraPayloadMapsTierSixAndDropsInternalSentinel() throws {
         let inner =
             "[6,[" +
@@ -201,11 +232,14 @@ final class GeminiWebResponseParserTests: XCTestCase {
     /// `)]}'\n\n<len>\n<wrb.fr entry>\n<tail-len>\n<tail-entry>\n`.
     /// The inner is JSON-encoded once (string-escaped) inside the
     /// outer JSON array.
-    private static func wireFormat(inner: String) -> Data {
+    private static func wireFormat(
+        inner: String,
+        rpcID: String = GeminiWebQuotaFetcher.quotaRPCId
+    ) -> Data {
         let escapedInner = inner
             .replacingOccurrences(of: "\\", with: "\\\\")
             .replacingOccurrences(of: "\"", with: "\\\"")
-        let wrbEntry = #"[["wrb.fr","\#(GeminiWebQuotaFetcher.quotaRPCId)","\#(escapedInner)",null,null,null,"generic"],["di",100],["af.httprm",100,"0",0]]"#
+        let wrbEntry = #"[["wrb.fr","\#(rpcID)","\#(escapedInner)",null,null,null,"generic"],["di",100],["af.httprm",100,"0",0]]"#
         let tail = #"[["e",4,null,null,0]]"#
         let wrbBytes = wrbEntry.utf8.count
         let tailBytes = tail.utf8.count

--- a/Tests/VibeBarCoreTests/GeminiWebResponseParserTests.swift
+++ b/Tests/VibeBarCoreTests/GeminiWebResponseParserTests.swift
@@ -2,8 +2,8 @@ import XCTest
 @testable import VibeBarCore
 
 /// Behavioural tests for `GeminiWebResponseParser`. The 2026-05-23
-/// reverse-engineering pass identified `jSf9Qc` as the live quota
-/// rpcid on `gemini.google.com`. These tests pin the wire format
+/// reverse-engineering pass identified the live quota response shape on
+/// `gemini.google.com`. These tests pin the wire format
 /// (chunked JSONP-prefixed envelope wrapping a doubly-encoded inner
 /// JSON payload) against fixtures captured from a live PRO session
 /// with the numbers scrubbed to synthetic values.
@@ -46,13 +46,18 @@ final class GeminiWebResponseParserTests: XCTestCase {
                 XCTFail("Expected parseFailure, got \(error)")
                 return
             }
-            XCTAssertTrue(message.contains("jSf9Qc"), "Message should reference the rpcid: \(message)")
+            XCTAssertTrue(
+                message.contains(GeminiWebQuotaFetcher.quotaRPCId),
+                "Message should reference the current rpcid: \(message)"
+            )
         }
     }
 
     func testParseMalformedInnerJsonThrowsParseFailure() {
         // wrb.fr entry present, but the inner JSON string is not an array.
-        let payload = Data(#")]}'\n[["wrb.fr","jSf9Qc","not-json",null,null,null,"generic"]]"#.utf8)
+        let payload = Data(
+            ")]}'\\n[[\"wrb.fr\",\"\(GeminiWebQuotaFetcher.quotaRPCId)\",\"not-json\",null,null,null,\"generic\"]]".utf8
+        )
         XCTAssertThrowsError(try GeminiWebResponseParser.parse(data: payload)) { error in
             guard case QuotaError.parseFailure = error else {
                 XCTFail("Expected parseFailure, got \(error)")
@@ -200,7 +205,7 @@ final class GeminiWebResponseParserTests: XCTestCase {
         let escapedInner = inner
             .replacingOccurrences(of: "\\", with: "\\\\")
             .replacingOccurrences(of: "\"", with: "\\\"")
-        let wrbEntry = #"[["wrb.fr","jSf9Qc","\#(escapedInner)",null,null,null,"generic"],["di",100],["af.httprm",100,"0",0]]"#
+        let wrbEntry = #"[["wrb.fr","\#(GeminiWebQuotaFetcher.quotaRPCId)","\#(escapedInner)",null,null,null,"generic"],["di",100],["af.httprm",100,"0",0]]"#
         let tail = #"[["e",4,null,null,0]]"#
         let wrbBytes = wrbEntry.utf8.count
         let tailBytes = tail.utf8.count

--- a/Tests/VibeBarCoreTests/GeminiWebUsageRecipeStoreTests.swift
+++ b/Tests/VibeBarCoreTests/GeminiWebUsageRecipeStoreTests.swift
@@ -1,0 +1,46 @@
+import XCTest
+@testable import VibeBarCore
+
+final class GeminiWebUsageRecipeStoreTests: XCTestCase {
+    func testMissingRecipeFallsBackToKnownContract() {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+            .appendingPathComponent("recipe.json")
+
+        XCTAssertEqual(GeminiWebUsageRecipeStore.load(from: url), .fallback)
+        XCTAssertEqual(GeminiWebUsageRecipe.fallback.rpcID, "jSf9Qc")
+        XCTAssertEqual(GeminiWebUsageRecipe.fallback.argument, "[]")
+    }
+
+    func testRecipeRoundTripsWithoutSessionData() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let url = directory.appendingPathComponent("recipe.json")
+        let recipe = GeminiWebUsageRecipe(
+            rpcID: "rotatedQuotaRPC",
+            argument: #"[["dynamic-argument"]]"#,
+            learnedAt: Date(timeIntervalSince1970: 1_700_000_000)
+        )
+
+        try GeminiWebUsageRecipeStore.save(recipe, to: url)
+
+        XCTAssertEqual(GeminiWebUsageRecipeStore.load(from: url), recipe)
+        let persisted = try String(contentsOf: url, encoding: .utf8)
+        XCTAssertFalse(persisted.contains("Cookie"))
+        XCTAssertFalse(persisted.contains("SNlM0e"))
+    }
+
+    func testInvalidRecipeIsRejectedAndNeverLoaded() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let url = directory.appendingPathComponent("recipe.json")
+        let invalid = GeminiWebUsageRecipe(rpcID: "bad rpc id", argument: "[]")
+
+        XCTAssertThrowsError(try GeminiWebUsageRecipeStore.save(invalid, to: url))
+        XCTAssertEqual(GeminiWebUsageRecipeStore.load(from: url), .fallback)
+    }
+}

--- a/Tests/VibeBarCoreTests/GeminiWebXsrfExtractionTests.swift
+++ b/Tests/VibeBarCoreTests/GeminiWebXsrfExtractionTests.swift
@@ -86,7 +86,7 @@ final class GeminiWebXsrfExtractionTests: XCTestCase {
             let formItems = form.queryItems ?? []
             XCTAssertEqual(
                 formItems.first(where: { $0.name == "f.req" })?.value,
-                #"[[["ESY5D","[[[\"bard_activity_enabled\"]]]",null,"generic"]]]"#
+                #"[[["jSf9Qc","[]",null,"generic"]]]"#
             )
             XCTAssertEqual(formItems.first(where: { $0.name == "at" })?.value, "synthetic-xsrf")
 
@@ -102,11 +102,68 @@ final class GeminiWebXsrfExtractionTests: XCTestCase {
         XCTAssertEqual(snapshot.buckets.map(\.usedPercent), [0, 0])
     }
 
-    private static func wireFormat(inner: String) -> Data {
+    func testFetchReplaysLearnedRecipe() async throws {
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [GeminiWebStubURLProtocol.self]
+        let session = URLSession(configuration: config)
+        let recipe = GeminiWebUsageRecipe(
+            rpcID: "newQuotaRPC",
+            argument: #"[["dynamic-argument"]]"#,
+            learnedAt: Date(timeIntervalSince1970: 1_700_000_000)
+        )
+
+        GeminiWebStubURLProtocol.handler = { request in
+            let response = HTTPURLResponse(
+                url: try XCTUnwrap(request.url),
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            if request.httpMethod == "GET" {
+                return (
+                    response,
+                    Data(#"<script>window.WIZ_global_data={"SNlM0e":"synthetic-xsrf"};</script>"#.utf8)
+                )
+            }
+
+            let query = URLComponents(
+                url: try XCTUnwrap(request.url),
+                resolvingAgainstBaseURL: false
+            )?.queryItems
+            XCTAssertEqual(query?.first(where: { $0.name == "rpcids" })?.value, recipe.rpcID)
+
+            let body = String(data: try Self.requestBody(request), encoding: .utf8) ?? ""
+            var form = URLComponents()
+            form.percentEncodedQuery = body
+            XCTAssertEqual(
+                form.queryItems?.first(where: { $0.name == "f.req" })?.value,
+                #"[[["newQuotaRPC","[[\"dynamic-argument\"]]",null,"generic"]]]"#
+            )
+            return (
+                response,
+                Self.wireFormat(
+                    inner: "[6,[[1,0,1,[[1779469511,0]]],[1,0,2,[[1780074311,0]]]],false]",
+                    rpcID: recipe.rpcID
+                )
+            )
+        }
+
+        let snapshot = try await GeminiWebQuotaFetcher(
+            session: session,
+            recipeProvider: { recipe }
+        ).fetch(cookieHeader: "__Secure-1PSID=synthetic")
+
+        XCTAssertEqual(snapshot.buckets.map(\.id), ["five_hour", "weekly"])
+    }
+
+    private static func wireFormat(
+        inner: String,
+        rpcID: String = GeminiWebQuotaFetcher.quotaRPCId
+    ) -> Data {
         let escapedInner = inner
             .replacingOccurrences(of: "\\", with: "\\\\")
             .replacingOccurrences(of: "\"", with: "\\\"")
-        let entry = #"[["wrb.fr","\#(GeminiWebQuotaFetcher.quotaRPCId)","\#(escapedInner)",null,null,null,"generic"]]"#
+        let entry = #"[["wrb.fr","\#(rpcID)","\#(escapedInner)",null,null,null,"generic"]]"#
         return Data(")]}'\\n\(entry.utf8.count)\\n\(entry)\\n".utf8)
     }
 

--- a/Tests/VibeBarCoreTests/GeminiWebXsrfExtractionTests.swift
+++ b/Tests/VibeBarCoreTests/GeminiWebXsrfExtractionTests.swift
@@ -7,6 +7,11 @@ import XCTest
 /// inline in the SSR HTML of `https://gemini.google.com/usage?pli=1`
 /// under that exact key name.
 final class GeminiWebXsrfExtractionTests: XCTestCase {
+    override func tearDown() {
+        GeminiWebStubURLProtocol.reset()
+        super.tearDown()
+    }
+
     func testExtractTokenFromCanonicalWizGlobalData() throws {
         let html = """
         <html><head><script>
@@ -48,4 +53,105 @@ final class GeminiWebXsrfExtractionTests: XCTestCase {
             }
         }
     }
+
+    func testFetchUsesCurrentQuotaRPCContract() async throws {
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [GeminiWebStubURLProtocol.self]
+        let session = URLSession(configuration: config)
+
+        GeminiWebStubURLProtocol.handler = { request in
+            let response = HTTPURLResponse(
+                url: try XCTUnwrap(request.url),
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: ["Content-Type": request.httpMethod == "POST" ? "application/json" : "text/html"]
+            )!
+
+            if request.httpMethod == "GET" {
+                XCTAssertEqual(request.url?.path, "/usage")
+                return (
+                    response,
+                    Data(#"<script>window.WIZ_global_data={"SNlM0e":"synthetic-xsrf"};</script>"#.utf8)
+                )
+            }
+
+            XCTAssertEqual(request.httpMethod, "POST")
+            let queryItems = URLComponents(url: try XCTUnwrap(request.url), resolvingAgainstBaseURL: false)?.queryItems
+            XCTAssertEqual(queryItems?.first(where: { $0.name == "rpcids" })?.value, GeminiWebQuotaFetcher.quotaRPCId)
+            XCTAssertEqual(queryItems?.first(where: { $0.name == "source-path" })?.value, "/usage")
+
+            let body = String(data: try Self.requestBody(request), encoding: .utf8) ?? ""
+            var form = URLComponents()
+            form.percentEncodedQuery = body
+            let formItems = form.queryItems ?? []
+            XCTAssertEqual(
+                formItems.first(where: { $0.name == "f.req" })?.value,
+                #"[[["ESY5D","[[[\"bard_activity_enabled\"]]]",null,"generic"]]]"#
+            )
+            XCTAssertEqual(formItems.first(where: { $0.name == "at" })?.value, "synthetic-xsrf")
+
+            return (response, Self.wireFormat(inner: "[6,[[1,0,1,[[1779469511,0]]],[1,0,2,[[1780074311,0]]]],false]"))
+        }
+
+        let snapshot = try await GeminiWebQuotaFetcher(session: session).fetch(
+            cookieHeader: "__Secure-1PSID=synthetic"
+        )
+
+        XCTAssertEqual(snapshot.planName, "Ultra")
+        XCTAssertEqual(snapshot.buckets.map(\.id), ["five_hour", "weekly"])
+        XCTAssertEqual(snapshot.buckets.map(\.usedPercent), [0, 0])
+    }
+
+    private static func wireFormat(inner: String) -> Data {
+        let escapedInner = inner
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+        let entry = #"[["wrb.fr","\#(GeminiWebQuotaFetcher.quotaRPCId)","\#(escapedInner)",null,null,null,"generic"]]"#
+        return Data(")]}'\\n\(entry.utf8.count)\\n\(entry)\\n".utf8)
+    }
+
+    private static func requestBody(_ request: URLRequest) throws -> Data {
+        if let body = request.httpBody { return body }
+        guard let stream = request.httpBodyStream else { return Data() }
+
+        stream.open()
+        defer { stream.close() }
+        var data = Data()
+        var buffer = [UInt8](repeating: 0, count: 4_096)
+        while stream.hasBytesAvailable {
+            let count = stream.read(&buffer, maxLength: buffer.count)
+            if count < 0 { throw stream.streamError ?? URLError(.cannotDecodeRawData) }
+            if count == 0 { break }
+            data.append(buffer, count: count)
+        }
+        return data
+    }
+}
+
+private final class GeminiWebStubURLProtocol: URLProtocol {
+    nonisolated(unsafe) static var handler: (@Sendable (URLRequest) throws -> (HTTPURLResponse, Data))?
+
+    static func reset() {
+        handler = nil
+    }
+
+    override class func canInit(with _: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        guard let handler = Self.handler else {
+            client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
+            return
+        }
+        do {
+            let (response, data) = try handler(request)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
 }

--- a/Tests/VibeBarCoreTests/PrivacyPersistenceTests.swift
+++ b/Tests/VibeBarCoreTests/PrivacyPersistenceTests.swift
@@ -81,6 +81,22 @@ final class PrivacyPersistenceTests: XCTestCase {
         XCTAssertNotEqual(component, VibeBarLocalStore.safeFileComponent(accountId))
     }
 
+    func testGeminiStoredQuotaNormalizesKnownBucketOrder() {
+        let quota = AccountQuota(
+            accountId: "gemini-web",
+            tool: .gemini,
+            buckets: [
+                QuotaBucket(id: "weekly", title: "Weekly", shortLabel: "Weekly", usedPercent: 2),
+                QuotaBucket(id: "five_hour", title: "5 Hours", shortLabel: "5 Hours", usedPercent: 0)
+            ],
+            queriedAt: Date(timeIntervalSince1970: 1_700_000_000)
+        )
+
+        let restored = QuotaCacheStore.StoredQuota(quota).quota(accountId: quota.accountId)
+
+        XCTAssertEqual(restored.buckets.map(\.id), ["five_hour", "weekly"])
+    }
+
     func testScanCacheStoresHashedPathKeys() throws {
         var cache = CostUsageScanCache()
         let mtime = Date(timeIntervalSince1970: 1_700_000_000)


### PR DESCRIPTION
## Summary
- keep the known Gemini Web quota recipe as the lightweight normal refresh path, then use an ephemeral hidden /usage WebView to observe and replay the page current quota request when Google rotates its private RPC or argument
- validate learned responses as the canonical 5 Hours and Weekly quota pair, cross-check them against rendered usage percentages, and return the calibrated quota in the same refresh
- persist only the non-secret RPC recipe; never persist cookies or response bodies, and never use Gemini CLI as a live quota source
- normalize both fresh and cached Gemini buckets to 5 Hours followed by Weekly

## Protocol correction
- ESY5D is an activity/settings payload, not the usage quota RPC; parser coverage now explicitly rejects it as quota data

## Test plan
- [x] swift build
- [x] swift test: 681 tests
- [x] release app packaging
- [x] entitlement inspection: empty dictionary
- [x] strict deep code-sign verification
- [x] git diff check