### PR TITLE
Merge selected Probe usage into Core totals

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,10 @@ It answers two questions that raw quota percentages do not:
   component uptime in the same place as quota data.
 - **Two floating layouts** — a spacious gauge view and a compact view that
   can stay pinned above your work.
-- **Local-first storage** — no Vibe Bar account, telemetry, or hosted backend.
+- **End-to-end encrypted remote machines** — outbound-only Linux Probes can
+  join selected cost/token totals without giving Relay or Control plaintext.
+- **Local-first usage** — no telemetry or hosted plaintext analytics backend;
+  the optional account/control service stores workspace/device metadata only.
 
 ## One Overview, Not Four Dashboards
 
@@ -95,6 +98,19 @@ patterns on the right.
   </tr>
 </table>
 
+## Remote Machines
+
+The separate [VibeBar Probe](https://github.com/AstroQore/vibebar-probe) can
+observe supported CLI logs on a systemd Linux machine without opening an
+inbound port. Probe facts are buffered locally, encrypted to the active Core,
+and routed through an opaque Relay. Each remote machine is excluded from totals
+until you explicitly enable **Include in totals**; selected usage then joins
+this Mac's local snapshots across Overview and the four core cost pages.
+
+See the [Remote Probe guide](https://vibebar.aqor.io/docs/guide/remote-probes)
+for binary installation, enrollment, updates, rollback, and the Web/iOS E2EE
+freshness model.
+
 ## More Coding Plans
 
 The Misc page keeps provider-specific quota semantics intentionally simple and
@@ -132,8 +148,10 @@ data as a successful update.
 
 ## Privacy and Local Data
 
-Vibe Bar has no account system, telemetry pipeline, or hosted analytics
-backend. Derived state stays under:
+Vibe Bar has no telemetry pipeline or hosted plaintext analytics backend.
+Local and remote-Probe usage analysis stays on the active Core. The optional
+hosted account/control service stores workspace, enrollment, Relay directory,
+and audit metadata only. Derived state stays under:
 
 ```text
 ~/.vibebar/
@@ -142,6 +160,8 @@ backend. Derived state stays under:
 ├── cost_snapshots/
 ├── scan_cache/
 ├── service_status.json
+├── remote_core.json
+├── remote_usage.sqlite3
 └── cost_history.json
 ```
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -50,7 +50,10 @@ Vibe Bar 把 ChatGPT/Codex、Claude Code、Gemini Web、AntiGravity、Grok
 - **服务状态** —— OpenAI、Anthropic、Google、xAI 的事故信息、组件状态与
   Uptime 和额度放在同一个界面。
 - **两种迷你浮窗** —— 真正不同的信息密度，可固定在第二块屏幕或全屏工作区上方。
-- **本地优先** —— 没有 Vibe Bar 账号、遥测系统或托管分析后端。
+- **端到端加密远端机器** —— 只出站的 Linux Probe 可按选择并入成本/Token，
+  Relay 与 Control 不会得到明文。
+- **用量本地优先** —— 没有遥测或托管明文分析后端；可选账号/控制服务只保存
+  Workspace 与设备元数据。
 
 ## 一个 Overview，而不是四个网页
 
@@ -90,6 +93,17 @@ Vibe Bar 把 ChatGPT/Codex、Claude Code、Gemini Web、AntiGravity、Grok
   </tr>
 </table>
 
+## 远端机器
+
+独立的 [VibeBar Probe](https://github.com/AstroQore/vibebar-probe) 可以观察带
+systemd 的 Linux 机器上的受支持 CLI Log，无需开放入站端口。Probe 在本地缓冲事实，
+加密给当前活跃 Core，再通过不透明 Relay 路由。每台远端机器默认不加入总计；只有
+明确打开 **Include in totals** 后，所选用量才会与这台 Mac 的本地 Snapshot 合并，
+显示在 Overview 与四个核心成本页面。
+
+二进制安装、纳管、更新、回滚以及 Web/iOS E2EE 新鲜度模型见
+[远端探针指南](https://vibebar.aqor.io/docs/zh/guide/remote-probes)。
+
 ## 更多 Coding Plan
 
 Misc 页面保留各服务商原本的额度语义，同时统一成容易扫读的卡片。现有集成包括
@@ -124,7 +138,9 @@ OpenCode Go、Ollama Cloud、智谱 GLM、小米 MiMo、Kimi、MiniMax、阿里�
 
 ## 隐私与本地数据
 
-Vibe Bar 没有账号系统、遥测管线或托管分析后端。衍生数据只保存在：
+Vibe Bar 没有遥测管线或托管明文分析后端。本地与远端 Probe 用量分析都留在当前
+活跃 Core 上；可选托管账号/控制服务只保存 Workspace、纳管、Relay 目录与审计
+元数据。衍生数据保存在：
 
 ```text
 ~/.vibebar/
@@ -133,6 +149,8 @@ Vibe Bar 没有账号系统、遥测管线或托管分析后端。衍生数据�
 ├── cost_snapshots/
 ├── scan_cache/
 ├── service_status.json
+├── remote_core.json
+├── remote_usage.sqlite3
 └── cost_history.json
 ```
 

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.3.0</string>
 	<key>CFBundleVersion</key>
-	<string>21</string>
+	<string>22</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>26.0</string>
 	<key>LSUIElement</key>

--- a/Sources/VibeBarApp/AppEnvironment.swift
+++ b/Sources/VibeBarApp/AppEnvironment.swift
@@ -48,6 +48,7 @@ final class AppEnvironment: ObservableObject {
     private var webCookiePresenceGeneration: UInt64 = 0
     private var routeHealthProbeGeneration: UInt64 = 0
     private var routeHealthWriteGeneration: [PrimaryProviderRoute: UInt64] = [:]
+    private var remoteCostAggregationGeneration: UInt64 = 0
     /// Long enough to fold the probes of one refresh burst — the Gemini card
     /// refreshes two providers back to back — and short enough that a cookie
     /// change made outside Vibe Bar still shows up on the next manual refresh.
@@ -224,6 +225,21 @@ final class AppEnvironment: ObservableObject {
             }
             .store(in: &cancellables)
 
+        // Remote facts become visible to cost surfaces only after the user
+        // selects their machine IDs. Rebuild after either a successful Relay
+        // import or a selection change; generation fencing prevents a slower
+        // old selection from publishing after a newer click.
+        remoteProbeService.$machines
+            .combineLatest(
+                settings.$settings
+                    .map(\.remoteCostIncludedMachineIDs)
+                    .removeDuplicates()
+            )
+            .sink { [weak self] _, machineIDs in
+                self?.scheduleRemoteCostAggregation(machineIDs: machineIDs)
+            }
+            .store(in: &cancellables)
+
         scheduler.start()
         serviceStatus.start()
         remoteProbeService.start()
@@ -284,6 +300,19 @@ final class AppEnvironment: ObservableObject {
 
     deinit {
         pricingRefreshTask?.cancel()
+    }
+
+    private func scheduleRemoteCostAggregation(machineIDs: Set<String>) {
+        remoteCostAggregationGeneration &+= 1
+        let generation = remoteCostAggregationGeneration
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            let snapshots = await remoteProbeService.costSnapshots(
+                includingMachineIDs: machineIDs
+            )
+            guard generation == remoteCostAggregationGeneration else { return }
+            costService.setRemoteSnapshots(snapshots)
+        }
     }
 
     func account(for tool: ToolType) -> AccountIdentity? {

--- a/Sources/VibeBarApp/Views/RemoteMachinesPage.swift
+++ b/Sources/VibeBarApp/Views/RemoteMachinesPage.swift
@@ -5,6 +5,7 @@ struct RemoteMachinesPage: View {
     let density: Theme.Density
 
     @EnvironmentObject private var service: RemoteProbeService
+    @EnvironmentObject private var settingsStore: SettingsStore
 
     var body: some View {
         VStack(alignment: .leading, spacing: density.interSectionSpacing) {
@@ -73,7 +74,7 @@ struct RemoteMachinesPage: View {
                         .foregroundStyle(.secondary)
                 }
                 Spacer()
-                freshness(machine.lastSeenAt)
+                freshness(machine)
             }
 
             HStack(spacing: 0) {
@@ -126,6 +127,11 @@ struct RemoteMachinesPage: View {
                         .background(Capsule().fill(Color.primary.opacity(0.04)))
                 }
                 Spacer(minLength: 0)
+                Toggle("Include in totals", isOn: includedInTotals(machine))
+                    .toggleStyle(.switch)
+                    .controlSize(.mini)
+                    .font(.caption2)
+                    .help("Add this machine's decrypted usage to Overview and provider cost pages on this Core")
                 Text("seq \(machine.lastSequence)")
                     .font(.caption2.monospacedDigit())
                     .foregroundStyle(.tertiary)
@@ -146,17 +152,21 @@ struct RemoteMachinesPage: View {
         .frame(maxWidth: .infinity, alignment: .leading)
     }
 
-    private func freshness(_ date: Date) -> some View {
-        let age = Date().timeIntervalSince(date)
+    private func freshness(_ machine: RemoteMachineSummary) -> some View {
+        let freshness = RemoteMachineFreshness.evaluate(
+            lastSeenAt: machine.lastSeenAt,
+            expectedReportIntervalSeconds: machine.expectedReportIntervalSeconds
+        )
         let label: String
         let color: Color
-        if age <= 120 {
+        switch freshness {
+        case .live:
             label = "Live"
             color = .green
-        } else if age <= 600 {
+        case .delayed:
             label = "Delayed"
             color = .orange
-        } else {
+        case .stale:
             label = "Stale"
             color = .red
         }
@@ -168,6 +178,19 @@ struct RemoteMachinesPage: View {
         .padding(.horizontal, 8)
         .padding(.vertical, 4)
         .background(Capsule().fill(color.opacity(0.10)))
+    }
+
+    private func includedInTotals(_ machine: RemoteMachineSummary) -> Binding<Bool> {
+        Binding(
+            get: { settingsStore.settings.remoteCostIncludedMachineIDs.contains(machine.id) },
+            set: { included in
+                if included {
+                    settingsStore.settings.remoteCostIncludedMachineIDs.insert(machine.id)
+                } else {
+                    settingsStore.settings.remoteCostIncludedMachineIDs.remove(machine.id)
+                }
+            }
+        )
     }
 
     private var cardBackground: some View {

--- a/Sources/VibeBarApp/Views/RemoteSettingsSection.swift
+++ b/Sources/VibeBarApp/Views/RemoteSettingsSection.swift
@@ -12,6 +12,7 @@ import VibeBarCore
 /// which routes the bearer token straight into the credential Vault.
 struct RemoteSettingsSection: View {
     @ObservedObject var service: RemoteProbeService
+    @EnvironmentObject private var settingsStore: SettingsStore
 
     @State private var exportStatus: String?
     @State private var importStatus: String?
@@ -39,12 +40,40 @@ struct RemoteSettingsSection: View {
             statusSection
             provisioningSection
             if service.isConfigured {
+                aggregationSection
                 disconnectSection
             }
         }
         // Only here, and only as an offer: a join is never completed behind
         // the user's back.
         .onAppear { restorePendingEnrollment() }
+    }
+
+    private var aggregationSection: some View {
+        section("Cost aggregation") {
+            Text("Choose which remote machines join this Mac's local cost and token totals. Selection and aggregation stay on this Core; the Relay never sees plaintext usage.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            if service.machines.isEmpty {
+                Text("Machines appear here after their first encrypted batch is imported.")
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+            } else {
+                ForEach(service.machines) { machine in
+                    Toggle(isOn: includedInTotals(machine)) {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(machine.alias)
+                                .font(.caption.weight(.medium))
+                            Text("\(machine.platform) · Probe \(machine.probeVersion)")
+                                .font(.caption2)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                    .toggleStyle(.switch)
+                    .controlSize(.small)
+                }
+            }
+        }
     }
 
     // MARK: - Status
@@ -413,6 +442,19 @@ struct RemoteSettingsSection: View {
                 .font(.caption.monospaced())
                 .textSelection(.enabled)
         }
+    }
+
+    private func includedInTotals(_ machine: RemoteMachineSummary) -> Binding<Bool> {
+        Binding(
+            get: { settingsStore.settings.remoteCostIncludedMachineIDs.contains(machine.id) },
+            set: { included in
+                if included {
+                    settingsStore.settings.remoteCostIncludedMachineIDs.insert(machine.id)
+                } else {
+                    settingsStore.settings.remoteCostIncludedMachineIDs.remove(machine.id)
+                }
+            }
+        )
     }
 
     /// Mirrors SettingsView.settingsSection so this pane matches the other

--- a/Sources/VibeBarCore/Models/AppSettings.swift
+++ b/Sources/VibeBarCore/Models/AppSettings.swift
@@ -47,6 +47,14 @@ public struct AppSettings: Codable, Equatable, Sendable {
     public var miscProviderInstances: [MiscProviderInstance]
     public var costData: CostDataSettings
 
+    /// Stable `workspace:producer` identifiers for remote machines whose
+    /// decrypted usage should join this Core's local cost snapshots.
+    ///
+    /// Empty by default on purpose: upgrading Vibe Bar must not silently add a
+    /// second machine's history to totals the user already understands. The
+    /// selection is local Core intent and never leaves this Mac.
+    public var remoteCostIncludedMachineIDs: Set<String>
+
     /// Silently re-import a cookie-sourced misc provider's browser
     /// session when its stored jar has gone stale, instead of leaving
     /// the card on "Needs re-login" until the user clicks Import.
@@ -129,7 +137,8 @@ public struct AppSettings: Codable, Equatable, Sendable {
         visibleMiscProviders: Self.defaultVisibleMiscProviders,
         miscProviderOrder: Self.defaultMiscProviderOrder,
         miscProviderInstances: Self.defaultMiscProviderInstances,
-        costData: .default
+        costData: .default,
+        remoteCostIncludedMachineIDs: []
     )
 
     /// Quota refresh cadences the Settings picker offers, fastest first.
@@ -225,6 +234,7 @@ public struct AppSettings: Codable, Equatable, Sendable {
         miscProviderOrder: [ToolType] = AppSettings.defaultMiscProviderOrder,
         miscProviderInstances: [MiscProviderInstance]? = nil,
         costData: CostDataSettings = .default,
+        remoteCostIncludedMachineIDs: Set<String> = [],
         overviewQuotaHistoryHiddenCurveIds: Set<String> = [],
         pageLayouts: [PageLayoutPageID: StoredPageLayout] = [:],
         pageLayoutPresets: [PageLayoutPageID: [StoredPageLayoutPreset]] = [:],
@@ -262,6 +272,9 @@ public struct AppSettings: Codable, Equatable, Sendable {
         self.visibleMiscProviders = Self.legacyVisibleMiscProviders(from: self.miscProviderInstances)
         self.miscProviderOrder = Self.legacyMiscProviderOrder(from: self.miscProviderInstances)
         self.costData = costData
+        self.remoteCostIncludedMachineIDs = Set(
+            remoteCostIncludedMachineIDs.map { $0.lowercased() }
+        )
         self.overviewQuotaHistoryHiddenCurveIds = overviewQuotaHistoryHiddenCurveIds
         self.pageLayouts = pageLayouts
         self.pageLayoutPresets = Self.normalizedPageLayoutPresets(pageLayoutPresets)
@@ -315,6 +328,7 @@ public struct AppSettings: Codable, Equatable, Sendable {
         case miscProviderOrder
         case miscProviderInstances
         case costData
+        case remoteCostIncludedMachineIDs
         case overviewQuotaHistoryHiddenCurveIds
         case pageLayouts
         case pageLayoutPresets
@@ -446,6 +460,10 @@ public struct AppSettings: Codable, Equatable, Sendable {
         self.miscProviderOrder = Self.legacyMiscProviderOrder(from: self.miscProviderInstances)
 
         self.costData = try c.decodeIfPresent(CostDataSettings.self, forKey: .costData) ?? .default
+        self.remoteCostIncludedMachineIDs = Set(
+            (try c.decodeIfPresent(Set<String>.self, forKey: .remoteCostIncludedMachineIDs) ?? [])
+                .map { $0.lowercased() }
+        )
         self.overviewQuotaHistoryHiddenCurveIds =
             try c.decodeIfPresent(Set<String>.self, forKey: .overviewQuotaHistoryHiddenCurveIds) ?? []
         // `try?` rather than `try`: a layout map mangled by hand should cost
@@ -509,6 +527,10 @@ public struct AppSettings: Codable, Equatable, Sendable {
         try c.encode(miscProviderOrder.map(\.rawValue), forKey: .miscProviderOrder)
         try c.encode(miscProviderInstances, forKey: .miscProviderInstances)
         try c.encode(costData, forKey: .costData)
+        try c.encode(
+            Set(remoteCostIncludedMachineIDs.map { $0.lowercased() }),
+            forKey: .remoteCostIncludedMachineIDs
+        )
         try c.encode(overviewQuotaHistoryHiddenCurveIds, forKey: .overviewQuotaHistoryHiddenCurveIds)
         try c.encode(pageLayouts, forKey: .pageLayouts)
         try c.encode(pageLayoutPresets, forKey: .pageLayoutPresets)

--- a/Sources/VibeBarCore/Models/RemoteMachineFreshness.swift
+++ b/Sources/VibeBarCore/Models/RemoteMachineFreshness.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+/// Health of one Probe relative to its own observed reporting cadence.
+///
+/// A five-minute Probe is not delayed merely because its last batch is three
+/// minutes old. The Core learns the cadence from Relay receipt timestamps and
+/// only warns after an expected report is actually missed. With too little
+/// history to learn from, the conservative legacy 2/10 minute thresholds are
+/// retained.
+public enum RemoteMachineFreshness: String, Equatable, Sendable {
+    case live
+    case delayed
+    case stale
+
+    public static func evaluate(
+        lastSeenAt: Date,
+        expectedReportIntervalSeconds: TimeInterval?,
+        now: Date = Date()
+    ) -> Self {
+        let age = max(0, now.timeIntervalSince(lastSeenAt))
+        guard let learned = expectedReportIntervalSeconds, learned.isFinite, learned > 0 else {
+            if age <= 120 { return .live }
+            if age <= 600 { return .delayed }
+            return .stale
+        }
+
+        // 40% jitter covers the Probe scan itself, network transit, and the
+        // Core's 60-second fetch loop without hiding a genuinely missed cycle.
+        let liveThrough = max(120, learned * 1.4)
+        // A second missed report is stale. Keep ten minutes as the floor for
+        // fast probes so a brief Mac sleep does not flash red immediately.
+        let delayedThrough = max(600, learned * 2.5)
+        if age <= liveThrough { return .live }
+        if age <= delayedThrough { return .delayed }
+        return .stale
+    }
+}

--- a/Sources/VibeBarCore/Models/RemoteSyncModels.swift
+++ b/Sources/VibeBarCore/Models/RemoteSyncModels.swift
@@ -208,6 +208,9 @@ public struct RemoteMachineSummary: Identifiable, Equatable, Sendable {
     public let probeVersion: String
     public let lastSeenAt: Date
     public let lastScanAt: Date
+    /// Median Relay receipt cadence learned from recent batches. `nil` until
+    /// enough batches exist to distinguish a real interval from a first sync.
+    public let expectedReportIntervalSeconds: TimeInterval?
     public let lastSequence: Int64
     public let sourceStatuses: [String: String]
     public let todayTokens: Int
@@ -217,7 +220,10 @@ public struct RemoteMachineSummary: Identifiable, Equatable, Sendable {
     public let last30DaysCostUSD: Double
     public let byTool: [RemoteToolUsageSummary]
 
-    public var id: String { workspaceID.uuidString + ":" + producerID.uuidString }
+    /// Stable local settings key. It is metadata, not a credential.
+    public var id: String {
+        workspaceID.uuidString.lowercased() + ":" + producerID.uuidString.lowercased()
+    }
 }
 
 public struct RemoteToolUsageSummary: Identifiable, Equatable, Sendable {

--- a/Sources/VibeBarCore/Services/CostUsageService.swift
+++ b/Sources/VibeBarCore/Services/CostUsageService.swift
@@ -37,6 +37,11 @@ public final class CostUsageService: ObservableObject {
     private let homeDirectory: String
     private let mockProvider: () -> Bool
     private let costDataSettingsProvider: () -> CostDataSettings
+    /// Keep authoritative local and selected-remote sources separate. Only the
+    /// merged dictionary is published, so remote facts are never written into
+    /// the local scan cache/history and cannot be counted again after relaunch.
+    private var localSnapshots: [ToolType: CostSnapshot] = [:]
+    private var remoteSnapshots: [ToolType: CostSnapshot] = [:]
     /// Every value the UI derives from `snapshots` — rebased per-tool
     /// snapshots, combined platform snapshots, the Overview rollups — is a pure
     /// function of the snapshots and the local day, and the popover asks for
@@ -66,13 +71,16 @@ public final class CostUsageService: ObservableObject {
             let cached = await CostSnapshotCache.shared.loadAll(retentionDays: costData.retentionDays, now: Date())
             // One assignment, not one per tool: every write to a `@Published`
             // dictionary is its own publish, and the popover re-renders on each.
-            var hydrated = self.snapshots
+            var hydrated = self.localSnapshots
             var addedAny = false
             for (tool, snap) in cached where hydrated[tool] == nil {
                 hydrated[tool] = snap
                 addedAny = true
             }
-            if addedAny { self.snapshots = hydrated }
+            if addedAny {
+                self.localSnapshots = hydrated
+                self.publishMergedSnapshots()
+            }
             if !cached.isEmpty {
                 self.lastRefreshedAt = cached.values.map(\.updatedAt).max()
             }
@@ -115,6 +123,15 @@ public final class CostUsageService: ObservableObject {
         extrasByTool[tool]
     }
 
+    /// Replace the selected Probe contribution. The caller supplies snapshots
+    /// built from the Core's decrypted ledger; this service keeps them in
+    /// memory only and combines them with local CLI snapshots for every
+    /// Overview/provider surface through the existing aggregation cache.
+    public func setRemoteSnapshots(_ snapshots: [ToolType: CostSnapshot]) {
+        remoteSnapshots = snapshots
+        publishMergedSnapshots()
+    }
+
     public func refreshAll() async {
         guard !isRefreshing else { return }
         isRefreshing = true
@@ -140,7 +157,8 @@ public final class CostUsageService: ObservableObject {
                     mockExtras[tool] = e
                 }
             }
-            snapshots = results
+            localSnapshots = results
+            publishMergedSnapshots()
             extrasByTool = mockExtras
             lastRefreshedAt = now
             return
@@ -180,7 +198,7 @@ public final class CostUsageService: ObservableObject {
             case .completed(let snapshot):
                 scanned = snapshot
             case .timedOut:
-                if let previous = snapshots[tool] { results[tool] = previous }
+                if let previous = localSnapshots[tool] { results[tool] = previous }
                 continue
             }
             if let scanned {
@@ -195,7 +213,8 @@ public final class CostUsageService: ObservableObject {
                 await CostSnapshotCache.shared.save(merged, retentionDays: retentionDays)
             }
         }
-        snapshots = results
+        localSnapshots = results
+        publishMergedSnapshots()
         // Extras (credits / overage) display was removed from the UI — see the
         // user-feedback round that turned them off because the loaders weren't
         // reliable. Parsing infrastructure for Claude.providerExtras is kept
@@ -243,7 +262,8 @@ public final class CostUsageService: ObservableObject {
         }
         await CostHistoryStore.shared.prune(retentionDays: costData.retentionDays)
         let cached = await CostSnapshotCache.shared.loadAll(retentionDays: costData.retentionDays, now: Date())
-        snapshots = cached
+        localSnapshots = cached
+        publishMergedSnapshots()
         lastRefreshedAt = cached.values.map(\.updatedAt).max()
     }
 
@@ -251,8 +271,35 @@ public final class CostUsageService: ObservableObject {
         await CostHistoryStore.shared.eraseAll()
         await CostSnapshotCache.shared.eraseAll()
         CostUsageScanCache.eraseAll(homeDirectory: homeDirectory)
-        snapshots = [:]
+        localSnapshots = [:]
+        publishMergedSnapshots()
         extrasByTool = [:]
         lastRefreshedAt = nil
+    }
+
+    private func publishMergedSnapshots(now: Date = Date()) {
+        guard !costDataSettingsProvider().privacyModeEnabled else {
+            snapshots = [:]
+            return
+        }
+        // Mock mode is a self-contained preview and must never leak real Probe
+        // totals into screenshots or tests.
+        guard !mockProvider() else {
+            snapshots = localSnapshots
+            return
+        }
+        var merged = localSnapshots
+        for (tool, remote) in remoteSnapshots {
+            if let local = localSnapshots[tool] {
+                merged[tool] = CostSnapshotAggregator.combinedSnapshot(
+                    tool: tool,
+                    snapshots: [local, remote],
+                    now: now
+                )
+            } else {
+                merged[tool] = remote
+            }
+        }
+        snapshots = merged
     }
 }

--- a/Sources/VibeBarCore/Services/RemoteCostSnapshotBuilder.swift
+++ b/Sources/VibeBarCore/Services/RemoteCostSnapshotBuilder.swift
@@ -1,0 +1,220 @@
+import Foundation
+
+/// Builds the same `CostSnapshot` shape used by local CLI scanners from facts
+/// that have already been authenticated, decrypted, and deduplicated by the
+/// remote ledger. Relay and Control Plane never participate in this step.
+struct RemoteCostSnapshotBuilder {
+    private let tool: ToolType
+    private let now: Date
+    private let calendar: Calendar
+    private let startOfToday: Date
+    private let startOfYesterday: Date
+    private let weekCutoff: Date
+    private let monthCutoff: Date
+    private let hourlyCutoff: Date
+
+    private var todayCost = 0.0
+    private var weekCost = 0.0
+    private var monthCost = 0.0
+    private var totalCost = 0.0
+    private var todayTokens = 0
+    private var weekTokens = 0
+    private var monthTokens = 0
+    private var totalTokens = 0
+    private var todayRequests = 0
+    private var weekRequests = 0
+    private var monthRequests = 0
+    private var totalRequests = 0
+    private var byDay: [Date: (cost: Double, tokens: Int)] = [:]
+    private var byHour: [Date: (cost: Double, tokens: Int)] = [:]
+    private var hourlyDays = Set<Date>()
+    private var heatmap = Array(repeating: Array(repeating: 0, count: 24), count: 7)
+    private var byModelAllTime: [String: (cost: Double, tokens: Int)] = [:]
+    private var byModel7d: [String: (cost: Double, tokens: Int)] = [:]
+    private var byDayModel: [Date: [String: (cost: Double, tokens: Int)]] = [:]
+    private var byHourModel: [Date: [String: (cost: Double, tokens: Int)]] = [:]
+
+    init(tool: ToolType, now: Date, calendar: Calendar = .current) {
+        self.tool = tool
+        self.now = now
+        self.calendar = calendar
+        self.startOfToday = calendar.startOfDay(for: now)
+        self.startOfYesterday = calendar.date(
+            byAdding: .day,
+            value: -1,
+            to: calendar.startOfDay(for: now)
+        ) ?? calendar.startOfDay(for: now)
+        self.weekCutoff = calendar.date(
+            byAdding: .day,
+            value: -6,
+            to: calendar.startOfDay(for: now)
+        ) ?? calendar.startOfDay(for: now)
+        self.monthCutoff = calendar.date(
+            byAdding: .day,
+            value: -29,
+            to: calendar.startOfDay(for: now)
+        ) ?? calendar.startOfDay(for: now)
+        self.hourlyCutoff = CostChartWindowPolicy.hourlyRetentionStart(
+            now: now,
+            calendar: calendar
+        )
+    }
+
+    mutating func add(
+        occurredAt date: Date,
+        model: String?,
+        tokens: Int,
+        costUSD: Double,
+        requestCount: Int
+    ) {
+        guard date <= now else { return }
+        let model = model?.trimmingCharacters(in: .whitespacesAndNewlines).nonEmpty
+            ?? "Unknown"
+        let requests = max(0, requestCount)
+        let day = calendar.startOfDay(for: date)
+
+        totalCost += costUSD
+        totalTokens = saturatedAdd(totalTokens, tokens)
+        totalRequests = saturatedAdd(totalRequests, requests)
+        if day == startOfToday {
+            todayCost += costUSD
+            todayTokens = saturatedAdd(todayTokens, tokens)
+            todayRequests = saturatedAdd(todayRequests, requests)
+        }
+        if day >= weekCutoff {
+            weekCost += costUSD
+            weekTokens = saturatedAdd(weekTokens, tokens)
+            weekRequests = saturatedAdd(weekRequests, requests)
+        }
+        if day >= monthCutoff {
+            monthCost += costUSD
+            monthTokens = saturatedAdd(monthTokens, tokens)
+            monthRequests = saturatedAdd(monthRequests, requests)
+        }
+
+        var dayValue = byDay[day] ?? (0, 0)
+        dayValue.cost += costUSD
+        dayValue.tokens = saturatedAdd(dayValue.tokens, tokens)
+        byDay[day] = dayValue
+
+        let weekday = calendar.component(.weekday, from: date) - 1
+        let hour = calendar.component(.hour, from: date)
+        if heatmap.indices.contains(weekday), heatmap[weekday].indices.contains(hour) {
+            heatmap[weekday][hour] = saturatedAdd(heatmap[weekday][hour], tokens)
+        }
+
+        accumulate(model: model, cost: costUSD, tokens: tokens, in: &byModelAllTime)
+        if day >= weekCutoff {
+            accumulate(model: model, cost: costUSD, tokens: tokens, in: &byModel7d)
+        }
+        var dayModels = byDayModel[day] ?? [:]
+        accumulate(model: model, cost: costUSD, tokens: tokens, in: &dayModels)
+        byDayModel[day] = dayModels
+
+        if date >= hourlyCutoff, day <= startOfToday,
+           let hourStart = calendar.dateInterval(of: .hour, for: date)?.start {
+            var hourValue = byHour[hourStart] ?? (0, 0)
+            hourValue.cost += costUSD
+            hourValue.tokens = saturatedAdd(hourValue.tokens, tokens)
+            byHour[hourStart] = hourValue
+            hourlyDays.insert(day)
+            var hourModels = byHourModel[hourStart] ?? [:]
+            accumulate(model: model, cost: costUSD, tokens: tokens, in: &hourModels)
+            byHourModel[hourStart] = hourModels
+        }
+    }
+
+    func snapshot(sourceCount: Int) -> CostSnapshot {
+        let currentHour = calendar.dateInterval(of: .hour, for: now)?.start ?? startOfToday
+        let recentDays = hourlyDays
+            .union([startOfToday, startOfYesterday])
+            .filter { $0 >= hourlyCutoff && $0 <= startOfToday }
+            .sorted()
+        return CostSnapshot(
+            tool: tool,
+            todayCostUSD: todayCost,
+            last7DaysCostUSD: weekCost,
+            last30DaysCostUSD: monthCost,
+            allTimeCostUSD: totalCost,
+            todayTokens: todayTokens,
+            last7DaysTokens: weekTokens,
+            last30DaysTokens: monthTokens,
+            allTimeTokens: totalTokens,
+            todayRequests: todayRequests,
+            last7DaysRequests: weekRequests,
+            last30DaysRequests: monthRequests,
+            allTimeRequests: totalRequests,
+            dailyHistory: byDay.sorted { $0.key < $1.key }.map {
+                DailyCostPoint(date: $0.key, costUSD: $0.value.cost, totalTokens: $0.value.tokens)
+            },
+            todayHourlyHistory: hourlyPoints(forDayStarting: startOfToday, notAfter: currentHour),
+            yesterdayHourlyHistory: hourlyPoints(forDayStarting: startOfYesterday, notAfter: nil),
+            recentHourlyHistory: recentDays.flatMap {
+                hourlyPoints(forDayStarting: $0, notAfter: $0 == startOfToday ? currentHour : nil)
+            },
+            hourlyCoverageStart: hourlyCutoff,
+            heatmap: UsageHeatmap(tool: tool, cells: heatmap, totalTokens: totalTokens),
+            modelBreakdowns: breakdowns(byModelAllTime),
+            last7DaysModelBreakdowns: breakdowns(byModel7d),
+            dailyModelBreakdown: byDayModel.mapValues(breakdowns),
+            hourlyModelBreakdown: byHourModel.mapValues(breakdowns),
+            // This field predates non-file sources and is used as the product's
+            // "has cost data" sentinel. Count contributing remote machines so
+            // selected remote-only providers render without inventing files.
+            jsonlFilesFound: max(0, sourceCount),
+            updatedAt: now
+        )
+    }
+
+    private func hourlyPoints(forDayStarting day: Date, notAfter limit: Date?) -> [HourlyCostPoint] {
+        guard let end = calendar.date(byAdding: .day, value: 1, to: day) else { return [] }
+        var result: [HourlyCostPoint] = []
+        var hour = day
+        while hour < end {
+            if let limit, hour > limit { break }
+            let value = byHour[hour] ?? (0, 0)
+            result.append(HourlyCostPoint(date: hour, costUSD: value.cost, totalTokens: value.tokens))
+            guard let next = calendar.date(byAdding: .hour, value: 1, to: hour), next > hour else {
+                break
+            }
+            hour = next
+        }
+        return result
+    }
+
+    private func breakdowns(
+        _ values: [String: (cost: Double, tokens: Int)]
+    ) -> [CostSnapshot.ModelBreakdown] {
+        values.sorted {
+            if $0.value.cost == $1.value.cost { return $0.value.tokens > $1.value.tokens }
+            return $0.value.cost > $1.value.cost
+        }.prefix(20).map {
+            CostSnapshot.ModelBreakdown(
+                modelName: $0.key,
+                costUSD: $0.value.cost,
+                totalTokens: $0.value.tokens
+            )
+        }
+    }
+
+    private func accumulate(
+        model: String,
+        cost: Double,
+        tokens: Int,
+        in values: inout [String: (cost: Double, tokens: Int)]
+    ) {
+        var value = values[model] ?? (0, 0)
+        value.cost += cost
+        value.tokens = saturatedAdd(value.tokens, tokens)
+        values[model] = value
+    }
+
+    private func saturatedAdd(_ lhs: Int, _ rhs: Int) -> Int {
+        let (sum, overflow) = lhs.addingReportingOverflow(rhs)
+        return overflow ? Int.max : sum
+    }
+}
+
+private extension String {
+    var nonEmpty: String? { isEmpty ? nil : self }
+}

--- a/Sources/VibeBarCore/Services/RemoteProbeService.swift
+++ b/Sources/VibeBarCore/Services/RemoteProbeService.swift
@@ -36,6 +36,26 @@ public final class RemoteProbeService: ObservableObject {
     public var relayURL: URL? { config?.relayURL }
     public var registeredProbeCount: Int { config?.probeSigningPublicKeys.count ?? 0 }
 
+    /// Decrypted, local-only cost snapshots for the machines the user chose to
+    /// merge into this Core. Returning an empty map on a transient ledger
+    /// failure keeps the ordinary local snapshots usable.
+    public func costSnapshots(
+        includingMachineIDs machineIDs: Set<String>,
+        now: Date = Date()
+    ) async -> [ToolType: CostSnapshot] {
+        guard let config, let ledger, !machineIDs.isEmpty else { return [:] }
+        do {
+            return try await ledger.costSnapshots(
+                workspaceID: config.workspaceID,
+                selectedMachineIDs: machineIDs,
+                now: now
+            )
+        } catch {
+            SafeLog.warn("remote cost aggregation skipped: invalid local ledger state")
+            return [:]
+        }
+    }
+
     public init() {
         loadConfiguration()
     }

--- a/Sources/VibeBarCore/Services/RemoteUsageLedger.swift
+++ b/Sources/VibeBarCore/Services/RemoteUsageLedger.swift
@@ -454,6 +454,10 @@ public actor RemoteUsageLedger {
                 producer: producerRaw,
                 now: now
             )
+            let expectedReportInterval = try expectedReportIntervalSeconds(
+                workspace: workspace,
+                producer: producerRaw
+            )
             summaries.append(
                 RemoteMachineSummary(
                     workspaceID: workspaceID,
@@ -463,6 +467,7 @@ public actor RemoteUsageLedger {
                     probeVersion: version,
                     lastSeenAt: Date(timeIntervalSince1970: TimeInterval(sqlite3_column_int64(statement, 4))),
                     lastScanAt: Date(timeIntervalSince1970: TimeInterval(sqlite3_column_int64(statement, 5))),
+                    expectedReportIntervalSeconds: expectedReportInterval,
                     lastSequence: sqlite3_column_int64(statement, 6),
                     sourceStatuses: sourceStatuses,
                     todayTokens: usage.today,
@@ -475,6 +480,109 @@ public actor RemoteUsageLedger {
             )
         }
         return summaries
+    }
+
+    /// Build provider snapshots from only the machines the user selected for
+    /// this Core's totals. The caller passes the same stable IDs shown by
+    /// `machineSummaries`; unknown, revoked, and cross-workspace IDs simply do
+    /// not match a row.
+    public func costSnapshots(
+        workspaceID: UUID,
+        selectedMachineIDs: Set<String>,
+        now: Date = Date()
+    ) throws -> [ToolType: CostSnapshot] {
+        let workspace = workspaceID.uuidString.lowercased()
+        let prefix = workspace + ":"
+        let selectedProducers = Set(selectedMachineIDs.compactMap { raw -> String? in
+            let normalized = raw.lowercased()
+            guard normalized.hasPrefix(prefix) else { return nil }
+            let producer = String(normalized.dropFirst(prefix.count))
+            guard UUID(uuidString: producer) != nil else { return nil }
+            return producer
+        })
+        guard !selectedProducers.isEmpty else { return [:] }
+
+        let statement = try prepare(
+            """
+            SELECT producer_id, tool, occurred_at, model, input_tokens, output_tokens,
+                   cache_read_tokens, cache_creation_tokens, reasoning_tokens,
+                   tool_tokens, total_only_tokens, request_count, service_tier
+              FROM remote_usage_facts WHERE workspace_id = ?
+            """
+        )
+        defer { sqlite3_finalize(statement) }
+        bind(.text(workspace), at: 1, to: statement)
+        var builders: [ToolType: RemoteCostSnapshotBuilder] = [:]
+        var contributingProducers: [ToolType: Set<String>] = [:]
+        while sqlite3_step(statement) == SQLITE_ROW {
+            guard let producer = columnText(statement, 0),
+                  selectedProducers.contains(producer),
+                  let rawTool = columnText(statement, 1),
+                  let tool = ToolType(rawValue: rawTool),
+                  tool.supportsTokenCost
+            else { continue }
+            let occurredAt = Date(
+                timeIntervalSince1970: TimeInterval(sqlite3_column_int64(statement, 2))
+            )
+            guard occurredAt <= now else { continue }
+            let row = UsageRow(
+                tool: rawTool,
+                model: columnText(statement, 3),
+                input: Int(sqlite3_column_int64(statement, 4)),
+                output: Int(sqlite3_column_int64(statement, 5)),
+                cacheRead: Int(sqlite3_column_int64(statement, 6)),
+                cacheCreation: Int(sqlite3_column_int64(statement, 7)),
+                reasoning: Int(sqlite3_column_int64(statement, 8)),
+                toolTokens: Int(sqlite3_column_int64(statement, 9)),
+                totalOnly: sqlite3_column_type(statement, 10) == SQLITE_NULL
+                    ? nil : Int(sqlite3_column_int64(statement, 10)),
+                serviceTier: columnText(statement, 12)
+            )
+            var builder = builders[tool] ?? RemoteCostSnapshotBuilder(tool: tool, now: now)
+            builder.add(
+                occurredAt: occurredAt,
+                model: row.model,
+                tokens: row.tokenTotal,
+                costUSD: costUSD(row),
+                requestCount: Int(sqlite3_column_int64(statement, 11))
+            )
+            builders[tool] = builder
+            contributingProducers[tool, default: []].insert(producer)
+        }
+        return Dictionary(uniqueKeysWithValues: builders.map { tool, builder in
+            (tool, builder.snapshot(sourceCount: contributingProducers[tool]?.count ?? 0))
+        })
+    }
+
+    private func expectedReportIntervalSeconds(
+        workspace: String,
+        producer: String
+    ) throws -> TimeInterval? {
+        let statement = try prepare(
+            """
+            SELECT imported_at FROM remote_imported_batches
+             WHERE workspace_id = ? AND producer_id = ?
+             ORDER BY sequence DESC LIMIT 8
+            """
+        )
+        defer { sqlite3_finalize(statement) }
+        bind(.text(workspace), at: 1, to: statement)
+        bind(.text(producer), at: 2, to: statement)
+        var stamps: [Int64] = []
+        while sqlite3_step(statement) == SQLITE_ROW {
+            stamps.append(sqlite3_column_int64(statement, 0))
+        }
+        let ordered = stamps.sorted()
+        let gaps = zip(ordered, ordered.dropFirst())
+            .map { $1 - $0 }
+            .filter { $0 >= 15 && $0 <= 86_400 }
+            .sorted()
+        guard !gaps.isEmpty else { return nil }
+        let middle = gaps.count / 2
+        if gaps.count.isMultiple(of: 2) {
+            return TimeInterval(gaps[middle - 1] + gaps[middle]) / 2
+        }
+        return TimeInterval(gaps[middle])
     }
 
     private func aggregateUsage(

--- a/Tests/VibeBarCoreTests/AppSettingsTests.swift
+++ b/Tests/VibeBarCoreTests/AppSettingsTests.swift
@@ -35,6 +35,28 @@ final class AppSettingsTests: XCTestCase {
         XCTAssertEqual(settings.costData.retentionDays, CostDataSettings.unlimitedRetentionDays)
         XCTAssertFalse(settings.costData.privacyModeEnabled)
         XCTAssertEqual(settings.updateChannel, .main)
+        XCTAssertTrue(settings.remoteCostIncludedMachineIDs.isEmpty)
+    }
+
+    func testRemoteCostMachineSelectionDefaultsEmptyNormalizesAndRoundTrips() throws {
+        let legacy = try JSONDecoder().decode(
+            AppSettings.self,
+            from: Data(#"{"displayMode":"remaining"}"#.utf8)
+        )
+        XCTAssertTrue(legacy.remoteCostIncludedMachineIDs.isEmpty)
+
+        var settings = AppSettings.default
+        settings.remoteCostIncludedMachineIDs = [
+            "11111111-1111-4111-8111-111111111111:AAAAAAAA-AAAA-4AAA-8AAA-AAAAAAAAAAAA"
+        ]
+        let decoded = try JSONDecoder().decode(
+            AppSettings.self,
+            from: try JSONEncoder().encode(settings)
+        )
+        XCTAssertEqual(
+            decoded.remoteCostIncludedMachineIDs,
+            ["11111111-1111-4111-8111-111111111111:aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"]
+        )
     }
 
     func testMiscCookieAutoImportDefaultsToOffAndRoundTrips() throws {

--- a/Tests/VibeBarCoreTests/RemoteCostAggregationTests.swift
+++ b/Tests/VibeBarCoreTests/RemoteCostAggregationTests.swift
@@ -1,0 +1,133 @@
+import XCTest
+@testable import VibeBarCore
+
+final class RemoteCostAggregationTests: XCTestCase {
+    private let workspace = UUID(uuidString: "11111111-1111-4111-8111-111111111111")!
+    private let producer = UUID(uuidString: "22222222-2222-4222-8222-222222222222")!
+    private let formatter = ISO8601DateFormatter()
+
+    func testSelectedMachineBuildsProviderSnapshotAndLearnsFiveMinuteCadence() async throws {
+        let ledger = try makeLedger()
+        let first = try RemotePayloadDecoder.decode(payload(sequence: 1, previous: nil))
+        let second = try RemotePayloadDecoder.decode(payload(sequence: 2, previous: 1))
+        _ = try await ledger.importBatch(
+            first,
+            sequence: 1,
+            receivedAt: try XCTUnwrap(formatter.date(from: "2026-08-03T06:05:00Z"))
+        )
+        _ = try await ledger.importBatch(
+            second,
+            sequence: 2,
+            receivedAt: try XCTUnwrap(formatter.date(from: "2026-08-03T06:10:00Z"))
+        )
+
+        let now = try XCTUnwrap(formatter.date(from: "2026-08-03T12:00:00Z"))
+        let machines = try await ledger.machineSummaries(workspaceID: workspace, now: now)
+        let machine = try XCTUnwrap(machines.first)
+        XCTAssertEqual(machine.id, workspace.uuidString.lowercased() + ":" + producer.uuidString.lowercased())
+        XCTAssertEqual(machine.expectedReportIntervalSeconds, 300)
+
+        let snapshots = try await ledger.costSnapshots(
+            workspaceID: workspace,
+            selectedMachineIDs: [machine.id],
+            now: now
+        )
+        let codex = try XCTUnwrap(snapshots[.codex])
+        XCTAssertEqual(codex.todayTokens, 30)
+        XCTAssertEqual(codex.allTimeTokens, 30)
+        XCTAssertEqual(codex.todayRequests, 2)
+        XCTAssertEqual(codex.jsonlFilesFound, 1)
+        XCTAssertEqual(codex.dailyHistory.map(\.totalTokens), [30])
+
+        let excluded = try await ledger.costSnapshots(
+            workspaceID: workspace,
+            selectedMachineIDs: [],
+            now: now
+        )
+        XCTAssertTrue(excluded.isEmpty)
+    }
+
+    func testFreshnessUsesLearnedCadenceAndKeepsLegacyFallback() throws {
+        let lastSeen = try XCTUnwrap(formatter.date(from: "2026-08-03T06:00:00Z"))
+        XCTAssertEqual(
+            RemoteMachineFreshness.evaluate(
+                lastSeenAt: lastSeen,
+                expectedReportIntervalSeconds: 300,
+                now: lastSeen.addingTimeInterval(240)
+            ),
+            .live
+        )
+        XCTAssertEqual(
+            RemoteMachineFreshness.evaluate(
+                lastSeenAt: lastSeen,
+                expectedReportIntervalSeconds: 300,
+                now: lastSeen.addingTimeInterval(500)
+            ),
+            .delayed
+        )
+        XCTAssertEqual(
+            RemoteMachineFreshness.evaluate(
+                lastSeenAt: lastSeen,
+                expectedReportIntervalSeconds: 300,
+                now: lastSeen.addingTimeInterval(800)
+            ),
+            .stale
+        )
+        XCTAssertEqual(
+            RemoteMachineFreshness.evaluate(
+                lastSeenAt: lastSeen,
+                expectedReportIntervalSeconds: nil,
+                now: lastSeen.addingTimeInterval(180)
+            ),
+            .delayed
+        )
+    }
+
+    private func makeLedger() throws -> RemoteUsageLedger {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("remote-cost-aggregation-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: false)
+        addTeardownBlock { try? FileManager.default.removeItem(at: directory) }
+        return try RemoteUsageLedger(url: directory.appendingPathComponent("ledger.sqlite3"))
+    }
+
+    private func payload(sequence: Int, previous: Int?) throws -> Data {
+        let operation: [String: Any] = [
+            "op": "usage_upsert",
+            "source_key": String(repeating: "s", count: 43),
+            "source_generation": 1,
+            "event_key": String(repeating: "e", count: 42) + String(sequence),
+            "tool": "codex",
+            "occurred_at": "2026-08-03T06:00:00Z",
+            "observed_at": "2026-08-03T06:01:00Z",
+            "model": "synthetic-model",
+            "tokens": [
+                "input": 10, "output": 5, "cache_read": 0,
+                "cache_creation": 0, "reasoning": 0, "tool": 0,
+                "total_only": NSNull()
+            ],
+            "request_count": 1,
+            "service_tier": NSNull(),
+            "accounting": "exact",
+            "parser_version": 1
+        ]
+        let body: [String: Any] = [
+            "schema": 1,
+            "workspace_id": workspace.uuidString.lowercased(),
+            "producer_id": producer.uuidString.lowercased(),
+            "probe": [
+                "alias": "Example machine", "version": "0.1.0",
+                "platform": "linux-x86_64", "timezone": "UTC"
+            ],
+            "previous_sequence": previous.map { $0 as Any } ?? NSNull(),
+            "operations": [operation],
+            "status": [
+                "last_scan_at": "2026-08-03T06:01:00Z",
+                "backlog_batches": 0,
+                "applied_control_sequence": 0,
+                "sources": ["codex": "ok"]
+            ]
+        ]
+        return try JSONSerialization.data(withJSONObject: body)
+    }
+}


### PR DESCRIPTION
## Summary
- learn each Probe's reporting cadence so healthy five-minute heartbeats remain Live
- let the Core select remote machines that join local cost/token snapshots across Overview and provider pages
- keep decrypted remote facts local-only and out of local cost cache/history to prevent double counting
- bump the dev build number to 22 and update public architecture copy

## Test plan
- [x] swift build
- [x] swift test (1124 tests)
- [x] ./Scripts/build_app.sh release
- [x] codesign --verify --deep --strict
- [x] empty entitlements; no app sandbox
- [x] packaged version 1.3.0 build 22
- [ ] GitHub CI