### PR TITLE
Prepare Vibe Bar 1.3.0 Dev build 19

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.3.0</string>
 	<key>CFBundleVersion</key>
-	<string>18</string>
+	<string>19</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>26.0</string>
 	<key>LSUIElement</key>


### PR DESCRIPTION
Dev prerelease carrying the Core-rotation cursor fix (PR #145): the local relay sync cursor is now bound to the Core device id, so a Mac that revoked its old Core and re-joined a workspace as a new Core no longer wedges on the previous device's cursor (relay 400 → 'relay_http_error / Last sync: never'). A currently-stuck Core self-heals on the very next sync after upgrade — no re-join needed.

CFBundleVersion 18 → 19; CFBundleShortVersionString stays 1.3.0.

- [x] swift build
- [x] swift test (1109 tests, 0 failures)
- [x] ./Scripts/build_app.sh release
- [x] codesign entitlements empty (no app-sandbox)
- [x] codesign --verify --deep --strict

🤖 Generated with [Claude Code](https://claude.com/claude-code)