### PR TITLE
Prepare Vibe Bar 1.2.0 Dev build 10

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -21,7 +21,7 @@
     <key>CFBundleShortVersionString</key>
     <string>1.2.0</string>
     <key>CFBundleVersion</key>
-    <string>9</string>
+    <string>10</string>
     <key>LSMinimumSystemVersion</key>
     <string>26.0</string>
     <key>LSUIElement</key>


### PR DESCRIPTION
Version bump for the Dev-channel release carrying PR #125 (layout modes + chart hover fixes): `CFBundleVersion` 9 → 10, `CFBundleShortVersionString` stays 1.2.0.

Verified in this worktree: `swift build` clean, 959 tests green, `./Scripts/build_app.sh release` + strict codesign pass, entitlements empty. After merge: tag `v1.2.0-dev.10` → release workflow → inspect draft → publish as Pre-release on the Dev channel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)