### PR TITLE
Polish history charts: layout, granularity, per-group quota charts

### DIFF
--- a/Sources/VibeBarApp/Views/CostHistoryView.swift
+++ b/Sources/VibeBarApp/Views/CostHistoryView.swift
@@ -23,9 +23,13 @@ private struct CostGranularityOption: Identifiable, Equatable {
         }
     }
 
-    func isEnabled(allowed: [CostChartGranularity]) -> Bool {
+    /// Auto is selectable at every span. A manual width is offered only when
+    /// picking it would actually stick — the same rule that demotes a pick
+    /// after a pan or a zoom, so the control never lights up an option the
+    /// chart would immediately hand back.
+    func isEnabled(for visibleSpan: TimeInterval) -> Bool {
         guard let granularity else { return true }
-        return allowed.contains(granularity)
+        return CostChartGranularity.survivesManualSelection(granularity, for: visibleSpan)
     }
 
     static let all: [CostGranularityOption] = [
@@ -132,7 +136,14 @@ struct CostHistoryView: View {
     private static let miniMarkLimit = 180
 
     var body: some View {
-        let window = self.window
+        // Derived, not just read: `rebuildWindow()` only runs once the card is
+        // on screen, and until it does `self.window` is nil. Measuring the card
+        // in that state reports the height of the "Building history…" note —
+        // roughly a third of the real card — and any ancestor that sizes from
+        // that first pass (the Overview waterfall proposes each card the height
+        // it measured) would lay the card out too short. Seeding the window
+        // here makes the first measurement the real one.
+        let window = self.window ?? initialWindow()
 
         VStack(alignment: .leading, spacing: density.cardSpacing) {
             header(window: window)
@@ -268,6 +279,42 @@ struct CostHistoryView: View {
         granularity: CostChartGranularity,
         window: Binding<ChartTimeWindow>
     ) -> some View {
+        // The bar width has to be resolved against the real plot width: Swift
+        // Charts sizes a calendar-unit bar to the whole unit, so a five-day
+        // window would otherwise draw five ~90pt slabs.
+        GeometryReader { geometry in
+            chartBody(
+                points: points,
+                average: average,
+                granularity: granularity,
+                window: window,
+                barWidth: barWidth(
+                    points: points,
+                    granularity: granularity,
+                    window: window.wrappedValue,
+                    plotWidth: geometry.size.width
+                )
+            )
+        }
+        .frame(height: chartHeight)
+        .overlay {
+            if points.isEmpty {
+                Text("No cost recorded in this range.")
+                    .font(.system(size: density.resetCountdownFontSize))
+                    .foregroundStyle(.tertiary)
+                    .allowsHitTesting(false)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func chartBody(
+        points: [CostChartPoint],
+        average: Double,
+        granularity: CostChartGranularity,
+        window: Binding<ChartTimeWindow>,
+        barWidth: MarkDimension
+    ) -> some View {
         Chart {
             if granularity == .hour {
                 ForEach(points) { point in
@@ -309,7 +356,8 @@ struct CostHistoryView: View {
                             unit: barUnit(granularity),
                             calendar: Self.barCalendar
                         ),
-                        y: .value("Cost", point.costUSD)
+                        y: .value("Cost", point.costUSD),
+                        width: barWidth
                     )
                     .foregroundStyle(point.costUSD > average * 1.5 ? Color.orange : Color.accentColor)
                     .cornerRadius(2)
@@ -345,15 +393,44 @@ struct CostHistoryView: View {
         .chartOverlay { proxy in
             interactionOverlay(proxy: proxy, points: points, window: window)
         }
-        .frame(height: chartHeight)
-        .overlay {
-            if points.isEmpty {
-                Text("No cost recorded in this range.")
-                    .font(.system(size: density.resetCountdownFontSize))
-                    .foregroundStyle(.tertiary)
-                    .allowsHitTesting(false)
-            }
-        }
+    }
+
+    /// Widest a single bar is allowed to get. Past this a bar stops reading as
+    /// a measurement and starts reading as a block of colour — a five-day
+    /// window is the common case, and its unit-wide bars are ~90pt.
+    private static let maximumBarWidth: CGFloat = 26
+    /// Gap kept between neighbouring bars once they are narrow enough that the
+    /// cap no longer applies.
+    private static let barGap: CGFloat = 2
+    /// Thinner than this and a bar disappears into the background.
+    private static let minimumBarWidth: CGFloat = 1
+
+    /// How wide to draw each bar, given how many of them share the plot.
+    ///
+    /// `.automatic` would hand every bar its whole calendar unit, so the width
+    /// has to be resolved here: take the per-bucket slice of the plot, leave a
+    /// hairline gap, and clamp it to something a reader can still compare.
+    /// Swift Charts keeps a fixed-width bar centred on the same anchor the
+    /// automatic one used — the middle of its bucket — so narrowing a bar does
+    /// not slide it off the day it represents.
+    private func barWidth(
+        points: [CostChartPoint],
+        granularity: CostChartGranularity,
+        window: ChartTimeWindow,
+        plotWidth: CGFloat
+    ) -> MarkDimension {
+        guard plotWidth > 0, !points.isEmpty else { return .automatic }
+        let span = window.visibleSpan
+        guard span > 0 else { return .automatic }
+        // Bucket count from the span rather than `points.count`: a range with
+        // gaps in the data still has to draw the bars at their true pitch.
+        let buckets = max(
+            Double(points.count),
+            span / granularity.approximateBucketSeconds
+        )
+        let pitch = CGFloat(Double(plotWidth) / max(1, buckets))
+        let width = min(Self.maximumBarWidth, pitch - Self.barGap)
+        return .fixed(max(Self.minimumBarWidth, width))
     }
 
     /// Thin daily bars for the brush strip. Always daily regardless of the main
@@ -564,6 +641,15 @@ struct CostHistoryView: View {
 
     // MARK: - Footer
 
+    /// TOTAL / AVG / PEAK plus the visible-extent note.
+    ///
+    /// The overview column is narrow enough that the four blocks cannot always
+    /// share one line, and an `HStack` given less width than it asked for lets
+    /// its children draw past the card rather than shrinking them. Offer the
+    /// same content at three widths instead and let `ViewThatFits` pick: roomy
+    /// row, tight row, then the note wrapped onto its own line. Every candidate
+    /// reports a finite ideal width — the spacer keeps a real `minLength` — so
+    /// the choice is made on what actually fits.
     @ViewBuilder
     private func footer(
         total: Double,
@@ -573,7 +659,62 @@ struct CostHistoryView: View {
         resolved: CostResolvedGranularity,
         window: ChartTimeWindow
     ) -> some View {
-        HStack(spacing: 16) {
+        let note = extentNote(resolved: resolved, window: window)
+        ViewThatFits(in: .horizontal) {
+            HStack(alignment: .top, spacing: Self.footerRowSpacing) {
+                metricsRow(
+                    spacing: Self.footerRowSpacing,
+                    total: total,
+                    average: average,
+                    peak: peak,
+                    peakDate: peakDate,
+                    resolved: resolved
+                )
+                Spacer(minLength: Self.footerRowSpacing)
+                note
+            }
+            HStack(alignment: .top, spacing: Self.footerTightSpacing) {
+                metricsRow(
+                    spacing: Self.footerTightSpacing,
+                    total: total,
+                    average: average,
+                    peak: peak,
+                    peakDate: peakDate,
+                    resolved: resolved
+                )
+                Spacer(minLength: Self.footerTightSpacing)
+                note
+            }
+            VStack(alignment: .leading, spacing: 2) {
+                metricsRow(
+                    spacing: Self.footerTightSpacing,
+                    total: total,
+                    average: average,
+                    peak: peak,
+                    peakDate: peakDate,
+                    resolved: resolved
+                )
+                note
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        }
+    }
+
+    /// Gap between the metric blocks when the card has room for it.
+    private static let footerRowSpacing: CGFloat = 16
+    /// The same gap once the card is narrow enough that 16pt would push the
+    /// extent note off the card.
+    private static let footerTightSpacing: CGFloat = 8
+
+    private func metricsRow(
+        spacing: CGFloat,
+        total: Double,
+        average: Double,
+        peak: Double,
+        peakDate: Date?,
+        resolved: CostResolvedGranularity
+    ) -> some View {
+        HStack(alignment: .top, spacing: spacing) {
             metric(label: "Total", value: formatCost(total))
             metric(
                 label: "Avg/\(resolved.granularity.displayName.lowercased())",
@@ -584,22 +725,33 @@ struct CostHistoryView: View {
                 value: formatCost(peak),
                 detail: peakDate.map { peakDetail($0, granularity: resolved.granularity) }
             )
-            Spacer(minLength: 8)
-            VStack(alignment: .trailing, spacing: 1) {
-                Text(visibleExtentNote(window: window))
-                    .font(.system(size: density.resetCountdownFontSize))
-                    .foregroundStyle(.tertiary)
-                if resolved.hourlyFallback {
-                    Text("hourly n/a · showing daily")
-                        .font(.system(size: max(8, density.resetCountdownFontSize - 1)))
-                        .foregroundStyle(.tertiary)
-                }
-            }
-            .lineLimit(1)
-            .minimumScaleFactor(0.8)
         }
     }
 
+    @ViewBuilder
+    private func extentNote(
+        resolved: CostResolvedGranularity,
+        window: ChartTimeWindow
+    ) -> some View {
+        VStack(alignment: .trailing, spacing: 1) {
+            Text(visibleExtentNote(window: window))
+                .font(.system(size: density.resetCountdownFontSize))
+                .foregroundStyle(.tertiary)
+            if resolved.hourlyFallback {
+                Text("hourly n/a · showing daily")
+                    .font(.system(size: max(8, density.resetCountdownFontSize - 1)))
+                    .foregroundStyle(.tertiary)
+            }
+        }
+        .lineLimit(1)
+        .fixedSize(horizontal: true, vertical: false)
+    }
+
+    /// One metric block. The three of them line up on two shared baselines —
+    /// the label row and the value row — because the sub-label row is always
+    /// laid out, blank when a metric has nothing to say there. Peak's date
+    /// therefore hangs below the shared value baseline instead of pushing its
+    /// own column up.
     @ViewBuilder
     private func metric(label: String, value: String, detail: String? = nil) -> some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -609,14 +761,14 @@ struct CostHistoryView: View {
                 .tracking(0.4)
             Text(value)
                 .font(.system(size: density.bucketTitleFontSize, weight: .semibold, design: .rounded).monospacedDigit())
-            if let detail {
-                Text(detail)
-                    .font(.system(size: max(8, density.resetCountdownFontSize - 2)))
-                    .foregroundStyle(.tertiary)
-                    .lineLimit(1)
-                    .minimumScaleFactor(0.8)
-            }
+            Text(detail ?? " ")
+                .font(.system(size: max(8, density.resetCountdownFontSize - 2)))
+                .foregroundStyle(.tertiary)
+                .opacity(detail == nil ? 0 : 1)
+                .accessibilityHidden(detail == nil)
         }
+        .lineLimit(1)
+        .fixedSize(horizontal: true, vertical: false)
     }
 
     // MARK: - Window
@@ -662,6 +814,21 @@ struct CostHistoryView: View {
         return start...end
     }
 
+    /// The window a card opens on, derived purely from the data. Used both to
+    /// seed `window` and to render the very first layout pass, before
+    /// `rebuildWindow()` has had a chance to run.
+    private func initialWindow() -> ChartTimeWindow? {
+        guard let domain = domainRange(), domain.upperBound > domain.lowerBound else {
+            return nil
+        }
+        return ChartTimeWindow(
+            domainStart: domain.lowerBound,
+            domainEnd: domain.upperBound,
+            minimumSpan: Self.minimumSpan,
+            visibleSpan: Self.resetSpan
+        )
+    }
+
     /// Re-anchor the window after a scan. Runs on data changes only — pans and
     /// zooms reuse the window they produced.
     private func rebuildWindow() {
@@ -688,12 +855,7 @@ struct CostHistoryView: View {
             window = next
             return
         }
-        window = ChartTimeWindow(
-            domainStart: domain.lowerBound,
-            domainEnd: domain.upperBound,
-            minimumSpan: Self.minimumSpan,
-            visibleSpan: Self.resetSpan
-        )
+        window = initialWindow()
     }
 
     // MARK: - Range presets
@@ -756,10 +918,10 @@ struct CostHistoryView: View {
 
     @ViewBuilder
     private func granularityControl(window: ChartTimeWindow) -> some View {
-        let allowed = CostChartGranularity.allowed(for: window.visibleSpan)
+        let span = window.visibleSpan
         HStack(spacing: 1) {
             ForEach(CostGranularityOption.all) { option in
-                let enabled = option.isEnabled(allowed: allowed)
+                let enabled = option.isEnabled(for: span)
                 Button {
                     granularityMode = option.mode
                 } label: {
@@ -810,9 +972,14 @@ struct CostHistoryView: View {
 
     /// A manual pick that stops making sense after a pan or a zoom returns to
     /// Auto rather than silently drawing something the span cannot carry.
+    ///
+    /// "Stops making sense" is two things: the option is no longer offered at
+    /// this span, or it is still offered but would draw fewer bars than
+    /// `CostChartGranularity.minimumManualBuckets` — a handful of slabs the
+    /// user cannot read a trend from.
     private func demoteDisallowedGranularity(span: TimeInterval?) {
         guard case .manual(let choice) = granularityMode, let span else { return }
-        if !CostChartGranularity.isAllowed(choice, for: span) {
+        if !CostChartGranularity.survivesManualSelection(choice, for: span) {
             granularityMode = .auto
         }
     }
@@ -827,7 +994,7 @@ struct CostHistoryView: View {
             // A pinch can invalidate the pick mid-gesture. Draw what the span
             // can carry straight away; `demoteDisallowedGranularity` moves the
             // selection back to Auto once the change settles.
-            requested = CostChartGranularity.isAllowed(choice, for: span)
+            requested = CostChartGranularity.survivesManualSelection(choice, for: span)
                 ? choice
                 : CostChartGranularity.resolve(autoFor: span)
         }

--- a/Sources/VibeBarApp/Views/PopoverRoot.swift
+++ b/Sources/VibeBarApp/Views/PopoverRoot.swift
@@ -722,12 +722,13 @@ private struct GeminiTabPage: View {
         accountId: String,
         titleOverride: String
     ) -> some View {
+        let allGroups = QuotaBucketGrouping.groups(
+            pageTool: .gemini,
+            itemTool: tool,
+            buckets: quotaService.cachedQuota(for: accountId)?.buckets ?? []
+        )
         let groups = QuotaBucketGrouping.chartable(
-            QuotaBucketGrouping.groups(
-                pageTool: .gemini,
-                itemTool: tool,
-                buckets: quotaService.cachedQuota(for: accountId)?.buckets ?? []
-            ),
+            allGroups,
             accountId: accountId,
             observations: quotaService.observationsByAccountBucket
         )
@@ -738,7 +739,10 @@ private struct GeminiTabPage: View {
                 group: group,
                 density: density,
                 titleOverride: titleOverride,
-                showsGroupTitle: groups.count > 1
+                // Unfiltered count: when other groups merely lack history yet,
+                // the surviving card still needs its group label to stay
+                // distinguishable from them.
+                showsGroupTitle: allGroups.count > 1
             )
         }
     }
@@ -1482,12 +1486,13 @@ private struct ProviderDetailView: View {
                 // Quotas that share a heading share a plot; quotas that reset
                 // on unrelated schedules never get merged behind a picker.
                 if let accountId = environment.account(for: tool)?.id {
+                    let allGroups = QuotaBucketGrouping.groups(
+                        pageTool: tool,
+                        itemTool: tool,
+                        buckets: environment.quota(for: tool)?.buckets ?? []
+                    )
                     let groups = QuotaBucketGrouping.chartable(
-                        QuotaBucketGrouping.groups(
-                            pageTool: tool,
-                            itemTool: tool,
-                            buckets: environment.quota(for: tool)?.buckets ?? []
-                        ),
+                        allGroups,
                         accountId: accountId,
                         observations: quotaService.observationsByAccountBucket
                     )
@@ -1497,7 +1502,10 @@ private struct ProviderDetailView: View {
                             accountId: accountId,
                             group: group,
                             density: density,
-                            showsGroupTitle: groups.count > 1
+                            // Unfiltered count, so a lone drawable group keeps
+                            // its label while sibling groups are still
+                            // accumulating history.
+                            showsGroupTitle: allGroups.count > 1
                         )
                     }
                 }

--- a/Sources/VibeBarApp/Views/PopoverRoot.swift
+++ b/Sources/VibeBarApp/Views/PopoverRoot.swift
@@ -681,25 +681,22 @@ private struct GeminiTabPage: View {
                         additionalQuotaSeries: antigravityQuotaSeries
                     )
                 }
-                // One card per account, in the same order the utilization card
-                // above stacks them: Gemini first, AntiGravity as the extra
-                // series. The two quotas reset on their own schedules, so they
-                // cannot share a chart the way they share a bucket list.
+                // One card per quota group, in the same order the utilization
+                // card above stacks them: Gemini's groups first, then
+                // AntiGravity's. The two products reset on their own schedules,
+                // so they never share a chart; neither do two groups inside one
+                // product.
                 if let geminiAccount = geminiAccounts.first {
-                    QuotaHistoryChartView(
+                    quotaHistoryCards(
                         tool: .gemini,
                         accountId: geminiAccount.id,
-                        buckets: quotaService.cachedQuota(for: geminiAccount.id)?.buckets ?? [],
-                        density: density,
                         titleOverride: "Gemini quota history"
                     )
                 }
                 if let antigravityAccount {
-                    QuotaHistoryChartView(
+                    quotaHistoryCards(
                         tool: .antigravity,
                         accountId: antigravityAccount.id,
-                        buckets: quotaService.cachedQuota(for: antigravityAccount.id)?.buckets ?? [],
-                        density: density,
                         titleOverride: "AntiGravity quota history"
                     )
                 }
@@ -714,6 +711,36 @@ private struct GeminiTabPage: View {
                 .frame(width: columns.right, alignment: .topLeading)
         }
         .frame(width: columns.total, alignment: .topLeading)
+    }
+
+    /// Quota-history cards for one of the two products on this page. The page
+    /// tool stays `.gemini` when grouping so an ungrouped Gemini Web quota gets
+    /// the same "Gemini Chat" heading the utilization card gives it.
+    @ViewBuilder
+    private func quotaHistoryCards(
+        tool: ToolType,
+        accountId: String,
+        titleOverride: String
+    ) -> some View {
+        let groups = QuotaBucketGrouping.chartable(
+            QuotaBucketGrouping.groups(
+                pageTool: .gemini,
+                itemTool: tool,
+                buckets: quotaService.cachedQuota(for: accountId)?.buckets ?? []
+            ),
+            accountId: accountId,
+            observations: quotaService.observationsByAccountBucket
+        )
+        ForEach(groups) { group in
+            QuotaHistoryChartView(
+                tool: tool,
+                accountId: accountId,
+                group: group,
+                density: density,
+                titleOverride: titleOverride,
+                showsGroupTitle: groups.count > 1
+            )
+        }
     }
 }
 
@@ -1449,13 +1476,30 @@ private struct ProviderDetailView: View {
                         now: context.date
                     )
                 }
+                // One history card per quota group, in the order the
+                // utilization card above prints its group headings — Claude's
+                // ungrouped 5 Hours + Weekly in one chart, Fable in the next.
+                // Quotas that share a heading share a plot; quotas that reset
+                // on unrelated schedules never get merged behind a picker.
                 if let accountId = environment.account(for: tool)?.id {
-                    QuotaHistoryChartView(
-                        tool: tool,
+                    let groups = QuotaBucketGrouping.chartable(
+                        QuotaBucketGrouping.groups(
+                            pageTool: tool,
+                            itemTool: tool,
+                            buckets: environment.quota(for: tool)?.buckets ?? []
+                        ),
                         accountId: accountId,
-                        buckets: environment.quota(for: tool)?.buckets ?? [],
-                        density: density
+                        observations: quotaService.observationsByAccountBucket
                     )
+                    ForEach(groups) { group in
+                        QuotaHistoryChartView(
+                            tool: tool,
+                            accountId: accountId,
+                            group: group,
+                            density: density,
+                            showsGroupTitle: groups.count > 1
+                        )
+                    }
                 }
                 ServiceStatusCard(tools: [tool], density: density)
             }

--- a/Sources/VibeBarApp/Views/QuotaHistoryChartView.swift
+++ b/Sources/VibeBarApp/Views/QuotaHistoryChartView.swift
@@ -2,6 +2,99 @@ import SwiftUI
 import Charts
 import VibeBarCore
 
+/// One headed group of independently resettable quotas.
+///
+/// Claude splits its weekly allowance across model scopes ("Fable", "Opus", …)
+/// and Codex splits its by limit name; each of those is a group, and the
+/// ungrouped remainder (Claude's 5 Hours + Weekly) is a group too — the one
+/// Subscription Utilization prints no heading for.
+struct QuotaBucketGroup: Identifiable {
+    let id: String
+    let title: String?
+    let buckets: [QuotaBucket]
+}
+
+/// Single source of truth for how a provider page splits an account's quotas
+/// into headed groups.
+///
+/// `SubscriptionUtilizationView` prints the heading above the first row of each
+/// group; the quota-history cards draw one chart per group. Both have to agree
+/// on where a group starts and what it is called, so both read this.
+enum QuotaBucketGrouping {
+    /// The heading a bucket belongs under, or `nil` for the ungrouped rows the
+    /// utilization card prints without a heading.
+    ///
+    /// `pageTool` is the provider page being rendered and `itemTool` the tool
+    /// the bucket actually came from — they differ only for linked products
+    /// (AntiGravity on the Gemini page).
+    static func title(pageTool: ToolType, itemTool: ToolType, bucket: QuotaBucket) -> String? {
+        if let title = bucket.groupTitle?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !title.isEmpty {
+            return title
+        }
+        if pageTool == .gemini, itemTool == .gemini {
+            return "Gemini Chat"
+        }
+        return nil
+    }
+
+    /// Split `buckets` into runs that share a heading, preserving the
+    /// provider's own bucket order.
+    ///
+    /// Contiguous by design: the utilization card decides "this row starts a
+    /// group" by comparing with the row above it, so a title that reappeared
+    /// after an interruption would print twice there. Grouping the same way
+    /// keeps one chart per printed heading rather than per distinct string.
+    static func groups(
+        pageTool: ToolType,
+        itemTool: ToolType,
+        buckets: [QuotaBucket]
+    ) -> [QuotaBucketGroup] {
+        var result: [QuotaBucketGroup] = []
+        for bucket in buckets {
+            let title = title(pageTool: pageTool, itemTool: itemTool, bucket: bucket)
+            if let last = result.last, last.title == title {
+                result[result.count - 1] = QuotaBucketGroup(
+                    id: last.id,
+                    title: last.title,
+                    buckets: last.buckets + [bucket]
+                )
+            } else {
+                result.append(
+                    QuotaBucketGroup(
+                        id: "\(itemTool.rawValue)|\(result.count)|\(title ?? "")",
+                        title: title,
+                        buckets: [bucket]
+                    )
+                )
+            }
+        }
+        return result
+    }
+
+    /// Groups worth giving a history card.
+    ///
+    /// A line needs two points, so a group nobody has observed twice yet would
+    /// render an empty card — and on a fresh install *every* group would. Keep
+    /// the ones with something to draw; when none of them has anything, keep
+    /// exactly one so the "history builds up as refreshes come in" note is
+    /// still said once instead of once per quota scope.
+    static func chartable(
+        _ groups: [QuotaBucketGroup],
+        accountId: String,
+        observations: [SubscriptionHistoryKey: [FillTimelinePoint]]
+    ) -> [QuotaBucketGroup] {
+        let drawable = groups.filter { group in
+            group.buckets.contains { bucket in
+                let key = SubscriptionHistoryKey(accountId: accountId, bucketId: bucket.id)
+                return (observations[key]?.count ?? 0) > 1
+            }
+        }
+        if !drawable.isEmpty { return drawable }
+        return groups.isEmpty ? [] : [groups[0]]
+    }
+}
+
 /// One drawable point on a quota history line. Segment membership travels with
 /// the point as `seriesKey` so Swift Charts never joins two sides of a reset
 /// (or of a stretch where Vibe Bar was not running) into one stroke.
@@ -21,9 +114,20 @@ private struct QuotaBandPoint: Identifiable {
     let high: Double
 }
 
-/// What the hover crosshair resolved to at one instant.
-private struct QuotaHoverReading {
-    let time: Date
+/// Everything one bucket contributes to the plot, already clipped and thinned.
+private struct QuotaBucketLines: Identifiable {
+    let id: String
+    let color: Color
+    let forecastColor: Color
+    let actual: [QuotaLinePoint]
+    let forecast: [QuotaLinePoint]
+}
+
+/// What the hover crosshair resolved to on one bucket's lines.
+private struct QuotaHoverBucketReading: Identifiable {
+    let id: String
+    let title: String
+    let color: Color
     let actual: Double?
     let pace: Double?
     let forecast: Double?
@@ -31,72 +135,104 @@ private struct QuotaHoverReading {
     var isEmpty: Bool { actual == nil && pace == nil && forecast == nil }
 }
 
+/// What the hover crosshair resolved to at one instant, across the group.
+private struct QuotaHoverReading {
+    let time: Date
+    let buckets: [QuotaHoverBucketReading]
+
+    var isEmpty: Bool { buckets.allSatisfy(\.isEmpty) }
+}
+
 /// Everything that decides the shape of the chart. Rebuilding is keyed on this
 /// rather than on the raw arrays: a quota refresh appends one point, and only
 /// then is it worth re-segmenting the series.
 private struct QuotaSeriesSignature: Equatable {
-    var bucketId: String
-    var fillCount: Int
-    var fillStart: Date?
-    var fillEnd: Date?
-    var forecastCount: Int
-    var forecastEnd: Date?
+    struct Entry: Equatable {
+        var bucketId: String
+        var fillCount: Int
+        var fillStart: Date?
+        var fillEnd: Date?
+        var forecastCount: Int
+        var forecastEnd: Date?
+    }
+
+    var entries: [Entry]
 }
 
-/// Quota history over time: what was left, what an even burn would have left,
-/// and what the forecast said would be left at reset — each drawn only where it
-/// was actually observed.
+/// Quota history over time for one group of quotas: what was left, what an even
+/// burn would have left, and what the forecast said would be left at reset —
+/// each drawn only where it was actually observed.
 ///
-/// The three lines answer three different questions and are deliberately not
-/// merged: `actual` is evidence, `pace` is the wall-clock reference, and
-/// `forecast` is the projection *as recorded at the time*, never recomputed
-/// with hindsight. Between quota windows there is simply no line, which is why
-/// the builder hands back segments instead of flat arrays.
+/// The card follows its group the way "Reset history" follows its bucket: one
+/// chart per heading, no picker. Buckets that reset on different schedules but
+/// belong to the same scope (Claude's 5 Hours and Weekly, say) overlay in one
+/// plot and are told apart by hue, because the question "how is this scope
+/// doing" is one question.
+///
+/// The lines answer different questions and are deliberately not merged:
+/// `actual` is evidence, `pace` is the wall-clock reference, and `forecast` is
+/// the projection *as recorded at the time*, never recomputed with hindsight.
+/// Between quota windows there is simply no line, which is why the builder
+/// hands back segments instead of flat arrays.
 ///
 /// Navigation is the approved thumbnail + gesture hybrid: a brush strip covers
 /// the whole domain, while drag-pan and pinch-zoom work directly on the plot.
 struct QuotaHistoryChartView: View {
     let tool: ToolType
     let accountId: String
-    let buckets: [QuotaBucket]
+    let group: QuotaBucketGroup
     let density: Theme.Density
-    /// Set when a page shows more than one of these cards and "Quota history"
-    /// alone would not say whose.
+    /// Set when a page shows more than one of these cards for *different
+    /// products* and "Quota history" alone would not say whose.
     var titleOverride: String? = nil
+    /// Print the group's name under the title. Set when the account has more
+    /// than one group, mirroring the headings in Subscription Utilization.
+    var showsGroupTitle: Bool = false
 
     @EnvironmentObject var quotaService: QuotaService
+    @Environment(\.colorScheme) private var colorScheme
 
-    @State private var selectedBucketId: String?
-    @State private var forecastPoints: [ForecastTimelinePoint] = []
-    @State private var series: QuotaHistorySeries = .empty
+    @State private var forecastByBucket: [String: [ForecastTimelinePoint]] = [:]
+    @State private var seriesByBucket: [String: QuotaHistorySeries] = [:]
     @State private var miniSegments: [[QuotaHistorySample]] = []
     @State private var window: ChartTimeWindow?
-    @State private var windowBucketId: String?
+    @State private var windowKey: String?
     @State private var initialSpan: TimeInterval = 24 * 3_600
     @State private var hoverDate: Date?
     @State private var panBase: ChartTimeWindow?
     @State private var magnifyBase: ChartTimeWindow?
 
-    /// Same green as a healthy remaining-quota bar, so "quota left" reads the
-    /// same on the chart as it does on the bar above it.
-    private static let actualColor = Color(red: 0.18, green: 0.74, blue: 0.55)
-    private static let forecastColor = Color(red: 0.20, green: 0.56, blue: 0.88)
+    /// Hue per bucket inside one group, reused from the accents the rest of the
+    /// app already spends: the healthy-quota green, the forecast blue, the
+    /// "watch" amber, AntiGravity's violet, Claude's coral. First bucket green
+    /// keeps a single-quota chart looking exactly like it did before groups.
+    private static let bucketPalette: [Color] = [
+        Color(red: 0.18, green: 0.74, blue: 0.55),
+        Color(red: 0.20, green: 0.56, blue: 0.88),
+        Color(red: 0.97, green: 0.62, blue: 0.20),
+        Color(red: 0.55, green: 0.40, blue: 0.92),
+        Color(red: 0.93, green: 0.40, blue: 0.40)
+    ]
     private static let paceColor = Color.secondary
 
     /// Marks per line inside the visible window. Beyond this the strokes stop
-    /// gaining detail and start costing frames on a zoomed-out weekly domain.
+    /// gaining detail and start costing frames on a zoomed-out weekly domain —
+    /// so the budget is shared out across however many buckets overlay.
     private static let visibleMarkLimit = 520
+    private static let minimumMarkLimit = 140
     private static let miniMarkLimit = 160
+    /// Past this many reset lines the plot reads as a picket fence rather than
+    /// as a set of boundaries, so a zoomed-out five-hour quota drops them.
+    private static let visibleResetLimit = 24
 
     var body: some View {
-        let historyBuckets = bucketsWithHistory
-        let bucket = activeBucket(in: historyBuckets)
+        let buckets = bucketsWithHistory
 
         VStack(alignment: .leading, spacing: density.cardSpacing) {
-            header(historyBuckets: historyBuckets)
+            header
 
-            if let bucket, let window, window.domainSpan > 0 {
-                chartBody(bucket: bucket, window: window)
+            if let first = buckets.first, let window, window.domainSpan > 0 {
+                chartBody(buckets: buckets, primary: first, window: window)
             } else {
                 emptyNote
             }
@@ -111,30 +247,36 @@ struct QuotaHistoryChartView: View {
                 .stroke(.separator.opacity(0.4), lineWidth: 0.5)
         )
         .task(id: forecastLoadKey) {
-            await loadForecastPoints(bucketId: bucket?.id)
+            await loadForecastPoints()
         }
-        .onChange(of: seriesSignature(for: bucket), initial: true) { _, signature in
-            rebuild(signature: signature, bucket: bucket)
+        .onChange(of: seriesSignature, initial: true) { _, _ in
+            rebuild()
         }
     }
 
     // MARK: - Header
 
-    @ViewBuilder
-    private func header(historyBuckets: [QuotaBucket]) -> some View {
-        VStack(alignment: .trailing, spacing: 4) {
-            HStack(alignment: .firstTextBaseline, spacing: 6) {
+    private var header: some View {
+        HStack(alignment: .firstTextBaseline, spacing: 6) {
+            VStack(alignment: .leading, spacing: 1) {
                 Text(titleOverride ?? "Quota history")
                     .font(.system(size: density.bucketTitleFontSize, weight: .semibold))
-                Spacer(minLength: 8)
-                if window != nil, !rangeOptions.isEmpty {
-                    pillGroup(rangeOptions) { option in
-                        applyRange(option)
-                    }
+                if showsGroupTitle, let groupTitle = group.title {
+                    // Same treatment as the group heading in Subscription
+                    // Utilization, so the two surfaces read as one section.
+                    Text(groupTitle)
+                        .font(.system(size: max(9, density.subtitleFontSize - 1), weight: .semibold))
+                        .foregroundStyle(.tertiary)
+                        .textCase(.uppercase)
+                        .tracking(0.4)
+                        .lineLimit(1)
                 }
             }
-            if historyBuckets.count > 1 {
-                bucketPills(bucketOptions(historyBuckets))
+            Spacer(minLength: 8)
+            if window != nil, !rangeOptions.isEmpty {
+                pillGroup(rangeOptions) { option in
+                    applyRange(option)
+                }
             }
         }
     }
@@ -150,20 +292,33 @@ struct QuotaHistoryChartView: View {
     // MARK: - Chart
 
     @ViewBuilder
-    private func chartBody(bucket: QuotaBucket, window: ChartTimeWindow) -> some View {
+    private func chartBody(
+        buckets: [QuotaBucket],
+        primary: QuotaBucket,
+        window: ChartTimeWindow
+    ) -> some View {
         let binding = Binding<ChartTimeWindow>(
             get: { self.window ?? window },
             set: { self.window = $0 }
         )
         let visible = window.visibleRange
-        let actualPoints = linePoints(series.actual, kind: "actual", range: visible)
-        let pacePoints = linePoints(series.pace, kind: "pace", range: visible)
-        let forecastLine = forecastLinePoints(range: visible)
-        let bandPoints = forecastBandPoints(range: visible)
-        let resets = series.resetBoundaries.filter { visible.contains($0) }
+        let isSingle = buckets.count == 1
+        let limit = max(Self.minimumMarkLimit, Self.visibleMarkLimit / max(1, buckets.count))
+        let lines = bucketLines(buckets: buckets, range: visible, limit: limit)
+        let primarySeries = seriesByBucket[primary.id] ?? .empty
+        // Only a single-bucket chart can afford the wall-clock reference and
+        // the uncertainty band: two of them overlaid is mud, and the pace
+        // reading moves into the hover tooltip instead.
+        let pacePoints = isSingle
+            ? linePoints(primarySeries.pace, kind: "pace", range: visible, limit: limit)
+            : []
+        let bandPoints = isSingle
+            ? forecastBandPoints(primarySeries.forecast, range: visible, limit: limit)
+            : []
+        let resets = resetMarks(primarySeries: primarySeries, range: visible)
 
         VStack(alignment: .leading, spacing: 6) {
-            legend(bucket: bucket)
+            legend(buckets: buckets)
 
             Chart {
                 ForEach(bandPoints) { point in
@@ -173,7 +328,7 @@ struct QuotaHistoryChartView: View {
                         yEnd: .value("High", point.high),
                         series: .value("Band", point.seriesKey)
                     )
-                    .foregroundStyle(Self.forecastColor.opacity(0.08))
+                    .foregroundStyle(forecastTint(Self.bucketPalette[0]).opacity(0.08))
                 }
                 ForEach(resets, id: \.self) { reset in
                     RuleMark(x: .value("Reset", reset))
@@ -189,23 +344,27 @@ struct QuotaHistoryChartView: View {
                     .foregroundStyle(Self.paceColor.opacity(0.85))
                     .lineStyle(StrokeStyle(lineWidth: 1.6, dash: [5, 4]))
                 }
-                ForEach(forecastLine) { point in
-                    LineMark(
-                        x: .value("Time", point.time),
-                        y: .value("Left", point.value),
-                        series: .value("Line", point.seriesKey)
-                    )
-                    .foregroundStyle(Self.forecastColor)
-                    .lineStyle(StrokeStyle(lineWidth: 1.8, lineCap: .round, dash: [2, 3.4]))
+                ForEach(lines) { line in
+                    ForEach(line.forecast) { point in
+                        LineMark(
+                            x: .value("Time", point.time),
+                            y: .value("Left", point.value),
+                            series: .value("Line", point.seriesKey)
+                        )
+                        .foregroundStyle(line.forecastColor)
+                        .lineStyle(StrokeStyle(lineWidth: 1.8, lineCap: .round, dash: [2, 3.4]))
+                    }
                 }
-                ForEach(actualPoints) { point in
-                    LineMark(
-                        x: .value("Time", point.time),
-                        y: .value("Left", point.value),
-                        series: .value("Line", point.seriesKey)
-                    )
-                    .foregroundStyle(Self.actualColor)
-                    .lineStyle(StrokeStyle(lineWidth: 2, lineCap: .round, lineJoin: .round))
+                ForEach(lines) { line in
+                    ForEach(line.actual) { point in
+                        LineMark(
+                            x: .value("Time", point.time),
+                            y: .value("Left", point.value),
+                            series: .value("Line", point.seriesKey)
+                        )
+                        .foregroundStyle(line.color)
+                        .lineStyle(StrokeStyle(lineWidth: 2, lineCap: .round, lineJoin: .round))
+                    }
                 }
             }
             .chartXScale(domain: visible)
@@ -229,20 +388,25 @@ struct QuotaHistoryChartView: View {
                 }
             }
             .chartOverlay { proxy in
-                interactionOverlay(proxy: proxy, bucket: bucket, window: binding)
+                interactionOverlay(
+                    proxy: proxy,
+                    buckets: buckets,
+                    primary: primary,
+                    window: binding
+                )
             }
             .frame(height: density.quotaHistoryChartHeight)
 
             ChartBrushNavigator(
                 window: binding,
-                accent: Self.actualColor,
+                accent: Self.bucketPalette[0],
                 height: density.chartBrushHeight,
                 accessibilityDescription: "Quota history range navigator"
             ) { geometry in
                 miniPath(in: geometry)
             }
 
-            Text(scopeNote(bucket: bucket, window: window))
+            Text(scopeNote(buckets: buckets, window: window))
                 .font(.system(size: max(8, density.resetCountdownFontSize - 1)))
                 .foregroundStyle(.tertiary)
                 .lineLimit(1)
@@ -271,9 +435,21 @@ struct QuotaHistoryChartView: View {
             }
         }
         .stroke(
-            Self.actualColor.opacity(0.75),
+            Self.bucketPalette[0].opacity(0.75),
             style: StrokeStyle(lineWidth: 1, lineCap: .round, lineJoin: .round)
         )
+    }
+
+    /// Reset lines for the plot. In a multi-bucket chart only the
+    /// shortest-window quota's boundaries are drawn — its sawtooth is the one a
+    /// reader is trying to line up, and stacking a second schedule on top of it
+    /// just stripes the plot.
+    private func resetMarks(
+        primarySeries: QuotaHistorySeries,
+        range: ClosedRange<Date>
+    ) -> [Date] {
+        let visible = primarySeries.resetBoundaries.filter { range.contains($0) }
+        return visible.count > Self.visibleResetLimit ? [] : visible
     }
 
     // MARK: - Legend
@@ -284,51 +460,135 @@ struct QuotaHistoryChartView: View {
         case dotted
     }
 
+    /// One legend column: a stroke swatch, what it is, where it stands now, and
+    /// an optional second reading underneath.
+    private struct LegendBlock: Identifiable {
+        let id: String
+        let stroke: LegendStroke
+        let color: Color
+        let label: String
+        let value: String
+        let detail: String?
+    }
+
+    /// Legend + current readings.
+    ///
+    /// Laid out as metric columns rather than a run of inline chips so the
+    /// swatch row, the percentage row, and the at-reset row each sit on one
+    /// shared baseline no matter how long a bucket's name is — the same fix the
+    /// cost card's footer uses. The detail row is laid out for every column
+    /// (blank when a bucket has no projection) so one forecast cannot push its
+    /// own column up out of line.
     @ViewBuilder
-    private func legend(bucket: QuotaBucket) -> some View {
-        let items: [(LegendStroke, Color, String, String?)] = [
-            (.solid, Self.actualColor, "Quota left", currentRemainingLabel(bucket: bucket)),
-            (.dashed, Self.paceColor, "Time-only pace", currentPaceLabel(bucket: bucket)),
-            (.dotted, Self.forecastColor, "Forecast at reset", currentForecastLabel(bucket: bucket))
-        ]
+    private func legend(buckets: [QuotaBucket]) -> some View {
+        let blocks = legendBlocks(buckets: buckets)
+        let showsDetail = blocks.contains { $0.detail != nil }
+        let hint = forecastHint(blocks: blocks)
         ViewThatFits(in: .horizontal) {
-            HStack(spacing: 12) {
-                ForEach(Array(items.enumerated()), id: \.offset) { _, item in
-                    legendItem(stroke: item.0, color: item.1, label: item.2, value: item.3)
-                }
-                Spacer(minLength: 0)
+            HStack(alignment: .top, spacing: 14) {
+                legendRow(blocks, spacing: 14, showsDetail: showsDetail)
+                Spacer(minLength: 14)
+                hint
+            }
+            HStack(alignment: .top, spacing: 8) {
+                legendRow(blocks, spacing: 8, showsDetail: showsDetail)
+                Spacer(minLength: 8)
+                hint
+            }
+            VStack(alignment: .leading, spacing: 2) {
+                legendRow(blocks, spacing: 8, showsDetail: showsDetail)
+                hint.frame(maxWidth: .infinity, alignment: .leading)
             }
             VStack(alignment: .leading, spacing: 3) {
-                ForEach(Array(items.enumerated()), id: \.offset) { _, item in
-                    legendItem(stroke: item.0, color: item.1, label: item.2, value: item.3)
+                ForEach(blocks) { block in
+                    legendBlock(block, showsDetail: showsDetail)
                 }
+                hint.frame(maxWidth: .infinity, alignment: .leading)
             }
         }
     }
 
-    private func legendItem(
-        stroke: LegendStroke,
-        color: Color,
-        label: String,
-        value: String?
+    private func legendRow(
+        _ blocks: [LegendBlock],
+        spacing: CGFloat,
+        showsDetail: Bool
     ) -> some View {
-        HStack(spacing: 4) {
-            legendSwatch(stroke: stroke, color: color)
-            Text(label)
-                .font(.system(size: max(9, density.subtitleFontSize - 1)))
-                .foregroundStyle(.secondary)
-            if let value {
-                Text(value)
-                    .font(
-                        .system(
-                            size: max(9, density.subtitleFontSize - 1),
-                            weight: .semibold,
-                            design: .rounded
-                        ).monospacedDigit()
-                    )
-                    .foregroundStyle(color)
+        HStack(alignment: .top, spacing: spacing) {
+            ForEach(blocks) { block in
+                legendBlock(block, showsDetail: showsDetail)
             }
         }
+    }
+
+    private func legendBlocks(buckets: [QuotaBucket]) -> [LegendBlock] {
+        var blocks: [LegendBlock] = buckets.enumerated().map { index, bucket in
+            LegendBlock(
+                id: "bucket-\(bucket.id)",
+                stroke: .solid,
+                color: color(at: index),
+                label: bucket.title,
+                value: currentRemainingLabel(bucket: bucket),
+                detail: currentForecastLabel(bucket: bucket).map { "\($0) at reset" }
+            )
+        }
+        // The wall-clock reference only gets a line (and therefore a legend
+        // entry) when it is the sole thing sharing the plot with one quota.
+        if buckets.count == 1, let pace = currentPaceLabel(bucket: buckets[0]) {
+            blocks.append(
+                LegendBlock(
+                    id: "pace",
+                    stroke: .dashed,
+                    color: Self.paceColor,
+                    label: "Time-only pace",
+                    value: pace,
+                    detail: nil
+                )
+            )
+        }
+        return blocks
+    }
+
+    @ViewBuilder
+    private func forecastHint(blocks: [LegendBlock]) -> some View {
+        if blocks.contains(where: { $0.detail != nil }) {
+            HStack(spacing: 4) {
+                legendSwatch(stroke: .dotted, color: .secondary)
+                Text("forecast")
+                    .font(.system(size: max(8, density.resetCountdownFontSize - 1)))
+                    .foregroundStyle(.tertiary)
+            }
+            .lineLimit(1)
+            .fixedSize(horizontal: true, vertical: false)
+        }
+    }
+
+    private func legendBlock(_ block: LegendBlock, showsDetail: Bool) -> some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack(spacing: 4) {
+                legendSwatch(stroke: block.stroke, color: block.color)
+                Text(block.label.uppercased())
+                    .font(.system(size: max(8, density.subtitleFontSize - 2), weight: .semibold))
+                    .foregroundStyle(.tertiary)
+                    .tracking(0.4)
+            }
+            Text(block.value)
+                .font(
+                    .system(
+                        size: density.bucketTitleFontSize,
+                        weight: .semibold,
+                        design: .rounded
+                    ).monospacedDigit()
+                )
+                .foregroundStyle(block.color)
+            if showsDetail {
+                Text(block.detail ?? " ")
+                    .font(.system(size: max(8, density.resetCountdownFontSize - 2)))
+                    .foregroundStyle(.tertiary)
+                    .opacity(block.detail == nil ? 0 : 1)
+                    .accessibilityHidden(block.detail == nil)
+            }
+        }
+        .lineLimit(1)
         .fixedSize(horizontal: true, vertical: false)
     }
 
@@ -351,7 +611,8 @@ struct QuotaHistoryChartView: View {
 
     private func interactionOverlay(
         proxy: ChartProxy,
-        bucket: QuotaBucket,
+        buckets: [QuotaBucket],
+        primary: QuotaBucket,
         window: Binding<ChartTimeWindow>
     ) -> some View {
         GeometryReader { geometry in
@@ -386,7 +647,7 @@ struct QuotaHistoryChartView: View {
                     }
 
                 if let hoverDate,
-                   let reading = hoverReading(at: hoverDate, bucket: bucket),
+                   let reading = hoverReading(at: hoverDate, buckets: buckets, primary: primary),
                    let x = proxy.position(forX: reading.time),
                    let plot {
                     Rectangle()
@@ -394,7 +655,7 @@ struct QuotaHistoryChartView: View {
                         .frame(width: 1, height: plot.height)
                         .offset(x: plotMinX + x, y: plot.minY)
                         .allowsHitTesting(false)
-                    tooltip(reading)
+                    tooltip(reading, showsBucketTitles: buckets.count > 1)
                         .offset(x: tooltipX(plotMinX: plotMinX, x: x, width: geometry.size.width))
                         .allowsHitTesting(false)
                 }
@@ -433,27 +694,43 @@ struct QuotaHistoryChartView: View {
     }
 
     private func tooltipX(plotMinX: CGFloat, x: CGFloat, width: CGFloat) -> CGFloat {
-        let tooltipWidth: CGFloat = 168
+        let tooltipWidth = Self.tooltipWidth
         return min(max(plotMinX + x - tooltipWidth / 2, 0), max(0, width - tooltipWidth))
     }
 
-    private func tooltip(_ reading: QuotaHoverReading) -> some View {
+    private static let tooltipWidth: CGFloat = 178
+
+    private func tooltip(_ reading: QuotaHoverReading, showsBucketTitles: Bool) -> some View {
         VStack(alignment: .leading, spacing: 3) {
             Text(Self.tooltipFormatter.string(from: reading.time))
                 .font(.system(size: 10, weight: .semibold))
-            if reading.isEmpty {
-                Text("No active window")
-                    .font(.system(size: 9))
-                    .foregroundStyle(.white.opacity(0.7))
-            } else {
-                if let actual = reading.actual {
-                    tooltipRow("Quota left", percent(actual), color: Self.actualColor)
+            ForEach(reading.buckets) { bucket in
+                if showsBucketTitles {
+                    HStack(spacing: 4) {
+                        Circle()
+                            .fill(bucket.color)
+                            .frame(width: 5, height: 5)
+                        Text(bucket.title)
+                            .font(.system(size: 9, weight: .semibold))
+                            .foregroundStyle(.white.opacity(0.85))
+                        Spacer(minLength: 0)
+                    }
+                    .padding(.top, 1)
                 }
-                if let pace = reading.pace {
-                    tooltipRow("Pace", percent(pace), color: .white.opacity(0.8))
-                }
-                if let forecast = reading.forecast {
-                    tooltipRow("At reset", percent(forecast), color: Self.forecastColor)
+                if bucket.isEmpty {
+                    Text("No active window")
+                        .font(.system(size: 9))
+                        .foregroundStyle(.white.opacity(0.7))
+                } else {
+                    if let actual = bucket.actual {
+                        tooltipRow("Quota left", percent(actual), color: bucket.color)
+                    }
+                    if let pace = bucket.pace {
+                        tooltipRow("Pace", percent(pace), color: .white.opacity(0.8))
+                    }
+                    if let forecast = bucket.forecast {
+                        tooltipRow("At reset", percent(forecast), color: bucket.color.opacity(0.75))
+                    }
                 }
             }
         }
@@ -461,11 +738,11 @@ struct QuotaHistoryChartView: View {
         .padding(.vertical, 6)
         .background(RoundedRectangle(cornerRadius: 6).fill(Color.black.opacity(0.87)))
         .foregroundStyle(.white)
-        .frame(width: 168, alignment: .leading)
+        .frame(width: Self.tooltipWidth, alignment: .leading)
     }
 
     private func tooltipRow(_ label: String, _ value: String, color: Color) -> some View {
-        HStack(spacing: 6) {
+        HStack(alignment: .firstTextBaseline, spacing: 6) {
             Text(label)
                 .font(.system(size: 9))
                 .foregroundStyle(.white.opacity(0.75))
@@ -476,22 +753,41 @@ struct QuotaHistoryChartView: View {
         }
     }
 
-    /// Nearest reading on each line, or nothing at all when the cursor sits in
-    /// a stretch with no coverage — a gap is information, not a rounding error,
-    /// so it is never bridged to the closest sample on either side.
-    private func hoverReading(at date: Date, bucket: QuotaBucket) -> QuotaHoverReading? {
+    /// Nearest reading on each line, per bucket, or nothing at all for a bucket
+    /// whose coverage does not reach the cursor — a gap is information, not a
+    /// rounding error, so it is never bridged to the closest sample on either
+    /// side. The time label follows the shortest-window quota, which is the one
+    /// sampled most densely.
+    private func hoverReading(
+        at date: Date,
+        buckets: [QuotaBucket],
+        primary: QuotaBucket
+    ) -> QuotaHoverReading? {
         guard let window else { return nil }
-        let slot = UsageTimelineSlotPolicy.slotSeconds(windowSeconds: bucket.rawWindowSeconds)
+        let slot = UsageTimelineSlotPolicy.slotSeconds(windowSeconds: primary.rawWindowSeconds)
         let tolerance = max(slot * 2, window.visibleSpan / 80)
-        let actual = nearestSample(in: series.actual, to: date, tolerance: tolerance)
-        let pace = nearestSample(in: series.pace, to: date, tolerance: tolerance)
-        let forecast = nearestForecast(to: date, tolerance: tolerance)
-        return QuotaHoverReading(
-            time: actual?.time ?? forecast?.time ?? date,
-            actual: actual?.remainingPercent,
-            pace: pace?.remainingPercent,
-            forecast: forecast?.remainingPercent
-        )
+        var readings: [QuotaHoverBucketReading] = []
+        var anchor: Date?
+        for (index, bucket) in buckets.enumerated() {
+            let series = seriesByBucket[bucket.id] ?? .empty
+            let actual = nearestSample(in: series.actual, to: date, tolerance: tolerance)
+            let pace = nearestSample(in: series.pace, to: date, tolerance: tolerance)
+            let forecast = nearestForecast(in: series.forecast, to: date, tolerance: tolerance)
+            if bucket.id == primary.id {
+                anchor = actual?.time ?? forecast?.time
+            }
+            readings.append(
+                QuotaHoverBucketReading(
+                    id: bucket.id,
+                    title: bucket.title,
+                    color: color(at: index),
+                    actual: actual?.remainingPercent,
+                    pace: pace?.remainingPercent,
+                    forecast: forecast?.remainingPercent
+                )
+            )
+        }
+        return QuotaHoverReading(time: anchor ?? date, buckets: readings)
     }
 
     private func nearestSample(
@@ -514,12 +810,13 @@ struct QuotaHistoryChartView: View {
     }
 
     private func nearestForecast(
+        in segments: [[QuotaHistoryForecastSample]],
         to date: Date,
         tolerance: TimeInterval
     ) -> QuotaHistoryForecastSample? {
         var best: QuotaHistoryForecastSample?
         var bestDistance = tolerance
-        for segment in series.forecast {
+        for segment in segments {
             for sample in segment {
                 let distance = abs(sample.time.timeIntervalSince(date))
                 if distance <= bestDistance {
@@ -567,18 +864,6 @@ struct QuotaHistoryChartView: View {
         return options
     }
 
-    private func bucketOptions(_ historyBuckets: [QuotaBucket]) -> [PillOption] {
-        let active = activeBucket(in: historyBuckets)?.id
-        return historyBuckets.map { bucket in
-            PillOption(
-                id: bucket.id,
-                label: bucketLabel(bucket),
-                span: nil,
-                isSelected: bucket.id == active
-            )
-        }
-    }
-
     private func applyRange(_ option: PillOption) {
         guard var current = window else { return }
         if let span = option.span {
@@ -588,48 +873,6 @@ struct QuotaHistoryChartView: View {
         }
         window = current
         hoverDate = nil
-    }
-
-    /// Claude can expose seven independently resettable quotas, which is more
-    /// pills than the narrow quota column fits on one line. Prefer one row,
-    /// then let `ViewThatFits` fall back to two or three — chunking keeps every
-    /// label fully legible instead of scaling them into illegibility.
-    @ViewBuilder
-    private func bucketPills(_ options: [PillOption]) -> some View {
-        let select: (PillOption) -> Void = { option in
-            guard option.id != selectedBucketId else { return }
-            selectedBucketId = option.id
-            // The forecast snapshots belong to the bucket that was showing;
-            // drop them so the reload cannot flash another quota's projection
-            // over the new line.
-            forecastPoints = []
-            hoverDate = nil
-        }
-        ViewThatFits(in: .horizontal) {
-            pillRows(options, rows: 1, action: select)
-            pillRows(options, rows: 2, action: select)
-            pillRows(options, rows: 3, action: select)
-        }
-    }
-
-    private func pillRows(
-        _ options: [PillOption],
-        rows: Int,
-        action: @escaping (PillOption) -> Void
-    ) -> some View {
-        VStack(alignment: .trailing, spacing: 2) {
-            ForEach(Array(chunked(options, rows: rows).enumerated()), id: \.offset) { _, chunk in
-                pillGroup(chunk, action: action)
-            }
-        }
-    }
-
-    private func chunked(_ options: [PillOption], rows: Int) -> [[PillOption]] {
-        guard rows > 1, options.count > rows else { return [options] }
-        let perRow = Int(ceil(Double(options.count) / Double(rows)))
-        return stride(from: 0, to: options.count, by: perRow).map {
-            Array(options[$0..<min($0 + perRow, options.count)])
-        }
     }
 
     private func pillGroup(
@@ -675,9 +918,11 @@ struct QuotaHistoryChartView: View {
     // MARK: - Data selection
 
     /// A single observation draws nothing — a line needs two points — so a
-    /// bucket only becomes selectable once it can actually be plotted.
+    /// bucket only joins the plot once it can actually be drawn. Shortest
+    /// window first: that quota anchors the reset lines, the brush mini, and
+    /// the zoom floor.
     private var bucketsWithHistory: [QuotaBucket] {
-        buckets
+        group.buckets
             .filter { fillPoints(bucketId: $0.id).count > 1 }
             .sorted {
                 let left = $0.rawWindowSeconds ?? Int.max
@@ -686,12 +931,15 @@ struct QuotaHistoryChartView: View {
             }
     }
 
-    private func activeBucket(in historyBuckets: [QuotaBucket]) -> QuotaBucket? {
-        if let selectedBucketId,
-           let match = historyBuckets.first(where: { $0.id == selectedBucketId }) {
-            return match
-        }
-        return historyBuckets.first
+    private func color(at index: Int) -> Color {
+        Self.bucketPalette[index % Self.bucketPalette.count]
+    }
+
+    /// Forecast strokes share their bucket's hue, lifted toward white on dark
+    /// backgrounds the same way `ForecastQuotaBar` lifts its forecast marker —
+    /// a 1.8pt dotted line loses more contrast than a solid one.
+    private func forecastTint(_ base: Color) -> Color {
+        colorScheme == .dark ? base.mix(with: .white, by: 0.16) : base
     }
 
     private func fillPoints(bucketId: String) -> [FillTimelinePoint] {
@@ -699,103 +947,96 @@ struct QuotaHistoryChartView: View {
         return quotaService.observationsByAccountBucket[key] ?? []
     }
 
-    /// Account, bucket, and the shape of the bucket's observed fill lane.
+    /// Account, group, and the shape of every bucket's observed fill lane.
     ///
     /// The forecast snapshots live in an actor-backed store this view cannot
     /// observe, so keying only on account and bucket would freeze the forecast
-    /// line at whatever was on disk when the page opened. Every refresh that
+    /// lines at whatever was on disk when the page opened. Every refresh that
     /// records a projection also appends a fill point to
     /// `QuotaService.observationsByAccountBucket`, which *is* `@Published` —
-    /// so the fill lane's count and newest timestamp are the cheapest honest
-    /// signal that there is a new projection to read.
+    /// so each lane's count and newest timestamp are the cheapest honest signal
+    /// that there is a new projection to read.
     private var forecastLoadKey: String {
-        let bucketId = activeBucket(in: bucketsWithHistory)?.id ?? ""
-        guard !bucketId.isEmpty else { return "\(accountId)||0|0" }
-        let fills = fillPoints(bucketId: bucketId)
-        let newest = fills.last?.sampledAt.timeIntervalSince1970 ?? 0
-        return "\(accountId)|\(bucketId)|\(fills.count)|\(newest)"
-    }
-
-    private func loadForecastPoints(bucketId: String?) async {
-        guard let bucketId else {
-            forecastPoints = []
-            return
+        let parts = bucketsWithHistory.map { bucket -> String in
+            let fills = fillPoints(bucketId: bucket.id)
+            let newest = fills.last?.sampledAt.timeIntervalSince1970 ?? 0
+            return "\(bucket.id):\(fills.count):\(newest)"
         }
-        let points = await UsageForecastTimelineStore.shared.points(
-            accountId: accountId,
-            bucketId: bucketId
-        )
-        forecastPoints = points
+        return "\(accountId)|\(group.id)|\(parts.joined(separator: ","))"
     }
 
-    private func seriesSignature(for bucket: QuotaBucket?) -> QuotaSeriesSignature {
-        guard let bucket else {
-            return QuotaSeriesSignature(
-                bucketId: "",
-                fillCount: 0,
-                fillStart: nil,
-                fillEnd: nil,
-                forecastCount: 0,
-                forecastEnd: nil
+    private func loadForecastPoints() async {
+        var result: [String: [ForecastTimelinePoint]] = [:]
+        for bucket in bucketsWithHistory {
+            result[bucket.id] = await UsageForecastTimelineStore.shared.points(
+                accountId: accountId,
+                bucketId: bucket.id
             )
         }
+        forecastByBucket = result
+    }
+
+    private var seriesSignature: QuotaSeriesSignature {
         // Both arrays arrive time-sorted (QuotaService sorts observations,
         // the forecast store sorts by slot), so the bounds are O(1).
-        let fills = fillPoints(bucketId: bucket.id)
-        return QuotaSeriesSignature(
-            bucketId: bucket.id,
-            fillCount: fills.count,
-            fillStart: fills.first?.sampledAt,
-            fillEnd: fills.last?.sampledAt,
-            forecastCount: forecastPoints.count,
-            forecastEnd: forecastPoints.last?.sampledAt
+        QuotaSeriesSignature(
+            entries: bucketsWithHistory.map { bucket in
+                let fills = fillPoints(bucketId: bucket.id)
+                let forecasts = forecastByBucket[bucket.id] ?? []
+                return QuotaSeriesSignature.Entry(
+                    bucketId: bucket.id,
+                    fillCount: fills.count,
+                    fillStart: fills.first?.sampledAt,
+                    fillEnd: fills.last?.sampledAt,
+                    forecastCount: forecasts.count,
+                    forecastEnd: forecasts.last?.sampledAt
+                )
+            }
         )
     }
 
-    /// Re-segment the series and re-anchor the visible window. Runs on data
-    /// changes only — pans and zooms reuse the series already built.
-    private func rebuild(signature: QuotaSeriesSignature, bucket: QuotaBucket?) {
-        guard let bucket, signature.fillCount > 0 else {
-            series = .empty
+    /// Re-segment every bucket's series and re-anchor the visible window. Runs
+    /// on data changes only — pans and zooms reuse the series already built.
+    private func rebuild() {
+        let buckets = bucketsWithHistory
+        guard let primary = buckets.first, let domain = domainRange(buckets: buckets) else {
+            seriesByBucket = [:]
             miniSegments = []
             window = nil
-            windowBucketId = nil
-            return
-        }
-        let fills = fillPoints(bucketId: bucket.id)
-        guard let domain = domainRange(fills: fills) else {
-            series = .empty
-            miniSegments = []
-            window = nil
-            windowBucketId = nil
+            windowKey = nil
             return
         }
 
-        series = QuotaHistorySeriesBuilder.build(
-            fillPoints: fills,
-            forecastPoints: forecastPoints,
-            range: domain
-        )
-        miniSegments = series.actual.map {
+        var built: [String: QuotaHistorySeries] = [:]
+        for bucket in buckets {
+            built[bucket.id] = QuotaHistorySeriesBuilder.build(
+                fillPoints: fillPoints(bucketId: bucket.id),
+                forecastPoints: forecastByBucket[bucket.id] ?? [],
+                range: domain
+            )
+        }
+        seriesByBucket = built
+        miniSegments = (built[primary.id]?.actual ?? []).map {
             ChartSeriesThinning.strided($0, limit: Self.miniMarkLimit)
         }
 
-        let minimumSpan = minimumSpan(for: bucket)
-        initialSpan = initialSpan(for: bucket)
+        let minimumSpan = minimumSpan(for: primary)
+        initialSpan = initialSpan(for: primary)
 
-        // A different quota gets a fresh window: the two buckets are sampled at
+        // A different set of quotas gets a fresh window: buckets are sampled at
         // the same instants, so their domains can match to the second while the
         // sensible zoom floor and opening span are completely different.
-        let sameBucket = windowBucketId == bucket.id
-        windowBucketId = bucket.id
+        let key = buckets.map(\.id).joined(separator: ",")
+        let sameQuotas = windowKey == key
+        windowKey = key
 
-        if sameBucket,
+        if sameQuotas,
            let existing = window,
            existing.domainStart == domain.lowerBound,
            existing.domainEnd == domain.upperBound {
             return
         }
-        if sameBucket, let existing = window {
+        if sameQuotas, let existing = window {
             // Domain grew (a refresh landed) — keep the user where they were,
             // unless they were pinned to the newest edge, which should follow.
             let followsEnd = existing.isAtDomainEnd
@@ -818,17 +1059,24 @@ struct QuotaHistoryChartView: View {
         )
     }
 
-    /// Full extent of the stored evidence, floored at six hours so a
-    /// freshly-installed app does not open on a two-sample domain that no
-    /// gesture can navigate.
-    private func domainRange(fills: [FillTimelinePoint]) -> ClosedRange<Date>? {
-        var low = fills.first?.sampledAt
-        var high = fills.last?.sampledAt
-        if let first = forecastPoints.first?.sampledAt {
-            low = low.map { min($0, first) } ?? first
-        }
-        if let last = forecastPoints.last?.sampledAt {
-            high = high.map { max($0, last) } ?? last
+    /// Full extent of the stored evidence across the group, floored at six
+    /// hours so a freshly-installed app does not open on a two-sample domain
+    /// that no gesture can navigate. One shared domain, because the overlaid
+    /// lines have to be readable against the same x axis.
+    private func domainRange(buckets: [QuotaBucket]) -> ClosedRange<Date>? {
+        var low: Date?
+        var high: Date?
+        for bucket in buckets {
+            let fills = fillPoints(bucketId: bucket.id)
+            let forecasts = forecastByBucket[bucket.id] ?? []
+            for candidate in [fills.first?.sampledAt, forecasts.first?.sampledAt] {
+                guard let candidate else { continue }
+                low = low.map { min($0, candidate) } ?? candidate
+            }
+            for candidate in [fills.last?.sampledAt, forecasts.last?.sampledAt] {
+                guard let candidate else { continue }
+                high = high.map { max($0, candidate) } ?? candidate
+            }
         }
         guard let low, let high, high >= low else { return nil }
         let floorSpan: TimeInterval = 6 * 3_600
@@ -840,6 +1088,8 @@ struct QuotaHistoryChartView: View {
 
     /// Zoom floor. A five-hour quota is legible at one hour; a weekly one has
     /// hourly slots at best, so half a day is as deep as its evidence goes.
+    /// Taken from the shortest window in the group — it is the one that still
+    /// has something to say at the deepest zoom.
     private func minimumSpan(for bucket: QuotaBucket) -> TimeInterval {
         guard let windowSeconds = bucket.rawWindowSeconds, windowSeconds > 0 else {
             return 6 * 3_600
@@ -856,16 +1106,45 @@ struct QuotaHistoryChartView: View {
 
     // MARK: - Mark shaping
 
+    private func bucketLines(
+        buckets: [QuotaBucket],
+        range: ClosedRange<Date>,
+        limit: Int
+    ) -> [QuotaBucketLines] {
+        buckets.enumerated().map { index, bucket in
+            let series = seriesByBucket[bucket.id] ?? .empty
+            let hue = color(at: index)
+            return QuotaBucketLines(
+                id: bucket.id,
+                color: hue,
+                forecastColor: forecastTint(hue),
+                actual: linePoints(
+                    series.actual,
+                    kind: "actual-\(index)",
+                    range: range,
+                    limit: limit
+                ),
+                forecast: forecastLinePoints(
+                    series.forecast,
+                    kind: "forecast-\(index)",
+                    range: range,
+                    limit: limit
+                )
+            )
+        }
+    }
+
     private func linePoints(
         _ segments: [[QuotaHistorySample]],
         kind: String,
-        range: ClosedRange<Date>
+        range: ClosedRange<Date>,
+        limit: Int
     ) -> [QuotaLinePoint] {
         var result: [QuotaLinePoint] = []
         for (index, segment) in segments.enumerated() {
             let clipped = clip(segment, time: { $0.time }, to: range)
             guard clipped.count > 0 else { continue }
-            let thinned = ChartSeriesThinning.strided(clipped, limit: Self.visibleMarkLimit)
+            let thinned = ChartSeriesThinning.strided(clipped, limit: limit)
             let key = "\(kind)-\(index)"
             for (offset, sample) in thinned.enumerated() {
                 result.append(
@@ -881,13 +1160,18 @@ struct QuotaHistoryChartView: View {
         return result
     }
 
-    private func forecastLinePoints(range: ClosedRange<Date>) -> [QuotaLinePoint] {
+    private func forecastLinePoints(
+        _ segments: [[QuotaHistoryForecastSample]],
+        kind: String,
+        range: ClosedRange<Date>,
+        limit: Int
+    ) -> [QuotaLinePoint] {
         var result: [QuotaLinePoint] = []
-        for (index, segment) in series.forecast.enumerated() {
+        for (index, segment) in segments.enumerated() {
             let clipped = clip(segment, time: { $0.time }, to: range)
             guard clipped.count > 0 else { continue }
-            let thinned = ChartSeriesThinning.strided(clipped, limit: Self.visibleMarkLimit)
-            let key = "forecast-\(index)"
+            let thinned = ChartSeriesThinning.strided(clipped, limit: limit)
+            let key = "\(kind)-\(index)"
             for (offset, sample) in thinned.enumerated() {
                 result.append(
                     QuotaLinePoint(
@@ -902,12 +1186,16 @@ struct QuotaHistoryChartView: View {
         return result
     }
 
-    private func forecastBandPoints(range: ClosedRange<Date>) -> [QuotaBandPoint] {
+    private func forecastBandPoints(
+        _ segments: [[QuotaHistoryForecastSample]],
+        range: ClosedRange<Date>,
+        limit: Int
+    ) -> [QuotaBandPoint] {
         var result: [QuotaBandPoint] = []
-        for (index, segment) in series.forecast.enumerated() {
+        for (index, segment) in segments.enumerated() {
             let clipped = clip(segment, time: { $0.time }, to: range)
             guard clipped.count > 1 else { continue }
-            let thinned = ChartSeriesThinning.strided(clipped, limit: Self.visibleMarkLimit)
+            let thinned = ChartSeriesThinning.strided(clipped, limit: limit)
             let key = "band-\(index)"
             for (offset, sample) in thinned.enumerated() {
                 result.append(
@@ -968,6 +1256,7 @@ struct QuotaHistoryChartView: View {
     /// by more than a couple of slots: a forecast that stopped being recordable
     /// last week is history, not a current reading.
     private func currentForecastLabel(bucket: QuotaBucket) -> String? {
+        let series = seriesByBucket[bucket.id] ?? .empty
         guard let last = series.forecast.last?.last else { return nil }
         if let newestActual = series.actual.last?.last?.time {
             let slot = UsageTimelineSlotPolicy.slotSeconds(windowSeconds: bucket.rawWindowSeconds)
@@ -980,23 +1269,12 @@ struct QuotaHistoryChartView: View {
         "\(Int(value.rounded()))%"
     }
 
-    /// Pill label. Claude titles six different weekly quotas "Weekly" and only
-    /// the group name tells them apart, so the group wins when it exists —
-    /// matching the section headings in Subscription Utilization.
-    private func bucketLabel(_ bucket: QuotaBucket) -> String {
-        if let group = bucket.groupTitle?.trimmingCharacters(in: .whitespacesAndNewlines),
-           !group.isEmpty {
-            return group
-        }
-        return bucket.title
-    }
-
-    private func scopeNote(bucket: QuotaBucket, window: ChartTimeWindow) -> String {
+    private func scopeNote(buckets: [QuotaBucket], window: ChartTimeWindow) -> String {
         let span = Self.spanLabel(window.visibleSpan)
         let total = Self.spanLabel(window.domainSpan)
-        let scope = bucket.groupTitle?.isEmpty == false
-            ? "\(bucketLabel(bucket)) · \(bucket.title)"
-            : bucket.title
+        let shown = buckets.prefix(3).map(\.title).joined(separator: " + ")
+        let names = buckets.count > 3 ? "\(shown) +\(buckets.count - 3)" : shown
+        let scope = group.title.map { "\($0) · \(names)" } ?? names
         return "\(scope) · showing \(span) of \(total) recorded"
     }
 

--- a/Sources/VibeBarApp/Views/SubscriptionUtilizationView.swift
+++ b/Sources/VibeBarApp/Views/SubscriptionUtilizationView.swift
@@ -679,15 +679,10 @@ struct SubscriptionUtilizationView: View {
         return itemTool.toolName
     }
 
+    /// Shared with the quota-history cards below this one, so a heading printed
+    /// here and a history chart down there always describe the same group.
     private func quotaGroupTitle(for itemTool: ToolType, bucket: QuotaBucket) -> String? {
-        if let title = bucket.groupTitle?.trimmingCharacters(in: .whitespacesAndNewlines),
-           !title.isEmpty {
-            return title
-        }
-        if tool == .gemini, itemTool == .gemini {
-            return "Gemini Chat"
-        }
-        return nil
+        QuotaBucketGrouping.title(pageTool: tool, itemTool: itemTool, bucket: bucket)
     }
 
     private func linkedProviderSection(tool linkedTool: ToolType, title: String) -> some View {

--- a/Sources/VibeBarCore/Models/CostChartGranularity.swift
+++ b/Sources/VibeBarCore/Models/CostChartGranularity.swift
@@ -57,12 +57,15 @@ public enum CostChartGranularity: String, CaseIterable, Sendable, Identifiable {
     /// bars; weekly only appears once there are enough weeks to compare, and
     /// monthly once there are at least two full months. Daily is always offered
     /// so the control never collapses to nothing.
+    ///
+    /// Weekly waits for four whole weeks rather than three: at three weeks the
+    /// chart draws three or four slabs, which reads as a bar chart of nothing.
     public static func allowed(for visibleSpan: TimeInterval) -> [CostChartGranularity] {
         let days = max(0, visibleSpan) / dayInterval
         var options: [CostChartGranularity] = []
         if days <= 7 { options.append(.hour) }
         options.append(.day)
-        if days >= 21 { options.append(.week) }
+        if days >= 28 { options.append(.week) }
         if days >= 60 { options.append(.month) }
         return options
     }
@@ -72,6 +75,38 @@ public enum CostChartGranularity: String, CaseIterable, Sendable, Identifiable {
         for visibleSpan: TimeInterval
     ) -> Bool {
         allowed(for: visibleSpan).contains(granularity)
+    }
+
+    /// The fewest bars a bucket width has to be able to draw before it stops
+    /// being a series and becomes a couple of slabs.
+    public static let minimumManualBuckets = 4
+
+    /// Whether `granularity` still fills the visible span with enough bars to
+    /// read as a shape.
+    public static func drawsEnoughBuckets(
+        _ granularity: CostChartGranularity,
+        for visibleSpan: TimeInterval,
+        minimum: Int = minimumManualBuckets
+    ) -> Bool {
+        guard minimum > 0 else { return true }
+        let buckets = max(0, visibleSpan) / granularity.approximateBucketSeconds
+        return buckets >= Double(minimum)
+    }
+
+    /// Whether a granularity the user picked by hand should survive a pan or a
+    /// zoom: it has to still be offered at this span *and* still draw enough
+    /// bars to be worth holding on to.
+    ///
+    /// `.day` is exempt from the bar floor. It is the one option the control
+    /// always offers, and Auto resolves to it across the same middle spans, so
+    /// dropping the user's pick there would trade a label for nothing.
+    public static func survivesManualSelection(
+        _ granularity: CostChartGranularity,
+        for visibleSpan: TimeInterval
+    ) -> Bool {
+        guard isAllowed(granularity, for: visibleSpan) else { return false }
+        guard granularity != .day else { return true }
+        return drawsEnoughBuckets(granularity, for: visibleSpan)
     }
 }
 

--- a/Tests/VibeBarCoreTests/CostChartGranularityTests.swift
+++ b/Tests/VibeBarCoreTests/CostChartGranularityTests.swift
@@ -59,16 +59,66 @@ final class CostChartGranularityTests: XCTestCase {
         XCTAssertEqual(CostChartGranularity.allowed(for: 7 * day + 1), [.day])
     }
 
-    func testWeekIsOfferedFromThreeWeeks() {
-        XCTAssertEqual(CostChartGranularity.allowed(for: 20 * day), [.day])
-        XCTAssertEqual(CostChartGranularity.allowed(for: 21 * day), [.day, .week])
+    func testWeekIsOfferedFromFourWeeks() {
+        XCTAssertEqual(CostChartGranularity.allowed(for: 21 * day), [.day])
+        XCTAssertEqual(CostChartGranularity.allowed(for: 27 * day), [.day])
+        XCTAssertEqual(CostChartGranularity.allowed(for: 28 * day), [.day, .week])
         XCTAssertEqual(CostChartGranularity.allowed(for: 365 * day), [.day, .week, .month])
+    }
+
+    /// The unlock threshold and the bar floor have to agree: the first span
+    /// that offers weekly must also be able to draw the four weekly bars a
+    /// manual pick has to survive.
+    func testWeekUnlocksExactlyWhenItCanDrawItsBarFloor() {
+        XCTAssertFalse(CostChartGranularity.drawsEnoughBuckets(.week, for: 27 * day))
+        XCTAssertTrue(CostChartGranularity.drawsEnoughBuckets(.week, for: 28 * day))
+        XCTAssertTrue(CostChartGranularity.survivesManualSelection(.week, for: 28 * day))
     }
 
     func testMonthIsOfferedFromSixtyDays() {
         XCTAssertEqual(CostChartGranularity.allowed(for: 59 * day), [.day, .week])
         XCTAssertEqual(CostChartGranularity.allowed(for: 60 * day), [.day, .week, .month])
         XCTAssertEqual(CostChartGranularity.allowed(for: 900 * day), [.day, .week, .month])
+    }
+
+    // MARK: - Manual selections that stop paying their way
+
+    func testManualPickIsDroppedWhenItWouldDrawTooFewBars() {
+        // Monthly is offered from 60 days, but 60 days is only two bars.
+        XCTAssertTrue(CostChartGranularity.isAllowed(.month, for: 60 * day))
+        XCTAssertFalse(CostChartGranularity.survivesManualSelection(.month, for: 60 * day))
+        XCTAssertTrue(CostChartGranularity.survivesManualSelection(.month, for: 120 * day))
+    }
+
+    func testManualPickIsDroppedWhenItIsNoLongerOffered() {
+        XCTAssertFalse(CostChartGranularity.survivesManualSelection(.hour, for: 30 * day))
+        XCTAssertFalse(CostChartGranularity.survivesManualSelection(.week, for: 10 * day))
+    }
+
+    func testHourAlwaysClearsTheBarFloorAtEveryUsableSpan() {
+        // The chart's zoom floor is half a day, which is still twelve bars.
+        for hours in [12.0, 24.0, 48.0, 7 * 24.0] {
+            XCTAssertTrue(
+                CostChartGranularity.survivesManualSelection(.hour, for: hours * 3_600),
+                "hour should survive a \(hours)h span"
+            )
+        }
+    }
+
+    /// Daily is the option the control always offers, so it is never taken
+    /// away — not even at the zoom floor, where it draws a single bar.
+    func testDayIsExemptFromTheBarFloor() {
+        XCTAssertFalse(CostChartGranularity.drawsEnoughBuckets(.day, for: 12 * 3_600))
+        XCTAssertTrue(CostChartGranularity.survivesManualSelection(.day, for: 12 * 3_600))
+        XCTAssertTrue(CostChartGranularity.survivesManualSelection(.day, for: 900 * day))
+    }
+
+    func testBarFloorCountsWholeBucketsAndIgnoresNegativeSpans() {
+        XCTAssertEqual(CostChartGranularity.minimumManualBuckets, 4)
+        XCTAssertFalse(CostChartGranularity.drawsEnoughBuckets(.week, for: -30 * day))
+        XCTAssertTrue(CostChartGranularity.drawsEnoughBuckets(.week, for: 30 * day, minimum: 0))
+        XCTAssertTrue(CostChartGranularity.drawsEnoughBuckets(.day, for: 4 * day, minimum: 4))
+        XCTAssertFalse(CostChartGranularity.drawsEnoughBuckets(.day, for: 3.9 * day, minimum: 4))
     }
 
     func testDayIsAlwaysAllowed() {


### PR DESCRIPTION
Follow-up to the 0.2.2 history-charts release, addressing AQ's hands-on feedback.

## Cost history fixes

- **Footer no longer clipped** — root cause: the card measured itself at its 125–145pt empty-state height on the first layout pass (the visible window wasn't built yet), and `ColumnMasonryLayout` froze that placeholder height into the column plan, clipping the TOTAL/AVG/PEAK row. The card now renders from a synthesized initial window so the first measurement equals the final height; the footer wraps honestly at narrow widths via `ViewThatFits` instead of scale-compressing.
- **Bar width capped at 26pt** (centered on the bucket midpoint) — a 5-day span no longer draws 90pt slabs.
- **More eager granularity demotion** — a manual Hour/Week/Month choice that would draw fewer than 4 buckets demotes to Auto immediately (pills grey out too); manual Week unlocks at 28d.
- **TOTAL / AVG / PEAK aligned** — labels and values sit on shared baselines; the peak date reserves its line instead of shifting the column.

## Quota history restructure (per AQ's design feedback)

- **One chart per quota group, no bucket picker** — charts follow the same group order/titles as the Subscription Utilization headings (shared `QuotaBucketGrouping` source of truth), so Claude gets separate charts for its general and per-model (e.g. Fable) scopes, like Reset history follows its groups.
- **Same-group buckets overlay in one chart** — per-bucket accent palette reused from existing app colors, legend with swatch/title/current %/forecast detail, per-bucket hover blocks. Pace line and forecast band draw only in single-bucket charts; multi-bucket charts carry pace in the tooltip and reset rules from the shortest window.

## Verification

`swift build` clean · `swift test` 796 green (790 + 6 granularity tests) · `./Scripts/build_app.sh release` + strict codesign pass, entitlements empty (no `app-sandbox`) · home-directory grep clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)