### PR TITLE
Acknowledge relay batches once per page and ride out 429s

### DIFF
--- a/Sources/VibeBarCore/Services/RemoteProbeService.swift
+++ b/Sources/VibeBarCore/Services/RemoteProbeService.swift
@@ -24,6 +24,11 @@ public final class RemoteProbeService: ObservableObject {
     /// configuration; it must stop publishing (and acknowledging) the moment
     /// this no longer matches the generation it started under.
     private var configurationGeneration = 0
+    /// Waits between retries of a Relay request the Relay asked us to repeat
+    /// (429/503): 1s, then 2s, so three attempts in all. A stored property
+    /// rather than a constant only so the test seam can collapse it to
+    /// near-zero; it is deliberately not part of the public API.
+    private var relayRetryDelays: [Duration] = [.seconds(1), .seconds(2)]
 
     /// Workspace this Core is bound to, for status display. Never a secret.
     public var workspaceID: UUID? { config?.workspaceID }
@@ -42,12 +47,14 @@ public final class RemoteProbeService: ObservableObject {
         config: RemoteCoreConfig,
         identity: RemoteCoreIdentity,
         client: RemoteRelayClient,
-        ledger: RemoteUsageLedger
+        ledger: RemoteUsageLedger,
+        relayRetryDelays: [Duration] = [.seconds(1), .seconds(2)]
     ) {
         self.config = config
         self.identity = identity
         self.client = client
         self.ledger = ledger
+        self.relayRetryDelays = relayRetryDelays
         self.isConfigured = true
     }
 
@@ -174,6 +181,77 @@ public final class RemoteProbeService: ObservableObject {
         }
     }
 
+    /// Thrown when `reconfigure()` replaced the configuration while a cycle was
+    /// asleep between Relay retries. It travels to `performRefresh`'s outer
+    /// catch, which already returns without publishing once the generation no
+    /// longer matches — so the stale cycle unwinds quietly instead of resuming
+    /// against a configuration it never validated.
+    private struct RefreshSuperseded: Error {}
+
+    /// Perform one Relay request, retrying a bounded number of times when the
+    /// Relay asks us to come back shortly.
+    ///
+    /// The Relay sits behind an nginx rate limiter. A burst of requests is
+    /// answered 429, and nginx (like most CDNs) also sheds load with 503.
+    /// Neither says the request was malformed, yet both used to abort the whole
+    /// cycle: the cursor stopped advancing and the UI reported
+    /// `relay_http_error` / "Last sync: never" even though every batch before
+    /// the burst had imported fine. Three attempts spread over 1s + 2s ride out
+    /// a limiter window; if they are exhausted the error propagates exactly as
+    /// before and the cycle records it.
+    ///
+    /// Only 429 and 503 are retried. 400 (a cursor replayed against the wrong
+    /// principal), 401, and 403 are real failures that will not fix themselves,
+    /// and retrying them would just delay the error the user needs to see.
+    ///
+    /// `Retry-After` is **not** honored. `RemoteRelayClient.validate` collapses
+    /// every non-200 into `RemoteSyncError.http(statusCode)`; widening that
+    /// public, `Equatable` error case to carry a response header would ripple
+    /// through the model, the client, and their tests for very little gain over
+    /// a fixed schedule.
+    private func withRelayRetry<T>(
+        generation: Int,
+        _ request: () async throws -> T
+    ) async throws -> T {
+        for delay in relayRetryDelays {
+            do {
+                return try await request()
+            } catch let error as RemoteSyncError {
+                guard case .http(let status) = error, status == 429 || status == 503 else {
+                    throw error
+                }
+                try await Task.sleep(for: delay)
+                guard generation == configurationGeneration else { throw RefreshSuperseded() }
+            }
+        }
+        // Retries exhausted: this attempt's failure is the cycle's failure.
+        return try await request()
+    }
+
+    /// Commit one page's progress: a single ack for the last batch the page
+    /// processed, then a single local cursor write at the same position.
+    ///
+    /// Both are watermarks, which is what makes the batching safe — the Relay
+    /// stores `MAX(existing, through)` and the ledger's `relay_cursor` is simply
+    /// where the next fetch resumes.
+    private func commitPage(
+        through cursor: String,
+        config: RemoteCoreConfig,
+        client: RemoteRelayClient,
+        ledger: RemoteUsageLedger,
+        generation: Int
+    ) async throws {
+        try await withRelayRetry(generation: generation) {
+            try await client.acknowledge(cursor: cursor)
+        }
+        try await ledger.recordSync(
+            workspaceID: config.workspaceID,
+            coreDeviceID: config.coreDeviceID,
+            cursor: cursor,
+            errorCode: nil
+        )
+    }
+
     private func performRefresh() async {
         guard !isRefreshing,
               var config = self.config,
@@ -193,63 +271,107 @@ public final class RemoteProbeService: ObservableObject {
             var skippedSuperseded = 0
             while pageCount < 100 {
                 pageCount += 1
-                let page = try await client.fetch(after: cursor)
+                let page = try await withRelayRetry(generation: generation) {
+                    try await client.fetch(after: cursor)
+                }
                 guard generation == configurationGeneration else { return }
                 guard !page.batches.isEmpty else { break }
-                for batch in page.batches {
-                    do {
-                        let opened = try RemoteProtocolCrypto.openIngestEnvelope(
-                            batch.envelope,
+                // One ack per page, not one per batch. The Relay's ack is a
+                // monotonic watermark (`last_batch_id = MAX(existing, through)`),
+                // so acknowledging only the last batch a page actually processed
+                // is exactly equivalent to acknowledging each of them — at a
+                // tenth of the requests. Draining a backlog of a few hundred
+                // queued batches used to fire that many POST /acks in a tight
+                // burst, which tripped the Relay's nginx rate limit; the
+                // resulting 429 is not the superseded case, so it escaped the
+                // per-batch catch and aborted the whole cycle with the cursor
+                // still parked at its starting position.
+                //
+                // Crash safety: if the app dies after a page is processed but
+                // before its ack lands, the next fetch re-delivers those
+                // batches. `importBatch` dedups on `remote_imported_batches` and
+                // `noteSupersededBatch` inserts with ON CONFLICT DO NOTHING, so
+                // a redelivery is a no-op — the work is repeated at worst, never
+                // double-counted.
+                var processed: String?
+                do {
+                    for batch in page.batches {
+                        do {
+                            let opened = try RemoteProtocolCrypto.openIngestEnvelope(
+                                batch.envelope,
+                                config: config,
+                                identity: identity,
+                                acceptedAt: batch.receivedAt
+                            )
+                            let payload = try RemotePayloadDecoder.decode(opened.plaintext)
+                            guard payload.workspaceID == config.workspaceID,
+                                  payload.producerID == opened.producerID
+                            else { throw RemoteSyncError.invalidPayload }
+                            _ = try await ledger.importBatch(
+                                payload,
+                                sequence: opened.sequence,
+                                receivedAt: batch.receivedAt
+                            )
+                        } catch RemoteSyncError.supersededEnvelope(let producerID, let sequence) {
+                            // Authenticated backlog from a revoked Core
+                            // generation: encrypted to a recipient key no current
+                            // device holds, so it can never be imported. Count it
+                            // as processed anyway so the page's ack lets the
+                            // Relay's cursor-aware GC reclaim it, then keep going.
+                            // Aborting here (the old behavior) would wedge the
+                            // cursor and make every later sync repeat this
+                            // failure. Every non-superseded error still propagates
+                            // to the outer catch, unchanged.
+                            //
+                            // Skipping is not the same as ignoring: the sequence
+                            // is recorded so the producer's watermark moves past
+                            // it. Advancing only the Relay cursor (the dev.18
+                            // behavior) left the ledger at 0 while the cursor
+                            // walked over the whole superseded backlog, so the
+                            // first current-epoch batch arrived as a
+                            // `sequence_gap` and wedged the sync in a different
+                            // place. The producer and sequence come from the error
+                            // itself — both were signature-verified inside
+                            // `openIngestEnvelope`, so the envelope is never
+                            // parsed a second time here.
+                            skippedSuperseded += 1
+                            try await ledger.noteSupersededBatch(
+                                workspaceID: config.workspaceID,
+                                producerID: producerID,
+                                sequence: sequence,
+                                receivedAt: batch.receivedAt
+                            )
+                        }
+                        processed = batch.cursor
+                    }
+                } catch {
+                    // A non-superseded failure still aborts the cycle, exactly as
+                    // before — but the batches this page already imported must not
+                    // be replayed on every future cycle, so their watermark is
+                    // committed before the error propagates. Both halves are
+                    // best-effort on purpose: the batch failure is the one the
+                    // cycle has to report, so neither a refused ack nor a ledger
+                    // write may replace it.
+                    if let processed {
+                        try? await commitPage(
+                            through: processed,
                             config: config,
-                            identity: identity,
-                            acceptedAt: batch.receivedAt
-                        )
-                        let payload = try RemotePayloadDecoder.decode(opened.plaintext)
-                        guard payload.workspaceID == config.workspaceID,
-                              payload.producerID == opened.producerID
-                        else { throw RemoteSyncError.invalidPayload }
-                        _ = try await ledger.importBatch(
-                            payload,
-                            sequence: opened.sequence,
-                            receivedAt: batch.receivedAt
-                        )
-                    } catch RemoteSyncError.supersededEnvelope(let producerID, let sequence) {
-                        // Authenticated backlog from a revoked Core generation:
-                        // encrypted to a recipient key no current device holds,
-                        // so it can never be imported. Acknowledge it anyway so
-                        // the Relay's cursor-aware GC reclaims it, then keep
-                        // going. Aborting here (the old behavior) would wedge the
-                        // cursor and make every later sync repeat this failure.
-                        // Every non-superseded error still propagates to the
-                        // outer catch, unchanged.
-                        //
-                        // Skipping is not the same as ignoring: the sequence is
-                        // recorded so the producer's watermark moves past it.
-                        // Advancing only the Relay cursor (the dev.18 behavior)
-                        // left the ledger at 0 while the cursor walked over the
-                        // whole superseded backlog, so the first current-epoch
-                        // batch arrived as a `sequence_gap` and wedged the sync
-                        // in a different place. The producer and sequence come
-                        // from the error itself — both were signature-verified
-                        // inside `openIngestEnvelope`, so the envelope is never
-                        // parsed a second time here.
-                        skippedSuperseded += 1
-                        try await ledger.noteSupersededBatch(
-                            workspaceID: config.workspaceID,
-                            producerID: producerID,
-                            sequence: sequence,
-                            receivedAt: batch.receivedAt
+                            client: client,
+                            ledger: ledger,
+                            generation: generation
                         )
                     }
-                    try await client.acknowledge(cursor: batch.cursor)
-                    cursor = batch.cursor
-                    try await ledger.recordSync(
-                        workspaceID: config.workspaceID,
-                        coreDeviceID: config.coreDeviceID,
-                        cursor: cursor,
-                        errorCode: nil
-                    )
+                    throw error
                 }
+                guard let processed else { break }
+                try await commitPage(
+                    through: processed,
+                    config: config,
+                    client: client,
+                    ledger: ledger,
+                    generation: generation
+                )
+                cursor = processed
                 if page.batches.count < 10 { break }
             }
             if skippedSuperseded > 0 {

--- a/Tests/VibeBarCoreTests/RemoteAckBatchingTests.swift
+++ b/Tests/VibeBarCoreTests/RemoteAckBatchingTests.swift
@@ -1,0 +1,587 @@
+import XCTest
+import CryptoKit
+@testable import VibeBarCore
+
+/// dev.20 acknowledged every batch individually inside the per-batch loop, so
+/// draining a backlog of a few hundred queued batches fired that many
+/// `POST /acks` in a tight burst. The Relay sits behind an nginx rate limiter:
+/// the burst tripped it, nginx answered 429, and because that is not the
+/// superseded case it escaped the per-batch catch and aborted the whole cycle —
+/// the cursor never advanced and the UI reported `relay_http_error` with
+/// "Last sync: never" even though batches had imported fine before the abort.
+///
+/// These tests pin both halves of the fix: the ack is a monotonic watermark, so
+/// one per page is exactly equivalent to one per batch; and a rate-limited
+/// request is retried with bounded backoff instead of aborting the cycle.
+///
+/// Synthetic UUIDs and freshly generated keys only; every envelope is sealed
+/// locally with the exact reverse of `RemoteProtocolCrypto.openIngestEnvelope`.
+final class RemoteAckBatchingTests: XCTestCase {
+    private let workspace = UUID(uuidString: "11111111-1111-4111-8111-111111111111")!
+    private let producer = UUID(uuidString: "22222222-2222-4222-8222-222222222222")!
+
+    override func tearDown() {
+        AckBatchingStubRelay.reset()
+        super.tearDown()
+    }
+
+    // MARK: - One ack per page
+
+    /// Two full pages — twenty batches — cost two acks, not twenty. This is the
+    /// request-count reduction the fix is for: the ack cursor is a watermark
+    /// (`last_batch_id = MAX(existing, through)`), so the last batch of a page
+    /// covers everything below it.
+    @MainActor
+    func testAFullPageIsAcknowledgedOnceAtItsLastCursor() async throws {
+        let identity = makeIdentity()
+        let signingKey = P256.Signing.PrivateKey()
+        let config = try makeConfig(keys: [producer: signingKey.publicKey.x963Representation])
+
+        AckBatchingStubRelay.reset()
+        AckBatchingStubRelay.deviceKey = signingKey.publicKey.x963Representation
+        AckBatchingStubRelay.producer = producer
+        AckBatchingStubRelay.core = config.coreDeviceID
+        AckBatchingStubRelay.pages = [
+            try page(sequences: Array(1...10), signer: signingKey, identity: identity),
+            try page(sequences: Array(11...20), signer: signingKey, identity: identity)
+        ]
+
+        let (ledger, service) = try makeService(config: config, identity: identity)
+        await service.refresh()
+
+        XCTAssertNil(service.lastErrorCode)
+        // Twenty batches imported...
+        XCTAssertEqual(service.machines.count, 1)
+        XCTAssertEqual(service.machines.first?.lastSequence, 20)
+        XCTAssertEqual(service.machines.first?.allTimeTokens, 20 * 15)
+        // ...through exactly two acks, one per page, each at that page's last
+        // cursor. The pre-fix loop issued twenty.
+        XCTAssertEqual(AckBatchingStubRelay.acknowledged(), ["c10", "c20"])
+        XCTAssertEqual(
+            AckBatchingStubRelay.ackAttemptCount(), 2,
+            "One ack request per page, not one per batch"
+        )
+        // And the persisted cursor is the same watermark.
+        let cursor = try await ledger.relayCursor(
+            workspaceID: workspace,
+            coreDeviceID: config.coreDeviceID
+        )
+        XCTAssertEqual(cursor, "c20")
+    }
+
+    // MARK: - Surviving the rate limiter
+
+    @MainActor
+    func testARateLimitedAckIsRetriedAndTheCycleSucceeds() async throws {
+        let identity = makeIdentity()
+        let signingKey = P256.Signing.PrivateKey()
+        let config = try makeConfig(keys: [producer: signingKey.publicKey.x963Representation])
+
+        AckBatchingStubRelay.reset()
+        AckBatchingStubRelay.deviceKey = signingKey.publicKey.x963Representation
+        AckBatchingStubRelay.producer = producer
+        AckBatchingStubRelay.core = config.coreDeviceID
+        AckBatchingStubRelay.pages = [
+            try page(sequences: [1, 2, 3], signer: signingKey, identity: identity)
+        ]
+        // nginx refuses the first attempt exactly as it did in production.
+        AckBatchingStubRelay.rateLimitedAckAttempts = 1
+
+        let (ledger, service) = try makeService(config: config, identity: identity)
+        await service.refresh()
+
+        // The 429 is a "come back shortly", not a failure: the retry lands and
+        // the cycle finishes clean.
+        XCTAssertNil(service.lastErrorCode)
+        XCTAssertEqual(service.machines.first?.lastSequence, 3)
+        XCTAssertEqual(AckBatchingStubRelay.ackAttemptCount(), 2, "One 429, then one success")
+        XCTAssertEqual(AckBatchingStubRelay.acknowledged(), ["c3"])
+        let cursor = try await ledger.relayCursor(
+            workspaceID: workspace,
+            coreDeviceID: config.coreDeviceID
+        )
+        XCTAssertEqual(cursor, "c3")
+    }
+
+    /// 503 is the other "come back shortly" answer nginx and CDNs use when they
+    /// shed load, and it must be treated like 429 rather than aborting.
+    @MainActor
+    func testAShedAckIsRetriedAndTheCycleSucceeds() async throws {
+        let identity = makeIdentity()
+        let signingKey = P256.Signing.PrivateKey()
+        let config = try makeConfig(keys: [producer: signingKey.publicKey.x963Representation])
+
+        AckBatchingStubRelay.reset()
+        AckBatchingStubRelay.deviceKey = signingKey.publicKey.x963Representation
+        AckBatchingStubRelay.producer = producer
+        AckBatchingStubRelay.core = config.coreDeviceID
+        AckBatchingStubRelay.pages = [
+            try page(sequences: [1], signer: signingKey, identity: identity)
+        ]
+        AckBatchingStubRelay.rateLimitedAckStatus = 503
+        AckBatchingStubRelay.rateLimitedAckAttempts = 2
+
+        let (_, service) = try makeService(config: config, identity: identity)
+        await service.refresh()
+
+        XCTAssertNil(service.lastErrorCode)
+        XCTAssertEqual(AckBatchingStubRelay.ackAttemptCount(), 3, "Two 503s, then the last attempt")
+        XCTAssertEqual(AckBatchingStubRelay.acknowledged(), ["c1"])
+    }
+
+    @MainActor
+    func testAnUnrelentingRateLimitRecordsTheErrorAfterBoundedRetries() async throws {
+        let identity = makeIdentity()
+        let signingKey = P256.Signing.PrivateKey()
+        let config = try makeConfig(keys: [producer: signingKey.publicKey.x963Representation])
+
+        AckBatchingStubRelay.reset()
+        AckBatchingStubRelay.deviceKey = signingKey.publicKey.x963Representation
+        AckBatchingStubRelay.producer = producer
+        AckBatchingStubRelay.core = config.coreDeviceID
+        AckBatchingStubRelay.pages = [
+            try page(sequences: [1, 2], signer: signingKey, identity: identity)
+        ]
+        AckBatchingStubRelay.rateLimitedAckAttempts = .max
+
+        let (_, service) = try makeService(config: config, identity: identity)
+        await service.refresh()
+
+        // Retries are bounded: three attempts in all, then the error surfaces
+        // exactly as it did before the fix. The point is that the cycle ends —
+        // it does not spin.
+        XCTAssertEqual(AckBatchingStubRelay.ackAttemptCount(), 3)
+        XCTAssertEqual(service.lastErrorCode, RemoteSyncError.http(429).code)
+        XCTAssertTrue(AckBatchingStubRelay.acknowledged().isEmpty)
+        // The single batch page was fetched once; a wedged ack must not send the
+        // loop around again.
+        XCTAssertEqual(AckBatchingStubRelay.batchRequestCount(), 1)
+    }
+
+    /// A non-retryable status is a real failure and must not buy three attempts
+    /// and two sleeps before surfacing.
+    @MainActor
+    func testAnUnauthorizedAckIsNotRetried() async throws {
+        let identity = makeIdentity()
+        let signingKey = P256.Signing.PrivateKey()
+        let config = try makeConfig(keys: [producer: signingKey.publicKey.x963Representation])
+
+        AckBatchingStubRelay.reset()
+        AckBatchingStubRelay.deviceKey = signingKey.publicKey.x963Representation
+        AckBatchingStubRelay.producer = producer
+        AckBatchingStubRelay.core = config.coreDeviceID
+        AckBatchingStubRelay.pages = [
+            try page(sequences: [1], signer: signingKey, identity: identity)
+        ]
+        AckBatchingStubRelay.rateLimitedAckStatus = 401
+        AckBatchingStubRelay.rateLimitedAckAttempts = .max
+
+        let (_, service) = try makeService(config: config, identity: identity)
+        await service.refresh()
+
+        XCTAssertEqual(AckBatchingStubRelay.ackAttemptCount(), 1, "401 fails on the first try")
+        XCTAssertEqual(service.lastErrorCode, RemoteSyncError.http(401).code)
+    }
+
+    // MARK: - Forward progress across a mid-page failure
+
+    /// Batching the ack must not cost forward progress. When a batch in the
+    /// middle of a page fails for a non-superseded reason the cycle still aborts
+    /// — but the batches ahead of it already landed in the ledger, so their
+    /// watermark is committed before the error propagates. Otherwise every
+    /// future cycle would re-walk the same prefix forever.
+    @MainActor
+    func testAMidPageFailureStillAcknowledgesTheBatchesBeforeIt() async throws {
+        let identity = makeIdentity()
+        let signingKey = P256.Signing.PrivateKey()
+        let config = try makeConfig(keys: [producer: signingKey.publicKey.x963Representation])
+
+        // Sequences 1 and 2 import; 4 skips a slot, which the ledger reports as
+        // a visible mid-stream gap.
+        let first = try seal(
+            signer: signingKey,
+            recipient: identity.recipientPrivateKey.publicKey,
+            sequence: 1,
+            plaintext: try usagePayload(sequence: 1)
+        )
+        let second = try seal(
+            signer: signingKey,
+            recipient: identity.recipientPrivateKey.publicKey,
+            sequence: 2,
+            plaintext: try usagePayload(sequence: 2)
+        )
+        let gapped = try seal(
+            signer: signingKey,
+            recipient: identity.recipientPrivateKey.publicKey,
+            sequence: 4,
+            plaintext: try usagePayload(sequence: 4)
+        )
+        let received = Int64(iso("2026-08-03T06:01:00Z").timeIntervalSince1970)
+
+        AckBatchingStubRelay.reset()
+        AckBatchingStubRelay.deviceKey = signingKey.publicKey.x963Representation
+        AckBatchingStubRelay.producer = producer
+        AckBatchingStubRelay.core = config.coreDeviceID
+        AckBatchingStubRelay.pages = [[
+            ["cursor": "c1", "received_at": received, "envelope": first],
+            ["cursor": "c2", "received_at": received, "envelope": second],
+            ["cursor": "c3", "received_at": received, "envelope": gapped]
+        ]]
+
+        let (ledger, service) = try makeService(config: config, identity: identity)
+        await service.refresh()
+
+        // The cycle aborts and reports the real reason, unchanged.
+        XCTAssertEqual(service.lastErrorCode, "sequence_gap")
+        // But the prefix that did import is acknowledged — once, at the last
+        // batch that actually succeeded.
+        XCTAssertEqual(AckBatchingStubRelay.acknowledged(), ["c2"])
+        let cursor = try await ledger.relayCursor(
+            workspaceID: workspace,
+            coreDeviceID: config.coreDeviceID
+        )
+        XCTAssertEqual(cursor, "c2", "The next cycle resumes after the last good batch")
+        // The error path's recordSync carries the cursor over rather than
+        // clearing it, so the recovered position survives the failure record.
+        XCTAssertEqual(service.machines.first?.lastSequence, 2)
+    }
+
+    // MARK: - Fixtures
+
+    @MainActor
+    private func makeService(
+        config: RemoteCoreConfig,
+        identity: RemoteCoreIdentity
+    ) throws -> (RemoteUsageLedger, RemoteProbeService) {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("remote-ack-batching-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: false)
+        addTeardownBlock { try? FileManager.default.removeItem(at: directory) }
+        let ledger = try RemoteUsageLedger(url: directory.appendingPathComponent("ledger.sqlite3"))
+
+        let sessionConfig = URLSessionConfiguration.ephemeral
+        sessionConfig.protocolClasses = [AckBatchingStubRelay.self]
+        let client = RemoteRelayClient(
+            config: config,
+            bearerToken: String(repeating: "t", count: 40),
+            session: URLSession(configuration: sessionConfig)
+        )
+        // Near-zero backoff: the retry arithmetic is what is under test, not the
+        // wall-clock waits. Production keeps the 1s / 2s default.
+        let service = RemoteProbeService(
+            config: config,
+            identity: identity,
+            client: client,
+            ledger: ledger,
+            relayRetryDelays: [.zero, .zero]
+        )
+        return (ledger, service)
+    }
+
+    /// One relay page: contiguous sequences, cursors `c<sequence>`, all sealed
+    /// to this Core's current epoch.
+    private func page(
+        sequences: [Int64],
+        signer: P256.Signing.PrivateKey,
+        identity: RemoteCoreIdentity
+    ) throws -> [[String: Any]] {
+        let received = Int64(iso("2026-08-03T06:01:00Z").timeIntervalSince1970)
+        return try sequences.map { sequence in
+            [
+                "cursor": "c\(sequence)",
+                "received_at": received,
+                "envelope": try seal(
+                    signer: signer,
+                    recipient: identity.recipientPrivateKey.publicKey,
+                    sequence: sequence,
+                    plaintext: try usagePayload(sequence: Int(sequence))
+                )
+            ]
+        }
+    }
+
+    private func makeIdentity() -> RemoteCoreIdentity {
+        RemoteCoreIdentity(
+            signingPrivateKey: P256.Signing.PrivateKey(),
+            recipientPrivateKey: P256.KeyAgreement.PrivateKey()
+        )
+    }
+
+    private func makeConfig(keys: [UUID: Data]) throws -> RemoteCoreConfig {
+        try RemoteCoreConfig(
+            workspaceID: workspace,
+            coreDeviceID: UUID(uuidString: "99999999-9999-4999-8999-999999999999")!,
+            relayURL: URL(string: "https://relay.example.invalid")!,
+            coreEpoch: 1,
+            ingestKeyID: "ingest-epoch-1",
+            probeSigningPublicKeys: keys
+        )
+    }
+
+    private func iso(_ value: String) -> Date {
+        ISO8601DateFormatter().date(from: value)!
+    }
+
+    /// Seal an ingest envelope with the exact reverse of the open path: AES-GCM
+    /// over the plaintext with the canonical header as AAD, then a P-256
+    /// signature over the canonical unsigned envelope.
+    private func seal(
+        signer: P256.Signing.PrivateKey,
+        recipient: P256.KeyAgreement.PublicKey,
+        coreEpoch: Int = 1,
+        keyID: String = "ingest-epoch-1",
+        sequence: Int64,
+        createdAt: String = "2026-08-03T06:00:00Z",
+        expiresAt: String = "2026-09-02T06:00:00Z",
+        plaintext: Data
+    ) throws -> [String: Any] {
+        let nonce = Data((0..<12).map { _ in UInt8.random(in: .min ... .max) })
+        let ephemeral = P256.KeyAgreement.PrivateKey()
+        let header: [String: Any] = [
+            "protocol_version": 1,
+            "minimum_consumer_version": 1,
+            "workspace_id": workspace.uuidString.lowercased(),
+            "stream": "ingest",
+            "producer_id": producer.uuidString.lowercased(),
+            "sequence": Int(sequence),
+            "core_epoch": coreEpoch,
+            "key_id": keyID,
+            "created_at": createdAt,
+            "expires_at": expiresAt,
+            "ephemeral_public_key": ephemeral.publicKey.x963Representation.base64EncodedString(),
+            "nonce": nonce.base64EncodedString(),
+            "signing_public_key": signer.publicKey.x963Representation.base64EncodedString()
+        ]
+        let secret = try ephemeral.sharedSecretFromKeyAgreement(with: recipient)
+        let symmetricKey = secret.hkdfDerivedSymmetricKey(
+            using: SHA256.self,
+            salt: Data("VibeBar Sync Protocol v1\0".utf8),
+            sharedInfo: hkdfInfo(sequence: sequence),
+            outputByteCount: 32
+        )
+        let sealed = try AES.GCM.seal(
+            plaintext,
+            using: symmetricKey,
+            nonce: AES.GCM.Nonce(data: nonce),
+            authenticating: try canonical(header)
+        )
+        var ciphertext = sealed.ciphertext
+        ciphertext.append(sealed.tag)
+        var object = header
+        object["ciphertext"] = ciphertext.base64EncodedString()
+        object["signature"] = try signer
+            .signature(for: try canonical(object)).rawRepresentation.base64EncodedString()
+        return object
+    }
+
+    /// Canonicalize through the same round trip `openIngestEnvelope` performs
+    /// (it re-parses `Data` before encoding), so the AAD and signature bytes
+    /// computed here match byte-for-byte.
+    private func canonical(_ object: [String: Any]) throws -> Data {
+        let reparsed = try JSONSerialization.jsonObject(
+            with: try JSONSerialization.data(withJSONObject: object)
+        )
+        return try RemoteCanonicalJSON.encode(reparsed)
+    }
+
+    private func hkdfInfo(sequence: Int64) -> Data {
+        var output = Data("vibebar/envelope/v1\0ingest\0".utf8)
+        output.append(contentsOf: workspace.uuidString.lowercased().utf8)
+        output.append(0)
+        output.append(contentsOf: producer.uuidString.lowercased().utf8)
+        output.append(0)
+        var bigEndian = UInt64(sequence).bigEndian
+        withUnsafeBytes(of: &bigEndian) { output.append(contentsOf: $0) }
+        return output
+    }
+
+    private func usagePayload(sequence: Int) throws -> Data {
+        let operation: [String: Any] = [
+            "op": "usage_upsert",
+            "source_key": String(repeating: "s", count: 43),
+            "source_generation": 1,
+            "event_key": String(repeating: "e", count: 42) + String(sequence),
+            "tool": "codex",
+            "occurred_at": "2026-08-03T06:00:00Z",
+            "observed_at": "2026-08-03T06:01:00Z",
+            "model": "example-model",
+            "tokens": [
+                "input": 10, "output": 5, "cache_read": 0,
+                "cache_creation": 0, "reasoning": 0, "tool": 0,
+                "total_only": NSNull()
+            ],
+            "request_count": 1,
+            "service_tier": NSNull(),
+            "accounting": "exact",
+            "parser_version": 1
+        ]
+        let body: [String: Any] = [
+            "schema": 1,
+            "workspace_id": workspace.uuidString.lowercased(),
+            "producer_id": producer.uuidString.lowercased(),
+            "probe": [
+                "alias": "Example machine", "version": "0.1.0",
+                "platform": "linux-x86_64", "timezone": "UTC"
+            ],
+            "previous_sequence": sequence == 1 ? NSNull() : (sequence - 1) as Any,
+            "operations": [operation],
+            "status": [
+                "last_scan_at": "2026-08-03T06:01:00Z",
+                "backlog_batches": 1,
+                "applied_control_sequence": 0,
+                "sources": ["codex": "ok"]
+            ]
+        ]
+        return try JSONSerialization.data(withJSONObject: body)
+    }
+}
+
+/// Stubs the three Relay endpoints the refresh loop touches. `/batches` drains
+/// `pages` in order and then answers empty, so the loop terminates the way a
+/// real drained stream does. `/acks` can be told to answer a retryable (or
+/// non-retryable) status for the first N attempts, which is how the production
+/// nginx 429 is reproduced. Every ack attempt and batch request is counted so a
+/// test can assert on the request volume itself, not just the outcome.
+private final class AckBatchingStubRelay: URLProtocol {
+    nonisolated(unsafe) static var pages: [[[String: Any]]] = []
+    nonisolated(unsafe) static var deviceKey = Data()
+    nonisolated(unsafe) static var producer = UUID()
+    nonisolated(unsafe) static var core = UUID()
+    /// How many leading `/acks` attempts are refused before the first success.
+    /// `.max` refuses every attempt.
+    nonisolated(unsafe) static var rateLimitedAckAttempts = 0
+    nonisolated(unsafe) static var rateLimitedAckStatus = 429
+    nonisolated(unsafe) private static var acks: [String] = []
+    nonisolated(unsafe) private static var ackAttempts = 0
+    nonisolated(unsafe) private static var batchRequests = 0
+    private static let lock = NSLock()
+
+    static func reset() {
+        lock.lock(); defer { lock.unlock() }
+        pages = []
+        deviceKey = Data()
+        rateLimitedAckAttempts = 0
+        rateLimitedAckStatus = 429
+        acks = []
+        ackAttempts = 0
+        batchRequests = 0
+    }
+
+    static func acknowledged() -> [String] {
+        lock.lock(); defer { lock.unlock() }
+        return acks
+    }
+
+    static func ackAttemptCount() -> Int {
+        lock.lock(); defer { lock.unlock() }
+        return ackAttempts
+    }
+
+    static func batchRequestCount() -> Int {
+        lock.lock(); defer { lock.unlock() }
+        return batchRequests
+    }
+
+    private static func nextPage() -> [[String: Any]] {
+        lock.lock(); defer { lock.unlock() }
+        batchRequests += 1
+        guard !pages.isEmpty else { return [] }
+        return pages.removeFirst()
+    }
+
+    /// Returns the status this attempt should answer, recording the attempt.
+    private static func ackStatus() -> Int {
+        lock.lock(); defer { lock.unlock() }
+        ackAttempts += 1
+        return ackAttempts <= rateLimitedAckAttempts ? rateLimitedAckStatus : 200
+    }
+
+    private static func recordAck(_ cursor: String) {
+        lock.lock(); defer { lock.unlock() }
+        acks.append(cursor)
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+    override func stopLoading() {}
+
+    override func startLoading() {
+        let path = request.url?.path ?? ""
+        if path.hasSuffix("/devices") {
+            respond(status: 200, body: [
+                "devices": [
+                    [
+                        "device_id": Self.producer.uuidString.lowercased(),
+                        "role": "probe",
+                        "status": "active",
+                        "signing_public_key": Self.deviceKey.base64EncodedString()
+                    ],
+                    [
+                        "device_id": Self.core.uuidString.lowercased(),
+                        "role": "core",
+                        "status": "active"
+                    ]
+                ]
+            ])
+            return
+        }
+        if path.hasSuffix("/batches") {
+            let batches = Self.nextPage()
+            let last = batches.last?["cursor"] as? String ?? ""
+            respond(status: 200, body: ["batches": batches, "next_cursor": last])
+            return
+        }
+        if path.hasSuffix("/acks") {
+            let status = Self.ackStatus()
+            guard status == 200 else {
+                respond(status: status, body: ["error": "rate_limited"])
+                return
+            }
+            let cursor = Self.ackCursor(request)
+            Self.recordAck(cursor)
+            respond(status: 200, body: ["acknowledged_cursor": cursor])
+            return
+        }
+        respond(status: 200, body: [:])
+    }
+
+    private func respond(status: Int, body: [String: Any]) {
+        let response = HTTPURLResponse(
+            url: request.url!,
+            statusCode: status,
+            httpVersion: "HTTP/1.1",
+            headerFields: ["Cache-Control": "no-store"]
+        )!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        if let data = try? JSONSerialization.data(withJSONObject: body) {
+            client?.urlProtocol(self, didLoad: data)
+        }
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    private static func ackCursor(_ request: URLRequest) -> String {
+        let data = requestBody(request)
+        guard let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let cursor = object["cursor"] as? String
+        else { return "" }
+        return cursor
+    }
+
+    /// URLProtocol receives POST bodies via `httpBodyStream`, not `httpBody`.
+    private static func requestBody(_ request: URLRequest) -> Data {
+        if let body = request.httpBody { return body }
+        guard let stream = request.httpBodyStream else { return Data() }
+        stream.open()
+        defer { stream.close() }
+        var data = Data()
+        let size = 4096
+        let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: size)
+        defer { buffer.deallocate() }
+        while stream.hasBytesAvailable {
+            let read = stream.read(buffer, maxLength: size)
+            if read <= 0 { break }
+            data.append(buffer, count: read)
+        }
+        return data
+    }
+}

--- a/Tests/VibeBarCoreTests/RemoteSupersededEpochTests.swift
+++ b/Tests/VibeBarCoreTests/RemoteSupersededEpochTests.swift
@@ -188,9 +188,11 @@ final class RemoteSupersededEpochTests: XCTestCase {
         XCTAssertEqual(service.machines.first?.producerID, producer)
         XCTAssertEqual(service.machines.first?.allTimeTokens, 15)
 
-        // Both cursors were acknowledged so the Relay GC can reclaim them, and
-        // the ledger cursor advanced past BOTH batches.
-        XCTAssertEqual(Set(StubRelay.acknowledged()), ["c1", "c2"])
+        // Both batches were acknowledged so the Relay GC can reclaim them, and
+        // the ledger cursor advanced past BOTH batches. The ack is a monotonic
+        // watermark, so the page sends exactly one — at the last batch it
+        // processed, which covers the superseded one underneath it.
+        XCTAssertEqual(StubRelay.acknowledged(), ["c2"])
         let cursor = try await ledger.relayCursor(
             workspaceID: workspace,
             coreDeviceID: config.coreDeviceID
@@ -275,8 +277,9 @@ final class RemoteSupersededEpochTests: XCTestCase {
         // just the one it imported.
         XCTAssertEqual(service.machines.first?.lastSequence, 3)
 
-        // Every batch was acknowledged and the cursor advanced past all three.
-        XCTAssertEqual(Set(StubRelay.acknowledged()), ["c1", "c2", "c3"])
+        // Every batch was acknowledged and the cursor advanced past all three —
+        // through one watermark ack at the last processed batch, not three.
+        XCTAssertEqual(StubRelay.acknowledged(), ["c3"])
         let cursor = try await ledger.relayCursor(
             workspaceID: workspace,
             coreDeviceID: config.coreDeviceID


### PR DESCRIPTION
## Summary

Production nginx logs showed a real 429 from `User-Agent: Vibe Bar/20` against the Relay's `POST /acks`. Two client-side bugs stacked:

- **Chattiness.** `performRefresh` acknowledged **every batch individually** inside the per-batch loop, so draining a backlog of a few hundred queued batches fired that many `POST /acks` in a tight burst.
- **Fragility.** The resulting 429 is not the superseded case, so it escaped the per-batch `catch`, aborted the whole cycle, and left the cursor parked — the UI showed `Latest sync error: relay_http_error` with `Last sync: never` even though batches had imported fine before the abort.

### Fix 1 — one ack per page, not one per batch

The Relay's ack is a monotonic watermark (`last_batch_id = MAX(existing, through)`), so acknowledging only the last batch a page processed is exactly equivalent to acknowledging each of them, at ~1/10th the requests. The loop now processes the whole page, tracks the cursor of the last batch it successfully processed, then issues **one** `acknowledge` and **one** `recordSync` at that cursor.

Crash safety is unchanged: if the app dies mid-page before the ack, the next fetch re-delivers those batches; `importBatch` dedups on `remote_imported_batches` and `noteSupersededBatch` inserts with `ON CONFLICT DO NOTHING`, so redelivery is a no-op.

A non-superseded error mid-page keeps today's semantics (propagate to the outer catch, abort the cycle) — but the prefix the page already processed is committed **best-effort** before the error propagates, so forward progress is never lost and the failing batch is not re-walked from the top forever.

### Fix 2 — survive rate limiting instead of aborting

`429` and `503` around the batch-path Relay calls (`fetch`, `acknowledge`) are now retried with bounded exponential backoff (1s, then 2s — three attempts total) via `Task.sleep`. Every other status (400/401/403) stays a first-try failure. The generation fence is re-checked after each sleep so a `reconfigure()` during backoff cancels the cycle cleanly instead of resuming under a stale configuration. When retries are exhausted the error propagates exactly as before and the cycle records it.

`Retry-After` is **not** honored: `RemoteRelayClient.validate` collapses every non-200 into `RemoteSyncError.http(statusCode)`, and widening that public `Equatable` case to carry a response header would ripple through the model, the client, and their tests for little gain over a fixed schedule. Documented in the code.

Unchanged: superseded skip semantics, the roster sync (already fail-soft), the 100-page cap, the count-only `SafeLog`, and the outer catch's error recording.

Backoff durations are injectable through the existing internal test seam (`relayRetryDelays`, production default `[1s, 2s]`) — no new public API.

## Test plan

- [x] `swift build`
- [x] `swift test` — 1121 tests, 0 failures
- [x] `./Scripts/build_app.sh release`
- [x] `codesign -d --entitlements :- ".build/Vibe Bar.app"` → empty `<dict/>`, no `app-sandbox`
- [x] `codesign --verify --deep --strict ".build/Vibe Bar.app"` → clean
- [x] AGENTS.md § 6 home-directory grep → no new hits (only the two pre-existing lines inside `RealHomeDirectory.swift`)

New `Tests/VibeBarCoreTests/RemoteAckBatchingTests.swift` (6 tests, stubbed `URLProtocol` + real ledger):

- Two full pages (20 batches) produce exactly **2** ack requests at `c10` / `c20` — the pre-fix loop issued 20. **10x request reduction, asserted on the request count itself.**
- A 429 on the first ack attempt then 200 → cycle completes with `lastErrorCode == nil` (2 attempts).
- A 503 for two attempts then 200 → cycle completes (3 attempts).
- 429 on every attempt → bounded at 3 attempts, `lastErrorCode == "relay_http_error"`, does not spin.
- 401 on the ack → not retried, fails on the first try.
- A `sequence_gap` mid-page → cycle still aborts with `sequence_gap`, but the prefix is acked at the last good cursor (`c2`) and the persisted relay cursor is `c2`.

Existing superseded/cursor/sequence tests still pass; the two ack assertions in `RemoteSupersededEpochTests` were **strengthened** from an order-insensitive `Set` of every cursor to an exact single-element array at the last processed cursor.

No manual smoke test of the relay path (needs a live workspace with a real backlog); the release bundle was built, signed, and verified.