### PR TITLE
Prepare Vibe Bar 1.2.0 Dev build 11

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -21,7 +21,7 @@
     <key>CFBundleShortVersionString</key>
     <string>1.2.0</string>
     <key>CFBundleVersion</key>
-    <string>10</string>
+    <string>11</string>
     <key>LSMinimumSystemVersion</key>
     <string>26.0</string>
     <key>LSUIElement</key>


### PR DESCRIPTION
Version bump for the 1.2.0-dev.11 Dev-channel release: CFBundleVersion 10 → 11, CFBundleShortVersionString stays 1.2.0. Two-line diff.

Ships #127 (segmented compact layout, forecast menu-bar colors, refresh jank fixes, batch cookie import), #128 and #129 (post-merge review fixes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)