### PR TITLE
Fix main release flag expansion

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -145,7 +145,7 @@ jobs:
           set -euo pipefail
           assets=(.build/release/*.zip .build/release/*.sha256 .build/release/appcast.xml)
           release_title="Vibe Bar ${RELEASE_TAG#v}"
-          release_flags=()
+          release_flags=(--draft --generate-notes --verify-tag)
           if [[ "$RELEASE_CHANNEL" == "dev" ]]; then
             release_title="Vibe Bar ${RELEASE_TAG#v} (Dev)"
             release_flags+=(--prerelease --latest=false)
@@ -162,9 +162,6 @@ jobs:
           else
             gh release create "$RELEASE_TAG" \
               "${assets[@]}" \
-              --draft \
-              --generate-notes \
               --title "$release_title" \
-              "${release_flags[@]}" \
-              --verify-tag
+              "${release_flags[@]}"
           fi


### PR DESCRIPTION
## Summary
- keep common GitHub Release flags in a non-empty Bash array
- preserve Dev prerelease flags while allowing Main releases under macOS Bash 3.2 with `set -u`

## Test plan
- [x] `git diff --check`
- [x] parse `.github/workflows/release.yml` as YAML
- [x] exercise Main and Dev flag arrays with `/bin/bash -u`

Co-Authored-By: Codex <noreply@openai.com>