### PR TITLE
Prepare Vibe Bar 1.3.0 Dev build 28

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.3.0</string>
 	<key>CFBundleVersion</key>
-	<string>27</string>
+	<string>28</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>26.0</string>
 	<key>LSUIElement</key>


### PR DESCRIPTION
## Summary
- bump CFBundleVersion from 27 to 28
- keep CFBundleShortVersionString at 1.3.0

## Test plan
- [x] swift build
- [x] swift test (1,444 tests, 0 failures, 1 skipped)
- [x] ./Scripts/build_app.sh release
- [x] codesign --verify --deep --strict
- [x] confirm empty entitlements, arm64 binary, build 28, and bundled pricing.json