### PR TITLE
Add remote Probe ingest and machine usage

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -54,6 +54,9 @@ let package = Package(
         .testTarget(
             name: "VibeBarCoreTests",
             dependencies: ["VibeBarCore"],
+            resources: [
+                .copy("Fixtures/RemoteSync")
+            ],
             swiftSettings: [.swiftLanguageMode(.v5)]
         )
     ]

--- a/Sources/VibeBarApp/AppDelegate.swift
+++ b/Sources/VibeBarApp/AppDelegate.swift
@@ -1,4 +1,5 @@
 import AppKit
+import Darwin
 import VibeBarCore
 
 @MainActor
@@ -7,6 +8,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var statusItem: StatusItemController?
 
     func applicationDidFinishLaunching(_ notification: Notification) {
+        if handleRemoteCommandLine() { return }
         // Belt-and-braces: Info.plist already sets LSUIElement, but if we are
         // launched from `swift run` (no bundle), force accessory policy here.
         if Bundle.main.bundleIdentifier == nil
@@ -55,7 +57,37 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         statusItem?.applicationWillTerminate()
         environment?.scheduler.stop()
         environment?.serviceStatus.stop()
+        environment?.remoteProbeService.stop()
         CookieRefreshScheduler.shared.stop()
         return .terminateNow
+    }
+
+    private func handleRemoteCommandLine() -> Bool {
+        let arguments = ProcessInfo.processInfo.arguments
+        let commands = ["--remote-identity-descriptor", "--install-remote-provisioning"]
+        let requested = commands.filter(arguments.contains)
+        guard !requested.isEmpty else { return false }
+        guard requested.count == 1,
+              let command = requested.first,
+              let index = arguments.firstIndex(of: command),
+              arguments.indices.contains(index + 1)
+        else {
+            FileHandle.standardError.write(Data("invalid_remote_command\n".utf8))
+            Darwin.exit(EXIT_FAILURE)
+        }
+        let url = URL(fileURLWithPath: arguments[index + 1]).standardizedFileURL
+        do {
+            if command == "--remote-identity-descriptor" {
+                try RemoteCoreConfigStore.writePublicDescriptor(to: url)
+            } else {
+                try RemoteCoreConfigStore.install(from: url)
+            }
+            FileHandle.standardOutput.write(Data("ok\n".utf8))
+            Darwin.exit(EXIT_SUCCESS)
+        } catch {
+            let code = (error as? RemoteSyncError)?.code ?? "remote_command_failed"
+            FileHandle.standardError.write(Data((code + "\n").utf8))
+            Darwin.exit(EXIT_FAILURE)
+        }
     }
 }

--- a/Sources/VibeBarApp/AppEnvironment.swift
+++ b/Sources/VibeBarApp/AppEnvironment.swift
@@ -10,6 +10,7 @@ final class AppEnvironment: ObservableObject {
     let scheduler: QuotaRefreshScheduler
     let serviceStatus: ServiceStatusController
     let costService: CostUsageService
+    let remoteProbeService: RemoteProbeService
     let updateController: AppUpdateController
     /// Per-page card arrangement, shared by the popover and the Settings
     /// layout editor. Loads `~/.vibebar/layout.json` once at startup.
@@ -91,6 +92,7 @@ final class AppEnvironment: ObservableObject {
             settings?.settings.costData ?? .default
         })
         self.costService = costService
+        self.remoteProbeService = RemoteProbeService()
 
         // Give the quota refresh path the same activity inputs the popover
         // passes when it renders a forecast (see
@@ -224,6 +226,7 @@ final class AppEnvironment: ObservableObject {
 
         scheduler.start()
         serviceStatus.start()
+        remoteProbeService.start()
 
         // Kick off an initial cost scan in the background. Cost data updates
         // slowly compared to live quota, so we re-scan only on app relaunch,
@@ -336,6 +339,9 @@ final class AppEnvironment: ObservableObject {
 
     func refreshAll() {
         reloadProviderCredentialsAndRefresh()
+        Task { @MainActor [weak self] in
+            await self?.remoteProbeService.refresh()
+        }
     }
 
     func refreshCostUsage() {

--- a/Sources/VibeBarApp/StatusItemController.swift
+++ b/Sources/VibeBarApp/StatusItemController.swift
@@ -100,6 +100,7 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
                 .environmentObject(environment.quotaService)
                 .environmentObject(environment.serviceStatus)
                 .environmentObject(environment.costService)
+                .environmentObject(environment.remoteProbeService)
                 .environmentObject(environment.pageLayout)
         )
         return popover

--- a/Sources/VibeBarApp/Views/PopoverRoot.swift
+++ b/Sources/VibeBarApp/Views/PopoverRoot.swift
@@ -11,6 +11,7 @@ struct PopoverRoot: View {
     @EnvironmentObject var environment: AppEnvironment
     @EnvironmentObject var settingsStore: SettingsStore
     @EnvironmentObject var quotaService: QuotaService
+    @EnvironmentObject var remoteProbeService: RemoteProbeService
     @State private var overviewPage: OverviewPage = .overview
 
     var body: some View {
@@ -91,6 +92,8 @@ struct PopoverRoot: View {
             GrokPage(density: density)
         case .misc:
             MiscProvidersPage(density: density)
+        case .machines:
+            RemoteMachinesPage(density: density)
         }
     }
 
@@ -102,6 +105,7 @@ struct PopoverRoot: View {
         case .googleAI: return "Gemini"
         case .grok: return "Grok"
         case .misc: return "Misc Providers"
+        case .machines: return "Machines"
         }
     }
 
@@ -113,6 +117,7 @@ struct PopoverRoot: View {
         case .googleAI: return "Gemini Web + AntiGravity · quota & status"
         case .grok: return "xAI · monthly credits, cost & status"
         case .misc: return "Usage-only · sign in or paste a key"
+        case .machines: return "End-to-end encrypted remote usage"
         }
     }
 
@@ -130,6 +135,9 @@ struct PopoverRoot: View {
         if overviewPage == .grok {
             return [.grok]
         }
+        if overviewPage == .machines {
+            return []
+        }
         switch overviewPage {
         case .overview:
             return settingsStore.settings.visibleCoreProviderList
@@ -138,16 +146,19 @@ struct PopoverRoot: View {
         case .googleAI: return ToolType.googleAIPair
         case .grok: return [.grok]
         case .misc: return settingsStore.settings.visibleMiscProviderList
+        case .machines: return []
         }
     }
 
     private var latestUpdated: Date? {
-        visibleAccounts
+        if overviewPage == .machines { return remoteProbeService.lastUpdated }
+        return visibleAccounts
             .compactMap { quotaService.lastUpdatedByAccount[$0.id] }
             .max()
     }
 
     private var isRefreshing: Bool {
+        if overviewPage == .machines { return remoteProbeService.isRefreshing }
         let ids = visibleAccounts.map(\.id)
         return ids.contains { quotaService.inFlightAccountIds.contains($0) }
     }
@@ -210,6 +221,7 @@ enum OverviewPage: String, CaseIterable, Identifiable {
     case googleAI
     case grok
     case misc
+    case machines
 
     var id: String { rawValue }
 
@@ -217,7 +229,7 @@ enum OverviewPage: String, CaseIterable, Identifiable {
     static func visiblePages(settings: AppSettings) -> [OverviewPage] {
         [.overview]
             + settings.visibleCoreProviderList.compactMap(OverviewPage.page(for:))
-            + [.misc]
+            + [.machines, .misc]
     }
 
     /// The layout-engine page this tab renders, or `nil` for tabs that are not
@@ -231,6 +243,7 @@ enum OverviewPage: String, CaseIterable, Identifiable {
         case .googleAI: return .detail(.gemini)
         case .grok:     return .detail(.grok)
         case .misc:     return nil
+        case .machines: return nil
         }
     }
 
@@ -248,6 +261,7 @@ enum OverviewPage: String, CaseIterable, Identifiable {
         case .googleAI: return "Gemini"
         case .grok:     return "Grok"
         case .misc:     return "Misc"
+        case .machines: return "Machines"
         }
     }
 
@@ -257,7 +271,7 @@ enum OverviewPage: String, CaseIterable, Identifiable {
         case .claude: return .claude
         case .googleAI: return .gemini
         case .grok: return .grok
-        case .overview, .misc: return nil
+        case .overview, .misc, .machines: return nil
         }
     }
 
@@ -352,6 +366,9 @@ private struct OverviewSwitchIcon: View {
                     .font(.system(size: Self.iconSize, weight: .semibold))
             case .misc:
                 Image(systemName: "square.grid.2x2")
+                    .font(.system(size: Self.iconSize, weight: .medium))
+            case .machines:
+                Image(systemName: "server.rack")
                     .font(.system(size: Self.iconSize, weight: .medium))
             case .openAI:
                 ToolBrandIconView(tool: .codex, size: Self.iconSize)

--- a/Sources/VibeBarApp/Views/RemoteMachinesPage.swift
+++ b/Sources/VibeBarApp/Views/RemoteMachinesPage.swift
@@ -1,0 +1,191 @@
+import SwiftUI
+import VibeBarCore
+
+struct RemoteMachinesPage: View {
+    let density: Theme.Density
+
+    @EnvironmentObject private var service: RemoteProbeService
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: density.interSectionSpacing) {
+            if !service.isConfigured {
+                stateCard(
+                    icon: "lock.slash",
+                    title: "Remote Core is not configured",
+                    detail: "Create a Core descriptor, provision a workspace-scoped Relay credential, then import the signed provisioning file. No inbound port is required on this Mac."
+                )
+            } else if service.machines.isEmpty {
+                stateCard(
+                    icon: service.isRefreshing ? "arrow.triangle.2.circlepath" : "server.rack",
+                    title: service.isRefreshing ? "Checking the Relay…" : "No remote machine data yet",
+                    detail: service.lastErrorCode.map { "Sync state: \($0)" }
+                        ?? "The Relay is connected. A Probe will appear after its first encrypted batch is decrypted and imported."
+                )
+            } else {
+                if let error = service.lastErrorCode {
+                    HStack(spacing: 7) {
+                        Image(systemName: "exclamationmark.triangle.fill")
+                            .foregroundStyle(.orange)
+                        Text("Latest sync: \(error)")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                LazyVStack(alignment: .leading, spacing: density.interSectionSpacing) {
+                    ForEach(service.machines) { machine in
+                        machineCard(machine)
+                    }
+                }
+            }
+        }
+    }
+
+    private func stateCard(icon: String, title: String, detail: String) -> some View {
+        VStack(spacing: 12) {
+            Image(systemName: icon)
+                .font(.system(size: 24, weight: .medium))
+                .foregroundStyle(.secondary)
+            Text(title)
+                .font(.system(size: density.titleFontSize, weight: .semibold))
+            Text(detail)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: 430)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(28)
+        .background(cardBackground)
+    }
+
+    private func machineCard(_ machine: RemoteMachineSummary) -> some View {
+        VStack(alignment: .leading, spacing: 14) {
+            HStack(alignment: .center, spacing: 10) {
+                Image(systemName: "server.rack")
+                    .font(.system(size: 17, weight: .medium))
+                    .frame(width: 28, height: 28)
+                    .background(Circle().fill(Color.accentColor.opacity(0.14)))
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(machine.alias)
+                        .font(.system(size: density.titleFontSize, weight: .semibold))
+                    Text("\(machine.platform) · Probe \(machine.probeVersion)")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+                freshness(machine.lastSeenAt)
+            }
+
+            HStack(spacing: 0) {
+                metric("Today", machine.todayTokens)
+                Divider().frame(height: 34)
+                metric("7 days", machine.last7DaysTokens)
+                Divider().frame(height: 34)
+                metric("30 days", machine.last30DaysTokens)
+                Divider().frame(height: 34)
+                VStack(alignment: .trailing, spacing: 2) {
+                    Text(machine.last30DaysCostUSD, format: .currency(code: "USD"))
+                        .font(.system(size: 14, weight: .semibold, design: .rounded))
+                    Text("30-day cost")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+                .frame(maxWidth: .infinity, alignment: .trailing)
+            }
+
+            if !machine.byTool.isEmpty {
+                Divider().opacity(0.45)
+                HStack(spacing: 8) {
+                    ForEach(machine.byTool) { usage in
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(toolLabel(usage.tool))
+                                .font(.caption2)
+                                .foregroundStyle(.secondary)
+                            Text(usage.tokens, format: .number.notation(.compactName))
+                                .font(.system(size: 12, weight: .semibold, design: .rounded))
+                        }
+                        .padding(.horizontal, 9)
+                        .padding(.vertical, 6)
+                        .background(
+                            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                                .fill(Color.primary.opacity(0.045))
+                        )
+                    }
+                    Spacer(minLength: 0)
+                }
+            }
+
+            HStack(spacing: 6) {
+                ForEach(machine.sourceStatuses.keys.sorted(), id: \.self) { source in
+                    let status = machine.sourceStatuses[source] ?? "error"
+                    Text("\(toolLabel(source)) · \(status)")
+                        .font(.system(size: 9.5, weight: .medium))
+                        .foregroundStyle(status == "ok" ? Color.secondary : Color.orange)
+                        .padding(.horizontal, 7)
+                        .padding(.vertical, 3)
+                        .background(Capsule().fill(Color.primary.opacity(0.04)))
+                }
+                Spacer(minLength: 0)
+                Text("seq \(machine.lastSequence)")
+                    .font(.caption2.monospacedDigit())
+                    .foregroundStyle(.tertiary)
+            }
+        }
+        .padding(16)
+        .background(cardBackground)
+    }
+
+    private func metric(_ title: String, _ value: Int) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(value, format: .number.notation(.compactName))
+                .font(.system(size: 14, weight: .semibold, design: .rounded))
+            Text(title)
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private func freshness(_ date: Date) -> some View {
+        let age = Date().timeIntervalSince(date)
+        let label: String
+        let color: Color
+        if age <= 120 {
+            label = "Live"
+            color = .green
+        } else if age <= 600 {
+            label = "Delayed"
+            color = .orange
+        } else {
+            label = "Stale"
+            color = .red
+        }
+        return HStack(spacing: 5) {
+            Circle().fill(color).frame(width: 7, height: 7)
+            Text(label).font(.caption.weight(.semibold))
+        }
+        .foregroundStyle(color)
+        .padding(.horizontal, 8)
+        .padding(.vertical, 4)
+        .background(Capsule().fill(color.opacity(0.10)))
+    }
+
+    private var cardBackground: some View {
+        RoundedRectangle(cornerRadius: 12, style: .continuous)
+            .fill(Color.primary.opacity(0.035))
+            .overlay(
+                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                    .stroke(Color.primary.opacity(0.07), lineWidth: 0.7)
+            )
+    }
+
+    private func toolLabel(_ raw: String) -> String {
+        switch raw {
+        case "codex": return "Codex"
+        case "claude": return "Claude"
+        case "antigravity": return "AntiGravity"
+        case "grok": return "Grok"
+        default: return raw
+        }
+    }
+}

--- a/Sources/VibeBarCore/Credentials/RemoteCoreIdentityStore.swift
+++ b/Sources/VibeBarCore/Credentials/RemoteCoreIdentityStore.swift
@@ -1,0 +1,90 @@
+import Foundation
+import CryptoKit
+
+public struct RemoteCoreIdentity: Sendable {
+    public let signingPrivateKey: P256.Signing.PrivateKey
+    public let recipientPrivateKey: P256.KeyAgreement.PrivateKey
+
+    public var publicDescriptor: RemoteCorePublicDescriptor {
+        RemoteCorePublicDescriptor(
+            signingPublicKey: signingPrivateKey.publicKey.x963Representation,
+            recipientPublicKey: recipientPrivateKey.publicKey.x963Representation
+        )
+    }
+}
+
+public enum RemoteCoreIdentityStore {
+    private static let service = "com.astroqore.VibeBar.remote-sync"
+    private static let identityAccount = "core-identity-v1"
+
+    private struct Payload: Codable {
+        let schema: Int
+        let signingPrivateKey: Data
+        let recipientPrivateKey: Data
+
+        private enum CodingKeys: String, CodingKey {
+            case schema
+            case signingPrivateKey = "signing_private_key"
+            case recipientPrivateKey = "recipient_private_key"
+        }
+    }
+
+    public static func loadOrCreate() throws -> RemoteCoreIdentity {
+        do {
+            let data = try VibeBarCredentialVault.readData(
+                service: service,
+                account: identityAccount
+            )
+            let payload = try JSONDecoder().decode(Payload.self, from: data)
+            guard payload.schema == 1 else { throw RemoteSyncError.invalidConfiguration }
+            return RemoteCoreIdentity(
+                signingPrivateKey: try P256.Signing.PrivateKey(
+                    rawRepresentation: payload.signingPrivateKey
+                ),
+                recipientPrivateKey: try P256.KeyAgreement.PrivateKey(
+                    rawRepresentation: payload.recipientPrivateKey
+                )
+            )
+        } catch KeychainStore.KeychainError.itemNotFound {
+            let identity = RemoteCoreIdentity(
+                signingPrivateKey: P256.Signing.PrivateKey(),
+                recipientPrivateKey: P256.KeyAgreement.PrivateKey()
+            )
+            let payload = Payload(
+                schema: 1,
+                signingPrivateKey: identity.signingPrivateKey.rawRepresentation,
+                recipientPrivateKey: identity.recipientPrivateKey.rawRepresentation
+            )
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = [.sortedKeys]
+            try VibeBarCredentialVault.writeData(
+                service: service,
+                account: identityAccount,
+                data: try encoder.encode(payload)
+            )
+            return identity
+        }
+    }
+
+    public static func relayBearerToken(workspaceID: UUID) throws -> String {
+        try VibeBarCredentialVault.readString(
+            service: service,
+            account: relayAccount(workspaceID)
+        )
+    }
+
+    static func storeRelayBearerToken(_ token: String, workspaceID: UUID) throws {
+        guard (32...512).contains(token.utf8.count),
+              token.unicodeScalars.allSatisfy({ !$0.properties.isWhitespace })
+        else { throw RemoteSyncError.invalidConfiguration }
+        try VibeBarCredentialVault.writeString(
+            service: service,
+            account: relayAccount(workspaceID),
+            value: token
+        )
+    }
+
+    private static func relayAccount(_ workspaceID: UUID) -> String {
+        "relay:" + workspaceID.uuidString.lowercased()
+    }
+}

--- a/Sources/VibeBarCore/Models/RemoteIngestPayload.swift
+++ b/Sources/VibeBarCore/Models/RemoteIngestPayload.swift
@@ -1,0 +1,227 @@
+import Foundation
+
+struct RemoteIngestPayload: Decodable {
+    let schema: Int
+    let workspaceID: UUID
+    let producerID: UUID
+    let probe: Probe
+    let previousSequence: Int64?
+    let operations: [Operation]
+    let status: Status
+
+    struct Probe: Decodable {
+        let alias: String
+        let version: String
+        let platform: String
+        let timezone: String
+    }
+
+    struct Status: Decodable {
+        let lastScanAt: String
+        let backlogBatches: Int
+        let appliedControlSequence: Int64
+        let sources: [String: String]
+
+        private enum CodingKeys: String, CodingKey {
+            case lastScanAt = "last_scan_at"
+            case backlogBatches = "backlog_batches"
+            case appliedControlSequence = "applied_control_sequence"
+            case sources
+        }
+    }
+
+    enum Operation: Decodable {
+        case usage(Usage)
+        case sourceReset(SourceReset)
+
+        private enum KindKeys: String, CodingKey { case op }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: KindKeys.self)
+            switch try container.decode(String.self, forKey: .op) {
+            case "usage_upsert": self = .usage(try Usage(from: decoder))
+            case "source_reset": self = .sourceReset(try SourceReset(from: decoder))
+            default: throw RemoteSyncError.invalidPayload
+            }
+        }
+    }
+
+    struct SourceReset: Decodable {
+        let op: String
+        let sourceKey: String
+        let sourceGeneration: Int
+        let tool: String
+        let observedAt: String
+        let parserVersion: Int
+
+        private enum CodingKeys: String, CodingKey {
+            case op, tool
+            case sourceKey = "source_key"
+            case sourceGeneration = "source_generation"
+            case observedAt = "observed_at"
+            case parserVersion = "parser_version"
+        }
+    }
+
+    struct Usage: Decodable {
+        let op: String
+        let sourceKey: String
+        let sourceGeneration: Int
+        let eventKey: String
+        let tool: String
+        let occurredAt: String
+        let observedAt: String
+        let model: String?
+        let tokens: Tokens
+        let requestCount: Int
+        let serviceTier: String?
+        let accounting: String
+        let parserVersion: Int
+
+        private enum CodingKeys: String, CodingKey {
+            case op, tool, model, tokens, accounting
+            case sourceKey = "source_key"
+            case sourceGeneration = "source_generation"
+            case eventKey = "event_key"
+            case occurredAt = "occurred_at"
+            case observedAt = "observed_at"
+            case requestCount = "request_count"
+            case serviceTier = "service_tier"
+            case parserVersion = "parser_version"
+        }
+    }
+
+    struct Tokens: Decodable {
+        let input: Int
+        let output: Int
+        let cacheRead: Int
+        let cacheCreation: Int
+        let reasoning: Int
+        let tool: Int
+        let totalOnly: Int?
+
+        private enum CodingKeys: String, CodingKey {
+            case input, output, reasoning, tool
+            case cacheRead = "cache_read"
+            case cacheCreation = "cache_creation"
+            case totalOnly = "total_only"
+        }
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case schema, probe, operations, status
+        case workspaceID = "workspace_id"
+        case producerID = "producer_id"
+        case previousSequence = "previous_sequence"
+    }
+}
+
+enum RemotePayloadDecoder {
+    private static let rootKeys: Set<String> = [
+        "schema", "workspace_id", "producer_id", "probe", "previous_sequence",
+        "operations", "status"
+    ]
+    private static let probeKeys: Set<String> = ["alias", "version", "platform", "timezone"]
+    private static let statusKeys: Set<String> = [
+        "last_scan_at", "backlog_batches", "applied_control_sequence", "sources"
+    ]
+    private static let usageKeys: Set<String> = [
+        "op", "source_key", "source_generation", "event_key", "tool", "occurred_at",
+        "observed_at", "model", "tokens", "request_count", "service_tier", "accounting",
+        "parser_version"
+    ]
+    private static let resetKeys: Set<String> = [
+        "op", "source_key", "source_generation", "tool", "observed_at", "parser_version"
+    ]
+    private static let tokenKeys: Set<String> = [
+        "input", "output", "cache_read", "cache_creation", "reasoning", "tool", "total_only"
+    ]
+    private static let tools: Set<String> = ["codex", "claude", "antigravity", "grok"]
+    private static let statuses: Set<String> = ["ok", "absent", "locked", "unsupported", "error"]
+
+    static func decode(_ data: Data) throws -> RemoteIngestPayload {
+        guard data.count <= 4 * 1_048_576,
+              let object = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+              Set(object.keys) == rootKeys,
+              let probe = object["probe"] as? [String: Any], Set(probe.keys) == probeKeys,
+              let status = object["status"] as? [String: Any], Set(status.keys) == statusKeys,
+              let sourceStatuses = status["sources"] as? [String: String],
+              Set(sourceStatuses.keys).isSubset(of: tools),
+              sourceStatuses.values.allSatisfy(statuses.contains),
+              let operations = object["operations"] as? [[String: Any]], operations.count <= 5000
+        else { throw RemoteSyncError.invalidPayload }
+        for operation in operations {
+            switch operation["op"] as? String {
+            case "usage_upsert":
+                guard Set(operation.keys) == usageKeys,
+                      let tokens = operation["tokens"] as? [String: Any],
+                      Set(tokens.keys) == tokenKeys
+                else { throw RemoteSyncError.invalidPayload }
+            case "source_reset":
+                guard Set(operation.keys) == resetKeys else {
+                    throw RemoteSyncError.invalidPayload
+                }
+            default:
+                throw RemoteSyncError.invalidPayload
+            }
+        }
+        let payload = try JSONDecoder().decode(RemoteIngestPayload.self, from: data)
+        try validate(payload)
+        return payload
+    }
+
+    private static func validate(_ payload: RemoteIngestPayload) throws {
+        guard payload.schema == 1,
+              (1...96).contains(payload.probe.alias.count),
+              (1...32).contains(payload.probe.version.count),
+              (1...64).contains(payload.probe.platform.count),
+              (1...64).contains(payload.probe.timezone.count),
+              RemoteProtocolCrypto.parseTimestamp(payload.status.lastScanAt) != nil,
+              (0...9_007_199_254_740_991).contains(payload.status.backlogBatches),
+              (0...9_007_199_254_740_991).contains(payload.status.appliedControlSequence)
+        else { throw RemoteSyncError.invalidPayload }
+        for operation in payload.operations {
+            switch operation {
+            case let .sourceReset(reset):
+                guard reset.op == "source_reset", (2..<Int(Int32.max)).contains(reset.sourceGeneration),
+                      tools.contains(reset.tool), (1..<Int(Int32.max)).contains(reset.parserVersion),
+                      validOpaqueKey(reset.sourceKey),
+                      RemoteProtocolCrypto.parseTimestamp(reset.observedAt) != nil
+                else { throw RemoteSyncError.invalidPayload }
+            case let .usage(usage):
+                let values = [
+                    usage.tokens.input, usage.tokens.output, usage.tokens.cacheRead,
+                    usage.tokens.cacheCreation, usage.tokens.reasoning, usage.tokens.tool,
+                    usage.requestCount
+                ]
+                let componentTotal = values.dropLast().reduce(0, +)
+                guard usage.op == "usage_upsert",
+                      (1..<Int(Int32.max)).contains(usage.sourceGeneration),
+                      tools.contains(usage.tool),
+                      (1..<Int(Int32.max)).contains(usage.parserVersion),
+                      validOpaqueKey(usage.sourceKey), validOpaqueKey(usage.eventKey),
+                      values.allSatisfy({ $0 >= 0 && $0 <= 9_007_199_254_740_991 }),
+                      componentTotal <= 9_007_199_254_740_991,
+                      RemoteProtocolCrypto.parseTimestamp(usage.occurredAt) != nil,
+                      RemoteProtocolCrypto.parseTimestamp(usage.observedAt) != nil,
+                      usage.model?.count ?? 0 <= 128,
+                      usage.serviceTier?.count ?? 0 <= 64
+                else { throw RemoteSyncError.invalidPayload }
+                if let totalOnly = usage.tokens.totalOnly {
+                    guard totalOnly >= 0, totalOnly <= 9_007_199_254_740_991,
+                          usage.tokens.input == 0, usage.tokens.output == 0,
+                          usage.tokens.cacheRead == 0, usage.tokens.cacheCreation == 0,
+                          usage.tokens.reasoning == 0, usage.tokens.tool == 0
+                    else { throw RemoteSyncError.invalidPayload }
+                }
+            }
+        }
+    }
+
+    private static func validOpaqueKey(_ value: String) -> Bool {
+        guard (32...96).contains(value.count) else { return false }
+        return value.unicodeScalars.allSatisfy {
+            CharacterSet.alphanumerics.contains($0) || $0 == "_" || $0 == "-"
+        }
+    }
+}

--- a/Sources/VibeBarCore/Models/RemoteSyncModels.swift
+++ b/Sources/VibeBarCore/Models/RemoteSyncModels.swift
@@ -1,0 +1,254 @@
+import Foundation
+
+public struct RemoteCoreConfig: Codable, Equatable, Sendable {
+    public let schema: Int
+    public let workspaceID: UUID
+    public let coreDeviceID: UUID
+    public let relayURL: URL
+    public let coreEpoch: Int
+    public let ingestKeyID: String
+    public let probeSigningPublicKeys: [UUID: Data]
+
+    public init(
+        schema: Int = 1,
+        workspaceID: UUID,
+        coreDeviceID: UUID,
+        relayURL: URL,
+        coreEpoch: Int,
+        ingestKeyID: String,
+        probeSigningPublicKeys: [UUID: Data]
+    ) throws {
+        guard schema == 1 else { throw RemoteSyncError.invalidConfiguration }
+        guard relayURL.scheme?.lowercased() == "https",
+              relayURL.host != nil,
+              relayURL.user == nil,
+              relayURL.password == nil,
+              relayURL.path.isEmpty || relayURL.path == "/",
+              relayURL.query == nil,
+              relayURL.fragment == nil
+        else { throw RemoteSyncError.invalidConfiguration }
+        guard (1..<Int(Int32.max)).contains(coreEpoch),
+              (1...128).contains(ingestKeyID.count),
+              (1...4096).contains(probeSigningPublicKeys.count),
+              probeSigningPublicKeys.values.allSatisfy({ $0.count == 65 && $0.first == 0x04 })
+        else { throw RemoteSyncError.invalidConfiguration }
+        self.schema = schema
+        self.workspaceID = workspaceID
+        self.coreDeviceID = coreDeviceID
+        self.relayURL = relayURL
+        self.coreEpoch = coreEpoch
+        self.ingestKeyID = ingestKeyID
+        self.probeSigningPublicKeys = probeSigningPublicKeys
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case schema
+        case workspaceID = "workspace_id"
+        case coreDeviceID = "core_device_id"
+        case relayURL = "relay_url"
+        case coreEpoch = "core_epoch"
+        case ingestKeyID = "ingest_key_id"
+        case probeSigningPublicKeys = "probe_signing_public_keys"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self = try RemoteCoreConfig(
+            schema: container.decode(Int.self, forKey: .schema),
+            workspaceID: container.decode(UUID.self, forKey: .workspaceID),
+            coreDeviceID: container.decode(UUID.self, forKey: .coreDeviceID),
+            relayURL: container.decode(URL.self, forKey: .relayURL),
+            coreEpoch: container.decode(Int.self, forKey: .coreEpoch),
+            ingestKeyID: container.decode(String.self, forKey: .ingestKeyID),
+            probeSigningPublicKeys: try decodeProbeSigningKeys(
+                container.decode([String: Data].self, forKey: .probeSigningPublicKeys)
+            )
+        )
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(schema, forKey: .schema)
+        try container.encode(workspaceID, forKey: .workspaceID)
+        try container.encode(coreDeviceID, forKey: .coreDeviceID)
+        try container.encode(relayURL, forKey: .relayURL)
+        try container.encode(coreEpoch, forKey: .coreEpoch)
+        try container.encode(ingestKeyID, forKey: .ingestKeyID)
+        try container.encode(encodeProbeSigningKeys(probeSigningPublicKeys), forKey: .probeSigningPublicKeys)
+    }
+}
+
+public struct RemoteCoreProvisioning: Codable, Sendable {
+    public let schema: Int
+    public let workspaceID: UUID
+    public let coreDeviceID: UUID
+    public let relayURL: URL
+    public let relayBearerToken: String
+    public let coreEpoch: Int
+    public let ingestKeyID: String
+    public let probeSigningPublicKeys: [UUID: Data]
+
+    public init(
+        schema: Int = 1,
+        workspaceID: UUID,
+        coreDeviceID: UUID,
+        relayURL: URL,
+        relayBearerToken: String,
+        coreEpoch: Int,
+        ingestKeyID: String,
+        probeSigningPublicKeys: [UUID: Data]
+    ) throws {
+        let config = try RemoteCoreConfig(
+            schema: schema,
+            workspaceID: workspaceID,
+            coreDeviceID: coreDeviceID,
+            relayURL: relayURL,
+            coreEpoch: coreEpoch,
+            ingestKeyID: ingestKeyID,
+            probeSigningPublicKeys: probeSigningPublicKeys
+        )
+        guard (32...512).contains(relayBearerToken.utf8.count),
+              relayBearerToken.unicodeScalars.allSatisfy({ !$0.properties.isWhitespace })
+        else { throw RemoteSyncError.invalidConfiguration }
+        self.schema = config.schema
+        self.workspaceID = config.workspaceID
+        self.coreDeviceID = config.coreDeviceID
+        self.relayURL = config.relayURL
+        self.relayBearerToken = relayBearerToken
+        self.coreEpoch = config.coreEpoch
+        self.ingestKeyID = config.ingestKeyID
+        self.probeSigningPublicKeys = config.probeSigningPublicKeys
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case schema
+        case workspaceID = "workspace_id"
+        case coreDeviceID = "core_device_id"
+        case relayURL = "relay_url"
+        case relayBearerToken = "relay_bearer_token"
+        case coreEpoch = "core_epoch"
+        case ingestKeyID = "ingest_key_id"
+        case probeSigningPublicKeys = "probe_signing_public_keys"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self = try RemoteCoreProvisioning(
+            schema: container.decode(Int.self, forKey: .schema),
+            workspaceID: container.decode(UUID.self, forKey: .workspaceID),
+            coreDeviceID: container.decode(UUID.self, forKey: .coreDeviceID),
+            relayURL: container.decode(URL.self, forKey: .relayURL),
+            relayBearerToken: container.decode(String.self, forKey: .relayBearerToken),
+            coreEpoch: container.decode(Int.self, forKey: .coreEpoch),
+            ingestKeyID: container.decode(String.self, forKey: .ingestKeyID),
+            probeSigningPublicKeys: try decodeProbeSigningKeys(
+                container.decode([String: Data].self, forKey: .probeSigningPublicKeys)
+            )
+        )
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(schema, forKey: .schema)
+        try container.encode(workspaceID, forKey: .workspaceID)
+        try container.encode(coreDeviceID, forKey: .coreDeviceID)
+        try container.encode(relayURL, forKey: .relayURL)
+        try container.encode(relayBearerToken, forKey: .relayBearerToken)
+        try container.encode(coreEpoch, forKey: .coreEpoch)
+        try container.encode(ingestKeyID, forKey: .ingestKeyID)
+        try container.encode(encodeProbeSigningKeys(probeSigningPublicKeys), forKey: .probeSigningPublicKeys)
+    }
+}
+
+private func decodeProbeSigningKeys(_ raw: [String: Data]) throws -> [UUID: Data] {
+    var decoded: [UUID: Data] = [:]
+    for (key, value) in raw {
+        guard let deviceID = UUID(uuidString: key), decoded[deviceID] == nil else {
+            throw RemoteSyncError.invalidConfiguration
+        }
+        decoded[deviceID] = value
+    }
+    guard decoded.count == raw.count else { throw RemoteSyncError.invalidConfiguration }
+    return decoded
+}
+
+private func encodeProbeSigningKeys(_ keys: [UUID: Data]) -> [String: Data] {
+    Dictionary(uniqueKeysWithValues: keys.map {
+        ($0.key.uuidString.lowercased(), $0.value)
+    })
+}
+
+public struct RemoteCorePublicDescriptor: Codable, Sendable {
+    public let schema: Int
+    public let signingPublicKey: Data
+    public let recipientPublicKey: Data
+
+    public init(schema: Int = 1, signingPublicKey: Data, recipientPublicKey: Data) {
+        self.schema = schema
+        self.signingPublicKey = signingPublicKey
+        self.recipientPublicKey = recipientPublicKey
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case schema
+        case signingPublicKey = "signing_public_key"
+        case recipientPublicKey = "recipient_public_key"
+    }
+}
+
+public struct RemoteMachineSummary: Identifiable, Equatable, Sendable {
+    public let workspaceID: UUID
+    public let producerID: UUID
+    public let alias: String
+    public let platform: String
+    public let probeVersion: String
+    public let lastSeenAt: Date
+    public let lastScanAt: Date
+    public let lastSequence: Int64
+    public let sourceStatuses: [String: String]
+    public let todayTokens: Int
+    public let last7DaysTokens: Int
+    public let last30DaysTokens: Int
+    public let allTimeTokens: Int
+    public let last30DaysCostUSD: Double
+    public let byTool: [RemoteToolUsageSummary]
+
+    public var id: String { workspaceID.uuidString + ":" + producerID.uuidString }
+}
+
+public struct RemoteToolUsageSummary: Identifiable, Equatable, Sendable {
+    public let tool: String
+    public let tokens: Int
+    public let costUSD: Double
+    public var id: String { tool }
+}
+
+public enum RemoteSyncError: Error, Equatable, Sendable {
+    case notConfigured
+    case invalidConfiguration
+    case invalidEnvelope
+    case unauthorizedProducer
+    case invalidSignature
+    case decryptionFailed
+    case invalidPayload
+    case sequenceGap(expected: Int64, received: Int64)
+    case rollback
+    case http(Int)
+    case invalidResponse
+
+    public var code: String {
+        switch self {
+        case .notConfigured: return "not_configured"
+        case .invalidConfiguration: return "invalid_configuration"
+        case .invalidEnvelope: return "invalid_envelope"
+        case .unauthorizedProducer: return "unauthorized_producer"
+        case .invalidSignature: return "invalid_signature"
+        case .decryptionFailed: return "decryption_failed"
+        case .invalidPayload: return "invalid_payload"
+        case .sequenceGap: return "sequence_gap"
+        case .rollback: return "rollback"
+        case .http: return "relay_http_error"
+        case .invalidResponse: return "invalid_response"
+        }
+    }
+}

--- a/Sources/VibeBarCore/Services/RemoteProbeService.swift
+++ b/Sources/VibeBarCore/Services/RemoteProbeService.swift
@@ -1,0 +1,113 @@
+import Foundation
+import Combine
+
+@MainActor
+public final class RemoteProbeService: ObservableObject {
+    @Published public private(set) var machines: [RemoteMachineSummary] = []
+    @Published public private(set) var isConfigured = false
+    @Published public private(set) var isRefreshing = false
+    @Published public private(set) var lastUpdated: Date?
+    @Published public private(set) var lastErrorCode: String?
+
+    private let config: RemoteCoreConfig?
+    private let identity: RemoteCoreIdentity?
+    private let client: RemoteRelayClient?
+    private let ledger: RemoteUsageLedger?
+    private var refreshLoop: Task<Void, Never>?
+
+    public init() {
+        do {
+            let config = try RemoteCoreConfigStore.load()
+            let identity = try RemoteCoreIdentityStore.loadOrCreate()
+            let bearer = try RemoteCoreIdentityStore.relayBearerToken(
+                workspaceID: config.workspaceID
+            )
+            let ledger = try RemoteUsageLedger()
+            self.config = config
+            self.identity = identity
+            self.client = RemoteRelayClient(config: config, bearerToken: bearer)
+            self.ledger = ledger
+            self.isConfigured = true
+        } catch {
+            self.config = nil
+            self.identity = nil
+            self.client = nil
+            self.ledger = nil
+            self.isConfigured = false
+            self.lastErrorCode = (error as? RemoteSyncError)?.code
+        }
+    }
+
+    public func start() {
+        guard refreshLoop == nil, isConfigured else { return }
+        refreshLoop = Task { [weak self] in
+            while !Task.isCancelled {
+                await self?.refresh()
+                do {
+                    try await Task.sleep(for: .seconds(60))
+                } catch {
+                    break
+                }
+            }
+        }
+    }
+
+    public func stop() {
+        refreshLoop?.cancel()
+        refreshLoop = nil
+    }
+
+    public func refresh() async {
+        guard !isRefreshing,
+              let config, let identity, let client, let ledger
+        else { return }
+        isRefreshing = true
+        defer { isRefreshing = false }
+        do {
+            var cursor = try await ledger.relayCursor(workspaceID: config.workspaceID)
+            var pageCount = 0
+            while pageCount < 100 {
+                pageCount += 1
+                let page = try await client.fetch(after: cursor)
+                guard !page.batches.isEmpty else { break }
+                for batch in page.batches {
+                    let opened = try RemoteProtocolCrypto.openIngestEnvelope(
+                        batch.envelope,
+                        config: config,
+                        identity: identity,
+                        acceptedAt: batch.receivedAt
+                    )
+                    let payload = try RemotePayloadDecoder.decode(opened.plaintext)
+                    guard payload.workspaceID == config.workspaceID,
+                          payload.producerID == opened.producerID
+                    else { throw RemoteSyncError.invalidPayload }
+                    _ = try await ledger.importBatch(
+                        payload,
+                        sequence: opened.sequence,
+                        receivedAt: batch.receivedAt
+                    )
+                    try await client.acknowledge(cursor: batch.cursor)
+                    cursor = batch.cursor
+                    try await ledger.recordSync(
+                        workspaceID: config.workspaceID,
+                        cursor: cursor,
+                        errorCode: nil
+                    )
+                }
+                if page.batches.count < 10 { break }
+            }
+            machines = try await ledger.machineSummaries(workspaceID: config.workspaceID)
+            lastUpdated = Date()
+            lastErrorCode = nil
+        } catch {
+            let code = (error as? RemoteSyncError)?.code ?? "sync_failed"
+            lastErrorCode = code
+            try? await ledger.recordSync(
+                workspaceID: config.workspaceID,
+                cursor: nil,
+                errorCode: code
+            )
+            machines = (try? await ledger.machineSummaries(workspaceID: config.workspaceID)) ?? machines
+        }
+    }
+}

--- a/Sources/VibeBarCore/Services/RemoteProtocolCrypto.swift
+++ b/Sources/VibeBarCore/Services/RemoteProtocolCrypto.swift
@@ -1,0 +1,214 @@
+import Foundation
+import CryptoKit
+import CoreFoundation
+
+enum RemoteCanonicalJSON {
+    static func encode(_ value: Any) throws -> Data {
+        var output = Data()
+        try append(value, to: &output)
+        return output
+    }
+
+    private static func append(_ value: Any, to output: inout Data) throws {
+        switch value {
+        case is NSNull:
+            output.append(contentsOf: "null".utf8)
+        case let number as NSNumber:
+            if CFGetTypeID(number) == CFBooleanGetTypeID() {
+                output.append(contentsOf: (number.boolValue ? "true" : "false").utf8)
+            } else {
+                guard !Self.isFloatingPoint(number) else {
+                    throw RemoteSyncError.invalidEnvelope
+                }
+                let integer = number.int64Value
+                guard NSNumber(value: integer) == number else {
+                    throw RemoteSyncError.invalidEnvelope
+                }
+                output.append(contentsOf: String(integer).utf8)
+            }
+        case let string as String:
+            appendString(string, to: &output)
+        case let array as [Any]:
+            output.append(0x5B)
+            for (index, item) in array.enumerated() {
+                if index > 0 { output.append(0x2C) }
+                try append(item, to: &output)
+            }
+            output.append(0x5D)
+        case let object as [String: Any]:
+            output.append(0x7B)
+            for (index, key) in object.keys.sorted().enumerated() {
+                if index > 0 { output.append(0x2C) }
+                appendString(key, to: &output)
+                output.append(0x3A)
+                guard let item = object[key] else { throw RemoteSyncError.invalidEnvelope }
+                try append(item, to: &output)
+            }
+            output.append(0x7D)
+        default:
+            throw RemoteSyncError.invalidEnvelope
+        }
+    }
+
+    private static func isFloatingPoint(_ number: NSNumber) -> Bool {
+        let type = String(cString: number.objCType)
+        return type == "f" || type == "d"
+    }
+
+    private static func appendString(_ value: String, to output: inout Data) {
+        output.append(0x22)
+        for scalar in value.unicodeScalars {
+            switch scalar.value {
+            case 0x22: output.append(contentsOf: "\\\"".utf8)
+            case 0x5C: output.append(contentsOf: "\\\\".utf8)
+            case 0x08: output.append(contentsOf: "\\b".utf8)
+            case 0x09: output.append(contentsOf: "\\t".utf8)
+            case 0x0A: output.append(contentsOf: "\\n".utf8)
+            case 0x0C: output.append(contentsOf: "\\f".utf8)
+            case 0x0D: output.append(contentsOf: "\\r".utf8)
+            case 0x00...0x1F:
+                output.append(contentsOf: String(format: "\\u%04x", scalar.value).utf8)
+            default:
+                output.append(contentsOf: String(scalar).utf8)
+            }
+        }
+        output.append(0x22)
+    }
+}
+
+struct RemoteOpenedEnvelope {
+    let sequence: Int64
+    let producerID: UUID
+    let plaintext: Data
+}
+
+enum RemoteProtocolCrypto {
+    private static let requiredEnvelopeKeys: Set<String> = [
+        "protocol_version", "minimum_consumer_version", "workspace_id", "stream",
+        "producer_id", "sequence", "core_epoch", "key_id", "created_at", "expires_at",
+        "ephemeral_public_key", "nonce", "ciphertext", "signing_public_key", "signature"
+    ]
+
+    static func openIngestEnvelope(
+        _ data: Data,
+        config: RemoteCoreConfig,
+        identity: RemoteCoreIdentity,
+        acceptedAt: Date = Date()
+    ) throws -> RemoteOpenedEnvelope {
+        guard data.count <= 1_048_576,
+              let object = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+              Set(object.keys) == requiredEnvelopeKeys,
+              exactInteger(object["protocol_version"]) == 1,
+              exactInteger(object["minimum_consumer_version"]) == 1,
+              object["stream"] as? String == "ingest",
+              let workspaceRaw = object["workspace_id"] as? String,
+              let workspaceID = UUID(uuidString: workspaceRaw),
+              workspaceID == config.workspaceID,
+              let producerRaw = object["producer_id"] as? String,
+              let producerID = UUID(uuidString: producerRaw),
+              let expectedSigningKey = config.probeSigningPublicKeys[producerID],
+              let sequence = exactInteger(object["sequence"]), sequence > 0,
+              exactInteger(object["core_epoch"]) == Int64(config.coreEpoch),
+              object["key_id"] as? String == config.ingestKeyID,
+              let createdRaw = object["created_at"] as? String,
+              let expiresRaw = object["expires_at"] as? String,
+              let createdAt = parseTimestamp(createdRaw),
+              let expiresAt = parseTimestamp(expiresRaw),
+              createdAt <= acceptedAt.addingTimeInterval(5 * 60),
+              expiresAt > acceptedAt,
+              expiresAt > createdAt,
+              expiresAt.timeIntervalSince(createdAt) <= 366 * 24 * 60 * 60,
+              let ephemeralRaw = object["ephemeral_public_key"] as? String,
+              let ephemeralData = Data(base64Encoded: ephemeralRaw),
+              ephemeralData.count == 65,
+              let nonceRaw = object["nonce"] as? String,
+              let nonceData = Data(base64Encoded: nonceRaw), nonceData.count == 12,
+              let ciphertextRaw = object["ciphertext"] as? String,
+              let ciphertext = Data(base64Encoded: ciphertextRaw), ciphertext.count >= 16,
+              let signingRaw = object["signing_public_key"] as? String,
+              let signingData = Data(base64Encoded: signingRaw),
+              signingData == expectedSigningKey,
+              let signatureRaw = object["signature"] as? String,
+              let signatureData = Data(base64Encoded: signatureRaw), signatureData.count == 64
+        else { throw RemoteSyncError.invalidEnvelope }
+
+        var unsigned = object
+        unsigned.removeValue(forKey: "signature")
+        let signature = try P256.Signing.ECDSASignature(rawRepresentation: signatureData)
+        let signingKey = try P256.Signing.PublicKey(x963Representation: signingData)
+        guard signingKey.isValidSignature(
+            signature,
+            for: try RemoteCanonicalJSON.encode(unsigned)
+        ) else { throw RemoteSyncError.invalidSignature }
+
+        let ephemeralKey = try P256.KeyAgreement.PublicKey(x963Representation: ephemeralData)
+        let secret = try identity.recipientPrivateKey.sharedSecretFromKeyAgreement(
+            with: ephemeralKey
+        )
+        let symmetricKey = secret.hkdfDerivedSymmetricKey(
+            using: SHA256.self,
+            salt: Data("VibeBar Sync Protocol v1\0".utf8),
+            sharedInfo: hkdfInfo(
+                workspaceID: config.workspaceID,
+                producerID: producerID,
+                sequence: sequence
+            ),
+            outputByteCount: 32
+        )
+        var header = object
+        header.removeValue(forKey: "ciphertext")
+        header.removeValue(forKey: "signature")
+        let sealed = try AES.GCM.SealedBox(
+            nonce: AES.GCM.Nonce(data: nonceData),
+            ciphertext: ciphertext.dropLast(16),
+            tag: ciphertext.suffix(16)
+        )
+        let plaintext: Data
+        do {
+            plaintext = try AES.GCM.open(
+                sealed,
+                using: symmetricKey,
+                authenticating: RemoteCanonicalJSON.encode(header)
+            )
+        } catch {
+            throw RemoteSyncError.decryptionFailed
+        }
+        return RemoteOpenedEnvelope(
+            sequence: sequence,
+            producerID: producerID,
+            plaintext: plaintext
+        )
+    }
+
+    private static func exactInteger(_ value: Any?) -> Int64? {
+        guard let number = value as? NSNumber,
+              CFGetTypeID(number) != CFBooleanGetTypeID()
+        else { return nil }
+        let type = String(cString: number.objCType)
+        guard type != "f", type != "d" else { return nil }
+        return number.int64Value
+    }
+
+    private static func hkdfInfo(
+        workspaceID: UUID,
+        producerID: UUID,
+        sequence: Int64
+    ) -> Data {
+        var output = Data("vibebar/envelope/v1\0ingest\0".utf8)
+        output.append(contentsOf: workspaceID.uuidString.lowercased().utf8)
+        output.append(0)
+        output.append(contentsOf: producerID.uuidString.lowercased().utf8)
+        output.append(0)
+        var bigEndian = UInt64(sequence).bigEndian
+        withUnsafeBytes(of: &bigEndian) { output.append(contentsOf: $0) }
+        return output
+    }
+
+    static func parseTimestamp(_ raw: String) -> Date? {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        if let date = formatter.date(from: raw) { return date }
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter.date(from: raw)
+    }
+}

--- a/Sources/VibeBarCore/Services/RemoteRelayClient.swift
+++ b/Sources/VibeBarCore/Services/RemoteRelayClient.swift
@@ -1,0 +1,148 @@
+import Foundation
+
+private final class RemoteNoRedirectDelegate: NSObject, URLSessionTaskDelegate, @unchecked Sendable {
+    func urlSession(
+        _ session: URLSession,
+        task: URLSessionTask,
+        willPerformHTTPRedirection response: HTTPURLResponse,
+        newRequest request: URLRequest,
+        completionHandler: @escaping (URLRequest?) -> Void
+    ) {
+        completionHandler(nil)
+    }
+}
+
+struct RemoteRelayBatch: Sendable {
+    let cursor: String
+    let receivedAt: Date
+    let envelope: Data
+}
+
+struct RemoteRelayPage: Sendable {
+    let batches: [RemoteRelayBatch]
+    let nextCursor: String
+}
+
+struct RemoteRelayClient: Sendable {
+    let config: RemoteCoreConfig
+    let bearerToken: String
+    let session: URLSession
+
+    init(
+        config: RemoteCoreConfig,
+        bearerToken: String,
+        session: URLSession = RemoteRelayClient.makeSession()
+    ) {
+        self.config = config
+        self.bearerToken = bearerToken
+        self.session = session
+    }
+
+    private static func makeSession() -> URLSession {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.requestCachePolicy = .reloadIgnoringLocalCacheData
+        configuration.urlCache = nil
+        configuration.httpCookieStorage = nil
+        configuration.httpShouldSetCookies = false
+        return URLSession(
+            configuration: configuration,
+            delegate: RemoteNoRedirectDelegate(),
+            delegateQueue: nil
+        )
+    }
+
+    func fetch(after cursor: String?) async throws -> RemoteRelayPage {
+        var components = URLComponents(
+            url: endpoint(resource: "batches"),
+            resolvingAgainstBaseURL: false
+        )
+        var query = [URLQueryItem(name: "limit", value: "10")]
+        if let cursor { query.append(URLQueryItem(name: "after", value: cursor)) }
+        components?.queryItems = query
+        guard let url = components?.url else { throw RemoteSyncError.invalidConfiguration }
+        var request = URLRequest(url: url)
+        request.setValue("Bearer \(bearerToken)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.cachePolicy = .reloadIgnoringLocalCacheData
+        request.timeoutInterval = 30
+        let (data, response) = try await HTTPResponseLimit.boundedData(
+            from: session,
+            for: request,
+            maxBytes: 12 * 1_048_576
+        )
+        try validate(response)
+        guard let object = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+              Set(object.keys) == ["batches", "next_cursor"],
+              let rawBatches = object["batches"] as? [[String: Any]],
+              rawBatches.count <= 10,
+              let nextCursor = object["next_cursor"] as? String
+        else { throw RemoteSyncError.invalidResponse }
+        let batches = try rawBatches.map { raw -> RemoteRelayBatch in
+            guard Set(raw.keys) == ["cursor", "received_at", "envelope"],
+                  let batchCursor = raw["cursor"] as? String,
+                  let received = exactNonnegativeInteger(raw["received_at"]),
+                  let envelope = raw["envelope"] as? [String: Any]
+            else { throw RemoteSyncError.invalidResponse }
+            return RemoteRelayBatch(
+                cursor: batchCursor,
+                receivedAt: Date(timeIntervalSince1970: TimeInterval(received)),
+                envelope: try JSONSerialization.data(withJSONObject: envelope)
+            )
+        }
+        if let last = batches.last, last.cursor != nextCursor {
+            throw RemoteSyncError.invalidResponse
+        }
+        return RemoteRelayPage(batches: batches, nextCursor: nextCursor)
+    }
+
+    func acknowledge(cursor: String) async throws {
+        var request = URLRequest(url: endpoint(resource: "acks"))
+        request.httpMethod = "POST"
+        request.httpBody = try JSONSerialization.data(withJSONObject: ["cursor": cursor])
+        request.setValue("Bearer \(bearerToken)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.cachePolicy = .reloadIgnoringLocalCacheData
+        request.timeoutInterval = 30
+        let (data, response) = try await HTTPResponseLimit.boundedData(
+            from: session,
+            for: request,
+            maxBytes: 64 * 1024
+        )
+        try validate(response)
+        guard let object = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+              Set(object.keys) == ["acknowledged_cursor"],
+              let acknowledged = object["acknowledged_cursor"] as? String,
+              acknowledged == cursor
+        else { throw RemoteSyncError.invalidResponse }
+    }
+
+    private func endpoint(resource: String) -> URL {
+        config.relayURL
+            .appendingPathComponent("v1")
+            .appendingPathComponent("workspaces")
+            .appendingPathComponent(config.workspaceID.uuidString.lowercased())
+            .appendingPathComponent("streams")
+            .appendingPathComponent("ingest")
+            .appendingPathComponent(resource)
+    }
+
+    private func validate(_ response: URLResponse) throws {
+        guard let http = response as? HTTPURLResponse else {
+            throw RemoteSyncError.invalidResponse
+        }
+        guard http.statusCode == 200 else { throw RemoteSyncError.http(http.statusCode) }
+        guard http.value(forHTTPHeaderField: "Cache-Control")?.lowercased().contains("no-store") == true else {
+            throw RemoteSyncError.invalidResponse
+        }
+    }
+
+    private func exactNonnegativeInteger(_ value: Any?) -> Int64? {
+        guard let number = value as? NSNumber,
+              CFGetTypeID(number) != CFBooleanGetTypeID()
+        else { return nil }
+        let type = String(cString: number.objCType)
+        guard type != "f", type != "d", number.int64Value >= 0 else { return nil }
+        return number.int64Value
+    }
+}

--- a/Sources/VibeBarCore/Services/RemoteUsageLedger.swift
+++ b/Sources/VibeBarCore/Services/RemoteUsageLedger.swift
@@ -1,0 +1,615 @@
+import Foundation
+import SQLite3
+
+public actor RemoteUsageLedger {
+    private var database: OpaquePointer?
+    private let transient = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
+
+    public init(url: URL = VibeBarLocalStore.remoteUsageLedgerURL) throws {
+        if url == VibeBarLocalStore.remoteUsageLedgerURL {
+            try VibeBarLocalStore.ensureBaseDirectory()
+        }
+        var handle: OpaquePointer?
+        guard sqlite3_open_v2(
+            url.path,
+            &handle,
+            SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_FULLMUTEX,
+            nil
+        ) == SQLITE_OK, let handle
+        else {
+            if handle != nil { sqlite3_close_v2(handle) }
+            throw RemoteSyncError.invalidConfiguration
+        }
+        sqlite3_busy_timeout(handle, 5_000)
+        do {
+            try Self.initialize(handle)
+            database = handle
+        } catch {
+            sqlite3_close_v2(handle)
+            throw error
+        }
+    }
+
+    deinit {
+        if let database { sqlite3_close_v2(database) }
+    }
+
+    private static func initialize(_ database: OpaquePointer) throws {
+        let sql = """
+            PRAGMA journal_mode=WAL;
+            PRAGMA synchronous=FULL;
+            PRAGMA foreign_keys=ON;
+            CREATE TABLE IF NOT EXISTS remote_machines (
+                workspace_id TEXT NOT NULL,
+                producer_id TEXT NOT NULL,
+                alias TEXT NOT NULL,
+                platform TEXT NOT NULL,
+                timezone TEXT NOT NULL,
+                probe_version TEXT NOT NULL,
+                last_seen_at INTEGER NOT NULL,
+                last_scan_at INTEGER NOT NULL,
+                last_sequence INTEGER NOT NULL,
+                source_status_json TEXT NOT NULL,
+                PRIMARY KEY(workspace_id, producer_id)
+            );
+            CREATE TABLE IF NOT EXISTS remote_source_generations (
+                workspace_id TEXT NOT NULL,
+                producer_id TEXT NOT NULL,
+                source_key TEXT NOT NULL,
+                generation INTEGER NOT NULL,
+                tool TEXT NOT NULL,
+                observed_at INTEGER NOT NULL,
+                PRIMARY KEY(workspace_id, producer_id, source_key)
+            );
+            CREATE TABLE IF NOT EXISTS remote_usage_facts (
+                workspace_id TEXT NOT NULL,
+                producer_id TEXT NOT NULL,
+                event_key TEXT NOT NULL,
+                source_key TEXT NOT NULL,
+                source_generation INTEGER NOT NULL,
+                tool TEXT NOT NULL,
+                occurred_at INTEGER NOT NULL,
+                observed_at INTEGER NOT NULL,
+                model TEXT,
+                input_tokens INTEGER NOT NULL,
+                output_tokens INTEGER NOT NULL,
+                cache_read_tokens INTEGER NOT NULL,
+                cache_creation_tokens INTEGER NOT NULL,
+                reasoning_tokens INTEGER NOT NULL,
+                tool_tokens INTEGER NOT NULL,
+                total_only_tokens INTEGER,
+                request_count INTEGER NOT NULL,
+                service_tier TEXT,
+                accounting TEXT NOT NULL,
+                parser_version INTEGER NOT NULL,
+                PRIMARY KEY(workspace_id, producer_id, event_key)
+            );
+            CREATE INDEX IF NOT EXISTS remote_usage_time_idx
+                ON remote_usage_facts(workspace_id, producer_id, occurred_at);
+            CREATE TABLE IF NOT EXISTS remote_imported_batches (
+                workspace_id TEXT NOT NULL,
+                producer_id TEXT NOT NULL,
+                sequence INTEGER NOT NULL,
+                imported_at INTEGER NOT NULL,
+                PRIMARY KEY(workspace_id, producer_id, sequence)
+            );
+            CREATE TABLE IF NOT EXISTS remote_sync_state (
+                workspace_id TEXT PRIMARY KEY,
+                relay_cursor TEXT,
+                last_sync_at INTEGER,
+                last_error_code TEXT
+            );
+            """
+        guard sqlite3_exec(database, sql, nil, nil, nil) == SQLITE_OK else {
+            throw RemoteSyncError.invalidConfiguration
+        }
+    }
+
+    @discardableResult
+    func importBatch(
+        _ payload: RemoteIngestPayload,
+        sequence: Int64,
+        receivedAt: Date
+    ) throws -> Bool {
+        guard payload.schema == 1 else { throw RemoteSyncError.invalidPayload }
+        let workspace = payload.workspaceID.uuidString.lowercased()
+        let producer = payload.producerID.uuidString.lowercased()
+        try execute("BEGIN IMMEDIATE")
+        do {
+            if try scalarInt64(
+                """
+                SELECT 1 FROM remote_imported_batches
+                WHERE workspace_id = ? AND producer_id = ? AND sequence = ?
+                """,
+                [.text(workspace), .text(producer), .integer(sequence)]
+            ) != nil {
+                try execute("COMMIT")
+                return false
+            }
+            let previous = try scalarInt64(
+                """
+                SELECT last_sequence FROM remote_machines
+                WHERE workspace_id = ? AND producer_id = ?
+                """,
+                [.text(workspace), .text(producer)]
+            )
+            let expected = (previous ?? 0) + 1
+            guard sequence == expected else {
+                if sequence < expected { throw RemoteSyncError.rollback }
+                throw RemoteSyncError.sequenceGap(expected: expected, received: sequence)
+            }
+            guard payload.previousSequence == (sequence == 1 ? nil : sequence - 1) else {
+                throw RemoteSyncError.sequenceGap(expected: expected, received: sequence)
+            }
+
+            for operation in payload.operations {
+                guard case let .sourceReset(reset) = operation else { continue }
+                let current = try sourceGeneration(
+                    workspace: workspace,
+                    producer: producer,
+                    sourceKey: reset.sourceKey
+                )
+                guard reset.sourceGeneration > (current ?? 0) else {
+                    throw RemoteSyncError.rollback
+                }
+                try upsertSourceGeneration(
+                    workspace: workspace,
+                    producer: producer,
+                    sourceKey: reset.sourceKey,
+                    generation: reset.sourceGeneration,
+                    tool: reset.tool,
+                    observedAt: try epoch(reset.observedAt)
+                )
+            }
+
+            for operation in payload.operations {
+                guard case let .usage(usage) = operation else { continue }
+                let current = try sourceGeneration(
+                    workspace: workspace,
+                    producer: producer,
+                    sourceKey: usage.sourceKey
+                ) ?? 1
+                guard usage.sourceGeneration == current else {
+                    throw usage.sourceGeneration < current
+                        ? RemoteSyncError.rollback
+                        : RemoteSyncError.invalidPayload
+                }
+                if try sourceGeneration(
+                    workspace: workspace,
+                    producer: producer,
+                    sourceKey: usage.sourceKey
+                ) == nil {
+                    try upsertSourceGeneration(
+                        workspace: workspace,
+                        producer: producer,
+                        sourceKey: usage.sourceKey,
+                        generation: usage.sourceGeneration,
+                        tool: usage.tool,
+                        observedAt: try epoch(usage.observedAt)
+                    )
+                }
+                try upsertUsage(workspace: workspace, producer: producer, usage: usage)
+            }
+
+            let sourceData = try JSONEncoder.sorted.encode(payload.status.sources)
+            guard let sourceJSON = String(data: sourceData, encoding: .utf8) else {
+                throw RemoteSyncError.invalidPayload
+            }
+            try run(
+                """
+                INSERT INTO remote_machines(
+                       workspace_id, producer_id, alias, platform, timezone, probe_version,
+                       last_seen_at, last_scan_at, last_sequence, source_status_json
+                   ) VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                   ON CONFLICT(workspace_id, producer_id) DO UPDATE SET
+                       alias = excluded.alias,
+                       platform = excluded.platform,
+                       timezone = excluded.timezone,
+                       probe_version = excluded.probe_version,
+                       last_seen_at = excluded.last_seen_at,
+                       last_scan_at = excluded.last_scan_at,
+                       last_sequence = excluded.last_sequence,
+                       source_status_json = excluded.source_status_json
+                """,
+                [
+                    .text(workspace), .text(producer), .text(payload.probe.alias),
+                    .text(payload.probe.platform), .text(payload.probe.timezone),
+                    .text(payload.probe.version), .integer(Int64(receivedAt.timeIntervalSince1970)),
+                    .integer(try epoch(payload.status.lastScanAt)), .integer(sequence),
+                    .text(sourceJSON)
+                ]
+            )
+            try run(
+                """
+                INSERT INTO remote_imported_batches(
+                       workspace_id, producer_id, sequence, imported_at
+                   ) VALUES(?, ?, ?, ?)
+                """,
+                [
+                    .text(workspace), .text(producer), .integer(sequence),
+                    .integer(Int64(receivedAt.timeIntervalSince1970))
+                ]
+            )
+            try execute("COMMIT")
+            return true
+        } catch {
+            try? execute("ROLLBACK")
+            throw error
+        }
+    }
+
+    public func relayCursor(workspaceID: UUID) throws -> String? {
+        try scalarText(
+            "SELECT relay_cursor FROM remote_sync_state WHERE workspace_id = ?",
+            [.text(workspaceID.uuidString.lowercased())]
+        )
+    }
+
+    public func recordSync(
+        workspaceID: UUID,
+        cursor: String?,
+        errorCode: String?,
+        at date: Date = Date()
+    ) throws {
+        try run(
+            """
+            INSERT INTO remote_sync_state(
+                   workspace_id, relay_cursor, last_sync_at, last_error_code
+               ) VALUES(?, ?, ?, ?)
+               ON CONFLICT(workspace_id) DO UPDATE SET
+                   relay_cursor = COALESCE(excluded.relay_cursor, remote_sync_state.relay_cursor),
+                   last_sync_at = excluded.last_sync_at,
+                   last_error_code = excluded.last_error_code
+            """,
+            [
+                .text(workspaceID.uuidString.lowercased()),
+                cursor.map(Binding.text) ?? .null,
+                .integer(Int64(date.timeIntervalSince1970)),
+                errorCode.map(Binding.text) ?? .null
+            ]
+        )
+    }
+
+    public func machineSummaries(
+        workspaceID: UUID,
+        now: Date = Date()
+    ) throws -> [RemoteMachineSummary] {
+        let workspace = workspaceID.uuidString.lowercased()
+        let statement = try prepare(
+            """
+            SELECT producer_id, alias, platform, probe_version, last_seen_at,
+                      last_scan_at, last_sequence, source_status_json
+               FROM remote_machines WHERE workspace_id = ? ORDER BY alias, producer_id
+            """
+        )
+        defer { sqlite3_finalize(statement) }
+        bind(.text(workspace), at: 1, to: statement)
+        var summaries: [RemoteMachineSummary] = []
+        while sqlite3_step(statement) == SQLITE_ROW {
+            guard let producerRaw = columnText(statement, 0),
+                  let producerID = UUID(uuidString: producerRaw),
+                  let alias = columnText(statement, 1),
+                  let platform = columnText(statement, 2),
+                  let version = columnText(statement, 3),
+                  let sourceJSON = columnText(statement, 7),
+                  let sourceData = sourceJSON.data(using: .utf8),
+                  let sourceStatuses = try? JSONDecoder().decode([String: String].self, from: sourceData)
+            else { throw RemoteSyncError.invalidPayload }
+            let usage = try aggregateUsage(
+                workspace: workspace,
+                producer: producerRaw,
+                now: now
+            )
+            summaries.append(
+                RemoteMachineSummary(
+                    workspaceID: workspaceID,
+                    producerID: producerID,
+                    alias: alias,
+                    platform: platform,
+                    probeVersion: version,
+                    lastSeenAt: Date(timeIntervalSince1970: TimeInterval(sqlite3_column_int64(statement, 4))),
+                    lastScanAt: Date(timeIntervalSince1970: TimeInterval(sqlite3_column_int64(statement, 5))),
+                    lastSequence: sqlite3_column_int64(statement, 6),
+                    sourceStatuses: sourceStatuses,
+                    todayTokens: usage.today,
+                    last7DaysTokens: usage.week,
+                    last30DaysTokens: usage.month,
+                    allTimeTokens: usage.all,
+                    last30DaysCostUSD: usage.cost,
+                    byTool: usage.byTool
+                )
+            )
+        }
+        return summaries
+    }
+
+    private func aggregateUsage(
+        workspace: String,
+        producer: String,
+        now: Date
+    ) throws -> (today: Int, week: Int, month: Int, all: Int, cost: Double, byTool: [RemoteToolUsageSummary]) {
+        let calendar = Calendar.current
+        let startToday = calendar.startOfDay(for: now)
+        let startWeek = calendar.date(byAdding: .day, value: -6, to: startToday) ?? startToday
+        let startMonth = calendar.date(byAdding: .day, value: -29, to: startToday) ?? startToday
+        let statement = try prepare(
+            """
+            SELECT tool, occurred_at, model, input_tokens, output_tokens,
+                      cache_read_tokens, cache_creation_tokens, reasoning_tokens,
+                      tool_tokens, total_only_tokens, service_tier
+               FROM remote_usage_facts WHERE workspace_id = ? AND producer_id = ?
+            """
+        )
+        defer { sqlite3_finalize(statement) }
+        bind(.text(workspace), at: 1, to: statement)
+        bind(.text(producer), at: 2, to: statement)
+        var today = 0, week = 0, month = 0, all = 0
+        var byTool: [String: (tokens: Int, cost: Double)] = [:]
+        var monthCost = 0.0
+        while sqlite3_step(statement) == SQLITE_ROW {
+            guard let tool = columnText(statement, 0) else { continue }
+            let date = Date(timeIntervalSince1970: TimeInterval(sqlite3_column_int64(statement, 1)))
+            let row = UsageRow(
+                tool: tool,
+                model: columnText(statement, 2),
+                input: Int(sqlite3_column_int64(statement, 3)),
+                output: Int(sqlite3_column_int64(statement, 4)),
+                cacheRead: Int(sqlite3_column_int64(statement, 5)),
+                cacheCreation: Int(sqlite3_column_int64(statement, 6)),
+                reasoning: Int(sqlite3_column_int64(statement, 7)),
+                toolTokens: Int(sqlite3_column_int64(statement, 8)),
+                totalOnly: sqlite3_column_type(statement, 9) == SQLITE_NULL
+                    ? nil : Int(sqlite3_column_int64(statement, 9)),
+                serviceTier: columnText(statement, 10)
+            )
+            let tokens = row.tokenTotal
+            all = clampedAdd(all, tokens)
+            if date >= startToday { today = clampedAdd(today, tokens) }
+            if date >= startWeek { week = clampedAdd(week, tokens) }
+            if date >= startMonth {
+                month = clampedAdd(month, tokens)
+                let cost = costUSD(row)
+                monthCost += cost
+                byTool[tool, default: (0, 0)].tokens += tokens
+                byTool[tool, default: (0, 0)].cost += cost
+            }
+        }
+        return (
+            today, week, month, all, monthCost,
+            byTool.map { RemoteToolUsageSummary(tool: $0.key, tokens: $0.value.tokens, costUSD: $0.value.cost) }
+                .sorted { $0.tokens > $1.tokens }
+        )
+    }
+
+    private func clampedAdd(_ lhs: Int, _ rhs: Int) -> Int {
+        let (sum, overflow) = lhs.addingReportingOverflow(rhs)
+        return overflow ? Int.max : sum
+    }
+
+    private struct UsageRow {
+        let tool: String
+        let model: String?
+        let input: Int
+        let output: Int
+        let cacheRead: Int
+        let cacheCreation: Int
+        let reasoning: Int
+        let toolTokens: Int
+        let totalOnly: Int?
+        let serviceTier: String?
+        var tokenTotal: Int {
+            totalOnly ?? input + output + cacheRead + cacheCreation + reasoning + toolTokens
+        }
+    }
+
+    private func costUSD(_ row: UsageRow) -> Double {
+        guard row.totalOnly == nil, let model = row.model else { return 0 }
+        switch row.tool {
+        case "codex":
+            return CostUsagePricing.codexCostUSD(
+                model: model,
+                inputTokens: row.input + row.cacheRead,
+                cachedInputTokens: row.cacheRead,
+                outputTokens: row.output,
+                isFast: row.serviceTier == "fast"
+            ) ?? 0
+        case "claude":
+            return CostUsagePricing.claudeCostUSD(
+                model: model,
+                inputTokens: row.input,
+                cacheReadInputTokens: row.cacheRead,
+                cacheCreationInputTokens: row.cacheCreation,
+                outputTokens: row.output,
+                isFast: row.serviceTier == "fast" || row.serviceTier == "priority"
+            ) ?? 0
+        case "antigravity":
+            return CostUsagePricing.antigravityCostUSD(
+                model: model,
+                inputTokens: row.input,
+                cacheReadInputTokens: row.cacheRead,
+                cacheCreationInputTokens: row.cacheCreation,
+                outputTokens: row.output + row.reasoning + row.toolTokens
+            ) ?? 0
+        case "grok":
+            return CostUsagePricing.grokCostUSD(
+                model: model,
+                inputTokens: row.input + row.cacheRead,
+                cachedInputTokens: row.cacheRead,
+                outputTokens: row.output
+            ) ?? 0
+        default:
+            return 0
+        }
+    }
+
+    private func upsertUsage(
+        workspace: String,
+        producer: String,
+        usage: RemoteIngestPayload.Usage
+    ) throws {
+        try run(
+            """
+            INSERT INTO remote_usage_facts(
+                   workspace_id, producer_id, event_key, source_key, source_generation,
+                   tool, occurred_at, observed_at, model, input_tokens, output_tokens,
+                   cache_read_tokens, cache_creation_tokens, reasoning_tokens, tool_tokens,
+                   total_only_tokens, request_count, service_tier, accounting, parser_version
+               ) VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+               ON CONFLICT(workspace_id, producer_id, event_key) DO UPDATE SET
+                   source_key = excluded.source_key,
+                   source_generation = excluded.source_generation,
+                   tool = excluded.tool,
+                   occurred_at = excluded.occurred_at,
+                   observed_at = excluded.observed_at,
+                   model = excluded.model,
+                   input_tokens = excluded.input_tokens,
+                   output_tokens = excluded.output_tokens,
+                   cache_read_tokens = excluded.cache_read_tokens,
+                   cache_creation_tokens = excluded.cache_creation_tokens,
+                   reasoning_tokens = excluded.reasoning_tokens,
+                   tool_tokens = excluded.tool_tokens,
+                   total_only_tokens = excluded.total_only_tokens,
+                   request_count = excluded.request_count,
+                   service_tier = excluded.service_tier,
+                   accounting = excluded.accounting,
+                   parser_version = excluded.parser_version
+            """,
+            [
+                .text(workspace), .text(producer), .text(usage.eventKey), .text(usage.sourceKey),
+                .integer(Int64(usage.sourceGeneration)), .text(usage.tool),
+                .integer(try epoch(usage.occurredAt)), .integer(try epoch(usage.observedAt)),
+                usage.model.map(Binding.text) ?? .null, .integer(Int64(usage.tokens.input)),
+                .integer(Int64(usage.tokens.output)), .integer(Int64(usage.tokens.cacheRead)),
+                .integer(Int64(usage.tokens.cacheCreation)), .integer(Int64(usage.tokens.reasoning)),
+                .integer(Int64(usage.tokens.tool)),
+                usage.tokens.totalOnly.map { .integer(Int64($0)) } ?? .null,
+                .integer(Int64(usage.requestCount)), usage.serviceTier.map(Binding.text) ?? .null,
+                .text(usage.accounting), .integer(Int64(usage.parserVersion))
+            ]
+        )
+    }
+
+    private func sourceGeneration(
+        workspace: String,
+        producer: String,
+        sourceKey: String
+    ) throws -> Int? {
+        try scalarInt64(
+            """
+            SELECT generation FROM remote_source_generations
+            WHERE workspace_id = ? AND producer_id = ? AND source_key = ?
+            """,
+            [.text(workspace), .text(producer), .text(sourceKey)]
+        ).map(Int.init)
+    }
+
+    private func upsertSourceGeneration(
+        workspace: String,
+        producer: String,
+        sourceKey: String,
+        generation: Int,
+        tool: String,
+        observedAt: Int64
+    ) throws {
+        try run(
+            """
+            INSERT INTO remote_source_generations(
+                   workspace_id, producer_id, source_key, generation, tool, observed_at
+               ) VALUES(?, ?, ?, ?, ?, ?)
+               ON CONFLICT(workspace_id, producer_id, source_key) DO UPDATE SET
+                   generation = excluded.generation,
+                   tool = excluded.tool,
+                   observed_at = excluded.observed_at
+            """,
+            [
+                .text(workspace), .text(producer), .text(sourceKey),
+                .integer(Int64(generation)), .text(tool), .integer(observedAt)
+            ]
+        )
+    }
+
+    private enum Binding {
+        case text(String)
+        case integer(Int64)
+        case null
+    }
+
+    private func epoch(_ value: String) throws -> Int64 {
+        guard let date = RemoteProtocolCrypto.parseTimestamp(value) else {
+            throw RemoteSyncError.invalidPayload
+        }
+        return Int64(date.timeIntervalSince1970)
+    }
+
+    private func execute(_ sql: String) throws {
+        guard let database, sqlite3_exec(database, sql, nil, nil, nil) == SQLITE_OK else {
+            throw RemoteSyncError.invalidPayload
+        }
+    }
+
+    private func prepare(_ sql: String) throws -> OpaquePointer {
+        var statement: OpaquePointer?
+        guard let database,
+              sqlite3_prepare_v2(database, sql, -1, &statement, nil) == SQLITE_OK,
+              let statement
+        else { throw RemoteSyncError.invalidPayload }
+        return statement
+    }
+
+    private func run(_ sql: String, _ bindings: [Binding]) throws {
+        let statement = try prepare(sql)
+        defer { sqlite3_finalize(statement) }
+        for (index, value) in bindings.enumerated() {
+            bind(value, at: Int32(index + 1), to: statement)
+        }
+        guard sqlite3_step(statement) == SQLITE_DONE else {
+            throw RemoteSyncError.invalidPayload
+        }
+    }
+
+    private func scalarInt64(_ sql: String, _ bindings: [Binding]) throws -> Int64? {
+        let statement = try prepare(sql)
+        defer { sqlite3_finalize(statement) }
+        for (index, value) in bindings.enumerated() {
+            bind(value, at: Int32(index + 1), to: statement)
+        }
+        let result = sqlite3_step(statement)
+        if result == SQLITE_DONE { return nil }
+        guard result == SQLITE_ROW else { throw RemoteSyncError.invalidPayload }
+        return sqlite3_column_type(statement, 0) == SQLITE_NULL
+            ? nil : sqlite3_column_int64(statement, 0)
+    }
+
+    private func scalarText(_ sql: String, _ bindings: [Binding]) throws -> String? {
+        let statement = try prepare(sql)
+        defer { sqlite3_finalize(statement) }
+        for (index, value) in bindings.enumerated() {
+            bind(value, at: Int32(index + 1), to: statement)
+        }
+        let result = sqlite3_step(statement)
+        if result == SQLITE_DONE { return nil }
+        guard result == SQLITE_ROW else { throw RemoteSyncError.invalidPayload }
+        return columnText(statement, 0)
+    }
+
+    private func bind(_ value: Binding, at index: Int32, to statement: OpaquePointer) {
+        switch value {
+        case let .text(text): sqlite3_bind_text(statement, index, text, -1, transient)
+        case let .integer(integer): sqlite3_bind_int64(statement, index, integer)
+        case .null: sqlite3_bind_null(statement, index)
+        }
+    }
+
+    private func columnText(_ statement: OpaquePointer, _ index: Int32) -> String? {
+        guard let raw = sqlite3_column_text(statement, index) else { return nil }
+        return String(cString: raw)
+    }
+}
+
+private extension JSONEncoder {
+    static var sorted: JSONEncoder {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        return encoder
+    }
+}

--- a/Sources/VibeBarCore/Services/RemoteUsageLedger.swift
+++ b/Sources/VibeBarCore/Services/RemoteUsageLedger.swift
@@ -349,6 +349,10 @@ public actor RemoteUsageLedger {
         while sqlite3_step(statement) == SQLITE_ROW {
             guard let tool = columnText(statement, 0) else { continue }
             let date = Date(timeIntervalSince1970: TimeInterval(sqlite3_column_int64(statement, 1)))
+            // A signed Probe may still have a clock that is ahead of Core.
+            // Keep the fact in the ledger, but do not surface it in any usage
+            // aggregate until its occurrence time has actually arrived.
+            guard date <= now else { continue }
             let row = UsageRow(
                 tool: tool,
                 model: columnText(statement, 2),

--- a/Sources/VibeBarCore/Storage/RemoteCoreConfigStore.swift
+++ b/Sources/VibeBarCore/Storage/RemoteCoreConfigStore.swift
@@ -1,0 +1,67 @@
+import Foundation
+
+public enum RemoteCoreConfigStore {
+    public static func load() throws -> RemoteCoreConfig {
+        let decoded = try VibeBarLocalStore.readJSON(
+            RemoteCoreConfig.self,
+            from: VibeBarLocalStore.remoteCoreConfigURL
+        )
+        return try RemoteCoreConfig(
+            schema: decoded.schema,
+            workspaceID: decoded.workspaceID,
+            coreDeviceID: decoded.coreDeviceID,
+            relayURL: decoded.relayURL,
+            coreEpoch: decoded.coreEpoch,
+            ingestKeyID: decoded.ingestKeyID,
+            probeSigningPublicKeys: decoded.probeSigningPublicKeys
+        )
+    }
+
+    public static func install(_ provisioning: RemoteCoreProvisioning) throws {
+        guard provisioning.schema == 1 else { throw RemoteSyncError.invalidConfiguration }
+        let config = try RemoteCoreConfig(
+            workspaceID: provisioning.workspaceID,
+            coreDeviceID: provisioning.coreDeviceID,
+            relayURL: provisioning.relayURL,
+            coreEpoch: provisioning.coreEpoch,
+            ingestKeyID: provisioning.ingestKeyID,
+            probeSigningPublicKeys: provisioning.probeSigningPublicKeys
+        )
+        // Store the secret first. A crash can leave an unused Vault entry, but
+        // never a plaintext config that claims to be usable without a token.
+        try RemoteCoreIdentityStore.storeRelayBearerToken(
+            provisioning.relayBearerToken,
+            workspaceID: provisioning.workspaceID
+        )
+        try VibeBarLocalStore.writeJSON(config, to: VibeBarLocalStore.remoteCoreConfigURL)
+    }
+
+    public static func install(from url: URL) throws {
+        let attributes = try FileManager.default.attributesOfItem(atPath: url.path)
+        guard attributes[.type] as? FileAttributeType == .typeRegular,
+              let permissions = attributes[.posixPermissions] as? NSNumber,
+              permissions.intValue & 0o077 == 0,
+              let size = attributes[.size] as? NSNumber,
+              (1...1_048_576).contains(size.intValue)
+        else {
+            throw RemoteSyncError.invalidConfiguration
+        }
+        let provisioning = try JSONDecoder().decode(
+            RemoteCoreProvisioning.self,
+            from: Data(contentsOf: url)
+        )
+        try install(provisioning)
+    }
+
+    public static func writePublicDescriptor(to url: URL) throws {
+        let descriptor = try RemoteCoreIdentityStore.loadOrCreate().publicDescriptor
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let data = try encoder.encode(descriptor)
+        try data.write(to: url, options: [.atomic])
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o600],
+            ofItemAtPath: url.path
+        )
+    }
+}

--- a/Sources/VibeBarCore/Storage/VibeBarLocalStore.swift
+++ b/Sources/VibeBarCore/Storage/VibeBarLocalStore.swift
@@ -93,6 +93,19 @@ public enum VibeBarLocalStore {
         baseDirectory.appendingPathComponent("mini_window_geometry.json")
     }
 
+    /// Non-secret workspace, Relay, and registered Probe metadata. Relay
+    /// bearer credentials and Core private keys live in the credential Vault.
+    public static var remoteCoreConfigURL: URL {
+        baseDirectory.appendingPathComponent("remote_core.json")
+    }
+
+    /// Source-aware remote event ledger and consumer cursor. This is separate
+    /// from `cost_history.json`: max-merged daily totals cannot represent
+    /// multiple producers or replay safely.
+    public static var remoteUsageLedgerURL: URL {
+        baseDirectory.appendingPathComponent("remote_usage.sqlite3")
+    }
+
     public static func readData(from url: URL) throws -> Data {
         try Data(contentsOf: url)
     }

--- a/Tests/VibeBarCoreTests/Fixtures/RemoteSync/ingest-p256-v1.json
+++ b/Tests/VibeBarCoreTests/Fixtures/RemoteSync/ingest-p256-v1.json
@@ -1,0 +1,55 @@
+{
+  "description": "Synthetic P-256/HKDF-SHA256/AES-256-GCM/P-256-ECDSA ingest vector",
+  "expected": {
+    "envelope": {
+      "ciphertext": "jaKiZeNAHQ20VXLaGAZHzvtHko5b/yedgS0jqhtZ3Tegdx2nnOv2eb04ih/+3UOevA26cjGGUB5g1jYDBOARrBky3iGUULUzVOU1vLkwgOyohQNmX4XM9KCW0byUUqj6/Cqg8CW8UR8qu1SIzfZeK4cyQkBBvAXUdGdJRrdPf2gr8B0EedU/zv01Ae0c05lbxVjCbMEqntEpkinjbjk4wdFS/rKmQoIT3UWuBeL3drDXRLT5AZKJ5dYUSmVD9uytAAZ2r+COc+CSJlXHM3F9B5KqVYEnitpTo0RfUQUoVG1eK2THkscJ2vfhnoViWUO4AxiypCEzSXK2cuUBF+eSoLMo/XnNFyn8raXN2W0sltaC9qyaCNggE/gTnh1wiSxRI6tmYtWMC7cWFQh8kIonWMSMmIVnWphJK+DjveFOGr6u7dSQKGJe71DCyTalEorRkL/xRT/qyqo0QfQvyzFBHtnhqM00/lnvKXFC1TsBSZyEY5ZI6RnlCoO0AlK1FkdwaVSn39ZWMSn+mDqoLjedLxZx2EJtYd+wCeBWeoz+FspNKmxvOnJfy84DMvWFq9VF2e+rpuekjpX6+bFCvWg06HC6nb2i64fRFg==",
+      "core_epoch": 1,
+      "created_at": "2026-08-03T06:01:00Z",
+      "ephemeral_public_key": "BI5TO2+gv3tGJbswZnwB+2B++fi4qA/vWzAGKHAxh7Kjc+sdveAzGDZtBp+DpvWQAFPHNjPLBBshxV4ahsH0ALQ=",
+      "expires_at": "2026-09-02T06:01:00Z",
+      "key_id": "ingest-epoch-1",
+      "minimum_consumer_version": 1,
+      "nonce": "AAECAwQFBgcICQoL",
+      "producer_id": "22222222-2222-4222-8222-222222222222",
+      "protocol_version": 1,
+      "sequence": 1,
+      "signature": "8WdodvC8HMtmze1gJoRWIsnvoyd9NwwPqvf8iDr7EjB9uLuMx3eMmztPQVu8Eo0Li+n3nDkvWLJi0TEKFJaKyw==",
+      "signing_public_key": "BFFZC3pRUUDS14TIVghmj9/vjIL9H1vlJCFVSg3D0DPt4MF9qJBKcn2K4b82v4p5Jg0BLwDU2AiI0dC7RP2hbaQ=",
+      "stream": "ingest",
+      "workspace_id": "11111111-1111-4111-8111-111111111111"
+    },
+    "recipient_public_key": "BF7L5NGmMwpEyPfvlR1L8WXmxrch762phftBZhvG5/1shzRkDEmY/343SwbOGmSi7NgqsDY4T7g9mnmxJ6J9UDI=",
+    "signing_public_key": "BFFZC3pRUUDS14TIVghmj9/vjIL9H1vlJCFVSg3D0DPt4MF9qJBKcn2K4b82v4p5Jg0BLwDU2AiI0dC7RP2hbaQ="
+  },
+  "inputs": {
+    "ephemeral_private_scalar_hex": "0000000000000000000000000000000000000000000000000000000000000007",
+    "nonce_hex": "000102030405060708090a0b",
+    "payload": {
+      "operations": [],
+      "previous_sequence": null,
+      "probe": {
+        "alias": "Example machine",
+        "platform": "linux-x86_64",
+        "timezone": "UTC",
+        "version": "0.1.0"
+      },
+      "producer_id": "22222222-2222-4222-8222-222222222222",
+      "schema": 1,
+      "status": {
+        "applied_control_sequence": 0,
+        "backlog_batches": 1,
+        "last_scan_at": "2026-08-03T06:01:00Z",
+        "sources": {
+          "antigravity": "absent",
+          "claude": "absent",
+          "codex": "absent",
+          "grok": "absent"
+        }
+      },
+      "workspace_id": "11111111-1111-4111-8111-111111111111"
+    },
+    "recipient_private_scalar_hex": "0000000000000000000000000000000000000000000000000000000000000003",
+    "signing_private_scalar_hex": "0000000000000000000000000000000000000000000000000000000000000005"
+  },
+  "schema": 1
+}

--- a/Tests/VibeBarCoreTests/RemoteSyncTests.swift
+++ b/Tests/VibeBarCoreTests/RemoteSyncTests.swift
@@ -1,0 +1,181 @@
+import XCTest
+import CryptoKit
+@testable import VibeBarCore
+
+final class RemoteSyncTests: XCTestCase {
+    private let workspace = UUID(uuidString: "11111111-1111-4111-8111-111111111111")!
+    private let producer = UUID(uuidString: "22222222-2222-4222-8222-222222222222")!
+
+    func testPythonGoldenVectorDecryptsAndValidates() throws {
+        let vector = try loadVector()
+        let expected = vector["expected"] as! [String: Any]
+        let envelope = expected["envelope"] as! [String: Any]
+        let signing = Data(base64Encoded: expected["signing_public_key"] as! String)!
+        let config = try RemoteCoreConfig(
+            workspaceID: workspace,
+            coreDeviceID: UUID(),
+            relayURL: URL(string: "https://relay.example.invalid")!,
+            coreEpoch: 1,
+            ingestKeyID: "ingest-epoch-1",
+            probeSigningPublicKeys: [producer: signing]
+        )
+        let identity = RemoteCoreIdentity(
+            signingPrivateKey: P256.Signing.PrivateKey(),
+            recipientPrivateKey: try P256.KeyAgreement.PrivateKey(
+                rawRepresentation: scalar(3)
+            )
+        )
+        let data = try JSONSerialization.data(withJSONObject: envelope)
+        let opened = try RemoteProtocolCrypto.openIngestEnvelope(
+            data,
+            config: config,
+            identity: identity,
+            acceptedAt: ISO8601DateFormatter().date(from: "2026-08-04T00:00:00Z")!
+        )
+        let payload = try RemotePayloadDecoder.decode(opened.plaintext)
+        XCTAssertEqual(opened.sequence, 1)
+        XCTAssertEqual(opened.producerID, producer)
+        XCTAssertEqual(payload.probe.alias, "Example machine")
+        XCTAssertTrue(payload.operations.isEmpty)
+    }
+
+    func testGoldenVectorRejectsMutation() throws {
+        let vector = try loadVector()
+        let expected = vector["expected"] as! [String: Any]
+        var envelope = expected["envelope"] as! [String: Any]
+        let signing = Data(base64Encoded: expected["signing_public_key"] as! String)!
+        let config = try RemoteCoreConfig(
+            workspaceID: workspace,
+            coreDeviceID: UUID(),
+            relayURL: URL(string: "https://relay.example.invalid")!,
+            coreEpoch: 1,
+            ingestKeyID: "ingest-epoch-1",
+            probeSigningPublicKeys: [producer: signing]
+        )
+        let identity = RemoteCoreIdentity(
+            signingPrivateKey: P256.Signing.PrivateKey(),
+            recipientPrivateKey: try P256.KeyAgreement.PrivateKey(rawRepresentation: scalar(3))
+        )
+        envelope["key_id"] = "mutated"
+        let data = try JSONSerialization.data(withJSONObject: envelope)
+        XCTAssertThrowsError(
+            try RemoteProtocolCrypto.openIngestEnvelope(
+                data,
+                config: config,
+                identity: identity,
+                acceptedAt: ISO8601DateFormatter().date(from: "2026-08-04T00:00:00Z")!
+            )
+        )
+    }
+
+    func testCoreConfigurationUsesUUIDKeyedJSONObjects() throws {
+        let signing = P256.Signing.PrivateKey().publicKey.x963Representation
+        let provisioning = try RemoteCoreProvisioning(
+            workspaceID: workspace,
+            coreDeviceID: UUID(),
+            relayURL: URL(string: "https://relay.example.invalid")!,
+            relayBearerToken: String(repeating: "t", count: 32),
+            coreEpoch: 1,
+            ingestKeyID: "ingest-epoch-1",
+            probeSigningPublicKeys: [producer: signing]
+        )
+        let encoded = try JSONEncoder().encode(provisioning)
+        let object = try JSONSerialization.jsonObject(with: encoded) as! [String: Any]
+        let keys = try XCTUnwrap(object["probe_signing_public_keys"] as? [String: String])
+        XCTAssertEqual(Set(keys.keys), [producer.uuidString.lowercased()])
+        XCTAssertEqual(try JSONDecoder().decode(RemoteCoreProvisioning.self, from: encoded).workspaceID, workspace)
+    }
+
+    func testLedgerIsIdempotentAndStopsAtSequenceGap() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("remote-ledger-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: false)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let ledger = try RemoteUsageLedger(url: directory.appendingPathComponent("ledger.sqlite3"))
+        let first = try RemotePayloadDecoder.decode(payload(sequence: 1, previous: nil, generation: 1))
+        let inserted = try await ledger.importBatch(first, sequence: 1, receivedAt: Date())
+        XCTAssertTrue(inserted)
+        let duplicate = try await ledger.importBatch(first, sequence: 1, receivedAt: Date())
+        XCTAssertFalse(duplicate)
+
+        let third = try RemotePayloadDecoder.decode(payload(sequence: 3, previous: 2, generation: 1))
+        do {
+            _ = try await ledger.importBatch(third, sequence: 3, receivedAt: Date())
+            XCTFail("Expected a visible sequence gap")
+        } catch let error as RemoteSyncError {
+            XCTAssertEqual(error, .sequenceGap(expected: 2, received: 3))
+        }
+        let summaries = try await ledger.machineSummaries(
+            workspaceID: workspace,
+            now: ISO8601DateFormatter().date(from: "2026-08-03T12:00:00Z")!
+        )
+        XCTAssertEqual(summaries.count, 1)
+        XCTAssertEqual(summaries[0].todayTokens, 15)
+        XCTAssertEqual(summaries[0].lastSequence, 1)
+    }
+
+    func testPayloadRejectsUnknownPrivacyField() throws {
+        var object = try JSONSerialization.jsonObject(
+            with: payload(sequence: 1, previous: nil, generation: 1)
+        ) as! [String: Any]
+        object["transcript"] = "must never be accepted"
+        XCTAssertThrowsError(
+            try RemotePayloadDecoder.decode(JSONSerialization.data(withJSONObject: object))
+        )
+    }
+
+    private func payload(sequence: Int, previous: Int?, generation: Int) throws -> Data {
+        let operation: [String: Any] = [
+            "op": "usage_upsert",
+            "source_key": String(repeating: "s", count: 43),
+            "source_generation": generation,
+            "event_key": String(repeating: "e", count: 42) + String(sequence),
+            "tool": "codex",
+            "occurred_at": "2026-08-03T06:00:00Z",
+            "observed_at": "2026-08-03T06:01:00Z",
+            "model": "example-model",
+            "tokens": [
+                "input": 10, "output": 5, "cache_read": 0,
+                "cache_creation": 0, "reasoning": 0, "tool": 0,
+                "total_only": NSNull()
+            ],
+            "request_count": 1,
+            "service_tier": NSNull(),
+            "accounting": "exact",
+            "parser_version": 1
+        ]
+        let body: [String: Any] = [
+            "schema": 1,
+            "workspace_id": workspace.uuidString.lowercased(),
+            "producer_id": producer.uuidString.lowercased(),
+            "probe": [
+                "alias": "Example machine", "version": "0.1.0",
+                "platform": "linux-x86_64", "timezone": "UTC"
+            ],
+            "previous_sequence": previous.map { $0 as Any } ?? NSNull(),
+            "operations": [operation],
+            "status": [
+                "last_scan_at": "2026-08-03T06:01:00Z",
+                "backlog_batches": 1,
+                "applied_control_sequence": 0,
+                "sources": ["codex": "ok"]
+            ]
+        ]
+        return try JSONSerialization.data(withJSONObject: body)
+    }
+
+    private func loadVector() throws -> [String: Any] {
+        let file = try XCTUnwrap(
+            Bundle.module.url(
+                forResource: "ingest-p256-v1",
+                withExtension: "json",
+                subdirectory: "RemoteSync"
+            )
+        )
+        return try JSONSerialization.jsonObject(with: Data(contentsOf: file)) as! [String: Any]
+    }
+
+    private func scalar(_ value: UInt8) -> Data {
+        Data(repeating: 0, count: 31) + Data([value])
+    }
+}

--- a/Tests/VibeBarCoreTests/RemoteSyncTests.swift
+++ b/Tests/VibeBarCoreTests/RemoteSyncTests.swift
@@ -124,14 +124,58 @@ final class RemoteSyncTests: XCTestCase {
         )
     }
 
-    private func payload(sequence: Int, previous: Int?, generation: Int) throws -> Data {
+    func testLedgerExcludesFutureEventsUntilTheyOccur() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("remote-ledger-future-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: false)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let ledger = try RemoteUsageLedger(url: directory.appendingPathComponent("ledger.sqlite3"))
+        let current = try RemotePayloadDecoder.decode(
+            payload(sequence: 1, previous: nil, generation: 1)
+        )
+        let future = try RemotePayloadDecoder.decode(
+            payload(
+                sequence: 2,
+                previous: 1,
+                generation: 1,
+                occurredAt: "2026-08-04T06:00:00Z"
+            )
+        )
+        _ = try await ledger.importBatch(current, sequence: 1, receivedAt: Date())
+        _ = try await ledger.importBatch(future, sequence: 2, receivedAt: Date())
+
+        let before = try await ledger.machineSummaries(
+            workspaceID: workspace,
+            now: ISO8601DateFormatter().date(from: "2026-08-03T12:00:00Z")!
+        )
+        XCTAssertEqual(before[0].todayTokens, 15)
+        XCTAssertEqual(before[0].last7DaysTokens, 15)
+        XCTAssertEqual(before[0].last30DaysTokens, 15)
+        XCTAssertEqual(before[0].allTimeTokens, 15)
+
+        let after = try await ledger.machineSummaries(
+            workspaceID: workspace,
+            now: ISO8601DateFormatter().date(from: "2026-08-04T12:00:00Z")!
+        )
+        XCTAssertEqual(after[0].todayTokens, 15)
+        XCTAssertEqual(after[0].last7DaysTokens, 30)
+        XCTAssertEqual(after[0].last30DaysTokens, 30)
+        XCTAssertEqual(after[0].allTimeTokens, 30)
+    }
+
+    private func payload(
+        sequence: Int,
+        previous: Int?,
+        generation: Int,
+        occurredAt: String = "2026-08-03T06:00:00Z"
+    ) throws -> Data {
         let operation: [String: Any] = [
             "op": "usage_upsert",
             "source_key": String(repeating: "s", count: 43),
             "source_generation": generation,
             "event_key": String(repeating: "e", count: 42) + String(sequence),
             "tool": "codex",
-            "occurred_at": "2026-08-03T06:00:00Z",
+            "occurred_at": occurredAt,
             "observed_at": "2026-08-03T06:01:00Z",
             "model": "example-model",
             "tokens": [


### PR DESCRIPTION
## Summary\n- add workspace-scoped Core identity and secure Relay provisioning\n- verify and decrypt E2EE Probe batches into a source-aware SQLite ledger\n- add a minimal Machines surface for remote usage\n\n## Architecture\n- Relay ciphertext and cursors remain on the Relay node\n- Mac Core is the only ingest decryptor in this thin slice\n- Web/frontend work is intentionally deferred\n\n## Test plan\n- [x] swift build\n- [x] swift test (1076 tests)\n- [x] ./Scripts/build_app.sh release\n- [x] codesign --verify --deep --strict\n- [x] empty unsandboxed entitlements verified