### PR TITLE
Make cost history time-zone tests deterministic

### DIFF
--- a/Sources/VibeBarCore/Services/CostHistoryStore.swift
+++ b/Sources/VibeBarCore/Services/CostHistoryStore.swift
@@ -88,11 +88,14 @@ public actor CostHistoryStore {
     /// cache-read over-count, so a corrected re-scan rebuilds them clean.
     private static let currentHistoryCorrectionVersion = 1
 
-    init(fileURL: URL = CostHistoryStore.defaultFileURL()) {
+    init(
+        fileURL: URL = CostHistoryStore.defaultFileURL(),
+        timeZone: TimeZone = .current
+    ) {
         self.fileURL = fileURL
         var cal = Calendar(identifier: .gregorian)
         cal.locale = Locale(identifier: "en_US_POSIX")
-        cal.timeZone = TimeZone.current
+        cal.timeZone = timeZone
         self.calendar = cal
         let f = DateFormatter()
         f.dateFormat = "yyyy-MM-dd"

--- a/Tests/VibeBarCoreTests/CostHistoryStoreTests.swift
+++ b/Tests/VibeBarCoreTests/CostHistoryStoreTests.swift
@@ -62,10 +62,7 @@ final class CostHistoryStoreTests: XCTestCase {
     }
 
     func testMergeAndAugmentKeepsLocalTodayWhenTimeZoneIsAheadOfUTC() async throws {
-        let previousTimeZone = NSTimeZone.default
         let shanghai = TimeZone(secondsFromGMT: 8 * 3600)!
-        NSTimeZone.default = shanghai
-        defer { NSTimeZone.default = previousTimeZone }
 
         let fileManager = FileManager.default
         let directory = fileManager.temporaryDirectory
@@ -85,7 +82,10 @@ final class CostHistoryStoreTests: XCTestCase {
         components.minute = 15
         let now = try XCTUnwrap(components.date)
         let today = calendar.startOfDay(for: now)
-        let store = CostHistoryStore(fileURL: directory.appendingPathComponent("cost_history.json"))
+        let store = CostHistoryStore(
+            fileURL: directory.appendingPathComponent("cost_history.json"),
+            timeZone: shanghai
+        )
         let snapshot = CostSnapshot(
             tool: .codex,
             todayCostUSD: 7,
@@ -113,10 +113,7 @@ final class CostHistoryStoreTests: XCTestCase {
     }
 
     func testLegacyUTCDateKeysMigrateToLocalDay() async throws {
-        let previousTimeZone = NSTimeZone.default
         let shanghai = TimeZone(secondsFromGMT: 8 * 3600)!
-        NSTimeZone.default = shanghai
-        defer { NSTimeZone.default = previousTimeZone }
 
         let fileManager = FileManager.default
         let directory = fileManager.temporaryDirectory
@@ -140,7 +137,7 @@ final class CostHistoryStoreTests: XCTestCase {
         components.day = 6
         components.hour = 2
         let now = try XCTUnwrap(components.date)
-        let store = CostHistoryStore(fileURL: url)
+        let store = CostHistoryStore(fileURL: url, timeZone: shanghai)
 
         let history = await store.history(
             for: .codex,
@@ -220,10 +217,7 @@ final class CostHistoryStoreTests: XCTestCase {
         try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
         defer { try? fileManager.removeItem(at: directory) }
 
-        let previousTimeZone = NSTimeZone.default
         let utc = TimeZone(secondsFromGMT: 0)!
-        NSTimeZone.default = utc
-        defer { NSTimeZone.default = previousTimeZone }
 
         let url = directory.appendingPathComponent("cost_history.json")
         let legacyCurrentSchemaJSON = """
@@ -235,7 +229,7 @@ final class CostHistoryStoreTests: XCTestCase {
         calendar.timeZone = utc
         let now = try XCTUnwrap(calendar.date(from: DateComponents(year: 2026, month: 5, day: 6, hour: 12)))
         let today = calendar.startOfDay(for: now)
-        let store = CostHistoryStore(fileURL: url)
+        let store = CostHistoryStore(fileURL: url, timeZone: utc)
         let fresh = CostSnapshot(
             tool: .claude,
             todayCostUSD: 1,


### PR DESCRIPTION
## Summary
- inject the calendar time zone into `CostHistoryStore` while preserving `.current` as the production default
- make local-day migration tests deterministic on UTC GitHub runners

## Test plan
- [x] `TZ=UTC swift test --filter CostHistoryStoreTests` (8/8)
- [x] `TZ=Asia/Shanghai swift test --filter CostHistoryStoreTests` (8/8)
- [x] `TZ=UTC ./Scripts/release_app.sh v0.1.0` (681/681)
- [x] release bundle signature, entitlements, archive integrity, and SHA-256 checksum