### PR TITLE
Fold reinserted hidden bands at the segment cap

### DIFF
--- a/Sources/VibeBarCore/Services/PageLayoutSegments.swift
+++ b/Sources/VibeBarCore/Services/PageLayoutSegments.swift
@@ -188,11 +188,21 @@ public enum PageLayoutSegments {
         let ordered = pending.enumerated().sorted {
             ($0.element.position, $0.offset) < ($1.element.position, $1.offset)
         }
-        for (inserted, item) in ordered.enumerated() {
-            segments.insert(
-                item.element.band,
-                at: min(item.element.position + inserted, segments.count)
-            )
+        var insertedCount = 0
+        for item in ordered {
+            let position = min(item.element.position + insertedCount, segments.count)
+            if segments.count < maximumCount {
+                segments.insert(item.element.band, at: position)
+                insertedCount += 1
+            } else {
+                // The editor offered "Add Segment" against the bands it could
+                // see, so the page can be at the cap before the hidden band is
+                // back. Folding here, into the hidden band's preceding
+                // neighbour, keeps the final `normalized` from collapsing a
+                // band the user just made — losing an invisible band's
+                // separateness costs less than losing a visible one's.
+                segments[max(0, position - 1)].append(contentsOf: item.element.band)
+            }
         }
         return normalized(segments)
     }

--- a/Tests/VibeBarCoreTests/PageLayoutTests.swift
+++ b/Tests/VibeBarCoreTests/PageLayoutTests.swift
@@ -1256,6 +1256,23 @@ final class PageLayoutTests: XCTestCase {
         XCTAssertEqual(merged, [[.quotaHistoryAll], [.status], [.costAll]])
     }
 
+    func testMergingAtTheBandCapFoldsTheHiddenBandNotTheUsersNewOne() {
+        // Six saved bands (the cap), one entirely hidden. The editor saw five,
+        // so it let the user split one into a sixth visible band. Reinserting
+        // the hidden band would make seven, and `normalized` would collapse the
+        // *last* band — the user's newest. The hidden band folds into its
+        // preceding neighbour instead, and every visible band survives.
+        let m = (0 ..< 6).map { PageLayoutModuleID("mod-\($0)") }
+        let hidden = PageLayoutModuleID("mod-hidden")
+        let stored = [[m[0]], [m[1]], [hidden], [m[2]], [m[3]], [m[4], m[5]]]
+        let edited = [[m[0]], [m[1]], [m[2]], [m[3]], [m[4]], [m[5]]]
+
+        let merged = PageLayoutSegments.mergingEdit(edited, into: stored, available: m)
+
+        XCTAssertEqual(merged.count, PageLayoutSegments.maximumCount)
+        XCTAssertEqual(merged, [[m[0]], [m[1], hidden], [m[2]], [m[3]], [m[4]], [m[5]]])
+    }
+
     func testMergingAnEditHonoursTheMoveItWasGiven() {
         let merged = PageLayoutSegments.mergingEdit(
             [[.status, .costAll], [.quotaHistoryAll]],


### PR DESCRIPTION
Follow-up to #128, addressing the Codex review finding that landed after auto-merge: when a page is at the six-band cap with one band entirely hidden, the editor (seeing five) allows adding a sixth visible band, and reinserting the hidden band during merge made seven — the final `normalized` then silently folded the user's newest band. `mergingEdit` now checks remaining capacity before reinserting: with none left, the hidden band's modules fold into its preceding neighbour, so the invisible band gives way instead of a visible one. Pinned by a cap-boundary test.

Verification: `swift build` clean, `swift test` 1046 tests / 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)