### PR TITLE
Prepare Vibe Bar 1.3.0 Dev build 24

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.3.0</string>
 	<key>CFBundleVersion</key>
-	<string>23</string>
+	<string>24</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>26.0</string>
 	<key>LSUIElement</key>


### PR DESCRIPTION
## Summary
- keep the short version at `1.3.0`
- increment `CFBundleVersion` from 23 to 24 for the next dev release

## Test plan
- [x] `swift build`
- [x] `swift test` (1430 tests)
- [x] `./Scripts/build_app.sh release`
- [x] `codesign --verify --deep --strict ".build/Vibe Bar.app"`
- [x] confirmed empty entitlements and packaged version `1.3.0 (24)`