### PR TITLE
Prepare Vibe Bar 1.2.0 Dev build 9

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -19,9 +19,9 @@
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleShortVersionString</key>
-    <string>1.1.0</string>
+    <string>1.2.0</string>
     <key>CFBundleVersion</key>
-    <string>8</string>
+    <string>9</string>
     <key>LSMinimumSystemVersion</key>
     <string>26.0</string>
     <key>LSUIElement</key>


### PR DESCRIPTION
Version bump for the Dev-channel release carrying PR #123 (page layout editor + per-group quota modules): `CFBundleShortVersionString` 1.1.0 → 1.2.0, `CFBundleVersion` 8 → 9.

Verified in this worktree: `swift build` clean, 898 tests green, `./Scripts/build_app.sh release` + strict codesign pass, entitlements empty. After merge: tag `v1.2.0-dev.9` → release workflow → inspect draft → publish as Pre-release on the Dev channel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)