### PR TITLE
Join a workspace with a one-time control-center code

### DIFF
--- a/Sources/VibeBarApp/Views/RemoteSettingsSection.swift
+++ b/Sources/VibeBarApp/Views/RemoteSettingsSection.swift
@@ -24,11 +24,15 @@ struct RemoteSettingsSection: View {
     @State private var showControlURLField = false
     @State private var isJoining = false
     @State private var joinError: String?
-    /// A workspace that accepted this Mac but whose credential could not be
-    /// saved locally. The pairing code is single-use and already spent, so the
-    /// result is held in memory — never rendered, never logged — until the
-    /// save succeeds or the user discards it.
+    /// A workspace that accepted this Mac but whose credential is not saved
+    /// yet. Mirrors the record in the credential Vault so the pane can offer a
+    /// resume; never rendered, never logged.
     @State private var pendingEnrollment: RemoteEnrollmentResult?
+    /// True when the pending record came from the Vault on appearance rather
+    /// than from a failure in this session — the affordance is then "resume",
+    /// not "retry", and deserves an explanation.
+    @State private var pendingWasRestored = false
+    @State private var confirmingDiscardPending = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: 18) {
@@ -38,6 +42,9 @@ struct RemoteSettingsSection: View {
                 disconnectSection
             }
         }
+        // Only here, and only as an offer: a join is never completed behind
+        // the user's back.
+        .onAppear { restorePendingEnrollment() }
     }
 
     // MARK: - Status
@@ -172,16 +179,31 @@ struct RemoteSettingsSection: View {
                     .textSelection(.enabled)
             }
             if pendingEnrollment != nil {
+                if pendingWasRestored {
+                    Text("A previous join was accepted by the control center but never finished saving on this Mac. Its pairing code is already spent, so resume the save instead of requesting a new code.")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
                 HStack(spacing: 10) {
                     Button {
                         retrySavingEnrollment()
                     } label: {
-                        Label("Retry saving", systemImage: "arrow.clockwise")
+                        Label(
+                            pendingWasRestored ? "Resume saving" : "Retry saving",
+                            systemImage: "arrow.clockwise"
+                        )
                     }
-                    Button("Discard") {
-                        pendingEnrollment = nil
-                        joinError = nil
-                    }
+                    Button("Discard") { confirmingDiscardPending = true }
+                }
+                .confirmationDialog(
+                    "Discard this pending join?",
+                    isPresented: $confirmingDiscardPending,
+                    titleVisibility: .visible
+                ) {
+                    Button("Discard", role: .destructive) { discardPendingEnrollment() }
+                    Button("Cancel", role: .cancel) {}
+                } message: {
+                    Text("Its pairing code is already spent, and the workspace still counts this Mac as its Core. To join again, revoke this Mac in the web control center, then create a fresh code.")
                 }
             }
         }
@@ -213,6 +235,13 @@ struct RemoteSettingsSection: View {
                 )
                 let enrollment = try await client.enrollCore(code: code)
                 joinCode = ""
+                // The code is spent the moment the control center answers, so
+                // put the result somewhere durable *before* touching the
+                // config — quitting between here and a successful save must
+                // not destroy the only copy. Starting another join supersedes
+                // this record; if the Vault write itself fails we simply fall
+                // through to the in-memory path, which is no worse than before.
+                try? RemoteCoreConfigStore.retainPendingEnrollment(enrollment)
                 saveEnrollment(enrollment)
             } catch let error as RemoteEnrollmentError {
                 joinError = error.message
@@ -229,14 +258,16 @@ struct RemoteSettingsSection: View {
     @MainActor
     private func saveEnrollment(_ enrollment: RemoteEnrollmentResult) {
         do {
+            // install() clears the retained record once the binding commits.
             try RemoteCoreConfigStore.install(enrollment)
             pendingEnrollment = nil
+            pendingWasRestored = false
             joinError = nil
             service.reconfigure()
             importStatus = "Joined the workspace as this Mac's Core. Syncing with the Relay; machines appear automatically as probes enroll."
         } catch {
             pendingEnrollment = enrollment
-            joinError = "The workspace accepted this Mac, but saving its credential here failed: \(shortCode(error)). The pairing code is already used — don't request a new one. Fix the problem (unlock the Keychain, free up disk space) and choose Retry saving."
+            joinError = "The workspace accepted this Mac, but saving its credential here failed: \(shortCode(error)). The pairing code is already used — don't request a new one. Fix the problem (unlock the Keychain, free up disk space) and save again; the join is kept until you do."
         }
     }
 
@@ -244,6 +275,25 @@ struct RemoteSettingsSection: View {
     private func retrySavingEnrollment() {
         guard let enrollment = pendingEnrollment else { return }
         saveEnrollment(enrollment)
+    }
+
+    /// Offer an unfinished join from an earlier session. Read-only: the
+    /// install itself still waits for the user to ask for it.
+    @MainActor
+    private func restorePendingEnrollment() {
+        guard pendingEnrollment == nil, !service.isConfigured,
+              let retained = RemoteCoreConfigStore.pendingEnrollment()
+        else { return }
+        pendingEnrollment = retained
+        pendingWasRestored = true
+    }
+
+    @MainActor
+    private func discardPendingEnrollment() {
+        RemoteCoreConfigStore.discardPendingEnrollment()
+        pendingEnrollment = nil
+        pendingWasRestored = false
+        joinError = nil
     }
 
     private func exportDescriptor() {
@@ -341,7 +391,7 @@ struct RemoteSettingsSection: View {
             exportStatus = nil
             joinError = nil
             joinCode = ""
-            pendingEnrollment = nil
+            discardPendingEnrollment()
         } catch {
             importError = "Disconnect failed: \(shortCode(error))"
         }

--- a/Sources/VibeBarApp/Views/RemoteSettingsSection.swift
+++ b/Sources/VibeBarApp/Views/RemoteSettingsSection.swift
@@ -17,6 +17,13 @@ struct RemoteSettingsSection: View {
     @State private var importStatus: String?
     @State private var importError: String?
     @State private var confirmingDisconnect = false
+    @State private var joinCode = ""
+    /// The hosted control center. Editable so a self-hosted deployment can be
+    /// paired without a provisioning file; the client still requires HTTPS.
+    @State private var controlURL = "https://vibebar.aqor.io"
+    @State private var showControlURLField = false
+    @State private var isJoining = false
+    @State private var joinError: String?
 
     var body: some View {
         VStack(alignment: .leading, spacing: 18) {
@@ -66,6 +73,13 @@ struct RemoteSettingsSection: View {
 
     private var provisioningSection: some View {
         section("Provisioning") {
+            if !service.isConfigured {
+                joinWithCode
+                Divider()
+                Text("Or pair manually.")
+                    .font(.caption.weight(.medium))
+                    .foregroundStyle(.secondary)
+            }
             Text("Pairing runs in three steps: export this Mac's Core identity, register it with your Relay to produce a provisioning file, then import that file here. Importing moves the Relay credential into the macOS Keychain — but the provisioning file itself still contains that credential, so delete the file once the import succeeds.")
                 .font(.caption)
                 .foregroundStyle(.secondary)
@@ -98,6 +112,95 @@ struct RemoteSettingsSection: View {
                     .font(.caption2)
                     .foregroundStyle(.orange)
                     .textSelection(.enabled)
+            }
+        }
+    }
+
+    // MARK: - Join with code
+
+    /// The one-step path: paste the one-time code the web control center
+    /// shows, and this Mac mints a fresh Core keypair, registers its public
+    /// halves, and installs the same configuration a provisioning file would
+    /// have carried. The code is single-use and short-lived, so it is never
+    /// persisted or logged.
+    private var joinWithCode: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Join with a code")
+                .font(.caption.weight(.medium))
+                .foregroundStyle(.secondary)
+            Text("Create a Core code in the Vibe Bar control center, then paste it here. This Mac joins as “\(deviceName)”.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            HStack(spacing: 8) {
+                TextField("VB-XXXXX-XXXXX", text: $joinCode)
+                    .textFieldStyle(.roundedBorder)
+                    .font(.caption.monospaced())
+                    .frame(width: 190)
+                    .disabled(isJoining)
+                    .onSubmit { join() }
+                Button("Join") { join() }
+                    .disabled(isJoining || trimmedJoinCode.isEmpty)
+                if isJoining {
+                    ProgressView()
+                        .controlSize(.small)
+                }
+                Spacer(minLength: 0)
+            }
+
+            Toggle("Use a different control center", isOn: $showControlURLField)
+                .toggleStyle(.checkbox)
+                .font(.caption)
+                .disabled(isJoining)
+            if showControlURLField {
+                TextField("https://vibebar.aqor.io", text: $controlURL)
+                    .textFieldStyle(.roundedBorder)
+                    .font(.caption.monospaced())
+                    .frame(maxWidth: 320)
+                    .disabled(isJoining)
+            }
+
+            if let joinError {
+                Text(joinError)
+                    .font(.caption2)
+                    .foregroundStyle(.orange)
+                    .textSelection(.enabled)
+            }
+        }
+    }
+
+    private var trimmedJoinCode: String {
+        joinCode.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private var deviceName: String {
+        RemoteEnrollmentClient.defaultDeviceName()
+    }
+
+    @MainActor
+    private func join() {
+        guard !isJoining, !trimmedJoinCode.isEmpty else { return }
+        let code = trimmedJoinCode
+        let control = controlURL
+        joinError = nil
+        importStatus = nil
+        importError = nil
+        isJoining = true
+        Task {
+            defer { isJoining = false }
+            do {
+                let client = try RemoteEnrollmentClient(
+                    controlURL: RemoteEnrollmentClient.controlURL(from: control)
+                )
+                let enrollment = try await client.enrollCore(code: code)
+                try RemoteCoreConfigStore.install(enrollment)
+                service.reconfigure()
+                joinCode = ""
+                importStatus = "Joined the workspace as this Mac's Core. Syncing with the Relay now. Enroll your other machines in the control center to see them here."
+            } catch let error as RemoteEnrollmentError {
+                joinError = error.message
+            } catch {
+                joinError = "Join failed: \(shortCode(error)). The code was accepted but this Mac could not store the credential."
             }
         }
     }
@@ -183,7 +286,7 @@ struct RemoteSettingsSection: View {
                 }
                 Button("Cancel", role: .cancel) {}
             } message: {
-                Text("Reconnecting later requires a new provisioning file.")
+                Text("Reconnecting later requires a new pairing code or provisioning file.")
             }
         }
     }
@@ -195,6 +298,8 @@ struct RemoteSettingsSection: View {
             importStatus = nil
             importError = nil
             exportStatus = nil
+            joinError = nil
+            joinCode = ""
         } catch {
             importError = "Disconnect failed: \(shortCode(error))"
         }

--- a/Sources/VibeBarApp/Views/RemoteSettingsSection.swift
+++ b/Sources/VibeBarApp/Views/RemoteSettingsSection.swift
@@ -24,6 +24,11 @@ struct RemoteSettingsSection: View {
     @State private var showControlURLField = false
     @State private var isJoining = false
     @State private var joinError: String?
+    /// A workspace that accepted this Mac but whose credential could not be
+    /// saved locally. The pairing code is single-use and already spent, so the
+    /// result is held in memory — never rendered, never logged — until the
+    /// save succeeds or the user discards it.
+    @State private var pendingEnrollment: RemoteEnrollmentResult?
 
     var body: some View {
         VStack(alignment: .leading, spacing: 18) {
@@ -166,6 +171,19 @@ struct RemoteSettingsSection: View {
                     .foregroundStyle(.orange)
                     .textSelection(.enabled)
             }
+            if pendingEnrollment != nil {
+                HStack(spacing: 10) {
+                    Button {
+                        retrySavingEnrollment()
+                    } label: {
+                        Label("Retry saving", systemImage: "arrow.clockwise")
+                    }
+                    Button("Discard") {
+                        pendingEnrollment = nil
+                        joinError = nil
+                    }
+                }
+            }
         }
     }
 
@@ -185,6 +203,7 @@ struct RemoteSettingsSection: View {
         joinError = nil
         importStatus = nil
         importError = nil
+        pendingEnrollment = nil
         isJoining = true
         Task {
             defer { isJoining = false }
@@ -193,16 +212,38 @@ struct RemoteSettingsSection: View {
                     controlURL: RemoteEnrollmentClient.controlURL(from: control)
                 )
                 let enrollment = try await client.enrollCore(code: code)
-                try RemoteCoreConfigStore.install(enrollment)
-                service.reconfigure()
                 joinCode = ""
-                importStatus = "Joined the workspace as this Mac's Core. Syncing with the Relay now. Enroll your other machines in the control center to see them here."
+                saveEnrollment(enrollment)
             } catch let error as RemoteEnrollmentError {
                 joinError = error.message
             } catch {
-                joinError = "Join failed: \(shortCode(error)). The code was accepted but this Mac could not store the credential."
+                joinError = "Join failed: \(shortCode(error))."
             }
         }
+    }
+
+    /// The only place the enrollment reaches disk and the Keychain. Splitting
+    /// it out of the network exchange is what makes "Retry saving" possible:
+    /// the code has already been consumed by the time this runs, so a local
+    /// failure must never send the user back for a second code.
+    @MainActor
+    private func saveEnrollment(_ enrollment: RemoteEnrollmentResult) {
+        do {
+            try RemoteCoreConfigStore.install(enrollment)
+            pendingEnrollment = nil
+            joinError = nil
+            service.reconfigure()
+            importStatus = "Joined the workspace as this Mac's Core. Syncing with the Relay; machines appear automatically as probes enroll."
+        } catch {
+            pendingEnrollment = enrollment
+            joinError = "The workspace accepted this Mac, but saving its credential here failed: \(shortCode(error)). The pairing code is already used — don't request a new one. Fix the problem (unlock the Keychain, free up disk space) and choose Retry saving."
+        }
+    }
+
+    @MainActor
+    private func retrySavingEnrollment() {
+        guard let enrollment = pendingEnrollment else { return }
+        saveEnrollment(enrollment)
     }
 
     private func exportDescriptor() {
@@ -300,6 +341,7 @@ struct RemoteSettingsSection: View {
             exportStatus = nil
             joinError = nil
             joinCode = ""
+            pendingEnrollment = nil
         } catch {
             importError = "Disconnect failed: \(shortCode(error))"
         }

--- a/Sources/VibeBarCore/Credentials/RemoteCoreIdentityStore.swift
+++ b/Sources/VibeBarCore/Credentials/RemoteCoreIdentityStore.swift
@@ -16,6 +16,7 @@ public struct RemoteCoreIdentity: Sendable {
 public enum RemoteCoreIdentityStore {
     private static let service = "com.astroqore.VibeBar.remote-sync"
     private static let identityAccount = "core-identity-v1"
+    private static let pendingEnrollmentAccount = "pending-enrollment-v1"
 
     private struct Payload: Codable {
         let schema: Int
@@ -74,6 +75,93 @@ public enum RemoteCoreIdentityStore {
             data: try encoder.encode(payload)
         )
     }
+
+    // MARK: - Pending enrollment
+
+    /// An enrollment the control center has already consumed but that this Mac
+    /// has not finished installing.
+    ///
+    /// The record carries the Relay bearer token and this Mac's Core private
+    /// keys, so it lives in the credential Vault and nowhere else — never on
+    /// disk, never in a log. One slot: starting another join supersedes it,
+    /// because only one enrollment can be outstanding at a time.
+    private struct PendingPayload: Codable {
+        let schema: Int
+        let provisioning: RemoteCoreProvisioning
+        let signingPrivateKey: Data
+        let recipientPrivateKey: Data
+        let deviceName: String
+
+        private enum CodingKeys: String, CodingKey {
+            case schema
+            case provisioning
+            case signingPrivateKey = "signing_private_key"
+            case recipientPrivateKey = "recipient_private_key"
+            case deviceName = "device_name"
+        }
+    }
+
+    /// Kept pure so the round-trip — including the private keys — is testable
+    /// without touching the Keychain.
+    static func encodePendingEnrollment(_ enrollment: RemoteEnrollmentResult) throws -> Data {
+        let payload = PendingPayload(
+            schema: 1,
+            provisioning: enrollment.provisioning,
+            signingPrivateKey: enrollment.identity.signingPrivateKey.rawRepresentation,
+            recipientPrivateKey: enrollment.identity.recipientPrivateKey.rawRepresentation,
+            deviceName: enrollment.deviceName
+        )
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        return try encoder.encode(payload)
+    }
+
+    static func decodePendingEnrollment(_ data: Data) throws -> RemoteEnrollmentResult {
+        let payload = try JSONDecoder().decode(PendingPayload.self, from: data)
+        guard payload.schema == 1 else { throw RemoteSyncError.invalidConfiguration }
+        return RemoteEnrollmentResult(
+            provisioning: payload.provisioning,
+            identity: RemoteCoreIdentity(
+                signingPrivateKey: try P256.Signing.PrivateKey(
+                    rawRepresentation: payload.signingPrivateKey
+                ),
+                recipientPrivateKey: try P256.KeyAgreement.PrivateKey(
+                    rawRepresentation: payload.recipientPrivateKey
+                )
+            ),
+            deviceName: payload.deviceName
+        )
+    }
+
+    static func storePendingEnrollment(_ enrollment: RemoteEnrollmentResult) throws {
+        try VibeBarCredentialVault.writeData(
+            service: service,
+            account: pendingEnrollmentAccount,
+            data: try encodePendingEnrollment(enrollment)
+        )
+    }
+
+    static func pendingEnrollment() throws -> RemoteEnrollmentResult {
+        try decodePendingEnrollment(
+            try VibeBarCredentialVault.readData(
+                service: service,
+                account: pendingEnrollmentAccount
+            )
+        )
+    }
+
+    static func deletePendingEnrollment() throws {
+        do {
+            try VibeBarCredentialVault.delete(
+                service: service,
+                account: pendingEnrollmentAccount
+            )
+        } catch KeychainStore.KeychainError.itemNotFound {
+            // Already gone — deletion is idempotent.
+        }
+    }
+
+    // MARK: - Relay credential
 
     public static func relayBearerToken(workspaceID: UUID) throws -> String {
         try VibeBarCredentialVault.readString(

--- a/Sources/VibeBarCore/Credentials/RemoteCoreIdentityStore.swift
+++ b/Sources/VibeBarCore/Credentials/RemoteCoreIdentityStore.swift
@@ -50,20 +50,29 @@ public enum RemoteCoreIdentityStore {
                 signingPrivateKey: P256.Signing.PrivateKey(),
                 recipientPrivateKey: P256.KeyAgreement.PrivateKey()
             )
-            let payload = Payload(
-                schema: 1,
-                signingPrivateKey: identity.signingPrivateKey.rawRepresentation,
-                recipientPrivateKey: identity.recipientPrivateKey.rawRepresentation
-            )
-            let encoder = JSONEncoder()
-            encoder.outputFormatting = [.sortedKeys]
-            try VibeBarCredentialVault.writeData(
-                service: service,
-                account: identityAccount,
-                data: try encoder.encode(payload)
-            )
+            try store(identity)
             return identity
         }
+    }
+
+    /// Persist an identity generated elsewhere. Joining a workspace with a
+    /// one-time code mints a fresh keypair and registers its public halves
+    /// with the control center, so the private halves must replace whatever
+    /// this Mac held — the previously exported descriptor no longer describes
+    /// the workspace's Core recipient key.
+    static func store(_ identity: RemoteCoreIdentity) throws {
+        let payload = Payload(
+            schema: 1,
+            signingPrivateKey: identity.signingPrivateKey.rawRepresentation,
+            recipientPrivateKey: identity.recipientPrivateKey.rawRepresentation
+        )
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        try VibeBarCredentialVault.writeData(
+            service: service,
+            account: identityAccount,
+            data: try encoder.encode(payload)
+        )
     }
 
     public static func relayBearerToken(workspaceID: UUID) throws -> String {

--- a/Sources/VibeBarCore/Models/RemoteSyncModels.swift
+++ b/Sources/VibeBarCore/Models/RemoteSyncModels.swift
@@ -27,9 +27,13 @@ public struct RemoteCoreConfig: Codable, Equatable, Sendable {
               relayURL.query == nil,
               relayURL.fragment == nil
         else { throw RemoteSyncError.invalidConfiguration }
+        // An empty probe map is legitimate: a Mac that has just joined a
+        // workspace is the Core before any probe has enrolled. It simply
+        // authorizes no producer yet, so every envelope is refused until the
+        // workspace registers its first probe.
         guard (1..<Int(Int32.max)).contains(coreEpoch),
               (1...128).contains(ingestKeyID.count),
-              (1...4096).contains(probeSigningPublicKeys.count),
+              (0...4096).contains(probeSigningPublicKeys.count),
               probeSigningPublicKeys.values.allSatisfy({ $0.count == 65 && $0.first == 0x04 })
         else { throw RemoteSyncError.invalidConfiguration }
         self.schema = schema

--- a/Sources/VibeBarCore/Services/RemoteEnrollmentClient.swift
+++ b/Sources/VibeBarCore/Services/RemoteEnrollmentClient.swift
@@ -1,0 +1,330 @@
+import Foundation
+import CryptoKit
+import CoreFoundation
+
+/// Everything a successful `POST /api/v1/enroll/consume` produced: the same
+/// non-secret configuration + Relay credential a provisioning file carries,
+/// plus the freshly generated Core identity whose public halves the control
+/// center just registered. Nothing here is installed yet — the caller decides
+/// when to commit it through `RemoteCoreConfigStore.install(_:)`, so a failed
+/// enrollment can never leave a half-written binding behind.
+public struct RemoteEnrollmentResult: Sendable {
+    public let provisioning: RemoteCoreProvisioning
+    public let identity: RemoteCoreIdentity
+    /// Server-assigned display name for this Mac, echoed back for the UI.
+    public let deviceName: String
+}
+
+/// Failure taxonomy for the join-with-code flow. Every case carries a short
+/// stable `code` for logs and a human-readable `message` for the settings
+/// pane. Neither ever contains the pairing code, the bearer token, or key
+/// material — see AGENTS.md § 8.
+public enum RemoteEnrollmentError: Error, Equatable, Sendable {
+    /// The control-center address is not a bare `https://host` origin.
+    case invalidControlURL
+    /// The pasted code is empty or not shaped like a pairing code.
+    case invalidCode
+    /// HTTP 404 `{"error": "invalid_code"}` — unknown, consumed, or expired.
+    case codeRejected
+    /// HTTP 409 `{"error": "core_exists"}` — the workspace already has a Core.
+    case coreExists
+    /// The grant was minted for a probe, so this Mac must not consume it.
+    case wrongRole(String)
+    /// HTTP 429 — the device endpoint's per-IP token bucket.
+    case rateLimited
+    /// Any other non-201 status.
+    case server(Int)
+    /// Transport failure: DNS, TLS, offline, timeout.
+    case network
+    /// 201 whose body does not match the documented contract.
+    case malformedResponse
+    /// The control center echoed a Core key other than the one this Mac just
+    /// generated, so nothing encrypted to it could ever be opened here.
+    case coreKeyMismatch
+
+    public var code: String {
+        switch self {
+        case .invalidControlURL: return "invalid_control_url"
+        case .invalidCode: return "invalid_pairing_code"
+        case .codeRejected: return "invalid_code"
+        case .coreExists: return "core_exists"
+        case .wrongRole: return "wrong_role"
+        case .rateLimited: return "rate_limited"
+        case .server: return "control_http_error"
+        case .network: return "network_unreachable"
+        case .malformedResponse: return "malformed_response"
+        case .coreKeyMismatch: return "core_key_mismatch"
+        }
+    }
+
+    public var message: String {
+        switch self {
+        case .invalidControlURL:
+            return "The control center address must be an https:// origin with no path, such as https://vibebar.aqor.io."
+        case .invalidCode:
+            return "That doesn't look like a pairing code. Copy the code shown in the control center, for example VB-XXXXX-XXXXX."
+        case .codeRejected:
+            return "This pairing code is unknown, already used, or expired. Generate a fresh one in the control center — codes last 15 minutes."
+        case .coreExists:
+            return "This workspace already has a Core Mac. Revoke the existing Core in the control center, then join again."
+        case .wrongRole(let role):
+            return "This code enrolls a \(role), not a Core Mac. Create a Core code in the control center and try again."
+        case .rateLimited:
+            return "Too many join attempts from this network. Wait a minute and try again."
+        case .server(let status):
+            return "The control center returned an unexpected error (HTTP \(status)). Try again in a moment."
+        case .network:
+            return "Could not reach the control center. Check your network connection and the address, then try again."
+        case .malformedResponse:
+            return "The control center returned a response Vibe Bar could not use. Confirm the address points at your Vibe Bar control center."
+        case .coreKeyMismatch:
+            return "The control center registered a different Core key than this Mac generated. Join again with a fresh code."
+        }
+    }
+}
+
+/// Consumes a one-time pairing code from the web control center so this Mac
+/// becomes a workspace's Core without a provisioning file.
+///
+/// The exchange is deliberately one-shot and side-effect free: a fresh signing
+/// and a fresh key-agreement P-256 keypair are generated in memory, only their
+/// public halves leave the machine, and the private halves are handed back to
+/// the caller inside `RemoteEnrollmentResult`. They reach the credential Vault
+/// only when the caller installs the result, so an HTTP failure, a malformed
+/// body, or a rejected code all leave the existing Core identity untouched.
+public struct RemoteEnrollmentClient: Sendable {
+    /// AstroQore's hosted control center. Callers may point at another
+    /// deployment; the origin is still required to be HTTPS.
+    public static let defaultControlURL = URL(string: "https://vibebar.aqor.io")!
+
+    private let controlURL: URL
+    private let session: URLSession
+
+    /// - Throws: `RemoteEnrollmentError.invalidControlURL` unless `controlURL`
+    ///   is a bare HTTPS origin. Mirrors the `relayURL` rule in
+    ///   `RemoteCoreConfig` so both endpoints are validated identically.
+    public init(
+        controlURL: URL = RemoteEnrollmentClient.defaultControlURL,
+        session: URLSession = RemoteEnrollmentClient.makeSession()
+    ) throws {
+        guard controlURL.scheme?.lowercased() == "https",
+              controlURL.host != nil,
+              controlURL.user == nil,
+              controlURL.password == nil,
+              controlURL.path.isEmpty || controlURL.path == "/",
+              controlURL.query == nil,
+              controlURL.fragment == nil
+        else { throw RemoteEnrollmentError.invalidControlURL }
+        self.controlURL = controlURL
+        self.session = session
+    }
+
+    /// Parses a user-typed control-center address. Empty input falls back to
+    /// the hosted default so the advanced field can be left blank.
+    public static func controlURL(from raw: String) throws -> URL {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return defaultControlURL }
+        guard let url = URL(string: trimmed) else {
+            throw RemoteEnrollmentError.invalidControlURL
+        }
+        return url
+    }
+
+    public static func makeSession() -> URLSession {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.requestCachePolicy = .reloadIgnoringLocalCacheData
+        configuration.urlCache = nil
+        configuration.httpCookieStorage = nil
+        configuration.httpShouldSetCookies = false
+        return URLSession(
+            configuration: configuration,
+            delegate: RemoteNoRedirectDelegate(),
+            delegateQueue: nil
+        )
+    }
+
+    /// Best-effort friendly name for this Mac. The control center needs
+    /// something a human recognizes in the device list; the host name is what
+    /// the probe CLI uses for the same purpose. Resolved once — the settings
+    /// pane reads it from a SwiftUI body, which must not repeat a syscall.
+    public static func defaultDeviceName() -> String { cachedDeviceName }
+
+    private static let cachedDeviceName: String = {
+        var name = ProcessInfo.processInfo.hostName
+        if name.hasSuffix(".local") { name.removeLast(6) }
+        name = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !name.isEmpty else { return "Mac" }
+        return String(name.prefix(96))
+    }()
+
+    /// Normalizes a pasted pairing code: whitespace trimmed, uppercased.
+    /// Rejects anything outside the `VB-XXXXX-XXXXX` character set early so an
+    /// obvious typo never becomes an HTTP round-trip.
+    public static func normalizedCode(_ raw: String) throws -> String {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines).uppercased()
+        guard (1...64).contains(trimmed.count),
+              trimmed.allSatisfy({ $0.isASCII && ($0.isUppercase || $0.isNumber || $0 == "-") })
+        else { throw RemoteEnrollmentError.invalidCode }
+        return trimmed
+    }
+
+    /// Exchanges a one-time code for this workspace's Core provisioning.
+    public func enrollCore(
+        code rawCode: String,
+        deviceName rawName: String = RemoteEnrollmentClient.defaultDeviceName()
+    ) async throws -> RemoteEnrollmentResult {
+        let code = try RemoteEnrollmentClient.normalizedCode(rawCode)
+        // The contract requires 1–96 characters; fall back rather than fail,
+        // because a blank name is never worth losing a single-use code over.
+        let trimmedName = rawName.trimmingCharacters(in: .whitespacesAndNewlines)
+        let name = String(
+            (trimmedName.isEmpty ? RemoteEnrollmentClient.defaultDeviceName() : trimmedName)
+                .prefix(96)
+        )
+
+        let identity = RemoteCoreIdentity(
+            signingPrivateKey: P256.Signing.PrivateKey(),
+            recipientPrivateKey: P256.KeyAgreement.PrivateKey()
+        )
+        let descriptor = identity.publicDescriptor
+
+        var request = URLRequest(
+            url: controlURL
+                .appendingPathComponent("api")
+                .appendingPathComponent("v1")
+                .appendingPathComponent("enroll")
+                .appendingPathComponent("consume")
+        )
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.cachePolicy = .reloadIgnoringLocalCacheData
+        request.timeoutInterval = 30
+        request.httpBody = try JSONSerialization.data(
+            withJSONObject: [
+                "code": code,
+                "name": name,
+                "platform": "macos",
+                "signing_public_key": descriptor.signingPublicKey.base64EncodedString(),
+                "encryption_public_key": descriptor.recipientPublicKey.base64EncodedString()
+            ],
+            options: [.sortedKeys]
+        )
+
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await HTTPResponseLimit.boundedData(
+                from: session,
+                for: request,
+                maxBytes: 64 * 1024
+            )
+        } catch {
+            SafeLog.net("remote enroll failed: transport")
+            throw RemoteEnrollmentError.network
+        }
+        guard let http = response as? HTTPURLResponse else {
+            throw RemoteEnrollmentError.malformedResponse
+        }
+        guard http.statusCode == 201 else {
+            let error = RemoteEnrollmentClient.mapFailure(
+                status: http.statusCode,
+                body: data
+            )
+            SafeLog.net("remote enroll rejected: \(error.code)")
+            throw error
+        }
+
+        let result = try RemoteEnrollmentClient.makeResult(
+            body: data,
+            identity: identity,
+            deviceName: name
+        )
+        SafeLog.net("remote enroll accepted: role=core")
+        return result
+    }
+
+    /// The contract distinguishes only two error bodies; everything else is
+    /// mapped by status so an unexpected shape still reaches the user as a
+    /// plain HTTP problem instead of a silent failure.
+    static func mapFailure(status: Int, body: Data) -> RemoteEnrollmentError {
+        let object = (try? JSONSerialization.jsonObject(with: body)) as? [String: Any]
+        let marker = (object?["error"] as? String) ?? ""
+        switch (status, marker) {
+        case (404, _), (_, "invalid_code"):
+            return .codeRejected
+        case (409, _):
+            return .coreExists
+        case (429, _):
+            return .rateLimited
+        default:
+            return .server(status)
+        }
+    }
+
+    /// Validates the 201 body against §2 "Device endpoint" of the control API
+    /// contract and folds it into the exact `RemoteCoreProvisioning` a
+    /// provisioning file would have produced.
+    static func makeResult(
+        body: Data,
+        identity: RemoteCoreIdentity,
+        deviceName: String
+    ) throws -> RemoteEnrollmentResult {
+        guard let object = try? JSONSerialization.jsonObject(with: body) as? [String: Any],
+              let workspaceRaw = object["workspace_id"] as? String,
+              let workspaceID = UUID(uuidString: workspaceRaw),
+              let deviceRaw = object["device_id"] as? String,
+              let deviceID = UUID(uuidString: deviceRaw),
+              let role = object["role"] as? String,
+              let relayRaw = object["relay_url"] as? String,
+              let relayURL = URL(string: relayRaw),
+              let bearerToken = object["bearer_token"] as? String,
+              let core = object["core"] as? [String: Any],
+              let corePublicRaw = core["public_key"] as? String,
+              let corePublicKey = Data(base64Encoded: corePublicRaw),
+              let epoch = exactInteger(core["epoch"]),
+              let keyID = core["key_id"] as? String
+        else { throw RemoteEnrollmentError.malformedResponse }
+
+        guard role == "core" else { throw RemoteEnrollmentError.wrongRole(role) }
+        guard corePublicKey == identity.recipientPrivateKey.publicKey.x963Representation else {
+            throw RemoteEnrollmentError.coreKeyMismatch
+        }
+        guard let epochValue = Int(exactly: epoch) else {
+            throw RemoteEnrollmentError.malformedResponse
+        }
+
+        // A workspace this Mac just joined has no registered probes yet; their
+        // signing keys arrive when each probe enrolls. Every other field is
+        // validated by RemoteCoreProvisioning itself, so an out-of-contract
+        // relay URL, epoch, key id, or bearer token surfaces here as a
+        // malformed response rather than an unusable installed config.
+        do {
+            let provisioning = try RemoteCoreProvisioning(
+                workspaceID: workspaceID,
+                coreDeviceID: deviceID,
+                relayURL: relayURL,
+                relayBearerToken: bearerToken,
+                coreEpoch: epochValue,
+                ingestKeyID: keyID,
+                probeSigningPublicKeys: [:]
+            )
+            return RemoteEnrollmentResult(
+                provisioning: provisioning,
+                identity: identity,
+                deviceName: deviceName
+            )
+        } catch {
+            throw RemoteEnrollmentError.malformedResponse
+        }
+    }
+
+    private static func exactInteger(_ value: Any?) -> Int64? {
+        guard let number = value as? NSNumber,
+              CFGetTypeID(number) != CFBooleanGetTypeID()
+        else { return nil }
+        let type = String(cString: number.objCType)
+        guard type != "f", type != "d" else { return nil }
+        return number.int64Value
+    }
+}

--- a/Sources/VibeBarCore/Services/RemoteProbeService.swift
+++ b/Sources/VibeBarCore/Services/RemoteProbeService.swift
@@ -119,13 +119,55 @@ public final class RemoteProbeService: ObservableObject {
         activeRefresh = nil
     }
 
+    /// Learn the workspace's current probe roster from the Relay before any
+    /// envelope is opened.
+    ///
+    /// A Core that joined with a one-time code authorizes nobody at all until
+    /// this runs, and a Core provisioned from a file goes stale the moment its
+    /// workspace enrolls or revokes a probe — so both paths repair themselves
+    /// here, once per cycle. A roster fetch that fails keeps the installed
+    /// map: an unreachable or older Relay must degrade to "no new probes",
+    /// never to "reject everything".
+    private func synchronizedProbeRoster(
+        _ config: RemoteCoreConfig,
+        client: RemoteRelayClient,
+        generation: Int
+    ) async -> RemoteCoreConfig {
+        do {
+            let devices = try await client.fetchDevices()
+            guard generation == configurationGeneration else { return config }
+            let resolution = RemoteProbeRoster.resolve(from: devices)
+            if resolution.skipped > 0 {
+                SafeLog.warn(
+                    "remote roster: skipped \(resolution.skipped) active probe(s) with an unusable signing key"
+                )
+            }
+            guard let updated = try RemoteProbeRoster.updatedConfiguration(
+                for: config,
+                resolution: resolution
+            ) else { return config }
+            try RemoteCoreConfigStore.updateProbeRoster(updated)
+            self.config = updated
+            SafeLog.net("remote roster updated: \(updated.probeSigningPublicKeys.count) authorized probe(s)")
+            return updated
+        } catch {
+            SafeLog.net(
+                "remote roster refresh skipped: \((error as? RemoteSyncError)?.code ?? "unavailable")"
+            )
+            return config
+        }
+    }
+
     private func performRefresh() async {
         guard !isRefreshing,
-              let config, let identity, let client, let ledger
+              var config = self.config,
+              let identity, let client, let ledger
         else { return }
         let generation = configurationGeneration
         isRefreshing = true
         defer { isRefreshing = false }
+        config = await synchronizedProbeRoster(config, client: client, generation: generation)
+        guard generation == configurationGeneration else { return }
         do {
             var cursor = try await ledger.relayCursor(workspaceID: config.workspaceID)
             var pageCount = 0

--- a/Sources/VibeBarCore/Services/RemoteRelayClient.swift
+++ b/Sources/VibeBarCore/Services/RemoteRelayClient.swift
@@ -1,6 +1,9 @@
 import Foundation
 
-private final class RemoteNoRedirectDelegate: NSObject, URLSessionTaskDelegate, @unchecked Sendable {
+/// Shared by every remote-sync session (Relay batches and control-center
+/// enrollment): a redirect off the configured origin would move a bearer
+/// token or a one-time pairing code to a host the user never approved.
+final class RemoteNoRedirectDelegate: NSObject, URLSessionTaskDelegate, @unchecked Sendable {
     func urlSession(
         _ session: URLSession,
         task: URLSessionTask,

--- a/Sources/VibeBarCore/Services/RemoteRelayClient.swift
+++ b/Sources/VibeBarCore/Services/RemoteRelayClient.swift
@@ -26,6 +26,64 @@ struct RemoteRelayPage: Sendable {
     let nextCursor: String
 }
 
+/// One row of the Relay's device roster. Public material only: who the device
+/// is, whether the workspace still trusts it, and the signing key its
+/// envelopes must carry. `signingPublicKey` is nil when the Relay omitted it
+/// or it was not an uncompressed P-256 x963 point.
+struct RemoteRelayDevice: Sendable, Equatable {
+    let deviceID: UUID
+    let role: String
+    let status: String
+    let signingPublicKey: Data?
+}
+
+/// Turns the Relay's device roster into the set of producers a Core
+/// authorizes. Kept pure and separate from both the HTTP client and the
+/// service so the "which probes may publish to me" rule is testable on its
+/// own.
+enum RemoteProbeRoster {
+    struct Resolution: Equatable {
+        let keys: [UUID: Data]
+        /// Active probes the Core had to ignore because their signing key was
+        /// missing or unusable. Counted so the failure is observable without
+        /// ever logging the offending value.
+        let skipped: Int
+    }
+
+    static func resolve(from devices: [RemoteRelayDevice]) -> Resolution {
+        var keys: [UUID: Data] = [:]
+        var skipped = 0
+        for device in devices where device.role == "probe" && device.status == "active" {
+            guard let key = device.signingPublicKey else {
+                skipped += 1
+                continue
+            }
+            keys[device.deviceID] = key
+        }
+        return Resolution(keys: keys, skipped: skipped)
+    }
+
+    /// The configuration this Core should adopt, or nil when the installed
+    /// roster already matches — the caller then skips both the store write and
+    /// the in-memory swap, so an unchanged workspace costs one GET per cycle
+    /// and nothing else.
+    static func updatedConfiguration(
+        for config: RemoteCoreConfig,
+        resolution: Resolution
+    ) throws -> RemoteCoreConfig? {
+        guard resolution.keys != config.probeSigningPublicKeys else { return nil }
+        return try RemoteCoreConfig(
+            schema: config.schema,
+            workspaceID: config.workspaceID,
+            coreDeviceID: config.coreDeviceID,
+            relayURL: config.relayURL,
+            coreEpoch: config.coreEpoch,
+            ingestKeyID: config.ingestKeyID,
+            probeSigningPublicKeys: resolution.keys
+        )
+    }
+}
+
 struct RemoteRelayClient: Sendable {
     let config: RemoteCoreConfig
     let bearerToken: String
@@ -98,6 +156,49 @@ struct RemoteRelayClient: Sendable {
         return RemoteRelayPage(batches: batches, nextCursor: nextCursor)
     }
 
+    /// The workspace's current device roster. Same device-bearer credential,
+    /// no-redirect session, and bounded response as the batch calls; the Relay
+    /// requires the caller to be the workspace's Core.
+    func fetchDevices() async throws -> [RemoteRelayDevice] {
+        var request = URLRequest(url: workspaceEndpoint(resource: "devices"))
+        request.setValue("Bearer \(bearerToken)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.cachePolicy = .reloadIgnoringLocalCacheData
+        request.timeoutInterval = 30
+        let (data, response) = try await HTTPResponseLimit.boundedData(
+            from: session,
+            for: request,
+            maxBytes: 1_048_576
+        )
+        try validate(response)
+        guard let object = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let rawDevices = object["devices"] as? [[String: Any]],
+              rawDevices.count <= 4096
+        else { throw RemoteSyncError.invalidResponse }
+        return try rawDevices.map { raw in
+            guard let idRaw = raw["device_id"] as? String,
+                  let deviceID = UUID(uuidString: idRaw),
+                  let role = raw["role"] as? String,
+                  let status = raw["status"] as? String
+            else { throw RemoteSyncError.invalidResponse }
+            // A key this Core cannot use is not a malformed roster: the row is
+            // still authoritative about the device's role and status, so keep
+            // it and let the roster policy decide (and count) the skip.
+            var signingPublicKey: Data?
+            if let keyRaw = raw["signing_public_key"] as? String,
+               let key = Data(base64Encoded: keyRaw),
+               key.count == 65, key.first == 0x04 {
+                signingPublicKey = key
+            }
+            return RemoteRelayDevice(
+                deviceID: deviceID,
+                role: role,
+                status: status,
+                signingPublicKey: signingPublicKey
+            )
+        }
+    }
+
     func acknowledge(cursor: String) async throws {
         var request = URLRequest(url: endpoint(resource: "acks"))
         request.httpMethod = "POST"
@@ -121,12 +222,16 @@ struct RemoteRelayClient: Sendable {
     }
 
     private func endpoint(resource: String) -> URL {
+        workspaceEndpoint(resource: "streams")
+            .appendingPathComponent("ingest")
+            .appendingPathComponent(resource)
+    }
+
+    private func workspaceEndpoint(resource: String) -> URL {
         config.relayURL
             .appendingPathComponent("v1")
             .appendingPathComponent("workspaces")
             .appendingPathComponent(config.workspaceID.uuidString.lowercased())
-            .appendingPathComponent("streams")
-            .appendingPathComponent("ingest")
             .appendingPathComponent(resource)
     }
 

--- a/Sources/VibeBarCore/Storage/RemoteCoreConfigStore.swift
+++ b/Sources/VibeBarCore/Storage/RemoteCoreConfigStore.swift
@@ -46,6 +46,15 @@ public enum RemoteCoreConfigStore {
         }
     }
 
+    /// Commit an enrollment obtained from the web control center. Identical to
+    /// the provisioning-file path once the identity is in place: the Core keys
+    /// were minted during the exchange rather than before it, so they have to
+    /// land in the Vault before the workspace binding that depends on them.
+    public static func install(_ enrollment: RemoteEnrollmentResult) throws {
+        try RemoteCoreIdentityStore.store(enrollment.identity)
+        try install(enrollment.provisioning)
+    }
+
     public static func install(from url: URL) throws {
         let attributes = try FileManager.default.attributesOfItem(atPath: url.path)
         guard attributes[.type] as? FileAttributeType == .typeRegular,

--- a/Sources/VibeBarCore/Storage/RemoteCoreConfigStore.swift
+++ b/Sources/VibeBarCore/Storage/RemoteCoreConfigStore.swift
@@ -10,6 +10,9 @@ struct RemoteCoreConfigSink {
     var storeIdentity: (RemoteCoreIdentity) throws -> Void
     var storeBearerToken: (String, UUID) throws -> Void
     var deleteBearerToken: (UUID) throws -> Void
+    var storePendingEnrollment: (RemoteEnrollmentResult) throws -> Void
+    var loadPendingEnrollment: () throws -> RemoteEnrollmentResult
+    var deletePendingEnrollment: () throws -> Void
 
     static let live = RemoteCoreConfigSink(
         loadConfig: { try RemoteCoreConfigStore.load() },
@@ -20,7 +23,10 @@ struct RemoteCoreConfigSink {
         storeBearerToken: {
             try RemoteCoreIdentityStore.storeRelayBearerToken($0, workspaceID: $1)
         },
-        deleteBearerToken: { try RemoteCoreIdentityStore.deleteRelayBearerToken(workspaceID: $0) }
+        deleteBearerToken: { try RemoteCoreIdentityStore.deleteRelayBearerToken(workspaceID: $0) },
+        storePendingEnrollment: { try RemoteCoreIdentityStore.storePendingEnrollment($0) },
+        loadPendingEnrollment: { try RemoteCoreIdentityStore.pendingEnrollment() },
+        deletePendingEnrollment: { try RemoteCoreIdentityStore.deletePendingEnrollment() }
     )
 }
 
@@ -96,6 +102,59 @@ public enum RemoteCoreConfigStore {
     ) throws {
         try sink.storeIdentity(enrollment.identity)
         try install(enrollment.provisioning, sink: sink)
+        // The binding has committed, so the recovery record has done its job.
+        // Best-effort: a leftover record is harmless — `pendingEnrollment()`
+        // refuses to hand back one once a workspace is installed, and clears
+        // it then.
+        try? sink.deletePendingEnrollment()
+    }
+
+    // MARK: - Pending enrollment recovery
+
+    /// Remember an enrollment the control center has already consumed, before
+    /// trying to install it.
+    ///
+    /// A pairing code is spent the moment the control center answers, so the
+    /// window between "accepted" and "saved" must survive a failed write, a
+    /// closed window, and a quit. The record carries the Relay credential and
+    /// this Mac's Core private keys, so it goes into the credential Vault and
+    /// nowhere else.
+    public static func retainPendingEnrollment(_ enrollment: RemoteEnrollmentResult) throws {
+        try retainPendingEnrollment(enrollment, sink: .live)
+    }
+
+    static func retainPendingEnrollment(
+        _ enrollment: RemoteEnrollmentResult,
+        sink: RemoteCoreConfigSink
+    ) throws {
+        try sink.storePendingEnrollment(enrollment)
+    }
+
+    /// A retained enrollment that never finished installing, if any.
+    ///
+    /// Returns nil once this Mac is bound to a workspace: the record is stale
+    /// then, and is cleared rather than offered as a resumable action.
+    public static func pendingEnrollment() -> RemoteEnrollmentResult? {
+        pendingEnrollment(sink: .live)
+    }
+
+    static func pendingEnrollment(sink: RemoteCoreConfigSink) -> RemoteEnrollmentResult? {
+        guard (try? sink.loadConfig()) == nil else {
+            try? sink.deletePendingEnrollment()
+            return nil
+        }
+        return try? sink.loadPendingEnrollment()
+    }
+
+    /// Forget a retained enrollment. The workspace still counts this Mac as
+    /// its Core, so the user's way back is to revoke this device in the web
+    /// control center and join again with a fresh code.
+    public static func discardPendingEnrollment() {
+        discardPendingEnrollment(sink: .live)
+    }
+
+    static func discardPendingEnrollment(sink: RemoteCoreConfigSink) {
+        try? sink.deletePendingEnrollment()
     }
 
     /// Persist a probe roster learned from the Relay during a sync. Only the

--- a/Sources/VibeBarCore/Storage/RemoteCoreConfigStore.swift
+++ b/Sources/VibeBarCore/Storage/RemoteCoreConfigStore.swift
@@ -1,5 +1,29 @@
 import Foundation
 
+/// The persistence side effects `RemoteCoreConfigStore.install` performs,
+/// gathered behind one value so the retry path can be exercised without
+/// touching the real credential Vault or `~/.vibebar/`. `.live` is the only
+/// sink product code uses.
+struct RemoteCoreConfigSink {
+    var loadConfig: () throws -> RemoteCoreConfig
+    var writeConfig: (RemoteCoreConfig) throws -> Void
+    var storeIdentity: (RemoteCoreIdentity) throws -> Void
+    var storeBearerToken: (String, UUID) throws -> Void
+    var deleteBearerToken: (UUID) throws -> Void
+
+    static let live = RemoteCoreConfigSink(
+        loadConfig: { try RemoteCoreConfigStore.load() },
+        writeConfig: {
+            try VibeBarLocalStore.writeJSON($0, to: VibeBarLocalStore.remoteCoreConfigURL)
+        },
+        storeIdentity: { try RemoteCoreIdentityStore.store($0) },
+        storeBearerToken: {
+            try RemoteCoreIdentityStore.storeRelayBearerToken($0, workspaceID: $1)
+        },
+        deleteBearerToken: { try RemoteCoreIdentityStore.deleteRelayBearerToken(workspaceID: $0) }
+    )
+}
+
 public enum RemoteCoreConfigStore {
     public static func load() throws -> RemoteCoreConfig {
         let decoded = try VibeBarLocalStore.readJSON(
@@ -17,9 +41,25 @@ public enum RemoteCoreConfigStore {
         )
     }
 
+    /// Install a workspace binding.
+    ///
+    /// Every write here is last-wins — the Vault replaces an entry with the
+    /// same service/account, and the config file is written atomically — so
+    /// calling this twice with the same provisioning is safe and converges.
+    /// That matters for the enrollment path: a one-time pairing code is spent
+    /// the moment the control center answers, so a Keychain or filesystem
+    /// failure afterwards must be recoverable by retrying the local save with
+    /// the result already in hand, not by requesting another code.
     public static func install(_ provisioning: RemoteCoreProvisioning) throws {
+        try install(provisioning, sink: .live)
+    }
+
+    static func install(
+        _ provisioning: RemoteCoreProvisioning,
+        sink: RemoteCoreConfigSink
+    ) throws {
         guard provisioning.schema == 1 else { throw RemoteSyncError.invalidConfiguration }
-        let previous = try? load()
+        let previous = try? sink.loadConfig()
         let config = try RemoteCoreConfig(
             workspaceID: provisioning.workspaceID,
             coreDeviceID: provisioning.coreDeviceID,
@@ -30,19 +70,14 @@ public enum RemoteCoreConfigStore {
         )
         // Store the secret first. A crash can leave an unused Vault entry, but
         // never a plaintext config that claims to be usable without a token.
-        try RemoteCoreIdentityStore.storeRelayBearerToken(
-            provisioning.relayBearerToken,
-            workspaceID: provisioning.workspaceID
-        )
-        try VibeBarLocalStore.writeJSON(config, to: VibeBarLocalStore.remoteCoreConfigURL)
+        try sink.storeBearerToken(provisioning.relayBearerToken, provisioning.workspaceID)
+        try sink.writeConfig(config)
         // Replacing workspace A with workspace B must not strand A's
         // still-valid Relay credential in the Vault. Best-effort, and only
         // after the new configuration has committed, so a cleanup failure
         // can't break an otherwise successful install.
         if let previous, previous.workspaceID != provisioning.workspaceID {
-            try? RemoteCoreIdentityStore.deleteRelayBearerToken(
-                workspaceID: previous.workspaceID
-            )
+            try? sink.deleteBearerToken(previous.workspaceID)
         }
     }
 
@@ -50,9 +85,32 @@ public enum RemoteCoreConfigStore {
     /// the provisioning-file path once the identity is in place: the Core keys
     /// were minted during the exchange rather than before it, so they have to
     /// land in the Vault before the workspace binding that depends on them.
+    /// Retryable for the same reason `install(_ provisioning:)` is.
     public static func install(_ enrollment: RemoteEnrollmentResult) throws {
-        try RemoteCoreIdentityStore.store(enrollment.identity)
-        try install(enrollment.provisioning)
+        try install(enrollment, sink: .live)
+    }
+
+    static func install(
+        _ enrollment: RemoteEnrollmentResult,
+        sink: RemoteCoreConfigSink
+    ) throws {
+        try sink.storeIdentity(enrollment.identity)
+        try install(enrollment.provisioning, sink: sink)
+    }
+
+    /// Persist a probe roster learned from the Relay during a sync. Only the
+    /// set of authorized producers moves: the workspace binding and its Relay
+    /// credential are untouched, so a configuration that points anywhere else
+    /// is refused rather than silently rebinding this Mac.
+    public static func updateProbeRoster(_ config: RemoteCoreConfig) throws {
+        let installed = try load()
+        guard installed.workspaceID == config.workspaceID,
+              installed.coreDeviceID == config.coreDeviceID,
+              installed.relayURL == config.relayURL,
+              installed.coreEpoch == config.coreEpoch,
+              installed.ingestKeyID == config.ingestKeyID
+        else { throw RemoteSyncError.invalidConfiguration }
+        try VibeBarLocalStore.writeJSON(config, to: VibeBarLocalStore.remoteCoreConfigURL)
     }
 
     public static func install(from url: URL) throws {

--- a/Tests/VibeBarCoreTests/RemoteDeviceRosterTests.swift
+++ b/Tests/VibeBarCoreTests/RemoteDeviceRosterTests.swift
@@ -1,0 +1,247 @@
+import XCTest
+import CryptoKit
+@testable import VibeBarCore
+
+/// Covers how a Core learns which probes it authorizes: parsing the Relay's
+/// device roster, folding it into the installed configuration, and refusing to
+/// churn the store when nothing moved. Synthetic UUIDs and keys only, and the
+/// HTTP half runs against a stubbed URLProtocol.
+final class RemoteDeviceRosterTests: XCTestCase {
+    private let workspace = UUID(uuidString: "11111111-1111-4111-8111-111111111111")!
+    private let core = UUID(uuidString: "22222222-2222-4222-8222-222222222222")!
+    private let probeA = UUID(uuidString: "33333333-3333-4333-8333-333333333333")!
+    private let probeB = UUID(uuidString: "44444444-4444-4444-8444-444444444444")!
+    private let probeC = UUID(uuidString: "55555555-5555-4555-8555-555555555555")!
+
+    private final class StubURLProtocol: URLProtocol {
+        nonisolated(unsafe) static var responder: (@Sendable (URLRequest) -> (HTTPURLResponse, Data?))?
+        nonisolated(unsafe) static var lastRequestURL: URL?
+
+        override class func canInit(with request: URLRequest) -> Bool { true }
+        override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+        override func startLoading() {
+            StubURLProtocol.lastRequestURL = request.url
+            guard let responder = StubURLProtocol.responder else {
+                client?.urlProtocol(self, didFailWithError: URLError(.notConnectedToInternet))
+                return
+            }
+            let (response, data) = responder(request)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            if let data { client?.urlProtocol(self, didLoad: data) }
+            client?.urlProtocolDidFinishLoading(self)
+        }
+
+        override func stopLoading() {}
+    }
+
+    override func tearDown() {
+        StubURLProtocol.responder = nil
+        StubURLProtocol.lastRequestURL = nil
+        super.tearDown()
+    }
+
+    private func signingKey(_ seed: UInt8) throws -> Data {
+        try P256.Signing.PrivateKey(
+            rawRepresentation: Data(repeating: 0, count: 31) + Data([seed])
+        ).publicKey.x963Representation
+    }
+
+    private func config(_ keys: [UUID: Data]) throws -> RemoteCoreConfig {
+        try RemoteCoreConfig(
+            workspaceID: workspace,
+            coreDeviceID: core,
+            relayURL: URL(string: "https://relay.example.invalid")!,
+            coreEpoch: 1,
+            ingestKeyID: "ingest-epoch-1",
+            probeSigningPublicKeys: keys
+        )
+    }
+
+    private func makeClient(_ config: RemoteCoreConfig) -> RemoteRelayClient {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [StubURLProtocol.self]
+        return RemoteRelayClient(
+            config: config,
+            bearerToken: String(repeating: "t", count: 40),
+            session: URLSession(configuration: configuration)
+        )
+    }
+
+    private func respond(_ body: Any?, status: Int = 200, noStore: Bool = true) {
+        StubURLProtocol.responder = { request in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: status,
+                httpVersion: "HTTP/1.1",
+                headerFields: noStore ? ["Cache-Control": "no-store"] : [:]
+            )!
+            guard let body else { return (response, nil) }
+            return (response, try? JSONSerialization.data(withJSONObject: body))
+        }
+    }
+
+    // MARK: - Roster policy
+
+    func testOnlyActiveProbesBecomeAuthorizedProducers() throws {
+        let devices = [
+            RemoteRelayDevice(deviceID: probeA, role: "probe", status: "active",
+                              signingPublicKey: try signingKey(3)),
+            // Revoked probes lose their authorization.
+            RemoteRelayDevice(deviceID: probeB, role: "probe", status: "revoked",
+                              signingPublicKey: try signingKey(4)),
+            // The Core itself never publishes to its own ingest stream.
+            RemoteRelayDevice(deviceID: core, role: "core", status: "active",
+                              signingPublicKey: try signingKey(5)),
+            RemoteRelayDevice(deviceID: probeC, role: "view", status: "active",
+                              signingPublicKey: try signingKey(6))
+        ]
+        let resolution = RemoteProbeRoster.resolve(from: devices)
+        XCTAssertEqual(Set(resolution.keys.keys), [probeA])
+        XCTAssertEqual(resolution.keys[probeA], try signingKey(3))
+        XCTAssertEqual(resolution.skipped, 0)
+    }
+
+    func testUnusableProbeKeysAreSkippedAndCounted() throws {
+        let devices = [
+            RemoteRelayDevice(deviceID: probeA, role: "probe", status: "active",
+                              signingPublicKey: try signingKey(3)),
+            RemoteRelayDevice(deviceID: probeB, role: "probe", status: "active",
+                              signingPublicKey: nil),
+            RemoteRelayDevice(deviceID: probeC, role: "probe", status: "active",
+                              signingPublicKey: nil)
+        ]
+        let resolution = RemoteProbeRoster.resolve(from: devices)
+        XCTAssertEqual(Set(resolution.keys.keys), [probeA])
+        XCTAssertEqual(resolution.skipped, 2)
+    }
+
+    func testNewProbeIsAddedAndRevokedProbeIsDropped() throws {
+        // Installed: A only — the state a file-provisioned Core is stuck in
+        // after its workspace enrolled B and revoked A.
+        let installed = try config([probeA: try signingKey(3)])
+        let resolution = RemoteProbeRoster.resolve(from: [
+            RemoteRelayDevice(deviceID: probeA, role: "probe", status: "revoked",
+                              signingPublicKey: try signingKey(3)),
+            RemoteRelayDevice(deviceID: probeB, role: "probe", status: "active",
+                              signingPublicKey: try signingKey(4))
+        ])
+        let updated = try XCTUnwrap(
+            RemoteProbeRoster.updatedConfiguration(for: installed, resolution: resolution)
+        )
+        XCTAssertEqual(Set(updated.probeSigningPublicKeys.keys), [probeB])
+        XCTAssertEqual(updated.probeSigningPublicKeys[probeB], try signingKey(4))
+        // Everything else about the binding is preserved verbatim.
+        XCTAssertEqual(updated.workspaceID, installed.workspaceID)
+        XCTAssertEqual(updated.coreDeviceID, installed.coreDeviceID)
+        XCTAssertEqual(updated.relayURL, installed.relayURL)
+        XCTAssertEqual(updated.coreEpoch, installed.coreEpoch)
+        XCTAssertEqual(updated.ingestKeyID, installed.ingestKeyID)
+    }
+
+    func testCodeJoinedCoreLearnsItsFirstProbe() throws {
+        // The empty map a code-based enrollment installs.
+        let installed = try config([:])
+        let resolution = RemoteProbeRoster.resolve(from: [
+            RemoteRelayDevice(deviceID: probeA, role: "probe", status: "active",
+                              signingPublicKey: try signingKey(3))
+        ])
+        let updated = try XCTUnwrap(
+            RemoteProbeRoster.updatedConfiguration(for: installed, resolution: resolution)
+        )
+        XCTAssertEqual(updated.probeSigningPublicKeys[probeA], try signingKey(3))
+    }
+
+    func testUnchangedRosterDoesNotRewriteTheConfiguration() throws {
+        let installed = try config([probeA: try signingKey(3)])
+        let resolution = RemoteProbeRoster.resolve(from: [
+            RemoteRelayDevice(deviceID: probeA, role: "probe", status: "active",
+                              signingPublicKey: try signingKey(3)),
+            // Ordering and irrelevant roles must not look like a change.
+            RemoteRelayDevice(deviceID: core, role: "core", status: "active",
+                              signingPublicKey: try signingKey(5))
+        ])
+        XCTAssertNil(
+            try RemoteProbeRoster.updatedConfiguration(for: installed, resolution: resolution),
+            "An unchanged roster must not touch the store"
+        )
+    }
+
+    // MARK: - Relay client
+
+    func testFetchDevicesParsesTheRelayRoster() async throws {
+        let installed = try config([:])
+        respond([
+            "devices": [
+                [
+                    "device_id": probeA.uuidString.lowercased(),
+                    "role": "probe",
+                    "status": "active",
+                    "signing_public_key": try signingKey(3).base64EncodedString(),
+                    "created_at": 1_700_000_000
+                ],
+                [
+                    "device_id": probeB.uuidString.lowercased(),
+                    "role": "probe",
+                    "status": "active",
+                    // Not a P-256 x963 point: kept as a row, key dropped.
+                    "signing_public_key": Data(repeating: 0x01, count: 12).base64EncodedString(),
+                    "created_at": 1_700_000_100
+                ],
+                [
+                    "device_id": core.uuidString.lowercased(),
+                    "role": "core",
+                    "status": "active",
+                    "created_at": 1_700_000_200
+                ]
+            ]
+        ])
+        let devices = try await makeClient(installed).fetchDevices()
+        XCTAssertEqual(devices.count, 3)
+        XCTAssertEqual(devices[0].signingPublicKey, try signingKey(3))
+        XCTAssertNil(devices[1].signingPublicKey)
+        XCTAssertNil(devices[2].signingPublicKey)
+        XCTAssertEqual(devices[2].role, "core")
+
+        let url = try XCTUnwrap(StubURLProtocol.lastRequestURL)
+        XCTAssertEqual(
+            url.path,
+            "/v1/workspaces/\(workspace.uuidString.lowercased())/devices"
+        )
+        // Malformed keys never silently authorize anyone.
+        XCTAssertEqual(RemoteProbeRoster.resolve(from: devices).skipped, 1)
+    }
+
+    func testFetchDevicesRejectsUnusableResponses() async throws {
+        let installed = try config([:])
+        let client = makeClient(installed)
+
+        respond(["not_devices": []])
+        await assertRelayFailure { _ = try await client.fetchDevices() }
+
+        respond(["devices": [["device_id": "not-a-uuid", "role": "probe", "status": "active"]]])
+        await assertRelayFailure { _ = try await client.fetchDevices() }
+
+        // A cacheable roster response is refused like every other Relay read.
+        respond(["devices": []], noStore: false)
+        await assertRelayFailure { _ = try await client.fetchDevices() }
+
+        respond(nil, status: 403)
+        await assertRelayFailure { _ = try await client.fetchDevices() }
+    }
+
+    private func assertRelayFailure(
+        _ operation: () async throws -> Void,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async {
+        do {
+            try await operation()
+            XCTFail("Expected the roster fetch to fail", file: file, line: line)
+        } catch is RemoteSyncError {
+            // Expected: the service keeps its installed map on any of these.
+        } catch {
+            XCTFail("Expected RemoteSyncError, got \(error)", file: file, line: line)
+        }
+    }
+}

--- a/Tests/VibeBarCoreTests/RemoteEnrollmentTests.swift
+++ b/Tests/VibeBarCoreTests/RemoteEnrollmentTests.swift
@@ -354,6 +354,9 @@ final class RemoteEnrollmentTests: XCTestCase {
         var tokens: [UUID: String] = [:]
         var failNextConfigWrite = false
         var configWriteAttempts = 0
+        /// Stored the way the live sink stores it — encoded — so the tests
+        /// exercise the real Vault payload rather than an object reference.
+        var pendingRecord: Data?
 
         func make() -> RemoteCoreConfigSink {
             RemoteCoreConfigSink(
@@ -371,7 +374,17 @@ final class RemoteEnrollmentTests: XCTestCase {
                 },
                 storeIdentity: { self.identity = $0 },
                 storeBearerToken: { token, workspaceID in self.tokens[workspaceID] = token },
-                deleteBearerToken: { self.tokens[$0] = nil }
+                deleteBearerToken: { self.tokens[$0] = nil },
+                storePendingEnrollment: {
+                    self.pendingRecord = try RemoteCoreIdentityStore.encodePendingEnrollment($0)
+                },
+                loadPendingEnrollment: {
+                    guard let data = self.pendingRecord else {
+                        throw KeychainStore.KeychainError.itemNotFound
+                    }
+                    return try RemoteCoreIdentityStore.decodePendingEnrollment(data)
+                },
+                deletePendingEnrollment: { self.pendingRecord = nil }
             )
         }
     }
@@ -413,6 +426,108 @@ final class RemoteEnrollmentTests: XCTestCase {
         XCTAssertNoThrow(try RemoteCoreConfigStore.install(enrollment, sink: sink.make()))
         XCTAssertEqual(sink.config, installed)
         XCTAssertEqual(sink.tokens.count, 1)
+    }
+
+    // MARK: - Durable pending-enrollment recovery
+
+    func testPendingEnrollmentRecordRoundTripsIntact() async throws {
+        respond(status: 201, json: successBody())
+        let enrollment = try await makeClient().enrollCore(
+            code: "VB-ABCDE-23456",
+            deviceName: "Example Mac"
+        )
+
+        let encoded = try RemoteCoreIdentityStore.encodePendingEnrollment(enrollment)
+        let restored = try RemoteCoreIdentityStore.decodePendingEnrollment(encoded)
+
+        XCTAssertEqual(restored.provisioning.workspaceID, workspace)
+        XCTAssertEqual(restored.provisioning.coreDeviceID, device)
+        XCTAssertEqual(restored.provisioning.relayURL, enrollment.provisioning.relayURL)
+        XCTAssertEqual(restored.provisioning.relayBearerToken, bearer)
+        XCTAssertEqual(restored.provisioning.coreEpoch, 1)
+        XCTAssertEqual(restored.provisioning.ingestKeyID, "ingest-epoch-1")
+        XCTAssertEqual(restored.deviceName, "Example Mac")
+        // Both private halves survive, or the workspace's registered Core key
+        // would be unusable after a resume.
+        XCTAssertEqual(
+            restored.identity.signingPrivateKey.rawRepresentation,
+            enrollment.identity.signingPrivateKey.rawRepresentation
+        )
+        XCTAssertEqual(
+            restored.identity.recipientPrivateKey.rawRepresentation,
+            enrollment.identity.recipientPrivateKey.rawRepresentation
+        )
+        // A corrupt or future-schema record fails closed rather than
+        // installing something half-understood.
+        XCTAssertThrowsError(
+            try RemoteCoreIdentityStore.decodePendingEnrollment(Data("{}".utf8))
+        )
+    }
+
+    func testPendingEnrollmentSurvivesAFailedInstallAndResumesLater() async throws {
+        respond(status: 201, json: successBody())
+        let enrollment = try await makeClient().enrollCore(
+            code: "VB-ABCDE-23456",
+            deviceName: "Example Mac"
+        )
+
+        let sink = RecordingSink()
+        // The pane retains the enrollment before the first install attempt.
+        try RemoteCoreConfigStore.retainPendingEnrollment(enrollment, sink: sink.make())
+        sink.failNextConfigWrite = true
+        XCTAssertThrowsError(try RemoteCoreConfigStore.install(enrollment, sink: sink.make()))
+        XCTAssertNotNil(sink.pendingRecord, "A failed install must not drop the record")
+        XCTAssertNil(sink.config)
+
+        // A later session finds it and resumes — no HTTP, no new code.
+        let resumed = try XCTUnwrap(RemoteCoreConfigStore.pendingEnrollment(sink: sink.make()))
+        XCTAssertEqual(resumed.provisioning.workspaceID, workspace)
+        XCTAssertNoThrow(try RemoteCoreConfigStore.install(resumed, sink: sink.make()))
+
+        let installed = try XCTUnwrap(sink.config)
+        XCTAssertEqual(installed.workspaceID, workspace)
+        XCTAssertEqual(installed.coreDeviceID, device)
+        XCTAssertEqual(sink.tokens[workspace], bearer)
+        XCTAssertEqual(
+            sink.identity?.recipientPrivateKey.rawRepresentation,
+            enrollment.identity.recipientPrivateKey.rawRepresentation
+        )
+        XCTAssertNil(sink.pendingRecord, "A committed install clears the record")
+        // Nothing is offered once the Mac is bound to a workspace.
+        XCTAssertNil(RemoteCoreConfigStore.pendingEnrollment(sink: sink.make()))
+    }
+
+    func testInstalledWorkspaceClearsAStalePendingRecord() async throws {
+        respond(status: 201, json: successBody())
+        let enrollment = try await makeClient().enrollCore(
+            code: "VB-ABCDE-23456",
+            deviceName: "Example Mac"
+        )
+        let sink = RecordingSink()
+        try RemoteCoreConfigStore.install(enrollment, sink: sink.make())
+        // A record left behind by an earlier failure is stale once a binding
+        // exists: never offered, and cleaned up on the way past.
+        try RemoteCoreConfigStore.retainPendingEnrollment(enrollment, sink: sink.make())
+        XCTAssertNil(RemoteCoreConfigStore.pendingEnrollment(sink: sink.make()))
+        XCTAssertNil(sink.pendingRecord)
+    }
+
+    func testDiscardingAPendingEnrollmentDeletesTheRecord() async throws {
+        respond(status: 201, json: successBody())
+        let enrollment = try await makeClient().enrollCore(
+            code: "VB-ABCDE-23456",
+            deviceName: "Example Mac"
+        )
+        let sink = RecordingSink()
+        try RemoteCoreConfigStore.retainPendingEnrollment(enrollment, sink: sink.make())
+        XCTAssertNotNil(sink.pendingRecord)
+
+        RemoteCoreConfigStore.discardPendingEnrollment(sink: sink.make())
+        XCTAssertNil(sink.pendingRecord)
+        XCTAssertNil(RemoteCoreConfigStore.pendingEnrollment(sink: sink.make()))
+        // Discarding twice is safe.
+        RemoteCoreConfigStore.discardPendingEnrollment(sink: sink.make())
+        XCTAssertNil(sink.pendingRecord)
     }
 
     func testFreshlyJoinedWorkspaceHasNoRegisteredProbes() throws {

--- a/Tests/VibeBarCoreTests/RemoteEnrollmentTests.swift
+++ b/Tests/VibeBarCoreTests/RemoteEnrollmentTests.swift
@@ -343,6 +343,78 @@ final class RemoteEnrollmentTests: XCTestCase {
         }
     }
 
+    // MARK: - Install retry
+
+    /// Records what `install` persisted, and can fail the config write once so
+    /// the spent-code recovery path is exercised without touching the real
+    /// credential Vault or `~/.vibebar/`.
+    private final class RecordingSink: @unchecked Sendable {
+        var config: RemoteCoreConfig?
+        var identity: RemoteCoreIdentity?
+        var tokens: [UUID: String] = [:]
+        var failNextConfigWrite = false
+        var configWriteAttempts = 0
+
+        func make() -> RemoteCoreConfigSink {
+            RemoteCoreConfigSink(
+                loadConfig: {
+                    guard let config = self.config else { throw RemoteSyncError.notConfigured }
+                    return config
+                },
+                writeConfig: { value in
+                    self.configWriteAttempts += 1
+                    if self.failNextConfigWrite {
+                        self.failNextConfigWrite = false
+                        throw CocoaError(.fileWriteNoPermission)
+                    }
+                    self.config = value
+                },
+                storeIdentity: { self.identity = $0 },
+                storeBearerToken: { token, workspaceID in self.tokens[workspaceID] = token },
+                deleteBearerToken: { self.tokens[$0] = nil }
+            )
+        }
+    }
+
+    func testFailedInstallIsRecoverableWithTheSameEnrollment() async throws {
+        respond(status: 201, json: successBody())
+        let enrollment = try await makeClient().enrollCore(
+            code: "VB-ABCDE-23456",
+            deviceName: "Example Mac"
+        )
+
+        let sink = RecordingSink()
+        sink.failNextConfigWrite = true
+        XCTAssertThrowsError(
+            try RemoteCoreConfigStore.install(enrollment, sink: sink.make()),
+            "A failing config write must surface, not be swallowed"
+        )
+        // The one-time code is already spent, so what did land stays landed…
+        XCTAssertNotNil(sink.identity)
+        XCTAssertEqual(sink.tokens[workspace], bearer)
+        XCTAssertNil(sink.config, "The binding must not claim to be usable yet")
+
+        // …and retrying the local save with the retained result converges,
+        // with no second HTTP call and no second code.
+        XCTAssertNoThrow(try RemoteCoreConfigStore.install(enrollment, sink: sink.make()))
+        let installed = try XCTUnwrap(sink.config)
+        XCTAssertEqual(installed.workspaceID, workspace)
+        XCTAssertEqual(installed.coreDeviceID, device)
+        XCTAssertEqual(installed.coreEpoch, 1)
+        XCTAssertEqual(installed.ingestKeyID, "ingest-epoch-1")
+        XCTAssertEqual(sink.tokens[workspace], bearer)
+        XCTAssertEqual(
+            sink.identity?.recipientPrivateKey.rawRepresentation,
+            enrollment.identity.recipientPrivateKey.rawRepresentation
+        )
+        XCTAssertEqual(sink.configWriteAttempts, 2)
+
+        // Installing a third time is still safe: every write is last-wins.
+        XCTAssertNoThrow(try RemoteCoreConfigStore.install(enrollment, sink: sink.make()))
+        XCTAssertEqual(sink.config, installed)
+        XCTAssertEqual(sink.tokens.count, 1)
+    }
+
     func testFreshlyJoinedWorkspaceHasNoRegisteredProbes() throws {
         // A Core that just joined authorizes no producer yet; the config must
         // still be representable, because probes enroll afterwards.

--- a/Tests/VibeBarCoreTests/RemoteEnrollmentTests.swift
+++ b/Tests/VibeBarCoreTests/RemoteEnrollmentTests.swift
@@ -1,0 +1,359 @@
+import XCTest
+import CryptoKit
+@testable import VibeBarCore
+
+/// Exercises the join-with-code enrollment client against a stubbed
+/// URLProtocol: no network, no Keychain, and only synthetic identifiers.
+/// The stub echoes the encryption public key straight out of the request, so
+/// the happy path also asserts the request encoding the control center's
+/// `POST /api/v1/enroll/consume` contract expects.
+final class RemoteEnrollmentTests: XCTestCase {
+    private let workspace = UUID(uuidString: "11111111-1111-4111-8111-111111111111")!
+    private let device = UUID(uuidString: "22222222-2222-4222-8222-222222222222")!
+    private let bearer = "vbr1." + String(repeating: "a", count: 40)
+    private let controlURL = URL(string: "https://control.example.invalid")!
+
+    private final class StubURLProtocol: URLProtocol {
+        nonisolated(unsafe) static var responder: (@Sendable (URLRequest, Data) -> (HTTPURLResponse, Data?))?
+        nonisolated(unsafe) static var lastRequestBody: Data?
+
+        override class func canInit(with request: URLRequest) -> Bool { true }
+        override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+        override func startLoading() {
+            let body = StubURLProtocol.body(of: request)
+            StubURLProtocol.lastRequestBody = body
+            guard let responder = StubURLProtocol.responder else {
+                client?.urlProtocol(self, didFailWithError: URLError(.notConnectedToInternet))
+                return
+            }
+            let (response, data) = responder(request, body)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            if let data {
+                client?.urlProtocol(self, didLoad: data)
+            }
+            client?.urlProtocolDidFinishLoading(self)
+        }
+
+        override func stopLoading() {}
+
+        /// URLSession replaces `httpBody` with a stream by the time a
+        /// URLProtocol sees the request, so read whichever one is populated.
+        private static func body(of request: URLRequest) -> Data {
+            if let body = request.httpBody { return body }
+            guard let stream = request.httpBodyStream else { return Data() }
+            stream.open()
+            defer { stream.close() }
+            var data = Data()
+            var buffer = [UInt8](repeating: 0, count: 4096)
+            while stream.hasBytesAvailable {
+                let read = stream.read(&buffer, maxLength: buffer.count)
+                if read <= 0 { break }
+                data.append(contentsOf: buffer[0..<read])
+            }
+            return data
+        }
+    }
+
+    private func makeStubbedSession() -> URLSession {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [StubURLProtocol.self]
+        return URLSession(configuration: configuration)
+    }
+
+    private func makeClient() throws -> RemoteEnrollmentClient {
+        try RemoteEnrollmentClient(controlURL: controlURL, session: makeStubbedSession())
+    }
+
+    override func tearDown() {
+        StubURLProtocol.responder = nil
+        StubURLProtocol.lastRequestBody = nil
+        super.tearDown()
+    }
+
+    // MARK: - Helpers
+
+    private func respond(
+        status: Int,
+        json: @escaping @Sendable ([String: Any]) -> [String: Any]?
+    ) {
+        StubURLProtocol.responder = { request, body in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: status,
+                httpVersion: "HTTP/1.1",
+                headerFields: ["Content-Type": "application/json"]
+            )!
+            let sent = (try? JSONSerialization.jsonObject(with: body)) as? [String: Any] ?? [:]
+            guard let object = json(sent) else { return (response, nil) }
+            return (response, try? JSONSerialization.data(withJSONObject: object))
+        }
+    }
+
+    private func successBody(
+        role: String = "core",
+        overridingCoreKey: String? = nil
+    ) -> @Sendable ([String: Any]) -> [String: Any]? {
+        let workspace = workspace
+        let device = device
+        let bearer = bearer
+        return { sent in
+            let echoed = overridingCoreKey ?? (sent["encryption_public_key"] as? String ?? "")
+            return [
+                "workspace_id": workspace.uuidString.lowercased(),
+                "device_id": device.uuidString.lowercased(),
+                "role": role,
+                "relay_url": "https://relay.example.invalid",
+                "bearer_token": bearer,
+                "core": [
+                    "public_key": echoed,
+                    "epoch": 1,
+                    "key_id": "ingest-epoch-1"
+                ]
+            ]
+        }
+    }
+
+    private func assertEnrollmentError(
+        _ expected: RemoteEnrollmentError,
+        _ operation: () async throws -> Void,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async {
+        do {
+            try await operation()
+            XCTFail("Expected \(expected.code)", file: file, line: line)
+        } catch let error as RemoteEnrollmentError {
+            XCTAssertEqual(error, expected, file: file, line: line)
+        } catch {
+            XCTFail("Expected \(expected.code), got \(error)", file: file, line: line)
+        }
+    }
+
+    // MARK: - Happy path
+
+    func testSuccessfulEnrollmentAssemblesLoadableConfiguration() async throws {
+        respond(status: 201, json: successBody())
+        let enrollment = try await makeClient().enrollCore(
+            code: " vb-abcde-23456 ",
+            deviceName: "Example Mac"
+        )
+
+        // The request matched the contract…
+        let sent = try XCTUnwrap(
+            (try? JSONSerialization.jsonObject(with: XCTUnwrap(StubURLProtocol.lastRequestBody)))
+                as? [String: Any]
+        )
+        XCTAssertEqual(sent["code"] as? String, "VB-ABCDE-23456")
+        XCTAssertEqual(sent["name"] as? String, "Example Mac")
+        XCTAssertEqual(sent["platform"] as? String, "macos")
+        for key in ["signing_public_key", "encryption_public_key"] {
+            let raw = try XCTUnwrap(sent[key] as? String)
+            let decoded = try XCTUnwrap(Data(base64Encoded: raw))
+            XCTAssertEqual(decoded.count, 65, "\(key) must be uncompressed x963")
+            XCTAssertEqual(decoded.first, 0x04, "\(key) must carry the x963 prefix")
+        }
+        XCTAssertEqual(
+            Data(base64Encoded: sent["signing_public_key"] as? String ?? ""),
+            enrollment.identity.signingPrivateKey.publicKey.x963Representation
+        )
+
+        // …and the response became exactly what a provisioning file installs.
+        let provisioning = enrollment.provisioning
+        XCTAssertEqual(provisioning.schema, 1)
+        XCTAssertEqual(provisioning.workspaceID, workspace)
+        XCTAssertEqual(provisioning.coreDeviceID, device)
+        XCTAssertEqual(provisioning.relayURL.absoluteString, "https://relay.example.invalid")
+        XCTAssertEqual(provisioning.relayBearerToken, bearer)
+        XCTAssertEqual(provisioning.coreEpoch, 1)
+        XCTAssertEqual(provisioning.ingestKeyID, "ingest-epoch-1")
+        XCTAssertTrue(provisioning.probeSigningPublicKeys.isEmpty)
+        XCTAssertEqual(enrollment.deviceName, "Example Mac")
+
+        // The non-secret half round-trips through the on-disk config format.
+        let config = try RemoteCoreConfig(
+            workspaceID: provisioning.workspaceID,
+            coreDeviceID: provisioning.coreDeviceID,
+            relayURL: provisioning.relayURL,
+            coreEpoch: provisioning.coreEpoch,
+            ingestKeyID: provisioning.ingestKeyID,
+            probeSigningPublicKeys: provisioning.probeSigningPublicKeys
+        )
+        let encoded = try JSONEncoder().encode(config)
+        XCTAssertEqual(try JSONDecoder().decode(RemoteCoreConfig.self, from: encoded), config)
+    }
+
+    // MARK: - Error taxonomy
+
+    func testInvalidCodeYieldsTypedError() async throws {
+        respond(status: 404) { _ in ["error": "invalid_code"] }
+        let client = try makeClient()
+        await assertEnrollmentError(.codeRejected) {
+            _ = try await client.enrollCore(code: "VB-ABCDE-23456", deviceName: "Example Mac")
+        }
+    }
+
+    func testCoreExistsYieldsTypedError() async throws {
+        respond(status: 409) { _ in ["error": "core_exists"] }
+        let client = try makeClient()
+        await assertEnrollmentError(.coreExists) {
+            _ = try await client.enrollCore(code: "VB-ABCDE-23456", deviceName: "Example Mac")
+        }
+    }
+
+    func testRateLimitAndServerErrorsAreDistinct() async throws {
+        respond(status: 429) { _ in nil }
+        let client = try makeClient()
+        await assertEnrollmentError(.rateLimited) {
+            _ = try await client.enrollCore(code: "VB-ABCDE-23456", deviceName: "Example Mac")
+        }
+        respond(status: 503) { _ in nil }
+        await assertEnrollmentError(.server(503)) {
+            _ = try await client.enrollCore(code: "VB-ABCDE-23456", deviceName: "Example Mac")
+        }
+    }
+
+    func testTransportFailureYieldsNetworkError() async throws {
+        StubURLProtocol.responder = nil
+        let client = try makeClient()
+        await assertEnrollmentError(.network) {
+            _ = try await client.enrollCore(code: "VB-ABCDE-23456", deviceName: "Example Mac")
+        }
+    }
+
+    func testProbeGrantIsRefusedByTheCore() async throws {
+        respond(status: 201, json: successBody(role: "probe"))
+        let client = try makeClient()
+        await assertEnrollmentError(.wrongRole("probe")) {
+            _ = try await client.enrollCore(code: "VB-ABCDE-23456", deviceName: "Example Mac")
+        }
+    }
+
+    func testEchoedCoreKeyMustMatchTheGeneratedKey() async throws {
+        let other = P256.KeyAgreement.PrivateKey().publicKey.x963Representation
+        respond(
+            status: 201,
+            json: successBody(overridingCoreKey: other.base64EncodedString())
+        )
+        let client = try makeClient()
+        await assertEnrollmentError(.coreKeyMismatch) {
+            _ = try await client.enrollCore(code: "VB-ABCDE-23456", deviceName: "Example Mac")
+        }
+    }
+
+    func testMalformedSuccessBodiesAreRejected() async throws {
+        let client = try makeClient()
+
+        // Missing relay_url entirely.
+        respond(status: 201) { sent in
+            [
+                "workspace_id": "11111111-1111-4111-8111-111111111111",
+                "device_id": "22222222-2222-4222-8222-222222222222",
+                "role": "core",
+                "bearer_token": String(repeating: "b", count: 44),
+                "core": [
+                    "public_key": sent["encryption_public_key"] as? String ?? "",
+                    "epoch": 1,
+                    "key_id": "ingest-epoch-1"
+                ]
+            ]
+        }
+        await assertEnrollmentError(.malformedResponse) {
+            _ = try await client.enrollCore(code: "VB-ABCDE-23456", deviceName: "Example Mac")
+        }
+
+        // A plaintext relay origin can never carry this protocol.
+        respond(status: 201) { sent in
+            [
+                "workspace_id": "11111111-1111-4111-8111-111111111111",
+                "device_id": "22222222-2222-4222-8222-222222222222",
+                "role": "core",
+                "relay_url": "http://relay.example.invalid",
+                "bearer_token": String(repeating: "b", count: 44),
+                "core": [
+                    "public_key": sent["encryption_public_key"] as? String ?? "",
+                    "epoch": 1,
+                    "key_id": "ingest-epoch-1"
+                ]
+            ]
+        }
+        await assertEnrollmentError(.malformedResponse) {
+            _ = try await client.enrollCore(code: "VB-ABCDE-23456", deviceName: "Example Mac")
+        }
+
+        // A too-short bearer token is rejected before it reaches the Vault.
+        respond(status: 201) { sent in
+            [
+                "workspace_id": "11111111-1111-4111-8111-111111111111",
+                "device_id": "22222222-2222-4222-8222-222222222222",
+                "role": "core",
+                "relay_url": "https://relay.example.invalid",
+                "bearer_token": "short",
+                "core": [
+                    "public_key": sent["encryption_public_key"] as? String ?? "",
+                    "epoch": 1,
+                    "key_id": "ingest-epoch-1"
+                ]
+            ]
+        }
+        await assertEnrollmentError(.malformedResponse) {
+            _ = try await client.enrollCore(code: "VB-ABCDE-23456", deviceName: "Example Mac")
+        }
+    }
+
+    // MARK: - Input validation
+
+    func testPlaintextControlURLIsRejected() {
+        for raw in [
+            "http://vibebar.example.invalid",
+            "https://vibebar.example.invalid/api",
+            "https://user:secret@vibebar.example.invalid",
+            "https://vibebar.example.invalid?token=x"
+        ] {
+            let url = URL(string: raw)!
+            XCTAssertThrowsError(try RemoteEnrollmentClient(controlURL: url)) { error in
+                XCTAssertEqual(error as? RemoteEnrollmentError, .invalidControlURL)
+            }
+        }
+        XCTAssertNoThrow(
+            try RemoteEnrollmentClient(controlURL: URL(string: "https://vibebar.example.invalid")!)
+        )
+    }
+
+    func testControlURLTextFallsBackToTheHostedDefault() throws {
+        XCTAssertEqual(
+            try RemoteEnrollmentClient.controlURL(from: "   "),
+            RemoteEnrollmentClient.defaultControlURL
+        )
+        XCTAssertEqual(
+            try RemoteEnrollmentClient.controlURL(from: " https://vibebar.example.invalid "),
+            URL(string: "https://vibebar.example.invalid")
+        )
+    }
+
+    func testPairingCodeNormalization() throws {
+        XCTAssertEqual(
+            try RemoteEnrollmentClient.normalizedCode("  vb-abcde-23456\n"),
+            "VB-ABCDE-23456"
+        )
+        for raw in ["", "   ", "VB ABCDE 23456", "VB-ABCDE-23456!", String(repeating: "A", count: 65)] {
+            XCTAssertThrowsError(try RemoteEnrollmentClient.normalizedCode(raw)) { error in
+                XCTAssertEqual(error as? RemoteEnrollmentError, .invalidCode)
+            }
+        }
+    }
+
+    func testFreshlyJoinedWorkspaceHasNoRegisteredProbes() throws {
+        // A Core that just joined authorizes no producer yet; the config must
+        // still be representable, because probes enroll afterwards.
+        let config = try RemoteCoreConfig(
+            workspaceID: workspace,
+            coreDeviceID: device,
+            relayURL: URL(string: "https://relay.example.invalid")!,
+            coreEpoch: 1,
+            ingestKeyID: "ingest-epoch-1",
+            probeSigningPublicKeys: [:]
+        )
+        XCTAssertTrue(config.probeSigningPublicKeys.isEmpty)
+    }
+}


### PR DESCRIPTION
## Summary

- Add `RemoteEnrollmentClient` (Core): mints a fresh P-256 signing keypair and a fresh P-256 key-agreement keypair, POSTs their x963 public halves plus the pairing code to `<control-url>/api/v1/enroll/consume`, and folds the 201 body into the exact `RemoteCoreProvisioning` a provisioning file produces. Default control URL `https://vibebar.aqor.io`; the origin is validated exactly like `relayURL` (bare HTTPS, no credentials/path/query/fragment).
- Install through the existing path: `RemoteCoreConfigStore.install(_ enrollment:)` stores the new Core identity in the credential Vault, then hands the provisioning to the same `install(_:)` the file import uses, so the Relay bearer token lands in the same Vault entry, `remote_core.json` is written by the same writer, and `RemoteProbeService.reconfigure()` picks the workspace up identically.
- Settings pane: when no remote configuration is installed, "Provisioning" now leads with a compact **Join with a code** affordance — code field (`VB-XXXXX-XXXXX`, trimmed and uppercased), Join button with inline progress, human-readable error text, and an optional "Use a different control center" URL override. The manual export/import flow is unchanged and still available underneath. After a successful join the pane refreshes to the connected state exactly like a file import.
- Error taxonomy surfaced to the UI, none of which can leak a secret: invalid/expired/consumed code (404 `invalid_code`), workspace already has a Core (409 `core_exists`), probe-role grant refused by a Core, rate limited (429), other HTTP status, transport failure, malformed 201 body, and an echoed Core key that does not match the keypair this Mac just generated.
- `RemoteCoreConfig` now accepts an empty probe map. A Mac that has just joined is the workspace's Core before any probe has enrolled; it authorizes no producer until one does, which is the correct fail-closed behavior.
- 12 new tests in `Tests/VibeBarCoreTests/RemoteEnrollmentTests.swift` run against a stubbed `URLProtocol` — no network, no Keychain, synthetic UUIDs and tokens only. The stub echoes the encryption key straight out of the request, so the happy path also asserts the request encoding.

### Follow-up (not in this PR)

A freshly joined Core has no registered probe signing keys, so it cannot yet open envelopes from probes enrolled afterwards. Learning those keys from the control API (`GET /api/v1/workspaces/:ws/devices`) is the natural next step; today the only way to register them is still a provisioning-file import.

## Test plan

- [x] `swift build`
- [x] `swift test` — 1089 tests, 0 failures
- [x] `./Scripts/build_app.sh release`
- [x] `codesign -d --entitlements - ".build/Vibe Bar.app"` → empty `<dict></dict>`, no `app-sandbox`
- [x] `codesign --verify --deep --strict ".build/Vibe Bar.app"` → clean
- [x] AGENTS.md § 6.3 home-directory grep → only the two pre-existing hits inside `RealHomeDirectory.swift`
- [ ] Manual smoke test of the join flow against a live control center — not run here: AQ's installed Vibe Bar was running, and launching a second instance from the worktree would have shared `~/.vibebar/` and the credential Vault with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)