### PR TITLE
Prepare Vibe Bar 1.2.0 stable

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -21,7 +21,7 @@
     <key>CFBundleShortVersionString</key>
     <string>1.2.0</string>
     <key>CFBundleVersion</key>
-    <string>13</string>
+    <string>14</string>
     <key>LSMinimumSystemVersion</key>
     <string>26.0</string>
     <key>LSUIElement</key>


### PR DESCRIPTION
Version bump for the v1.2.0 stable-channel release: CFBundleVersion 13 → 14, CFBundleShortVersionString stays 1.2.0. Two-line diff.

Promotes the current main — history charts, per-group quota cards, the segmented layout editor with presets and per-module visibility, forecast-colored menu bar, refresh-jank fixes, and batch/auto browser-cookie import, soaked through dev builds 8–13 — to the stable Sparkle channel, which is currently at 1.0.0 (build 7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)