### PR TITLE
Skip superseded-epoch relay backlog instead of wedging sync

### DIFF
--- a/Sources/VibeBarCore/Models/RemoteSyncModels.swift
+++ b/Sources/VibeBarCore/Models/RemoteSyncModels.swift
@@ -235,6 +235,12 @@ public enum RemoteSyncError: Error, Equatable, Sendable {
     case invalidSignature
     case decryptionFailed
     case invalidPayload
+    /// An authenticated batch from an earlier, superseded Core generation
+    /// (a strictly lower `core_epoch`). Its recipient key was revoked when the
+    /// Core rotated, so no current device can ever decrypt it. This is not a
+    /// failure: the batch is skipped and acknowledged so the Relay's
+    /// cursor-aware GC can reclaim it, and the stream keeps advancing.
+    case supersededEnvelope
     case sequenceGap(expected: Int64, received: Int64)
     case rollback
     case http(Int)
@@ -249,6 +255,7 @@ public enum RemoteSyncError: Error, Equatable, Sendable {
         case .invalidSignature: return "invalid_signature"
         case .decryptionFailed: return "decryption_failed"
         case .invalidPayload: return "invalid_payload"
+        case .supersededEnvelope: return "superseded_envelope"
         case .sequenceGap: return "sequence_gap"
         case .rollback: return "rollback"
         case .http: return "relay_http_error"

--- a/Sources/VibeBarCore/Services/RemoteProbeService.swift
+++ b/Sources/VibeBarCore/Services/RemoteProbeService.swift
@@ -35,6 +35,22 @@ public final class RemoteProbeService: ObservableObject {
         loadConfiguration()
     }
 
+    /// Test seam: build a service already bound to an in-memory configuration
+    /// and stubbed relay/ledger, bypassing the Keychain and `~/.vibebar` reads
+    /// the production initializer performs. Not used by product code.
+    init(
+        config: RemoteCoreConfig,
+        identity: RemoteCoreIdentity,
+        client: RemoteRelayClient,
+        ledger: RemoteUsageLedger
+    ) {
+        self.config = config
+        self.identity = identity
+        self.client = client
+        self.ledger = ledger
+        self.isConfigured = true
+    }
+
     private func loadConfiguration() {
         configurationGeneration += 1
         do {
@@ -171,27 +187,40 @@ public final class RemoteProbeService: ObservableObject {
         do {
             var cursor = try await ledger.relayCursor(workspaceID: config.workspaceID)
             var pageCount = 0
+            var skippedSuperseded = 0
             while pageCount < 100 {
                 pageCount += 1
                 let page = try await client.fetch(after: cursor)
                 guard generation == configurationGeneration else { return }
                 guard !page.batches.isEmpty else { break }
                 for batch in page.batches {
-                    let opened = try RemoteProtocolCrypto.openIngestEnvelope(
-                        batch.envelope,
-                        config: config,
-                        identity: identity,
-                        acceptedAt: batch.receivedAt
-                    )
-                    let payload = try RemotePayloadDecoder.decode(opened.plaintext)
-                    guard payload.workspaceID == config.workspaceID,
-                          payload.producerID == opened.producerID
-                    else { throw RemoteSyncError.invalidPayload }
-                    _ = try await ledger.importBatch(
-                        payload,
-                        sequence: opened.sequence,
-                        receivedAt: batch.receivedAt
-                    )
+                    do {
+                        let opened = try RemoteProtocolCrypto.openIngestEnvelope(
+                            batch.envelope,
+                            config: config,
+                            identity: identity,
+                            acceptedAt: batch.receivedAt
+                        )
+                        let payload = try RemotePayloadDecoder.decode(opened.plaintext)
+                        guard payload.workspaceID == config.workspaceID,
+                              payload.producerID == opened.producerID
+                        else { throw RemoteSyncError.invalidPayload }
+                        _ = try await ledger.importBatch(
+                            payload,
+                            sequence: opened.sequence,
+                            receivedAt: batch.receivedAt
+                        )
+                    } catch RemoteSyncError.supersededEnvelope {
+                        // Authenticated backlog from a revoked Core generation:
+                        // encrypted to a recipient key no current device holds,
+                        // so it can never be imported. Acknowledge it anyway so
+                        // the Relay's cursor-aware GC reclaims it, then keep
+                        // going. Aborting here (the old behavior) would wedge the
+                        // cursor and make every later sync repeat this failure.
+                        // Every non-superseded error still propagates to the
+                        // outer catch, unchanged.
+                        skippedSuperseded += 1
+                    }
                     try await client.acknowledge(cursor: batch.cursor)
                     cursor = batch.cursor
                     try await ledger.recordSync(
@@ -201,6 +230,12 @@ public final class RemoteProbeService: ObservableObject {
                     )
                 }
                 if page.batches.count < 10 { break }
+            }
+            if skippedSuperseded > 0 {
+                // Count only — never envelope contents or keys.
+                SafeLog.warn(
+                    "remote sync skipped \(skippedSuperseded) superseded-epoch batch(es)"
+                )
             }
             let summaries = try await ledger.machineSummaries(workspaceID: config.workspaceID)
             guard generation == configurationGeneration else { return }

--- a/Sources/VibeBarCore/Services/RemoteProtocolCrypto.swift
+++ b/Sources/VibeBarCore/Services/RemoteProtocolCrypto.swift
@@ -95,6 +95,14 @@ enum RemoteProtocolCrypto {
         identity: RemoteCoreIdentity,
         acceptedAt: Date = Date()
     ) throws -> RemoteOpenedEnvelope {
+        // Structural validation. Every check here is exactly as before EXCEPT
+        // the two that pin an envelope to the *current* generation —
+        // `core_epoch` and `key_id`. Those are decided below, after the
+        // signature proves the producer, so that an authenticated batch from an
+        // earlier generation can be classified `.supersededEnvelope` instead of
+        // a fatal `.invalidEnvelope`. `core_epoch` is still required to be a
+        // positive integer and `key_id` a string; only their equality with the
+        // config moves.
         guard data.count <= 1_048_576,
               let object = try JSONSerialization.jsonObject(with: data) as? [String: Any],
               Set(object.keys) == requiredEnvelopeKeys,
@@ -108,8 +116,8 @@ enum RemoteProtocolCrypto {
               let producerID = UUID(uuidString: producerRaw),
               let expectedSigningKey = config.probeSigningPublicKeys[producerID],
               let sequence = exactInteger(object["sequence"]), sequence > 0,
-              exactInteger(object["core_epoch"]) == Int64(config.coreEpoch),
-              object["key_id"] as? String == config.ingestKeyID,
+              let coreEpoch = exactInteger(object["core_epoch"]), coreEpoch > 0,
+              let keyID = object["key_id"] as? String,
               let createdRaw = object["created_at"] as? String,
               let expiresRaw = object["expires_at"] as? String,
               let createdAt = parseTimestamp(createdRaw),
@@ -132,6 +140,21 @@ enum RemoteProtocolCrypto {
               let signatureData = Data(base64Encoded: signatureRaw), signatureData.count == 64
         else { throw RemoteSyncError.invalidEnvelope }
 
+        // Generation gates that must stay fatal are decided BEFORE the signature
+        // check, so their error (`.invalidEnvelope`) is preserved exactly as the
+        // pre-restructure guard produced it, whether the signature is valid or
+        // not:
+        //   * current epoch but a key id that is not the current generation's;
+        //   * a future epoch — the Core is behind and this must surface, never
+        //     silently skip forward.
+        let expectedEpoch = Int64(config.coreEpoch)
+        if coreEpoch == expectedEpoch, keyID != config.ingestKeyID {
+            throw RemoteSyncError.invalidEnvelope
+        }
+        if coreEpoch > expectedEpoch {
+            throw RemoteSyncError.invalidEnvelope
+        }
+
         var unsigned = object
         unsigned.removeValue(forKey: "signature")
         let signature = try P256.Signing.ECDSASignature(rawRepresentation: signatureData)
@@ -140,6 +163,17 @@ enum RemoteProtocolCrypto {
             signature,
             for: try RemoteCanonicalJSON.encode(unsigned)
         ) else { throw RemoteSyncError.invalidSignature }
+
+        // The signature verified against a producer key already in the config's
+        // roster: forging it requires that probe's signing private key, which is
+        // game-over-equivalent. Only now, with the producer proven, is a batch
+        // from a strictly earlier Core generation classified as superseded
+        // backlog. It is never decrypted or imported — the caller skips and
+        // acknowledges it. A current-generation envelope (equal epoch, matching
+        // key id) falls through to decryption unchanged.
+        if coreEpoch < expectedEpoch {
+            throw RemoteSyncError.supersededEnvelope
+        }
 
         let ephemeralKey = try P256.KeyAgreement.PublicKey(x963Representation: ephemeralData)
         let secret = try identity.recipientPrivateKey.sharedSecretFromKeyAgreement(

--- a/Tests/VibeBarCoreTests/RemoteSupersededEpochTests.swift
+++ b/Tests/VibeBarCoreTests/RemoteSupersededEpochTests.swift
@@ -1,0 +1,448 @@
+import XCTest
+import CryptoKit
+@testable import VibeBarCore
+
+/// A Core rotation (revoke Core → new Core enrolls) bumps `core_epoch` and
+/// mints a new ingest key, but the Relay still holds a backlog of the previous
+/// generation's ciphertext — encrypted to the revoked recipient key no current
+/// device can decrypt. These tests pin the fix: such backlog is classified
+/// `.supersededEnvelope` (skip + ack), never fatal, and the classification can
+/// never be reached without a valid producer signature.
+///
+/// Synthetic UUIDs and freshly generated keys only. The crypto half seals real
+/// envelopes with the exact reverse of `RemoteProtocolCrypto.openIngestEnvelope`
+/// so a passing test also proves the seal/open pair agrees; the service half
+/// drives `RemoteProbeService` against a stubbed `URLProtocol`.
+final class RemoteSupersededEpochTests: XCTestCase {
+    private let workspace = UUID(uuidString: "11111111-1111-4111-8111-111111111111")!
+    private let producer = UUID(uuidString: "22222222-2222-4222-8222-222222222222")!
+
+    // MARK: - openIngestEnvelope classification
+
+    func testSupersededEpochEnvelopeIsClassifiedSuperseded() throws {
+        let identity = makeIdentity()
+        let producerSigningKey = P256.Signing.PrivateKey()
+        let config = try makeConfig(
+            coreEpoch: 2,
+            ingestKeyID: "ingest-epoch-2",
+            keys: [producer: producerSigningKey.publicKey.x963Representation]
+        )
+        // A properly signed batch from the previous generation: config.coreEpoch
+        // - 1, with the old generation's key id.
+        let envelope = try seal(
+            signer: producerSigningKey,
+            recipient: identity.recipientPrivateKey.publicKey,
+            coreEpoch: 1,
+            keyID: "ingest-epoch-1",
+            sequence: 1,
+            plaintext: Data("never decrypted".utf8)
+        )
+        let data = try JSONSerialization.data(withJSONObject: envelope)
+        XCTAssertThrowsError(
+            try RemoteProtocolCrypto.openIngestEnvelope(
+                data, config: config, identity: identity,
+                acceptedAt: iso("2026-08-03T06:01:00Z")
+            )
+        ) { error in
+            XCTAssertEqual(
+                error as? RemoteSyncError, .supersededEnvelope,
+                "An authenticated older-epoch batch must be superseded, not invalid_envelope"
+            )
+        }
+    }
+
+    func testSupersededClassificationRequiresAValidSignature() throws {
+        let identity = makeIdentity()
+        let producerSigningKey = P256.Signing.PrivateKey()
+        // Not in the roster. It signs the batch, but the envelope still
+        // advertises (and the config still expects) the producer's key.
+        let attacker = P256.Signing.PrivateKey()
+        let config = try makeConfig(
+            coreEpoch: 2,
+            ingestKeyID: "ingest-epoch-2",
+            keys: [producer: producerSigningKey.publicKey.x963Representation]
+        )
+        let envelope = try seal(
+            signer: producerSigningKey,
+            signatureKey: attacker,
+            recipient: identity.recipientPrivateKey.publicKey,
+            coreEpoch: 1,
+            keyID: "ingest-epoch-1",
+            sequence: 1,
+            plaintext: Data("forged".utf8)
+        )
+        let data = try JSONSerialization.data(withJSONObject: envelope)
+        XCTAssertThrowsError(
+            try RemoteProtocolCrypto.openIngestEnvelope(
+                data, config: config, identity: identity,
+                acceptedAt: iso("2026-08-03T06:01:00Z")
+            )
+        ) { error in
+            // The signature gate fires before the superseded decision, so a
+            // forged old-epoch batch is rejected, never silently skipped.
+            XCTAssertEqual(error as? RemoteSyncError, .invalidSignature)
+            XCTAssertNotEqual(error as? RemoteSyncError, .supersededEnvelope)
+        }
+    }
+
+    func testFutureEpochStaysFatal() throws {
+        let identity = makeIdentity()
+        let producerSigningKey = P256.Signing.PrivateKey()
+        let config = try makeConfig(
+            coreEpoch: 2,
+            ingestKeyID: "ingest-epoch-2",
+            keys: [producer: producerSigningKey.publicKey.x963Representation]
+        )
+        // A properly signed batch whose epoch is AHEAD of this Core: the Core is
+        // behind and this must surface, never skip forward.
+        let envelope = try seal(
+            signer: producerSigningKey,
+            recipient: identity.recipientPrivateKey.publicKey,
+            coreEpoch: 3,
+            keyID: "ingest-epoch-3",
+            sequence: 1,
+            plaintext: Data("ahead".utf8)
+        )
+        let data = try JSONSerialization.data(withJSONObject: envelope)
+        XCTAssertThrowsError(
+            try RemoteProtocolCrypto.openIngestEnvelope(
+                data, config: config, identity: identity,
+                acceptedAt: iso("2026-08-03T06:01:00Z")
+            )
+        ) { error in
+            XCTAssertEqual(error as? RemoteSyncError, .invalidEnvelope)
+        }
+    }
+
+    // MARK: - Service-level: superseded backlog does not wedge the stream
+
+    @MainActor
+    func testRefreshSkipsSupersededBatchAndImportsCurrentOne() async throws {
+        let identity = makeIdentity()
+        let producerSigningKey = P256.Signing.PrivateKey()
+        let config = try makeConfig(
+            coreEpoch: 2,
+            ingestKeyID: "ingest-epoch-2",
+            keys: [producer: producerSigningKey.publicKey.x963Representation]
+        )
+
+        // First batch: superseded backlog from epoch 1, encrypted to a revoked
+        // recipient key the current Core does not hold.
+        let superseded = try seal(
+            signer: producerSigningKey,
+            recipient: P256.KeyAgreement.PrivateKey().publicKey,
+            coreEpoch: 1,
+            keyID: "ingest-epoch-1",
+            sequence: 1,
+            plaintext: Data("cannot be opened".utf8)
+        )
+        // Second batch: current epoch, encrypted to this Core's recipient key,
+        // carrying a real usage payload at sequence 1.
+        let current = try seal(
+            signer: producerSigningKey,
+            recipient: identity.recipientPrivateKey.publicKey,
+            coreEpoch: 2,
+            keyID: "ingest-epoch-2",
+            sequence: 1,
+            plaintext: try usagePayload(sequence: 1)
+        )
+
+        let received = Int64(iso("2026-08-03T06:01:00Z").timeIntervalSince1970)
+        StubRelay.reset()
+        StubRelay.deviceKey = producerSigningKey.publicKey.x963Representation
+        StubRelay.producer = producer
+        StubRelay.core = config.coreDeviceID
+        StubRelay.page = [
+            ["cursor": "c1", "received_at": received, "envelope": superseded],
+            ["cursor": "c2", "received_at": received, "envelope": current]
+        ]
+        StubRelay.nextCursor = "c2"
+        defer { StubRelay.reset() }
+
+        let client = makeClient(config)
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("remote-superseded-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: false)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let ledger = try RemoteUsageLedger(url: directory.appendingPathComponent("ledger.sqlite3"))
+
+        let service = RemoteProbeService(
+            config: config, identity: identity, client: client, ledger: ledger
+        )
+        await service.refresh()
+
+        // The superseded batch was skipped but not fatal: the current batch
+        // imported and the sync succeeded.
+        XCTAssertNil(service.lastErrorCode)
+        XCTAssertEqual(service.machines.count, 1)
+        XCTAssertEqual(service.machines.first?.producerID, producer)
+        XCTAssertEqual(service.machines.first?.allTimeTokens, 15)
+
+        // Both cursors were acknowledged so the Relay GC can reclaim them, and
+        // the ledger cursor advanced past BOTH batches.
+        XCTAssertEqual(Set(StubRelay.acknowledged()), ["c1", "c2"])
+        let cursor = try await ledger.relayCursor(workspaceID: workspace)
+        XCTAssertEqual(cursor, "c2")
+    }
+
+    // MARK: - Fixtures
+
+    private func makeIdentity() -> RemoteCoreIdentity {
+        RemoteCoreIdentity(
+            signingPrivateKey: P256.Signing.PrivateKey(),
+            recipientPrivateKey: P256.KeyAgreement.PrivateKey()
+        )
+    }
+
+    private func makeConfig(
+        coreEpoch: Int,
+        ingestKeyID: String,
+        keys: [UUID: Data]
+    ) throws -> RemoteCoreConfig {
+        try RemoteCoreConfig(
+            workspaceID: workspace,
+            coreDeviceID: UUID(uuidString: "99999999-9999-4999-8999-999999999999")!,
+            relayURL: URL(string: "https://relay.example.invalid")!,
+            coreEpoch: coreEpoch,
+            ingestKeyID: ingestKeyID,
+            probeSigningPublicKeys: keys
+        )
+    }
+
+    private func iso(_ value: String) -> Date {
+        ISO8601DateFormatter().date(from: value)!
+    }
+
+    /// Seal an ingest envelope with the exact reverse of the open path:
+    /// AES-GCM over the plaintext with the canonical header as AAD, then a P-256
+    /// signature over the canonical unsigned envelope. `signatureKey`, when set,
+    /// signs with a different key than the one the envelope advertises — used to
+    /// forge a bad signature while keeping the advertised producer key intact.
+    private func seal(
+        signer: P256.Signing.PrivateKey,
+        signatureKey: P256.Signing.PrivateKey? = nil,
+        recipient: P256.KeyAgreement.PublicKey,
+        coreEpoch: Int,
+        keyID: String,
+        sequence: Int64,
+        createdAt: String = "2026-08-03T06:00:00Z",
+        expiresAt: String = "2026-09-02T06:00:00Z",
+        plaintext: Data,
+        nonce: Data = Data((0..<12).map { UInt8($0) })
+    ) throws -> [String: Any] {
+        let ephemeral = P256.KeyAgreement.PrivateKey()
+        let header: [String: Any] = [
+            "protocol_version": 1,
+            "minimum_consumer_version": 1,
+            "workspace_id": workspace.uuidString.lowercased(),
+            "stream": "ingest",
+            "producer_id": producer.uuidString.lowercased(),
+            "sequence": Int(sequence),
+            "core_epoch": coreEpoch,
+            "key_id": keyID,
+            "created_at": createdAt,
+            "expires_at": expiresAt,
+            "ephemeral_public_key": ephemeral.publicKey.x963Representation.base64EncodedString(),
+            "nonce": nonce.base64EncodedString(),
+            "signing_public_key": signer.publicKey.x963Representation.base64EncodedString()
+        ]
+        let secret = try ephemeral.sharedSecretFromKeyAgreement(with: recipient)
+        let symmetricKey = secret.hkdfDerivedSymmetricKey(
+            using: SHA256.self,
+            salt: Data("VibeBar Sync Protocol v1\0".utf8),
+            sharedInfo: hkdfInfo(sequence: sequence),
+            outputByteCount: 32
+        )
+        let sealed = try AES.GCM.seal(
+            plaintext,
+            using: symmetricKey,
+            nonce: AES.GCM.Nonce(data: nonce),
+            authenticating: try canonical(header)
+        )
+        var ciphertext = sealed.ciphertext
+        ciphertext.append(sealed.tag)
+        var object = header
+        object["ciphertext"] = ciphertext.base64EncodedString()
+        let signature = try (signatureKey ?? signer)
+            .signature(for: try canonical(object)).rawRepresentation
+        object["signature"] = signature.base64EncodedString()
+        return object
+    }
+
+    /// Canonicalize through the same round trip `openIngestEnvelope` performs
+    /// (it re-parses `Data` before encoding), so the AAD and signature bytes
+    /// computed here match byte-for-byte.
+    private func canonical(_ object: [String: Any]) throws -> Data {
+        let reparsed = try JSONSerialization.jsonObject(
+            with: try JSONSerialization.data(withJSONObject: object)
+        )
+        return try RemoteCanonicalJSON.encode(reparsed)
+    }
+
+    private func hkdfInfo(sequence: Int64) -> Data {
+        var output = Data("vibebar/envelope/v1\0ingest\0".utf8)
+        output.append(contentsOf: workspace.uuidString.lowercased().utf8)
+        output.append(0)
+        output.append(contentsOf: producer.uuidString.lowercased().utf8)
+        output.append(0)
+        var bigEndian = UInt64(sequence).bigEndian
+        withUnsafeBytes(of: &bigEndian) { output.append(contentsOf: $0) }
+        return output
+    }
+
+    private func usagePayload(sequence: Int) throws -> Data {
+        let operation: [String: Any] = [
+            "op": "usage_upsert",
+            "source_key": String(repeating: "s", count: 43),
+            "source_generation": 1,
+            "event_key": String(repeating: "e", count: 42) + String(sequence),
+            "tool": "codex",
+            "occurred_at": "2026-08-03T06:00:00Z",
+            "observed_at": "2026-08-03T06:01:00Z",
+            "model": "example-model",
+            "tokens": [
+                "input": 10, "output": 5, "cache_read": 0,
+                "cache_creation": 0, "reasoning": 0, "tool": 0,
+                "total_only": NSNull()
+            ],
+            "request_count": 1,
+            "service_tier": NSNull(),
+            "accounting": "exact",
+            "parser_version": 1
+        ]
+        let body: [String: Any] = [
+            "schema": 1,
+            "workspace_id": workspace.uuidString.lowercased(),
+            "producer_id": producer.uuidString.lowercased(),
+            "probe": [
+                "alias": "Example machine", "version": "0.1.0",
+                "platform": "linux-x86_64", "timezone": "UTC"
+            ],
+            "previous_sequence": sequence == 1 ? NSNull() : (sequence - 1) as Any,
+            "operations": [operation],
+            "status": [
+                "last_scan_at": "2026-08-03T06:01:00Z",
+                "backlog_batches": 1,
+                "applied_control_sequence": 0,
+                "sources": ["codex": "ok"]
+            ]
+        ]
+        return try JSONSerialization.data(withJSONObject: body)
+    }
+
+    private func makeClient(_ config: RemoteCoreConfig) -> RemoteRelayClient {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [StubRelay.self]
+        return RemoteRelayClient(
+            config: config,
+            bearerToken: String(repeating: "t", count: 40),
+            session: URLSession(configuration: configuration)
+        )
+    }
+}
+
+/// Stubs the three Relay endpoints the refresh loop touches (devices roster,
+/// batch page, ack) and records the cursors that were acknowledged.
+private final class StubRelay: URLProtocol {
+    nonisolated(unsafe) static var page: [[String: Any]] = []
+    nonisolated(unsafe) static var nextCursor = ""
+    nonisolated(unsafe) static var deviceKey = Data()
+    nonisolated(unsafe) static var producer = UUID()
+    nonisolated(unsafe) static var core = UUID()
+    nonisolated(unsafe) private static var acks: [String] = []
+    private static let lock = NSLock()
+
+    static func reset() {
+        lock.lock(); defer { lock.unlock() }
+        page = []
+        nextCursor = ""
+        deviceKey = Data()
+        acks = []
+    }
+
+    static func acknowledged() -> [String] {
+        lock.lock(); defer { lock.unlock() }
+        return acks
+    }
+
+    private static func recordAck(_ cursor: String) {
+        lock.lock(); defer { lock.unlock() }
+        acks.append(cursor)
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+    override func stopLoading() {}
+
+    override func startLoading() {
+        let response = HTTPURLResponse(
+            url: request.url!,
+            statusCode: 200,
+            httpVersion: "HTTP/1.1",
+            headerFields: ["Cache-Control": "no-store"]
+        )!
+        let body = Self.body(for: request)
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        if let body { client?.urlProtocol(self, didLoad: body) }
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    private static func body(for request: URLRequest) -> Data? {
+        let path = request.url?.path ?? ""
+        if path.hasSuffix("/devices") {
+            return try? JSONSerialization.data(withJSONObject: [
+                "devices": [
+                    [
+                        "device_id": producer.uuidString.lowercased(),
+                        "role": "probe",
+                        "status": "active",
+                        "signing_public_key": deviceKey.base64EncodedString()
+                    ],
+                    [
+                        "device_id": core.uuidString.lowercased(),
+                        "role": "core",
+                        "status": "active"
+                    ]
+                ]
+            ])
+        }
+        if path.hasSuffix("/batches") {
+            return try? JSONSerialization.data(withJSONObject: [
+                "batches": page,
+                "next_cursor": nextCursor
+            ])
+        }
+        if path.hasSuffix("/acks") {
+            let cursor = ackCursor(request)
+            recordAck(cursor)
+            return try? JSONSerialization.data(withJSONObject: ["acknowledged_cursor": cursor])
+        }
+        return nil
+    }
+
+    private static func ackCursor(_ request: URLRequest) -> String {
+        let data = requestBody(request)
+        guard let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let cursor = object["cursor"] as? String
+        else { return "" }
+        return cursor
+    }
+
+    /// URLProtocol receives POST bodies via `httpBodyStream`, not `httpBody`.
+    private static func requestBody(_ request: URLRequest) -> Data {
+        if let body = request.httpBody { return body }
+        guard let stream = request.httpBodyStream else { return Data() }
+        stream.open()
+        defer { stream.close() }
+        var data = Data()
+        let size = 4096
+        let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: size)
+        defer { buffer.deallocate() }
+        while stream.hasBytesAvailable {
+            let read = stream.read(buffer, maxLength: size)
+            if read <= 0 { break }
+            data.append(buffer, count: read)
+        }
+        return data
+    }
+}


### PR DESCRIPTION
## Summary
- Fixes a security-boundary correctness bug where a **Core rotation** (revoke Core → new Core enrolls → `coreEpoch` 1→2, new `ingestKeyID`) permanently wedged remote sync. The Relay still holds a backlog of the previous generation's ciphertext, encrypted to the revoked recipient key no current device can decrypt. `openIngestEnvelope` threw `.invalidEnvelope` on the first epoch-1 batch, the per-batch loop had no error handling, the whole refresh aborted, the cursor never advanced, and every later sync repeated the failure (`Latest sync error: invalid_envelope`, `Last sync: never`).
- `RemoteProtocolCrypto.openIngestEnvelope` now classifies an **authenticated older-generation** batch as the new dedicated `RemoteSyncError.supersededEnvelope` (code `"superseded_envelope"`), distinct from every other validation failure.
- `RemoteProbeService.performRefresh` **skips + acknowledges** a superseded batch (so the Relay's cursor-aware GC reclaims it) and keeps consuming, instead of aborting. Any other error keeps today's fatal behavior.

## Why the superseded path cannot be abused
A batch reaches the superseded branch only after it (1) passes **every** structural check the current-generation path passes — workspace binding, known producer, size/timestamp bounds, well-formed crypto material, signing-key match — and (2) its producer **signature verifies** against a key already in `config.probeSigningPublicKeys`. Forging that signature needs the probe's signing private key, which is game-over-equivalent. Only then, if `core_epoch` is a positive integer **strictly less than** `config.coreEpoch`, is it superseded — and the sole effect is ack+skip; nothing is decrypted or imported. `core_epoch == config` with a mismatched `key_id`, and any `core_epoch > config`, stay fatal `.invalidEnvelope` and are decided **before** the signature check, so their exact error is preserved. No existing check is weakened.

## Changes
- `Sources/VibeBarCore/Models/RemoteSyncModels.swift` — add `.supersededEnvelope` case + `"superseded_envelope"` code.
- `Sources/VibeBarCore/Services/RemoteProtocolCrypto.swift` — restructure `openIngestEnvelope`: move the `core_epoch`/`key_id` generation checks out of the structural guard, verify the signature before the superseded decision, classify strictly-lower authenticated epochs as `.supersededEnvelope`.
- `Sources/VibeBarCore/Services/RemoteProbeService.swift` — per-batch `do/catch` for `.supersededEnvelope` only (ack + advance cursor + count + continue); count-only `SafeLog` line. Adds an internal test-only initializer.
- `Tests/VibeBarCoreTests/RemoteSupersededEpochTests.swift` — new tests (see below).

## Test plan
- [x] `swift build`
- [x] `swift test` — 1105 tests pass, including 4 new:
  - superseded epoch (`config.coreEpoch - 1`, properly signed) → `.supersededEnvelope`, not `.invalidEnvelope`
  - bad signature + old epoch → `.invalidSignature` (classification never bypasses signature auth)
  - future epoch (`> config`) → fatal `.invalidEnvelope`
  - service-level: page whose first batch is superseded and second is current imports the second, advances the cursor past both, acks both, ends with `lastErrorCode == nil`
- [x] `./Scripts/build_app.sh release`
- [x] `codesign -d --entitlements` — empty `<dict/>`, no `app-sandbox`
- [x] `codesign --verify --deep --strict` — OK
- [x] AGENTS.md §6 home-directory grep — no new hits (only the canonical `RealHomeDirectory.swift`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)