### PR TITLE
Prepare Vibe Bar 0.2.2

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -19,9 +19,9 @@
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.2.1</string>
+    <string>0.2.2</string>
     <key>CFBundleVersion</key>
-    <string>4</string>
+    <string>5</string>
     <key>LSMinimumSystemVersion</key>
     <string>26.0</string>
     <key>LSUIElement</key>


### PR DESCRIPTION
Version bump for the history-charts release (PR #113): `CFBundleShortVersionString` 0.2.1 → 0.2.2, `CFBundleVersion` 4 → 5.

Verified in this worktree: `swift build` clean, 790 tests green, `./Scripts/build_app.sh release` + strict codesign pass, entitlements empty (no `app-sandbox`), bundle ID unchanged, `SUPublicEDKey`/`SUFeedURL` intact.

After merge: tag `v0.2.2` → release workflow → inspect draft assets → publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)