### PR TITLE
Add Workbench window with per-request usage statistics

### DIFF
--- a/Sources/VibeBarApp/AppDelegate.swift
+++ b/Sources/VibeBarApp/AppDelegate.swift
@@ -16,6 +16,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             NSApp.setActivationPolicy(.accessory)
         }
 
+        installMainMenuIfNeeded()
+
         let env = AppEnvironment()
         self.environment = env
         do {
@@ -51,6 +53,102 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 }
             }
         }
+    }
+
+    /// Clicking the Dock icon — which only exists while the Workbench holds a
+    /// Dock token — should bring that window back rather than do nothing. The
+    /// Workbench is never created here: a Dock icon without a live Workbench
+    /// means the window is mid-teardown, and resurrecting it would fight the
+    /// close the user just asked for.
+    func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
+        environment?.frontWorkbenchIfOpen()
+        return true
+    }
+
+    /// An `LSUIElement` app starts with no main menu, and without one the
+    /// standard key equivalents never reach a window — ⌘W won't close the
+    /// Workbench and ⌘C/⌘V won't work in its text fields. Installed once, and
+    /// only when nothing else has claimed the menu bar.
+    private func installMainMenuIfNeeded() {
+        guard NSApp.mainMenu == nil else { return }
+        let mainMenu = NSMenu()
+        mainMenu.addItem(appMenuItem())
+        mainMenu.addItem(fileMenuItem())
+        mainMenu.addItem(editMenuItem())
+        mainMenu.addItem(windowMenuItem())
+        NSApp.mainMenu = mainMenu
+    }
+
+    private func appMenuItem() -> NSMenuItem {
+        let appName = "Vibe Bar"
+        let menu = NSMenu(title: appName)
+        menu.addItem(NSMenuItem(
+            title: "About \(appName)",
+            action: #selector(NSApplication.orderFrontStandardAboutPanel(_:)),
+            keyEquivalent: ""
+        ))
+        menu.addItem(.separator())
+        menu.addItem(NSMenuItem(
+            title: "Quit \(appName)",
+            action: #selector(NSApplication.terminate(_:)),
+            keyEquivalent: "q"
+        ))
+        return submenuItem(title: appName, submenu: menu)
+    }
+
+    private func fileMenuItem() -> NSMenuItem {
+        let menu = NSMenu(title: "File")
+        menu.addItem(NSMenuItem(
+            title: "Close",
+            action: #selector(NSWindow.performClose(_:)),
+            keyEquivalent: "w"
+        ))
+        return submenuItem(title: "File", submenu: menu)
+    }
+
+    private func editMenuItem() -> NSMenuItem {
+        let menu = NSMenu(title: "Edit")
+        menu.addItem(NSMenuItem(
+            title: "Undo",
+            action: NSSelectorFromString("undo:"),
+            keyEquivalent: "z"
+        ))
+        let redo = NSMenuItem(
+            title: "Redo",
+            action: NSSelectorFromString("redo:"),
+            keyEquivalent: "z"
+        )
+        redo.keyEquivalentModifierMask = [.command, .shift]
+        menu.addItem(redo)
+        menu.addItem(.separator())
+        menu.addItem(NSMenuItem(title: "Cut", action: #selector(NSText.cut(_:)), keyEquivalent: "x"))
+        menu.addItem(NSMenuItem(title: "Copy", action: #selector(NSText.copy(_:)), keyEquivalent: "c"))
+        menu.addItem(NSMenuItem(title: "Paste", action: #selector(NSText.paste(_:)), keyEquivalent: "v"))
+        menu.addItem(NSMenuItem(title: "Select All", action: #selector(NSText.selectAll(_:)), keyEquivalent: "a"))
+        return submenuItem(title: "Edit", submenu: menu)
+    }
+
+    private func windowMenuItem() -> NSMenuItem {
+        let menu = NSMenu(title: "Window")
+        menu.addItem(NSMenuItem(
+            title: "Minimize",
+            action: #selector(NSWindow.performMiniaturize(_:)),
+            keyEquivalent: "m"
+        ))
+        menu.addItem(NSMenuItem(
+            title: "Zoom",
+            action: #selector(NSWindow.performZoom(_:)),
+            keyEquivalent: ""
+        ))
+        let item = submenuItem(title: "Window", submenu: menu)
+        NSApp.windowsMenu = menu
+        return item
+    }
+
+    private func submenuItem(title: String, submenu: NSMenu) -> NSMenuItem {
+        let item = NSMenuItem(title: title, action: nil, keyEquivalent: "")
+        item.submenu = submenu
+        return item
     }
 
     func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {

--- a/Sources/VibeBarApp/AppEnvironment.swift
+++ b/Sources/VibeBarApp/AppEnvironment.swift
@@ -15,6 +15,10 @@ final class AppEnvironment: ObservableObject {
     /// Per-page card arrangement, shared by the popover and the Settings
     /// layout editor. Loads `~/.vibebar/layout.json` once at startup.
     let pageLayout: PageLayoutModel
+    /// Per-request usage ledger, opened once. `nil` when the SQLite file
+    /// cannot be opened — every reader treats that as "no history", so a
+    /// broken ledger costs the usage page, not the app.
+    let usageLedger: UsageEventLedger?
 
     @Published private(set) var hasClaudeWebCookies: Bool
     @Published private(set) var hasOpenAIWebCookies: Bool
@@ -35,6 +39,7 @@ final class AppEnvironment: ObservableObject {
     private let miscWebLoginRegistry = MiscWebLoginRegistry()
     private let settingsWindowController = SettingsWindowController()
     private let workbenchWindowController = WorkbenchWindowController()
+    private var workbenchServicesStorage: WorkbenchServices?
     private var cancellables: Set<AnyCancellable> = []
     private var routineBudgetInFlightAccountIds: Set<String> = []
     private var lastRoutineBudgetAttemptByAccount: [String: Date] = [:]
@@ -88,11 +93,19 @@ final class AppEnvironment: ObservableObject {
         self.quotaService = service
         self.pageLayout = PageLayoutModel(settingsStore: settings)
         self.serviceStatus = ServiceStatusController()
+        let ledger: UsageEventLedger?
+        do {
+            ledger = try UsageEventLedger()
+        } catch {
+            SafeLog.warn("Opening the usage ledger failed: \(SafeLog.sanitize(error.localizedDescription))")
+            ledger = nil
+        }
+        self.usageLedger = ledger
         let costService = CostUsageService(mockProvider: { [weak settings] in
             settings?.mockEnabled ?? false
         }, costDataSettingsProvider: { [weak settings] in
             settings?.settings.costData ?? .default
-        })
+        }, usageLedger: ledger)
         self.costService = costService
         self.remoteProbeService = RemoteProbeService()
 
@@ -489,6 +502,16 @@ final class AppEnvironment: ObservableObject {
 
     func showWorkbench(page: WorkbenchPage? = nil) {
         workbenchWindowController.show(environment: self, page: page)
+    }
+
+    /// Built on the first Workbench open and kept for the process lifetime, so
+    /// reopening the window lands on the state the user left rather than on a
+    /// fresh set of queries.
+    var workbenchServices: WorkbenchServices {
+        if let workbenchServicesStorage { return workbenchServicesStorage }
+        let services = WorkbenchServices(usageLedger: usageLedger, costService: costService)
+        workbenchServicesStorage = services
+        return services
     }
 
     /// Front an already-open Workbench without creating one. Used by the Dock

--- a/Sources/VibeBarApp/AppEnvironment.swift
+++ b/Sources/VibeBarApp/AppEnvironment.swift
@@ -34,6 +34,7 @@ final class AppEnvironment: ObservableObject {
     private let claudeWebLoginController = ClaudeWebLoginController()
     private let miscWebLoginRegistry = MiscWebLoginRegistry()
     private let settingsWindowController = SettingsWindowController()
+    private let workbenchWindowController = WorkbenchWindowController()
     private var cancellables: Set<AnyCancellable> = []
     private var routineBudgetInFlightAccountIds: Set<String> = []
     private var lastRoutineBudgetAttemptByAccount: [String: Date] = [:]
@@ -484,6 +485,17 @@ final class AppEnvironment: ObservableObject {
 
     func showSettingsWindow() {
         settingsWindowController.show(environment: self)
+    }
+
+    func showWorkbench(page: WorkbenchPage? = nil) {
+        workbenchWindowController.show(environment: self, page: page)
+    }
+
+    /// Front an already-open Workbench without creating one. Used by the Dock
+    /// reopen path, which must not resurrect a window the user just closed.
+    @discardableResult
+    func frontWorkbenchIfOpen() -> Bool {
+        workbenchWindowController.frontExistingWindow()
     }
 
     func openClaudeWebLogin() {

--- a/Sources/VibeBarApp/Controllers/DockActivationController.swift
+++ b/Sources/VibeBarApp/Controllers/DockActivationController.swift
@@ -1,0 +1,35 @@
+import AppKit
+
+/// Owns the app's activation policy.
+///
+/// Vibe Bar ships as an `LSUIElement` agent, so it normally has no Dock icon
+/// and no app menu. Full windows such as the Workbench need both, and they
+/// need them to survive a second window opening and closing underneath. Each
+/// surface holds a token while it is on screen; the Dock icon appears while at
+/// least one token is held and disappears once the last one is released.
+@MainActor
+final class DockActivationController {
+    static let shared = DockActivationController()
+
+    enum DockToken: String, Hashable {
+        case workbench
+    }
+
+    private var tokens: Set<DockToken> = []
+
+    private init() {}
+
+    func acquire(_ token: DockToken) {
+        guard tokens.insert(token).inserted else { return }
+        applyActivationPolicy()
+    }
+
+    func release(_ token: DockToken) {
+        guard tokens.remove(token) != nil else { return }
+        applyActivationPolicy()
+    }
+
+    private func applyActivationPolicy() {
+        NSApp.setActivationPolicy(tokens.isEmpty ? .accessory : .regular)
+    }
+}

--- a/Sources/VibeBarApp/Controllers/UsageStatsViewModel.swift
+++ b/Sources/VibeBarApp/Controllers/UsageStatsViewModel.swift
@@ -1,0 +1,418 @@
+import Combine
+import Foundation
+import VibeBarCore
+
+/// Filter state and query results behind the Workbench's Usage Stats page.
+///
+/// Every published result is a plain value produced by `UsageEventLedger`,
+/// which is an actor: the queries run on its executor and only the finished
+/// snapshot is assigned here, so a 30-day scan never blocks a frame.
+@MainActor
+final class UsageStatsViewModel: ObservableObject {
+    /// Range presets deliberately mix two shapes:
+    ///
+    /// - `today` is the local calendar day so far — midnight → now.
+    /// - every `N`-day preset is a *rolling* window of exactly `N × 86400`
+    ///   seconds ending now.
+    ///
+    /// Making the N-day presets calendar-aligned too would collapse "Today"
+    /// and "24 h" into the same button for most of the day, and a rolling
+    /// 24 h window is also what keeps `UsageTrendBucket.recommended` on
+    /// hourly buckets for the shortest preset.
+    enum RangePreset: String, CaseIterable, Identifiable {
+        case today
+        case day1
+        case day7
+        case day14
+        case day30
+        case custom
+
+        var id: String { rawValue }
+
+        var title: String {
+            switch self {
+            case .today:  "Today"
+            case .day1:   "24 h"
+            case .day7:   "7 d"
+            case .day14:  "14 d"
+            case .day30:  "30 d"
+            case .custom: "Custom"
+            }
+        }
+
+        var systemImage: String {
+            switch self {
+            case .today:  "sun.max"
+            case .day1:   "clock"
+            case .day7:   "calendar"
+            case .day14:  "calendar"
+            case .day30:  "calendar"
+            case .custom: "calendar.badge.clock"
+            }
+        }
+
+        /// Seconds of the rolling window, `nil` for the two presets that are
+        /// not a fixed span.
+        var rollingSpan: TimeInterval? {
+            switch self {
+            case .today, .custom: nil
+            case .day1:  86_400
+            case .day7:  7 * 86_400
+            case .day14: 14 * 86_400
+            case .day30: 30 * 86_400
+            }
+        }
+    }
+
+    enum RefreshInterval: Int, CaseIterable, Identifiable {
+        case off = 0
+        case fiveSeconds = 5
+        case tenSeconds = 10
+        case thirtySeconds = 30
+        case sixtySeconds = 60
+
+        var id: Int { rawValue }
+
+        var title: String {
+            self == .off ? "Off" : "\(rawValue)s"
+        }
+    }
+
+    // MARK: - Filter state
+
+    @Published var rangePreset: RangePreset = .day7 {
+        didSet {
+            guard oldValue != rangePreset else { return }
+            reload(cascadeModels: false)
+        }
+    }
+
+    @Published var customStart: Date {
+        didSet {
+            guard oldValue != customStart, rangePreset == .custom else { return }
+            reload(cascadeModels: false)
+        }
+    }
+
+    @Published var customEnd: Date {
+        didSet {
+            guard oldValue != customEnd, rangePreset == .custom else { return }
+            reload(cascadeModels: false)
+        }
+    }
+
+    @Published var refreshInterval: RefreshInterval = .off {
+        didSet {
+            guard oldValue != refreshInterval else { return }
+            restartTimer()
+        }
+    }
+
+    /// `nil` means "every provider". An empty selection is normalized back to
+    /// `nil` rather than kept as "match nothing" — a filter bar with no chip
+    /// lit should read as unfiltered, not as an empty page.
+    @Published private(set) var selectedTools: Set<ToolType>?
+    @Published private(set) var selectedModels: Set<String>?
+
+    // MARK: - Results
+
+    @Published private(set) var summary: UsageSummaryMetrics = .empty
+    @Published private(set) var trend = UsageTrendSeries(bucket: .day, points: [])
+    @Published private(set) var providerStats: [UsageProviderStat] = []
+    @Published private(set) var modelStats: [UsageModelStat] = []
+    @Published private(set) var requestRows: [UsageRequestRow] = []
+    @Published private(set) var requestTotalCount = 0
+    @Published private(set) var availableModels: [String] = []
+    /// Providers offered as filter chips: the cost-aware set, widened by any
+    /// provider the ledger actually has rows for.
+    @Published private(set) var knownTools: [ToolType] = ToolType.costAwareProviders
+    @Published private(set) var isLoading = false
+    @Published private(set) var isLoadingMore = false
+    @Published private(set) var lastUpdatedAt: Date?
+
+    let isLedgerAvailable: Bool
+
+    var hasMoreRequests: Bool {
+        requestRows.count < requestTotalCount
+    }
+
+    var range: DateInterval {
+        let now = Date()
+        switch rangePreset {
+        case .today:
+            let start = min(Calendar.current.startOfDay(for: now), now)
+            return DateInterval(start: start, end: now)
+        case .custom:
+            let start = min(customStart, customEnd)
+            let end = max(customStart, customEnd)
+            return DateInterval(start: start, end: max(end, start.addingTimeInterval(60)))
+        case .day1, .day7, .day14, .day30:
+            let span = rangePreset.rollingSpan ?? 86_400
+            return DateInterval(start: now.addingTimeInterval(-span), end: now)
+        }
+    }
+
+    var filter: UsageQueryFilter {
+        UsageQueryFilter(
+            range: range,
+            tools: selectedTools.map { $0.sorted { $0.rawValue < $1.rawValue } },
+            models: selectedModels.map { $0.sorted() }
+        )
+    }
+
+    var trendBucket: UsageTrendBucket {
+        trend.bucket
+    }
+
+    // MARK: - Dependencies
+
+    private let ledger: UsageEventLedger?
+    private let costService: CostUsageService
+
+    private var reloadTask: Task<Void, Never>?
+    private var tickTask: Task<Void, Never>?
+    private var lastCostRefreshAt: Date?
+    private var loadedRequestPages = 0
+    private var generation: UInt64 = 0
+    private var hasLoadedOnce = false
+    /// The filter page 0 was fetched with. Later pages reuse it verbatim: a
+    /// rolling preset's `now` moves between pages, and re-deriving the range
+    /// per page would slide the offsets under the rows already on screen.
+    private var activeFilter: UsageQueryFilter?
+    /// Providers the ledger has been seen carrying, accumulated across
+    /// reloads. Derived from the *filtered* results, so it must only grow —
+    /// otherwise narrowing to one provider would retire every other chip and
+    /// strand the user with no way back except "All providers".
+    private var observedTools: Set<ToolType> = []
+
+    private nonisolated static let requestPageSize = 50
+    /// A poll re-reads the ledger every tick, but the ledger only moves when a
+    /// cost scan writes to it — and a scan walks the whole session tree. One
+    /// rescan a minute is the ceiling regardless of how fast the poll runs.
+    private static let costRefreshMinimumInterval: TimeInterval = 60
+
+    init(ledger: UsageEventLedger?, costService: CostUsageService) {
+        self.ledger = ledger
+        self.costService = costService
+        self.isLedgerAvailable = ledger != nil
+        let now = Date()
+        self.customEnd = now
+        self.customStart = now.addingTimeInterval(-7 * 86_400)
+    }
+
+    // MARK: - Lifecycle
+
+    /// First load on window open; a re-open re-queries instead of rebuilding,
+    /// because the view model outlives the window.
+    func activate() {
+        restartTimer()
+        if hasLoadedOnce {
+            reload(cascadeModels: false)
+        } else {
+            hasLoadedOnce = true
+            reload(cascadeModels: true)
+        }
+    }
+
+    func stop() {
+        tickTask?.cancel()
+        tickTask = nil
+        reloadTask?.cancel()
+        reloadTask = nil
+    }
+
+    // MARK: - Filter mutation
+
+    func setSelectedTools(_ tools: Set<ToolType>?) {
+        let normalized = (tools?.isEmpty ?? true) ? nil : tools
+        guard normalized != selectedTools else { return }
+        selectedTools = normalized
+        reload(cascadeModels: true)
+    }
+
+    func toggleTool(_ tool: ToolType) {
+        var next = selectedTools ?? Set(knownTools)
+        if next.contains(tool) { next.remove(tool) } else { next.insert(tool) }
+        // Re-selecting everything is the same statement as "no provider
+        // filter", and saying it that way keeps the query unrestricted.
+        setSelectedTools(next.count == knownTools.count ? nil : next)
+    }
+
+    func setSelectedModels(_ models: Set<String>?) {
+        let normalized = (models?.isEmpty ?? true) ? nil : models
+        guard normalized != selectedModels else { return }
+        selectedModels = normalized
+        reload(cascadeModels: false)
+    }
+
+    func toggleModel(_ model: String) {
+        var next = selectedModels ?? Set(availableModels)
+        if next.contains(model) { next.remove(model) } else { next.insert(model) }
+        setSelectedModels(next.count == availableModels.count ? nil : next)
+    }
+
+    func setCustomRange(start: Date, end: Date) {
+        customStart = start
+        customEnd = end
+    }
+
+    // MARK: - Queries
+
+    func refresh() {
+        reload(cascadeModels: true)
+    }
+
+    /// Next zero-based page of request rows, appended to what is already on
+    /// screen. Pages from a superseded filter are dropped on arrival.
+    func loadMoreRequests() {
+        guard let ledger, let filter = activeFilter,
+              !isLoadingMore, !isLoading, hasMoreRequests
+        else { return }
+        let generation = self.generation
+        let page = loadedRequestPages
+        isLoadingMore = true
+        Task { [weak self] in
+            let result = try? await ledger.requestPage(
+                filter, page: page, pageSize: Self.requestPageSize
+            )
+            guard let self, generation == self.generation else { return }
+            self.isLoadingMore = false
+            guard let result else { return }
+            self.append(result)
+        }
+    }
+
+    private func reload(cascadeModels: Bool) {
+        generation &+= 1
+        let generation = self.generation
+        reloadTask?.cancel()
+        loadedRequestPages = 0
+        activeFilter = nil
+        // A page still in flight is now for a filter nobody is looking at; it
+        // drops itself on the generation check and never clears this, so the
+        // reload has to, or paging stays wedged for the rest of the session.
+        isLoadingMore = false
+        guard let ledger else {
+            applyEmpty()
+            return
+        }
+        let tools = filter.tools
+        isLoading = true
+        reloadTask = Task { [weak self] in
+            let models = (try? await ledger.availableModels(tools: tools)) ?? []
+            guard let self, !Task.isCancelled, generation == self.generation else { return }
+            // Models first: a narrowed provider set can strand a model that no
+            // longer exists in the picker, and querying with it would report
+            // an empty page the user has no control to clear.
+            if cascadeModels {
+                self.pruneSelectedModels(to: models)
+            }
+            self.availableModels = models
+            let resolved = self.filter
+            let snapshot = await Self.load(ledger: ledger, filter: resolved)
+            guard !Task.isCancelled, generation == self.generation else { return }
+            self.activeFilter = resolved
+            self.apply(snapshot)
+        }
+    }
+
+    private func pruneSelectedModels(to models: [String]) {
+        guard let selectedModels else { return }
+        let kept = selectedModels.intersection(models)
+        self.selectedModels = kept.isEmpty ? nil : kept
+    }
+
+    private func apply(_ snapshot: LoadedUsage) {
+        summary = snapshot.summary
+        trend = snapshot.trend
+        providerStats = snapshot.providers
+        modelStats = snapshot.models
+        requestRows = snapshot.requests.rows
+        requestTotalCount = snapshot.requests.totalCount
+        loadedRequestPages = 1
+        observedTools.formUnion(snapshot.providers.map(\.tool))
+        observedTools.formUnion(selectedTools ?? [])
+        knownTools = ToolType.allCases.filter {
+            $0.supportsTokenCost || observedTools.contains($0)
+        }
+        lastUpdatedAt = Date()
+        isLoading = false
+    }
+
+    private func applyEmpty() {
+        summary = .empty
+        trend = UsageTrendSeries(bucket: UsageTrendBucket.recommended(for: range), points: [])
+        providerStats = []
+        modelStats = []
+        requestRows = []
+        requestTotalCount = 0
+        availableModels = []
+        isLoading = false
+    }
+
+    private func append(_ page: UsageRequestPage) {
+        guard page.page == loadedRequestPages else { return }
+        let known = Set(requestRows.map(\.id))
+        requestRows.append(contentsOf: page.rows.filter { !known.contains($0.id) })
+        requestTotalCount = page.totalCount
+        loadedRequestPages = page.page + 1
+    }
+
+    // MARK: - Polling
+
+    private func restartTimer() {
+        tickTask?.cancel()
+        let seconds = refreshInterval.rawValue
+        guard seconds > 0 else {
+            tickTask = nil
+            return
+        }
+        tickTask = Task { [weak self] in
+            while !Task.isCancelled {
+                try? await Task.sleep(for: .seconds(seconds))
+                guard !Task.isCancelled, let self else { return }
+                await self.tick()
+            }
+        }
+    }
+
+    private func tick() async {
+        let now = Date()
+        let due = lastCostRefreshAt.map { now.timeIntervalSince($0) >= Self.costRefreshMinimumInterval }
+        if due ?? true {
+            lastCostRefreshAt = now
+            await costService.refreshAll()
+        }
+        reload(cascadeModels: false)
+    }
+
+    // MARK: - Off-main load
+
+    private struct LoadedUsage: Sendable {
+        let summary: UsageSummaryMetrics
+        let trend: UsageTrendSeries
+        let providers: [UsageProviderStat]
+        let models: [UsageModelStat]
+        let requests: UsageRequestPage
+    }
+
+    private nonisolated static func load(
+        ledger: UsageEventLedger,
+        filter: UsageQueryFilter
+    ) async -> LoadedUsage {
+        let summary = (try? await ledger.summary(filter)) ?? .empty
+        let trend = (try? await ledger.trend(filter))
+            ?? UsageTrendSeries(bucket: UsageTrendBucket.recommended(for: filter.range), points: [])
+        let providers = (try? await ledger.providerStats(filter)) ?? []
+        let models = (try? await ledger.modelStats(filter)) ?? []
+        let requests = (try? await ledger.requestPage(filter, page: 0, pageSize: requestPageSize))
+            ?? UsageRequestPage(rows: [], totalCount: 0, page: 0, pageSize: requestPageSize)
+        return LoadedUsage(
+            summary: summary,
+            trend: trend,
+            providers: providers,
+            models: models,
+            requests: requests
+        )
+    }
+}

--- a/Sources/VibeBarApp/Controllers/WorkbenchServices.swift
+++ b/Sources/VibeBarApp/Controllers/WorkbenchServices.swift
@@ -1,0 +1,25 @@
+import Foundation
+import VibeBarCore
+
+/// Window-scoped state for the Workbench, built on first open.
+///
+/// The Workbench's page models are expensive enough to be worth keeping —
+/// the usage page holds a whole query snapshot and can be polling — but
+/// pointless for the menu-bar-only session that never opens the window. So
+/// `AppEnvironment` holds this lazily, and the models inside it are lazy in
+/// turn: opening the Workbench on Sessions never builds the usage queries.
+@MainActor
+final class WorkbenchServices: ObservableObject {
+    private let usageLedger: UsageEventLedger?
+    private let costService: CostUsageService
+
+    init(usageLedger: UsageEventLedger?, costService: CostUsageService) {
+        self.usageLedger = usageLedger
+        self.costService = costService
+    }
+
+    lazy var usageStats = UsageStatsViewModel(
+        ledger: usageLedger,
+        costService: costService
+    )
+}

--- a/Sources/VibeBarApp/Controllers/WorkbenchWindowController.swift
+++ b/Sources/VibeBarApp/Controllers/WorkbenchWindowController.swift
@@ -1,0 +1,92 @@
+import AppKit
+import SwiftUI
+import VibeBarCore
+
+/// Hosts the Workbench in a standalone window.
+///
+/// The popover is transient and Settings is a place users pass through; the
+/// Workbench is where they stay. It is therefore a first-class window: it
+/// remembers its frame, and it holds a Dock token for as long as it is open so
+/// the agent-only app can be reached from the Dock and the app switcher.
+@MainActor
+final class WorkbenchWindowController: NSObject {
+    static let frameAutosaveName = "VibeBarWorkbenchWindow"
+
+    private var window: NSWindow?
+    private weak var environment: AppEnvironment?
+
+    func show(environment: AppEnvironment, page: WorkbenchPage? = nil) {
+        self.environment = environment
+        // Before the window exists: switching activation policy reorders the
+        // app's windows, and doing that after `makeKeyAndOrderFront` can drop
+        // the new window behind whatever was in front.
+        DockActivationController.shared.acquire(.workbench)
+
+        if let window {
+            window.makeKeyAndOrderFront(nil)
+            NSApp.activate(ignoringOtherApps: true)
+            return
+        }
+
+        let hosting = NSHostingController(
+            rootView: WorkbenchRootView(initialPage: page)
+                .environmentObject(environment)
+                .environmentObject(environment.accountStore)
+                .environmentObject(environment.settingsStore)
+                .environmentObject(environment.quotaService)
+                .environmentObject(environment.serviceStatus)
+                .environmentObject(environment.costService)
+                .environmentObject(environment.remoteProbeService)
+                .environmentObject(environment.pageLayout)
+        )
+        let initialSize = NSSize(width: 1180, height: 820)
+        let win = NSWindow(
+            contentRect: NSRect(origin: .zero, size: initialSize),
+            styleMask: [.titled, .closable, .miniaturizable, .resizable, .fullSizeContentView],
+            backing: .buffered,
+            defer: false
+        )
+        win.title = "Workbench"
+        win.titlebarAppearsTransparent = true
+        win.titleVisibility = .visible
+        win.isReleasedWhenClosed = false
+        win.contentViewController = hosting
+        win.center()
+        win.minSize = NSSize(width: 980, height: 680)
+        win.setFrameAutosaveName(Self.frameAutosaveName)
+        win.delegate = self
+        self.window = win
+
+        win.makeKeyAndOrderFront(nil)
+        NSApp.activate(ignoringOtherApps: true)
+    }
+
+    /// Bring an already-created Workbench back to the front without building
+    /// one. Reports whether there was anything to front, so a Dock reopen can
+    /// stay a no-op when the user has closed the Workbench.
+    @discardableResult
+    func frontExistingWindow() -> Bool {
+        // The cached window survives close, so visibility — not existence —
+        // is what separates "re-front the open Workbench" from resurrecting
+        // one the user dismissed. Re-acquiring the token is idempotent and
+        // covers a reopen that arrives while another surface holds the Dock.
+        guard let window, window.isVisible else { return false }
+        DockActivationController.shared.acquire(.workbench)
+        window.makeKeyAndOrderFront(nil)
+        NSApp.activate(ignoringOtherApps: true)
+        return true
+    }
+
+    func close() {
+        window?.close()
+    }
+}
+
+extension WorkbenchWindowController: NSWindowDelegate {
+    func windowWillClose(_ notification: Notification) {
+        // The window itself stays cached so reopening is instant; only the
+        // Dock icon goes away, which is what "the Workbench is closed" means
+        // for an agent app.
+        DockActivationController.shared.release(.workbench)
+    }
+}

--- a/Sources/VibeBarApp/Controllers/WorkbenchWindowController.swift
+++ b/Sources/VibeBarApp/Controllers/WorkbenchWindowController.swift
@@ -38,6 +38,7 @@ final class WorkbenchWindowController: NSObject {
                 .environmentObject(environment.costService)
                 .environmentObject(environment.remoteProbeService)
                 .environmentObject(environment.pageLayout)
+                .environmentObject(environment.workbenchServices)
         )
         let initialSize = NSSize(width: 1180, height: 820)
         let win = NSWindow(

--- a/Sources/VibeBarApp/StatusItemController.swift
+++ b/Sources/VibeBarApp/StatusItemController.swift
@@ -350,6 +350,7 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
         menu.addItem(.separator())
         menu.addItem(actionMenuItem("Refresh", action: #selector(refreshFromContextMenu(_:)), keyEquivalent: "r"))
         menu.addItem(actionMenuItem("Open Mini Window", action: #selector(toggleMiniFromContextMenu(_:))))
+        menu.addItem(actionMenuItem("Open Workbench", action: #selector(openWorkbenchFromContextMenu(_:))))
         menu.addItem(actionMenuItem("Open Settings", action: #selector(openSettingsFromContextMenu(_:)), keyEquivalent: ","))
         let updateItem = actionMenuItem(
             "Check for Updates…",
@@ -445,6 +446,10 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
 
     @objc private func toggleMiniFromContextMenu(_ sender: NSMenuItem) {
         toggleMiniWindow()
+    }
+
+    @objc private func openWorkbenchFromContextMenu(_ sender: NSMenuItem) {
+        environment.showWorkbench()
     }
 
     @objc private func openSettingsFromContextMenu(_ sender: NSMenuItem) {

--- a/Sources/VibeBarApp/Views/HeaderView.swift
+++ b/Sources/VibeBarApp/Views/HeaderView.swift
@@ -14,6 +14,7 @@ struct HeaderView: View {
     let accessory: AnyView?
     let onRefresh: () -> Void
     let onToggleMiniWindow: () -> Void
+    let onShowWorkbench: () -> Void
     let onShowSettings: () -> Void
 
     @State private var rotation: Double = 0
@@ -53,6 +54,12 @@ struct HeaderView: View {
                 help: "Mini",
                 size: max(11, subtitleFontSize),
                 action: onToggleMiniWindow
+            )
+            BorderlessIconButton(
+                systemImage: "macwindow",
+                help: "Open Workbench",
+                size: max(11, subtitleFontSize),
+                action: onShowWorkbench
             )
             BorderlessIconButton(
                 systemImage: "gearshape",

--- a/Sources/VibeBarApp/Views/PopoverRoot.swift
+++ b/Sources/VibeBarApp/Views/PopoverRoot.swift
@@ -30,6 +30,7 @@ struct PopoverRoot: View {
                 accessory: AnyView(OverviewPageSwitch(selection: $overviewPage, density: shellDensity)),
                 onRefresh: { environment.refreshAll() },
                 onToggleMiniWindow: onToggleMiniWindow,
+                onShowWorkbench: { environment.showWorkbench() },
                 onShowSettings: { environment.showSettingsWindow() }
             )
             .frame(height: shellDensity.headerHeight, alignment: .center)

--- a/Sources/VibeBarApp/Views/Workbench/UsageBreakdownTables.swift
+++ b/Sources/VibeBarApp/Views/Workbench/UsageBreakdownTables.swift
@@ -1,0 +1,307 @@
+import SwiftUI
+import VibeBarCore
+
+/// The bottom half of the Usage Stats page: the same range, read three ways.
+///
+/// One card with a segmented switch rather than three stacked tables — the
+/// three views answer the same question at different resolutions, and only
+/// one of them is ever the one being read.
+struct UsageBreakdownTables: View {
+    let density: Theme.Density
+    @ObservedObject var model: UsageStatsViewModel
+
+    @State private var tab: Tab = .requests
+
+    enum Tab: String, CaseIterable, Identifiable {
+        case requests
+        case providers
+        case models
+
+        var id: String { rawValue }
+
+        var title: String {
+            switch self {
+            case .requests:  "Requests"
+            case .providers: "Providers"
+            case .models:    "Models"
+            }
+        }
+    }
+
+    private var tableHeight: CGFloat {
+        switch density.profile {
+        case .compact:  340
+        case .regular:  400
+        case .spacious: 460
+        }
+    }
+
+    private var sortedProviders: [UsageProviderStat] {
+        model.providerStats.sorted { $0.costMicros > $1.costMicros }
+    }
+
+    private var sortedModels: [UsageModelStat] {
+        model.modelStats.sorted { $0.costMicros > $1.costMicros }
+    }
+
+    var body: some View {
+        CardShell(density: density, spacing: density.cardSpacing) {
+            header
+            content
+                .frame(height: tableHeight)
+        }
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        HStack(spacing: 10) {
+            Picker("", selection: $tab) {
+                ForEach(Tab.allCases) { value in
+                    Text(value.title).tag(value)
+                }
+            }
+            .pickerStyle(.segmented)
+            .labelsHidden()
+            .fixedSize()
+            Spacer(minLength: 8)
+            Text(countSummary)
+                .font(.system(size: max(9, density.resetCountdownFontSize), design: .rounded)
+                    .monospacedDigit())
+                .foregroundStyle(.tertiary)
+                .lineLimit(1)
+            if model.isLoadingMore {
+                ProgressView().controlSize(.small)
+            }
+        }
+    }
+
+    private var countSummary: String {
+        switch tab {
+        case .requests:
+            let loaded = model.requestRows.count
+            let total = model.requestTotalCount
+            return loaded < total
+                ? "\(loaded) of \(total) requests"
+                : "\(total) request\(total == 1 ? "" : "s")"
+        case .providers:
+            return "\(model.providerStats.count) provider\(model.providerStats.count == 1 ? "" : "s")"
+        case .models:
+            return "\(model.modelStats.count) model\(model.modelStats.count == 1 ? "" : "s")"
+        }
+    }
+
+    // MARK: - Tables
+
+    @ViewBuilder
+    private var content: some View {
+        switch tab {
+        case .requests:
+            if model.requestRows.isEmpty {
+                empty("No request-level rows in this range")
+            } else {
+                requestsTable
+            }
+        case .providers:
+            if sortedProviders.isEmpty {
+                empty("No provider totals in this range")
+            } else {
+                providersTable
+            }
+        case .models:
+            if sortedModels.isEmpty {
+                empty("No model totals in this range")
+            } else {
+                modelsTable
+            }
+        }
+    }
+
+    private var requestsTable: some View {
+        Table(model.requestRows) {
+            TableColumn("Time") { row in
+                Text(timestamp(row.date))
+                    .font(numericFont)
+                    .foregroundStyle(.secondary)
+                    // The Table is the page's only lazy surface, so paging is
+                    // driven from the last realized row rather than from a
+                    // scroll offset the card never sees.
+                    .onAppear { loadMoreIfLast(row) }
+            }
+            .width(min: 112, ideal: 132)
+
+            TableColumn("Provider") { row in
+                providerCell(row.tool)
+            }
+            .width(min: 118, ideal: 148)
+
+            TableColumn("Model") { row in
+                Text(row.model)
+                    .font(bodyFont)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                    .help(row.model)
+            }
+            .width(min: 130, ideal: 190)
+
+            TableColumn("Input") { row in
+                VStack(alignment: .leading, spacing: 0) {
+                    Text(UsageFormatting.compactTokens(row.freshInput))
+                        .font(numericFont)
+                    if row.cacheRead > 0 || row.cacheCreation > 0 {
+                        Text("R \(UsageFormatting.compactTokens(row.cacheRead))"
+                            + " · W \(UsageFormatting.compactTokens(row.cacheCreation))")
+                            .font(.caption2.monospacedDigit())
+                            .foregroundStyle(.tertiary)
+                            .lineLimit(1)
+                    }
+                }
+            }
+            .width(min: 86, ideal: 104)
+
+            TableColumn("Output") { row in
+                Text(UsageFormatting.compactTokens(row.output))
+                    .font(numericFont)
+            }
+            .width(min: 68, ideal: 82)
+
+            TableColumn("Cost") { row in
+                if let micros = row.costMicros {
+                    Text(UsageFormatting.formatMicroUSD(micros))
+                        .font(numericFont)
+                } else {
+                    Text("unpriced")
+                        .font(.caption2)
+                        .foregroundStyle(.tertiary)
+                }
+            }
+            .width(min: 72, ideal: 88)
+
+            TableColumn("Tier") { row in
+                Text(row.serviceTier ?? "—")
+                    .font(bodyFont)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+            .width(min: 62, ideal: 78)
+        }
+        .tableStyle(.inset(alternatesRowBackgrounds: true))
+    }
+
+    private var providersTable: some View {
+        Table(sortedProviders) {
+            TableColumn("Provider") { stat in
+                providerCell(stat.tool)
+            }
+            .width(min: 150, ideal: 220)
+
+            TableColumn("Requests") { stat in
+                Text(stat.requests.formatted(.number.grouping(.automatic)))
+                    .font(numericFont)
+            }
+            .width(min: 80, ideal: 100)
+
+            TableColumn("Tokens") { stat in
+                Text(UsageFormatting.compactTokens(stat.totalTokens))
+                    .font(numericFont)
+            }
+            .width(min: 84, ideal: 110)
+
+            TableColumn("Cost") { stat in
+                Text(UsageFormatting.formatMicroUSD(stat.costMicros))
+                    .font(numericFont)
+            }
+            .width(min: 84, ideal: 110)
+        }
+        .tableStyle(.inset(alternatesRowBackgrounds: true))
+    }
+
+    private var modelsTable: some View {
+        Table(sortedModels) {
+            TableColumn("Model") { stat in
+                Text(stat.model)
+                    .font(bodyFont)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                    .help(stat.model)
+            }
+            .width(min: 160, ideal: 260)
+
+            TableColumn("Requests") { stat in
+                Text(stat.requests.formatted(.number.grouping(.automatic)))
+                    .font(numericFont)
+            }
+            .width(min: 80, ideal: 98)
+
+            TableColumn("Tokens") { stat in
+                Text(UsageFormatting.compactTokens(stat.totalTokens))
+                    .font(numericFont)
+            }
+            .width(min: 84, ideal: 104)
+
+            TableColumn("Cost") { stat in
+                Text(UsageFormatting.formatMicroUSD(stat.costMicros))
+                    .font(numericFont)
+            }
+            .width(min: 84, ideal: 104)
+
+            TableColumn("Avg/req") { stat in
+                Text(UsageFormatting.formatMicroUSD(stat.avgCostMicrosPerRequest, precision: 4))
+                    .font(numericFont)
+                    .foregroundStyle(.secondary)
+            }
+            .width(min: 88, ideal: 108)
+        }
+        .tableStyle(.inset(alternatesRowBackgrounds: true))
+    }
+
+    // MARK: - Cells
+
+    private func providerCell(_ tool: ToolType) -> some View {
+        HStack(spacing: 6) {
+            ToolBrandBadge(tool: tool, iconSize: 13, containerSize: 16)
+            Text(tool.menuTitle)
+                .font(bodyFont)
+                .lineLimit(1)
+        }
+        .help(tool.displayName)
+    }
+
+    private func empty(_ message: String) -> some View {
+        VStack(spacing: 6) {
+            Image(systemName: "tray")
+                .font(.system(size: 20, weight: .light))
+                .foregroundStyle(.tertiary)
+            Text(message)
+                .font(.system(size: density.subtitleFontSize))
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private func loadMoreIfLast(_ row: UsageRequestRow) {
+        guard row.id == model.requestRows.last?.id else { return }
+        model.loadMoreRequests()
+    }
+
+    private var bodyFont: Font {
+        .system(size: max(10, density.subtitleFontSize))
+    }
+
+    private var numericFont: Font {
+        .system(size: max(10, density.subtitleFontSize), design: .rounded).monospacedDigit()
+    }
+
+    private func timestamp(_ date: Date) -> String {
+        Self.timestampFormatter.string(from: date)
+    }
+
+    /// Cached: the requests table formats one of these per visible row, and
+    /// building a `DateFormatter` per cell is the expensive half of scrolling.
+    private static let timestampFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.locale = Locale.current
+        formatter.setLocalizedDateFormatFromTemplate("MMMd HH:mm:ss")
+        return formatter
+    }()
+}

--- a/Sources/VibeBarApp/Views/Workbench/UsageFiltersBar.swift
+++ b/Sources/VibeBarApp/Views/Workbench/UsageFiltersBar.swift
@@ -1,0 +1,273 @@
+import SwiftUI
+import VibeBarCore
+
+/// Everything that narrows the Usage Stats page: provider chips, a model
+/// picker, the date range, and how often the page re-queries.
+///
+/// Providers are chips rather than another menu because they are the filter
+/// users reach for most, and because a chip can carry the brand accent —
+/// which is how this app says "provider" everywhere else.
+struct UsageFiltersBar: View {
+    let density: Theme.Density
+    @ObservedObject var model: UsageStatsViewModel
+
+    @State private var showsCustomRange = false
+
+    var body: some View {
+        CardShell(density: density, spacing: density.cardSpacing) {
+            providerChips
+            Divider().opacity(0.35)
+            controlRow
+        }
+    }
+
+    // MARK: - Providers
+
+    private var providerChips: some View {
+        ScrollView(.horizontal) {
+            HStack(spacing: 6) {
+                allProvidersChip
+                ForEach(model.knownTools, id: \.self) { tool in
+                    providerChip(tool)
+                }
+            }
+            .padding(.vertical, 1)
+        }
+        .scrollIndicators(.never)
+    }
+
+    private var allProvidersChip: some View {
+        Button {
+            model.setSelectedTools(nil)
+        } label: {
+            Text("All providers")
+                .font(.system(size: density.segmentedFontSize - 1, weight: .semibold))
+                .foregroundStyle(model.selectedTools == nil ? .primary : .secondary)
+                .padding(.horizontal, 10)
+                .frame(minHeight: 24)
+        }
+        .buttonStyle(.plain)
+        .background(chipBackground(tint: .accentColor, selected: model.selectedTools == nil))
+        .accessibilityLabel("Show every provider")
+    }
+
+    private func providerChip(_ tool: ToolType) -> some View {
+        let accent = Theme.providerAccent(for: tool)
+        let selected = model.selectedTools?.contains(tool) ?? true
+        return Button {
+            model.toggleTool(tool)
+        } label: {
+            HStack(spacing: 5) {
+                ToolBrandIconView(tool: tool, size: density.segmentedFontSize + 1)
+                Text(tool.menuTitle)
+                    .font(.system(size: density.segmentedFontSize - 1, weight: .semibold))
+                    .lineLimit(1)
+            }
+            .padding(.horizontal, 9)
+            .frame(minHeight: 24)
+        }
+        .buttonStyle(.plain)
+        .background(chipBackground(tint: accent, selected: selected))
+        // Unselected chips stay legible but recede — the accent is the signal
+        // that a provider is in the query, so an off chip must not wear it.
+        .opacity(selected ? 1 : 0.45)
+        .saturation(selected ? 1 : 0.2)
+        .help(tool.displayName)
+        .accessibilityLabel(tool.displayName)
+        .accessibilityAddTraits(selected ? [.isSelected] : [])
+    }
+
+    private func chipBackground(tint: Color, selected: Bool) -> some View {
+        ZStack {
+            Capsule().fill(tint.opacity(selected ? 0.16 : 0.05))
+            Capsule().stroke(tint.opacity(selected ? 0.55 : 0.18), lineWidth: 0.8)
+        }
+    }
+
+    // MARK: - Controls
+
+    private var controlRow: some View {
+        HStack(spacing: 8) {
+            rangeMenu
+            modelMenu
+            refreshMenu
+            Spacer(minLength: 8)
+            statusText
+            SectionRefreshButton(isRefreshing: model.isLoading) {
+                model.refresh()
+            }
+            .help("Re-run every usage query now")
+        }
+    }
+
+    private var rangeMenu: some View {
+        Menu {
+            ForEach(UsageStatsViewModel.RangePreset.allCases) { preset in
+                Button {
+                    model.rangePreset = preset
+                    if preset == .custom { showsCustomRange = true }
+                } label: {
+                    Label(preset.title, systemImage: preset.systemImage)
+                }
+            }
+            Divider()
+            Button("Edit custom range…") {
+                model.rangePreset = .custom
+                showsCustomRange = true
+            }
+        } label: {
+            menuLabel(systemImage: "calendar", title: model.rangePreset.title, detail: rangeSummary)
+        }
+        .menuStyle(.button)
+        .buttonStyle(.glass)
+        .menuIndicator(.hidden)
+        .fixedSize()
+        .popover(isPresented: $showsCustomRange, arrowEdge: .bottom) {
+            customRangeEditor
+        }
+        .accessibilityLabel("Choose the date range")
+    }
+
+    private var customRangeEditor: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("CUSTOM RANGE")
+                .font(.system(size: max(8, density.subtitleFontSize - 2), weight: .semibold))
+                .foregroundStyle(.tertiary)
+                .tracking(0.4)
+            DatePicker(
+                "From",
+                selection: $model.customStart,
+                in: ...Date(),
+                displayedComponents: [.date, .hourAndMinute]
+            )
+            DatePicker(
+                "To",
+                selection: $model.customEnd,
+                displayedComponents: [.date, .hourAndMinute]
+            )
+            Text("Buckets switch from hourly to daily past a 24-hour span.")
+                .font(.system(size: max(9, density.resetCountdownFontSize - 1)))
+                .foregroundStyle(.tertiary)
+        }
+        .datePickerStyle(.compact)
+        .padding(14)
+        .frame(width: 300)
+    }
+
+    private var modelMenu: some View {
+        Menu {
+            Button("All models") { model.setSelectedModels(nil) }
+            if model.availableModels.isEmpty {
+                Text("No models in range")
+            } else {
+                Divider()
+                ForEach(model.availableModels, id: \.self) { name in
+                    Toggle(isOn: modelBinding(name)) {
+                        Text(name)
+                    }
+                }
+            }
+        } label: {
+            menuLabel(systemImage: "cpu", title: "Models", detail: modelSummary)
+        }
+        .menuStyle(.button)
+        .buttonStyle(.glass)
+        .menuIndicator(.hidden)
+        .fixedSize()
+        .accessibilityLabel("Choose which models to include")
+    }
+
+    private var refreshMenu: some View {
+        Menu {
+            Picker("Auto refresh", selection: $model.refreshInterval) {
+                ForEach(UsageStatsViewModel.RefreshInterval.allCases) { interval in
+                    Text(interval == .off ? "Off" : "Every \(interval.rawValue)s")
+                        .tag(interval)
+                }
+            }
+            .pickerStyle(.inline)
+        } label: {
+            menuLabel(
+                systemImage: model.refreshInterval == .off ? "pause.circle" : "arrow.clockwise.circle",
+                title: "Auto",
+                detail: model.refreshInterval.title
+            )
+        }
+        .menuStyle(.button)
+        .buttonStyle(.glass)
+        .menuIndicator(.hidden)
+        .fixedSize()
+        .accessibilityLabel("Choose how often the page re-queries")
+    }
+
+    private var statusText: some View {
+        Text(statusSummary)
+            .font(.system(size: max(9, density.resetCountdownFontSize - 1), design: .rounded)
+                .monospacedDigit())
+            .foregroundStyle(.tertiary)
+            .lineLimit(1)
+    }
+
+    // MARK: - Labels
+
+    private func menuLabel(systemImage: String, title: String, detail: String) -> some View {
+        HStack(spacing: 5) {
+            Image(systemName: systemImage)
+                .font(.system(size: max(8, density.segmentedFontSize - 2), weight: .semibold))
+                .foregroundStyle(.secondary)
+            Text(title.uppercased())
+                .font(.system(size: max(8, density.segmentedFontSize - 3), weight: .semibold))
+                .foregroundStyle(.tertiary)
+                .tracking(0.4)
+            Text(detail)
+                .font(.system(size: density.segmentedFontSize - 1, weight: .semibold, design: .rounded)
+                    .monospacedDigit())
+                .foregroundStyle(.primary)
+                .lineLimit(1)
+        }
+        .frame(minHeight: 22)
+    }
+
+    private func modelBinding(_ name: String) -> Binding<Bool> {
+        Binding(
+            get: { model.selectedModels?.contains(name) ?? true },
+            set: { _ in model.toggleModel(name) }
+        )
+    }
+
+    private var rangeSummary: String {
+        let range = model.range
+        let formatter = range.duration <= 86_400 ? Self.hourFormatter : Self.dayFormatter
+        return "\(formatter.string(from: range.start)) – \(formatter.string(from: range.end))"
+    }
+
+    private static let hourFormatter = localizedFormatter("MMMd HH:mm")
+    private static let dayFormatter = localizedFormatter("MMMd")
+
+    private static let updatedFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.locale = Locale.current
+        formatter.dateStyle = .none
+        formatter.timeStyle = .medium
+        return formatter
+    }()
+
+    private static func localizedFormatter(_ template: String) -> DateFormatter {
+        let formatter = DateFormatter()
+        formatter.locale = Locale.current
+        formatter.setLocalizedDateFormatFromTemplate(template)
+        return formatter
+    }
+
+    private var modelSummary: String {
+        guard let selected = model.selectedModels else { return "All" }
+        if selected.count == 1, let only = selected.first { return only }
+        return "\(selected.count) selected"
+    }
+
+    private var statusSummary: String {
+        guard model.isLedgerAvailable else { return "ledger unavailable" }
+        guard let updated = model.lastUpdatedAt else { return "loading…" }
+        return "updated \(Self.updatedFormatter.string(from: updated))"
+    }
+}

--- a/Sources/VibeBarApp/Views/Workbench/UsageHeroCards.swift
+++ b/Sources/VibeBarApp/Views/Workbench/UsageHeroCards.swift
@@ -1,0 +1,150 @@
+import SwiftUI
+import VibeBarCore
+
+/// The four headline numbers of the Usage Stats page.
+///
+/// One tile per metric on its own `CardShell` in an adaptive grid, so the
+/// row degrades to 2×2 and then to a column as the window narrows instead of
+/// squeezing four values into an unreadable strip.
+struct UsageHeroCards: View {
+    let density: Theme.Density
+    let summary: UsageSummaryMetrics
+
+    private static let tileMinimum: CGFloat = 210
+
+    var body: some View {
+        LazyVGrid(
+            columns: [
+                GridItem(
+                    .adaptive(minimum: Self.tileMinimum),
+                    spacing: density.interSectionSpacing,
+                    alignment: .topLeading
+                )
+            ],
+            spacing: density.interSectionSpacing
+        ) {
+            tokensTile
+            costTile
+            requestsTile
+            cacheTile
+        }
+    }
+
+    // MARK: - Tiles
+
+    private var tokensTile: some View {
+        tile(label: "REAL TOKENS", value: UsageFormatting.compactTokens(summary.realTotalTokens)) {
+            Text(componentLine)
+                .font(.system(size: max(9, density.resetCountdownFontSize - 1), design: .rounded)
+                    .monospacedDigit())
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+                .minimumScaleFactor(0.7)
+        }
+    }
+
+    private var costTile: some View {
+        tile(label: "TOTAL COST", value: costValue) {
+            if summary.unpricedRequests > 0 {
+                badge(
+                    text: "unpriced \(summary.unpricedRequests)",
+                    tint: .orange,
+                    help: "\(summary.unpricedRequests) request(s) had no usable price and contribute $0."
+                )
+            } else {
+                Text(summary.costMicros == nil ? "no priced requests in range" : "all requests priced")
+                    .font(.system(size: max(9, density.resetCountdownFontSize - 1)))
+                    .foregroundStyle(.tertiary)
+                    .lineLimit(1)
+            }
+        }
+    }
+
+    private var requestsTile: some View {
+        tile(label: "REQUESTS", value: summary.requests.formatted(.number.grouping(.automatic))) {
+            Text(summary.requests == 0 ? "no traffic in range" : "in the selected range")
+                .font(.system(size: max(9, density.resetCountdownFontSize - 1)))
+                .foregroundStyle(.tertiary)
+                .lineLimit(1)
+        }
+    }
+
+    private var cacheTile: some View {
+        tile(label: "CACHE HIT RATE", value: UsageFormatting.formatPercent(summary.cacheHitRate)) {
+            cacheBar
+        }
+    }
+
+    // MARK: - Pieces
+
+    /// Slim capsule track. Read as reassurance rather than as a warning: a
+    /// high hit rate is the good outcome, so the fill greens up as it grows.
+    private var cacheBar: some View {
+        let rate = summary.cacheHitRate ?? 0
+        return GeometryReader { geometry in
+            ZStack(alignment: .leading) {
+                Capsule().fill(Theme.barTrack)
+                Capsule()
+                    .fill(cacheTint(rate))
+                    .frame(width: max(0, min(1, rate)) * geometry.size.width)
+            }
+        }
+        .frame(height: max(4, density.bucketBarHeight - 6))
+        .accessibilityHidden(true)
+    }
+
+    private func cacheTint(_ rate: Double) -> Color {
+        if summary.cacheHitRate == nil { return Color.secondary.opacity(0.4) }
+        if rate >= 0.6 { return .green }
+        if rate >= 0.3 { return .teal }
+        return .orange
+    }
+
+    private var costValue: String {
+        guard let micros = summary.costMicros else { return "—" }
+        return UsageFormatting.formatMicroUSD(micros)
+    }
+
+    private var componentLine: String {
+        "In \(UsageFormatting.compactTokens(summary.freshInput))"
+            + " · Out \(UsageFormatting.compactTokens(summary.output))"
+            + " · CacheW \(UsageFormatting.compactTokens(summary.cacheCreation))"
+            + " · CacheR \(UsageFormatting.compactTokens(summary.cacheRead))"
+    }
+
+    private func badge(text: String, tint: Color, help: String) -> some View {
+        Text(text)
+            .font(.system(size: max(8, density.resetCountdownFontSize - 2), weight: .semibold))
+            .foregroundStyle(tint)
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(Capsule().fill(tint.opacity(0.14)))
+            .help(help)
+    }
+
+    @ViewBuilder
+    private func tile(
+        label: String,
+        value: String,
+        @ViewBuilder detail: @escaping () -> some View
+    ) -> some View {
+        CardShell(density: density, spacing: 6) {
+            Text(label)
+                .font(.system(size: max(8, density.subtitleFontSize - 2), weight: .semibold))
+                .foregroundStyle(.tertiary)
+                .tracking(0.4)
+            Text(value)
+                .font(.system(
+                    size: density.titleFontSize + 8,
+                    weight: .bold,
+                    design: .rounded
+                ).monospacedDigit())
+                .foregroundStyle(.primary)
+                .lineLimit(1)
+                .minimumScaleFactor(0.6)
+            detail()
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .frame(maxWidth: .infinity, alignment: .topLeading)
+    }
+}

--- a/Sources/VibeBarApp/Views/Workbench/UsageStatsPage.swift
+++ b/Sources/VibeBarApp/Views/Workbench/UsageStatsPage.swift
@@ -1,0 +1,50 @@
+import SwiftUI
+import VibeBarCore
+
+/// The Workbench's Usage Stats page.
+///
+/// One scrolling column, coarse to fine: what is being counted (filters),
+/// the four headline numbers, the shape of the range over time, and finally
+/// the rows behind it. Every section is a `CardShell` at the window's density,
+/// so the page reads as the same material as the popover's cards.
+struct UsageStatsPage: View {
+    let density: Theme.Density
+    @ObservedObject var model: UsageStatsViewModel
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: density.interSectionSpacing) {
+                UsageFiltersBar(density: density, model: model)
+                if model.isLedgerAvailable {
+                    UsageHeroCards(density: density, summary: model.summary)
+                    UsageTrendChartView(density: density, series: model.trend)
+                    UsageBreakdownTables(density: density, model: model)
+                } else {
+                    unavailableCard
+                }
+            }
+            .padding(.horizontal, density.popoverPaddingH)
+            .padding(.vertical, density.popoverPaddingV)
+            .frame(maxWidth: .infinity, alignment: .topLeading)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .task { model.activate() }
+    }
+
+    private var unavailableCard: some View {
+        CardShell(density: density, alignment: .center) {
+            Image(systemName: "externaldrive.badge.exclamationmark")
+                .font(.system(size: 26, weight: .light))
+                .foregroundStyle(.secondary)
+            Text("Usage ledger unavailable")
+                .font(.system(size: density.titleFontSize, weight: .semibold))
+            Text("The per-request ledger under ~/.vibebar could not be opened, "
+                + "so only live cost cards are available this session.")
+                .font(.system(size: density.subtitleFontSize))
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: 420)
+        }
+        .frame(maxWidth: .infinity)
+    }
+}

--- a/Sources/VibeBarApp/Views/Workbench/UsageTrendChartView.swift
+++ b/Sources/VibeBarApp/Views/Workbench/UsageTrendChartView.swift
@@ -1,0 +1,430 @@
+import Charts
+import SwiftUI
+import VibeBarCore
+
+/// The four token components a request is billed on.
+///
+/// Their hues are deliberately *not* provider accents: a stacked band here
+/// means "cache read", not "Claude", and reusing the brand palette would make
+/// the two readings fight. Four widely separated semantic-ish hues instead,
+/// kept in one table so the legend, the bands, and the tooltip agree.
+enum UsageTokenSeries: String, CaseIterable, Identifiable, Hashable {
+    case freshInput
+    case output
+    case cacheCreation
+    case cacheRead
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .freshInput:    "Input"
+        case .output:        "Output"
+        case .cacheCreation: "Cache write"
+        case .cacheRead:     "Cache read"
+        }
+    }
+
+    var color: Color {
+        switch self {
+        case .freshInput:    Color(red: 0.33, green: 0.55, blue: 0.95)  // blue
+        case .output:        Color(red: 0.20, green: 0.72, blue: 0.58)  // green
+        case .cacheCreation: Color(red: 0.96, green: 0.66, blue: 0.22)  // amber
+        case .cacheRead:     Color(red: 0.62, green: 0.45, blue: 0.93)  // violet
+        }
+    }
+
+    var gradient: LinearGradient {
+        LinearGradient(
+            colors: [color.opacity(0.72), color.opacity(0.20)],
+            startPoint: .top,
+            endPoint: .bottom
+        )
+    }
+
+    func value(in point: UsageTrendPoint) -> Int64 {
+        switch self {
+        case .freshInput:    point.freshInput
+        case .output:        point.output
+        case .cacheCreation: point.cacheCreation
+        case .cacheRead:     point.cacheRead
+        }
+    }
+}
+
+/// Tokens and cost over the selected range, as two x-synchronized panes in a
+/// single card.
+///
+/// The panes are separate `Chart`s rather than one chart with two y scales —
+/// stacked token bands and a cost curve share no unit, and overlaying them
+/// would force one of the two into a scale nobody can read. They stay aligned
+/// because both pin the same leading axis-label width and the same x domain,
+/// and they share one hovered bucket, so the cursor reads both at once.
+///
+/// The range is drawn whole: no brush strip, no pan/zoom. `ChartTimeWindow`
+/// and `ChartBrushNavigator` earn their keep on the cost history card, whose
+/// domain is "everything Vibe Bar ever recorded"; here the domain *is* the
+/// filter, and the filter bar is already the navigation.
+struct UsageTrendChartView: View {
+    let density: Theme.Density
+    let series: UsageTrendSeries
+
+    @State private var hiddenSeries: Set<UsageTokenSeries> = []
+    @State private var hoveredDate: Date?
+
+    /// Floor for the leading axis-label column on both panes. Without a shared
+    /// floor the token pane ("3.40M") and the cost pane ("$12") inset their
+    /// plots differently and the two x axes stop lining up.
+    private static let axisLabelWidth: CGFloat = 46
+    private static let tooltipWidth: CGFloat = 186
+
+    private var visibleSeries: [UsageTokenSeries] {
+        UsageTokenSeries.allCases.filter { !hiddenSeries.contains($0) }
+    }
+
+    private var hasData: Bool {
+        series.points.contains { $0.totalTokens > 0 || $0.costMicros != 0 }
+    }
+
+    private var domain: ClosedRange<Date> {
+        guard let first = series.points.first?.bucketStart,
+              let last = series.points.last?.bucketStart
+        else {
+            let now = Date()
+            return now.addingTimeInterval(-3_600)...now
+        }
+        return first...max(last, first.addingTimeInterval(1))
+    }
+
+    private var hoveredPoint: UsageTrendPoint? {
+        guard let hoveredDate else { return nil }
+        return series.points.first { $0.bucketStart == hoveredDate }
+    }
+
+    var body: some View {
+        CardShell(density: density, spacing: density.cardSpacing) {
+            header
+            if hasData {
+                tokenPane
+                costPane
+            } else {
+                emptyState
+            }
+        }
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        HStack(alignment: .firstTextBaseline, spacing: 8) {
+            Text("TOKENS & COST")
+                .font(.system(size: max(8, density.subtitleFontSize - 2), weight: .semibold))
+                .foregroundStyle(.tertiary)
+                .tracking(0.4)
+            Spacer(minLength: 8)
+            legend
+        }
+    }
+
+    private var legend: some View {
+        HStack(spacing: 6) {
+            ForEach(UsageTokenSeries.allCases) { kind in
+                let visible = !hiddenSeries.contains(kind)
+                Button {
+                    toggle(kind)
+                } label: {
+                    HStack(spacing: 4) {
+                        Capsule()
+                            .fill(kind.color)
+                            .frame(width: 10, height: 4)
+                        Text(kind.title)
+                            .font(.system(size: max(8, density.segmentedFontSize - 2), weight: .semibold))
+                    }
+                    .padding(.horizontal, 7)
+                    .frame(minHeight: 20)
+                }
+                .buttonStyle(.plain)
+                .background(
+                    Capsule().fill(kind.color.opacity(visible ? 0.14 : 0.04))
+                )
+                .opacity(visible ? 1 : 0.42)
+                .saturation(visible ? 1 : 0.15)
+                .help(visible ? "Hide \(kind.title)" : "Show \(kind.title)")
+                .accessibilityAddTraits(visible ? [.isSelected] : [])
+            }
+        }
+    }
+
+    private func toggle(_ kind: UsageTokenSeries) {
+        if hiddenSeries.contains(kind) {
+            hiddenSeries.remove(kind)
+        } else if hiddenSeries.count < UsageTokenSeries.allCases.count - 1 {
+            // Never let the last band go: an empty token pane reads as "no
+            // data" rather than as "you turned everything off".
+            hiddenSeries.insert(kind)
+        }
+    }
+
+    // MARK: - Panes
+
+    private var tokenPane: some View {
+        Chart {
+            ForEach(visibleSeries) { kind in
+                ForEach(series.points, id: \.bucketStart) { point in
+                    AreaMark(
+                        x: .value("Time", point.bucketStart),
+                        y: .value("Tokens", kind.value(in: point)),
+                        series: .value("Series", kind.title),
+                        stacking: .standard
+                    )
+                    .foregroundStyle(kind.gradient)
+                }
+            }
+            if let hoveredDate {
+                RuleMark(x: .value("Time", hoveredDate))
+                    .foregroundStyle(.secondary.opacity(0.5))
+                    .lineStyle(StrokeStyle(lineWidth: 1, dash: [3, 3]))
+            }
+        }
+        .chartLegend(.hidden)
+        .chartXScale(domain: domain)
+        .chartPlotStyle { $0.clipped() }
+        .chartYAxis {
+            AxisMarks(position: .leading, values: .automatic(desiredCount: 3)) { value in
+                AxisGridLine().foregroundStyle(.secondary.opacity(0.15))
+                AxisValueLabel {
+                    if let raw = value.as(Double.self) {
+                        Text(UsageFormatting.compactTokens(Int64(raw)))
+                            .font(.system(size: 9, design: .rounded).monospacedDigit())
+                            .frame(minWidth: Self.axisLabelWidth, alignment: .trailing)
+                    }
+                }
+            }
+        }
+        .chartXAxis {
+            AxisMarks(values: .automatic(desiredCount: 5)) { _ in
+                AxisGridLine().foregroundStyle(.secondary.opacity(0.10))
+            }
+        }
+        .chartOverlay { proxy in
+            hoverSurface(proxy: proxy) { geometry in
+                if let point = hoveredPoint {
+                    tooltip(point)
+                        .offset(x: tooltipOffset(point.bucketStart, proxy: proxy, geometry: geometry))
+                }
+            }
+        }
+        .frame(height: density.overviewCostChartHeight)
+    }
+
+    private var costPane: some View {
+        Chart {
+            ForEach(series.points, id: \.bucketStart) { point in
+                AreaMark(
+                    x: .value("Time", point.bucketStart),
+                    y: .value("Cost", costUSD(point))
+                )
+                .interpolationMethod(.monotone)
+                .foregroundStyle(
+                    LinearGradient(
+                        colors: [Color.accentColor.opacity(0.20), Color.accentColor.opacity(0.02)],
+                        startPoint: .top,
+                        endPoint: .bottom
+                    )
+                )
+                LineMark(
+                    x: .value("Time", point.bucketStart),
+                    y: .value("Cost", costUSD(point))
+                )
+                .interpolationMethod(.monotone)
+                .foregroundStyle(Color.accentColor)
+                .lineStyle(StrokeStyle(lineWidth: 1.8, lineCap: .round, lineJoin: .round))
+            }
+            if let hoveredDate {
+                RuleMark(x: .value("Time", hoveredDate))
+                    .foregroundStyle(.secondary.opacity(0.5))
+                    .lineStyle(StrokeStyle(lineWidth: 1, dash: [3, 3]))
+            }
+        }
+        .chartLegend(.hidden)
+        .chartXScale(domain: domain)
+        .chartPlotStyle { $0.clipped() }
+        .chartYAxis {
+            AxisMarks(position: .leading, values: .automatic(desiredCount: 2)) { value in
+                AxisGridLine().foregroundStyle(.secondary.opacity(0.15))
+                AxisValueLabel {
+                    if let raw = value.as(Double.self) {
+                        Text(UsageFormatting.formatMicroUSD(Int64(raw * 1_000_000)))
+                            .font(.system(size: 9, design: .rounded).monospacedDigit())
+                            .frame(minWidth: Self.axisLabelWidth, alignment: .trailing)
+                    }
+                }
+            }
+        }
+        .chartXAxis {
+            AxisMarks(values: .automatic(desiredCount: 5)) { _ in
+                AxisGridLine().foregroundStyle(.secondary.opacity(0.10))
+                AxisValueLabel(format: axisFormat)
+                    .font(.system(size: 9))
+            }
+        }
+        .chartOverlay { proxy in
+            hoverSurface(proxy: proxy) { geometry in
+                if let point = hoveredPoint {
+                    costPill(point)
+                        .offset(x: costPillOffset(point.bucketStart, proxy: proxy, geometry: geometry))
+                }
+            }
+        }
+        .frame(height: max(88, density.overviewCostChartHeight * 0.5))
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: 6) {
+            Image(systemName: "chart.xyaxis.line")
+                .font(.system(size: 22, weight: .light))
+                .foregroundStyle(.tertiary)
+            Text("No usage recorded in this range")
+                .font(.system(size: density.subtitleFontSize))
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity)
+        .frame(height: density.overviewCostChartHeight)
+    }
+
+    // MARK: - Hover
+
+    /// One hover surface, mounted on both panes. Whichever pane the cursor is
+    /// over writes the same `hoveredDate`, so the rule and the readouts move
+    /// together instead of each pane tracking its own cursor.
+    private func hoverSurface(
+        proxy: ChartProxy,
+        @ViewBuilder overlay: @escaping (GeometryProxy) -> some View
+    ) -> some View {
+        GeometryReader { geometry in
+            let plotMinX = proxy.plotFrame.map { geometry[$0].minX } ?? 0
+            ZStack(alignment: .topLeading) {
+                Rectangle()
+                    .fill(Color.clear)
+                    .contentShape(Rectangle())
+                    .onContinuousHover { phase in
+                        switch phase {
+                        case .active(let location):
+                            if let date: Date = proxy.value(
+                                atX: location.x - plotMinX, as: Date.self
+                            ) {
+                                hoveredDate = nearestBucket(to: date)
+                            }
+                        case .ended:
+                            hoveredDate = nil
+                        }
+                    }
+                overlay(geometry)
+                    .allowsHitTesting(false)
+            }
+        }
+    }
+
+    private func nearestBucket(to date: Date) -> Date? {
+        series.points
+            .min { lhs, rhs in
+                abs(lhs.bucketStart.timeIntervalSince(date))
+                    < abs(rhs.bucketStart.timeIntervalSince(date))
+            }?
+            .bucketStart
+    }
+
+    private func tooltip(_ point: UsageTrendPoint) -> some View {
+        VStack(alignment: .leading, spacing: 3) {
+            HStack(spacing: 8) {
+                Text(tooltipDate(point.bucketStart))
+                    .font(.system(size: 10, weight: .semibold))
+                Spacer(minLength: 4)
+                Text(UsageFormatting.formatMicroUSD(point.costMicros))
+                    .font(.system(size: 10, weight: .semibold, design: .rounded).monospacedDigit())
+            }
+            Divider().opacity(0.3)
+            ForEach(UsageTokenSeries.allCases) { kind in
+                HStack(spacing: 6) {
+                    Capsule()
+                        .fill(kind.color)
+                        .frame(width: 8, height: 4)
+                    Text(kind.title)
+                        .font(.system(size: 9))
+                        .foregroundStyle(hiddenSeries.contains(kind) ? .tertiary : .secondary)
+                    Spacer(minLength: 4)
+                    Text(UsageFormatting.compactTokens(kind.value(in: point)))
+                        .font(.system(size: 9, design: .rounded).monospacedDigit())
+                }
+            }
+        }
+        .padding(.horizontal, 9)
+        .padding(.vertical, 7)
+        .frame(width: Self.tooltipWidth)
+        .glassEffect(.regular, in: .rect(cornerRadius: 10))
+        .padding(.top, 4)
+    }
+
+    private func costPill(_ point: UsageTrendPoint) -> some View {
+        Text(UsageFormatting.formatMicroUSD(point.costMicros))
+            .font(.system(size: 10, weight: .semibold, design: .rounded).monospacedDigit())
+            .padding(.horizontal, 9)
+            .frame(minHeight: 20)
+            .glassEffect(.regular, in: .capsule)
+            .padding(.top, 4)
+    }
+
+    private func tooltipOffset(
+        _ date: Date,
+        proxy: ChartProxy,
+        geometry: GeometryProxy
+    ) -> CGFloat {
+        offset(date, proxy: proxy, geometry: geometry, width: Self.tooltipWidth)
+    }
+
+    private func costPillOffset(
+        _ date: Date,
+        proxy: ChartProxy,
+        geometry: GeometryProxy
+    ) -> CGFloat {
+        offset(date, proxy: proxy, geometry: geometry, width: 70)
+    }
+
+    private func offset(
+        _ date: Date,
+        proxy: ChartProxy,
+        geometry: GeometryProxy,
+        width: CGFloat
+    ) -> CGFloat {
+        let plotMinX = proxy.plotFrame.map { geometry[$0].minX } ?? 0
+        let x = (proxy.position(forX: date) ?? 0) + plotMinX
+        return min(max(0, x - width / 2), max(0, geometry.size.width - width))
+    }
+
+    // MARK: - Formatting
+
+    private func costUSD(_ point: UsageTrendPoint) -> Double {
+        Double(point.costMicros) / 1_000_000
+    }
+
+    private var axisFormat: Date.FormatStyle {
+        series.bucket == .hour
+            ? .dateTime.hour()
+            : .dateTime.month(.abbreviated).day()
+    }
+
+    private func tooltipDate(_ date: Date) -> String {
+        let formatter = series.bucket == .hour ? Self.hourFormatter : Self.dayFormatter
+        return formatter.string(from: date)
+    }
+
+    private static let hourFormatter = localizedFormatter("MMMd HH:mm")
+    private static let dayFormatter = localizedFormatter("EEEMMMd")
+
+    private static func localizedFormatter(_ template: String) -> DateFormatter {
+        let formatter = DateFormatter()
+        formatter.locale = Locale.current
+        formatter.setLocalizedDateFormatFromTemplate(template)
+        return formatter
+    }
+}

--- a/Sources/VibeBarApp/Views/Workbench/WorkbenchPlaceholderPage.swift
+++ b/Sources/VibeBarApp/Views/Workbench/WorkbenchPlaceholderPage.swift
@@ -1,0 +1,37 @@
+import SwiftUI
+
+/// Stand-in detail page for Workbench sections that have no content yet.
+struct WorkbenchPlaceholderPage: View {
+    let page: WorkbenchPage
+    let density: Theme.Density
+
+    var body: some View {
+        CardShell(density: density, alignment: .center) {
+            Image(systemName: page.systemImage)
+                .font(.system(size: 30, weight: .light))
+                .foregroundStyle(.secondary)
+            Text(page.title)
+                .font(.system(size: 15, weight: .semibold))
+                .foregroundStyle(.primary)
+            Text(detail)
+                .font(.system(size: 12))
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: 380)
+        }
+        .frame(maxWidth: 520)
+        .padding(density.popoverPaddingH)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private var detail: String {
+        switch page {
+        case .usageStats:
+            "Full-window usage and cost analytics are on their way."
+        case .sessionManager:
+            "Browsing and searching local Codex and Claude Code sessions is on its way."
+        case .skillsManager:
+            "Reviewing and organizing installed agent skills is on its way."
+        }
+    }
+}

--- a/Sources/VibeBarApp/Views/Workbench/WorkbenchRootView.swift
+++ b/Sources/VibeBarApp/Views/Workbench/WorkbenchRootView.swift
@@ -1,0 +1,70 @@
+import SwiftUI
+import VibeBarCore
+
+enum WorkbenchPage: String, CaseIterable, Identifiable {
+    case usageStats
+    case sessionManager
+    case skillsManager
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .usageStats: "Usage Stats"
+        case .sessionManager: "Sessions"
+        case .skillsManager: "Skills"
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .usageStats: "chart.xyaxis.line"
+        case .sessionManager: "bubble.left.and.text.bubble.right"
+        case .skillsManager: "puzzlepiece.extension"
+        }
+    }
+}
+
+/// Top-level content for the standalone Workbench window.
+///
+/// The selected page lives in `UserDefaults` rather than `AppSettings`: it is
+/// window state, not a preference, and writing it through the settings store
+/// would fan a page switch out to the menu bar renderer and every popover
+/// subscriber.
+struct WorkbenchRootView: View {
+    let initialPage: WorkbenchPage?
+
+    @EnvironmentObject private var settingsStore: SettingsStore
+    @AppStorage("workbench.selectedPage") private var storedPage: String = WorkbenchPage.usageStats.rawValue
+    @State private var selection: WorkbenchPage?
+
+    private var page: WorkbenchPage {
+        selection ?? .usageStats
+    }
+
+    var body: some View {
+        // One density for the whole window, resolved once: pages share the
+        // popover's card metrics so a card looks the same in both surfaces.
+        let density = Theme.overviewDensity(for: settingsStore.settings.popoverDensity)
+        NavigationSplitView {
+            List(selection: $selection) {
+                ForEach(WorkbenchPage.allCases) { page in
+                    Label(page.title, systemImage: page.systemImage)
+                        .tag(page)
+                }
+            }
+            .navigationSplitViewColumnWidth(min: 188, ideal: 208, max: 268)
+        } detail: {
+            WorkbenchPlaceholderPage(page: page, density: density)
+                .navigationTitle(page.title)
+        }
+        .onAppear {
+            guard selection == nil else { return }
+            selection = initialPage ?? WorkbenchPage(rawValue: storedPage) ?? .usageStats
+        }
+        .onChange(of: selection) { _, newValue in
+            guard let newValue else { return }
+            storedPage = newValue.rawValue
+        }
+    }
+}

--- a/Sources/VibeBarApp/Views/Workbench/WorkbenchRootView.swift
+++ b/Sources/VibeBarApp/Views/Workbench/WorkbenchRootView.swift
@@ -35,6 +35,7 @@ struct WorkbenchRootView: View {
     let initialPage: WorkbenchPage?
 
     @EnvironmentObject private var settingsStore: SettingsStore
+    @EnvironmentObject private var workbench: WorkbenchServices
     @AppStorage("workbench.selectedPage") private var storedPage: String = WorkbenchPage.usageStats.rawValue
     @State private var selection: WorkbenchPage?
 
@@ -55,7 +56,7 @@ struct WorkbenchRootView: View {
             }
             .navigationSplitViewColumnWidth(min: 188, ideal: 208, max: 268)
         } detail: {
-            WorkbenchPlaceholderPage(page: page, density: density)
+            detail(for: page, density: density)
                 .navigationTitle(page.title)
         }
         .onAppear {
@@ -65,6 +66,16 @@ struct WorkbenchRootView: View {
         .onChange(of: selection) { _, newValue in
             guard let newValue else { return }
             storedPage = newValue.rawValue
+        }
+    }
+
+    @ViewBuilder
+    private func detail(for page: WorkbenchPage, density: Theme.Density) -> some View {
+        switch page {
+        case .usageStats:
+            UsageStatsPage(density: density, model: workbench.usageStats)
+        case .sessionManager, .skillsManager:
+            WorkbenchPlaceholderPage(page: page, density: density)
         }
     }
 }

--- a/Sources/VibeBarCore/Models/UsageEventFileBatch.swift
+++ b/Sources/VibeBarCore/Models/UsageEventFileBatch.swift
@@ -1,0 +1,88 @@
+import Foundation
+
+/// One scanned event plus the price the cost pipeline put on it.
+///
+/// `costMicros` is `nil` when the event could not be priced at all — an
+/// unknown model, a provider with no rate table, or a `totals`-only record.
+/// A `nil` is deliberately *not* collapsed to `0`: the ledger counts those
+/// rows separately so a usage UI can say "spend excludes N unpriced
+/// requests" instead of quietly under-reporting.
+public struct PricedUsageEvent: Sendable, Equatable {
+    public let event: CostUsageScanCache.ParsedEvent
+    public let costMicros: Int64?
+
+    public init(event: CostUsageScanCache.ParsedEvent, costMicros: Int64?) {
+        self.event = event
+        self.costMicros = costMicros
+    }
+
+    /// The single place a `Double` cost becomes money. Everything
+    /// downstream — storage, sums, averages — is `Int64` micro-USD.
+    public init(event: CostUsageScanCache.ParsedEvent, costUSD: Double?) {
+        self.init(event: event, costMicros: costUSD.flatMap(Self.micros(fromUSD:)))
+    }
+
+    static func micros(fromUSD usd: Double) -> Int64? {
+        let scaled = (usd * 1_000_000).rounded()
+        guard scaled.isFinite,
+              scaled >= Double(Int64.min),
+              scaled <= Double(Int64.max)
+        else { return nil }
+        return Int64(scaled)
+    }
+
+    public static func == (lhs: PricedUsageEvent, rhs: PricedUsageEvent) -> Bool {
+        lhs.costMicros == rhs.costMicros
+            && lhs.event.date == rhs.event.date
+            && lhs.event.model == rhs.event.model
+            && lhs.event.input == rhs.event.input
+            && lhs.event.output == rhs.event.output
+            && lhs.event.cache == rhs.event.cache
+            && lhs.event.cacheCreation == rhs.event.cacheCreation
+            && lhs.event.messageId == rhs.event.messageId
+            && lhs.event.requestId == rhs.event.requestId
+    }
+}
+
+/// Everything `CostUsageScanner` finished with for one source file.
+///
+/// `mtime` / `size` are the same fingerprint `CostUsageScanCache` uses, so
+/// a sink can skip a file it has already ingested without re-reading it.
+public struct UsageEventFileBatch: Sendable {
+    public let tool: ToolType
+    public let filePath: String
+    public let mtime: Date
+    public let size: Int64
+    public let events: [PricedUsageEvent]
+
+    /// Sentinel `size` for a batch whose events came from a stale cache
+    /// fallback rather than from the file on disk (the AntiGravity `.pb`
+    /// path when the language server is not reachable). A real fingerprint
+    /// can never be negative, so recording this value keeps repeated stale
+    /// emissions idempotent while still letting the first *real* batch for
+    /// the same file re-ingest.
+    public static let staleFallbackSize: Int64 = -1
+
+    public init(
+        tool: ToolType,
+        filePath: String,
+        mtime: Date,
+        size: Int64,
+        events: [PricedUsageEvent]
+    ) {
+        self.tool = tool
+        self.filePath = filePath
+        self.mtime = mtime
+        self.size = size
+        self.events = events
+    }
+}
+
+/// Receiver for per-file scan output.
+///
+/// `CostUsageScanner` calls this once per source file, for freshly parsed
+/// *and* cache-reused files, so a sink attached to an empty store still
+/// backfills from a warm scan cache on the very first pass.
+public protocol CostUsageEventSink: Sendable {
+    func consume(_ batch: UsageEventFileBatch) async
+}

--- a/Sources/VibeBarCore/Models/UsageQueryModels.swift
+++ b/Sources/VibeBarCore/Models/UsageQueryModels.swift
@@ -1,0 +1,275 @@
+import Foundation
+
+/// Query surface for the per-request usage ledger (`UsageEventLedger`).
+///
+/// Every type here is a plain value: the ledger is an actor, so query
+/// results have to cross an isolation boundary and must be `Sendable`.
+/// Money is always `Int64` micro-USD (1 USD = 1_000_000 micros) — the
+/// ledger never stores or sums a `Double`, so totals over millions of
+/// requests stay exact. Formatting back to a `$x.yz` string is
+/// `UsageFormatting`'s job.
+
+// MARK: - Filter
+
+/// Range + optional provider / model narrowing applied to every query.
+///
+/// `range` is half-open: `start` inclusive, `end` exclusive.
+/// A `nil` list means "no restriction"; an *empty* list means "nothing
+/// matches" and every query returns an empty result for it.
+public struct UsageQueryFilter: Sendable, Equatable {
+    public var range: DateInterval
+    public var tools: [ToolType]?
+    public var models: [String]?
+
+    public init(range: DateInterval, tools: [ToolType]? = nil, models: [String]? = nil) {
+        self.range = range
+        self.tools = tools
+        self.models = models
+    }
+}
+
+// MARK: - Trend bucketing
+
+public enum UsageTrendBucket: String, Sendable, Equatable, CaseIterable, Codable {
+    case hour
+    case day
+
+    /// A day of history or less is drawn per hour; anything wider is drawn
+    /// per local calendar day. Kept as a static rule rather than a UI
+    /// decision so the ledger, the chart, and the tests all agree.
+    public static func recommended(for range: DateInterval) -> UsageTrendBucket {
+        range.duration <= 24 * 60 * 60 ? .hour : .day
+    }
+}
+
+// MARK: - Summary
+
+/// Headline metrics over a filter.
+///
+/// Token columns are already normalized by the ledger: `freshInput` is
+/// non-cached prompt tokens, `cacheRead` is cache hits, `cacheCreation` is
+/// cache writes. They never overlap, so they can be summed freely.
+public struct UsageSummaryMetrics: Sendable, Equatable {
+    public let requests: Int
+    /// Requests whose provider/model had no usable price. They contribute
+    /// `0` to `costMicros`; this counter is how a UI says "3 of 40 requests
+    /// are unpriced" instead of silently under-reporting spend.
+    public let unpricedRequests: Int
+    /// `nil` only when *no* row in range carried a price at all. A mix of
+    /// priced and unpriced rows still reports the priced subtotal.
+    public let costMicros: Int64?
+    public let freshInput: Int64
+    public let output: Int64
+    public let cacheRead: Int64
+    public let cacheCreation: Int64
+
+    public init(
+        requests: Int,
+        unpricedRequests: Int,
+        costMicros: Int64?,
+        freshInput: Int64,
+        output: Int64,
+        cacheRead: Int64,
+        cacheCreation: Int64
+    ) {
+        self.requests = requests
+        self.unpricedRequests = unpricedRequests
+        self.costMicros = costMicros
+        self.freshInput = freshInput
+        self.output = output
+        self.cacheRead = cacheRead
+        self.cacheCreation = cacheCreation
+    }
+
+    public static let empty = UsageSummaryMetrics(
+        requests: 0,
+        unpricedRequests: 0,
+        costMicros: nil,
+        freshInput: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheCreation: 0
+    )
+
+    /// Every token the provider actually moved, cache hits included.
+    public var realTotalTokens: Int64 {
+        freshInput + output + cacheCreation + cacheRead
+    }
+
+    /// Share of *input-side* tokens served from cache. Output tokens are
+    /// deliberately excluded — they are never cacheable, and folding them in
+    /// would make a chatty session look like a cache miss. `nil` when there
+    /// was no input-side traffic at all.
+    public var cacheHitRate: Double? {
+        let denominator = freshInput + cacheCreation + cacheRead
+        guard denominator > 0 else { return nil }
+        return Double(cacheRead) / Double(denominator)
+    }
+}
+
+// MARK: - Trend series
+
+public struct UsageTrendPoint: Sendable, Equatable {
+    public let bucketStart: Date
+    public let freshInput: Int64
+    public let output: Int64
+    public let cacheRead: Int64
+    public let cacheCreation: Int64
+    public let costMicros: Int64
+
+    public init(
+        bucketStart: Date,
+        freshInput: Int64,
+        output: Int64,
+        cacheRead: Int64,
+        cacheCreation: Int64,
+        costMicros: Int64
+    ) {
+        self.bucketStart = bucketStart
+        self.freshInput = freshInput
+        self.output = output
+        self.cacheRead = cacheRead
+        self.cacheCreation = cacheCreation
+        self.costMicros = costMicros
+    }
+
+    public var totalTokens: Int64 {
+        freshInput + output + cacheRead + cacheCreation
+    }
+}
+
+/// Zero-filled series: every bucket between the filter's `start` and `end`
+/// is present, including the empty ones, so a chart never has to invent
+/// gaps.
+public struct UsageTrendSeries: Sendable, Equatable {
+    public let bucket: UsageTrendBucket
+    public let points: [UsageTrendPoint]
+
+    public init(bucket: UsageTrendBucket, points: [UsageTrendPoint]) {
+        self.bucket = bucket
+        self.points = points
+    }
+}
+
+// MARK: - Request log
+
+public struct UsageRequestRow: Sendable, Equatable, Identifiable {
+    public let id: Int64
+    public let date: Date
+    public let tool: ToolType
+    public let model: String
+    public let freshInput: Int64
+    public let output: Int64
+    public let cacheRead: Int64
+    public let cacheCreation: Int64
+    public let costMicros: Int64?
+    public let serviceTier: String?
+    public let sessionId: String?
+    public let sourceKey: String?
+
+    public init(
+        id: Int64,
+        date: Date,
+        tool: ToolType,
+        model: String,
+        freshInput: Int64,
+        output: Int64,
+        cacheRead: Int64,
+        cacheCreation: Int64,
+        costMicros: Int64?,
+        serviceTier: String?,
+        sessionId: String?,
+        sourceKey: String?
+    ) {
+        self.id = id
+        self.date = date
+        self.tool = tool
+        self.model = model
+        self.freshInput = freshInput
+        self.output = output
+        self.cacheRead = cacheRead
+        self.cacheCreation = cacheCreation
+        self.costMicros = costMicros
+        self.serviceTier = serviceTier
+        self.sessionId = sessionId
+        self.sourceKey = sourceKey
+    }
+
+    public var totalTokens: Int64 {
+        freshInput + output + cacheRead + cacheCreation
+    }
+}
+
+/// One page of the request log. `page` is **zero-based**; a page past the
+/// end is not an error, it just comes back with no rows and the real
+/// `totalCount`.
+public struct UsageRequestPage: Sendable, Equatable {
+    public let rows: [UsageRequestRow]
+    public let totalCount: Int
+    public let page: Int
+    public let pageSize: Int
+
+    public init(rows: [UsageRequestRow], totalCount: Int, page: Int, pageSize: Int) {
+        self.rows = rows
+        self.totalCount = totalCount
+        self.page = page
+        self.pageSize = pageSize
+    }
+
+    public var pageCount: Int {
+        guard pageSize > 0 else { return 0 }
+        return (totalCount + pageSize - 1) / pageSize
+    }
+}
+
+// MARK: - Grouped stats
+
+public struct UsageProviderStat: Sendable, Equatable, Identifiable {
+    public let tool: ToolType
+    public let requests: Int
+    public let totalTokens: Int64
+    public let costMicros: Int64
+
+    public var id: ToolType { tool }
+
+    public init(tool: ToolType, requests: Int, totalTokens: Int64, costMicros: Int64) {
+        self.tool = tool
+        self.requests = requests
+        self.totalTokens = totalTokens
+        self.costMicros = costMicros
+    }
+}
+
+public struct UsageModelStat: Sendable, Equatable, Identifiable {
+    public let model: String
+    public let requests: Int
+    public let totalTokens: Int64
+    public let costMicros: Int64
+    /// Integer micro-USD, half-up rounded. Zero when `requests == 0`.
+    public let avgCostMicrosPerRequest: Int64
+
+    public var id: String { model }
+
+    public init(
+        model: String,
+        requests: Int,
+        totalTokens: Int64,
+        costMicros: Int64,
+        avgCostMicrosPerRequest: Int64
+    ) {
+        self.model = model
+        self.requests = requests
+        self.totalTokens = totalTokens
+        self.costMicros = costMicros
+        self.avgCostMicrosPerRequest = avgCostMicrosPerRequest
+    }
+
+    /// Half-up integer average, kept out of `Double` so a long tail of
+    /// cheap requests can't drift the reported per-request cost.
+    public static func averageMicros(total: Int64, requests: Int) -> Int64 {
+        guard requests > 0 else { return 0 }
+        let count = Int64(requests)
+        if total >= 0 { return (total + count / 2) / count }
+        return -((-total + count / 2) / count)
+    }
+}

--- a/Sources/VibeBarCore/Services/CostUsageScanner.swift
+++ b/Sources/VibeBarCore/Services/CostUsageScanner.swift
@@ -13,23 +13,31 @@ import Foundation
 ///   Each assistant message has `message.usage`; we sum per-message and bucket
 ///   by message timestamp.
 public enum CostUsageScanner {
+    /// - Parameter eventSink: Optional receiver for the per-request events
+    ///   behind the returned snapshot. One batch is emitted per source file,
+    ///   for cache-reused files as well as freshly parsed ones, so a sink
+    ///   attached to an empty store backfills from a warm scan cache on its
+    ///   first pass. Each event carries the same cost the aggregator used,
+    ///   converted once to `Int64` micro-USD (`nil` when unpriceable). When
+    ///   the sink is `nil` the scan behaves exactly as before.
     public static func scan(
         tool: ToolType,
         homeDirectory: String = RealHomeDirectory.path,
         now: Date = Date(),
-        retentionDays: Int? = nil
+        retentionDays: Int? = nil,
+        eventSink: (any CostUsageEventSink)? = nil
     ) async -> CostSnapshot? {
         switch tool {
         case .codex:
-            return await scanCodex(homeDirectory: homeDirectory, now: now, retentionDays: retentionDays)
+            return await scanCodex(homeDirectory: homeDirectory, now: now, retentionDays: retentionDays, eventSink: eventSink)
         case .claude:
-            return await scanClaude(homeDirectory: homeDirectory, now: now, retentionDays: retentionDays)
+            return await scanClaude(homeDirectory: homeDirectory, now: now, retentionDays: retentionDays, eventSink: eventSink)
         case .gemini:
-            return await scanGemini(homeDirectory: homeDirectory, now: now, retentionDays: retentionDays)
+            return await scanGemini(homeDirectory: homeDirectory, now: now, retentionDays: retentionDays, eventSink: eventSink)
         case .grok:
-            return await scanGrok(homeDirectory: homeDirectory, now: now, retentionDays: retentionDays)
+            return await scanGrok(homeDirectory: homeDirectory, now: now, retentionDays: retentionDays, eventSink: eventSink)
         case .antigravity:
-            return await scanAntigravity(homeDirectory: homeDirectory, now: now, retentionDays: retentionDays)
+            return await scanAntigravity(homeDirectory: homeDirectory, now: now, retentionDays: retentionDays, eventSink: eventSink)
         case .alibaba, .alibabaTokenPlan, .copilot, .zai, .minimax, .kimi, .cursor, .mimo, .iflytek, .tencentHunyuan, .tencentTokenPlan, .volcengine, .volcengineAgentPlan, .baiduQianfan, .openCodeGo, .kilo, .kiro, .ollama, .openRouter, .warp:
             // Misc providers don't expose token-level cost data through
             // any documented public protocol. The cost-history pipeline
@@ -45,7 +53,8 @@ public enum CostUsageScanner {
     private static func scanCodex(
         homeDirectory: String,
         now: Date,
-        retentionDays: Int?
+        retentionDays: Int?,
+        eventSink: (any CostUsageEventSink)? = nil
     ) async -> CostSnapshot {
         let roots = [
             URL(fileURLWithPath: homeDirectory).appendingPathComponent(".codex/sessions"),
@@ -67,11 +76,18 @@ public enum CostUsageScanner {
                 if retained.count != cached.count {
                     cache.store(retained, for: file.path, mtime: mtime, size: size)
                 }
+                var priced: [PricedUsageEvent] = []
+                priced.reserveCapacity(eventSink == nil ? 0 : retained.count)
                 for event in retained {
-                    let cost = costUSD(tool: .codex, event: event, codexFastTier: codexFastTier)
+                    let optionalCost = costUSDIfPriceable(tool: .codex, event: event, codexFastTier: codexFastTier)
+                    let cost = optionalCost ?? 0
+                    if eventSink != nil {
+                        priced.append(PricedUsageEvent(event: event, costUSD: optionalCost))
+                    }
                     aggregator.add(at: event.date, model: event.model, input: event.input,
                                    output: event.output, cache: event.cache, costUSD: cost)
                 }
+                await emit(eventSink, tool: .codex, file: file, mtime: mtime, size: size, events: priced)
                 continue
             }
 
@@ -79,6 +95,7 @@ public enum CostUsageScanner {
             // Delta from one snapshot to the next is what was used in that interval.
             var previous: CodexEvent.Totals? = nil
             var parsed: [CostUsageScanCache.ParsedEvent] = []
+            var priced: [PricedUsageEvent] = []
             parsed.reserveCapacity(raw.count)
             for event in raw {
                 let delta: CodexEvent.Totals
@@ -93,13 +110,14 @@ public enum CostUsageScanner {
                 }
                 previous = event.totals
                 if delta.isEmpty { continue }
-                let cost = CostUsagePricing.codexCostUSD(
+                let optionalCost = CostUsagePricing.codexCostUSD(
                     model: event.model,
                     inputTokens: delta.input,
                     cachedInputTokens: delta.cached,
                     outputTokens: delta.output,
                     isFast: codexFastTier
-                ) ?? 0
+                )
+                let cost = optionalCost ?? 0
                 let parsedEvent = CostUsageScanCache.ParsedEvent(
                     date: event.date,
                     model: event.model,
@@ -109,11 +127,15 @@ public enum CostUsageScanner {
                 )
                 guard isRetained(parsedEvent.date, cutoff: cutoff) else { continue }
                 parsed.append(parsedEvent)
+                if eventSink != nil {
+                    priced.append(PricedUsageEvent(event: parsedEvent, costUSD: optionalCost))
+                }
                 aggregator.add(at: parsedEvent.date, model: parsedEvent.model,
                                input: parsedEvent.input, output: parsedEvent.output,
                                cache: parsedEvent.cache, costUSD: cost)
             }
             cache.store(parsed, for: file.path, mtime: mtime, size: size)
+            await emit(eventSink, tool: .codex, file: file, mtime: mtime, size: size, events: priced)
         }
         cache.prune(known: Set(files.map(\.path)))
         cache.save(homeDirectory: homeDirectory, tool: .codex)
@@ -185,7 +207,8 @@ public enum CostUsageScanner {
     private static func scanClaude(
         homeDirectory: String,
         now: Date,
-        retentionDays: Int?
+        retentionDays: Int?,
+        eventSink: (any CostUsageEventSink)? = nil
     ) async -> CostSnapshot {
         let projectsRoot = URL(fileURLWithPath: homeDirectory).appendingPathComponent(".claude/projects")
         let altRoot = URL(fileURLWithPath: homeDirectory).appendingPathComponent(".config/claude/projects")
@@ -203,6 +226,7 @@ public enum CostUsageScanner {
                     cache.store(retained, for: file.path, mtime: mtime, size: size)
                 }
                 allEvents.append(contentsOf: retained)
+                await emitClaude(eventSink, file: file, mtime: mtime, size: size, events: retained)
                 continue
             }
 
@@ -263,11 +287,13 @@ public enum CostUsageScanner {
             }
             guard didRead else {
                 cache.store([], for: file.path, mtime: mtime, size: size)
+                await emitClaude(eventSink, file: file, mtime: mtime, size: size, events: [])
                 continue
             }
             let parsed = keyedRows.keys.sorted().compactMap { keyedRows[$0] } + unkeyedRows
             cache.store(parsed, for: file.path, mtime: mtime, size: size)
             allEvents.append(contentsOf: parsed)
+            await emitClaude(eventSink, file: file, mtime: mtime, size: size, events: parsed)
         }
         cache.prune(known: Set(files.map(\.path)))
         cache.save(homeDirectory: homeDirectory, tool: .claude)
@@ -316,7 +342,8 @@ public enum CostUsageScanner {
     private static func scanGemini(
         homeDirectory: String,
         now: Date,
-        retentionDays: Int?
+        retentionDays: Int?,
+        eventSink: (any CostUsageEventSink)? = nil
     ) async -> CostSnapshot {
         let telemetryCandidates = geminiTelemetryFileCandidates(homeDirectory: homeDirectory)
         let chatCandidates = geminiChatFileCandidates(homeDirectory: homeDirectory)
@@ -334,24 +361,31 @@ public enum CostUsageScanner {
                 if retained.count != cached.count {
                     cache.store(retained, for: file.path, mtime: mtime, size: size)
                 }
+                var priced: [PricedUsageEvent] = []
+                priced.reserveCapacity(eventSink == nil ? 0 : retained.count)
                 for event in retained {
-                    let cost = costUSD(tool: .gemini, event: event)
+                    let optionalCost = costUSDIfPriceable(tool: .gemini, event: event)
+                    if eventSink != nil {
+                        priced.append(PricedUsageEvent(event: event, costUSD: optionalCost))
+                    }
                     aggregator.add(at: event.date, model: event.model, input: event.input,
-                                   output: event.output, cache: event.cache, costUSD: cost)
+                                   output: event.output, cache: event.cache, costUSD: optionalCost ?? 0)
                 }
+                await emit(eventSink, tool: .gemini, file: file, mtime: mtime, size: size, events: priced)
                 continue
             }
 
             let isChatFile = file.path.contains("/chats/")
-            let parsed: [CostUsageScanCache.ParsedEvent]
+            let priced: [PricedUsageEvent]
             let didRead: Bool
             if isChatFile {
-                (parsed, didRead) = parseGeminiChatFile(file: file, cutoff: cutoff, aggregator: &aggregator)
+                (priced, didRead) = parseGeminiChatFile(file: file, cutoff: cutoff, aggregator: &aggregator)
             } else {
-                (parsed, didRead) = parseGeminiTelemetryFile(file: file, now: now, cutoff: cutoff, aggregator: &aggregator)
+                (priced, didRead) = parseGeminiTelemetryFile(file: file, now: now, cutoff: cutoff, aggregator: &aggregator)
             }
             if didRead {
-                cache.store(parsed, for: file.path, mtime: mtime, size: size)
+                cache.store(priced.map(\.event), for: file.path, mtime: mtime, size: size)
+                await emit(eventSink, tool: .gemini, file: file, mtime: mtime, size: size, events: priced)
             }
         }
         cache.prune(known: Set(allFiles.map(\.path)))
@@ -369,8 +403,8 @@ public enum CostUsageScanner {
         now: Date,
         cutoff: Date?,
         aggregator: inout CostAggregator
-    ) -> ([CostUsageScanCache.ParsedEvent], Bool) {
-        var parsed: [CostUsageScanCache.ParsedEvent] = []
+    ) -> ([PricedUsageEvent], Bool) {
+        var parsed: [PricedUsageEvent] = []
         let fileMTimeFallback = fileMTime(file) ?? now
         let didRead = forEachJSONLLine(in: file) { lineData in
             guard !lineData.isEmpty,
@@ -408,16 +442,16 @@ public enum CostUsageScanner {
                 messageId: promptId
             )
             guard isRetained(parsedEvent.date, cutoff: cutoff) else { return }
-            parsed.append(parsedEvent)
-            let cost = CostUsagePricing.geminiCostUSD(
+            let optionalCost = CostUsagePricing.geminiCostUSD(
                 model: model,
                 inputTokens: input,
                 cacheReadInputTokens: cached,
                 outputTokens: output
-            ) ?? 0
+            )
+            parsed.append(PricedUsageEvent(event: parsedEvent, costUSD: optionalCost))
             aggregator.add(at: parsedEvent.date, model: parsedEvent.model,
                            input: parsedEvent.input, output: parsedEvent.output,
-                           cache: parsedEvent.cache, costUSD: cost)
+                           cache: parsedEvent.cache, costUSD: optionalCost ?? 0)
         }
         return (parsed, didRead)
     }
@@ -433,8 +467,8 @@ public enum CostUsageScanner {
         file: URL,
         cutoff: Date?,
         aggregator: inout CostAggregator
-    ) -> ([CostUsageScanCache.ParsedEvent], Bool) {
-        var parsed: [CostUsageScanCache.ParsedEvent] = []
+    ) -> ([PricedUsageEvent], Bool) {
+        var parsed: [PricedUsageEvent] = []
         var sessionIdFromHeader: String? = nil
         let didRead = forEachJSONLLine(in: file) { lineData in
             guard !lineData.isEmpty,
@@ -472,16 +506,16 @@ public enum CostUsageScanner {
                 messageId: raw["id"] as? String
             )
             guard isRetained(parsedEvent.date, cutoff: cutoff) else { return }
-            parsed.append(parsedEvent)
-            let cost = CostUsagePricing.geminiCostUSD(
+            let optionalCost = CostUsagePricing.geminiCostUSD(
                 model: model,
                 inputTokens: inputTotal,
                 cacheReadInputTokens: cached,
                 outputTokens: outputBilled
-            ) ?? 0
+            )
+            parsed.append(PricedUsageEvent(event: parsedEvent, costUSD: optionalCost))
             aggregator.add(at: parsedEvent.date, model: parsedEvent.model,
                            input: parsedEvent.input, output: parsedEvent.output,
-                           cache: parsedEvent.cache, costUSD: cost)
+                           cache: parsedEvent.cache, costUSD: optionalCost ?? 0)
         }
         return (parsed, didRead)
     }
@@ -611,7 +645,8 @@ public enum CostUsageScanner {
     private static func scanGrok(
         homeDirectory: String,
         now: Date,
-        retentionDays: Int?
+        retentionDays: Int?,
+        eventSink: (any CostUsageEventSink)? = nil
     ) async -> CostSnapshot {
         let root = URL(fileURLWithPath: homeDirectory)
             .appendingPathComponent(".grok/sessions")
@@ -627,16 +662,23 @@ public enum CostUsageScanner {
                 if retained.count != cached.count {
                     cache.store(retained, for: file.path, mtime: mtime, size: size)
                 }
+                var priced: [PricedUsageEvent] = []
+                priced.reserveCapacity(eventSink == nil ? 0 : retained.count)
                 for event in retained {
-                    let cost = costUSD(tool: .grok, event: event)
+                    let optionalCost = costUSDIfPriceable(tool: .grok, event: event)
+                    if eventSink != nil {
+                        priced.append(PricedUsageEvent(event: event, costUSD: optionalCost))
+                    }
                     aggregator.add(at: event.date, model: event.model, input: event.input,
-                                   output: event.output, cache: event.cache, costUSD: cost)
+                                   output: event.output, cache: event.cache, costUSD: optionalCost ?? 0)
                 }
+                await emit(eventSink, tool: .grok, file: file, mtime: mtime, size: size, events: priced)
                 continue
             }
 
             let raw = parseGrokUpdatesFile(file: file)
             var parsed: [CostUsageScanCache.ParsedEvent] = []
+            var priced: [PricedUsageEvent] = []
             parsed.reserveCapacity(raw.count)
             var previousTotal: Int? = nil
             for snapshot in raw {
@@ -660,12 +702,16 @@ public enum CostUsageScanner {
                 )
                 guard isRetained(parsedEvent.date, cutoff: cutoff) else { continue }
                 parsed.append(parsedEvent)
-                let cost = costUSD(tool: .grok, event: parsedEvent)
+                let optionalCost = costUSDIfPriceable(tool: .grok, event: parsedEvent)
+                if eventSink != nil {
+                    priced.append(PricedUsageEvent(event: parsedEvent, costUSD: optionalCost))
+                }
                 aggregator.add(at: parsedEvent.date, model: parsedEvent.model,
                                input: parsedEvent.input, output: parsedEvent.output,
-                               cache: parsedEvent.cache, costUSD: cost)
+                               cache: parsedEvent.cache, costUSD: optionalCost ?? 0)
             }
             cache.store(parsed, for: file.path, mtime: mtime, size: size)
+            await emit(eventSink, tool: .grok, file: file, mtime: mtime, size: size, events: priced)
         }
         cache.prune(known: Set(files.map(\.path)))
         cache.save(homeDirectory: homeDirectory, tool: .grok)
@@ -916,7 +962,8 @@ public enum CostUsageScanner {
     private static func scanAntigravity(
         homeDirectory: String,
         now: Date,
-        retentionDays: Int?
+        retentionDays: Int?,
+        eventSink: (any CostUsageEventSink)? = nil
     ) async -> CostSnapshot {
         let roots = antigravityConversationDirs.map {
             URL(fileURLWithPath: homeDirectory).appendingPathComponent($0)
@@ -954,7 +1001,10 @@ public enum CostUsageScanner {
                     if retained.count != cached.count {
                         cache.store(retained, for: dbFile.path, mtime: mtime, size: size)
                     }
-                    aggregateAntigravity(retained, labels: labels, into: &aggregator)
+                    let priced = aggregateAntigravity(
+                        retained, labels: labels, into: &aggregator, collecting: eventSink != nil
+                    )
+                    await emit(eventSink, tool: .antigravity, file: dbFile, mtime: mtime, size: size, events: priced)
                     if !cached.isEmpty { handledByDB = true }
                     continue
                 }
@@ -962,7 +1012,10 @@ public enum CostUsageScanner {
                 if case let .success(turns) = readResult, !turns.isEmpty {
                     let parsed = antigravityEvents(fromDB: turns, sessionId: cascade.id, cutoff: cutoff)
                     cache.store(parsed, for: dbFile.path, mtime: mtime, size: size)
-                    aggregateAntigravity(parsed, labels: labels, into: &aggregator)
+                    let priced = aggregateAntigravity(
+                        parsed, labels: labels, into: &aggregator, collecting: eventSink != nil
+                    )
+                    await emit(eventSink, tool: .antigravity, file: dbFile, mtime: mtime, size: size, events: priced)
                     handledByDB = true
                     continue
                 }
@@ -976,7 +1029,17 @@ public enum CostUsageScanner {
                     // scan retries this database.
                     if let cached {
                         let retained = retainedEvents(cached, cutoff: cutoff)
-                        aggregateAntigravity(retained, labels: labels, into: &aggregator)
+                        let priced = aggregateAntigravity(
+                            retained, labels: labels, into: &aggregator, collecting: eventSink != nil
+                        )
+                        // Stale fingerprint: the cached rows did not come
+                        // from the file as it exists right now, so record
+                        // them under the sentinel size rather than blessing
+                        // the current fingerprint as ingested.
+                        await emit(
+                            eventSink, tool: .antigravity, file: dbFile, mtime: mtime,
+                            size: UsageEventFileBatch.staleFallbackSize, events: priced
+                        )
                         if !cached.isEmpty { handledByDB = true }
                     }
                     continue
@@ -985,6 +1048,7 @@ public enum CostUsageScanner {
                 // conversation. A successful empty decode is authoritative,
                 // so cache it and allow a `.pb` sibling to provide usage.
                 cache.store([], for: dbFile.path, mtime: mtime, size: size)
+                await emit(eventSink, tool: .antigravity, file: dbFile, mtime: mtime, size: size, events: [])
             }
             if handledByDB { continue }
 
@@ -999,7 +1063,10 @@ public enum CostUsageScanner {
                     if retained.count != cached.count {
                         cache.store(retained, for: pbFile.path, mtime: mtime, size: size)
                     }
-                    aggregateAntigravity(retained, labels: labels, into: &aggregator)
+                    let priced = aggregateAntigravity(
+                        retained, labels: labels, into: &aggregator, collecting: eventSink != nil
+                    )
+                    await emit(eventSink, tool: .antigravity, file: pbFile, mtime: mtime, size: size, events: priced)
                     continue
                 }
                 if endpoints == nil && !serverUnavailable {
@@ -1017,14 +1084,27 @@ public enum CostUsageScanner {
                         cutoff: cutoff
                     )
                     cache.store(parsed, for: pbFile.path, mtime: mtime, size: size)
-                    aggregateAntigravity(parsed, labels: labels, into: &aggregator)
+                    let priced = aggregateAntigravity(
+                        parsed, labels: labels, into: &aggregator, collecting: eventSink != nil
+                    )
+                    await emit(eventSink, tool: .antigravity, file: pbFile, mtime: mtime, size: size, events: priced)
                     continue
                 }
                 // 3. RPC unavailable / failed → reuse the last good fetch
                 //    (ignoring the fingerprint) so usage doesn't vanish
                 //    while Antigravity is closed.
                 if let stale = cache.lastKnownEvents(for: pbFile.path) {
-                    aggregateAntigravity(retainedEvents(stale, cutoff: cutoff), labels: labels, into: &aggregator)
+                    let priced = aggregateAntigravity(
+                        retainedEvents(stale, cutoff: cutoff), labels: labels,
+                        into: &aggregator, collecting: eventSink != nil
+                    )
+                    // Sentinel size: these rows predate the file's current
+                    // fingerprint, so the next successful RPC must still be
+                    // allowed to ingest.
+                    await emit(
+                        eventSink, tool: .antigravity, file: pbFile, mtime: mtime,
+                        size: UsageEventFileBatch.staleFallbackSize, events: priced
+                    )
                 }
             }
         }
@@ -1158,11 +1238,19 @@ public enum CostUsageScanner {
         return parsed
     }
 
+    /// Resolve each event's model label, price it, and fold it into the
+    /// aggregator. Returns the resolved + priced events when `collecting`
+    /// is set so the scan can hand the same rows — same model name, same
+    /// cost — to an event sink without re-deriving either.
+    @discardableResult
     private static func aggregateAntigravity(
         _ events: [CostUsageScanCache.ParsedEvent],
         labels: AntigravityModelLabelStore,
-        into aggregator: inout CostAggregator
-    ) {
+        into aggregator: inout CostAggregator,
+        collecting: Bool = false
+    ) -> [PricedUsageEvent] {
+        var priced: [PricedUsageEvent] = []
+        priced.reserveCapacity(collecting ? events.count : 0)
         for event in events {
             // Resolve the raw model id to its real label (when known),
             // then price + group under that name. A placeholder id
@@ -1184,10 +1272,14 @@ public enum CostUsageScanner {
                 sessionId: event.sessionId,
                 messageId: event.messageId
             )
-            let cost = costUSD(tool: .antigravity, event: resolved)
+            let optionalCost = costUSDIfPriceable(tool: .antigravity, event: resolved)
+            if collecting {
+                priced.append(PricedUsageEvent(event: resolved, costUSD: optionalCost))
+            }
             aggregator.add(at: resolved.date, model: resolved.model, input: resolved.input,
-                           output: resolved.output, cache: resolved.cache, costUSD: cost)
+                           output: resolved.output, cache: resolved.cache, costUSD: optionalCost ?? 0)
         }
+        return priced
     }
 
     private static func retentionCutoff(now: Date, retentionDays: Int?) -> Date? {
@@ -1244,6 +1336,18 @@ public enum CostUsageScanner {
     }
 
     private static func costUSD(tool: ToolType, event: CostUsageScanCache.ParsedEvent, codexFastTier: Bool = false) -> Double {
+        costUSDIfPriceable(tool: tool, event: event, codexFastTier: codexFastTier) ?? 0
+    }
+
+    /// Same pricing math as `costUSD`, but keeps the pricing table's `nil`
+    /// instead of collapsing it to `0`. A `nil` means "this model / provider
+    /// has no rate we can apply", which the usage ledger records as an
+    /// unpriced request rather than as a free one.
+    private static func costUSDIfPriceable(
+        tool: ToolType,
+        event: CostUsageScanCache.ParsedEvent,
+        codexFastTier: Bool = false
+    ) -> Double? {
         switch tool {
         case .codex:
             return CostUsagePricing.codexCostUSD(
@@ -1252,7 +1356,7 @@ public enum CostUsageScanner {
                 cachedInputTokens: event.cache,
                 outputTokens: event.output,
                 isFast: codexFastTier
-            ) ?? 0
+            )
         case .claude:
             let cacheCreation = max(0, event.cacheCreation ?? 0)
             let cacheRead = max(0, event.cache - cacheCreation)
@@ -1263,21 +1367,21 @@ public enum CostUsageScanner {
                 cacheCreationInputTokens: cacheCreation,
                 outputTokens: event.output,
                 isFast: eventIsFast(event)
-            ) ?? 0
+            )
         case .gemini:
             return CostUsagePricing.geminiCostUSD(
                 model: event.model,
                 inputTokens: event.input + event.cache,
                 cacheReadInputTokens: event.cache,
                 outputTokens: event.output
-            ) ?? 0
+            )
         case .grok:
             return CostUsagePricing.grokCostUSD(
                 model: event.model,
                 inputTokens: event.input + event.cache,
                 cachedInputTokens: event.cache,
                 outputTokens: event.output
-            ) ?? 0
+            )
         case .antigravity:
             let cacheCreation = max(0, event.cacheCreation ?? 0)
             let cacheRead = max(0, event.cache - cacheCreation)
@@ -1287,10 +1391,49 @@ public enum CostUsageScanner {
                 cacheReadInputTokens: cacheRead,
                 cacheCreationInputTokens: cacheCreation,
                 outputTokens: event.output
-            ) ?? 0
+            )
         case .alibaba, .alibabaTokenPlan, .copilot, .zai, .minimax, .kimi, .cursor, .mimo, .iflytek, .tencentHunyuan, .tencentTokenPlan, .volcengine, .volcengineAgentPlan, .baiduQianfan, .openCodeGo, .kilo, .kiro, .ollama, .openRouter, .warp:
-            return 0
+            return nil
         }
+    }
+
+    // MARK: - Event sink
+
+    /// Hand one file's finished, priced events to the sink. A `nil` sink
+    /// short-circuits before any allocation, so a scan without a ledger
+    /// behaves exactly as it did before the sink existed.
+    private static func emit(
+        _ sink: (any CostUsageEventSink)?,
+        tool: ToolType,
+        file: URL,
+        mtime: Date,
+        size: Int64,
+        events: [PricedUsageEvent]
+    ) async {
+        guard let sink else { return }
+        await sink.consume(
+            UsageEventFileBatch(
+                tool: tool, filePath: file.path, mtime: mtime, size: size, events: events
+            )
+        )
+    }
+
+    /// Claude events are priced per message, independently of the
+    /// cross-file dedup the aggregator runs afterwards, so a per-file batch
+    /// can be emitted as soon as the file is parsed. The ledger applies the
+    /// same preference rules on its `dedupe_key` conflict.
+    private static func emitClaude(
+        _ sink: (any CostUsageEventSink)?,
+        file: URL,
+        mtime: Date,
+        size: Int64,
+        events: [CostUsageScanCache.ParsedEvent]
+    ) async {
+        guard let sink else { return }
+        let priced = events.map {
+            PricedUsageEvent(event: $0, costUSD: costUSDIfPriceable(tool: .claude, event: $0))
+        }
+        await emit(sink, tool: .claude, file: file, mtime: mtime, size: size, events: priced)
     }
 
     private static func claudePathRole(file: URL) -> CostUsageScanCache.PathRole {

--- a/Sources/VibeBarCore/Services/CostUsageService.swift
+++ b/Sources/VibeBarCore/Services/CostUsageService.swift
@@ -34,9 +34,20 @@ public final class CostUsageService: ObservableObject {
     /// `ProcessRunner`, so this can be generous without risking a freeze.
     private static let perToolScanTimeoutSeconds: Double = 300
 
+    /// Number of days of request-level rows the usage ledger keeps before
+    /// folding a day into its daily rollups. Everything the usage UI shows
+    /// per request lives inside this window; older history stays available
+    /// as totals.
+    private static let ledgerDetailDays = 30
+
     private let homeDirectory: String
     private let mockProvider: () -> Bool
     private let costDataSettingsProvider: () -> CostDataSettings
+    /// Optional per-request event ledger. When present it receives every
+    /// event behind each scan, so a usage UI can query request-level
+    /// history without re-walking the JSONL. Nil keeps the scan pipeline
+    /// byte-identical to the pre-ledger behaviour.
+    private let usageLedger: UsageEventLedger?
     /// Keep authoritative local and selected-remote sources separate. Only the
     /// merged dictionary is published, so remote facts are never written into
     /// the local scan cache/history and cannot be counted again after relaunch.
@@ -53,11 +64,13 @@ public final class CostUsageService: ObservableObject {
     public init(
         homeDirectory: String = RealHomeDirectory.path,
         mockProvider: @escaping () -> Bool = { false },
-        costDataSettingsProvider: @escaping () -> CostDataSettings = { .default }
+        costDataSettingsProvider: @escaping () -> CostDataSettings = { .default },
+        usageLedger: UsageEventLedger? = nil
     ) {
         self.homeDirectory = homeDirectory
         self.mockProvider = mockProvider
         self.costDataSettingsProvider = costDataSettingsProvider
+        self.usageLedger = usageLedger
         // Surface the most recent persisted snapshot per tool immediately so
         // the popover doesn't render an empty Cost panel while the first
         // background scan is still running. The fresh scan replaces this when
@@ -172,6 +185,9 @@ public final class CostUsageService: ObservableObject {
 
         var results: [ToolType: CostSnapshot] = [:]
         let home = homeDirectory
+        // Privacy mode is already handled above (it erases and returns), so
+        // reaching here means the ledger is allowed to record.
+        let sink = usageLedger
         for tool in ToolType.allCases where tool.supportsTokenCost {
             // Scan on a detached utility task so JSONL parsing doesn't block
             // the main actor. CostUsageService itself is `@MainActor`; without
@@ -190,7 +206,8 @@ public final class CostUsageService: ObservableObject {
                     tool: tool,
                     homeDirectory: home,
                     now: now,
-                    retentionDays: retentionDays
+                    retentionDays: retentionDays,
+                    eventSink: sink
                 )
             }
             let scanned: CostSnapshot?
@@ -211,6 +228,15 @@ public final class CostUsageService: ObservableObject {
                 // Persist the post-merge snapshot so a future launch can show
                 // these numbers without waiting for a fresh scan.
                 await CostSnapshotCache.shared.save(merged, retentionDays: retentionDays)
+                // Fold this tool's freshly ingested history down to daily
+                // rollups past the detail window and apply retention. Done
+                // per tool rather than once at the end so a long pass never
+                // leaves the ledger holding an unbounded detail table.
+                try? await usageLedger?.rollupAndPrune(
+                    now: now,
+                    detailDays: Self.ledgerDetailDays,
+                    retentionDays: retentionDays
+                )
             }
         }
         localSnapshots = results
@@ -261,6 +287,11 @@ public final class CostUsageService: ObservableObject {
             return
         }
         await CostHistoryStore.shared.prune(retentionDays: costData.retentionDays)
+        try? await usageLedger?.rollupAndPrune(
+            now: Date(),
+            detailDays: Self.ledgerDetailDays,
+            retentionDays: costData.retentionDays
+        )
         let cached = await CostSnapshotCache.shared.loadAll(retentionDays: costData.retentionDays, now: Date())
         localSnapshots = cached
         publishMergedSnapshots()
@@ -271,6 +302,7 @@ public final class CostUsageService: ObservableObject {
         await CostHistoryStore.shared.eraseAll()
         await CostSnapshotCache.shared.eraseAll()
         CostUsageScanCache.eraseAll(homeDirectory: homeDirectory)
+        try? await usageLedger?.eraseAll()
         localSnapshots = [:]
         publishMergedSnapshots()
         extrasByTool = [:]

--- a/Sources/VibeBarCore/Services/UsageEventLedger.swift
+++ b/Sources/VibeBarCore/Services/UsageEventLedger.swift
@@ -1,0 +1,1050 @@
+import Foundation
+import SQLite3
+
+public enum UsageLedgerError: Error, Sendable {
+    /// The SQLite file could not be opened or migrated.
+    case open
+    /// A statement failed to prepare, bind, or step.
+    case statement
+}
+
+/// Durable per-request ledger for locally scanned CLI usage.
+///
+/// `CostUsageScanner` already parses every Codex / Claude / Gemini / Grok /
+/// AntiGravity session log into per-request events and prices each one, but
+/// it only keeps the *aggregate* (`CostSnapshot`). This actor persists the
+/// events themselves so a usage UI can answer per-request questions —
+/// "which model ran at 14:05?", "what did the last 200 requests cost?" —
+/// without re-walking gigabytes of JSONL.
+///
+/// Shape mirrors `RemoteUsageLedger`: raw `sqlite3` C API, WAL, a 5 s busy
+/// timeout, `CREATE TABLE IF NOT EXISTS` with a version stamp in a meta
+/// table. Unlike the remote ledger, a schema-version mismatch here simply
+/// drops and recreates every table: the authoritative copy of this data is
+/// the scan cache on disk, so the next refresh re-ingests it for free.
+///
+/// # Token column semantics
+///
+/// `CostUsageScanCache.ParsedEvent` carries `input` / `cache` /
+/// `cacheCreation`, and those mean slightly different things per provider.
+/// Ingest normalizes all of them into three non-overlapping columns:
+///
+/// | column           | source                                    |
+/// |------------------|-------------------------------------------|
+/// | `fresh_input`    | `event.input`                             |
+/// | `cache_creation` | `max(0, event.cacheCreation ?? 0)`         |
+/// | `cache_read`     | `max(0, event.cache - cache_creation)`    |
+///
+/// Per provider, verified against the scanner's construction sites:
+///
+/// - **Codex** — `input` is already `delta.input - delta.cached`, i.e.
+///   non-cached prompt tokens; `cache` is `delta.cached` (cache *reads*);
+///   `cacheCreation` is never set. → `cache_creation = 0`.
+/// - **Claude** — `input` is `usage.input_tokens`, which Anthropic already
+///   reports net of cache; `cache` is the **sum** of
+///   `cache_read_input_tokens + cache_creation_input_tokens`, and
+///   `cacheCreation` repeats the creation half. Subtracting recovers the
+///   read half — exactly what the scanner's own costing does.
+/// - **Gemini** — both the OTLP and chat-history parsers store
+///   `max(0, rawInput - cached)` in `input` and `cached` in `cache`;
+///   `cacheCreation` is never set.
+/// - **Grok** — the session total is split 70/30 into `input`/`output`
+///   with `cache = 0`; no cache columns exist in the source at all.
+/// - **AntiGravity** — the `.db` decoder stores this turn's cache-read
+///   increment in `cache` and leaves `cacheCreation` nil (the protobuf has
+///   no cache-creation field); the `.pb` RPC fallback has no cache data at
+///   all and stores `0`.
+///
+/// So `cache_creation` is non-zero for Claude only, and the three columns
+/// sum to the real token count without double counting anywhere.
+public actor UsageEventLedger: CostUsageEventSink {
+    private var database: OpaquePointer?
+    private let transient = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
+    private let calendar: Calendar
+    private let dayFormatter: DateFormatter
+
+    /// Bumping this drops and rebuilds every table on the next open.
+    static let schemaVersion = 1
+    private static let schemaVersionKey = "schema_version"
+    private static let floorKeyPrefix = "detail_floor_day:"
+    /// Guard rail on zero-filled trend enumeration: ~135 years of daily
+    /// buckets. A filter wider than this is a caller bug, not a chart.
+    private static let maximumTrendBuckets = 50_000
+
+    public init(url: URL = VibeBarLocalStore.usageEventsLedgerURL) throws {
+        if url == VibeBarLocalStore.usageEventsLedgerURL {
+            try VibeBarLocalStore.ensureBaseDirectory()
+        }
+        var gregorian = Calendar(identifier: .gregorian)
+        gregorian.locale = Locale(identifier: "en_US_POSIX")
+        self.calendar = gregorian
+        let formatter = DateFormatter()
+        formatter.calendar = gregorian
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = gregorian.timeZone
+        formatter.dateFormat = "yyyy-MM-dd"
+        self.dayFormatter = formatter
+
+        var handle: OpaquePointer?
+        guard sqlite3_open_v2(
+            url.path,
+            &handle,
+            SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_FULLMUTEX,
+            nil
+        ) == SQLITE_OK, let handle
+        else {
+            if handle != nil { sqlite3_close_v2(handle) }
+            throw UsageLedgerError.open
+        }
+        sqlite3_busy_timeout(handle, 5_000)
+        do {
+            try Self.initialize(handle)
+            database = handle
+        } catch {
+            sqlite3_close_v2(handle)
+            throw error
+        }
+    }
+
+    deinit {
+        if let database { sqlite3_close_v2(database) }
+    }
+
+    // MARK: - Schema
+
+    private static func initialize(_ database: OpaquePointer) throws {
+        let preamble = """
+            PRAGMA journal_mode=WAL;
+            PRAGMA synchronous=NORMAL;
+            CREATE TABLE IF NOT EXISTS ledger_meta (
+                key TEXT PRIMARY KEY,
+                value TEXT
+            );
+            """
+        guard sqlite3_exec(database, preamble, nil, nil, nil) == SQLITE_OK else {
+            throw UsageLedgerError.open
+        }
+        if let stored = storedSchemaVersion(database), stored != schemaVersion {
+            // Every row here is reconstructible from the on-disk scan cache,
+            // so a migration is never worth writing: drop, recreate, and let
+            // the next refresh re-ingest.
+            let reset = """
+                DROP TABLE IF EXISTS usage_events;
+                DROP TABLE IF EXISTS usage_daily_rollups;
+                DROP TABLE IF EXISTS ingested_files;
+                DELETE FROM ledger_meta;
+                """
+            guard sqlite3_exec(database, reset, nil, nil, nil) == SQLITE_OK else {
+                throw UsageLedgerError.open
+            }
+        }
+        let schema = """
+            CREATE TABLE IF NOT EXISTS usage_events (
+                id INTEGER PRIMARY KEY,
+                tool TEXT NOT NULL,
+                ts INTEGER NOT NULL,
+                day TEXT NOT NULL,
+                model TEXT NOT NULL,
+                fresh_input INTEGER NOT NULL DEFAULT 0,
+                output INTEGER NOT NULL DEFAULT 0,
+                cache_read INTEGER NOT NULL DEFAULT 0,
+                cache_creation INTEGER NOT NULL DEFAULT 0,
+                cost_micros INTEGER,
+                session_id TEXT,
+                message_id TEXT,
+                request_id TEXT,
+                service_tier TEXT,
+                is_sidechain INTEGER,
+                path_role TEXT,
+                source_key TEXT,
+                dedupe_key TEXT NOT NULL UNIQUE
+            );
+            CREATE INDEX IF NOT EXISTS usage_events_tool_ts_idx ON usage_events(tool, ts);
+            CREATE INDEX IF NOT EXISTS usage_events_day_idx ON usage_events(day);
+            CREATE INDEX IF NOT EXISTS usage_events_model_idx ON usage_events(model);
+            CREATE TABLE IF NOT EXISTS usage_daily_rollups (
+                day TEXT NOT NULL,
+                tool TEXT NOT NULL,
+                model TEXT NOT NULL,
+                requests INTEGER NOT NULL DEFAULT 0,
+                fresh_input INTEGER NOT NULL DEFAULT 0,
+                output INTEGER NOT NULL DEFAULT 0,
+                cache_read INTEGER NOT NULL DEFAULT 0,
+                cache_creation INTEGER NOT NULL DEFAULT 0,
+                cost_micros INTEGER NOT NULL DEFAULT 0,
+                unpriced INTEGER NOT NULL DEFAULT 0,
+                PRIMARY KEY(day, tool, model)
+            );
+            CREATE TABLE IF NOT EXISTS ingested_files (
+                tool TEXT NOT NULL,
+                file_key TEXT NOT NULL,
+                mtime REAL NOT NULL,
+                size INTEGER NOT NULL,
+                PRIMARY KEY(tool, file_key)
+            );
+            """
+        guard sqlite3_exec(database, schema, nil, nil, nil) == SQLITE_OK else {
+            throw UsageLedgerError.open
+        }
+        var statement: OpaquePointer?
+        guard sqlite3_prepare_v2(
+            database,
+            """
+            INSERT INTO ledger_meta(key, value) VALUES(?, ?)
+               ON CONFLICT(key) DO UPDATE SET value = excluded.value
+            """,
+            -1, &statement, nil
+        ) == SQLITE_OK, let statement else { throw UsageLedgerError.open }
+        defer { sqlite3_finalize(statement) }
+        let destructor = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
+        sqlite3_bind_text(statement, 1, schemaVersionKey, -1, destructor)
+        sqlite3_bind_text(statement, 2, String(schemaVersion), -1, destructor)
+        guard sqlite3_step(statement) == SQLITE_DONE else { throw UsageLedgerError.open }
+    }
+
+    private static func storedSchemaVersion(_ database: OpaquePointer) -> Int? {
+        var statement: OpaquePointer?
+        guard sqlite3_prepare_v2(
+            database,
+            "SELECT value FROM ledger_meta WHERE key = '\(schemaVersionKey)'",
+            -1, &statement, nil
+        ) == SQLITE_OK, let statement else { return nil }
+        defer { sqlite3_finalize(statement) }
+        guard sqlite3_step(statement) == SQLITE_ROW,
+              let raw = sqlite3_column_text(statement, 0)
+        else { return nil }
+        return Int(String(cString: raw))
+    }
+
+    // MARK: - Ingest
+
+    /// `CostUsageEventSink` conformance. Failures are swallowed on purpose:
+    /// the ledger is a side channel of the cost scan, and a locked or
+    /// corrupt database must never take the scan (or the popover) down with
+    /// it. The next refresh retries the same batch.
+    public func consume(_ batch: UsageEventFileBatch) async {
+        try? ingest(batch)
+    }
+
+    /// Throwing form of `consume`, for tests and for callers that want to
+    /// see ingest failures.
+    public func ingest(_ batch: UsageEventFileBatch) throws {
+        let fileKey = CostUsageScanCache.entryKey(for: batch.filePath)
+        if let stored = try storedFingerprint(tool: batch.tool, fileKey: fileKey),
+           stored.size == batch.size,
+           abs(stored.mtime - batch.mtime.timeIntervalSince1970) <= 1.0 {
+            return
+        }
+        let floor = try detailFloorDay(for: batch.tool)
+        try execute("BEGIN IMMEDIATE")
+        do {
+            let statement = try prepare(Self.insertEventSQL)
+            defer { sqlite3_finalize(statement) }
+            for (index, priced) in batch.events.enumerated() {
+                let event = priced.event
+                let day = dayString(for: event.date)
+                // Below the floor the detail rows have already been folded
+                // into `usage_daily_rollups`; re-inserting them would double
+                // count every historical day on the next full re-scan.
+                if let floor, day <= floor { continue }
+                let cacheCreation = Int64(max(0, event.cacheCreation ?? 0))
+                let cacheRead = max(0, Int64(event.cache) - cacheCreation)
+                let freshInput = Int64(max(0, event.input))
+                let output = Int64(max(0, event.output))
+                let timestamp = Int64(event.date.timeIntervalSince1970.rounded(.down))
+                let key = dedupeKey(
+                    event: event,
+                    tool: batch.tool,
+                    fileKey: fileKey,
+                    index: index,
+                    timestamp: timestamp,
+                    freshInput: freshInput,
+                    output: output,
+                    cacheRead: cacheRead,
+                    cacheCreation: cacheCreation
+                )
+                let bindings: [Binding] = [
+                    .text(batch.tool.rawValue),
+                    .integer(timestamp),
+                    .text(day),
+                    .text(event.model),
+                    .integer(freshInput),
+                    .integer(output),
+                    .integer(cacheRead),
+                    .integer(cacheCreation),
+                    priced.costMicros.map(Binding.integer) ?? .null,
+                    event.sessionId.map(Binding.text) ?? .null,
+                    event.messageId.map(Binding.text) ?? .null,
+                    event.requestId.map(Binding.text) ?? .null,
+                    event.serviceTier.map(Binding.text) ?? .null,
+                    event.isSidechain.map { Binding.integer($0 ? 1 : 0) } ?? .null,
+                    event.pathRole.map { Binding.text($0.rawValue) } ?? .null,
+                    event.sourceKey.map(Binding.text) ?? .null,
+                    .text(key)
+                ]
+                sqlite3_reset(statement)
+                sqlite3_clear_bindings(statement)
+                for (offset, value) in bindings.enumerated() {
+                    bind(value, at: Int32(offset + 1), to: statement)
+                }
+                guard sqlite3_step(statement) == SQLITE_DONE else {
+                    throw UsageLedgerError.statement
+                }
+            }
+            try run(
+                """
+                INSERT INTO ingested_files(tool, file_key, mtime, size) VALUES(?, ?, ?, ?)
+                   ON CONFLICT(tool, file_key) DO UPDATE SET
+                       mtime = excluded.mtime,
+                       size = excluded.size
+                """,
+                [
+                    .text(batch.tool.rawValue), .text(fileKey),
+                    .real(batch.mtime.timeIntervalSince1970), .integer(batch.size)
+                ]
+            )
+            try execute("COMMIT")
+        } catch {
+            try? execute("ROLLBACK")
+            throw error
+        }
+    }
+
+    /// Conflict resolution mirrors `CostUsageScanner.claudeEventWins`: the
+    /// same assistant message can appear in a parent transcript and in a
+    /// sidechain / subagent copy, and only one of them is a real billable
+    /// request. Preference order, best first:
+    ///
+    /// 1. not a sidechain,
+    /// 2. `pathRole == .parent` (i.e. not under `/subagents/`),
+    /// 3. lexicographically smallest `source_key`.
+    ///
+    /// The third rule is the scanner's actual tiebreak — it keeps the
+    /// winner stable no matter which file the scan walks first — so the
+    /// ledger and the aggregator agree on which copy survives. Expressed as
+    /// a `DO UPDATE ... WHERE`: when the incoming row loses, SQLite leaves
+    /// the stored row untouched and the insert is silently dropped.
+    private static let insertEventSQL = """
+        INSERT INTO usage_events(
+               tool, ts, day, model, fresh_input, output, cache_read, cache_creation,
+               cost_micros, session_id, message_id, request_id, service_tier,
+               is_sidechain, path_role, source_key, dedupe_key
+           ) VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+           ON CONFLICT(dedupe_key) DO UPDATE SET
+               tool = excluded.tool,
+               ts = excluded.ts,
+               day = excluded.day,
+               model = excluded.model,
+               fresh_input = excluded.fresh_input,
+               output = excluded.output,
+               cache_read = excluded.cache_read,
+               cache_creation = excluded.cache_creation,
+               cost_micros = excluded.cost_micros,
+               session_id = excluded.session_id,
+               message_id = excluded.message_id,
+               request_id = excluded.request_id,
+               service_tier = excluded.service_tier,
+               is_sidechain = excluded.is_sidechain,
+               path_role = excluded.path_role,
+               source_key = excluded.source_key
+           WHERE
+               (CASE WHEN COALESCE(excluded.is_sidechain, 0) = 0 THEN 0 ELSE 1 END)
+             < (CASE WHEN COALESCE(usage_events.is_sidechain, 0) = 0 THEN 0 ELSE 1 END)
+            OR (
+               (CASE WHEN COALESCE(excluded.is_sidechain, 0) = 0 THEN 0 ELSE 1 END)
+             = (CASE WHEN COALESCE(usage_events.is_sidechain, 0) = 0 THEN 0 ELSE 1 END)
+             AND (
+                  (CASE WHEN COALESCE(excluded.path_role, 'parent') = 'parent' THEN 0 ELSE 1 END)
+                < (CASE WHEN COALESCE(usage_events.path_role, 'parent') = 'parent' THEN 0 ELSE 1 END)
+               OR (
+                  (CASE WHEN COALESCE(excluded.path_role, 'parent') = 'parent' THEN 0 ELSE 1 END)
+                = (CASE WHEN COALESCE(usage_events.path_role, 'parent') = 'parent' THEN 0 ELSE 1 END)
+                AND COALESCE(excluded.source_key, '') < COALESCE(usage_events.source_key, '')
+               )
+             )
+            )
+        """
+
+    /// A Claude request is uniquely identified by `(messageId, requestId)`
+    /// across every transcript file that copied it, so that pair is the
+    /// natural key. Every other provider leaves at least one of them nil;
+    /// those fall back to a digest that is stable across re-scans of the
+    /// same file (hashed path + position + timestamp + model + tokens) so a
+    /// re-ingest updates instead of duplicating.
+    private func dedupeKey(
+        event: CostUsageScanCache.ParsedEvent,
+        tool: ToolType,
+        fileKey: String,
+        index: Int,
+        timestamp: Int64,
+        freshInput: Int64,
+        output: Int64,
+        cacheRead: Int64,
+        cacheCreation: Int64
+    ) -> String {
+        if let messageId = event.messageId, let requestId = event.requestId {
+            return "m:\(messageId)\u{0}\(requestId)"
+        }
+        let seed = [
+            tool.rawValue, fileKey, String(index), String(timestamp), event.model,
+            String(freshInput), String(output), String(cacheRead), String(cacheCreation)
+        ].joined(separator: "|")
+        return "f:" + PrivacyPreservingHash.fileComponent(prefix: "ue-v1", rawValue: seed)
+    }
+
+    private func storedFingerprint(
+        tool: ToolType,
+        fileKey: String
+    ) throws -> (mtime: TimeInterval, size: Int64)? {
+        let statement = try prepare(
+            "SELECT mtime, size FROM ingested_files WHERE tool = ? AND file_key = ?"
+        )
+        defer { sqlite3_finalize(statement) }
+        bind(.text(tool.rawValue), at: 1, to: statement)
+        bind(.text(fileKey), at: 2, to: statement)
+        let result = sqlite3_step(statement)
+        if result == SQLITE_DONE { return nil }
+        guard result == SQLITE_ROW else { throw UsageLedgerError.statement }
+        return (sqlite3_column_double(statement, 0), sqlite3_column_int64(statement, 1))
+    }
+
+    // MARK: - Rollup / retention
+
+    /// Fold detail rows older than `detailDays` into `usage_daily_rollups`,
+    /// delete them, and advance the per-tool detail floor so a later
+    /// re-scan of the same history cannot re-insert them.
+    ///
+    /// When `retentionDays > 0`, rollup rows (and any straggling detail
+    /// rows) older than the retention window are deleted outright, and the
+    /// floor advances past the pruned window for the same reason.
+    public func rollupAndPrune(
+        now: Date = Date(),
+        detailDays: Int = 30,
+        retentionDays: Int
+    ) throws {
+        let today = calendar.startOfDay(for: now)
+        let detailFrom = calendar.date(byAdding: .day, value: -max(0, detailDays), to: today) ?? today
+        let rollupCutoffDay = dayString(for: detailFrom)
+        var floorTarget = dayString(
+            for: calendar.date(byAdding: .day, value: -1, to: detailFrom) ?? detailFrom
+        )
+
+        let normalizedRetention = CostDataSettings.normalizedRetentionDays(retentionDays)
+        var retentionDay: String?
+        if normalizedRetention > 0 {
+            let start = calendar.date(
+                byAdding: .day, value: -(normalizedRetention - 1), to: today
+            ) ?? today
+            retentionDay = dayString(for: start)
+            let dayBefore = dayString(
+                for: calendar.date(byAdding: .day, value: -1, to: start) ?? start
+            )
+            if dayBefore > floorTarget { floorTarget = dayBefore }
+        }
+
+        try execute("BEGIN IMMEDIATE")
+        do {
+            try run(Self.rollupSQL, [.text(rollupCutoffDay)])
+            try run("DELETE FROM usage_events WHERE day < ?", [.text(rollupCutoffDay)])
+            if let retentionDay {
+                try run("DELETE FROM usage_daily_rollups WHERE day < ?", [.text(retentionDay)])
+                try run("DELETE FROM usage_events WHERE day < ?", [.text(retentionDay)])
+            }
+            // Only tools that have actually been ingested get a floor. A
+            // provider whose first scan lands after this call must still be
+            // allowed to backfill its own history.
+            for tool in try ingestedTools() {
+                let current = try detailFloorDay(for: tool)
+                guard current == nil || current! < floorTarget else { continue }
+                try run(
+                    """
+                    INSERT INTO ledger_meta(key, value) VALUES(?, ?)
+                       ON CONFLICT(key) DO UPDATE SET value = excluded.value
+                    """,
+                    [.text(Self.floorKeyPrefix + tool.rawValue), .text(floorTarget)]
+                )
+            }
+            try execute("COMMIT")
+        } catch {
+            try? execute("ROLLBACK")
+            throw error
+        }
+    }
+
+    private static let rollupSQL = """
+        INSERT INTO usage_daily_rollups(
+               day, tool, model, requests, fresh_input, output,
+               cache_read, cache_creation, cost_micros, unpriced
+           )
+           SELECT day, tool, model, COUNT(*),
+                  COALESCE(SUM(fresh_input), 0), COALESCE(SUM(output), 0),
+                  COALESCE(SUM(cache_read), 0), COALESCE(SUM(cache_creation), 0),
+                  COALESCE(SUM(cost_micros), 0),
+                  SUM(CASE WHEN cost_micros IS NULL THEN 1 ELSE 0 END)
+             FROM usage_events WHERE day < ?
+            GROUP BY day, tool, model
+           ON CONFLICT(day, tool, model) DO UPDATE SET
+               requests = usage_daily_rollups.requests + excluded.requests,
+               fresh_input = usage_daily_rollups.fresh_input + excluded.fresh_input,
+               output = usage_daily_rollups.output + excluded.output,
+               cache_read = usage_daily_rollups.cache_read + excluded.cache_read,
+               cache_creation = usage_daily_rollups.cache_creation + excluded.cache_creation,
+               cost_micros = usage_daily_rollups.cost_micros + excluded.cost_micros,
+               unpriced = usage_daily_rollups.unpriced + excluded.unpriced
+        """
+
+    /// Wipe every ingested row. The schema (and its version stamp) stays so
+    /// the next scan can start writing immediately.
+    public func eraseAll() throws {
+        try execute("BEGIN IMMEDIATE")
+        do {
+            try execute("DELETE FROM usage_events")
+            try execute("DELETE FROM usage_daily_rollups")
+            try execute("DELETE FROM ingested_files")
+            try run("DELETE FROM ledger_meta WHERE key <> ?", [.text(Self.schemaVersionKey)])
+            try execute("COMMIT")
+        } catch {
+            try? execute("ROLLBACK")
+            throw error
+        }
+    }
+
+    /// Oldest day that still has request-level rows for `tool`, or nil when
+    /// nothing has been rolled up yet.
+    public func detailFloorDay(for tool: ToolType) throws -> String? {
+        try scalarText(
+            "SELECT value FROM ledger_meta WHERE key = ?",
+            [.text(Self.floorKeyPrefix + tool.rawValue)]
+        )
+    }
+
+    private func ingestedTools() throws -> [ToolType] {
+        let statement = try prepare("SELECT DISTINCT tool FROM ingested_files")
+        defer { sqlite3_finalize(statement) }
+        var tools: [ToolType] = []
+        while sqlite3_step(statement) == SQLITE_ROW {
+            if let raw = columnText(statement, 0), let tool = ToolType(rawValue: raw) {
+                tools.append(tool)
+            }
+        }
+        return tools
+    }
+
+    // MARK: - Queries
+
+    /// Headline totals over `filter`, stitched across the detail/rollup
+    /// boundary: request-level rows contribute for the days above each
+    /// tool's floor, daily rollups contribute for the whole days below it.
+    public func summary(_ filter: UsageQueryFilter) throws -> UsageSummaryMetrics {
+        var requests = 0
+        var unpriced = 0
+        var priced = 0
+        var freshInput: Int64 = 0
+        var output: Int64 = 0
+        var cacheRead: Int64 = 0
+        var cacheCreation: Int64 = 0
+        var cost: Int64 = 0
+
+        let detail = detailPredicate(filter)
+        let detailStatement = try prepare(
+            """
+            SELECT COUNT(*), COALESCE(SUM(fresh_input), 0), COALESCE(SUM(output), 0),
+                   COALESCE(SUM(cache_read), 0), COALESCE(SUM(cache_creation), 0),
+                   COALESCE(SUM(cost_micros), 0),
+                   COALESCE(SUM(CASE WHEN cost_micros IS NULL THEN 1 ELSE 0 END), 0)
+              FROM usage_events WHERE \(detail.sql)
+            """
+        )
+        defer { sqlite3_finalize(detailStatement) }
+        bindAll(detail.bindings, to: detailStatement)
+        if sqlite3_step(detailStatement) == SQLITE_ROW {
+            requests += Int(sqlite3_column_int64(detailStatement, 0))
+            freshInput += sqlite3_column_int64(detailStatement, 1)
+            output += sqlite3_column_int64(detailStatement, 2)
+            cacheRead += sqlite3_column_int64(detailStatement, 3)
+            cacheCreation += sqlite3_column_int64(detailStatement, 4)
+            cost += sqlite3_column_int64(detailStatement, 5)
+            let detailUnpriced = Int(sqlite3_column_int64(detailStatement, 6))
+            unpriced += detailUnpriced
+            priced += Int(sqlite3_column_int64(detailStatement, 0)) - detailUnpriced
+        }
+
+        if let rollup = rollupPredicate(filter) {
+            let statement = try prepare(
+                """
+                SELECT COALESCE(SUM(requests), 0), COALESCE(SUM(fresh_input), 0),
+                       COALESCE(SUM(output), 0), COALESCE(SUM(cache_read), 0),
+                       COALESCE(SUM(cache_creation), 0), COALESCE(SUM(cost_micros), 0),
+                       COALESCE(SUM(unpriced), 0)
+                  FROM usage_daily_rollups WHERE \(rollup.sql)
+                """
+            )
+            defer { sqlite3_finalize(statement) }
+            bindAll(rollup.bindings, to: statement)
+            if sqlite3_step(statement) == SQLITE_ROW {
+                let rollupRequests = Int(sqlite3_column_int64(statement, 0))
+                let rollupUnpriced = Int(sqlite3_column_int64(statement, 6))
+                requests += rollupRequests
+                freshInput += sqlite3_column_int64(statement, 1)
+                output += sqlite3_column_int64(statement, 2)
+                cacheRead += sqlite3_column_int64(statement, 3)
+                cacheCreation += sqlite3_column_int64(statement, 4)
+                cost += sqlite3_column_int64(statement, 5)
+                unpriced += rollupUnpriced
+                priced += rollupRequests - rollupUnpriced
+            }
+        }
+
+        return UsageSummaryMetrics(
+            requests: requests,
+            unpricedRequests: unpriced,
+            costMicros: priced > 0 ? cost : nil,
+            freshInput: freshInput,
+            output: output,
+            cacheRead: cacheRead,
+            cacheCreation: cacheCreation
+        )
+    }
+
+    /// Zero-filled series across the filter's range.
+    ///
+    /// Hourly buckets read request-level rows only — daily rollups have no
+    /// sub-day resolution to give back — which is why the recommended
+    /// bucket is `.hour` only for ranges of a day or less, well inside the
+    /// detail window.
+    public func trend(
+        _ filter: UsageQueryFilter,
+        bucket: UsageTrendBucket? = nil
+    ) throws -> UsageTrendSeries {
+        let resolved = bucket ?? UsageTrendBucket.recommended(for: filter.range)
+        let starts = bucketStarts(for: filter.range, bucket: resolved)
+        var totals: [Date: Accumulator] = [:]
+
+        switch resolved {
+        case .hour:
+            let detail = detailPredicate(filter)
+            let statement = try prepare(
+                """
+                SELECT ts, fresh_input, output, cache_read, cache_creation,
+                       COALESCE(cost_micros, 0)
+                  FROM usage_events WHERE \(detail.sql)
+                """
+            )
+            defer { sqlite3_finalize(statement) }
+            bindAll(detail.bindings, to: statement)
+            while sqlite3_step(statement) == SQLITE_ROW {
+                let date = Date(timeIntervalSince1970: TimeInterval(sqlite3_column_int64(statement, 0)))
+                guard let key = calendar.dateInterval(of: .hour, for: date)?.start else { continue }
+                totals[key, default: .zero].add(statement, offset: 1)
+            }
+        case .day:
+            let detail = detailPredicate(filter)
+            let detailStatement = try prepare(
+                """
+                SELECT day, COALESCE(SUM(fresh_input), 0), COALESCE(SUM(output), 0),
+                       COALESCE(SUM(cache_read), 0), COALESCE(SUM(cache_creation), 0),
+                       COALESCE(SUM(cost_micros), 0)
+                  FROM usage_events WHERE \(detail.sql) GROUP BY day
+                """
+            )
+            defer { sqlite3_finalize(detailStatement) }
+            bindAll(detail.bindings, to: detailStatement)
+            while sqlite3_step(detailStatement) == SQLITE_ROW {
+                guard let raw = columnText(detailStatement, 0),
+                      let key = dayFormatter.date(from: raw)
+                else { continue }
+                totals[key, default: .zero].add(detailStatement, offset: 1)
+            }
+            if let rollup = rollupPredicate(filter) {
+                let statement = try prepare(
+                    """
+                    SELECT day, COALESCE(SUM(fresh_input), 0), COALESCE(SUM(output), 0),
+                           COALESCE(SUM(cache_read), 0), COALESCE(SUM(cache_creation), 0),
+                           COALESCE(SUM(cost_micros), 0)
+                      FROM usage_daily_rollups WHERE \(rollup.sql) GROUP BY day
+                    """
+                )
+                defer { sqlite3_finalize(statement) }
+                bindAll(rollup.bindings, to: statement)
+                while sqlite3_step(statement) == SQLITE_ROW {
+                    guard let raw = columnText(statement, 0),
+                          let key = dayFormatter.date(from: raw)
+                    else { continue }
+                    totals[key, default: .zero].add(statement, offset: 1)
+                }
+            }
+        }
+
+        let points = starts.map { start -> UsageTrendPoint in
+            let value = totals[start] ?? .zero
+            return UsageTrendPoint(
+                bucketStart: start,
+                freshInput: value.freshInput,
+                output: value.output,
+                cacheRead: value.cacheRead,
+                cacheCreation: value.cacheCreation,
+                costMicros: value.cost
+            )
+        }
+        return UsageTrendSeries(bucket: resolved, points: points)
+    }
+
+    /// One page of request-level rows, newest first.
+    ///
+    /// Request-level rows exist only **above** each tool's detail floor —
+    /// older history has been folded into `usage_daily_rollups` and can no
+    /// longer be enumerated per request. `totalCount` therefore counts the
+    /// detail rows in range, not the summary's request count.
+    /// `page` is zero-based; a page past the end returns no rows.
+    public func requestPage(
+        _ filter: UsageQueryFilter,
+        page: Int,
+        pageSize: Int
+    ) throws -> UsageRequestPage {
+        let size = min(max(1, pageSize), 1_000)
+        let index = max(0, page)
+        let detail = detailPredicate(filter)
+
+        let countStatement = try prepare(
+            "SELECT COUNT(*) FROM usage_events WHERE \(detail.sql)"
+        )
+        defer { sqlite3_finalize(countStatement) }
+        bindAll(detail.bindings, to: countStatement)
+        var total = 0
+        if sqlite3_step(countStatement) == SQLITE_ROW {
+            total = Int(sqlite3_column_int64(countStatement, 0))
+        }
+
+        let statement = try prepare(
+            """
+            SELECT id, tool, ts, model, fresh_input, output, cache_read, cache_creation,
+                   cost_micros, service_tier, session_id, source_key
+              FROM usage_events WHERE \(detail.sql)
+             ORDER BY ts DESC, id DESC LIMIT ? OFFSET ?
+            """
+        )
+        defer { sqlite3_finalize(statement) }
+        bindAll(detail.bindings, to: statement)
+        let offset = Int32(detail.bindings.count)
+        bind(.integer(Int64(size)), at: offset + 1, to: statement)
+        bind(.integer(Int64(index) * Int64(size)), at: offset + 2, to: statement)
+
+        var rows: [UsageRequestRow] = []
+        while sqlite3_step(statement) == SQLITE_ROW {
+            guard let rawTool = columnText(statement, 1),
+                  let tool = ToolType(rawValue: rawTool),
+                  let model = columnText(statement, 3)
+            else { continue }
+            rows.append(
+                UsageRequestRow(
+                    id: sqlite3_column_int64(statement, 0),
+                    date: Date(timeIntervalSince1970: TimeInterval(sqlite3_column_int64(statement, 2))),
+                    tool: tool,
+                    model: model,
+                    freshInput: sqlite3_column_int64(statement, 4),
+                    output: sqlite3_column_int64(statement, 5),
+                    cacheRead: sqlite3_column_int64(statement, 6),
+                    cacheCreation: sqlite3_column_int64(statement, 7),
+                    costMicros: sqlite3_column_type(statement, 8) == SQLITE_NULL
+                        ? nil : sqlite3_column_int64(statement, 8),
+                    serviceTier: columnText(statement, 9),
+                    sessionId: columnText(statement, 10),
+                    sourceKey: columnText(statement, 11)
+                )
+            )
+        }
+        return UsageRequestPage(rows: rows, totalCount: total, page: index, pageSize: size)
+    }
+
+    /// Per-provider totals, detail ∪ rollups, heaviest first.
+    public func providerStats(_ filter: UsageQueryFilter) throws -> [UsageProviderStat] {
+        var totals: [ToolType: (requests: Int, tokens: Int64, cost: Int64)] = [:]
+        try forEachGroup(filter, column: "tool") { key, requests, tokens, cost in
+            guard let tool = ToolType(rawValue: key) else { return }
+            totals[tool, default: (0, 0, 0)].requests += requests
+            totals[tool, default: (0, 0, 0)].tokens += tokens
+            totals[tool, default: (0, 0, 0)].cost += cost
+        }
+        return totals
+            .map {
+                UsageProviderStat(
+                    tool: $0.key, requests: $0.value.requests,
+                    totalTokens: $0.value.tokens, costMicros: $0.value.cost
+                )
+            }
+            .sorted {
+                $0.totalTokens == $1.totalTokens
+                    ? $0.tool.rawValue < $1.tool.rawValue
+                    : $0.totalTokens > $1.totalTokens
+            }
+    }
+
+    /// Per-model totals, detail ∪ rollups, heaviest first.
+    public func modelStats(_ filter: UsageQueryFilter) throws -> [UsageModelStat] {
+        var totals: [String: (requests: Int, tokens: Int64, cost: Int64)] = [:]
+        try forEachGroup(filter, column: "model") { key, requests, tokens, cost in
+            totals[key, default: (0, 0, 0)].requests += requests
+            totals[key, default: (0, 0, 0)].tokens += tokens
+            totals[key, default: (0, 0, 0)].cost += cost
+        }
+        return totals
+            .map { entry in
+                UsageModelStat(
+                    model: entry.key,
+                    requests: entry.value.requests,
+                    totalTokens: entry.value.tokens,
+                    costMicros: entry.value.cost,
+                    avgCostMicrosPerRequest: UsageModelStat.averageMicros(
+                        total: entry.value.cost, requests: entry.value.requests
+                    )
+                )
+            }
+            .sorted {
+                $0.totalTokens == $1.totalTokens
+                    ? $0.model < $1.model
+                    : $0.totalTokens > $1.totalTokens
+            }
+    }
+
+    /// Every model name the ledger knows about, detail ∪ rollups, sorted.
+    /// Intended to populate a filter picker, so it deliberately ignores the
+    /// date range.
+    public func availableModels(tools: [ToolType]? = nil) throws -> [String] {
+        if let tools, tools.isEmpty { return [] }
+        var clause = ""
+        var bindings: [Binding] = []
+        if let tools {
+            clause = " WHERE tool IN (\(placeholders(tools.count)))"
+            bindings = tools.map { .text($0.rawValue) }
+        }
+        let statement = try prepare(
+            """
+            SELECT model FROM usage_events\(clause)
+            UNION
+            SELECT model FROM usage_daily_rollups\(clause)
+            ORDER BY 1
+            """
+        )
+        defer { sqlite3_finalize(statement) }
+        bindAll(bindings + bindings, to: statement)
+        var models: [String] = []
+        while sqlite3_step(statement) == SQLITE_ROW {
+            if let model = columnText(statement, 0) { models.append(model) }
+        }
+        return models
+    }
+
+    private func forEachGroup(
+        _ filter: UsageQueryFilter,
+        column: String,
+        _ body: (String, Int, Int64, Int64) -> Void
+    ) throws {
+        let detail = detailPredicate(filter)
+        let detailStatement = try prepare(
+            """
+            SELECT \(column), COUNT(*),
+                   COALESCE(SUM(fresh_input + output + cache_read + cache_creation), 0),
+                   COALESCE(SUM(cost_micros), 0)
+              FROM usage_events WHERE \(detail.sql) GROUP BY \(column)
+            """
+        )
+        defer { sqlite3_finalize(detailStatement) }
+        bindAll(detail.bindings, to: detailStatement)
+        while sqlite3_step(detailStatement) == SQLITE_ROW {
+            guard let key = columnText(detailStatement, 0) else { continue }
+            body(
+                key,
+                Int(sqlite3_column_int64(detailStatement, 1)),
+                sqlite3_column_int64(detailStatement, 2),
+                sqlite3_column_int64(detailStatement, 3)
+            )
+        }
+        guard let rollup = rollupPredicate(filter) else { return }
+        let statement = try prepare(
+            """
+            SELECT \(column), COALESCE(SUM(requests), 0),
+                   COALESCE(SUM(fresh_input + output + cache_read + cache_creation), 0),
+                   COALESCE(SUM(cost_micros), 0)
+              FROM usage_daily_rollups WHERE \(rollup.sql) GROUP BY \(column)
+            """
+        )
+        defer { sqlite3_finalize(statement) }
+        bindAll(rollup.bindings, to: statement)
+        while sqlite3_step(statement) == SQLITE_ROW {
+            guard let key = columnText(statement, 0) else { continue }
+            body(
+                key,
+                Int(sqlite3_column_int64(statement, 1)),
+                sqlite3_column_int64(statement, 2),
+                sqlite3_column_int64(statement, 3)
+            )
+        }
+    }
+
+    // MARK: - Predicates
+
+    private struct Predicate {
+        let sql: String
+        let bindings: [Binding]
+    }
+
+    private struct Accumulator {
+        var freshInput: Int64 = 0
+        var output: Int64 = 0
+        var cacheRead: Int64 = 0
+        var cacheCreation: Int64 = 0
+        var cost: Int64 = 0
+
+        static let zero = Accumulator()
+
+        mutating func add(_ statement: OpaquePointer, offset: Int32) {
+            freshInput += sqlite3_column_int64(statement, offset)
+            output += sqlite3_column_int64(statement, offset + 1)
+            cacheRead += sqlite3_column_int64(statement, offset + 2)
+            cacheCreation += sqlite3_column_int64(statement, offset + 3)
+            cost += sqlite3_column_int64(statement, offset + 4)
+        }
+    }
+
+    private func detailPredicate(_ filter: UsageQueryFilter) -> Predicate {
+        if filter.tools?.isEmpty == true || filter.models?.isEmpty == true {
+            return Predicate(sql: "0", bindings: [])
+        }
+        var clauses = ["ts >= ?", "ts < ?"]
+        var bindings: [Binding] = [
+            .integer(Int64(filter.range.start.timeIntervalSince1970.rounded(.down))),
+            .integer(Int64(filter.range.end.timeIntervalSince1970.rounded(.up)))
+        ]
+        if let tools = filter.tools {
+            clauses.append("tool IN (\(placeholders(tools.count)))")
+            bindings.append(contentsOf: tools.map { .text($0.rawValue) })
+        }
+        if let models = filter.models {
+            clauses.append("model IN (\(placeholders(models.count)))")
+            bindings.append(contentsOf: models.map { .text($0) })
+        }
+        return Predicate(sql: clauses.joined(separator: " AND "), bindings: bindings)
+    }
+
+    /// Rollup rows are whole days, so they may only answer for days the
+    /// filter covers end to end. A range that starts mid-afternoon simply
+    /// does not see that day's rollup — which is correct, because a partial
+    /// day cannot be reconstructed from a daily total.
+    private func rollupPredicate(_ filter: UsageQueryFilter) -> Predicate? {
+        if filter.tools?.isEmpty == true || filter.models?.isEmpty == true { return nil }
+        let startOfStart = calendar.startOfDay(for: filter.range.start)
+        let firstFull = startOfStart == filter.range.start
+            ? startOfStart
+            : (calendar.date(byAdding: .day, value: 1, to: startOfStart) ?? startOfStart)
+        let endBoundary = calendar.startOfDay(for: filter.range.end)
+        guard let lastFull = calendar.date(byAdding: .day, value: -1, to: endBoundary),
+              lastFull >= firstFull
+        else { return nil }
+
+        var clauses = ["day >= ?", "day <= ?"]
+        var bindings: [Binding] = [.text(dayString(for: firstFull)), .text(dayString(for: lastFull))]
+        if let tools = filter.tools {
+            clauses.append("tool IN (\(placeholders(tools.count)))")
+            bindings.append(contentsOf: tools.map { .text($0.rawValue) })
+        }
+        if let models = filter.models {
+            clauses.append("model IN (\(placeholders(models.count)))")
+            bindings.append(contentsOf: models.map { .text($0) })
+        }
+        return Predicate(sql: clauses.joined(separator: " AND "), bindings: bindings)
+    }
+
+    private func placeholders(_ count: Int) -> String {
+        Array(repeating: "?", count: max(1, count)).joined(separator: ", ")
+    }
+
+    private func bucketStarts(for range: DateInterval, bucket: UsageTrendBucket) -> [Date] {
+        let component: Calendar.Component = bucket == .hour ? .hour : .day
+        var cursor: Date
+        switch bucket {
+        case .hour:
+            cursor = calendar.dateInterval(of: .hour, for: range.start)?.start ?? range.start
+        case .day:
+            cursor = calendar.startOfDay(for: range.start)
+        }
+        var out: [Date] = []
+        while cursor < range.end, out.count < Self.maximumTrendBuckets {
+            out.append(cursor)
+            guard let next = calendar.date(byAdding: component, value: 1, to: cursor),
+                  next > cursor
+            else { break }
+            cursor = next
+        }
+        return out
+    }
+
+    /// Local-calendar day key. Matches `CostAggregator`'s bucketing —
+    /// gregorian calendar, `en_US_POSIX` locale, the machine's time zone —
+    /// so a ledger day and a snapshot day are always the same day.
+    func dayString(for date: Date) -> String {
+        dayFormatter.string(from: calendar.startOfDay(for: date))
+    }
+
+    // MARK: - SQLite plumbing
+
+    private enum Binding {
+        case text(String)
+        case integer(Int64)
+        case real(Double)
+        case null
+    }
+
+    private func execute(_ sql: String) throws {
+        guard let database, sqlite3_exec(database, sql, nil, nil, nil) == SQLITE_OK else {
+            throw UsageLedgerError.statement
+        }
+    }
+
+    private func prepare(_ sql: String) throws -> OpaquePointer {
+        var statement: OpaquePointer?
+        guard let database,
+              sqlite3_prepare_v2(database, sql, -1, &statement, nil) == SQLITE_OK,
+              let statement
+        else { throw UsageLedgerError.statement }
+        return statement
+    }
+
+    private func run(_ sql: String, _ bindings: [Binding]) throws {
+        let statement = try prepare(sql)
+        defer { sqlite3_finalize(statement) }
+        bindAll(bindings, to: statement)
+        guard sqlite3_step(statement) == SQLITE_DONE else {
+            throw UsageLedgerError.statement
+        }
+    }
+
+    private func scalarText(_ sql: String, _ bindings: [Binding]) throws -> String? {
+        let statement = try prepare(sql)
+        defer { sqlite3_finalize(statement) }
+        bindAll(bindings, to: statement)
+        let result = sqlite3_step(statement)
+        if result == SQLITE_DONE { return nil }
+        guard result == SQLITE_ROW else { throw UsageLedgerError.statement }
+        return columnText(statement, 0)
+    }
+
+    private func bindAll(_ bindings: [Binding], to statement: OpaquePointer) {
+        for (index, value) in bindings.enumerated() {
+            bind(value, at: Int32(index + 1), to: statement)
+        }
+    }
+
+    private func bind(_ value: Binding, at index: Int32, to statement: OpaquePointer) {
+        switch value {
+        case let .text(text): sqlite3_bind_text(statement, index, text, -1, transient)
+        case let .integer(integer): sqlite3_bind_int64(statement, index, integer)
+        case let .real(double): sqlite3_bind_double(statement, index, double)
+        case .null: sqlite3_bind_null(statement, index)
+        }
+    }
+
+    private func columnText(_ statement: OpaquePointer, _ index: Int32) -> String? {
+        guard let raw = sqlite3_column_text(statement, index) else { return nil }
+        return String(cString: raw)
+    }
+}

--- a/Sources/VibeBarCore/Storage/VibeBarLocalStore.swift
+++ b/Sources/VibeBarCore/Storage/VibeBarLocalStore.swift
@@ -106,6 +106,13 @@ public enum VibeBarLocalStore {
         baseDirectory.appendingPathComponent("remote_usage.sqlite3")
     }
 
+    /// Per-request local usage ledger written by `UsageEventLedger`. Kept
+    /// apart from `remote_usage.sqlite3` (other machines' facts) and from
+    /// the per-file scan cache (parse results, not query-able history).
+    public static var usageEventsLedgerURL: URL {
+        baseDirectory.appendingPathComponent("usage_events.sqlite3")
+    }
+
     public static func readData(from url: URL) throws -> Data {
         try Data(contentsOf: url)
     }

--- a/Sources/VibeBarCore/Utilities/UsageFormatting.swift
+++ b/Sources/VibeBarCore/Utilities/UsageFormatting.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+/// Display helpers for the usage ledger's `Int64` micro-USD money and
+/// `Int64` token counts.
+///
+/// Money is stored and summed as integer micro-USD everywhere; this is the
+/// only place it becomes a `Double`, and only to be printed. Conventions
+/// match the existing cost cards (`$1.23`, `1.2k tok`, `3.40M tok`) so the
+/// new usage surfaces read the same as the ones already shipping.
+public enum UsageFormatting {
+    /// `1_234_567` → `"$1.23"`. `precision` is clamped to 0…6 (a micro is
+    /// the smallest unit stored, so more digits would be invented).
+    /// Sub-unit amounts round rather than floor, but a non-zero amount
+    /// never prints as `$0.00`: it falls back to `<$0.01` so a long tail of
+    /// cheap requests doesn't look free.
+    public static func formatMicroUSD(_ micros: Int64, precision: Int = 2) -> String {
+        let digits = min(max(0, precision), 6)
+        let value = Double(micros) / 1_000_000
+        let magnitude = abs(value)
+        if micros != 0, magnitude < pow(10, -Double(digits)) / 2 {
+            let sign = micros < 0 ? "-" : ""
+            let smallest = String(format: "%.\(digits)f", pow(10, -Double(digits)))
+            return "\(sign)<$\(smallest)"
+        }
+        if value < 0 {
+            return String(format: "-$%.\(digits)f", magnitude)
+        }
+        return String(format: "$%.\(digits)f", value)
+    }
+
+    /// `1_234` → `"1.2k"`, `3_400_000` → `"3.40M"`. No unit suffix — the
+    /// caller decides whether to append `" tok"`.
+    public static func compactTokens(_ tokens: Int64) -> String {
+        let sign = tokens < 0 ? "-" : ""
+        let magnitude = Double(tokens.magnitude)
+        if magnitude < 1_000 { return "\(tokens)" }
+        if magnitude < 1_000_000 { return sign + String(format: "%.1fk", magnitude / 1_000) }
+        if magnitude < 1_000_000_000 { return sign + String(format: "%.2fM", magnitude / 1_000_000) }
+        return sign + String(format: "%.2fB", magnitude / 1_000_000_000)
+    }
+
+    /// `compactTokens` with the `" tok"` suffix the cost cards already use.
+    public static func formatTokens(_ tokens: Int64) -> String {
+        "\(compactTokens(tokens)) tok"
+    }
+
+    /// A 0…1 ratio as a percentage. `nil` — no input-side traffic at all —
+    /// prints as an em dash rather than a misleading `0%`.
+    public static func formatPercent(_ ratio: Double?, precision: Int = 1) -> String {
+        guard let ratio, ratio.isFinite else { return "—" }
+        let digits = min(max(0, precision), 4)
+        return String(format: "%.\(digits)f%%", ratio * 100)
+    }
+}

--- a/Tests/VibeBarCoreTests/CostUsageServiceLedgerTests.swift
+++ b/Tests/VibeBarCoreTests/CostUsageServiceLedgerTests.swift
@@ -1,0 +1,179 @@
+import XCTest
+@testable import VibeBarCore
+
+/// End-to-end cover for the wiring `CostUsageService` sets up: a real scan
+/// of synthetic session logs, with a `UsageEventLedger` attached as the
+/// scanner's event sink.
+///
+/// The service itself is deliberately not instantiated here. Its refresh
+/// path talks to `CostHistoryStore.shared` / `CostSnapshotCache.shared`,
+/// which are singletons rooted at the *real* `~/.vibebar`, and its
+/// privacy-mode branch erases them — running that in a unit test would
+/// delete the developer's own cost history. What the service contributes
+/// on top of this test is three one-liners (pass the sink, call
+/// `rollupAndPrune`, call `eraseAll`), and the behaviours those depend on
+/// are exercised directly below.
+final class CostUsageServiceLedgerTests: XCTestCase {
+    private static let isoFormatter: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter
+    }()
+
+    private func makeCodexHome(now: Date) throws -> URL {
+        let fileManager = FileManager.default
+        let home = fileManager.temporaryDirectory
+            .appendingPathComponent("VibeBarLedgerScan-\(UUID().uuidString)", isDirectory: true)
+        let sessions = home
+            .appendingPathComponent(".codex", isDirectory: true)
+            .appendingPathComponent("sessions", isDirectory: true)
+        try fileManager.createDirectory(at: sessions, withIntermediateDirectories: true)
+        let lines = [
+            codexTokenCountLine(
+                timestamp: now.addingTimeInterval(-3 * 3_600), model: "gpt-5",
+                input: 1_000_000, cached: 0, output: 20_000
+            ),
+            codexTokenCountLine(
+                timestamp: now.addingTimeInterval(-2 * 3_600), model: "gpt-5",
+                input: 1_400_000, cached: 200_000, output: 50_000
+            ),
+            codexTokenCountLine(
+                timestamp: now.addingTimeInterval(-3_600), model: "gpt-5-mini",
+                input: 1_600_000, cached: 400_000, output: 90_000
+            )
+        ]
+        try lines.joined(separator: "\n").write(
+            to: sessions.appendingPathComponent("session.jsonl"),
+            atomically: true,
+            encoding: .utf8
+        )
+        return home
+    }
+
+    func testScanWithSinkFillsTheLedgerWithTheSnapshotTotals() async throws {
+        let now = Date(timeIntervalSince1970: 1_762_339_200)
+        let home = try makeCodexHome(now: now)
+        defer { try? FileManager.default.removeItem(at: home) }
+        let (ledger, directory) = try UsageLedgerFixtures.makeLedger("ServiceScan")
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let scanned = await CostUsageScanner.scan(
+            tool: .codex, homeDirectory: home.path, now: now, eventSink: ledger
+        )
+        let snapshot = try XCTUnwrap(scanned)
+        XCTAssertGreaterThan(snapshot.allTimeRequests, 0)
+
+        let filter = UsageLedgerFixtures.wideFilter(around: now)
+        let summary = try await ledger.summary(filter)
+        XCTAssertEqual(summary.requests, snapshot.allTimeRequests)
+        XCTAssertEqual(Int(summary.realTotalTokens), snapshot.allTimeTokens)
+        XCTAssertEqual(
+            Double(try XCTUnwrap(summary.costMicros)) / 1_000_000,
+            snapshot.allTimeCostUSD,
+            accuracy: 0.000_01
+        )
+        XCTAssertEqual(summary.unpricedRequests, 0)
+
+        // Codex reports non-cached input separately, so nothing lands in
+        // the cache-creation column and cache reads come through intact.
+        XCTAssertEqual(summary.cacheCreation, 0)
+        XCTAssertEqual(summary.cacheRead, 400_000)
+
+        let providers = try await ledger.providerStats(filter)
+        XCTAssertEqual(providers.map(\.tool), [.codex])
+        XCTAssertEqual(Int(try XCTUnwrap(providers.first?.totalTokens)), snapshot.allTimeTokens)
+
+        let models = try await ledger.modelStats(filter)
+        XCTAssertEqual(Set(models.map(\.model)), ["gpt-5", "gpt-5-mini"])
+
+        let page = try await ledger.requestPage(filter, page: 0, pageSize: 10)
+        XCTAssertEqual(page.totalCount, snapshot.allTimeRequests)
+        XCTAssertEqual(page.rows.first?.model, "gpt-5-mini")
+    }
+
+    /// The scan cache goes warm after the first pass; a sink attached to a
+    /// fresh ledger has to see the cache-reused files too, or a ledger
+    /// created after the first refresh would never backfill.
+    func testCacheReusedFilesStillReachTheSink() async throws {
+        let now = Date(timeIntervalSince1970: 1_762_339_200)
+        let home = try makeCodexHome(now: now)
+        defer { try? FileManager.default.removeItem(at: home) }
+
+        let (first, firstDirectory) = try UsageLedgerFixtures.makeLedger("ServiceWarmA")
+        defer { try? FileManager.default.removeItem(at: firstDirectory) }
+        _ = await CostUsageScanner.scan(
+            tool: .codex, homeDirectory: home.path, now: now, eventSink: first
+        )
+        let filter = UsageLedgerFixtures.wideFilter(around: now)
+        let seeded = try await first.summary(filter)
+        XCTAssertGreaterThan(seeded.requests, 0)
+
+        // Second pass reads entirely from the warm scan cache.
+        let (second, secondDirectory) = try UsageLedgerFixtures.makeLedger("ServiceWarmB")
+        defer { try? FileManager.default.removeItem(at: secondDirectory) }
+        _ = await CostUsageScanner.scan(
+            tool: .codex, homeDirectory: home.path, now: now, eventSink: second
+        )
+        let backfilled = try await second.summary(filter)
+        XCTAssertEqual(backfilled.requests, seeded.requests)
+        XCTAssertEqual(backfilled.realTotalTokens, seeded.realTotalTokens)
+        XCTAssertEqual(backfilled.costMicros, seeded.costMicros)
+
+        // Re-scanning into the already-populated ledger must not duplicate.
+        _ = await CostUsageScanner.scan(
+            tool: .codex, homeDirectory: home.path, now: now, eventSink: first
+        )
+        let repeated = try await first.summary(filter)
+        XCTAssertEqual(repeated.requests, seeded.requests)
+        XCTAssertEqual(repeated.realTotalTokens, seeded.realTotalTokens)
+    }
+
+    /// Privacy mode never reaches the scanner with a sink attached — the
+    /// service returns before scanning — so a nil sink must leave the
+    /// ledger untouched and the snapshot unchanged.
+    func testScanWithoutSinkWritesNothingAndErasePurges() async throws {
+        let now = Date(timeIntervalSince1970: 1_762_339_200)
+        let home = try makeCodexHome(now: now)
+        defer { try? FileManager.default.removeItem(at: home) }
+        let (ledger, directory) = try UsageLedgerFixtures.makeLedger("ServicePrivacy")
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let filter = UsageLedgerFixtures.wideFilter(around: now)
+        let unsinkedScan = await CostUsageScanner.scan(
+            tool: .codex, homeDirectory: home.path, now: now
+        )
+        let withoutSink = try XCTUnwrap(unsinkedScan)
+        let withoutSinkRequests = try await ledger.summary(filter).requests
+        XCTAssertEqual(withoutSinkRequests, 0)
+
+        let sinkedScan = await CostUsageScanner.scan(
+            tool: .codex, homeDirectory: home.path, now: now, eventSink: ledger
+        )
+        let withSink = try XCTUnwrap(sinkedScan)
+        // The sink is a pure side channel: the snapshot is identical.
+        XCTAssertEqual(withSink.allTimeRequests, withoutSink.allTimeRequests)
+        XCTAssertEqual(withSink.allTimeTokens, withoutSink.allTimeTokens)
+        XCTAssertEqual(withSink.allTimeCostUSD, withoutSink.allTimeCostUSD, accuracy: 0.000_01)
+        let withSinkRequests = try await ledger.summary(filter).requests
+        XCTAssertGreaterThan(withSinkRequests, 0)
+
+        try await ledger.eraseAll()
+        let afterEraseRequests = try await ledger.summary(filter).requests
+        XCTAssertEqual(afterEraseRequests, 0)
+        let afterEraseCost = try await ledger.summary(filter).costMicros
+        XCTAssertNil(afterEraseCost)
+    }
+
+    private func codexTokenCountLine(
+        timestamp: Date,
+        model: String,
+        input: Int,
+        cached: Int,
+        output: Int
+    ) -> String {
+        let timestampString = Self.isoFormatter.string(from: timestamp)
+        return """
+        {"timestamp":"\(timestampString)","type":"event_msg","payload":{"type":"token_count","model":"\(model)","info":{"total_token_usage":{"input_tokens":\(input),"cached_input_tokens":\(cached),"output_tokens":\(output)}}}}
+        """
+    }
+}

--- a/Tests/VibeBarCoreTests/UsageEventLedgerTests.swift
+++ b/Tests/VibeBarCoreTests/UsageEventLedgerTests.swift
@@ -1,0 +1,354 @@
+import XCTest
+@testable import VibeBarCore
+
+/// Shared fixtures for the `UsageEventLedger` test files. Everything is
+/// synthetic: `/Users/example/...` paths and fake session / message ids.
+enum UsageLedgerFixtures {
+    static var calendar: Calendar {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.locale = Locale(identifier: "en_US_POSIX")
+        return calendar
+    }
+
+    /// A ledger on a throwaway file, plus the directory to delete after.
+    static func makeLedger(_ label: String) throws -> (UsageEventLedger, URL) {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("VibeBar\(label)-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let url = directory.appendingPathComponent("usage_events.sqlite3")
+        return (try UsageEventLedger(url: url), directory)
+    }
+
+    static func event(
+        date: Date,
+        model: String = "gpt-5",
+        input: Int = 1_000,
+        output: Int = 200,
+        cache: Int = 0,
+        cacheCreation: Int? = nil,
+        sessionId: String? = nil,
+        messageId: String? = nil,
+        requestId: String? = nil,
+        isSidechain: Bool? = nil,
+        pathRole: CostUsageScanCache.PathRole? = nil,
+        sourceKey: String? = nil,
+        serviceTier: String? = nil
+    ) -> CostUsageScanCache.ParsedEvent {
+        CostUsageScanCache.ParsedEvent(
+            date: date,
+            model: model,
+            input: input,
+            output: output,
+            cache: cache,
+            cacheCreation: cacheCreation,
+            sessionId: sessionId,
+            messageId: messageId,
+            requestId: requestId,
+            isSidechain: isSidechain,
+            pathRole: pathRole,
+            sourceKey: sourceKey,
+            serviceTier: serviceTier
+        )
+    }
+
+    static func priced(
+        _ event: CostUsageScanCache.ParsedEvent,
+        costUSD: Double? = 0.25
+    ) -> PricedUsageEvent {
+        PricedUsageEvent(event: event, costUSD: costUSD)
+    }
+
+    static func batch(
+        tool: ToolType = .codex,
+        path: String = "/Users/example/.codex/sessions/session-a.jsonl",
+        mtime: Date = Date(timeIntervalSince1970: 1_700_000_000),
+        size: Int64 = 4_096,
+        events: [PricedUsageEvent]
+    ) -> UsageEventFileBatch {
+        UsageEventFileBatch(tool: tool, filePath: path, mtime: mtime, size: size, events: events)
+    }
+
+    /// A filter wide enough to catch everything these tests write.
+    static func wideFilter(
+        around date: Date,
+        tools: [ToolType]? = nil,
+        models: [String]? = nil
+    ) -> UsageQueryFilter {
+        UsageQueryFilter(
+            range: DateInterval(
+                start: date.addingTimeInterval(-400 * 86_400),
+                end: date.addingTimeInterval(2 * 86_400)
+            ),
+            tools: tools,
+            models: models
+        )
+    }
+}
+
+final class UsageEventLedgerTests: XCTestCase {
+    private let now = Date(timeIntervalSince1970: 1_762_339_200)
+
+    func testInitCreatesUsableDatabaseOnATemporaryFile() async throws {
+        let (ledger, directory) = try UsageLedgerFixtures.makeLedger("LedgerInit")
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let summary = try await ledger.summary(UsageLedgerFixtures.wideFilter(around: now))
+        XCTAssertEqual(summary.requests, 0)
+        XCTAssertNil(summary.costMicros)
+        XCTAssertNil(summary.cacheHitRate)
+        XCTAssertTrue(
+            FileManager.default.fileExists(
+                atPath: directory.appendingPathComponent("usage_events.sqlite3").path
+            )
+        )
+    }
+
+    /// A second batch carrying the same `(mtime, size)` fingerprint is
+    /// skipped wholesale — proven by handing it *more* events than the
+    /// first and watching the extra one never land.
+    func testUnchangedFingerprintSkipsTheWholeBatch() async throws {
+        let (ledger, directory) = try UsageLedgerFixtures.makeLedger("LedgerFingerprint")
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let first = UsageLedgerFixtures.batch(events: [
+            UsageLedgerFixtures.priced(UsageLedgerFixtures.event(date: now)),
+            UsageLedgerFixtures.priced(UsageLedgerFixtures.event(date: now.addingTimeInterval(-60)))
+        ])
+        try await ledger.ingest(first)
+        let afterFirstIngest = try await ledger.summary(UsageLedgerFixtures.wideFilter(around: now)).requests
+        XCTAssertEqual(afterFirstIngest, 2)
+
+        let sameFingerprint = UsageLedgerFixtures.batch(
+            events: first.events + [
+                UsageLedgerFixtures.priced(UsageLedgerFixtures.event(date: now.addingTimeInterval(-120)))
+            ]
+        )
+        try await ledger.ingest(sameFingerprint)
+        let afterSameFingerprint = try await ledger.summary(UsageLedgerFixtures.wideFilter(around: now)).requests
+        XCTAssertEqual(afterSameFingerprint, 2)
+
+        // A changed fingerprint re-ingests: the two originals upsert onto
+        // their existing dedupe keys, the third is new.
+        let changed = UsageEventFileBatch(
+            tool: sameFingerprint.tool,
+            filePath: sameFingerprint.filePath,
+            mtime: sameFingerprint.mtime.addingTimeInterval(120),
+            size: sameFingerprint.size + 1,
+            events: sameFingerprint.events
+        )
+        try await ledger.ingest(changed)
+        let afterChangedFingerprint = try await ledger.summary(UsageLedgerFixtures.wideFilter(around: now)).requests
+        XCTAssertEqual(afterChangedFingerprint, 3)
+    }
+
+    /// `(messageId, requestId)` is the same billable request no matter how
+    /// many transcripts copied it. The parent, non-sidechain copy must win
+    /// regardless of which file the scan reached first.
+    func testDedupeConflictPrefersTheParentNonSidechainCopy() async throws {
+        for sidechainFirst in [true, false] {
+            let (ledger, directory) = try UsageLedgerFixtures.makeLedger("LedgerConflict")
+            defer { try? FileManager.default.removeItem(at: directory) }
+
+            let parent = UsageLedgerFixtures.event(
+                date: now, model: "claude-sonnet-4-5", input: 100, output: 50,
+                sessionId: "session-1", messageId: "msg-1", requestId: "req-1",
+                isSidechain: false, pathRole: .parent, sourceKey: "path-v1-aaa"
+            )
+            let sidechain = UsageLedgerFixtures.event(
+                date: now, model: "claude-sonnet-4-5", input: 900, output: 400,
+                sessionId: "session-1", messageId: "msg-1", requestId: "req-1",
+                isSidechain: true, pathRole: .subagent, sourceKey: "path-v1-bbb"
+            )
+            let parentBatch = UsageLedgerFixtures.batch(
+                tool: .claude,
+                path: "/Users/example/.claude/projects/demo/parent.jsonl",
+                events: [UsageLedgerFixtures.priced(parent, costUSD: 0.10)]
+            )
+            let sidechainBatch = UsageLedgerFixtures.batch(
+                tool: .claude,
+                path: "/Users/example/.claude/projects/demo/subagents/child.jsonl",
+                events: [UsageLedgerFixtures.priced(sidechain, costUSD: 0.90)]
+            )
+            if sidechainFirst {
+                try await ledger.ingest(sidechainBatch)
+                try await ledger.ingest(parentBatch)
+            } else {
+                try await ledger.ingest(parentBatch)
+                try await ledger.ingest(sidechainBatch)
+            }
+
+            let summary = try await ledger.summary(UsageLedgerFixtures.wideFilter(around: now))
+            XCTAssertEqual(summary.requests, 1, "sidechainFirst=\(sidechainFirst)")
+            XCTAssertEqual(summary.freshInput, 100, "sidechainFirst=\(sidechainFirst)")
+            XCTAssertEqual(summary.output, 50, "sidechainFirst=\(sidechainFirst)")
+            XCTAssertEqual(summary.costMicros, 100_000, "sidechainFirst=\(sidechainFirst)")
+        }
+    }
+
+    /// Same message, both copies in a parent path: the smaller source key
+    /// wins, matching `CostUsageScanner.claudeEventWins`'s final tiebreak.
+    func testDedupeConflictTiebreaksOnSourceKey() async throws {
+        let (ledger, directory) = try UsageLedgerFixtures.makeLedger("LedgerTiebreak")
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let low = UsageLedgerFixtures.event(
+            date: now, model: "claude-sonnet-4-5", input: 111, output: 11,
+            messageId: "msg-2", requestId: "req-2",
+            isSidechain: false, pathRole: .parent, sourceKey: "path-v1-aaa"
+        )
+        let high = UsageLedgerFixtures.event(
+            date: now, model: "claude-sonnet-4-5", input: 222, output: 22,
+            messageId: "msg-2", requestId: "req-2",
+            isSidechain: false, pathRole: .parent, sourceKey: "path-v1-zzz"
+        )
+        try await ledger.ingest(UsageLedgerFixtures.batch(
+            tool: .claude, path: "/Users/example/.claude/projects/demo/z.jsonl",
+            events: [UsageLedgerFixtures.priced(high)]
+        ))
+        try await ledger.ingest(UsageLedgerFixtures.batch(
+            tool: .claude, path: "/Users/example/.claude/projects/demo/a.jsonl",
+            events: [UsageLedgerFixtures.priced(low)]
+        ))
+
+        let summary = try await ledger.summary(UsageLedgerFixtures.wideFilter(around: now))
+        XCTAssertEqual(summary.requests, 1)
+        XCTAssertEqual(summary.freshInput, 111)
+    }
+
+    /// Claude reports `cache` as read + creation combined and repeats the
+    /// creation half in `cacheCreation`; ingest must split them back apart.
+    func testClaudeCombinedCacheFieldSplitsIntoReadAndCreation() async throws {
+        let (ledger, directory) = try UsageLedgerFixtures.makeLedger("LedgerCacheSplit")
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let event = UsageLedgerFixtures.event(
+            date: now, model: "claude-sonnet-4-5", input: 400, output: 80,
+            cache: 700, cacheCreation: 100,
+            messageId: "msg-3", requestId: "req-3"
+        )
+        try await ledger.ingest(UsageLedgerFixtures.batch(
+            tool: .claude, path: "/Users/example/.claude/projects/demo/s.jsonl",
+            events: [UsageLedgerFixtures.priced(event)]
+        ))
+
+        let summary = try await ledger.summary(UsageLedgerFixtures.wideFilter(around: now))
+        XCTAssertEqual(summary.freshInput, 400)
+        XCTAssertEqual(summary.cacheRead, 600)
+        XCTAssertEqual(summary.cacheCreation, 100)
+        XCTAssertEqual(summary.output, 80)
+        XCTAssertEqual(summary.realTotalTokens, 1_180)
+    }
+
+    func testUnpricedRowsAreCountedButContributeNoCost() async throws {
+        let (ledger, directory) = try UsageLedgerFixtures.makeLedger("LedgerUnpriced")
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        try await ledger.ingest(UsageLedgerFixtures.batch(events: [
+            UsageLedgerFixtures.priced(UsageLedgerFixtures.event(date: now), costUSD: 0.50),
+            UsageLedgerFixtures.priced(
+                UsageLedgerFixtures.event(date: now.addingTimeInterval(-60)), costUSD: nil
+            ),
+            UsageLedgerFixtures.priced(
+                UsageLedgerFixtures.event(date: now.addingTimeInterval(-120)), costUSD: nil
+            )
+        ]))
+
+        let summary = try await ledger.summary(UsageLedgerFixtures.wideFilter(around: now))
+        XCTAssertEqual(summary.requests, 3)
+        XCTAssertEqual(summary.unpricedRequests, 2)
+        XCTAssertEqual(summary.costMicros, 500_000)
+    }
+
+    /// With nothing priced at all, cost is `nil` rather than a misleading
+    /// `$0.00`.
+    func testCostIsNilWhenNoRowCarriedAPrice() async throws {
+        let (ledger, directory) = try UsageLedgerFixtures.makeLedger("LedgerAllUnpriced")
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        try await ledger.ingest(UsageLedgerFixtures.batch(events: [
+            UsageLedgerFixtures.priced(UsageLedgerFixtures.event(date: now), costUSD: nil)
+        ]))
+
+        let summary = try await ledger.summary(UsageLedgerFixtures.wideFilter(around: now))
+        XCTAssertEqual(summary.requests, 1)
+        XCTAssertEqual(summary.unpricedRequests, 1)
+        XCTAssertNil(summary.costMicros)
+    }
+
+    func testEraseAllClearsEventsRollupsAndFingerprints() async throws {
+        let (ledger, directory) = try UsageLedgerFixtures.makeLedger("LedgerErase")
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let batch = UsageLedgerFixtures.batch(events: [
+            UsageLedgerFixtures.priced(UsageLedgerFixtures.event(date: now))
+        ])
+        try await ledger.ingest(batch)
+        try await ledger.rollupAndPrune(now: now, detailDays: 0, retentionDays: 0)
+        let floorAfterRollup = try await ledger.detailFloorDay(for: .codex)
+        XCTAssertNotNil(floorAfterRollup)
+
+        try await ledger.eraseAll()
+
+        let summary = try await ledger.summary(UsageLedgerFixtures.wideFilter(around: now))
+        XCTAssertEqual(summary.requests, 0)
+        XCTAssertNil(summary.costMicros)
+        let floorAfterErase = try await ledger.detailFloorDay(for: .codex)
+        XCTAssertNil(floorAfterErase)
+        // The fingerprint went with it, so the very same batch re-ingests.
+        try await ledger.ingest(batch)
+        let afterReingest = try await ledger.summary(UsageLedgerFixtures.wideFilter(around: now)).requests
+        XCTAssertEqual(afterReingest, 1)
+    }
+
+    func testProviderAndModelStatsGroupAcrossTools() async throws {
+        let (ledger, directory) = try UsageLedgerFixtures.makeLedger("LedgerStats")
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        try await ledger.ingest(UsageLedgerFixtures.batch(
+            tool: .codex,
+            path: "/Users/example/.codex/sessions/one.jsonl",
+            events: [
+                UsageLedgerFixtures.priced(
+                    UsageLedgerFixtures.event(date: now, model: "gpt-5", input: 1_000, output: 100),
+                    costUSD: 1.0
+                ),
+                UsageLedgerFixtures.priced(
+                    UsageLedgerFixtures.event(
+                        date: now.addingTimeInterval(-60), model: "gpt-5", input: 500, output: 50
+                    ),
+                    costUSD: 0.5
+                )
+            ]
+        ))
+        try await ledger.ingest(UsageLedgerFixtures.batch(
+            tool: .claude,
+            path: "/Users/example/.claude/projects/demo/one.jsonl",
+            events: [
+                UsageLedgerFixtures.priced(
+                    UsageLedgerFixtures.event(
+                        date: now, model: "claude-sonnet-4-5", input: 10, output: 5,
+                        messageId: "msg-9", requestId: "req-9"
+                    ),
+                    costUSD: 0.25
+                )
+            ]
+        ))
+
+        let providers = try await ledger.providerStats(UsageLedgerFixtures.wideFilter(around: now))
+        XCTAssertEqual(providers.map(\.tool), [.codex, .claude])
+        XCTAssertEqual(providers.first?.requests, 2)
+        XCTAssertEqual(providers.first?.totalTokens, 1_650)
+        XCTAssertEqual(providers.first?.costMicros, 1_500_000)
+
+        let models = try await ledger.modelStats(UsageLedgerFixtures.wideFilter(around: now))
+        XCTAssertEqual(models.map(\.model), ["gpt-5", "claude-sonnet-4-5"])
+        XCTAssertEqual(models.first?.avgCostMicrosPerRequest, 750_000)
+
+        let allModels = try await ledger.availableModels()
+        XCTAssertEqual(allModels, ["claude-sonnet-4-5", "gpt-5"])
+        let claudeModels = try await ledger.availableModels(tools: [.claude])
+        XCTAssertEqual(claudeModels, ["claude-sonnet-4-5"])
+        let noToolModels = try await ledger.availableModels(tools: [])
+        XCTAssertEqual(noToolModels, [])
+    }
+}

--- a/Tests/VibeBarCoreTests/UsageFormattingTests.swift
+++ b/Tests/VibeBarCoreTests/UsageFormattingTests.swift
@@ -1,0 +1,66 @@
+import XCTest
+@testable import VibeBarCore
+
+final class UsageFormattingTests: XCTestCase {
+    func testMicroUSDFormatting() {
+        XCTAssertEqual(UsageFormatting.formatMicroUSD(0), "$0.00")
+        XCTAssertEqual(UsageFormatting.formatMicroUSD(1_234_567), "$1.23")
+        XCTAssertEqual(UsageFormatting.formatMicroUSD(1_235_000), "$1.24")
+        XCTAssertEqual(UsageFormatting.formatMicroUSD(123_456_789), "$123.46")
+        XCTAssertEqual(UsageFormatting.formatMicroUSD(1_234_567, precision: 0), "$1")
+        XCTAssertEqual(UsageFormatting.formatMicroUSD(1_234_567, precision: 4), "$1.2346")
+    }
+
+    /// A tiny-but-nonzero amount must never print as `$0.00` — that reads
+    /// as free, and the whole point of the ledger is that a long tail of
+    /// cheap requests adds up.
+    func testSubCentAmountsFallBackToALessThanForm() {
+        XCTAssertEqual(UsageFormatting.formatMicroUSD(1), "<$0.01")
+        XCTAssertEqual(UsageFormatting.formatMicroUSD(4_000), "<$0.01")
+        XCTAssertEqual(UsageFormatting.formatMicroUSD(-1), "-<$0.01")
+        XCTAssertEqual(UsageFormatting.formatMicroUSD(5_000), "$0.01")
+    }
+
+    func testNegativeAmountsKeepTheSignOutsideTheCurrency() {
+        XCTAssertEqual(UsageFormatting.formatMicroUSD(-1_500_000), "-$1.50")
+    }
+
+    func testPrecisionIsClampedToTheStoredResolution() {
+        XCTAssertEqual(UsageFormatting.formatMicroUSD(1_234_567, precision: -5), "$1")
+        XCTAssertEqual(UsageFormatting.formatMicroUSD(1_234_567, precision: 99), "$1.234567")
+    }
+
+    func testCompactTokenFormatting() {
+        XCTAssertEqual(UsageFormatting.compactTokens(0), "0")
+        XCTAssertEqual(UsageFormatting.compactTokens(999), "999")
+        XCTAssertEqual(UsageFormatting.compactTokens(1_000), "1.0k")
+        XCTAssertEqual(UsageFormatting.compactTokens(12_345), "12.3k")
+        XCTAssertEqual(UsageFormatting.compactTokens(3_400_000), "3.40M")
+        XCTAssertEqual(UsageFormatting.compactTokens(2_000_000_000), "2.00B")
+        XCTAssertEqual(UsageFormatting.compactTokens(-12_345), "-12.3k")
+    }
+
+    func testTokenFormattingKeepsTheExistingSuffix() {
+        XCTAssertEqual(UsageFormatting.formatTokens(500), "500 tok")
+        XCTAssertEqual(UsageFormatting.formatTokens(1_500_000), "1.50M tok")
+    }
+
+    func testPercentFormatting() {
+        XCTAssertEqual(UsageFormatting.formatPercent(nil), "—")
+        XCTAssertEqual(UsageFormatting.formatPercent(0), "0.0%")
+        XCTAssertEqual(UsageFormatting.formatPercent(0.6), "60.0%")
+        XCTAssertEqual(UsageFormatting.formatPercent(0.12345, precision: 2), "12.35%")
+        XCTAssertEqual(UsageFormatting.formatPercent(1), "100.0%")
+        XCTAssertEqual(UsageFormatting.formatPercent(.nan), "—")
+    }
+
+    /// The one place a `Double` cost becomes money.
+    func testCostUSDToMicrosRoundsHalfAwayFromZeroOnce() {
+        XCTAssertEqual(PricedUsageEvent.micros(fromUSD: 1.2345675), 1_234_568)
+        XCTAssertEqual(PricedUsageEvent.micros(fromUSD: 0), 0)
+        XCTAssertEqual(PricedUsageEvent.micros(fromUSD: -0.5), -500_000)
+        XCTAssertNil(PricedUsageEvent.micros(fromUSD: .nan))
+        XCTAssertNil(PricedUsageEvent.micros(fromUSD: .infinity))
+        XCTAssertNil(PricedUsageEvent.micros(fromUSD: 1e30))
+    }
+}

--- a/Tests/VibeBarCoreTests/UsageLedgerRollupTests.swift
+++ b/Tests/VibeBarCoreTests/UsageLedgerRollupTests.swift
@@ -1,0 +1,193 @@
+import XCTest
+@testable import VibeBarCore
+
+final class UsageLedgerRollupTests: XCTestCase {
+    private let now = Date(timeIntervalSince1970: 1_762_339_200)
+    private let calendar = UsageLedgerFixtures.calendar
+
+    /// Local noon `offset` days from today, so a day bucket is never
+    /// ambiguous across time zones.
+    private func day(_ offset: Int) throws -> Date {
+        let today = calendar.startOfDay(for: now)
+        let start = try XCTUnwrap(calendar.date(byAdding: .day, value: offset, to: today))
+        return try XCTUnwrap(calendar.date(byAdding: .hour, value: 12, to: start))
+    }
+
+    private func seedBatch(size: Int64 = 4_096) throws -> UsageEventFileBatch {
+        UsageLedgerFixtures.batch(
+            size: size,
+            events: try [-40, -35, -5, 0].map { offset in
+                UsageLedgerFixtures.priced(
+                    UsageLedgerFixtures.event(
+                        date: try day(offset), model: "gpt-5", input: 1_000, output: 100
+                    ),
+                    costUSD: 1.0
+                )
+            }
+        )
+    }
+
+    private var fullRange: UsageQueryFilter {
+        UsageLedgerFixtures.wideFilter(around: now)
+    }
+
+    func testRollupMovesOldDetailIntoRollupsExactlyOnce() async throws {
+        let (ledger, directory) = try UsageLedgerFixtures.makeLedger("RollupOnce")
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        try await ledger.ingest(try seedBatch())
+        let before = try await ledger.summary(fullRange)
+        XCTAssertEqual(before.requests, 4)
+        XCTAssertEqual(before.costMicros, 4_000_000)
+        let seededPage = try await ledger.requestPage(fullRange, page: 0, pageSize: 50)
+        XCTAssertEqual(seededPage.totalCount, 4)
+
+        try await ledger.rollupAndPrune(now: now, detailDays: 30, retentionDays: 0)
+
+        // Totals survive the fold; only the request-level rows shrink.
+        let after = try await ledger.summary(fullRange)
+        XCTAssertEqual(after.requests, 4)
+        XCTAssertEqual(after.costMicros, 4_000_000)
+        XCTAssertEqual(after.realTotalTokens, before.realTotalTokens)
+        let foldedPage = try await ledger.requestPage(fullRange, page: 0, pageSize: 50)
+        XCTAssertEqual(foldedPage.totalCount, 2)
+
+        // Running it again must not double count the rows it already folded.
+        try await ledger.rollupAndPrune(now: now, detailDays: 30, retentionDays: 0)
+        let again = try await ledger.summary(fullRange)
+        XCTAssertEqual(again.requests, 4)
+        XCTAssertEqual(again.costMicros, 4_000_000)
+    }
+
+    func testReconsumingPreFloorEventsIsDropped() async throws {
+        let (ledger, directory) = try UsageLedgerFixtures.makeLedger("RollupFloor")
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        try await ledger.ingest(try seedBatch())
+        try await ledger.rollupAndPrune(now: now, detailDays: 30, retentionDays: 0)
+
+        let floor = try await ledger.detailFloorDay(for: .codex)
+        XCTAssertNotNil(floor)
+
+        // Same file, changed fingerprint — a full re-parse after a scan
+        // cache reset. The two pre-floor events must not come back.
+        try await ledger.ingest(try seedBatch(size: 8_192))
+
+        let summary = try await ledger.summary(fullRange)
+        XCTAssertEqual(summary.requests, 4)
+        XCTAssertEqual(summary.costMicros, 4_000_000)
+        let reconsumedPage = try await ledger.requestPage(fullRange, page: 0, pageSize: 50)
+        XCTAssertEqual(reconsumedPage.totalCount, 2)
+    }
+
+    func testRetentionPrunesRollupsAndStragglingDetail() async throws {
+        let (ledger, directory) = try UsageLedgerFixtures.makeLedger("RollupRetention")
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        try await ledger.ingest(try seedBatch())
+        try await ledger.rollupAndPrune(now: now, detailDays: 30, retentionDays: 0)
+        let foldedRequests = try await ledger.summary(fullRange).requests
+        XCTAssertEqual(foldedRequests, 4)
+
+        // A 7-day window keeps today and the day-5 event only.
+        try await ledger.rollupAndPrune(now: now, detailDays: 30, retentionDays: 7)
+
+        let summary = try await ledger.summary(fullRange)
+        XCTAssertEqual(summary.requests, 2)
+        XCTAssertEqual(summary.costMicros, 2_000_000)
+    }
+
+    /// The chart has to read straight across the detail/rollup boundary
+    /// without a visible seam.
+    func testTrendStitchesRollupDaysAndDetailDays() async throws {
+        let (ledger, directory) = try UsageLedgerFixtures.makeLedger("RollupTrend")
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        try await ledger.ingest(try seedBatch())
+        try await ledger.rollupAndPrune(now: now, detailDays: 30, retentionDays: 0)
+
+        let start = calendar.startOfDay(for: try day(-45))
+        let end = try XCTUnwrap(
+            calendar.date(byAdding: .day, value: 1, to: calendar.startOfDay(for: now))
+        )
+        let filter = UsageQueryFilter(range: DateInterval(start: start, end: end))
+        let series = try await ledger.trend(filter, bucket: .day)
+
+        XCTAssertEqual(series.bucket, .day)
+        XCTAssertEqual(series.points.count, 46)
+        let nonEmpty = series.points.filter { $0.totalTokens > 0 }
+        XCTAssertEqual(nonEmpty.count, 4)
+        XCTAssertEqual(nonEmpty.map(\.costMicros), [1_000_000, 1_000_000, 1_000_000, 1_000_000])
+        XCTAssertEqual(series.points.reduce(Int64(0)) { $0 + $1.totalTokens }, 4_400)
+
+        // The two oldest are rollup-backed, the two newest detail-backed.
+        let oldest = try day(-40)
+        let recent = try day(-5)
+        let rolledUp = try XCTUnwrap(
+            nonEmpty.first { calendar.isDate($0.bucketStart, inSameDayAs: oldest) }
+        )
+        XCTAssertEqual(rolledUp.freshInput, 1_000)
+        XCTAssertEqual(rolledUp.output, 100)
+        let detailed = try XCTUnwrap(
+            nonEmpty.first { calendar.isDate($0.bucketStart, inSameDayAs: recent) }
+        )
+        XCTAssertEqual(detailed.freshInput, 1_000)
+
+        let summary = try await ledger.summary(filter)
+        XCTAssertEqual(summary.requests, 4)
+        XCTAssertEqual(summary.costMicros, 4_000_000)
+    }
+
+    /// Rollups are whole days, so a range that only covers part of a day
+    /// must not pick that day's rollup up.
+    func testPartialDayRangeDoesNotReadWholeDayRollups() async throws {
+        let (ledger, directory) = try UsageLedgerFixtures.makeLedger("RollupPartial")
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        try await ledger.ingest(try seedBatch())
+        try await ledger.rollupAndPrune(now: now, detailDays: 30, retentionDays: 0)
+
+        let noon = try day(-40)
+        let partial = UsageQueryFilter(
+            range: DateInterval(start: noon.addingTimeInterval(-3_600), end: noon.addingTimeInterval(3_600))
+        )
+        let partialRequests = try await ledger.summary(partial).requests
+        XCTAssertEqual(partialRequests, 0)
+
+        let wholeDay = try XCTUnwrap(calendar.dateInterval(of: .day, for: noon))
+        let wholeDayRequests = try await ledger.summary(UsageQueryFilter(range: wholeDay)).requests
+        XCTAssertEqual(wholeDayRequests, 1)
+    }
+
+    /// A provider whose first ingest lands after another provider's rollup
+    /// must still be allowed to backfill its own history.
+    func testFloorIsPerToolSoALateProviderStillBackfills() async throws {
+        let (ledger, directory) = try UsageLedgerFixtures.makeLedger("RollupPerTool")
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        try await ledger.ingest(try seedBatch())
+        try await ledger.rollupAndPrune(now: now, detailDays: 30, retentionDays: 0)
+        let claudeFloor = try await ledger.detailFloorDay(for: .claude)
+        XCTAssertNil(claudeFloor)
+
+        try await ledger.ingest(UsageLedgerFixtures.batch(
+            tool: .claude,
+            path: "/Users/example/.claude/projects/demo/old.jsonl",
+            events: [
+                UsageLedgerFixtures.priced(
+                    UsageLedgerFixtures.event(
+                        date: try day(-60), model: "claude-sonnet-4-5", input: 7, output: 3,
+                        messageId: "msg-old", requestId: "req-old"
+                    ),
+                    costUSD: 0.01
+                )
+            ]
+        ))
+
+        let claudeOnly = UsageLedgerFixtures.wideFilter(around: now, tools: [.claude])
+        let claudeRequests = try await ledger.summary(claudeOnly).requests
+        XCTAssertEqual(claudeRequests, 1)
+        let claudeTokens = try await ledger.summary(claudeOnly).realTotalTokens
+        XCTAssertEqual(claudeTokens, 10)
+    }
+}

--- a/Tests/VibeBarCoreTests/UsageQueryMetricsTests.swift
+++ b/Tests/VibeBarCoreTests/UsageQueryMetricsTests.swift
@@ -1,0 +1,250 @@
+import XCTest
+@testable import VibeBarCore
+
+final class UsageQueryMetricsTests: XCTestCase {
+    private let now = Date(timeIntervalSince1970: 1_762_339_200)
+    private let calendar = UsageLedgerFixtures.calendar
+
+    // MARK: - Pure formulas
+
+    func testRealTotalTokensSumsEveryNonOverlappingColumn() {
+        let metrics = UsageSummaryMetrics(
+            requests: 3, unpricedRequests: 0, costMicros: 1,
+            freshInput: 100, output: 20, cacheRead: 700, cacheCreation: 80
+        )
+        XCTAssertEqual(metrics.realTotalTokens, 900)
+    }
+
+    func testCacheHitRateExcludesOutputAndIsNilWithoutInputTraffic() throws {
+        let hot = UsageSummaryMetrics(
+            requests: 1, unpricedRequests: 0, costMicros: 0,
+            freshInput: 100, output: 9_999, cacheRead: 300, cacheCreation: 100
+        )
+        XCTAssertEqual(try XCTUnwrap(hot.cacheHitRate), 0.6, accuracy: 0.000_001)
+
+        let outputOnly = UsageSummaryMetrics(
+            requests: 1, unpricedRequests: 0, costMicros: 0,
+            freshInput: 0, output: 500, cacheRead: 0, cacheCreation: 0
+        )
+        XCTAssertNil(outputOnly.cacheHitRate)
+        XCTAssertNil(UsageSummaryMetrics.empty.cacheHitRate)
+    }
+
+    func testAverageMicrosRoundsHalfUpAndGuardsZeroRequests() {
+        XCTAssertEqual(UsageModelStat.averageMicros(total: 10, requests: 4), 3)
+        XCTAssertEqual(UsageModelStat.averageMicros(total: 1_500_000, requests: 2), 750_000)
+        XCTAssertEqual(UsageModelStat.averageMicros(total: -10, requests: 4), -3)
+        XCTAssertEqual(UsageModelStat.averageMicros(total: 99, requests: 0), 0)
+    }
+
+    func testTrendBucketRuleSwitchesAtTwentyFourHours() {
+        let start = Date(timeIntervalSince1970: 1_762_300_000)
+        XCTAssertEqual(
+            UsageTrendBucket.recommended(for: DateInterval(start: start, duration: 3_600)), .hour
+        )
+        XCTAssertEqual(
+            UsageTrendBucket.recommended(for: DateInterval(start: start, duration: 24 * 3_600)), .hour
+        )
+        XCTAssertEqual(
+            UsageTrendBucket.recommended(for: DateInterval(start: start, duration: 24 * 3_600 + 1)), .day
+        )
+        XCTAssertEqual(
+            UsageTrendBucket.recommended(for: DateInterval(start: start, duration: 30 * 86_400)), .day
+        )
+    }
+
+    func testRequestPageCountReportsWholePages() {
+        XCTAssertEqual(UsageRequestPage(rows: [], totalCount: 10, page: 0, pageSize: 5).pageCount, 2)
+        XCTAssertEqual(UsageRequestPage(rows: [], totalCount: 11, page: 0, pageSize: 5).pageCount, 3)
+        XCTAssertEqual(UsageRequestPage(rows: [], totalCount: 0, page: 0, pageSize: 5).pageCount, 0)
+    }
+
+    // MARK: - Zero-filled trend
+
+    func testHourlyTrendZeroFillsEveryBucketInRange() async throws {
+        let (ledger, directory) = try UsageLedgerFixtures.makeLedger("MetricsHourly")
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let hourStart = try XCTUnwrap(calendar.dateInterval(of: .hour, for: now)).start
+        let start = try XCTUnwrap(calendar.date(byAdding: .hour, value: -23, to: hourStart))
+        let end = try XCTUnwrap(calendar.date(byAdding: .hour, value: 1, to: hourStart))
+        let inFirstHour = start.addingTimeInterval(120)
+        let inLastHour = hourStart.addingTimeInterval(120)
+
+        try await ledger.ingest(UsageLedgerFixtures.batch(events: [
+            UsageLedgerFixtures.priced(
+                UsageLedgerFixtures.event(date: inFirstHour, input: 300, output: 30), costUSD: 0.3
+            ),
+            UsageLedgerFixtures.priced(
+                UsageLedgerFixtures.event(date: inLastHour, input: 700, output: 70), costUSD: 0.7
+            )
+        ]))
+
+        let filter = UsageQueryFilter(range: DateInterval(start: start, end: end))
+        XCTAssertEqual(UsageTrendBucket.recommended(for: filter.range), .hour)
+
+        let series = try await ledger.trend(filter)
+        XCTAssertEqual(series.bucket, .hour)
+        XCTAssertEqual(series.points.count, 24)
+        XCTAssertEqual(series.points.first?.bucketStart, start)
+        XCTAssertEqual(series.points.first?.freshInput, 300)
+        XCTAssertEqual(series.points.last?.bucketStart, hourStart)
+        XCTAssertEqual(series.points.last?.freshInput, 700)
+        XCTAssertEqual(series.points.filter { $0.totalTokens == 0 }.count, 22)
+        XCTAssertEqual(series.points.reduce(Int64(0)) { $0 + $1.costMicros }, 1_000_000)
+    }
+
+    func testDailyTrendZeroFillsEveryDayInRange() async throws {
+        let (ledger, directory) = try UsageLedgerFixtures.makeLedger("MetricsDaily")
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let today = calendar.startOfDay(for: now)
+        let start = try XCTUnwrap(calendar.date(byAdding: .day, value: -6, to: today))
+        let end = try XCTUnwrap(calendar.date(byAdding: .day, value: 1, to: today))
+        let midday = try XCTUnwrap(calendar.date(byAdding: .hour, value: 10, to: start))
+
+        try await ledger.ingest(UsageLedgerFixtures.batch(events: [
+            UsageLedgerFixtures.priced(
+                UsageLedgerFixtures.event(date: midday, input: 10, output: 1), costUSD: 0.01
+            )
+        ]))
+
+        let filter = UsageQueryFilter(range: DateInterval(start: start, end: end))
+        XCTAssertEqual(UsageTrendBucket.recommended(for: filter.range), .day)
+
+        let series = try await ledger.trend(filter)
+        XCTAssertEqual(series.bucket, .day)
+        XCTAssertEqual(series.points.count, 7)
+        XCTAssertEqual(series.points.first?.bucketStart, start)
+        XCTAssertEqual(series.points.first?.totalTokens, 11)
+        XCTAssertEqual(series.points.dropFirst().reduce(Int64(0)) { $0 + $1.totalTokens }, 0)
+    }
+
+    // MARK: - Filters
+
+    func testToolAndModelFiltersNarrowEveryQuery() async throws {
+        let (ledger, directory) = try UsageLedgerFixtures.makeLedger("MetricsFilters")
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        try await ledger.ingest(UsageLedgerFixtures.batch(
+            tool: .codex,
+            path: "/Users/example/.codex/sessions/mixed.jsonl",
+            events: [
+                UsageLedgerFixtures.priced(
+                    UsageLedgerFixtures.event(date: now, model: "gpt-5", input: 100, output: 10),
+                    costUSD: 0.1
+                ),
+                UsageLedgerFixtures.priced(
+                    UsageLedgerFixtures.event(
+                        date: now.addingTimeInterval(-60), model: "gpt-5-mini", input: 200, output: 20
+                    ),
+                    costUSD: 0.2
+                )
+            ]
+        ))
+        try await ledger.ingest(UsageLedgerFixtures.batch(
+            tool: .claude,
+            path: "/Users/example/.claude/projects/demo/mixed.jsonl",
+            events: [
+                UsageLedgerFixtures.priced(
+                    UsageLedgerFixtures.event(
+                        date: now, model: "claude-sonnet-4-5", input: 400, output: 40,
+                        messageId: "msg-f", requestId: "req-f"
+                    ),
+                    costUSD: 0.4
+                )
+            ]
+        ))
+
+        let all = try await ledger.summary(UsageLedgerFixtures.wideFilter(around: now))
+        XCTAssertEqual(all.requests, 3)
+
+        let codexOnly = try await ledger.summary(
+            UsageLedgerFixtures.wideFilter(around: now, tools: [.codex])
+        )
+        XCTAssertEqual(codexOnly.requests, 2)
+        XCTAssertEqual(codexOnly.costMicros, 300_000)
+
+        let miniOnly = try await ledger.summary(
+            UsageLedgerFixtures.wideFilter(around: now, models: ["gpt-5-mini"])
+        )
+        XCTAssertEqual(miniOnly.requests, 1)
+        XCTAssertEqual(miniOnly.freshInput, 200)
+
+        let bothNarrowed = try await ledger.summary(
+            UsageLedgerFixtures.wideFilter(around: now, tools: [.claude], models: ["gpt-5"])
+        )
+        XCTAssertEqual(bothNarrowed.requests, 0)
+
+        // An empty list means "nothing selected", not "everything".
+        let noTools = try await ledger.summary(
+            UsageLedgerFixtures.wideFilter(around: now, tools: [])
+        )
+        XCTAssertEqual(noTools.requests, 0)
+        XCTAssertNil(noTools.costMicros)
+
+        let providers = try await ledger.providerStats(
+            UsageLedgerFixtures.wideFilter(around: now, tools: [.claude])
+        )
+        XCTAssertEqual(providers.map(\.tool), [.claude])
+
+        // Out-of-range: everything is older than this window.
+        let future = UsageQueryFilter(
+            range: DateInterval(
+                start: now.addingTimeInterval(86_400), end: now.addingTimeInterval(2 * 86_400)
+            )
+        )
+        let futureRequests = try await ledger.summary(future).requests
+        XCTAssertEqual(futureRequests, 0)
+    }
+
+    // MARK: - Pagination
+
+    func testRequestPageBoundaries() async throws {
+        let (ledger, directory) = try UsageLedgerFixtures.makeLedger("MetricsPaging")
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let events = (0..<10).map { index in
+            UsageLedgerFixtures.priced(
+                UsageLedgerFixtures.event(
+                    date: now.addingTimeInterval(TimeInterval(-60 * index)),
+                    input: 100 + index, output: 1
+                ),
+                costUSD: 0.01
+            )
+        }
+        try await ledger.ingest(UsageLedgerFixtures.batch(events: events))
+        let filter = UsageLedgerFixtures.wideFilter(around: now)
+
+        let first = try await ledger.requestPage(filter, page: 0, pageSize: 5)
+        XCTAssertEqual(first.totalCount, 10)
+        XCTAssertEqual(first.rows.count, 5)
+        XCTAssertEqual(first.pageCount, 2)
+        // Newest first.
+        XCTAssertEqual(first.rows.first?.date, now)
+        XCTAssertEqual(first.rows.first?.freshInput, 100)
+        XCTAssertEqual(first.rows.first?.tool, .codex)
+        XCTAssertEqual(first.rows.first?.costMicros, 10_000)
+
+        let second = try await ledger.requestPage(filter, page: 1, pageSize: 5)
+        XCTAssertEqual(second.rows.count, 5)
+        XCTAssertEqual(second.rows.last?.freshInput, 109)
+
+        // Exact multiple: the page right after the last full one is empty
+        // but still reports the real total.
+        let past = try await ledger.requestPage(filter, page: 2, pageSize: 5)
+        XCTAssertTrue(past.rows.isEmpty)
+        XCTAssertEqual(past.totalCount, 10)
+        XCTAssertEqual(past.page, 2)
+
+        let wayPast = try await ledger.requestPage(filter, page: 99, pageSize: 5)
+        XCTAssertTrue(wayPast.rows.isEmpty)
+        XCTAssertEqual(wayPast.totalCount, 10)
+
+        // Negative page and zero page size are clamped, never fatal.
+        let clamped = try await ledger.requestPage(filter, page: -3, pageSize: 0)
+        XCTAssertEqual(clamped.page, 0)
+        XCTAssertEqual(clamped.pageSize, 1)
+        XCTAssertEqual(clamped.rows.count, 1)
+    }
+}


### PR DESCRIPTION
## Summary

First of three Workbench deliverables: a standalone window (with a Dock presence while open) hosting Usage Stats, plus placeholders for the upcoming Sessions and Skills pages.

**Window shell + Dock activation**
- `WorkbenchWindowController` mirrors the Settings window pattern (cached NSWindow, full environment-object injection, frame autosave); `DockActivationController` flips the LSUIElement app between `.accessory` and `.regular` by token refcount so the Dock icon exists exactly while the Workbench is open.
- A minimal main menu gives LSUIElement windows working ⌘W/⌘C/⌘V; Dock reopen re-fronts an open Workbench but never resurrects a closed one. Entry points: popover header button and the status-item context menu.

**Per-request usage ledger (Core)**
- `CostUsageScanner` gains an optional event sink that forwards each file's priced per-request events — including cache-reused files, so a fresh ledger backfills from existing scan caches in one pass with zero re-parsing. Behavior with a nil sink is byte-identical (all pre-existing tests unchanged).
- `UsageEventLedger` (SQLite actor, `~/.vibebar/usage_events.sqlite3`) stores events with file-fingerprint idempotency and the scanner's own Claude dedupe preference (non-sidechain → parent → lexicographic sourceKey), rolls detail older than 30 days into daily rollups behind a per-tool floor, prunes to the retention setting, and answers summary / trend / request-page / provider / model queries. Money is integer micro-USD end to end; unpriced events stay NULL.

**Usage Stats page**
- Brand-accented provider chips, model + date-range + auto-refresh menus with cascading filters; hero tiles (real tokens, cost with unpriced badge, requests, cache hit rate); a two-pane Swift Charts card (stacked token-component gradients over a cost line, shared snapped hover with glass tooltip); segmented Requests / Providers / Models tables with infinite scroll.

## Verification

- `swift build` clean; `swift test` 1160 tests, 0 failures (35 new ledger/rollup/metrics/formatting/service tests).
- `./Scripts/build_app.sh release` + `codesign -d --entitlements -` (empty `<dict/>`, no `app-sandbox`) + `codesign --verify --deep --strict` all pass.
- Real-home grep gate clean; ledger SQL fully parameterized.

🤖 Generated with [Claude Code](https://claude.com/claude-code)