### PR TITLE
Restyle Machines page with shared card shell

### DIFF
--- a/Sources/VibeBarApp/Views/CardShell.swift
+++ b/Sources/VibeBarApp/Views/CardShell.swift
@@ -1,0 +1,41 @@
+import SwiftUI
+
+/// The popover's card surface, in one place.
+///
+/// Every card in the workspace — quota groups, cost modules, misc providers,
+/// machines — is the same rounded rectangle: density padding, a tertiary
+/// background fill, and a hairline separator stroke. Repeating that stack by
+/// hand is how a page ends up with its own corner radius and its own opacity,
+/// so callers compose `CardShell` instead.
+///
+/// Use `cardSurface(density:)` directly when the card already owns its
+/// internal layout (a centered empty state, a pinned-height summary) and only
+/// needs the background and stroke.
+struct CardShell<Content: View>: View {
+    let density: Theme.Density
+    /// Defaults to `density.cardSpacing`.
+    var spacing: CGFloat?
+    var alignment: HorizontalAlignment = .leading
+    @ViewBuilder var content: () -> Content
+
+    var body: some View {
+        VStack(alignment: alignment, spacing: spacing ?? density.cardSpacing) {
+            content()
+        }
+        .padding(density.cardPadding)
+        .cardSurface(density: density)
+    }
+}
+
+extension View {
+    func cardSurface(density: Theme.Density) -> some View {
+        background(
+            RoundedRectangle(cornerRadius: density.cardCornerRadius, style: .continuous)
+                .fill(.background.tertiary.opacity(0.6))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: density.cardCornerRadius, style: .continuous)
+                .stroke(.separator.opacity(0.4), lineWidth: 0.5)
+        )
+    }
+}

--- a/Sources/VibeBarApp/Views/MiscProvidersPage.swift
+++ b/Sources/VibeBarApp/Views/MiscProvidersPage.swift
@@ -304,14 +304,7 @@ private struct MiscProviderCardShell<Content: View>: View {
         }
         .padding(density.cardPadding)
         .frame(maxWidth: .infinity, alignment: .topLeading)
-        .background(
-            RoundedRectangle(cornerRadius: density.cardCornerRadius, style: .continuous)
-                .fill(.background.tertiary.opacity(0.6))
-        )
-        .overlay(
-            RoundedRectangle(cornerRadius: density.cardCornerRadius, style: .continuous)
-                .stroke(.separator.opacity(0.4), lineWidth: 0.5)
-        )
+        .cardSurface(density: density)
     }
 }
 

--- a/Sources/VibeBarApp/Views/RemoteMachinesPage.swift
+++ b/Sources/VibeBarApp/Views/RemoteMachinesPage.swift
@@ -24,132 +24,195 @@ struct RemoteMachinesPage: View {
                 )
             } else {
                 if let error = service.lastErrorCode {
-                    HStack(spacing: 7) {
-                        Image(systemName: "exclamationmark.triangle.fill")
-                            .foregroundStyle(.orange)
-                        Text("Latest sync: \(error)")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                    }
+                    syncErrorBanner(error)
                 }
-                LazyVStack(alignment: .leading, spacing: density.interSectionSpacing) {
-                    ForEach(service.machines) { machine in
-                        machineCard(machine)
-                    }
-                }
+                machineGrid
             }
         }
     }
 
-    private func stateCard(icon: String, title: String, detail: String) -> some View {
-        VStack(spacing: 12) {
-            Image(systemName: icon)
-                .font(.system(size: 24, weight: .medium))
-                .foregroundStyle(.secondary)
-            Text(title)
-                .font(.system(size: density.titleFontSize, weight: .semibold))
-            Text(detail)
-                .font(.caption)
-                .foregroundStyle(.secondary)
-                .multilineTextAlignment(.center)
-                .frame(maxWidth: 430)
+    /// One machine gets a single readable column; a fleet gets the same
+    /// two-column waterfall the Misc page uses, so tall cards don't leave a
+    /// half-empty page behind them.
+    @ViewBuilder
+    private var machineGrid: some View {
+        if service.machines.count > 1 {
+            ColumnMasonryLayout(columns: 2, spacing: density.interSectionSpacing) {
+                ForEach(service.machines) { machine in
+                    machineCard(machine)
+                        .overviewMasonryItem(id: machine.id, phase: .auxiliary)
+                }
+            }
+        } else {
+            ForEach(service.machines) { machine in
+                machineCard(machine)
+                    .frame(maxWidth: 720, alignment: .leading)
+            }
         }
-        .frame(maxWidth: .infinity)
-        .padding(28)
-        .background(cardBackground)
     }
 
     private func machineCard(_ machine: RemoteMachineSummary) -> some View {
-        VStack(alignment: .leading, spacing: 14) {
-            HStack(alignment: .center, spacing: 10) {
-                Image(systemName: "server.rack")
-                    .font(.system(size: 17, weight: .medium))
-                    .frame(width: 28, height: 28)
-                    .background(Circle().fill(Color.accentColor.opacity(0.14)))
-                VStack(alignment: .leading, spacing: 2) {
-                    Text(machine.alias)
-                        .font(.system(size: density.titleFontSize, weight: .semibold))
-                    Text("\(machine.platform) · Probe \(machine.probeVersion)")
-                        .font(.caption2)
-                        .foregroundStyle(.secondary)
-                }
-                Spacer()
-                freshness(machine)
-            }
-
-            HStack(spacing: 0) {
-                metric("Today", machine.todayTokens)
-                Divider().frame(height: 34)
-                metric("7 days", machine.last7DaysTokens)
-                Divider().frame(height: 34)
-                metric("30 days", machine.last30DaysTokens)
-                Divider().frame(height: 34)
-                VStack(alignment: .trailing, spacing: 2) {
-                    Text(machine.last30DaysCostUSD, format: .currency(code: "USD"))
-                        .font(.system(size: 14, weight: .semibold, design: .rounded))
-                    Text("30-day cost")
-                        .font(.caption2)
-                        .foregroundStyle(.secondary)
-                }
-                .frame(maxWidth: .infinity, alignment: .trailing)
-            }
-
+        CardShell(density: density) {
+            header(machine)
+            Divider().opacity(0.25)
+            metrics(machine)
             if !machine.byTool.isEmpty {
-                Divider().opacity(0.45)
-                HStack(spacing: 8) {
-                    ForEach(machine.byTool) { usage in
-                        VStack(alignment: .leading, spacing: 2) {
-                            Text(toolLabel(usage.tool))
-                                .font(.caption2)
-                                .foregroundStyle(.secondary)
-                            Text(usage.tokens, format: .number.notation(.compactName))
-                                .font(.system(size: 12, weight: .semibold, design: .rounded))
-                        }
-                        .padding(.horizontal, 9)
-                        .padding(.vertical, 6)
-                        .background(
-                            RoundedRectangle(cornerRadius: 8, style: .continuous)
-                                .fill(Color.primary.opacity(0.045))
-                        )
-                    }
-                    Spacer(minLength: 0)
-                }
+                toolBreakdown(machine)
             }
-
-            HStack(spacing: 6) {
-                ForEach(machine.sourceStatuses.keys.sorted(), id: \.self) { source in
-                    let status = machine.sourceStatuses[source] ?? "error"
-                    Text("\(toolLabel(source)) · \(status)")
-                        .font(.system(size: 9.5, weight: .medium))
-                        .foregroundStyle(status == "ok" ? Color.secondary : Color.orange)
-                        .padding(.horizontal, 7)
-                        .padding(.vertical, 3)
-                        .background(Capsule().fill(Color.primary.opacity(0.04)))
-                }
-                Spacer(minLength: 0)
-                Toggle("Include in totals", isOn: includedInTotals(machine))
-                    .toggleStyle(.switch)
-                    .controlSize(.mini)
-                    .font(.caption2)
-                    .help("Add this machine's decrypted usage to Overview and provider cost pages on this Core")
-                Text("seq \(machine.lastSequence)")
-                    .font(.caption2.monospacedDigit())
-                    .foregroundStyle(.tertiary)
-            }
+            Divider().opacity(0.2)
+            footer(machine)
         }
-        .padding(16)
-        .background(cardBackground)
     }
 
-    private func metric(_ title: String, _ value: Int) -> some View {
+    private func header(_ machine: RemoteMachineSummary) -> some View {
+        HStack(alignment: .center, spacing: 10) {
+            Image(systemName: "server.rack")
+                .font(.system(size: max(12, density.bucketTitleFontSize), weight: .medium))
+                .foregroundStyle(Color.accentColor)
+                .frame(width: 26, height: 26)
+                .background(Circle().fill(Color.accentColor.opacity(0.14)))
+            VStack(alignment: .leading, spacing: 2) {
+                Text(machine.alias)
+                    .font(.system(size: density.titleFontSize, weight: .semibold))
+                    .lineLimit(1)
+                Text("\(machine.platform) · Probe \(machine.probeVersion)")
+                    .font(.system(size: max(9, density.subtitleFontSize - 1)))
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+            Spacer(minLength: 4)
+            freshness(machine)
+        }
+    }
+
+    private func metrics(_ machine: RemoteMachineSummary) -> some View {
+        HStack(alignment: .top, spacing: 0) {
+            metric("Today", Text(machine.todayTokens, format: .number.notation(.compactName)))
+            metricDivider
+            metric("7 days", Text(machine.last7DaysTokens, format: .number.notation(.compactName)))
+            metricDivider
+            metric("30 days", Text(machine.last30DaysTokens, format: .number.notation(.compactName)))
+            metricDivider
+            metric("30-day cost", Text(machine.last30DaysCostUSD, format: .currency(code: "USD")))
+        }
+    }
+
+    private func metric(_ title: String, _ value: Text) -> some View {
         VStack(alignment: .leading, spacing: 2) {
-            Text(value, format: .number.notation(.compactName))
-                .font(.system(size: 14, weight: .semibold, design: .rounded))
             Text(title)
-                .font(.caption2)
-                .foregroundStyle(.secondary)
+                .font(.system(size: max(8, density.subtitleFontSize - 2), weight: .semibold))
+                .textCase(.uppercase)
+                .tracking(0.4)
+                .foregroundStyle(.tertiary)
+                .lineLimit(1)
+            value
+                .font(.system(
+                    size: density.bucketTitleFontSize,
+                    weight: .semibold,
+                    design: .rounded
+                ).monospacedDigit())
+                .foregroundStyle(.primary)
+                .lineLimit(1)
+                .minimumScaleFactor(0.7)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var metricDivider: some View {
+        Divider()
+            .frame(height: 28)
+            .padding(.horizontal, 4)
+    }
+
+    private func toolBreakdown(_ machine: RemoteMachineSummary) -> some View {
+        LazyVGrid(
+            columns: [GridItem(.adaptive(minimum: 96), spacing: 6)],
+            alignment: .leading,
+            spacing: 6
+        ) {
+            ForEach(machine.byTool) { usage in
+                toolChip(usage)
+            }
+        }
+    }
+
+    /// A Probe reports whatever tool ids it scanned, including ones this build
+    /// doesn't model yet. Known ids get the provider's brand mark and accent;
+    /// anything else stays neutral rather than being dropped.
+    private func toolChip(_ usage: RemoteToolUsageSummary) -> some View {
+        let tool = ToolType(rawValue: usage.tool)
+        let accent = tool.map { Theme.providerAccent(for: $0) }
+        return VStack(alignment: .leading, spacing: 3) {
+            HStack(spacing: 4) {
+                if let tool {
+                    ToolBrandIconView(tool: tool, size: max(10, density.subtitleFontSize - 1))
+                }
+                Text(tool?.menuTitle ?? usage.tool.capitalized)
+                    .font(.system(size: max(8, density.subtitleFontSize - 2), weight: .medium))
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+            HStack(alignment: .firstTextBaseline, spacing: 4) {
+                Text(usage.tokens, format: .number.notation(.compactName))
+                    .font(.system(
+                        size: density.subtitleFontSize,
+                        weight: .semibold,
+                        design: .rounded
+                    ).monospacedDigit())
+                    .foregroundStyle(accent ?? Color.primary)
+                if usage.costUSD > 0 {
+                    Text(usage.costUSD, format: .currency(code: "USD"))
+                        .font(.system(
+                            size: max(8, density.subtitleFontSize - 2),
+                            design: .rounded
+                        ).monospacedDigit())
+                        .foregroundStyle(.tertiary)
+                }
+            }
+            .lineLimit(1)
+            .minimumScaleFactor(0.7)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, 8)
+        .padding(.vertical, 6)
+        .background(
+            RoundedRectangle(cornerRadius: chipCornerRadius, style: .continuous)
+                .fill(accent?.opacity(0.10) ?? Color.primary.opacity(0.05))
+        )
+    }
+
+    private func footer(_ machine: RemoteMachineSummary) -> some View {
+        HStack(alignment: .center, spacing: density.statusComponentSpacing) {
+            ForEach(machine.sourceStatuses.keys.sorted(), id: \.self) { source in
+                sourceCapsule(source, status: machine.sourceStatuses[source] ?? "error")
+            }
+            Spacer(minLength: 8)
+            Text("seq \(machine.lastSequence)")
+                .font(.caption2.monospacedDigit())
+                .foregroundStyle(.tertiary)
+            Toggle("Include in totals", isOn: includedInTotals(machine))
+                .toggleStyle(.switch)
+                .controlSize(.mini)
+                .font(.system(size: max(9, density.subtitleFontSize - 1)))
+                .fixedSize()
+                .help("Add this machine's decrypted usage to Overview and provider cost pages on this Core")
+        }
+    }
+
+    private func sourceCapsule(_ source: String, status: String) -> some View {
+        let isHealthy = status == "ok"
+        let label = ToolType(rawValue: source)?.menuTitle ?? source.capitalized
+        return Text("\(label) · \(status)")
+            .font(.system(size: max(8, density.subtitleFontSize - 3), weight: .medium))
+            .foregroundStyle(isHealthy ? Color.secondary : Color.orange)
+            .lineLimit(1)
+            .padding(.horizontal, 7)
+            .padding(.vertical, 3)
+            .background(
+                Capsule().fill(
+                    isHealthy ? Color.primary.opacity(0.05) : Color.orange.opacity(0.12)
+                )
+            )
     }
 
     private func freshness(_ machine: RemoteMachineSummary) -> some View {
@@ -172,12 +235,57 @@ struct RemoteMachinesPage: View {
         }
         return HStack(spacing: 5) {
             Circle().fill(color).frame(width: 7, height: 7)
-            Text(label).font(.caption.weight(.semibold))
+            Text(label)
+                .font(.system(size: max(9, density.subtitleFontSize), weight: .semibold))
         }
         .foregroundStyle(color)
         .padding(.horizontal, 8)
         .padding(.vertical, 4)
         .background(Capsule().fill(color.opacity(0.10)))
+    }
+
+    private func syncErrorBanner(_ code: String) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: 7) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .foregroundStyle(.orange)
+            Text("Latest sync: \(code)")
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+            Spacer(minLength: 0)
+        }
+        .font(.system(size: density.subtitleFontSize))
+        .padding(density.cardPadding)
+        .background(
+            RoundedRectangle(cornerRadius: density.cardCornerRadius, style: .continuous)
+                .fill(Color.orange.opacity(0.08))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: density.cardCornerRadius, style: .continuous)
+                .stroke(Color.orange.opacity(0.35), lineWidth: 0.5)
+        )
+    }
+
+    private func stateCard(icon: String, title: String, detail: String) -> some View {
+        VStack(spacing: density.cardSpacing) {
+            Image(systemName: icon)
+                .font(.system(size: density.titleFontSize + 8, weight: .light))
+                .foregroundStyle(.secondary)
+            Text(title)
+                .font(.system(size: density.titleFontSize, weight: .semibold))
+            Text(detail)
+                .font(.system(size: density.subtitleFontSize))
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: 430)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.horizontal, density.cardPadding)
+        .padding(.vertical, density.cardPadding * 2)
+        .cardSurface(density: density)
+    }
+
+    private var chipCornerRadius: CGFloat {
+        max(6, density.cardCornerRadius - 6)
     }
 
     private func includedInTotals(_ machine: RemoteMachineSummary) -> Binding<Bool> {
@@ -191,24 +299,5 @@ struct RemoteMachinesPage: View {
                 }
             }
         )
-    }
-
-    private var cardBackground: some View {
-        RoundedRectangle(cornerRadius: 12, style: .continuous)
-            .fill(Color.primary.opacity(0.035))
-            .overlay(
-                RoundedRectangle(cornerRadius: 12, style: .continuous)
-                    .stroke(Color.primary.opacity(0.07), lineWidth: 0.7)
-            )
-    }
-
-    private func toolLabel(_ raw: String) -> String {
-        switch raw {
-        case "codex": return "Codex"
-        case "claude": return "Claude"
-        case "antigravity": return "AntiGravity"
-        case "grok": return "Grok"
-        default: return raw
-        }
     }
 }


### PR DESCRIPTION
## Summary

The Machines tab was the only page in the app not following the shared card design language: flat `Color.primary` card fills that read muddy on the popover's vibrancy, hard-coded corner radius / padding / font sizes ignoring `Theme.Density` tokens, a single full-width column stretching cards across the whole workspace, a misaligned 4-up metric row, non-wrapping gray tool chips, and an unstyled sync-error banner.

- Promote the app-wide card surface contract (`.background.tertiary` fill + hairline separator stroke + density radius/padding) into a shared `CardShell` view and `cardSurface(density:)` modifier; `MiscProviderCardShell` now delegates to it (zero visual delta).
- Rebuild the Machines page on that contract: density-token typography with `.monospacedDigit()` metrics cloned from the Overview cost card, two-column `ColumnMasonryLayout` when more than one machine reports (single machines get a readable constrained column), brand-accented per-tool chips with `ToolBrandIconView` in a wrapping adaptive grid, an orange warning card for sync errors, tinted source-status capsules, and an evenly spaced footer row for seq + the include-in-totals toggle.
- No behavior changes: freshness evaluation, the `remoteCostIncludedMachineIDs` binding, and all copy are untouched. No Core changes.

## Verification

- `swift build` clean; `swift test` 1124 tests, 0 failures.
- `./Scripts/build_app.sh release` succeeded; `codesign -d --entitlements -` shows an empty `<dict/>` (no `app-sandbox`); `codesign --verify --deep --strict` passes.
- Real-home grep gate clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)