### PR TITLE
Prepare Vibe Bar 1.2.0 Dev build 12

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -21,7 +21,7 @@
     <key>CFBundleShortVersionString</key>
     <string>1.2.0</string>
     <key>CFBundleVersion</key>
-    <string>11</string>
+    <string>12</string>
     <key>LSMinimumSystemVersion</key>
     <string>26.0</string>
     <key>LSUIElement</key>


### PR DESCRIPTION
Version bump for the 1.2.0-dev.12 Dev-channel release: CFBundleVersion 11 → 12, CFBundleShortVersionString stays 1.2.0. Two-line diff.

Ships #131 (segment relay flow in all modes + per-module visibility) and #132 (post-merge review fixes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)