### PR TITLE
Prepare Vibe Bar 0.2.1

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -19,9 +19,9 @@
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.2.0</string>
+    <string>0.2.1</string>
     <key>CFBundleVersion</key>
-    <string>3</string>
+    <string>4</string>
     <key>LSMinimumSystemVersion</key>
     <string>26.0</string>
     <key>LSUIElement</key>


### PR DESCRIPTION
## Summary
- bump Vibe Bar from 0.2.0 to 0.2.1
- increment the bundle build number from 3 to 4
- prepare the Peak Tok Day correction from #111 for a patch release

## Test plan
- [x] `swift build`
- [x] `swift test` (683 tests)
- [x] `./Scripts/build_app.sh release`
- [x] packaged app reports version `0.2.1` and build `4`
- [x] bundled pricing resource exists
- [x] entitlements are empty and contain no App Sandbox key
- [x] `codesign --verify --deep --strict ".build/Vibe Bar.app"`
- [ ] tag merged `main` as `v0.2.1`
- [ ] inspect and publish the generated draft GitHub Release