### PR TITLE
Prepare Vibe Bar 1.3.0 Dev build 21

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.3.0</string>
 	<key>CFBundleVersion</key>
-	<string>20</string>
+	<string>21</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>26.0</string>
 	<key>LSUIElement</key>


### PR DESCRIPTION
Dev prerelease carrying the ack-batching fix (PR #149). Draining a backlog used to fire one POST /acks per batch — a few hundred requests in a tight burst that tripped the relay's nginx rate limit, and the resulting 429 aborted the whole cycle ('relay_http_error', 'Last sync: never') even though the batches had imported. The Core now acknowledges once per page (~10x fewer requests, verified on request count) and retries 429/503 with bounded backoff instead of failing the cycle. A mid-page failure still aborts, but commits the watermark for what it already processed so progress is never replayed.

CFBundleVersion 20 → 21; CFBundleShortVersionString stays 1.3.0.

- [x] swift build
- [x] swift test (1121 tests, 0 failures)
- [x] ./Scripts/build_app.sh release
- [x] codesign entitlements empty (no app-sandbox)
- [x] codesign --verify --deep --strict

🤖 Generated with [Claude Code](https://claude.com/claude-code)