### PR TITLE
Polish Workbench navigation and usage analytics

### DIFF
--- a/Resources/ProviderIcons/ProviderIcon-hermes.svg
+++ b/Resources/ProviderIcons/ProviderIcon-hermes.svg
@@ -1,0 +1,4 @@
+<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+  <!-- Source: NousResearch/hermes-agent website/static/img/favicon.svg (official Hermes mark). -->
+  <text y=".9em" font-size="90">⚕</text>
+</svg>

--- a/Sources/VibeBarApp/Controllers/UsageStatsViewModel.swift
+++ b/Sources/VibeBarApp/Controllers/UsageStatsViewModel.swift
@@ -80,6 +80,7 @@ final class UsageStatsViewModel: ObservableObject {
     @Published var rangePreset: RangePreset = .day7 {
         didSet {
             guard oldValue != rangePreset else { return }
+            windowStart = nil
             reload(cascadeModels: false)
         }
     }
@@ -87,6 +88,7 @@ final class UsageStatsViewModel: ObservableObject {
     @Published var customStart: Date {
         didSet {
             guard oldValue != customStart, rangePreset == .custom else { return }
+            windowStart = nil
             reload(cascadeModels: false)
         }
     }
@@ -94,6 +96,15 @@ final class UsageStatsViewModel: ObservableObject {
     @Published var customEnd: Date {
         didSet {
             guard oldValue != customEnd, rangePreset == .custom else { return }
+            windowStart = nil
+            reload(cascadeModels: false)
+        }
+    }
+
+    /// This changes the ledger query's grouping, not just the chart label.
+    @Published var trendGranularity: UsageTrendGranularity = .automatic {
+        didSet {
+            guard oldValue != trendGranularity else { return }
             reload(cascadeModels: false)
         }
     }
@@ -134,6 +145,27 @@ final class UsageStatsViewModel: ObservableObject {
     }
 
     var range: DateInterval {
+        windowStart.map(anchoredRange(start:)) ?? currentRange
+    }
+
+    var canNavigateForward: Bool { windowStart != nil }
+
+    /// Manual buckets stay available only while they remain a useful
+    /// interactive chart. The renderer also thins marks, but avoiding a huge
+    /// zero-filled provider matrix here keeps a years-long custom range from
+    /// allocating tens of thousands of points before drawing even begins.
+    func isTrendGranularityAvailable(_ granularity: UsageTrendGranularity) -> Bool {
+        guard granularity != .automatic else { return true }
+        let seconds: TimeInterval = switch granularity {
+        case .automatic: 1
+        case .hour: 3_600
+        case .day: 86_400
+        case .week: 7 * 86_400
+        }
+        return Int(ceil(range.duration / seconds)) + 1 <= Self.maximumInteractiveTrendBuckets
+    }
+
+    private var currentRange: DateInterval {
         let now = Date()
         switch rangePreset {
         case .today:
@@ -154,6 +186,58 @@ final class UsageStatsViewModel: ObservableObject {
                 to: today
             ) ?? today
             return DateInterval(start: start, end: now)
+        }
+    }
+
+    func navigateWindow(by direction: Int) {
+        guard direction == -1 || direction == 1 else { return }
+        let present = currentRange
+        let candidate = shiftedStart(range.start, by: direction)
+        if direction > 0, candidate >= present.start {
+            resetWindow()
+        } else {
+            windowStart = candidate
+            reload(cascadeModels: false)
+        }
+    }
+
+    func resetWindow() {
+        guard windowStart != nil else { return }
+        windowStart = nil
+        reload(cascadeModels: false)
+    }
+
+    private func anchoredRange(start: Date) -> DateInterval {
+        switch rangePreset {
+        case .today:
+            let end = Calendar.current.date(byAdding: .day, value: 1, to: start)
+                ?? start.addingTimeInterval(86_400)
+            return DateInterval(start: start, end: end)
+        case .day1:
+            return DateInterval(start: start, duration: 86_400)
+        case .day7, .day14, .day30:
+            let days = rangePreset.calendarDayCount ?? 1
+            let end = Calendar.current.date(byAdding: .day, value: days, to: start)
+                ?? start.addingTimeInterval(TimeInterval(days * 86_400))
+            return DateInterval(start: start, end: end)
+        case .custom:
+            return DateInterval(start: start, duration: max(60, currentRange.duration))
+        }
+    }
+
+    private func shiftedStart(_ start: Date, by direction: Int) -> Date {
+        switch rangePreset {
+        case .today:
+            return Calendar.current.date(byAdding: .day, value: direction, to: start)
+                ?? start.addingTimeInterval(TimeInterval(direction * 86_400))
+        case .day1:
+            return start.addingTimeInterval(TimeInterval(direction * 86_400))
+        case .day7, .day14, .day30:
+            let days = (rangePreset.calendarDayCount ?? 1) * direction
+            return Calendar.current.date(byAdding: .day, value: days, to: start)
+                ?? start.addingTimeInterval(TimeInterval(days * 86_400))
+        case .custom:
+            return start.addingTimeInterval(currentRange.duration * Double(direction))
         }
     }
 
@@ -180,6 +264,8 @@ final class UsageStatsViewModel: ObservableObject {
     private var loadedRequestPages = 0
     private var generation: UInt64 = 0
     private var hasLoadedOnce = false
+    /// A historical window start, or `nil` when the preset follows now.
+    private var windowStart: Date?
     /// The filter page 0 was fetched with. Later pages reuse it verbatim: a
     /// rolling preset's `now` moves between pages, and re-deriving the range
     /// per page would slide the offsets under the rows already on screen.
@@ -191,6 +277,7 @@ final class UsageStatsViewModel: ObservableObject {
     private var observedTools: Set<ToolType> = []
 
     private nonisolated static let requestPageSize = 50
+    private static let maximumInteractiveTrendBuckets = 1_200
     /// A poll re-reads the ledger every tick, but the ledger only moves when a
     /// cost scan writes to it — and a scan walks the whole session tree. One
     /// rescan a minute is the ceiling regardless of how fast the poll runs.
@@ -288,6 +375,10 @@ final class UsageStatsViewModel: ObservableObject {
     }
 
     private func reload(cascadeModels: Bool) {
+        if !isTrendGranularityAvailable(trendGranularity) {
+            trendGranularity = .automatic
+            return
+        }
         generation &+= 1
         let generation = self.generation
         reloadTask?.cancel()
@@ -314,7 +405,10 @@ final class UsageStatsViewModel: ObservableObject {
             }
             self.availableModels = models
             let resolved = self.filter
-            let snapshot = await Self.load(ledger: ledger, filter: resolved)
+            let granularity = self.trendGranularity
+            let snapshot = await Self.load(
+                ledger: ledger, filter: resolved, granularity: granularity
+            )
             guard !Task.isCancelled, generation == self.generation else { return }
             self.activeFilter = resolved
             self.apply(snapshot)
@@ -346,7 +440,9 @@ final class UsageStatsViewModel: ObservableObject {
 
     private func applyEmpty() {
         summary = .empty
-        trend = UsageTrendSeries(bucket: UsageTrendBucket.recommended(for: range), points: [])
+        trend = UsageTrendSeries(
+            bucket: trendGranularity.resolved(for: range), points: []
+        )
         providerStats = []
         modelStats = []
         requestRows = []
@@ -403,11 +499,13 @@ final class UsageStatsViewModel: ObservableObject {
 
     private nonisolated static func load(
         ledger: UsageEventLedger,
-        filter: UsageQueryFilter
+        filter: UsageQueryFilter,
+        granularity: UsageTrendGranularity
     ) async -> LoadedUsage {
         let summary = (try? await ledger.summary(filter)) ?? .empty
-        let trend = (try? await ledger.trend(filter))
-            ?? UsageTrendSeries(bucket: UsageTrendBucket.recommended(for: filter.range), points: [])
+        let bucket = granularity.resolved(for: filter.range)
+        let trend = (try? await ledger.trend(filter, bucket: bucket))
+            ?? UsageTrendSeries(bucket: bucket, points: [])
         let providers = (try? await ledger.providerStats(filter)) ?? []
         let models = (try? await ledger.modelStats(filter)) ?? []
         let requests = (try? await ledger.requestPage(filter, page: 0, pageSize: requestPageSize))

--- a/Sources/VibeBarApp/Controllers/UsageStatsViewModel.swift
+++ b/Sources/VibeBarApp/Controllers/UsageStatsViewModel.swift
@@ -137,6 +137,10 @@ final class UsageStatsViewModel: ObservableObject {
     @Published private(set) var isLoading = false
     @Published private(set) var isLoadingMore = false
     @Published private(set) var lastUpdatedAt: Date?
+    /// True only when the current filter lies wholly above every selected
+    /// provider's ledger detail floor. This drives the Hourly menu state and
+    /// is refreshed alongside the query it describes.
+    @Published private(set) var isHourlyTrendAvailable = true
 
     let isLedgerAvailable: Bool
 
@@ -156,6 +160,7 @@ final class UsageStatsViewModel: ObservableObject {
     /// allocating tens of thousands of points before drawing even begins.
     func isTrendGranularityAvailable(_ granularity: UsageTrendGranularity) -> Bool {
         guard granularity != .automatic else { return true }
+        if granularity == .hour, !isHourlyTrendAvailable { return false }
         let seconds: TimeInterval = switch granularity {
         case .automatic: 1
         case .hour: 3_600
@@ -405,6 +410,16 @@ final class UsageStatsViewModel: ObservableObject {
             }
             self.availableModels = models
             let resolved = self.filter
+            let supportsHourly = (try? await ledger.supportsHourlyTrend(resolved)) ?? false
+            guard !Task.isCancelled, generation == self.generation else { return }
+            self.isHourlyTrendAvailable = supportsHourly
+            if self.trendGranularity == .hour, !supportsHourly {
+                // Keep the Picker's intent and the returned series aligned.
+                // `trend` also falls back defensively in case the floor moves
+                // between this check and the subsequent query.
+                self.trendGranularity = .automatic
+                return
+            }
             let granularity = self.trendGranularity
             let snapshot = await Self.load(
                 ledger: ledger, filter: resolved, granularity: granularity

--- a/Sources/VibeBarApp/Views/ChartBrushNavigator.swift
+++ b/Sources/VibeBarApp/Views/ChartBrushNavigator.swift
@@ -107,6 +107,33 @@ struct ChartBrushNavigator<Mini: View>: View {
         .frame(height: height)
         .accessibilityElement()
         .accessibilityLabel(accessibilityDescription)
+        .accessibilityValue(accessibilityRangeValue)
+        .accessibilityAdjustableAction { direction in
+            let step = max(window.effectiveMinimumSpan, window.visibleSpan * 0.25)
+            switch direction {
+            case .increment:
+                window = window.panned(by: step)
+            case .decrement:
+                window = window.panned(by: -step)
+            @unknown default:
+                break
+            }
+        }
+        .accessibilityAction(named: "Zoom In") {
+            window = window.zoomed(scale: 1.6, around: window.visibleMidpoint)
+        }
+        .accessibilityAction(named: "Zoom Out") {
+            window = window.zoomed(scale: 0.625, around: window.visibleMidpoint)
+        }
+        .accessibilityAction(named: "Show Full Range") {
+            window = window.jumped(toSpan: window.domainSpan)
+        }
+    }
+
+    private var accessibilityRangeValue: String {
+        let start = window.visibleStart.formatted(date: .abbreviated, time: .shortened)
+        let end = window.visibleEnd.formatted(date: .abbreviated, time: .shortened)
+        return "\(start) to \(end)"
     }
 
     // MARK: - Overlay pieces

--- a/Sources/VibeBarApp/Views/Theme.swift
+++ b/Sources/VibeBarApp/Views/Theme.swift
@@ -294,7 +294,10 @@ enum Theme {
         case .alibabaTokenPlan: return Color(red: 1.00, green: 0.48, blue: 0.18)  // deeper amber
         case .gemini:      return Color(red: 0.34, green: 0.62, blue: 0.96)  // google blue
         case .antigravity: return Color(red: 0.55, green: 0.40, blue: 0.92)  // violet
-        case .grok:        return Color(red: 0.18, green: 0.18, blue: 0.18)  // xAI near-black
+        // xAI's black wordmark is not a usable data colour: it vanishes on
+        // dark cards, while one fixed pale replacement disappears on white.
+        // The semantic slate resolves darker in Aqua and lighter in Dark Aqua.
+        case .grok:        return adaptiveNeutralAccent
         case .copilot:     return Color(red: 0.46, green: 0.46, blue: 0.46)  // graphite
         case .zai:         return Color(red: 0.26, green: 0.74, blue: 0.55)  // emerald
         case .minimax:     return Color(red: 0.97, green: 0.30, blue: 0.45)  // pink
@@ -314,6 +317,17 @@ enum Theme {
         case .openRouter:  return Color(red: 0.98, green: 0.62, blue: 0.16)  // orange
         case .warp:        return Color(red: 0.58, green: 0.55, blue: 0.71)  // warp violet-grey
         }
+    }
+
+    private static var adaptiveNeutralAccent: Color {
+        Color(
+            nsColor: NSColor(name: nil) { appearance in
+                if appearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua {
+                    return NSColor(srgbRed: 0.68, green: 0.75, blue: 0.83, alpha: 1)
+                }
+                return NSColor(srgbRed: 0.30, green: 0.38, blue: 0.47, alpha: 1)
+            }
+        )
     }
 
     static func barColor(percent: Double, mode: DisplayMode) -> Color {

--- a/Sources/VibeBarApp/Views/Workbench/SessionListView.swift
+++ b/Sources/VibeBarApp/Views/Workbench/SessionListView.swift
@@ -24,7 +24,7 @@ struct SessionListView: View {
                             }
                         } header: {
                             Text(group.title)
-                                .font(.system(size: max(8, density.subtitleFontSize - 2), weight: .semibold))
+                                .font(.system(size: max(10, density.subtitleFontSize - 2), weight: .semibold))
                                 .foregroundStyle(.tertiary)
                                 .tracking(0.4)
                         }
@@ -115,51 +115,69 @@ private struct SessionRow: View {
     let onToggleCheck: () -> Void
     let onSelect: () -> Void
 
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var isHovering = false
+
     private var summary: SessionSummary { row.summary }
 
     var body: some View {
-        HStack(alignment: .top, spacing: 9) {
-            if isDeleteMode {
-                checkbox
-            }
-            ToolBrandBadge(tool: summary.provider.tool, iconSize: 15, containerSize: 20)
-                .padding(.top, 1)
-            VStack(alignment: .leading, spacing: 3) {
-                Text(title)
-                    .font(.system(size: density.subtitleFontSize + 1, weight: .semibold))
-                    .foregroundStyle(.primary)
-                    .lineLimit(1)
-                if let snippet = row.snippet {
-                    Text(SessionSnippet.attributed(snippet))
-                        .font(.system(size: density.subtitleFontSize - 1))
-                        .foregroundStyle(.secondary)
-                        .lineLimit(2)
-                } else if let subtitle {
-                    Text(subtitle)
-                        .font(.system(size: density.subtitleFontSize - 1))
-                        .foregroundStyle(.secondary)
-                        .lineLimit(1)
-                }
-                footer
-            }
-            Spacer(minLength: 0)
-        }
-        .padding(.horizontal, 8)
-        .padding(.vertical, 7)
-        .background(
-            RoundedRectangle(cornerRadius: 8, style: .continuous)
-                .fill(summary.provider.accent.opacity(isSelected ? 0.16 : 0))
-        )
-        .overlay(
-            RoundedRectangle(cornerRadius: 8, style: .continuous)
-                .stroke(summary.provider.accent.opacity(isSelected ? 0.45 : 0), lineWidth: 0.8)
-        )
-        .contentShape(Rectangle())
-        .onTapGesture {
+        Button {
             if isDeleteMode { onToggleCheck() } else { onSelect() }
+        } label: {
+            HStack(alignment: .top, spacing: 9) {
+                if isDeleteMode {
+                    checkbox
+                }
+                ToolBrandBadge(tool: summary.provider.tool, iconSize: 15, containerSize: 20)
+                    .padding(.top, 1)
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(title)
+                        .font(.system(size: density.subtitleFontSize + 1, weight: .semibold))
+                        .foregroundStyle(.primary)
+                        .lineLimit(1)
+                    if let snippet = row.snippet {
+                        Text(SessionSnippet.attributed(snippet))
+                            .font(.system(size: density.subtitleFontSize - 1))
+                            .foregroundStyle(.secondary)
+                            .lineLimit(2)
+                    } else if let subtitle {
+                        Text(subtitle)
+                            .font(.system(size: density.subtitleFontSize - 1))
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                    }
+                    footer
+                }
+                Spacer(minLength: 0)
+            }
+            .padding(.horizontal, 8)
+            .padding(.vertical, 7)
+            .background(
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .fill(rowFill)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .stroke(rowBorder, lineWidth: isSelected || isHovering ? 0.8 : 0.5)
+            )
+            .contentShape(Rectangle())
         }
+        .buttonStyle(.plain)
+        .onHover { isHovering = $0 }
+        .animation(reduceMotion ? nil : .easeOut(duration: 0.14), value: isHovering)
         .accessibilityElement(children: .combine)
-        .accessibilityAddTraits(isSelected ? [.isSelected, .isButton] : .isButton)
+        .accessibilityAddTraits(isSelected ? .isSelected : [])
+        .accessibilityHint(isDeleteMode ? "Toggle this session for deletion" : "Show this transcript")
+    }
+
+    private var rowFill: Color {
+        if isSelected { return summary.provider.accent.opacity(isHovering ? 0.20 : 0.16) }
+        return Color.primary.opacity(isHovering ? 0.055 : 0)
+    }
+
+    private var rowBorder: Color {
+        if isSelected { return summary.provider.accent.opacity(isHovering ? 0.56 : 0.45) }
+        return Color.primary.opacity(isHovering ? 0.14 : 0)
     }
 
     private var checkbox: some View {
@@ -168,7 +186,6 @@ private struct SessionRow: View {
             .foregroundStyle(isChecked ? Color.accentColor : Color.secondary)
             .opacity(SessionManagerModel.isDeletable(summary) ? 1 : 0.3)
             .padding(.top, 2)
-            .onTapGesture { onToggleCheck() }
             .help(SessionManagerModel.isDeletable(summary)
                 ? "Include this session in the deletion"
                 : "AntiGravity sessions are managed by the IDE")
@@ -208,7 +225,7 @@ private struct SessionRow: View {
                     .help("\(summary.messageCount) messages")
             }
         }
-        .font(.system(size: max(9, density.resetCountdownFontSize - 1)))
+        .font(.system(size: max(10, density.resetCountdownFontSize - 1)))
         .foregroundStyle(.tertiary)
     }
 

--- a/Sources/VibeBarApp/Views/Workbench/SessionManagerPage.swift
+++ b/Sources/VibeBarApp/Views/Workbench/SessionManagerPage.swift
@@ -122,7 +122,7 @@ struct SessionFiltersBar: View {
                 .foregroundStyle(.secondary)
             TextField("Search titles, projects, and message text", text: $model.searchText)
                 .textFieldStyle(.plain)
-                .font(.system(size: density.segmentedFontSize))
+                .font(.system(size: max(12, density.segmentedFontSize)))
             if !model.searchText.isEmpty {
                 BorderlessIconButton(systemImage: "xmark.circle.fill", help: "Clear the search") {
                     model.searchText = ""
@@ -130,10 +130,10 @@ struct SessionFiltersBar: View {
             }
         }
         .padding(.horizontal, 11)
-        .frame(minHeight: 27)
+        .frame(minHeight: 30)
         .background(
-            Capsule().fill(Color.primary.opacity(0.055))
-                .overlay(Capsule().stroke(Color.primary.opacity(0.09), lineWidth: 0.6))
+            Capsule().fill(.background.tertiary.opacity(0.72))
+                .overlay(Capsule().stroke(.separator.opacity(0.45), lineWidth: 0.6))
         )
     }
 
@@ -189,10 +189,10 @@ struct SessionFiltersBar: View {
             model.setProviderFilter(nil)
         } label: {
             Text("All providers")
-                .font(.system(size: density.segmentedFontSize - 1, weight: .semibold))
+                .font(.system(size: max(10, density.segmentedFontSize - 1), weight: .semibold))
                 .foregroundStyle(model.providerFilter == nil ? .primary : .secondary)
                 .padding(.horizontal, 10)
-                .frame(minHeight: 24)
+                .frame(minHeight: 28)
         }
         .buttonStyle(.plain)
         .background(chipBackground(tint: .accentColor, selected: model.providerFilter == nil))
@@ -208,7 +208,7 @@ struct SessionFiltersBar: View {
             HStack(spacing: 5) {
                 ToolBrandIconView(tool: provider.tool, size: density.segmentedFontSize + 1)
                 Text(provider.displayName)
-                    .font(.system(size: density.segmentedFontSize - 1, weight: .semibold))
+                    .font(.system(size: max(10, density.segmentedFontSize - 1), weight: .semibold))
                     .lineLimit(1)
                 if count > 0 {
                     Text("\(count)")
@@ -218,12 +218,12 @@ struct SessionFiltersBar: View {
                 }
             }
             .padding(.horizontal, 9)
-            .frame(minHeight: 24)
+            .frame(minHeight: 28)
         }
         .buttonStyle(.plain)
         .background(chipBackground(tint: provider.accent, selected: selected))
-        .opacity(selected ? 1 : 0.45)
-        .saturation(selected ? 1 : 0.2)
+        .opacity(selected ? 1 : 0.70)
+        .saturation(selected ? 1 : 0.50)
         .help(provider.displayName)
         .accessibilityAddTraits(selected ? [.isSelected] : [])
     }
@@ -259,7 +259,7 @@ struct SessionFiltersBar: View {
             menuLabel(systemImage: "calendar", title: "When", detail: model.dateRange.title)
         }
         .menuStyle(.button)
-        .buttonStyle(.glass)
+        .buttonStyle(.bordered)
         .menuIndicator(.hidden)
         .fixedSize()
         .accessibilityLabel("Choose how far back to list sessions")
@@ -283,7 +283,7 @@ struct SessionFiltersBar: View {
             )
         }
         .menuStyle(.button)
-        .buttonStyle(.glass)
+        .buttonStyle(.bordered)
         .menuIndicator(.hidden)
         .fixedSize()
         .accessibilityLabel("Choose how the list is ordered")
@@ -304,7 +304,7 @@ struct SessionFiltersBar: View {
             menuLabel(systemImage: "slider.horizontal.3", title: "Options", detail: model.preferredTerminal.displayName)
         }
         .menuStyle(.button)
-        .buttonStyle(.glass)
+        .buttonStyle(.bordered)
         .menuIndicator(.hidden)
         .fixedSize()
         .accessibilityLabel("Terminal and index options")
@@ -319,7 +319,7 @@ struct SessionFiltersBar: View {
                 Text(model.checkedIDs.isEmpty ? "Delete" : "Delete \(model.checkedIDs.count)")
                     .font(.system(size: density.segmentedFontSize - 1, weight: .semibold))
             }
-            .buttonStyle(.glass)
+            .buttonStyle(.borderedProminent)
             .disabled(model.checkedIDs.isEmpty)
             .fixedSize()
         }
@@ -330,7 +330,7 @@ struct SessionFiltersBar: View {
                 .font(.system(size: density.segmentedFontSize - 1, weight: .semibold))
                 .labelStyle(.titleAndIcon)
         }
-        .buttonStyle(.glass)
+        .buttonStyle(.bordered)
         .fixedSize()
         .help("Pick sessions to delete")
     }
@@ -359,6 +359,6 @@ struct SessionFiltersBar: View {
                 .foregroundStyle(.primary)
                 .lineLimit(1)
         }
-        .frame(minHeight: 22)
+        .frame(minHeight: 28)
     }
 }

--- a/Sources/VibeBarApp/Views/Workbench/SkillBackupsSheet.swift
+++ b/Sources/VibeBarApp/Views/Workbench/SkillBackupsSheet.swift
@@ -105,7 +105,7 @@ struct SkillBackupsSheet: View {
                 ProgressView().controlSize(.small)
             }
             Button("Restore") { model.restoreBackup(backup) }
-                .buttonStyle(.glass)
+                .buttonStyle(.bordered)
                 .disabled(busy)
                 .help("Copy the snapshot back into ~/.agents/skills")
             Button {
@@ -130,7 +130,7 @@ struct SkillBackupsSheet: View {
                 .fixedSize(horizontal: false, vertical: true)
             Spacer(minLength: 8)
             Button("Done") { dismiss() }
-                .buttonStyle(.glassProminent)
+                .buttonStyle(.borderedProminent)
                 .keyboardShortcut(.defaultAction)
         }
         .padding(.horizontal, density.popoverPaddingH)

--- a/Sources/VibeBarApp/Views/Workbench/SkillDiscoverSheet.swift
+++ b/Sources/VibeBarApp/Views/Workbench/SkillDiscoverSheet.swift
@@ -53,10 +53,10 @@ struct SkillDiscoverSheet: View {
                     : Set(SkillAppTarget.allCases)
                 overrides.removeAll()
             }
-            .buttonStyle(.glass)
+            .buttonStyle(.bordered)
             .help("Set which agent CLIs every row installs into")
             Button("Done") { dismiss() }
-                .buttonStyle(.glassProminent)
+                .buttonStyle(.borderedProminent)
                 .keyboardShortcut(.defaultAction)
         }
         .padding(.horizontal, density.popoverPaddingH)
@@ -86,7 +86,7 @@ struct SkillDiscoverSheet: View {
                     }
                     .frame(minHeight: 22)
                 }
-                .buttonStyle(.glass)
+                .buttonStyle(.bordered)
                 .disabled(model.repoList.isEmpty)
             }
 
@@ -123,7 +123,7 @@ struct SkillDiscoverSheet: View {
                     .font(.system(size: density.subtitleFontSize, design: .monospaced))
                     .onSubmit { addRepo() }
                 Button("Add") { addRepo() }
-                    .buttonStyle(.glass)
+                    .buttonStyle(.bordered)
                     .disabled(!isRepoDraftValid)
             }
             if !repoDraft.isEmpty, !isRepoDraftValid {
@@ -311,7 +311,7 @@ struct SkillDiscoverSheet: View {
             }
             .frame(minHeight: 22)
         }
-        .buttonStyle(.glass)
+        .buttonStyle(.bordered)
         .disabled(model.isBusy(busyKey))
     }
 

--- a/Sources/VibeBarApp/Views/Workbench/SkillImportSheet.swift
+++ b/Sources/VibeBarApp/Views/Workbench/SkillImportSheet.swift
@@ -77,7 +77,7 @@ struct SkillImportSheet: View {
                 model.isImportSheetPresented = false
                 dismiss()
             }
-            .buttonStyle(.glass)
+            .buttonStyle(.bordered)
             Button {
                 model.runImport(
                     apps: Array(adoptedApps).sorted { $0.rawValue < $1.rawValue },
@@ -92,7 +92,7 @@ struct SkillImportSheet: View {
                         + (report.adopted.count + adopting.count == 1 ? "" : "s"))
                 }
             }
-            .buttonStyle(.glassProminent)
+            .buttonStyle(.borderedProminent)
             .keyboardShortcut(.defaultAction)
             .disabled(report.adopted.isEmpty && adopting.isEmpty)
         }
@@ -113,7 +113,7 @@ struct SkillImportSheet: View {
                 VStack(alignment: .leading, spacing: 8) {
                     HStack(spacing: 8) {
                         Text("Keep evidence for")
-                            .font(.system(size: max(9, density.resetCountdownFontSize)))
+                            .font(.system(size: max(10, density.resetCountdownFontSize)))
                             .foregroundStyle(.tertiary)
                         SkillAppToggleRow(
                             isOn: { adoptedApps.contains($0) },
@@ -187,7 +187,7 @@ struct SkillImportSheet: View {
                         .font(.system(size: density.bucketTitleFontSize, weight: .semibold))
                         .lineLimit(1)
                     Text("found in " + entry.foundIn.map(\.displayName).joined(separator: ", "))
-                        .font(.system(size: max(9, density.resetCountdownFontSize)))
+                        .font(.system(size: max(10, density.resetCountdownFontSize)))
                         .foregroundStyle(.tertiary)
                 }
             }
@@ -218,7 +218,7 @@ struct SkillImportSheet: View {
                 .font(.system(size: density.subtitleFontSize))
                 .foregroundStyle(.secondary)
             Text(report.unrecognized.joined(separator: ", "))
-                .font(.system(size: max(9, density.resetCountdownFontSize), design: .monospaced))
+                .font(.system(size: max(10, density.resetCountdownFontSize), design: .monospaced))
                 .foregroundStyle(.tertiary)
                 .fixedSize(horizontal: false, vertical: true)
         }
@@ -236,10 +236,10 @@ struct SkillImportSheet: View {
                 HStack(spacing: 8) {
                     SkillAppGlyph(app: conflict.app, size: 11)
                     Text(conflict.directoryName)
-                        .font(.system(size: max(9, density.resetCountdownFontSize), design: .monospaced))
+                        .font(.system(size: max(10, density.resetCountdownFontSize), design: .monospaced))
                         .foregroundStyle(.secondary)
                     Text(conflict.app.displayName)
-                        .font(.system(size: max(9, density.resetCountdownFontSize)))
+                        .font(.system(size: max(10, density.resetCountdownFontSize)))
                         .foregroundStyle(.tertiary)
                 }
             }
@@ -249,12 +249,12 @@ struct SkillImportSheet: View {
     private func sectionHeader(_ title: String, detail: String) -> some View {
         HStack(spacing: 8) {
             Text(title.uppercased())
-                .font(.system(size: max(8, density.segmentedFontSize - 3), weight: .semibold))
+                .font(.system(size: max(10, density.segmentedFontSize - 3), weight: .semibold))
                 .foregroundStyle(.tertiary)
                 .tracking(0.4)
             Spacer(minLength: 8)
             Text(detail)
-                .font(.system(size: max(9, density.resetCountdownFontSize), design: .rounded)
+                .font(.system(size: max(10, density.resetCountdownFontSize), design: .rounded)
                     .monospacedDigit())
                 .foregroundStyle(.tertiary)
         }

--- a/Sources/VibeBarApp/Views/Workbench/SkillListRow.swift
+++ b/Sources/VibeBarApp/Views/Workbench/SkillListRow.swift
@@ -1,16 +1,16 @@
+import AppKit
 import SwiftUI
 import VibeBarCore
 
 extension SkillAppTarget {
     /// The provider this agent CLI shares a brand mark with, when there is
     /// one. Five of the seven targets are also usage providers, so their rows
-    /// wear the same glyph and accent they wear everywhere else in the app;
-    /// Hermes and OpenCode have no provider entry and fall back to a symbol.
+    /// wear the same glyph and accent they wear everywhere else in the app.
     var brandTool: ToolType? { ToolType(rawValue: rawValue) }
 
     var fallbackSystemImage: String {
         switch self {
-        case .hermes: return "bolt.horizontal.circle"
+        case .hermes: return "cross.case"
         case .opencode: return "chevron.left.forwardslash.chevron.right"
         case .claude, .codex, .gemini, .grok, .antigravity: return "puzzlepiece.extension"
         }
@@ -30,12 +30,43 @@ struct SkillAppGlyph: View {
     var body: some View {
         if let tool = app.brandTool {
             ToolBrandIconView(tool: tool, size: size)
+        } else if app == .hermes, let image = hermesImage {
+            Image(nsImage: image)
+                .resizable()
+                .renderingMode(.template)
+                .scaledToFit()
+                .frame(width: size, height: size)
+                .foregroundStyle(.primary)
+                .accessibilityHidden(true)
         } else {
             Image(systemName: app.fallbackSystemImage)
                 .font(.system(size: size * 0.92, weight: .semibold))
                 .frame(width: size, height: size)
                 .accessibilityHidden(true)
         }
+    }
+
+    /// Official Hermes mark from NousResearch's hermes-agent site:
+    /// https://github.com/NousResearch/hermes-agent/blob/main/website/static/img/favicon.svg
+    private var hermesImage: NSImage? {
+        let filename = "ProviderIcon-hermes.svg"
+        let bundled = Bundle.main.url(
+            forResource: "ProviderIcon-hermes",
+            withExtension: "svg",
+            subdirectory: "ProviderIcons"
+        )
+        let local = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("Resources/ProviderIcons/\(filename)")
+        guard let url = bundled ?? (FileManager.default.fileExists(atPath: local.path) ? local : nil),
+              let image = NSImage(contentsOf: url)
+        else { return nil }
+        image.size = NSSize(width: size, height: size)
+        image.isTemplate = true
+        return image
     }
 }
 
@@ -51,6 +82,8 @@ struct SkillAppToggleRow: View {
     var glyphSize: CGFloat = 13
     var spacing: CGFloat = 4
     var helpSuffix: String?
+
+    @State private var hoveredApp: SkillAppTarget?
 
     var body: some View {
         HStack(spacing: spacing) {
@@ -69,20 +102,22 @@ struct SkillAppToggleRow: View {
             SkillAppGlyph(app: app, size: glyphSize)
                 .frame(width: diameter, height: diameter)
                 .background(
-                    Circle().fill(accent.opacity(on ? 0.18 : 0.05))
+                    Circle().fill(accent.opacity(on ? 0.18 : hoveredApp == app ? 0.10 : 0.05))
                 )
                 .overlay(
-                    Circle().stroke(accent.opacity(on ? 0.6 : 0.16), lineWidth: 0.8)
+                    Circle().stroke(accent.opacity(on ? 0.6 : hoveredApp == app ? 0.42 : 0.20), lineWidth: 0.8)
                 )
         }
         .buttonStyle(.plain)
         // An off app has to stay readable — the user is picking from these —
         // but must not wear the accent, which is the only signal that says
         // "this skill is live here".
-        .opacity(on ? 1 : 0.35)
-        .saturation(on ? 1 : 0.15)
+        .opacity(on ? 1 : 0.62)
+        .saturation(on ? 1 : 0.45)
+        .onHover { hovering in hoveredApp = hovering ? app : nil }
         .help(helpSuffix.map { "\(app.displayName) — \($0)" } ?? app.displayName)
         .accessibilityLabel(app.displayName)
+        .accessibilityValue(on ? "Enabled" : "Disabled")
         .accessibilityAddTraits(on ? [.isSelected] : [])
     }
 }
@@ -99,6 +134,7 @@ struct SkillListRow: View {
     let onUninstall: () -> Void
 
     @State private var confirmingUninstall = false
+    @State private var isHovering = false
 
     var body: some View {
         HStack(alignment: .top, spacing: 12) {
@@ -112,14 +148,27 @@ struct SkillListRow: View {
             .disabled(isBusy)
             overflowMenu
         }
-        .padding(.vertical, 5)
+        .padding(.horizontal, 8)
+        .padding(.vertical, 7)
         .opacity(isBusy ? 0.55 : 1)
+        .background(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .fill(isHovering ? Color.accentColor.opacity(0.08) : .clear)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .stroke(
+                    isHovering ? Color(nsColor: .separatorColor).opacity(0.7) : Color.clear,
+                    lineWidth: 0.5
+                )
+        )
         .overlay(alignment: .trailing) {
             if isBusy {
                 ProgressView().controlSize(.small)
             }
         }
         .contentShape(Rectangle())
+        .onHover { isHovering = $0 }
         .confirmationDialog(
             "Uninstall \(skill.name)?",
             isPresented: $confirmingUninstall,
@@ -136,7 +185,7 @@ struct SkillListRow: View {
         VStack(alignment: .leading, spacing: 3) {
             HStack(spacing: 6) {
                 Text(skill.name)
-                    .font(.system(size: density.bucketTitleFontSize, weight: .semibold))
+                    .font(.system(size: max(12, density.bucketTitleFontSize), weight: .semibold))
                     .lineLimit(1)
                 sourceBadge
                 if updateState?.updateAvailable == true {
@@ -145,7 +194,7 @@ struct SkillListRow: View {
             }
             if let description = skill.description, !description.isEmpty {
                 Text(description)
-                    .font(.system(size: density.subtitleFontSize))
+                    .font(.system(size: max(10, density.subtitleFontSize)))
                     .foregroundStyle(.tertiary)
                     .lineLimit(2)
                     .fixedSize(horizontal: false, vertical: true)
@@ -155,7 +204,7 @@ struct SkillListRow: View {
 
     private var sourceBadge: some View {
         Text(skill.id.repositorySlug ?? "local")
-            .font(.system(size: max(8, density.resetCountdownFontSize - 1), design: .rounded))
+            .font(.system(size: max(10, density.resetCountdownFontSize - 1), design: .rounded))
             .foregroundStyle(.secondary)
             .lineLimit(1)
             .padding(.horizontal, 6)
@@ -166,7 +215,7 @@ struct SkillListRow: View {
 
     private var updateBadge: some View {
         Text("UPDATE")
-            .font(.system(size: max(8, density.resetCountdownFontSize - 2), weight: .semibold))
+            .font(.system(size: max(10, density.resetCountdownFontSize - 2), weight: .semibold))
             .tracking(0.4)
             .foregroundStyle(Color.accentColor)
             .padding(.horizontal, 6)
@@ -185,12 +234,12 @@ struct SkillListRow: View {
             }
         } label: {
             Image(systemName: "ellipsis")
-                .font(.system(size: density.subtitleFontSize, weight: .semibold))
+                .font(.system(size: max(10, density.subtitleFontSize), weight: .semibold))
                 .foregroundStyle(.secondary)
-                .frame(width: 22, height: 22)
+                .frame(width: 28, height: 28)
         }
         .menuStyle(.button)
-        .buttonStyle(.plain)
+        .buttonStyle(.borderless)
         .menuIndicator(.hidden)
         .fixedSize()
         .disabled(isBusy)

--- a/Sources/VibeBarApp/Views/Workbench/SkillsManagerPage.swift
+++ b/Sources/VibeBarApp/Views/Workbench/SkillsManagerPage.swift
@@ -79,11 +79,11 @@ struct SkillsManagerPage: View {
     private var searchField: some View {
         HStack(spacing: 6) {
             Image(systemName: "magnifyingglass")
-                .font(.system(size: density.segmentedFontSize - 1, weight: .semibold))
+                .font(.system(size: max(10, density.segmentedFontSize - 1), weight: .semibold))
                 .foregroundStyle(.secondary)
             TextField("Filter installed skills", text: $model.searchText)
                 .textFieldStyle(.plain)
-                .font(.system(size: density.segmentedFontSize))
+                .font(.system(size: max(12, density.segmentedFontSize)))
             if !model.searchText.isEmpty {
                 Button {
                     model.searchText = ""
@@ -96,7 +96,7 @@ struct SkillsManagerPage: View {
             }
         }
         .padding(.horizontal, 10)
-        .frame(height: 26)
+        .frame(minHeight: 30)
         .frame(maxWidth: 320)
         .background(Capsule().fill(.background.tertiary.opacity(0.7)))
         .overlay(Capsule().stroke(.separator.opacity(0.45), lineWidth: 0.5))
@@ -104,58 +104,68 @@ struct SkillsManagerPage: View {
 
     private var actionButtons: some View {
         HStack(spacing: 6) {
-            Button {
-                model.checkForUpdates()
+            Menu {
+                Button {
+                    model.presentImportSheet()
+                } label: {
+                    Label("Import Existing…", systemImage: "square.and.arrow.down.on.square")
+                }
+                Button {
+                    showsZipImporter = true
+                } label: {
+                    Label("Install from ZIP…", systemImage: "doc.zipper")
+                }
             } label: {
                 buttonLabel(
-                    systemImage: "arrow.triangle.2.circlepath",
+                    systemImage: "plus",
+                    title: "Add",
+                    busy: model.isBusy(SkillsManagerModel.BusyKey.zip)
+                        || model.isBusy(SkillsManagerModel.BusyKey.importing)
+                )
+            }
+            .menuStyle(.button)
+            .buttonStyle(.bordered)
+            .menuIndicator(.hidden)
+            .help("Import skills already on this Mac or install a ZIP archive")
+
+            Menu {
+                Button {
+                    model.checkForUpdates()
+                } label: {
+                    Label(
+                        model.updatesAvailableCount > 0
+                            ? "Updates Available (\(model.updatesAvailableCount))"
+                            : "Check for Updates",
+                        systemImage: "arrow.triangle.2.circlepath"
+                    )
+                }
+                .disabled(model.isBusy(SkillsManagerModel.BusyKey.updates))
+                Divider()
+                Button {
+                    model.presentBackupsSheet()
+                } label: {
+                    Label("Backups…", systemImage: "clock.arrow.circlepath")
+                }
+            } label: {
+                buttonLabel(
+                    systemImage: "ellipsis.circle",
                     title: model.updatesAvailableCount > 0
-                        ? "Updates (\(model.updatesAvailableCount))"
-                        : "Check Updates",
+                        ? "More · \(model.updatesAvailableCount)"
+                        : "More",
                     busy: model.isBusy(SkillsManagerModel.BusyKey.updates)
                 )
             }
-            .buttonStyle(.glass)
-            .help("Compare every repository-backed skill against its source")
-
-            Button {
-                showsZipImporter = true
-            } label: {
-                buttonLabel(
-                    systemImage: "doc.zipper",
-                    title: "Install from ZIP",
-                    busy: model.isBusy(SkillsManagerModel.BusyKey.zip)
-                )
-            }
-            .buttonStyle(.glass)
-            .help("Install every skill inside a local .zip archive")
-
-            Button {
-                model.presentImportSheet()
-            } label: {
-                buttonLabel(
-                    systemImage: "square.and.arrow.down.on.square",
-                    title: "Import Existing",
-                    busy: model.isBusy(SkillsManagerModel.BusyKey.importing)
-                )
-            }
-            .buttonStyle(.glass)
-            .help("Recognize skills already on this Mac without moving them")
-
-            Button {
-                model.presentBackupsSheet()
-            } label: {
-                buttonLabel(systemImage: "clock.arrow.circlepath", title: "Backups", busy: false)
-            }
-            .buttonStyle(.glass)
-            .help("Restore a skill from a pre-uninstall snapshot")
+            .menuStyle(.button)
+            .buttonStyle(.bordered)
+            .menuIndicator(.hidden)
+            .help("Check repository updates or restore a backup")
 
             Button {
                 model.isDiscoverSheetPresented = true
             } label: {
                 buttonLabel(systemImage: "sparkle.magnifyingglass", title: "Discover", busy: false)
             }
-            .buttonStyle(.glassProminent)
+            .buttonStyle(.borderedProminent)
             .help("Browse configured repositories and the skills.sh index")
         }
     }
@@ -169,10 +179,10 @@ struct SkillsManagerPage: View {
                     .font(.system(size: max(9, density.segmentedFontSize - 1), weight: .semibold))
             }
             Text(title)
-                .font(.system(size: density.segmentedFontSize - 1, weight: .semibold))
+                .font(.system(size: max(10, density.segmentedFontSize - 1), weight: .semibold))
                 .lineLimit(1)
         }
-        .frame(minHeight: 22)
+        .frame(minHeight: 28)
     }
 
     /// How many skills each agent CLI currently sees. The single number that
@@ -185,11 +195,11 @@ struct SkillsManagerPage: View {
                 HStack(spacing: 4) {
                     SkillAppGlyph(app: app, size: density.segmentedFontSize)
                     Text("\(count)")
-                        .font(.system(size: density.segmentedFontSize - 1, weight: .semibold,
+                        .font(.system(size: max(10, density.segmentedFontSize - 1), weight: .semibold,
                                       design: .rounded).monospacedDigit())
                 }
                 .padding(.horizontal, 8)
-                .frame(minHeight: 22)
+                .frame(minHeight: 28)
                 .background(Capsule().fill(app.accent.opacity(count == 0 ? 0.05 : 0.14)))
                 .overlay(Capsule().stroke(app.accent.opacity(count == 0 ? 0.16 : 0.45), lineWidth: 0.8))
                 .opacity(count == 0 ? 0.5 : 1)
@@ -199,7 +209,7 @@ struct SkillsManagerPage: View {
             }
             Spacer(minLength: 8)
             Text(countSummary)
-                .font(.system(size: max(9, density.resetCountdownFontSize), design: .rounded)
+                .font(.system(size: max(10, density.resetCountdownFontSize), design: .rounded)
                     .monospacedDigit())
                 .foregroundStyle(.tertiary)
                 .lineLimit(1)

--- a/Sources/VibeBarApp/Views/Workbench/TranscriptView.swift
+++ b/Sources/VibeBarApp/Views/Workbench/TranscriptView.swift
@@ -10,6 +10,7 @@ struct TranscriptView: View {
     let density: Theme.Density
     @ObservedObject var model: SessionManagerModel
 
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var query = ""
     @State private var matches: [Int] = []
     @State private var matchIndex = 0
@@ -33,10 +34,26 @@ struct TranscriptView: View {
 
     private func content(for summary: SessionSummary) -> some View {
         ScrollViewReader { proxy in
-            ScrollView {
-                LazyVStack(alignment: .leading, spacing: density.cardSpacing) {
-                    SessionMetadataHeader(density: density, model: model, summary: summary)
+            VStack(spacing: 0) {
+                // Keep the session's identity and recovery controls in view while
+                // reviewing a long log. The scroll view below is intentionally
+                // limited to transcript content; the header is a stable reading
+                // anchor rather than another item in the transcript.
+                SessionMetadataHeader(density: density, model: model, summary: summary)
+                    .padding(.horizontal, density.popoverPaddingH)
+                    .padding(.top, density.popoverPaddingV)
+
+                HStack(spacing: 8) {
                     searchBar(proxy: proxy)
+                    outlineButton(proxy: proxy)
+                }
+                .padding(.horizontal, density.popoverPaddingH)
+                .padding(.vertical, max(8, density.popoverPaddingV / 2))
+
+                Divider().opacity(0.45)
+
+                ScrollView {
+                    LazyVStack(alignment: .leading, spacing: density.cardSpacing) {
                     if model.isLoadingTranscript {
                         loading
                     } else if let error = model.transcriptError {
@@ -60,12 +77,13 @@ struct TranscriptView: View {
                             }
                         }
                     }
+                    }
+                    .padding(.horizontal, density.popoverPaddingH)
+                    .padding(.vertical, density.popoverPaddingV)
+                    .frame(maxWidth: .infinity, alignment: .topLeading)
                 }
-                .padding(.horizontal, density.popoverPaddingH)
-                .padding(.vertical, density.popoverPaddingV)
-                .frame(maxWidth: .infinity, alignment: .topLeading)
             }
-            .overlay(alignment: .topTrailing) { outlineButton(proxy: proxy) }
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
             .onChange(of: model.transcript) { _, _ in focusOnSearchHit(proxy: proxy) }
         }
     }
@@ -156,11 +174,12 @@ struct TranscriptView: View {
             }
         }
         .padding(.horizontal, 11)
-        .frame(minHeight: 27)
+        .frame(minHeight: 30)
         .background(
-            Capsule().fill(Color.primary.opacity(0.055))
-                .overlay(Capsule().stroke(Color.primary.opacity(0.09), lineWidth: 0.6))
+            Capsule().fill(Color.primary.opacity(0.045))
+                .overlay(Capsule().stroke(Color.primary.opacity(0.11), lineWidth: 0.6))
         )
+        .accessibilityLabel("Find in transcript")
         .onChange(of: query) { _, _ in recomputeMatches(proxy: proxy) }
         .onChange(of: model.transcript) { _, _ in recomputeMatches(proxy: proxy) }
     }
@@ -191,8 +210,12 @@ struct TranscriptView: View {
     }
 
     private func scroll(to seq: Int, proxy: ScrollViewProxy) {
-        withAnimation(.easeOut(duration: 0.2)) {
+        if reduceMotion {
             proxy.scrollTo(seq, anchor: .top)
+        } else {
+            withAnimation(.easeOut(duration: 0.2)) {
+                proxy.scrollTo(seq, anchor: .top)
+            }
         }
         flash(seq)
     }
@@ -229,12 +252,10 @@ struct TranscriptView: View {
         } label: {
             Image(systemName: "list.bullet.indent")
                 .font(.system(size: density.segmentedFontSize, weight: .semibold))
-                .padding(.horizontal, 9)
-                .frame(minHeight: 26)
+                .frame(width: 28, height: 28)
         }
-        .buttonStyle(.glass)
-        .padding(.trailing, density.popoverPaddingH)
-        .padding(.top, density.popoverPaddingV)
+        .buttonStyle(.bordered)
+        .controlSize(.small)
         .help("Jump to a prompt")
         .accessibilityLabel("Show the transcript outline")
         .popover(isPresented: $showsOutline, arrowEdge: .trailing) {
@@ -274,37 +295,89 @@ struct SessionMetadataHeader: View {
     @ObservedObject var model: SessionManagerModel
     let summary: SessionSummary
 
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var showsDetails = false
+
     var body: some View {
-        CardShell(density: density, spacing: density.cardSpacing) {
-            HStack(alignment: .top, spacing: 10) {
+        CardShell(density: density, spacing: max(7, density.cardSpacing)) {
+            HStack(alignment: .center, spacing: 10) {
                 ToolBrandBadge(tool: summary.provider.tool, iconSize: 20, containerSize: 26)
                 VStack(alignment: .leading, spacing: 3) {
                     Text(title)
                         .font(.system(size: density.titleFontSize, weight: .semibold))
-                        .lineLimit(2)
-                    HStack(spacing: 6) {
-                        Text(providerLabel)
-                            .font(.system(size: max(8, density.subtitleFontSize - 2), weight: .semibold))
-                            .padding(.horizontal, 7)
-                            .frame(minHeight: 17)
-                            .background(Capsule().fill(summary.provider.accent.opacity(0.16)))
-                        if summary.hasKnownMessageCount {
-                            Text("\(summary.messageCount) messages")
-                                .font(.system(size: max(9, density.resetCountdownFontSize - 1), design: .rounded)
-                                    .monospacedDigit())
-                                .foregroundStyle(.tertiary)
-                        }
-                    }
+                        .lineLimit(1)
+                    compactMetadata
                 }
                 Spacer(minLength: 0)
+                headerActions
             }
-            Divider().opacity(0.35)
-            facts
-            if summary.provider == .antigravity {
-                notice
+            if showsDetails {
+                Divider().opacity(0.42)
+                facts
+                if summary.provider == .antigravity {
+                    notice
+                }
+                resumeRow
             }
-            resumeRow
         }
+    }
+
+    private var compactMetadata: some View {
+        HStack(spacing: 6) {
+            Text(providerLabel)
+                .font(.system(size: max(10, density.subtitleFontSize - 2), weight: .semibold))
+                .padding(.horizontal, 7)
+                .frame(minHeight: 18)
+                .background(Capsule().fill(summary.provider.accent.opacity(0.16)))
+            if let project = summary.projectDir {
+                Label(SessionManagerModel.projectTitle(project), systemImage: "folder")
+                    .lineLimit(1)
+                    .help(project)
+            }
+            if summary.hasKnownMessageCount {
+                Text("\(summary.messageCount) messages")
+                    .monospacedDigit()
+            }
+        }
+        .font(.system(size: max(10, density.resetCountdownFontSize - 1), design: .rounded))
+        .foregroundStyle(.secondary)
+    }
+
+    private var headerActions: some View {
+        HStack(spacing: 6) {
+            if model.resumeShellLine(for: summary) != nil {
+                Button {
+                    model.copyResumeCommand(for: summary)
+                } label: {
+                    Image(systemName: "doc.on.doc")
+                        .frame(width: 16, height: 16)
+                }
+                .help("Copy resume command")
+                .accessibilityLabel("Copy resume command")
+
+                Button {
+                    model.resumeInTerminal(summary)
+                } label: {
+                    Label("Open", systemImage: "terminal")
+                        .font(.system(size: max(10, density.segmentedFontSize - 1), weight: .semibold))
+                }
+                .help("Run it in \(model.preferredTerminal.displayName)")
+            }
+
+            Button {
+                withAnimation(reduceMotion ? nil : .easeInOut(duration: 0.16)) {
+                    showsDetails.toggle()
+                }
+            } label: {
+                Label("Details", systemImage: "chevron.down")
+                    .font(.system(size: max(10, density.segmentedFontSize - 1), weight: .semibold))
+                    .labelStyle(.titleAndIcon)
+            }
+            .accessibilityValue(showsDetails ? "Expanded" : "Collapsed")
+        }
+        .buttonStyle(.bordered)
+        .controlSize(.small)
+        .fixedSize()
     }
 
     private var title: String {
@@ -376,7 +449,7 @@ struct SessionMetadataHeader: View {
 
     private func factLabel(_ text: String) -> some View {
         Text(text.uppercased())
-            .font(.system(size: max(8, density.resetCountdownFontSize - 2), weight: .semibold))
+            .font(.system(size: max(10, density.resetCountdownFontSize - 2), weight: .semibold))
             .foregroundStyle(.tertiary)
             .tracking(0.4)
             .frame(width: 74, alignment: .leading)
@@ -401,12 +474,23 @@ struct SessionMetadataHeader: View {
     private var resumeRow: some View {
         if let line = model.resumeShellLine(for: summary) {
             VStack(alignment: .leading, spacing: 6) {
+                Text("RESUME")
+                    .font(.system(size: max(10, density.resetCountdownFontSize - 2), weight: .semibold))
+                    .foregroundStyle(.tertiary)
+                    .tracking(0.4)
                 Text(line)
                     .font(.system(size: density.subtitleFontSize - 1, design: .monospaced))
                     .foregroundStyle(.secondary)
                     .lineLimit(2)
                     .truncationMode(.middle)
                     .textSelection(.enabled)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 6)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(
+                        RoundedRectangle(cornerRadius: 6, style: .continuous)
+                            .fill(Color.primary.opacity(0.045))
+                    )
                 HStack(spacing: 8) {
                     Button {
                         model.copyResumeCommand(for: summary)
@@ -414,14 +498,16 @@ struct SessionMetadataHeader: View {
                         Label("Copy", systemImage: "doc.on.doc")
                             .font(.system(size: density.segmentedFontSize - 1, weight: .semibold))
                     }
-                    .buttonStyle(.glass)
+                    .buttonStyle(.bordered)
+                    .frame(minHeight: 28)
                     Button {
                         model.resumeInTerminal(summary)
                     } label: {
                         Label("Open in Terminal", systemImage: "terminal")
                             .font(.system(size: density.segmentedFontSize - 1, weight: .semibold))
                     }
-                    .buttonStyle(.glass)
+                    .buttonStyle(.borderedProminent)
+                    .frame(minHeight: 28)
                     .help("Run it in \(model.preferredTerminal.displayName)")
                     Spacer(minLength: 0)
                 }
@@ -453,6 +539,7 @@ struct TranscriptMessageCard: View {
     let onToggleExpanded: () -> Void
     let onCopy: () -> Void
 
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var isHovering = false
 
     /// Past this a card stops being a message and starts being a document —
@@ -484,27 +571,49 @@ struct TranscriptMessageCard: View {
         .padding(.horizontal, 9)
         .background(
             RoundedRectangle(cornerRadius: density.cardCornerRadius, style: .continuous)
-                .fill(isHighlighted ? accent.opacity(0.14) : Color.primary.opacity(0.035))
+                .fill(surfaceFill)
         )
+        .overlay(
+            RoundedRectangle(cornerRadius: density.cardCornerRadius, style: .continuous)
+                .stroke(borderColor, lineWidth: isHovering || isHighlighted ? 0.8 : 0.5)
+        )
+        .contentShape(RoundedRectangle(cornerRadius: density.cardCornerRadius, style: .continuous))
         .onHover { isHovering = $0 }
+        .animation(reduceMotion ? nil : .easeOut(duration: 0.14), value: isHovering)
+        .animation(reduceMotion ? nil : .easeOut(duration: 0.18), value: isHighlighted)
+        .contextMenu {
+            Button {
+                onCopy()
+            } label: {
+                Label("Copy Message", systemImage: "doc.on.doc")
+            }
+        }
     }
 
     private var header: some View {
         HStack(spacing: 6) {
             Text(roleLabel.uppercased())
-                .font(.system(size: max(8, density.resetCountdownFontSize - 1), weight: .semibold))
+                .font(.system(size: max(10, density.resetCountdownFontSize - 1), weight: .semibold))
                 .foregroundStyle(.tertiary)
                 .tracking(0.4)
             if let timestamp = message.timestamp {
                 Text(Self.time.string(from: timestamp))
-                    .font(.system(size: max(8, density.resetCountdownFontSize - 1), design: .rounded)
+                    .font(.system(size: max(10, density.resetCountdownFontSize - 1), design: .rounded)
                         .monospacedDigit())
                     .foregroundStyle(.tertiary)
             }
             Spacer(minLength: 0)
-            if isHovering {
-                BorderlessIconButton(systemImage: "doc.on.doc", help: "Copy this message", action: onCopy)
+            Button(action: onCopy) {
+                Image(systemName: "doc.on.doc")
+                    .font(.system(size: 11, weight: .semibold))
+                    .frame(width: 26, height: 26)
+                    .background(Circle().fill(Color.primary.opacity(isHovering ? 0.09 : 0)))
             }
+            .buttonStyle(.plain)
+            .foregroundStyle(isHovering ? .secondary : .tertiary)
+            .opacity(isHovering ? 1 : 0.42)
+            .help("Copy this message")
+            .accessibilityLabel("Copy this message")
         }
     }
 
@@ -540,6 +649,16 @@ struct TranscriptMessageCard: View {
         case .system:    Color.secondary.opacity(0.18)
         case .other:     Color.secondary.opacity(0.18)
         }
+    }
+
+    private var surfaceFill: Color {
+        if isHighlighted { return accent.opacity(isHovering ? 0.18 : 0.14) }
+        return Color.primary.opacity(isHovering ? 0.07 : 0.032)
+    }
+
+    private var borderColor: Color {
+        if isHighlighted { return accent.opacity(isHovering ? 0.52 : 0.36) }
+        return Color.primary.opacity(isHovering ? 0.18 : 0.075)
     }
 
     private var roleLabel: String {

--- a/Sources/VibeBarApp/Views/Workbench/UsageBreakdownTables.swift
+++ b/Sources/VibeBarApp/Views/Workbench/UsageBreakdownTables.swift
@@ -11,6 +11,7 @@ struct UsageBreakdownTables: View {
     let density: Theme.Density
     @ObservedObject var model: UsageStatsViewModel
 
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var tab: Tab = .periods
 
     enum Tab: String, CaseIterable, Identifiable {
@@ -76,14 +77,14 @@ struct UsageBreakdownTables: View {
                 ForEach(Tab.allCases) { value in
                     let selected = tab == value
                     Button {
-                        withAnimation(.easeOut(duration: 0.16)) { tab = value }
+                        withAnimation(reduceMotion ? nil : .easeOut(duration: 0.16)) { tab = value }
                     } label: {
                         Label(value.title, systemImage: value.systemImage)
-                            .font(.system(size: max(9, density.segmentedFontSize - 1), weight: .semibold))
+                            .font(.system(size: max(10, density.segmentedFontSize - 1), weight: .semibold))
                             .labelStyle(.titleAndIcon)
                             .foregroundStyle(selected ? Color.primary : Color.secondary)
                             .padding(.horizontal, 10)
-                            .frame(minHeight: 25)
+                            .frame(minHeight: 28)
                     }
                     .buttonStyle(.plain)
                     .background(
@@ -124,7 +125,7 @@ struct UsageBreakdownTables: View {
     private var countSummary: String {
         switch tab {
         case .periods:
-            return "\(populatedPeriods.count) active \(model.trend.bucket == .hour ? "hour" : "day")"
+            return "\(populatedPeriods.count) active \(periodUnit)"
                 + (populatedPeriods.count == 1 ? "" : "s")
         case .requests:
             let loaded = model.requestRows.count
@@ -173,7 +174,7 @@ struct UsageBreakdownTables: View {
 
     private var periodsTable: some View {
         Table(populatedPeriods) {
-            TableColumn(model.trend.bucket == .hour ? "Hour" : "Day") { point in
+            TableColumn(periodColumnTitle) { point in
                 Text(period(point.bucketStart))
                     .font(bodyFont)
             }
@@ -184,32 +185,37 @@ struct UsageBreakdownTables: View {
                     .font(numericFont)
             }
             .width(min: 82, ideal: 104)
+            .alignment(.trailing)
 
             TableColumn("Output") { point in
                 Text(UsageFormatting.compactTokens(point.output))
                     .font(numericFont)
             }
             .width(min: 82, ideal: 104)
+            .alignment(.trailing)
 
             TableColumn("Cache") { point in
                 Text(UsageFormatting.compactTokens(point.cacheRead + point.cacheCreation))
                     .font(numericFont)
             }
             .width(min: 82, ideal: 104)
+            .alignment(.trailing)
 
             TableColumn("Tokens") { point in
                 Text(UsageFormatting.compactTokens(point.totalTokens))
                     .font(numericFont)
             }
             .width(min: 88, ideal: 112)
+            .alignment(.trailing)
 
             TableColumn("Cost") { point in
                 Text(UsageFormatting.formatMicroUSD(point.costMicros))
                     .font(numericFont)
             }
             .width(min: 88, ideal: 112)
+            .alignment(.trailing)
         }
-        .tableStyle(.inset(alternatesRowBackgrounds: false))
+        .tableStyle(.inset(alternatesRowBackgrounds: true))
     }
 
     private var requestsTable: some View {
@@ -253,12 +259,14 @@ struct UsageBreakdownTables: View {
                 }
             }
             .width(min: 86, ideal: 104)
+            .alignment(.trailing)
 
             TableColumn("Output") { row in
                 Text(UsageFormatting.compactTokens(row.output))
                     .font(numericFont)
             }
             .width(min: 68, ideal: 82)
+            .alignment(.trailing)
 
             TableColumn("Cost") { row in
                 if let micros = row.costMicros {
@@ -271,6 +279,7 @@ struct UsageBreakdownTables: View {
                 }
             }
             .width(min: 72, ideal: 88)
+            .alignment(.trailing)
 
             TableColumn("Tier") { row in
                 Text(row.serviceTier ?? "—")
@@ -280,7 +289,7 @@ struct UsageBreakdownTables: View {
             }
             .width(min: 62, ideal: 78)
         }
-        .tableStyle(.inset(alternatesRowBackgrounds: false))
+        .tableStyle(.inset(alternatesRowBackgrounds: true))
     }
 
     private var providersTable: some View {
@@ -295,20 +304,23 @@ struct UsageBreakdownTables: View {
                     .font(numericFont)
             }
             .width(min: 80, ideal: 100)
+            .alignment(.trailing)
 
             TableColumn("Tokens") { stat in
                 Text(UsageFormatting.compactTokens(stat.totalTokens))
                     .font(numericFont)
             }
             .width(min: 84, ideal: 110)
+            .alignment(.trailing)
 
             TableColumn("Cost") { stat in
                 Text(UsageFormatting.formatMicroUSD(stat.costMicros))
                     .font(numericFont)
             }
             .width(min: 84, ideal: 110)
+            .alignment(.trailing)
         }
-        .tableStyle(.inset(alternatesRowBackgrounds: false))
+        .tableStyle(.inset(alternatesRowBackgrounds: true))
     }
 
     private var modelsTable: some View {
@@ -327,18 +339,21 @@ struct UsageBreakdownTables: View {
                     .font(numericFont)
             }
             .width(min: 80, ideal: 98)
+            .alignment(.trailing)
 
             TableColumn("Tokens") { stat in
                 Text(UsageFormatting.compactTokens(stat.totalTokens))
                     .font(numericFont)
             }
             .width(min: 84, ideal: 104)
+            .alignment(.trailing)
 
             TableColumn("Cost") { stat in
                 Text(UsageFormatting.formatMicroUSD(stat.costMicros))
                     .font(numericFont)
             }
             .width(min: 84, ideal: 104)
+            .alignment(.trailing)
 
             TableColumn("Avg/req") { stat in
                 Text(UsageFormatting.formatMicroUSD(stat.avgCostMicrosPerRequest, precision: 4))
@@ -346,8 +361,9 @@ struct UsageBreakdownTables: View {
                     .foregroundStyle(.secondary)
             }
             .width(min: 88, ideal: 108)
+            .alignment(.trailing)
         }
-        .tableStyle(.inset(alternatesRowBackgrounds: false))
+        .tableStyle(.inset(alternatesRowBackgrounds: true))
     }
 
     // MARK: - Cells
@@ -392,8 +408,29 @@ struct UsageBreakdownTables: View {
     }
 
     private func period(_ date: Date) -> String {
-        let formatter = model.trend.bucket == .hour ? Self.periodHourFormatter : Self.periodDayFormatter
+        let formatter: DateFormatter
+        switch model.trend.bucket {
+        case .hour: formatter = Self.periodHourFormatter
+        case .day: formatter = Self.periodDayFormatter
+        case .week: formatter = Self.periodWeekFormatter
+        }
         return formatter.string(from: date)
+    }
+
+    private var periodUnit: String {
+        switch model.trend.bucket {
+        case .hour: "hour"
+        case .day: "day"
+        case .week: "week"
+        }
+    }
+
+    private var periodColumnTitle: String {
+        switch model.trend.bucket {
+        case .hour: "Hour"
+        case .day: "Day"
+        case .week: "Week of"
+        }
     }
 
     /// Cached: the requests table formats one of these per visible row, and
@@ -416,6 +453,13 @@ struct UsageBreakdownTables: View {
         let formatter = DateFormatter()
         formatter.locale = Locale.current
         formatter.setLocalizedDateFormatFromTemplate("EEEEMMMd")
+        return formatter
+    }()
+
+    private static let periodWeekFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.locale = Locale.current
+        formatter.setLocalizedDateFormatFromTemplate("MMMd")
         return formatter
     }()
 }

--- a/Sources/VibeBarApp/Views/Workbench/UsageFiltersBar.swift
+++ b/Sources/VibeBarApp/Views/Workbench/UsageFiltersBar.swift
@@ -41,10 +41,10 @@ struct UsageFiltersBar: View {
             model.setSelectedTools(nil)
         } label: {
             Text("All providers")
-                .font(.system(size: density.segmentedFontSize - 1, weight: .semibold))
+                .font(.system(size: max(10, density.segmentedFontSize - 1), weight: .semibold))
                 .foregroundStyle(model.selectedTools == nil ? .primary : .secondary)
                 .padding(.horizontal, 10)
-                .frame(minHeight: 24)
+                .frame(minHeight: 28)
         }
         .buttonStyle(.plain)
         .background(chipBackground(tint: .accentColor, selected: model.selectedTools == nil))
@@ -60,18 +60,18 @@ struct UsageFiltersBar: View {
             HStack(spacing: 5) {
                 ToolBrandIconView(tool: tool, size: density.segmentedFontSize + 1)
                 Text(tool.menuTitle)
-                    .font(.system(size: density.segmentedFontSize - 1, weight: .semibold))
+                    .font(.system(size: max(10, density.segmentedFontSize - 1), weight: .semibold))
                     .lineLimit(1)
             }
             .padding(.horizontal, 9)
-            .frame(minHeight: 24)
+            .frame(minHeight: 28)
         }
         .buttonStyle(.plain)
         .background(chipBackground(tint: accent, selected: selected))
         // Unselected chips stay legible but recede — the accent is the signal
         // that a provider is in the query, so an off chip must not wear it.
-        .opacity(selected ? 1 : 0.45)
-        .saturation(selected ? 1 : 0.2)
+        .opacity(selected ? 1 : 0.70)
+        .saturation(selected ? 1 : 0.50)
         .help(tool.displayName)
         .accessibilityLabel(tool.displayName)
         .accessibilityAddTraits(selected ? [.isSelected] : [])
@@ -97,13 +97,11 @@ struct UsageFiltersBar: View {
                     model.setSelectedModels(nil)
                 } label: {
                     Label("Clear", systemImage: "xmark")
-                        .font(.system(size: max(9, density.segmentedFontSize - 1), weight: .semibold))
+                        .font(.system(size: max(10, density.segmentedFontSize - 1), weight: .semibold))
                         .foregroundStyle(.secondary)
-                        .padding(.horizontal, 9)
-                        .frame(minHeight: 28)
-                        .background(controlBackground)
+                        .frame(minHeight: 22)
                 }
-                .buttonStyle(.plain)
+                .buttonStyle(.bordered)
                 .help("Clear provider and model filters")
             }
             Spacer(minLength: 8)
@@ -134,7 +132,7 @@ struct UsageFiltersBar: View {
             menuLabel(systemImage: "calendar", title: model.rangePreset.title, detail: rangeSummary)
         }
         .menuStyle(.button)
-        .buttonStyle(.plain)
+        .buttonStyle(.bordered)
         .menuIndicator(.hidden)
         .fixedSize()
         .popover(isPresented: $showsCustomRange, arrowEdge: .bottom) {
@@ -160,7 +158,7 @@ struct UsageFiltersBar: View {
                 selection: $model.customEnd,
                 displayedComponents: [.date, .hourAndMinute]
             )
-            Text("Buckets switch from hourly to daily past a 24-hour span.")
+            Text("Choose hourly, daily, or weekly buckets from the chart toolbar.")
                 .font(.system(size: max(9, density.resetCountdownFontSize - 1)))
                 .foregroundStyle(.tertiary)
         }
@@ -186,7 +184,7 @@ struct UsageFiltersBar: View {
             menuLabel(systemImage: "cpu", title: "Models", detail: modelSummary)
         }
         .menuStyle(.button)
-        .buttonStyle(.plain)
+        .buttonStyle(.bordered)
         .menuIndicator(.hidden)
         .fixedSize()
         .accessibilityLabel("Choose which models to include")
@@ -209,7 +207,7 @@ struct UsageFiltersBar: View {
             )
         }
         .menuStyle(.button)
-        .buttonStyle(.plain)
+        .buttonStyle(.bordered)
         .menuIndicator(.hidden)
         .fixedSize()
         .accessibilityLabel("Choose how often the page re-queries")
@@ -228,30 +226,19 @@ struct UsageFiltersBar: View {
     private func menuLabel(systemImage: String, title: String, detail: String) -> some View {
         HStack(spacing: 5) {
             Image(systemName: systemImage)
-                .font(.system(size: max(8, density.segmentedFontSize - 2), weight: .semibold))
+                .font(.system(size: max(10, density.segmentedFontSize - 2), weight: .semibold))
                 .foregroundStyle(.secondary)
             Text(title.uppercased())
-                .font(.system(size: max(8, density.segmentedFontSize - 3), weight: .semibold))
+                .font(.system(size: max(10, density.segmentedFontSize - 3), weight: .semibold))
                 .foregroundStyle(.tertiary)
                 .tracking(0.4)
             Text(detail)
-                .font(.system(size: density.segmentedFontSize - 1, weight: .semibold, design: .rounded)
+                .font(.system(size: max(10, density.segmentedFontSize - 1), weight: .semibold, design: .rounded)
                     .monospacedDigit())
                 .foregroundStyle(.primary)
                 .lineLimit(1)
         }
-        .padding(.horizontal, 10)
-        .frame(minHeight: 28)
-        .background(controlBackground)
-    }
-
-    private var controlBackground: some View {
-        RoundedRectangle(cornerRadius: 8, style: .continuous)
-            .fill(Color.primary.opacity(0.045))
-            .overlay(
-                RoundedRectangle(cornerRadius: 8, style: .continuous)
-                    .stroke(Color.primary.opacity(0.09), lineWidth: 0.6)
-            )
+        .frame(minHeight: 22)
     }
 
     private func modelBinding(_ name: String) -> Binding<Bool> {

--- a/Sources/VibeBarApp/Views/Workbench/UsageStatsPage.swift
+++ b/Sources/VibeBarApp/Views/Workbench/UsageStatsPage.swift
@@ -3,34 +3,41 @@ import VibeBarCore
 
 /// The Workbench's Usage Stats page.
 ///
-/// One scrolling column, coarse to fine: what is being counted (filters),
-/// the four headline numbers, the shape of the range over time, and finally
-/// the rows behind it. Every section is a `CardShell` at the window's density,
-/// so the page reads as the same material as the popover's cards.
+/// The filter bar is a fixed command surface; only the analytical content
+/// scrolls. Keeping the active range/providers in view makes a long table
+/// remain explainable instead of losing its query context above the fold.
 struct UsageStatsPage: View {
     let density: Theme.Density
     @ObservedObject var model: UsageStatsViewModel
 
     var body: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: density.interSectionSpacing) {
-                UsageFiltersBar(density: density, model: model)
-                if model.isLedgerAvailable {
-                    UsageHeroCards(density: density, summary: model.summary)
-                    UsageCompositionCards(
-                        density: density,
-                        summary: model.summary,
-                        providers: model.providerStats
-                    )
-                    UsageTrendChartView(density: density, series: model.trend)
-                    UsageBreakdownTables(density: density, model: model)
-                } else {
-                    unavailableCard
+        VStack(spacing: 0) {
+            UsageFiltersBar(density: density, model: model)
+                .padding(.horizontal, density.popoverPaddingH)
+                .padding(.top, density.popoverPaddingV)
+                .padding(.bottom, max(8, density.popoverPaddingV / 2))
+
+            Divider().opacity(0.45)
+
+            ScrollView {
+                VStack(alignment: .leading, spacing: density.interSectionSpacing) {
+                    if model.isLedgerAvailable {
+                        UsageHeroCards(density: density, summary: model.summary)
+                        UsageCompositionCards(
+                            density: density,
+                            summary: model.summary,
+                            providers: model.providerStats
+                        )
+                        UsageTrendChartView(density: density, model: model)
+                        UsageBreakdownTables(density: density, model: model)
+                    } else {
+                        unavailableCard
+                    }
                 }
+                .padding(.horizontal, density.popoverPaddingH)
+                .padding(.vertical, density.popoverPaddingV)
+                .frame(maxWidth: .infinity, alignment: .topLeading)
             }
-            .padding(.horizontal, density.popoverPaddingH)
-            .padding(.vertical, density.popoverPaddingV)
-            .frame(maxWidth: .infinity, alignment: .topLeading)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .task { model.activate() }

--- a/Sources/VibeBarApp/Views/Workbench/UsageTrendChartView.swift
+++ b/Sources/VibeBarApp/Views/Workbench/UsageTrendChartView.swift
@@ -2,56 +2,6 @@ import Charts
 import SwiftUI
 import VibeBarCore
 
-/// The four token components a request is billed on.
-///
-/// Their hues are deliberately *not* provider accents: a stacked band here
-/// means "cache read", not "Claude", and reusing the brand palette would make
-/// the two readings fight. Four widely separated semantic-ish hues instead,
-/// kept in one table so the legend, the bands, and the tooltip agree.
-enum UsageTokenSeries: String, CaseIterable, Identifiable, Hashable {
-    case freshInput
-    case output
-    case cacheCreation
-    case cacheRead
-
-    var id: String { rawValue }
-
-    var title: String {
-        switch self {
-        case .freshInput:    "Input"
-        case .output:        "Output"
-        case .cacheCreation: "Cache write"
-        case .cacheRead:     "Cache read"
-        }
-    }
-
-    var color: Color {
-        switch self {
-        case .freshInput:    Color(red: 0.33, green: 0.55, blue: 0.95)  // blue
-        case .output:        Color(red: 0.20, green: 0.72, blue: 0.58)  // green
-        case .cacheCreation: Color(red: 0.96, green: 0.66, blue: 0.22)  // amber
-        case .cacheRead:     Color(red: 0.62, green: 0.45, blue: 0.93)  // violet
-        }
-    }
-
-    var gradient: LinearGradient {
-        LinearGradient(
-            colors: [color.opacity(0.72), color.opacity(0.20)],
-            startPoint: .top,
-            endPoint: .bottom
-        )
-    }
-
-    func value(in point: UsageTrendPoint) -> Int64 {
-        switch self {
-        case .freshInput:    point.freshInput
-        case .output:        point.output
-        case .cacheCreation: point.cacheCreation
-        case .cacheRead:     point.cacheRead
-        }
-    }
-}
-
 private enum UsageChartMetric: String, CaseIterable, Identifiable {
     case tokens
     case cost
@@ -61,30 +11,38 @@ private enum UsageChartMetric: String, CaseIterable, Identifiable {
     var systemImage: String { self == .tokens ? "sum" : "dollarsign" }
 }
 
-/// Tokens or cost over the selected range in one deliberate chart surface.
-/// The metric switch mirrors the established cost-history interaction instead
-/// of stacking two unrelated plots and asking the user to read both at once.
-///
-/// The range is drawn whole: no brush strip, no pan/zoom. `ChartTimeWindow`
-/// and `ChartBrushNavigator` earn their keep on the cost history card, whose
-/// domain is "everything Vibe Bar ever recorded"; here the domain *is* the
-/// filter, and the filter bar is already the navigation.
+/// Tokens or cost over the selected range, grouped by provider. This mirrors
+/// the Overview chart's compact navigation vocabulary while keeping the
+/// Usage filter as the single source for every card and table on the page.
 struct UsageTrendChartView: View {
     let density: Theme.Density
-    let series: UsageTrendSeries
+    @ObservedObject var model: UsageStatsViewModel
 
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var metric: UsageChartMetric = .tokens
-    @State private var hiddenSeries: Set<UsageTokenSeries> = []
+    @State private var hiddenTools: Set<ToolType> = []
     @State private var hoveredDate: Date?
+    @State private var chartWindow: ChartTimeWindow?
 
     /// Floor for the leading axis-label column on both panes. Without a shared
     /// floor the token pane ("3.40M") and the cost pane ("$12") inset their
     /// plots differently and the two x axes stop lining up.
     private static let axisLabelWidth: CGFloat = 46
     private static let tooltipWidth: CGFloat = 186
+    private static let mainMarkBudget = 1_200
+    private static let navigatorMarkBudget = 480
 
-    private var visibleSeries: [UsageTokenSeries] {
-        UsageTokenSeries.allCases.filter { !hiddenSeries.contains($0) }
+    private struct DomainKey: Equatable {
+        let bucket: UsageTrendBucket
+        let start: Date?
+        let end: Date?
+        let providers: [ToolType]
+    }
+
+    private var series: UsageTrendSeries { model.trend }
+
+    private var visibleProviders: [UsageProviderTrendSeries] {
+        series.providerSeries.filter { !hiddenTools.contains($0.tool) }
     }
 
     private var hasData: Bool {
@@ -98,7 +56,37 @@ struct UsageTrendChartView: View {
             let now = Date()
             return now.addingTimeInterval(-3_600)...now
         }
-        return first...max(last, first.addingTimeInterval(1))
+        return first...max(bucketEnd(after: last), first.addingTimeInterval(1))
+    }
+
+    private var visibleDomain: ClosedRange<Date> {
+        resolvedChartWindow.visibleRange
+    }
+
+    private var domainKey: DomainKey {
+        DomainKey(
+            bucket: series.bucket,
+            start: series.points.first?.bucketStart,
+            end: series.points.last?.bucketStart,
+            providers: series.providerSeries.map(\.tool)
+        )
+    }
+
+    private var resolvedChartWindow: ChartTimeWindow {
+        chartWindow ?? ChartTimeWindow(
+            domainStart: domain.lowerBound,
+            domainEnd: domain.upperBound,
+            minimumSpan: minimumChartSpan,
+            visibleStart: domain.lowerBound,
+            visibleEnd: domain.upperBound
+        )
+    }
+
+    private var chartWindowBinding: Binding<ChartTimeWindow> {
+        Binding(
+            get: { resolvedChartWindow },
+            set: { chartWindow = $0 }
+        )
     }
 
     private var hoveredPoint: UsageTrendPoint? {
@@ -111,8 +99,26 @@ struct UsageTrendChartView: View {
             header
             if hasData {
                 if metric == .tokens { tokenPane } else { costPane }
+                ChartBrushNavigator(
+                    window: chartWindowBinding,
+                    accent: .accentColor,
+                    height: density.chartBrushHeight,
+                    accessibilityDescription: "Usage chart range navigator"
+                ) { geometry in
+                    miniProviderPaths(in: geometry)
+                }
+                chartScopeRow
             } else {
                 emptyState
+            }
+        }
+        .onChange(of: domainKey) { _, newValue in
+            chartWindow = nil
+            hoveredDate = nil
+            let available = Set(newValue.providers)
+            hiddenTools.formIntersection(available)
+            if !available.isEmpty, hiddenTools.count == available.count {
+                hiddenTools.removeAll()
             }
         }
     }
@@ -120,19 +126,36 @@ struct UsageTrendChartView: View {
     // MARK: - Header
 
     private var header: some View {
-        HStack(alignment: .center, spacing: 10) {
-            VStack(alignment: .leading, spacing: 2) {
-                Text("USAGE OVER TIME")
-                    .font(.system(size: max(8, density.subtitleFontSize - 2), weight: .semibold))
-                    .foregroundStyle(.tertiary)
-                    .tracking(0.4)
-                Text(series.bucket == .hour ? "Hourly buckets" : "Local calendar days")
-                    .font(.system(size: max(9, density.resetCountdownFontSize - 1)))
-                    .foregroundStyle(.secondary)
+        VStack(alignment: .leading, spacing: 7) {
+            HStack(alignment: .center, spacing: 10) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("USAGE OVER TIME")
+                        .font(.system(size: max(8, density.subtitleFontSize - 2), weight: .semibold))
+                        .foregroundStyle(.tertiary)
+                        .tracking(0.4)
+                    Text(bucketSubtitle)
+                        .font(.system(size: max(9, density.resetCountdownFontSize - 1)))
+                        .foregroundStyle(.secondary)
+                }
+                metricSelector
+                granularitySelector
+                Spacer(minLength: 8)
+                windowNavigator
             }
-            metricSelector
-            Spacer(minLength: 8)
-            if metric == .tokens { legend }
+            if !series.providerSeries.isEmpty {
+                ScrollView(.horizontal) {
+                    legend
+                }
+                .scrollIndicators(.never)
+            }
+        }
+    }
+
+    private var bucketSubtitle: String {
+        switch series.bucket {
+        case .hour: "Hourly buckets"
+        case .day: "Local calendar days"
+        case .week: "Local calendar weeks"
         }
     }
 
@@ -141,7 +164,7 @@ struct UsageTrendChartView: View {
             ForEach(UsageChartMetric.allCases) { value in
                 let selected = metric == value
                 Button {
-                    withAnimation(.easeOut(duration: 0.16)) { metric = value }
+                    withAnimation(reduceMotion ? nil : .easeOut(duration: 0.16)) { metric = value }
                 } label: {
                     Label(value.title, systemImage: value.systemImage)
                         .font(.system(size: max(9, density.segmentedFontSize - 1), weight: .semibold))
@@ -173,18 +196,61 @@ struct UsageTrendChartView: View {
         )
     }
 
+    private var granularitySelector: some View {
+        Menu {
+            Picker("Granularity", selection: $model.trendGranularity) {
+                ForEach(UsageTrendGranularity.allCases, id: \.self) { value in
+                    Text(granularityTitle(value)).tag(value)
+                        .disabled(!model.isTrendGranularityAvailable(value))
+                }
+            }
+        } label: {
+            Label(granularityTitle(model.trendGranularity), systemImage: "chart.bar.xaxis")
+                .font(.system(size: max(10, density.segmentedFontSize - 1), weight: .semibold))
+                .frame(minHeight: 22)
+        }
+        .menuStyle(.button)
+        .menuIndicator(.hidden)
+        .buttonStyle(.bordered)
+        .controlSize(.small)
+        .accessibilityLabel("Choose chart granularity")
+    }
+
+    private var windowNavigator: some View {
+        ControlGroup {
+            Button { model.navigateWindow(by: -1) } label: {
+                Image(systemName: "chevron.left")
+            }
+            .help("Previous window")
+            Button { model.navigateWindow(by: 1) } label: {
+                Image(systemName: "chevron.right")
+            }
+            .disabled(!model.canNavigateForward)
+            .help("Next window")
+            Button { model.resetWindow() } label: {
+                Label("Now", systemImage: "arrow.clockwise")
+                    .labelStyle(.titleAndIcon)
+            }
+            .disabled(!model.canNavigateForward)
+            .help("Return to current window")
+        }
+        .font(.system(size: 10, weight: .semibold))
+        .controlSize(.small)
+    }
+
     private var legend: some View {
         HStack(spacing: 6) {
-            ForEach(UsageTokenSeries.allCases) { kind in
-                let visible = !hiddenSeries.contains(kind)
+            ForEach(series.providerSeries) { provider in
+                let visible = !hiddenTools.contains(provider.tool)
+                let color = Theme.providerAccent(for: provider.tool)
                 Button {
-                    toggle(kind)
+                    toggle(provider.tool)
                 } label: {
                     HStack(spacing: 4) {
                         Capsule()
-                            .fill(kind.color)
+                            .fill(color)
                             .frame(width: 10, height: 4)
-                        Text(kind.title)
+                        Text(provider.tool.menuTitle)
                             .font(.system(size: max(8, density.segmentedFontSize - 2), weight: .semibold))
                     }
                     .padding(.horizontal, 7)
@@ -192,23 +258,23 @@ struct UsageTrendChartView: View {
                 }
                 .buttonStyle(.plain)
                 .background(
-                    Capsule().fill(kind.color.opacity(visible ? 0.14 : 0.04))
+                    Capsule().fill(color.opacity(visible ? 0.14 : 0.04))
                 )
-                .opacity(visible ? 1 : 0.42)
-                .saturation(visible ? 1 : 0.15)
-                .help(visible ? "Hide \(kind.title)" : "Show \(kind.title)")
+                .opacity(visible ? 1 : 0.68)
+                .saturation(visible ? 1 : 0.45)
+                .help(visible ? "Hide \(provider.tool.displayName)" : "Show \(provider.tool.displayName)")
                 .accessibilityAddTraits(visible ? [.isSelected] : [])
             }
         }
     }
 
-    private func toggle(_ kind: UsageTokenSeries) {
-        if hiddenSeries.contains(kind) {
-            hiddenSeries.remove(kind)
-        } else if hiddenSeries.count < UsageTokenSeries.allCases.count - 1 {
-            // Never let the last band go: an empty token pane reads as "no
-            // data" rather than as "you turned everything off".
-            hiddenSeries.insert(kind)
+    private func toggle(_ tool: ToolType) {
+        if hiddenTools.contains(tool) {
+            hiddenTools.remove(tool)
+        } else if hiddenTools.count < series.providerSeries.count - 1 {
+            // Never let the last provider go: an empty chart reads as missing
+            // data rather than as "you turned every series off".
+            hiddenTools.insert(tool)
         }
     }
 
@@ -216,15 +282,31 @@ struct UsageTrendChartView: View {
 
     private var tokenPane: some View {
         Chart {
-            ForEach(visibleSeries) { kind in
-                ForEach(series.points, id: \.bucketStart) { point in
+            ForEach(visibleProviders) { provider in
+                let color = Theme.providerAccent(for: provider.tool)
+                ForEach(renderedPoints(for: provider), id: \.bucketStart) { point in
                     AreaMark(
                         x: .value("Time", point.bucketStart),
-                        y: .value("Tokens", kind.value(in: point)),
-                        series: .value("Series", kind.title),
-                        stacking: .standard
+                        y: .value("Tokens", point.totalTokens),
+                        series: .value("Provider", provider.tool.rawValue)
                     )
-                    .foregroundStyle(kind.gradient)
+                    .foregroundStyle(areaGradient(color))
+                    LineMark(
+                        x: .value("Time", point.bucketStart),
+                        y: .value("Tokens", point.totalTokens),
+                        series: .value("Provider", provider.tool.rawValue)
+                    )
+                    .interpolationMethod(.linear)
+                    .foregroundStyle(color)
+                    .lineStyle(StrokeStyle(lineWidth: 1.8, lineCap: .round, lineJoin: .round))
+                }
+                if let hoveredDate, let point = providerPoint(for: provider, at: hoveredDate) {
+                    PointMark(
+                        x: .value("Time", point.bucketStart),
+                        y: .value("Tokens", point.totalTokens)
+                    )
+                    .foregroundStyle(color)
+                    .symbolSize(34)
                 }
             }
             if let hoveredDate {
@@ -234,7 +316,7 @@ struct UsageTrendChartView: View {
             }
         }
         .chartLegend(.hidden)
-        .chartXScale(domain: domain)
+        .chartXScale(domain: visibleDomain)
         .chartPlotStyle { $0.clipped() }
         .chartYAxis {
             AxisMarks(position: .leading, values: .automatic(desiredCount: 3)) { value in
@@ -251,6 +333,8 @@ struct UsageTrendChartView: View {
         .chartXAxis {
             AxisMarks(values: .automatic(desiredCount: 5)) { _ in
                 AxisGridLine().foregroundStyle(.secondary.opacity(0.10))
+                AxisValueLabel(format: axisFormat)
+                    .font(.system(size: 9))
             }
         }
         .chartOverlay { proxy in
@@ -262,30 +346,39 @@ struct UsageTrendChartView: View {
             }
         }
         .frame(height: density.overviewCostChartHeight)
+        .accessibilityLabel("Token usage over time")
+        .accessibilityValue(chartAccessibilityValue)
     }
 
     private var costPane: some View {
         Chart {
-            ForEach(series.points, id: \.bucketStart) { point in
-                AreaMark(
-                    x: .value("Time", point.bucketStart),
-                    y: .value("Cost", costUSD(point))
-                )
-                .interpolationMethod(.monotone)
-                .foregroundStyle(
-                    LinearGradient(
-                        colors: [Color.accentColor.opacity(0.20), Color.accentColor.opacity(0.02)],
-                        startPoint: .top,
-                        endPoint: .bottom
+            ForEach(visibleProviders) { provider in
+                let color = Theme.providerAccent(for: provider.tool)
+                ForEach(renderedPoints(for: provider), id: \.bucketStart) { point in
+                    AreaMark(
+                        x: .value("Time", point.bucketStart),
+                        y: .value("Cost", costUSD(point)),
+                        series: .value("Provider", provider.tool.rawValue)
                     )
-                )
-                LineMark(
-                    x: .value("Time", point.bucketStart),
-                    y: .value("Cost", costUSD(point))
-                )
-                .interpolationMethod(.monotone)
-                .foregroundStyle(Color.accentColor)
-                .lineStyle(StrokeStyle(lineWidth: 1.8, lineCap: .round, lineJoin: .round))
+                    .interpolationMethod(.linear)
+                    .foregroundStyle(areaGradient(color))
+                    LineMark(
+                        x: .value("Time", point.bucketStart),
+                        y: .value("Cost", costUSD(point)),
+                        series: .value("Provider", provider.tool.rawValue)
+                    )
+                    .interpolationMethod(.linear)
+                    .foregroundStyle(color)
+                    .lineStyle(StrokeStyle(lineWidth: 1.8, lineCap: .round, lineJoin: .round))
+                }
+                if let hoveredDate, let point = providerPoint(for: provider, at: hoveredDate) {
+                    PointMark(
+                        x: .value("Time", point.bucketStart),
+                        y: .value("Cost", costUSD(point))
+                    )
+                    .foregroundStyle(color)
+                    .symbolSize(34)
+                }
             }
             if let hoveredDate {
                 RuleMark(x: .value("Time", hoveredDate))
@@ -294,7 +387,7 @@ struct UsageTrendChartView: View {
             }
         }
         .chartLegend(.hidden)
-        .chartXScale(domain: domain)
+        .chartXScale(domain: visibleDomain)
         .chartPlotStyle { $0.clipped() }
         .chartYAxis {
             AxisMarks(position: .leading, values: .automatic(desiredCount: 2)) { value in
@@ -324,6 +417,8 @@ struct UsageTrendChartView: View {
             }
         }
         .frame(height: density.overviewCostChartHeight)
+        .accessibilityLabel("Cost over time")
+        .accessibilityValue(chartAccessibilityValue)
     }
 
     private var emptyState: some View {
@@ -374,6 +469,7 @@ struct UsageTrendChartView: View {
 
     private func nearestBucket(to date: Date) -> Date? {
         series.points
+            .filter { visibleDomain.contains($0.bucketStart) }
             .min { lhs, rhs in
                 abs(lhs.bucketStart.timeIntervalSince(date))
                     < abs(rhs.bucketStart.timeIntervalSince(date))
@@ -387,20 +483,24 @@ struct UsageTrendChartView: View {
                 Text(tooltipDate(point.bucketStart))
                     .font(.system(size: 10, weight: .semibold))
                 Spacer(minLength: 4)
-                Text(UsageFormatting.formatMicroUSD(point.costMicros))
+                Text(UsageFormatting.formatMicroUSD(visibleCostMicros(at: point.bucketStart)))
                     .font(.system(size: 10, weight: .semibold, design: .rounded).monospacedDigit())
             }
             Divider().opacity(0.3)
-            ForEach(UsageTokenSeries.allCases) { kind in
+            ForEach(visibleProviders) { provider in
+                let providerPoint = providerPoint(for: provider, at: point.bucketStart)
                 HStack(spacing: 6) {
                     Capsule()
-                        .fill(kind.color)
+                        .fill(Theme.providerAccent(for: provider.tool))
                         .frame(width: 8, height: 4)
-                    Text(kind.title)
+                    Text(provider.tool.menuTitle)
                         .font(.system(size: 9))
-                        .foregroundStyle(hiddenSeries.contains(kind) ? .tertiary : .secondary)
+                        .foregroundStyle(.secondary)
                     Spacer(minLength: 4)
-                    Text(UsageFormatting.compactTokens(kind.value(in: point)))
+                    Text(metric == .tokens
+                        ? UsageFormatting.compactTokens(providerPoint?.totalTokens ?? 0)
+                        : UsageFormatting.formatMicroUSD(providerPoint?.costMicros ?? 0)
+                    )
                         .font(.system(size: 9, design: .rounded).monospacedDigit())
                 }
             }
@@ -413,7 +513,7 @@ struct UsageTrendChartView: View {
     }
 
     private func costPill(_ point: UsageTrendPoint) -> some View {
-        Text(UsageFormatting.formatMicroUSD(point.costMicros))
+        Text(UsageFormatting.formatMicroUSD(visibleCostMicros(at: point.bucketStart)))
             .font(.system(size: 10, weight: .semibold, design: .rounded).monospacedDigit())
             .padding(.horizontal, 9)
             .frame(minHeight: 20)
@@ -454,10 +554,137 @@ struct UsageTrendChartView: View {
         Double(point.costMicros) / 1_000_000
     }
 
+    private func providerPoint(
+        for provider: UsageProviderTrendSeries,
+        at date: Date
+    ) -> UsageTrendPoint? {
+        provider.points.first { $0.bucketStart == date }
+    }
+
+    private func visibleCostMicros(at date: Date) -> Int64 {
+        visibleProviders.reduce(Int64(0)) { total, provider in
+            total + (providerPoint(for: provider, at: date)?.costMicros ?? 0)
+        }
+    }
+
+    private func renderedPoints(for provider: UsageProviderTrendSeries) -> [UsageTrendPoint] {
+        let points = provider.points.filter { visibleDomain.contains($0.bucketStart) }
+        let perProvider = max(2, Self.mainMarkBudget / max(1, visibleProviders.count))
+        return ChartSeriesThinning.strided(points, limit: perProvider)
+    }
+
+    private func navigatorPoints(for provider: UsageProviderTrendSeries) -> [UsageTrendPoint] {
+        let perProvider = max(2, Self.navigatorMarkBudget / max(1, visibleProviders.count))
+        return ChartSeriesThinning.strided(provider.points, limit: perProvider)
+    }
+
+    private func areaGradient(_ color: Color) -> LinearGradient {
+        LinearGradient(
+            colors: [color.opacity(0.26), color.opacity(0.025)],
+            startPoint: .top,
+            endPoint: .bottom
+        )
+    }
+
+    private var minimumChartSpan: TimeInterval {
+        switch series.bucket {
+        case .hour: 2 * 3_600
+        case .day: 2 * 86_400
+        case .week: 2 * 7 * 86_400
+        }
+    }
+
+    private func bucketEnd(after start: Date) -> Date {
+        let calendar = Calendar.current
+        switch series.bucket {
+        case .hour:
+            return calendar.date(byAdding: .hour, value: 1, to: start)
+                ?? start.addingTimeInterval(3_600)
+        case .day:
+            return calendar.date(byAdding: .day, value: 1, to: start)
+                ?? start.addingTimeInterval(86_400)
+        case .week:
+            return calendar.date(byAdding: .weekOfYear, value: 1, to: start)
+                ?? start.addingTimeInterval(7 * 86_400)
+        }
+    }
+
+    private func miniProviderPaths(in geometry: ChartBrushGeometry) -> some View {
+        let maximum = navigationMaximum
+        return ZStack {
+            ForEach(visibleProviders) { provider in
+                Path { path in
+                    var hasPoint = false
+                    for point in navigatorPoints(for: provider) {
+                        let value = metric == .tokens
+                            ? Double(point.totalTokens)
+                            : Double(point.costMicros)
+                        let position = CGPoint(
+                            x: geometry.x(for: point.bucketStart),
+                            y: geometry.y(forFraction: maximum > 0 ? value / maximum : 0)
+                        )
+                        if hasPoint { path.addLine(to: position) } else { path.move(to: position) }
+                        hasPoint = true
+                    }
+                }
+                .stroke(
+                    Theme.providerAccent(for: provider.tool).opacity(0.78),
+                    style: StrokeStyle(lineWidth: 1, lineCap: .round, lineJoin: .round)
+                )
+            }
+        }
+    }
+
+    private var navigationMaximum: Double {
+        visibleProviders
+            .flatMap(\.points)
+            .map { metric == .tokens ? Double($0.totalTokens) : Double($0.costMicros) }
+            .max() ?? 0
+    }
+
+    private var chartScopeRow: some View {
+        HStack(spacing: 8) {
+            Text("Drag the navigator handles to focus this chart; filters and tables keep the full window.")
+                .font(.system(size: max(9, density.resetCountdownFontSize - 1)))
+                .foregroundStyle(.tertiary)
+                .lineLimit(1)
+            Spacer(minLength: 8)
+            if !resolvedChartWindow.coversDomain {
+                Button("Fit") {
+                    chartWindow = nil
+                }
+                .buttonStyle(.borderless)
+                .font(.system(size: 10, weight: .semibold))
+                .help("Show the full selected window")
+            }
+        }
+    }
+
+    private var chartAccessibilityValue: String {
+        let visiblePoints = visibleProviders
+            .flatMap(\.points)
+            .filter { visibleDomain.contains($0.bucketStart) }
+        let totalTokens = visiblePoints.reduce(Int64(0)) { $0 + $1.totalTokens }
+        let totalCost = visiblePoints.reduce(Int64(0)) { $0 + $1.costMicros }
+        return "\(visibleProviders.count) providers, \(UsageFormatting.compactTokens(totalTokens)) tokens, "
+            + "\(UsageFormatting.formatMicroUSD(totalCost))"
+    }
+
+    private func granularityTitle(_ value: UsageTrendGranularity) -> String {
+        switch value {
+        case .automatic: "Auto"
+        case .hour: "Hourly"
+        case .day: "Daily"
+        case .week: "Weekly"
+        }
+    }
+
     private var axisFormat: Date.FormatStyle {
-        series.bucket == .hour
-            ? .dateTime.hour()
-            : .dateTime.month(.abbreviated).day()
+        switch series.bucket {
+        case .hour: .dateTime.hour()
+        case .day: .dateTime.month(.abbreviated).day()
+        case .week: .dateTime.month(.abbreviated).day()
+        }
     }
 
     private func tooltipDate(_ date: Date) -> String {

--- a/Sources/VibeBarApp/Views/Workbench/UsageTrendChartView.swift
+++ b/Sources/VibeBarApp/Views/Workbench/UsageTrendChartView.swift
@@ -570,12 +570,12 @@ struct UsageTrendChartView: View {
     private func renderedPoints(for provider: UsageProviderTrendSeries) -> [UsageTrendPoint] {
         let points = provider.points.filter { visibleDomain.contains($0.bucketStart) }
         let perProvider = max(2, Self.mainMarkBudget / max(1, visibleProviders.count))
-        return ChartSeriesThinning.strided(points, limit: perProvider)
+        return UsageTrendSeriesDownsampling.points(points, limit: perProvider)
     }
 
     private func navigatorPoints(for provider: UsageProviderTrendSeries) -> [UsageTrendPoint] {
         let perProvider = max(2, Self.navigatorMarkBudget / max(1, visibleProviders.count))
-        return ChartSeriesThinning.strided(provider.points, limit: perProvider)
+        return UsageTrendSeriesDownsampling.points(provider.points, limit: perProvider)
     }
 
     private func areaGradient(_ color: Color) -> LinearGradient {

--- a/Sources/VibeBarApp/Views/Workbench/WorkbenchRootView.swift
+++ b/Sources/VibeBarApp/Views/Workbench/WorkbenchRootView.swift
@@ -49,16 +49,21 @@ struct WorkbenchRootView: View {
         let density = Theme.overviewDensity(for: settingsStore.settings.popoverDensity)
         NavigationSplitView {
             List(selection: $selection) {
-                ForEach(WorkbenchPage.allCases) { page in
-                    Label(page.title, systemImage: page.systemImage)
-                        .tag(page)
+                Section("WORKBENCH") {
+                    ForEach(WorkbenchPage.allCases) { page in
+                        Label(page.title, systemImage: page.systemImage)
+                            .tag(page)
+                    }
                 }
             }
+            .listStyle(.sidebar)
+            .navigationTitle("Workbench")
             .navigationSplitViewColumnWidth(min: 188, ideal: 208, max: 268)
         } detail: {
             detail(for: page, density: density)
                 .navigationTitle(page.title)
         }
+        .navigationSplitViewStyle(.balanced)
         .onAppear {
             guard selection == nil else { return }
             selection = initialPage ?? WorkbenchPage(rawValue: storedPage) ?? .usageStats

--- a/Sources/VibeBarCore/Models/ChartSeriesPlanning.swift
+++ b/Sources/VibeBarCore/Models/ChartSeriesPlanning.swift
@@ -31,6 +31,75 @@ public enum ChartSeriesThinning {
     }
 }
 
+/// Bounded chart projection for usage buckets.
+///
+/// Generic striding is appropriate for sampled lines such as quota history,
+/// but it can erase a usage spike entirely. This projection draws only exact
+/// source buckets. Once the budget reaches two marks, endpoints win; the
+/// token and cost peaks follow in that order as the third and fourth marks.
+/// Any remaining time span then contributes its most significant exact point.
+/// Keeping every drawn point unmodified is important because the Workbench
+/// hover reads the original bucket at the same timestamp.
+public enum UsageTrendSeriesDownsampling {
+    public static func points(
+        _ input: [UsageTrendPoint],
+        limit: Int
+    ) -> [UsageTrendPoint] {
+        guard limit > 0, input.count > limit else { return input }
+        guard limit > 1 else {
+            return [input[peakIndex(in: input, by: \.totalTokens)]]
+        }
+
+        var selected: Set<Int> = [0, input.count - 1]
+        let tokenPeak = peakIndex(in: input, by: \.totalTokens)
+        let costPeak = peakIndex(in: input, by: \.costMicros)
+        for index in [tokenPeak, costPeak] where selected.count < limit {
+            selected.insert(index)
+        }
+
+        // Spend the leftover budget across contiguous spans so a busy period
+        // cannot monopolize the whole path. The score is normalized by each
+        // metric's global peak, making a cost spike visible even when its
+        // token count is modest (and vice versa).
+        let extraSlots = limit - selected.count
+        if extraSlots > 0 {
+            let maximumTokens = max(1, input[tokenPeak].totalTokens)
+            let maximumCost = max(1, input[costPeak].costMicros)
+            for slot in 0..<extraSlots {
+                let lower = slot * input.count / extraSlots
+                let upper = (slot + 1) * input.count / extraSlots
+                let candidate = (lower..<upper)
+                    .filter { !selected.contains($0) }
+                    .max { lhs, rhs in
+                        significance(input[lhs], tokens: maximumTokens, cost: maximumCost)
+                            < significance(input[rhs], tokens: maximumTokens, cost: maximumCost)
+                    }
+                if let candidate { selected.insert(candidate) }
+            }
+        }
+        return selected.sorted().map { input[$0] }
+    }
+
+    private static func peakIndex(
+        in points: [UsageTrendPoint],
+        by value: (UsageTrendPoint) -> Int64 = { $0.totalTokens }
+    ) -> Int {
+        points.indices.max { lhs, rhs in
+            value(points[lhs]) == value(points[rhs])
+                ? lhs > rhs
+                : value(points[lhs]) < value(points[rhs])
+        }!
+    }
+
+    private static func significance(
+        _ point: UsageTrendPoint,
+        tokens: Int64,
+        cost: Int64
+    ) -> Double {
+        Double(point.totalTokens) / Double(tokens) + Double(point.costMicros) / Double(cost)
+    }
+}
+
 /// Splitting one curve's mark budget across the segments it is drawn in.
 ///
 /// A quota history curve is not one array but a run of segments — one per

--- a/Sources/VibeBarCore/Models/UsageQueryModels.swift
+++ b/Sources/VibeBarCore/Models/UsageQueryModels.swift
@@ -33,12 +33,35 @@ public struct UsageQueryFilter: Sendable, Equatable {
 public enum UsageTrendBucket: String, Sendable, Equatable, CaseIterable, Codable {
     case hour
     case day
+    case week
 
     /// A day of history or less is drawn per hour; anything wider is drawn
-    /// per local calendar day. Kept as a static rule rather than a UI
-    /// decision so the ledger, the chart, and the tests all agree.
+    /// per local calendar day. Wider windows collapse to local calendar
+    /// weeks, keeping the automatic chart legible without making a UI-only
+    /// decision that disagrees with the ledger.
     public static func recommended(for range: DateInterval) -> UsageTrendBucket {
-        range.duration <= 24 * 60 * 60 ? .hour : .day
+        if range.duration <= 24 * 60 * 60 { return .hour }
+        if range.duration <= 45 * 24 * 60 * 60 { return .day }
+        return .week
+    }
+}
+
+/// The chart control's intent. `auto` resolves through the same Core policy
+/// as callers that do not specify a bucket, so changing it always changes the
+/// underlying query rather than merely relabelling an already-built series.
+public enum UsageTrendGranularity: String, Sendable, Equatable, CaseIterable, Codable {
+    case automatic
+    case hour
+    case day
+    case week
+
+    public func resolved(for range: DateInterval) -> UsageTrendBucket {
+        switch self {
+        case .automatic: .recommended(for: range)
+        case .hour: .hour
+        case .day: .day
+        case .week: .week
+        }
     }
 }
 
@@ -140,16 +163,37 @@ public struct UsageTrendPoint: Sendable, Equatable, Identifiable {
     }
 }
 
+/// One provider's zero-filled projection of a trend. It deliberately shares
+/// the parent series' buckets, which keeps legend, lines, hover selection and
+/// totals on one semantic source of truth.
+public struct UsageProviderTrendSeries: Sendable, Equatable, Identifiable {
+    public let tool: ToolType
+    public let points: [UsageTrendPoint]
+
+    public var id: ToolType { tool }
+
+    public init(tool: ToolType, points: [UsageTrendPoint]) {
+        self.tool = tool
+        self.points = points
+    }
+}
+
 /// Zero-filled series: every bucket between the filter's `start` and `end`
 /// is present, including the empty ones, so a chart never has to invent
 /// gaps.
 public struct UsageTrendSeries: Sendable, Equatable {
     public let bucket: UsageTrendBucket
     public let points: [UsageTrendPoint]
+    public let providerSeries: [UsageProviderTrendSeries]
 
-    public init(bucket: UsageTrendBucket, points: [UsageTrendPoint]) {
+    public init(
+        bucket: UsageTrendBucket,
+        points: [UsageTrendPoint],
+        providerSeries: [UsageProviderTrendSeries] = []
+    ) {
         self.bucket = bucket
         self.points = points
+        self.providerSeries = providerSeries
     }
 }
 

--- a/Sources/VibeBarCore/Services/UsageEventLedger.swift
+++ b/Sources/VibeBarCore/Services/UsageEventLedger.swift
@@ -623,14 +623,17 @@ public actor UsageEventLedger: CostUsageEventSink {
     /// Zero-filled series across the filter's range.
     ///
     /// Hourly buckets read request-level rows only — daily rollups have no
-    /// sub-day resolution to give back — which is why the recommended
-    /// bucket is `.hour` only for ranges of a day or less, well inside the
-    /// detail window.
+    /// sub-day resolution to give back. An explicitly requested hourly range
+    /// can nevertheless cross a tool's detail floor after retention has run,
+    /// so resolve it against the floors actually recorded in this ledger. A
+    /// day series is preferable to an apparently valid all-zero hourly chart
+    /// that disagrees with the summary beside it.
     public func trend(
         _ filter: UsageQueryFilter,
         bucket: UsageTrendBucket? = nil
     ) throws -> UsageTrendSeries {
-        let resolved = bucket ?? UsageTrendBucket.recommended(for: filter.range)
+        let requested = bucket ?? UsageTrendBucket.recommended(for: filter.range)
+        let resolved = try resolvedTrendBucket(for: filter, requested: requested)
         let starts = bucketStarts(for: filter.range, bucket: resolved)
         var totals: [Date: Accumulator] = [:]
         var providerTotals: [ToolType: [Date: Accumulator]] = [:]
@@ -734,6 +737,45 @@ public actor UsageEventLedger: CostUsageEventSink {
             }
             .sorted { $0.tool.rawValue < $1.tool.rawValue }
         return UsageTrendSeries(bucket: resolved, points: points, providerSeries: providers)
+    }
+
+    /// The finest trend bucket this ledger can draw honestly for `filter`.
+    ///
+    /// A floor is the last local day folded into `usage_daily_rollups`; detail
+    /// starts on the following midnight. A range touching that folded day has
+    /// no hour-level evidence, even if it has only 24 buckets and even if a
+    /// different selected tool has newer detail. Falling back for the whole
+    /// series keeps the stacked provider chart and its summary on the same
+    /// data contract.
+    private func resolvedTrendBucket(
+        for filter: UsageQueryFilter,
+        requested: UsageTrendBucket
+    ) throws -> UsageTrendBucket {
+        guard requested == .hour else { return requested }
+
+        let tools: [ToolType]
+        if let filteredTools = filter.tools {
+            tools = filteredTools
+        } else {
+            tools = try ingestedTools()
+        }
+        for tool in tools {
+            guard let floor = try detailFloorDay(for: tool),
+                  let floorDay = dayFormatter.date(from: floor),
+                  let firstDetailDay = calendar.date(byAdding: .day, value: 1, to: floorDay)
+            else { continue }
+            if filter.range.start < firstDetailDay {
+                return .day
+            }
+        }
+        return .hour
+    }
+
+    /// Whether every selected provider still has request-level evidence for
+    /// every hour in `filter`. The Workbench uses this to keep the Hourly
+    /// picker synchronized with the defensive fallback in `trend`.
+    public func supportsHourlyTrend(_ filter: UsageQueryFilter) throws -> Bool {
+        try resolvedTrendBucket(for: filter, requested: .hour) == .hour
     }
 
     /// One page of request-level rows, newest first.

--- a/Sources/VibeBarCore/Services/UsageEventLedger.swift
+++ b/Sources/VibeBarCore/Services/UsageEventLedger.swift
@@ -633,13 +633,19 @@ public actor UsageEventLedger: CostUsageEventSink {
         let resolved = bucket ?? UsageTrendBucket.recommended(for: filter.range)
         let starts = bucketStarts(for: filter.range, bucket: resolved)
         var totals: [Date: Accumulator] = [:]
+        var providerTotals: [ToolType: [Date: Accumulator]] = [:]
+
+        func add(_ statement: OpaquePointer, tool: ToolType, key: Date, offset: Int32) {
+            totals[key, default: .zero].add(statement, offset: offset)
+            providerTotals[tool, default: [:]][key, default: .zero].add(statement, offset: offset)
+        }
 
         switch resolved {
         case .hour:
             let detail = detailPredicate(filter)
             let statement = try prepare(
                 """
-                SELECT ts, fresh_input, output, cache_read, cache_creation,
+                SELECT ts, tool, fresh_input, output, cache_read, cache_creation,
                        COALESCE(cost_micros, 0)
                   FROM usage_events WHERE \(detail.sql)
                 """
@@ -648,43 +654,52 @@ public actor UsageEventLedger: CostUsageEventSink {
             bindAll(detail.bindings, to: statement)
             while sqlite3_step(statement) == SQLITE_ROW {
                 let date = Date(timeIntervalSince1970: TimeInterval(sqlite3_column_int64(statement, 0)))
-                guard let key = calendar.dateInterval(of: .hour, for: date)?.start else { continue }
-                totals[key, default: .zero].add(statement, offset: 1)
+                guard let key = calendar.dateInterval(of: .hour, for: date)?.start,
+                      let rawTool = columnText(statement, 1),
+                      let tool = ToolType(rawValue: rawTool)
+                else { continue }
+                add(statement, tool: tool, key: key, offset: 2)
             }
-        case .day:
+        case .day, .week:
             let detail = detailPredicate(filter)
             let detailStatement = try prepare(
                 """
-                SELECT day, COALESCE(SUM(fresh_input), 0), COALESCE(SUM(output), 0),
+                SELECT day, tool, COALESCE(SUM(fresh_input), 0), COALESCE(SUM(output), 0),
                        COALESCE(SUM(cache_read), 0), COALESCE(SUM(cache_creation), 0),
                        COALESCE(SUM(cost_micros), 0)
-                  FROM usage_events WHERE \(detail.sql) GROUP BY day
+                  FROM usage_events WHERE \(detail.sql) GROUP BY day, tool
                 """
             )
             defer { sqlite3_finalize(detailStatement) }
             bindAll(detail.bindings, to: detailStatement)
             while sqlite3_step(detailStatement) == SQLITE_ROW {
                 guard let raw = columnText(detailStatement, 0),
-                      let key = dayFormatter.date(from: raw)
+                      let day = dayFormatter.date(from: raw),
+                      let key = bucketStart(for: day, bucket: resolved),
+                      let rawTool = columnText(detailStatement, 1),
+                      let tool = ToolType(rawValue: rawTool)
                 else { continue }
-                totals[key, default: .zero].add(detailStatement, offset: 1)
+                add(detailStatement, tool: tool, key: key, offset: 2)
             }
             if let rollup = rollupPredicate(filter) {
                 let statement = try prepare(
                     """
-                    SELECT day, COALESCE(SUM(fresh_input), 0), COALESCE(SUM(output), 0),
+                    SELECT day, tool, COALESCE(SUM(fresh_input), 0), COALESCE(SUM(output), 0),
                            COALESCE(SUM(cache_read), 0), COALESCE(SUM(cache_creation), 0),
                            COALESCE(SUM(cost_micros), 0)
-                      FROM usage_daily_rollups WHERE \(rollup.sql) GROUP BY day
+                      FROM usage_daily_rollups WHERE \(rollup.sql) GROUP BY day, tool
                     """
                 )
                 defer { sqlite3_finalize(statement) }
                 bindAll(rollup.bindings, to: statement)
                 while sqlite3_step(statement) == SQLITE_ROW {
                     guard let raw = columnText(statement, 0),
-                          let key = dayFormatter.date(from: raw)
+                          let day = dayFormatter.date(from: raw),
+                          let key = bucketStart(for: day, bucket: resolved),
+                          let rawTool = columnText(statement, 1),
+                          let tool = ToolType(rawValue: rawTool)
                     else { continue }
-                    totals[key, default: .zero].add(statement, offset: 1)
+                    add(statement, tool: tool, key: key, offset: 2)
                 }
             }
         }
@@ -700,7 +715,25 @@ public actor UsageEventLedger: CostUsageEventSink {
                 costMicros: value.cost
             )
         }
-        return UsageTrendSeries(bucket: resolved, points: points)
+        let providers = providerTotals
+            .map { tool, values in
+                UsageProviderTrendSeries(
+                    tool: tool,
+                    points: starts.map { start in
+                        let value = values[start] ?? .zero
+                        return UsageTrendPoint(
+                            bucketStart: start,
+                            freshInput: value.freshInput,
+                            output: value.output,
+                            cacheRead: value.cacheRead,
+                            cacheCreation: value.cacheCreation,
+                            costMicros: value.cost
+                        )
+                    }
+                )
+            }
+            .sorted { $0.tool.rawValue < $1.tool.rawValue }
+        return UsageTrendSeries(bucket: resolved, points: points, providerSeries: providers)
     }
 
     /// One page of request-level rows, newest first.
@@ -973,13 +1006,19 @@ public actor UsageEventLedger: CostUsageEventSink {
     }
 
     private func bucketStarts(for range: DateInterval, bucket: UsageTrendBucket) -> [Date] {
-        let component: Calendar.Component = bucket == .hour ? .hour : .day
+        let component: Calendar.Component
         var cursor: Date
         switch bucket {
         case .hour:
+            component = .hour
             cursor = calendar.dateInterval(of: .hour, for: range.start)?.start ?? range.start
         case .day:
+            component = .day
             cursor = calendar.startOfDay(for: range.start)
+        case .week:
+            component = .weekOfYear
+            cursor = calendar.dateInterval(of: .weekOfYear, for: range.start)?.start
+                ?? calendar.startOfDay(for: range.start)
         }
         var out: [Date] = []
         while cursor < range.end, out.count < Self.maximumTrendBuckets {
@@ -990,6 +1029,17 @@ public actor UsageEventLedger: CostUsageEventSink {
             cursor = next
         }
         return out
+    }
+
+    private func bucketStart(for date: Date, bucket: UsageTrendBucket) -> Date? {
+        switch bucket {
+        case .hour:
+            calendar.dateInterval(of: .hour, for: date)?.start
+        case .day:
+            calendar.startOfDay(for: date)
+        case .week:
+            calendar.dateInterval(of: .weekOfYear, for: date)?.start
+        }
     }
 
     /// Local-calendar day key. Matches `CostAggregator`'s bucketing —

--- a/Tests/VibeBarCoreTests/ChartSeriesPlanningTests.swift
+++ b/Tests/VibeBarCoreTests/ChartSeriesPlanningTests.swift
@@ -106,6 +106,54 @@ final class ChartMarkBudgetTests: XCTestCase {
         XCTAssertEqual(thinned.last, 999)
         XCTAssertEqual(thinned, thinned.sorted())
     }
+
+    func testUsageDownsamplingPreservesExactEndpointsPeaksAndMarkBudget() {
+        let base = Date(timeIntervalSince1970: 1_800_000_000)
+        var input: [UsageTrendPoint] = []
+        for index in 0..<100 {
+            let tokens: Int64 = index == 37 ? 10_000 : 10
+            let output: Int64 = index == 37 ? 1_000 : 1
+            let cost: Int64 = index == 61 ? 900_000 : 100
+            input.append(
+                UsageTrendPoint(
+                    bucketStart: base.addingTimeInterval(TimeInterval(index * 3_600)),
+                    freshInput: tokens,
+                    output: output,
+                    cacheRead: 0,
+                    cacheCreation: 0,
+                    costMicros: cost
+                )
+            )
+        }
+
+        let projected = UsageTrendSeriesDownsampling.points(input, limit: 15)
+        let tokenPeak = input[37]
+        let costPeak = input[61]
+        let timestamps: [Date] = projected.map { $0.bucketStart }
+
+        XCTAssertLessThanOrEqual(projected.count, 15)
+        XCTAssertEqual(projected.first, input.first)
+        XCTAssertEqual(projected.last, input.last)
+        XCTAssertTrue(projected.contains(tokenPeak))
+        XCTAssertTrue(projected.contains(costPeak))
+        XCTAssertTrue(projected.allSatisfy { input.contains($0) })
+        XCTAssertEqual(timestamps, timestamps.sorted())
+    }
+
+    func testUsageDownsamplingHonorsSmallBudgetsWithDocumentedPriorities() {
+        let base = Date(timeIntervalSince1970: 1_800_000_000)
+        let input = [
+            UsageTrendPoint(bucketStart: base, freshInput: 1, output: 0, cacheRead: 0, cacheCreation: 0, costMicros: 1),
+            UsageTrendPoint(bucketStart: base.addingTimeInterval(3_600), freshInput: 100, output: 0, cacheRead: 0, cacheCreation: 0, costMicros: 2),
+            UsageTrendPoint(bucketStart: base.addingTimeInterval(7_200), freshInput: 2, output: 0, cacheRead: 0, cacheCreation: 0, costMicros: 100),
+            UsageTrendPoint(bucketStart: base.addingTimeInterval(10_800), freshInput: 3, output: 0, cacheRead: 0, cacheCreation: 0, costMicros: 3)
+        ]
+
+        XCTAssertEqual(UsageTrendSeriesDownsampling.points(input, limit: 1), [input[1]])
+        XCTAssertEqual(UsageTrendSeriesDownsampling.points(input, limit: 2), [input[0], input[3]])
+        XCTAssertEqual(UsageTrendSeriesDownsampling.points(input, limit: 3), [input[0], input[1], input[3]])
+        XCTAssertEqual(UsageTrendSeriesDownsampling.points(input, limit: 4), input)
+    }
 }
 
 final class ChartSampleSearchTests: XCTestCase {

--- a/Tests/VibeBarCoreTests/UsageQueryMetricsTests.swift
+++ b/Tests/VibeBarCoreTests/UsageQueryMetricsTests.swift
@@ -51,6 +51,9 @@ final class UsageQueryMetricsTests: XCTestCase {
         XCTAssertEqual(
             UsageTrendBucket.recommended(for: DateInterval(start: start, duration: 30 * 86_400)), .day
         )
+        XCTAssertEqual(
+            UsageTrendBucket.recommended(for: DateInterval(start: start, duration: 46 * 86_400)), .week
+        )
     }
 
     func testRequestPageCountReportsWholePages() {
@@ -118,6 +121,75 @@ final class UsageQueryMetricsTests: XCTestCase {
         XCTAssertEqual(series.points.first?.bucketStart, start)
         XCTAssertEqual(series.points.first?.totalTokens, 11)
         XCTAssertEqual(series.points.dropFirst().reduce(Int64(0)) { $0 + $1.totalTokens }, 0)
+    }
+
+    func testWeeklyTrendGroupsProviderSeriesOnTheSameBuckets() async throws {
+        let (ledger, directory) = try UsageLedgerFixtures.makeLedger("MetricsWeeklyProviders")
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let start = try XCTUnwrap(calendar.dateInterval(of: .weekOfYear, for: now)).start
+        let end = try XCTUnwrap(calendar.date(byAdding: .weekOfYear, value: 2, to: start))
+        let first = try XCTUnwrap(calendar.date(byAdding: .hour, value: 4, to: start))
+        let second = try XCTUnwrap(calendar.date(byAdding: .day, value: 8, to: start))
+
+        try await ledger.ingest(UsageLedgerFixtures.batch(
+            tool: .codex,
+            path: "/Users/example/.codex/sessions/weekly.jsonl",
+            events: [UsageLedgerFixtures.priced(
+                UsageLedgerFixtures.event(date: first, input: 100, output: 10), costUSD: 0.10
+            )]
+        ))
+        try await ledger.ingest(UsageLedgerFixtures.batch(
+            tool: .grok,
+            path: "/Users/example/.grok/sessions/weekly.jsonl",
+            events: [UsageLedgerFixtures.priced(
+                UsageLedgerFixtures.event(date: second, input: 200, output: 20), costUSD: 0.20
+            )]
+        ))
+
+        let series = try await ledger.trend(
+            UsageQueryFilter(range: DateInterval(start: start, end: end)), bucket: .week
+        )
+        XCTAssertEqual(series.bucket, .week)
+        XCTAssertEqual(series.points.count, 2)
+        XCTAssertEqual(series.points.map(\.totalTokens), [110, 220])
+        XCTAssertEqual(series.providerSeries.map(\.tool), [.codex, .grok])
+        XCTAssertEqual(series.providerSeries[0].points.map(\.totalTokens), [110, 0])
+        XCTAssertEqual(series.providerSeries[1].points.map(\.totalTokens), [0, 220])
+    }
+
+    func testWeeklyTrendKeepsPartialBoundaryWeeksButExcludesOutOfRangeRows() async throws {
+        let (ledger, directory) = try UsageLedgerFixtures.makeLedger("MetricsPartialWeeks")
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let weekStart = try XCTUnwrap(calendar.dateInterval(of: .weekOfYear, for: now)).start
+        let rangeStart = try XCTUnwrap(calendar.date(byAdding: .day, value: 2, to: weekStart))
+        let rangeEnd = try XCTUnwrap(calendar.date(byAdding: .day, value: 10, to: weekStart))
+        let beforeRange = try XCTUnwrap(calendar.date(byAdding: .day, value: 1, to: weekStart))
+        let insideFirstPartialWeek = try XCTUnwrap(calendar.date(byAdding: .day, value: 3, to: weekStart))
+        let insideLastPartialWeek = try XCTUnwrap(calendar.date(byAdding: .day, value: 8, to: weekStart))
+
+        try await ledger.ingest(UsageLedgerFixtures.batch(events: [
+            UsageLedgerFixtures.priced(
+                UsageLedgerFixtures.event(date: beforeRange, input: 900, output: 90), costUSD: 0.90
+            ),
+            UsageLedgerFixtures.priced(
+                UsageLedgerFixtures.event(date: insideFirstPartialWeek, input: 100, output: 10),
+                costUSD: 0.10
+            ),
+            UsageLedgerFixtures.priced(
+                UsageLedgerFixtures.event(date: insideLastPartialWeek, input: 200, output: 20),
+                costUSD: 0.20
+            ),
+        ]))
+
+        let series = try await ledger.trend(
+            UsageQueryFilter(range: DateInterval(start: rangeStart, end: rangeEnd)), bucket: .week
+        )
+        let secondWeek = try XCTUnwrap(calendar.date(byAdding: .weekOfYear, value: 1, to: weekStart))
+        XCTAssertEqual(series.points.map(\.bucketStart), [weekStart, secondWeek])
+        XCTAssertEqual(series.points.map(\.totalTokens), [110, 220])
+        XCTAssertEqual(series.points.reduce(Int64(0)) { $0 + $1.costMicros }, 300_000)
     }
 
     // MARK: - Filters

--- a/Tests/VibeBarCoreTests/UsageQueryMetricsTests.swift
+++ b/Tests/VibeBarCoreTests/UsageQueryMetricsTests.swift
@@ -97,6 +97,33 @@ final class UsageQueryMetricsTests: XCTestCase {
         XCTAssertEqual(series.points.reduce(Int64(0)) { $0 + $1.costMicros }, 1_000_000)
     }
 
+    func testHourlyTrendFallsBackToDailyWhenRangeCrossesActualDetailFloor() async throws {
+        let (ledger, directory) = try UsageLedgerFixtures.makeLedger("MetricsHourlyFloor")
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let today = calendar.startOfDay(for: now)
+        let rolledUpDay = try XCTUnwrap(calendar.date(byAdding: .day, value: -35, to: today))
+        let end = try XCTUnwrap(calendar.date(byAdding: .day, value: 1, to: rolledUpDay))
+        let event = try XCTUnwrap(calendar.date(byAdding: .hour, value: 10, to: rolledUpDay))
+
+        try await ledger.ingest(UsageLedgerFixtures.batch(events: [
+            UsageLedgerFixtures.priced(
+                UsageLedgerFixtures.event(date: event, input: 300, output: 30), costUSD: 0.3
+            )
+        ]))
+        try await ledger.rollupAndPrune(now: now, detailDays: 30, retentionDays: 365)
+
+        let filter = UsageQueryFilter(range: DateInterval(start: rolledUpDay, end: end))
+        // This is only 24 buckets, so bucket-count gating alone would still
+        // offer Hourly. The ledger's stored floor must force the day fallback.
+        let series = try await ledger.trend(filter, bucket: .hour)
+        let supportsHourly = try await ledger.supportsHourlyTrend(filter)
+        XCTAssertFalse(supportsHourly)
+        XCTAssertEqual(series.bucket, .day)
+        XCTAssertEqual(series.points.map(\.totalTokens), [330])
+        XCTAssertEqual(series.points.map(\.costMicros), [300_000])
+    }
+
     func testDailyTrendZeroFillsEveryDayInRange() async throws {
         let (ledger, directory) = try UsageLedgerFixtures.makeLedger("MetricsDaily")
         defer { try? FileManager.default.removeItem(at: directory) }


### PR DESCRIPTION
## Summary

- keep Session metadata, transcript search, and Usage filters fixed while their content scrolls
- redesign Workbench controls, hover states, tables, Grok contrast, and the Hermes skill mark for macOS light and dark appearances
- add provider-aligned usage series, previous/next windows, an Overview-style brush navigator, and Auto/Hourly/Daily/Weekly aggregation
- bound chart buckets and marks so long custom ranges do not make Workbench unresponsive

## Test plan

- [x] `swift build --target VibeBarApp`
- [x] `swift test` (1432 tests)
- [x] `./Scripts/build_app.sh release`
- [x] `codesign --verify --deep --strict ".build/Vibe Bar.app"`
- [x] empty entitlements confirmed
- [ ] manual light/dark UI smoke test (bundle was not launched to avoid triggering the reported Keychain prompt)

Co-Authored-By: Codex <noreply@openai.com>