### PR TITLE
Prepare Vibe Bar 1.3.0 Dev build 20

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.3.0</string>
 	<key>CFBundleVersion</key>
-	<string>19</string>
+	<string>20</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>26.0</string>
 	<key>LSUIElement</key>


### PR DESCRIPTION
Dev prerelease carrying the sequence-watermark fix (PR #147). dev.18 let a rotated Core skip the previous generation's undecryptable backlog, but the skip never moved the producer's sequence watermark — so the first batch the new Core *could* decrypt arrived as a gap and the sync wedged on 'sequence_gap'. Skipped batches now claim their sequence slot, and a Core with no recorded position for a producer adopts the first sequence it can decrypt (a Core joining an already-running workspace can never see sequence 1). Contiguity stays strict once a watermark exists. A wedged Core self-heals on its next sync — no re-join.

CFBundleVersion 19 → 20; CFBundleShortVersionString stays 1.3.0.

- [x] swift build
- [x] swift test (1115 tests, 0 failures)
- [x] ./Scripts/build_app.sh release
- [x] codesign entitlements empty (no app-sandbox)
- [x] codesign --verify --deep --strict

🤖 Generated with [Claude Code](https://claude.com/claude-code)