### PR TITLE
Post-merge review fixes: hidden-band merging and manual-only reimport guard

### DIFF
--- a/Sources/VibeBarCore/BrowserCookies/MiscCookieResolver.swift
+++ b/Sources/VibeBarCore/BrowserCookies/MiscCookieResolver.swift
@@ -336,7 +336,17 @@ public enum MiscCookieResolver {
     @discardableResult
     public static func silentReimport(spec: Spec, instanceID: String) -> Bool {
         let settings = currentSettings(for: spec.tool, instanceID: instanceID)
-        guard SlotFilter(settings: settings) != .none else { return false }
+        // Only when browser-origin slots can actually be used. `manualOnly` is
+        // an explicit "do not touch my browser" — reading the cookie stores
+        // for a slot the resolver would then filter out anyway would be a
+        // background read the user opted out of. (Source modes are normalized
+        // to auto today, but this guard is what honors them if they return.)
+        switch SlotFilter(settings: settings) {
+        case .all, .browserOnly:
+            break
+        case .manualOnly, .none:
+            return false
+        }
 
         let refreshable = MiscCookieSlotStore
             .slots(for: spec.tool, instanceID: instanceID)

--- a/Sources/VibeBarCore/Services/PageLayoutSegments.swift
+++ b/Sources/VibeBarCore/Services/PageLayoutSegments.swift
@@ -145,8 +145,13 @@ public enum PageLayoutSegments {
     /// cards before any session log is found — and moving one card would
     /// silently reset the rest of the page.
     ///
-    /// A hidden module stays in the band index it was saved in, clamped into
-    /// range. Only an explicit reset forgets a page.
+    /// A hidden module follows its surviving bandmates — the user dragged (or
+    /// left) the band, and the module belongs to it wherever it went. A band
+    /// whose every module is hidden has no bandmate to follow and is re-created
+    /// where it was saved, next to its nearest surviving stored neighbour:
+    /// clamping it into the last visible band instead would collapse the saved
+    /// grouping the first time the user dragged anything else, and the module
+    /// would come back in the wrong band. Only an explicit reset forgets a page.
     public static func mergingEdit(
         _ edited: [[PageLayoutModuleID]],
         into stored: [[PageLayoutModuleID]],
@@ -154,13 +159,40 @@ public enum PageLayoutSegments {
     ) -> [[PageLayoutModuleID]] {
         let availableSet = Set(available)
         var segments = normalized(edited)
-        guard !segments.isEmpty else { return normalized(stored) }
+        let storedBands = normalized(stored)
+        guard !segments.isEmpty else { return storedBands }
 
-        for (index, band) in normalized(stored).enumerated() {
-            for moduleID in band where !availableSet.contains(moduleID) {
-                guard !segments.contains(where: { $0.contains(moduleID) }) else { continue }
-                segments[min(index, segments.count - 1)].append(moduleID)
+        var editedIndex: [PageLayoutModuleID: Int] = [:]
+        for (index, band) in segments.enumerated() {
+            for moduleID in band { editedIndex[moduleID] = index }
+        }
+
+        // Bands that lost every module to unavailability, queued for
+        // re-insertion after the band holding their nearest preceding stored
+        // anchor. The user may have reordered bands, so positions are not
+        // necessarily monotone in stored order — a stable sort by position
+        // (stored order as the tie-break) makes the offset insertion exact.
+        var pending: [(position: Int, band: [PageLayoutModuleID])] = []
+        var lastAnchoredPosition = -1
+        for band in storedBands {
+            let hidden = band.filter { !availableSet.contains($0) && editedIndex[$0] == nil }
+            if let anchor = band.first(where: { editedIndex[$0] != nil }) {
+                let anchorIndex = editedIndex[anchor]!
+                lastAnchoredPosition = anchorIndex
+                guard !hidden.isEmpty else { continue }
+                segments[anchorIndex].append(contentsOf: hidden)
+            } else if !hidden.isEmpty {
+                pending.append((position: lastAnchoredPosition + 1, band: hidden))
             }
+        }
+        let ordered = pending.enumerated().sorted {
+            ($0.element.position, $0.offset) < ($1.element.position, $1.offset)
+        }
+        for (inserted, item) in ordered.enumerated() {
+            segments.insert(
+                item.element.band,
+                at: min(item.element.position + inserted, segments.count)
+            )
         }
         return normalized(segments)
     }

--- a/Tests/VibeBarCoreTests/PageLayoutTests.swift
+++ b/Tests/VibeBarCoreTests/PageLayoutTests.swift
@@ -1220,6 +1220,42 @@ final class PageLayoutTests: XCTestCase {
         XCTAssertEqual(merged, [[.status, .quotaHistoryAll], [.costAll]])
     }
 
+    func testMergingAnEditRecreatesABandWhoseEveryModuleIsHidden() {
+        // The middle band's only module is off screen. Dragging costAll into
+        // status's band must not collapse the hidden band into a neighbour:
+        // it comes back as its own band, after its preceding stored neighbour.
+        let merged = PageLayoutSegments.mergingEdit(
+            [[.status, .costAll]],
+            into: [[.status], [.quotaHistoryAll], [.costAll]],
+            available: [.status, .costAll]
+        )
+
+        XCTAssertEqual(merged, [[.status, .costAll], [.quotaHistoryAll]])
+    }
+
+    func testMergingAnEditKeepsAHiddenModuleWithItsDraggedBandmates() {
+        // status and the hidden quota history share a stored band; the user
+        // drags status into the second band. The hidden module belongs to its
+        // band, so it follows status instead of staying behind at index 0.
+        let merged = PageLayoutSegments.mergingEdit(
+            [[.costAll], [.status]],
+            into: [[.status, .quotaHistoryAll], [.costAll]],
+            available: [.status, .costAll]
+        )
+
+        XCTAssertEqual(merged, [[.costAll], [.status, .quotaHistoryAll]])
+    }
+
+    func testMergingAnEditRecreatesALeadingHiddenBandFirst() {
+        let merged = PageLayoutSegments.mergingEdit(
+            [[.status], [.costAll]],
+            into: [[.quotaHistoryAll], [.status], [.costAll]],
+            available: [.status, .costAll]
+        )
+
+        XCTAssertEqual(merged, [[.quotaHistoryAll], [.status], [.costAll]])
+    }
+
     func testMergingAnEditHonoursTheMoveItWasGiven() {
         let merged = PageLayoutSegments.mergingEdit(
             [[.status, .costAll], [.quotaHistoryAll]],


### PR DESCRIPTION
Follow-up to #127, addressing the two Codex review findings that landed after auto-merge:

- **Preserve empty hidden bands while merging edits** — `PageLayoutSegments.mergingEdit` no longer clamps the modules of an entirely-hidden band into the last visible band. Hidden modules follow their surviving bandmates; a band with no survivors is re-created after its nearest preceding stored anchor (stable-sorted insertion so band reorders stay exact). Three new tests cover the collapse case, the follow-your-bandmate case, and a leading hidden band.
- **Honor manual-only mode before reading browser cookies** — `MiscCookieResolver.silentReimport` now requires a slot filter that actually permits browser-origin slots (`all`/`browserOnly`); `manualOnly` and `none` return early, so an explicit manual-only choice can never trigger a background browser-cookie read. Source modes are normalized to auto today, so this is defensive — the exhaustive switch forces reconsideration if the modes return.

Verification: `swift build` clean, `swift test` 1045 tests / 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)