### PR TITLE
Limit Sparkle secret exposure

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,6 @@ jobs:
       APPLE_ID: ${{ secrets.APPLE_ID }}
       APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
       APPLE_APP_PASSWORD: ${{ secrets.APPLE_APP_PASSWORD }}
-      SPARKLE_ED_PRIVATE_KEY: ${{ secrets.SPARKLE_ED_PRIVATE_KEY }}
 
     steps:
       - name: Check out tagged source
@@ -42,15 +41,6 @@ jobs:
           sw_vers -productVersion
           xcode-select -p
           swift --version
-
-      - name: Verify Sparkle signing key
-        shell: bash
-        run: |
-          set -euo pipefail
-          if [[ -z "$SPARKLE_ED_PRIVATE_KEY" ]]; then
-            echo "SPARKLE_ED_PRIVATE_KEY is required for signed in-app updates." >&2
-            exit 1
-          fi
 
       - name: Import optional Developer ID certificate
         if: ${{ env.MACOS_CERTIFICATE_P12 != '' }}
@@ -95,7 +85,16 @@ jobs:
           echo "VIBEBAR_CODESIGN_IDENTITY=$SIGNING_IDENTITY" >> "$GITHUB_ENV"
 
       - name: Build verified release assets
-        run: ./Scripts/release_app.sh "$RELEASE_TAG"
+        env:
+          SPARKLE_ED_PRIVATE_KEY: ${{ secrets.SPARKLE_ED_PRIVATE_KEY }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ -z "$SPARKLE_ED_PRIVATE_KEY" ]]; then
+            echo "SPARKLE_ED_PRIVATE_KEY is required for signed in-app updates." >&2
+            exit 1
+          fi
+          ./Scripts/release_app.sh "$RELEASE_TAG"
 
       - name: Create or update draft release
         env:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -839,9 +839,10 @@ moment step 1 lands.
   `CFBundleShortVersionString`. The workflow creates a draft GitHub Release
   so its assets can be inspected before publishing.
 - Every published release must include the ZIP, checksum, and signed
-  `appcast.xml`. The workflow requires the repository secret
-  `SPARKLE_ED_PRIVATE_KEY`; the matching public key is `SUPublicEDKey` in
-  `Resources/Info.plist`.
+  `appcast.xml`. The workflow requires the repository Actions secret
+  `SPARKLE_ED_PRIVATE_KEY`, exposes it only to the release-asset build step,
+  and passes it to Sparkle over standard input. The matching public key is
+  `SUPublicEDKey` in `Resources/Info.plist`.
 - The stable in-app update feed is the `appcast.xml` asset on GitHub's latest
   published release. Never hand-edit an appcast after generation.
 - The license is AGPL-3.0-only; don't relicense without an explicit

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -77,12 +77,14 @@ Generate one organization-scoped Sparkle key on a trusted maintainer Mac:
 Keep the printed public key in `Resources/Info.plist` as `SUPublicEDKey`.
 The private key remains in the login Keychain. For GitHub Actions, export it
 to a temporary permission-restricted file, save its contents as the repository
-secret `SPARKLE_ED_PRIVATE_KEY`, and immediately delete the temporary file.
-Never commit or print the private key.
+Actions secret `SPARKLE_ED_PRIVATE_KEY`, and immediately delete the temporary
+file. Never commit or print the private key.
 
 Local releases use the `astroqore-vibe-bar` Keychain account by default.
-CI reads `SPARKLE_ED_PRIVATE_KEY` from standard input and fails before
-packaging when the secret is absent. `Scripts/release_app.sh` also rejects an
+CI exposes `SPARKLE_ED_PRIVATE_KEY` only to the release-asset build step,
+passes it to Sparkle over standard input, and fails before packaging when the
+secret is absent. The value is not written to the checkout, command line,
+release assets, or workflow output. `Scripts/release_app.sh` also rejects an
 appcast that lacks an EdDSA archive signature or the expected build number.
 
 The stable feed URL is:


### PR DESCRIPTION
## Summary
- expose `SPARKLE_ED_PRIVATE_KEY` only to the release-asset build step
- fail immediately when the repository Actions secret is missing
- document stdin-only key handling and the no-checkout/no-log/no-asset boundary

## Test plan
- [x] workflow YAML parse
- [x] `swift build`
- [x] `swift test` (681 tests)
- [x] `./Scripts/build_app.sh release`
- [x] empty entitlement and strict nested codesign verification

Co-Authored-By: Codex <noreply@openai.com>