### PR TITLE
Add Remote Probes settings pane with import, export, disconnect

### DIFF
--- a/Sources/VibeBarApp/Views/RemoteSettingsSection.swift
+++ b/Sources/VibeBarApp/Views/RemoteSettingsSection.swift
@@ -66,7 +66,7 @@ struct RemoteSettingsSection: View {
 
     private var provisioningSection: some View {
         section("Provisioning") {
-            Text("Pairing runs in three steps: export this Mac's Core identity, register it with your Relay to produce a provisioning file, then import that file here. The provisioning file embeds a Relay credential — it is stored in the macOS Keychain, never on disk.")
+            Text("Pairing runs in three steps: export this Mac's Core identity, register it with your Relay to produce a provisioning file, then import that file here. Importing moves the Relay credential into the macOS Keychain — but the provisioning file itself still contains that credential, so delete the file once the import succeeds.")
                 .font(.caption)
                 .foregroundStyle(.secondary)
 
@@ -110,6 +110,11 @@ struct RemoteSettingsSection: View {
         panel.title = "Export Core Identity Descriptor"
         guard panel.runModal() == .OK, let url = panel.url else { return }
         do {
+            // Narrow, deliberate exception to the "never write outside
+            // ~/.vibebar/" rule (AGENTS.md § coding conventions): the
+            // destination is chosen by the user in a save panel, the payload
+            // is public-key material only, and the file lands 0600 — the
+            // same contract as the --remote-identity-descriptor launch flag.
             try RemoteCoreConfigStore.writePublicDescriptor(to: url)
             exportStatus = "Descriptor exported. It contains public keys only."
         } catch {
@@ -130,7 +135,7 @@ struct RemoteSettingsSection: View {
         do {
             try RemoteCoreConfigStore.install(from: url)
             service.reconfigure()
-            importStatus = "Provisioning installed. Syncing with the Relay now."
+            importStatus = "Provisioning installed. Syncing with the Relay now. Delete the provisioning file — it still contains the Relay credential."
         } catch {
             importError = importHint(for: url, underlying: error)
         }
@@ -144,9 +149,16 @@ struct RemoteSettingsSection: View {
         let attributes = try? FileManager.default.attributesOfItem(atPath: url.path)
         if let permissions = attributes?[.posixPermissions] as? NSNumber,
            permissions.intValue & 0o077 != 0 {
-            return "Import failed: the file must be readable by you alone. Run: chmod 600 \"\(url.path)\" and import again."
+            return "Import failed: the file must be readable by you alone. Run: chmod 600 \(shellQuoted(url.path)) and import again."
         }
         return "Import failed: \(shortCode(error)). Check that this is an unmodified provisioning file for this Mac."
+    }
+
+    /// POSIX single-quote escaping so a filename containing shell
+    /// metacharacters (quotes, `$(...)`) stays inert if the user copies the
+    /// suggested command into Terminal.
+    private func shellQuoted(_ path: String) -> String {
+        "'" + path.replacingOccurrences(of: "'", with: "'\\''") + "'"
     }
 
     // MARK: - Disconnect

--- a/Sources/VibeBarApp/Views/RemoteSettingsSection.swift
+++ b/Sources/VibeBarApp/Views/RemoteSettingsSection.swift
@@ -1,0 +1,234 @@
+import AppKit
+import SwiftUI
+import UniformTypeIdentifiers
+import VibeBarCore
+
+/// Settings pane for the remote-probe Core. Surfaces everything that was
+/// previously reachable only through the hidden `--remote-identity-descriptor`
+/// and `--install-remote-provisioning` launch flags: connection status,
+/// identity export, provisioning import, and disconnect. Secrets never
+/// transit this view — the descriptor is public-key material and the
+/// provisioning file is consumed by `RemoteCoreConfigStore.install(from:)`,
+/// which routes the bearer token straight into the credential Vault.
+struct RemoteSettingsSection: View {
+    @ObservedObject var service: RemoteProbeService
+
+    @State private var exportStatus: String?
+    @State private var importStatus: String?
+    @State private var importError: String?
+    @State private var confirmingDisconnect = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 18) {
+            statusSection
+            provisioningSection
+            if service.isConfigured {
+                disconnectSection
+            }
+        }
+    }
+
+    // MARK: - Status
+
+    private var statusSection: some View {
+        section("Remote Core") {
+            if service.isConfigured {
+                infoRow("Workspace", service.workspaceID?.uuidString.lowercased() ?? "—")
+                infoRow("Relay", service.relayURL?.absoluteString ?? "—")
+                infoRow("Registered probes", "\(service.registeredProbeCount)")
+                infoRow("Machines synced", "\(service.machines.count)")
+                infoRow("Last sync", lastSyncText)
+                if let code = service.lastErrorCode {
+                    Text("Latest sync error: \(code)")
+                        .font(.caption2)
+                        .foregroundStyle(.orange)
+                }
+                Button {
+                    Task { await service.refresh() }
+                } label: {
+                    Label("Sync now", systemImage: "arrow.triangle.2.circlepath")
+                }
+                .disabled(service.isRefreshing)
+            } else {
+                Text("This Mac is not connected to a workspace. Remote probes collect normalized usage on your other machines, encrypt it to this Mac's Core keys, and drop it at a Relay — no inbound port is ever opened here.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    private var lastSyncText: String {
+        guard let date = service.lastUpdated else { return "never" }
+        return date.formatted(date: .abbreviated, time: .shortened)
+    }
+
+    // MARK: - Provisioning
+
+    private var provisioningSection: some View {
+        section("Provisioning") {
+            Text("Pairing runs in three steps: export this Mac's Core identity, register it with your Relay to produce a provisioning file, then import that file here. The provisioning file embeds a Relay credential — it is stored in the macOS Keychain, never on disk.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            HStack(spacing: 10) {
+                Button {
+                    exportDescriptor()
+                } label: {
+                    Label("Export Core Identity…", systemImage: "square.and.arrow.up")
+                }
+                Button {
+                    importProvisioning()
+                } label: {
+                    Label("Import Provisioning File…", systemImage: "square.and.arrow.down")
+                }
+            }
+
+            if let exportStatus {
+                Text(exportStatus)
+                    .font(.caption2)
+                    .foregroundStyle(.green)
+            }
+            if let importStatus {
+                Text(importStatus)
+                    .font(.caption2)
+                    .foregroundStyle(.green)
+            }
+            if let importError {
+                Text(importError)
+                    .font(.caption2)
+                    .foregroundStyle(.orange)
+                    .textSelection(.enabled)
+            }
+        }
+    }
+
+    private func exportDescriptor() {
+        exportStatus = nil
+        let panel = NSSavePanel()
+        panel.allowedContentTypes = [.json]
+        panel.nameFieldStringValue = "vibebar-core-descriptor.json"
+        panel.title = "Export Core Identity Descriptor"
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+        do {
+            try RemoteCoreConfigStore.writePublicDescriptor(to: url)
+            exportStatus = "Descriptor exported. It contains public keys only."
+        } catch {
+            exportStatus = nil
+            importError = "Export failed: \(shortCode(error))"
+        }
+    }
+
+    private func importProvisioning() {
+        importStatus = nil
+        importError = nil
+        let panel = NSOpenPanel()
+        panel.allowedContentTypes = [.json]
+        panel.allowsMultipleSelection = false
+        panel.canChooseDirectories = false
+        panel.title = "Import Remote Provisioning File"
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+        do {
+            try RemoteCoreConfigStore.install(from: url)
+            service.reconfigure()
+            importStatus = "Provisioning installed. Syncing with the Relay now."
+        } catch {
+            importError = importHint(for: url, underlying: error)
+        }
+    }
+
+    /// `install(from:)` rejects group/world-readable files by design; a file
+    /// straight out of Downloads usually fails that check. Distinguish the
+    /// permissions case so the fix is one obvious command, without loosening
+    /// the store's rule.
+    private func importHint(for url: URL, underlying error: Error) -> String {
+        let attributes = try? FileManager.default.attributesOfItem(atPath: url.path)
+        if let permissions = attributes?[.posixPermissions] as? NSNumber,
+           permissions.intValue & 0o077 != 0 {
+            return "Import failed: the file must be readable by you alone. Run: chmod 600 \"\(url.path)\" and import again."
+        }
+        return "Import failed: \(shortCode(error)). Check that this is an unmodified provisioning file for this Mac."
+    }
+
+    // MARK: - Disconnect
+
+    private var disconnectSection: some View {
+        section("Disconnect") {
+            Text("Disconnecting removes this Mac's Relay credential from the Keychain and its workspace binding. Probes keep uploading to the Relay until they are revoked there. Usage already decrypted stays in the local ledger.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            Button(role: .destructive) {
+                confirmingDisconnect = true
+            } label: {
+                Label("Disconnect from Workspace…", systemImage: "bolt.slash")
+            }
+            .confirmationDialog(
+                "Disconnect from this workspace?",
+                isPresented: $confirmingDisconnect,
+                titleVisibility: .visible
+            ) {
+                Button("Disconnect", role: .destructive) {
+                    disconnect()
+                }
+                Button("Cancel", role: .cancel) {}
+            } message: {
+                Text("Reconnecting later requires a new provisioning file.")
+            }
+        }
+    }
+
+    private func disconnect() {
+        do {
+            try RemoteCoreConfigStore.uninstall()
+            service.reconfigure()
+            importStatus = nil
+            importError = nil
+            exportStatus = nil
+        } catch {
+            importError = "Disconnect failed: \(shortCode(error))"
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func shortCode(_ error: Error) -> String {
+        (error as? RemoteSyncError)?.code ?? error.localizedDescription
+    }
+
+    private func infoRow(_ label: String, _ value: String) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: 8) {
+            Text(label)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .frame(width: 128, alignment: .leading)
+            Text(value)
+                .font(.caption.monospaced())
+                .textSelection(.enabled)
+        }
+    }
+
+    /// Mirrors SettingsView.settingsSection so this pane matches the other
+    /// pages without widening that private helper's access.
+    private func section<Content: View>(
+        _ title: String,
+        @ViewBuilder content: () -> Content
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text(title)
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(.secondary)
+            VStack(alignment: .leading, spacing: 10) {
+                content()
+            }
+            .padding(12)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .fill(Color.primary.opacity(0.045))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .stroke(Color.primary.opacity(0.08), lineWidth: 0.6)
+            )
+        }
+    }
+}

--- a/Sources/VibeBarApp/Views/SettingsSidebarView.swift
+++ b/Sources/VibeBarApp/Views/SettingsSidebarView.swift
@@ -18,6 +18,7 @@ struct SettingsSidebarView: View {
     private let basicPages: [SettingsSectionID] = [
         .system,
         .costData,
+        .remote,
         .privacy,
         .menuBar,
         .miniWindow,

--- a/Sources/VibeBarApp/Views/SettingsView.swift
+++ b/Sources/VibeBarApp/Views/SettingsView.swift
@@ -13,6 +13,7 @@ enum SettingsSectionID: String {
     case system
     case costData
     case privacy
+    case remote
 
     var id: String { rawValue }
 
@@ -29,6 +30,7 @@ enum SettingsSectionID: String {
         case .system: "System"
         case .costData: "Cost Data"
         case .privacy: "Privacy"
+        case .remote: "Remote Probes"
         }
     }
 
@@ -45,6 +47,7 @@ enum SettingsSectionID: String {
         case .system: "desktopcomputer"
         case .costData: "chart.bar.xaxis"
         case .privacy: "hand.raised.fill"
+        case .remote: "antenna.radiowaves.left.and.right"
         }
     }
 }
@@ -578,6 +581,11 @@ struct SettingsView: View {
                             .foregroundStyle(.tertiary)
                     }
                     .id(SettingsSectionID.costData.id)
+                    }
+
+                    if selectedSection == .remote {
+                    RemoteSettingsSection(service: environment.remoteProbeService)
+                        .id(SettingsSectionID.remote.id)
                     }
 
                     if selectedSection == .privacy {

--- a/Sources/VibeBarCore/Credentials/RemoteCoreIdentityStore.swift
+++ b/Sources/VibeBarCore/Credentials/RemoteCoreIdentityStore.swift
@@ -84,6 +84,17 @@ public enum RemoteCoreIdentityStore {
         )
     }
 
+    static func deleteRelayBearerToken(workspaceID: UUID) throws {
+        do {
+            try VibeBarCredentialVault.delete(
+                service: service,
+                account: relayAccount(workspaceID)
+            )
+        } catch KeychainStore.KeychainError.itemNotFound {
+            // Already gone — deletion is idempotent.
+        }
+    }
+
     private static func relayAccount(_ workspaceID: UUID) -> String {
         "relay:" + workspaceID.uuidString.lowercased()
     }

--- a/Sources/VibeBarCore/Services/RemoteProbeService.swift
+++ b/Sources/VibeBarCore/Services/RemoteProbeService.swift
@@ -9,13 +9,23 @@ public final class RemoteProbeService: ObservableObject {
     @Published public private(set) var lastUpdated: Date?
     @Published public private(set) var lastErrorCode: String?
 
-    private let config: RemoteCoreConfig?
-    private let identity: RemoteCoreIdentity?
-    private let client: RemoteRelayClient?
-    private let ledger: RemoteUsageLedger?
+    private var config: RemoteCoreConfig?
+    private var identity: RemoteCoreIdentity?
+    private var client: RemoteRelayClient?
+    private var ledger: RemoteUsageLedger?
     private var refreshLoop: Task<Void, Never>?
 
+    /// Workspace this Core is bound to, for status display. Never a secret.
+    public var workspaceID: UUID? { config?.workspaceID }
+    public var coreDeviceID: UUID? { config?.coreDeviceID }
+    public var relayURL: URL? { config?.relayURL }
+    public var registeredProbeCount: Int { config?.probeSigningPublicKeys.count ?? 0 }
+
     public init() {
+        loadConfiguration()
+    }
+
+    private func loadConfiguration() {
         do {
             let config = try RemoteCoreConfigStore.load()
             let identity = try RemoteCoreIdentityStore.loadOrCreate()
@@ -28,13 +38,27 @@ public final class RemoteProbeService: ObservableObject {
             self.client = RemoteRelayClient(config: config, bearerToken: bearer)
             self.ledger = ledger
             self.isConfigured = true
+            self.lastErrorCode = nil
         } catch {
             self.config = nil
             self.identity = nil
             self.client = nil
             self.ledger = nil
             self.isConfigured = false
+            self.machines = []
+            self.lastUpdated = nil
             self.lastErrorCode = (error as? RemoteSyncError)?.code
+        }
+    }
+
+    /// Re-read provisioning from disk after the settings pane installs or
+    /// removes it, so a restart is never required. Stops the refresh loop,
+    /// reloads, and resumes only when a valid configuration is present.
+    public func reconfigure() {
+        stop()
+        loadConfiguration()
+        if isConfigured {
+            start()
         }
     }
 

--- a/Sources/VibeBarCore/Services/RemoteProbeService.swift
+++ b/Sources/VibeBarCore/Services/RemoteProbeService.swift
@@ -14,6 +14,10 @@ public final class RemoteProbeService: ObservableObject {
     private var client: RemoteRelayClient?
     private var ledger: RemoteUsageLedger?
     private var refreshLoop: Task<Void, Never>?
+    /// Bumped by every (re)load. An in-flight refresh() captured the previous
+    /// configuration; it must stop publishing (and acknowledging) the moment
+    /// this no longer matches the generation it started under.
+    private var configurationGeneration = 0
 
     /// Workspace this Core is bound to, for status display. Never a secret.
     public var workspaceID: UUID? { config?.workspaceID }
@@ -26,6 +30,7 @@ public final class RemoteProbeService: ObservableObject {
     }
 
     private func loadConfiguration() {
+        configurationGeneration += 1
         do {
             let config = try RemoteCoreConfigStore.load()
             let identity = try RemoteCoreIdentityStore.loadOrCreate()
@@ -52,13 +57,21 @@ public final class RemoteProbeService: ObservableObject {
     }
 
     /// Re-read provisioning from disk after the settings pane installs or
-    /// removes it, so a restart is never required. Stops the refresh loop,
-    /// reloads, and resumes only when a valid configuration is present.
+    /// removes it, so a restart is never required. Cancels and awaits the old
+    /// refresh loop before reloading, so a sync captured under the previous
+    /// configuration can never interleave with the new one; stray refreshes
+    /// started outside the loop are fenced by `configurationGeneration`.
     public func reconfigure() {
-        stop()
-        loadConfiguration()
-        if isConfigured {
-            start()
+        let oldLoop = refreshLoop
+        refreshLoop?.cancel()
+        refreshLoop = nil
+        Task { [weak self] in
+            await oldLoop?.value
+            guard let self else { return }
+            self.loadConfiguration()
+            if self.isConfigured {
+                self.start()
+            }
         }
     }
 
@@ -85,6 +98,7 @@ public final class RemoteProbeService: ObservableObject {
         guard !isRefreshing,
               let config, let identity, let client, let ledger
         else { return }
+        let generation = configurationGeneration
         isRefreshing = true
         defer { isRefreshing = false }
         do {
@@ -93,6 +107,7 @@ public final class RemoteProbeService: ObservableObject {
             while pageCount < 100 {
                 pageCount += 1
                 let page = try await client.fetch(after: cursor)
+                guard generation == configurationGeneration else { return }
                 guard !page.batches.isEmpty else { break }
                 for batch in page.batches {
                     let opened = try RemoteProtocolCrypto.openIngestEnvelope(
@@ -120,10 +135,13 @@ public final class RemoteProbeService: ObservableObject {
                 }
                 if page.batches.count < 10 { break }
             }
-            machines = try await ledger.machineSummaries(workspaceID: config.workspaceID)
+            let summaries = try await ledger.machineSummaries(workspaceID: config.workspaceID)
+            guard generation == configurationGeneration else { return }
+            machines = summaries
             lastUpdated = Date()
             lastErrorCode = nil
         } catch {
+            guard generation == configurationGeneration else { return }
             let code = (error as? RemoteSyncError)?.code ?? "sync_failed"
             lastErrorCode = code
             try? await ledger.recordSync(
@@ -131,7 +149,9 @@ public final class RemoteProbeService: ObservableObject {
                 cursor: nil,
                 errorCode: code
             )
-            machines = (try? await ledger.machineSummaries(workspaceID: config.workspaceID)) ?? machines
+            let summaries = try? await ledger.machineSummaries(workspaceID: config.workspaceID)
+            guard generation == configurationGeneration else { return }
+            machines = summaries ?? machines
         }
     }
 }

--- a/Sources/VibeBarCore/Services/RemoteProbeService.swift
+++ b/Sources/VibeBarCore/Services/RemoteProbeService.swift
@@ -14,6 +14,12 @@ public final class RemoteProbeService: ObservableObject {
     private var client: RemoteRelayClient?
     private var ledger: RemoteUsageLedger?
     private var refreshLoop: Task<Void, Never>?
+    /// The one sync currently executing, whether the loop, the settings
+    /// pane's Sync now, or AppEnvironment started it. refresh() serializes
+    /// on this so syncs never overlap, and reconfigure() drains it so no
+    /// refresh from the old configuration is still running when the new one
+    /// loads.
+    private var activeRefresh: Task<Void, Never>?
     /// Bumped by every (re)load. An in-flight refresh() captured the previous
     /// configuration; it must stop publishing (and acknowledging) the moment
     /// this no longer matches the generation it started under.
@@ -67,6 +73,12 @@ public final class RemoteProbeService: ObservableObject {
         refreshLoop = nil
         Task { [weak self] in
             await oldLoop?.value
+            // Also drain refreshes launched outside the loop (Sync now,
+            // AppEnvironment.refreshAll) so the restarted loop's first pass
+            // runs immediately instead of skipping and sleeping 60s.
+            while let active = self?.activeRefresh {
+                await active.value
+            }
             guard let self else { return }
             self.loadConfiguration()
             if self.isConfigured {
@@ -95,6 +107,19 @@ public final class RemoteProbeService: ObservableObject {
     }
 
     public func refresh() async {
+        // Serialize: wait out any in-flight sync, then run a full pass of our
+        // own. Piled-up callers each get a pass; the cursor-based protocol
+        // makes back-to-back passes cheap no-ops.
+        while let existing = activeRefresh {
+            await existing.value
+        }
+        let task = Task { await performRefresh() }
+        activeRefresh = task
+        await task.value
+        activeRefresh = nil
+    }
+
+    private func performRefresh() async {
         guard !isRefreshing,
               let config, let identity, let client, let ledger
         else { return }

--- a/Sources/VibeBarCore/Storage/RemoteCoreConfigStore.swift
+++ b/Sources/VibeBarCore/Storage/RemoteCoreConfigStore.swift
@@ -53,6 +53,19 @@ public enum RemoteCoreConfigStore {
         try install(provisioning)
     }
 
+    /// Remove this Mac's workspace binding. The relay credential leaves the
+    /// Vault first, then the non-secret config file — mirroring install(),
+    /// which stores the secret first. The decrypted usage ledger stays: it
+    /// is the user's own data and re-provisioning must not lose history.
+    public static func uninstall() throws {
+        if let config = try? load() {
+            try RemoteCoreIdentityStore.deleteRelayBearerToken(
+                workspaceID: config.workspaceID
+            )
+        }
+        try VibeBarLocalStore.deleteFile(at: VibeBarLocalStore.remoteCoreConfigURL)
+    }
+
     public static func writePublicDescriptor(to url: URL) throws {
         let descriptor = try RemoteCoreIdentityStore.loadOrCreate().publicDescriptor
         let encoder = JSONEncoder()

--- a/Sources/VibeBarCore/Storage/RemoteCoreConfigStore.swift
+++ b/Sources/VibeBarCore/Storage/RemoteCoreConfigStore.swift
@@ -19,6 +19,7 @@ public enum RemoteCoreConfigStore {
 
     public static func install(_ provisioning: RemoteCoreProvisioning) throws {
         guard provisioning.schema == 1 else { throw RemoteSyncError.invalidConfiguration }
+        let previous = try? load()
         let config = try RemoteCoreConfig(
             workspaceID: provisioning.workspaceID,
             coreDeviceID: provisioning.coreDeviceID,
@@ -34,6 +35,15 @@ public enum RemoteCoreConfigStore {
             workspaceID: provisioning.workspaceID
         )
         try VibeBarLocalStore.writeJSON(config, to: VibeBarLocalStore.remoteCoreConfigURL)
+        // Replacing workspace A with workspace B must not strand A's
+        // still-valid Relay credential in the Vault. Best-effort, and only
+        // after the new configuration has committed, so a cleanup failure
+        // can't break an otherwise successful install.
+        if let previous, previous.workspaceID != provisioning.workspaceID {
+            try? RemoteCoreIdentityStore.deleteRelayBearerToken(
+                workspaceID: previous.workspaceID
+            )
+        }
     }
 
     public static func install(from url: URL) throws {


### PR DESCRIPTION
## Summary

The remote Core shipped in 1.3.0-dev.15 was configurable only through the hidden `--remote-identity-descriptor` / `--install-remote-provisioning` launch flags. This surfaces the whole flow in Settings under a new **Remote Probes** page:

- Connection status: workspace, relay endpoint, registered probes, machines synced, last sync + error code, manual "Sync now"
- **Export Core Identity…** — save panel, public-key descriptor only
- **Import Provisioning File…** — open panel into `RemoteCoreConfigStore.install(from:)`; the bearer token goes straight to the Keychain Vault. The store's owner-only file-permission rule is kept; a too-open file now gets an actionable `chmod 600` hint instead of a bare error code
- **Disconnect** — confirmation dialog; removes the Vault credential and workspace binding, keeps the decrypted usage ledger
- `RemoteProbeService.reconfigure()` so install/remove takes effect without relaunching

## Verification

- `swift build` ✓
- `swift test` — 1077 tests, 0 failures ✓
- `./Scripts/build_app.sh release` ✓
- `codesign -d --entitlements` — empty dict, no app-sandbox ✓
- Sandbox container absent ✓
- Launch smoke skipped deliberately: the production Vibe Bar instance was running; same-bundle-ID launch would collide with it

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>