### PR TITLE
Prepare Vibe Bar 1.3.0 Dev build 17

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.3.0</string>
 	<key>CFBundleVersion</key>
-	<string>16</string>
+	<string>17</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>26.0</string>
 	<key>LSUIElement</key>


### PR DESCRIPTION
Dev prerelease for the join-with-code milestone: the Remote Probes pane can now join a workspace by pasting a one-time pairing code from the web control center (PR #141) — fresh Core keypair minted on-device, probe roster self-heals from the Relay each sync, and an interrupted install is resumable from the Keychain without burning another code.

CFBundleVersion 16 → 17; CFBundleShortVersionString stays 1.3.0.

- [x] swift build
- [x] swift test (1101 tests, 0 failures)
- [x] ./Scripts/build_app.sh release
- [x] codesign entitlements empty (no app-sandbox)
- [x] codesign --verify --deep --strict

🤖 Generated with [Claude Code](https://claude.com/claude-code)