### PR TITLE
Align quota groups and usage statistics

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ visibility and ordering from one two-column settings window.
 | ChatGPT / Codex | Codex subscription windows, Spark, OpenAI status | `~/.codex/sessions/**/*.jsonl` |
 | Claude Code | 5 Hours, Weekly, Fable, Anthropic status | `~/.claude/projects/**/*.jsonl` |
 | Gemini + AntiGravity | Gemini Web quotas and local AntiGravity language-server quotas | Local Gemini/AntiGravity usage records |
-| Grok + Cursor Agent | Grok Build quota, Cursor Models, Other Models, Grok Bot weekly quota, xAI status | Local Grok Build records + Cursor account usage events; Grok Bot is quota-only |
+| Grok + Cursor | Grok Build quota, Cursor Models, Other Models, Grok Bot weekly quota, xAI status | Local Grok Build records + Cursor account usage events; Grok Bot is quota-only |
 | Misc providers | Provider-specific coding/token plan endpoints | Quota-only unless an adapter exposes local usage |
 
 Provider contracts can change without notice. Vibe Bar keeps refresh errors

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -130,7 +130,7 @@ OpenCode Go、Ollama Cloud、智谱 GLM、小米 MiMo、Kimi、MiniMax、阿里�
 | ChatGPT / Codex | Codex 订阅窗口、Spark、OpenAI 状态 | `~/.codex/sessions/**/*.jsonl` |
 | Claude Code | 5 Hours、Weekly、Fable、Anthropic 状态 | `~/.claude/projects/**/*.jsonl` |
 | Gemini + AntiGravity | Gemini Web 配额与本地 AntiGravity Language Server 配额 | 本地 Gemini/AntiGravity 用量记录 |
-| Grok + Cursor Agent | Grok Build 配额、Cursor Models、Other Models、Grok Bot 周配额、xAI 状态 | 本地 Grok Build 记录 + Cursor 账户用量事件；Grok Bot 仅显示配额 |
+| Grok + Cursor | Grok Build 配额、Cursor Models、Other Models、Grok Bot 周配额、xAI 状态 | 本地 Grok Build 记录 + Cursor 账户用量事件；Grok Bot 仅显示配额 |
 | Misc Providers | 各服务商自己的 Coding/Token Plan 接口 | 除非 Adapter 能取得本地用量，否则仅显示额度 |
 
 服务商的私有接口随时可能变化。Vibe Bar 会明确显示刷新错误，保留上一次成功

--- a/Sources/VibeBarApp/Controllers/UsageStatsViewModel.swift
+++ b/Sources/VibeBarApp/Controllers/UsageStatsViewModel.swift
@@ -124,16 +124,21 @@ final class UsageStatsViewModel: ObservableObject {
 
     // MARK: - Results
 
-    @Published private(set) var summary: UsageSummaryMetrics = .empty
-    @Published private(set) var trend = UsageTrendSeries(bucket: .day, points: [])
-    @Published private(set) var providerStats: [UsageProviderStat] = []
-    @Published private(set) var modelStats: [UsageModelStat] = []
-    @Published private(set) var requestRows: [UsageRequestRow] = []
-    @Published private(set) var requestTotalCount = 0
+    /// One publication for the query's mutually consistent result set. The
+    /// old six independent `@Published` writes made SwiftUI rebuild the whole
+    /// Workbench analytics tree six times after a 30-day query, even though
+    /// every value came from the same ledger snapshot.
+    @Published private var results = UsageResults.empty
+    var summary: UsageSummaryMetrics { results.summary }
+    var trend: UsageTrendSeries { results.trend }
+    var providerStats: [UsageProviderStat] { results.providerStats }
+    var modelStats: [UsageModelStat] { results.modelStats }
+    var requestRows: [UsageRequestRow] { results.requestRows }
+    var requestTotalCount: Int { results.requestTotalCount }
     @Published private(set) var availableModels: [String] = []
     /// Providers offered as filter chips: the cost-aware set, widened by any
     /// provider the ledger actually has rows for.
-    @Published private(set) var knownTools: [ToolType] = ToolType.costAwareProviders
+    @Published private(set) var knownTools: [ToolType] = ToolType.usageStatsProviders
     @Published private(set) var isLoading = false
     @Published private(set) var isLoadingMore = false
     @Published private(set) var lastUpdatedAt: Date?
@@ -400,8 +405,18 @@ final class UsageStatsViewModel: ObservableObject {
         let tools = filter.tools
         isLoading = true
         reloadTask = Task { [weak self] in
-            let models = (try? await ledger.availableModels(tools: tools)) ?? []
-            guard let self, !Task.isCancelled, generation == self.generation else { return }
+            guard let self else { return }
+            // Model availability depends on the provider filter, not the time
+            // range. Re-query it only when that filter cascades; changing 7 d
+            // to 30 d should go straight to the range queries instead of
+            // scanning the ledger's full model index first.
+            let models: [String]
+            if cascadeModels || self.availableModels.isEmpty {
+                models = (try? await ledger.availableModels(tools: tools)) ?? []
+            } else {
+                models = self.availableModels
+            }
+            guard !Task.isCancelled, generation == self.generation else { return }
             // Models first: a narrowed provider set can strand a model that no
             // longer exists in the picker, and querying with it would report
             // an empty page the user has no control to clear.
@@ -437,31 +452,35 @@ final class UsageStatsViewModel: ObservableObject {
     }
 
     private func apply(_ snapshot: LoadedUsage) {
-        summary = snapshot.summary
-        trend = snapshot.trend
-        providerStats = snapshot.providers
-        modelStats = snapshot.models
-        requestRows = snapshot.requests.rows
-        requestTotalCount = snapshot.requests.totalCount
+        results = UsageResults(
+            summary: snapshot.summary,
+            trend: snapshot.trend,
+            providerStats: snapshot.providers,
+            modelStats: snapshot.models,
+            requestRows: snapshot.requests.rows,
+            requestTotalCount: snapshot.requests.totalCount
+        )
         loadedRequestPages = 1
         observedTools.formUnion(snapshot.providers.map(\.tool))
         observedTools.formUnion(selectedTools ?? [])
         knownTools = ToolType.allCases.filter {
-            $0.supportsTokenCost || observedTools.contains($0)
+            ToolType.usageStatsProviders.contains($0) || observedTools.contains($0)
         }
         lastUpdatedAt = Date()
         isLoading = false
     }
 
     private func applyEmpty() {
-        summary = .empty
-        trend = UsageTrendSeries(
-            bucket: trendGranularity.resolved(for: range), points: []
+        results = UsageResults(
+            summary: .empty,
+            trend: UsageTrendSeries(
+                bucket: trendGranularity.resolved(for: range), points: []
+            ),
+            providerStats: [],
+            modelStats: [],
+            requestRows: [],
+            requestTotalCount: 0
         )
-        providerStats = []
-        modelStats = []
-        requestRows = []
-        requestTotalCount = 0
         availableModels = []
         isLoading = false
     }
@@ -469,8 +488,10 @@ final class UsageStatsViewModel: ObservableObject {
     private func append(_ page: UsageRequestPage) {
         guard page.page == loadedRequestPages else { return }
         let known = Set(requestRows.map(\.id))
-        requestRows.append(contentsOf: page.rows.filter { !known.contains($0.id) })
-        requestTotalCount = page.totalCount
+        var updated = results
+        updated.requestRows.append(contentsOf: page.rows.filter { !known.contains($0.id) })
+        updated.requestTotalCount = page.totalCount
+        results = updated
         loadedRequestPages = page.page + 1
     }
 
@@ -510,6 +531,24 @@ final class UsageStatsViewModel: ObservableObject {
         let providers: [UsageProviderStat]
         let models: [UsageModelStat]
         let requests: UsageRequestPage
+    }
+
+    private struct UsageResults {
+        var summary: UsageSummaryMetrics
+        var trend: UsageTrendSeries
+        var providerStats: [UsageProviderStat]
+        var modelStats: [UsageModelStat]
+        var requestRows: [UsageRequestRow]
+        var requestTotalCount: Int
+
+        static let empty = UsageResults(
+            summary: .empty,
+            trend: UsageTrendSeries(bucket: .day, points: []),
+            providerStats: [],
+            modelStats: [],
+            requestRows: [],
+            requestTotalCount: 0
+        )
     }
 
     private nonisolated static func load(

--- a/Sources/VibeBarApp/Controllers/UsageStatsViewModel.swift
+++ b/Sources/VibeBarApp/Controllers/UsageStatsViewModel.swift
@@ -272,6 +272,7 @@ final class UsageStatsViewModel: ObservableObject {
     private var tickTask: Task<Void, Never>?
     private var lastCostRefreshAt: Date?
     private var loadedRequestPages = 0
+    private var lastAvailableModelsRevision: UInt64?
     private var generation: UInt64 = 0
     private var hasLoadedOnce = false
     /// A historical window start, or `nil` when the preset follows now.
@@ -406,13 +407,23 @@ final class UsageStatsViewModel: ObservableObject {
         isLoading = true
         reloadTask = Task { [weak self] in
             guard let self else { return }
-            // Model availability depends on the provider filter, not the time
-            // range. Re-query it only when that filter cascades; changing 7 d
-            // to 30 d should go straight to the range queries instead of
-            // scanning the ledger's full model index first.
+            // Model availability depends on the provider filter and ledger
+            // contents, not the time range. The ledger revision lets 7 d →
+            // 30 d reuse the same options while an automatic usage refresh
+            // still exposes a newly observed model immediately.
+            let ledgerRevision = await ledger.contentRevision()
             let models: [String]
-            if cascadeModels || self.availableModels.isEmpty {
-                models = (try? await ledger.availableModels(tools: tools)) ?? []
+            var refreshedModelsRevision: UInt64?
+            if cascadeModels
+                || self.availableModels.isEmpty
+                || self.lastAvailableModelsRevision != ledgerRevision
+            {
+                if let refreshed = try? await ledger.availableModels(tools: tools) {
+                    models = refreshed
+                    refreshedModelsRevision = ledgerRevision
+                } else {
+                    models = self.availableModels
+                }
             } else {
                 models = self.availableModels
             }
@@ -424,6 +435,9 @@ final class UsageStatsViewModel: ObservableObject {
                 self.pruneSelectedModels(to: models)
             }
             self.availableModels = models
+            if let refreshedModelsRevision {
+                self.lastAvailableModelsRevision = refreshedModelsRevision
+            }
             let resolved = self.filter
             let supportsHourly = (try? await ledger.supportsHourlyTrend(resolved)) ?? false
             guard !Task.isCancelled, generation == self.generation else { return }

--- a/Sources/VibeBarApp/MiniQuotaWindowController.swift
+++ b/Sources/VibeBarApp/MiniQuotaWindowController.swift
@@ -230,6 +230,10 @@ final class MiniQuotaWindowController: NSObject, NSWindowDelegate {
             return "claude.fable"
         case "weekly_oauth_apps":
             return "claude.oauth"
+        case "models" where tool == .cursor:
+            return "cursor.models"
+        case "other_models" where tool == .cursor:
+            return "cursor.other-models"
         case "grok_bot_weekly" where tool == .cursor:
             return "cursor.grok-bot"
         default:
@@ -296,7 +300,7 @@ final class MiniQuotaWindowController: NSObject, NSWindowDelegate {
         // Sizing now mirrors the L2-grouped layout in
         // `MiniWindowProviderLayout`: consecutive tools sharing the
         // same L2 productName (Gemini Web + AntiGravity → "Gemini",
-        // Grok Build + Cursor Agent → "Grok")
+        // Grok Build + Cursor → "Grok")
         // share one provider column with an internal divider between
         // L3 sub-tools. Group dividers come from the actual primary +
         // branch-group count derived from selected bucket ids; the

--- a/Sources/VibeBarApp/StatusItemController.swift
+++ b/Sources/VibeBarApp/StatusItemController.swift
@@ -865,7 +865,8 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
             bucket: bucket,
             activityHeatmap: snapshot?.heatmap,
             dailyActivity: snapshot?.dailyHistory ?? [],
-            now: Date()
+            now: Date(),
+            allowsPostResetGrace: true
         )?.verdict
     }
 

--- a/Sources/VibeBarApp/Views/MiniQuotaWindowView.swift
+++ b/Sources/VibeBarApp/Views/MiniQuotaWindowView.swift
@@ -279,6 +279,8 @@ private struct MiniBranchCell: Identifiable {
         case "weekly_opus": return "Weekly"
         case "weekly_fable": return "Weekly"
         case "weekly_oauth_apps": return "Weekly"
+        case let id where tool == .cursor && ["models", "other_models", "grok_bot_weekly"].contains(id):
+            return "Weekly"
         case let id where tool == .antigravity && id.contains("gpt-oss"):
             return "GPT"
         case let id where tool == .antigravity && id.contains("sonnet"):
@@ -315,6 +317,12 @@ private struct MiniBranchCell: Identifiable {
             return "claude.fable"
         case "weekly_oauth_apps":
             return "claude.oauth"
+        case "models" where tool == .cursor:
+            return "cursor.models"
+        case "other_models" where tool == .cursor:
+            return "cursor.other-models"
+        case "grok_bot_weekly" where tool == .cursor:
+            return "cursor.grok-bot"
         case let id where tool == .antigravity && ["gemini_five_hour", "gemini_weekly"].contains(id):
             return "antigravity.gemini-models"
         case let id where tool == .antigravity && ["claude_gpt_five_hour", "claude_gpt_weekly"].contains(id):
@@ -359,6 +367,12 @@ private struct MiniBranchCell: Identifiable {
             return "Fable"
         case "weekly_oauth_apps":
             return "OAuth"
+        case "models" where tool == .cursor:
+            return "Cursor Models"
+        case "other_models" where tool == .cursor:
+            return "Other Models"
+        case "grok_bot_weekly" where tool == .cursor:
+            return "Grok Bot"
         case let id where tool == .antigravity && ["gemini_five_hour", "gemini_weekly"].contains(id):
             return "Gemini"
         case let id where tool == .antigravity && ["claude_gpt_five_hour", "claude_gpt_weekly"].contains(id):
@@ -438,7 +452,8 @@ private func miniQuotaForecast(
         bucket: bucket,
         activityHeatmap: snapshot?.heatmap,
         dailyActivity: snapshot?.dailyHistory ?? [],
-        now: now
+        now: now,
+        allowsPostResetGrace: true
     )
 }
 
@@ -551,7 +566,7 @@ private func miniPrimaryGroupTitle(
 /// Renders one L2 product super-column in the regular (ring) layout.
 /// Single-tool groups (ChatGPT / Claude) get a compact L2 header + bucket
 /// rings. Multi-tool groups (Gemini = Gemini Web + AntiGravity; Grok = Grok
-/// Build + Cursor Agent) get the L2 header on top, each L3 tool as a
+/// Build + Cursor) get the L2 header on top, each L3 tool as a
 /// sub-section beneath with its own small toolName sub-label,
 /// separated by a thin divider.
 private struct MiniL2GroupColumn: View {
@@ -743,7 +758,7 @@ private struct MiniBranchRingCell: View {
 
     @ViewBuilder
     private func content(now: Date) -> some View {
-        let pace = UsagePace.compute(bucket: cell.bucket, now: now)
+        let pace = UsagePace.compute(bucket: cell.bucket, now: now, allowsPostResetGrace: true)
         let forecast = miniQuotaForecast(
             tool: cell.tool,
             bucket: cell.bucket,
@@ -865,7 +880,9 @@ private struct MiniRingCell: View {
 
     @ViewBuilder
     private func content(now: Date) -> some View {
-        let pace = cell.bucket.flatMap { UsagePace.compute(bucket: $0, now: now) }
+        let pace = cell.bucket.flatMap {
+            UsagePace.compute(bucket: $0, now: now, allowsPostResetGrace: true)
+        }
         let forecast = cell.bucket.flatMap {
             miniQuotaForecast(
                 tool: cell.tool,
@@ -1212,7 +1229,9 @@ private struct MiniCompactBarCell: View {
 
     @ViewBuilder
     private func content(now: Date) -> some View {
-        let pace = data.bucket.flatMap { UsagePace.compute(bucket: $0, now: now) }
+        let pace = data.bucket.flatMap {
+            UsagePace.compute(bucket: $0, now: now, allowsPostResetGrace: true)
+        }
         let forecast = data.bucket.flatMap {
             miniQuotaForecast(
                 tool: data.tool,

--- a/Sources/VibeBarApp/Views/MiniWindowGroupLabelCatalog.swift
+++ b/Sources/VibeBarApp/Views/MiniWindowGroupLabelCatalog.swift
@@ -23,7 +23,10 @@ enum MiniWindowGroupLabelCatalog {
         .init(id: "gemini.flash-lite", title: "GEMINI · Flash Lite", defaultLabel: "Lite"),
         .init(id: "antigravity.gemini-models", title: "ANTIGRAVITY · Gemini Models", defaultLabel: "Gemini"),
         .init(id: "antigravity.claude-gpt-models", title: "ANTIGRAVITY · Claude + GPT Models", defaultLabel: "C+G"),
-        .init(id: "grok.all-models", title: "GROK · All Models", defaultLabel: "All Models")
+        .init(id: "grok.all-models", title: "GROK · All Models", defaultLabel: "All Models"),
+        .init(id: "cursor.models", title: "CURSOR · Cursor Models", defaultLabel: "Cursor Models"),
+        .init(id: "cursor.other-models", title: "CURSOR · Other Models", defaultLabel: "Other Models"),
+        .init(id: "cursor.grok-bot", title: "CURSOR · Grok Bot", defaultLabel: "Grok Bot")
     ]
 
     static func defaultLabel(for id: String) -> String? {

--- a/Sources/VibeBarApp/Views/MiscProvidersPage.swift
+++ b/Sources/VibeBarApp/Views/MiscProvidersPage.swift
@@ -362,7 +362,7 @@ private struct MiscQuotaBody: View {
         // dedicated cards get works here too; buckets without window data
         // just fall back to the plain bar.
         let now = Date()
-        let pace = UsagePace.compute(bucket: bucket, now: now)
+        let pace = UsagePace.compute(bucket: bucket, now: now, allowsPostResetGrace: true)
         let expectedDisplayed = pace.map { p -> Double in
             switch mode {
             case .used:      return p.expectedUsedPercent

--- a/Sources/VibeBarApp/Views/PageModuleCatalog.swift
+++ b/Sources/VibeBarApp/Views/PageModuleCatalog.swift
@@ -470,7 +470,7 @@ enum PageModuleCatalog {
         )
     }
 
-    /// Combined Grok Build local sessions + Cursor Agent dashboard events.
+    /// Combined Grok Build local sessions + Cursor dashboard events.
     @MainActor
     static func grokCostSnapshot(environment: AppEnvironment) -> CostSnapshot {
         environment.costService.combinedSnapshot(

--- a/Sources/VibeBarApp/Views/PopoverRoot.swift
+++ b/Sources/VibeBarApp/Views/PopoverRoot.swift
@@ -116,7 +116,7 @@ struct PopoverRoot: View {
         case .openAI: return ToolType.codex.subtitle
         case .claude: return ToolType.claude.subtitle
         case .googleAI: return "Gemini Web + AntiGravity · quota & status"
-        case .grok: return "xAI · Grok Build, Cursor Agent, cost & status"
+        case .grok: return "xAI · Grok Build, Cursor, cost & status"
         case .misc: return "Usage-only · sign in or paste a key"
         case .machines: return "End-to-end encrypted remote usage"
         }
@@ -591,7 +591,7 @@ private struct OverviewWaterfall: View {
                     density: density,
                     snapshotOverride: context.grokSnapshot,
                     titleOverride: "Grok Cost",
-                    emptyMessageOverride: "No Grok Build or Cursor Agent usage found yet.",
+                    emptyMessageOverride: "No Grok Build or Cursor usage found yet.",
                     toolNameOverride: "Grok",
                     heatmapTitleOverride: "When you use Grok"
                 )
@@ -795,7 +795,7 @@ private struct GeminiCombinedCard: View {
 }
 
 /// Overview card for the Grok product family. Grok Build remains the primary
-/// xAI surface; Cursor Agent contributes its Cursor Models / Other Models pools
+/// xAI surface; Cursor contributes its Cursor Models / Other Models pools
 /// plus the cloud-only Grok Bot weekly quota as a linked L3 tool.
 private struct GrokCombinedCard: View {
     let density: Theme.Density
@@ -832,7 +832,7 @@ private struct GrokCombinedCard: View {
                 }
                 BorderlessIconButton(
                     systemImage: "arrow.clockwise",
-                    help: "Refresh Grok Build + Cursor Agent"
+                    help: "Refresh Grok Build + Cursor"
                 ) {
                     environment.refresh(.grok)
                     environment.refresh(.cursor)
@@ -1725,7 +1725,7 @@ private struct ProviderPageModule: View {
             if context.pageTool == .gemini {
                 GeminiCostEmptyCard(density: density)
             } else if context.pageTool == .grok {
-                Text("No Grok Build or Cursor Agent usage found yet.")
+                Text("No Grok Build or Cursor usage found yet.")
                     .font(.system(size: density.subtitleFontSize))
                     .foregroundStyle(.tertiary)
                     .padding(.vertical, 24)
@@ -2136,7 +2136,7 @@ private struct ProviderBucketRow: View {
     @ViewBuilder
     private func content(now: Date) -> some View {
         let percent = bucket.displayPercent(mode, tool: tool)
-        let pace = UsagePace.compute(bucket: bucket, now: now)
+        let pace = UsagePace.compute(bucket: bucket, now: now, allowsPostResetGrace: true)
         let forecast = paceForecast(now: now)
         let timePaceDisplayed = pace.map { expectedDisplay(for: $0, mode: mode) }
         VStack(alignment: .leading, spacing: density.bucketRowSpacing) {
@@ -2209,7 +2209,8 @@ private struct ProviderBucketRow: View {
             bucket: bucket,
             activityHeatmap: snapshot?.heatmap,
             dailyActivity: snapshot?.dailyHistory ?? [],
-            now: now
+            now: now,
+            allowsPostResetGrace: true
         )
     }
 

--- a/Sources/VibeBarApp/Views/QuotaGroupCard.swift
+++ b/Sources/VibeBarApp/Views/QuotaGroupCard.swift
@@ -34,6 +34,9 @@ struct QuotaGroupModule: Identifiable {
     let accountId: String?
     /// The group's heading, `nil` for the unnamed run.
     let title: String?
+    /// Optional brand mark beside a group heading. Grok Bot has no separate
+    /// bundled asset, so its section deliberately reuses the Grok glyph.
+    let groupTitleIconTool: ToolType?
     /// Account-scoped identity of the group's history chart. Unchanged from the
     /// pre-split card so an existing chart keeps its state.
     let chartKey: String
@@ -136,6 +139,7 @@ enum QuotaGroupModuleBuilder {
                     tool: head.tool,
                     accountId: head.accountId,
                     title: title,
+                    groupTitleIconTool: head.tool == .cursor && title == "Grok Bot" ? .grok : nil,
                     chartKey: chartKeys[index],
                     rows: raw[index...end].map {
                         QuotaGroupModule.Row(
@@ -174,6 +178,7 @@ enum QuotaGroupModuleBuilder {
             tool: pageTool,
             accountId: accountId,
             title: title,
+            groupTitleIconTool: nil,
             chartKey: QuotaBucketGrouping.key(accountId: nil, itemTool: pageTool, title: title),
             rows: [],
             linkedSectionTitle: nil,
@@ -275,11 +280,17 @@ struct QuotaGroupCard: View {
                 }
             }
             if let title = module.title {
-                Text(title)
-                    .font(.system(size: max(9, density.subtitleFontSize - 1), weight: .semibold))
-                    .foregroundStyle(.tertiary)
-                    .textCase(.uppercase)
-                    .tracking(0.4)
+                HStack(spacing: 5) {
+                    if let iconTool = module.groupTitleIconTool {
+                        ToolBrandIconView(tool: iconTool, size: 11)
+                            .opacity(0.78)
+                    }
+                    Text(title)
+                        .font(.system(size: max(9, density.subtitleFontSize - 1), weight: .semibold))
+                        .foregroundStyle(.tertiary)
+                        .textCase(.uppercase)
+                        .tracking(0.4)
+                }
             }
         }
     }
@@ -362,7 +373,7 @@ struct QuotaGroupCard: View {
     @ViewBuilder
     private func row(for item: QuotaGroupModule.Row) -> some View {
         let bucket = item.bucket
-        let pace = UsagePace.compute(bucket: bucket, now: now)
+        let pace = UsagePace.compute(bucket: bucket, now: now, allowsPostResetGrace: true)
         let forecast = paceForecast(for: item)
         let used = bucket.displayPercent(.used, tool: item.tool)
         let timeExpected = pace.map { displayedPercent(fromUsed: $0.expectedUsedPercent) }
@@ -505,7 +516,8 @@ struct QuotaGroupCard: View {
             bucket: item.bucket,
             activityHeatmap: snapshot?.heatmap,
             dailyActivity: snapshot?.dailyHistory ?? [],
-            now: now
+            now: now,
+            allowsPostResetGrace: true
         )
     }
 

--- a/Sources/VibeBarApp/Views/SettingsView.swift
+++ b/Sources/VibeBarApp/Views/SettingsView.swift
@@ -473,7 +473,7 @@ struct SettingsView: View {
                         coreProviderPlanBadgeRows(for: [.grok, .cursor])
                         Divider()
                             .padding(.vertical, 2)
-                        Text("Grok combines Grok Build with Cursor Agent. Grok Build reads `~/.grok/auth.json` or grok.com cookies; Cursor Agent reads Cursor.app first, then cursor.com cookie slots. Grok Bot contributes quota only — its cloud runs do not add token/cost rows.")
+                        Text("Grok combines Grok Build with Cursor. Grok Build reads `~/.grok/auth.json` or grok.com cookies; Cursor reads Cursor.app first, then cursor.com cookie slots. Grok Bot contributes quota only — its cloud runs do not add token/cost rows.")
                             .font(.caption)
                             .foregroundStyle(.secondary)
 
@@ -521,7 +521,7 @@ struct SettingsView: View {
                         Divider()
                             .padding(.vertical, 2)
 
-                        sourceSummary(label: "Cursor Agent source", value: "Cursor.app → Web")
+                        sourceSummary(label: "Cursor source", value: "Cursor.app → Web")
                         if environment.account(for: .cursor)?.source == .cliDetected {
                             Label("Cursor.app signed-in session detected", systemImage: "checkmark.circle")
                                 .font(.caption2)

--- a/Sources/VibeBarCore/Adapters/AntigravityQuotaAdapter.swift
+++ b/Sources/VibeBarCore/Adapters/AntigravityQuotaAdapter.swift
@@ -157,8 +157,14 @@ enum AntigravityResponseParser {
 
         func mergingIdentity(_ identity: Snapshot?) -> Snapshot {
             guard let identity else { return self }
+            var mergedBuckets = buckets
+            let existingIds = Set(mergedBuckets.map(\.id))
+            mergedBuckets.append(contentsOf: identity.buckets.filter { !existingIds.contains($0.id) })
+            let orderedBuckets = QuotaSummarySlot.displayOrder.compactMap { slot in
+                mergedBuckets.first { $0.id == slot.id }
+            }
             return Snapshot(
-                buckets: buckets,
+                buckets: orderedBuckets,
                 planName: identity.planName ?? planName,
                 email: identity.email ?? email,
                 modelLabels: identity.modelLabels.isEmpty ? modelLabels : identity.modelLabels
@@ -232,15 +238,47 @@ enum AntigravityResponseParser {
         }
 
         var modelLabels: [String: String] = [:]
+        var fallbackFiveHourBuckets: [QuotaSummaryGroupKind: QuotaBucket] = [:]
         for config in userStatus.cascadeModelConfigData?.clientModelConfigs ?? [] {
             if let rawModel = config.modelOrAlias?.model {
                 let trimmed = rawModel.trimmingCharacters(in: .whitespacesAndNewlines)
                 if !trimmed.isEmpty { modelLabels[trimmed] = config.label }
             }
+            // RetrieveUserQuotaSummary can omit a group's 5-hour lane when
+            // its weekly pool is exhausted. GetUserStatus still exposes the
+            // same live 5-hour state on each model config, so retain one
+            // conservative group-level candidate as a fallback. Summary rows
+            // remain authoritative and win during `mergingIdentity`.
+            guard let quota = config.quotaInfo,
+                  let group = quotaGroupKind(
+                      groupName: config.label,
+                      bucketId: config.modelOrAlias?.model
+                  )
+            else { continue }
+            let slot = QuotaSummarySlot(group: group, cadence: .fiveHour)
+            let candidate = quotaBucket(
+                slot: slot,
+                remainingFraction: quota.remainingFraction ?? 0,
+                resetAt: quota.resetTime.flatMap(parseDate)
+            )
+            if let current = fallbackFiveHourBuckets[group],
+               current.usedPercent >= candidate.usedPercent {
+                continue
+            }
+            fallbackFiveHourBuckets[group] = candidate
         }
 
         let plan = userStatus.userTier?.preferredName ?? userStatus.planStatus?.planInfo?.preferredName
-        return Snapshot(buckets: [], planName: plan, email: userStatus.email, modelLabels: modelLabels)
+        let fallbackBuckets = QuotaSummarySlot.displayOrder.compactMap { slot -> QuotaBucket? in
+            guard slot.cadence == .fiveHour else { return nil }
+            return fallbackFiveHourBuckets[slot.group]
+        }
+        return Snapshot(
+            buckets: fallbackBuckets,
+            planName: plan,
+            email: userStatus.email,
+            modelLabels: modelLabels
+        )
     }
 
     static func parseDate(_ raw: String) -> Date? {
@@ -469,10 +507,16 @@ private struct AntigravityModelConfigData: Decodable {
 private struct AntigravityModelConfig: Decodable {
     let label: String
     let modelOrAlias: AntigravityModelAlias?
+    let quotaInfo: AntigravityQuotaInfo?
 }
 
 private struct AntigravityModelAlias: Decodable {
     let model: String
+}
+
+private struct AntigravityQuotaInfo: Decodable {
+    let remainingFraction: Double?
+    let resetTime: String?
 }
 
 /// AntiGravity's `code` field can be either a number or a string —

--- a/Sources/VibeBarCore/Adapters/AntigravityQuotaAdapter.swift
+++ b/Sources/VibeBarCore/Adapters/AntigravityQuotaAdapter.swift
@@ -250,6 +250,8 @@ enum AntigravityResponseParser {
             // conservative group-level candidate as a fallback. Summary rows
             // remain authoritative and win during `mergingIdentity`.
             guard let quota = config.quotaInfo,
+                  let remainingFraction = quota.remainingFraction,
+                  remainingFraction.isFinite,
                   let group = quotaGroupKind(
                       groupName: config.label,
                       bucketId: config.modelOrAlias?.model
@@ -258,7 +260,7 @@ enum AntigravityResponseParser {
             let slot = QuotaSummarySlot(group: group, cadence: .fiveHour)
             let candidate = quotaBucket(
                 slot: slot,
-                remainingFraction: quota.remainingFraction ?? 0,
+                remainingFraction: remainingFraction,
                 resetAt: quota.resetTime.flatMap(parseDate)
             )
             if let current = fallbackFiveHourBuckets[group],

--- a/Sources/VibeBarCore/Adapters/CursorQuotaAdapter.swift
+++ b/Sources/VibeBarCore/Adapters/CursorQuotaAdapter.swift
@@ -17,7 +17,7 @@ import Foundation
 /// Output:
 /// - **Cursor Models** — Cursor's first-party pool (Cursor Grok + Composer).
 /// - **Other Models** — named third-party models.
-/// - **Grok Bot / Weekly usage** — Cursor's cloud-only Bot allowance.
+/// - **Grok Bot / Weekly** — Cursor's cloud-only Bot allowance.
 ///
 /// Edge-case tests (`CursorParserEdgeCasesTests`) pin the four
 /// shapes the plan called out: Pro fractional percent (no `× 100`),
@@ -292,21 +292,23 @@ enum CursorResponseParser {
         if let auto = autoPct {
             buckets.append(QuotaBucket(
                 id: "models",
-                title: "Cursor Models",
+                title: "Weekly",
                 shortLabel: "Cursor",
                 usedPercent: auto,
                 resetAt: billingCycleEnd,
-                rawWindowSeconds: billingWindow
+                rawWindowSeconds: billingWindow,
+                groupTitle: "Cursor Models"
             ))
         }
         if let api = apiPct {
             buckets.append(QuotaBucket(
                 id: "other_models",
-                title: "Other Models",
+                title: "Weekly",
                 shortLabel: "Other",
                 usedPercent: api,
                 resetAt: billingCycleEnd,
-                rawWindowSeconds: billingWindow
+                rawWindowSeconds: billingWindow,
+                groupTitle: "Other Models"
             ))
         }
 
@@ -315,11 +317,12 @@ enum CursorResponseParser {
         if buckets.isEmpty {
             buckets.append(QuotaBucket(
                 id: "models",
-                title: "Cursor Models",
+                title: "Weekly",
                 shortLabel: "Cursor",
                 usedPercent: totalPct,
                 resetAt: billingCycleEnd,
-                rawWindowSeconds: billingWindow
+                rawWindowSeconds: billingWindow,
+                groupTitle: "Cursor Models"
             ))
         }
 
@@ -330,7 +333,7 @@ enum CursorResponseParser {
             let resetAt = parseBillingCycleEnd(bot.nextResetTimestampUtc)
             buckets.append(QuotaBucket(
                 id: "grok_bot_weekly",
-                title: "Weekly usage",
+                title: "Weekly",
                 shortLabel: "Grok Bot",
                 usedPercent: clampPercent(percent),
                 resetAt: resetAt,

--- a/Sources/VibeBarCore/Adapters/CursorSessionResolver.swift
+++ b/Sources/VibeBarCore/Adapters/CursorSessionResolver.swift
@@ -60,7 +60,7 @@ enum CursorSessionResolver {
             id: stableAccountID,
             tool: .cursor,
             email: identity?.email,
-            alias: "Cursor Agent",
+            alias: "Cursor",
             source: source,
             allowsWebFallback: hasCookieFallback,
             allowsCLIFallback: appSession != nil,

--- a/Sources/VibeBarCore/Models/MenuBarSettings.swift
+++ b/Sources/VibeBarCore/Models/MenuBarSettings.swift
@@ -246,8 +246,8 @@ public enum MenuBarFieldCatalog {
     ]
 
     public static let cursorFields: [MenuBarFieldOption] = [
-        option(.cursor, "models", "Cursor Agent · Cursor Models", "Cursor Models"),
-        option(.cursor, "other_models", "Cursor Agent · Other Models", "Other Models"),
+        option(.cursor, "models", "Cursor Models · Weekly", "Cursor Models"),
+        option(.cursor, "other_models", "Other Models · Weekly", "Other Models"),
         option(.cursor, "grok_bot_weekly", "Grok Bot · Weekly", "Grok Bot")
     ]
 

--- a/Sources/VibeBarCore/Models/ProviderHierarchy.swift
+++ b/Sources/VibeBarCore/Models/ProviderHierarchy.swift
@@ -10,7 +10,7 @@ import Foundation
 ///   AntiGravity IDE share the Gemini product because that's how
 ///   Google brands them.
 /// - `tool` (L3) — the specific surface Vibe Bar tracks
-///   (Codex, Claude Code, Gemini Web, AntiGravity, Grok Build, Cursor Agent).
+///   (Codex, Claude Code, Gemini Web, AntiGravity, Grok Build, Cursor).
 ///
 /// `ToolType` derives its `vendorName` / `productName` / `toolName`
 /// from a single entry per case in `ProviderHierarchyCatalog`, so
@@ -38,14 +38,14 @@ public enum ProviderHierarchyCatalog {
     //
     //   L1 vendor   : OpenAI    | Anthropic   | Google    | Google      | xAI        | Cursor
     //   L2 product  : ChatGPT   | Claude      | Gemini    | Gemini      | Grok       | Grok
-    //   L3 tool     : Codex     | Claude Code | Gemini Web| AntiGravity | Grok Build | Cursor Agent
+    //   L3 tool     : Codex     | Claude Code | Gemini Web| AntiGravity | Grok Build | Cursor
 
     public static let codex       = ProviderHierarchy(vendor: "OpenAI",    product: "ChatGPT", tool: "Codex")
     public static let claude      = ProviderHierarchy(vendor: "Anthropic", product: "Claude",  tool: "Claude Code")
     public static let gemini      = ProviderHierarchy(vendor: "Google",    product: "Gemini",  tool: "Gemini Web")
     public static let antigravity = ProviderHierarchy(vendor: "Google",    product: "Gemini",  tool: "AntiGravity")
     public static let grok        = ProviderHierarchy(vendor: "xAI",       product: "Grok",    tool: "Grok Build")
-    public static let cursor      = ProviderHierarchy(vendor: "Cursor",    product: "Grok",    tool: "Cursor Agent")
+    public static let cursor      = ProviderHierarchy(vendor: "Cursor",    product: "Grok",    tool: "Cursor")
 
     // MARK: - Misc providers
     //

--- a/Sources/VibeBarCore/Models/ToolType.swift
+++ b/Sources/VibeBarCore/Models/ToolType.swift
@@ -26,7 +26,7 @@ import Foundation
 ///   integration, dedicated popover pages, mini-window slots.
 /// - **Partial-Primary** (`.gemini`, `.antigravity`, `.grok`, `.cursor`) —
 ///   dedicated product surfaces. Gemini+AntiGravity share Google AI;
-///   Grok Build+Cursor Agent share Grok. These can still opt into token-cost
+///   Grok Build + Cursor share Grok. These can still opt into token-cost
 ///   scanning and status polling as provider data becomes known.
 /// - **Misc** (`.alibaba`, `.alibabaTokenPlan`, `.copilot`, `.zai`,
 ///   `.minimax`, `.kimi`, `.mimo`, `.iflytek`,
@@ -128,6 +128,21 @@ public enum ToolType: String, Codable, CaseIterable, Hashable, Sendable {
         allCases.filter { $0.supportsTokenCost }
     }
 
+    /// Provider keys exposed by the Workbench usage ledger. Cursor dashboard
+    /// events are a source inside the Grok product total, matching the Grok
+    /// cost card instead of creating a second, contradictory provider total.
+    public static var usageStatsProviders: [ToolType] {
+        var seen: Set<ToolType> = []
+        return costAwareProviders.compactMap { tool in
+            let representative = tool.usageStatsRepresentative
+            return seen.insert(representative).inserted ? representative : nil
+        }
+    }
+
+    public var usageStatsRepresentative: ToolType {
+        self == .cursor ? .grok : self
+    }
+
     public static var statusPageProviders: [ToolType] {
         allCases.filter { $0.supportsStatusPage }
     }
@@ -169,7 +184,7 @@ public enum ToolType: String, Codable, CaseIterable, Hashable, Sendable {
         [.gemini, .antigravity]
     }
 
-    /// Grok Build plus Cursor Agent, presented as one Grok product family.
+    /// Grok Build plus Cursor, presented as one Grok product family.
     public static var grokFamily: [ToolType] {
         [.grok, .cursor]
     }
@@ -374,7 +389,7 @@ public enum ToolType: String, Codable, CaseIterable, Hashable, Sendable {
     /// L1 vendor name — used by ServiceStatusCard and any surface
     /// that should pick one consistent level across all tools. The
     /// dedicated tools roll up to their vendors. `.antigravity` shares
-    /// Google's status feed with `.gemini`; Cursor Agent is linked under Grok
+    /// Google's status feed with `.gemini`; Cursor is linked under Grok
     /// for quota/cost but retains Cursor as its billing vendor.
     public var statusProviderName: String {
         switch self {

--- a/Sources/VibeBarCore/Services/CostUsageService.swift
+++ b/Sources/VibeBarCore/Services/CostUsageService.swift
@@ -206,7 +206,8 @@ public final class CostUsageService: ObservableObject {
                     await CursorCostUsageFetcher.fetch(
                         homeDirectory: home,
                         now: now,
-                        retentionDays: retentionDays
+                        retentionDays: retentionDays,
+                        eventSink: sink
                     )
                 }
                 guard !costDataSettingsProvider().privacyModeEnabled else {
@@ -216,6 +217,14 @@ public final class CostUsageService: ObservableObject {
                 switch outcome {
                 case .completed(.success(let snapshot)):
                     directRemoteResults[.cursor] = snapshot
+                    // Cursor dashboard events now feed the same request ledger
+                    // as local scanners, so Workbench and the outer Grok cost
+                    // surface share one set of token/cost facts.
+                    try? await usageLedger?.rollupAndPrune(
+                        now: now,
+                        detailDays: Self.ledgerDetailDays,
+                        retentionDays: retentionDays
+                    )
                 case .completed(.unavailable):
                     directRemoteResults.removeValue(forKey: .cursor)
                 case .completed(.failed), .timedOut:

--- a/Sources/VibeBarCore/Services/CursorCostUsageFetcher.swift
+++ b/Sources/VibeBarCore/Services/CursorCostUsageFetcher.swift
@@ -6,7 +6,7 @@ enum CursorCostFetchOutcome: Sendable {
     case failed
 }
 
-/// Fetches Cursor Agent token/cost events from Cursor's account dashboard.
+/// Fetches Cursor token/cost events from Cursor's account dashboard.
 ///
 /// Cursor's local agent transcripts do not carry token counters. The dashboard
 /// event rows do, including authoritative `tokenUsage.totalCents`; Grok Bot's
@@ -35,7 +35,8 @@ struct CursorCostUsageFetcher: Sendable {
         now: Date = Date(),
         retentionDays: Int,
         session: URLSession = .shared,
-        resolutionPlan override: CursorSessionResolutionPlan? = nil
+        resolutionPlan override: CursorSessionResolutionPlan? = nil,
+        eventSink: (any CostUsageEventSink)? = nil
     ) async -> CursorCostFetchOutcome {
         let plan = override ?? CursorSessionResolver.plan(
             homeDirectory: homeDirectory,
@@ -57,7 +58,9 @@ struct CursorCostUsageFetcher: Sendable {
                     cookieHeader: preferred.header,
                     since: since,
                     until: now,
-                    now: now
+                    now: now,
+                    eventSink: eventSink,
+                    sourceID: sourceIdentifier(for: preferred)
                 )
                 return .success(snapshot)
             } catch let error as QuotaError {
@@ -78,7 +81,9 @@ struct CursorCostUsageFetcher: Sendable {
                     cookieHeader: resolution.header,
                     since: since,
                     until: now,
-                    now: now
+                    now: now,
+                    eventSink: eventSink,
+                    sourceID: sourceIdentifier(for: resolution)
                 )
                 snapshots.append(snapshot)
             } catch {
@@ -97,7 +102,9 @@ struct CursorCostUsageFetcher: Sendable {
         cookieHeader: String,
         since: Date?,
         until: Date?,
-        now: Date
+        now: Date,
+        eventSink: (any CostUsageEventSink)? = nil,
+        sourceID: String = "default"
     ) async throws -> CostSnapshot {
         let events = try await fetchAllEvents(
             cookieHeader: cookieHeader,
@@ -106,6 +113,10 @@ struct CursorCostUsageFetcher: Sendable {
         )
         var accumulator = CostUsageScanner.CostAggregator(tool: .cursor, now: now)
         var includedEvents = 0
+        var pricedEvents: [PricedUsageEvent] = []
+        pricedEvents.reserveCapacity(eventSink == nil ? 0 : events.count)
+        var eventOccurrences: [String: Int] = [:]
+        var latestEventDate: Date?
         for event in events {
             guard let date = event.date,
                   event.clientType?.lowercased() != "grok-bot",
@@ -113,17 +124,56 @@ struct CursorCostUsageFetcher: Sendable {
                   usage.totalTokens > 0
             else { continue }
             let model = event.model.flatMap { $0.isEmpty ? nil : $0 } ?? "cursor-unknown"
+            let costUSD = max(0, (usage.totalCents ?? 0) / 100)
             accumulator.add(
                 at: date,
                 model: model,
                 input: usage.inputTokens + usage.cacheWriteTokens,
                 output: usage.outputTokens,
                 cache: usage.cacheReadTokens,
-                costUSD: max(0, (usage.totalCents ?? 0) / 100)
+                costUSD: costUSD
             )
+            if eventSink != nil {
+                let seed = event.stableIdentitySeed(model: model)
+                let occurrence = (eventOccurrences[seed] ?? 0) + 1
+                eventOccurrences[seed] = occurrence
+                let sourceKey = PrivacyPreservingHash.fileComponent(
+                    prefix: "cursor-event-v1",
+                    rawValue: "\(sourceID)|\(seed)|\(occurrence)"
+                )
+                pricedEvents.append(PricedUsageEvent(
+                    event: CostUsageScanCache.ParsedEvent(
+                        date: date,
+                        model: model,
+                        input: usage.inputTokens,
+                        output: usage.outputTokens,
+                        cache: usage.cacheWriteTokens + usage.cacheReadTokens,
+                        cacheCreation: usage.cacheWriteTokens,
+                        sourceKey: sourceKey
+                    ),
+                    costUSD: costUSD
+                ))
+            }
+            if latestEventDate.map({ date > $0 }) ?? true { latestEventDate = date }
             includedEvents += 1
         }
+        if let eventSink {
+            await eventSink.consume(UsageEventFileBatch(
+                // Workbench uses the same product-level contract as the Grok
+                // cost card: Grok Build + Cursor is one final Grok total.
+                tool: .grok,
+                filePath: "cursor-dashboard://\(sourceID)",
+                mtime: latestEventDate ?? now,
+                size: Int64(includedEvents),
+                events: pricedEvents
+            ))
+        }
         return accumulator.snapshot(jsonlFilesFound: includedEvents)
+    }
+
+    private static func sourceIdentifier(for resolution: MiscCookieResolver.Resolution) -> String {
+        let raw = resolution.slotID?.uuidString ?? resolution.sourceLabel
+        return PrivacyPreservingHash.fileComponent(prefix: "cursor-source-v1", rawValue: raw)
     }
 
     private func fetchAllEvents(
@@ -288,6 +338,21 @@ private struct CursorUsageEvent: Decodable, Hashable {
         else { return nil }
         return Date(timeIntervalSince1970: milliseconds / 1_000)
     }
+
+    func stableIdentitySeed(model resolvedModel: String) -> String {
+        [
+            timestamp?.stableValue ?? "",
+            resolvedModel,
+            tokenUsage?.inputTokensRaw?.stableValue ?? "",
+            tokenUsage?.outputTokensRaw?.stableValue ?? "",
+            tokenUsage?.cacheWriteTokensRaw?.stableValue ?? "",
+            tokenUsage?.cacheReadTokensRaw?.stableValue ?? "",
+            tokenUsage?.totalCentsRaw?.stableValue ?? "",
+            kind ?? "",
+            isHeadless.map(String.init) ?? "",
+            clientType ?? ""
+        ].joined(separator: "|")
+    }
 }
 
 private struct CursorEventTokenUsage: Decodable, Hashable {
@@ -359,6 +424,13 @@ private enum CursorFlexibleNumber: Decodable, Hashable {
         case .decimal(let value):
             guard value >= 0 else { return 0 }
             return Int(exactly: value) ?? 0
+        }
+    }
+
+    var stableValue: String {
+        switch self {
+        case .integer(let value): return String(value)
+        case .decimal(let value): return String(value)
         }
     }
 }

--- a/Sources/VibeBarCore/Services/CursorCostUsageFetcher.swift
+++ b/Sources/VibeBarCore/Services/CursorCostUsageFetcher.swift
@@ -164,7 +164,11 @@ struct CursorCostUsageFetcher: Sendable {
                 tool: .grok,
                 filePath: "cursor-dashboard://\(sourceID)",
                 mtime: latestEventDate ?? now,
-                size: Int64(includedEvents),
+                // Synthetic source: use a content-derived fingerprint rather
+                // than `(event count, latest timestamp)`. Cursor can correct
+                // an existing row in place; the Workbench must then re-ingest
+                // the same event identity with its revised tokens/cents.
+                size: Self.batchFingerprint(pricedEvents),
                 events: pricedEvents
             ))
         }
@@ -174,6 +178,29 @@ struct CursorCostUsageFetcher: Sendable {
     private static func sourceIdentifier(for resolution: MiscCookieResolver.Resolution) -> String {
         let raw = resolution.slotID?.uuidString ?? resolution.sourceLabel
         return PrivacyPreservingHash.fileComponent(prefix: "cursor-source-v1", rawValue: raw)
+    }
+
+    private static func batchFingerprint(_ events: [PricedUsageEvent]) -> Int64 {
+        let content = events.map { priced in
+            let event = priced.event
+            return [
+                event.sourceKey ?? "",
+                String(event.date.timeIntervalSince1970),
+                event.model,
+                String(event.input),
+                String(event.output),
+                String(event.cache),
+                event.cacheCreation.map(String.init) ?? "",
+                priced.costMicros.map(String.init) ?? "nil"
+            ].joined(separator: "|")
+        }.joined(separator: "\n")
+        let digest = PrivacyPreservingHash.fileComponent(
+            prefix: "cursor-batch-v1",
+            rawValue: content
+        )
+        let tail = String(digest.suffix(16))
+        let value = Int64(bitPattern: UInt64(tail, radix: 16) ?? 0)
+        return value == UsageEventFileBatch.staleFallbackSize ? -2 : value
     }
 
     private func fetchAllEvents(
@@ -343,11 +370,6 @@ private struct CursorUsageEvent: Decodable, Hashable {
         [
             timestamp?.stableValue ?? "",
             resolvedModel,
-            tokenUsage?.inputTokensRaw?.stableValue ?? "",
-            tokenUsage?.outputTokensRaw?.stableValue ?? "",
-            tokenUsage?.cacheWriteTokensRaw?.stableValue ?? "",
-            tokenUsage?.cacheReadTokensRaw?.stableValue ?? "",
-            tokenUsage?.totalCentsRaw?.stableValue ?? "",
             kind ?? "",
             isHeadless.map(String.init) ?? "",
             clientType ?? ""

--- a/Sources/VibeBarCore/Services/MockDataProvider.swift
+++ b/Sources/VibeBarCore/Services/MockDataProvider.swift
@@ -267,11 +267,13 @@ public enum MockDataProvider {
         case .cursor:
             let monthlyReset = now.addingTimeInterval(26 * 24 * 3600)
             buckets = [
-                QuotaBucket(id: "models", title: "Cursor Models", shortLabel: "Cursor",
-                            usedPercent: 1, resetAt: monthlyReset, rawWindowSeconds: 2_678_400),
-                QuotaBucket(id: "other_models", title: "Other Models", shortLabel: "Other",
-                            usedPercent: 1, resetAt: monthlyReset, rawWindowSeconds: 2_678_400),
-                QuotaBucket(id: "grok_bot_weekly", title: "Weekly usage", shortLabel: "Grok Bot",
+                QuotaBucket(id: "models", title: "Weekly", shortLabel: "Cursor",
+                            usedPercent: 1, resetAt: monthlyReset, rawWindowSeconds: 2_678_400,
+                            groupTitle: "Cursor Models"),
+                QuotaBucket(id: "other_models", title: "Weekly", shortLabel: "Other",
+                            usedPercent: 1, resetAt: monthlyReset, rawWindowSeconds: 2_678_400,
+                            groupTitle: "Other Models"),
+                QuotaBucket(id: "grok_bot_weekly", title: "Weekly", shortLabel: "Grok Bot",
                             usedPercent: 5, resetAt: weeklyReset, rawWindowSeconds: 604_800,
                             groupTitle: "Grok Bot")
             ]

--- a/Sources/VibeBarCore/Services/QuotaPaceForecast.swift
+++ b/Sources/VibeBarCore/Services/QuotaPaceForecast.swift
@@ -129,27 +129,39 @@ public struct QuotaPaceForecast: Sendable, Equatable {
         activityHeatmap: UsageHeatmap? = nil,
         dailyActivity: [DailyCostPoint] = [],
         now: Date = Date(),
-        calendar: Calendar = .current
+        calendar: Calendar = .current,
+        allowsPostResetGrace: Bool = false
     ) -> QuotaPaceForecast? {
         guard let resetAt = bucket.resetAt,
               let rawWindowSeconds = bucket.rawWindowSeconds,
               rawWindowSeconds > 0
         else { return nil }
 
+        guard let evaluationDate = QuotaWindowEvaluation.date(
+            resetAt: resetAt,
+            now: now,
+            allowsPostResetGrace: allowsPostResetGrace
+        ) else {
+            return nil
+        }
+
         let duration = TimeInterval(rawWindowSeconds)
-        let remainingTime = resetAt.timeIntervalSince(now)
-        guard remainingTime > 0, remainingTime <= duration * 1.1 else { return nil }
+        let remainingTime = resetAt.timeIntervalSince(evaluationDate)
+        guard remainingTime <= duration * 1.1 else { return nil }
 
         let windowStart = resetAt.addingTimeInterval(-duration)
         let actual = clamp(bucket.usedPercent, 0, 100)
         let profile = ActivityProfile(heatmap: activityHeatmap, calendar: calendar)
         let totalActivity = max(0.001, profile.weight(from: windowStart, to: resetAt))
-        let elapsedActivity = clamp(profile.weight(from: windowStart, to: now), 0, totalActivity)
+        let elapsedActivity = clamp(profile.weight(from: windowStart, to: evaluationDate), 0, totalActivity)
         let futureActivity = max(0, totalActivity - elapsedActivity)
         let behavioralProgress = clamp(elapsedActivity / totalActivity, 0, 1)
 
         let currentPoints = observations
-            .filter { $0.sampledAt >= windowStart.addingTimeInterval(-300) && $0.sampledAt <= now.addingTimeInterval(60) }
+            .filter {
+                $0.sampledAt >= windowStart.addingTimeInterval(-300)
+                    && $0.sampledAt <= evaluationDate.addingTimeInterval(60)
+            }
             .sorted { $0.sampledAt < $1.sampledAt }
 
         let recent = recentSlope(points: currentPoints, profile: profile)
@@ -160,7 +172,7 @@ public struct QuotaPaceForecast: Sendable, Equatable {
             currentProgress: behavioralProgress,
             profile: profile
         )
-        let trendResult = activityTrend(dailyActivity, now: now, calendar: calendar)
+        let trendResult = activityTrend(dailyActivity, now: evaluationDate, calendar: calendar)
         let trend = trendResult.multiplier
 
         let recentProjection = recent.rate.flatMap { recentRate in
@@ -201,7 +213,7 @@ public struct QuotaPaceForecast: Sendable, Equatable {
         let observationCoverage: Double = {
             guard let first = currentPoints.first, let last = currentPoints.last else { return 0 }
             let span = max(0, last.sampledAt.timeIntervalSince(first.sampledAt))
-            let elapsed = max(1, now.timeIntervalSince(windowStart))
+            let elapsed = max(1, evaluationDate.timeIntervalSince(windowStart))
             let countScore = min(1, Double(currentPoints.count) / 10)
             let spanScore = min(1, span / elapsed)
             return countScore * 0.65 + spanScore * 0.35
@@ -210,7 +222,11 @@ public struct QuotaPaceForecast: Sendable, Equatable {
         let freshness: Double = {
             guard let last = currentPoints.last else { return 0 }
             let naturalSlot: TimeInterval = rawWindowSeconds <= 6 * 3_600 ? 5 * 60 : 3_600
-            return clamp(1 - now.timeIntervalSince(last.sampledAt) / max(60, naturalSlot * 3), 0, 1)
+            return clamp(
+                1 - evaluationDate.timeIntervalSince(last.sampledAt) / max(60, naturalSlot * 3),
+                0,
+                1
+            )
         }()
         let activityCoverage = (activityHeatmap?.totalTokens ?? 0) > 0 ? 1.0 : 0.0
         let confidenceScore = clamp(
@@ -258,15 +274,19 @@ public struct QuotaPaceForecast: Sendable, Equatable {
         let targetUsed = 100 - targetRemaining
         let planned = clamp(targetUsed * behavioralProgress, 0, targetUsed)
         let runOutAt: Date? = {
-            guard upper >= 100, actual < 100 else { return actual >= 100 ? now : nil }
+            guard upper >= 100, actual < 100 else { return actual >= 100 ? evaluationDate : nil }
             if let recentRate = recent.rate, recentRate > 0 {
                 let neededWeight = (100 - actual) / recentRate
-                return profile.date(after: now, accumulating: neededWeight, noLaterThan: resetAt)
+                return profile.date(after: evaluationDate, accumulating: neededWeight, noLaterThan: resetAt)
             }
             let additional = projected - actual
             guard additional > 0 else { return nil }
             let fraction = clamp((100 - actual) / additional, 0, 1)
-            return profile.date(after: now, accumulating: futureActivity * fraction, noLaterThan: resetAt)
+            return profile.date(
+                after: evaluationDate,
+                accumulating: futureActivity * fraction,
+                noLaterThan: resetAt
+            )
         }()
 
         return QuotaPaceForecast(

--- a/Sources/VibeBarCore/Services/QuotaService.swift
+++ b/Sources/VibeBarCore/Services/QuotaService.swift
@@ -198,7 +198,8 @@ public final class QuotaService: ObservableObject {
         bucket: QuotaBucket,
         activityHeatmap: UsageHeatmap? = nil,
         dailyActivity: [DailyCostPoint] = [],
-        now: Date = Date()
+        now: Date = Date(),
+        allowsPostResetGrace: Bool = false
     ) -> QuotaPaceForecast? {
         let key = SubscriptionHistoryKey(accountId: accountId, bucketId: bucket.id)
         return QuotaPaceForecast.compute(
@@ -207,7 +208,8 @@ public final class QuotaService: ObservableObject {
             cycles: historyByAccountBucket[key] ?? [],
             activityHeatmap: activityHeatmap,
             dailyActivity: dailyActivity,
-            now: now
+            now: now,
+            allowsPostResetGrace: allowsPostResetGrace
         )
     }
 

--- a/Sources/VibeBarCore/Services/UsageEventLedger.swift
+++ b/Sources/VibeBarCore/Services/UsageEventLedger.swift
@@ -11,9 +11,10 @@ public enum UsageLedgerError: Error, Sendable {
 /// Durable per-request ledger for locally scanned CLI usage.
 ///
 /// `CostUsageScanner` already parses every Codex / Claude / Gemini / Grok /
-/// AntiGravity session log into per-request events and prices each one, but
-/// it only keeps the *aggregate* (`CostSnapshot`). This actor persists the
-/// events themselves so a usage UI can answer per-request questions —
+/// AntiGravity session log into per-request events, while the Cursor dashboard
+/// fetcher supplies the same normalized event shape for account-wide usage.
+/// The cost surface only keeps the *aggregate* (`CostSnapshot`); this actor
+/// persists the events themselves so a usage UI can answer per-request questions —
 /// "which model ran at 14:05?", "what did the last 200 requests cost?" —
 /// without re-walking gigabytes of JSONL.
 ///
@@ -54,9 +55,14 @@ public enum UsageLedgerError: Error, Sendable {
 ///   increment in `cache` and leaves `cacheCreation` nil (the protobuf has
 ///   no cache-creation field); the `.pb` RPC fallback has no cache data at
 ///   all and stores `0`.
+/// - **Cursor** — dashboard rows report fresh input, cache writes, cache reads,
+///   output, and authoritative metered cents independently. The fetcher keeps
+///   those token columns non-overlapping and records them under `.grok`, so the
+///   Workbench final total matches the Grok Build + Cursor product card.
 ///
-/// So `cache_creation` is non-zero for Claude only, and the three columns
-/// sum to the real token count without double counting anywhere.
+/// So `cache_creation` is non-zero for Claude and Cursor when their sources
+/// report writes, and the three columns sum to the real token count without
+/// double counting anywhere.
 public actor UsageEventLedger: CostUsageEventSink {
     private var database: OpaquePointer?
     private let transient = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
@@ -161,6 +167,7 @@ public actor UsageEventLedger: CostUsageEventSink {
                 dedupe_key TEXT NOT NULL UNIQUE
             );
             CREATE INDEX IF NOT EXISTS usage_events_tool_ts_idx ON usage_events(tool, ts);
+            CREATE INDEX IF NOT EXISTS usage_events_ts_id_idx ON usage_events(ts DESC, id DESC);
             CREATE INDEX IF NOT EXISTS usage_events_day_idx ON usage_events(day);
             CREATE INDEX IF NOT EXISTS usage_events_model_idx ON usage_events(model);
             CREATE TABLE IF NOT EXISTS usage_daily_rollups (
@@ -400,6 +407,14 @@ public actor UsageEventLedger: CostUsageEventSink {
                 .joined(separator: "|")
             return PrivacyPreservingHash.fileComponent(prefix: "cm-v3", rawValue: tuple)
         }
+        if tool == .grok,
+           let sourceKey = event.sourceKey,
+           sourceKey.hasPrefix("cursor-event-v1") {
+            return PrivacyPreservingHash.fileComponent(
+                prefix: "cursor-ledger-v1",
+                rawValue: sourceKey
+            )
+        }
         let seed = [
             tool.rawValue, fileKey, String(index), String(timestamp), event.model,
             String(freshInput), String(output), String(cacheRead), String(cacheCreation)
@@ -546,6 +561,12 @@ public actor UsageEventLedger: CostUsageEventSink {
         try execute("BEGIN IMMEDIATE")
         do {
             for row in details {
+                // Cursor dashboard cents are authoritative provider facts,
+                // not estimates from our price table. They are stored under
+                // the Grok product key for final-total consistency, so source
+                // provenance—not `tool`—must keep repricing from overwriting
+                // them with Grok Build rates.
+                if row.sourceKey?.hasPrefix("cursor-event-v1") == true { continue }
                 let costBinding: Binding = if let micros = costMicros(for: row) {
                     .integer(micros)
                 } else {
@@ -598,13 +619,14 @@ public actor UsageEventLedger: CostUsageEventSink {
         let cacheRead: Int64
         let cacheCreation: Int64
         let serviceTier: String?
+        let sourceKey: String?
     }
 
     private func detailRows() throws -> [RepricingRow] {
         let statement = try prepare(
             """
             SELECT id, day, tool, model, fresh_input, output,
-                   cache_read, cache_creation, service_tier
+                   cache_read, cache_creation, service_tier, source_key
               FROM usage_events
             """
         )
@@ -625,7 +647,8 @@ public actor UsageEventLedger: CostUsageEventSink {
                 output: sqlite3_column_int64(statement, 5),
                 cacheRead: sqlite3_column_int64(statement, 6),
                 cacheCreation: sqlite3_column_int64(statement, 7),
-                serviceTier: columnText(statement, 8)
+                serviceTier: columnText(statement, 8),
+                sourceKey: columnText(statement, 9)
             ))
         }
         return rows
@@ -655,7 +678,8 @@ public actor UsageEventLedger: CostUsageEventSink {
                 output: sqlite3_column_int64(statement, 4),
                 cacheRead: sqlite3_column_int64(statement, 5),
                 cacheCreation: sqlite3_column_int64(statement, 6),
-                serviceTier: nil
+                serviceTier: nil,
+                sourceKey: nil
             ))
         }
         return rows

--- a/Sources/VibeBarCore/Services/UsageEventLedger.swift
+++ b/Sources/VibeBarCore/Services/UsageEventLedger.swift
@@ -65,6 +65,9 @@ public enum UsageLedgerError: Error, Sendable {
 /// double counting anywhere.
 public actor UsageEventLedger: CostUsageEventSink {
     private var database: OpaquePointer?
+    /// In-process change token for cheap view-model cache invalidation. It
+    /// advances only after a batch mutation or erase commits successfully.
+    private var contentRevisionValue: UInt64 = 0
     private let transient = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
     private let calendar: Calendar
     private let dayFormatter: DateFormatter
@@ -234,6 +237,10 @@ public actor UsageEventLedger: CostUsageEventSink {
         try? ingest(batch)
     }
 
+    public func contentRevision() -> UInt64 {
+        contentRevisionValue
+    }
+
     /// Throwing form of `consume`, for tests and for callers that want to
     /// see ingest failures.
     public func ingest(_ batch: UsageEventFileBatch) throws {
@@ -312,6 +319,7 @@ public actor UsageEventLedger: CostUsageEventSink {
                 ]
             )
             try execute("COMMIT")
+            contentRevisionValue &+= 1
         } catch {
             try? execute("ROLLBACK")
             throw error
@@ -356,7 +364,12 @@ public actor UsageEventLedger: CostUsageEventSink {
                path_role = excluded.path_role,
                source_key = excluded.source_key
            WHERE
-               (CASE WHEN COALESCE(excluded.is_sidechain, 0) = 0 THEN 0 ELSE 1 END)
+               (
+                   excluded.tool = 'grok'
+                   AND excluded.source_key LIKE 'cursor-event-v1-%'
+                   AND excluded.source_key = usage_events.source_key
+               )
+            OR (CASE WHEN COALESCE(excluded.is_sidechain, 0) = 0 THEN 0 ELSE 1 END)
              < (CASE WHEN COALESCE(usage_events.is_sidechain, 0) = 0 THEN 0 ELSE 1 END)
             OR (
                (CASE WHEN COALESCE(excluded.is_sidechain, 0) = 0 THEN 0 ELSE 1 END)
@@ -533,6 +546,7 @@ public actor UsageEventLedger: CostUsageEventSink {
             try execute("DELETE FROM ingested_files")
             try run("DELETE FROM ledger_meta WHERE key <> ?", [.text(Self.schemaVersionKey)])
             try execute("COMMIT")
+            contentRevisionValue &+= 1
         } catch {
             try? execute("ROLLBACK")
             throw error

--- a/Sources/VibeBarCore/Services/UsagePace.swift
+++ b/Sources/VibeBarCore/Services/UsagePace.swift
@@ -1,5 +1,22 @@
 import Foundation
 
+/// Keeps pace/forecast overlays stable while the boundary refresher replaces
+/// a just-expired provider snapshot. The scheduler reads again two minutes
+/// after reset; allowing one extra minute prevents the bar from dropping all
+/// of its predictive context during that bounded handoff without treating an
+/// actually stale cache as a current cycle.
+enum QuotaWindowEvaluation {
+    static let postResetGraceSeconds: TimeInterval = 180
+
+    static func date(resetAt: Date, now: Date, allowsPostResetGrace: Bool) -> Date? {
+        let remaining = resetAt.timeIntervalSince(now)
+        if remaining > 0 { return now }
+        guard allowsPostResetGrace else { return nil }
+        guard remaining >= -postResetGraceSeconds else { return nil }
+        return resetAt.addingTimeInterval(-1)
+    }
+}
+
 /// Burn-rate / pace projection for a single quota bucket.
 ///
 /// Given a bucket's current `usedPercent`, its `resetAt`, and the total window
@@ -44,13 +61,24 @@ public struct UsagePace: Sendable, Equatable {
     }
 
     /// Compute pace for a quota bucket. Returns nil when there isn't enough
-    /// information (no reset time, no window size, reset already passed, etc.).
-    public static func compute(bucket: QuotaBucket, now: Date = Date()) -> UsagePace? {
+    /// information (no reset time, no window size, reset beyond the short
+    /// boundary-refresh grace period, etc.).
+    public static func compute(
+        bucket: QuotaBucket,
+        now: Date = Date(),
+        allowsPostResetGrace: Bool = false
+    ) -> UsagePace? {
         guard let resetsAt = bucket.resetAt else { return nil }
         guard let windowSeconds = bucket.rawWindowSeconds, windowSeconds > 0 else { return nil }
+        guard let evaluationDate = QuotaWindowEvaluation.date(
+            resetAt: resetsAt,
+            now: now,
+            allowsPostResetGrace: allowsPostResetGrace
+        ) else {
+            return nil
+        }
         let duration = TimeInterval(windowSeconds)
-        let timeUntilReset = resetsAt.timeIntervalSince(now)
-        guard timeUntilReset > 0 else { return nil }
+        let timeUntilReset = resetsAt.timeIntervalSince(evaluationDate)
         guard timeUntilReset <= duration else { return nil }
 
         let elapsed = clamp(duration - timeUntilReset, lower: 0, upper: duration)

--- a/Sources/VibeBarCore/Storage/AccountStore.swift
+++ b/Sources/VibeBarCore/Storage/AccountStore.swift
@@ -56,7 +56,7 @@ public final class AccountStore: ObservableObject {
         if let grok = autoDetectGrok() {
             detected.append(grok)
         }
-        // Cursor Agent is a linked Grok-family surface. Keep its stable account
+        // Cursor is a linked Grok-family surface. Keep its stable account
         // present even while signed out so the xAI Settings cookie controls can
         // establish a session without first creating a legacy Misc instance.
         detected.append(CursorSessionResolver.accountIdentity())

--- a/Tests/VibeBarCoreTests/AntigravityParserTests.swift
+++ b/Tests/VibeBarCoreTests/AntigravityParserTests.swift
@@ -283,6 +283,27 @@ final class AntigravityParserTests: XCTestCase {
         XCTAssertEqual(snap.modelLabels["MODEL_PLACEHOLDER_M132"], "Gemini Flash")
     }
 
+    func testUserStatusDoesNotInventFallbackWithoutRemainingFraction() throws {
+        let json = """
+        {
+          "code": 0,
+          "userStatus": {
+            "cascadeModelConfigData": {
+              "clientModelConfigs": [
+                {
+                  "label": "Claude Sonnet 4.6 (Thinking)",
+                  "modelOrAlias": {"model": "MODEL_PLACEHOLDER_M35"},
+                  "quotaInfo": {"resetTime": "1800018000"}
+                }
+              ]
+            }
+          }
+        }
+        """
+        let snap = try AntigravityResponseParser.parseUserStatus(data: Data(json.utf8))
+        XCTAssertTrue(snap.buckets.isEmpty)
+    }
+
     func testMissingUserStatusThrowsParseFailure() {
         let json = """
         { "code": 0 }

--- a/Tests/VibeBarCoreTests/AntigravityParserTests.swift
+++ b/Tests/VibeBarCoreTests/AntigravityParserTests.swift
@@ -183,6 +183,7 @@ final class AntigravityParserTests: XCTestCase {
         XCTAssertEqual(snapshot.email, "user@example.com")
         XCTAssertEqual(snapshot.planName, "Ultra Lite")
         XCTAssertEqual(snapshot.modelLabels["MODEL_PLACEHOLDER_M132"], "Gemini Flash")
+        XCTAssertEqual(snapshot.buckets.first?.remainingPercent ?? -1, 91, accuracy: 0.001)
     }
 
     func testFetchLocalSnapshotKeepsFourBucketsWhenIdentityFails() async throws {
@@ -197,7 +198,62 @@ final class AntigravityParserTests: XCTestCase {
         XCTAssertNil(snapshot.planName)
     }
 
-    func testUserStatusProvidesIdentityAndLabelsButNoLegacyQuotaRows() throws {
+    func testFetchLocalSnapshotRestoresMissingFiveHourLaneFromUserStatus() async throws {
+        let summary = """
+        {
+          "groups": [
+            {
+              "displayName": "Gemini Models",
+              "buckets": [
+                {"bucketId": "gemini-5h", "remainingFraction": 0.98},
+                {"bucketId": "gemini-weekly", "remainingFraction": 0.94}
+              ]
+            },
+            {
+              "displayName": "Claude and GPT Models",
+              "buckets": [
+                {"bucketId": "3p-weekly", "remainingFraction": 0.0}
+              ]
+            }
+          ]
+        }
+        """
+        let identity = """
+        {
+          "code": 0,
+          "userStatus": {
+            "cascadeModelConfigData": {
+              "clientModelConfigs": [
+                {
+                  "label": "Claude Sonnet 4.6 (Thinking)",
+                  "modelOrAlias": {"model": "MODEL_PLACEHOLDER_M35"},
+                  "quotaInfo": {
+                    "remainingFraction": 0.75,
+                    "resetTime": "1800018000"
+                  }
+                }
+              ]
+            }
+          }
+        }
+        """
+        let snapshot = try await AntigravityQuotaAdapter.fetchLocalSnapshot { path, _ in
+            Data((path.contains("RetrieveUserQuotaSummary") ? summary : identity).utf8)
+        }
+
+        XCTAssertEqual(snapshot.buckets.map(\.id), [
+            "gemini_five_hour",
+            "gemini_weekly",
+            "claude_gpt_five_hour",
+            "claude_gpt_weekly"
+        ])
+        let fallback = try XCTUnwrap(snapshot.buckets.first { $0.id == "claude_gpt_five_hour" })
+        XCTAssertEqual(fallback.remainingPercent, 75, accuracy: 0.001)
+        XCTAssertEqual(fallback.resetAt, Date(timeIntervalSince1970: 1_800_018_000))
+        XCTAssertEqual(snapshot.buckets.last?.usedPercent, 100)
+    }
+
+    func testUserStatusProvidesIdentityLabelsAndFiveHourFallback() throws {
         let json = """
         {
           "code": 0,
@@ -209,7 +265,10 @@ final class AntigravityParserTests: XCTestCase {
                 {
                   "label": "Gemini Flash",
                   "modelOrAlias": {"model": "MODEL_PLACEHOLDER_M132"},
-                  "quotaInfo": {"remainingFraction": 0.42}
+                  "quotaInfo": {
+                    "remainingFraction": 0.42,
+                    "resetTime": "1800018000"
+                  }
                 }
               ]
             }
@@ -219,7 +278,8 @@ final class AntigravityParserTests: XCTestCase {
         let snap = try AntigravityResponseParser.parseUserStatus(data: Data(json.utf8))
         XCTAssertEqual(snap.email, "user@example.com")
         XCTAssertEqual(snap.planName, "Pro")
-        XCTAssertTrue(snap.buckets.isEmpty, "GetUserStatus must no longer restore per-model quota rows.")
+        XCTAssertEqual(snap.buckets.map(\.id), ["gemini_five_hour"])
+        XCTAssertEqual(snap.buckets.first?.remainingPercent ?? -1, 42, accuracy: 0.001)
         XCTAssertEqual(snap.modelLabels["MODEL_PLACEHOLDER_M132"], "Gemini Flash")
     }
 
@@ -285,7 +345,11 @@ final class AntigravityParserTests: XCTestCase {
         "userTier": {"id": "g1-ultra-lite-tier", "name": "Ultra Lite"},
         "cascadeModelConfigData": {
           "clientModelConfigs": [
-            {"label": "Gemini Flash", "modelOrAlias": {"model": "MODEL_PLACEHOLDER_M132"}}
+            {
+              "label": "Gemini Flash",
+              "modelOrAlias": {"model": "MODEL_PLACEHOLDER_M132"},
+              "quotaInfo": {"remainingFraction": 0.01, "resetTime": "1800018000"}
+            }
           ]
         }
       }

--- a/Tests/VibeBarCoreTests/CursorCostUsageFetcherTests.swift
+++ b/Tests/VibeBarCoreTests/CursorCostUsageFetcherTests.swift
@@ -12,6 +12,8 @@ final class CursorCostUsageFetcherTests: XCTestCase {
         configuration.protocolClasses = [CursorCostStubURLProtocol.self]
         let session = URLSession(configuration: configuration)
         let now = Date(timeIntervalSince1970: 1_786_968_000)
+        let (ledger, directory) = try UsageLedgerFixtures.makeLedger("cursor-dashboard")
+        defer { try? FileManager.default.removeItem(at: directory) }
 
         CursorCostStubURLProtocol.handler = { request in
             XCTAssertEqual(request.url?.path, "/api/dashboard/get-filtered-usage-events")
@@ -83,7 +85,9 @@ final class CursorCostUsageFetcherTests: XCTestCase {
             cookieHeader: "WorkosCursorSessionToken=fixture",
             since: nil,
             until: now,
-            now: now
+            now: now,
+            eventSink: ledger,
+            sourceID: "fixture-account"
         )
 
         XCTAssertEqual(snapshot.tool, .cursor)
@@ -94,6 +98,42 @@ final class CursorCostUsageFetcherTests: XCTestCase {
             "cursor-grok-4.6-high-fast", "composer-2.5"
         ])
         XCTAssertFalse(snapshot.modelBreakdowns.contains { $0.modelName == "cloud-model" })
+
+        let filter = UsageQueryFilter(range: DateInterval(
+            start: now.addingTimeInterval(-300),
+            end: now.addingTimeInterval(1)
+        ))
+        let ledgerSummary = try await ledger.summary(filter)
+        XCTAssertEqual(ledgerSummary.requests, snapshot.allTimeRequests)
+        XCTAssertEqual(ledgerSummary.realTotalTokens, Int64(snapshot.allTimeTokens))
+        XCTAssertEqual(ledgerSummary.costMicros, 1_500_000)
+        XCTAssertEqual(ledgerSummary.freshInput, 110)
+        XCTAssertEqual(ledgerSummary.output, 55)
+        XCTAssertEqual(ledgerSummary.cacheCreation, 5)
+        XCTAssertEqual(ledgerSummary.cacheRead, 10)
+        let ledgerTools = try await ledger.providerStats(filter).map(\.tool)
+        XCTAssertEqual(ledgerTools, [.grok])
+        _ = try await ledger.prepareForPricingRevision("cursor-authoritative-v1")
+        let repricedSummary = try await ledger.summary(filter)
+        XCTAssertEqual(repricedSummary.costMicros, ledgerSummary.costMicros)
+
+        // Re-fetching an unchanged dashboard must update neither side's
+        // final totals nor duplicate request rows in the Workbench ledger.
+        _ = try await CursorCostUsageFetcher(
+            session: session,
+            baseURL: URL(string: "https://cursor.test")!,
+            pageSize: 2,
+            maxPages: 3
+        ).fetchSnapshot(
+            cookieHeader: "WorkosCursorSessionToken=fixture",
+            since: nil,
+            until: now,
+            now: now,
+            eventSink: ledger,
+            sourceID: "fixture-account"
+        )
+        let secondLedgerSummary = try await ledger.summary(filter)
+        XCTAssertEqual(secondLedgerSummary, ledgerSummary)
     }
 
     func testRejectedCursorAppSessionFallsBackWithoutDoubleCounting() async throws {

--- a/Tests/VibeBarCoreTests/CursorCostUsageFetcherTests.swift
+++ b/Tests/VibeBarCoreTests/CursorCostUsageFetcherTests.swift
@@ -14,6 +14,8 @@ final class CursorCostUsageFetcherTests: XCTestCase {
         let now = Date(timeIntervalSince1970: 1_786_968_000)
         let (ledger, directory) = try UsageLedgerFixtures.makeLedger("cursor-dashboard")
         defer { try? FileManager.default.removeItem(at: directory) }
+        var firstEventInputTokens = 100
+        var firstEventCostCents = 100
 
         CursorCostStubURLProtocol.handler = { request in
             XCTAssertEqual(request.url?.path, "/api/dashboard/get-filtered-usage-events")
@@ -33,11 +35,11 @@ final class CursorCostUsageFetcherTests: XCTestCase {
                       "model": "cursor-grok-4.6-high-fast",
                       "clientType": "cli",
                       "tokenUsage": {
-                        "inputTokens": 100,
+                        "inputTokens": \(firstEventInputTokens),
                         "outputTokens": 50,
                         "cacheWriteTokens": 5,
                         "cacheReadTokens": 10,
-                        "totalCents": 100
+                        "totalCents": \(firstEventCostCents)
                       }
                     },
                     {
@@ -134,6 +136,33 @@ final class CursorCostUsageFetcherTests: XCTestCase {
         )
         let secondLedgerSummary = try await ledger.summary(filter)
         XCTAssertEqual(secondLedgerSummary, ledgerSummary)
+
+        // Cursor may correct a row in place while keeping both the total event
+        // count and latest timestamp unchanged. The content fingerprint must
+        // force a re-ingest, while the stable event identity updates instead
+        // of duplicating the request.
+        firstEventInputTokens = 120
+        firstEventCostCents = 125
+        let correctedSnapshot = try await CursorCostUsageFetcher(
+            session: session,
+            baseURL: URL(string: "https://cursor.test")!,
+            pageSize: 2,
+            maxPages: 3
+        ).fetchSnapshot(
+            cookieHeader: "WorkosCursorSessionToken=fixture",
+            since: nil,
+            until: now,
+            now: now,
+            eventSink: ledger,
+            sourceID: "fixture-account"
+        )
+        let correctedLedgerSummary = try await ledger.summary(filter)
+        XCTAssertEqual(correctedSnapshot.allTimeRequests, 2)
+        XCTAssertEqual(correctedSnapshot.allTimeTokens, 200)
+        XCTAssertEqual(correctedSnapshot.allTimeCostUSD, 1.75, accuracy: 0.000_001)
+        XCTAssertEqual(correctedLedgerSummary.requests, 2)
+        XCTAssertEqual(correctedLedgerSummary.realTotalTokens, 200)
+        XCTAssertEqual(correctedLedgerSummary.costMicros, 1_750_000)
     }
 
     func testRejectedCursorAppSessionFallsBackWithoutDoubleCounting() async throws {

--- a/Tests/VibeBarCoreTests/CursorParserEdgeCasesTests.swift
+++ b/Tests/VibeBarCoreTests/CursorParserEdgeCasesTests.swift
@@ -32,7 +32,8 @@ final class CursorParserEdgeCasesTests: XCTestCase {
             now: now
         )
         XCTAssertEqual(snap.planName, "Pro")
-        XCTAssertEqual(snap.buckets.map(\.title), ["Cursor Models", "Other Models"])
+        XCTAssertEqual(snap.buckets.map(\.title), ["Weekly", "Weekly"])
+        XCTAssertEqual(snap.buckets.map(\.groupTitle), ["Cursor Models", "Other Models"])
         let cursorModels = try XCTUnwrap(snap.buckets.first { $0.id == "models" })
         XCTAssertEqual(cursorModels.usedPercent, 0.20, accuracy: 0.001)
         let otherModels = try XCTUnwrap(snap.buckets.first { $0.id == "other_models" })
@@ -166,7 +167,7 @@ final class CursorParserEdgeCasesTests: XCTestCase {
             now: now
         )
         let weekly = try XCTUnwrap(snap.buckets.first { $0.id == "grok_bot_weekly" })
-        XCTAssertEqual(weekly.title, "Weekly usage")
+        XCTAssertEqual(weekly.title, "Weekly")
         XCTAssertEqual(weekly.groupTitle, "Grok Bot")
         XCTAssertEqual(weekly.usedPercent, 5.361195, accuracy: 0.000_001)
         XCTAssertEqual(weekly.rawWindowSeconds, 604_800)

--- a/Tests/VibeBarCoreTests/CursorQuotaAdapterFallbackTests.swift
+++ b/Tests/VibeBarCoreTests/CursorQuotaAdapterFallbackTests.swift
@@ -60,7 +60,7 @@ final class CursorQuotaAdapterFallbackTests: XCTestCase {
         let account = AccountIdentity(
             id: CursorSessionResolver.stableAccountID,
             tool: .cursor,
-            alias: "Cursor Agent",
+            alias: "Cursor",
             source: .cliDetected
         )
         let quota = try await CursorQuotaAdapter(

--- a/Tests/VibeBarCoreTests/MenuBarFieldCatalogTests.swift
+++ b/Tests/VibeBarCoreTests/MenuBarFieldCatalogTests.swift
@@ -49,6 +49,21 @@ final class MenuBarFieldCatalogTests: XCTestCase {
         }
     }
 
+    func testCursorFieldsUseGroupedWeeklyLabels() throws {
+        XCTAssertEqual(
+            try XCTUnwrap(MenuBarFieldCatalog.field(id: "cursor.models")).title,
+            "Cursor Models · Weekly"
+        )
+        XCTAssertEqual(
+            try XCTUnwrap(MenuBarFieldCatalog.field(id: "cursor.other_models")).title,
+            "Other Models · Weekly"
+        )
+        XCTAssertEqual(
+            try XCTUnwrap(MenuBarFieldCatalog.field(id: "cursor.grok_bot_weekly")).title,
+            "Grok Bot · Weekly"
+        )
+    }
+
     func testGeminiCLIModelIdsMigrateToWebBuckets() {
         // Old Gemini CLI fields no longer have catalog entries; all of
         // them must migrate to the Web parser's `gemini.five_hour`

--- a/Tests/VibeBarCoreTests/PartialPrimaryToolTypeTests.swift
+++ b/Tests/VibeBarCoreTests/PartialPrimaryToolTypeTests.swift
@@ -18,7 +18,7 @@ final class PartialPrimaryToolTypeTests: XCTestCase {
         XCTAssertEqual(ToolType.cursor.coreProviderRepresentative, .grok)
     }
 
-    func testPartialPrimaryProvidersIncludeCursorAgent() {
+    func testPartialPrimaryProvidersIncludeCursor() {
         XCTAssertEqual(ToolType.partialPrimaryProviders, [.gemini, .antigravity, .grok, .cursor])
     }
 
@@ -59,7 +59,7 @@ final class PartialPrimaryToolTypeTests: XCTestCase {
         XCTAssertFalse(ToolType.cursor.supportsStatusPage)
         XCTAssertFalse(ToolType.cursor.isMiscPageProvider)
         XCTAssertEqual(ToolType.cursor.productName, ToolType.grok.productName)
-        XCTAssertEqual(ToolType.cursor.toolName, "Cursor Agent")
+        XCTAssertEqual(ToolType.cursor.toolName, "Cursor")
     }
 
     func testGoogleAIPairSupportsStatusPage() {
@@ -89,6 +89,14 @@ final class PartialPrimaryToolTypeTests: XCTestCase {
         XCTAssertEqual(
             ToolType.costAwareProviders,
             [.codex, .claude, .gemini, .antigravity, .grok, .cursor]
+        )
+    }
+
+    func testUsageStatsFoldsCursorIntoGrok() {
+        XCTAssertEqual(ToolType.cursor.usageStatsRepresentative, .grok)
+        XCTAssertEqual(
+            ToolType.usageStatsProviders,
+            [.codex, .claude, .gemini, .antigravity, .grok]
         )
     }
 

--- a/Tests/VibeBarCoreTests/QuotaPaceForecastTests.swift
+++ b/Tests/VibeBarCoreTests/QuotaPaceForecastTests.swift
@@ -46,6 +46,35 @@ final class QuotaPaceForecastTests: XCTestCase {
         XCTAssertEqual(forecast.diagnostics.recentSampleCount, 0)
     }
 
+    func testForecastSurvivesTheBoundaryRefreshGrace() throws {
+        let reset = Date(timeIntervalSince1970: 1_800_000_000)
+        XCTAssertNil(QuotaPaceForecast.compute(
+            bucket: bucket(used: 30, resetAt: reset),
+            observations: [],
+            cycles: [],
+            now: reset.addingTimeInterval(120)
+        ))
+        let forecast = QuotaPaceForecast.compute(
+            bucket: bucket(used: 30, resetAt: reset),
+            observations: [],
+            cycles: [],
+            now: reset.addingTimeInterval(120),
+            allowsPostResetGrace: true
+        )
+        XCTAssertNotNil(forecast)
+    }
+
+    func testForecastStopsAfterTheBoundaryRefreshGrace() {
+        let reset = Date(timeIntervalSince1970: 1_800_000_000)
+        let forecast = QuotaPaceForecast.compute(
+            bucket: bucket(used: 30, resetAt: reset),
+            observations: [],
+            cycles: [],
+            now: reset.addingTimeInterval(181)
+        )
+        XCTAssertNil(forecast)
+    }
+
     func testRecentAccelerationPredictsRunOutBeforeReset() throws {
         let now = Date(timeIntervalSince1970: 1_800_000_000)
         let reset = now.addingTimeInterval(2 * 86_400)

--- a/Tests/VibeBarCoreTests/UsageEventLedgerTests.swift
+++ b/Tests/VibeBarCoreTests/UsageEventLedgerTests.swift
@@ -140,7 +140,10 @@ final class UsageEventLedgerTests: XCTestCase {
             UsageLedgerFixtures.priced(UsageLedgerFixtures.event(date: now)),
             UsageLedgerFixtures.priced(UsageLedgerFixtures.event(date: now.addingTimeInterval(-60)))
         ])
+        let initialRevision = await ledger.contentRevision()
         try await ledger.ingest(first)
+        let firstRevision = await ledger.contentRevision()
+        XCTAssertEqual(firstRevision, initialRevision + 1)
         let afterFirstIngest = try await ledger.summary(UsageLedgerFixtures.wideFilter(around: now)).requests
         XCTAssertEqual(afterFirstIngest, 2)
 
@@ -150,6 +153,8 @@ final class UsageEventLedgerTests: XCTestCase {
             ]
         )
         try await ledger.ingest(sameFingerprint)
+        let sameRevision = await ledger.contentRevision()
+        XCTAssertEqual(sameRevision, firstRevision)
         let afterSameFingerprint = try await ledger.summary(UsageLedgerFixtures.wideFilter(around: now)).requests
         XCTAssertEqual(afterSameFingerprint, 2)
 
@@ -163,6 +168,8 @@ final class UsageEventLedgerTests: XCTestCase {
             events: sameFingerprint.events
         )
         try await ledger.ingest(changed)
+        let changedRevision = await ledger.contentRevision()
+        XCTAssertEqual(changedRevision, firstRevision + 1)
         let afterChangedFingerprint = try await ledger.summary(UsageLedgerFixtures.wideFilter(around: now)).requests
         XCTAssertEqual(afterChangedFingerprint, 3)
     }

--- a/Tests/VibeBarCoreTests/UsageEventLedgerTests.swift
+++ b/Tests/VibeBarCoreTests/UsageEventLedgerTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import SQLite3
 @testable import VibeBarCore
 
 /// Shared fixtures for the `UsageEventLedger` test files. Everything is
@@ -101,6 +102,31 @@ final class UsageEventLedgerTests: XCTestCase {
                 atPath: directory.appendingPathComponent("usage_events.sqlite3").path
             )
         )
+    }
+
+    func testInitCreatesTimeOrderedRequestIndex() throws {
+        let (_, directory) = try UsageLedgerFixtures.makeLedger("LedgerTimeIndex")
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let url = directory.appendingPathComponent("usage_events.sqlite3")
+        var database: OpaquePointer?
+        XCTAssertEqual(
+            sqlite3_open_v2(url.path, &database, SQLITE_OPEN_READONLY, nil),
+            SQLITE_OK
+        )
+        defer { if let database { sqlite3_close_v2(database) } }
+        var statement: OpaquePointer?
+        XCTAssertEqual(
+            sqlite3_prepare_v2(
+                database,
+                "SELECT 1 FROM sqlite_master WHERE type = 'index' AND name = 'usage_events_ts_id_idx'",
+                -1,
+                &statement,
+                nil
+            ),
+            SQLITE_OK
+        )
+        defer { if let statement { sqlite3_finalize(statement) } }
+        XCTAssertEqual(sqlite3_step(statement), SQLITE_ROW)
     }
 
     /// A second batch carrying the same `(mtime, size)` fingerprint is

--- a/Tests/VibeBarCoreTests/UsagePaceTests.swift
+++ b/Tests/VibeBarCoreTests/UsagePaceTests.swift
@@ -88,8 +88,18 @@ final class UsagePaceTests: XCTestCase {
         XCTAssertNil(UsagePace.compute(bucket: b, now: now))
     }
 
-    func testReturnsNilWhenAlreadyPastReset() {
-        let b = bucket(used: 30, secondsUntilReset: -60, windowSeconds: fiveHourSeconds)
+    func testKeepsPaceDuringBoundaryRefreshGrace() {
+        let b = bucket(used: 30, secondsUntilReset: -120, windowSeconds: fiveHourSeconds)
+        XCTAssertNil(UsagePace.compute(bucket: b, now: now))
+        XCTAssertNotNil(UsagePace.compute(
+            bucket: b,
+            now: now,
+            allowsPostResetGrace: true
+        ))
+    }
+
+    func testReturnsNilWhenPastBoundaryRefreshGrace() {
+        let b = bucket(used: 30, secondsUntilReset: -181, windowSeconds: fiveHourSeconds)
         XCTAssertNil(UsagePace.compute(bucket: b, now: now))
     }
 


### PR DESCRIPTION
## Summary
- restore missing AntiGravity five-hour lanes from the local user-status fallback and keep forecast overlays stable across the reset refresh boundary
- group Cursor Models, Other Models, and Grok Bot as Weekly quota sections; rename the surface to Cursor and reuse the Grok icon for Grok Bot
- ingest Cursor dashboard events into the same Grok Workbench total used by the outer cost card, preserving authoritative Cursor cents
- speed up 30-day Workbench ranges with a time-ordered request index, cached model filters, and one result publication

## Test plan
- [x] swift build
- [x] swift test (1459 tests, 1 skipped, 0 failures)
- [x] Scripts/build_app.sh release
- [x] verify arm64 bundle, empty entitlements, and deep code signature
- [x] verify 30-day request query uses usage_events_ts_id_idx (local 134860-row sample: about 0.20s to 0.00s)

Co-Authored-By: Codex <noreply@openai.com>