### PR TITLE
Prepare Vibe Bar 1.3.0 Dev build 18

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.3.0</string>
 	<key>CFBundleVersion</key>
-	<string>17</string>
+	<string>18</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>26.0</string>
 	<key>LSUIElement</key>


### PR DESCRIPTION
Dev prerelease carrying the Core-rotation sync fix (PR #143): after a workspace revokes and replaces its Core, the new Core no longer wedges on the previous generation's undecryptable ingest backlog. Superseded-epoch batches — only after their producer signature verifies — are skipped and acknowledged so the relay reclaims them, and the stream keeps advancing. Fixes the live 'invalid_envelope / Last sync: never' stall.

CFBundleVersion 17 → 18; CFBundleShortVersionString stays 1.3.0.

- [x] swift build
- [x] swift test (1105 tests, 0 failures)
- [x] ./Scripts/build_app.sh release
- [x] codesign entitlements empty (no app-sandbox)
- [x] codesign --verify --deep --strict

🤖 Generated with [Claude Code](https://claude.com/claude-code)