### PR TITLE
Calculate token peak independently from cost peak

### DIFF
--- a/Sources/VibeBarApp/Views/PopoverRoot.swift
+++ b/Sources/VibeBarApp/Views/PopoverRoot.swift
@@ -832,15 +832,10 @@ private struct CombinedTotalsRow: View {
         let yesterdayTokens = snapshots.reduce(0) { $0 + CostTimeframe.yesterday.tokens(in: $1) }
         let weekTokens = snapshots.reduce(0) { $0 + $1.last7DaysTokens }
         let monthTokens = snapshots.reduce(0) { $0 + $1.last30DaysTokens }
-        // Pick the single day with the highest cost across all
-        // providers, then surface both its cost and token totals so
-        // the user sees what they spent *and* burned on their worst
-        // day. Using `.max(by:)` rather than two separate `.max()`
-        // calls keeps the two numbers from drifting onto different
-        // days when token-heavy and dollar-heavy days disagree.
-        let peakDayPoint = dailyHistory.max(by: { $0.costUSD < $1.costUSD })
-        let peakDayCost = peakDayPoint?.costUSD ?? 0
-        let peakDayTokens = peakDayPoint?.totalTokens ?? 0
+        // Cost and token peaks are independent: the most expensive day
+        // is not necessarily the day with the highest token volume.
+        let peakDayCost = CostSnapshotAggregator.peakDailyCost(in: dailyHistory)
+        let peakTokenDayTokens = CostSnapshotAggregator.peakDailyTokens(in: dailyHistory)
         GeometryReader { geometry in
             let spacing = density.interSectionSpacing
             let availableWidth = max(0, geometry.size.width - spacing)
@@ -879,7 +874,7 @@ private struct CombinedTotalsRow: View {
                             divider
                             metric(label: "PEAK DAY", value: formatCost(peakDayCost))
                             divider
-                            metric(label: "PEAK DAY TOK", value: formatTokens(peakDayTokens))
+                            metric(label: "PEAK TOK DAY", value: formatTokens(peakTokenDayTokens))
                         }
                         Spacer(minLength: 8)
                         HStack(alignment: .top, spacing: 0) {

--- a/Sources/VibeBarCore/Models/CostSnapshot.swift
+++ b/Sources/VibeBarCore/Models/CostSnapshot.swift
@@ -336,6 +336,14 @@ public struct CostSnapshot: Sendable, Equatable, Codable {
 ///   we sum costs/tokens under the shared name. The output is sorted by cost
 ///   desc to match the existing single-provider rendering.
 public enum CostSnapshotAggregator {
+    public static func peakDailyCost(in history: [DailyCostPoint]) -> Double {
+        history.map(\.costUSD).max() ?? 0
+    }
+
+    public static func peakDailyTokens(in history: [DailyCostPoint]) -> Int {
+        history.map(\.totalTokens).max() ?? 0
+    }
+
     public static func combinedDailyHistory(
         _ snapshots: [CostSnapshot],
         calendar: Calendar = .current

--- a/Tests/VibeBarCoreTests/CostSnapshotAggregatorTests.swift
+++ b/Tests/VibeBarCoreTests/CostSnapshotAggregatorTests.swift
@@ -71,6 +71,24 @@ final class CostSnapshotAggregatorTests: XCTestCase {
         XCTAssertEqual(combined[1].totalTokens, 750)
     }
 
+    func testDailyCostAndTokenPeaksUseIndependentDays() throws {
+        let cal = calendar()
+        let costPeakDay = try XCTUnwrap(cal.date(from: DateComponents(year: 2026, month: 5, day: 1)))
+        let tokenPeakDay = try XCTUnwrap(cal.date(from: DateComponents(year: 2026, month: 5, day: 2)))
+        let history = [
+            DailyCostPoint(date: costPeakDay, costUSD: 100, totalTokens: 1_000),
+            DailyCostPoint(date: tokenPeakDay, costUSD: 10, totalTokens: 9_000),
+        ]
+
+        XCTAssertEqual(CostSnapshotAggregator.peakDailyCost(in: history), 100, accuracy: 0.0001)
+        XCTAssertEqual(CostSnapshotAggregator.peakDailyTokens(in: history), 9_000)
+    }
+
+    func testDailyPeaksDefaultToZeroForEmptyHistory() {
+        XCTAssertEqual(CostSnapshotAggregator.peakDailyCost(in: []), 0, accuracy: 0.0001)
+        XCTAssertEqual(CostSnapshotAggregator.peakDailyTokens(in: []), 0)
+    }
+
     func testCombinedHeatmapAddsCellsAndTotalsAcrossProviders() {
         var codexCells = Array(repeating: Array(repeating: 0, count: 24), count: 7)
         codexCells[1][9] = 100


### PR DESCRIPTION
## Summary
- calculate the cost-day and token-day peaks independently
- rename the token metric to `PEAK TOK DAY` so its meaning is explicit
- add regression coverage where the cost and token peaks occur on different days

## Test plan
- [x] `swift build`
- [x] `swift test` (683 tests)
- [x] `./Scripts/build_app.sh release`
- [x] empty entitlements inspection
- [x] `codesign --verify --deep --strict ".build/Vibe Bar.app"`
- [ ] manual smoke test (not required for this data-selection fix)