### PR TITLE
Add verified GitHub release packaging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,110 @@
+name: Build GitHub Release
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing v-prefixed tag to package
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
+  cancel-in-progress: false
+
+jobs:
+  package:
+    name: Test, package, and draft release
+    runs-on: macos-26
+    env:
+      RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
+      MACOS_CERTIFICATE_P12: ${{ secrets.MACOS_CERTIFICATE_P12 }}
+      MACOS_CERTIFICATE_PASSWORD: ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
+      APPLE_ID: ${{ secrets.APPLE_ID }}
+      APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+      APPLE_APP_PASSWORD: ${{ secrets.APPLE_APP_PASSWORD }}
+
+    steps:
+      - name: Check out tagged source
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.RELEASE_TAG }}
+
+      - name: Verify toolchain
+        run: |
+          sw_vers -productVersion
+          xcode-select -p
+          swift --version
+
+      - name: Import optional Developer ID certificate
+        if: ${{ env.MACOS_CERTIFICATE_P12 != '' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ -z "$MACOS_CERTIFICATE_PASSWORD" ]]; then
+            echo "MACOS_CERTIFICATE_PASSWORD is required with MACOS_CERTIFICATE_P12" >&2
+            exit 1
+          fi
+
+          KEYCHAIN_PATH="$RUNNER_TEMP/vibebar-release.keychain-db"
+          KEYCHAIN_PASSWORD="$(uuidgen)"
+          CERTIFICATE_PATH="$RUNNER_TEMP/developer-id.p12"
+          echo "::add-mask::$KEYCHAIN_PASSWORD"
+
+          printf '%s' "$MACOS_CERTIFICATE_P12" | base64 -D > "$CERTIFICATE_PATH"
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security import "$CERTIFICATE_PATH" \
+            -k "$KEYCHAIN_PATH" \
+            -P "$MACOS_CERTIFICATE_PASSWORD" \
+            -T /usr/bin/codesign \
+            -T /usr/bin/security
+          security set-key-partition-list \
+            -S apple-tool:,apple:,codesign: \
+            -s \
+            -k "$KEYCHAIN_PASSWORD" \
+            "$KEYCHAIN_PATH"
+          security list-keychains -d user -s "$KEYCHAIN_PATH"
+
+          SIGNING_IDENTITY="$(
+            security find-identity -v -p codesigning "$KEYCHAIN_PATH" \
+              | sed -n 's/.*"\(Developer ID Application:[^"]*\)".*/\1/p' \
+              | head -n 1
+          )"
+          if [[ -z "$SIGNING_IDENTITY" ]]; then
+            echo "No Developer ID Application identity found in imported certificate" >&2
+            exit 1
+          fi
+          echo "VIBEBAR_CODESIGN_IDENTITY=$SIGNING_IDENTITY" >> "$GITHUB_ENV"
+
+      - name: Build verified release assets
+        run: ./Scripts/release_app.sh "$RELEASE_TAG"
+
+      - name: Create or update draft release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          assets=(.build/release/*.zip .build/release/*.sha256)
+          if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+            if [[ "$(gh release view "$RELEASE_TAG" --json isDraft --jq .isDraft)" != "true" ]]; then
+              echo "Refusing to replace assets on a published release." >&2
+              exit 1
+            fi
+            gh release upload "$RELEASE_TAG" "${assets[@]}" --clobber
+          else
+            gh release create "$RELEASE_TAG" \
+              "${assets[@]}" \
+              --draft \
+              --generate-notes \
+              --title "Vibe Bar ${RELEASE_TAG#v}" \
+              --verify-tag
+          fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,7 @@ Humans are welcome here too. The shorter, human-focused version is
 | [AGENTS.md](AGENTS.md) (this file) | AI agents (and curious humans) | Comprehensive operating manual: orientation, build, conventions, home-directory rule, PR, release. |
 | [AGENT-DEPLOY.md](AGENT-DEPLOY.md) | AI agents | Focused "clone → build → smoke-test → optional install" walkthrough. |
 | [AGENT-PR.md](AGENT-PR.md) | AI agents | Focused "branch → verify → push → open PR" walkthrough. |
+| [RELEASING.md](RELEASING.md) | Maintainers | Tag → verified asset → draft GitHub Release, with optional Developer ID notarization. |
 | [CONTRIBUTING.md](CONTRIBUTING.md) | Humans | Short version of this file's project rules. |
 | [SECURITY.md](SECURITY.md) | Anyone | Security disclosure policy and what not to paste in reports. |
 | [README.md](README.md) / [README.zh-CN.md](README.zh-CN.md) | End users | What Vibe Bar is and how to install it. |
@@ -30,10 +31,10 @@ and Anthropic/Claude Code (often side-by-side) and want subscription
 quota, usage pace, local token cost, and provider service status visible
 in one quiet desktop surface — without opening multiple dashboards.
 
-It is a pure Swift package, distributed as **source only**. There is no
-Xcode workspace, no installer, no notarized release, and no production
-server. The "deploy" target is the user's own Mac (and optionally
-`/Applications`); the "publish" target is GitHub.
+It is a pure Swift package with source-first distribution and an optional
+tag-driven GitHub Release workflow. There is no Xcode workspace, installer,
+or production server. The "deploy" target is the user's own Mac (and
+optionally `/Applications`); the "publish" target is GitHub.
 
 Key product surfaces:
 
@@ -816,15 +817,23 @@ moment step 1 lands.
 
 ## 12. Releases
 
+- Follow [RELEASING.md](RELEASING.md) for the complete tag, asset, signing,
+  notarization, and draft-publishing flow.
 - Bundle ID is `com.astroqore.VibeBar`. Bump
   `CFBundleShortVersionString` and `CFBundleVersion` in
   `Resources/Info.plist` for a new release.
 - Confirm `Resources/VibeBar.entitlements` still matches the rule in
   **§ 4.5** — empty `<dict/>`, no `app-sandbox` key.
-- Run **§ 4.3 – § 4.6** before tagging or announcing a release.
+- Run **§ 4.3 – § 4.6** before tagging or announcing a release. The GitHub
+  workflow repeats those checks on a macOS 26 runner.
+- Tag the merged `main` with exactly `v` plus
+  `CFBundleShortVersionString`. The workflow creates a draft GitHub Release
+  so its assets can be inspected before publishing.
 - The license is AGPL-3.0-only; don't relicense without an explicit
   board decision.
-- There is no notarization step (ad-hoc signed only) and no homebrew
+- Releases remain ad-hoc signed when Apple credentials are absent. With the
+  documented Developer ID secrets, the same workflow signs with hardened
+  runtime, notarizes, and staples the unsandboxed app. There is no Homebrew
   formula in this repo.
 
 ## 13. What You Should Not Change Without Explicit Instruction

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,99 @@
+# Releasing Vibe Bar
+
+Vibe Bar releases are built from a versioned tag and uploaded to a draft
+GitHub Release. The release remains a draft until a maintainer checks the
+assets and publishes it in the GitHub UI.
+
+The same workflow supports both today's ad-hoc signature and a future
+Developer ID + notarization setup. Neither path enables the App Sandbox;
+`Resources/VibeBar.entitlements` must remain an empty plist because the misc
+provider integrations require the current unsandboxed runtime.
+
+## Prepare a version
+
+1. Update both values in `Resources/Info.plist`:
+   - `CFBundleShortVersionString` — user-facing version, for example `0.2.0`.
+   - `CFBundleVersion` — monotonically increasing build number.
+2. Merge that version bump to `main` through a PR.
+3. From the updated `main`, create and push the matching tag:
+
+   ```sh
+   git tag -a v0.2.0 -m "Vibe Bar 0.2.0"
+   git push origin v0.2.0
+   ```
+
+The tag must be exactly `v` plus `CFBundleShortVersionString`. A mismatch
+fails before an asset is uploaded.
+
+## What the workflow does
+
+`.github/workflows/release.yml` runs on GitHub's macOS 26 runner. It:
+
+1. checks out the tagged source and reports the active toolchain;
+2. optionally imports a Developer ID certificate;
+3. runs the complete Swift test suite;
+4. builds and signs the release app;
+5. verifies the strict code signature and rejects sandboxed entitlements;
+6. optionally notarizes and staples a Developer ID build;
+7. creates an architecture-labelled ZIP and SHA-256 checksum; and
+8. creates or updates a draft GitHub Release.
+
+Review the generated draft and then select **Publish release** on GitHub.
+Re-running the workflow for the same tag replaces its assets.
+
+## Release assets
+
+The reusable local entry point is:
+
+```sh
+./Scripts/release_app.sh v0.2.0
+```
+
+It writes architecture-labelled files under `.build/release/`, for example:
+
+```text
+Vibe-Bar-0.2.0-macOS-arm64.zip
+Vibe-Bar-0.2.0-macOS-arm64.zip.sha256
+```
+
+Without signing credentials this produces an ad-hoc-signed build. GitHub can
+host that build, but Gatekeeper will require users to approve it manually.
+
+## Enable Developer ID signing and notarization
+
+After joining the Apple Developer Program, export a **Developer ID
+Application** certificate as a password-protected `.p12`. Add these Actions
+repository secrets:
+
+| Secret | Value |
+| --- | --- |
+| `MACOS_CERTIFICATE_P12` | Base64-encoded `.p12` file |
+| `MACOS_CERTIFICATE_PASSWORD` | Password used when exporting the `.p12` |
+| `APPLE_ID` | Apple Developer account email |
+| `APPLE_TEAM_ID` | Apple Developer team ID |
+| `APPLE_APP_PASSWORD` | App-specific password used by `notarytool` |
+
+For example, encode the certificate locally without printing it:
+
+```sh
+base64 -i DeveloperID.p12 | pbcopy
+```
+
+Once `MACOS_CERTIFICATE_P12` is present, the workflow refuses to create a
+half-configured public build: it requires the certificate password and all
+three notarization credentials, signs with hardened runtime, waits for Apple
+notarization, staples the ticket, and assesses the finished app with
+Gatekeeper.
+
+For a local Developer ID release, import the certificate into the login
+Keychain and store notarization credentials once:
+
+```sh
+xcrun notarytool store-credentials "vibebar-release"
+VIBEBAR_CODESIGN_IDENTITY="Developer ID Application: Example (TEAMID)" \
+VIBEBAR_NOTARY_KEYCHAIN_PROFILE="vibebar-release" \
+./Scripts/release_app.sh v0.2.0
+```
+
+Never commit certificates, passwords, Apple IDs, team IDs, or notarization
+profiles to the repository.

--- a/Scripts/build_app.sh
+++ b/Scripts/build_app.sh
@@ -1,10 +1,15 @@
 #!/usr/bin/env bash
-# Build Vibe Bar executable, wrap into a proper .app bundle, and ad-hoc sign.
+# Build Vibe Bar executable, wrap it into a proper .app bundle, and sign it.
 # Usage: ./Scripts/build_app.sh [debug|release]
 # Output: .build/Vibe Bar.app
+#
+# Signing defaults to ad-hoc for local builds. Public release automation can
+# set VIBEBAR_CODESIGN_IDENTITY to a Developer ID Application identity; the
+# same unsandboxed entitlements remain in force in both modes.
 set -euo pipefail
 
 CONFIG="${1:-release}"
+SIGN_IDENTITY="${VIBEBAR_CODESIGN_IDENTITY:--}"
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT"
 
@@ -43,8 +48,20 @@ if [[ ! -f "$ENTITLEMENTS" ]]; then
     exit 1
 fi
 
-echo "==> ad-hoc codesign with entitlements"
-codesign --force --deep --sign - --entitlements "$ENTITLEMENTS" "$APP_DIR"
+if [[ "$SIGN_IDENTITY" == "-" ]]; then
+    echo "==> ad-hoc codesign with entitlements"
+    codesign --force --deep --sign - --entitlements "$ENTITLEMENTS" "$APP_DIR"
+else
+    echo "==> Developer ID codesign with hardened runtime"
+    codesign \
+        --force \
+        --deep \
+        --options runtime \
+        --timestamp \
+        --sign "$SIGN_IDENTITY" \
+        --entitlements "$ENTITLEMENTS" \
+        "$APP_DIR"
+fi
 
 echo "==> done: $APP_DIR"
 echo "Run with: open \"$APP_DIR\""

--- a/Scripts/release_app.sh
+++ b/Scripts/release_app.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# Produce a verified GitHub Release asset for the version in Info.plist.
+#
+# Usage:
+#   ./Scripts/release_app.sh [v<version>]
+#
+# Default output:
+#   .build/release/Vibe-Bar-<version>-macOS-<arch>.zip
+#   .build/release/Vibe-Bar-<version>-macOS-<arch>.zip.sha256
+#
+# Without extra environment variables the app is ad-hoc signed. To create a
+# public Developer ID build, set VIBEBAR_CODESIGN_IDENTITY and one notarization
+# credential method:
+#
+#   VIBEBAR_NOTARY_KEYCHAIN_PROFILE=<notarytool-profile>
+#
+# or all of:
+#
+#   APPLE_ID=<developer-account-email>
+#   APPLE_TEAM_ID=<team-id>
+#   APPLE_APP_PASSWORD=<app-specific-password>
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PLIST="$ROOT/Resources/Info.plist"
+APP_DIR="$ROOT/.build/Vibe Bar.app"
+DIST_DIR="$ROOT/.build/release"
+SIGN_IDENTITY="${VIBEBAR_CODESIGN_IDENTITY:--}"
+
+usage() {
+    printf '%s\n' \
+        "Produce a verified GitHub Release asset for the version in Info.plist." \
+        "" \
+        "Usage: ./Scripts/release_app.sh [v<version>]" \
+        "" \
+        "Signing defaults to ad-hoc. See RELEASING.md for Developer ID" \
+        "signing, notarization, GitHub secrets, and publishing instructions."
+}
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+    usage
+    exit 0
+fi
+
+if [[ ! -f "$PLIST" ]]; then
+    echo "Info.plist not found at $PLIST" >&2
+    exit 1
+fi
+
+VERSION="$(plutil -extract CFBundleShortVersionString raw -o - "$PLIST")"
+BUILD_NUMBER="$(plutil -extract CFBundleVersion raw -o - "$PLIST")"
+RELEASE_TAG="${1:-${VIBEBAR_RELEASE_TAG:-v$VERSION}}"
+
+if [[ "$RELEASE_TAG" != "v$VERSION" ]]; then
+    echo "Release tag $RELEASE_TAG does not match Info.plist version v$VERSION" >&2
+    echo "Bump CFBundleShortVersionString before releasing this tag." >&2
+    exit 1
+fi
+
+if [[ "${VIBEBAR_SKIP_TESTS:-0}" != "1" ]]; then
+    echo "==> running full test suite"
+    (cd "$ROOT" && swift test)
+fi
+
+echo "==> building Vibe Bar $VERSION ($BUILD_NUMBER)"
+(cd "$ROOT" && ./Scripts/build_app.sh release)
+
+echo "==> verifying bundle signature"
+codesign --verify --deep --strict "$APP_DIR"
+ENTITLEMENTS="$(codesign -d --entitlements - "$APP_DIR" 2>&1)"
+if grep -q 'com.apple.security.app-sandbox' <<<"$ENTITLEMENTS"; then
+    echo "Refusing to release a sandboxed Vibe Bar bundle." >&2
+    exit 1
+fi
+
+ARCH_LIST="$(lipo -archs "$APP_DIR/Contents/MacOS/VibeBar")"
+if [[ " $ARCH_LIST " == *" arm64 "* && " $ARCH_LIST " == *" x86_64 "* ]]; then
+    ARCH_LABEL="universal"
+elif [[ " $ARCH_LIST " == *" arm64 "* ]]; then
+    ARCH_LABEL="arm64"
+elif [[ " $ARCH_LIST " == *" x86_64 "* ]]; then
+    ARCH_LABEL="x86_64"
+else
+    ARCH_LABEL="$(tr ' ' '-' <<<"$ARCH_LIST")"
+fi
+
+rm -rf "$DIST_DIR"
+mkdir -p "$DIST_DIR"
+ARCHIVE="$DIST_DIR/Vibe-Bar-$VERSION-macOS-$ARCH_LABEL.zip"
+
+package_app() {
+    rm -f "$ARCHIVE"
+    ditto -c -k --sequesterRsrc --keepParent "$APP_DIR" "$ARCHIVE"
+}
+
+package_app
+
+if [[ "$SIGN_IDENTITY" != "-" ]]; then
+    echo "==> notarizing Developer ID build"
+    if [[ -n "${VIBEBAR_NOTARY_KEYCHAIN_PROFILE:-}" ]]; then
+        xcrun notarytool submit "$ARCHIVE" \
+            --keychain-profile "$VIBEBAR_NOTARY_KEYCHAIN_PROFILE" \
+            --wait
+    elif [[ -n "${APPLE_ID:-}" && -n "${APPLE_TEAM_ID:-}" && -n "${APPLE_APP_PASSWORD:-}" ]]; then
+        xcrun notarytool submit "$ARCHIVE" \
+            --apple-id "$APPLE_ID" \
+            --team-id "$APPLE_TEAM_ID" \
+            --password "$APPLE_APP_PASSWORD" \
+            --wait
+    else
+        echo "Developer ID signing requires notarization credentials." >&2
+        echo "Set VIBEBAR_NOTARY_KEYCHAIN_PROFILE, or APPLE_ID, APPLE_TEAM_ID," >&2
+        echo "and APPLE_APP_PASSWORD." >&2
+        exit 1
+    fi
+
+    echo "==> stapling notarization ticket"
+    xcrun stapler staple "$APP_DIR"
+    xcrun stapler validate "$APP_DIR"
+    spctl --assess --type execute --verbose=2 "$APP_DIR"
+    package_app
+else
+    echo "==> ad-hoc release asset (Gatekeeper will require manual approval)"
+fi
+
+CHECKSUM="$ARCHIVE.sha256"
+(cd "$DIST_DIR" && shasum -a 256 "$(basename "$ARCHIVE")" > "$(basename "$CHECKSUM")")
+
+echo "==> release assets ready"
+echo "$ARCHIVE"
+echo "$CHECKSUM"

--- a/Sources/VibeBarApp/Views/PopoverRoot.swift
+++ b/Sources/VibeBarApp/Views/PopoverRoot.swift
@@ -38,7 +38,13 @@ struct PopoverRoot: View {
                 .padding(.bottom, shellDensity.interSectionSpacing)
             ScrollView(.vertical, showsIndicators: false) {
                 content(density: contentDensity)
-                    .frame(maxWidth: .infinity, alignment: .topLeading)
+                    // A vertical ScrollView does not always pass a finite
+                    // horizontal proposal through to intrinsically wide
+                    // HStacks. Provider detail pages then grow to the sum of
+                    // both columns' ideal widths and their right edge escapes
+                    // the shared popover shell. Give every tab the exact same
+                    // viewport width so only its height remains scrollable.
+                    .frame(width: shellContentWidth, alignment: .topLeading)
                     .padding(.bottom, 4)
             }
             .frame(maxHeight: maxScrollHeight)
@@ -650,6 +656,7 @@ private struct GeminiTabPage: View {
     @EnvironmentObject var quotaService: QuotaService
 
     var body: some View {
+        let columns = ProviderDetailColumnWidths(density: density)
         let geminiAccounts = environment.accountStore
             .accounts(for: .gemini)
             .sorted { $0.id < $1.id }
@@ -677,34 +684,14 @@ private struct GeminiTabPage: View {
                 ServiceStatusCard(tools: [.gemini], density: density)
             }
             .frame(
-                minWidth: leftColumnMinWidth,
-                idealWidth: leftColumnIdealWidth,
-                maxWidth: leftColumnMaxWidth,
+                width: columns.left,
                 alignment: .topLeading
             )
 
             GeminiCostColumn(density: density)
-                .frame(minWidth: rightColumnMinWidth, maxWidth: .infinity, alignment: .topLeading)
+                .frame(width: columns.right, alignment: .topLeading)
         }
-    }
-
-    private var leftColumnMinWidth: CGFloat {
-        density.detailLeftColumnRange.lowerBound
-    }
-
-    private var leftColumnIdealWidth: CGFloat {
-        min(
-            density.detailLeftColumnRange.upperBound,
-            max(leftColumnMinWidth, density.popoverWidth * density.detailLeftColumnFraction)
-        )
-    }
-
-    private var leftColumnMaxWidth: CGFloat {
-        density.detailLeftColumnRange.upperBound
-    }
-
-    private var rightColumnMinWidth: CGFloat {
-        density.detailRightColumnMinimum
+        .frame(width: columns.total, alignment: .topLeading)
     }
 }
 
@@ -1431,6 +1418,7 @@ private struct ProviderDetailView: View {
     @EnvironmentObject var quotaService: QuotaService
 
     var body: some View {
+        let columns = ProviderDetailColumnWidths(density: density)
         let snapshot = environment.costService.snapshot(for: tool)
         let hasCostData = (snapshot?.jsonlFilesFound ?? 0) > 0
         HStack(alignment: .top, spacing: density.interSectionSpacing) {
@@ -1447,9 +1435,7 @@ private struct ProviderDetailView: View {
                 ServiceStatusCard(tools: [tool], density: density)
             }
             .frame(
-                minWidth: leftColumnMinWidth,
-                idealWidth: leftColumnIdealWidth,
-                maxWidth: leftColumnMaxWidth,
+                width: columns.left,
                 alignment: .topLeading
             )
 
@@ -1477,27 +1463,38 @@ private struct ProviderDetailView: View {
                         .frame(maxWidth: .infinity)
                 }
             }
-            .frame(minWidth: rightColumnMinWidth, maxWidth: .infinity, alignment: .topLeading)
+            .frame(width: columns.right, alignment: .topLeading)
         }
+        .frame(width: columns.total, alignment: .topLeading)
     }
+}
 
-    private var leftColumnMinWidth: CGFloat {
-        density.detailLeftColumnRange.lowerBound
-    }
+/// Exact widths for the shared provider-detail shell. Flexible HStack children
+/// use their intrinsic ideal size inside a vertical ScrollView, which can make
+/// the analytics column wider than the visible popover. Resolve the two
+/// columns from the shell's finite content width instead, while preserving the
+/// existing narrow-left / wide-right density ratios.
+private struct ProviderDetailColumnWidths {
+    let left: CGFloat
+    let right: CGFloat
+    let total: CGFloat
 
-    private var leftColumnIdealWidth: CGFloat {
-        min(
+    init(density: Theme.Density) {
+        total = max(0, density.popoverWidth - density.popoverPaddingH * 2)
+        let usable = max(0, total - density.interSectionSpacing)
+        let preferredLeft = min(
             density.detailLeftColumnRange.upperBound,
-            max(leftColumnMinWidth, density.popoverWidth * density.detailLeftColumnFraction)
+            max(
+                density.detailLeftColumnRange.lowerBound,
+                density.popoverWidth * density.detailLeftColumnFraction
+            )
         )
-    }
-
-    private var leftColumnMaxWidth: CGFloat {
-        density.detailLeftColumnRange.upperBound
-    }
-
-    private var rightColumnMinWidth: CGFloat {
-        density.detailRightColumnMinimum
+        let maximumLeft = max(
+            density.detailLeftColumnRange.lowerBound,
+            usable - density.detailRightColumnMinimum
+        )
+        left = min(preferredLeft, maximumLeft)
+        right = max(0, usable - left)
     }
 }
 


### PR DESCRIPTION
## Summary\n- add a tag-driven macOS 26 draft GitHub Release workflow and reusable local packaging script\n- support current ad-hoc signing plus optional Developer ID signing, notarization, stapling, and Gatekeeper assessment\n- constrain ChatGPT, Claude, Gemini, and Grok detail columns to the shared popover viewport\n\n## Test plan\n- [x] swift build\n- [x] full release script: 681 tests, 0 failures\n- [x] release build and strict codesign verification\n- [x] confirm empty entitlements and no app sandbox\n- [x] verify ZIP integrity and SHA-256 checksum\n- [x] parse release workflow YAML\n- [x] git diff --check