### PR TITLE
Seed grouped phase planning and keep hidden cards' segments in presets

### DIFF
--- a/Sources/VibeBarApp/PageLayoutModel.swift
+++ b/Sources/VibeBarApp/PageLayoutModel.swift
@@ -658,7 +658,8 @@ final class PageLayoutModel: ObservableObject {
     /// arrangement it is showing is captured instead.
     func presetSnapshot(
         for page: PageLayoutPageID,
-        displayed: PageLayoutArrangement
+        displayed: PageLayoutArrangement,
+        descriptors: [PageModuleDescriptor]
     ) -> StoredPageLayout {
         let mode = mode(for: page)
         if mode == .manual, let stored = storedLayouts[page], !stored.isEmpty {
@@ -672,8 +673,17 @@ final class PageLayoutModel: ObservableObject {
             // now, so the resolved segments are captured rather than the saved
             // ones: a preset taken before the user re-grouped anything still
             // restores the page they were looking at instead of an empty "use
-            // the default" marker.
-            segments: displayed.moduleSegments,
+            // the default" marker. The displayed segments cannot contain a
+            // hidden card, though — the arrangement filtered it — while the
+            // preset's hidden list does. Merging the hidden-inclusive
+            // resolution back in keeps that card's membership, so unhiding it
+            // after applying the preset restores the captured grouping rather
+            // than the default one.
+            segments: PageLayoutSegments.mergingEdit(
+                displayed.moduleSegments,
+                into: resolvedSegments(for: page, descriptors: descriptors, includingHidden: true),
+                available: visibleModuleIDs(for: page, descriptors: descriptors)
+            ),
             hidden: storedLayouts[page]?.hidden ?? []
         )
     }

--- a/Sources/VibeBarApp/Views/LayoutEditorView.swift
+++ b/Sources/VibeBarApp/Views/LayoutEditorView.swift
@@ -115,7 +115,7 @@ struct LayoutEditorView: View {
 
         VStack(alignment: .leading, spacing: 12) {
             pagePicker(pages: pages, selected: page)
-            modeRow(page: page, mode: mode, arrangement: arrangement)
+            modeRow(page: page, mode: mode, arrangement: arrangement, descriptors: descriptors)
             controlRow(page: page, config: config)
             if descriptors.isEmpty {
                 Text("This page has no arrangeable cards yet. Open it in the popover once so Vibe Bar can measure them.")
@@ -218,7 +218,8 @@ struct LayoutEditorView: View {
     private func modeRow(
         page: PageLayoutPageID,
         mode: PageLayoutMode,
-        arrangement: PageLayoutArrangement
+        arrangement: PageLayoutArrangement,
+        descriptors: [PageModuleDescriptor]
     ) -> some View {
         HStack(spacing: 10) {
             HStack(spacing: 4) {
@@ -232,7 +233,7 @@ struct LayoutEditorView: View {
                     .fill(Color.primary.opacity(0.045))
             )
             Spacer(minLength: 8)
-            presetsMenu(page: page, arrangement: arrangement)
+            presetsMenu(page: page, arrangement: arrangement, descriptors: descriptors)
             Button {
                 layoutModel.reset(for: page)
             } label: {
@@ -313,7 +314,7 @@ struct LayoutEditorView: View {
         }
     }
 
-    private func presetsMenu(page: PageLayoutPageID, arrangement: PageLayoutArrangement) -> some View {
+    private func presetsMenu(page: PageLayoutPageID, arrangement: PageLayoutArrangement, descriptors: [PageModuleDescriptor]) -> some View {
         let presets = layoutModel.presets(for: page)
         return Menu {
             // Reachable even on a full page: replacing a preset by name costs
@@ -349,11 +350,11 @@ struct LayoutEditorView: View {
                 : "This page is holding all \(AppSettings.maximumPresetsPerPage) saved arrangements — save over one by reusing its name."
         )
         .popover(isPresented: $isNamingPreset, arrowEdge: .bottom) {
-            presetNameForm(page: page, arrangement: arrangement)
+            presetNameForm(page: page, arrangement: arrangement, descriptors: descriptors)
         }
     }
 
-    private func presetNameForm(page: PageLayoutPageID, arrangement: PageLayoutArrangement) -> some View {
+    private func presetNameForm(page: PageLayoutPageID, arrangement: PageLayoutArrangement, descriptors: [PageModuleDescriptor]) -> some View {
         let trimmed = StoredPageLayoutPreset.normalizedName(presetName)
         let replaces = layoutModel.presetWouldReplace(named: trimmed, for: page)
         // Only a genuinely new name is blocked by the cap; reusing an existing
@@ -370,7 +371,7 @@ struct LayoutEditorView: View {
             TextField("Name", text: $presetName)
                 .textFieldStyle(.roundedBorder)
                 .frame(width: 230)
-                .onSubmit { savePreset(page: page, arrangement: arrangement) }
+                .onSubmit { savePreset(page: page, arrangement: arrangement, descriptors: descriptors) }
             if blockedByLimit {
                 Label(
                     "Preset limit reached — use an existing name to replace.",
@@ -390,7 +391,7 @@ struct LayoutEditorView: View {
             HStack {
                 Spacer(minLength: 0)
                 Button("Cancel") { isNamingPreset = false }
-                Button(replaces ? "Replace" : "Save") { savePreset(page: page, arrangement: arrangement) }
+                Button(replaces ? "Replace" : "Save") { savePreset(page: page, arrangement: arrangement, descriptors: descriptors) }
                     .keyboardShortcut(.defaultAction)
                     .disabled(!layoutModel.canSavePreset(named: presetName, for: page))
             }
@@ -398,8 +399,8 @@ struct LayoutEditorView: View {
         .padding(13)
     }
 
-    private func savePreset(page: PageLayoutPageID, arrangement: PageLayoutArrangement) {
-        let snapshot = layoutModel.presetSnapshot(for: page, displayed: arrangement)
+    private func savePreset(page: PageLayoutPageID, arrangement: PageLayoutArrangement, descriptors: [PageModuleDescriptor]) {
+        let snapshot = layoutModel.presetSnapshot(for: page, displayed: arrangement, descriptors: descriptors)
         guard layoutModel.savePreset(named: presetName, for: page, layout: snapshot) else { return }
         presetName = ""
         isNamingPreset = false

--- a/Sources/VibeBarCore/Services/OverviewMasonryPlanner.swift
+++ b/Sources/VibeBarCore/Services/OverviewMasonryPlanner.swift
@@ -114,11 +114,16 @@ public enum OverviewMasonryPlanner {
         let auxiliary = group.filter { $0.phase == .auxiliary }
 
         // The summary band is a row, not a balanced pair: its cards carry one
-        // pinned height, so declaration order decides which side each takes and
-        // the band seeds every column equally. Balancing it instead would stack
-        // two equal cards in one column the moment a third appeared.
+        // pinned height, so declaration order decides the pairing. Balancing it
+        // instead would stack two equal cards in one column the moment a third
+        // appeared. The *columns* are taken shorter-first, though: after an
+        // asymmetric earlier group the row has to start in the hole that group
+        // left, not on top of its taller side. With level columns — the default
+        // segmentation, where summary comes first — this is the old
+        // left-then-right placement exactly.
+        let summaryColumns = heights[0] <= heights[1] ? [0, 1] : [1, 0]
         for (offset, item) in summaries.enumerated() {
-            append(item, to: offset % columnCount, spacing: spacing, heights: &heights, positions: &positions)
+            append(item, to: summaryColumns[offset % columnCount], spacing: spacing, heights: &heights, positions: &positions)
         }
 
         // AQ's Overview has four quota cards. Enumerating all 24 orders lets
@@ -126,7 +131,7 @@ public enum OverviewMasonryPlanner {
         // two quota cards per column. For any other count, use deterministic
         // shortest-column placement rather than making brittle assumptions.
         if quotas.count == 4 {
-            let order = bestQuotaOrder(quotas, spacing: spacing)
+            let order = bestQuotaOrder(quotas, seededBy: heights, spacing: spacing)
             for (offset, item) in order.enumerated() {
                 let column = offset < 2 ? 0 : 1
                 append(item, to: column, spacing: spacing, heights: &heights, positions: &positions)
@@ -211,11 +216,11 @@ public enum OverviewMasonryPlanner {
         return result.filter { !$0.isEmpty }
     }
 
-    private static func bestQuotaOrder(_ items: [Item], spacing: Double) -> [Item] {
+    private static func bestQuotaOrder(_ items: [Item], seededBy seed: [Double], spacing: Double) -> [Item] {
         var best = items
-        var bestScore = quotaScore(items, spacing: spacing)
+        var bestScore = quotaScore(items, seededBy: seed, spacing: spacing)
         for permutation in permutations(items) {
-            let score = quotaScore(permutation, spacing: spacing)
+            let score = quotaScore(permutation, seededBy: seed, spacing: spacing)
             if score.lexicographicallyPrecedes(bestScore) {
                 best = permutation
                 bestScore = score
@@ -224,12 +229,23 @@ public enum OverviewMasonryPlanner {
         return best
     }
 
-    /// Balance the quota block itself first. The lexicographic tail is a
-    /// stable tie-breaker that favors original declaration order.
-    private static func quotaScore(_ order: [Item], spacing: Double) -> [Double] {
-        let left = stackedHeight(Array(order.prefix(2)), spacing: spacing)
-        let right = stackedHeight(Array(order.dropFirst(2)), spacing: spacing)
+    /// Balance the quota columns as they will *end up*, seeds included: after
+    /// an asymmetric earlier group the heavier pair belongs under the shorter
+    /// column. With level seeds — no earlier group, or the default
+    /// segmentation's equal-height summary row — every candidate shifts by the
+    /// same constant, so this picks exactly what the old block-only balance
+    /// picked. The lexicographic tail is a stable tie-breaker that favors
+    /// original declaration order.
+    private static func quotaScore(_ order: [Item], seededBy seed: [Double], spacing: Double) -> [Double] {
+        let left = stacked(onto: seed.first ?? 0, Array(order.prefix(2)), spacing: spacing)
+        let right = stacked(onto: seed.count > 1 ? seed[1] : 0, Array(order.dropFirst(2)), spacing: spacing)
         return [abs(left - right), max(left, right)]
+    }
+
+    /// `append`'s arithmetic, folded over a stack: a card pays the gap iff the
+    /// column already carries anything — seed or earlier card.
+    private static func stacked(onto seed: Double, _ items: [Item], spacing: Double) -> Double {
+        items.reduce(seed) { appendedHeight($0, $1.height, spacing: spacing) }
     }
 
     private static func bestCostColumns(
@@ -289,11 +305,6 @@ public enum OverviewMasonryPlanner {
 
     private static func appendedHeight(_ current: Double, _ item: Double, spacing: Double) -> Double {
         current + (current > 0 ? spacing : 0) + item
-    }
-
-    private static func stackedHeight(_ items: [Item], spacing: Double) -> Double {
-        guard !items.isEmpty else { return 0 }
-        return items.reduce(0) { appendedHeight($0, $1.height, spacing: spacing) }
     }
 
     private static func shortestColumn(_ heights: [Double]) -> Int {

--- a/Tests/VibeBarCoreTests/OverviewMasonryPlannerTests.swift
+++ b/Tests/VibeBarCoreTests/OverviewMasonryPlannerTests.swift
@@ -277,4 +277,55 @@ final class OverviewMasonryPlannerTests: XCTestCase {
         XCTAssertEqual(try XCTUnwrap(locked.positions["summary-cost"]).y, 0)
         XCTAssertEqual(try XCTUnwrap(locked.positions["summary-status"]).y, 0)
     }
+
+    func testASummaryRowAfterAnAsymmetricGroupStartsInTheShorterColumn() throws {
+        // A custom segmentation puts one tall card ahead of the summary row.
+        // The row's first card must start in the hole that group left, not on
+        // top of its taller side — the pairing (declaration order) is
+        // unchanged, only the column choice flips.
+        let items: [OverviewMasonryPlanner.Item] = [
+            .init(id: "tall", height: 400, phase: .auxiliary),
+            .init(id: "summary-cost", height: 150, phase: .summary),
+            .init(id: "summary-status", height: 150, phase: .summary)
+        ]
+
+        let plan = OverviewMasonryPlanner.plan(
+            items: items,
+            groups: [["tall"], ["summary-cost", "summary-status"]],
+            spacing: 12
+        )
+
+        XCTAssertEqual(plan.positions["tall"]?.column, 0)
+        XCTAssertEqual(plan.positions["summary-cost"]?.column, 1)
+        XCTAssertEqual(try XCTUnwrap(plan.positions["summary-cost"]).y, 0)
+        XCTAssertEqual(plan.positions["summary-status"]?.column, 0)
+    }
+
+    func testTheQuotaBlockAfterAnAsymmetricGroupBalancesTheFinalColumns() throws {
+        // Balancing the quota block in isolation would split the pairs
+        // 10+400 / 10+400 (a perfect block balance) and then stack one of them
+        // on the already-tall column: 400+410 = 810 against 410. Balancing the
+        // *totals* puts the light pair under the seeded column instead:
+        // 420 against 800, a shorter page.
+        let items: [OverviewMasonryPlanner.Item] = [
+            .init(id: "seed", height: 400, phase: .auxiliary),
+            .init(id: "q1", height: 10, phase: .quota),
+            .init(id: "q2", height: 10, phase: .quota),
+            .init(id: "q3", height: 400, phase: .quota),
+            .init(id: "q4", height: 400, phase: .quota)
+        ]
+
+        let plan = OverviewMasonryPlanner.plan(
+            items: items,
+            groups: [["seed"], ["q1", "q2", "q3", "q4"]],
+            spacing: 0
+        )
+
+        XCTAssertEqual(plan.positions["seed"]?.column, 0)
+        XCTAssertEqual(plan.positions["q1"]?.column, 0)
+        XCTAssertEqual(plan.positions["q2"]?.column, 0)
+        XCTAssertEqual(plan.positions["q3"]?.column, 1)
+        XCTAssertEqual(plan.positions["q4"]?.column, 1)
+        XCTAssertEqual(plan.columnHeights, [420, 800])
+    }
 }


### PR DESCRIPTION
Follow-up to #131, addressing the two Codex review findings that landed after auto-merge:

- **Account for prior heights in phase-specific group planning** — `OverviewMasonryPlanner`'s summary row now starts in the currently-shorter column (pairing/declaration order unchanged), and `bestQuotaOrder` scores the 24 permutations against the accumulated column heights (final totals) instead of the block in isolation. With level seeds — the default segmentation or no grouping — every candidate shifts by the same constant, so default plans are unchanged (existing equivalence pins still pass). Two new tests cover the asymmetric-group cases (summary starts in the hole; the light quota pair goes under the seeded column, 420/800 instead of 810/410).
- **Include hidden modules when snapshotting segments** — `presetSnapshot` now merges the hidden-inclusive segment resolution into the displayed segments via the existing `PageLayoutSegments.mergingEdit` machinery, so a hidden card's membership rides along with the preset and unhiding after applying restores the captured grouping rather than the default one. Descriptors are threaded through the editor's preset call chain.

Verification: `swift build` clean, `swift test` 1071 tests / 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)