### PR TITLE
Integrate Cursor quotas into Grok

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,12 +134,12 @@ visibility and ordering from one two-column settings window.
 
 ## What Vibe Bar Reads
 
-| Surface | Quota and status | Local cost and activity |
+| Surface | Quota and status | Cost and activity sources |
 | --- | --- | --- |
 | ChatGPT / Codex | Codex subscription windows, Spark, OpenAI status | `~/.codex/sessions/**/*.jsonl` |
 | Claude Code | 5 Hours, Weekly, Fable, Anthropic status | `~/.claude/projects/**/*.jsonl` |
 | Gemini + AntiGravity | Gemini Web quotas and local AntiGravity language-server quotas | Local Gemini/AntiGravity usage records |
-| Grok | Grok subscription quota and xAI status | Local Grok Build usage records |
+| Grok + Cursor Agent | Grok Build quota, Cursor Models, Other Models, Grok Bot weekly quota, xAI status | Local Grok Build records + Cursor account usage events; Grok Bot is quota-only |
 | Misc providers | Provider-specific coding/token plan endpoints | Quota-only unless an adapter exposes local usage |
 
 Provider contracts can change without notice. Vibe Bar keeps refresh errors

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -125,12 +125,12 @@ OpenCode Go、Ollama Cloud、智谱 GLM、小米 MiMo、Kimi、MiniMax、阿里�
 
 ## Vibe Bar 会读取什么
 
-| 页面 | 配额与状态 | 本地成本与活动 |
+| 页面 | 配额与状态 | 成本与活动来源 |
 | --- | --- | --- |
 | ChatGPT / Codex | Codex 订阅窗口、Spark、OpenAI 状态 | `~/.codex/sessions/**/*.jsonl` |
 | Claude Code | 5 Hours、Weekly、Fable、Anthropic 状态 | `~/.claude/projects/**/*.jsonl` |
 | Gemini + AntiGravity | Gemini Web 配额与本地 AntiGravity Language Server 配额 | 本地 Gemini/AntiGravity 用量记录 |
-| Grok | Grok 订阅额度与 xAI 状态 | 本地 Grok Build 用量记录 |
+| Grok + Cursor Agent | Grok Build 配额、Cursor Models、Other Models、Grok Bot 周配额、xAI 状态 | 本地 Grok Build 记录 + Cursor 账户用量事件；Grok Bot 仅显示配额 |
 | Misc Providers | 各服务商自己的 Coding/Token Plan 接口 | 除非 Adapter 能取得本地用量，否则仅显示额度 |
 
 服务商的私有接口随时可能变化。Vibe Bar 会明确显示刷新错误，保留上一次成功

--- a/Sources/VibeBarApp/MiniQuotaWindowController.swift
+++ b/Sources/VibeBarApp/MiniQuotaWindowController.swift
@@ -230,6 +230,8 @@ final class MiniQuotaWindowController: NSObject, NSWindowDelegate {
             return "claude.fable"
         case "weekly_oauth_apps":
             return "claude.oauth"
+        case "grok_bot_weekly" where tool == .cursor:
+            return "cursor.grok-bot"
         default:
             break
         }
@@ -293,7 +295,8 @@ final class MiniQuotaWindowController: NSObject, NSWindowDelegate {
 
         // Sizing now mirrors the L2-grouped layout in
         // `MiniWindowProviderLayout`: consecutive tools sharing the
-        // same L2 productName (Gemini Web + AntiGravity → "Gemini")
+        // same L2 productName (Gemini Web + AntiGravity → "Gemini",
+        // Grok Build + Cursor Agent → "Grok")
         // share one provider column with an internal divider between
         // L3 sub-tools. Group dividers come from the actual primary +
         // branch-group count derived from selected bucket ids; the

--- a/Sources/VibeBarApp/ProviderBrandIcon.swift
+++ b/Sources/VibeBarApp/ProviderBrandIcon.swift
@@ -368,7 +368,7 @@ extension ToolType {
 
     var providerIconDrawScale: CGFloat {
         switch self {
-        // All five primary tools render at the same overshoot scale.
+        // All dedicated and linked tools render at the same overshoot scale.
         // The previous 1.0 for codex/claude let the SVG paths reach
         // the canvas edge — the anti-aliased boundary that produced
         // read as a "细线" (thin line / halo) around the glyph, while

--- a/Sources/VibeBarApp/StatusItemController.swift
+++ b/Sources/VibeBarApp/StatusItemController.swift
@@ -531,7 +531,7 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
                     ]
                 ))
             }
-            let percent = bucket.displayPercent(settings.displayMode)
+            let percent = bucket.displayPercent(settings.displayMode, tool: field.tool)
             let label = label(for: field, bucket: bucket, itemSettings: itemSettings)
             attributed.append(menuPiece(
                 label: label,
@@ -572,7 +572,7 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
                 let field = MenuBarFieldCatalog.field(id: fieldId),
                 let bucket = environment.quota(for: field.tool)?.bucket(id: field.bucketId)
             else { return nil }
-            let percent = bucket.displayPercent(settings.displayMode)
+            let percent = bucket.displayPercent(settings.displayMode, tool: field.tool)
             return menuTextPiece(
                 label: label(for: field, bucket: bucket, itemSettings: itemSettings),
                 percent: percent,
@@ -643,7 +643,7 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
                 let field = MenuBarFieldCatalog.field(id: fieldId),
                 let bucket = environment.quota(for: field.tool)?.bucket(id: field.bucketId)
             else { return nil }
-            let percent = bucket.displayPercent(settings.displayMode)
+            let percent = bucket.displayPercent(settings.displayMode, tool: field.tool)
             return menuTextPiece(
                 label: label(for: field, bucket: bucket, itemSettings: itemSettings),
                 percent: percent,
@@ -846,7 +846,7 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
             for: MenuBarPercentColor.resolve(
                 basis: basis,
                 verdict: verdict,
-                percent: bucket.displayPercent(settings.displayMode),
+                percent: bucket.displayPercent(settings.displayMode, tool: field.tool),
                 displayMode: settings.displayMode
             )
         )

--- a/Sources/VibeBarApp/Views/MiniQuotaWindowView.swift
+++ b/Sources/VibeBarApp/Views/MiniQuotaWindowView.swift
@@ -549,9 +549,9 @@ private func miniPrimaryGroupTitle(
 }
 
 /// Renders one L2 product super-column in the regular (ring) layout.
-/// Single-tool groups (ChatGPT / Claude / Grok) get a compact L2
-/// header + bucket rings. Multi-tool groups (Gemini = Gemini Web +
-/// AntiGravity) get the L2 header on top, each L3 tool as a
+/// Single-tool groups (ChatGPT / Claude) get a compact L2 header + bucket
+/// rings. Multi-tool groups (Gemini = Gemini Web + AntiGravity; Grok = Grok
+/// Build + Cursor Agent) get the L2 header on top, each L3 tool as a
 /// sub-section beneath with its own small toolName sub-label,
 /// separated by a thin divider.
 private struct MiniL2GroupColumn: View {
@@ -751,7 +751,7 @@ private struct MiniBranchRingCell: View {
             quotaService: quotaService,
             now: now
         )
-        let percent = cell.bucket.displayPercent(settingsStore.displayMode)
+        let percent = cell.bucket.displayPercent(settingsStore.displayMode, tool: cell.tool)
         let color = Theme.barColor(percent: percent, mode: settingsStore.displayMode)
         VStack(spacing: 3) {
             let expected: Double? = forecast.map { miniForecastPlan($0, mode: settingsStore.displayMode) } ?? pace.map { p in
@@ -950,7 +950,7 @@ private struct MiniRingCell: View {
     @ViewBuilder
     private func ringGauge(pace: UsagePace?, forecast: QuotaPaceForecast?, now: Date) -> some View {
         if let bucket = cell.bucket {
-            let percent = bucket.displayPercent(settingsStore.displayMode)
+            let percent = bucket.displayPercent(settingsStore.displayMode, tool: cell.tool)
             let expected: Double? = forecast.map { miniForecastPlan($0, mode: settingsStore.displayMode) } ?? pace.map { p in
                 switch settingsStore.displayMode {
                 case .used:      return p.expectedUsedPercent
@@ -1222,14 +1222,19 @@ private struct MiniCompactBarCell: View {
                 now: now
             )
         }
-        let percent = data.bucket?.displayPercent(settingsStore.displayMode) ?? 0
+        let percent = data.bucket?.displayPercent(settingsStore.displayMode, tool: data.tool) ?? 0
         let expected: Double? = forecast.map { miniForecastPlan($0, mode: settingsStore.displayMode) } ?? pace.map { p in
             switch settingsStore.displayMode {
             case .used:      return p.expectedUsedPercent
             case .remaining: return 100 - p.expectedUsedPercent
             }
         }
-        let color = data.bucket.map { Theme.barColor(percent: $0.displayPercent(settingsStore.displayMode), mode: settingsStore.displayMode) }
+        let color = data.bucket.map {
+            Theme.barColor(
+                percent: $0.displayPercent(settingsStore.displayMode, tool: data.tool),
+                mode: settingsStore.displayMode
+            )
+        }
             ?? .secondary.opacity(0.45)
 
         VStack(spacing: 1.5) {

--- a/Sources/VibeBarApp/Views/PageModuleCatalog.swift
+++ b/Sources/VibeBarApp/Views/PageModuleCatalog.swift
@@ -408,6 +408,13 @@ enum PageModuleCatalog {
                 additional = (environment.quotaService.cachedQuota(for: antigravity.id)?.buckets ?? [])
                     .map { FillTimelineSeries(tool: .antigravity, accountId: antigravity.id, bucket: $0) }
             }
+        } else if tool == .grok {
+            accountId = environment.account(for: .grok)?.id
+            buckets = environment.quota(for: .grok)?.buckets ?? []
+            if let cursor = environment.account(for: .cursor) {
+                additional = (environment.quotaService.cachedQuota(for: cursor.id)?.buckets ?? [])
+                    .map { FillTimelineSeries(tool: .cursor, accountId: cursor.id, bucket: $0) }
+            }
         } else {
             accountId = environment.account(for: tool)?.id
             buckets = environment.quota(for: tool)?.buckets ?? []
@@ -424,7 +431,11 @@ enum PageModuleCatalog {
 
     /// Tools whose refresh button the provider-header quota card pumps.
     static func quotaRefreshTools(for tool: ToolType) -> [ToolType] {
-        tool == .gemini ? ToolType.googleAIPair : [tool]
+        switch tool {
+        case .gemini: ToolType.googleAIPair
+        case .grok: ToolType.grokFamily
+        default: [tool]
+        }
     }
 
     /// Cost snapshot behind a provider page. Gemini's page shows the combined
@@ -434,8 +445,14 @@ enum PageModuleCatalog {
         tool: ToolType,
         environment: AppEnvironment
     ) -> CostSnapshot? {
-        guard tool == .gemini else { return environment.costService.snapshot(for: tool) }
-        return googleAICostSnapshot(environment: environment)
+        switch tool {
+        case .gemini:
+            return googleAICostSnapshot(environment: environment)
+        case .grok:
+            return grokCostSnapshot(environment: environment)
+        default:
+            return environment.costService.snapshot(for: tool)
+        }
     }
 
     /// Combined Gemini + AntiGravity cost, surfaced as the single "Gemini"
@@ -450,6 +467,15 @@ enum PageModuleCatalog {
         environment.costService.combinedSnapshot(
             of: ToolType.googleAIPair,
             labelledAs: .antigravity
+        )
+    }
+
+    /// Combined Grok Build local sessions + Cursor Agent dashboard events.
+    @MainActor
+    static func grokCostSnapshot(environment: AppEnvironment) -> CostSnapshot {
+        environment.costService.combinedSnapshot(
+            of: ToolType.grokFamily,
+            labelledAs: .grok
         )
     }
 
@@ -477,14 +503,16 @@ enum PageModuleCatalog {
         environment: AppEnvironment,
         settings: AppSettings
     ) -> CostRollup {
-        environment.costService.rollup(
-            individualTools: overviewCostProviders(settings: settings),
-            // The Gemini group is labelled `.antigravity` for the same reason
-            // `googleAICostSnapshot` is: AntiGravity is the live Google usage
-            // source, and both call sites must land on the same cached snapshot.
-            groups: settings.isCoreProviderVisible(.gemini)
-                ? [CostSnapshotGroup(label: .antigravity, tools: ToolType.googleAIPair)]
-                : [],
+        var groups: [CostSnapshotGroup] = []
+        if settings.isCoreProviderVisible(.gemini) {
+            groups.append(CostSnapshotGroup(label: .antigravity, tools: ToolType.googleAIPair))
+        }
+        if settings.isCoreProviderVisible(.grok) {
+            groups.append(CostSnapshotGroup(label: .grok, tools: ToolType.grokFamily))
+        }
+        return environment.costService.rollup(
+            individualTools: overviewCostProviders(settings: settings).filter { $0 != .grok },
+            groups: groups,
             labelledAs: .codex
         )
     }
@@ -500,6 +528,9 @@ enum PageModuleCatalog {
         var tools = overviewCostProviders(settings: settings)
         if settings.isCoreProviderVisible(.gemini) {
             tools.append(contentsOf: ToolType.googleAIPair)
+        }
+        if settings.isCoreProviderVisible(.grok) {
+            tools.append(.cursor)
         }
         return environment.costService.hasJSONLFiles(in: tools)
     }

--- a/Sources/VibeBarApp/Views/PopoverRoot.swift
+++ b/Sources/VibeBarApp/Views/PopoverRoot.swift
@@ -126,8 +126,8 @@ struct PopoverRoot: View {
         // Header timestamps and refresh state aggregate the providers
         // visible in the current popover. The Misc subpage owns its
         // usage-only integrations; the Google AI subpage aggregates the
-        // linked partial-primary tools; the Grok page resolves Cursor through
-        // its own product-family helper instead of adding a separate tab.
+        // linked partial-primary tools; the Grok page aggregates its family
+        // without adding a separate Cursor tab.
         if overviewPage == .misc {
             return settingsStore.settings.visibleMiscProviderList
         }
@@ -135,7 +135,7 @@ struct PopoverRoot: View {
             return ToolType.googleAIPair
         }
         if overviewPage == .grok {
-            return [.grok]
+            return ToolType.grokFamily
         }
         if overviewPage == .machines {
             return []
@@ -146,7 +146,7 @@ struct PopoverRoot: View {
         case .openAI: return [.codex]
         case .claude: return [.claude]
         case .googleAI: return ToolType.googleAIPair
-        case .grok: return [.grok]
+        case .grok: return ToolType.grokFamily
         case .misc: return settingsStore.settings.visibleMiscProviderList
         case .machines: return []
         }

--- a/Sources/VibeBarApp/Views/PopoverRoot.swift
+++ b/Sources/VibeBarApp/Views/PopoverRoot.swift
@@ -116,7 +116,7 @@ struct PopoverRoot: View {
         case .openAI: return ToolType.codex.subtitle
         case .claude: return ToolType.claude.subtitle
         case .googleAI: return "Gemini Web + AntiGravity · quota & status"
-        case .grok: return "xAI · monthly credits, cost & status"
+        case .grok: return "xAI · Grok Build, Cursor Agent, cost & status"
         case .misc: return "Usage-only · sign in or paste a key"
         case .machines: return "End-to-end encrypted remote usage"
         }
@@ -126,7 +126,8 @@ struct PopoverRoot: View {
         // Header timestamps and refresh state aggregate the providers
         // visible in the current popover. The Misc subpage owns its
         // usage-only integrations; the Google AI subpage aggregates the
-        // partial-primary pair; the Grok subpage shows just `.grok`.
+        // linked partial-primary tools; the Grok page resolves Cursor through
+        // its own product-family helper instead of adding a separate tab.
         if overviewPage == .misc {
             return settingsStore.settings.visibleMiscProviderList
         }
@@ -439,10 +440,15 @@ private struct OverviewWaterfall: View {
             heatmap: rollup.heatmap,
             models: rollup.modelBreakdowns,
             combinedSnapshot: rollup.combinedSnapshot,
-            // Present exactly when the Gemini card is: the rollup only carries
-            // the group when the provider is visible, and the module that reads
-            // this exists under the same condition.
-            googleAISnapshot: rollup.groupSnapshots.first ?? .empty(tool: .antigravity)
+            // Product-family snapshots are requested only when their matching
+            // Overview modules are visible; the aggregation cache makes these
+            // reads share the rollup's already-computed inputs.
+            googleAISnapshot: settings.isCoreProviderVisible(.gemini)
+                ? PageModuleCatalog.googleAICostSnapshot(environment: environment)
+                : .empty(tool: .antigravity),
+            grokSnapshot: settings.isCoreProviderVisible(.grok)
+                ? PageModuleCatalog.grokCostSnapshot(environment: environment)
+                : .empty(tool: .grok)
         )
 
         // `auto` is the only mode the balancer runs in. `compact` and `manual`
@@ -543,6 +549,8 @@ private struct OverviewWaterfall: View {
             if tool == .gemini {
                 // Gemini Web and AntiGravity roll up to one Google AI product.
                 GeminiCombinedCard(density: density)
+            } else if tool == .grok {
+                GrokCombinedCard(density: density)
             } else {
                 ProviderQuotaCard(tool: tool, density: density, compact: false)
             }
@@ -576,6 +584,16 @@ private struct OverviewWaterfall: View {
                     emptyMessageOverride: "No Gemini / AntiGravity usage yet — open AntiGravity once so Vibe Bar can sync it.",
                     toolNameOverride: "Gemini",
                     heatmapTitleOverride: "When you use Gemini"
+                )
+            } else if tool == .grok {
+                OverviewCostCard(
+                    tool: .grok,
+                    density: density,
+                    snapshotOverride: context.grokSnapshot,
+                    titleOverride: "Grok Cost",
+                    emptyMessageOverride: "No Grok Build or Cursor Agent usage found yet.",
+                    toolNameOverride: "Grok",
+                    heatmapTitleOverride: "When you use Grok"
                 )
             } else {
                 OverviewCostCard(tool: tool, density: density)
@@ -616,6 +634,7 @@ private struct OverviewModuleContext {
     let models: [CostSnapshot.ModelBreakdown]
     let combinedSnapshot: CostSnapshot
     let googleAISnapshot: CostSnapshot
+    let grokSnapshot: CostSnapshot
 }
 
 private struct GrokPage: View {
@@ -772,6 +791,108 @@ private struct GeminiCombinedCard: View {
         )
         let trimmed = label?.trimmingCharacters(in: .whitespacesAndNewlines)
         return (trimmed?.isEmpty == false) ? trimmed : nil
+    }
+}
+
+/// Overview card for the Grok product family. Grok Build remains the primary
+/// xAI surface; Cursor Agent contributes its Cursor Models / Other Models pools
+/// plus the cloud-only Grok Bot weekly quota as a linked L3 tool.
+private struct GrokCombinedCard: View {
+    let density: Theme.Density
+
+    @EnvironmentObject var environment: AppEnvironment
+    @EnvironmentObject var settingsStore: SettingsStore
+    @EnvironmentObject var quotaService: QuotaService
+
+    var body: some View {
+        let grokAccount = environment.account(for: .grok)
+        let cursorAccount = environment.account(for: .cursor)
+        let showsCursor = (cursorAccount.map { $0.source != .notConfigured } ?? false)
+            || cursorAccount.flatMap { quotaService.cachedQuota(for: $0.id) } != nil
+        let anyInFlight = [grokAccount, cursorAccount].compactMap { $0 }.contains {
+            quotaService.inFlightAccountIds.contains($0.id)
+        }
+        let grokBadge = planBadge(for: .grok, account: grokAccount)
+        let cursorBadge = planBadge(for: .cursor, account: cursorAccount)
+
+        VStack(alignment: .leading, spacing: density.cardSpacing) {
+            HStack(alignment: .center, spacing: 8) {
+                ProviderSectionTitle(
+                    tool: .grok,
+                    title: ToolType.grok.productName,
+                    subtitle: ToolType.grok.statusProviderName,
+                    titleFontSize: density.titleFontSize,
+                    subtitleFontSize: density.subtitleFontSize,
+                    iconSize: 16,
+                    badgeSize: 24
+                )
+                Spacer(minLength: 4)
+                if let grokBadge {
+                    PlanBadgeView(text: grokBadge, fontSize: max(9, density.subtitleFontSize - 1))
+                }
+                BorderlessIconButton(
+                    systemImage: "arrow.clockwise",
+                    help: "Refresh Grok Build + Cursor Agent"
+                ) {
+                    environment.refresh(.grok)
+                    environment.refresh(.cursor)
+                }
+                .disabled(anyInFlight)
+                if anyInFlight {
+                    ProgressView().controlSize(.small)
+                        .frame(width: 16, height: 16)
+                }
+            }
+
+            ProviderQuotaCard(
+                tool: .grok,
+                density: density,
+                compact: false,
+                embedded: true
+            )
+
+            if showsCursor {
+                HStack(alignment: .center, spacing: 6) {
+                    ToolBrandIconView(tool: .cursor, size: 13)
+                        .opacity(0.85)
+                    Text(ToolType.cursor.toolName)
+                        .font(.system(size: max(10, density.subtitleFontSize), weight: .semibold))
+                        .foregroundStyle(.secondary)
+                    Spacer(minLength: 4)
+                    if let cursorBadge {
+                        PlanBadgeView(text: cursorBadge, fontSize: max(8, density.subtitleFontSize - 2))
+                    }
+                }
+                .padding(.top, 4)
+
+                ProviderQuotaCard(
+                    tool: .cursor,
+                    density: density,
+                    compact: false,
+                    embedded: true
+                )
+            }
+        }
+        .padding(density.cardPadding)
+        .background(
+            RoundedRectangle(cornerRadius: density.cardCornerRadius, style: .continuous)
+                .fill(.background.tertiary.opacity(0.6))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: density.cardCornerRadius, style: .continuous)
+                .stroke(.separator.opacity(0.4), lineWidth: 0.5)
+        )
+    }
+
+    private func planBadge(for tool: ToolType, account: AccountIdentity?) -> String? {
+        let quotaPlan = account.flatMap { quotaService.cachedQuota(for: $0.id)?.plan }
+        let label = settingsStore.settings.planBadgeLabel(
+            for: tool,
+            quotaPlan: quotaPlan,
+            accountPlan: account?.plan
+        )
+        let trimmed = label?.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed?.isEmpty == false ? trimmed : nil
     }
 }
 
@@ -1603,6 +1724,12 @@ private struct ProviderPageModule: View {
         case .costEmpty:
             if context.pageTool == .gemini {
                 GeminiCostEmptyCard(density: density)
+            } else if context.pageTool == .grok {
+                Text("No Grok Build or Cursor Agent usage found yet.")
+                    .font(.system(size: density.subtitleFontSize))
+                    .foregroundStyle(.tertiary)
+                    .padding(.vertical, 24)
+                    .frame(maxWidth: .infinity)
             } else {
                 Text("No \(context.pageTool.menuTitle) CLI sessions found yet.")
                     .font(.system(size: density.subtitleFontSize))
@@ -1910,7 +2037,9 @@ struct ProviderQuotaCard: View {
         switch tool {
         case .codex:  return "Run codex login, then refresh."
         case .claude: return "Run claude login, then refresh."
-        case .alibaba, .alibabaTokenPlan, .gemini, .antigravity, .grok, .copilot, .zai, .minimax, .kimi, .cursor, .mimo, .iflytek, .tencentHunyuan, .tencentTokenPlan, .volcengine, .volcengineAgentPlan, .baiduQianfan, .openCodeGo, .kilo, .kiro, .ollama, .openRouter, .warp:
+        case .grok: return "Run grok login or import grok.com cookies, then refresh."
+        case .cursor: return "Sign in to Cursor.app or import cursor.com cookies, then refresh."
+        case .alibaba, .alibabaTokenPlan, .gemini, .antigravity, .copilot, .zai, .minimax, .kimi, .mimo, .iflytek, .tencentHunyuan, .tencentTokenPlan, .volcengine, .volcengineAgentPlan, .baiduQianfan, .openCodeGo, .kilo, .kiro, .ollama, .openRouter, .warp:
             // Misc providers route through the Misc page's per-card
             // setup CTA. This empty-message path is only reachable from
             // a primary-provider detail view, but cover misc cases
@@ -2006,7 +2135,7 @@ private struct ProviderBucketRow: View {
 
     @ViewBuilder
     private func content(now: Date) -> some View {
-        let percent = bucket.displayPercent(mode)
+        let percent = bucket.displayPercent(mode, tool: tool)
         let pace = UsagePace.compute(bucket: bucket, now: now)
         let forecast = paceForecast(now: now)
         let timePaceDisplayed = pace.map { expectedDisplay(for: $0, mode: mode) }

--- a/Sources/VibeBarApp/Views/QuotaGroupCard.swift
+++ b/Sources/VibeBarApp/Views/QuotaGroupCard.swift
@@ -364,7 +364,7 @@ struct QuotaGroupCard: View {
         let bucket = item.bucket
         let pace = UsagePace.compute(bucket: bucket, now: now)
         let forecast = paceForecast(for: item)
-        let used = bucket.usedPercent
+        let used = bucket.displayPercent(.used, tool: item.tool)
         let timeExpected = pace.map { displayedPercent(fromUsed: $0.expectedUsedPercent) }
         let forecastProjection = forecast.map {
             QuotaForecastBarProjection(
@@ -402,7 +402,7 @@ struct QuotaGroupCard: View {
                 forecastColor: forecast.map { QuotaForecastPalette.color(for: $0.verdict) }
             )
             Text(SubscriptionWindowProgress.summary(
-                usedPercent: bucket.usedPercent,
+                usedPercent: used,
                 resetAt: bucket.resetAt,
                 rawWindowSeconds: bucket.rawWindowSeconds,
                 displayMode: mode,

--- a/Sources/VibeBarApp/Views/SettingsView.swift
+++ b/Sources/VibeBarApp/Views/SettingsView.swift
@@ -470,10 +470,10 @@ struct SettingsView: View {
                             representative: .grok,
                             healthProviders: [.grok]
                         )
-                        coreProviderPlanBadgeRows(for: [.grok])
+                        coreProviderPlanBadgeRows(for: [.grok, .cursor])
                         Divider()
                             .padding(.vertical, 2)
-                        Text("Vibe Bar can read Grok usage from `~/.grok/auth.json` (preferred — written by `grok login`) or from a signed-in grok.com browser session. Either source is enough.")
+                        Text("Grok combines Grok Build with Cursor Agent. Grok Build reads `~/.grok/auth.json` or grok.com cookies; Cursor Agent reads Cursor.app first, then cursor.com cookie slots. Grok Bot contributes quota only — its cloud runs do not add token/cost rows.")
                             .font(.caption)
                             .foregroundStyle(.secondary)
 
@@ -517,6 +517,26 @@ struct SettingsView: View {
                             Text("Could not delete saved Grok cookies.")
                                 .font(.caption2).foregroundStyle(.orange)
                         }
+
+                        Divider()
+                            .padding(.vertical, 2)
+
+                        sourceSummary(label: "Cursor Agent source", value: "Cursor.app → Web")
+                        if environment.account(for: .cursor)?.source == .cliDetected {
+                            Label("Cursor.app signed-in session detected", systemImage: "checkmark.circle")
+                                .font(.caption2)
+                                .foregroundStyle(.green)
+                        } else {
+                            Label("No usable Cursor.app session — import cursor.com cookies below.",
+                                  systemImage: "exclamationmark.circle")
+                                .font(.caption2)
+                                .foregroundStyle(.secondary)
+                        }
+                        CookieSourceControls(
+                            tool: .cursor,
+                            instanceID: ToolType.cursor.rawValue,
+                            manualPrompt: "Paste cursor.com Cookie header (WorkosCursorSessionToken=...)"
+                        )
 
                         Divider()
                             .padding(.vertical, 2)
@@ -1244,6 +1264,7 @@ private struct MiniWindowFieldProviderSection {
         .init(tool: .claude,      title: ToolType.claude.productName,      fields: MenuBarFieldCatalog.claudeFields),
         .init(tool: .gemini,      title: ToolType.gemini.productName + " Web", fields: MenuBarFieldCatalog.geminiFields),
         .init(tool: .antigravity, title: ToolType.antigravity.toolName,    fields: MenuBarFieldCatalog.antigravityFields),
-        .init(tool: .grok,        title: ToolType.grok.productName,        fields: MenuBarFieldCatalog.grokFields)
+        .init(tool: .grok,        title: ToolType.grok.toolName,           fields: MenuBarFieldCatalog.grokFields),
+        .init(tool: .cursor,      title: ToolType.cursor.toolName,         fields: MenuBarFieldCatalog.cursorFields)
     ]
 }

--- a/Sources/VibeBarCore/Adapters/CursorQuotaAdapter.swift
+++ b/Sources/VibeBarCore/Adapters/CursorQuotaAdapter.swift
@@ -28,6 +28,7 @@ public struct CursorQuotaAdapter: QuotaAdapter {
 
     private let session: URLSession
     private let now: @Sendable () -> Date
+    private let resolutionPlanProvider: (@Sendable (AccountIdentity, Date) -> CursorSessionResolutionPlan)?
 
     public static let cookieSpec = MiscCookieResolver.Spec(
         tool: .cursor,
@@ -51,17 +52,38 @@ public struct CursorQuotaAdapter: QuotaAdapter {
     ) {
         self.session = session
         self.now = now
+        self.resolutionPlanProvider = nil
+    }
+
+    init(
+        session: URLSession,
+        now: @escaping @Sendable () -> Date,
+        resolutionPlanProvider: @escaping @Sendable (AccountIdentity, Date) -> CursorSessionResolutionPlan
+    ) {
+        self.session = session
+        self.now = now
+        self.resolutionPlanProvider = resolutionPlanProvider
     }
 
     public func fetch(for account: AccountIdentity) async throws -> AccountQuota {
-        let resolutions = CursorSessionResolver.resolutions(account: account, now: now())
-        guard !resolutions.isEmpty else { throw QuotaError.noCredential }
-
         let queriedAt = now()
+        let plan = resolutionPlanProvider?(account, queriedAt)
+            ?? CursorSessionResolver.plan(account: account, now: queriedAt)
+        guard !plan.isEmpty else { throw QuotaError.noCredential }
+
+        if let preferred = plan.preferred {
+            do {
+                return try await fetchOneSlot(preferred, account: account, queriedAt: queriedAt)
+            } catch let error as QuotaError {
+                guard error.isCredentialState, !plan.fallbacks.isEmpty else { throw error }
+            }
+        }
+
+        guard !plan.fallbacks.isEmpty else { throw QuotaError.noCredential }
         let results = await MiscCookieAutoImporter.shared.gatherSlotResults(
             spec: CursorQuotaAdapter.cookieSpec,
             account: account,
-            resolutions: resolutions
+            resolutions: plan.fallbacks
         ) { resolution in
             try await self.fetchOneSlot(resolution, account: account, queriedAt: queriedAt)
         }

--- a/Sources/VibeBarCore/Adapters/CursorQuotaAdapter.swift
+++ b/Sources/VibeBarCore/Adapters/CursorQuotaAdapter.swift
@@ -2,29 +2,22 @@ import Foundation
 
 /// Cursor (cursor.com) usage adapter.
 ///
-/// Cursor is web-only — there's no API key path. Auth flows through
-/// `MiscCookieResolver` against `cursor.com` / `cursor.sh`; the
-/// resolver hands us a browser-imported cookie header containing
-/// the session token (one of `WorkosCursorSessionToken`,
-/// `__Secure-next-auth.session-token`, `wos-session`, etc.).
+/// Automatic auth prefers Cursor.app's read-only local session, then falls
+/// back to the existing browser/manual cookie slots. Both paths resolve to a
+/// first-party cursor.com cookie; Vibe Bar never refreshes Cursor's token.
 ///
-/// Three endpoints in priority order:
+/// Four endpoints:
 ///
 /// 1. `GET /api/usage-summary` — Pro / Business / Enterprise / Free.
 /// 2. `GET /api/auth/me` — identity (email, plan).
-/// 3. `GET /api/usage?user=<id>` — fallback for legacy "request
+/// 3. `POST /api/dashboard/get-sand-usage-status` — Grok Bot weekly quota.
+/// 4. `GET /api/usage?user=<id>` — fallback for legacy "request
 ///    plan" accounts whose summary is partial.
 ///
 /// Output:
-/// - **Total** (primary) — combined percent across the precedence
-///   chain spelled out in `parseSummary`.
-/// - **Auto** (secondary) — `autoPercentUsed` if present.
-/// - **API** (tertiary) — `apiPercentUsed` if present.
-/// - **On-demand** (extra row) — `$used / $limit` rendered through
-///   `groupTitle` so the misc card surfaces it without polluting
-///   `~/.vibebar/cost_history.json`. `supportsTokenCost == false`
-///   for `.cursor`, so the global cost pipeline ignores it
-///   regardless.
+/// - **Cursor Models** — Cursor's first-party pool (Cursor Grok + Composer).
+/// - **Other Models** — named third-party models.
+/// - **Grok Bot / Weekly usage** — Cursor's cloud-only Bot allowance.
 ///
 /// Edge-case tests (`CursorParserEdgeCasesTests`) pin the four
 /// shapes the plan called out: Pro fractional percent (no `× 100`),
@@ -61,7 +54,7 @@ public struct CursorQuotaAdapter: QuotaAdapter {
     }
 
     public func fetch(for account: AccountIdentity) async throws -> AccountQuota {
-        let resolutions = MiscCookieResolver.resolveAll(for: CursorQuotaAdapter.cookieSpec, account: account)
+        let resolutions = CursorSessionResolver.resolutions(account: account, now: now())
         guard !resolutions.isEmpty else { throw QuotaError.noCredential }
 
         let queriedAt = now()
@@ -88,8 +81,11 @@ public struct CursorQuotaAdapter: QuotaAdapter {
         let summaryData = try await get(path: "/api/usage-summary", cookieHeader: resolution.header)
         let summary = try CursorResponseParser.decodeUsageSummary(data: summaryData)
 
-        let userInfoData = try? await get(path: "/api/auth/me", cookieHeader: resolution.header)
+        async let userInfoFetch = try? get(path: "/api/auth/me", cookieHeader: resolution.header)
+        async let grokBotFetch = try? post(path: "/api/dashboard/get-sand-usage-status", cookieHeader: resolution.header)
+        let userInfoData = await userInfoFetch
         let userInfo = userInfoData.flatMap(CursorResponseParser.decodeUserInfo)
+        let grokBotUsage = (await grokBotFetch).flatMap(CursorResponseParser.decodeGrokBotUsage)
 
         // Legacy request-plan fallback fires when usage-summary is
         // missing the plan block entirely. Codexbar gates the
@@ -104,6 +100,7 @@ public struct CursorQuotaAdapter: QuotaAdapter {
             summary: summary,
             userInfo: userInfo,
             requestUsage: requestUsage,
+            grokBotUsage: grokBotUsage,
             now: queriedAt
         )
 
@@ -149,6 +146,36 @@ public struct CursorQuotaAdapter: QuotaAdapter {
         return data
     }
 
+    private func post(path: String, cookieHeader: String) async throws -> Data {
+        var request = URLRequest(url: CursorQuotaAdapter.baseURL.appendingPathComponent(path))
+        request.httpMethod = "POST"
+        request.httpBody = Data("{}".utf8)
+        request.setValue(cookieHeader, forHTTPHeaderField: "Cookie")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("https://cursor.com", forHTTPHeaderField: "Origin")
+        request.setValue(
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Safari/537.36",
+            forHTTPHeaderField: "User-Agent"
+        )
+
+        let (data, response): (Data, URLResponse)
+        do {
+            (data, response) = try await session.data(for: request)
+        } catch {
+            throw QuotaError.network("Cursor network error: \(error.localizedDescription)")
+        }
+        guard let http = response as? HTTPURLResponse else {
+            throw QuotaError.network("Cursor: invalid response object")
+        }
+        guard http.statusCode == 200 else {
+            if http.statusCode == 401 || http.statusCode == 403 { throw QuotaError.needsLogin }
+            if http.statusCode == 429 { throw QuotaError.rateLimited }
+            throw QuotaError.network("Cursor \(path) returned HTTP \(http.statusCode).")
+        }
+        return data
+    }
+
     private func fetchRequestUsage(userId: String, cookieHeader: String) async throws -> CursorRequestUsage {
         var components = URLComponents(url: CursorQuotaAdapter.baseURL.appendingPathComponent("/api/usage"),
                                        resolvingAgainstBaseURL: false)!
@@ -181,6 +208,10 @@ enum CursorResponseParser {
         try? JSONDecoder().decode(CursorUserInfo.self, from: data)
     }
 
+    static func decodeGrokBotUsage(data: Data) -> CursorGrokBotUsage? {
+        try? JSONDecoder().decode(CursorGrokBotUsage.self, from: data)
+    }
+
     /// Parse the assembled response into bucket form. Pulled out to
     /// its own function so unit tests can drive every edge case
     /// without faking HTTP.
@@ -188,6 +219,7 @@ enum CursorResponseParser {
         summary: CursorUsageSummary,
         userInfo: CursorUserInfo?,
         requestUsage: CursorRequestUsage?,
+        grokBotUsage: CursorGrokBotUsage? = nil,
         now: Date
     ) -> Snapshot {
         let plan = summary.individualUsage?.plan
@@ -228,67 +260,61 @@ enum CursorResponseParser {
             return 0
         }()
 
-        var buckets: [QuotaBucket] = [
-            QuotaBucket(
-                id: "cursor.total",
-                title: "Total",
-                shortLabel: "Total",
-                usedPercent: totalPct,
-                resetAt: parseBillingCycleEnd(summary.billingCycleEnd),
-                rawWindowSeconds: nil
-            )
-        ]
+        let billingCycleStart = parseBillingCycleEnd(summary.billingCycleStart)
+        let billingCycleEnd = parseBillingCycleEnd(summary.billingCycleEnd)
+        let billingWindow = windowSeconds(start: billingCycleStart, end: billingCycleEnd)
+        var buckets: [QuotaBucket] = []
 
+        // Cursor renamed the old Auto/API lanes in August 2026. Preserve the
+        // wire fields for compatibility, but use the product's current labels.
         if let auto = autoPct {
             buckets.append(QuotaBucket(
-                id: "cursor.auto",
-                title: "Auto",
-                shortLabel: "Auto",
+                id: "models",
+                title: "Cursor Models",
+                shortLabel: "Cursor",
                 usedPercent: auto,
-                resetAt: parseBillingCycleEnd(summary.billingCycleEnd),
-                rawWindowSeconds: nil
+                resetAt: billingCycleEnd,
+                rawWindowSeconds: billingWindow
             ))
         }
         if let api = apiPct {
             buckets.append(QuotaBucket(
-                id: "cursor.api",
-                title: "API",
-                shortLabel: "API",
+                id: "other_models",
+                title: "Other Models",
+                shortLabel: "Other",
                 usedPercent: api,
-                resetAt: parseBillingCycleEnd(summary.billingCycleEnd),
-                rawWindowSeconds: nil
+                resetAt: billingCycleEnd,
+                rawWindowSeconds: billingWindow
             ))
         }
 
-        // On-demand budget. Surface as a regular bucket with the
-        // dollar amounts in `groupTitle` so the misc card can lift
-        // them as a discrete extra row. We deliberately don't fold
-        // on-demand spend into the global cost pipeline — the
-        // `tool.supportsTokenCost == false` short-circuit keeps it
-        // out of `cost_history.json`.
-        if let onDemand = summary.individualUsage?.onDemand,
-           let used = onDemand.used {
-            let usedDollars = Double(used) / 100.0
-            let label: String
-            let percent: Double
-            if let limit = onDemand.limit, limit > 0 {
-                let limitDollars = Double(limit) / 100.0
-                label = String(format: "On-demand: $%.2f / $%.2f", usedDollars, limitDollars)
-                percent = clampPercent(Double(used) / Double(limit) * 100)
-            } else {
-                label = String(format: "On-demand: $%.2f / unlimited", usedDollars)
-                percent = 0
-            }
-            var bucket = QuotaBucket(
-                id: "cursor.onDemand",
-                title: "On-demand",
-                shortLabel: "OD",
-                usedPercent: percent,
-                resetAt: nil,
-                rawWindowSeconds: nil
-            )
-            bucket.groupTitle = label
-            buckets.append(bucket)
+        // Older plan shapes expose one aggregate/request quota rather than the
+        // two modern pools. Keep that usage visible under Cursor Models.
+        if buckets.isEmpty {
+            buckets.append(QuotaBucket(
+                id: "models",
+                title: "Cursor Models",
+                shortLabel: "Cursor",
+                usedPercent: totalPct,
+                resetAt: billingCycleEnd,
+                rawWindowSeconds: billingWindow
+            ))
+        }
+
+        if let bot = grokBotUsage,
+           let percent = bot.usagePercent,
+           bot.hasNonZeroIncludedLimit != false {
+            let periodStart = parseBillingCycleEnd(bot.currentPeriodStart)
+            let resetAt = parseBillingCycleEnd(bot.nextResetTimestampUtc)
+            buckets.append(QuotaBucket(
+                id: "grok_bot_weekly",
+                title: "Weekly usage",
+                shortLabel: "Grok Bot",
+                usedPercent: clampPercent(percent),
+                resetAt: resetAt,
+                rawWindowSeconds: windowSeconds(start: periodStart, end: resetAt),
+                groupTitle: "Grok Bot"
+            ))
         }
 
         let planName = displayPlanName(
@@ -315,6 +341,11 @@ enum CursorResponseParser {
         let plain = ISO8601DateFormatter()
         plain.formatOptions = [.withInternetDateTime]
         return plain.date(from: raw)
+    }
+
+    private static func windowSeconds(start: Date?, end: Date?) -> Int? {
+        guard let start, let end, end > start else { return nil }
+        return Int(end.timeIntervalSince(start).rounded())
     }
 
     private static func displayPlanName(
@@ -344,6 +375,7 @@ public struct CursorUsageSummary: Decodable, Sendable {
     public let individualUsage: CursorIndividualUsage?
     public let teamUsage: CursorTeamUsage?
     public let membershipType: String?
+    public let billingCycleStart: String?
     public let billingCycleEnd: String?
 }
 
@@ -375,6 +407,15 @@ public struct CursorUserInfo: Decodable, Sendable {
     public let email: String?
     public let id: String?
     public let sub: String?
+}
+
+public struct CursorGrokBotUsage: Decodable, Sendable, Equatable {
+    public let currentPeriodStart: String?
+    public let nextResetTimestampUtc: String?
+    public let usagePercent: Double?
+    public let includedLimitZero: Bool?
+    public let hasAvailableUsage: Bool?
+    public let hasNonZeroIncludedLimit: Bool?
 }
 
 public struct CursorRequestUsage: Decodable, Sendable {

--- a/Sources/VibeBarCore/Adapters/CursorSessionResolver.swift
+++ b/Sources/VibeBarCore/Adapters/CursorSessionResolver.swift
@@ -1,5 +1,12 @@
 import Foundation
 
+struct CursorSessionResolutionPlan: Sendable {
+    let preferred: MiscCookieResolver.Resolution?
+    let fallbacks: [MiscCookieResolver.Resolution]
+
+    var isEmpty: Bool { preferred == nil && fallbacks.isEmpty }
+}
+
 /// Resolves one Cursor account without mixing identities.
 ///
 /// Automatic mode prefers Cursor.app's active session. Browser/manual cookie
@@ -9,29 +16,34 @@ import Foundation
 enum CursorSessionResolver {
     static let stableAccountID = AccountStore.miscAccountId(for: .cursor)
 
-    static func resolutions(
+    static func plan(
         account: AccountIdentity? = nil,
         homeDirectory: String = RealHomeDirectory.path,
         now: Date = Date()
-    ) -> [MiscCookieResolver.Resolution] {
-        if let session = try? CursorAppAuthStore(homeDirectory: homeDirectory).loadSession(now: now),
-           let header = try? session.cookieHeader() {
-            return [
-                MiscCookieResolver.Resolution(
-                    slotID: nil,
-                    header: header,
-                    sourceLabel: "Cursor.app"
-                )
-            ]
+    ) -> CursorSessionResolutionPlan {
+        let fallbacks: [MiscCookieResolver.Resolution]
+        if let account {
+            fallbacks = MiscCookieResolver.resolveAll(for: CursorQuotaAdapter.cookieSpec, account: account)
+        } else {
+            fallbacks = MiscCookieResolver.resolveAll(
+                for: CursorQuotaAdapter.cookieSpec,
+                instanceID: ToolType.cursor.rawValue
+            )
         }
 
-        if let account {
-            return MiscCookieResolver.resolveAll(for: CursorQuotaAdapter.cookieSpec, account: account)
+        if let session = try? CursorAppAuthStore(homeDirectory: homeDirectory).loadSession(now: now),
+           let header = try? session.cookieHeader() {
+            let preferred = MiscCookieResolver.Resolution(
+                slotID: nil,
+                header: header,
+                sourceLabel: "Cursor.app"
+            )
+            return CursorSessionResolutionPlan(
+                preferred: preferred,
+                fallbacks: fallbacks.filter { $0.header != header }
+            )
         }
-        return MiscCookieResolver.resolveAll(
-            for: CursorQuotaAdapter.cookieSpec,
-            instanceID: ToolType.cursor.rawValue
-        )
+        return CursorSessionResolutionPlan(preferred: nil, fallbacks: fallbacks)
     }
 
     static func accountIdentity(

--- a/Sources/VibeBarCore/Adapters/CursorSessionResolver.swift
+++ b/Sources/VibeBarCore/Adapters/CursorSessionResolver.swift
@@ -1,0 +1,60 @@
+import Foundation
+
+/// Resolves one Cursor account without mixing identities.
+///
+/// Automatic mode prefers Cursor.app's active session. Browser/manual cookie
+/// slots remain a fallback for machines where Cursor.app is absent or logged
+/// out, and preserve the existing `misc-cursor` Keychain account during the
+/// move from the Misc page into the Grok product family.
+enum CursorSessionResolver {
+    static let stableAccountID = AccountStore.miscAccountId(for: .cursor)
+
+    static func resolutions(
+        account: AccountIdentity? = nil,
+        homeDirectory: String = RealHomeDirectory.path,
+        now: Date = Date()
+    ) -> [MiscCookieResolver.Resolution] {
+        if let session = try? CursorAppAuthStore(homeDirectory: homeDirectory).loadSession(now: now),
+           let header = try? session.cookieHeader() {
+            return [
+                MiscCookieResolver.Resolution(
+                    slotID: nil,
+                    header: header,
+                    sourceLabel: "Cursor.app"
+                )
+            ]
+        }
+
+        if let account {
+            return MiscCookieResolver.resolveAll(for: CursorQuotaAdapter.cookieSpec, account: account)
+        }
+        return MiscCookieResolver.resolveAll(
+            for: CursorQuotaAdapter.cookieSpec,
+            instanceID: ToolType.cursor.rawValue
+        )
+    }
+
+    static func accountIdentity(
+        homeDirectory: String = RealHomeDirectory.path,
+        now: Date = Date()
+    ) -> AccountIdentity {
+        let appSession = try? CursorAppAuthStore(homeDirectory: homeDirectory).loadSession(now: now)
+        let identity = appSession?.identity
+        let hasCookieFallback = MiscCookieSlotStore.hasAnySlot(for: .cursor)
+        let source: CredentialSource = appSession != nil
+            ? .cliDetected
+            : (hasCookieFallback ? .browserCookie : .notConfigured)
+        return AccountIdentity(
+            id: stableAccountID,
+            tool: .cursor,
+            email: identity?.email,
+            alias: "Cursor Agent",
+            source: source,
+            allowsWebFallback: hasCookieFallback,
+            allowsCLIFallback: appSession != nil,
+            allowsOAuthFallback: false,
+            createdAt: now,
+            updatedAt: now
+        )
+    }
+}

--- a/Sources/VibeBarCore/BrowserCookies/MiscCookieResolver.swift
+++ b/Sources/VibeBarCore/BrowserCookies/MiscCookieResolver.swift
@@ -69,7 +69,7 @@ public enum MiscCookieResolver {
         }
     }
 
-    public struct Resolution {
+    public struct Resolution: Sendable {
         public let slotID: UUID?
         public let header: String
         public let sourceLabel: String

--- a/Sources/VibeBarCore/Credentials/CursorAppAuth.swift
+++ b/Sources/VibeBarCore/Credentials/CursorAppAuth.swift
@@ -1,0 +1,148 @@
+import Foundation
+import SQLite3
+
+/// Read-only view of Cursor.app's local login session.
+///
+/// Cursor stores its access token in the VS Code-style global state database.
+/// Vibe Bar never refreshes or rewrites that token: it only derives the
+/// first-party `WorkosCursorSessionToken` cookie accepted by cursor.com.
+struct CursorAppAuthSession: Sendable, Equatable {
+    let accessToken: String
+
+    var identity: CursorAppAuthIdentity? {
+        try? CursorAppAuthIdentity(jwt: accessToken)
+    }
+
+    func isUsable(now: Date = Date()) -> Bool {
+        guard let identity, let expiresAt = identity.expiresAt else { return false }
+        return !identity.userID.isEmpty && expiresAt.timeIntervalSince(now) > 60
+    }
+
+    func cookieHeader() throws -> String {
+        let identity = try CursorAppAuthIdentity(jwt: accessToken)
+        guard !identity.userID.isEmpty else { throw CursorAppAuthError.missingUserID }
+        return "WorkosCursorSessionToken=\(identity.userID)%3A%3A\(accessToken)"
+    }
+}
+
+struct CursorAppAuthIdentity: Sendable, Equatable {
+    let userID: String
+    let email: String?
+    let expiresAt: Date?
+
+    init(jwt: String) throws {
+        let components = jwt.split(separator: ".", omittingEmptySubsequences: false)
+        guard components.count >= 2 else { throw CursorAppAuthError.invalidJWT }
+
+        var payload = String(components[1])
+            .replacingOccurrences(of: "-", with: "+")
+            .replacingOccurrences(of: "_", with: "/")
+        payload += String(repeating: "=", count: (4 - payload.count % 4) % 4)
+        guard let data = Data(base64Encoded: payload),
+              let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else {
+            throw CursorAppAuthError.invalidJWT
+        }
+
+        let subject = (object["sub"] as? String) ?? ""
+        let candidate = subject.split(separator: "|", omittingEmptySubsequences: true).last.map(String.init) ?? ""
+        let allowed = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "._-"))
+        guard !candidate.isEmpty,
+              candidate.unicodeScalars.allSatisfy(allowed.contains)
+        else {
+            throw CursorAppAuthError.missingUserID
+        }
+
+        self.userID = candidate
+        self.email = (object["email"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines)
+        self.expiresAt = (object["exp"] as? NSNumber).map {
+            Date(timeIntervalSince1970: $0.doubleValue)
+        }
+    }
+}
+
+enum CursorAppAuthError: Error {
+    case invalidJWT
+    case missingUserID
+    case sqlite(String)
+}
+
+/// Opens Cursor.app's global-state SQLite database strictly read-only.
+struct CursorAppAuthStore: Sendable {
+    private let dbPath: String
+
+    init(
+        homeDirectory: String = RealHomeDirectory.path,
+        dbPath: String? = nil
+    ) {
+        self.dbPath = dbPath ?? URL(fileURLWithPath: homeDirectory, isDirectory: true)
+            .appendingPathComponent("Library/Application Support/Cursor/User/globalStorage/state.vscdb")
+            .path
+    }
+
+    func loadSession(now: Date = Date()) throws -> CursorAppAuthSession? {
+        guard FileManager.default.fileExists(atPath: dbPath),
+              let token = try value(for: "cursorAuth/accessToken")?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !token.isEmpty
+        else {
+            return nil
+        }
+        let session = CursorAppAuthSession(accessToken: token)
+        return session.isUsable(now: now) ? session : nil
+    }
+
+    private func value(for key: String) throws -> String? {
+        do {
+            return try value(for: key, immutable: false)
+        } catch {
+            let walMissing = !FileManager.default.fileExists(atPath: dbPath + "-wal")
+                && !FileManager.default.fileExists(atPath: dbPath + "-shm")
+            guard walMissing else { throw error }
+            return try value(for: key, immutable: true)
+        }
+    }
+
+    private func value(for key: String, immutable: Bool) throws -> String? {
+        var database: OpaquePointer?
+        let databaseURL = URL(fileURLWithPath: dbPath, isDirectory: false).absoluteURL
+        let filename = immutable ? "\(databaseURL.absoluteString)?immutable=1" : dbPath
+        let flags = immutable ? SQLITE_OPEN_READONLY | SQLITE_OPEN_URI : SQLITE_OPEN_READONLY
+        guard sqlite3_open_v2(filename, &database, flags, nil) == SQLITE_OK else {
+            let message = database.map { String(cString: sqlite3_errmsg($0)) } ?? "unknown error"
+            sqlite3_close(database)
+            throw CursorAppAuthError.sqlite(message)
+        }
+        defer { sqlite3_close(database) }
+        sqlite3_busy_timeout(database, 250)
+
+        let sql = "SELECT value FROM ItemTable WHERE key = ? LIMIT 1;"
+        var statement: OpaquePointer?
+        guard sqlite3_prepare_v2(database, sql, -1, &statement, nil) == SQLITE_OK else {
+            throw CursorAppAuthError.sqlite(String(cString: sqlite3_errmsg(database)))
+        }
+        defer { sqlite3_finalize(statement) }
+        sqlite3_bind_text(statement, 1, key, -1, cursorSQLiteTransient)
+
+        switch sqlite3_step(statement) {
+        case SQLITE_DONE:
+            return nil
+        case SQLITE_ROW:
+            switch sqlite3_column_type(statement, 0) {
+            case SQLITE_TEXT:
+                guard let bytes = sqlite3_column_text(statement, 0) else { return nil }
+                return String(cString: bytes)
+            case SQLITE_BLOB:
+                guard let bytes = sqlite3_column_blob(statement, 0) else { return nil }
+                let data = Data(bytes: bytes, count: Int(sqlite3_column_bytes(statement, 0)))
+                return String(data: data, encoding: .utf8)
+                    ?? String(data: data, encoding: .utf16LittleEndian)
+            default:
+                return nil
+            }
+        default:
+            throw CursorAppAuthError.sqlite(String(cString: sqlite3_errmsg(database)))
+        }
+    }
+}
+
+private let cursorSQLiteTransient = unsafeBitCast(-1, to: sqlite3_destructor_type.self)

--- a/Sources/VibeBarCore/Models/AppSettings.swift
+++ b/Sources/VibeBarCore/Models/AppSettings.swift
@@ -235,8 +235,8 @@ public struct AppSettings: Codable, Equatable, Sendable {
     /// Default `MiscProviderSettings` for every misc-page provider. Source
     /// selection is intentionally automatic and not exposed in the UI;
     /// region / enterprise host remain as provider-specific knobs.
-    /// Partial-primary providers (`.gemini`, `.antigravity`) are excluded —
-    /// they have dedicated `*UsageMode` top-level fields instead.
+    /// Linked partial-primary tools (`.gemini`, `.antigravity`, `.cursor`) are
+    /// excluded — they live on the Google AI / Grok product surfaces instead.
     public static var defaultMiscProviders: [ToolType: MiscProviderSettings] {
         var out: [ToolType: MiscProviderSettings] = [:]
         for tool in ToolType.miscPageProviders {
@@ -473,10 +473,9 @@ public struct AppSettings: Codable, Equatable, Sendable {
         // dropped. `MiscProviderSettings`' own decoder rejects fields
         // whose names look like secrets — together they keep
         // settings.json minimal and credential-free. Partial-primary
-        // providers (`.gemini`, `.antigravity`) are also dropped here:
-        // their settings have been lifted into top-level
-        // `geminiUsageMode` / `antigravityUsageMode` fields and any
-        // legacy entries in `settings.json` are stale.
+        // linked providers (`.gemini`, `.antigravity`, `.cursor`) are also dropped here:
+        // Gemini/Antigravity use top-level UsageMode fields; Cursor uses its
+        // local-app/session resolver. Legacy Misc entries are stale either way.
         let decodedLegacyProviders: [ToolType: MiscProviderSettings]
         if let raw = try c.decodeIfPresent([String: MiscProviderSettings].self, forKey: .miscProviders) {
             var map: [ToolType: MiscProviderSettings] = [:]
@@ -785,10 +784,9 @@ public struct AppSettings: Codable, Equatable, Sendable {
 
         if let instances, !instances.isEmpty {
             for raw in instances {
-                // Partial-primary providers (`.gemini`, `.antigravity`)
-                // are silently dropped: any legacy instances from older
-                // `settings.json` files belong to top-level
-                // `*UsageMode` fields now.
+                // Linked partial-primary providers (`.gemini`, `.antigravity`, `.cursor`)
+                // are silently dropped: their linked provider surfaces own
+                // source selection now.
                 guard raw.tool.isMiscPageProvider else { continue }
                 let trimmedID = raw.id.trimmingCharacters(in: .whitespacesAndNewlines)
                 guard !trimmedID.isEmpty, seenIDs.insert(trimmedID).inserted else { continue }

--- a/Sources/VibeBarCore/Models/MenuBarSettings.swift
+++ b/Sources/VibeBarCore/Models/MenuBarSettings.swift
@@ -245,8 +245,14 @@ public enum MenuBarFieldCatalog {
         option(.grok, "weekly", "Weekly Credits", "Weekly")
     ]
 
+    public static let cursorFields: [MenuBarFieldOption] = [
+        option(.cursor, "models", "Cursor Agent · Cursor Models", "Cursor Models"),
+        option(.cursor, "other_models", "Cursor Agent · Other Models", "Other Models"),
+        option(.cursor, "grok_bot_weekly", "Grok Bot · Weekly", "Grok Bot")
+    ]
+
     public static let allFields: [MenuBarFieldOption] =
-        codexFields + claudeFields + geminiFields + antigravityFields + grokFields
+        codexFields + claudeFields + geminiFields + antigravityFields + grokFields + cursorFields
 
     public static func fields(for kind: MenuBarItemKind) -> [MenuBarFieldOption] {
         allFields

--- a/Sources/VibeBarCore/Models/ProviderHierarchy.swift
+++ b/Sources/VibeBarCore/Models/ProviderHierarchy.swift
@@ -10,7 +10,7 @@ import Foundation
 ///   AntiGravity IDE share the Gemini product because that's how
 ///   Google brands them.
 /// - `tool` (L3) — the specific surface Vibe Bar tracks
-///   (Codex, Claude Code, Gemini Web, AntiGravity, Grok Build).
+///   (Codex, Claude Code, Gemini Web, AntiGravity, Grok Build, Cursor Agent).
 ///
 /// `ToolType` derives its `vendorName` / `productName` / `toolName`
 /// from a single entry per case in `ProviderHierarchyCatalog`, so
@@ -28,23 +28,24 @@ public struct ProviderHierarchy: Sendable, Equatable, Hashable {
     }
 }
 
-/// Canonical lookup table for the five primary tools and every misc
+/// Canonical lookup table for the dedicated/linked tools and every misc
 /// provider Vibe Bar tracks. Each `ToolType` maps to exactly one
 /// entry; the constants below double as the public spec — adding or
 /// renaming a provider is a single edit here, not a hunt across
 /// five `switch` statements.
 public enum ProviderHierarchyCatalog {
-    // MARK: - Primary five-tool hierarchy
+    // MARK: - Dedicated and linked tool hierarchy
     //
-    //   L1 vendor   : OpenAI    | Anthropic   | Google    | Google      | xAI
-    //   L2 product  : ChatGPT   | Claude      | Gemini    | Gemini      | Grok
-    //   L3 tool     : Codex     | Claude Code | Gemini Web| AntiGravity | Grok Build
+    //   L1 vendor   : OpenAI    | Anthropic   | Google    | Google      | xAI        | Cursor
+    //   L2 product  : ChatGPT   | Claude      | Gemini    | Gemini      | Grok       | Grok
+    //   L3 tool     : Codex     | Claude Code | Gemini Web| AntiGravity | Grok Build | Cursor Agent
 
     public static let codex       = ProviderHierarchy(vendor: "OpenAI",    product: "ChatGPT", tool: "Codex")
     public static let claude      = ProviderHierarchy(vendor: "Anthropic", product: "Claude",  tool: "Claude Code")
     public static let gemini      = ProviderHierarchy(vendor: "Google",    product: "Gemini",  tool: "Gemini Web")
     public static let antigravity = ProviderHierarchy(vendor: "Google",    product: "Gemini",  tool: "AntiGravity")
     public static let grok        = ProviderHierarchy(vendor: "xAI",       product: "Grok",    tool: "Grok Build")
+    public static let cursor      = ProviderHierarchy(vendor: "Cursor",    product: "Grok",    tool: "Cursor Agent")
 
     // MARK: - Misc providers
     //
@@ -59,7 +60,6 @@ public enum ProviderHierarchyCatalog {
     public static let zai              = ProviderHierarchy(vendor: "Zhipu",      product: "GLM",         tool: "GLM Coding Plan")
     public static let minimax          = ProviderHierarchy(vendor: "MiniMax",    product: "MiniMax",     tool: "MiniMax Token Plan")
     public static let kimi             = ProviderHierarchy(vendor: "Moonshot",   product: "Kimi",        tool: "Kimi Coding Plan")
-    public static let cursor           = ProviderHierarchy(vendor: "Cursor",     product: "Cursor",      tool: "Cursor")
     public static let mimo             = ProviderHierarchy(vendor: "Xiaomi",     product: "MiMo",        tool: "MiMo Token Plan")
     public static let iflytek          = ProviderHierarchy(vendor: "iFlytek",    product: "Spark",       tool: "Spark Coding Plan")
     public static let tencentHunyuan   = ProviderHierarchy(vendor: "Tencent",    product: "Hunyuan",     tool: "Hunyuan Coding Plan")

--- a/Sources/VibeBarCore/Models/QuotaBucket.swift
+++ b/Sources/VibeBarCore/Models/QuotaBucket.swift
@@ -98,4 +98,17 @@ public struct QuotaBucket: Codable, Identifiable, Hashable, Sendable {
         case .used: return usedPercent
         }
     }
+
+    /// Provider-aware display normalization. Cursor's current dashboard labels
+    /// any positive sub-1% pool as `1% used`; keep the stored observation exact
+    /// for history/forecast math while matching that visible contract.
+    public func displayPercent(_ mode: DisplayMode, tool: ToolType) -> Double {
+        let displayedUsed = tool == .cursor && usedPercent > 0 && usedPercent < 1
+            ? 1
+            : usedPercent
+        switch mode {
+        case .remaining: return max(0, min(100, 100 - displayedUsed))
+        case .used: return displayedUsed
+        }
+    }
 }

--- a/Sources/VibeBarCore/Models/ToolType.swift
+++ b/Sources/VibeBarCore/Models/ToolType.swift
@@ -24,12 +24,12 @@ import Foundation
 /// Tools split into three tiers:
 /// - **Primary** (`.codex`, `.claude`) — full quota + cost + service-status
 ///   integration, dedicated popover pages, mini-window slots.
-/// - **Partial-Primary** (`.gemini`, `.antigravity`, `.grok`) — dedicated
-///   popover sub-page (Google AI dual page for Gemini+Antigravity, single
-///   provider page for Grok) + SettingsView panel. These can still opt into
-///   token-cost scanning and status polling as provider data becomes known.
+/// - **Partial-Primary** (`.gemini`, `.antigravity`, `.grok`, `.cursor`) —
+///   dedicated product surfaces. Gemini+AntiGravity share Google AI;
+///   Grok Build+Cursor Agent share Grok. These can still opt into token-cost
+///   scanning and status polling as provider data becomes known.
 /// - **Misc** (`.alibaba`, `.alibabaTokenPlan`, `.copilot`, `.zai`,
-///   `.minimax`, `.kimi`, `.cursor`, `.mimo`, `.iflytek`,
+///   `.minimax`, `.kimi`, `.mimo`, `.iflytek`,
 ///   `.tencentHunyuan`, `.tencentTokenPlan`, `.volcengine`,
 ///   `.volcengineAgentPlan`, `.baiduQianfan`,
 ///   `.openCodeGo`, `.kilo`, `.kiro`, `.ollama`, `.openRouter`, `.warp`) —
@@ -39,7 +39,7 @@ import Foundation
 /// scanner and the status-page poller; `supportsDedicatedCard` is the
 /// predicate the dedicated-card UI uses; `isMiscPageProvider` is the
 /// filter the Misc tab and `defaultMiscProviderInstances` use. Note
-/// `isMisc` still reports true for the partial-primary pair so legacy
+/// `isMisc` still reports true for linked partial-primary tools so legacy
 /// `tool.isMisc` callers keep their original semantics — new misc-only
 /// code paths should switch to `isMiscPageProvider`.
 public enum ToolType: String, Codable, CaseIterable, Hashable, Sendable {
@@ -85,11 +85,11 @@ public enum ToolType: String, Codable, CaseIterable, Hashable, Sendable {
     /// True for providers that get a dedicated popover card, a SettingsView
     /// panel, and multi-source credential fallback. Primary providers are a
     /// proper subset of this set; partial-primary providers (Gemini,
-    /// Antigravity, Grok) live here without dedicated menu-bar item kinds.
+    /// Antigravity, Grok, Cursor) live here without dedicated menu-bar item kinds.
     public var supportsDedicatedCard: Bool {
         switch self {
-        case .codex, .claude, .gemini, .antigravity, .grok: return true
-        case .alibaba, .alibabaTokenPlan, .copilot, .zai, .minimax, .kimi, .cursor, .mimo, .iflytek, .tencentHunyuan, .tencentTokenPlan, .volcengine, .volcengineAgentPlan, .baiduQianfan, .openCodeGo, .kilo, .kiro, .ollama, .openRouter, .warp:
+        case .codex, .claude, .gemini, .antigravity, .grok, .cursor: return true
+        case .alibaba, .alibabaTokenPlan, .copilot, .zai, .minimax, .kimi, .mimo, .iflytek, .tencentHunyuan, .tencentTokenPlan, .volcengine, .volcengineAgentPlan, .baiduQianfan, .openCodeGo, .kilo, .kiro, .ollama, .openRouter, .warp:
             return false
         }
     }
@@ -103,7 +103,7 @@ public enum ToolType: String, Codable, CaseIterable, Hashable, Sendable {
     /// True for providers that show up on the Misc settings tab and in
     /// `defaultMiscProviderInstances`. Equivalent to "no dedicated card" —
     /// narrower than `isMisc`, which still reports true for the
-    /// partial-primary pair so legacy `tool.isMisc` callers keep working.
+    /// partial-primary tools so legacy `tool.isMisc` callers keep working.
     public var isMiscPageProvider: Bool {
         !supportsDedicatedCard
     }
@@ -149,8 +149,10 @@ public enum ToolType: String, Codable, CaseIterable, Hashable, Sendable {
             return self
         case .antigravity:
             return .gemini
+        case .cursor:
+            return .grok
         case .alibaba, .alibabaTokenPlan, .copilot, .zai, .minimax, .kimi,
-             .cursor, .mimo, .iflytek, .tencentHunyuan, .tencentTokenPlan,
+             .mimo, .iflytek, .tencentHunyuan, .tencentTokenPlan,
              .volcengine, .volcengineAgentPlan, .baiduQianfan, .openCodeGo,
              .kilo, .kiro, .ollama, .openRouter, .warp:
             return nil
@@ -165,6 +167,11 @@ public enum ToolType: String, Codable, CaseIterable, Hashable, Sendable {
     /// Overview popover's "Google AI" page.
     public static var googleAIPair: [ToolType] {
         [.gemini, .antigravity]
+    }
+
+    /// Grok Build plus Cursor Agent, presented as one Grok product family.
+    public static var grokFamily: [ToolType] {
+        [.grok, .cursor]
     }
 
     /// True for providers we can build a per-token cost panel for.
@@ -185,10 +192,13 @@ public enum ToolType: String, Codable, CaseIterable, Hashable, Sendable {
     ///   field. Grok exposes only a session-level total (no per-call
     ///   input / output split), so the USD figure is a blended
     ///   approximation against the published `grok-build` rate.
+    /// - `.cursor` reads account usage events from Cursor's dashboard API.
+    ///   Local Cursor transcripts do not expose stable token/cost counters;
+    ///   each dashboard event carries token counts and `totalCents`.
     public var supportsTokenCost: Bool {
         switch self {
-        case .codex, .claude, .gemini, .antigravity, .grok: return true
-        case .alibaba, .alibabaTokenPlan, .copilot, .zai, .minimax, .kimi, .cursor, .mimo, .iflytek, .tencentHunyuan, .tencentTokenPlan, .volcengine, .volcengineAgentPlan, .baiduQianfan, .openCodeGo, .kilo, .kiro, .ollama, .openRouter, .warp:
+        case .codex, .claude, .gemini, .antigravity, .grok, .cursor: return true
+        case .alibaba, .alibabaTokenPlan, .copilot, .zai, .minimax, .kimi, .mimo, .iflytek, .tencentHunyuan, .tencentTokenPlan, .volcengine, .volcengineAgentPlan, .baiduQianfan, .openCodeGo, .kilo, .kiro, .ollama, .openRouter, .warp:
             return false
         }
     }
@@ -224,7 +234,7 @@ public enum ToolType: String, Codable, CaseIterable, Hashable, Sendable {
     // Misc-provider tools (Alibaba / Tencent / Volcengine / etc.) get
     // best-effort hierarchy entries too so callers don't have to
     // special-case them, but the consistency contract only applies to
-    // the five primary tools (`[.codex, .claude] +
+    // the dedicated/linked tools (`[.codex, .claude] +
     // ToolType.partialPrimaryProviders`).
 
     /// The single hierarchy entry every L1/L2/L3 accessor reads from.
@@ -274,7 +284,7 @@ public enum ToolType: String, Codable, CaseIterable, Hashable, Sendable {
     /// "Alibaba Bailian Coding Plan" vs "Alibaba Bailian Token Plan".
     public var displayName: String {
         switch self {
-        case .codex, .claude, .gemini, .antigravity, .grok:
+        case .codex, .claude, .gemini, .antigravity, .grok, .cursor:
             return hierarchy.tool
         case .alibaba:          return "Alibaba Bailian Coding Plan"
         case .alibabaTokenPlan: return "Alibaba Bailian Token Plan"
@@ -282,7 +292,6 @@ public enum ToolType: String, Codable, CaseIterable, Hashable, Sendable {
         case .zai:              return "Zhipu GLM Coding Plan"
         case .minimax:          return "MiniMax Token Plan"
         case .kimi:             return "Kimi Coding Plan"
-        case .cursor:           return "Cursor"
         case .mimo:             return "Xiaomi MiMo Token Plan"
         case .iflytek:          return "iFlytek Spark Coding Plan"
         case .tencentHunyuan:   return "Tencent Hunyuan Coding Plan"
@@ -300,7 +309,7 @@ public enum ToolType: String, Codable, CaseIterable, Hashable, Sendable {
     }
 
     /// Card subtitle rendered under the L2 product title. For the
-    /// primary five tools this is the L3 tool name from `hierarchy`
+    /// dedicated/linked tools this is the L3 tool name from `hierarchy`
     /// so the Overview popover reads "Gemini · Gemini Web" / "Gemini ·
     /// AntiGravity" instead of the old ad-hoc "Usage" / "Local LSP"
     /// labels. Misc tools keep their plan-flavour descriptor since
@@ -308,7 +317,7 @@ public enum ToolType: String, Codable, CaseIterable, Hashable, Sendable {
     /// Plan vs Token Plan).
     public var subtitle: String {
         switch self {
-        case .codex, .claude, .gemini, .antigravity, .grok:
+        case .codex, .claude, .gemini, .antigravity, .grok, .cursor:
             return hierarchy.tool
         case .alibaba:          return "Coding Plan"
         case .alibabaTokenPlan: return "Token Plan"
@@ -316,7 +325,6 @@ public enum ToolType: String, Codable, CaseIterable, Hashable, Sendable {
         case .zai:              return "Coding Plan"
         case .minimax:          return "Token Plan"
         case .kimi:             return "Coding Plan"
-        case .cursor:           return "Cursor"
         case .mimo:             return "Token Plan"
         case .iflytek:          return "Coding Plan"
         case .tencentHunyuan:   return "Coding Plan"
@@ -342,14 +350,13 @@ public enum ToolType: String, Codable, CaseIterable, Hashable, Sendable {
     /// "Hunyuan", which would clash with other Tencent surfaces).
     public var menuTitle: String {
         switch self {
-        case .codex, .claude, .gemini, .antigravity, .grok:
+        case .codex, .claude, .gemini, .antigravity, .grok, .cursor:
             return hierarchy.product
         case .alibaba, .alibabaTokenPlan: return "Bailian"
         case .copilot:          return "Copilot"
         case .zai:              return "Zhipu GLM"
         case .minimax:          return "MiniMax"
         case .kimi:             return "Kimi"
-        case .cursor:           return "Cursor"
         case .mimo:             return "Xiaomi MiMo"
         case .iflytek:          return "iFlytek Spark"
         case .tencentHunyuan, .tencentTokenPlan: return "Tencent Hunyuan"
@@ -366,19 +373,18 @@ public enum ToolType: String, Codable, CaseIterable, Hashable, Sendable {
 
     /// L1 vendor name — used by ServiceStatusCard and any surface
     /// that should pick one consistent level across all tools. The
-    /// five primary tools all roll up to four vendors (OpenAI,
-    /// Anthropic, Google, xAI); `.antigravity` shares Google's
-    /// status feed with `.gemini` for the same reason.
+    /// dedicated tools roll up to their vendors. `.antigravity` shares
+    /// Google's status feed with `.gemini`; Cursor Agent is linked under Grok
+    /// for quota/cost but retains Cursor as its billing vendor.
     public var statusProviderName: String {
         switch self {
-        case .codex, .claude, .gemini, .antigravity, .grok:
+        case .codex, .claude, .gemini, .antigravity, .grok, .cursor:
             return hierarchy.vendor
         case .alibaba, .alibabaTokenPlan: return "Alibaba"
         case .copilot:          return "GitHub"
         case .zai:              return "Z.ai"
         case .minimax:          return "MiniMax"
         case .kimi:             return "Moonshot"
-        case .cursor:           return "Cursor"
         case .mimo:             return "Xiaomi"
         case .iflytek:          return "iFlytek"
         case .tencentHunyuan, .tencentTokenPlan: return "Tencent Cloud"

--- a/Sources/VibeBarCore/Services/CostUsageScanner.swift
+++ b/Sources/VibeBarCore/Services/CostUsageScanner.swift
@@ -1488,7 +1488,11 @@ public enum CostUsageScanner {
 
     // MARK: - Aggregator
 
-    private struct CostAggregator {
+    /// Shared accumulator for local scans and authoritative remote usage rows.
+    /// Cursor's dashboard is the latter: its local transcripts contain content
+    /// but no stable token/cost counters, so the same snapshot math is fed from
+    /// cursor.com's account usage events instead.
+    struct CostAggregator {
         let tool: ToolType
         let now: Date
         let calendar: Calendar

--- a/Sources/VibeBarCore/Services/CostUsageService.swift
+++ b/Sources/VibeBarCore/Services/CostUsageService.swift
@@ -52,6 +52,10 @@ public final class CostUsageService: ObservableObject {
     /// merged dictionary is published, so remote facts are never written into
     /// the local scan cache/history and cannot be counted again after relaunch.
     private var localSnapshots: [ToolType: CostSnapshot] = [:]
+    /// Account-wide provider APIs that are authoritative but not local files.
+    /// Kept memory-only so a dashboard refresh can never be mistaken for a
+    /// newly scanned local session on the next launch.
+    private var directRemoteSnapshots: [ToolType: CostSnapshot] = [:]
     private var remoteSnapshots: [ToolType: CostSnapshot] = [:]
     /// Every value the UI derives from `snapshots` — rebased per-tool
     /// snapshots, combined platform snapshots, the Overview rollups — is a pure
@@ -191,11 +195,33 @@ public final class CostUsageService: ObservableObject {
         _ = try? await usageLedger?.prepareForPricingRevision(PricingResolver.activeRevision)
 
         var results: [ToolType: CostSnapshot] = [:]
+        var directRemoteResults = directRemoteSnapshots
         let home = homeDirectory
         // Privacy mode is already handled above (it erases and returns), so
         // reaching here means the ledger is allowed to record.
         let sink = usageLedger
         for tool in ToolType.allCases where tool.supportsTokenCost {
+            if tool == .cursor {
+                let outcome = await AsyncTimeout.run(seconds: Self.perToolScanTimeoutSeconds) {
+                    await CursorCostUsageFetcher.fetch(
+                        homeDirectory: home,
+                        now: now,
+                        retentionDays: retentionDays
+                    )
+                }
+                switch outcome {
+                case .completed(.success(let snapshot)):
+                    directRemoteResults[.cursor] = snapshot
+                case .completed(.unavailable):
+                    directRemoteResults.removeValue(forKey: .cursor)
+                case .completed(.failed), .timedOut:
+                    // A transient dashboard failure keeps the last in-memory
+                    // success, just as a timed-out local scan keeps its prior
+                    // snapshot. Logging happens inside the fetcher.
+                    break
+                }
+                continue
+            }
             // Scan on a detached utility task so JSONL parsing doesn't block
             // the main actor. CostUsageService itself is `@MainActor`; without
             // this hop, `nonisolated async` callees still run inline on the
@@ -247,6 +273,7 @@ public final class CostUsageService: ObservableObject {
             }
         }
         localSnapshots = results
+        directRemoteSnapshots = directRemoteResults
         publishMergedSnapshots()
         // Extras (credits / overage) display was removed from the UI — see the
         // user-feedback round that turned them off because the loaders weren't
@@ -311,6 +338,7 @@ public final class CostUsageService: ObservableObject {
         CostUsageScanCache.eraseAll(homeDirectory: homeDirectory)
         try? await usageLedger?.eraseAll()
         localSnapshots = [:]
+        directRemoteSnapshots = [:]
         publishMergedSnapshots()
         extrasByTool = [:]
         lastRefreshedAt = nil
@@ -328,8 +356,19 @@ public final class CostUsageService: ObservableObject {
             return
         }
         var merged = localSnapshots
+        for (tool, remote) in directRemoteSnapshots {
+            if let local = merged[tool] {
+                merged[tool] = CostSnapshotAggregator.combinedSnapshot(
+                    tool: tool,
+                    snapshots: [local, remote],
+                    now: now
+                )
+            } else {
+                merged[tool] = remote
+            }
+        }
         for (tool, remote) in remoteSnapshots {
-            if let local = localSnapshots[tool] {
+            if let local = merged[tool] {
                 merged[tool] = CostSnapshotAggregator.combinedSnapshot(
                     tool: tool,
                     snapshots: [local, remote],

--- a/Sources/VibeBarCore/Services/CostUsageService.swift
+++ b/Sources/VibeBarCore/Services/CostUsageService.swift
@@ -209,6 +209,10 @@ public final class CostUsageService: ObservableObject {
                         retentionDays: retentionDays
                     )
                 }
+                guard !costDataSettingsProvider().privacyModeEnabled else {
+                    await eraseLocalCostData()
+                    return
+                }
                 switch outcome {
                 case .completed(.success(let snapshot)):
                     directRemoteResults[.cursor] = snapshot

--- a/Sources/VibeBarCore/Services/CursorCostUsageFetcher.swift
+++ b/Sources/VibeBarCore/Services/CursorCostUsageFetcher.swift
@@ -1,0 +1,343 @@
+import Foundation
+
+enum CursorCostFetchOutcome: Sendable {
+    case unavailable
+    case success(CostSnapshot)
+    case failed
+}
+
+/// Fetches Cursor Agent token/cost events from Cursor's account dashboard.
+///
+/// Cursor's local agent transcripts do not carry token counters. The dashboard
+/// event rows do, including authoritative `tokenUsage.totalCents`; Grok Bot's
+/// cloud-only weekly allowance is a separate endpoint and is intentionally not
+/// synthesized into these events.
+struct CursorCostUsageFetcher: Sendable {
+    private let session: URLSession
+    private let baseURL: URL
+    private let pageSize: Int
+    private let maxPages: Int
+
+    init(
+        session: URLSession = .shared,
+        baseURL: URL = URL(string: "https://cursor.com")!,
+        pageSize: Int = 1_000,
+        maxPages: Int = 200
+    ) {
+        self.session = session
+        self.baseURL = baseURL
+        self.pageSize = pageSize
+        self.maxPages = maxPages
+    }
+
+    static func fetch(
+        homeDirectory: String = RealHomeDirectory.path,
+        now: Date = Date(),
+        retentionDays: Int,
+        session: URLSession = .shared,
+        resolutions override: [MiscCookieResolver.Resolution]? = nil
+    ) async -> CursorCostFetchOutcome {
+        let resolutions = override ?? CursorSessionResolver.resolutions(
+            homeDirectory: homeDirectory,
+            now: now
+        )
+        guard !resolutions.isEmpty else { return .unavailable }
+
+        let normalizedRetention = CostDataSettings.normalizedRetentionDays(retentionDays)
+        let calendar = Calendar.current
+        let today = calendar.startOfDay(for: now)
+        let since = normalizedRetention > 0
+            ? calendar.date(byAdding: .day, value: -(normalizedRetention - 1), to: today)
+            : nil
+        let fetcher = CursorCostUsageFetcher(session: session)
+        var snapshots: [CostSnapshot] = []
+        for resolution in resolutions {
+            do {
+                let snapshot = try await fetcher.fetchSnapshot(
+                    cookieHeader: resolution.header,
+                    since: since,
+                    until: now,
+                    now: now
+                )
+                snapshots.append(snapshot)
+            } catch {
+                SafeLog.net("Cursor cost refresh failed: \(SafeLog.sanitize(error.localizedDescription))")
+            }
+        }
+        guard !snapshots.isEmpty else { return .failed }
+        return .success(CostSnapshotAggregator.combinedSnapshot(
+            tool: .cursor,
+            snapshots: snapshots,
+            now: now
+        ))
+    }
+
+    func fetchSnapshot(
+        cookieHeader: String,
+        since: Date?,
+        until: Date?,
+        now: Date
+    ) async throws -> CostSnapshot {
+        let events = try await fetchAllEvents(
+            cookieHeader: cookieHeader,
+            since: since,
+            until: until
+        )
+        var accumulator = CostUsageScanner.CostAggregator(tool: .cursor, now: now)
+        var includedEvents = 0
+        for event in events {
+            guard let date = event.date,
+                  event.clientType?.lowercased() != "grok-bot",
+                  let usage = event.tokenUsage,
+                  usage.totalTokens > 0
+            else { continue }
+            let model = event.model.flatMap { $0.isEmpty ? nil : $0 } ?? "cursor-unknown"
+            accumulator.add(
+                at: date,
+                model: model,
+                input: usage.inputTokens + usage.cacheWriteTokens,
+                output: usage.outputTokens,
+                cache: usage.cacheReadTokens,
+                costUSD: max(0, (usage.totalCents ?? 0) / 100)
+            )
+            includedEvents += 1
+        }
+        return accumulator.snapshot(jsonlFilesFound: includedEvents)
+    }
+
+    private func fetchAllEvents(
+        cookieHeader: String,
+        since: Date?,
+        until: Date?
+    ) async throws -> [CursorUsageEvent] {
+        var pages: [[CursorUsageEvent]] = []
+        var expectedTotal: Int?
+        var completed = false
+
+        for page in 1...maxPages {
+            let response = try await fetchPage(
+                cookieHeader: cookieHeader,
+                page: page,
+                since: since,
+                until: until
+            )
+            if let total = response.totalUsageEventsCount {
+                guard total >= 0 else { throw QuotaError.parseFailure("Cursor event count is negative") }
+                if let expectedTotal, expectedTotal != total {
+                    throw QuotaError.parseFailure("Cursor event count changed during pagination")
+                }
+                expectedTotal = total
+            }
+            let pageEvents = response.usageEventsDisplay
+            if pageEvents.isEmpty {
+                completed = true
+                break
+            }
+            pages.append(pageEvents)
+            if pageEvents.count < pageSize {
+                completed = true
+                break
+            }
+        }
+
+        let rawEvents = pages.flatMap(\.self)
+        guard completed else {
+            throw QuotaError.parseFailure("Cursor usage pagination reached its safety cap")
+        }
+        guard let expectedTotal else { return rawEvents }
+        guard rawEvents.count >= expectedTotal else {
+            throw QuotaError.parseFailure("Cursor usage pagination returned a partial result")
+        }
+        guard rawEvents.count > expectedTotal else { return rawEvents }
+
+        // The endpoint has no stable event id and can repeat exact rows at page
+        // boundaries. Remove only the overlap proven by its authoritative count.
+        var removalsRemaining = rawEvents.count - expectedTotal
+        var reconciled = pages.first ?? []
+        for index in pages.indices.dropFirst() {
+            let page = pages[index]
+            let overlap = Self.boundaryOverlap(
+                previousPage: pages[index - 1],
+                currentPage: page
+            )
+            let removalCount = min(overlap, removalsRemaining)
+            reconciled.append(contentsOf: page.dropFirst(removalCount))
+            removalsRemaining -= removalCount
+        }
+        guard removalsRemaining == 0, reconciled.count == expectedTotal else {
+            throw QuotaError.parseFailure("Cursor usage pagination could not reconcile duplicate rows")
+        }
+        return reconciled
+    }
+
+    private func fetchPage(
+        cookieHeader: String,
+        page: Int,
+        since: Date?,
+        until: Date?
+    ) async throws -> CursorUsageEventsPage {
+        var request = URLRequest(
+            url: baseURL.appendingPathComponent("/api/dashboard/get-filtered-usage-events")
+        )
+        request.httpMethod = "POST"
+        request.timeoutInterval = 30
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.setValue(cookieHeader, forHTTPHeaderField: "Cookie")
+        request.setValue("\(baseURL.scheme ?? "https")://\(baseURL.host ?? "cursor.com")", forHTTPHeaderField: "Origin")
+        request.httpBody = try JSONEncoder().encode(CursorFilteredUsageRequest(
+            page: page,
+            pageSize: pageSize,
+            startDate: Self.millisString(since),
+            endDate: Self.millisString(until)
+        ))
+
+        let (data, response) = try await session.data(for: request)
+        guard let http = response as? HTTPURLResponse else {
+            throw QuotaError.network("Cursor usage returned an invalid response")
+        }
+        if http.statusCode == 401 || http.statusCode == 403 { throw QuotaError.needsLogin }
+        guard http.statusCode == 200 else {
+            throw QuotaError.network("Cursor usage returned HTTP \(http.statusCode)")
+        }
+        do {
+            return try JSONDecoder().decode(CursorUsageEventsPage.self, from: data)
+        } catch {
+            throw QuotaError.parseFailure("Cursor usage events are not parseable: \(error.localizedDescription)")
+        }
+    }
+
+    private static func millisString(_ date: Date?) -> String? {
+        date.map { String(Int64(($0.timeIntervalSince1970 * 1_000).rounded())) }
+    }
+
+    private static func boundaryOverlap(
+        previousPage: [CursorUsageEvent],
+        currentPage: [CursorUsageEvent]
+    ) -> Int {
+        let limit = min(previousPage.count, currentPage.count)
+        guard limit > 0 else { return 0 }
+        for count in stride(from: limit, through: 1, by: -1)
+            where previousPage.suffix(count).elementsEqual(currentPage.prefix(count)) {
+            return count
+        }
+        return 0
+    }
+}
+
+private struct CursorFilteredUsageRequest: Encodable {
+    let page: Int
+    let pageSize: Int
+    let startDate: String?
+    let endDate: String?
+}
+
+private struct CursorUsageEventsPage: Decodable {
+    let totalUsageEventsCount: Int?
+    let usageEventsDisplay: [CursorUsageEvent]
+
+    private enum CodingKeys: String, CodingKey {
+        case totalUsageEventsCount
+        case usageEventsDisplay
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let rawCount = try? container.decode(CursorFlexibleNumber.self, forKey: .totalUsageEventsCount)
+        self.totalUsageEventsCount = rawCount?.nonnegativeInt
+        self.usageEventsDisplay = try container.decode(
+            [CursorUsageEvent].self,
+            forKey: .usageEventsDisplay
+        )
+    }
+}
+
+private struct CursorUsageEvent: Decodable, Hashable {
+    let timestamp: CursorFlexibleNumber?
+    let model: String?
+    let tokenUsage: CursorEventTokenUsage?
+    let kind: String?
+    let isHeadless: Bool?
+    let clientType: String?
+
+    var date: Date? {
+        guard let milliseconds = timestamp?.doubleValue,
+              milliseconds.isFinite,
+              milliseconds > 0
+        else { return nil }
+        return Date(timeIntervalSince1970: milliseconds / 1_000)
+    }
+}
+
+private struct CursorEventTokenUsage: Decodable, Hashable {
+    let inputTokensRaw: CursorFlexibleNumber?
+    let outputTokensRaw: CursorFlexibleNumber?
+    let cacheWriteTokensRaw: CursorFlexibleNumber?
+    let cacheReadTokensRaw: CursorFlexibleNumber?
+    let totalCentsRaw: CursorFlexibleNumber?
+
+    private enum CodingKeys: String, CodingKey {
+        case inputTokensRaw = "inputTokens"
+        case outputTokensRaw = "outputTokens"
+        case cacheWriteTokensRaw = "cacheWriteTokens"
+        case cacheReadTokensRaw = "cacheReadTokens"
+        case totalCentsRaw = "totalCents"
+    }
+
+    var inputTokens: Int { inputTokensRaw?.nonnegativeInt ?? 0 }
+    var outputTokens: Int { outputTokensRaw?.nonnegativeInt ?? 0 }
+    var cacheWriteTokens: Int { cacheWriteTokensRaw?.nonnegativeInt ?? 0 }
+    var cacheReadTokens: Int { cacheReadTokensRaw?.nonnegativeInt ?? 0 }
+    var totalCents: Double? { totalCentsRaw?.doubleValue }
+
+    var totalTokens: Int {
+        var total = 0
+        for value in [inputTokens, outputTokens, cacheWriteTokens, cacheReadTokens] {
+            let (sum, overflow) = total.addingReportingOverflow(value)
+            guard !overflow else { return 0 }
+            total = sum
+        }
+        return total
+    }
+}
+
+private enum CursorFlexibleNumber: Decodable, Hashable {
+    case integer(Int64)
+    case decimal(Double)
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if let value = try? container.decode(Int64.self) {
+            self = .integer(value)
+            return
+        }
+        if let value = try? container.decode(Double.self), value.isFinite {
+            self = .decimal(value)
+            return
+        }
+        if let raw = try? container.decode(String.self),
+           let value = Double(raw), value.isFinite {
+            self = .decimal(value)
+            return
+        }
+        throw DecodingError.dataCorruptedError(in: container, debugDescription: "Invalid Cursor number")
+    }
+
+    var doubleValue: Double {
+        switch self {
+        case .integer(let value): return Double(value)
+        case .decimal(let value): return value
+        }
+    }
+
+    var nonnegativeInt: Int {
+        switch self {
+        case .integer(let value):
+            guard value >= 0 else { return 0 }
+            return Int(exactly: value) ?? 0
+        case .decimal(let value):
+            guard value >= 0 else { return 0 }
+            return Int(exactly: value) ?? 0
+        }
+    }
+}

--- a/Sources/VibeBarCore/Services/CursorCostUsageFetcher.swift
+++ b/Sources/VibeBarCore/Services/CursorCostUsageFetcher.swift
@@ -35,13 +35,13 @@ struct CursorCostUsageFetcher: Sendable {
         now: Date = Date(),
         retentionDays: Int,
         session: URLSession = .shared,
-        resolutions override: [MiscCookieResolver.Resolution]? = nil
+        resolutionPlan override: CursorSessionResolutionPlan? = nil
     ) async -> CursorCostFetchOutcome {
-        let resolutions = override ?? CursorSessionResolver.resolutions(
+        let plan = override ?? CursorSessionResolver.plan(
             homeDirectory: homeDirectory,
             now: now
         )
-        guard !resolutions.isEmpty else { return .unavailable }
+        guard !plan.isEmpty else { return .unavailable }
 
         let normalizedRetention = CostDataSettings.normalizedRetentionDays(retentionDays)
         let calendar = Calendar.current
@@ -50,8 +50,29 @@ struct CursorCostUsageFetcher: Sendable {
             ? calendar.date(byAdding: .day, value: -(normalizedRetention - 1), to: today)
             : nil
         let fetcher = CursorCostUsageFetcher(session: session)
+
+        if let preferred = plan.preferred {
+            do {
+                let snapshot = try await fetcher.fetchSnapshot(
+                    cookieHeader: preferred.header,
+                    since: since,
+                    until: now,
+                    now: now
+                )
+                return .success(snapshot)
+            } catch let error as QuotaError {
+                guard error.isCredentialState, !plan.fallbacks.isEmpty else {
+                    SafeLog.net("Cursor cost refresh failed: \(SafeLog.sanitize(error.localizedDescription))")
+                    return .failed
+                }
+            } catch {
+                SafeLog.net("Cursor cost refresh failed: \(SafeLog.sanitize(error.localizedDescription))")
+                return .failed
+            }
+        }
+
         var snapshots: [CostSnapshot] = []
-        for resolution in resolutions {
+        for resolution in plan.fallbacks {
             do {
                 let snapshot = try await fetcher.fetchSnapshot(
                     cookieHeader: resolution.header,

--- a/Sources/VibeBarCore/Services/MockDataProvider.swift
+++ b/Sources/VibeBarCore/Services/MockDataProvider.swift
@@ -264,7 +264,18 @@ public enum MockDataProvider {
                     rawWindowSeconds: 604_800
                 )
             ]
-        case .alibaba, .alibabaTokenPlan, .copilot, .zai, .minimax, .kimi, .cursor, .mimo, .iflytek, .tencentHunyuan, .tencentTokenPlan, .volcengine, .volcengineAgentPlan, .baiduQianfan, .openCodeGo, .kilo, .kiro, .ollama, .openRouter, .warp:
+        case .cursor:
+            let monthlyReset = now.addingTimeInterval(26 * 24 * 3600)
+            buckets = [
+                QuotaBucket(id: "models", title: "Cursor Models", shortLabel: "Cursor",
+                            usedPercent: 1, resetAt: monthlyReset, rawWindowSeconds: 2_678_400),
+                QuotaBucket(id: "other_models", title: "Other Models", shortLabel: "Other",
+                            usedPercent: 1, resetAt: monthlyReset, rawWindowSeconds: 2_678_400),
+                QuotaBucket(id: "grok_bot_weekly", title: "Weekly usage", shortLabel: "Grok Bot",
+                            usedPercent: 5, resetAt: weeklyReset, rawWindowSeconds: 604_800,
+                            groupTitle: "Grok Bot")
+            ]
+        case .alibaba, .alibabaTokenPlan, .copilot, .zai, .minimax, .kimi, .mimo, .iflytek, .tencentHunyuan, .tencentTokenPlan, .volcengine, .volcengineAgentPlan, .baiduQianfan, .openCodeGo, .kilo, .kiro, .ollama, .openRouter, .warp:
             // Misc providers' mock data lands in subsequent phases as
             // each adapter is wired up. For now return a single
             // illustrative bucket so the card renders something during

--- a/Sources/VibeBarCore/Services/UsageFillTimelineStore.swift
+++ b/Sources/VibeBarCore/Services/UsageFillTimelineStore.swift
@@ -35,7 +35,7 @@ public actor UsageFillTimelineStore {
     private static let storageSchemaVersion = 2
     private static let saveThrottleInterval: TimeInterval = 30
     private static let maxFileBytes = 24 * 1024 * 1024
-    private static let supportedTools: Set<ToolType> = [.codex, .claude, .gemini, .antigravity, .grok]
+    private static let supportedTools: Set<ToolType> = [.codex, .claude, .gemini, .antigravity, .grok, .cursor]
 
     public init(fileURL: URL = UsageFillTimelineStore.defaultFileURL()) {
         self.fileURL = fileURL

--- a/Sources/VibeBarCore/Services/UsageForecastTimelineStore.swift
+++ b/Sources/VibeBarCore/Services/UsageForecastTimelineStore.swift
@@ -43,7 +43,7 @@ public actor UsageForecastTimelineStore {
     /// point is roughly twice the payload, so the real file stays far under a
     /// megabyte; a file past this size is corrupt, not legitimate history.
     private static let maxFileBytes = 24 * 1024 * 1024
-    private static let supportedTools: Set<ToolType> = [.codex, .claude, .gemini, .antigravity, .grok]
+    private static let supportedTools: Set<ToolType> = [.codex, .claude, .gemini, .antigravity, .grok, .cursor]
 
     public init(fileURL: URL = UsageForecastTimelineStore.defaultFileURL()) {
         self.fileURL = fileURL

--- a/Sources/VibeBarCore/Storage/AccountStore.swift
+++ b/Sources/VibeBarCore/Storage/AccountStore.swift
@@ -56,6 +56,10 @@ public final class AccountStore: ObservableObject {
         if let grok = autoDetectGrok() {
             detected.append(grok)
         }
+        // Cursor Agent is a linked Grok-family surface. Keep its stable account
+        // present even while signed out so the xAI Settings cookie controls can
+        // establish a session without first creating a legacy Misc instance.
+        detected.append(CursorSessionResolver.accountIdentity())
 
         // Misc provider instances always present, regardless of credentials.
         detected.append(contentsOf: Self.miscAccounts(for: miscProviderInstances))

--- a/Tests/VibeBarCoreTests/AppSettingsGoogleAIMigrationTests.swift
+++ b/Tests/VibeBarCoreTests/AppSettingsGoogleAIMigrationTests.swift
@@ -1,9 +1,8 @@
 import XCTest
 @testable import VibeBarCore
 
-/// Locks the one-way migration from "Gemini / Antigravity were misc
-/// providers" to "they're partial-primary, have top-level
-/// `*UsageMode` fields, and are excluded from `miscProviderInstances`."
+/// Locks the one-way migration from linked tools being Misc providers to the
+/// dedicated Google AI / Grok product families.
 ///
 /// The migration runs on every `init(from:)` because both the decode
 /// path and the normalisation helpers now filter by `isMiscPageProvider`.
@@ -44,8 +43,8 @@ final class AppSettingsGoogleAIMigrationTests: XCTestCase {
         XCTAssertEqual(settings.geminiUsageMode, .webOnly)
     }
 
-    func testLegacyGeminiMiscInstanceIsDroppedOnDecode() throws {
-        // Older settings files include `.gemini` / `.antigravity` in
+    func testLegacyLinkedToolMiscInstancesAreDroppedOnDecode() throws {
+        // Older settings files include `.gemini` / `.antigravity` / `.cursor` in
         // `miscProviderInstances`. After the partial-primary upgrade
         // those entries are stale and must not survive a decode.
         let json = """
@@ -68,8 +67,8 @@ final class AppSettingsGoogleAIMigrationTests: XCTestCase {
                        "legacy .gemini misc instance must be filtered out")
         XCTAssertFalse(settings.miscProviderInstances.contains { $0.tool == .antigravity },
                        "legacy .antigravity misc instance must be filtered out")
-        XCTAssertTrue(settings.miscProviderInstances.contains { $0.tool == .cursor },
-                      "unrelated misc instances must survive the migration")
+        XCTAssertFalse(settings.miscProviderInstances.contains { $0.tool == .cursor },
+                       "Cursor now belongs to the Grok product family")
     }
 
     func testLegacyGeminiMiscEntryInMiscProvidersDictIsDroppedOnDecode() throws {
@@ -93,7 +92,7 @@ final class AppSettingsGoogleAIMigrationTests: XCTestCase {
 
         XCTAssertNil(settings.miscProviders[.gemini])
         XCTAssertNil(settings.miscProviders[.antigravity])
-        XCTAssertNotNil(settings.miscProviders[.cursor])
+        XCTAssertNil(settings.miscProviders[.cursor])
     }
 
     func testMigrationIsIdempotent() throws {
@@ -117,5 +116,6 @@ final class AppSettingsGoogleAIMigrationTests: XCTestCase {
 
         XCTAssertFalse(secondPass.miscProviderInstances.contains { $0.tool == .gemini })
         XCTAssertFalse(secondPass.miscProviderInstances.contains { $0.tool == .antigravity })
+        XCTAssertFalse(secondPass.miscProviderInstances.contains { $0.tool == .cursor })
     }
 }

--- a/Tests/VibeBarCoreTests/CursorAppAuthTests.swift
+++ b/Tests/VibeBarCoreTests/CursorAppAuthTests.swift
@@ -1,0 +1,81 @@
+import XCTest
+import SQLite3
+@testable import VibeBarCore
+
+final class CursorAppAuthTests: XCTestCase {
+    func testReadsUsableSessionAndBuildsFirstPartyCookie() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("VibeBarCursorAuth-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let database = directory.appendingPathComponent("state.vscdb")
+        let token = try makeJWT(expiration: Date(timeIntervalSince1970: 2_000_000_000))
+        try writeDatabase(database, token: token)
+
+        let session = try XCTUnwrap(
+            CursorAppAuthStore(dbPath: database.path).loadSession(
+                now: Date(timeIntervalSince1970: 1_900_000_000)
+            )
+        )
+        XCTAssertEqual(session.identity?.userID, "user_fixture")
+        XCTAssertEqual(session.identity?.email, "cursor@example.invalid")
+        XCTAssertEqual(
+            try session.cookieHeader(),
+            "WorkosCursorSessionToken=user_fixture%3A%3A\(token)"
+        )
+    }
+
+    func testExpiredSessionFailsClosed() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("VibeBarCursorAuthExpired-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let database = directory.appendingPathComponent("state.vscdb")
+        try writeDatabase(
+            database,
+            token: makeJWT(expiration: Date(timeIntervalSince1970: 1_800_000_000))
+        )
+
+        XCTAssertNil(try CursorAppAuthStore(dbPath: database.path).loadSession(
+            now: Date(timeIntervalSince1970: 1_900_000_000)
+        ))
+    }
+
+    private func writeDatabase(_ url: URL, token: String) throws {
+        var database: OpaquePointer?
+        XCTAssertEqual(sqlite3_open(url.path, &database), SQLITE_OK)
+        defer { sqlite3_close(database) }
+        XCTAssertEqual(
+            sqlite3_exec(database, "CREATE TABLE ItemTable (key TEXT PRIMARY KEY, value BLOB);", nil, nil, nil),
+            SQLITE_OK
+        )
+        var statement: OpaquePointer?
+        XCTAssertEqual(
+            sqlite3_prepare_v2(database, "INSERT INTO ItemTable(key, value) VALUES(?, ?);", -1, &statement, nil),
+            SQLITE_OK
+        )
+        defer { sqlite3_finalize(statement) }
+        sqlite3_bind_text(statement, 1, "cursorAuth/accessToken", -1, SQLITE_TRANSIENT)
+        sqlite3_bind_text(statement, 2, token, -1, SQLITE_TRANSIENT)
+        XCTAssertEqual(sqlite3_step(statement), SQLITE_DONE)
+    }
+
+    private func makeJWT(expiration: Date) throws -> String {
+        let header = try JSONSerialization.data(withJSONObject: ["alg": "none"])
+        let payload = try JSONSerialization.data(withJSONObject: [
+            "sub": "auth0|user_fixture",
+            "email": "cursor@example.invalid",
+            "exp": expiration.timeIntervalSince1970
+        ])
+        return "\(base64URL(header)).\(base64URL(payload)).signature"
+    }
+
+    private func base64URL(_ data: Data) -> String {
+        data.base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
+}
+
+private let SQLITE_TRANSIENT = unsafeBitCast(-1, to: sqlite3_destructor_type.self)

--- a/Tests/VibeBarCoreTests/CursorCostUsageFetcherTests.swift
+++ b/Tests/VibeBarCoreTests/CursorCostUsageFetcherTests.swift
@@ -1,0 +1,144 @@
+import XCTest
+@testable import VibeBarCore
+
+final class CursorCostUsageFetcherTests: XCTestCase {
+    override func tearDown() {
+        CursorCostStubURLProtocol.handler = nil
+        super.tearDown()
+    }
+
+    func testBuildsSnapshotFromCursorEventsAndExcludesGrokBotRows() async throws {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [CursorCostStubURLProtocol.self]
+        let session = URLSession(configuration: configuration)
+        let now = Date(timeIntervalSince1970: 1_786_968_000)
+
+        CursorCostStubURLProtocol.handler = { request in
+            XCTAssertEqual(request.url?.path, "/api/dashboard/get-filtered-usage-events")
+            XCTAssertEqual(request.value(forHTTPHeaderField: "Origin"), "https://cursor.test")
+            XCTAssertEqual(request.value(forHTTPHeaderField: "Cookie"), "WorkosCursorSessionToken=fixture")
+            let body = try Self.body(of: request)
+            let object = try XCTUnwrap(JSONSerialization.jsonObject(with: body) as? [String: Any])
+            let page = try XCTUnwrap(object["page"] as? Int)
+
+            if page == 1 {
+                return Self.response("""
+                {
+                  "totalUsageEventsCount": 3,
+                  "usageEventsDisplay": [
+                    {
+                      "timestamp": "1786967900000",
+                      "model": "cursor-grok-4.6-high-fast",
+                      "clientType": "cli",
+                      "tokenUsage": {
+                        "inputTokens": 100,
+                        "outputTokens": 50,
+                        "cacheWriteTokens": 5,
+                        "cacheReadTokens": 10,
+                        "totalCents": 100
+                      }
+                    },
+                    {
+                      "timestamp": "1786967950000",
+                      "model": "composer-2.5",
+                      "tokenUsage": {
+                        "inputTokens": "10",
+                        "outputTokens": "5",
+                        "cacheWriteTokens": 0,
+                        "cacheReadTokens": 0,
+                        "totalCents": "50"
+                      }
+                    }
+                  ]
+                }
+                """)
+            }
+            return Self.response("""
+            {
+              "totalUsageEventsCount": "3",
+              "usageEventsDisplay": [
+                {
+                  "timestamp": "1786967990000",
+                  "model": "cloud-model",
+                  "clientType": "grok-bot",
+                  "tokenUsage": {
+                    "inputTokens": 999,
+                    "outputTokens": 999,
+                    "cacheWriteTokens": 0,
+                    "cacheReadTokens": 0,
+                    "totalCents": 999
+                  }
+                }
+              ]
+            }
+            """)
+        }
+
+        let snapshot = try await CursorCostUsageFetcher(
+            session: session,
+            baseURL: URL(string: "https://cursor.test")!,
+            pageSize: 2,
+            maxPages: 3
+        ).fetchSnapshot(
+            cookieHeader: "WorkosCursorSessionToken=fixture",
+            since: nil,
+            until: now,
+            now: now
+        )
+
+        XCTAssertEqual(snapshot.tool, .cursor)
+        XCTAssertEqual(snapshot.allTimeRequests, 2)
+        XCTAssertEqual(snapshot.allTimeTokens, 180)
+        XCTAssertEqual(snapshot.allTimeCostUSD, 1.50, accuracy: 0.000_001)
+        XCTAssertEqual(Set(snapshot.modelBreakdowns.map(\.modelName)), [
+            "cursor-grok-4.6-high-fast", "composer-2.5"
+        ])
+        XCTAssertFalse(snapshot.modelBreakdowns.contains { $0.modelName == "cloud-model" })
+    }
+
+    private static func body(of request: URLRequest) throws -> Data {
+        if let body = request.httpBody { return body }
+        guard let stream = request.httpBodyStream else { return Data() }
+        stream.open()
+        defer { stream.close() }
+        var data = Data()
+        var buffer = [UInt8](repeating: 0, count: 4_096)
+        while stream.hasBytesAvailable {
+            let count = stream.read(&buffer, maxLength: buffer.count)
+            if count <= 0 { break }
+            data.append(buffer, count: count)
+        }
+        return data
+    }
+
+    private static func response(_ body: String) -> (Int, Data) {
+        (200, Data(body.utf8))
+    }
+}
+
+private final class CursorCostStubURLProtocol: URLProtocol {
+    static var handler: ((URLRequest) throws -> (Int, Data))?
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        do {
+            let handler = try XCTUnwrap(Self.handler)
+            let (status, body) = try handler(request)
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: status,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "application/json"]
+            )!
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: body)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
+}

--- a/Tests/VibeBarCoreTests/CursorCostUsageFetcherTests.swift
+++ b/Tests/VibeBarCoreTests/CursorCostUsageFetcherTests.swift
@@ -96,6 +96,62 @@ final class CursorCostUsageFetcherTests: XCTestCase {
         XCTAssertFalse(snapshot.modelBreakdowns.contains { $0.modelName == "cloud-model" })
     }
 
+    func testRejectedCursorAppSessionFallsBackWithoutDoubleCounting() async throws {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [CursorCostStubURLProtocol.self]
+        let session = URLSession(configuration: configuration)
+        let preferred = MiscCookieResolver.Resolution(
+            slotID: nil,
+            header: "WorkosCursorSessionToken=revoked-app",
+            sourceLabel: "Cursor.app"
+        )
+        let fallback = MiscCookieResolver.Resolution(
+            slotID: UUID(),
+            header: "WorkosCursorSessionToken=working-browser",
+            sourceLabel: "Browser"
+        )
+        let plan = CursorSessionResolutionPlan(preferred: preferred, fallbacks: [fallback])
+
+        CursorCostStubURLProtocol.handler = { request in
+            if request.value(forHTTPHeaderField: "Cookie") == preferred.header {
+                return (401, Data())
+            }
+            XCTAssertEqual(request.value(forHTTPHeaderField: "Cookie"), fallback.header)
+            return Self.response("""
+            {
+              "totalUsageEventsCount": 1,
+              "usageEventsDisplay": [
+                {
+                  "timestamp": "1786967900000",
+                  "model": "composer-2.5",
+                  "tokenUsage": {
+                    "inputTokens": 100,
+                    "outputTokens": 50,
+                    "cacheWriteTokens": 0,
+                    "cacheReadTokens": 0,
+                    "totalCents": 25
+                  }
+                }
+              ]
+            }
+            """)
+        }
+
+        let outcome = await CursorCostUsageFetcher.fetch(
+            homeDirectory: "/Users/example",
+            now: Date(timeIntervalSince1970: 1_786_968_000),
+            retentionDays: 30,
+            session: session,
+            resolutionPlan: plan
+        )
+        guard case .success(let snapshot) = outcome else {
+            return XCTFail("Expected browser fallback snapshot")
+        }
+        XCTAssertEqual(snapshot.allTimeRequests, 1)
+        XCTAssertEqual(snapshot.allTimeTokens, 150)
+        XCTAssertEqual(snapshot.allTimeCostUSD, 0.25, accuracy: 0.000_001)
+    }
+
     private static func body(of request: URLRequest) throws -> Data {
         if let body = request.httpBody { return body }
         guard let stream = request.httpBodyStream else { return Data() }

--- a/Tests/VibeBarCoreTests/CursorParserEdgeCasesTests.swift
+++ b/Tests/VibeBarCoreTests/CursorParserEdgeCasesTests.swift
@@ -32,14 +32,11 @@ final class CursorParserEdgeCasesTests: XCTestCase {
             now: now
         )
         XCTAssertEqual(snap.planName, "Pro")
-        // Total bucket
-        let total = try XCTUnwrap(snap.buckets.first { $0.id == "cursor.total" })
-        XCTAssertEqual(total.usedPercent, 0.36, accuracy: 0.001)
-        // Auto / API
-        let auto = try XCTUnwrap(snap.buckets.first { $0.id == "cursor.auto" })
-        XCTAssertEqual(auto.usedPercent, 0.20, accuracy: 0.001)
-        let api = try XCTUnwrap(snap.buckets.first { $0.id == "cursor.api" })
-        XCTAssertEqual(api.usedPercent, 0.52, accuracy: 0.001)
+        XCTAssertEqual(snap.buckets.map(\.title), ["Cursor Models", "Other Models"])
+        let cursorModels = try XCTUnwrap(snap.buckets.first { $0.id == "models" })
+        XCTAssertEqual(cursorModels.usedPercent, 0.20, accuracy: 0.001)
+        let otherModels = try XCTUnwrap(snap.buckets.first { $0.id == "other_models" })
+        XCTAssertEqual(otherModels.usedPercent, 0.52, accuracy: 0.001)
     }
 
     /// Enterprise / team-member personal cap reported under
@@ -61,8 +58,8 @@ final class CursorParserEdgeCasesTests: XCTestCase {
             now: now
         )
         XCTAssertEqual(snap.planName, "Enterprise")
-        // Total derives from overall.used / overall.limit * 100.
-        XCTAssertEqual(snap.buckets.first(where: { $0.id == "cursor.total" })?.usedPercent ?? -1,
+        // Legacy aggregate derives from overall.used / overall.limit * 100.
+        XCTAssertEqual(snap.buckets.first(where: { $0.id == "models" })?.usedPercent ?? -1,
                        75.0, accuracy: 0.01)
     }
 
@@ -84,7 +81,7 @@ final class CursorParserEdgeCasesTests: XCTestCase {
             now: now
         )
         XCTAssertEqual(snap.planName, "Business")
-        XCTAssertEqual(snap.buckets.first(where: { $0.id == "cursor.total" })?.usedPercent ?? -1,
+        XCTAssertEqual(snap.buckets.first(where: { $0.id == "models" })?.usedPercent ?? -1,
                        8.0, accuracy: 0.01)
     }
 
@@ -115,15 +112,13 @@ final class CursorParserEdgeCasesTests: XCTestCase {
         )
         XCTAssertEqual(snap.planName, "Legacy")
         // 350 / 500 * 100 = 70%
-        XCTAssertEqual(snap.buckets.first(where: { $0.id == "cursor.total" })?.usedPercent ?? -1,
+        XCTAssertEqual(snap.buckets.first(where: { $0.id == "models" })?.usedPercent ?? -1,
                        70.0, accuracy: 0.01)
     }
 
-    /// On-demand budget surfaces as a dedicated bucket with the
-    /// dollar amounts in groupTitle — the misc card lifts that as a
-    /// separate row. Crucially, this does *not* go through the global
-    /// cost pipeline (covered by `tool.supportsTokenCost == false`).
-    func testOnDemandBucketCarriesDollarString() throws {
+    /// On-demand spend is billing state, not a subscription quota lane. Cursor
+    /// cost now comes from token-level dashboard events instead.
+    func testOnDemandDoesNotBecomeQuotaBucket() throws {
         let json = """
         {
           "membershipType": "pro",
@@ -140,33 +135,41 @@ final class CursorParserEdgeCasesTests: XCTestCase {
             requestUsage: nil,
             now: now
         )
-        let onDemand = try XCTUnwrap(snap.buckets.first { $0.id == "cursor.onDemand" })
-        XCTAssertEqual(onDemand.groupTitle, "On-demand: $7.30 / $20.00")
-        XCTAssertEqual(onDemand.usedPercent, 36.5, accuracy: 0.01)
+        XCTAssertFalse(snap.buckets.contains { $0.id == "on_demand" })
+        XCTAssertEqual(snap.buckets.map(\.id), ["models"])
     }
 
-    /// Unlimited on-demand: limit is 0 / nil. Bucket still renders,
-    /// label says "unlimited", percent is zero.
-    func testOnDemandUnlimitedRendersUnlimited() throws {
+    func testGrokBotWeeklyBucketUsesDedicatedResetWindow() throws {
         let json = """
         {
-          "membershipType": "business",
-          "individualUsage": {
-            "plan": {"used": 0, "limit": 0, "totalPercentUsed": 0.0},
-            "onDemand": {"used": 1234}
-          }
+          "membershipType": "ultra",
+          "billingCycleStart": "2026-08-12T05:36:22.000Z",
+          "billingCycleEnd": "2026-09-12T05:36:22.000Z",
+          "individualUsage": {"plan": {"autoPercentUsed": 1, "apiPercentUsed": 2}}
         }
         """
         let summary = try CursorResponseParser.decodeUsageSummary(data: Data(json.utf8))
+        let bot = try XCTUnwrap(CursorResponseParser.decodeGrokBotUsage(data: Data("""
+        {
+          "currentPeriodStart": "2026-08-12T05:39:26.906Z",
+          "nextResetTimestampUtc": "2026-08-19T05:39:26.906Z",
+          "usagePercent": 5.361195,
+          "hasAvailableUsage": true,
+          "hasNonZeroIncludedLimit": true
+        }
+        """.utf8)))
         let snap = CursorResponseParser.parseSummary(
             summary: summary,
             userInfo: nil,
             requestUsage: nil,
+            grokBotUsage: bot,
             now: now
         )
-        let onDemand = try XCTUnwrap(snap.buckets.first { $0.id == "cursor.onDemand" })
-        XCTAssertEqual(onDemand.groupTitle, "On-demand: $12.34 / unlimited")
-        XCTAssertEqual(onDemand.usedPercent, 0.0, accuracy: 0.01)
+        let weekly = try XCTUnwrap(snap.buckets.first { $0.id == "grok_bot_weekly" })
+        XCTAssertEqual(weekly.title, "Weekly usage")
+        XCTAssertEqual(weekly.groupTitle, "Grok Bot")
+        XCTAssertEqual(weekly.usedPercent, 5.361195, accuracy: 0.000_001)
+        XCTAssertEqual(weekly.rawWindowSeconds, 604_800)
     }
 
     /// Plan name unknown / missing returns nil so the misc card

--- a/Tests/VibeBarCoreTests/CursorQuotaAdapterFallbackTests.swift
+++ b/Tests/VibeBarCoreTests/CursorQuotaAdapterFallbackTests.swift
@@ -1,0 +1,102 @@
+import XCTest
+@testable import VibeBarCore
+
+final class CursorQuotaAdapterFallbackTests: XCTestCase {
+    override func tearDown() {
+        CursorQuotaFallbackStub.handler = nil
+        super.tearDown()
+    }
+
+    func testRejectedCursorAppSessionFallsBackToSavedCookie() async throws {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [CursorQuotaFallbackStub.self]
+        let session = URLSession(configuration: configuration)
+        let preferred = MiscCookieResolver.Resolution(
+            slotID: nil,
+            header: "WorkosCursorSessionToken=revoked-app",
+            sourceLabel: "Cursor.app"
+        )
+        let fallback = MiscCookieResolver.Resolution(
+            slotID: UUID(),
+            header: "WorkosCursorSessionToken=working-browser",
+            sourceLabel: "Browser"
+        )
+        let plan = CursorSessionResolutionPlan(preferred: preferred, fallbacks: [fallback])
+
+        CursorQuotaFallbackStub.handler = { request in
+            let cookie = request.value(forHTTPHeaderField: "Cookie")
+            if cookie == preferred.header {
+                return (401, Data())
+            }
+            XCTAssertEqual(cookie, fallback.header)
+            switch request.url?.path {
+            case "/api/usage-summary":
+                return (200, Data("""
+                {
+                  "membershipType": "ultra",
+                  "billingCycleStart": "2026-08-12T00:00:00Z",
+                  "billingCycleEnd": "2026-09-12T00:00:00Z",
+                  "individualUsage": {
+                    "plan": {"autoPercentUsed": 1, "apiPercentUsed": 2}
+                  }
+                }
+                """.utf8))
+            case "/api/auth/me":
+                return (200, Data(#"{"sub":"fixture-user"}"#.utf8))
+            case "/api/dashboard/get-sand-usage-status":
+                return (200, Data("""
+                {
+                  "currentPeriodStart": "2026-08-12T00:00:00Z",
+                  "nextResetTimestampUtc": "2026-08-19T00:00:00Z",
+                  "usagePercent": 5,
+                  "hasNonZeroIncludedLimit": true
+                }
+                """.utf8))
+            default:
+                return (404, Data())
+            }
+        }
+
+        let account = AccountIdentity(
+            id: CursorSessionResolver.stableAccountID,
+            tool: .cursor,
+            alias: "Cursor Agent",
+            source: .cliDetected
+        )
+        let quota = try await CursorQuotaAdapter(
+            session: session,
+            now: { Date(timeIntervalSince1970: 1_786_968_000) },
+            resolutionPlanProvider: { _, _ in plan }
+        ).fetch(for: account)
+
+        XCTAssertEqual(quota.plan, "Ultra")
+        XCTAssertEqual(quota.buckets.map(\.id), ["models", "other_models", "grok_bot_weekly"])
+    }
+}
+
+private final class CursorQuotaFallbackStub: URLProtocol {
+    static var handler: ((URLRequest) throws -> (Int, Data))?
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        do {
+            let handler = try XCTUnwrap(Self.handler)
+            let (status, body) = try handler(request)
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: status,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "application/json"]
+            )!
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: body)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
+}

--- a/Tests/VibeBarCoreTests/MenuBarFieldCatalogTests.swift
+++ b/Tests/VibeBarCoreTests/MenuBarFieldCatalogTests.swift
@@ -14,7 +14,10 @@ final class MenuBarFieldCatalogTests: XCTestCase {
             "antigravity.gemini_weekly",
             "antigravity.claude_gpt_five_hour",
             "antigravity.claude_gpt_weekly",
-            "grok.weekly"
+            "grok.weekly",
+            "cursor.models",
+            "cursor.other_models",
+            "cursor.grok_bot_weekly"
         ]
 
         for id in expected {
@@ -31,6 +34,9 @@ final class MenuBarFieldCatalogTests: XCTestCase {
         XCTAssertTrue(selected.contains("antigravity.claude_gpt_five_hour"))
         XCTAssertTrue(selected.contains("antigravity.claude_gpt_weekly"))
         XCTAssertTrue(selected.contains("grok.weekly"))
+        XCTAssertTrue(selected.contains("cursor.models"))
+        XCTAssertTrue(selected.contains("cursor.other_models"))
+        XCTAssertTrue(selected.contains("cursor.grok_bot_weekly"))
     }
 
     func testDefaultLabelsUseFullQuotaWindowNames() {

--- a/Tests/VibeBarCoreTests/PartialPrimaryToolTypeTests.swift
+++ b/Tests/VibeBarCoreTests/PartialPrimaryToolTypeTests.swift
@@ -13,14 +13,19 @@ final class PartialPrimaryToolTypeTests: XCTestCase {
         XCTAssertEqual(ToolType.googleAIPair, [.gemini, .antigravity])
     }
 
-    func testPartialPrimaryProvidersAreGeminiAntigravityAndGrok() {
-        XCTAssertEqual(ToolType.partialPrimaryProviders, [.gemini, .antigravity, .grok])
+    func testGrokFamilyIsExactlyGrokAndCursor() {
+        XCTAssertEqual(ToolType.grokFamily, [.grok, .cursor])
+        XCTAssertEqual(ToolType.cursor.coreProviderRepresentative, .grok)
+    }
+
+    func testPartialPrimaryProvidersIncludeCursorAgent() {
+        XCTAssertEqual(ToolType.partialPrimaryProviders, [.gemini, .antigravity, .grok, .cursor])
     }
 
     func testDedicatedCardProvidersIncludePrimaryAndPartialPrimary() {
         XCTAssertEqual(
             ToolType.dedicatedCardProviders,
-            [.codex, .claude, .gemini, .antigravity, .grok]
+            [.codex, .claude, .gemini, .antigravity, .grok, .cursor]
         )
     }
 
@@ -47,6 +52,16 @@ final class PartialPrimaryToolTypeTests: XCTestCase {
                       "AntiGravity should support token cost via per-conversation SQLite scanning")
     }
 
+    func testCursorIsGrokLinkedAndCostAware() {
+        XCTAssertTrue(ToolType.cursor.supportsDedicatedCard)
+        XCTAssertTrue(ToolType.cursor.isPartialPrimary)
+        XCTAssertTrue(ToolType.cursor.supportsTokenCost)
+        XCTAssertFalse(ToolType.cursor.supportsStatusPage)
+        XCTAssertFalse(ToolType.cursor.isMiscPageProvider)
+        XCTAssertEqual(ToolType.cursor.productName, ToolType.grok.productName)
+        XCTAssertEqual(ToolType.cursor.toolName, "Cursor Agent")
+    }
+
     func testGoogleAIPairSupportsStatusPage() {
         // Both Gemini and Antigravity share Google's Workspace Status
         // dashboard feed (one product entry covers the Gemini family).
@@ -70,15 +85,15 @@ final class PartialPrimaryToolTypeTests: XCTestCase {
         )
     }
 
-    func testCostAwareProvidersIncludeGoogleAIAndGrok() {
+    func testCostAwareProvidersIncludeGoogleAIAndGrokFamily() {
         XCTAssertEqual(
             ToolType.costAwareProviders,
-            [.codex, .claude, .gemini, .antigravity, .grok]
+            [.codex, .claude, .gemini, .antigravity, .grok, .cursor]
         )
     }
 
-    func testGoogleAIPairSupportsDedicatedCard() {
-        for tool in ToolType.googleAIPair {
+    func testPartialPrimaryProvidersSupportDedicatedCards() {
+        for tool in ToolType.partialPrimaryProviders {
             XCTAssertTrue(tool.supportsDedicatedCard, "\(tool) should support a dedicated card")
             XCTAssertTrue(tool.isPartialPrimary, "\(tool) should be partial-primary")
             XCTAssertFalse(tool.isPrimary, "\(tool) should not be `isPrimary`")
@@ -87,7 +102,7 @@ final class PartialPrimaryToolTypeTests: XCTestCase {
     }
 
     func testIsMiscStaysTrueForPartialPrimaryForBackwardCompat() {
-        // The plan keeps `isMisc` true for Gemini/Antigravity so legacy
+        // Keep `isMisc` true for linked tools so legacy
         // misc-only call sites (MiscCookieSlotStore, etc.) keep working.
         // Code that wants to filter the Misc page should use the new
         // `isMiscPageProvider`.
@@ -100,6 +115,6 @@ final class PartialPrimaryToolTypeTests: XCTestCase {
         XCTAssertFalse(ToolType.miscPageProviders.contains(.gemini))
         XCTAssertFalse(ToolType.miscPageProviders.contains(.antigravity))
         XCTAssertTrue(ToolType.miscPageProviders.contains(.copilot))
-        XCTAssertTrue(ToolType.miscPageProviders.contains(.cursor))
+        XCTAssertFalse(ToolType.miscPageProviders.contains(.cursor))
     }
 }

--- a/Tests/VibeBarCoreTests/ProviderPlanDisplayTests.swift
+++ b/Tests/VibeBarCoreTests/ProviderPlanDisplayTests.swift
@@ -86,7 +86,7 @@ final class ProviderPlanDisplayTests: XCTestCase {
     /// We keep the assertions for the primary tools only because
     /// they're the ones the user mentally maps to the hierarchy.
     func testPrimaryToolHierarchyLevelsAreDistinct() {
-        let tools: [ToolType] = [.codex, .claude, .gemini, .antigravity, .grok]
+        let tools: [ToolType] = [.codex, .claude, .gemini, .antigravity, .grok, .cursor]
         for tool in tools {
             // L1 vendor and L2 product must not be empty.
             XCTAssertFalse(tool.vendorName.isEmpty, "vendorName for \(tool)")
@@ -103,6 +103,8 @@ final class ProviderPlanDisplayTests: XCTestCase {
         // under the Google vendor — the dual page relies on this.
         XCTAssertEqual(ToolType.gemini.vendorName, ToolType.antigravity.vendorName)
         XCTAssertEqual(ToolType.gemini.productName, ToolType.antigravity.productName)
+        XCTAssertEqual(ToolType.grok.productName, ToolType.cursor.productName)
+        XCTAssertNotEqual(ToolType.grok.vendorName, ToolType.cursor.vendorName)
     }
 
     private func makeJWT(payload: [String: Any]) throws -> String {

--- a/Tests/VibeBarCoreTests/QuotaBucketTests.swift
+++ b/Tests/VibeBarCoreTests/QuotaBucketTests.swift
@@ -2,6 +2,20 @@ import XCTest
 @testable import VibeBarCore
 
 final class QuotaBucketTests: XCTestCase {
+    func testCursorPositiveSubPercentDisplaysAsOneWithoutChangingStoredValue() {
+        let bucket = QuotaBucket(
+            id: "models",
+            title: "Cursor Models",
+            shortLabel: "Cursor",
+            usedPercent: 0.016
+        )
+
+        XCTAssertEqual(bucket.usedPercent, 0.016, accuracy: 0.000_001)
+        XCTAssertEqual(bucket.displayPercent(.used, tool: .cursor), 1)
+        XCTAssertEqual(bucket.displayPercent(.remaining, tool: .cursor), 99)
+        XCTAssertEqual(bucket.displayPercent(.used, tool: .grok), 0.016, accuracy: 0.000_001)
+    }
+
     /// `min/max` over Doubles passes NaN through in one ordering and
     /// silently turns it into the bound in the other. Without an
     /// explicit isFinite gate, a non-finite percent from a buggy


### PR DESCRIPTION
## Summary
- move Cursor from Misc into the Grok product family and show Cursor Models, Other Models, and Grok Bot weekly quota alongside Grok Build
- prefer read-only Cursor.app auth with existing cursor.com cookie slots as fallback
- import Cursor dashboard token/cost events, keep Grok Bot quota-only, and combine Cursor Agent with Grok Build across Grok cost surfaces
- update mini-window fields, xAI settings, migrations, bilingual docs, and regression coverage

## Test plan
- [x] `swift build`
- [x] `swift test` — 1450 tests, 1 skipped, 0 failures
- [x] `./Scripts/build_app.sh release`
- [x] empty entitlements confirmed; no `com.apple.security.app-sandbox`
- [x] `codesign --verify --deep --strict ".build/Vibe Bar.app"`
- [x] live read-only Cursor validation: Cursor Models / Other Models response, Grok Bot weekly reset response, and token/cost event shape

Co-Authored-By: Codex <noreply@openai.com>