### PR TITLE
Add the Workbench Skills page with SSOT sync

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -450,6 +450,26 @@ Tests keep working because they pass an explicit value.
   discipline a sandboxed app would: read only the credential / cookie /
   config files you actually need, never write outside `~/.vibebar/`,
   and never log raw secrets.
+- **The Skills manager is a narrow, documented exception to that write
+  scope.** It writes to exactly two things: `~/.agents/skills/` — the
+  single source of truth every agent CLI is projected from — and the
+  seven managed app skills directories (`~/.claude/skills`,
+  `~/.codex/skills`, `~/.gemini/skills`, `~/.grok/skills`,
+  `~/.hermes/skills`, `~/.config/opencode/skills`,
+  `~/.gemini/config/skills`). Nothing else, and never directly: every
+  create, link, copy, and delete goes through `SkillSyncEngine` /
+  `SkillsService`, which validate each directory name as a single safe
+  path segment, refuse any resolved path outside those roots, require a
+  `SKILL.md` before any sync, create missing ancestors one component at
+  a time, never follow a symlink while deleting, and remove only
+  symlinks that resolve back into the SSOT or copies whose recorded
+  content hash still matches — so a folder the user authored or edited
+  is left in place. Vibe Bar reads `~/.agents/.skill-lock.json` for
+  provenance and never writes it, and pre-uninstall snapshots stay under
+  `~/.vibebar/skill_backups/`. `~/.gemini/config/skills` is
+  AntiGravity's customization root, not the Gemini CLI's — nothing else
+  under `~/.gemini/config/` may be touched. New code that needs a skills
+  path goes through those two types; do not add a second write path.
 - **Performance.** Avoid `TimelineView(.periodic(...))` in deep view
   trees that may be eagerly instantiated; prefer scoping to the visible
   surface. The mini window's screen position is persisted to its own
@@ -669,7 +689,9 @@ Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
 - **Avoid `TimelineView(.periodic(...))` in deep view trees** that may
   be eagerly instantiated. Scope live timers to the visible surface.
 - **New persistent state** goes through `VibeBarLocalStore` and lives
-  under `~/.vibebar/`. Do not write to `~/` directly from new code.
+  under `~/.vibebar/`. Do not write to `~/` directly from new code. The
+  only exception is the skills write allow-list in § 7, and it is
+  reached exclusively through `SkillSyncEngine` / `SkillsService`.
 - **Every user-facing Settings control must round-trip through
   `AppSettings`.** Add its Codable key, a backward-compatible decode default,
   and a round-trip test. Migrations must be one-time and evidence-based; never

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,10 +65,14 @@ ignored. The full reasoning and grep recipes live in `AGENTS.md`.
    one-line entitlement edit. The flip side: unsandboxed *is not* a
    license for casual filesystem access — read only the credential /
    cookie / config files you actually need, never write outside
-   `~/.vibebar/`, never log raw secrets. The single exception is
-   whole-session deletion through `SessionDeleter`, performed only at the
-   user's explicit request and on the containment / symlink /
-   re-parsed-session-id terms `AGENTS.md` § 5 sets out.
+   `~/.vibebar/`, never log raw secrets. There are exactly two
+   exceptions: whole-session deletion through `SessionDeleter`,
+   performed only at the user's explicit request and on the
+   containment / symlink / re-parsed-session-id terms `AGENTS.md` § 5
+   sets out; and the Skills manager, which may write to
+   `~/.agents/skills/` and the seven managed app skills directories
+   and nowhere else, only through `SkillSyncEngine` / `SkillsService`
+   — see `AGENTS.md` § 7 for the full terms.
 4. **Verification before completion.** Before claiming a change works,
    run all four:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,9 +74,12 @@ See `AGENTS.md` § 6 for the full reasoning.
   the user's filesystem with the same discipline a sandboxed app would:
   read only the credential / cookie / config files you actually need,
   never write outside `~/.vibebar/`, and never log raw secrets.
-- The single exception is whole-session deletion through `SessionDeleter`,
-  performed only at the user's explicit request and on the containment /
-  symlink / re-parsed-session-id terms `AGENTS.md` § 5 sets out.
+- There are exactly two exceptions: whole-session deletion through
+  `SessionDeleter`, performed only at the user's explicit request and on
+  the containment / symlink / re-parsed-session-id terms `AGENTS.md` § 5
+  sets out; and the Skills manager, which writes only to
+  `~/.agents/skills/` and the seven managed app skills directories, and
+  only through `SkillSyncEngine` / `SkillsService` (`AGENTS.md` § 7).
 
 ## Implementation Notes
 

--- a/Sources/VibeBarApp/Controllers/SkillsManagerModel.swift
+++ b/Sources/VibeBarApp/Controllers/SkillsManagerModel.swift
@@ -1,0 +1,436 @@
+import Combine
+import Foundation
+import VibeBarCore
+
+/// State behind the Workbench's Skills page.
+///
+/// `SkillsService` is an actor and every method here reaches it through
+/// `await`, so no filesystem walk, no zip extraction, and no repository
+/// download ever runs on the main thread — only the finished value is assigned
+/// back to a `@Published` property.
+///
+/// Every mutating action goes through `perform(_:_:)`, which owns the three
+/// things each of them needs identically: a busy key so a second tap on the
+/// same row is a no-op, a reload of the registry afterwards so the list
+/// describes the disk again, and one error surface (`toast`) rather than a
+/// per-action alert.
+@MainActor
+final class SkillsManagerModel: ObservableObject {
+    /// Keys into `busy`. Strings rather than an enum because the set mixes
+    /// page-wide operations with per-skill and per-row ones.
+    enum BusyKey {
+        static let updates = "updates"
+        static let discover = "discover"
+        static let search = "search"
+        static let importing = "import"
+        static let zip = "zip"
+
+        static func skill(_ id: SkillID) -> String { "skill:\(id.rawValue)" }
+        static func install(_ id: SkillID) -> String { "install:\(id.rawValue)" }
+        static func searchRow(_ id: String) -> String { "search-row:\(id)" }
+        static func backup(_ name: String) -> String { "backup:\(name)" }
+    }
+
+    // MARK: - Installed skills
+
+    @Published private(set) var skills: [Skill] = []
+    @Published var searchText = ""
+    @Published private(set) var updateStates: [SkillID: SkillUpdateState] = [:]
+    @Published private(set) var busy: Set<String> = []
+    @Published var toast: String?
+
+    // MARK: - Sheets
+
+    @Published var importReport: SkillImportReport?
+    @Published var isImportSheetPresented = false
+    @Published var isDiscoverSheetPresented = false
+    @Published var isBackupsSheetPresented = false
+
+    @Published private(set) var repoList: [String] = []
+    @Published private(set) var discoverResults: [DiscoveredSkill] = []
+    /// What produced `discoverResults`. Shown in the sheet because a single
+    /// staging directory backs them: scanning the configured repos and
+    /// installing a skills.sh hit are the same operation underneath, and the
+    /// second replaces the first.
+    @Published private(set) var discoverSource: String?
+    @Published private(set) var searchResults: [SkillsShSearchResult] = []
+    @Published private(set) var backups: [SkillBackupManager.Backup] = []
+
+    private let settingsStore: SettingsStore
+    private let service: SkillsService
+    private let searchClient: SkillsSearchClient
+    private var searchTask: Task<Void, Never>?
+    private var hasActivated = false
+
+    init(
+        settingsStore: SettingsStore,
+        service: SkillsService = SkillsService(),
+        searchClient: SkillsSearchClient = SkillsSearchClient()
+    ) {
+        self.settingsStore = settingsStore
+        self.service = service
+        self.searchClient = searchClient
+    }
+
+    // MARK: - Derived
+
+    /// Case-insensitive match on name, description, and the serialized id, so
+    /// `owner/repo` narrows to one repository's skills.
+    var filteredSkills: [Skill] {
+        let needle = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !needle.isEmpty else { return skills }
+        return skills.filter { skill in
+            skill.name.localizedCaseInsensitiveContains(needle)
+                || (skill.description?.localizedCaseInsensitiveContains(needle) ?? false)
+                || skill.id.rawValue.localizedCaseInsensitiveContains(needle)
+        }
+    }
+
+    func installedCount(for app: SkillAppTarget) -> Int {
+        skills.reduce(into: 0) { total, skill in
+            if skill.isEnabled(for: app) { total += 1 }
+        }
+    }
+
+    func updateState(for skill: Skill) -> SkillUpdateState? {
+        updateStates[skill.id]
+    }
+
+    var updatesAvailableCount: Int {
+        updateStates.values.count { $0.updateAvailable }
+    }
+
+    func isBusy(_ key: String) -> Bool { busy.contains(key) }
+
+    func isBusy(skill: Skill) -> Bool { busy.contains(BusyKey.skill(skill.id)) }
+
+    // MARK: - Lifecycle
+
+    /// Loads the registry, and — on a machine that has skills on disk but
+    /// nothing recorded — opens the import sheet unasked. That is the primary
+    /// onboarding path: `~/.agents/skills` is usually already full, linked
+    /// into the app dirs by another installer, and recording it is a read-only
+    /// scan followed by one confirmation.
+    func activate() {
+        guard !hasActivated else { return }
+        hasActivated = true
+        Task {
+            await reloadSkills()
+            repoList = await service.discoverRepos()
+            guard skills.isEmpty else { return }
+            let report = await scanForImport()
+            guard !report.adopted.isEmpty || !report.unmanagedDirectories.isEmpty else { return }
+            importReport = report
+            isImportSheetPresented = true
+        }
+    }
+
+    func refresh() {
+        Task { await reloadSkills() }
+    }
+
+    // MARK: - Per-skill actions
+
+    func toggle(skill: Skill, app: SkillAppTarget) {
+        let enable = !skill.isEnabled(for: app)
+        let method = settingsStore.settings.skillsSyncMethod
+        let id = skill.id
+        perform(BusyKey.skill(id)) { [self] in
+            let changed = try await service.setEnabled(id, app: app, enabled: enable, method: method)
+            // Disabling reports `false` when the app-side entry was a foreign
+            // directory or an edited copy: the enable bit still cleared, but
+            // the user's files were left where they are and they should hear
+            // about it rather than discover the skill still loading.
+            if !enable, !changed {
+                toast = "\(skill.name) is no longer managed for \(app.displayName), "
+                    + "but the existing folder was left in place."
+            }
+        }
+    }
+
+    func uninstall(_ skill: Skill) {
+        let id = skill.id
+        perform(BusyKey.skill(id)) { [self] in
+            let result = try await service.uninstall(id)
+            updateStates[id] = nil
+            let kept = SkillAppTarget.allCases
+                .filter { skill.isEnabled(for: $0) && result.removedByApp[$0] == false }
+            toast = kept.isEmpty
+                ? "Uninstalled \(skill.name). A backup was saved."
+                : "Uninstalled \(skill.name). Left in place for "
+                    + kept.map(\.displayName).joined(separator: ", ") + "."
+        }
+    }
+
+    func checkForUpdates() {
+        perform(BusyKey.updates) { [self] in
+            let states = await service.checkForUpdates()
+            updateStates = Dictionary(uniqueKeysWithValues: states.map { ($0.id, $0) })
+            let available = states.count { $0.updateAvailable }
+            toast = available == 0
+                ? "Every repository skill is up to date."
+                : "\(available) skill\(available == 1 ? "" : "s") can be updated."
+        }
+    }
+
+    func updateSkill(_ skill: Skill) {
+        let id = skill.id
+        perform(BusyKey.skill(id)) { [self] in
+            let updated = try await service.update(id)
+            updateStates[id] = nil
+            toast = "Updated \(updated.name)."
+        }
+    }
+
+    // MARK: - Discovery
+
+    func discover() {
+        perform(BusyKey.discover) { [self] in
+            let refs = await service.discoverRepoRefs()
+            guard !refs.isEmpty else {
+                discoverResults = []
+                discoverSource = nil
+                toast = "Add a repository first."
+                return
+            }
+            discoverResults = await service.discoverSkills(from: refs)
+            discoverSource = "Configured repositories"
+            if discoverResults.isEmpty {
+                toast = "No skills were found in the configured repositories."
+            }
+        }
+    }
+
+    /// Drops the staging directory the last discovery pass left behind. Called
+    /// when the sheet closes: the extracted trees are only useful while their
+    /// rows are on screen, and they can be hundreds of megabytes.
+    func discoverSheetDismissed() {
+        searchTask?.cancel()
+        searchTask = nil
+        Task { [service] in await service.clearDiscoveryStaging() }
+        discoverResults = []
+        discoverSource = nil
+        searchResults = []
+    }
+
+    /// Debounced so typing a query does not put one request per keystroke on
+    /// skills.sh.
+    func searchSkillsSh(query: String) {
+        searchTask?.cancel()
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            searchResults = []
+            busy.remove(BusyKey.search)
+            return
+        }
+        busy.insert(BusyKey.search)
+        searchTask = Task { [searchClient] in
+            try? await Task.sleep(for: .milliseconds(300))
+            guard !Task.isCancelled else { return }
+            do {
+                let results = try await searchClient.search(trimmed)
+                guard !Task.isCancelled else { return }
+                searchResults = results
+                if results.isEmpty { toast = "skills.sh returned no matches." }
+            } catch {
+                guard !Task.isCancelled else { return }
+                searchResults = []
+                toast = error.localizedDescription
+            }
+            busy.remove(BusyKey.search)
+        }
+    }
+
+    func installDiscovered(_ discovered: DiscoveredSkill, apps: [SkillAppTarget]) {
+        let method = settingsStore.settings.skillsSyncMethod
+        perform(BusyKey.install(discovered.id)) { [self] in
+            let installed = try await service.install(discovered, enableFor: apps, method: method)
+            toast = apps.isEmpty
+                ? "Installed \(installed.name)."
+                : "Installed \(installed.name) for \(apps.map(\.displayName).joined(separator: ", "))."
+        }
+    }
+
+    /// Installs a skills.sh hit by downloading the repository it names and
+    /// picking the matching skill out of it.
+    ///
+    /// The download replaces the discovery staging, so the repo's other skills
+    /// become the visible results — the alternative would be leaving rows on
+    /// screen whose sources have just been deleted underneath them.
+    func installSearchResult(_ result: SkillsShSearchResult, apps: [SkillAppTarget]) {
+        let method = settingsStore.settings.skillsSyncMethod
+        perform(BusyKey.searchRow(result.id)) { [self] in
+            let found = await service.discoverSkills(from: [result.repo])
+            discoverResults = found
+            discoverSource = "\(result.repo.descriptor) (from skills.sh)"
+            guard let match = Self.match(result.name, in: found) else {
+                toast = "\(result.name) was not found in \(result.repo.slug)."
+                return
+            }
+            let installed = try await service.install(match, enableFor: apps, method: method)
+            toast = apps.isEmpty
+                ? "Installed \(installed.name)."
+                : "Installed \(installed.name) for \(apps.map(\.displayName).joined(separator: ", "))."
+        }
+    }
+
+    func installZip(url: URL, apps: [SkillAppTarget]) {
+        let method = settingsStore.settings.skillsSyncMethod
+        perform(BusyKey.zip) { [self] in
+            let installed = try await service.installFromZip(at: url, enableFor: apps, method: method)
+            guard !installed.isEmpty else {
+                toast = "Nothing in that archive could be installed."
+                return
+            }
+            let count = "\(installed.count) skill\(installed.count == 1 ? "" : "s")"
+            toast = apps.isEmpty
+                ? "Installed \(count) from the archive. Switch each one on for the apps you want."
+                : "Installed \(count) from the archive for \(apps.map(\.displayName).joined(separator: ", "))."
+        }
+    }
+
+    // MARK: - Repository list
+
+    func addRepo(_ raw: String) {
+        perform(BusyKey.discover) { [self] in
+            guard try await service.addDiscoverRepo(raw) else {
+                toast = "\"\(raw)\" is not a new owner/repo[@branch] reference."
+                return
+            }
+            repoList = await service.discoverRepos()
+        }
+    }
+
+    func removeRepo(_ raw: String) {
+        perform(BusyKey.discover) { [self] in
+            _ = try await service.removeDiscoverRepo(raw)
+            repoList = await service.discoverRepos()
+        }
+    }
+
+    // MARK: - Import
+
+    func presentImportSheet() {
+        perform(BusyKey.importing) { [self] in
+            importReport = await scanForImport()
+            isImportSheetPresented = true
+        }
+    }
+
+    /// Records the scan's adopted skills, then copies each opted-in unmanaged
+    /// directory into the SSOT.
+    ///
+    /// Adoption is per directory rather than all-or-nothing because an
+    /// unmanaged directory is real content in an app's own folder: bringing it
+    /// under management replaces it with a link, and that is a decision the
+    /// user makes one row at a time.
+    func runImport(apps: [SkillAppTarget], adopting: [String: [SkillAppTarget]]) {
+        guard let report = importReport else { return }
+        let method = settingsStore.settings.skillsSyncMethod
+        perform(BusyKey.importing) { [self] in
+            var recorded = try await service.importAdopted(report, apps: apps).count
+            var failed = 0
+            for directory in adopting.keys.sorted() {
+                guard
+                    let targets = adopting[directory], !targets.isEmpty,
+                    let source = report.unmanagedDirectories
+                        .first(where: { $0.directoryName == directory })?
+                        .foundIn.first
+                else { continue }
+                do {
+                    _ = try await service.adoptUnmanaged(
+                        directoryName: directory,
+                        from: source,
+                        apps: targets,
+                        method: method
+                    )
+                    recorded += 1
+                } catch {
+                    failed += 1
+                    toast = error.localizedDescription
+                }
+            }
+            isImportSheetPresented = false
+            importReport = nil
+            if failed == 0 {
+                toast = "Recorded \(recorded) skill\(recorded == 1 ? "" : "s")."
+            }
+        }
+    }
+
+    // MARK: - Backups
+
+    func presentBackupsSheet() {
+        Task {
+            backups = await listBackups()
+            isBackupsSheetPresented = true
+        }
+    }
+
+    func reloadBackups() {
+        Task { backups = await listBackups() }
+    }
+
+    func restoreBackup(_ backup: SkillBackupManager.Backup) {
+        perform(BusyKey.backup(backup.directoryName)) { [self] in
+            let restored = try await service.restoreBackup(backup.url)
+            backups = await listBackups()
+            toast = "Restored \(restored.name). Enable it for the apps you want it in."
+        }
+    }
+
+    func deleteBackup(_ backup: SkillBackupManager.Backup) {
+        perform(BusyKey.backup(backup.directoryName)) { [self] in
+            let service = self.service
+            let url = backup.url
+            try await Task.detached { try service.deleteBackup(url) }.value
+            backups = await listBackups()
+        }
+    }
+
+    // MARK: - Internals
+
+    /// Runs one mutating action: guards re-entry on `key`, reloads the
+    /// registry when it finishes, and routes any error to `toast`.
+    private func perform(_ key: String, _ body: @MainActor @escaping () async throws -> Void) {
+        guard !busy.contains(key) else { return }
+        busy.insert(key)
+        Task {
+            do {
+                try await body()
+            } catch {
+                toast = error.localizedDescription
+            }
+            await reloadSkills()
+            busy.remove(key)
+        }
+    }
+
+    private func reloadSkills() async {
+        skills = await service.installedSkills()
+    }
+
+    /// `scanForImport` and `listBackups` are `nonisolated` on the service —
+    /// convenient, but they walk the filesystem, so they are pushed off the
+    /// main thread explicitly instead of being called inline.
+    private func scanForImport() async -> SkillImportReport {
+        let service = self.service
+        return await Task.detached { service.scanForImport() }.value
+    }
+
+    private func listBackups() async -> [SkillBackupManager.Backup] {
+        let service = self.service
+        return await Task.detached { service.listBackups() }.value
+    }
+
+    /// skills.sh reports a display name; the repository lays the skill out
+    /// under a directory. Match on either, case-insensitively, because neither
+    /// side promises the other's spelling.
+    private static func match(_ name: String, in discovered: [DiscoveredSkill]) -> DiscoveredSkill? {
+        discovered.first { $0.name == name || $0.directory == name }
+            ?? discovered.first {
+                $0.name.caseInsensitiveCompare(name) == .orderedSame
+                    || $0.directory.caseInsensitiveCompare(name) == .orderedSame
+            }
+    }
+}

--- a/Sources/VibeBarApp/Controllers/WorkbenchServices.swift
+++ b/Sources/VibeBarApp/Controllers/WorkbenchServices.swift
@@ -26,4 +26,9 @@ final class WorkbenchServices: ObservableObject {
     )
 
     lazy var sessions = SessionManagerModel(settingsStore: settingsStore)
+
+    /// Lazy for the same reason as the usage page, and more so: building it
+    /// opens `~/.vibebar/skills.json` and, on first activation, walks every
+    /// agent CLI's skills directory.
+    lazy var skills = SkillsManagerModel(settingsStore: settingsStore)
 }

--- a/Sources/VibeBarApp/Views/Workbench/SkillBackupsSheet.swift
+++ b/Sources/VibeBarApp/Views/Workbench/SkillBackupsSheet.swift
@@ -1,0 +1,147 @@
+import SwiftUI
+import VibeBarCore
+
+/// Snapshots taken before an uninstall or an update.
+///
+/// A repository-backed skill can always be fetched again; a locally authored
+/// one exists here and nowhere else once its directory is gone. That is why
+/// restore is one click and delete asks first.
+struct SkillBackupsSheet: View {
+    let density: Theme.Density
+    @ObservedObject var model: SkillsManagerModel
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var pendingDeletion: SkillBackupManager.Backup?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            header
+            Divider()
+            content
+            Divider()
+            footer
+        }
+        .frame(width: 620, height: 520)
+        .confirmationDialog(
+            pendingDeletion.map { "Delete the backup of \($0.skill?.name ?? $0.directoryName)?" }
+                ?? "Delete this backup?",
+            isPresented: Binding(
+                get: { pendingDeletion != nil },
+                set: { if !$0 { pendingDeletion = nil } }
+            ),
+            titleVisibility: .visible
+        ) {
+            Button("Delete", role: .destructive) {
+                if let backup = pendingDeletion { model.deleteBackup(backup) }
+                pendingDeletion = nil
+            }
+            Button("Cancel", role: .cancel) { pendingDeletion = nil }
+        } message: {
+            Text("The snapshot is removed from ~/.vibebar and cannot be restored afterwards.")
+        }
+    }
+
+    private var header: some View {
+        HStack(spacing: 10) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Skill Backups")
+                    .font(.system(size: density.titleFontSize, weight: .semibold))
+                Text("Taken automatically before an uninstall or an update.")
+                    .font(.system(size: density.subtitleFontSize))
+                    .foregroundStyle(.secondary)
+            }
+            Spacer(minLength: 8)
+            SectionRefreshButton(isRefreshing: false) { model.reloadBackups() }
+                .help("Re-read the backup directory")
+        }
+        .padding(.horizontal, density.popoverPaddingH)
+        .padding(.vertical, 12)
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if model.backups.isEmpty {
+            VStack(spacing: 10) {
+                Image(systemName: "clock.arrow.circlepath")
+                    .font(.system(size: 24, weight: .light))
+                    .foregroundStyle(.secondary)
+                Text("No backups yet")
+                    .font(.system(size: density.subtitleFontSize))
+                    .foregroundStyle(.secondary)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else {
+            List(model.backups) { backup in
+                row(backup)
+                    .listRowBackground(Color.clear)
+            }
+            .listStyle(.inset)
+            .scrollContentBackground(.hidden)
+        }
+    }
+
+    private func row(_ backup: SkillBackupManager.Backup) -> some View {
+        let busy = model.isBusy(SkillsManagerModel.BusyKey.backup(backup.directoryName))
+        return HStack(spacing: 10) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(backup.skill?.name ?? backup.directoryName)
+                    .font(.system(size: density.bucketTitleFontSize, weight: .semibold))
+                    .lineLimit(1)
+                HStack(spacing: 6) {
+                    Text(Self.dateFormatter.string(from: backup.createdAt))
+                        .font(.system(size: max(9, density.resetCountdownFontSize), design: .rounded)
+                            .monospacedDigit())
+                        .foregroundStyle(.tertiary)
+                    if let slug = backup.skill?.id.repositorySlug {
+                        Text(slug)
+                            .font(.system(size: max(9, density.resetCountdownFontSize),
+                                          design: .monospaced))
+                            .foregroundStyle(.tertiary)
+                    }
+                }
+            }
+            Spacer(minLength: 8)
+            if busy {
+                ProgressView().controlSize(.small)
+            }
+            Button("Restore") { model.restoreBackup(backup) }
+                .buttonStyle(.glass)
+                .disabled(busy)
+                .help("Copy the snapshot back into ~/.agents/skills")
+            Button {
+                pendingDeletion = backup
+            } label: {
+                Image(systemName: "trash")
+                    .foregroundStyle(.secondary)
+            }
+            .buttonStyle(.plain)
+            .disabled(busy)
+            .accessibilityLabel("Delete this backup")
+        }
+        .padding(.vertical, 4)
+    }
+
+    private var footer: some View {
+        HStack(spacing: 10) {
+            Text("Restoring recreates the shared directory only — enable the skill for the apps "
+                + "you want it in afterwards.")
+                .font(.system(size: max(9, density.resetCountdownFontSize)))
+                .foregroundStyle(.tertiary)
+                .fixedSize(horizontal: false, vertical: true)
+            Spacer(minLength: 8)
+            Button("Done") { dismiss() }
+                .buttonStyle(.glassProminent)
+                .keyboardShortcut(.defaultAction)
+        }
+        .padding(.horizontal, density.popoverPaddingH)
+        .padding(.vertical, 12)
+    }
+
+    private static let dateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.locale = Locale.current
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .short
+        return formatter
+    }()
+}

--- a/Sources/VibeBarApp/Views/Workbench/SkillDiscoverSheet.swift
+++ b/Sources/VibeBarApp/Views/Workbench/SkillDiscoverSheet.swift
@@ -1,0 +1,334 @@
+import SwiftUI
+import VibeBarCore
+
+/// Where new skills come from: the repositories the user has configured, and
+/// the skills.sh community index.
+///
+/// Both are in one sheet because they answer the same question and end in the
+/// same action. They also share one staging directory underneath — installing
+/// a skills.sh hit downloads that repository, which is why its skills replace
+/// whatever the results list was showing and the header says which source is
+/// on screen.
+struct SkillDiscoverSheet: View {
+    let density: Theme.Density
+    @ObservedObject var model: SkillsManagerModel
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var repoDraft = ""
+    @State private var query = ""
+    /// Apps a row installs into when it has not been touched. Empty by
+    /// design: installing is about getting the skill onto the machine, and
+    /// silently switching it on for seven agent CLIs is not that.
+    @State private var defaultApps: Set<SkillAppTarget> = []
+    @State private var overrides: [String: Set<SkillAppTarget>] = [:]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            header
+            Divider()
+            ScrollView {
+                VStack(alignment: .leading, spacing: density.interSectionSpacing) {
+                    repositoriesSection
+                    searchSection
+                    resultsSection
+                }
+                .padding(.horizontal, density.popoverPaddingH)
+                .padding(.vertical, density.popoverPaddingV)
+                .frame(maxWidth: .infinity, alignment: .topLeading)
+            }
+        }
+        .frame(width: 760, height: 640)
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        HStack(spacing: 10) {
+            Text("Discover Skills")
+                .font(.system(size: density.titleFontSize, weight: .semibold))
+            Spacer(minLength: 8)
+            Button(defaultApps.count == SkillAppTarget.allCases.count ? "Select none" : "Select all") {
+                defaultApps = defaultApps.count == SkillAppTarget.allCases.count
+                    ? []
+                    : Set(SkillAppTarget.allCases)
+                overrides.removeAll()
+            }
+            .buttonStyle(.glass)
+            .help("Set which agent CLIs every row installs into")
+            Button("Done") { dismiss() }
+                .buttonStyle(.glassProminent)
+                .keyboardShortcut(.defaultAction)
+        }
+        .padding(.horizontal, density.popoverPaddingH)
+        .padding(.vertical, 12)
+    }
+
+    // MARK: - Configured repositories
+
+    private var repositoriesSection: some View {
+        CardShell(density: density, spacing: density.cardSpacing) {
+            HStack(spacing: 8) {
+                sectionTitle("Configured repositories")
+                Spacer(minLength: 8)
+                Button {
+                    model.discover()
+                } label: {
+                    HStack(spacing: 5) {
+                        if model.isBusy(SkillsManagerModel.BusyKey.discover) {
+                            ProgressView().controlSize(.small).scaleEffect(0.7)
+                                .frame(width: 12, height: 12)
+                        } else {
+                            Image(systemName: "arrow.down.circle")
+                                .font(.system(size: max(9, density.segmentedFontSize - 1), weight: .semibold))
+                        }
+                        Text("Scan repos")
+                            .font(.system(size: density.segmentedFontSize - 1, weight: .semibold))
+                    }
+                    .frame(minHeight: 22)
+                }
+                .buttonStyle(.glass)
+                .disabled(model.repoList.isEmpty)
+            }
+
+            if model.repoList.isEmpty {
+                Text("No repositories configured. Add one as owner/repo, optionally owner/repo@branch.")
+                    .font(.system(size: density.subtitleFontSize))
+                    .foregroundStyle(.secondary)
+            } else {
+                ForEach(model.repoList, id: \.self) { repo in
+                    HStack(spacing: 8) {
+                        Image(systemName: "shippingbox")
+                            .font(.system(size: density.subtitleFontSize))
+                            .foregroundStyle(.tertiary)
+                        Text(repo)
+                            .font(.system(size: density.subtitleFontSize, design: .monospaced))
+                            .lineLimit(1)
+                        Spacer(minLength: 8)
+                        Button {
+                            model.removeRepo(repo)
+                        } label: {
+                            Image(systemName: "minus.circle")
+                                .foregroundStyle(.secondary)
+                        }
+                        .buttonStyle(.plain)
+                        .help("Stop scanning \(repo)")
+                        .accessibilityLabel("Remove \(repo)")
+                    }
+                }
+            }
+
+            HStack(spacing: 8) {
+                TextField("owner/repo or owner/repo@branch", text: $repoDraft)
+                    .textFieldStyle(.roundedBorder)
+                    .font(.system(size: density.subtitleFontSize, design: .monospaced))
+                    .onSubmit { addRepo() }
+                Button("Add") { addRepo() }
+                    .buttonStyle(.glass)
+                    .disabled(!isRepoDraftValid)
+            }
+            if !repoDraft.isEmpty, !isRepoDraftValid {
+                Text("Owners take letters, digits, and hyphens; names and branches also take "
+                    + "dots and underscores.")
+                    .font(.system(size: max(9, density.resetCountdownFontSize)))
+                    .foregroundStyle(.tertiary)
+            }
+        }
+    }
+
+    private var isRepoDraftValid: Bool {
+        SkillRepoRef(repoDraft) != nil
+    }
+
+    private func addRepo() {
+        guard isRepoDraftValid else { return }
+        model.addRepo(repoDraft)
+        repoDraft = ""
+    }
+
+    // MARK: - skills.sh
+
+    private var searchSection: some View {
+        CardShell(density: density, spacing: density.cardSpacing) {
+            HStack(spacing: 8) {
+                sectionTitle("skills.sh index")
+                Spacer(minLength: 8)
+                if model.isBusy(SkillsManagerModel.BusyKey.search) {
+                    ProgressView().controlSize(.small)
+                }
+            }
+            TextField("Search the community index", text: $query)
+                .textFieldStyle(.roundedBorder)
+                .font(.system(size: density.subtitleFontSize))
+                .onChange(of: query) { _, newValue in
+                    model.searchSkillsSh(query: newValue)
+                }
+
+            if model.searchResults.isEmpty {
+                Text("Results come back with the repository that publishes them; installing one "
+                    + "downloads that repository and lists the rest of it below.")
+                    .font(.system(size: max(9, density.resetCountdownFontSize)))
+                    .foregroundStyle(.tertiary)
+            } else {
+                ForEach(model.searchResults) { result in
+                    searchRow(result)
+                    if result.id != model.searchResults.last?.id {
+                        Divider().opacity(0.3)
+                    }
+                }
+            }
+        }
+    }
+
+    private func searchRow(_ result: SkillsShSearchResult) -> some View {
+        let key = result.id
+        return HStack(alignment: .top, spacing: 10) {
+            VStack(alignment: .leading, spacing: 3) {
+                Text(result.name)
+                    .font(.system(size: density.bucketTitleFontSize, weight: .semibold))
+                    .lineLimit(1)
+                HStack(spacing: 6) {
+                    Text(result.repo.descriptor)
+                        .font(.system(size: max(9, density.resetCountdownFontSize), design: .monospaced))
+                        .foregroundStyle(.secondary)
+                    if let installs = result.installs {
+                        Text("\(installs) install\(installs == 1 ? "" : "s")")
+                            .font(.system(size: max(9, density.resetCountdownFontSize), design: .rounded)
+                                .monospacedDigit())
+                            .foregroundStyle(.tertiary)
+                    }
+                }
+            }
+            Spacer(minLength: 8)
+            appSelector(key: key)
+            installButton(busyKey: SkillsManagerModel.BusyKey.searchRow(key)) {
+                model.installSearchResult(result, apps: Array(apps(for: key)).sorted { $0.rawValue < $1.rawValue })
+            }
+        }
+        .padding(.vertical, 3)
+    }
+
+    // MARK: - Results
+
+    @ViewBuilder
+    private var resultsSection: some View {
+        CardShell(density: density, spacing: density.cardSpacing) {
+            HStack(spacing: 8) {
+                sectionTitle("Available skills")
+                Spacer(minLength: 8)
+                if let source = model.discoverSource {
+                    Text(source)
+                        .font(.system(size: max(9, density.resetCountdownFontSize)))
+                        .foregroundStyle(.tertiary)
+                        .lineLimit(1)
+                }
+            }
+            if model.discoverResults.isEmpty {
+                Text("Scan the configured repositories, or install a skills.sh result, to list "
+                    + "what is available.")
+                    .font(.system(size: density.subtitleFontSize))
+                    .foregroundStyle(.secondary)
+            } else {
+                ForEach(groupedResults, id: \.repo) { group in
+                    Text(group.repo)
+                        .font(.system(size: max(9, density.resetCountdownFontSize), weight: .semibold,
+                                      design: .monospaced))
+                        .foregroundStyle(.tertiary)
+                        .padding(.top, 2)
+                    ForEach(group.skills) { discovered in
+                        discoveredRow(discovered)
+                    }
+                }
+            }
+        }
+    }
+
+    private var groupedResults: [(repo: String, skills: [DiscoveredSkill])] {
+        Dictionary(grouping: model.discoverResults) { $0.repositorySlug ?? "local" }
+            .map { (repo: $0.key, skills: $0.value) }
+            .sorted { $0.repo.localizedCaseInsensitiveCompare($1.repo) == .orderedAscending }
+    }
+
+    private func discoveredRow(_ discovered: DiscoveredSkill) -> some View {
+        let key = discovered.id.rawValue
+        let installed = model.skills.contains { $0.id == discovered.id }
+        return HStack(alignment: .top, spacing: 10) {
+            VStack(alignment: .leading, spacing: 3) {
+                HStack(spacing: 6) {
+                    Text(discovered.name)
+                        .font(.system(size: density.bucketTitleFontSize, weight: .semibold))
+                        .lineLimit(1)
+                    if installed {
+                        Text("INSTALLED")
+                            .font(.system(size: max(8, density.resetCountdownFontSize - 2), weight: .semibold))
+                            .tracking(0.4)
+                            .foregroundStyle(.secondary)
+                            .padding(.horizontal, 6)
+                            .padding(.vertical, 1)
+                            .background(Capsule().fill(.quaternary.opacity(0.5)))
+                    }
+                }
+                if let description = discovered.description, !description.isEmpty {
+                    Text(description)
+                        .font(.system(size: density.subtitleFontSize))
+                        .foregroundStyle(.tertiary)
+                        .lineLimit(2)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+            Spacer(minLength: 8)
+            appSelector(key: key)
+            installButton(busyKey: SkillsManagerModel.BusyKey.install(discovered.id)) {
+                model.installDiscovered(
+                    discovered,
+                    apps: Array(apps(for: key)).sorted { $0.rawValue < $1.rawValue }
+                )
+            }
+        }
+        .padding(.vertical, 3)
+    }
+
+    // MARK: - Shared row pieces
+
+    private func appSelector(key: String) -> some View {
+        SkillAppToggleRow(
+            isOn: { apps(for: key).contains($0) },
+            toggle: { toggleApp($0, for: key) },
+            diameter: 22,
+            glyphSize: 11,
+            spacing: 3,
+            helpSuffix: "install into"
+        )
+    }
+
+    private func installButton(busyKey: String, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            HStack(spacing: 5) {
+                if model.isBusy(busyKey) {
+                    ProgressView().controlSize(.small).scaleEffect(0.7).frame(width: 12, height: 12)
+                }
+                Text("Install")
+                    .font(.system(size: density.segmentedFontSize - 1, weight: .semibold))
+            }
+            .frame(minHeight: 22)
+        }
+        .buttonStyle(.glass)
+        .disabled(model.isBusy(busyKey))
+    }
+
+    private func sectionTitle(_ text: String) -> some View {
+        Text(text.uppercased())
+            .font(.system(size: max(8, density.segmentedFontSize - 3), weight: .semibold))
+            .foregroundStyle(.tertiary)
+            .tracking(0.4)
+    }
+
+    private func apps(for key: String) -> Set<SkillAppTarget> {
+        overrides[key] ?? defaultApps
+    }
+
+    private func toggleApp(_ app: SkillAppTarget, for key: String) {
+        var selection = apps(for: key)
+        selection.formSymmetricDifference([app])
+        overrides[key] = selection
+    }
+}

--- a/Sources/VibeBarApp/Views/Workbench/SkillImportSheet.swift
+++ b/Sources/VibeBarApp/Views/Workbench/SkillImportSheet.swift
@@ -1,0 +1,270 @@
+import SwiftUI
+import VibeBarCore
+
+/// What an import scan found, and what Vibe Bar would do about it.
+///
+/// The scan itself changed nothing — it only read directories and symlinks —
+/// so this sheet is where the user turns a description of the machine into
+/// records. Adopting the SSOT skills is one button because it writes no files
+/// at all; adopting a foreign app-side directory is per row, because that one
+/// copies real content into `~/.agents/skills` and replaces the original with
+/// a link.
+struct SkillImportSheet: View {
+    let density: Theme.Density
+    @ObservedObject var model: SkillsManagerModel
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var adoptedApps: Set<SkillAppTarget> = []
+    @State private var adopting: [String: Set<SkillAppTarget>] = [:]
+
+    private var report: SkillImportReport? { model.importReport }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            header
+            Divider()
+            if let report {
+                ScrollView {
+                    VStack(alignment: .leading, spacing: density.interSectionSpacing) {
+                        adoptedSection(report)
+                        if !report.unmanagedDirectories.isEmpty { unmanagedSection(report) }
+                        if !report.unrecognized.isEmpty { unrecognizedSection(report) }
+                        if !report.conflicts.isEmpty { conflictsSection(report) }
+                    }
+                    .padding(.horizontal, density.popoverPaddingH)
+                    .padding(.vertical, density.popoverPaddingV)
+                    .frame(maxWidth: .infinity, alignment: .topLeading)
+                }
+                Divider()
+                footer(report)
+            } else {
+                Spacer()
+                ProgressView().controlSize(.small)
+                    .frame(maxWidth: .infinity)
+                Spacer()
+            }
+        }
+        .frame(width: 760, height: 640)
+        .onAppear { seedSelection() }
+        .onChange(of: report) { _, _ in seedSelection() }
+    }
+
+    // MARK: - Chrome
+
+    private var header: some View {
+        HStack(spacing: 10) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Import Existing Skills")
+                    .font(.system(size: density.titleFontSize, weight: .semibold))
+                Text("Nothing here has been changed yet — this is what is on the machine.")
+                    .font(.system(size: density.subtitleFontSize))
+                    .foregroundStyle(.secondary)
+            }
+            Spacer(minLength: 8)
+        }
+        .padding(.horizontal, density.popoverPaddingH)
+        .padding(.vertical, 12)
+    }
+
+    private func footer(_ report: SkillImportReport) -> some View {
+        HStack(spacing: 10) {
+            Text(summary(report))
+                .font(.system(size: density.subtitleFontSize))
+                .foregroundStyle(.secondary)
+            Spacer(minLength: 8)
+            Button("Cancel") {
+                model.isImportSheetPresented = false
+                dismiss()
+            }
+            .buttonStyle(.glass)
+            Button {
+                model.runImport(
+                    apps: Array(adoptedApps).sorted { $0.rawValue < $1.rawValue },
+                    adopting: adopting.mapValues { Array($0).sorted { $0.rawValue < $1.rawValue } }
+                )
+            } label: {
+                HStack(spacing: 5) {
+                    if model.isBusy(SkillsManagerModel.BusyKey.importing) {
+                        ProgressView().controlSize(.small).scaleEffect(0.7).frame(width: 12, height: 12)
+                    }
+                    Text("Record \(report.adopted.count + adopting.count) skill"
+                        + (report.adopted.count + adopting.count == 1 ? "" : "s"))
+                }
+            }
+            .buttonStyle(.glassProminent)
+            .keyboardShortcut(.defaultAction)
+            .disabled(report.adopted.isEmpty && adopting.isEmpty)
+        }
+        .padding(.horizontal, density.popoverPaddingH)
+        .padding(.vertical, 12)
+    }
+
+    private func summary(_ report: SkillImportReport) -> String {
+        "\(report.adopted.count) in ~/.agents/skills · \(report.unmanagedDirectories.count) app-side "
+            + "· \(report.conflicts.count) conflict\(report.conflicts.count == 1 ? "" : "s")"
+    }
+
+    // MARK: - Adopted
+
+    private func adoptedSection(_ report: SkillImportReport) -> some View {
+        CardShell(density: density, spacing: density.cardSpacing) {
+            sectionHeader(
+                "Already in ~/.agents/skills",
+                detail: "\(report.adopted.count) skill\(report.adopted.count == 1 ? "" : "s")"
+            )
+            Text("These have a SKILL.md in the shared directory. Recording them writes nothing to "
+                + "disk — it only teaches Vibe Bar which apps already link to them.")
+                .font(.system(size: density.subtitleFontSize))
+                .foregroundStyle(.secondary)
+            if report.adopted.isEmpty {
+                Text("Nothing found.")
+                    .font(.system(size: density.subtitleFontSize))
+                    .foregroundStyle(.tertiary)
+            } else {
+                HStack(spacing: 8) {
+                    Text("Keep evidence for")
+                        .font(.system(size: max(9, density.resetCountdownFontSize)))
+                        .foregroundStyle(.tertiary)
+                    SkillAppToggleRow(
+                        isOn: { adoptedApps.contains($0) },
+                        toggle: { adoptedApps.formSymmetricDifference([$0]) },
+                        diameter: 22,
+                        glyphSize: 11,
+                        spacing: 3,
+                        helpSuffix: "keep the links already on disk"
+                    )
+                }
+                VStack(alignment: .leading, spacing: 2) {
+                    ForEach(report.adopted) { skill in
+                        HStack(spacing: 8) {
+                            Text(skill.name)
+                                .font(.system(size: density.subtitleFontSize))
+                                .lineLimit(1)
+                            Spacer(minLength: 8)
+                            HStack(spacing: 3) {
+                                ForEach(skill.enabledApps, id: \.self) { app in
+                                    SkillAppGlyph(app: app, size: 11)
+                                        .help(app.displayName)
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - Unmanaged
+
+    private func unmanagedSection(_ report: SkillImportReport) -> some View {
+        CardShell(density: density, spacing: density.cardSpacing) {
+            sectionHeader(
+                "Only inside an app's own folder",
+                detail: "\(report.unmanagedDirectories.count)"
+            )
+            Text("Adopting one copies it into ~/.agents/skills and replaces the original folder "
+                + "with a link, so every app you pick reads the same copy.")
+                .font(.system(size: density.subtitleFontSize))
+                .foregroundStyle(.secondary)
+            ForEach(report.unmanagedDirectories, id: \.directoryName) { entry in
+                unmanagedRow(entry)
+            }
+        }
+    }
+
+    private func unmanagedRow(_ entry: UnmanagedSkillDirectory) -> some View {
+        let opted = adopting[entry.directoryName] != nil
+        return HStack(alignment: .top, spacing: 10) {
+            Toggle(isOn: Binding(
+                get: { opted },
+                set: { isOn in
+                    adopting[entry.directoryName] = isOn ? Set(entry.foundIn) : nil
+                }
+            )) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(entry.name ?? entry.directoryName)
+                        .font(.system(size: density.bucketTitleFontSize, weight: .semibold))
+                        .lineLimit(1)
+                    Text("found in " + entry.foundIn.map(\.displayName).joined(separator: ", "))
+                        .font(.system(size: max(9, density.resetCountdownFontSize)))
+                        .foregroundStyle(.tertiary)
+                }
+            }
+            .toggleStyle(.checkbox)
+            Spacer(minLength: 8)
+            SkillAppToggleRow(
+                isOn: { adopting[entry.directoryName]?.contains($0) ?? false },
+                toggle: { app in
+                    var selection = adopting[entry.directoryName] ?? []
+                    selection.formSymmetricDifference([app])
+                    adopting[entry.directoryName] = selection.isEmpty ? nil : selection
+                },
+                diameter: 22,
+                glyphSize: 11,
+                spacing: 3,
+                helpSuffix: "link into after adopting"
+            )
+        }
+        .padding(.vertical, 2)
+    }
+
+    // MARK: - Read-only findings
+
+    private func unrecognizedSection(_ report: SkillImportReport) -> some View {
+        CardShell(density: density, spacing: density.cardSpacing) {
+            sectionHeader("Not skills", detail: "\(report.unrecognized.count)")
+            Text("Directories in ~/.agents/skills with no SKILL.md. Left exactly as they are.")
+                .font(.system(size: density.subtitleFontSize))
+                .foregroundStyle(.secondary)
+            Text(report.unrecognized.joined(separator: ", "))
+                .font(.system(size: max(9, density.resetCountdownFontSize), design: .monospaced))
+                .foregroundStyle(.tertiary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    private func conflictsSection(_ report: SkillImportReport) -> some View {
+        CardShell(density: density, spacing: density.cardSpacing) {
+            sectionHeader("Shadowing a shared skill", detail: "\(report.conflicts.count)")
+            Text("A real folder in an app's skills directory has the same name as one in "
+                + "~/.agents/skills. Vibe Bar will not overwrite it — resolve it by hand, or "
+                + "enable the shared skill for that app once the folder is gone.")
+                .font(.system(size: density.subtitleFontSize))
+                .foregroundStyle(.secondary)
+            ForEach(report.conflicts, id: \.self) { conflict in
+                HStack(spacing: 8) {
+                    SkillAppGlyph(app: conflict.app, size: 11)
+                    Text(conflict.directoryName)
+                        .font(.system(size: max(9, density.resetCountdownFontSize), design: .monospaced))
+                        .foregroundStyle(.secondary)
+                    Text(conflict.app.displayName)
+                        .font(.system(size: max(9, density.resetCountdownFontSize)))
+                        .foregroundStyle(.tertiary)
+                }
+            }
+        }
+    }
+
+    private func sectionHeader(_ title: String, detail: String) -> some View {
+        HStack(spacing: 8) {
+            Text(title.uppercased())
+                .font(.system(size: max(8, density.segmentedFontSize - 3), weight: .semibold))
+                .foregroundStyle(.tertiary)
+                .tracking(0.4)
+            Spacer(minLength: 8)
+            Text(detail)
+                .font(.system(size: max(9, density.resetCountdownFontSize), design: .rounded)
+                    .monospacedDigit())
+                .foregroundStyle(.tertiary)
+        }
+    }
+
+    /// Pre-checks exactly the apps the scan found evidence for: the default
+    /// import records the machine as it is, and unchecking an app is how the
+    /// user says "stop treating that link as mine".
+    private func seedSelection() {
+        guard let report else { return }
+        adoptedApps = Set(report.adopted.flatMap(\.enabledApps))
+        adopting = [:]
+    }
+}

--- a/Sources/VibeBarApp/Views/Workbench/SkillListRow.swift
+++ b/Sources/VibeBarApp/Views/Workbench/SkillListRow.swift
@@ -1,0 +1,199 @@
+import SwiftUI
+import VibeBarCore
+
+extension SkillAppTarget {
+    /// The provider this agent CLI shares a brand mark with, when there is
+    /// one. Five of the seven targets are also usage providers, so their rows
+    /// wear the same glyph and accent they wear everywhere else in the app;
+    /// Hermes and OpenCode have no provider entry and fall back to a symbol.
+    var brandTool: ToolType? { ToolType(rawValue: rawValue) }
+
+    var fallbackSystemImage: String {
+        switch self {
+        case .hermes: return "bolt.horizontal.circle"
+        case .opencode: return "chevron.left.forwardslash.chevron.right"
+        case .claude, .codex, .gemini, .grok, .antigravity: return "puzzlepiece.extension"
+        }
+    }
+
+    var accent: Color {
+        brandTool.map(Theme.providerAccent(for:)) ?? .accentColor
+    }
+}
+
+/// One agent CLI's mark at a given size — brand icon where the app has one,
+/// SF Symbol where it does not.
+struct SkillAppGlyph: View {
+    let app: SkillAppTarget
+    var size: CGFloat = 13
+
+    var body: some View {
+        if let tool = app.brandTool {
+            ToolBrandIconView(tool: tool, size: size)
+        } else {
+            Image(systemName: app.fallbackSystemImage)
+                .font(.system(size: size * 0.92, weight: .semibold))
+                .frame(width: size, height: size)
+                .accessibilityHidden(true)
+        }
+    }
+}
+
+/// The seven-app row: one circular brand button per agent CLI.
+///
+/// Used both as a live control (an installed skill's enable bits) and as a
+/// selection (which apps a pending install should be enabled for) — the two
+/// read identically on purpose, because they mean the same thing.
+struct SkillAppToggleRow: View {
+    let isOn: (SkillAppTarget) -> Bool
+    let toggle: (SkillAppTarget) -> Void
+    var diameter: CGFloat = 25
+    var glyphSize: CGFloat = 13
+    var spacing: CGFloat = 4
+    var helpSuffix: String?
+
+    var body: some View {
+        HStack(spacing: spacing) {
+            ForEach(SkillAppTarget.allCases, id: \.self) { app in
+                button(for: app)
+            }
+        }
+    }
+
+    private func button(for app: SkillAppTarget) -> some View {
+        let on = isOn(app)
+        let accent = app.accent
+        return Button {
+            toggle(app)
+        } label: {
+            SkillAppGlyph(app: app, size: glyphSize)
+                .frame(width: diameter, height: diameter)
+                .background(
+                    Circle().fill(accent.opacity(on ? 0.18 : 0.05))
+                )
+                .overlay(
+                    Circle().stroke(accent.opacity(on ? 0.6 : 0.16), lineWidth: 0.8)
+                )
+        }
+        .buttonStyle(.plain)
+        // An off app has to stay readable — the user is picking from these —
+        // but must not wear the accent, which is the only signal that says
+        // "this skill is live here".
+        .opacity(on ? 1 : 0.35)
+        .saturation(on ? 1 : 0.15)
+        .help(helpSuffix.map { "\(app.displayName) — \($0)" } ?? app.displayName)
+        .accessibilityLabel(app.displayName)
+        .accessibilityAddTraits(on ? [.isSelected] : [])
+    }
+}
+
+/// One installed skill: what it is, where it came from, and which agent CLIs
+/// currently see it.
+struct SkillListRow: View {
+    let density: Theme.Density
+    let skill: Skill
+    let updateState: SkillUpdateState?
+    let isBusy: Bool
+    let onToggle: (SkillAppTarget) -> Void
+    let onUpdate: () -> Void
+    let onUninstall: () -> Void
+
+    @State private var confirmingUninstall = false
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 12) {
+            details
+            Spacer(minLength: 8)
+            SkillAppToggleRow(
+                isOn: { skill.isEnabled(for: $0) },
+                toggle: onToggle,
+                helpSuffix: nil
+            )
+            .disabled(isBusy)
+            overflowMenu
+        }
+        .padding(.vertical, 5)
+        .opacity(isBusy ? 0.55 : 1)
+        .overlay(alignment: .trailing) {
+            if isBusy {
+                ProgressView().controlSize(.small)
+            }
+        }
+        .contentShape(Rectangle())
+        .confirmationDialog(
+            "Uninstall \(skill.name)?",
+            isPresented: $confirmingUninstall,
+            titleVisibility: .visible
+        ) {
+            Button("Uninstall", role: .destructive) { onUninstall() }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("The skill is backed up first, and removed from every app that links to it.")
+        }
+    }
+
+    private var details: some View {
+        VStack(alignment: .leading, spacing: 3) {
+            HStack(spacing: 6) {
+                Text(skill.name)
+                    .font(.system(size: density.bucketTitleFontSize, weight: .semibold))
+                    .lineLimit(1)
+                sourceBadge
+                if updateState?.updateAvailable == true {
+                    updateBadge
+                }
+            }
+            if let description = skill.description, !description.isEmpty {
+                Text(description)
+                    .font(.system(size: density.subtitleFontSize))
+                    .foregroundStyle(.tertiary)
+                    .lineLimit(2)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+    }
+
+    private var sourceBadge: some View {
+        Text(skill.id.repositorySlug ?? "local")
+            .font(.system(size: max(8, density.resetCountdownFontSize - 1), design: .rounded))
+            .foregroundStyle(.secondary)
+            .lineLimit(1)
+            .padding(.horizontal, 6)
+            .padding(.vertical, 1)
+            .background(Capsule().fill(.quaternary.opacity(0.5)))
+            .help(skill.repoBranch.map { "Branch \($0)" } ?? "Installed locally")
+    }
+
+    private var updateBadge: some View {
+        Text("UPDATE")
+            .font(.system(size: max(8, density.resetCountdownFontSize - 2), weight: .semibold))
+            .tracking(0.4)
+            .foregroundStyle(Color.accentColor)
+            .padding(.horizontal, 6)
+            .padding(.vertical, 1)
+            .background(Capsule().fill(Color.accentColor.opacity(0.14)))
+            .overlay(Capsule().stroke(Color.accentColor.opacity(0.45), lineWidth: 0.7))
+    }
+
+    private var overflowMenu: some View {
+        Menu {
+            Button("Update from repository", systemImage: "arrow.down.circle") { onUpdate() }
+                .disabled(!skill.id.isRepositoryBacked)
+            Divider()
+            Button("Uninstall…", systemImage: "trash", role: .destructive) {
+                confirmingUninstall = true
+            }
+        } label: {
+            Image(systemName: "ellipsis")
+                .font(.system(size: density.subtitleFontSize, weight: .semibold))
+                .foregroundStyle(.secondary)
+                .frame(width: 22, height: 22)
+        }
+        .menuStyle(.button)
+        .buttonStyle(.plain)
+        .menuIndicator(.hidden)
+        .fixedSize()
+        .disabled(isBusy)
+        .accessibilityLabel("More actions for \(skill.name)")
+    }
+}

--- a/Sources/VibeBarApp/Views/Workbench/SkillsManagerPage.swift
+++ b/Sources/VibeBarApp/Views/Workbench/SkillsManagerPage.swift
@@ -1,0 +1,307 @@
+import SwiftUI
+import UniformTypeIdentifiers
+import VibeBarCore
+
+/// The Workbench's Skills page.
+///
+/// Unlike Usage Stats, which is one scrolling column of cards, this page is a
+/// fixed toolbar over a list that owns the remaining height: the installed set
+/// is routinely a hundred rows on a machine that already uses skills, and a
+/// list that scrolls inside its own frame keeps the search field and the
+/// action buttons on screen while the user works through it.
+struct SkillsManagerPage: View {
+    let density: Theme.Density
+    @ObservedObject var model: SkillsManagerModel
+
+    @State private var showsZipImporter = false
+    @State private var toastDismissal: Task<Void, Never>?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: density.interSectionSpacing) {
+            toolbar
+            skillList
+        }
+        .padding(.horizontal, density.popoverPaddingH)
+        .padding(.vertical, density.popoverPaddingV)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .overlay(alignment: .bottom) { toastBanner }
+        .task { model.activate() }
+        .onChange(of: model.toast) { _, newValue in
+            toastDismissal?.cancel()
+            guard newValue != nil else { return }
+            toastDismissal = Task {
+                try? await Task.sleep(for: .seconds(6))
+                guard !Task.isCancelled else { return }
+                model.toast = nil
+            }
+        }
+        .fileImporter(
+            isPresented: $showsZipImporter,
+            allowedContentTypes: [.zip],
+            allowsMultipleSelection: false
+        ) { result in
+            switch result {
+            case let .success(urls):
+                guard let url = urls.first else { return }
+                // Installed into the shared directory only. An archive can
+                // hold several skills, and switching all of them on for every
+                // agent CLI is not what picking a file asked for.
+                model.installZip(url: url, apps: [])
+            case let .failure(error):
+                model.toast = error.localizedDescription
+            }
+        }
+        .sheet(isPresented: $model.isDiscoverSheetPresented, onDismiss: model.discoverSheetDismissed) {
+            SkillDiscoverSheet(density: density, model: model)
+        }
+        .sheet(isPresented: $model.isImportSheetPresented) {
+            SkillImportSheet(density: density, model: model)
+        }
+        .sheet(isPresented: $model.isBackupsSheetPresented) {
+            SkillBackupsSheet(density: density, model: model)
+        }
+    }
+
+    // MARK: - Toolbar
+
+    private var toolbar: some View {
+        CardShell(density: density, spacing: density.cardSpacing) {
+            HStack(spacing: 8) {
+                searchField
+                Spacer(minLength: 8)
+                actionButtons
+            }
+            Divider().opacity(0.35)
+            appCountRow
+        }
+    }
+
+    private var searchField: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "magnifyingglass")
+                .font(.system(size: density.segmentedFontSize - 1, weight: .semibold))
+                .foregroundStyle(.secondary)
+            TextField("Filter installed skills", text: $model.searchText)
+                .textFieldStyle(.plain)
+                .font(.system(size: density.segmentedFontSize))
+            if !model.searchText.isEmpty {
+                Button {
+                    model.searchText = ""
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundStyle(.tertiary)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Clear the filter")
+            }
+        }
+        .padding(.horizontal, 10)
+        .frame(height: 26)
+        .frame(maxWidth: 320)
+        .background(Capsule().fill(.background.tertiary.opacity(0.7)))
+        .overlay(Capsule().stroke(.separator.opacity(0.45), lineWidth: 0.5))
+    }
+
+    private var actionButtons: some View {
+        HStack(spacing: 6) {
+            Button {
+                model.checkForUpdates()
+            } label: {
+                buttonLabel(
+                    systemImage: "arrow.triangle.2.circlepath",
+                    title: model.updatesAvailableCount > 0
+                        ? "Updates (\(model.updatesAvailableCount))"
+                        : "Check Updates",
+                    busy: model.isBusy(SkillsManagerModel.BusyKey.updates)
+                )
+            }
+            .buttonStyle(.glass)
+            .help("Compare every repository-backed skill against its source")
+
+            Button {
+                showsZipImporter = true
+            } label: {
+                buttonLabel(
+                    systemImage: "doc.zipper",
+                    title: "Install from ZIP",
+                    busy: model.isBusy(SkillsManagerModel.BusyKey.zip)
+                )
+            }
+            .buttonStyle(.glass)
+            .help("Install every skill inside a local .zip archive")
+
+            Button {
+                model.presentImportSheet()
+            } label: {
+                buttonLabel(
+                    systemImage: "square.and.arrow.down.on.square",
+                    title: "Import Existing",
+                    busy: model.isBusy(SkillsManagerModel.BusyKey.importing)
+                )
+            }
+            .buttonStyle(.glass)
+            .help("Recognize skills already on this Mac without moving them")
+
+            Button {
+                model.presentBackupsSheet()
+            } label: {
+                buttonLabel(systemImage: "clock.arrow.circlepath", title: "Backups", busy: false)
+            }
+            .buttonStyle(.glass)
+            .help("Restore a skill from a pre-uninstall snapshot")
+
+            Button {
+                model.isDiscoverSheetPresented = true
+            } label: {
+                buttonLabel(systemImage: "sparkle.magnifyingglass", title: "Discover", busy: false)
+            }
+            .buttonStyle(.glassProminent)
+            .help("Browse configured repositories and the skills.sh index")
+        }
+    }
+
+    private func buttonLabel(systemImage: String, title: String, busy: Bool) -> some View {
+        HStack(spacing: 5) {
+            if busy {
+                ProgressView().controlSize(.small).scaleEffect(0.7).frame(width: 12, height: 12)
+            } else {
+                Image(systemName: systemImage)
+                    .font(.system(size: max(9, density.segmentedFontSize - 1), weight: .semibold))
+            }
+            Text(title)
+                .font(.system(size: density.segmentedFontSize - 1, weight: .semibold))
+                .lineLimit(1)
+        }
+        .frame(minHeight: 22)
+    }
+
+    /// How many skills each agent CLI currently sees. The single number that
+    /// answers "did that toggle actually land", and the reason the row sits
+    /// above the list rather than inside a menu.
+    private var appCountRow: some View {
+        HStack(spacing: 6) {
+            ForEach(SkillAppTarget.allCases, id: \.self) { app in
+                let count = model.installedCount(for: app)
+                HStack(spacing: 4) {
+                    SkillAppGlyph(app: app, size: density.segmentedFontSize)
+                    Text("\(count)")
+                        .font(.system(size: density.segmentedFontSize - 1, weight: .semibold,
+                                      design: .rounded).monospacedDigit())
+                }
+                .padding(.horizontal, 8)
+                .frame(minHeight: 22)
+                .background(Capsule().fill(app.accent.opacity(count == 0 ? 0.05 : 0.14)))
+                .overlay(Capsule().stroke(app.accent.opacity(count == 0 ? 0.16 : 0.45), lineWidth: 0.8))
+                .opacity(count == 0 ? 0.5 : 1)
+                .saturation(count == 0 ? 0.2 : 1)
+                .help("\(app.displayName): \(count) skill\(count == 1 ? "" : "s")")
+                .accessibilityLabel("\(app.displayName), \(count) skills")
+            }
+            Spacer(minLength: 8)
+            Text(countSummary)
+                .font(.system(size: max(9, density.resetCountdownFontSize), design: .rounded)
+                    .monospacedDigit())
+                .foregroundStyle(.tertiary)
+                .lineLimit(1)
+        }
+    }
+
+    private var countSummary: String {
+        let total = model.skills.count
+        let shown = model.filteredSkills.count
+        if shown == total { return "\(total) skill\(total == 1 ? "" : "s")" }
+        return "\(shown) of \(total) skills"
+    }
+
+    // MARK: - List
+
+    @ViewBuilder
+    private var skillList: some View {
+        if model.skills.isEmpty {
+            emptyCard
+        } else if model.filteredSkills.isEmpty {
+            CardShell(density: density, alignment: .center) {
+                Text("No skill matches \"\(model.searchText)\"")
+                    .font(.system(size: density.subtitleFontSize))
+                    .foregroundStyle(.secondary)
+            }
+            .frame(maxWidth: .infinity)
+        } else {
+            List(model.filteredSkills) { skill in
+                SkillListRow(
+                    density: density,
+                    skill: skill,
+                    updateState: model.updateState(for: skill),
+                    isBusy: model.isBusy(skill: skill),
+                    onToggle: { model.toggle(skill: skill, app: $0) },
+                    onUpdate: { model.updateSkill(skill) },
+                    onUninstall: { model.uninstall(skill) }
+                )
+                .listRowBackground(Color.clear)
+            }
+            .listStyle(.inset)
+            .scrollContentBackground(.hidden)
+            .cardSurface(density: density)
+            .frame(maxHeight: .infinity)
+        }
+    }
+
+    private var emptyCard: some View {
+        CardShell(density: density, alignment: .center) {
+            Image(systemName: "puzzlepiece.extension")
+                .font(.system(size: 26, weight: .light))
+                .foregroundStyle(.secondary)
+            Text("No skills recorded yet")
+                .font(.system(size: density.titleFontSize, weight: .semibold))
+            Text("Vibe Bar keeps one copy of every skill in ~/.agents/skills and links it into "
+                + "each agent CLI. Import what is already on this Mac, or install something new "
+                + "from a repository.")
+                .font(.system(size: density.subtitleFontSize))
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: 440)
+            HStack(spacing: 10) {
+                Button("Import Existing") { model.presentImportSheet() }
+                    .buttonStyle(.bordered)
+                Button("Discover") { model.isDiscoverSheetPresented = true }
+                    .buttonStyle(.borderedProminent)
+            }
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    // MARK: - Toast
+
+    @ViewBuilder
+    private var toastBanner: some View {
+        if let toast = model.toast {
+            HStack(spacing: 8) {
+                Text(toast)
+                    .font(.system(size: density.subtitleFontSize))
+                    .lineLimit(3)
+                    .fixedSize(horizontal: false, vertical: true)
+                Button {
+                    model.toast = nil
+                } label: {
+                    Image(systemName: "xmark")
+                        .font(.system(size: density.subtitleFontSize - 2, weight: .semibold))
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Dismiss")
+            }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 10)
+            .frame(maxWidth: 520)
+            .background(
+                RoundedRectangle(cornerRadius: density.cardCornerRadius, style: .continuous)
+                    .fill(.regularMaterial)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: density.cardCornerRadius, style: .continuous)
+                    .stroke(.separator.opacity(0.5), lineWidth: 0.5)
+            )
+            .padding(.bottom, density.popoverPaddingV)
+            .transition(.move(edge: .bottom).combined(with: .opacity))
+        }
+    }
+}

--- a/Sources/VibeBarApp/Views/Workbench/WorkbenchRootView.swift
+++ b/Sources/VibeBarApp/Views/Workbench/WorkbenchRootView.swift
@@ -77,7 +77,7 @@ struct WorkbenchRootView: View {
         case .sessionManager:
             SessionManagerPage(density: density, model: workbench.sessions)
         case .skillsManager:
-            WorkbenchPlaceholderPage(page: page, density: density)
+            SkillsManagerPage(density: density, model: workbench.skills)
         }
     }
 }

--- a/Sources/VibeBarCore/Models/AppSettings.swift
+++ b/Sources/VibeBarCore/Models/AppSettings.swift
@@ -77,6 +77,21 @@ public struct AppSettings: Codable, Equatable, Sendable {
     /// new behavior — rather than to the pre-forecast thresholds.
     public var menuBarColorBasis: MenuBarColorBasis
 
+    /// How the Skills manager projects a skill from `~/.agents/skills` into an
+    /// agent CLI's skills directory.
+    ///
+    /// `.auto` — symlink, falling back to a copy where linking fails — is the
+    /// only value that keeps every app reading the same bytes, so it is both
+    /// the default and what an absent key decodes to. The two explicit values
+    /// exist for machines where one side of the pair is wrong: a tool that
+    /// refuses to follow symlinks needs `.copy`, and a layout already built out
+    /// of links stays honest with `.symlink`.
+    ///
+    /// The list of repositories the discovery browser reads is deliberately
+    /// *not* here — that is state the skills UI edits, and it lives in
+    /// `~/.vibebar/skills.json` next to the registry it describes.
+    public var skillsSyncMethod: SkillSyncMethod
+
     /// Curves the user switched **off** in the Overview's all-providers quota
     /// history chart, as `"<tool>|<accountId>|<bucketId>"`.
     ///
@@ -257,7 +272,8 @@ public struct AppSettings: Codable, Equatable, Sendable {
         miscCookieAutoImportEnabled: Bool = false,
         menuBarColorBasis: MenuBarColorBasis = .forecast,
         preferredTerminal: PreferredTerminal = .terminal,
-        sessionBodyIndexingEnabled: Bool = true
+        sessionBodyIndexingEnabled: Bool = true,
+        skillsSyncMethod: SkillSyncMethod = .auto
     ) {
         self.displayMode = displayMode
         self.refreshIntervalSeconds = refreshIntervalSeconds
@@ -300,6 +316,7 @@ public struct AppSettings: Codable, Equatable, Sendable {
         self.menuBarColorBasis = menuBarColorBasis
         self.preferredTerminal = preferredTerminal
         self.sessionBodyIndexingEnabled = sessionBodyIndexingEnabled
+        self.skillsSyncMethod = skillsSyncMethod
     }
 
     /// Drops unnamed presets, collapses names that differ only by case (the
@@ -356,6 +373,7 @@ public struct AppSettings: Codable, Equatable, Sendable {
         case menuBarColorBasis
         case preferredTerminal
         case sessionBodyIndexingEnabled
+        case skillsSyncMethod
     }
 
     public init(from decoder: Decoder) throws {
@@ -522,6 +540,12 @@ public struct AppSettings: Codable, Equatable, Sendable {
         self.sessionBodyIndexingEnabled =
             try c.decodeIfPresent(Bool.self, forKey: .sessionBodyIndexingEnabled)
             ?? Self.default.sessionBodyIndexingEnabled
+        // `.auto` is the only value that keeps the app dirs pointing at one
+        // copy of a skill, so both an absent key and an unrecognized one land
+        // there rather than costing the user the rest of the file.
+        self.skillsSyncMethod =
+            (try? c.decodeIfPresent(SkillSyncMethod.self, forKey: .skillsSyncMethod))
+            ?? Self.default.skillsSyncMethod
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -569,6 +593,7 @@ public struct AppSettings: Codable, Equatable, Sendable {
         try c.encode(menuBarColorBasis, forKey: .menuBarColorBasis)
         try c.encode(preferredTerminal, forKey: .preferredTerminal)
         try c.encode(sessionBodyIndexingEnabled, forKey: .sessionBodyIndexingEnabled)
+        try c.encode(skillsSyncMethod, forKey: .skillsSyncMethod)
     }
 
     public func menuBarItem(_ kind: MenuBarItemKind) -> MenuBarItemSettings {

--- a/Sources/VibeBarCore/Skills/SkillAppCatalog.swift
+++ b/Sources/VibeBarCore/Skills/SkillAppCatalog.swift
@@ -1,0 +1,84 @@
+import Foundation
+
+/// Where every agent CLI keeps its skills, relative to the real user home.
+///
+/// This is the one table the whole Skills feature reads. Adding an app means
+/// adding a `SkillAppTarget` case and a row here — nothing else in the sync
+/// engine is app-aware.
+///
+/// AntiGravity is the odd one out: its global customization root is
+/// `~/.gemini/config/`, *not* `~/.gemini/`, so it does not share the Gemini
+/// CLI's `~/.gemini/skills`. That directory frequently does not exist yet, so
+/// it is created lazily on the first materialize — one component at a time, so
+/// no sibling of `config/` or `skills/` is ever touched.
+public enum SkillAppCatalog {
+    /// Single source of truth every app dir is projected from.
+    public static let ssotRelativePath = ".agents/skills"
+    /// Provenance file written by the third-party skill installer. Vibe Bar
+    /// reads it during import and never writes it.
+    public static let lockFileRelativePath = ".agents/.skill-lock.json"
+
+    public static func relativePath(for app: SkillAppTarget) -> String {
+        switch app {
+        case .claude: return ".claude/skills"
+        case .codex: return ".codex/skills"
+        case .gemini: return ".gemini/skills"
+        case .grok: return ".grok/skills"
+        case .hermes: return ".hermes/skills"
+        case .opencode: return ".config/opencode/skills"
+        case .antigravity: return ".gemini/config/skills"
+        }
+    }
+
+    public static func ssotDirectory(homeDirectory: String = RealHomeDirectory.path) -> URL {
+        url(homeDirectory: homeDirectory, relativePath: ssotRelativePath)
+    }
+
+    public static func lockFileURL(homeDirectory: String = RealHomeDirectory.path) -> URL {
+        url(homeDirectory: homeDirectory, relativePath: lockFileRelativePath)
+    }
+
+    public static func skillsDirectory(
+        for app: SkillAppTarget,
+        homeDirectory: String = RealHomeDirectory.path
+    ) -> URL {
+        url(homeDirectory: homeDirectory, relativePath: relativePath(for: app))
+    }
+
+    /// The SSOT plus every app skills dir. The sync engine hard-asserts that
+    /// each path it mutates sits under one of these, so a malformed skill name
+    /// can never reach into the rest of the home directory.
+    public static func allowedWriteRoots(homeDirectory: String = RealHomeDirectory.path) -> [URL] {
+        [ssotDirectory(homeDirectory: homeDirectory)]
+            + SkillAppTarget.allCases.map { skillsDirectory(for: $0, homeDirectory: homeDirectory) }
+    }
+
+    /// Lexical containment check on standardized paths. Deliberately does not
+    /// resolve symlinks: the caller has already lstat-ed the entry, and
+    /// resolving here would let a symlinked app dir vouch for a path outside
+    /// the allowed roots.
+    public static func isWriteAllowed(
+        _ url: URL,
+        homeDirectory: String = RealHomeDirectory.path
+    ) -> Bool {
+        let candidate = url.standardizedFileURL.path
+        return allowedWriteRoots(homeDirectory: homeDirectory).contains { root in
+            let rootPath = root.standardizedFileURL.path
+            return candidate == rootPath || candidate.hasPrefix(rootPath + "/")
+        }
+    }
+
+    public static func isPath(_ url: URL, under root: URL) -> Bool {
+        let candidate = url.standardizedFileURL.path
+        let rootPath = root.standardizedFileURL.path
+        return candidate == rootPath || candidate.hasPrefix(rootPath + "/")
+    }
+
+    private static func url(homeDirectory: String, relativePath: String) -> URL {
+        relativePath
+            .split(separator: "/")
+            .reduce(URL(fileURLWithPath: homeDirectory, isDirectory: true)) { partial, component in
+                partial.appendingPathComponent(String(component), isDirectory: true)
+            }
+    }
+}

--- a/Sources/VibeBarCore/Skills/SkillArchiveExtractor.swift
+++ b/Sources/VibeBarCore/Skills/SkillArchiveExtractor.swift
@@ -1,0 +1,507 @@
+import Compression
+import Foundation
+
+public enum SkillArchiveError: Error, Equatable, Sendable {
+    case notAZipArchive
+    case corruptArchive(String)
+    case unsupportedZip64
+    case unsupportedCompressionMethod(UInt16)
+    case encryptedEntry(String)
+    case tooManyEntries(limit: Int)
+    case archiveTooLarge(limit: Int64)
+    case unsafeEntryPath(String)
+    case symlinkEntry(String)
+    case duplicateEntry(String)
+    case invalidEntryName
+    case checksumMismatch(String)
+}
+
+extension SkillArchiveError: LocalizedError {
+    public var errorDescription: String? {
+        switch self {
+        case .notAZipArchive:
+            return "The downloaded file is not a ZIP archive."
+        case let .corruptArchive(detail):
+            return "The ZIP archive is corrupt (\(detail))."
+        case .unsupportedZip64:
+            return "ZIP64 archives are not supported."
+        case let .unsupportedCompressionMethod(method):
+            return "Unsupported ZIP compression method \(method)."
+        case let .encryptedEntry(name):
+            return "The archive entry \"\(name)\" is encrypted."
+        case let .tooManyEntries(limit):
+            return "The archive holds more than \(limit) entries."
+        case let .archiveTooLarge(limit):
+            return "The archive expands past its \(limit)-byte limit."
+        case let .unsafeEntryPath(name):
+            return "The archive entry \"\(name)\" points outside the extraction directory."
+        case let .symlinkEntry(name):
+            return "The archive entry \"\(name)\" is a symbolic link."
+        case let .duplicateEntry(name):
+            return "The archive holds \"\(name)\" more than once."
+        case .invalidEntryName:
+            return "The archive holds an entry whose name is not valid UTF-8."
+        case let .checksumMismatch(name):
+            return "The archive entry \"\(name)\" failed its checksum."
+        }
+    }
+}
+
+/// Minimal, deliberately hostile-input-hardened ZIP reader.
+///
+/// Vibe Bar downloads zipballs of arbitrary third-party GitHub repositories, so
+/// extraction is the sharpest edge in the whole feature. Shelling out to
+/// `/usr/bin/unzip` or `ditto` is not an option (no `Process` in product code,
+/// and neither tool would enforce our budgets anyway), and no dependency is
+/// worth adding for it — macOS already ships the one hard part, raw DEFLATE, in
+/// the `Compression` framework.
+///
+/// What is supported: the single-disk, non-ZIP64 subset the whole world
+/// actually produces — an end-of-central-directory record found by scanning the
+/// tail, central-directory headers as the authority for sizes and attributes
+/// (never the local header, whose sizes are zero when a data descriptor is
+/// used), and entries stored (method 0) or deflated (method 8). CRC-32 is
+/// verified for every file. Anything else — ZIP64 sentinels, encryption,
+/// multi-disk, another compression method — is refused by name rather than
+/// guessed at.
+///
+/// What is refused, entry by entry:
+/// - absolute paths, `..` in any component, empty components, backslashes,
+///   control characters, and over-long components;
+/// - symlinks, recognized from the Unix mode in the central-directory external
+///   attributes (a link is the classic way to turn a "safe" relative path into
+///   a write anywhere on disk);
+/// - names that are not valid UTF-8;
+/// - duplicate paths, compared case- and Unicode-normalization-insensitively,
+///   because the destination filesystem usually is — a second entry must never
+///   silently overwrite what the first one wrote;
+/// - anything past the entry-count budget or the running extracted-byte budget.
+///
+/// The byte budget is checked twice: once against the sizes the central
+/// directory declares (a cheap up-front rejection) and again against bytes
+/// actually produced by the inflater, so a lying header buys nothing.
+public struct SkillArchiveExtractor {
+    /// Enough for the largest skill repository by a wide margin;
+    /// `anthropics/skills` is ~200 files.
+    public static let maxEntries = 10_000
+    public static let maxExtractedBytes: Int64 = 512 * 1024 * 1024
+    /// One path component. Well under `NAME_MAX`, and past any real filename.
+    public static let maxComponentLength = 200
+
+    /// Extracts every file entry of `zipFileURL` under `destination`, creating
+    /// intermediate directories as needed. Returns the number of files written.
+    ///
+    /// The budgets are parameters so callers (and tests) can tighten them; the
+    /// defaults are the ones the skills feature runs with.
+    @discardableResult
+    public static func extract(
+        zipFileURL: URL,
+        into destination: URL,
+        maxEntries: Int = SkillArchiveExtractor.maxEntries,
+        maxExtractedBytes: Int64 = SkillArchiveExtractor.maxExtractedBytes
+    ) throws -> Int {
+        let data = try Data(contentsOf: zipFileURL, options: [.mappedIfSafe])
+        let reader = ByteReader(data: data)
+        let directory = try readCentralDirectory(reader, maxEntries: maxEntries)
+
+        var declared: Int64 = 0
+        for entry in directory where !entry.isDirectory {
+            declared += Int64(entry.uncompressedSize)
+            if declared > maxExtractedBytes { throw SkillArchiveError.archiveTooLarge(limit: maxExtractedBytes) }
+        }
+
+        try FileManager.default.createDirectory(at: destination, withIntermediateDirectories: true)
+        var written = 0
+        var produced: Int64 = 0
+        for entry in directory {
+            let target = try resolve(components: entry.components, under: destination)
+            if entry.isDirectory {
+                try FileManager.default.createDirectory(at: target, withIntermediateDirectories: true)
+                continue
+            }
+            try FileManager.default.createDirectory(
+                at: target.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            let payload = try payload(
+                for: entry,
+                reader: reader,
+                remainingBudget: maxExtractedBytes - produced
+            )
+            produced += Int64(payload.count)
+            if produced > maxExtractedBytes { throw SkillArchiveError.archiveTooLarge(limit: maxExtractedBytes) }
+            try payload.write(to: target, options: [.atomic])
+            // Only the execute bit is carried over, and only from a Unix
+            // archive: setuid/setgid/sticky are never restored from content
+            // fetched off the network.
+            if let mode = entry.unixMode, mode & 0o111 != 0 {
+                try? FileManager.default.setAttributes(
+                    [.posixPermissions: 0o755],
+                    ofItemAtPath: target.path
+                )
+            }
+            written += 1
+        }
+        return written
+    }
+
+    // MARK: - Central directory
+
+    struct Entry {
+        let name: String
+        let components: [String]
+        let isDirectory: Bool
+        let method: UInt16
+        let crc32: UInt32
+        let compressedSize: UInt32
+        let uncompressedSize: UInt32
+        let localHeaderOffset: UInt32
+        let unixMode: UInt16?
+    }
+
+    private static let endOfCentralDirectorySignature: UInt32 = 0x0605_4b50
+    private static let centralHeaderSignature: UInt32 = 0x0201_4b50
+    private static let localHeaderSignature: UInt32 = 0x0403_4b50
+    private static let zip64Sentinel32: UInt32 = 0xFFFF_FFFF
+
+    private static func readCentralDirectory(_ reader: ByteReader, maxEntries: Int) throws -> [Entry] {
+        guard reader.count >= 22 else { throw SkillArchiveError.notAZipArchive }
+        guard let eocd = locateEndOfCentralDirectory(reader) else {
+            throw SkillArchiveError.notAZipArchive
+        }
+        let totalEntries = Int(try reader.u16(eocd + 10))
+        let centralSize = try reader.u32(eocd + 12)
+        let centralOffset = try reader.u32(eocd + 16)
+        guard centralSize != Self.zip64Sentinel32, centralOffset != Self.zip64Sentinel32 else {
+            throw SkillArchiveError.unsupportedZip64
+        }
+        guard totalEntries <= maxEntries else {
+            throw SkillArchiveError.tooManyEntries(limit: maxEntries)
+        }
+
+        var cursor = Int(centralOffset)
+        let end = min(reader.count, cursor + Int(centralSize))
+        var entries: [Entry] = []
+        var seen = Set<String>()
+        while cursor + 46 <= end {
+            guard try reader.u32(cursor) == Self.centralHeaderSignature else { break }
+            let versionMadeBy = try reader.u16(cursor + 4)
+            let flags = try reader.u16(cursor + 8)
+            let method = try reader.u16(cursor + 10)
+            let crc = try reader.u32(cursor + 16)
+            let compressedSize = try reader.u32(cursor + 20)
+            let uncompressedSize = try reader.u32(cursor + 24)
+            let nameLength = Int(try reader.u16(cursor + 28))
+            let extraLength = Int(try reader.u16(cursor + 30))
+            let commentLength = Int(try reader.u16(cursor + 32))
+            let externalAttributes = try reader.u32(cursor + 38)
+            let localOffset = try reader.u32(cursor + 42)
+
+            let nameData = try reader.slice(cursor + 46, nameLength)
+            guard let name = String(data: nameData, encoding: .utf8) else {
+                throw SkillArchiveError.invalidEntryName
+            }
+            if flags & 0x0001 != 0 { throw SkillArchiveError.encryptedEntry(name) }
+            guard
+                compressedSize != Self.zip64Sentinel32,
+                uncompressedSize != Self.zip64Sentinel32,
+                localOffset != Self.zip64Sentinel32
+            else { throw SkillArchiveError.unsupportedZip64 }
+
+            entries.append(
+                try makeEntry(
+                    name: name,
+                    versionMadeBy: versionMadeBy,
+                    method: method,
+                    crc: crc,
+                    compressedSize: compressedSize,
+                    uncompressedSize: uncompressedSize,
+                    localOffset: localOffset,
+                    externalAttributes: externalAttributes,
+                    seen: &seen
+                )
+            )
+            guard entries.count <= maxEntries else {
+                throw SkillArchiveError.tooManyEntries(limit: maxEntries)
+            }
+            cursor += 46 + nameLength + extraLength + commentLength
+        }
+        return entries
+    }
+
+    private static func makeEntry(
+        name: String,
+        versionMadeBy: UInt16,
+        method: UInt16,
+        crc: UInt32,
+        compressedSize: UInt32,
+        uncompressedSize: UInt32,
+        localOffset: UInt32,
+        externalAttributes: UInt32,
+        seen: inout Set<String>
+    ) throws -> Entry {
+        // Host system 3 is Unix; only then do the high 16 bits of the external
+        // attributes carry a `st_mode`.
+        let unixMode: UInt16? = (versionMadeBy >> 8) == 3 ? UInt16(truncatingIfNeeded: externalAttributes >> 16) : nil
+        if let unixMode, unixMode & UInt16(S_IFMT) == UInt16(S_IFLNK) {
+            throw SkillArchiveError.symlinkEntry(name)
+        }
+        let isDirectory = name.hasSuffix("/")
+        let components = try safeComponents(of: name)
+        let normalized = components
+            .joined(separator: "/")
+            .precomposedStringWithCanonicalMapping
+            .lowercased()
+        guard seen.insert(normalized).inserted else {
+            throw SkillArchiveError.duplicateEntry(name)
+        }
+        if !isDirectory, method != 0, method != 8 {
+            throw SkillArchiveError.unsupportedCompressionMethod(method)
+        }
+        return Entry(
+            name: name,
+            components: components,
+            isDirectory: isDirectory,
+            method: method,
+            crc32: crc,
+            compressedSize: compressedSize,
+            uncompressedSize: uncompressedSize,
+            localHeaderOffset: localOffset,
+            unixMode: unixMode
+        )
+    }
+
+    /// Scans the tail for the EOCD signature, newest first. The record can sit
+    /// up to 64 KiB from the end because of the archive comment, so the window
+    /// is that plus the record itself.
+    private static func locateEndOfCentralDirectory(_ reader: ByteReader) -> Int? {
+        let maximumComment = 0xFFFF
+        let lowest = max(0, reader.count - maximumComment - 22)
+        var offset = reader.count - 22
+        while offset >= lowest {
+            if let signature = try? reader.u32(offset), signature == Self.endOfCentralDirectorySignature {
+                let commentLength = (try? reader.u16(offset + 20)).map(Int.init) ?? -1
+                if commentLength >= 0, offset + 22 + commentLength <= reader.count { return offset }
+            }
+            offset -= 1
+        }
+        return nil
+    }
+
+    // MARK: - Payloads
+
+    private static func payload(
+        for entry: Entry,
+        reader: ByteReader,
+        remainingBudget: Int64
+    ) throws -> Data {
+        let header = Int(entry.localHeaderOffset)
+        guard header + 30 <= reader.count, try reader.u32(header) == Self.localHeaderSignature else {
+            throw SkillArchiveError.corruptArchive("local header for \(entry.name)")
+        }
+        let nameLength = Int(try reader.u16(header + 26))
+        let extraLength = Int(try reader.u16(header + 28))
+        let start = header + 30 + nameLength + extraLength
+        let compressed = try reader.slice(start, Int(entry.compressedSize))
+
+        let payload: Data
+        switch entry.method {
+        case 0:
+            payload = compressed
+        case 8:
+            payload = try RawDeflate.inflate(
+                compressed,
+                expectedSize: Int(entry.uncompressedSize),
+                limit: max(0, remainingBudget)
+            )
+        default:
+            throw SkillArchiveError.unsupportedCompressionMethod(entry.method)
+        }
+        guard payload.count == Int(entry.uncompressedSize) else {
+            throw SkillArchiveError.corruptArchive("size mismatch for \(entry.name)")
+        }
+        guard CRC32.checksum(payload) == entry.crc32 else {
+            throw SkillArchiveError.checksumMismatch(entry.name)
+        }
+        return payload
+    }
+
+    // MARK: - Path safety
+
+    /// Splits an entry name into components, refusing everything that could
+    /// escape the destination. Directory entries lose their trailing slash.
+    static func safeComponents(of name: String) throws -> [String] {
+        guard !name.isEmpty, !name.hasPrefix("/"), !name.contains("\\") else {
+            throw SkillArchiveError.unsafeEntryPath(name)
+        }
+        // A Windows drive prefix ("C:/x") is not a relative path either.
+        if isDrivePrefixed(name) { throw SkillArchiveError.unsafeEntryPath(name) }
+        for scalar in name.unicodeScalars where scalar.value < 0x20 || scalar.value == 0x7F {
+            throw SkillArchiveError.unsafeEntryPath(name)
+        }
+        var trimmed = Substring(name)
+        while trimmed.hasSuffix("/") { trimmed = trimmed.dropLast() }
+        guard !trimmed.isEmpty else { throw SkillArchiveError.unsafeEntryPath(name) }
+
+        var components: [String] = []
+        for raw in trimmed.split(separator: "/", omittingEmptySubsequences: false) {
+            let component = String(raw)
+            guard
+                !component.isEmpty,
+                component != ".",
+                component != "..",
+                component.utf8.count <= maxComponentLength
+            else {
+                throw SkillArchiveError.unsafeEntryPath(name)
+            }
+            components.append(component)
+        }
+        guard !components.isEmpty else { throw SkillArchiveError.unsafeEntryPath(name) }
+        return components
+    }
+
+    private static func isDrivePrefixed(_ name: String) -> Bool {
+        let scalars = Array(name.unicodeScalars.prefix(2))
+        guard scalars.count == 2, scalars[1] == ":" else { return false }
+        let letter = scalars[0]
+        return ("a"..."z").contains(letter) || ("A"..."Z").contains(letter)
+    }
+
+    /// Appends validated components one at a time and re-asserts containment on
+    /// the result: the component check is the guarantee, this is the audit.
+    private static func resolve(components: [String], under destination: URL) throws -> URL {
+        var url = destination
+        for component in components {
+            url = url.appendingPathComponent(component, isDirectory: false)
+        }
+        let root = destination.standardizedFileURL.path
+        let candidate = url.standardizedFileURL.path
+        guard candidate.hasPrefix(root.hasSuffix("/") ? root : root + "/") else {
+            throw SkillArchiveError.unsafeEntryPath(components.joined(separator: "/"))
+        }
+        return url
+    }
+}
+
+/// Bounds-checked little-endian view over the archive bytes. Every read goes
+/// through here so a truncated or hand-crafted file produces an error instead
+/// of a trap.
+struct ByteReader {
+    let data: Data
+
+    var count: Int { data.count }
+
+    func byte(_ offset: Int) throws -> UInt8 {
+        guard offset >= 0, offset < data.count else {
+            throw SkillArchiveError.corruptArchive("read past end")
+        }
+        return data[data.startIndex + offset]
+    }
+
+    func u16(_ offset: Int) throws -> UInt16 {
+        UInt16(try byte(offset)) | (UInt16(try byte(offset + 1)) << 8)
+    }
+
+    func u32(_ offset: Int) throws -> UInt32 {
+        UInt32(try u16(offset)) | (UInt32(try u16(offset + 2)) << 16)
+    }
+
+    func slice(_ offset: Int, _ length: Int) throws -> Data {
+        guard offset >= 0, length >= 0, offset + length <= data.count else {
+            throw SkillArchiveError.corruptArchive("read past end")
+        }
+        let start = data.startIndex + offset
+        return Data(data[start..<(start + length)])
+    }
+}
+
+/// Raw DEFLATE (RFC 1951) decode over `Compression`.
+///
+/// `COMPRESSION_ZLIB` in Apple's framework is the *raw* deflate stream — no
+/// zlib header, no trailer — which is exactly what ZIP method 8 stores, so no
+/// wrapper stripping is needed. The output is bounded as it is produced: a
+/// bomb is stopped at the budget rather than after materializing gigabytes.
+enum RawDeflate {
+    static func inflate(_ source: Data, expectedSize: Int, limit: Int64) throws -> Data {
+        if source.isEmpty { return Data() }
+        let bufferSize = 64 * 1024
+        let destination = UnsafeMutablePointer<UInt8>.allocate(capacity: bufferSize)
+        defer { destination.deallocate() }
+
+        var stream = compression_stream(
+            dst_ptr: destination,
+            dst_size: bufferSize,
+            src_ptr: destination,
+            src_size: 0,
+            state: nil
+        )
+        guard compression_stream_init(&stream, COMPRESSION_STREAM_DECODE, COMPRESSION_ZLIB) == COMPRESSION_STATUS_OK else {
+            throw SkillArchiveError.corruptArchive("inflate init")
+        }
+        defer { compression_stream_destroy(&stream) }
+
+        var output = Data()
+        output.reserveCapacity(min(expectedSize, 8 * 1024 * 1024))
+        var overflowed = false
+        try source.withUnsafeBytes { (raw: UnsafeRawBufferPointer) in
+            guard let base = raw.bindMemory(to: UInt8.self).baseAddress else {
+                throw SkillArchiveError.corruptArchive("empty deflate stream")
+            }
+            stream.src_ptr = base
+            stream.src_size = raw.count
+            stream.dst_ptr = destination
+            stream.dst_size = bufferSize
+
+            var status = COMPRESSION_STATUS_OK
+            repeat {
+                status = compression_stream_process(&stream, Int32(COMPRESSION_STREAM_FINALIZE.rawValue))
+                switch status {
+                case COMPRESSION_STATUS_OK, COMPRESSION_STATUS_END:
+                    let produced = bufferSize - stream.dst_size
+                    if produced > 0 {
+                        output.append(destination, count: produced)
+                        stream.dst_ptr = destination
+                        stream.dst_size = bufferSize
+                    } else if status == COMPRESSION_STATUS_OK {
+                        // No progress with the whole input available means the
+                        // stream cannot be finished — refuse rather than spin.
+                        throw SkillArchiveError.corruptArchive("stalled deflate stream")
+                    }
+                    if Int64(output.count) > limit {
+                        overflowed = true
+                        return
+                    }
+                default:
+                    throw SkillArchiveError.corruptArchive("deflate stream")
+                }
+            } while status == COMPRESSION_STATUS_OK
+        }
+        if overflowed { throw SkillArchiveError.archiveTooLarge(limit: limit) }
+        return output
+    }
+}
+
+/// CRC-32 (IEEE 802.3), the checksum ZIP records for every entry. Verifying it
+/// costs one pass over data we already hold and turns a silently corrupted
+/// download into an error.
+enum CRC32 {
+    private static let table: [UInt32] = {
+        (0..<256).map { index -> UInt32 in
+            var value = UInt32(index)
+            for _ in 0..<8 {
+                value = (value & 1 == 1) ? (0xEDB8_8320 ^ (value >> 1)) : (value >> 1)
+            }
+            return value
+        }
+    }()
+
+    static func checksum(_ data: Data) -> UInt32 {
+        var crc: UInt32 = 0xFFFF_FFFF
+        data.withUnsafeBytes { (raw: UnsafeRawBufferPointer) in
+            for byte in raw {
+                crc = table[Int((crc ^ UInt32(byte)) & 0xFF)] ^ (crc >> 8)
+            }
+        }
+        return crc ^ 0xFFFF_FFFF
+    }
+}

--- a/Sources/VibeBarCore/Skills/SkillBackupManager.swift
+++ b/Sources/VibeBarCore/Skills/SkillBackupManager.swift
@@ -1,0 +1,188 @@
+import Foundation
+
+/// Pre-uninstall snapshots of skill directories under
+/// `~/.vibebar/skill_backups/`.
+///
+/// Layout of one backup:
+///
+/// ```text
+/// 20260807_161200_my-skill[_2]/
+/// ├── skill/       # verbatim recursive copy of ~/.agents/skills/my-skill
+/// └── meta.json    # the Skill record, when it was taken, where it came from
+/// ```
+///
+/// This is the only reason uninstalling a skill is safe to offer: a skill that
+/// came from a repository can be re-fetched, but a locally authored one only
+/// exists here once its SSOT directory is gone.
+public struct SkillBackupManager: Sendable {
+    public struct Metadata: Codable, Sendable {
+        public let skill: Skill
+        public let backupCreatedAt: Date
+        public let sourcePath: String
+
+        public init(skill: Skill, backupCreatedAt: Date, sourcePath: String) {
+            self.skill = skill
+            self.backupCreatedAt = backupCreatedAt
+            self.sourcePath = sourcePath
+        }
+    }
+
+    public struct Backup: Sendable, Hashable, Identifiable {
+        public var id: String { directoryName }
+        public let url: URL
+        public let directoryName: String
+        public let createdAt: Date
+        public let skill: Skill?
+    }
+
+    public static let defaultRetainedBackups = 20
+
+    public let homeDirectory: String
+
+    public init(homeDirectory: String = RealHomeDirectory.path) {
+        self.homeDirectory = homeDirectory
+    }
+
+    public var rootDirectory: URL {
+        VibeBarLocalStore.skillBackupsDirectoryURL(homeDirectory: homeDirectory)
+    }
+
+    @discardableResult
+    public func createBackup(of skillDirectoryName: String, skill: Skill) throws -> URL {
+        try SkillPathValidator.validate(directoryName: skillDirectoryName)
+        let source = SkillAppCatalog.ssotDirectory(homeDirectory: homeDirectory)
+            .appendingPathComponent(skillDirectoryName, isDirectory: true)
+        guard SkillFileSystem.kind(of: source) == .directory else {
+            throw SkillError.sourceDirectoryMissing(skillDirectoryName)
+        }
+
+        let root = rootDirectory
+        try SkillFileSystem.ensureDirectory(root, stopAt: homeURL, permissions: 0o700)
+
+        let createdAt = Date()
+        let backupURL = try uniqueBackupURL(for: skillDirectoryName, at: createdAt, in: root)
+        try FileManager.default.createDirectory(at: backupURL, withIntermediateDirectories: false)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o700],
+            ofItemAtPath: backupURL.path
+        )
+        try FileManager.default.copyItem(at: source, to: backupURL.appendingPathComponent("skill"))
+        let metadata = Metadata(skill: skill, backupCreatedAt: createdAt, sourcePath: source.path)
+        try VibeBarLocalStore.writeJSON(
+            metadata,
+            to: backupURL.appendingPathComponent("meta.json"),
+            base: VibeBarLocalStore.baseDirectory(homeDirectory: homeDirectory)
+        )
+        prune()
+        return backupURL
+    }
+
+    /// Newest first.
+    public func listBackups() -> [Backup] {
+        let root = rootDirectory
+        guard let names = try? FileManager.default.contentsOfDirectory(atPath: root.path) else {
+            return []
+        }
+        let backups: [Backup] = names.compactMap { name in
+            guard !name.hasPrefix(".") else { return nil }
+            let url = root.appendingPathComponent(name, isDirectory: true)
+            guard SkillFileSystem.kind(of: url) == .directory else { return nil }
+            let metadata = self.metadata(at: url)
+            let createdAt = metadata?.backupCreatedAt ?? modificationDate(of: url) ?? .distantPast
+            return Backup(url: url, directoryName: name, createdAt: createdAt, skill: metadata?.skill)
+        }
+        return backups.sorted {
+            if $0.createdAt != $1.createdAt { return $0.createdAt > $1.createdAt }
+            return $0.directoryName > $1.directoryName
+        }
+    }
+
+    /// Copies a backup's payload back into the SSOT and returns the restored
+    /// record with a freshly computed content hash. Refuses to overwrite: if
+    /// the SSOT directory came back some other way, the user resolves that
+    /// before restoring.
+    @discardableResult
+    public func restore(backupURL: URL) throws -> Skill {
+        guard SkillAppCatalog.isPath(backupURL, under: rootDirectory) else {
+            throw SkillError.writeOutsideAllowedRoots(backupURL.path)
+        }
+        guard SkillFileSystem.kind(of: backupURL) == .directory else {
+            throw SkillError.backupNotFound(backupURL.lastPathComponent)
+        }
+        guard let metadata = metadata(at: backupURL) else {
+            throw SkillError.backupCorrupted(backupURL.lastPathComponent)
+        }
+        let payload = backupURL.appendingPathComponent("skill", isDirectory: true)
+        guard SkillFileSystem.kind(of: payload) == .directory else {
+            throw SkillError.backupCorrupted(backupURL.lastPathComponent)
+        }
+
+        var skill = metadata.skill
+        try SkillPathValidator.validate(directoryName: skill.directory)
+        let ssot = SkillAppCatalog.ssotDirectory(homeDirectory: homeDirectory)
+        let destination = ssot.appendingPathComponent(skill.directory, isDirectory: true)
+        guard SkillAppCatalog.isWriteAllowed(destination, homeDirectory: homeDirectory) else {
+            throw SkillError.writeOutsideAllowedRoots(destination.path)
+        }
+        guard SkillFileSystem.kind(of: destination) == .missing else {
+            throw SkillError.destinationExists(skill.directory)
+        }
+        try SkillFileSystem.ensureDirectory(ssot, stopAt: homeURL)
+        try SkillFileSystem.replaceDirectory(at: destination, withCopyOf: payload)
+        skill.contentHash = try SkillDirectoryHasher.hash(directory: destination)
+        return skill
+    }
+
+    public func deleteBackup(_ url: URL) throws {
+        let root = rootDirectory
+        guard
+            SkillAppCatalog.isPath(url, under: root),
+            url.standardizedFileURL.path != root.standardizedFileURL.path
+        else {
+            throw SkillError.writeOutsideAllowedRoots(url.path)
+        }
+        guard SkillFileSystem.kind(of: url) != .missing else {
+            throw SkillError.backupNotFound(url.lastPathComponent)
+        }
+        try FileManager.default.removeItem(at: url)
+    }
+
+    public func prune(keeping: Int = SkillBackupManager.defaultRetainedBackups) {
+        let backups = listBackups()
+        guard backups.count > keeping else { return }
+        for backup in backups.dropFirst(keeping) {
+            try? deleteBackup(backup.url)
+        }
+    }
+
+    // MARK: - Internals
+
+    private var homeURL: URL { URL(fileURLWithPath: homeDirectory, isDirectory: true) }
+
+    private func metadata(at backupURL: URL) -> Metadata? {
+        guard let data = try? Data(contentsOf: backupURL.appendingPathComponent("meta.json")) else {
+            return nil
+        }
+        return try? JSONDecoder().decode(Metadata.self, from: data)
+    }
+
+    private func modificationDate(of url: URL) -> Date? {
+        (try? FileManager.default.attributesOfItem(atPath: url.path))?[.modificationDate] as? Date
+    }
+
+    private func uniqueBackupURL(for name: String, at date: Date, in root: URL) throws -> URL {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "yyyyMMdd_HHmmss"
+        let stamp = formatter.string(from: date)
+        let base = "\(stamp)_\(name)"
+        var candidate = root.appendingPathComponent(base, isDirectory: true)
+        var suffix = 2
+        while SkillFileSystem.kind(of: candidate) != .missing {
+            candidate = root.appendingPathComponent("\(base)_\(suffix)", isDirectory: true)
+            suffix += 1
+            if suffix > 1_000 { throw SkillError.destinationExists(base) }
+        }
+        return candidate
+    }
+}

--- a/Sources/VibeBarCore/Skills/SkillDirectoryHasher.swift
+++ b/Sources/VibeBarCore/Skills/SkillDirectoryHasher.swift
@@ -1,0 +1,66 @@
+import CryptoKit
+import Foundation
+
+/// Content fingerprint for a skill directory.
+///
+/// One SHA-256 over every non-hidden regular file, walked recursively and
+/// ordered by relative POSIX path (compared as UTF-8 bytes, so the digest does
+/// not depend on locale collation). Each file contributes
+/// `<relative path>\0<payload>\0` — the separators are what stop
+/// `{"ab": "c"}` and `{"a": "bc"}` from hashing identically.
+///
+/// Symlinks *inside* a skill hash as their target path string, not the bytes
+/// they point at: it is cheap, it keeps the walk from following a link out of
+/// the tree (or into a cycle), and a re-pointed link is itself a content
+/// change worth noticing.
+///
+/// Hidden entries are skipped at every level, so `.git/` and `.DS_Store`
+/// churn does not invalidate a copy that is otherwise untouched. Empty
+/// directories contribute nothing and are therefore invisible to the digest.
+public enum SkillDirectoryHasher {
+    public static func hash(directory: URL) throws -> String {
+        var entries: [(path: String, url: URL, isSymlink: Bool)] = []
+        try collect(directory: directory, relativePath: "", into: &entries)
+        entries.sort { $0.path.utf8.lexicographicallyPrecedes($1.path.utf8) }
+
+        var hasher = SHA256()
+        let separator = Data([0])
+        for entry in entries {
+            hasher.update(data: Data(entry.path.utf8))
+            hasher.update(data: separator)
+            if entry.isSymlink {
+                let target = (try? FileManager.default.destinationOfSymbolicLink(atPath: entry.url.path)) ?? ""
+                hasher.update(data: Data(target.utf8))
+            } else {
+                hasher.update(data: try Data(contentsOf: entry.url, options: [.mappedIfSafe]))
+            }
+            hasher.update(data: separator)
+        }
+        return hasher.finalize().map { String(format: "%02x", $0) }.joined()
+    }
+
+    private static func collect(
+        directory: URL,
+        relativePath: String,
+        into entries: inout [(path: String, url: URL, isSymlink: Bool)]
+    ) throws {
+        let fm = FileManager.default
+        let names = try fm.contentsOfDirectory(atPath: directory.path)
+        for name in names {
+            if name.hasPrefix(".") { continue }
+            let child = directory.appendingPathComponent(name)
+            let childRelativePath = relativePath.isEmpty ? name : "\(relativePath)/\(name)"
+            guard let attributes = try? fm.attributesOfItem(atPath: child.path) else { continue }
+            switch attributes[.type] as? FileAttributeType {
+            case .typeDirectory:
+                try collect(directory: child, relativePath: childRelativePath, into: &entries)
+            case .typeSymbolicLink:
+                entries.append((childRelativePath, child, true))
+            case .typeRegular:
+                entries.append((childRelativePath, child, false))
+            default:
+                continue
+            }
+        }
+    }
+}

--- a/Sources/VibeBarCore/Skills/SkillFrontmatterParser.swift
+++ b/Sources/VibeBarCore/Skills/SkillFrontmatterParser.swift
@@ -1,0 +1,88 @@
+import Foundation
+
+/// Minimal YAML frontmatter reader for `SKILL.md`.
+///
+/// Only the two top-level scalars Vibe Bar displays are recovered — `name` and
+/// `description` — in plain, quoted, and folded (`>` / `>-` / `|`) forms.
+/// Everything else (nested `metadata:` trees, anchors, flow collections) is
+/// skipped rather than parsed, and any shape this does not understand yields
+/// `nil` fields instead of an error: a skill with exotic frontmatter still
+/// installs, it just falls back to its directory name.
+public enum SkillFrontmatterParser {
+    public struct Frontmatter: Equatable, Sendable {
+        public let name: String?
+        public let description: String?
+
+        public init(name: String?, description: String?) {
+            self.name = name
+            self.description = description
+        }
+
+        public static let empty = Frontmatter(name: nil, description: nil)
+    }
+
+    public static func parse(contentsOf url: URL) -> Frontmatter {
+        guard
+            let data = try? Data(contentsOf: url),
+            let text = String(data: data, encoding: .utf8)
+        else { return .empty }
+        return parse(text)
+    }
+
+    public static func parse(_ raw: String) -> Frontmatter {
+        var text = raw
+        if text.hasPrefix("\u{FEFF}") { text.removeFirst() }
+        var lines = text.components(separatedBy: "\n").map {
+            $0.hasSuffix("\r") ? String($0.dropLast()) : $0
+        }
+        guard let opener = lines.first, opener.trimmingCharacters(in: .whitespaces) == "---" else {
+            return .empty
+        }
+        lines.removeFirst()
+
+        var values: [String: String] = [:]
+        var blockKey: String?
+        var blockLines: [String] = []
+        func flushBlock() {
+            if let key = blockKey, values[key] == nil, !blockLines.isEmpty {
+                values[key] = blockLines.joined(separator: " ")
+            }
+            blockKey = nil
+            blockLines = []
+        }
+
+        for line in lines {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            if trimmed == "---" || trimmed == "..." { break }
+            if trimmed.isEmpty { continue }
+            if line.first == " " || line.first == "\t" {
+                if blockKey != nil { blockLines.append(trimmed) }
+                continue
+            }
+            flushBlock()
+            guard let colon = line.firstIndex(of: ":") else { continue }
+            let key = String(line[line.startIndex..<colon]).trimmingCharacters(in: .whitespaces)
+            guard key == "name" || key == "description" else { continue }
+            let value = String(line[line.index(after: colon)...]).trimmingCharacters(in: .whitespaces)
+            if value.isEmpty || value.hasPrefix(">") || value.hasPrefix("|") {
+                blockKey = key
+            } else if values[key] == nil {
+                values[key] = unquoted(value)
+            }
+        }
+        flushBlock()
+        return Frontmatter(name: values["name"], description: values["description"])
+    }
+
+    private static func unquoted(_ value: String) -> String {
+        guard
+            value.count >= 2,
+            let first = value.first,
+            let last = value.last,
+            first == last,
+            first == "\"" || first == "'"
+        else { return value }
+        let inner = String(value.dropFirst().dropLast())
+        return first == "\"" ? inner.replacingOccurrences(of: "\\\"", with: "\"") : inner
+    }
+}

--- a/Sources/VibeBarCore/Skills/SkillImportScanner.swift
+++ b/Sources/VibeBarCore/Skills/SkillImportScanner.swift
@@ -1,0 +1,340 @@
+import Foundation
+
+/// A skill directory found in an agent CLI's skills dir that has no SSOT
+/// counterpart — installed by hand, or by a tool that never used
+/// `~/.agents/skills`. Importing one copies it into the SSOT first.
+public struct UnmanagedSkillDirectory: Sendable, Hashable {
+    public let directoryName: String
+    public let foundIn: [SkillAppTarget]
+    public let name: String?
+    public let description: String?
+
+    public init(
+        directoryName: String,
+        foundIn: [SkillAppTarget],
+        name: String? = nil,
+        description: String? = nil
+    ) {
+        self.directoryName = directoryName
+        self.foundIn = foundIn
+        self.name = name
+        self.description = description
+    }
+}
+
+/// A real directory in an app's skills dir that shadows a same-named SSOT
+/// skill. Materializing over it would destroy whatever it holds, so import
+/// surfaces it and lets the user decide.
+public struct SkillImportConflict: Sendable, Hashable {
+    public let directoryName: String
+    public let app: SkillAppTarget
+
+    public init(directoryName: String, app: SkillAppTarget) {
+        self.directoryName = directoryName
+        self.app = app
+    }
+}
+
+public struct SkillImportReport: Sendable, Hashable {
+    /// SSOT skills, fully formed, with `apps` populated from the symlinks
+    /// already on disk.
+    public let adopted: [Skill]
+    public let unmanagedDirectories: [UnmanagedSkillDirectory]
+    /// SSOT directories with no SKILL.md — not skills, left alone.
+    public let unrecognized: [String]
+    public let conflicts: [SkillImportConflict]
+
+    public init(
+        adopted: [Skill],
+        unmanagedDirectories: [UnmanagedSkillDirectory],
+        unrecognized: [String],
+        conflicts: [SkillImportConflict]
+    ) {
+        self.adopted = adopted
+        self.unmanagedDirectories = unmanagedDirectories
+        self.unrecognized = unrecognized
+        self.conflicts = conflicts
+    }
+
+    public var isEmpty: Bool {
+        adopted.isEmpty && unmanagedDirectories.isEmpty && unrecognized.isEmpty && conflicts.isEmpty
+    }
+}
+
+/// Recognizes an existing skills layout without changing a byte of it.
+///
+/// The machines this ships to already have `~/.agents/skills` full of skills
+/// and every app dir full of absolute symlinks into it, created by a different
+/// tool. Import therefore has exactly one job: describe what is there — which
+/// SSOT directories are skills, which app dirs already point at them, which
+/// app-side directories are foreign, and what provenance
+/// `~/.agents/.skill-lock.json` can still tell us — so Vibe Bar can start
+/// managing that layout in place instead of rebuilding it.
+///
+/// Every filesystem call here is a read. The scan performs no creation, no
+/// deletion, no relinking, and never writes the lock file, which belongs to
+/// the tool that created it.
+public enum SkillImportScanner {
+    public static func scan(homeDirectory: String = RealHomeDirectory.path) -> SkillImportReport {
+        let fm = FileManager.default
+        let ssot = SkillAppCatalog.ssotDirectory(homeDirectory: homeDirectory)
+        let engine = SkillSyncEngine(homeDirectory: homeDirectory)
+
+        var candidates: [String] = []
+        var unrecognized: [String] = []
+        for name in directoryEntries(at: ssot) {
+            let directory = ssot.appendingPathComponent(name, isDirectory: true)
+            guard SkillFileSystem.kind(of: directory) == .directory else { continue }
+            if fm.fileExists(atPath: directory.appendingPathComponent("SKILL.md").path) {
+                candidates.append(name)
+            } else {
+                unrecognized.append(name)
+            }
+        }
+        let candidateNames = Set(candidates)
+        let ssotNames = candidateNames.union(unrecognized)
+
+        var evidence: [String: [SkillAppTarget]] = [:]
+        var unmanaged: [String: [SkillAppTarget]] = [:]
+        var unmanagedSample: [String: URL] = [:]
+        var conflicts: [SkillImportConflict] = []
+
+        for app in SkillAppTarget.allCases {
+            let appDirectory = SkillAppCatalog.skillsDirectory(for: app, homeDirectory: homeDirectory)
+            for name in directoryEntries(at: appDirectory) {
+                let entry = appDirectory.appendingPathComponent(name, isDirectory: true)
+                switch SkillFileSystem.kind(of: entry) {
+                case .symlink:
+                    // Dangling links, and links aimed anywhere other than this
+                    // skill's own SSOT directory, are not adoption evidence.
+                    guard
+                        candidateNames.contains(name),
+                        engine.adoptionState(skillDirectoryName: name, app: app) != nil
+                    else { continue }
+                    evidence[name, default: []].append(app)
+                case .directory:
+                    if ssotNames.contains(name) {
+                        conflicts.append(SkillImportConflict(directoryName: name, app: app))
+                    } else {
+                        unmanaged[name, default: []].append(app)
+                        if unmanagedSample[name] == nil { unmanagedSample[name] = entry }
+                    }
+                default:
+                    continue
+                }
+            }
+        }
+
+        let lock = SkillLockFileReader.read(homeDirectory: homeDirectory)
+        let adopted: [Skill] = candidates.map { name in
+            let directory = ssot.appendingPathComponent(name, isDirectory: true)
+            let frontmatter = SkillFrontmatterParser.parse(
+                contentsOf: directory.appendingPathComponent("SKILL.md")
+            )
+            let provenance = lock.provenance(for: name)
+            var apps: [SkillAppTarget: SkillMaterialization] = [:]
+            for app in evidence[name] ?? [] {
+                apps[app] = SkillMaterialization(method: .symlink, adopted: true)
+            }
+            return Skill(
+                id: provenance.id,
+                name: frontmatter.name ?? name,
+                description: frontmatter.description,
+                directory: name,
+                repoBranch: provenance.branch,
+                installedAt: provenance.installedAt ?? fileDate(of: directory, key: .creationDate) ?? .distantPast,
+                contentHash: try? SkillDirectoryHasher.hash(directory: directory),
+                updatedAt: provenance.updatedAt ?? fileDate(of: directory, key: .modificationDate),
+                apps: apps
+            )
+        }
+
+        let unmanagedDirectories: [UnmanagedSkillDirectory] = unmanaged.keys.sorted().map { name in
+            let frontmatter = unmanagedSample[name].map {
+                SkillFrontmatterParser.parse(contentsOf: $0.appendingPathComponent("SKILL.md"))
+            } ?? .empty
+            return UnmanagedSkillDirectory(
+                directoryName: name,
+                foundIn: unmanaged[name] ?? [],
+                name: frontmatter.name,
+                description: frontmatter.description
+            )
+        }
+
+        return SkillImportReport(
+            adopted: adopted,
+            unmanagedDirectories: unmanagedDirectories,
+            unrecognized: unrecognized,
+            conflicts: conflicts
+        )
+    }
+
+    private static func directoryEntries(at url: URL) -> [String] {
+        let names = (try? FileManager.default.contentsOfDirectory(atPath: url.path)) ?? []
+        return names.filter { !$0.hasPrefix(".") }.sorted()
+    }
+
+    private static func fileDate(of url: URL, key: FileAttributeKey) -> Date? {
+        (try? FileManager.default.attributesOfItem(atPath: url.path))?[key] as? Date
+    }
+}
+
+/// Read-only view of `~/.agents/.skill-lock.json`, the provenance file another
+/// tool maintains. Vibe Bar recovers repository identity and branch from it so
+/// adopted skills know where they came from; it never writes the file, and
+/// treats every field as optional because the schema is not ours.
+struct SkillLockFileReader {
+    struct Provenance {
+        let id: SkillID
+        let branch: String?
+        let installedAt: Date?
+        let updatedAt: Date?
+    }
+
+    private let entries: [String: Entry]
+
+    static func read(homeDirectory: String) -> SkillLockFileReader {
+        let url = SkillAppCatalog.lockFileURL(homeDirectory: homeDirectory)
+        guard
+            let data = try? Data(contentsOf: url),
+            let file = try? JSONDecoder().decode(LockFile.self, from: data)
+        else {
+            return SkillLockFileReader(entries: [:])
+        }
+        var entries: [String: Entry] = [:]
+        for (name, lossy) in file.skills ?? [:] {
+            guard let entry = lossy.entry else { continue }
+            entries[name] = entry
+        }
+        return SkillLockFileReader(entries: entries)
+    }
+
+    func provenance(for directoryName: String) -> Provenance {
+        let entry = entries[directoryName]
+        return Provenance(
+            id: Self.identity(for: directoryName, entry: entry),
+            branch: Self.branch(for: entry),
+            installedAt: entry?.installedAt.flatMap(Self.date(from:)),
+            updatedAt: entry?.updatedAt.flatMap(Self.date(from:))
+        )
+    }
+
+    // MARK: - Parsing
+
+    private static func identity(for directoryName: String, entry: Entry?) -> SkillID {
+        guard
+            let entry,
+            entry.sourceType?.lowercased() == "github",
+            let source = entry.source
+        else { return .local(directory: directoryName) }
+        let parts = source.split(separator: "/", omittingEmptySubsequences: false)
+        guard parts.count == 2, !parts[0].isEmpty, !parts[1].isEmpty else {
+            return .local(directory: directoryName)
+        }
+        return .repo(owner: String(parts[0]), repo: String(parts[1]), directory: directoryName)
+    }
+
+    private static func branch(for entry: Entry?) -> String? {
+        guard let entry else { return nil }
+        if let branch = entry.branch, !branch.isEmpty { return branch }
+        if let branch = entry.sourceBranch, !branch.isEmpty { return branch }
+        guard let sourceURL = entry.sourceUrl else { return nil }
+        return branch(fromSourceURL: sourceURL)
+    }
+
+    /// `sourceUrl` is a plain clone URL most of the time, but the installer
+    /// also accepts the browse-URL forms people paste. Checked in order:
+    /// a `/tree/<branch>/…` path segment, a `#branch` fragment, then a
+    /// `?branch=` / `?ref=` query value. Only the first path segment after
+    /// `/tree/` is taken — a slashed branch name is indistinguishable from
+    /// `<branch>/<path>` without asking the remote.
+    static func branch(fromSourceURL raw: String) -> String? {
+        var base = raw
+        var fragment: String?
+        if let hash = base.firstIndex(of: "#") {
+            fragment = String(base[base.index(after: hash)...])
+            base = String(base[base.startIndex..<hash])
+        }
+        var query: String?
+        if let mark = base.firstIndex(of: "?") {
+            query = String(base[base.index(after: mark)...])
+            base = String(base[base.startIndex..<mark])
+        }
+        if let treeRange = base.range(of: "/tree/") {
+            let segment = base[treeRange.upperBound...]
+                .split(separator: "/", maxSplits: 1, omittingEmptySubsequences: false)
+                .first
+                .map(String.init) ?? ""
+            if !segment.isEmpty { return segment }
+        }
+        if let fragment, !fragment.isEmpty { return fragment }
+        for pair in (query ?? "").split(separator: "&") {
+            let parts = pair.split(separator: "=", maxSplits: 1, omittingEmptySubsequences: false)
+            guard parts.count == 2, parts[0] == "branch" || parts[0] == "ref" else { continue }
+            let value = String(parts[1]).removingPercentEncoding ?? String(parts[1])
+            if !value.isEmpty { return value }
+        }
+        return nil
+    }
+
+    private static func date(from raw: String) -> Date? {
+        let withFraction = ISO8601DateFormatter()
+        withFraction.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        if let date = withFraction.date(from: raw) { return date }
+        let plain = ISO8601DateFormatter()
+        plain.formatOptions = [.withInternetDateTime]
+        return plain.date(from: raw)
+    }
+
+    // MARK: - Wire shape
+
+    private struct LockFile: Decodable {
+        let version: Int?
+        let skills: [String: LossyEntry]?
+
+        private enum CodingKeys: String, CodingKey {
+            case version, skills
+        }
+
+        init(from decoder: Decoder) throws {
+            let c = try decoder.container(keyedBy: CodingKeys.self)
+            self.version = try? c.decodeIfPresent(Int.self, forKey: .version)
+            self.skills = try? c.decodeIfPresent([String: LossyEntry].self, forKey: .skills)
+        }
+    }
+
+    private struct LossyEntry: Decodable {
+        let entry: Entry?
+
+        init(from decoder: Decoder) throws {
+            entry = try? Entry(from: decoder)
+        }
+    }
+
+    struct Entry: Decodable {
+        let source: String?
+        let sourceType: String?
+        let sourceUrl: String?
+        let skillPath: String?
+        let branch: String?
+        let sourceBranch: String?
+        let installedAt: String?
+        let updatedAt: String?
+
+        private enum CodingKeys: String, CodingKey {
+            case source, sourceType, sourceUrl, skillPath, branch, sourceBranch, installedAt, updatedAt
+        }
+
+        init(from decoder: Decoder) throws {
+            let c = try decoder.container(keyedBy: CodingKeys.self)
+            self.source = try? c.decodeIfPresent(String.self, forKey: .source)
+            self.sourceType = try? c.decodeIfPresent(String.self, forKey: .sourceType)
+            self.sourceUrl = try? c.decodeIfPresent(String.self, forKey: .sourceUrl)
+            self.skillPath = try? c.decodeIfPresent(String.self, forKey: .skillPath)
+            self.branch = try? c.decodeIfPresent(String.self, forKey: .branch)
+            self.sourceBranch = try? c.decodeIfPresent(String.self, forKey: .sourceBranch)
+            self.installedAt = try? c.decodeIfPresent(String.self, forKey: .installedAt)
+            self.updatedAt = try? c.decodeIfPresent(String.self, forKey: .updatedAt)
+        }
+    }
+}

--- a/Sources/VibeBarCore/Skills/SkillModels.swift
+++ b/Sources/VibeBarCore/Skills/SkillModels.swift
@@ -1,0 +1,262 @@
+import Foundation
+
+/// Stable identity of a skill.
+///
+/// A skill is identified by where it came from plus the directory name it
+/// occupies in the SSOT (`~/.agents/skills/<directory>`). The directory name
+/// is part of the identity because it is what every app-side materialization
+/// is keyed on — two skills cannot share a directory.
+///
+/// Serialized form:
+/// - `owner/repo:directory` for a GitHub-backed skill
+/// - `local:directory` for a hand-installed or adopted one
+///
+/// Parsing splits on the *first* colon, so a directory name may itself contain
+/// a colon and still round-trips. `local` always wins over a GitHub owner
+/// literally named `local`, which cannot exist as a repo slug anyway (a slug
+/// requires a `/`).
+public enum SkillID: RawRepresentable, Hashable, Sendable, Codable {
+    case repo(owner: String, repo: String, directory: String)
+    case local(directory: String)
+
+    public static let localSource = "local"
+
+    public init?(rawValue: String) {
+        guard let separator = rawValue.firstIndex(of: ":") else { return nil }
+        let source = String(rawValue[rawValue.startIndex..<separator])
+        let directory = String(rawValue[rawValue.index(after: separator)...])
+        guard !directory.isEmpty else { return nil }
+        if source == Self.localSource {
+            self = .local(directory: directory)
+            return
+        }
+        let parts = source.split(separator: "/", omittingEmptySubsequences: false)
+        guard parts.count == 2, !parts[0].isEmpty, !parts[1].isEmpty else { return nil }
+        self = .repo(owner: String(parts[0]), repo: String(parts[1]), directory: directory)
+    }
+
+    public var rawValue: String {
+        switch self {
+        case let .repo(owner, repo, directory):
+            return "\(owner)/\(repo):\(directory)"
+        case let .local(directory):
+            return "\(Self.localSource):\(directory)"
+        }
+    }
+
+    /// SSOT directory name this identity occupies.
+    public var directory: String {
+        switch self {
+        case let .repo(_, _, directory): return directory
+        case let .local(directory): return directory
+        }
+    }
+
+    /// `owner/repo` for GitHub-backed skills, `nil` for local ones.
+    public var repositorySlug: String? {
+        switch self {
+        case let .repo(owner, repo, _): return "\(owner)/\(repo)"
+        case .local: return nil
+        }
+    }
+
+    public var isRepositoryBacked: Bool { repositorySlug != nil }
+
+    public init(from decoder: Decoder) throws {
+        let raw = try decoder.singleValueContainer().decode(String.self)
+        guard let parsed = SkillID(rawValue: raw) else {
+            throw DecodingError.dataCorrupted(
+                DecodingError.Context(
+                    codingPath: decoder.codingPath,
+                    debugDescription: "Unrecognized skill id"
+                )
+            )
+        }
+        self = parsed
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(rawValue)
+    }
+}
+
+/// One agent CLI that can consume skills. The raw values are the persisted
+/// keys in `skills.json`, so renaming one is a schema change.
+public enum SkillAppTarget: String, CaseIterable, Codable, Hashable, Sendable {
+    case claude
+    case codex
+    case gemini
+    case grok
+    case hermes
+    case opencode
+    case antigravity
+
+    public var displayName: String {
+        switch self {
+        case .claude: return "Claude Code"
+        case .codex: return "Codex"
+        case .gemini: return "Gemini CLI"
+        case .grok: return "Grok"
+        case .hermes: return "Hermes"
+        case .opencode: return "OpenCode"
+        case .antigravity: return "AntiGravity"
+        }
+    }
+}
+
+/// How a skill should be projected from the SSOT into an app's skills dir.
+///
+/// `auto` is a *request*, never a recorded outcome: the sync engine resolves
+/// it against what is already on disk and records the concrete method.
+public enum SkillSyncMethod: String, CaseIterable, Codable, Hashable, Sendable {
+    case auto
+    case symlink
+    case copy
+}
+
+/// What the sync engine actually did for one (skill, app) pair.
+public struct SkillMaterialization: Codable, Hashable, Sendable {
+    /// Always `.symlink` or `.copy` — `.auto` is resolved before recording.
+    public let method: SkillSyncMethod
+    /// True when the entry was already on disk (created by another tool) and
+    /// Vibe Bar merely recognized it during import.
+    public let adopted: Bool
+    /// Directory hash captured right after a copy. `unmaterialize` refuses to
+    /// delete a copy whose hash has since changed, so user edits survive.
+    public let contentHashAtCopy: String?
+
+    public init(method: SkillSyncMethod, adopted: Bool = false, contentHashAtCopy: String? = nil) {
+        self.method = method == .auto ? .copy : method
+        self.adopted = adopted
+        self.contentHashAtCopy = contentHashAtCopy
+    }
+}
+
+/// A skill installed in the SSOT (`~/.agents/skills/<directory>`), plus the
+/// per-app materializations Vibe Bar knows about.
+public struct Skill: Codable, Hashable, Sendable, Identifiable {
+    public var id: SkillID
+    /// `name:` from SKILL.md frontmatter, falling back to the directory name.
+    public var name: String
+    public var description: String?
+    /// SSOT directory name. Kept alongside `id` because every filesystem
+    /// operation keys on it and `id` is opaque to call sites.
+    public var directory: String
+    public var repoBranch: String?
+    public var installedAt: Date
+    public var contentHash: String?
+    public var updatedAt: Date?
+    public var apps: [SkillAppTarget: SkillMaterialization]
+
+    public init(
+        id: SkillID,
+        name: String,
+        description: String? = nil,
+        directory: String,
+        repoBranch: String? = nil,
+        installedAt: Date,
+        contentHash: String? = nil,
+        updatedAt: Date? = nil,
+        apps: [SkillAppTarget: SkillMaterialization] = [:]
+    ) {
+        self.id = id
+        self.name = name
+        self.description = description
+        self.directory = directory
+        self.repoBranch = repoBranch
+        self.installedAt = installedAt
+        self.contentHash = contentHash
+        self.updatedAt = updatedAt
+        self.apps = apps
+    }
+
+    public var enabledApps: [SkillAppTarget] {
+        SkillAppTarget.allCases.filter { apps[$0] != nil }
+    }
+
+    public func isEnabled(for app: SkillAppTarget) -> Bool {
+        apps[app] != nil
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case id, name, description, directory, repoBranch, installedAt, contentHash, updatedAt, apps
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        self.id = try c.decode(SkillID.self, forKey: .id)
+        self.directory = try c.decodeIfPresent(String.self, forKey: .directory) ?? id.directory
+        self.name = try c.decodeIfPresent(String.self, forKey: .name) ?? directory
+        self.description = try c.decodeIfPresent(String.self, forKey: .description)
+        self.repoBranch = try c.decodeIfPresent(String.self, forKey: .repoBranch)
+        self.installedAt = try c.decodeIfPresent(Date.self, forKey: .installedAt) ?? Date(timeIntervalSince1970: 0)
+        self.contentHash = try c.decodeIfPresent(String.self, forKey: .contentHash)
+        self.updatedAt = try c.decodeIfPresent(Date.self, forKey: .updatedAt)
+        // App keys are decoded through their raw strings so a file written by
+        // a newer build (which knows more agent CLIs) still loads here, minus
+        // the entries this build cannot act on.
+        let raw = try c.decodeIfPresent([String: SkillMaterialization].self, forKey: .apps) ?? [:]
+        var apps: [SkillAppTarget: SkillMaterialization] = [:]
+        for (key, value) in raw {
+            guard let app = SkillAppTarget(rawValue: key) else { continue }
+            apps[app] = value
+        }
+        self.apps = apps
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        try c.encode(id, forKey: .id)
+        try c.encode(name, forKey: .name)
+        try c.encodeIfPresent(description, forKey: .description)
+        try c.encode(directory, forKey: .directory)
+        try c.encodeIfPresent(repoBranch, forKey: .repoBranch)
+        try c.encode(installedAt, forKey: .installedAt)
+        try c.encodeIfPresent(contentHash, forKey: .contentHash)
+        try c.encodeIfPresent(updatedAt, forKey: .updatedAt)
+        var rawApps: [String: SkillMaterialization] = [:]
+        for (app, value) in apps { rawApps[app.rawValue] = value }
+        try c.encode(rawApps, forKey: .apps)
+    }
+}
+
+public enum SkillError: Error, Equatable, Sendable {
+    case invalidDirectoryName(String)
+    case missingSkillMD(String)
+    case directoryConflict(String)
+    case notInstalled(SkillID)
+    case writeOutsideAllowedRoots(String)
+    case sourceDirectoryMissing(String)
+    case sourceNotADirectory(String)
+    case destinationExists(String)
+    case backupNotFound(String)
+    case backupCorrupted(String)
+}
+
+extension SkillError: LocalizedError {
+    public var errorDescription: String? {
+        switch self {
+        case let .invalidDirectoryName(name):
+            return "\"\(name)\" is not a valid skill directory name."
+        case let .missingSkillMD(name):
+            return "Skill \"\(name)\" has no SKILL.md."
+        case let .directoryConflict(name):
+            return "\"\(name)\" already exists and was not created by Vibe Bar."
+        case let .notInstalled(id):
+            return "Skill \"\(id.directory)\" is not installed."
+        case let .writeOutsideAllowedRoots(path):
+            return "Refusing to write outside the managed skill directories: \(path)"
+        case let .sourceDirectoryMissing(name):
+            return "Skill directory \"\(name)\" is missing."
+        case let .sourceNotADirectory(name):
+            return "\"\(name)\" is not a directory."
+        case let .destinationExists(name):
+            return "\"\(name)\" already exists."
+        case let .backupNotFound(name):
+            return "Backup \"\(name)\" was not found."
+        case let .backupCorrupted(name):
+            return "Backup \"\(name)\" is missing its metadata."
+        }
+    }
+}

--- a/Sources/VibeBarCore/Skills/SkillModels.swift
+++ b/Sources/VibeBarCore/Skills/SkillModels.swift
@@ -232,6 +232,8 @@ public enum SkillError: Error, Equatable, Sendable {
     case destinationExists(String)
     case backupNotFound(String)
     case backupCorrupted(String)
+    case notRepositoryBacked(SkillID)
+    case updateSourceMissing(String)
 }
 
 extension SkillError: LocalizedError {
@@ -257,6 +259,10 @@ extension SkillError: LocalizedError {
             return "Backup \"\(name)\" was not found."
         case let .backupCorrupted(name):
             return "Backup \"\(name)\" is missing its metadata."
+        case let .notRepositoryBacked(id):
+            return "Skill \"\(id.directory)\" was not installed from a repository, so it cannot be updated."
+        case let .updateSourceMissing(name):
+            return "Skill \"\(name)\" is no longer in its source repository."
         }
     }
 }

--- a/Sources/VibeBarCore/Skills/SkillPathValidator.swift
+++ b/Sources/VibeBarCore/Skills/SkillPathValidator.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+/// Gatekeeper for every skill directory name that reaches the filesystem.
+///
+/// A skill name must be exactly one path component. Rejecting `..`, embedded
+/// separators, and leading dots here is what lets the sync engine treat
+/// `<root>/<name>` as guaranteed-inside-`<root>` before it does anything
+/// destructive; the write-root assertion in the engine is the second line of
+/// defense, not the first.
+public enum SkillPathValidator {
+    public static func validate(directoryName: String) throws {
+        guard isValid(directoryName) else {
+            throw SkillError.invalidDirectoryName(directoryName)
+        }
+    }
+
+    public static func isValid(_ directoryName: String) -> Bool {
+        guard !directoryName.isEmpty else { return false }
+        guard directoryName != "." && directoryName != ".." else { return false }
+        guard !directoryName.hasPrefix(".") else { return false }
+        guard !directoryName.contains("/") && !directoryName.contains("\\") else { return false }
+        for scalar in directoryName.unicodeScalars {
+            if scalar.value < 0x20 || scalar.value == 0x7F { return false }
+        }
+        return true
+    }
+}

--- a/Sources/VibeBarCore/Skills/SkillRepoFetcher.swift
+++ b/Sources/VibeBarCore/Skills/SkillRepoFetcher.swift
@@ -1,0 +1,355 @@
+import Foundation
+
+/// A GitHub repository the skills feature can read, written the way users type
+/// it: `owner/repo`, optionally `owner/repo@branch`.
+///
+/// The shape is validated strictly rather than escaped later, because these
+/// three strings are interpolated straight into a URL path and (for the
+/// repository name) can become a directory name. GitHub's own rules are the
+/// ceiling: owners are alphanumerics and hyphens, repository and branch names
+/// add `.` and `_`. `..`, leading dots, and separators are refused outright.
+public struct SkillRepoRef: Hashable, Sendable, Codable {
+    public let owner: String
+    public let repo: String
+    public let branch: String?
+
+    public var slug: String { "\(owner)/\(repo)" }
+
+    /// Round-trips through `init?(_:)`.
+    public var descriptor: String { branch.map { "\(slug)@\($0)" } ?? slug }
+
+    public init?(owner: String, repo: String, branch: String? = nil) {
+        guard
+            Self.isValidOwner(owner),
+            Self.isValidName(repo),
+            branch.map(Self.isValidName) ?? true
+        else { return nil }
+        self.owner = owner
+        self.repo = repo
+        self.branch = branch
+    }
+
+    public init?(_ raw: String) {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        var body = trimmed
+        var branch: String?
+        if let marker = body.firstIndex(of: "@") {
+            branch = String(body[body.index(after: marker)...])
+            body = String(body[body.startIndex..<marker])
+        }
+        let parts = body.split(separator: "/", omittingEmptySubsequences: false)
+        guard parts.count == 2 else { return nil }
+        self.init(owner: String(parts[0]), repo: String(parts[1]), branch: branch)
+    }
+
+    public init(from decoder: Decoder) throws {
+        let raw = try decoder.singleValueContainer().decode(String.self)
+        guard let parsed = SkillRepoRef(raw) else {
+            throw DecodingError.dataCorrupted(
+                DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Bad repository reference")
+            )
+        }
+        self = parsed
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(descriptor)
+    }
+
+    /// Same ref with the branch replaced — used once a fallback branch has
+    /// actually been resolved.
+    public func with(branch: String?) -> SkillRepoRef {
+        SkillRepoRef(owner: owner, repo: repo, branch: branch) ?? self
+    }
+
+    private static let maxLength = 100
+
+    private static func isValidOwner(_ value: String) -> Bool {
+        guard (1...maxLength).contains(value.count) else { return false }
+        return value.unicodeScalars.allSatisfy { scalar in
+            scalar == "-" || CharacterSet.alphanumerics.contains(scalar) && scalar.isASCII
+        }
+    }
+
+    private static func isValidName(_ value: String) -> Bool {
+        guard (1...maxLength).contains(value.count) else { return false }
+        guard !value.hasPrefix("."), value != "..", !value.contains("..") else { return false }
+        return value.unicodeScalars.allSatisfy { scalar in
+            scalar == "-" || scalar == "_" || scalar == "."
+                || (CharacterSet.alphanumerics.contains(scalar) && scalar.isASCII)
+        }
+    }
+}
+
+/// One skill directory found inside a downloaded repository, before install.
+public struct DiscoveredSkill: Sendable, Hashable, Identifiable {
+    public let id: SkillID
+    public let name: String
+    public let description: String?
+    /// The SSOT directory name this would install as — the last path segment.
+    public let directory: String
+    /// Path of the skill directory inside the repository, `""` when the
+    /// repository root is itself the skill.
+    public let repoRelativePath: String
+    public let branch: String
+    public let readmeURL: URL?
+    /// Where the extracted copy lives right now. Valid only while the
+    /// downloading service keeps its staging directory alive.
+    public let sourceRoot: URL
+
+    public init(
+        id: SkillID,
+        name: String,
+        description: String?,
+        directory: String,
+        repoRelativePath: String,
+        branch: String,
+        readmeURL: URL?,
+        sourceRoot: URL
+    ) {
+        self.id = id
+        self.name = name
+        self.description = description
+        self.directory = directory
+        self.repoRelativePath = repoRelativePath
+        self.branch = branch
+        self.readmeURL = readmeURL
+        self.sourceRoot = sourceRoot
+    }
+
+    public var repositorySlug: String? { id.repositorySlug }
+}
+
+public enum SkillRepoError: Error, Equatable, Sendable {
+    case invalidRepositoryReference(String)
+    case branchNotFound(slug: String, tried: [String])
+    case malformedArchive(String)
+}
+
+extension SkillRepoError: LocalizedError {
+    public var errorDescription: String? {
+        switch self {
+        case let .invalidRepositoryReference(raw):
+            return "\"\(raw)\" is not a valid owner/repo reference."
+        case let .branchNotFound(slug, tried):
+            return "Could not download \(slug) (tried \(tried.joined(separator: ", "))))."
+        case let .malformedArchive(detail):
+            return "The repository archive was not laid out as expected (\(detail))."
+        }
+    }
+}
+
+/// The seam `SkillsService` reaches the network through. Everything network-
+/// facing in the skills feature is behind these two calls, so the service's
+/// install / update / discovery logic is testable with a fake.
+public protocol SkillRepoFetching: Sendable {
+    /// Downloads and extracts `ref` under `tempDir`, returning the repository
+    /// root inside the extraction and the branch that actually answered.
+    func downloadRepo(_ ref: SkillRepoRef, into tempDir: URL) async throws -> (root: URL, resolvedBranch: String)
+
+    func scanSkills(
+        inRepoRoot root: URL,
+        ref: SkillRepoRef,
+        resolvedBranch: String
+    ) throws -> [DiscoveredSkill]
+}
+
+/// Downloads GitHub repository zipballs and finds the skills inside them.
+///
+/// No git, no API token, no clone: `codeload.github.com` serves a zip of any
+/// public branch, and `github.com/<o>/<r>/archive/refs/heads/<b>.zip` is the
+/// stable public form of that URL — it 302s to codeload, which is why both
+/// hosts are on the allowlist and why the redirect check in `BoundedDownloader`
+/// is a set membership test rather than a same-host test.
+///
+/// Branch resolution is "whatever answers first" over
+/// `[requested, main, master]`: a 404 is a normal outcome for `main` on older
+/// repositories, not an error worth surfacing. Only when every candidate fails
+/// does this report `branchNotFound`, naming what it tried.
+public struct SkillRepoFetcher: SkillRepoFetching {
+    /// A GitHub zipball of a skills repository is a few hundred KB; 128 MiB is
+    /// a hard stop for something that has gone wrong, not a working budget.
+    public static let maxArchiveBytes: Int64 = 128 * 1024 * 1024
+    public static let defaultTimeout: TimeInterval = 60
+    public static let allowedHosts: Set<String> = ["github.com", "codeload.github.com"]
+    public static let fallbackBranches = ["main", "master"]
+
+    private let downloader: BoundedDownloader
+    private let maxArchiveBytes: Int64
+    private let timeout: TimeInterval
+
+    public init(
+        downloader: BoundedDownloader = BoundedDownloader(),
+        maxArchiveBytes: Int64 = SkillRepoFetcher.maxArchiveBytes,
+        timeout: TimeInterval = SkillRepoFetcher.defaultTimeout
+    ) {
+        self.downloader = downloader
+        self.maxArchiveBytes = maxArchiveBytes
+        self.timeout = timeout
+    }
+
+    public static func archiveURL(owner: String, repo: String, branch: String) -> URL? {
+        URL(string: "https://github.com/\(owner)/\(repo)/archive/refs/heads/\(branch).zip")
+    }
+
+    public func downloadRepo(
+        _ ref: SkillRepoRef,
+        into tempDir: URL
+    ) async throws -> (root: URL, resolvedBranch: String) {
+        let candidates = Self.branchCandidates(for: ref)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+
+        var lastError: Error?
+        for branch in candidates {
+            guard let url = Self.archiveURL(owner: ref.owner, repo: ref.repo, branch: branch) else { continue }
+            let zipURL = tempDir.appendingPathComponent("\(ref.repo)-\(branch).zip")
+            do {
+                try await downloader.download(
+                    from: url,
+                    to: zipURL,
+                    maxBytes: maxArchiveBytes,
+                    timeout: timeout,
+                    allowedHosts: Self.allowedHosts
+                )
+            } catch let error as BoundedDownloader.DownloadError {
+                // A redirect off the allowlist is a security signal, not a
+                // "try the next branch" signal.
+                if case .redirectHostNotAllowed = error { throw error }
+                lastError = error
+                continue
+            } catch {
+                lastError = error
+                continue
+            }
+            defer { try? FileManager.default.removeItem(at: zipURL) }
+            let extraction = tempDir.appendingPathComponent("extract-\(branch)", isDirectory: true)
+            try? FileManager.default.removeItem(at: extraction)
+            try SkillArchiveExtractor.extract(zipFileURL: zipURL, into: extraction)
+            let root = try Self.repositoryRoot(in: extraction)
+            SafeLog.net("Skills: fetched \(ref.slug)@\(branch)")
+            return (root, branch)
+        }
+        if let lastError, !(lastError is BoundedDownloader.DownloadError) { throw lastError }
+        throw SkillRepoError.branchNotFound(slug: ref.slug, tried: candidates)
+    }
+
+    public func scanSkills(
+        inRepoRoot root: URL,
+        ref: SkillRepoRef,
+        resolvedBranch: String
+    ) throws -> [DiscoveredSkill] {
+        let found = SkillTreeScanner.scan(root: root)
+        var seen = Set<String>()
+        var results: [DiscoveredSkill] = []
+        for entry in found {
+            let directory = entry.relativePath.isEmpty
+                ? ref.repo
+                : String(entry.relativePath.split(separator: "/").last ?? "")
+            guard SkillPathValidator.isValid(directory), seen.insert(directory).inserted else { continue }
+            let frontmatter = SkillFrontmatterParser.parse(
+                contentsOf: entry.url.appendingPathComponent("SKILL.md")
+            )
+            let markdownPath = entry.relativePath.isEmpty ? "SKILL.md" : "\(entry.relativePath)/SKILL.md"
+            results.append(
+                DiscoveredSkill(
+                    id: .repo(owner: ref.owner, repo: ref.repo, directory: directory),
+                    name: frontmatter.name ?? directory,
+                    description: frontmatter.description,
+                    directory: directory,
+                    repoRelativePath: entry.relativePath,
+                    branch: resolvedBranch,
+                    readmeURL: Self.blobURL(ref: ref, branch: resolvedBranch, path: markdownPath),
+                    sourceRoot: entry.url
+                )
+            )
+        }
+        return results.sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+    }
+
+    // MARK: - Internals
+
+    static func branchCandidates(for ref: SkillRepoRef) -> [String] {
+        var seen = Set<String>()
+        return ([ref.branch].compactMap { $0 } + fallbackBranches).filter { seen.insert($0).inserted }
+    }
+
+    static func blobURL(ref: SkillRepoRef, branch: String, path: String) -> URL? {
+        let encoded = path
+            .split(separator: "/")
+            .map { $0.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? String($0) }
+            .joined(separator: "/")
+        return URL(string: "https://github.com/\(ref.owner)/\(ref.repo)/blob/\(branch)/\(encoded)")
+    }
+
+    /// A GitHub zipball wraps everything in one `<repo>-<branch>` directory.
+    /// Any single top-level directory is accepted, since the wrapper name is
+    /// GitHub's business (a slashed branch name flattens it, for one).
+    static func repositoryRoot(in extraction: URL) throws -> URL {
+        let names = ((try? FileManager.default.contentsOfDirectory(atPath: extraction.path)) ?? [])
+            .filter { !$0.hasPrefix(".") && $0 != "__MACOSX" }
+        guard names.count == 1 else {
+            throw SkillRepoError.malformedArchive("expected one top-level directory, found \(names.count)")
+        }
+        let root = extraction.appendingPathComponent(names[0], isDirectory: true)
+        guard SkillFileSystem.kind(of: root) == .directory else {
+            throw SkillRepoError.malformedArchive("top-level entry is not a directory")
+        }
+        return root
+    }
+}
+
+/// Finds skill directories in an arbitrary extracted tree.
+///
+/// One rule: a directory holding `SKILL.md` *is* a skill, and the walk does not
+/// descend into it. Skills bundle reference material and helper scripts, and
+/// some of that material is itself a `SKILL.md` example — descending would turn
+/// one skill into several. Hidden directories are skipped, which is also how
+/// `.git/` and `.github/` stay out of the results.
+enum SkillTreeScanner {
+    struct Found: Hashable {
+        /// Path relative to the scan root; `""` when the root is the skill.
+        let relativePath: String
+        let url: URL
+    }
+
+    static let maxDepth = 8
+    static let maxResults = 2_000
+
+    static func scan(root: URL, maxDepth: Int = SkillTreeScanner.maxDepth) -> [Found] {
+        guard SkillFileSystem.kind(of: root) == .directory else { return [] }
+        if isSkillDirectory(root) { return [Found(relativePath: "", url: root)] }
+        var results: [Found] = []
+        walk(directory: root, relativePath: "", depth: 0, maxDepth: maxDepth, into: &results)
+        return results.sorted { $0.relativePath.utf8.lexicographicallyPrecedes($1.relativePath.utf8) }
+    }
+
+    static func isSkillDirectory(_ url: URL) -> Bool {
+        SkillFileSystem.kind(of: url.appendingPathComponent("SKILL.md")) == .regularFile
+    }
+
+    private static func walk(
+        directory: URL,
+        relativePath: String,
+        depth: Int,
+        maxDepth: Int,
+        into results: inout [Found]
+    ) {
+        guard depth <= maxDepth, results.count < maxResults else { return }
+        let names = ((try? FileManager.default.contentsOfDirectory(atPath: directory.path)) ?? []).sorted()
+        for name in names where !name.hasPrefix(".") {
+            let child = directory.appendingPathComponent(name, isDirectory: true)
+            // lstat, not stat: a symlinked directory inside the archive is
+            // never followed. `SkillArchiveExtractor` refuses symlink entries,
+            // so this only matters for trees that arrived another way.
+            guard SkillFileSystem.kind(of: child) == .directory else { continue }
+            let childPath = relativePath.isEmpty ? name : "\(relativePath)/\(name)"
+            if isSkillDirectory(child) {
+                results.append(Found(relativePath: childPath, url: child))
+                continue
+            }
+            walk(directory: child, relativePath: childPath, depth: depth + 1, maxDepth: maxDepth, into: &results)
+        }
+    }
+}

--- a/Sources/VibeBarCore/Skills/SkillSyncEngine.swift
+++ b/Sources/VibeBarCore/Skills/SkillSyncEngine.swift
@@ -1,0 +1,291 @@
+import Foundation
+
+/// lstat-level classification of a path. Everything in the skills layer
+/// inspects the filesystem through this instead of `fileExists`, because the
+/// whole feature turns on telling a symlink apart from the directory it points
+/// at — and on never following one while deleting.
+enum SkillFileKind: Equatable {
+    case missing
+    case symlink
+    case directory
+    case regularFile
+    case other
+}
+
+enum SkillFileSystem {
+    static func kind(of url: URL) -> SkillFileKind {
+        guard let attributes = try? FileManager.default.attributesOfItem(atPath: url.path) else {
+            return .missing
+        }
+        switch attributes[.type] as? FileAttributeType {
+        case .typeSymbolicLink: return .symlink
+        case .typeDirectory: return .directory
+        case .typeRegular: return .regularFile
+        default: return .other
+        }
+    }
+
+    /// Creates `url` and any missing ancestors up to (but never above) `root`,
+    /// one component at a time. `withIntermediateDirectories: true` would do
+    /// the same thing in one call, but walking the chain explicitly keeps the
+    /// creation provably confined to the terminal path — AntiGravity's
+    /// `~/.gemini/config/skills` is created without the code ever being in a
+    /// position to touch a sibling of `config/`.
+    static func ensureDirectory(_ url: URL, stopAt root: URL, permissions: Int = 0o755) throws {
+        switch kind(of: url) {
+        case .directory: return
+        case .missing: break
+        default: throw SkillError.destinationExists(url.path)
+        }
+        let parent = url.deletingLastPathComponent()
+        guard
+            SkillAppCatalog.isPath(url, under: root),
+            parent.standardizedFileURL.path != url.standardizedFileURL.path
+        else {
+            throw SkillError.writeOutsideAllowedRoots(url.path)
+        }
+        try ensureDirectory(parent, stopAt: root, permissions: permissions)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: false)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: permissions],
+            ofItemAtPath: url.path
+        )
+    }
+
+    /// Recursive copy that swaps `destination` in as a unit: the tree is built
+    /// in a hidden sibling first and only then renamed into place, so an
+    /// interrupted copy can never leave a half-written skill where an agent
+    /// CLI would read it.
+    ///
+    /// `destination` must be missing or a real directory — callers unlink a
+    /// symlink first, since replacing through one would write to its target.
+    static func replaceDirectory(at destination: URL, withCopyOf source: URL) throws {
+        let fm = FileManager.default
+        let staging = destination
+            .deletingLastPathComponent()
+            .appendingPathComponent(
+                ".\(destination.lastPathComponent).tmp-\(getpid())-\(UInt32.random(in: 0...UInt32.max))"
+            )
+        try? fm.removeItem(at: staging)
+        defer { try? fm.removeItem(at: staging) }
+        try fm.copyItem(at: source, to: staging)
+        if kind(of: destination) == .missing {
+            try fm.moveItem(at: staging, to: destination)
+            return
+        }
+        do {
+            _ = try fm.replaceItemAt(destination, withItemAt: staging)
+        } catch {
+            try fm.removeItem(at: destination)
+            try fm.moveItem(at: staging, to: destination)
+        }
+    }
+
+    /// Resolves a symlink's recorded target lexically — relative targets
+    /// against the link's own directory, `..` collapsed in the string. It
+    /// deliberately does not resolve intermediate symlinks or require the
+    /// target to exist: a dangling link still reports where it meant to point.
+    static func lexicalSymlinkTarget(of link: URL) -> URL? {
+        guard let target = try? FileManager.default.destinationOfSymbolicLink(atPath: link.path) else {
+            return nil
+        }
+        return URL(fileURLWithPath: target, relativeTo: link.deletingLastPathComponent())
+            .absoluteURL
+            .standardizedFileURL
+    }
+}
+
+/// Projects skills from the SSOT (`~/.agents/skills`) into each agent CLI's
+/// skills directory, and takes them back out again.
+///
+/// Two invariants hold for every mutation:
+/// 1. the skill name passed `SkillPathValidator`, and the resolved path sits
+///    under `SkillAppCatalog.allowedWriteRoots`;
+/// 2. deletion never follows a symlink, and never removes anything the user
+///    could have authored — a foreign directory, or a copy whose content has
+///    drifted from the hash recorded when Vibe Bar wrote it.
+public struct SkillSyncEngine: Sendable {
+    public let homeDirectory: String
+
+    public init(homeDirectory: String = RealHomeDirectory.path) {
+        self.homeDirectory = homeDirectory
+    }
+
+    public func sourceDirectory(for skillDirectoryName: String) -> URL {
+        SkillAppCatalog.ssotDirectory(homeDirectory: homeDirectory)
+            .appendingPathComponent(skillDirectoryName, isDirectory: true)
+    }
+
+    public func destination(for skillDirectoryName: String, app: SkillAppTarget) -> URL {
+        SkillAppCatalog.skillsDirectory(for: app, homeDirectory: homeDirectory)
+            .appendingPathComponent(skillDirectoryName, isDirectory: true)
+    }
+
+    /// Materializes `skillDirectoryName` into `app` and reports what it did.
+    ///
+    /// `recorded` is the materialization already stored for this pair, if any.
+    /// It only matters when `.symlink` is forced over an existing real
+    /// directory: that directory is replaceable when its hash still matches
+    /// the copy Vibe Bar made (recorded hash, or a byte-identical copy of the
+    /// current SSOT content). Anything else is user data and throws
+    /// `directoryConflict`.
+    @discardableResult
+    public func materialize(
+        skillDirectoryName: String,
+        into app: SkillAppTarget,
+        method: SkillSyncMethod,
+        recorded: SkillMaterialization? = nil
+    ) throws -> SkillMaterialization {
+        try SkillPathValidator.validate(directoryName: skillDirectoryName)
+        let source = sourceDirectory(for: skillDirectoryName)
+        switch SkillFileSystem.kind(of: source) {
+        case .directory: break
+        case .missing: throw SkillError.sourceDirectoryMissing(skillDirectoryName)
+        default: throw SkillError.sourceNotADirectory(skillDirectoryName)
+        }
+        guard
+            FileManager.default.fileExists(atPath: source.appendingPathComponent("SKILL.md").path)
+        else {
+            throw SkillError.missingSkillMD(skillDirectoryName)
+        }
+
+        let appDirectory = SkillAppCatalog.skillsDirectory(for: app, homeDirectory: homeDirectory)
+        let destination = destination(for: skillDirectoryName, app: app)
+        guard SkillAppCatalog.isWriteAllowed(destination, homeDirectory: homeDirectory) else {
+            throw SkillError.writeOutsideAllowedRoots(destination.path)
+        }
+        try SkillFileSystem.ensureDirectory(appDirectory, stopAt: homeURL)
+
+        let fm = FileManager.default
+        let existing = SkillFileSystem.kind(of: destination)
+        switch method {
+        case .auto:
+            switch existing {
+            case .missing:
+                do {
+                    return try link(source: source, destination: destination)
+                } catch {
+                    return try copy(source: source, destination: destination)
+                }
+            case .symlink:
+                try fm.removeItem(at: destination)
+                return try link(source: source, destination: destination)
+            case .directory:
+                return try copy(source: source, destination: destination)
+            default:
+                throw SkillError.directoryConflict(skillDirectoryName)
+            }
+
+        case .symlink:
+            switch existing {
+            case .missing:
+                break
+            case .symlink:
+                try fm.removeItem(at: destination)
+            case .directory:
+                guard try isVibeBarCopy(destination: destination, source: source, recorded: recorded) else {
+                    throw SkillError.directoryConflict(skillDirectoryName)
+                }
+                try fm.removeItem(at: destination)
+            default:
+                throw SkillError.directoryConflict(skillDirectoryName)
+            }
+            return try link(source: source, destination: destination)
+
+        case .copy:
+            switch existing {
+            case .missing, .directory:
+                break
+            case .symlink:
+                try fm.removeItem(at: destination)
+            default:
+                throw SkillError.directoryConflict(skillDirectoryName)
+            }
+            return try copy(source: source, destination: destination)
+        }
+    }
+
+    /// Removes `skillDirectoryName` from `app`, and reports whether anything
+    /// was actually removed. `false` means the entry was left alone on
+    /// purpose: it is a foreign directory, a link pointing outside the SSOT,
+    /// or a copy the user has since edited.
+    @discardableResult
+    public func unmaterialize(
+        skillDirectoryName: String,
+        from app: SkillAppTarget,
+        recorded: SkillMaterialization?
+    ) throws -> Bool {
+        try SkillPathValidator.validate(directoryName: skillDirectoryName)
+        let destination = destination(for: skillDirectoryName, app: app)
+        guard SkillAppCatalog.isWriteAllowed(destination, homeDirectory: homeDirectory) else {
+            throw SkillError.writeOutsideAllowedRoots(destination.path)
+        }
+
+        switch SkillFileSystem.kind(of: destination) {
+        case .missing:
+            return true
+        case .symlink:
+            guard
+                let resolved = SkillFileSystem.lexicalSymlinkTarget(of: destination),
+                SkillAppCatalog.isPath(resolved, under: SkillAppCatalog.ssotDirectory(homeDirectory: homeDirectory))
+            else { return false }
+            try FileManager.default.removeItem(at: destination)
+            return true
+        case .directory:
+            guard
+                recorded?.method == .copy,
+                let expected = recorded?.contentHashAtCopy,
+                let current = try? SkillDirectoryHasher.hash(directory: destination),
+                current == expected
+            else { return false }
+            try FileManager.default.removeItem(at: destination)
+            return true
+        case .regularFile, .other:
+            return false
+        }
+    }
+
+    /// lstat-only inspection used by import: reports an existing symlink into
+    /// the SSOT as an already-materialized skill Vibe Bar can adopt as-is. A
+    /// real directory returns `nil` — it is foreign until the user says
+    /// otherwise.
+    public func adoptionState(skillDirectoryName: String, app: SkillAppTarget) -> SkillMaterialization? {
+        guard SkillPathValidator.isValid(skillDirectoryName) else { return nil }
+        let destination = destination(for: skillDirectoryName, app: app)
+        guard SkillFileSystem.kind(of: destination) == .symlink else { return nil }
+        guard let resolved = SkillFileSystem.lexicalSymlinkTarget(of: destination) else { return nil }
+        let source = sourceDirectory(for: skillDirectoryName).standardizedFileURL
+        guard resolved.path == source.path else { return nil }
+        return SkillMaterialization(method: .symlink, adopted: true)
+    }
+
+    // MARK: - Internals
+
+    var homeURL: URL { URL(fileURLWithPath: homeDirectory, isDirectory: true) }
+
+    private func link(source: URL, destination: URL) throws -> SkillMaterialization {
+        try FileManager.default.createSymbolicLink(
+            at: destination,
+            withDestinationURL: source.standardizedFileURL
+        )
+        return SkillMaterialization(method: .symlink)
+    }
+
+    private func copy(source: URL, destination: URL) throws -> SkillMaterialization {
+        try SkillFileSystem.replaceDirectory(at: destination, withCopyOf: source)
+        let hash = try SkillDirectoryHasher.hash(directory: destination)
+        return SkillMaterialization(method: .copy, contentHashAtCopy: hash)
+    }
+
+    private func isVibeBarCopy(
+        destination: URL,
+        source: URL,
+        recorded: SkillMaterialization?
+    ) throws -> Bool {
+        let current = try SkillDirectoryHasher.hash(directory: destination)
+        if recorded?.method == .copy, let recordedHash = recorded?.contentHashAtCopy {
+            if recordedHash == current { return true }
+        }
+        return current == (try SkillDirectoryHasher.hash(directory: source))
+    }
+}

--- a/Sources/VibeBarCore/Skills/SkillsSearchClient.swift
+++ b/Sources/VibeBarCore/Skills/SkillsSearchClient.swift
@@ -1,0 +1,177 @@
+import Foundation
+
+/// One row of a skills.sh search response, after validation.
+public struct SkillsShSearchResult: Sendable, Hashable, Identifiable {
+    public var id: String { "\(repo.descriptor)#\(name)" }
+    public let name: String
+    /// Install count as reported by the index; absent when the field is
+    /// missing or not a number.
+    public let installs: Int?
+    public let repo: SkillRepoRef
+
+    public init(name: String, installs: Int?, repo: SkillRepoRef) {
+        self.name = name
+        self.installs = installs
+        self.repo = repo
+    }
+}
+
+public enum SkillsSearchError: Error, Equatable, Sendable {
+    case emptyQuery
+    case badRequest
+    case notHTTP
+    case httpStatus(Int)
+    case malformedResponse
+}
+
+extension SkillsSearchError: LocalizedError {
+    public var errorDescription: String? {
+        switch self {
+        case .emptyQuery: return "Enter something to search for."
+        case .badRequest: return "The search query could not be encoded."
+        case .notHTTP: return "skills.sh did not return an HTTP response."
+        case let .httpStatus(code): return "skills.sh returned HTTP \(code)."
+        case .malformedResponse: return "skills.sh returned an unrecognized response."
+        }
+    }
+}
+
+/// Read-only client for the skills.sh community index.
+///
+/// One unauthenticated GET, no API key, no account: the index only answers
+/// with a name, an install count, and an `owner/repo` source. That last field
+/// is the only one that matters — it is what the rest of the feature turns into
+/// a download URL — so a row whose `source` does not pass `SkillRepoRef`
+/// validation is dropped rather than repaired. Everything else is decoded
+/// tolerantly, because this is a third-party index whose schema is not ours:
+/// unknown keys are ignored, `id`/`skillId` stand in for a missing `name`, and
+/// an install count that arrives as a string is still read as a number.
+///
+/// The response is size-capped through `HTTPResponseLimit`; the search string
+/// itself never reaches the log, only the endpoint's host and path.
+public struct SkillsSearchClient: Sendable {
+    public static let host = "skills.sh"
+    public static let searchPath = "/api/search"
+    public static let maxResponseBytes = 4 * 1024 * 1024
+    public static let defaultTimeout: TimeInterval = 10
+    public static let defaultLimit = 25
+    public static let maxLimit = 100
+
+    private let session: URLSession
+    private let timeout: TimeInterval
+
+    public init(session: URLSession = .shared, timeout: TimeInterval = SkillsSearchClient.defaultTimeout) {
+        self.session = session
+        self.timeout = timeout
+    }
+
+    public func search(
+        _ query: String,
+        limit: Int = SkillsSearchClient.defaultLimit
+    ) async throws -> [SkillsShSearchResult] {
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { throw SkillsSearchError.emptyQuery }
+        guard let url = Self.searchURL(query: trimmed, limit: limit) else {
+            throw SkillsSearchError.badRequest
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.timeoutInterval = timeout
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.setValue("VibeBar/skills", forHTTPHeaderField: "User-Agent")
+
+        let (data, response) = try await HTTPResponseLimit.boundedData(
+            from: session,
+            for: request,
+            maxBytes: Self.maxResponseBytes
+        )
+        guard let http = response as? HTTPURLResponse else { throw SkillsSearchError.notHTTP }
+        guard http.statusCode == 200 else { throw SkillsSearchError.httpStatus(http.statusCode) }
+        guard let payload = try? JSONDecoder().decode(Payload.self, from: data) else {
+            throw SkillsSearchError.malformedResponse
+        }
+        return payload.skills.compactMap(\.result)
+    }
+
+    static func searchURL(query: String, limit: Int) -> URL? {
+        var components = URLComponents()
+        components.scheme = "https"
+        components.host = host
+        components.path = searchPath
+        components.queryItems = [
+            URLQueryItem(name: "q", value: query),
+            URLQueryItem(name: "limit", value: String(min(max(limit, 1), maxLimit)))
+        ]
+        return components.url
+    }
+
+    // MARK: - Wire shape
+
+    private struct Payload: Decodable {
+        let skills: [Row]
+
+        private enum CodingKeys: String, CodingKey { case skills }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            skills = ((try? container.decodeIfPresent([Row].self, forKey: .skills)) ?? nil) ?? []
+        }
+    }
+
+    /// Decodes to `nil` rather than throwing on any row shape we cannot use, so
+    /// one bad entry never costs the user the rest of the results.
+    private struct Row: Decodable {
+        let result: SkillsShSearchResult?
+
+        private enum CodingKeys: String, CodingKey {
+            case id, skillId, name, installs, source
+        }
+
+        init(from decoder: Decoder) throws {
+            guard let container = try? decoder.container(keyedBy: CodingKeys.self) else {
+                result = nil
+                return
+            }
+            let name = Self.string(container, .name)
+                ?? Self.string(container, .skillId)
+                ?? Self.string(container, .id)
+            guard
+                let source = Self.string(container, .source),
+                let repo = SkillRepoRef(source),
+                let name, !name.isEmpty
+            else {
+                result = nil
+                return
+            }
+            result = SkillsShSearchResult(
+                name: name,
+                installs: Self.installs(from: container),
+                repo: repo
+            )
+        }
+
+        private static func string(
+            _ container: KeyedDecodingContainer<CodingKeys>,
+            _ key: CodingKeys
+        ) -> String? {
+            guard
+                let raw = ((try? container.decodeIfPresent(String.self, forKey: key)) ?? nil)?
+                    .trimmingCharacters(in: .whitespacesAndNewlines),
+                !raw.isEmpty
+            else { return nil }
+            return raw
+        }
+
+        private static func installs(from container: KeyedDecodingContainer<CodingKeys>) -> Int? {
+            if let value = ((try? container.decodeIfPresent(Int.self, forKey: .installs)) ?? nil) {
+                return value
+            }
+            if let value = ((try? container.decodeIfPresent(Double.self, forKey: .installs)) ?? nil),
+               value.isFinite {
+                return Int(value)
+            }
+            return Self.string(container, .installs).flatMap(Int.init)
+        }
+    }
+}

--- a/Sources/VibeBarCore/Skills/SkillsService+Repositories.swift
+++ b/Sources/VibeBarCore/Skills/SkillsService+Repositories.swift
@@ -1,0 +1,425 @@
+import Foundation
+
+/// What an update check found for one installed, repository-backed skill.
+public struct SkillUpdateState: Sendable, Hashable, Identifiable {
+    public let id: SkillID
+    public let name: String
+    public let localHash: String?
+    public let remoteHash: String?
+    public let updateAvailable: Bool
+
+    public init(id: SkillID, name: String, localHash: String?, remoteHash: String?, updateAvailable: Bool) {
+        self.id = id
+        self.name = name
+        self.localHash = localHash
+        self.remoteHash = remoteHash
+        self.updateAvailable = updateAvailable
+    }
+}
+
+/// The repository-facing half of `SkillsService`: browse, install, check, and
+/// update.
+///
+/// The ordering rule from the core actor holds throughout — **filesystem
+/// first, store second**. A skill is copied into the SSOT and materialized into
+/// every requested app *before* `skills.json` learns it exists, so a failed
+/// install leaves a registry that still describes the disk.
+///
+/// Failure isolation is per repository. Discovery over four repositories where
+/// one has been deleted returns the skills from the other three and logs the
+/// miss; it is a browser, not a transaction.
+extension SkillsService {
+    // MARK: - Configured repositories
+
+    public func discoverRepos() async -> [String] {
+        await store.discoverRepos()
+    }
+
+    public func discoverRepoRefs() async -> [SkillRepoRef] {
+        await store.discoverRepoRefs()
+    }
+
+    public func setDiscoverRepos(_ repos: [String]) async throws {
+        try await store.setDiscoverRepos(repos)
+    }
+
+    @discardableResult
+    public func addDiscoverRepo(_ raw: String) async throws -> Bool {
+        try await store.addDiscoverRepo(raw)
+    }
+
+    @discardableResult
+    public func removeDiscoverRepo(_ raw: String) async throws -> Bool {
+        try await store.removeDiscoverRepo(raw)
+    }
+
+    // MARK: - Discovery
+
+    /// Downloads every configured repository and lists the skills in them.
+    public func discoverSkills() async -> [DiscoveredSkill] {
+        await discoverSkills(from: await store.discoverRepoRefs())
+    }
+
+    /// Downloads `repos` in parallel and lists the skills in them.
+    ///
+    /// The results point into a staging directory this actor owns; it survives
+    /// until the next discovery pass or `clearDiscoveryStaging()`, which is
+    /// what makes `install(_:enableFor:)` able to copy from them later.
+    public func discoverSkills(from repos: [SkillRepoRef]) async -> [DiscoveredSkill] {
+        guard !repos.isEmpty else { return [] }
+        clearDiscoveryStaging()
+        let staging = Self.temporaryDirectory(prefix: "discover")
+        do {
+            try FileManager.default.createDirectory(at: staging, withIntermediateDirectories: true)
+        } catch {
+            SafeLog.warn("Skills discovery: no staging directory")
+            return []
+        }
+        discoveryStaging = staging
+
+        let fetcher = self.fetcher
+        let discovered = await withTaskGroup(of: [DiscoveredSkill].self) { group in
+            for (index, ref) in repos.enumerated() {
+                let directory = staging.appendingPathComponent("repo-\(index)", isDirectory: true)
+                group.addTask {
+                    do {
+                        let (root, branch) = try await fetcher.downloadRepo(ref, into: directory)
+                        return try fetcher.scanSkills(inRepoRoot: root, ref: ref, resolvedBranch: branch)
+                    } catch {
+                        SafeLog.warn(
+                            "Skills discovery skipped \(ref.slug): \(SafeLog.sanitize(error.localizedDescription))"
+                        )
+                        return []
+                    }
+                }
+            }
+            var all: [DiscoveredSkill] = []
+            for await batch in group { all.append(contentsOf: batch) }
+            return all
+        }
+
+        var seen = Set<SkillID>()
+        return discovered
+            .filter { seen.insert($0.id).inserted }
+            .sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+    }
+
+    /// Drops the extracted repositories the last discovery pass left behind.
+    /// Any `DiscoveredSkill` from that pass becomes uninstallable afterwards.
+    public func clearDiscoveryStaging() {
+        guard let staging = discoveryStaging else { return }
+        discoveryStaging = nil
+        try? FileManager.default.removeItem(at: staging)
+    }
+
+    // MARK: - Install
+
+    /// Installs a discovered skill into the SSOT and enables it for `apps`.
+    ///
+    /// Re-installing the same id is an enable, not a conflict: the SSOT copy is
+    /// left alone (`update(_:)` is the way to refresh content) and only the
+    /// requested apps are materialized. A *different* skill already holding the
+    /// directory name is a `directoryConflict` — the directory name is part of
+    /// every skill's identity and cannot be shared.
+    @discardableResult
+    public func install(
+        _ discovered: DiscoveredSkill,
+        enableFor apps: [SkillAppTarget],
+        method: SkillSyncMethod = .auto
+    ) async throws -> Skill {
+        try SkillPathValidator.validate(directoryName: discovered.directory)
+
+        if let existing = await store.skill(directory: discovered.directory) {
+            guard existing.id == discovered.id else {
+                throw SkillError.directoryConflict(discovered.directory)
+            }
+            var skill = existing
+            for app in apps {
+                skill.apps[app] = try engine.materialize(
+                    skillDirectoryName: skill.directory,
+                    into: app,
+                    method: method,
+                    recorded: skill.apps[app]
+                )
+            }
+            try await store.upsert(skill)
+            return skill
+        }
+
+        guard SkillFileSystem.kind(of: discovered.sourceRoot) == .directory else {
+            throw SkillError.sourceNotADirectory(discovered.directory)
+        }
+        guard SkillTreeScanner.isSkillDirectory(discovered.sourceRoot) else {
+            throw SkillError.missingSkillMD(discovered.directory)
+        }
+        try copyIntoSSOT(from: discovered.sourceRoot, directoryName: discovered.directory)
+
+        let installed = ssotDirectory(for: discovered.directory)
+        var skill = Skill(
+            id: discovered.id,
+            name: discovered.name,
+            description: discovered.description,
+            directory: discovered.directory,
+            repoBranch: discovered.branch,
+            installedAt: Date(),
+            contentHash: try SkillDirectoryHasher.hash(directory: installed)
+        )
+        for app in apps {
+            skill.apps[app] = try engine.materialize(
+                skillDirectoryName: skill.directory,
+                into: app,
+                method: method
+            )
+        }
+        try await store.upsert(skill)
+        return skill
+    }
+
+    /// Installs every skill found inside a local `.zip`, as `.local` skills.
+    ///
+    /// Best-effort by design: a zip holding five skills where two collide with
+    /// installed directories installs the other three. It throws only when the
+    /// archive itself is unusable or holds no skill at all — the caller can
+    /// compare the returned count against what it expected.
+    @discardableResult
+    public func installFromZip(
+        at zipURL: URL,
+        enableFor apps: [SkillAppTarget],
+        method: SkillSyncMethod = .auto
+    ) async throws -> [Skill] {
+        let staging = Self.temporaryDirectory(prefix: "zip")
+        defer { try? FileManager.default.removeItem(at: staging) }
+        try FileManager.default.createDirectory(at: staging, withIntermediateDirectories: true)
+        try SkillArchiveExtractor.extract(zipFileURL: zipURL, into: staging)
+
+        // Three archive shapes reach this line and the scanner handles all of
+        // them: a bare `SKILL.md` at the root (the zip *is* the skill, named
+        // after the file), a single skill folder, and a folder of skill
+        // folders. Nobody has to tell us which one the user picked.
+        let found = SkillTreeScanner.scan(root: staging)
+        guard !found.isEmpty else {
+            throw SkillError.missingSkillMD(zipURL.deletingPathExtension().lastPathComponent)
+        }
+
+        var installed: [Skill] = []
+        for entry in found {
+            let directory = entry.relativePath.isEmpty
+                ? zipURL.deletingPathExtension().lastPathComponent
+                : String(entry.relativePath.split(separator: "/").last ?? "")
+            guard SkillPathValidator.isValid(directory) else {
+                SafeLog.warn("Skills zip import skipped an entry with an unusable directory name")
+                continue
+            }
+            if await store.skill(directory: directory) != nil { continue }
+            do {
+                installed.append(
+                    try await installLocalDirectory(
+                        at: entry.url,
+                        directoryName: directory,
+                        enableFor: apps,
+                        method: method
+                    )
+                )
+            } catch {
+                SafeLog.warn("Skills zip import skipped a skill: \(SafeLog.sanitize(error.localizedDescription))")
+            }
+        }
+        return installed
+    }
+
+    // MARK: - Updates
+
+    /// Downloads every repository that has installed skills (once per
+    /// owner/repo/branch, however many skills came from it) and compares
+    /// directory hashes.
+    ///
+    /// A local hash missing from the registry — an adopted skill, or one
+    /// written by an older build — is computed here and written back, so the
+    /// next check has it.
+    public func checkForUpdates() async -> [SkillUpdateState] {
+        let installed = await store.all().filter { $0.id.isRepositoryBacked }
+        guard !installed.isEmpty else { return [] }
+
+        var groups: [String: (ref: SkillRepoRef, skills: [Skill])] = [:]
+        for skill in installed {
+            guard
+                case let .repo(owner, repo, _) = skill.id,
+                let ref = SkillRepoRef(owner: owner, repo: repo, branch: skill.repoBranch)
+            else { continue }
+            groups[ref.descriptor, default: (ref, [])].skills.append(skill)
+        }
+        guard !groups.isEmpty else { return [] }
+
+        let staging = Self.temporaryDirectory(prefix: "updates")
+        defer { try? FileManager.default.removeItem(at: staging) }
+        try? FileManager.default.createDirectory(at: staging, withIntermediateDirectories: true)
+
+        let fetcher = self.fetcher
+        let remoteHashes: [SkillID: String] = await withTaskGroup(
+            of: [SkillID: String].self
+        ) { group in
+            for (index, entry) in groups.values.enumerated() {
+                let directory = staging.appendingPathComponent("repo-\(index)", isDirectory: true)
+                let ref = entry.ref
+                let wanted = entry.skills.map(\.directory)
+                group.addTask {
+                    do {
+                        let (root, branch) = try await fetcher.downloadRepo(ref, into: directory)
+                        let discovered = try fetcher.scanSkills(
+                            inRepoRoot: root,
+                            ref: ref,
+                            resolvedBranch: branch
+                        )
+                        var hashes: [SkillID: String] = [:]
+                        for name in wanted {
+                            guard
+                                let match = Self.match(directory: name, in: discovered),
+                                let hash = try? SkillDirectoryHasher.hash(directory: match.sourceRoot)
+                            else { continue }
+                            hashes[.repo(owner: ref.owner, repo: ref.repo, directory: name)] = hash
+                        }
+                        return hashes
+                    } catch {
+                        SafeLog.warn(
+                            "Skills update check skipped \(ref.slug): \(SafeLog.sanitize(error.localizedDescription))"
+                        )
+                        return [:]
+                    }
+                }
+            }
+            var merged: [SkillID: String] = [:]
+            for await batch in group { merged.merge(batch) { current, _ in current } }
+            return merged
+        }
+
+        var states: [SkillUpdateState] = []
+        for skill in installed {
+            var localHash = skill.contentHash
+            if localHash == nil {
+                localHash = try? SkillDirectoryHasher.hash(directory: ssotDirectory(for: skill.directory))
+                if let localHash {
+                    var backfilled = skill
+                    backfilled.contentHash = localHash
+                    try? await store.upsert(backfilled)
+                }
+            }
+            let remoteHash = remoteHashes[skill.id]
+            states.append(
+                SkillUpdateState(
+                    id: skill.id,
+                    name: skill.name,
+                    localHash: localHash,
+                    remoteHash: remoteHash,
+                    updateAvailable: remoteHash != nil && localHash != nil && remoteHash != localHash
+                )
+            )
+        }
+        return states.sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+    }
+
+    /// Re-downloads a repository-backed skill and replaces its SSOT directory.
+    ///
+    /// A backup is taken first — same contract as uninstall — because the
+    /// replacement is destructive to anything the user edited in place. Apps
+    /// that had the skill enabled are re-materialized with the method they were
+    /// already using, so an app holding a managed *copy* sees the new content
+    /// rather than silently keeping the old one.
+    @discardableResult
+    public func update(_ id: SkillID) async throws -> Skill {
+        guard let existing = await store.skill(with: id) else { throw SkillError.notInstalled(id) }
+        guard
+            case let .repo(owner, repo, _) = id,
+            let ref = SkillRepoRef(owner: owner, repo: repo, branch: existing.repoBranch)
+        else { throw SkillError.notRepositoryBacked(id) }
+
+        let staging = Self.temporaryDirectory(prefix: "update")
+        defer { try? FileManager.default.removeItem(at: staging) }
+        try FileManager.default.createDirectory(at: staging, withIntermediateDirectories: true)
+
+        let (root, branch) = try await fetcher.downloadRepo(ref, into: staging)
+        let discovered = try fetcher.scanSkills(inRepoRoot: root, ref: ref, resolvedBranch: branch)
+        guard let match = Self.match(directory: existing.directory, in: discovered) else {
+            throw SkillError.updateSourceMissing(existing.directory)
+        }
+        guard SkillTreeScanner.isSkillDirectory(match.sourceRoot) else {
+            throw SkillError.missingSkillMD(existing.directory)
+        }
+
+        try backups.createBackup(of: existing.directory, skill: existing)
+
+        let destination = ssotDirectory(for: existing.directory)
+        guard SkillAppCatalog.isWriteAllowed(destination, homeDirectory: homeDirectory) else {
+            throw SkillError.writeOutsideAllowedRoots(destination.path)
+        }
+        try SkillFileSystem.replaceDirectory(at: destination, withCopyOf: match.sourceRoot)
+
+        var skill = existing
+        skill.name = match.name
+        skill.description = match.description
+        skill.repoBranch = branch
+        skill.contentHash = try SkillDirectoryHasher.hash(directory: destination)
+        skill.updatedAt = Date()
+        for (app, materialization) in existing.apps {
+            skill.apps[app] = try engine.materialize(
+                skillDirectoryName: skill.directory,
+                into: app,
+                method: materialization.method,
+                recorded: materialization
+            )
+        }
+        try await store.upsert(skill)
+        return skill
+    }
+
+    // MARK: - Internals
+
+    /// Installs one already-extracted skill directory as a `.local` skill and
+    /// enables the requested apps. Filesystem first, store second.
+    private func installLocalDirectory(
+        at source: URL,
+        directoryName: String,
+        enableFor apps: [SkillAppTarget],
+        method: SkillSyncMethod
+    ) async throws -> Skill {
+        try SkillPathValidator.validate(directoryName: directoryName)
+        guard SkillTreeScanner.isSkillDirectory(source) else {
+            throw SkillError.missingSkillMD(directoryName)
+        }
+        try copyIntoSSOT(from: source, directoryName: directoryName)
+
+        let installed = ssotDirectory(for: directoryName)
+        let frontmatter = SkillFrontmatterParser.parse(
+            contentsOf: installed.appendingPathComponent("SKILL.md")
+        )
+        var skill = Skill(
+            id: .local(directory: directoryName),
+            name: frontmatter.name ?? directoryName,
+            description: frontmatter.description,
+            directory: directoryName,
+            installedAt: Date(),
+            contentHash: try SkillDirectoryHasher.hash(directory: installed)
+        )
+        for app in apps {
+            skill.apps[app] = try engine.materialize(
+                skillDirectoryName: directoryName,
+                into: app,
+                method: method
+            )
+        }
+        try await store.upsert(skill)
+        return skill
+    }
+
+    /// Repository layouts are not case-consistent (`PDF/` vs `pdf/`), and the
+    /// SSOT lives on a case-insensitive filesystem, so matching an installed
+    /// directory to a discovered one is case-insensitive too.
+    static func match(directory: String, in discovered: [DiscoveredSkill]) -> DiscoveredSkill? {
+        discovered.first { $0.directory == directory }
+            ?? discovered.first { $0.directory.caseInsensitiveCompare(directory) == .orderedSame }
+    }
+
+    static func temporaryDirectory(prefix: String) -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("VibeBarSkills-\(prefix)-\(UUID().uuidString)", isDirectory: true)
+    }
+}

--- a/Sources/VibeBarCore/Skills/SkillsService.swift
+++ b/Sources/VibeBarCore/Skills/SkillsService.swift
@@ -1,0 +1,247 @@
+import Foundation
+
+/// Orchestrates the registry, the sync engine, and backups.
+///
+/// The ordering rule every mutating method follows: **filesystem first, store
+/// second**. `skills.json` is a description of what is on disk, so a failed
+/// materialize must leave the registry exactly as it was rather than claiming
+/// a state the filesystem never reached. The reverse order would make the
+/// enable bits lie after the first permission error.
+///
+/// Update checks against GitHub land in the networking layer on top of this
+/// actor: `Skill.id` carries the repository slug and `Skill.repoBranch` the
+/// branch, and `SkillsStore.upsert` is the write path a refreshed record goes
+/// through. Nothing here reaches the network.
+public actor SkillsService {
+    public struct UninstallResult: Sendable {
+        public let backupURL: URL
+        /// Per app: whether the app-side entry was actually removed. `false`
+        /// means something the user could have authored was left in place.
+        public let removedByApp: [SkillAppTarget: Bool]
+    }
+
+    private let homeDirectory: String
+    private let store: SkillsStore
+    private let engine: SkillSyncEngine
+    private let backups: SkillBackupManager
+
+    public init(homeDirectory: String = RealHomeDirectory.path) {
+        self.homeDirectory = homeDirectory
+        self.store = SkillsStore(homeDirectory: homeDirectory)
+        self.engine = SkillSyncEngine(homeDirectory: homeDirectory)
+        self.backups = SkillBackupManager(homeDirectory: homeDirectory)
+    }
+
+    public func installedSkills() async -> [Skill] {
+        await store.all()
+    }
+
+    public func skill(with id: SkillID) async -> Skill? {
+        await store.skill(with: id)
+    }
+
+    /// Enables or disables `id` for one app. Returns whether the filesystem
+    /// changed: disabling reports `false` when the app-side entry was left
+    /// alone (a foreign directory, or a copy the user has edited), while the
+    /// enable bit still clears — the user asked Vibe Bar to stop managing it.
+    @discardableResult
+    public func setEnabled(
+        _ id: SkillID,
+        app: SkillAppTarget,
+        enabled: Bool,
+        method: SkillSyncMethod = .auto
+    ) async throws -> Bool {
+        guard var skill = await store.skill(with: id) else { throw SkillError.notInstalled(id) }
+        if enabled {
+            let materialization = try engine.materialize(
+                skillDirectoryName: skill.directory,
+                into: app,
+                method: method,
+                recorded: skill.apps[app]
+            )
+            skill.apps[app] = materialization
+            try await store.upsert(skill)
+            return true
+        }
+        let removed = try engine.unmaterialize(
+            skillDirectoryName: skill.directory,
+            from: app,
+            recorded: skill.apps[app]
+        )
+        skill.apps[app] = nil
+        try await store.upsert(skill)
+        return removed
+    }
+
+    /// Backs the skill up, unmaterializes it from every app, deletes the SSOT
+    /// directory, and forgets it. The backup is taken first so a failure
+    /// anywhere later still leaves the content recoverable.
+    @discardableResult
+    public func uninstall(_ id: SkillID) async throws -> UninstallResult {
+        guard let skill = await store.skill(with: id) else { throw SkillError.notInstalled(id) }
+        let backupURL = try backups.createBackup(of: skill.directory, skill: skill)
+        var removedByApp: [SkillAppTarget: Bool] = [:]
+        for app in SkillAppTarget.allCases {
+            removedByApp[app] = try engine.unmaterialize(
+                skillDirectoryName: skill.directory,
+                from: app,
+                recorded: skill.apps[app]
+            )
+        }
+        try removeFromSSOT(skill.directory)
+        try await store.remove(id: id)
+        return UninstallResult(backupURL: backupURL, removedByApp: removedByApp)
+    }
+
+    public nonisolated func scanForImport() -> SkillImportReport {
+        SkillImportScanner.scan(homeDirectory: homeDirectory)
+    }
+
+    /// Records the skills an import scan recognized. Only materializations for
+    /// `apps` are taken from the report; anything already recorded for another
+    /// app is preserved, so a partial import never drops known state.
+    @discardableResult
+    public func importAdopted(
+        _ report: SkillImportReport,
+        apps: [SkillAppTarget] = SkillAppTarget.allCases
+    ) async throws -> [Skill] {
+        let allowed = Set(apps)
+        var imported: [Skill] = []
+        for scanned in report.adopted {
+            var skill = scanned
+            skill.apps = skill.apps.filter { allowed.contains($0.key) }
+            if let existing = await store.skill(with: skill.id) {
+                var merged = existing
+                merged.name = skill.name
+                merged.description = skill.description
+                merged.directory = skill.directory
+                merged.repoBranch = skill.repoBranch
+                merged.contentHash = skill.contentHash
+                merged.updatedAt = skill.updatedAt
+                for (app, materialization) in skill.apps { merged.apps[app] = materialization }
+                skill = merged
+            }
+            try await store.upsert(skill)
+            imported.append(skill)
+        }
+        return imported
+    }
+
+    /// Brings a foreign app-side skill directory under management: copies it
+    /// into the SSOT, then materializes it into the chosen apps (including,
+    /// normally, the one it came from — which replaces the original directory
+    /// with a link or a managed copy).
+    @discardableResult
+    public func adoptUnmanaged(
+        directoryName: String,
+        from app: SkillAppTarget,
+        apps: [SkillAppTarget],
+        method: SkillSyncMethod = .auto
+    ) async throws -> Skill {
+        try SkillPathValidator.validate(directoryName: directoryName)
+        let source = SkillAppCatalog.skillsDirectory(for: app, homeDirectory: homeDirectory)
+            .appendingPathComponent(directoryName, isDirectory: true)
+        guard SkillFileSystem.kind(of: source) == .directory else {
+            throw SkillError.sourceNotADirectory(directoryName)
+        }
+        guard FileManager.default.fileExists(atPath: source.appendingPathComponent("SKILL.md").path) else {
+            throw SkillError.missingSkillMD(directoryName)
+        }
+        try copyIntoSSOT(from: source, directoryName: directoryName)
+
+        var skill = try makeLocalSkill(directoryName: directoryName)
+        for target in apps {
+            skill.apps[target] = try engine.materialize(
+                skillDirectoryName: directoryName,
+                into: target,
+                method: method
+            )
+        }
+        try await store.upsert(skill)
+        return skill
+    }
+
+    /// Installs a skill from an arbitrary directory on disk. No app is enabled
+    /// — the caller decides that separately.
+    @discardableResult
+    public func installLocal(from sourceDir: URL, name: String) async throws -> Skill {
+        try SkillPathValidator.validate(directoryName: name)
+        guard SkillFileSystem.kind(of: sourceDir) == .directory else {
+            throw SkillError.sourceNotADirectory(sourceDir.lastPathComponent)
+        }
+        guard FileManager.default.fileExists(atPath: sourceDir.appendingPathComponent("SKILL.md").path) else {
+            throw SkillError.missingSkillMD(name)
+        }
+        try copyIntoSSOT(from: sourceDir, directoryName: name)
+        let skill = try makeLocalSkill(directoryName: name)
+        try await store.upsert(skill)
+        return skill
+    }
+
+    // MARK: - Backups
+
+    public nonisolated func listBackups() -> [SkillBackupManager.Backup] {
+        backups.listBackups()
+    }
+
+    @discardableResult
+    public func restoreBackup(_ backupURL: URL) async throws -> Skill {
+        let skill = try backups.restore(backupURL: backupURL)
+        try await store.upsert(skill)
+        return skill
+    }
+
+    public nonisolated func deleteBackup(_ backupURL: URL) throws {
+        try backups.deleteBackup(backupURL)
+    }
+
+    // MARK: - Internals
+
+    private var homeURL: URL { URL(fileURLWithPath: homeDirectory, isDirectory: true) }
+
+    private func copyIntoSSOT(from source: URL, directoryName: String) throws {
+        let ssot = SkillAppCatalog.ssotDirectory(homeDirectory: homeDirectory)
+        let destination = ssot.appendingPathComponent(directoryName, isDirectory: true)
+        guard SkillAppCatalog.isWriteAllowed(destination, homeDirectory: homeDirectory) else {
+            throw SkillError.writeOutsideAllowedRoots(destination.path)
+        }
+        guard SkillFileSystem.kind(of: destination) == .missing else {
+            throw SkillError.directoryConflict(directoryName)
+        }
+        try SkillFileSystem.ensureDirectory(ssot, stopAt: homeURL)
+        try SkillFileSystem.replaceDirectory(at: destination, withCopyOf: source)
+    }
+
+    private func removeFromSSOT(_ directoryName: String) throws {
+        try SkillPathValidator.validate(directoryName: directoryName)
+        let ssot = SkillAppCatalog.ssotDirectory(homeDirectory: homeDirectory)
+        let directory = ssot.appendingPathComponent(directoryName, isDirectory: true)
+        guard
+            SkillAppCatalog.isPath(directory, under: ssot),
+            SkillAppCatalog.isWriteAllowed(directory, homeDirectory: homeDirectory)
+        else {
+            throw SkillError.writeOutsideAllowedRoots(directory.path)
+        }
+        switch SkillFileSystem.kind(of: directory) {
+        case .missing: return
+        case .directory: try FileManager.default.removeItem(at: directory)
+        default: throw SkillError.sourceNotADirectory(directoryName)
+        }
+    }
+
+    private func makeLocalSkill(directoryName: String) throws -> Skill {
+        let directory = SkillAppCatalog.ssotDirectory(homeDirectory: homeDirectory)
+            .appendingPathComponent(directoryName, isDirectory: true)
+        let frontmatter = SkillFrontmatterParser.parse(
+            contentsOf: directory.appendingPathComponent("SKILL.md")
+        )
+        return Skill(
+            id: .local(directory: directoryName),
+            name: frontmatter.name ?? directoryName,
+            description: frontmatter.description,
+            directory: directoryName,
+            installedAt: Date(),
+            contentHash: try SkillDirectoryHasher.hash(directory: directory)
+        )
+    }
+}

--- a/Sources/VibeBarCore/Skills/SkillsService.swift
+++ b/Sources/VibeBarCore/Skills/SkillsService.swift
@@ -8,10 +8,10 @@ import Foundation
 /// a state the filesystem never reached. The reverse order would make the
 /// enable bits lie after the first permission error.
 ///
-/// Update checks against GitHub land in the networking layer on top of this
-/// actor: `Skill.id` carries the repository slug and `Skill.repoBranch` the
-/// branch, and `SkillsStore.upsert` is the write path a refreshed record goes
-/// through. Nothing here reaches the network.
+/// Everything that reaches the network does so through `SkillRepoFetching`,
+/// which is injected: `Skill.id` carries the repository slug and
+/// `Skill.repoBranch` the branch, so discovery, install, update checks, and
+/// updates are all expressible against that one seam — and testable without it.
 public actor SkillsService {
     public struct UninstallResult: Sendable {
         public let backupURL: URL
@@ -20,16 +20,32 @@ public actor SkillsService {
         public let removedByApp: [SkillAppTarget: Bool]
     }
 
-    private let homeDirectory: String
-    private let store: SkillsStore
-    private let engine: SkillSyncEngine
-    private let backups: SkillBackupManager
+    // Internal rather than private: the repository-facing half of this actor
+    // lives in `SkillsService+Repositories.swift`.
+    let homeDirectory: String
+    let store: SkillsStore
+    let engine: SkillSyncEngine
+    let backups: SkillBackupManager
+    let fetcher: SkillRepoFetching
+    /// Where the trees behind the current `[DiscoveredSkill]` live. Discovery
+    /// results reference files on disk, so the extraction has to outlive the
+    /// call that produced it; it is replaced on the next discovery pass and can
+    /// be dropped explicitly once the user closes the browser.
+    var discoveryStaging: URL?
 
-    public init(homeDirectory: String = RealHomeDirectory.path) {
+    public init(
+        homeDirectory: String = RealHomeDirectory.path,
+        fetcher: SkillRepoFetching = SkillRepoFetcher()
+    ) {
         self.homeDirectory = homeDirectory
         self.store = SkillsStore(homeDirectory: homeDirectory)
         self.engine = SkillSyncEngine(homeDirectory: homeDirectory)
         self.backups = SkillBackupManager(homeDirectory: homeDirectory)
+        self.fetcher = fetcher
+    }
+
+    deinit {
+        if let discoveryStaging { try? FileManager.default.removeItem(at: discoveryStaging) }
     }
 
     public func installedSkills() async -> [Skill] {
@@ -197,9 +213,14 @@ public actor SkillsService {
 
     // MARK: - Internals
 
-    private var homeURL: URL { URL(fileURLWithPath: homeDirectory, isDirectory: true) }
+    var homeURL: URL { URL(fileURLWithPath: homeDirectory, isDirectory: true) }
 
-    private func copyIntoSSOT(from source: URL, directoryName: String) throws {
+    func ssotDirectory(for directoryName: String) -> URL {
+        SkillAppCatalog.ssotDirectory(homeDirectory: homeDirectory)
+            .appendingPathComponent(directoryName, isDirectory: true)
+    }
+
+    func copyIntoSSOT(from source: URL, directoryName: String) throws {
         let ssot = SkillAppCatalog.ssotDirectory(homeDirectory: homeDirectory)
         let destination = ssot.appendingPathComponent(directoryName, isDirectory: true)
         guard SkillAppCatalog.isWriteAllowed(destination, homeDirectory: homeDirectory) else {

--- a/Sources/VibeBarCore/Skills/SkillsStore.swift
+++ b/Sources/VibeBarCore/Skills/SkillsStore.swift
@@ -14,17 +14,34 @@ import Foundation
 public actor SkillsStore {
     public static let currentSchemaVersion = 1
 
+    /// Repositories the discovery browser reads by default. These are *state*,
+    /// not preferences — they live here rather than in `AppSettings` because
+    /// the user edits the list from the skills UI and it only ever means
+    /// "where to look for skills next".
+    public static let defaultDiscoverRepos = [
+        "anthropics/skills",
+        "ComposioHQ/awesome-claude-skills@master",
+        "cexll/myclaude@master",
+        "JimLiu/baoyu-skills"
+    ]
+
     struct Storage: Codable, Sendable {
         var schemaVersion: Int
         var skills: [Skill]
+        var discoverRepos: [String]
 
-        init(schemaVersion: Int = SkillsStore.currentSchemaVersion, skills: [Skill]) {
+        init(
+            schemaVersion: Int = SkillsStore.currentSchemaVersion,
+            skills: [Skill],
+            discoverRepos: [String] = SkillsStore.defaultDiscoverRepos
+        ) {
             self.schemaVersion = schemaVersion
             self.skills = skills
+            self.discoverRepos = discoverRepos
         }
 
         private enum CodingKeys: String, CodingKey {
-            case schemaVersion, skills
+            case schemaVersion, skills, discoverRepos
         }
 
         private struct LossySkill: Decodable {
@@ -40,12 +57,16 @@ public actor SkillsStore {
             self.schemaVersion = try c.decodeIfPresent(Int.self, forKey: .schemaVersion) ?? 1
             let entries = try c.decodeIfPresent([LossySkill].self, forKey: .skills) ?? []
             self.skills = entries.compactMap(\.skill)
+            // Absent means "never configured" and seeds the defaults; an empty
+            // array means the user cleared the list and is left empty.
+            self.discoverRepos = try c.decodeIfPresent([String].self, forKey: .discoverRepos)
+                ?? SkillsStore.defaultDiscoverRepos
         }
     }
 
     private let fileURL: URL
     private let baseDirectory: URL
-    private var cache: [Skill]?
+    private var cache: Storage?
 
     public init(homeDirectory: String = RealHomeDirectory.path) {
         self.fileURL = VibeBarLocalStore.skillsStoreURL(homeDirectory: homeDirectory)
@@ -53,10 +74,57 @@ public actor SkillsStore {
     }
 
     public func all() -> [Skill] {
-        if let cache { return cache }
-        let loaded = Self.load(from: fileURL)
-        cache = loaded
-        return loaded
+        loaded().skills
+    }
+
+    // MARK: - Discovery repositories
+
+    /// The configured list, as typed. Invalid entries are filtered by
+    /// `discoverRepoRefs()` rather than dropped from the file.
+    public func discoverRepos() -> [String] {
+        loaded().discoverRepos
+    }
+
+    public func discoverRepoRefs() -> [SkillRepoRef] {
+        var seen = Set<String>()
+        return discoverRepos().compactMap(SkillRepoRef.init).filter {
+            seen.insert($0.descriptor.lowercased()).inserted
+        }
+    }
+
+    /// Replaces the list, keeping only well-formed references in canonical
+    /// `owner/repo[@branch]` form and dropping case-insensitive duplicates.
+    public func setDiscoverRepos(_ repos: [String]) throws {
+        var seen = Set<String>()
+        let normalized = repos.compactMap(SkillRepoRef.init)
+            .map(\.descriptor)
+            .filter { seen.insert($0.lowercased()).inserted }
+        var storage = loaded()
+        storage.discoverRepos = normalized
+        try save(storage)
+    }
+
+    /// Returns `false` when `raw` is malformed or already listed.
+    @discardableResult
+    public func addDiscoverRepo(_ raw: String) throws -> Bool {
+        guard let ref = SkillRepoRef(raw) else { return false }
+        var storage = loaded()
+        let existing = Set(storage.discoverRepos.map { $0.lowercased() })
+        guard !existing.contains(ref.descriptor.lowercased()) else { return false }
+        storage.discoverRepos.append(ref.descriptor)
+        try save(storage)
+        return true
+    }
+
+    @discardableResult
+    public func removeDiscoverRepo(_ raw: String) throws -> Bool {
+        let needle = (SkillRepoRef(raw)?.descriptor ?? raw).lowercased()
+        var storage = loaded()
+        let remaining = storage.discoverRepos.filter { $0.lowercased() != needle }
+        guard remaining.count != storage.discoverRepos.count else { return false }
+        storage.discoverRepos = remaining
+        try save(storage)
+        return true
     }
 
     public func skill(with id: SkillID) -> Skill? {
@@ -68,26 +136,28 @@ public actor SkillsStore {
     }
 
     public func upsert(_ skill: Skill) throws {
-        var skills = all()
-        if let index = skills.firstIndex(where: { $0.id == skill.id }) {
-            skills[index] = skill
+        var storage = loaded()
+        if let index = storage.skills.firstIndex(where: { $0.id == skill.id }) {
+            storage.skills[index] = skill
         } else {
-            skills.append(skill)
+            storage.skills.append(skill)
         }
-        try save(skills)
+        try save(storage)
     }
 
     @discardableResult
     public func remove(id: SkillID) throws -> Bool {
-        var skills = all()
-        guard let index = skills.firstIndex(where: { $0.id == id }) else { return false }
-        skills.remove(at: index)
-        try save(skills)
+        var storage = loaded()
+        guard let index = storage.skills.firstIndex(where: { $0.id == id }) else { return false }
+        storage.skills.remove(at: index)
+        try save(storage)
         return true
     }
 
     public func replaceAll(_ skills: [Skill]) throws {
-        try save(skills)
+        var storage = loaded()
+        storage.skills = skills
+        try save(storage)
     }
 
     /// Drops the in-memory copy so the next read re-reads the file. Only
@@ -96,18 +166,28 @@ public actor SkillsStore {
         cache = nil
     }
 
-    private func save(_ skills: [Skill]) throws {
-        let sorted = skills.sorted { $0.directory.utf8.lexicographicallyPrecedes($1.directory.utf8) }
-        let storage = Storage(skills: sorted)
-        try VibeBarLocalStore.writeJSON(storage, to: fileURL, base: baseDirectory)
-        cache = sorted
+    private func loaded() -> Storage {
+        if let cache { return cache }
+        let storage = Self.load(from: fileURL)
+        cache = storage
+        return storage
     }
 
-    private static func load(from url: URL) -> [Skill] {
+    private func save(_ storage: Storage) throws {
+        var next = storage
+        next.schemaVersion = Self.currentSchemaVersion
+        next.skills.sort { $0.directory.utf8.lexicographicallyPrecedes($1.directory.utf8) }
+        try VibeBarLocalStore.writeJSON(next, to: fileURL, base: baseDirectory)
+        cache = next
+    }
+
+    private static func load(from url: URL) -> Storage {
         guard
             let data = try? Data(contentsOf: url),
             let storage = try? JSONDecoder().decode(Storage.self, from: data)
-        else { return [] }
-        return storage.skills
+        else {
+            return Storage(skills: [])
+        }
+        return storage
     }
 }

--- a/Sources/VibeBarCore/Skills/SkillsStore.swift
+++ b/Sources/VibeBarCore/Skills/SkillsStore.swift
@@ -1,0 +1,113 @@
+import Foundation
+
+/// Registry of installed skills at `~/.vibebar/skills.json`.
+///
+/// This file records *what Vibe Bar knows*, never the skill payloads — those
+/// live in the SSOT. It is therefore disposable: deleting it loses the enable
+/// bits and provenance, and the import scanner can rebuild both from the
+/// filesystem.
+///
+/// Loading is deliberately forgiving. A skill entry that fails to decode is
+/// dropped rather than taking the whole registry down with it, and app keys
+/// this build does not know (a newer Vibe Bar learned another agent CLI) are
+/// dropped per entry in `Skill`'s decoder.
+public actor SkillsStore {
+    public static let currentSchemaVersion = 1
+
+    struct Storage: Codable, Sendable {
+        var schemaVersion: Int
+        var skills: [Skill]
+
+        init(schemaVersion: Int = SkillsStore.currentSchemaVersion, skills: [Skill]) {
+            self.schemaVersion = schemaVersion
+            self.skills = skills
+        }
+
+        private enum CodingKeys: String, CodingKey {
+            case schemaVersion, skills
+        }
+
+        private struct LossySkill: Decodable {
+            let skill: Skill?
+
+            init(from decoder: Decoder) throws {
+                skill = try? Skill(from: decoder)
+            }
+        }
+
+        init(from decoder: Decoder) throws {
+            let c = try decoder.container(keyedBy: CodingKeys.self)
+            self.schemaVersion = try c.decodeIfPresent(Int.self, forKey: .schemaVersion) ?? 1
+            let entries = try c.decodeIfPresent([LossySkill].self, forKey: .skills) ?? []
+            self.skills = entries.compactMap(\.skill)
+        }
+    }
+
+    private let fileURL: URL
+    private let baseDirectory: URL
+    private var cache: [Skill]?
+
+    public init(homeDirectory: String = RealHomeDirectory.path) {
+        self.fileURL = VibeBarLocalStore.skillsStoreURL(homeDirectory: homeDirectory)
+        self.baseDirectory = VibeBarLocalStore.baseDirectory(homeDirectory: homeDirectory)
+    }
+
+    public func all() -> [Skill] {
+        if let cache { return cache }
+        let loaded = Self.load(from: fileURL)
+        cache = loaded
+        return loaded
+    }
+
+    public func skill(with id: SkillID) -> Skill? {
+        all().first { $0.id == id }
+    }
+
+    public func skill(directory: String) -> Skill? {
+        all().first { $0.directory == directory }
+    }
+
+    public func upsert(_ skill: Skill) throws {
+        var skills = all()
+        if let index = skills.firstIndex(where: { $0.id == skill.id }) {
+            skills[index] = skill
+        } else {
+            skills.append(skill)
+        }
+        try save(skills)
+    }
+
+    @discardableResult
+    public func remove(id: SkillID) throws -> Bool {
+        var skills = all()
+        guard let index = skills.firstIndex(where: { $0.id == id }) else { return false }
+        skills.remove(at: index)
+        try save(skills)
+        return true
+    }
+
+    public func replaceAll(_ skills: [Skill]) throws {
+        try save(skills)
+    }
+
+    /// Drops the in-memory copy so the next read re-reads the file. Only
+    /// needed when something outside this actor rewrote it.
+    public func invalidate() {
+        cache = nil
+    }
+
+    private func save(_ skills: [Skill]) throws {
+        let sorted = skills.sorted { $0.directory.utf8.lexicographicallyPrecedes($1.directory.utf8) }
+        let storage = Storage(skills: sorted)
+        try VibeBarLocalStore.writeJSON(storage, to: fileURL, base: baseDirectory)
+        cache = sorted
+    }
+
+    private static func load(from url: URL) -> [Skill] {
+        guard
+            let data = try? Data(contentsOf: url),
+            let storage = try? JSONDecoder().decode(Storage.self, from: data)
+        else { return [] }
+        return storage.skills
+    }
+}

--- a/Sources/VibeBarCore/Storage/VibeBarLocalStore.swift
+++ b/Sources/VibeBarCore/Storage/VibeBarLocalStore.swift
@@ -4,7 +4,13 @@ public enum VibeBarLocalStore {
     public static let directoryName = ".vibebar"
 
     public static var baseDirectory: URL {
-        RealHomeDirectory.url
+        baseDirectory(homeDirectory: RealHomeDirectory.path)
+    }
+
+    /// Explicit-home variant for stores that take a `homeDirectory:`
+    /// parameter (test isolation — see AGENTS.md § 6.4).
+    public static func baseDirectory(homeDirectory: String) -> URL {
+        URL(fileURLWithPath: homeDirectory, isDirectory: true)
             .appendingPathComponent(directoryName, isDirectory: true)
     }
 
@@ -120,14 +126,35 @@ public enum VibeBarLocalStore {
         baseDirectory.appendingPathComponent("session_index.sqlite3")
     }
 
+    /// Skills manager registry: which skills are installed in the SSOT
+    /// (`~/.agents/skills`) and how each one is materialized per agent CLI.
+    /// The skill payloads themselves live in the SSOT, not here.
+    public static func skillsStoreURL(homeDirectory: String = RealHomeDirectory.path) -> URL {
+        baseDirectory(homeDirectory: homeDirectory).appendingPathComponent("skills.json")
+    }
+
+    /// Pre-uninstall snapshots of skill directories, so removing a skill is
+    /// recoverable without going back to its origin repository.
+    public static func skillBackupsDirectoryURL(homeDirectory: String = RealHomeDirectory.path) -> URL {
+        baseDirectory(homeDirectory: homeDirectory)
+            .appendingPathComponent("skill_backups", isDirectory: true)
+    }
+
     public static func readData(from url: URL) throws -> Data {
         try Data(contentsOf: url)
     }
 
     public static func writeData(_ data: Data, to url: URL) throws {
-        try ensureBaseDirectory()
+        try writeData(data, to: url, base: baseDirectory)
+    }
+
+    /// Explicit-base variant for stores that take a `homeDirectory:`
+    /// parameter: same atomic write and 0600 mode, but it creates
+    /// `<home>/.vibebar` instead of the real-home one.
+    public static func writeData(_ data: Data, to url: URL, base: URL) throws {
+        try ensureDirectory(base)
         let parent = url.deletingLastPathComponent()
-        if parent.path != baseDirectory.path {
+        if parent.path != base.path {
             try ensureDirectory(parent)
         }
         try data.write(to: url, options: [.atomic])
@@ -155,10 +182,14 @@ public enum VibeBarLocalStore {
     }
 
     public static func writeJSON<T: Encodable>(_ value: T, to url: URL) throws {
+        try writeJSON(value, to: url, base: baseDirectory)
+    }
+
+    public static func writeJSON<T: Encodable>(_ value: T, to url: URL, base: URL) throws {
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
         let data = try encoder.encode(value)
-        try writeData(data, to: url)
+        try writeData(data, to: url, base: base)
     }
 
     public static func deleteFile(at url: URL) throws {

--- a/Sources/VibeBarCore/Utilities/BoundedDownloader.swift
+++ b/Sources/VibeBarCore/Utilities/BoundedDownloader.swift
@@ -1,0 +1,228 @@
+import Foundation
+
+/// HTTPS download to a file with a hard ceiling enforced *while* streaming.
+///
+/// `HTTPResponseLimit` covers the small JSON/HTML responses Vibe Bar reads into
+/// memory; this is its counterpart for the one thing that must land on disk —
+/// a GitHub repository zipball. The difference matters: `URLSession.data(for:)`
+/// buffers the whole body before anyone can look at its size, so a hostile or
+/// broken host can exhaust memory before the check runs. Here the byte count is
+/// tested on every delivered chunk and the task is cancelled the moment it goes
+/// over, with the partial file removed.
+///
+/// Three other rules are enforced for the same reason the skills feature exists
+/// at all — it fetches third-party content:
+/// 1. `https` only, and the origin host must be in `allowedHosts`;
+/// 2. redirects are re-checked against the same allowlist, so a 302 cannot walk
+///    the download off github.com (this is not hypothetical: the archive URL
+///    legitimately redirects to codeload.github.com, which is why the allowlist
+///    is a set rather than a single host);
+/// 3. a `Content-Length` that already exceeds the cap is refused before a
+///    single body byte is accepted.
+///
+/// The session is created per download from a caller-supplied configuration —
+/// ephemeral by default, so nothing is cached, and injectable so tests can
+/// stub `URLProtocol`.
+public struct BoundedDownloader: Sendable {
+    public typealias ConfigurationProvider = @Sendable () -> URLSessionConfiguration
+
+    public enum DownloadError: Error, Equatable, Sendable {
+        case insecureScheme(String)
+        case hostNotAllowed(String)
+        case redirectHostNotAllowed(String)
+        case notHTTP
+        case httpStatus(Int)
+        case tooLarge(limit: Int64)
+        case cannotCreateFile(String)
+    }
+
+    private let makeConfiguration: ConfigurationProvider
+
+    public init(configuration: @escaping ConfigurationProvider = { .ephemeral }) {
+        self.makeConfiguration = configuration
+    }
+
+    /// Streams `url` into `fileURL`, replacing whatever was there.
+    ///
+    /// Throws before touching the network on a non-https URL or a host outside
+    /// `allowedHosts`; throws mid-stream once more than `maxBytes` have
+    /// arrived. `fileURL` only exists when this returns normally.
+    public func download(
+        from url: URL,
+        to fileURL: URL,
+        maxBytes: Int64,
+        timeout: TimeInterval,
+        allowedHosts: Set<String>
+    ) async throws {
+        let hosts = Set(allowedHosts.map { $0.lowercased() })
+        try Self.validate(url: url, allowedHosts: hosts)
+
+        let fm = FileManager.default
+        try? fm.removeItem(at: fileURL)
+        try fm.createDirectory(
+            at: fileURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        guard fm.createFile(atPath: fileURL.path, contents: nil) else {
+            throw DownloadError.cannotCreateFile(fileURL.lastPathComponent)
+        }
+        let handle = try FileHandle(forWritingTo: fileURL)
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.timeoutInterval = timeout
+        request.setValue("VibeBar/skills", forHTTPHeaderField: "User-Agent")
+
+        let configuration = makeConfiguration()
+        configuration.timeoutIntervalForRequest = timeout
+        configuration.requestCachePolicy = .reloadIgnoringLocalCacheData
+        let queue = OperationQueue()
+        queue.maxConcurrentOperationCount = 1
+        let sink = Sink(handle: handle, maxBytes: maxBytes, allowedHosts: hosts)
+        let session = URLSession(configuration: configuration, delegate: sink, delegateQueue: queue)
+        defer { session.invalidateAndCancel() }
+
+        do {
+            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+                sink.onFinish = { continuation.resume(with: $0) }
+                session.dataTask(with: request).resume()
+            }
+        } catch {
+            try? handle.close()
+            try? fm.removeItem(at: fileURL)
+            SafeLog.net("BoundedDownloader failed for \(Self.safeDescription(of: url))")
+            throw error
+        }
+        try handle.close()
+    }
+
+    // MARK: - Internals
+
+    static func validate(url: URL, allowedHosts: Set<String>) throws {
+        guard url.scheme?.lowercased() == "https" else {
+            throw DownloadError.insecureScheme(url.scheme ?? "")
+        }
+        guard let host = url.host?.lowercased(), allowedHosts.contains(host) else {
+            throw DownloadError.hostNotAllowed(url.host ?? "")
+        }
+    }
+
+    /// Host plus path only — a download URL's query is never log material.
+    static func safeDescription(of url: URL) -> String {
+        "\(url.host ?? "?")\(url.path)"
+    }
+
+    /// Owns the byte budget for one download. Every callback lands on the
+    /// session's serial delegate queue, so the counters need no locking; the
+    /// one cross-thread hand-off (`onFinish`) is installed before the task is
+    /// resumed and read only from that queue.
+    private final class Sink: NSObject, URLSessionDataDelegate, @unchecked Sendable {
+        private let handle: FileHandle
+        private let maxBytes: Int64
+        private let allowedHosts: Set<String>
+        private var received: Int64 = 0
+        private var failure: Error?
+
+        var onFinish: ((Result<Void, Error>) -> Void)?
+
+        init(handle: FileHandle, maxBytes: Int64, allowedHosts: Set<String>) {
+            self.handle = handle
+            self.maxBytes = maxBytes
+            self.allowedHosts = allowedHosts
+        }
+
+        func urlSession(
+            _ session: URLSession,
+            dataTask: URLSessionDataTask,
+            didReceive response: URLResponse,
+            completionHandler: @escaping (URLSession.ResponseDisposition) -> Void
+        ) {
+            guard let http = response as? HTTPURLResponse else {
+                failure = DownloadError.notHTTP
+                completionHandler(.cancel)
+                return
+            }
+            guard (200..<300).contains(http.statusCode) else {
+                failure = DownloadError.httpStatus(http.statusCode)
+                completionHandler(.cancel)
+                return
+            }
+            if http.expectedContentLength > 0, http.expectedContentLength > maxBytes {
+                failure = DownloadError.tooLarge(limit: maxBytes)
+                completionHandler(.cancel)
+                return
+            }
+            completionHandler(.allow)
+        }
+
+        func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {
+            guard failure == nil else { return }
+            received += Int64(data.count)
+            if received > maxBytes {
+                failure = DownloadError.tooLarge(limit: maxBytes)
+                dataTask.cancel()
+                return
+            }
+            do {
+                try handle.write(contentsOf: data)
+            } catch {
+                failure = error
+                dataTask.cancel()
+            }
+        }
+
+        func urlSession(
+            _ session: URLSession,
+            task: URLSessionTask,
+            willPerformHTTPRedirection response: HTTPURLResponse,
+            newRequest request: URLRequest,
+            completionHandler: @escaping (URLRequest?) -> Void
+        ) {
+            guard
+                let url = request.url,
+                url.scheme?.lowercased() == "https",
+                let host = url.host?.lowercased(),
+                allowedHosts.contains(host)
+            else {
+                failure = DownloadError.redirectHostNotAllowed(request.url?.host ?? "")
+                completionHandler(nil)
+                task.cancel()
+                return
+            }
+            completionHandler(request)
+        }
+
+        func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
+            let finish = onFinish
+            onFinish = nil
+            if let failure {
+                finish?(.failure(failure))
+            } else if let error {
+                finish?(.failure(error))
+            } else {
+                finish?(.success(()))
+            }
+        }
+    }
+}
+
+extension BoundedDownloader.DownloadError: LocalizedError {
+    public var errorDescription: String? {
+        switch self {
+        case let .insecureScheme(scheme):
+            return "Refusing a non-HTTPS download (scheme \"\(scheme)\")."
+        case let .hostNotAllowed(host):
+            return "Downloads from \"\(host)\" are not allowed."
+        case let .redirectHostNotAllowed(host):
+            return "The download was redirected to \"\(host)\", which is not allowed."
+        case .notHTTP:
+            return "The server did not return an HTTP response."
+        case let .httpStatus(code):
+            return "The server returned HTTP \(code)."
+        case let .tooLarge(limit):
+            return "The download exceeded its \(limit)-byte limit."
+        case let .cannotCreateFile(name):
+            return "Could not create \"\(name)\"."
+        }
+    }
+}

--- a/Tests/VibeBarCoreTests/AppSettingsTests.swift
+++ b/Tests/VibeBarCoreTests/AppSettingsTests.swift
@@ -145,6 +145,34 @@ final class AppSettingsTests: XCTestCase {
         XCTAssertEqual(settings.displayMode, .used)
     }
 
+    func testSkillsSyncMethodDefaultsToAutoAndRoundTrips() throws {
+        // `.auto` links where it can and copies where it cannot, which is the
+        // only value that keeps every agent CLI reading one copy of a skill —
+        // so a settings file written before the Skills manager existed has to
+        // decode to it, and so does a raw value this build does not know.
+        let legacy = try JSONDecoder().decode(
+            AppSettings.self,
+            from: Data(#"{"displayMode":"remaining"}"#.utf8)
+        )
+        XCTAssertEqual(legacy.skillsSyncMethod, .auto)
+        XCTAssertEqual(AppSettings.default.skillsSyncMethod, .auto)
+
+        var settings = AppSettings.default
+        settings.skillsSyncMethod = .copy
+        let decoded = try JSONDecoder().decode(
+            AppSettings.self,
+            from: try JSONEncoder().encode(settings)
+        )
+        XCTAssertEqual(decoded.skillsSyncMethod, .copy)
+
+        let unknown = try JSONDecoder().decode(
+            AppSettings.self,
+            from: Data(#"{"displayMode":"used","skillsSyncMethod":"hardlink"}"#.utf8)
+        )
+        XCTAssertEqual(unknown.skillsSyncMethod, .auto)
+        XCTAssertEqual(unknown.displayMode, .used)
+    }
+
     func testOverviewQuotaHistoryHiddenCurvesDefaultToNoneAndRoundTrip() throws {
         // Stored as *hidden* ids, so a settings file written before the
         // Overview chart existed has to mean "show everything" — not "show

--- a/Tests/VibeBarCoreTests/SkillArchiveExtractorTests.swift
+++ b/Tests/VibeBarCoreTests/SkillArchiveExtractorTests.swift
@@ -1,0 +1,327 @@
+import XCTest
+@testable import VibeBarCore
+
+/// The archive reader is the only place Vibe Bar parses attacker-shaped bytes,
+/// so these tests are split evenly between "does it read a real zip correctly"
+/// (fixtures from `/usr/bin/zip`) and "does it refuse the classic zip attacks"
+/// (hand-built archives — see `SkillZipFixtures`).
+final class SkillArchiveExtractorTests: XCTestCase {
+    private var workspace: URL!
+
+    override func setUpWithError() throws {
+        workspace = FileManager.default.temporaryDirectory
+            .appendingPathComponent("VibeBarZip-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: workspace, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: workspace)
+    }
+
+    // MARK: - Real archives
+
+    func testExtractsANestedSkillTreeByteIdentically() throws {
+        let source = workspace.appendingPathComponent("payload", isDirectory: true)
+        let nested = source.appendingPathComponent("skills/pdf/reference", isDirectory: true)
+        try FileManager.default.createDirectory(at: nested, withIntermediateDirectories: true)
+        try "---\nname: pdf\n---\n# PDF\n".write(
+            to: source.appendingPathComponent("skills/pdf/SKILL.md"),
+            atomically: true,
+            encoding: .utf8
+        )
+        // Big enough that `zip` reaches for deflate rather than storing it.
+        let bulky = String(repeating: "the quick brown fox jumps over the lazy dog\n", count: 2_000)
+        try bulky.write(to: nested.appendingPathComponent("notes.md"), atomically: true, encoding: .utf8)
+        try Data((0..<256).map { UInt8($0) }).write(to: nested.appendingPathComponent("bytes.bin"))
+        try "top".write(
+            to: source.appendingPathComponent("README.md"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let archive = try SkillZipFixtures.zipDirectory(named: "payload", in: workspace)
+        let destination = workspace.appendingPathComponent("out", isDirectory: true)
+        let written = try SkillArchiveExtractor.extract(zipFileURL: archive, into: destination)
+
+        XCTAssertEqual(written, 4)
+        let extracted = destination.appendingPathComponent("payload", isDirectory: true)
+        XCTAssertEqual(
+            try SkillDirectoryHasher.hash(directory: extracted),
+            try SkillDirectoryHasher.hash(directory: source),
+            "The extracted tree must hash identically to the one that was zipped"
+        )
+        XCTAssertEqual(
+            try Data(contentsOf: extracted.appendingPathComponent("skills/pdf/reference/bytes.bin")),
+            Data((0..<256).map { UInt8($0) })
+        )
+        XCTAssertEqual(
+            try String(contentsOf: extracted.appendingPathComponent("skills/pdf/reference/notes.md"), encoding: .utf8),
+            bulky
+        )
+    }
+
+    func testRejectsASymlinkEntryWrittenByRealZip() throws {
+        let source = workspace.appendingPathComponent("linked", isDirectory: true)
+        try FileManager.default.createDirectory(at: source, withIntermediateDirectories: true)
+        try "real".write(to: source.appendingPathComponent("SKILL.md"), atomically: true, encoding: .utf8)
+        try FileManager.default.createSymbolicLink(
+            atPath: source.appendingPathComponent("escape").path,
+            withDestinationPath: "/etc/passwd"
+        )
+
+        let archive = try SkillZipFixtures.zipDirectory(
+            named: "linked",
+            in: workspace,
+            extraArguments: ["--symlinks"]
+        )
+        let destination = workspace.appendingPathComponent("out", isDirectory: true)
+
+        XCTAssertThrowsError(try SkillArchiveExtractor.extract(zipFileURL: archive, into: destination)) { error in
+            guard case .symlinkEntry = error as? SkillArchiveError ?? .notAZipArchive else {
+                return XCTFail("Expected symlinkEntry, got \(error)")
+            }
+        }
+        XCTAssertFalse(FileManager.default.fileExists(atPath: destination.appendingPathComponent("linked/escape").path))
+    }
+
+    func testEnforcesTheExtractedByteBudgetOnADeclaredSize() throws {
+        let source = workspace.appendingPathComponent("bulk", isDirectory: true)
+        try FileManager.default.createDirectory(at: source, withIntermediateDirectories: true)
+        // 8 MiB of zeros deflates to a handful of kilobytes: the archive is
+        // tiny, the expansion is not.
+        try Data(count: 8 * 1024 * 1024).write(to: source.appendingPathComponent("zeros.bin"))
+        let archive = try SkillZipFixtures.zipDirectory(named: "bulk", in: workspace)
+        XCTAssertLessThan(
+            try Data(contentsOf: archive).count,
+            256 * 1024,
+            "Fixture assumption: the archive itself stays small"
+        )
+
+        XCTAssertThrowsError(
+            try SkillArchiveExtractor.extract(
+                zipFileURL: archive,
+                into: workspace.appendingPathComponent("out", isDirectory: true),
+                maxExtractedBytes: 1024 * 1024
+            )
+        ) { error in
+            XCTAssertEqual(error as? SkillArchiveError, .archiveTooLarge(limit: 1024 * 1024))
+        }
+    }
+
+    func testEnforcesTheEntryCountBudgetOnARealArchive() throws {
+        let source = workspace.appendingPathComponent("many", isDirectory: true)
+        try FileManager.default.createDirectory(at: source, withIntermediateDirectories: true)
+        for index in 0..<6 {
+            try "\(index)".write(
+                to: source.appendingPathComponent("file\(index).txt"),
+                atomically: true,
+                encoding: .utf8
+            )
+        }
+        let archive = try SkillZipFixtures.zipDirectory(named: "many", in: workspace)
+
+        XCTAssertThrowsError(
+            try SkillArchiveExtractor.extract(
+                zipFileURL: archive,
+                into: workspace.appendingPathComponent("out", isDirectory: true),
+                maxEntries: 3
+            )
+        ) { error in
+            XCTAssertEqual(error as? SkillArchiveError, .tooManyEntries(limit: 3))
+        }
+    }
+
+    // MARK: - Hand-built archives
+
+    func testRejectsZipSlipEntries() throws {
+        for name in ["../escape.txt", "skills/../../escape.txt", "/etc/escape.txt", "a/./b.txt"] {
+            var builder = RawZipBuilder()
+            builder.entries = [.file(name, "owned")]
+            let archive = try builder.write(to: workspace.appendingPathComponent("slip.zip"))
+            let destination = workspace.appendingPathComponent("out-\(UUID().uuidString)", isDirectory: true)
+
+            XCTAssertThrowsError(
+                try SkillArchiveExtractor.extract(zipFileURL: archive, into: destination),
+                "\(name) must be refused"
+            ) { error in
+                XCTAssertEqual(error as? SkillArchiveError, .unsafeEntryPath(name))
+            }
+            XCTAssertFalse(
+                FileManager.default.fileExists(atPath: workspace.appendingPathComponent("escape.txt").path)
+            )
+        }
+    }
+
+    func testRejectsAHandBuiltSymlinkEntry() throws {
+        var builder = RawZipBuilder()
+        builder.entries = [
+            .file("skill/SKILL.md", "---\nname: x\n---\n"),
+            .symlink("skill/link", target: "../../../../etc/passwd")
+        ]
+        let archive = try builder.write(to: workspace.appendingPathComponent("link.zip"))
+
+        XCTAssertThrowsError(
+            try SkillArchiveExtractor.extract(
+                zipFileURL: archive,
+                into: workspace.appendingPathComponent("out", isDirectory: true)
+            )
+        ) { error in
+            XCTAssertEqual(error as? SkillArchiveError, .symlinkEntry("skill/link"))
+        }
+    }
+
+    func testRejectsAnInflatedEntryOnTheRunningBudget() throws {
+        // The central directory lies about the uncompressed size, so the
+        // up-front check waves it through; the inflater's own accounting is
+        // what must stop it.
+        let payload = Data(count: 4 * 1024 * 1024)
+        var builder = RawZipBuilder()
+        builder.entries = [.deflated("zeros.bin", payload: payload, declaredSize: 64)]
+        let archive = try builder.write(to: workspace.appendingPathComponent("bomb.zip"))
+
+        XCTAssertThrowsError(
+            try SkillArchiveExtractor.extract(
+                zipFileURL: archive,
+                into: workspace.appendingPathComponent("out", isDirectory: true),
+                maxExtractedBytes: 512 * 1024
+            )
+        ) { error in
+            XCTAssertEqual(error as? SkillArchiveError, .archiveTooLarge(limit: 512 * 1024))
+        }
+    }
+
+    func testRejectsAnEndOfCentralDirectoryClaimingTooManyEntries() throws {
+        var builder = RawZipBuilder()
+        builder.entries = [.file("a.txt", "a")]
+        builder.entryCountOverride = 20_000
+        let archive = try builder.write(to: workspace.appendingPathComponent("count.zip"))
+
+        XCTAssertThrowsError(
+            try SkillArchiveExtractor.extract(
+                zipFileURL: archive,
+                into: workspace.appendingPathComponent("out", isDirectory: true)
+            )
+        ) { error in
+            XCTAssertEqual(
+                error as? SkillArchiveError,
+                .tooManyEntries(limit: SkillArchiveExtractor.maxEntries)
+            )
+        }
+    }
+
+    func testReportsAnUnsupportedCompressionMethodByID() throws {
+        var builder = RawZipBuilder()
+        var entry = RawZipBuilder.Entry.file("a.txt", "a")
+        entry.method = 12  // bzip2 — legal ZIP, not something we decode.
+        builder.entries = [entry]
+        let archive = try builder.write(to: workspace.appendingPathComponent("bzip.zip"))
+
+        XCTAssertThrowsError(
+            try SkillArchiveExtractor.extract(
+                zipFileURL: archive,
+                into: workspace.appendingPathComponent("out", isDirectory: true)
+            )
+        ) { error in
+            XCTAssertEqual(error as? SkillArchiveError, .unsupportedCompressionMethod(12))
+        }
+    }
+
+    func testRejectsDuplicateNormalizedEntries() throws {
+        var builder = RawZipBuilder()
+        builder.entries = [.file("skill/notes.md", "first"), .file("skill/Notes.md", "second")]
+        let archive = try builder.write(to: workspace.appendingPathComponent("dupe.zip"))
+
+        XCTAssertThrowsError(
+            try SkillArchiveExtractor.extract(
+                zipFileURL: archive,
+                into: workspace.appendingPathComponent("out", isDirectory: true)
+            )
+        ) { error in
+            XCTAssertEqual(error as? SkillArchiveError, .duplicateEntry("skill/Notes.md"))
+        }
+    }
+
+    func testRejectsAnEntryNameThatIsNotUTF8() throws {
+        var entry = RawZipBuilder.Entry.file("bad", "x")
+        entry.rawName = Data([0x66, 0xFF, 0xFE, 0x2E, 0x6D, 0x64])
+        var builder = RawZipBuilder()
+        builder.entries = [entry]
+        let archive = try builder.write(to: workspace.appendingPathComponent("utf8.zip"))
+
+        XCTAssertThrowsError(
+            try SkillArchiveExtractor.extract(
+                zipFileURL: archive,
+                into: workspace.appendingPathComponent("out", isDirectory: true)
+            )
+        ) { error in
+            XCTAssertEqual(error as? SkillArchiveError, .invalidEntryName)
+        }
+    }
+
+    func testRejectsAnEncryptedEntry() throws {
+        var entry = RawZipBuilder.Entry.file("secret.md", "x")
+        entry.flags = 0x0801
+        var builder = RawZipBuilder()
+        builder.entries = [entry]
+        let archive = try builder.write(to: workspace.appendingPathComponent("crypt.zip"))
+
+        XCTAssertThrowsError(
+            try SkillArchiveExtractor.extract(
+                zipFileURL: archive,
+                into: workspace.appendingPathComponent("out", isDirectory: true)
+            )
+        ) { error in
+            XCTAssertEqual(error as? SkillArchiveError, .encryptedEntry("secret.md"))
+        }
+    }
+
+    func testRejectsAChecksumMismatch() throws {
+        var entry = RawZipBuilder.Entry.file("a.txt", "hello")
+        entry.crc = 0xDEAD_BEEF
+        var builder = RawZipBuilder()
+        builder.entries = [entry]
+        let archive = try builder.write(to: workspace.appendingPathComponent("crc.zip"))
+
+        XCTAssertThrowsError(
+            try SkillArchiveExtractor.extract(
+                zipFileURL: archive,
+                into: workspace.appendingPathComponent("out", isDirectory: true)
+            )
+        ) { error in
+            XCTAssertEqual(error as? SkillArchiveError, .checksumMismatch("a.txt"))
+        }
+    }
+
+    func testRejectsSomethingThatIsNotAZipAtAll() throws {
+        let file = workspace.appendingPathComponent("not.zip")
+        try Data("this is plainly not a zip archive".utf8).write(to: file)
+
+        XCTAssertThrowsError(
+            try SkillArchiveExtractor.extract(
+                zipFileURL: file,
+                into: workspace.appendingPathComponent("out", isDirectory: true)
+            )
+        ) { error in
+            XCTAssertEqual(error as? SkillArchiveError, .notAZipArchive)
+        }
+    }
+
+    func testExtractsStoredEntriesAndDirectoryMarkers() throws {
+        var builder = RawZipBuilder()
+        builder.entries = [
+            .directory("skill"),
+            .file("skill/SKILL.md", "---\nname: demo\n---\n"),
+            .file("skill/reference/notes.md", "deep")
+        ]
+        let archive = try builder.write(to: workspace.appendingPathComponent("plain.zip"))
+        let destination = workspace.appendingPathComponent("out", isDirectory: true)
+
+        let written = try SkillArchiveExtractor.extract(zipFileURL: archive, into: destination)
+
+        XCTAssertEqual(written, 2)
+        XCTAssertEqual(
+            try String(contentsOf: destination.appendingPathComponent("skill/reference/notes.md"), encoding: .utf8),
+            "deep"
+        )
+    }
+}

--- a/Tests/VibeBarCoreTests/SkillBackupManagerTests.swift
+++ b/Tests/VibeBarCoreTests/SkillBackupManagerTests.swift
@@ -1,0 +1,154 @@
+import XCTest
+@testable import VibeBarCore
+
+final class SkillBackupManagerTests: XCTestCase {
+    private func makeSkill(_ directory: String) -> Skill {
+        Skill(
+            id: .local(directory: directory),
+            name: directory,
+            description: "a synthetic skill",
+            directory: directory,
+            installedAt: Date(timeIntervalSince1970: 1_700_000_000),
+            contentHash: "stale-hash"
+        )
+    }
+
+    func testCreateBackupCopiesPayloadAndMetadata() throws {
+        let home = try SkillTestHome()
+        try home.makeSSOTSkill("alpha", extraFiles: ["ref.md": "payload", "nested/deep.md": "deep"])
+        let manager = SkillBackupManager(homeDirectory: home.path)
+
+        let backupURL = try manager.createBackup(of: "alpha", skill: makeSkill("alpha"))
+
+        XCTAssertTrue(SkillAppCatalog.isPath(backupURL, under: manager.rootDirectory))
+        XCTAssertTrue(backupURL.lastPathComponent.hasSuffix("_alpha"))
+        XCTAssertEqual(home.contents(of: backupURL.appendingPathComponent("skill/ref.md")), "payload")
+        XCTAssertEqual(home.contents(of: backupURL.appendingPathComponent("skill/nested/deep.md")), "deep")
+
+        let data = try Data(contentsOf: backupURL.appendingPathComponent("meta.json"))
+        let metadata = try JSONDecoder().decode(SkillBackupManager.Metadata.self, from: data)
+        XCTAssertEqual(metadata.skill.directory, "alpha")
+        XCTAssertEqual(metadata.sourcePath, home.ssot.appendingPathComponent("alpha").path)
+        XCTAssertLessThan(abs(metadata.backupCreatedAt.timeIntervalSinceNow), 30)
+        // The SSOT is untouched by taking a backup.
+        XCTAssertTrue(home.exists(home.ssot.appendingPathComponent("alpha/SKILL.md")))
+    }
+
+    func testCreateBackupRefusesAMissingSkill() throws {
+        let home = try SkillTestHome()
+        let manager = SkillBackupManager(homeDirectory: home.path)
+        XCTAssertThrowsError(try manager.createBackup(of: "ghost", skill: makeSkill("ghost"))) { error in
+            XCTAssertEqual(error as? SkillError, .sourceDirectoryMissing("ghost"))
+        }
+        XCTAssertThrowsError(try manager.createBackup(of: "../evil", skill: makeSkill("../evil"))) { error in
+            XCTAssertEqual(error as? SkillError, .invalidDirectoryName("../evil"))
+        }
+    }
+
+    func testListBackupsIsNewestFirst() throws {
+        let home = try SkillTestHome()
+        try home.makeSSOTSkill("alpha")
+        let manager = SkillBackupManager(homeDirectory: home.path)
+        let first = try manager.createBackup(of: "alpha", skill: makeSkill("alpha"))
+        let second = try manager.createBackup(of: "alpha", skill: makeSkill("alpha"))
+
+        let listed = manager.listBackups()
+        XCTAssertEqual(listed.count, 2)
+        XCTAssertEqual(listed.first?.url.lastPathComponent, second.lastPathComponent)
+        XCTAssertEqual(listed.last?.url.lastPathComponent, first.lastPathComponent)
+        XCTAssertEqual(listed.first?.skill?.directory, "alpha")
+        // Same-second backups get a numeric suffix rather than colliding.
+        XCTAssertNotEqual(first.lastPathComponent, second.lastPathComponent)
+    }
+
+    func testRestoreRefusesWhenTheSSOTDirectoryStillExists() throws {
+        let home = try SkillTestHome()
+        try home.makeSSOTSkill("alpha")
+        let manager = SkillBackupManager(homeDirectory: home.path)
+        let backupURL = try manager.createBackup(of: "alpha", skill: makeSkill("alpha"))
+
+        XCTAssertThrowsError(try manager.restore(backupURL: backupURL)) { error in
+            XCTAssertEqual(error as? SkillError, .destinationExists("alpha"))
+        }
+    }
+
+    func testRestoreCopiesBackAndRecomputesTheHash() throws {
+        let home = try SkillTestHome()
+        let source = try home.makeSSOTSkill("alpha", extraFiles: ["ref.md": "payload"])
+        let manager = SkillBackupManager(homeDirectory: home.path)
+        let expectedHash = try SkillDirectoryHasher.hash(directory: source)
+        let backupURL = try manager.createBackup(of: "alpha", skill: makeSkill("alpha"))
+        try FileManager.default.removeItem(at: source)
+
+        let restored = try manager.restore(backupURL: backupURL)
+
+        XCTAssertEqual(restored.directory, "alpha")
+        XCTAssertEqual(restored.contentHash, expectedHash)
+        XCTAssertEqual(home.contents(of: source.appendingPathComponent("ref.md")), "payload")
+        XCTAssertEqual(SkillFileSystem.kind(of: source), .directory)
+    }
+
+    func testRestoreAndDeleteRefusePathsOutsideTheBackupRoot() throws {
+        let home = try SkillTestHome()
+        let manager = SkillBackupManager(homeDirectory: home.path)
+        let outside = home.url.appendingPathComponent("elsewhere", isDirectory: true)
+        try home.makeDirectory(outside)
+
+        XCTAssertThrowsError(try manager.restore(backupURL: outside)) { error in
+            XCTAssertEqual(error as? SkillError, .writeOutsideAllowedRoots(outside.path))
+        }
+        XCTAssertThrowsError(try manager.deleteBackup(outside)) { error in
+            XCTAssertEqual(error as? SkillError, .writeOutsideAllowedRoots(outside.path))
+        }
+        XCTAssertThrowsError(try manager.deleteBackup(manager.rootDirectory)) { error in
+            XCTAssertEqual(error as? SkillError, .writeOutsideAllowedRoots(manager.rootDirectory.path))
+        }
+        XCTAssertTrue(home.exists(outside))
+    }
+
+    func testRestoreRejectsABackupWithoutMetadata() throws {
+        let home = try SkillTestHome()
+        try home.makeSSOTSkill("alpha")
+        let manager = SkillBackupManager(homeDirectory: home.path)
+        let backupURL = try manager.createBackup(of: "alpha", skill: makeSkill("alpha"))
+        try FileManager.default.removeItem(at: backupURL.appendingPathComponent("meta.json"))
+
+        XCTAssertThrowsError(try manager.restore(backupURL: backupURL)) { error in
+            XCTAssertEqual(error as? SkillError, .backupCorrupted(backupURL.lastPathComponent))
+        }
+    }
+
+    func testPruneKeepsTheNewestTwenty() throws {
+        let home = try SkillTestHome()
+        try home.makeSSOTSkill("alpha")
+        let manager = SkillBackupManager(homeDirectory: home.path)
+
+        var created: [URL] = []
+        for _ in 0..<23 {
+            created.append(try manager.createBackup(of: "alpha", skill: makeSkill("alpha")))
+        }
+
+        let listed = manager.listBackups()
+        XCTAssertEqual(listed.count, SkillBackupManager.defaultRetainedBackups)
+        XCTAssertEqual(listed.first?.url.path, created.last?.path)
+        XCTAssertTrue(home.exists(created[22]))
+
+        manager.prune(keeping: 5)
+        XCTAssertEqual(manager.listBackups().count, 5)
+        XCTAssertEqual(manager.listBackups().first?.url.path, created.last?.path)
+    }
+
+    func testDeleteBackupRemovesOneBackup() throws {
+        let home = try SkillTestHome()
+        try home.makeSSOTSkill("alpha")
+        let manager = SkillBackupManager(homeDirectory: home.path)
+        let backupURL = try manager.createBackup(of: "alpha", skill: makeSkill("alpha"))
+
+        try manager.deleteBackup(backupURL)
+        XCTAssertFalse(home.exists(backupURL))
+        XCTAssertTrue(manager.listBackups().isEmpty)
+        XCTAssertThrowsError(try manager.deleteBackup(backupURL)) { error in
+            XCTAssertEqual(error as? SkillError, .backupNotFound(backupURL.lastPathComponent))
+        }
+    }
+}

--- a/Tests/VibeBarCoreTests/SkillDirectoryHasherTests.swift
+++ b/Tests/VibeBarCoreTests/SkillDirectoryHasherTests.swift
@@ -1,0 +1,94 @@
+import XCTest
+@testable import VibeBarCore
+
+final class SkillDirectoryHasherTests: XCTestCase {
+    func testHashIsIndependentOfFileCreationOrder() throws {
+        let home = try SkillTestHome()
+        let first = home.url.appendingPathComponent("first", isDirectory: true)
+        try home.write("alpha", to: first.appendingPathComponent("a.md"))
+        try home.write("beta", to: first.appendingPathComponent("nested/b.md"))
+        try home.write("gamma", to: first.appendingPathComponent("c.md"))
+
+        let second = home.url.appendingPathComponent("second", isDirectory: true)
+        try home.write("gamma", to: second.appendingPathComponent("c.md"))
+        try home.write("beta", to: second.appendingPathComponent("nested/b.md"))
+        try home.write("alpha", to: second.appendingPathComponent("a.md"))
+
+        XCTAssertEqual(
+            try SkillDirectoryHasher.hash(directory: first),
+            try SkillDirectoryHasher.hash(directory: second)
+        )
+    }
+
+    func testHiddenEntriesAreExcluded() throws {
+        let home = try SkillTestHome()
+        let directory = try home.makeSSOTSkill("hidden-skill")
+        let before = try SkillDirectoryHasher.hash(directory: directory)
+
+        try home.write("junk", to: directory.appendingPathComponent(".DS_Store"))
+        try home.write("ref: refs/heads/main", to: directory.appendingPathComponent(".git/HEAD"))
+        XCTAssertEqual(try SkillDirectoryHasher.hash(directory: directory), before)
+
+        try home.write("visible", to: directory.appendingPathComponent("visible.md"))
+        XCTAssertNotEqual(try SkillDirectoryHasher.hash(directory: directory), before)
+    }
+
+    func testSymlinksHashAsTargetPathNotTargetContents() throws {
+        let home = try SkillTestHome()
+        let outside = home.url.appendingPathComponent("outside", isDirectory: true)
+        try home.write("original", to: outside.appendingPathComponent("payload.txt"))
+        let other = home.url.appendingPathComponent("other", isDirectory: true)
+        try home.write("different", to: other.appendingPathComponent("payload.txt"))
+
+        let directory = try home.makeSSOTSkill("linky")
+        let link = directory.appendingPathComponent("payload.txt")
+        try FileManager.default.createSymbolicLink(
+            atPath: link.path,
+            withDestinationPath: outside.appendingPathComponent("payload.txt").path
+        )
+        let before = try SkillDirectoryHasher.hash(directory: directory)
+
+        // Rewriting what the link points at must not move the hash...
+        try home.write("rewritten", to: outside.appendingPathComponent("payload.txt"))
+        XCTAssertEqual(try SkillDirectoryHasher.hash(directory: directory), before)
+
+        // ...but re-pointing the link itself must.
+        try FileManager.default.removeItem(at: link)
+        try FileManager.default.createSymbolicLink(
+            atPath: link.path,
+            withDestinationPath: other.appendingPathComponent("payload.txt").path
+        )
+        XCTAssertNotEqual(try SkillDirectoryHasher.hash(directory: directory), before)
+    }
+
+    func testSeparatorsPreventPathContentCollisions() throws {
+        let home = try SkillTestHome()
+        let first = home.url.appendingPathComponent("collide-a", isDirectory: true)
+        try home.write("c", to: first.appendingPathComponent("ab"))
+
+        let second = home.url.appendingPathComponent("collide-b", isDirectory: true)
+        try home.write("bc", to: second.appendingPathComponent("a"))
+
+        XCTAssertNotEqual(
+            try SkillDirectoryHasher.hash(directory: first),
+            try SkillDirectoryHasher.hash(directory: second)
+        )
+    }
+
+    func testContentChangeMovesTheHash() throws {
+        let home = try SkillTestHome()
+        let directory = try home.makeSSOTSkill("mutable", extraFiles: ["notes.md": "one"])
+        let before = try SkillDirectoryHasher.hash(directory: directory)
+        try home.write("two", to: directory.appendingPathComponent("notes.md"))
+        XCTAssertNotEqual(try SkillDirectoryHasher.hash(directory: directory), before)
+    }
+
+    func testHashIsStableAcrossRepeatedRuns() throws {
+        let home = try SkillTestHome()
+        let directory = try home.makeSSOTSkill("stable", extraFiles: ["a/b/c.md": "deep"])
+        XCTAssertEqual(
+            try SkillDirectoryHasher.hash(directory: directory),
+            try SkillDirectoryHasher.hash(directory: directory)
+        )
+    }
+}

--- a/Tests/VibeBarCoreTests/SkillFrontmatterParserTests.swift
+++ b/Tests/VibeBarCoreTests/SkillFrontmatterParserTests.swift
@@ -1,0 +1,113 @@
+import XCTest
+@testable import VibeBarCore
+
+final class SkillFrontmatterParserTests: XCTestCase {
+    func testParsesDoubleQuotedScalars() {
+        let parsed = SkillFrontmatterParser.parse("""
+        ---
+        name: "lark-base"
+        description: "Base operations: tables, fields, records."
+        ---
+
+        # body
+        """)
+        XCTAssertEqual(parsed.name, "lark-base")
+        XCTAssertEqual(parsed.description, "Base operations: tables, fields, records.")
+    }
+
+    func testParsesSingleQuotedAndPlainScalars() {
+        let parsed = SkillFrontmatterParser.parse("""
+        ---
+        name: 'quoted-name'
+        description: plain description without quotes
+        ---
+        """)
+        XCTAssertEqual(parsed.name, "quoted-name")
+        XCTAssertEqual(parsed.description, "plain description without quotes")
+    }
+
+    func testParsesFoldedDescription() {
+        let parsed = SkillFrontmatterParser.parse("""
+        ---
+        name: check-work
+        description: >
+          Check your work with a verification subagent that reviews diffs,
+          runs builds and tests, and evaluates correctness.
+        metadata:
+          short-description: "Verify changes with a subagent"
+        ---
+        """)
+        XCTAssertEqual(parsed.name, "check-work")
+        XCTAssertEqual(
+            parsed.description,
+            "Check your work with a verification subagent that reviews diffs, runs builds and tests, and evaluates correctness."
+        )
+    }
+
+    func testParsesStrippedFoldedAndLiteralBlocks() {
+        let stripped = SkillFrontmatterParser.parse("""
+        ---
+        description: >-
+          first line
+          second line
+        ---
+        """)
+        XCTAssertEqual(stripped.description, "first line second line")
+
+        let literal = SkillFrontmatterParser.parse("""
+        ---
+        description: |
+          first line
+          second line
+        ---
+        """)
+        XCTAssertEqual(literal.description, "first line second line")
+    }
+
+    func testSkipsNestedKeysAndUnknownTopLevelKeys() {
+        let parsed = SkillFrontmatterParser.parse("""
+        ---
+        name: nested-skill
+        version: 1.2.3
+        metadata:
+          requires:
+            bins: ["lark-cli"]
+          name: not-the-skill-name
+        ---
+        """)
+        XCTAssertEqual(parsed.name, "nested-skill")
+        XCTAssertNil(parsed.description)
+    }
+
+    func testToleratesByteOrderMarkAndCRLF() {
+        let parsed = SkillFrontmatterParser.parse("\u{FEFF}---\r\nname: bom-skill\r\ndescription: with CRLF\r\n---\r\n")
+        XCTAssertEqual(parsed.name, "bom-skill")
+        XCTAssertEqual(parsed.description, "with CRLF")
+    }
+
+    func testReturnsEmptyWithoutFrontmatter() {
+        XCTAssertEqual(SkillFrontmatterParser.parse("# just markdown\n\nname: not-frontmatter\n"), .empty)
+        XCTAssertEqual(SkillFrontmatterParser.parse(""), .empty)
+    }
+
+    func testMissingFieldsStayNil() {
+        let parsed = SkillFrontmatterParser.parse("""
+        ---
+        name: only-a-name
+        ---
+        """)
+        XCTAssertEqual(parsed.name, "only-a-name")
+        XCTAssertNil(parsed.description)
+    }
+
+    func testReadsFromDisk() throws {
+        let home = try SkillTestHome()
+        let directory = try home.makeSSOTSkill("disk-skill", name: "disk-skill", description: "read from a file")
+        let parsed = SkillFrontmatterParser.parse(contentsOf: directory.appendingPathComponent("SKILL.md"))
+        XCTAssertEqual(parsed.name, "disk-skill")
+        XCTAssertEqual(parsed.description, "read from a file")
+
+        let missing = SkillFrontmatterParser.parse(contentsOf: directory.appendingPathComponent("NOPE.md"))
+        XCTAssertEqual(missing, .empty)
+    }
+}

--- a/Tests/VibeBarCoreTests/SkillImportScannerTests.swift
+++ b/Tests/VibeBarCoreTests/SkillImportScannerTests.swift
@@ -1,0 +1,238 @@
+import XCTest
+@testable import VibeBarCore
+
+/// These tests replicate the layout a real machine already has when Vibe Bar
+/// first sees it: a populated `~/.agents/skills`, app directories full of
+/// symlinks another tool created, and a `.skill-lock.json` Vibe Bar does not
+/// own. Import must describe all of it and change none of it.
+final class SkillImportScannerTests: XCTestCase {
+    private func makeMachineLayout() throws -> SkillTestHome {
+        let home = try SkillTestHome()
+
+        try home.makeSSOTSkill("alpha", name: "alpha-skill", description: "Alpha does things")
+        try home.makeSSOTSkill("beta")
+        try home.makeSSOTSkill("gamma")
+        try home.makeSSOTSkill("delta")
+        try home.makeSSOTSkill("epsilon")
+        try home.makeSSOTSkill("zeta")
+        try home.makeSSOTSkill("eta")
+        try home.makeSSOTSkill("theta")
+        // An SSOT directory with no SKILL.md, and a stray file: neither is a skill.
+        try home.makeDirectory(home.ssot.appendingPathComponent("notaskill"))
+        try home.write("scratch", to: home.ssot.appendingPathComponent("notaskill/notes.md"))
+        try home.write("# not a skill", to: home.ssot.appendingPathComponent("README.md"))
+
+        try home.write(Self.lockFileJSON, to: SkillAppCatalog.lockFileURL(homeDirectory: home.path))
+
+        for name in ["alpha", "beta", "eta"] {
+            try home.makeAbsoluteSymlink(name, in: .claude, toSSOT: name)
+        }
+        try home.makeSymlink("gamma", in: .claude, rawTarget: "../../.agents/skills/gamma")
+        try home.makeSymlink("notaskill", in: .claude, rawTarget: home.ssot.appendingPathComponent("notaskill").path)
+        try home.makeSymlink("ghost", in: .claude, rawTarget: home.ssot.appendingPathComponent("ghost").path)
+        try home.makeSkillDirectory(
+            at: home.appDirectory(.claude).appendingPathComponent("legacy-helper"),
+            name: "Legacy Helper",
+            description: "hand written"
+        )
+
+        try home.makeAbsoluteSymlink("alpha", in: .gemini, toSSOT: "alpha")
+        try home.makeSkillDirectory(at: home.appDirectory(.gemini).appendingPathComponent("beta"))
+
+        try home.makeAbsoluteSymlink("alpha", in: .antigravity, toSSOT: "alpha")
+
+        try home.makeSkillDirectory(
+            at: home.appDirectory(.grok).appendingPathComponent("legacy-helper"),
+            name: "Legacy Helper",
+            description: "hand written"
+        )
+
+        return home
+    }
+
+    func testPartitionsTheExistingLayout() throws {
+        let home = try makeMachineLayout()
+        let report = SkillImportScanner.scan(homeDirectory: home.path)
+
+        XCTAssertEqual(
+            report.adopted.map(\.directory),
+            ["alpha", "beta", "delta", "epsilon", "eta", "gamma", "theta", "zeta"]
+        )
+        XCTAssertEqual(report.unrecognized, ["notaskill"])
+        XCTAssertEqual(report.conflicts, [SkillImportConflict(directoryName: "beta", app: .gemini)])
+        XCTAssertEqual(report.unmanagedDirectories.count, 1)
+        let unmanaged = try XCTUnwrap(report.unmanagedDirectories.first)
+        XCTAssertEqual(unmanaged.directoryName, "legacy-helper")
+        XCTAssertEqual(unmanaged.foundIn, [.claude, .grok])
+        XCTAssertEqual(unmanaged.name, "Legacy Helper")
+        XCTAssertEqual(unmanaged.description, "hand written")
+    }
+
+    func testAdoptionEvidenceComesFromSymlinksOnly() throws {
+        let home = try makeMachineLayout()
+        let report = SkillImportScanner.scan(homeDirectory: home.path)
+        let byDirectory = Dictionary(uniqueKeysWithValues: report.adopted.map { ($0.directory, $0) })
+
+        // Absolute links in three different app dirs, including AntiGravity's
+        // ~/.gemini/config/skills, which is distinct from the Gemini CLI's.
+        XCTAssertEqual(byDirectory["alpha"]?.enabledApps, [.claude, .gemini, .antigravity])
+        XCTAssertEqual(byDirectory["alpha"]?.apps[.claude], SkillMaterialization(method: .symlink, adopted: true))
+        XCTAssertEqual(byDirectory["alpha"]?.name, "alpha-skill")
+        XCTAssertEqual(byDirectory["alpha"]?.description, "Alpha does things")
+        XCTAssertNotNil(byDirectory["alpha"]?.contentHash)
+
+        // A relative link resolves the same way an absolute one does.
+        XCTAssertEqual(byDirectory["gamma"]?.enabledApps, [.claude])
+        // The Gemini side of beta is a real directory: a conflict, not evidence.
+        XCTAssertEqual(byDirectory["beta"]?.enabledApps, [.claude])
+        // Never linked anywhere.
+        XCTAssertEqual(byDirectory["delta"]?.enabledApps, [])
+    }
+
+    func testRecoversProvenanceFromTheLockFile() throws {
+        let home = try makeMachineLayout()
+        let report = SkillImportScanner.scan(homeDirectory: home.path)
+        let byDirectory = Dictionary(uniqueKeysWithValues: report.adopted.map { ($0.directory, $0) })
+
+        let iso = ISO8601DateFormatter()
+        iso.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        XCTAssertEqual(byDirectory["alpha"]?.id, .repo(owner: "acme", repo: "skills", directory: "alpha"))
+        XCTAssertNil(byDirectory["alpha"]?.repoBranch)
+        XCTAssertEqual(byDirectory["alpha"]?.installedAt, iso.date(from: "2026-04-28T16:51:41.354Z"))
+        XCTAssertEqual(byDirectory["alpha"]?.updatedAt, iso.date(from: "2026-08-03T07:30:25.276Z"))
+
+        XCTAssertEqual(byDirectory["beta"]?.repoBranch, "dev")
+        XCTAssertEqual(byDirectory["epsilon"]?.repoBranch, "release-2.0")
+        XCTAssertEqual(byDirectory["zeta"]?.repoBranch, "feature-x")
+        XCTAssertEqual(byDirectory["eta"]?.repoBranch, "explicit-branch")
+        XCTAssertEqual(byDirectory["theta"]?.repoBranch, "fallback-branch")
+
+        // Unknown sourceType and absent entries both fall back to local.
+        XCTAssertEqual(byDirectory["gamma"]?.id, .local(directory: "gamma"))
+        XCTAssertNil(byDirectory["gamma"]?.repoBranch)
+        XCTAssertEqual(byDirectory["delta"]?.id, .local(directory: "delta"))
+    }
+
+    func testBranchParsingForms() {
+        XCTAssertNil(SkillLockFileReader.branch(fromSourceURL: "https://github.com/acme/skills.git"))
+        XCTAssertEqual(
+            SkillLockFileReader.branch(fromSourceURL: "https://github.com/acme/skills/tree/dev/skills/beta"),
+            "dev"
+        )
+        XCTAssertEqual(
+            SkillLockFileReader.branch(fromSourceURL: "https://github.com/acme/skills/tree/main"),
+            "main"
+        )
+        XCTAssertEqual(
+            SkillLockFileReader.branch(fromSourceURL: "https://github.com/acme/skills.git#feature-x"),
+            "feature-x"
+        )
+        XCTAssertEqual(
+            SkillLockFileReader.branch(fromSourceURL: "https://github.com/acme/skills.git?branch=next"),
+            "next"
+        )
+        XCTAssertEqual(
+            SkillLockFileReader.branch(fromSourceURL: "https://github.com/acme/skills.git?ref=release%2F2.0"),
+            "release/2.0"
+        )
+        // A /tree/ segment wins over a query, and the fragment never leaks into it.
+        XCTAssertEqual(
+            SkillLockFileReader.branch(fromSourceURL: "https://github.com/acme/skills/tree/dev?ref=other#frag"),
+            "dev"
+        )
+    }
+
+    func testScanPerformsNoFilesystemMutations() throws {
+        let home = try makeMachineLayout()
+        let before = home.lstatSnapshot()
+
+        _ = SkillImportScanner.scan(homeDirectory: home.path)
+
+        let after = home.lstatSnapshot()
+        XCTAssertEqual(Set(before.keys), Set(after.keys))
+        XCTAssertEqual(before, after)
+        // Nothing was conjured up for the apps that have no skills dir yet.
+        XCTAssertFalse(home.exists(home.appDirectory(.codex)))
+        XCTAssertFalse(home.exists(home.appDirectory(.hermes)))
+        XCTAssertFalse(home.exists(home.appDirectory(.opencode)))
+        XCTAssertFalse(home.exists(VibeBarLocalStore.baseDirectory(homeDirectory: home.path)))
+        // The dangling link is left dangling — not repaired, not deleted.
+        XCTAssertEqual(
+            SkillFileSystem.kind(of: home.appDirectory(.claude).appendingPathComponent("ghost")),
+            .symlink
+        )
+        XCTAssertFalse(home.exists(home.ssot.appendingPathComponent("ghost")))
+    }
+
+    func testRescanIsIdempotent() throws {
+        let home = try makeMachineLayout()
+        XCTAssertEqual(
+            SkillImportScanner.scan(homeDirectory: home.path),
+            SkillImportScanner.scan(homeDirectory: home.path)
+        )
+    }
+
+    func testEmptyHomeScansCleanly() throws {
+        let home = try SkillTestHome()
+        let report = SkillImportScanner.scan(homeDirectory: home.path)
+        XCTAssertTrue(report.isEmpty)
+        XCTAssertFalse(home.exists(home.ssot))
+    }
+
+    private static let lockFileJSON = """
+    {
+      "version": 3,
+      "skills": {
+        "alpha": {
+          "source": "acme/skills",
+          "sourceType": "github",
+          "sourceUrl": "https://github.com/acme/skills.git",
+          "skillPath": "skills/alpha/SKILL.md",
+          "skillFolderHash": "0000000000000000000000000000000000000000",
+          "installedAt": "2026-04-28T16:51:41.354Z",
+          "updatedAt": "2026-08-03T07:30:25.276Z"
+        },
+        "beta": {
+          "source": "acme/skills",
+          "sourceType": "github",
+          "sourceUrl": "https://github.com/acme/skills/tree/dev/skills/beta",
+          "skillPath": "skills/beta/SKILL.md"
+        },
+        "gamma": {
+          "source": "acme/skills",
+          "sourceType": "gitlab",
+          "sourceUrl": "https://gitlab.example.com/acme/skills.git"
+        },
+        "epsilon": {
+          "source": "acme/skills",
+          "sourceType": "github",
+          "sourceUrl": "https://github.com/acme/skills.git?ref=release-2.0"
+        },
+        "zeta": {
+          "source": "acme/skills",
+          "sourceType": "github",
+          "sourceUrl": "https://github.com/acme/skills.git#feature-x"
+        },
+        "eta": {
+          "source": "acme/skills",
+          "sourceType": "github",
+          "sourceUrl": "https://github.com/acme/skills/tree/other/skills/eta",
+          "branch": "explicit-branch"
+        },
+        "theta": {
+          "source": "acme/skills",
+          "sourceType": "github",
+          "sourceUrl": "https://github.com/acme/skills.git",
+          "sourceBranch": "fallback-branch"
+        },
+        "removed-skill": {
+          "source": "acme/skills",
+          "sourceType": "github",
+          "sourceUrl": "https://github.com/acme/skills.git"
+        },
+        "malformed": 42
+      },
+      "dismissed": {}
+    }
+    """
+}

--- a/Tests/VibeBarCoreTests/SkillPathValidatorTests.swift
+++ b/Tests/VibeBarCoreTests/SkillPathValidatorTests.swift
@@ -1,0 +1,66 @@
+import XCTest
+@testable import VibeBarCore
+
+final class SkillPathValidatorTests: XCTestCase {
+    func testAcceptsOrdinarySingleComponentNames() {
+        let accepted = [
+            "a",
+            "my-skill",
+            "my_skill",
+            "my.skill",
+            "MySkill",
+            "skill123",
+            "skill with space",
+            "日本語スキル",
+            "skill:with-colon",
+            "skill-"
+        ]
+        for name in accepted {
+            XCTAssertTrue(SkillPathValidator.isValid(name), "expected \(name) to be valid")
+            XCTAssertNoThrow(try SkillPathValidator.validate(directoryName: name))
+        }
+    }
+
+    func testRejectsEmptySeparatorsDotsAndHiddenNames() {
+        let rejected = [
+            "",
+            ".",
+            "..",
+            "...",
+            ".hidden",
+            ".DS_Store",
+            "/",
+            "\\",
+            "a/b",
+            "../evil",
+            "..%2Fevil/..",
+            "a\\b",
+            "/absolute",
+            "trailing/",
+            "nested/dir/name"
+        ]
+        for name in rejected {
+            XCTAssertFalse(SkillPathValidator.isValid(name), "expected \(name) to be rejected")
+        }
+    }
+
+    func testRejectsControlCharacters() {
+        let rejected = [
+            "line\nbreak",
+            "tab\tseparated",
+            "carriage\rreturn",
+            "null\u{0}byte",
+            "delete\u{7F}char",
+            "\u{1}"
+        ]
+        for name in rejected {
+            XCTAssertFalse(SkillPathValidator.isValid(name), "expected control char in \(name.debugDescription) to be rejected")
+        }
+    }
+
+    func testValidateThrowsInvalidDirectoryName() {
+        XCTAssertThrowsError(try SkillPathValidator.validate(directoryName: "../escape")) { error in
+            XCTAssertEqual(error as? SkillError, .invalidDirectoryName("../escape"))
+        }
+    }
+}

--- a/Tests/VibeBarCoreTests/SkillRepoFetcherTests.swift
+++ b/Tests/VibeBarCoreTests/SkillRepoFetcherTests.swift
@@ -1,0 +1,415 @@
+import XCTest
+@testable import VibeBarCore
+
+/// Covers the three jobs of the fetcher — parsing what the user typed,
+/// downloading a branch, and recognizing skills in what came back — plus the
+/// `BoundedDownloader` guarantees the download leans on. Nothing here touches
+/// the real network: every request is served by a `URLProtocol` stub, which is
+/// also the only way to exercise the redirect check.
+final class SkillRepoFetcherTests: XCTestCase {
+    private var workspace: URL!
+
+    override func setUpWithError() throws {
+        workspace = FileManager.default.temporaryDirectory
+            .appendingPathComponent("VibeBarFetcher-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: workspace, withIntermediateDirectories: true)
+        StubURLProtocol.reset()
+    }
+
+    override func tearDownWithError() throws {
+        StubURLProtocol.reset()
+        try? FileManager.default.removeItem(at: workspace)
+    }
+
+    // MARK: - Reference parsing
+
+    func testParsesWellFormedReferences() {
+        XCTAssertEqual(SkillRepoRef("anthropics/skills")?.descriptor, "anthropics/skills")
+        XCTAssertEqual(SkillRepoRef("cexll/myclaude@master")?.branch, "master")
+        XCTAssertEqual(SkillRepoRef("  JimLiu/baoyu-skills  ")?.slug, "JimLiu/baoyu-skills")
+        XCTAssertEqual(SkillRepoRef("a/b.c_d-e@v1.2_x-y")?.descriptor, "a/b.c_d-e@v1.2_x-y")
+        XCTAssertNil(SkillRepoRef("anthropics/skills")?.branch)
+    }
+
+    func testRejectsMalformedReferences() {
+        let bad = [
+            "", "anthropics", "anthropics/", "/skills", "a/b/c", "a b/c",
+            "a/..", "a/../b", "a/b@..", "a/b@x/y", "a/b@", "a/.hidden",
+            "a/b@.hidden", "own er/repo", "a/b c", "https://github.com/a/b",
+            "a/b#main", "a_b/c", String(repeating: "x", count: 101) + "/repo"
+        ]
+        for raw in bad {
+            XCTAssertNil(SkillRepoRef(raw), "\"\(raw)\" must not parse")
+        }
+    }
+
+    func testBranchCandidatesTryTheRequestedBranchFirstAndNeverRepeat() {
+        XCTAssertEqual(
+            SkillRepoFetcher.branchCandidates(for: SkillRepoRef("a/b@dev")!),
+            ["dev", "main", "master"]
+        )
+        XCTAssertEqual(
+            SkillRepoFetcher.branchCandidates(for: SkillRepoRef("a/b@main")!),
+            ["main", "master"]
+        )
+        XCTAssertEqual(SkillRepoFetcher.branchCandidates(for: SkillRepoRef("a/b")!), ["main", "master"])
+    }
+
+    // MARK: - Scanning
+
+    func testScanFindsNestedSkillsAndStopsDescendingAtSkillMD() throws {
+        let root = workspace.appendingPathComponent("myskills-master", isDirectory: true)
+        try makeSkill(at: root.appendingPathComponent("skills/pdf"), name: "PDF tools", description: "Reads PDFs")
+        try makeSkill(at: root.appendingPathComponent("skills/deep/nested/docx"))
+        // A SKILL.md used as sample material inside another skill must not
+        // become a second skill.
+        try makeSkill(at: root.appendingPathComponent("skills/pdf/examples/sample"))
+        try makeSkill(at: root.appendingPathComponent(".github/hidden"))
+        try write("# readme", to: root.appendingPathComponent("README.md"))
+
+        let ref = SkillRepoRef("acme/myskills@master")!
+        let found = try SkillRepoFetcher().scanSkills(inRepoRoot: root, ref: ref, resolvedBranch: "master")
+
+        XCTAssertEqual(found.map(\.directory), ["docx", "pdf"])
+        let pdf = try XCTUnwrap(found.first { $0.directory == "pdf" })
+        XCTAssertEqual(pdf.id, .repo(owner: "acme", repo: "myskills", directory: "pdf"))
+        XCTAssertEqual(pdf.name, "PDF tools")
+        XCTAssertEqual(pdf.description, "Reads PDFs")
+        XCTAssertEqual(pdf.repoRelativePath, "skills/pdf")
+        XCTAssertEqual(pdf.branch, "master")
+        XCTAssertEqual(
+            pdf.readmeURL?.absoluteString,
+            "https://github.com/acme/myskills/blob/master/skills/pdf/SKILL.md"
+        )
+        XCTAssertEqual(pdf.sourceRoot.lastPathComponent, "pdf")
+    }
+
+    func testScanTreatsARepositoryThatIsItselfASkillAsOne() throws {
+        let root = workspace.appendingPathComponent("solo-main", isDirectory: true)
+        try makeSkill(at: root, name: "Solo")
+
+        let ref = SkillRepoRef("acme/solo")!
+        let found = try SkillRepoFetcher().scanSkills(inRepoRoot: root, ref: ref, resolvedBranch: "main")
+
+        XCTAssertEqual(found.count, 1)
+        XCTAssertEqual(found[0].directory, "solo")
+        XCTAssertEqual(found[0].repoRelativePath, "")
+        XCTAssertEqual(
+            found[0].readmeURL?.absoluteString,
+            "https://github.com/acme/solo/blob/main/SKILL.md"
+        )
+    }
+
+    // MARK: - Downloading
+
+    func testDownloadsAndFallsBackFromMainToMaster() async throws {
+        StubURLProtocol.replies[Self.archive("acme", "myskills", "main")] = .init(statusCode: 404)
+        StubURLProtocol.replies[Self.archive("acme", "myskills", "master")] = .init(body: Self.repositoryZip())
+
+        let fetcher = SkillRepoFetcher(downloader: Self.stubbedDownloader())
+        let (root, branch) = try await fetcher.downloadRepo(
+            SkillRepoRef("acme/myskills")!,
+            into: workspace.appendingPathComponent("dl", isDirectory: true)
+        )
+
+        XCTAssertEqual(branch, "master")
+        XCTAssertEqual(root.lastPathComponent, "myskills-master")
+        let skills = try fetcher.scanSkills(
+            inRepoRoot: root,
+            ref: SkillRepoRef("acme/myskills")!,
+            resolvedBranch: branch
+        )
+        XCTAssertEqual(skills.map(\.directory), ["alpha"])
+        XCTAssertEqual(skills[0].name, "Alpha")
+        XCTAssertEqual(
+            StubURLProtocol.requested,
+            [Self.archive("acme", "myskills", "main"), Self.archive("acme", "myskills", "master")]
+        )
+    }
+
+    func testRefusesARedirectThatLeavesTheAllowedHosts() async {
+        StubURLProtocol.replies[Self.archive("acme", "myskills", "main")] = .init(
+            redirectTo: URL(string: "https://evil.example.com/payload.zip")!
+        )
+        StubURLProtocol.replies["https://evil.example.com/payload.zip"] = .init(body: Self.repositoryZip())
+
+        let fetcher = SkillRepoFetcher(downloader: Self.stubbedDownloader())
+        do {
+            _ = try await fetcher.downloadRepo(
+                SkillRepoRef("acme/myskills@main")!,
+                into: workspace.appendingPathComponent("dl", isDirectory: true)
+            )
+            XCTFail("A redirect off the allowlist must fail the download")
+        } catch let error as BoundedDownloader.DownloadError {
+            XCTAssertEqual(error, .redirectHostNotAllowed("evil.example.com"))
+        } catch {
+            XCTFail("Unexpected error \(error)")
+        }
+        XCTAssertFalse(
+            StubURLProtocol.requested.contains("https://evil.example.com/payload.zip"),
+            "The blocked redirect must never be fetched"
+        )
+    }
+
+    func testFollowsARedirectThatStaysOnTheAllowedHosts() async throws {
+        // github.com legitimately 302s to codeload.github.com.
+        StubURLProtocol.replies[Self.archive("acme", "myskills", "main")] = .init(
+            redirectTo: URL(string: "https://codeload.github.com/acme/myskills/zip/refs/heads/main")!
+        )
+        StubURLProtocol.replies["https://codeload.github.com/acme/myskills/zip/refs/heads/main"] = .init(
+            body: Self.repositoryZip(branch: "main")
+        )
+
+        let fetcher = SkillRepoFetcher(downloader: Self.stubbedDownloader())
+        let (root, branch) = try await fetcher.downloadRepo(
+            SkillRepoRef("acme/myskills@main")!,
+            into: workspace.appendingPathComponent("dl", isDirectory: true)
+        )
+
+        XCTAssertEqual(branch, "main")
+        XCTAssertEqual(root.lastPathComponent, "myskills-main")
+    }
+
+    func testReportsBranchNotFoundWhenNoCandidateAnswers() async {
+        let fetcher = SkillRepoFetcher(downloader: Self.stubbedDownloader())
+        do {
+            _ = try await fetcher.downloadRepo(
+                SkillRepoRef("acme/ghost")!,
+                into: workspace.appendingPathComponent("dl", isDirectory: true)
+            )
+            XCTFail("Expected branchNotFound")
+        } catch let error as SkillRepoError {
+            XCTAssertEqual(error, .branchNotFound(slug: "acme/ghost", tried: ["main", "master"]))
+        } catch {
+            XCTFail("Unexpected error \(error)")
+        }
+    }
+
+    func testRejectsAnArchiveWithoutASingleTopLevelDirectory() async {
+        var builder = RawZipBuilder()
+        builder.entries = [.file("a/SKILL.md", "---\n"), .file("b/SKILL.md", "---\n")]
+        StubURLProtocol.replies[Self.archive("acme", "flat", "main")] = .init(body: builder.build())
+
+        let fetcher = SkillRepoFetcher(downloader: Self.stubbedDownloader())
+        do {
+            _ = try await fetcher.downloadRepo(
+                SkillRepoRef("acme/flat@main")!,
+                into: workspace.appendingPathComponent("dl", isDirectory: true)
+            )
+            XCTFail("Expected malformedArchive")
+        } catch let error as SkillRepoError {
+            XCTAssertEqual(
+                error,
+                .malformedArchive("expected one top-level directory, found 2")
+            )
+        } catch {
+            XCTFail("Unexpected error \(error)")
+        }
+    }
+
+    // MARK: - BoundedDownloader
+
+    func testDownloaderRefusesPlainHTTPAndForeignHostsBeforeTheNetwork() async {
+        let downloader = Self.stubbedDownloader()
+        let destination = workspace.appendingPathComponent("out.zip")
+
+        do {
+            try await downloader.download(
+                from: URL(string: "http://github.com/a/b.zip")!,
+                to: destination,
+                maxBytes: 1024,
+                timeout: 5,
+                allowedHosts: SkillRepoFetcher.allowedHosts
+            )
+            XCTFail("Expected insecureScheme")
+        } catch {
+            XCTAssertEqual(error as? BoundedDownloader.DownloadError, .insecureScheme("http"))
+        }
+
+        do {
+            try await downloader.download(
+                from: URL(string: "https://example.com/a/b.zip")!,
+                to: destination,
+                maxBytes: 1024,
+                timeout: 5,
+                allowedHosts: SkillRepoFetcher.allowedHosts
+            )
+            XCTFail("Expected hostNotAllowed")
+        } catch {
+            XCTAssertEqual(error as? BoundedDownloader.DownloadError, .hostNotAllowed("example.com"))
+        }
+        XCTAssertTrue(StubURLProtocol.requested.isEmpty)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: destination.path))
+    }
+
+    func testDownloaderStopsMidStreamOnAnUndeclaredOversizeBody() async {
+        // No Content-Length, so only the running byte count can catch this.
+        StubURLProtocol.replies["https://github.com/a/b.zip"] = .init(
+            body: Data(repeating: 0x41, count: 300_000),
+            includeContentLength: false
+        )
+        let destination = workspace.appendingPathComponent("out.zip")
+
+        do {
+            try await Self.stubbedDownloader().download(
+                from: URL(string: "https://github.com/a/b.zip")!,
+                to: destination,
+                maxBytes: 4_096,
+                timeout: 5,
+                allowedHosts: ["github.com"]
+            )
+            XCTFail("Expected tooLarge")
+        } catch {
+            XCTAssertEqual(error as? BoundedDownloader.DownloadError, .tooLarge(limit: 4_096))
+        }
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: destination.path),
+            "The partial download must be deleted"
+        )
+    }
+
+    func testDownloaderRefusesADeclaredOversizeBodyBeforeReadingIt() async {
+        StubURLProtocol.replies["https://github.com/a/b.zip"] = .init(
+            body: Data(repeating: 0x41, count: 300_000)
+        )
+        do {
+            try await Self.stubbedDownloader().download(
+                from: URL(string: "https://github.com/a/b.zip")!,
+                to: workspace.appendingPathComponent("out.zip"),
+                maxBytes: 1_024,
+                timeout: 5,
+                allowedHosts: ["github.com"]
+            )
+            XCTFail("Expected tooLarge")
+        } catch {
+            XCTAssertEqual(error as? BoundedDownloader.DownloadError, .tooLarge(limit: 1_024))
+        }
+    }
+
+    func testDownloaderWritesTheBodyItWasGiven() async throws {
+        let payload = Data(repeating: 0x5A, count: 12_345)
+        StubURLProtocol.replies["https://github.com/a/b.zip"] = .init(body: payload)
+        let destination = workspace.appendingPathComponent("nested/out.zip")
+
+        try await Self.stubbedDownloader().download(
+            from: URL(string: "https://github.com/a/b.zip")!,
+            to: destination,
+            maxBytes: 1_000_000,
+            timeout: 5,
+            allowedHosts: ["github.com"]
+        )
+
+        XCTAssertEqual(try Data(contentsOf: destination), payload)
+    }
+
+    // MARK: - Helpers
+
+    private static func stubbedDownloader() -> BoundedDownloader {
+        BoundedDownloader {
+            let configuration = URLSessionConfiguration.ephemeral
+            configuration.protocolClasses = [StubURLProtocol.self]
+            return configuration
+        }
+    }
+
+    private static func archive(_ owner: String, _ repo: String, _ branch: String) -> String {
+        SkillRepoFetcher.archiveURL(owner: owner, repo: repo, branch: branch)!.absoluteString
+    }
+
+    /// A zipball shaped the way GitHub ships one: everything under a single
+    /// `<repo>-<branch>` directory.
+    private static func repositoryZip(branch: String = "master") -> Data {
+        var builder = RawZipBuilder()
+        builder.entries = [
+            .directory("myskills-\(branch)"),
+            .file("myskills-\(branch)/README.md", "# myskills"),
+            .file("myskills-\(branch)/skills/alpha/SKILL.md", "---\nname: Alpha\n---\n# Alpha\n"),
+            .file("myskills-\(branch)/skills/alpha/ref.md", "reference")
+        ]
+        return builder.build()
+    }
+
+    private func makeSkill(at url: URL, name: String? = nil, description: String? = nil) throws {
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        var frontmatter = "---\nname: \(name ?? url.lastPathComponent)\n"
+        if let description { frontmatter += "description: \(description)\n" }
+        frontmatter += "---\n\n# \(url.lastPathComponent)\n"
+        try write(frontmatter, to: url.appendingPathComponent("SKILL.md"))
+    }
+
+    private func write(_ contents: String, to url: URL) throws {
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try contents.write(to: url, atomically: true, encoding: .utf8)
+    }
+}
+
+/// Serves canned replies keyed by absolute URL, including real redirects — the
+/// only way to drive `URLSession`'s redirect delegate from a test.
+final class StubURLProtocol: URLProtocol {
+    struct Reply {
+        var statusCode = 200
+        var body: Data?
+        var redirectTo: URL?
+        var includeContentLength = true
+    }
+
+    nonisolated(unsafe) static var replies: [String: Reply] = [:]
+    nonisolated(unsafe) static var requested: [String] = []
+
+    static func reset() {
+        replies = [:]
+        requested = []
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+    override func stopLoading() {}
+
+    override func startLoading() {
+        guard let url = request.url else {
+            client?.urlProtocol(self, didFailWithError: URLError(.badURL))
+            return
+        }
+        Self.requested.append(url.absoluteString)
+        let reply = Self.replies[url.absoluteString] ?? Reply(statusCode: 404)
+
+        if let redirect = reply.redirectTo {
+            let response = HTTPURLResponse(
+                url: url,
+                statusCode: 302,
+                httpVersion: "HTTP/1.1",
+                headerFields: ["Location": redirect.absoluteString]
+            )!
+            var followUp = URLRequest(url: redirect)
+            followUp.httpMethod = "GET"
+            client?.urlProtocol(self, wasRedirectedTo: followUp, redirectResponse: response)
+            return
+        }
+
+        var headers: [String: String] = [:]
+        if reply.includeContentLength {
+            headers["Content-Length"] = String(reply.body?.count ?? 0)
+        }
+        let response = HTTPURLResponse(
+            url: url,
+            statusCode: reply.statusCode,
+            httpVersion: "HTTP/1.1",
+            headerFields: headers
+        )!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        if let body = reply.body, reply.statusCode == 200 {
+            // Delivered in slices so the streaming byte cap has something to
+            // count rather than one all-or-nothing chunk.
+            var offset = 0
+            while offset < body.count {
+                let end = min(offset + 32_768, body.count)
+                client?.urlProtocol(self, didLoad: body.subdata(in: offset..<end))
+                offset = end
+            }
+        }
+        client?.urlProtocolDidFinishLoading(self)
+    }
+}

--- a/Tests/VibeBarCoreTests/SkillSyncEngineTests.swift
+++ b/Tests/VibeBarCoreTests/SkillSyncEngineTests.swift
@@ -1,0 +1,334 @@
+import XCTest
+@testable import VibeBarCore
+
+final class SkillSyncEngineTests: XCTestCase {
+    func testAutoOverRealDirectoryReplacesItWithACopyAndRecordsTheHash() throws {
+        let home = try SkillTestHome()
+        let source = try home.makeSSOTSkill("alpha", extraFiles: ["ref.md": "fresh"])
+        let destination = home.appDirectory(.claude).appendingPathComponent("alpha")
+        try home.write("stale", to: destination.appendingPathComponent("ref.md"))
+        try home.write("leftover", to: destination.appendingPathComponent("orphan.md"))
+
+        let engine = SkillSyncEngine(homeDirectory: home.path)
+        let materialization = try engine.materialize(
+            skillDirectoryName: "alpha",
+            into: .claude,
+            method: .auto
+        )
+
+        XCTAssertEqual(materialization.method, .copy)
+        XCTAssertFalse(materialization.adopted)
+        XCTAssertEqual(SkillFileSystem.kind(of: destination), .directory)
+        XCTAssertEqual(home.contents(of: destination.appendingPathComponent("ref.md")), "fresh")
+        // Replaced as a unit, not merged into: the stale file is gone.
+        XCTAssertFalse(home.exists(destination.appendingPathComponent("orphan.md")))
+        XCTAssertEqual(materialization.contentHashAtCopy, try SkillDirectoryHasher.hash(directory: destination))
+        XCTAssertEqual(materialization.contentHashAtCopy, try SkillDirectoryHasher.hash(directory: source))
+        // No staging directory survives the swap.
+        let leftovers = try FileManager.default
+            .contentsOfDirectory(atPath: home.appDirectory(.claude).path)
+            .filter { $0.hasPrefix(".alpha.tmp-") }
+        XCTAssertEqual(leftovers, [])
+    }
+
+    func testAutoOverStaleSymlinkRelinksIntoTheSSOT() throws {
+        let home = try SkillTestHome()
+        try home.makeSSOTSkill("alpha")
+        let elsewhere = try home.makeSkillDirectory(at: home.url.appendingPathComponent("elsewhere/alpha"))
+        try home.makeSymlink("alpha", in: .claude, rawTarget: elsewhere.path)
+
+        let engine = SkillSyncEngine(homeDirectory: home.path)
+        let materialization = try engine.materialize(
+            skillDirectoryName: "alpha",
+            into: .claude,
+            method: .auto
+        )
+
+        XCTAssertEqual(materialization.method, .symlink)
+        let destination = home.appDirectory(.claude).appendingPathComponent("alpha")
+        XCTAssertEqual(SkillFileSystem.kind(of: destination), .symlink)
+        XCTAssertEqual(
+            try FileManager.default.destinationOfSymbolicLink(atPath: destination.path),
+            home.ssot.appendingPathComponent("alpha").path
+        )
+        // The old target is untouched — we unlinked, never followed.
+        XCTAssertTrue(home.exists(elsewhere.appendingPathComponent("SKILL.md")))
+    }
+
+    func testSymlinkMethodCreatesAnAbsoluteLinkToTheSSOT() throws {
+        let home = try SkillTestHome()
+        try home.makeSSOTSkill("alpha")
+
+        let engine = SkillSyncEngine(homeDirectory: home.path)
+        let materialization = try engine.materialize(
+            skillDirectoryName: "alpha",
+            into: .codex,
+            method: .symlink
+        )
+
+        XCTAssertEqual(materialization.method, .symlink)
+        XCTAssertNil(materialization.contentHashAtCopy)
+        let target = try FileManager.default.destinationOfSymbolicLink(
+            atPath: home.appDirectory(.codex).appendingPathComponent("alpha").path
+        )
+        XCTAssertTrue(target.hasPrefix("/"))
+        XCTAssertEqual(target, home.ssot.appendingPathComponent("alpha").path)
+    }
+
+    func testSymlinkMethodRefusesAForeignDirectoryButReplacesAFaithfulCopy() throws {
+        let home = try SkillTestHome()
+        try home.makeSSOTSkill("alpha", extraFiles: ["ref.md": "fresh"])
+        let destination = home.appDirectory(.claude).appendingPathComponent("alpha")
+        try home.makeSkillDirectory(at: destination, extraFiles: ["ref.md": "hand-edited"])
+
+        let engine = SkillSyncEngine(homeDirectory: home.path)
+        XCTAssertThrowsError(
+            try engine.materialize(skillDirectoryName: "alpha", into: .claude, method: .symlink)
+        ) { error in
+            XCTAssertEqual(error as? SkillError, .directoryConflict("alpha"))
+        }
+        XCTAssertEqual(SkillFileSystem.kind(of: destination), .directory)
+        XCTAssertEqual(home.contents(of: destination.appendingPathComponent("ref.md")), "hand-edited")
+
+        let copied = try engine.materialize(skillDirectoryName: "alpha", into: .claude, method: .copy)
+        XCTAssertEqual(copied.method, .copy)
+        let linked = try engine.materialize(
+            skillDirectoryName: "alpha",
+            into: .claude,
+            method: .symlink,
+            recorded: copied
+        )
+        XCTAssertEqual(linked.method, .symlink)
+        XCTAssertEqual(SkillFileSystem.kind(of: destination), .symlink)
+    }
+
+    func testMaterializeRefusesASourceWithoutSkillMarkdown() throws {
+        let home = try SkillTestHome()
+        try home.makeDirectory(home.ssot.appendingPathComponent("not-a-skill"))
+
+        let engine = SkillSyncEngine(homeDirectory: home.path)
+        XCTAssertThrowsError(
+            try engine.materialize(skillDirectoryName: "not-a-skill", into: .claude, method: .auto)
+        ) { error in
+            XCTAssertEqual(error as? SkillError, .missingSkillMD("not-a-skill"))
+        }
+        XCTAssertFalse(home.exists(home.appDirectory(.claude).appendingPathComponent("not-a-skill")))
+    }
+
+    func testMaterializeRefusesAMissingSource() throws {
+        let home = try SkillTestHome()
+        let engine = SkillSyncEngine(homeDirectory: home.path)
+        XCTAssertThrowsError(
+            try engine.materialize(skillDirectoryName: "ghost", into: .claude, method: .auto)
+        ) { error in
+            XCTAssertEqual(error as? SkillError, .sourceDirectoryMissing("ghost"))
+        }
+    }
+
+    func testAntigravityDirectoryIsCreatedLazilyAndOnlyAtTheLeaf() throws {
+        let home = try SkillTestHome()
+        try home.makeSSOTSkill("alpha")
+        let gemini = home.url.appendingPathComponent(".gemini", isDirectory: true)
+        try home.write("{}", to: gemini.appendingPathComponent("settings.json"))
+
+        XCTAssertFalse(home.exists(gemini.appendingPathComponent("config")))
+        let engine = SkillSyncEngine(homeDirectory: home.path)
+        try engine.materialize(skillDirectoryName: "alpha", into: .antigravity, method: .symlink)
+
+        XCTAssertEqual(
+            SkillFileSystem.kind(of: gemini.appendingPathComponent("config/skills")),
+            .directory
+        )
+        // AntiGravity's root is ~/.gemini/config — the Gemini CLI's own
+        // ~/.gemini/skills must not be conjured up alongside it, and the
+        // pre-existing sibling file is untouched.
+        XCTAssertFalse(home.exists(gemini.appendingPathComponent("skills")))
+        XCTAssertEqual(home.contents(of: gemini.appendingPathComponent("settings.json")), "{}")
+        XCTAssertEqual(
+            try FileManager.default.contentsOfDirectory(atPath: gemini.path).sorted(),
+            ["config", "settings.json"]
+        )
+        XCTAssertEqual(
+            try FileManager.default.contentsOfDirectory(atPath: gemini.appendingPathComponent("config").path),
+            ["skills"]
+        )
+    }
+
+    func testTraversalNamesAreRejectedBeforeAnyFilesystemWrite() throws {
+        let home = try SkillTestHome()
+        let engine = SkillSyncEngine(homeDirectory: home.path)
+
+        for name in ["../evil", "..", "a/b", ".hidden"] {
+            XCTAssertThrowsError(
+                try engine.materialize(skillDirectoryName: name, into: .claude, method: .auto)
+            ) { error in
+                XCTAssertEqual(error as? SkillError, .invalidDirectoryName(name))
+            }
+            XCTAssertThrowsError(
+                try engine.unmaterialize(skillDirectoryName: name, from: .claude, recorded: nil)
+            ) { error in
+                XCTAssertEqual(error as? SkillError, .invalidDirectoryName(name))
+            }
+        }
+        XCTAssertFalse(home.exists(home.appDirectory(.claude)))
+    }
+
+    func testWriteRootsCoverTheSSOTAndEveryAppDirectoryOnly() throws {
+        let home = try SkillTestHome()
+        XCTAssertEqual(SkillAppCatalog.allowedWriteRoots(homeDirectory: home.path).count, 8)
+        XCTAssertTrue(SkillAppCatalog.isWriteAllowed(
+            home.ssot.appendingPathComponent("alpha"),
+            homeDirectory: home.path
+        ))
+        XCTAssertTrue(SkillAppCatalog.isWriteAllowed(
+            home.appDirectory(.opencode).appendingPathComponent("alpha"),
+            homeDirectory: home.path
+        ))
+        XCTAssertFalse(SkillAppCatalog.isWriteAllowed(
+            home.appDirectory(.claude).appendingPathComponent("../../.ssh/authorized_keys"),
+            homeDirectory: home.path
+        ))
+        XCTAssertFalse(SkillAppCatalog.isWriteAllowed(
+            home.url.appendingPathComponent(".claude/settings.json"),
+            homeDirectory: home.path
+        ))
+    }
+
+    func testUnmaterializeRemovesAnSSOTSymlinkAndIsIdempotent() throws {
+        let home = try SkillTestHome()
+        try home.makeSSOTSkill("alpha")
+        let engine = SkillSyncEngine(homeDirectory: home.path)
+        let materialization = try engine.materialize(
+            skillDirectoryName: "alpha",
+            into: .claude,
+            method: .symlink
+        )
+
+        XCTAssertTrue(try engine.unmaterialize(
+            skillDirectoryName: "alpha",
+            from: .claude,
+            recorded: materialization
+        ))
+        XCTAssertFalse(home.exists(home.appDirectory(.claude).appendingPathComponent("alpha")))
+        // The SSOT copy is never followed into.
+        XCTAssertTrue(home.exists(home.ssot.appendingPathComponent("alpha/SKILL.md")))
+        XCTAssertTrue(try engine.unmaterialize(
+            skillDirectoryName: "alpha",
+            from: .claude,
+            recorded: materialization
+        ))
+    }
+
+    func testUnmaterializeLeavesALinkPointingOutsideTheSSOT() throws {
+        let home = try SkillTestHome()
+        try home.makeSSOTSkill("alpha")
+        let elsewhere = try home.makeSkillDirectory(at: home.url.appendingPathComponent("elsewhere/alpha"))
+        try home.makeSymlink("alpha", in: .claude, rawTarget: elsewhere.path)
+
+        let engine = SkillSyncEngine(homeDirectory: home.path)
+        XCTAssertFalse(try engine.unmaterialize(
+            skillDirectoryName: "alpha",
+            from: .claude,
+            recorded: SkillMaterialization(method: .symlink)
+        ))
+        XCTAssertEqual(
+            SkillFileSystem.kind(of: home.appDirectory(.claude).appendingPathComponent("alpha")),
+            .symlink
+        )
+    }
+
+    func testUnmaterializeResolvesRelativeLinksIntoTheSSOT() throws {
+        let home = try SkillTestHome()
+        try home.makeSSOTSkill("alpha")
+        try home.makeSymlink("alpha", in: .claude, rawTarget: "../../.agents/skills/alpha")
+
+        let engine = SkillSyncEngine(homeDirectory: home.path)
+        XCTAssertTrue(try engine.unmaterialize(
+            skillDirectoryName: "alpha",
+            from: .claude,
+            recorded: nil
+        ))
+        XCTAssertFalse(home.exists(home.appDirectory(.claude).appendingPathComponent("alpha")))
+        XCTAssertTrue(home.exists(home.ssot.appendingPathComponent("alpha/SKILL.md")))
+    }
+
+    func testUnmaterializeLeavesAForeignDirectoryAlone() throws {
+        let home = try SkillTestHome()
+        try home.makeSSOTSkill("alpha")
+        let destination = home.appDirectory(.claude).appendingPathComponent("alpha")
+        try home.makeSkillDirectory(at: destination, extraFiles: ["ref.md": "hand-written"])
+
+        let engine = SkillSyncEngine(homeDirectory: home.path)
+        XCTAssertFalse(try engine.unmaterialize(
+            skillDirectoryName: "alpha",
+            from: .claude,
+            recorded: nil
+        ))
+        XCTAssertEqual(home.contents(of: destination.appendingPathComponent("ref.md")), "hand-written")
+    }
+
+    func testUnmaterializeRemovesAnUnmodifiedCopyButKeepsAModifiedOne() throws {
+        let home = try SkillTestHome()
+        try home.makeSSOTSkill("alpha", extraFiles: ["ref.md": "fresh"])
+        let engine = SkillSyncEngine(homeDirectory: home.path)
+        let materialization = try engine.materialize(
+            skillDirectoryName: "alpha",
+            into: .grok,
+            method: .copy
+        )
+        let destination = home.appDirectory(.grok).appendingPathComponent("alpha")
+
+        try home.write("edited by the user", to: destination.appendingPathComponent("ref.md"))
+        XCTAssertFalse(try engine.unmaterialize(
+            skillDirectoryName: "alpha",
+            from: .grok,
+            recorded: materialization
+        ))
+        XCTAssertEqual(SkillFileSystem.kind(of: destination), .directory)
+
+        try home.write("fresh", to: destination.appendingPathComponent("ref.md"))
+        XCTAssertTrue(try engine.unmaterialize(
+            skillDirectoryName: "alpha",
+            from: .grok,
+            recorded: materialization
+        ))
+        XCTAssertFalse(home.exists(destination))
+    }
+
+    func testUnmaterializeKeepsACopyItWasNeverToldAbout() throws {
+        let home = try SkillTestHome()
+        try home.makeSSOTSkill("alpha")
+        let engine = SkillSyncEngine(homeDirectory: home.path)
+        try engine.materialize(skillDirectoryName: "alpha", into: .hermes, method: .copy)
+
+        XCTAssertFalse(try engine.unmaterialize(
+            skillDirectoryName: "alpha",
+            from: .hermes,
+            recorded: SkillMaterialization(method: .symlink)
+        ))
+        XCTAssertEqual(
+            SkillFileSystem.kind(of: home.appDirectory(.hermes).appendingPathComponent("alpha")),
+            .directory
+        )
+    }
+
+    func testAdoptionStateRecognizesSSOTLinksOnly() throws {
+        let home = try SkillTestHome()
+        try home.makeSSOTSkill("alpha")
+        try home.makeSSOTSkill("beta")
+        try home.makeAbsoluteSymlink("alpha", in: .claude, toSSOT: "alpha")
+        try home.makeSymlink("beta", in: .claude, rawTarget: "../../.agents/skills/beta")
+        try home.makeSkillDirectory(at: home.appDirectory(.gemini).appendingPathComponent("alpha"))
+        let elsewhere = try home.makeSkillDirectory(at: home.url.appendingPathComponent("elsewhere/gamma"))
+        try home.makeSymlink("gamma", in: .grok, rawTarget: elsewhere.path)
+
+        let engine = SkillSyncEngine(homeDirectory: home.path)
+        let adopted = engine.adoptionState(skillDirectoryName: "alpha", app: .claude)
+        XCTAssertEqual(adopted?.method, .symlink)
+        XCTAssertEqual(adopted?.adopted, true)
+        XCTAssertEqual(engine.adoptionState(skillDirectoryName: "beta", app: .claude)?.method, .symlink)
+        XCTAssertNil(engine.adoptionState(skillDirectoryName: "alpha", app: .gemini))
+        XCTAssertNil(engine.adoptionState(skillDirectoryName: "gamma", app: .grok))
+        XCTAssertNil(engine.adoptionState(skillDirectoryName: "alpha", app: .codex))
+    }
+}

--- a/Tests/VibeBarCoreTests/SkillZipFixtures.swift
+++ b/Tests/VibeBarCoreTests/SkillZipFixtures.swift
@@ -1,0 +1,192 @@
+import Compression
+import Foundation
+@testable import VibeBarCore
+
+/// ZIP fixtures for the archive tests.
+///
+/// Two ways to get an archive, both used on purpose:
+///
+/// 1. `/usr/bin/zip` — a real encoder, so the reader is checked against bytes
+///    it did not produce (deflate streams, directory entries, the flags and
+///    Unix attributes a genuine tool writes). `Process` is fine in tests; the
+///    product code has no way to reach a shell.
+/// 2. `RawZipBuilder` — a hand-written encoder for the archives no sane tool
+///    will emit: a `..` in an entry name, a lying uncompressed size, a bogus
+///    entry count in the end-of-central-directory record, a compression method
+///    that does not exist. Deterministic, byte-for-byte, and no dependency on
+///    what version of `zip` a machine happens to ship.
+enum SkillZipFixtures {
+    /// Zips `name` (a directory in `parent`) into `parent/<name>.zip` and
+    /// returns the archive URL. `-X` keeps extra attributes out so the
+    /// extraction compares cleanly.
+    @discardableResult
+    static func zipDirectory(
+        named name: String,
+        in parent: URL,
+        extraArguments: [String] = []
+    ) throws -> URL {
+        let archive = parent.appendingPathComponent("\(name).zip")
+        try? FileManager.default.removeItem(at: archive)
+        let status = try run(
+            "/usr/bin/zip",
+            arguments: ["-r", "-X", "-q"] + extraArguments + [archive.lastPathComponent, name],
+            in: parent
+        )
+        guard status == 0 else {
+            throw NSError(domain: "SkillZipFixtures", code: Int(status), userInfo: [
+                NSLocalizedDescriptionKey: "/usr/bin/zip exited with \(status)"
+            ])
+        }
+        return archive
+    }
+
+    @discardableResult
+    static func run(_ tool: String, arguments: [String], in directory: URL) throws -> Int32 {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: tool)
+        process.arguments = arguments
+        process.currentDirectoryURL = directory
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = FileHandle.nullDevice
+        try process.run()
+        process.waitUntilExit()
+        return process.terminationStatus
+    }
+
+    /// Raw DEFLATE, the same stream ZIP method 8 stores.
+    static func rawDeflate(_ payload: Data) -> Data {
+        let capacity = payload.count + 64 * 1024
+        var output = Data(count: capacity)
+        let produced: Int = output.withUnsafeMutableBytes { destination in
+            payload.withUnsafeBytes { source in
+                guard
+                    let destinationBase = destination.bindMemory(to: UInt8.self).baseAddress,
+                    let sourceBase = source.bindMemory(to: UInt8.self).baseAddress
+                else { return 0 }
+                return compression_encode_buffer(
+                    destinationBase,
+                    capacity,
+                    sourceBase,
+                    payload.count,
+                    nil,
+                    COMPRESSION_ZLIB
+                )
+            }
+        }
+        output.removeSubrange(produced...)
+        return output
+    }
+}
+
+/// Minimal ZIP writer with every field overridable, so a test can produce
+/// exactly the malformed archive it wants to see refused.
+struct RawZipBuilder {
+    struct Entry {
+        var name: String
+        /// Overrides the UTF-8 encoding of `name` — for invalid-UTF-8 tests.
+        var rawName: Data?
+        var payload = Data()
+        var method: UInt16 = 0
+        /// Bit 11 marks the name as UTF-8, which is what modern encoders set.
+        var flags: UInt16 = 0x0800
+        /// High byte 3 = Unix, which is what makes the mode bits meaningful.
+        var versionMadeBy: UInt16 = 0x031E
+        var externalAttributes: UInt32 = UInt32(0o100_644) << 16
+        var crc: UInt32?
+        var declaredUncompressedSize: UInt32?
+
+        static func file(_ name: String, _ contents: String) -> Entry {
+            Entry(name: name, payload: Data(contents.utf8))
+        }
+
+        static func directory(_ name: String) -> Entry {
+            Entry(
+                name: name.hasSuffix("/") ? name : name + "/",
+                externalAttributes: UInt32(0o040_755) << 16
+            )
+        }
+
+        static func symlink(_ name: String, target: String) -> Entry {
+            Entry(
+                name: name,
+                payload: Data(target.utf8),
+                externalAttributes: (UInt32(S_IFLNK) | 0o777) << 16
+            )
+        }
+
+        /// A deflated entry whose header claims a different uncompressed size.
+        static func deflated(_ name: String, payload: Data, declaredSize: UInt32?) -> Entry {
+            Entry(
+                name: name,
+                payload: SkillZipFixtures.rawDeflate(payload),
+                method: 8,
+                crc: CRC32.checksum(payload),
+                declaredUncompressedSize: declaredSize
+            )
+        }
+    }
+
+    var entries: [Entry] = []
+    /// Lets a test claim more entries than it wrote.
+    var entryCountOverride: UInt16?
+
+    func build() -> Data {
+        var body = Data()
+        var central = Data()
+        for entry in entries {
+            let nameBytes = entry.rawName ?? Data(entry.name.utf8)
+            let offset = UInt32(body.count)
+            let crc = entry.crc ?? CRC32.checksum(entry.payload)
+            let compressedSize = UInt32(entry.payload.count)
+            let uncompressedSize = entry.declaredUncompressedSize ?? compressedSize
+
+            body += Self.u32(0x0403_4b50)
+            body += Self.u16(20) + Self.u16(entry.flags) + Self.u16(entry.method)
+            body += Self.u16(0) + Self.u16(0x21)
+            body += Self.u32(crc) + Self.u32(compressedSize) + Self.u32(uncompressedSize)
+            body += Self.u16(UInt16(nameBytes.count)) + Self.u16(0)
+            body += nameBytes
+            body += entry.payload
+
+            central += Self.u32(0x0201_4b50)
+            central += Self.u16(entry.versionMadeBy) + Self.u16(20)
+            central += Self.u16(entry.flags) + Self.u16(entry.method)
+            central += Self.u16(0) + Self.u16(0x21)
+            central += Self.u32(crc) + Self.u32(compressedSize) + Self.u32(uncompressedSize)
+            central += Self.u16(UInt16(nameBytes.count)) + Self.u16(0) + Self.u16(0)
+            central += Self.u16(0) + Self.u16(0) + Self.u32(entry.externalAttributes)
+            central += Self.u32(offset)
+            central += nameBytes
+        }
+
+        let centralOffset = UInt32(body.count)
+        let count = entryCountOverride ?? UInt16(entries.count)
+        var archive = body
+        archive += central
+        archive += Self.u32(0x0605_4b50)
+        archive += Self.u16(0) + Self.u16(0)
+        archive += Self.u16(count) + Self.u16(count)
+        archive += Self.u32(UInt32(central.count)) + Self.u32(centralOffset)
+        archive += Self.u16(0)
+        return archive
+    }
+
+    @discardableResult
+    func write(to url: URL) throws -> URL {
+        try build().write(to: url)
+        return url
+    }
+
+    private static func u16(_ value: UInt16) -> Data {
+        Data([UInt8(value & 0xFF), UInt8((value >> 8) & 0xFF)])
+    }
+
+    private static func u32(_ value: UInt32) -> Data {
+        Data([
+            UInt8(value & 0xFF),
+            UInt8((value >> 8) & 0xFF),
+            UInt8((value >> 16) & 0xFF),
+            UInt8((value >> 24) & 0xFF)
+        ])
+    }
+}

--- a/Tests/VibeBarCoreTests/SkillsSearchClientTests.swift
+++ b/Tests/VibeBarCoreTests/SkillsSearchClientTests.swift
@@ -1,0 +1,142 @@
+import XCTest
+@testable import VibeBarCore
+
+/// skills.sh is a third-party index whose schema is not ours, so the tests are
+/// mostly about tolerance: unknown keys, a missing `name`, an install count
+/// that arrives as a string. The one strict rule is `source` — it becomes a
+/// download URL, so a row that cannot produce a valid `owner/repo` is dropped.
+final class SkillsSearchClientTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        StubURLProtocol.reset()
+    }
+
+    override func tearDown() {
+        StubURLProtocol.reset()
+        super.tearDown()
+    }
+
+    private func makeClient() -> SkillsSearchClient {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [StubURLProtocol.self]
+        return SkillsSearchClient(session: URLSession(configuration: configuration))
+    }
+
+    private func stub(query: String, limit: Int = SkillsSearchClient.defaultLimit, body: Data, status: Int = 200) {
+        let url = SkillsSearchClient.searchURL(query: query, limit: limit)!
+        StubURLProtocol.replies[url.absoluteString] = .init(statusCode: status, body: body)
+    }
+
+    func testBuildsAnEncodedSearchURL() throws {
+        let url = try XCTUnwrap(SkillsSearchClient.searchURL(query: "pdf tools & more", limit: 5))
+        XCTAssertEqual(url.host, "skills.sh")
+        XCTAssertEqual(url.path, "/api/search")
+        let query = try XCTUnwrap(url.query)
+        XCTAssertTrue(query.contains("q=pdf%20tools%20%26%20more") || query.contains("q=pdf+tools+%26+more"), query)
+        XCTAssertTrue(query.contains("limit=5"))
+
+        // Out-of-range limits are clamped rather than sent through.
+        XCTAssertTrue(SkillsSearchClient.searchURL(query: "x", limit: 0)!.query!.contains("limit=1"))
+        XCTAssertTrue(SkillsSearchClient.searchURL(query: "x", limit: 5_000)!.query!.contains("limit=100"))
+    }
+
+    func testParsesACannedResponse() async throws {
+        let body = Data("""
+        {
+          "query": "pdf",
+          "count": 3,
+          "skills": [
+            {"id": "pdf", "name": "PDF Tools", "installs": 4210, "source": "anthropics/skills"},
+            {"skillId": "docx", "installs": "77", "source": "ComposioHQ/awesome-claude-skills@master"},
+            {"id": "brand-new", "name": "Brand New", "source": "JimLiu/baoyu-skills", "unknownKey": {"a": 1}}
+          ]
+        }
+        """.utf8)
+        stub(query: "pdf", body: body)
+
+        let results = try await makeClient().search("pdf")
+
+        XCTAssertEqual(results.map(\.name), ["PDF Tools", "docx", "Brand New"])
+        XCTAssertEqual(results[0].installs, 4_210)
+        XCTAssertEqual(results[0].repo, SkillRepoRef("anthropics/skills"))
+        XCTAssertEqual(results[1].installs, 77, "An install count sent as a string is still a number")
+        XCTAssertEqual(results[1].repo.branch, "master")
+        XCTAssertNil(results[2].installs)
+    }
+
+    func testDropsRowsWhoseSourceIsUnusable() async throws {
+        let body = Data("""
+        {
+          "skills": [
+            {"name": "good", "source": "acme/skills"},
+            {"name": "no source"},
+            {"name": "bad slug", "source": "not-a-repo"},
+            {"name": "too deep", "source": "a/b/c"},
+            {"name": "traversal", "source": "a/../b"},
+            {"name": "url", "source": "https://github.com/acme/skills"},
+            {"name": "", "source": "acme/other"},
+            "not even an object",
+            {"source": "acme/nameless"}
+          ]
+        }
+        """.utf8)
+        stub(query: "junk", body: body)
+
+        let results = try await makeClient().search("junk")
+
+        XCTAssertEqual(results.map(\.name), ["good"])
+    }
+
+    func testTreatsAResponseWithoutSkillsAsEmpty() async throws {
+        stub(query: "none", body: Data(#"{"query":"none","count":0}"#.utf8))
+        let results = try await makeClient().search("none")
+        XCTAssertTrue(results.isEmpty)
+    }
+
+    func testRejectsAnOversizedResponse() async {
+        var body = Data(#"{"skills":[{"name":"x","source":"a/b"}],"padding":""#.utf8)
+        body.append(Data(repeating: 0x20, count: SkillsSearchClient.maxResponseBytes + 1))
+        body.append(Data(#""}"#.utf8))
+        stub(query: "big", body: body)
+
+        do {
+            _ = try await makeClient().search("big")
+            XCTFail("Expected the response cap to reject this")
+        } catch {
+            XCTAssertEqual(
+                error as? HTTPResponseLimit.BoundedError,
+                .responseTooLarge(limit: SkillsSearchClient.maxResponseBytes)
+            )
+        }
+    }
+
+    func testReportsAnHTTPFailure() async {
+        stub(query: "boom", body: Data(), status: 503)
+        do {
+            _ = try await makeClient().search("boom")
+            XCTFail("Expected httpStatus")
+        } catch {
+            XCTAssertEqual(error as? SkillsSearchError, .httpStatus(503))
+        }
+    }
+
+    func testRejectsAnEmptyQueryWithoutHittingTheNetwork() async {
+        do {
+            _ = try await makeClient().search("   \n ")
+            XCTFail("Expected emptyQuery")
+        } catch {
+            XCTAssertEqual(error as? SkillsSearchError, .emptyQuery)
+        }
+        XCTAssertTrue(StubURLProtocol.requested.isEmpty)
+    }
+
+    func testReportsAMalformedBody() async {
+        stub(query: "garbage", body: Data("<html>not json</html>".utf8))
+        do {
+            _ = try await makeClient().search("garbage")
+            XCTFail("Expected malformedResponse")
+        } catch {
+            XCTAssertEqual(error as? SkillsSearchError, .malformedResponse)
+        }
+    }
+}

--- a/Tests/VibeBarCoreTests/SkillsServiceNetworkTests.swift
+++ b/Tests/VibeBarCoreTests/SkillsServiceNetworkTests.swift
@@ -1,0 +1,449 @@
+import XCTest
+@testable import VibeBarCore
+
+/// The repository half of `SkillsService`, driven through the `SkillRepoFetching`
+/// seam so nothing here needs a network — the fake writes the tree a download
+/// would have produced and then defers to the *real* scanner, so discovery,
+/// matching, and hashing are the production code paths.
+final class SkillsServiceNetworkTests: XCTestCase {
+    // MARK: - Install
+
+    func testInstallsADiscoveredSkillAndEnablesTheChosenApps() async throws {
+        let home = try SkillTestHome()
+        let staging = try home.makeSkillDirectory(
+            at: home.url.appendingPathComponent("staging/pdf"),
+            name: "PDF Tools",
+            description: "Reads PDFs",
+            extraFiles: ["reference/notes.md": "deep"]
+        )
+        let service = SkillsService(homeDirectory: home.path)
+
+        let skill = try await service.install(
+            Self.discovered(directory: "pdf", sourceRoot: staging, name: "PDF Tools", description: "Reads PDFs"),
+            enableFor: [.claude, .codex]
+        )
+
+        XCTAssertEqual(skill.id, .repo(owner: "acme", repo: "myskills", directory: "pdf"))
+        XCTAssertEqual(skill.name, "PDF Tools")
+        XCTAssertEqual(skill.description, "Reads PDFs")
+        XCTAssertEqual(skill.repoBranch, "master")
+        XCTAssertEqual(Set(skill.enabledApps), [.claude, .codex])
+        XCTAssertEqual(
+            home.contents(of: home.ssot.appendingPathComponent("pdf/reference/notes.md")),
+            "deep"
+        )
+        XCTAssertEqual(
+            skill.contentHash,
+            try SkillDirectoryHasher.hash(directory: home.ssot.appendingPathComponent("pdf"))
+        )
+        for app in [SkillAppTarget.claude, .codex] {
+            XCTAssertEqual(
+                SkillFileSystem.kind(of: home.appDirectory(app).appendingPathComponent("pdf")),
+                .symlink
+            )
+        }
+        let installed = await service.installedSkills()
+        XCTAssertEqual(installed.map(\.directory), ["pdf"])
+    }
+
+    func testInstallRefusesADirectoryHeldByADifferentSkill() async throws {
+        let home = try SkillTestHome()
+        let staging = try home.makeSkillDirectory(at: home.url.appendingPathComponent("staging/pdf"))
+        let service = SkillsService(homeDirectory: home.path)
+        _ = try await service.installLocal(from: staging, name: "pdf")
+
+        do {
+            _ = try await service.install(
+                Self.discovered(directory: "pdf", sourceRoot: staging),
+                enableFor: [.claude]
+            )
+            XCTFail("Expected directoryConflict")
+        } catch {
+            XCTAssertEqual(error as? SkillError, .directoryConflict("pdf"))
+        }
+        let installed = await service.installedSkills()
+        XCTAssertEqual(installed.map(\.id), [.local(directory: "pdf")])
+    }
+
+    func testReinstallingTheSameSkillOnlyEnablesMoreApps() async throws {
+        let home = try SkillTestHome()
+        let staging = try home.makeSkillDirectory(at: home.url.appendingPathComponent("staging/pdf"))
+        let service = SkillsService(homeDirectory: home.path)
+        let discovered = Self.discovered(directory: "pdf", sourceRoot: staging)
+        _ = try await service.install(discovered, enableFor: [.claude])
+        // Local edits to the SSOT copy must survive a repeat install.
+        try home.write("edited", to: home.ssot.appendingPathComponent("pdf/local.md"))
+
+        let again = try await service.install(discovered, enableFor: [.gemini])
+
+        XCTAssertEqual(Set(again.enabledApps), [.claude, .gemini])
+        XCTAssertEqual(home.contents(of: home.ssot.appendingPathComponent("pdf/local.md")), "edited")
+    }
+
+    func testInstallRejectsASourceWithoutSkillMD() async throws {
+        let home = try SkillTestHome()
+        let empty = try home.makeDirectory(home.url.appendingPathComponent("staging/blank"))
+        let service = SkillsService(homeDirectory: home.path)
+
+        do {
+            _ = try await service.install(
+                Self.discovered(directory: "blank", sourceRoot: empty),
+                enableFor: []
+            )
+            XCTFail("Expected missingSkillMD")
+        } catch {
+            XCTAssertEqual(error as? SkillError, .missingSkillMD("blank"))
+        }
+    }
+
+    // MARK: - Zip import
+
+    func testInstallsEverySkillInAZipAndSkipsDuplicates() async throws {
+        let home = try SkillTestHome()
+        let bundle = home.url.appendingPathComponent("bundle", isDirectory: true)
+        try home.makeSkillDirectory(at: bundle.appendingPathComponent("alpha"), name: "Alpha")
+        try home.makeSkillDirectory(
+            at: bundle.appendingPathComponent("nested/beta"),
+            name: "Beta",
+            extraFiles: ["ref.md": "beta reference"]
+        )
+        let archive = try SkillZipFixtures.zipDirectory(named: "bundle", in: home.url)
+
+        let service = SkillsService(homeDirectory: home.path)
+        let installed = try await service.installFromZip(at: archive, enableFor: [.claude])
+
+        XCTAssertEqual(installed.map(\.directory).sorted(), ["alpha", "beta"])
+        XCTAssertEqual(installed.map(\.id).sorted { $0.rawValue < $1.rawValue }, [
+            .local(directory: "alpha"),
+            .local(directory: "beta")
+        ])
+        XCTAssertEqual(installed.first { $0.directory == "beta" }?.name, "Beta")
+        XCTAssertEqual(
+            home.contents(of: home.ssot.appendingPathComponent("beta/ref.md")),
+            "beta reference"
+        )
+        XCTAssertEqual(
+            SkillFileSystem.kind(of: home.appDirectory(.claude).appendingPathComponent("alpha")),
+            .symlink
+        )
+
+        // Second pass: both are already installed, so nothing new lands and the
+        // existing SSOT copies are untouched.
+        let again = try await service.installFromZip(at: archive, enableFor: [.claude])
+        XCTAssertTrue(again.isEmpty)
+        let all = await service.installedSkills()
+        XCTAssertEqual(all.map(\.directory), ["alpha", "beta"])
+    }
+
+    func testInstallFromZipRejectsAnArchiveWithoutASkill() async throws {
+        let home = try SkillTestHome()
+        let junk = home.url.appendingPathComponent("junk", isDirectory: true)
+        try home.write("nothing to see", to: junk.appendingPathComponent("notes.txt"))
+        let archive = try SkillZipFixtures.zipDirectory(named: "junk", in: home.url)
+
+        let service = SkillsService(homeDirectory: home.path)
+        do {
+            _ = try await service.installFromZip(at: archive, enableFor: [])
+            XCTFail("Expected missingSkillMD")
+        } catch {
+            XCTAssertEqual(error as? SkillError, .missingSkillMD("junk"))
+        }
+    }
+
+    func testInstallFromZipAcceptsAnArchiveOfASingleSkillFolder() async throws {
+        let home = try SkillTestHome()
+        try home.makeSkillDirectory(
+            at: home.url.appendingPathComponent("solo"),
+            name: "Solo Skill"
+        )
+        let archive = try SkillZipFixtures.zipDirectory(named: "solo", in: home.url)
+
+        let service = SkillsService(homeDirectory: home.path)
+        let installed = try await service.installFromZip(at: archive, enableFor: [])
+
+        XCTAssertEqual(installed.map(\.directory), ["solo"])
+        XCTAssertEqual(installed[0].name, "Solo Skill")
+    }
+
+    // MARK: - Discovery
+
+    func testDiscoverySkipsARepositoryThatFailsAndKeepsTheRest() async throws {
+        let home = try SkillTestHome()
+        let fetcher = FakeRepoFetcher()
+        fetcher.repos["acme/good"] = FakeRepoFetcher.Repo(
+            branch: "main",
+            skills: ["skills/alpha": ["SKILL.md": Self.frontmatter(name: "Alpha")]]
+        )
+        let service = SkillsService(homeDirectory: home.path, fetcher: fetcher)
+
+        let discovered = await service.discoverSkills(from: [
+            SkillRepoRef("acme/good")!,
+            SkillRepoRef("acme/missing")!
+        ])
+
+        XCTAssertEqual(discovered.map(\.directory), ["alpha"])
+        XCTAssertEqual(discovered[0].id, .repo(owner: "acme", repo: "good", directory: "alpha"))
+        // The staging tree is still on disk, which is what makes install work.
+        let installed = try await service.install(discovered[0], enableFor: [.claude])
+        XCTAssertEqual(installed.directory, "alpha")
+
+        await service.clearDiscoveryStaging()
+        XCTAssertFalse(FileManager.default.fileExists(atPath: discovered[0].sourceRoot.path))
+    }
+
+    func testDiscoveryDedupesAndSortsByName() async throws {
+        let home = try SkillTestHome()
+        let fetcher = FakeRepoFetcher()
+        fetcher.repos["acme/one"] = FakeRepoFetcher.Repo(
+            branch: "main",
+            skills: [
+                "skills/zeta": ["SKILL.md": Self.frontmatter(name: "Zeta")],
+                "skills/alpha": ["SKILL.md": Self.frontmatter(name: "Alpha")]
+            ]
+        )
+        let service = SkillsService(homeDirectory: home.path, fetcher: fetcher)
+
+        let discovered = await service.discoverSkills(from: [
+            SkillRepoRef("acme/one")!,
+            SkillRepoRef("acme/one")!
+        ])
+
+        XCTAssertEqual(discovered.map(\.name), ["Alpha", "Zeta"])
+    }
+
+    // MARK: - Update checks
+
+    func testCheckForUpdatesComparesHashesAndBackfillsAMissingLocalOne() async throws {
+        let home = try SkillTestHome()
+        let fetcher = FakeRepoFetcher()
+        fetcher.repos["acme/one"] = FakeRepoFetcher.Repo(
+            branch: "main",
+            skills: [
+                "skills/alpha": ["SKILL.md": Self.frontmatter(name: "Alpha"), "ref.md": "v1"],
+                "skills/beta": ["SKILL.md": Self.frontmatter(name: "Beta")]
+            ]
+        )
+        let service = SkillsService(homeDirectory: home.path, fetcher: fetcher)
+        let discovered = await service.discoverSkills(from: [SkillRepoRef("acme/one")!])
+        for skill in discovered { _ = try await service.install(skill, enableFor: []) }
+        await service.clearDiscoveryStaging()
+
+        // Alpha moves on upstream; beta does not. Beta also loses its recorded
+        // hash, standing in for a skill adopted by an older build.
+        fetcher.repos["acme/one"]?.skills["skills/alpha"]?["ref.md"] = "v2"
+        let store = SkillsStore(homeDirectory: home.path)
+        let stored = await store.skill(directory: "beta")
+        var beta = try XCTUnwrap(stored)
+        beta.contentHash = nil
+        try await store.upsert(beta)
+
+        let states = await service.checkForUpdates()
+
+        XCTAssertEqual(states.map(\.name), ["Alpha", "Beta"])
+        let alpha = try XCTUnwrap(states.first { $0.name == "Alpha" })
+        XCTAssertTrue(alpha.updateAvailable)
+        XCTAssertNotEqual(alpha.localHash, alpha.remoteHash)
+        let betaState = try XCTUnwrap(states.first { $0.name == "Beta" })
+        XCTAssertFalse(betaState.updateAvailable)
+        XCTAssertEqual(betaState.localHash, betaState.remoteHash)
+        XCTAssertNotNil(betaState.localHash)
+        XCTAssertEqual(fetcher.downloadCount, 2, "One download for discovery, one for the check")
+    }
+
+    func testCheckForUpdatesIgnoresLocalSkillsAndUnreachableRepositories() async throws {
+        let home = try SkillTestHome()
+        let staging = try home.makeSkillDirectory(at: home.url.appendingPathComponent("staging/solo"))
+        let fetcher = FakeRepoFetcher()
+        let service = SkillsService(homeDirectory: home.path, fetcher: fetcher)
+        _ = try await service.installLocal(from: staging, name: "solo")
+        _ = try await service.install(
+            Self.discovered(directory: "ghost", sourceRoot: staging),
+            enableFor: []
+        )
+
+        let states = await service.checkForUpdates()
+
+        XCTAssertEqual(states.map(\.name), ["ghost"], "Local skills are not update candidates")
+        XCTAssertNil(states[0].remoteHash)
+        XCTAssertFalse(states[0].updateAvailable)
+    }
+
+    // MARK: - Update
+
+    func testUpdateBacksUpReplacesAndRematerializes() async throws {
+        let home = try SkillTestHome()
+        let fetcher = FakeRepoFetcher()
+        fetcher.repos["acme/one"] = FakeRepoFetcher.Repo(
+            branch: "main",
+            skills: ["skills/alpha": [
+                "SKILL.md": Self.frontmatter(name: "Alpha"),
+                "ref.md": "v1",
+                "gone.md": "removed upstream later"
+            ]]
+        )
+        let service = SkillsService(homeDirectory: home.path, fetcher: fetcher)
+        let discovered = await service.discoverSkills(from: [SkillRepoRef("acme/one")!])
+        let installed = try await service.install(discovered[0], enableFor: [.claude], method: .copy)
+        await service.clearDiscoveryStaging()
+        XCTAssertEqual(installed.apps[.claude]?.method, .copy)
+
+        fetcher.repos["acme/one"]?.skills["skills/alpha"] = [
+            "SKILL.md": Self.frontmatter(name: "Alpha 2", description: "now with more"),
+            "ref.md": "v2"
+        ]
+
+        let updated = try await service.update(installed.id)
+
+        XCTAssertEqual(updated.name, "Alpha 2")
+        XCTAssertEqual(updated.description, "now with more")
+        XCTAssertNotNil(updated.updatedAt)
+        XCTAssertNotEqual(updated.contentHash, installed.contentHash)
+        XCTAssertEqual(home.contents(of: home.ssot.appendingPathComponent("alpha/ref.md")), "v2")
+        XCTAssertFalse(home.exists(home.ssot.appendingPathComponent("alpha/gone.md")))
+
+        // The app-side managed copy is refreshed, not left on the old content.
+        let appCopy = home.appDirectory(.claude).appendingPathComponent("alpha")
+        XCTAssertEqual(SkillFileSystem.kind(of: appCopy), .directory)
+        XCTAssertEqual(home.contents(of: appCopy.appendingPathComponent("ref.md")), "v2")
+        XCTAssertEqual(
+            updated.apps[.claude]?.contentHashAtCopy,
+            try SkillDirectoryHasher.hash(directory: appCopy)
+        )
+
+        // The pre-update content is recoverable.
+        let backups = service.listBackups()
+        XCTAssertEqual(backups.count, 1)
+        XCTAssertEqual(
+            home.contents(of: backups[0].url.appendingPathComponent("skill/ref.md")),
+            "v1"
+        )
+    }
+
+    func testUpdateRefusesALocalSkillAndAVanishedOne() async throws {
+        let home = try SkillTestHome()
+        let staging = try home.makeSkillDirectory(at: home.url.appendingPathComponent("staging/solo"))
+        let fetcher = FakeRepoFetcher()
+        fetcher.repos["acme/one"] = FakeRepoFetcher.Repo(
+            branch: "main",
+            skills: ["skills/other": ["SKILL.md": Self.frontmatter(name: "Other")]]
+        )
+        let service = SkillsService(homeDirectory: home.path, fetcher: fetcher)
+        _ = try await service.installLocal(from: staging, name: "solo")
+        let ghost = try await service.install(
+            Self.discovered(
+                directory: "ghost",
+                sourceRoot: staging,
+                owner: "acme",
+                repo: "one",
+                branch: "main"
+            ),
+            enableFor: []
+        )
+
+        do {
+            _ = try await service.update(.local(directory: "solo"))
+            XCTFail("Expected notRepositoryBacked")
+        } catch {
+            XCTAssertEqual(error as? SkillError, .notRepositoryBacked(.local(directory: "solo")))
+        }
+        do {
+            _ = try await service.update(ghost.id)
+            XCTFail("Expected updateSourceMissing")
+        } catch {
+            XCTAssertEqual(error as? SkillError, .updateSourceMissing("ghost"))
+        }
+        XCTAssertTrue(service.listBackups().isEmpty, "A failed update takes no backup")
+        do {
+            _ = try await service.update(.repo(owner: "acme", repo: "one", directory: "nope"))
+            XCTFail("Expected notInstalled")
+        } catch {
+            XCTAssertEqual(error as? SkillError, .notInstalled(.repo(owner: "acme", repo: "one", directory: "nope")))
+        }
+    }
+
+    // MARK: - Helpers
+
+    private static func discovered(
+        directory: String,
+        sourceRoot: URL,
+        name: String? = nil,
+        description: String? = nil,
+        owner: String = "acme",
+        repo: String = "myskills",
+        branch: String = "master"
+    ) -> DiscoveredSkill {
+        DiscoveredSkill(
+            id: .repo(owner: owner, repo: repo, directory: directory),
+            name: name ?? directory,
+            description: description,
+            directory: directory,
+            repoRelativePath: "skills/\(directory)",
+            branch: branch,
+            readmeURL: nil,
+            sourceRoot: sourceRoot
+        )
+    }
+
+    private static func frontmatter(name: String, description: String? = nil) -> String {
+        var text = "---\nname: \(name)\n"
+        if let description { text += "description: \(description)\n" }
+        text += "---\n\n# \(name)\n"
+        return text
+    }
+}
+
+/// Stands in for `SkillRepoFetcher`: materializes a declared tree into the
+/// directory the service hands it, then defers to the real scanner so only the
+/// network is faked.
+final class FakeRepoFetcher: SkillRepoFetching, @unchecked Sendable {
+    struct Repo {
+        var branch: String
+        /// Repository-relative skill directory → file name → contents.
+        var skills: [String: [String: String]]
+    }
+
+    private let lock = NSLock()
+    private var storage: [String: Repo] = [:]
+    private var downloads = 0
+
+    var repos: [String: Repo] {
+        get { lock.withLock { storage } }
+        set { lock.withLock { storage = newValue } }
+    }
+
+    var downloadCount: Int { lock.withLock { downloads } }
+
+    func downloadRepo(_ ref: SkillRepoRef, into tempDir: URL) async throws -> (root: URL, resolvedBranch: String) {
+        guard let repo = repos[ref.slug] else {
+            throw SkillRepoError.branchNotFound(
+                slug: ref.slug,
+                tried: SkillRepoFetcher.branchCandidates(for: ref)
+            )
+        }
+        lock.withLock { downloads += 1 }
+        let root = tempDir.appendingPathComponent("\(ref.repo)-\(repo.branch)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        for (path, files) in repo.skills {
+            let directory = path
+                .split(separator: "/")
+                .reduce(root) { $0.appendingPathComponent(String($1), isDirectory: true) }
+            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+            for (name, contents) in files {
+                try contents.write(
+                    to: directory.appendingPathComponent(name),
+                    atomically: true,
+                    encoding: .utf8
+                )
+            }
+        }
+        return (root, repo.branch)
+    }
+
+    func scanSkills(
+        inRepoRoot root: URL,
+        ref: SkillRepoRef,
+        resolvedBranch: String
+    ) throws -> [DiscoveredSkill] {
+        try SkillRepoFetcher().scanSkills(inRepoRoot: root, ref: ref, resolvedBranch: resolvedBranch)
+    }
+}

--- a/Tests/VibeBarCoreTests/SkillsServiceTests.swift
+++ b/Tests/VibeBarCoreTests/SkillsServiceTests.swift
@@ -1,0 +1,274 @@
+import XCTest
+@testable import VibeBarCore
+
+final class SkillsServiceTests: XCTestCase {
+    func testInstallLocalCopiesIntoTheSSOTAndEnablesNothing() async throws {
+        let home = try SkillTestHome()
+        let staging = try home.makeSkillDirectory(
+            at: home.url.appendingPathComponent("Downloads/alpha"),
+            name: "alpha-skill",
+            description: "from disk",
+            extraFiles: ["ref.md": "payload"]
+        )
+        let service = SkillsService(homeDirectory: home.path)
+
+        let skill = try await service.installLocal(from: staging, name: "alpha")
+
+        XCTAssertEqual(skill.id, .local(directory: "alpha"))
+        XCTAssertEqual(skill.name, "alpha-skill")
+        XCTAssertEqual(skill.description, "from disk")
+        XCTAssertTrue(skill.apps.isEmpty)
+        XCTAssertEqual(
+            home.contents(of: home.ssot.appendingPathComponent("alpha/ref.md")),
+            "payload"
+        )
+        XCTAssertEqual(
+            skill.contentHash,
+            try SkillDirectoryHasher.hash(directory: home.ssot.appendingPathComponent("alpha"))
+        )
+        let installed = await service.installedSkills()
+        XCTAssertEqual(installed.map(\.directory), ["alpha"])
+        for app in SkillAppTarget.allCases {
+            XCTAssertFalse(home.exists(home.appDirectory(app)))
+        }
+    }
+
+    func testInstallLocalRefusesAnExistingDirectoryAndANonSkill() async throws {
+        let home = try SkillTestHome()
+        let staging = try home.makeSkillDirectory(at: home.url.appendingPathComponent("Downloads/alpha"))
+        let service = SkillsService(homeDirectory: home.path)
+        _ = try await service.installLocal(from: staging, name: "alpha")
+
+        do {
+            _ = try await service.installLocal(from: staging, name: "alpha")
+            XCTFail("expected a conflict")
+        } catch {
+            XCTAssertEqual(error as? SkillError, .directoryConflict("alpha"))
+        }
+
+        let bare = try home.makeDirectory(home.url.appendingPathComponent("Downloads/bare"))
+        do {
+            _ = try await service.installLocal(from: bare, name: "bare")
+            XCTFail("expected a missing SKILL.md")
+        } catch {
+            XCTAssertEqual(error as? SkillError, .missingSkillMD("bare"))
+        }
+        XCTAssertFalse(home.exists(home.ssot.appendingPathComponent("bare")))
+    }
+
+    func testSetEnabledMaterializesThenPersists() async throws {
+        let home = try SkillTestHome()
+        let staging = try home.makeSkillDirectory(at: home.url.appendingPathComponent("Downloads/alpha"))
+        let service = SkillsService(homeDirectory: home.path)
+        let skill = try await service.installLocal(from: staging, name: "alpha")
+
+        let enabled = try await service.setEnabled(skill.id, app: .claude, enabled: true)
+        XCTAssertTrue(enabled)
+        XCTAssertEqual(
+            SkillFileSystem.kind(of: home.appDirectory(.claude).appendingPathComponent("alpha")),
+            .symlink
+        )
+        let afterEnable = await service.skill(with: skill.id)
+        XCTAssertEqual(afterEnable?.apps[.claude]?.method, .symlink)
+        let persisted = await SkillsStore(homeDirectory: home.path).all()
+        XCTAssertEqual(persisted.first?.enabledApps, [.claude])
+
+        let disabled = try await service.setEnabled(skill.id, app: .claude, enabled: false)
+        XCTAssertTrue(disabled)
+        XCTAssertFalse(home.exists(home.appDirectory(.claude).appendingPathComponent("alpha")))
+        let afterDisable = await SkillsStore(homeDirectory: home.path).all()
+        XCTAssertEqual(afterDisable.first?.enabledApps, [])
+    }
+
+    func testFailedMaterializeLeavesTheStoreUntouched() async throws {
+        let home = try SkillTestHome()
+        let staging = try home.makeSkillDirectory(at: home.url.appendingPathComponent("Downloads/alpha"))
+        let service = SkillsService(homeDirectory: home.path)
+        let skill = try await service.installLocal(from: staging, name: "alpha")
+
+        // The engine refuses a source without SKILL.md; because the file
+        // operation runs first, the enable bit must not be recorded.
+        try FileManager.default.removeItem(at: home.ssot.appendingPathComponent("alpha/SKILL.md"))
+        do {
+            _ = try await service.setEnabled(skill.id, app: .claude, enabled: true)
+            XCTFail("expected the materialize to fail")
+        } catch {
+            XCTAssertEqual(error as? SkillError, .missingSkillMD("alpha"))
+        }
+
+        let inMemory = await service.skill(with: skill.id)
+        XCTAssertEqual(inMemory?.apps, [:])
+        let onDisk = await SkillsStore(homeDirectory: home.path).all()
+        XCTAssertEqual(onDisk.first?.apps, [:])
+        XCTAssertFalse(home.exists(home.appDirectory(.claude).appendingPathComponent("alpha")))
+    }
+
+    func testDisableClearsTheBitButKeepsAModifiedCopy() async throws {
+        let home = try SkillTestHome()
+        let staging = try home.makeSkillDirectory(
+            at: home.url.appendingPathComponent("Downloads/alpha"),
+            extraFiles: ["ref.md": "payload"]
+        )
+        let service = SkillsService(homeDirectory: home.path)
+        let skill = try await service.installLocal(from: staging, name: "alpha")
+        _ = try await service.setEnabled(skill.id, app: .grok, enabled: true, method: .copy)
+
+        let destination = home.appDirectory(.grok).appendingPathComponent("alpha")
+        try home.write("edited by the user", to: destination.appendingPathComponent("ref.md"))
+
+        let removed = try await service.setEnabled(skill.id, app: .grok, enabled: false)
+        XCTAssertFalse(removed)
+        XCTAssertEqual(SkillFileSystem.kind(of: destination), .directory)
+        XCTAssertEqual(home.contents(of: destination.appendingPathComponent("ref.md")), "edited by the user")
+        let stored = await service.skill(with: skill.id)
+        XCTAssertEqual(stored?.enabledApps, [])
+    }
+
+    func testSetEnabledRejectsAnUnknownSkill() async throws {
+        let home = try SkillTestHome()
+        let service = SkillsService(homeDirectory: home.path)
+        do {
+            _ = try await service.setEnabled(.local(directory: "ghost"), app: .claude, enabled: true)
+            XCTFail("expected notInstalled")
+        } catch {
+            XCTAssertEqual(error as? SkillError, .notInstalled(.local(directory: "ghost")))
+        }
+    }
+
+    func testUninstallBacksUpThenRemovesEverywhere() async throws {
+        let home = try SkillTestHome()
+        let staging = try home.makeSkillDirectory(
+            at: home.url.appendingPathComponent("Downloads/alpha"),
+            extraFiles: ["ref.md": "payload"]
+        )
+        let service = SkillsService(homeDirectory: home.path)
+        let skill = try await service.installLocal(from: staging, name: "alpha")
+        _ = try await service.setEnabled(skill.id, app: .claude, enabled: true, method: .symlink)
+        _ = try await service.setEnabled(skill.id, app: .grok, enabled: true, method: .copy)
+
+        let result = try await service.uninstall(skill.id)
+
+        XCTAssertEqual(result.removedByApp[.claude], true)
+        XCTAssertEqual(result.removedByApp[.grok], true)
+        XCTAssertFalse(home.exists(home.appDirectory(.claude).appendingPathComponent("alpha")))
+        XCTAssertFalse(home.exists(home.appDirectory(.grok).appendingPathComponent("alpha")))
+        XCTAssertFalse(home.exists(home.ssot.appendingPathComponent("alpha")))
+        let remaining = await service.installedSkills()
+        XCTAssertTrue(remaining.isEmpty)
+
+        XCTAssertEqual(
+            home.contents(of: result.backupURL.appendingPathComponent("skill/ref.md")),
+            "payload"
+        )
+        XCTAssertEqual(service.listBackups().count, 1)
+
+        let restored = try await service.restoreBackup(result.backupURL)
+        XCTAssertEqual(restored.directory, "alpha")
+        XCTAssertTrue(home.exists(home.ssot.appendingPathComponent("alpha/SKILL.md")))
+        let afterRestore = await service.installedSkills()
+        XCTAssertEqual(afterRestore.map(\.directory), ["alpha"])
+    }
+
+    func testUninstallLeavesAForeignDirectoryBehindAndReportsIt() async throws {
+        let home = try SkillTestHome()
+        let staging = try home.makeSkillDirectory(at: home.url.appendingPathComponent("Downloads/alpha"))
+        let service = SkillsService(homeDirectory: home.path)
+        let skill = try await service.installLocal(from: staging, name: "alpha")
+        let foreign = home.appDirectory(.hermes).appendingPathComponent("alpha")
+        try home.makeSkillDirectory(at: foreign, extraFiles: ["ref.md": "hand written"])
+
+        let result = try await service.uninstall(skill.id)
+
+        XCTAssertEqual(result.removedByApp[.hermes], false)
+        XCTAssertEqual(home.contents(of: foreign.appendingPathComponent("ref.md")), "hand written")
+        XCTAssertFalse(home.exists(home.ssot.appendingPathComponent("alpha")))
+    }
+
+    func testImportAdoptedPersistsTheScannedLayout() async throws {
+        let home = try SkillTestHome()
+        try home.makeSSOTSkill("alpha", name: "alpha-skill")
+        try home.makeSSOTSkill("beta")
+        try home.makeAbsoluteSymlink("alpha", in: .claude, toSSOT: "alpha")
+        try home.makeAbsoluteSymlink("alpha", in: .gemini, toSSOT: "alpha")
+        let service = SkillsService(homeDirectory: home.path)
+
+        let report = service.scanForImport()
+        let imported = try await service.importAdopted(report, apps: [.claude])
+
+        XCTAssertEqual(imported.map(\.directory), ["alpha", "beta"])
+        let persisted = await SkillsStore(homeDirectory: home.path).all()
+        XCTAssertEqual(persisted.count, 2)
+        // Only the requested app is recorded, and it is marked as adopted.
+        XCTAssertEqual(persisted.first?.enabledApps, [.claude])
+        XCTAssertEqual(persisted.first?.apps[.claude]?.adopted, true)
+        // Import changed nothing on disk.
+        XCTAssertEqual(
+            SkillFileSystem.kind(of: home.appDirectory(.gemini).appendingPathComponent("alpha")),
+            .symlink
+        )
+
+        // A second import with another app selected keeps what was known.
+        _ = try await service.importAdopted(report, apps: [.gemini])
+        let merged = await SkillsStore(homeDirectory: home.path).all()
+        XCTAssertEqual(merged.first?.enabledApps, [.claude, .gemini])
+    }
+
+    func testAdoptUnmanagedCopiesIntoTheSSOTThenMaterializes() async throws {
+        let home = try SkillTestHome()
+        let foreign = try home.makeSkillDirectory(
+            at: home.appDirectory(.claude).appendingPathComponent("legacy-helper"),
+            name: "Legacy Helper",
+            description: "hand written",
+            extraFiles: ["ref.md": "payload"]
+        )
+        let service = SkillsService(homeDirectory: home.path)
+
+        let report = service.scanForImport()
+        XCTAssertEqual(report.unmanagedDirectories.map(\.directoryName), ["legacy-helper"])
+
+        let adopted = try await service.adoptUnmanaged(
+            directoryName: "legacy-helper",
+            from: .claude,
+            apps: [.claude, .codex],
+            method: .symlink
+        )
+
+        XCTAssertEqual(adopted.id, .local(directory: "legacy-helper"))
+        XCTAssertEqual(adopted.name, "Legacy Helper")
+        XCTAssertEqual(adopted.description, "hand written")
+        XCTAssertEqual(
+            home.contents(of: home.ssot.appendingPathComponent("legacy-helper/ref.md")),
+            "payload"
+        )
+        XCTAssertEqual(adopted.enabledApps, [.claude, .codex])
+        XCTAssertEqual(SkillFileSystem.kind(of: foreign), .symlink)
+        XCTAssertEqual(
+            try FileManager.default.destinationOfSymbolicLink(atPath: foreign.path),
+            home.ssot.appendingPathComponent("legacy-helper").path
+        )
+        XCTAssertEqual(
+            SkillFileSystem.kind(of: home.appDirectory(.codex).appendingPathComponent("legacy-helper")),
+            .symlink
+        )
+        let persisted = await SkillsStore(homeDirectory: home.path).all()
+        XCTAssertEqual(persisted.map(\.directory), ["legacy-helper"])
+    }
+
+    func testAdoptUnmanagedRefusesWhenTheSSOTAlreadyHasThatName() async throws {
+        let home = try SkillTestHome()
+        try home.makeSSOTSkill("legacy-helper")
+        try home.makeSkillDirectory(at: home.appDirectory(.claude).appendingPathComponent("legacy-helper"))
+        let service = SkillsService(homeDirectory: home.path)
+
+        do {
+            _ = try await service.adoptUnmanaged(
+                directoryName: "legacy-helper",
+                from: .claude,
+                apps: [.claude]
+            )
+            XCTFail("expected a conflict")
+        } catch {
+            XCTAssertEqual(error as? SkillError, .directoryConflict("legacy-helper"))
+        }
+    }
+}

--- a/Tests/VibeBarCoreTests/SkillsStoreTests.swift
+++ b/Tests/VibeBarCoreTests/SkillsStoreTests.swift
@@ -1,0 +1,136 @@
+import XCTest
+@testable import VibeBarCore
+
+final class SkillsStoreTests: XCTestCase {
+    private func makeSkill(
+        _ id: SkillID,
+        apps: [SkillAppTarget: SkillMaterialization] = [:]
+    ) -> Skill {
+        Skill(
+            id: id,
+            name: id.directory,
+            description: "a synthetic skill",
+            directory: id.directory,
+            repoBranch: id.isRepositoryBacked ? "main" : nil,
+            installedAt: Date(timeIntervalSince1970: 1_700_000_000),
+            contentHash: "deadbeef",
+            updatedAt: Date(timeIntervalSince1970: 1_700_000_500),
+            apps: apps
+        )
+    }
+
+    func testRoundTripsThroughDisk() async throws {
+        let home = try SkillTestHome()
+        let store = SkillsStore(homeDirectory: home.path)
+        let alpha = makeSkill(
+            .repo(owner: "acme", repo: "skills", directory: "alpha"),
+            apps: [
+                .claude: SkillMaterialization(method: .symlink, adopted: true),
+                .grok: SkillMaterialization(method: .copy, contentHashAtCopy: "abc123")
+            ]
+        )
+        let beta = makeSkill(.local(directory: "beta"))
+        try await store.upsert(alpha)
+        try await store.upsert(beta)
+
+        let reloaded = await SkillsStore(homeDirectory: home.path).all()
+        XCTAssertEqual(reloaded.map(\.directory), ["alpha", "beta"])
+        XCTAssertEqual(reloaded.first, alpha)
+        XCTAssertEqual(reloaded.first?.apps[.claude]?.adopted, true)
+        XCTAssertEqual(reloaded.first?.apps[.grok]?.contentHashAtCopy, "abc123")
+        XCTAssertEqual(reloaded.last?.id, .local(directory: "beta"))
+    }
+
+    func testFileIsWrittenPrivatelyUnderVibeBar() async throws {
+        let home = try SkillTestHome()
+        let store = SkillsStore(homeDirectory: home.path)
+        try await store.upsert(makeSkill(.local(directory: "alpha")))
+
+        let url = VibeBarLocalStore.skillsStoreURL(homeDirectory: home.path)
+        XCTAssertEqual(url.path, home.url.appendingPathComponent(".vibebar/skills.json").path)
+        let permissions = try FileManager.default.attributesOfItem(atPath: url.path)[.posixPermissions] as? NSNumber
+        XCTAssertEqual(permissions?.int16Value, 0o600)
+    }
+
+    func testUpsertReplacesAndRemoveDeletes() async throws {
+        let home = try SkillTestHome()
+        let store = SkillsStore(homeDirectory: home.path)
+        let id = SkillID.local(directory: "alpha")
+        try await store.upsert(makeSkill(id))
+
+        var updated = makeSkill(id)
+        updated.name = "renamed"
+        try await store.upsert(updated)
+        let all = await store.all()
+        XCTAssertEqual(all.count, 1)
+        XCTAssertEqual(all.first?.name, "renamed")
+        let found = await store.skill(with: id)
+        XCTAssertEqual(found?.name, "renamed")
+        let missing = await store.skill(with: .local(directory: "nope"))
+        XCTAssertNil(missing)
+
+        let firstRemoval = try await store.remove(id: id)
+        XCTAssertTrue(firstRemoval)
+        let secondRemoval = try await store.remove(id: id)
+        XCTAssertFalse(secondRemoval)
+        let empty = await SkillsStore(homeDirectory: home.path).all()
+        XCTAssertTrue(empty.isEmpty)
+    }
+
+    func testUnknownAppKeysAndUndecodableEntriesAreDropped() async throws {
+        let home = try SkillTestHome()
+        let json = """
+        {
+          "schemaVersion": 1,
+          "skills": [
+            {
+              "id": "acme/skills:alpha",
+              "name": "alpha",
+              "directory": "alpha",
+              "installedAt": 0,
+              "apps": {
+                "claude": { "method": "symlink", "adopted": true },
+                "borgcli": { "method": "symlink", "adopted": true }
+              }
+            },
+            { "id": "not a valid id", "name": "broken", "directory": "broken", "installedAt": 0 },
+            { "id": "local:beta", "name": "beta", "directory": "beta", "installedAt": 0, "apps": {} }
+          ]
+        }
+        """
+        try home.write(json, to: VibeBarLocalStore.skillsStoreURL(homeDirectory: home.path))
+
+        let skills = await SkillsStore(homeDirectory: home.path).all()
+        XCTAssertEqual(skills.map(\.directory), ["alpha", "beta"])
+        XCTAssertEqual(skills.first?.enabledApps, [.claude])
+        XCTAssertEqual(skills.first?.id, .repo(owner: "acme", repo: "skills", directory: "alpha"))
+    }
+
+    func testMissingOrCorruptFileLoadsEmpty() async throws {
+        let home = try SkillTestHome()
+        let empty = await SkillsStore(homeDirectory: home.path).all()
+        XCTAssertTrue(empty.isEmpty)
+
+        try home.write("{ not json", to: VibeBarLocalStore.skillsStoreURL(homeDirectory: home.path))
+        let corrupt = await SkillsStore(homeDirectory: home.path).all()
+        XCTAssertTrue(corrupt.isEmpty)
+    }
+
+    func testSkillIDSerializationRoundTrip() {
+        XCTAssertEqual(
+            SkillID(rawValue: "acme/skills:alpha"),
+            .repo(owner: "acme", repo: "skills", directory: "alpha")
+        )
+        XCTAssertEqual(SkillID(rawValue: "local:alpha"), .local(directory: "alpha"))
+        XCTAssertEqual(SkillID.local(directory: "alpha").rawValue, "local:alpha")
+        XCTAssertEqual(
+            SkillID.repo(owner: "acme", repo: "skills", directory: "alpha").rawValue,
+            "acme/skills:alpha"
+        )
+        XCTAssertEqual(SkillID.repo(owner: "acme", repo: "skills", directory: "alpha").repositorySlug, "acme/skills")
+        XCTAssertNil(SkillID.local(directory: "alpha").repositorySlug)
+        XCTAssertNil(SkillID(rawValue: "alpha"))
+        XCTAssertNil(SkillID(rawValue: "acme/skills:"))
+        XCTAssertNil(SkillID(rawValue: "acme:alpha"))
+    }
+}

--- a/Tests/VibeBarCoreTests/SkillsStoreTests.swift
+++ b/Tests/VibeBarCoreTests/SkillsStoreTests.swift
@@ -116,6 +116,55 @@ final class SkillsStoreTests: XCTestCase {
         XCTAssertTrue(corrupt.isEmpty)
     }
 
+    func testDiscoverReposSeedTheDefaultsAndRoundTrip() async throws {
+        let home = try SkillTestHome()
+        let store = SkillsStore(homeDirectory: home.path)
+
+        // Never configured → the shipped seed list.
+        let seeded = await store.discoverRepos()
+        XCTAssertEqual(seeded, SkillsStore.defaultDiscoverRepos)
+        let refs = await store.discoverRepoRefs()
+        XCTAssertEqual(refs.map(\.slug).first, "anthropics/skills")
+        XCTAssertEqual(refs.first { $0.repo == "myclaude" }?.branch, "master")
+
+        // Writing a skill must persist the list alongside it.
+        try await store.upsert(makeSkill(.local(directory: "alpha")))
+        let reloaded = await SkillsStore(homeDirectory: home.path).discoverRepos()
+        XCTAssertEqual(reloaded, SkillsStore.defaultDiscoverRepos)
+
+        let added = try await store.addDiscoverRepo("acme/extra@dev")
+        XCTAssertTrue(added)
+        let addedAgain = try await store.addDiscoverRepo("ACME/EXTRA@dev")
+        XCTAssertFalse(addedAgain, "Duplicates are case-insensitive")
+        let addedJunk = try await store.addDiscoverRepo("not a repo")
+        XCTAssertFalse(addedJunk)
+        let removed = try await store.removeDiscoverRepo("anthropics/skills")
+        XCTAssertTrue(removed)
+        let removedAgain = try await store.removeDiscoverRepo("anthropics/skills")
+        XCTAssertFalse(removedAgain)
+
+        let afterEdits = await SkillsStore(homeDirectory: home.path).discoverRepos()
+        XCTAssertFalse(afterEdits.contains("anthropics/skills"))
+        XCTAssertTrue(afterEdits.contains("acme/extra@dev"))
+        let survivors = await SkillsStore(homeDirectory: home.path).all()
+        XCTAssertEqual(survivors.map(\.directory), ["alpha"])
+    }
+
+    func testSetDiscoverReposNormalizesAndAnEmptyListStaysEmpty() async throws {
+        let home = try SkillTestHome()
+        let store = SkillsStore(homeDirectory: home.path)
+
+        try await store.setDiscoverRepos(["  acme/one  ", "acme/one", "junk", "acme/two@dev", "a/b/c"])
+        let normalized = await store.discoverRepos()
+        XCTAssertEqual(normalized, ["acme/one", "acme/two@dev"])
+
+        // An explicitly cleared list is a decision, not an absent key: it must
+        // not re-seed on the next load.
+        try await store.setDiscoverRepos([])
+        let cleared = await SkillsStore(homeDirectory: home.path).discoverRepos()
+        XCTAssertTrue(cleared.isEmpty)
+    }
+
     func testSkillIDSerializationRoundTrip() {
         XCTAssertEqual(
             SkillID(rawValue: "acme/skills:alpha"),

--- a/Tests/VibeBarCoreTests/SkillsTestFixtures.swift
+++ b/Tests/VibeBarCoreTests/SkillsTestFixtures.swift
@@ -1,0 +1,124 @@
+import Foundation
+@testable import VibeBarCore
+
+/// Disposable home directory for the skills tests: `<tmp>/VibeBarSkills-<uuid>`
+/// standing in for the user's real home, torn down when the test's reference
+/// goes away. Every path in these tests is synthetic — nothing reads or writes
+/// the machine's actual `~/.agents`, `~/.claude`, or `~/.vibebar`.
+final class SkillTestHome {
+    let url: URL
+
+    var path: String { url.path }
+
+    init() throws {
+        url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("VibeBarSkills-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+    }
+
+    deinit {
+        try? FileManager.default.removeItem(at: url)
+    }
+
+    var ssot: URL { SkillAppCatalog.ssotDirectory(homeDirectory: path) }
+
+    func appDirectory(_ app: SkillAppTarget) -> URL {
+        SkillAppCatalog.skillsDirectory(for: app, homeDirectory: path)
+    }
+
+    @discardableResult
+    func makeDirectory(_ url: URL) throws -> URL {
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    func write(_ contents: String, to url: URL) throws {
+        try makeDirectory(url.deletingLastPathComponent())
+        try contents.write(to: url, atomically: true, encoding: .utf8)
+    }
+
+    /// Builds a minimal skill directory: SKILL.md with frontmatter, plus any
+    /// extra files given as `relative path: contents`.
+    @discardableResult
+    func makeSkillDirectory(
+        at url: URL,
+        name: String? = nil,
+        description: String? = nil,
+        extraFiles: [String: String] = [:]
+    ) throws -> URL {
+        try makeDirectory(url)
+        var frontmatter = "---\n"
+        frontmatter += "name: \(name ?? url.lastPathComponent)\n"
+        if let description { frontmatter += "description: \"\(description)\"\n" }
+        frontmatter += "---\n\n# \(url.lastPathComponent)\n"
+        try write(frontmatter, to: url.appendingPathComponent("SKILL.md"))
+        for (relativePath, contents) in extraFiles {
+            try write(contents, to: url.appendingPathComponent(relativePath))
+        }
+        return url
+    }
+
+    @discardableResult
+    func makeSSOTSkill(
+        _ directoryName: String,
+        name: String? = nil,
+        description: String? = nil,
+        extraFiles: [String: String] = [:]
+    ) throws -> URL {
+        try makeSkillDirectory(
+            at: ssot.appendingPathComponent(directoryName, isDirectory: true),
+            name: name,
+            description: description,
+            extraFiles: extraFiles
+        )
+    }
+
+    /// Creates a symlink with an exact target string, so tests can build the
+    /// absolute, relative, and dangling links a real machine has.
+    func makeSymlink(_ entryName: String, in app: SkillAppTarget, rawTarget: String) throws {
+        let directory = appDirectory(app)
+        try makeDirectory(directory)
+        try FileManager.default.createSymbolicLink(
+            atPath: directory.appendingPathComponent(entryName).path,
+            withDestinationPath: rawTarget
+        )
+    }
+
+    func makeAbsoluteSymlink(_ entryName: String, in app: SkillAppTarget, toSSOT ssotName: String) throws {
+        try makeSymlink(
+            entryName,
+            in: app,
+            rawTarget: ssot.appendingPathComponent(ssotName, isDirectory: true).path
+        )
+    }
+
+    func contents(of url: URL) -> String? {
+        try? String(contentsOf: url, encoding: .utf8)
+    }
+
+    func exists(_ url: URL) -> Bool {
+        SkillFileSystem.kind(of: url) != .missing
+    }
+
+    /// lstat snapshot of every path under the home directory: type, inode,
+    /// size, and mtime. Import must leave this byte-for-byte identical.
+    func lstatSnapshot() -> [String: String] {
+        var snapshot: [String: String] = [:]
+        let fm = FileManager.default
+        var stack = [url]
+        while let current = stack.popLast() {
+            guard let attributes = try? fm.attributesOfItem(atPath: current.path) else { continue }
+            let type = (attributes[.type] as? FileAttributeType)?.rawValue ?? "?"
+            let inode = (attributes[.systemFileNumber] as? NSNumber)?.stringValue ?? "?"
+            let size = (attributes[.size] as? NSNumber)?.stringValue ?? "?"
+            let mtime = (attributes[.modificationDate] as? Date)?.timeIntervalSince1970 ?? -1
+            let relative = String(current.path.dropFirst(url.path.count))
+            snapshot[relative] = "\(type)|\(inode)|\(size)|\(mtime)"
+            guard type == FileAttributeType.typeDirectory.rawValue else { continue }
+            for name in (try? fm.contentsOfDirectory(atPath: current.path)) ?? [] {
+                stack.append(current.appendingPathComponent(name))
+            }
+        }
+        return snapshot
+    }
+}


### PR DESCRIPTION
## Summary

Third and final Workbench deliverable: a native skills manager over the unified `~/.agents/skills` single source of truth.

**Sync engine (Core)**
- Skills live in the SSOT and are materialized into seven per-app skills directories (Claude, Codex, Gemini, Grok, Hermes, OpenCode, and AntiGravity's own customization root `~/.gemini/config/skills`) by symlink or atomic copy-replace, with the resolved method and content hash recorded per app. Unmaterialize removes only symlinks resolving into the SSOT or copies whose hash still matches the record — user-modified copies and foreign directories are never touched.
- **Lossless adoption**: this machine already has ~90 skills symlinked by another tool; the import scanner is a pure read that partitions the layout into adopted / unmanaged / unrecognized / conflicting, recovers GitHub provenance from `.skill-lock.json` (never written), and records adopted links without touching them — a filesystem lstat-snapshot test enforces the zero-mutation guarantee.

**Install sources (Core, zero new dependencies)**
- GitHub repo discovery (configured list, seeded with four repos; branch fallback main→master) through a streaming downloader with hard byte caps and host-allowlisted redirects, plus a skills.sh search client.
- A hardened ZIP reader over the Compression framework: central directory as sole authority, CRC verification, ZIP64/encryption/symlink-entry/traversal/duplicate rejection, entry and size budgets checked against both declared and actually inflated bytes — tested against real `/usr/bin/zip` output and hand-crafted attack archives.
- Content-hash update checks and backup-first updates; pre-uninstall snapshots kept under `~/.vibebar/skill_backups/` (newest 20).

**UI**
- Pinned toolbar (search, check updates, ZIP install, import, backups, discover) over a lazy list; each row carries seven brand-tinted per-app toggles with materialize-first ordering. Import auto-offers on first open when the machine's existing layout is detected. ZIP installs land in the SSOT without enabling any app.
- AGENTS.md § 7/§ 11, CLAUDE.md, and CONTRIBUTING.md document the skills write allow-list as the second narrow exception to the `~/.vibebar` write scope (merged with the session-delete exception wording from #155).

## Verification

- `swift build` clean (also under `-strict-concurrency=complete`); `swift test` 1424 tests, 0 failures (121 new).
- `./Scripts/build_app.sh release`, empty entitlements `<dict/>`, `codesign --verify --deep --strict` pass; real-home grep gate clean; no `Process` in product code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)