### PR TITLE
Resolve precise AntiGravity session model labels

### DIFF
--- a/Sources/VibeBarCore/Services/AntigravitySessionReader.swift
+++ b/Sources/VibeBarCore/Services/AntigravitySessionReader.swift
@@ -40,6 +40,9 @@ public enum AntigravitySessionReader {
         public let toolTokens: Int
         public let requestId: String?
         public let model: String?
+        /// Field-19 router alias retained as a safe display/pricing fallback
+        /// while an opaque field-20 model enum has no learned label.
+        public let routedModel: String?
 
         public init(
             date: Date,
@@ -49,7 +52,8 @@ public enum AntigravitySessionReader {
             thoughtsTokens: Int,
             toolTokens: Int,
             requestId: String?,
-            model: String? = nil
+            model: String? = nil,
+            routedModel: String? = nil
         ) {
             self.date = date
             self.inputTokens = inputTokens
@@ -59,7 +63,14 @@ public enum AntigravitySessionReader {
             self.toolTokens = toolTokens
             self.requestId = requestId
             self.model = model
+            self.routedModel = routedModel
         }
+    }
+
+    enum ReadError: Error {
+        case openDatabase
+        case prepareStatement
+        case stepStatement
     }
 
     /// Open the SQLite database in read-only mode, walk the
@@ -68,13 +79,24 @@ public enum AntigravitySessionReader {
     /// rather than throwing — a malformed database shouldn't sink
     /// the rest of the scan.
     public static func readGenMetadata(at file: URL) -> [Turn] {
+        switch readGenMetadataResult(at: file) {
+        case let .success(turns):
+            return turns
+        case .failure:
+            return []
+        }
+    }
+
+    /// Result-bearing variant used by cache migrations, where a valid empty
+    /// database must be distinguished from a temporary SQLite read failure.
+    static func readGenMetadataResult(at file: URL) -> Result<[Turn], ReadError> {
         let path = file.path
         var db: OpaquePointer? = nil
         let openFlags = SQLITE_OPEN_READONLY | SQLITE_OPEN_NOMUTEX | SQLITE_OPEN_URI
         let uri = "file:\(path)?immutable=1"
         guard sqlite3_open_v2(uri, &db, openFlags, nil) == SQLITE_OK, let db else {
             if db != nil { sqlite3_close_v2(db) }
-            return []
+            return .failure(.openDatabase)
         }
         defer { sqlite3_close_v2(db) }
 
@@ -82,21 +104,28 @@ public enum AntigravitySessionReader {
         let sql = "SELECT idx, data FROM gen_metadata ORDER BY idx"
         guard sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK, let statement else {
             if statement != nil { sqlite3_finalize(statement) }
-            return []
+            return .failure(.prepareStatement)
         }
         defer { sqlite3_finalize(statement) }
 
         var turns: [Turn] = []
-        while sqlite3_step(statement) == SQLITE_ROW {
-            guard let raw = sqlite3_column_blob(statement, 1) else { continue }
-            let length = Int(sqlite3_column_bytes(statement, 1))
-            guard length > 0 else { continue }
-            let blob = Data(bytes: raw, count: length)
-            if let turn = decodeTurn(blob: blob) {
-                turns.append(turn)
+        var stepResult = sqlite3_step(statement)
+        while stepResult == SQLITE_ROW {
+            if let raw = sqlite3_column_blob(statement, 1) {
+                let length = Int(sqlite3_column_bytes(statement, 1))
+                if length > 0 {
+                    let blob = Data(bytes: raw, count: length)
+                    if let turn = decodeTurn(blob: blob) {
+                        turns.append(turn)
+                    }
+                }
             }
+            stepResult = sqlite3_step(statement)
         }
-        return turns
+        guard stepResult == SQLITE_DONE else {
+            return .failure(.stepStatement)
+        }
+        return .success(turns)
     }
 
     // MARK: - Blob decoding
@@ -146,7 +175,8 @@ public enum AntigravitySessionReader {
             thoughtsTokens: thoughts,
             toolTokens: tool,
             requestId: requestId,
-            model: model
+            model: model,
+            routedModel: modelLabel == nil && modelEnum != nil ? routedModel : nil
         )
     }
 

--- a/Sources/VibeBarCore/Services/AntigravitySessionReader.swift
+++ b/Sources/VibeBarCore/Services/AntigravitySessionReader.swift
@@ -22,7 +22,10 @@ import SQLite3
 ///     dedupe key in the scan cache
 ///   - `1.9.4.1` / `1.9.4.2` — seconds + nanoseconds of the wall
 ///     clock when the turn started
-///   - `1.19` — model id, e.g. `gemini-3-flash-a`
+///   - `1.19` — routed model alias, e.g. `gemini-default`
+///   - `1.20["model_enum"]` — internal model id, e.g.
+///     `MODEL_PLACEHOLDER_M84`
+///   - `1.21` — precise human label, e.g. `Gemini 3.5 Flash (High)`
 ///
 /// Unknown fields are ignored. Missing fields default to 0 / nil so
 /// callers never have to special-case a turn whose blob is short on
@@ -112,7 +115,20 @@ public enum AntigravitySessionReader {
         let thoughts = Int(extractVarint(bytes: usage, fieldNumber: 9) ?? 0)
         let tool = Int(extractVarint(bytes: usage, fieldNumber: 10) ?? 0)
         let requestId = extractString(bytes: usage, fieldNumber: 11)
-        let model = extractString(bytes: outer, fieldNumber: 19)
+        // Field 19 is only the routed alias in recent AntiGravity builds
+        // (`gemini-default`, `gemini-3.6-flash`, ...). The same turn also
+        // carries the precise model label in field 21 and, when that label is
+        // absent, an internal model enum in the repeated field-20 metadata.
+        // Prefer those values so cost ranking and pricing reflect the model
+        // that actually served the turn instead of the router alias.
+        let routedModel = normalized(extractString(bytes: outer, fieldNumber: 19))
+        let modelEnum = normalized(extractMetadataValue(
+            bytes: outer,
+            fieldNumber: 20,
+            key: "model_enum"
+        ))
+        let modelLabel = normalized(extractString(bytes: outer, fieldNumber: 21))
+        let model = modelLabel ?? modelEnum ?? routedModel
 
         let date: Date
         if let seconds = extractVarint(bytes: timeBlock, fieldNumber: 1) {
@@ -199,6 +215,61 @@ public enum AntigravitySessionReader {
             return nil
         }
         return String(bytes: payload, encoding: .utf8)
+    }
+
+    /// Read a string value from AntiGravity's repeated key/value metadata
+    /// entries. Each entry is a length-delimited message whose field 1 is the
+    /// key and field 2 is the value.
+    static func extractMetadataValue(
+        bytes: [UInt8],
+        fieldNumber: UInt64,
+        key: String
+    ) -> String? {
+        for payload in extractLengthDelimitedValues(bytes: bytes, fieldNumber: fieldNumber) {
+            guard extractString(bytes: payload, fieldNumber: 1) == key else { continue }
+            return extractString(bytes: payload, fieldNumber: 2)
+        }
+        return nil
+    }
+
+    private static func extractLengthDelimitedValues(
+        bytes: [UInt8],
+        fieldNumber: UInt64
+    ) -> [[UInt8]] {
+        var values: [[UInt8]] = []
+        var index = 0
+        while let (number, wireType) = readTag(bytes: bytes, index: &index) {
+            switch wireType {
+            case 0:
+                _ = readVarint(bytes: bytes, index: &index)
+            case 1:
+                guard index + 8 <= bytes.count else { return values }
+                index += 8
+            case 2:
+                guard let length = readVarint(bytes: bytes, index: &index) else { return values }
+                let end = index + Int(length)
+                guard end <= bytes.count else { return values }
+                if number == fieldNumber {
+                    values.append(Array(bytes[index..<end]))
+                }
+                index = end
+            case 5:
+                guard index + 4 <= bytes.count else { return values }
+                index += 4
+            default:
+                return values
+            }
+        }
+        return values
+    }
+
+    private static func normalized(_ raw: String?) -> String? {
+        guard let value = raw?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !value.isEmpty
+        else {
+            return nil
+        }
+        return value
     }
 
     private static func readTag(bytes: [UInt8], index: inout Int) -> (UInt64, UInt64)? {

--- a/Sources/VibeBarCore/Services/CostHistoryStore.swift
+++ b/Sources/VibeBarCore/Services/CostHistoryStore.swift
@@ -86,7 +86,11 @@ public actor CostHistoryStore {
     /// Bumped to run a new one-time history correction on the next load.
     /// v1: drop legacy AntiGravity entries inflated by the cumulative
     /// cache-read over-count, so a corrected re-scan rebuilds them clean.
-    private static let currentHistoryCorrectionVersion = 1
+    /// v2: drop AntiGravity entries priced from coarse routed model aliases
+    /// such as `gemini-default`, so the precise per-turn model labels can
+    /// rebuild both the ranking and daily cost without max-merge pinning the
+    /// old, usually higher Gemini Pro fallback price.
+    private static let currentHistoryCorrectionVersion = 2
 
     init(
         fileURL: URL = CostHistoryStore.defaultFileURL(),
@@ -323,12 +327,10 @@ public actor CostHistoryStore {
         guard storage.historyCorrectionVersion != Self.currentHistoryCorrectionVersion else {
             return false
         }
-        // v1: the AntiGravity `.db` decoder used to re-sum the cumulative
-        // cache-read counter per turn, so historical antigravity cost +
-        // tokens were inflated and max-merge pinned the bad peak forever.
-        // Drop only the antigravity entries; the corrected scanner rebuilds
-        // them from the persistent `.db`/`.pb` conversations on the next
-        // scan. Other tools' history is untouched.
+        // v1 fixed cumulative-cache over-counting; v2 fixes pricing from
+        // coarse routed model aliases. Both corrections need the same narrow
+        // repair: drop only AntiGravity history, then let the corrected
+        // `.db`/`.pb` scanner rebuild it. Other tools stay untouched.
         let antigravityKey = ToolType.antigravity.rawValue
         storage.entries.removeAll { $0.tool == antigravityKey }
         storage.historyCorrectionVersion = Self.currentHistoryCorrectionVersion

--- a/Sources/VibeBarCore/Services/CostUsageScanner.swift
+++ b/Sources/VibeBarCore/Services/CostUsageScanner.swift
@@ -907,6 +907,11 @@ public enum CostUsageScanner {
         ".gemini/antigravity-cli/conversations",
         ".gemini/antigravity-ide/conversations"
     ]
+    /// v2 reads the precise field-21 model label (or field-20
+    /// `model_enum`) instead of grouping every routed field-19 alias such as
+    /// `gemini-default`. The scan cache keeps this independent of its global
+    /// schema so only `.db` events are reparsed once; `.pb` RPC events survive.
+    private static let antigravityDBParserVersion = 2
 
     private static func scanAntigravity(
         homeDirectory: String,
@@ -920,6 +925,8 @@ public enum CostUsageScanner {
         var aggregator = CostAggregator(tool: .antigravity, now: now)
         var cache = CostUsageScanCache.load(homeDirectory: homeDirectory, tool: .antigravity, retentionDays: retentionDays)
         let cutoff = retentionCutoff(now: now, retentionDays: retentionDays)
+        let shouldReparseDatabases =
+            cache.antigravityDBParserVersion != antigravityDBParserVersion
         // Resolve placeholder model ids (e.g. MODEL_PLACEHOLDER_M132) to
         // real names + rates using labels learned from GetUserStatus.
         let labels = AntigravityModelLabelStore.load(homeDirectory: homeDirectory)
@@ -940,7 +947,8 @@ public enum CostUsageScanner {
                 fileCount += 1
                 knownPaths.insert(dbFile.path)
                 let (mtime, size) = fileFingerprint(dbFile)
-                if let cached = cache.reusable(for: dbFile.path, mtime: mtime, size: size) {
+                let cached = cache.reusable(for: dbFile.path, mtime: mtime, size: size)
+                if let cached, !shouldReparseDatabases {
                     let retained = retainedEvents(cached, cutoff: cutoff)
                     if retained.count != cached.count {
                         cache.store(retained, for: dbFile.path, mtime: mtime, size: size)
@@ -950,10 +958,24 @@ public enum CostUsageScanner {
                     continue
                 }
                 let turns = AntigravitySessionReader.readGenMetadata(at: dbFile)
-                let parsed = antigravityEvents(fromDB: turns, sessionId: cascade.id, cutoff: cutoff)
-                cache.store(parsed, for: dbFile.path, mtime: mtime, size: size)
-                aggregateAntigravity(parsed, labels: labels, into: &aggregator)
-                if !turns.isEmpty { handledByDB = true }
+                if !turns.isEmpty {
+                    let parsed = antigravityEvents(fromDB: turns, sessionId: cascade.id, cutoff: cutoff)
+                    cache.store(parsed, for: dbFile.path, mtime: mtime, size: size)
+                    aggregateAntigravity(parsed, labels: labels, into: &aggregator)
+                    handledByDB = true
+                    continue
+                }
+                // A parser migration must never erase a previously readable
+                // conversation if a database is temporarily locked or
+                // malformed. Keep its last cooked events and continue to
+                // prefer them over a `.pb` sibling to avoid double-counting.
+                if let cached {
+                    let retained = retainedEvents(cached, cutoff: cutoff)
+                    aggregateAntigravity(retained, labels: labels, into: &aggregator)
+                    if !cached.isEmpty { handledByDB = true }
+                    continue
+                }
+                cache.store([], for: dbFile.path, mtime: mtime, size: size)
             }
             if handledByDB { continue }
 
@@ -998,6 +1020,7 @@ public enum CostUsageScanner {
             }
         }
         cache.prune(known: knownPaths)
+        cache.antigravityDBParserVersion = antigravityDBParserVersion
         cache.save(homeDirectory: homeDirectory, tool: .antigravity)
         return aggregator.snapshot(jsonlFilesFound: fileCount)
     }

--- a/Sources/VibeBarCore/Services/CostUsageScanner.swift
+++ b/Sources/VibeBarCore/Services/CostUsageScanner.swift
@@ -939,6 +939,7 @@ public enum CostUsageScanner {
 
         var knownPaths: Set<String> = []
         var fileCount = 0
+        var completedRequiredDatabaseReparses = true
 
         for cascade in cascades {
             // 1. Prefer the offline `.db` decode.
@@ -957,24 +958,32 @@ public enum CostUsageScanner {
                     if !cached.isEmpty { handledByDB = true }
                     continue
                 }
-                let turns = AntigravitySessionReader.readGenMetadata(at: dbFile)
-                if !turns.isEmpty {
+                let readResult = AntigravitySessionReader.readGenMetadataResult(at: dbFile)
+                if case let .success(turns) = readResult, !turns.isEmpty {
                     let parsed = antigravityEvents(fromDB: turns, sessionId: cascade.id, cutoff: cutoff)
                     cache.store(parsed, for: dbFile.path, mtime: mtime, size: size)
                     aggregateAntigravity(parsed, labels: labels, into: &aggregator)
                     handledByDB = true
                     continue
                 }
-                // A parser migration must never erase a previously readable
-                // conversation if a database is temporarily locked or
-                // malformed. Keep its last cooked events and continue to
-                // prefer them over a `.pb` sibling to avoid double-counting.
-                if let cached {
-                    let retained = retainedEvents(cached, cutoff: cutoff)
-                    aggregateAntigravity(retained, labels: labels, into: &aggregator)
-                    if !cached.isEmpty { handledByDB = true }
+                if case .failure = readResult {
+                    if shouldReparseDatabases {
+                        completedRequiredDatabaseReparses = false
+                    }
+                    // A parser migration must never erase a previously
+                    // readable conversation if SQLite is temporarily locked
+                    // or malformed. Keep the old parser version so the next
+                    // scan retries this database.
+                    if let cached {
+                        let retained = retainedEvents(cached, cutoff: cutoff)
+                        aggregateAntigravity(retained, labels: labels, into: &aggregator)
+                        if !cached.isEmpty { handledByDB = true }
+                    }
                     continue
                 }
+                // A parser migration must never erase a previously readable
+                // conversation. A successful empty decode is authoritative,
+                // so cache it and allow a `.pb` sibling to provide usage.
                 cache.store([], for: dbFile.path, mtime: mtime, size: size)
             }
             if handledByDB { continue }
@@ -1020,7 +1029,9 @@ public enum CostUsageScanner {
             }
         }
         cache.prune(known: knownPaths)
-        cache.antigravityDBParserVersion = antigravityDBParserVersion
+        if !shouldReparseDatabases || completedRequiredDatabaseReparses {
+            cache.antigravityDBParserVersion = antigravityDBParserVersion
+        }
         cache.save(homeDirectory: homeDirectory, tool: .antigravity)
         return aggregator.snapshot(jsonlFilesFound: fileCount)
     }
@@ -1097,9 +1108,12 @@ public enum CostUsageScanner {
             let output = turn.outputTokens + turn.thoughtsTokens + turn.toolTokens
             guard input > 0 || output > 0 || cacheReadThisTurn > 0 else { continue }
             let model = normalizedNonEmpty(turn.model) ?? "antigravity-default"
+            let fallback = normalizedNonEmpty(turn.routedModel)
+                .flatMap { $0 == model ? nil : $0 }
             let event = CostUsageScanCache.ParsedEvent(
                 date: turn.date,
                 model: model,
+                modelFallback: fallback,
                 input: input,
                 output: output,
                 cache: cacheReadThisTurn,
@@ -1155,10 +1169,14 @@ public enum CostUsageScanner {
             // normalizes to `antigravity-default` (Sonnet rate); the
             // resolved label (e.g. "Gemini 3.5 Flash") normalizes to the
             // correct — usually much cheaper — rate.
-            let name = labels.resolve(event.model)
+            let learnedName = labels.resolve(event.model)
+            let name = learnedName == event.model
+                ? (normalizedNonEmpty(event.modelFallback) ?? learnedName)
+                : learnedName
             let resolved = name == event.model ? event : CostUsageScanCache.ParsedEvent(
                 date: event.date,
                 model: name,
+                modelFallback: event.modelFallback,
                 input: event.input,
                 output: event.output,
                 cache: event.cache,

--- a/Sources/VibeBarCore/Storage/AntigravityModelLabelStore.swift
+++ b/Sources/VibeBarCore/Storage/AntigravityModelLabelStore.swift
@@ -2,12 +2,13 @@ import Foundation
 
 /// Maps AntiGravity's internal model ids to human labels.
 ///
-/// AntiGravity reports usage under opaque ids — `MODEL_PLACEHOLDER_M132`,
-/// `MODEL_PLACEHOLDER_M20`, … — both in the cost trajectories and in the
-/// `GetUserStatus` model config. `GetUserStatus`'s `clientModelConfigs`
-/// is the one place that also carries the label (`Gemini 3.5 Flash
-/// (High)`), so the quota adapter feeds those `id → label` pairs in here
-/// each time it refreshes, and the cost scanner reads them back to:
+/// Some AntiGravity trajectories expose only opaque ids —
+/// `MODEL_PLACEHOLDER_M132`, `MODEL_PLACEHOLDER_M20`, … — while newer
+/// database turns also carry their precise field-21 label. `GetUserStatus`'s
+/// `clientModelConfigs` independently carries the same id + label
+/// (`Gemini 3.5 Flash (High)`), so the quota adapter feeds those
+/// `id → label` pairs in here each time it refreshes. The cost scanner uses
+/// this store whenever a trajectory or RPC response lacks the embedded label:
 ///   1. show real model names instead of placeholders, and
 ///   2. price placeholder models at their real rate — a bare
 ///      `MODEL_PLACEHOLDER_*` normalizes to `antigravity-default`

--- a/Sources/VibeBarCore/Storage/CostUsageScanCache.swift
+++ b/Sources/VibeBarCore/Storage/CostUsageScanCache.swift
@@ -24,6 +24,10 @@ public struct CostUsageScanCache: Codable, Sendable {
     public struct ParsedEvent: Codable, Sendable {
         public let date: Date
         public let model: String
+        /// Optional provider-native alias used only when `model` is an
+        /// unresolved opaque identifier. AntiGravity keeps its field-19
+        /// router alias here until the field-20 enum gains a learned label.
+        public let modelFallback: String?
         public let input: Int
         public let output: Int
         public let cache: Int
@@ -45,6 +49,7 @@ public struct CostUsageScanCache: Codable, Sendable {
         public init(
             date: Date,
             model: String,
+            modelFallback: String? = nil,
             input: Int,
             output: Int,
             cache: Int,
@@ -59,6 +64,7 @@ public struct CostUsageScanCache: Codable, Sendable {
         ) {
             self.date = date
             self.model = model
+            self.modelFallback = modelFallback
             self.input = input
             self.output = output
             self.cache = cache

--- a/Sources/VibeBarCore/Storage/CostUsageScanCache.swift
+++ b/Sources/VibeBarCore/Storage/CostUsageScanCache.swift
@@ -81,22 +81,37 @@ public struct CostUsageScanCache: Codable, Sendable {
 
     public var schemaVersion: Int
     public var retentionDays: Int?
+    /// Version of the AntiGravity `.db` protobuf projection used to cook
+    /// cached events. This is deliberately separate from `schemaVersion`:
+    /// advancing it reparses only AntiGravity databases while preserving
+    /// opaque `.pb` RPC results and every other provider's warm cache.
+    public var antigravityDBParserVersion: Int?
     public var entries: [String: FileEntry]
 
-    public init(entries: [String: FileEntry] = [:], retentionDays: Int? = nil, schemaVersion: Int = Self.currentSchemaVersion) {
+    public init(
+        entries: [String: FileEntry] = [:],
+        retentionDays: Int? = nil,
+        schemaVersion: Int = Self.currentSchemaVersion,
+        antigravityDBParserVersion: Int? = nil
+    ) {
         self.schemaVersion = schemaVersion
         self.retentionDays = retentionDays.map(CostDataSettings.normalizedRetentionDays)
+        self.antigravityDBParserVersion = antigravityDBParserVersion
         self.entries = entries
     }
 
     private enum CodingKeys: String, CodingKey {
-        case schemaVersion, retentionDays, entries
+        case schemaVersion, retentionDays, antigravityDBParserVersion, entries
     }
 
     public init(from decoder: Decoder) throws {
         let c = try decoder.container(keyedBy: CodingKeys.self)
         self.schemaVersion = try c.decodeIfPresent(Int.self, forKey: .schemaVersion) ?? 1
         self.retentionDays = try c.decodeIfPresent(Int.self, forKey: .retentionDays)
+        self.antigravityDBParserVersion = try c.decodeIfPresent(
+            Int.self,
+            forKey: .antigravityDBParserVersion
+        )
         self.entries = try c.decode([String: FileEntry].self, forKey: .entries)
     }
 

--- a/Tests/VibeBarCoreTests/AntigravityCostScannerTests.swift
+++ b/Tests/VibeBarCoreTests/AntigravityCostScannerTests.swift
@@ -195,6 +195,7 @@ final class AntigravityCostScannerTests: XCTestCase {
         let turn = try XCTUnwrap(AntigravitySessionReader.decodeTurn(blob: blob))
 
         XCTAssertEqual(turn.model, "Gemini 3.5 Flash (High)")
+        XCTAssertNil(turn.routedModel)
     }
 
     func testDecoderFallsBackToModelEnumBeforeRoutedAlias() throws {
@@ -210,6 +211,7 @@ final class AntigravityCostScannerTests: XCTestCase {
         let turn = try XCTUnwrap(AntigravitySessionReader.decodeTurn(blob: blob))
 
         XCTAssertEqual(turn.model, "MODEL_PLACEHOLDER_M84")
+        XCTAssertEqual(turn.routedModel, "gemini-default")
     }
 
     func testDecoderKeepsLegacyBlobsWithoutModelReadable() throws {
@@ -433,6 +435,69 @@ final class AntigravityCostScannerTests: XCTestCase {
         XCTAssertLessThan(snap.allTimeCostUSD, 1.0)
     }
 
+    func testUnknownModelEnumUsesRoutedAliasUntilLabelIsLearned() async throws {
+        let home = try makeTempHome()
+        defer { cleanup(home) }
+        let convDir = home
+            .appendingPathComponent(".gemini/antigravity/conversations", isDirectory: true)
+        try FileManager.default.createDirectory(at: convDir, withIntermediateDirectories: true)
+
+        let now = Date(timeIntervalSince1970: 1_779_434_500)
+        let base = UInt64(now.addingTimeInterval(-600).timeIntervalSince1970)
+        let dbURL = convDir.appendingPathComponent("enum-fallback.db")
+        try writeAntigravityDB(at: dbURL, turns: [
+            TurnSpec(idx: 0, blob: encodeTurnBlob(
+                seconds: base,
+                input: 1_000_000,
+                output: 0,
+                cumulativeCache: 0,
+                model: "gemini-3-flash-a",
+                modelEnum: "MODEL_PLACEHOLDER_M84"
+            ))
+        ])
+
+        let firstResult = await CostUsageScanner.scan(
+            tool: .antigravity,
+            homeDirectory: home.path,
+            now: now
+        )
+        let first = try XCTUnwrap(firstResult)
+        XCTAssertEqual(first.modelBreakdowns.map(\.modelName), ["gemini-3-flash-a"])
+        XCTAssertGreaterThan(first.allTimeCostUSD, 0)
+        XCTAssertLessThan(first.allTimeCostUSD, 3.0)
+
+        let scannedDBPath = try XCTUnwrap(
+            FileManager.default.contentsOfDirectory(
+                at: convDir,
+                includingPropertiesForKeys: nil
+            ).first
+        ).path
+        let cacheData = try Data(contentsOf: CostUsageScanCache.fileURL(
+            homeDirectory: home.path,
+            tool: .antigravity
+        ))
+        let decodedCache = try JSONDecoder().decode(CostUsageScanCache.self, from: cacheData)
+        XCTAssertEqual(
+            decodedCache.entries.keys.sorted(),
+            [CostUsageScanCache.entryKey(for: scannedDBPath)]
+        )
+        let cached = decodedCache.lastKnownEvents(for: scannedDBPath)?.first
+        XCTAssertEqual(cached?.model, "MODEL_PLACEHOLDER_M84")
+        XCTAssertEqual(cached?.modelFallback, "gemini-3-flash-a")
+
+        AntigravityModelLabelStore(labels: [
+            "MODEL_PLACEHOLDER_M84": "Gemini 3.5 Flash (High)"
+        ]).save(homeDirectory: home.path)
+
+        let secondResult = await CostUsageScanner.scan(
+            tool: .antigravity,
+            homeDirectory: home.path,
+            now: now
+        )
+        let second = try XCTUnwrap(secondResult)
+        XCTAssertEqual(second.modelBreakdowns.map(\.modelName), ["Gemini 3.5 Flash (High)"])
+    }
+
     func testModelParserMigrationReparsesOnlyDatabaseEvents() async throws {
         let home = try makeTempHome()
         defer { cleanup(home) }
@@ -458,6 +523,12 @@ final class AntigravityCostScannerTests: XCTestCase {
         let attributes = try FileManager.default.attributesOfItem(atPath: dbURL.path)
         let mtime = try XCTUnwrap(attributes[.modificationDate] as? Date)
         let size = try XCTUnwrap((attributes[.size] as? NSNumber)?.int64Value)
+        let scannedDBPath = try XCTUnwrap(
+            FileManager.default.contentsOfDirectory(
+                at: convDir,
+                includingPropertiesForKeys: nil
+            ).first
+        ).path
         let staleEvent = CostUsageScanCache.ParsedEvent(
             date: eventDate,
             model: "gemini-default",
@@ -467,7 +538,7 @@ final class AntigravityCostScannerTests: XCTestCase {
             sessionId: "cached-model"
         )
         var cache = CostUsageScanCache(antigravityDBParserVersion: 1)
-        cache.store([staleEvent], for: dbURL.path, mtime: mtime, size: size)
+        cache.store([staleEvent], for: scannedDBPath, mtime: mtime, size: size)
         cache.save(homeDirectory: home.path, tool: .antigravity)
 
         let snapshot = await CostUsageScanner.scan(
@@ -483,6 +554,81 @@ final class AntigravityCostScannerTests: XCTestCase {
 
         XCTAssertEqual(snap.modelBreakdowns.map(\.modelName), ["Gemini 3.5 Flash (High)"])
         XCTAssertEqual(migratedCache.antigravityDBParserVersion, 2)
+    }
+
+    func testModelParserMigrationRetriesDatabaseAfterTemporaryReadFailure() async throws {
+        let home = try makeTempHome()
+        defer { cleanup(home) }
+        let convDir = home
+            .appendingPathComponent(".gemini/antigravity/conversations", isDirectory: true)
+        try FileManager.default.createDirectory(at: convDir, withIntermediateDirectories: true)
+
+        let now = Date(timeIntervalSince1970: 1_779_434_500)
+        let eventDate = now.addingTimeInterval(-600)
+        let dbURL = convDir.appendingPathComponent("temporarily-unreadable.db")
+        try Data("not-a-sqlite-database".utf8).write(to: dbURL)
+
+        let attributes = try FileManager.default.attributesOfItem(atPath: dbURL.path)
+        let mtime = try XCTUnwrap(attributes[.modificationDate] as? Date)
+        let size = try XCTUnwrap((attributes[.size] as? NSNumber)?.int64Value)
+        let scannedDBPath = try XCTUnwrap(
+            FileManager.default.contentsOfDirectory(
+                at: convDir,
+                includingPropertiesForKeys: nil
+            ).first
+        ).path
+        let staleEvent = CostUsageScanCache.ParsedEvent(
+            date: eventDate,
+            model: "gemini-default",
+            input: 1_000,
+            output: 200,
+            cache: 0,
+            sessionId: "temporarily-unreadable"
+        )
+        var cache = CostUsageScanCache(antigravityDBParserVersion: 1)
+        cache.store([staleEvent], for: scannedDBPath, mtime: mtime, size: size)
+        cache.save(homeDirectory: home.path, tool: .antigravity)
+
+        let failedMigrationResult = await CostUsageScanner.scan(
+            tool: .antigravity,
+            homeDirectory: home.path,
+            now: now
+        )
+        let failedMigration = try XCTUnwrap(failedMigrationResult)
+        XCTAssertEqual(failedMigration.modelBreakdowns.map(\.modelName), ["gemini-default"])
+        XCTAssertEqual(
+            CostUsageScanCache.load(homeDirectory: home.path, tool: .antigravity)
+                .antigravityDBParserVersion,
+            1
+        )
+
+        try FileManager.default.removeItem(at: dbURL)
+        try writeAntigravityDB(at: dbURL, turns: [
+            TurnSpec(idx: 0, blob: encodeTurnBlob(
+                seconds: UInt64(eventDate.timeIntervalSince1970),
+                input: 1_000,
+                output: 200,
+                cumulativeCache: 0,
+                model: "gemini-default",
+                modelLabel: "Gemini 3.5 Flash (High)"
+            ))
+        ])
+
+        let recoveredMigrationResult = await CostUsageScanner.scan(
+            tool: .antigravity,
+            homeDirectory: home.path,
+            now: now
+        )
+        let recoveredMigration = try XCTUnwrap(recoveredMigrationResult)
+        XCTAssertEqual(
+            recoveredMigration.modelBreakdowns.map(\.modelName),
+            ["Gemini 3.5 Flash (High)"]
+        )
+        XCTAssertEqual(
+            CostUsageScanCache.load(homeDirectory: home.path, tool: .antigravity)
+                .antigravityDBParserVersion,
+            2
+        )
     }
 
     func testModelParserVersionRoundTripPreservesOpaqueProtobufCache() throws {

--- a/Tests/VibeBarCoreTests/AntigravityCostScannerTests.swift
+++ b/Tests/VibeBarCoreTests/AntigravityCostScannerTests.swift
@@ -52,7 +52,9 @@ final class AntigravityCostScannerTests: XCTestCase {
         thoughts: UInt64 = 0,
         tool: UInt64 = 0,
         requestId: String = "test-request",
-        model: String? = "gemini-3-flash-a"
+        model: String? = "gemini-3-flash-a",
+        modelEnum: String? = nil,
+        modelLabel: String? = nil
     ) -> Data {
         var usage: [UInt8] = []
         usage += encodeVarintField(1, systemPrompt)
@@ -70,6 +72,17 @@ final class AntigravityCostScannerTests: XCTestCase {
         var outer = encodeLengthDelimited(4, usage) + encodeLengthDelimited(9, systemBlock)
         if let model {
             outer += encodeString(19, model)
+        }
+        if let modelEnum {
+            let precedingMetadata =
+                encodeString(1, "last_step_index") + encodeString(2, "1")
+            outer += encodeLengthDelimited(20, precedingMetadata)
+            let modelMetadata =
+                encodeString(1, "model_enum") + encodeString(2, modelEnum)
+            outer += encodeLengthDelimited(20, modelMetadata)
+        }
+        if let modelLabel {
+            outer += encodeString(21, modelLabel)
         }
         let blob = encodeLengthDelimited(1, outer)
         return Data(blob)
@@ -166,6 +179,37 @@ final class AntigravityCostScannerTests: XCTestCase {
         XCTAssertEqual(turn.thoughtsTokens, 0)
         XCTAssertEqual(turn.toolTokens, 0)
         XCTAssertEqual(turn.model, "gemini-3-flash-a")
+    }
+
+    func testDecoderPrefersPreciseModelLabelOverRoutedAlias() throws {
+        let blob = encodeTurnBlob(
+            seconds: 1_779_434_426,
+            input: 1_000,
+            output: 200,
+            cumulativeCache: 0,
+            model: "gemini-default",
+            modelEnum: "MODEL_PLACEHOLDER_M84",
+            modelLabel: "Gemini 3.5 Flash (High)"
+        )
+
+        let turn = try XCTUnwrap(AntigravitySessionReader.decodeTurn(blob: blob))
+
+        XCTAssertEqual(turn.model, "Gemini 3.5 Flash (High)")
+    }
+
+    func testDecoderFallsBackToModelEnumBeforeRoutedAlias() throws {
+        let blob = encodeTurnBlob(
+            seconds: 1_779_434_426,
+            input: 1_000,
+            output: 200,
+            cumulativeCache: 0,
+            model: "gemini-default",
+            modelEnum: "MODEL_PLACEHOLDER_M84"
+        )
+
+        let turn = try XCTUnwrap(AntigravitySessionReader.decodeTurn(blob: blob))
+
+        XCTAssertEqual(turn.model, "MODEL_PLACEHOLDER_M84")
     }
 
     func testDecoderKeepsLegacyBlobsWithoutModelReadable() throws {
@@ -354,6 +398,140 @@ final class AntigravityCostScannerTests: XCTestCase {
         // Only the `.db` is counted; the `.pb` sibling is skipped.
         XCTAssertEqual(snap.jsonlFilesFound, 1)
         XCTAssertEqual(snap.allTimeTokens, 4_600)
+    }
+
+    func testScannerUsesEmbeddedModelLabelAndRepricesRoutedAlias() async throws {
+        let home = try makeTempHome()
+        defer { cleanup(home) }
+        let convDir = home
+            .appendingPathComponent(".gemini/antigravity/conversations", isDirectory: true)
+        try FileManager.default.createDirectory(at: convDir, withIntermediateDirectories: true)
+
+        let now = Date(timeIntervalSince1970: 1_779_434_500)
+        let base = UInt64(now.addingTimeInterval(-600).timeIntervalSince1970)
+        try writeAntigravityDB(at: convDir.appendingPathComponent("precise-model.db"), turns: [
+            TurnSpec(idx: 0, blob: encodeTurnBlob(
+                seconds: base,
+                input: 1_000_000,
+                output: 0,
+                cumulativeCache: 0,
+                model: "gemini-default",
+                modelEnum: "MODEL_PLACEHOLDER_M84",
+                modelLabel: "Gemini 3.5 Flash (High)"
+            ))
+        ])
+
+        let snapshot = await CostUsageScanner.scan(
+            tool: .antigravity,
+            homeDirectory: home.path,
+            now: now
+        )
+        let snap = try XCTUnwrap(snapshot)
+
+        XCTAssertEqual(snap.modelBreakdowns.map(\.modelName), ["Gemini 3.5 Flash (High)"])
+        XCTAssertGreaterThan(snap.allTimeCostUSD, 0)
+        XCTAssertLessThan(snap.allTimeCostUSD, 1.0)
+    }
+
+    func testModelParserMigrationReparsesOnlyDatabaseEvents() async throws {
+        let home = try makeTempHome()
+        defer { cleanup(home) }
+        let convDir = home
+            .appendingPathComponent(".gemini/antigravity/conversations", isDirectory: true)
+        try FileManager.default.createDirectory(at: convDir, withIntermediateDirectories: true)
+
+        let now = Date(timeIntervalSince1970: 1_779_434_500)
+        let eventDate = now.addingTimeInterval(-600)
+        let dbURL = convDir.appendingPathComponent("cached-model.db")
+        try writeAntigravityDB(at: dbURL, turns: [
+            TurnSpec(idx: 0, blob: encodeTurnBlob(
+                seconds: UInt64(eventDate.timeIntervalSince1970),
+                input: 1_000,
+                output: 200,
+                cumulativeCache: 0,
+                model: "gemini-default",
+                modelEnum: "MODEL_PLACEHOLDER_M84",
+                modelLabel: "Gemini 3.5 Flash (High)"
+            ))
+        ])
+
+        let attributes = try FileManager.default.attributesOfItem(atPath: dbURL.path)
+        let mtime = try XCTUnwrap(attributes[.modificationDate] as? Date)
+        let size = try XCTUnwrap((attributes[.size] as? NSNumber)?.int64Value)
+        let staleEvent = CostUsageScanCache.ParsedEvent(
+            date: eventDate,
+            model: "gemini-default",
+            input: 1_000,
+            output: 200,
+            cache: 0,
+            sessionId: "cached-model"
+        )
+        var cache = CostUsageScanCache(antigravityDBParserVersion: 1)
+        cache.store([staleEvent], for: dbURL.path, mtime: mtime, size: size)
+        cache.save(homeDirectory: home.path, tool: .antigravity)
+
+        let snapshot = await CostUsageScanner.scan(
+            tool: .antigravity,
+            homeDirectory: home.path,
+            now: now
+        )
+        let snap = try XCTUnwrap(snapshot)
+        let migratedCache = CostUsageScanCache.load(
+            homeDirectory: home.path,
+            tool: .antigravity
+        )
+
+        XCTAssertEqual(snap.modelBreakdowns.map(\.modelName), ["Gemini 3.5 Flash (High)"])
+        XCTAssertEqual(migratedCache.antigravityDBParserVersion, 2)
+    }
+
+    func testModelParserVersionRoundTripPreservesOpaqueProtobufCache() throws {
+        let home = try makeTempHome()
+        defer { cleanup(home) }
+        let convDir = home
+            .appendingPathComponent(".gemini/antigravity/conversations", isDirectory: true)
+        try FileManager.default.createDirectory(at: convDir, withIntermediateDirectories: true)
+
+        let eventDate = Date(timeIntervalSince1970: 1_779_433_900)
+        let pbURL = convDir.appendingPathComponent("opaque.pb")
+        try Data([0x00, 0x01, 0x02]).write(to: pbURL)
+
+        let attributes = try FileManager.default.attributesOfItem(atPath: pbURL.path)
+        let mtime = try XCTUnwrap(attributes[.modificationDate] as? Date)
+        let size = try XCTUnwrap((attributes[.size] as? NSNumber)?.int64Value)
+        let cachedEvent = CostUsageScanCache.ParsedEvent(
+            date: eventDate,
+            model: "gemini-default",
+            input: 1_000,
+            output: 200,
+            cache: 0,
+            sessionId: "opaque"
+        )
+        var cache = CostUsageScanCache(antigravityDBParserVersion: 1)
+        cache.store([cachedEvent], for: pbURL.path, mtime: mtime, size: size)
+        cache.save(homeDirectory: home.path, tool: .antigravity)
+        var migratedCache = CostUsageScanCache.load(
+            homeDirectory: home.path,
+            tool: .antigravity
+        )
+        XCTAssertEqual(migratedCache.antigravityDBParserVersion, 1)
+        XCTAssertEqual(
+            migratedCache.reusable(for: pbURL.path, mtime: mtime, size: size)?.count,
+            1
+        )
+        migratedCache.antigravityDBParserVersion = 2
+        migratedCache.save(homeDirectory: home.path, tool: .antigravity)
+
+        var reloadedCache = CostUsageScanCache.load(
+            homeDirectory: home.path,
+            tool: .antigravity
+        )
+
+        XCTAssertEqual(reloadedCache.antigravityDBParserVersion, 2)
+        XCTAssertEqual(
+            reloadedCache.reusable(for: pbURL.path, mtime: mtime, size: size)?.first?.model,
+            "gemini-default"
+        )
     }
 
     func testAntigravityCostUsesSonnetRatesForDefault() throws {

--- a/Tests/VibeBarCoreTests/CostHistoryStoreTests.swift
+++ b/Tests/VibeBarCoreTests/CostHistoryStoreTests.swift
@@ -150,20 +150,20 @@ final class CostHistoryStoreTests: XCTestCase {
         XCTAssertEqual(history.days.first?.totalTokens, 700)
     }
 
-    func testOneTimeCorrectionDropsLegacyAntigravityHistoryButKeepsOtherTools() async throws {
+    func testSecondCorrectionDropsVersionOneAntigravityHistoryButKeepsOtherTools() async throws {
         let fileManager = FileManager.default
         let directory = fileManager.temporaryDirectory
             .appendingPathComponent("VibeBarCostHistoryAntigravityCorrection-\(UUID().uuidString)", isDirectory: true)
         try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
         defer { try? fileManager.removeItem(at: directory) }
 
-        // A pre-correction file (no `historyCorrectionVersion`) carrying the
-        // inflated antigravity day that max-merge pinned, alongside a codex
-        // day. `calculationVersion` matches the current value so the
-        // calc-version wipe doesn't fire and confound the assertion.
+        // A v1-corrected file still carries cost priced from the coarse
+        // `gemini-default` alias. `calculationVersion` matches the current
+        // value so the calc-version wipe doesn't fire and confound the
+        // targeted v2 assertion.
         let url = directory.appendingPathComponent("cost_history.json")
         let json = """
-        {"schemaVersion":2,"calculationVersion":\(CostUsagePricing.calculationVersion),"entries":[\
+        {"schemaVersion":2,"calculationVersion":\(CostUsagePricing.calculationVersion),"historyCorrectionVersion":1,"entries":[\
         {"tool":"antigravity","date":"2026-05-28","costUSD":45.36,"totalTokens":395000000},\
         {"tool":"codex","date":"2026-05-28","costUSD":1.5,"totalTokens":1000}]}
         """


### PR DESCRIPTION
## Summary\n\n- decode AntiGravity session metadata with a deterministic display-label priority\n- invalidate only affected AntiGravity scan/history data so existing gemini-default rows can be corrected\n- add parser, cache and history regression coverage\n\n## Test plan\n\n- [x] swift build\n- [x] swift test (801 tests)\n- [x] ./Scripts/build_app.sh release\n- [x] empty entitlements and strict deep codesign verification\n\nCo-Authored-By: Codex <noreply@openai.com>