### PR TITLE
Polish Workbench usage and stabilize local data

### DIFF
--- a/Sources/VibeBarApp/Controllers/SessionManagerModel.swift
+++ b/Sources/VibeBarApp/Controllers/SessionManagerModel.swift
@@ -106,6 +106,8 @@ final class SessionManagerModel: ObservableObject {
     @Published private(set) var rows: [Row] = []
     @Published private(set) var groupedRows: [ProjectGroup] = []
     @Published private(set) var providerCounts: [SessionProvider: Int] = [:]
+    @Published private(set) var totalSessionCount = 0
+    @Published private(set) var isLoadingSummaries = false
 
     @Published var searchText = "" {
         didSet {
@@ -116,13 +118,20 @@ final class SessionManagerModel: ObservableObject {
     }
 
     @Published var providerFilter: Set<SessionProvider>? {
-        didSet { refreshRows() }
+        didSet {
+            reloadSummaryPage(reset: true)
+            rerunSearch()
+            refreshRows()
+        }
     }
     @Published var dateRange: DateRange = .all {
-        didSet { refreshRows() }
+        didSet {
+            reloadSummaryPage(reset: true)
+            refreshRows()
+        }
     }
     @Published var sortOrder: SortOrder = .recentFirst {
-        didSet { refreshRows() }
+        didSet { reloadSummaryPage(reset: true) }
     }
     @Published var groupByProject = false {
         didSet { refreshRows() }
@@ -171,6 +180,7 @@ final class SessionManagerModel: ObservableObject {
     private var toastTask: Task<Void, Never>?
     private var transcriptGeneration: UInt64 = 0
     private var searchGeneration: UInt64 = 0
+    private var summaryGeneration: UInt64 = 0
     private var hasActivated = false
     private var lastScanFinishedAt: Date?
 
@@ -182,7 +192,12 @@ final class SessionManagerModel: ObservableObject {
     private static let searchDebounce = Duration.milliseconds(250)
     /// The index reports per file; publishing every one of those would put
     /// thousands of main-actor hops between the user and a scroll.
-    private nonisolated static let progressStride = 25
+    private nonisolated static let progressStride = 250
+    private static let summaryPageSize = 250
+
+    var hasMoreSummaries: Bool {
+        summaries.count < totalSessionCount
+    }
 
     /// `AppSettings.sessionBodyIndexingEnabled`, readable from the index
     /// actor's executor. The setting lives on the main actor and the scan
@@ -243,7 +258,7 @@ final class SessionManagerModel: ObservableObject {
     /// switching between Workbench pages re-runs this too, and a full sweep
     /// of every provider's logs is not what a tab click should cost.
     func activate() {
-        loadSummaries()
+        reloadSummaryPage(reset: true)
         guard refreshTask == nil else { return }
         if let last = lastScanFinishedAt, Date().timeIntervalSince(last) < Self.rescanMinimumInterval {
             return
@@ -280,7 +295,7 @@ final class SessionManagerModel: ObservableObject {
             self.indexProgress = nil
             self.refreshTask = nil
             self.lastScanFinishedAt = Date()
-            self.loadSummaries()
+            self.reloadSummaryPage(reset: true)
             self.rerunSearch()
         }
     }
@@ -297,16 +312,53 @@ final class SessionManagerModel: ObservableObject {
             if !cleared { self.show(toast: "The session index could not be cleared.") }
             self.summaries = []
             self.hits = []
+            self.totalSessionCount = 0
             self.refreshIndex()
         }
     }
 
-    private func loadSummaries() {
+    func loadMoreSummaries() {
+        guard searchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+              hasMoreSummaries,
+              !isLoadingSummaries
+        else { return }
+        reloadSummaryPage(reset: false)
+    }
+
+    private func reloadSummaryPage(reset: Bool) {
         guard let service else { return }
+        summaryGeneration &+= 1
+        let generation = summaryGeneration
+        let offset = reset ? 0 : summaries.count
+        let providers = providerFilter.map { Array($0).sorted { $0.rawValue < $1.rawValue } }
+        let since = dateRange.start()
+        let order: SessionSummaryOrder
+        switch sortOrder {
+        case .recentFirst: order = .recentFirst
+        case .oldestFirst: order = .oldestFirst
+        case .byProject: order = .byProject
+        }
+        isLoadingSummaries = true
         Task { [weak self] in
-            let loaded = (try? await service.allSummaries()) ?? []
-            guard let self else { return }
-            self.summaries = loaded
+            let page = try? await service.summaryPage(
+                providers: providers,
+                since: since,
+                order: order,
+                offset: offset,
+                limit: Self.summaryPageSize
+            )
+            let counts = reset ? (try? await service.providerCounts()) : nil
+            guard let self, generation == self.summaryGeneration else { return }
+            self.isLoadingSummaries = false
+            guard let page else { return }
+            if reset {
+                self.summaries = page.summaries
+            } else {
+                let existing = Set(self.summaries.map(\.id))
+                self.summaries.append(contentsOf: page.summaries.filter { !existing.contains($0.id) })
+            }
+            self.totalSessionCount = page.totalCount
+            if let counts { self.providerCounts = counts }
             self.reconcileSelection()
         }
     }
@@ -369,14 +421,8 @@ final class SessionManagerModel: ObservableObject {
                 Row(summary: $0, snippet: nil, matchedSeq: nil)
             }
         }
-        rows = sorted(base.filter(passesFilters))
+        rows = needle.isEmpty ? base : sorted(base.filter(passesFilters))
         groupedRows = groupByProject ? Self.grouped(rows) : []
-
-        var counts: [SessionProvider: Int] = [:]
-        for summary in summaries {
-            counts[summary.provider, default: 0] += 1
-        }
-        providerCounts = counts
     }
 
     private static func grouped(_ rows: [Row]) -> [ProjectGroup] {
@@ -462,7 +508,6 @@ final class SessionManagerModel: ObservableObject {
 
     func setProviderFilter(_ providers: Set<SessionProvider>?) {
         providerFilter = (providers?.isEmpty ?? true) ? nil : providers
-        rerunSearch()
     }
 
     // MARK: - Selection
@@ -655,7 +700,7 @@ final class SessionManagerModel: ObservableObject {
             try? await store.removeSessions(sourcePathIn: removed.map(\.sourcePath))
         }
         checkedIDs.subtract(removed.map(\.id))
-        loadSummaries()
+        reloadSummaryPage(reset: true)
 
         let failures = outcomes.filter { !$0.success }
         if failures.isEmpty {

--- a/Sources/VibeBarApp/Controllers/SkillsManagerModel.swift
+++ b/Sources/VibeBarApp/Controllers/SkillsManagerModel.swift
@@ -106,11 +106,12 @@ final class SkillsManagerModel: ObservableObject {
 
     // MARK: - Lifecycle
 
-    /// Loads the registry, and — on a machine that has skills on disk but
-    /// nothing recorded — opens the import sheet unasked. That is the primary
-    /// onboarding path: `~/.agents/skills` is usually already full, linked
-    /// into the app dirs by another installer, and recording it is a read-only
-    /// scan followed by one confirmation.
+    /// Loads the registry and reconciles an existing canonical layout without
+    /// pretending it needs to be imported again. CC Switch and other installers
+    /// already use `~/.agents/skills` as the shared source; recording those
+    /// directories in Vibe Bar changes no skill payload or app link, so it is a
+    /// safe first-run migration. Only app-local directories that genuinely need
+    /// to be copied into the shared source open the review sheet.
     func activate() {
         guard !hasActivated else { return }
         hasActivated = true
@@ -119,9 +120,31 @@ final class SkillsManagerModel: ObservableObject {
             repoList = await service.discoverRepos()
             guard skills.isEmpty else { return }
             let report = await scanForImport()
-            guard !report.adopted.isEmpty || !report.unmanagedDirectories.isEmpty else { return }
-            importReport = report
-            isImportSheetPresented = true
+            guard !report.isEmpty else { return }
+            do {
+                if !report.adopted.isEmpty {
+                    _ = try await service.importAdopted(report)
+                    await reloadSkills()
+                }
+                if !report.unmanagedDirectories.isEmpty {
+                    importReport = SkillImportReport(
+                        adopted: [],
+                        unmanagedDirectories: report.unmanagedDirectories,
+                        unrecognized: report.unrecognized,
+                        conflicts: report.conflicts
+                    )
+                    isImportSheetPresented = true
+                } else if !report.conflicts.isEmpty {
+                    toast = "Recognized \(report.adopted.count) existing skills. "
+                        + "Left \(report.conflicts.count) conflicting app copies unchanged."
+                }
+            } catch {
+                // Nothing on disk was rewritten by adoption; leave the full
+                // report available so the user can retry explicitly.
+                importReport = report
+                isImportSheetPresented = true
+                toast = error.localizedDescription
+            }
         }
     }
 

--- a/Sources/VibeBarApp/Controllers/UsageStatsViewModel.swift
+++ b/Sources/VibeBarApp/Controllers/UsageStatsViewModel.swift
@@ -12,13 +12,13 @@ final class UsageStatsViewModel: ObservableObject {
     /// Range presets deliberately mix two shapes:
     ///
     /// - `today` is the local calendar day so far — midnight → now.
-    /// - every `N`-day preset is a *rolling* window of exactly `N × 86400`
-    ///   seconds ending now.
+    /// - `24 h` is a rolling window ending now;
+    /// - every multi-day preset is aligned to local calendar days, matching
+    ///   `CostSnapshot.last7Days*` / `last30Days*` everywhere else in Vibe Bar.
     ///
-    /// Making the N-day presets calendar-aligned too would collapse "Today"
-    /// and "24 h" into the same button for most of the day, and a rolling
-    /// 24 h window is also what keeps `UsageTrendBucket.recommended` on
-    /// hourly buckets for the shortest preset.
+    /// Keeping only `24 h` rolling preserves an hourly comparison without
+    /// creating a second, contradictory definition of "7 days" inside the
+    /// same app.
     enum RangePreset: String, CaseIterable, Identifiable {
         case today
         case day1
@@ -51,15 +51,12 @@ final class UsageStatsViewModel: ObservableObject {
             }
         }
 
-        /// Seconds of the rolling window, `nil` for the two presets that are
-        /// not a fixed span.
-        var rollingSpan: TimeInterval? {
+        var calendarDayCount: Int? {
             switch self {
-            case .today, .custom: nil
-            case .day1:  86_400
-            case .day7:  7 * 86_400
-            case .day14: 14 * 86_400
-            case .day30: 30 * 86_400
+            case .day7: 7
+            case .day14: 14
+            case .day30: 30
+            case .today, .day1, .custom: nil
             }
         }
     }
@@ -146,9 +143,17 @@ final class UsageStatsViewModel: ObservableObject {
             let start = min(customStart, customEnd)
             let end = max(customStart, customEnd)
             return DateInterval(start: start, end: max(end, start.addingTimeInterval(60)))
-        case .day1, .day7, .day14, .day30:
-            let span = rangePreset.rollingSpan ?? 86_400
-            return DateInterval(start: now.addingTimeInterval(-span), end: now)
+        case .day1:
+            return DateInterval(start: now.addingTimeInterval(-86_400), end: now)
+        case .day7, .day14, .day30:
+            let days = rangePreset.calendarDayCount ?? 1
+            let today = Calendar.current.startOfDay(for: now)
+            let start = Calendar.current.date(
+                byAdding: .day,
+                value: -(days - 1),
+                to: today
+            ) ?? today
+            return DateInterval(start: start, end: now)
         }
     }
 

--- a/Sources/VibeBarApp/Views/RemoteMachinesPage.swift
+++ b/Sources/VibeBarApp/Views/RemoteMachinesPage.swift
@@ -1,6 +1,43 @@
 import SwiftUI
 import VibeBarCore
 
+enum RemoteSyncStatusCopy {
+    static func title(for code: String) -> String {
+        switch code {
+        case "network_offline": return "This Mac is offline"
+        case "network_timeout": return "Relay connection timed out"
+        case "host_lookup_failed": return "Relay host could not be resolved"
+        case "connection_failed": return "Relay connection was interrupted"
+        case "secure_connection_failed": return "Secure Relay connection failed"
+        case "relay_http_401", "relay_http_403": return "Relay access was rejected"
+        case "relay_http_429", "relay_http_503": return "Relay is temporarily busy"
+        case "sequence_gap": return "Probe history has a sequence gap"
+        case "invalid_signature", "unauthorized_producer": return "A Probe could not be verified"
+        case "invalid_response": return "Relay returned an unexpected response"
+        case "sync_failed", "transport_failed": return "Relay transport failed"
+        default: return "Remote sync needs attention"
+        }
+    }
+
+    static func detail(for code: String) -> String {
+        switch code {
+        case "network_timeout", "connection_failed", "secure_connection_failed",
+             "relay_http_429", "relay_http_503":
+            return "Existing machine data is still available. Vibe Bar will retry automatically."
+        case "network_offline", "host_lookup_failed":
+            return "Check this Mac's network or proxy path; existing machine data is still available."
+        case "relay_http_401", "relay_http_403":
+            return "The workspace credential may have been revoked. Reconnect this Core in Settings."
+        case "sequence_gap":
+            return "A Probe batch is missing from the Relay stream, so later batches were not imported."
+        case "invalid_signature", "unauthorized_producer":
+            return "The current workspace roster does not authorize one of the received batches."
+        default:
+            return "No local usage was deleted. Retry now or inspect Remote Core settings for the error code."
+        }
+    }
+}
+
 struct RemoteMachinesPage: View {
     let density: Theme.Density
 
@@ -19,7 +56,7 @@ struct RemoteMachinesPage: View {
                 stateCard(
                     icon: service.isRefreshing ? "arrow.triangle.2.circlepath" : "server.rack",
                     title: service.isRefreshing ? "Checking the Relay…" : "No remote machine data yet",
-                    detail: service.lastErrorCode.map { "Sync state: \($0)" }
+                    detail: service.lastErrorCode.map { RemoteSyncStatusCopy.detail(for: $0) }
                         ?? "The Relay is connected. A Probe will appear after its first encrypted batch is decrypted and imported."
                 )
             } else {
@@ -245,13 +282,36 @@ struct RemoteMachinesPage: View {
     }
 
     private func syncErrorBanner(_ code: String) -> some View {
-        HStack(alignment: .firstTextBaseline, spacing: 7) {
+        HStack(alignment: .top, spacing: 9) {
             Image(systemName: "exclamationmark.triangle.fill")
                 .foregroundStyle(.orange)
-            Text("Latest sync: \(code)")
-                .foregroundStyle(.secondary)
-                .fixedSize(horizontal: false, vertical: true)
+                .padding(.top, 2)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(RemoteSyncStatusCopy.title(for: code))
+                    .fontWeight(.semibold)
+                    .foregroundStyle(.primary)
+                Text(RemoteSyncStatusCopy.detail(for: code))
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+                Text(code)
+                    .font(.caption2.monospaced())
+                    .foregroundStyle(.tertiary)
+            }
             Spacer(minLength: 0)
+            Button {
+                Task { await service.refresh() }
+            } label: {
+                Label("Retry", systemImage: "arrow.clockwise")
+                    .font(.system(size: max(9, density.segmentedFontSize - 1), weight: .semibold))
+                    .padding(.horizontal, 10)
+                    .frame(minHeight: 26)
+                    .background(
+                        RoundedRectangle(cornerRadius: 8, style: .continuous)
+                            .fill(Color.orange.opacity(0.12))
+                    )
+            }
+            .buttonStyle(.plain)
+            .disabled(service.isRefreshing)
         }
         .font(.system(size: density.subtitleFontSize))
         .padding(density.cardPadding)

--- a/Sources/VibeBarApp/Views/RemoteSettingsSection.swift
+++ b/Sources/VibeBarApp/Views/RemoteSettingsSection.swift
@@ -87,7 +87,7 @@ struct RemoteSettingsSection: View {
                 infoRow("Machines synced", "\(service.machines.count)")
                 infoRow("Last sync", lastSyncText)
                 if let code = service.lastErrorCode {
-                    Text("Latest sync error: \(code)")
+                    Text("\(RemoteSyncStatusCopy.title(for: code)) · \(code)")
                         .font(.caption2)
                         .foregroundStyle(.orange)
                 }

--- a/Sources/VibeBarApp/Views/Workbench/SessionListView.swift
+++ b/Sources/VibeBarApp/Views/Workbench/SessionListView.swift
@@ -41,6 +41,15 @@ struct SessionListView: View {
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .overlay(alignment: .bottom) {
+            if model.isLoadingSummaries && !model.rows.isEmpty {
+                ProgressView()
+                    .controlSize(.small)
+                    .padding(8)
+                    .background(.regularMaterial, in: Capsule())
+                    .padding(.bottom, 8)
+            }
+        }
     }
 
     private func rowView(_ row: SessionManagerModel.Row) -> some View {
@@ -55,6 +64,9 @@ struct SessionListView: View {
         )
         .listRowInsets(EdgeInsets(top: 2, leading: 4, bottom: 2, trailing: 4))
         .listRowSeparator(.hidden)
+        .onAppear {
+            if row.id == model.rows.last?.id { model.loadMoreSummaries() }
+        }
         .contextMenu {
             Button("Open in Terminal") { model.resumeInTerminal(row.summary) }
                 .disabled(model.resumeCommand(for: row.summary) == nil)

--- a/Sources/VibeBarApp/Views/Workbench/SessionManagerPage.swift
+++ b/Sources/VibeBarApp/Views/Workbench/SessionManagerPage.swift
@@ -162,6 +162,10 @@ struct SessionFiltersBar: View {
     private var countSummary: String {
         guard model.isIndexAvailable else { return "index unavailable" }
         let shown = model.rows.count
+        if model.searchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+           shown < model.totalSessionCount {
+            return "\(shown) of \(model.totalSessionCount) sessions"
+        }
         return shown == 1 ? "1 session" : "\(shown) sessions"
     }
 

--- a/Sources/VibeBarApp/Views/Workbench/SkillImportSheet.swift
+++ b/Sources/VibeBarApp/Views/Workbench/SkillImportSheet.swift
@@ -16,6 +16,7 @@ struct SkillImportSheet: View {
     @Environment(\.dismiss) private var dismiss
     @State private var adoptedApps: Set<SkillAppTarget> = []
     @State private var adopting: [String: Set<SkillAppTarget>] = [:]
+    @State private var showsExistingSkills = false
 
     private var report: SkillImportReport? { model.importReport }
 
@@ -26,7 +27,7 @@ struct SkillImportSheet: View {
             if let report {
                 ScrollView {
                     VStack(alignment: .leading, spacing: density.interSectionSpacing) {
-                        adoptedSection(report)
+                        if !report.adopted.isEmpty { adoptedSection(report) }
                         if !report.unmanagedDirectories.isEmpty { unmanagedSection(report) }
                         if !report.unrecognized.isEmpty { unrecognizedSection(report) }
                         if !report.conflicts.isEmpty { conflictsSection(report) }
@@ -54,9 +55,9 @@ struct SkillImportSheet: View {
     private var header: some View {
         HStack(spacing: 10) {
             VStack(alignment: .leading, spacing: 2) {
-                Text("Import Existing Skills")
+                Text("Review On-Disk Skills")
                     .font(.system(size: density.titleFontSize, weight: .semibold))
-                Text("Nothing here has been changed yet — this is what is on the machine.")
+                Text("Vibe Bar already recognizes shared skills. Only selected app-local folders will move.")
                     .font(.system(size: density.subtitleFontSize))
                     .foregroundStyle(.secondary)
             }
@@ -87,7 +88,7 @@ struct SkillImportSheet: View {
                     if model.isBusy(SkillsManagerModel.BusyKey.importing) {
                         ProgressView().controlSize(.small).scaleEffect(0.7).frame(width: 12, height: 12)
                     }
-                    Text("Record \(report.adopted.count + adopting.count) skill"
+                    Text("Apply \(report.adopted.count + adopting.count) change"
                         + (report.adopted.count + adopting.count == 1 ? "" : "s"))
                 }
             }
@@ -100,57 +101,57 @@ struct SkillImportSheet: View {
     }
 
     private func summary(_ report: SkillImportReport) -> String {
-        "\(report.adopted.count) in ~/.agents/skills · \(report.unmanagedDirectories.count) app-side "
-            + "· \(report.conflicts.count) conflict\(report.conflicts.count == 1 ? "" : "s")"
+        "\(report.adopted.count) already shared · \(report.unmanagedDirectories.count) need adoption "
+            + "· \(report.conflicts.count) left unchanged"
     }
 
     // MARK: - Adopted
 
     private func adoptedSection(_ report: SkillImportReport) -> some View {
         CardShell(density: density, spacing: density.cardSpacing) {
-            sectionHeader(
-                "Already in ~/.agents/skills",
-                detail: "\(report.adopted.count) skill\(report.adopted.count == 1 ? "" : "s")"
-            )
-            Text("These have a SKILL.md in the shared directory. Recording them writes nothing to "
-                + "disk — it only teaches Vibe Bar which apps already link to them.")
-                .font(.system(size: density.subtitleFontSize))
-                .foregroundStyle(.secondary)
-            if report.adopted.isEmpty {
-                Text("Nothing found.")
-                    .font(.system(size: density.subtitleFontSize))
-                    .foregroundStyle(.tertiary)
-            } else {
-                HStack(spacing: 8) {
-                    Text("Keep evidence for")
-                        .font(.system(size: max(9, density.resetCountdownFontSize)))
-                        .foregroundStyle(.tertiary)
-                    SkillAppToggleRow(
-                        isOn: { adoptedApps.contains($0) },
-                        toggle: { adoptedApps.formSymmetricDifference([$0]) },
-                        diameter: 22,
-                        glyphSize: 11,
-                        spacing: 3,
-                        helpSuffix: "keep the links already on disk"
-                    )
-                }
-                VStack(alignment: .leading, spacing: 2) {
-                    ForEach(report.adopted) { skill in
-                        HStack(spacing: 8) {
-                            Text(skill.name)
-                                .font(.system(size: density.subtitleFontSize))
-                                .lineLimit(1)
-                            Spacer(minLength: 8)
-                            HStack(spacing: 3) {
-                                ForEach(skill.enabledApps, id: \.self) { app in
-                                    SkillAppGlyph(app: app, size: 11)
-                                        .help(app.displayName)
+            DisclosureGroup(isExpanded: $showsExistingSkills) {
+                VStack(alignment: .leading, spacing: 8) {
+                    HStack(spacing: 8) {
+                        Text("Keep evidence for")
+                            .font(.system(size: max(9, density.resetCountdownFontSize)))
+                            .foregroundStyle(.tertiary)
+                        SkillAppToggleRow(
+                            isOn: { adoptedApps.contains($0) },
+                            toggle: { adoptedApps.formSymmetricDifference([$0]) },
+                            diameter: 22,
+                            glyphSize: 11,
+                            spacing: 3,
+                            helpSuffix: "keep the links already on disk"
+                        )
+                    }
+                    LazyVStack(alignment: .leading, spacing: 2) {
+                        ForEach(report.adopted) { skill in
+                            HStack(spacing: 8) {
+                                Text(skill.name)
+                                    .font(.system(size: density.subtitleFontSize))
+                                    .lineLimit(1)
+                                Spacer(minLength: 8)
+                                HStack(spacing: 3) {
+                                    ForEach(skill.enabledApps, id: \.self) { app in
+                                        SkillAppGlyph(app: app, size: 11)
+                                            .help(app.displayName)
+                                    }
                                 }
                             }
                         }
                     }
                 }
+                .padding(.top, 8)
+            } label: {
+                sectionHeader(
+                    "Already shared",
+                    detail: "\(report.adopted.count) recognized"
+                )
             }
+            Text("These already live in ~/.agents/skills, including layouts created by CC Switch. "
+                + "Vibe Bar records their existing links; it does not import or copy them again.")
+                .font(.system(size: density.subtitleFontSize))
+                .foregroundStyle(.secondary)
         }
     }
 
@@ -159,11 +160,11 @@ struct SkillImportSheet: View {
     private func unmanagedSection(_ report: SkillImportReport) -> some View {
         CardShell(density: density, spacing: density.cardSpacing) {
             sectionHeader(
-                "Only inside an app's own folder",
+                "Needs adoption",
                 detail: "\(report.unmanagedDirectories.count)"
             )
-            Text("Adopting one copies it into ~/.agents/skills and replaces the original folder "
-                + "with a link, so every app you pick reads the same copy.")
+            Text("These do not exist in the shared directory yet. Selecting one copies it into "
+                + "~/.agents/skills, then replaces the chosen app copies with managed links.")
                 .font(.system(size: density.subtitleFontSize))
                 .foregroundStyle(.secondary)
             ForEach(report.unmanagedDirectories, id: \.directoryName) { entry in
@@ -225,7 +226,7 @@ struct SkillImportSheet: View {
 
     private func conflictsSection(_ report: SkillImportReport) -> some View {
         CardShell(density: density, spacing: density.cardSpacing) {
-            sectionHeader("Shadowing a shared skill", detail: "\(report.conflicts.count)")
+            sectionHeader("Conflicting app copies", detail: "\(report.conflicts.count) unchanged")
             Text("A real folder in an app's skills directory has the same name as one in "
                 + "~/.agents/skills. Vibe Bar will not overwrite it — resolve it by hand, or "
                 + "enable the shared skill for that app once the folder is gone.")

--- a/Sources/VibeBarApp/Views/Workbench/UsageBreakdownTables.swift
+++ b/Sources/VibeBarApp/Views/Workbench/UsageBreakdownTables.swift
@@ -1,18 +1,20 @@
 import SwiftUI
 import VibeBarCore
 
-/// The bottom half of the Usage Stats page: the same range, read three ways.
+/// The bottom half of the Usage Stats page: the same range, read four ways.
 ///
-/// One card with a segmented switch rather than three stacked tables — the
-/// three views answer the same question at different resolutions, and only
-/// one of them is ever the one being read.
+/// The selector is intentionally drawn in Vibe Bar's own card vocabulary
+/// rather than using AppKit's default segmented control. Periods exposes the
+/// exact buckets behind the chart, so a visual and its table can be reconciled
+/// without switching to another page.
 struct UsageBreakdownTables: View {
     let density: Theme.Density
     @ObservedObject var model: UsageStatsViewModel
 
-    @State private var tab: Tab = .requests
+    @State private var tab: Tab = .periods
 
     enum Tab: String, CaseIterable, Identifiable {
+        case periods
         case requests
         case providers
         case models
@@ -21,9 +23,19 @@ struct UsageBreakdownTables: View {
 
         var title: String {
             switch self {
+            case .periods:   "Periods"
             case .requests:  "Requests"
             case .providers: "Providers"
             case .models:    "Models"
+            }
+        }
+
+        var systemImage: String {
+            switch self {
+            case .periods:   "calendar.day.timeline.leading"
+            case .requests:  "list.bullet.rectangle"
+            case .providers: "square.grid.2x2"
+            case .models:    "cpu"
             }
         }
     }
@@ -44,6 +56,10 @@ struct UsageBreakdownTables: View {
         model.modelStats.sorted { $0.costMicros > $1.costMicros }
     }
 
+    private var populatedPeriods: [UsageTrendPoint] {
+        Array(model.trend.points.filter { $0.totalTokens > 0 || $0.costMicros != 0 }.reversed())
+    }
+
     var body: some View {
         CardShell(density: density, spacing: density.cardSpacing) {
             header
@@ -56,14 +72,43 @@ struct UsageBreakdownTables: View {
 
     private var header: some View {
         HStack(spacing: 10) {
-            Picker("", selection: $tab) {
+            HStack(spacing: 2) {
                 ForEach(Tab.allCases) { value in
-                    Text(value.title).tag(value)
+                    let selected = tab == value
+                    Button {
+                        withAnimation(.easeOut(duration: 0.16)) { tab = value }
+                    } label: {
+                        Label(value.title, systemImage: value.systemImage)
+                            .font(.system(size: max(9, density.segmentedFontSize - 1), weight: .semibold))
+                            .labelStyle(.titleAndIcon)
+                            .foregroundStyle(selected ? Color.primary : Color.secondary)
+                            .padding(.horizontal, 10)
+                            .frame(minHeight: 25)
+                    }
+                    .buttonStyle(.plain)
+                    .background(
+                        RoundedRectangle(cornerRadius: 7, style: .continuous)
+                            .fill(selected ? Color.accentColor.opacity(0.16) : Color.clear)
+                    )
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 7, style: .continuous)
+                            .stroke(
+                                selected ? Color.accentColor.opacity(0.38) : Color.clear,
+                                lineWidth: 0.7
+                            )
+                    )
+                    .accessibilityAddTraits(selected ? [.isSelected] : [])
                 }
             }
-            .pickerStyle(.segmented)
-            .labelsHidden()
-            .fixedSize()
+            .padding(2)
+            .background(
+                RoundedRectangle(cornerRadius: 9, style: .continuous)
+                    .fill(Color.primary.opacity(0.045))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 9, style: .continuous)
+                    .stroke(Color.primary.opacity(0.08), lineWidth: 0.6)
+            )
             Spacer(minLength: 8)
             Text(countSummary)
                 .font(.system(size: max(9, density.resetCountdownFontSize), design: .rounded)
@@ -78,6 +123,9 @@ struct UsageBreakdownTables: View {
 
     private var countSummary: String {
         switch tab {
+        case .periods:
+            return "\(populatedPeriods.count) active \(model.trend.bucket == .hour ? "hour" : "day")"
+                + (populatedPeriods.count == 1 ? "" : "s")
         case .requests:
             let loaded = model.requestRows.count
             let total = model.requestTotalCount
@@ -96,6 +144,12 @@ struct UsageBreakdownTables: View {
     @ViewBuilder
     private var content: some View {
         switch tab {
+        case .periods:
+            if populatedPeriods.isEmpty {
+                empty("No active periods in this range")
+            } else {
+                periodsTable
+            }
         case .requests:
             if model.requestRows.isEmpty {
                 empty("No request-level rows in this range")
@@ -115,6 +169,47 @@ struct UsageBreakdownTables: View {
                 modelsTable
             }
         }
+    }
+
+    private var periodsTable: some View {
+        Table(populatedPeriods) {
+            TableColumn(model.trend.bucket == .hour ? "Hour" : "Day") { point in
+                Text(period(point.bucketStart))
+                    .font(bodyFont)
+            }
+            .width(min: 130, ideal: 190)
+
+            TableColumn("Input") { point in
+                Text(UsageFormatting.compactTokens(point.freshInput))
+                    .font(numericFont)
+            }
+            .width(min: 82, ideal: 104)
+
+            TableColumn("Output") { point in
+                Text(UsageFormatting.compactTokens(point.output))
+                    .font(numericFont)
+            }
+            .width(min: 82, ideal: 104)
+
+            TableColumn("Cache") { point in
+                Text(UsageFormatting.compactTokens(point.cacheRead + point.cacheCreation))
+                    .font(numericFont)
+            }
+            .width(min: 82, ideal: 104)
+
+            TableColumn("Tokens") { point in
+                Text(UsageFormatting.compactTokens(point.totalTokens))
+                    .font(numericFont)
+            }
+            .width(min: 88, ideal: 112)
+
+            TableColumn("Cost") { point in
+                Text(UsageFormatting.formatMicroUSD(point.costMicros))
+                    .font(numericFont)
+            }
+            .width(min: 88, ideal: 112)
+        }
+        .tableStyle(.inset(alternatesRowBackgrounds: false))
     }
 
     private var requestsTable: some View {
@@ -185,7 +280,7 @@ struct UsageBreakdownTables: View {
             }
             .width(min: 62, ideal: 78)
         }
-        .tableStyle(.inset(alternatesRowBackgrounds: true))
+        .tableStyle(.inset(alternatesRowBackgrounds: false))
     }
 
     private var providersTable: some View {
@@ -213,7 +308,7 @@ struct UsageBreakdownTables: View {
             }
             .width(min: 84, ideal: 110)
         }
-        .tableStyle(.inset(alternatesRowBackgrounds: true))
+        .tableStyle(.inset(alternatesRowBackgrounds: false))
     }
 
     private var modelsTable: some View {
@@ -252,7 +347,7 @@ struct UsageBreakdownTables: View {
             }
             .width(min: 88, ideal: 108)
         }
-        .tableStyle(.inset(alternatesRowBackgrounds: true))
+        .tableStyle(.inset(alternatesRowBackgrounds: false))
     }
 
     // MARK: - Cells
@@ -296,12 +391,31 @@ struct UsageBreakdownTables: View {
         Self.timestampFormatter.string(from: date)
     }
 
+    private func period(_ date: Date) -> String {
+        let formatter = model.trend.bucket == .hour ? Self.periodHourFormatter : Self.periodDayFormatter
+        return formatter.string(from: date)
+    }
+
     /// Cached: the requests table formats one of these per visible row, and
     /// building a `DateFormatter` per cell is the expensive half of scrolling.
     private static let timestampFormatter: DateFormatter = {
         let formatter = DateFormatter()
         formatter.locale = Locale.current
         formatter.setLocalizedDateFormatFromTemplate("MMMd HH:mm:ss")
+        return formatter
+    }()
+
+    private static let periodHourFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.locale = Locale.current
+        formatter.setLocalizedDateFormatFromTemplate("EEEMMMdHHmm")
+        return formatter
+    }()
+
+    private static let periodDayFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.locale = Locale.current
+        formatter.setLocalizedDateFormatFromTemplate("EEEEMMMd")
         return formatter
     }()
 }

--- a/Sources/VibeBarApp/Views/Workbench/UsageCompositionCards.swift
+++ b/Sources/VibeBarApp/Views/Workbench/UsageCompositionCards.swift
@@ -1,0 +1,168 @@
+import SwiftUI
+import VibeBarCore
+
+/// Two compact explanations of the selected range: where traffic came from
+/// and what kind of tokens moved. Both are projections of the same filtered
+/// ledger query as the headline cards and chart, so they cannot drift into a
+/// second usage definition.
+struct UsageCompositionCards: View {
+    let density: Theme.Density
+    let summary: UsageSummaryMetrics
+    let providers: [UsageProviderStat]
+
+    private var providerRows: [UsageProviderStat] {
+        providers
+            .filter { $0.totalTokens > 0 }
+            .sorted { lhs, rhs in
+                if lhs.totalTokens != rhs.totalTokens {
+                    return lhs.totalTokens > rhs.totalTokens
+                }
+                return lhs.tool.rawValue < rhs.tool.rawValue
+            }
+            .prefix(6)
+            .map { $0 }
+    }
+
+    var body: some View {
+        HStack(alignment: .top, spacing: density.interSectionSpacing) {
+            providerMix
+            tokenFlow
+        }
+    }
+
+    private var providerMix: some View {
+        CardShell(density: density, spacing: 8) {
+            sectionTitle("PROVIDER MIX", detail: "by real tokens")
+            if providerRows.isEmpty {
+                emptyLine("No provider traffic in this range")
+            } else {
+                ForEach(providerRows) { row in
+                    providerRow(row)
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .topLeading)
+    }
+
+    private func providerRow(_ row: UsageProviderStat) -> some View {
+        let total = max(1, summary.realTotalTokens)
+        let fraction = min(1, max(0, Double(row.totalTokens) / Double(total)))
+        let tint = Theme.providerAccent(for: row.tool)
+        return VStack(spacing: 4) {
+            HStack(spacing: 7) {
+                ToolBrandBadge(tool: row.tool, iconSize: 12, containerSize: 18)
+                Text(row.tool.displayName)
+                    .font(.system(size: density.subtitleFontSize, weight: .semibold))
+                    .lineLimit(1)
+                Spacer(minLength: 6)
+                Text(fraction.formatted(.percent.precision(.fractionLength(0))))
+                    .foregroundStyle(.secondary)
+                Text(UsageFormatting.compactTokens(row.totalTokens))
+                    .frame(minWidth: 50, alignment: .trailing)
+            }
+            .font(.system(size: max(9, density.resetCountdownFontSize), design: .rounded)
+                .monospacedDigit())
+            GeometryReader { geometry in
+                ZStack(alignment: .leading) {
+                    Capsule().fill(Theme.barTrack)
+                    Capsule()
+                        .fill(tint.gradient)
+                        .frame(width: geometry.size.width * fraction)
+                }
+            }
+            .frame(height: max(5, density.bucketBarHeight - 5))
+            .accessibilityHidden(true)
+        }
+    }
+
+    private var tokenFlow: some View {
+        CardShell(density: density, spacing: 10) {
+            sectionTitle("TOKEN FLOW", detail: "input, output & cache")
+            compositionBar
+            LazyVGrid(
+                columns: [GridItem(.flexible()), GridItem(.flexible())],
+                alignment: .leading,
+                spacing: 8
+            ) {
+                legend("Fresh input", value: summary.freshInput, tint: .blue)
+                legend("Output", value: summary.output, tint: .purple)
+                legend("Cache read", value: summary.cacheRead, tint: .green)
+                legend("Cache write", value: summary.cacheCreation, tint: .orange)
+            }
+            Divider().opacity(0.3)
+            HStack(spacing: 8) {
+                Label("Cache hit", systemImage: "bolt.fill")
+                    .foregroundStyle(.secondary)
+                Spacer(minLength: 6)
+                Text(UsageFormatting.formatPercent(summary.cacheHitRate))
+                    .fontWeight(.semibold)
+                if summary.unpricedRequests > 0 {
+                    Text("\(summary.unpricedRequests) unpriced")
+                        .font(.system(size: max(8, density.resetCountdownFontSize - 1), weight: .semibold))
+                        .foregroundStyle(.orange)
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .background(Capsule().fill(Color.orange.opacity(0.13)))
+                }
+            }
+            .font(.system(size: density.subtitleFontSize, design: .rounded).monospacedDigit())
+        }
+        .frame(maxWidth: .infinity, alignment: .topLeading)
+    }
+
+    private var compositionBar: some View {
+        GeometryReader { geometry in
+            let total = max(1, summary.realTotalTokens)
+            HStack(spacing: 2) {
+                segment(summary.freshInput, total: total, tint: .blue, width: geometry.size.width)
+                segment(summary.output, total: total, tint: .purple, width: geometry.size.width)
+                segment(summary.cacheRead, total: total, tint: .green, width: geometry.size.width)
+                segment(summary.cacheCreation, total: total, tint: .orange, width: geometry.size.width)
+            }
+            .clipShape(Capsule())
+            .background(Capsule().fill(Theme.barTrack))
+        }
+        .frame(height: max(10, density.bucketBarHeight))
+        .accessibilityLabel("Token composition")
+    }
+
+    private func segment(_ value: Int64, total: Int64, tint: Color, width: CGFloat) -> some View {
+        Rectangle()
+            .fill(tint.gradient)
+            .frame(width: value > 0 ? width * Double(value) / Double(total) : 0)
+    }
+
+    private func legend(_ label: String, value: Int64, tint: Color) -> some View {
+        HStack(spacing: 7) {
+            Circle().fill(tint).frame(width: 7, height: 7)
+            VStack(alignment: .leading, spacing: 1) {
+                Text(label)
+                    .font(.system(size: max(9, density.resetCountdownFontSize)))
+                    .foregroundStyle(.secondary)
+                Text(UsageFormatting.compactTokens(value))
+                    .font(.system(size: density.subtitleFontSize, weight: .semibold, design: .rounded)
+                        .monospacedDigit())
+            }
+        }
+    }
+
+    private func sectionTitle(_ title: String, detail: String) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: 8) {
+            Text(title)
+                .font(.system(size: max(8, density.subtitleFontSize - 2), weight: .semibold))
+                .foregroundStyle(.tertiary)
+                .tracking(0.4)
+            Spacer(minLength: 6)
+            Text(detail)
+                .font(.system(size: max(9, density.resetCountdownFontSize - 1)))
+                .foregroundStyle(.tertiary)
+        }
+    }
+
+    private func emptyLine(_ text: String) -> some View {
+        Text(text)
+            .font(.system(size: density.subtitleFontSize))
+            .foregroundStyle(.secondary)
+            .frame(maxWidth: .infinity, minHeight: 80, alignment: .center)
+    }
+}

--- a/Sources/VibeBarApp/Views/Workbench/UsageFiltersBar.swift
+++ b/Sources/VibeBarApp/Views/Workbench/UsageFiltersBar.swift
@@ -91,6 +91,21 @@ struct UsageFiltersBar: View {
             rangeMenu
             modelMenu
             refreshMenu
+            if model.selectedTools != nil || model.selectedModels != nil {
+                Button {
+                    model.setSelectedTools(nil)
+                    model.setSelectedModels(nil)
+                } label: {
+                    Label("Clear", systemImage: "xmark")
+                        .font(.system(size: max(9, density.segmentedFontSize - 1), weight: .semibold))
+                        .foregroundStyle(.secondary)
+                        .padding(.horizontal, 9)
+                        .frame(minHeight: 28)
+                        .background(controlBackground)
+                }
+                .buttonStyle(.plain)
+                .help("Clear provider and model filters")
+            }
             Spacer(minLength: 8)
             statusText
             SectionRefreshButton(isRefreshing: model.isLoading) {
@@ -119,7 +134,7 @@ struct UsageFiltersBar: View {
             menuLabel(systemImage: "calendar", title: model.rangePreset.title, detail: rangeSummary)
         }
         .menuStyle(.button)
-        .buttonStyle(.glass)
+        .buttonStyle(.plain)
         .menuIndicator(.hidden)
         .fixedSize()
         .popover(isPresented: $showsCustomRange, arrowEdge: .bottom) {
@@ -171,7 +186,7 @@ struct UsageFiltersBar: View {
             menuLabel(systemImage: "cpu", title: "Models", detail: modelSummary)
         }
         .menuStyle(.button)
-        .buttonStyle(.glass)
+        .buttonStyle(.plain)
         .menuIndicator(.hidden)
         .fixedSize()
         .accessibilityLabel("Choose which models to include")
@@ -194,7 +209,7 @@ struct UsageFiltersBar: View {
             )
         }
         .menuStyle(.button)
-        .buttonStyle(.glass)
+        .buttonStyle(.plain)
         .menuIndicator(.hidden)
         .fixedSize()
         .accessibilityLabel("Choose how often the page re-queries")
@@ -225,7 +240,18 @@ struct UsageFiltersBar: View {
                 .foregroundStyle(.primary)
                 .lineLimit(1)
         }
-        .frame(minHeight: 22)
+        .padding(.horizontal, 10)
+        .frame(minHeight: 28)
+        .background(controlBackground)
+    }
+
+    private var controlBackground: some View {
+        RoundedRectangle(cornerRadius: 8, style: .continuous)
+            .fill(Color.primary.opacity(0.045))
+            .overlay(
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .stroke(Color.primary.opacity(0.09), lineWidth: 0.6)
+            )
     }
 
     private func modelBinding(_ name: String) -> Binding<Bool> {

--- a/Sources/VibeBarApp/Views/Workbench/UsageStatsPage.swift
+++ b/Sources/VibeBarApp/Views/Workbench/UsageStatsPage.swift
@@ -17,6 +17,11 @@ struct UsageStatsPage: View {
                 UsageFiltersBar(density: density, model: model)
                 if model.isLedgerAvailable {
                     UsageHeroCards(density: density, summary: model.summary)
+                    UsageCompositionCards(
+                        density: density,
+                        summary: model.summary,
+                        providers: model.providerStats
+                    )
                     UsageTrendChartView(density: density, series: model.trend)
                     UsageBreakdownTables(density: density, model: model)
                 } else {

--- a/Sources/VibeBarApp/Views/Workbench/UsageTrendChartView.swift
+++ b/Sources/VibeBarApp/Views/Workbench/UsageTrendChartView.swift
@@ -52,14 +52,18 @@ enum UsageTokenSeries: String, CaseIterable, Identifiable, Hashable {
     }
 }
 
-/// Tokens and cost over the selected range, as two x-synchronized panes in a
-/// single card.
-///
-/// The panes are separate `Chart`s rather than one chart with two y scales —
-/// stacked token bands and a cost curve share no unit, and overlaying them
-/// would force one of the two into a scale nobody can read. They stay aligned
-/// because both pin the same leading axis-label width and the same x domain,
-/// and they share one hovered bucket, so the cursor reads both at once.
+private enum UsageChartMetric: String, CaseIterable, Identifiable {
+    case tokens
+    case cost
+
+    var id: String { rawValue }
+    var title: String { self == .tokens ? "Tokens" : "Cost" }
+    var systemImage: String { self == .tokens ? "sum" : "dollarsign" }
+}
+
+/// Tokens or cost over the selected range in one deliberate chart surface.
+/// The metric switch mirrors the established cost-history interaction instead
+/// of stacking two unrelated plots and asking the user to read both at once.
 ///
 /// The range is drawn whole: no brush strip, no pan/zoom. `ChartTimeWindow`
 /// and `ChartBrushNavigator` earn their keep on the cost history card, whose
@@ -69,6 +73,7 @@ struct UsageTrendChartView: View {
     let density: Theme.Density
     let series: UsageTrendSeries
 
+    @State private var metric: UsageChartMetric = .tokens
     @State private var hiddenSeries: Set<UsageTokenSeries> = []
     @State private var hoveredDate: Date?
 
@@ -105,8 +110,7 @@ struct UsageTrendChartView: View {
         CardShell(density: density, spacing: density.cardSpacing) {
             header
             if hasData {
-                tokenPane
-                costPane
+                if metric == .tokens { tokenPane } else { costPane }
             } else {
                 emptyState
             }
@@ -116,14 +120,57 @@ struct UsageTrendChartView: View {
     // MARK: - Header
 
     private var header: some View {
-        HStack(alignment: .firstTextBaseline, spacing: 8) {
-            Text("TOKENS & COST")
-                .font(.system(size: max(8, density.subtitleFontSize - 2), weight: .semibold))
-                .foregroundStyle(.tertiary)
-                .tracking(0.4)
+        HStack(alignment: .center, spacing: 10) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("USAGE OVER TIME")
+                    .font(.system(size: max(8, density.subtitleFontSize - 2), weight: .semibold))
+                    .foregroundStyle(.tertiary)
+                    .tracking(0.4)
+                Text(series.bucket == .hour ? "Hourly buckets" : "Local calendar days")
+                    .font(.system(size: max(9, density.resetCountdownFontSize - 1)))
+                    .foregroundStyle(.secondary)
+            }
+            metricSelector
             Spacer(minLength: 8)
-            legend
+            if metric == .tokens { legend }
         }
+    }
+
+    private var metricSelector: some View {
+        HStack(spacing: 2) {
+            ForEach(UsageChartMetric.allCases) { value in
+                let selected = metric == value
+                Button {
+                    withAnimation(.easeOut(duration: 0.16)) { metric = value }
+                } label: {
+                    Label(value.title, systemImage: value.systemImage)
+                        .font(.system(size: max(9, density.segmentedFontSize - 1), weight: .semibold))
+                        .labelStyle(.titleAndIcon)
+                        .foregroundStyle(selected ? Color.primary : Color.secondary)
+                        .padding(.horizontal, 9)
+                        .frame(minHeight: 24)
+                }
+                .buttonStyle(.plain)
+                .background(
+                    RoundedRectangle(cornerRadius: 7, style: .continuous)
+                        .fill(selected ? Color.accentColor.opacity(0.16) : Color.clear)
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: 7, style: .continuous)
+                        .stroke(selected ? Color.accentColor.opacity(0.38) : Color.clear, lineWidth: 0.7)
+                )
+                .accessibilityAddTraits(selected ? [.isSelected] : [])
+            }
+        }
+        .padding(2)
+        .background(
+            RoundedRectangle(cornerRadius: 9, style: .continuous)
+                .fill(Color.primary.opacity(0.045))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 9, style: .continuous)
+                .stroke(Color.primary.opacity(0.08), lineWidth: 0.6)
+        )
     }
 
     private var legend: some View {
@@ -276,7 +323,7 @@ struct UsageTrendChartView: View {
                 }
             }
         }
-        .frame(height: max(88, density.overviewCostChartHeight * 0.5))
+        .frame(height: density.overviewCostChartHeight)
     }
 
     private var emptyState: some View {

--- a/Sources/VibeBarCore/Models/RemoteSyncModels.swift
+++ b/Sources/VibeBarCore/Models/RemoteSyncModels.swift
@@ -257,6 +257,12 @@ public enum RemoteSyncError: Error, Equatable, Sendable {
     case rollback
     case http(Int)
     case invalidResponse
+    case networkOffline
+    case networkTimeout
+    case hostLookupFailed
+    case connectionFailed
+    case secureConnectionFailed
+    case transportFailed
 
     public var code: String {
         switch self {
@@ -270,8 +276,56 @@ public enum RemoteSyncError: Error, Equatable, Sendable {
         case .supersededEnvelope: return "superseded_envelope"
         case .sequenceGap: return "sequence_gap"
         case .rollback: return "rollback"
-        case .http: return "relay_http_error"
+        case .http(let status): return "relay_http_\(status)"
         case .invalidResponse: return "invalid_response"
+        case .networkOffline: return "network_offline"
+        case .networkTimeout: return "network_timeout"
+        case .hostLookupFailed: return "host_lookup_failed"
+        case .connectionFailed: return "connection_failed"
+        case .secureConnectionFailed: return "secure_connection_failed"
+        case .transportFailed: return "transport_failed"
+        }
+    }
+
+    public var isTransient: Bool {
+        switch self {
+        case .networkOffline, .networkTimeout, .hostLookupFailed,
+             .connectionFailed, .secureConnectionFailed, .transportFailed:
+            return true
+        case .http(let status):
+            return status == 429 || status == 503
+        default:
+            return false
+        }
+    }
+
+    /// Collapse Foundation transport errors into stable, non-sensitive codes.
+    /// URLSession otherwise falls through to the meaningless `sync_failed`
+    /// banner, which hides whether the Relay, DNS, TLS, or the local network is
+    /// the thing that needs attention.
+    public static func normalized(_ error: Error) -> RemoteSyncError {
+        if let known = error as? RemoteSyncError { return known }
+        // Only URLSession failures are transport failures. JSON decoding,
+        // bounded-response rejection, and other protocol-layer errors must
+        // remain non-transient; retrying them hides a bad Relay response as a
+        // network wobble and can repeat work that will never succeed.
+        guard let urlError = error as? URLError else { return .invalidResponse }
+        switch urlError.code {
+        case .notConnectedToInternet, .dataNotAllowed, .internationalRoamingOff:
+            return .networkOffline
+        case .timedOut:
+            return .networkTimeout
+        case .cannotFindHost, .dnsLookupFailed:
+            return .hostLookupFailed
+        case .cannotConnectToHost, .networkConnectionLost:
+            return .connectionFailed
+        case .secureConnectionFailed, .serverCertificateHasBadDate,
+             .serverCertificateUntrusted, .serverCertificateHasUnknownRoot,
+             .serverCertificateNotYetValid, .clientCertificateRejected,
+             .clientCertificateRequired:
+            return .secureConnectionFailed
+        default:
+            return .transportFailed
         }
     }
 }

--- a/Sources/VibeBarCore/Models/UsageQueryModels.swift
+++ b/Sources/VibeBarCore/Models/UsageQueryModels.swift
@@ -109,13 +109,15 @@ public struct UsageSummaryMetrics: Sendable, Equatable {
 
 // MARK: - Trend series
 
-public struct UsageTrendPoint: Sendable, Equatable {
+public struct UsageTrendPoint: Sendable, Equatable, Identifiable {
     public let bucketStart: Date
     public let freshInput: Int64
     public let output: Int64
     public let cacheRead: Int64
     public let cacheCreation: Int64
     public let costMicros: Int64
+
+    public var id: Date { bucketStart }
 
     public init(
         bucketStart: Date,

--- a/Sources/VibeBarCore/Services/RemoteProbeService.swift
+++ b/Sources/VibeBarCore/Services/RemoteProbeService.swift
@@ -224,7 +224,7 @@ public final class RemoteProbeService: ObservableObject {
     private struct RefreshSuperseded: Error {}
 
     /// Perform one Relay request, retrying a bounded number of times when the
-    /// Relay asks us to come back shortly.
+    /// Relay or the network path reports a recoverable failure.
     ///
     /// The Relay sits behind an nginx rate limiter. A burst of requests is
     /// answered 429, and nginx (like most CDNs) also sheds load with 503.
@@ -235,9 +235,10 @@ public final class RemoteProbeService: ObservableObject {
     /// a limiter window; if they are exhausted the error propagates exactly as
     /// before and the cycle records it.
     ///
-    /// Only 429 and 503 are retried. 400 (a cursor replayed against the wrong
-    /// principal), 401, and 403 are real failures that will not fix themselves,
-    /// and retrying them would just delay the error the user needs to see.
+    /// Transport failures (offline, DNS, timeout, connection, TLS) use the same
+    /// bounded schedule. 400 (a cursor replayed against the wrong principal),
+    /// 401, and 403 are real failures that will not fix themselves, and retrying
+    /// them would just delay the error the user needs to see.
     ///
     /// `Retry-After` is **not** honored. `RemoteRelayClient.validate` collapses
     /// every non-200 into `RemoteSyncError.http(statusCode)`; widening that
@@ -251,10 +252,9 @@ public final class RemoteProbeService: ObservableObject {
         for delay in relayRetryDelays {
             do {
                 return try await request()
-            } catch let error as RemoteSyncError {
-                guard case .http(let status) = error, status == 429 || status == 503 else {
-                    throw error
-                }
+            } catch {
+                let failure = RemoteSyncError.normalized(error)
+                guard failure.isTransient else { throw failure }
                 try await Task.sleep(for: delay)
                 guard generation == configurationGeneration else { throw RefreshSuperseded() }
             }
@@ -422,8 +422,10 @@ public final class RemoteProbeService: ObservableObject {
             lastErrorCode = nil
         } catch {
             guard generation == configurationGeneration else { return }
-            let code = (error as? RemoteSyncError)?.code ?? "sync_failed"
+            let failure = RemoteSyncError.normalized(error)
+            let code = failure.code
             lastErrorCode = code
+            SafeLog.net("remote sync failed: \(code)")
             try? await ledger.recordSync(
                 workspaceID: config.workspaceID,
                 coreDeviceID: config.coreDeviceID,

--- a/Sources/VibeBarCore/Services/UsageEventLedger.swift
+++ b/Sources/VibeBarCore/Services/UsageEventLedger.swift
@@ -64,7 +64,7 @@ public actor UsageEventLedger: CostUsageEventSink {
     private let dayFormatter: DateFormatter
 
     /// Bumping this drops and rebuilds every table on the next open.
-    static let schemaVersion = 1
+    static let schemaVersion = 3
     private static let schemaVersionKey = "schema_version"
     private static let floorKeyPrefix = "detail_floor_day:"
     /// Guard rail on zero-filled trend enumeration: ~135 years of daily
@@ -365,9 +365,12 @@ public actor UsageEventLedger: CostUsageEventSink {
             )
         """
 
-    /// A Claude request is uniquely identified by `(messageId, requestId)`
-    /// across every transcript file that copied it, so that pair is the
-    /// natural key. Every other provider leaves at least one of them nil;
+    /// A Claude request is uniquely identified by
+    /// `(sessionId, messageId, requestId)` across every transcript file that
+    /// copied it. Message/request ids can be reused by different sessions, so
+    /// omitting the session id silently merged unrelated billable requests and
+    /// made Workbench totals disagree with the CostSnapshot built by the same
+    /// scan. Every other provider leaves at least one of them nil;
     /// those fall back to a digest that is stable across re-scans of the
     /// same file (hashed path + position + timestamp + model + tokens) so a
     /// re-ingest updates instead of duplicating.
@@ -382,8 +385,19 @@ public actor UsageEventLedger: CostUsageEventSink {
         cacheRead: Int64,
         cacheCreation: Int64
     ) -> String {
-        if let messageId = event.messageId, let requestId = event.requestId {
-            return "m:\(messageId)\u{0}\(requestId)"
+        if tool == .claude,
+           let sessionId = event.sessionId,
+           let messageId = event.messageId,
+           let requestId = event.requestId {
+            // `Binding.text` uses SQLite's NUL-terminated form. Keeping the
+            // scanner's in-memory `\0` separator here would therefore persist
+            // only `m:<sessionId>` and collapse an entire Claude session into
+            // one request. Hash the length-delimited tuple into a printable,
+            // fixed-width key instead.
+            let tuple = [sessionId, messageId, requestId]
+                .map { "\($0.utf8.count):\($0)" }
+                .joined(separator: "|")
+            return PrivacyPreservingHash.fileComponent(prefix: "cm-v3", rawValue: tuple)
         }
         let seed = [
             tool.rawValue, fileKey, String(index), String(timestamp), event.model,

--- a/Sources/VibeBarCore/Sessions/SessionIndexService.swift
+++ b/Sources/VibeBarCore/Sessions/SessionIndexService.swift
@@ -79,6 +79,26 @@ public actor SessionIndexService {
         try await store.allSummaries()
     }
 
+    public func summaryPage(
+        providers: [SessionProvider]? = nil,
+        since: Date? = nil,
+        order: SessionSummaryOrder = .recentFirst,
+        offset: Int = 0,
+        limit: Int = 250
+    ) async throws -> SessionSummaryPage {
+        try await store.summaryPage(
+            providers: providers,
+            since: since,
+            order: order,
+            offset: offset,
+            limit: limit
+        )
+    }
+
+    public func providerCounts() async throws -> [SessionProvider: Int] {
+        try await store.providerCounts()
+    }
+
     public func search(
         _ text: String,
         providers: [SessionProvider]? = nil,

--- a/Sources/VibeBarCore/Sessions/SessionIndexStore.swift
+++ b/Sources/VibeBarCore/Sessions/SessionIndexStore.swift
@@ -152,6 +152,10 @@ public actor SessionIndexStore {
         );
         CREATE INDEX IF NOT EXISTS sessions_last_active_idx
             ON sessions(last_active_at DESC);
+        CREATE INDEX IF NOT EXISTS sessions_effective_active_idx
+            ON sessions(COALESCE(last_active_at, created_at) DESC, id DESC);
+        CREATE INDEX IF NOT EXISTS sessions_provider_effective_active_idx
+            ON sessions(provider, COALESCE(last_active_at, created_at) DESC, id DESC);
         CREATE INDEX IF NOT EXISTS sessions_provider_project_idx
             ON sessions(provider, project_dir);
         CREATE TABLE IF NOT EXISTS session_files (
@@ -465,6 +469,80 @@ public actor SessionIndexStore {
             if let summary = self.summary(statement, offset: 0) { out.append(summary) }
         }
         return out
+    }
+
+    /// One filtered, ordered page. This is the product read path; the unbounded
+    /// `allSummaries()` remains for tests and maintenance tools.
+    public func summaryPage(
+        providers: [SessionProvider]? = nil,
+        since: Date? = nil,
+        order: SessionSummaryOrder = .recentFirst,
+        offset: Int = 0,
+        limit: Int = 250
+    ) throws -> SessionSummaryPage {
+        if let providers, providers.isEmpty {
+            return SessionSummaryPage(summaries: [], totalCount: 0, offset: 0, limit: max(1, limit))
+        }
+        let safeOffset = max(0, offset)
+        let safeLimit = min(max(1, limit), 500)
+        var clauses: [String] = []
+        var bindings: [Binding] = []
+        if let providers {
+            clauses.append("s.provider IN (\(Array(repeating: "?", count: providers.count).joined(separator: ", ")))")
+            bindings.append(contentsOf: providers.map { .text($0.rawValue) })
+        }
+        if let since {
+            clauses.append("COALESCE(s.last_active_at, s.created_at) >= ?")
+            bindings.append(.integer(Int64(since.timeIntervalSince1970.rounded(.down))))
+        }
+        let whereSQL = clauses.isEmpty ? "" : " WHERE " + clauses.joined(separator: " AND ")
+        let orderSQL: String
+        switch order {
+        case .recentFirst:
+            orderSQL = "COALESCE(s.last_active_at, s.created_at) DESC, s.id DESC"
+        case .oldestFirst:
+            orderSQL = "COALESCE(s.last_active_at, s.created_at) ASC, s.id ASC"
+        case .byProject:
+            orderSQL = "s.project_dir IS NULL, s.project_dir COLLATE NOCASE ASC, "
+                + "COALESCE(s.last_active_at, s.created_at) DESC, s.id DESC"
+        }
+
+        let total = Int(try scalarInt(
+            "SELECT COUNT(*) FROM sessions s\(whereSQL)",
+            bindings
+        ) ?? 0)
+        let statement = try prepare(
+            """
+            SELECT \(Self.sessionColumns) FROM sessions s\(whereSQL)
+             ORDER BY \(orderSQL) LIMIT ? OFFSET ?
+            """
+        )
+        defer { sqlite3_finalize(statement) }
+        bindAll(bindings + [.integer(Int64(safeLimit)), .integer(Int64(safeOffset))], to: statement)
+        var out: [SessionSummary] = []
+        out.reserveCapacity(min(safeLimit, total))
+        while sqlite3_step(statement) == SQLITE_ROW {
+            if let summary = self.summary(statement, offset: 0) { out.append(summary) }
+        }
+        return SessionSummaryPage(
+            summaries: out,
+            totalCount: total,
+            offset: safeOffset,
+            limit: safeLimit
+        )
+    }
+
+    public func providerCounts() throws -> [SessionProvider: Int] {
+        let statement = try prepare("SELECT provider, COUNT(*) FROM sessions GROUP BY provider")
+        defer { sqlite3_finalize(statement) }
+        var counts: [SessionProvider: Int] = [:]
+        while sqlite3_step(statement) == SQLITE_ROW {
+            guard let raw = columnText(statement, 0), let provider = SessionProvider(rawValue: raw) else {
+                continue
+            }
+            counts[provider] = Int(sqlite3_column_int64(statement, 1))
+        }
+        return counts
     }
 
     public func sessionCount() throws -> Int {

--- a/Sources/VibeBarCore/Sessions/SessionModels.swift
+++ b/Sources/VibeBarCore/Sessions/SessionModels.swift
@@ -98,6 +98,28 @@ public struct SessionSummary: Identifiable, Hashable, Codable, Sendable {
     }
 }
 
+public enum SessionSummaryOrder: String, Sendable, Hashable {
+    case recentFirst
+    case oldestFirst
+    case byProject
+}
+
+/// A bounded window from the session index. The Workbench renders one page at
+/// a time instead of publishing every historical session into SwiftUI.
+public struct SessionSummaryPage: Sendable, Equatable {
+    public let summaries: [SessionSummary]
+    public let totalCount: Int
+    public let offset: Int
+    public let limit: Int
+
+    public init(summaries: [SessionSummary], totalCount: Int, offset: Int, limit: Int) {
+        self.summaries = summaries
+        self.totalCount = totalCount
+        self.offset = offset
+        self.limit = limit
+    }
+}
+
 public enum SessionRole: String, Codable, Sendable, CaseIterable, Hashable {
     case user
     case assistant

--- a/Tests/VibeBarCoreTests/RemoteSyncErrorTests.swift
+++ b/Tests/VibeBarCoreTests/RemoteSyncErrorTests.swift
@@ -1,0 +1,42 @@
+import Foundation
+import XCTest
+@testable import VibeBarCore
+
+final class RemoteSyncErrorTests: XCTestCase {
+    func testTransportErrorsNormalizeIntoActionableStableCodes() {
+        XCTAssertEqual(
+            RemoteSyncError.normalized(URLError(.timedOut)),
+            .networkTimeout
+        )
+        XCTAssertEqual(
+            RemoteSyncError.normalized(URLError(.cannotFindHost)),
+            .hostLookupFailed
+        )
+        XCTAssertEqual(
+            RemoteSyncError.normalized(URLError(.secureConnectionFailed)),
+            .secureConnectionFailed
+        )
+        XCTAssertEqual(
+            RemoteSyncError.normalized(CocoaError(.fileReadUnknown)),
+            .invalidResponse
+        )
+        XCTAssertEqual(
+            RemoteSyncError.normalized(
+                HTTPResponseLimit.BoundedError.responseTooLarge(limit: 1024)
+            ),
+            .invalidResponse
+        )
+    }
+
+    func testOnlyRecoverableRemoteErrorsAreRetried() {
+        XCTAssertTrue(RemoteSyncError.networkTimeout.isTransient)
+        XCTAssertTrue(RemoteSyncError.http(429).isTransient)
+        XCTAssertTrue(RemoteSyncError.http(503).isTransient)
+        XCTAssertFalse(RemoteSyncError.http(401).isTransient)
+        XCTAssertFalse(RemoteSyncError.invalidSignature.isTransient)
+    }
+
+    func testHTTPStatusRemainsVisibleInTheDiagnosticCode() {
+        XCTAssertEqual(RemoteSyncError.http(502).code, "relay_http_502")
+    }
+}

--- a/Tests/VibeBarCoreTests/SessionIndexStoreTests.swift
+++ b/Tests/VibeBarCoreTests/SessionIndexStoreTests.swift
@@ -114,6 +114,42 @@ final class SessionIndexStoreTests: XCTestCase {
         XCTAssertEqual(variant, "cli")
     }
 
+    func testSummaryPageFiltersOrdersAndBoundsTheRead() async throws {
+        let store = try makeStore()
+        try await store.upsertSession(summary(
+            provider: .claude, id: "claude-old", projectDir: "/Users/example/alpha",
+            lastActive: Date(timeIntervalSince1970: 1_000), path: "/claude-old"
+        ))
+        try await store.upsertSession(summary(
+            provider: .claude, id: "claude-new", projectDir: "/Users/example/beta",
+            lastActive: Date(timeIntervalSince1970: 3_000), path: "/claude-new"
+        ))
+        try await store.upsertSession(summary(
+            provider: .codex, id: "codex", projectDir: "/Users/example/gamma",
+            lastActive: Date(timeIntervalSince1970: 4_000), path: "/codex"
+        ))
+
+        let first = try await store.summaryPage(
+            providers: [.claude],
+            since: Date(timeIntervalSince1970: 1_500),
+            order: .recentFirst,
+            offset: 0,
+            limit: 1
+        )
+        XCTAssertEqual(first.totalCount, 1)
+        XCTAssertEqual(first.summaries.map(\.sessionID), ["claude-new"])
+        XCTAssertEqual(first.limit, 1)
+
+        let oldest = try await store.summaryPage(order: .oldestFirst, offset: 1, limit: 2)
+        XCTAssertEqual(oldest.totalCount, 3)
+        XCTAssertEqual(oldest.summaries.map(\.sessionID), ["claude-new", "codex"])
+
+        let counts = try await store.providerCounts()
+        XCTAssertEqual(counts[.claude], 2)
+        XCTAssertEqual(counts[.codex], 1)
+        XCTAssertNil(counts[.grok])
+    }
+
     // MARK: - Search
 
     func testTrigramSearchMatchesAnEnglishSubstring() async throws {

--- a/Tests/VibeBarCoreTests/UsageEventLedgerTests.swift
+++ b/Tests/VibeBarCoreTests/UsageEventLedgerTests.swift
@@ -185,6 +185,69 @@ final class UsageEventLedgerTests: XCTestCase {
         }
     }
 
+    /// Claude only guarantees message/request ids inside one session. Two
+    /// sessions that reuse those ids are two billable requests and must stay
+    /// separate, matching `CostUsageScanner`'s source aggregation.
+    func testClaudeDedupeKeepsMatchingMessageIDsFromDifferentSessions() async throws {
+        let (ledger, directory) = try UsageLedgerFixtures.makeLedger("LedgerSessionScopedDedupe")
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        for (session, input, path) in [
+            ("session-a", 111, "/Users/example/.claude/projects/demo/a.jsonl"),
+            ("session-b", 222, "/Users/example/.claude/projects/demo/b.jsonl")
+        ] {
+            let event = UsageLedgerFixtures.event(
+                date: now,
+                model: "claude-sonnet-4-5",
+                input: input,
+                output: 10,
+                sessionId: session,
+                messageId: "msg-reused",
+                requestId: "req-reused",
+                isSidechain: false,
+                pathRole: .parent,
+                sourceKey: "path-v1-\(session)"
+            )
+            try await ledger.ingest(UsageLedgerFixtures.batch(
+                tool: .claude,
+                path: path,
+                events: [UsageLedgerFixtures.priced(event)]
+            ))
+        }
+
+        let summary = try await ledger.summary(UsageLedgerFixtures.wideFilter(around: now))
+        XCTAssertEqual(summary.requests, 2)
+        XCTAssertEqual(summary.freshInput, 333)
+        XCTAssertEqual(summary.output, 20)
+    }
+
+    /// The persisted dedupe key must include the fields after the session id.
+    /// SQLite text bindings are NUL terminated, so an embedded `\0` separator
+    /// would silently collapse these two requests into one row.
+    func testClaudeDedupeKeepsDifferentMessagesInsideOneSession() async throws {
+        let (ledger, directory) = try UsageLedgerFixtures.makeLedger("LedgerMessageScopedDedupe")
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let events = [
+            UsageLedgerFixtures.event(
+                date: now, input: 100, sessionId: "session-shared",
+                messageId: "message-a", requestId: "request-a"
+            ),
+            UsageLedgerFixtures.event(
+                date: now.addingTimeInterval(1), input: 200, sessionId: "session-shared",
+                messageId: "message-b", requestId: "request-b"
+            )
+        ]
+        try await ledger.ingest(UsageLedgerFixtures.batch(
+            tool: .claude,
+            events: events.map { UsageLedgerFixtures.priced($0) }
+        ))
+
+        let summary = try await ledger.summary(UsageLedgerFixtures.wideFilter(around: now))
+        XCTAssertEqual(summary.requests, 2)
+        XCTAssertEqual(summary.freshInput, 300)
+    }
+
     /// Same message, both copies in a parent path: the smaller source key
     /// wins, matching `CostUsageScanner.claudeEventWins`'s final tiebreak.
     func testDedupeConflictTiebreaksOnSourceKey() async throws {
@@ -193,12 +256,12 @@ final class UsageEventLedgerTests: XCTestCase {
 
         let low = UsageLedgerFixtures.event(
             date: now, model: "claude-sonnet-4-5", input: 111, output: 11,
-            messageId: "msg-2", requestId: "req-2",
+            sessionId: "session-2", messageId: "msg-2", requestId: "req-2",
             isSidechain: false, pathRole: .parent, sourceKey: "path-v1-aaa"
         )
         let high = UsageLedgerFixtures.event(
             date: now, model: "claude-sonnet-4-5", input: 222, output: 22,
-            messageId: "msg-2", requestId: "req-2",
+            sessionId: "session-2", messageId: "msg-2", requestId: "req-2",
             isSidechain: false, pathRole: .parent, sourceKey: "path-v1-zzz"
         )
         try await ledger.ingest(UsageLedgerFixtures.batch(


### PR DESCRIPTION
## Summary
- redesign Workbench usage controls, composition cards, charts, and breakdown tables around the shared usage ledger
- page and filter large session indexes to keep Sessions responsive
- adopt existing shared skills automatically and improve remote sync retry diagnostics

## Test plan
- [x] `swift build`
- [x] `swift test` (1430 tests)
- [x] `./Scripts/build_app.sh release`
- [x] `codesign --verify --deep --strict ".build/Vibe Bar.app"`
- [x] verified empty app entitlements