### PR TITLE
Prepare Vibe Bar 1.3.0 Dev build 25

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.3.0</string>
 	<key>CFBundleVersion</key>
-	<string>24</string>
+	<string>25</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>26.0</string>
 	<key>LSUIElement</key>


### PR DESCRIPTION
## Summary
- advance CFBundleVersion from 24 to 25
- keep CFBundleShortVersionString at 1.3.0 for the Dev channel

## Test plan
- [x] swift build
- [x] swift test — 1435 tests, 0 failures
- [x] ./Scripts/build_app.sh release
- [x] codesign --verify --deep --strict .build/Vibe Bar.app
- [x] confirm empty entitlements and embedded version 1.3.0 (25)