### PR TITLE
Prepare Vibe Bar 1.1.0 Dev build 8

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -19,9 +19,9 @@
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleShortVersionString</key>
-    <string>1.0.0</string>
+    <string>1.1.0</string>
     <key>CFBundleVersion</key>
-    <string>7</string>
+    <string>8</string>
     <key>LSMinimumSystemVersion</key>
     <string>26.0</string>
     <key>LSUIElement</key>


### PR DESCRIPTION
Version bump for the Dev-channel release carrying PR #121 (history charts round 2): `CFBundleShortVersionString` 1.0.0 → 1.1.0, `CFBundleVersion` 7 → 8.

Verified in this worktree: `swift build` clean, 845 tests green, `./Scripts/build_app.sh release` + strict codesign pass, entitlements empty. After merge: tag `v1.1.0-dev.8` → release workflow → inspect draft → publish as Pre-release on the Dev channel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)