### PR TITLE
Prepare Vibe Bar 1.2.0 Dev build 13

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -21,7 +21,7 @@
     <key>CFBundleShortVersionString</key>
     <string>1.2.0</string>
     <key>CFBundleVersion</key>
-    <string>12</string>
+    <string>13</string>
     <key>LSMinimumSystemVersion</key>
     <string>26.0</string>
     <key>LSUIElement</key>


### PR DESCRIPTION
Version bump for the 1.2.0-dev.13 Dev-channel release: CFBundleVersion 12 → 13, CFBundleShortVersionString stays 1.2.0. Two-line diff.

Ships #134 (Cost/Status summary cards pinned back to one shared height, tiles fitted inside the pin).

🤖 Generated with [Claude Code](https://claude.com/claude-code)