### PR TITLE
Add layout modes with compact packing and fix chart hover misses

### DIFF
--- a/Sources/VibeBarApp/PageLayoutModel.swift
+++ b/Sources/VibeBarApp/PageLayoutModel.swift
@@ -29,10 +29,42 @@ final class PageLayoutModel: ObservableObject {
     /// `@Published` — see the type comment.
     private var measured: [PageLayoutPageID: [PageLayoutModuleID: Double]] = [:]
 
+    /// Chosen partition per `compact` page, with the inputs it was chosen
+    /// from. Not `@Published` for the same reason the heights are not: it is
+    /// read and refreshed from inside a layout pass.
+    private var compactPackings: [PageLayoutPageID: CompactPacking] = [:]
+
     /// Sub-pixel wobble is not a layout change. Matches
     /// `PageLayoutStore.heightChangeEpsilon` so a measurement the store would
     /// discard never even reaches it.
     private static let heightEpsilon: Double = 0.5
+
+    /// Total height change, summed across a page's cards, before a `compact`
+    /// page is re-packed. A card settles over several passes as its content
+    /// arrives — a chart gets its axis, a quota card its second bucket — and
+    /// re-packing on each of those would shuffle cards while the user watches.
+    private static let compactRepackThreshold: Double = 4
+
+    /// How much shorter a fresh packing has to be before it displaces the one
+    /// already on screen.
+    ///
+    /// The two columns are not the same width, so a card that moves sides is
+    /// re-measured at a new height — which can be exactly the evidence that
+    /// sends it back. Requiring each move to strictly improve the page by this
+    /// margin makes such a cycle impossible: a loop would have to shorten the
+    /// page forever.
+    private static let compactRepackHysteresis: Double = 8
+
+    /// One `compact` page's chosen partition, plus everything it depended on.
+    private struct CompactPacking {
+        var moduleIDs: [PageLayoutModuleID]
+        var ratio: PageColumnRatio
+        var spacing: Double
+        /// Heights the partition was packed from — the baseline drift is
+        /// measured against.
+        var heights: [PageLayoutModuleID: Double]
+        var columns: [[PageLayoutModuleID]]
+    }
 
     private let settingsStore: SettingsStore
     private let store: PageLayoutStore
@@ -62,11 +94,26 @@ final class PageLayoutModel: ObservableObject {
         return stored.config(measuredHeights: measuredHeights(for: page))
     }
 
-    /// True when the user has arranged this page by hand. Pages answer this to
-    /// decide between their built-in layout path and fixed-order rendering.
+    /// How this page decides where its cards go. A page with no saved entry is
+    /// `auto`, which is also what every page was before modes existed.
+    func mode(for page: PageLayoutPageID) -> PageLayoutMode {
+        storedLayouts[page]?.mode ?? .auto
+    }
+
+    /// Width split this page renders at. Only consulted outside `auto`, where
+    /// each page keeps its built-in widths.
+    func ratio(for page: PageLayoutPageID) -> PageColumnRatio {
+        storedLayouts[page]?.ratio ?? PageModuleCatalog.defaultRatio(for: page)
+    }
+
+    /// True when the page no longer draws itself the way it always did. Pages
+    /// answer this to decide between their built-in layout path and fixed-order
+    /// rendering; the editor uses it for the "customized" marker.
+    ///
+    /// `compact` counts: the page is arranged by Vibe Bar, but by a rule the
+    /// user picked, not the one the page ships with.
     func isCustomized(_ page: PageLayoutPageID) -> Bool {
-        guard let stored = storedLayouts[page] else { return false }
-        return !stored.isEmpty
+        mode(for: page) != .auto
     }
 
     func measuredHeights(for page: PageLayoutPageID) -> [PageLayoutModuleID: Double] {
@@ -93,6 +140,118 @@ final class PageLayoutModel: ObservableObject {
         return resolved
     }
 
+    // MARK: - Modes
+
+    /// The arrangement this page should render right now, for whichever mode
+    /// it is in.
+    ///
+    /// The single place the three modes are turned into columns, so the
+    /// popover and the Settings preview cannot disagree about what `compact`
+    /// currently produces. The Overview's `auto` mode is the one caller that
+    /// does not render from this: it hands its cards to `ColumnMasonryLayout`
+    /// and lets SwiftUI balance them live. What comes back here for that case
+    /// is the same planner's answer the editor has always previewed.
+    func arrangement(
+        for page: PageLayoutPageID,
+        descriptors: [PageModuleDescriptor],
+        spacing: Double
+    ) -> PageLayoutConfig {
+        let defaults = PageModuleCatalog.defaultConfig(
+            for: page,
+            descriptors: descriptors,
+            measuredHeights: measuredHeights(for: page),
+            spacing: spacing
+        )
+        switch mode(for: page) {
+        case .auto:
+            var config = defaults
+            for (moduleID, height) in measuredHeights(for: page) {
+                config.measuredHeights[moduleID] = height
+            }
+            return config
+        case .compact:
+            return compactConfig(for: page, descriptors: descriptors, spacing: spacing)
+        case .manual:
+            return resolvedConfig(
+                for: page,
+                available: descriptors.map(\.id),
+                default: defaults
+            )
+        }
+    }
+
+    /// The shortest two-column arrangement of this page's cards.
+    ///
+    /// Memoized, and deliberately sticky. `PageLayoutPacker` is cheap, but the
+    /// answer it gives depends on heights that are still settling on the first
+    /// few passes after a page opens, and a card that changes column changes
+    /// width and therefore height. So a page is re-packed only once its cards
+    /// have moved by more than `compactRepackThreshold` in total, and the new
+    /// packing only replaces the visible one if it is shorter by more than
+    /// `compactRepackHysteresis`.
+    func compactConfig(
+        for page: PageLayoutPageID,
+        descriptors: [PageModuleDescriptor],
+        spacing: Double
+    ) -> PageLayoutConfig {
+        let ratio = ratio(for: page)
+        let moduleIDs = descriptors.map(\.id)
+        let measured = measuredHeights(for: page)
+        // A card the page has never drawn still has to be placed somewhere;
+        // its family's stand-in is what the editor draws it at too.
+        var heights: [PageLayoutModuleID: Double] = [:]
+        for descriptor in descriptors {
+            heights[descriptor.id] = measured[descriptor.id] ?? descriptor.fallbackHeight
+        }
+        let items = descriptors.map {
+            PageLayoutPacker.Item(id: $0.id, height: heights[$0.id] ?? 0)
+        }
+
+        var packing: CompactPacking
+        if var cached = compactPackings[page],
+           cached.moduleIDs == moduleIDs,
+           cached.ratio == ratio,
+           cached.spacing == spacing {
+            let drift = moduleIDs.reduce(0.0) { total, moduleID in
+                total + abs((heights[moduleID] ?? 0) - (cached.heights[moduleID] ?? 0))
+            }
+            if drift <= Self.compactRepackThreshold {
+                return config(columns: cached.columns, ratio: ratio, measured: measured)
+            }
+            let candidate = PageLayoutPacker.pack(items: items, spacing: spacing, ratio: ratio)
+            let onScreen = PageLayoutPacker.pageHeight(
+                columns: cached.columns,
+                heights: heights,
+                spacing: spacing
+            )
+            if candidate.pageHeight < onScreen - Self.compactRepackHysteresis {
+                cached.columns = candidate.columns
+            }
+            // Either way the baseline moves forward, so a page that keeps its
+            // arrangement is not re-evaluated on every single pass.
+            cached.heights = heights
+            packing = cached
+        } else {
+            packing = CompactPacking(
+                moduleIDs: moduleIDs,
+                ratio: ratio,
+                spacing: spacing,
+                heights: heights,
+                columns: PageLayoutPacker.pack(items: items, spacing: spacing, ratio: ratio).columns
+            )
+        }
+        compactPackings[page] = packing
+        return config(columns: packing.columns, ratio: ratio, measured: measured)
+    }
+
+    private func config(
+        columns: [[PageLayoutModuleID]],
+        ratio: PageColumnRatio,
+        measured: [PageLayoutModuleID: Double]
+    ) -> PageLayoutConfig {
+        PageLayoutConfig(ratio: ratio, columns: columns, measuredHeights: measured)
+    }
+
     // MARK: - Writing
 
     /// Persist an arrangement. `SettingsStore` writes through on assignment, so
@@ -103,41 +262,165 @@ final class PageLayoutModel: ObservableObject {
     /// replacing it — otherwise reordering one card would discard the saved
     /// position of every module that is temporarily unavailable (a quota group
     /// before the first refresh, cost cards before any session log is found).
+    /// - Parameter mode: an arrangement written by hand is a `manual` one, and
+    ///   the drag gesture is only offered in that mode, so this defaults to
+    ///   `manual` rather than being spelled out at every call site.
     func apply(
         _ config: PageLayoutConfig,
         for page: PageLayoutPageID,
-        available: [PageLayoutModuleID]
+        available: [PageLayoutModuleID],
+        mode: PageLayoutMode = .manual
     ) {
         let merged = PageLayoutResolver.mergingEdit(
             config,
             into: configuredConfig(for: page),
             available: available
         )
-        settingsStore.settings.pageLayouts[page] = StoredPageLayout(merged)
+        settingsStore.settings.pageLayouts[page] = StoredPageLayout(merged, mode: mode)
     }
 
-    /// Replace only the column ratio. Materializes the currently resolved
-    /// columns too — a ratio on its own is still a customization, and a page
-    /// left "uncustomized" would ignore it.
+    /// Switch a page between automatic, compact and hand-arranged.
+    ///
+    /// - Parameter displayed: the arrangement currently on screen. Switching
+    ///   to `manual` materializes it, so the first drag starts from what the
+    ///   user was looking at rather than from the built-in split.
+    func setMode(
+        _ mode: PageLayoutMode,
+        for page: PageLayoutPageID,
+        displayed: PageLayoutConfig,
+        available: [PageLayoutModuleID]
+    ) {
+        guard mode != self.mode(for: page) else { return }
+        switch mode {
+        case .manual:
+            apply(displayed, for: page, available: available, mode: .manual)
+        case .auto, .compact:
+            let stored = storedLayouts[page]
+            settingsStore.settings.pageLayouts[page] = StoredPageLayout(
+                mode: mode,
+                ratio: stored?.ratio ?? displayed.ratio,
+                // A hand arrangement survives a trip through the computed
+                // modes: switching away and back is not a reset, and only
+                // `reset(for:)` forgets a page.
+                columns: stored?.columns ?? []
+            )
+        }
+        compactPackings.removeValue(forKey: page)
+    }
+
+    /// Replace only the column ratio.
+    ///
+    /// In `compact` the ratio is one of the packer's inputs, so it is stored on
+    /// its own and the page re-packs. In the other two modes it materializes
+    /// the currently resolved columns as well: picking a width split has always
+    /// been a way to take a page over, and a page left on `auto` would ignore
+    /// the ratio entirely.
     func setRatio(
         _ ratio: PageColumnRatio,
         for page: PageLayoutPageID,
         resolved: PageLayoutConfig,
         available: [PageLayoutModuleID]
     ) {
+        guard mode(for: page) != .compact else {
+            let stored = storedLayouts[page]
+            settingsStore.settings.pageLayouts[page] = StoredPageLayout(
+                mode: .compact,
+                ratio: ratio,
+                columns: stored?.columns ?? []
+            )
+            compactPackings.removeValue(forKey: page)
+            return
+        }
         var next = resolved
         next.ratio = ratio
-        apply(next, for: page, available: available)
+        apply(next, for: page, available: available, mode: .manual)
     }
 
     /// Forget a page's arrangement, returning it to the built-in layout. The
     /// only path that discards saved intent, including the positions of modules
-    /// that are not on screen.
+    /// that are not on screen. Saved presets are untouched — they exist so an
+    /// arrangement survives exactly this.
     func reset(for page: PageLayoutPageID) {
         settingsStore.settings.pageLayouts.removeValue(forKey: page)
         measured.removeValue(forKey: page)
+        compactPackings.removeValue(forKey: page)
         Task { [store] in
             await store.clearMeasuredHeights(for: page)
+        }
+    }
+
+    // MARK: - Presets
+
+    func presets(for page: PageLayoutPageID) -> [StoredPageLayoutPreset] {
+        settingsStore.settings.pageLayoutPresets[page] ?? []
+    }
+
+    func canSavePreset(for page: PageLayoutPageID) -> Bool {
+        presets(for: page).count < AppSettings.maximumPresetsPerPage
+    }
+
+    /// What "save the current arrangement" captures.
+    ///
+    /// A hand-arranged page's saved entry knows more than the screen does — it
+    /// still remembers where modules the page cannot draw right now belong — so
+    /// that is what gets stored. A computed page has no such entry, so the
+    /// arrangement it is showing is captured instead.
+    func presetSnapshot(
+        for page: PageLayoutPageID,
+        displayed: PageLayoutConfig
+    ) -> StoredPageLayout {
+        let mode = mode(for: page)
+        if mode == .manual, let stored = storedLayouts[page], !stored.isEmpty {
+            return stored
+        }
+        return StoredPageLayout(mode: mode, ratio: displayed.ratio, columns: displayed.columns)
+    }
+
+    /// Save an arrangement under a name, replacing a preset of the same name in
+    /// place. Returns false when the name is blank or the page is already
+    /// holding as many presets as it may.
+    @discardableResult
+    func savePreset(
+        named name: String,
+        for page: PageLayoutPageID,
+        layout: StoredPageLayout
+    ) -> Bool {
+        let preset = StoredPageLayoutPreset(name: name, layout: layout)
+        guard preset.isValid else { return false }
+        var entries = presets(for: page)
+        if let index = entries.firstIndex(where: { $0.name.lowercased() == preset.name.lowercased() }) {
+            entries[index] = preset
+        } else {
+            guard entries.count < AppSettings.maximumPresetsPerPage else { return false }
+            entries.append(preset)
+        }
+        settingsStore.settings.pageLayoutPresets[page] = entries
+        return true
+    }
+
+    /// Put a saved arrangement back. Always lands in `manual`: a preset is one
+    /// specific arrangement, and re-entering `compact` would recompute from
+    /// whatever the heights happen to be now instead of restoring it.
+    ///
+    /// The columns are written verbatim; `PageLayoutResolver` reconciles them
+    /// against the modules the page can actually draw at render time, so a
+    /// preset saved when a provider was signed in still applies afterwards.
+    func applyPreset(_ preset: StoredPageLayoutPreset, to page: PageLayoutPageID) {
+        settingsStore.settings.pageLayouts[page] = StoredPageLayout(
+            mode: .manual,
+            ratio: preset.layout.ratio,
+            columns: preset.layout.columns
+        )
+        compactPackings.removeValue(forKey: page)
+    }
+
+    func deletePreset(named name: String, for page: PageLayoutPageID) {
+        let key = StoredPageLayoutPreset.normalizedName(name).lowercased()
+        let remaining = presets(for: page).filter { $0.name.lowercased() != key }
+        if remaining.isEmpty {
+            settingsStore.settings.pageLayoutPresets.removeValue(forKey: page)
+        } else {
+            settingsStore.settings.pageLayoutPresets[page] = remaining
         }
     }
 

--- a/Sources/VibeBarApp/PageLayoutModel.swift
+++ b/Sources/VibeBarApp/PageLayoutModel.swift
@@ -282,8 +282,10 @@ final class PageLayoutModel: ObservableObject {
     /// Switch a page between automatic, compact and hand-arranged.
     ///
     /// - Parameter displayed: the arrangement currently on screen. Switching
-    ///   to `manual` materializes it, so the first drag starts from what the
-    ///   user was looking at rather than from the built-in split.
+    ///   to `manual` materializes it *only* when the page has no hand
+    ///   arrangement saved, so a first drag starts from what the user was
+    ///   looking at rather than from the built-in split. A page that was
+    ///   arranged before gets its own arrangement back instead.
     func setMode(
         _ mode: PageLayoutMode,
         for page: PageLayoutPageID,
@@ -293,7 +295,18 @@ final class PageLayoutModel: ObservableObject {
         guard mode != self.mode(for: page) else { return }
         switch mode {
         case .manual:
-            apply(displayed, for: page, available: available, mode: .manual)
+            // A page that was arranged by hand before it was switched to a
+            // computed mode gets that arrangement back, not the one Compact
+            // or the balancer happened to be showing. Keeping the columns
+            // through `auto`/`compact` would be pointless if returning to
+            // Manual overwrote them. `restoredAsManual` is `nil` only when
+            // there is nothing to restore, and then the arrangement on screen
+            // is the right place for a first-time edit to start.
+            if let restored = storedLayouts[page]?.restoredAsManual() {
+                settingsStore.settings.pageLayouts[page] = restored
+            } else {
+                apply(displayed, for: page, available: available, mode: .manual)
+            }
         case .auto, .compact:
             let stored = storedLayouts[page]
             settingsStore.settings.pageLayouts[page] = StoredPageLayout(
@@ -355,8 +368,25 @@ final class PageLayoutModel: ObservableObject {
         settingsStore.settings.pageLayoutPresets[page] ?? []
     }
 
-    func canSavePreset(for page: PageLayoutPageID) -> Bool {
+    /// True when this page has room for a preset it does not already have.
+    /// Replacing one by name stays possible either way — see
+    /// `presetWouldReplace(named:for:)`.
+    func canAddPreset(for page: PageLayoutPageID) -> Bool {
         presets(for: page).count < AppSettings.maximumPresetsPerPage
+    }
+
+    /// True when saving under this name would overwrite a preset the page
+    /// already has, rather than adding one. A replacement leaves the count
+    /// unchanged, so it is allowed even on a full page.
+    func presetWouldReplace(named name: String, for page: PageLayoutPageID) -> Bool {
+        StoredPageLayoutPreset.index(of: name, in: presets(for: page)) != nil
+    }
+
+    /// Whether `savePreset` would succeed, so the editor can say why not
+    /// before the user commits to a name.
+    func canSavePreset(named name: String, for page: PageLayoutPageID) -> Bool {
+        guard !StoredPageLayoutPreset.normalizedName(name).isEmpty else { return false }
+        return presetWouldReplace(named: name, for: page) || canAddPreset(for: page)
     }
 
     /// What "save the current arrangement" captures.
@@ -377,8 +407,11 @@ final class PageLayoutModel: ObservableObject {
     }
 
     /// Save an arrangement under a name, replacing a preset of the same name in
-    /// place. Returns false when the name is blank or the page is already
-    /// holding as many presets as it may.
+    /// place and keeping its position in the menu.
+    ///
+    /// Returns false only when the name is blank, or when it is a *new* name on
+    /// a page already holding as many presets as it may. Replacing is never
+    /// blocked by the cap: it does not add anything.
     @discardableResult
     func savePreset(
         named name: String,
@@ -388,7 +421,7 @@ final class PageLayoutModel: ObservableObject {
         let preset = StoredPageLayoutPreset(name: name, layout: layout)
         guard preset.isValid else { return false }
         var entries = presets(for: page)
-        if let index = entries.firstIndex(where: { $0.name.lowercased() == preset.name.lowercased() }) {
+        if let index = StoredPageLayoutPreset.index(of: preset.name, in: entries) {
             entries[index] = preset
         } else {
             guard entries.count < AppSettings.maximumPresetsPerPage else { return false }
@@ -415,8 +448,9 @@ final class PageLayoutModel: ObservableObject {
     }
 
     func deletePreset(named name: String, for page: PageLayoutPageID) {
-        let key = StoredPageLayoutPreset.normalizedName(name).lowercased()
-        let remaining = presets(for: page).filter { $0.name.lowercased() != key }
+        var remaining = presets(for: page)
+        guard let index = StoredPageLayoutPreset.index(of: name, in: remaining) else { return }
+        remaining.remove(at: index)
         if remaining.isEmpty {
             settingsStore.settings.pageLayoutPresets.removeValue(forKey: page)
         } else {

--- a/Sources/VibeBarApp/Views/ChartBrushNavigator.swift
+++ b/Sources/VibeBarApp/Views/ChartBrushNavigator.swift
@@ -325,26 +325,16 @@ enum QuotaChartMarks {
     }
 
     /// Keep one sample beyond each edge so a line entering the window starts at
-    /// the frame border instead of at its first visible observation.
+    /// the frame border instead of at its first visible observation — and keep
+    /// the straddling pair when a segment crosses the window without landing a
+    /// sample in it. Both rules live in `ChartSegmentClip`, which is where they
+    /// are tested.
     static func clip<Element>(
         _ segment: [Element],
         time: (Element) -> Date,
         to range: ClosedRange<Date>
     ) -> [Element] {
-        guard !segment.isEmpty else { return [] }
-        var first: Int?
-        var last: Int?
-        for (index, element) in segment.enumerated() {
-            let stamp = time(element)
-            if stamp >= range.lowerBound, stamp <= range.upperBound {
-                if first == nil { first = index }
-                last = index
-            }
-        }
-        guard let first, let last else { return [] }
-        let lower = max(0, first - 1)
-        let upper = min(segment.count - 1, last + 1)
-        return Array(segment[lower...upper])
+        ChartSegmentClip.visible(segment, time: time, to: range)
     }
 
     /// How a bridge is stroked, everywhere one is drawn.

--- a/Sources/VibeBarApp/Views/LayoutEditorView.swift
+++ b/Sources/VibeBarApp/Views/LayoutEditorView.swift
@@ -1,7 +1,8 @@
 import SwiftUI
 import VibeBarCore
 
-/// Settings → Layout: arrange each popover page's cards into two columns.
+/// Settings → Layout: choose how each popover page arranges its cards, and
+/// arrange them by hand when that is what you want.
 ///
 /// The blocks are drawn at the cards' *measured* heights, scaled down. A list
 /// of equal-sized rows would make the two columns look balanced when the real
@@ -10,6 +11,12 @@ import VibeBarCore
 /// Modules and their names come from `PageModuleCatalog` — the same registry
 /// the popover pages render from — so a card that appears in the popover
 /// appears here, with the same identity, without a second list to maintain.
+///
+/// The three modes are not three editors. `PageLayoutModel.arrangement` hands
+/// back whatever the selected mode currently produces, and this screen draws
+/// that; only in `manual` are the blocks draggable. So what the editor shows is
+/// what the popover shows, including a `compact` packing that will move again
+/// the next time the cards are measured.
 struct LayoutEditorView: View {
     @EnvironmentObject private var environment: AppEnvironment
     @EnvironmentObject private var settingsStore: SettingsStore
@@ -30,6 +37,8 @@ struct LayoutEditorView: View {
     /// other page's position.
     @State private var blockFrames: [String: CGRect] = [:]
     @State private var zoneFrames: [Int: CGRect] = [:]
+    @State private var isNamingPreset = false
+    @State private var presetName = ""
 
     private static let space = "vibebar.layout.editor"
     /// A card is never shorter than this in the editor, however short it is on
@@ -77,7 +86,8 @@ struct LayoutEditorView: View {
             environment: environment,
             settings: settingsStore.settings
         )
-        let config = resolvedConfig(for: page, descriptors: descriptors)
+        let mode = layoutModel.mode(for: page)
+        let config = displayedConfig(for: page, descriptors: descriptors)
         let blocks = Dictionary(
             descriptors.map { descriptor in
                 (descriptor.id, Block(descriptor: descriptor, measured: config.measuredHeight(for: descriptor.id)))
@@ -87,6 +97,7 @@ struct LayoutEditorView: View {
 
         VStack(alignment: .leading, spacing: 12) {
             pagePicker(pages: pages, selected: page)
+            modeRow(page: page, mode: mode, config: config)
             controlRow(page: page, config: config)
             if descriptors.isEmpty {
                 Text("This page has no arrangeable cards yet. Open it in the popover once so Vibe Bar can measure them.")
@@ -95,11 +106,11 @@ struct LayoutEditorView: View {
                     .frame(maxWidth: .infinity, alignment: .leading)
             } else {
                 HStack(alignment: .top, spacing: 14) {
-                    zones(page: page, config: config, blocks: blocks)
+                    zones(page: page, config: config, blocks: blocks, mode: mode)
                     preview(config: config, blocks: blocks)
                 }
             }
-            Text(footnote(page: page))
+            Text(footnote(page: page, mode: mode))
                 .font(.caption2)
                 .foregroundStyle(.secondary)
                 .fixedSize(horizontal: false, vertical: true)
@@ -117,6 +128,9 @@ struct LayoutEditorView: View {
             // A provider hidden from the popover takes its page with it.
             if selectedPage != newValue { selectedPage = newValue }
             drag = nil
+            // The name sheet belongs to the page it was opened from; carrying
+            // it across would save the new page's arrangement under it.
+            isNamingPreset = false
         }
     }
 
@@ -169,7 +183,177 @@ struct LayoutEditorView: View {
         )
     }
 
-    // MARK: - Ratio + reset
+    // MARK: - Mode + presets
+
+    private func modeRow(
+        page: PageLayoutPageID,
+        mode: PageLayoutMode,
+        config: PageLayoutConfig
+    ) -> some View {
+        HStack(spacing: 10) {
+            HStack(spacing: 4) {
+                ForEach(PageLayoutMode.allCases, id: \.self) { candidate in
+                    modeButton(candidate, page: page, selected: mode, config: config)
+                }
+            }
+            .padding(3)
+            .background(
+                Capsule(style: .continuous)
+                    .fill(Color.primary.opacity(0.045))
+            )
+            Spacer(minLength: 8)
+            presetsMenu(page: page, config: config)
+            Button {
+                layoutModel.reset(for: page)
+            } label: {
+                Label("Restore Defaults", systemImage: "arrow.uturn.backward")
+                    .font(.system(size: 11))
+            }
+            .disabled(!layoutModel.isCustomized(page))
+        }
+    }
+
+    private func modeButton(
+        _ mode: PageLayoutMode,
+        page: PageLayoutPageID,
+        selected: PageLayoutMode,
+        config: PageLayoutConfig
+    ) -> some View {
+        let isSelected = mode == selected
+        return Button {
+            layoutModel.setMode(
+                mode,
+                for: page,
+                displayed: config,
+                available: availableModuleIDs(for: page)
+            )
+        } label: {
+            HStack(spacing: 5) {
+                Image(systemName: modeIcon(mode))
+                    .font(.system(size: 10, weight: .medium))
+                Text(modeLabel(mode))
+                    .font(.system(size: 11.5, weight: .semibold, design: .rounded))
+            }
+            .foregroundStyle(isSelected ? Color.primary : Color.secondary)
+            .padding(.horizontal, 11)
+            .frame(height: 24)
+            .background {
+                if isSelected {
+                    Capsule(style: .continuous)
+                        .fill(Color.accentColor.opacity(0.20))
+                        .overlay(
+                            Capsule(style: .continuous)
+                                .stroke(Color.accentColor.opacity(0.34), lineWidth: 0.7)
+                        )
+                }
+            }
+            .contentShape(Capsule(style: .continuous))
+        }
+        .buttonStyle(.plain)
+        .focusable(false)
+        .help(modeHelp(mode, page: page))
+    }
+
+    private func modeLabel(_ mode: PageLayoutMode) -> String {
+        switch mode {
+        case .auto: "Auto"
+        case .compact: "Compact"
+        case .manual: "Manual"
+        }
+    }
+
+    private func modeIcon(_ mode: PageLayoutMode) -> String {
+        switch mode {
+        case .auto: "wand.and.stars"
+        case .compact: "arrow.down.forward.and.arrow.up.backward"
+        case .manual: "hand.point.up.left"
+        }
+    }
+
+    private func modeHelp(_ mode: PageLayoutMode, page: PageLayoutPageID) -> String {
+        switch mode {
+        case .auto:
+            return page.isOverview
+                ? "Auto — the Overview balances its columns as the cards are measured."
+                : "Auto — this page's built-in arrangement."
+        case .compact:
+            return "Compact — pack the cards into the shortest page they fit in."
+        case .manual:
+            return "Manual — your arrangement, exactly as you dragged it."
+        }
+    }
+
+    private func presetsMenu(page: PageLayoutPageID, config: PageLayoutConfig) -> some View {
+        let presets = layoutModel.presets(for: page)
+        return Menu {
+            Button("Save Current…") {
+                presetName = ""
+                isNamingPreset = true
+            }
+            .disabled(!layoutModel.canSavePreset(for: page))
+            if presets.isEmpty {
+                Text("No saved arrangements")
+            } else {
+                Divider()
+                ForEach(presets, id: \.name) { preset in
+                    Menu(preset.name) {
+                        Button("Apply") {
+                            layoutModel.applyPreset(preset, to: page)
+                        }
+                        Button("Delete", role: .destructive) {
+                            layoutModel.deletePreset(named: preset.name, for: page)
+                        }
+                    }
+                }
+            }
+        } label: {
+            Label("Presets", systemImage: "square.stack.3d.up")
+                .font(.system(size: 11))
+        }
+        .menuStyle(.borderlessButton)
+        .fixedSize()
+        .help(
+            layoutModel.canSavePreset(for: page)
+                ? "Save this arrangement under a name, or put a saved one back."
+                : "This page is already holding \(AppSettings.maximumPresetsPerPage) saved arrangements."
+        )
+        .popover(isPresented: $isNamingPreset, arrowEdge: .bottom) {
+            presetNameForm(page: page, config: config)
+        }
+    }
+
+    private func presetNameForm(page: PageLayoutPageID, config: PageLayoutConfig) -> some View {
+        VStack(alignment: .leading, spacing: 9) {
+            Text("Save arrangement")
+                .font(.system(size: 12, weight: .semibold))
+            Text("Saving “\(modeLabel(layoutModel.mode(for: page)))” as it stands now. Applying it later arranges the page by hand.")
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+                .frame(width: 230, alignment: .leading)
+            TextField("Name", text: $presetName)
+                .textFieldStyle(.roundedBorder)
+                .frame(width: 230)
+                .onSubmit { savePreset(page: page, config: config) }
+            HStack {
+                Spacer(minLength: 0)
+                Button("Cancel") { isNamingPreset = false }
+                Button("Save") { savePreset(page: page, config: config) }
+                    .keyboardShortcut(.defaultAction)
+                    .disabled(StoredPageLayoutPreset.normalizedName(presetName).isEmpty)
+            }
+        }
+        .padding(13)
+    }
+
+    private func savePreset(page: PageLayoutPageID, config: PageLayoutConfig) {
+        let snapshot = layoutModel.presetSnapshot(for: page, displayed: config)
+        guard layoutModel.savePreset(named: presetName, for: page, layout: snapshot) else { return }
+        presetName = ""
+        isNamingPreset = false
+    }
+
+    // MARK: - Ratio + status
 
     private func controlRow(page: PageLayoutPageID, config: PageLayoutConfig) -> some View {
         HStack(spacing: 10) {
@@ -186,13 +370,6 @@ struct LayoutEditorView: View {
                     .font(.system(size: 10, weight: .semibold))
                     .foregroundStyle(.tertiary)
             }
-            Button {
-                layoutModel.reset(for: page)
-            } label: {
-                Label("Restore Defaults", systemImage: "arrow.uturn.backward")
-                    .font(.system(size: 11))
-            }
-            .disabled(!layoutModel.isCustomized(page))
         }
     }
 
@@ -262,25 +439,38 @@ struct LayoutEditorView: View {
     private func zones(
         page: PageLayoutPageID,
         config: PageLayoutConfig,
-        blocks: [PageLayoutModuleID: Block]
+        blocks: [PageLayoutModuleID: Block],
+        mode: PageLayoutMode
     ) -> some View {
         let totals = (0..<PageLayoutConfig.columnCount).map { index in
             config.column(index).reduce(0.0) { $0 + (blocks[$1]?.height ?? 0) }
         }
         let scale = min(0.4, Self.editorColumnHeight / max(1, totals.max() ?? 1))
-        let target = dropTarget(page: page, config: config)
-        return HStack(alignment: .top, spacing: 10) {
-            ForEach(0..<PageLayoutConfig.columnCount, id: \.self) { index in
-                zone(
-                    index,
-                    page: page,
-                    config: config,
-                    blocks: blocks,
-                    total: totals[index],
-                    scale: scale,
-                    insertionIndex: target?.column == index ? target?.index : nil
-                )
-                .frame(maxWidth: .infinity, alignment: .topLeading)
+        // Only `manual` is an editor. The other two modes show what they
+        // currently produce as a read-only picture, so a drag cannot silently
+        // discard an arrangement the app is about to recompute.
+        let isEditable = mode == .manual
+        let target = isEditable ? dropTarget(page: page, config: config) : nil
+        return VStack(alignment: .leading, spacing: 7) {
+            HStack(alignment: .top, spacing: 10) {
+                ForEach(0..<PageLayoutConfig.columnCount, id: \.self) { index in
+                    zone(
+                        index,
+                        page: page,
+                        config: config,
+                        blocks: blocks,
+                        total: totals[index],
+                        scale: scale,
+                        isEditable: isEditable,
+                        insertionIndex: target?.column == index ? target?.index : nil
+                    )
+                    .frame(maxWidth: .infinity, alignment: .topLeading)
+                }
+            }
+            if !isEditable {
+                Label("Switch to Manual to arrange by hand", systemImage: "hand.point.up.left")
+                    .font(.system(size: 10))
+                    .foregroundStyle(.tertiary)
             }
         }
     }
@@ -292,6 +482,7 @@ struct LayoutEditorView: View {
         blocks: [PageLayoutModuleID: Block],
         total: Double,
         scale: Double,
+        isEditable: Bool,
         insertionIndex: Int?
     ) -> some View {
         let moduleIDs = config.column(index)
@@ -308,7 +499,7 @@ struct LayoutEditorView: View {
             VStack(spacing: Self.blockSpacing) {
                 ForEach(moduleIDs, id: \.self) { moduleID in
                     if let block = blocks[moduleID] {
-                        blockView(block, page: page, config: config, scale: scale)
+                        blockView(block, page: page, config: config, scale: scale, isEditable: isEditable)
                             // The card stays where it is, dimmed, while its
                             // ghost floats: pulling it out of the stack would
                             // shift every block below it, moving the very
@@ -375,24 +566,30 @@ struct LayoutEditorView: View {
         return frame.minY - zone.minY - Self.blockSpacing / 2
     }
 
+    @ViewBuilder
     private func blockView(
         _ block: Block,
         page: PageLayoutPageID,
         config: PageLayoutConfig,
-        scale: Double
+        scale: Double,
+        isEditable: Bool
     ) -> some View {
         let height = max(Self.minimumBlockHeight, CGFloat(block.height * scale))
-        return blockBody(block, height: height)
+        let body = blockBody(block, height: height, isEditable: isEditable)
             .onGeometryChange(for: CGRect.self) { proxy in
                 proxy.frame(in: .named(Self.space))
             } action: { frame in
                 blockFrames[frameKey(page, block.id)] = frame
             }
-            .gesture(dragGesture(block: block, page: page, config: config, height: height))
             .help("\(block.descriptor.displayName) · \(block.heightLabel)")
+        if isEditable {
+            body.gesture(dragGesture(block: block, page: page, config: config, height: height))
+        } else {
+            body
+        }
     }
 
-    private func blockBody(_ block: Block, height: CGFloat) -> some View {
+    private func blockBody(_ block: Block, height: CGFloat, isEditable: Bool) -> some View {
         let accent = block.descriptor.accent.color
         return HStack(alignment: .top, spacing: 7) {
             RoundedRectangle(cornerRadius: 1.5, style: .continuous)
@@ -409,9 +606,13 @@ struct LayoutEditorView: View {
                     .foregroundStyle(.secondary)
             }
             Spacer(minLength: 0)
-            Image(systemName: "line.3.horizontal")
-                .font(.system(size: 9, weight: .medium))
-                .foregroundStyle(.tertiary)
+            // The grip is the affordance, so it appears only where dragging
+            // actually does something.
+            if isEditable {
+                Image(systemName: "line.3.horizontal")
+                    .font(.system(size: 9, weight: .medium))
+                    .foregroundStyle(.tertiary)
+            }
         }
         .padding(.horizontal, 7)
         .padding(.vertical, 5)
@@ -608,34 +809,34 @@ struct LayoutEditorView: View {
         .map(\.id)
     }
 
-    private func resolvedConfig(
+    /// Exactly what the popover would draw for this page right now — the same
+    /// call the popover itself makes, so the two cannot disagree.
+    private func displayedConfig(
         for page: PageLayoutPageID,
         descriptors: [PageModuleDescriptor]
     ) -> PageLayoutConfig {
-        let defaults = PageModuleCatalog.defaultConfig(
+        layoutModel.arrangement(
             for: page,
             descriptors: descriptors,
-            measuredHeights: layoutModel.measuredHeights(for: page),
-            // The popover's own card gap, so the Overview default the editor
-            // shows is the column split the balancer actually produced.
+            // The popover's own card gap, so the arrangement the editor shows
+            // is the one the popover's spacing produces.
             spacing: Double(
                 Theme.overviewDensity(for: settingsStore.settings.popoverDensity).interSectionSpacing
             )
         )
-        return layoutModel.resolvedConfig(
-            for: page,
-            available: descriptors.map(\.id),
-            default: defaults
-        )
     }
 
-    private func footnote(page: PageLayoutPageID) -> String {
-        if layoutModel.isCustomized(page) {
+    private func footnote(page: PageLayoutPageID, mode: PageLayoutMode) -> String {
+        switch mode {
+        case .manual:
             return "Drag a card to reorder it or move it between columns. Cards are drawn at their measured height, so the taller column here is the taller column in the popover. A card with no measurement yet shows “—pt”."
+        case .compact:
+            return "Compact packs the cards into whichever two columns make the page shortest, ignoring the usual quota-then-cost grouping. It re-packs when the measured heights move enough to change the answer."
+        case .auto:
+            if page.isOverview {
+                return "The Overview balances its columns automatically, quota cards first. Blocks below show what that balance currently produces."
+            }
+            return "This page uses its built-in arrangement. Pick Compact or Manual, or a width split, to take it over."
         }
-        if page.isOverview {
-            return "The Overview balances its columns automatically until you move a card. Blocks below show what that balance currently produces."
-        }
-        return "This page uses its built-in arrangement. Drag a card, or pick a width split, to take it over."
     }
 }

--- a/Sources/VibeBarApp/Views/LayoutEditorView.swift
+++ b/Sources/VibeBarApp/Views/LayoutEditorView.swift
@@ -286,11 +286,12 @@ struct LayoutEditorView: View {
     private func presetsMenu(page: PageLayoutPageID, config: PageLayoutConfig) -> some View {
         let presets = layoutModel.presets(for: page)
         return Menu {
+            // Reachable even on a full page: replacing a preset by name costs
+            // no slot, and the form below is where that is explained.
             Button("Save Current…") {
                 presetName = ""
                 isNamingPreset = true
             }
-            .disabled(!layoutModel.canSavePreset(for: page))
             if presets.isEmpty {
                 Text("No saved arrangements")
             } else {
@@ -313,9 +314,9 @@ struct LayoutEditorView: View {
         .menuStyle(.borderlessButton)
         .fixedSize()
         .help(
-            layoutModel.canSavePreset(for: page)
+            layoutModel.canAddPreset(for: page)
                 ? "Save this arrangement under a name, or put a saved one back."
-                : "This page is already holding \(AppSettings.maximumPresetsPerPage) saved arrangements."
+                : "This page is holding all \(AppSettings.maximumPresetsPerPage) saved arrangements — save over one by reusing its name."
         )
         .popover(isPresented: $isNamingPreset, arrowEdge: .bottom) {
             presetNameForm(page: page, config: config)
@@ -323,7 +324,12 @@ struct LayoutEditorView: View {
     }
 
     private func presetNameForm(page: PageLayoutPageID, config: PageLayoutConfig) -> some View {
-        VStack(alignment: .leading, spacing: 9) {
+        let trimmed = StoredPageLayoutPreset.normalizedName(presetName)
+        let replaces = layoutModel.presetWouldReplace(named: trimmed, for: page)
+        // Only a genuinely new name is blocked by the cap; reusing an existing
+        // one overwrites it and leaves the count where it was.
+        let blockedByLimit = !trimmed.isEmpty && !replaces && !layoutModel.canAddPreset(for: page)
+        return VStack(alignment: .leading, spacing: 9) {
             Text("Save arrangement")
                 .font(.system(size: 12, weight: .semibold))
             Text("Saving “\(modeLabel(layoutModel.mode(for: page)))” as it stands now. Applying it later arranges the page by hand.")
@@ -335,12 +341,28 @@ struct LayoutEditorView: View {
                 .textFieldStyle(.roundedBorder)
                 .frame(width: 230)
                 .onSubmit { savePreset(page: page, config: config) }
+            if blockedByLimit {
+                Label(
+                    "Preset limit reached — use an existing name to replace.",
+                    systemImage: "exclamationmark.triangle"
+                )
+                .font(.caption2)
+                .foregroundStyle(.orange)
+                .fixedSize(horizontal: false, vertical: true)
+                .frame(width: 230, alignment: .leading)
+            } else if replaces {
+                Label("Replaces “\(trimmed)”.", systemImage: "arrow.triangle.2.circlepath")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .frame(width: 230, alignment: .leading)
+            }
             HStack {
                 Spacer(minLength: 0)
                 Button("Cancel") { isNamingPreset = false }
-                Button("Save") { savePreset(page: page, config: config) }
+                Button(replaces ? "Replace" : "Save") { savePreset(page: page, config: config) }
                     .keyboardShortcut(.defaultAction)
-                    .disabled(StoredPageLayoutPreset.normalizedName(presetName).isEmpty)
+                    .disabled(!layoutModel.canSavePreset(named: presetName, for: page))
             }
         }
         .padding(13)

--- a/Sources/VibeBarApp/Views/OverviewQuotaHistoryCard.swift
+++ b/Sources/VibeBarApp/Views/OverviewQuotaHistoryCard.swift
@@ -21,6 +21,12 @@ struct OverviewQuotaCurve: Identifiable, Equatable {
     /// Masked account hint, set only when a tool has more than one account with
     /// history and the bucket titles alone would be ambiguous.
     let accountQualifier: String?
+    /// The quota's window length, carried so the hover can size its tolerance
+    /// to *this* curve's sampling rhythm. This card mixes five-hour lanes
+    /// (five-minute slots) with weekly ones (hourly slots) by design, and one
+    /// shared tolerance reads the sparse ones as blank. See
+    /// `ChartHoverTolerance`.
+    let windowSeconds: Int?
     let color: Color
     let dash: [CGFloat]
 
@@ -514,7 +520,10 @@ struct OverviewQuotaHistoryCard: View {
             Text(Self.tooltipFormatter.string(from: date))
                 .font(.system(size: 10, weight: .semibold))
             if readings.isEmpty {
-                Text("Nothing recorded here")
+                // Same wording as the per-group chart's empty row, and for the
+                // same reason: an absent sample says the app was not watching,
+                // not that the quota was between windows.
+                Text("No data recorded")
                     .font(.system(size: 9))
                     .foregroundStyle(.white.opacity(0.7))
             } else {
@@ -559,19 +568,24 @@ struct OverviewQuotaHistoryCard: View {
     /// coverage near the cursor are omitted rather than shown as zero.
     ///
     /// Resolved by binary search over each curve's flattened, time-sorted
-    /// samples, because this runs on every pointer move.
+    /// samples, because this runs on every pointer move — and with a tolerance
+    /// resolved per curve, because this card exists to overlay quotas whose
+    /// windows (and therefore whose sampling rhythms) differ by orders of
+    /// magnitude.
     private func hoverReadings(
         at date: Date,
         curves shown: [OverviewQuotaCurve]
     ) -> [OverviewHoverReading] {
         guard let window else { return [] }
-        let tolerance = max(600, window.visibleSpan / 60)
         var result: [OverviewHoverReading] = []
         for curve in shown {
             guard let sample = ChartSampleSearch.nearest(
                 in: flatByCurve[curve.id] ?? [],
                 to: date,
-                tolerance: tolerance,
+                tolerance: ChartHoverTolerance.seconds(
+                    windowSeconds: curve.windowSeconds,
+                    visibleSpan: window.visibleSpan
+                ),
                 time: { $0.time }
             ) else { continue }
             result.append(
@@ -721,6 +735,7 @@ struct OverviewQuotaHistoryCard: View {
                     accountQualifier: (accountsPerTool[account.tool]?.count ?? 0) > 1
                         ? Self.qualifier(for: account)
                         : nil,
+                    windowSeconds: bucket.rawWindowSeconds,
                     color: variant.color,
                     dash: variant.dash
                 )

--- a/Sources/VibeBarApp/Views/PopoverRoot.swift
+++ b/Sources/VibeBarApp/Views/PopoverRoot.swift
@@ -419,29 +419,29 @@ private struct OverviewWaterfall: View {
 
         VStack(alignment: .leading, spacing: density.interSectionSpacing) {
             CombinedTotalsRow(density: density)
-            if layoutModel.isCustomized(page) {
-                arrangedWaterfall(descriptors: descriptors, context: context)
-            } else {
+            // `auto` is the only mode the balancer runs in. `compact` and
+            // `manual` both render fixed columns — one packed for height by
+            // `PageLayoutPacker`, one arranged by hand — through the same
+            // path, so the two can never diverge in anything but their source
+            // of column order.
+            if layoutModel.mode(for: page) == .auto {
                 balancedWaterfall(descriptors: descriptors, context: context)
+            } else {
+                arrangedWaterfall(descriptors: descriptors, context: context)
             }
         }
     }
 
-    /// The page as the user arranged it: fixed order, saved column widths.
+    /// The page as it was arranged — by the user in `manual`, by the packer in
+    /// `compact`: fixed order, saved column widths.
     private func arrangedWaterfall(
         descriptors: [PageModuleDescriptor],
         context: OverviewModuleContext
     ) -> some View {
-        let defaults = PageModuleCatalog.defaultConfig(
+        let resolved = layoutModel.arrangement(
             for: page,
             descriptors: descriptors,
-            measuredHeights: layoutModel.measuredHeights(for: page),
             spacing: Double(density.interSectionSpacing)
-        )
-        let resolved = layoutModel.resolvedConfig(
-            for: page,
-            available: descriptors.map(\.id),
-            default: defaults
         )
         return PageLayoutColumns(
             page: page,
@@ -1415,16 +1415,13 @@ private struct ProviderDetailView: View {
             environment: environment,
             settings: settingsStore.settings
         )
-        let defaults = PageModuleCatalog.defaultConfig(
+        // `auto` returns the page's built-in split here, so a provider page
+        // needs no second branch: every mode renders the same fixed-order
+        // columns, only their contents differ.
+        let resolved = layoutModel.arrangement(
             for: page,
             descriptors: descriptors,
-            measuredHeights: layoutModel.measuredHeights(for: page),
             spacing: Double(density.interSectionSpacing)
-        )
-        let resolved = layoutModel.resolvedConfig(
-            for: page,
-            available: descriptors.map(\.id),
-            default: defaults
         )
         let context = ProviderPageContext(
             pageTool: tool,
@@ -1441,9 +1438,10 @@ private struct ProviderDetailView: View {
                 page: page,
                 descriptors: descriptors,
                 config: resolved,
-                // Until the page is arranged by hand its columns keep the exact
-                // clamped narrow-left widths they have always had; the ratio
-                // presets only take over once the user picks one.
+                // On `auto` the columns keep the exact clamped narrow-left
+                // widths they have always had. The ratio presets take over in
+                // the other two modes — including `compact`, where the ratio
+                // is one of the inputs the packer balanced against.
                 widths: layoutModel.isCustomized(page)
                     ? PageColumnWidths(density: density, ratio: resolved.ratio)
                     : ProviderDetailColumnWidths(density: density).columnWidths,

--- a/Sources/VibeBarApp/Views/QuotaHistoryChartView.swift
+++ b/Sources/VibeBarApp/Views/QuotaHistoryChartView.swift
@@ -853,7 +853,14 @@ struct QuotaHistoryChartView: View, Equatable {
                     .padding(.top, 1)
                 }
                 if bucket.isEmpty {
-                    Text("No active window")
+                    // Deliberately about the *evidence*, not about the quota.
+                    // Nothing here means no sample was taken near this instant
+                    // — the Mac was asleep, the app was quit, a refresh was
+                    // skipped. The window itself was very probably wide open,
+                    // and nothing in a fill lane can tell the two apart, so
+                    // claiming there was no active window was a guess dressed
+                    // up as a reading.
+                    Text("No data recorded")
                         .font(.system(size: 9))
                         .foregroundStyle(.white.opacity(0.7))
                 } else {
@@ -894,6 +901,13 @@ struct QuotaHistoryChartView: View, Equatable {
     /// side. The time label follows the shortest-window quota, which is the one
     /// sampled most densely.
     ///
+    /// The tolerance is resolved **per bucket**, not once for the group. The
+    /// buckets overlaid here are sampled at different rhythms — Claude's 5
+    /// Hours is filed into five-minute slots and its Weekly into hourly ones —
+    /// so a single tolerance taken from the shortest window missed the sparse
+    /// lanes on most cursor positions and reported them as having nothing to
+    /// say while their line ran under the crosshair. See `ChartHoverTolerance`.
+    ///
     /// Binary search rather than a scan: this runs on every pointer move, and a
     /// densely sampled lane under unlimited retention is tens of thousands of
     /// samples per bucket.
@@ -903,11 +917,13 @@ struct QuotaHistoryChartView: View, Equatable {
         primary: QuotaBucket
     ) -> QuotaHoverReading? {
         guard let window else { return nil }
-        let slot = UsageTimelineSlotPolicy.slotSeconds(windowSeconds: primary.rawWindowSeconds)
-        let tolerance = max(slot * 2, window.visibleSpan / 80)
         var readings: [QuotaHoverBucketReading] = []
         var anchor: Date?
         for (index, bucket) in buckets.enumerated() {
+            let tolerance = ChartHoverTolerance.seconds(
+                windowSeconds: bucket.rawWindowSeconds,
+                visibleSpan: window.visibleSpan
+            )
             let lookup = lookupByBucket[bucket.id] ?? BucketLookup()
             let actual = ChartSampleSearch.nearest(
                 in: lookup.actual, to: date, tolerance: tolerance, time: { $0.time }

--- a/Sources/VibeBarCore/Models/AppSettings.swift
+++ b/Sources/VibeBarCore/Models/AppSettings.swift
@@ -70,6 +70,20 @@ public struct AppSettings: Codable, Equatable, Sendable {
     /// built-in arrangement with no migration.
     public var pageLayouts: [PageLayoutPageID: StoredPageLayout]
 
+    /// Named arrangements the user saved for a page, keyed the same way as
+    /// `pageLayouts`. Applying one writes it back into `pageLayouts`; the
+    /// preset itself is never the live layout.
+    ///
+    /// Empty by default and normalized on the way in — unnamed presets are
+    /// dropped, names are trimmed and length-capped, and a page keeps at most
+    /// `maximumPresetsPerPage` of them, so a settings file cannot grow without
+    /// bound behind a menu that only shows a handful.
+    public var pageLayoutPresets: [PageLayoutPageID: [StoredPageLayoutPreset]]
+
+    /// How many named arrangements one page may keep. Generous relative to the
+    /// handful a menu stays usable with.
+    public static let maximumPresetsPerPage = 20
+
     public static let `default` = AppSettings(
         displayMode: .remaining,
         refreshIntervalSeconds: 600,
@@ -190,7 +204,8 @@ public struct AppSettings: Codable, Equatable, Sendable {
         miscProviderInstances: [MiscProviderInstance]? = nil,
         costData: CostDataSettings = .default,
         overviewQuotaHistoryHiddenCurveIds: Set<String> = [],
-        pageLayouts: [PageLayoutPageID: StoredPageLayout] = [:]
+        pageLayouts: [PageLayoutPageID: StoredPageLayout] = [:],
+        pageLayoutPresets: [PageLayoutPageID: [StoredPageLayoutPreset]] = [:]
     ) {
         self.displayMode = displayMode
         self.refreshIntervalSeconds = refreshIntervalSeconds
@@ -225,6 +240,28 @@ public struct AppSettings: Codable, Equatable, Sendable {
         self.costData = costData
         self.overviewQuotaHistoryHiddenCurveIds = overviewQuotaHistoryHiddenCurveIds
         self.pageLayouts = pageLayouts
+        self.pageLayoutPresets = Self.normalizedPageLayoutPresets(pageLayoutPresets)
+    }
+
+    /// Drops unnamed presets, collapses names that differ only by case (the
+    /// first wins, which is what "save over the one already in the menu"
+    /// produces), and caps each page's list.
+    static func normalizedPageLayoutPresets(
+        _ presets: [PageLayoutPageID: [StoredPageLayoutPreset]]
+    ) -> [PageLayoutPageID: [StoredPageLayoutPreset]] {
+        var result: [PageLayoutPageID: [StoredPageLayoutPreset]] = [:]
+        for (page, entries) in presets {
+            var seen = Set<String>()
+            var kept: [StoredPageLayoutPreset] = []
+            for preset in entries where preset.isValid {
+                guard seen.insert(preset.name.lowercased()).inserted else { continue }
+                kept.append(preset)
+                if kept.count == maximumPresetsPerPage { break }
+            }
+            guard !kept.isEmpty else { continue }
+            result[page] = kept
+        }
+        return result
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -254,6 +291,7 @@ public struct AppSettings: Codable, Equatable, Sendable {
         case costData
         case overviewQuotaHistoryHiddenCurveIds
         case pageLayouts
+        case pageLayoutPresets
     }
 
     public init(from decoder: Decoder) throws {
@@ -386,6 +424,14 @@ public struct AppSettings: Codable, Equatable, Sendable {
         // the user their card arrangement, not every other setting in the file.
         self.pageLayouts =
             (try? c.decodeIfPresent([PageLayoutPageID: StoredPageLayout].self, forKey: .pageLayouts)) ?? [:]
+        // Same `try?` reasoning: a mangled preset list costs the user their
+        // saved arrangements, not the rest of the file.
+        self.pageLayoutPresets = Self.normalizedPageLayoutPresets(
+            (try? c.decodeIfPresent(
+                [PageLayoutPageID: [StoredPageLayoutPreset]].self,
+                forKey: .pageLayoutPresets
+            )) ?? [:]
+        )
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -424,6 +470,7 @@ public struct AppSettings: Codable, Equatable, Sendable {
         try c.encode(costData, forKey: .costData)
         try c.encode(overviewQuotaHistoryHiddenCurveIds, forKey: .overviewQuotaHistoryHiddenCurveIds)
         try c.encode(pageLayouts, forKey: .pageLayouts)
+        try c.encode(pageLayoutPresets, forKey: .pageLayoutPresets)
     }
 
     public func menuBarItem(_ kind: MenuBarItemKind) -> MenuBarItemSettings {

--- a/Sources/VibeBarCore/Models/ChartSeriesPlanning.swift
+++ b/Sources/VibeBarCore/Models/ChartSeriesPlanning.swift
@@ -129,6 +129,99 @@ public enum ChartMarkBudget {
     }
 }
 
+/// The slice of one segment a visible range actually has to draw.
+///
+/// Splitting this out of the mark builders because "which samples does this
+/// window need" is a question about evidence, not about SwiftUI, and because
+/// the answer has a case that is easy to get wrong: a segment can cross the
+/// visible range without putting a single sample inside it.
+public enum ChartSegmentClip {
+    /// Samples of `segment` that `range` needs, `segment` being ascending by
+    /// `time`.
+    ///
+    /// Three cases, and the third is the one this exists for:
+    ///
+    /// - Samples inside the range: they are returned with one extra sample on
+    ///   each side, so a line entering the window starts at the frame border
+    ///   rather than at its first visible observation.
+    /// - No samples anywhere near it: nothing to draw.
+    /// - **No samples inside, but samples on both sides of it.** The lane's
+    ///   line runs straight through the window and has to be drawn, so the
+    ///   straddling pair is returned. Dropping it was a real defect and a
+    ///   lopsided one: lanes are filed into slots sized by their quota window
+    ///   (`UsageTimelineSlotPolicy`), so a five-hour quota's five-minute slots
+    ///   almost always land something inside a window a user would zoom to,
+    ///   while an hourly-slotted weekly lane — and much worse, the daily slots
+    ///   a quota with no reported window length gets — often do not. The
+    ///   symptom was a chart that drew its five-hour curve and silently
+    ///   dropped the weekly one.
+    public static func visible<Element>(
+        _ segment: [Element],
+        time: (Element) -> Date,
+        to range: ClosedRange<Date>
+    ) -> [Element] {
+        guard !segment.isEmpty else { return [] }
+        var first: Int?
+        var last: Int?
+        for (index, element) in segment.enumerated() {
+            let stamp = time(element)
+            if stamp >= range.lowerBound, stamp <= range.upperBound {
+                if first == nil { first = index }
+                last = index
+            }
+        }
+        if let first, let last {
+            let lower = max(0, first - 1)
+            let upper = min(segment.count - 1, last + 1)
+            return Array(segment[lower...upper])
+        }
+        // Nothing inside. Keep the pair that brackets the range, if there is
+        // one — that is a line crossing the window, not an absence of one.
+        guard let before = segment.lastIndex(where: { time($0) < range.lowerBound }),
+              segment.indices.contains(before + 1),
+              time(segment[before + 1]) > range.upperBound
+        else { return [] }
+        return [segment[before], segment[before + 1]]
+    }
+}
+
+/// How far from the crosshair one lane's nearest sample may sit and still count
+/// as what that lane read there.
+///
+/// A quota chart overlays lanes that are deliberately *not* sampled at the same
+/// rhythm: `UsageTimelineSlotPolicy` files a five-hour quota into five-minute
+/// slots, a weekly one into hourly slots, a monthly one into six-hour slots,
+/// and a quota whose window length the provider never reported into daily ones.
+/// One tolerance sized for the densest lane therefore misses on most hover
+/// positions of every sparser lane — which is how a weekly bucket sitting
+/// mid-window, with its line drawn under the crosshair, came to report that it
+/// had nothing to say.
+///
+/// So the tolerance is per lane, and it is derived from the widest spacing that
+/// lane's own samples can legitimately have. Two things set that spacing: the
+/// slot width the lane is filed into, and the refresh cadence, because no lane
+/// is sampled more often than the app refreshes — the same pair
+/// `QuotaHistorySeriesBuilder` weighs when deciding whether coverage stopped.
+public enum ChartHoverTolerance {
+    /// Fraction of a lane's own sampling rhythm that still counts as "here".
+    ///
+    /// Above a half so a cursor parked exactly between two maximally-spaced
+    /// samples resolves to one of them instead of falling into a hole that
+    /// only exists because of where the pointer happened to stop.
+    static let cadenceFraction: Double = 0.75
+
+    /// Zoomed far out, one pixel of plot is many minutes of history and the
+    /// user cannot aim more precisely than that, so the tolerance never drops
+    /// below a slice of the visible span.
+    static let pointerSlopFraction: Double = 1.0 / 80.0
+
+    public static func seconds(windowSeconds: Int?, visibleSpan: TimeInterval) -> TimeInterval {
+        let slot = UsageTimelineSlotPolicy.slotSeconds(windowSeconds: windowSeconds)
+        let cadence = max(slot, TimeInterval(AppSettings.slowestRefreshIntervalSeconds))
+        return max(cadence * cadenceFraction, max(0, visibleSpan) * pointerSlopFraction)
+    }
+}
+
 /// Finding the observation nearest a point in time.
 ///
 /// The charts resolve a hover by asking every curve "what did you read here?".

--- a/Sources/VibeBarCore/Models/PageLayoutConfig.swift
+++ b/Sources/VibeBarCore/Models/PageLayoutConfig.swift
@@ -236,6 +236,25 @@ public struct StoredPageLayout: Hashable, Sendable {
     /// test `PageLayoutConfig.isEmpty` makes. Independent of `mode`: an `auto`
     /// page can still be holding the columns it had before the user switched.
     public var isEmpty: Bool { columns.allSatisfy(\.isEmpty) }
+
+    /// The entry a page should get when the user switches it back to `manual`.
+    ///
+    /// `auto` and `compact` deliberately keep the columns they were handed, so
+    /// returning to `manual` has to give the user back the arrangement they
+    /// dragged — not whatever the computed mode happened to be showing when
+    /// they flipped the switch. Overwriting it with the computed columns would
+    /// make a round trip through Compact a silent, unannounced reset of a hand
+    /// arrangement, which is precisely what keeping the columns was for.
+    ///
+    /// `nil` when nothing was ever arranged by hand; the caller then
+    /// materializes what is on screen instead, which is the right starting
+    /// point for a first-time edit. The restored columns still go through
+    /// `PageLayoutResolver` at render time, so modules that came or went while
+    /// the page was computed are reconciled as usual.
+    public func restoredAsManual() -> StoredPageLayout? {
+        guard !isEmpty else { return nil }
+        return StoredPageLayout(mode: .manual, ratio: ratio, columns: columns)
+    }
 }
 
 extension StoredPageLayout: Codable {
@@ -292,6 +311,27 @@ public struct StoredPageLayoutPreset: Hashable, Sendable {
     /// A preset with no name cannot be picked out of a menu, so it is dropped
     /// on the way in rather than rendered as a blank row.
     public var isValid: Bool { !name.isEmpty }
+
+    /// Case-insensitive identity. Two presets whose names differ only by case
+    /// are the same menu entry, so they are the same preset.
+    public var matchKey: String { name.lowercased() }
+
+    /// Where `name` would land in `presets`, under the one matching rule the
+    /// whole feature uses — `AppSettings` dedupes with it, saving replaces
+    /// with it, deleting removes with it.
+    ///
+    /// `nil` means the name is new, which is also what decides whether saving
+    /// costs a slot against the per-page cap: replacing an existing preset
+    /// leaves the count unchanged and must stay available even when the page
+    /// is full.
+    public static func index(
+        of name: String,
+        in presets: [StoredPageLayoutPreset]
+    ) -> Int? {
+        let key = normalizedName(name).lowercased()
+        guard !key.isEmpty else { return nil }
+        return presets.firstIndex { $0.matchKey == key }
+    }
 }
 
 extension StoredPageLayoutPreset: Codable {

--- a/Sources/VibeBarCore/Models/PageLayoutConfig.swift
+++ b/Sources/VibeBarCore/Models/PageLayoutConfig.swift
@@ -269,13 +269,20 @@ extension StoredPageLayout: Codable {
     /// cannot read instead of discarding the user's whole arrangement.
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        // Decoded as a raw string rather than through `PageLayoutMode`'s own
-        // tolerant decoder, which cannot tell "the key is missing" from "the
-        // key says auto". Every entry written before modes existed is missing
-        // it, and those entries are arrangements the user dragged — they must
-        // come back as `manual`, not as `auto`.
-        let mode = (try? container.decode(String.self, forKey: .mode))
-            .flatMap(PageLayoutMode.init(rawValue:))
+        // Decoded by hand rather than through `PageLayoutMode`'s own tolerant
+        // decoder, because the two absence shapes mean different things. A
+        // MISSING key is an entry written before modes existed — a hand-dragged
+        // arrangement that must come back as `manual`. A PRESENT key with an
+        // unrecognized value is a newer build's mode — that falls back to
+        // `auto` instead of promoting the saved columns to a fixed manual
+        // layout after a downgrade.
+        let mode: PageLayoutMode?
+        if container.contains(.mode) {
+            mode = (try? container.decode(String.self, forKey: .mode))
+                .flatMap(PageLayoutMode.init(rawValue:)) ?? PageLayoutMode.fallback
+        } else {
+            mode = nil
+        }
         let ratio = (try? container.decode(PageColumnRatio.self, forKey: .ratio)) ?? .equal
         let columns = (try? container.decode([[PageLayoutModuleID]].self, forKey: .columns)) ?? []
         self.init(mode: mode, ratio: ratio, columns: columns)

--- a/Sources/VibeBarCore/Models/PageLayoutConfig.swift
+++ b/Sources/VibeBarCore/Models/PageLayoutConfig.swift
@@ -37,6 +37,41 @@ public enum PageColumnRatio: String, CaseIterable, Codable, Hashable, Sendable {
     }
 }
 
+/// How a page decides where its cards go.
+///
+/// Three modes rather than a customized/not-customized flag, because "let the
+/// app arrange it" turned out to mean two different things:
+///
+/// - `auto` keeps each page's built-in behaviour — the Overview's phase-aware
+///   `ColumnMasonryLayout` balancer, a provider page's hand-coded split.
+/// - `compact` ignores phases entirely and asks `PageLayoutPacker` for the
+///   partition that makes the page as short as possible. The balancer cannot
+///   reach that arrangement: it places every quota card before any cost card,
+///   and that constraint alone can cost a page a few hundred points.
+/// - `manual` renders the arrangement the user dragged, and nothing else
+///   touches it.
+public enum PageLayoutMode: String, CaseIterable, Codable, Hashable, Sendable {
+    case auto
+    case compact
+    case manual
+
+    /// What an unrecognized mode decodes to when there is nothing better to go
+    /// on. `StoredPageLayout` has more context and uses it — see its decoder.
+    public static let fallback: PageLayoutMode = .auto
+
+    /// Forward-tolerant, like `PageColumnRatio`: a mode written by a newer
+    /// build decodes to `auto` instead of failing the enclosing value.
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let raw = try container.decode(String.self)
+        self = PageLayoutMode(rawValue: raw) ?? Self.fallback
+    }
+
+    /// True when the page draws itself and the saved columns are only a
+    /// starting point for the editor.
+    public var isComputed: Bool { self != .manual }
+}
+
 /// One page's saved layout: the column ratio, the two ordered module columns,
 /// and the last-known measured height of each module.
 ///
@@ -162,18 +197,32 @@ public struct PageLayoutConfig: Hashable, Sendable {
 /// Heights stay in `~/.vibebar/layout.json` via `PageLayoutStore`; the two are
 /// recombined at render time.
 public struct StoredPageLayout: Hashable, Sendable {
+    /// Which arrangement the page renders. `columns` is kept in every mode:
+    /// switching to `auto` or `compact` and back must not throw away an
+    /// arrangement the user dragged by hand.
+    public var mode: PageLayoutMode
     public var ratio: PageColumnRatio
     public private(set) var columns: [[PageLayoutModuleID]]
 
-    public init(ratio: PageColumnRatio = .equal, columns: [[PageLayoutModuleID]] = []) {
+    /// - Parameter mode: `nil` derives the mode from the columns — an entry
+    ///   that carries an arrangement is a `manual` one, an entry that carries
+    ///   none is `auto`. That is the same rule the decoder applies to an entry
+    ///   written before modes existed, kept in one place so the two cannot
+    ///   drift apart.
+    public init(
+        mode: PageLayoutMode? = nil,
+        ratio: PageColumnRatio = .equal,
+        columns: [[PageLayoutModuleID]] = []
+    ) {
         let normalized = PageLayoutConfig(ratio: ratio, columns: columns)
+        self.mode = mode ?? (normalized.isEmpty ? .auto : .manual)
         self.ratio = normalized.ratio
         self.columns = normalized.columns
     }
 
     /// The intent half of a live config; measured heights are dropped.
-    public init(_ config: PageLayoutConfig) {
-        self.init(ratio: config.ratio, columns: config.columns)
+    public init(_ config: PageLayoutConfig, mode: PageLayoutMode? = nil) {
+        self.init(mode: mode, ratio: config.ratio, columns: config.columns)
     }
 
     /// Back to the canonical model, with this page's measurements folded in.
@@ -184,12 +233,14 @@ public struct StoredPageLayout: Hashable, Sendable {
     }
 
     /// True when the entry carries no arrangement — the same "not customized"
-    /// test `PageLayoutConfig.isEmpty` makes.
+    /// test `PageLayoutConfig.isEmpty` makes. Independent of `mode`: an `auto`
+    /// page can still be holding the columns it had before the user switched.
     public var isEmpty: Bool { columns.allSatisfy(\.isEmpty) }
 }
 
 extension StoredPageLayout: Codable {
     private enum CodingKeys: String, CodingKey {
+        case mode
         case ratio
         case columns
     }
@@ -199,9 +250,61 @@ extension StoredPageLayout: Codable {
     /// cannot read instead of discarding the user's whole arrangement.
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
+        // Decoded as a raw string rather than through `PageLayoutMode`'s own
+        // tolerant decoder, which cannot tell "the key is missing" from "the
+        // key says auto". Every entry written before modes existed is missing
+        // it, and those entries are arrangements the user dragged — they must
+        // come back as `manual`, not as `auto`.
+        let mode = (try? container.decode(String.self, forKey: .mode))
+            .flatMap(PageLayoutMode.init(rawValue:))
         let ratio = (try? container.decode(PageColumnRatio.self, forKey: .ratio)) ?? .equal
         let columns = (try? container.decode([[PageLayoutModuleID]].self, forKey: .columns)) ?? []
-        self.init(ratio: ratio, columns: columns)
+        self.init(mode: mode, ratio: ratio, columns: columns)
+    }
+}
+
+/// One saved arrangement the user named, so a layout worth keeping can be put
+/// back later without re-dragging it.
+///
+/// Stores a whole `StoredPageLayout` — mode, ratio and columns — so a preset
+/// records what it was captured from. Applying one always lands in `manual`
+/// mode: a preset is "this exact arrangement", and re-entering `compact` would
+/// just recompute from whatever the heights happen to be now.
+public struct StoredPageLayoutPreset: Hashable, Sendable {
+    /// Long enough for "Wide left, cost on the right", short enough that a
+    /// pasted paragraph cannot bloat `settings.json`.
+    public static let maximumNameLength = 48
+
+    public var name: String
+    public var layout: StoredPageLayout
+
+    public init(name: String, layout: StoredPageLayout) {
+        self.name = Self.normalizedName(name)
+        self.layout = layout
+    }
+
+    /// Trimmed and length-capped. The UI shows the normalized form, so what
+    /// the user sees in the menu is exactly what was stored.
+    public static func normalizedName(_ raw: String) -> String {
+        String(raw.trimmingCharacters(in: .whitespacesAndNewlines).prefix(maximumNameLength))
+    }
+
+    /// A preset with no name cannot be picked out of a menu, so it is dropped
+    /// on the way in rather than rendered as a blank row.
+    public var isValid: Bool { !name.isEmpty }
+}
+
+extension StoredPageLayoutPreset: Codable {
+    private enum CodingKeys: String, CodingKey {
+        case name
+        case layout
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let name = (try? container.decode(String.self, forKey: .name)) ?? ""
+        let layout = (try? container.decode(StoredPageLayout.self, forKey: .layout)) ?? StoredPageLayout()
+        self.init(name: name, layout: layout)
     }
 }
 

--- a/Sources/VibeBarCore/Services/PageLayoutPacker.swift
+++ b/Sources/VibeBarCore/Services/PageLayoutPacker.swift
@@ -1,0 +1,328 @@
+import Foundation
+
+/// Packs a page's cards into two columns so the rendered page is as short as
+/// possible.
+///
+/// This is the engine behind `PageLayoutMode.compact`. It differs from
+/// `OverviewMasonryPlanner` in exactly one way, and that way is the whole
+/// point: the planner places cards in phases — every quota card first, then the
+/// cost cards from those seeded column heights, then the analytics — because
+/// the Overview reads better with the subscription panels at the top. The
+/// phase constraint also puts arrangements out of reach that are simply
+/// shorter, which is why a hand-packed page can beat the balancer. `compact`
+/// drops the constraint and optimizes for height alone.
+///
+/// Pure and deterministic: same items, same spacing, same ratio, same answer.
+/// SwiftUI stays responsible only for measuring heights.
+///
+/// ### Objective
+///
+/// A page's height is the taller of its two column stacks, where a stack is the
+/// sum of its cards plus one inter-card gap between each neighbouring pair.
+/// Minimizing that is the two-way partition problem — NP-hard in general, and
+/// entirely tractable at the sizes involved here (a page has at most a dozen
+/// cards).
+public enum PageLayoutPacker {
+    /// One card to place, with the height it last rendered at.
+    public struct Item: Hashable, Sendable {
+        public let id: PageLayoutModuleID
+        public let height: Double
+
+        public init(id: PageLayoutModuleID, height: Double) {
+            self.id = id
+            // A card that has never been measured, or measured as NaN mid
+            // layout pass, contributes nothing rather than poisoning every
+            // comparison it takes part in.
+            self.height = height.isFinite ? max(0, height) : 0
+        }
+    }
+
+    /// A chosen partition, with the column heights it implies.
+    public struct Packing: Hashable, Sendable {
+        /// Exactly `PageLayoutConfig.columnCount` columns. Within each column
+        /// the cards keep the relative order they arrived in.
+        public let columns: [[PageLayoutModuleID]]
+        public let columnHeights: [Double]
+        /// False when the module count forced the greedy fallback, i.e. the
+        /// result is a good partition rather than a provably optimal one.
+        public let isExact: Bool
+
+        public init(columns: [[PageLayoutModuleID]], columnHeights: [Double], isExact: Bool) {
+            self.columns = columns
+            self.columnHeights = columnHeights
+            self.isExact = isExact
+        }
+
+        /// What the page will measure: the taller column.
+        public var pageHeight: Double { columnHeights.max() ?? 0 }
+    }
+
+    /// Largest module count still searched exhaustively.
+    ///
+    /// A real page has at most about a dozen cards, so the search never
+    /// actually runs at the limit; 2^16 leaves plenty of headroom before the
+    /// greedy fallback takes over, and with the two bounds below most of that
+    /// space is never visited. The cap exists so a future page with dozens of
+    /// modules degrades in speed rather than hanging the layout pass.
+    public static let exactSearchLimit = 16
+
+    // MARK: - Packing
+
+    /// The partition of `items` that minimizes the page's height.
+    ///
+    /// - Parameters:
+    ///   - items: cards in the order they should appear *within* a column —
+    ///     normally the page's default config read left column then right, so
+    ///     a compact page still reads in its familiar order top to bottom.
+    ///     Duplicate identifiers are collapsed, keeping the first.
+    ///   - spacing: the page's inter-card gap. Counted between neighbours
+    ///     only, so a column of one card carries no gap and the packer is not
+    ///     biased towards splitting.
+    ///   - ratio: the page's width split. Does not change which partitions
+    ///     exist — the heights are what they are — but breaks ties in favour
+    ///     of putting the heavier stack under the wider column, which is where
+    ///     those cards will render shortest next time they are measured.
+    public static func pack(
+        items: [Item],
+        spacing: Double,
+        ratio: PageColumnRatio = .equal
+    ) -> Packing {
+        let unique = deduplicated(items)
+        let gap = spacing.isFinite ? max(0, spacing) : 0
+        guard !unique.isEmpty else {
+            return Packing(
+                columns: [[PageLayoutModuleID]](repeating: [], count: PageLayoutConfig.columnCount),
+                columnHeights: [Double](repeating: 0, count: PageLayoutConfig.columnCount),
+                isExact: true
+            )
+        }
+
+        let isExact = unique.count <= exactSearchLimit
+        let assignment = isExact
+            ? exactAssignment(unique, spacing: gap, ratio: ratio)
+            : greedyAssignment(unique, spacing: gap, ratio: ratio)
+
+        var columns = [[PageLayoutModuleID]](repeating: [], count: PageLayoutConfig.columnCount)
+        var heights = [Double](repeating: 0, count: PageLayoutConfig.columnCount)
+        for (index, item) in unique.enumerated() {
+            let column = min(max(0, assignment[index]), PageLayoutConfig.columnCount - 1)
+            heights[column] = appended(heights[column], columns[column].count, item.height, spacing: gap)
+            columns[column].append(item.id)
+        }
+        return Packing(columns: columns, columnHeights: heights, isExact: isExact)
+    }
+
+    /// `pack(items:spacing:ratio:)` as a `PageLayoutConfig`, ready to hand to
+    /// the fixed-order renderer.
+    public static func packedConfig(
+        items: [Item],
+        spacing: Double,
+        ratio: PageColumnRatio = .equal,
+        measuredHeights: [PageLayoutModuleID: Double] = [:]
+    ) -> PageLayoutConfig {
+        PageLayoutConfig(
+            ratio: ratio,
+            columns: pack(items: items, spacing: spacing, ratio: ratio).columns,
+            measuredHeights: measuredHeights
+        )
+    }
+
+    // MARK: - Measuring an arrangement
+
+    /// Height of one column: its cards plus a gap between each neighbouring
+    /// pair. A module with no known height counts as zero.
+    public static func stackedHeight(
+        _ moduleIDs: [PageLayoutModuleID],
+        heights: [PageLayoutModuleID: Double],
+        spacing: Double
+    ) -> Double {
+        let gap = spacing.isFinite ? max(0, spacing) : 0
+        var total = 0.0
+        var count = 0
+        for moduleID in moduleIDs {
+            let height = heights[moduleID].map { $0.isFinite ? max(0, $0) : 0 } ?? 0
+            total = appended(total, count, height, spacing: gap)
+            count += 1
+        }
+        return total
+    }
+
+    /// What an already-chosen arrangement would measure at these heights — the
+    /// number to beat before moving a card the user is currently looking at.
+    public static func pageHeight(
+        columns: [[PageLayoutModuleID]],
+        heights: [PageLayoutModuleID: Double],
+        spacing: Double
+    ) -> Double {
+        columns
+            .map { stackedHeight($0, heights: heights, spacing: spacing) }
+            .max() ?? 0
+    }
+
+    // MARK: - Exact search
+
+    /// Depth-first search over every assignment of cards to columns, with two
+    /// bounds that cut most of the tree:
+    ///
+    /// 1. A partial stack only grows, so once the taller partial column
+    ///    already exceeds the best complete page found, nothing below can beat
+    ///    it.
+    /// 2. Even a perfect split of what is left cannot bring the page below
+    ///    half the total height still to place.
+    ///
+    /// Both prune on strict `>` so subtrees that could *tie* the best score are
+    /// still explored — the tie-breaks below decide those, not the traversal.
+    private static func exactAssignment(
+        _ items: [Item],
+        spacing: Double,
+        ratio: PageColumnRatio
+    ) -> [Int] {
+        let count = items.count
+        var remaining = [Double](repeating: 0, count: count + 1)
+        for index in stride(from: count - 1, through: 0, by: -1) {
+            remaining[index] = remaining[index + 1] + items[index].height
+        }
+
+        var assignment = [Int](repeating: 0, count: count)
+        var best = [Int](repeating: 0, count: count)
+        var bestScore = [Double](repeating: .infinity, count: 4)
+
+        func visit(
+            _ index: Int,
+            _ left: Double,
+            _ leftCount: Int,
+            _ right: Double,
+            _ rightCount: Int,
+            _ mask: Double
+        ) {
+            if max(left, right) > bestScore[0] { return }
+            if (left + right + remaining[index]) / 2 > bestScore[0] { return }
+            guard index < count else {
+                let score = [
+                    max(left, right),
+                    ratioPenalty(left: left, right: right, ratio: ratio),
+                    abs(left - right),
+                    mask
+                ]
+                if score.precedesLexicographically(bestScore) {
+                    bestScore = score
+                    best = assignment
+                }
+                return
+            }
+            let height = items[index].height
+            // The mask weights the *first* card most heavily, so minimizing it
+            // is a left-first preference read in input order: among partitions
+            // that are otherwise exactly as good, the one that leaves the
+            // earliest cards where the page's default put them wins. Making it
+            // a score term rather than relying on "first one found" keeps the
+            // answer independent of the traversal.
+            assignment[index] = 0
+            visit(
+                index + 1,
+                appended(left, leftCount, height, spacing: spacing),
+                leftCount + 1,
+                right,
+                rightCount,
+                mask
+            )
+            assignment[index] = 1
+            visit(
+                index + 1,
+                left,
+                leftCount,
+                appended(right, rightCount, height, spacing: spacing),
+                rightCount + 1,
+                mask + Double(1 << (count - 1 - index))
+            )
+        }
+
+        visit(0, 0, 0, 0, 0, 0)
+        return best
+    }
+
+    /// Longest-processing-time-first: place the tallest card remaining into
+    /// whichever column it leaves shorter. The classic 4/3 approximation, and
+    /// the fallback once the module count puts an exhaustive search out of
+    /// reach. Input order is restored by the caller, so the greedy pass decides
+    /// columns only, never the order within one.
+    private static func greedyAssignment(
+        _ items: [Item],
+        spacing: Double,
+        ratio: PageColumnRatio
+    ) -> [Int] {
+        let tallestFirst = items.indices.sorted { lhs, rhs in
+            items[lhs].height == items[rhs].height
+                ? lhs < rhs
+                : items[lhs].height > items[rhs].height
+        }
+        var assignment = [Int](repeating: 0, count: items.count)
+        var heights = [Double](repeating: 0, count: PageLayoutConfig.columnCount)
+        var counts = [Int](repeating: 0, count: PageLayoutConfig.columnCount)
+        let preferred = widerColumn(ratio)
+        for index in tallestFirst {
+            let height = items[index].height
+            let candidates = (0..<PageLayoutConfig.columnCount).map {
+                appended(heights[$0], counts[$0], height, spacing: spacing)
+            }
+            let shortest = candidates.min() ?? 0
+            let tied = candidates.indices.filter { candidates[$0] == shortest }
+            let column = tied.contains(preferred) ? preferred : (tied.first ?? 0)
+            assignment[index] = column
+            heights[column] = candidates[column]
+            counts[column] += 1
+        }
+        return assignment
+    }
+
+    // MARK: - Scoring
+
+    /// Penalty applied when the heavier stack sits under the *narrower*
+    /// column.
+    ///
+    /// Two partitions can leave the page exactly as tall while disagreeing
+    /// about which side carries the load. Cards render shorter where they are
+    /// wider, so loading the wide side is the arrangement more likely to be
+    /// genuinely shorter once these cards are measured again. With an equal
+    /// split there is no wider side and nothing to prefer.
+    private static func ratioPenalty(
+        left: Double,
+        right: Double,
+        ratio: PageColumnRatio
+    ) -> Double {
+        guard ratio != .equal, left != right else { return 0 }
+        return (left > right) == (ratio.leftFraction > ratio.rightFraction) ? 0 : 1
+    }
+
+    private static func widerColumn(_ ratio: PageColumnRatio) -> Int {
+        ratio.leftFraction >= ratio.rightFraction ? 0 : 1
+    }
+
+    // MARK: - Helpers
+
+    /// A column's height after one more card. The gap is counted only between
+    /// neighbours, so the first card in a column adds no spacing.
+    private static func appended(
+        _ current: Double,
+        _ count: Int,
+        _ height: Double,
+        spacing: Double
+    ) -> Double {
+        count == 0 ? height : current + spacing + height
+    }
+
+    private static func deduplicated(_ items: [Item]) -> [Item] {
+        var seen = Set<PageLayoutModuleID>()
+        return items.filter { !$0.id.rawValue.isEmpty && seen.insert($0.id).inserted }
+    }
+}
+
+private extension Array where Element == Double {
+    /// Strict lexicographic comparison over a fixed-length score vector.
+    func precedesLexicographically(_ other: [Double]) -> Bool {
+        for (lhs, rhs) in zip(self, other) where lhs != rhs {
+            return lhs < rhs
+        }
+        return count < other.count
+    }
+}

--- a/Tests/VibeBarCoreTests/AppSettingsTests.swift
+++ b/Tests/VibeBarCoreTests/AppSettingsTests.swift
@@ -98,6 +98,197 @@ final class AppSettingsTests: XCTestCase {
         )
     }
 
+    func testPageLayoutModesRoundTripPerPage() throws {
+        var settings = AppSettings.default
+        settings.pageLayouts[.overview] = StoredPageLayout(mode: .compact, ratio: .wideNarrow)
+        settings.pageLayouts[.detail(.claude)] = StoredPageLayout(
+            mode: .manual,
+            ratio: .narrowWide,
+            columns: [[.quotaGroup(tool: .claude, groupKey: "all")], [.cost(tool: .claude)]]
+        )
+        settings.pageLayouts[.detail(.codex)] = StoredPageLayout(
+            mode: .auto,
+            ratio: .equal,
+            columns: [[.status], [.cost(tool: .codex)]]
+        )
+
+        let decoded = try JSONDecoder().decode(
+            AppSettings.self,
+            from: try JSONEncoder().encode(settings)
+        )
+
+        XCTAssertEqual(decoded.pageLayouts[.overview]?.mode, .compact)
+        XCTAssertEqual(decoded.pageLayouts[.overview]?.ratio, .wideNarrow)
+        XCTAssertEqual(decoded.pageLayouts[.detail(.claude)]?.mode, .manual)
+        // An `auto` page keeps the arrangement it had before the switch, so
+        // going back to Manual restores it instead of starting over.
+        XCTAssertEqual(decoded.pageLayouts[.detail(.codex)]?.mode, .auto)
+        XCTAssertEqual(
+            decoded.pageLayouts[.detail(.codex)]?.columns,
+            [[.status], [.cost(tool: .codex)]]
+        )
+    }
+
+    func testLayoutsSavedBeforeModesExistedComeBackAsManual() throws {
+        // The upgrade path that matters: a settings file from the build that
+        // shipped the drag editor has no `mode` key anywhere, and every entry
+        // in it is an arrangement the user made by hand.
+        let json = #"""
+        {
+          "displayMode": "remaining",
+          "pageLayouts": {
+            "overview": {"ratio": "equal", "columns": [["status", "cost-all"], ["quota-history-all"]]},
+            "detail:claude": {"ratio": "narrow-wide", "columns": [[], []]}
+          }
+        }
+        """#
+        let decoded = try JSONDecoder().decode(AppSettings.self, from: Data(json.utf8))
+
+        XCTAssertEqual(decoded.pageLayouts[.overview]?.mode, .manual)
+        XCTAssertEqual(
+            decoded.pageLayouts[.overview]?.columns,
+            [[.status, .costAll], [.quotaHistoryAll]]
+        )
+        // An entry with no arrangement was never a customization to begin with.
+        XCTAssertEqual(decoded.pageLayouts[.detail(.claude)]?.mode, .auto)
+    }
+
+    func testPageLayoutPresetsDefaultToNoneAndRoundTrip() throws {
+        let legacy = try JSONDecoder().decode(
+            AppSettings.self,
+            from: Data(#"{"displayMode":"remaining"}"#.utf8)
+        )
+        XCTAssertTrue(legacy.pageLayoutPresets.isEmpty)
+        XCTAssertTrue(AppSettings.default.pageLayoutPresets.isEmpty)
+
+        var settings = AppSettings.default
+        settings.pageLayoutPresets[.overview] = [
+            StoredPageLayoutPreset(
+                name: "Cost on the left",
+                layout: StoredPageLayout(
+                    mode: .manual,
+                    ratio: .wideNarrow,
+                    columns: [[.costAll], [.status, .quotaHistoryAll]]
+                )
+            ),
+            StoredPageLayoutPreset(
+                name: "Shortest",
+                layout: StoredPageLayout(mode: .compact, ratio: .equal)
+            )
+        ]
+
+        let decoded = try JSONDecoder().decode(
+            AppSettings.self,
+            from: try JSONEncoder().encode(settings)
+        )
+
+        let presets = try XCTUnwrap(decoded.pageLayoutPresets[.overview])
+        XCTAssertEqual(presets.count, 2)
+        XCTAssertEqual(presets.map(\.name), ["Cost on the left", "Shortest"])
+        XCTAssertEqual(presets[0].layout.ratio, .wideNarrow)
+        XCTAssertEqual(presets[0].layout.columns, [[.costAll], [.status, .quotaHistoryAll]])
+        XCTAssertEqual(presets[1].layout.mode, .compact)
+    }
+
+    func testPageLayoutPresetsEncodeAsAPlainObjectKeyedByPage() throws {
+        var settings = AppSettings.default
+        settings.pageLayoutPresets[.detail(.codex)] = [
+            StoredPageLayoutPreset(
+                name: "Tall left",
+                layout: StoredPageLayout(mode: .manual, ratio: .equal, columns: [[.status], []])
+            )
+        ]
+
+        let data = try JSONEncoder().encode(settings)
+        let root = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        let byPage = try XCTUnwrap(root["pageLayoutPresets"] as? [String: Any])
+        let codex = try XCTUnwrap(byPage["detail:codex"] as? [[String: Any]])
+        XCTAssertEqual(codex.count, 1)
+        XCTAssertEqual(codex[0]["name"] as? String, "Tall left")
+        let layout = try XCTUnwrap(codex[0]["layout"] as? [String: Any])
+        XCTAssertEqual(layout["mode"] as? String, "manual")
+        XCTAssertEqual(layout["columns"] as? [[String]], [["status"], []])
+    }
+
+    func testPageLayoutPresetsAreNormalizedOnTheWayIn() {
+        var settings = AppSettings.default
+        settings.pageLayoutPresets = [
+            .overview: [
+                StoredPageLayoutPreset(name: "  Keep  ", layout: StoredPageLayout()),
+                // Unnamed presets cannot be picked out of a menu.
+                StoredPageLayoutPreset(name: "   ", layout: StoredPageLayout()),
+                // A name that differs only by case is the same menu entry.
+                StoredPageLayoutPreset(name: "keep", layout: StoredPageLayout(ratio: .wideNarrow))
+            ],
+            .detail(.claude): []
+        ]
+
+        let normalized = AppSettings(
+            displayMode: .remaining,
+            refreshIntervalSeconds: 600,
+            launchAtLogin: false,
+            menuBarTextEnabled: true,
+            mockEnabled: false,
+            pageLayoutPresets: settings.pageLayoutPresets
+        )
+
+        XCTAssertEqual(normalized.pageLayoutPresets[.overview]?.map(\.name), ["Keep"])
+        // A page with nothing left keeps no empty entry.
+        XCTAssertNil(normalized.pageLayoutPresets[.detail(.claude)])
+    }
+
+    func testPageLayoutPresetsAreCappedPerPage() {
+        let tooMany = (0..<(AppSettings.maximumPresetsPerPage + 8)).map { index in
+            StoredPageLayoutPreset(name: "preset-\(index)", layout: StoredPageLayout())
+        }
+        let normalized = AppSettings(
+            displayMode: .remaining,
+            refreshIntervalSeconds: 600,
+            launchAtLogin: false,
+            menuBarTextEnabled: true,
+            mockEnabled: false,
+            pageLayoutPresets: [.overview: tooMany]
+        )
+
+        XCTAssertEqual(
+            normalized.pageLayoutPresets[.overview]?.count,
+            AppSettings.maximumPresetsPerPage
+        )
+        // The cap keeps the oldest, so saving more never reshuffles the menu.
+        XCTAssertEqual(normalized.pageLayoutPresets[.overview]?.first?.name, "preset-0")
+    }
+
+    func testMangledPageLayoutPresetsDoNotCostTheRestOfTheSettings() throws {
+        let json = #"""
+        {"displayMode": "used", "refreshIntervalSeconds": 1800, "pageLayoutPresets": "not-an-object"}
+        """#
+        let decoded = try JSONDecoder().decode(AppSettings.self, from: Data(json.utf8))
+
+        XCTAssertTrue(decoded.pageLayoutPresets.isEmpty)
+        XCTAssertEqual(decoded.displayMode, .used)
+        XCTAssertEqual(decoded.refreshIntervalSeconds, 1800)
+    }
+
+    func testPageLayoutPresetsSurviveUnknownPagesAndModules() throws {
+        let json = #"""
+        {
+          "displayMode": "remaining",
+          "pageLayoutPresets": {
+            "detail:some-future-provider": [
+              {"name": "From v9", "layout": {"mode": "manual", "ratio": "equal", "columns": [["future-card:v9"], []]}}
+            ]
+          }
+        }
+        """#
+        let decoded = try JSONDecoder().decode(AppSettings.self, from: Data(json.utf8))
+
+        let presets = try XCTUnwrap(
+            decoded.pageLayoutPresets[PageLayoutPageID("detail:some-future-provider")]
+        )
+        XCTAssertEqual(presets.first?.name, "From v9")
+        XCTAssertEqual(presets.first?.layout.columns.first, [PageLayoutModuleID("future-card:v9")])
+    }
+
     func testPageLayoutsEncodeAsAPlainObjectKeyedByPageAndModuleIdentifiers() throws {
         var settings = AppSettings.default
         settings.pageLayouts[.detail(.codex)] = StoredPageLayout(

--- a/Tests/VibeBarCoreTests/ChartSeriesPlanningTests.swift
+++ b/Tests/VibeBarCoreTests/ChartSeriesPlanningTests.swift
@@ -185,3 +185,153 @@ final class ChartSampleSearchTests: XCTestCase {
         }
     }
 }
+
+final class ChartSegmentClipTests: XCTestCase {
+    private struct Sample {
+        let time: Date
+        let value: Int
+    }
+
+    private let base = Date(timeIntervalSince1970: 1_800_000_000)
+
+    private func samples(_ offsets: [TimeInterval]) -> [Sample] {
+        offsets.enumerated().map { Sample(time: base.addingTimeInterval($0.element), value: $0.offset) }
+    }
+
+    private func range(_ from: TimeInterval, _ to: TimeInterval) -> ClosedRange<Date> {
+        base.addingTimeInterval(from)...base.addingTimeInterval(to)
+    }
+
+    private func clip(_ segment: [Sample], _ window: ClosedRange<Date>) -> [Int] {
+        ChartSegmentClip.visible(segment, time: { $0.time }, to: window).map(\.value)
+    }
+
+    func testKeepsOneSampleBeyondEachEdge() {
+        // So a line entering the window starts at the frame border rather than
+        // at its first visible observation.
+        let segment = samples([0, 300, 600, 900, 1_200])
+        XCTAssertEqual(clip(segment, range(400, 800)), [1, 2, 3])
+    }
+
+    func testSegmentCrossingTheWindowWithNoSampleInsideStillDraws() {
+        // The regression this exists for. An hourly-slotted weekly lane can
+        // step straight over a window a user zoomed into; dropping the segment
+        // erased the whole curve while the five-minute-slotted five-hour lane
+        // beside it drew normally.
+        let segment = samples([0, 3_600, 7_200])
+        XCTAssertEqual(clip(segment, range(4_000, 5_000)), [1, 2])
+    }
+
+    func testDailySlotsSurviveASixHourWindow() {
+        // A quota whose window length the provider never reported is filed into
+        // daily slots, so almost every window a user would open contains none
+        // of its samples at all.
+        let segment = samples([0, 86_400, 172_800])
+        let sixHoursIn = range(30 * 3_600, 36 * 3_600)
+        XCTAssertEqual(clip(segment, sixHoursIn), [1, 2])
+    }
+
+    func testNoCoverageNearTheWindowDrawsNothing() {
+        // A hole is information: only a segment that actually crosses the
+        // window is kept, never the nearest samples on one side of it.
+        let before = samples([0, 300])
+        XCTAssertEqual(clip(before, range(10_000, 20_000)), [])
+        let after = samples([30_000, 30_300])
+        XCTAssertEqual(clip(after, range(10_000, 20_000)), [])
+        XCTAssertEqual(clip([], range(0, 100)), [])
+    }
+
+    func testSingleSampleSegmentsAreNotInventedIntoLines() {
+        // One observation is one observation, whichever side of the window it
+        // sits on — the straddle rule needs a pair or it declines.
+        XCTAssertEqual(clip(samples([0]), range(1_000, 2_000)), [])
+        XCTAssertEqual(clip(samples([1_500]), range(1_000, 2_000)), [0])
+    }
+
+    func testSamplesOnTheBoundaryCountAsInside() {
+        let segment = samples([0, 300, 600])
+        XCTAssertEqual(clip(segment, range(300, 600)), [0, 1, 2])
+    }
+}
+
+final class ChartHoverToleranceTests: XCTestCase {
+    /// Widest spacing a lane's own samples can have: its slot width, or the
+    /// refresh cadence when that is slower.
+    private func spacing(windowSeconds: Int?) -> TimeInterval {
+        max(
+            UsageTimelineSlotPolicy.slotSeconds(windowSeconds: windowSeconds),
+            TimeInterval(AppSettings.slowestRefreshIntervalSeconds)
+        )
+    }
+
+    func testEveryLaneResolvesASampleHalfItsOwnRhythmAway() {
+        // The defect: one tolerance for the whole chart. A cursor parked
+        // between two of a lane's consecutive samples has to resolve to one of
+        // them, whatever that lane's sampling rhythm is.
+        for window: Int? in [18_000, 604_800, 30 * 86_400, 90 * 86_400, nil] {
+            let tolerance = ChartHoverTolerance.seconds(
+                windowSeconds: window,
+                visibleSpan: 6 * 3_600
+            )
+            XCTAssertGreaterThanOrEqual(
+                tolerance,
+                spacing(windowSeconds: window) / 2,
+                "window \(String(describing: window))"
+            )
+        }
+    }
+
+    func testSparseLanesGetAWiderToleranceThanDenseOnes() {
+        let visibleSpan: TimeInterval = 6 * 3_600
+        let fiveHour = ChartHoverTolerance.seconds(windowSeconds: 18_000, visibleSpan: visibleSpan)
+        let weekly = ChartHoverTolerance.seconds(windowSeconds: 604_800, visibleSpan: visibleSpan)
+        let monthly = ChartHoverTolerance.seconds(windowSeconds: 30 * 86_400, visibleSpan: visibleSpan)
+        XCTAssertLessThan(fiveHour, weekly)
+        XCTAssertLessThan(weekly, monthly)
+    }
+
+    func testAWeeklyLaneNoLongerMissesOnAFiveHourSizedTolerance() {
+        // Reproduces the reported hover: a six-hour view of a group whose
+        // shortest window is five hours. The old tolerance came from that
+        // shortest window (five-minute slots), so an hourly-slotted weekly
+        // sample half an hour from the cursor was reported as no reading at
+        // all while its line was drawn under the crosshair.
+        let visibleSpan: TimeInterval = 6 * 3_600
+        let old = max(UsageTimelineSlotPolicy.slotSeconds(windowSeconds: 18_000) * 2, visibleSpan / 80)
+        let cursor = Date(timeIntervalSince1970: 1_800_000_000)
+        let weeklySamples = [cursor.addingTimeInterval(-1_800), cursor.addingTimeInterval(1_800)]
+
+        XCTAssertNil(
+            ChartSampleSearch.nearest(in: weeklySamples, to: cursor, tolerance: old, time: { $0 })
+        )
+        XCTAssertNotNil(
+            ChartSampleSearch.nearest(
+                in: weeklySamples,
+                to: cursor,
+                tolerance: ChartHoverTolerance.seconds(
+                    windowSeconds: 604_800,
+                    visibleSpan: visibleSpan
+                ),
+                time: { $0 }
+            )
+        )
+    }
+
+    func testZoomingOutWidensTheToleranceButZoomingInNeverGoesBelowTheRhythm() {
+        let wide = ChartHoverTolerance.seconds(windowSeconds: 18_000, visibleSpan: 60 * 86_400)
+        XCTAssertGreaterThan(wide, 60 * 86_400 / 100)
+        let tight = ChartHoverTolerance.seconds(windowSeconds: 604_800, visibleSpan: 0)
+        XCTAssertEqual(tight, spacing(windowSeconds: 604_800) * ChartHoverTolerance.cadenceFraction)
+    }
+
+    func testAFastLaneStillCoversTheSlowestRefreshCadenceAUserCanPick() {
+        // Five-minute slots do not mean five-minute samples: on the slowest
+        // cadence the picker offers, even a five-hour lane is sampled half an
+        // hour apart, and the hover has to survive that.
+        let tolerance = ChartHoverTolerance.seconds(windowSeconds: 18_000, visibleSpan: 3_600)
+        XCTAssertGreaterThanOrEqual(
+            tolerance,
+            TimeInterval(AppSettings.slowestRefreshIntervalSeconds) / 2
+        )
+    }
+}

--- a/Tests/VibeBarCoreTests/PageLayoutPackerTests.swift
+++ b/Tests/VibeBarCoreTests/PageLayoutPackerTests.swift
@@ -1,0 +1,392 @@
+import XCTest
+@testable import VibeBarCore
+
+/// `PageLayoutMode.compact` lives or dies on this being both optimal and
+/// stable, so the tests pin exact partitions rather than "looks balanced":
+/// a packing that changes between runs would move cards under the user.
+final class PageLayoutPackerTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    private func module(_ name: String) -> PageLayoutModuleID {
+        PageLayoutModuleID(rawValue: name)
+    }
+
+    private func items(_ pairs: [(String, Double)]) -> [PageLayoutPacker.Item] {
+        pairs.map { PageLayoutPacker.Item(id: module($0.0), height: $0.1) }
+    }
+
+    // MARK: - Degenerate input
+
+    func testEmptyInputYieldsTwoEmptyColumns() {
+        let packing = PageLayoutPacker.pack(items: [], spacing: 10)
+
+        XCTAssertEqual(packing.columns, [[], []])
+        XCTAssertEqual(packing.columnHeights, [0, 0])
+        XCTAssertEqual(packing.pageHeight, 0)
+        XCTAssertTrue(packing.isExact)
+    }
+
+    func testSingleModuleTakesTheLeftColumnAndCarriesNoSpacing() {
+        let packing = PageLayoutPacker.pack(items: items([("a", 240)]), spacing: 12)
+
+        XCTAssertEqual(packing.columns, [[module("a")], []])
+        // One card in a column means no neighbour, so no gap.
+        XCTAssertEqual(packing.columnHeights, [240, 0])
+        XCTAssertEqual(packing.pageHeight, 240)
+    }
+
+    func testDuplicateIdentifiersCollapseToTheFirstOccurrence() {
+        let packing = PageLayoutPacker.pack(
+            items: items([("a", 100), ("a", 900), ("b", 100)]),
+            spacing: 0
+        )
+
+        XCTAssertEqual(packing.columns.flatMap { $0 }.count, 2)
+        // The 900 is the duplicate and never reaches the arrangement.
+        XCTAssertEqual(packing.pageHeight, 100)
+    }
+
+    func testEmptyIdentifiersAreDropped() {
+        let packing = PageLayoutPacker.pack(
+            items: items([("", 500), ("a", 100)]),
+            spacing: 0
+        )
+
+        XCTAssertEqual(packing.columns, [[module("a")], []])
+    }
+
+    func testNonFiniteAndNegativeHeightsAreClampedToZero() {
+        let packing = PageLayoutPacker.pack(
+            items: [
+                PageLayoutPacker.Item(id: module("nan"), height: .nan),
+                PageLayoutPacker.Item(id: module("infinite"), height: .infinity),
+                PageLayoutPacker.Item(id: module("negative"), height: -400)
+            ],
+            spacing: 0
+        )
+
+        // Nothing has a usable height, so nothing can make the page taller.
+        XCTAssertEqual(packing.pageHeight, 0)
+        XCTAssertEqual(packing.columns.flatMap { $0 }.count, 3)
+    }
+
+    func testNonFiniteSpacingIsTreatedAsNoGap() {
+        let packing = PageLayoutPacker.pack(
+            items: items([("a", 100), ("b", 100), ("c", 100)]),
+            spacing: .nan
+        )
+
+        XCTAssertEqual(packing.pageHeight, 200)
+    }
+
+    // MARK: - The objective
+
+    func testEqualCardsAreSplitRatherThanStacked() {
+        let packing = PageLayoutPacker.pack(
+            items: items([("a", 100), ("b", 100)]),
+            spacing: 10
+        )
+
+        XCTAssertEqual(packing.columns, [[module("a")], [module("b")]])
+        XCTAssertEqual(packing.pageHeight, 100)
+    }
+
+    func testSpacingIsCountedBetweenNeighboursOnly() {
+        // Three cards that cannot be split evenly: two of them share a column
+        // and pay exactly one gap between them.
+        let packing = PageLayoutPacker.pack(
+            items: items([("a", 100), ("b", 100), ("c", 100)]),
+            spacing: 10
+        )
+
+        XCTAssertEqual(packing.columns, [[module("a"), module("b")], [module("c")]])
+        XCTAssertEqual(packing.columnHeights, [210, 100])
+        XCTAssertEqual(packing.pageHeight, 210)
+    }
+
+    func testFourEqualCardsSplitTwoAndTwoInInputOrder() {
+        let packing = PageLayoutPacker.pack(
+            items: items([("a", 100), ("b", 100), ("c", 100), ("d", 100)]),
+            spacing: 10
+        )
+
+        XCTAssertEqual(
+            packing.columns,
+            [[module("a"), module("b")], [module("c"), module("d")]]
+        )
+        XCTAssertEqual(packing.pageHeight, 210)
+    }
+
+    func testUnevenCardsFindThePartitionThatMinimizesTheTallerColumn() {
+        // 300 / 200 / 150 / 50: the only split that gets both sides to 350 is
+        // {300, 50} against {200, 150}, which greedy largest-first also finds,
+        // but only after rejecting the obvious {300} / {200,150,50}.
+        let packing = PageLayoutPacker.pack(
+            items: items([("a", 300), ("b", 200), ("c", 150), ("d", 50)]),
+            spacing: 0
+        )
+
+        XCTAssertEqual(packing.pageHeight, 350)
+        XCTAssertEqual(packing.columnHeights, [350, 350])
+        XCTAssertEqual(
+            Set(packing.columns[0]),
+            Set([module("a"), module("d")])
+        )
+    }
+
+    func testWithinAColumnCardsKeepTheirInputOrder() {
+        // Input order is the page's default reading order, so a compact page
+        // still reads top to bottom the way the user expects.
+        let packing = PageLayoutPacker.pack(
+            items: items([("a", 90), ("b", 10), ("c", 10), ("d", 90)]),
+            spacing: 0
+        )
+
+        for column in packing.columns {
+            let positions = column.map { id in
+                ["a", "b", "c", "d"].firstIndex(of: id.rawValue) ?? -1
+            }
+            XCTAssertEqual(positions, positions.sorted())
+        }
+    }
+
+    // MARK: - Tie-breaking
+
+    func testTiesKeepTheEarliestCardsInTheLeftColumn() {
+        // Every 2/1 split of three equal cards makes the same 210 pt page. The
+        // winner is the one that leaves the first cards where the page's
+        // default already had them.
+        let packing = PageLayoutPacker.pack(
+            items: items([("a", 100), ("b", 100), ("c", 100)]),
+            spacing: 10
+        )
+
+        XCTAssertEqual(packing.columns[0], [module("a"), module("b")])
+    }
+
+    func testRatioBreaksTiesTowardTheWiderColumn() {
+        let pairs = [("a", 100.0), ("b", 50.0)]
+
+        // Mirror images: one card each, 100 pt page either way. With no wider
+        // side to prefer, the left-first tie-break decides.
+        let equal = PageLayoutPacker.pack(items: items(pairs), spacing: 0, ratio: .equal)
+        XCTAssertEqual(equal.columns, [[module("a")], [module("b")]])
+        XCTAssertEqual(equal.pageHeight, 100)
+
+        // Left is the wide side, and the heavier card belongs under it.
+        let wideLeft = PageLayoutPacker.pack(items: items(pairs), spacing: 0, ratio: .wideNarrow)
+        XCTAssertEqual(wideLeft.columns, [[module("a")], [module("b")]])
+
+        // Right is the wide side, so the same two cards swap.
+        let wideRight = PageLayoutPacker.pack(items: items(pairs), spacing: 0, ratio: .narrowWide)
+        XCTAssertEqual(wideRight.columns, [[module("b")], [module("a")]])
+        XCTAssertEqual(wideRight.pageHeight, 100)
+    }
+
+    func testPackingIsDeterministic() {
+        let input = items([
+            ("a", 317), ("b", 208), ("c", 96), ("d", 451), ("e", 133), ("f", 274)
+        ])
+
+        let first = PageLayoutPacker.pack(items: input, spacing: 9, ratio: .wideNarrow)
+        let second = PageLayoutPacker.pack(items: input, spacing: 9, ratio: .wideNarrow)
+
+        XCTAssertEqual(first, second)
+    }
+
+    // MARK: - Why `compact` exists
+
+    func testCompactBeatsThePhaseConstrainedBalancer() {
+        // AQ's report in one test: his hand-packed Overview was shorter than
+        // the auto balancer's. The balancer places every quota card before any
+        // cost card, and that constraint alone costs this page 110 pt —
+        // `compact` drops it and optimizes for height alone.
+        let spacing = 10.0
+        let heights: [(String, Double, OverviewMasonryPlanner.Phase)] = [
+            ("quota-1", 300, .quota),
+            ("quota-2", 300, .quota),
+            ("quota-3", 120, .quota),
+            ("quota-4", 120, .quota),
+            ("cost-1", 500, .cost),
+            ("cost-2", 260, .cost)
+        ]
+
+        let balanced = OverviewMasonryPlanner.plan(
+            items: heights.map {
+                OverviewMasonryPlanner.Item(id: $0.0, height: $0.1, phase: $0.2)
+            },
+            columns: 2,
+            spacing: spacing
+        )
+        let packed = PageLayoutPacker.pack(
+            items: items(heights.map { ($0.0, $0.1) }),
+            spacing: spacing
+        )
+
+        XCTAssertEqual(balanced.columnHeights.max(), 940)
+        XCTAssertEqual(packed.pageHeight, 830)
+        XCTAssertLessThan(packed.pageHeight, balanced.columnHeights.max() ?? 0)
+
+        // Every card still placed exactly once.
+        XCTAssertEqual(Set(packed.columns.flatMap { $0 }).count, heights.count)
+    }
+
+    func testCompactIgnoresPhaseGroupingAndMixesQuotaWithCost() {
+        let packed = PageLayoutPacker.pack(
+            items: items([
+                ("quota-1", 300), ("quota-2", 300), ("quota-3", 120), ("quota-4", 120),
+                ("cost-1", 500), ("cost-2", 260)
+            ]),
+            spacing: 10
+        )
+
+        // Neither column is purely quota or purely cost — which is exactly the
+        // arrangement the phased balancer cannot reach.
+        for column in packed.columns {
+            let families = Set(column.map { $0.rawValue.split(separator: "-").first.map(String.init) ?? "" })
+            XCTAssertGreaterThan(families.count, 1)
+        }
+    }
+
+    // MARK: - Search limits
+
+    func testModuleCountsUpToTheLimitAreSearchedExactly() {
+        let exact = PageLayoutPacker.pack(
+            items: items((0..<PageLayoutPacker.exactSearchLimit).map { ("m\($0)", Double(10 + $0)) }),
+            spacing: 4
+        )
+
+        XCTAssertTrue(exact.isExact)
+    }
+
+    func testBeyondTheLimitTheGreedyFallbackTakesOverAndStillBalances() {
+        let count = PageLayoutPacker.exactSearchLimit + 1
+        let ids = (0..<count).map { "m\($0)" }
+        let packing = PageLayoutPacker.pack(
+            items: items(ids.map { ($0, 100.0) }),
+            spacing: 0
+        )
+
+        XCTAssertFalse(packing.isExact)
+        // Longest-processing-time-first alternates 17 equal cards 9 / 8.
+        XCTAssertEqual(packing.columns[0].count, 9)
+        XCTAssertEqual(packing.columns[1].count, 8)
+        XCTAssertEqual(packing.columnHeights, [900, 800])
+        // Still one column each, still in input order.
+        XCTAssertEqual(Set(packing.columns.flatMap { $0 }).count, count)
+        XCTAssertEqual(
+            packing.columns[0],
+            stride(from: 0, to: count, by: 2).map { module("m\($0)") }
+        )
+    }
+
+    func testGreedyFallbackNeverLosesOrDuplicatesACard() {
+        let count = 24
+        let packing = PageLayoutPacker.pack(
+            items: items((0..<count).map { ("m\($0)", Double(20 + ($0 * 37) % 260)) }),
+            spacing: 8
+        )
+
+        let placed = packing.columns.flatMap { $0 }
+        XCTAssertEqual(placed.count, count)
+        XCTAssertEqual(Set(placed).count, count)
+    }
+
+    // MARK: - Measuring an arrangement
+
+    func testStackedHeightSumsCardsAndTheGapsBetweenThem() {
+        let heights: [PageLayoutModuleID: Double] = [
+            module("a"): 100,
+            module("b"): 50,
+            module("c"): 25
+        ]
+
+        XCTAssertEqual(
+            PageLayoutPacker.stackedHeight(
+                [module("a"), module("b"), module("c")],
+                heights: heights,
+                spacing: 10
+            ),
+            195
+        )
+        XCTAssertEqual(
+            PageLayoutPacker.stackedHeight([module("a")], heights: heights, spacing: 10),
+            100
+        )
+        XCTAssertEqual(
+            PageLayoutPacker.stackedHeight([], heights: heights, spacing: 10),
+            0
+        )
+        // A card the page has never measured contributes no height, but it is
+        // still a card, so the gap on either side of it is real.
+        XCTAssertEqual(
+            PageLayoutPacker.stackedHeight(
+                [module("a"), module("unmeasured")],
+                heights: heights,
+                spacing: 10
+            ),
+            110
+        )
+    }
+
+    func testPageHeightIsTheTallerColumn() {
+        let heights: [PageLayoutModuleID: Double] = [
+            module("a"): 100,
+            module("b"): 50,
+            module("c"): 25
+        ]
+
+        XCTAssertEqual(
+            PageLayoutPacker.pageHeight(
+                columns: [[module("a"), module("b")], [module("c")]],
+                heights: heights,
+                spacing: 10
+            ),
+            160
+        )
+        XCTAssertEqual(
+            PageLayoutPacker.pageHeight(columns: [[], []], heights: heights, spacing: 10),
+            0
+        )
+    }
+
+    func testPageHeightMeasuresTheArrangementThePackerChose() {
+        let input = items([("a", 300), ("b", 200), ("c", 150), ("d", 50)])
+        let packing = PageLayoutPacker.pack(items: input, spacing: 7)
+        let heights = Dictionary(uniqueKeysWithValues: input.map { ($0.id, $0.height) })
+
+        XCTAssertEqual(
+            PageLayoutPacker.pageHeight(
+                columns: packing.columns,
+                heights: heights,
+                spacing: 7
+            ),
+            packing.pageHeight
+        )
+    }
+
+    // MARK: - Config bridge
+
+    func testPackedConfigCarriesTheRatioColumnsAndHeights() {
+        let input = items([("a", 300), ("b", 200), ("c", 150), ("d", 50)])
+        let measured: [PageLayoutModuleID: Double] = [module("a"): 300]
+
+        let config = PageLayoutPacker.packedConfig(
+            items: input,
+            spacing: 6,
+            ratio: .wideNarrow,
+            measuredHeights: measured
+        )
+
+        XCTAssertEqual(config.ratio, .wideNarrow)
+        XCTAssertEqual(config.columns.count, PageLayoutConfig.columnCount)
+        XCTAssertEqual(
+            config.columns,
+            PageLayoutPacker.pack(items: input, spacing: 6, ratio: .wideNarrow).columns
+        )
+        XCTAssertEqual(config.measuredHeight(for: module("a")), 300)
+        // Straight through `PageLayoutConfig`, so the invariants hold.
+        XCTAssertEqual(Set(config.moduleIDs).count, config.moduleIDs.count)
+    }
+}

--- a/Tests/VibeBarCoreTests/PageLayoutTests.swift
+++ b/Tests/VibeBarCoreTests/PageLayoutTests.swift
@@ -639,4 +639,174 @@ final class PageLayoutTests: XCTestCase {
         // the editor can still draw it to scale.
         XCTAssertEqual(merged.measuredHeight(for: .quotaHistoryAll), 300)
     }
+
+    // MARK: - PageLayoutMode
+
+    func testLayoutModeRoundTripsAndFallsBackForUnknownValues() throws {
+        for mode in PageLayoutMode.allCases {
+            let data = try JSONEncoder().encode([mode])
+            XCTAssertEqual(try JSONDecoder().decode([PageLayoutMode].self, from: data), [mode])
+        }
+
+        let unknown = Data(#"["telepathic"]"#.utf8)
+        XCTAssertEqual(try JSONDecoder().decode([PageLayoutMode].self, from: unknown), [.auto])
+    }
+
+    func testOnlyManualIsNotComputed() {
+        XCTAssertTrue(PageLayoutMode.auto.isComputed)
+        XCTAssertTrue(PageLayoutMode.compact.isComputed)
+        XCTAssertFalse(PageLayoutMode.manual.isComputed)
+    }
+
+    // MARK: - StoredPageLayout modes
+
+    func testStoredLayoutDerivesItsModeFromItsColumnsWhenUnspecified() {
+        // An entry that carries an arrangement is one somebody arranged.
+        let arranged = StoredPageLayout(ratio: .equal, columns: [[.status], [.costAll]])
+        XCTAssertEqual(arranged.mode, .manual)
+
+        // An entry that carries none is a page still drawing itself.
+        XCTAssertEqual(StoredPageLayout().mode, .auto)
+        XCTAssertEqual(StoredPageLayout(ratio: .wideNarrow).mode, .auto)
+    }
+
+    func testStoredLayoutHonoursAnExplicitModeOverTheDerivedOne() {
+        let compact = StoredPageLayout(mode: .compact, ratio: .equal, columns: [[.status], []])
+        XCTAssertEqual(compact.mode, .compact)
+        // The columns survive: switching modes is not a reset.
+        XCTAssertEqual(compact.columns.first, [.status])
+
+        let auto = StoredPageLayout(mode: .auto, ratio: .equal, columns: [[.status], [.costAll]])
+        XCTAssertEqual(auto.mode, .auto)
+        XCTAssertFalse(auto.isEmpty)
+
+        let manual = StoredPageLayout(mode: .manual)
+        XCTAssertEqual(manual.mode, .manual)
+        XCTAssertTrue(manual.isEmpty)
+    }
+
+    func testStoredLayoutFromAConfigTakesTheGivenMode() {
+        let config = PageLayoutConfig(
+            ratio: .narrowWide,
+            columns: [[.status], [.costAll]],
+            measuredHeights: [.status: 140]
+        )
+
+        XCTAssertEqual(StoredPageLayout(config).mode, .manual)
+        XCTAssertEqual(StoredPageLayout(config, mode: .compact).mode, .compact)
+        // Measurement never rides along into settings.
+        XCTAssertEqual(StoredPageLayout(config, mode: .compact).columns, [[.status], [.costAll]])
+    }
+
+    func testLegacyStoredLayoutWithoutAModeDecodesByItsColumns() throws {
+        // Every entry written before modes existed is an arrangement the user
+        // dragged, so it has to come back as `manual` — decoding it as `auto`
+        // would silently discard their layout on first launch.
+        let arranged = Data(#"{"ratio":"wide-narrow","columns":[["status"],["cost-all"]]}"#.utf8)
+        let decodedArranged = try JSONDecoder().decode(StoredPageLayout.self, from: arranged)
+        XCTAssertEqual(decodedArranged.mode, .manual)
+        XCTAssertEqual(decodedArranged.ratio, .wideNarrow)
+        XCTAssertEqual(decodedArranged.columns, [[.status], [.costAll]])
+
+        // A heights-only entry carried no arrangement and stays automatic.
+        let bare = Data(#"{"ratio":"equal","columns":[[],[]]}"#.utf8)
+        XCTAssertEqual(try JSONDecoder().decode(StoredPageLayout.self, from: bare).mode, .auto)
+    }
+
+    func testStoredLayoutWithAnUnknownModeFallsBackToItsColumnsToo() throws {
+        // A mode from a newer build is as good as no mode: the columns are
+        // still the better evidence of what the user wanted.
+        let json = Data(#"{"mode":"telepathic","ratio":"equal","columns":[["status"],[]]}"#.utf8)
+        let decoded = try JSONDecoder().decode(StoredPageLayout.self, from: json)
+
+        XCTAssertEqual(decoded.mode, .manual)
+        XCTAssertEqual(decoded.columns.first, [.status])
+    }
+
+    func testStoredLayoutRoundTripsEveryModeIncludingAutoWithColumns() throws {
+        for mode in PageLayoutMode.allCases {
+            let stored = StoredPageLayout(
+                mode: mode,
+                ratio: .narrowWide,
+                columns: [[.status], [.costAll, .quotaHistoryAll]]
+            )
+            let decoded = try JSONDecoder().decode(
+                StoredPageLayout.self,
+                from: try JSONEncoder().encode(stored)
+            )
+
+            XCTAssertEqual(decoded.mode, mode)
+            XCTAssertEqual(decoded.ratio, .narrowWide)
+            XCTAssertEqual(decoded.columns, [[.status], [.costAll, .quotaHistoryAll]])
+        }
+    }
+
+    func testStoredLayoutEncodesTheModeAsAPlainString() throws {
+        let stored = StoredPageLayout(mode: .compact, ratio: .equal, columns: [[.status], []])
+        let data = try JSONEncoder().encode(stored)
+        let object = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+
+        XCTAssertEqual(object["mode"] as? String, "compact")
+    }
+
+    // MARK: - StoredPageLayoutPreset
+
+    func testPresetTrimsAndCapsItsName() {
+        XCTAssertEqual(
+            StoredPageLayoutPreset(name: "  Cost on the left  ", layout: StoredPageLayout()).name,
+            "Cost on the left"
+        )
+        let long = String(repeating: "x", count: StoredPageLayoutPreset.maximumNameLength + 40)
+        XCTAssertEqual(
+            StoredPageLayoutPreset(name: long, layout: StoredPageLayout()).name.count,
+            StoredPageLayoutPreset.maximumNameLength
+        )
+    }
+
+    func testAPresetWithNoUsableNameIsInvalid() {
+        XCTAssertFalse(StoredPageLayoutPreset(name: "   ", layout: StoredPageLayout()).isValid)
+        XCTAssertFalse(StoredPageLayoutPreset(name: "", layout: StoredPageLayout()).isValid)
+        XCTAssertTrue(StoredPageLayoutPreset(name: "Tall left", layout: StoredPageLayout()).isValid)
+    }
+
+    func testPresetRoundTripsItsWholeLayout() throws {
+        let preset = StoredPageLayoutPreset(
+            name: "Cost first",
+            layout: StoredPageLayout(
+                mode: .compact,
+                ratio: .wideNarrow,
+                columns: [[.costAll], [.status, .quotaHistoryAll]]
+            )
+        )
+
+        let decoded = try JSONDecoder().decode(
+            StoredPageLayoutPreset.self,
+            from: try JSONEncoder().encode(preset)
+        )
+
+        XCTAssertEqual(decoded.name, "Cost first")
+        XCTAssertEqual(decoded.layout.mode, .compact)
+        XCTAssertEqual(decoded.layout.ratio, .wideNarrow)
+        XCTAssertEqual(decoded.layout.columns, [[.costAll], [.status, .quotaHistoryAll]])
+    }
+
+    func testPresetDecodeToleratesMissingAndMalformedFields() throws {
+        // A nameless preset decodes, then fails `isValid` so the settings
+        // normalizer can drop it rather than showing a blank menu row.
+        let nameless = try JSONDecoder().decode(
+            StoredPageLayoutPreset.self,
+            from: Data(#"{"layout":{"mode":"manual","columns":[["status"],[]]}}"#.utf8)
+        )
+        XCTAssertFalse(nameless.isValid)
+        XCTAssertEqual(nameless.layout.columns.first, [.status])
+
+        // A mangled layout costs the arrangement, not the whole preset list.
+        let mangled = try JSONDecoder().decode(
+            StoredPageLayoutPreset.self,
+            from: Data(#"{"name":"Broken","layout":"not-an-object"}"#.utf8)
+        )
+        XCTAssertTrue(mangled.isValid)
+        XCTAssertTrue(mangled.layout.isEmpty)
+        XCTAssertEqual(mangled.layout.mode, .auto)
+    }
 }

--- a/Tests/VibeBarCoreTests/PageLayoutTests.swift
+++ b/Tests/VibeBarCoreTests/PageLayoutTests.swift
@@ -713,13 +713,16 @@ final class PageLayoutTests: XCTestCase {
         XCTAssertEqual(try JSONDecoder().decode(StoredPageLayout.self, from: bare).mode, .auto)
     }
 
-    func testStoredLayoutWithAnUnknownModeFallsBackToItsColumnsToo() throws {
-        // A mode from a newer build is as good as no mode: the columns are
-        // still the better evidence of what the user wanted.
+    func testStoredLayoutWithAnUnknownModeFallsBackToAuto() throws {
+        // A PRESENT but unrecognized mode is a newer build's setting, not a
+        // pre-modes entry — after a downgrade the page should fall back to
+        // automatic rather than surprise-activate a fixed manual layout. The
+        // columns survive untouched for when the newer build returns.
         let json = Data(#"{"mode":"telepathic","ratio":"equal","columns":[["status"],[]]}"#.utf8)
         let decoded = try JSONDecoder().decode(StoredPageLayout.self, from: json)
 
-        XCTAssertEqual(decoded.mode, .manual)
+        XCTAssertEqual(decoded.mode, PageLayoutMode.fallback)
+        XCTAssertEqual(decoded.mode, .auto)
         XCTAssertEqual(decoded.columns.first, [.status])
     }
 

--- a/Tests/VibeBarCoreTests/PageLayoutTests.swift
+++ b/Tests/VibeBarCoreTests/PageLayoutTests.swift
@@ -749,7 +749,82 @@ final class PageLayoutTests: XCTestCase {
         XCTAssertEqual(object["mode"] as? String, "compact")
     }
 
+    // MARK: - Returning to Manual
+
+    func testReturningToManualRestoresTheSavedArrangement() {
+        // The round trip that must not lose work: arrange by hand, switch to a
+        // computed mode, switch back. The columns kept through `compact` are
+        // the ones that come back — not whatever the packer was showing.
+        let arranged = StoredPageLayout(
+            mode: .manual,
+            ratio: .wideNarrow,
+            columns: [[.costAll], [.status, .quotaHistoryAll]]
+        )
+        let parked = StoredPageLayout(
+            mode: .compact,
+            ratio: arranged.ratio,
+            columns: arranged.columns
+        )
+
+        let restored = parked.restoredAsManual()
+
+        XCTAssertEqual(restored?.mode, .manual)
+        XCTAssertEqual(restored?.ratio, .wideNarrow)
+        XCTAssertEqual(restored?.columns, [[.costAll], [.status, .quotaHistoryAll]])
+    }
+
+    func testReturningToManualRestoresFromAutoToo() {
+        let parked = StoredPageLayout(
+            mode: .auto,
+            ratio: .narrowWide,
+            columns: [[.status], [.costAll]]
+        )
+
+        XCTAssertEqual(parked.restoredAsManual()?.columns, [[.status], [.costAll]])
+        XCTAssertEqual(parked.restoredAsManual()?.ratio, .narrowWide)
+    }
+
+    func testAPageWithNoHandArrangementHasNothingToRestore() {
+        // Nil is the caller's signal to materialize what is on screen, which is
+        // the right starting point for a first-time edit.
+        XCTAssertNil(StoredPageLayout().restoredAsManual())
+        XCTAssertNil(StoredPageLayout(mode: .compact, ratio: .equal).restoredAsManual())
+        XCTAssertNil(StoredPageLayout(mode: .auto, ratio: .wideNarrow, columns: [[], []]).restoredAsManual())
+    }
+
+    func testRestoringAsManualIsIdempotent() {
+        let manual = StoredPageLayout(mode: .manual, ratio: .equal, columns: [[.status], [.costAll]])
+
+        XCTAssertEqual(manual.restoredAsManual(), manual)
+        XCTAssertEqual(manual.restoredAsManual()?.restoredAsManual(), manual)
+    }
+
     // MARK: - StoredPageLayoutPreset
+
+    func testPresetMatchingIsCaseInsensitiveAndTrimmed() {
+        let presets = [
+            StoredPageLayoutPreset(name: "Tall left", layout: StoredPageLayout()),
+            StoredPageLayoutPreset(name: "Shortest", layout: StoredPageLayout())
+        ]
+
+        XCTAssertEqual(StoredPageLayoutPreset.index(of: "Tall left", in: presets), 0)
+        XCTAssertEqual(StoredPageLayoutPreset.index(of: "TALL LEFT", in: presets), 0)
+        XCTAssertEqual(StoredPageLayoutPreset.index(of: "  shortest  ", in: presets), 1)
+        // A new name is what costs a slot against the per-page cap.
+        XCTAssertNil(StoredPageLayoutPreset.index(of: "Widest", in: presets))
+        XCTAssertNil(StoredPageLayoutPreset.index(of: "   ", in: presets))
+        XCTAssertNil(StoredPageLayoutPreset.index(of: "Tall left", in: []))
+    }
+
+    func testPresetMatchingUsesTheSameRuleAsTheSettingsDedupe() {
+        // One rule, so saving, deleting and the settings normalizer cannot
+        // disagree about which presets are "the same".
+        let presets = [StoredPageLayoutPreset(name: "Keep", layout: StoredPageLayout())]
+        let duplicate = StoredPageLayoutPreset(name: "  keep  ", layout: StoredPageLayout())
+
+        XCTAssertEqual(duplicate.matchKey, presets[0].matchKey)
+        XCTAssertNotNil(StoredPageLayoutPreset.index(of: duplicate.name, in: presets))
+    }
 
     func testPresetTrimsAndCapsItsName() {
         XCTAssertEqual(


### PR DESCRIPTION
Round 3 from AQ's hands-on feedback.

## Chart fixes (all root-caused against real local timeline data)

- **Weekly hover missed constantly** — tolerance was derived once from the chart's shortest window (600s for a 5h primary) and applied to every lane, but weekly lanes sample on hourly slots. Now per-lane: `max(slot, slowest refresh) × 0.75`. Continuous-coverage hit rate → 100%.
- **Slow lanes vanished while 5h drew** — segment clipping dropped segments with no sample inside the visible range even when their samples bracketed it. Daily-slot lanes: 89% blank windows → 0%.
- **"No active window" → "No data recorded"** — a fill lane can't distinguish an idle window from a sleeping Mac (screen-off = no refresh timer = no samples), so the tooltip stops guessing.

## Layout modes + presets

- Per-page **mode**: `Auto` (existing balancer) / `Compact` (exact min-height two-column packing from measured heights — ignores the phase constraint that kept quota cards above cost cards; a test encodes AQ's observed case where hand-packing beat the balancer 830pt vs 940pt) / `Manual` (dragged arrangement). Anti-thrash: re-pack only on >4pt height drift and >8pt improvement, so cross-column re-measurement can't oscillate.
- **Named arrangement presets** per page (save/apply/delete, AppSettings with tolerant decoding, cap 20). Applying lands in Manual and reconciles against currently-available modules.
- Editor: mode segmented control; Auto/Compact render as read-only previews ("Switch to Manual to arrange by hand"); ratio stays live in every mode. Pre-modes settings entries decode as Manual — existing customizations keep behaving.

## Verification

`swift build` clean · `swift test` **953 green** (898 + 55) · `./Scripts/build_app.sh release` + strict codesign pass, entitlements empty · home grep clean · hover/clip fixes validated against real fill-timeline lanes (no identifiers in code or tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)