### PR TITLE
Flow segments as a relay in all modes, add per-module visibility

### DIFF
--- a/Sources/VibeBarApp/PageLayoutModel.swift
+++ b/Sources/VibeBarApp/PageLayoutModel.swift
@@ -58,16 +58,16 @@ final class PageLayoutModel: ObservableObject {
     /// One `compact` page's chosen partition, plus everything it depended on.
     private struct CompactPacking {
         var moduleIDs: [PageLayoutModuleID]
-        /// Band membership the partition was computed under. Part of the key,
-        /// not of the answer: re-banding a page changes what "shortest" means,
-        /// so a cached packing from the old bands cannot be reused.
+        /// Segment membership the partition was computed under. Part of the key,
+        /// not of the answer: re-grouping a page changes what "shortest" means,
+        /// so a cached packing from the old segments cannot be reused.
         var segments: [[PageLayoutModuleID]]
         var ratio: PageColumnRatio
         var spacing: Double
         /// Heights the partition was packed from — the baseline drift is
         /// measured against.
         var heights: [PageLayoutModuleID: Double]
-        /// Two columns per band, in band order.
+        /// Two columns per segment, in segment order.
         var segmentColumns: [[[PageLayoutModuleID]]]
     }
 
@@ -121,8 +121,79 @@ final class PageLayoutModel: ObservableObject {
         mode(for: page) != .auto
     }
 
+    /// True when the page carries any saved intent at all — a non-default mode,
+    /// a hand arrangement, a chosen segmentation, or a card switched off.
+    ///
+    /// Distinct from `isCustomized` on purpose: that one answers "does this page
+    /// still draw itself the way it always did", which is what a provider page's
+    /// column widths hang off, and re-grouping or hiding a card does not change
+    /// the answer to it. This one is what "Restore Defaults" has to enable.
+    func hasSavedIntent(_ page: PageLayoutPageID) -> Bool {
+        guard let stored = storedLayouts[page] else { return false }
+        return stored.mode != .auto
+            || !stored.isEmpty
+            || !stored.segments.isEmpty
+            || !stored.hidden.isEmpty
+    }
+
     func measuredHeights(for page: PageLayoutPageID) -> [PageLayoutModuleID: Double] {
         measured[page] ?? [:]
+    }
+
+    // MARK: - Visibility
+
+    /// Cards the user switched off on this page.
+    func hiddenModules(for page: PageLayoutPageID) -> [PageLayoutModuleID] {
+        storedLayouts[page]?.hidden ?? []
+    }
+
+    func isHidden(_ moduleID: PageLayoutModuleID, on page: PageLayoutPageID) -> Bool {
+        storedLayouts[page]?.isHidden(moduleID) ?? false
+    }
+
+    /// The descriptors a page actually draws — every arrangement path starts
+    /// here, so a hidden card is invisible to the packer, the planner and the
+    /// resolver alike rather than being filtered out at the last moment by each
+    /// renderer.
+    func visibleDescriptors(
+        for page: PageLayoutPageID,
+        descriptors: [PageModuleDescriptor]
+    ) -> [PageModuleDescriptor] {
+        guard let stored = storedLayouts[page], !stored.hidden.isEmpty else { return descriptors }
+        return descriptors.filter { !stored.isHidden($0.id) }
+    }
+
+    /// Module identities the page can arrange right now — what every
+    /// `mergingEdit` call has to be handed as `available`.
+    ///
+    /// Hidden modules are deliberately absent: the merge machinery already knows
+    /// how to keep the saved column and segment of something it cannot see, so
+    /// switching a card off and back on returns it to where it was.
+    func visibleModuleIDs(
+        for page: PageLayoutPageID,
+        descriptors: [PageModuleDescriptor]
+    ) -> [PageLayoutModuleID] {
+        visibleDescriptors(for: page, descriptors: descriptors).map(\.id)
+    }
+
+    /// Switch one card off, or back on. Nothing else about the page changes —
+    /// not the mode, not the columns, not the segmentation — so un-hiding is a
+    /// true undo.
+    func setHidden(
+        _ isHidden: Bool,
+        for moduleID: PageLayoutModuleID,
+        page: PageLayoutPageID
+    ) {
+        let stored = storedLayouts[page] ?? StoredPageLayout(
+            mode: mode(for: page),
+            ratio: ratio(for: page)
+        )
+        let next = stored.settingHidden(moduleID, isHidden)
+        guard next != storedLayouts[page] else { return }
+        settingsStore.settings.pageLayouts[page] = next
+        // The module set changed, so the cached packing was computed for a
+        // different page.
+        compactPackings.removeValue(forKey: page)
     }
 
     /// The arrangement to render right now: the saved one reconciled against
@@ -147,18 +218,26 @@ final class PageLayoutModel: ObservableObject {
 
     // MARK: - Modes
 
-    /// Bands this page's `compact` mode packs one at a time: the ones the user
-    /// chose, or the page's default banding when they have not.
+    /// Segments this page arranges within — in every mode, not just `compact`:
+    /// the ones the user chose, or the page's default grouping when they have
+    /// not.
     ///
-    /// Every currently drawable module lands in exactly one band, so this is
-    /// also the membership the editor drags against.
+    /// Every currently drawable module lands in exactly one segment.
+    ///
+    /// - Parameter includingHidden: pass `true` for the editor, which has to
+    ///   show a switched-off card in the segment it will come back to. The
+    ///   render path always wants the default, `false`.
     func resolvedSegments(
         for page: PageLayoutPageID,
-        descriptors: [PageModuleDescriptor]
+        descriptors: [PageModuleDescriptor],
+        includingHidden: Bool = false
     ) -> [[PageLayoutModuleID]] {
-        PageLayoutSegments.resolve(
+        let available = includingHidden
+            ? descriptors.map(\.id)
+            : visibleModuleIDs(for: page, descriptors: descriptors)
+        return PageLayoutSegments.resolve(
             stored: storedLayouts[page]?.segments ?? [],
-            available: descriptors.map(\.id),
+            available: available,
             defaultSegments: PageModuleCatalog.defaultSegments(for: page, descriptors: descriptors)
         )
     }
@@ -173,45 +252,101 @@ final class PageLayoutModel: ObservableObject {
     /// and lets SwiftUI balance them live. What comes back here for that case
     /// is the same planner's answer the editor has always previewed.
     ///
-    /// `auto` and `manual` return a single band — the two-column page they have
-    /// always been — and only `compact` can return more than one.
+    /// All three modes obey the page's segmentation, each in the way its own
+    /// engine can: `compact` packs the segments as a relay, `auto` plans them in
+    /// order, and `manual` stable-sorts its saved columns by segment. What comes
+    /// back always renders as two continuous columns — `PageLayoutArrangement`
+    /// keeps the per-segment structure only so the editor can draw the grouping.
+    ///
+    /// Cards the user switched off are filtered out here, once, so no mode has
+    /// to know about visibility.
     func arrangement(
         for page: PageLayoutPageID,
         descriptors: [PageModuleDescriptor],
         spacing: Double
     ) -> PageLayoutArrangement {
+        let visible = visibleDescriptors(for: page, descriptors: descriptors)
+        let segments = resolvedSegments(for: page, descriptors: descriptors)
+        let measured = measuredHeights(for: page)
         let defaults = PageModuleCatalog.defaultConfig(
             for: page,
-            descriptors: descriptors,
-            measuredHeights: measuredHeights(for: page),
-            spacing: spacing
+            descriptors: visible,
+            measuredHeights: measured,
+            spacing: spacing,
+            segments: segments
         )
         switch mode(for: page) {
         case .auto:
-            var config = defaults
-            for (moduleID, height) in measuredHeights(for: page) {
-                config.measuredHeights[moduleID] = height
-            }
-            return PageLayoutArrangement(config)
+            // `defaults` was already planned inside the segments, so the columns
+            // obey them; splitting them back apart is only for the editor.
+            return Self.segmented(
+                columns: defaults.columns,
+                segments: segments,
+                ratio: defaults.ratio,
+                measured: measured
+            )
         case .compact:
             return compactArrangement(for: page, descriptors: descriptors, spacing: spacing)
         case .manual:
-            return PageLayoutArrangement(
-                resolvedConfig(
-                    for: page,
-                    available: descriptors.map(\.id),
-                    default: defaults
-                )
+            let resolved = resolvedConfig(
+                for: page,
+                available: visible.map(\.id),
+                default: defaults
+            )
+            return Self.segmented(
+                // The saved columns are the user's, the segmentation is the
+                // user's, and where the two disagree the segmentation wins:
+                // it is an ordering constraint the columns obey, and the stable
+                // sort keeps the hand order inside each segment.
+                columns: PageLayoutSegments.sortedColumns(resolved.columns, segments: segments),
+                segments: segments,
+                ratio: resolved.ratio,
+                measured: measured
             )
         }
     }
 
-    /// The shortest arrangement of this page's cards, band by band.
+    /// Two already-flowing columns split back into the per-segment structure the
+    /// editor draws. The columns must already obey the segmentation, which every
+    /// caller guarantees, so this is a partition into contiguous runs and never
+    /// re-orders anything.
+    private static func segmented(
+        columns: [[PageLayoutModuleID]],
+        segments: [[PageLayoutModuleID]],
+        ratio: PageColumnRatio,
+        measured: [PageLayoutModuleID: Double]
+    ) -> PageLayoutArrangement {
+        guard segments.count > 1 else {
+            return PageLayoutArrangement(
+                PageLayoutConfig(ratio: ratio, columns: columns, measuredHeights: measured)
+            )
+        }
+        let rank = PageLayoutSegments.ordering(segments)
+        var buckets = [[[PageLayoutModuleID]]](
+            repeating: [[PageLayoutModuleID]](repeating: [], count: PageLayoutConfig.columnCount),
+            count: segments.count
+        )
+        for (index, column) in columns.enumerated() where index < PageLayoutConfig.columnCount {
+            for moduleID in column {
+                let bucket = min(rank[moduleID] ?? segments.count - 1, segments.count - 1)
+                buckets[bucket][index].append(moduleID)
+            }
+        }
+        return PageLayoutArrangement(
+            segments: buckets.map {
+                PageLayoutConfig(ratio: ratio, columns: $0, measuredHeights: measured)
+            }
+        )
+    }
+
+    /// The shortest arrangement of this page's cards, segment by segment.
     ///
-    /// Each band is packed on its own and the bands stack in order, so the page
-    /// is as short as it can be *without* reordering the groups the user reads
-    /// it in. A page with one band is the plain shortest-page packing `compact`
-    /// has always produced.
+    /// The segments are packed as a relay — each one starts from the column
+    /// heights the one before it finished at — so the page is as short as it can
+    /// be *without* reordering the groups the user reads it in, and a segment
+    /// that filled one column leaves the next one free to fill the other. A page
+    /// with one segment is the plain shortest-page packing `compact` has always
+    /// produced.
     ///
     /// Memoized, and deliberately sticky. `PageLayoutPacker` is cheap, but the
     /// answer it gives depends on heights that are still settling on the first
@@ -219,21 +354,22 @@ final class PageLayoutModel: ObservableObject {
     /// width and therefore height. So a page is re-packed only once its cards
     /// have moved by more than `compactRepackThreshold` in total, and the new
     /// packing only replaces the visible one if it is shorter by more than
-    /// `compactRepackHysteresis` — measured across the whole segmented page,
-    /// including the gaps between bands.
+    /// `compactRepackHysteresis` — measured on the whole page, i.e. its taller
+    /// column once every segment has flowed into it.
     func compactArrangement(
         for page: PageLayoutPageID,
         descriptors: [PageModuleDescriptor],
         spacing: Double
     ) -> PageLayoutArrangement {
         let ratio = ratio(for: page)
-        let moduleIDs = descriptors.map(\.id)
+        let visible = visibleDescriptors(for: page, descriptors: descriptors)
+        let moduleIDs = visible.map(\.id)
         let segments = resolvedSegments(for: page, descriptors: descriptors)
         let measured = measuredHeights(for: page)
         // A card the page has never drawn still has to be placed somewhere;
         // its family's stand-in is what the editor draws it at too.
         var heights: [PageLayoutModuleID: Double] = [:]
-        for descriptor in descriptors {
+        for descriptor in visible {
             heights[descriptor.id] = measured[descriptor.id] ?? descriptor.fallbackHeight
         }
 
@@ -342,38 +478,56 @@ final class PageLayoutModel: ObservableObject {
             into: configuredConfig(for: page),
             available: available
         )
+        let stored = storedLayouts[page]
         settingsStore.settings.pageLayouts[page] = StoredPageLayout(
             merged,
             mode: mode,
-            // Columns and bands are separate intents. Dragging a card in Manual
-            // says nothing about how the user banded the page for Compact, so
-            // the bands ride through untouched.
-            segments: storedLayouts[page]?.segments ?? []
+            // Columns and segments are separate intents. Dragging a card within
+            // a segment says nothing about the grouping, so it rides through
+            // untouched — as does the set of cards switched off.
+            segments: stored?.segments ?? [],
+            hidden: stored?.hidden ?? []
         )
     }
 
-    /// Persist a banding the user just dragged in the editor.
+    /// Persist a segmentation the user just dragged in the editor, optionally
+    /// together with the hand arrangement the same drag implies.
     ///
-    /// `compact` is the only mode that packs bands, and the editor only offers
-    /// the controls there, so writing a banding also selects it — that keeps a
-    /// page from ending up with bands nothing reads.
+    /// The mode is deliberately left alone. Segments used to be a `compact`-only
+    /// input, so writing one selected that mode; all three modes obey them now,
+    /// and re-grouping an `auto` page into Compact behind the user's back would
+    /// be a mode change they did not ask for.
+    ///
+    /// - Parameter columns: `nil` in the modes that compute their own columns.
+    ///   In `manual` the drop decides column and position as well as membership,
+    ///   and both halves have to land in one write — two writes would fan out
+    ///   through every settings subscriber twice for one gesture.
     func applySegments(
         _ segments: [[PageLayoutModuleID]],
+        columns: PageLayoutConfig? = nil,
         for page: PageLayoutPageID,
         available: [PageLayoutModuleID]
     ) {
         let stored = storedLayouts[page]
+        let mergedColumns = columns.map {
+            PageLayoutResolver.mergingEdit(
+                $0,
+                into: configuredConfig(for: page),
+                available: available
+            )
+        }
         settingsStore.settings.pageLayouts[page] = StoredPageLayout(
-            mode: .compact,
-            ratio: stored?.ratio ?? PageModuleCatalog.defaultRatio(for: page),
-            // Same reason `apply` keeps the bands: a hand arrangement survives
-            // being re-banded.
-            columns: stored?.columns ?? [],
+            mode: mode(for: page),
+            ratio: mergedColumns?.ratio ?? stored?.ratio ?? PageModuleCatalog.defaultRatio(for: page),
+            // Same reason `apply` keeps the segments: a hand arrangement
+            // survives being re-grouped.
+            columns: mergedColumns?.columns ?? stored?.columns ?? [],
             segments: PageLayoutSegments.mergingEdit(
                 segments,
                 into: stored?.segments ?? [],
                 available: available
-            )
+            ),
+            hidden: stored?.hidden ?? []
         )
         compactPackings.removeValue(forKey: page)
     }
@@ -416,9 +570,11 @@ final class PageLayoutModel: ObservableObject {
                 ratio: stored?.ratio ?? displayed.ratio,
                 // A hand arrangement survives a trip through the computed
                 // modes: switching away and back is not a reset, and only
-                // `reset(for:)` forgets a page. The same holds for the bands.
+                // `reset(for:)` forgets a page. The same holds for the segments
+                // and for the cards switched off.
                 columns: stored?.columns ?? [],
-                segments: stored?.segments ?? []
+                segments: stored?.segments ?? [],
+                hidden: stored?.hidden ?? []
             )
         }
         compactPackings.removeValue(forKey: page)
@@ -443,7 +599,8 @@ final class PageLayoutModel: ObservableObject {
                 mode: .compact,
                 ratio: ratio,
                 columns: stored?.columns ?? [],
-                segments: stored?.segments ?? []
+                segments: stored?.segments ?? [],
+                hidden: stored?.hidden ?? []
             )
             compactPackings.removeValue(forKey: page)
             return
@@ -511,13 +668,13 @@ final class PageLayoutModel: ObservableObject {
             mode: mode,
             ratio: displayed.ratio,
             columns: displayed.flattened.columns,
-            // On a packed page the bands *are* the arrangement, so the resolved
-            // ones are captured rather than the saved ones: a preset taken
-            // before the user re-banded anything still restores the page they
-            // were looking at instead of an empty "use the default" marker.
-            segments: mode == .compact
-                ? displayed.moduleSegments
-                : (storedLayouts[page]?.segments ?? [])
+            // The grouping on screen *is* part of the arrangement in every mode
+            // now, so the resolved segments are captured rather than the saved
+            // ones: a preset taken before the user re-grouped anything still
+            // restores the page they were looking at instead of an empty "use
+            // the default" marker.
+            segments: displayed.moduleSegments,
+            hidden: storedLayouts[page]?.hidden ?? []
         )
     }
 

--- a/Sources/VibeBarApp/Views/ColumnMasonryLayout.swift
+++ b/Sources/VibeBarApp/Views/ColumnMasonryLayout.swift
@@ -47,11 +47,20 @@ struct ColumnMasonryLayout: Layout {
 
     var columns: Int = 2
     var spacing: CGFloat = 12
+    /// Ordered groups the planner places in, i.e. the page's resolved segments.
+    /// Empty means "group by phase", the Overview's default segmentation.
+    var groups: [[String]] = []
     let session: Session
 
-    init(columns: Int = 2, spacing: CGFloat = 12, session: Session = Session()) {
+    init(
+        columns: Int = 2,
+        spacing: CGFloat = 12,
+        groups: [[String]] = [],
+        session: Session = Session()
+    ) {
         self.columns = columns
         self.spacing = spacing
+        self.groups = groups
         self.session = session
     }
 
@@ -111,6 +120,7 @@ struct ColumnMasonryLayout: Layout {
         if session.columnsByID.isEmpty, columnWidth > 0, !items.isEmpty {
             let optimized = OverviewMasonryPlanner.plan(
                 items: items,
+                groups: groups,
                 columns: columns,
                 spacing: Double(spacing)
             )
@@ -119,6 +129,7 @@ struct ColumnMasonryLayout: Layout {
         if session.columnsByID.isEmpty {
             return OverviewMasonryPlanner.plan(
                 items: items,
+                groups: groups,
                 columns: columns,
                 spacing: Double(spacing)
             )
@@ -126,6 +137,7 @@ struct ColumnMasonryLayout: Layout {
         return OverviewMasonryPlanner.plan(
             items: items,
             fixedColumns: session.columnsByID,
+            groups: groups,
             columns: columns,
             spacing: Double(spacing)
         )

--- a/Sources/VibeBarApp/Views/LayoutEditorView.swift
+++ b/Sources/VibeBarApp/Views/LayoutEditorView.swift
@@ -17,14 +17,15 @@ import VibeBarCore
 /// that. So what the editor shows is what the popover shows, including a
 /// `compact` packing that will move again the next time the cards are measured.
 ///
-/// What is editable follows from what each mode leaves to the user:
+/// One editor for all three modes, laid out as the page's segments, because
+/// segments belong to all three. The header controls — reorder, merge, add,
+/// hide — work the same everywhere; what a *drag* decides is the only thing
+/// that follows from the mode:
 ///
-/// - `manual` — two column zones, and a drag decides both column and position.
-/// - `compact` — one zone per segment. Position inside a segment belongs to the
-///   packer, so a drag only decides *which* segment a card is in; the header
-///   controls reorder, merge and add segments.
-/// - `auto` — read-only. The page arranges itself, and a drag would be
-///   discarded on the next measurement.
+/// - `manual` — segment, column and position.
+/// - `compact` / `auto` — segment only. Position inside a segment belongs to the
+///   packer or the balancer, and a drag deciding it would be discarded on the
+///   next measurement.
 struct LayoutEditorView: View {
     @EnvironmentObject private var environment: AppEnvironment
     @EnvironmentObject private var settingsStore: SettingsStore
@@ -49,7 +50,7 @@ struct LayoutEditorView: View {
     /// Segments the user has added but not dragged anything into yet.
     ///
     /// An empty segment is never stored — `PageLayoutSegments.normalized` drops
-    /// it, which is what keeps a saved layout from accumulating bands nothing
+    /// it, which is what keeps a saved layout from accumulating groups nothing
     /// renders. So "add a segment, then drag a card into it" only works if the
     /// empty one lives in view state until it has a card, which is what this is.
     @State private var pendingSegments = 0
@@ -123,7 +124,13 @@ struct LayoutEditorView: View {
                     .frame(maxWidth: .infinity, alignment: .leading)
             } else {
                 HStack(alignment: .top, spacing: 14) {
-                    zones(page: page, arrangement: arrangement, blocks: blocks, mode: mode)
+                    zones(
+                        page: page,
+                        arrangement: arrangement,
+                        blocks: blocks,
+                        mode: mode,
+                        descriptors: descriptors
+                    )
                     preview(arrangement: arrangement, blocks: blocks)
                 }
             }
@@ -172,7 +179,7 @@ struct LayoutEditorView: View {
                     HStack(spacing: 5) {
                         Text(entry.title)
                             .font(.system(size: 11.5, weight: .semibold, design: .rounded))
-                        if layoutModel.isCustomized(entry.page) {
+                        if layoutModel.hasSavedIntent(entry.page) {
                             Circle()
                                 .fill(Color.accentColor)
                                 .frame(width: 5, height: 5)
@@ -195,7 +202,7 @@ struct LayoutEditorView: View {
                 }
                 .buttonStyle(.plain)
                 .focusable(false)
-                .help(layoutModel.isCustomized(entry.page) ? "\(entry.title) — customized" : entry.title)
+                .help(layoutModel.hasSavedIntent(entry.page) ? "\(entry.title) — customized" : entry.title)
             }
             Spacer(minLength: 0)
         }
@@ -232,7 +239,7 @@ struct LayoutEditorView: View {
                 Label("Restore Defaults", systemImage: "arrow.uturn.backward")
                     .font(.system(size: 11))
             }
-            .disabled(!layoutModel.isCustomized(page))
+            .disabled(!layoutModel.hasSavedIntent(page))
         }
     }
 
@@ -300,7 +307,7 @@ struct LayoutEditorView: View {
                 ? "Auto — the Overview balances its columns as the cards are measured."
                 : "Auto — this page's built-in arrangement."
         case .compact:
-            return "Compact — pack each segment into the shortest band its cards fit in."
+            return "Compact — pack each segment into the shortest arrangement its cards fit in."
         case .manual:
             return "Manual — your arrangement, exactly as you dragged it."
         }
@@ -406,7 +413,7 @@ struct LayoutEditorView: View {
                 ratioButton(ratio, page: page, config: config)
             }
             Spacer(minLength: 8)
-            if layoutModel.isCustomized(page) {
+            if layoutModel.hasSavedIntent(page) {
                 Text("Customized")
                     .font(.system(size: 10, weight: .semibold))
                     .foregroundStyle(Color.accentColor)
@@ -481,187 +488,45 @@ struct LayoutEditorView: View {
 
     // MARK: - Zones
 
-    /// The editable picture of the page. Two column zones in `manual` and
-    /// `auto`, one zone per segment in `compact` — which is the only mode where
-    /// segments exist, because it is the only mode that packs.
-    @ViewBuilder
+    /// The editable picture of the page: one bordered group per segment, each
+    /// holding that segment's slice of the two columns.
+    ///
+    /// One editor for all three modes, because segments now belong to all three.
+    /// What a drag decides is the only thing that differs:
+    ///
+    /// - `manual` — segment, column and position, with an insertion line.
+    /// - `compact` / `auto` — segment only. Where the card lands inside it is
+    ///   the packer's or the balancer's answer, so a drop into its own segment
+    ///   is deliberately a no-op rather than a re-order that would be discarded
+    ///   on the next measurement.
+    ///
+    /// The groups are drawn as boxes; the popover draws no boundary at all. That
+    /// is the point of the picture — the boxes say what the ordering constraint
+    /// is, and the preview beside them says what it produces.
     private func zones(
         page: PageLayoutPageID,
         arrangement: PageLayoutArrangement,
         blocks: [PageLayoutModuleID: Block],
-        mode: PageLayoutMode
+        mode: PageLayoutMode,
+        descriptors: [PageModuleDescriptor]
     ) -> some View {
-        if mode == .compact {
-            segmentZones(page: page, arrangement: arrangement, blocks: blocks)
-        } else {
-            columnZones(page: page, config: arrangement.flattened, blocks: blocks, mode: mode)
-        }
-    }
-
-    // MARK: - Column zones
-
-    private func columnZones(
-        page: PageLayoutPageID,
-        config: PageLayoutConfig,
-        blocks: [PageLayoutModuleID: Block],
-        mode: PageLayoutMode
-    ) -> some View {
-        let totals = (0..<PageLayoutConfig.columnCount).map { index in
-            config.column(index).reduce(0.0) { $0 + (blocks[$1]?.height ?? 0) }
-        }
-        let scale = min(0.4, Self.editorColumnHeight / max(1, totals.max() ?? 1))
-        // `auto` shows what the page currently produces as a read-only picture,
-        // so a drag cannot silently discard an arrangement the app is about to
-        // recompute.
-        let isEditable = mode == .manual
-        let target = isEditable ? dropTarget(page: page, config: config) : nil
-        return VStack(alignment: .leading, spacing: 7) {
-            HStack(alignment: .top, spacing: 10) {
-                ForEach(0..<PageLayoutConfig.columnCount, id: \.self) { index in
-                    zone(
-                        index,
-                        page: page,
-                        config: config,
-                        blocks: blocks,
-                        total: totals[index],
-                        scale: scale,
-                        isEditable: isEditable,
-                        insertionIndex: target?.column == index ? target?.index : nil
-                    )
-                    .frame(maxWidth: .infinity, alignment: .topLeading)
-                }
-            }
-            if !isEditable {
-                Label("Switch to Compact or Manual to arrange this page", systemImage: "hand.point.up.left")
-                    .font(.system(size: 10))
-                    .foregroundStyle(.tertiary)
-            }
-        }
-    }
-
-    private func zone(
-        _ index: Int,
-        page: PageLayoutPageID,
-        config: PageLayoutConfig,
-        blocks: [PageLayoutModuleID: Block],
-        total: Double,
-        scale: Double,
-        isEditable: Bool,
-        insertionIndex: Int?
-    ) -> some View {
-        let moduleIDs = config.column(index)
-        let others = moduleIDs.filter { $0 != drag?.moduleID }
-        return VStack(alignment: .leading, spacing: 7) {
-            HStack(spacing: 6) {
-                Text(index == 0 ? "Left column" : "Right column")
-                    .font(.system(size: 11, weight: .semibold))
-                Spacer(minLength: 4)
-                Text("\(moduleIDs.count) card\(moduleIDs.count == 1 ? "" : "s") · \(Int(total.rounded()))pt")
-                    .font(.system(size: 10, design: .rounded).monospacedDigit())
-                    .foregroundStyle(.secondary)
-            }
-            VStack(spacing: Self.blockSpacing) {
-                ForEach(moduleIDs, id: \.self) { moduleID in
-                    if let block = blocks[moduleID] {
-                        blockView(block, page: page, scale: scale, isEditable: isEditable) {
-                            applyColumnDrop(block, page: page, config: config)
-                        }
-                        // The card stays where it is, dimmed, while its ghost
-                        // floats: pulling it out of the stack would shift every
-                        // block below it, moving the very frames the drop
-                        // target is computed from.
-                        .opacity(drag?.engaged == true && drag?.moduleID == moduleID ? 0.25 : 1)
-                    }
-                }
-                if moduleIDs.isEmpty {
-                    Text("Empty")
-                        .font(.system(size: 10))
-                        .foregroundStyle(.tertiary)
-                        .frame(maxWidth: .infinity, minHeight: 44)
-                }
-            }
-            .frame(maxWidth: .infinity, alignment: .top)
-        }
-        .padding(8)
-        .frame(maxWidth: .infinity, alignment: .topLeading)
-        .background(
-            RoundedRectangle(cornerRadius: 9, style: .continuous)
-                .fill(Color.primary.opacity(0.035))
-        )
-        .overlay(
-            RoundedRectangle(cornerRadius: 9, style: .continuous)
-                .stroke(
-                    insertionIndex == nil ? Color.primary.opacity(0.07) : Color.accentColor.opacity(0.45),
-                    lineWidth: 0.8
-                )
-        )
-        // Drawn as an overlay, not inserted into the stack, for the same
-        // reason: an inline 2.5 pt line would nudge every block below it.
-        .overlay(alignment: .top) {
-            if let insertionIndex,
-               let offset = insertionOffset(page: page, column: index, at: insertionIndex, others: others) {
-                Capsule(style: .continuous)
-                    .fill(Color.accentColor)
-                    .frame(height: 2.5)
-                    .padding(.horizontal, 8)
-                    .offset(y: offset)
-            }
-        }
-        .onGeometryChange(for: CGRect.self) { proxy in
-            proxy.frame(in: .named(Self.space))
-        } action: { frame in
-            zoneFrames[index] = frame
-        }
-    }
-
-    /// Vertical position of the insertion line, measured from the top of the
-    /// column zone, from the frames the blocks actually occupy.
-    private func insertionOffset(
-        page: PageLayoutPageID,
-        column: Int,
-        at index: Int,
-        others: [PageLayoutModuleID]
-    ) -> CGFloat? {
-        guard let zone = zoneFrames[column] else { return nil }
-        guard !others.isEmpty else { return 34 }
-        if index >= others.count {
-            guard let last = blockFrames[frameKey(page, others[others.count - 1])] else { return nil }
-            return last.maxY - zone.minY + Self.blockSpacing / 2
-        }
-        guard let frame = blockFrames[frameKey(page, others[index])] else { return nil }
-        return frame.minY - zone.minY - Self.blockSpacing / 2
-    }
-
-    // MARK: - Segment zones
-
-    /// One bordered group per segment, each holding that segment's own packed
-    /// two columns.
-    ///
-    /// Order *inside* a segment is the packer's answer, not intent, so there is
-    /// no insertion line here and dropping a card back into its own segment does
-    /// nothing. What a drag decides is membership.
-    private func segmentZones(
-        page: PageLayoutPageID,
-        arrangement: PageLayoutArrangement,
-        blocks: [PageLayoutModuleID: Block]
-    ) -> some View {
-        let bands = displayedBands(arrangement)
-        let membership = bands.map { $0.flatMap { $0 } }
-        let heights = bands.map { segmentHeight($0, blocks: blocks) }
+        let structure = segmentStructure(page: page, arrangement: arrangement, descriptors: descriptors)
+        let heights = structure.map { segmentHeight($0.columns, blocks: blocks) }
         // Scaled against the whole page, not one segment, so a tall segment
         // still reads as the tall one.
         let scale = min(0.4, Self.editorColumnHeight / max(1, heights.reduce(0, +)))
-        let target = segmentDropTarget(count: bands.count)
+        let target = segmentDropTarget(count: structure.count)
         return VStack(alignment: .leading, spacing: 7) {
-            ForEach(Array(bands.enumerated()), id: \.offset) { index, columns in
+            ForEach(Array(structure.enumerated()), id: \.offset) { index, segment in
                 segmentZone(
                     index,
                     page: page,
-                    columns: columns,
-                    membership: membership,
+                    segment: segment,
+                    structure: structure,
                     blocks: blocks,
                     height: heights[index],
                     scale: scale,
+                    mode: mode,
                     isTarget: target == index
                 )
             }
@@ -672,9 +537,9 @@ struct LayoutEditorView: View {
                     Label("Add Segment", systemImage: "plus.rectangle.on.rectangle")
                         .font(.system(size: 11))
                 }
-                .disabled(bands.count >= PageLayoutSegments.maximumCount)
+                .disabled(structure.count >= PageLayoutSegments.maximumCount)
                 .help(
-                    bands.count >= PageLayoutSegments.maximumCount
+                    structure.count >= PageLayoutSegments.maximumCount
                         ? "A page holds at most \(PageLayoutSegments.maximumCount) segments."
                         : "Add an empty segment, then drag a card into it."
                 )
@@ -683,16 +548,85 @@ struct LayoutEditorView: View {
         }
     }
 
-    /// The segments on screen: the ones the arrangement produced, plus any the
-    /// user added and has not filled yet.
-    private func displayedBands(_ arrangement: PageLayoutArrangement) -> [[[PageLayoutModuleID]]] {
-        let empty = [[PageLayoutModuleID]](repeating: [], count: PageLayoutConfig.columnCount)
-        return arrangement.segments.map(\.columns)
-            + [[[PageLayoutModuleID]]](repeating: empty, count: pendingSegments)
+    /// One segment as the editor draws it.
+    private struct SegmentSlice {
+        /// Everything the segment holds, switched-off cards included — this is
+        /// what an edit persists, so a hidden card keeps its group.
+        let members: [PageLayoutModuleID]
+        /// The visible cards, split the way the page will actually render them.
+        let columns: [[PageLayoutModuleID]]
+        /// Cards the user switched off, shown dimmed so they can be found and
+        /// switched back on.
+        let hidden: [PageLayoutModuleID]
     }
 
-    /// What one segment contributes to the page: its taller column, the same
-    /// rule `PageLayoutPacker.pageHeight` measures a packed page by.
+    /// The segments on screen: the page's resolved grouping — including cards
+    /// switched off, which is the only place they can be found — with each
+    /// segment's visible cards placed in the columns the arrangement gave them,
+    /// plus any empty segment the user added and has not filled yet.
+    private func segmentStructure(
+        page: PageLayoutPageID,
+        arrangement: PageLayoutArrangement,
+        descriptors: [PageModuleDescriptor]
+    ) -> [SegmentSlice] {
+        let groups = layoutModel.resolvedSegments(
+            for: page,
+            descriptors: descriptors,
+            includingHidden: true
+        )
+        let flowed = arrangement.flattened
+        var placement: [PageLayoutModuleID: (column: Int, rank: Int)] = [:]
+        for index in 0..<PageLayoutConfig.columnCount {
+            for (rank, moduleID) in flowed.column(index).enumerated() {
+                placement[moduleID] = (index, rank)
+            }
+        }
+        var slices = groups.map { members -> SegmentSlice in
+            var columns = [[PageLayoutModuleID]](
+                repeating: [],
+                count: PageLayoutConfig.columnCount
+            )
+            var hidden: [PageLayoutModuleID] = []
+            for moduleID in members {
+                // Classified by what the user chose, not by what happens to be
+                // missing from the arrangement: the eye has to toggle the same
+                // flag it is drawn from, or a card could get stuck showing
+                // "hidden" with no way back. Anything else the arrangement did
+                // not place is still shown, at the end of the left column.
+                guard !layoutModel.isHidden(moduleID, on: page) else {
+                    hidden.append(moduleID)
+                    continue
+                }
+                columns[placement[moduleID]?.column ?? 0].append(moduleID)
+            }
+            // The arrangement's own order down each column, not the segment's
+            // membership order, so the editor stacks the blocks the way the page
+            // stacks the cards.
+            columns = columns.map { column in
+                column.sorted {
+                    (placement[$0]?.rank ?? .max) < (placement[$1]?.rank ?? .max)
+                }
+            }
+            return SegmentSlice(members: members, columns: columns, hidden: hidden)
+        }
+        slices.append(
+            contentsOf: (0..<pendingSegments).map { _ in
+                SegmentSlice(
+                    members: [],
+                    columns: [[PageLayoutModuleID]](
+                        repeating: [],
+                        count: PageLayoutConfig.columnCount
+                    ),
+                    hidden: []
+                )
+            }
+        )
+        return slices
+    }
+
+    /// What one segment contributes to the page: its taller column. Cards the
+    /// user switched off contribute nothing, because the popover will not draw
+    /// them.
     private func segmentHeight(
         _ columns: [[PageLayoutModuleID]],
         blocks: [PageLayoutModuleID: Block]
@@ -705,17 +639,23 @@ struct LayoutEditorView: View {
     private func segmentZone(
         _ index: Int,
         page: PageLayoutPageID,
-        columns: [[PageLayoutModuleID]],
-        membership: [[PageLayoutModuleID]],
+        segment: SegmentSlice,
+        structure: [SegmentSlice],
         blocks: [PageLayoutModuleID: Block],
         height: Double,
         scale: Double,
+        mode: PageLayoutMode,
         isTarget: Bool
     ) -> some View {
-        let cards = columns.flatMap { $0 }
+        let membership = structure.map(\.members)
+        let cards = segment.columns.flatMap { $0 }
+        let isEmpty = segment.members.isEmpty
         // An empty segment is always one the user just added, so it is only ever
         // trailing: moving a card past it, or a segment below it, is meaningless.
         let nextIsEmpty = membership.indices.contains(index + 1) && membership[index + 1].isEmpty
+        let target = mode == .manual
+            ? manualDropTarget(page: page, segment: segment, at: index, count: structure.count)
+            : nil
         return VStack(alignment: .leading, spacing: 6) {
             HStack(spacing: 6) {
                 Text("Segment \(index + 1)")
@@ -727,12 +667,12 @@ struct LayoutEditorView: View {
                 segmentButton("chevron.up", help: "Move this segment up") {
                     moveSegment(index, by: -1, page: page, membership: membership)
                 }
-                .disabled(index == 0 || cards.isEmpty)
+                .disabled(index == 0 || isEmpty)
                 segmentButton("chevron.down", help: "Move this segment down") {
                     moveSegment(index, by: 1, page: page, membership: membership)
                 }
-                .disabled(index >= membership.count - 1 || cards.isEmpty || nextIsEmpty)
-                if cards.isEmpty {
+                .disabled(index >= membership.count - 1 || isEmpty || nextIsEmpty)
+                if isEmpty {
                     segmentButton("xmark", help: "Remove this empty segment") {
                         pendingSegments = max(0, pendingSegments - 1)
                     }
@@ -748,21 +688,23 @@ struct LayoutEditorView: View {
             }
             HStack(alignment: .top, spacing: 10) {
                 ForEach(0..<PageLayoutConfig.columnCount, id: \.self) { column in
-                    VStack(spacing: Self.blockSpacing) {
-                        ForEach(columns.indices.contains(column) ? columns[column] : [], id: \.self) { moduleID in
-                            if let block = blocks[moduleID] {
-                                blockView(block, page: page, scale: scale, isEditable: true) {
-                                    applySegmentDrop(block, page: page, membership: membership)
-                                }
-                                .opacity(drag?.engaged == true && drag?.moduleID == moduleID ? 0.25 : 1)
-                            }
-                        }
-                    }
-                    .frame(maxWidth: .infinity, alignment: .top)
+                    segmentColumn(
+                        column,
+                        page: page,
+                        segment: segment,
+                        structure: structure,
+                        blocks: blocks,
+                        scale: scale,
+                        mode: mode,
+                        insertionIndex: target?.column == column ? target?.index : nil
+                    )
                 }
             }
+            if !segment.hidden.isEmpty {
+                hiddenStrip(segment.hidden, page: page, blocks: blocks)
+            }
             if cards.isEmpty {
-                Text("Empty — drag a card here")
+                Text(isEmpty ? "Empty — drag a card here" : "Every card here is hidden")
                     .font(.system(size: 10))
                     .foregroundStyle(.tertiary)
                     .frame(maxWidth: .infinity, minHeight: 38)
@@ -786,6 +728,94 @@ struct LayoutEditorView: View {
         } action: { frame in
             segmentFrames[index] = frame
         }
+    }
+
+    private func segmentColumn(
+        _ column: Int,
+        page: PageLayoutPageID,
+        segment: SegmentSlice,
+        structure: [SegmentSlice],
+        blocks: [PageLayoutModuleID: Block],
+        scale: Double,
+        mode: PageLayoutMode,
+        insertionIndex: Int?
+    ) -> some View {
+        let moduleIDs = segment.columns.indices.contains(column) ? segment.columns[column] : []
+        let others = moduleIDs.filter { $0 != drag?.moduleID }
+        return VStack(spacing: Self.blockSpacing) {
+            ForEach(moduleIDs, id: \.self) { moduleID in
+                if let block = blocks[moduleID] {
+                    blockView(block, page: page, scale: scale, isEditable: true, isHidden: false) {
+                        applyDrop(block, page: page, mode: mode, structure: structure)
+                    }
+                    // The card stays where it is, dimmed, while its ghost
+                    // floats: pulling it out of the stack would shift every
+                    // block below it, moving the very frames the drop target
+                    // is computed from.
+                    .opacity(drag?.engaged == true && drag?.moduleID == moduleID ? 0.25 : 1)
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .top)
+        // Drawn as an overlay, not inserted into the stack, for the same
+        // reason: an inline 2.5 pt line would nudge every block below it.
+        .overlay(alignment: .top) {
+            if let insertionIndex,
+               let offset = insertionOffset(page: page, at: insertionIndex, others: others) {
+                Capsule(style: .continuous)
+                    .fill(Color.accentColor)
+                    .frame(height: 2.5)
+                    .offset(y: offset)
+            }
+        }
+        .onGeometryChange(for: CGRect.self) { proxy in
+            proxy.frame(in: .named(Self.space))
+        } action: { frame in
+            // Every segment reports the same two x ranges, so the last writer
+            // wins harmlessly: the column hit test only reads `x`.
+            zoneFrames[column] = frame
+        }
+    }
+
+    /// Cards switched off in this segment, kept on screen so they can be found
+    /// and switched back on. They are not draggable — a card that renders
+    /// nowhere has no position to choose — and they carry no height.
+    private func hiddenStrip(
+        _ moduleIDs: [PageLayoutModuleID],
+        page: PageLayoutPageID,
+        blocks: [PageLayoutModuleID: Block]
+    ) -> some View {
+        VStack(alignment: .leading, spacing: Self.blockSpacing) {
+            Text("Hidden")
+                .font(.system(size: 9, weight: .semibold))
+                .foregroundStyle(.tertiary)
+            ForEach(moduleIDs, id: \.self) { moduleID in
+                if let block = blocks[moduleID] {
+                    blockView(block, page: page, scale: 0, isEditable: false, isHidden: true) {}
+                }
+            }
+        }
+        .padding(.top, 4)
+    }
+
+    /// Vertical position of the insertion line, measured from the top of the
+    /// segment's column stack, from the frames the blocks actually occupy.
+    private func insertionOffset(
+        page: PageLayoutPageID,
+        at index: Int,
+        others: [PageLayoutModuleID]
+    ) -> CGFloat? {
+        guard !others.isEmpty else { return 0 }
+        if index >= others.count {
+            guard let last = blockFrames[frameKey(page, others[others.count - 1])],
+                  let first = blockFrames[frameKey(page, others[0])]
+            else { return nil }
+            return last.maxY - first.minY + Self.blockSpacing / 2
+        }
+        guard let frame = blockFrames[frameKey(page, others[index])],
+              let first = blockFrames[frameKey(page, others[0])]
+        else { return nil }
+        return frame.minY - first.minY - Self.blockSpacing / 2
     }
 
     private func segmentButton(
@@ -812,24 +842,66 @@ struct LayoutEditorView: View {
         page: PageLayoutPageID,
         scale: Double,
         isEditable: Bool,
+        isHidden: Bool,
         onRelease: @escaping () -> Void
     ) -> some View {
-        let height = max(Self.minimumBlockHeight, CGFloat(block.height * scale))
-        let body = blockBody(block, height: height, isEditable: isEditable)
+        // A hidden card is drawn at the minimum height whatever it measures: it
+        // contributes nothing to the page, so drawing it proportionally would
+        // make a switched-off chart dominate the picture of a page it is not on.
+        let height = isHidden
+            ? Self.minimumBlockHeight
+            : max(Self.minimumBlockHeight, CGFloat(block.height * scale))
+        let body = blockBody(block, height: height, isEditable: isEditable, isHidden: isHidden)
             .onGeometryChange(for: CGRect.self) { proxy in
                 proxy.frame(in: .named(Self.space))
             } action: { frame in
                 blockFrames[frameKey(page, block.id)] = frame
             }
             .help("\(block.descriptor.displayName) · \(block.heightLabel)")
-        if isEditable {
-            body.gesture(dragGesture(block: block, page: page, height: height, onRelease: onRelease))
-        } else {
-            body
+        Group {
+            if isEditable {
+                body.gesture(dragGesture(block: block, page: page, height: height, onRelease: onRelease))
+            } else {
+                body
+            }
+        }
+        // On top of the block rather than beside it, so the eye is inside the
+        // card's own bounds and — being the topmost view — takes the click that
+        // the drag gesture underneath would otherwise capture.
+        .overlay(alignment: .topTrailing) {
+            visibilityToggle(block, page: page, isHidden: isHidden)
         }
     }
 
-    private func blockBody(_ block: Block, height: CGFloat, isEditable: Bool) -> some View {
+    private func visibilityToggle(
+        _ block: Block,
+        page: PageLayoutPageID,
+        isHidden: Bool
+    ) -> some View {
+        Button {
+            layoutModel.setHidden(!isHidden, for: block.id, page: page)
+        } label: {
+            Image(systemName: isHidden ? "eye.slash" : "eye")
+                .font(.system(size: 9, weight: .medium))
+                .foregroundStyle(.secondary)
+                .frame(width: 20, height: 20)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .focusable(false)
+        .help(
+            isHidden
+                ? "Show “\(block.descriptor.displayName)” on this page"
+                : "Hide “\(block.descriptor.displayName)” from this page"
+        )
+    }
+
+    private func blockBody(
+        _ block: Block,
+        height: CGFloat,
+        isEditable: Bool,
+        isHidden: Bool
+    ) -> some View {
         let accent = block.descriptor.accent.color
         return HStack(alignment: .top, spacing: 7) {
             RoundedRectangle(cornerRadius: 1.5, style: .continuous)
@@ -841,7 +913,7 @@ struct LayoutEditorView: View {
                     .font(.system(size: 11, weight: .semibold))
                     .lineLimit(1)
                     .minimumScaleFactor(0.8)
-                Text(block.heightLabel)
+                Text(isHidden ? "hidden" : block.heightLabel)
                     .font(.system(size: 9, design: .rounded).monospacedDigit())
                     .foregroundStyle(.secondary)
             }
@@ -854,20 +926,26 @@ struct LayoutEditorView: View {
                     .foregroundStyle(.tertiary)
             }
         }
-        .padding(.horizontal, 7)
+        .padding(.leading, 7)
+        // Room for the eye, which floats over the block's trailing edge.
+        .padding(.trailing, 22)
         .padding(.vertical, 5)
         .frame(height: height, alignment: .top)
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(
             RoundedRectangle(cornerRadius: 6, style: .continuous)
-                .fill(accent.opacity(0.11))
+                .fill(accent.opacity(isHidden ? 0.05 : 0.11))
         )
         .overlay(
             RoundedRectangle(cornerRadius: 6, style: .continuous)
-                .stroke(accent.opacity(0.30), lineWidth: 0.7)
+                .stroke(
+                    accent.opacity(isHidden ? 0.14 : 0.30),
+                    style: StrokeStyle(lineWidth: 0.7, dash: isHidden ? [3, 2] : [])
+                )
         )
         .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
         .contentShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
+        .opacity(isHidden ? 0.5 : 1)
     }
 
     // MARK: - Dragging
@@ -910,39 +988,125 @@ struct LayoutEditorView: View {
             }
     }
 
-    /// Manual: the card takes the column and position it was dropped at.
-    private func applyColumnDrop(
+    /// The card joins the segment it was dropped on — and, in `manual`, the
+    /// column and position too.
+    ///
+    /// In the computed modes a drop inside the card's own segment is
+    /// deliberately a no-op: where it sits inside is the packer's or the
+    /// balancer's answer, and a re-order would be discarded on the next pass.
+    private func applyDrop(
         _ block: Block,
         page: PageLayoutPageID,
-        config: PageLayoutConfig
+        mode: PageLayoutMode,
+        structure: [SegmentSlice]
     ) {
-        guard let target = dropTarget(page: page, config: config) else { return }
-        let moved = config.moving(block.id, toColumn: target.column, at: target.index)
-        guard moved.columns != config.columns || !layoutModel.isCustomized(page) else { return }
-        layoutModel.apply(moved, for: page, available: availableModuleIDs(for: page))
-    }
-
-    /// Compact: the card joins the segment it was dropped on. Where it lands
-    /// inside that segment is the packer's call, so a drop inside its own
-    /// segment is deliberately a no-op rather than a re-order.
-    private func applySegmentDrop(
-        _ block: Block,
-        page: PageLayoutPageID,
-        membership: [[PageLayoutModuleID]]
-    ) {
-        guard let target = segmentDropTarget(count: membership.count),
-              membership.indices.contains(target)
+        let membership = structure.map(\.members)
+        guard let target = segmentDropTarget(count: structure.count),
+              structure.indices.contains(target)
         else { return }
-        guard !membership[target].contains(block.id) else { return }
+
         var next = membership
         for index in next.indices {
             next[index].removeAll { $0 == block.id }
         }
         next[target].append(block.id)
-        layoutModel.applySegments(next, for: page, available: availableModuleIDs(for: page))
-        // Whatever is still empty cannot be stored, so it goes back to being a
-        // pending segment instead of vanishing under the user's pointer.
+
+        guard mode == .manual else {
+            guard !membership[target].contains(block.id) else { return }
+            layoutModel.applySegments(next, for: page, available: availableModuleIDs(for: page))
+            // Whatever is still empty cannot be stored, so it goes back to being
+            // a pending segment instead of vanishing under the user's pointer.
+            pendingSegments = next.filter(\.isEmpty).count
+            return
+        }
+
+        let movedColumns = manualDropTarget(
+            page: page,
+            segment: structure[target],
+            at: target,
+            count: structure.count
+        )
+        .flatMap { spot in
+            manualColumns(
+                moving: block.id,
+                to: spot,
+                inSegment: target,
+                structure: structure,
+                membership: next,
+                ratio: layoutModel.ratio(for: page)
+            )
+        }
+        // The two halves of a manual drop change independently: a card can
+        // change segment without changing its place in the column (the segment
+        // below starts exactly where it already sat), and it can move within its
+        // own segment without changing group. Either one alone is an edit; a
+        // click-sized drag that does neither must not write the settings file.
+        let changedSegment = !membership[target].contains(block.id)
+        guard changedSegment || movedColumns != nil else { return }
+        layoutModel.applySegments(
+            next,
+            columns: movedColumns,
+            for: page,
+            available: availableModuleIDs(for: page)
+        )
         pendingSegments = next.filter(\.isEmpty).count
+    }
+
+    /// Where the dragged block would land inside the segment it is over — the
+    /// column, and the index among that segment's cards in it.
+    ///
+    /// `nil` unless the pointer is actually over this segment, so only the
+    /// segment being targeted draws an insertion line.
+    private func manualDropTarget(
+        page: PageLayoutPageID,
+        segment: SegmentSlice,
+        at index: Int,
+        count: Int
+    ) -> (column: Int, index: Int)? {
+        guard let drag, drag.engaged, segmentDropTarget(count: count) == index else { return nil }
+        let column = nearestColumn(to: drag.location)
+        let others = (segment.columns.indices.contains(column) ? segment.columns[column] : [])
+            .filter { $0 != drag.moduleID }
+        var position = others.count
+        for (offset, moduleID) in others.enumerated() {
+            guard let frame = blockFrames[frameKey(page, moduleID)] else { continue }
+            if drag.location.y < frame.midY {
+                position = offset
+                break
+            }
+        }
+        return (column, position)
+    }
+
+    /// The page's two columns with `moduleID` moved to `spot` inside segment
+    /// `index` — the absolute position that local drop implies once the earlier
+    /// segments' share of the column is counted.
+    ///
+    /// `nil` when nothing actually moved, so a click-sized drag does not write
+    /// the settings file.
+    private func manualColumns(
+        moving moduleID: PageLayoutModuleID,
+        to spot: (column: Int, index: Int),
+        inSegment index: Int,
+        structure: [SegmentSlice],
+        membership: [[PageLayoutModuleID]],
+        ratio: PageColumnRatio
+    ) -> PageLayoutConfig? {
+        var columns = [[PageLayoutModuleID]](repeating: [], count: PageLayoutConfig.columnCount)
+        for segment in structure {
+            for column in columns.indices where segment.columns.indices.contains(column) {
+                columns[column].append(contentsOf: segment.columns[column])
+            }
+        }
+        let before = columns
+        let rank = PageLayoutSegments.ordering(membership)
+        let preceding = columns[spot.column]
+            .filter { $0 != moduleID && (rank[$0] ?? index) < index }
+            .count
+        let moved = PageLayoutConfig(ratio: ratio, columns: columns)
+            .moving(moduleID, toColumn: spot.column, at: preceding + spot.index)
+        guard moved.columns != before else { return nil }
+        return moved
     }
 
     private func moveSegment(
@@ -991,23 +1155,6 @@ struct LayoutEditorView: View {
             }
         }
         return best
-    }
-
-    /// Where the dragged block would land if the pointer were released now.
-    private func dropTarget(page: PageLayoutPageID, config: PageLayoutConfig) -> (column: Int, index: Int)? {
-        guard let drag, drag.engaged else { return nil }
-        let point = drag.location
-        let column = nearestColumn(to: point)
-        let others = config.column(column).filter { $0 != drag.moduleID }
-        var index = others.count
-        for (offset, moduleID) in others.enumerated() {
-            guard let frame = blockFrames[frameKey(page, moduleID)] else { continue }
-            if point.y < frame.midY {
-                index = offset
-                break
-            }
-        }
-        return (column, index)
     }
 
     private func frameKey(_ page: PageLayoutPageID, _ moduleID: PageLayoutModuleID) -> String {
@@ -1059,10 +1206,14 @@ struct LayoutEditorView: View {
         arrangement: PageLayoutArrangement,
         blocks: [PageLayoutModuleID: Block]
     ) -> some View {
-        // The same segments the popover will stack, through the same
-        // arrangement call, so the preview cannot disagree with the page.
-        let bands = arrangement.segments.map(\.columns)
-        let pageHeight = bands.reduce(0.0) { $0 + segmentHeight($1, blocks: blocks) }
+        // Exactly what the popover will draw: the two continuous columns, from
+        // the same arrangement call the popover makes. The zones beside this
+        // show the segment boxes; this shows what they produce, which is a page
+        // with no boundary in it at all.
+        let flowed = arrangement.flattened
+        let pageHeight = (0..<PageLayoutConfig.columnCount)
+            .map { index in flowed.column(index).reduce(0.0) { $0 + (blocks[$1]?.height ?? 0) } }
+            .max() ?? 0
         let scale = min(0.12, Self.previewColumnHeight / max(1, pageHeight))
         let width: CGFloat = 150
         let gap: CGFloat = 4
@@ -1077,21 +1228,11 @@ struct LayoutEditorView: View {
                 RoundedRectangle(cornerRadius: 2, style: .continuous)
                     .fill(Color.primary.opacity(0.14))
                     .frame(height: 7)
-                ForEach(Array(bands.enumerated()), id: \.offset) { _, columns in
-                    HStack(alignment: .top, spacing: gap) {
-                        previewColumn(
-                            columns.indices.contains(0) ? columns[0] : [],
-                            blocks: blocks,
-                            scale: scale
-                        )
+                HStack(alignment: .top, spacing: gap) {
+                    previewColumn(flowed.column(0), blocks: blocks, scale: scale)
                         .frame(width: leftWidth)
-                        previewColumn(
-                            columns.indices.contains(1) ? columns[1] : [],
-                            blocks: blocks,
-                            scale: scale
-                        )
+                    previewColumn(flowed.column(1), blocks: blocks, scale: scale)
                         .frame(width: max(0, width - gap - leftWidth))
-                    }
                 }
             }
             .padding(7)
@@ -1133,13 +1274,18 @@ struct LayoutEditorView: View {
     /// Modules the page can draw right now. The saved layout may name more;
     /// `PageLayoutResolver.mergingEdit` needs this set to tell "the user moved
     /// this away" from "this is not on screen at the moment".
+    ///
+    /// Cards the user switched off count as not on screen, which is what makes
+    /// switching one back on return it to the column and segment it left.
     private func availableModuleIDs(for page: PageLayoutPageID) -> [PageLayoutModuleID] {
-        PageModuleCatalog.descriptors(
+        layoutModel.visibleModuleIDs(
             for: page,
-            environment: environment,
-            settings: settingsStore.settings
+            descriptors: PageModuleCatalog.descriptors(
+                for: page,
+                environment: environment,
+                settings: settingsStore.settings
+            )
         )
-        .map(\.id)
     }
 
     /// Exactly what the popover would draw for this page right now — the same
@@ -1160,16 +1306,17 @@ struct LayoutEditorView: View {
     }
 
     private func footnote(page: PageLayoutPageID, mode: PageLayoutMode) -> String {
+        let shared = "Segments are a reading order, not a row: a segment's cards sit above the next segment's inside each column, and the columns never wait for each other, so the page has no gap at a boundary. The eye on a card hides it from this page — it keeps its place and comes back where it was. An empty segment is forgotten once you leave this screen."
         switch mode {
         case .manual:
-            return "Drag a card to reorder it or move it between columns. Cards are drawn at their measured height, so the taller column here is the taller column in the popover. A card with no measurement yet shows “—pt”."
+            return "Drag a card to reorder it, move it between columns, or move it into another segment. Cards are drawn at their measured height, so the taller column here is the taller column in the popover; a card with no measurement yet shows “—pt”. \(shared)"
         case .compact:
-            return "Compact packs each segment on its own into whichever two columns make it shortest, and stacks the segments in the order shown. Drag a card onto another segment to move it — where it lands inside is the packer's call. It re-packs when the measured heights move enough to change the answer, and an empty segment is forgotten once you leave this screen."
+            return "Compact packs each segment into whichever two columns make the page shortest, starting each one from the heights the segment above left behind. Drag a card onto another segment to move it — where it lands inside is the packer's call. It re-packs when the measured heights move enough to change the answer. \(shared)"
         case .auto:
-            if page.isOverview {
-                return "The Overview balances its columns automatically, quota cards first. Blocks below show what that balance currently produces."
-            }
-            return "This page uses its built-in arrangement. Pick Compact or Manual, or a width split, to take it over."
+            let intro = page.isOverview
+                ? "The Overview balances its columns automatically, quota cards first, inside the segments shown."
+                : "This page uses its built-in split, ordered by the segments shown. Pick Compact or Manual, or a width split, to take the columns over too."
+            return "\(intro) Drag a card onto another segment to re-group it; which column it lands in stays automatic. \(shared)"
         }
     }
 }

--- a/Sources/VibeBarApp/Views/PageLayoutColumns.swift
+++ b/Sources/VibeBarApp/Views/PageLayoutColumns.swift
@@ -29,15 +29,19 @@ struct PageColumnWidths {
 /// Renders a page as fixed-order columns straight out of a
 /// `PageLayoutArrangement`.
 ///
-/// Used whenever the user has arranged the page by hand, and on provider pages
-/// always — their built-in split is itself a fixed two-column arrangement, so
-/// the default config reproduces it exactly and there is no second code path
-/// to keep in sync.
+/// Used whenever the page is not drawing itself with the live-measured
+/// `ColumnMasonryLayout`, and on provider pages always — their built-in split is
+/// itself a fixed two-column arrangement, so the default config reproduces it
+/// exactly and there is no second code path to keep in sync. A module the user
+/// switched off is simply absent from the arrangement, so nothing here has to
+/// know about visibility.
 ///
-/// A `compact` page can hand over several bands, which stack vertically at the
-/// page's own card gap. One band renders as exactly the single two-column
-/// `HStack` this view has always drawn, which is what `auto` and `manual` pass,
-/// so segmentation cannot change how an unsegmented page looks.
+/// A segmented page is drawn as one two-column `HStack`, not as a stack of
+/// per-segment rows. Segments are an ordering constraint inside each column —
+/// segment *k*'s cards above segment *k+1*'s — and the columns are never made to
+/// line up at a boundary. Drawing them as bands made the shorter column wait for
+/// the taller one, which is exactly the blank rectangle the user reported; the
+/// arrangement's `flattened` columns are what the page has to render instead.
 ///
 /// Every card reports its rendered height back to the model on the way past;
 /// the layout editor draws its blocks from those measurements.
@@ -56,15 +60,12 @@ struct PageLayoutColumns<Content: View>: View {
         // descriptor set every pass and skip anything stale rather than
         // trusting the saved identifiers.
         let byID = Dictionary(descriptors.map { ($0.id, $0) }, uniquingKeysWith: { first, _ in first })
-        VStack(alignment: .leading, spacing: spacing) {
-            ForEach(Array(arrangement.segments.enumerated()), id: \.offset) { _, segment in
-                HStack(alignment: .top, spacing: spacing) {
-                    column(segment.column(0), byID: byID)
-                        .frame(width: widths.left, alignment: .topLeading)
-                    column(segment.column(1), byID: byID)
-                        .frame(width: widths.right, alignment: .topLeading)
-                }
-            }
+        let flowed = arrangement.flattened
+        HStack(alignment: .top, spacing: spacing) {
+            column(flowed.column(0), byID: byID)
+                .frame(width: widths.left, alignment: .topLeading)
+            column(flowed.column(1), byID: byID)
+                .frame(width: widths.right, alignment: .topLeading)
         }
         .frame(width: widths.total, alignment: .topLeading)
     }

--- a/Sources/VibeBarApp/Views/PageModuleCatalog.swift
+++ b/Sources/VibeBarApp/Views/PageModuleCatalog.swift
@@ -510,16 +510,22 @@ enum PageModuleCatalog {
     /// editor sees.
     ///
     /// Provider pages have a hand-coded split, so their default is simply the
-    /// descriptors' own `defaultColumn`. The Overview has no hand-coded split —
-    /// it auto-balances — so its default is what the balancer would produce
-    /// from the last measured heights, computed with the same Core planner the
-    /// live waterfall uses. That keeps the editor's "before you touched it"
+    /// descriptors' own `defaultColumn`, re-ordered to obey the segmentation.
+    /// The Overview has no hand-coded split — it auto-balances — so its default
+    /// is what the balancer would produce from the last measured heights,
+    /// computed with the same Core planner the live waterfall uses, and handed
+    /// the same segments. That keeps the editor's "before you touched it"
     /// picture honest instead of showing an arrangement the popover never had.
+    ///
+    /// - Parameter segments: the page's resolved segmentation. Empty falls back
+    ///   to "no grouping", which on the Overview means the planner's own phase
+    ///   grouping.
     static func defaultConfig(
         for page: PageLayoutPageID,
         descriptors: [PageModuleDescriptor],
         measuredHeights: [PageLayoutModuleID: Double],
-        spacing: Double
+        spacing: Double,
+        segments: [[PageLayoutModuleID]] = []
     ) -> PageLayoutConfig {
         guard page.isOverview else {
             var columns = [[PageLayoutModuleID]](repeating: [], count: PageLayoutConfig.columnCount)
@@ -527,7 +533,13 @@ enum PageModuleCatalog {
                 let column = min(max(0, descriptor.defaultColumn), PageLayoutConfig.columnCount - 1)
                 columns[column].append(descriptor.id)
             }
-            return PageLayoutConfig(ratio: defaultRatio(for: page), columns: columns)
+            return PageLayoutConfig(
+                ratio: defaultRatio(for: page),
+                // A provider page's built-in split decides the column; the
+                // segmentation decides the order down it. Catalog order survives
+                // inside a segment because the sort is stable.
+                columns: PageLayoutSegments.sortedColumns(columns, segments: segments)
+            )
         }
 
         let items = descriptors.map { descriptor in
@@ -537,7 +549,12 @@ enum PageModuleCatalog {
                 phase: descriptor.masonryPhase.corePhase
             )
         }
-        let plan = OverviewMasonryPlanner.plan(items: items, columns: 2, spacing: spacing)
+        let plan = OverviewMasonryPlanner.plan(
+            items: items,
+            groups: segments.map { $0.map(\.rawValue) },
+            columns: 2,
+            spacing: spacing
+        )
         var columns = [[(module: PageLayoutModuleID, y: Double)]](
             repeating: [],
             count: PageLayoutConfig.columnCount
@@ -566,14 +583,16 @@ enum PageModuleCatalog {
 
     // MARK: - Default segmentation
 
-    /// The bands `compact` packs one at a time when the user has not chosen a
+    /// The groups every mode arranges within when the user has not chosen a
     /// segmentation of their own.
     ///
     /// Derived from the modules' `masonryPhase`, so the grouping the Overview
-    /// reads in is the grouping `compact` respects — this is the whole reason a
-    /// packed Overview no longer slots a heatmap between two quota cards. The
-    /// policy itself is `PageLayoutSegments.defaultSegments`; this is the
-    /// adapter from the catalog's descriptors to it.
+    /// reads in is the grouping every mode respects — this is the whole reason a
+    /// packed Overview no longer slots a heatmap between two quota cards, and
+    /// the reason handing these to `auto` changes nothing about an Overview
+    /// nobody has re-grouped: the planner's phase grouping *is* this. The policy
+    /// itself is `PageLayoutSegments.defaultSegments`; this is the adapter from
+    /// the catalog's descriptors to it.
     static func defaultSegments(
         for page: PageLayoutPageID,
         descriptors: [PageModuleDescriptor]

--- a/Sources/VibeBarApp/Views/PopoverRoot.swift
+++ b/Sources/VibeBarApp/Views/PopoverRoot.swift
@@ -462,21 +462,39 @@ private struct OverviewWaterfall: View {
         }
     }
 
-    /// The built-in arrangement: the auto-balancing waterfall, untouched.
+    /// The built-in arrangement: the auto-balancing waterfall, planned inside
+    /// the page's segments.
+    ///
+    /// The segments are handed to the layout rather than derived from the
+    /// descriptors' phases, so a grouping the user chose in Settings changes what
+    /// the balancer balances. With no chosen grouping the resolved segments *are*
+    /// the phase grouping, so the untouched Overview plans exactly as before.
     private func balancedWaterfall(
         descriptors: [PageModuleDescriptor],
         context: OverviewModuleContext
     ) -> some View {
-        ColumnMasonryLayout(
+        let visible = layoutModel.visibleDescriptors(for: page, descriptors: descriptors)
+        let groups = layoutModel
+            .resolvedSegments(for: page, descriptors: descriptors)
+            .map { $0.map(\.rawValue) }
+        return ColumnMasonryLayout(
             columns: 2,
             spacing: density.interSectionSpacing,
+            groups: groups,
             session: masonrySession
         ) {
-            ForEach(descriptors) { descriptor in
+            ForEach(visible) { descriptor in
                 card(for: descriptor, context: context)
                     .measuredPageModule(descriptor.id, page: page, model: layoutModel)
                     .overviewMasonryItem(id: descriptor.id.rawValue, phase: descriptor.masonryPhase)
             }
+        }
+        // The session lock exists so refreshes cannot reshuffle the dashboard
+        // under the user. Re-grouping the page is not a refresh — it is the user
+        // asking for a different arrangement — so the lock is released for one
+        // pass and the planner answers the new question.
+        .onChange(of: groups) { _, _ in
+            masonrySession.columnsByID = [:]
         }
     }
 

--- a/Sources/VibeBarCore/Models/PageLayoutConfig.swift
+++ b/Sources/VibeBarCore/Models/PageLayoutConfig.swift
@@ -182,42 +182,48 @@ public struct PageLayoutConfig: Hashable, Sendable {
     }
 }
 
-/// A page's cards as they will be drawn: one or more bands, each a two-column
-/// arrangement of its own, stacked in reading order.
+/// A page's cards as they will be drawn: an ordered list of segments, each a
+/// two-column arrangement of its own.
 ///
-/// Every mode produces one of these. `auto` and `manual` produce exactly one
-/// band, so they render through the same path as a segmented `compact` page and
-/// cannot drift from it — one band is, by construction, the single `HStack` the
-/// pages have always been.
+/// The segments are **not** drawn as bands. `flattened` concatenates them into
+/// the two columns the page actually renders, so segment *k*'s cards sit above
+/// segment *k+1*'s inside each column and the two columns never wait for each
+/// other at a boundary. Keeping the per-segment structure here anyway is what
+/// lets the editor show the grouping, and what lets the packer be handed one
+/// segment at a time.
+///
+/// Every mode produces one of these. `auto` and `manual` produce exactly the
+/// same shape as `compact`, so all three render through one path.
 public struct PageLayoutArrangement: Hashable, Sendable {
-    /// Never empty: a page with nothing to draw is one empty band, so callers
-    /// can read `ratio` and the first band without unwrapping.
+    /// Never empty: a page with nothing to draw is one empty segment, so callers
+    /// can read `ratio` and the first segment without unwrapping.
     public var segments: [PageLayoutConfig]
 
     public init(segments: [PageLayoutConfig]) {
         self.segments = segments.isEmpty ? [PageLayoutConfig()] : segments
     }
 
-    /// One band — every mode but `compact`.
+    /// One segment — a page with no chosen grouping.
     public init(_ config: PageLayoutConfig) {
         self.init(segments: [config])
     }
 
     /// Width split the whole page renders at. There is one ratio per page, not
-    /// one per band: a band boundary is a horizontal cut, and cutting the
-    /// columns at different widths per band would read as two different pages.
+    /// one per segment: the columns run the full height of the page, and a
+    /// segment boundary does not cut them.
     public var ratio: PageColumnRatio { segments[0].ratio }
 
-    /// Band membership in reading order — what the editor persists and what a
-    /// preset captures. Order *within* a band is the packer's answer, not
-    /// intent, so it is not what gets stored.
+    /// Segment membership in reading order — what the editor persists and what a
+    /// preset captures. Order *within* a segment is the arranging mode's answer,
+    /// not intent, so it is not what gets stored.
     public var moduleSegments: [[PageLayoutModuleID]] { segments.map(\.moduleIDs) }
 
-    /// The whole arrangement as one two-column config: every band's left column
-    /// stacked, then every band's right column.
+    /// The whole arrangement as the two columns the page renders: every
+    /// segment's left column concatenated, then every segment's right column.
     ///
-    /// The shape the page-wide controls work in — the drag editor, the ratio
-    /// buttons, the preset snapshot — none of which are per band.
+    /// This is the rendered truth, not a convenience view of it — the renderer
+    /// draws exactly this — and it is also the shape the page-wide controls work
+    /// in: the drag editor, the ratio buttons, the preset snapshot.
     public var flattened: PageLayoutConfig {
         guard segments.count > 1 else { return segments[0] }
         var columns = [[PageLayoutModuleID]](repeating: [], count: PageLayoutConfig.columnCount)
@@ -254,7 +260,7 @@ public struct StoredPageLayout: Hashable, Sendable {
     public var ratio: PageColumnRatio
     public private(set) var columns: [[PageLayoutModuleID]]
 
-    /// Ordered bands `compact` packs one at a time, normalized by
+    /// Ordered groups every mode arranges within, normalized by
     /// `PageLayoutSegments`. Empty means "no chosen segmentation": the page
     /// falls back to the default for its family, which is what every page did
     /// before segments existed.
@@ -264,32 +270,90 @@ public struct StoredPageLayout: Hashable, Sendable {
     /// into the last one, which would destroy this.
     public private(set) var segments: [[PageLayoutModuleID]]
 
+    /// Modules the user switched off on this page.
+    ///
+    /// A hidden module is treated exactly like one the page cannot draw right
+    /// now: it is filtered out of `available` before anything is arranged, so
+    /// `PageLayoutResolver` and `PageLayoutSegments` preserve its saved column
+    /// and segment for free, and un-hiding puts it back where it was rather than
+    /// appending it as a newcomer. That reuse is the whole reason visibility is
+    /// modelled as a subtraction from availability instead of as a fourth column.
+    ///
+    /// Identifiers this build does not recognize are preserved, for the same
+    /// reason `segments` preserves them: a downgrade must not silently un-hide a
+    /// card the newer build let the user switch off.
+    public private(set) var hidden: [PageLayoutModuleID]
+
     /// - Parameter mode: `nil` derives the mode from the columns — an entry
     ///   that carries an arrangement is a `manual` one, an entry that carries
     ///   none is `auto`. That is the same rule the decoder applies to an entry
     ///   written before modes existed, kept in one place so the two cannot
-    ///   drift apart. Bands deliberately do not take part: a page can carry a
-    ///   segmentation and still be drawing itself automatically.
+    ///   drift apart. Segments and hidden modules deliberately do not take part:
+    ///   a page can carry a segmentation, or a switched-off card, and still be
+    ///   drawing itself automatically.
     public init(
         mode: PageLayoutMode? = nil,
         ratio: PageColumnRatio = .equal,
         columns: [[PageLayoutModuleID]] = [],
-        segments: [[PageLayoutModuleID]] = []
+        segments: [[PageLayoutModuleID]] = [],
+        hidden: [PageLayoutModuleID] = []
     ) {
         let normalized = PageLayoutConfig(ratio: ratio, columns: columns)
         self.mode = mode ?? (normalized.isEmpty ? .auto : .manual)
         self.ratio = normalized.ratio
         self.columns = normalized.columns
         self.segments = PageLayoutSegments.normalized(segments)
+        self.hidden = Self.normalizedHidden(hidden)
     }
 
     /// The intent half of a live config; measured heights are dropped.
     public init(
         _ config: PageLayoutConfig,
         mode: PageLayoutMode? = nil,
-        segments: [[PageLayoutModuleID]] = []
+        segments: [[PageLayoutModuleID]] = [],
+        hidden: [PageLayoutModuleID] = []
     ) {
-        self.init(mode: mode, ratio: config.ratio, columns: config.columns, segments: segments)
+        self.init(
+            mode: mode,
+            ratio: config.ratio,
+            columns: config.columns,
+            segments: segments,
+            hidden: hidden
+        )
+    }
+
+    /// Deduplicated, order-preserving, empty identifiers dropped — the same
+    /// treatment `PageLayoutConfig` gives a column.
+    static func normalizedHidden(_ hidden: [PageLayoutModuleID]) -> [PageLayoutModuleID] {
+        var seen = Set<PageLayoutModuleID>()
+        return hidden.filter { !$0.rawValue.isEmpty && seen.insert($0).inserted }
+    }
+
+    /// True when this page should not draw `moduleID` at all.
+    public func isHidden(_ moduleID: PageLayoutModuleID) -> Bool {
+        hidden.contains(moduleID)
+    }
+
+    /// The same entry with `moduleID` switched on or off. Everything else —
+    /// mode, ratio, columns, segments — rides through untouched, because
+    /// switching a card off is not an arrangement edit.
+    public func settingHidden(_ moduleID: PageLayoutModuleID, _ isHidden: Bool) -> StoredPageLayout {
+        guard !moduleID.rawValue.isEmpty else { return self }
+        var next = hidden
+        if isHidden {
+            guard !next.contains(moduleID) else { return self }
+            next.append(moduleID)
+        } else {
+            guard next.contains(moduleID) else { return self }
+            next.removeAll { $0 == moduleID }
+        }
+        return StoredPageLayout(
+            mode: mode,
+            ratio: ratio,
+            columns: columns,
+            segments: segments,
+            hidden: next
+        )
     }
 
     /// Back to the canonical model, with this page's measurements folded in.
@@ -324,10 +388,17 @@ public struct StoredPageLayout: Hashable, Sendable {
     /// the page was computed are reconciled as usual.
     public func restoredAsManual() -> StoredPageLayout? {
         guard !isEmpty else { return nil }
-        // The bands ride along for the same reason the columns do on the way
+        // The segments ride along for the same reason the columns do on the way
         // out: a round trip through Manual must not be a silent reset of the
-        // segmentation the user chose for Compact.
-        return StoredPageLayout(mode: .manual, ratio: ratio, columns: columns, segments: segments)
+        // segmentation the user chose — and even less of the cards they switched
+        // off, which are not an arrangement at all.
+        return StoredPageLayout(
+            mode: .manual,
+            ratio: ratio,
+            columns: columns,
+            segments: segments,
+            hidden: hidden
+        )
     }
 }
 
@@ -337,6 +408,7 @@ extension StoredPageLayout: Codable {
         case ratio
         case columns
         case segments
+        case hidden
     }
 
     /// Field-by-field tolerant, like `PageLayoutConfig`'s own decoder: a page
@@ -364,19 +436,24 @@ extension StoredPageLayout: Codable {
         // malformed one is a file somebody edited by hand: both mean "no chosen
         // segmentation", which is the page's default banding, not an empty page.
         let segments = (try? container.decode([[PageLayoutModuleID]].self, forKey: .segments)) ?? []
-        self.init(mode: mode, ratio: ratio, columns: columns, segments: segments)
+        // Same rule again: an entry written before per-module visibility existed
+        // has nothing switched off, and neither does one somebody mangled by
+        // hand. "Show everything" is the safe reading of both — a card the user
+        // can see and switch off again beats one that vanished.
+        let hidden = (try? container.decode([PageLayoutModuleID].self, forKey: .hidden)) ?? []
+        self.init(mode: mode, ratio: ratio, columns: columns, segments: segments, hidden: hidden)
     }
 }
 
 /// One saved arrangement the user named, so a layout worth keeping can be put
 /// back later without re-dragging it.
 ///
-/// Stores a whole `StoredPageLayout` — mode, ratio, columns and bands — so a
-/// preset records what it was captured from, and applying one restores that
-/// mode. A `manual` preset puts its exact columns back; a `compact` preset puts
-/// its bands back and lets the packer re-derive the columns inside them, because
-/// on a packed page the segmentation is the arrangement worth keeping and one
-/// particular packing of it is not.
+/// Stores a whole `StoredPageLayout` — mode, ratio, columns, segments and the
+/// cards switched off — so a preset records what it was captured from, and
+/// applying one restores that mode. A `manual` preset puts its exact columns
+/// back; a `compact` preset puts its segments back and lets the packer re-derive
+/// the columns inside them, because on a packed page the segmentation is the
+/// arrangement worth keeping and one particular packing of it is not.
 public struct StoredPageLayoutPreset: Hashable, Sendable {
     /// Long enough for "Wide left, cost on the right", short enough that a
     /// pasted paragraph cannot bloat `settings.json`.
@@ -414,7 +491,15 @@ public struct StoredPageLayoutPreset: Hashable, Sendable {
         guard layout.mode == .compact, !layout.isEmpty, layout.segments.isEmpty else {
             return layout
         }
-        return StoredPageLayout(mode: .manual, ratio: layout.ratio, columns: layout.columns)
+        return StoredPageLayout(
+            mode: .manual,
+            ratio: layout.ratio,
+            columns: layout.columns,
+            // Only the *mode* is being reinterpreted here. What the user
+            // switched off is not part of that legacy ambiguity, so it applies
+            // exactly as captured.
+            hidden: layout.hidden
+        )
     }
 
     /// Case-insensitive identity. Two presets whose names differ only by case

--- a/Sources/VibeBarCore/Services/OverviewMasonryPlanner.swift
+++ b/Sources/VibeBarCore/Services/OverviewMasonryPlanner.swift
@@ -8,6 +8,13 @@ import Foundation
 /// cards finally fill the shorter column. Keeping this policy in Core makes the
 /// behavior deterministic and testable while SwiftUI remains responsible only
 /// for live height measurement.
+///
+/// The *grouping* those phases run inside is an input rather than a constant:
+/// the page's resolved `PageLayoutSegments` decide which cards are planned
+/// together and in what order, so `auto` obeys a segmentation the user chose
+/// exactly the way `compact` does. Passing no grouping means "group by phase",
+/// which is the Overview's default segmentation and therefore the behaviour this
+/// planner has always had.
 public enum OverviewMasonryPlanner {
     public enum Phase: Int, Sendable, Comparable {
         /// The Overview's header band: cards pinned to one shared height that
@@ -56,8 +63,15 @@ public enum OverviewMasonryPlanner {
         }
     }
 
+    /// - Parameter groups: ordered groups the cards are planned in — the page's
+    ///   resolved segments. Every group is planned from the column heights the
+    ///   one before it finished at, so a later group's cards flow up into
+    ///   whichever column is shorter; the two columns are never aligned at a
+    ///   group boundary. Empty means "group by phase", which reproduces the
+    ///   Overview's default segmentation.
     public static func plan(
         items: [Item],
+        groups: [[String]] = [],
         columns: Int = 2,
         spacing: Double
     ) -> Plan {
@@ -66,12 +80,38 @@ public enum OverviewMasonryPlanner {
             return greedyPlan(items: items, columns: columnCount, spacing: spacing)
         }
 
-        let summaries = items.filter { $0.phase == .summary }
-        let quotas = items.filter { $0.phase == .quota }
-        let costs = items.filter { $0.phase == .cost }
-        let auxiliary = items.filter { $0.phase == .auxiliary }
         var positions: [String: Position] = [:]
         var heights = Array(repeating: 0.0, count: columnCount)
+        for group in grouped(items, by: groups) {
+            plan(
+                group: group,
+                columnCount: columnCount,
+                spacing: spacing,
+                heights: &heights,
+                positions: &positions
+            )
+        }
+        return Plan(positions: positions, columnHeights: heights)
+    }
+
+    /// One group's cards, placed from the column heights already accumulated.
+    ///
+    /// The phases keep their own strategies *inside* the group, and run in phase
+    /// order: with the default phase grouping every group holds exactly one
+    /// phase, so this is byte-for-byte the placement policy the Overview has
+    /// always used. A user-chosen segmentation only decides which cards share a
+    /// group and which group comes first.
+    private static func plan(
+        group: [Item],
+        columnCount: Int,
+        spacing: Double,
+        heights: inout [Double],
+        positions: inout [String: Position]
+    ) {
+        let summaries = group.filter { $0.phase == .summary }
+        let quotas = group.filter { $0.phase == .quota }
+        let costs = group.filter { $0.phase == .cost }
+        let auxiliary = group.filter { $0.phase == .auxiliary }
 
         // The summary band is a row, not a balanced pair: its cards carry one
         // pinned height, so declaration order decides which side each takes and
@@ -112,17 +152,17 @@ public enum OverviewMasonryPlanner {
             let column = shortestColumn(heights)
             append(item, to: column, spacing: spacing, heights: &heights, positions: &positions)
         }
-        return Plan(positions: positions, columnHeights: heights)
     }
 
     /// Rebuild positions from a previously chosen column assignment while
     /// honoring each item's current height. Interactive card expansion can
     /// therefore push later cards down within the same column without making
     /// any card jump to the other side. Declaration order remains the vertical
-    /// order within each phase.
+    /// order within each phase of each group.
     public static func plan(
         items: [Item],
         fixedColumns: [String: Int],
+        groups: [[String]] = [],
         columns: Int = 2,
         spacing: Double
     ) -> Plan {
@@ -130,20 +170,45 @@ public enum OverviewMasonryPlanner {
         var positions: [String: Position] = [:]
         var heights = Array(repeating: 0.0, count: columnCount)
 
-        for phase in [Phase.summary, .quota, .cost, .auxiliary] {
-            for item in items where item.phase == phase {
-                let preferred = fixedColumns[item.id] ?? shortestColumn(heights)
-                let column = min(max(0, preferred), columnCount - 1)
-                append(
-                    item,
-                    to: column,
-                    spacing: spacing,
-                    heights: &heights,
-                    positions: &positions
-                )
+        for group in grouped(items, by: groups) {
+            for phase in [Phase.summary, .quota, .cost, .auxiliary] {
+                for item in group where item.phase == phase {
+                    let preferred = fixedColumns[item.id] ?? shortestColumn(heights)
+                    let column = min(max(0, preferred), columnCount - 1)
+                    append(
+                        item,
+                        to: column,
+                        spacing: spacing,
+                        heights: &heights,
+                        positions: &positions
+                    )
+                }
             }
         }
         return Plan(positions: positions, columnHeights: heights)
+    }
+
+    /// The items split into the groups they are planned in, in group order.
+    ///
+    /// An item no group claims joins the last one, for the same reason
+    /// `PageLayoutSegments.resolve` clamps a newcomer into range: visible at the
+    /// end beats silently unplaced. No grouping at all means one group per
+    /// phase, in phase order.
+    private static func grouped(_ items: [Item], by groups: [[String]]) -> [[Item]] {
+        guard !groups.isEmpty else {
+            return [Phase.summary, .quota, .cost, .auxiliary]
+                .map { phase in items.filter { $0.phase == phase } }
+                .filter { !$0.isEmpty }
+        }
+        var rank: [String: Int] = [:]
+        for (index, group) in groups.enumerated() {
+            for id in group where rank[id] == nil { rank[id] = index }
+        }
+        var result = [[Item]](repeating: [], count: groups.count)
+        for item in items {
+            result[min(rank[item.id] ?? groups.count - 1, groups.count - 1)].append(item)
+        }
+        return result.filter { !$0.isEmpty }
     }
 
     private static func bestQuotaOrder(_ items: [Item], spacing: Double) -> [Item] {

--- a/Sources/VibeBarCore/Services/PageLayoutPacker.swift
+++ b/Sources/VibeBarCore/Services/PageLayoutPacker.swift
@@ -37,11 +37,33 @@ public enum PageLayoutPacker {
         }
     }
 
+    /// What a column already carries when a packing starts.
+    ///
+    /// Segments are packed as a relay rather than as isolated bands: the first
+    /// segment's answer becomes the second's starting point, so the second
+    /// segment's cards flow up into whichever column the first one left short.
+    /// `isOccupied` is separate from `height` because a column can be non-empty
+    /// and still measure zero (a card the page has never rendered), and it is
+    /// occupancy — not height — that decides whether the next card pays a gap.
+    public struct ColumnSeed: Hashable, Sendable {
+        public let height: Double
+        public let isOccupied: Bool
+
+        public init(height: Double, isOccupied: Bool) {
+            self.height = height.isFinite ? max(0, height) : 0
+            self.isOccupied = isOccupied
+        }
+
+        public static let empty = ColumnSeed(height: 0, isOccupied: false)
+    }
+
     /// A chosen partition, with the column heights it implies.
     public struct Packing: Hashable, Sendable {
         /// Exactly `PageLayoutConfig.columnCount` columns. Within each column
         /// the cards keep the relative order they arrived in.
         public let columns: [[PageLayoutModuleID]]
+        /// Each column's height *after* this packing, seeds included — so on a
+        /// segmented page the last segment's `pageHeight` is the whole page's.
         public let columnHeights: [Double]
         /// False when the module count forced the greedy fallback, i.e. the
         /// result is a good partition rather than a provably optimal one.
@@ -82,31 +104,43 @@ public enum PageLayoutPacker {
     ///     exist — the heights are what they are — but breaks ties in favour
     ///     of putting the heavier stack under the wider column, which is where
     ///     those cards will render shortest next time they are measured.
+    ///   - seeds: what each column already carries. Empty on an unsegmented
+    ///     page; on a segmented one it is the previous segment's answer, and
+    ///     every score term — the page height it minimizes as well as the
+    ///     tie-breaks — is computed on the resulting *totals*, because the
+    ///     page's height is what the columns measure at the bottom, not what
+    ///     this one segment contributed.
     public static func pack(
         items: [Item],
         spacing: Double,
-        ratio: PageColumnRatio = .equal
+        ratio: PageColumnRatio = .equal,
+        seeds: [ColumnSeed] = []
     ) -> Packing {
         let unique = deduplicated(items)
         let gap = spacing.isFinite ? max(0, spacing) : 0
+        let seeded = normalized(seeds)
         guard !unique.isEmpty else {
+            // A segment with nothing in it must hand the relay on untouched,
+            // not reset the columns to zero.
             return Packing(
                 columns: [[PageLayoutModuleID]](repeating: [], count: PageLayoutConfig.columnCount),
-                columnHeights: [Double](repeating: 0, count: PageLayoutConfig.columnCount),
+                columnHeights: seeded.map(\.height),
                 isExact: true
             )
         }
 
         let isExact = unique.count <= exactSearchLimit
         let assignment = isExact
-            ? exactAssignment(unique, spacing: gap, ratio: ratio)
-            : greedyAssignment(unique, spacing: gap, ratio: ratio)
+            ? exactAssignment(unique, spacing: gap, ratio: ratio, seeds: seeded)
+            : greedyAssignment(unique, spacing: gap, ratio: ratio, seeds: seeded)
 
         var columns = [[PageLayoutModuleID]](repeating: [], count: PageLayoutConfig.columnCount)
-        var heights = [Double](repeating: 0, count: PageLayoutConfig.columnCount)
+        var heights = seeded.map(\.height)
+        var counts = seeded.map { $0.isOccupied ? 1 : 0 }
         for (index, item) in unique.enumerated() {
             let column = min(max(0, assignment[index]), PageLayoutConfig.columnCount - 1)
-            heights[column] = appended(heights[column], columns[column].count, item.height, spacing: gap)
+            heights[column] = appended(heights[column], counts[column], item.height, spacing: gap)
+            counts[column] += 1
             columns[column].append(item.id)
         }
         return Packing(columns: columns, columnHeights: heights, isExact: isExact)
@@ -129,29 +163,47 @@ public enum PageLayoutPacker {
 
     // MARK: - Segments
 
-    /// Pack each band on its own, in order.
+    /// Pack the segments as a relay: each one starts from the column heights the
+    /// one before it finished at.
     ///
-    /// A band is packed exactly the way a whole page is — its two columns are
-    /// still balanced for height — but nothing crosses a band boundary, so the
-    /// grouping the user chose survives the packing. See `PageLayoutSegments`
-    /// for why that grouping exists.
+    /// A segment is an ordering constraint, not a horizontal cut. Every card in
+    /// segment *k* renders above every card in segment *k+1* **within its own
+    /// column**, and the two columns are never made to line up at the boundary —
+    /// so a segment whose cards all landed on one side leaves the other side
+    /// short, and the next segment's cards flow straight up into it. Packing the
+    /// segments independently instead left that gap on screen as a hole, which
+    /// is the bug this relay exists to fix.
     ///
-    /// Identifiers are deduplicated across bands as well as within one, keeping
-    /// the first occurrence, so a hand-edited file cannot render one card twice.
+    /// Identifiers are deduplicated across segments as well as within one,
+    /// keeping the first occurrence, so a hand-edited file cannot render one
+    /// card twice.
     public static func pack(
         segments: [[Item]],
         spacing: Double,
         ratio: PageColumnRatio = .equal
     ) -> [Packing] {
         var seen = Set<PageLayoutModuleID>()
-        return segments.map { segment in
+        var seeds = [ColumnSeed](repeating: .empty, count: PageLayoutConfig.columnCount)
+        var result: [Packing] = []
+        result.reserveCapacity(segments.count)
+        for segment in segments {
             let unique = segment.filter { !$0.id.rawValue.isEmpty && seen.insert($0.id).inserted }
-            return pack(items: unique, spacing: spacing, ratio: ratio)
+            let packing = pack(items: unique, spacing: spacing, ratio: ratio, seeds: seeds)
+            seeds = (0..<PageLayoutConfig.columnCount).map { index in
+                ColumnSeed(
+                    height: packing.columnHeights[index],
+                    // Occupancy is cumulative: a column filled by segment 0 and
+                    // skipped by segment 1 still owes a gap to segment 2.
+                    isOccupied: seeds[index].isOccupied || !packing.columns[index].isEmpty
+                )
+            }
+            result.append(packing)
         }
+        return result
     }
 
-    /// `pack(segments:spacing:ratio:)` as the per-band columns the renderer
-    /// draws.
+    /// `pack(segments:spacing:ratio:)` as the per-segment columns the renderer
+    /// concatenates.
     public static func packedSegmentColumns(
         segments: [[Item]],
         spacing: Double,
@@ -192,26 +244,37 @@ public enum PageLayoutPacker {
             .max() ?? 0
     }
 
-    /// What a *segmented* arrangement would measure: every band's taller column,
-    /// plus one inter-band gap between neighbours.
+    /// The two columns of a segmented arrangement as they actually flow:
+    /// segment 0's left column, then segment 1's, and so on, and the same for
+    /// the right.
+    ///
+    /// This is what the renderer draws. A segment boundary exists only inside a
+    /// column, which is why there is nothing here that lines the two sides up.
+    public static func flowColumns(
+        segments: [[[PageLayoutModuleID]]]
+    ) -> [[PageLayoutModuleID]] {
+        var columns = [[PageLayoutModuleID]](repeating: [], count: PageLayoutConfig.columnCount)
+        for segment in segments {
+            for index in columns.indices where segment.indices.contains(index) {
+                columns[index].append(contentsOf: segment[index])
+            }
+        }
+        return columns
+    }
+
+    /// What a *segmented* arrangement would measure: the taller of the two
+    /// columns once every segment has flowed into them.
     ///
     /// The number `compact`'s re-pack hysteresis has to compare once a page has
-    /// bands. Comparing one band's height against a whole page's would let a
-    /// segmented page grow without ever being re-packed.
+    /// segments. It used to sum each band's taller column plus an inter-band
+    /// gap, which is what a page of rigid horizontal bands measured; the
+    /// segments flow now, so the page is exactly as tall as its taller column.
     public static func pageHeight(
         segments: [[[PageLayoutModuleID]]],
         heights: [PageLayoutModuleID: Double],
         spacing: Double
     ) -> Double {
-        let gap = spacing.isFinite ? max(0, spacing) : 0
-        var total = 0.0
-        var count = 0
-        for segment in segments {
-            let height = pageHeight(columns: segment, heights: heights, spacing: gap)
-            total = appended(total, count, height, spacing: gap)
-            count += 1
-        }
-        return total
+        pageHeight(columns: flowColumns(segments: segments), heights: heights, spacing: spacing)
     }
 
     // MARK: - Exact search
@@ -227,10 +290,14 @@ public enum PageLayoutPacker {
     ///
     /// Both prune on strict `>` so subtrees that could *tie* the best score are
     /// still explored — the tie-breaks below decide those, not the traversal.
+    ///
+    /// The seeds only move where the search starts: both bounds stay valid
+    /// because a seeded column, like an empty one, can only grow.
     private static func exactAssignment(
         _ items: [Item],
         spacing: Double,
-        ratio: PageColumnRatio
+        ratio: PageColumnRatio,
+        seeds: [ColumnSeed]
     ) -> [Int] {
         let count = items.count
         var remaining = [Double](repeating: 0, count: count + 1)
@@ -292,7 +359,14 @@ public enum PageLayoutPacker {
             )
         }
 
-        visit(0, 0, 0, 0, 0, 0)
+        visit(
+            0,
+            seeds[0].height,
+            seeds[0].isOccupied ? 1 : 0,
+            seeds[1].height,
+            seeds[1].isOccupied ? 1 : 0,
+            0
+        )
         return best
     }
 
@@ -304,7 +378,8 @@ public enum PageLayoutPacker {
     private static func greedyAssignment(
         _ items: [Item],
         spacing: Double,
-        ratio: PageColumnRatio
+        ratio: PageColumnRatio,
+        seeds: [ColumnSeed]
     ) -> [Int] {
         let tallestFirst = items.indices.sorted { lhs, rhs in
             items[lhs].height == items[rhs].height
@@ -312,8 +387,8 @@ public enum PageLayoutPacker {
                 : items[lhs].height > items[rhs].height
         }
         var assignment = [Int](repeating: 0, count: items.count)
-        var heights = [Double](repeating: 0, count: PageLayoutConfig.columnCount)
-        var counts = [Int](repeating: 0, count: PageLayoutConfig.columnCount)
+        var heights = seeds.map(\.height)
+        var counts = seeds.map { $0.isOccupied ? 1 : 0 }
         let preferred = widerColumn(ratio)
         for index in tallestFirst {
             let height = items[index].height
@@ -364,6 +439,14 @@ public enum PageLayoutPacker {
         spacing: Double
     ) -> Double {
         count == 0 ? height : current + spacing + height
+    }
+
+    /// Exactly `PageLayoutConfig.columnCount` seeds, so the search can index
+    /// them without checking.
+    private static func normalized(_ seeds: [ColumnSeed]) -> [ColumnSeed] {
+        (0..<PageLayoutConfig.columnCount).map { index in
+            seeds.indices.contains(index) ? seeds[index] : .empty
+        }
     }
 
     private static func deduplicated(_ items: [Item]) -> [Item] {

--- a/Sources/VibeBarCore/Services/PageLayoutSegments.swift
+++ b/Sources/VibeBarCore/Services/PageLayoutSegments.swift
@@ -1,23 +1,33 @@
 import Foundation
 
-/// Ordered bands a page's cards are packed into, one band at a time.
+/// Ordered groups a page's cards flow through, in every mode.
 ///
 /// `PageLayoutMode.compact` asks `PageLayoutPacker` for the shortest two-column
 /// arrangement of a whole page, and the shortest page is free to slot an
 /// analytics card between two quota cards. That is exactly what a user who
 /// wants "my quotas together, packed as tight as they go, everything else
 /// below" does not want. Segments put that grouping back under the user's
-/// control without giving up the packing: inside a band the packer is still
-/// free, across bands the reading order is fixed.
+/// control without giving up the packing: inside a segment the packer is still
+/// free, across segments the reading order is fixed.
+///
+/// A segment is a **vertical ordering constraint, not a horizontal band**: every
+/// card in segment *k* renders above every card in segment *k+1* within its own
+/// column, and the two columns are never made to line up at the boundary. That
+/// distinction is the whole feature — bands used to make the shorter column wait
+/// for the taller one, which drew a visible hole at every boundary.
+///
+/// All three modes obey the ordering: `compact` packs the segments as a relay,
+/// `auto` plans them in order, and `manual` stable-sorts its saved columns by
+/// segment index.
 ///
 /// Segments live *beside* `PageLayoutConfig.columns`, never inside it:
 /// `PageLayoutConfig.normalized` folds every column past the second into the
 /// last one and dedupes globally, which would flatten any structure stored
 /// there into two flat columns.
 public enum PageLayoutSegments {
-    /// Most bands one page may hold. A band the user cannot tell apart from its
-    /// neighbour is worse than no band, and the cap also keeps a hand-edited
-    /// settings file from asking the editor to draw fifty headers.
+    /// Most segments one page may hold. A segment the user cannot tell apart
+    /// from its neighbour is worse than no segment, and the cap also keeps a
+    /// hand-edited settings file from asking the editor to draw fifty headers.
     public static let maximumCount = 6
 
     /// One module as the segmenter sees it: an identity plus the family it
@@ -32,14 +42,14 @@ public enum PageLayoutSegments {
         }
     }
 
-    /// Phases that share a band in the Overview's default segmentation: the
+    /// Phases that share a segment in the Overview's default segmentation: the
     /// pinned summary header, then the quota cards packed among themselves,
     /// then cost together with the analytics derived from it.
     ///
     /// This is the answer to the complaint segments exist for — a user who
     /// picks Compact on the Overview gets a minimal-height quota block without
     /// having to arrange anything.
-    static let overviewBands: [[OverviewMasonryPlanner.Phase]] = [
+    static let overviewPhaseGroups: [[OverviewMasonryPlanner.Phase]] = [
         [.summary],
         [.quota],
         [.cost, .auxiliary]
@@ -47,59 +57,59 @@ public enum PageLayoutSegments {
 
     /// Segmentation a page gets when the user has not chosen one.
     ///
-    /// Provider pages are a single band: `compact` there keeps meaning exactly
-    /// what it always meant, one packing of the whole page.
+    /// Provider pages are a single segment: every mode there keeps meaning
+    /// exactly what it always meant, one arrangement of the whole page.
     public static func defaultSegments(
         modules: [Module],
         page: PageLayoutPageID
     ) -> [[PageLayoutModuleID]] {
         guard page.isOverview else { return normalized([modules.map(\.id)]) }
         return normalized(
-            overviewBands.map { band in
-                modules.filter { band.contains($0.phase) }.map(\.id)
+            overviewPhaseGroups.map { group in
+                modules.filter { group.contains($0.phase) }.map(\.id)
             }
         )
     }
 
-    /// Drops empty identifiers and empty bands, collapses an identifier that
-    /// appears in more than one band onto its first occurrence, and folds bands
-    /// past `maximumCount` into the last one.
+    /// Drops empty identifiers and empty segments, collapses an identifier that
+    /// appears in more than one segment onto its first occurrence, and folds
+    /// segments past `maximumCount` into the last one.
     ///
     /// Identifiers this build does not recognize are preserved verbatim, for the
-    /// same reason `PageLayoutModuleID` is a string wrapper: a band written by a
-    /// newer build has to survive a downgrade's round trip rather than being
-    /// quietly dropped from the user's arrangement.
+    /// same reason `PageLayoutModuleID` is a string wrapper: a segment written
+    /// by a newer build has to survive a downgrade's round trip rather than
+    /// being quietly dropped from the user's arrangement.
     public static func normalized(_ segments: [[PageLayoutModuleID]]) -> [[PageLayoutModuleID]] {
         var result: [[PageLayoutModuleID]] = []
         var seen = Set<PageLayoutModuleID>()
         for segment in segments {
-            var band: [PageLayoutModuleID] = []
+            var group: [PageLayoutModuleID] = []
             for moduleID in segment where !moduleID.rawValue.isEmpty {
                 guard seen.insert(moduleID).inserted else { continue }
-                band.append(moduleID)
+                group.append(moduleID)
             }
-            guard !band.isEmpty else { continue }
+            guard !group.isEmpty else { continue }
             if result.count < maximumCount {
-                result.append(band)
+                result.append(group)
             } else {
-                result[result.count - 1].append(contentsOf: band)
+                result[result.count - 1].append(contentsOf: group)
             }
         }
         return result
     }
 
-    /// Band membership to render right now: the saved bands reconciled against
-    /// the modules the page can actually draw this pass.
+    /// Segment membership to render right now: the saved segments reconciled
+    /// against the modules the page can actually draw this pass.
     ///
-    /// - Saved bands with no chosen segmentation (`stored` empty) fall back to
-    ///   `defaultSegments`, which is what every page did before segments
+    /// - Saved segments with no chosen segmentation (`stored` empty) fall back
+    ///   to `defaultSegments`, which is what every page did before segments
     ///   existed.
     /// - A saved module the page cannot draw is left out of the result. It stays
-    ///   in the *saved* bands — see `mergingEdit`.
-    /// - A module the saved bands have never seen joins the band its family
-    ///   defaults to, clamped into range: a page saved with fewer bands than the
-    ///   default has nowhere else to put it.
-    /// - A band whose cards have all gone is not drawn.
+    ///   in the *saved* segments — see `mergingEdit`.
+    /// - A module the saved segments have never seen joins the one its family
+    ///   defaults to, clamped into range: a page saved with fewer segments than
+    ///   the default has nowhere else to put it.
+    /// - A segment whose cards have all gone is not drawn.
     ///
     /// Every available module appears exactly once in the result.
     public static func resolve(
@@ -116,8 +126,8 @@ public enum PageLayoutSegments {
 
         let defaults = normalized(defaultSegments)
         var defaultIndex: [PageLayoutModuleID: Int] = [:]
-        for (index, band) in defaults.enumerated() {
-            for moduleID in band { defaultIndex[moduleID] = index }
+        for (index, group) in defaults.enumerated() {
+            for moduleID in group { defaultIndex[moduleID] = index }
         }
 
         let base = normalized(stored.isEmpty ? defaults : stored)
@@ -135,23 +145,68 @@ public enum PageLayoutSegments {
         return normalized(segments)
     }
 
-    /// Fold an edit made against the *resolved* bands back into the *saved*
+    /// Where each module sits in the segment order. A module no segment claims
+    /// ranks after every one that is claimed, so it sorts to the end rather than
+    /// jumping to the front.
+    public static func ordering(
+        _ segments: [[PageLayoutModuleID]]
+    ) -> [PageLayoutModuleID: Int] {
+        var result: [PageLayoutModuleID: Int] = [:]
+        for (index, segment) in segments.enumerated() {
+            for moduleID in segment where result[moduleID] == nil {
+                result[moduleID] = index
+            }
+        }
+        return result
+    }
+
+    /// Re-order hand-arranged columns so they obey the segmentation.
+    ///
+    /// This is what makes `manual` honour segments without taking the drag
+    /// editor away from it: the user still decides which column a card is in and
+    /// where among its own segment-mates it sits, and the segmentation decides
+    /// which block of the column that is. The sort is stable, so the relative
+    /// order the user dragged *within* a segment is preserved exactly.
+    public static func sortedColumns(
+        _ columns: [[PageLayoutModuleID]],
+        segments: [[PageLayoutModuleID]]
+    ) -> [[PageLayoutModuleID]] {
+        guard segments.count > 1 else { return columns }
+        let rank = ordering(segments)
+        let unsegmented = segments.count
+        return columns.map { column in
+            column.enumerated()
+                .sorted { lhs, rhs in
+                    let lhsRank = rank[lhs.element] ?? unsegmented
+                    let rhsRank = rank[rhs.element] ?? unsegmented
+                    return lhsRank == rhsRank ? lhs.offset < rhs.offset : lhsRank < rhsRank
+                }
+                .map(\.element)
+        }
+    }
+
+    /// Fold an edit made against the *resolved* segments back into the *saved*
     /// ones, without forgetting modules the page cannot draw right now.
     ///
     /// The same contract `PageLayoutResolver.mergingEdit` gives the columns, and
     /// for the same reason: the editor can only drag what is on screen, so
-    /// persisting its output verbatim would erase the band of every module that
-    /// happened to be missing — a quota group before the first refresh, the cost
-    /// cards before any session log is found — and moving one card would
-    /// silently reset the rest of the page.
+    /// persisting its output verbatim would erase the segment of every module
+    /// that happened to be missing — a quota group before the first refresh, the
+    /// cost cards before any session log is found, a card the user switched off
+    /// — and moving one card would silently reset the rest of the page.
     ///
-    /// A hidden module follows its surviving bandmates — the user dragged (or
-    /// left) the band, and the module belongs to it wherever it went. A band
-    /// whose every module is hidden has no bandmate to follow and is re-created
-    /// where it was saved, next to its nearest surviving stored neighbour:
-    /// clamping it into the last visible band instead would collapse the saved
-    /// grouping the first time the user dragged anything else, and the module
-    /// would come back in the wrong band. Only an explicit reset forgets a page.
+    /// An off-screen module follows its surviving segment-mates — the user
+    /// dragged (or left) the segment, and the module belongs to it wherever it
+    /// went. A segment whose every module is off screen has no mate to follow
+    /// and is re-created where it was saved, next to its nearest surviving
+    /// stored neighbour: clamping it into the last visible segment instead would
+    /// collapse the saved grouping the first time the user dragged anything
+    /// else, and the module would come back in the wrong place. Only an explicit
+    /// reset forgets a page.
+    ///
+    /// A module `edited` names explicitly is always honoured, available or not —
+    /// which is how the editor moves a switched-off card, the one off-screen
+    /// case it can actually see and drag.
     public static func mergingEdit(
         _ edited: [[PageLayoutModuleID]],
         into stored: [[PageLayoutModuleID]],
@@ -159,30 +214,30 @@ public enum PageLayoutSegments {
     ) -> [[PageLayoutModuleID]] {
         let availableSet = Set(available)
         var segments = normalized(edited)
-        let storedBands = normalized(stored)
-        guard !segments.isEmpty else { return storedBands }
+        let storedSegments = normalized(stored)
+        guard !segments.isEmpty else { return storedSegments }
 
         var editedIndex: [PageLayoutModuleID: Int] = [:]
-        for (index, band) in segments.enumerated() {
-            for moduleID in band { editedIndex[moduleID] = index }
+        for (index, group) in segments.enumerated() {
+            for moduleID in group { editedIndex[moduleID] = index }
         }
 
-        // Bands that lost every module to unavailability, queued for
-        // re-insertion after the band holding their nearest preceding stored
-        // anchor. The user may have reordered bands, so positions are not
+        // Segments that lost every module to unavailability, queued for
+        // re-insertion after the segment holding their nearest preceding stored
+        // anchor. The user may have reordered them, so positions are not
         // necessarily monotone in stored order — a stable sort by position
         // (stored order as the tie-break) makes the offset insertion exact.
-        var pending: [(position: Int, band: [PageLayoutModuleID])] = []
+        var pending: [(position: Int, orphans: [PageLayoutModuleID])] = []
         var lastAnchoredPosition = -1
-        for band in storedBands {
-            let hidden = band.filter { !availableSet.contains($0) && editedIndex[$0] == nil }
-            if let anchor = band.first(where: { editedIndex[$0] != nil }) {
+        for group in storedSegments {
+            let offScreen = group.filter { !availableSet.contains($0) && editedIndex[$0] == nil }
+            if let anchor = group.first(where: { editedIndex[$0] != nil }) {
                 let anchorIndex = editedIndex[anchor]!
                 lastAnchoredPosition = anchorIndex
-                guard !hidden.isEmpty else { continue }
-                segments[anchorIndex].append(contentsOf: hidden)
-            } else if !hidden.isEmpty {
-                pending.append((position: lastAnchoredPosition + 1, band: hidden))
+                guard !offScreen.isEmpty else { continue }
+                segments[anchorIndex].append(contentsOf: offScreen)
+            } else if !offScreen.isEmpty {
+                pending.append((position: lastAnchoredPosition + 1, orphans: offScreen))
             }
         }
         let ordered = pending.enumerated().sorted {
@@ -192,16 +247,16 @@ public enum PageLayoutSegments {
         for item in ordered {
             let position = min(item.element.position + insertedCount, segments.count)
             if segments.count < maximumCount {
-                segments.insert(item.element.band, at: position)
+                segments.insert(item.element.orphans, at: position)
                 insertedCount += 1
             } else {
-                // The editor offered "Add Segment" against the bands it could
-                // see, so the page can be at the cap before the hidden band is
-                // back. Folding here, into the hidden band's preceding
-                // neighbour, keeps the final `normalized` from collapsing a
-                // band the user just made — losing an invisible band's
-                // separateness costs less than losing a visible one's.
-                segments[max(0, position - 1)].append(contentsOf: item.element.band)
+                // The editor offered "Add Segment" against the segments it could
+                // see, so the page can be at the cap before the off-screen
+                // segment is back. Folding here, into its preceding neighbour,
+                // keeps the final `normalized` from collapsing a segment the
+                // user just made — losing an invisible segment's separateness
+                // costs less than losing a visible one's.
+                segments[max(0, position - 1)].append(contentsOf: item.element.orphans)
             }
         }
         return normalized(segments)

--- a/Tests/VibeBarCoreTests/OverviewMasonryPlannerTests.swift
+++ b/Tests/VibeBarCoreTests/OverviewMasonryPlannerTests.swift
@@ -139,6 +139,122 @@ final class OverviewMasonryPlannerTests: XCTestCase {
         }
     }
 
+    // MARK: - Grouping
+
+    func testPlanningWithNoGroupingIsExactlyGroupingByPhase() {
+        // The compatibility pin: `auto` gets its grouping from the page's
+        // resolved segments now, and an Overview with no chosen segmentation
+        // resolves to the phase grouping. The two must be the same plan, or
+        // shipping segments to `auto` would silently re-arrange every untouched
+        // Overview.
+        let items: [OverviewMasonryPlanner.Item] = [
+            .init(id: "s1", height: 178, phase: .summary),
+            .init(id: "s2", height: 178, phase: .summary),
+            .init(id: "q1", height: 300, phase: .quota),
+            .init(id: "q2", height: 280, phase: .quota),
+            .init(id: "q3", height: 120, phase: .quota),
+            .init(id: "q4", height: 100, phase: .quota),
+            .init(id: "c1", height: 320, phase: .cost),
+            .init(id: "c2", height: 210, phase: .cost),
+            .init(id: "a1", height: 80, phase: .auxiliary)
+        ]
+
+        XCTAssertEqual(
+            OverviewMasonryPlanner.plan(items: items, spacing: 12),
+            OverviewMasonryPlanner.plan(
+                items: items,
+                groups: [["s1", "s2"], ["q1", "q2", "q3", "q4"], ["c1", "c2"], ["a1"]],
+                spacing: 12
+            )
+        )
+    }
+
+    func testAChosenGroupingDecidesWhatIsBalancedTogether() throws {
+        let items: [OverviewMasonryPlanner.Item] = [
+            .init(id: "q1", height: 300, phase: .quota),
+            .init(id: "q2", height: 100, phase: .quota),
+            .init(id: "c1", height: 300, phase: .cost),
+            .init(id: "c2", height: 100, phase: .cost)
+        ]
+
+        // By phase: both quota cards are placed before either cost card, so q2
+        // balances against q1 and lands on the right.
+        let byPhase = OverviewMasonryPlanner.plan(items: items, spacing: 0)
+        XCTAssertEqual(try XCTUnwrap(byPhase.positions["q1"]).column, 0)
+        XCTAssertEqual(try XCTUnwrap(byPhase.positions["q2"]).column, 1)
+
+        // Grouped {q1, c1} then {q2, c2}: q2 is now planned after c1 took the
+        // right column, so it goes left instead. Same page height, different
+        // reading order — which is the point of letting the user group.
+        let grouped = OverviewMasonryPlanner.plan(
+            items: items,
+            groups: [["q1", "c1"], ["q2", "c2"]],
+            spacing: 0
+        )
+        XCTAssertEqual(try XCTUnwrap(grouped.positions["q1"]).column, 0)
+        XCTAssertEqual(try XCTUnwrap(grouped.positions["c1"]).column, 1)
+        XCTAssertEqual(try XCTUnwrap(grouped.positions["q2"]).column, 0)
+        XCTAssertEqual(try XCTUnwrap(grouped.positions["c2"]).column, 1)
+        XCTAssertEqual(grouped.columnHeights, [400, 400])
+    }
+
+    func testALaterGroupFlowsIntoTheColumnTheEarlierOneLeftShort() throws {
+        // The planner's half of the fix the packer got: a group starts from the
+        // column heights the one before it finished at, so its cards fill the
+        // short side instead of waiting for the tall one.
+        let plan = OverviewMasonryPlanner.plan(
+            items: [
+                .init(id: "tall", height: 400, phase: .quota),
+                .init(id: "short", height: 100, phase: .quota),
+                .init(id: "a", height: 50, phase: .auxiliary),
+                .init(id: "b", height: 50, phase: .auxiliary)
+            ],
+            groups: [["tall", "short"], ["a", "b"]],
+            spacing: 0
+        )
+
+        XCTAssertEqual(try XCTUnwrap(plan.positions["a"]).column, 1)
+        XCTAssertEqual(try XCTUnwrap(plan.positions["a"]).y, 100)
+        XCTAssertEqual(try XCTUnwrap(plan.positions["b"]).column, 1)
+        XCTAssertEqual(try XCTUnwrap(plan.positions["b"]).y, 150)
+        XCTAssertEqual(plan.columnHeights, [400, 200])
+    }
+
+    func testAnItemNoGroupClaimsJoinsTheLastGroup() throws {
+        // Same rule `PageLayoutSegments.resolve` clamps a newcomer by: visible
+        // at the end beats silently unplaced.
+        let plan = OverviewMasonryPlanner.plan(
+            items: [
+                .init(id: "known", height: 100, phase: .quota),
+                .init(id: "stranger", height: 100, phase: .quota)
+            ],
+            groups: [["known"]],
+            spacing: 0
+        )
+
+        XCTAssertNotNil(plan.positions["stranger"])
+        XCTAssertEqual(plan.columnHeights, [100, 100])
+    }
+
+    func testFixedColumnsFollowTheGroupOrderRatherThanThePhaseOrder() throws {
+        let items: [OverviewMasonryPlanner.Item] = [
+            .init(id: "quota", height: 100, phase: .quota),
+            .init(id: "cost", height: 200, phase: .cost)
+        ]
+
+        // Both pinned to the left column, and the grouping says cost reads
+        // first. Without the grouping the phase order would put quota on top.
+        let locked = OverviewMasonryPlanner.plan(
+            items: items,
+            fixedColumns: ["quota": 0, "cost": 0],
+            groups: [["cost"], ["quota"]],
+            spacing: 10
+        )
+
+        XCTAssertEqual(try XCTUnwrap(locked.positions["cost"]).y, 0)
+        XCTAssertEqual(try XCTUnwrap(locked.positions["quota"]).y, 210)
+    }
+
     func testALockedSessionKeepsTheSummaryBandWhereItWas() throws {
         let items: [OverviewMasonryPlanner.Item] = [
             .init(id: "summary-cost", height: 178, phase: .summary),

--- a/Tests/VibeBarCoreTests/PageLayoutPackerTests.swift
+++ b/Tests/VibeBarCoreTests/PageLayoutPackerTests.swift
@@ -392,10 +392,14 @@ final class PageLayoutPackerTests: XCTestCase {
 
     // MARK: - Segments
 
-    func testEachSegmentIsPackedOnItsOwn() {
-        // The point of segments: a card can only be balanced against the cards
-        // in its own band, so the tall one in band 0 cannot pull the small ones
-        // from band 1 up beside it.
+    func testALaterSegmentFlowsUpIntoTheColumnAnEarlierOneLeftShort() {
+        // The bug segments used to have, in one test. Segment 0 is lopsided:
+        // 400 pt on the left, 100 pt on the right. Packed as independent bands,
+        // segment 1 split its two cards one per column and both waited for the
+        // 400 pt column to finish — a 300 pt hole under `short`, and a page of
+        // 400 + 10 + 50 = 460 pt. As a relay, segment 1 starts from (400, 100)
+        // and puts *both* its cards in the short column, filling the hole and
+        // leaving the page exactly as tall as segment 0 already made it.
         let packed = PageLayoutPacker.pack(
             segments: [
                 items([("tall", 400), ("short", 100)]),
@@ -406,7 +410,46 @@ final class PageLayoutPackerTests: XCTestCase {
 
         XCTAssertEqual(packed.count, 2)
         XCTAssertEqual(packed[0].columns, [[module("tall")], [module("short")]])
-        XCTAssertEqual(packed[1].columns, [[module("a")], [module("b")]])
+        XCTAssertEqual(packed[0].columnHeights, [400, 100])
+        XCTAssertEqual(packed[1].columns, [[], [module("a"), module("b")]])
+        // Seeds included, so the last segment's heights are the page's.
+        XCTAssertEqual(packed[1].columnHeights, [400, 220])
+        XCTAssertEqual(packed[1].pageHeight, 400)
+        XCTAssertLessThan(packed[1].pageHeight, 460)
+
+        // Membership still never crosses a segment: that is the constraint the
+        // relay preserves while removing the gap.
+        XCTAssertEqual(
+            Set(packed[0].columns.flatMap { $0 }),
+            [module("tall"), module("short")]
+        )
+        XCTAssertEqual(Set(packed[1].columns.flatMap { $0 }), [module("a"), module("b")])
+    }
+
+    func testSegmentingCanStillCostHeightBecauseEarlierSegmentsChooseFirst() {
+        // The relay is greedy across segments, not globally optimal, so
+        // segmenting is still a trade — it just no longer pays for a gap.
+        // Free, {a,b} and {c} pair off into a 20 pt page. Segment 0 has only its
+        // own two cards to balance, splits them one each, and leaves segment 1's
+        // single 20 pt card nowhere better than a 30 pt column.
+        let first = items([("a", 10), ("b", 10)])
+        let second = items([("c", 20)])
+        let heights = Dictionary(
+            uniqueKeysWithValues: (first + second).map { ($0.id, $0.height) }
+        )
+
+        let free = PageLayoutPacker.pack(items: first + second, spacing: 0)
+        let relayed = PageLayoutPacker.pageHeight(
+            segments: PageLayoutPacker.packedSegmentColumns(
+                segments: [first, second],
+                spacing: 0
+            ),
+            heights: heights,
+            spacing: 0
+        )
+
+        XCTAssertEqual(free.pageHeight, 20)
+        XCTAssertEqual(relayed, 30)
     }
 
     func testSegmentPackingIsTheSameAnswerAsPackingThatBandAlone() {
@@ -429,35 +472,90 @@ final class PageLayoutPackerTests: XCTestCase {
         XCTAssertEqual(packed[1].columns.flatMap { $0 }, [module("b")])
     }
 
-    func testAnEmptySegmentPacksToEmptyColumns() {
-        let packed = PageLayoutPacker.pack(segments: [[], items([("a", 100)])], spacing: 10)
+    func testAnEmptySegmentPacksToEmptyColumnsAndHandsTheRelayOnUntouched() {
+        let packed = PageLayoutPacker.pack(
+            segments: [items([("a", 100)]), [], items([("b", 100)])],
+            spacing: 10
+        )
 
-        XCTAssertEqual(packed[0].columns, [[], []])
-        XCTAssertEqual(packed[0].pageHeight, 0)
-        XCTAssertEqual(packed[1].pageHeight, 100)
+        XCTAssertEqual(packed[1].columns, [[], []])
+        // A segment with nothing in it must not reset the columns to zero, or
+        // everything below it would be planned against a page that does not
+        // exist.
+        XCTAssertEqual(packed[1].columnHeights, packed[0].columnHeights)
+        XCTAssertEqual(packed[0].columnHeights, [100, 0])
+        // `b` still lands beside `a` rather than under it.
+        XCTAssertEqual(packed[2].columns, [[], [module("b")]])
+        XCTAssertEqual(packed[2].columnHeights, [100, 100])
     }
 
-    func testSegmentedPageHeightSumsTheBandsAndTheGapsBetweenThem() {
+    func testSeedsShiftWhereThePackerStartsAndCountTowardsTheAnswer() {
+        // The relay's primitive, on its own: with the left column already 300 pt
+        // tall and occupied, a 100 pt card belongs on the right even though the
+        // right column would be the taller one considered in isolation.
+        let seeded = PageLayoutPacker.pack(
+            items: items([("a", 100)]),
+            spacing: 10,
+            seeds: [
+                PageLayoutPacker.ColumnSeed(height: 300, isOccupied: true),
+                PageLayoutPacker.ColumnSeed(height: 0, isOccupied: false)
+            ]
+        )
+
+        XCTAssertEqual(seeded.columns, [[], [module("a")]])
+        // The right column was empty, so the card pays no gap; the left column's
+        // seed rides through untouched.
+        XCTAssertEqual(seeded.columnHeights, [300, 100])
+        XCTAssertEqual(seeded.pageHeight, 300)
+
+        // Occupied but zero-height is not the same as empty: the gap is owed to
+        // the card that is there, not to the height it happens to measure.
+        let occupiedButEmptyLooking = PageLayoutPacker.pack(
+            items: items([("a", 100)]),
+            spacing: 10,
+            seeds: [
+                PageLayoutPacker.ColumnSeed(height: 0, isOccupied: true),
+                PageLayoutPacker.ColumnSeed(height: 0, isOccupied: true)
+            ]
+        )
+        XCTAssertEqual(occupiedButEmptyLooking.columnHeights, [110, 0])
+    }
+
+    func testFlowColumnsConcatenateEachColumnInSegmentOrder() {
+        let flowed = PageLayoutPacker.flowColumns(
+            segments: [
+                [[module("a")], [module("b")]],
+                [[], [module("c")]],
+                [[module("d")], []]
+            ]
+        )
+
+        XCTAssertEqual(flowed, [[module("a"), module("d")], [module("b"), module("c")]])
+    }
+
+    func testSegmentedPageHeightIsTheTallerColumnOnceEverySegmentHasFlowedIn() {
         let heights: [PageLayoutModuleID: Double] = [
             module("a"): 100,
             module("b"): 50,
             module("c"): 200
         ]
 
-        // Band 0 measures 100 (its taller column), band 1 measures 200, and one
-        // gap sits between them.
+        // The left column holds only `a`; the right holds `b` then `c` with one
+        // gap between them. Nothing lines up at the boundary, so the page is
+        // 260 pt — not the 100 + 10 + 200 = 310 pt a stack of rigid bands cost,
+        // which is the 50 pt hole the user was looking at.
         XCTAssertEqual(
             PageLayoutPacker.pageHeight(
                 segments: [
                     [[module("a")], [module("b")]],
-                    [[module("c")], []]
+                    [[], [module("c")]]
                 ],
                 heights: heights,
                 spacing: 10
             ),
-            310
+            260
         )
-        // One band is a plain page, gap-free.
+        // One segment is a plain page.
         XCTAssertEqual(
             PageLayoutPacker.pageHeight(
                 segments: [[[module("a")], [module("b")]]],
@@ -474,39 +572,31 @@ final class PageLayoutPackerTests: XCTestCase {
 
     func testSegmentedPageHeightMeasuresWhatTheSegmentedPackerChose() {
         let bands = [items([("a", 300), ("b", 200)]), items([("c", 150), ("d", 50)])]
-        let packed = PageLayoutPacker.packedSegmentColumns(segments: bands, spacing: 7)
+        let packed = PageLayoutPacker.pack(segments: bands, spacing: 7)
         let heights = Dictionary(
             uniqueKeysWithValues: bands.flatMap { $0 }.map { ($0.id, $0.height) }
         )
 
+        // Segment 0 splits 300 / 200; segment 1 then puts the 150 under the 200
+        // and the 50 under the 300, landing both columns on 357.
+        XCTAssertEqual(packed[1].columns, [[module("d")], [module("c")]])
         XCTAssertEqual(
-            PageLayoutPacker.pageHeight(segments: packed, heights: heights, spacing: 7),
-            PageLayoutPacker.pack(segments: bands, spacing: 7)
-                .map(\.pageHeight)
-                .reduce(0) { $0 + $1 } + 7
-        )
-    }
-
-    func testSegmentingCostsHeightComparedToPackingTheWholePage() {
-        // Segments are a deliberate trade: the page is taller than the freest
-        // packing, and in exchange the grouping the user reads it in survives.
-        let quota = items([("q1", 300), ("q2", 100)])
-        let rest = items([("c1", 300), ("c2", 100)])
-
-        let free = PageLayoutPacker.pack(items: quota + rest, spacing: 10).pageHeight
-        let heights = Dictionary(
-            uniqueKeysWithValues: (quota + rest).map { ($0.id, $0.height) }
-        )
-        let banded = PageLayoutPacker.pageHeight(
-            segments: PageLayoutPacker.packedSegmentColumns(
-                segments: [quota, rest],
-                spacing: 10
+            PageLayoutPacker.pageHeight(
+                segments: packed.map(\.columns),
+                heights: heights,
+                spacing: 7
             ),
-            heights: heights,
-            spacing: 10
+            357
         )
-
-        XCTAssertEqual(free, 410)
-        XCTAssertEqual(banded, 610)
+        // The measurement and the packer agree, and the last segment's own
+        // heights already carry the whole page.
+        XCTAssertEqual(
+            PageLayoutPacker.pageHeight(
+                segments: packed.map(\.columns),
+                heights: heights,
+                spacing: 7
+            ),
+            packed[packed.count - 1].pageHeight
+        )
     }
 }

--- a/Tests/VibeBarCoreTests/PageLayoutTests.swift
+++ b/Tests/VibeBarCoreTests/PageLayoutTests.swift
@@ -1030,6 +1030,171 @@ final class PageLayoutTests: XCTestCase {
         XCTAssertEqual(manual.layoutToApply, manual.layout)
     }
 
+    // MARK: - Hidden modules
+
+    func testStoredLayoutRoundTripsItsHiddenModules() throws {
+        let stored = StoredPageLayout(
+            mode: .manual,
+            ratio: .wideNarrow,
+            columns: [[.status], [.costAll]],
+            segments: [[.status], [.costAll]],
+            hidden: [.quotaHistoryAll]
+        )
+
+        let decoded = try JSONDecoder().decode(
+            StoredPageLayout.self,
+            from: try JSONEncoder().encode(stored)
+        )
+
+        XCTAssertEqual(decoded.hidden, [.quotaHistoryAll])
+        XCTAssertTrue(decoded.isHidden(.quotaHistoryAll))
+        XCTAssertFalse(decoded.isHidden(.status))
+        // The rest of the entry is untouched by visibility.
+        XCTAssertEqual(decoded.columns, [[.status], [.costAll]])
+        XCTAssertEqual(decoded.segments, [[.status], [.costAll]])
+    }
+
+    func testStoredLayoutEncodesHiddenAsAnArrayOfIdentifierStrings() throws {
+        let stored = StoredPageLayout(mode: .compact, hidden: [.status, .costAll])
+        let object = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: try JSONEncoder().encode(stored)) as? [String: Any]
+        )
+
+        XCTAssertEqual(object["hidden"] as? [String], ["status", "cost-all"])
+    }
+
+    func testStoredLayoutWithoutHiddenDecodesToNothingHidden() throws {
+        // Every entry written before per-module visibility existed. Showing
+        // everything is what those pages were already doing.
+        let legacy = Data(#"{"mode":"manual","ratio":"equal","columns":[["status"],[]]}"#.utf8)
+        let decoded = try JSONDecoder().decode(StoredPageLayout.self, from: legacy)
+
+        XCTAssertEqual(decoded.hidden, [])
+        XCTAssertEqual(decoded.columns.first, [.status])
+    }
+
+    func testMalformedHiddenCostsTheVisibilityAndNothingElse() throws {
+        let mangled = Data(#"{"mode":"manual","columns":[["status"],[]],"hidden":{"a":1}}"#.utf8)
+        let decoded = try JSONDecoder().decode(StoredPageLayout.self, from: mangled)
+
+        XCTAssertEqual(decoded.hidden, [])
+        XCTAssertEqual(decoded.columns.first, [.status])
+    }
+
+    func testStoredHiddenIsDedupedAndKeepsUnknownIdentifiers() {
+        let future = PageLayoutModuleID("overview-something-new:v3")
+        let stored = StoredPageLayout(
+            hidden: [.status, .status, PageLayoutModuleID(""), future]
+        )
+
+        // A downgrade must not silently switch a card back on that a newer build
+        // let the user switch off.
+        XCTAssertEqual(stored.hidden, [.status, future])
+    }
+
+    func testSettingHiddenTogglesOneModuleAndLeavesEverythingElseAlone() {
+        let base = StoredPageLayout(
+            mode: .compact,
+            ratio: .wideNarrow,
+            columns: [[.status], [.costAll]],
+            segments: [[.status], [.costAll]]
+        )
+
+        let hidden = base.settingHidden(.costAll, true)
+        XCTAssertEqual(hidden.hidden, [.costAll])
+        XCTAssertEqual(hidden.mode, .compact)
+        XCTAssertEqual(hidden.ratio, .wideNarrow)
+        XCTAssertEqual(hidden.columns, [[.status], [.costAll]])
+        XCTAssertEqual(hidden.segments, [[.status], [.costAll]])
+
+        // Un-hiding is a true undo, and both directions are idempotent.
+        XCTAssertEqual(hidden.settingHidden(.costAll, true), hidden)
+        XCTAssertEqual(hidden.settingHidden(.costAll, false), base)
+        XCTAssertEqual(base.settingHidden(.costAll, false), base)
+    }
+
+    func testAnEntryCanHideCardsAndStillCountAsUncustomized() {
+        // `isEmpty` asks "is there a hand arrangement to go back to". Switching
+        // a card off is not one.
+        let stored = StoredPageLayout(mode: .auto, hidden: [.status])
+
+        XCTAssertTrue(stored.isEmpty)
+        XCTAssertNil(stored.restoredAsManual())
+    }
+
+    func testReturningToManualKeepsTheHiddenCards() {
+        let parked = StoredPageLayout(
+            mode: .compact,
+            columns: [[.costAll], [.status]],
+            hidden: [.quotaHistoryAll]
+        )
+
+        XCTAssertEqual(parked.restoredAsManual()?.hidden, [.quotaHistoryAll])
+    }
+
+    func testPresetCarriesTheHiddenCardsItWasCapturedFrom() throws {
+        let preset = StoredPageLayoutPreset(
+            name: "No heatmaps",
+            layout: StoredPageLayout(
+                mode: .compact,
+                segments: [[.status], [.costAll]],
+                hidden: [.quotaHistoryAll]
+            )
+        )
+
+        let decoded = try JSONDecoder().decode(
+            StoredPageLayoutPreset.self,
+            from: try JSONEncoder().encode(preset)
+        )
+
+        XCTAssertEqual(decoded.layout.hidden, [.quotaHistoryAll])
+        XCTAssertEqual(decoded.layoutToApply.hidden, [.quotaHistoryAll])
+    }
+
+    func testALegacyCompactPresetKeepsItsHiddenCardsWhileItsModeIsReinterpreted() {
+        // Only the *mode* is ambiguous on a pre-segments compact preset. What
+        // the user switched off is not, so it applies exactly as captured.
+        let legacy = StoredPageLayoutPreset(
+            name: "Old packing",
+            layout: StoredPageLayout(
+                mode: .compact,
+                columns: [[.status, .costAll], [.quotaHistoryAll]],
+                hidden: [.costAll]
+            )
+        )
+
+        XCTAssertEqual(legacy.layoutToApply.mode, .manual)
+        XCTAssertEqual(legacy.layoutToApply.hidden, [.costAll])
+    }
+
+    func testAHiddenModuleKeepsItsSavedColumnBecauseItIsMergedAsUnavailable() {
+        // The whole reason visibility is modelled as a subtraction from
+        // `available`: the merge machinery already preserves the position of
+        // anything it cannot see, so switching a card off and back on returns it
+        // to exactly where it was.
+        let stored = PageLayoutConfig(columns: [[.status, .costAll], [.quotaHistoryAll]])
+        // The editor can only arrange the two cards still on screen.
+        let edited = PageLayoutConfig(columns: [[.status], [.quotaHistoryAll]])
+
+        let merged = PageLayoutResolver.mergingEdit(
+            edited,
+            into: stored,
+            available: [.status, .quotaHistoryAll]
+        )
+
+        XCTAssertEqual(merged.columns, [[.status, .costAll], [.quotaHistoryAll]])
+    }
+
+    func testAHiddenModuleKeepsItsSegmentForTheSameReason() {
+        let merged = PageLayoutSegments.mergingEdit(
+            [[.status], [.quotaHistoryAll]],
+            into: [[.status, .costAll], [.quotaHistoryAll]],
+            available: [.status, .quotaHistoryAll]
+        )
+
+        XCTAssertEqual(merged, [[.status, .costAll], [.quotaHistoryAll]])
+    }
+
     // MARK: - PageLayoutSegments
 
     private static let summaryCost = PageLayoutModuleID("overview-summary-cost")
@@ -1273,6 +1438,61 @@ final class PageLayoutTests: XCTestCase {
         XCTAssertEqual(merged, [[m[0]], [m[1], hidden], [m[2]], [m[3]], [m[4]], [m[5]]])
     }
 
+    // MARK: - Segments as an ordering constraint
+
+    func testOrderingRanksEveryModuleByTheSegmentThatClaimsItFirst() {
+        let ordering = PageLayoutSegments.ordering(
+            [[.status, .costAll], [.quotaHistoryAll], [.status]]
+        )
+
+        XCTAssertEqual(ordering[.status], 0)
+        XCTAssertEqual(ordering[.costAll], 0)
+        XCTAssertEqual(ordering[.quotaHistoryAll], 1)
+        XCTAssertNil(ordering[PageLayoutModuleID("never-seen")])
+    }
+
+    func testSortedColumnsPutEarlierSegmentsFirstAndKeepHandOrderInside() {
+        // How `manual` obeys a segmentation without giving up its drag editor:
+        // the user still owns the column and the order among a card's own
+        // segment-mates, and the segmentation owns which block of the column
+        // that is.
+        let a = PageLayoutModuleID("a")
+        let b = PageLayoutModuleID("b")
+        let c = PageLayoutModuleID("c")
+        let d = PageLayoutModuleID("d")
+
+        let sorted = PageLayoutSegments.sortedColumns(
+            [[c, a, b], [d]],
+            segments: [[a, b], [c, d]]
+        )
+
+        // `c` belongs to the second segment, so it drops below `a` and `b` —
+        // and `a` before `b` is the hand order, preserved by the stable sort.
+        XCTAssertEqual(sorted, [[a, b, c], [d]])
+    }
+
+    func testSortedColumnsLeaveAPageWithOneSegmentExactlyAsItWas() {
+        let columns: [[PageLayoutModuleID]] = [[.costAll, .status], [.quotaHistoryAll]]
+
+        XCTAssertEqual(
+            PageLayoutSegments.sortedColumns(columns, segments: [[.status, .costAll]]),
+            columns
+        )
+        XCTAssertEqual(PageLayoutSegments.sortedColumns(columns, segments: []), columns)
+    }
+
+    func testAModuleNoSegmentClaimsSortsToTheEndOfItsColumn() {
+        let stranger = PageLayoutModuleID("stranger")
+
+        XCTAssertEqual(
+            PageLayoutSegments.sortedColumns(
+                [[stranger, .costAll, .status], []],
+                segments: [[.status], [.costAll]]
+            ),
+            [[.status, .costAll, stranger], []]
+        )
+    }
+
     func testMergingAnEditHonoursTheMoveItWasGiven() {
         let merged = PageLayoutSegments.mergingEdit(
             [[.status, .costAll], [.quotaHistoryAll]],
@@ -1285,13 +1505,13 @@ final class PageLayoutTests: XCTestCase {
 
     // MARK: - Compact, end to end
 
-    func testCompactOverviewPacksTheQuotaCardsAsTheirOwnBand() {
-        // The user's actual complaint: on a packed Overview the quota cards must
+    func testCompactOverviewPacksTheQuotaCardsAsTheirOwnSegment() {
+        // The user's first complaint: on a packed Overview the quota cards must
         // form one minimal-height block, with the summary above them and
         // everything else below — no stored segmentation required.
         //
         // This is the pipeline `PageLayoutModel.compactArrangement` runs:
-        // default banding from the catalog's phases, then one packing per band.
+        // default grouping from the catalog's phases, then the relay packing.
         let modules = overviewModules()
         let heights: [PageLayoutModuleID: Double] = [
             Self.summaryCost: 178,
@@ -1327,7 +1547,7 @@ final class PageLayoutTests: XCTestCase {
                 .quotaHistoryAll
             ])
         )
-        // Nothing from below leaks into the quota band, which is exactly what
+        // Nothing from below leaks into the quota segment, which is exactly what
         // the unsegmented packer was free to do.
         XCTAssertEqual(
             Set(packed[2].flatMap { $0 }),
@@ -1338,10 +1558,31 @@ final class PageLayoutTests: XCTestCase {
                 PageLayoutModuleID("heatmap-year:all")
             ])
         )
-        // The summary band is one row: one card per column.
+        // The summary segment is one row: one card per column.
         XCTAssertEqual(packed[0][0].count, 1)
         XCTAssertEqual(packed[0][1].count, 1)
-        // And each band is genuinely balanced, not just grouped.
+
+        // The user's second complaint, on the same page: the columns flow, so
+        // the page is its taller column and nothing waits at a boundary. Summing
+        // each segment's taller column plus a gap — what the retired bands
+        // measured — is strictly worse, and the difference is the hole.
+        let flowed = PageLayoutPacker.pageHeight(
+            segments: packed,
+            heights: heights,
+            spacing: 12
+        )
+        let asRigidBands = packed
+            .map { PageLayoutPacker.pageHeight(columns: $0, heights: heights, spacing: 12) }
+            .reduce(0) { $0 + $1 } + 12 * Double(packed.count - 1)
+        XCTAssertLessThan(flowed, asRigidBands)
+        XCTAssertEqual(
+            flowed,
+            PageLayoutPacker.flowColumns(segments: packed)
+                .map { PageLayoutPacker.stackedHeight($0, heights: heights, spacing: 12) }
+                .max()
+        )
+
+        // And each segment is genuinely balanced, not just grouped.
         let quotaColumns = packed[1].map {
             PageLayoutPacker.stackedHeight($0, heights: heights, spacing: 12)
         }


### PR DESCRIPTION
## Summary

Round-7 feedback on the dev.11 segmented layout:

1. **No more segment gaps** — segments were rendered as rigid horizontal bands, so the shorter column showed a blank hole at each boundary. Segments are now an *ordering constraint within each column*: the renderer draws one continuous two-column flow, and Compact packs each segment starting from the column heights the previous segment finished at (`PageLayoutPacker.ColumnSeed` relay — same seeding idea the auto masonry planner already used for phases). The next segment's cards flow up into whichever column the previous one left short.
2. **Segments in all three modes** — the auto Overview masonry planner now takes the page's resolved segments as its groups (default = the old phase grouping, byte-identical plan pinned by test); provider-page auto columns sort stably by segment; manual columns obey segment order while preserving hand order within a segment. The layout editor edits segments in every mode — manual keeps its precise column drag inside the segment groups; the preview shows the boundary-free flowed result.
3. **Per-module show/hide** — every block gets an eye toggle. `StoredPageLayout.hidden` (tolerant decode, round-trip tested) persists it; a hidden module is treated exactly like an unavailable one, so the existing merge machinery preserves its column/segment and unhiding restores it in place. Hidden cards stay findable in the editor (dimmed strip in their segment). Presets carry visibility.

## Verification
- `swift build` clean · `swift test` **1069 tests / 0 failures** (+23 over dev.11)
- `./Scripts/build_app.sh release` signs · `codesign -d --entitlements -` = empty `[Dict]` · `codesign --verify --deep --strict` OK · no sandbox container
- Packer tests rewritten where they pinned the retired banded arithmetic (independence/Σ-band-height), replaced with relay pins; all other suites pass unmodified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)