### PR TITLE
Keep usage ledger aligned with refreshed model pricing

### DIFF
--- a/Sources/VibeBarCore/Services/CostUsageService.swift
+++ b/Sources/VibeBarCore/Services/CostUsageService.swift
@@ -185,8 +185,9 @@ public final class CostUsageService: ObservableObject {
 
         // The Workbench reads persisted request costs from UsageEventLedger,
         // while the outer ranking is rebuilt directly from each fresh scan.
-        // Reset the derived ledger whenever the effective catalog (including
-        // local overrides) changes so both surfaces use the same rates.
+        // Reprice previously unpriced ledger rows whenever the effective
+        // catalog (including local overrides) changes so both surfaces can
+        // adopt newly covered models without losing rotated history.
         _ = try? await usageLedger?.prepareForPricingRevision(PricingResolver.activeRevision)
 
         var results: [ToolType: CostSnapshot] = [:]

--- a/Sources/VibeBarCore/Services/CostUsageService.swift
+++ b/Sources/VibeBarCore/Services/CostUsageService.swift
@@ -181,7 +181,13 @@ public final class CostUsageService: ObservableObject {
         // last pass. Swapping here — at the pass boundary, before any scan
         // starts — keeps every scan below on one consistent table while
         // letting new model rates land without an app relaunch.
-        PricingResolver.reloadIfChanged()
+        PricingResolver.reloadIfChanged(homeDirectory: homeDirectory)
+
+        // The Workbench reads persisted request costs from UsageEventLedger,
+        // while the outer ranking is rebuilt directly from each fresh scan.
+        // Reset the derived ledger whenever the effective catalog (including
+        // local overrides) changes so both surfaces use the same rates.
+        _ = try? await usageLedger?.prepareForPricingRevision(PricingResolver.activeRevision)
 
         var results: [ToolType: CostSnapshot] = [:]
         let home = homeDirectory

--- a/Sources/VibeBarCore/Services/UsageEventLedger.swift
+++ b/Sources/VibeBarCore/Services/UsageEventLedger.swift
@@ -66,6 +66,7 @@ public actor UsageEventLedger: CostUsageEventSink {
     /// Bumping this drops and rebuilds every table on the next open.
     static let schemaVersion = 3
     private static let schemaVersionKey = "schema_version"
+    private static let pricingRevisionKey = "pricing_revision"
     private static let floorKeyPrefix = "detail_floor_day:"
     /// Guard rail on zero-filled trend enumeration: ~135 years of daily
     /// buckets. A filter wider than this is a caller bug, not a chart.
@@ -517,6 +518,46 @@ public actor UsageEventLedger: CostUsageEventSink {
             try execute("DELETE FROM ingested_files")
             try run("DELETE FROM ledger_meta WHERE key <> ?", [.text(Self.schemaVersionKey)])
             try execute("COMMIT")
+        } catch {
+            try? execute("ROLLBACK")
+            throw error
+        }
+    }
+
+    /// Make the persisted costs match the active pricing table.
+    ///
+    /// File mtime/size fingerprints are intentionally blind to price changes,
+    /// and older request rows may already have been folded into daily
+    /// rollups. Rebuilding the derived ledger is the only exact update for
+    /// both shapes. The scanner's parsed-event cache remains authoritative,
+    /// so the following pass repopulates this database without reparsing the
+    /// original JSONL files.
+    @discardableResult
+    public func prepareForPricingRevision(_ revision: String) throws -> Bool {
+        let stored = try scalarText(
+            "SELECT value FROM ledger_meta WHERE key = ?",
+            [.text(Self.pricingRevisionKey)]
+        )
+        guard stored != revision else { return false }
+
+        try execute("BEGIN IMMEDIATE")
+        do {
+            try execute("DELETE FROM usage_events")
+            try execute("DELETE FROM usage_daily_rollups")
+            try execute("DELETE FROM ingested_files")
+            try run(
+                "DELETE FROM ledger_meta WHERE key <> ?",
+                [.text(Self.schemaVersionKey)]
+            )
+            try run(
+                """
+                INSERT INTO ledger_meta(key, value) VALUES(?, ?)
+                   ON CONFLICT(key) DO UPDATE SET value = excluded.value
+                """,
+                [.text(Self.pricingRevisionKey), .text(revision)]
+            )
+            try execute("COMMIT")
+            return true
         } catch {
             try? execute("ROLLBACK")
             throw error

--- a/Sources/VibeBarCore/Services/UsageEventLedger.swift
+++ b/Sources/VibeBarCore/Services/UsageEventLedger.swift
@@ -524,14 +524,14 @@ public actor UsageEventLedger: CostUsageEventSink {
         }
     }
 
-    /// Make the persisted costs match the active pricing table.
+    /// Fill previously unpriced rows from the active pricing table.
     ///
-    /// File mtime/size fingerprints are intentionally blind to price changes,
-    /// and older request rows may already have been folded into daily
-    /// rollups. Rebuilding the derived ledger is the only exact update for
-    /// both shapes. The scanner's parsed-event cache remains authoritative,
-    /// so the following pass repopulates this database without reparsing the
-    /// original JSONL files.
+    /// File mtime/size fingerprints are intentionally blind to price changes.
+    /// Repricing in place preserves history whose source file has since been
+    /// rotated or removed. Detail rows retain per-request precision; a fully
+    /// unpriced daily rollup can also be recovered from its provider-neutral
+    /// model/token totals. Already-priced rollups stay untouched because their
+    /// per-request tier/threshold boundaries are no longer available.
     @discardableResult
     public func prepareForPricingRevision(_ revision: String) throws -> Bool {
         let stored = try scalarText(
@@ -540,15 +540,31 @@ public actor UsageEventLedger: CostUsageEventSink {
         )
         guard stored != revision else { return false }
 
+        let details = try unpricedDetailRows()
+        let rollups = try fullyUnpricedRollupRows()
         try execute("BEGIN IMMEDIATE")
         do {
-            try execute("DELETE FROM usage_events")
-            try execute("DELETE FROM usage_daily_rollups")
-            try execute("DELETE FROM ingested_files")
-            try run(
-                "DELETE FROM ledger_meta WHERE key <> ?",
-                [.text(Self.schemaVersionKey)]
-            )
+            for row in details {
+                guard let micros = costMicros(for: row) else { continue }
+                try run(
+                    "UPDATE usage_events SET cost_micros = ? WHERE id = ? AND cost_micros IS NULL",
+                    [.integer(micros), .integer(row.id)]
+                )
+            }
+            for row in rollups {
+                guard let micros = costMicros(for: row) else { continue }
+                try run(
+                    """
+                    UPDATE usage_daily_rollups
+                       SET cost_micros = ?, unpriced = 0
+                     WHERE day = ? AND tool = ? AND model = ? AND unpriced = requests
+                    """,
+                    [
+                        .integer(micros), .text(row.day),
+                        .text(row.tool.rawValue), .text(row.model)
+                    ]
+                )
+            }
             try run(
                 """
                 INSERT INTO ledger_meta(key, value) VALUES(?, ?)
@@ -562,6 +578,141 @@ public actor UsageEventLedger: CostUsageEventSink {
             try? execute("ROLLBACK")
             throw error
         }
+    }
+
+    private struct RepricingRow {
+        let id: Int64
+        let day: String
+        let tool: ToolType
+        let model: String
+        let freshInput: Int64
+        let output: Int64
+        let cacheRead: Int64
+        let cacheCreation: Int64
+        let serviceTier: String?
+    }
+
+    private func unpricedDetailRows() throws -> [RepricingRow] {
+        let statement = try prepare(
+            """
+            SELECT id, day, tool, model, fresh_input, output,
+                   cache_read, cache_creation, service_tier
+              FROM usage_events WHERE cost_micros IS NULL
+            """
+        )
+        defer { sqlite3_finalize(statement) }
+        var rows: [RepricingRow] = []
+        while sqlite3_step(statement) == SQLITE_ROW {
+            guard let day = columnText(statement, 1),
+                  let rawTool = columnText(statement, 2),
+                  let tool = ToolType(rawValue: rawTool),
+                  let model = columnText(statement, 3)
+            else { continue }
+            rows.append(RepricingRow(
+                id: sqlite3_column_int64(statement, 0),
+                day: day,
+                tool: tool,
+                model: model,
+                freshInput: sqlite3_column_int64(statement, 4),
+                output: sqlite3_column_int64(statement, 5),
+                cacheRead: sqlite3_column_int64(statement, 6),
+                cacheCreation: sqlite3_column_int64(statement, 7),
+                serviceTier: columnText(statement, 8)
+            ))
+        }
+        return rows
+    }
+
+    private func fullyUnpricedRollupRows() throws -> [RepricingRow] {
+        let statement = try prepare(
+            """
+            SELECT day, tool, model, fresh_input, output, cache_read, cache_creation
+              FROM usage_daily_rollups WHERE unpriced > 0 AND unpriced = requests
+            """
+        )
+        defer { sqlite3_finalize(statement) }
+        var rows: [RepricingRow] = []
+        while sqlite3_step(statement) == SQLITE_ROW {
+            guard let day = columnText(statement, 0),
+                  let rawTool = columnText(statement, 1),
+                  let tool = ToolType(rawValue: rawTool),
+                  let model = columnText(statement, 2)
+            else { continue }
+            rows.append(RepricingRow(
+                id: 0,
+                day: day,
+                tool: tool,
+                model: model,
+                freshInput: sqlite3_column_int64(statement, 3),
+                output: sqlite3_column_int64(statement, 4),
+                cacheRead: sqlite3_column_int64(statement, 5),
+                cacheCreation: sqlite3_column_int64(statement, 6),
+                serviceTier: nil
+            ))
+        }
+        return rows
+    }
+
+    private func costMicros(for row: RepricingRow) -> Int64? {
+        guard row.freshInput >= 0, row.output >= 0,
+              row.cacheRead >= 0, row.cacheCreation >= 0,
+              let freshInput = Int(exactly: row.freshInput),
+              let output = Int(exactly: row.output),
+              let cacheRead = Int(exactly: row.cacheRead),
+              let cacheCreation = Int(exactly: row.cacheCreation)
+        else { return nil }
+        let inputSum = freshInput.addingReportingOverflow(cacheRead)
+        guard !inputSum.overflow else { return nil }
+        let inputWithCache = inputSum.partialValue
+
+        let isFast = row.serviceTier == "fast" || row.serviceTier == "priority"
+        let cost: Double? = switch row.tool {
+        case .codex:
+            CostUsagePricing.codexCostUSD(
+                model: row.model,
+                inputTokens: inputWithCache,
+                cachedInputTokens: cacheRead,
+                outputTokens: output,
+                isFast: isFast
+            )
+        case .claude:
+            CostUsagePricing.claudeCostUSD(
+                model: row.model,
+                inputTokens: freshInput,
+                cacheReadInputTokens: cacheRead,
+                cacheCreationInputTokens: cacheCreation,
+                outputTokens: output,
+                isFast: isFast
+            )
+        case .gemini:
+            CostUsagePricing.geminiCostUSD(
+                model: row.model,
+                inputTokens: inputWithCache,
+                cacheReadInputTokens: cacheRead,
+                outputTokens: output
+            )
+        case .grok:
+            CostUsagePricing.grokCostUSD(
+                model: row.model,
+                inputTokens: inputWithCache,
+                cachedInputTokens: cacheRead,
+                outputTokens: output
+            )
+        case .antigravity:
+            CostUsagePricing.antigravityCostUSD(
+                model: row.model,
+                inputTokens: freshInput,
+                cacheReadInputTokens: cacheRead,
+                cacheCreationInputTokens: cacheCreation,
+                outputTokens: output
+            )
+        case .alibaba, .alibabaTokenPlan, .copilot, .zai, .minimax, .kimi,
+             .cursor, .mimo, .iflytek, .tencentHunyuan, .tencentTokenPlan,
+             .volcengine, .volcengineAgentPlan, .baiduQianfan, .openCodeGo,
+             .kilo, .kiro, .ollama, .openRouter, .warp:
+            nil
+        }
+        return cost.flatMap(PricedUsageEvent.micros(fromUSD:))
     }
 
     /// Oldest day that still has request-level rows for `tool`, or nil when

--- a/Sources/VibeBarCore/Services/UsageEventLedger.swift
+++ b/Sources/VibeBarCore/Services/UsageEventLedger.swift
@@ -524,14 +524,15 @@ public actor UsageEventLedger: CostUsageEventSink {
         }
     }
 
-    /// Fill previously unpriced rows from the active pricing table.
+    /// Refresh persisted costs from the active pricing table.
     ///
     /// File mtime/size fingerprints are intentionally blind to price changes.
     /// Repricing in place preserves history whose source file has since been
-    /// rotated or removed. Detail rows retain per-request precision; a fully
-    /// unpriced daily rollup can also be recovered from its provider-neutral
-    /// model/token totals. Already-priced rollups stay untouched because their
-    /// per-request tier/threshold boundaries are no longer available.
+    /// rotated or removed. Every detail row retains enough request context to
+    /// be recalculated. A fully unpriced daily rollup is recovered only when
+    /// the active model has linear, tier-independent pricing; ambiguous and
+    /// already-priced rollups stay untouched because their request boundaries
+    /// are no longer available.
     @discardableResult
     public func prepareForPricingRevision(_ revision: String) throws -> Bool {
         let stored = try scalarText(
@@ -540,18 +541,25 @@ public actor UsageEventLedger: CostUsageEventSink {
         )
         guard stored != revision else { return false }
 
-        let details = try unpricedDetailRows()
+        let details = try detailRows()
         let rollups = try fullyUnpricedRollupRows()
         try execute("BEGIN IMMEDIATE")
         do {
             for row in details {
-                guard let micros = costMicros(for: row) else { continue }
+                let costBinding: Binding = if let micros = costMicros(for: row) {
+                    .integer(micros)
+                } else {
+                    .null
+                }
                 try run(
-                    "UPDATE usage_events SET cost_micros = ? WHERE id = ? AND cost_micros IS NULL",
-                    [.integer(micros), .integer(row.id)]
+                    "UPDATE usage_events SET cost_micros = ? WHERE id = ?",
+                    [costBinding, .integer(row.id)]
                 )
             }
             for row in rollups {
+                guard CostUsagePricing.canRepriceAggregate(tool: row.tool, model: row.model) else {
+                    continue
+                }
                 guard let micros = costMicros(for: row) else { continue }
                 try run(
                     """
@@ -592,12 +600,12 @@ public actor UsageEventLedger: CostUsageEventSink {
         let serviceTier: String?
     }
 
-    private func unpricedDetailRows() throws -> [RepricingRow] {
+    private func detailRows() throws -> [RepricingRow] {
         let statement = try prepare(
             """
             SELECT id, day, tool, model, fresh_input, output,
                    cache_read, cache_creation, service_tier
-              FROM usage_events WHERE cost_micros IS NULL
+              FROM usage_events
             """
         )
         defer { sqlite3_finalize(statement) }

--- a/Sources/VibeBarCore/Vendored/CostUsage/CostUsagePricing.swift
+++ b/Sources/VibeBarCore/Vendored/CostUsage/CostUsagePricing.swift
@@ -37,6 +37,44 @@ public enum CostUsagePricing {
         return multiplier > 0 ? multiplier : 1.0
     }
 
+    /// Whether summed daily token columns contain enough information to
+    /// reproduce request-level pricing exactly. Threshold and premium-tier
+    /// models require request boundaries that legacy rollups no longer keep.
+    static func canRepriceAggregate(tool: ToolType, model: String) -> Bool {
+        let dataSet = PricingResolver.active
+        switch tool {
+        case .codex:
+            guard let pricing = dataSet.providers.codex.models[normalizeCodexModel(model)] else {
+                return false
+            }
+            return pricing.thresholdTokens == nil
+                && (pricing.fastMultiplier ?? 1.0) == 1.0
+        case .claude:
+            guard let pricing = dataSet.providers.claude.models[normalizeClaudeModel(model)] else {
+                return false
+            }
+            return pricing.thresholdTokens == nil
+                && (pricing.fastMultiplier ?? 1.0) == 1.0
+        case .gemini:
+            guard let pricing = dataSet.providers.gemini.models[normalizeGeminiModel(model)] else {
+                return false
+            }
+            return pricing.thresholdTokens == nil
+        case .grok:
+            guard let pricing = dataSet.providers.grok.models[normalizeGrokModel(model)] else {
+                return false
+            }
+            return pricing.thresholdTokens == nil
+        case .antigravity:
+            return dataSet.providers.antigravity.models[normalizeAntigravityModel(model)] != nil
+        case .alibaba, .alibabaTokenPlan, .copilot, .zai, .minimax, .kimi,
+             .cursor, .mimo, .iflytek, .tencentHunyuan, .tencentTokenPlan,
+             .volcengine, .volcengineAgentPlan, .baiduQianfan, .openCodeGo,
+             .kilo, .kiro, .ollama, .openRouter, .warp:
+            return false
+        }
+    }
+
     private static func tieredCost(
         tokens: Int,
         base: Double,

--- a/Sources/VibeBarCore/Vendored/CostUsage/PortkeyPricingTransformer.swift
+++ b/Sources/VibeBarCore/Vendored/CostUsage/PortkeyPricingTransformer.swift
@@ -64,7 +64,7 @@ public enum PortkeyPricingTransformer {
                 guard let rates = rates(entry) else { continue }
                 let id = rawID.lowercased()
                 switch family {
-                case .codex where id.hasPrefix("gpt-"):
+                case .codex where isCodexModel(id):
                     codex[id] = .init(
                         input: rates.input,
                         output: rates.output,
@@ -125,5 +125,14 @@ public enum PortkeyPricingTransformer {
             cacheRead: payg.cacheReadInputToken.map { $0.price / 100 },
             cacheWrite: payg.cacheWriteInputToken.map { $0.price / 100 }
         )
+    }
+
+    /// Portkey's OpenAI catalog mostly uses the public `gpt-*` names, but
+    /// Codex also emits this first-party internal usage category directly in
+    /// session logs. Keep the allow-list narrow so embeddings, image, audio,
+    /// and moderation SKUs from the same provider file do not leak into the
+    /// Codex model picker.
+    private static func isCodexModel(_ id: String) -> Bool {
+        id.hasPrefix("gpt-") || id == "codex-auto-review"
     }
 }

--- a/Sources/VibeBarCore/Vendored/CostUsage/PricingResolver.swift
+++ b/Sources/VibeBarCore/Vendored/CostUsage/PricingResolver.swift
@@ -41,6 +41,25 @@ public enum PricingResolver {
         return resolved
     }
 
+    /// Stable content identity for the complete active pricing table.
+    ///
+    /// The usage ledger persists costs, not just tokens. A session file can
+    /// therefore be byte-identical while its correct cost changes after a
+    /// catalog refresh or local override. The ledger records this revision
+    /// and rebuilds its derived rows when it changes.
+    static var activeRevision: String {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        guard let data = try? encoder.encode(active) else {
+            let dataSet = active
+            return "pricing-v1-\(dataSet.schemaVersion)-\(dataSet.calculationVersion)-\(dataSet.updatedAt)"
+        }
+        return PrivacyPreservingHash.fileComponent(
+            prefix: "pricing-v1",
+            rawValue: String(decoding: data, as: UTF8.self)
+        )
+    }
+
     /// Test-friendly entry point. Production code path goes through
     /// `active` which uses the real home directory.
     public static func resolve(homeDirectory: String) -> PricingDataSet {

--- a/Sources/VibeBarCore/Vendored/CostUsage/PricingResolver.swift
+++ b/Sources/VibeBarCore/Vendored/CostUsage/PricingResolver.swift
@@ -46,18 +46,41 @@ public enum PricingResolver {
     /// The usage ledger persists costs, not just tokens. A session file can
     /// therefore be byte-identical while its correct cost changes after a
     /// catalog refresh or local override. The ledger records this revision
-    /// and rebuilds its derived rows when it changes.
+    /// and retries previously unpriced rows when it changes.
     static var activeRevision: String {
+        let dataSet = active
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.sortedKeys]
-        guard let data = try? encoder.encode(active) else {
-            let dataSet = active
-            return "pricing-v1-\(dataSet.schemaVersion)-\(dataSet.calculationVersion)-\(dataSet.updatedAt)"
+        guard let encoded = try? encoder.encode(dataSet),
+              let object = try? JSONSerialization.jsonObject(with: encoded),
+              let data = try? JSONSerialization.data(
+                  withJSONObject: costRevisionObject(object),
+                  options: [.sortedKeys]
+              )
+        else {
+            return "pricing-v1-\(dataSet.schemaVersion)-\(dataSet.calculationVersion)"
         }
         return PrivacyPreservingHash.fileComponent(
             prefix: "pricing-v1",
             rawValue: String(decoding: data, as: UTF8.self)
         )
+    }
+
+    /// Strip catalog presentation/freshness metadata that cannot change a
+    /// request's cost. A daily `updatedAt` refresh or a display-label edit
+    /// must not make the ledger revisit its historical unpriced rows.
+    private static func costRevisionObject(_ value: Any) -> Any {
+        if let dictionary = value as? [String: Any] {
+            let ignored = Set(["updatedAt", "displayName", "displayLabel"])
+            return dictionary.reduce(into: [String: Any]()) { result, entry in
+                guard !ignored.contains(entry.key) else { return }
+                result[entry.key] = costRevisionObject(entry.value)
+            }
+        }
+        if let array = value as? [Any] {
+            return array.map(costRevisionObject)
+        }
+        return value
     }
 
     /// Test-friendly entry point. Production code path goes through

--- a/Tests/VibeBarCoreTests/MultiSourcePricingTests.swift
+++ b/Tests/VibeBarCoreTests/MultiSourcePricingTests.swift
@@ -39,6 +39,12 @@ final class MultiSourcePricingTests: XCTestCase {
         )
         XCTAssertEqual(composer.input, 3e-6, accuracy: 1e-12)
         XCTAssertEqual(composer.output, 15e-6, accuracy: 1e-12)
+
+        let autoReview = try XCTUnwrap(
+            merged.providers.codex.models["codex-auto-review"]
+        )
+        XCTAssertEqual(autoReview.input, 2.5e-6, accuracy: 1e-12)
+        XCTAssertEqual(autoReview.output, 15e-6, accuracy: 1e-12)
     }
 
     func testModelsDevCarriesLongContextAndFastPricing() throws {
@@ -79,6 +85,14 @@ final class MultiSourcePricingTests: XCTestCase {
     func testPortkeyConvertsCentsPerTokenToDollarsPerToken() throws {
         let data = Data(#"""
         {
+          "codex-auto-review": {
+            "pricing_config": {
+              "pay_as_you_go": {
+                "request_token": {"price": 0.00025},
+                "response_token": {"price": 0.0015}
+              }
+            }
+          },
           "grok-4.6": {
             "pricing_config": {
               "pay_as_you_go": {
@@ -92,8 +106,12 @@ final class MultiSourcePricingTests: XCTestCase {
         """#.utf8)
 
         let set = try XCTUnwrap(PortkeyPricingTransformer.transform(
-            [.grok: data], updatedAt: "2026-08-14", calculationVersion: 1
+            [.codex: data, .grok: data], updatedAt: "2026-08-14", calculationVersion: 1
         ))
+        let autoReview = try XCTUnwrap(set.providers.codex.models["codex-auto-review"])
+        XCTAssertEqual(autoReview.input, 2.5e-6, accuracy: 1e-12)
+        XCTAssertEqual(autoReview.output, 15e-6, accuracy: 1e-12)
+
         let model = try XCTUnwrap(set.providers.grok.models["grok-4.6"])
         XCTAssertEqual(model.input, 2e-6, accuracy: 1e-12)
         XCTAssertEqual(model.output, 6e-6, accuracy: 1e-12)

--- a/Tests/VibeBarCoreTests/PricingResolverTests.swift
+++ b/Tests/VibeBarCoreTests/PricingResolverTests.swift
@@ -232,7 +232,12 @@ final class PricingResolverTests: XCTestCase {
         XCTAssertEqual(first, PricingResolver.activeRevision)
 
         PricingResolver.testOverride = hotReloadDataSet(
-            updatedAt: "2099-01-01", sentinelOutput: 0.0001
+            updatedAt: "2099-01-02", sentinelOutput: 0.00005
+        )
+        XCTAssertEqual(first, PricingResolver.activeRevision)
+
+        PricingResolver.testOverride = hotReloadDataSet(
+            updatedAt: "2099-01-02", sentinelOutput: 0.0001
         )
         XCTAssertNotEqual(first, PricingResolver.activeRevision)
     }

--- a/Tests/VibeBarCoreTests/PricingResolverTests.swift
+++ b/Tests/VibeBarCoreTests/PricingResolverTests.swift
@@ -222,6 +222,21 @@ final class PricingResolverTests: XCTestCase {
         XCTAssertEqual(PricingResolver.active.updatedAt, "2099-01-01")
     }
 
+    func testActiveRevisionChangesWithPricingContent() throws {
+        defer { PricingResolver.testOverride = nil }
+
+        PricingResolver.testOverride = hotReloadDataSet(
+            updatedAt: "2099-01-01", sentinelOutput: 0.00005
+        )
+        let first = PricingResolver.activeRevision
+        XCTAssertEqual(first, PricingResolver.activeRevision)
+
+        PricingResolver.testOverride = hotReloadDataSet(
+            updatedAt: "2099-01-01", sentinelOutput: 0.0001
+        )
+        XCTAssertNotEqual(first, PricingResolver.activeRevision)
+    }
+
     func testReloadIfChangedIsNoOpUnderTestOverride() throws {
         let home = try makeTempHome()
         PricingResolver.forgetCachedStateForTests()

--- a/Tests/VibeBarCoreTests/UsageEventLedgerTests.swift
+++ b/Tests/VibeBarCoreTests/UsageEventLedgerTests.swift
@@ -175,9 +175,10 @@ final class UsageEventLedgerTests: XCTestCase {
         let oldBatch = UsageLedgerFixtures.batch(
             tool: .grok,
             path: "/Users/example/.grok/sessions/session-a.jsonl",
-            events: [oldEvent, recentEvent].map {
-                UsageLedgerFixtures.priced($0, costUSD: nil)
-            }
+            events: [
+                UsageLedgerFixtures.priced(oldEvent, costUSD: nil),
+                UsageLedgerFixtures.priced(recentEvent, costUSD: 9.0)
+            ]
         )
         try await ledger.ingest(oldBatch)
         try await ledger.rollupAndPrune(now: now, detailDays: 30, retentionDays: 90)
@@ -185,8 +186,8 @@ final class UsageEventLedgerTests: XCTestCase {
         let filter = UsageLedgerFixtures.wideFilter(around: now)
         let before = try await ledger.summary(filter)
         XCTAssertEqual(before.requests, 2)
-        XCTAssertEqual(before.unpricedRequests, 2)
-        XCTAssertNil(before.costMicros)
+        XCTAssertEqual(before.unpricedRequests, 1)
+        XCTAssertEqual(before.costMicros, 9_000_000)
         let repeatedOldRevision = try await ledger.prepareForPricingRevision("pricing-old")
         XCTAssertFalse(repeatedOldRevision)
         let unchanged = try await ledger.summary(filter)
@@ -204,6 +205,59 @@ final class UsageEventLedgerTests: XCTestCase {
         XCTAssertEqual(detailPage.totalCount, 1)
         let modelStats = try await ledger.modelStats(filter)
         XCTAssertEqual(modelStats.first?.costMicros, 5_200_000)
+    }
+
+    func testPricingRevisionLeavesAmbiguousTieredAndFastRollupsUnpriced() async throws {
+        let (ledger, directory) = try UsageLedgerFixtures.makeLedger("LedgerAmbiguousRepricing")
+        defer { try? FileManager.default.removeItem(at: directory) }
+        defer { PricingResolver.testOverride = nil }
+
+        let base = PricingHardcoded.fallback
+        var codexModels = base.providers.codex.models
+        codexModels["tiered-test"] = .init(
+            input: 1e-6, output: 2e-6, cacheRead: nil,
+            thresholdTokens: 200_000,
+            inputAboveThreshold: 2e-6,
+            outputAboveThreshold: 4e-6
+        )
+        codexModels["fast-test"] = .init(
+            input: 1e-6, output: 2e-6, cacheRead: nil,
+            fastMultiplier: 2.0
+        )
+        PricingResolver.testOverride = PricingDataSet(
+            schemaVersion: base.schemaVersion,
+            updatedAt: "test-ambiguous-repricing",
+            calculationVersion: base.calculationVersion,
+            providers: .init(
+                codex: .init(displayName: "OpenAI", models: codexModels),
+                claude: base.providers.claude,
+                gemini: base.providers.gemini,
+                grok: base.providers.grok,
+                antigravity: base.providers.antigravity
+            )
+        )
+
+        for (index, model) in ["tiered-test", "fast-test"].enumerated() {
+            let event = UsageLedgerFixtures.event(
+                date: now.addingTimeInterval(-60 * 86_400),
+                model: model,
+                input: 150_000,
+                output: 10_000,
+                serviceTier: index == 1 ? "fast" : nil
+            )
+            try await ledger.ingest(UsageLedgerFixtures.batch(
+                path: "/Users/example/.codex/sessions/ambiguous-\(index).jsonl",
+                events: [UsageLedgerFixtures.priced(event, costUSD: nil)]
+            ))
+        }
+        try await ledger.rollupAndPrune(now: now, detailDays: 30, retentionDays: 90)
+
+        let prepared = try await ledger.prepareForPricingRevision("pricing-new")
+        XCTAssertTrue(prepared)
+        let summary = try await ledger.summary(UsageLedgerFixtures.wideFilter(around: now))
+        XCTAssertEqual(summary.requests, 2)
+        XCTAssertEqual(summary.unpricedRequests, 2)
+        XCTAssertNil(summary.costMicros)
     }
 
     /// `(messageId, requestId)` is the same billable request no matter how

--- a/Tests/VibeBarCoreTests/UsageEventLedgerTests.swift
+++ b/Tests/VibeBarCoreTests/UsageEventLedgerTests.swift
@@ -141,57 +141,69 @@ final class UsageEventLedgerTests: XCTestCase {
         XCTAssertEqual(afterChangedFingerprint, 3)
     }
 
-    func testPricingRevisionRebuildsUnpricedDetailAndRollups() async throws {
+    func testPricingRevisionRepricesWithoutDeletingDetailOrRollups() async throws {
         let (ledger, directory) = try UsageLedgerFixtures.makeLedger("LedgerRepricing")
         defer { try? FileManager.default.removeItem(at: directory) }
+        defer { PricingResolver.testOverride = nil }
+
+        let base = PricingHardcoded.fallback
+        var grokModels = base.providers.grok.models
+        grokModels["grok-4.6"] = .init(input: 2e-6, output: 6e-6, cacheRead: nil)
+        PricingResolver.testOverride = PricingDataSet(
+            schemaVersion: base.schemaVersion,
+            updatedAt: "test-repricing",
+            calculationVersion: base.calculationVersion,
+            providers: .init(
+                codex: base.providers.codex,
+                claude: base.providers.claude,
+                gemini: base.providers.gemini,
+                grok: .init(displayName: "xAI", models: grokModels),
+                antigravity: base.providers.antigravity
+            )
+        )
 
         let preparedOldRevision = try await ledger.prepareForPricingRevision("pricing-old")
         XCTAssertTrue(preparedOldRevision)
         let oldEvent = UsageLedgerFixtures.event(
-            date: now.addingTimeInterval(-60 * 86_400),
-            model: "grok-4.6",
-            input: 1_000_000,
-            output: 100_000
+            date: now.addingTimeInterval(-60 * 86_400), model: "grok-4.6",
+            input: 1_000_000, output: 100_000
+        )
+        let recentEvent = UsageLedgerFixtures.event(
+            date: now.addingTimeInterval(-5 * 86_400), model: "grok-4.6",
+            input: 1_000_000, output: 100_000
         )
         let oldBatch = UsageLedgerFixtures.batch(
             tool: .grok,
             path: "/Users/example/.grok/sessions/session-a.jsonl",
-            events: [UsageLedgerFixtures.priced(oldEvent, costUSD: nil)]
+            events: [oldEvent, recentEvent].map {
+                UsageLedgerFixtures.priced($0, costUSD: nil)
+            }
         )
         try await ledger.ingest(oldBatch)
         try await ledger.rollupAndPrune(now: now, detailDays: 30, retentionDays: 90)
 
         let filter = UsageLedgerFixtures.wideFilter(around: now)
         let before = try await ledger.summary(filter)
-        XCTAssertEqual(before.requests, 1)
-        XCTAssertEqual(before.unpricedRequests, 1)
+        XCTAssertEqual(before.requests, 2)
+        XCTAssertEqual(before.unpricedRequests, 2)
         XCTAssertNil(before.costMicros)
         let repeatedOldRevision = try await ledger.prepareForPricingRevision("pricing-old")
         XCTAssertFalse(repeatedOldRevision)
         let unchanged = try await ledger.summary(filter)
-        XCTAssertEqual(unchanged.requests, 1)
+        XCTAssertEqual(unchanged.requests, 2)
 
         let preparedNewRevision = try await ledger.prepareForPricingRevision("pricing-new")
         XCTAssertTrue(preparedNewRevision)
-        let emptied = try await ledger.summary(filter)
-        XCTAssertEqual(emptied.requests, 0)
+        let repriced = try await ledger.summary(filter)
+        XCTAssertEqual(repriced.requests, 2)
+        XCTAssertEqual(repriced.unpricedRequests, 0)
+        XCTAssertEqual(repriced.costMicros, 5_200_000)
         let detailFloor = try await ledger.detailFloorDay(for: .grok)
-        XCTAssertNil(detailFloor)
-
-        let repriced = UsageEventFileBatch(
-            tool: oldBatch.tool,
-            filePath: oldBatch.filePath,
-            mtime: oldBatch.mtime,
-            size: oldBatch.size,
-            events: [UsageLedgerFixtures.priced(oldEvent, costUSD: 2.60)]
-        )
-        try await ledger.ingest(repriced)
-        let after = try await ledger.summary(filter)
-        XCTAssertEqual(after.requests, 1)
-        XCTAssertEqual(after.unpricedRequests, 0)
-        XCTAssertEqual(after.costMicros, 2_600_000)
+        XCTAssertNotNil(detailFloor)
+        let detailPage = try await ledger.requestPage(filter, page: 0, pageSize: 10)
+        XCTAssertEqual(detailPage.totalCount, 1)
         let modelStats = try await ledger.modelStats(filter)
-        XCTAssertEqual(modelStats.first?.costMicros, 2_600_000)
+        XCTAssertEqual(modelStats.first?.costMicros, 5_200_000)
     }
 
     /// `(messageId, requestId)` is the same billable request no matter how

--- a/Tests/VibeBarCoreTests/UsageEventLedgerTests.swift
+++ b/Tests/VibeBarCoreTests/UsageEventLedgerTests.swift
@@ -141,6 +141,59 @@ final class UsageEventLedgerTests: XCTestCase {
         XCTAssertEqual(afterChangedFingerprint, 3)
     }
 
+    func testPricingRevisionRebuildsUnpricedDetailAndRollups() async throws {
+        let (ledger, directory) = try UsageLedgerFixtures.makeLedger("LedgerRepricing")
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let preparedOldRevision = try await ledger.prepareForPricingRevision("pricing-old")
+        XCTAssertTrue(preparedOldRevision)
+        let oldEvent = UsageLedgerFixtures.event(
+            date: now.addingTimeInterval(-60 * 86_400),
+            model: "grok-4.6",
+            input: 1_000_000,
+            output: 100_000
+        )
+        let oldBatch = UsageLedgerFixtures.batch(
+            tool: .grok,
+            path: "/Users/example/.grok/sessions/session-a.jsonl",
+            events: [UsageLedgerFixtures.priced(oldEvent, costUSD: nil)]
+        )
+        try await ledger.ingest(oldBatch)
+        try await ledger.rollupAndPrune(now: now, detailDays: 30, retentionDays: 90)
+
+        let filter = UsageLedgerFixtures.wideFilter(around: now)
+        let before = try await ledger.summary(filter)
+        XCTAssertEqual(before.requests, 1)
+        XCTAssertEqual(before.unpricedRequests, 1)
+        XCTAssertNil(before.costMicros)
+        let repeatedOldRevision = try await ledger.prepareForPricingRevision("pricing-old")
+        XCTAssertFalse(repeatedOldRevision)
+        let unchanged = try await ledger.summary(filter)
+        XCTAssertEqual(unchanged.requests, 1)
+
+        let preparedNewRevision = try await ledger.prepareForPricingRevision("pricing-new")
+        XCTAssertTrue(preparedNewRevision)
+        let emptied = try await ledger.summary(filter)
+        XCTAssertEqual(emptied.requests, 0)
+        let detailFloor = try await ledger.detailFloorDay(for: .grok)
+        XCTAssertNil(detailFloor)
+
+        let repriced = UsageEventFileBatch(
+            tool: oldBatch.tool,
+            filePath: oldBatch.filePath,
+            mtime: oldBatch.mtime,
+            size: oldBatch.size,
+            events: [UsageLedgerFixtures.priced(oldEvent, costUSD: 2.60)]
+        )
+        try await ledger.ingest(repriced)
+        let after = try await ledger.summary(filter)
+        XCTAssertEqual(after.requests, 1)
+        XCTAssertEqual(after.unpricedRequests, 0)
+        XCTAssertEqual(after.costMicros, 2_600_000)
+        let modelStats = try await ledger.modelStats(filter)
+        XCTAssertEqual(modelStats.first?.costMicros, 2_600_000)
+    }
+
     /// `(messageId, requestId)` is the same billable request no matter how
     /// many transcripts copied it. The parent, non-sidechain copy must win
     /// regardless of which file the scan reached first.


### PR DESCRIPTION
## Summary
- import codex-auto-review pricing from Portkey at 2.50 USD/M input and 15 USD/M output
- fingerprint the effective merged pricing table and rebuild derived Workbench usage rows when it changes
- cover detail rows, daily rollups, source conversion, and live four-source merging with regression tests

## Test plan
- [x] git diff --check
- [x] swift build
- [x] swift test (1,443 tests; 1 skipped; 0 failures)
- [x] live four-source pricing refresh test
- [x] ./Scripts/build_app.sh release
- [x] codesign --verify --deep --strict .build/Vibe Bar.app
- [x] verified empty entitlements