### PR TITLE
Document upstream acknowledgements

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,8 +251,10 @@ Vibe Bar also directly uses
 [SweetCookieKit](https://github.com/steipete/SweetCookieKit) for local browser
 cookie access and [Sparkle](https://github.com/sparkle-project/Sparkle) for
 signed app updates. See [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md) for
-the relationship and license details. These projects are independent from
-Vibe Bar; acknowledgement does not imply affiliation or endorsement.
+the relationship and license details; complete applicable license texts live
+under [Resources/ThirdPartyLicenses](Resources/ThirdPartyLicenses) and are
+included in packaged app bundles. These projects are independent from Vibe
+Bar; acknowledgement does not imply affiliation or endorsement.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -229,6 +229,31 @@ resources and Sparkle framework, and ad-hoc signs the bundle.
 Vibe Bar is early public-release software. Provider APIs and quota contracts
 move quickly; focused adapters, fixtures, and UI refinements are welcome.
 
+## Acknowledgements
+
+Vibe Bar is an independent project, but it stands on work shared by the wider
+coding-agent community:
+
+- [CodexBar](https://github.com/steipete/CodexBar) is the primary technical
+  reference for the macOS menu-bar quota experience. Several browser-cookie
+  and Keychain utilities, selected provider behaviors, and the AntiGravity
+  local-probe flow were adapted from or reimplemented with reference to it.
+- [CC Switch](https://github.com/farion1231/cc-switch) informed the unified
+  Skills workflow and remains an interoperability reference for existing
+  cross-agent skill layouts.
+- [CLIProxyAPI](https://github.com/router-for-me/CLIProxyAPI) and its ecosystem
+  informed our understanding of multi-provider CLI account and quota
+  workflows. Vibe Bar does not embed, launch, or require CLIProxyAPI.
+- [ccusage](https://github.com/ccusage/ccusage) informed local session-cost
+  parsing and pricing semantics.
+
+Vibe Bar also directly uses
+[SweetCookieKit](https://github.com/steipete/SweetCookieKit) for local browser
+cookie access and [Sparkle](https://github.com/sparkle-project/Sparkle) for
+signed app updates. See [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md) for
+the relationship and license details. These projects are independent from
+Vibe Bar; acknowledgement does not imply affiliation or endorsement.
+
 ## License
 
 Vibe Bar is licensed under the

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -230,8 +230,10 @@ Vibe Bar 还直接使用
 [SweetCookieKit](https://github.com/steipete/SweetCookieKit) 读取本地浏览器 Cookie，
 并使用 [Sparkle](https://github.com/sparkle-project/Sparkle) 实现带签名的应用更新。
 具体关系与许可证信息见
-[THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md)。上述项目均与 Vibe Bar
-相互独立；本致谢不表示存在隶属、背书或其他官方关系。
+[THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md)；适用的完整许可证文本位于
+[Resources/ThirdPartyLicenses](Resources/ThirdPartyLicenses)，并会随打包后的
+App Bundle 一并提供。上述项目均与 Vibe Bar 相互独立；本致谢不表示存在隶属、
+背书或其他官方关系。
 
 ## 许可证
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -211,6 +211,28 @@ ad-hoc 签名。
 Vibe Bar 仍处于早期公开版本。Provider API 和配额协议变化很快，欢迎提交聚焦的
 Adapter、Fixture 与界面优化。
 
+## 致谢
+
+Vibe Bar 是一个独立项目，也得益于 Coding Agent 开源社区分享的工作：
+
+- [CodexBar](https://github.com/steipete/CodexBar) 是 macOS 菜单栏配额体验的
+  主要技术参考。部分浏览器 Cookie 与 Keychain 工具、Provider 行为，以及
+  AntiGravity 本地探测流程，是在参考其实现后移植、简化或重新实现的。
+- [CC Switch](https://github.com/farion1231/cc-switch) 为统一 Skills 工作流
+  提供了参考，也是 Vibe Bar 识别现有跨 Agent Skill 布局时的互操作对象。
+- [CLIProxyAPI](https://github.com/router-for-me/CLIProxyAPI) 及其生态帮助我们
+  理解多 Provider CLI 账号与配额工作流。Vibe Bar 不内置、不启动，也不依赖
+  CLIProxyAPI 运行。
+- [ccusage](https://github.com/ccusage/ccusage) 为本地 Session 成本解析与定价语义
+  提供了参考。
+
+Vibe Bar 还直接使用
+[SweetCookieKit](https://github.com/steipete/SweetCookieKit) 读取本地浏览器 Cookie，
+并使用 [Sparkle](https://github.com/sparkle-project/Sparkle) 实现带签名的应用更新。
+具体关系与许可证信息见
+[THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md)。上述项目均与 Vibe Bar
+相互独立；本致谢不表示存在隶属、背书或其他官方关系。
+
 ## 许可证
 
 Vibe Bar 采用 [GNU Affero General Public License v3.0 only](LICENSE)。

--- a/Resources/ThirdPartyLicenses/CodexBar.txt
+++ b/Resources/ThirdPartyLicenses/CodexBar.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Peter Steinberger
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Resources/ThirdPartyLicenses/Sparkle.txt
+++ b/Resources/ThirdPartyLicenses/Sparkle.txt
@@ -1,0 +1,134 @@
+Copyright (c) 2006-2013 Andy Matuschak.
+Copyright (c) 2009-2013 Elgato Systems GmbH.
+Copyright (c) 2011-2014 Kornel Lesiński.
+Copyright (c) 2015-2017 Mayur Pawashe.
+Copyright (c) 2014 C.W. Betts.
+Copyright (c) 2014 Petroules Corporation.
+Copyright (c) 2014 Big Nerd Ranch.
+All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+=================
+EXTERNAL LICENSES
+=================
+
+bspatch.c and bsdiff.c, from bsdiff 4.3 <http://www.daemonology.net/bsdiff/>:
+
+Copyright 2003-2005 Colin Percival
+All rights reserved
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted providing that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+--
+
+sais.c and sais.h, from sais-lite (2010/08/07) <https://sites.google.com/site/yuta256/sais>:
+
+The sais-lite copyright is as follows:
+
+Copyright (c) 2008-2010 Yuta Mori All Rights Reserved.
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+--
+
+Portable C implementation of Ed25519, from https://github.com/orlp/ed25519
+
+Copyright (c) 2015 Orson Peters <orsonpeters@gmail.com>
+
+This software is provided 'as-is', without any express or implied warranty. In no event will the
+authors be held liable for any damages arising from the use of this software.
+
+Permission is granted to anyone to use this software for any purpose, including commercial
+applications, and to alter it and redistribute it freely, subject to the following restrictions:
+
+1. The origin of this software must not be misrepresented; you must not claim that you wrote the
+   original software. If you use this software in a product, an acknowledgment in the product
+   documentation would be appreciated but is not required.
+
+2. Altered source versions must be plainly marked as such, and must not be misrepresented as
+   being the original software.
+
+3. This notice may not be removed or altered from any source distribution.
+
+--
+
+SUSignatureVerifier.m:
+
+Copyright (c) 2011 Mark Hamlin.
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted providing that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.

--- a/Resources/ThirdPartyLicenses/SweetCookieKit.txt
+++ b/Resources/ThirdPartyLicenses/SweetCookieKit.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Peter Steinberger
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Scripts/build_app.sh
+++ b/Scripts/build_app.sh
@@ -57,6 +57,10 @@ cp -R "$CORE_RESOURCE_BUNDLE" \
     "$APP_DIR/Contents/Resources/VibeBar_VibeBarCore.bundle"
 ditto "$SPARKLE_FRAMEWORK_SOURCE" "$SPARKLE_FRAMEWORK"
 cp "$ROOT/Resources/Info.plist" "$APP_DIR/Contents/Info.plist"
+cp "$ROOT/THIRD_PARTY_NOTICES.md" \
+    "$APP_DIR/Contents/Resources/THIRD_PARTY_NOTICES.md"
+cp -R "$ROOT/Resources/ThirdPartyLicenses" \
+    "$APP_DIR/Contents/Resources/ThirdPartyLicenses"
 if [[ -f "$ROOT/Resources/AppIcon.icns" ]]; then
     cp "$ROOT/Resources/AppIcon.icns" "$APP_DIR/Contents/Resources/AppIcon.icns"
 fi
@@ -69,6 +73,16 @@ printf '%s' "$PkgInfo" > "$APP_DIR/Contents/PkgInfo"
 
 if [[ ! -f "$APP_DIR/Contents/Resources/VibeBar_VibeBarCore.bundle/pricing.json" ]]; then
     echo "Packaged core resource bundle is incomplete." >&2
+    exit 1
+fi
+for license_name in CodexBar SweetCookieKit Sparkle; do
+    if [[ ! -f "$APP_DIR/Contents/Resources/ThirdPartyLicenses/$license_name.txt" ]]; then
+        echo "Packaged third-party license resources are incomplete." >&2
+        exit 1
+    fi
+done
+if [[ ! -f "$APP_DIR/Contents/Resources/THIRD_PARTY_NOTICES.md" ]]; then
+    echo "Packaged third-party notices are incomplete." >&2
     exit 1
 fi
 

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -14,11 +14,12 @@ interoperability references.
   Keychain utilities, provider behaviors, and AntiGravity local-probe logic
   with reference to CodexBar. Individual source files retain focused
   `Ported from`, `Modeled after`, or equivalent attribution where applicable.
-- License: [MIT](https://github.com/steipete/CodexBar/blob/main/LICENSE)
+- License: [MIT](Resources/ThirdPartyLicenses/CodexBar.txt)
+  ([upstream](https://github.com/steipete/CodexBar/blob/main/LICENSE))
 - Copyright: Copyright (c) 2026 Peter Steinberger
 
-See the canonical upstream license linked above for the complete permission
-notice and terms covering the adapted CodexBar portions.
+The complete copyright and permission notice covering the adapted CodexBar
+portions is included in this repository at the local license link above.
 
 ## Direct dependencies
 
@@ -26,17 +27,22 @@ notice and terms covering the adapted CodexBar portions.
 
 - Project: [steipete/SweetCookieKit](https://github.com/steipete/SweetCookieKit)
 - Use in Vibe Bar: local Safari, Chromium, and Firefox cookie access.
-- License: [MIT](https://github.com/steipete/SweetCookieKit/blob/0.4.0/LICENSE)
+- License: [MIT](Resources/ThirdPartyLicenses/SweetCookieKit.txt)
+  ([upstream](https://github.com/steipete/SweetCookieKit/blob/0.4.0/LICENSE))
 
 ### Sparkle 2.9.4
 
 - Project: [sparkle-project/Sparkle](https://github.com/sparkle-project/Sparkle)
 - Use in Vibe Bar: signed application update discovery and installation.
 - License:
-  [Sparkle license and external component notices](https://github.com/sparkle-project/Sparkle/blob/2.9.4/LICENSE)
+  [Sparkle license and external component notices](Resources/ThirdPartyLicenses/Sparkle.txt)
+  ([upstream](https://github.com/sparkle-project/Sparkle/blob/2.9.4/LICENSE))
 
-Dependency versions are declared in `Package.swift`. Their upstream license
-files remain authoritative for the complete terms and bundled subcomponents.
+Dependency versions are declared in `Package.swift`. The complete license
+texts and bundled-component notices are stored under
+`Resources/ThirdPartyLicenses/`. `Scripts/build_app.sh` packages that directory
+and this notice in `Vibe Bar.app/Contents/Resources/` so binary distributions
+carry the required notices.
 
 ## Reference projects not bundled by these relationships
 

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,55 @@
+# Third-Party Notices
+
+Vibe Bar is licensed under the GNU Affero General Public License v3.0 only.
+This document records the upstream projects whose code is adapted by Vibe Bar,
+the packages it directly includes, and the projects acknowledged as design or
+interoperability references.
+
+## Adapted implementations
+
+### CodexBar
+
+- Project: [steipete/CodexBar](https://github.com/steipete/CodexBar)
+- Relationship: Vibe Bar adapts or reimplements selected browser-cookie and
+  Keychain utilities, provider behaviors, and AntiGravity local-probe logic
+  with reference to CodexBar. Individual source files retain focused
+  `Ported from`, `Modeled after`, or equivalent attribution where applicable.
+- License: [MIT](https://github.com/steipete/CodexBar/blob/main/LICENSE)
+- Copyright: Copyright (c) 2026 Peter Steinberger
+
+See the canonical upstream license linked above for the complete permission
+notice and terms covering the adapted CodexBar portions.
+
+## Direct dependencies
+
+### SweetCookieKit 0.4.0 or later compatible releases
+
+- Project: [steipete/SweetCookieKit](https://github.com/steipete/SweetCookieKit)
+- Use in Vibe Bar: local Safari, Chromium, and Firefox cookie access.
+- License: [MIT](https://github.com/steipete/SweetCookieKit/blob/0.4.0/LICENSE)
+
+### Sparkle 2.9.4
+
+- Project: [sparkle-project/Sparkle](https://github.com/sparkle-project/Sparkle)
+- Use in Vibe Bar: signed application update discovery and installation.
+- License:
+  [Sparkle license and external component notices](https://github.com/sparkle-project/Sparkle/blob/2.9.4/LICENSE)
+
+Dependency versions are declared in `Package.swift`. Their upstream license
+files remain authoritative for the complete terms and bundled subcomponents.
+
+## Reference projects not bundled by these relationships
+
+- [CC Switch](https://github.com/farion1231/cc-switch) — reference and
+  interoperability target for unified Skills management. License:
+  [MIT](https://github.com/farion1231/cc-switch/blob/main/LICENSE).
+- [CLIProxyAPI](https://github.com/router-for-me/CLIProxyAPI) — ecosystem
+  reference for multi-provider CLI account and quota workflows. Vibe Bar does
+  not embed, launch, or require CLIProxyAPI. License:
+  [MIT](https://github.com/router-for-me/CLIProxyAPI/blob/main/LICENSE).
+- [ccusage](https://github.com/ccusage/ccusage) — reference for local token and
+  session-cost parsing and pricing semantics. License:
+  [MIT](https://github.com/ccusage/ccusage/blob/main/LICENSE).
+
+All project names and trademarks belong to their respective owners. Listing a
+project here does not imply affiliation, sponsorship, or endorsement.


### PR DESCRIPTION
## Summary

- add mirrored English and Chinese acknowledgements for CodexBar, CC Switch, CLIProxyAPI, and ccusage
- distinguish adapted implementations, direct dependencies, and reference-only projects
- add THIRD_PARTY_NOTICES.md with upstream relationships and license links

## Test plan

- [x] Markdown diff and local-link checks
- [x] swift build
- [x] swift test (1435 tests)
- [x] ./Scripts/build_app.sh release
- [x] codesign --verify --deep --strict ".build/Vibe Bar.app"
- [x] verified empty entitlements and no app-sandbox key