### PR TITLE
Package SwiftPM pricing resources in Vibe Bar 0.1.1

### DIFF
--- a/AGENT-DEPLOY.md
+++ b/AGENT-DEPLOY.md
@@ -109,10 +109,13 @@ What the script does (so you can recognize each phase in its output):
    skeleton at `.build/Vibe Bar.app/Contents/{MacOS,Resources}`.
 4. Copies the freshly built `VibeBar` executable into
    `Contents/MacOS/VibeBar`.
-5. Copies `Resources/Info.plist` and `Resources/AppIcon.icns` into the
+5. Copies SwiftPM's generated `VibeBar_VibeBarCore.bundle` into
+   `Contents/Resources`; `PricingResolver` checks this installed-app
+   location before falling back to `Bundle.module`.
+6. Copies `Resources/Info.plist` and `Resources/AppIcon.icns` into the
    bundle.
-6. Writes `Contents/PkgInfo`.
-7. Runs `codesign --force --deep --sign - --entitlements
+7. Writes `Contents/PkgInfo`.
+8. Runs `codesign --force --deep --sign - --entitlements
    Resources/VibeBar.entitlements ".build/Vibe Bar.app"`.
 
 The output bundle is `.build/Vibe Bar.app` (the bundle name has a literal

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -180,10 +180,13 @@ What the script does (so each phase in its output is recognizable):
    skeleton at `.build/Vibe Bar.app/Contents/{MacOS,Resources}`.
 4. Copies the freshly built `VibeBar` executable into
    `Contents/MacOS/VibeBar`.
-5. Copies `Resources/Info.plist` and `Resources/AppIcon.icns` into the
+5. Copies SwiftPM's generated `VibeBar_VibeBarCore.bundle` into
+   `Contents/Resources`; `PricingResolver` checks this installed-app
+   location before falling back to `Bundle.module`.
+6. Copies `Resources/Info.plist` and `Resources/AppIcon.icns` into the
    bundle.
-6. Writes `Contents/PkgInfo`.
-7. `codesign --force --deep --sign - --entitlements Resources/VibeBar.entitlements ".build/Vibe Bar.app"`.
+7. Writes `Contents/PkgInfo`.
+8. `codesign --force --deep --sign - --entitlements Resources/VibeBar.entitlements ".build/Vibe Bar.app"`.
 
 The output bundle is `.build/Vibe Bar.app` (the bundle name has a
 literal space).

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -19,9 +19,9 @@
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.1.0</string>
+    <string>0.1.1</string>
     <key>CFBundleVersion</key>
-    <string>1</string>
+    <string>2</string>
     <key>LSMinimumSystemVersion</key>
     <string>26.0</string>
     <key>LSUIElement</key>

--- a/Scripts/build_app.sh
+++ b/Scripts/build_app.sh
@@ -18,9 +18,14 @@ swift build -c "$CONFIG"
 
 BIN_DIR="$(swift build -c "$CONFIG" --show-bin-path)"
 EXEC_PATH="$BIN_DIR/VibeBar"
+CORE_RESOURCE_BUNDLE="$BIN_DIR/VibeBar_VibeBarCore.bundle"
 
 if [[ ! -x "$EXEC_PATH" ]]; then
     echo "Executable not found at $EXEC_PATH" >&2
+    exit 1
+fi
+if [[ ! -f "$CORE_RESOURCE_BUNDLE/pricing.json" ]]; then
+    echo "Core resource bundle not found at $CORE_RESOURCE_BUNDLE" >&2
     exit 1
 fi
 
@@ -32,6 +37,11 @@ mkdir -p "$APP_DIR/Contents/MacOS"
 mkdir -p "$APP_DIR/Contents/Resources"
 
 cp "$EXEC_PATH" "$APP_DIR/Contents/MacOS/VibeBar"
+# A signed macOS app may only contain its conventional Contents tree. Core's
+# pricing resolver explicitly discovers this SwiftPM bundle under Resources
+# before falling back to Bundle.module for source builds and tests.
+cp -R "$CORE_RESOURCE_BUNDLE" \
+    "$APP_DIR/Contents/Resources/VibeBar_VibeBarCore.bundle"
 cp "$ROOT/Resources/Info.plist" "$APP_DIR/Contents/Info.plist"
 if [[ -f "$ROOT/Resources/AppIcon.icns" ]]; then
     cp "$ROOT/Resources/AppIcon.icns" "$APP_DIR/Contents/Resources/AppIcon.icns"
@@ -42,6 +52,11 @@ fi
 
 PkgInfo="APPL????"
 printf '%s' "$PkgInfo" > "$APP_DIR/Contents/PkgInfo"
+
+if [[ ! -f "$APP_DIR/Contents/Resources/VibeBar_VibeBarCore.bundle/pricing.json" ]]; then
+    echo "Packaged core resource bundle is incomplete." >&2
+    exit 1
+fi
 
 if [[ ! -f "$ENTITLEMENTS" ]]; then
     echo "Entitlements file not found at $ENTITLEMENTS" >&2

--- a/Scripts/release_app.sh
+++ b/Scripts/release_app.sh
@@ -65,6 +65,12 @@ fi
 echo "==> building Vibe Bar $VERSION ($BUILD_NUMBER)"
 (cd "$ROOT" && ./Scripts/build_app.sh release)
 
+echo "==> verifying bundled pricing resources"
+if [[ ! -f "$APP_DIR/Contents/Resources/VibeBar_VibeBarCore.bundle/pricing.json" ]]; then
+    echo "Refusing to release an app without the VibeBarCore resource bundle." >&2
+    exit 1
+fi
+
 echo "==> verifying bundle signature"
 codesign --verify --deep --strict "$APP_DIR"
 ENTITLEMENTS="$(codesign -d --entitlements - "$APP_DIR" 2>&1)"

--- a/Sources/VibeBarCore/Vendored/CostUsage/PricingResolver.swift
+++ b/Sources/VibeBarCore/Vendored/CostUsage/PricingResolver.swift
@@ -100,11 +100,33 @@ public enum PricingResolver {
     }
 
     static func loadBundled() -> PricingDataSet? {
-        guard let url = Bundle.module.url(forResource: "pricing", withExtension: "json"),
+        guard let url = bundledPricingURL(),
               let data = try? Data(contentsOf: url),
               let decoded = try? JSONDecoder().decode(PricingDataSet.self, from: data),
               decoded.schemaVersion == PricingDataSet.currentSchemaVersion
         else { return nil }
         return decoded
+    }
+
+    /// SwiftPM's generated `Bundle.module` accessor only knows the absolute
+    /// build directory and a bundle next to `Bundle.main.bundleURL`. Neither
+    /// location is valid after the executable is installed in a signed macOS
+    /// app: the CI build directory is gone, while non-Contents files make
+    /// codesign reject the app. The packaging script therefore embeds the
+    /// generated resource bundle in the conventional Resources directory.
+    private static func bundledPricingURL() -> URL? {
+        if let resourcesURL = Bundle.main.resourceURL {
+            let embeddedBundleURL = resourcesURL
+                .appendingPathComponent("VibeBar_VibeBarCore.bundle", isDirectory: true)
+            if let embeddedBundle = Bundle(url: embeddedBundleURL),
+               let url = embeddedBundle.url(
+                   forResource: "pricing",
+                   withExtension: "json"
+               )
+            {
+                return url
+            }
+        }
+        return Bundle.module.url(forResource: "pricing", withExtension: "json")
     }
 }


### PR DESCRIPTION
## Summary
- package the generated VibeBarCore pricing resource bundle inside the signed app Resources directory
- resolve installed resources before the SwiftPM build-path fallback and block incomplete release assets
- bump the app to v0.1.1 (build 2)

## Test plan
- [x] `swift build`
- [x] `swift test` — 681 tests passed
- [x] `./Scripts/release_app.sh v0.1.1`
- [x] `codesign --verify --deep --strict ".build/Vibe Bar.app"`
- [x] verified empty entitlements
- [x] verified ZIP SHA-256 and archived `pricing.json`
- [ ] manual launch smoke test — not run; release workflow and installed-app replacement remain separate verification steps

## Regression
The v0.1.0 app omitted `VibeBar_VibeBarCore.bundle`. Once the 24-hour pricing cache expired, `PricingRefresher` reached `Bundle.module`, whose CI build path no longer existed, and the app terminated with `SIGTRAP` during startup.