### PR TITLE
Advance the sequence watermark for skipped superseded batches

### DIFF
--- a/Sources/VibeBarCore/Models/RemoteSyncModels.swift
+++ b/Sources/VibeBarCore/Models/RemoteSyncModels.swift
@@ -240,7 +240,13 @@ public enum RemoteSyncError: Error, Equatable, Sendable {
     /// Core rotated, so no current device can ever decrypt it. This is not a
     /// failure: the batch is skipped and acknowledged so the Relay's
     /// cursor-aware GC can reclaim it, and the stream keeps advancing.
-    case supersededEnvelope
+    ///
+    /// The producer and sequence travel with the error because the caller has
+    /// to record the skip in the ledger — a skipped sequence still consumes a
+    /// slot in that producer's chain, so the watermark must move past it or the
+    /// next importable batch looks like a `sequenceGap`. Both values are
+    /// signature-verified before this is thrown, and neither is a secret.
+    case supersededEnvelope(producerID: UUID, sequence: Int64)
     case sequenceGap(expected: Int64, received: Int64)
     case rollback
     case http(Int)

--- a/Sources/VibeBarCore/Services/RemoteProbeService.swift
+++ b/Sources/VibeBarCore/Services/RemoteProbeService.swift
@@ -213,7 +213,7 @@ public final class RemoteProbeService: ObservableObject {
                             sequence: opened.sequence,
                             receivedAt: batch.receivedAt
                         )
-                    } catch RemoteSyncError.supersededEnvelope {
+                    } catch RemoteSyncError.supersededEnvelope(let producerID, let sequence) {
                         // Authenticated backlog from a revoked Core generation:
                         // encrypted to a recipient key no current device holds,
                         // so it can never be imported. Acknowledge it anyway so
@@ -222,7 +222,24 @@ public final class RemoteProbeService: ObservableObject {
                         // cursor and make every later sync repeat this failure.
                         // Every non-superseded error still propagates to the
                         // outer catch, unchanged.
+                        //
+                        // Skipping is not the same as ignoring: the sequence is
+                        // recorded so the producer's watermark moves past it.
+                        // Advancing only the Relay cursor (the dev.18 behavior)
+                        // left the ledger at 0 while the cursor walked over the
+                        // whole superseded backlog, so the first current-epoch
+                        // batch arrived as a `sequence_gap` and wedged the sync
+                        // in a different place. The producer and sequence come
+                        // from the error itself — both were signature-verified
+                        // inside `openIngestEnvelope`, so the envelope is never
+                        // parsed a second time here.
                         skippedSuperseded += 1
+                        try await ledger.noteSupersededBatch(
+                            workspaceID: config.workspaceID,
+                            producerID: producerID,
+                            sequence: sequence,
+                            receivedAt: batch.receivedAt
+                        )
                     }
                     try await client.acknowledge(cursor: batch.cursor)
                     cursor = batch.cursor

--- a/Sources/VibeBarCore/Services/RemoteProtocolCrypto.swift
+++ b/Sources/VibeBarCore/Services/RemoteProtocolCrypto.swift
@@ -172,7 +172,10 @@ enum RemoteProtocolCrypto {
         // acknowledges it. A current-generation envelope (equal epoch, matching
         // key id) falls through to decryption unchanged.
         if coreEpoch < expectedEpoch {
-            throw RemoteSyncError.supersededEnvelope
+            throw RemoteSyncError.supersededEnvelope(
+                producerID: producerID,
+                sequence: sequence
+            )
         }
 
         let ephemeralKey = try P256.KeyAgreement.PublicKey(x963Representation: ephemeralData)

--- a/Sources/VibeBarCore/Services/RemoteUsageLedger.swift
+++ b/Sources/VibeBarCore/Services/RemoteUsageLedger.swift
@@ -173,17 +173,33 @@ public actor RemoteUsageLedger {
                 try execute("COMMIT")
                 return false
             }
-            let previous = try scalarInt64(
+            let watermark = try scalarInt64(
                 """
                 SELECT last_sequence FROM remote_machines
                 WHERE workspace_id = ? AND producer_id = ?
                 """,
                 [.text(workspace), .text(producer)]
-            )
-            let expected = (previous ?? 0) + 1
-            guard sequence == expected else {
+            ) ?? 0
+            let expected = watermark + 1
+            if sequence != expected {
                 if sequence < expected { throw RemoteSyncError.rollback }
-                throw RemoteSyncError.sequenceGap(expected: expected, received: sequence)
+                // Adopt-on-first-batch. A Core that joins an already-running
+                // workspace — or whose earlier backlog was superseded by a Core
+                // rotation, or garbage-collected at the Relay — has no way to
+                // ever see sequence 1. Refusing to start is a permanent wedge:
+                // every later cycle re-reads the same unreachable expectation
+                // and reports `sequence_gap` forever. Adopting the first
+                // sequence this Core can actually decrypt only means "history
+                // before this point is not in this Core's ledger", which is
+                // exactly true and already how a freshly enrolled Core behaves.
+                //
+                // The relaxation applies only while no watermark exists. Once
+                // this producer has a recorded position (> 0), a forward jump is
+                // a real mid-stream gap and still throws, and a lower sequence
+                // still throws `.rollback` above.
+                guard watermark == 0 else {
+                    throw RemoteSyncError.sequenceGap(expected: expected, received: sequence)
+                }
             }
             guard payload.previousSequence == (sequence == 1 ? nil : sequence - 1) else {
                 throw RemoteSyncError.sequenceGap(expected: expected, received: sequence)
@@ -285,6 +301,64 @@ public actor RemoteUsageLedger {
         }
     }
 
+    /// Account for a batch that was skipped because it belongs to a superseded
+    /// Core generation (`RemoteSyncError.supersededEnvelope`).
+    ///
+    /// Its ciphertext is encrypted to a recipient key no current device holds,
+    /// so no device will ever import it — but it still occupies a slot in that
+    /// producer's sequence chain. Leaving the watermark behind makes the first
+    /// importable batch look like a `sequenceGap` and wedges the stream, so the
+    /// skip is recorded exactly like an import for bookkeeping purposes:
+    /// `remote_imported_batches` gains the sequence (a re-delivery then dedups)
+    /// and the producer's watermark moves forward.
+    ///
+    /// The watermark only ever moves forward (`MAX`), so a page delivered out of
+    /// order can never lower a position an import already reached. The
+    /// `remote_machines` row is created when absent, but with none of the probe
+    /// metadata invented: the descriptive columns are left at the empty
+    /// placeholder the NOT NULL schema requires, and `machineSummaries` skips
+    /// such a row so a producer that has only ever sent superseded batches does
+    /// not render as a nameless machine. A later current-epoch import fills the
+    /// real metadata in through the ordinary upsert.
+    func noteSupersededBatch(
+        workspaceID: UUID,
+        producerID: UUID,
+        sequence: Int64,
+        receivedAt: Date
+    ) throws {
+        guard sequence > 0 else { throw RemoteSyncError.invalidPayload }
+        let workspace = workspaceID.uuidString.lowercased()
+        let producer = producerID.uuidString.lowercased()
+        let stamp = Int64(receivedAt.timeIntervalSince1970)
+        try execute("BEGIN IMMEDIATE")
+        do {
+            try run(
+                """
+                INSERT INTO remote_imported_batches(
+                       workspace_id, producer_id, sequence, imported_at
+                   ) VALUES(?, ?, ?, ?)
+                   ON CONFLICT(workspace_id, producer_id, sequence) DO NOTHING
+                """,
+                [.text(workspace), .text(producer), .integer(sequence), .integer(stamp)]
+            )
+            try run(
+                """
+                INSERT INTO remote_machines(
+                       workspace_id, producer_id, alias, platform, timezone, probe_version,
+                       last_seen_at, last_scan_at, last_sequence, source_status_json
+                   ) VALUES(?, ?, '', '', '', '', 0, 0, ?, '{}')
+                   ON CONFLICT(workspace_id, producer_id) DO UPDATE SET
+                       last_sequence = MAX(remote_machines.last_sequence, excluded.last_sequence)
+                """,
+                [.text(workspace), .text(producer), .integer(sequence)]
+            )
+            try execute("COMMIT")
+        } catch {
+            try? execute("ROLLBACK")
+            throw error
+        }
+    }
+
     /// The stored relay cursor for this workspace, but only when it was minted
     /// by `coreDeviceID`. The Relay HMAC-binds every cursor to the device that
     /// consumed it, so a cursor left by an earlier Core (revoked, then this Mac
@@ -350,11 +424,16 @@ public actor RemoteUsageLedger {
         now: Date = Date()
     ) throws -> [RemoteMachineSummary] {
         let workspace = workspaceID.uuidString.lowercased()
+        // `alias <> ''` excludes the watermark-only rows `noteSupersededBatch`
+        // creates for a producer whose batches were all superseded. A real
+        // import always carries a 1...96 character alias (the payload decoder
+        // enforces it), so this can never hide a machine that actually reported.
         let statement = try prepare(
             """
             SELECT producer_id, alias, platform, probe_version, last_seen_at,
                       last_scan_at, last_sequence, source_status_json
-               FROM remote_machines WHERE workspace_id = ? ORDER BY alias, producer_id
+               FROM remote_machines WHERE workspace_id = ? AND alias <> ''
+               ORDER BY alias, producer_id
             """
         )
         defer { sqlite3_finalize(statement) }

--- a/Tests/VibeBarCoreTests/RemoteSupersededEpochTests.swift
+++ b/Tests/VibeBarCoreTests/RemoteSupersededEpochTests.swift
@@ -44,8 +44,12 @@ final class RemoteSupersededEpochTests: XCTestCase {
                 acceptedAt: iso("2026-08-03T06:01:00Z")
             )
         ) { error in
+            // The classification carries the producer and sequence the caller
+            // needs to record the skip in the ledger, so the envelope never has
+            // to be parsed twice.
             XCTAssertEqual(
-                error as? RemoteSyncError, .supersededEnvelope,
+                error as? RemoteSyncError,
+                .supersededEnvelope(producerID: producer, sequence: 1),
                 "An authenticated older-epoch batch must be superseded, not invalid_envelope"
             )
         }
@@ -81,7 +85,10 @@ final class RemoteSupersededEpochTests: XCTestCase {
             // The signature gate fires before the superseded decision, so a
             // forged old-epoch batch is rejected, never silently skipped.
             XCTAssertEqual(error as? RemoteSyncError, .invalidSignature)
-            XCTAssertNotEqual(error as? RemoteSyncError, .supersededEnvelope)
+            XCTAssertNotEqual(
+                error as? RemoteSyncError,
+                .supersededEnvelope(producerID: producer, sequence: 1)
+            )
         }
     }
 
@@ -137,14 +144,17 @@ final class RemoteSupersededEpochTests: XCTestCase {
             plaintext: Data("cannot be opened".utf8)
         )
         // Second batch: current epoch, encrypted to this Core's recipient key,
-        // carrying a real usage payload at sequence 1.
+        // carrying a real usage payload at the next sequence. A probe's chain is
+        // monotonic across a Core rotation — the superseded backlog occupies the
+        // sequences below the first current-epoch batch — so the current batch
+        // continues the chain rather than restarting it.
         let current = try seal(
             signer: producerSigningKey,
             recipient: identity.recipientPrivateKey.publicKey,
             coreEpoch: 2,
             keyID: "ingest-epoch-2",
-            sequence: 1,
-            plaintext: try usagePayload(sequence: 1)
+            sequence: 2,
+            plaintext: try usagePayload(sequence: 2)
         )
 
         let received = Int64(iso("2026-08-03T06:01:00Z").timeIntervalSince1970)
@@ -186,6 +196,92 @@ final class RemoteSupersededEpochTests: XCTestCase {
             coreDeviceID: config.coreDeviceID
         )
         XCTAssertEqual(cursor, "c2")
+    }
+
+    /// The regression this file's fix originally missed: skipping a superseded
+    /// batch has to move the producer's sequence watermark too. With a run of
+    /// superseded batches ahead of the first importable one, a skip that only
+    /// advanced the Relay cursor left the ledger expecting sequence 1 forever,
+    /// so the current-epoch batch arrived as a `sequence_gap` and aborted every
+    /// later cycle.
+    @MainActor
+    func testRefreshAdvancesTheWatermarkAcrossASupersededRun() async throws {
+        let identity = makeIdentity()
+        let producerSigningKey = P256.Signing.PrivateKey()
+        let config = try makeConfig(
+            coreEpoch: 2,
+            ingestKeyID: "ingest-epoch-2",
+            keys: [producer: producerSigningKey.publicKey.x963Representation]
+        )
+
+        let revokedRecipient = P256.KeyAgreement.PrivateKey().publicKey
+        let firstSuperseded = try seal(
+            signer: producerSigningKey,
+            recipient: revokedRecipient,
+            coreEpoch: 1,
+            keyID: "ingest-epoch-1",
+            sequence: 1,
+            plaintext: Data("cannot be opened".utf8)
+        )
+        let secondSuperseded = try seal(
+            signer: producerSigningKey,
+            recipient: revokedRecipient,
+            coreEpoch: 1,
+            keyID: "ingest-epoch-1",
+            sequence: 2,
+            plaintext: Data("cannot be opened either".utf8)
+        )
+        let current = try seal(
+            signer: producerSigningKey,
+            recipient: identity.recipientPrivateKey.publicKey,
+            coreEpoch: 2,
+            keyID: "ingest-epoch-2",
+            sequence: 3,
+            plaintext: try usagePayload(sequence: 3)
+        )
+
+        let received = Int64(iso("2026-08-03T06:01:00Z").timeIntervalSince1970)
+        StubRelay.reset()
+        StubRelay.deviceKey = producerSigningKey.publicKey.x963Representation
+        StubRelay.producer = producer
+        StubRelay.core = config.coreDeviceID
+        StubRelay.page = [
+            ["cursor": "c1", "received_at": received, "envelope": firstSuperseded],
+            ["cursor": "c2", "received_at": received, "envelope": secondSuperseded],
+            ["cursor": "c3", "received_at": received, "envelope": current]
+        ]
+        StubRelay.nextCursor = "c3"
+        defer { StubRelay.reset() }
+
+        let client = makeClient(config)
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("remote-superseded-run-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: false)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let ledger = try RemoteUsageLedger(url: directory.appendingPathComponent("ledger.sqlite3"))
+
+        let service = RemoteProbeService(
+            config: config, identity: identity, client: client, ledger: ledger
+        )
+        await service.refresh()
+
+        // Two skips and one import, with no error: the run of superseded
+        // sequences did not turn into a gap.
+        XCTAssertNil(service.lastErrorCode)
+        XCTAssertEqual(service.machines.count, 1)
+        XCTAssertEqual(service.machines.first?.producerID, producer)
+        XCTAssertEqual(service.machines.first?.allTimeTokens, 15)
+        // The watermark accounts for every sequence the Core walked past, not
+        // just the one it imported.
+        XCTAssertEqual(service.machines.first?.lastSequence, 3)
+
+        // Every batch was acknowledged and the cursor advanced past all three.
+        XCTAssertEqual(Set(StubRelay.acknowledged()), ["c1", "c2", "c3"])
+        let cursor = try await ledger.relayCursor(
+            workspaceID: workspace,
+            coreDeviceID: config.coreDeviceID
+        )
+        XCTAssertEqual(cursor, "c3")
     }
 
     // MARK: - Fixtures

--- a/Tests/VibeBarCoreTests/RemoteSupersededSequenceTests.swift
+++ b/Tests/VibeBarCoreTests/RemoteSupersededSequenceTests.swift
@@ -1,0 +1,248 @@
+import XCTest
+import SQLite3
+@testable import VibeBarCore
+
+/// A skipped superseded batch still consumes a slot in its producer's sequence
+/// chain. dev.18 advanced only the Relay cursor when it skipped one, so the
+/// ledger watermark stayed at 0 while the cursor walked over the whole
+/// superseded backlog — and the first current-epoch batch then arrived as a
+/// `sequence_gap` that aborted every later sync.
+///
+/// These tests pin both halves of the fix at the ledger level: recording a skip
+/// moves the watermark forward (and only forward), and a Core with no recorded
+/// position at all adopts the first sequence it can actually decrypt instead of
+/// demanding a sequence 1 that no longer exists anywhere.
+///
+/// Synthetic UUIDs only; every payload is built locally.
+final class RemoteSupersededSequenceTests: XCTestCase {
+    private let workspace = UUID(uuidString: "11111111-1111-4111-8111-111111111111")!
+    private let producer = UUID(uuidString: "22222222-2222-4222-8222-222222222222")!
+
+    // MARK: - noteSupersededBatch
+
+    func testNoteSupersededBatchAdvancesWatermarkAndDedupsARedelivery() async throws {
+        let (ledger, url) = try makeLedger()
+
+        try await ledger.noteSupersededBatch(
+            workspaceID: workspace, producerID: producer, sequence: 1, receivedAt: Date()
+        )
+        try await ledger.noteSupersededBatch(
+            workspaceID: workspace, producerID: producer, sequence: 2, receivedAt: Date()
+        )
+        XCTAssertEqual(try storedWatermark(at: url), 2)
+
+        // A re-delivery of an already-accounted-for sequence is a no-op import,
+        // exactly like a re-delivered imported batch.
+        let redelivered = try RemotePayloadDecoder.decode(payload(sequence: 2, previous: 1))
+        let imported = try await ledger.importBatch(redelivered, sequence: 2, receivedAt: Date())
+        XCTAssertFalse(imported)
+
+        // And the batch that follows the skipped run imports as the contiguous
+        // next sequence — the wedge the fix removes.
+        let next = try RemotePayloadDecoder.decode(payload(sequence: 3, previous: 2))
+        let importedNext = try await ledger.importBatch(next, sequence: 3, receivedAt: Date())
+        XCTAssertTrue(importedNext)
+        let summaries = try await ledger.machineSummaries(
+            workspaceID: workspace,
+            now: ISO8601DateFormatter().date(from: "2026-08-03T12:00:00Z")!
+        )
+        XCTAssertEqual(summaries.count, 1)
+        XCTAssertEqual(summaries[0].lastSequence, 3)
+        XCTAssertEqual(summaries[0].todayTokens, 15)
+    }
+
+    func testNoteSupersededBatchNeverLowersAHigherWatermark() async throws {
+        let (ledger, url) = try makeLedger()
+
+        // Import first so the watermark is owned by real data.
+        let first = try RemotePayloadDecoder.decode(payload(sequence: 1, previous: nil))
+        _ = try await ledger.importBatch(first, sequence: 1, receivedAt: Date())
+        let second = try RemotePayloadDecoder.decode(payload(sequence: 2, previous: 1))
+        _ = try await ledger.importBatch(second, sequence: 2, receivedAt: Date())
+        XCTAssertEqual(try storedWatermark(at: url), 2)
+
+        // An out-of-order superseded skip for an earlier sequence must not drag
+        // the position backwards.
+        try await ledger.noteSupersededBatch(
+            workspaceID: workspace, producerID: producer, sequence: 1, receivedAt: Date()
+        )
+        XCTAssertEqual(try storedWatermark(at: url), 2)
+
+        // The probe's real metadata survives a skip as well: the placeholder
+        // insert only ever touches last_sequence.
+        let summaries = try await ledger.machineSummaries(
+            workspaceID: workspace,
+            now: ISO8601DateFormatter().date(from: "2026-08-03T12:00:00Z")!
+        )
+        XCTAssertEqual(summaries.count, 1)
+        XCTAssertEqual(summaries[0].alias, "Example machine")
+        XCTAssertEqual(summaries[0].lastSequence, 2)
+
+        // A forward skip still moves it.
+        try await ledger.noteSupersededBatch(
+            workspaceID: workspace, producerID: producer, sequence: 5, receivedAt: Date()
+        )
+        XCTAssertEqual(try storedWatermark(at: url), 5)
+    }
+
+    func testProducerWithOnlySupersededBatchesDoesNotSurfaceAsAMachine() async throws {
+        let (ledger, url) = try makeLedger()
+        try await ledger.noteSupersededBatch(
+            workspaceID: workspace, producerID: producer, sequence: 7, receivedAt: Date()
+        )
+
+        // The watermark row exists...
+        XCTAssertEqual(try storedWatermark(at: url), 7)
+        // ...but a machine whose metadata was never received is not rendered as
+        // a nameless entry in the UI.
+        let summaries = try await ledger.machineSummaries(
+            workspaceID: workspace,
+            now: ISO8601DateFormatter().date(from: "2026-08-03T12:00:00Z")!
+        )
+        XCTAssertTrue(summaries.isEmpty)
+
+        // The first importable batch fills the real metadata in and the machine
+        // appears with its own alias.
+        let current = try RemotePayloadDecoder.decode(payload(sequence: 8, previous: 7))
+        let importedCurrent = try await ledger.importBatch(current, sequence: 8, receivedAt: Date())
+        XCTAssertTrue(importedCurrent)
+        let healed = try await ledger.machineSummaries(
+            workspaceID: workspace,
+            now: ISO8601DateFormatter().date(from: "2026-08-03T12:00:00Z")!
+        )
+        XCTAssertEqual(healed.count, 1)
+        XCTAssertEqual(healed[0].alias, "Example machine")
+        XCTAssertEqual(healed[0].lastSequence, 8)
+    }
+
+    // MARK: - Adopt-on-first-batch
+
+    func testImportAdoptsTheFirstEverSequenceForAProducer() async throws {
+        let (ledger, _) = try makeLedger()
+
+        // A Core that already skipped (or never saw) sequences 1...147 can never
+        // obtain them. Starting at the first batch it can decrypt is the only
+        // non-wedging behavior.
+        let adopted = try RemotePayloadDecoder.decode(payload(sequence: 148, previous: 147))
+        let importedAdopted = try await ledger.importBatch(adopted, sequence: 148, receivedAt: Date())
+        XCTAssertTrue(importedAdopted)
+        let summaries = try await ledger.machineSummaries(
+            workspaceID: workspace,
+            now: ISO8601DateFormatter().date(from: "2026-08-03T12:00:00Z")!
+        )
+        XCTAssertEqual(summaries.count, 1)
+        XCTAssertEqual(summaries[0].lastSequence, 148)
+        XCTAssertEqual(summaries[0].todayTokens, 15)
+    }
+
+    func testAdoptionDoesNotRelaxContiguityOnceAWatermarkExists() async throws {
+        let (ledger, _) = try makeLedger()
+        let adopted = try RemotePayloadDecoder.decode(payload(sequence: 148, previous: 147))
+        _ = try await ledger.importBatch(adopted, sequence: 148, receivedAt: Date())
+
+        // A real mid-stream gap must still be visible.
+        let skipped = try RemotePayloadDecoder.decode(payload(sequence: 150, previous: 149))
+        do {
+            _ = try await ledger.importBatch(skipped, sequence: 150, receivedAt: Date())
+            XCTFail("Expected a visible sequence gap once a watermark exists")
+        } catch let error as RemoteSyncError {
+            XCTAssertEqual(error, .sequenceGap(expected: 149, received: 150))
+        }
+
+        // A sequence below the watermark is still a rollback.
+        let stale = try RemotePayloadDecoder.decode(payload(sequence: 147, previous: 146))
+        do {
+            _ = try await ledger.importBatch(stale, sequence: 147, receivedAt: Date())
+            XCTFail("Expected a rollback for a sequence below the watermark")
+        } catch let error as RemoteSyncError {
+            XCTAssertEqual(error, .rollback)
+        }
+
+        // The contiguous next sequence still imports normally.
+        let next = try RemotePayloadDecoder.decode(payload(sequence: 149, previous: 148))
+        let importedNext = try await ledger.importBatch(next, sequence: 149, receivedAt: Date())
+        XCTAssertTrue(importedNext)
+    }
+
+    // MARK: - Fixtures
+
+    private func makeLedger() throws -> (RemoteUsageLedger, URL) {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("remote-superseded-seq-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: false)
+        addTeardownBlock { try? FileManager.default.removeItem(at: directory) }
+        let url = directory.appendingPathComponent("ledger.sqlite3")
+        return (try RemoteUsageLedger(url: url), url)
+    }
+
+    /// Read `remote_machines.last_sequence` straight from the file, so a
+    /// watermark-only row (which `machineSummaries` deliberately hides) is still
+    /// observable.
+    private func storedWatermark(at url: URL) throws -> Int64? {
+        var handle: OpaquePointer?
+        guard sqlite3_open_v2(url.path, &handle, SQLITE_OPEN_READONLY, nil) == SQLITE_OK,
+              let handle
+        else {
+            XCTFail("could not open the ledger for verification")
+            throw RemoteSyncError.invalidConfiguration
+        }
+        defer { sqlite3_close_v2(handle) }
+        var statement: OpaquePointer?
+        let sql = """
+            SELECT last_sequence FROM remote_machines
+            WHERE workspace_id = ? AND producer_id = ?
+            """
+        guard sqlite3_prepare_v2(handle, sql, -1, &statement, nil) == SQLITE_OK,
+              let statement
+        else {
+            XCTFail("could not prepare the verification query")
+            throw RemoteSyncError.invalidConfiguration
+        }
+        defer { sqlite3_finalize(statement) }
+        let transient = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
+        sqlite3_bind_text(statement, 1, workspace.uuidString.lowercased(), -1, transient)
+        sqlite3_bind_text(statement, 2, producer.uuidString.lowercased(), -1, transient)
+        guard sqlite3_step(statement) == SQLITE_ROW else { return nil }
+        return sqlite3_column_int64(statement, 0)
+    }
+
+    private func payload(sequence: Int, previous: Int?) throws -> Data {
+        let operation: [String: Any] = [
+            "op": "usage_upsert",
+            "source_key": String(repeating: "s", count: 43),
+            "source_generation": 1,
+            "event_key": String(repeating: "e", count: 42) + String(sequence),
+            "tool": "codex",
+            "occurred_at": "2026-08-03T06:00:00Z",
+            "observed_at": "2026-08-03T06:01:00Z",
+            "model": "example-model",
+            "tokens": [
+                "input": 10, "output": 5, "cache_read": 0,
+                "cache_creation": 0, "reasoning": 0, "tool": 0,
+                "total_only": NSNull()
+            ],
+            "request_count": 1,
+            "service_tier": NSNull(),
+            "accounting": "exact",
+            "parser_version": 1
+        ]
+        let body: [String: Any] = [
+            "schema": 1,
+            "workspace_id": workspace.uuidString.lowercased(),
+            "producer_id": producer.uuidString.lowercased(),
+            "probe": [
+                "alias": "Example machine", "version": "0.1.0",
+                "platform": "linux-x86_64", "timezone": "UTC"
+            ],
+            "previous_sequence": previous.map { $0 as Any } ?? NSNull(),
+            "operations": [operation],
+            "status": [
+                "last_scan_at": "2026-08-03T06:01:00Z",
+                "backlog_batches": 1,
+                "applied_control_sequence": 0,
+                "sources": ["codex": "ok"]
+            ]
+        ]
+        return try JSONSerialization.data(withJSONObject: body)
+    }
+}


### PR DESCRIPTION
## Summary

- A rotated Core skipped + ack'd the previous generation's backlog (dev.18) but never told the ledger, so `remote_machines.last_sequence` stayed at 0 while the Relay cursor walked past the superseded run. The first current-epoch batch then threw `.sequenceGap` from `importBatch` — not caught by the superseded-only `catch` — aborting every refresh with `Latest sync error: sequence_gap`.
- `RemoteSyncError.supersededEnvelope` now carries `(producerID:sequence:)`, both already signature-verified inside `openIngestEnvelope`, so the service never re-parses the envelope. Its `code` string is unchanged (`superseded_envelope`).
- New `RemoteUsageLedger.noteSupersededBatch(workspaceID:producerID:sequence:receivedAt:)`: one transaction that records the sequence in `remote_imported_batches` (a re-delivery then dedups) and advances the producer's watermark with `MAX` semantics — forward only. It creates the `remote_machines` row when absent without inventing probe metadata; `machineSummaries` filters those placeholder rows (`alias <> ''`), and the first real import fills the metadata in.
- Self-heal for a Core that is already wedged: `importBatch` adopts the first sequence it ever sees for a producer (watermark 0 / no row) instead of demanding sequence 1, since a Core that joins a running workspace — or whose backlog was superseded or GC'd — can never obtain the earlier sequences. Once a watermark exists nothing is relaxed: a forward jump still throws `.sequenceGap`, a lower sequence still throws `.rollback`.
- Everything else is unchanged: non-superseded errors still propagate and abort the cycle, the ack + cursor advance still happens for skipped batches, and the skipped-batch log stays count-only.

## Test plan

- [x] `swift build`
- [x] `swift test` (all suites green; 5 new `RemoteSupersededSequenceTests`, 1 new service-level test in `RemoteSupersededEpochTests`)
- [x] `./Scripts/build_app.sh release`
- [x] `codesign -d --entitlements :- ".build/Vibe Bar.app"` → empty `<dict></dict>`, no `app-sandbox`
- [x] `codesign --verify --deep --strict ".build/Vibe Bar.app"` → clean
- [x] AGENTS.md §6 home-directory grep → only the two pre-existing hits inside `RealHomeDirectory.swift`
- [x] `Resources/Info.plist` untouched (no version bump)

New coverage:
- ledger: `noteSupersededBatch` advances the watermark, dedups a later import of the same sequence, and never lowers a higher watermark.
- ledger: a producer with only superseded batches does not surface in `machineSummaries`, and appears with its real alias once a current batch imports.
- ledger: adopt-on-first-ever-batch (148 into an empty ledger succeeds, watermark 148), then 150 → `.sequenceGap`, 147 → `.rollback`, 149 → imports.
- service: a page of `[superseded(1), superseded(2), current(3)]` acks all three, advances the cursor past all of them, imports the current one, ends with `lastErrorCode == nil` and watermark 3.

The existing `testRefreshSkipsSupersededBatchAndImportsCurrentOne` now seals its current-epoch batch at sequence 2 rather than reusing sequence 1: a probe's chain is monotonic across a Core rotation (the live relay data shows one producer's superseded backlog at 1..147 and its current batches from 148), so a superseded and a current batch never share a sequence. The assertions it makes are otherwise unchanged.