### PR TITLE
History charts round 2: fix broken Claude curves, embed per group, Overview all-quota chart

### DIFF
--- a/Sources/VibeBarApp/Views/ChartBrushNavigator.swift
+++ b/Sources/VibeBarApp/Views/ChartBrushNavigator.swift
@@ -245,20 +245,34 @@ struct QuotaChartLinePoint: Identifiable {
 /// which surface you looked at.
 enum QuotaChartMarks {
     /// Clipped and thinned marks for a series' real observations.
+    ///
+    /// `budget` is the whole curve's allowance, not each segment's: the visible
+    /// segments are clipped first, then the budget is split across them by
+    /// `ChartMarkBudget`, so a curve broken into forty windows costs the same
+    /// as one drawn in a single stroke. Segment indices are preserved across
+    /// the clip so a series key stays stable while panning.
     static func points<Element>(
         _ segments: [[Element]],
         kind: String,
         range: ClosedRange<Date>,
-        limit: Int,
+        budget: Int,
         time: (Element) -> Date,
         value: (Element) -> Double
     ) -> [QuotaChartLinePoint] {
-        var result: [QuotaChartLinePoint] = []
+        var visible: [(index: Int, samples: [Element])] = []
         for (index, segment) in segments.enumerated() {
             let clipped = clip(segment, time: time, to: range)
             guard !clipped.isEmpty else { continue }
-            let thinned = ChartSeriesThinning.strided(clipped, limit: limit)
-            let key = "\(kind)-\(index)"
+            visible.append((index, clipped))
+        }
+        let allowance = ChartMarkBudget.allocate(
+            segmentCounts: visible.map { $0.samples.count },
+            budget: budget
+        )
+        var result: [QuotaChartLinePoint] = []
+        for (slot, entry) in visible.enumerated() {
+            let thinned = ChartSeriesThinning.strided(entry.samples, limit: allowance[slot])
+            let key = "\(kind)-\(entry.index)"
             for (offset, sample) in thinned.enumerated() {
                 result.append(
                     QuotaChartLinePoint(
@@ -421,30 +435,6 @@ struct ChartRangePills: View {
     }
 }
 
-/// Uniform-stride thinning for brush minis and zoomed-out main charts.
-///
-/// Purely a drawing concern — the series itself keeps every observation, this
-/// only decides how many of them are worth turning into marks at the current
-/// scale.
-enum ChartSeriesThinning {
-    static func strided<Element>(_ elements: [Element], limit: Int) -> [Element] {
-        guard limit > 1, elements.count > limit else { return elements }
-        let step = Double(elements.count - 1) / Double(limit - 1)
-        var result: [Element] = []
-        result.reserveCapacity(limit)
-        var lastIndex = -1
-        for slot in 0..<limit {
-            let index = min(elements.count - 1, Int((Double(slot) * step).rounded()))
-            if index != lastIndex {
-                result.append(elements[index])
-                lastIndex = index
-            }
-        }
-        // The newest sample carries the "where are we now" reading, so never
-        // let rounding drop it.
-        if lastIndex != elements.count - 1 {
-            result.append(elements[elements.count - 1])
-        }
-        return result
-    }
-}
+// `ChartSeriesThinning`, `ChartMarkBudget` and `ChartSampleSearch` live in
+// VibeBarCore (`ChartSeriesPlanning.swift`) — they are pure arithmetic over a
+// series and belong where they can be tested.

--- a/Sources/VibeBarApp/Views/ChartBrushNavigator.swift
+++ b/Sources/VibeBarApp/Views/ChartBrushNavigator.swift
@@ -226,6 +226,201 @@ struct ChartBrushNavigator<Mini: View>: View {
     }
 }
 
+/// One drawable point on a quota line. Segment membership travels with the
+/// point as `seriesKey` so Swift Charts never joins two sides of a reset (or of
+/// a stretch where Vibe Bar was not running) into one stroke.
+struct QuotaChartLinePoint: Identifiable {
+    let id: String
+    let seriesKey: String
+    let time: Date
+    let value: Double
+}
+
+/// Turning segmented series into Swift Charts marks.
+///
+/// Shared by the per-group chart inside Subscription Utilization and the
+/// all-providers chart on the Overview: both clip to the visible window, thin
+/// to a mark budget, and bridge the holes between segments, and the two have to
+/// agree on all three or the same history would read differently depending on
+/// which surface you looked at.
+enum QuotaChartMarks {
+    /// Clipped and thinned marks for a series' real observations.
+    static func points<Element>(
+        _ segments: [[Element]],
+        kind: String,
+        range: ClosedRange<Date>,
+        limit: Int,
+        time: (Element) -> Date,
+        value: (Element) -> Double
+    ) -> [QuotaChartLinePoint] {
+        var result: [QuotaChartLinePoint] = []
+        for (index, segment) in segments.enumerated() {
+            let clipped = clip(segment, time: time, to: range)
+            guard !clipped.isEmpty else { continue }
+            let thinned = ChartSeriesThinning.strided(clipped, limit: limit)
+            let key = "\(kind)-\(index)"
+            for (offset, sample) in thinned.enumerated() {
+                result.append(
+                    QuotaChartLinePoint(
+                        id: "\(key)-\(offset)",
+                        seriesKey: key,
+                        time: time(sample),
+                        value: value(sample)
+                    )
+                )
+            }
+        }
+        return result
+    }
+
+    /// Straight connectors across the holes between consecutive segments.
+    ///
+    /// A hole is real information — coverage stopped, or the window refilled —
+    /// but a plot full of orphaned stubs reads as broken rather than as honest,
+    /// so the shape is carried across it. The connector is deliberately not
+    /// drawn like data (hairline, dashed, faint), it is never thinned, and the
+    /// hover readout still reports nothing over a bridged span, because nothing
+    /// was observed there.
+    static func bridges<Element>(
+        _ segments: [[Element]],
+        kind: String,
+        range: ClosedRange<Date>,
+        time: (Element) -> Date,
+        value: (Element) -> Double
+    ) -> [QuotaChartLinePoint] {
+        guard segments.count > 1 else { return [] }
+        var result: [QuotaChartLinePoint] = []
+        for index in 0..<(segments.count - 1) {
+            guard let tail = segments[index].last,
+                  let head = segments[index + 1].first
+            else { continue }
+            let start = time(tail)
+            let end = time(head)
+            // Overlap, not containment: a bridge that spans the whole visible
+            // window has both endpoints outside it and still has to draw.
+            guard end >= range.lowerBound, start <= range.upperBound else { continue }
+            let key = "\(kind)-bridge-\(index)"
+            result.append(
+                QuotaChartLinePoint(id: "\(key)-0", seriesKey: key, time: start, value: value(tail))
+            )
+            result.append(
+                QuotaChartLinePoint(id: "\(key)-1", seriesKey: key, time: end, value: value(head))
+            )
+        }
+        return result
+    }
+
+    /// Keep one sample beyond each edge so a line entering the window starts at
+    /// the frame border instead of at its first visible observation.
+    static func clip<Element>(
+        _ segment: [Element],
+        time: (Element) -> Date,
+        to range: ClosedRange<Date>
+    ) -> [Element] {
+        guard !segment.isEmpty else { return [] }
+        var first: Int?
+        var last: Int?
+        for (index, element) in segment.enumerated() {
+            let stamp = time(element)
+            if stamp >= range.lowerBound, stamp <= range.upperBound {
+                if first == nil { first = index }
+                last = index
+            }
+        }
+        guard let first, let last else { return [] }
+        let lower = max(0, first - 1)
+        let upper = min(segment.count - 1, last + 1)
+        return Array(segment[lower...upper])
+    }
+
+    /// How a bridge is stroked, everywhere one is drawn.
+    static let bridgeStroke = StrokeStyle(lineWidth: 1, dash: [2, 3])
+    static let bridgeOpacity: Double = 0.35
+}
+
+/// Preset-span selector for a navigable chart: "6h · 24h · 3d · 7d · All".
+///
+/// Only spans the recorded domain can actually show are offered, and the
+/// current one is highlighted by comparing against the live window rather than
+/// by remembering which pill was last tapped — so a pan or a pinch quietly
+/// deselects instead of leaving a lie on screen.
+struct ChartRangePills: View {
+    @Binding var window: ChartTimeWindow
+    var fontSize: CGFloat = 10
+    /// Called after a pill changes the window, so a chart can drop a stale
+    /// hover crosshair.
+    var onSelect: () -> Void = {}
+
+    private struct Option: Identifiable, Equatable {
+        let id: String
+        let label: String
+        let span: TimeInterval?
+        let isSelected: Bool
+    }
+
+    private static let spans: [(String, TimeInterval)] = [
+        ("6h", 6 * 3_600),
+        ("24h", 24 * 3_600),
+        ("3d", 3 * 86_400),
+        ("7d", 7 * 86_400)
+    ]
+
+    private var options: [Option] {
+        guard window.domainSpan > 0 else { return [] }
+        var result = Self.spans
+            .filter { $0.1 < window.domainSpan }
+            .map { label, span in
+                Option(
+                    id: label,
+                    label: label,
+                    span: span,
+                    isSelected: !window.coversDomain
+                        && window.isAtDomainEnd
+                        && abs(window.visibleSpan - span) <= span * 0.03
+                )
+            }
+        result.append(Option(id: "all", label: "All", span: nil, isSelected: window.coversDomain))
+        return result
+    }
+
+    var isEmpty: Bool { options.isEmpty }
+
+    var body: some View {
+        let options = self.options
+        if !options.isEmpty {
+            HStack(spacing: 1) {
+                ForEach(options) { option in
+                    Button {
+                        window.jump(toSpan: option.span ?? window.domainSpan)
+                        onSelect()
+                    } label: {
+                        Text(option.label)
+                            .font(.system(size: fontSize, weight: .semibold, design: .rounded))
+                            .foregroundStyle(option.isSelected ? .primary : .secondary)
+                            .lineLimit(1)
+                            .minimumScaleFactor(0.75)
+                            .padding(.horizontal, 6)
+                            .frame(minHeight: 20)
+                            .contentShape(Rectangle())
+                    }
+                    .buttonStyle(.plain)
+                    .focusable(false)
+                    .background {
+                        if option.isSelected {
+                            RoundedRectangle(cornerRadius: 6, style: .continuous)
+                                .fill(Color.primary.opacity(0.12))
+                        }
+                    }
+                    .accessibilityLabel(option.label)
+                }
+            }
+            .padding(2)
+            .background(RoundedRectangle(cornerRadius: 7).fill(Color.primary.opacity(0.08)))
+            .fixedSize(horizontal: true, vertical: false)
+        }
+    }
+}
+
 /// Uniform-stride thinning for brush minis and zoomed-out main charts.
 ///
 /// Purely a drawing concern — the series itself keeps every observation, this

--- a/Sources/VibeBarApp/Views/CostHistoryView.swift
+++ b/Sources/VibeBarApp/Views/CostHistoryView.swift
@@ -57,6 +57,50 @@ private struct CostGranularityOption: Identifiable, Equatable {
     ]
 }
 
+/// Range presets the navigable cost chart offers.
+///
+/// Deliberately not `CostTimeframe`, which still carries a Yesterday case for
+/// the summary tiles. The chart dropped its Yesterday pill: free navigation
+/// reaches yesterday with one drag, and the pill's label was the widest in the
+/// busiest row of the card — it pushed the bucket-width control off the edge in
+/// a narrow Overview column for a range the user can already reach.
+private enum CostRangePreset: String, CaseIterable, Identifiable {
+    case today
+    case week
+    case month
+    case all
+
+    var id: String { rawValue }
+
+    /// Calendar days back from the end of today, or `nil` for the whole domain.
+    var days: Int? {
+        switch self {
+        case .today: 1
+        case .week: 7
+        case .month: 30
+        case .all: nil
+        }
+    }
+
+    var shortLabel: String {
+        switch self {
+        case .today: "Today"
+        case .week: "7d"
+        case .month: "30d"
+        case .all: "All"
+        }
+    }
+
+    var label: String {
+        switch self {
+        case .today: "Today"
+        case .week: "7 days"
+        case .month: "30 days"
+        case .all: "All"
+        }
+    }
+}
+
 /// A bucket already summed by Core, before its model roll-up is attached.
 private struct CostBucketTotal {
     let start: Date
@@ -188,8 +232,19 @@ struct CostHistoryView: View {
                 }
             }
             if let window {
-                // Five presets plus five bucket widths do not fit on one line in
-                // a compact popover. Prefer the single row, then stack.
+                // Four presets plus five bucket widths do not fit on one line
+                // in a compact popover, and the two groups are the widest thing
+                // in the card. Offer the same pair at three widths and let
+                // `ViewThatFits` pick.
+                //
+                // The last candidate is the one that matters: `ViewThatFits`
+                // falls back to it when *nothing* fits, so it has to be the one
+                // that compresses. The first two hold their natural width —
+                // pills that shrink when they don't need to look broken — while
+                // the last drops `fixedSize` and lets the labels take their
+                // `minimumScaleFactor`. Before this, the narrowest candidate
+                // was still rigid, so an Overview column narrower than the two
+                // groups drew "Week Month" straight past the card edge.
                 ViewThatFits(in: .horizontal) {
                     HStack(spacing: 6) {
                         Spacer(minLength: 0)
@@ -200,18 +255,24 @@ struct CostHistoryView: View {
                         presetBar(window: window)
                         granularityControl(window: window)
                     }
+                    VStack(alignment: .trailing, spacing: 3) {
+                        presetBar(window: window, compressible: true)
+                        granularityControl(window: window, compressible: true)
+                    }
                 }
             }
         }
     }
 
-    private func presetBar(window: ChartTimeWindow) -> some View {
+    private func presetBar(window: ChartTimeWindow, compressible: Bool = false) -> some View {
         CostRangePresetBar(
             active: activePreset(window: window),
             density: density,
             action: applyPreset
         )
-        .fixedSize(horizontal: true, vertical: false)
+        // `fixedSize(horizontal: false)` is a no-op, so the compressible
+        // candidate simply doesn't pin the width.
+        .fixedSize(horizontal: !compressible, vertical: false)
     }
 
     private var emptyNote: some View {
@@ -292,7 +353,9 @@ struct CostHistoryView: View {
                     points: points,
                     granularity: granularity,
                     window: window.wrappedValue,
-                    plotWidth: geometry.size.width
+                    // The GeometryReader measures the whole chart, gutter
+                    // included; the bars only ever get what is left of it.
+                    plotWidth: geometry.size.width - Self.yAxisGutterWidth
                 )
             )
         }
@@ -371,6 +434,15 @@ struct CostHistoryView: View {
             }
         }
         .chartXScale(domain: window.wrappedValue.visibleRange)
+        // Marks are laid out against the scale, not against the plot rect, so a
+        // bucket that straddles the visible range's leading edge draws half its
+        // body to the left of the plot — straight across the "$0.00" label
+        // column. `visiblePoints` keeps those straddling buckets whole on
+        // purpose (cutting them would make the footer disagree with the chart),
+        // so the bar has to be clipped rather than dropped.
+        .chartPlotStyle { plotArea in
+            plotArea.clipped()
+        }
         .chartYAxis {
             AxisMarks(position: .leading, values: .automatic(desiredCount: 3)) { value in
                 AxisGridLine().foregroundStyle(.secondary.opacity(0.15))
@@ -378,6 +450,15 @@ struct CostHistoryView: View {
                     if let raw = value.as(Double.self) {
                         Text(formatAxisCost(raw))
                             .font(.system(size: 9, design: .rounded).monospacedDigit())
+                            // Swift Charts insets the plot by whatever the
+                            // widest label reports, so a floor here is a floor
+                            // on the gutter. Without it the column is as narrow
+                            // as "$10" at some zoom levels and as wide as
+                            // "$0.00" at others, and the plot edge — and with
+                            // it the first bar — slides sideways as the user
+                            // pans. `minWidth` rather than `width` so a
+                            // four-figure total still gets the room it needs.
+                            .frame(minWidth: Self.yAxisLabelWidth, alignment: .trailing)
                     }
                 }
             }
@@ -394,6 +475,16 @@ struct CostHistoryView: View {
             interactionOverlay(proxy: proxy, points: points, window: window)
         }
     }
+
+    /// Floor for the leading y-axis label column. "$0.00" at 9pt monospaced
+    /// digits is about 24pt; the extra keeps the gutter stable when the axis
+    /// switches between "$0.00" and "$10".
+    private static let yAxisLabelWidth: CGFloat = 30
+    /// What the label column costs the plot: the label itself plus the gap
+    /// Swift Charts leaves between it and the plot edge. Subtracted before
+    /// bar widths are derived, so the pitch is measured against the width the
+    /// bars actually get rather than the width of the whole card.
+    private static let yAxisGutterWidth: CGFloat = yAxisLabelWidth + 6
 
     /// Widest a single bar is allowed to get. Past this a bar stops reading as
     /// a measurement and starts reading as a block of colour — a five-day
@@ -785,22 +876,24 @@ struct CostHistoryView: View {
             firstDay: snapshot?.dailyHistory.first?.date,
             lastDay: snapshot?.dailyHistory.last?.date,
             dayCount: snapshot?.dailyHistory.count ?? 0,
-            hourlyEnd: snapshot?.todayHourlyHistory.last?.date
+            hourlyEnd: hourlyPoints.last?.date
         )
     }
 
     /// The full navigable extent: first recorded day through the end of today.
     ///
     /// The newest edge is the end of the current day rather than this instant so
-    /// today's bar is drawn whole and the Today / Yesterday presets land exactly
-    /// on calendar-day boundaries — the same frame the old fixed-timeframe chart
+    /// today's bar is drawn whole and every preset lands exactly on a
+    /// calendar-day boundary — the same frame the old fixed-timeframe chart
     /// used. Floored at 24h so a first-run domain is still navigable.
     private func domainRange() -> ClosedRange<Date>? {
         guard let snapshot else { return nil }
         let calendar = Calendar.current
         var low = snapshot.dailyHistory.first?.date
-        if let firstHour = snapshot.yesterdayHourlyHistory.first?.date
-            ?? snapshot.todayHourlyHistory.first?.date {
+        // The oldest hourly *bucket*, not the retention start: an empty
+        // retained window is not history, and treating it as domain would open
+        // a first-run chart on two weeks of nothing.
+        if let firstHour = hourlyPoints.first?.date {
             low = low.map { min($0, firstHour) } ?? firstHour
         }
         guard let low else { return nil }
@@ -863,26 +956,14 @@ struct CostHistoryView: View {
     /// Presets are calendar spans, not multiples of 86 400 seconds: the domain
     /// ends at the end of today, so a span measured back from there with
     /// `Calendar` lands on a midnight even across a 23- or 25-hour DST day.
-    private func applyPreset(_ preset: CostTimeframe) {
+    ///
+    /// Every preset is anchored at the domain's newest edge, which is what let
+    /// the Yesterday pill go: it was the only one that wasn't.
+    private func applyPreset(_ preset: CostRangePreset) {
         guard var current = window else { return }
-        switch preset {
-        case .today:
-            current.jump(toSpan: CostChartWindowPolicy.anchoredSpan(days: 1))
-        case .yesterday:
-            // The one preset that is not anchored at the newest edge.
-            let (start, end) = CostChartWindowPolicy.yesterdayBounds()
-            current = ChartTimeWindow(
-                domainStart: current.domainStart,
-                domainEnd: current.domainEnd,
-                minimumSpan: current.minimumSpan,
-                visibleStart: start,
-                visibleEnd: end
-            )
-        case .week:
-            current.jump(toSpan: CostChartWindowPolicy.anchoredSpan(days: 7))
-        case .month:
-            current.jump(toSpan: CostChartWindowPolicy.anchoredSpan(days: 30))
-        case .all:
+        if let days = preset.days {
+            current.jump(toSpan: CostChartWindowPolicy.anchoredSpan(days: days))
+        } else {
             current.jump(toSpan: current.domainSpan)
         }
         window = current
@@ -896,28 +977,21 @@ struct CostHistoryView: View {
     /// Matched against the same calendar spans `applyPreset` produces, so a DST
     /// day's extra (or missing) hour cannot push a freshly applied preset out
     /// of its own tolerance.
-    private func activePreset(window: ChartTimeWindow) -> CostTimeframe? {
+    private func activePreset(window: ChartTimeWindow) -> CostRangePreset? {
         if window.coversDomain { return .all }
-        let span = window.visibleSpan
-        let tolerance = Self.dayInterval * 0.03
-        let (yesterdayStart, yesterdayEnd) = CostChartWindowPolicy.yesterdayBounds()
-        if abs(span - yesterdayEnd.timeIntervalSince(yesterdayStart)) <= tolerance,
-           abs(window.visibleStart.timeIntervalSince(yesterdayStart)) <= tolerance {
-            return .yesterday
-        }
         guard window.isAtDomainEnd else { return nil }
-        let anchored: [(CostTimeframe, TimeInterval)] = [
-            (.today, CostChartWindowPolicy.anchoredSpan(days: 1)),
-            (.week, CostChartWindowPolicy.anchoredSpan(days: 7)),
-            (.month, CostChartWindowPolicy.anchoredSpan(days: 30))
-        ]
-        return anchored.first { abs(span - $0.1) <= $0.1 * 0.03 }?.0
+        let span = window.visibleSpan
+        return CostRangePreset.allCases.first { preset in
+            guard let days = preset.days else { return false }
+            let anchored = CostChartWindowPolicy.anchoredSpan(days: days)
+            return abs(span - anchored) <= anchored * 0.03
+        }
     }
 
     // MARK: - Granularity
 
     @ViewBuilder
-    private func granularityControl(window: ChartTimeWindow) -> some View {
+    private func granularityControl(window: ChartTimeWindow, compressible: Bool = false) -> some View {
         let span = window.visibleSpan
         HStack(spacing: 1) {
             ForEach(CostGranularityOption.all) { option in
@@ -943,12 +1017,21 @@ struct CostHistoryView: View {
             }
         }
         .padding(2)
-        .frame(width: CGFloat(CostGranularityOption.all.count) * 32)
+        // Fixed width keeps the five options evenly pitched; the compressible
+        // candidate caps instead of pins, so a narrow card shrinks the segments
+        // (the labels already carry `minimumScaleFactor`) rather than letting
+        // the last two draw past the card.
+        .frame(
+            minWidth: compressible ? nil : Self.granularityControlWidth,
+            maxWidth: Self.granularityControlWidth
+        )
         .background(
             RoundedRectangle(cornerRadius: 7, style: .continuous)
                 .fill(Color.primary.opacity(0.08))
         )
     }
+
+    private static let granularityControlWidth = CGFloat(CostGranularityOption.all.count) * 32
 
     private func granularityOptionLabel(
         _ option: CostGranularityOption,
@@ -1013,17 +1096,32 @@ struct CostHistoryView: View {
         currentGranularity.rawValue
     }
 
-    /// Hourly detail only exists for yesterday and today — the scanner keeps
-    /// per-hour buckets for those two days and nothing older. Reported as whole
-    /// days: inside a retained day, an hour with no bucket means nothing was
-    /// spent rather than evidence being missing.
+    /// Every per-hour bucket the snapshot carries, oldest first.
+    ///
+    /// `recentHourlyHistory` is a superset of the two day-scoped lanes, so it
+    /// is used alone when present. Snapshots cached before the window widened
+    /// have only the two days, and concatenating those is the fallback — never
+    /// both, or every bucket for yesterday and today would be counted twice.
+    private var hourlyPoints: [HourlyCostPoint] {
+        guard let snapshot else { return [] }
+        if !snapshot.recentHourlyHistory.isEmpty { return snapshot.recentHourlyHistory }
+        return snapshot.yesterdayHourlyHistory + snapshot.todayHourlyHistory
+    }
+
+    /// The stretch the chart has hourly evidence for, as whole days.
+    ///
+    /// The lower bound comes from the snapshot's declared retention start when
+    /// it has one: a day inside the retained window with no buckets was
+    /// scanned and found idle, which is coverage, whereas the oldest *bucket*
+    /// would leave an idle Monday looking like missing evidence and drop the
+    /// chart back to daily bars. Older snapshots don't declare a start, so
+    /// there the oldest bucket is all the proof there is.
     private var hourlyCoverage: ClosedRange<Date>? {
         guard let snapshot else { return nil }
+        let points = hourlyPoints
         return CostChartWindowPolicy.hourlyCoverage(
-            firstHour: snapshot.yesterdayHourlyHistory.first?.date
-                ?? snapshot.todayHourlyHistory.first?.date,
-            lastHour: snapshot.todayHourlyHistory.last?.date
-                ?? snapshot.yesterdayHourlyHistory.last?.date
+            firstHour: snapshot.hourlyCoverageStart ?? points.first?.date,
+            lastHour: points.last?.date
         )
     }
 
@@ -1050,8 +1148,7 @@ struct CostHistoryView: View {
         let range = window.visibleRange
         switch granularity {
         case .hour:
-            let hours = snapshot.yesterdayHourlyHistory + snapshot.todayHourlyHistory
-            return clip(hours, date: \.date, bucket: clipBucket(.hour), to: range).map { point in
+            return clip(hourlyPoints, date: \.date, bucket: clipBucket(.hour), to: range).map { point in
                 CostChartPoint(
                     date: point.date,
                     costUSD: point.costUSD,
@@ -1306,15 +1403,15 @@ struct CostHistoryView: View {
 
 /// The original timeframe pills, repurposed as window presets. Selection is
 /// derived from the window rather than owned here: free navigation can leave
-/// every pill unlit, which a `Binding<CostTimeframe>` could not express.
+/// every pill unlit, which a `Binding<CostRangePreset>` could not express.
 private struct CostRangePresetBar: View {
-    let active: CostTimeframe?
+    let active: CostRangePreset?
     let density: Theme.Density
-    let action: (CostTimeframe) -> Void
+    let action: (CostRangePreset) -> Void
 
     var body: some View {
         HStack(spacing: 1) {
-            ForEach(CostTimeframe.allCases) { preset in
+            ForEach(CostRangePreset.allCases) { preset in
                 Button {
                     action(preset)
                 } label: {

--- a/Sources/VibeBarApp/Views/MiniQuotaWindowView.swift
+++ b/Sources/VibeBarApp/Views/MiniQuotaWindowView.swift
@@ -387,34 +387,10 @@ private struct MiniBranchCell: Identifiable {
     }
 }
 
+/// Brand hue for a provider. The table itself lives in `Theme` so the charts
+/// that colour-code providers share exactly these hues.
 private func providerAccent(for tool: ToolType) -> Color {
-    switch tool {
-    case .codex:       return Color(red: 0.30, green: 0.78, blue: 0.74)  // teal
-    case .claude:      return Color(red: 0.93, green: 0.40, blue: 0.40)  // coral
-    case .alibaba:     return Color(red: 1.00, green: 0.62, blue: 0.20)  // amber
-    case .alibabaTokenPlan: return Color(red: 1.00, green: 0.48, blue: 0.18)  // deeper amber
-    case .gemini:      return Color(red: 0.34, green: 0.62, blue: 0.96)  // google blue
-    case .antigravity: return Color(red: 0.55, green: 0.40, blue: 0.92)  // violet
-    case .grok:        return Color(red: 0.18, green: 0.18, blue: 0.18)  // xAI near-black
-    case .copilot:     return Color(red: 0.46, green: 0.46, blue: 0.46)  // graphite
-    case .zai:         return Color(red: 0.26, green: 0.74, blue: 0.55)  // emerald
-    case .minimax:     return Color(red: 0.97, green: 0.30, blue: 0.45)  // pink
-    case .kimi:        return Color(red: 0.20, green: 0.20, blue: 0.20)  // ink
-    case .cursor:      return Color(red: 0.55, green: 0.55, blue: 0.96)  // periwinkle
-    case .mimo:        return Color(red: 0.97, green: 0.50, blue: 0.20)  // xiaomi orange
-    case .iflytek:     return Color(red: 0.10, green: 0.37, blue: 0.75)  // iflytek blue
-    case .tencentHunyuan:   return Color(red: 0.00, green: 0.49, blue: 0.91)  // tencent blue
-    case .tencentTokenPlan: return Color(red: 0.18, green: 0.62, blue: 0.96)  // tencent token blue
-    case .volcengine:  return Color(red: 0.92, green: 0.30, blue: 0.30)  // doubao red
-    case .volcengineAgentPlan: return Color(red: 0.96, green: 0.45, blue: 0.22)  // doubao agent amber
-    case .baiduQianfan: return Color(red: 0.16, green: 0.40, blue: 0.93)  // baidu blue
-    case .openCodeGo:  return Color(red: 0.22, green: 0.66, blue: 0.50)  // green
-    case .kilo:        return Color(red: 0.47, green: 0.37, blue: 0.93)  // purple
-    case .kiro:        return Color(red: 0.24, green: 0.48, blue: 0.94)  // blue
-    case .ollama:      return Color(red: 0.18, green: 0.18, blue: 0.18)  // graphite
-    case .openRouter:  return Color(red: 0.98, green: 0.62, blue: 0.16)  // orange
-    case .warp:        return Color(red: 0.58, green: 0.55, blue: 0.71)  // warp violet-grey
-    }
+    Theme.providerAccent(for: tool)
 }
 
 private func providerTitle(for tool: ToolType) -> String {

--- a/Sources/VibeBarApp/Views/OverviewQuotaHistoryCard.swift
+++ b/Sources/VibeBarApp/Views/OverviewQuotaHistoryCard.swift
@@ -81,6 +81,11 @@ struct OverviewQuotaHistoryCard: View {
 
     @State private var curves: [OverviewQuotaCurve] = []
     @State private var segmentsByCurve: [String: [[QuotaHistorySample]]] = [:]
+    /// Each curve's samples flattened into one ascending array — the segments
+    /// are already time-sorted and contiguous, so concatenating them keeps the
+    /// order a binary search needs. Built with the series so a pointer move
+    /// costs a search rather than a scan.
+    @State private var flatByCurve: [String: [QuotaHistorySample]] = [:]
     @State private var window: ChartTimeWindow?
     @State private var windowKey: String?
     @State private var initialSpan: TimeInterval = 7 * 86_400
@@ -91,10 +96,12 @@ struct OverviewQuotaHistoryCard: View {
     /// Shared across every visible curve, so a provider with nine quotas
     /// cannot starve the rest of the chart of detail.
     private static let visibleMarkBudget = 900
-    private static let minimumMarkLimit = 90
+    private static let minimumMarkBudget = 90
     private static let miniMarkLimit = 120
     /// Past this many rows the tooltip stops being a readout and becomes a
-    /// second chart; the rest are counted instead.
+    /// second chart; the rest are counted instead. Safe to cap only because
+    /// the rows are sorted lowest-remaining first — the quotas that get folded
+    /// into "+N more" are the ones with the most headroom.
     private static let tooltipRowLimit = 8
 
     var body: some View {
@@ -248,7 +255,11 @@ struct OverviewQuotaHistoryCard: View {
     private func chartBody(window: ChartTimeWindow) -> some View {
         let visible = window.visibleRange
         let shown = visibleCurves
-        let limit = max(Self.minimumMarkLimit, Self.visibleMarkBudget / max(1, shown.count))
+        // One budget per curve, split again across the segments that curve is
+        // drawn in — a five-hour quota over months of history is hundreds of
+        // small segments, and thinning each to the curve's budget would have
+        // meant multiplying it by their count.
+        let budget = max(Self.minimumMarkBudget, Self.visibleMarkBudget / max(1, shown.count))
         let lines = shown.map { curve -> (OverviewQuotaCurve, [QuotaChartLinePoint], [QuotaChartLinePoint]) in
             let segments = segmentsByCurve[curve.id] ?? []
             return (
@@ -257,7 +268,7 @@ struct OverviewQuotaHistoryCard: View {
                     segments,
                     kind: curve.id,
                     range: visible,
-                    limit: limit,
+                    budget: budget,
                     time: { $0.time },
                     value: { $0.remainingPercent }
                 ),
@@ -357,11 +368,14 @@ struct OverviewQuotaHistoryCard: View {
         ZStack {
             ForEach(shown) { curve in
                 Path { path in
-                    for segment in segmentsByCurve[curve.id] ?? [] {
-                        let thinned = ChartSeriesThinning.strided(segment, limit: Self.miniMarkLimit)
-                        guard let first = thinned.first else { continue }
+                    let strip = ChartMarkBudget.thinned(
+                        segmentsByCurve[curve.id] ?? [],
+                        budget: Self.miniMarkLimit
+                    )
+                    for segment in strip {
+                        guard let first = segment.first else { continue }
                         path.move(to: miniPoint(first, in: geometry))
-                        for sample in thinned.dropFirst() {
+                        for sample in segment.dropFirst() {
                             path.addLine(to: miniPoint(sample, in: geometry))
                         }
                     }
@@ -536,9 +550,16 @@ struct OverviewQuotaHistoryCard: View {
         .frame(width: Self.tooltipWidth, alignment: .leading)
     }
 
-    /// Nearest observation per curve, highest first — the reader is scanning
-    /// for who is lowest, and a sorted column makes that one glance. Curves
-    /// with no coverage near the cursor are omitted rather than shown as zero.
+    /// Nearest observation per curve, **lowest remaining first**.
+    ///
+    /// The order is the whole point of the card: the reader is looking for
+    /// whichever quota is closest to running out, and the tooltip caps its rows
+    /// — so sorting the fullest quotas to the top would have buried exactly the
+    /// curves this card exists to surface behind "+N more". Curves with no
+    /// coverage near the cursor are omitted rather than shown as zero.
+    ///
+    /// Resolved by binary search over each curve's flattened, time-sorted
+    /// samples, because this runs on every pointer move.
     private func hoverReadings(
         at date: Date,
         curves shown: [OverviewQuotaCurve]
@@ -547,28 +568,22 @@ struct OverviewQuotaHistoryCard: View {
         let tolerance = max(600, window.visibleSpan / 60)
         var result: [OverviewHoverReading] = []
         for curve in shown {
-            var best: QuotaHistorySample?
-            var bestDistance = tolerance
-            for segment in segmentsByCurve[curve.id] ?? [] {
-                for sample in segment {
-                    let distance = abs(sample.time.timeIntervalSince(date))
-                    if distance <= bestDistance {
-                        best = sample
-                        bestDistance = distance
-                    }
-                }
-            }
-            guard let best else { continue }
+            guard let sample = ChartSampleSearch.nearest(
+                in: flatByCurve[curve.id] ?? [],
+                to: date,
+                tolerance: tolerance,
+                time: { $0.time }
+            ) else { continue }
             result.append(
                 OverviewHoverReading(
                     id: curve.id,
                     label: curve.label,
                     color: curve.color,
-                    value: best.remainingPercent
+                    value: sample.remainingPercent
                 )
             )
         }
-        return result.sorted { $0.value > $1.value }
+        return result.sorted { $0.value < $1.value }
     }
 
     // MARK: - Selection
@@ -668,6 +683,7 @@ struct OverviewQuotaHistoryCard: View {
         guard !lanes.isEmpty, let domain = domainRange(lanes) else {
             curves = []
             segmentsByCurve = [:]
+            flatByCurve = [:]
             window = nil
             windowKey = nil
             return
@@ -683,6 +699,7 @@ struct OverviewQuotaHistoryCard: View {
 
         var built: [OverviewQuotaCurve] = []
         var series: [String: [[QuotaHistorySample]]] = [:]
+        var flat: [String: [QuotaHistorySample]] = [:]
         var indexPerTool: [ToolType: Int] = [:]
         for (account, bucket) in lanes {
             let id = OverviewQuotaCurve.id(
@@ -708,14 +725,17 @@ struct OverviewQuotaHistoryCard: View {
                     dash: variant.dash
                 )
             )
-            series[id] = QuotaHistorySeriesBuilder.build(
+            let actual = QuotaHistorySeriesBuilder.build(
                 fillPoints: fillPoints(accountId: account.id, bucketId: bucket.id),
                 range: domain
             ).actual
+            series[id] = actual
+            flat[id] = actual.flatMap { $0 }
         }
 
         curves = built
         segmentsByCurve = series
+        flatByCurve = flat
 
         let key = built.map(\.id).joined(separator: ",")
         let sameCurves = windowKey == key

--- a/Sources/VibeBarApp/Views/OverviewQuotaHistoryCard.swift
+++ b/Sources/VibeBarApp/Views/OverviewQuotaHistoryCard.swift
@@ -1,0 +1,870 @@
+import SwiftUI
+import Charts
+import VibeBarCore
+
+/// One curve in the all-providers quota history chart: the observed
+/// remaining-percent line of a single `(tool, account, bucket)`.
+///
+/// Everything the chart needs to draw and name the curve is resolved once, when
+/// the series are rebuilt, rather than per frame — including the colour, which
+/// costs an `NSColor` round trip to make appearance-aware.
+struct OverviewQuotaCurve: Identifiable, Equatable {
+    /// `"<tool>|<accountId>|<bucketId>"`. Also the key persisted in
+    /// `AppSettings.overviewQuotaHistoryHiddenCurveIds`, so it has to stay
+    /// stable across launches — no indices, no display strings.
+    let id: String
+    let tool: ToolType
+    let accountId: String
+    let bucketId: String
+    let toolTitle: String
+    let bucketTitle: String
+    /// Masked account hint, set only when a tool has more than one account with
+    /// history and the bucket titles alone would be ambiguous.
+    let accountQualifier: String?
+    let color: Color
+    let dash: [CGFloat]
+
+    var label: String {
+        let base = "\(toolTitle) · \(bucketTitle)"
+        guard let accountQualifier else { return base }
+        return "\(base) · \(accountQualifier)"
+    }
+
+    static func id(tool: ToolType, accountId: String, bucketId: String) -> String {
+        "\(tool.rawValue)|\(accountId)|\(bucketId)"
+    }
+}
+
+/// What the crosshair resolved to on one curve.
+private struct OverviewHoverReading: Identifiable {
+    let id: String
+    let label: String
+    let color: Color
+    let value: Double
+}
+
+/// Rebuild trigger. Keyed on the shape of every recorded lane rather than on
+/// the arrays themselves: a refresh appends one point per bucket, and only then
+/// is it worth re-segmenting every provider's history.
+private struct OverviewSeriesSignature: Equatable {
+    struct Entry: Equatable {
+        var curveId: String
+        var title: String
+        var count: Int
+        var first: Date?
+        var last: Date?
+    }
+
+    var entries: [Entry]
+}
+
+/// Every recorded quota, from every provider and account, on one time axis.
+///
+/// The per-provider cards answer "how am I doing on this one quota"; this one
+/// answers the question they cannot — "which of my quotas is the one that is
+/// actually going to run out". That only works if the curves share an axis, so
+/// this card draws observed remaining-percent only: pace lines, forecasts and
+/// uncertainty bands are meaningful against a single quota and are mud against
+/// a dozen.
+///
+/// A pull-down picks which curves are drawn, and the choice persists — see
+/// `AppSettings.overviewQuotaHistoryHiddenCurveIds`.
+///
+/// Like `QuotaHistoryChartView`, this view reads no wall clock and no
+/// environment value, so it is safe under any re-proposal from above.
+struct OverviewQuotaHistoryCard: View {
+    let density: Theme.Density
+
+    @EnvironmentObject var accountStore: AccountStore
+    @EnvironmentObject var quotaService: QuotaService
+    @EnvironmentObject var settingsStore: SettingsStore
+
+    @State private var curves: [OverviewQuotaCurve] = []
+    @State private var segmentsByCurve: [String: [[QuotaHistorySample]]] = [:]
+    @State private var window: ChartTimeWindow?
+    @State private var windowKey: String?
+    @State private var initialSpan: TimeInterval = 7 * 86_400
+    @State private var hoverDate: Date?
+    @State private var panBase: ChartTimeWindow?
+    @State private var magnifyBase: ChartTimeWindow?
+
+    /// Shared across every visible curve, so a provider with nine quotas
+    /// cannot starve the rest of the chart of detail.
+    private static let visibleMarkBudget = 900
+    private static let minimumMarkLimit = 90
+    private static let miniMarkLimit = 120
+    /// Past this many rows the tooltip stops being a readout and becomes a
+    /// second chart; the rest are counted instead.
+    private static let tooltipRowLimit = 8
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: density.cardSpacing) {
+            header
+            if let window, window.domainSpan > 0, !visibleCurves.isEmpty {
+                chartBody(window: window)
+            } else if curves.isEmpty {
+                note("Quota history builds up as refreshes come in.")
+            } else {
+                note("Every curve is hidden — pick one from the menu above.")
+            }
+        }
+        .padding(density.cardPadding)
+        .background(
+            RoundedRectangle(cornerRadius: density.cardCornerRadius, style: .continuous)
+                .fill(.background.tertiary.opacity(0.6))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: density.cardCornerRadius, style: .continuous)
+                .stroke(.separator.opacity(0.4), lineWidth: 0.5)
+        )
+        .onChange(of: seriesSignature, initial: true) { _, _ in
+            rebuild()
+        }
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        HStack(alignment: .firstTextBaseline, spacing: 6) {
+            Text("Quota history")
+                .font(.system(size: density.titleFontSize, weight: .semibold))
+            Text("All providers")
+                .font(.system(size: density.subtitleFontSize))
+                .foregroundStyle(.tertiary)
+            Spacer(minLength: 8)
+            if !curves.isEmpty {
+                curvePicker
+            }
+            if window != nil {
+                ChartRangePills(
+                    window: rangeBinding,
+                    fontSize: max(9, density.segmentedFontSize - 2),
+                    onSelect: { hoverDate = nil }
+                )
+            }
+        }
+    }
+
+    private func note(_ text: String) -> some View {
+        Text(text)
+            .font(.system(size: density.subtitleFontSize))
+            .foregroundStyle(.tertiary)
+            .fixedSize(horizontal: false, vertical: true)
+            .padding(.vertical, 6)
+    }
+
+    // MARK: - Curve picker
+
+    private var curvePicker: some View {
+        Menu {
+            Button("Show all curves") { setHidden([]) }
+            if visibleCurves.count > 1 {
+                Button("Show only the busiest") { showOnlyBusiest() }
+            }
+            Divider()
+            ForEach(curvesByTool, id: \.0) { tool, toolCurves in
+                Section(displayTitle(for: tool)) {
+                    ForEach(toolCurves) { curve in
+                        Toggle(isOn: binding(for: curve)) {
+                            Text(curve.accountQualifier.map { "\(curve.bucketTitle) · \($0)" }
+                                ?? curve.bucketTitle)
+                        }
+                    }
+                }
+            }
+        } label: {
+            HStack(spacing: 4) {
+                Image(systemName: "line.3.horizontal.decrease")
+                    .font(.system(size: max(8, density.segmentedFontSize - 3), weight: .semibold))
+                Text(selectionSummary)
+                    .font(
+                        .system(
+                            size: max(9, density.segmentedFontSize - 2),
+                            weight: .semibold,
+                            design: .rounded
+                        )
+                    )
+                    .lineLimit(1)
+            }
+            .foregroundStyle(.secondary)
+            .padding(.horizontal, 7)
+            .frame(minHeight: 22)
+            .background(RoundedRectangle(cornerRadius: 7).fill(Color.primary.opacity(0.08)))
+        }
+        .menuStyle(.borderlessButton)
+        .menuIndicator(.hidden)
+        .fixedSize()
+        .accessibilityLabel("Choose which quota curves to show")
+    }
+
+    private var selectionSummary: String {
+        let shown = visibleCurves.count
+        let total = curves.count
+        return shown == total ? "All \(total)" : "\(shown) of \(total)"
+    }
+
+    private func binding(for curve: OverviewQuotaCurve) -> Binding<Bool> {
+        Binding(
+            get: { !settingsStore.settings.overviewQuotaHistoryHiddenCurveIds.contains(curve.id) },
+            set: { isVisible in
+                var hidden = settingsStore.settings.overviewQuotaHistoryHiddenCurveIds
+                if isVisible {
+                    hidden.remove(curve.id)
+                } else {
+                    hidden.insert(curve.id)
+                }
+                setHidden(hidden)
+            }
+        )
+    }
+
+    private func setHidden(_ hidden: Set<String>) {
+        guard hidden != settingsStore.settings.overviewQuotaHistoryHiddenCurveIds else { return }
+        settingsStore.settings.overviewQuotaHistoryHiddenCurveIds = hidden
+        hoverDate = nil
+    }
+
+    /// Quick way back to a readable chart from a wall of curves: keep the ones
+    /// that have actually moved recently and hide the flat ones.
+    private func showOnlyBusiest() {
+        let ranked = curves
+            .map { ($0.id, movement(of: $0)) }
+            .sorted { $0.1 > $1.1 }
+        let keep = Set(ranked.prefix(5).map(\.0))
+        setHidden(Set(curves.map(\.id)).subtracting(keep))
+    }
+
+    /// How much a curve's newest segment actually swings — a quota sitting at
+    /// 100% all week tells the reader nothing.
+    private func movement(of curve: OverviewQuotaCurve) -> Double {
+        guard let segment = segmentsByCurve[curve.id]?.last, segment.count > 1 else { return 0 }
+        let values = segment.map(\.remainingPercent)
+        return (values.max() ?? 0) - (values.min() ?? 0)
+    }
+
+    // MARK: - Chart
+
+    @ViewBuilder
+    private func chartBody(window: ChartTimeWindow) -> some View {
+        let visible = window.visibleRange
+        let shown = visibleCurves
+        let limit = max(Self.minimumMarkLimit, Self.visibleMarkBudget / max(1, shown.count))
+        let lines = shown.map { curve -> (OverviewQuotaCurve, [QuotaChartLinePoint], [QuotaChartLinePoint]) in
+            let segments = segmentsByCurve[curve.id] ?? []
+            return (
+                curve,
+                QuotaChartMarks.points(
+                    segments,
+                    kind: curve.id,
+                    range: visible,
+                    limit: limit,
+                    time: { $0.time },
+                    value: { $0.remainingPercent }
+                ),
+                QuotaChartMarks.bridges(
+                    segments,
+                    kind: curve.id,
+                    range: visible,
+                    time: { $0.time },
+                    value: { $0.remainingPercent }
+                )
+            )
+        }
+
+        VStack(alignment: .leading, spacing: 6) {
+            legend(shown)
+
+            Chart {
+                // Bridges first so a real observation always draws over the
+                // connector that leads into it.
+                ForEach(lines, id: \.0.id) { curve, _, bridges in
+                    ForEach(bridges) { point in
+                        LineMark(
+                            x: .value("Time", point.time),
+                            y: .value("Left", point.value),
+                            series: .value("Line", point.seriesKey)
+                        )
+                        .foregroundStyle(curve.color.opacity(QuotaChartMarks.bridgeOpacity))
+                        .lineStyle(QuotaChartMarks.bridgeStroke)
+                    }
+                }
+                ForEach(lines, id: \.0.id) { curve, points, _ in
+                    ForEach(points) { point in
+                        LineMark(
+                            x: .value("Time", point.time),
+                            y: .value("Left", point.value),
+                            series: .value("Line", point.seriesKey)
+                        )
+                        .foregroundStyle(curve.color)
+                        .lineStyle(
+                            StrokeStyle(
+                                lineWidth: 1.6,
+                                lineCap: .round,
+                                lineJoin: .round,
+                                dash: curve.dash
+                            )
+                        )
+                    }
+                }
+            }
+            .chartLegend(.hidden)
+            .chartXScale(domain: visible)
+            .chartYScale(domain: 0...100)
+            .chartYAxis {
+                AxisMarks(position: .leading, values: [0, 25, 50, 75, 100]) { value in
+                    AxisGridLine().foregroundStyle(.secondary.opacity(0.15))
+                    AxisValueLabel {
+                        if let raw = value.as(Double.self) {
+                            Text("\(Int(raw))%")
+                                .font(.system(size: 9, design: .rounded).monospacedDigit())
+                        }
+                    }
+                }
+            }
+            .chartXAxis {
+                AxisMarks(values: .automatic(desiredCount: 4)) { _ in
+                    AxisGridLine().foregroundStyle(.secondary.opacity(0.10))
+                    AxisValueLabel()
+                        .font(.system(size: 9))
+                }
+            }
+            .chartOverlay { proxy in
+                interactionOverlay(proxy: proxy, curves: shown)
+            }
+            .frame(height: density.overviewQuotaHistoryChartHeight)
+
+            ChartBrushNavigator(
+                window: rangeBinding,
+                accent: Color.secondary,
+                height: density.chartBrushHeight,
+                accessibilityDescription: "All-providers quota history range navigator"
+            ) { geometry in
+                miniPaths(shown, in: geometry)
+            }
+
+            Text(scopeNote(shown, window: window))
+                .font(.system(size: max(8, density.resetCountdownFontSize - 1)))
+                .foregroundStyle(.tertiary)
+                .lineLimit(1)
+                .minimumScaleFactor(0.85)
+        }
+    }
+
+    private func miniPaths(
+        _ shown: [OverviewQuotaCurve],
+        in geometry: ChartBrushGeometry
+    ) -> some View {
+        ZStack {
+            ForEach(shown) { curve in
+                Path { path in
+                    for segment in segmentsByCurve[curve.id] ?? [] {
+                        let thinned = ChartSeriesThinning.strided(segment, limit: Self.miniMarkLimit)
+                        guard let first = thinned.first else { continue }
+                        path.move(to: miniPoint(first, in: geometry))
+                        for sample in thinned.dropFirst() {
+                            path.addLine(to: miniPoint(sample, in: geometry))
+                        }
+                    }
+                }
+                .stroke(
+                    curve.color.opacity(0.6),
+                    style: StrokeStyle(lineWidth: 0.8, lineCap: .round, lineJoin: .round)
+                )
+            }
+        }
+    }
+
+    private func miniPoint(
+        _ sample: QuotaHistorySample,
+        in geometry: ChartBrushGeometry
+    ) -> CGPoint {
+        CGPoint(
+            x: geometry.x(for: sample.time),
+            y: geometry.y(forFraction: sample.remainingPercent / 100)
+        )
+    }
+
+    // MARK: - Legend
+
+    private func legend(_ shown: [OverviewQuotaCurve]) -> some View {
+        LazyVGrid(
+            columns: [GridItem(.adaptive(minimum: 138), spacing: 8)],
+            alignment: .leading,
+            spacing: 3
+        ) {
+            ForEach(shown) { curve in
+                HStack(spacing: 4) {
+                    swatch(curve)
+                    Text(curve.label)
+                        .font(.system(size: max(8, density.subtitleFontSize - 2)))
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                    Spacer(minLength: 0)
+                }
+            }
+        }
+    }
+
+    private func swatch(_ curve: OverviewQuotaCurve) -> some View {
+        Path { path in
+            path.move(to: CGPoint(x: 0, y: 1))
+            path.addLine(to: CGPoint(x: 13, y: 1))
+        }
+        .stroke(curve.color, style: StrokeStyle(lineWidth: 2, lineCap: .round, dash: curve.dash))
+        .frame(width: 13, height: 2)
+    }
+
+    // MARK: - Hover + gestures
+
+    private func interactionOverlay(
+        proxy: ChartProxy,
+        curves shown: [OverviewQuotaCurve]
+    ) -> some View {
+        GeometryReader { geometry in
+            let plot = proxy.plotFrame.map { geometry[$0] }
+            let plotMinX = plot?.minX ?? 0
+            let plotWidth = plot?.width ?? geometry.size.width
+            ZStack(alignment: .topLeading) {
+                Rectangle()
+                    .fill(Color.clear)
+                    .contentShape(Rectangle())
+                    .onContinuousHover { phase in
+                        switch phase {
+                        case .active(let location):
+                            let value = proxy.value(atX: location.x - plotMinX, as: Date.self)
+                            hoverDate = value.flatMap {
+                                window?.visibleRange.contains($0) == true ? $0 : nil
+                            }
+                        case .ended:
+                            hoverDate = nil
+                        }
+                    }
+                    .gesture(panGesture(plotWidth: plotWidth))
+                    .simultaneousGesture(magnifyGesture(proxy: proxy, plotMinX: plotMinX))
+                    .onTapGesture(count: 2) {
+                        window = window?.jumped(toSpan: initialSpan)
+                        hoverDate = nil
+                    }
+
+                if let hoverDate,
+                   let x = proxy.position(forX: hoverDate),
+                   let plot {
+                    let readings = hoverReadings(at: hoverDate, curves: shown)
+                    Rectangle()
+                        .fill(Color.primary.opacity(0.22))
+                        .frame(width: 1, height: plot.height)
+                        .offset(x: plotMinX + x, y: plot.minY)
+                        .allowsHitTesting(false)
+                    tooltip(at: hoverDate, readings: readings)
+                        .offset(x: tooltipX(plotMinX: plotMinX, x: x, width: geometry.size.width))
+                        .allowsHitTesting(false)
+                }
+            }
+        }
+    }
+
+    private func panGesture(plotWidth: CGFloat) -> some Gesture {
+        DragGesture(minimumDistance: 3)
+            .onChanged { value in
+                guard plotWidth > 0, let current = window else { return }
+                let base = panBase ?? current
+                if panBase == nil { panBase = base }
+                let secondsPerPoint = base.visibleSpan / TimeInterval(plotWidth)
+                window = base.panned(by: -TimeInterval(value.translation.width) * secondsPerPoint)
+            }
+            .onEnded { _ in panBase = nil }
+    }
+
+    private func magnifyGesture(proxy: ChartProxy, plotMinX: CGFloat) -> some Gesture {
+        MagnifyGesture(minimumScaleDelta: 0.01)
+            .onChanged { value in
+                guard let current = window else { return }
+                let base = magnifyBase ?? current
+                if magnifyBase == nil { magnifyBase = base }
+                let anchor = proxy.value(atX: value.startLocation.x - plotMinX, as: Date.self)
+                    ?? base.visibleMidpoint
+                window = base.zoomed(scale: value.magnification, around: anchor)
+            }
+            .onEnded { _ in magnifyBase = nil }
+    }
+
+    private static let tooltipWidth: CGFloat = 214
+
+    private func tooltipX(plotMinX: CGFloat, x: CGFloat, width: CGFloat) -> CGFloat {
+        min(max(plotMinX + x - Self.tooltipWidth / 2, 0), max(0, width - Self.tooltipWidth))
+    }
+
+    private func tooltip(at date: Date, readings: [OverviewHoverReading]) -> some View {
+        VStack(alignment: .leading, spacing: 3) {
+            Text(Self.tooltipFormatter.string(from: date))
+                .font(.system(size: 10, weight: .semibold))
+            if readings.isEmpty {
+                Text("Nothing recorded here")
+                    .font(.system(size: 9))
+                    .foregroundStyle(.white.opacity(0.7))
+            } else {
+                ForEach(readings.prefix(Self.tooltipRowLimit)) { reading in
+                    HStack(alignment: .firstTextBaseline, spacing: 6) {
+                        Circle()
+                            .fill(reading.color)
+                            .frame(width: 5, height: 5)
+                        Text(reading.label)
+                            .font(.system(size: 9))
+                            .foregroundStyle(.white.opacity(0.78))
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                        Spacer(minLength: 6)
+                        Text("\(Int(reading.value.rounded()))%")
+                            .font(
+                                .system(size: 9, weight: .semibold, design: .rounded)
+                                    .monospacedDigit()
+                            )
+                    }
+                }
+                if readings.count > Self.tooltipRowLimit {
+                    Text("+\(readings.count - Self.tooltipRowLimit) more")
+                        .font(.system(size: 9))
+                        .foregroundStyle(.white.opacity(0.55))
+                }
+            }
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 6)
+        .background(RoundedRectangle(cornerRadius: 6).fill(Color.black.opacity(0.87)))
+        .foregroundStyle(.white)
+        .frame(width: Self.tooltipWidth, alignment: .leading)
+    }
+
+    /// Nearest observation per curve, highest first — the reader is scanning
+    /// for who is lowest, and a sorted column makes that one glance. Curves
+    /// with no coverage near the cursor are omitted rather than shown as zero.
+    private func hoverReadings(
+        at date: Date,
+        curves shown: [OverviewQuotaCurve]
+    ) -> [OverviewHoverReading] {
+        guard let window else { return [] }
+        let tolerance = max(600, window.visibleSpan / 60)
+        var result: [OverviewHoverReading] = []
+        for curve in shown {
+            var best: QuotaHistorySample?
+            var bestDistance = tolerance
+            for segment in segmentsByCurve[curve.id] ?? [] {
+                for sample in segment {
+                    let distance = abs(sample.time.timeIntervalSince(date))
+                    if distance <= bestDistance {
+                        best = sample
+                        bestDistance = distance
+                    }
+                }
+            }
+            guard let best else { continue }
+            result.append(
+                OverviewHoverReading(
+                    id: curve.id,
+                    label: curve.label,
+                    color: curve.color,
+                    value: best.remainingPercent
+                )
+            )
+        }
+        return result.sorted { $0.value > $1.value }
+    }
+
+    // MARK: - Selection
+
+    private var visibleCurves: [OverviewQuotaCurve] {
+        let hidden = settingsStore.settings.overviewQuotaHistoryHiddenCurveIds
+        return curves.filter { !hidden.contains($0.id) }
+    }
+
+    private var curvesByTool: [(ToolType, [OverviewQuotaCurve])] {
+        var order: [ToolType] = []
+        var grouped: [ToolType: [OverviewQuotaCurve]] = [:]
+        for curve in curves {
+            if grouped[curve.tool] == nil { order.append(curve.tool) }
+            grouped[curve.tool, default: []].append(curve)
+        }
+        return order.map { ($0, grouped[$0] ?? []) }
+    }
+
+    private var rangeBinding: Binding<ChartTimeWindow> {
+        Binding(
+            get: {
+                window ?? ChartTimeWindow(
+                    domainStart: .distantPast,
+                    domainEnd: .distantPast,
+                    minimumSpan: 0,
+                    visibleSpan: 0
+                )
+            },
+            set: { window = $0 }
+        )
+    }
+
+    // MARK: - Discovery
+
+    /// Every `(tool, account, bucket)` with a drawable lane, in a stable order:
+    /// core providers in the user's configured order first, then everything
+    /// else, and inside a provider the account and bucket order the adapters
+    /// produced.
+    private var candidateLanes: [(account: AccountIdentity, bucket: QuotaBucket)] {
+        let order = settingsStore.settings.orderedCoreProviders
+        let rank: (ToolType) -> Int = { tool in
+            order.firstIndex(of: tool.coreProviderRepresentative ?? tool) ?? order.count
+        }
+        let accounts = accountStore.accounts.sorted { left, right in
+            let leftRank = rank(left.tool)
+            let rightRank = rank(right.tool)
+            if leftRank != rightRank { return leftRank < rightRank }
+            if left.tool != right.tool { return left.tool.rawValue < right.tool.rawValue }
+            return left.id < right.id
+        }
+        var lanes: [(AccountIdentity, QuotaBucket)] = []
+        for account in accounts {
+            guard let buckets = quotaService.cachedQuota(for: account.id)?.buckets else { continue }
+            for bucket in buckets where drawableCount(account: account, bucket: bucket) > 1 {
+                lanes.append((account, bucket))
+            }
+        }
+        return lanes
+    }
+
+    private func drawableCount(account: AccountIdentity, bucket: QuotaBucket) -> Int {
+        let key = SubscriptionHistoryKey(accountId: account.id, bucketId: bucket.id)
+        return quotaService.observationsByAccountBucket[key]?.count ?? 0
+    }
+
+    private func fillPoints(accountId: String, bucketId: String) -> [FillTimelinePoint] {
+        let key = SubscriptionHistoryKey(accountId: accountId, bucketId: bucketId)
+        return quotaService.observationsByAccountBucket[key] ?? []
+    }
+
+    private var seriesSignature: OverviewSeriesSignature {
+        OverviewSeriesSignature(
+            entries: candidateLanes.map { account, bucket in
+                let points = fillPoints(accountId: account.id, bucketId: bucket.id)
+                return OverviewSeriesSignature.Entry(
+                    curveId: OverviewQuotaCurve.id(
+                        tool: account.tool,
+                        accountId: account.id,
+                        bucketId: bucket.id
+                    ),
+                    // Titles are part of the signature because a plan change can
+                    // rename a bucket without adding an observation.
+                    title: bucket.title,
+                    count: points.count,
+                    first: points.first?.sampledAt,
+                    last: points.last?.sampledAt
+                )
+            }
+        )
+    }
+
+    // MARK: - Rebuild
+
+    private func rebuild() {
+        let lanes = candidateLanes
+        guard !lanes.isEmpty, let domain = domainRange(lanes) else {
+            curves = []
+            segmentsByCurve = [:]
+            window = nil
+            windowKey = nil
+            return
+        }
+
+        // A tool only gets an account qualifier when it actually has more than
+        // one account here — otherwise every Claude curve would carry a masked
+        // address that distinguishes nothing.
+        var accountsPerTool: [ToolType: Set<String>] = [:]
+        for (account, _) in lanes {
+            accountsPerTool[account.tool, default: []].insert(account.id)
+        }
+
+        var built: [OverviewQuotaCurve] = []
+        var series: [String: [[QuotaHistorySample]]] = [:]
+        var indexPerTool: [ToolType: Int] = [:]
+        for (account, bucket) in lanes {
+            let id = OverviewQuotaCurve.id(
+                tool: account.tool,
+                accountId: account.id,
+                bucketId: bucket.id
+            )
+            let index = indexPerTool[account.tool, default: 0]
+            indexPerTool[account.tool] = index + 1
+            let variant = Self.variant(Theme.providerAccent(for: account.tool), index: index)
+            built.append(
+                OverviewQuotaCurve(
+                    id: id,
+                    tool: account.tool,
+                    accountId: account.id,
+                    bucketId: bucket.id,
+                    toolTitle: displayTitle(for: account.tool),
+                    bucketTitle: bucketTitle(bucket),
+                    accountQualifier: (accountsPerTool[account.tool]?.count ?? 0) > 1
+                        ? Self.qualifier(for: account)
+                        : nil,
+                    color: variant.color,
+                    dash: variant.dash
+                )
+            )
+            series[id] = QuotaHistorySeriesBuilder.build(
+                fillPoints: fillPoints(accountId: account.id, bucketId: bucket.id),
+                range: domain
+            ).actual
+        }
+
+        curves = built
+        segmentsByCurve = series
+
+        let key = built.map(\.id).joined(separator: ",")
+        let sameCurves = windowKey == key
+        windowKey = key
+        initialSpan = min(7 * 86_400, max(6 * 3_600, domain.upperBound.timeIntervalSince(domain.lowerBound)))
+
+        if sameCurves,
+           let existing = window,
+           existing.domainStart == domain.lowerBound,
+           existing.domainEnd == domain.upperBound {
+            return
+        }
+        if sameCurves, let existing = window {
+            let followsEnd = existing.isAtDomainEnd
+            var next = ChartTimeWindow(
+                domainStart: domain.lowerBound,
+                domainEnd: domain.upperBound,
+                minimumSpan: Self.minimumSpan,
+                visibleStart: existing.visibleStart,
+                visibleEnd: existing.visibleEnd
+            )
+            if followsEnd { next.jump(toSpan: existing.visibleSpan) }
+            window = next
+            return
+        }
+        window = ChartTimeWindow(
+            domainStart: domain.lowerBound,
+            domainEnd: domain.upperBound,
+            minimumSpan: Self.minimumSpan,
+            visibleSpan: initialSpan
+        )
+    }
+
+    /// Zoom floor for a chart that mixes five-hour and weekly quotas: deep
+    /// enough for the fast ones to show their sawtooth, shallow enough that a
+    /// weekly line is never a single flat pixel-row.
+    private static let minimumSpan: TimeInterval = 3 * 3_600
+
+    private func domainRange(
+        _ lanes: [(account: AccountIdentity, bucket: QuotaBucket)]
+    ) -> ClosedRange<Date>? {
+        var low: Date?
+        var high: Date?
+        for (account, bucket) in lanes {
+            let points = fillPoints(accountId: account.id, bucketId: bucket.id)
+            if let first = points.first?.sampledAt {
+                low = low.map { min($0, first) } ?? first
+            }
+            if let last = points.last?.sampledAt {
+                high = high.map { max($0, last) } ?? last
+            }
+        }
+        guard let low, let high, high >= low else { return nil }
+        let floorSpan: TimeInterval = 6 * 3_600
+        if high.timeIntervalSince(low) < floorSpan {
+            return high.addingTimeInterval(-floorSpan)...high
+        }
+        return low...high
+    }
+
+    // MARK: - Naming
+
+    private func displayTitle(for tool: ToolType) -> String {
+        tool == .gemini ? "Gemini" : tool.menuTitle
+    }
+
+    /// Claude titles six different quotas "Weekly" and only the group name
+    /// tells them apart, so the group wins when there is one — matching the
+    /// section headings in Subscription Utilization.
+    private func bucketTitle(_ bucket: QuotaBucket) -> String {
+        guard let group = bucket.groupTitle?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !group.isEmpty
+        else { return bucket.title }
+        return group == bucket.title ? group : "\(group) \(bucket.title)"
+    }
+
+    /// Short, non-identifying account hint. Aliases are the user's own words so
+    /// they pass through; an address is masked, never printed raw.
+    private static func qualifier(for account: AccountIdentity) -> String {
+        if let alias = account.alias?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !alias.isEmpty {
+            return alias
+        }
+        let masked = EmailMasker.mask(account.email)
+        return masked.isEmpty ? String(account.id.suffix(4)) : masked
+    }
+
+    private func scopeNote(_ shown: [OverviewQuotaCurve], window: ChartTimeWindow) -> String {
+        let providers = Set(shown.map(\.tool)).count
+        let curveWord = shown.count == 1 ? "curve" : "curves"
+        let providerWord = providers == 1 ? "provider" : "providers"
+        return "\(shown.count) \(curveWord) · \(providers) \(providerWord) · showing "
+            + "\(Self.spanLabel(window.visibleSpan)) of \(Self.spanLabel(window.domainSpan)) recorded"
+    }
+
+    // MARK: - Palette
+
+    /// One brand hue per provider, stepped in lightness (then in dash pattern)
+    /// so the quotas inside a provider stay recognisably that provider's while
+    /// still being told apart — Claude's 5 Hours and Weekly are the same coral
+    /// at two weights, not two unrelated colours.
+    private static func variant(_ base: Color, index: Int) -> (color: Color, dash: [CGFloat]) {
+        let lightnessSteps: [Double] = [0, 0.34, -0.24, 0.58]
+        let dashes: [[CGFloat]] = [[], [5, 3], [1.8, 2.6]]
+        let step = lightnessSteps[index % lightnessSteps.count]
+        let dash = dashes[(index / lightnessSteps.count) % dashes.count]
+        let shifted: Color
+        if step > 0 {
+            shifted = base.mix(with: .white, by: step)
+        } else if step < 0 {
+            shifted = base.mix(with: .black, by: -step)
+        } else {
+            shifted = base
+        }
+        return (legible(shifted), dash)
+    }
+
+    /// Make a brand hue survive a dark card.
+    ///
+    /// Two providers ship near-black accents (xAI, Kimi/Ollama) that would be
+    /// invisible as a 1.6pt line on a dark background, so a dark accent is
+    /// lifted hard and everything else gets the same small lift the forecast
+    /// strokes get. Resolved by *appearance* rather than by reading
+    /// `@Environment(\.colorScheme)`: an environment read would be a hidden
+    /// dependency, and a dynamic `NSColor` re-resolves itself at draw time.
+    private static func legible(_ base: Color) -> Color {
+        let plain = NSColor(base)
+        let srgb = plain.usingColorSpace(.sRGB) ?? plain
+        let luminance = 0.2126 * srgb.redComponent
+            + 0.7152 * srgb.greenComponent
+            + 0.0722 * srgb.blueComponent
+        let lifted = NSColor(base.mix(with: .white, by: luminance < 0.28 ? 0.58 : 0.16))
+        return Color(
+            nsColor: NSColor(name: nil) { appearance in
+                appearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua ? lifted : plain
+            }
+        )
+    }
+
+    private static func spanLabel(_ seconds: TimeInterval) -> String {
+        if seconds < 90 * 60 { return "\(max(1, Int((seconds / 60).rounded())))m" }
+        if seconds < 48 * 3_600 { return "\(Int((seconds / 3_600).rounded()))h" }
+        return "\(Int((seconds / 86_400).rounded()))d"
+    }
+
+    private static let tooltipFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "MMM d · HH:mm"
+        return formatter
+    }()
+}

--- a/Sources/VibeBarApp/Views/PopoverRoot.swift
+++ b/Sources/VibeBarApp/Views/PopoverRoot.swift
@@ -380,6 +380,12 @@ private struct OverviewWaterfall: View {
                 ForEach(settingsStore.settings.visibleCoreProviderList, id: \.self) { tool in
                     overviewQuotaCard(for: tool)
                 }
+                // Sits with the quota cards, not with the analytics: it is the
+                // cross-provider version of what they each show one slice of,
+                // and it is the only card that can answer "which of my quotas
+                // runs out first".
+                OverviewQuotaHistoryCard(density: density)
+                    .overviewMasonryItem(id: "quota-history-all", phase: .quota)
                 if hasCostData {
                     CostHistoryView(
                         tool: .codex,
@@ -681,25 +687,9 @@ private struct GeminiTabPage: View {
                         additionalQuotaSeries: antigravityQuotaSeries
                     )
                 }
-                // One card per quota group, in the same order the utilization
-                // card above stacks them: Gemini's groups first, then
-                // AntiGravity's. The two products reset on their own schedules,
-                // so they never share a chart; neither do two groups inside one
-                // product.
-                if let geminiAccount = geminiAccounts.first {
-                    quotaHistoryCards(
-                        tool: .gemini,
-                        accountId: geminiAccount.id,
-                        titleOverride: "Gemini quota history"
-                    )
-                }
-                if let antigravityAccount {
-                    quotaHistoryCards(
-                        tool: .antigravity,
-                        accountId: antigravityAccount.id,
-                        titleOverride: "AntiGravity quota history"
-                    )
-                }
+                // Quota history is no longer a card of its own: each group's
+                // chart is drawn inside the utilization card above, directly
+                // under the rows it describes — AntiGravity's included.
                 ServiceStatusCard(tools: [.gemini], density: density)
             }
             .frame(
@@ -711,40 +701,6 @@ private struct GeminiTabPage: View {
                 .frame(width: columns.right, alignment: .topLeading)
         }
         .frame(width: columns.total, alignment: .topLeading)
-    }
-
-    /// Quota-history cards for one of the two products on this page. The page
-    /// tool stays `.gemini` when grouping so an ungrouped Gemini Web quota gets
-    /// the same "Gemini Chat" heading the utilization card gives it.
-    @ViewBuilder
-    private func quotaHistoryCards(
-        tool: ToolType,
-        accountId: String,
-        titleOverride: String
-    ) -> some View {
-        let allGroups = QuotaBucketGrouping.groups(
-            pageTool: .gemini,
-            itemTool: tool,
-            buckets: quotaService.cachedQuota(for: accountId)?.buckets ?? []
-        )
-        let groups = QuotaBucketGrouping.chartable(
-            allGroups,
-            accountId: accountId,
-            observations: quotaService.observationsByAccountBucket
-        )
-        ForEach(groups) { group in
-            QuotaHistoryChartView(
-                tool: tool,
-                accountId: accountId,
-                group: group,
-                density: density,
-                titleOverride: titleOverride,
-                // Unfiltered count: when other groups merely lack history yet,
-                // the surviving card still needs its group label to stay
-                // distinguishable from them.
-                showsGroupTitle: allGroups.count > 1
-            )
-        }
     }
 }
 
@@ -1463,7 +1419,6 @@ private struct ProviderDetailView: View {
 
     @EnvironmentObject var environment: AppEnvironment
     @EnvironmentObject var settingsStore: SettingsStore
-    @EnvironmentObject var quotaService: QuotaService
 
     var body: some View {
         let columns = ProviderDetailColumnWidths(density: density)
@@ -1480,35 +1435,10 @@ private struct ProviderDetailView: View {
                         now: context.date
                     )
                 }
-                // One history card per quota group, in the order the
-                // utilization card above prints its group headings — Claude's
-                // ungrouped 5 Hours + Weekly in one chart, Fable in the next.
-                // Quotas that share a heading share a plot; quotas that reset
-                // on unrelated schedules never get merged behind a picker.
-                if let accountId = environment.account(for: tool)?.id {
-                    let allGroups = QuotaBucketGrouping.groups(
-                        pageTool: tool,
-                        itemTool: tool,
-                        buckets: environment.quota(for: tool)?.buckets ?? []
-                    )
-                    let groups = QuotaBucketGrouping.chartable(
-                        allGroups,
-                        accountId: accountId,
-                        observations: quotaService.observationsByAccountBucket
-                    )
-                    ForEach(groups) { group in
-                        QuotaHistoryChartView(
-                            tool: tool,
-                            accountId: accountId,
-                            group: group,
-                            density: density,
-                            // Unfiltered count, so a lone drawable group keeps
-                            // its label while sibling groups are still
-                            // accumulating history.
-                            showsGroupTitle: allGroups.count > 1
-                        )
-                    }
-                }
+                // Quota history is no longer a card of its own: each group's
+                // chart is drawn inside the utilization card above, directly
+                // under the rows it describes — "all models" under the
+                // all-models rows, Spark under Spark's.
                 ServiceStatusCard(tools: [tool], density: density)
             }
             .frame(

--- a/Sources/VibeBarApp/Views/QuotaHistoryChartView.swift
+++ b/Sources/VibeBarApp/Views/QuotaHistoryChartView.swift
@@ -168,6 +168,7 @@ struct QuotaHistoryChartView: View, Equatable {
 
     @State private var forecastByBucket: [String: [ForecastTimelinePoint]] = [:]
     @State private var seriesByBucket: [String: QuotaHistorySeries] = [:]
+    @State private var lookupByBucket: [String: BucketLookup] = [:]
     @State private var miniSegments: [[QuotaHistorySample]] = []
     @State private var window: ChartTimeWindow?
     @State private var windowKey: String?
@@ -191,9 +192,10 @@ struct QuotaHistoryChartView: View, Equatable {
 
     /// Marks per line inside the visible window. Beyond this the strokes stop
     /// gaining detail and start costing frames on a zoomed-out weekly domain —
-    /// so the budget is shared out across however many buckets overlay.
-    private static let visibleMarkLimit = 520
-    private static let minimumMarkLimit = 140
+    /// so the budget is shared out across however many buckets overlay, and
+    /// then again across the segments each bucket is drawn in.
+    private static let visibleMarkBudget = 520
+    private static let minimumMarkBudget = 140
     private static let miniMarkLimit = 160
     /// Past this many reset lines the plot reads as a picket fence rather than
     /// as a set of boundaries, so a zoomed-out five-hour quota drops them.
@@ -303,14 +305,16 @@ struct QuotaHistoryChartView: View, Equatable {
         )
         let visible = window.visibleRange
         let isSingle = buckets.count == 1
-        let limit = max(Self.minimumMarkLimit, Self.visibleMarkLimit / max(1, buckets.count))
-        let lines = bucketLines(buckets: buckets, range: visible, limit: limit)
+        // One budget per bucket, shared out across however many segments that
+        // bucket happens to be drawn in.
+        let budget = max(Self.minimumMarkBudget, Self.visibleMarkBudget / max(1, buckets.count))
+        let lines = bucketLines(buckets: buckets, range: visible, budget: budget)
         let primarySeries = seriesByBucket[primary.id] ?? .empty
         // Only a single-bucket chart can afford the wall-clock reference and
         // the uncertainty band: two of them overlaid is mud, and the pace
         // reading moves into the hover tooltip instead.
         let pacePoints = isSingle
-            ? linePoints(primarySeries.pace, kind: "pace", range: visible, limit: limit)
+            ? linePoints(primarySeries.pace, kind: "pace", range: visible, budget: budget)
             : []
         let paceBridges = isSingle
             ? bridgePoints(
@@ -322,7 +326,7 @@ struct QuotaHistoryChartView: View, Equatable {
             )
             : []
         let bandPoints = isSingle
-            ? forecastBandPoints(primarySeries.forecast, range: visible, limit: limit)
+            ? forecastBandPoints(primarySeries.forecast, range: visible, budget: budget)
             : []
         let resets = resetMarks(primarySeries: primarySeries, range: visible)
 
@@ -818,6 +822,10 @@ struct QuotaHistoryChartView: View, Equatable {
     /// rounding error, so it is never bridged to the closest sample on either
     /// side. The time label follows the shortest-window quota, which is the one
     /// sampled most densely.
+    ///
+    /// Binary search rather than a scan: this runs on every pointer move, and a
+    /// densely sampled lane under unlimited retention is tens of thousands of
+    /// samples per bucket.
     private func hoverReading(
         at date: Date,
         buckets: [QuotaBucket],
@@ -829,10 +837,16 @@ struct QuotaHistoryChartView: View, Equatable {
         var readings: [QuotaHoverBucketReading] = []
         var anchor: Date?
         for (index, bucket) in buckets.enumerated() {
-            let series = seriesByBucket[bucket.id] ?? .empty
-            let actual = nearestSample(in: series.actual, to: date, tolerance: tolerance)
-            let pace = nearestSample(in: series.pace, to: date, tolerance: tolerance)
-            let forecast = nearestForecast(in: series.forecast, to: date, tolerance: tolerance)
+            let lookup = lookupByBucket[bucket.id] ?? BucketLookup()
+            let actual = ChartSampleSearch.nearest(
+                in: lookup.actual, to: date, tolerance: tolerance, time: { $0.time }
+            )
+            let pace = ChartSampleSearch.nearest(
+                in: lookup.pace, to: date, tolerance: tolerance, time: { $0.time }
+            )
+            let forecast = ChartSampleSearch.nearest(
+                in: lookup.forecast, to: date, tolerance: tolerance, time: { $0.time }
+            )
             if bucket.id == primary.id {
                 anchor = actual?.time ?? forecast?.time
             }
@@ -850,42 +864,15 @@ struct QuotaHistoryChartView: View, Equatable {
         return QuotaHoverReading(time: anchor ?? date, buckets: readings)
     }
 
-    private func nearestSample(
-        in segments: [[QuotaHistorySample]],
-        to date: Date,
-        tolerance: TimeInterval
-    ) -> QuotaHistorySample? {
-        var best: QuotaHistorySample?
-        var bestDistance = tolerance
-        for segment in segments {
-            for sample in segment {
-                let distance = abs(sample.time.timeIntervalSince(date))
-                if distance <= bestDistance {
-                    best = sample
-                    bestDistance = distance
-                }
-            }
-        }
-        return best
-    }
-
-    private func nearestForecast(
-        in segments: [[QuotaHistoryForecastSample]],
-        to date: Date,
-        tolerance: TimeInterval
-    ) -> QuotaHistoryForecastSample? {
-        var best: QuotaHistoryForecastSample?
-        var bestDistance = tolerance
-        for segment in segments {
-            for sample in segment {
-                let distance = abs(sample.time.timeIntervalSince(date))
-                if distance <= bestDistance {
-                    best = sample
-                    bestDistance = distance
-                }
-            }
-        }
-        return best
+    /// Flattened, ascending copies of one bucket's lines.
+    ///
+    /// The segments are contiguous runs of an already time-sorted array, so
+    /// concatenating them keeps the order a binary search needs. Built once per
+    /// data change rather than walked per pointer move.
+    private struct BucketLookup {
+        var actual: [QuotaHistorySample] = []
+        var pace: [QuotaHistorySample] = []
+        var forecast: [QuotaHistoryForecastSample] = []
     }
 
     // MARK: - Range pills
@@ -1020,6 +1007,7 @@ struct QuotaHistoryChartView: View, Equatable {
         let buckets = bucketsWithHistory
         guard let primary = buckets.first, let domain = domainRange(buckets: buckets) else {
             seriesByBucket = [:]
+            lookupByBucket = [:]
             miniSegments = []
             window = nil
             windowKey = nil
@@ -1035,9 +1023,17 @@ struct QuotaHistoryChartView: View, Equatable {
             )
         }
         seriesByBucket = built
-        miniSegments = (built[primary.id]?.actual ?? []).map {
-            ChartSeriesThinning.strided($0, limit: Self.miniMarkLimit)
+        lookupByBucket = built.mapValues {
+            BucketLookup(
+                actual: $0.actual.flatMap { $0 },
+                pace: $0.pace.flatMap { $0 },
+                forecast: $0.forecast.flatMap { $0 }
+            )
         }
+        miniSegments = ChartMarkBudget.thinned(
+            built[primary.id]?.actual ?? [],
+            budget: Self.miniMarkLimit
+        )
 
         let minimumSpan = minimumSpan(for: primary)
         initialSpan = initialSpan(for: primary)
@@ -1128,7 +1124,7 @@ struct QuotaHistoryChartView: View, Equatable {
     private func bucketLines(
         buckets: [QuotaBucket],
         range: ClosedRange<Date>,
-        limit: Int
+        budget: Int
     ) -> [QuotaBucketLines] {
         buckets.enumerated().map { index, bucket in
             let series = seriesByBucket[bucket.id] ?? .empty
@@ -1141,7 +1137,7 @@ struct QuotaHistoryChartView: View, Equatable {
                     series.actual,
                     kind: "actual-\(index)",
                     range: range,
-                    limit: limit
+                    budget: budget
                 ),
                 actualBridges: bridgePoints(
                     series.actual,
@@ -1154,7 +1150,7 @@ struct QuotaHistoryChartView: View, Equatable {
                     series.forecast,
                     kind: "forecast-\(index)",
                     range: range,
-                    limit: limit
+                    budget: budget
                 ),
                 forecastBridges: bridgePoints(
                     series.forecast,
@@ -1181,13 +1177,13 @@ struct QuotaHistoryChartView: View, Equatable {
         _ segments: [[QuotaHistorySample]],
         kind: String,
         range: ClosedRange<Date>,
-        limit: Int
+        budget: Int
     ) -> [QuotaChartLinePoint] {
         QuotaChartMarks.points(
             segments,
             kind: kind,
             range: range,
-            limit: limit,
+            budget: budget,
             time: { $0.time },
             value: { $0.remainingPercent }
         )
@@ -1197,13 +1193,13 @@ struct QuotaHistoryChartView: View, Equatable {
         _ segments: [[QuotaHistoryForecastSample]],
         kind: String,
         range: ClosedRange<Date>,
-        limit: Int
+        budget: Int
     ) -> [QuotaChartLinePoint] {
         QuotaChartMarks.points(
             segments,
             kind: kind,
             range: range,
-            limit: limit,
+            budget: budget,
             time: { $0.time },
             value: { $0.remainingPercent }
         )
@@ -1212,14 +1208,22 @@ struct QuotaHistoryChartView: View, Equatable {
     private func forecastBandPoints(
         _ segments: [[QuotaHistoryForecastSample]],
         range: ClosedRange<Date>,
-        limit: Int
+        budget: Int
     ) -> [QuotaBandPoint] {
-        var result: [QuotaBandPoint] = []
+        var visible: [(index: Int, samples: [QuotaHistoryForecastSample])] = []
         for (index, segment) in segments.enumerated() {
             let clipped = QuotaChartMarks.clip(segment, time: { $0.time }, to: range)
             guard clipped.count > 1 else { continue }
-            let thinned = ChartSeriesThinning.strided(clipped, limit: limit)
-            let key = "band-\(index)"
+            visible.append((index, clipped))
+        }
+        let allowance = ChartMarkBudget.allocate(
+            segmentCounts: visible.map { $0.samples.count },
+            budget: budget
+        )
+        var result: [QuotaBandPoint] = []
+        for (slot, entry) in visible.enumerated() {
+            let thinned = ChartSeriesThinning.strided(entry.samples, limit: allowance[slot])
+            let key = "band-\(entry.index)"
             for (offset, sample) in thinned.enumerated() {
                 result.append(
                     QuotaBandPoint(

--- a/Sources/VibeBarApp/Views/QuotaHistoryChartView.swift
+++ b/Sources/VibeBarApp/Views/QuotaHistoryChartView.swift
@@ -8,7 +8,7 @@ import VibeBarCore
 /// and Codex splits its by limit name; each of those is a group, and the
 /// ungrouped remainder (Claude's 5 Hours + Weekly) is a group too — the one
 /// Subscription Utilization prints no heading for.
-struct QuotaBucketGroup: Identifiable {
+struct QuotaBucketGroup: Identifiable, Equatable {
     let id: String
     let title: String?
     let buckets: [QuotaBucket]
@@ -38,71 +38,15 @@ enum QuotaBucketGrouping {
         return nil
     }
 
-    /// Split `buckets` into runs that share a heading, preserving the
-    /// provider's own bucket order.
+    /// Stable identity for the run of rows a heading covers.
     ///
-    /// Contiguous by design: the utilization card decides "this row starts a
-    /// group" by comparing with the row above it, so a title that reappeared
-    /// after an interruption would print twice there. Grouping the same way
-    /// keeps one chart per printed heading rather than per distinct string.
-    static func groups(
-        pageTool: ToolType,
-        itemTool: ToolType,
-        buckets: [QuotaBucket]
-    ) -> [QuotaBucketGroup] {
-        var result: [QuotaBucketGroup] = []
-        for bucket in buckets {
-            let title = title(pageTool: pageTool, itemTool: itemTool, bucket: bucket)
-            if let last = result.last, last.title == title {
-                result[result.count - 1] = QuotaBucketGroup(
-                    id: last.id,
-                    title: last.title,
-                    buckets: last.buckets + [bucket]
-                )
-            } else {
-                result.append(
-                    QuotaBucketGroup(
-                        id: "\(itemTool.rawValue)|\(result.count)|\(title ?? "")",
-                        title: title,
-                        buckets: [bucket]
-                    )
-                )
-            }
-        }
-        return result
+    /// Account- and tool-scoped because one card can stack two products'
+    /// quotas (Gemini Web + AntiGravity), and `nil`-safe because the ungrouped
+    /// run (Claude's 5 Hours + Weekly — "all models") is a group for charting
+    /// purposes even though the utilization card prints no heading above it.
+    static func key(accountId: String?, itemTool: ToolType, title: String?) -> String {
+        "\(accountId ?? "")|\(itemTool.rawValue)|\(title ?? "")"
     }
-
-    /// Groups worth giving a history card.
-    ///
-    /// A line needs two points, so a group nobody has observed twice yet would
-    /// render an empty card — and on a fresh install *every* group would. Keep
-    /// the ones with something to draw; when none of them has anything, keep
-    /// exactly one so the "history builds up as refreshes come in" note is
-    /// still said once instead of once per quota scope.
-    static func chartable(
-        _ groups: [QuotaBucketGroup],
-        accountId: String,
-        observations: [SubscriptionHistoryKey: [FillTimelinePoint]]
-    ) -> [QuotaBucketGroup] {
-        let drawable = groups.filter { group in
-            group.buckets.contains { bucket in
-                let key = SubscriptionHistoryKey(accountId: accountId, bucketId: bucket.id)
-                return (observations[key]?.count ?? 0) > 1
-            }
-        }
-        if !drawable.isEmpty { return drawable }
-        return groups.isEmpty ? [] : [groups[0]]
-    }
-}
-
-/// One drawable point on a quota history line. Segment membership travels with
-/// the point as `seriesKey` so Swift Charts never joins two sides of a reset
-/// (or of a stretch where Vibe Bar was not running) into one stroke.
-private struct QuotaLinePoint: Identifiable {
-    let id: String
-    let seriesKey: String
-    let time: Date
-    let value: Double
 }
 
 /// One drawable point of the forecast's uncertainty band.
@@ -119,8 +63,10 @@ private struct QuotaBucketLines: Identifiable {
     let id: String
     let color: Color
     let forecastColor: Color
-    let actual: [QuotaLinePoint]
-    let forecast: [QuotaLinePoint]
+    let actual: [QuotaChartLinePoint]
+    let actualBridges: [QuotaChartLinePoint]
+    let forecast: [QuotaChartLinePoint]
+    let forecastBridges: [QuotaChartLinePoint]
 }
 
 /// What the hover crosshair resolved to on one bucket's lines.
@@ -177,20 +123,48 @@ private struct QuotaSeriesSignature: Equatable {
 ///
 /// Navigation is the approved thumbnail + gesture hybrid: a brush strip covers
 /// the whole domain, while drag-pan and pinch-zoom work directly on the plot.
-struct QuotaHistoryChartView: View {
+///
+/// `Equatable` on purpose. The chart is rendered inside Subscription
+/// Utilization, whose call sites wrap it in `TimelineView(.periodic(by: 30))`
+/// so the pace rows can re-read the wall clock. Every tick re-proposes this
+/// view; without `.equatable()` each tick would re-segment, re-clip and
+/// re-thin thousands of marks and could land in the middle of a pan. The
+/// comparison covers exactly the inputs that change what is drawn — the
+/// `@State`/`@EnvironmentObject` storage is deliberately excluded, because
+/// those invalidate the view through their own dependency, not through the
+/// parent's diff.
+///
+/// The other half of that contract: **this view must never read the current
+/// time**. There is no `now` parameter and no `Date()` anywhere in it — every
+/// "current" reading in the legend comes from the newest recorded sample, so a
+/// tick genuinely has nothing new to say.
+struct QuotaHistoryChartView: View, Equatable {
     let tool: ToolType
     let accountId: String
     let group: QuotaBucketGroup
     let density: Theme.Density
-    /// Set when a page shows more than one of these cards for *different
+    /// Set when a page shows more than one of these charts for *different
     /// products* and "Quota history" alone would not say whose.
     var titleOverride: String? = nil
-    /// Print the group's name under the title. Set when the account has more
-    /// than one group, mirroring the headings in Subscription Utilization.
+    /// Print the group's name under the title. Set when the chart is shown
+    /// away from its group's heading and needs to name itself.
     var showsGroupTitle: Bool = false
+    /// Drawn inside the utilization card, directly under the group's rows —
+    /// so no card chrome of its own, and a quiet caption-sized title, exactly
+    /// like the "Reset history" strip it sits beside.
+    var isEmbedded: Bool = false
 
     @EnvironmentObject var quotaService: QuotaService
-    @Environment(\.colorScheme) private var colorScheme
+
+    static func == (lhs: QuotaHistoryChartView, rhs: QuotaHistoryChartView) -> Bool {
+        lhs.tool == rhs.tool
+            && lhs.accountId == rhs.accountId
+            && lhs.group == rhs.group
+            && lhs.density == rhs.density
+            && lhs.titleOverride == rhs.titleOverride
+            && lhs.showsGroupTitle == rhs.showsGroupTitle
+            && lhs.isEmbedded == rhs.isEmbedded
+    }
 
     @State private var forecastByBucket: [String: [ForecastTimelinePoint]] = [:]
     @State private var seriesByBucket: [String: QuotaHistorySeries] = [:]
@@ -227,25 +201,42 @@ struct QuotaHistoryChartView: View {
 
     var body: some View {
         let buckets = bucketsWithHistory
+        let drawable = buckets.first.flatMap { first in
+            window.flatMap { $0.domainSpan > 0 ? (first, $0) : nil }
+        }
 
-        VStack(alignment: .leading, spacing: density.cardSpacing) {
-            header
-
-            if let first = buckets.first, let window, window.domainSpan > 0 {
-                chartBody(buckets: buckets, primary: first, window: window)
+        Group {
+            if isEmbedded {
+                // Nothing to draw yet: stay silent rather than repeating a
+                // "history builds up" note under every quota scope in the card.
+                // The Reset history strip on the row above already says it.
+                if let drawable {
+                    VStack(alignment: .leading, spacing: 5) {
+                        embeddedHeader
+                        chartBody(buckets: buckets, primary: drawable.0, window: drawable.1)
+                    }
+                    .padding(.top, 5)
+                }
             } else {
-                emptyNote
+                VStack(alignment: .leading, spacing: density.cardSpacing) {
+                    cardHeader
+                    if let drawable {
+                        chartBody(buckets: buckets, primary: drawable.0, window: drawable.1)
+                    } else {
+                        emptyNote
+                    }
+                }
+                .padding(density.cardPadding)
+                .background(
+                    RoundedRectangle(cornerRadius: density.cardCornerRadius, style: .continuous)
+                        .fill(.background.tertiary.opacity(0.6))
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: density.cardCornerRadius, style: .continuous)
+                        .stroke(.separator.opacity(0.4), lineWidth: 0.5)
+                )
             }
         }
-        .padding(density.cardPadding)
-        .background(
-            RoundedRectangle(cornerRadius: density.cardCornerRadius, style: .continuous)
-                .fill(.background.tertiary.opacity(0.6))
-        )
-        .overlay(
-            RoundedRectangle(cornerRadius: density.cardCornerRadius, style: .continuous)
-                .stroke(.separator.opacity(0.4), lineWidth: 0.5)
-        )
         .task(id: forecastLoadKey) {
             await loadForecastPoints()
         }
@@ -256,7 +247,20 @@ struct QuotaHistoryChartView: View {
 
     // MARK: - Header
 
-    private var header: some View {
+    /// Embedded title, styled like the "Reset history" caption directly above
+    /// it — the chart is a continuation of the group's rows, not a new card
+    /// competing with the section heading.
+    private var embeddedHeader: some View {
+        HStack(alignment: .firstTextBaseline, spacing: 8) {
+            Text("Quota history")
+                .font(.system(size: max(9, density.subtitleFontSize - 2), weight: .medium))
+                .foregroundStyle(.tertiary)
+            Spacer(minLength: 8)
+            rangePills
+        }
+    }
+
+    private var cardHeader: some View {
         HStack(alignment: .firstTextBaseline, spacing: 6) {
             VStack(alignment: .leading, spacing: 1) {
                 Text(titleOverride ?? "Quota history")
@@ -273,11 +277,7 @@ struct QuotaHistoryChartView: View {
                 }
             }
             Spacer(minLength: 8)
-            if window != nil, !rangeOptions.isEmpty {
-                pillGroup(rangeOptions) { option in
-                    applyRange(option)
-                }
-            }
+            rangePills
         }
     }
 
@@ -312,6 +312,15 @@ struct QuotaHistoryChartView: View {
         let pacePoints = isSingle
             ? linePoints(primarySeries.pace, kind: "pace", range: visible, limit: limit)
             : []
+        let paceBridges = isSingle
+            ? bridgePoints(
+                primarySeries.pace,
+                time: { $0.time },
+                value: { $0.remainingPercent },
+                kind: "pace",
+                range: visible
+            )
+            : []
         let bandPoints = isSingle
             ? forecastBandPoints(primarySeries.forecast, range: visible, limit: limit)
             : []
@@ -335,6 +344,15 @@ struct QuotaHistoryChartView: View {
                         .foregroundStyle(Color.primary.opacity(0.16))
                         .lineStyle(StrokeStyle(lineWidth: 1, dash: [3, 3]))
                 }
+                ForEach(paceBridges) { point in
+                    LineMark(
+                        x: .value("Time", point.time),
+                        y: .value("Left", point.value),
+                        series: .value("Line", point.seriesKey)
+                    )
+                    .foregroundStyle(Self.paceColor.opacity(QuotaChartMarks.bridgeOpacity))
+                    .lineStyle(QuotaChartMarks.bridgeStroke)
+                }
                 ForEach(pacePoints) { point in
                     LineMark(
                         x: .value("Time", point.time),
@@ -345,6 +363,17 @@ struct QuotaHistoryChartView: View {
                     .lineStyle(StrokeStyle(lineWidth: 1.6, dash: [5, 4]))
                 }
                 ForEach(lines) { line in
+                    ForEach(line.forecastBridges) { point in
+                        LineMark(
+                            x: .value("Time", point.time),
+                            y: .value("Left", point.value),
+                            series: .value("Line", point.seriesKey)
+                        )
+                        .foregroundStyle(line.forecastColor.opacity(QuotaChartMarks.bridgeOpacity))
+                        .lineStyle(QuotaChartMarks.bridgeStroke)
+                    }
+                }
+                ForEach(lines) { line in
                     ForEach(line.forecast) { point in
                         LineMark(
                             x: .value("Time", point.time),
@@ -353,6 +382,17 @@ struct QuotaHistoryChartView: View {
                         )
                         .foregroundStyle(line.forecastColor)
                         .lineStyle(StrokeStyle(lineWidth: 1.8, lineCap: .round, dash: [2, 3.4]))
+                    }
+                }
+                ForEach(lines) { line in
+                    ForEach(line.actualBridges) { point in
+                        LineMark(
+                            x: .value("Time", point.time),
+                            y: .value("Left", point.value),
+                            series: .value("Line", point.seriesKey)
+                        )
+                        .foregroundStyle(line.color.opacity(QuotaChartMarks.bridgeOpacity))
+                        .lineStyle(QuotaChartMarks.bridgeStroke)
                     }
                 }
                 ForEach(lines) { line in
@@ -415,28 +455,48 @@ struct QuotaHistoryChartView: View {
     }
 
     private func miniPath(in geometry: ChartBrushGeometry) -> some View {
-        Path { path in
-            for segment in miniSegments {
-                guard let first = segment.first else { continue }
-                path.move(
-                    to: CGPoint(
-                        x: geometry.x(for: first.time),
-                        y: geometry.y(forFraction: first.remainingPercent / 100)
-                    )
+        ZStack {
+            // Connectors first so the observed line always sits on top of them.
+            miniBridgePath(in: geometry)
+                .stroke(
+                    Self.bucketPalette[0].opacity(0.28),
+                    style: StrokeStyle(lineWidth: 0.7, lineCap: .round)
                 )
-                for sample in segment.dropFirst() {
-                    path.addLine(
-                        to: CGPoint(
-                            x: geometry.x(for: sample.time),
-                            y: geometry.y(forFraction: sample.remainingPercent / 100)
-                        )
-                    )
+            Path { path in
+                for segment in miniSegments {
+                    guard let first = segment.first else { continue }
+                    path.move(to: miniPoint(first, in: geometry))
+                    for sample in segment.dropFirst() {
+                        path.addLine(to: miniPoint(sample, in: geometry))
+                    }
                 }
             }
+            .stroke(
+                Self.bucketPalette[0].opacity(0.75),
+                style: StrokeStyle(lineWidth: 1, lineCap: .round, lineJoin: .round)
+            )
         }
-        .stroke(
-            Self.bucketPalette[0].opacity(0.75),
-            style: StrokeStyle(lineWidth: 1, lineCap: .round, lineJoin: .round)
+    }
+
+    /// Straight hops across the holes in the brush mini. Thin and faint rather
+    /// than dashed — at this scale a dash pattern is just noise.
+    private func miniBridgePath(in geometry: ChartBrushGeometry) -> Path {
+        Path { path in
+            guard miniSegments.count > 1 else { return }
+            for index in 0..<(miniSegments.count - 1) {
+                guard let tail = miniSegments[index].last,
+                      let head = miniSegments[index + 1].first
+                else { continue }
+                path.move(to: miniPoint(tail, in: geometry))
+                path.addLine(to: miniPoint(head, in: geometry))
+            }
+        }
+    }
+
+    private func miniPoint(_ sample: QuotaHistorySample, in geometry: ChartBrushGeometry) -> CGPoint {
+        CGPoint(
+            x: geometry.x(for: sample.time),
+            y: geometry.y(forFraction: sample.remainingPercent / 100)
         )
     }
 
@@ -830,89 +890,25 @@ struct QuotaHistoryChartView: View {
 
     // MARK: - Range pills
 
-    private struct PillOption: Identifiable, Equatable {
-        let id: String
-        let label: String
-        let span: TimeInterval?
-        let isSelected: Bool
-    }
-
-    private static let rangeSpans: [(String, TimeInterval)] = [
-        ("6h", 6 * 3_600),
-        ("24h", 24 * 3_600),
-        ("3d", 3 * 86_400),
-        ("7d", 7 * 86_400)
-    ]
-
-    private var rangeOptions: [PillOption] {
-        guard let window, window.domainSpan > 0 else { return [] }
-        var options = Self.rangeSpans
-            .filter { $0.1 < window.domainSpan }
-            .map { label, span in
-                PillOption(
-                    id: label,
-                    label: label,
-                    span: span,
-                    isSelected: !window.coversDomain
-                        && window.isAtDomainEnd
-                        && abs(window.visibleSpan - span) <= span * 0.03
-                )
-            }
-        options.append(
-            PillOption(id: "all", label: "All", span: nil, isSelected: window.coversDomain)
-        )
-        return options
-    }
-
-    private func applyRange(_ option: PillOption) {
-        guard var current = window else { return }
-        if let span = option.span {
-            current.jump(toSpan: span)
-        } else {
-            current.jump(toSpan: current.domainSpan)
+    /// Preset spans, shared with the Overview chart so both surfaces offer the
+    /// same navigation vocabulary. Rendered only once a window exists.
+    @ViewBuilder
+    private var rangePills: some View {
+        if window != nil {
+            ChartRangePills(
+                window: Binding(
+                    get: { self.window ?? ChartTimeWindow(
+                        domainStart: .distantPast,
+                        domainEnd: .distantPast,
+                        minimumSpan: 0,
+                        visibleSpan: 0
+                    ) },
+                    set: { self.window = $0 }
+                ),
+                fontSize: max(9, density.segmentedFontSize - 2),
+                onSelect: { hoverDate = nil }
+            )
         }
-        window = current
-        hoverDate = nil
-    }
-
-    private func pillGroup(
-        _ options: [PillOption],
-        action: @escaping (PillOption) -> Void
-    ) -> some View {
-        HStack(spacing: 1) {
-            ForEach(options) { option in
-                Button {
-                    action(option)
-                } label: {
-                    Text(option.label)
-                        .font(
-                            .system(
-                                size: max(9, density.segmentedFontSize - 2),
-                                weight: .semibold,
-                                design: .rounded
-                            )
-                        )
-                        .foregroundStyle(option.isSelected ? .primary : .secondary)
-                        .lineLimit(1)
-                        .minimumScaleFactor(0.75)
-                        .padding(.horizontal, 6)
-                        .frame(minHeight: 20)
-                        .contentShape(Rectangle())
-                }
-                .buttonStyle(.plain)
-                .focusable(false)
-                .background {
-                    if option.isSelected {
-                        RoundedRectangle(cornerRadius: 6, style: .continuous)
-                            .fill(Color.primary.opacity(0.12))
-                    }
-                }
-                .accessibilityLabel(option.label)
-            }
-        }
-        .padding(2)
-        .background(RoundedRectangle(cornerRadius: 7).fill(Color.primary.opacity(0.08)))
-        .fixedSize(horizontal: true, vertical: false)
     }
 
     // MARK: - Data selection
@@ -938,9 +934,32 @@ struct QuotaHistoryChartView: View {
     /// Forecast strokes share their bucket's hue, lifted toward white on dark
     /// backgrounds the same way `ForecastQuotaBar` lifts its forecast marker —
     /// a 1.8pt dotted line loses more contrast than a solid one.
+    ///
+    /// Resolved by the *appearance* rather than by reading
+    /// `@Environment(\.colorScheme)`: an environment read is a dependency this
+    /// view would otherwise carry into its `Equatable` contract, and a dynamic
+    /// `NSColor` re-resolves itself at draw time for free. Cached because the
+    /// palette is fixed and building one per mark would not be.
     private func forecastTint(_ base: Color) -> Color {
-        colorScheme == .dark ? base.mix(with: .white, by: 0.16) : base
+        Self.forecastTints[base] ?? base
     }
+
+    private static let forecastTints: [Color: Color] = Dictionary(
+        uniqueKeysWithValues: bucketPalette.map { base in
+            let lifted = NSColor(base.mix(with: .white, by: 0.16))
+            let plain = NSColor(base)
+            return (
+                base,
+                Color(
+                    nsColor: NSColor(name: nil) { appearance in
+                        appearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua
+                            ? lifted
+                            : plain
+                    }
+                )
+            )
+        }
+    )
 
     private func fillPoints(bucketId: String) -> [FillTimelinePoint] {
         let key = SubscriptionHistoryKey(accountId: accountId, bucketId: bucketId)
@@ -1124,14 +1143,38 @@ struct QuotaHistoryChartView: View {
                     range: range,
                     limit: limit
                 ),
+                actualBridges: bridgePoints(
+                    series.actual,
+                    time: { $0.time },
+                    value: { $0.remainingPercent },
+                    kind: "actual-\(index)",
+                    range: range
+                ),
                 forecast: forecastLinePoints(
                     series.forecast,
                     kind: "forecast-\(index)",
                     range: range,
                     limit: limit
+                ),
+                forecastBridges: bridgePoints(
+                    series.forecast,
+                    time: { $0.time },
+                    value: { $0.remainingPercent },
+                    kind: "forecast-\(index)",
+                    range: range
                 )
             )
         }
+    }
+
+    private func bridgePoints<Element>(
+        _ segments: [[Element]],
+        time: (Element) -> Date,
+        value: (Element) -> Double,
+        kind: String,
+        range: ClosedRange<Date>
+    ) -> [QuotaChartLinePoint] {
+        QuotaChartMarks.bridges(segments, kind: kind, range: range, time: time, value: value)
     }
 
     private func linePoints(
@@ -1139,25 +1182,15 @@ struct QuotaHistoryChartView: View {
         kind: String,
         range: ClosedRange<Date>,
         limit: Int
-    ) -> [QuotaLinePoint] {
-        var result: [QuotaLinePoint] = []
-        for (index, segment) in segments.enumerated() {
-            let clipped = clip(segment, time: { $0.time }, to: range)
-            guard clipped.count > 0 else { continue }
-            let thinned = ChartSeriesThinning.strided(clipped, limit: limit)
-            let key = "\(kind)-\(index)"
-            for (offset, sample) in thinned.enumerated() {
-                result.append(
-                    QuotaLinePoint(
-                        id: "\(key)-\(offset)",
-                        seriesKey: key,
-                        time: sample.time,
-                        value: sample.remainingPercent
-                    )
-                )
-            }
-        }
-        return result
+    ) -> [QuotaChartLinePoint] {
+        QuotaChartMarks.points(
+            segments,
+            kind: kind,
+            range: range,
+            limit: limit,
+            time: { $0.time },
+            value: { $0.remainingPercent }
+        )
     }
 
     private func forecastLinePoints(
@@ -1165,25 +1198,15 @@ struct QuotaHistoryChartView: View {
         kind: String,
         range: ClosedRange<Date>,
         limit: Int
-    ) -> [QuotaLinePoint] {
-        var result: [QuotaLinePoint] = []
-        for (index, segment) in segments.enumerated() {
-            let clipped = clip(segment, time: { $0.time }, to: range)
-            guard clipped.count > 0 else { continue }
-            let thinned = ChartSeriesThinning.strided(clipped, limit: limit)
-            let key = "\(kind)-\(index)"
-            for (offset, sample) in thinned.enumerated() {
-                result.append(
-                    QuotaLinePoint(
-                        id: "\(key)-\(offset)",
-                        seriesKey: key,
-                        time: sample.time,
-                        value: sample.remainingPercent
-                    )
-                )
-            }
-        }
-        return result
+    ) -> [QuotaChartLinePoint] {
+        QuotaChartMarks.points(
+            segments,
+            kind: kind,
+            range: range,
+            limit: limit,
+            time: { $0.time },
+            value: { $0.remainingPercent }
+        )
     }
 
     private func forecastBandPoints(
@@ -1193,7 +1216,7 @@ struct QuotaHistoryChartView: View {
     ) -> [QuotaBandPoint] {
         var result: [QuotaBandPoint] = []
         for (index, segment) in segments.enumerated() {
-            let clipped = clip(segment, time: { $0.time }, to: range)
+            let clipped = QuotaChartMarks.clip(segment, time: { $0.time }, to: range)
             guard clipped.count > 1 else { continue }
             let thinned = ChartSeriesThinning.strided(clipped, limit: limit)
             let key = "band-\(index)"
@@ -1212,38 +1235,24 @@ struct QuotaHistoryChartView: View {
         return result
     }
 
-    /// Keep one sample beyond each edge so a line entering the window starts at
-    /// the frame border instead of at its first visible observation.
-    private func clip<Element>(
-        _ segment: [Element],
-        time: (Element) -> Date,
-        to range: ClosedRange<Date>
-    ) -> [Element] {
-        guard !segment.isEmpty else { return [] }
-        var first: Int?
-        var last: Int?
-        for (index, element) in segment.enumerated() {
-            let stamp = time(element)
-            if stamp >= range.lowerBound, stamp <= range.upperBound {
-                if first == nil { first = index }
-                last = index
-            }
-        }
-        guard let first, let last else { return [] }
-        let lower = max(0, first - 1)
-        let upper = min(segment.count - 1, last + 1)
-        return Array(segment[lower...upper])
-    }
-
     // MARK: - Current values
 
     private func currentRemainingLabel(bucket: QuotaBucket) -> String {
         percent(max(0, 100 - bucket.usedPercent))
     }
 
+    /// The newest *recorded* pace reading rather than one computed against the
+    /// wall clock.
+    ///
+    /// Two reasons, and the second is the load-bearing one. It matches the end
+    /// of the pace line the reader is looking at instead of a value a few
+    /// minutes ahead of it — and it keeps this view free of `Date()`, which is
+    /// what lets `.equatable()` skip the 30-second `TimelineView` tick the
+    /// utilization card ticks on. The live wall-clock pace is already on the
+    /// row directly above.
     private func currentPaceLabel(bucket: QuotaBucket) -> String? {
-        guard let pace = UsagePace.compute(bucket: bucket, now: Date()) else { return nil }
-        return percent(max(0, 100 - pace.expectedUsedPercent))
+        guard let last = (seriesByBucket[bucket.id] ?? .empty).pace.last?.last else { return nil }
+        return percent(last.remainingPercent)
     }
 
     /// The newest *recorded* projection rather than a freshly computed one:

--- a/Sources/VibeBarApp/Views/SubscriptionUtilizationView.swift
+++ b/Sources/VibeBarApp/Views/SubscriptionUtilizationView.swift
@@ -79,6 +79,22 @@ struct SubscriptionUtilizationView: View {
         let startsSection: Bool
         let groupTitle: String?
         let startsGroup: Bool
+        /// Set on the last row of a quota group. The group's history chart is
+        /// drawn here, so it lands exactly where the group visually ends —
+        /// "all models" under the all-models rows, Spark under Spark's — the
+        /// same way each row's Reset history strip sits under its own bar.
+        let endsGroup: Bool
+        /// Every bucket sharing this row's heading, in provider order. Only
+        /// populated on the row that ends the group; that is the one that
+        /// draws them.
+        let groupBuckets: [QuotaBucket]
+
+        /// Identity of the group's chart. Account- and tool-scoped and
+        /// `nil`-safe, because the ungrouped run is a group here even though it
+        /// prints no heading.
+        var groupKey: String {
+            QuotaBucketGrouping.key(accountId: accountId, itemTool: tool, title: groupTitle)
+        }
     }
 
     /// Keep live utilization and reset-cycle history on the same complete
@@ -104,9 +120,21 @@ struct SubscriptionUtilizationView: View {
         let additional = additionalQuotaSeries.map {
             RawBucket(id: $0.id, tool: $0.tool, accountId: $0.accountId, bucket: $0.bucket)
         }
+        let raw = primary + additional
+        // Chart groups are runs of adjacent rows sharing a heading — the same
+        // contiguity the heading logic below already assumes. Resolved up front
+        // so the row that *ends* a run can be identified, which is where the
+        // group's history chart goes.
+        let chartKeys = raw.map {
+            QuotaBucketGrouping.key(
+                accountId: $0.accountId,
+                itemTool: $0.tool,
+                title: quotaGroupTitle(for: $0.tool, bucket: $0.bucket)
+            )
+        }
         var previousSectionKey: String?
         var previousGroupKey: String?
-        return (primary + additional).map { item in
+        return raw.enumerated().map { index, item in
             let sectionTitle = linkedSectionTitle(for: item.tool)
             let sectionKey = sectionTitle.map { "\(item.tool.rawValue):\($0)" }
             let startsSection = sectionKey != nil && sectionKey != previousSectionKey
@@ -118,6 +146,8 @@ struct SubscriptionUtilizationView: View {
             let groupKey = groupTitle.map { "\(item.tool.rawValue):\($0)" }
             let startsGroup = groupKey != nil && groupKey != previousGroupKey
             if groupKey != nil { previousGroupKey = groupKey }
+            let chartKey = chartKeys[index]
+            let endsGroup = index == raw.count - 1 || chartKeys[index + 1] != chartKey
             return UtilizationBucket(
                 id: item.id,
                 tool: item.tool,
@@ -126,7 +156,11 @@ struct SubscriptionUtilizationView: View {
                 sectionTitle: sectionTitle,
                 startsSection: startsSection,
                 groupTitle: groupTitle,
-                startsGroup: startsGroup
+                startsGroup: startsGroup,
+                endsGroup: endsGroup,
+                groupBuckets: endsGroup
+                    ? zip(raw, chartKeys).filter { $0.1 == chartKey }.map(\.0.bucket)
+                    : []
             )
         }
     }
@@ -236,6 +270,26 @@ struct SubscriptionUtilizationView: View {
             }
             if let forecast {
                 forecastExplanation(itemID: item.id, forecast: forecast, pace: pace)
+            }
+            if item.endsGroup, let accountId = item.accountId, !item.groupBuckets.isEmpty {
+                // `.equatable()` is load-bearing, not an optimisation: this
+                // card is re-proposed every 30 seconds by the `TimelineView`
+                // the rows above need for their countdowns, and the chart
+                // reads no clock of its own. Without it every tick would
+                // re-segment and re-thin thousands of marks — and could land
+                // mid-pan.
+                QuotaHistoryChartView(
+                    tool: item.tool,
+                    accountId: accountId,
+                    group: QuotaBucketGroup(
+                        id: item.groupKey,
+                        title: item.groupTitle,
+                        buckets: item.groupBuckets
+                    ),
+                    density: density,
+                    isEmbedded: true
+                )
+                .equatable()
             }
         }
     }

--- a/Sources/VibeBarApp/Views/Theme.swift
+++ b/Sources/VibeBarApp/Views/Theme.swift
@@ -15,7 +15,11 @@ enum Theme {
     /// One profile drives the full tabbed workspace. The semantic tokens below
     /// deliberately change layout, chart presence, and information rhythm —
     /// not just every number by the same scale factor.
-    struct Density {
+    /// `Equatable` so views that are expensive to rebuild can be wrapped in
+    /// `.equatable()` and skip a parent-driven update that changed nothing —
+    /// notably the quota history chart, which lives inside a `TimelineView`
+    /// that re-proposes it every 30 seconds.
+    struct Density: Equatable {
         let profile: PopoverDensity
         let popoverPaddingH: CGFloat
         let popoverPaddingV: CGFloat
@@ -74,6 +78,17 @@ enum Theme {
             case .compact: 140
             case .regular: 172
             case .spacious: 210
+            }
+        }
+
+        /// Main plot height for the all-providers quota history chart on the
+        /// Overview. Taller than the per-group chart: it carries every
+        /// provider's curves at once and sits in a wider Overview column.
+        var overviewQuotaHistoryChartHeight: CGFloat {
+            switch profile {
+            case .compact: 172
+            case .regular: 206
+            case .spacious: 248
             }
         }
 
@@ -264,6 +279,41 @@ enum Theme {
             bucketBarHeight: base.bucketBarHeight,
             segmentedFontSize: base.segmentedFontSize
         )
+    }
+
+    /// Brand accent per provider — the hue that identifies a tool wherever a
+    /// surface has to tell providers apart by colour rather than by name.
+    ///
+    /// One table, because a provider that is teal in the mini window and green
+    /// in a chart is two providers as far as the reader is concerned.
+    static func providerAccent(for tool: ToolType) -> Color {
+        switch tool {
+        case .codex:       return Color(red: 0.30, green: 0.78, blue: 0.74)  // teal
+        case .claude:      return Color(red: 0.93, green: 0.40, blue: 0.40)  // coral
+        case .alibaba:     return Color(red: 1.00, green: 0.62, blue: 0.20)  // amber
+        case .alibabaTokenPlan: return Color(red: 1.00, green: 0.48, blue: 0.18)  // deeper amber
+        case .gemini:      return Color(red: 0.34, green: 0.62, blue: 0.96)  // google blue
+        case .antigravity: return Color(red: 0.55, green: 0.40, blue: 0.92)  // violet
+        case .grok:        return Color(red: 0.18, green: 0.18, blue: 0.18)  // xAI near-black
+        case .copilot:     return Color(red: 0.46, green: 0.46, blue: 0.46)  // graphite
+        case .zai:         return Color(red: 0.26, green: 0.74, blue: 0.55)  // emerald
+        case .minimax:     return Color(red: 0.97, green: 0.30, blue: 0.45)  // pink
+        case .kimi:        return Color(red: 0.20, green: 0.20, blue: 0.20)  // ink
+        case .cursor:      return Color(red: 0.55, green: 0.55, blue: 0.96)  // periwinkle
+        case .mimo:        return Color(red: 0.97, green: 0.50, blue: 0.20)  // xiaomi orange
+        case .iflytek:     return Color(red: 0.10, green: 0.37, blue: 0.75)  // iflytek blue
+        case .tencentHunyuan:   return Color(red: 0.00, green: 0.49, blue: 0.91)  // tencent blue
+        case .tencentTokenPlan: return Color(red: 0.18, green: 0.62, blue: 0.96)  // tencent token blue
+        case .volcengine:  return Color(red: 0.92, green: 0.30, blue: 0.30)  // doubao red
+        case .volcengineAgentPlan: return Color(red: 0.96, green: 0.45, blue: 0.22)  // doubao agent amber
+        case .baiduQianfan: return Color(red: 0.16, green: 0.40, blue: 0.93)  // baidu blue
+        case .openCodeGo:  return Color(red: 0.22, green: 0.66, blue: 0.50)  // green
+        case .kilo:        return Color(red: 0.47, green: 0.37, blue: 0.93)  // purple
+        case .kiro:        return Color(red: 0.24, green: 0.48, blue: 0.94)  // blue
+        case .ollama:      return Color(red: 0.18, green: 0.18, blue: 0.18)  // graphite
+        case .openRouter:  return Color(red: 0.98, green: 0.62, blue: 0.16)  // orange
+        case .warp:        return Color(red: 0.58, green: 0.55, blue: 0.71)  // warp violet-grey
+        }
     }
 
     static func barColor(percent: Double, mode: DisplayMode) -> Color {

--- a/Sources/VibeBarCore/Models/AppSettings.swift
+++ b/Sources/VibeBarCore/Models/AppSettings.swift
@@ -47,6 +47,15 @@ public struct AppSettings: Codable, Equatable, Sendable {
     public var miscProviderInstances: [MiscProviderInstance]
     public var costData: CostDataSettings
 
+    /// Curves the user switched **off** in the Overview's all-providers quota
+    /// history chart, as `"<tool>|<accountId>|<bucketId>"`.
+    ///
+    /// Hidden rather than visible on purpose: the default is "show everything",
+    /// so an empty set is the correct starting state, no migration is needed,
+    /// and a quota that only starts being recorded next week shows up on its
+    /// own instead of being invisible until the user goes looking for it.
+    public var overviewQuotaHistoryHiddenCurveIds: Set<String>
+
     public static let `default` = AppSettings(
         displayMode: .remaining,
         refreshIntervalSeconds: 600,
@@ -165,7 +174,8 @@ public struct AppSettings: Codable, Equatable, Sendable {
         visibleMiscProviders: Set<ToolType> = AppSettings.defaultVisibleMiscProviders,
         miscProviderOrder: [ToolType] = AppSettings.defaultMiscProviderOrder,
         miscProviderInstances: [MiscProviderInstance]? = nil,
-        costData: CostDataSettings = .default
+        costData: CostDataSettings = .default,
+        overviewQuotaHistoryHiddenCurveIds: Set<String> = []
     ) {
         self.displayMode = displayMode
         self.refreshIntervalSeconds = refreshIntervalSeconds
@@ -198,6 +208,7 @@ public struct AppSettings: Codable, Equatable, Sendable {
         self.visibleMiscProviders = Self.legacyVisibleMiscProviders(from: self.miscProviderInstances)
         self.miscProviderOrder = Self.legacyMiscProviderOrder(from: self.miscProviderInstances)
         self.costData = costData
+        self.overviewQuotaHistoryHiddenCurveIds = overviewQuotaHistoryHiddenCurveIds
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -225,6 +236,7 @@ public struct AppSettings: Codable, Equatable, Sendable {
         case miscProviderOrder
         case miscProviderInstances
         case costData
+        case overviewQuotaHistoryHiddenCurveIds
     }
 
     public init(from decoder: Decoder) throws {
@@ -351,6 +363,8 @@ public struct AppSettings: Codable, Equatable, Sendable {
         self.miscProviderOrder = Self.legacyMiscProviderOrder(from: self.miscProviderInstances)
 
         self.costData = try c.decodeIfPresent(CostDataSettings.self, forKey: .costData) ?? .default
+        self.overviewQuotaHistoryHiddenCurveIds =
+            try c.decodeIfPresent(Set<String>.self, forKey: .overviewQuotaHistoryHiddenCurveIds) ?? []
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -387,6 +401,7 @@ public struct AppSettings: Codable, Equatable, Sendable {
         try c.encode(miscProviderOrder.map(\.rawValue), forKey: .miscProviderOrder)
         try c.encode(miscProviderInstances, forKey: .miscProviderInstances)
         try c.encode(costData, forKey: .costData)
+        try c.encode(overviewQuotaHistoryHiddenCurveIds, forKey: .overviewQuotaHistoryHiddenCurveIds)
     }
 
     public func menuBarItem(_ kind: MenuBarItemKind) -> MenuBarItemSettings {

--- a/Sources/VibeBarCore/Models/ChartSeriesPlanning.swift
+++ b/Sources/VibeBarCore/Models/ChartSeriesPlanning.swift
@@ -1,0 +1,180 @@
+import Foundation
+
+/// Uniform-stride thinning for brush minis and zoomed-out main charts.
+///
+/// Purely a drawing concern — the series itself keeps every observation, this
+/// only decides how many of them are worth turning into marks at the current
+/// scale. Both endpoints always survive: the first because slot 0 maps to index
+/// 0, the last because the final slot maps to the final index. That matters
+/// beyond aesthetics — a segment's endpoints are what the gap-bridging
+/// connectors are anchored to.
+public enum ChartSeriesThinning {
+    public static func strided<Element>(_ elements: [Element], limit: Int) -> [Element] {
+        guard limit > 1, elements.count > limit else { return elements }
+        let step = Double(elements.count - 1) / Double(limit - 1)
+        var result: [Element] = []
+        result.reserveCapacity(limit)
+        var lastIndex = -1
+        for slot in 0..<limit {
+            let index = min(elements.count - 1, Int((Double(slot) * step).rounded()))
+            if index != lastIndex {
+                result.append(elements[index])
+                lastIndex = index
+            }
+        }
+        // The newest sample carries the "where are we now" reading, so never
+        // let rounding drop it.
+        if lastIndex != elements.count - 1 {
+            result.append(elements[elements.count - 1])
+        }
+        return result
+    }
+}
+
+/// Splitting one curve's mark budget across the segments it is drawn in.
+///
+/// A quota history curve is not one array but a run of segments — one per
+/// window, per coverage gap. Thinning each segment to the curve's budget
+/// independently means the budget is really `segmentCount × budget`, and it is
+/// worse than it sounds: a five-hour quota's segments are individually *small*
+/// (a window's worth of five-minute slots), so each one sits under the limit
+/// and is never thinned at all. Zoomed out over months of history that is tens
+/// of thousands of marks for a single curve, and Swift Charts lays out every
+/// one of them on the main thread.
+///
+/// So the budget is allocated first, then spent: each segment gets a share
+/// proportional to how much of the curve it actually is, and only then is it
+/// thinned to that share.
+public enum ChartMarkBudget {
+    /// Fewest points a segment may be reduced to.
+    ///
+    /// Two, because a line needs two points — and because the two that survive
+    /// striding are the segment's endpoints, which are exactly the points the
+    /// bridging connectors between segments attach to. Thinning must never be
+    /// able to detach a bridge from the data it bridges.
+    public static let minimumSegmentPoints = 2
+
+    /// How many points each segment may keep, given the whole curve's budget.
+    ///
+    /// Returns the inputs unchanged when the curve already fits — thinning a
+    /// series that does not need it only costs fidelity.
+    ///
+    /// When the floors alone exceed the budget (a curve shattered into hundreds
+    /// of tiny segments) the floors win and the result is deliberately over
+    /// budget: dropping segments entirely would delete evidence, and two marks
+    /// per segment is already the cheapest honest rendering of it.
+    public static func allocate(segmentCounts: [Int], budget: Int) -> [Int] {
+        let counts = segmentCounts.map { max(0, $0) }
+        guard budget > 0 else { return counts }
+        let total = counts.reduce(0, +)
+        guard total > budget else { return counts }
+
+        let floors = counts.map { min($0, minimumSegmentPoints) }
+        let floorTotal = floors.reduce(0, +)
+        guard floorTotal < budget else { return floors }
+
+        var allowance = floors
+        let excess = zip(counts, floors).map { $0 - $1 }
+        let excessTotal = excess.reduce(0, +)
+        guard excessTotal > 0 else { return allowance }
+
+        // Proportional share of what is left after the floors, rounded down so
+        // the budget can never be overshot here…
+        let spare = budget - floorTotal
+        var remainders: [(index: Int, fraction: Double)] = []
+        for index in counts.indices where excess[index] > 0 {
+            let exact = Double(spare) * Double(excess[index]) / Double(excessTotal)
+            let whole = min(excess[index], Int(exact.rounded(.down)))
+            allowance[index] += whole
+            remainders.append((index, exact - Double(whole)))
+        }
+
+        // …and the rounding crumbs handed out by largest remainder, so the
+        // budget is spent exactly instead of quietly drifting below it.
+        var leftover = budget - allowance.reduce(0, +)
+        if leftover > 0 {
+            for (index, _) in remainders.sorted(by: { $0.fraction > $1.fraction }) {
+                guard leftover > 0 else { break }
+                guard allowance[index] < counts[index] else { continue }
+                allowance[index] += 1
+                leftover -= 1
+            }
+        }
+        // Segments that hit their own size can refuse a crumb; give what is
+        // still unspent to the densest segments that have room, since they are
+        // the ones losing the most detail.
+        if leftover > 0 {
+            for index in counts.indices.sorted(by: { counts[$0] > counts[$1] }) {
+                guard leftover > 0 else { break }
+                let room = counts[index] - allowance[index]
+                guard room > 0 else { continue }
+                let take = min(room, leftover)
+                allowance[index] += take
+                leftover -= take
+            }
+        }
+        return allowance
+    }
+
+    /// Allocate and spend in one step: the segments a curve draws, thinned so
+    /// the whole curve stays inside `budget`.
+    public static func thinned<Element>(
+        _ segments: [[Element]],
+        budget: Int
+    ) -> [[Element]] {
+        let allowance = allocate(segmentCounts: segments.map(\.count), budget: budget)
+        return zip(segments, allowance).map { segment, limit in
+            ChartSeriesThinning.strided(segment, limit: limit)
+        }
+    }
+}
+
+/// Finding the observation nearest a point in time.
+///
+/// The charts resolve a hover by asking every curve "what did you read here?".
+/// Scanning each curve's samples makes that O(total samples) *per pointer
+/// move* — with unlimited retention and five-minute slots, hundreds of
+/// thousands of comparisons on the main thread every time the mouse twitches.
+/// The samples are already time-sorted, so a binary search answers the same
+/// question in O(log n).
+public enum ChartSampleSearch {
+    /// Nearest element to `target`, or `nil` when the closest one is farther
+    /// away than `tolerance`.
+    ///
+    /// `sorted` must be ascending by `time`. A gap wider than the tolerance
+    /// returns nothing on purpose: the absence of coverage is information, and
+    /// bridging it to whichever sample happens to be nearest would invent a
+    /// reading that was never taken.
+    public static func nearest<Element>(
+        in sorted: [Element],
+        to target: Date,
+        tolerance: TimeInterval,
+        time: (Element) -> Date
+    ) -> Element? {
+        guard !sorted.isEmpty, tolerance >= 0 else { return nil }
+        // First index at or after `target`.
+        var low = 0
+        var high = sorted.count
+        while low < high {
+            let mid = low + (high - low) / 2
+            if time(sorted[mid]) < target {
+                low = mid + 1
+            } else {
+                high = mid
+            }
+        }
+        var best: Element?
+        var bestDistance = tolerance
+        for index in [low - 1, low] where index >= 0 && index < sorted.count {
+            let distance = abs(time(sorted[index]).timeIntervalSince(target))
+            // Strictly-better after the first candidate, so a cursor sitting
+            // exactly between two samples resolves to the earlier one — the
+            // reading that had actually been taken at that moment — instead of
+            // flickering with floating-point noise.
+            guard distance <= bestDistance, best == nil || distance < bestDistance else { continue }
+            best = sorted[index]
+            bestDistance = distance
+        }
+        return best
+    }
+}

--- a/Sources/VibeBarCore/Models/CostChartGranularity.swift
+++ b/Sources/VibeBarCore/Models/CostChartGranularity.swift
@@ -38,16 +38,24 @@ public enum CostChartGranularity: String, CaseIterable, Sendable, Identifiable {
 
     /// What "Auto" resolves to for a visible span.
     ///
-    /// Thresholds are picked so each mode lands at a readable bar count: about
-    /// 62 hourly bars at the top of the hour range, about 110 daily bars at the
-    /// top of the day range, about 60 weekly bars at the top of the week range,
-    /// and months beyond that — a multi-year domain is a shape, not a series of
-    /// individual weeks.
+    /// The ladder is chosen by how many bars a mode would leave on screen, not
+    /// by how many it *could* draw:
+    ///
+    /// - **≤ 5 days → hour.** Fewer than about six daily bars is a sparse
+    ///   chart: three or four slabs floating in a wide plot. The same span
+    ///   carries 24–120 hourly points, which is where a cost chart actually
+    ///   shows the shape of a working day.
+    /// - **≤ 110 days → day.** The everyday range; 110 daily bars is about as
+    ///   dense as this card can draw before bars stop being comparable.
+    /// - **≤ 240 days → week.** Roughly 16 to 34 weekly bars.
+    /// - **beyond → month.** Eight months is already 34+ weeks; past that the
+    ///   domain is a shape, not a series of individual weeks. A ten-month
+    ///   "All" domain lands here.
     public static func resolve(autoFor visibleSpan: TimeInterval) -> CostChartGranularity {
         let days = max(0, visibleSpan) / dayInterval
-        if days <= 2.6 { return .hour }
+        if days <= 5 { return .hour }
         if days <= 110 { return .day }
-        if days <= 420 { return .week }
+        if days <= 240 { return .week }
         return .month
     }
 
@@ -57,6 +65,10 @@ public enum CostChartGranularity: String, CaseIterable, Sendable, Identifiable {
     /// bars; weekly only appears once there are enough weeks to compare, and
     /// monthly once there are at least two full months. Daily is always offered
     /// so the control never collapses to nothing.
+    ///
+    /// The hour unlock stays wider than the Auto threshold on purpose: Auto
+    /// stops reaching for hours at five days, but a user who wants to compare a
+    /// full week hour-by-hour can still ask for it.
     ///
     /// Weekly waits for four whole weeks rather than three: at three weeks the
     /// chart draws three or four slabs, which reads as a bar chart of nothing.

--- a/Sources/VibeBarCore/Models/CostChartWindowPolicy.swift
+++ b/Sources/VibeBarCore/Models/CostChartWindowPolicy.swift
@@ -9,6 +9,28 @@ import Foundation
 public enum CostChartWindowPolicy {
     private static let dayInterval: TimeInterval = 86_400
 
+    /// How many local days of per-hour cost buckets the scanner keeps.
+    ///
+    /// Auto granularity reaches for hours at five days and under, and the user
+    /// can ask for hours across a whole week, so retaining only yesterday and
+    /// today would make Hour mode fall back to Day for almost every span that
+    /// wants it. Fourteen days covers both, plus a week of panning behind the
+    /// newest edge, at 14 × 24 = 336 buckets per tool — small next to the
+    /// per-day series the same snapshot already carries.
+    public static let hourlyRetentionDays = 14
+
+    /// Midnight on the oldest day whose per-hour buckets are still retained at
+    /// `now` — the start of the `hourlyRetentionDays`-long window ending with
+    /// today.
+    public static func hourlyRetentionStart(
+        now: Date = Date(),
+        calendar: Calendar = .current
+    ) -> Date {
+        let today = calendar.startOfDay(for: now)
+        return calendar.date(byAdding: .day, value: -(hourlyRetentionDays - 1), to: today)
+            ?? today.addingTimeInterval(-Double(hourlyRetentionDays - 1) * dayInterval)
+    }
+
     /// Does a bucket starting at `start` and `width` seconds wide occupy any
     /// visible time inside `range`?
     ///
@@ -47,26 +69,19 @@ public enum CostChartWindowPolicy {
         return end.timeIntervalSince(start)
     }
 
-    /// Calendar bounds of the Yesterday preset — the one preset not anchored
-    /// at the newest edge.
-    public static func yesterdayBounds(
-        now: Date = Date(),
-        calendar: Calendar = .current
-    ) -> (start: Date, end: Date) {
-        let today = calendar.startOfDay(for: now)
-        let start = calendar.date(byAdding: .day, value: -1, to: today)
-            ?? today.addingTimeInterval(-dayInterval)
-        return (start, today)
-    }
-
-    /// Whole-day stretch the hourly cost lane retains, from the oldest and
-    /// newest hourly buckets on hand.
+    /// Whole-day stretch the hourly cost lane retains.
     ///
-    /// The scanner keeps per-hour buckets for yesterday and today only. Inside
-    /// a retained day an hour with no bucket means nothing was spent, not that
-    /// evidence is missing — so coverage is reported as whole days rather than
-    /// as the extent of the points themselves. Otherwise Today would read as
-    /// "not covered" for every hour after the last one that saw usage.
+    /// `firstHour` is the oldest retained instant — `hourlyRetentionStart` when
+    /// the snapshot reports one, otherwise the oldest bucket on hand — and
+    /// `lastHour` is the newest bucket the scan produced. Inside a retained day
+    /// an hour with no bucket means nothing was spent, not that evidence is
+    /// missing, so coverage is reported as whole days rather than as the extent
+    /// of the points themselves. Otherwise Today would read as "not covered"
+    /// for every hour after the last one that saw usage, and an idle Tuesday
+    /// would punch a hole in a week that was fully scanned.
+    ///
+    /// Returns `nil` when the newest bucket predates the retention start —
+    /// a snapshot that stale has nothing left inside the window.
     public static func hourlyCoverage(
         firstHour: Date?,
         lastHour: Date?,

--- a/Sources/VibeBarCore/Models/CostSnapshot.swift
+++ b/Sources/VibeBarCore/Models/CostSnapshot.swift
@@ -36,6 +36,25 @@ public struct CostSnapshot: Sendable, Equatable, Codable {
     /// Per-hour series for the previous local day. Kept separately so the
     /// Yesterday range can retain the same line-chart detail as Today.
     public let yesterdayHourlyHistory: [HourlyCostPoint]
+    /// Per-hour series across the whole retained hourly window
+    /// (`CostChartWindowPolicy.hourlyRetentionDays` local days ending today),
+    /// ordered ascending.
+    ///
+    /// A **superset** of `todayHourlyHistory` and `yesterdayHourlyHistory`, not
+    /// a complement — never sum it with either. Days with no activity at all
+    /// are simply absent; `hourlyCoverageStart` is what says they were scanned
+    /// and found empty rather than never retained.
+    ///
+    /// Empty on snapshots written before the window widened, which is why the
+    /// chart still falls back to yesterday + today.
+    public let recentHourlyHistory: [HourlyCostPoint]
+    /// Midnight of the oldest day this snapshot has per-hour evidence for.
+    ///
+    /// Distinct from `recentHourlyHistory.first?.date`: an idle day inside the
+    /// window has no buckets but *is* covered — nothing was spent. `nil` on
+    /// snapshots written before the field existed, where the honest fallback is
+    /// to trust only the days that actually carry buckets.
+    public let hourlyCoverageStart: Date?
     /// 7×24 cells: weekday (1-7, Sunday=1) × hour (0-23) → token total.
     public let heatmap: UsageHeatmap
     /// Top models in the all-time window.
@@ -83,6 +102,8 @@ public struct CostSnapshot: Sendable, Equatable, Codable {
         dailyHistory: [DailyCostPoint],
         todayHourlyHistory: [HourlyCostPoint] = [],
         yesterdayHourlyHistory: [HourlyCostPoint] = [],
+        recentHourlyHistory: [HourlyCostPoint] = [],
+        hourlyCoverageStart: Date? = nil,
         heatmap: UsageHeatmap,
         modelBreakdowns: [ModelBreakdown],
         last7DaysModelBreakdowns: [ModelBreakdown] = [],
@@ -107,6 +128,8 @@ public struct CostSnapshot: Sendable, Equatable, Codable {
         self.dailyHistory = dailyHistory
         self.todayHourlyHistory = todayHourlyHistory
         self.yesterdayHourlyHistory = yesterdayHourlyHistory
+        self.recentHourlyHistory = recentHourlyHistory
+        self.hourlyCoverageStart = hourlyCoverageStart
         self.heatmap = heatmap
         self.modelBreakdowns = modelBreakdowns
         self.last7DaysModelBreakdowns = last7DaysModelBreakdowns
@@ -167,6 +190,16 @@ public struct CostSnapshot: Sendable, Equatable, Codable {
         let hourlyYesterday = yesterdayHourlyHistory.filter {
             calendar.isDate($0.date, inSameDayAs: yesterday)
         }
+        // The wide hourly lane is a rolling window, so it ages by dropping its
+        // oldest days rather than by being emptied: a snapshot cached two days
+        // ago still describes those two days correctly, it just no longer
+        // reaches as far back. Buckets dated past today are clock skew and go.
+        let hourlyWindowStart = CostChartWindowPolicy.hourlyRetentionStart(now: now, calendar: calendar)
+        let tomorrow = calendar.date(byAdding: .day, value: 1, to: today) ?? today
+        let hourlyRecent = recentHourlyHistory.filter {
+            $0.date >= hourlyWindowStart && $0.date < tomorrow
+        }
+        let coverageStart = hourlyCoverageStart.map { max($0, hourlyWindowStart) }
 
         // Request counts have no daily history — they pass through
         // verbatim except for the today bucket, which we zero out
@@ -190,6 +223,8 @@ public struct CostSnapshot: Sendable, Equatable, Codable {
             dailyHistory: dailyHistory,
             todayHourlyHistory: hourlyToday,
             yesterdayHourlyHistory: hourlyYesterday,
+            recentHourlyHistory: hourlyRecent,
+            hourlyCoverageStart: coverageStart,
             heatmap: heatmap,
             modelBreakdowns: modelBreakdowns,
             last7DaysModelBreakdowns: last7DaysModelBreakdowns,
@@ -226,6 +261,7 @@ public struct CostSnapshot: Sendable, Equatable, Codable {
         case todayTokens, last7DaysTokens, last30DaysTokens, allTimeTokens
         case todayRequests, last7DaysRequests, last30DaysRequests, allTimeRequests
         case dailyHistory, todayHourlyHistory, yesterdayHourlyHistory, heatmap, modelBreakdowns, last7DaysModelBreakdowns
+        case recentHourlyHistory, hourlyCoverageStart
         case dailyModelBreakdown, hourlyModelBreakdown
         case jsonlFilesFound, updatedAt
     }
@@ -257,6 +293,16 @@ public struct CostSnapshot: Sendable, Equatable, Codable {
         self.dailyHistory = try c.decode([DailyCostPoint].self, forKey: .dailyHistory)
         self.todayHourlyHistory = try c.decodeIfPresent([HourlyCostPoint].self, forKey: .todayHourlyHistory) ?? []
         self.yesterdayHourlyHistory = try c.decodeIfPresent([HourlyCostPoint].self, forKey: .yesterdayHourlyHistory) ?? []
+        // Absent on snapshots cached before the hourly window widened. Empty /
+        // `nil` is the honest reading of those: the chart falls back to the two
+        // days it can prove, and the next scan fills the rest in. Wiping the
+        // cache instead would only trade a few seconds of narrower hourly range
+        // for a popover with no numbers at all on launch.
+        self.recentHourlyHistory = try c.decodeIfPresent(
+            [HourlyCostPoint].self,
+            forKey: .recentHourlyHistory
+        ) ?? []
+        self.hourlyCoverageStart = try c.decodeIfPresent(Date.self, forKey: .hourlyCoverageStart)
         self.heatmap = try c.decode(UsageHeatmap.self, forKey: .heatmap)
         self.modelBreakdowns = try c.decode([ModelBreakdown].self, forKey: .modelBreakdowns)
         self.last7DaysModelBreakdowns = try c.decodeIfPresent(
@@ -303,6 +349,8 @@ public struct CostSnapshot: Sendable, Equatable, Codable {
         try c.encode(dailyHistory, forKey: .dailyHistory)
         try c.encode(todayHourlyHistory, forKey: .todayHourlyHistory)
         try c.encode(yesterdayHourlyHistory, forKey: .yesterdayHourlyHistory)
+        try c.encode(recentHourlyHistory, forKey: .recentHourlyHistory)
+        try c.encodeIfPresent(hourlyCoverageStart, forKey: .hourlyCoverageStart)
         try c.encode(heatmap, forKey: .heatmap)
         try c.encode(modelBreakdowns, forKey: .modelBreakdowns)
         try c.encode(last7DaysModelBreakdowns, forKey: .last7DaysModelBreakdowns)
@@ -384,6 +432,30 @@ public enum CostSnapshotAggregator {
         calendar: Calendar = .current
     ) -> [HourlyCostPoint] {
         combineHourlyPoints(snapshots.flatMap(\.yesterdayHourlyHistory), calendar: calendar)
+    }
+
+    public static func combinedRecentHourlyHistory(
+        _ snapshots: [CostSnapshot],
+        calendar: Calendar = .current
+    ) -> [HourlyCostPoint] {
+        combineHourlyPoints(snapshots.flatMap(\.recentHourlyHistory), calendar: calendar)
+    }
+
+    /// Where the combined hourly lane starts being trustworthy: the *newest* of
+    /// the per-provider starts, because a stretch is only fully covered once
+    /// every provider in the sum covers it.
+    ///
+    /// One provider without a declared start (a snapshot cached before the
+    /// field existed) makes the whole combination unknown rather than
+    /// optimistic — the alternative is drawing that provider's missing days as
+    /// zero spend.
+    public static func combinedHourlyCoverageStart(_ snapshots: [CostSnapshot]) -> Date? {
+        var newest: Date?
+        for snapshot in snapshots {
+            guard let start = snapshot.hourlyCoverageStart else { return nil }
+            newest = newest.map { max($0, start) } ?? start
+        }
+        return newest
     }
 
     public static func combinedHourlyModelBreakdown(
@@ -502,6 +574,8 @@ public enum CostSnapshotAggregator {
             dailyHistory: combinedDailyHistory(rebased, calendar: calendar),
             todayHourlyHistory: combinedHourlyHistory(rebased, calendar: calendar),
             yesterdayHourlyHistory: combinedYesterdayHourlyHistory(rebased, calendar: calendar),
+            recentHourlyHistory: combinedRecentHourlyHistory(rebased, calendar: calendar),
+            hourlyCoverageStart: combinedHourlyCoverageStart(rebased),
             heatmap: combinedHeatmap(rebased, tool: tool),
             modelBreakdowns: combinedModelBreakdowns(rebased),
             last7DaysModelBreakdowns: combinedLast7DaysModelBreakdowns(rebased),

--- a/Sources/VibeBarCore/Services/CostHistoryStore.swift
+++ b/Sources/VibeBarCore/Services/CostHistoryStore.swift
@@ -199,6 +199,8 @@ public actor CostHistoryStore {
             dailyHistory: dailyPoints,
             todayHourlyHistory: snapshot.todayHourlyHistory,
             yesterdayHourlyHistory: snapshot.yesterdayHourlyHistory,
+            recentHourlyHistory: snapshot.recentHourlyHistory,
+            hourlyCoverageStart: snapshot.hourlyCoverageStart,
             heatmap: snapshot.heatmap,
             modelBreakdowns: snapshot.modelBreakdowns,
             last7DaysModelBreakdowns: snapshot.last7DaysModelBreakdowns,

--- a/Sources/VibeBarCore/Services/CostUsageScanner.swift
+++ b/Sources/VibeBarCore/Services/CostUsageScanner.swift
@@ -1351,6 +1351,8 @@ public enum CostUsageScanner {
         let calendar: Calendar
         let startOfToday: Date
         let startOfYesterday: Date
+        /// Midnight of the oldest day that still gets per-hour buckets.
+        let hourlyCutoff: Date
         let weekCutoff: Date
         let monthCutoff: Date
 
@@ -1359,8 +1361,14 @@ public enum CostUsageScanner {
         var weekCost: Double = 0, weekTokens: Int = 0, weekRequests: Int = 0
         var monthCost: Double = 0, monthTokens: Int = 0, monthRequests: Int = 0
         var byDay: [Date: (cost: Double, tokens: Int)] = [:]
-        var byHourToday: [Date: (cost: Double, tokens: Int)] = [:]
-        var byHourYesterday: [Date: (cost: Double, tokens: Int)] = [:]
+        /// Per-hour buckets across the whole retained hourly window, not just
+        /// yesterday and today — the chart's Hour mode needs evidence wherever
+        /// the user can navigate to inside the window.
+        var byHour: [Date: (cost: Double, tokens: Int)] = [:]
+        /// Midnights inside the hourly window that saw at least one event. Days
+        /// with nothing at all are left out of the emitted series entirely;
+        /// `hourlyCoverageStart` is what tells the chart they were scanned.
+        var hourlyDays: Set<Date> = []
         var heatmap: [[Int]] = Array(repeating: Array(repeating: 0, count: 24), count: 7)
         /// Model ranking across every scanned session.
         var byModelAllTime: [String: (cost: Double, tokens: Int)] = [:]
@@ -1379,6 +1387,7 @@ public enum CostUsageScanner {
             self.calendar = cal
             self.startOfToday = cal.startOfDay(for: now)
             self.startOfYesterday = cal.date(byAdding: .day, value: -1, to: startOfToday) ?? startOfToday
+            self.hourlyCutoff = CostChartWindowPolicy.hourlyRetentionStart(now: now, calendar: cal)
             self.weekCutoff = cal.date(byAdding: .day, value: -6, to: startOfToday) ?? now
             self.monthCutoff = cal.date(byAdding: .day, value: -29, to: startOfToday) ?? now
         }
@@ -1392,19 +1401,6 @@ public enum CostUsageScanner {
                 todayCost += costUSD
                 todayTokens += tokens
                 todayRequests += 1
-                if let hourKey = calendar.dateInterval(of: .hour, for: date)?.start {
-                    var hourBucket = byHourToday[hourKey] ?? (0, 0)
-                    hourBucket.cost += costUSD
-                    hourBucket.tokens += tokens
-                    byHourToday[hourKey] = hourBucket
-                }
-            }
-            if date >= startOfYesterday, date < startOfToday,
-               let hourKey = calendar.dateInterval(of: .hour, for: date)?.start {
-                var hourBucket = byHourYesterday[hourKey] ?? (0, 0)
-                hourBucket.cost += costUSD
-                hourBucket.tokens += tokens
-                byHourYesterday[hourKey] = hourBucket
             }
             if date >= weekCutoff {
                 weekCost += costUSD
@@ -1421,6 +1417,18 @@ public enum CostUsageScanner {
             bucket.cost += costUSD
             bucket.tokens += tokens
             byDay[dayKey] = bucket
+
+            // One hourly lane for the whole retained window. Events dated after
+            // today are clock skew rather than history, and a future bucket
+            // would push the lane past the chart's domain, so they stay out.
+            if date >= hourlyCutoff, dayKey <= startOfToday,
+               let hourKey = calendar.dateInterval(of: .hour, for: date)?.start {
+                var hourBucket = byHour[hourKey] ?? (0, 0)
+                hourBucket.cost += costUSD
+                hourBucket.tokens += tokens
+                byHour[hourKey] = hourBucket
+                hourlyDays.insert(dayKey)
+            }
 
             let weekday = calendar.component(.weekday, from: date) - 1     // 0..6, Sunday=0
             let hour = calendar.component(.hour, from: date)
@@ -1447,7 +1455,7 @@ public enum CostUsageScanner {
             dayModels[model] = dayModelEntry
             byDayModel[dayKey] = dayModels
 
-            if date >= startOfYesterday,
+            if date >= hourlyCutoff, dayKey <= startOfToday,
                let hourKey = calendar.dateInterval(of: .hour, for: date)?.start {
                 var hourModels = byHourModel[hourKey] ?? [:]
                 var hourModelEntry = hourModels[model] ?? (0, 0)
@@ -1458,20 +1466,51 @@ public enum CostUsageScanner {
             }
         }
 
+        /// Zero-filled hourly buckets for one local day, oldest first.
+        ///
+        /// Walked with the calendar rather than by adding 24 fixed offsets to
+        /// midnight: a spring-forward day is 23 hours long and a fall-back day
+        /// 25, and offset arithmetic would spill the last bucket into the next
+        /// day — where it would collide with that day's own midnight bucket in
+        /// the combined series. `notAfter` stops today's lane at the hour in
+        /// progress instead of drawing the rest of the day as zeros.
+        func hourlyPoints(forDayStarting day: Date, notAfter limit: Date?) -> [HourlyCostPoint] {
+            guard let dayEnd = calendar.date(byAdding: .day, value: 1, to: day) else { return [] }
+            var points: [HourlyCostPoint] = []
+            var hour = day
+            while hour < dayEnd {
+                if let limit, hour > limit { break }
+                let value = byHour[hour] ?? (0, 0)
+                points.append(
+                    HourlyCostPoint(date: hour, costUSD: value.cost, totalTokens: value.tokens)
+                )
+                guard let next = calendar.date(byAdding: .hour, value: 1, to: hour), next > hour else {
+                    break
+                }
+                hour = next
+            }
+            return points
+        }
+
         func snapshot(jsonlFilesFound: Int) -> CostSnapshot {
             let sortedDays = byDay
                 .sorted { $0.key < $1.key }
                 .map { DailyCostPoint(date: $0.key, costUSD: $0.value.cost, totalTokens: $0.value.tokens) }
-            let currentHour = calendar.component(.hour, from: now)
-            let hourlyToday = (0...max(0, currentHour)).compactMap { offset -> HourlyCostPoint? in
-                guard let hour = calendar.date(byAdding: .hour, value: offset, to: startOfToday) else { return nil }
-                let value = byHourToday[hour] ?? (0, 0)
-                return HourlyCostPoint(date: hour, costUSD: value.cost, totalTokens: value.tokens)
-            }
-            let hourlyYesterday = (0..<24).compactMap { offset -> HourlyCostPoint? in
-                guard let hour = calendar.date(byAdding: .hour, value: offset, to: startOfYesterday) else { return nil }
-                let value = byHourYesterday[hour] ?? (0, 0)
-                return HourlyCostPoint(date: hour, costUSD: value.cost, totalTokens: value.tokens)
+            let currentHourStart = calendar.dateInterval(of: .hour, for: now)?.start ?? startOfToday
+            let hourlyToday = hourlyPoints(forDayStarting: startOfToday, notAfter: currentHourStart)
+            let hourlyYesterday = hourlyPoints(forDayStarting: startOfYesterday, notAfter: nil)
+            // Today and yesterday are always emitted, even at zero, so a chart
+            // opened on a quiet morning still reads as "covered, nothing spent"
+            // rather than falling back to daily bars.
+            let recentDays = hourlyDays
+                .union([startOfToday, startOfYesterday])
+                .filter { $0 >= hourlyCutoff && $0 <= startOfToday }
+                .sorted()
+            let hourlyRecent = recentDays.flatMap { day in
+                hourlyPoints(
+                    forDayStarting: day,
+                    notAfter: day == startOfToday ? currentHourStart : nil
+                )
             }
             let sevenDayBreakdowns = byModel7d
                 .sorted { $0.value.cost > $1.value.cost }
@@ -1513,6 +1552,8 @@ public enum CostUsageScanner {
                 dailyHistory: sortedDays,
                 todayHourlyHistory: hourlyToday,
                 yesterdayHourlyHistory: hourlyYesterday,
+                recentHourlyHistory: hourlyRecent,
+                hourlyCoverageStart: hourlyCutoff,
                 heatmap: UsageHeatmap(tool: tool, cells: heatmap, totalTokens: totalTokens),
                 modelBreakdowns: Array(allTimeBreakdowns),
                 last7DaysModelBreakdowns: Array(sevenDayBreakdowns),

--- a/Sources/VibeBarCore/Services/QuotaHistorySeriesBuilder.swift
+++ b/Sources/VibeBarCore/Services/QuotaHistorySeriesBuilder.swift
@@ -103,6 +103,29 @@ public enum QuotaHistorySeriesBuilder {
         gapSlotMultiplier * TimeInterval(AppSettings.slowestRefreshIntervalSeconds)
             + refreshTimerTolerance
 
+    /// Slack allowed on a recorded reset instant before a later sample counts
+    /// as belonging to the next window.
+    ///
+    /// A stored `resetAt` is an *estimate*, not a fact. Several providers report
+    /// "resets in N seconds" and Vibe Bar turns that into an absolute `Date` at
+    /// fetch time, so two samples taken inside one window disagree about the
+    /// reset instant by however long each round trip took — sub-second in
+    /// practice, but never exactly equal. Sixty seconds absorbs that (and the
+    /// refresh scheduler's own timer slack) while staying far below the
+    /// one-minute-at-the-fastest sampling cadence, so a genuine crossing is
+    /// still caught on the very next sample.
+    static let resetEstimateTolerance: TimeInterval = 60
+
+    /// Fraction of a window the recorded reset has to jump forward by before
+    /// the jump alone counts as a new window.
+    ///
+    /// Belt to the crossing test's braces: a sample can land exactly *on* the
+    /// old reset instant rather than after it, and the provider will already be
+    /// reporting the next window. Half a window is far above any estimate
+    /// jitter or legitimate mid-session drift, and far below the full-window
+    /// step a real reset takes.
+    private static let resetJumpWindowFraction: Double = 0.5
+
     /// Build the three series for one `(accountId, tool, bucketId)`.
     ///
     /// Inputs must already be scoped to a single bucket — the builder filters
@@ -234,13 +257,19 @@ public enum QuotaHistorySeriesBuilder {
         var previous: Element?
         for element in elements {
             if let previous {
-                let windowChanged = resetAt(previous) != resetAt(element)
-                let slot = UsageTimelineSlotPolicy.slotSeconds(
-                    windowSeconds: windowSeconds(previous)
-                )
+                let previousWindow = windowSeconds(previous)
+                let slot = UsageTimelineSlotPolicy.slotSeconds(windowSeconds: previousWindow)
                 let gap = time(element).timeIntervalSince(time(previous))
                 let threshold = max(slot * gapSlotMultiplier, minimumGapSeconds)
-                if windowChanged || gap > threshold {
+                let boundary = windowBoundary(
+                    previousReset: resetAt(previous),
+                    previousWindowSeconds: previousWindow,
+                    elementTime: time(element),
+                    elementReset: resetAt(element),
+                    elementWindowSeconds: windowSeconds(element),
+                    gapThreshold: threshold
+                )
+                if boundary || gap > threshold {
                     if !current.isEmpty { segments.append(current) }
                     current = []
                 }
@@ -250,6 +279,59 @@ public enum QuotaHistorySeriesBuilder {
         }
         if !current.isEmpty { segments.append(current) }
         return segments
+    }
+
+    /// Did the window the previous point was measured in end before this one
+    /// was taken?
+    ///
+    /// This used to be `previousReset != elementReset`, which looked exact and
+    /// was catastrophically wrong: on providers that report a *relative* reset
+    /// the two estimates differ by milliseconds on every single pair, so every
+    /// consecutive pair read as a new window, every segment collapsed to one
+    /// point, and a one-point segment draws nothing. Whole quota lines silently
+    /// vanished from the chart while their legend readings stayed correct.
+    ///
+    /// Three honest signals replace it:
+    ///
+    /// - **Crossing.** A sample taken after the previous sample's own reset
+    ///   instant is in the next window, whatever either sample claims the
+    ///   instant is. No tolerance on the estimate is needed, and a provider
+    ///   that legitimately slides a rolling window forward mid-session does not
+    ///   tear the line.
+    /// - **A jump of at least half a window.** Covers the sample that lands
+    ///   exactly on the boundary rather than past it.
+    /// - **A different window *length*.** An integer count of seconds is not an
+    ///   estimate, so a plan whose shape actually changed is still a hard edge.
+    ///
+    /// Points recorded before Vibe Bar stored `resetAt` cannot answer any of
+    /// this; those runs fall through to sampling-gap segmentation alone, which
+    /// is what keeps the actual line drawable over legacy history.
+    private static func windowBoundary(
+        previousReset: Date?,
+        previousWindowSeconds: Int?,
+        elementTime: Date,
+        elementReset: Date?,
+        elementWindowSeconds: Int?,
+        gapThreshold: TimeInterval
+    ) -> Bool {
+        if let previousWindowSeconds,
+           let elementWindowSeconds,
+           previousWindowSeconds != elementWindowSeconds {
+            return true
+        }
+        guard let previousReset else { return false }
+        if elementTime > previousReset.addingTimeInterval(resetEstimateTolerance) {
+            return true
+        }
+        guard let elementReset else { return false }
+        // Without a window length there is nothing to take a fraction of, so
+        // fall back to the coverage-gap threshold as the "this is a big move"
+        // yardstick.
+        let jumpThreshold = previousWindowSeconds
+            .map { TimeInterval($0) * resetJumpWindowFraction }
+            ?? gapThreshold
+        return elementReset.timeIntervalSince(previousReset)
+            >= max(jumpThreshold, resetEstimateTolerance)
     }
 
     private static func clampPercent(_ value: Double) -> Double {

--- a/Sources/VibeBarCore/Storage/CostSnapshotCache.swift
+++ b/Sources/VibeBarCore/Storage/CostSnapshotCache.swift
@@ -5,10 +5,18 @@ import Foundation
 ///
 /// Files: `~/.vibebar/cost_snapshots/{tool}.json` (mode 0600).
 ///
-/// The full snapshot — heatmap, model breakdowns, daily history, totals —
-/// fits in well under 1 MB even for heavy users, so we just write the whole
-/// blob each time. CostHistoryStore still owns the canonical max-merged
-/// per-day series; this cache is a snapshot of derived view data.
+/// The full snapshot — heatmap, model breakdowns, daily history, totals, and
+/// the `CostChartWindowPolicy.hourlyRetentionDays`-long hourly window — fits in
+/// well under 1 MB even for heavy users, so we just write the whole blob each
+/// time. CostHistoryStore still owns the canonical max-merged per-day series;
+/// this cache is a snapshot of derived view data.
+///
+/// No schema version of its own: every field the scanner added since is
+/// optional on decode, so an older file loads with the new fields empty and the
+/// popover still opens on real numbers. The next scan — seconds later — writes
+/// the complete shape. Wiping the file on a version bump would trade that for a
+/// blank launch. `calculationVersion` still forces a wipe, because a repricing
+/// makes the stored numbers wrong rather than merely narrow.
 public actor CostSnapshotCache {
     public static let shared = CostSnapshotCache()
 

--- a/Tests/VibeBarCoreTests/AppSettingsTests.swift
+++ b/Tests/VibeBarCoreTests/AppSettingsTests.swift
@@ -37,6 +37,32 @@ final class AppSettingsTests: XCTestCase {
         XCTAssertEqual(settings.updateChannel, .main)
     }
 
+    func testOverviewQuotaHistoryHiddenCurvesDefaultToNoneAndRoundTrip() throws {
+        // Stored as *hidden* ids, so a settings file written before the
+        // Overview chart existed has to mean "show everything" — not "show
+        // nothing", which is what a visible-id list would have decoded to.
+        let legacy = try JSONDecoder().decode(
+            AppSettings.self,
+            from: Data(#"{"displayMode":"remaining"}"#.utf8)
+        )
+        XCTAssertTrue(legacy.overviewQuotaHistoryHiddenCurveIds.isEmpty)
+        XCTAssertTrue(AppSettings.default.overviewQuotaHistoryHiddenCurveIds.isEmpty)
+
+        var settings = AppSettings.default
+        settings.overviewQuotaHistoryHiddenCurveIds = [
+            "claude|account-1|weekly_fable",
+            "codex|account-2|five_hour"
+        ]
+        let decoded = try JSONDecoder().decode(
+            AppSettings.self,
+            from: try JSONEncoder().encode(settings)
+        )
+        XCTAssertEqual(
+            decoded.overviewQuotaHistoryHiddenCurveIds,
+            ["claude|account-1|weekly_fable", "codex|account-2|five_hour"]
+        )
+    }
+
     func testUpdateChannelRoundTripsAndUnknownValuesFallBackToMain() throws {
         var settings = AppSettings.default
         settings.updateChannel = .dev

--- a/Tests/VibeBarCoreTests/ChartSeriesPlanningTests.swift
+++ b/Tests/VibeBarCoreTests/ChartSeriesPlanningTests.swift
@@ -1,0 +1,187 @@
+import XCTest
+@testable import VibeBarCore
+
+final class ChartMarkBudgetTests: XCTestCase {
+    // MARK: - Allocation
+
+    func testSeriesAlreadyInsideBudgetIsLeftAlone() {
+        // Thinning a series that does not need it only costs fidelity.
+        let counts = [4, 9, 2]
+        XCTAssertEqual(ChartMarkBudget.allocate(segmentCounts: counts, budget: 100), counts)
+    }
+
+    func testManySmallSegmentsStayInsideTheBudget() {
+        // The regression this exists for: a five-hour quota over months of
+        // history is hundreds of segments, each individually smaller than the
+        // budget. Thinning them one at a time meant every one passed through
+        // untouched and the curve rendered segmentCount × budget marks.
+        let counts = Array(repeating: 60, count: 300)   // 18,000 points
+        let allowance = ChartMarkBudget.allocate(segmentCounts: counts, budget: 900)
+        XCTAssertEqual(allowance.count, counts.count)
+        XCTAssertLessThanOrEqual(allowance.reduce(0, +), 900)
+        XCTAssertTrue(allowance.allSatisfy { $0 >= ChartMarkBudget.minimumSegmentPoints })
+    }
+
+    func testBudgetIsSpentAlmostExactlyRatherThanDriftingLow() {
+        let counts = [130, 47, 900, 3, 61]
+        let allowance = ChartMarkBudget.allocate(segmentCounts: counts, budget: 400)
+        XCTAssertEqual(allowance.reduce(0, +), 400)
+    }
+
+    func testShareIsProportionalToHowMuchOfTheCurveASegmentIs() {
+        let allowance = ChartMarkBudget.allocate(segmentCounts: [900, 100], budget: 200)
+        XCTAssertEqual(allowance.reduce(0, +), 200)
+        XCTAssertGreaterThan(allowance[0], allowance[1])
+        // Roughly 9:1, allowing for the two-point floors coming off the top.
+        XCTAssertEqual(Double(allowance[0]) / Double(allowance[1]), 9, accuracy: 1.5)
+    }
+
+    func testNoSegmentIsAllocatedMoreThanItHas() {
+        let counts = [3, 3, 5_000]
+        let allowance = ChartMarkBudget.allocate(segmentCounts: counts, budget: 600)
+        for (allowed, count) in zip(allowance, counts) {
+            XCTAssertLessThanOrEqual(allowed, count)
+        }
+        XCTAssertLessThanOrEqual(allowance.reduce(0, +), 600)
+    }
+
+    func testEverySegmentKeepsAtLeastItsTwoEndpoints() {
+        // Segment endpoints are what the bridging connectors attach to, so
+        // thinning must never be able to strand a bridge.
+        let allowance = ChartMarkBudget.allocate(
+            segmentCounts: Array(repeating: 40, count: 50),
+            budget: 60
+        )
+        XCTAssertTrue(allowance.allSatisfy { $0 == ChartMarkBudget.minimumSegmentPoints })
+    }
+
+    func testSingletonSegmentsKeepTheirOnlyPoint() {
+        let allowance = ChartMarkBudget.allocate(segmentCounts: [1, 1, 500], budget: 20)
+        XCTAssertEqual(allowance[0], 1)
+        XCTAssertEqual(allowance[1], 1)
+        XCTAssertLessThanOrEqual(allowance.reduce(0, +), 20)
+    }
+
+    func testFloorsWinWhenTheyAlreadyExceedTheBudget() {
+        // Deliberately over budget: dropping segments would delete evidence,
+        // and two marks each is already the cheapest honest rendering.
+        let allowance = ChartMarkBudget.allocate(
+            segmentCounts: Array(repeating: 9, count: 100),
+            budget: 50
+        )
+        XCTAssertEqual(allowance, Array(repeating: 2, count: 100))
+    }
+
+    func testEmptyAndZeroBudgetInputsAreHandled() {
+        XCTAssertEqual(ChartMarkBudget.allocate(segmentCounts: [], budget: 100), [])
+        XCTAssertEqual(ChartMarkBudget.allocate(segmentCounts: [5, 5], budget: 0), [5, 5])
+    }
+
+    // MARK: - Allocation applied
+
+    func testThinnedKeepsWholeCurveInsideBudgetAndPreservesEndpoints() {
+        let segments = (0..<40).map { segment in
+            (0..<120).map { point in segment * 1_000 + point }
+        }
+        let thinned = ChartMarkBudget.thinned(segments, budget: 500)
+        XCTAssertLessThanOrEqual(thinned.reduce(0) { $0 + $1.count }, 500)
+        for (original, drawn) in zip(segments, thinned) {
+            XCTAssertEqual(drawn.first, original.first)
+            XCTAssertEqual(drawn.last, original.last)
+        }
+    }
+
+    func testThinnedLeavesAShortCurveUntouched() {
+        let segments = [[1, 2, 3], [4, 5]]
+        XCTAssertEqual(ChartMarkBudget.thinned(segments, budget: 500), segments)
+    }
+
+    // MARK: - Striding
+
+    func testStridedKeepsBothEndpointsAndRespectsTheLimit() {
+        let elements = Array(0..<1_000)
+        let thinned = ChartSeriesThinning.strided(elements, limit: 37)
+        XCTAssertLessThanOrEqual(thinned.count, 37)
+        XCTAssertEqual(thinned.first, 0)
+        XCTAssertEqual(thinned.last, 999)
+        XCTAssertEqual(thinned, thinned.sorted())
+    }
+}
+
+final class ChartSampleSearchTests: XCTestCase {
+    private struct Sample {
+        let time: Date
+        let value: Int
+    }
+
+    private let base = Date(timeIntervalSince1970: 1_800_000_000)
+
+    private func samples(_ offsets: [TimeInterval]) -> [Sample] {
+        offsets.enumerated().map { Sample(time: base.addingTimeInterval($0.element), value: $0.offset) }
+    }
+
+    func testFindsTheNearestSampleOnEitherSide() {
+        let sorted = samples([0, 300, 600, 900])
+        let before = ChartSampleSearch.nearest(
+            in: sorted, to: base.addingTimeInterval(340), tolerance: 600, time: { $0.time }
+        )
+        let after = ChartSampleSearch.nearest(
+            in: sorted, to: base.addingTimeInterval(560), tolerance: 600, time: { $0.time }
+        )
+        XCTAssertEqual(before?.value, 1)
+        XCTAssertEqual(after?.value, 2)
+    }
+
+    func testExactHitsAndTheArrayEdgesResolve() {
+        let sorted = samples([0, 300, 600])
+        XCTAssertEqual(
+            ChartSampleSearch.nearest(
+                in: sorted, to: base.addingTimeInterval(300), tolerance: 1, time: { $0.time }
+            )?.value,
+            1
+        )
+        XCTAssertEqual(
+            ChartSampleSearch.nearest(
+                in: sorted, to: base.addingTimeInterval(-10), tolerance: 60, time: { $0.time }
+            )?.value,
+            0
+        )
+        XCTAssertEqual(
+            ChartSampleSearch.nearest(
+                in: sorted, to: base.addingTimeInterval(610), tolerance: 60, time: { $0.time }
+            )?.value,
+            2
+        )
+    }
+
+    func testNothingIsReturnedBeyondTheTolerance() {
+        // A gap is information: the hover must say "nothing here" rather than
+        // reach across it for whichever sample happens to be closest.
+        let sorted = samples([0, 86_400])
+        XCTAssertNil(
+            ChartSampleSearch.nearest(
+                in: sorted, to: base.addingTimeInterval(43_200), tolerance: 600, time: { $0.time }
+            )
+        )
+        XCTAssertNil(
+            ChartSampleSearch.nearest(
+                in: [], to: base, tolerance: 600, time: { (_: Sample) in base }
+            )
+        )
+    }
+
+    func testMatchesAnExhaustiveScanAcrossTheWholeArray() {
+        let sorted = samples(stride(from: 0, to: 400 * 300, by: 300).map(TimeInterval.init))
+        let tolerance: TimeInterval = 900
+        for step in stride(from: -1_000, through: 400 * 300 + 1_000, by: 617) {
+            let target = base.addingTimeInterval(TimeInterval(step))
+            let expected = sorted
+                .filter { abs($0.time.timeIntervalSince(target)) <= tolerance }
+                .min { abs($0.time.timeIntervalSince(target)) < abs($1.time.timeIntervalSince(target)) }
+            let actual = ChartSampleSearch.nearest(
+                in: sorted, to: target, tolerance: tolerance, time: { $0.time }
+            )
+            XCTAssertEqual(actual?.value, expected?.value, "target offset \(step)")
+        }
+    }
+}

--- a/Tests/VibeBarCoreTests/CostChartGranularityTests.swift
+++ b/Tests/VibeBarCoreTests/CostChartGranularityTests.swift
@@ -9,24 +9,51 @@ final class CostChartGranularityTests: XCTestCase {
     func testAutoResolvesToHourForShortSpans() {
         XCTAssertEqual(CostChartGranularity.resolve(autoFor: 0), .hour)
         XCTAssertEqual(CostChartGranularity.resolve(autoFor: 3_600), .hour)
-        XCTAssertEqual(CostChartGranularity.resolve(autoFor: 2.6 * day), .hour)
+        XCTAssertEqual(CostChartGranularity.resolve(autoFor: 5 * day), .hour)
+    }
+
+    /// The reason Auto reaches for hours as far out as five days: below about
+    /// six daily bars the chart is a handful of slabs, and the same span has
+    /// 72–120 hourly points to draw instead.
+    func testAutoPrefersHourWhileDailyBarsWouldBeSparse() {
+        for days in [3.0, 4.0, 4.9, 5.0] {
+            XCTAssertEqual(
+                CostChartGranularity.resolve(autoFor: days * day),
+                .hour,
+                "\(days) days is only \(days) daily bars"
+            )
+        }
     }
 
     func testAutoResolvesToDayJustPastTheHourThreshold() {
-        XCTAssertEqual(CostChartGranularity.resolve(autoFor: 2.6 * day + 1), .day)
+        XCTAssertEqual(CostChartGranularity.resolve(autoFor: 5 * day + 1), .day)
         XCTAssertEqual(CostChartGranularity.resolve(autoFor: 30 * day), .day)
         XCTAssertEqual(CostChartGranularity.resolve(autoFor: 110 * day), .day)
     }
 
     func testAutoResolvesToWeekPastTheDayThreshold() {
         XCTAssertEqual(CostChartGranularity.resolve(autoFor: 110 * day + 1), .week)
-        XCTAssertEqual(CostChartGranularity.resolve(autoFor: 365 * day), .week)
-        XCTAssertEqual(CostChartGranularity.resolve(autoFor: 420 * day), .week)
+        XCTAssertEqual(CostChartGranularity.resolve(autoFor: 180 * day), .week)
+        XCTAssertEqual(CostChartGranularity.resolve(autoFor: 240 * day), .week)
     }
 
     func testAutoResolvesToMonthPastTheWeekThreshold() {
-        XCTAssertEqual(CostChartGranularity.resolve(autoFor: 420 * day + 1), .month)
+        XCTAssertEqual(CostChartGranularity.resolve(autoFor: 240 * day + 1), .month)
+        XCTAssertEqual(CostChartGranularity.resolve(autoFor: 365 * day), .month)
         XCTAssertEqual(CostChartGranularity.resolve(autoFor: 3 * 365 * day), .month)
+    }
+
+    /// A long "All" domain is the case this ladder exists for: eight calendar
+    /// months is 242–245 days however the months fall, and ten is past 300.
+    /// Both are monthly bars, not thirty-plus weekly ones.
+    func testAutoResolvesLongAllDomainsToMonth() {
+        for days in [242.0, 245.0, 305.0] {
+            XCTAssertEqual(
+                CostChartGranularity.resolve(autoFor: days * day),
+                .month,
+                "\(days) days should be a monthly shape"
+            )
+        }
     }
 
     func testAutoResolutionIsMonotonicAcrossThresholds() {
@@ -59,11 +86,39 @@ final class CostChartGranularityTests: XCTestCase {
         XCTAssertEqual(CostChartGranularity.allowed(for: 7 * day + 1), [.day])
     }
 
+    /// The manual unlock stays wider than the Auto threshold: Auto stops
+    /// reaching for hours at five days, but six and seven are still offered to
+    /// a user who wants to compare a whole week hour by hour.
+    func testHourStaysManuallyAvailablePastTheAutoThreshold() {
+        for days in [5.5, 6.0, 7.0] {
+            XCTAssertNotEqual(CostChartGranularity.resolve(autoFor: days * day), .hour)
+            XCTAssertTrue(
+                CostChartGranularity.survivesManualSelection(.hour, for: days * day),
+                "hour should still be pickable at \(days) days"
+            )
+        }
+    }
+
     func testWeekIsOfferedFromFourWeeks() {
         XCTAssertEqual(CostChartGranularity.allowed(for: 21 * day), [.day])
         XCTAssertEqual(CostChartGranularity.allowed(for: 27 * day), [.day])
         XCTAssertEqual(CostChartGranularity.allowed(for: 28 * day), [.day, .week])
         XCTAssertEqual(CostChartGranularity.allowed(for: 365 * day), [.day, .week, .month])
+    }
+
+    /// Auto's own steps have to be offered by the control that shows them, or
+    /// the selector lights up "Auto" next to a greyed-out width Auto just used.
+    func testEveryAutoStepIsOfferedAtItsOwnThreshold() {
+        let steps: [(Double, CostChartGranularity)] = [
+            (5, .hour), (110, .day), (240, .week), (241, .month)
+        ]
+        for (days, expected) in steps {
+            XCTAssertEqual(CostChartGranularity.resolve(autoFor: days * day), expected)
+            XCTAssertTrue(
+                CostChartGranularity.allowed(for: days * day).contains(expected),
+                "\(expected) is not offered at \(days) days"
+            )
+        }
     }
 
     /// The unlock threshold and the bar floor have to agree: the first span

--- a/Tests/VibeBarCoreTests/CostChartWindowPolicyTests.swift
+++ b/Tests/VibeBarCoreTests/CostChartWindowPolicyTests.swift
@@ -143,24 +143,25 @@ final class CostChartWindowPolicyTests: XCTestCase {
         XCTAssertEqual(span, day)
     }
 
-    // MARK: - Yesterday bounds
+    // MARK: - Hourly retention window
 
-    func testYesterdayBoundsAreCalendarDays() {
-        let (start, end) = CostChartWindowPolicy.yesterdayBounds(
-            now: date(2026, 6, 20, 17),
-            calendar: calendar
+    func testHourlyRetentionStartIsMidnightThirteenDaysBack() {
+        XCTAssertEqual(CostChartWindowPolicy.hourlyRetentionDays, 14)
+        XCTAssertEqual(
+            CostChartWindowPolicy.hourlyRetentionStart(now: date(2026, 6, 20, 17), calendar: calendar),
+            date(2026, 6, 7)
         )
-        XCTAssertEqual(start, date(2026, 6, 19))
-        XCTAssertEqual(end, date(2026, 6, 20))
     }
 
-    func testYesterdayBoundsKeepTheShortDayShortAcrossDst() {
-        let (start, end) = CostChartWindowPolicy.yesterdayBounds(
-            now: date(2026, 3, 9, 17),
+    /// Counted in calendar days, not in 86 400-second multiples, so the window
+    /// still starts at a midnight when a DST change falls inside it.
+    func testHourlyRetentionStartLandsOnMidnightAcrossDst() {
+        let start = CostChartWindowPolicy.hourlyRetentionStart(
+            now: date(2026, 3, 14, 17),
             calendar: calendar
         )
-        XCTAssertEqual(start, date(2026, 3, 8))
-        XCTAssertEqual(end.timeIntervalSince(start), 23 * 3_600)
+        XCTAssertEqual(start, date(2026, 3, 1))
+        XCTAssertEqual(calendar.startOfDay(for: start), start)
     }
 
     // MARK: - Hourly coverage
@@ -204,6 +205,59 @@ final class CostChartWindowPolicyTests: XCTestCase {
         let yesterday = date(2026, 6, 19)...date(2026, 6, 20)
         XCTAssertTrue(CostChartWindowPolicy.covers(coverage, range: today))
         XCTAssertTrue(CostChartWindowPolicy.covers(coverage, range: yesterday))
+    }
+
+    /// Fed the declared retention start rather than the oldest bucket, the same
+    /// function reports the whole retained window — which is what lets Auto
+    /// reach Hour at three, four and five days instead of falling back to Day
+    /// because the scan only found spend yesterday.
+    func testCoverageFromRetentionStartSpansTheWholeWindow() {
+        let now = date(2026, 6, 20, 10)
+        let coverage = CostChartWindowPolicy.hourlyCoverage(
+            firstHour: CostChartWindowPolicy.hourlyRetentionStart(now: now, calendar: calendar),
+            lastHour: date(2026, 6, 20, 10),
+            calendar: calendar
+        )
+        XCTAssertEqual(coverage?.lowerBound, date(2026, 6, 7))
+        XCTAssertEqual(coverage?.upperBound, date(2026, 6, 21))
+        for days in [3, 4, 5, 7] {
+            let start = calendar.date(byAdding: .day, value: -days, to: date(2026, 6, 21))!
+            XCTAssertTrue(
+                CostChartWindowPolicy.covers(coverage, range: start...date(2026, 6, 21)),
+                "a \(days)-day window inside the retained window should be covered"
+            )
+        }
+    }
+
+    /// A window reaching past the retained days is still not hourly, however
+    /// the coverage was derived — the point of the retention constant is that
+    /// it has an edge.
+    func testWindowOlderThanTheRetentionWindowIsNotCovered() {
+        let now = date(2026, 6, 20, 10)
+        let coverage = CostChartWindowPolicy.hourlyCoverage(
+            firstHour: CostChartWindowPolicy.hourlyRetentionStart(now: now, calendar: calendar),
+            lastHour: date(2026, 6, 20, 10),
+            calendar: calendar
+        )
+        XCTAssertFalse(
+            CostChartWindowPolicy.covers(coverage, range: date(2026, 6, 6)...date(2026, 6, 21))
+        )
+        XCTAssertFalse(
+            CostChartWindowPolicy.covers(coverage, range: date(2026, 5, 20)...date(2026, 6, 21))
+        )
+    }
+
+    /// A snapshot cached longer ago than the whole window has nothing left
+    /// inside it, and must not claim coverage from its retention start.
+    func testCoverageIsNilWhenTheNewestBucketPredatesTheWindow() {
+        let now = date(2026, 6, 20, 10)
+        XCTAssertNil(
+            CostChartWindowPolicy.hourlyCoverage(
+                firstHour: CostChartWindowPolicy.hourlyRetentionStart(now: now, calendar: calendar),
+                lastHour: date(2026, 5, 30, 9),
+                calendar: calendar
+            )
+        )
     }
 
     /// The regression: a 3-day window overlaps the retained hourly days, and

--- a/Tests/VibeBarCoreTests/CostHistoryStoreTests.swift
+++ b/Tests/VibeBarCoreTests/CostHistoryStoreTests.swift
@@ -15,6 +15,8 @@ final class CostHistoryStoreTests: XCTestCase {
         let todayHour = try XCTUnwrap(calendar.date(byAdding: .hour, value: 10, to: today))
         let yesterday = try XCTUnwrap(calendar.date(byAdding: .day, value: -1, to: today))
         let yesterdayHour = try XCTUnwrap(calendar.date(byAdding: .hour, value: 17, to: yesterday))
+        let olderDay = try XCTUnwrap(calendar.date(byAdding: .day, value: -4, to: today))
+        let olderHour = try XCTUnwrap(calendar.date(byAdding: .hour, value: 11, to: olderDay))
         let todayModels = [
             CostSnapshot.ModelBreakdown(modelName: "gpt-today", costUSD: 1.5, totalTokens: 1_500)
         ]
@@ -41,6 +43,12 @@ final class CostHistoryStoreTests: XCTestCase {
             yesterdayHourlyHistory: [
                 HourlyCostPoint(date: yesterdayHour, costUSD: 2.5, totalTokens: 2_500)
             ],
+            recentHourlyHistory: [
+                HourlyCostPoint(date: olderHour, costUSD: 3.5, totalTokens: 3_500),
+                HourlyCostPoint(date: yesterdayHour, costUSD: 2.5, totalTokens: 2_500),
+                HourlyCostPoint(date: todayHour, costUSD: 1.5, totalTokens: 1_500)
+            ],
+            hourlyCoverageStart: CostChartWindowPolicy.hourlyRetentionStart(now: now, calendar: calendar),
             heatmap: .empty(tool: .codex),
             modelBreakdowns: todayModels + yesterdayModels,
             dailyModelBreakdown: [today: todayModels, yesterday: yesterdayModels],
@@ -57,6 +65,12 @@ final class CostHistoryStoreTests: XCTestCase {
 
         XCTAssertEqual(merged.todayHourlyHistory, snapshot.todayHourlyHistory)
         XCTAssertEqual(merged.yesterdayHourlyHistory, snapshot.yesterdayHourlyHistory)
+        // The merge rebuilds the daily series from the store but must carry the
+        // hourly window through untouched — it is live-scan-only data the store
+        // never sees, and dropping it here would strand the chart on two days
+        // no matter how far back the scanner reached.
+        XCTAssertEqual(merged.recentHourlyHistory, snapshot.recentHourlyHistory)
+        XCTAssertEqual(merged.hourlyCoverageStart, snapshot.hourlyCoverageStart)
         XCTAssertEqual(merged.topModels(forHour: todayHour, limit: .max), todayModels)
         XCTAssertEqual(merged.topModels(forHour: yesterdayHour, limit: .max), yesterdayModels)
     }

--- a/Tests/VibeBarCoreTests/CostSnapshotAggregatorTests.swift
+++ b/Tests/VibeBarCoreTests/CostSnapshotAggregatorTests.swift
@@ -193,4 +193,81 @@ final class CostSnapshotAggregatorTests: XCTestCase {
         XCTAssertEqual(combined.jsonlFilesFound, 2)
         XCTAssertEqual(combined.updatedAt, hour)
     }
+
+    // MARK: - Hourly window
+
+    private func windowSnapshot(
+        tool: ToolType,
+        hours: [(Date, Double, Int)],
+        coverageStart: Date?,
+        updatedAt: Date
+    ) -> CostSnapshot {
+        CostSnapshot(
+            tool: tool,
+            todayCostUSD: 0, last7DaysCostUSD: 0, last30DaysCostUSD: 0, allTimeCostUSD: 0,
+            todayTokens: 0, last7DaysTokens: 0, last30DaysTokens: 0, allTimeTokens: 0,
+            dailyHistory: [],
+            recentHourlyHistory: hours.map {
+                HourlyCostPoint(date: $0.0, costUSD: $0.1, totalTokens: $0.2)
+            },
+            hourlyCoverageStart: coverageStart,
+            heatmap: .empty(tool: tool),
+            modelBreakdowns: [],
+            jsonlFilesFound: 1,
+            updatedAt: updatedAt
+        )
+    }
+
+    /// The all-providers card is the one AQ actually looks at, so the wide
+    /// hourly lane has to survive the combine — summed per hour, not appended.
+    func testCombinedSnapshotSumsTheHourlyWindowPerHour() throws {
+        let cal = calendar()
+        let now = try XCTUnwrap(cal.date(from: DateComponents(year: 2026, month: 5, day: 20, hour: 9)))
+        let today = cal.startOfDay(for: now)
+        let threeDaysBack = try XCTUnwrap(
+            cal.date(byAdding: .hour, value: 10, to: cal.date(byAdding: .day, value: -3, to: today)!)
+        )
+        let start = CostChartWindowPolicy.hourlyRetentionStart(now: now, calendar: cal)
+
+        let combined = CostSnapshotAggregator.combinedSnapshot(
+            tool: .codex,
+            snapshots: [
+                windowSnapshot(tool: .codex, hours: [(threeDaysBack, 1.25, 100)], coverageStart: start, updatedAt: now),
+                windowSnapshot(tool: .claude, hours: [(threeDaysBack, 0.75, 50)], coverageStart: start, updatedAt: now)
+            ],
+            now: now,
+            calendar: cal
+        )
+
+        XCTAssertEqual(combined.recentHourlyHistory.count, 1)
+        XCTAssertEqual(combined.recentHourlyHistory.first?.costUSD ?? 0, 2.00, accuracy: 0.0001)
+        XCTAssertEqual(combined.recentHourlyHistory.first?.totalTokens, 150)
+        XCTAssertEqual(combined.hourlyCoverageStart, start)
+    }
+
+    /// A stretch is only covered once every provider in the sum covers it, and
+    /// one provider that declares nothing makes the whole thing unknown — the
+    /// alternative is drawing its missing days as zero spend.
+    func testCombinedHourlyCoverageIsTheMostConservativeStart() throws {
+        let cal = calendar()
+        let now = try XCTUnwrap(cal.date(from: DateComponents(year: 2026, month: 5, day: 20, hour: 9)))
+        let today = cal.startOfDay(for: now)
+        let old = try XCTUnwrap(cal.date(byAdding: .day, value: -13, to: today))
+        let recent = try XCTUnwrap(cal.date(byAdding: .day, value: -2, to: today))
+
+        XCTAssertEqual(
+            CostSnapshotAggregator.combinedHourlyCoverageStart([
+                windowSnapshot(tool: .codex, hours: [], coverageStart: old, updatedAt: now),
+                windowSnapshot(tool: .claude, hours: [], coverageStart: recent, updatedAt: now)
+            ]),
+            recent
+        )
+        XCTAssertNil(
+            CostSnapshotAggregator.combinedHourlyCoverageStart([
+                windowSnapshot(tool: .codex, hours: [], coverageStart: old, updatedAt: now),
+                windowSnapshot(tool: .claude, hours: [], coverageStart: nil, updatedAt: now)
+            ])
+        )
+        XCTAssertNil(CostSnapshotAggregator.combinedHourlyCoverageStart([]))
+    }
 }

--- a/Tests/VibeBarCoreTests/CostSnapshotTests.swift
+++ b/Tests/VibeBarCoreTests/CostSnapshotTests.swift
@@ -63,4 +63,119 @@ final class CostSnapshotTests: XCTestCase {
         XCTAssertEqual(rebased.last7DaysTokens, 1_043_270_000)
         XCTAssertEqual(rebased.allTimeCostUSD, 720, accuracy: 0.001)
     }
+
+    private func utcCalendar() -> Calendar {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.locale = Locale(identifier: "en_US_POSIX")
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+        return calendar
+    }
+
+    private func hourlySnapshot(
+        hours: [Date],
+        coverageStart: Date?,
+        updatedAt: Date
+    ) -> CostSnapshot {
+        CostSnapshot(
+            tool: .codex,
+            todayCostUSD: 0, last7DaysCostUSD: 0, last30DaysCostUSD: 0, allTimeCostUSD: 0,
+            todayTokens: 0, last7DaysTokens: 0, last30DaysTokens: 0, allTimeTokens: 0,
+            dailyHistory: [],
+            recentHourlyHistory: hours.map { HourlyCostPoint(date: $0, costUSD: 1, totalTokens: 10) },
+            hourlyCoverageStart: coverageStart,
+            heatmap: .empty(tool: .codex),
+            modelBreakdowns: [],
+            jsonlFilesFound: 1,
+            updatedAt: updatedAt
+        )
+    }
+
+    /// The wide hourly lane ages by dropping days off its old end, not by being
+    /// emptied the way the today / yesterday lanes are — otherwise rebasing a
+    /// cached snapshot on load would undo the whole retention window.
+    func testRebasedForCurrentDayKeepsTheHourlyWindowAndTrimsItsEdges() throws {
+        let calendar = utcCalendar()
+        let now = try XCTUnwrap(calendar.date(from: DateComponents(year: 2026, month: 5, day: 20, hour: 9)))
+        let today = calendar.startOfDay(for: now)
+        func hoursBack(_ days: Int) -> Date {
+            calendar.date(byAdding: .day, value: -days, to: today)!.addingTimeInterval(3_600)
+        }
+        let tomorrow = try XCTUnwrap(calendar.date(byAdding: .day, value: 1, to: today))
+
+        let rebased = hourlySnapshot(
+            hours: [hoursBack(20), hoursBack(13), hoursBack(4), hoursBack(0), tomorrow],
+            coverageStart: calendar.date(byAdding: .day, value: -30, to: today),
+            updatedAt: now
+        ).rebasedForCurrentDay(now: now, calendar: calendar)
+
+        XCTAssertEqual(rebased.recentHourlyHistory.map(\.date), [hoursBack(13), hoursBack(4), hoursBack(0)])
+        // A start older than the window would have the chart claim coverage it
+        // no longer has.
+        XCTAssertEqual(
+            rebased.hourlyCoverageStart,
+            CostChartWindowPolicy.hourlyRetentionStart(now: now, calendar: calendar)
+        )
+    }
+
+    func testRebasedForCurrentDayEmptiesAnHourlyWindowThatFellOutOfRange() throws {
+        let calendar = utcCalendar()
+        let scannedAt = try XCTUnwrap(calendar.date(from: DateComponents(year: 2026, month: 4, day: 1, hour: 9)))
+        let now = try XCTUnwrap(calendar.date(from: DateComponents(year: 2026, month: 5, day: 20, hour: 9)))
+
+        let rebased = hourlySnapshot(
+            hours: [scannedAt],
+            coverageStart: calendar.startOfDay(for: scannedAt),
+            updatedAt: scannedAt
+        ).rebasedForCurrentDay(now: now, calendar: calendar)
+
+        XCTAssertTrue(rebased.recentHourlyHistory.isEmpty)
+    }
+
+    /// Snapshots cached before the window widened decode to an empty lane and
+    /// no declared coverage, which is what makes the chart fall back to the two
+    /// days it can still prove rather than drawing twelve days of false zeros.
+    func testDecodingASnapshotWithoutTheHourlyWindowIsEmptyRatherThanOptimistic() throws {
+        let calendar = utcCalendar()
+        let hour = try XCTUnwrap(calendar.date(from: DateComponents(year: 2026, month: 5, day: 20, hour: 9)))
+        let legacy = CostSnapshot(
+            tool: .codex,
+            todayCostUSD: 1, last7DaysCostUSD: 1, last30DaysCostUSD: 1, allTimeCostUSD: 1,
+            todayTokens: 10, last7DaysTokens: 10, last30DaysTokens: 10, allTimeTokens: 10,
+            dailyHistory: [],
+            todayHourlyHistory: [HourlyCostPoint(date: hour, costUSD: 1, totalTokens: 10)],
+            heatmap: .empty(tool: .codex),
+            modelBreakdowns: [],
+            jsonlFilesFound: 1,
+            updatedAt: hour
+        )
+        var json = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: try JSONEncoder().encode(legacy)) as? [String: Any]
+        )
+        json.removeValue(forKey: "recentHourlyHistory")
+        json.removeValue(forKey: "hourlyCoverageStart")
+
+        let decoded = try JSONDecoder().decode(
+            CostSnapshot.self,
+            from: try JSONSerialization.data(withJSONObject: json)
+        )
+
+        XCTAssertTrue(decoded.recentHourlyHistory.isEmpty)
+        XCTAssertNil(decoded.hourlyCoverageStart)
+        XCTAssertEqual(decoded.todayHourlyHistory.count, 1)
+    }
+
+    func testHourlyWindowRoundTripsThroughCoding() throws {
+        let calendar = utcCalendar()
+        let hour = try XCTUnwrap(calendar.date(from: DateComponents(year: 2026, month: 5, day: 20, hour: 9)))
+        let start = calendar.startOfDay(for: hour)
+        let original = hourlySnapshot(hours: [hour], coverageStart: start, updatedAt: hour)
+
+        let decoded = try JSONDecoder().decode(
+            CostSnapshot.self,
+            from: try JSONEncoder().encode(original)
+        )
+
+        XCTAssertEqual(decoded.recentHourlyHistory, original.recentHourlyHistory)
+        XCTAssertEqual(decoded.hourlyCoverageStart, start)
+    }
 }

--- a/Tests/VibeBarCoreTests/CostUsageScannerTests.swift
+++ b/Tests/VibeBarCoreTests/CostUsageScannerTests.swift
@@ -100,6 +100,165 @@ final class CostUsageScannerTests: XCTestCase {
         XCTAssertEqual(snapshot.todayHourlyHistory.reduce(0) { $0 + $1.totalTokens }, 300_000)
     }
 
+    /// The reason Auto's new Hour step is reachable at all: hourly buckets now
+    /// span the whole retention window, not just yesterday and today.
+    func testCodexScanKeepsHourlyBucketsAcrossTheRetentionWindow() async throws {
+        let fileManager = FileManager.default
+        let home = fileManager.temporaryDirectory
+            .appendingPathComponent("VibeBarCostUsageRecentHourly-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fileManager.removeItem(at: home) }
+
+        let sessions = home
+            .appendingPathComponent(".codex", isDirectory: true)
+            .appendingPathComponent("sessions", isDirectory: true)
+        try fileManager.createDirectory(at: sessions, withIntermediateDirectories: true)
+
+        var calendar = Calendar.current
+        calendar.locale = Locale(identifier: "en_US_POSIX")
+        let now = try XCTUnwrap(calendar.date(from: DateComponents(year: 2026, month: 5, day: 20, hour: 20)))
+        let today = calendar.startOfDay(for: now)
+        // Four days back is inside the window and well past yesterday; twenty
+        // days back is outside it.
+        let inWindow = try XCTUnwrap(
+            calendar.date(byAdding: .hour, value: 10, to: calendar.date(byAdding: .day, value: -4, to: today)!)
+        )
+        let outOfWindow = try XCTUnwrap(
+            calendar.date(byAdding: .hour, value: 10, to: calendar.date(byAdding: .day, value: -20, to: today)!)
+        )
+        let lines = [
+            codexTokenCountLine(timestamp: outOfWindow, model: "gpt-5", input: 100_000, cached: 0, output: 0),
+            codexTokenCountLine(timestamp: inWindow, model: "gpt-5", input: 300_000, cached: 0, output: 0)
+        ]
+        try lines.joined(separator: "\n").write(
+            to: sessions.appendingPathComponent("session.jsonl"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let scanned = await CostUsageScanner.scan(tool: .codex, homeDirectory: home.path, now: now)
+        let snapshot = try XCTUnwrap(scanned)
+
+        XCTAssertEqual(
+            snapshot.hourlyCoverageStart,
+            CostChartWindowPolicy.hourlyRetentionStart(now: now, calendar: calendar)
+        )
+        let recentByHour = Dictionary(
+            uniqueKeysWithValues: snapshot.recentHourlyHistory.map { ($0.date, $0.totalTokens) }
+        )
+        XCTAssertEqual(recentByHour[inWindow], 200_000)
+        XCTAssertNil(recentByHour[outOfWindow], "a bucket outside the window must not be retained")
+        // Days with spend are zero-filled whole, so the line dips between
+        // sessions instead of cutting a diagonal across the idle hours.
+        XCTAssertEqual(
+            snapshot.recentHourlyHistory.filter { calendar.isDate($0.date, inSameDayAs: inWindow) }.count,
+            24
+        )
+        // Model detail follows the buckets, or the inspector would go blank for
+        // every hour older than yesterday.
+        XCTAssertEqual(snapshot.topModels(forHour: inWindow, limit: .max).count, 1)
+        XCTAssertTrue(snapshot.topModels(forHour: outOfWindow, limit: .max).isEmpty)
+    }
+
+    /// Idle days inside the window carry no buckets — `hourlyCoverageStart` is
+    /// what says they were scanned — but today and yesterday are always drawn,
+    /// so a chart opened on a quiet morning still reads as covered.
+    func testCodexScanAlwaysEmitsTodayAndYesterdayHourlyLanes() async throws {
+        let fileManager = FileManager.default
+        let home = fileManager.temporaryDirectory
+            .appendingPathComponent("VibeBarCostUsageIdleHourly-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fileManager.removeItem(at: home) }
+
+        let sessions = home
+            .appendingPathComponent(".codex", isDirectory: true)
+            .appendingPathComponent("sessions", isDirectory: true)
+        try fileManager.createDirectory(at: sessions, withIntermediateDirectories: true)
+
+        var calendar = Calendar.current
+        calendar.locale = Locale(identifier: "en_US_POSIX")
+        let now = try XCTUnwrap(calendar.date(from: DateComponents(year: 2026, month: 5, day: 20, hour: 6)))
+        let today = calendar.startOfDay(for: now)
+        let threeDaysBack = try XCTUnwrap(
+            calendar.date(byAdding: .hour, value: 10, to: calendar.date(byAdding: .day, value: -3, to: today)!)
+        )
+        try codexTokenCountLine(timestamp: threeDaysBack, model: "gpt-5", input: 100_000, cached: 0, output: 0)
+            .write(to: sessions.appendingPathComponent("session.jsonl"), atomically: true, encoding: .utf8)
+
+        let scanned = await CostUsageScanner.scan(tool: .codex, homeDirectory: home.path, now: now)
+        let snapshot = try XCTUnwrap(scanned)
+
+        let days = Set(snapshot.recentHourlyHistory.map { calendar.startOfDay(for: $0.date) })
+        let yesterday = try XCTUnwrap(calendar.date(byAdding: .day, value: -1, to: today))
+        XCTAssertTrue(days.contains(today))
+        XCTAssertTrue(days.contains(yesterday))
+        XCTAssertFalse(
+            days.contains(try XCTUnwrap(calendar.date(byAdding: .day, value: -2, to: today))),
+            "an idle day carries no buckets"
+        )
+        // Today stops at the hour in progress rather than drawing the rest of
+        // the day as zeros.
+        XCTAssertEqual(snapshot.recentHourlyHistory.filter { $0.date >= today }.count, 7)
+        XCTAssertEqual(snapshot.recentHourlyHistory.filter { $0.date >= today }, snapshot.todayHourlyHistory)
+        XCTAssertEqual(
+            snapshot.recentHourlyHistory.filter { calendar.isDate($0.date, inSameDayAs: yesterday) },
+            snapshot.yesterdayHourlyHistory
+        )
+    }
+
+    /// `recentHourlyHistory` is a superset of the two day lanes, so it must
+    /// never repeat an hour — a duplicate would both double the total and give
+    /// two chart marks the same identity.
+    func testRecentHourlyHistoryHasNoDuplicateHours() async throws {
+        let fileManager = FileManager.default
+        let home = fileManager.temporaryDirectory
+            .appendingPathComponent("VibeBarCostUsageHourlyDupes-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fileManager.removeItem(at: home) }
+
+        let sessions = home
+            .appendingPathComponent(".codex", isDirectory: true)
+            .appendingPathComponent("sessions", isDirectory: true)
+        try fileManager.createDirectory(at: sessions, withIntermediateDirectories: true)
+
+        var calendar = Calendar.current
+        calendar.timeZone = try XCTUnwrap(TimeZone(identifier: "America/New_York"))
+        calendar.locale = Locale(identifier: "en_US_POSIX")
+        // The day after a spring-forward: the window contains a 23-hour day, so
+        // fixed 24-offset arithmetic would spill one bucket into the next day.
+        let now = try XCTUnwrap(calendar.date(from: DateComponents(year: 2026, month: 3, day: 12, hour: 20)))
+        var lines: [String] = []
+        for dayOffset in 1...6 {
+            let day = try XCTUnwrap(
+                calendar.date(byAdding: .day, value: -dayOffset, to: calendar.startOfDay(for: now))
+            )
+            let stamp = try XCTUnwrap(calendar.date(byAdding: .hour, value: 12, to: day))
+            lines.append(
+                codexTokenCountLine(
+                    timestamp: stamp,
+                    model: "gpt-5",
+                    input: 100_000 * (dayOffset + 1),
+                    cached: 0,
+                    output: 0
+                )
+            )
+        }
+        try lines.joined(separator: "\n").write(
+            to: sessions.appendingPathComponent("session.jsonl"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let scanned = await CostUsageScanner.scan(tool: .codex, homeDirectory: home.path, now: now)
+        let snapshot = try XCTUnwrap(scanned)
+        let dates = snapshot.recentHourlyHistory.map(\.date)
+
+        XCTAssertEqual(Set(dates).count, dates.count, "hourly buckets must be unique")
+        XCTAssertEqual(dates, dates.sorted(), "hourly buckets must be ordered oldest first")
+        // The 23-hour day really is short, and the 24-hour ones really are not.
+        let shortDay = try XCTUnwrap(calendar.date(from: DateComponents(year: 2026, month: 3, day: 8)))
+        XCTAssertEqual(dates.filter { calendar.isDate($0, inSameDayAs: shortDay) }.count, 23)
+        let normalDay = try XCTUnwrap(calendar.date(from: DateComponents(year: 2026, month: 3, day: 9)))
+        XCTAssertEqual(dates.filter { calendar.isDate($0, inSameDayAs: normalDay) }.count, 24)
+    }
+
     func testCodexScanKeepsEveryPerHourAndPerDayModel() async throws {
         let fileManager = FileManager.default
         let home = fileManager.temporaryDirectory

--- a/Tests/VibeBarCoreTests/QuotaHistorySeriesBuilderTests.swift
+++ b/Tests/VibeBarCoreTests/QuotaHistorySeriesBuilderTests.swift
@@ -97,6 +97,160 @@ final class QuotaHistorySeriesBuilderTests: XCTestCase {
         XCTAssertEqual(series.actual[1].map(\.remainingPercent), [98, 94])
     }
 
+    func testJitteringResetEstimatesStayInOneSegment() {
+        // The bug this guards: a provider that reports "resets in N seconds"
+        // yields a slightly different absolute instant on every fetch. Exact
+        // comparison made every consecutive pair look like a new window, so a
+        // weekly lane became a run of one-point segments and drew nothing at
+        // all while its legend kept showing the right percentage.
+        let reset = base.addingTimeInterval(TimeInterval(week) / 2)
+        let drifts: [TimeInterval] = [0, -0.81, 0.34, -0.19, 0.94]
+        let points = drifts.enumerated().map { index, drift in
+            fill(
+                used: Double(10 + index),
+                at: base.addingTimeInterval(TimeInterval(index) * 3_600),
+                resetAt: reset.addingTimeInterval(drift)
+            )
+        }
+        let series = QuotaHistorySeriesBuilder.build(fillPoints: points, range: range())
+        XCTAssertEqual(series.actual.count, 1)
+        XCTAssertEqual(series.actual[0].map(\.remainingPercent), [90, 89, 88, 87, 86])
+        XCTAssertEqual(series.pace.count, 1)
+        XCTAssertEqual(series.pace[0].count, 5)
+    }
+
+    func testSampleAfterRecordedResetStartsNewSegment() {
+        // Crossing is the honest signal: the second sample is taken past the
+        // instant the first one said the window would refill.
+        let reset = base.addingTimeInterval(3_600)
+        let series = QuotaHistorySeriesBuilder.build(
+            fillPoints: [
+                fill(used: 80, at: base, resetAt: reset),
+                fill(
+                    used: 3,
+                    at: reset.addingTimeInterval(QuotaHistorySeriesBuilder.resetEstimateTolerance + 1),
+                    resetAt: reset.addingTimeInterval(TimeInterval(week))
+                )
+            ],
+            range: range()
+        )
+        XCTAssertEqual(series.actual.count, 2)
+    }
+
+    func testSampleInsideTheResetToleranceStaysInOneSegment() {
+        let reset = base.addingTimeInterval(3_600)
+        let series = QuotaHistorySeriesBuilder.build(
+            fillPoints: [
+                fill(used: 80, at: base, resetAt: reset),
+                // Still the same window: a sample a few seconds past a reset
+                // estimate has not proved anything refilled.
+                fill(used: 82, at: reset.addingTimeInterval(5), resetAt: reset.addingTimeInterval(0.4))
+            ],
+            range: range()
+        )
+        XCTAssertEqual(series.actual.count, 1)
+        XCTAssertEqual(series.actual[0].count, 2)
+    }
+
+    func testWindowLengthChangeStartsNewSegment() {
+        let reset = base.addingTimeInterval(TimeInterval(week) / 2)
+        let series = QuotaHistorySeriesBuilder.build(
+            fillPoints: [
+                fill(used: 40, at: base, resetAt: reset, windowSeconds: week),
+                // A count of seconds is not an estimate — the plan's shape
+                // really did change.
+                fill(used: 41, at: base.addingTimeInterval(3_600), resetAt: reset, windowSeconds: 18_000)
+            ],
+            range: range()
+        )
+        XCTAssertEqual(series.actual.count, 2)
+    }
+
+    func testActualDrawsForPointsWithoutResetMetadata() {
+        // Legacy weekly-style history: no reset instant was ever recorded, so
+        // nothing can be replayed — but the observations themselves are still
+        // evidence and have to draw.
+        let series = QuotaHistorySeriesBuilder.build(
+            fillPoints: (0..<4).map { index in
+                fill(
+                    used: Double(20 + index * 5),
+                    at: base.addingTimeInterval(TimeInterval(index) * 3_600),
+                    resetAt: nil,
+                    windowSeconds: week
+                )
+            },
+            range: range()
+        )
+        XCTAssertEqual(series.actual.count, 1)
+        XCTAssertEqual(series.actual[0].map(\.remainingPercent), [80, 75, 70, 65])
+        XCTAssertTrue(series.pace.isEmpty)
+    }
+
+    func testResetMetadataAppearingMidLaneDoesNotSplitTheActualLine() {
+        // Vibe Bar started recording `resetAt` partway through this lane's
+        // history. That is a change in what *we* stored, not evidence that the
+        // quota refilled, so the line stays continuous.
+        let reset = base.addingTimeInterval(TimeInterval(week) / 2)
+        let series = QuotaHistorySeriesBuilder.build(
+            fillPoints: [
+                fill(used: 20, at: base, resetAt: nil, windowSeconds: week),
+                fill(used: 24, at: base.addingTimeInterval(3_600), resetAt: nil, windowSeconds: week),
+                fill(used: 28, at: base.addingTimeInterval(7_200), resetAt: reset),
+                fill(used: 31, at: base.addingTimeInterval(10_800), resetAt: reset.addingTimeInterval(0.6))
+            ],
+            range: range()
+        )
+        XCTAssertEqual(series.actual.count, 1)
+        XCTAssertEqual(series.actual[0].count, 4)
+        XCTAssertEqual(series.pace.count, 1)
+        XCTAssertEqual(series.pace[0].count, 2)
+    }
+
+    func testNilResetPointsStillSplitOnSamplingGap() {
+        let series = QuotaHistorySeriesBuilder.build(
+            fillPoints: [
+                fill(used: 20, at: base, resetAt: nil, windowSeconds: week),
+                fill(used: 24, at: base.addingTimeInterval(3_600), resetAt: nil, windowSeconds: week),
+                // Beyond two hourly slots: coverage genuinely stopped.
+                fill(
+                    used: 61,
+                    at: base.addingTimeInterval(TimeInterval(3 * 3_600 + 1)),
+                    resetAt: nil,
+                    windowSeconds: week
+                )
+            ],
+            range: range()
+        )
+        XCTAssertEqual(series.actual.count, 2)
+        XCTAssertEqual(series.actual[0].count, 2)
+        XCTAssertEqual(series.actual[1].count, 1)
+    }
+
+    func testForecastToleratesJitteringResetEstimates() {
+        let reset = base.addingTimeInterval(TimeInterval(week) / 2)
+        let drifts: [TimeInterval] = [0.27, -0.63, 0.11]
+        var points: [ForecastTimelinePoint] = []
+        for (index, drift) in drifts.enumerated() {
+            let at: Date = base.addingTimeInterval(TimeInterval(index) * 3_600)
+            points.append(
+                forecast(
+                    projected: Double(50 + index),
+                    lower: 40,
+                    upper: 70,
+                    at: at,
+                    resetAt: reset.addingTimeInterval(drift)
+                )
+            )
+        }
+        let series = QuotaHistorySeriesBuilder.build(
+            fillPoints: [],
+            forecastPoints: points,
+            range: range()
+        )
+        XCTAssertEqual(series.forecast.count, 1)
+        XCTAssertEqual(series.forecast[0].count, 3)
+    }
+
     func testSamplingGapBeyondTwoSlotsStartsNewSegment() {
         let reset = base.addingTimeInterval(TimeInterval(week))
         // Weekly windows use hourly slots, so the split threshold is 2 hours —


### PR DESCRIPTION
Third iteration from AQ's hands-on feedback (screenshots on the popover).

## Fixes

- **Claude's quota chart was visibly broken** — root cause: providers reporting resets as a countdown yield a slightly different absolute `resetAt` on every fetch, and exact-equality segmentation collapsed nearly every window into undrawable single-point segments (weekly line missing entirely; 5-hour line ending 7.8h in the past, disagreeing with the legend). Segmentation now uses honest boundary signals (crossing the previous sample's reset instant / ≥half-window jump / changed window length); nil-`resetAt` points draw and split on sampling gaps alone. Verified against the real fill timeline: affected lanes went from 16/2/0 drawable segments to fully drawable with zero-lag right edges.
- **Lines no longer break** — consecutive segments bridge with faint dashed connectors (data stays solid, bridges read as "not data"), per AQ's request.
- **Charts sit immediately under their group** — embedded inside the utilization card right after each group's rows (all-models under all-models, Spark under Spark, AntiGravity in its own section), value-stable under the 30s countdown tick so pans aren't interrupted; standalone sibling cards removed.
- **Y-axis labels no longer overpainted** — plot content clips and the label gutter is floored; a bucket straddling the leading edge renders as a sliver instead of painting across "$0.00".
- **Granularity ladder rebalanced** (AQ: switch to Hour when bars get sparse, reach Month automatically): Auto = hour ≤5d, day ≤110d, week ≤240d, month beyond; **hourly retention widened to 14 days** (with an hourly-coverage start so idle days count as covered) so Hour actually works at 3-5d spans. Yesterday preset removed (navigation covers it); header pills wrap in narrow cards.

## New

- **Overview "Quota history" card**: every recorded quota curve across tools/accounts/buckets in one chart — provider-accent hues stepped per bucket, per-tool toggle pull-down (persisted as a hidden-curve set in AppSettings), full navigation, capped descending hover readout, legend chips that wrap.

## Verification

`swift build` clean · `swift test` **829 green** (804 on main + 25 net new across granularity/scanner/builder/settings) · `./Scripts/build_app.sh release` + strict codesign pass, entitlements empty (no `app-sandbox`) · home-directory grep clean · segmentation fix validated against real local fill-timeline data (no identifiers in code or tests).

Note: the Overview card is compile/test-verified but not visually smoke-tested (launching would spawn a second status item beside the running copy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)