### PR TITLE
Segmented compact layout, forecast menu-bar colors, refresh jank fixes, batch cookie import

### DIFF
--- a/Sources/VibeBarApp/AppEnvironment.swift
+++ b/Sources/VibeBarApp/AppEnvironment.swift
@@ -43,6 +43,11 @@ final class AppEnvironment: ObservableObject {
     private var browserGeminiCookieImportInFlight = false
     private var browserGrokCookieImportInFlight = false
     private var pricingRefreshTask: Task<Void, Never>?
+    private var webCookiePresenceProbedAt: Date?
+    /// Long enough to fold the probes of one refresh burst — the Gemini card
+    /// refreshes two providers back to back — and short enough that a cookie
+    /// change made outside Vibe Bar still shows up on the next manual refresh.
+    private static let webCookiePresenceTTL: TimeInterval = 5
 
     init() {
         let settings = SettingsStore()
@@ -102,7 +107,12 @@ final class AppEnvironment: ObservableObject {
         self.hasOpenAIWebCookies = OpenAIWebCookieStore.hasCookieHeader()
         self.hasGeminiWebCookies = GeminiWebCookieStore.hasCookieHeader()
         self.hasGrokWebCookies = GrokWebCookieStore.hasCookieHeader()
-        self.routeHealth = PrimaryProviderRouteHealthChecker.checkAll()
+        // Filled in by the async probe at the end of `init`. Checking all
+        // twelve routes synchronously here meant launch blocked on a dozen
+        // Keychain round trips plus a `/bin/ps` spawn before the menu bar item
+        // even appeared; the surfaces that read this treat a missing route as
+        // "not checked yet", which for the first few milliseconds is the truth.
+        self.routeHealth = [:]
 
         let scheduler = QuotaRefreshScheduler(
             service: service,
@@ -243,6 +253,7 @@ final class AppEnvironment: ObservableObject {
                 }
             }
         }
+        recheckPrimaryRouteHealth()
         importPersistentClaudeCookiesAndRefreshIfNeeded()
         importClaudeBrowserCookiesAndRefreshIfNeeded()
         importPersistentOpenAICookiesAndRefreshIfNeeded()
@@ -294,10 +305,10 @@ final class AppEnvironment: ObservableObject {
     }
 
     func reloadProviderCredentialsAndRefresh() {
-        hasClaudeWebCookies = ClaudeWebCookieStore.hasCookieHeader()
-        hasOpenAIWebCookies = OpenAIWebCookieStore.hasCookieHeader()
-        hasGeminiWebCookies = GeminiWebCookieStore.hasCookieHeader()
-        hasGrokWebCookies = GrokWebCookieStore.hasCookieHeader()
+        // Forced: this is the path a login, a sign-out, or an explicit "reload
+        // credentials" takes, so a cached presence reading would be exactly the
+        // wrong answer.
+        refreshWebCookiePresence(force: true)
         recheckPrimaryRouteHealth()
         importPersistentOpenAICookiesAndRefreshIfNeeded()
         importOpenAIBrowserCookiesAndRefreshIfNeeded()
@@ -337,10 +348,7 @@ final class AppEnvironment: ObservableObject {
     }
 
     func refresh(_ tool: ToolType) {
-        hasClaudeWebCookies = ClaudeWebCookieStore.hasCookieHeader()
-        hasOpenAIWebCookies = OpenAIWebCookieStore.hasCookieHeader()
-        hasGeminiWebCookies = GeminiWebCookieStore.hasCookieHeader()
-        hasGrokWebCookies = GrokWebCookieStore.hasCookieHeader()
+        refreshWebCookiePresence()
         recheckPrimaryRouteHealth(provider: tool)
         accountStore.reload(
             codexUsageMode: settingsStore.settings.codexUsageMode,
@@ -364,14 +372,59 @@ final class AppEnvironment: ObservableObject {
         }
     }
 
+    /// Re-probe the credential routes behind one provider, or all of them.
+    ///
+    /// Runs off the main actor: every route reads a credential file, a Keychain
+    /// item, or — for AntiGravity — spawns `/bin/ps` and blocks on it, and this
+    /// is reached from every refresh, including the one a popover open triggers.
+    /// The results land back in one published assignment.
     func recheckPrimaryRouteHealth(provider: ToolType? = nil) {
         let routes = provider.map(PrimaryProviderRoute.routes(for:)) ?? PrimaryProviderRoute.allCases
-        var next = routeHealth
-        let now = Date()
-        for route in routes {
-            next[route] = PrimaryProviderRouteHealthChecker.check(route, now: now)
+        Task { @MainActor [weak self] in
+            let checked = await PrimaryProviderRouteHealthChecker.checkOffActor(routes, now: Date())
+            guard let self else { return }
+            self.routeHealth = self.routeHealth.merging(checked) { _, fresh in fresh }
         }
-        routeHealth = next
+    }
+
+    /// Whether each provider has a saved web session cookie.
+    ///
+    /// Four Keychain round trips, and `SecureCookieHeaderStore` only caches
+    /// *found* items — a provider the user has never signed into re-queries the
+    /// Keychain every single time. That used to happen on the main actor once
+    /// per refresh and once per *provider* refresh, so opening the Gemini card
+    /// alone paid for eight of them. Probed off the actor, and reused inside one
+    /// refresh burst so the Gemini pair does not probe twice.
+    private func refreshWebCookiePresence(force: Bool = false) {
+        let now = Date()
+        if !force,
+           let probedAt = webCookiePresenceProbedAt,
+           now.timeIntervalSince(probedAt) < Self.webCookiePresenceTTL {
+            return
+        }
+        webCookiePresenceProbedAt = now
+        Task { @MainActor [weak self] in
+            let presence = await Task.detached(priority: .userInitiated) {
+                WebCookiePresence(
+                    claude: ClaudeWebCookieStore.hasCookieHeader(),
+                    openAI: OpenAIWebCookieStore.hasCookieHeader(),
+                    gemini: GeminiWebCookieStore.hasCookieHeader(),
+                    grok: GrokWebCookieStore.hasCookieHeader()
+                )
+            }.value
+            guard let self else { return }
+            self.hasClaudeWebCookies = presence.claude
+            self.hasOpenAIWebCookies = presence.openAI
+            self.hasGeminiWebCookies = presence.gemini
+            self.hasGrokWebCookies = presence.grok
+        }
+    }
+
+    private struct WebCookiePresence: Sendable {
+        let claude: Bool
+        let openAI: Bool
+        let gemini: Bool
+        let grok: Bool
     }
 
     func showSettingsWindow() {
@@ -789,6 +842,27 @@ final class AppEnvironment: ObservableObject {
     /// at the next refresh anyway.
     private static let routineBudgetFailureCooldown: TimeInterval = 3600
 
+    /// How long the probe waits when the popover is on screen.
+    ///
+    /// Every Claude refresh reaches this, and opening the popover triggers a
+    /// refresh — so the WebView used to boot in the same run-loop turns the
+    /// popover was laying itself out in, on the main actor, next to the
+    /// rendering. Waiting lets the refresh settle first. Deliberately a delay
+    /// rather than "skip while visible": the routines bucket only gets its
+    /// "used / limit" label from this probe, and a user who leaves the popover
+    /// open would otherwise never see it.
+    private static let routineBudgetVisiblePopoverDelay: TimeInterval = 2
+
+    /// Set by `StatusItemController` when the popover is shown or dismissed.
+    /// Deliberately not `@Published`: nothing renders from it, and publishing it
+    /// would invalidate every view observing this object at the exact moment the
+    /// popover is trying to appear.
+    private(set) var isPopoverVisible = false
+
+    func setPopoverVisible(_ isVisible: Bool) {
+        isPopoverVisible = isVisible
+    }
+
     private func scheduleClaudeRoutineBudgetPatchIfNeeded(for quota: AccountQuota) {
         guard quota.tool == .claude, !settingsStore.mockEnabled else { return }
         guard let routine = quota.bucket(id: "daily_routines") else { return }
@@ -806,9 +880,13 @@ final class AppEnvironment: ObservableObject {
         routineBudgetInFlightAccountIds.insert(quota.accountId)
         lastRoutineBudgetAttemptByAccount[quota.accountId] = now
 
+        let deferBy = isPopoverVisible ? Self.routineBudgetVisiblePopoverDelay : 0
         Task { @MainActor [weak self, accountId = quota.accountId] in
             guard let self else { return }
             defer { self.routineBudgetInFlightAccountIds.remove(accountId) }
+            if deferBy > 0 {
+                try? await Task.sleep(for: .seconds(deferBy))
+            }
             guard let result = await ClaudeRoutineBudgetWebViewFetcher.fetch() else { return }
             self.quotaService.replaceBucket(self.routinesBucket(from: result), for: accountId)
             // Success: clear the cooldown so a future cookie rotation can

--- a/Sources/VibeBarApp/AppEnvironment.swift
+++ b/Sources/VibeBarApp/AppEnvironment.swift
@@ -44,6 +44,9 @@ final class AppEnvironment: ObservableObject {
     private var browserGrokCookieImportInFlight = false
     private var pricingRefreshTask: Task<Void, Never>?
     private var webCookiePresenceProbedAt: Date?
+    private var webCookiePresenceGeneration: UInt64 = 0
+    private var routeHealthProbeGeneration: UInt64 = 0
+    private var routeHealthWriteGeneration: [PrimaryProviderRoute: UInt64] = [:]
     /// Long enough to fold the probes of one refresh burst — the Gemini card
     /// refreshes two providers back to back — and short enough that a cookie
     /// change made outside Vibe Bar still shows up on the next manual refresh.
@@ -380,10 +383,22 @@ final class AppEnvironment: ObservableObject {
     /// The results land back in one published assignment.
     func recheckPrimaryRouteHealth(provider: ToolType? = nil) {
         let routes = provider.map(PrimaryProviderRoute.routes(for:)) ?? PrimaryProviderRoute.allCases
+        // Probes overlap: a slow all-route sweep can still be reading files
+        // when a credential change fires a short provider-specific probe. The
+        // newer probe describes the newer world, so each route remembers the
+        // generation that last wrote it and an older sweep cannot roll it back.
+        routeHealthProbeGeneration &+= 1
+        let generation = routeHealthProbeGeneration
         Task { @MainActor [weak self] in
             let checked = await PrimaryProviderRouteHealthChecker.checkOffActor(routes, now: Date())
             guard let self else { return }
-            self.routeHealth = self.routeHealth.merging(checked) { _, fresh in fresh }
+            var merged = self.routeHealth
+            for (route, health) in checked {
+                if let written = self.routeHealthWriteGeneration[route], written > generation { continue }
+                merged[route] = health
+                self.routeHealthWriteGeneration[route] = generation
+            }
+            self.routeHealth = merged
         }
     }
 
@@ -403,6 +418,11 @@ final class AppEnvironment: ObservableObject {
             return
         }
         webCookiePresenceProbedAt = now
+        // The snapshot is all-or-nothing, so only the newest probe may publish:
+        // a login or cookie deletion forces a fresh probe, and a still-running
+        // older one finishing after it must not put the pre-login state back.
+        webCookiePresenceGeneration &+= 1
+        let generation = webCookiePresenceGeneration
         Task { @MainActor [weak self] in
             let presence = await Task.detached(priority: .userInitiated) {
                 WebCookiePresence(
@@ -412,7 +432,7 @@ final class AppEnvironment: ObservableObject {
                     grok: GrokWebCookieStore.hasCookieHeader()
                 )
             }.value
-            guard let self else { return }
+            guard let self, generation == self.webCookiePresenceGeneration else { return }
             self.hasClaudeWebCookies = presence.claude
             self.hasOpenAIWebCookies = presence.openAI
             self.hasGeminiWebCookies = presence.gemini

--- a/Sources/VibeBarApp/PageLayoutModel.swift
+++ b/Sources/VibeBarApp/PageLayoutModel.swift
@@ -58,12 +58,17 @@ final class PageLayoutModel: ObservableObject {
     /// One `compact` page's chosen partition, plus everything it depended on.
     private struct CompactPacking {
         var moduleIDs: [PageLayoutModuleID]
+        /// Band membership the partition was computed under. Part of the key,
+        /// not of the answer: re-banding a page changes what "shortest" means,
+        /// so a cached packing from the old bands cannot be reused.
+        var segments: [[PageLayoutModuleID]]
         var ratio: PageColumnRatio
         var spacing: Double
         /// Heights the partition was packed from — the baseline drift is
         /// measured against.
         var heights: [PageLayoutModuleID: Double]
-        var columns: [[PageLayoutModuleID]]
+        /// Two columns per band, in band order.
+        var segmentColumns: [[[PageLayoutModuleID]]]
     }
 
     private let settingsStore: SettingsStore
@@ -142,6 +147,22 @@ final class PageLayoutModel: ObservableObject {
 
     // MARK: - Modes
 
+    /// Bands this page's `compact` mode packs one at a time: the ones the user
+    /// chose, or the page's default banding when they have not.
+    ///
+    /// Every currently drawable module lands in exactly one band, so this is
+    /// also the membership the editor drags against.
+    func resolvedSegments(
+        for page: PageLayoutPageID,
+        descriptors: [PageModuleDescriptor]
+    ) -> [[PageLayoutModuleID]] {
+        PageLayoutSegments.resolve(
+            stored: storedLayouts[page]?.segments ?? [],
+            available: descriptors.map(\.id),
+            defaultSegments: PageModuleCatalog.defaultSegments(for: page, descriptors: descriptors)
+        )
+    }
+
     /// The arrangement this page should render right now, for whichever mode
     /// it is in.
     ///
@@ -151,11 +172,14 @@ final class PageLayoutModel: ObservableObject {
     /// does not render from this: it hands its cards to `ColumnMasonryLayout`
     /// and lets SwiftUI balance them live. What comes back here for that case
     /// is the same planner's answer the editor has always previewed.
+    ///
+    /// `auto` and `manual` return a single band — the two-column page they have
+    /// always been — and only `compact` can return more than one.
     func arrangement(
         for page: PageLayoutPageID,
         descriptors: [PageModuleDescriptor],
         spacing: Double
-    ) -> PageLayoutConfig {
+    ) -> PageLayoutArrangement {
         let defaults = PageModuleCatalog.defaultConfig(
             for: page,
             descriptors: descriptors,
@@ -168,19 +192,26 @@ final class PageLayoutModel: ObservableObject {
             for (moduleID, height) in measuredHeights(for: page) {
                 config.measuredHeights[moduleID] = height
             }
-            return config
+            return PageLayoutArrangement(config)
         case .compact:
-            return compactConfig(for: page, descriptors: descriptors, spacing: spacing)
+            return compactArrangement(for: page, descriptors: descriptors, spacing: spacing)
         case .manual:
-            return resolvedConfig(
-                for: page,
-                available: descriptors.map(\.id),
-                default: defaults
+            return PageLayoutArrangement(
+                resolvedConfig(
+                    for: page,
+                    available: descriptors.map(\.id),
+                    default: defaults
+                )
             )
         }
     }
 
-    /// The shortest two-column arrangement of this page's cards.
+    /// The shortest arrangement of this page's cards, band by band.
+    ///
+    /// Each band is packed on its own and the bands stack in order, so the page
+    /// is as short as it can be *without* reordering the groups the user reads
+    /// it in. A page with one band is the plain shortest-page packing `compact`
+    /// has always produced.
     ///
     /// Memoized, and deliberately sticky. `PageLayoutPacker` is cheap, but the
     /// answer it gives depends on heights that are still settling on the first
@@ -188,14 +219,16 @@ final class PageLayoutModel: ObservableObject {
     /// width and therefore height. So a page is re-packed only once its cards
     /// have moved by more than `compactRepackThreshold` in total, and the new
     /// packing only replaces the visible one if it is shorter by more than
-    /// `compactRepackHysteresis`.
-    func compactConfig(
+    /// `compactRepackHysteresis` — measured across the whole segmented page,
+    /// including the gaps between bands.
+    func compactArrangement(
         for page: PageLayoutPageID,
         descriptors: [PageModuleDescriptor],
         spacing: Double
-    ) -> PageLayoutConfig {
+    ) -> PageLayoutArrangement {
         let ratio = ratio(for: page)
         let moduleIDs = descriptors.map(\.id)
+        let segments = resolvedSegments(for: page, descriptors: descriptors)
         let measured = measuredHeights(for: page)
         // A card the page has never drawn still has to be placed somewhere;
         // its family's stand-in is what the editor draws it at too.
@@ -203,29 +236,37 @@ final class PageLayoutModel: ObservableObject {
         for descriptor in descriptors {
             heights[descriptor.id] = measured[descriptor.id] ?? descriptor.fallbackHeight
         }
-        let items = descriptors.map {
-            PageLayoutPacker.Item(id: $0.id, height: heights[$0.id] ?? 0)
-        }
 
         var packing: CompactPacking
         if var cached = compactPackings[page],
            cached.moduleIDs == moduleIDs,
+           cached.segments == segments,
            cached.ratio == ratio,
            cached.spacing == spacing {
             let drift = moduleIDs.reduce(0.0) { total, moduleID in
                 total + abs((heights[moduleID] ?? 0) - (cached.heights[moduleID] ?? 0))
             }
             if drift <= Self.compactRepackThreshold {
-                return config(columns: cached.columns, ratio: ratio, measured: measured)
+                return arrangement(segmentColumns: cached.segmentColumns, ratio: ratio, measured: measured)
             }
-            let candidate = PageLayoutPacker.pack(items: items, spacing: spacing, ratio: ratio)
-            let onScreen = PageLayoutPacker.pageHeight(
-                columns: cached.columns,
+            let candidate = Self.packedSegmentColumns(
+                segments: segments,
+                heights: heights,
+                spacing: spacing,
+                ratio: ratio
+            )
+            let candidateHeight = PageLayoutPacker.pageHeight(
+                segments: candidate,
                 heights: heights,
                 spacing: spacing
             )
-            if candidate.pageHeight < onScreen - Self.compactRepackHysteresis {
-                cached.columns = candidate.columns
+            let onScreen = PageLayoutPacker.pageHeight(
+                segments: cached.segmentColumns,
+                heights: heights,
+                spacing: spacing
+            )
+            if candidateHeight < onScreen - Self.compactRepackHysteresis {
+                cached.segmentColumns = candidate
             }
             // Either way the baseline moves forward, so a page that keeps its
             // arrangement is not re-evaluated on every single pass.
@@ -234,22 +275,47 @@ final class PageLayoutModel: ObservableObject {
         } else {
             packing = CompactPacking(
                 moduleIDs: moduleIDs,
+                segments: segments,
                 ratio: ratio,
                 spacing: spacing,
                 heights: heights,
-                columns: PageLayoutPacker.pack(items: items, spacing: spacing, ratio: ratio).columns
+                segmentColumns: Self.packedSegmentColumns(
+                    segments: segments,
+                    heights: heights,
+                    spacing: spacing,
+                    ratio: ratio
+                )
             )
         }
         compactPackings[page] = packing
-        return config(columns: packing.columns, ratio: ratio, measured: measured)
+        return arrangement(segmentColumns: packing.segmentColumns, ratio: ratio, measured: measured)
     }
 
-    private func config(
-        columns: [[PageLayoutModuleID]],
+    private static func packedSegmentColumns(
+        segments: [[PageLayoutModuleID]],
+        heights: [PageLayoutModuleID: Double],
+        spacing: Double,
+        ratio: PageColumnRatio
+    ) -> [[[PageLayoutModuleID]]] {
+        PageLayoutPacker.packedSegmentColumns(
+            segments: segments.map { segment in
+                segment.map { PageLayoutPacker.Item(id: $0, height: heights[$0] ?? 0) }
+            },
+            spacing: spacing,
+            ratio: ratio
+        )
+    }
+
+    private func arrangement(
+        segmentColumns: [[[PageLayoutModuleID]]],
         ratio: PageColumnRatio,
         measured: [PageLayoutModuleID: Double]
-    ) -> PageLayoutConfig {
-        PageLayoutConfig(ratio: ratio, columns: columns, measuredHeights: measured)
+    ) -> PageLayoutArrangement {
+        PageLayoutArrangement(
+            segments: segmentColumns.map { columns in
+                PageLayoutConfig(ratio: ratio, columns: columns, measuredHeights: measured)
+            }
+        )
     }
 
     // MARK: - Writing
@@ -276,7 +342,40 @@ final class PageLayoutModel: ObservableObject {
             into: configuredConfig(for: page),
             available: available
         )
-        settingsStore.settings.pageLayouts[page] = StoredPageLayout(merged, mode: mode)
+        settingsStore.settings.pageLayouts[page] = StoredPageLayout(
+            merged,
+            mode: mode,
+            // Columns and bands are separate intents. Dragging a card in Manual
+            // says nothing about how the user banded the page for Compact, so
+            // the bands ride through untouched.
+            segments: storedLayouts[page]?.segments ?? []
+        )
+    }
+
+    /// Persist a banding the user just dragged in the editor.
+    ///
+    /// `compact` is the only mode that packs bands, and the editor only offers
+    /// the controls there, so writing a banding also selects it — that keeps a
+    /// page from ending up with bands nothing reads.
+    func applySegments(
+        _ segments: [[PageLayoutModuleID]],
+        for page: PageLayoutPageID,
+        available: [PageLayoutModuleID]
+    ) {
+        let stored = storedLayouts[page]
+        settingsStore.settings.pageLayouts[page] = StoredPageLayout(
+            mode: .compact,
+            ratio: stored?.ratio ?? PageModuleCatalog.defaultRatio(for: page),
+            // Same reason `apply` keeps the bands: a hand arrangement survives
+            // being re-banded.
+            columns: stored?.columns ?? [],
+            segments: PageLayoutSegments.mergingEdit(
+                segments,
+                into: stored?.segments ?? [],
+                available: available
+            )
+        )
+        compactPackings.removeValue(forKey: page)
     }
 
     /// Switch a page between automatic, compact and hand-arranged.
@@ -289,7 +388,7 @@ final class PageLayoutModel: ObservableObject {
     func setMode(
         _ mode: PageLayoutMode,
         for page: PageLayoutPageID,
-        displayed: PageLayoutConfig,
+        displayed: PageLayoutArrangement,
         available: [PageLayoutModuleID]
     ) {
         guard mode != self.mode(for: page) else { return }
@@ -305,7 +404,10 @@ final class PageLayoutModel: ObservableObject {
             if let restored = storedLayouts[page]?.restoredAsManual() {
                 settingsStore.settings.pageLayouts[page] = restored
             } else {
-                apply(displayed, for: page, available: available, mode: .manual)
+                // A segmented page flattens into the two columns Manual works
+                // in, band by band, so a first hand edit starts from the cards
+                // in the order they were just on screen.
+                apply(displayed.flattened, for: page, available: available, mode: .manual)
             }
         case .auto, .compact:
             let stored = storedLayouts[page]
@@ -314,8 +416,9 @@ final class PageLayoutModel: ObservableObject {
                 ratio: stored?.ratio ?? displayed.ratio,
                 // A hand arrangement survives a trip through the computed
                 // modes: switching away and back is not a reset, and only
-                // `reset(for:)` forgets a page.
-                columns: stored?.columns ?? []
+                // `reset(for:)` forgets a page. The same holds for the bands.
+                columns: stored?.columns ?? [],
+                segments: stored?.segments ?? []
             )
         }
         compactPackings.removeValue(forKey: page)
@@ -339,7 +442,8 @@ final class PageLayoutModel: ObservableObject {
             settingsStore.settings.pageLayouts[page] = StoredPageLayout(
                 mode: .compact,
                 ratio: ratio,
-                columns: stored?.columns ?? []
+                columns: stored?.columns ?? [],
+                segments: stored?.segments ?? []
             )
             compactPackings.removeValue(forKey: page)
             return
@@ -397,13 +501,24 @@ final class PageLayoutModel: ObservableObject {
     /// arrangement it is showing is captured instead.
     func presetSnapshot(
         for page: PageLayoutPageID,
-        displayed: PageLayoutConfig
+        displayed: PageLayoutArrangement
     ) -> StoredPageLayout {
         let mode = mode(for: page)
         if mode == .manual, let stored = storedLayouts[page], !stored.isEmpty {
             return stored
         }
-        return StoredPageLayout(mode: mode, ratio: displayed.ratio, columns: displayed.columns)
+        return StoredPageLayout(
+            mode: mode,
+            ratio: displayed.ratio,
+            columns: displayed.flattened.columns,
+            // On a packed page the bands *are* the arrangement, so the resolved
+            // ones are captured rather than the saved ones: a preset taken
+            // before the user re-banded anything still restores the page they
+            // were looking at instead of an empty "use the default" marker.
+            segments: mode == .compact
+                ? displayed.moduleSegments
+                : (storedLayouts[page]?.segments ?? [])
+        )
     }
 
     /// Save an arrangement under a name, replacing a preset of the same name in
@@ -431,18 +546,26 @@ final class PageLayoutModel: ObservableObject {
         return true
     }
 
-    /// Put a saved arrangement back. Always lands in `manual`: a preset is one
-    /// specific arrangement, and re-entering `compact` would recompute from
-    /// whatever the heights happen to be now instead of restoring it.
+    /// Put a saved arrangement back, in the mode it was captured in.
     ///
-    /// The columns are written verbatim; `PageLayoutResolver` reconciles them
-    /// against the modules the page can actually draw at render time, so a
-    /// preset saved when a provider was signed in still applies afterwards.
+    /// This used to force `manual` on the grounds that a preset is one specific
+    /// arrangement. Bands made that wrong: what is worth keeping about a packed
+    /// page is how it is grouped, not the particular packing those heights
+    /// produced, and restoring a `compact` preset as a frozen manual layout
+    /// threw the grouping away and froze the packing. So a `manual` preset
+    /// restores its exact columns and a `compact` one restores its bands and
+    /// lets the packer work inside them.
+    ///
+    /// Columns and bands are written verbatim; `PageLayoutResolver` and
+    /// `PageLayoutSegments` reconcile them against the modules the page can
+    /// actually draw at render time, so a preset saved when a provider was
+    /// signed in still applies afterwards.
     func applyPreset(_ preset: StoredPageLayoutPreset, to page: PageLayoutPageID) {
         settingsStore.settings.pageLayouts[page] = StoredPageLayout(
-            mode: .manual,
+            mode: preset.layout.mode,
             ratio: preset.layout.ratio,
-            columns: preset.layout.columns
+            columns: preset.layout.columns,
+            segments: preset.layout.segments
         )
         compactPackings.removeValue(forKey: page)
     }

--- a/Sources/VibeBarApp/PageLayoutModel.swift
+++ b/Sources/VibeBarApp/PageLayoutModel.swift
@@ -560,13 +560,12 @@ final class PageLayoutModel: ObservableObject {
     /// `PageLayoutSegments` reconcile them against the modules the page can
     /// actually draw at render time, so a preset saved when a provider was
     /// signed in still applies afterwards.
+    ///
+    /// `layoutToApply` rather than `layout`: a compact preset saved before
+    /// bands existed restores as the manual arrangement it captured, not as a
+    /// re-pack under default bands it never saw.
     func applyPreset(_ preset: StoredPageLayoutPreset, to page: PageLayoutPageID) {
-        settingsStore.settings.pageLayouts[page] = StoredPageLayout(
-            mode: preset.layout.mode,
-            ratio: preset.layout.ratio,
-            columns: preset.layout.columns,
-            segments: preset.layout.segments
-        )
+        settingsStore.settings.pageLayouts[page] = preset.layoutToApply
         compactPackings.removeValue(forKey: page)
     }
 

--- a/Sources/VibeBarApp/StatusItemController.swift
+++ b/Sources/VibeBarApp/StatusItemController.swift
@@ -132,10 +132,20 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
 
         // Coalesce all render triggers into one throttled pipeline so a burst
         // of quota, settings, account, and status updates only redraws once.
+        //
+        // Observations, cycle history, and cost snapshots are in the set
+        // because forecast coloring depends on them, and they land *after*
+        // `$lastSuccessByAccount` — a refresh publishes the new quota first and
+        // records the observation in a follow-up task. Without them the color
+        // would always describe the previous refresh. The extra churn is
+        // bounded: observations publish once per account per refresh.
         let renderTriggers: [AnyPublisher<Void, Never>] = [
             environment.settingsStore.$settings.map { _ in () }.eraseToAnyPublisher(),
             environment.quotaService.$lastSuccessByAccount.map { _ in () }.eraseToAnyPublisher(),
             environment.quotaService.$lastErrorByAccount.map { _ in () }.eraseToAnyPublisher(),
+            environment.quotaService.$observationsByAccountBucket.map { _ in () }.eraseToAnyPublisher(),
+            environment.quotaService.$historyByAccountBucket.map { _ in () }.eraseToAnyPublisher(),
+            environment.costService.$snapshots.map { _ in () }.eraseToAnyPublisher(),
             environment.accountStore.$accounts.map { _ in () }.eraseToAnyPublisher(),
             environment.serviceStatus.$snapshotByTool.map { _ in () }.eraseToAnyPublisher()
         ]
@@ -511,7 +521,7 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
             attributed.append(menuPiece(
                 label: label,
                 percent: percent,
-                color: barColor(for: percent, mode: settings.displayMode),
+                color: percentColor(for: field, bucket: bucket, settings: settings),
                 fontSize: fontSize
             ))
             displayed += 1
@@ -551,7 +561,7 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
             return menuTextPiece(
                 label: label(for: field, bucket: bucket, itemSettings: itemSettings),
                 percent: percent,
-                color: barColor(for: percent, mode: settings.displayMode),
+                color: percentColor(for: field, bucket: bucket, settings: settings),
                 fontSize: fontSize
             )
         }
@@ -622,7 +632,7 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
             return menuTextPiece(
                 label: label(for: field, bucket: bucket, itemSettings: itemSettings),
                 percent: percent,
-                color: barColor(for: percent, mode: settings.displayMode),
+                color: percentColor(for: field, bucket: bucket, settings: settings),
                 fontSize: MenuBarStatusMetrics.twoRowFontSize
             )
         }
@@ -807,16 +817,53 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
         compactStatusItem
     }
 
-    private func barColor(for percent: Double, mode: DisplayMode) -> NSColor {
-        switch mode {
-        case .remaining:
-            if percent < 10 { return NSColor.systemRed }
-            if percent < 30 { return NSColor.systemOrange }
-            return NSColor.systemGreen
-        case .used:
-            if percent >= 90 { return NSColor.systemRed }
-            if percent >= 70 { return NSColor.systemOrange }
-            return NSColor.systemGreen
+    /// Color for one rendered menu-bar percentage. The thresholds and the
+    /// verdict mapping live in `MenuBarPercentColor`; this only resolves the
+    /// forecast input and translates the result to AppKit.
+    private func percentColor(
+        for field: MenuBarFieldOption,
+        bucket: QuotaBucket,
+        settings: AppSettings
+    ) -> NSColor {
+        let basis = settings.menuBarColorBasis
+        let verdict = basis == .forecast ? forecastVerdict(for: field.tool, bucket: bucket) : nil
+        return Self.nsColor(
+            for: MenuBarPercentColor.resolve(
+                basis: basis,
+                verdict: verdict,
+                percent: bucket.displayPercent(settings.displayMode),
+                displayMode: settings.displayMode
+            )
+        )
+    }
+
+    /// Forecast verdict for one menu-bar bucket, computed at render time.
+    ///
+    /// Affordable here because every input is already in memory — cached quota
+    /// observations, cached cycle history, and a rebased cost snapshot — and
+    /// only the handful of buckets the user put in the menu bar are asked for.
+    private func forecastVerdict(for tool: ToolType, bucket: QuotaBucket) -> QuotaPaceForecast.Verdict? {
+        guard let accountId = environment.account(for: tool)?.id else { return nil }
+        let snapshot = environment.costService.snapshot(for: tool)
+        return environment.quotaService.paceForecast(
+            accountId: accountId,
+            bucket: bucket,
+            activityHeatmap: snapshot?.heatmap,
+            dailyActivity: snapshot?.dailyHistory ?? [],
+            now: Date()
+        )?.verdict
+    }
+
+    /// AppKit twin of `QuotaForecastPalette`. System colors rather than the
+    /// popover's literal RGB values: the menu bar has to stay legible against
+    /// light, dark, and tinted wallpapers, and these are the exact colors the
+    /// pre-forecast menu bar used.
+    private static func nsColor(for color: MenuBarPercentColor) -> NSColor {
+        switch color {
+        case .healthy: return NSColor.systemGreen
+        case .surplus: return NSColor.systemBlue
+        case .watch: return NSColor.systemOrange
+        case .risk: return NSColor.systemRed
         }
     }
 }

--- a/Sources/VibeBarApp/StatusItemController.swift
+++ b/Sources/VibeBarApp/StatusItemController.swift
@@ -257,6 +257,12 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
             )
             return
         }
+        // A trailing task may still be queued from the previous burst — on a
+        // busy main actor it can wake after its deadline, land here *after*
+        // this newer report, and resize the popover back to the stale height
+        // it captured. Supersede both the task and its pending height.
+        popoverResizeTasks.removeValue(forKey: kind)?.cancel()
+        pendingPopoverHeights.removeValue(forKey: kind)
         applyPopoverResize(kind: kind, toContentHeight: height)
     }
 
@@ -264,7 +270,10 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
         guard popoverResizeTasks[kind] == nil else { return }
         popoverResizeTasks[kind] = Task { @MainActor [weak self] in
             try? await Task.sleep(for: .milliseconds(Int(max(10, delay * 1_000))))
-            guard let self else { return }
+            // Checked before touching shared state: an immediate resize may
+            // have superseded this task and re-registered a fresh one, whose
+            // bookkeeping a cancelled sleeper must not clobber.
+            guard let self, !Task.isCancelled else { return }
             self.popoverResizeTasks[kind] = nil
             guard let height = self.pendingPopoverHeights.removeValue(forKey: kind) else { return }
             self.applyPopoverResize(kind: kind, toContentHeight: height)

--- a/Sources/VibeBarApp/StatusItemController.swift
+++ b/Sources/VibeBarApp/StatusItemController.swift
@@ -39,6 +39,10 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
     /// Records the time each kind's popover most recently started closing.
     /// Used by `togglePopover` to ignore the click that triggered the close.
     private var popoverCloseStamps: [MenuBarItemKind: Date] = [:]
+    /// Coalescing state for `resizePopover`.
+    private var lastPopoverResizeAt: [MenuBarItemKind: Date] = [:]
+    private var pendingPopoverHeights: [MenuBarItemKind: CGFloat] = [:]
+    private var popoverResizeTasks: [MenuBarItemKind: Task<Void, Never>] = [:]
 
     init(environment: AppEnvironment) {
         self.environment = environment
@@ -171,6 +175,10 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
             enabled: settings.refreshOnPopoverOpen,
             cooldownSeconds: settings.popoverOpenRefreshCooldownSeconds
         )
+        // Set before `show`: the refresh above publishes into the popover's own
+        // render pass, and anything that would rather not compete with it (the
+        // hidden Claude budget WebView) checks this flag.
+        environment.setPopoverVisible(true)
         popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
         popover.contentViewController?.view.window?.makeKey()
     }
@@ -183,6 +191,9 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
                 self.popoverCloseStamps[kind] = Date()
                 break
             }
+            self.environment.setPopoverVisible(
+                self.popovers.values.contains { $0.isShown && $0 !== popover }
+            )
         }
     }
 
@@ -217,7 +228,41 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
         }
     }
 
+    /// Height reports arrive per layout pass, and a refresh relayouts the
+    /// popover many times in a row — every one of which used to write
+    /// `contentSize`, which itself forces another layout pass and another
+    /// report. Apply the first report of a burst immediately (so opening the
+    /// popover still sizes without a visible delay) and coalesce the rest into
+    /// one trailing resize, which lands on the final height.
+    private static let popoverResizeCoalesceWindow: TimeInterval = 0.1
+
     private func resizePopover(kind: MenuBarItemKind, toContentHeight height: CGFloat) {
+        guard height.isFinite, height > 0 else { return }
+        let sinceLast = lastPopoverResizeAt[kind].map { Date().timeIntervalSince($0) }
+        if let sinceLast, sinceLast < Self.popoverResizeCoalesceWindow {
+            pendingPopoverHeights[kind] = height
+            scheduleCoalescedResize(
+                kind: kind,
+                after: Self.popoverResizeCoalesceWindow - sinceLast
+            )
+            return
+        }
+        applyPopoverResize(kind: kind, toContentHeight: height)
+    }
+
+    private func scheduleCoalescedResize(kind: MenuBarItemKind, after delay: TimeInterval) {
+        guard popoverResizeTasks[kind] == nil else { return }
+        popoverResizeTasks[kind] = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: .milliseconds(Int(max(10, delay * 1_000))))
+            guard let self else { return }
+            self.popoverResizeTasks[kind] = nil
+            guard let height = self.pendingPopoverHeights.removeValue(forKey: kind) else { return }
+            self.applyPopoverResize(kind: kind, toContentHeight: height)
+        }
+    }
+
+    private func applyPopoverResize(kind: MenuBarItemKind, toContentHeight height: CGFloat) {
+        lastPopoverResizeAt[kind] = Date()
         guard let popover = popovers[kind] else { return }
         guard height.isFinite, height > 0 else { return }
         let maxHeight = maxPopoverHeight(for: popover)

--- a/Sources/VibeBarApp/Views/ColumnMasonryLayout.swift
+++ b/Sources/VibeBarApp/Views/ColumnMasonryLayout.swift
@@ -2,12 +2,14 @@ import SwiftUI
 import VibeBarCore
 
 enum OverviewMasonryPhase: Int {
+    case summary
     case quota
     case cost
     case auxiliary
 
     var corePhase: OverviewMasonryPlanner.Phase {
         switch self {
+        case .summary: .summary
         case .quota: .quota
         case .cost: .cost
         case .auxiliary: .auxiliary

--- a/Sources/VibeBarApp/Views/LayoutEditorView.swift
+++ b/Sources/VibeBarApp/Views/LayoutEditorView.swift
@@ -14,9 +14,17 @@ import VibeBarCore
 ///
 /// The three modes are not three editors. `PageLayoutModel.arrangement` hands
 /// back whatever the selected mode currently produces, and this screen draws
-/// that; only in `manual` are the blocks draggable. So what the editor shows is
-/// what the popover shows, including a `compact` packing that will move again
-/// the next time the cards are measured.
+/// that. So what the editor shows is what the popover shows, including a
+/// `compact` packing that will move again the next time the cards are measured.
+///
+/// What is editable follows from what each mode leaves to the user:
+///
+/// - `manual` — two column zones, and a drag decides both column and position.
+/// - `compact` — one zone per segment. Position inside a segment belongs to the
+///   packer, so a drag only decides *which* segment a card is in; the header
+///   controls reorder, merge and add segments.
+/// - `auto` — read-only. The page arranges itself, and a drag would be
+///   discarded on the next measurement.
 struct LayoutEditorView: View {
     @EnvironmentObject private var environment: AppEnvironment
     @EnvironmentObject private var settingsStore: SettingsStore
@@ -37,6 +45,14 @@ struct LayoutEditorView: View {
     /// other page's position.
     @State private var blockFrames: [String: CGRect] = [:]
     @State private var zoneFrames: [Int: CGRect] = [:]
+    @State private var segmentFrames: [Int: CGRect] = [:]
+    /// Segments the user has added but not dragged anything into yet.
+    ///
+    /// An empty segment is never stored — `PageLayoutSegments.normalized` drops
+    /// it, which is what keeps a saved layout from accumulating bands nothing
+    /// renders. So "add a segment, then drag a card into it" only works if the
+    /// empty one lives in view state until it has a card, which is what this is.
+    @State private var pendingSegments = 0
     @State private var isNamingPreset = false
     @State private var presetName = ""
 
@@ -87,7 +103,8 @@ struct LayoutEditorView: View {
             settings: settingsStore.settings
         )
         let mode = layoutModel.mode(for: page)
-        let config = displayedConfig(for: page, descriptors: descriptors)
+        let arrangement = displayedArrangement(for: page, descriptors: descriptors)
+        let config = arrangement.flattened
         let blocks = Dictionary(
             descriptors.map { descriptor in
                 (descriptor.id, Block(descriptor: descriptor, measured: config.measuredHeight(for: descriptor.id)))
@@ -97,7 +114,7 @@ struct LayoutEditorView: View {
 
         VStack(alignment: .leading, spacing: 12) {
             pagePicker(pages: pages, selected: page)
-            modeRow(page: page, mode: mode, config: config)
+            modeRow(page: page, mode: mode, arrangement: arrangement)
             controlRow(page: page, config: config)
             if descriptors.isEmpty {
                 Text("This page has no arrangeable cards yet. Open it in the popover once so Vibe Bar can measure them.")
@@ -106,8 +123,8 @@ struct LayoutEditorView: View {
                     .frame(maxWidth: .infinity, alignment: .leading)
             } else {
                 HStack(alignment: .top, spacing: 14) {
-                    zones(page: page, config: config, blocks: blocks, mode: mode)
-                    preview(config: config, blocks: blocks)
+                    zones(page: page, arrangement: arrangement, blocks: blocks, mode: mode)
+                    preview(arrangement: arrangement, blocks: blocks)
                 }
             }
             Text(footnote(page: page, mode: mode))
@@ -131,6 +148,12 @@ struct LayoutEditorView: View {
             // The name sheet belongs to the page it was opened from; carrying
             // it across would save the new page's arrangement under it.
             isNamingPreset = false
+            // Same for a half-finished segment: it is this page's edit.
+            pendingSegments = 0
+        }
+        .onChange(of: mode) { _, _ in
+            drag = nil
+            pendingSegments = 0
         }
     }
 
@@ -188,12 +211,12 @@ struct LayoutEditorView: View {
     private func modeRow(
         page: PageLayoutPageID,
         mode: PageLayoutMode,
-        config: PageLayoutConfig
+        arrangement: PageLayoutArrangement
     ) -> some View {
         HStack(spacing: 10) {
             HStack(spacing: 4) {
                 ForEach(PageLayoutMode.allCases, id: \.self) { candidate in
-                    modeButton(candidate, page: page, selected: mode, config: config)
+                    modeButton(candidate, page: page, selected: mode, arrangement: arrangement)
                 }
             }
             .padding(3)
@@ -202,7 +225,7 @@ struct LayoutEditorView: View {
                     .fill(Color.primary.opacity(0.045))
             )
             Spacer(minLength: 8)
-            presetsMenu(page: page, config: config)
+            presetsMenu(page: page, arrangement: arrangement)
             Button {
                 layoutModel.reset(for: page)
             } label: {
@@ -217,14 +240,14 @@ struct LayoutEditorView: View {
         _ mode: PageLayoutMode,
         page: PageLayoutPageID,
         selected: PageLayoutMode,
-        config: PageLayoutConfig
+        arrangement: PageLayoutArrangement
     ) -> some View {
         let isSelected = mode == selected
         return Button {
             layoutModel.setMode(
                 mode,
                 for: page,
-                displayed: config,
+                displayed: arrangement,
                 available: availableModuleIDs(for: page)
             )
         } label: {
@@ -277,13 +300,13 @@ struct LayoutEditorView: View {
                 ? "Auto — the Overview balances its columns as the cards are measured."
                 : "Auto — this page's built-in arrangement."
         case .compact:
-            return "Compact — pack the cards into the shortest page they fit in."
+            return "Compact — pack each segment into the shortest band its cards fit in."
         case .manual:
             return "Manual — your arrangement, exactly as you dragged it."
         }
     }
 
-    private func presetsMenu(page: PageLayoutPageID, config: PageLayoutConfig) -> some View {
+    private func presetsMenu(page: PageLayoutPageID, arrangement: PageLayoutArrangement) -> some View {
         let presets = layoutModel.presets(for: page)
         return Menu {
             // Reachable even on a full page: replacing a preset by name costs
@@ -319,11 +342,11 @@ struct LayoutEditorView: View {
                 : "This page is holding all \(AppSettings.maximumPresetsPerPage) saved arrangements — save over one by reusing its name."
         )
         .popover(isPresented: $isNamingPreset, arrowEdge: .bottom) {
-            presetNameForm(page: page, config: config)
+            presetNameForm(page: page, arrangement: arrangement)
         }
     }
 
-    private func presetNameForm(page: PageLayoutPageID, config: PageLayoutConfig) -> some View {
+    private func presetNameForm(page: PageLayoutPageID, arrangement: PageLayoutArrangement) -> some View {
         let trimmed = StoredPageLayoutPreset.normalizedName(presetName)
         let replaces = layoutModel.presetWouldReplace(named: trimmed, for: page)
         // Only a genuinely new name is blocked by the cap; reusing an existing
@@ -332,7 +355,7 @@ struct LayoutEditorView: View {
         return VStack(alignment: .leading, spacing: 9) {
             Text("Save arrangement")
                 .font(.system(size: 12, weight: .semibold))
-            Text("Saving “\(modeLabel(layoutModel.mode(for: page)))” as it stands now. Applying it later arranges the page by hand.")
+            Text("Saving “\(modeLabel(layoutModel.mode(for: page)))” as it stands now. Applying it later puts the page back into that mode — a Manual preset restores its exact columns, a Compact one its segments.")
                 .font(.caption2)
                 .foregroundStyle(.secondary)
                 .fixedSize(horizontal: false, vertical: true)
@@ -340,7 +363,7 @@ struct LayoutEditorView: View {
             TextField("Name", text: $presetName)
                 .textFieldStyle(.roundedBorder)
                 .frame(width: 230)
-                .onSubmit { savePreset(page: page, config: config) }
+                .onSubmit { savePreset(page: page, arrangement: arrangement) }
             if blockedByLimit {
                 Label(
                     "Preset limit reached — use an existing name to replace.",
@@ -360,7 +383,7 @@ struct LayoutEditorView: View {
             HStack {
                 Spacer(minLength: 0)
                 Button("Cancel") { isNamingPreset = false }
-                Button(replaces ? "Replace" : "Save") { savePreset(page: page, config: config) }
+                Button(replaces ? "Replace" : "Save") { savePreset(page: page, arrangement: arrangement) }
                     .keyboardShortcut(.defaultAction)
                     .disabled(!layoutModel.canSavePreset(named: presetName, for: page))
             }
@@ -368,8 +391,8 @@ struct LayoutEditorView: View {
         .padding(13)
     }
 
-    private func savePreset(page: PageLayoutPageID, config: PageLayoutConfig) {
-        let snapshot = layoutModel.presetSnapshot(for: page, displayed: config)
+    private func savePreset(page: PageLayoutPageID, arrangement: PageLayoutArrangement) {
+        let snapshot = layoutModel.presetSnapshot(for: page, displayed: arrangement)
         guard layoutModel.savePreset(named: presetName, for: page, layout: snapshot) else { return }
         presetName = ""
         isNamingPreset = false
@@ -456,9 +479,28 @@ struct LayoutEditorView: View {
         }
     }
 
+    // MARK: - Zones
+
+    /// The editable picture of the page. Two column zones in `manual` and
+    /// `auto`, one zone per segment in `compact` — which is the only mode where
+    /// segments exist, because it is the only mode that packs.
+    @ViewBuilder
+    private func zones(
+        page: PageLayoutPageID,
+        arrangement: PageLayoutArrangement,
+        blocks: [PageLayoutModuleID: Block],
+        mode: PageLayoutMode
+    ) -> some View {
+        if mode == .compact {
+            segmentZones(page: page, arrangement: arrangement, blocks: blocks)
+        } else {
+            columnZones(page: page, config: arrangement.flattened, blocks: blocks, mode: mode)
+        }
+    }
+
     // MARK: - Column zones
 
-    private func zones(
+    private func columnZones(
         page: PageLayoutPageID,
         config: PageLayoutConfig,
         blocks: [PageLayoutModuleID: Block],
@@ -468,9 +510,9 @@ struct LayoutEditorView: View {
             config.column(index).reduce(0.0) { $0 + (blocks[$1]?.height ?? 0) }
         }
         let scale = min(0.4, Self.editorColumnHeight / max(1, totals.max() ?? 1))
-        // Only `manual` is an editor. The other two modes show what they
-        // currently produce as a read-only picture, so a drag cannot silently
-        // discard an arrangement the app is about to recompute.
+        // `auto` shows what the page currently produces as a read-only picture,
+        // so a drag cannot silently discard an arrangement the app is about to
+        // recompute.
         let isEditable = mode == .manual
         let target = isEditable ? dropTarget(page: page, config: config) : nil
         return VStack(alignment: .leading, spacing: 7) {
@@ -490,7 +532,7 @@ struct LayoutEditorView: View {
                 }
             }
             if !isEditable {
-                Label("Switch to Manual to arrange by hand", systemImage: "hand.point.up.left")
+                Label("Switch to Compact or Manual to arrange this page", systemImage: "hand.point.up.left")
                     .font(.system(size: 10))
                     .foregroundStyle(.tertiary)
             }
@@ -521,12 +563,14 @@ struct LayoutEditorView: View {
             VStack(spacing: Self.blockSpacing) {
                 ForEach(moduleIDs, id: \.self) { moduleID in
                     if let block = blocks[moduleID] {
-                        blockView(block, page: page, config: config, scale: scale, isEditable: isEditable)
-                            // The card stays where it is, dimmed, while its
-                            // ghost floats: pulling it out of the stack would
-                            // shift every block below it, moving the very
-                            // frames the drop target is computed from.
-                            .opacity(drag?.engaged == true && drag?.moduleID == moduleID ? 0.25 : 1)
+                        blockView(block, page: page, scale: scale, isEditable: isEditable) {
+                            applyColumnDrop(block, page: page, config: config)
+                        }
+                        // The card stays where it is, dimmed, while its ghost
+                        // floats: pulling it out of the stack would shift every
+                        // block below it, moving the very frames the drop
+                        // target is computed from.
+                        .opacity(drag?.engaged == true && drag?.moduleID == moduleID ? 0.25 : 1)
                     }
                 }
                 if moduleIDs.isEmpty {
@@ -588,13 +632,187 @@ struct LayoutEditorView: View {
         return frame.minY - zone.minY - Self.blockSpacing / 2
     }
 
+    // MARK: - Segment zones
+
+    /// One bordered group per segment, each holding that segment's own packed
+    /// two columns.
+    ///
+    /// Order *inside* a segment is the packer's answer, not intent, so there is
+    /// no insertion line here and dropping a card back into its own segment does
+    /// nothing. What a drag decides is membership.
+    private func segmentZones(
+        page: PageLayoutPageID,
+        arrangement: PageLayoutArrangement,
+        blocks: [PageLayoutModuleID: Block]
+    ) -> some View {
+        let bands = displayedBands(arrangement)
+        let membership = bands.map { $0.flatMap { $0 } }
+        let heights = bands.map { segmentHeight($0, blocks: blocks) }
+        // Scaled against the whole page, not one segment, so a tall segment
+        // still reads as the tall one.
+        let scale = min(0.4, Self.editorColumnHeight / max(1, heights.reduce(0, +)))
+        let target = segmentDropTarget(count: bands.count)
+        return VStack(alignment: .leading, spacing: 7) {
+            ForEach(Array(bands.enumerated()), id: \.offset) { index, columns in
+                segmentZone(
+                    index,
+                    page: page,
+                    columns: columns,
+                    membership: membership,
+                    blocks: blocks,
+                    height: heights[index],
+                    scale: scale,
+                    isTarget: target == index
+                )
+            }
+            HStack(spacing: 8) {
+                Button {
+                    pendingSegments += 1
+                } label: {
+                    Label("Add Segment", systemImage: "plus.rectangle.on.rectangle")
+                        .font(.system(size: 11))
+                }
+                .disabled(bands.count >= PageLayoutSegments.maximumCount)
+                .help(
+                    bands.count >= PageLayoutSegments.maximumCount
+                        ? "A page holds at most \(PageLayoutSegments.maximumCount) segments."
+                        : "Add an empty segment, then drag a card into it."
+                )
+                Spacer(minLength: 0)
+            }
+        }
+    }
+
+    /// The segments on screen: the ones the arrangement produced, plus any the
+    /// user added and has not filled yet.
+    private func displayedBands(_ arrangement: PageLayoutArrangement) -> [[[PageLayoutModuleID]]] {
+        let empty = [[PageLayoutModuleID]](repeating: [], count: PageLayoutConfig.columnCount)
+        return arrangement.segments.map(\.columns)
+            + [[[PageLayoutModuleID]]](repeating: empty, count: pendingSegments)
+    }
+
+    /// What one segment contributes to the page: its taller column, the same
+    /// rule `PageLayoutPacker.pageHeight` measures a packed page by.
+    private func segmentHeight(
+        _ columns: [[PageLayoutModuleID]],
+        blocks: [PageLayoutModuleID: Block]
+    ) -> Double {
+        columns
+            .map { column in column.reduce(0.0) { $0 + (blocks[$1]?.height ?? 0) } }
+            .max() ?? 0
+    }
+
+    private func segmentZone(
+        _ index: Int,
+        page: PageLayoutPageID,
+        columns: [[PageLayoutModuleID]],
+        membership: [[PageLayoutModuleID]],
+        blocks: [PageLayoutModuleID: Block],
+        height: Double,
+        scale: Double,
+        isTarget: Bool
+    ) -> some View {
+        let cards = columns.flatMap { $0 }
+        // An empty segment is always one the user just added, so it is only ever
+        // trailing: moving a card past it, or a segment below it, is meaningless.
+        let nextIsEmpty = membership.indices.contains(index + 1) && membership[index + 1].isEmpty
+        return VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: 6) {
+                Text("Segment \(index + 1)")
+                    .font(.system(size: 11, weight: .semibold))
+                Text("· \(cards.count) card\(cards.count == 1 ? "" : "s") · \(Int(height.rounded()))pt")
+                    .font(.system(size: 10, design: .rounded).monospacedDigit())
+                    .foregroundStyle(.secondary)
+                Spacer(minLength: 4)
+                segmentButton("chevron.up", help: "Move this segment up") {
+                    moveSegment(index, by: -1, page: page, membership: membership)
+                }
+                .disabled(index == 0 || cards.isEmpty)
+                segmentButton("chevron.down", help: "Move this segment down") {
+                    moveSegment(index, by: 1, page: page, membership: membership)
+                }
+                .disabled(index >= membership.count - 1 || cards.isEmpty || nextIsEmpty)
+                if cards.isEmpty {
+                    segmentButton("xmark", help: "Remove this empty segment") {
+                        pendingSegments = max(0, pendingSegments - 1)
+                    }
+                } else {
+                    segmentButton(
+                        "arrow.triangle.merge",
+                        help: "Merge these cards into the segment above"
+                    ) {
+                        mergeSegmentUp(index, page: page, membership: membership)
+                    }
+                    .disabled(index == 0)
+                }
+            }
+            HStack(alignment: .top, spacing: 10) {
+                ForEach(0..<PageLayoutConfig.columnCount, id: \.self) { column in
+                    VStack(spacing: Self.blockSpacing) {
+                        ForEach(columns.indices.contains(column) ? columns[column] : [], id: \.self) { moduleID in
+                            if let block = blocks[moduleID] {
+                                blockView(block, page: page, scale: scale, isEditable: true) {
+                                    applySegmentDrop(block, page: page, membership: membership)
+                                }
+                                .opacity(drag?.engaged == true && drag?.moduleID == moduleID ? 0.25 : 1)
+                            }
+                        }
+                    }
+                    .frame(maxWidth: .infinity, alignment: .top)
+                }
+            }
+            if cards.isEmpty {
+                Text("Empty — drag a card here")
+                    .font(.system(size: 10))
+                    .foregroundStyle(.tertiary)
+                    .frame(maxWidth: .infinity, minHeight: 38)
+            }
+        }
+        .padding(8)
+        .frame(maxWidth: .infinity, alignment: .topLeading)
+        .background(
+            RoundedRectangle(cornerRadius: 9, style: .continuous)
+                .fill(Color.primary.opacity(0.035))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 9, style: .continuous)
+                .stroke(
+                    isTarget ? Color.accentColor.opacity(0.45) : Color.primary.opacity(0.07),
+                    lineWidth: 0.8
+                )
+        )
+        .onGeometryChange(for: CGRect.self) { proxy in
+            proxy.frame(in: .named(Self.space))
+        } action: { frame in
+            segmentFrames[index] = frame
+        }
+    }
+
+    private func segmentButton(
+        _ systemImage: String,
+        help: String,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            Image(systemName: systemImage)
+                .font(.system(size: 9, weight: .semibold))
+                .frame(width: 16, height: 16)
+        }
+        .buttonStyle(.plain)
+        .focusable(false)
+        .foregroundStyle(.secondary)
+        .help(help)
+    }
+
+    // MARK: - Blocks
+
     @ViewBuilder
     private func blockView(
         _ block: Block,
         page: PageLayoutPageID,
-        config: PageLayoutConfig,
         scale: Double,
-        isEditable: Bool
+        isEditable: Bool,
+        onRelease: @escaping () -> Void
     ) -> some View {
         let height = max(Self.minimumBlockHeight, CGFloat(block.height * scale))
         let body = blockBody(block, height: height, isEditable: isEditable)
@@ -605,7 +823,7 @@ struct LayoutEditorView: View {
             }
             .help("\(block.descriptor.displayName) · \(block.heightLabel)")
         if isEditable {
-            body.gesture(dragGesture(block: block, page: page, config: config, height: height))
+            body.gesture(dragGesture(block: block, page: page, height: height, onRelease: onRelease))
         } else {
             body
         }
@@ -657,8 +875,8 @@ struct LayoutEditorView: View {
     private func dragGesture(
         block: Block,
         page: PageLayoutPageID,
-        config: PageLayoutConfig,
-        height: CGFloat
+        height: CGFloat,
+        onRelease: @escaping () -> Void
     ) -> some Gesture {
         // `minimumDistance: 0` so the press is captured immediately — the
         // gesture then owns the pointer until release, the way a pointer
@@ -684,13 +902,95 @@ struct LayoutEditorView: View {
                 drag = state
             }
             .onEnded { _ in
+                // The drop reads `drag`, so it runs before the `defer` clears
+                // it.
                 defer { drag = nil }
                 guard let state = drag, state.moduleID == block.id, state.engaged else { return }
-                guard let target = dropTarget(page: page, config: config) else { return }
-                let moved = config.moving(block.id, toColumn: target.column, at: target.index)
-                guard moved.columns != config.columns || !layoutModel.isCustomized(page) else { return }
-                layoutModel.apply(moved, for: page, available: availableModuleIDs(for: page))
+                onRelease()
             }
+    }
+
+    /// Manual: the card takes the column and position it was dropped at.
+    private func applyColumnDrop(
+        _ block: Block,
+        page: PageLayoutPageID,
+        config: PageLayoutConfig
+    ) {
+        guard let target = dropTarget(page: page, config: config) else { return }
+        let moved = config.moving(block.id, toColumn: target.column, at: target.index)
+        guard moved.columns != config.columns || !layoutModel.isCustomized(page) else { return }
+        layoutModel.apply(moved, for: page, available: availableModuleIDs(for: page))
+    }
+
+    /// Compact: the card joins the segment it was dropped on. Where it lands
+    /// inside that segment is the packer's call, so a drop inside its own
+    /// segment is deliberately a no-op rather than a re-order.
+    private func applySegmentDrop(
+        _ block: Block,
+        page: PageLayoutPageID,
+        membership: [[PageLayoutModuleID]]
+    ) {
+        guard let target = segmentDropTarget(count: membership.count),
+              membership.indices.contains(target)
+        else { return }
+        guard !membership[target].contains(block.id) else { return }
+        var next = membership
+        for index in next.indices {
+            next[index].removeAll { $0 == block.id }
+        }
+        next[target].append(block.id)
+        layoutModel.applySegments(next, for: page, available: availableModuleIDs(for: page))
+        // Whatever is still empty cannot be stored, so it goes back to being a
+        // pending segment instead of vanishing under the user's pointer.
+        pendingSegments = next.filter(\.isEmpty).count
+    }
+
+    private func moveSegment(
+        _ index: Int,
+        by offset: Int,
+        page: PageLayoutPageID,
+        membership: [[PageLayoutModuleID]]
+    ) {
+        var next = membership
+        let target = index + offset
+        guard next.indices.contains(index), next.indices.contains(target) else { return }
+        next.swapAt(index, target)
+        layoutModel.applySegments(next, for: page, available: availableModuleIDs(for: page))
+        pendingSegments = next.filter(\.isEmpty).count
+    }
+
+    private func mergeSegmentUp(
+        _ index: Int,
+        page: PageLayoutPageID,
+        membership: [[PageLayoutModuleID]]
+    ) {
+        guard index > 0, membership.indices.contains(index) else { return }
+        var next = membership
+        next[index - 1].append(contentsOf: next.remove(at: index))
+        layoutModel.applySegments(next, for: page, available: availableModuleIDs(for: page))
+        pendingSegments = next.filter(\.isEmpty).count
+    }
+
+    /// Which segment the pointer is over. Segments stack vertically, so this is
+    /// a `y` hit test — the mirror of `nearestColumn`'s `x` one.
+    ///
+    /// - Parameter count: segments on screen right now. `segmentFrames` can
+    ///   still hold the frame of one that has just been removed, and the nearest
+    ///   match must not be an index that no longer exists.
+    private func segmentDropTarget(count: Int) -> Int? {
+        guard let drag, drag.engaged else { return nil }
+        let point = drag.location
+        var best: Int?
+        var bestDistance = Double.greatestFiniteMagnitude
+        for (index, frame) in segmentFrames where index < count {
+            if frame.minY <= point.y, point.y <= frame.maxY { return index }
+            let distance = Double(min(abs(point.y - frame.minY), abs(point.y - frame.maxY)))
+            if distance < bestDistance {
+                bestDistance = distance
+                best = index
+            }
+        }
+        return best
     }
 
     /// Where the dragged block would land if the pointer were released now.
@@ -756,16 +1056,17 @@ struct LayoutEditorView: View {
     // MARK: - Preview
 
     private func preview(
-        config: PageLayoutConfig,
+        arrangement: PageLayoutArrangement,
         blocks: [PageLayoutModuleID: Block]
     ) -> some View {
-        let totals = (0..<PageLayoutConfig.columnCount).map { index in
-            config.column(index).reduce(0.0) { $0 + (blocks[$1]?.height ?? 0) }
-        }
-        let scale = min(0.12, Self.previewColumnHeight / max(1, totals.max() ?? 1))
+        // The same segments the popover will stack, through the same
+        // arrangement call, so the preview cannot disagree with the page.
+        let bands = arrangement.segments.map(\.columns)
+        let pageHeight = bands.reduce(0.0) { $0 + segmentHeight($1, blocks: blocks) }
+        let scale = min(0.12, Self.previewColumnHeight / max(1, pageHeight))
         let width: CGFloat = 150
         let gap: CGFloat = 4
-        let leftWidth = (width - gap) * ratioFraction(config.ratio)
+        let leftWidth = (width - gap) * ratioFraction(arrangement.ratio)
         return VStack(alignment: .leading, spacing: 6) {
             Text("Preview")
                 .font(.system(size: 11, weight: .semibold))
@@ -776,11 +1077,21 @@ struct LayoutEditorView: View {
                 RoundedRectangle(cornerRadius: 2, style: .continuous)
                     .fill(Color.primary.opacity(0.14))
                     .frame(height: 7)
-                HStack(alignment: .top, spacing: gap) {
-                    previewColumn(config.column(0), blocks: blocks, scale: scale)
+                ForEach(Array(bands.enumerated()), id: \.offset) { _, columns in
+                    HStack(alignment: .top, spacing: gap) {
+                        previewColumn(
+                            columns.indices.contains(0) ? columns[0] : [],
+                            blocks: blocks,
+                            scale: scale
+                        )
                         .frame(width: leftWidth)
-                    previewColumn(config.column(1), blocks: blocks, scale: scale)
+                        previewColumn(
+                            columns.indices.contains(1) ? columns[1] : [],
+                            blocks: blocks,
+                            scale: scale
+                        )
                         .frame(width: max(0, width - gap - leftWidth))
+                    }
                 }
             }
             .padding(7)
@@ -833,10 +1144,10 @@ struct LayoutEditorView: View {
 
     /// Exactly what the popover would draw for this page right now — the same
     /// call the popover itself makes, so the two cannot disagree.
-    private func displayedConfig(
+    private func displayedArrangement(
         for page: PageLayoutPageID,
         descriptors: [PageModuleDescriptor]
-    ) -> PageLayoutConfig {
+    ) -> PageLayoutArrangement {
         layoutModel.arrangement(
             for: page,
             descriptors: descriptors,
@@ -853,7 +1164,7 @@ struct LayoutEditorView: View {
         case .manual:
             return "Drag a card to reorder it or move it between columns. Cards are drawn at their measured height, so the taller column here is the taller column in the popover. A card with no measurement yet shows “—pt”."
         case .compact:
-            return "Compact packs the cards into whichever two columns make the page shortest, ignoring the usual quota-then-cost grouping. It re-packs when the measured heights move enough to change the answer."
+            return "Compact packs each segment on its own into whichever two columns make it shortest, and stacks the segments in the order shown. Drag a card onto another segment to move it — where it lands inside is the packer's call. It re-packs when the measured heights move enough to change the answer, and an empty segment is forgotten once you leave this screen."
         case .auto:
             if page.isOverview {
                 return "The Overview balances its columns automatically, quota cards first. Blocks below show what that balance currently produces."

--- a/Sources/VibeBarApp/Views/MiscProviderLandingView.swift
+++ b/Sources/VibeBarApp/Views/MiscProviderLandingView.swift
@@ -1,0 +1,173 @@
+import SwiftUI
+import VibeBarCore
+
+/// What the Misc Providers pane shows before the user picks a provider
+/// from the sidebar.
+///
+/// It hosts the two controls that are about *all* cookie-sourced
+/// providers at once rather than any single one: a batch browser import,
+/// and the opt-in silent re-import setting. Per-provider controls stay
+/// in `MiscProviderSettingsSection`.
+struct MiscProviderLandingView: View {
+    @EnvironmentObject var environment: AppEnvironment
+    @EnvironmentObject var settingsStore: SettingsStore
+
+    @State private var isImporting = false
+    @State private var outcomes: [MiscCookieResolver.BatchImportOutcome] = []
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("Select a provider from the sidebar. Hidden providers keep their saved setup and credentials.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            Divider()
+
+            Text("Browser Cookies")
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(.secondary)
+
+            if cookieTargets.isEmpty {
+                Text("No cookie-based providers are configured.")
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+            } else {
+                HStack(spacing: 8) {
+                    Button(action: importAll) {
+                        Label(
+                            "Import Browser Cookies for All Providers",
+                            systemImage: "safari"
+                        )
+                    }
+                    .disabled(isImporting)
+                    if isImporting {
+                        ProgressView()
+                            .controlSize(.small)
+                    }
+                }
+                Text("Reads your browsers once for all \(cookieTargets.count) cookie-based providers and adds a slot to each. Existing cookies stay; quotas are averaged across slots. macOS may ask for your login-keychain password once per Chromium-family browser involved.")
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+
+                if isImporting {
+                    Text("Importing…")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                } else if !outcomes.isEmpty {
+                    VStack(alignment: .leading, spacing: 3) {
+                        ForEach(outcomes, id: \.instanceID) { outcome in
+                            OutcomeRow(
+                                title: displayName(forInstanceID: outcome.instanceID, tool: outcome.tool),
+                                outcome: outcome.result
+                            )
+                        }
+                    }
+                }
+            }
+
+            Divider()
+
+            Toggle(
+                "Auto re-import from browser when cookies expire",
+                isOn: autoImportBinding
+            )
+            Text("Off by default. When on, a provider that reports \"Needs re-login\" gets one silent re-read of your browser cookie store before the error is shown. It never asks for your Keychain password on its own — pasted cookies are left untouched.")
+                .font(.caption2)
+                .foregroundStyle(.tertiary)
+        }
+    }
+
+    private var autoImportBinding: Binding<Bool> {
+        Binding(
+            get: { settingsStore.settings.miscCookieAutoImportEnabled },
+            set: { settingsStore.settings.miscCookieAutoImportEnabled = $0 }
+        )
+    }
+
+    /// Every configured provider instance whose credentials are browser
+    /// cookies, in sidebar order.
+    private var cookieTargets: [MiscCookieResolver.BatchImportTarget] {
+        settingsStore.settings.miscProviderInstances.compactMap { instance in
+            guard let spec = MiscCookieSpecCatalog.spec(for: instance.tool) else { return nil }
+            return MiscCookieResolver.BatchImportTarget(spec: spec, instanceID: instance.id)
+        }
+    }
+
+    private func displayName(forInstanceID instanceID: String, tool: ToolType) -> String {
+        let instance = settingsStore.settings.miscProviderInstance(id: instanceID)
+        let copies = settingsStore.settings.miscProviderInstances.filter { $0.tool == tool }
+        guard copies.count > 1 else { return instance?.displayName ?? tool.menuTitle }
+        let index = (copies.firstIndex { $0.id == instanceID } ?? 0) + 1
+        return instance?.displayName ?? "\(tool.menuTitle) (Copy \(index))"
+    }
+
+    private func importAll() {
+        let targets = cookieTargets
+        guard !targets.isEmpty else { return }
+        isImporting = true
+        outcomes = []
+        // Off the main thread: this walks browser cookie stores and
+        // writes the Keychain once per provider.
+        DispatchQueue.global(qos: .userInitiated).async {
+            let results = MiscCookieResolver.appendBrowserImports(for: targets)
+            DispatchQueue.main.async {
+                isImporting = false
+                outcomes = results
+                // One refresh for the whole batch rather than one per
+                // provider — the quota service fans out on its own.
+                environment.refreshAll()
+            }
+        }
+    }
+}
+
+/// One provider's line in the batch-import result list.
+private struct OutcomeRow: View {
+    let title: String
+    let outcome: MiscCookieResolver.BatchImportOutcome.Result
+
+    var body: some View {
+        HStack(spacing: 6) {
+            Image(systemName: symbol)
+                .font(.caption2)
+                .foregroundStyle(tint)
+                .frame(width: 12)
+            Text(title)
+                .font(.caption)
+            Spacer(minLength: 6)
+            Text(detail)
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private var symbol: String {
+        switch outcome {
+        case .imported:        return "checkmark.circle"
+        case .noSessionFound:  return "minus.circle"
+        case .cookiesDisabled: return "slash.circle"
+        case .saveFailed:      return "exclamationmark.triangle"
+        }
+    }
+
+    private var tint: Color {
+        switch outcome {
+        case .imported:                        return .green
+        case .noSessionFound, .cookiesDisabled: return .secondary
+        case .saveFailed:                      return .orange
+        }
+    }
+
+    private var detail: String {
+        switch outcome {
+        case .imported(let sourceLabel):
+            return "Imported from \(sourceLabel)"
+        case .noSessionFound:
+            return "No signed-in session found"
+        case .cookiesDisabled:
+            return "Cookies disabled for this provider"
+        case .saveFailed:
+            return "Could not save to Keychain"
+        }
+    }
+}

--- a/Sources/VibeBarApp/Views/MiscProviderSettingsSection.swift
+++ b/Sources/VibeBarApp/Views/MiscProviderSettingsSection.swift
@@ -124,7 +124,6 @@ struct MiscProviderSettingsSection: View {
                 CookieSourceControls(
                     tool: .alibaba,
                     instanceID: instanceID,
-                    spec: AlibabaQuotaAdapter.cookieSpec,
                     manualPrompt: "Paste console.aliyun.com Cookie header (login_aliyunid_csrf=…; cna=…; …)"
                 )
                 MiscWebLoginRow(
@@ -150,7 +149,6 @@ struct MiscProviderSettingsSection: View {
                 CookieSourceControls(
                     tool: .alibabaTokenPlan,
                     instanceID: instanceID,
-                    spec: AlibabaTokenPlanQuotaAdapter.cookieSpec,
                     manualPrompt: "Paste console.aliyun.com Cookie header (login_aliyunid_csrf=…; cna=…; …)"
                 )
                 MiscWebLoginRow(
@@ -173,14 +171,12 @@ struct MiscProviderSettingsSection: View {
             CookieSourceControls(
                 tool: .kimi,
                 instanceID: instanceID,
-                spec: KimiQuotaAdapter.cookieSpec,
                 manualPrompt: "Paste www.kimi.com Cookie header (kimi-auth=eyJ...)"
             )
         case .cursor:
             CookieSourceControls(
                 tool: .cursor,
                 instanceID: instanceID,
-                spec: CursorQuotaAdapter.cookieSpec,
                 manualPrompt: "Paste cursor.com Cookie header (WorkosCursorSessionToken=...)"
             )
         case .mimo:
@@ -188,7 +184,6 @@ struct MiscProviderSettingsSection: View {
                 CookieSourceControls(
                     tool: .mimo,
                     instanceID: instanceID,
-                    spec: MimoQuotaAdapter.cookieSpec,
                     manualPrompt: "Paste platform.xiaomimimo.com Cookie header (userId=...; api-platform_slh=...; api-platform_ph=...; api-platform_serviceToken=...)"
                 )
                 MiscWebLoginRow(
@@ -201,7 +196,6 @@ struct MiscProviderSettingsSection: View {
             CookieSourceControls(
                 tool: .iflytek,
                 instanceID: instanceID,
-                spec: IFlyTekQuotaAdapter.cookieSpec,
                 manualPrompt: "Paste maas.xfyun.cn Cookie header (atp-auth-token=…; account_id=…; ssoSessionId=…; tenantToken=…)"
             )
         case .tencentHunyuan:
@@ -209,7 +203,6 @@ struct MiscProviderSettingsSection: View {
                 CookieSourceControls(
                     tool: .tencentHunyuan,
                     instanceID: instanceID,
-                    spec: TencentHunyuanQuotaAdapter.cookieSpec,
                     manualPrompt: "Paste cloud.tencent.com Cookie header (skey=…; uin=…; …)"
                 )
                 MiscWebLoginRow(
@@ -224,7 +217,6 @@ struct MiscProviderSettingsSection: View {
                 CookieSourceControls(
                     tool: .tencentTokenPlan,
                     instanceID: instanceID,
-                    spec: TencentTokenPlanQuotaAdapter.cookieSpec,
                     manualPrompt: "Paste cloud.tencent.com Cookie header (skey=…; uin=…; …)"
                 )
                 MiscWebLoginRow(
@@ -238,7 +230,6 @@ struct MiscProviderSettingsSection: View {
                 CookieSourceControls(
                     tool: .volcengine,
                     instanceID: instanceID,
-                    spec: VolcengineQuotaAdapter.cookieSpec,
                     manualPrompt: "Paste console.volcengine.com Cookie header (csrfToken=…; AccountID=…; …)"
                 )
                 MiscWebLoginRow(
@@ -260,7 +251,6 @@ struct MiscProviderSettingsSection: View {
                 CookieSourceControls(
                     tool: .baiduQianfan,
                     instanceID: instanceID,
-                    spec: BaiduQianfanQuotaAdapter.cookieSpec,
                     manualPrompt: "Paste console.bce.baidu.com Cookie header (BDUSS=…; STOKEN=…; __bid_n=…; …)"
                 )
                 MiscWebLoginRow(
@@ -274,7 +264,6 @@ struct MiscProviderSettingsSection: View {
                 CookieSourceControls(
                     tool: .openCodeGo,
                     instanceID: instanceID,
-                    spec: OpenCodeGoQuotaAdapter.cookieSpec,
                     manualPrompt: "Paste opencode.ai Cookie header (__Host-auth=... or auth=...)"
                 )
                 WorkspaceIDField(
@@ -296,7 +285,6 @@ struct MiscProviderSettingsSection: View {
             CookieSourceControls(
                 tool: .ollama,
                 instanceID: instanceID,
-                spec: OllamaQuotaAdapter.cookieSpec,
                 manualPrompt: "Paste ollama.com Cookie header (session=... or next-auth.session-token=...)"
             )
         case .openRouter:
@@ -759,7 +747,6 @@ struct KiroStatusRow: View {
 struct CookieSourceControls: View {
     let tool: ToolType
     let instanceID: String
-    let spec: MiscCookieResolver.Spec
     let manualPrompt: String
 
     @EnvironmentObject var environment: AppEnvironment
@@ -769,7 +756,26 @@ struct CookieSourceControls: View {
     @State private var manualDraft: String = ""
     @State private var importStatus: String?
 
+    /// Which cookies to look for. Comes from `MiscCookieSpecCatalog`
+    /// rather than the caller so this row and the all-providers batch
+    /// import can never disagree about a provider's domains. `nil` means
+    /// a provider row was wired up without registering a spec, which is
+    /// a programmer error rather than a user-facing state.
+    private var spec: MiscCookieResolver.Spec? {
+        MiscCookieSpecCatalog.spec(for: tool)
+    }
+
     var body: some View {
+        if spec == nil {
+            Text("No cookie spec is registered for \(tool.menuTitle).")
+                .font(.caption)
+                .foregroundStyle(.orange)
+        } else {
+            controls
+        }
+    }
+
+    private var controls: some View {
         VStack(alignment: .leading, spacing: 6) {
             if slots.isEmpty {
                 Text("No cookies imported yet — import from your browser or paste below.")
@@ -829,8 +835,8 @@ struct CookieSourceControls: View {
     }
 
     private func importNow() {
+        guard let snapshotSpec = spec else { return }
         importStatus = "Importing…"
-        let snapshotSpec = spec
         let snapshotInstanceID = instanceID
         DispatchQueue.global(qos: .userInitiated).async {
             let result = MiscCookieResolver.appendBrowserImport(for: snapshotSpec, instanceID: snapshotInstanceID)
@@ -901,14 +907,14 @@ struct CookieSourceControls: View {
     }
 
     private func normalizedManualCookie(from raw: String) -> String? {
-        if spec.requiredNames.isEmpty {
+        guard let spec, !spec.requiredNames.isEmpty else {
             return CookieHeaderNormalizer.normalize(raw)
         }
         return CookieHeaderNormalizer.filteredHeader(from: raw, allowedNames: spec.requiredNames)
     }
 
     private var missingCookieMessage: String {
-        if spec.requiredNames.isEmpty {
+        guard let spec, !spec.requiredNames.isEmpty else {
             return "No usable cookie found in pasted text."
         }
         return "No \(spec.requiredNames.sorted().joined(separator: ", ")) cookie found in pasted text."

--- a/Sources/VibeBarApp/Views/OverviewQuotaHistoryCard.swift
+++ b/Sources/VibeBarApp/Views/OverviewQuotaHistoryCard.swift
@@ -64,6 +64,20 @@ private struct OverviewSeriesSignature: Equatable {
     var entries: [Entry]
 }
 
+/// What building one lane produced, plus everything that decides whether the
+/// result is still valid.
+private struct OverviewLaneBuild {
+    var signature: OverviewSeriesSignature.Entry
+    /// The palette slot and the account qualifier depend on the *set* of lanes
+    /// rather than on this lane alone — a second Claude account appearing
+    /// renames every Claude curve — so both belong to the validity check.
+    var variantIndex: Int
+    var qualifier: String?
+    var curve: OverviewQuotaCurve
+    var segments: [[QuotaHistorySample]]
+    var flat: [QuotaHistorySample]
+}
+
 /// Every recorded quota, from every provider and account, on one time axis.
 ///
 /// The per-provider cards answer "how am I doing on this one quota"; this one
@@ -86,6 +100,9 @@ struct OverviewQuotaHistoryCard: View {
     @EnvironmentObject var settingsStore: SettingsStore
 
     @State private var curves: [OverviewQuotaCurve] = []
+    /// Last build output per curve, so a refresh that appends one point to one
+    /// provider's lane re-segments that lane instead of all thirty.
+    @State private var laneCache: [String: OverviewLaneBuild] = [:]
     @State private var segmentsByCurve: [String: [[QuotaHistorySample]]] = [:]
     /// Each curve's samples flattened into one ascending array — the segments
     /// are already time-sorted and contiguous, so concatenating them keeps the
@@ -671,31 +688,47 @@ struct OverviewQuotaHistoryCard: View {
 
     private var seriesSignature: OverviewSeriesSignature {
         OverviewSeriesSignature(
-            entries: candidateLanes.map { account, bucket in
-                let points = fillPoints(accountId: account.id, bucketId: bucket.id)
-                return OverviewSeriesSignature.Entry(
-                    curveId: OverviewQuotaCurve.id(
-                        tool: account.tool,
-                        accountId: account.id,
-                        bucketId: bucket.id
-                    ),
-                    // Titles are part of the signature because a plan change can
-                    // rename a bucket without adding an observation.
-                    title: bucket.title,
-                    count: points.count,
-                    first: points.first?.sampledAt,
-                    last: points.last?.sampledAt
-                )
-            }
+            entries: candidateLanes.map { signatureEntry(account: $0.account, bucket: $0.bucket) }
+        )
+    }
+
+    /// One lane's shape. Shared by the rebuild trigger and by the per-lane cache
+    /// key so the two can never disagree about what "changed".
+    private func signatureEntry(
+        account: AccountIdentity,
+        bucket: QuotaBucket
+    ) -> OverviewSeriesSignature.Entry {
+        let points = fillPoints(accountId: account.id, bucketId: bucket.id)
+        return OverviewSeriesSignature.Entry(
+            curveId: OverviewQuotaCurve.id(
+                tool: account.tool,
+                accountId: account.id,
+                bucketId: bucket.id
+            ),
+            // Titles are part of the signature because a plan change can
+            // rename a bucket without adding an observation.
+            title: bucketTitle(bucket),
+            count: points.count,
+            first: points.first?.sampledAt,
+            last: points.last?.sampledAt
         )
     }
 
     // MARK: - Rebuild
 
+    /// Re-segment the lanes whose inputs changed and keep the rest.
+    ///
+    /// Reusing a lane built against an *earlier* domain is safe because the
+    /// domain is the union of every lane's own span, only ever widened (the
+    /// six-hour floor extends the lower bound downwards): every lane's samples
+    /// therefore always lie inside it, so the builder's range filter never drops
+    /// one, and this card draws only `.actual` — the one part of the series that
+    /// does not otherwise depend on the range.
     private func rebuild() {
         let lanes = candidateLanes
         guard !lanes.isEmpty, let domain = domainRange(lanes) else {
             curves = []
+            laneCache = [:]
             segmentsByCurve = [:]
             flatByCurve = [:]
             window = nil
@@ -714,6 +747,7 @@ struct OverviewQuotaHistoryCard: View {
         var built: [OverviewQuotaCurve] = []
         var series: [String: [[QuotaHistorySample]]] = [:]
         var flat: [String: [QuotaHistorySample]] = [:]
+        var rebuiltCache: [String: OverviewLaneBuild] = [:]
         var indexPerTool: [ToolType: Int] = [:]
         for (account, bucket) in lanes {
             let id = OverviewQuotaCurve.id(
@@ -723,32 +757,54 @@ struct OverviewQuotaHistoryCard: View {
             )
             let index = indexPerTool[account.tool, default: 0]
             indexPerTool[account.tool] = index + 1
+            let qualifier = (accountsPerTool[account.tool]?.count ?? 0) > 1
+                ? Self.qualifier(for: account)
+                : nil
+            let signature = signatureEntry(account: account, bucket: bucket)
+            if let cached = laneCache[id],
+               cached.signature == signature,
+               cached.variantIndex == index,
+               cached.qualifier == qualifier {
+                built.append(cached.curve)
+                series[id] = cached.segments
+                flat[id] = cached.flat
+                rebuiltCache[id] = cached
+                continue
+            }
+
             let variant = Self.variant(Theme.providerAccent(for: account.tool), index: index)
-            built.append(
-                OverviewQuotaCurve(
-                    id: id,
-                    tool: account.tool,
-                    accountId: account.id,
-                    bucketId: bucket.id,
-                    toolTitle: displayTitle(for: account.tool),
-                    bucketTitle: bucketTitle(bucket),
-                    accountQualifier: (accountsPerTool[account.tool]?.count ?? 0) > 1
-                        ? Self.qualifier(for: account)
-                        : nil,
-                    windowSeconds: bucket.rawWindowSeconds,
-                    color: variant.color,
-                    dash: variant.dash
-                )
+            let curve = OverviewQuotaCurve(
+                id: id,
+                tool: account.tool,
+                accountId: account.id,
+                bucketId: bucket.id,
+                toolTitle: displayTitle(for: account.tool),
+                bucketTitle: bucketTitle(bucket),
+                accountQualifier: qualifier,
+                windowSeconds: bucket.rawWindowSeconds,
+                color: variant.color,
+                dash: variant.dash
             )
             let actual = QuotaHistorySeriesBuilder.build(
                 fillPoints: fillPoints(accountId: account.id, bucketId: bucket.id),
                 range: domain
             ).actual
+            let flattened = actual.flatMap { $0 }
+            built.append(curve)
             series[id] = actual
-            flat[id] = actual.flatMap { $0 }
+            flat[id] = flattened
+            rebuiltCache[id] = OverviewLaneBuild(
+                signature: signature,
+                variantIndex: index,
+                qualifier: qualifier,
+                curve: curve,
+                segments: actual,
+                flat: flattened
+            )
         }
 
         curves = built
+        laneCache = rebuiltCache
         segmentsByCurve = series
         flatByCurve = flat
 

--- a/Sources/VibeBarApp/Views/OverviewQuotaHistoryCard.swift
+++ b/Sources/VibeBarApp/Views/OverviewQuotaHistoryCard.swift
@@ -111,7 +111,7 @@ struct OverviewQuotaHistoryCard: View {
     @State private var flatByCurve: [String: [QuotaHistorySample]] = [:]
     @State private var window: ChartTimeWindow?
     @State private var windowKey: String?
-    @State private var initialSpan: TimeInterval = 7 * 86_400
+    @State private var initialSpan: TimeInterval = OverviewQuotaHistoryCard.preferredInitialSpan
     @State private var hoverDate: Date?
     @State private var panBase: ChartTimeWindow?
     @State private var magnifyBase: ChartTimeWindow?
@@ -811,7 +811,10 @@ struct OverviewQuotaHistoryCard: View {
         let key = built.map(\.id).joined(separator: ",")
         let sameCurves = windowKey == key
         windowKey = key
-        initialSpan = min(7 * 86_400, max(6 * 3_600, domain.upperBound.timeIntervalSince(domain.lowerBound)))
+        initialSpan = min(
+            Self.preferredInitialSpan,
+            max(6 * 3_600, domain.upperBound.timeIntervalSince(domain.lowerBound))
+        )
 
         if sameCurves,
            let existing = window,
@@ -844,6 +847,12 @@ struct OverviewQuotaHistoryCard: View {
     /// enough for the fast ones to show their sawtooth, shallow enough that a
     /// weekly line is never a single flat pixel-row.
     private static let minimumSpan: TimeInterval = 3 * 3_600
+
+    /// Opening zoom, matching the per-group chart: one day of recent movement
+    /// rather than a whole week compressed into the card's width. Still clamped
+    /// to the stored domain, so a chart with only a few hours of evidence opens
+    /// on what it actually has.
+    private static let preferredInitialSpan: TimeInterval = 24 * 3_600
 
     private func domainRange(
         _ lanes: [(account: AccountIdentity, bucket: QuotaBucket)]

--- a/Sources/VibeBarApp/Views/PageLayoutColumns.swift
+++ b/Sources/VibeBarApp/Views/PageLayoutColumns.swift
@@ -26,47 +26,56 @@ struct PageColumnWidths {
     }
 }
 
-/// Renders a page as two fixed-order columns straight out of a
-/// `PageLayoutConfig`.
+/// Renders a page as fixed-order columns straight out of a
+/// `PageLayoutArrangement`.
 ///
 /// Used whenever the user has arranged the page by hand, and on provider pages
 /// always — their built-in split is itself a fixed two-column arrangement, so
 /// the default config reproduces it exactly and there is no second code path
 /// to keep in sync.
 ///
+/// A `compact` page can hand over several bands, which stack vertically at the
+/// page's own card gap. One band renders as exactly the single two-column
+/// `HStack` this view has always drawn, which is what `auto` and `manual` pass,
+/// so segmentation cannot change how an unsegmented page looks.
+///
 /// Every card reports its rendered height back to the model on the way past;
 /// the layout editor draws its blocks from those measurements.
 struct PageLayoutColumns<Content: View>: View {
     let page: PageLayoutPageID
     let descriptors: [PageModuleDescriptor]
-    let config: PageLayoutConfig
+    let arrangement: PageLayoutArrangement
     let widths: PageColumnWidths
     let spacing: CGFloat
     let model: PageLayoutModel
     @ViewBuilder let content: (PageModuleDescriptor) -> Content
 
     var body: some View {
-        // The config can name a module that went away between refreshes (a
+        // The arrangement can name a module that went away between refreshes (a
         // quota group whose buckets emptied). Resolve through the live
         // descriptor set every pass and skip anything stale rather than
         // trusting the saved identifiers.
         let byID = Dictionary(descriptors.map { ($0.id, $0) }, uniquingKeysWith: { first, _ in first })
-        HStack(alignment: .top, spacing: spacing) {
-            column(0, byID: byID)
-                .frame(width: widths.left, alignment: .topLeading)
-            column(1, byID: byID)
-                .frame(width: widths.right, alignment: .topLeading)
+        VStack(alignment: .leading, spacing: spacing) {
+            ForEach(Array(arrangement.segments.enumerated()), id: \.offset) { _, segment in
+                HStack(alignment: .top, spacing: spacing) {
+                    column(segment.column(0), byID: byID)
+                        .frame(width: widths.left, alignment: .topLeading)
+                    column(segment.column(1), byID: byID)
+                        .frame(width: widths.right, alignment: .topLeading)
+                }
+            }
         }
         .frame(width: widths.total, alignment: .topLeading)
     }
 
     @ViewBuilder
     private func column(
-        _ index: Int,
+        _ moduleIDs: [PageLayoutModuleID],
         byID: [PageLayoutModuleID: PageModuleDescriptor]
     ) -> some View {
         VStack(alignment: .leading, spacing: spacing) {
-            ForEach(config.column(index), id: \.self) { moduleID in
+            ForEach(moduleIDs, id: \.self) { moduleID in
                 if let descriptor = byID[moduleID] {
                     content(descriptor)
                         .measuredPageModule(moduleID, page: page, model: model)

--- a/Sources/VibeBarApp/Views/PageModuleCatalog.swift
+++ b/Sources/VibeBarApp/Views/PageModuleCatalog.swift
@@ -29,6 +29,10 @@ enum PageModuleAccent {
 /// views.
 enum PageModuleKind: Hashable {
     // Overview
+    /// The cost + token headline grid. A module like any other since the
+    /// summary band stopped being hard-coded above the waterfall.
+    case overviewCostSummary
+    case overviewStatusSummary
     case overviewQuota(ToolType)
     case overviewQuotaHistoryAll
     case overviewCostAll
@@ -82,6 +86,10 @@ enum PageModuleCatalog {
         static let analytics: Double = 200
         static let status: Double = 150
         static let placeholder: Double = 90
+        /// The summary cards are pinned to `Theme.Density.overviewSummaryHeight`
+        /// (148 / 178 / 210), so this stand-in only has to be the right order of
+        /// magnitude until the first measurement replaces it.
+        static let summary: Double = 150
     }
 
     // MARK: - Pages
@@ -120,6 +128,34 @@ enum PageModuleCatalog {
         // Order below is the order `OverviewWaterfall` hands the cards to
         // `ColumnMasonryLayout`. The planner's quota/cost pairing depends on
         // it, so the two must not diverge.
+        //
+        // The two summary cards come first and carry the `.summary` phase, which
+        // is what puts them side by side in the top row in `auto` and in their
+        // own band in `compact`. They used to be a hard-coded header row above
+        // the waterfall, which is why they were the two cards on the Overview
+        // the user could not move.
+        result.append(
+            PageModuleDescriptor(
+                id: .custom("overview-summary-cost"),
+                kind: .overviewCostSummary,
+                displayName: "Cost Summary",
+                defaultColumn: 0,
+                accent: .cost,
+                masonryPhase: .summary,
+                fallbackHeight: FallbackHeight.summary
+            )
+        )
+        result.append(
+            PageModuleDescriptor(
+                id: .custom("overview-summary-status"),
+                kind: .overviewStatusSummary,
+                displayName: "Status Summary",
+                defaultColumn: 1,
+                accent: .neutral,
+                masonryPhase: .summary,
+                fallbackHeight: FallbackHeight.summary
+            )
+        )
         for tool in settings.visibleCoreProviderList {
             result.append(
                 PageModuleDescriptor(
@@ -526,5 +562,27 @@ enum PageModuleCatalog {
     /// design; the Overview balances two equal columns.
     static func defaultRatio(for page: PageLayoutPageID) -> PageColumnRatio {
         page.isOverview ? .equal : .narrowWide
+    }
+
+    // MARK: - Default segmentation
+
+    /// The bands `compact` packs one at a time when the user has not chosen a
+    /// segmentation of their own.
+    ///
+    /// Derived from the modules' `masonryPhase`, so the grouping the Overview
+    /// reads in is the grouping `compact` respects — this is the whole reason a
+    /// packed Overview no longer slots a heatmap between two quota cards. The
+    /// policy itself is `PageLayoutSegments.defaultSegments`; this is the
+    /// adapter from the catalog's descriptors to it.
+    static func defaultSegments(
+        for page: PageLayoutPageID,
+        descriptors: [PageModuleDescriptor]
+    ) -> [[PageLayoutModuleID]] {
+        PageLayoutSegments.defaultSegments(
+            modules: descriptors.map {
+                PageLayoutSegments.Module(id: $0.id, phase: $0.masonryPhase.corePhase)
+            },
+            page: page
+        )
     }
 }

--- a/Sources/VibeBarApp/Views/PageModuleCatalog.swift
+++ b/Sources/VibeBarApp/Views/PageModuleCatalog.swift
@@ -404,10 +404,17 @@ enum PageModuleCatalog {
 
     /// Combined Gemini + AntiGravity cost, surfaced as the single "Gemini"
     /// (Google AI) platform.
+    ///
+    /// Routed through the service's memo rather than combining here: combining
+    /// re-rebases both providers and re-buckets ~720 hourly keys, and this is
+    /// asked for from the module catalog, the Overview's Gemini card, and the
+    /// Gemini page — all within one render pass.
     @MainActor
     static func googleAICostSnapshot(environment: AppEnvironment) -> CostSnapshot {
-        let parts = ToolType.googleAIPair.compactMap { environment.costService.snapshot(for: $0) }
-        return CostSnapshotAggregator.combinedSnapshot(tool: .antigravity, snapshots: parts)
+        environment.costService.combinedSnapshot(
+            of: ToolType.googleAIPair,
+            labelledAs: .antigravity
+        )
     }
 
     /// Cost providers rendered as their own per-provider card on the Overview.
@@ -419,25 +426,46 @@ enum PageModuleCatalog {
         }
     }
 
-    /// Snapshots feeding the Overview's "All providers" rollups.
+    /// Every cross-provider rollup the Overview's "all providers" cards need,
+    /// as one memoized value: the per-provider snapshots, the combined daily
+    /// history, heatmap, model ranking and combined snapshot.
+    ///
+    /// One call per render pass, and the answer is cached in
+    /// `CostUsageService` until the next cost refresh or the next local day.
+    /// The Overview used to derive these four separate times per `body` — once
+    /// inside the module catalog, once for the context, once for the
+    /// all-providers cost card and once for the Gemini card — each of which
+    /// re-rebased every provider's whole daily history.
     @MainActor
-    static func overviewCostSnapshots(
+    static func overviewRollup(
         environment: AppEnvironment,
         settings: AppSettings
-    ) -> [CostSnapshot] {
-        var snaps = overviewCostProviders(settings: settings)
-            .compactMap { environment.costService.snapshot(for: $0) }
-        if settings.isCoreProviderVisible(.gemini) {
-            let googleAI = googleAICostSnapshot(environment: environment)
-            if googleAI.jsonlFilesFound > 0 { snaps.append(googleAI) }
-        }
-        return snaps
+    ) -> CostRollup {
+        environment.costService.rollup(
+            individualTools: overviewCostProviders(settings: settings),
+            // The Gemini group is labelled `.antigravity` for the same reason
+            // `googleAICostSnapshot` is: AntiGravity is the live Google usage
+            // source, and both call sites must land on the same cached snapshot.
+            groups: settings.isCoreProviderVisible(.gemini)
+                ? [CostSnapshotGroup(label: .antigravity, tools: ToolType.googleAIPair)]
+                : [],
+            labelledAs: .codex
+        )
     }
 
+    /// Whether the Overview has any cost data at all.
+    ///
+    /// Answered from raw file counts, never from a rollup: `jsonlFilesFound`
+    /// survives rebasing and combining untouched, so the question that decides
+    /// whether the cost and analytics modules exist costs a handful of
+    /// dictionary lookups instead of a full cross-provider combine.
     @MainActor
     static func hasCostData(environment: AppEnvironment, settings: AppSettings) -> Bool {
-        overviewCostSnapshots(environment: environment, settings: settings)
-            .contains { $0.jsonlFilesFound > 0 }
+        var tools = overviewCostProviders(settings: settings)
+        if settings.isCoreProviderVisible(.gemini) {
+            tools.append(contentsOf: ToolType.googleAIPair)
+        }
+        return environment.costService.hasJSONLFiles(in: tools)
     }
 
     // MARK: - Default configuration

--- a/Sources/VibeBarApp/Views/PopoverRoot.swift
+++ b/Sources/VibeBarApp/Views/PopoverRoot.swift
@@ -402,19 +402,23 @@ private struct OverviewWaterfall: View {
             environment: environment,
             settings: settings
         )
-        let snapshots = PageModuleCatalog.overviewCostSnapshots(
+        // One rollup for the whole pass. Every aggregation below used to be
+        // re-derived per card — and the module catalog above derived them a
+        // fourth time — which is why an unrelated quota publish could cost the
+        // Overview several full cross-provider combines per re-render.
+        let rollup = PageModuleCatalog.overviewRollup(
             environment: environment,
             settings: settings
         )
         let context = OverviewModuleContext(
-            history: CostSnapshotAggregator.combinedDailyHistory(snapshots),
-            heatmap: CostSnapshotAggregator.combinedHeatmap(snapshots),
-            models: CostSnapshotAggregator.combinedModelBreakdowns(snapshots),
-            combinedSnapshot: CostSnapshotAggregator.combinedSnapshot(
-                tool: .codex,
-                snapshots: snapshots
-            ),
-            googleAISnapshot: PageModuleCatalog.googleAICostSnapshot(environment: environment)
+            history: rollup.dailyHistory,
+            heatmap: rollup.heatmap,
+            models: rollup.modelBreakdowns,
+            combinedSnapshot: rollup.combinedSnapshot,
+            // Present exactly when the Gemini card is: the rollup only carries
+            // the group when the provider is visible, and the module that reads
+            // this exists under the same condition.
+            googleAISnapshot: rollup.groupSnapshots.first ?? .empty(tool: .antigravity)
         )
 
         VStack(alignment: .leading, spacing: density.interSectionSpacing) {
@@ -801,23 +805,10 @@ private struct CombinedTotalsRow: View {
         let visibleCostProviders = ToolType.costAwareProviders.filter {
             settingsStore.settings.isCoreProviderVisible($0)
         }
-        let snapshots = visibleCostProviders
-            .compactMap { environment.costService.snapshot(for: $0) }
-        let dailyHistory = CostSnapshotAggregator.combinedDailyHistory(snapshots)
-        let totalCost = snapshots.reduce(0.0) { $0 + $1.allTimeCostUSD }
-        let todayCost = snapshots.reduce(0.0) { $0 + $1.todayCostUSD }
-        let yesterdayCost = snapshots.reduce(0.0) { $0 + CostTimeframe.yesterday.cost(in: $1) }
-        let weekCost = snapshots.reduce(0.0) { $0 + $1.last7DaysCostUSD }
-        let monthCost = snapshots.reduce(0.0) { $0 + $1.last30DaysCostUSD }
-        let totalTokens = snapshots.reduce(0) { $0 + $1.allTimeTokens }
-        let todayTokens = snapshots.reduce(0) { $0 + $1.todayTokens }
-        let yesterdayTokens = snapshots.reduce(0) { $0 + CostTimeframe.yesterday.tokens(in: $1) }
-        let weekTokens = snapshots.reduce(0) { $0 + $1.last7DaysTokens }
-        let monthTokens = snapshots.reduce(0) { $0 + $1.last30DaysTokens }
-        // Cost and token peaks are independent: the most expensive day
-        // is not necessarily the day with the highest token volume.
-        let peakDayCost = CostSnapshotAggregator.peakDailyCost(in: dailyHistory)
-        let peakTokenDayTokens = CostSnapshotAggregator.peakDailyTokens(in: dailyHistory)
+        // Ten reduce passes, a per-provider calendar scan for "yesterday", and
+        // two peak scans over the combined daily history — all of it derived
+        // once per cost refresh in Core rather than once per render pass here.
+        let totals = costService.totals(of: visibleCostProviders)
         GeometryReader { geometry in
             let spacing = density.interSectionSpacing
             let availableWidth = max(0, geometry.size.width - spacing)
@@ -850,33 +841,33 @@ private struct CombinedTotalsRow: View {
                     // instead of leaving one empty band below the third row.
                     VStack(alignment: .leading, spacing: 0) {
                         HStack(alignment: .top, spacing: 0) {
-                            metric(label: "TOTAL COST", value: formatCost(totalCost), highlight: true)
+                            metric(label: "TOTAL COST", value: formatCost(totals.allTimeCostUSD), highlight: true)
                             divider
-                            metric(label: "TOTAL TOK", value: formatTokens(totalTokens), highlight: true)
+                            metric(label: "TOTAL TOK", value: formatTokens(totals.allTimeTokens), highlight: true)
                             divider
-                            metric(label: "PEAK DAY", value: formatCost(peakDayCost))
+                            metric(label: "PEAK DAY", value: formatCost(totals.peakDayCostUSD))
                             divider
-                            metric(label: "PEAK TOK DAY", value: formatTokens(peakTokenDayTokens))
+                            metric(label: "PEAK TOK DAY", value: formatTokens(totals.peakDayTokens))
                         }
                         Spacer(minLength: 8)
                         HStack(alignment: .top, spacing: 0) {
-                            metric(label: "TODAY", value: formatCost(todayCost))
+                            metric(label: "TODAY", value: formatCost(totals.todayCostUSD))
                             divider
-                            metric(label: "YESTERDAY", value: formatCost(yesterdayCost))
+                            metric(label: "YESTERDAY", value: formatCost(totals.yesterdayCostUSD))
                             divider
-                            metric(label: "7-DAY", value: formatCost(weekCost))
+                            metric(label: "7-DAY", value: formatCost(totals.last7DaysCostUSD))
                             divider
-                            metric(label: "30-DAY", value: formatCost(monthCost))
+                            metric(label: "30-DAY", value: formatCost(totals.last30DaysCostUSD))
                         }
                         Spacer(minLength: 8)
                         HStack(alignment: .top, spacing: 0) {
-                            metric(label: "TODAY TOK", value: formatTokens(todayTokens))
+                            metric(label: "TODAY TOK", value: formatTokens(totals.todayTokens))
                             divider
-                            metric(label: "YESTERDAY TOK", value: formatTokens(yesterdayTokens))
+                            metric(label: "YESTERDAY TOK", value: formatTokens(totals.yesterdayTokens))
                             divider
-                            metric(label: "7-DAY TOK", value: formatTokens(weekTokens))
+                            metric(label: "7-DAY TOK", value: formatTokens(totals.last7DaysTokens))
                             divider
-                            metric(label: "30-DAY TOK", value: formatTokens(monthTokens))
+                            metric(label: "30-DAY TOK", value: formatTokens(totals.last30DaysTokens))
                         }
                     }
                     .frame(maxHeight: .infinity)

--- a/Sources/VibeBarApp/Views/PopoverRoot.swift
+++ b/Sources/VibeBarApp/Views/PopoverRoot.swift
@@ -368,17 +368,23 @@ private struct OverviewSwitchIcon: View {
     }
 }
 
-/// Overview popover content, top-to-bottom:
-///   1. `CombinedTotalsRow` — cost+token grid plus live service status. A fixed
-///      header band, not part of the arrangeable module set: it is two
-///      half-width cards pinned to one shared height, which is not something
-///      two independently flowing columns can express.
-///   2. The module waterfall. Until the user arranges the page by hand this is
-///      the live-measured `ColumnMasonryLayout` it has always been — it
-///      globally balances the quota cards first, then places Cost cards from
-///      those seeded column heights, and finally fills the shorter side with
-///      supporting analytics. Once a saved arrangement exists, the same cards
-///      render in the saved order at the saved column widths.
+/// Overview popover content: one module waterfall, cost and status summary
+/// included.
+///
+/// The two summary cards used to be a hard-coded header row above the
+/// waterfall, on the grounds that "two half-width cards pinned to one shared
+/// height" was not something two independently flowing columns could express.
+/// They are ordinary modules now, carrying `OverviewMasonryPhase.summary`: the
+/// planner places a summary phase across the columns in declaration order
+/// rather than balancing it, which reproduces that row exactly while making the
+/// two cards arrangeable like everything else.
+///
+/// Until the user arranges the page by hand this is the live-measured
+/// `ColumnMasonryLayout` it has always been — summary row first, then the quota
+/// cards balanced globally, then Cost from those seeded column heights, and
+/// finally the shorter side filled with supporting analytics. Once a saved
+/// arrangement exists, the same cards render in the saved order at the saved
+/// column widths.
 private struct OverviewWaterfall: View {
     let density: Theme.Density
 
@@ -421,18 +427,15 @@ private struct OverviewWaterfall: View {
             googleAISnapshot: rollup.groupSnapshots.first ?? .empty(tool: .antigravity)
         )
 
-        VStack(alignment: .leading, spacing: density.interSectionSpacing) {
-            CombinedTotalsRow(density: density)
-            // `auto` is the only mode the balancer runs in. `compact` and
-            // `manual` both render fixed columns — one packed for height by
-            // `PageLayoutPacker`, one arranged by hand — through the same
-            // path, so the two can never diverge in anything but their source
-            // of column order.
-            if layoutModel.mode(for: page) == .auto {
-                balancedWaterfall(descriptors: descriptors, context: context)
-            } else {
-                arrangedWaterfall(descriptors: descriptors, context: context)
-            }
+        // `auto` is the only mode the balancer runs in. `compact` and `manual`
+        // both render fixed columns — one packed for height by
+        // `PageLayoutPacker`, band by band, one arranged by hand — through the
+        // same path, so the two can never diverge in anything but their source
+        // of column order.
+        if layoutModel.mode(for: page) == .auto {
+            balancedWaterfall(descriptors: descriptors, context: context)
+        } else {
+            arrangedWaterfall(descriptors: descriptors, context: context)
         }
     }
 
@@ -450,7 +453,7 @@ private struct OverviewWaterfall: View {
         return PageLayoutColumns(
             page: page,
             descriptors: descriptors,
-            config: resolved,
+            arrangement: resolved,
             widths: PageColumnWidths(density: density, ratio: resolved.ratio),
             spacing: density.interSectionSpacing,
             model: layoutModel
@@ -492,6 +495,14 @@ private struct OverviewWaterfall: View {
         context: OverviewModuleContext
     ) -> some View {
         switch descriptor.kind {
+        case .overviewCostSummary:
+            OverviewCostSummaryCard(density: density)
+        case .overviewStatusSummary:
+            OverviewStatusSummaryCard(
+                density: density,
+                minHeight: density.overviewSummaryHeight,
+                tools: settingsStore.settings.visibleCoreProviderList
+            )
         case let .overviewQuota(tool):
             if tool == .gemini {
                 // Gemini Web and AntiGravity roll up to one Google AI product.
@@ -788,15 +799,19 @@ private struct GeminiCostEmptyCard: View {
     }
 }
 
-/// Sits above the per-provider columns: cost and token summary on the left,
-/// current provider status on the right. The two cards use equal columns so
-/// the Overview header aligns with the waterfall below it.
-private struct CombinedTotalsRow: View {
+/// The Overview's cost and token headline grid — the left half of what used to
+/// be a hard-coded header row, now an arrangeable module.
+///
+/// It keeps its pinned height (`Theme.Density.overviewSummaryHeight`), which is
+/// what makes it read as one row with the status card beside it; the width comes
+/// from whichever column the layout puts it in, like every other card.
+private struct OverviewCostSummaryCard: View {
     let density: Theme.Density
 
     @EnvironmentObject var environment: AppEnvironment
     @EnvironmentObject var costService: CostUsageService
     @EnvironmentObject var settingsStore: SettingsStore
+
     var body: some View {
         // Headline totals span every cost-aware provider, including
         // Google AI (Gemini + AntiGravity): AntiGravity usage is now
@@ -809,102 +824,79 @@ private struct CombinedTotalsRow: View {
         // two peak scans over the combined daily history — all of it derived
         // once per cost refresh in Core rather than once per render pass here.
         let totals = costService.totals(of: visibleCostProviders)
-        GeometryReader { geometry in
-            let spacing = density.interSectionSpacing
-            let availableWidth = max(0, geometry.size.width - spacing)
-            let columnWidth = availableWidth / 2
-
-            HStack(alignment: .top, spacing: spacing) {
-                VStack(alignment: .leading, spacing: 8) {
-                HStack(alignment: .firstTextBaseline) {
-                    Text("Cost")
-                        .font(.system(size: density.bucketTitleFontSize, weight: .semibold))
-                    Spacer()
-                    if let lastRefreshed = costService.lastRefreshedAt {
-                        Text(ResetCountdownFormatter.updatedAgo(from: lastRefreshed, now: Date()))
-                            .font(.system(size: max(9, density.subtitleFontSize - 1)))
-                            .foregroundStyle(.tertiary)
-                    }
-                    if costService.isRefreshing {
-                        ProgressView()
-                            .controlSize(.small)
-                            .frame(width: 12, height: 12)
-                    }
-                    BorderlessIconButton(systemImage: "arrow.clockwise", help: "Refresh cost data") {
-                        environment.refreshCostUsage()
-                    }
-                    .disabled(costService.isRefreshing)
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(alignment: .firstTextBaseline) {
+                Text("Cost")
+                    .font(.system(size: density.bucketTitleFontSize, weight: .semibold))
+                Spacer()
+                if let lastRefreshed = costService.lastRefreshedAt {
+                    Text(ResetCountdownFormatter.updatedAgo(from: lastRefreshed, now: Date()))
+                        .font(.system(size: max(9, density.subtitleFontSize - 1)))
+                        .foregroundStyle(.tertiary)
                 }
-                    // 4 × 3 summary: durable all-time/peak context first,
-                    // followed by matching cost and token timeframes. The
-                    // flexible gaps use the full height shared with Status,
-                    // instead of leaving one empty band below the third row.
-                    VStack(alignment: .leading, spacing: 0) {
-                        HStack(alignment: .top, spacing: 0) {
-                            metric(label: "TOTAL COST", value: formatCost(totals.allTimeCostUSD), highlight: true)
-                            divider
-                            metric(label: "TOTAL TOK", value: formatTokens(totals.allTimeTokens), highlight: true)
-                            divider
-                            metric(label: "PEAK DAY", value: formatCost(totals.peakDayCostUSD))
-                            divider
-                            metric(label: "PEAK TOK DAY", value: formatTokens(totals.peakDayTokens))
-                        }
-                        Spacer(minLength: 8)
-                        HStack(alignment: .top, spacing: 0) {
-                            metric(label: "TODAY", value: formatCost(totals.todayCostUSD))
-                            divider
-                            metric(label: "YESTERDAY", value: formatCost(totals.yesterdayCostUSD))
-                            divider
-                            metric(label: "7-DAY", value: formatCost(totals.last7DaysCostUSD))
-                            divider
-                            metric(label: "30-DAY", value: formatCost(totals.last30DaysCostUSD))
-                        }
-                        Spacer(minLength: 8)
-                        HStack(alignment: .top, spacing: 0) {
-                            metric(label: "TODAY TOK", value: formatTokens(totals.todayTokens))
-                            divider
-                            metric(label: "YESTERDAY TOK", value: formatTokens(totals.yesterdayTokens))
-                            divider
-                            metric(label: "7-DAY TOK", value: formatTokens(totals.last7DaysTokens))
-                            divider
-                            metric(label: "30-DAY TOK", value: formatTokens(totals.last30DaysTokens))
-                        }
-                    }
-                    .frame(maxHeight: .infinity)
+                if costService.isRefreshing {
+                    ProgressView()
+                        .controlSize(.small)
+                        .frame(width: 12, height: 12)
                 }
-                .padding(density.cardPadding)
-                .frame(
-                    minWidth: columnWidth,
-                    idealWidth: columnWidth,
-                    maxWidth: columnWidth,
-                    minHeight: density.overviewSummaryHeight,
-                    idealHeight: density.overviewSummaryHeight,
-                    maxHeight: density.overviewSummaryHeight,
-                    alignment: .topLeading
-                )
-                .background(
-                    RoundedRectangle(cornerRadius: density.cardCornerRadius, style: .continuous)
-                        .fill(.background.tertiary.opacity(0.6))
-                )
-                .overlay(
-                    RoundedRectangle(cornerRadius: density.cardCornerRadius, style: .continuous)
-                        .stroke(.separator.opacity(0.4), lineWidth: 0.5)
-                )
-
-                OverviewStatusSummaryCard(
-                    density: density,
-                    minHeight: density.overviewSummaryHeight,
-                    tools: settingsStore.settings.visibleCoreProviderList
-                )
-                    .frame(
-                        minWidth: columnWidth,
-                        idealWidth: columnWidth,
-                        maxWidth: columnWidth,
-                        alignment: .topLeading
-                    )
+                BorderlessIconButton(systemImage: "arrow.clockwise", help: "Refresh cost data") {
+                    environment.refreshCostUsage()
+                }
+                .disabled(costService.isRefreshing)
             }
+            // 4 × 3 summary: durable all-time/peak context first, followed by
+            // matching cost and token timeframes. The flexible gaps use the
+            // full pinned height, instead of leaving one empty band below the
+            // third row.
+            VStack(alignment: .leading, spacing: 0) {
+                HStack(alignment: .top, spacing: 0) {
+                    metric(label: "TOTAL COST", value: formatCost(totals.allTimeCostUSD), highlight: true)
+                    divider
+                    metric(label: "TOTAL TOK", value: formatTokens(totals.allTimeTokens), highlight: true)
+                    divider
+                    metric(label: "PEAK DAY", value: formatCost(totals.peakDayCostUSD))
+                    divider
+                    metric(label: "PEAK TOK DAY", value: formatTokens(totals.peakDayTokens))
+                }
+                Spacer(minLength: 8)
+                HStack(alignment: .top, spacing: 0) {
+                    metric(label: "TODAY", value: formatCost(totals.todayCostUSD))
+                    divider
+                    metric(label: "YESTERDAY", value: formatCost(totals.yesterdayCostUSD))
+                    divider
+                    metric(label: "7-DAY", value: formatCost(totals.last7DaysCostUSD))
+                    divider
+                    metric(label: "30-DAY", value: formatCost(totals.last30DaysCostUSD))
+                }
+                Spacer(minLength: 8)
+                HStack(alignment: .top, spacing: 0) {
+                    metric(label: "TODAY TOK", value: formatTokens(totals.todayTokens))
+                    divider
+                    metric(label: "YESTERDAY TOK", value: formatTokens(totals.yesterdayTokens))
+                    divider
+                    metric(label: "7-DAY TOK", value: formatTokens(totals.last7DaysTokens))
+                    divider
+                    metric(label: "30-DAY TOK", value: formatTokens(totals.last30DaysTokens))
+                }
+            }
+            .frame(maxHeight: .infinity)
         }
-        .frame(height: density.overviewSummaryHeight)
+        .padding(density.cardPadding)
+        .frame(
+            maxWidth: .infinity,
+            minHeight: density.overviewSummaryHeight,
+            idealHeight: density.overviewSummaryHeight,
+            maxHeight: density.overviewSummaryHeight,
+            alignment: .topLeading
+        )
+        .background(
+            RoundedRectangle(cornerRadius: density.cardCornerRadius, style: .continuous)
+                .fill(.background.tertiary.opacity(0.6))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: density.cardCornerRadius, style: .continuous)
+                .stroke(.separator.opacity(0.4), lineWidth: 0.5)
+        )
     }
 
     private var divider: some View {
@@ -954,6 +946,12 @@ private struct CombinedTotalsRow: View {
     }
 }
 
+/// The Overview's live provider-status grid — the right half of the old header
+/// row, now an arrangeable module.
+///
+/// Pinned to `minHeight` rather than an exact height so it matches the cost
+/// summary beside it at any density but can still grow rather than clip if the
+/// user has enough providers visible to need a third row of tiles.
 private struct OverviewStatusSummaryCard: View {
     let density: Theme.Density
     let minHeight: CGFloat
@@ -1428,7 +1426,7 @@ private struct ProviderDetailView: View {
             PageLayoutColumns(
                 page: page,
                 descriptors: descriptors,
-                config: resolved,
+                arrangement: resolved,
                 // On `auto` the columns keep the exact clamped narrow-left
                 // widths they have always had. The ratio presets take over in
                 // the other two modes — including `compact`, where the ratio
@@ -1551,9 +1549,9 @@ private struct ProviderPageModule: View {
                     .padding(.vertical, 24)
                     .frame(maxWidth: .infinity)
             }
-        case .overviewQuota, .overviewQuotaHistoryAll, .overviewCostAll,
-             .overviewCost, .overviewModelRanking, .overviewYearHeatmap,
-             .overviewActivityHeatmap:
+        case .overviewCostSummary, .overviewStatusSummary, .overviewQuota,
+             .overviewQuotaHistoryAll, .overviewCostAll, .overviewCost,
+             .overviewModelRanking, .overviewYearHeatmap, .overviewActivityHeatmap:
             // Overview families. `PageModuleCatalog` never puts them on a
             // provider page, and a stale identifier is dropped before it gets
             // here, so this is unreachable rather than a fallback.

--- a/Sources/VibeBarApp/Views/QuotaGroupCard.swift
+++ b/Sources/VibeBarApp/Views/QuotaGroupCard.swift
@@ -325,11 +325,36 @@ struct QuotaGroupCard: View {
                     title: module.title,
                     buckets: module.groupBuckets
                 ),
+                fillPointsByBucket: fillPointsByBucket(
+                    accountId: accountId,
+                    buckets: module.groupBuckets
+                ),
                 density: density,
                 isEmbedded: true
             )
             .equatable()
         }
+    }
+
+    /// The chart's fill lanes, read here instead of inside the chart.
+    ///
+    /// This card already observes `QuotaService`, so pulling the lanes out here
+    /// costs nothing extra — while an `@EnvironmentObject` read *inside* the
+    /// `.equatable()` chart invalidated it directly on every service publish,
+    /// straight past the diff that is supposed to keep a refresh from
+    /// re-segmenting thousands of marks.
+    private func fillPointsByBucket(
+        accountId: String,
+        buckets: [QuotaBucket]
+    ) -> [String: [FillTimelinePoint]] {
+        var lanes: [String: [FillTimelinePoint]] = [:]
+        for bucket in buckets {
+            let key = SubscriptionHistoryKey(accountId: accountId, bucketId: bucket.id)
+            if let points = quotaService.observationsByAccountBucket[key] {
+                lanes[bucket.id] = points
+            }
+        }
+        return lanes
     }
 
     // MARK: - Rows

--- a/Sources/VibeBarApp/Views/QuotaHistoryChartView.swift
+++ b/Sources/VibeBarApp/Views/QuotaHistoryChartView.swift
@@ -254,7 +254,7 @@ struct QuotaHistoryChartView: View, Equatable {
     @State private var miniSegments: [[QuotaHistorySample]] = []
     @State private var window: ChartTimeWindow?
     @State private var windowKey: String?
-    @State private var initialSpan: TimeInterval = 24 * 3_600
+    @State private var initialSpan: TimeInterval = QuotaHistoryChartView.defaultInitialSpan
     @State private var hoverDate: Date?
     @State private var panBase: ChartTimeWindow?
     @State private var magnifyBase: ChartTimeWindow?
@@ -1133,7 +1133,7 @@ struct QuotaHistoryChartView: View, Equatable {
         )
 
         let minimumSpan = minimumSpan(for: primary)
-        initialSpan = initialSpan(for: primary)
+        initialSpan = Self.defaultInitialSpan
 
         // A different set of quotas gets a fresh window: buckets are sampled at
         // the same instants, so their domains can match to the second while the
@@ -1209,12 +1209,14 @@ struct QuotaHistoryChartView: View, Equatable {
         return min(max(TimeInterval(windowSeconds) / 5, 3_600), 12 * 3_600)
     }
 
-    private func initialSpan(for bucket: QuotaBucket) -> TimeInterval {
-        guard let windowSeconds = bucket.rawWindowSeconds, windowSeconds > 0 else {
-            return 7 * 86_400
-        }
-        return windowSeconds <= 6 * 3_600 ? 24 * 3_600 : 7 * 86_400
-    }
+    /// Opening zoom, one day for every group regardless of its shortest window.
+    /// A weekly quota used to open on all seven days, which answers the wrong
+    /// question first: a week of samples squeezed into the card's width flattens
+    /// the recent movement the chart is opened to read. Zooming out is one
+    /// gesture, and double-tap comes back here.
+    ///
+    /// Never below `minimumSpan(for:)`, which tops out at half a day.
+    private static let defaultInitialSpan: TimeInterval = 24 * 3_600
 
     // MARK: - Mark shaping
 

--- a/Sources/VibeBarApp/Views/QuotaHistoryChartView.swift
+++ b/Sources/VibeBarApp/Views/QuotaHistoryChartView.swift
@@ -200,10 +200,11 @@ private struct QuotaSeriesSignature: Equatable {
 /// so the pace rows can re-read the wall clock. Every tick re-proposes this
 /// view; without `.equatable()` each tick would re-segment, re-clip and
 /// re-thin thousands of marks and could land in the middle of a pan. The
-/// comparison covers exactly the inputs that change what is drawn — the
-/// `@State`/`@EnvironmentObject` storage is deliberately excluded, because
-/// those invalidate the view through their own dependency, not through the
-/// parent's diff.
+/// comparison covers exactly the inputs that change what is drawn, which is
+/// why every one of them is a plain `let`: the `@State` storage is excluded
+/// because it invalidates through its own dependency, and this view holds no
+/// `@EnvironmentObject` at all — an environment read here would bypass the
+/// diff entirely and re-run the body on every unrelated service publish.
 ///
 /// The other half of that contract: **this view must never read the current
 /// time**. There is no `now` parameter and no `Date()` anywhere in it — every
@@ -213,6 +214,17 @@ struct QuotaHistoryChartView: View, Equatable {
     let tool: ToolType
     let accountId: String
     let group: QuotaBucketGroup
+    /// Recorded fill observations per bucket id, handed down as plain values.
+    ///
+    /// This used to be read from `QuotaService` through an
+    /// `@EnvironmentObject` in here, which quietly defeated the `.equatable()`
+    /// the parent wraps this view in: an environment object invalidates the
+    /// views that read it *directly*, so every publish from the service — and a
+    /// refresh publishes repeatedly — re-ran this body and re-segmented every
+    /// lane, `==` or no `==`. The parent already observes the service, so it
+    /// reads the lanes and passes them in; comparing them is nearly free
+    /// because unchanged lanes are the same array buffer.
+    let fillPointsByBucket: [String: [FillTimelinePoint]]
     let density: Theme.Density
     /// Set when a page shows more than one of these charts for *different
     /// products* and "Quota history" alone would not say whose.
@@ -225,12 +237,11 @@ struct QuotaHistoryChartView: View, Equatable {
     /// like the "Reset history" strip it sits beside.
     var isEmbedded: Bool = false
 
-    @EnvironmentObject var quotaService: QuotaService
-
     static func == (lhs: QuotaHistoryChartView, rhs: QuotaHistoryChartView) -> Bool {
         lhs.tool == rhs.tool
             && lhs.accountId == rhs.accountId
             && lhs.group == rhs.group
+            && lhs.fillPointsByBucket == rhs.fillPointsByBucket
             && lhs.density == rhs.density
             && lhs.titleOverride == rhs.titleOverride
             && lhs.showsGroupTitle == rhs.showsGroupTitle
@@ -1036,8 +1047,7 @@ struct QuotaHistoryChartView: View, Equatable {
     )
 
     private func fillPoints(bucketId: String) -> [FillTimelinePoint] {
-        let key = SubscriptionHistoryKey(accountId: accountId, bucketId: bucketId)
-        return quotaService.observationsByAccountBucket[key] ?? []
+        fillPointsByBucket[bucketId] ?? []
     }
 
     /// Account, group, and the shape of every bucket's observed fill lane.

--- a/Sources/VibeBarApp/Views/SettingsView.swift
+++ b/Sources/VibeBarApp/Views/SettingsView.swift
@@ -529,9 +529,7 @@ struct SettingsView: View {
                         MiscProviderSettingsSection(instance: instance)
                     } else {
                         settingsSection("Misc Provider") {
-                            Text("Select a provider from the sidebar. Hidden providers keep their saved setup and credentials.")
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
+                            MiscProviderLandingView()
                         }
                     }
                     }

--- a/Sources/VibeBarApp/Views/SettingsView.swift
+++ b/Sources/VibeBarApp/Views/SettingsView.swift
@@ -754,6 +754,13 @@ struct SettingsView: View {
             Text(settingsStore.settings.popoverDensity.detail)
                 .font(.caption2)
                 .foregroundStyle(.tertiary)
+            Picker("Percent color", selection: menuBarColorBasisBinding()) {
+                ForEach(MenuBarColorBasis.allCases) { Text($0.label).tag($0) }
+            }
+            .pickerStyle(.segmented)
+            Text(settingsStore.settings.menuBarColorBasis.detail)
+                .font(.caption2)
+                .foregroundStyle(.tertiary)
             if !MenuBarFieldCatalog.fields(for: kind).isEmpty {
                 Text("Fields")
                     .font(.caption)
@@ -992,6 +999,13 @@ struct SettingsView: View {
                 item.layout = value
                 settingsStore.settings.setMenuBarItem(item)
             }
+        )
+    }
+
+    private func menuBarColorBasisBinding() -> Binding<MenuBarColorBasis> {
+        Binding(
+            get: { settingsStore.settings.menuBarColorBasis },
+            set: { settingsStore.settings.menuBarColorBasis = $0 }
         )
     }
 

--- a/Sources/VibeBarCore/Adapters/AlibabaQuotaAdapter.swift
+++ b/Sources/VibeBarCore/Adapters/AlibabaQuotaAdapter.swift
@@ -106,7 +106,11 @@ public struct AlibabaQuotaAdapter: QuotaAdapter {
         guard !cookieResolutions.isEmpty else {
             throw QuotaError.noCredential
         }
-        let results = await MiscQuotaAggregator.gatherSlotResults(cookieResolutions) { resolution in
+        let results = await MiscCookieAutoImporter.shared.gatherSlotResults(
+            spec: AlibabaQuotaAdapter.cookieSpec,
+            account: account,
+            resolutions: cookieResolutions
+        ) { resolution in
             try await self.fetchViaCookieSlot(
                 resolution: resolution,
                 regions: preferred,

--- a/Sources/VibeBarCore/Adapters/AlibabaTokenPlanQuotaAdapter.swift
+++ b/Sources/VibeBarCore/Adapters/AlibabaTokenPlanQuotaAdapter.swift
@@ -86,7 +86,11 @@ public struct AlibabaTokenPlanQuotaAdapter: QuotaAdapter {
             throw QuotaError.noCredential
         }
 
-        let results = await MiscQuotaAggregator.gatherSlotResults(cookieResolutions) { resolution in
+        let results = await MiscCookieAutoImporter.shared.gatherSlotResults(
+            spec: AlibabaTokenPlanQuotaAdapter.cookieSpec,
+            account: account,
+            resolutions: cookieResolutions
+        ) { resolution in
             try await self.fetchViaCookieSlot(
                 resolution: resolution,
                 variant: variant,

--- a/Sources/VibeBarCore/Adapters/BaiduQianfanQuotaAdapter.swift
+++ b/Sources/VibeBarCore/Adapters/BaiduQianfanQuotaAdapter.swift
@@ -63,7 +63,11 @@ public struct BaiduQianfanQuotaAdapter: QuotaAdapter {
         guard !resolutions.isEmpty else { throw QuotaError.noCredential }
 
         let queriedAt = now()
-        let results = await MiscQuotaAggregator.gatherSlotResults(resolutions) { resolution in
+        let results = await MiscCookieAutoImporter.shared.gatherSlotResults(
+            spec: BaiduQianfanQuotaAdapter.cookieSpec,
+            account: account,
+            resolutions: resolutions
+        ) { resolution in
             try await self.fetchOneSlot(resolution, account: account, queriedAt: queriedAt)
         }
         return MiscQuotaAggregator.aggregate(

--- a/Sources/VibeBarCore/Adapters/CursorQuotaAdapter.swift
+++ b/Sources/VibeBarCore/Adapters/CursorQuotaAdapter.swift
@@ -65,7 +65,11 @@ public struct CursorQuotaAdapter: QuotaAdapter {
         guard !resolutions.isEmpty else { throw QuotaError.noCredential }
 
         let queriedAt = now()
-        let results = await MiscQuotaAggregator.gatherSlotResults(resolutions) { resolution in
+        let results = await MiscCookieAutoImporter.shared.gatherSlotResults(
+            spec: CursorQuotaAdapter.cookieSpec,
+            account: account,
+            resolutions: resolutions
+        ) { resolution in
             try await self.fetchOneSlot(resolution, account: account, queriedAt: queriedAt)
         }
         return MiscQuotaAggregator.aggregate(

--- a/Sources/VibeBarCore/Adapters/IFlyTekQuotaAdapter.swift
+++ b/Sources/VibeBarCore/Adapters/IFlyTekQuotaAdapter.swift
@@ -63,7 +63,11 @@ public struct IFlyTekQuotaAdapter: QuotaAdapter {
         guard !resolutions.isEmpty else { throw QuotaError.noCredential }
 
         let queriedAt = now()
-        let results = await MiscQuotaAggregator.gatherSlotResults(resolutions) { resolution in
+        let results = await MiscCookieAutoImporter.shared.gatherSlotResults(
+            spec: IFlyTekQuotaAdapter.cookieSpec,
+            account: account,
+            resolutions: resolutions
+        ) { resolution in
             try await self.fetchOneSlot(resolution, account: account, queriedAt: queriedAt)
         }
         return MiscQuotaAggregator.aggregate(

--- a/Sources/VibeBarCore/Adapters/KimiQuotaAdapter.swift
+++ b/Sources/VibeBarCore/Adapters/KimiQuotaAdapter.swift
@@ -45,7 +45,11 @@ public struct KimiQuotaAdapter: QuotaAdapter {
         guard !resolutions.isEmpty else { throw QuotaError.noCredential }
 
         let queriedAt = now()
-        let results = await MiscQuotaAggregator.gatherSlotResults(resolutions) { resolution in
+        let results = await MiscCookieAutoImporter.shared.gatherSlotResults(
+            spec: KimiQuotaAdapter.cookieSpec,
+            account: account,
+            resolutions: resolutions
+        ) { resolution in
             try await self.fetchOneSlot(resolution, account: account, queriedAt: queriedAt)
         }
         return MiscQuotaAggregator.aggregate(

--- a/Sources/VibeBarCore/Adapters/MimoQuotaAdapter.swift
+++ b/Sources/VibeBarCore/Adapters/MimoQuotaAdapter.swift
@@ -62,7 +62,11 @@ public struct MimoQuotaAdapter: QuotaAdapter {
         guard !resolutions.isEmpty else { throw QuotaError.noCredential }
 
         let queriedAt = now()
-        let results = await MiscQuotaAggregator.gatherSlotResults(resolutions) { resolution in
+        let results = await MiscCookieAutoImporter.shared.gatherSlotResults(
+            spec: MimoQuotaAdapter.cookieSpec,
+            account: account,
+            resolutions: resolutions
+        ) { resolution in
             try await self.fetchOneSlot(resolution, account: account, queriedAt: queriedAt)
         }
         return MiscQuotaAggregator.aggregate(

--- a/Sources/VibeBarCore/Adapters/OllamaQuotaAdapter.swift
+++ b/Sources/VibeBarCore/Adapters/OllamaQuotaAdapter.swift
@@ -31,7 +31,11 @@ public struct OllamaQuotaAdapter: QuotaAdapter {
         guard !resolutions.isEmpty else { throw QuotaError.noCredential }
 
         let queriedAt = now()
-        let results = await MiscQuotaAggregator.gatherSlotResults(resolutions) { resolution in
+        let results = await MiscCookieAutoImporter.shared.gatherSlotResults(
+            spec: Self.cookieSpec,
+            account: account,
+            resolutions: resolutions
+        ) { resolution in
             try await self.fetchOneSlot(resolution, account: account, queriedAt: queriedAt)
         }
         return MiscQuotaAggregator.aggregate(

--- a/Sources/VibeBarCore/Adapters/OpenCodeGoQuotaAdapter.swift
+++ b/Sources/VibeBarCore/Adapters/OpenCodeGoQuotaAdapter.swift
@@ -35,7 +35,11 @@ public struct OpenCodeGoQuotaAdapter: QuotaAdapter {
         guard !resolutions.isEmpty else { throw QuotaError.noCredential }
 
         let queriedAt = now()
-        let results = await MiscQuotaAggregator.gatherSlotResults(resolutions) { resolution in
+        let results = await MiscCookieAutoImporter.shared.gatherSlotResults(
+            spec: Self.cookieSpec,
+            account: account,
+            resolutions: resolutions
+        ) { resolution in
             try await self.fetchOneSlot(resolution, account: account, queriedAt: queriedAt)
         }
         return MiscQuotaAggregator.aggregate(

--- a/Sources/VibeBarCore/Adapters/TencentHunyuanQuotaAdapter.swift
+++ b/Sources/VibeBarCore/Adapters/TencentHunyuanQuotaAdapter.swift
@@ -66,7 +66,11 @@ public struct TencentHunyuanQuotaAdapter: QuotaAdapter {
         guard !resolutions.isEmpty else { throw QuotaError.noCredential }
 
         let queriedAt = now()
-        let results = await MiscQuotaAggregator.gatherSlotResults(resolutions) { resolution in
+        let results = await MiscCookieAutoImporter.shared.gatherSlotResults(
+            spec: TencentHunyuanQuotaAdapter.cookieSpec,
+            account: account,
+            resolutions: resolutions
+        ) { resolution in
             try await self.fetchOneSlot(resolution, account: account, queriedAt: queriedAt)
         }
         return MiscQuotaAggregator.aggregate(

--- a/Sources/VibeBarCore/Adapters/TencentTokenPlanQuotaAdapter.swift
+++ b/Sources/VibeBarCore/Adapters/TencentTokenPlanQuotaAdapter.swift
@@ -70,7 +70,11 @@ public struct TencentTokenPlanQuotaAdapter: QuotaAdapter {
         guard !resolutions.isEmpty else { throw QuotaError.noCredential }
 
         let queriedAt = now()
-        let results = await MiscQuotaAggregator.gatherSlotResults(resolutions) { resolution in
+        let results = await MiscCookieAutoImporter.shared.gatherSlotResults(
+            spec: TencentTokenPlanQuotaAdapter.cookieSpec,
+            account: account,
+            resolutions: resolutions
+        ) { resolution in
             try await self.fetchOneSlot(resolution, variant: variant, account: account, queriedAt: queriedAt)
         }
         return MiscQuotaAggregator.aggregate(

--- a/Sources/VibeBarCore/Adapters/VolcengineQuotaAdapter.swift
+++ b/Sources/VibeBarCore/Adapters/VolcengineQuotaAdapter.swift
@@ -60,7 +60,11 @@ public struct VolcengineQuotaAdapter: QuotaAdapter {
         guard !resolutions.isEmpty else { throw QuotaError.noCredential }
 
         let queriedAt = now()
-        let results = await MiscQuotaAggregator.gatherSlotResults(resolutions) { resolution in
+        let results = await MiscCookieAutoImporter.shared.gatherSlotResults(
+            spec: VolcengineQuotaAdapter.cookieSpec,
+            account: account,
+            resolutions: resolutions
+        ) { resolution in
             try await self.fetchOneSlot(resolution, account: account, queriedAt: queriedAt)
         }
         return MiscQuotaAggregator.aggregate(

--- a/Sources/VibeBarCore/BrowserCookies/BrowserCookieImportOrder.swift
+++ b/Sources/VibeBarCore/BrowserCookies/BrowserCookieImportOrder.swift
@@ -11,9 +11,18 @@ extension Array where Element == Browser {
     /// Filter to browsers that are worth attempting a cookie read
     /// against right now — installed, with profile data on disk, and
     /// not in `BrowserCookieAccessGate`'s cooldown window.
+    ///
+    /// `warmKeychainBrowsers` carries the `Browser.rawValue`s whose
+    /// Safe Storage key SweetCookieKit already holds in this process
+    /// (see `MiscCookieResolver.markKeychainWarm`). Those skip the gate
+    /// on a silent read, because the gate's veto there is a
+    /// false positive: its preflight reports "would need interaction"
+    /// while the cached key would in fact have decrypted the jar
+    /// without any prompt.
     public func cookieImportCandidates(
         using detection: BrowserDetection,
-        allowKeychainPrompt: Bool = false
+        allowKeychainPrompt: Bool = false,
+        warmKeychainBrowsers: Set<String> = []
     ) -> [Browser] {
         let candidates = filter { browser in
             if !allowKeychainPrompt,
@@ -35,7 +44,10 @@ extension Array where Element == Browser {
             }
             return scoped
         }
-        return candidates.filter { BrowserCookieAccessGate.shouldAttempt($0) }
+        return candidates.filter { browser in
+            warmKeychainBrowsers.contains(browser.rawValue)
+                || BrowserCookieAccessGate.shouldAttempt(browser)
+        }
     }
 
     /// Filter to browsers with usable profile data, ignoring the

--- a/Sources/VibeBarCore/BrowserCookies/MiscCookieAutoImporter.swift
+++ b/Sources/VibeBarCore/BrowserCookies/MiscCookieAutoImporter.swift
@@ -1,0 +1,145 @@
+import Foundation
+
+/// Opt-in "re-import once, then retry once" wrapper around a misc
+/// provider's per-slot quota fetch.
+///
+/// This is the misc-provider analogue of `ClaudeQuotaAdapter`'s
+/// `reimportWebCookieOnStale` hook: a cookie jar that has expired shows
+/// up as `QuotaError.needsLogin`, and the browser the user is signed
+/// into usually already holds a fresh one. Rather than leaving the card
+/// on "Needs re-login" until the user notices, pull the fresh session in
+/// and try the request again.
+///
+/// Three properties are deliberate:
+///
+/// - **Off by default.** Gated on `AppSettings.miscCookieAutoImportEnabled`,
+///   which a settings file written by an older build decodes to `false`.
+/// - **Never prompts.** The re-import runs with
+///   `allowKeychainPrompt: false`; a browser whose Safe Storage key
+///   isn't already unlocked in this process is simply skipped.
+/// - **Exactly one retry.** A slot that fails, gets a fresh header, and
+///   fails again surfaces the original credential error. No loops.
+///
+/// The hooks are injectable so the gating and merge logic can be tested
+/// without a Keychain, a browser, or a network.
+public struct MiscCookieAutoImporter: Sendable {
+    /// The instance the adapters use.
+    public static let shared = MiscCookieAutoImporter()
+
+    private let isEnabled: @Sendable () -> Bool
+    private let reimport: @Sendable (MiscCookieResolver.Spec, String) async -> Bool
+    private let resolve: @Sendable (MiscCookieResolver.Spec, String) -> [MiscCookieResolver.Resolution]
+
+    public init(
+        isEnabled: (@Sendable () -> Bool)? = nil,
+        reimport: (@Sendable (MiscCookieResolver.Spec, String) async -> Bool)? = nil,
+        resolve: (@Sendable (MiscCookieResolver.Spec, String) -> [MiscCookieResolver.Resolution])? = nil
+    ) {
+        self.isEnabled = isEnabled ?? Self.defaultIsEnabled
+        self.reimport = reimport ?? Self.defaultReimport
+        self.resolve = resolve ?? Self.defaultResolve
+    }
+
+    /// Fan `fetch` out across `resolutions`, and when a slot comes back
+    /// in a credential state (`needsLogin` / `noCredential`), optionally
+    /// re-import that provider's cookies from the browser and retry the
+    /// affected slots once.
+    ///
+    /// Drop-in replacement for `MiscQuotaAggregator.gatherSlotResults`;
+    /// the returned results go straight into
+    /// `MiscQuotaAggregator.aggregate` exactly as before.
+    public func gatherSlotResults(
+        spec: MiscCookieResolver.Spec,
+        account: AccountIdentity,
+        resolutions: [MiscCookieResolver.Resolution],
+        fetch: @Sendable @escaping (MiscCookieResolver.Resolution) async throws -> AccountQuota
+    ) async -> [MiscQuotaAggregator.SlotResult] {
+        let first = await MiscQuotaAggregator.gatherSlotResults(resolutions, fetch: fetch)
+
+        let staleSlotIDs = Set(first.compactMap { result -> UUID? in
+            guard case let .failure(error) = result.outcome, error.isCredentialState else { return nil }
+            return result.slotID
+        })
+        // Nothing expired, or the user hasn't opted in. Checking the
+        // setting last keeps the happy path free of a settings read.
+        guard !staleSlotIDs.isEmpty, isEnabled() else { return first }
+
+        let instanceID = AccountStore.miscInstanceID(
+            fromAccountID: account.id,
+            fallbackTool: spec.tool
+        )
+        guard await reimport(spec, instanceID) else { return first }
+
+        // Retry only the slots we actually tried and that actually
+        // changed. Restricting to the original slot IDs also preserves
+        // any adapter-side filtering of the resolution list (Ollama
+        // drops slots without a recognised session cookie) — a slot the
+        // adapter excluded was never in `resolutions` and stays out.
+        let previousHeaders = Dictionary(
+            resolutions.compactMap { resolution -> (UUID, String)? in
+                guard let slotID = resolution.slotID else { return nil }
+                return (slotID, resolution.header)
+            },
+            uniquingKeysWith: { first, _ in first }
+        )
+        let retryTargets = resolve(spec, instanceID).filter { resolution in
+            guard let slotID = resolution.slotID, staleSlotIDs.contains(slotID) else { return false }
+            return previousHeaders[slotID] != resolution.header
+        }
+        guard !retryTargets.isEmpty else { return first }
+
+        let retried = await MiscQuotaAggregator.gatherSlotResults(retryTargets, fetch: fetch)
+        return Self.merge(original: first, retried: retried)
+    }
+
+    /// Replace each original result with its retried counterpart,
+    /// keeping the original ordering and any slot that wasn't retried.
+    static func merge(
+        original: [MiscQuotaAggregator.SlotResult],
+        retried: [MiscQuotaAggregator.SlotResult]
+    ) -> [MiscQuotaAggregator.SlotResult] {
+        guard !retried.isEmpty else { return original }
+        var bySlotID: [UUID: MiscQuotaAggregator.SlotResult] = [:]
+        for result in retried {
+            guard let slotID = result.slotID else { continue }
+            bySlotID[slotID] = result
+        }
+        return original.map { result in
+            guard let slotID = result.slotID, let replacement = bySlotID[slotID] else { return result }
+            return replacement
+        }
+    }
+
+    // MARK: - Defaults
+
+    @Sendable
+    private static func defaultIsEnabled() -> Bool {
+        let settings = (try? VibeBarLocalStore.readJSON(
+            AppSettings.self,
+            from: VibeBarLocalStore.settingsURL
+        )) ?? .default
+        return settings.miscCookieAutoImportEnabled
+    }
+
+    /// Offloaded to a detached task for the same reason
+    /// `ClaudeQuotaAdapter` does it: the browser read is SQLite plus
+    /// Keychain work and has no business running on the executor that
+    /// is driving the quota fetch.
+    @Sendable
+    private static func defaultReimport(
+        _ spec: MiscCookieResolver.Spec,
+        _ instanceID: String
+    ) async -> Bool {
+        await Task.detached(priority: .utility) {
+            MiscCookieResolver.silentReimport(spec: spec, instanceID: instanceID)
+        }.value
+    }
+
+    @Sendable
+    private static func defaultResolve(
+        _ spec: MiscCookieResolver.Spec,
+        _ instanceID: String
+    ) -> [MiscCookieResolver.Resolution] {
+        MiscCookieResolver.resolveAll(for: spec, instanceID: instanceID)
+    }
+}

--- a/Sources/VibeBarCore/BrowserCookies/MiscCookieResolver.swift
+++ b/Sources/VibeBarCore/BrowserCookies/MiscCookieResolver.swift
@@ -1,4 +1,5 @@
 import Foundation
+import os.lock
 import SweetCookieKit
 
 /// Picks `Cookie:` headers for a misc-provider adapter at fetch time.
@@ -206,9 +207,251 @@ public enum MiscCookieResolver {
         appendBrowserImport(for: spec, instanceID: instanceID)
     }
 
+    // MARK: - Batch import
+
+    /// One provider instance to import cookies for.
+    public struct BatchImportTarget {
+        public let spec: Spec
+        public let instanceID: String
+
+        public init(spec: Spec, instanceID: String) {
+            self.spec = spec
+            self.instanceID = instanceID
+        }
+
+        public var tool: ToolType { spec.tool }
+    }
+
+    /// What happened for one target in a batch import.
+    public struct BatchImportOutcome {
+        public enum Result: Equatable {
+            /// A new (or refreshed) slot now holds a browser session.
+            case imported(sourceLabel: String)
+            /// The browsers we were allowed to read had no usable
+            /// session for this provider's domains.
+            case noSessionFound
+            /// The provider's source mode bans cookies entirely, so we
+            /// never looked.
+            case cookiesDisabled
+            /// A session was found but the Keychain write failed.
+            case saveFailed
+        }
+
+        public let tool: ToolType
+        public let instanceID: String
+        public let result: Result
+
+        public init(tool: ToolType, instanceID: String, result: Result) {
+            self.tool = tool
+            self.instanceID = instanceID
+            self.result = result
+        }
+    }
+
+    /// Import browser cookies for many provider instances in one pass.
+    ///
+    /// This is the "do all of them" version of `appendBrowserImport`,
+    /// and it exists for two reasons beyond saving the user twelve
+    /// clicks:
+    ///
+    /// 1. `BrowserDetection` caches its filesystem probes **per
+    ///    instance**, so building one per provider re-stats every
+    ///    browser profile twelve times over. One shared instance turns
+    ///    that into a single pass. (The Chromium "Safe Storage" key
+    ///    itself is cached per browser in a SweetCookieKit static, so
+    ///    the user sees at most one Keychain prompt per distinct
+    ///    Chromium browser regardless — but the shared
+    ///    `BrowserCookieClient` keeps the whole batch on one handle.)
+    /// 2. Targets are walked **sequentially**. Every append rewrites the
+    ///    same Keychain item through `VibeBarCredentialVault`, so
+    ///    parallel writes would just contend on the vault's lock and
+    ///    risk interleaved read-modify-write.
+    ///
+    /// The one-Chromium-browser-per-call prompt cap in
+    /// `cookieImportCandidates` still applies per target, which is what
+    /// keeps a batch from fanning out into a stack of password prompts.
+    public static func appendBrowserImports(
+        for targets: [BatchImportTarget]
+    ) -> [BatchImportOutcome] {
+        let context = BrowserImportContext()
+        return targets.map { target in
+            let settings = currentSettings(for: target.tool, instanceID: target.instanceID)
+            guard SlotFilter(settings: settings) != .none else {
+                return BatchImportOutcome(
+                    tool: target.tool,
+                    instanceID: target.instanceID,
+                    result: .cookiesDisabled
+                )
+            }
+            guard let imported = importFromBrowsers(
+                spec: target.spec,
+                settings: settings,
+                allowKeychainPrompt: true,
+                context: context
+            ) else {
+                return BatchImportOutcome(
+                    tool: target.tool,
+                    instanceID: target.instanceID,
+                    result: .noSessionFound
+                )
+            }
+            let slot = MiscCookieSlot(
+                cookieHeader: imported.header,
+                sourceLabel: imported.sourceLabel,
+                importedAt: Date(),
+                origin: .browserImport
+            )
+            guard MiscCookieSlotStore.append(
+                slot,
+                for: target.tool,
+                instanceID: target.instanceID
+            ) else {
+                return BatchImportOutcome(
+                    tool: target.tool,
+                    instanceID: target.instanceID,
+                    result: .saveFailed
+                )
+            }
+            return BatchImportOutcome(
+                tool: target.tool,
+                instanceID: target.instanceID,
+                result: .imported(sourceLabel: imported.sourceLabel)
+            )
+        }
+    }
+
+    // MARK: - Silent re-import
+
+    /// Refresh the provider's existing browser-origin slots from the
+    /// browser without ever prompting for the Keychain password.
+    ///
+    /// Used by `MiscCookieAutoImporter` when a fetch came back
+    /// `needsLogin`. Slots are replaced **in place** with origin
+    /// `.autoRefresh`; `origin == .manual` slots are left alone, the
+    /// same policy `HiddenCookieRefresher` follows — a cookie the user
+    /// pasted by hand is theirs to manage.
+    ///
+    /// Returns `true` when at least one slot's header actually changed,
+    /// which is the caller's signal that a retry is worth a round-trip.
+    @discardableResult
+    public static func silentReimport(spec: Spec, instanceID: String) -> Bool {
+        let settings = currentSettings(for: spec.tool, instanceID: instanceID)
+        guard SlotFilter(settings: settings) != .none else { return false }
+
+        let refreshable = MiscCookieSlotStore
+            .slots(for: spec.tool, instanceID: instanceID)
+            .filter { $0.origin != .manual }
+        guard !refreshable.isEmpty else { return false }
+
+        let sessions = browserSessions(
+            spec: spec,
+            settings: settings,
+            allowKeychainPrompt: false,
+            context: BrowserImportContext(),
+            maxSessions: nil
+        )
+        guard !sessions.isEmpty else { return false }
+
+        var unclaimed = sessions
+        var changed = false
+        for slot in refreshable {
+            // Prefer the browser session whose label matches the slot's
+            // — that's how a user with stacked work / personal profiles
+            // keeps each slot pointed at its own account. With exactly
+            // one refreshable slot and one session, fall back to taking
+            // that session so the common case still self-heals; the
+            // slot's `sourceLabel` is rewritten too, so if the browser
+            // has since switched accounts the Settings row says which
+            // profile the slot now follows rather than hiding it.
+            let matchIndex = unclaimed.firstIndex { $0.sourceLabel == slot.sourceLabel }
+                ?? (refreshable.count == 1 && unclaimed.count == 1 ? 0 : nil)
+            guard let matchIndex else { continue }
+            let session = unclaimed.remove(at: matchIndex)
+            guard session.header != slot.cookieHeader else { continue }
+            let ok = MiscCookieSlotStore.updateHeader(
+                slotID: slot.id,
+                for: spec.tool,
+                instanceID: instanceID,
+                header: session.header,
+                sourceLabel: session.sourceLabel,
+                importedAt: Date(),
+                origin: .autoRefresh
+            )
+            if ok {
+                changed = true
+                // Length + hash only. A cookie header is a live
+                // credential and never belongs in a log line.
+                SafeLog.info(
+                    "MiscCookieResolver auto re-import tool=\(spec.tool.rawValue) slot=\(slot.id.uuidString.prefix(8)) len=\(session.header.count) fp=\(headerFingerprint(session.header))"
+                )
+            }
+        }
+        // `MiscCookieSlotStore.updateHeader` posts its own change
+        // notification, which is what redraws the Settings slot list.
+        // No quota refresh is posted here: the caller is mid-fetch and
+        // retries with the fresh header itself.
+        return changed
+    }
+
+    // MARK: - Chromium Keychain warmth
+
+    /// Browsers whose Chromium "Safe Storage" key SweetCookieKit has
+    /// already decrypted in this process, courtesy of a user-initiated
+    /// import that was allowed to prompt.
+    ///
+    /// This exists to bridge a mismatch: SweetCookieKit caches that key
+    /// in a process-wide `[Browser: Data]` static, but
+    /// `BrowserCookieAccessGate`'s non-interactive preflight can still
+    /// report `interactionRequired` and install a 6-hour cooldown —
+    /// vetoing a silent read that would in fact have decrypted fine from
+    /// the cache. Once a browser is warm we ask for its records with
+    /// `allowKeychainPrompt: true`, which is the gate's own documented
+    /// bypass rather than a poke at its internals, and which cannot
+    /// actually surface a prompt while that browser's key is cached.
+    ///
+    /// Tracked per browser, not as one global flag, because the upstream
+    /// cache is per browser: Chrome being unlocked says nothing about
+    /// whether reading Brave would prompt.
+    private static let warmKeychainBrowsers = OSAllocatedUnfairLock<Set<String>>(initialState: [])
+
+    static func markKeychainWarm(_ browser: Browser) {
+        guard browser.usesKeychainForCookieDecryption else { return }
+        warmKeychainBrowsers.withLock { $0.insert(browser.rawValue) }
+    }
+
+    static func clearKeychainWarmth(_ browser: Browser) {
+        warmKeychainBrowsers.withLock { $0.remove(browser.rawValue) }
+    }
+
+    static var warmKeychainBrowserIDs: Set<String> {
+        warmKeychainBrowsers.withLock { $0 }
+    }
+
+    /// Test hook — process-global state has to be resettable between
+    /// cases or the suite's ordering starts to matter.
+    static func resetKeychainWarmthForTesting() {
+        warmKeychainBrowsers.withLock { $0.removeAll() }
+    }
+
     // MARK: - Internals
 
-    private struct BrowserImportResult {
+    /// Shared browser-access objects. Building one per import is the
+    /// wrong shape for a batch: `BrowserDetection`'s probe cache and
+    /// SweetCookieKit's decrypted-key state both live on the instance.
+    struct BrowserImportContext {
+        let detection: BrowserDetection
+        let client: BrowserCookieClient
+
+        init(
+            detection: BrowserDetection = BrowserDetection(),
+            client: BrowserCookieClient = BrowserCookieClient()
+        ) {
+            self.detection = detection
+            self.client = client
+        }
+    }
+
+    struct BrowserImportResult {
         let header: String
         let sourceLabel: String
     }
@@ -216,36 +459,71 @@ public enum MiscCookieResolver {
     private static func importFromBrowsers(
         spec: Spec,
         settings: MiscProviderSettings,
-        allowKeychainPrompt: Bool = false
+        allowKeychainPrompt: Bool = false,
+        context: BrowserImportContext = BrowserImportContext()
     ) -> BrowserImportResult? {
-        let detection = BrowserDetection()
+        browserSessions(
+            spec: spec,
+            settings: settings,
+            allowKeychainPrompt: allowKeychainPrompt,
+            context: context,
+            maxSessions: 1
+        ).first
+    }
+
+    /// Walk the candidate browsers and return every usable session for
+    /// `spec`'s domains.
+    ///
+    /// `maxSessions: 1` reproduces the single-import behaviour exactly —
+    /// stop at the first usable session so we never touch a browser we
+    /// didn't need to. Pass `nil` only when the caller genuinely needs
+    /// the full list (the silent re-import matches sessions to slots by
+    /// label).
+    private static func browserSessions(
+        spec: Spec,
+        settings: MiscProviderSettings,
+        allowKeychainPrompt: Bool,
+        context: BrowserImportContext,
+        maxSessions: Int?
+    ) -> [BrowserImportResult] {
         let preferred: [Browser]
         if let kind = settings.preferredBrowser {
             preferred = kind.sweetCookieKitBrowsers
         } else {
             preferred = spec.importOrder
         }
+        let warm = allowKeychainPrompt ? [] : warmKeychainBrowserIDs
         let candidates = preferred.cookieImportCandidates(
-            using: detection,
-            allowKeychainPrompt: allowKeychainPrompt
+            using: context.detection,
+            allowKeychainPrompt: allowKeychainPrompt,
+            warmKeychainBrowsers: warm
         )
-        guard !candidates.isEmpty else { return nil }
+        guard !candidates.isEmpty else { return [] }
 
         let query = BrowserCookieQuery(domains: spec.domains)
 
-        let client = BrowserCookieClient()
+        var collected: [BrowserImportResult] = []
         for browser in candidates {
+            let mayPrompt = allowKeychainPrompt || warm.contains(browser.rawValue)
             let records: [BrowserCookieStoreRecords]
             do {
-                records = try client.vibeBarRecords(
+                records = try context.client.vibeBarRecords(
                     matching: query,
                     in: browser,
-                    allowKeychainPrompt: allowKeychainPrompt,
+                    allowKeychainPrompt: mayPrompt,
                     logger: nil
                 )
             } catch {
                 BrowserCookieAccessGate.recordIfNeeded(error)
+                // A warm browser that suddenly refuses means the cached
+                // Safe Storage key is gone (keychain relocked, browser
+                // rotated it). Forget the warmth so we stop bypassing
+                // the gate and risking a prompt the user didn't ask for.
+                clearKeychainWarmth(browser)
                 continue
+            }
+            if allowKeychainPrompt, !records.isEmpty {
+                markKeychainWarm(browser)
             }
             for session in mergedSessions(from: records) {
                 let cookies = session.records
@@ -257,10 +535,23 @@ public enum MiscCookieResolver {
                 guard spec.requiredNames.isEmpty || !pairs.isEmpty else { continue }
                 let header = pairs.joined(separator: "; ")
                 guard !header.isEmpty, spec.hasRequiredCredential(in: header) else { continue }
-                return BrowserImportResult(header: header, sourceLabel: session.label)
+                collected.append(BrowserImportResult(header: header, sourceLabel: session.label))
+                if let maxSessions, collected.count >= maxSessions { return collected }
             }
         }
-        return nil
+        return collected
+    }
+
+    /// Hash a cookie header so a log line can say "did this change?"
+    /// without writing the secret anywhere. Same idiom as
+    /// `HiddenCookieRefresher`.
+    static func headerFingerprint(_ header: String) -> String {
+        guard !header.isEmpty else { return "empty" }
+        var hash: UInt64 = 5381
+        for byte in header.utf8 {
+            hash = ((hash << 5) &+ hash) &+ UInt64(byte)
+        }
+        return String(hash, radix: 16)
     }
 
     private struct BrowserSession {

--- a/Sources/VibeBarCore/BrowserCookies/MiscCookieSpecCatalog.swift
+++ b/Sources/VibeBarCore/BrowserCookies/MiscCookieSpecCatalog.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+/// `ToolType` → `MiscCookieResolver.Spec` index for the misc providers
+/// whose only credential is a browser cookie jar.
+///
+/// The specs themselves stay on the adapters (`…QuotaAdapter.cookieSpec`)
+/// — the domain list and cookie-name minimisation rules belong next to
+/// the code that talks to the provider. This catalog is only the index,
+/// and it exists because three callers need "the spec for this
+/// `ToolType`" rather than "Kimi's spec": the Settings rows, the
+/// all-providers batch browser import, and the silent re-import that
+/// runs when a stored jar goes stale.
+///
+/// The switch is exhaustive on purpose. A new `ToolType` case fails to
+/// compile here until it is classified as cookie-sourced or not, and
+/// `MiscCookieSpecCatalogTests` additionally asserts every misc-page
+/// provider is accounted for — a cookie provider that never made it
+/// into the catalog would silently drop out of the batch import.
+public enum MiscCookieSpecCatalog {
+    public static func spec(for tool: ToolType) -> MiscCookieResolver.Spec? {
+        switch tool {
+        case .alibaba:           return AlibabaQuotaAdapter.cookieSpec
+        case .alibabaTokenPlan:  return AlibabaTokenPlanQuotaAdapter.cookieSpec
+        case .baiduQianfan:      return BaiduQianfanQuotaAdapter.cookieSpec
+        case .cursor:            return CursorQuotaAdapter.cookieSpec
+        case .iflytek:           return IFlyTekQuotaAdapter.cookieSpec
+        case .kimi:              return KimiQuotaAdapter.cookieSpec
+        case .mimo:              return MimoQuotaAdapter.cookieSpec
+        case .ollama:            return OllamaQuotaAdapter.cookieSpec
+        case .openCodeGo:        return OpenCodeGoQuotaAdapter.cookieSpec
+        case .tencentHunyuan:    return TencentHunyuanQuotaAdapter.cookieSpec
+        case .tencentTokenPlan:  return TencentTokenPlanQuotaAdapter.cookieSpec
+        case .volcengine:        return VolcengineQuotaAdapter.cookieSpec
+
+        // Not cookie-sourced. API key / device login / AK-SK / local
+        // process probe providers, plus the primary and partial-primary
+        // families, which carry their own dedicated credential paths.
+        case .codex, .claude, .gemini, .antigravity, .grok,
+             .copilot, .zai, .minimax, .volcengineAgentPlan,
+             .kilo, .kiro, .openRouter, .warp:
+            return nil
+        }
+    }
+
+    public static func isCookieSourced(_ tool: ToolType) -> Bool {
+        spec(for: tool) != nil
+    }
+
+    /// Cookie-sourced providers in `ToolType.allCases` declaration
+    /// order, which is also the Misc page's default order.
+    public static var allCookieSourcedTools: [ToolType] {
+        ToolType.allCases.filter { isCookieSourced($0) }
+    }
+
+    public static var allSpecs: [MiscCookieResolver.Spec] {
+        allCookieSourcedTools.compactMap { spec(for: $0) }
+    }
+}

--- a/Sources/VibeBarCore/Credentials/SecureCookieHeaderStore.swift
+++ b/Sources/VibeBarCore/Credentials/SecureCookieHeaderStore.swift
@@ -135,7 +135,11 @@ public enum SecureCookieHeaderStore {
                 : .found(entry.cookieHeader)
         } catch KeychainStore.KeychainError.itemNotFound {
             cacheLock.lock()
-            cache[account] = nil
+            // `cache[account] = nil` would remove the key, so a provider the
+            // user never signed into would hit the Keychain on every call.
+            // `updateValue` stores the negative entry the `.some(.none)` case
+            // above reads back as `.missing`.
+            cache.updateValue(nil, forKey: account)
             cacheLock.unlock()
             return .missing
         } catch KeychainStore.KeychainError.interactionNotAllowed {

--- a/Sources/VibeBarCore/Models/AppSettings.swift
+++ b/Sources/VibeBarCore/Models/AppSettings.swift
@@ -59,6 +59,16 @@ public struct AppSettings: Codable, Equatable, Sendable {
     /// ask for.
     public var miscCookieAutoImportEnabled: Bool
 
+    /// Which signal colors the menu bar's percentages.
+    ///
+    /// `.forecast` is the product behavior, not an opt-in: a quota at 24%
+    /// remaining that the forecast says will comfortably survive until reset is
+    /// not a warning, and orange there trains the user to ignore the color.
+    /// The setting exists so someone who wants the old raw-threshold reading
+    /// can ask for it, which is why an absent key decodes to `.forecast` — the
+    /// new behavior — rather than to the pre-forecast thresholds.
+    public var menuBarColorBasis: MenuBarColorBasis
+
     /// Curves the user switched **off** in the Overview's all-providers quota
     /// history chart, as `"<tool>|<accountId>|<bucketId>"`.
     ///
@@ -218,7 +228,8 @@ public struct AppSettings: Codable, Equatable, Sendable {
         overviewQuotaHistoryHiddenCurveIds: Set<String> = [],
         pageLayouts: [PageLayoutPageID: StoredPageLayout] = [:],
         pageLayoutPresets: [PageLayoutPageID: [StoredPageLayoutPreset]] = [:],
-        miscCookieAutoImportEnabled: Bool = false
+        miscCookieAutoImportEnabled: Bool = false,
+        menuBarColorBasis: MenuBarColorBasis = .forecast
     ) {
         self.displayMode = displayMode
         self.refreshIntervalSeconds = refreshIntervalSeconds
@@ -255,6 +266,7 @@ public struct AppSettings: Codable, Equatable, Sendable {
         self.pageLayouts = pageLayouts
         self.pageLayoutPresets = Self.normalizedPageLayoutPresets(pageLayoutPresets)
         self.miscCookieAutoImportEnabled = miscCookieAutoImportEnabled
+        self.menuBarColorBasis = menuBarColorBasis
     }
 
     /// Drops unnamed presets, collapses names that differ only by case (the
@@ -307,6 +319,7 @@ public struct AppSettings: Codable, Equatable, Sendable {
         case pageLayouts
         case pageLayoutPresets
         case miscCookieAutoImportEnabled
+        case menuBarColorBasis
     }
 
     public init(from decoder: Decoder) throws {
@@ -453,6 +466,13 @@ public struct AppSettings: Codable, Equatable, Sendable {
         self.miscCookieAutoImportEnabled =
             try c.decodeIfPresent(Bool.self, forKey: .miscCookieAutoImportEnabled)
             ?? Self.default.miscCookieAutoImportEnabled
+        // An absent key deliberately means `.forecast`, unlike most fields
+        // added here: forecast coloring is the intended menu-bar behavior, so
+        // an existing settings file has to pick it up on upgrade. `try?` keeps
+        // an unknown raw value from failing the whole file.
+        self.menuBarColorBasis =
+            (try? c.decodeIfPresent(MenuBarColorBasis.self, forKey: .menuBarColorBasis))
+            ?? Self.default.menuBarColorBasis
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -493,6 +513,7 @@ public struct AppSettings: Codable, Equatable, Sendable {
         try c.encode(pageLayouts, forKey: .pageLayouts)
         try c.encode(pageLayoutPresets, forKey: .pageLayoutPresets)
         try c.encode(miscCookieAutoImportEnabled, forKey: .miscCookieAutoImportEnabled)
+        try c.encode(menuBarColorBasis, forKey: .menuBarColorBasis)
     }
 
     public func menuBarItem(_ kind: MenuBarItemKind) -> MenuBarItemSettings {

--- a/Sources/VibeBarCore/Models/AppSettings.swift
+++ b/Sources/VibeBarCore/Models/AppSettings.swift
@@ -47,6 +47,18 @@ public struct AppSettings: Codable, Equatable, Sendable {
     public var miscProviderInstances: [MiscProviderInstance]
     public var costData: CostDataSettings
 
+    /// Silently re-import a cookie-sourced misc provider's browser
+    /// session when its stored jar has gone stale, instead of leaving
+    /// the card on "Needs re-login" until the user clicks Import.
+    ///
+    /// Off by default, and deliberately so: an existing settings file
+    /// must not start doing background Keychain work because it was
+    /// opened by a newer build. When it is on, the re-import runs with
+    /// `allowKeychainPrompt: false`, so the worst case is that it finds
+    /// nothing — it can never surface a password prompt the user didn't
+    /// ask for.
+    public var miscCookieAutoImportEnabled: Bool
+
     /// Curves the user switched **off** in the Overview's all-providers quota
     /// history chart, as `"<tool>|<accountId>|<bucketId>"`.
     ///
@@ -205,7 +217,8 @@ public struct AppSettings: Codable, Equatable, Sendable {
         costData: CostDataSettings = .default,
         overviewQuotaHistoryHiddenCurveIds: Set<String> = [],
         pageLayouts: [PageLayoutPageID: StoredPageLayout] = [:],
-        pageLayoutPresets: [PageLayoutPageID: [StoredPageLayoutPreset]] = [:]
+        pageLayoutPresets: [PageLayoutPageID: [StoredPageLayoutPreset]] = [:],
+        miscCookieAutoImportEnabled: Bool = false
     ) {
         self.displayMode = displayMode
         self.refreshIntervalSeconds = refreshIntervalSeconds
@@ -241,6 +254,7 @@ public struct AppSettings: Codable, Equatable, Sendable {
         self.overviewQuotaHistoryHiddenCurveIds = overviewQuotaHistoryHiddenCurveIds
         self.pageLayouts = pageLayouts
         self.pageLayoutPresets = Self.normalizedPageLayoutPresets(pageLayoutPresets)
+        self.miscCookieAutoImportEnabled = miscCookieAutoImportEnabled
     }
 
     /// Drops unnamed presets, collapses names that differ only by case (the
@@ -292,6 +306,7 @@ public struct AppSettings: Codable, Equatable, Sendable {
         case overviewQuotaHistoryHiddenCurveIds
         case pageLayouts
         case pageLayoutPresets
+        case miscCookieAutoImportEnabled
     }
 
     public init(from decoder: Decoder) throws {
@@ -432,6 +447,12 @@ public struct AppSettings: Codable, Equatable, Sendable {
                 forKey: .pageLayoutPresets
             )) ?? [:]
         )
+        // Absent key means "settings written before auto re-import
+        // existed", which must decode to off — an upgrade cannot start
+        // reading browser cookie stores in the background on its own.
+        self.miscCookieAutoImportEnabled =
+            try c.decodeIfPresent(Bool.self, forKey: .miscCookieAutoImportEnabled)
+            ?? Self.default.miscCookieAutoImportEnabled
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -471,6 +492,7 @@ public struct AppSettings: Codable, Equatable, Sendable {
         try c.encode(overviewQuotaHistoryHiddenCurveIds, forKey: .overviewQuotaHistoryHiddenCurveIds)
         try c.encode(pageLayouts, forKey: .pageLayouts)
         try c.encode(pageLayoutPresets, forKey: .pageLayoutPresets)
+        try c.encode(miscCookieAutoImportEnabled, forKey: .miscCookieAutoImportEnabled)
     }
 
     public func menuBarItem(_ kind: MenuBarItemKind) -> MenuBarItemSettings {

--- a/Sources/VibeBarCore/Models/MenuBarSettings.swift
+++ b/Sources/VibeBarCore/Models/MenuBarSettings.swift
@@ -36,6 +36,94 @@ public enum MenuBarLayout: String, Codable, CaseIterable, Identifiable, Sendable
     }
 }
 
+/// Which signal decides the color of a menu-bar percentage.
+///
+/// Declaration order is the Settings picker order, so the default sits first.
+public enum MenuBarColorBasis: String, Codable, CaseIterable, Identifiable, Sendable {
+    /// Color by the bucket's pace forecast: whether the quota is projected to
+    /// survive until it refills, and whether a chunk of it is projected to go
+    /// unused.
+    case forecast
+    /// Color by the displayed percentage alone, against fixed thresholds.
+    case actual
+
+    public var id: String { rawValue }
+
+    public var label: String {
+        switch self {
+        case .forecast: return "Forecast"
+        case .actual: return "Actual"
+        }
+    }
+
+    /// Spelled out for the Settings caption: the menu bar has no room for a
+    /// legend, and blue is the one color whose meaning nobody can guess.
+    public var detail: String {
+        switch self {
+        case .forecast:
+            return "Green projected to last · blue a chunk will likely go unused · "
+                + "orange may run short · red projected to run out. "
+                + "Falls back to the percentage while a quota has too little history to forecast."
+        case .actual:
+            return "Colored by the displayed percentage alone, ignoring the forecast."
+        }
+    }
+}
+
+/// The semantic color one menu-bar percentage should be painted in.
+///
+/// Kept as a value rather than a platform color so the thresholds and the
+/// verdict mapping are testable without AppKit; `StatusItemController` owns the
+/// `NSColor` translation.
+public enum MenuBarPercentColor: Equatable, Sendable {
+    case healthy
+    case surplus
+    case watch
+    case risk
+
+    /// Resolves the color for one rendered percentage.
+    ///
+    /// `verdict` is `nil` when the bucket has no forecast at all (no account,
+    /// no observations yet) and `.learning` while the forecast is still
+    /// gathering evidence. Both fall back to the `.actual` thresholds on
+    /// purpose: the menu bar shows one colored number with no legend and no
+    /// room for an explanation, so a distinct "no opinion" shade would read as
+    /// a broken app rather than as a forecast that has not converged.
+    public static func resolve(
+        basis: MenuBarColorBasis,
+        verdict: QuotaPaceForecast.Verdict?,
+        percent: Double,
+        displayMode: DisplayMode
+    ) -> MenuBarPercentColor {
+        guard basis == .forecast, let verdict else {
+            return threshold(percent: percent, displayMode: displayMode)
+        }
+        switch verdict {
+        case .enough: return .healthy
+        case .surplus: return .surplus
+        case .watch: return .watch
+        case .atRisk: return .risk
+        case .learning: return threshold(percent: percent, displayMode: displayMode)
+        }
+    }
+
+    /// The pre-forecast thresholds, unchanged so `.actual` is exact parity with
+    /// what the menu bar has always shown. Never yields `.surplus`: an isolated
+    /// percentage cannot tell whether capacity is going to waste.
+    private static func threshold(percent: Double, displayMode: DisplayMode) -> MenuBarPercentColor {
+        switch displayMode {
+        case .remaining:
+            if percent < 10 { return .risk }
+            if percent < 30 { return .watch }
+            return .healthy
+        case .used:
+            if percent >= 90 { return .risk }
+            if percent >= 70 { return .watch }
+            return .healthy
+        }
+    }
+}
+
 public struct MenuBarItemSettings: Codable, Equatable, Identifiable, Sendable {
     public var kind: MenuBarItemKind
     public var isVisible: Bool

--- a/Sources/VibeBarCore/Models/PageLayoutConfig.swift
+++ b/Sources/VibeBarCore/Models/PageLayoutConfig.swift
@@ -400,6 +400,23 @@ public struct StoredPageLayoutPreset: Hashable, Sendable {
     /// on the way in rather than rendered as a blank row.
     public var isValid: Bool { !name.isEmpty }
 
+    /// The layout applying this preset should install.
+    ///
+    /// A `compact` preset captured before bands existed carries the packed
+    /// columns and no segments. When it was saved, applying it entered Manual
+    /// and put those exact columns back; restoring it as `compact` today would
+    /// discard the saved columns and re-pack under the default bands — a
+    /// different arrangement than the one the user named. So a compact preset
+    /// with columns but no bands comes back as the manual layout it always
+    /// effectively was. Presets captured by current builds store their resolved
+    /// bands, so they never take this path.
+    public var layoutToApply: StoredPageLayout {
+        guard layout.mode == .compact, !layout.isEmpty, layout.segments.isEmpty else {
+            return layout
+        }
+        return StoredPageLayout(mode: .manual, ratio: layout.ratio, columns: layout.columns)
+    }
+
     /// Case-insensitive identity. Two presets whose names differ only by case
     /// are the same menu entry, so they are the same preset.
     public var matchKey: String { name.lowercased() }

--- a/Sources/VibeBarCore/Models/PageLayoutConfig.swift
+++ b/Sources/VibeBarCore/Models/PageLayoutConfig.swift
@@ -182,6 +182,56 @@ public struct PageLayoutConfig: Hashable, Sendable {
     }
 }
 
+/// A page's cards as they will be drawn: one or more bands, each a two-column
+/// arrangement of its own, stacked in reading order.
+///
+/// Every mode produces one of these. `auto` and `manual` produce exactly one
+/// band, so they render through the same path as a segmented `compact` page and
+/// cannot drift from it — one band is, by construction, the single `HStack` the
+/// pages have always been.
+public struct PageLayoutArrangement: Hashable, Sendable {
+    /// Never empty: a page with nothing to draw is one empty band, so callers
+    /// can read `ratio` and the first band without unwrapping.
+    public var segments: [PageLayoutConfig]
+
+    public init(segments: [PageLayoutConfig]) {
+        self.segments = segments.isEmpty ? [PageLayoutConfig()] : segments
+    }
+
+    /// One band — every mode but `compact`.
+    public init(_ config: PageLayoutConfig) {
+        self.init(segments: [config])
+    }
+
+    /// Width split the whole page renders at. There is one ratio per page, not
+    /// one per band: a band boundary is a horizontal cut, and cutting the
+    /// columns at different widths per band would read as two different pages.
+    public var ratio: PageColumnRatio { segments[0].ratio }
+
+    /// Band membership in reading order — what the editor persists and what a
+    /// preset captures. Order *within* a band is the packer's answer, not
+    /// intent, so it is not what gets stored.
+    public var moduleSegments: [[PageLayoutModuleID]] { segments.map(\.moduleIDs) }
+
+    /// The whole arrangement as one two-column config: every band's left column
+    /// stacked, then every band's right column.
+    ///
+    /// The shape the page-wide controls work in — the drag editor, the ratio
+    /// buttons, the preset snapshot — none of which are per band.
+    public var flattened: PageLayoutConfig {
+        guard segments.count > 1 else { return segments[0] }
+        var columns = [[PageLayoutModuleID]](repeating: [], count: PageLayoutConfig.columnCount)
+        var heights: [PageLayoutModuleID: Double] = [:]
+        for segment in segments {
+            for index in columns.indices {
+                columns[index].append(contentsOf: segment.column(index))
+            }
+            heights.merge(segment.measuredHeights) { _, latest in latest }
+        }
+        return PageLayoutConfig(ratio: ratio, columns: columns, measuredHeights: heights)
+    }
+}
+
 /// One page's layout **intent** — the half of `PageLayoutConfig` the user
 /// actually chose — as stored in `AppSettings`.
 ///
@@ -204,25 +254,42 @@ public struct StoredPageLayout: Hashable, Sendable {
     public var ratio: PageColumnRatio
     public private(set) var columns: [[PageLayoutModuleID]]
 
+    /// Ordered bands `compact` packs one at a time, normalized by
+    /// `PageLayoutSegments`. Empty means "no chosen segmentation": the page
+    /// falls back to the default for its family, which is what every page did
+    /// before segments existed.
+    ///
+    /// Deliberately a sibling of `columns` rather than something folded into it:
+    /// `PageLayoutConfig.normalized` flattens everything past the second column
+    /// into the last one, which would destroy this.
+    public private(set) var segments: [[PageLayoutModuleID]]
+
     /// - Parameter mode: `nil` derives the mode from the columns — an entry
     ///   that carries an arrangement is a `manual` one, an entry that carries
     ///   none is `auto`. That is the same rule the decoder applies to an entry
     ///   written before modes existed, kept in one place so the two cannot
-    ///   drift apart.
+    ///   drift apart. Bands deliberately do not take part: a page can carry a
+    ///   segmentation and still be drawing itself automatically.
     public init(
         mode: PageLayoutMode? = nil,
         ratio: PageColumnRatio = .equal,
-        columns: [[PageLayoutModuleID]] = []
+        columns: [[PageLayoutModuleID]] = [],
+        segments: [[PageLayoutModuleID]] = []
     ) {
         let normalized = PageLayoutConfig(ratio: ratio, columns: columns)
         self.mode = mode ?? (normalized.isEmpty ? .auto : .manual)
         self.ratio = normalized.ratio
         self.columns = normalized.columns
+        self.segments = PageLayoutSegments.normalized(segments)
     }
 
     /// The intent half of a live config; measured heights are dropped.
-    public init(_ config: PageLayoutConfig, mode: PageLayoutMode? = nil) {
-        self.init(mode: mode, ratio: config.ratio, columns: config.columns)
+    public init(
+        _ config: PageLayoutConfig,
+        mode: PageLayoutMode? = nil,
+        segments: [[PageLayoutModuleID]] = []
+    ) {
+        self.init(mode: mode, ratio: config.ratio, columns: config.columns, segments: segments)
     }
 
     /// Back to the canonical model, with this page's measurements folded in.
@@ -235,6 +302,10 @@ public struct StoredPageLayout: Hashable, Sendable {
     /// True when the entry carries no arrangement — the same "not customized"
     /// test `PageLayoutConfig.isEmpty` makes. Independent of `mode`: an `auto`
     /// page can still be holding the columns it had before the user switched.
+    ///
+    /// Bands are deliberately not consulted. This question is "is there a hand
+    /// arrangement to return to", and a segmentation is not one: it is an input
+    /// to `compact`, which computes its own columns.
     public var isEmpty: Bool { columns.allSatisfy(\.isEmpty) }
 
     /// The entry a page should get when the user switches it back to `manual`.
@@ -253,7 +324,10 @@ public struct StoredPageLayout: Hashable, Sendable {
     /// the page was computed are reconciled as usual.
     public func restoredAsManual() -> StoredPageLayout? {
         guard !isEmpty else { return nil }
-        return StoredPageLayout(mode: .manual, ratio: ratio, columns: columns)
+        // The bands ride along for the same reason the columns do on the way
+        // out: a round trip through Manual must not be a silent reset of the
+        // segmentation the user chose for Compact.
+        return StoredPageLayout(mode: .manual, ratio: ratio, columns: columns, segments: segments)
     }
 }
 
@@ -262,6 +336,7 @@ extension StoredPageLayout: Codable {
         case mode
         case ratio
         case columns
+        case segments
     }
 
     /// Field-by-field tolerant, like `PageLayoutConfig`'s own decoder: a page
@@ -285,17 +360,23 @@ extension StoredPageLayout: Codable {
         }
         let ratio = (try? container.decode(PageColumnRatio.self, forKey: .ratio)) ?? .equal
         let columns = (try? container.decode([[PageLayoutModuleID]].self, forKey: .columns)) ?? []
-        self.init(mode: mode, ratio: ratio, columns: columns)
+        // A missing key is an entry written before segments existed, and a
+        // malformed one is a file somebody edited by hand: both mean "no chosen
+        // segmentation", which is the page's default banding, not an empty page.
+        let segments = (try? container.decode([[PageLayoutModuleID]].self, forKey: .segments)) ?? []
+        self.init(mode: mode, ratio: ratio, columns: columns, segments: segments)
     }
 }
 
 /// One saved arrangement the user named, so a layout worth keeping can be put
 /// back later without re-dragging it.
 ///
-/// Stores a whole `StoredPageLayout` — mode, ratio and columns — so a preset
-/// records what it was captured from. Applying one always lands in `manual`
-/// mode: a preset is "this exact arrangement", and re-entering `compact` would
-/// just recompute from whatever the heights happen to be now.
+/// Stores a whole `StoredPageLayout` — mode, ratio, columns and bands — so a
+/// preset records what it was captured from, and applying one restores that
+/// mode. A `manual` preset puts its exact columns back; a `compact` preset puts
+/// its bands back and lets the packer re-derive the columns inside them, because
+/// on a packed page the segmentation is the arrangement worth keeping and one
+/// particular packing of it is not.
 public struct StoredPageLayoutPreset: Hashable, Sendable {
     /// Long enough for "Wide left, cost on the right", short enough that a
     /// pasted paragraph cannot bloat `settings.json`.

--- a/Sources/VibeBarCore/Models/PrimaryProviderRouteHealth.swift
+++ b/Sources/VibeBarCore/Models/PrimaryProviderRouteHealth.swift
@@ -85,11 +85,33 @@ public struct PrimaryProviderRouteHealth: Identifiable, Sendable, Equatable {
 
 public enum PrimaryProviderRouteHealthChecker {
     public static func checkAll(now: Date = Date()) -> [PrimaryProviderRoute: PrimaryProviderRouteHealth] {
+        check(PrimaryProviderRoute.allCases, now: now)
+    }
+
+    public static func check(
+        _ routes: [PrimaryProviderRoute],
+        now: Date = Date()
+    ) -> [PrimaryProviderRoute: PrimaryProviderRouteHealth] {
         Dictionary(
-            uniqueKeysWithValues: PrimaryProviderRoute.allCases.map { route in
+            uniqueKeysWithValues: routes.map { route in
                 (route, check(route, now: now))
             }
         )
+    }
+
+    /// Same answers, computed off the calling actor.
+    ///
+    /// Every route here does blocking work — Keychain round trips, credential
+    /// file reads, and for AntiGravity a `/bin/ps` spawn drained
+    /// synchronously — and the App re-checks routes on every refresh. None of
+    /// that belongs on the main actor while the popover is drawing.
+    public static func checkOffActor(
+        _ routes: [PrimaryProviderRoute],
+        now: Date = Date()
+    ) async -> [PrimaryProviderRoute: PrimaryProviderRouteHealth] {
+        await Task.detached(priority: .userInitiated) {
+            check(routes, now: now)
+        }.value
     }
 
     public static func check(_ route: PrimaryProviderRoute, now: Date = Date()) -> PrimaryProviderRouteHealth {
@@ -161,7 +183,7 @@ public enum PrimaryProviderRouteHealthChecker {
             .appendingPathComponent(".gemini/antigravity")
         return antigravityLocalProbeHealth(
             route: route,
-            languageServerRunning: antigravityLanguageServerIsRunning(),
+            languageServerRunning: antigravityLanguageServerIsRunning(now: now),
             hasLocalData: FileManager.default.fileExists(atPath: dataRoot.path),
             now: now
         )
@@ -239,7 +261,46 @@ public enum PrimaryProviderRouteHealthChecker {
         }
     }
 
-    private static func antigravityLanguageServerIsRunning() -> Bool {
+    /// How long a language-server probe result is reused.
+    ///
+    /// The probe spawns `/bin/ps -ax`, drains its whole stdout and waits for it
+    /// to exit — tens of milliseconds of blocking work for a question whose
+    /// answer is "is AntiGravity open". Route health is re-checked on every
+    /// refresh and on every per-provider refresh, so without a TTL a Gemini
+    /// card refresh alone spawned it twice. A language server does not start
+    /// and stop inside a minute of itself, and a stale "running" reading only
+    /// delays the switch to the cached-data wording by that minute.
+    private static let languageServerProbeTTL: TimeInterval = 60
+    private static let languageServerProbeLock = NSLock()
+    private nonisolated(unsafe) static var languageServerProbe: (checkedAt: Date, isRunning: Bool)?
+
+    static func antigravityLanguageServerIsRunning(
+        now: Date = Date(),
+        probe: () -> Bool = probeAntigravityLanguageServer
+    ) -> Bool {
+        languageServerProbeLock.lock()
+        let cached = languageServerProbe
+        languageServerProbeLock.unlock()
+        if let cached, now.timeIntervalSince(cached.checkedAt) < languageServerProbeTTL {
+            return cached.isRunning
+        }
+
+        let isRunning = probe()
+        languageServerProbeLock.lock()
+        languageServerProbe = (now, isRunning)
+        languageServerProbeLock.unlock()
+        return isRunning
+    }
+
+    /// Drops the cached probe result. Test hook, and the honest thing to call
+    /// if a future caller learns AntiGravity just launched.
+    public static func invalidateLanguageServerProbeCache() {
+        languageServerProbeLock.lock()
+        languageServerProbe = nil
+        languageServerProbeLock.unlock()
+    }
+
+    private static func probeAntigravityLanguageServer() -> Bool {
         guard let result = captureProcessOutput(
             executablePath: "/bin/ps",
             arguments: ["-ax", "-o", "command="]

--- a/Sources/VibeBarCore/Models/ToolType.swift
+++ b/Sources/VibeBarCore/Models/ToolType.swift
@@ -7,6 +7,7 @@ import Foundation
 /// - MockDataProvider.swift: sampleQuota
 /// - ServiceStatusClient.swift: fetch (or short-circuit on `!supportsStatusPage`)
 /// - AccountStore.swift: autoDetect helper
+/// - MiscCookieSpecCatalog.swift: cookie-sourced or not
 /// - PopoverRoot.swift: emptyMessage / sections
 /// - SettingsView.swift: menuItemIcon
 /// - StatusItemController.swift: status item tag mapping

--- a/Sources/VibeBarCore/Services/CostAggregationCache.swift
+++ b/Sources/VibeBarCore/Services/CostAggregationCache.swift
@@ -153,7 +153,8 @@ public final class CostAggregationCache {
         let label: ToolType
     }
 
-    private let calendar: Calendar
+    private var calendar: Calendar
+    private var timeZoneObserver: NSObjectProtocol?
 
     private var source: [ToolType: CostSnapshot] = [:]
     private var rebasedByTool: [ToolType: CostSnapshot] = [:]
@@ -165,6 +166,36 @@ public final class CostAggregationCache {
 
     public init(calendar: Calendar = .current) {
         self.calendar = calendar
+        // `Calendar.current` freezes the time zone it was read under, and this
+        // cache lives as long as the menu bar does. Without this, a system
+        // zone change (travel, DST rule updates) would keep "today" cut at the
+        // old midnight until relaunch, because `refreshDay`'s fast path never
+        // consults the zone again. Main queue on purpose: the cache is owned
+        // by the `@MainActor` service and is not thread-safe.
+        timeZoneObserver = NotificationCenter.default.addObserver(
+            forName: .NSSystemTimeZoneDidChange,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            self?.adoptCalendar(.current)
+        }
+    }
+
+    deinit {
+        if let timeZoneObserver {
+            NotificationCenter.default.removeObserver(timeZoneObserver)
+        }
+    }
+
+    /// Switch to a calendar (and thus time zone) and drop every derived value —
+    /// the memos were all cut at the old midnight. Internal so a test can hand
+    /// in a fixed-zone calendar; production only ever passes `.current`, which
+    /// also overwrites an injected calendar the moment the system zone really
+    /// changes, matching what the default initializer would have captured.
+    func adoptCalendar(_ calendar: Calendar) {
+        self.calendar = calendar
+        dayRange = nil
+        invalidateDerived()
     }
 
     /// Replace the raw snapshots and drop every derived value.

--- a/Sources/VibeBarCore/Services/CostAggregationCache.swift
+++ b/Sources/VibeBarCore/Services/CostAggregationCache.swift
@@ -1,0 +1,323 @@
+import Foundation
+
+/// The cross-provider rollups the Overview's "all providers" cards draw.
+///
+/// Bundled into one value because they share every input: recomputing them
+/// individually meant re-rebasing and re-bucketing the same snapshots once per
+/// card per render pass.
+public struct CostRollup: Sendable, Equatable {
+    /// Everything that went into the rollup: each individual provider that has
+    /// a snapshot at all, plus one combined snapshot per group that carries
+    /// data. This is the list the "does the Overview have cost cards" question
+    /// is answered from.
+    public let snapshots: [CostSnapshot]
+    /// One combined snapshot per requested group, in the order the groups were
+    /// passed — Gemini Web + AntiGravity rolled up as the single "Gemini"
+    /// platform. Kept separately because the per-group card needs its own
+    /// group's total, not the all-providers sum.
+    public let groupSnapshots: [CostSnapshot]
+    public let dailyHistory: [DailyCostPoint]
+    public let heatmap: UsageHeatmap
+    public let modelBreakdowns: [CostSnapshot.ModelBreakdown]
+    public let combinedSnapshot: CostSnapshot
+
+    public init(
+        snapshots: [CostSnapshot],
+        groupSnapshots: [CostSnapshot],
+        dailyHistory: [DailyCostPoint],
+        heatmap: UsageHeatmap,
+        modelBreakdowns: [CostSnapshot.ModelBreakdown],
+        combinedSnapshot: CostSnapshot
+    ) {
+        self.snapshots = snapshots
+        self.groupSnapshots = groupSnapshots
+        self.dailyHistory = dailyHistory
+        self.heatmap = heatmap
+        self.modelBreakdowns = modelBreakdowns
+        self.combinedSnapshot = combinedSnapshot
+    }
+
+    /// Whether any provider in the rollup has found session logs. The Overview
+    /// gates its cost and analytics cards on this.
+    public var hasCostData: Bool {
+        snapshots.contains { $0.jsonlFilesFound > 0 }
+    }
+}
+
+/// Several tools the product presents as one platform, and the tool the
+/// combined snapshot is labelled with — Gemini Web + AntiGravity combined and
+/// labelled `.antigravity`, which is what the "Gemini" cost card renders.
+public struct CostSnapshotGroup: Hashable, Sendable {
+    public let label: ToolType
+    public let tools: [ToolType]
+
+    public init(label: ToolType, tools: [ToolType]) {
+        self.label = label
+        self.tools = tools
+    }
+}
+
+/// Cost and token totals across a set of providers, for the Overview's
+/// headline grid.
+public struct CostTotals: Sendable, Equatable {
+    public let allTimeCostUSD: Double
+    public let todayCostUSD: Double
+    public let yesterdayCostUSD: Double
+    public let last7DaysCostUSD: Double
+    public let last30DaysCostUSD: Double
+    public let allTimeTokens: Int
+    public let todayTokens: Int
+    public let yesterdayTokens: Int
+    public let last7DaysTokens: Int
+    public let last30DaysTokens: Int
+    /// Cost and token peaks are independent: the most expensive day is not
+    /// necessarily the day with the highest token volume.
+    public let peakDayCostUSD: Double
+    public let peakDayTokens: Int
+
+    public static let empty = CostTotals(
+        allTimeCostUSD: 0,
+        todayCostUSD: 0,
+        yesterdayCostUSD: 0,
+        last7DaysCostUSD: 0,
+        last30DaysCostUSD: 0,
+        allTimeTokens: 0,
+        todayTokens: 0,
+        yesterdayTokens: 0,
+        last7DaysTokens: 0,
+        last30DaysTokens: 0,
+        peakDayCostUSD: 0,
+        peakDayTokens: 0
+    )
+
+    public init(
+        allTimeCostUSD: Double,
+        todayCostUSD: Double,
+        yesterdayCostUSD: Double,
+        last7DaysCostUSD: Double,
+        last30DaysCostUSD: Double,
+        allTimeTokens: Int,
+        todayTokens: Int,
+        yesterdayTokens: Int,
+        last7DaysTokens: Int,
+        last30DaysTokens: Int,
+        peakDayCostUSD: Double,
+        peakDayTokens: Int
+    ) {
+        self.allTimeCostUSD = allTimeCostUSD
+        self.todayCostUSD = todayCostUSD
+        self.yesterdayCostUSD = yesterdayCostUSD
+        self.last7DaysCostUSD = last7DaysCostUSD
+        self.last30DaysCostUSD = last30DaysCostUSD
+        self.allTimeTokens = allTimeTokens
+        self.todayTokens = todayTokens
+        self.yesterdayTokens = yesterdayTokens
+        self.last7DaysTokens = last7DaysTokens
+        self.last30DaysTokens = last30DaysTokens
+        self.peakDayCostUSD = peakDayCostUSD
+        self.peakDayTokens = peakDayTokens
+    }
+}
+
+/// Memoizes everything the cost UI derives from the raw per-tool snapshots.
+///
+/// Three separate costs used to be paid on every single popover render pass,
+/// including the ones triggered by an unrelated quota publish:
+///
+/// - `CostSnapshot.rebasedForCurrentDay()` walks a provider's whole daily
+///   history with a `Calendar` round trip per point, and roughly ten call
+///   sites ask for it — several of them from inside a SwiftUI `body`.
+/// - `CostSnapshotAggregator.combinedSnapshot` re-rebases every provider and
+///   then re-buckets ~720 hourly keys.
+/// - The Overview asked for both of those four times per `body`, because the
+///   module catalog, the rollup context, and the Gemini card each recomputed
+///   them independently.
+///
+/// Every one of those is a pure function of (raw snapshots, local day), so the
+/// results live here until `setSource` replaces the snapshots or the day rolls
+/// over. Day rollover is detected against a cached midnight-to-midnight range
+/// so the common path is a `Date` range check rather than a calendar round
+/// trip.
+///
+/// Not thread-safe by design: it is owned by the `@MainActor`
+/// `CostUsageService` and only ever touched from there.
+public final class CostAggregationCache {
+    private struct RollupKey: Hashable {
+        let individualTools: [ToolType]
+        let groups: [CostSnapshotGroup]
+        let label: ToolType
+    }
+
+    private struct CombinedKey: Hashable {
+        let tools: [ToolType]
+        let label: ToolType
+    }
+
+    private let calendar: Calendar
+
+    private var source: [ToolType: CostSnapshot] = [:]
+    private var rebasedByTool: [ToolType: CostSnapshot] = [:]
+    private var combinedByKey: [CombinedKey: CostSnapshot] = [:]
+    private var rollupByKey: [RollupKey: CostRollup] = [:]
+    private var totalsByTools: [[ToolType]: CostTotals] = [:]
+    /// The local day every memo above was computed for, as a half-open range.
+    private var dayRange: Range<Date>?
+
+    public init(calendar: Calendar = .current) {
+        self.calendar = calendar
+    }
+
+    /// Replace the raw snapshots and drop every derived value.
+    public func setSource(_ snapshots: [ToolType: CostSnapshot]) {
+        source = snapshots
+        invalidateDerived()
+    }
+
+    /// Test hook: replace the raw snapshots *without* announcing the change, so
+    /// a test can prove an answer came out of the memo instead of being
+    /// recomputed.
+    func setSourceWithoutInvalidatingForTesting(_ snapshots: [ToolType: CostSnapshot]) {
+        source = snapshots
+    }
+
+    /// Raw file count for one tool, without rebasing or combining anything.
+    ///
+    /// `jsonlFilesFound` survives both rebasing and combining untouched, so
+    /// "does this provider have cost data" never needs either — and the module
+    /// catalog asks that question on every render pass.
+    public func jsonlFilesFound(for tool: ToolType) -> Int {
+        source[tool]?.jsonlFilesFound ?? 0
+    }
+
+    public func hasJSONLFiles(in tools: [ToolType]) -> Bool {
+        tools.contains { jsonlFilesFound(for: $0) > 0 }
+    }
+
+    /// The view-safe snapshot for one tool: window totals evaluated against
+    /// today rather than against the day the snapshot was scanned.
+    public func snapshot(for tool: ToolType, now: Date = Date()) -> CostSnapshot? {
+        refreshDay(now: now)
+        guard let raw = source[tool] else { return nil }
+        if let cached = rebasedByTool[tool] { return cached }
+        let rebased = raw.rebasedForCurrentDay(now: now, calendar: calendar)
+        rebasedByTool[tool] = rebased
+        return rebased
+    }
+
+    /// One snapshot for several tools that the product presents as a single
+    /// platform.
+    public func combinedSnapshot(
+        of tools: [ToolType],
+        labelledAs label: ToolType,
+        now: Date = Date()
+    ) -> CostSnapshot {
+        refreshDay(now: now)
+        let key = CombinedKey(tools: tools, label: label)
+        if let cached = combinedByKey[key] { return cached }
+        let parts = tools.compactMap { source[$0] }
+        let combined = CostSnapshotAggregator.combinedSnapshot(
+            tool: label,
+            snapshots: parts,
+            now: now,
+            calendar: calendar
+        )
+        combinedByKey[key] = combined
+        return combined
+    }
+
+    /// The Overview's rollup: `individualTools` contribute their own snapshot,
+    /// each entry of `groups` is combined into one snapshot first, and the
+    /// whole set is then aggregated.
+    ///
+    /// A group only joins the aggregate when it actually has data — an empty
+    /// Gemini + AntiGravity pair would otherwise contribute a zero-filled
+    /// snapshot and make `hasCostData` true for a provider with no logs.
+    ///
+    /// Group snapshots go through `combinedSnapshot`, so the group total here
+    /// and the same platform's own card share one cache entry rather than
+    /// combining the pair twice.
+    public func rollup(
+        individualTools: [ToolType],
+        groups: [CostSnapshotGroup] = [],
+        labelledAs label: ToolType,
+        now: Date = Date()
+    ) -> CostRollup {
+        refreshDay(now: now)
+        let key = RollupKey(individualTools: individualTools, groups: groups, label: label)
+        if let cached = rollupByKey[key] { return cached }
+
+        let groupSnapshots = groups.map {
+            combinedSnapshot(of: $0.tools, labelledAs: $0.label, now: now)
+        }
+        var snapshots = individualTools.compactMap { snapshot(for: $0, now: now) }
+        snapshots.append(contentsOf: groupSnapshots.filter { $0.jsonlFilesFound > 0 })
+
+        let rollup = CostRollup(
+            snapshots: snapshots,
+            groupSnapshots: groupSnapshots,
+            dailyHistory: CostSnapshotAggregator.combinedDailyHistory(snapshots, calendar: calendar),
+            heatmap: CostSnapshotAggregator.combinedHeatmap(snapshots),
+            modelBreakdowns: CostSnapshotAggregator.combinedModelBreakdowns(snapshots),
+            combinedSnapshot: CostSnapshotAggregator.combinedSnapshot(
+                tool: label,
+                snapshots: snapshots,
+                now: now,
+                calendar: calendar
+            )
+        )
+        rollupByKey[key] = rollup
+        return rollup
+    }
+
+    /// Headline cost and token totals over a set of providers.
+    public func totals(of tools: [ToolType], now: Date = Date()) -> CostTotals {
+        refreshDay(now: now)
+        if let cached = totalsByTools[tools] { return cached }
+        let snapshots = tools.compactMap { snapshot(for: $0, now: now) }
+        let dailyHistory = CostSnapshotAggregator.combinedDailyHistory(snapshots, calendar: calendar)
+        let yesterday = calendar.date(
+            byAdding: .day,
+            value: -1,
+            to: calendar.startOfDay(for: now)
+        ) ?? now
+        let yesterdayPoints = snapshots.compactMap { snapshot in
+            snapshot.dailyHistory.first { calendar.isDate($0.date, inSameDayAs: yesterday) }
+        }
+        let totals = CostTotals(
+            allTimeCostUSD: snapshots.reduce(0) { $0 + $1.allTimeCostUSD },
+            todayCostUSD: snapshots.reduce(0) { $0 + $1.todayCostUSD },
+            yesterdayCostUSD: yesterdayPoints.reduce(0) { $0 + $1.costUSD },
+            last7DaysCostUSD: snapshots.reduce(0) { $0 + $1.last7DaysCostUSD },
+            last30DaysCostUSD: snapshots.reduce(0) { $0 + $1.last30DaysCostUSD },
+            allTimeTokens: snapshots.reduce(0) { $0 + $1.allTimeTokens },
+            todayTokens: snapshots.reduce(0) { $0 + $1.todayTokens },
+            yesterdayTokens: yesterdayPoints.reduce(0) { $0 + $1.totalTokens },
+            last7DaysTokens: snapshots.reduce(0) { $0 + $1.last7DaysTokens },
+            last30DaysTokens: snapshots.reduce(0) { $0 + $1.last30DaysTokens },
+            peakDayCostUSD: CostSnapshotAggregator.peakDailyCost(in: dailyHistory),
+            peakDayTokens: CostSnapshotAggregator.peakDailyTokens(in: dailyHistory)
+        )
+        totalsByTools[tools] = totals
+        return totals
+    }
+
+    // MARK: - Private
+
+    private func refreshDay(now: Date) {
+        if let dayRange, dayRange.contains(now) { return }
+        let start = calendar.startOfDay(for: now)
+        let end = calendar.date(byAdding: .day, value: 1, to: start) ?? start.addingTimeInterval(86_400)
+        // A clock that jumps backwards (manual change, NTP correction) lands
+        // outside the cached range too, which is exactly the right response:
+        // every window total is relative to "today".
+        dayRange = start..<max(end, start.addingTimeInterval(1))
+        invalidateDerived()
+    }
+
+    private func invalidateDerived() {
+        rebasedByTool.removeAll(keepingCapacity: true)
+        combinedByKey.removeAll(keepingCapacity: true)
+        rollupByKey.removeAll(keepingCapacity: true)
+        totalsByTools.removeAll(keepingCapacity: true)
+    }
+}

--- a/Sources/VibeBarCore/Services/CostUsageService.swift
+++ b/Sources/VibeBarCore/Services/CostUsageService.swift
@@ -6,7 +6,9 @@ import Combine
 /// recent data survives CLI log rotation without keeping an unlimited profile.
 @MainActor
 public final class CostUsageService: ObservableObject {
-    @Published public private(set) var snapshots: [ToolType: CostSnapshot] = [:]
+    @Published public private(set) var snapshots: [ToolType: CostSnapshot] = [:] {
+        didSet { aggregations.setSource(snapshots) }
+    }
     @Published public private(set) var extrasByTool: [ToolType: ProviderExtras] = [:]
     @Published public private(set) var isRefreshing: Bool = false
     @Published public private(set) var lastRefreshedAt: Date?
@@ -35,6 +37,13 @@ public final class CostUsageService: ObservableObject {
     private let homeDirectory: String
     private let mockProvider: () -> Bool
     private let costDataSettingsProvider: () -> CostDataSettings
+    /// Every value the UI derives from `snapshots` — rebased per-tool
+    /// snapshots, combined platform snapshots, the Overview rollups — is a pure
+    /// function of the snapshots and the local day, and the popover asks for
+    /// them dozens of times per render pass. The cache keeps that work at once
+    /// per refresh instead of once per read; it is dropped automatically by the
+    /// `snapshots` observer above and on day rollover.
+    private let aggregations = CostAggregationCache()
 
     public init(
         homeDirectory: String = RealHomeDirectory.path,
@@ -55,9 +64,15 @@ public final class CostUsageService: ObservableObject {
                 return
             }
             let cached = await CostSnapshotCache.shared.loadAll(retentionDays: costData.retentionDays, now: Date())
-            for (tool, snap) in cached where self.snapshots[tool] == nil {
-                self.snapshots[tool] = snap
+            // One assignment, not one per tool: every write to a `@Published`
+            // dictionary is its own publish, and the popover re-renders on each.
+            var hydrated = self.snapshots
+            var addedAny = false
+            for (tool, snap) in cached where hydrated[tool] == nil {
+                hydrated[tool] = snap
+                addedAny = true
             }
+            if addedAny { self.snapshots = hydrated }
             if !cached.isEmpty {
                 self.lastRefreshedAt = cached.values.map(\.updatedAt).max()
             }
@@ -65,7 +80,35 @@ public final class CostUsageService: ObservableObject {
     }
 
     public func snapshot(for tool: ToolType) -> CostSnapshot? {
-        snapshots[tool]?.rebasedForCurrentDay()
+        aggregations.snapshot(for: tool)
+    }
+
+    /// Cost for several tools the product presents as one platform (Gemini Web
+    /// + AntiGravity as "Gemini").
+    public func combinedSnapshot(of tools: [ToolType], labelledAs label: ToolType) -> CostSnapshot {
+        aggregations.combinedSnapshot(of: tools, labelledAs: label)
+    }
+
+    /// Cross-provider rollups for the Overview's "all providers" cards.
+    public func rollup(
+        individualTools: [ToolType],
+        groups: [CostSnapshotGroup] = [],
+        labelledAs label: ToolType
+    ) -> CostRollup {
+        aggregations.rollup(individualTools: individualTools, groups: groups, labelledAs: label)
+    }
+
+    /// Headline cost and token totals over a set of providers.
+    public func totals(of tools: [ToolType]) -> CostTotals {
+        aggregations.totals(of: tools)
+    }
+
+    /// Whether any of these providers has found session logs. Deliberately
+    /// reads the raw file count instead of a rebased or combined snapshot:
+    /// `jsonlFilesFound` survives both untouched, and this is asked on every
+    /// render pass to decide whether the cost cards exist at all.
+    public func hasJSONLFiles(in tools: [ToolType]) -> Bool {
+        aggregations.hasJSONLFiles(in: tools)
     }
 
     public func extras(for tool: ToolType) -> ProviderExtras? {

--- a/Sources/VibeBarCore/Services/OverviewMasonryPlanner.swift
+++ b/Sources/VibeBarCore/Services/OverviewMasonryPlanner.swift
@@ -2,13 +2,19 @@ import Foundation
 
 /// Pure layout planner for the Overview's two-column waterfall.
 ///
-/// Placement is deliberately phased: quota cards are balanced first without
-/// considering anything below them, cost cards are then balanced from those
-/// seeded column heights, and auxiliary cards finally fill the shorter column.
-/// Keeping this policy in Core makes the behavior deterministic and testable
-/// while SwiftUI remains responsible only for live height measurement.
+/// Placement is deliberately phased: the summary band takes the top row, quota
+/// cards are balanced below it without considering anything further down, cost
+/// cards are then balanced from those seeded column heights, and auxiliary
+/// cards finally fill the shorter column. Keeping this policy in Core makes the
+/// behavior deterministic and testable while SwiftUI remains responsible only
+/// for live height measurement.
 public enum OverviewMasonryPlanner {
     public enum Phase: Int, Sendable, Comparable {
+        /// The Overview's header band: cards pinned to one shared height that
+        /// read as a single row. Placed across the columns in declaration
+        /// order rather than balanced, because a band whose cards are all the
+        /// same height has nothing to balance.
+        case summary
         case quota
         case cost
         case auxiliary
@@ -60,11 +66,20 @@ public enum OverviewMasonryPlanner {
             return greedyPlan(items: items, columns: columnCount, spacing: spacing)
         }
 
+        let summaries = items.filter { $0.phase == .summary }
         let quotas = items.filter { $0.phase == .quota }
         let costs = items.filter { $0.phase == .cost }
         let auxiliary = items.filter { $0.phase == .auxiliary }
         var positions: [String: Position] = [:]
         var heights = Array(repeating: 0.0, count: columnCount)
+
+        // The summary band is a row, not a balanced pair: its cards carry one
+        // pinned height, so declaration order decides which side each takes and
+        // the band seeds every column equally. Balancing it instead would stack
+        // two equal cards in one column the moment a third appeared.
+        for (offset, item) in summaries.enumerated() {
+            append(item, to: offset % columnCount, spacing: spacing, heights: &heights, positions: &positions)
+        }
 
         // AQ's Overview has four quota cards. Enumerating all 24 orders lets
         // either pair occupy either column while preserving the invariant of
@@ -115,7 +130,7 @@ public enum OverviewMasonryPlanner {
         var positions: [String: Position] = [:]
         var heights = Array(repeating: 0.0, count: columnCount)
 
-        for phase in [Phase.quota, .cost, .auxiliary] {
+        for phase in [Phase.summary, .quota, .cost, .auxiliary] {
             for item in items where item.phase == phase {
                 let preferred = fixedColumns[item.id] ?? shortestColumn(heights)
                 let column = min(max(0, preferred), columnCount - 1)

--- a/Sources/VibeBarCore/Services/PageLayoutPacker.swift
+++ b/Sources/VibeBarCore/Services/PageLayoutPacker.swift
@@ -127,6 +127,39 @@ public enum PageLayoutPacker {
         )
     }
 
+    // MARK: - Segments
+
+    /// Pack each band on its own, in order.
+    ///
+    /// A band is packed exactly the way a whole page is — its two columns are
+    /// still balanced for height — but nothing crosses a band boundary, so the
+    /// grouping the user chose survives the packing. See `PageLayoutSegments`
+    /// for why that grouping exists.
+    ///
+    /// Identifiers are deduplicated across bands as well as within one, keeping
+    /// the first occurrence, so a hand-edited file cannot render one card twice.
+    public static func pack(
+        segments: [[Item]],
+        spacing: Double,
+        ratio: PageColumnRatio = .equal
+    ) -> [Packing] {
+        var seen = Set<PageLayoutModuleID>()
+        return segments.map { segment in
+            let unique = segment.filter { !$0.id.rawValue.isEmpty && seen.insert($0.id).inserted }
+            return pack(items: unique, spacing: spacing, ratio: ratio)
+        }
+    }
+
+    /// `pack(segments:spacing:ratio:)` as the per-band columns the renderer
+    /// draws.
+    public static func packedSegmentColumns(
+        segments: [[Item]],
+        spacing: Double,
+        ratio: PageColumnRatio = .equal
+    ) -> [[[PageLayoutModuleID]]] {
+        pack(segments: segments, spacing: spacing, ratio: ratio).map(\.columns)
+    }
+
     // MARK: - Measuring an arrangement
 
     /// Height of one column: its cards plus a gap between each neighbouring
@@ -157,6 +190,28 @@ public enum PageLayoutPacker {
         columns
             .map { stackedHeight($0, heights: heights, spacing: spacing) }
             .max() ?? 0
+    }
+
+    /// What a *segmented* arrangement would measure: every band's taller column,
+    /// plus one inter-band gap between neighbours.
+    ///
+    /// The number `compact`'s re-pack hysteresis has to compare once a page has
+    /// bands. Comparing one band's height against a whole page's would let a
+    /// segmented page grow without ever being re-packed.
+    public static func pageHeight(
+        segments: [[[PageLayoutModuleID]]],
+        heights: [PageLayoutModuleID: Double],
+        spacing: Double
+    ) -> Double {
+        let gap = spacing.isFinite ? max(0, spacing) : 0
+        var total = 0.0
+        var count = 0
+        for segment in segments {
+            let height = pageHeight(columns: segment, heights: heights, spacing: gap)
+            total = appended(total, count, height, spacing: gap)
+            count += 1
+        }
+        return total
     }
 
     // MARK: - Exact search

--- a/Sources/VibeBarCore/Services/PageLayoutSegments.swift
+++ b/Sources/VibeBarCore/Services/PageLayoutSegments.swift
@@ -1,0 +1,167 @@
+import Foundation
+
+/// Ordered bands a page's cards are packed into, one band at a time.
+///
+/// `PageLayoutMode.compact` asks `PageLayoutPacker` for the shortest two-column
+/// arrangement of a whole page, and the shortest page is free to slot an
+/// analytics card between two quota cards. That is exactly what a user who
+/// wants "my quotas together, packed as tight as they go, everything else
+/// below" does not want. Segments put that grouping back under the user's
+/// control without giving up the packing: inside a band the packer is still
+/// free, across bands the reading order is fixed.
+///
+/// Segments live *beside* `PageLayoutConfig.columns`, never inside it:
+/// `PageLayoutConfig.normalized` folds every column past the second into the
+/// last one and dedupes globally, which would flatten any structure stored
+/// there into two flat columns.
+public enum PageLayoutSegments {
+    /// Most bands one page may hold. A band the user cannot tell apart from its
+    /// neighbour is worse than no band, and the cap also keeps a hand-edited
+    /// settings file from asking the editor to draw fifty headers.
+    public static let maximumCount = 6
+
+    /// One module as the segmenter sees it: an identity plus the family it
+    /// belongs to, which is what the default segmentation groups by.
+    public struct Module: Hashable, Sendable {
+        public let id: PageLayoutModuleID
+        public let phase: OverviewMasonryPlanner.Phase
+
+        public init(id: PageLayoutModuleID, phase: OverviewMasonryPlanner.Phase) {
+            self.id = id
+            self.phase = phase
+        }
+    }
+
+    /// Phases that share a band in the Overview's default segmentation: the
+    /// pinned summary header, then the quota cards packed among themselves,
+    /// then cost together with the analytics derived from it.
+    ///
+    /// This is the answer to the complaint segments exist for — a user who
+    /// picks Compact on the Overview gets a minimal-height quota block without
+    /// having to arrange anything.
+    static let overviewBands: [[OverviewMasonryPlanner.Phase]] = [
+        [.summary],
+        [.quota],
+        [.cost, .auxiliary]
+    ]
+
+    /// Segmentation a page gets when the user has not chosen one.
+    ///
+    /// Provider pages are a single band: `compact` there keeps meaning exactly
+    /// what it always meant, one packing of the whole page.
+    public static func defaultSegments(
+        modules: [Module],
+        page: PageLayoutPageID
+    ) -> [[PageLayoutModuleID]] {
+        guard page.isOverview else { return normalized([modules.map(\.id)]) }
+        return normalized(
+            overviewBands.map { band in
+                modules.filter { band.contains($0.phase) }.map(\.id)
+            }
+        )
+    }
+
+    /// Drops empty identifiers and empty bands, collapses an identifier that
+    /// appears in more than one band onto its first occurrence, and folds bands
+    /// past `maximumCount` into the last one.
+    ///
+    /// Identifiers this build does not recognize are preserved verbatim, for the
+    /// same reason `PageLayoutModuleID` is a string wrapper: a band written by a
+    /// newer build has to survive a downgrade's round trip rather than being
+    /// quietly dropped from the user's arrangement.
+    public static func normalized(_ segments: [[PageLayoutModuleID]]) -> [[PageLayoutModuleID]] {
+        var result: [[PageLayoutModuleID]] = []
+        var seen = Set<PageLayoutModuleID>()
+        for segment in segments {
+            var band: [PageLayoutModuleID] = []
+            for moduleID in segment where !moduleID.rawValue.isEmpty {
+                guard seen.insert(moduleID).inserted else { continue }
+                band.append(moduleID)
+            }
+            guard !band.isEmpty else { continue }
+            if result.count < maximumCount {
+                result.append(band)
+            } else {
+                result[result.count - 1].append(contentsOf: band)
+            }
+        }
+        return result
+    }
+
+    /// Band membership to render right now: the saved bands reconciled against
+    /// the modules the page can actually draw this pass.
+    ///
+    /// - Saved bands with no chosen segmentation (`stored` empty) fall back to
+    ///   `defaultSegments`, which is what every page did before segments
+    ///   existed.
+    /// - A saved module the page cannot draw is left out of the result. It stays
+    ///   in the *saved* bands — see `mergingEdit`.
+    /// - A module the saved bands have never seen joins the band its family
+    ///   defaults to, clamped into range: a page saved with fewer bands than the
+    ///   default has nowhere else to put it.
+    /// - A band whose cards have all gone is not drawn.
+    ///
+    /// Every available module appears exactly once in the result.
+    public static func resolve(
+        stored: [[PageLayoutModuleID]],
+        available: [PageLayoutModuleID],
+        defaultSegments: [[PageLayoutModuleID]]
+    ) -> [[PageLayoutModuleID]] {
+        var availableSet = Set<PageLayoutModuleID>()
+        var orderedAvailable: [PageLayoutModuleID] = []
+        for moduleID in available
+        where !moduleID.rawValue.isEmpty && availableSet.insert(moduleID).inserted {
+            orderedAvailable.append(moduleID)
+        }
+
+        let defaults = normalized(defaultSegments)
+        var defaultIndex: [PageLayoutModuleID: Int] = [:]
+        for (index, band) in defaults.enumerated() {
+            for moduleID in band { defaultIndex[moduleID] = index }
+        }
+
+        let base = normalized(stored.isEmpty ? defaults : stored)
+        var segments = base.map { $0.filter(availableSet.contains) }
+        guard !segments.isEmpty else {
+            return orderedAvailable.isEmpty ? [] : [orderedAvailable]
+        }
+
+        var placed = Set(segments.flatMap { $0 })
+        for moduleID in orderedAvailable where !placed.contains(moduleID) {
+            let target = min(defaultIndex[moduleID] ?? segments.count - 1, segments.count - 1)
+            segments[target].append(moduleID)
+            placed.insert(moduleID)
+        }
+        return normalized(segments)
+    }
+
+    /// Fold an edit made against the *resolved* bands back into the *saved*
+    /// ones, without forgetting modules the page cannot draw right now.
+    ///
+    /// The same contract `PageLayoutResolver.mergingEdit` gives the columns, and
+    /// for the same reason: the editor can only drag what is on screen, so
+    /// persisting its output verbatim would erase the band of every module that
+    /// happened to be missing — a quota group before the first refresh, the cost
+    /// cards before any session log is found — and moving one card would
+    /// silently reset the rest of the page.
+    ///
+    /// A hidden module stays in the band index it was saved in, clamped into
+    /// range. Only an explicit reset forgets a page.
+    public static func mergingEdit(
+        _ edited: [[PageLayoutModuleID]],
+        into stored: [[PageLayoutModuleID]],
+        available: [PageLayoutModuleID]
+    ) -> [[PageLayoutModuleID]] {
+        let availableSet = Set(available)
+        var segments = normalized(edited)
+        guard !segments.isEmpty else { return normalized(stored) }
+
+        for (index, band) in normalized(stored).enumerated() {
+            for moduleID in band where !availableSet.contains(moduleID) {
+                guard !segments.contains(where: { $0.contains(moduleID) }) else { continue }
+                segments[min(index, segments.count - 1)].append(moduleID)
+            }
+        }
+        return normalized(segments)
+    }
+}

--- a/Sources/VibeBarCore/Services/QuotaPaceForecast.swift
+++ b/Sources/VibeBarCore/Services/QuotaPaceForecast.swift
@@ -375,28 +375,86 @@ public struct QuotaPaceForecast: Sendable, Equatable {
         )
     }
 
-    private struct ActivityProfile {
-        let heatmap: UsageHeatmap?
+    /// Time-of-week activity weighting, evaluated as the integral of a per-hour
+    /// weight curve.
+    ///
+    /// `weight(from:to:)` is asked for once per completed cycle **and** once per
+    /// stored observation by `historicalRemainingUsage`, and the profile is
+    /// rebuilt per bucket. Walking the window hour by hour therefore cost two
+    /// `Calendar` round trips per hour of every window it was asked about —
+    /// six figures of them for a monthly bucket, sometimes from inside a
+    /// SwiftUI `body`. This version answers a query with integer arithmetic
+    /// against a table built once per profile.
+    ///
+    /// **The hour grid, and where it approximates.** Blocks are laid out
+    /// uniformly 3600s apart, phased so a boundary lands on a local hour
+    /// boundary at the table's anchor. That is exact, not approximate, for
+    /// every zone whose DST shift is a whole hour: changing the UTC offset by
+    /// 3600 leaves `offset % 3600` alone, so local hour boundaries stay on the
+    /// same epoch grid and only their (weekday, hour) *labels* move — which is
+    /// all the weight depends on. A spring-forward day simply has no block
+    /// labelled 02:00, and a fall-back day has two labelled 01:00; both are the
+    /// honest reading of a weekday×hour habit curve. Only the half-hour DST
+    /// oddities (Lord Howe Island) shift the grid: there a block straddles two
+    /// local hours across the transition and takes the weight of the hour its
+    /// start falls in — at most half an hour of misattribution, twice a year,
+    /// on a curve whose entire job is to say "this person tends to work around
+    /// this time of week".
+    final class ActivityProfile {
         let calendar: Calendar
-        let maximumCell: Double
+
+        /// Flattened 7×24 weights, or `nil` when the heatmap carries no usable
+        /// shape and every hour weighs the same. The uniform case then needs no
+        /// table at all — the integral is just the elapsed duration.
+        private let cellWeights: [Double]?
+        /// Offset of every block boundary from the epoch, in `[0, 3600)`.
+        /// Resolved on the first table build and then frozen, so growing the
+        /// table never moves the grid underneath cached values.
+        private var phase: TimeInterval?
+        private var table: HourTable?
+
+        /// Widest span one table may cover. Real spans are bounded by the
+        /// retention horizon (weeks), so this only exists to keep a corrupt
+        /// stored date from asking for a hundred-million-entry array; wider
+        /// queries are answered chunk by chunk instead.
+        private static let maximumTableSeconds: TimeInterval = 400 * 86_400
+        /// Slack added around a requested span so the usual sequence of queries
+        /// (this window, then each older cycle) grows the table a few times
+        /// rather than once per query.
+        private static let tablePaddingSeconds: TimeInterval = 2 * 86_400
 
         init(heatmap: UsageHeatmap?, calendar: Calendar) {
-            self.heatmap = heatmap
             self.calendar = calendar
-            self.maximumCell = Double(heatmap?.cells.flatMap { $0 }.max() ?? 0)
+            let maximum = Double(heatmap?.cells.flatMap { $0 }.max() ?? 0)
+            guard let heatmap, heatmap.totalTokens > 0, maximum > 0 else {
+                self.cellWeights = nil
+                return
+            }
+            var weights = [Double](repeating: 1, count: 7 * 24)
+            for weekday in 0..<7 where heatmap.cells.indices.contains(weekday) {
+                let row = heatmap.cells[weekday]
+                for hour in 0..<24 where row.indices.contains(hour) {
+                    let normalized = sqrt(Double(row[hour]) / maximum)
+                    // Laplace-like floor prevents an empty historical cell from
+                    // asserting that future work there is impossible.
+                    weights[weekday * 24 + hour] = 0.15 + normalized * 0.85
+                }
+            }
+            self.cellWeights = weights
         }
 
         func weight(from start: Date, to end: Date) -> Double {
             guard end > start else { return 0 }
-            var cursor = start
+            guard cellWeights != nil else {
+                return end.timeIntervalSince(start) / 3_600
+            }
+            let upper = end.timeIntervalSince1970
+            var lower = start.timeIntervalSince1970
             var total = 0.0
-            while cursor < end {
-                let nextHour = calendar.date(byAdding: .hour, value: 1, to: calendar.dateInterval(of: .hour, for: cursor)?.start ?? cursor)
-                    ?? cursor.addingTimeInterval(3_600)
-                let next = min(end, max(cursor.addingTimeInterval(60), nextHour))
-                let hours = next.timeIntervalSince(cursor) / 3_600
-                total += hourWeight(at: cursor) * hours
-                cursor = next
+            while lower < upper {
+                let chunkEnd = min(upper, lower + Self.maximumTableSeconds)
+                total += table(covering: lower, chunkEnd).integral(from: lower, to: chunkEnd)
+                lower = chunkEnd
             }
             return total
         }
@@ -419,15 +477,148 @@ public struct QuotaPaceForecast: Sendable, Equatable {
             return nil
         }
 
-        private func hourWeight(at date: Date) -> Double {
-            guard let heatmap, heatmap.totalTokens > 0, maximumCell > 0 else { return 1 }
-            let weekday = max(0, min(6, calendar.component(.weekday, from: date) - 1))
-            let hour = max(0, min(23, calendar.component(.hour, from: date)))
-            guard heatmap.cells.indices.contains(weekday), heatmap.cells[weekday].indices.contains(hour) else { return 1 }
-            let normalized = sqrt(Double(heatmap.cells[weekday][hour]) / maximumCell)
-            // Laplace-like floor prevents an empty historical cell from
-            // asserting that future work there is impossible.
-            return 0.15 + normalized * 0.85
+        func hourWeight(at date: Date) -> Double {
+            guard cellWeights != nil else { return 1 }
+            let time = date.timeIntervalSince1970
+            return table(covering: time, time).weight(at: time)
+        }
+
+        // MARK: - Hour table
+
+        /// Per-block weights with prefix sums, so a query costs two block
+        /// lookups and one subtraction whatever its span.
+        private struct HourTable {
+            let phase: TimeInterval
+            let firstIndex: Int
+            let weights: [Double]
+            /// `cumulative[i]` is the total weight, in weight-hours, of the
+            /// blocks `[firstIndex, firstIndex + i)`.
+            let cumulative: [Double]
+
+            func index(for time: TimeInterval) -> Int {
+                Int(((time - phase) / 3_600).rounded(.down))
+            }
+
+            func blockStart(_ index: Int) -> TimeInterval {
+                Double(index) * 3_600 + phase
+            }
+
+            func covers(_ time: TimeInterval) -> Bool {
+                let index = index(for: time) - firstIndex
+                return index >= 0 && index < weights.count
+            }
+
+            func weight(at time: TimeInterval) -> Double {
+                let index = index(for: time) - firstIndex
+                guard weights.indices.contains(index) else { return 1 }
+                return weights[index]
+            }
+
+            func integral(from lower: TimeInterval, to upper: TimeInterval) -> Double {
+                guard upper > lower else { return 0 }
+                let lowerBlock = index(for: lower)
+                let upperBlock = index(for: upper)
+                if lowerBlock == upperBlock {
+                    return weight(at: lower) * (upper - lower) / 3_600
+                }
+                var total = weight(at: lower) * (blockStart(lowerBlock + 1) - lower) / 3_600
+                total += weight(at: upper) * (upper - blockStart(upperBlock)) / 3_600
+                let from = lowerBlock + 1 - firstIndex
+                let to = upperBlock - firstIndex
+                if to > from, cumulative.indices.contains(from), cumulative.indices.contains(to) {
+                    total += cumulative[to] - cumulative[from]
+                }
+                return total
+            }
+        }
+
+        private func table(covering lower: TimeInterval, _ upper: TimeInterval) -> HourTable {
+            if let table, table.covers(lower), table.covers(upper) { return table }
+            let phase = self.phase ?? Self.hourPhase(
+                for: Date(timeIntervalSince1970: lower),
+                timeZone: calendar.timeZone
+            )
+            self.phase = phase
+
+            var from = min(lower, upper) - Self.tablePaddingSeconds
+            var to = max(lower, upper) + Self.tablePaddingSeconds
+            // Grow to cover what the table already answered so a query that
+            // walks backwards through history does not thrash the build.
+            if let table {
+                let existingFrom = table.blockStart(table.firstIndex)
+                let existingTo = table.blockStart(table.firstIndex + table.weights.count)
+                if max(to, existingTo) - min(from, existingFrom) <= Self.maximumTableSeconds {
+                    from = min(from, existingFrom)
+                    to = max(to, existingTo)
+                }
+            }
+            let built = buildTable(phase: phase, from: from, to: to)
+            table = built
+            return built
+        }
+
+        private func buildTable(phase: TimeInterval, from: TimeInterval, to: TimeInterval) -> HourTable {
+            let firstIndex = Int(((from - phase) / 3_600).rounded(.down))
+            let lastIndex = Int(((to - phase) / 3_600).rounded(.down))
+            let count = max(1, lastIndex - firstIndex + 1)
+            let cells = cellWeights ?? [Double](repeating: 1, count: 7 * 24)
+
+            let timeZone = calendar.timeZone
+            let anchorStart = Double(firstIndex) * 3_600 + phase
+            let anchorDate = Date(timeIntervalSince1970: anchorStart)
+            var offset = timeZone.secondsFromGMT(for: anchorDate)
+            // Weekday numbering is read off the calendar once and then advanced
+            // by whole days, instead of hardcoding "epoch day zero was a
+            // Thursday" — a non-Gregorian calendar still lands on the heatmap
+            // row it was written with.
+            let anchorWeekday = max(0, min(6, calendar.component(.weekday, from: anchorDate) - 1))
+            let anchorDay = Self.floorDiv(Int(anchorStart.rounded(.down)) + offset, 86_400)
+            var nextTransition = timeZone
+                .nextDaylightSavingTimeTransition(after: anchorDate)?
+                .timeIntervalSince1970
+
+            var weights = [Double](repeating: 1, count: count)
+            var cumulative = [Double](repeating: 0, count: count + 1)
+            for step in 0..<count {
+                let blockStart = Double(firstIndex + step) * 3_600 + phase
+                while let transition = nextTransition, blockStart >= transition {
+                    offset = timeZone.secondsFromGMT(for: Date(timeIntervalSince1970: blockStart))
+                    nextTransition = timeZone
+                        .nextDaylightSavingTimeTransition(after: Date(timeIntervalSince1970: transition))?
+                        .timeIntervalSince1970
+                }
+                let local = Int(blockStart.rounded(.down)) + offset
+                let hour = Self.floorMod(Self.floorDiv(local, 3_600), 24)
+                let weekday = Self.floorMod(
+                    anchorWeekday + Self.floorDiv(local, 86_400) - anchorDay,
+                    7
+                )
+                weights[step] = cells[weekday * 24 + hour]
+                cumulative[step + 1] = cumulative[step] + weights[step]
+            }
+            return HourTable(
+                phase: phase,
+                firstIndex: firstIndex,
+                weights: weights,
+                cumulative: cumulative
+            )
+        }
+
+        /// Where the local hour boundaries sit on the epoch grid, for the
+        /// offset in force at `date`. Zones offset by a half or quarter hour
+        /// (India, Nepal) land on a non-zero phase; that is the point.
+        private static func hourPhase(for date: Date, timeZone: TimeZone) -> TimeInterval {
+            TimeInterval(floorMod(-timeZone.secondsFromGMT(for: date), 3_600))
+        }
+
+        private static func floorDiv(_ value: Int, _ divisor: Int) -> Int {
+            let quotient = value / divisor
+            return (value % divisor != 0 && (value < 0) != (divisor < 0)) ? quotient - 1 : quotient
+        }
+
+        private static func floorMod(_ value: Int, _ divisor: Int) -> Int {
+            let remainder = value % divisor
+            return remainder < 0 ? remainder + divisor : remainder
         }
     }
 

--- a/Sources/VibeBarCore/Services/QuotaService.swift
+++ b/Sources/VibeBarCore/Services/QuotaService.swift
@@ -180,7 +180,9 @@ public final class QuotaService: ObservableObject {
         lastSuccessByAccount.removeValue(forKey: accountId)
         lastErrorByAccount.removeValue(forKey: accountId)
         lastUpdatedByAccount.removeValue(forKey: accountId)
-        try? QuotaCacheStore.delete(accountId: accountId)
+        // Through the writer so a coalesced write for this account cannot land
+        // after the delete and resurrect the file.
+        Task { await QuotaCacheWriter.shared.delete(accountId: accountId) }
     }
 
     public func replaceBucket(_ bucket: QuotaBucket, for accountId: String) {
@@ -215,11 +217,6 @@ public final class QuotaService: ObservableObject {
         lastSuccessByAccount[success.accountId] = success
         lastErrorByAccount.removeValue(forKey: success.accountId)
         lastUpdatedByAccount[success.accountId] = success.queriedAt
-        do {
-            try QuotaCacheStore.save(success)
-        } catch {
-            SafeLog.warn("Saving quota cache failed: \(SafeLog.sanitize(error.localizedDescription))")
-        }
 
         // Store both the point observations used by the personal forecast and
         // the inferred completed cycles used by reset history. Both paths
@@ -227,6 +224,10 @@ public final class QuotaService: ObservableObject {
         let retention = retentionProvider()
         let quota = success
         Task { [weak self] in
+            // Every step below is deliberately actor work rather than main-actor
+            // work: the cache write is an encode plus an atomic file write, and
+            // the two stores parse and prune their whole file.
+            await QuotaCacheWriter.shared.save(quota)
             await UsageFillTimelineStore.shared.observe(quota, retentionDays: retention)
             await SubscriptionHistoryStore.shared.observe(quota, retentionDays: retention)
             await self?.refreshObservations(for: quota)
@@ -248,16 +249,21 @@ public final class QuotaService: ObservableObject {
         now: Date = Date()
     ) async {
         let context = activityContextProvider?(quota.tool) ?? .empty
-        let observations = quota.buckets.compactMap { bucket -> BucketForecastObservation? in
-            guard let forecast = paceForecast(
-                accountId: quota.accountId,
+        let inputs = quota.buckets.map { bucket in
+            let key = SubscriptionHistoryKey(accountId: quota.accountId, bucketId: bucket.id)
+            return ForecastInput(
                 bucket: bucket,
-                activityHeatmap: context.heatmap,
-                dailyActivity: context.dailyActivity,
-                now: now
-            ) else { return nil }
-            return BucketForecastObservation(bucket: bucket, forecast: forecast)
+                observations: observationsByAccountBucket[key] ?? [],
+                cycles: historyByAccountBucket[key] ?? []
+            )
         }
+        // Snapshot the inputs here, blend them there: the forecast is pure value
+        // math, but it is a full blend per bucket over every stored observation,
+        // and a thirty-bucket account paid for all of it on the main actor while
+        // the popover was trying to draw.
+        let observations = await Task.detached(priority: .utility) {
+            Self.forecastObservations(inputs: inputs, context: context, now: now)
+        }.value
         guard !observations.isEmpty else { return }
         await UsageForecastTimelineStore.shared.observe(
             observations,
@@ -266,6 +272,32 @@ public final class QuotaService: ObservableObject {
             now: now,
             retentionDays: retentionDays
         )
+    }
+
+    /// One bucket's forecast inputs, snapshotted from main-actor state so the
+    /// blend itself can run off it.
+    private struct ForecastInput: Sendable {
+        let bucket: QuotaBucket
+        let observations: [FillTimelinePoint]
+        let cycles: [SubscriptionWindowSample]
+    }
+
+    private nonisolated static func forecastObservations(
+        inputs: [ForecastInput],
+        context: QuotaActivityContext,
+        now: Date
+    ) -> [BucketForecastObservation] {
+        inputs.compactMap { input in
+            guard let forecast = QuotaPaceForecast.compute(
+                bucket: input.bucket,
+                observations: input.observations,
+                cycles: input.cycles,
+                activityHeatmap: context.heatmap,
+                dailyActivity: context.dailyActivity,
+                now: now
+            ) else { return nil }
+            return BucketForecastObservation(bucket: input.bucket, forecast: forecast)
+        }
     }
 
     private func applyInitialObservations(_ points: [FillTimelinePoint]) {
@@ -277,15 +309,28 @@ public final class QuotaService: ObservableObject {
         observationsByAccountBucket = grouped.mapValues { $0.sorted { $0.sampledAt < $1.sampledAt } }
     }
 
+    /// Republish every bucket's observation lane for one account.
+    ///
+    /// Gathering across the single `await` and applying the result in one
+    /// assignment is load-bearing, not tidiness: this dictionary is
+    /// `@Published`, and the previous shape — one store round trip and one
+    /// assignment per bucket — put every bucket in its own main-actor tick.
+    /// A Claude account with thirty buckets therefore re-rendered the whole
+    /// popover thirty times per refresh, and the all-providers history card
+    /// re-segmented every lane on each of them.
     private func refreshObservations(for quota: AccountQuota) async {
-        for bucket in quota.buckets {
-            let key = SubscriptionHistoryKey(accountId: quota.accountId, bucketId: bucket.id)
-            let points = await UsageFillTimelineStore.shared.points(
-                accountId: quota.accountId,
-                bucketId: bucket.id
-            )
-            observationsByAccountBucket[key] = points
+        let bucketIds = quota.buckets.map(\.id)
+        guard !bucketIds.isEmpty else { return }
+        let grouped = await UsageFillTimelineStore.shared.points(
+            accountId: quota.accountId,
+            bucketIds: bucketIds
+        )
+        var updated = observationsByAccountBucket
+        for bucketId in bucketIds {
+            let key = SubscriptionHistoryKey(accountId: quota.accountId, bucketId: bucketId)
+            updated[key] = grouped[bucketId] ?? []
         }
+        observationsByAccountBucket = updated
     }
 
     private func applyInitialSubscriptionHistory(_ samples: [SubscriptionWindowSample]) {
@@ -310,9 +355,12 @@ public final class QuotaService: ObservableObject {
             let key = SubscriptionHistoryKey(accountId: quota.accountId, bucketId: bucket.id)
             updates[key] = samples
         }
+        // Same one-publish rule as `refreshObservations`.
+        var merged = historyByAccountBucket
         for (key, samples) in updates {
-            historyByAccountBucket[key] = samples
+            merged[key] = samples
         }
+        historyByAccountBucket = merged
     }
 
     private func store(error: QuotaError, for account: AccountIdentity) {

--- a/Sources/VibeBarCore/Services/UsageFillTimelineStore.swift
+++ b/Sources/VibeBarCore/Services/UsageFillTimelineStore.swift
@@ -96,6 +96,24 @@ public actor UsageFillTimelineStore {
             .sorted { $0.slotStart < $1.slotStart }
     }
 
+    /// Points for several buckets of one account, oldest first per bucket.
+    ///
+    /// One actor hop for the whole account instead of one per bucket: the
+    /// caller republishes the result into `@Published` state, and an `await`
+    /// between buckets meant every bucket landed in its own main-actor tick —
+    /// which is a full popover re-render each, thirty-odd of them per refresh.
+    /// Buckets with no recorded points are absent from the result.
+    public func points(accountId: String, bucketIds: [String]) -> [String: [FillTimelinePoint]] {
+        let wanted = Set(bucketIds)
+        guard !wanted.isEmpty else { return [:] }
+        var grouped: [String: [FillTimelinePoint]] = [:]
+        for point in load().points
+        where point.accountId == accountId && wanted.contains(point.bucketId) {
+            grouped[point.bucketId, default: []].append(point)
+        }
+        return grouped.mapValues { $0.sorted { $0.slotStart < $1.slotStart } }
+    }
+
     public func allPoints() -> [FillTimelinePoint] {
         load().points
     }

--- a/Sources/VibeBarCore/Storage/QuotaCacheWriter.swift
+++ b/Sources/VibeBarCore/Storage/QuotaCacheWriter.swift
@@ -1,0 +1,91 @@
+import Foundation
+
+/// Serializes and coalesces quota-cache writes off the main actor.
+///
+/// `QuotaCacheStore.save` pretty-prints a whole account's quota, writes it
+/// atomically and then sets file permissions — tens of milliseconds of
+/// synchronous filesystem work. `QuotaService` used to pay that on the main
+/// actor once per successful account refresh, so the refresh a popover-open
+/// triggers stalled rendering once per provider.
+///
+/// Coalescing follows `UsageFillTimelineStore`: the newest quota for an account
+/// always wins, and at most one write per account lands per throttle window.
+/// Dropping the last few seconds of writes on a hard kill is acceptable here —
+/// the file is a warm-start cache whose only job is to show the last known
+/// numbers before the first live refresh of the next launch completes.
+public actor QuotaCacheWriter {
+    public static let shared = QuotaCacheWriter()
+
+    private let throttleInterval: TimeInterval
+    private let write: @Sendable (AccountQuota) throws -> Void
+    private let remove: @Sendable (String) throws -> Void
+
+    private var lastWrittenAt: [String: Date] = [:]
+    private var pending: [String: AccountQuota] = [:]
+    private var flushTask: Task<Void, Never>?
+
+    public init(
+        throttleInterval: TimeInterval = 15,
+        write: @escaping @Sendable (AccountQuota) throws -> Void = { try QuotaCacheStore.save($0) },
+        remove: @escaping @Sendable (String) throws -> Void = { try QuotaCacheStore.delete(accountId: $0) }
+    ) {
+        self.throttleInterval = throttleInterval
+        self.write = write
+        self.remove = remove
+    }
+
+    public func save(_ quota: AccountQuota, now: Date = Date()) {
+        if let last = lastWrittenAt[quota.accountId],
+           now.timeIntervalSince(last) < throttleInterval {
+            pending[quota.accountId] = quota
+            scheduleFlush(after: throttleInterval - now.timeIntervalSince(last))
+            return
+        }
+        persist(quota, now: now)
+    }
+
+    /// Forget an account and delete its file. Routed through the writer rather
+    /// than called directly so a throttled write still in flight cannot
+    /// resurrect the cache of an account the user just signed out of.
+    public func delete(accountId: String) {
+        pending.removeValue(forKey: accountId)
+        lastWrittenAt.removeValue(forKey: accountId)
+        do {
+            try remove(accountId)
+        } catch {
+            SafeLog.warn("Deleting quota cache failed: \(SafeLog.sanitize(error.localizedDescription))")
+        }
+    }
+
+    public func flushPendingWrites() {
+        let queued = pending
+        pending = [:]
+        flushTask?.cancel()
+        flushTask = nil
+        let now = Date()
+        for quota in queued.values {
+            persist(quota, now: now)
+        }
+    }
+
+    // MARK: - Private
+
+    private func persist(_ quota: AccountQuota, now: Date) {
+        do {
+            try write(quota)
+        } catch {
+            SafeLog.warn("Saving quota cache failed: \(SafeLog.sanitize(error.localizedDescription))")
+        }
+        lastWrittenAt[quota.accountId] = now
+        pending.removeValue(forKey: quota.accountId)
+    }
+
+    private func scheduleFlush(after delay: TimeInterval) {
+        if flushTask != nil { return }
+        let nanoseconds = UInt64(max(0.05, delay) * 1_000_000_000)
+        flushTask = Task { [weak self] in
+            try? await Task.sleep(nanoseconds: nanoseconds)
+            await self?.flushPendingWrites()
+        }
+    }
+}

--- a/Tests/VibeBarCoreTests/AppSettingsTests.swift
+++ b/Tests/VibeBarCoreTests/AppSettingsTests.swift
@@ -57,6 +57,38 @@ final class AppSettingsTests: XCTestCase {
         XCTAssertTrue(decoded.miscCookieAutoImportEnabled)
     }
 
+    func testMenuBarColorBasisDefaultsToForecastAndRoundTrips() throws {
+        // Deliberately the opposite of the usual "absent key keeps the old
+        // behavior" rule: forecast coloring is the intended menu-bar reading,
+        // so a settings file written before the picker existed has to adopt it
+        // on upgrade. The picker exists to opt *back* into raw thresholds.
+        let legacy = try JSONDecoder().decode(
+            AppSettings.self,
+            from: Data(#"{"displayMode":"remaining"}"#.utf8)
+        )
+        XCTAssertEqual(legacy.menuBarColorBasis, .forecast)
+        XCTAssertEqual(AppSettings.default.menuBarColorBasis, .forecast)
+
+        var settings = AppSettings.default
+        settings.menuBarColorBasis = .actual
+        let decoded = try JSONDecoder().decode(
+            AppSettings.self,
+            from: try JSONEncoder().encode(settings)
+        )
+        XCTAssertEqual(decoded.menuBarColorBasis, .actual)
+    }
+
+    func testUnknownMenuBarColorBasisFallsBackWithoutFailingTheFile() throws {
+        // A hand-edited or downgraded raw value must cost the user this one
+        // preference, not every other setting in the file.
+        let settings = try JSONDecoder().decode(
+            AppSettings.self,
+            from: Data(#"{"displayMode":"used","menuBarColorBasis":"vibes"}"#.utf8)
+        )
+        XCTAssertEqual(settings.menuBarColorBasis, .forecast)
+        XCTAssertEqual(settings.displayMode, .used)
+    }
+
     func testOverviewQuotaHistoryHiddenCurvesDefaultToNoneAndRoundTrip() throws {
         // Stored as *hidden* ids, so a settings file written before the
         // Overview chart existed has to mean "show everything" — not "show

--- a/Tests/VibeBarCoreTests/AppSettingsTests.swift
+++ b/Tests/VibeBarCoreTests/AppSettingsTests.swift
@@ -37,6 +37,26 @@ final class AppSettingsTests: XCTestCase {
         XCTAssertEqual(settings.updateChannel, .main)
     }
 
+    func testMiscCookieAutoImportDefaultsToOffAndRoundTrips() throws {
+        // Must decode to `false` for a settings file written before the
+        // toggle existed: opening an old config with a newer build cannot
+        // be what starts background browser / Keychain reads.
+        let legacy = try JSONDecoder().decode(
+            AppSettings.self,
+            from: Data(#"{"displayMode":"remaining"}"#.utf8)
+        )
+        XCTAssertFalse(legacy.miscCookieAutoImportEnabled)
+        XCTAssertFalse(AppSettings.default.miscCookieAutoImportEnabled)
+
+        var settings = AppSettings.default
+        settings.miscCookieAutoImportEnabled = true
+        let decoded = try JSONDecoder().decode(
+            AppSettings.self,
+            from: try JSONEncoder().encode(settings)
+        )
+        XCTAssertTrue(decoded.miscCookieAutoImportEnabled)
+    }
+
     func testOverviewQuotaHistoryHiddenCurvesDefaultToNoneAndRoundTrip() throws {
         // Stored as *hidden* ids, so a settings file written before the
         // Overview chart existed has to mean "show everything" — not "show

--- a/Tests/VibeBarCoreTests/CostAggregationCacheTests.swift
+++ b/Tests/VibeBarCoreTests/CostAggregationCacheTests.swift
@@ -81,6 +81,36 @@ final class CostAggregationCacheTests: XCTestCase {
         )
     }
 
+    func testAdoptingACalendarDropsEveryMemoAndMovesTheDayBoundary() throws {
+        let now = day(2026, 7, 30)
+        let source = snapshot(
+            tool: .codex,
+            history: [(day(2026, 7, 30, hour: 9), 2, 200)],
+            updatedAt: now
+        )
+        let cache = CostAggregationCache(calendar: calendar)
+        cache.setSource([.codex: source])
+        XCTAssertNotNil(cache.snapshot(for: .codex, now: now))
+
+        // Prove the memo is warm, then change the zone the way the system
+        // notification handler does. The swapped-in source must become visible
+        // without any `setSource`: a zone change re-cuts "today", so serving
+        // the old memo would keep totals offset until relaunch.
+        let replaced = snapshot(tool: .codex, history: [(day(2026, 7, 30, hour: 9), 99, 9)], updatedAt: now)
+        cache.setSourceWithoutInvalidatingForTesting([.codex: replaced])
+        XCTAssertEqual(cache.snapshot(for: .codex, now: now)?.todayCostUSD ?? 0, 2, accuracy: 0.0001)
+
+        var tokyo = Calendar(identifier: .gregorian)
+        tokyo.timeZone = TimeZone(identifier: "Asia/Tokyo")!
+        cache.adoptCalendar(tokyo)
+        XCTAssertEqual(cache.snapshot(for: .codex, now: now)?.todayCostUSD ?? 0, 99, accuracy: 0.0001)
+
+        // And the answer is the Tokyo-day answer, not the LA memo re-served:
+        // recomputing directly under the adopted calendar must agree exactly.
+        let tokyoExpected = replaced.rebasedForCurrentDay(now: now, calendar: tokyo)
+        XCTAssertEqual(cache.snapshot(for: .codex, now: now), tokyoExpected)
+    }
+
     func testDayRolloverDropsEveryMemo() throws {
         let today = day(2026, 7, 30)
         let source = snapshot(

--- a/Tests/VibeBarCoreTests/CostAggregationCacheTests.swift
+++ b/Tests/VibeBarCoreTests/CostAggregationCacheTests.swift
@@ -1,0 +1,250 @@
+import XCTest
+@testable import VibeBarCore
+
+/// The popover reads these derived values dozens of times per render pass, so
+/// the cache has to be both correct (same answers as recomputing) and actually
+/// caching (a changed source that was never announced must NOT be picked up —
+/// that is what proves the memo, and why every write path has to call
+/// `setSource`).
+final class CostAggregationCacheTests: XCTestCase {
+    private var calendar: Calendar = {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "America/Los_Angeles")!
+        return calendar
+    }()
+
+    private func day(_ year: Int, _ month: Int, _ dayOfMonth: Int, hour: Int = 12) -> Date {
+        calendar.date(from: DateComponents(year: year, month: month, day: dayOfMonth, hour: hour))!
+    }
+
+    private func snapshot(
+        tool: ToolType,
+        history: [(Date, Double, Int)],
+        jsonlFilesFound: Int = 3,
+        updatedAt: Date
+    ) -> CostSnapshot {
+        CostSnapshot(
+            tool: tool,
+            todayCostUSD: 0,
+            last7DaysCostUSD: 0,
+            last30DaysCostUSD: 0,
+            allTimeCostUSD: 0,
+            todayTokens: 0,
+            last7DaysTokens: 0,
+            last30DaysTokens: 0,
+            allTimeTokens: 0,
+            dailyHistory: history.map {
+                DailyCostPoint(date: $0.0, costUSD: $0.1, totalTokens: $0.2)
+            },
+            heatmap: UsageHeatmap(
+                tool: tool,
+                cells: Array(repeating: Array(repeating: 1, count: 24), count: 7),
+                totalTokens: 168
+            ),
+            modelBreakdowns: [
+                CostSnapshot.ModelBreakdown(modelName: "model-a", costUSD: 1, totalTokens: 10)
+            ],
+            jsonlFilesFound: jsonlFilesFound,
+            updatedAt: updatedAt
+        )
+    }
+
+    func testRebasedSnapshotMatchesDirectComputationAndIsMemoized() throws {
+        let now = day(2026, 7, 30)
+        let source = snapshot(
+            tool: .codex,
+            history: [
+                (day(2026, 7, 30, hour: 9), 2, 200),
+                (day(2026, 7, 29, hour: 9), 3, 300),
+                (day(2026, 6, 1, hour: 9), 40, 4_000)
+            ],
+            updatedAt: now
+        )
+        let cache = CostAggregationCache(calendar: calendar)
+        cache.setSource([.codex: source])
+
+        let expected = source.rebasedForCurrentDay(now: now, calendar: calendar)
+        XCTAssertEqual(cache.snapshot(for: .codex, now: now), expected)
+
+        // A source swapped in behind the cache's back is deliberately not
+        // visible: that is the memo doing its job.
+        let replaced = snapshot(tool: .codex, history: [(day(2026, 7, 30, hour: 9), 99, 9)], updatedAt: now)
+        cache.setSourceWithoutInvalidatingForTesting([.codex: replaced])
+        XCTAssertEqual(cache.snapshot(for: .codex, now: now)?.todayCostUSD, expected.todayCostUSD)
+
+        // Announced, it is.
+        cache.setSource([.codex: replaced])
+        XCTAssertEqual(
+            try XCTUnwrap(cache.snapshot(for: .codex, now: now)).todayCostUSD,
+            99,
+            accuracy: 0.0001
+        )
+    }
+
+    func testDayRolloverDropsEveryMemo() throws {
+        let today = day(2026, 7, 30)
+        let source = snapshot(
+            tool: .codex,
+            history: [
+                (day(2026, 7, 30, hour: 9), 2, 200),
+                (day(2026, 7, 31, hour: 9), 5, 500)
+            ],
+            updatedAt: today
+        )
+        let cache = CostAggregationCache(calendar: calendar)
+        cache.setSource([.codex: source])
+
+        // Tomorrow's point is in the future today, so it is excluded — and
+        // included once the day rolls over. Same object, no `setSource`.
+        XCTAssertEqual(
+            try XCTUnwrap(cache.snapshot(for: .codex, now: today)).allTimeCostUSD,
+            2,
+            accuracy: 0.0001
+        )
+        let tomorrow = day(2026, 7, 31)
+        XCTAssertEqual(
+            try XCTUnwrap(cache.snapshot(for: .codex, now: tomorrow)).allTimeCostUSD,
+            7,
+            accuracy: 0.0001
+        )
+    }
+
+    func testCombinedSnapshotMatchesAggregatorAndSharesTheMemoWithRollupGroups() {
+        let now = day(2026, 7, 30)
+        let gemini = snapshot(tool: .gemini, history: [(day(2026, 7, 30, hour: 8), 1, 100)], updatedAt: now)
+        let antigravity = snapshot(
+            tool: .antigravity,
+            history: [(day(2026, 7, 30, hour: 8), 4, 400)],
+            updatedAt: now
+        )
+        let cache = CostAggregationCache(calendar: calendar)
+        cache.setSource([.gemini: gemini, .antigravity: antigravity])
+
+        let expected = CostSnapshotAggregator.combinedSnapshot(
+            tool: .antigravity,
+            snapshots: [gemini, antigravity],
+            now: now,
+            calendar: calendar
+        )
+        let combined = cache.combinedSnapshot(of: [.gemini, .antigravity], labelledAs: .antigravity, now: now)
+        XCTAssertEqual(combined, expected)
+
+        let rollup = cache.rollup(
+            individualTools: [],
+            groups: [CostSnapshotGroup(label: .antigravity, tools: [.gemini, .antigravity])],
+            labelledAs: .codex,
+            now: now
+        )
+        XCTAssertEqual(rollup.groupSnapshots.first, combined)
+        XCTAssertEqual(rollup.snapshots.count, 1)
+        XCTAssertTrue(rollup.hasCostData)
+    }
+
+    func testRollupMatchesAggregatorAndDropsEmptyGroups() {
+        let now = day(2026, 7, 30)
+        let codex = snapshot(tool: .codex, history: [(day(2026, 7, 29, hour: 8), 2, 200)], updatedAt: now)
+        let emptyGemini = snapshot(
+            tool: .gemini,
+            history: [],
+            jsonlFilesFound: 0,
+            updatedAt: now
+        )
+        let cache = CostAggregationCache(calendar: calendar)
+        cache.setSource([.codex: codex, .gemini: emptyGemini])
+
+        let rollup = cache.rollup(
+            individualTools: [.codex],
+            groups: [CostSnapshotGroup(label: .antigravity, tools: [.gemini, .antigravity])],
+            labelledAs: .codex,
+            now: now
+        )
+        // A group with no session logs contributes nothing to the aggregate —
+        // otherwise a zero-filled snapshot would claim the Overview has data.
+        XCTAssertEqual(rollup.snapshots.count, 1)
+        XCTAssertEqual(rollup.groupSnapshots.count, 1)
+        XCTAssertEqual(rollup.groupSnapshots.first?.jsonlFilesFound, 0)
+
+        let rebased = codex.rebasedForCurrentDay(now: now, calendar: calendar)
+        XCTAssertEqual(
+            rollup.dailyHistory,
+            CostSnapshotAggregator.combinedDailyHistory([rebased], calendar: calendar)
+        )
+        XCTAssertEqual(rollup.heatmap, CostSnapshotAggregator.combinedHeatmap([rebased]))
+        XCTAssertEqual(
+            rollup.modelBreakdowns,
+            CostSnapshotAggregator.combinedModelBreakdowns([rebased])
+        )
+        XCTAssertEqual(
+            rollup.combinedSnapshot,
+            CostSnapshotAggregator.combinedSnapshot(
+                tool: .codex,
+                snapshots: [rebased],
+                now: now,
+                calendar: calendar
+            )
+        )
+    }
+
+    func testHasJSONLFilesReadsRawCountsWithoutRebasing() {
+        let now = day(2026, 7, 30)
+        let cache = CostAggregationCache(calendar: calendar)
+        cache.setSource([
+            .codex: snapshot(tool: .codex, history: [], jsonlFilesFound: 0, updatedAt: now),
+            .gemini: snapshot(tool: .gemini, history: [], jsonlFilesFound: 2, updatedAt: now)
+        ])
+
+        XCTAssertFalse(cache.hasJSONLFiles(in: [.codex]))
+        XCTAssertFalse(cache.hasJSONLFiles(in: [.claude]))
+        XCTAssertTrue(cache.hasJSONLFiles(in: [.codex, .gemini]))
+        // The Overview's real question: a Gemini snapshot with logs but no
+        // history still counts, which is what keeps the cost cards on screen
+        // while the daily history is empty.
+        XCTAssertTrue(cache.hasJSONLFiles(in: [.gemini, .antigravity]))
+    }
+
+    func testTotalsMatchPerProviderSumsIncludingYesterdayAndPeaks() {
+        let now = day(2026, 7, 30)
+        let codex = snapshot(
+            tool: .codex,
+            history: [
+                (day(2026, 7, 30, hour: 8), 2, 200),
+                (day(2026, 7, 29, hour: 8), 7, 700)
+            ],
+            updatedAt: now
+        )
+        let claude = snapshot(
+            tool: .claude,
+            history: [
+                (day(2026, 7, 30, hour: 8), 3, 300),
+                (day(2026, 7, 29, hour: 8), 1, 100)
+            ],
+            updatedAt: now
+        )
+        let cache = CostAggregationCache(calendar: calendar)
+        cache.setSource([.codex: codex, .claude: claude])
+
+        let totals = cache.totals(of: [.codex, .claude], now: now)
+        XCTAssertEqual(totals.todayCostUSD, 5, accuracy: 0.0001)
+        XCTAssertEqual(totals.yesterdayCostUSD, 8, accuracy: 0.0001)
+        XCTAssertEqual(totals.allTimeCostUSD, 13, accuracy: 0.0001)
+        XCTAssertEqual(totals.todayTokens, 500)
+        XCTAssertEqual(totals.yesterdayTokens, 800)
+        XCTAssertEqual(totals.allTimeTokens, 1_300)
+        // Peaks are over the *combined* day, so yesterday's 7 + 1 outranks
+        // today's 2 + 3.
+        XCTAssertEqual(totals.peakDayCostUSD, 8, accuracy: 0.0001)
+        XCTAssertEqual(totals.peakDayTokens, 800)
+    }
+
+    func testTotalsAreKeyedByProviderSetSoHidingOneChangesTheAnswer() {
+        let now = day(2026, 7, 30)
+        let cache = CostAggregationCache(calendar: calendar)
+        cache.setSource([
+            .codex: snapshot(tool: .codex, history: [(day(2026, 7, 30, hour: 8), 2, 200)], updatedAt: now),
+            .claude: snapshot(tool: .claude, history: [(day(2026, 7, 30, hour: 8), 3, 300)], updatedAt: now)
+        ])
+
+        XCTAssertEqual(cache.totals(of: [.codex, .claude], now: now).todayCostUSD, 5, accuracy: 0.0001)
+        XCTAssertEqual(cache.totals(of: [.codex], now: now).todayCostUSD, 2, accuracy: 0.0001)
+    }
+}

--- a/Tests/VibeBarCoreTests/MenuBarPercentColorTests.swift
+++ b/Tests/VibeBarCoreTests/MenuBarPercentColorTests.swift
@@ -1,0 +1,167 @@
+import XCTest
+@testable import VibeBarCore
+
+final class MenuBarPercentColorTests: XCTestCase {
+    /// Every verdict the forecast can produce. `Verdict` is not `CaseIterable`,
+    /// so the list is spelled out — a new case fails to compile here, which is
+    /// the point.
+    private static let allVerdicts: [QuotaPaceForecast.Verdict] = [
+        .enough, .surplus, .watch, .atRisk, .learning
+    ]
+
+    private func resolve(
+        _ basis: MenuBarColorBasis,
+        _ verdict: QuotaPaceForecast.Verdict?,
+        _ percent: Double,
+        _ mode: DisplayMode
+    ) -> MenuBarPercentColor {
+        MenuBarPercentColor.resolve(
+            basis: basis,
+            verdict: verdict,
+            percent: percent,
+            displayMode: mode
+        )
+    }
+
+    // MARK: - Actual basis
+
+    func testActualBasisMatchesLegacyRemainingThresholds() {
+        // Exactly the boundaries the pre-forecast menu bar used: < 10 red,
+        // < 30 orange, otherwise green. Regression fence for "Actual" being
+        // a true opt-back-in rather than a new palette.
+        let cases: [(Double, MenuBarPercentColor)] = [
+            (0, .risk),
+            (9.9, .risk),
+            (10, .watch),
+            (29.9, .watch),
+            (30, .healthy),
+            (100, .healthy)
+        ]
+        for (percent, expected) in cases {
+            XCTAssertEqual(
+                resolve(.actual, nil, percent, .remaining),
+                expected,
+                "remaining \(percent)"
+            )
+        }
+    }
+
+    func testActualBasisMatchesLegacyUsedThresholds() {
+        let cases: [(Double, MenuBarPercentColor)] = [
+            (0, .healthy),
+            (69.9, .healthy),
+            (70, .watch),
+            (89.9, .watch),
+            (90, .risk),
+            (100, .risk)
+        ]
+        for (percent, expected) in cases {
+            XCTAssertEqual(
+                resolve(.actual, nil, percent, .used),
+                expected,
+                "used \(percent)"
+            )
+        }
+    }
+
+    func testActualBasisIgnoresEveryVerdict() {
+        // The forecast may be fully converged and still must not touch the
+        // color once the user asked for raw thresholds.
+        for verdict in Self.allVerdicts {
+            XCTAssertEqual(resolve(.actual, verdict, 5, .remaining), .risk)
+            XCTAssertEqual(resolve(.actual, verdict, 55, .remaining), .healthy)
+            XCTAssertEqual(resolve(.actual, verdict, 95, .used), .risk)
+            XCTAssertEqual(resolve(.actual, verdict, 5, .used), .healthy)
+        }
+    }
+
+    func testActualBasisNeverReportsSurplus() {
+        for percent in stride(from: 0.0, through: 100.0, by: 0.5) {
+            for mode in DisplayMode.allCases {
+                XCTAssertNotEqual(resolve(.actual, nil, percent, mode), .surplus)
+            }
+        }
+    }
+
+    // MARK: - Forecast basis
+
+    func testForecastBasisMapsVerdictsRegardlessOfPercentOrMode() {
+        let mapping: [(QuotaPaceForecast.Verdict, MenuBarPercentColor)] = [
+            (.enough, .healthy),
+            (.surplus, .surplus),
+            (.watch, .watch),
+            (.atRisk, .risk)
+        ]
+        for (verdict, expected) in mapping {
+            for percent in [0.0, 9.0, 24.0, 30.0, 70.0, 90.0, 100.0] {
+                for mode in DisplayMode.allCases {
+                    XCTAssertEqual(
+                        resolve(.forecast, verdict, percent, mode),
+                        expected,
+                        "\(verdict) at \(percent) \(mode)"
+                    )
+                }
+            }
+        }
+    }
+
+    func testForecastBasisTurnsALowButSurvivableQuotaGreen() {
+        // The reported case: 24% remaining, reset hours away, forecast says it
+        // lasts. Raw thresholds call that orange; the forecast basis must not.
+        XCTAssertEqual(resolve(.actual, .enough, 24, .remaining), .watch)
+        XCTAssertEqual(resolve(.forecast, .enough, 24, .remaining), .healthy)
+    }
+
+    func testForecastBasisWithoutAVerdictFallsBackToThresholds() {
+        // No account, or no observations recorded yet. A menu bar cannot show
+        // "unknown" — a gray percentage reads as a broken app.
+        for (percent, mode, expected) in [
+            (5.0, DisplayMode.remaining, MenuBarPercentColor.risk),
+            (20.0, DisplayMode.remaining, MenuBarPercentColor.watch),
+            (80.0, DisplayMode.remaining, MenuBarPercentColor.healthy),
+            (95.0, DisplayMode.used, MenuBarPercentColor.risk),
+            (75.0, DisplayMode.used, MenuBarPercentColor.watch),
+            (10.0, DisplayMode.used, MenuBarPercentColor.healthy)
+        ] {
+            XCTAssertEqual(resolve(.forecast, nil, percent, mode), expected)
+        }
+    }
+
+    func testForecastBasisWhileLearningFallsBackToThresholds() {
+        // Same constraint as a missing verdict: until the forecast converges
+        // the thresholds are the only thing left to say.
+        for (percent, mode, expected) in [
+            (5.0, DisplayMode.remaining, MenuBarPercentColor.risk),
+            (20.0, DisplayMode.remaining, MenuBarPercentColor.watch),
+            (80.0, DisplayMode.remaining, MenuBarPercentColor.healthy),
+            (95.0, DisplayMode.used, MenuBarPercentColor.risk),
+            (75.0, DisplayMode.used, MenuBarPercentColor.watch),
+            (10.0, DisplayMode.used, MenuBarPercentColor.healthy)
+        ] {
+            XCTAssertEqual(resolve(.forecast, .learning, percent, mode), expected)
+            XCTAssertEqual(
+                resolve(.forecast, .learning, percent, mode),
+                resolve(.actual, nil, percent, mode)
+            )
+        }
+    }
+
+    // MARK: - Basis enum
+
+    func testColorBasisRawValuesAreStable() {
+        // Persisted in settings.json — renaming a raw value silently resets
+        // the user's choice.
+        XCTAssertEqual(MenuBarColorBasis.forecast.rawValue, "forecast")
+        XCTAssertEqual(MenuBarColorBasis.actual.rawValue, "actual")
+        XCTAssertEqual(MenuBarColorBasis.allCases, [.forecast, .actual])
+    }
+
+    func testForecastBasisCaptionNamesEveryColorItCanPaint() {
+        // The menu bar shows a bare colored number, so this caption is the only
+        // legend the feature has — blue especially cannot be guessed.
+        let detail = MenuBarColorBasis.forecast.detail.lowercased()
+        for word in ["green", "blue", "orange", "red"] {
+            XCTAssertTrue(detail.contains(word), "caption omits \(word)")
+        }
+    }
+}

--- a/Tests/VibeBarCoreTests/MiscCookieAutoImporterTests.swift
+++ b/Tests/VibeBarCoreTests/MiscCookieAutoImporterTests.swift
@@ -1,0 +1,323 @@
+import XCTest
+@testable import VibeBarCore
+
+/// Covers the gating and retry-merge logic of the opt-in silent
+/// re-import. The browser read itself (`MiscCookieResolver.silentReimport`)
+/// needs a real cookie store and Keychain, so it's injected here — what
+/// matters for correctness is *whether* and *how often* it runs.
+final class MiscCookieAutoImporterTests: XCTestCase {
+    private let account = AccountIdentity(
+        id: "misc-kimi",
+        tool: .kimi,
+        email: "user@example.com",
+        source: .browserCookie
+    )
+
+    private let spec = MiscCookieResolver.Spec(
+        tool: .kimi,
+        domains: ["www.kimi.com"],
+        requiredNames: ["kimi-auth"]
+    )
+
+    private let queriedAt = Date(timeIntervalSince1970: 1_700_000_000)
+
+    private func quota() -> AccountQuota {
+        AccountQuota(
+            accountId: account.id,
+            tool: .kimi,
+            buckets: [
+                QuotaBucket(
+                    id: "kimi.weekly",
+                    title: "Weekly",
+                    shortLabel: "Wk",
+                    usedPercent: 42,
+                    resetAt: nil,
+                    rawWindowSeconds: 7 * 86_400
+                )
+            ],
+            plan: nil
+        )
+    }
+
+    /// The whole point of the default-off setting: a stale jar must not
+    /// trigger any browser or Keychain work until the user opts in.
+    func testDisabledSettingSkipsReimportEntirely() async {
+        let slotID = UUID()
+        let reimportCalls = Counter()
+        let importer = MiscCookieAutoImporter(
+            isEnabled: { false },
+            reimport: { _, _ in
+                reimportCalls.increment()
+                return true
+            },
+            resolve: { _, _ in
+                XCTFail("resolve must not run when the setting is off")
+                return []
+            }
+        )
+
+        let results = await importer.gatherSlotResults(
+            spec: spec,
+            account: account,
+            resolutions: [.init(slotID: slotID, header: "kimi-auth=stale", sourceLabel: "Chrome")]
+        ) { _ in
+            throw QuotaError.needsLogin
+        }
+
+        XCTAssertEqual(reimportCalls.value, 0)
+        XCTAssertEqual(results.count, 1)
+        XCTAssertEqual(results.first?.outcome.failureError, .needsLogin)
+    }
+
+    /// A healthy fetch must not pay for a settings read, a browser walk,
+    /// or a second network round-trip.
+    func testSuccessfulFetchNeverReimports() async {
+        let reimportCalls = Counter()
+        let importer = MiscCookieAutoImporter(
+            isEnabled: {
+                XCTFail("the setting should not even be consulted when nothing is stale")
+                return true
+            },
+            reimport: { _, _ in
+                reimportCalls.increment()
+                return true
+            },
+            resolve: { _, _ in [] }
+        )
+
+        let results = await importer.gatherSlotResults(
+            spec: spec,
+            account: account,
+            resolutions: [.init(slotID: UUID(), header: "kimi-auth=good", sourceLabel: "Chrome")]
+        ) { _ in
+            self.quota()
+        }
+
+        XCTAssertEqual(reimportCalls.value, 0)
+        XCTAssertNil(results.first?.outcome.failureError)
+    }
+
+    func testEnabledSettingReimportsOnceAndRetriesWithTheFreshHeader() async {
+        let slotID = UUID()
+        let reimportCalls = Counter()
+        let seenHeaders = HeaderLog()
+        let importer = MiscCookieAutoImporter(
+            isEnabled: { true },
+            reimport: { _, _ in
+                reimportCalls.increment()
+                return true
+            },
+            resolve: { _, _ in
+                [.init(slotID: slotID, header: "kimi-auth=fresh", sourceLabel: "Chrome")]
+            }
+        )
+
+        let results = await importer.gatherSlotResults(
+            spec: spec,
+            account: account,
+            resolutions: [.init(slotID: slotID, header: "kimi-auth=stale", sourceLabel: "Chrome")]
+        ) { resolution in
+            seenHeaders.append(resolution.header)
+            guard resolution.header == "kimi-auth=fresh" else { throw QuotaError.needsLogin }
+            return self.quota()
+        }
+
+        XCTAssertEqual(reimportCalls.value, 1, "exactly one re-import, no loop")
+        XCTAssertEqual(seenHeaders.values, ["kimi-auth=stale", "kimi-auth=fresh"])
+        XCTAssertEqual(results.count, 1)
+        XCTAssertNil(results.first?.outcome.failureError, "the retry's success should replace the failure")
+    }
+
+    /// A second `needsLogin` surfaces as `needsLogin`, and the retry does
+    /// not itself trigger another re-import.
+    func testRetryFailureStillSurfacesTheCredentialError() async {
+        let slotID = UUID()
+        let reimportCalls = Counter()
+        let fetchCalls = Counter()
+        let importer = MiscCookieAutoImporter(
+            isEnabled: { true },
+            reimport: { _, _ in
+                reimportCalls.increment()
+                return true
+            },
+            resolve: { _, _ in
+                [.init(slotID: slotID, header: "kimi-auth=also-stale", sourceLabel: "Chrome")]
+            }
+        )
+
+        let results = await importer.gatherSlotResults(
+            spec: spec,
+            account: account,
+            resolutions: [.init(slotID: slotID, header: "kimi-auth=stale", sourceLabel: "Chrome")]
+        ) { _ in
+            fetchCalls.increment()
+            throw QuotaError.needsLogin
+        }
+
+        XCTAssertEqual(reimportCalls.value, 1)
+        XCTAssertEqual(fetchCalls.value, 2, "one original attempt plus exactly one retry")
+        XCTAssertEqual(results.first?.outcome.failureError, .needsLogin)
+    }
+
+    /// A re-import that produced the same header means the browser had
+    /// nothing newer — spending another request on it is pointless.
+    func testUnchangedHeaderSkipsTheRetry() async {
+        let slotID = UUID()
+        let fetchCalls = Counter()
+        let importer = MiscCookieAutoImporter(
+            isEnabled: { true },
+            reimport: { _, _ in true },
+            resolve: { _, _ in
+                [.init(slotID: slotID, header: "kimi-auth=stale", sourceLabel: "Chrome")]
+            }
+        )
+
+        _ = await importer.gatherSlotResults(
+            spec: spec,
+            account: account,
+            resolutions: [.init(slotID: slotID, header: "kimi-auth=stale", sourceLabel: "Chrome")]
+        ) { _ in
+            fetchCalls.increment()
+            throw QuotaError.needsLogin
+        }
+
+        XCTAssertEqual(fetchCalls.value, 1)
+    }
+
+    /// A slot that resolves fresh but was never in the adapter's own
+    /// resolution list (Ollama filters out slots with no recognised
+    /// session cookie) must stay out of the retry.
+    func testRetryIsLimitedToSlotsTheAdapterActuallyTried() async {
+        let triedSlot = UUID()
+        let filteredOutSlot = UUID()
+        let fetchedSlotIDs = SlotIDLog()
+        let importer = MiscCookieAutoImporter(
+            isEnabled: { true },
+            reimport: { _, _ in true },
+            resolve: { _, _ in
+                [
+                    .init(slotID: triedSlot, header: "kimi-auth=fresh", sourceLabel: "Chrome"),
+                    .init(slotID: filteredOutSlot, header: "kimi-auth=other", sourceLabel: "Safari")
+                ]
+            }
+        )
+
+        _ = await importer.gatherSlotResults(
+            spec: spec,
+            account: account,
+            resolutions: [.init(slotID: triedSlot, header: "kimi-auth=stale", sourceLabel: "Chrome")]
+        ) { resolution in
+            fetchedSlotIDs.append(resolution.slotID)
+            throw QuotaError.needsLogin
+        }
+
+        XCTAssertEqual(fetchedSlotIDs.values, [triedSlot, triedSlot])
+        XCTAssertFalse(fetchedSlotIDs.values.contains(filteredOutSlot))
+    }
+
+    /// Non-credential errors are not a stale cookie; a flaky network must
+    /// not be answered by rewriting the user's Keychain slot.
+    func testNetworkErrorDoesNotTriggerReimport() async {
+        let reimportCalls = Counter()
+        let importer = MiscCookieAutoImporter(
+            isEnabled: { true },
+            reimport: { _, _ in
+                reimportCalls.increment()
+                return true
+            },
+            resolve: { _, _ in [] }
+        )
+
+        let results = await importer.gatherSlotResults(
+            spec: spec,
+            account: account,
+            resolutions: [.init(slotID: UUID(), header: "kimi-auth=good", sourceLabel: "Chrome")]
+        ) { _ in
+            throw QuotaError.network("timeout")
+        }
+
+        XCTAssertEqual(reimportCalls.value, 0)
+        XCTAssertEqual(results.first?.outcome.failureError, .network("timeout"))
+    }
+
+    func testMergeKeepsOrderAndUntouchedSlots() {
+        let slotA = UUID()
+        let slotB = UUID()
+        let original: [MiscQuotaAggregator.SlotResult] = [
+            .init(slotID: slotA, sourceLabel: "Chrome", outcome: .failure(.needsLogin)),
+            .init(slotID: slotB, sourceLabel: "Safari", outcome: .failure(.rateLimited))
+        ]
+        let retried: [MiscQuotaAggregator.SlotResult] = [
+            .init(slotID: slotA, sourceLabel: "Chrome", outcome: .success(quota()))
+        ]
+
+        let merged = MiscCookieAutoImporter.merge(original: original, retried: retried)
+
+        XCTAssertEqual(merged.map(\.slotID), [slotA, slotB])
+        XCTAssertNil(merged[0].outcome.failureError)
+        XCTAssertEqual(merged[1].outcome.failureError, .rateLimited)
+    }
+}
+
+// MARK: - Test helpers
+
+/// `@Sendable` closures can't capture a mutating local, and the fetch
+/// closures run inside a task group, so counters need a lock.
+private final class Counter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var count = 0
+
+    func increment() {
+        lock.lock()
+        count += 1
+        lock.unlock()
+    }
+
+    var value: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return count
+    }
+}
+
+private final class HeaderLog: @unchecked Sendable {
+    private let lock = NSLock()
+    private var headers: [String] = []
+
+    func append(_ header: String) {
+        lock.lock()
+        headers.append(header)
+        lock.unlock()
+    }
+
+    var values: [String] {
+        lock.lock()
+        defer { lock.unlock() }
+        return headers
+    }
+}
+
+private final class SlotIDLog: @unchecked Sendable {
+    private let lock = NSLock()
+    private var ids: [UUID] = []
+
+    func append(_ id: UUID?) {
+        guard let id else { return }
+        lock.lock()
+        ids.append(id)
+        lock.unlock()
+    }
+
+    var values: [UUID] {
+        lock.lock()
+        defer { lock.unlock() }
+        return ids
+    }
+}
+
+private extension Result where Success == AccountQuota, Failure == QuotaError {
+    var failureError: QuotaError? {
+        if case let .failure(error) = self { return error }
+        return nil
+    }
+}

--- a/Tests/VibeBarCoreTests/MiscCookieSpecCatalogTests.swift
+++ b/Tests/VibeBarCoreTests/MiscCookieSpecCatalogTests.swift
@@ -1,0 +1,105 @@
+import XCTest
+@testable import VibeBarCore
+
+final class MiscCookieSpecCatalogTests: XCTestCase {
+    /// The providers that authenticate with something other than a
+    /// browser cookie jar: API keys, a device-login flow, AK/SK signing,
+    /// or a local process probe. Listed explicitly so the coverage test
+    /// below can insist every misc-page provider is classified — a new
+    /// cookie provider that nobody registered in the catalog would
+    /// silently drop out of the batch import.
+    private let nonCookieMiscProviders: Set<ToolType> = [
+        .copilot,            // GitHub device login
+        .zai,                // API key
+        .minimax,            // API key
+        .volcengineAgentPlan, // AK/SK signed Ark API
+        .kilo,               // API key / ~/.local/share/kilo/auth.json
+        .kiro,               // local `kiro-cli` probe
+        .openRouter,         // API key
+        .warp,               // API key
+        .antigravity         // local language-server probe
+    ]
+
+    func testEveryMiscPageProviderIsClassified() {
+        let cookieSourced = Set(MiscCookieSpecCatalog.allCookieSourcedTools)
+        for tool in ToolType.miscPageProviders {
+            XCTAssertTrue(
+                cookieSourced.contains(tool) || nonCookieMiscProviders.contains(tool),
+                "\(tool.rawValue) is neither in MiscCookieSpecCatalog nor listed as non-cookie. "
+                    + "Register its cookieSpec in the catalog, or add it to nonCookieMiscProviders."
+            )
+        }
+        XCTAssertTrue(
+            cookieSourced.isDisjoint(with: nonCookieMiscProviders),
+            "A provider cannot be both cookie-sourced and non-cookie."
+        )
+    }
+
+    func testCatalogCoversExactlyTheTwelveCookieProviders() {
+        XCTAssertEqual(
+            MiscCookieSpecCatalog.allCookieSourcedTools,
+            [
+                .alibaba,
+                .alibabaTokenPlan,
+                .kimi,
+                .cursor,
+                .mimo,
+                .iflytek,
+                .tencentHunyuan,
+                .tencentTokenPlan,
+                .volcengine,
+                .baiduQianfan,
+                .openCodeGo,
+                .ollama
+            ],
+            "allCookieSourcedTools should follow ToolType declaration order."
+        )
+        XCTAssertEqual(MiscCookieSpecCatalog.allSpecs.count, 12)
+    }
+
+    /// Guards the copy-paste failure mode the catalog invites: a switch
+    /// arm returning the *wrong* adapter's spec compiles fine and would
+    /// silently import Cursor's cookies for Kimi.
+    func testCatalogEntriesMatchTheAdapterStatics() {
+        let expected: [ToolType: MiscCookieResolver.Spec] = [
+            .alibaba: AlibabaQuotaAdapter.cookieSpec,
+            .alibabaTokenPlan: AlibabaTokenPlanQuotaAdapter.cookieSpec,
+            .baiduQianfan: BaiduQianfanQuotaAdapter.cookieSpec,
+            .cursor: CursorQuotaAdapter.cookieSpec,
+            .iflytek: IFlyTekQuotaAdapter.cookieSpec,
+            .kimi: KimiQuotaAdapter.cookieSpec,
+            .mimo: MimoQuotaAdapter.cookieSpec,
+            .ollama: OllamaQuotaAdapter.cookieSpec,
+            .openCodeGo: OpenCodeGoQuotaAdapter.cookieSpec,
+            .tencentHunyuan: TencentHunyuanQuotaAdapter.cookieSpec,
+            .tencentTokenPlan: TencentTokenPlanQuotaAdapter.cookieSpec,
+            .volcengine: VolcengineQuotaAdapter.cookieSpec
+        ]
+        for (tool, adapterSpec) in expected {
+            guard let catalogSpec = MiscCookieSpecCatalog.spec(for: tool) else {
+                return XCTFail("No catalog spec for \(tool.rawValue)")
+            }
+            XCTAssertEqual(catalogSpec.tool, tool, "\(tool.rawValue) spec points at the wrong tool")
+            XCTAssertEqual(catalogSpec.tool, adapterSpec.tool)
+            XCTAssertEqual(catalogSpec.domains, adapterSpec.domains, "\(tool.rawValue) domains")
+            XCTAssertEqual(catalogSpec.requiredNames, adapterSpec.requiredNames, "\(tool.rawValue) requiredNames")
+            XCTAssertEqual(
+                catalogSpec.credentialNames,
+                adapterSpec.credentialNames,
+                "\(tool.rawValue) credentialNames"
+            )
+        }
+    }
+
+    func testNonCookieProvidersHaveNoSpec() {
+        for tool in nonCookieMiscProviders {
+            XCTAssertNil(MiscCookieSpecCatalog.spec(for: tool), tool.rawValue)
+            XCTAssertFalse(MiscCookieSpecCatalog.isCookieSourced(tool), tool.rawValue)
+        }
+        // Primary / partial-primary families carry their own credential
+        // paths and must not appear in the misc cookie catalog.
+        for tool in [ToolType.codex, .claude, .gemini, .grok] {
+            XCTAssertNil(MiscCookieSpecCatalog.spec(for: tool), tool.rawValue)
+        }
+    }
+}

--- a/Tests/VibeBarCoreTests/MiscCookieWarmKeychainTests.swift
+++ b/Tests/VibeBarCoreTests/MiscCookieWarmKeychainTests.swift
@@ -1,0 +1,71 @@
+import XCTest
+@testable import VibeBarCore
+import SweetCookieKit
+
+/// The silent re-import path has to reach browsers whose Safe Storage key
+/// SweetCookieKit already holds, even though `BrowserCookieAccessGate`'s
+/// non-interactive preflight would veto them. These tests pin that
+/// bypass so a future gate change can't quietly re-block it.
+final class MiscCookieWarmKeychainTests: XCTestCase {
+    /// Reports every path as present with a single `Default` profile, so
+    /// `BrowserDetection` finds a usable Chromium cookie store without a
+    /// browser actually being installed on the test machine.
+    private func fakeDetection() -> BrowserDetection {
+        BrowserDetection(
+            homeDirectory: "/Users/example",
+            fileExists: { _ in true },
+            directoryContents: { _ in ["Default"] }
+        )
+    }
+
+    override func setUp() {
+        super.setUp()
+        BrowserCookieAccessGate.reset()
+        MiscCookieResolver.resetKeychainWarmthForTesting()
+        KeychainAccessGate.isDisabled = false
+    }
+
+    override func tearDown() {
+        BrowserCookieAccessGate.reset()
+        MiscCookieResolver.resetKeychainWarmthForTesting()
+        KeychainAccessGate.isDisabled = false
+        super.tearDown()
+    }
+
+    func testCooldownBrowserIsSkippedOnASilentRead() {
+        BrowserCookieAccessGate.recordDenied(for: .chrome)
+        XCTAssertEqual([Browser.chrome].cookieImportCandidates(using: fakeDetection()), [])
+    }
+
+    func testWarmBrowserBypassesTheCooldownOnASilentRead() {
+        BrowserCookieAccessGate.recordDenied(for: .chrome)
+        let candidates = [Browser.chrome].cookieImportCandidates(
+            using: fakeDetection(),
+            warmKeychainBrowsers: [Browser.chrome.rawValue]
+        )
+        XCTAssertEqual(candidates, [.chrome])
+    }
+
+    func testWarmthOnlyTracksBrowsersThatNeedKeychainDecryption() {
+        MiscCookieResolver.markKeychainWarm(.safari)
+        MiscCookieResolver.markKeychainWarm(.firefox)
+        XCTAssertTrue(
+            MiscCookieResolver.warmKeychainBrowserIDs.isEmpty,
+            "Safari / Firefox never unlock a Safe Storage key, so marking them warm is meaningless."
+        )
+
+        MiscCookieResolver.markKeychainWarm(.chrome)
+        XCTAssertEqual(MiscCookieResolver.warmKeychainBrowserIDs, [Browser.chrome.rawValue])
+    }
+
+    /// Warmth is a prompt-avoidance shortcut, not a way around the user's
+    /// own kill switch.
+    func testGlobalKeychainKillSwitchStillWinsOverWarmth() {
+        KeychainAccessGate.isDisabled = true
+        let candidates = [Browser.chrome].cookieImportCandidates(
+            using: fakeDetection(),
+            warmKeychainBrowsers: [Browser.chrome.rawValue]
+        )
+        XCTAssertEqual(candidates, [])
+    }
+}

--- a/Tests/VibeBarCoreTests/OverviewMasonryPlannerTests.swift
+++ b/Tests/VibeBarCoreTests/OverviewMasonryPlannerTests.swift
@@ -87,4 +87,78 @@ final class OverviewMasonryPlannerTests: XCTestCase {
             XCTAssertGreaterThan(following.y, detail.y + 420)
         }
     }
+
+    func testTheSummaryBandTakesTheTopRowBeforeAnythingIsBalanced() throws {
+        // The Overview's cost and status summaries used to be a hard-coded row
+        // above the waterfall. As modules they have to land exactly where that
+        // row was: one per column, at the top, whatever the quota cards do.
+        let items: [OverviewMasonryPlanner.Item] = [
+            .init(id: "summary-cost", height: 178, phase: .summary),
+            .init(id: "summary-status", height: 178, phase: .summary),
+            .init(id: "q1", height: 300, phase: .quota),
+            .init(id: "q2", height: 280, phase: .quota),
+            .init(id: "q3", height: 120, phase: .quota),
+            .init(id: "q4", height: 100, phase: .quota),
+            .init(id: "cost", height: 320, phase: .cost)
+        ]
+
+        let plan = OverviewMasonryPlanner.plan(items: items, spacing: 12)
+
+        let cost = try XCTUnwrap(plan.positions["summary-cost"])
+        let status = try XCTUnwrap(plan.positions["summary-status"])
+        XCTAssertEqual(cost.column, 0)
+        XCTAssertEqual(status.column, 1)
+        XCTAssertEqual(cost.y, 0)
+        XCTAssertEqual(status.y, 0)
+        // Everything below starts under the band, in both columns.
+        for id in ["q1", "q2", "q3", "q4", "cost"] {
+            XCTAssertGreaterThanOrEqual(try XCTUnwrap(plan.positions[id]).y, 190)
+        }
+    }
+
+    func testTheSummaryBandSeedsBothColumnsEquallySoQuotaBalancingIsUnchanged() throws {
+        let quotas: [OverviewMasonryPlanner.Item] = [
+            .init(id: "q1", height: 300, phase: .quota),
+            .init(id: "q2", height: 280, phase: .quota),
+            .init(id: "q3", height: 120, phase: .quota),
+            .init(id: "q4", height: 100, phase: .quota)
+        ]
+        let summaries: [OverviewMasonryPlanner.Item] = [
+            .init(id: "s1", height: 178, phase: .summary),
+            .init(id: "s2", height: 178, phase: .summary)
+        ]
+
+        let withoutBand = OverviewMasonryPlanner.plan(items: quotas, spacing: 12)
+        let withBand = OverviewMasonryPlanner.plan(items: summaries + quotas, spacing: 12)
+
+        for item in quotas {
+            XCTAssertEqual(
+                withBand.positions[item.id]?.column,
+                withoutBand.positions[item.id]?.column
+            )
+        }
+    }
+
+    func testALockedSessionKeepsTheSummaryBandWhereItWas() throws {
+        let items: [OverviewMasonryPlanner.Item] = [
+            .init(id: "summary-cost", height: 178, phase: .summary),
+            .init(id: "summary-status", height: 178, phase: .summary),
+            .init(id: "q1", height: 200, phase: .quota),
+            .init(id: "q2", height: 180, phase: .quota)
+        ]
+        let fixedColumns = OverviewMasonryPlanner.plan(items: items, spacing: 12)
+            .positions
+            .mapValues(\.column)
+
+        let locked = OverviewMasonryPlanner.plan(
+            items: items,
+            fixedColumns: fixedColumns,
+            spacing: 12
+        )
+
+        XCTAssertEqual(locked.positions["summary-cost"]?.column, 0)
+        XCTAssertEqual(locked.positions["summary-status"]?.column, 1)
+        XCTAssertEqual(try XCTUnwrap(locked.positions["summary-cost"]).y, 0)
+        XCTAssertEqual(try XCTUnwrap(locked.positions["summary-status"]).y, 0)
+    }
 }

--- a/Tests/VibeBarCoreTests/PageLayoutPackerTests.swift
+++ b/Tests/VibeBarCoreTests/PageLayoutPackerTests.swift
@@ -389,4 +389,124 @@ final class PageLayoutPackerTests: XCTestCase {
         // Straight through `PageLayoutConfig`, so the invariants hold.
         XCTAssertEqual(Set(config.moduleIDs).count, config.moduleIDs.count)
     }
+
+    // MARK: - Segments
+
+    func testEachSegmentIsPackedOnItsOwn() {
+        // The point of segments: a card can only be balanced against the cards
+        // in its own band, so the tall one in band 0 cannot pull the small ones
+        // from band 1 up beside it.
+        let packed = PageLayoutPacker.pack(
+            segments: [
+                items([("tall", 400), ("short", 100)]),
+                items([("a", 50), ("b", 50)])
+            ],
+            spacing: 10
+        )
+
+        XCTAssertEqual(packed.count, 2)
+        XCTAssertEqual(packed[0].columns, [[module("tall")], [module("short")]])
+        XCTAssertEqual(packed[1].columns, [[module("a")], [module("b")]])
+    }
+
+    func testSegmentPackingIsTheSameAnswerAsPackingThatBandAlone() {
+        let band = items([("a", 300), ("b", 200), ("c", 150), ("d", 50)])
+
+        XCTAssertEqual(
+            PageLayoutPacker.pack(segments: [band], spacing: 8, ratio: .wideNarrow)[0].columns,
+            PageLayoutPacker.pack(items: band, spacing: 8, ratio: .wideNarrow).columns
+        )
+    }
+
+    func testAnIdentifierInTwoSegmentsIsKeptOnlyInTheFirst() {
+        // A hand-edited file must not make one card render twice.
+        let packed = PageLayoutPacker.pack(
+            segments: [items([("a", 100)]), items([("a", 100), ("b", 40)])],
+            spacing: 10
+        )
+
+        XCTAssertEqual(packed[0].columns.flatMap { $0 }, [module("a")])
+        XCTAssertEqual(packed[1].columns.flatMap { $0 }, [module("b")])
+    }
+
+    func testAnEmptySegmentPacksToEmptyColumns() {
+        let packed = PageLayoutPacker.pack(segments: [[], items([("a", 100)])], spacing: 10)
+
+        XCTAssertEqual(packed[0].columns, [[], []])
+        XCTAssertEqual(packed[0].pageHeight, 0)
+        XCTAssertEqual(packed[1].pageHeight, 100)
+    }
+
+    func testSegmentedPageHeightSumsTheBandsAndTheGapsBetweenThem() {
+        let heights: [PageLayoutModuleID: Double] = [
+            module("a"): 100,
+            module("b"): 50,
+            module("c"): 200
+        ]
+
+        // Band 0 measures 100 (its taller column), band 1 measures 200, and one
+        // gap sits between them.
+        XCTAssertEqual(
+            PageLayoutPacker.pageHeight(
+                segments: [
+                    [[module("a")], [module("b")]],
+                    [[module("c")], []]
+                ],
+                heights: heights,
+                spacing: 10
+            ),
+            310
+        )
+        // One band is a plain page, gap-free.
+        XCTAssertEqual(
+            PageLayoutPacker.pageHeight(
+                segments: [[[module("a")], [module("b")]]],
+                heights: heights,
+                spacing: 10
+            ),
+            100
+        )
+        XCTAssertEqual(
+            PageLayoutPacker.pageHeight(segments: [], heights: heights, spacing: 10),
+            0
+        )
+    }
+
+    func testSegmentedPageHeightMeasuresWhatTheSegmentedPackerChose() {
+        let bands = [items([("a", 300), ("b", 200)]), items([("c", 150), ("d", 50)])]
+        let packed = PageLayoutPacker.packedSegmentColumns(segments: bands, spacing: 7)
+        let heights = Dictionary(
+            uniqueKeysWithValues: bands.flatMap { $0 }.map { ($0.id, $0.height) }
+        )
+
+        XCTAssertEqual(
+            PageLayoutPacker.pageHeight(segments: packed, heights: heights, spacing: 7),
+            PageLayoutPacker.pack(segments: bands, spacing: 7)
+                .map(\.pageHeight)
+                .reduce(0) { $0 + $1 } + 7
+        )
+    }
+
+    func testSegmentingCostsHeightComparedToPackingTheWholePage() {
+        // Segments are a deliberate trade: the page is taller than the freest
+        // packing, and in exchange the grouping the user reads it in survives.
+        let quota = items([("q1", 300), ("q2", 100)])
+        let rest = items([("c1", 300), ("c2", 100)])
+
+        let free = PageLayoutPacker.pack(items: quota + rest, spacing: 10).pageHeight
+        let heights = Dictionary(
+            uniqueKeysWithValues: (quota + rest).map { ($0.id, $0.height) }
+        )
+        let banded = PageLayoutPacker.pageHeight(
+            segments: PageLayoutPacker.packedSegmentColumns(
+                segments: [quota, rest],
+                spacing: 10
+            ),
+            heights: heights,
+            spacing: 10
+        )
+
+        XCTAssertEqual(free, 410)
+        XCTAssertEqual(banded, 610)
+    }
 }

--- a/Tests/VibeBarCoreTests/PageLayoutTests.swift
+++ b/Tests/VibeBarCoreTests/PageLayoutTests.swift
@@ -997,6 +997,39 @@ final class PageLayoutTests: XCTestCase {
         XCTAssertEqual(decoded.layout.segments, [[.status], [.costAll, .quotaHistoryAll]])
     }
 
+    func testALegacyCompactPresetAppliesAsTheManualLayoutItCaptured() {
+        // Saved by a build where presets existed but bands did not: mode is
+        // compact, the packed columns were snapshotted, segments are absent.
+        // Back then applying it entered Manual with exactly these columns;
+        // restoring it as compact today would throw the columns away and
+        // re-pack under default bands the preset never saw.
+        let legacy = StoredPageLayoutPreset(
+            name: "Old packing",
+            layout: StoredPageLayout(
+                mode: .compact,
+                ratio: .wideNarrow,
+                columns: [[.status, .costAll], [.quotaHistoryAll]]
+            )
+        )
+        let applied = legacy.layoutToApply
+        XCTAssertEqual(applied.mode, .manual)
+        XCTAssertEqual(applied.ratio, .wideNarrow)
+        XCTAssertEqual(applied.columns, [[.status, .costAll], [.quotaHistoryAll]])
+
+        // A compact preset that does carry bands is current-format and applies
+        // verbatim; so does a manual preset with columns.
+        let current = StoredPageLayoutPreset(
+            name: "Banded",
+            layout: StoredPageLayout(mode: .compact, segments: [[.status], [.costAll]])
+        )
+        XCTAssertEqual(current.layoutToApply, current.layout)
+        let manual = StoredPageLayoutPreset(
+            name: "Hand made",
+            layout: StoredPageLayout(mode: .manual, columns: [[.status], [.costAll]])
+        )
+        XCTAssertEqual(manual.layoutToApply, manual.layout)
+    }
+
     // MARK: - PageLayoutSegments
 
     private static let summaryCost = PageLayoutModuleID("overview-summary-cost")

--- a/Tests/VibeBarCoreTests/PageLayoutTests.swift
+++ b/Tests/VibeBarCoreTests/PageLayoutTests.swift
@@ -887,4 +887,378 @@ final class PageLayoutTests: XCTestCase {
         XCTAssertTrue(mangled.layout.isEmpty)
         XCTAssertEqual(mangled.layout.mode, .auto)
     }
+
+    // MARK: - Stored segments
+
+    func testStoredLayoutRoundTripsItsSegments() throws {
+        let stored = StoredPageLayout(
+            mode: .compact,
+            ratio: .wideNarrow,
+            columns: [[.status], [.costAll]],
+            segments: [[.status], [.costAll, .quotaHistoryAll]]
+        )
+
+        let decoded = try JSONDecoder().decode(
+            StoredPageLayout.self,
+            from: try JSONEncoder().encode(stored)
+        )
+
+        XCTAssertEqual(decoded.mode, .compact)
+        XCTAssertEqual(decoded.columns, [[.status], [.costAll]])
+        XCTAssertEqual(decoded.segments, [[.status], [.costAll, .quotaHistoryAll]])
+    }
+
+    func testStoredLayoutEncodesSegmentsAsArraysOfIdentifierStrings() throws {
+        let stored = StoredPageLayout(
+            mode: .compact,
+            segments: [[.status], [.costAll, .quotaHistoryAll]]
+        )
+        let object = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: try JSONEncoder().encode(stored)) as? [String: Any]
+        )
+
+        XCTAssertEqual(
+            object["segments"] as? [[String]],
+            [["status"], ["cost-all", "quota-history-all"]]
+        )
+    }
+
+    func testStoredLayoutWithoutSegmentsDecodesToNoChosenSegmentation() throws {
+        // Every entry written before segments existed: the page falls back to
+        // its default banding, which is what it was already doing.
+        let legacy = Data(#"{"mode":"compact","ratio":"equal","columns":[["status"],[]]}"#.utf8)
+        let decoded = try JSONDecoder().decode(StoredPageLayout.self, from: legacy)
+
+        XCTAssertEqual(decoded.segments, [])
+        XCTAssertEqual(decoded.mode, .compact)
+        XCTAssertEqual(decoded.columns.first, [.status])
+    }
+
+    func testMalformedSegmentsCostTheSegmentationAndNothingElse() throws {
+        let mangled = Data(#"{"mode":"compact","columns":[["status"],[]],"segments":"nope"}"#.utf8)
+        let decoded = try JSONDecoder().decode(StoredPageLayout.self, from: mangled)
+
+        XCTAssertEqual(decoded.segments, [])
+        XCTAssertEqual(decoded.columns.first, [.status])
+    }
+
+    func testStoredSegmentsAreNormalizedOnTheWayIn() {
+        // A duplicate across bands would render one card twice; an empty band
+        // would draw a header with nothing under it.
+        let stored = StoredPageLayout(
+            mode: .compact,
+            segments: [[.status, .costAll], [], [.costAll, .quotaHistoryAll], [PageLayoutModuleID("")]]
+        )
+
+        XCTAssertEqual(stored.segments, [[.status, .costAll], [.quotaHistoryAll]])
+    }
+
+    func testAnEntryCanCarrySegmentsAndStillCountAsUncustomized() {
+        // `isEmpty` asks "is there a hand arrangement to go back to". A banding
+        // is an input to Compact, not a hand arrangement.
+        let stored = StoredPageLayout(mode: .compact, segments: [[.status], [.costAll]])
+
+        XCTAssertTrue(stored.isEmpty)
+        XCTAssertNil(stored.restoredAsManual())
+    }
+
+    func testReturningToManualKeepsTheSegmentation() {
+        let parked = StoredPageLayout(
+            mode: .compact,
+            ratio: .wideNarrow,
+            columns: [[.costAll], [.status]],
+            segments: [[.status], [.costAll]]
+        )
+
+        let restored = parked.restoredAsManual()
+
+        XCTAssertEqual(restored?.mode, .manual)
+        XCTAssertEqual(restored?.segments, [[.status], [.costAll]])
+    }
+
+    func testPresetCarriesTheSegmentationItWasCapturedFrom() throws {
+        let preset = StoredPageLayoutPreset(
+            name: "Quotas first",
+            layout: StoredPageLayout(
+                mode: .compact,
+                ratio: .equal,
+                segments: [[.status], [.costAll, .quotaHistoryAll]]
+            )
+        )
+
+        let decoded = try JSONDecoder().decode(
+            StoredPageLayoutPreset.self,
+            from: try JSONEncoder().encode(preset)
+        )
+
+        // The mode rides along too: applying a Compact preset has to put the
+        // page back into Compact, not freeze one packing of it as Manual.
+        XCTAssertEqual(decoded.layout.mode, .compact)
+        XCTAssertEqual(decoded.layout.segments, [[.status], [.costAll, .quotaHistoryAll]])
+    }
+
+    // MARK: - PageLayoutSegments
+
+    private static let summaryCost = PageLayoutModuleID("overview-summary-cost")
+    private static let summaryStatus = PageLayoutModuleID("overview-summary-status")
+
+    /// The Overview's module set, in catalog declaration order, with the phases
+    /// `PageModuleCatalog` gives them.
+    private func overviewModules() -> [PageLayoutSegments.Module] {
+        [
+            .init(id: Self.summaryCost, phase: .summary),
+            .init(id: Self.summaryStatus, phase: .summary),
+            .init(id: PageLayoutModuleID("overview-quota:codex"), phase: .quota),
+            .init(id: PageLayoutModuleID("overview-quota:claude"), phase: .quota),
+            .init(id: PageLayoutModuleID("overview-quota:gemini"), phase: .quota),
+            .init(id: PageLayoutModuleID("overview-quota:grok"), phase: .quota),
+            .init(id: .quotaHistoryAll, phase: .quota),
+            .init(id: .costAll, phase: .cost),
+            .init(id: .cost(tool: .codex), phase: .cost),
+            .init(id: PageLayoutModuleID("model-breakdown:all"), phase: .auxiliary),
+            .init(id: PageLayoutModuleID("heatmap-year:all"), phase: .auxiliary)
+        ]
+    }
+
+    func testOverviewDefaultsToSummaryThenQuotaThenEverythingElse() {
+        let segments = PageLayoutSegments.defaultSegments(
+            modules: overviewModules(),
+            page: .overview
+        )
+
+        XCTAssertEqual(segments.count, 3)
+        XCTAssertEqual(segments[0], [Self.summaryCost, Self.summaryStatus])
+        XCTAssertEqual(
+            segments[1],
+            [
+                PageLayoutModuleID("overview-quota:codex"),
+                PageLayoutModuleID("overview-quota:claude"),
+                PageLayoutModuleID("overview-quota:gemini"),
+                PageLayoutModuleID("overview-quota:grok"),
+                .quotaHistoryAll
+            ]
+        )
+        // Cost and the analytics derived from it read as one block.
+        XCTAssertEqual(
+            segments[2],
+            [
+                .costAll,
+                .cost(tool: .codex),
+                PageLayoutModuleID("model-breakdown:all"),
+                PageLayoutModuleID("heatmap-year:all")
+            ]
+        )
+    }
+
+    func testAProviderPageDefaultsToASingleSegment() {
+        // `compact` on a provider page keeps meaning exactly what it meant
+        // before segments existed: one packing of the whole page.
+        let modules: [PageLayoutSegments.Module] = [
+            .init(id: .quotaGroup(tool: .claude, groupKey: "five_hour"), phase: .quota),
+            .init(id: .status, phase: .quota),
+            .init(id: .cost(tool: .claude), phase: .cost),
+            .init(id: .modelBreakdown(tool: .claude), phase: .auxiliary)
+        ]
+
+        let segments = PageLayoutSegments.defaultSegments(modules: modules, page: .detail(.claude))
+
+        XCTAssertEqual(segments.count, 1)
+        XCTAssertEqual(segments[0].count, 4)
+    }
+
+    func testEmptyPhasesDoNotProduceEmptySegments() {
+        // A page with no cost data at all is two bands, not three with a hole.
+        let segments = PageLayoutSegments.defaultSegments(
+            modules: [
+                .init(id: Self.summaryCost, phase: .summary),
+                .init(id: .quotaHistoryAll, phase: .quota)
+            ],
+            page: .overview
+        )
+
+        XCTAssertEqual(segments, [[Self.summaryCost], [.quotaHistoryAll]])
+    }
+
+    func testSegmentNormalizationFoldsBandsPastTheCapIntoTheLast() {
+        let overflowing = (0..<(PageLayoutSegments.maximumCount + 2)).map {
+            [PageLayoutModuleID("card-\($0)")]
+        }
+
+        let normalized = PageLayoutSegments.normalized(overflowing)
+
+        XCTAssertEqual(normalized.count, PageLayoutSegments.maximumCount)
+        // Folding rather than dropping: no card is lost to the cap.
+        XCTAssertEqual(normalized.flatMap { $0 }.count, PageLayoutSegments.maximumCount + 2)
+        XCTAssertEqual(
+            normalized[PageLayoutSegments.maximumCount - 1],
+            [
+                PageLayoutModuleID("card-\(PageLayoutSegments.maximumCount - 1)"),
+                PageLayoutModuleID("card-\(PageLayoutSegments.maximumCount)"),
+                PageLayoutModuleID("card-\(PageLayoutSegments.maximumCount + 1)")
+            ]
+        )
+    }
+
+    func testSegmentNormalizationKeepsIdentifiersThisBuildDoesNotKnow() {
+        let future = PageLayoutModuleID("overview-something-new:v3")
+
+        XCTAssertEqual(
+            PageLayoutSegments.normalized([[future], [.status]]),
+            [[future], [.status]]
+        )
+    }
+
+    func testResolvingWithoutStoredSegmentsUsesThePageDefault() {
+        let modules = overviewModules()
+        let defaults = PageLayoutSegments.defaultSegments(modules: modules, page: .overview)
+
+        let resolved = PageLayoutSegments.resolve(
+            stored: [],
+            available: modules.map(\.id),
+            defaultSegments: defaults
+        )
+
+        XCTAssertEqual(resolved, defaults)
+    }
+
+    func testResolvingDropsModulesThePageCannotDrawAndTheirEmptyBands() {
+        let resolved = PageLayoutSegments.resolve(
+            stored: [[.status], [.costAll], [.quotaHistoryAll]],
+            available: [.status, .quotaHistoryAll],
+            defaultSegments: [[.status], [.quotaHistoryAll]]
+        )
+
+        XCTAssertEqual(resolved, [[.status], [.quotaHistoryAll]])
+    }
+
+    func testANewModuleJoinsTheBandItsFamilyDefaultsTo() {
+        // The case that matters in practice: a build adds a card, or a provider
+        // is switched back on, while the user has a saved banding.
+        let resolved = PageLayoutSegments.resolve(
+            stored: [[Self.summaryCost], [.quotaHistoryAll], [.costAll]],
+            available: [Self.summaryCost, Self.summaryStatus, .quotaHistoryAll, .costAll],
+            defaultSegments: [
+                [Self.summaryCost, Self.summaryStatus],
+                [.quotaHistoryAll],
+                [.costAll]
+            ]
+        )
+
+        XCTAssertEqual(resolved[0], [Self.summaryCost, Self.summaryStatus])
+        XCTAssertEqual(resolved[1], [.quotaHistoryAll])
+        XCTAssertEqual(resolved[2], [.costAll])
+    }
+
+    func testANewModuleWithNowhereToGoLandsInTheLastBand() {
+        // A page saved with fewer bands than the default has no band for the
+        // newcomer's family; visible at the end beats silently missing.
+        let resolved = PageLayoutSegments.resolve(
+            stored: [[Self.summaryCost, Self.summaryStatus]],
+            available: [Self.summaryCost, Self.summaryStatus, .costAll],
+            defaultSegments: [[Self.summaryCost, Self.summaryStatus], [.quotaHistoryAll], [.costAll]]
+        )
+
+        XCTAssertEqual(resolved, [[Self.summaryCost, Self.summaryStatus, .costAll]])
+    }
+
+    func testResolvingPlacesEveryAvailableModuleExactlyOnce() {
+        let modules = overviewModules()
+        let resolved = PageLayoutSegments.resolve(
+            // A hand-edited file: duplicated, unknown and missing entries.
+            stored: [[.costAll, .costAll], [PageLayoutModuleID("gone:forever")]],
+            available: modules.map(\.id),
+            defaultSegments: PageLayoutSegments.defaultSegments(modules: modules, page: .overview)
+        )
+
+        let placed = resolved.flatMap { $0 }
+        XCTAssertEqual(Set(placed), Set(modules.map(\.id)))
+        XCTAssertEqual(placed.count, modules.count)
+    }
+
+    func testMergingAnEditKeepsBandsForModulesThatAreNotOnScreen() {
+        // The quota card of a provider that is mid-refresh must not lose its
+        // band because the user dragged something else.
+        let merged = PageLayoutSegments.mergingEdit(
+            [[.status], [.costAll]],
+            into: [[.status, .quotaHistoryAll], [.costAll]],
+            available: [.status, .costAll]
+        )
+
+        XCTAssertEqual(merged, [[.status, .quotaHistoryAll], [.costAll]])
+    }
+
+    func testMergingAnEditHonoursTheMoveItWasGiven() {
+        let merged = PageLayoutSegments.mergingEdit(
+            [[.status, .costAll], [.quotaHistoryAll]],
+            into: [[.status], [.costAll, .quotaHistoryAll]],
+            available: [.status, .costAll, .quotaHistoryAll]
+        )
+
+        XCTAssertEqual(merged, [[.status, .costAll], [.quotaHistoryAll]])
+    }
+
+    // MARK: - Compact, end to end
+
+    func testCompactOverviewPacksTheQuotaCardsAsTheirOwnBand() {
+        // The user's actual complaint: on a packed Overview the quota cards must
+        // form one minimal-height block, with the summary above them and
+        // everything else below — no stored segmentation required.
+        //
+        // This is the pipeline `PageLayoutModel.compactArrangement` runs:
+        // default banding from the catalog's phases, then one packing per band.
+        let modules = overviewModules()
+        let heights: [PageLayoutModuleID: Double] = [
+            Self.summaryCost: 178,
+            Self.summaryStatus: 178,
+            PageLayoutModuleID("overview-quota:codex"): 300,
+            PageLayoutModuleID("overview-quota:claude"): 260,
+            PageLayoutModuleID("overview-quota:gemini"): 220,
+            PageLayoutModuleID("overview-quota:grok"): 180,
+            .quotaHistoryAll: 300,
+            .costAll: 340,
+            .cost(tool: .codex): 320,
+            PageLayoutModuleID("model-breakdown:all"): 200,
+            PageLayoutModuleID("heatmap-year:all"): 210
+        ]
+        let segments = PageLayoutSegments.defaultSegments(modules: modules, page: .overview)
+
+        let packed = PageLayoutPacker.packedSegmentColumns(
+            segments: segments.map { band in
+                band.map { PageLayoutPacker.Item(id: $0, height: heights[$0] ?? 0) }
+            },
+            spacing: 12
+        )
+
+        XCTAssertEqual(packed.count, 3)
+        XCTAssertEqual(Set(packed[0].flatMap { $0 }), [Self.summaryCost, Self.summaryStatus])
+        XCTAssertEqual(
+            Set(packed[1].flatMap { $0 }),
+            Set([
+                PageLayoutModuleID("overview-quota:codex"),
+                PageLayoutModuleID("overview-quota:claude"),
+                PageLayoutModuleID("overview-quota:gemini"),
+                PageLayoutModuleID("overview-quota:grok"),
+                .quotaHistoryAll
+            ])
+        )
+        // Nothing from below leaks into the quota band, which is exactly what
+        // the unsegmented packer was free to do.
+        XCTAssertEqual(
+            Set(packed[2].flatMap { $0 }),
+            Set([
+                .costAll,
+                .cost(tool: .codex),
+                PageLayoutModuleID("model-breakdown:all"),
+                PageLayoutModuleID("heatmap-year:all")
+            ])
+        )
+        // The summary band is one row: one card per column.
+        XCTAssertEqual(packed[0][0].count, 1)
+        XCTAssertEqual(packed[0][1].count, 1)
+        // And each band is genuinely balanced, not just grouped.
+        let quotaColumns = packed[1].map {
+            PageLayoutPacker.stackedHeight($0, heights: heights, spacing: 12)
+        }
+        XCTAssertLessThan(abs(quotaColumns[0] - quotaColumns[1]), 100)
+    }
 }

--- a/Tests/VibeBarCoreTests/PrimaryProviderRouteHealthTests.swift
+++ b/Tests/VibeBarCoreTests/PrimaryProviderRouteHealthTests.swift
@@ -55,4 +55,43 @@ final class PrimaryProviderRouteHealthTests: XCTestCase {
         XCTAssertEqual(health.status, .missing)
         XCTAssertEqual(health.detail, "No local Antigravity data")
     }
+
+    /// The probe spawns `/bin/ps` and blocks until it exits, and route health is
+    /// re-checked on every refresh — including per provider, so refreshing the
+    /// Gemini card alone used to spawn it twice. Inside the TTL the answer is
+    /// reused; past it, and after an explicit invalidation, it is re-probed.
+    func testLanguageServerProbeIsCachedForItsTTL() {
+        PrimaryProviderRouteHealthChecker.invalidateLanguageServerProbeCache()
+        defer { PrimaryProviderRouteHealthChecker.invalidateLanguageServerProbeCache() }
+
+        var probes = 0
+        let start = Date(timeIntervalSince1970: 1_700_000_000)
+        let probe: () -> Bool = {
+            probes += 1
+            return true
+        }
+
+        XCTAssertTrue(PrimaryProviderRouteHealthChecker.antigravityLanguageServerIsRunning(
+            now: start,
+            probe: probe
+        ))
+        XCTAssertTrue(PrimaryProviderRouteHealthChecker.antigravityLanguageServerIsRunning(
+            now: start.addingTimeInterval(30),
+            probe: probe
+        ))
+        XCTAssertEqual(probes, 1)
+
+        XCTAssertTrue(PrimaryProviderRouteHealthChecker.antigravityLanguageServerIsRunning(
+            now: start.addingTimeInterval(61),
+            probe: probe
+        ))
+        XCTAssertEqual(probes, 2)
+
+        PrimaryProviderRouteHealthChecker.invalidateLanguageServerProbeCache()
+        XCTAssertTrue(PrimaryProviderRouteHealthChecker.antigravityLanguageServerIsRunning(
+            now: start.addingTimeInterval(61),
+            probe: probe
+        ))
+        XCTAssertEqual(probes, 3)
+    }
 }

--- a/Tests/VibeBarCoreTests/QuotaActivityProfileTests.swift
+++ b/Tests/VibeBarCoreTests/QuotaActivityProfileTests.swift
@@ -1,0 +1,257 @@
+import XCTest
+@testable import VibeBarCore
+
+/// `QuotaPaceForecast.ActivityProfile.weight` used to walk a window hour by
+/// hour, asking `Calendar` for the next hour boundary and for the weekday/hour
+/// of every step — two round trips per hour, per query, and the forecast issues
+/// one query per stored observation per completed cycle. It now integrates a
+/// precomputed hour table instead.
+///
+/// These tests pin the new implementation against the retired walk
+/// (`referenceWeight` below, a faithful copy of it) so the swap stays a
+/// performance change rather than a behaviour change.
+final class QuotaActivityProfileTests: XCTestCase {
+    /// The retired hour-by-hour walk, kept here as the equivalence oracle.
+    private func referenceWeight(
+        from start: Date,
+        to end: Date,
+        heatmap: UsageHeatmap?,
+        calendar: Calendar
+    ) -> Double {
+        guard end > start else { return 0 }
+        let maximumCell = Double(heatmap?.cells.flatMap { $0 }.max() ?? 0)
+        func hourWeight(at date: Date) -> Double {
+            guard let heatmap, heatmap.totalTokens > 0, maximumCell > 0 else { return 1 }
+            let weekday = max(0, min(6, calendar.component(.weekday, from: date) - 1))
+            let hour = max(0, min(23, calendar.component(.hour, from: date)))
+            guard heatmap.cells.indices.contains(weekday),
+                  heatmap.cells[weekday].indices.contains(hour) else { return 1 }
+            let normalized = sqrt(Double(heatmap.cells[weekday][hour]) / maximumCell)
+            return 0.15 + normalized * 0.85
+        }
+
+        var cursor = start
+        var total = 0.0
+        while cursor < end {
+            let nextHour = calendar.date(
+                byAdding: .hour,
+                value: 1,
+                to: calendar.dateInterval(of: .hour, for: cursor)?.start ?? cursor
+            ) ?? cursor.addingTimeInterval(3_600)
+            let next = min(end, max(cursor.addingTimeInterval(60), nextHour))
+            total += hourWeight(at: cursor) * next.timeIntervalSince(cursor) / 3_600
+            cursor = next
+        }
+        return total
+    }
+
+    /// A lumpy but realistic week: heavy weekday afternoons, quiet nights, one
+    /// completely empty day so the 0.15 floor is exercised.
+    private func shapedHeatmap() -> UsageHeatmap {
+        var cells = Array(repeating: Array(repeating: 0, count: 24), count: 7)
+        for weekday in 1...5 {
+            for hour in 0..<24 {
+                cells[weekday][hour] = hour >= 9 && hour <= 18 ? 400 + hour * 37 : hour % 5
+            }
+        }
+        cells[6] = (0..<24).map { $0 * 11 }
+        return UsageHeatmap(
+            tool: .codex,
+            cells: cells,
+            totalTokens: cells.flatMap { $0 }.reduce(0, +)
+        )
+    }
+
+    private func calendar(_ identifier: String) -> Calendar {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: identifier)!
+        return calendar
+    }
+
+    /// The retired walk attributed up to one minute of a window to the wrong
+    /// side of an hour boundary (its step had a 60s floor), so equivalence is
+    /// asserted to within that much weight — one minute of the widest possible
+    /// weight gap, 1 minus the 0.15 floor.
+    private let tolerance = 0.02
+
+    private func assertMatchesReference(
+        from start: Date,
+        to end: Date,
+        heatmap: UsageHeatmap?,
+        calendar: Calendar,
+        _ message: String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        let profile = QuotaPaceForecast.ActivityProfile(heatmap: heatmap, calendar: calendar)
+        XCTAssertEqual(
+            profile.weight(from: start, to: end),
+            referenceWeight(from: start, to: end, heatmap: heatmap, calendar: calendar),
+            accuracy: tolerance,
+            message,
+            file: file,
+            line: line
+        )
+    }
+
+    func testUniformProfileIsExactlyElapsedHours() {
+        let calendar = calendar("America/Los_Angeles")
+        let start = calendar.date(from: DateComponents(year: 2026, month: 7, day: 30, hour: 3, minute: 17))!
+        let profile = QuotaPaceForecast.ActivityProfile(heatmap: nil, calendar: calendar)
+        XCTAssertEqual(profile.weight(from: start, to: start.addingTimeInterval(9_000)), 2.5, accuracy: 1e-9)
+        XCTAssertEqual(profile.weight(from: start, to: start), 0)
+        XCTAssertEqual(profile.weight(from: start, to: start.addingTimeInterval(-3_600)), 0)
+        // An all-zero heatmap carries no shape, so it must stay on the uniform
+        // path rather than weighting every hour at the 0.15 floor.
+        let empty = UsageHeatmap(
+            tool: .codex,
+            cells: Array(repeating: Array(repeating: 0, count: 24), count: 7),
+            totalTokens: 0
+        )
+        let emptyProfile = QuotaPaceForecast.ActivityProfile(heatmap: empty, calendar: calendar)
+        XCTAssertEqual(emptyProfile.weight(from: start, to: start.addingTimeInterval(7_200)), 2, accuracy: 1e-9)
+    }
+
+    func testMatchesRetiredWalkOverAlignedAndPartialWindows() {
+        let calendar = calendar("America/Los_Angeles")
+        let heatmap = shapedHeatmap()
+        let midnight = calendar.date(from: DateComponents(year: 2026, month: 7, day: 27, hour: 0))!
+
+        assertMatchesReference(
+            from: midnight,
+            to: midnight.addingTimeInterval(7 * 86_400),
+            heatmap: heatmap,
+            calendar: calendar,
+            "a whole hour-aligned week"
+        )
+        assertMatchesReference(
+            from: midnight.addingTimeInterval(13 * 3_600 + 1_237),
+            to: midnight.addingTimeInterval(5 * 86_400 + 47 * 60 + 12),
+            heatmap: heatmap,
+            calendar: calendar,
+            "partial hours at both ends"
+        )
+        assertMatchesReference(
+            from: midnight.addingTimeInterval(3_600 + 900),
+            to: midnight.addingTimeInterval(3_600 + 2_700),
+            heatmap: heatmap,
+            calendar: calendar,
+            "entirely inside one hour"
+        )
+        assertMatchesReference(
+            from: midnight.addingTimeInterval(9 * 3_600 - 30),
+            to: midnight.addingTimeInterval(9 * 3_600 + 30),
+            heatmap: heatmap,
+            calendar: calendar,
+            "one minute straddling the boundary into the busiest hour"
+        )
+        assertMatchesReference(
+            from: midnight.addingTimeInterval(-21 * 86_400),
+            to: midnight.addingTimeInterval(30 * 86_400),
+            heatmap: heatmap,
+            calendar: calendar,
+            "seven weeks, the span a monthly bucket with history asks for"
+        )
+    }
+
+    func testMatchesRetiredWalkAcrossDaylightSavingTransitions() {
+        let calendar = calendar("America/Los_Angeles")
+        let heatmap = shapedHeatmap()
+        // Spring forward: 2026-03-08 02:00 local does not exist.
+        let beforeSpring = calendar.date(from: DateComponents(year: 2026, month: 3, day: 7, hour: 20))!
+        assertMatchesReference(
+            from: beforeSpring,
+            to: beforeSpring.addingTimeInterval(2 * 86_400),
+            heatmap: heatmap,
+            calendar: calendar,
+            "across spring forward"
+        )
+        // Fall back: 2026-11-01 01:00 local happens twice.
+        let beforeFall = calendar.date(from: DateComponents(year: 2026, month: 10, day: 31, hour: 20))!
+        assertMatchesReference(
+            from: beforeFall,
+            to: beforeFall.addingTimeInterval(2 * 86_400),
+            heatmap: heatmap,
+            calendar: calendar,
+            "across fall back"
+        )
+        // And a window that contains both, so the table has to follow two
+        // offset changes while it is being built.
+        assertMatchesReference(
+            from: beforeSpring,
+            to: beforeFall.addingTimeInterval(2 * 86_400),
+            heatmap: heatmap,
+            calendar: calendar,
+            "a span containing both transitions"
+        )
+    }
+
+    func testMatchesRetiredWalkInHalfHourOffsetZones() {
+        // India is UTC+5:30 with no DST: local hour boundaries sit half an hour
+        // off the epoch grid, which is exactly what the table's phase is for.
+        let calendar = calendar("Asia/Kolkata")
+        let heatmap = shapedHeatmap()
+        let start = calendar.date(from: DateComponents(year: 2026, month: 7, day: 27, hour: 6, minute: 41))!
+        assertMatchesReference(
+            from: start,
+            to: start.addingTimeInterval(4 * 86_400 + 1_111),
+            heatmap: heatmap,
+            calendar: calendar,
+            "half-hour zone offset"
+        )
+    }
+
+    func testWeightIsAdditiveAcrossSplitPoints() {
+        let calendar = calendar("Europe/Amsterdam")
+        let heatmap = shapedHeatmap()
+        let profile = QuotaPaceForecast.ActivityProfile(heatmap: heatmap, calendar: calendar)
+        let start = calendar.date(from: DateComponents(year: 2026, month: 3, day: 28, hour: 21, minute: 5))!
+        let end = start.addingTimeInterval(3 * 86_400 + 4_321)
+        let splits: [TimeInterval] = [60, 3_600, 42_000, 90_000, 200_000]
+        let whole = profile.weight(from: start, to: end)
+        for split in splits {
+            let middle = start.addingTimeInterval(split)
+            XCTAssertEqual(
+                profile.weight(from: start, to: middle) + profile.weight(from: middle, to: end),
+                whole,
+                accuracy: 1e-9,
+                "splitting at \(split)s must not change the integral"
+            )
+        }
+    }
+
+    /// The forecast asks for the same profile over widening ranges as it walks
+    /// back through completed cycles, so growing the table must not move the
+    /// grid underneath the values already handed out.
+    func testGrowingTheTableKeepsEarlierAnswersStable() {
+        let calendar = calendar("America/Los_Angeles")
+        let heatmap = shapedHeatmap()
+        let profile = QuotaPaceForecast.ActivityProfile(heatmap: heatmap, calendar: calendar)
+        let anchor = calendar.date(from: DateComponents(year: 2026, month: 7, day: 30, hour: 11, minute: 23))!
+        let near = profile.weight(from: anchor, to: anchor.addingTimeInterval(6 * 3_600))
+        // Force several rebuilds, forwards and backwards.
+        _ = profile.weight(from: anchor.addingTimeInterval(-40 * 86_400), to: anchor)
+        _ = profile.weight(from: anchor, to: anchor.addingTimeInterval(40 * 86_400))
+        _ = profile.weight(from: anchor.addingTimeInterval(-200 * 86_400), to: anchor)
+        XCTAssertEqual(
+            profile.weight(from: anchor, to: anchor.addingTimeInterval(6 * 3_600)),
+            near,
+            accuracy: 1e-9
+        )
+    }
+
+    /// A stored date far outside the retention horizon must not turn into a
+    /// hundred-million-entry table; the answer is chunked instead.
+    func testAbsurdlyWideSpanStaysBoundedAndMonotonic() {
+        let calendar = calendar("America/Los_Angeles")
+        let profile = QuotaPaceForecast.ActivityProfile(heatmap: shapedHeatmap(), calendar: calendar)
+        let anchor = calendar.date(from: DateComponents(year: 2026, month: 7, day: 30, hour: 11))!
+        let wide = profile.weight(from: anchor.addingTimeInterval(-4_000 * 86_400), to: anchor)
+        let narrow = profile.weight(from: anchor.addingTimeInterval(-40 * 86_400), to: anchor)
+        XCTAssertGreaterThan(wide, narrow)
+        // Every hour weighs between the 0.15 floor and 1, so the integral is
+        // bounded by the elapsed hours either way.
+        XCTAssertLessThanOrEqual(wide, 4_000 * 24)
+        XCTAssertGreaterThanOrEqual(wide, 4_000 * 24 * 0.15)
+    }
+}

--- a/Tests/VibeBarCoreTests/QuotaCacheWriterTests.swift
+++ b/Tests/VibeBarCoreTests/QuotaCacheWriterTests.swift
@@ -1,0 +1,125 @@
+import XCTest
+@testable import VibeBarCore
+
+/// The writer exists so `QuotaService` stops encoding and writing an account's
+/// quota cache on the main actor once per successful refresh. What has to hold:
+/// the first write for an account lands immediately, further writes inside the
+/// throttle window are coalesced to the newest one, and a delete cannot be
+/// undone by a write still sitting in the queue.
+final class QuotaCacheWriterTests: XCTestCase {
+    private final class Recorder: @unchecked Sendable {
+        private let lock = NSLock()
+        private var storage: [(accountId: String, plan: String?)] = []
+        private var deletions: [String] = []
+
+        func record(_ quota: AccountQuota) {
+            lock.lock()
+            storage.append((quota.accountId, quota.plan))
+            lock.unlock()
+        }
+
+        func recordDeletion(_ accountId: String) {
+            lock.lock()
+            deletions.append(accountId)
+            lock.unlock()
+        }
+
+        var writes: [(accountId: String, plan: String?)] {
+            lock.lock()
+            defer { lock.unlock() }
+            return storage
+        }
+
+        var deletes: [String] {
+            lock.lock()
+            defer { lock.unlock() }
+            return deletions
+        }
+    }
+
+    private func quota(accountId: String = "acct-1", plan: String?) -> AccountQuota {
+        AccountQuota(
+            accountId: accountId,
+            tool: .claude,
+            buckets: [],
+            plan: plan,
+            email: nil,
+            queriedAt: Date()
+        )
+    }
+
+    private func makeWriter(_ recorder: Recorder, throttle: TimeInterval) -> QuotaCacheWriter {
+        QuotaCacheWriter(
+            throttleInterval: throttle,
+            write: { recorder.record($0) },
+            remove: { recorder.recordDeletion($0) }
+        )
+    }
+
+    func testFirstWritePerAccountLandsImmediately() async {
+        let recorder = Recorder()
+        let writer = makeWriter(recorder, throttle: 60)
+        let start = Date(timeIntervalSince1970: 1_800_000_000)
+
+        await writer.save(quota(plan: "first"), now: start)
+        await writer.save(quota(accountId: "acct-2", plan: "other"), now: start)
+
+        XCTAssertEqual(recorder.writes.map(\.plan), ["first", "other"])
+    }
+
+    func testWritesInsideTheWindowCoalesceToTheNewest() async {
+        let recorder = Recorder()
+        let writer = makeWriter(recorder, throttle: 60)
+        let start = Date(timeIntervalSince1970: 1_800_000_000)
+
+        await writer.save(quota(plan: "first"), now: start)
+        await writer.save(quota(plan: "second"), now: start.addingTimeInterval(1))
+        await writer.save(quota(plan: "third"), now: start.addingTimeInterval(2))
+        XCTAssertEqual(recorder.writes.map(\.plan), ["first"])
+
+        await writer.flushPendingWrites()
+        XCTAssertEqual(recorder.writes.map(\.plan), ["first", "third"])
+
+        // Nothing is queued any more, so a second flush must be a no-op rather
+        // than rewriting the same quota.
+        await writer.flushPendingWrites()
+        XCTAssertEqual(recorder.writes.count, 2)
+    }
+
+    func testWriteAfterTheWindowLandsImmediatelyAgain() async {
+        let recorder = Recorder()
+        let writer = makeWriter(recorder, throttle: 10)
+        let start = Date(timeIntervalSince1970: 1_800_000_000)
+
+        await writer.save(quota(plan: "first"), now: start)
+        await writer.save(quota(plan: "second"), now: start.addingTimeInterval(11))
+        XCTAssertEqual(recorder.writes.map(\.plan), ["first", "second"])
+    }
+
+    func testDeleteDropsAPendingWriteSoASignedOutAccountStaysGone() async {
+        let recorder = Recorder()
+        let writer = makeWriter(recorder, throttle: 60)
+        let start = Date(timeIntervalSince1970: 1_800_000_000)
+
+        await writer.save(quota(plan: "first"), now: start)
+        await writer.save(quota(plan: "queued"), now: start.addingTimeInterval(1))
+        await writer.delete(accountId: "acct-1")
+        await writer.flushPendingWrites()
+
+        XCTAssertEqual(recorder.deletes, ["acct-1"])
+        XCTAssertEqual(recorder.writes.map(\.plan), ["first"])
+    }
+
+    func testCoalescedWriteIsFlushedOnItsOwnWithoutAnExplicitFlush() async throws {
+        let recorder = Recorder()
+        let writer = makeWriter(recorder, throttle: 0.2)
+        let now = Date()
+
+        await writer.save(quota(plan: "first"), now: now)
+        await writer.save(quota(plan: "queued"), now: now)
+        XCTAssertEqual(recorder.writes.map(\.plan), ["first"])
+
+        try await Task.sleep(nanoseconds: 700_000_000)
+        XCTAssertEqual(recorder.writes.map(\.plan), ["first", "queued"])
+    }
+}

--- a/Tests/VibeBarCoreTests/UsageFillTimelineStoreTests.swift
+++ b/Tests/VibeBarCoreTests/UsageFillTimelineStoreTests.swift
@@ -87,6 +87,43 @@ final class UsageFillTimelineStoreTests: XCTestCase {
         XCTAssertLessThan(points[0].slotStart, points[1].slotStart)
     }
 
+    /// The batch read exists so `QuotaService` can republish every bucket of an
+    /// account in one main-actor tick instead of one per bucket. It has to agree
+    /// with the single-bucket read exactly, stay scoped to the account, and omit
+    /// buckets it has nothing for.
+    func testBatchPointsMatchPerBucketReadsAndStayScopedToTheAccount() async {
+        let store = UsageFillTimelineStore(fileURL: tempURL)
+        let base = Date(timeIntervalSince1970: 1_780_000_000)
+        await store.observe(quota(buckets: [
+            bucket(id: "five_hour", used: 41, windowSeconds: 18_000),
+            bucket(id: "weekly", used: 12)
+        ]), now: base)
+        await store.observe(quota(buckets: [
+            bucket(id: "five_hour", used: 48, windowSeconds: 18_000),
+            bucket(id: "weekly", used: 14)
+        ]), now: base.addingTimeInterval(4_000))
+        await store.observe(quota(
+            accountId: "acct-2",
+            buckets: [bucket(id: "weekly", used: 90)]
+        ), now: base)
+
+        let batch = await store.points(
+            accountId: "acct-1",
+            bucketIds: ["five_hour", "weekly", "never_seen"]
+        )
+        let fiveHour = await store.points(accountId: "acct-1", bucketId: "five_hour")
+        let weekly = await store.points(accountId: "acct-1", bucketId: "weekly")
+        XCTAssertEqual(batch["five_hour"], fiveHour)
+        XCTAssertEqual(batch["weekly"], weekly)
+        XCTAssertNil(batch["never_seen"])
+        XCTAssertEqual(batch.count, 2)
+        XCTAssertEqual(batch["weekly"]?.map(\.usedPercent), [12, 14])
+        XCTAssertFalse(batch.values.flatMap { $0 }.contains { $0.usedPercent == 90 })
+
+        let empty = await store.points(accountId: "acct-1", bucketIds: [])
+        XCTAssertTrue(empty.isEmpty)
+    }
+
     func testMiscProvidersAreDropped() async {
         let store = UsageFillTimelineStore(fileURL: tempURL)
         await store.observe(quota(tool: .zai, buckets: [bucket(id: "weekly", used: 50)]))


### PR DESCRIPTION
## Summary

Four workstreams from the latest feedback round on 1.2.0-dev.10:

### 1. Refresh-time jank fixes (`afa8325`)
Opening the popover still triggers a full refresh, but the UI no longer degrades while it runs:
- Quota observations publish **once per account** instead of once per bucket (was 25–40 full re-renders per refresh).
- New `CostAggregationCache` memoizes rebased/combined cost rollups (invalidated on new scans and local-day rollover); the Overview no longer recomputes cross-provider aggregation 4× per body pass.
- `ActivityProfile.weight` is now a prefix-summed table (epoch arithmetic) instead of an hour-by-hour Calendar walk — equivalence-tested against the retired implementation incl. DST transitions and a half-hour-offset zone.
- Quota cache writes and forecast blending moved off the main actor (`QuotaCacheWriter` actor with coalescing); the synchronous `/bin/ps` route probe and Keychain presence checks are TTL-cached off-actor.
- Overview history lanes rebuild per curve instead of all ~30 per write; the per-group chart takes fill points by value so `.equatable()` genuinely gates it; popover resizes coalesce; the hidden Claude budget WebView defers while the popover is visible.
- Bonus: fixed a double-optional bug in `SecureCookieHeaderStore`'s negative cache (`cache[account] = nil` removed the key instead of storing the miss).

### 2. Batch browser-cookie import + opt-in auto re-import (`cde78bb`)
- New `MiscCookieSpecCatalog` maps every `ToolType` to its adapter's cookie spec (exhaustive switch — a new provider fails to compile until classified; parity tests against the adapter statics).
- One-click **Import Browser Cookies for All Providers** on the misc landing page: one browser-detection pass, per-provider outcome list, one `refreshAll()` at the end. Keychain prompts stay at one per Chromium-family browser involved (SweetCookieKit caches the Safe Storage key per browser).
- Opt-in `miscCookieAutoImportEnabled` (default **off**): when a cookie-sourced provider reports a credential failure, one silent re-import (`allowKeychainPrompt: false` — can never prompt) and one retry, at the slot-aggregation chokepoint shared by all 12 adapters. Manual slots are never overwritten. Warm Chromium keys bypass the preflight cooldown through the gate's documented path — no gate internals touched.
- Framing note for review: this is N browser reads → N vault-entry writes on the **single existing** credential-vault item — not a bulk Keychain repair surface (AGENTS.md §5).

### 3. Segmented compact layout + modular summary cards (`97b1d22`)
- Compact mode now packs **ordered bands** independently and stacks them. Overview defaults to `[summary] [quota cards] [everything else]` — the "quota gets its own min-height" arrangement.
- The two Overview top cards (cost totals, service status) are now real layout modules (`overview-summary-cost` / `overview-summary-status`, new `.summary` masonry phase) and participate in auto/compact/manual. Auto visuals are unchanged (equal pinned heights seed both columns identically).
- Band membership persists on `StoredPageLayout.segments` (tolerant decode, normalization, unknown ids preserved; missing key → page default). The layout editor gains segment groups in Compact mode: drag cards between bands, reorder bands, add/merge/remove; transient empty bands live only in view state.
- Presets now restore their stored **mode** (a compact preset restores compact + bands) instead of always forcing manual.
- Accepted behavior: pre-existing *manual* Overview layouts get the two new summary modules appended at the end of their columns (drag to taste).

### 4. Forecast-colored menu bar + 24h chart default (`10a33ff`)
- Menu bar percentage colors follow the forecast verdict by default: green projected-to-last, **blue likely-surplus (you're leaving quota unused)**, orange may-run-short, red projected-to-run-out. A bar at 24% that resets in 11h with a healthy forecast now reads green, not orange.
- Thresholds + verdict mapping live in a tested Core policy (`MenuBarPercentColor`); `menuBarColorBasis` (Settings › Menu Bar › "Percent color") switches back to actual-percent thresholds; learning/absent forecasts fall back to them. Default is `.forecast` on purpose — the decode comment documents that absent keys adopt the new behavior.
- Quota history charts (per-group and Overview all-providers) open on a **24h** window instead of 7d; double-tap reset follows.

## Verification
- `swift build` clean, `swift test` **1040 tests / 0 failures** (959 → 1040, +81 this branch)
- `./Scripts/build_app.sh release` signs; `codesign -d --entitlements -` = empty `[Dict]` (no `app-sandbox`); `codesign --verify --deep --strict` OK
- No sandbox container created; real-home grep clean; no secrets/personal paths in sources or tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)