### PR TITLE
Scope the relay sync cursor to the consuming Core device

### DIFF
--- a/Sources/VibeBarCore/Services/RemoteProbeService.swift
+++ b/Sources/VibeBarCore/Services/RemoteProbeService.swift
@@ -185,7 +185,10 @@ public final class RemoteProbeService: ObservableObject {
         config = await synchronizedProbeRoster(config, client: client, generation: generation)
         guard generation == configurationGeneration else { return }
         do {
-            var cursor = try await ledger.relayCursor(workspaceID: config.workspaceID)
+            var cursor = try await ledger.relayCursor(
+                workspaceID: config.workspaceID,
+                coreDeviceID: config.coreDeviceID
+            )
             var pageCount = 0
             var skippedSuperseded = 0
             while pageCount < 100 {
@@ -225,6 +228,7 @@ public final class RemoteProbeService: ObservableObject {
                     cursor = batch.cursor
                     try await ledger.recordSync(
                         workspaceID: config.workspaceID,
+                        coreDeviceID: config.coreDeviceID,
                         cursor: cursor,
                         errorCode: nil
                     )
@@ -248,6 +252,7 @@ public final class RemoteProbeService: ObservableObject {
             lastErrorCode = code
             try? await ledger.recordSync(
                 workspaceID: config.workspaceID,
+                coreDeviceID: config.coreDeviceID,
                 cursor: nil,
                 errorCode: code
             )

--- a/Sources/VibeBarCore/Services/RemoteUsageLedger.swift
+++ b/Sources/VibeBarCore/Services/RemoteUsageLedger.swift
@@ -97,12 +97,59 @@ public actor RemoteUsageLedger {
                 workspace_id TEXT PRIMARY KEY,
                 relay_cursor TEXT,
                 last_sync_at INTEGER,
-                last_error_code TEXT
+                last_error_code TEXT,
+                core_device_id TEXT
             );
             """
         guard sqlite3_exec(database, sql, nil, nil, nil) == SQLITE_OK else {
             throw RemoteSyncError.invalidConfiguration
         }
+        try migrateSyncStateCoreDevice(database)
+    }
+
+    /// The relay cursor is HMAC-bound to the consuming device, so a cursor
+    /// stored by a previous Core (same workspace, different `core_device_id`)
+    /// is rejected by the Relay if replayed. `core_device_id` records which
+    /// Core minted the stored cursor; `relayCursor(workspaceID:coreDeviceID:)`
+    /// drops any cursor that does not belong to the current Core. Databases
+    /// created before this column exists must gain it without losing data, so
+    /// add it idempotently: brand-new DBs already have it from the CREATE
+    /// above (skip), pre-migration DBs get it as NULL (self-heals on the next
+    /// sync, no re-join needed).
+    private static func migrateSyncStateCoreDevice(_ database: OpaquePointer) throws {
+        guard !columnExists(database, table: "remote_sync_state", column: "core_device_id") else {
+            return
+        }
+        guard sqlite3_exec(
+            database,
+            "ALTER TABLE remote_sync_state ADD COLUMN core_device_id TEXT",
+            nil, nil, nil
+        ) == SQLITE_OK else {
+            throw RemoteSyncError.invalidConfiguration
+        }
+    }
+
+    /// Whether `table` already has `column`, via `PRAGMA table_info`. Both
+    /// arguments are fixed internal identifiers, never user input.
+    private static func columnExists(
+        _ database: OpaquePointer,
+        table: String,
+        column: String
+    ) -> Bool {
+        var statement: OpaquePointer?
+        guard sqlite3_prepare_v2(
+            database,
+            "PRAGMA table_info(\(table))",
+            -1, &statement, nil
+        ) == SQLITE_OK, let statement else { return false }
+        defer { sqlite3_finalize(statement) }
+        while sqlite3_step(statement) == SQLITE_ROW {
+            if let raw = sqlite3_column_text(statement, 1),
+               String(cString: raw) == column {
+                return true
+            }
+        }
+        return false
     }
 
     @discardableResult
@@ -238,34 +285,62 @@ public actor RemoteUsageLedger {
         }
     }
 
-    public func relayCursor(workspaceID: UUID) throws -> String? {
-        try scalarText(
-            "SELECT relay_cursor FROM remote_sync_state WHERE workspace_id = ?",
-            [.text(workspaceID.uuidString.lowercased())]
+    /// The stored relay cursor for this workspace, but only when it was minted
+    /// by `coreDeviceID`. The Relay HMAC-binds every cursor to the device that
+    /// consumed it, so a cursor left by an earlier Core (revoked, then this Mac
+    /// re-joined as a new Core with the same workspace) would make the Relay
+    /// reject the replay with a 400 and wedge the stream. Returning nil on a
+    /// mismatch — including a pre-migration row whose `core_device_id` is NULL
+    /// — makes the next fetch pass `after: nil`, so the Relay serves from this
+    /// device's own server-side cursor and the local stale cursor is discarded.
+    public func relayCursor(workspaceID: UUID, coreDeviceID: UUID) throws -> String? {
+        let statement = try prepare(
+            "SELECT relay_cursor, core_device_id FROM remote_sync_state WHERE workspace_id = ?"
         )
+        defer { sqlite3_finalize(statement) }
+        bind(.text(workspaceID.uuidString.lowercased()), at: 1, to: statement)
+        let result = sqlite3_step(statement)
+        if result == SQLITE_DONE { return nil }
+        guard result == SQLITE_ROW else { throw RemoteSyncError.invalidPayload }
+        guard let storedDevice = columnText(statement, 1),
+              storedDevice == coreDeviceID.uuidString.lowercased()
+        else { return nil }
+        return columnText(statement, 0)
     }
 
     public func recordSync(
         workspaceID: UUID,
+        coreDeviceID: UUID,
         cursor: String?,
         errorCode: String?,
         at date: Date = Date()
     ) throws {
+        // `core_device_id` moves in lockstep with `relay_cursor`: it is only
+        // (re)written when a fresh cursor is supplied, and preserved verbatim
+        // whenever the cursor is carried over via COALESCE (the error path
+        // passes cursor: nil). That invariant matters — stamping the current
+        // device onto a carried-over cursor from another Core would re-arm the
+        // exact 400 wedge this fix removes.
         try run(
             """
             INSERT INTO remote_sync_state(
-                   workspace_id, relay_cursor, last_sync_at, last_error_code
-               ) VALUES(?, ?, ?, ?)
+                   workspace_id, relay_cursor, last_sync_at, last_error_code, core_device_id
+               ) VALUES(?, ?, ?, ?, ?)
                ON CONFLICT(workspace_id) DO UPDATE SET
                    relay_cursor = COALESCE(excluded.relay_cursor, remote_sync_state.relay_cursor),
                    last_sync_at = excluded.last_sync_at,
-                   last_error_code = excluded.last_error_code
+                   last_error_code = excluded.last_error_code,
+                   core_device_id = CASE
+                       WHEN excluded.relay_cursor IS NOT NULL THEN excluded.core_device_id
+                       ELSE remote_sync_state.core_device_id
+                   END
             """,
             [
                 .text(workspaceID.uuidString.lowercased()),
                 cursor.map(Binding.text) ?? .null,
                 .integer(Int64(date.timeIntervalSince1970)),
-                errorCode.map(Binding.text) ?? .null
+                errorCode.map(Binding.text) ?? .null,
+                .text(coreDeviceID.uuidString.lowercased())
             ]
         )
     }

--- a/Tests/VibeBarCoreTests/RemoteCursorDeviceBindingTests.swift
+++ b/Tests/VibeBarCoreTests/RemoteCursorDeviceBindingTests.swift
@@ -1,0 +1,269 @@
+import XCTest
+import CryptoKit
+import SQLite3
+@testable import VibeBarCore
+
+/// The Relay HMAC-binds every batch cursor to the device that consumed it. When
+/// a Mac revokes its old Core and re-joins the same workspace as a *new* Core
+/// (new `core_device_id`, same `workspace_id`), the cursor cached locally by the
+/// old Core no longer belongs to the current principal — replaying it makes the
+/// Relay answer 400 and the sync wedges forever on `relay_http_error`.
+///
+/// These tests pin the fix: the local cursor is scoped to the Core device that
+/// minted it, a foreign or pre-migration (NULL) owner is treated as "no cursor",
+/// and the very next sync recovers with `after: nil` — no re-join required,
+/// because the Relay remembers each device's own server-side cursor.
+final class RemoteCursorDeviceBindingTests: XCTestCase {
+    private let workspace = UUID(uuidString: "11111111-1111-4111-8111-111111111111")!
+    private let coreDeviceA = UUID(uuidString: "88888888-8888-4888-8888-888888888888")!
+    private let coreDeviceB = UUID(uuidString: "99999999-9999-4999-8999-999999999999")!
+
+    // MARK: - Ledger unit tests
+
+    func testRelayCursorIsScopedToCoreDevice() async throws {
+        let ledger = try makeLedger()
+        try await ledger.recordSync(
+            workspaceID: workspace,
+            coreDeviceID: coreDeviceA,
+            cursor: "cursor-a",
+            errorCode: nil
+        )
+
+        // The device that stored it reads it back.
+        let owned = try await ledger.relayCursor(workspaceID: workspace, coreDeviceID: coreDeviceA)
+        XCTAssertEqual(owned, "cursor-a")
+
+        // A different Core device (a re-joined Core) sees no cursor at all.
+        let foreign = try await ledger.relayCursor(workspaceID: workspace, coreDeviceID: coreDeviceB)
+        XCTAssertNil(foreign)
+    }
+
+    func testErrorPathPreservesCursorOwnershipWithoutRearmingTheWedge() async throws {
+        let ledger = try makeLedger()
+        try await ledger.recordSync(
+            workspaceID: workspace,
+            coreDeviceID: coreDeviceA,
+            cursor: "cursor-a",
+            errorCode: nil
+        )
+        // A failed sync by a *different* Core (cursor: nil, error set) must not
+        // stamp its own device onto the carried-over cursor — that would make
+        // `cursor-a` look like it belongs to device B and re-arm the 400 wedge.
+        try await ledger.recordSync(
+            workspaceID: workspace,
+            coreDeviceID: coreDeviceB,
+            cursor: nil,
+            errorCode: "relay_http_error"
+        )
+        let ownerCursor = try await ledger.relayCursor(workspaceID: workspace, coreDeviceID: coreDeviceA)
+        XCTAssertEqual(ownerCursor, "cursor-a", "The original owner still owns the carried-over cursor")
+        let errorDeviceCursor = try await ledger.relayCursor(workspaceID: workspace, coreDeviceID: coreDeviceB)
+        XCTAssertNil(errorDeviceCursor, "A device that only recorded an error never inherits the cursor")
+    }
+
+    func testPreMigrationNullDeviceRowInvalidatesCursor() async throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let url = directory.appendingPathComponent("ledger.sqlite3")
+
+        // Reproduce a database written before `core_device_id` existed: the old
+        // schema, with a cursor row and no ownership column.
+        try writeLegacySyncState(at: url, cursor: "legacy-cursor")
+
+        // Opening through the current ledger runs the additive migration
+        // (ALTER TABLE ... ADD COLUMN core_device_id), leaving the legacy row's
+        // ownership NULL.
+        let ledger = try RemoteUsageLedger(url: url)
+
+        // A NULL owner never matches any Core, so the stale cursor is dropped
+        // and the next fetch will start from the Relay's server-side cursor.
+        let legacyForA = try await ledger.relayCursor(workspaceID: workspace, coreDeviceID: coreDeviceA)
+        XCTAssertNil(legacyForA)
+        let legacyForB = try await ledger.relayCursor(workspaceID: workspace, coreDeviceID: coreDeviceB)
+        XCTAssertNil(legacyForB)
+
+        // The migration is non-destructive: a fresh recordSync re-establishes
+        // ownership and the cursor becomes readable again.
+        try await ledger.recordSync(
+            workspaceID: workspace,
+            coreDeviceID: coreDeviceA,
+            cursor: "healed-cursor",
+            errorCode: nil
+        )
+        let healed = try await ledger.relayCursor(workspaceID: workspace, coreDeviceID: coreDeviceA)
+        XCTAssertEqual(healed, "healed-cursor")
+    }
+
+    // MARK: - Service-level: a foreign-device cursor does not wedge the stream
+
+    @MainActor
+    func testRefreshDiscardsForeignDeviceCursorAndDoesNotWedge() async throws {
+        let config = try RemoteCoreConfig(
+            workspaceID: workspace,
+            coreDeviceID: coreDeviceB,
+            relayURL: URL(string: "https://relay.example.invalid")!,
+            coreEpoch: 1,
+            ingestKeyID: "ingest-epoch-1",
+            probeSigningPublicKeys: [:]
+        )
+        let identity = RemoteCoreIdentity(
+            signingPrivateKey: P256.Signing.PrivateKey(),
+            recipientPrivateKey: P256.KeyAgreement.PrivateKey()
+        )
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let ledger = try RemoteUsageLedger(url: directory.appendingPathComponent("ledger.sqlite3"))
+
+        // Seed a cursor left behind by the *revoked* Core (device A) before this
+        // Mac re-joined as device B.
+        try await ledger.recordSync(
+            workspaceID: workspace,
+            coreDeviceID: coreDeviceA,
+            cursor: "stale-cursor",
+            errorCode: nil
+        )
+
+        CursorBindingStubRelay.reset()
+        defer { CursorBindingStubRelay.reset() }
+        let sessionConfig = URLSessionConfiguration.ephemeral
+        sessionConfig.protocolClasses = [CursorBindingStubRelay.self]
+        let client = RemoteRelayClient(
+            config: config,
+            bearerToken: String(repeating: "t", count: 40),
+            session: URLSession(configuration: sessionConfig)
+        )
+        let service = RemoteProbeService(
+            config: config, identity: identity, client: client, ledger: ledger
+        )
+        await service.refresh()
+
+        // The foreign cursor was dropped: the batch fetch went out with no
+        // `after` param (had it replayed "stale-cursor", the stub answers 400),
+        // so the stream did not wedge.
+        XCTAssertNil(service.lastErrorCode)
+        let afters = CursorBindingStubRelay.recordedAfters()
+        XCTAssertEqual(afters.count, 1, "Exactly one batch page was requested")
+        XCTAssertNil(afters.first!, "The batch fetch omitted the stale cursor")
+
+        // The stale cursor stays invisible to the current Core on a re-read.
+        let currentCursor = try await ledger.relayCursor(workspaceID: workspace, coreDeviceID: coreDeviceB)
+        XCTAssertNil(currentCursor)
+    }
+
+    // MARK: - Fixtures
+
+    private func makeLedger() throws -> RemoteUsageLedger {
+        let directory = try makeTemporaryDirectory()
+        addTeardownBlock { try? FileManager.default.removeItem(at: directory) }
+        return try RemoteUsageLedger(url: directory.appendingPathComponent("ledger.sqlite3"))
+    }
+
+    private func makeTemporaryDirectory() throws -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("remote-cursor-binding-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: false)
+        return directory
+    }
+
+    /// Create the pre-migration `remote_sync_state` schema (no `core_device_id`
+    /// column) with one cursor row, using raw SQLite so the ledger's own
+    /// migration path is exercised on open. `cursor` is a test literal.
+    private func writeLegacySyncState(at url: URL, cursor: String) throws {
+        var handle: OpaquePointer?
+        guard sqlite3_open_v2(
+            url.path,
+            &handle,
+            SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE,
+            nil
+        ) == SQLITE_OK, let handle else {
+            XCTFail("could not open legacy ledger")
+            throw RemoteSyncError.invalidConfiguration
+        }
+        defer { sqlite3_close_v2(handle) }
+        let create = """
+            CREATE TABLE remote_sync_state (
+                workspace_id TEXT PRIMARY KEY,
+                relay_cursor TEXT,
+                last_sync_at INTEGER,
+                last_error_code TEXT
+            );
+            """
+        guard sqlite3_exec(handle, create, nil, nil, nil) == SQLITE_OK else {
+            XCTFail("could not create legacy schema")
+            throw RemoteSyncError.invalidConfiguration
+        }
+        let insert = """
+            INSERT INTO remote_sync_state(workspace_id, relay_cursor, last_sync_at, last_error_code)
+            VALUES('\(workspace.uuidString.lowercased())', '\(cursor)', 1000, NULL);
+            """
+        guard sqlite3_exec(handle, insert, nil, nil, nil) == SQLITE_OK else {
+            XCTFail("could not seed legacy row")
+            throw RemoteSyncError.invalidConfiguration
+        }
+    }
+}
+
+/// Stubs the two Relay endpoints this scenario touches: the device roster
+/// (empty — the config authorizes no probe) and the batch page. The batch page
+/// answers 400 for any request that carries an `after` cursor — the Relay's
+/// real response when a cursor is replayed against a device it was not bound to
+/// — and 200 with an empty page when `after` is omitted. Each batch request's
+/// `after` value is recorded so the test can assert the stale cursor was
+/// dropped.
+private final class CursorBindingStubRelay: URLProtocol {
+    nonisolated(unsafe) private static var afters: [String?] = []
+    private static let lock = NSLock()
+
+    static func reset() {
+        lock.lock(); defer { lock.unlock() }
+        afters = []
+    }
+
+    static func recordedAfters() -> [String?] {
+        lock.lock(); defer { lock.unlock() }
+        return afters
+    }
+
+    private static func recordAfter(_ value: String?) {
+        lock.lock(); defer { lock.unlock() }
+        afters.append(value)
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+    override func stopLoading() {}
+
+    override func startLoading() {
+        let path = request.url?.path ?? ""
+        if path.hasSuffix("/devices") {
+            respond(status: 200, body: ["devices": []])
+            return
+        }
+        if path.hasSuffix("/batches") {
+            let after = URLComponents(url: request.url!, resolvingAgainstBaseURL: false)?
+                .queryItems?.first(where: { $0.name == "after" })?.value
+            Self.recordAfter(after)
+            if after != nil {
+                respond(status: 400, body: ["error": "cursor_principal_mismatch"])
+            } else {
+                respond(status: 200, body: ["batches": [], "next_cursor": ""])
+            }
+            return
+        }
+        respond(status: 200, body: [:])
+    }
+
+    private func respond(status: Int, body: [String: Any]) {
+        let response = HTTPURLResponse(
+            url: request.url!,
+            statusCode: status,
+            httpVersion: "HTTP/1.1",
+            headerFields: ["Cache-Control": "no-store"]
+        )!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        if let data = try? JSONSerialization.data(withJSONObject: body) {
+            client?.urlProtocol(self, didLoad: data)
+        }
+        client?.urlProtocolDidFinishLoading(self)
+    }
+}

--- a/Tests/VibeBarCoreTests/RemoteSupersededEpochTests.swift
+++ b/Tests/VibeBarCoreTests/RemoteSupersededEpochTests.swift
@@ -181,7 +181,10 @@ final class RemoteSupersededEpochTests: XCTestCase {
         // Both cursors were acknowledged so the Relay GC can reclaim them, and
         // the ledger cursor advanced past BOTH batches.
         XCTAssertEqual(Set(StubRelay.acknowledged()), ["c1", "c2"])
-        let cursor = try await ledger.relayCursor(workspaceID: workspace)
+        let cursor = try await ledger.relayCursor(
+            workspaceID: workspace,
+            coreDeviceID: config.coreDeviceID
+        )
         XCTAssertEqual(cursor, "c2")
     }
 


### PR DESCRIPTION
## Summary

Fixes a live correctness bug (confirmed via relay 400 logs) where the
remote-sync stream wedges forever on `relay_http_error` / "Last sync:
never" after a Mac revokes its old Core and re-joins the same workspace
as a **new** Core.

The relay HMAC-binds every batch cursor to the device that consumed it,
but the local ledger cached the cursor keyed by `workspace_id` only. On
re-join (new `core_device_id`, same `workspace_id`), `performRefresh`
replayed the *old* Core's cursor as `?after=<cursor>`; the relay decodes
it against the new principal, the HMAC mismatches, and it returns 400 →
`RemoteRelayClient` throws `.http(400)` → the sync wedges.

`fetch(after: nil)` sends no `after` param, and the relay then serves
from that device's own server-side cursor (0 for a never-synced device),
so discarding a cursor that belongs to a different Core is safe — the
relay remembers where each device left off.

### What changed (local cursor bookkeeping only — no relay / wire / request-shape change)

- `remote_sync_state` gains a `core_device_id TEXT` column via an
  **idempotent additive migration** (`PRAGMA table_info` guard +
  `ALTER TABLE ... ADD COLUMN`). New DBs get it from `CREATE TABLE`;
  existing on-disk DBs get it as `NULL`.
- `relayCursor(workspaceID:coreDeviceID:)` returns the stored cursor
  **only** when `core_device_id` matches the current Core. A foreign
  owner — or a pre-migration `NULL` owner — returns `nil`.
- `recordSync(...)` persists `core_device_id` in lockstep with
  `relay_cursor`: it is (re)written only when a fresh cursor is supplied
  and preserved verbatim on the carried-over (error, `cursor: nil`) path,
  so a cursor from another Core is never restamped with the current
  device (which would re-arm the same 400 wedge).
- `RemoteProbeService.performRefresh` passes `config.coreDeviceID` into
  `relayCursor` and both `recordSync` calls.

### Self-heals stuck installs with no re-join

A pre-migration row has `core_device_id = NULL`, which is treated as a
mismatch. On the very next sync after upgrade, the stale cursor is
dropped, the fetch uses `after: nil`, and the relay resumes from the new
device's server cursor. No revoke/re-join needed.

## Test plan

- [x] `swift build`
- [x] `swift test` — 1109 tests, 0 failures (4 new tests added)
- [x] `./Scripts/build_app.sh release`
- [x] `codesign -d --entitlements :- ".build/Vibe Bar.app"` — empty `<dict/>`, no `app-sandbox`
- [x] `codesign --verify --deep --strict ".build/Vibe Bar.app"`
- [x] AGENTS.md §6 home grep — no new hits (only `RealHomeDirectory.swift` itself)

New tests (`RemoteCursorDeviceBindingTests`):
- Ledger: cursor is device-scoped (device A reads it, device B gets nil).
- Ledger: an error-only `recordSync` from another device never inherits the cursor.
- Ledger: a raw pre-migration `NULL`-owner row is invalidated after the migration, and re-heals on the next `recordSync`.
- Service: with a stale cursor owned by a foreign device pre-seeded, `performRefresh` fetches with `after: nil` (a stubbed relay 400s any replayed cursor) and does **not** surface `relay_http_error`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)