### PR TITLE
Unify provider hierarchy and refresh live quotas

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ It answers two questions that raw quota percentages do not:
   spend and tokens, plus per-model ranking.
 - **Usage history** — daily/weekly/monthly cost charts, reset-cycle fill
   history, yearly heatmaps, and hour-of-week activity maps.
-- **Live provider status** — OpenAI, Anthropic, Google, and xAI incidents and
+- **Live provider status** — OpenAI, Anthropic, Google AI, SpaceXAI, and Cursor incidents and
   component uptime in the same place as quota data.
 - **Two floating layouts** — a spacious gauge view and a compact view that
   can stay pinned above your work.
@@ -89,12 +89,12 @@ patterns on the right.
 
 <table>
   <tr>
-    <td width="50%"><img src="Resources/README/openai-detail.png" alt="ChatGPT and Codex detail page"><br><sub><strong>ChatGPT / Codex</strong> — weekly and Spark quota, cost, model ranking, reset history, and OpenAI status.</sub></td>
+    <td width="50%"><img src="Resources/README/openai-detail.png" alt="OpenAI detail page"><br><sub><strong>OpenAI</strong> — ChatGPT Agentic quota, cost, model ranking, reset history, and service status.</sub></td>
     <td width="50%"><img src="Resources/README/claude-detail.png" alt="Claude Code detail page"><br><sub><strong>Claude Code</strong> — 5 Hours, Weekly, Fable, cost analytics, reset history, and Anthropic status.</sub></td>
   </tr>
   <tr>
-    <td width="50%"><img src="Resources/README/gemini-detail.png" alt="Gemini and AntiGravity detail page"><br><sub><strong>Gemini + AntiGravity</strong> — Gemini Chat and model-family quotas alongside local usage analytics.</sub></td>
-    <td width="50%"><img src="Resources/README/grok-detail.png" alt="Grok detail page"><br><sub><strong>Grok</strong> — weekly quota, model cost, reset history, xAI status, and activity patterns.</sub></td>
+    <td width="50%"><img src="Resources/README/gemini-detail.png" alt="Google AI detail page"><br><sub><strong>Google AI</strong> — Gemini Web and AntiGravity quotas alongside local usage analytics.</sub></td>
+    <td width="50%"><img src="Resources/README/grok-detail.png" alt="Grok detail page"><br><sub><strong>SpaceXAI</strong> — Grok quota, model cost, Cursor status, reset history, and activity patterns.</sub></td>
   </tr>
 </table>
 
@@ -139,7 +139,7 @@ visibility and ordering from one two-column settings window.
 | ChatGPT / Codex | Codex subscription windows, Spark, OpenAI status | `~/.codex/sessions/**/*.jsonl` |
 | Claude Code | 5 Hours, Weekly, Fable, Anthropic status | `~/.claude/projects/**/*.jsonl` |
 | Gemini + AntiGravity | Gemini Web quotas and local AntiGravity language-server quotas | Local Gemini/AntiGravity usage records |
-| Grok + Cursor | Grok Build quota, Cursor Models, Other Models, Grok Bot weekly quota, xAI status | Local Grok Build records + Cursor account usage events; Grok Bot is quota-only |
+| Grok + Cursor | Grok quota, Cursor Models, Other Models, Grok Bot weekly quota, SpaceXAI + Cursor status | Local Grok records + Cursor account usage events; Grok Bot is quota-only |
 | Misc providers | Provider-specific coding/token plan endpoints | Quota-only unless an adapter exposes local usage |
 
 Provider contracts can change without notice. Vibe Bar keeps refresh errors

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -47,7 +47,7 @@ Vibe Bar 把 ChatGPT/Codex、Claude Code、Gemini Web、AntiGravity、Grok
   Token 以及模型排行。
 - **使用历史** —— 按日/周/月查看成本，按重置周期查看利用率，再配合年度热力图
   和一周 168 小时使用分布。
-- **服务状态** —— OpenAI、Anthropic、Google、xAI 的事故信息、组件状态与
+- **服务状态** —— OpenAI、Anthropic、Google AI、SpaceXAI、Cursor 的事故信息、组件状态与
   Uptime 和额度放在同一个界面。
 - **两种迷你浮窗** —— 真正不同的信息密度，可固定在第二块屏幕或全屏工作区上方。
 - **端到端加密远端机器** —— 只出站的 Linux Probe 可按选择并入成本/Token，
@@ -84,12 +84,12 @@ Vibe Bar 把 ChatGPT/Codex、Claude Code、Gemini Web、AntiGravity、Grok
 
 <table>
   <tr>
-    <td width="50%"><img src="Resources/README/openai-detail.png" alt="ChatGPT 与 Codex 详情页"><br><sub><strong>ChatGPT / Codex</strong> —— Weekly、Spark、成本、模型排行、重置历史和 OpenAI 状态。</sub></td>
+    <td width="50%"><img src="Resources/README/openai-detail.png" alt="OpenAI 详情页"><br><sub><strong>OpenAI</strong> —— ChatGPT Agentic 额度、成本、模型排行、重置历史与服务状态。</sub></td>
     <td width="50%"><img src="Resources/README/claude-detail.png" alt="Claude Code 详情页"><br><sub><strong>Claude Code</strong> —— 5 Hours、Weekly、Fable、成本分析、重置历史和 Anthropic 状态。</sub></td>
   </tr>
   <tr>
-    <td width="50%"><img src="Resources/README/gemini-detail.png" alt="Gemini 与 AntiGravity 详情页"><br><sub><strong>Gemini + AntiGravity</strong> —— Gemini Chat 与模型族额度，并列展示本地用量分析。</sub></td>
-    <td width="50%"><img src="Resources/README/grok-detail.png" alt="Grok 详情页"><br><sub><strong>Grok</strong> —— Weekly 额度、模型成本、重置历史、xAI 状态与使用习惯。</sub></td>
+    <td width="50%"><img src="Resources/README/gemini-detail.png" alt="Google AI 详情页"><br><sub><strong>Google AI</strong> —— Gemini Web 与 AntiGravity 额度，并列展示本地用量分析。</sub></td>
+    <td width="50%"><img src="Resources/README/grok-detail.png" alt="Grok 详情页"><br><sub><strong>SpaceXAI</strong> —— Grok 额度、模型成本、Cursor 状态、重置历史与使用习惯。</sub></td>
   </tr>
 </table>
 
@@ -130,7 +130,7 @@ OpenCode Go、Ollama Cloud、智谱 GLM、小米 MiMo、Kimi、MiniMax、阿里�
 | ChatGPT / Codex | Codex 订阅窗口、Spark、OpenAI 状态 | `~/.codex/sessions/**/*.jsonl` |
 | Claude Code | 5 Hours、Weekly、Fable、Anthropic 状态 | `~/.claude/projects/**/*.jsonl` |
 | Gemini + AntiGravity | Gemini Web 配额与本地 AntiGravity Language Server 配额 | 本地 Gemini/AntiGravity 用量记录 |
-| Grok + Cursor | Grok Build 配额、Cursor Models、Other Models、Grok Bot 周配额、xAI 状态 | 本地 Grok Build 记录 + Cursor 账户用量事件；Grok Bot 仅显示配额 |
+| Grok + Cursor | Grok 配额、Cursor Models、Other Models、Grok Bot 周配额、SpaceXAI + Cursor 状态 | 本地 Grok 记录 + Cursor 账户用量事件；Grok Bot 仅显示配额 |
 | Misc Providers | 各服务商自己的 Coding/Token Plan 接口 | 除非 Adapter 能取得本地用量，否则仅显示额度 |
 
 服务商的私有接口随时可能变化。Vibe Bar 会明确显示刷新错误，保留上一次成功

--- a/Sources/VibeBarApp/Controllers/SessionManagerModel.swift
+++ b/Sources/VibeBarApp/Controllers/SessionManagerModel.swift
@@ -499,8 +499,17 @@ final class SessionManagerModel: ObservableObject {
     // MARK: - Filter mutation
 
     func toggleProvider(_ provider: SessionProvider) {
+        toggleProviders([provider])
+    }
+
+    func toggleProviders(_ providers: Set<SessionProvider>) {
+        guard !providers.isEmpty else { return }
         var next = providerFilter ?? Set(SessionProvider.allCases)
-        if next.contains(provider) { next.remove(provider) } else { next.insert(provider) }
+        if providers.allSatisfy(next.contains) {
+            next.subtract(providers)
+        } else {
+            next.formUnion(providers)
+        }
         // Everything selected is the same statement as no filter, and saying
         // it that way keeps the chip row and the FTS query in agreement.
         setProviderFilter(next.count == SessionProvider.allCases.count ? nil : next)

--- a/Sources/VibeBarApp/Controllers/UsageStatsViewModel.swift
+++ b/Sources/VibeBarApp/Controllers/UsageStatsViewModel.swift
@@ -11,6 +11,7 @@ import VibeBarCore
 final class UsageStatsViewModel: ObservableObject {
     /// Range presets deliberately mix two shapes:
     ///
+    /// - `all` starts at the ledger's first retained fact;
     /// - `today` is the local calendar day so far — midnight → now.
     /// - `24 h` is a rolling window ending now;
     /// - every multi-day preset is aligned to local calendar days, matching
@@ -20,6 +21,7 @@ final class UsageStatsViewModel: ObservableObject {
     /// creating a second, contradictory definition of "7 days" inside the
     /// same app.
     enum RangePreset: String, CaseIterable, Identifiable {
+        case all
         case today
         case day1
         case day7
@@ -31,6 +33,7 @@ final class UsageStatsViewModel: ObservableObject {
 
         var title: String {
             switch self {
+            case .all:    "All"
             case .today:  "Today"
             case .day1:   "24 h"
             case .day7:   "7 d"
@@ -42,6 +45,7 @@ final class UsageStatsViewModel: ObservableObject {
 
         var systemImage: String {
             switch self {
+            case .all:    "infinity"
             case .today:  "sun.max"
             case .day1:   "clock"
             case .day7:   "calendar"
@@ -56,7 +60,25 @@ final class UsageStatsViewModel: ObservableObject {
             case .day7: 7
             case .day14: 14
             case .day30: 30
-            case .today, .day1, .custom: nil
+            case .all, .today, .day1, .custom: nil
+            }
+        }
+    }
+
+    enum Breakdown: String, CaseIterable, Identifiable, Sendable {
+        case periods
+        case requests
+        case providers
+        case models
+
+        var id: String { rawValue }
+
+        var title: String {
+            switch self {
+            case .periods: "Periods"
+            case .requests: "Requests"
+            case .providers: "Providers"
+            case .models: "Models"
             }
         }
     }
@@ -81,6 +103,7 @@ final class UsageStatsViewModel: ObservableObject {
         didSet {
             guard oldValue != rangePreset else { return }
             windowStart = nil
+            allTimeStart = nil
             reload(cascadeModels: false)
         }
     }
@@ -116,11 +139,12 @@ final class UsageStatsViewModel: ObservableObject {
         }
     }
 
-    /// `nil` means "every provider". An empty selection is normalized back to
+    /// `nil` means "every SubProvider". An empty selection is normalized back to
     /// `nil` rather than kept as "match nothing" — a filter bar with no chip
     /// lit should read as unfiltered, not as an empty page.
     @Published private(set) var selectedTools: Set<ToolType>?
     @Published private(set) var selectedModels: Set<String>?
+    @Published private(set) var activeBreakdown: Breakdown = .periods
 
     // MARK: - Results
 
@@ -132,12 +156,15 @@ final class UsageStatsViewModel: ObservableObject {
     var summary: UsageSummaryMetrics { results.summary }
     var trend: UsageTrendSeries { results.trend }
     var providerStats: [UsageProviderStat] { results.providerStats }
+    var companyProviderStats: [UsageProviderStat] {
+        UsageProviderStat.mergedByCompany(results.providerStats)
+    }
     var modelStats: [UsageModelStat] { results.modelStats }
     var requestRows: [UsageRequestRow] { results.requestRows }
     var requestTotalCount: Int { results.requestTotalCount }
     @Published private(set) var availableModels: [String] = []
-    /// Providers offered as filter chips: the cost-aware set, widened by any
-    /// provider the ledger actually has rows for.
+    /// SubProviders offered as filter chips: the cost-aware set, widened by
+    /// any tool the ledger actually has rows for.
     @Published private(set) var knownTools: [ToolType] = ToolType.usageStatsProviders
     @Published private(set) var isLoading = false
     @Published private(set) var isLoadingMore = false
@@ -153,11 +180,24 @@ final class UsageStatsViewModel: ObservableObject {
         requestRows.count < requestTotalCount
     }
 
+    var knownCompanyRepresentatives: [ToolType] {
+        ToolType.coreProviderRepresentatives.filter { representative in
+            !Set(representative.coreProviderMembers).isDisjoint(with: knownTools)
+        }
+    }
+
+    func isCompanySelected(_ representative: ToolType) -> Bool {
+        guard let selectedTools else { return true }
+        let members = representative.coreProviderMembers.filter { knownTools.contains($0) }
+        return !members.isEmpty && members.allSatisfy(selectedTools.contains)
+    }
+
     var range: DateInterval {
         windowStart.map(anchoredRange(start:)) ?? currentRange
     }
 
-    var canNavigateForward: Bool { windowStart != nil }
+    var canNavigateBackward: Bool { rangePreset != .all }
+    var canNavigateForward: Bool { rangePreset != .all && windowStart != nil }
 
     /// Manual buckets stay available only while they remain a useful
     /// interactive chart. The renderer also thins marks, but avoiding a huge
@@ -178,6 +218,9 @@ final class UsageStatsViewModel: ObservableObject {
     private var currentRange: DateInterval {
         let now = Date()
         switch rangePreset {
+        case .all:
+            let start = min(allTimeStart ?? now.addingTimeInterval(-60), now)
+            return DateInterval(start: start, end: max(now, start.addingTimeInterval(60)))
         case .today:
             let start = min(Calendar.current.startOfDay(for: now), now)
             return DateInterval(start: start, end: now)
@@ -200,7 +243,7 @@ final class UsageStatsViewModel: ObservableObject {
     }
 
     func navigateWindow(by direction: Int) {
-        guard direction == -1 || direction == 1 else { return }
+        guard rangePreset != .all, direction == -1 || direction == 1 else { return }
         let present = currentRange
         let candidate = shiftedStart(range.start, by: direction)
         if direction > 0, candidate >= present.start {
@@ -219,6 +262,8 @@ final class UsageStatsViewModel: ObservableObject {
 
     private func anchoredRange(start: Date) -> DateInterval {
         switch rangePreset {
+        case .all:
+            return currentRange
         case .today:
             let end = Calendar.current.date(byAdding: .day, value: 1, to: start)
                 ?? start.addingTimeInterval(86_400)
@@ -237,6 +282,8 @@ final class UsageStatsViewModel: ObservableObject {
 
     private func shiftedStart(_ start: Date, by direction: Int) -> Date {
         switch rangePreset {
+        case .all:
+            return start
         case .today:
             return Calendar.current.date(byAdding: .day, value: direction, to: start)
                 ?? start.addingTimeInterval(TimeInterval(direction * 86_400))
@@ -275,6 +322,9 @@ final class UsageStatsViewModel: ObservableObject {
     private var lastAvailableModelsRevision: UInt64?
     private var generation: UInt64 = 0
     private var hasLoadedOnce = false
+    /// Resolved lazily from the ledger whenever All is active. Keeping it at
+    /// the real data floor prevents zero-filled decades and large chart trees.
+    private var allTimeStart: Date?
     /// A historical window start, or `nil` when the preset follows now.
     private var windowStart: Date?
     /// The filter page 0 was fetched with. Later pages reuse it verbatim: a
@@ -330,6 +380,7 @@ final class UsageStatsViewModel: ObservableObject {
         let normalized = (tools?.isEmpty ?? true) ? nil : tools
         guard normalized != selectedTools else { return }
         selectedTools = normalized
+        if rangePreset == .all { allTimeStart = nil }
         reload(cascadeModels: true)
     }
 
@@ -338,6 +389,18 @@ final class UsageStatsViewModel: ObservableObject {
         if next.contains(tool) { next.remove(tool) } else { next.insert(tool) }
         // Re-selecting everything is the same statement as "no provider
         // filter", and saying it that way keeps the query unrestricted.
+        setSelectedTools(next.count == knownTools.count ? nil : next)
+    }
+
+    func toggleCompany(_ representative: ToolType) {
+        let members = Set(representative.coreProviderMembers.filter { knownTools.contains($0) })
+        guard !members.isEmpty else { return }
+        var next = selectedTools ?? Set(knownTools)
+        if members.allSatisfy(next.contains) {
+            next.subtract(members)
+        } else {
+            next.formUnion(members)
+        }
         setSelectedTools(next.count == knownTools.count ? nil : next)
     }
 
@@ -359,6 +422,18 @@ final class UsageStatsViewModel: ObservableObject {
         customEnd = end
     }
 
+    func setActiveBreakdown(_ breakdown: Breakdown) {
+        guard activeBreakdown != breakdown else { return }
+        activeBreakdown = breakdown
+        // Periods and Providers are already backed by the chart/provider
+        // queries. Models and Requests are intentionally loaded only when the
+        // user opens those tabs, avoiding two full 30-day scans on every range
+        // change.
+        if breakdown == .models || breakdown == .requests {
+            reload(cascadeModels: false)
+        }
+    }
+
     // MARK: - Queries
 
     func refresh() {
@@ -369,6 +444,7 @@ final class UsageStatsViewModel: ObservableObject {
     /// screen. Pages from a superseded filter are dropped on arrival.
     func loadMoreRequests() {
         guard let ledger, let filter = activeFilter,
+              activeBreakdown == .requests,
               !isLoadingMore, !isLoading, hasMoreRequests
         else { return }
         let generation = self.generation
@@ -403,10 +479,17 @@ final class UsageStatsViewModel: ObservableObject {
             applyEmpty()
             return
         }
-        let tools = filter.tools
+        let toolsForBounds = selectedTools.map { $0.sorted { $0.rawValue < $1.rawValue } }
         isLoading = true
         reloadTask = Task { [weak self] in
             guard let self else { return }
+            if self.rangePreset == .all {
+                let earliest = try? await ledger.earliestUsageDate(tools: toolsForBounds)
+                guard !Task.isCancelled, generation == self.generation else { return }
+                self.allTimeStart = earliest.map { Calendar.current.startOfDay(for: $0) }
+                    ?? Date().addingTimeInterval(-60)
+            }
+            let tools = self.filter.tools
             // Model availability depends on the provider filter and ledger
             // contents, not the time range. The ledger revision lets 7 d →
             // 30 d reuse the same options while an automatic usage refresh
@@ -451,7 +534,10 @@ final class UsageStatsViewModel: ObservableObject {
             }
             let granularity = self.trendGranularity
             let snapshot = await Self.load(
-                ledger: ledger, filter: resolved, granularity: granularity
+                ledger: ledger,
+                filter: resolved,
+                granularity: granularity,
+                breakdown: self.activeBreakdown
             )
             guard !Task.isCancelled, generation == self.generation else { return }
             self.activeFilter = resolved
@@ -474,7 +560,7 @@ final class UsageStatsViewModel: ObservableObject {
             requestRows: snapshot.requests.rows,
             requestTotalCount: snapshot.requests.totalCount
         )
-        loadedRequestPages = 1
+        loadedRequestPages = activeBreakdown == .requests ? 1 : 0
         observedTools.formUnion(snapshot.providers.map(\.tool))
         observedTools.formUnion(selectedTools ?? [])
         knownTools = ToolType.allCases.filter {
@@ -568,16 +654,21 @@ final class UsageStatsViewModel: ObservableObject {
     private nonisolated static func load(
         ledger: UsageEventLedger,
         filter: UsageQueryFilter,
-        granularity: UsageTrendGranularity
+        granularity: UsageTrendGranularity,
+        breakdown: Breakdown
     ) async -> LoadedUsage {
         let summary = (try? await ledger.summary(filter)) ?? .empty
         let bucket = granularity.resolved(for: filter.range)
         let trend = (try? await ledger.trend(filter, bucket: bucket))
             ?? UsageTrendSeries(bucket: bucket, points: [])
         let providers = (try? await ledger.providerStats(filter)) ?? []
-        let models = (try? await ledger.modelStats(filter)) ?? []
-        let requests = (try? await ledger.requestPage(filter, page: 0, pageSize: requestPageSize))
-            ?? UsageRequestPage(rows: [], totalCount: 0, page: 0, pageSize: requestPageSize)
+        let models = breakdown == .models
+            ? ((try? await ledger.modelStats(filter)) ?? [])
+            : []
+        let requests = breakdown == .requests
+            ? ((try? await ledger.requestPage(filter, page: 0, pageSize: requestPageSize))
+                ?? UsageRequestPage(rows: [], totalCount: 0, page: 0, pageSize: requestPageSize))
+            : UsageRequestPage(rows: [], totalCount: 0, page: 0, pageSize: requestPageSize)
         return LoadedUsage(
             summary: summary,
             trend: trend,

--- a/Sources/VibeBarApp/Controllers/UsageStatsViewModel.swift
+++ b/Sources/VibeBarApp/Controllers/UsageStatsViewModel.swift
@@ -159,6 +159,9 @@ final class UsageStatsViewModel: ObservableObject {
     var companyProviderStats: [UsageProviderStat] {
         UsageProviderStat.mergedByCompany(results.providerStats)
     }
+    var companySubProviderSummaries: [ToolType: String] {
+        UsageProviderStat.subProviderSummariesByCompany(results.providerStats)
+    }
     var modelStats: [UsageModelStat] { results.modelStats }
     var requestRows: [UsageRequestRow] { results.requestRows }
     var requestTotalCount: Int { results.requestTotalCount }
@@ -488,6 +491,10 @@ final class UsageStatsViewModel: ObservableObject {
                 guard !Task.isCancelled, generation == self.generation else { return }
                 self.allTimeStart = earliest.map { Calendar.current.startOfDay(for: $0) }
                     ?? Date().addingTimeInterval(-60)
+                if !self.isTrendGranularityAvailable(self.trendGranularity) {
+                    self.trendGranularity = .automatic
+                    return
+                }
             }
             let tools = self.filter.tools
             // Model availability depends on the provider filter and ledger

--- a/Sources/VibeBarApp/MiniQuotaWindowController.swift
+++ b/Sources/VibeBarApp/MiniQuotaWindowController.swift
@@ -299,10 +299,10 @@ final class MiniQuotaWindowController: NSObject, NSWindowDelegate {
 
         // Sizing now mirrors the L2-grouped layout in
         // `MiniWindowProviderLayout`: consecutive tools sharing the
-        // same L2 productName (Gemini Web + AntiGravity → "Gemini",
-        // Grok Build + Cursor → "Grok")
-        // share one provider column with an internal divider between
-        // L3 sub-tools. Group dividers come from the actual primary +
+        // same L1 vendorName (Gemini Web + AntiGravity → "Google AI",
+        // Grok + Cursor → "SpaceXAI")
+        // share one company column with an internal divider between
+        // SubProviders. Group dividers come from the actual primary +
         // branch-group count derived from selected bucket ids; the
         // old `min(count - 1, 4)` heuristic over-counted dividers for
         // tools with many primary cells (Codex 4 cells reserved space
@@ -310,7 +310,7 @@ final class MiniQuotaWindowController: NSObject, NSWindowDelegate {
         // visible empty padding on the L/R edges of the panel.
         var width: CGFloat = 0
         var visibleProductGroupCount = 0
-        var lastProductName: String? = nil
+        var lastCompanyName: String? = nil
         for tool in ToolType.dedicatedCardProviders {
             guard let bucketIds = bucketsByTool[tool], !bucketIds.isEmpty else { continue }
             let cellCount = bucketIds.count
@@ -318,13 +318,13 @@ final class MiniQuotaWindowController: NSObject, NSWindowDelegate {
             width += CGFloat(max(0, cellCount - 1)) * cellSpacing
             let groupCount = Self.miniGroupCount(tool: tool, selectedBucketIds: bucketIds)
             width += CGFloat(max(0, groupCount - 1)) * groupDividerReserve
-            if lastProductName == tool.productName {
-                // Same L2 product as the previous tool — adds one
-                // intra-group divider between L3 sub-columns.
+            if lastCompanyName == tool.vendorName {
+                // Same L1 company as the previous tool — adds one
+                // intra-group divider between SubProvider columns.
                 width += groupDividerReserve
             } else {
                 visibleProductGroupCount += 1
-                lastProductName = tool.productName
+                lastCompanyName = tool.vendorName
             }
         }
         if visibleProductGroupCount > 1 {

--- a/Sources/VibeBarApp/StatusItemController.swift
+++ b/Sources/VibeBarApp/StatusItemController.swift
@@ -186,6 +186,7 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
             enabled: settings.refreshOnPopoverOpen,
             cooldownSeconds: settings.popoverOpenRefreshCooldownSeconds
         )
+        environment.scheduler.triggerRefreshForStaleCacheIfNeeded()
         // Set before `show`: the refresh above publishes into the popover's own
         // render pass, and anything that would rather not compete with it (the
         // hidden Claude budget WebView) checks this flag.

--- a/Sources/VibeBarApp/StatusItemController.swift
+++ b/Sources/VibeBarApp/StatusItemController.swift
@@ -344,7 +344,7 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
         }
         menu.addItem(.separator())
         menu.addItem(disabledMenuItem("Service Status"))
-        for tool in ToolType.statusPageProviders {
+        for tool in ToolType.combinedStatusPageProviders {
             menu.addItem(disabledMenuItem(statusSummaryLine(for: tool)))
         }
         menu.addItem(.separator())
@@ -404,13 +404,20 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
     }
 
     private func statusSummaryLine(for tool: ToolType) -> String {
-        if environment.serviceStatus.inFlight.contains(tool) {
+        let members: [ToolType] = tool == .grok ? [.grok, .cursor] : [tool]
+        if members.contains(where: environment.serviceStatus.inFlight.contains) {
             return "\(tool.statusProviderName) · Checking"
         }
-        if environment.serviceStatus.errorByTool[tool] != nil {
+        if members.contains(where: { environment.serviceStatus.errorByTool[$0] != nil }) {
             return "\(tool.statusProviderName) · Down"
         }
-        guard let snapshot = environment.serviceStatus.snapshotByTool[tool] else {
+        let snapshot = tool == .grok
+            ? ServiceStatusSnapshot.mergedSpaceXAI(
+                grok: environment.serviceStatus.snapshotByTool[.grok],
+                cursor: environment.serviceStatus.snapshotByTool[.cursor]
+            )
+            : environment.serviceStatus.snapshotByTool[tool]
+        guard let snapshot else {
             return "\(tool.statusProviderName) · Checking"
         }
         let label: String

--- a/Sources/VibeBarApp/StatusItemController.swift
+++ b/Sources/VibeBarApp/StatusItemController.swift
@@ -182,11 +182,13 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
             other.performClose(nil)
         }
         let settings = environment.settingsStore.settings
-        environment.scheduler.triggerRefreshForPopoverOpenIfNeeded(
+        let scheduledFullRefresh = environment.scheduler.triggerRefreshForPopoverOpenIfNeeded(
             enabled: settings.refreshOnPopoverOpen,
             cooldownSeconds: settings.popoverOpenRefreshCooldownSeconds
         )
-        environment.scheduler.triggerRefreshForStaleCacheIfNeeded()
+        if !scheduledFullRefresh {
+            environment.scheduler.triggerRefreshForStaleCacheIfNeeded()
+        }
         // Set before `show`: the refresh above publishes into the popover's own
         // render pass, and anything that would rather not compete with it (the
         // hidden Claude budget WebView) checks this flag.

--- a/Sources/VibeBarApp/StatusItemController.swift
+++ b/Sources/VibeBarApp/StatusItemController.swift
@@ -407,24 +407,37 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
     }
 
     private func statusSummaryLine(for tool: ToolType) -> String {
-        let members: [ToolType] = tool == .grok ? [.grok, .cursor] : [tool]
+        let members: [ToolType] = switch tool {
+        case .gemini: [.gemini, .antigravity]
+        case .grok: [.grok, .cursor]
+        default: [tool]
+        }
         if members.contains(where: environment.serviceStatus.inFlight.contains) {
             return "\(tool.statusProviderName) · Checking"
         }
-        if members.contains(where: { environment.serviceStatus.errorByTool[$0] != nil }) {
-            return "\(tool.statusProviderName) · Down"
-        }
-        let snapshot = tool == .grok
-            ? ServiceStatusSnapshot.mergedSpaceXAI(
+        let snapshot: ServiceStatusSnapshot? = switch tool {
+        case .gemini:
+            ServiceStatusSnapshot.preferredGoogleAI(
+                gemini: environment.serviceStatus.snapshotByTool[.gemini],
+                antigravity: environment.serviceStatus.snapshotByTool[.antigravity]
+            )
+        case .grok:
+            ServiceStatusSnapshot.mergedSpaceXAI(
                 grok: environment.serviceStatus.snapshotByTool[.grok],
                 cursor: environment.serviceStatus.snapshotByTool[.cursor]
             )
-            : environment.serviceStatus.snapshotByTool[tool]
+        default:
+            environment.serviceStatus.snapshotByTool[tool]
+        }
+        if snapshot == nil,
+           members.contains(where: { environment.serviceStatus.errorByTool[$0] != nil }) {
+            return "\(tool.statusProviderName) · Down"
+        }
         guard let snapshot else {
             return "\(tool.statusProviderName) · Checking"
         }
         let label: String
-        switch snapshot.indicator {
+        switch snapshot.effectiveIndicator {
         case .none:        label = "Up"
         case .maintenance: label = "Maintenance"
         case .minor,

--- a/Sources/VibeBarApp/Views/EffectivePricingCatalogView.swift
+++ b/Sources/VibeBarApp/Views/EffectivePricingCatalogView.swift
@@ -1,0 +1,246 @@
+import SwiftUI
+import VibeBarCore
+
+/// Filterable projection of the exact merged price table used by cost scans.
+/// The fixed viewport and LazyVStack keep large remote catalogs from inflating
+/// the whole Settings page or eagerly creating every row.
+struct EffectivePricingCatalogView: View {
+    @EnvironmentObject private var environment: AppEnvironment
+    @EnvironmentObject private var settingsStore: SettingsStore
+
+    @State private var searchText = ""
+    @State private var selectedProvider: PricingProviderFamily?
+    @State private var localOverridesOnly = false
+
+    var body: some View {
+        let allRows = PricingResolver.active.effectiveModelPrices
+        let rows = filteredRows(allRows)
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(alignment: .firstTextBaseline) {
+                Text("Effective price table")
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(.secondary)
+                Spacer()
+                Text("\(rows.count) of \(allRows.count) models")
+                    .font(.caption2.monospacedDigit())
+                    .foregroundStyle(.tertiary)
+            }
+
+            Text("The resolved catalog currently used for cost calculations. Prices are USD per one million tokens; local overrides are already applied.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            HStack(spacing: 8) {
+                TextField("Filter model name", text: $searchText)
+                    .textFieldStyle(.roundedBorder)
+                Menu {
+                    Button("All SubProviders") { selectedProvider = nil }
+                    Divider()
+                    ForEach(PricingProviderFamily.allCases) { provider in
+                        Button(provider.label) { selectedProvider = provider }
+                    }
+                } label: {
+                    Label(selectedProvider?.label ?? "All SubProviders", systemImage: "line.3.horizontal.decrease.circle")
+                }
+                .menuStyle(.button)
+                Toggle("Local overrides only", isOn: $localOverridesOnly)
+                    .toggleStyle(.switch)
+                    .fixedSize()
+            }
+
+            ScrollView([.horizontal, .vertical]) {
+                LazyVStack(spacing: 0) {
+                    pricingHeader
+                    ForEach(rows) { row in
+                        EffectivePricingRowView(
+                            row: row,
+                            isLocalOverride: localOverrideKeys.contains(row.normalizedKey)
+                        )
+                        Divider().opacity(0.45)
+                    }
+                }
+                .frame(minWidth: 780, alignment: .topLeading)
+            }
+            .frame(height: 420)
+            .background(Color.primary.opacity(0.018))
+            .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+            .overlay(
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .stroke(Color.primary.opacity(0.08), lineWidth: 0.7)
+            )
+            .overlay {
+                if rows.isEmpty {
+                    ContentUnavailableView(
+                        "No matching models",
+                        systemImage: "magnifyingglass",
+                        description: Text("Change the SubProvider, model-name, or override filter.")
+                    )
+                }
+            }
+
+            if let mergedAt = environment.pricingRefreshStatus.mergedAt {
+                Text("Active catalog merged \(mergedAt.formatted(date: .abbreviated, time: .shortened))")
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+            }
+        }
+        .padding(14)
+        .background(
+            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                .fill(Color.primary.opacity(0.035))
+        )
+    }
+
+    private var localOverrideKeys: Set<String> {
+        Set(settingsStore.settings.modelPricingOverrides.compactMap { entry in
+            guard entry.isUsable else { return nil }
+            return "\(entry.provider.rawValue):\(entry.normalizedModel)"
+        })
+    }
+
+    private func filteredRows(
+        _ rows: [EffectiveModelPricingRow]
+    ) -> [EffectiveModelPricingRow] {
+        let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        let overrideKeys = localOverrideKeys
+        return rows.filter { row in
+            if let selectedProvider, row.provider != selectedProvider { return false }
+            if localOverridesOnly, !overrideKeys.contains(row.normalizedKey) { return false }
+            guard !query.isEmpty else { return true }
+            return row.model.lowercased().contains(query)
+                || row.displayLabel?.lowercased().contains(query) == true
+                || row.companyName.lowercased().contains(query)
+                || row.subProviderName.lowercased().contains(query)
+        }
+    }
+
+    private var pricingHeader: some View {
+        HStack(spacing: 8) {
+            headerCell("Provider / SubProvider", width: 154)
+            headerCell("Model", width: 242)
+            headerCell("Input / 1M", width: 84, alignment: .trailing)
+            headerCell("Output / 1M", width: 84, alignment: .trailing)
+            headerCell("Cache read", width: 84, alignment: .trailing)
+            headerCell("Cache write", width: 84, alignment: .trailing)
+        }
+        .padding(.horizontal, 10)
+        .frame(minHeight: 30)
+        .background(Color.primary.opacity(0.035))
+    }
+
+    private func headerCell(
+        _ text: String,
+        width: CGFloat,
+        alignment: Alignment = .leading
+    ) -> some View {
+        Text(text.uppercased())
+            .font(.system(size: 9, weight: .semibold))
+            .foregroundStyle(.tertiary)
+            .tracking(0.45)
+            .frame(width: width, alignment: alignment)
+    }
+}
+
+private struct EffectivePricingRowView: View {
+    let row: EffectiveModelPricingRow
+    let isLocalOverride: Bool
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack(spacing: 8) {
+                HStack(spacing: 6) {
+                    ToolBrandIconView(tool: row.tool, size: 13)
+                    VStack(alignment: .leading, spacing: 1) {
+                        Text(row.companyName)
+                            .font(.system(size: 10, weight: .semibold))
+                        Text(row.subProviderName)
+                            .font(.system(size: 9))
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                .frame(width: 154, alignment: .leading)
+
+                VStack(alignment: .leading, spacing: 1) {
+                    Text(row.displayLabel ?? row.model)
+                        .font(.system(size: 10.5, weight: .medium))
+                        .lineLimit(1)
+                    if row.displayLabel != nil {
+                        Text(row.model)
+                            .font(.system(size: 9, design: .monospaced))
+                            .foregroundStyle(.tertiary)
+                            .lineLimit(1)
+                    }
+                }
+                .frame(width: 242, alignment: .leading)
+
+                price(row.inputPerMillion)
+                price(row.outputPerMillion)
+                price(row.cacheReadPerMillion)
+                price(row.cacheWritePerMillion)
+            }
+
+            if let detail = advancedDetail {
+                HStack(spacing: 6) {
+                    if isLocalOverride {
+                        Text("LOCAL OVERRIDE")
+                            .font(.system(size: 8, weight: .bold))
+                            .foregroundStyle(.blue)
+                    }
+                    Text(detail)
+                        .font(.system(size: 8.5, design: .rounded))
+                        .foregroundStyle(.tertiary)
+                        .lineLimit(1)
+                }
+                .padding(.leading, 168)
+            } else if isLocalOverride {
+                Text("LOCAL OVERRIDE")
+                    .font(.system(size: 8, weight: .bold))
+                    .foregroundStyle(.blue)
+                    .padding(.leading, 168)
+            }
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 7)
+    }
+
+    private func price(_ value: Double?) -> some View {
+        Text(value.map(Self.formatPrice) ?? "—")
+            .font(.system(size: 9.5, weight: .medium, design: .rounded).monospacedDigit())
+            .foregroundStyle(value == nil ? Color.secondary : Color.primary)
+            .opacity(value == nil ? 0.65 : 1)
+            .frame(width: 84, alignment: .trailing)
+    }
+
+    private var advancedDetail: String? {
+        var parts: [String] = []
+        if let threshold = row.thresholdTokens {
+            var rates: [String] = []
+            if let value = row.inputAboveThresholdPerMillion {
+                rates.append("input \(Self.formatPrice(value))")
+            }
+            if let value = row.outputAboveThresholdPerMillion {
+                rates.append("output \(Self.formatPrice(value))")
+            }
+            if let value = row.cacheReadAboveThresholdPerMillion {
+                rates.append("cache read \(Self.formatPrice(value))")
+            }
+            if let value = row.cacheWriteAboveThresholdPerMillion {
+                rates.append("cache write \(Self.formatPrice(value))")
+            }
+            let suffix = rates.isEmpty ? "" : ": " + rates.joined(separator: " · ")
+            parts.append("Above \(threshold.formatted(.number.notation(.compactName))) tokens\(suffix)")
+        }
+        if let multiplier = row.fastMultiplier, multiplier != 1 {
+            parts.append("Fast tier ×\(multiplier.formatted(.number.precision(.fractionLength(0...2))))")
+        }
+        return parts.isEmpty ? nil : parts.joined(separator: " · ")
+    }
+
+    private static func formatPrice(_ value: Double) -> String {
+        value.formatted(
+            .currency(code: "USD")
+                .precision(.fractionLength(0...6))
+                .presentation(.narrow)
+        )
+    }
+}

--- a/Sources/VibeBarApp/Views/MiniQuotaWindowView.swift
+++ b/Sources/VibeBarApp/Views/MiniQuotaWindowView.swift
@@ -279,7 +279,9 @@ private struct MiniBranchCell: Identifiable {
         case "weekly_opus": return "Weekly"
         case "weekly_fable": return "Weekly"
         case "weekly_oauth_apps": return "Weekly"
-        case let id where tool == .cursor && ["models", "other_models", "grok_bot_weekly"].contains(id):
+        case let id where tool == .cursor && ["models", "other_models"].contains(id):
+            return "Monthly"
+        case "grok_bot_weekly" where tool == .cursor:
             return "Weekly"
         case let id where tool == .antigravity && id.contains("gpt-oss"):
             return "GPT"

--- a/Sources/VibeBarApp/Views/MiniQuotaWindowView.swift
+++ b/Sources/VibeBarApp/Views/MiniQuotaWindowView.swift
@@ -153,42 +153,42 @@ private struct MiniL2Member {
     let content: MiniToolContent
 }
 
-/// Tools sharing the same L2 product (e.g. Gemini Web + AntiGravity)
-/// collapse into one super-column with a single L2 header and one
-/// L3 sub-label per tool. The mini window renders one super-column
-/// per `MiniL2Group`, not one per `ToolType`.
-private struct MiniL2Group: Identifiable {
-    let productName: String
+/// Tools sharing the same L1 enterprise/brand (e.g. Gemini Web + AntiGravity)
+/// collapse into one super-column with a single company header and one
+/// SubProvider label per tool. The mini window renders one super-column
+/// per `MiniCompanyGroup`, not one per `ToolType`.
+private struct MiniCompanyGroup: Identifiable {
+    let companyName: String
     let accentTool: ToolType
     let members: [MiniL2Member]
 
-    var id: String { productName }
+    var id: String { companyName }
     var isMultiTool: Bool { members.count > 1 }
 }
 
 /// Walks `visibleTools` in their `dedicatedCardProviders` order and
-/// folds consecutive tools sharing the same `productName` into one
-/// `MiniL2Group`. Tools with empty content are skipped.
+/// folds consecutive tools sharing the same `vendorName` into one
+/// `MiniCompanyGroup`. Tools with empty content are skipped.
 private func miniProductGroups(
     visibleTools: [ToolType],
     contentByTool: [ToolType: MiniToolContent]
-) -> [MiniL2Group] {
-    var groups: [MiniL2Group] = []
+) -> [MiniCompanyGroup] {
+    var groups: [MiniCompanyGroup] = []
     for tool in visibleTools {
         guard let content = contentByTool[tool], !content.isEmpty else { continue }
-        let product = tool.productName
+        let company = tool.vendorName
         let member = MiniL2Member(tool: tool, content: content)
-        if let last = groups.last, last.productName == product {
-            let merged = MiniL2Group(
-                productName: last.productName,
+        if let last = groups.last, last.companyName == company {
+            let merged = MiniCompanyGroup(
+                companyName: last.companyName,
                 accentTool: last.accentTool,
                 members: last.members + [member]
             )
             groups[groups.count - 1] = merged
         } else {
             groups.append(
-                MiniL2Group(
-                    productName: product,
+                MiniCompanyGroup(
+                    companyName: company,
                     accentTool: tool,
                     members: [member]
                 )
@@ -213,7 +213,7 @@ private struct MiniWindowProviderLayout: View {
                 }
                 switch displayMode {
                 case .regular:
-                    MiniL2GroupColumn(group: group)
+                    MiniCompanyGroupColumn(group: group)
                 case .compact:
                     MiniCompactL2GroupColumn(group: group)
                 }
@@ -569,8 +569,8 @@ private func miniPrimaryGroupTitle(
 /// Build + Cursor) get the L2 header on top, each L3 tool as a
 /// sub-section beneath with its own small toolName sub-label,
 /// separated by a thin divider.
-private struct MiniL2GroupColumn: View {
-    let group: MiniL2Group
+private struct MiniCompanyGroupColumn: View {
+    let group: MiniCompanyGroup
 
     @EnvironmentObject var settingsStore: SettingsStore
 
@@ -580,7 +580,7 @@ private struct MiniL2GroupColumn: View {
                 Circle()
                     .fill(providerAccent(for: group.accentTool))
                     .frame(width: 5, height: 5)
-                Text(group.productName.uppercased())
+                Text(group.companyName.uppercased())
                     .font(.system(size: 10, weight: .semibold, design: .rounded))
                     .foregroundStyle(.primary.opacity(0.86))
                     .tracking(0.2)
@@ -1016,11 +1016,11 @@ private enum MiniCompactMetrics {
     static let resetHeight: CGFloat = 8
 }
 
-/// Compact-mode counterpart of `MiniL2GroupColumn`. Same L2 header
-/// + (optional L3 sub-label) + bar cells, sized for the shorter
+/// Compact-mode counterpart of `MiniCompanyGroupColumn`. Same L1 header
+/// + SubProvider labels + bar cells, sized for the shorter
 /// compact panel.
 private struct MiniCompactL2GroupColumn: View {
-    let group: MiniL2Group
+    let group: MiniCompanyGroup
 
     @EnvironmentObject var settingsStore: SettingsStore
 
@@ -1030,7 +1030,7 @@ private struct MiniCompactL2GroupColumn: View {
                 Circle()
                     .fill(providerAccent(for: group.accentTool))
                     .frame(width: 5, height: 5)
-                Text(group.productName.uppercased())
+                Text(group.companyName.uppercased())
                     .font(.system(size: 9.5, weight: .semibold, design: .rounded))
                     .foregroundStyle(.primary.opacity(0.86))
                     .tracking(0.2)

--- a/Sources/VibeBarApp/Views/PageModuleCatalog.swift
+++ b/Sources/VibeBarApp/Views/PageModuleCatalog.swift
@@ -161,7 +161,7 @@ enum PageModuleCatalog {
                 PageModuleDescriptor(
                     id: .custom("overview-quota:\(tool.rawValue)"),
                     kind: .overviewQuota(tool),
-                    displayName: "\(tool.menuTitle) Quota",
+                    displayName: "\(tool.vendorName) Quota",
                     defaultColumn: 0,
                     accent: .provider(tool),
                     masonryPhase: .quota,
@@ -199,7 +199,7 @@ enum PageModuleCatalog {
                 PageModuleDescriptor(
                     id: .cost(tool: tool),
                     kind: .overviewCost(tool),
-                    displayName: "\(tool.menuTitle) Cost",
+                    displayName: "\(tool.vendorName) Cost",
                     defaultColumn: 1,
                     accent: .cost,
                     masonryPhase: .cost,
@@ -212,7 +212,7 @@ enum PageModuleCatalog {
                 PageModuleDescriptor(
                     id: .cost(tool: .gemini),
                     kind: .overviewCost(.gemini),
-                    displayName: "Gemini Cost",
+                    displayName: "Google AI Cost",
                     defaultColumn: 1,
                     accent: .cost,
                     masonryPhase: .cost,
@@ -298,7 +298,7 @@ enum PageModuleCatalog {
         )
 
         // Right column: cost, then the analytics derived from it.
-        let costTitle = tool == .gemini ? "Gemini" : tool.menuTitle
+        let costTitle = tool.vendorName
         guard let snapshot = detailCostSnapshot(tool: tool, environment: environment),
               snapshot.jsonlFilesFound > 0
         else {
@@ -375,7 +375,7 @@ enum PageModuleCatalog {
 
     private static func quotaGroupDisplayName(_ module: QuotaGroupModule) -> String {
         let scope = module.title ?? "All Models"
-        // A linked product's groups (AntiGravity under Gemini) say whose they
+        // A linked SubProvider's groups (AntiGravity under Google AI) say whose they
         // are; the page tool's own groups do not need repeating.
         guard module.tool != module.pageTool else { return scope }
         return "\(module.tool.toolName) · \(scope)"
@@ -470,7 +470,7 @@ enum PageModuleCatalog {
         )
     }
 
-    /// Combined Grok Build local sessions + Cursor dashboard events.
+    /// Combined Grok CLI sessions + Cursor dashboard events.
     @MainActor
     static func grokCostSnapshot(environment: AppEnvironment) -> CostSnapshot {
         environment.costService.combinedSnapshot(

--- a/Sources/VibeBarApp/Views/PopoverRoot.swift
+++ b/Sources/VibeBarApp/Views/PopoverRoot.swift
@@ -60,6 +60,9 @@ struct PopoverRoot: View {
         .frame(width: width, alignment: .topLeading)
         .fixedSize(horizontal: false, vertical: true)
         .readHeight(onContentHeightChange)
+        .onChange(of: overviewPage) { _, _ in
+            environment.scheduler.triggerRefreshForStaleCacheIfNeeded()
+        }
     }
 
     /// The tabbed popover is one shared shell. The title band, content cards,

--- a/Sources/VibeBarApp/Views/PopoverRoot.swift
+++ b/Sources/VibeBarApp/Views/PopoverRoot.swift
@@ -101,10 +101,10 @@ struct PopoverRoot: View {
     private var headerTitle: String {
         switch overviewPage {
         case .overview: return "Overview"
-        case .openAI: return "ChatGPT"
-        case .claude: return "Claude"
-        case .googleAI: return "Gemini"
-        case .grok: return "Grok"
+        case .openAI: return "OpenAI"
+        case .claude: return "Anthropic"
+        case .googleAI: return "Google AI"
+        case .grok: return "SpaceXAI"
         case .misc: return "Misc Providers"
         case .machines: return "Machines"
         }
@@ -113,10 +113,7 @@ struct PopoverRoot: View {
     private var headerSubtitle: String? {
         switch overviewPage {
         case .overview: return "All providers · quota & cost"
-        case .openAI: return ToolType.codex.subtitle
-        case .claude: return ToolType.claude.subtitle
-        case .googleAI: return "Gemini Web + AntiGravity · quota & status"
-        case .grok: return "xAI · Grok Build, Cursor, cost & status"
+        case .openAI, .claude, .googleAI, .grok: return nil
         case .misc: return "Usage-only · sign in or paste a key"
         case .machines: return "End-to-end encrypted remote usage"
         }
@@ -249,19 +246,15 @@ enum OverviewPage: String, CaseIterable, Identifiable {
         }
     }
 
-    /// L2 product-family labels. The tab strip used to mix L1 vendor
-    /// names (OpenAI, Google AI) with L2 product names (Claude, Grok);
-    /// pinning every tab to L2 means the tab strip reads "ChatGPT ·
-    /// Claude · Gemini · Grok" — what the user calls the AI, not how
-    /// they're billed. Gemini's tab covers both Gemini Web and the
-    /// AntiGravity IDE since both roll up to the Gemini product.
+    /// L1 enterprise/brand labels. SubProviders are named inside each card,
+    /// so the tab strip and card header use one consistent level.
     var label: String {
         switch self {
         case .overview: return "Overview"
-        case .openAI:   return "ChatGPT"
-        case .claude:   return "Claude"
-        case .googleAI: return "Gemini"
-        case .grok:     return "Grok"
+        case .openAI:   return "OpenAI"
+        case .claude:   return "Anthropic"
+        case .googleAI: return "Google AI"
+        case .grok:     return "SpaceXAI"
         case .misc:     return "Misc"
         case .machines: return "Machines"
         }
@@ -547,7 +540,7 @@ private struct OverviewWaterfall: View {
             )
         case let .overviewQuota(tool):
             if tool == .gemini {
-                // Gemini Web and AntiGravity roll up to one Google AI product.
+                // Gemini Web and AntiGravity share one Google AI company card.
                 GeminiCombinedCard(density: density)
             } else if tool == .grok {
                 GrokCombinedCard(density: density)
@@ -571,7 +564,7 @@ private struct OverviewWaterfall: View {
         case let .overviewCost(tool):
             if tool == .gemini {
                 // Google AI (Gemini + AntiGravity) cost, surfaced as the
-                // single "Gemini" platform aligned with the other three.
+                // single Google AI platform aligned with the other three.
                 // AntiGravity is now the only live Google/Gemini usage
                 // source (Gemini CLI no longer writes local telemetry);
                 // its `.pb`-only cascades are filled via the
@@ -580,20 +573,20 @@ private struct OverviewWaterfall: View {
                     tool: .antigravity,
                     density: density,
                     snapshotOverride: context.googleAISnapshot,
-                    titleOverride: "Gemini Cost",
-                    emptyMessageOverride: "No Gemini / AntiGravity usage yet — open AntiGravity once so Vibe Bar can sync it.",
-                    toolNameOverride: "Gemini",
-                    heatmapTitleOverride: "When you use Gemini"
+                    titleOverride: "Google AI Cost",
+                    emptyMessageOverride: "No Gemini Web / AntiGravity usage yet — refresh after signing in to AntiGravity or agy.",
+                    toolNameOverride: "Google AI",
+                    heatmapTitleOverride: "When you use Google AI"
                 )
             } else if tool == .grok {
                 OverviewCostCard(
                     tool: .grok,
                     density: density,
                     snapshotOverride: context.grokSnapshot,
-                    titleOverride: "Grok Cost",
-                    emptyMessageOverride: "No Grok Build or Cursor usage found yet.",
-                    toolNameOverride: "Grok",
-                    heatmapTitleOverride: "When you use Grok"
+                    titleOverride: "SpaceXAI Cost",
+                    emptyMessageOverride: "No Grok or Cursor usage found yet.",
+                    toolNameOverride: "SpaceXAI",
+                    heatmapTitleOverride: "When you use SpaceXAI"
                 )
             } else {
                 OverviewCostCard(tool: tool, density: density)
@@ -645,10 +638,10 @@ private struct GrokPage: View {
     }
 }
 
-/// Overview popover card that merges Gemini Web + AntiGravity into a
-/// single L2 "Gemini" surface, with each tool as an L3 sub-section.
+/// Overview popover card that merges Gemini Web + AntiGravity into one
+/// Google AI company card, with each one rendered as an L2 SubProvider.
 /// Replaces the previous side-by-side ProviderQuotaCard pair so the
-/// two surfaces under the Gemini product no longer look like
+/// the two SubProviders no longer look like
 /// unrelated tools to the user.
 ///
 /// The card itself owns the outer card chrome; the inner
@@ -684,20 +677,14 @@ private struct GeminiCombinedCard: View {
             HStack(alignment: .center, spacing: 8) {
                 ProviderSectionTitle(
                     tool: .gemini,
-                    title: ToolType.gemini.productName,
-                    subtitle: ToolType.gemini.statusProviderName,
+                    title: ToolType.gemini.vendorName,
+                    subtitle: nil,
                     titleFontSize: density.titleFontSize,
                     subtitleFontSize: density.subtitleFontSize,
                     iconSize: 16,
                     badgeSize: 24
                 )
                 Spacer(minLength: 4)
-                if let label = geminiPlanBadge {
-                    PlanBadgeView(
-                        text: label,
-                        fontSize: max(9, density.subtitleFontSize - 1)
-                    )
-                }
                 BorderlessIconButton(
                     systemImage: "arrow.clockwise",
                     help: "Refresh Gemini Web + AntiGravity"
@@ -713,13 +700,21 @@ private struct GeminiCombinedCard: View {
                 }
             }
 
-            // Gemini Web buckets ride directly under the main L2
-            // header — no second sub-header needed because the card
-            // title already reads "Gemini · Google" and the Web
-            // surface is the primary one. AntiGravity gets its own
-            // L3 sub-header below (logo + name + plan badge) so the
-            // IDE-side model buckets are visibly separated from the
-            // Web quota even though both live in the same card.
+            HStack(alignment: .center, spacing: 6) {
+                ToolBrandIconView(tool: .gemini, size: 13)
+                    .opacity(0.85)
+                Text("Gemini Web")
+                    .font(.system(size: max(10, density.subtitleFontSize), weight: .semibold))
+                    .foregroundStyle(.secondary)
+                Spacer(minLength: 4)
+                if let label = geminiPlanBadge {
+                    PlanBadgeView(text: label, fontSize: max(9, density.subtitleFontSize - 1))
+                }
+            }
+
+            // Gemini Web buckets follow its SubProvider row. AntiGravity gets
+            // an equivalent row below so the two L2 services and their L3
+            // quota/model groups remain visually distinct.
             ForEach(geminiAccounts, id: \.id) { account in
                 ProviderQuotaCard(
                     tool: .gemini,
@@ -748,7 +743,7 @@ private struct GeminiCombinedCard: View {
                 if let label = antigravityPlanBadge {
                     PlanBadgeView(
                         text: label,
-                        fontSize: max(8, density.subtitleFontSize - 2)
+                        fontSize: max(9, density.subtitleFontSize - 1)
                     )
                 }
             }
@@ -772,7 +767,7 @@ private struct GeminiCombinedCard: View {
         )
     }
 
-    /// Resolve the plan-badge text for a Gemini-family sub-tool. Looks
+    /// Resolve the plan-badge text for a Google AI SubProvider. Looks
     /// at the cached quota first (Gemini Web returns "Pro" / "Ultra" /
     /// "Free") and falls back to the account-level plan string. nil
     /// when nothing meaningful is set so the caller suppresses the
@@ -794,9 +789,8 @@ private struct GeminiCombinedCard: View {
     }
 }
 
-/// Overview card for the Grok product family. Grok Build remains the primary
-/// xAI surface; Cursor contributes its Cursor Models / Other Models pools
-/// plus the cloud-only Grok Bot weekly quota as a linked L3 tool.
+/// Overview card for the SpaceXAI provider family. Grok, Cursor, and the
+/// cloud-only Grok Bot quota are separate SubProviders in the same card.
 private struct GrokCombinedCard: View {
     let density: Theme.Density
 
@@ -819,20 +813,17 @@ private struct GrokCombinedCard: View {
             HStack(alignment: .center, spacing: 8) {
                 ProviderSectionTitle(
                     tool: .grok,
-                    title: ToolType.grok.productName,
-                    subtitle: ToolType.grok.statusProviderName,
+                    title: ToolType.grok.vendorName,
+                    subtitle: nil,
                     titleFontSize: density.titleFontSize,
                     subtitleFontSize: density.subtitleFontSize,
                     iconSize: 16,
                     badgeSize: 24
                 )
                 Spacer(minLength: 4)
-                if let grokBadge {
-                    PlanBadgeView(text: grokBadge, fontSize: max(9, density.subtitleFontSize - 1))
-                }
                 BorderlessIconButton(
                     systemImage: "arrow.clockwise",
-                    help: "Refresh Grok Build + Cursor"
+                    help: "Refresh Grok + Cursor"
                 ) {
                     environment.refresh(.grok)
                     environment.refresh(.cursor)
@@ -841,6 +832,19 @@ private struct GrokCombinedCard: View {
                 if anyInFlight {
                     ProgressView().controlSize(.small)
                         .frame(width: 16, height: 16)
+                }
+            }
+
+
+            HStack(alignment: .center, spacing: 6) {
+                ToolBrandIconView(tool: .grok, size: 13)
+                    .opacity(0.85)
+                Text("Grok")
+                    .font(.system(size: max(10, density.subtitleFontSize), weight: .semibold))
+                    .foregroundStyle(.secondary)
+                Spacer(minLength: 4)
+                if let grokBadge {
+                    PlanBadgeView(text: grokBadge, fontSize: max(9, density.subtitleFontSize - 1))
                 }
             }
 
@@ -860,7 +864,7 @@ private struct GrokCombinedCard: View {
                         .foregroundStyle(.secondary)
                     Spacer(minLength: 4)
                     if let cursorBadge {
-                        PlanBadgeView(text: cursorBadge, fontSize: max(8, density.subtitleFontSize - 2))
+                        PlanBadgeView(text: cursorBadge, fontSize: max(9, density.subtitleFontSize - 1))
                     }
                 }
                 .padding(.top, 4)
@@ -869,7 +873,31 @@ private struct GrokCombinedCard: View {
                     tool: .cursor,
                     density: density,
                     compact: false,
-                    embedded: true
+                    embedded: true,
+                    includedBucketIDs: ["models", "other_models"]
+                )
+
+                HStack(alignment: .center, spacing: 6) {
+                    ToolBrandIconView(tool: .grok, size: 13)
+                        .opacity(0.85)
+                    Text("Grok Bot")
+                        .font(.system(size: max(10, density.subtitleFontSize), weight: .semibold))
+                        .foregroundStyle(.secondary)
+                    Spacer(minLength: 4)
+                    if let cursorBadge {
+                        PlanBadgeView(text: cursorBadge, fontSize: max(9, density.subtitleFontSize - 1))
+                    }
+                }
+                .padding(.top, 4)
+
+                ProviderQuotaCard(
+                    tool: .cursor,
+                    density: density,
+                    compact: false,
+                    embedded: true,
+                    includedBucketIDs: ["grok_bot_weekly"],
+                    suppressGroupTitles: true,
+                    showsFreshnessWarning: false
                 )
             }
         }
@@ -896,8 +924,8 @@ private struct GrokCombinedCard: View {
     }
 }
 
-/// The dedicated Gemini sub-page (still routed through `OverviewPage.googleAI`
-/// for backwards-compat with the menu-bar settings, but labelled "Gemini" at
+/// The dedicated Google AI sub-page (still routed through `OverviewPage.googleAI`
+/// for backwards compatibility with persisted menu-bar settings, but labelled "Google AI" at
 /// every user-facing surface). Provider pages share one asymmetric layout:
 /// live quota, forecast and service status remain together in the narrow left
 /// column; cost and analytics use the wider right column.
@@ -905,8 +933,7 @@ private struct GeminiTabPage: View {
     let density: Theme.Density
 
     var body: some View {
-        // Gemini's page is a provider page whose cost surface is the combined
-        // Gemini + AntiGravity total, relabelled as the one "Gemini" platform.
+        // The Google AI page combines Gemini Web + AntiGravity cost.
         ProviderDetailView(tool: .gemini, density: density)
     }
 }
@@ -936,7 +963,7 @@ private struct GeminiCostEmptyCard: View {
                 Text("No Gemini or AntiGravity usage found yet.")
                     .font(.system(size: density.subtitleFontSize))
                     .foregroundStyle(.secondary)
-                Text("AntiGravity is the live Google/Gemini source. Open AntiGravity at least once while Vibe Bar is running so it can sync cascade usage from the language server; cached results then persist after you quit it.")
+                Text("Vibe Bar reads live AntiGravity quota from the desktop app when available, then falls back to the installed agy CLI. Cached values are marked stale when neither local source can refresh them.")
                     .font(.system(size: max(10, density.subtitleFontSize - 1)))
                     .foregroundStyle(.tertiary)
                     .lineLimit(nil)
@@ -1316,6 +1343,13 @@ private struct OverviewStatusSummaryCard: View {
             return serviceStatus.snapshotByTool[.gemini]
                 ?? serviceStatus.snapshotByTool[.antigravity]
         }
+        if tool == .grok {
+            let grok = serviceStatus.snapshotByTool[.grok]
+            let cursor = serviceStatus.snapshotByTool[.cursor]
+            guard let grok else { return cursor }
+            guard let cursor else { return grok }
+            return cursor.indicator.severity > grok.indicator.severity ? cursor : grok
+        }
         return serviceStatus.snapshotByTool[tool]
     }
 
@@ -1323,6 +1357,10 @@ private struct OverviewStatusSummaryCard: View {
         if tool == .gemini {
             return serviceStatus.inFlight.contains(.gemini)
                 || serviceStatus.inFlight.contains(.antigravity)
+        }
+        if tool == .grok {
+            return serviceStatus.inFlight.contains(.grok)
+                || serviceStatus.inFlight.contains(.cursor)
         }
         return serviceStatus.inFlight.contains(tool)
     }
@@ -1332,6 +1370,11 @@ private struct OverviewStatusSummaryCard: View {
             if statusSnapshot(for: tool) != nil { return nil }
             return serviceStatus.errorByTool[.gemini]
                 ?? serviceStatus.errorByTool[.antigravity]
+        }
+        if tool == .grok {
+            if statusSnapshot(for: tool) != nil { return nil }
+            return serviceStatus.errorByTool[.grok]
+                ?? serviceStatus.errorByTool[.cursor]
         }
         return serviceStatus.errorByTool[tool]
     }
@@ -1406,8 +1449,8 @@ private struct OverviewCostCard: View {
 
     var body: some View {
         let snapshot = snapshotOverride ?? environment.costService.snapshot(for: tool)
-        let title = titleOverride ?? "\(tool.menuTitle) Cost"
-        let toolName = toolNameOverride ?? tool.menuTitle
+        let title = titleOverride ?? "\(tool.vendorName) Cost"
+        let toolName = toolNameOverride ?? tool.vendorName
         VStack(alignment: .leading, spacing: density.cardSpacing) {
             HStack(alignment: .center) {
                 ProviderSectionTitle(
@@ -1487,7 +1530,7 @@ private struct OverviewCostCard: View {
         case .claude: return "No Claude CLI sessions found yet."
         case .gemini: return "No Gemini CLI or chat-history usage found yet."
         case .antigravity: return "No Antigravity conversation token metadata found yet."
-        case .grok: return "No Grok Build session usage found yet."
+        case .grok: return "No Grok session usage found yet."
         case .alibaba, .alibabaTokenPlan, .copilot, .zai, .minimax, .kimi, .cursor, .mimo, .iflytek, .tencentHunyuan, .tencentTokenPlan, .volcengine, .volcengineAgentPlan, .baiduQianfan, .openCodeGo, .kilo, .kiro, .ollama, .openRouter, .warp:
             // Misc providers' empty cost-history view shouldn't be
             // reachable (cost cards are gated on
@@ -1518,7 +1561,7 @@ private struct CostDetailPopoverContent: View {
                 HStack(alignment: .center) {
                     ProviderSectionTitle(
                         tool: tool,
-                        title: titleOverride ?? "\(tool.menuTitle) Cost — Full Charts",
+                        title: titleOverride ?? "\(tool.vendorName) Cost — Full Charts",
                         titleFontSize: density.titleFontSize,
                         subtitleFontSize: density.subtitleFontSize,
                         iconSize: 15,
@@ -1640,11 +1683,11 @@ private struct ProviderPageContext {
 
     /// Tool the cost cards are labelled and keyed by. Gemini's page shows the
     /// combined Gemini + AntiGravity total, which is carried on an AntiGravity
-    /// snapshot but presented as the single "Gemini" platform.
+    /// snapshot but presented under the page's L1 company/brand.
     var costTool: ToolType { pageTool == .gemini ? .antigravity : pageTool }
-    var costTitle: String? { pageTool == .gemini ? "Gemini Cost" : nil }
-    var costToolName: String { pageTool == .gemini ? "Gemini" : pageTool.menuTitle }
-    var activityHeatmapTitle: String? { pageTool == .gemini ? "When you use Gemini" : nil }
+    var costTitle: String? { "\(pageTool.vendorName) Cost" }
+    var costToolName: String { pageTool.vendorName }
+    var activityHeatmapTitle: String? { pageTool == .gemini ? "When you use Google AI" : nil }
 
     func group(id: String) -> QuotaGroupModule? {
         groups.first { $0.id == id }
@@ -1689,7 +1732,7 @@ private struct ProviderPageModule: View {
                     snapshot: snapshot,
                     density: density,
                     titleOverride: context.costTitle,
-                    toolNameOverride: context.pageTool == .gemini ? "Gemini" : nil
+                    toolNameOverride: context.pageTool.vendorName
                 )
             }
         case .costHistory:
@@ -1725,7 +1768,7 @@ private struct ProviderPageModule: View {
             if context.pageTool == .gemini {
                 GeminiCostEmptyCard(density: density)
             } else if context.pageTool == .grok {
-                Text("No Grok Build or Cursor usage found yet.")
+                Text("No Grok or Cursor usage found yet.")
                     .font(.system(size: density.subtitleFontSize))
                     .foregroundStyle(.tertiary)
                     .padding(.vertical, 24)
@@ -1798,7 +1841,7 @@ private struct CostHeaderCard: View {
             HStack(alignment: .center) {
                 ProviderSectionTitle(
                     tool: tool,
-                    title: titleOverride ?? "\(tool.menuTitle) Cost",
+                    title: titleOverride ?? "\(tool.vendorName) Cost",
                     titleFontSize: density.titleFontSize,
                     subtitleFontSize: density.subtitleFontSize,
                     iconSize: 15,
@@ -1874,47 +1917,18 @@ struct ProviderQuotaCard: View {
     /// so every bucket appears (Sonnet, Designs, Daily Routines, …).
     var compact: Bool = false
     /// When true, drop the outer rounded-rectangle chrome so the card can
-    /// be nested inside a larger container (the unified Gemini card uses
-    /// this to host Gemini Web + AntiGravity as L3 sub-sections inside a
-    /// single L2 Gemini surface).
+    /// be nested inside a larger L1 company card. The combined Google AI and
+    /// SpaceXAI cards use this for their L2 SubProvider sections.
     var embedded: Bool = false
+    var includedBucketIDs: Set<String>?
+    var suppressGroupTitles: Bool = false
+    var showsFreshnessWarning: Bool = true
 
     @EnvironmentObject var environment: AppEnvironment
     @EnvironmentObject var settingsStore: SettingsStore
     @EnvironmentObject var quotaService: QuotaService
 
     var body: some View {
-        let account: AccountIdentity? = {
-            if let accountId {
-                return environment.accountStore.accounts.first { $0.id == accountId }
-            }
-            return environment.account(for: tool)
-        }()
-        let quota: AccountQuota? = {
-            if let account, let cached = quotaService.cachedQuota(for: account.id) {
-                return cached
-            }
-            return accountId == nil ? environment.quota(for: tool) : nil
-        }()
-        let liveError = displayableError(
-            account.flatMap { quotaService.lastErrorByAccount[$0.id] },
-            with: quota
-        )
-        let isProviderRefreshing = account.map { quotaService.inFlightAccountIds.contains($0.id) } == true
-        let planBadge = settingsStore.settings.planBadgeLabel(
-            for: tool,
-            quotaPlan: quota?.plan,
-            accountPlan: account?.plan
-        )
-        let cardTitle = (accountId != nil ? account?.alias : nil) ?? tool.menuTitle
-        let cardSubtitle: String = {
-            guard accountId != nil else { return tool.subtitle }
-            switch account?.source {
-            case .webCookie: return "gemini.google.com · current + weekly"
-            default: return tool.subtitle
-            }
-        }()
-
         VStack(alignment: .leading, spacing: density.cardSpacing) {
             // The embedded variant lives inside a parent container
             // (e.g. GeminiCombinedCard) that already owns the L2
@@ -1926,20 +1940,14 @@ struct ProviderQuotaCard: View {
                 HStack(alignment: .center, spacing: 8) {
                     ProviderSectionTitle(
                         tool: tool,
-                        title: cardTitle,
-                        subtitle: cardSubtitle,
+                        title: tool.vendorName,
+                        subtitle: nil,
                         titleFontSize: density.titleFontSize,
                         subtitleFontSize: density.subtitleFontSize,
                         iconSize: 16,
                         badgeSize: 24
                     )
                     Spacer(minLength: 4)
-                    if planBadge?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false {
-                        PlanBadgeView(
-                            text: planBadge,
-                            fontSize: max(9, density.subtitleFontSize - 1)
-                        )
-                    }
                     BorderlessIconButton(systemImage: "arrow.clockwise", help: "Refresh") {
                         environment.refresh(tool)
                     }
@@ -1949,17 +1957,39 @@ struct ProviderQuotaCard: View {
                             .frame(width: 16, height: 16)
                     }
                 }
+                HStack(alignment: .center, spacing: 6) {
+                    ToolBrandIconView(tool: tool, size: 13)
+                        .opacity(0.85)
+                    Text(subProviderTitle)
+                        .font(.system(size: max(10, density.subtitleFontSize), weight: .semibold))
+                        .foregroundStyle(.secondary)
+                    Spacer(minLength: 4)
+                    if resolvedPlanBadge?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false {
+                        PlanBadgeView(
+                            text: resolvedPlanBadge,
+                            fontSize: max(9, density.subtitleFontSize - 1)
+                        )
+                    }
+                }
             }
 
-            if let quota, !quota.buckets.isEmpty {
-                bucketContent(quota.buckets, accountId: account?.id)
-                if tool == .codex, let credits = quota.resetCredits, credits.availableCount > 0 {
+            if let freshnessWarning = currentFreshnessWarning {
+                Label(freshnessWarning.label, systemImage: "clock.badge.exclamationmark")
+                    .font(.system(size: max(9, density.subtitleFontSize - 1), weight: .medium))
+                    .foregroundStyle(.orange)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .help(freshnessWarning.help)
+            }
+
+            if !visibleBuckets.isEmpty {
+                bucketContent(visibleBuckets, accountId: resolvedAccount?.id)
+                if tool == .codex, let credits = resolvedQuota?.resetCredits, credits.availableCount > 0 {
                     ResetCreditsRow(credits: credits, density: density)
                 }
-                if let liveError {
+                if let liveError = resolvedLiveError {
                     messageRow(text: "Update failed: \(liveError.userFacingMessage)", color: .orange)
                 }
-            } else if let liveError {
+            } else if let liveError = resolvedLiveError {
                 messageRow(text: liveError.userFacingMessage, color: .orange)
             } else {
                 messageRow(text: emptyMessage, color: .secondary)
@@ -1981,6 +2011,79 @@ struct ProviderQuotaCard: View {
                     RoundedRectangle(cornerRadius: density.cardCornerRadius, style: .continuous)
                         .stroke(.separator.opacity(0.4), lineWidth: 0.5)
                 )
+        )
+    }
+
+    private var resolvedAccount: AccountIdentity? {
+        if let accountId {
+            return environment.accountStore.accounts.first { $0.id == accountId }
+        }
+        return environment.account(for: tool)
+    }
+
+    private var resolvedQuota: AccountQuota? {
+        if let account = resolvedAccount, let cached = quotaService.cachedQuota(for: account.id) {
+            return cached
+        }
+        return accountId == nil ? environment.quota(for: tool) : nil
+    }
+
+    private var resolvedLiveError: QuotaError? {
+        displayableError(
+            resolvedAccount.flatMap { quotaService.lastErrorByAccount[$0.id] },
+            with: resolvedQuota
+        )
+    }
+
+    private var isProviderRefreshing: Bool {
+        resolvedAccount.map { quotaService.inFlightAccountIds.contains($0.id) } == true
+    }
+
+    private var currentFreshnessWarning: (label: String, help: String)? {
+        guard showsFreshnessWarning else { return nil }
+        return resolvedAccount.flatMap { freshnessWarning(for: $0, now: Date()) }
+    }
+
+    private var resolvedPlanBadge: String? {
+        settingsStore.settings.planBadgeLabel(
+            for: tool,
+            quotaPlan: resolvedQuota?.plan,
+            accountPlan: resolvedAccount?.plan
+        )
+    }
+
+    private var visibleBuckets: [QuotaBucket] {
+        displayBuckets(from: resolvedQuota)
+    }
+
+    private var subProviderTitle: String {
+        tool.quotaSubProviderName()
+    }
+
+    private func displayBuckets(from quota: AccountQuota?) -> [QuotaBucket] {
+        guard let quota else { return [] }
+        return quota.buckets.compactMap { bucket in
+            guard includedBucketIDs?.contains(bucket.id) ?? true else { return nil }
+            guard suppressGroupTitles else { return bucket }
+            var copy = bucket
+            copy.groupTitle = nil
+            return copy
+        }
+    }
+
+    private func freshnessWarning(
+        for account: AccountIdentity,
+        now: Date
+    ) -> (label: String, help: String)? {
+        guard let updatedAt = quotaService.lastUpdatedByAccount[account.id] else { return nil }
+        let age = now.timeIntervalSince(updatedAt)
+        let staleAfter = TimeInterval(max(300, settingsStore.settings.refreshIntervalSeconds * 2))
+        let error = quotaService.lastErrorByAccount[account.id]
+        guard age >= staleAfter || error != nil else { return nil }
+        let updated = ResetCountdownFormatter.updatedAgo(from: updatedAt, now: now)
+        return (
+            label: age >= staleAfter ? "Stale · \(updated)" : "Refresh failed · \(updated)",
+            help: error?.userFacingMessage ?? "Live quota has not refreshed within the expected interval."
         )
     }
 

--- a/Sources/VibeBarApp/Views/PopoverRoot.swift
+++ b/Sources/VibeBarApp/Views/PopoverRoot.swift
@@ -801,8 +801,11 @@ private struct GrokCombinedCard: View {
     var body: some View {
         let grokAccount = environment.account(for: .grok)
         let cursorAccount = environment.account(for: .cursor)
+        let cursorQuota = cursorAccount.flatMap { quotaService.cachedQuota(for: $0.id) }
+            ?? environment.quota(for: .cursor)
         let showsCursor = (cursorAccount.map { $0.source != .notConfigured } ?? false)
-            || cursorAccount.flatMap { quotaService.cachedQuota(for: $0.id) } != nil
+            || cursorQuota != nil
+        let showsGrokBot = cursorQuota?.buckets.contains { $0.id == "grok_bot_weekly" } == true
         let anyInFlight = [grokAccount, cursorAccount].compactMap { $0 }.contains {
             quotaService.inFlightAccountIds.contains($0.id)
         }
@@ -877,28 +880,30 @@ private struct GrokCombinedCard: View {
                     includedBucketIDs: ["models", "other_models"]
                 )
 
-                HStack(alignment: .center, spacing: 6) {
-                    ToolBrandIconView(tool: .grok, size: 13)
-                        .opacity(0.85)
-                    Text("Grok Bot")
-                        .font(.system(size: max(10, density.subtitleFontSize), weight: .semibold))
-                        .foregroundStyle(.secondary)
-                    Spacer(minLength: 4)
-                    if let cursorBadge {
-                        PlanBadgeView(text: cursorBadge, fontSize: max(9, density.subtitleFontSize - 1))
+                if showsGrokBot {
+                    HStack(alignment: .center, spacing: 6) {
+                        ToolBrandIconView(tool: .grok, size: 13)
+                            .opacity(0.85)
+                        Text("Grok Bot")
+                            .font(.system(size: max(10, density.subtitleFontSize), weight: .semibold))
+                            .foregroundStyle(.secondary)
+                        Spacer(minLength: 4)
+                        if let cursorBadge {
+                            PlanBadgeView(text: cursorBadge, fontSize: max(9, density.subtitleFontSize - 1))
+                        }
                     }
-                }
-                .padding(.top, 4)
+                    .padding(.top, 4)
 
-                ProviderQuotaCard(
-                    tool: .cursor,
-                    density: density,
-                    compact: false,
-                    embedded: true,
-                    includedBucketIDs: ["grok_bot_weekly"],
-                    suppressGroupTitles: true,
-                    showsFreshnessWarning: false
-                )
+                    ProviderQuotaCard(
+                        tool: .cursor,
+                        density: density,
+                        compact: false,
+                        embedded: true,
+                        includedBucketIDs: ["grok_bot_weekly"],
+                        suppressGroupTitles: true,
+                        showsFreshnessWarning: false
+                    )
+                }
             }
         }
         .padding(density.cardPadding)

--- a/Sources/VibeBarApp/Views/PopoverRoot.swift
+++ b/Sources/VibeBarApp/Views/PopoverRoot.swift
@@ -1348,8 +1348,10 @@ private struct OverviewStatusSummaryCard: View {
 
     private func statusSnapshot(for tool: ToolType) -> ServiceStatusSnapshot? {
         if tool == .gemini {
-            return serviceStatus.snapshotByTool[.gemini]
-                ?? serviceStatus.snapshotByTool[.antigravity]
+            return ServiceStatusSnapshot.preferredGoogleAI(
+                gemini: serviceStatus.snapshotByTool[.gemini],
+                antigravity: serviceStatus.snapshotByTool[.antigravity]
+            )
         }
         if tool == .grok {
             return ServiceStatusSnapshot.mergedSpaceXAI(

--- a/Sources/VibeBarApp/Views/PopoverRoot.swift
+++ b/Sources/VibeBarApp/Views/PopoverRoot.swift
@@ -1320,7 +1320,7 @@ private struct OverviewStatusSummaryCard: View {
         if statusError(for: tool) != nil {
             return .down
         }
-        guard let indicator = statusSnapshot(for: tool)?.indicator else {
+        guard let indicator = statusSnapshot(for: tool)?.effectiveIndicator else {
             return .checking
         }
         switch indicator {
@@ -1352,11 +1352,10 @@ private struct OverviewStatusSummaryCard: View {
                 ?? serviceStatus.snapshotByTool[.antigravity]
         }
         if tool == .grok {
-            let grok = serviceStatus.snapshotByTool[.grok]
-            let cursor = serviceStatus.snapshotByTool[.cursor]
-            guard let grok else { return cursor }
-            guard let cursor else { return grok }
-            return cursor.indicator.severity > grok.indicator.severity ? cursor : grok
+            return ServiceStatusSnapshot.mergedSpaceXAI(
+                grok: serviceStatus.snapshotByTool[.grok],
+                cursor: serviceStatus.snapshotByTool[.cursor]
+            )
         }
         return serviceStatus.snapshotByTool[tool]
     }

--- a/Sources/VibeBarApp/Views/PricingSettingsSection.swift
+++ b/Sources/VibeBarApp/Views/PricingSettingsSection.swift
@@ -36,11 +36,13 @@ struct PricingSettingsSection: View {
                             .foregroundStyle(.secondary)
                     }
                     Spacer()
-                    Text("\(environment.pricingRefreshStatus.mergedModelCount) models")
+                    Text("\(PricingResolver.active.effectiveModelPrices.count) models")
                         .font(.caption2.monospacedDigit())
                         .foregroundStyle(.secondary)
                 }
             }
+
+            EffectivePricingCatalogView()
 
             settingsSection("Priority and source health") {
                 priorityRow(number: 1, name: "Local overrides", detail: "Always wins")

--- a/Sources/VibeBarApp/Views/QuotaGroupCard.swift
+++ b/Sources/VibeBarApp/Views/QuotaGroupCard.swift
@@ -264,13 +264,6 @@ struct QuotaGroupCard: View {
                         }
                     }
                 }
-                if let warning = providerFreshnessWarning {
-                    Label(warning.label, systemImage: "clock.badge.exclamationmark")
-                        .font(.system(size: max(9, density.subtitleFontSize - 1), weight: .medium))
-                        .foregroundStyle(.orange)
-                        .fixedSize(horizontal: false, vertical: true)
-                        .help(warning.help)
-                }
             }
             if let linkedSectionTitle = module.linkedSectionTitle {
                 // The pre-split card separated a linked SubProvider's rows with a
@@ -290,6 +283,13 @@ struct QuotaGroupCard: View {
                         )
                     }
                 }
+            }
+            if let warning = providerFreshnessWarning {
+                Label(warning.label, systemImage: "clock.badge.exclamationmark")
+                    .font(.system(size: max(9, density.subtitleFontSize - 1), weight: .medium))
+                    .foregroundStyle(.orange)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .help(warning.help)
             }
             if module.showsGroupTitle, let title = module.title {
                 HStack(spacing: 5) {
@@ -311,7 +311,7 @@ struct QuotaGroupCard: View {
     }
 
     private var providerFreshnessWarning: (label: String, help: String)? {
-        guard module.showsProviderHeader,
+        guard module.showsProviderHeader || module.linkedSectionTitle != nil,
               let accountId = module.accountId,
               let updatedAt = quotaService.lastUpdatedByAccount[accountId]
         else { return nil }

--- a/Sources/VibeBarApp/Views/QuotaGroupCard.swift
+++ b/Sources/VibeBarApp/Views/QuotaGroupCard.swift
@@ -14,7 +14,7 @@ struct QuotaGroupModule: Identifiable {
     struct Row: Identifiable {
         let id: String
         /// The tool this bucket actually came from — differs from the module's
-        /// page tool only for linked products (AntiGravity on the Gemini page).
+        /// page tool only for linked SubProviders (AntiGravity on Google AI).
         let tool: ToolType
         let accountId: String?
         let bucket: QuotaBucket
@@ -34,16 +34,17 @@ struct QuotaGroupModule: Identifiable {
     let accountId: String?
     /// The group's heading, `nil` for the unnamed run.
     let title: String?
-    /// Optional brand mark beside a group heading. Grok Bot has no separate
-    /// bundled asset, so its section deliberately reuses the Grok glyph.
-    let groupTitleIconTool: ToolType?
+    /// Whether the quota/model group heading is distinct from its SubProvider
+    /// heading. Grok Bot is itself a SubProvider, not a model group.
+    let showsGroupTitle: Bool
     /// Account-scoped identity of the group's history chart. Unchanged from the
     /// pre-split card so an existing chart keeps its state.
     let chartKey: String
     let rows: [Row]
-    /// Set on the first card of a linked product's run. That card names the
-    /// product (icon + title) the way the in-card divider used to.
+    /// Set on the first card of a SubProvider run (ChatGPT Agentic, Claude,
+    /// Gemini Web, AntiGravity, Grok, Cursor, or Grok Bot).
     let linkedSectionTitle: String?
+    let linkedSectionIconTool: ToolType?
     /// Set on the first card of the page. It inherits the provider header —
     /// brand icon, product name, plan badge, refresh button — that the single
     /// pre-split card carried at the top.
@@ -56,7 +57,7 @@ struct QuotaGroupModule: Identifiable {
 
 /// Resolves a provider page's quota buckets into the per-group card modules the
 /// page renders, preserving the pre-split card's ordering exactly: primary
-/// buckets first in provider order, then any linked product's, split wherever
+/// buckets first in provider order, then any linked SubProvider's, split wherever
 /// `QuotaBucketGrouping.key` changes.
 enum QuotaGroupModuleBuilder {
     private struct RawBucket {
@@ -70,8 +71,8 @@ enum QuotaGroupModuleBuilder {
     ///   - pageTool: the provider page being rendered.
     ///   - buckets: the page tool's own live quotas.
     ///   - primaryAccountId: account behind `buckets`, `nil` when signed out.
-    ///   - additionalQuotaSeries: linked products stacked under the page tool
-    ///     (AntiGravity on the Gemini page).
+    ///   - additionalQuotaSeries: linked SubProviders stacked under the page
+    ///     tool (AntiGravity on Google AI).
     static func modules(
         pageTool: ToolType,
         buckets: [QuotaBucket],
@@ -112,15 +113,14 @@ enum QuotaGroupModuleBuilder {
             let head = raw[index]
             let title = titles[index]
 
-            // A linked product's name is printed once, on the first card of its
-            // run. A section boundary always implies a group boundary, because
-            // changing tool changes the chart key too.
+            // A SubProvider name is printed once on the first card in its run.
+            // Grok Bot is a distinct SubProvider even though its quota comes
+            // from the Cursor dashboard adapter.
             var linkedSectionTitle: String?
-            if head.tool != pageTool {
-                let sectionKey = "\(head.tool.rawValue):\(head.tool.toolName)"
-                if seenSectionKeys.insert(sectionKey).inserted {
-                    linkedSectionTitle = head.tool.toolName
-                }
+            let resolvedSubProviderTitle = head.tool.quotaSubProviderName(bucketID: head.bucket.id)
+            let sectionKey = "\(head.tool.rawValue):\(resolvedSubProviderTitle)"
+            if seenSectionKeys.insert(sectionKey).inserted {
+                linkedSectionTitle = resolvedSubProviderTitle
             }
 
             // Two runs can in principle carry the same heading (a heading that
@@ -139,7 +139,7 @@ enum QuotaGroupModuleBuilder {
                     tool: head.tool,
                     accountId: head.accountId,
                     title: title,
-                    groupTitleIconTool: head.tool == .cursor && title == "Grok Bot" ? .grok : nil,
+                    showsGroupTitle: !(head.tool == .cursor && head.bucket.id == "grok_bot_weekly"),
                     chartKey: chartKeys[index],
                     rows: raw[index...end].map {
                         QuotaGroupModule.Row(
@@ -150,6 +150,9 @@ enum QuotaGroupModuleBuilder {
                         )
                     },
                     linkedSectionTitle: linkedSectionTitle,
+                    linkedSectionIconTool: head.tool == .cursor && head.bucket.id == "grok_bot_weekly"
+                        ? .grok
+                        : head.tool,
                     showsProviderHeader: modules.isEmpty
                 )
             )
@@ -178,13 +181,15 @@ enum QuotaGroupModuleBuilder {
             tool: pageTool,
             accountId: accountId,
             title: title,
-            groupTitleIconTool: nil,
+            showsGroupTitle: true,
             chartKey: QuotaBucketGrouping.key(accountId: nil, itemTool: pageTool, title: title),
             rows: [],
-            linkedSectionTitle: nil,
+            linkedSectionTitle: pageTool.quotaSubProviderName(),
+            linkedSectionIconTool: pageTool,
             showsProviderHeader: true
         )
     }
+
 }
 
 /// One quota group as a self-contained card module.
@@ -245,46 +250,49 @@ struct QuotaGroupCard: View {
                 HStack(alignment: .center, spacing: 8) {
                     ProviderSectionTitle(
                         tool: module.pageTool,
-                        title: module.pageTool.menuTitle,
-                        subtitle: providerSubtitle,
+                        title: module.pageTool.vendorName,
+                        subtitle: nil,
                         titleFontSize: density.titleFontSize,
                         subtitleFontSize: density.subtitleFontSize,
                         iconSize: 16,
                         badgeSize: 24
                     )
                     Spacer(minLength: 4)
-                    if let providerPlanBadge {
-                        PlanBadgeView(
-                            text: providerPlanBadge,
-                            fontSize: max(9, density.subtitleFontSize - 1)
-                        )
-                    }
                     SectionRefreshButton(isRefreshing: isRefreshing) {
                         for refreshTool in refreshTools {
                             environment.refresh(refreshTool)
                         }
                     }
                 }
+                if let warning = providerFreshnessWarning {
+                    Label(warning.label, systemImage: "clock.badge.exclamationmark")
+                        .font(.system(size: max(9, density.subtitleFontSize - 1), weight: .medium))
+                        .foregroundStyle(.orange)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .help(warning.help)
+                }
             }
             if let linkedSectionTitle = module.linkedSectionTitle {
-                // The pre-split card separated a linked product's rows with a
+                // The pre-split card separated a linked SubProvider's rows with a
                 // divider; the card boundary does that now, so only the name
                 // and brand icon survive.
                 HStack(alignment: .center, spacing: 6) {
-                    ToolBrandIconView(tool: module.tool, size: 13)
+                    ToolBrandIconView(tool: module.linkedSectionIconTool ?? module.tool, size: 13)
                         .opacity(0.85)
                     Text(linkedSectionTitle)
                         .font(.system(size: max(10, density.subtitleFontSize), weight: .semibold))
                         .foregroundStyle(.secondary)
                     Spacer(minLength: 4)
+                    if let subProviderPlanBadge {
+                        PlanBadgeView(
+                            text: subProviderPlanBadge,
+                            fontSize: max(9, density.subtitleFontSize - 1)
+                        )
+                    }
                 }
             }
-            if let title = module.title {
+            if module.showsGroupTitle, let title = module.title {
                 HStack(spacing: 5) {
-                    if let iconTool = module.groupTitleIconTool {
-                        ToolBrandIconView(tool: iconTool, size: 11)
-                            .opacity(0.78)
-                    }
                     Text(title)
                         .font(.system(size: max(9, density.subtitleFontSize - 1), weight: .semibold))
                         .foregroundStyle(.tertiary)
@@ -302,16 +310,29 @@ struct QuotaGroupCard: View {
         }
     }
 
-    private var providerSubtitle: String {
-        module.pageTool == .gemini ? module.pageTool.statusProviderName : module.pageTool.subtitle
+    private var providerFreshnessWarning: (label: String, help: String)? {
+        guard module.showsProviderHeader,
+              let accountId = module.accountId,
+              let updatedAt = quotaService.lastUpdatedByAccount[accountId]
+        else { return nil }
+        let age = now.timeIntervalSince(updatedAt)
+        let staleAfter = TimeInterval(max(300, settingsStore.settings.refreshIntervalSeconds * 2))
+        let error = quotaService.lastErrorByAccount[accountId]
+        guard age >= staleAfter || error != nil else { return nil }
+        let updated = ResetCountdownFormatter.updatedAgo(from: updatedAt, now: now)
+        let label = age >= staleAfter ? "Stale · \(updated)" : "Refresh failed · \(updated)"
+        return (
+            label: label,
+            help: error?.userFacingMessage ?? "Live quota has not refreshed within the expected interval."
+        )
     }
 
-    private var providerPlanBadge: String? {
-        let account = environment.account(for: module.pageTool)
+    private var subProviderPlanBadge: String? {
+        let account = environment.account(for: module.tool)
         let quotaPlan = account.flatMap { quotaService.cachedQuota(for: $0.id)?.plan }
-            ?? environment.quota(for: module.pageTool)?.plan
+            ?? environment.quota(for: module.tool)?.plan
         let label = settingsStore.settings.planBadgeLabel(
-            for: module.pageTool,
+            for: module.tool,
             quotaPlan: quotaPlan,
             accountPlan: account?.plan
         )?.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Sources/VibeBarApp/Views/ServiceStatusCard.swift
+++ b/Sources/VibeBarApp/Views/ServiceStatusCard.swift
@@ -137,21 +137,9 @@ private struct ServiceStatusRow: View {
 
     private var displaySnapshot: ServiceStatusSnapshot? {
         guard tool == .grok else { return serviceStatus.snapshotByTool[tool] }
-        let grok = serviceStatus.snapshotByTool[.grok]
-        guard let cursor = serviceStatus.snapshotByTool[.cursor] else { return grok }
-        let base = grok ?? ServiceStatusSnapshot(
-            tool: .grok,
-            indicator: .none,
-            description: "Cursor status available",
-            updatedAt: cursor.updatedAt,
-            groups: [],
-            components: [],
-            recentIncidents: []
-        )
-        return base.mergingSubProvider(
-            cursor,
-            groupID: "subprovider:cursor",
-            groupName: "Cursor"
+        return ServiceStatusSnapshot.mergedSpaceXAI(
+            grok: serviceStatus.snapshotByTool[.grok],
+            cursor: serviceStatus.snapshotByTool[.cursor]
         )
     }
 

--- a/Sources/VibeBarApp/Views/ServiceStatusCard.swift
+++ b/Sources/VibeBarApp/Views/ServiceStatusCard.swift
@@ -17,7 +17,13 @@ struct ServiceStatusCard: View {
         // they never belong in this card. Default to the providers
         // that actually publish a status feed; callers can still pass
         // an explicit subset (e.g. just `.codex` or `.claude`).
-        self.tools = tools.filter(\.supportsStatusPage)
+        var filtered = tools.filter(\.supportsStatusPage)
+        if filtered.contains(.grok) {
+            // Cursor is a SubProvider group inside SpaceXAI, not a duplicate
+            // top-level company row.
+            filtered.removeAll { $0 == .cursor }
+        }
+        self.tools = filtered
         self.density = density
     }
 
@@ -69,9 +75,11 @@ private struct ServiceStatusRow: View {
     @EnvironmentObject var serviceStatus: ServiceStatusController
 
     var body: some View {
-        let snapshot = serviceStatus.snapshotByTool[tool]
+        let snapshot = displaySnapshot
         let inFlight = serviceStatus.inFlight.contains(tool)
+            || (tool == .grok && serviceStatus.inFlight.contains(.cursor))
         let error = serviceStatus.errorByTool[tool]
+            ?? (tool == .grok ? serviceStatus.errorByTool[.cursor] : nil)
 
         VStack(alignment: .leading, spacing: density.statusComponentSpacing + 2) {
             HStack(alignment: .center, spacing: 8) {
@@ -127,6 +135,26 @@ private struct ServiceStatusRow: View {
         }
     }
 
+    private var displaySnapshot: ServiceStatusSnapshot? {
+        guard tool == .grok else { return serviceStatus.snapshotByTool[tool] }
+        let grok = serviceStatus.snapshotByTool[.grok]
+        guard let cursor = serviceStatus.snapshotByTool[.cursor] else { return grok }
+        let base = grok ?? ServiceStatusSnapshot(
+            tool: .grok,
+            indicator: .none,
+            description: "Cursor status available",
+            updatedAt: cursor.updatedAt,
+            groups: [],
+            components: [],
+            recentIncidents: []
+        )
+        return base.mergingSubProvider(
+            cursor,
+            groupID: "subprovider:cursor",
+            groupName: "Cursor"
+        )
+    }
+
     @ViewBuilder
     private func groupedComponents(_ snapshot: ServiceStatusSnapshot) -> some View {
         // Default-expand most provider component groups so the
@@ -135,7 +163,7 @@ private struct ServiceStatusRow: View {
         // Codex / FedRAMP groups, and AQ only cares about Codex on
         // this app, so we open just that one and let the user click
         // through to APIs / ChatGPT / FedRAMP if they want. Claude /
-        // Google / xAI keep the all-expanded behaviour.
+        // Google AI / SpaceXAI keep the all-expanded behaviour.
         if snapshot.groups.isEmpty {
             ComponentGroupBlock(
                 title: "Components",
@@ -185,10 +213,7 @@ private struct ServiceStatusRow: View {
         return true
     }
 
-    /// Service Status rows now render at the L1 vendor level
-    /// (`tool.statusProviderName`), so `.gemini` reads "Google" in
-    /// line with the rest of the hierarchy. The old "Google AI"
-    /// override predated the unified L1/L2/L3 catalog.
+    /// Service Status rows render at the L1 company/brand level.
     private var displayName: String {
         tool.statusProviderName
     }

--- a/Sources/VibeBarApp/Views/ServiceStatusCard.swift
+++ b/Sources/VibeBarApp/Views/ServiceStatusCard.swift
@@ -76,10 +76,14 @@ private struct ServiceStatusRow: View {
 
     var body: some View {
         let snapshot = displaySnapshot
-        let inFlight = serviceStatus.inFlight.contains(tool)
-            || (tool == .grok && serviceStatus.inFlight.contains(.cursor))
-        let error = serviceStatus.errorByTool[tool]
-            ?? (tool == .grok ? serviceStatus.errorByTool[.cursor] : nil)
+        let members: [ToolType] = switch tool {
+        case .gemini: [.gemini, .antigravity]
+        case .grok: [.grok, .cursor]
+        default: [tool]
+        }
+        let inFlight = members.contains(where: serviceStatus.inFlight.contains)
+        let memberError = members.compactMap { serviceStatus.errorByTool[$0] }.first
+        let error = snapshot == nil ? memberError : nil
 
         VStack(alignment: .leading, spacing: density.statusComponentSpacing + 2) {
             HStack(alignment: .center, spacing: 8) {
@@ -136,11 +140,20 @@ private struct ServiceStatusRow: View {
     }
 
     private var displaySnapshot: ServiceStatusSnapshot? {
-        guard tool == .grok else { return serviceStatus.snapshotByTool[tool] }
-        return ServiceStatusSnapshot.mergedSpaceXAI(
-            grok: serviceStatus.snapshotByTool[.grok],
-            cursor: serviceStatus.snapshotByTool[.cursor]
-        )
+        switch tool {
+        case .gemini:
+            return ServiceStatusSnapshot.preferredGoogleAI(
+                gemini: serviceStatus.snapshotByTool[.gemini],
+                antigravity: serviceStatus.snapshotByTool[.antigravity]
+            )
+        case .grok:
+            return ServiceStatusSnapshot.mergedSpaceXAI(
+                grok: serviceStatus.snapshotByTool[.grok],
+                cursor: serviceStatus.snapshotByTool[.cursor]
+            )
+        default:
+            return serviceStatus.snapshotByTool[tool]
+        }
     }
 
     @ViewBuilder

--- a/Sources/VibeBarApp/Views/SettingsSidebarView.swift
+++ b/Sources/VibeBarApp/Views/SettingsSidebarView.swift
@@ -302,7 +302,7 @@ struct SettingsSidebarView: View {
         case .codex: "OpenAI"
         case .claude: "Anthropic"
         case .gemini: "Google AI"
-        case .grok: "xAI"
+        case .grok: "SpaceXAI"
         default: tool.vendorName
         }
     }

--- a/Sources/VibeBarApp/Views/SettingsView.swift
+++ b/Sources/VibeBarApp/Views/SettingsView.swift
@@ -26,7 +26,7 @@ enum SettingsSectionID: String {
         case .openAI: "OpenAI"
         case .anthropic: "Anthropic"
         case .googleAI: "Google AI"
-        case .xAI: "xAI"
+        case .xAI: "SpaceXAI"
         case .miscProviders: "Misc Providers"
         case .system: "System"
         case .costData: "Cost Data"
@@ -83,7 +83,7 @@ enum SettingsDestination: Hashable {
             case .codex: return "OpenAI"
             case .claude: return "Anthropic"
             case .gemini: return "Google AI"
-            case .grok: return "xAI"
+            case .grok: return "SpaceXAI"
             default: return tool.vendorName
             }
         case let .miscProvider(id):
@@ -465,7 +465,7 @@ struct SettingsView: View {
                     }
 
                     if selectedSection == .xAI {
-                    settingsSection("xAI") {
+                    settingsSection("SpaceXAI") {
                         coreProviderSummary(
                             representative: .grok,
                             healthProviders: [.grok]
@@ -473,7 +473,7 @@ struct SettingsView: View {
                         coreProviderPlanBadgeRows(for: [.grok, .cursor])
                         Divider()
                             .padding(.vertical, 2)
-                        Text("Grok combines Grok Build with Cursor. Grok Build reads `~/.grok/auth.json` or grok.com cookies; Cursor reads Cursor.app first, then cursor.com cookie slots. Grok Bot contributes quota only — its cloud runs do not add token/cost rows.")
+                        Text("The SpaceXAI page combines Grok with Cursor. Grok reads `~/.grok/auth.json` or grok.com cookies; Cursor reads Cursor.app first, then cursor.com cookie slots. Grok Bot contributes quota only — its cloud runs do not add token/cost rows.")
                             .font(.caption)
                             .foregroundStyle(.secondary)
 
@@ -544,10 +544,10 @@ struct SettingsView: View {
                         Button {
                             environment.recheckPrimaryRouteHealth(provider: .grok)
                         } label: {
-                            Label("Check xAI connections", systemImage: "checkmark.circle")
+                            Label("Check SpaceXAI connections", systemImage: "checkmark.circle")
                         }
 
-                        Link("Open xAI status page",
+                        Link("Open SpaceXAI status page",
                              destination: ToolType.grok.statusPageURL)
                             .font(.caption2)
                     }
@@ -963,14 +963,7 @@ struct SettingsView: View {
     }
 
     private func providerBadgeTitle(for tool: ToolType) -> String {
-        switch tool {
-        case .codex: return "ChatGPT"
-        case .claude: return "Claude"
-        case .gemini: return "Gemini Web"
-        case .antigravity: return "AntiGravity"
-        case .grok: return "Grok"
-        default: return tool.menuTitle
-        }
+        tool.quotaSubProviderName()
     }
 
     private func fieldRowHorizontal(
@@ -1262,7 +1255,7 @@ private struct MiniWindowFieldProviderSection {
     static let all: [MiniWindowFieldProviderSection] = [
         .init(tool: .codex,       title: ToolType.codex.productName,       fields: MenuBarFieldCatalog.codexFields),
         .init(tool: .claude,      title: ToolType.claude.productName,      fields: MenuBarFieldCatalog.claudeFields),
-        .init(tool: .gemini,      title: ToolType.gemini.productName + " Web", fields: MenuBarFieldCatalog.geminiFields),
+        .init(tool: .gemini,      title: ToolType.gemini.productName, fields: MenuBarFieldCatalog.geminiFields),
         .init(tool: .antigravity, title: ToolType.antigravity.toolName,    fields: MenuBarFieldCatalog.antigravityFields),
         .init(tool: .grok,        title: ToolType.grok.toolName,           fields: MenuBarFieldCatalog.grokFields),
         .init(tool: .cursor,      title: ToolType.cursor.toolName,         fields: MenuBarFieldCatalog.cursorFields)

--- a/Sources/VibeBarApp/Views/Workbench/SessionListView.swift
+++ b/Sources/VibeBarApp/Views/Workbench/SessionListView.swift
@@ -106,7 +106,7 @@ struct SessionListView: View {
         }
         if model.indexProgress != nil { return "Still scanning the session logs on disk." }
         if !model.searchText.isEmpty { return "Nothing in the indexed sessions matches that search." }
-        return "No Codex, Claude Code, Grok, Gemini, or AntiGravity session logs were found on this Mac."
+        return "No Codex, Claude Code, Grok, Gemini CLI, or AntiGravity session logs were found on this Mac."
     }
 }
 

--- a/Sources/VibeBarApp/Views/Workbench/SessionManagerPage.swift
+++ b/Sources/VibeBarApp/Views/Workbench/SessionManagerPage.swift
@@ -131,6 +131,7 @@ struct SessionFiltersBar: View {
                     ForEach(SessionCompanyFilter.all) { group in
                         providerChip(group)
                     }
+                    sessionSourceMenu
                     rangeMenu
                     sortMenu
                     optionsMenu
@@ -256,6 +257,29 @@ struct SessionFiltersBar: View {
 
     // MARK: - Controls
 
+    private var sessionSourceMenu: some View {
+        Menu {
+            Button("All session sources") { model.setProviderFilter(nil) }
+            Divider()
+            ForEach(SessionProvider.allCases, id: \.self) { provider in
+                Toggle(isOn: sessionSourceBinding(provider)) {
+                    Text(provider.displayName)
+                }
+            }
+        } label: {
+            menuLabel(
+                systemImage: "square.stack.3d.up",
+                title: "Sources",
+                detail: sessionSourceSummary
+            )
+        }
+        .menuStyle(.button)
+        .buttonStyle(WorkbenchPillButtonStyle())
+        .menuIndicator(.hidden)
+        .fixedSize()
+        .accessibilityLabel("Choose individual session sources")
+    }
+
     private var rangeMenu: some View {
         Menu {
             Picker("Date range", selection: $model.dateRange) {
@@ -352,6 +376,19 @@ struct SessionFiltersBar: View {
 
     private var bodyIndexingBinding: Binding<Bool> {
         Binding(get: { model.isBodyIndexingEnabled }, set: { model.setBodyIndexing($0) })
+    }
+
+    private func sessionSourceBinding(_ provider: SessionProvider) -> Binding<Bool> {
+        Binding(
+            get: { model.providerFilter?.contains(provider) ?? true },
+            set: { _ in model.toggleProvider(provider) }
+        )
+    }
+
+    private var sessionSourceSummary: String {
+        guard let selected = model.providerFilter else { return "All" }
+        if selected.count == 1, let only = selected.first { return only.displayName }
+        return "\(selected.count) selected"
     }
 
     private func menuLabel(systemImage: String, title: String, detail: String) -> some View {

--- a/Sources/VibeBarApp/Views/Workbench/SessionManagerPage.swift
+++ b/Sources/VibeBarApp/Views/Workbench/SessionManagerPage.swift
@@ -18,6 +18,20 @@ extension SessionProvider {
     var accent: Color { Theme.providerAccent(for: tool) }
 }
 
+private struct SessionCompanyFilter: Identifiable {
+    let representative: ToolType
+    let providers: Set<SessionProvider>
+
+    var id: ToolType { representative }
+
+    static let all: [SessionCompanyFilter] = [
+        SessionCompanyFilter(representative: .codex, providers: [.codex]),
+        SessionCompanyFilter(representative: .claude, providers: [.claude]),
+        SessionCompanyFilter(representative: .gemini, providers: [.gemini, .antigravity]),
+        SessionCompanyFilter(representative: .grok, providers: [.grok])
+    ]
+}
+
 /// The Workbench's Sessions page.
 ///
 /// A split, not a scroll: the list is a place you keep coming back to while
@@ -114,8 +128,8 @@ struct SessionFiltersBar: View {
                     }
                     .help("Rescan the session logs on disk")
                     allProvidersChip
-                    ForEach(SessionProvider.allCases, id: \.self) { provider in
-                        providerChip(provider)
+                    ForEach(SessionCompanyFilter.all) { group in
+                        providerChip(group)
                     }
                     rangeMenu
                     sortMenu
@@ -202,15 +216,17 @@ struct SessionFiltersBar: View {
         .accessibilityLabel("Show every provider")
     }
 
-    private func providerChip(_ provider: SessionProvider) -> some View {
-        let selected = model.providerFilter?.contains(provider) ?? true
-        let count = model.providerCounts[provider] ?? 0
+    private func providerChip(_ group: SessionCompanyFilter) -> some View {
+        let selected = model.providerFilter.map { selected in
+            group.providers.allSatisfy(selected.contains)
+        } ?? true
+        let count = group.providers.reduce(0) { $0 + (model.providerCounts[$1] ?? 0) }
         return Button {
-            model.toggleProvider(provider)
+            model.toggleProviders(group.providers)
         } label: {
             HStack(spacing: 5) {
-                ToolBrandIconView(tool: provider.tool, size: density.segmentedFontSize + 1)
-                Text(provider.displayName)
+                ToolBrandIconView(tool: group.representative, size: density.segmentedFontSize + 1)
+                Text(group.representative.vendorName)
                     .font(.system(size: max(10, density.segmentedFontSize - 1), weight: .semibold))
                     .lineLimit(1)
                 if count > 0 {
@@ -224,10 +240,10 @@ struct SessionFiltersBar: View {
             .frame(minHeight: 28)
         }
         .buttonStyle(.plain)
-        .background(chipBackground(tint: provider.accent, selected: selected))
+        .background(chipBackground(tint: Theme.providerAccent(for: group.representative), selected: selected))
         .opacity(selected ? 1 : 0.70)
         .saturation(selected ? 1 : 0.50)
-        .help(provider.displayName)
+        .help(group.representative.vendorName)
         .accessibilityAddTraits(selected ? [.isSelected] : [])
     }
 

--- a/Sources/VibeBarApp/Views/Workbench/UsageBreakdownTables.swift
+++ b/Sources/VibeBarApp/Views/Workbench/UsageBreakdownTables.swift
@@ -12,28 +12,10 @@ struct UsageBreakdownTables: View {
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @Environment(\.colorScheme) private var colorScheme
-    @State private var tab: Tab = .periods
-
-    private enum Tab: String, CaseIterable, Identifiable {
-        case periods
-        case requests
-        case providers
-        case models
-
-        var id: String { rawValue }
-
-        var title: String {
-            switch self {
-            case .periods: "Periods"
-            case .requests: "Requests"
-            case .providers: "Providers"
-            case .models: "Models"
-            }
-        }
-    }
+    @State private var tab: UsageStatsViewModel.Breakdown = .periods
 
     private var sortedProviders: [UsageProviderStat] {
-        model.providerStats.sorted { $0.costMicros > $1.costMicros }
+        model.companyProviderStats.sorted { $0.costMicros > $1.costMicros }
     }
 
     private var sortedModels: [UsageModelStat] {
@@ -56,12 +38,13 @@ struct UsageBreakdownTables: View {
     private var header: some View {
         HStack(spacing: 10) {
             HStack(spacing: 2) {
-                ForEach(Tab.allCases) { value in
+                ForEach(UsageStatsViewModel.Breakdown.allCases) { value in
                     let selected = tab == value
                     Button {
                         withAnimation(reduceMotion ? nil : .easeOut(duration: 0.16)) {
                             tab = value
                         }
+                        model.setActiveBreakdown(value)
                     } label: {
                         Text(value.title)
                             .font(.system(size: 10.5, weight: .semibold))
@@ -125,7 +108,7 @@ struct UsageBreakdownTables: View {
                 ? "\(loaded) of \(total) requests"
                 : "\(total) request\(total == 1 ? "" : "s")"
         case .providers:
-            return "\(model.providerStats.count) provider\(model.providerStats.count == 1 ? "" : "s")"
+            return "\(model.companyProviderStats.count) compan\(model.companyProviderStats.count == 1 ? "y" : "ies")"
         case .models:
             return "\(model.modelStats.count) model\(model.modelStats.count == 1 ? "" : "s")"
         }
@@ -204,7 +187,7 @@ struct UsageBreakdownTables: View {
             VStack(spacing: 0) {
                 tableHeader {
                     headerCell("Time", width: 138)
-                    headerCell("Provider", width: 138)
+                    headerCell("SubProvider", width: 138)
                     headerCell("Model", width: 220)
                     headerCell("Input", width: 114, alignment: .trailing)
                     headerCell("Output", width: 88, alignment: .trailing)
@@ -215,8 +198,12 @@ struct UsageBreakdownTables: View {
                     ForEach(model.requestRows) { row in
                         PorcelainUsageRow(accessibilityLabel: requestAccessibilityLabel(row)) {
                             valueCell(timestamp(row.date), width: 138, secondary: true, tooltip: timestamp(row.date))
-                            providerCell(row.tool, width: 138)
-                            valueCell(row.model, width: 220, tooltip: row.model)
+                            subProviderCell(row.tool, width: 138)
+                            valueCell(
+                                UsageModelNaming.canonicalDisplayName(row.model),
+                                width: 220,
+                                tooltip: row.model
+                            )
                             inputCell(row, width: 114)
                             numericCell(row.output, width: 88)
                             optionalMoneyCell(row.costMicros, width: 96)
@@ -246,7 +233,7 @@ struct UsageBreakdownTables: View {
                 LazyVStack(spacing: 0) {
                     ForEach(sortedProviders) { stat in
                         PorcelainUsageRow(accessibilityLabel: providerAccessibilityLabel(stat)) {
-                            providerCell(stat.tool, width: providerWidth)
+                            companyCell(stat.tool, width: providerWidth)
                             countCell(stat.requests, width: 112)
                             numericCell(stat.totalTokens, width: 132, emphasis: true)
                             moneyCell(stat.costMicros, width: 120, emphasis: true)
@@ -273,7 +260,11 @@ struct UsageBreakdownTables: View {
                 LazyVStack(spacing: 0) {
                     ForEach(sortedModels) { stat in
                         PorcelainUsageRow(accessibilityLabel: modelAccessibilityLabel(stat)) {
-                            valueCell(stat.model, width: modelWidth, tooltip: stat.model)
+                            valueCell(
+                                UsageModelNaming.canonicalDisplayName(stat.model),
+                                width: modelWidth,
+                                tooltip: stat.model
+                            )
                             countCell(stat.requests, width: 112)
                             numericCell(stat.totalTokens, width: 132, emphasis: true)
                             moneyCell(stat.costMicros, width: 120, emphasis: true)
@@ -330,15 +321,26 @@ struct UsageBreakdownTables: View {
             .help(tooltip ?? value)
     }
 
-    private func providerCell(_ tool: ToolType, width: CGFloat) -> some View {
+    private func subProviderCell(_ tool: ToolType, width: CGFloat) -> some View {
         HStack(spacing: 7) {
             ToolBrandBadge(tool: tool, iconSize: 13, containerSize: 16)
-            Text(tool.menuTitle)
+            Text(tool.productName)
                 .font(bodyFont)
                 .lineLimit(1)
         }
         .frame(width: width, alignment: .leading)
-        .help(tool.displayName)
+        .help("\(tool.vendorName) · \(tool.productName)")
+    }
+
+    private func companyCell(_ tool: ToolType, width: CGFloat) -> some View {
+        HStack(spacing: 7) {
+            ToolBrandBadge(tool: tool, iconSize: 13, containerSize: 16)
+            Text(tool.vendorName)
+                .font(bodyFont)
+                .lineLimit(1)
+        }
+        .frame(width: width, alignment: .leading)
+        .help(tool.vendorName)
     }
 
     private func inputCell(_ row: UsageRequestRow, width: CGFloat) -> some View {
@@ -479,15 +481,15 @@ struct UsageBreakdownTables: View {
     }
 
     private func requestAccessibilityLabel(_ row: UsageRequestRow) -> String {
-        "\(timestamp(row.date)), \(row.tool.displayName), \(row.model), \(UsageFormatting.formatTokens(row.totalTokens)), \(row.costMicros.map { UsageFormatting.formatMicroUSD($0) } ?? "unpriced")"
+        "\(timestamp(row.date)), \(row.tool.productName), \(UsageModelNaming.canonicalDisplayName(row.model)), \(UsageFormatting.formatTokens(row.totalTokens)), \(row.costMicros.map { UsageFormatting.formatMicroUSD($0) } ?? "unpriced")"
     }
 
     private func providerAccessibilityLabel(_ stat: UsageProviderStat) -> String {
-        "\(stat.tool.displayName), \(stat.requests) requests, \(UsageFormatting.formatTokens(stat.totalTokens)), \(UsageFormatting.formatMicroUSD(stat.costMicros))"
+        "\(stat.tool.vendorName), \(stat.requests) requests, \(UsageFormatting.formatTokens(stat.totalTokens)), \(UsageFormatting.formatMicroUSD(stat.costMicros))"
     }
 
     private func modelAccessibilityLabel(_ stat: UsageModelStat) -> String {
-        "\(stat.model), \(stat.requests) requests, \(UsageFormatting.formatTokens(stat.totalTokens)), \(UsageFormatting.formatMicroUSD(stat.costMicros))"
+        "\(UsageModelNaming.canonicalDisplayName(stat.model)), \(stat.requests) requests, \(UsageFormatting.formatTokens(stat.totalTokens)), \(UsageFormatting.formatMicroUSD(stat.costMicros))"
     }
 
     /// Cached: request rows can be formatted while scrolling a long ledger.

--- a/Sources/VibeBarApp/Views/Workbench/UsageBreakdownTables.swift
+++ b/Sources/VibeBarApp/Views/Workbench/UsageBreakdownTables.swift
@@ -12,7 +12,6 @@ struct UsageBreakdownTables: View {
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @Environment(\.colorScheme) private var colorScheme
-    @State private var tab: UsageStatsViewModel.Breakdown = .periods
 
     private var sortedProviders: [UsageProviderStat] {
         model.companyProviderStats.sorted { $0.costMicros > $1.costMicros }
@@ -39,12 +38,11 @@ struct UsageBreakdownTables: View {
         HStack(spacing: 10) {
             HStack(spacing: 2) {
                 ForEach(UsageStatsViewModel.Breakdown.allCases) { value in
-                    let selected = tab == value
+                    let selected = model.activeBreakdown == value
                     Button {
                         withAnimation(reduceMotion ? nil : .easeOut(duration: 0.16)) {
-                            tab = value
+                            model.setActiveBreakdown(value)
                         }
-                        model.setActiveBreakdown(value)
                     } label: {
                         Text(value.title)
                             .font(.system(size: 10.5, weight: .semibold))
@@ -97,7 +95,7 @@ struct UsageBreakdownTables: View {
     }
 
     private var countSummary: String {
-        switch tab {
+        switch model.activeBreakdown {
         case .periods:
             return "\(populatedPeriods.count) active \(periodUnit)"
                 + (populatedPeriods.count == 1 ? "" : "s")
@@ -118,7 +116,7 @@ struct UsageBreakdownTables: View {
 
     @ViewBuilder
     private var content: some View {
-        switch tab {
+        switch model.activeBreakdown {
         case .periods:
             if populatedPeriods.isEmpty {
                 empty("No active periods in this range")

--- a/Sources/VibeBarApp/Views/Workbench/UsageCompositionCards.swift
+++ b/Sources/VibeBarApp/Views/Workbench/UsageCompositionCards.swift
@@ -7,6 +7,7 @@ struct UsageCompositionCards: View {
     let density: Theme.Density
     let summary: UsageSummaryMetrics
     let providers: [UsageProviderStat]
+    let subProviderSummaries: [ToolType: String]
 
     private var providerRows: [UsageProviderStat] {
         providers
@@ -65,8 +66,8 @@ struct UsageCompositionCards: View {
                 VStack(alignment: .leading, spacing: 1) {
                     Text(row.tool.vendorName)
                         .font(.system(size: density.subtitleFontSize, weight: .semibold))
-                    if row.tool.coreProviderMembers.count > 1 {
-                        Text(row.tool.companySubProviderSummary)
+                    if let summary = subProviderSummaries[row.tool], !summary.isEmpty {
+                        Text(summary)
                             .font(.system(size: max(8, density.resetCountdownFontSize - 1)))
                             .foregroundStyle(.secondary)
                     }

--- a/Sources/VibeBarApp/Views/Workbench/UsageCompositionCards.swift
+++ b/Sources/VibeBarApp/Views/Workbench/UsageCompositionCards.swift
@@ -44,7 +44,7 @@ struct UsageCompositionCards: View {
                 Spacer(minLength: 0)
                 Divider().opacity(0.45)
                 HStack {
-                    Text("\(providerRows.count) provider\(providerRows.count == 1 ? "" : "s") active in range")
+                    Text("\(providerRows.count) compan\(providerRows.count == 1 ? "y" : "ies") active in range")
                     Spacer(minLength: 8)
                     Text("\(summary.requests.formatted(.number.grouping(.automatic))) requests")
                 }
@@ -62,9 +62,16 @@ struct UsageCompositionCards: View {
         return VStack(spacing: 5) {
             HStack(spacing: 7) {
                 ToolBrandBadge(tool: row.tool, iconSize: 12, containerSize: 19)
-                Text(row.tool.displayName)
-                    .font(.system(size: density.subtitleFontSize, weight: .semibold))
-                    .lineLimit(1)
+                VStack(alignment: .leading, spacing: 1) {
+                    Text(row.tool.vendorName)
+                        .font(.system(size: density.subtitleFontSize, weight: .semibold))
+                    if row.tool.coreProviderMembers.count > 1 {
+                        Text(row.tool.companySubProviderSummary)
+                            .font(.system(size: max(8, density.resetCountdownFontSize - 1)))
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                .lineLimit(1)
                 Spacer(minLength: 6)
                 Text(fraction.formatted(.percent.precision(.fractionLength(0))))
                     .foregroundStyle(.secondary)

--- a/Sources/VibeBarApp/Views/Workbench/UsageFiltersBar.swift
+++ b/Sources/VibeBarApp/Views/Workbench/UsageFiltersBar.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 import VibeBarCore
 
-/// Everything that narrows the Usage Stats page: provider chips, a model
+/// Everything that narrows the Usage Stats page: company/provider chips, a model
 /// picker, the date range, and how often the page re-queries.
 ///
 /// Providers are chips rather than another menu because they are the filter
@@ -38,8 +38,8 @@ struct UsageFiltersBar: View {
         ScrollView(.horizontal) {
             HStack(spacing: 6) {
                 allProvidersChip
-                ForEach(model.knownTools, id: \.self) { tool in
-                    providerChip(tool)
+                ForEach(model.knownCompanyRepresentatives, id: \.self) { representative in
+                    providerChip(representative)
                 }
             }
             .padding(.vertical, 1)
@@ -64,13 +64,13 @@ struct UsageFiltersBar: View {
 
     private func providerChip(_ tool: ToolType) -> some View {
         let accent = Theme.providerAccent(for: tool)
-        let selected = model.selectedTools?.contains(tool) ?? true
+        let selected = model.isCompanySelected(tool)
         return Button {
-            model.toggleTool(tool)
+            model.toggleCompany(tool)
         } label: {
             HStack(spacing: 5) {
                 ToolBrandIconView(tool: tool, size: density.segmentedFontSize + 1)
-                Text(tool.menuTitle)
+                Text(tool.vendorName)
                     .font(.system(size: max(10, density.segmentedFontSize - 1), weight: .semibold))
                     .lineLimit(1)
             }
@@ -83,8 +83,8 @@ struct UsageFiltersBar: View {
         // that a provider is in the query, so an off chip must not wear it.
         .opacity(selected ? 1 : 0.70)
         .saturation(selected ? 1 : 0.50)
-        .help(tool.displayName)
-        .accessibilityLabel(tool.displayName)
+        .help("\(tool.vendorName) · \(tool.companySubProviderSummary)")
+        .accessibilityLabel(tool.vendorName)
         .accessibilityAddTraits(selected ? [.isSelected] : [])
     }
 
@@ -182,7 +182,7 @@ struct UsageFiltersBar: View {
                 Divider()
                 ForEach(model.availableModels, id: \.self) { name in
                     Toggle(isOn: modelBinding(name)) {
-                        Text(name)
+                        Text(UsageModelNaming.canonicalDisplayName(name))
                     }
                 }
             }
@@ -247,6 +247,7 @@ struct UsageFiltersBar: View {
     }
 
     private var rangeSummary: String {
+        if model.rangePreset == .all { return "All time" }
         let range = model.range
         let formatter = range.duration <= 86_400 ? Self.hourFormatter : Self.dayFormatter
         return "\(formatter.string(from: range.start)) – \(formatter.string(from: range.end))"
@@ -272,7 +273,9 @@ struct UsageFiltersBar: View {
 
     private var modelSummary: String {
         guard let selected = model.selectedModels else { return "All" }
-        if selected.count == 1, let only = selected.first { return only }
+        if selected.count == 1, let only = selected.first {
+            return UsageModelNaming.canonicalDisplayName(only)
+        }
         return "\(selected.count) selected"
     }
 

--- a/Sources/VibeBarApp/Views/Workbench/UsageFiltersBar.swift
+++ b/Sources/VibeBarApp/Views/Workbench/UsageFiltersBar.swift
@@ -100,6 +100,7 @@ struct UsageFiltersBar: View {
     private var controls: some View {
         HStack(spacing: 8) {
             rangeMenu
+            subProviderMenu
             modelMenu
             refreshMenu
             if model.selectedTools != nil || model.selectedModels != nil {
@@ -196,6 +197,29 @@ struct UsageFiltersBar: View {
         .accessibilityLabel("Choose which models to include")
     }
 
+    private var subProviderMenu: some View {
+        Menu {
+            Button("All SubProviders") { model.setSelectedTools(nil) }
+            Divider()
+            ForEach(model.knownTools, id: \.self) { tool in
+                Toggle(isOn: subProviderBinding(tool)) {
+                    Text("\(tool.vendorName) · \(tool.productName)")
+                }
+            }
+        } label: {
+            menuLabel(
+                systemImage: "square.stack.3d.up",
+                title: "SubProviders",
+                detail: subProviderSummary
+            )
+        }
+        .menuStyle(.button)
+        .buttonStyle(WorkbenchPillButtonStyle())
+        .menuIndicator(.hidden)
+        .fixedSize()
+        .accessibilityLabel("Choose individual SubProviders")
+    }
+
     private var refreshMenu: some View {
         Menu {
             Picker("Auto refresh", selection: $model.refreshInterval) {
@@ -246,6 +270,13 @@ struct UsageFiltersBar: View {
         )
     }
 
+    private func subProviderBinding(_ tool: ToolType) -> Binding<Bool> {
+        Binding(
+            get: { model.selectedTools?.contains(tool) ?? true },
+            set: { _ in model.toggleTool(tool) }
+        )
+    }
+
     private var rangeSummary: String {
         if model.rangePreset == .all { return "All time" }
         let range = model.range
@@ -276,6 +307,12 @@ struct UsageFiltersBar: View {
         if selected.count == 1, let only = selected.first {
             return UsageModelNaming.canonicalDisplayName(only)
         }
+        return "\(selected.count) selected"
+    }
+
+    private var subProviderSummary: String {
+        guard let selected = model.selectedTools else { return "All" }
+        if selected.count == 1, let only = selected.first { return only.productName }
         return "\(selected.count) selected"
     }
 

--- a/Sources/VibeBarApp/Views/Workbench/UsageStatsPage.swift
+++ b/Sources/VibeBarApp/Views/Workbench/UsageStatsPage.swift
@@ -50,7 +50,7 @@ struct UsageStatsPage: View {
                 UsageCompositionCards(
                     density: density,
                     summary: model.summary,
-                    providers: model.providerStats
+                    providers: model.companyProviderStats
                 )
                 .frame(minWidth: 300, maxWidth: .infinity)
             }
@@ -59,7 +59,7 @@ struct UsageStatsPage: View {
                 UsageCompositionCards(
                     density: density,
                     summary: model.summary,
-                    providers: model.providerStats
+                    providers: model.companyProviderStats
                 )
             }
         }

--- a/Sources/VibeBarApp/Views/Workbench/UsageStatsPage.swift
+++ b/Sources/VibeBarApp/Views/Workbench/UsageStatsPage.swift
@@ -50,7 +50,8 @@ struct UsageStatsPage: View {
                 UsageCompositionCards(
                     density: density,
                     summary: model.summary,
-                    providers: model.companyProviderStats
+                    providers: model.companyProviderStats,
+                    subProviderSummaries: model.companySubProviderSummaries
                 )
                 .frame(minWidth: 300, maxWidth: .infinity)
             }
@@ -59,7 +60,8 @@ struct UsageStatsPage: View {
                 UsageCompositionCards(
                     density: density,
                     summary: model.summary,
-                    providers: model.companyProviderStats
+                    providers: model.companyProviderStats,
+                    subProviderSummaries: model.companySubProviderSummaries
                 )
             }
         }

--- a/Sources/VibeBarApp/Views/Workbench/UsageTrendChartView.swift
+++ b/Sources/VibeBarApp/Views/Workbench/UsageTrendChartView.swift
@@ -262,6 +262,7 @@ struct UsageTrendChartView: View {
             Button { model.navigateWindow(by: -1) } label: {
                 Image(systemName: "chevron.left")
             }
+            .disabled(!model.canNavigateBackward)
             .help("Previous window")
             Button { model.navigateWindow(by: 1) } label: {
                 Image(systemName: "chevron.right")

--- a/Sources/VibeBarCore/Adapters/AntigravityCLIQuotaFetcher.swift
+++ b/Sources/VibeBarCore/Adapters/AntigravityCLIQuotaFetcher.swift
@@ -14,7 +14,6 @@ enum AntigravityCLIQuotaFetcher {
     private static let pollIntervalNanoseconds: UInt64 = 350_000_000
 
     static func fetch() async throws -> AntigravityResponseParser.Snapshot {
-        let deadline = Date().addingTimeInterval(readinessTimeout)
         var lastError: Error?
 
         for pid in await runningAgyPIDs() {
@@ -31,16 +30,14 @@ enum AntigravityCLIQuotaFetcher {
         let process = try AntigravityCLIQuotaProcess.launch(binary: binary)
         defer { process.stop() }
 
-        do {
-            return try await fetch(
-                pid: process.pid,
-                deadline: deadline,
-                isRunning: { process.isRunning },
-                drainOutput: { process.drainOutput() }
-            )
-        } catch {
-            throw error
-        }
+        // Start the readiness window only once the launched process exists, so
+        // probing stale user-owned `agy` processes above never eats into it.
+        return try await fetch(
+            pid: process.pid,
+            deadline: Date().addingTimeInterval(readinessTimeout),
+            isRunning: { process.isRunning },
+            drainOutput: { process.drainOutput() }
+        )
     }
 
     static func parseAgyPIDs(_ output: String) -> [Int] {

--- a/Sources/VibeBarCore/Adapters/AntigravityCLIQuotaFetcher.swift
+++ b/Sources/VibeBarCore/Adapters/AntigravityCLIQuotaFetcher.swift
@@ -1,0 +1,218 @@
+import Darwin
+import Foundation
+
+/// Reads AntiGravity's live quota from the installed `agy` CLI when the
+/// desktop language server is absent or exposes only a partial quota summary.
+///
+/// `agy` hosts the same tokenless loopback HTTPS service while its TUI is
+/// alive. Vibe Bar never sends a prompt or scrapes the TUI: it keeps a PTY
+/// drained, probes the local ports, reads the quota RPCs, then terminates only
+/// the process it launched. An already-running user-owned `agy` is reused and
+/// never stopped.
+enum AntigravityCLIQuotaFetcher {
+    private static let readinessTimeout: TimeInterval = 15
+    private static let pollIntervalNanoseconds: UInt64 = 350_000_000
+
+    static func fetch() async throws -> AntigravityResponseParser.Snapshot {
+        let deadline = Date().addingTimeInterval(readinessTimeout)
+        var lastError: Error?
+
+        for pid in await runningAgyPIDs() {
+            do {
+                return try await fetch(pid: pid, deadline: Date().addingTimeInterval(2.5))
+            } catch {
+                lastError = error
+            }
+        }
+
+        guard let binary = resolveBinary() else {
+            throw lastError ?? QuotaError.noCredential
+        }
+        let process = try AntigravityCLIQuotaProcess.launch(binary: binary)
+        defer { process.stop() }
+
+        do {
+            return try await fetch(
+                pid: process.pid,
+                deadline: deadline,
+                isRunning: { process.isRunning },
+                drainOutput: { process.drainOutput() }
+            )
+        } catch {
+            throw error
+        }
+    }
+
+    static func parseAgyPIDs(_ output: String) -> [Int] {
+        output.split(separator: "\n").compactMap { line in
+            let parts = line.split(whereSeparator: \.isWhitespace)
+            guard parts.count >= 2,
+                  let pid = Int(parts[0]),
+                  ["agy", "antigravity-cli", "antigravity_cli"].contains(
+                      URL(fileURLWithPath: String(parts[1])).lastPathComponent.lowercased()
+                  )
+            else { return nil }
+            return pid
+        }
+    }
+
+    static func resolveBinary(
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        homeDirectory: String = RealHomeDirectory.path
+    ) -> String? {
+        var candidates: [String] = []
+        if let override = environment["ANTIGRAVITY_CLI_PATH"]?.trimmingCharacters(
+            in: .whitespacesAndNewlines
+        ), !override.isEmpty {
+            candidates.append(override)
+        }
+        candidates.append(
+            URL(fileURLWithPath: homeDirectory, isDirectory: true)
+                .appendingPathComponent(".local/bin/agy").path
+        )
+        for directory in (environment["PATH"] ?? "").split(separator: ":") {
+            candidates.append(URL(fileURLWithPath: String(directory), isDirectory: true)
+                .appendingPathComponent("agy").path)
+        }
+        candidates.append(contentsOf: ["/opt/homebrew/bin/agy", "/usr/local/bin/agy"])
+
+        var seen: Set<String> = []
+        return candidates.first { candidate in
+            guard seen.insert(candidate).inserted else { return false }
+            return FileManager.default.isExecutableFile(atPath: candidate)
+        }
+    }
+
+    private static func runningAgyPIDs() async -> [Int] {
+        guard let result = try? await ProcessRunner.run(
+            binary: "/bin/ps",
+            arguments: ["-ax", "-o", "pid=,comm="],
+            timeout: 2,
+            label: "antigravity-agy-ps"
+        ) else { return [] }
+        return parseAgyPIDs(result.stdout)
+    }
+
+    private static func fetch(
+        pid: Int,
+        deadline: Date,
+        isRunning: () -> Bool = { true },
+        drainOutput: () -> Void = {}
+    ) async throws -> AntigravityResponseParser.Snapshot {
+        let client = AntigravityLanguageServerClient(timeout: 2)
+        var lastError: Error?
+
+        while Date() < deadline, isRunning() {
+            drainOutput()
+            let ports = (try? await client.listeningPorts(pid: pid)) ?? []
+            for port in ports {
+                for scheme in ["https", "http"] {
+                    let endpoint = AntigravityLanguageServerClient.Endpoint(
+                        scheme: scheme,
+                        port: port,
+                        csrfToken: ""
+                    )
+                    do {
+                        return try await AntigravityQuotaAdapter.fetchLocalSnapshot { path, body in
+                            try await client.postLocal(endpoint: endpoint, path: path, body: body)
+                        }
+                    } catch {
+                        lastError = error
+                    }
+                }
+            }
+            try await Task.sleep(nanoseconds: pollIntervalNanoseconds)
+        }
+        throw lastError ?? QuotaError.noCredential
+    }
+}
+
+private final class AntigravityCLIQuotaProcess: @unchecked Sendable {
+    let pid: Int
+    private let process: Process
+    private let primaryFD: Int32
+    private let primaryHandle: FileHandle
+    private let secondaryHandle: FileHandle
+    private let lock = NSLock()
+    private var stopped = false
+
+    private init(
+        process: Process,
+        primaryFD: Int32,
+        primaryHandle: FileHandle,
+        secondaryHandle: FileHandle
+    ) {
+        self.process = process
+        self.pid = Int(process.processIdentifier)
+        self.primaryFD = primaryFD
+        self.primaryHandle = primaryHandle
+        self.secondaryHandle = secondaryHandle
+    }
+
+    static func launch(binary: String) throws -> AntigravityCLIQuotaProcess {
+        var primaryFD: Int32 = -1
+        var secondaryFD: Int32 = -1
+        var window = winsize(ws_row: 50, ws_col: 160, ws_xpixel: 0, ws_ypixel: 0)
+        guard openpty(&primaryFD, &secondaryFD, nil, nil, &window) == 0 else {
+            throw QuotaError.unknown("Could not open a PTY for agy.")
+        }
+        _ = fcntl(primaryFD, F_SETFL, O_NONBLOCK)
+
+        let primaryHandle = FileHandle(fileDescriptor: primaryFD, closeOnDealloc: true)
+        let secondaryHandle = FileHandle(fileDescriptor: secondaryFD, closeOnDealloc: true)
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: binary)
+        process.currentDirectoryURL = URL(
+            fileURLWithPath: RealHomeDirectory.path,
+            isDirectory: true
+        )
+        var environment = ProcessInfo.processInfo.environment
+        environment["PWD"] = RealHomeDirectory.path
+        environment["TERM"] = "xterm-256color"
+        process.environment = environment
+        process.standardInput = secondaryHandle
+        process.standardOutput = secondaryHandle
+        process.standardError = secondaryHandle
+        do {
+            try process.run()
+        } catch {
+            try? primaryHandle.close()
+            try? secondaryHandle.close()
+            throw QuotaError.unknown("Could not launch agy: \(error.localizedDescription)")
+        }
+        return AntigravityCLIQuotaProcess(
+            process: process,
+            primaryFD: primaryFD,
+            primaryHandle: primaryHandle,
+            secondaryHandle: secondaryHandle
+        )
+    }
+
+    var isRunning: Bool { process.isRunning }
+
+    func drainOutput() {
+        var buffer = [UInt8](repeating: 0, count: 8_192)
+        for _ in 0..<32 {
+            let count = read(primaryFD, &buffer, buffer.count)
+            if count <= 0 { break }
+        }
+    }
+
+    func stop() {
+        lock.lock()
+        guard !stopped else {
+            lock.unlock()
+            return
+        }
+        stopped = true
+        lock.unlock()
+
+        if process.isRunning {
+            process.terminate()
+        }
+        try? primaryHandle.close()
+        try? secondaryHandle.close()
+    }
+
+    deinit { stop() }
+}

--- a/Sources/VibeBarCore/Adapters/AntigravityQuotaAdapter.swift
+++ b/Sources/VibeBarCore/Adapters/AntigravityQuotaAdapter.swift
@@ -108,10 +108,26 @@ public struct AntigravityQuotaAdapter: QuotaAdapter {
         do {
             let snapshot = try await AntigravityCLIQuotaFetcher.fetch()
             return accountQuota(snapshot: snapshot, account: account)
-        } catch {
+        } catch let cliError {
             if let localQuota { return localQuota }
-            throw mapError(localError ?? error)
+            throw Self.preferredLocalSourceError(
+                desktopError: localError.map { mapError($0) },
+                cliError: mapError(cliError)
+            )
         }
+    }
+
+    /// A missing desktop process is expected and must not hide an actionable
+    /// error from the installed CLI. A specific desktop failure still wins
+    /// because it came from the preferred source.
+    static func preferredLocalSourceError(
+        desktopError: QuotaError?,
+        cliError: QuotaError
+    ) -> QuotaError {
+        guard let desktopError, desktopError != .noCredential else {
+            return cliError
+        }
+        return desktopError
     }
 
     private func accountQuota(

--- a/Sources/VibeBarCore/Adapters/AntigravityQuotaAdapter.swift
+++ b/Sources/VibeBarCore/Adapters/AntigravityQuotaAdapter.swift
@@ -40,7 +40,7 @@ public struct AntigravityQuotaAdapter: QuotaAdapter {
             do {
                 switch source {
                 case .localProbe:
-                    return try await fetchWithLocalProbe(for: account)
+                    return try await fetchWithLocalSources(for: account)
                 case .webCookie:
                     // Spike-gated: returns `.noCredential` until the
                     // Antigravity Cloud endpoint is reverse-engineered
@@ -68,29 +68,77 @@ public struct AntigravityQuotaAdapter: QuotaAdapter {
         let client = AntigravityLanguageServerClient(timeout: timeout)
         let endpoints = try await client.connectedEndpoints()
         var lastError: Error?
+        var bestSnapshot: AntigravityResponseParser.Snapshot?
         for endpoint in endpoints {
             do {
                 let snapshot = try await Self.fetchLocalSnapshot { path, body in
                     try await client.postLocal(endpoint: endpoint, path: path, body: body)
                 }
-                // Keep the id → label map fresh so the cost scanner can
-                // resolve placeholder model ids to real names and rates.
-                AntigravityModelLabelStore.merge(snapshot.modelLabels)
-                return AccountQuota(
-                    accountId: account.id,
-                    tool: .antigravity,
-                    buckets: snapshot.buckets,
-                    plan: snapshot.planName,
-                    email: snapshot.email,
-                    queriedAt: now(),
-                    error: nil
-                )
+                if Self.hasCompleteSharedQuota(snapshot.buckets) {
+                    return accountQuota(snapshot: snapshot, account: account)
+                }
+                if bestSnapshot.map({ snapshot.buckets.count > $0.buckets.count }) ?? true {
+                    bestSnapshot = snapshot
+                }
             } catch {
                 lastError = error
                 continue
             }
         }
+        if let bestSnapshot {
+            return accountQuota(snapshot: bestSnapshot, account: account)
+        }
         throw mapError(lastError)
+    }
+
+    /// Prefer the desktop language server when it has all four shared lanes;
+    /// otherwise ask the installed `agy` CLI for its richer local summary.
+    /// A partial desktop result remains the fallback if `agy` is unavailable.
+    private func fetchWithLocalSources(for account: AccountIdentity) async throws -> AccountQuota {
+        var localQuota: AccountQuota?
+        var localError: Error?
+        do {
+            let quota = try await fetchWithLocalProbe(for: account)
+            if Self.hasCompleteSharedQuota(quota.buckets) { return quota }
+            localQuota = quota
+        } catch {
+            localError = error
+        }
+
+        do {
+            let snapshot = try await AntigravityCLIQuotaFetcher.fetch()
+            return accountQuota(snapshot: snapshot, account: account)
+        } catch {
+            if let localQuota { return localQuota }
+            throw mapError(localError ?? error)
+        }
+    }
+
+    private func accountQuota(
+        snapshot: AntigravityResponseParser.Snapshot,
+        account: AccountIdentity
+    ) -> AccountQuota {
+        // Keep the id → label map fresh so the cost scanner can resolve
+        // placeholder model ids to real names and rates.
+        AntigravityModelLabelStore.merge(snapshot.modelLabels)
+        return AccountQuota(
+            accountId: account.id,
+            tool: .antigravity,
+            buckets: snapshot.buckets,
+            plan: snapshot.planName,
+            email: snapshot.email,
+            queriedAt: now(),
+            error: nil
+        )
+    }
+
+    static func hasCompleteSharedQuota(_ buckets: [QuotaBucket]) -> Bool {
+        Set(buckets.map(\.id)).isSuperset(of: [
+            "gemini_five_hour",
+            "gemini_weekly",
+            "claude_gpt_five_hour",
+            "claude_gpt_weekly"
+        ])
     }
 
     /// Fetch the grouped quota payload first, then attach identity on a

--- a/Sources/VibeBarCore/Adapters/AntigravityQuotaAdapter.swift
+++ b/Sources/VibeBarCore/Adapters/AntigravityQuotaAdapter.swift
@@ -107,7 +107,10 @@ public struct AntigravityQuotaAdapter: QuotaAdapter {
 
         do {
             let snapshot = try await AntigravityCLIQuotaFetcher.fetch()
-            return accountQuota(snapshot: snapshot, account: account)
+            let cliQuota = accountQuota(snapshot: snapshot, account: account)
+            return localQuota.map {
+                Self.mergingPartialQuota(primary: $0, fallback: cliQuota)
+            } ?? cliQuota
         } catch let cliError {
             if let localQuota { return localQuota }
             throw Self.preferredLocalSourceError(
@@ -128,6 +131,39 @@ public struct AntigravityQuotaAdapter: QuotaAdapter {
             return cliError
         }
         return desktopError
+    }
+
+    /// Keep every desktop lane and append only lanes recovered by `agy`.
+    /// Known shared buckets are normalized back to their canonical order.
+    static func mergingPartialQuota(primary: AccountQuota, fallback: AccountQuota) -> AccountQuota {
+        var buckets = primary.buckets
+        var seen = Set(buckets.map(\.id))
+        for bucket in fallback.buckets where seen.insert(bucket.id).inserted {
+            buckets.append(bucket)
+        }
+        let canonical = [
+            "gemini_five_hour",
+            "gemini_weekly",
+            "claude_gpt_five_hour",
+            "claude_gpt_weekly"
+        ]
+        var byID: [String: QuotaBucket] = [:]
+        for bucket in buckets where byID[bucket.id] == nil {
+            byID[bucket.id] = bucket
+        }
+        let canonicalBuckets = canonical.compactMap { byID[$0] }
+        let extras = buckets.filter { !canonical.contains($0.id) }
+        return AccountQuota(
+            accountId: primary.accountId,
+            tool: primary.tool,
+            buckets: canonicalBuckets + extras,
+            plan: primary.plan ?? fallback.plan,
+            email: primary.email ?? fallback.email,
+            queriedAt: max(primary.queriedAt, fallback.queriedAt),
+            error: nil,
+            providerExtras: primary.providerExtras ?? fallback.providerExtras,
+            resetCredits: primary.resetCredits ?? fallback.resetCredits
+        )
     }
 
     private func accountQuota(

--- a/Sources/VibeBarCore/Adapters/CursorQuotaAdapter.swift
+++ b/Sources/VibeBarCore/Adapters/CursorQuotaAdapter.swift
@@ -15,8 +15,8 @@ import Foundation
 ///    plan" accounts whose summary is partial.
 ///
 /// Output:
-/// - **Cursor Models** — Cursor's first-party pool (Cursor Grok + Composer).
-/// - **Other Models** — named third-party models.
+/// - **Cursor Models / Monthly** — Cursor's first-party pool (Cursor Grok + Composer).
+/// - **Other Models / Monthly** — named third-party models.
 /// - **Grok Bot / Weekly** — Cursor's cloud-only Bot allowance.
 ///
 /// Edge-case tests (`CursorParserEdgeCasesTests`) pin the four
@@ -292,7 +292,7 @@ enum CursorResponseParser {
         if let auto = autoPct {
             buckets.append(QuotaBucket(
                 id: "models",
-                title: "Weekly",
+                title: "Monthly",
                 shortLabel: "Cursor",
                 usedPercent: auto,
                 resetAt: billingCycleEnd,
@@ -303,7 +303,7 @@ enum CursorResponseParser {
         if let api = apiPct {
             buckets.append(QuotaBucket(
                 id: "other_models",
-                title: "Weekly",
+                title: "Monthly",
                 shortLabel: "Other",
                 usedPercent: api,
                 resetAt: billingCycleEnd,
@@ -317,7 +317,7 @@ enum CursorResponseParser {
         if buckets.isEmpty {
             buckets.append(QuotaBucket(
                 id: "models",
-                title: "Weekly",
+                title: "Monthly",
                 shortLabel: "Cursor",
                 usedPercent: totalPct,
                 resetAt: billingCycleEnd,

--- a/Sources/VibeBarCore/Adapters/CursorSessionResolver.swift
+++ b/Sources/VibeBarCore/Adapters/CursorSessionResolver.swift
@@ -12,7 +12,7 @@ struct CursorSessionResolutionPlan: Sendable {
 /// Automatic mode prefers Cursor.app's active session. Browser/manual cookie
 /// slots remain a fallback for machines where Cursor.app is absent or logged
 /// out, and preserve the existing `misc-cursor` Keychain account during the
-/// move from the Misc page into the Grok product family.
+/// move from the Misc page into the SpaceXAI provider family.
 enum CursorSessionResolver {
     static let stableAccountID = AccountStore.miscAccountId(for: .cursor)
 

--- a/Sources/VibeBarCore/Models/AppSettings.swift
+++ b/Sources/VibeBarCore/Models/AppSettings.swift
@@ -236,7 +236,7 @@ public struct AppSettings: Codable, Equatable, Sendable {
     /// selection is intentionally automatic and not exposed in the UI;
     /// region / enterprise host remain as provider-specific knobs.
     /// Linked partial-primary tools (`.gemini`, `.antigravity`, `.cursor`) are
-    /// excluded — they live on the Google AI / Grok product surfaces instead.
+    /// excluded — they live on the Google AI / SpaceXAI company surfaces instead.
     public static var defaultMiscProviders: [ToolType: MiscProviderSettings] {
         var out: [ToolType: MiscProviderSettings] = [:]
         for tool in ToolType.miscPageProviders {
@@ -1248,19 +1248,19 @@ public enum AntigravityUsageMode: String, Codable, CaseIterable, Identifiable, S
     public var label: String {
         switch self {
         case .auto: return "Auto"
-        case .localThenWeb: return "Local LSP, then Web"
-        case .webThenLocal: return "Web, then Local LSP"
-        case .localOnly: return "Local LSP only"
+        case .localThenWeb: return "Local sources, then Web"
+        case .webThenLocal: return "Web, then Local sources"
+        case .localOnly: return "Local sources only"
         case .webOnly: return "Web only"
         }
     }
 
     public var detail: String {
         switch self {
-        case .auto: return "Probe the running Antigravity language server first; fall back to imported cookies when the web source is available."
-        case .localThenWeb: return "Probe the running Antigravity language server first; fall back to imported cookies."
-        case .webThenLocal: return "Use imported cookies first; fall back to the running Antigravity language server."
-        case .localOnly: return "Only probe the running Antigravity language server."
+        case .auto: return "Use the Antigravity app first, then the installed agy CLI; fall back to imported cookies when the web source is available."
+        case .localThenWeb: return "Use the Antigravity app or agy CLI first; fall back to imported cookies."
+        case .webThenLocal: return "Use imported cookies first; fall back to the Antigravity app or agy CLI."
+        case .localOnly: return "Only use the Antigravity app or installed agy CLI."
         case .webOnly: return "Only use imported cookies. Falls back to the local probe until the Antigravity Cloud endpoint ships."
         }
     }

--- a/Sources/VibeBarCore/Models/EffectiveModelPricing.swift
+++ b/Sources/VibeBarCore/Models/EffectiveModelPricing.swift
@@ -1,0 +1,153 @@
+import Foundation
+
+/// One row from the fully resolved runtime price table. Rates are converted to
+/// the Settings unit (USD per one million tokens) at this boundary so the UI
+/// never needs to know the stored per-token representation.
+public struct EffectiveModelPricingRow: Sendable, Equatable, Identifiable {
+    public let provider: PricingProviderFamily
+    public let model: String
+    public let displayLabel: String?
+    public let inputPerMillion: Double
+    public let outputPerMillion: Double
+    public let cacheReadPerMillion: Double?
+    public let cacheWritePerMillion: Double?
+    public let thresholdTokens: Int?
+    public let inputAboveThresholdPerMillion: Double?
+    public let outputAboveThresholdPerMillion: Double?
+    public let cacheReadAboveThresholdPerMillion: Double?
+    public let cacheWriteAboveThresholdPerMillion: Double?
+    public let fastMultiplier: Double?
+
+    public var id: String { "\(provider.rawValue):\(model)" }
+    public var normalizedKey: String {
+        "\(provider.rawValue):\(model.trimmingCharacters(in: .whitespacesAndNewlines).lowercased())"
+    }
+    public var tool: ToolType { provider.tool }
+    public var companyName: String { tool.vendorName }
+    public var subProviderName: String { tool.productName }
+
+    public init(
+        provider: PricingProviderFamily,
+        model: String,
+        displayLabel: String? = nil,
+        inputPerMillion: Double,
+        outputPerMillion: Double,
+        cacheReadPerMillion: Double? = nil,
+        cacheWritePerMillion: Double? = nil,
+        thresholdTokens: Int? = nil,
+        inputAboveThresholdPerMillion: Double? = nil,
+        outputAboveThresholdPerMillion: Double? = nil,
+        cacheReadAboveThresholdPerMillion: Double? = nil,
+        cacheWriteAboveThresholdPerMillion: Double? = nil,
+        fastMultiplier: Double? = nil
+    ) {
+        self.provider = provider
+        self.model = model
+        self.displayLabel = displayLabel
+        self.inputPerMillion = inputPerMillion
+        self.outputPerMillion = outputPerMillion
+        self.cacheReadPerMillion = cacheReadPerMillion
+        self.cacheWritePerMillion = cacheWritePerMillion
+        self.thresholdTokens = thresholdTokens
+        self.inputAboveThresholdPerMillion = inputAboveThresholdPerMillion
+        self.outputAboveThresholdPerMillion = outputAboveThresholdPerMillion
+        self.cacheReadAboveThresholdPerMillion = cacheReadAboveThresholdPerMillion
+        self.cacheWriteAboveThresholdPerMillion = cacheWriteAboveThresholdPerMillion
+        self.fastMultiplier = fastMultiplier
+    }
+}
+
+extension PricingProviderFamily {
+    public var tool: ToolType {
+        switch self {
+        case .codex: .codex
+        case .claude: .claude
+        case .gemini: .gemini
+        case .grok: .grok
+        case .antigravity: .antigravity
+        }
+    }
+}
+
+extension PricingDataSet {
+    public var effectiveModelPrices: [EffectiveModelPricingRow] {
+        let million = 1_000_000.0
+        var rows: [EffectiveModelPricingRow] = []
+
+        for (model, entry) in providers.codex.models.sorted(by: { $0.key < $1.key }) {
+            rows.append(EffectiveModelPricingRow(
+                provider: .codex,
+                model: model,
+                displayLabel: entry.displayLabel,
+                inputPerMillion: entry.input * million,
+                outputPerMillion: entry.output * million,
+                cacheReadPerMillion: entry.cacheRead.map { $0 * million },
+                cacheWritePerMillion: entry.cacheCreation.map { $0 * million },
+                thresholdTokens: entry.thresholdTokens,
+                inputAboveThresholdPerMillion: entry.inputAboveThreshold.map { $0 * million },
+                outputAboveThresholdPerMillion: entry.outputAboveThreshold.map { $0 * million },
+                cacheReadAboveThresholdPerMillion: entry.cacheReadAboveThreshold.map { $0 * million },
+                cacheWriteAboveThresholdPerMillion: entry.cacheCreationAboveThreshold.map { $0 * million },
+                fastMultiplier: entry.fastMultiplier
+            ))
+        }
+        for (model, entry) in providers.claude.models.sorted(by: { $0.key < $1.key }) {
+            rows.append(EffectiveModelPricingRow(
+                provider: .claude,
+                model: model,
+                inputPerMillion: entry.input * million,
+                outputPerMillion: entry.output * million,
+                cacheReadPerMillion: entry.cacheRead * million,
+                cacheWritePerMillion: entry.cacheCreation * million,
+                thresholdTokens: entry.thresholdTokens,
+                inputAboveThresholdPerMillion: entry.inputAboveThreshold.map { $0 * million },
+                outputAboveThresholdPerMillion: entry.outputAboveThreshold.map { $0 * million },
+                cacheReadAboveThresholdPerMillion: entry.cacheReadAboveThreshold.map { $0 * million },
+                cacheWriteAboveThresholdPerMillion: entry.cacheCreationAboveThreshold.map { $0 * million },
+                fastMultiplier: entry.fastMultiplier
+            ))
+        }
+        for (model, entry) in providers.gemini.models.sorted(by: { $0.key < $1.key }) {
+            rows.append(EffectiveModelPricingRow(
+                provider: .gemini,
+                model: model,
+                displayLabel: entry.displayLabel,
+                inputPerMillion: entry.input * million,
+                outputPerMillion: entry.output * million,
+                cacheReadPerMillion: entry.cacheRead.map { $0 * million },
+                thresholdTokens: entry.thresholdTokens,
+                inputAboveThresholdPerMillion: entry.inputAboveThreshold.map { $0 * million },
+                outputAboveThresholdPerMillion: entry.outputAboveThreshold.map { $0 * million },
+                cacheReadAboveThresholdPerMillion: entry.cacheReadAboveThreshold.map { $0 * million }
+            ))
+        }
+        for (model, entry) in providers.antigravity.models.sorted(by: { $0.key < $1.key }) {
+            rows.append(EffectiveModelPricingRow(
+                provider: .antigravity,
+                model: model,
+                displayLabel: entry.displayLabel,
+                inputPerMillion: entry.input * million,
+                outputPerMillion: entry.output * million,
+                cacheReadPerMillion: entry.cacheRead * million,
+                cacheWritePerMillion: entry.cacheCreation * million
+            ))
+        }
+        for (model, entry) in providers.grok.models.sorted(by: { $0.key < $1.key }) {
+            rows.append(EffectiveModelPricingRow(
+                provider: .grok,
+                model: model,
+                displayLabel: entry.displayLabel,
+                inputPerMillion: entry.input * million,
+                outputPerMillion: entry.output * million,
+                cacheReadPerMillion: entry.cacheRead.map { $0 * million },
+                thresholdTokens: entry.thresholdTokens,
+                inputAboveThresholdPerMillion: entry.inputAboveThreshold.map { $0 * million },
+                outputAboveThresholdPerMillion: entry.outputAboveThreshold.map { $0 * million },
+                cacheReadAboveThresholdPerMillion: entry.cacheReadAboveThreshold.map { $0 * million }
+            ))
+        }
+        return rows.filter {
+            !$0.model.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        }
+    }
+}

--- a/Sources/VibeBarCore/Models/MenuBarSettings.swift
+++ b/Sources/VibeBarCore/Models/MenuBarSettings.swift
@@ -246,8 +246,8 @@ public enum MenuBarFieldCatalog {
     ]
 
     public static let cursorFields: [MenuBarFieldOption] = [
-        option(.cursor, "models", "Cursor Models · Weekly", "Cursor Models"),
-        option(.cursor, "other_models", "Other Models · Weekly", "Other Models"),
+        option(.cursor, "models", "Cursor Models · Monthly", "Cursor Models"),
+        option(.cursor, "other_models", "Other Models · Monthly", "Other Models"),
         option(.cursor, "grok_bot_weekly", "Grok Bot · Weekly", "Grok Bot")
     ]
 

--- a/Sources/VibeBarCore/Models/ModelPricingSettings.swift
+++ b/Sources/VibeBarCore/Models/ModelPricingSettings.swift
@@ -4,18 +4,18 @@ public enum PricingProviderFamily: String, Codable, CaseIterable, Sendable, Iden
     case codex
     case claude
     case gemini
-    case grok
     case antigravity
+    case grok
 
     public var id: String { rawValue }
 
     public var label: String {
         switch self {
-        case .codex: "OpenAI / Codex"
-        case .claude: "Anthropic / Claude"
-        case .gemini: "Google / Gemini"
-        case .grok: "xAI / Grok"
-        case .antigravity: "AntiGravity"
+        case .codex: "OpenAI · ChatGPT Agentic"
+        case .claude: "Anthropic · Claude"
+        case .gemini: "Google AI · Gemini Web"
+        case .grok: "SpaceXAI · Grok"
+        case .antigravity: "Google AI · AntiGravity"
         }
     }
 }

--- a/Sources/VibeBarCore/Models/PrimaryProviderRouteHealth.swift
+++ b/Sources/VibeBarCore/Models/PrimaryProviderRouteHealth.swift
@@ -42,7 +42,7 @@ public enum PrimaryProviderRoute: String, CaseIterable, Identifiable, Sendable {
         case .claudeOAuth: return "OAuth"
         case .claudeCLI: return "CLI"
         case .geminiBrowserCookies: return "Chrome/Safari cookies"
-        case .antigravityLocalProbe: return "Local language server"
+        case .antigravityLocalProbe: return "Local Antigravity / agy"
         case .grokAuthJSON: return "~/.grok/auth.json"
         case .grokBrowserCookies: return "Chrome/Safari cookies"
         }
@@ -184,19 +184,20 @@ public enum PrimaryProviderRouteHealthChecker {
         return antigravityLocalProbeHealth(
             route: route,
             languageServerRunning: antigravityLanguageServerIsRunning(now: now),
+            cliAvailable: AntigravityCLIQuotaFetcher.resolveBinary() != nil,
             hasLocalData: FileManager.default.fileExists(atPath: dataRoot.path),
             now: now
         )
     }
 
     /// Separates the AntiGravity availability semantics from process and file
-    /// probing so the important cached-data fallback remains testable. A
-    /// stopped language server is not a broken connection when Vibe Bar still
-    /// has usable local AntiGravity data; it only means live synchronization is
-    /// paused until AntiGravity runs again.
+    /// probing so app, CLI, and stale-cache states remain testable. Cached
+    /// quota may still render for continuity, but it is not reported healthy
+    /// when neither the app language server nor `agy` can refresh it.
     static func antigravityLocalProbeHealth(
         route: PrimaryProviderRoute = .antigravityLocalProbe,
         languageServerRunning: Bool,
+        cliAvailable: Bool = false,
         hasLocalData: Bool,
         now: Date
     ) -> PrimaryProviderRouteHealth {
@@ -208,11 +209,19 @@ public enum PrimaryProviderRouteHealthChecker {
                 checkedAt: now
             )
         }
-        if hasLocalData {
+        if cliAvailable {
             return PrimaryProviderRouteHealth(
                 route: route,
                 status: .ok,
-                detail: "Local data available; LSP offline",
+                detail: "agy CLI available",
+                checkedAt: now
+            )
+        }
+        if hasLocalData {
+            return PrimaryProviderRouteHealth(
+                route: route,
+                status: .failed,
+                detail: "Cached data only; live quota unavailable",
                 checkedAt: now
             )
         }

--- a/Sources/VibeBarCore/Models/ProviderHierarchy.swift
+++ b/Sources/VibeBarCore/Models/ProviderHierarchy.swift
@@ -3,14 +3,12 @@ import Foundation
 /// Three-level vendor / product / tool hierarchy used everywhere the
 /// UI needs to identify a provider at a single, consistent level.
 ///
-/// - `vendor` (L1) — who issues the plan / bills the account
-///   (OpenAI, Anthropic, Google, xAI).
-/// - `product` (L2) — what users call the AI brand
-///   (ChatGPT, Claude, Gemini, Grok). Both Gemini Web and the
-///   AntiGravity IDE share the Gemini product because that's how
-///   Google brands them.
-/// - `tool` (L3) — the specific surface Vibe Bar tracks
-///   (Codex, Claude Code, Gemini Web, AntiGravity, Grok Build, Cursor).
+/// - `vendor` (L1) — the enterprise / brand owner shown by Vibe Bar
+///   (OpenAI, Anthropic, Google AI, SpaceXAI).
+/// - `product` (L2) — the SubProvider users consume inside that owner
+///   (ChatGPT Agentic, Claude, Gemini Web, AntiGravity, Grok, Cursor).
+/// - `tool` (L3) — the concrete local or web surface Vibe Bar tracks
+///   (Codex, Claude Code, Gemini Web, AntiGravity, Grok, Cursor).
 ///
 /// `ToolType` derives its `vendorName` / `productName` / `toolName`
 /// from a single entry per case in `ProviderHierarchyCatalog`, so
@@ -36,16 +34,16 @@ public struct ProviderHierarchy: Sendable, Equatable, Hashable {
 public enum ProviderHierarchyCatalog {
     // MARK: - Dedicated and linked tool hierarchy
     //
-    //   L1 vendor   : OpenAI    | Anthropic   | Google    | Google      | xAI        | Cursor
-    //   L2 product  : ChatGPT   | Claude      | Gemini    | Gemini      | Grok       | Grok
-    //   L3 tool     : Codex     | Claude Code | Gemini Web| AntiGravity | Grok Build | Cursor
+    //   L1 vendor      : OpenAI         | Anthropic   | Google AI | Google AI   | SpaceXAI | SpaceXAI
+    //   L2 SubProvider : ChatGPT Agentic| Claude      | Gemini Web| AntiGravity | Grok     | Cursor
+    //   L3 tool        : Codex          | Claude Code | Gemini Web| AntiGravity | Grok     | Cursor
 
-    public static let codex       = ProviderHierarchy(vendor: "OpenAI",    product: "ChatGPT", tool: "Codex")
-    public static let claude      = ProviderHierarchy(vendor: "Anthropic", product: "Claude",  tool: "Claude Code")
-    public static let gemini      = ProviderHierarchy(vendor: "Google",    product: "Gemini",  tool: "Gemini Web")
-    public static let antigravity = ProviderHierarchy(vendor: "Google",    product: "Gemini",  tool: "AntiGravity")
-    public static let grok        = ProviderHierarchy(vendor: "xAI",       product: "Grok",    tool: "Grok Build")
-    public static let cursor      = ProviderHierarchy(vendor: "Cursor",    product: "Grok",    tool: "Cursor")
+    public static let codex       = ProviderHierarchy(vendor: "OpenAI",    product: "ChatGPT Agentic", tool: "Codex")
+    public static let claude      = ProviderHierarchy(vendor: "Anthropic", product: "Claude",          tool: "Claude Code")
+    public static let gemini      = ProviderHierarchy(vendor: "Google AI", product: "Gemini Web",      tool: "Gemini Web")
+    public static let antigravity = ProviderHierarchy(vendor: "Google AI", product: "AntiGravity",     tool: "AntiGravity")
+    public static let grok        = ProviderHierarchy(vendor: "SpaceXAI",  product: "Grok",    tool: "Grok")
+    public static let cursor      = ProviderHierarchy(vendor: "SpaceXAI",  product: "Cursor",  tool: "Cursor")
 
     // MARK: - Misc providers
     //

--- a/Sources/VibeBarCore/Models/ServiceStatus.swift
+++ b/Sources/VibeBarCore/Models/ServiceStatus.swift
@@ -222,4 +222,38 @@ public struct ServiceStatusSnapshot: Sendable, Hashable, Codable {
             return components.filter { $0.groupId == nil }
         }
     }
+
+    /// Adds a linked provider as one component group while preserving this
+    /// snapshot's L1 company identity. Used by the SpaceXAI card to include
+    /// Cursor Status without implying a second top-level company row.
+    public func mergingSubProvider(
+        _ child: ServiceStatusSnapshot,
+        groupID: String,
+        groupName: String
+    ) -> ServiceStatusSnapshot {
+        let childComponents = child.components.map { component in
+            ServiceComponentSummary(
+                id: "\(groupID):\(component.id)",
+                name: component.name,
+                status: component.status,
+                groupId: groupID,
+                uptimePercent: component.uptimePercent,
+                recentDays: component.recentDays
+            )
+        }
+        let childIsWorse = child.effectiveIndicator.severity > effectiveIndicator.severity
+        let incidents = (recentIncidents + child.recentIncidents)
+            .sorted { $0.createdAt > $1.createdAt }
+        return ServiceStatusSnapshot(
+            tool: tool,
+            indicator: childIsWorse ? child.effectiveIndicator : effectiveIndicator,
+            description: childIsWorse ? "\(groupName) · \(child.effectiveDescription)" : effectiveDescription,
+            updatedAt: max(updatedAt, child.updatedAt),
+            groups: groups + [ServiceComponentGroup(id: groupID, name: groupName)],
+            components: components + childComponents,
+            recentIncidents: Array(incidents.prefix(4)),
+            incidentDays: incidentDays,
+            incidentAdjustedUptimePercent: incidentAdjustedUptimePercent
+        )
+    }
 }

--- a/Sources/VibeBarCore/Models/ServiceStatus.swift
+++ b/Sources/VibeBarCore/Models/ServiceStatus.swift
@@ -256,4 +256,27 @@ public struct ServiceStatusSnapshot: Sendable, Hashable, Codable {
             incidentAdjustedUptimePercent: incidentAdjustedUptimePercent
         )
     }
+
+    /// One canonical SpaceXAI status projection shared by the Workbench card
+    /// and the menu-bar context menu.
+    public static func mergedSpaceXAI(
+        grok: ServiceStatusSnapshot?,
+        cursor: ServiceStatusSnapshot?
+    ) -> ServiceStatusSnapshot? {
+        guard let cursor else { return grok }
+        let base = grok ?? ServiceStatusSnapshot(
+            tool: .grok,
+            indicator: .none,
+            description: "Cursor status available",
+            updatedAt: cursor.updatedAt,
+            groups: [],
+            components: [],
+            recentIncidents: []
+        )
+        return base.mergingSubProvider(
+            cursor,
+            groupID: "subprovider:cursor",
+            groupName: "Cursor"
+        )
+    }
 }

--- a/Sources/VibeBarCore/Models/ServiceStatus.swift
+++ b/Sources/VibeBarCore/Models/ServiceStatus.swift
@@ -264,7 +264,7 @@ public struct ServiceStatusSnapshot: Sendable, Hashable, Codable {
         cursor: ServiceStatusSnapshot?
     ) -> ServiceStatusSnapshot? {
         guard let cursor else { return grok }
-        let base = grok ?? ServiceStatusSnapshot(
+        var base = grok ?? ServiceStatusSnapshot(
             tool: .grok,
             indicator: .none,
             description: "Cursor status available",
@@ -273,6 +273,29 @@ public struct ServiceStatusSnapshot: Sendable, Hashable, Codable {
             components: [],
             recentIncidents: []
         )
+        if grok != nil {
+            let groupID = "subprovider:grok"
+            base = ServiceStatusSnapshot(
+                tool: base.tool,
+                indicator: base.indicator,
+                description: base.description,
+                updatedAt: base.updatedAt,
+                groups: [ServiceComponentGroup(id: groupID, name: "Grok")],
+                components: base.components.map { component in
+                    ServiceComponentSummary(
+                        id: component.id,
+                        name: component.name,
+                        status: component.status,
+                        groupId: groupID,
+                        uptimePercent: component.uptimePercent,
+                        recentDays: component.recentDays
+                    )
+                },
+                recentIncidents: base.recentIncidents,
+                incidentDays: base.incidentDays,
+                incidentAdjustedUptimePercent: base.incidentAdjustedUptimePercent
+            )
+        }
         return base.mergingSubProvider(
             cursor,
             groupID: "subprovider:cursor",

--- a/Sources/VibeBarCore/Models/ServiceStatus.swift
+++ b/Sources/VibeBarCore/Models/ServiceStatus.swift
@@ -302,4 +302,20 @@ public struct ServiceStatusSnapshot: Sendable, Hashable, Codable {
             groupName: "Cursor"
         )
     }
+
+    /// Gemini Web and AntiGravity poll the same Google AI feed. Prefer the
+    /// worse effective state (including open incidents), then the newer cache.
+    public static func preferredGoogleAI(
+        gemini: ServiceStatusSnapshot?,
+        antigravity: ServiceStatusSnapshot?
+    ) -> ServiceStatusSnapshot? {
+        guard let gemini else { return antigravity }
+        guard let antigravity else { return gemini }
+        if gemini.effectiveIndicator.severity != antigravity.effectiveIndicator.severity {
+            return gemini.effectiveIndicator.severity > antigravity.effectiveIndicator.severity
+                ? gemini
+                : antigravity
+        }
+        return gemini.updatedAt >= antigravity.updatedAt ? gemini : antigravity
+    }
 }

--- a/Sources/VibeBarCore/Models/ToolType.swift
+++ b/Sources/VibeBarCore/Models/ToolType.swift
@@ -140,7 +140,7 @@ public enum ToolType: String, Codable, CaseIterable, Hashable, Sendable {
     }
 
     public var usageStatsRepresentative: ToolType {
-        self == .cursor ? .grok : self
+        self
     }
 
     public static var statusPageProviders: [ToolType] {
@@ -172,6 +172,21 @@ public enum ToolType: String, Codable, CaseIterable, Hashable, Sendable {
              .kilo, .kiro, .ollama, .openRouter, .warp:
             return nil
         }
+    }
+
+    /// L2 members represented by one L1 company filter / aggregate row.
+    public var coreProviderMembers: [ToolType] {
+        switch coreProviderRepresentative ?? self {
+        case .codex: [.codex]
+        case .claude: [.claude]
+        case .gemini: [.gemini, .antigravity]
+        case .grok: [.grok, .cursor]
+        default: [self]
+        }
+    }
+
+    public var companySubProviderSummary: String {
+        coreProviderMembers.map(\.productName).joined(separator: " + ")
     }
 
     public static var miscPageProviders: [ToolType] {

--- a/Sources/VibeBarCore/Models/ToolType.swift
+++ b/Sources/VibeBarCore/Models/ToolType.swift
@@ -26,7 +26,7 @@ import Foundation
 ///   integration, dedicated popover pages, mini-window slots.
 /// - **Partial-Primary** (`.gemini`, `.antigravity`, `.grok`, `.cursor`) —
 ///   dedicated product surfaces. Gemini+AntiGravity share Google AI;
-///   Grok Build + Cursor share Grok. These can still opt into token-cost
+///   Grok CLI + Cursor share SpaceXAI. These can still opt into token-cost
 ///   scanning and status polling as provider data becomes known.
 /// - **Misc** (`.alibaba`, `.alibabaTokenPlan`, `.copilot`, `.zai`,
 ///   `.minimax`, `.kimi`, `.mimo`, `.iflytek`,
@@ -129,7 +129,7 @@ public enum ToolType: String, Codable, CaseIterable, Hashable, Sendable {
     }
 
     /// Provider keys exposed by the Workbench usage ledger. Cursor dashboard
-    /// events are a source inside the Grok product total, matching the Grok
+    /// events are a source inside the SpaceXAI provider total, matching the combined
     /// cost card instead of creating a second, contradictory provider total.
     public static var usageStatsProviders: [ToolType] {
         var seen: Set<ToolType> = []
@@ -184,7 +184,7 @@ public enum ToolType: String, Codable, CaseIterable, Hashable, Sendable {
         [.gemini, .antigravity]
     }
 
-    /// Grok Build plus Cursor, presented as one Grok product family.
+    /// Grok plus Cursor, presented as one SpaceXAI provider family.
     public static var grokFamily: [ToolType] {
         [.grok, .cursor]
     }
@@ -222,12 +222,13 @@ public enum ToolType: String, Codable, CaseIterable, Hashable, Sendable {
     /// `.antigravity` share the Google Apps Status dashboard feed
     /// (`https://www.google.com/appsstatus/dashboard/incidents.json`,
     /// filtered to product id `npdyhgECDJ6tB66MxXyo` = "Gemini").
-    /// Grok reads the xAI service-status HTML at `https://status.x.ai/`.
+    /// Grok reads the SpaceXAI service-status HTML at `https://status.x.ai/`;
+    /// Cursor reads its Statuspage v2 JSON feed.
     /// Codex / Claude use their own Atlassian / incident.io feeds.
     public var supportsStatusPage: Bool {
         switch self {
-        case .codex, .claude, .gemini, .antigravity, .grok: return true
-        case .alibaba, .alibabaTokenPlan, .copilot, .zai, .minimax, .kimi, .cursor, .mimo, .iflytek, .tencentHunyuan, .tencentTokenPlan, .volcengine, .volcengineAgentPlan, .baiduQianfan, .openCodeGo, .kilo, .kiro, .ollama, .openRouter, .warp:
+        case .codex, .claude, .gemini, .antigravity, .grok, .cursor: return true
+        case .alibaba, .alibabaTokenPlan, .copilot, .zai, .minimax, .kimi, .mimo, .iflytek, .tencentHunyuan, .tencentTokenPlan, .volcengine, .volcengineAgentPlan, .baiduQianfan, .openCodeGo, .kilo, .kiro, .ollama, .openRouter, .warp:
             return false
         }
     }
@@ -237,10 +238,10 @@ public enum ToolType: String, Codable, CaseIterable, Hashable, Sendable {
     // Every UI surface that needs to identify a provider picks one of
     // three explicit levels from `hierarchy` and stays at that level:
     //
-    //   L1 vendor  → who bills you (OpenAI / Anthropic / Google / xAI)
-    //   L2 product → what users call the AI (ChatGPT / Claude / Gemini / Grok)
-    //   L3 tool    → the specific surface Vibe Bar tracks (Codex,
-    //                Claude Code, Gemini Web, AntiGravity, Grok Build)
+    //   L1 vendor      → enterprise / brand owner
+    //   L2 SubProvider → service group inside that owner
+    //   L3 tool        → the specific surface Vibe Bar tracks (Codex,
+    //                Claude Code, Gemini Web, AntiGravity, Grok CLI)
     //
     // The catalog in `ProviderHierarchyCatalog` is the single source of
     // truth — renaming a provider is one edit there, not a hunt across
@@ -286,11 +287,19 @@ public enum ToolType: String, Codable, CaseIterable, Hashable, Sendable {
     /// Level 1 — the vendor that issues the plan / bills the account.
     public var vendorName: String { hierarchy.vendor }
 
-    /// Level 2 — the product brand a user identifies with.
+    /// Level 2 — the SubProvider inside an enterprise / brand owner.
     public var productName: String { hierarchy.product }
 
     /// Level 3 — the specific surface Vibe Bar tracks usage for.
     public var toolName: String { hierarchy.tool }
+
+    /// L2 SubProvider name used inside an L1 enterprise/brand card. Quota and
+    /// model group names sit one level below this. Grok Bot shares Cursor's
+    /// adapter but is intentionally promoted to its own SubProvider.
+    public func quotaSubProviderName(bucketID: String? = nil) -> String {
+        if self == .cursor, bucketID == "grok_bot_weekly" { return "Grok Bot" }
+        return productName
+    }
 
     /// Long-form name used by Spotlight-y surfaces (system menu items,
     /// account-list aliases). Primary tools use the L3 tool name from
@@ -356,10 +365,10 @@ public enum ToolType: String, Codable, CaseIterable, Hashable, Sendable {
         }
     }
 
-    /// L2 product family — what users call the AI brand. Used by
+    /// L2 SubProvider — the service group inside an enterprise/brand. Used by
     /// menu-bar tile titles, popover sub-page headers, and anywhere
     /// the surface should pick one consistent level across all tools.
-    /// Primary tools take their L2 product directly from `hierarchy`;
+    /// Primary tools take their L2 SubProvider directly from `hierarchy`;
     /// misc tools keep curated forms that prefix the vendor for
     /// disambiguation (e.g. "Tencent Hunyuan" rather than bare
     /// "Hunyuan", which would clash with other Tencent surfaces).
@@ -389,8 +398,8 @@ public enum ToolType: String, Codable, CaseIterable, Hashable, Sendable {
     /// L1 vendor name — used by ServiceStatusCard and any surface
     /// that should pick one consistent level across all tools. The
     /// dedicated tools roll up to their vendors. `.antigravity` shares
-    /// Google's status feed with `.gemini`; Cursor is linked under Grok
-    /// for quota/cost but retains Cursor as its billing vendor.
+    /// Google's status feed with `.gemini`; Cursor is grouped under SpaceXAI
+    /// for quota/cost and contributes a nested Cursor Status group.
     public var statusProviderName: String {
         switch self {
         case .codex, .claude, .gemini, .antigravity, .grok, .cursor:

--- a/Sources/VibeBarCore/Models/UsageQueryModels.swift
+++ b/Sources/VibeBarCore/Models/UsageQueryModels.swift
@@ -284,6 +284,31 @@ public struct UsageProviderStat: Sendable, Equatable, Identifiable {
         self.totalTokens = totalTokens
         self.costMicros = costMicros
     }
+
+    /// Collapse tool/SubProvider rows into the L1 company/brand totals used by
+    /// Provider Mix and the Providers table. Filters and request rows remain
+    /// at L2 so users can still narrow individual SubProviders.
+    public static func mergedByCompany(_ rows: [UsageProviderStat]) -> [UsageProviderStat] {
+        var totals: [ToolType: (requests: Int, tokens: Int64, cost: Int64)] = [:]
+        for row in rows {
+            let representative = row.tool.coreProviderRepresentative ?? row.tool
+            totals[representative, default: (0, 0, 0)].requests += row.requests
+            totals[representative, default: (0, 0, 0)].tokens += row.totalTokens
+            totals[representative, default: (0, 0, 0)].cost += row.costMicros
+        }
+        return totals.map { tool, total in
+            UsageProviderStat(
+                tool: tool,
+                requests: total.requests,
+                totalTokens: total.tokens,
+                costMicros: total.cost
+            )
+        }.sorted {
+            $0.totalTokens == $1.totalTokens
+                ? $0.tool.vendorName < $1.tool.vendorName
+                : $0.totalTokens > $1.totalTokens
+        }
+    }
 }
 
 public struct UsageModelStat: Sendable, Equatable, Identifiable {

--- a/Sources/VibeBarCore/Models/UsageQueryModels.swift
+++ b/Sources/VibeBarCore/Models/UsageQueryModels.swift
@@ -309,6 +309,22 @@ public struct UsageProviderStat: Sendable, Equatable, Identifiable {
                 : $0.totalTokens > $1.totalTokens
         }
     }
+
+    /// L2 contributors for each L1 total, ordered by the canonical company
+    /// membership rather than by token volume. Filtered-out tools never appear.
+    public static func subProviderSummariesByCompany(
+        _ rows: [UsageProviderStat]
+    ) -> [ToolType: String] {
+        var contributors: [ToolType: Set<ToolType>] = [:]
+        for row in rows where row.totalTokens > 0 {
+            let representative = row.tool.coreProviderRepresentative ?? row.tool
+            contributors[representative, default: []].insert(row.tool)
+        }
+        return contributors.reduce(into: [:]) { result, entry in
+            let ordered = entry.key.coreProviderMembers.filter { entry.value.contains($0) }
+            result[entry.key] = ordered.map(\.productName).joined(separator: " + ")
+        }
+    }
 }
 
 public struct UsageModelStat: Sendable, Equatable, Identifiable {

--- a/Sources/VibeBarCore/Services/CostHistoryStore.swift
+++ b/Sources/VibeBarCore/Services/CostHistoryStore.swift
@@ -1,16 +1,19 @@
 import Foundation
 
-/// Persists daily cost samples with **max-merge** semantics so old data isn't
-/// lost when Codex/Claude rotate their JSONL session logs.
+/// Persists daily cost samples with source-aware update semantics.
 ///
-/// Rule: for each (tool, day), the stored value is `max(saved, freshly-scanned)`
-/// — both for cost USD and total tokens. This means:
+/// Local session scans use `max(saved, freshly-scanned)` for each (tool, day)
+/// so old data isn't lost when Codex/Claude rotate their JSONL logs. This means:
 ///   - If Codex log rotation drops a session that occurred 28 days ago, the
 ///     saved value stays.
 ///   - If a fresh scan finds a higher cost (because the user added new sessions
 ///     that day), we replace with the higher number.
 ///   - If a scan returns a lower number (rotation removed entries), we keep
 ///     the saved one.
+///
+/// Authoritative account-wide sources such as Cursor use replacement semantics
+/// through `replaceAndAugment`, so provider corrections can lower or remove a
+/// previously reported day.
 ///
 /// File: `~/.vibebar/cost_history.json` (mode 0600). Retention is controlled
 /// by `AppSettings.costData.retentionDays`.
@@ -151,6 +154,57 @@ public actor CostHistoryStore {
         retentionDays: Int = CostDataSettings.defaultRetentionDays
     ) -> CostSnapshot {
         mergeSeries(snapshot.dailyHistory, tool: snapshot.tool, retentionDays: retentionDays)
+        return augmentedSnapshot(snapshot, retentionDays: retentionDays)
+    }
+
+    /// Replace the complete retained series for an authoritative source, then
+    /// rebuild its window totals from that corrected history. A successful
+    /// Cursor dashboard response covers the requested retention interval in
+    /// full, so omitted days are authoritative zeroes rather than rotated logs.
+    public func replaceAndAugment(
+        _ snapshot: CostSnapshot,
+        retentionDays: Int = CostDataSettings.defaultRetentionDays
+    ) -> CostSnapshot {
+        replaceSeries(
+            snapshot.dailyHistory,
+            tool: snapshot.tool,
+            now: snapshot.updatedAt,
+            retentionDays: retentionDays
+        )
+        return augmentedSnapshot(snapshot, retentionDays: retentionDays)
+    }
+
+    private func replaceSeries(
+        _ series: [DailyCostPoint],
+        tool: ToolType,
+        now: Date,
+        retentionDays: Int
+    ) {
+        var storage = load()
+        let toolKey = tool.rawValue
+        let cutoffKey = retentionCutoffKey(now: now, retentionDays: retentionDays)
+        var replacements: [String: Entry] = [:]
+        for point in series {
+            let key = dateFormatter.string(from: point.date)
+            if let cutoffKey, key < cutoffKey { continue }
+            guard point.costUSD > 0 || point.totalTokens > 0 else { continue }
+            replacements[key] = Entry(
+                tool: toolKey,
+                date: key,
+                costUSD: point.costUSD,
+                totalTokens: point.totalTokens
+            )
+        }
+        storage.entries.removeAll { $0.tool == toolKey }
+        storage.entries.append(contentsOf: replacements.values)
+        prune(&storage, retentionDays: retentionDays)
+        save(storage)
+    }
+
+    private func augmentedSnapshot(
+        _ snapshot: CostSnapshot,
+        retentionDays: Int
+    ) -> CostSnapshot {
         let storage = load()
         let toolKey = snapshot.tool.rawValue
         let today = calendar.startOfDay(for: snapshot.updatedAt)

--- a/Sources/VibeBarCore/Services/CostUsageService.swift
+++ b/Sources/VibeBarCore/Services/CostUsageService.swift
@@ -216,7 +216,15 @@ public final class CostUsageService: ObservableObject {
                 }
                 switch outcome {
                 case .completed(.success(let snapshot)):
-                    directRemoteResults[.cursor] = snapshot
+                    let merged = await CostHistoryStore.shared.mergeAndAugment(
+                        snapshot,
+                        retentionDays: retentionDays
+                    )
+                    directRemoteResults[.cursor] = merged
+                    await CostSnapshotCache.shared.save(
+                        merged,
+                        retentionDays: retentionDays
+                    )
                     // Cursor dashboard events now feed the same request ledger
                     // as local scanners, so Workbench and the outer Grok cost
                     // surface share one set of token/cost facts.

--- a/Sources/VibeBarCore/Services/CostUsageService.swift
+++ b/Sources/VibeBarCore/Services/CostUsageService.swift
@@ -53,8 +53,9 @@ public final class CostUsageService: ObservableObject {
     /// the local scan cache/history and cannot be counted again after relaunch.
     private var localSnapshots: [ToolType: CostSnapshot] = [:]
     /// Account-wide provider APIs that are authoritative but not local files.
-    /// Kept memory-only so a dashboard refresh can never be mistaken for a
-    /// newly scanned local session on the next launch.
+    /// Cursor's last-known dashboard snapshot is persisted for launch
+    /// hydration, but remains in this lane so it can never be combined with
+    /// itself as if it were a newly scanned local session.
     private var directRemoteSnapshots: [ToolType: CostSnapshot] = [:]
     private var remoteSnapshots: [ToolType: CostSnapshot] = [:]
     /// Every value the UI derives from `snapshots` — rebased per-tool
@@ -88,14 +89,14 @@ public final class CostUsageService: ObservableObject {
             let cached = await CostSnapshotCache.shared.loadAll(retentionDays: costData.retentionDays, now: Date())
             // One assignment, not one per tool: every write to a `@Published`
             // dictionary is its own publish, and the popover re-renders on each.
-            var hydrated = self.localSnapshots
-            var addedAny = false
-            for (tool, snap) in cached where hydrated[tool] == nil {
-                hydrated[tool] = snap
-                addedAny = true
-            }
-            if addedAny {
-                self.localSnapshots = hydrated
+            let hydrated = Self.partitionPersistedSnapshots(
+                cached,
+                local: self.localSnapshots,
+                directRemote: self.directRemoteSnapshots
+            )
+            if hydrated.local != self.localSnapshots || hydrated.directRemote != self.directRemoteSnapshots {
+                self.localSnapshots = hydrated.local
+                self.directRemoteSnapshots = hydrated.directRemote
                 self.publishMergedSnapshots()
             }
             if !cached.isEmpty {
@@ -348,7 +349,9 @@ public final class CostUsageService: ObservableObject {
             retentionDays: costData.retentionDays
         )
         let cached = await CostSnapshotCache.shared.loadAll(retentionDays: costData.retentionDays, now: Date())
-        localSnapshots = cached
+        let hydrated = Self.partitionPersistedSnapshots(cached)
+        localSnapshots = hydrated.local
+        directRemoteSnapshots = hydrated.directRemote
         publishMergedSnapshots()
         lastRefreshedAt = cached.values.map(\.updatedAt).max()
     }
@@ -400,5 +403,28 @@ public final class CostUsageService: ObservableObject {
             }
         }
         snapshots = merged
+    }
+
+    /// Persisted Cursor data came from an account-wide dashboard rather than
+    /// a local session scan. Keep it in the direct-remote lane when hydrating
+    /// so a failed first refresh after launch retains the last-known snapshot
+    /// and a later successful refresh replaces it instead of adding it twice.
+    static func partitionPersistedSnapshots(
+        _ cached: [ToolType: CostSnapshot],
+        local: [ToolType: CostSnapshot] = [:],
+        directRemote: [ToolType: CostSnapshot] = [:]
+    ) -> (local: [ToolType: CostSnapshot], directRemote: [ToolType: CostSnapshot]) {
+        var hydratedLocal = local
+        var hydratedDirectRemote = directRemote
+        for (tool, snapshot) in cached {
+            if tool == .cursor {
+                if hydratedDirectRemote[tool] == nil {
+                    hydratedDirectRemote[tool] = snapshot
+                }
+            } else if hydratedLocal[tool] == nil {
+                hydratedLocal[tool] = snapshot
+            }
+        }
+        return (hydratedLocal, hydratedDirectRemote)
     }
 }

--- a/Sources/VibeBarCore/Services/CostUsageService.swift
+++ b/Sources/VibeBarCore/Services/CostUsageService.swift
@@ -1,9 +1,10 @@
 import Foundation
 import Combine
 
-/// Owns per-tool CostSnapshot + ProviderExtras. Merges fresh JSONL scans with
-/// the persisted CostHistoryStore using max() per retained (tool, day), so
-/// recent data survives CLI log rotation without keeping an unlimited profile.
+/// Owns per-tool CostSnapshot + ProviderExtras. Fresh JSONL scans max-merge
+/// with persisted history so log rotation cannot erase usage; authoritative
+/// Cursor dashboard snapshots replace their retained history so corrections
+/// stay consistent with the request ledger.
 @MainActor
 public final class CostUsageService: ObservableObject {
     @Published public private(set) var snapshots: [ToolType: CostSnapshot] = [:] {
@@ -217,7 +218,7 @@ public final class CostUsageService: ObservableObject {
                 }
                 switch outcome {
                 case .completed(.success(let snapshot)):
-                    let merged = await CostHistoryStore.shared.mergeAndAugment(
+                    let merged = await CostHistoryStore.shared.replaceAndAugment(
                         snapshot,
                         retentionDays: retentionDays
                     )

--- a/Sources/VibeBarCore/Services/CostUsageService.swift
+++ b/Sources/VibeBarCore/Services/CostUsageService.swift
@@ -237,6 +237,10 @@ public final class CostUsageService: ObservableObject {
                     )
                 case .completed(.unavailable):
                     directRemoteResults.removeValue(forKey: .cursor)
+                    // Match the in-memory decision on the next launch: once
+                    // every Cursor session is gone, an old hydrated dashboard
+                    // snapshot must not reappear from cursor.json.
+                    await CostSnapshotCache.shared.remove(tool: .cursor)
                 case .completed(.failed), .timedOut:
                     // A transient dashboard failure keeps the last in-memory
                     // success, just as a timed-out local scan keeps its prior

--- a/Sources/VibeBarCore/Services/CursorCostUsageFetcher.swift
+++ b/Sources/VibeBarCore/Services/CursorCostUsageFetcher.swift
@@ -160,7 +160,7 @@ struct CursorCostUsageFetcher: Sendable {
         if let eventSink {
             await eventSink.consume(UsageEventFileBatch(
                 // Workbench uses the same product-level contract as the Grok
-                // cost card: Grok Build + Cursor is one final Grok total.
+                // cost card: Grok CLI + Cursor is one final SpaceXAI total.
                 tool: .grok,
                 filePath: "cursor-dashboard://\(sourceID)",
                 mtime: latestEventDate ?? now,

--- a/Sources/VibeBarCore/Services/CursorCostUsageFetcher.swift
+++ b/Sources/VibeBarCore/Services/CursorCostUsageFetcher.swift
@@ -159,9 +159,10 @@ struct CursorCostUsageFetcher: Sendable {
         }
         if let eventSink {
             await eventSink.consume(UsageEventFileBatch(
-                // Workbench uses the same product-level contract as the Grok
-                // cost card: Grok CLI + Cursor is one final SpaceXAI total.
-                tool: .grok,
+                // Preserve Cursor as an L2 SubProvider in the request ledger.
+                // Provider Mix folds it into SpaceXAI, while the outer cost
+                // card independently combines Grok + Cursor snapshots.
+                tool: .cursor,
                 filePath: "cursor-dashboard://\(sourceID)",
                 mtime: latestEventDate ?? now,
                 // Synthetic source: use a content-derived fingerprint rather

--- a/Sources/VibeBarCore/Services/CursorCostUsageFetcher.swift
+++ b/Sources/VibeBarCore/Services/CursorCostUsageFetcher.swift
@@ -13,6 +13,11 @@ enum CursorCostFetchOutcome: Sendable {
 /// cloud-only weekly allowance is a separate endpoint and is intentionally not
 /// synthesized into these events.
 struct CursorCostUsageFetcher: Sendable {
+    private struct PreparedSnapshot: Sendable {
+        let snapshot: CostSnapshot
+        let eventBatch: UsageEventFileBatch?
+    }
+
     private let session: URLSession
     private let baseURL: URL
     private let pageSize: Int
@@ -51,18 +56,22 @@ struct CursorCostUsageFetcher: Sendable {
             ? calendar.date(byAdding: .day, value: -(normalizedRetention - 1), to: today)
             : nil
         let fetcher = CursorCostUsageFetcher(session: session)
+        let includeEventBatch = eventSink != nil
 
         if let preferred = plan.preferred {
             do {
-                let snapshot = try await fetcher.fetchSnapshot(
+                let prepared = try await fetcher.prepareSnapshot(
                     cookieHeader: preferred.header,
                     since: since,
                     until: now,
                     now: now,
-                    eventSink: eventSink,
-                    sourceID: sourceIdentifier(for: preferred)
+                    sourceID: sourceIdentifier(for: preferred),
+                    includeEventBatch: includeEventBatch
                 )
-                return .success(snapshot)
+                if let eventSink, let batch = prepared.eventBatch {
+                    await eventSink.consume(batch)
+                }
+                return .success(prepared.snapshot)
             } catch let error as QuotaError {
                 guard error.isCredentialState, !plan.fallbacks.isEmpty else {
                     SafeLog.net("Cursor cost refresh failed: \(SafeLog.sanitize(error.localizedDescription))")
@@ -74,26 +83,38 @@ struct CursorCostUsageFetcher: Sendable {
             }
         }
 
-        var snapshots: [CostSnapshot] = []
+        var preparedSnapshots: [PreparedSnapshot] = []
+        var allFallbacksSucceeded = true
         for resolution in plan.fallbacks {
             do {
-                let snapshot = try await fetcher.fetchSnapshot(
+                let prepared = try await fetcher.prepareSnapshot(
                     cookieHeader: resolution.header,
                     since: since,
                     until: now,
                     now: now,
-                    eventSink: eventSink,
-                    sourceID: sourceIdentifier(for: resolution)
+                    sourceID: sourceIdentifier(for: resolution),
+                    includeEventBatch: includeEventBatch
                 )
-                snapshots.append(snapshot)
+                preparedSnapshots.append(prepared)
             } catch {
+                allFallbacksSucceeded = false
                 SafeLog.net("Cursor cost refresh failed: \(SafeLog.sanitize(error.localizedDescription))")
             }
         }
-        guard !snapshots.isEmpty else { return .failed }
+        guard allFallbacksSucceeded, !preparedSnapshots.isEmpty else {
+            // Cookie slots may represent independent Cursor accounts. Never
+            // publish or ingest a partial set: CostUsageService treats success
+            // as a complete authoritative replacement of retained history.
+            return .failed
+        }
+        if let eventSink {
+            for prepared in preparedSnapshots {
+                if let batch = prepared.eventBatch { await eventSink.consume(batch) }
+            }
+        }
         return .success(CostSnapshotAggregator.combinedSnapshot(
             tool: .cursor,
-            snapshots: snapshots,
+            snapshots: preparedSnapshots.map(\.snapshot),
             now: now
         ))
     }
@@ -106,6 +127,28 @@ struct CursorCostUsageFetcher: Sendable {
         eventSink: (any CostUsageEventSink)? = nil,
         sourceID: String = "default"
     ) async throws -> CostSnapshot {
+        let prepared = try await prepareSnapshot(
+            cookieHeader: cookieHeader,
+            since: since,
+            until: until,
+            now: now,
+            sourceID: sourceID,
+            includeEventBatch: eventSink != nil
+        )
+        if let eventSink, let batch = prepared.eventBatch {
+            await eventSink.consume(batch)
+        }
+        return prepared.snapshot
+    }
+
+    private func prepareSnapshot(
+        cookieHeader: String,
+        since: Date?,
+        until: Date?,
+        now: Date,
+        sourceID: String,
+        includeEventBatch: Bool
+    ) async throws -> PreparedSnapshot {
         let events = try await fetchAllEvents(
             cookieHeader: cookieHeader,
             since: since,
@@ -114,7 +157,7 @@ struct CursorCostUsageFetcher: Sendable {
         var accumulator = CostUsageScanner.CostAggregator(tool: .cursor, now: now)
         var includedEvents = 0
         var pricedEvents: [PricedUsageEvent] = []
-        pricedEvents.reserveCapacity(eventSink == nil ? 0 : events.count)
+        pricedEvents.reserveCapacity(includeEventBatch ? events.count : 0)
         var eventOccurrences: [String: Int] = [:]
         var latestEventDate: Date?
         for event in events {
@@ -133,7 +176,7 @@ struct CursorCostUsageFetcher: Sendable {
                 cache: usage.cacheReadTokens,
                 costUSD: costUSD
             )
-            if eventSink != nil {
+            if includeEventBatch {
                 let seed = event.stableIdentitySeed(model: model)
                 let occurrence = (eventOccurrences[seed] ?? 0) + 1
                 eventOccurrences[seed] = occurrence
@@ -157,8 +200,8 @@ struct CursorCostUsageFetcher: Sendable {
             if latestEventDate.map({ date > $0 }) ?? true { latestEventDate = date }
             includedEvents += 1
         }
-        if let eventSink {
-            await eventSink.consume(UsageEventFileBatch(
+        let eventBatch: UsageEventFileBatch? = if includeEventBatch {
+            UsageEventFileBatch(
                 // Preserve Cursor as an L2 SubProvider in the request ledger.
                 // Provider Mix folds it into SpaceXAI, while the outer cost
                 // card independently combines Grok + Cursor snapshots.
@@ -171,9 +214,14 @@ struct CursorCostUsageFetcher: Sendable {
                 // the same event identity with its revised tokens/cents.
                 size: Self.batchFingerprint(pricedEvents),
                 events: pricedEvents
-            ))
+            )
+        } else {
+            nil
         }
-        return accumulator.snapshot(jsonlFilesFound: includedEvents)
+        return PreparedSnapshot(
+            snapshot: accumulator.snapshot(jsonlFilesFound: includedEvents),
+            eventBatch: eventBatch
+        )
     }
 
     private static func sourceIdentifier(for resolution: MiscCookieResolver.Resolution) -> String {

--- a/Sources/VibeBarCore/Services/MockDataProvider.swift
+++ b/Sources/VibeBarCore/Services/MockDataProvider.swift
@@ -267,10 +267,10 @@ public enum MockDataProvider {
         case .cursor:
             let monthlyReset = now.addingTimeInterval(26 * 24 * 3600)
             buckets = [
-                QuotaBucket(id: "models", title: "Weekly", shortLabel: "Cursor",
+                QuotaBucket(id: "models", title: "Monthly", shortLabel: "Cursor",
                             usedPercent: 1, resetAt: monthlyReset, rawWindowSeconds: 2_678_400,
                             groupTitle: "Cursor Models"),
-                QuotaBucket(id: "other_models", title: "Weekly", shortLabel: "Other",
+                QuotaBucket(id: "other_models", title: "Monthly", shortLabel: "Other",
                             usedPercent: 1, resetAt: monthlyReset, rawWindowSeconds: 2_678_400,
                             groupTitle: "Other Models"),
                 QuotaBucket(id: "grok_bot_weekly", title: "Weekly", shortLabel: "Grok Bot",

--- a/Sources/VibeBarCore/Services/QuotaRefreshScheduler.swift
+++ b/Sources/VibeBarCore/Services/QuotaRefreshScheduler.swift
@@ -22,6 +22,7 @@ public final class QuotaRefreshScheduler {
     private var boundaryAccountIds: Set<String> = []
     private var lastBoundaryRefreshByAccount: [String: Date] = [:]
     private var lastPopoverOpenRefreshAt: Date?
+    private var refreshTask: Task<Void, Never>?
     private var pathMonitor: NWPathMonitor?
     private var lastNetworkStatus: NWPath.Status = .satisfied
     private var observers: [NSObjectProtocol] = []
@@ -58,6 +59,8 @@ public final class QuotaRefreshScheduler {
         boundaryTimer?.invalidate()
         boundaryTimer = nil
         boundaryAccountIds = []
+        refreshTask?.cancel()
+        refreshTask = nil
         pathMonitor?.cancel()
         pathMonitor = nil
         #if canImport(AppKit)
@@ -77,11 +80,7 @@ public final class QuotaRefreshScheduler {
         onRefreshTriggered()
         let accounts = accountsProvider()
         guard !accounts.isEmpty else { return }
-        Task { @MainActor in
-            for account in accounts {
-                _ = await service.refresh(account)
-            }
-        }
+        _ = startAccountRefresh(accounts)
     }
 
     /// Refresh when the user explicitly opens the menu popover, subject to a
@@ -111,18 +110,14 @@ public final class QuotaRefreshScheduler {
     /// full cost scan.
     @discardableResult
     public func triggerRefreshForStaleCacheIfNeeded(now: Date = Date()) -> Bool {
+        guard refreshTask == nil else { return false }
         let maxAge = TimeInterval(max(60, intervalProvider()))
         let accounts = accountsProvider().filter { account in
             !service.inFlightAccountIds.contains(account.id)
                 && service.needsRefresh(accountId: account.id, now: now, maxAge: maxAge)
         }
         guard !accounts.isEmpty else { return false }
-        Task { @MainActor in
-            for account in accounts {
-                _ = await service.refresh(account)
-            }
-        }
-        return true
+        return startAccountRefresh(accounts)
     }
 
     private func scheduleTimer() {
@@ -194,13 +189,34 @@ public final class QuotaRefreshScheduler {
             scheduleBoundaryTimer()
             return
         }
-        Task { @MainActor in
+        let started = startAccountRefresh(accounts) { [weak self] in
+            self?.scheduleBoundaryTimer()
+        }
+        if started {
+            let refreshedAt = Date()
             for account in accounts {
-                lastBoundaryRefreshByAccount[account.id] = Date()
-                _ = await service.refresh(account)
+                lastBoundaryRefreshByAccount[account.id] = refreshedAt
             }
+        } else {
             scheduleBoundaryTimer()
         }
+    }
+
+    @discardableResult
+    private func startAccountRefresh(
+        _ accounts: [AccountIdentity],
+        completion: @escaping @MainActor () -> Void = {}
+    ) -> Bool {
+        guard refreshTask == nil, !accounts.isEmpty else { return false }
+        refreshTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            for account in accounts where !Task.isCancelled {
+                _ = await self.service.refresh(account)
+            }
+            self.refreshTask = nil
+            completion()
+        }
+        return true
     }
 
     private func installSystemObservers() {
@@ -233,6 +249,7 @@ public final class QuotaRefreshScheduler {
     deinit {
         timer?.invalidate()
         boundaryTimer?.invalidate()
+        refreshTask?.cancel()
         pathMonitor?.cancel()
         #if canImport(AppKit)
         for observer in observers {

--- a/Sources/VibeBarCore/Services/QuotaRefreshScheduler.swift
+++ b/Sources/VibeBarCore/Services/QuotaRefreshScheduler.swift
@@ -105,6 +105,26 @@ public final class QuotaRefreshScheduler {
         return true
     }
 
+    /// Even when the user disables unconditional popover-open refresh, an
+    /// actually missing/stale/expired cache must not remain silently visible.
+    /// This path refreshes only the affected accounts and does not trigger a
+    /// full cost scan.
+    @discardableResult
+    public func triggerRefreshForStaleCacheIfNeeded(now: Date = Date()) -> Bool {
+        let maxAge = TimeInterval(max(60, intervalProvider()))
+        let accounts = accountsProvider().filter { account in
+            !service.inFlightAccountIds.contains(account.id)
+                && service.needsRefresh(accountId: account.id, now: now, maxAge: maxAge)
+        }
+        guard !accounts.isEmpty else { return false }
+        Task { @MainActor in
+            for account in accounts {
+                _ = await service.refresh(account)
+            }
+        }
+        return true
+    }
+
     private func scheduleTimer() {
         timer?.invalidate()
         let interval = TimeInterval(max(60, intervalProvider()))

--- a/Sources/VibeBarCore/Services/QuotaRefreshScheduler.swift
+++ b/Sources/VibeBarCore/Services/QuotaRefreshScheduler.swift
@@ -23,6 +23,9 @@ public final class QuotaRefreshScheduler {
     private var lastBoundaryRefreshByAccount: [String: Date] = [:]
     private var lastPopoverOpenRefreshAt: Date?
     private var refreshTask: Task<Void, Never>?
+    private var activeAccountIds: Set<String> = []
+    private var pendingAccounts: [String: AccountIdentity] = [:]
+    private var refreshCompletions: [@MainActor () -> Void] = []
     private var pathMonitor: NWPathMonitor?
     private var lastNetworkStatus: NWPath.Status = .satisfied
     private var observers: [NSObjectProtocol] = []
@@ -61,6 +64,9 @@ public final class QuotaRefreshScheduler {
         boundaryAccountIds = []
         refreshTask?.cancel()
         refreshTask = nil
+        activeAccountIds = []
+        pendingAccounts = [:]
+        refreshCompletions = []
         pathMonitor?.cancel()
         pathMonitor = nil
         #if canImport(AppKit)
@@ -110,10 +116,10 @@ public final class QuotaRefreshScheduler {
     /// full cost scan.
     @discardableResult
     public func triggerRefreshForStaleCacheIfNeeded(now: Date = Date()) -> Bool {
-        guard refreshTask == nil else { return false }
         let maxAge = TimeInterval(max(60, intervalProvider()))
         let accounts = accountsProvider().filter { account in
-            !service.inFlightAccountIds.contains(account.id)
+            !activeAccountIds.contains(account.id)
+                && !service.inFlightAccountIds.contains(account.id)
                 && service.needsRefresh(accountId: account.id, now: now, maxAge: maxAge)
         }
         guard !accounts.isEmpty else { return false }
@@ -207,14 +213,32 @@ public final class QuotaRefreshScheduler {
         _ accounts: [AccountIdentity],
         completion: @escaping @MainActor () -> Void = {}
     ) -> Bool {
-        guard refreshTask == nil, !accounts.isEmpty else { return false }
+        guard !accounts.isEmpty else { return false }
+        refreshCompletions.append(completion)
+        if refreshTask != nil {
+            for account in accounts where !activeAccountIds.contains(account.id) {
+                pendingAccounts[account.id] = account
+            }
+            return true
+        }
+        activeAccountIds = Set(accounts.map(\.id))
         refreshTask = Task { @MainActor [weak self] in
             guard let self else { return }
             for account in accounts where !Task.isCancelled {
                 _ = await self.service.refresh(account)
             }
             self.refreshTask = nil
-            completion()
+            self.activeAccountIds = []
+            if !self.pendingAccounts.isEmpty {
+                let next = Array(self.pendingAccounts.values)
+                    .sorted { $0.id < $1.id }
+                self.pendingAccounts = [:]
+                _ = self.startAccountRefresh(next)
+            } else {
+                let callbacks = self.refreshCompletions
+                self.refreshCompletions = []
+                for callback in callbacks { callback() }
+            }
         }
         return true
     }

--- a/Sources/VibeBarCore/Services/QuotaRefreshScheduler.swift
+++ b/Sources/VibeBarCore/Services/QuotaRefreshScheduler.swift
@@ -190,6 +190,12 @@ public final class QuotaRefreshScheduler {
         boundaryAccountIds = []
         boundaryTimer?.invalidate()
         boundaryTimer = nil
+        triggerBoundaryRefresh(accountIds: ids)
+    }
+
+    /// Kept internal so the scheduler's coalescing behavior can be exercised
+    /// deterministically without installing a wall-clock Timer in tests.
+    func triggerBoundaryRefresh(accountIds ids: Set<String>) {
         let accounts = accountsProvider().filter { ids.contains($0.id) }
         guard !accounts.isEmpty else {
             scheduleBoundaryTimer()
@@ -226,6 +232,10 @@ public final class QuotaRefreshScheduler {
             guard let self else { return }
             for account in accounts where !Task.isCancelled {
                 _ = await self.service.refresh(account)
+                // A later trigger (especially the post-reset observation) must
+                // be able to queue an account that already completed earlier
+                // in this still-running multi-account walk.
+                self.activeAccountIds.remove(account.id)
             }
             self.refreshTask = nil
             self.activeAccountIds = []

--- a/Sources/VibeBarCore/Services/QuotaService.swift
+++ b/Sources/VibeBarCore/Services/QuotaService.swift
@@ -173,6 +173,11 @@ public final class QuotaService: ObservableObject {
         maxAge: TimeInterval
     ) -> Bool {
         guard let cached = lastSuccessByAccount[accountId] else { return true }
+        if cached.buckets.contains(where: { bucket in
+            bucket.resetAt.map { $0 <= now } ?? false
+        }) {
+            return true
+        }
         return now.timeIntervalSince(cached.queriedAt) >= max(0, maxAge)
     }
 

--- a/Sources/VibeBarCore/Services/ServiceStatusClient.swift
+++ b/Sources/VibeBarCore/Services/ServiceStatusClient.swift
@@ -257,18 +257,20 @@ public actor ServiceStatusClient {
             guard let match,
                   let dateRange = Range(match.range(at: 1), in: normalized),
                   let nameRange = Range(match.range(at: 2), in: normalized),
+                  let durationRange = Range(match.range(at: 3), in: normalized),
                   let impactRange = Range(match.range(at: 4), in: normalized),
                   let createdAt = parseXAIStatusDate(String(normalized[dateRange]))
             else { return }
             let name = String(normalized[nameRange]).trimmingCharacters(in: .whitespacesAndNewlines)
             let impact = xAIIncidentImpact(String(normalized[impactRange]))
+            let duration = parseXAIDuration(String(normalized[durationRange]))
             incidents.append(
                 IncidentSummary(
                     id: "\(componentId)-\(Int(createdAt.timeIntervalSince1970))-\(xAISlug(name))",
                     name: name,
                     impact: impact,
                     createdAt: createdAt,
-                    resolvedAt: createdAt,
+                    resolvedAt: createdAt.addingTimeInterval(duration ?? 0),
                     url: url
                 )
             )
@@ -284,24 +286,68 @@ public actor ServiceStatusClient {
         return formatter.date(from: raw)
     }
 
+    nonisolated static func parseXAIDuration(_ raw: String) -> TimeInterval? {
+        let pattern = #"(\d+(?:\.\d+)?)\s*(days?|hours?|minutes?|seconds?)"#
+        guard let regex = try? NSRegularExpression(pattern: pattern, options: [.caseInsensitive]) else {
+            return nil
+        }
+        let range = NSRange(raw.startIndex..<raw.endIndex, in: raw)
+        var total: TimeInterval = 0
+        var matched = false
+        regex.enumerateMatches(in: raw, options: [], range: range) { match, _, _ in
+            guard let match,
+                  let valueRange = Range(match.range(at: 1), in: raw),
+                  let unitRange = Range(match.range(at: 2), in: raw),
+                  let value = Double(raw[valueRange]),
+                  value.isFinite,
+                  value >= 0
+            else { return }
+            let unit = raw[unitRange].lowercased()
+            let multiplier: TimeInterval
+            if unit.hasPrefix("day") {
+                multiplier = 86_400
+            } else if unit.hasPrefix("hour") {
+                multiplier = 3_600
+            } else if unit.hasPrefix("minute") {
+                multiplier = 60
+            } else {
+                multiplier = 1
+            }
+            total += value * multiplier
+            matched = true
+        }
+        return matched ? total : nil
+    }
+
     private nonisolated static func xAIComponentStatus(from lines: [String]) -> ComponentStatusLevel {
-        let head = lines.prefix(12).joined(separator: " ").lowercased()
-        if head.contains("service fully operational")
-            || head.contains("not aware of any issues")
-            || head.contains("available") {
-            return .operational
-        }
-        if head.contains("major outage") || head.contains("unavailable") {
-            return .majorOutage
-        }
-        if head.contains("partial outage") {
-            return .partialOutage
-        }
-        if head.contains("maintenance") {
-            return .underMaintenance
-        }
-        if head.contains("degraded") || head.contains("disruption") {
-            return .degradedPerformance
+        // Status appears before Past Issues. Parse each visible line in order
+        // so a historical incident cannot override the current status, and
+        // require an availability word boundary so "unavailable" never
+        // satisfies "available".
+        for rawLine in lines.prefix(12) {
+            let line = rawLine.lowercased()
+            if line.contains("service fully operational")
+                || line.contains("not aware of any issues") {
+                return .operational
+            }
+            if line.contains("major outage")
+                || line.contains("service unavailable")
+                || line == "unavailable"
+                || line.hasSuffix(" unavailable") {
+                return .majorOutage
+            }
+            if line.contains("partial outage") {
+                return .partialOutage
+            }
+            if line.contains("maintenance") {
+                return .underMaintenance
+            }
+            if line.contains("degraded") || line.contains("disruption") {
+                return .degradedPerformance
+            }
+            if line == "available" || line.hasSuffix(" available") {
+                return .operational
+            }
         }
         return .operational
     }

--- a/Sources/VibeBarCore/Services/ServiceStatusClient.swift
+++ b/Sources/VibeBarCore/Services/ServiceStatusClient.swift
@@ -139,16 +139,17 @@ public actor ServiceStatusClient {
                 now: now
             )
         }
-        let components: [ServiceComponentSummary]
-        if parsedComponents.isEmpty {
-            components = parseXAIOverviewComponents(
-                overviewHTML,
-                dayCount: dayCount,
-                now: now
-            )
-        } else {
-            components = parsedComponents.map(\.component)
-        }
+        let detailedComponents = parsedComponents.map(\.component)
+        let detailedNames = Set(detailedComponents.map { xAISlug($0.name) })
+        // Every component page is an independent request. Keep the richer
+        // history for pages that succeeded, then backfill any failed request
+        // from the all-components overview so its outage status is not lost.
+        let overviewFallbacks = parseXAIOverviewComponents(
+            overviewHTML,
+            dayCount: dayCount,
+            now: now
+        ).filter { !detailedNames.contains(xAISlug($0.name)) }
+        let components = detailedComponents + overviewFallbacks
 
         let recentIncidents = parsedComponents
             .flatMap(\.incidents)

--- a/Sources/VibeBarCore/Services/ServiceStatusClient.swift
+++ b/Sources/VibeBarCore/Services/ServiceStatusClient.swift
@@ -26,7 +26,9 @@ public actor ServiceStatusClient {
             return try await fetchGoogleAppsStatus(tool: tool, dayCount: dayCount, now: now)
         case .grok:
             return try await fetchXAIStatus(dayCount: dayCount, now: now)
-        case .alibaba, .alibabaTokenPlan, .copilot, .zai, .minimax, .kimi, .cursor, .mimo, .iflytek, .tencentHunyuan, .tencentTokenPlan, .volcengine, .volcengineAgentPlan, .baiduQianfan, .openCodeGo, .kilo, .kiro, .ollama, .openRouter, .warp:
+        case .cursor:
+            return try await fetchStatuspage(tool: .cursor)
+        case .alibaba, .alibabaTokenPlan, .copilot, .zai, .minimax, .kimi, .mimo, .iflytek, .tencentHunyuan, .tencentTokenPlan, .volcengine, .volcengineAgentPlan, .baiduQianfan, .openCodeGo, .kilo, .kiro, .ollama, .openRouter, .warp:
             // Misc providers don't expose known machine-readable status APIs.
             // `tool.supportsStatusPage` is `false` for all of them, and
             // upstream callers should already be filtering to primary
@@ -44,6 +46,48 @@ public actor ServiceStatusClient {
                 recentIncidents: []
             )
         }
+    }
+
+    // MARK: - Generic Statuspage v2 (Cursor)
+
+    private func fetchStatuspage(tool: ToolType) async throws -> ServiceStatusSnapshot {
+        let summary = try await fetchJSON(SummaryDTO.self, from: tool.statusSummaryAPI)
+        let incidentsDTO = try await fetchJSON(IncidentsDTO.self, from: tool.statusIncidentsAPI)
+        let groups = summary.components.compactMap { component -> ServiceComponentGroup? in
+            guard component.group == true else { return nil }
+            return ServiceComponentGroup(id: component.id, name: component.name)
+        }
+        let components = summary.components.compactMap { component -> ServiceComponentSummary? in
+            guard component.group != true else { return nil }
+            return ServiceComponentSummary(
+                id: component.id,
+                name: component.name,
+                status: component.status,
+                groupId: component.group_id
+            )
+        }
+        let incidents = incidentsDTO.incidents
+            .sorted { $0.created_at > $1.created_at }
+            .prefix(4)
+            .map {
+                IncidentSummary(
+                    id: $0.id,
+                    name: $0.name,
+                    impact: $0.impact,
+                    createdAt: $0.created_at,
+                    resolvedAt: $0.resolved_at,
+                    url: $0.shortlink
+                )
+            }
+        return ServiceStatusSnapshot(
+            tool: tool,
+            indicator: summary.status.indicator,
+            description: summary.status.description,
+            updatedAt: summary.page.updated_at,
+            groups: groups,
+            components: components,
+            recentIncidents: Array(incidents)
+        )
     }
 
     // MARK: - xAI Status (HTML status.x.ai)
@@ -373,9 +417,8 @@ public actor ServiceStatusClient {
 
     /// Product id for Gemini on Google's Workspace Status dashboard.
     /// Confirmed against `https://www.google.com/appsstatus/dashboard/products.json`
-    /// on 2026-05-22. Antigravity quotas / incidents currently roll up
-    /// into the same Gemini product entry — Google hasn't split them
-    /// out.
+    /// on 2026-05-22. Gemini Web and AntiGravity currently share this
+    /// Google status product entry — Google hasn't split them out.
     private static let googleGeminiProductId = "npdyhgECDJ6tB66MxXyo"
     private static let googleIncidentsURL = URL(string: "https://www.google.com/appsstatus/dashboard/incidents.json")!
 

--- a/Sources/VibeBarCore/Services/UsageEventLedger.swift
+++ b/Sources/VibeBarCore/Services/UsageEventLedger.swift
@@ -301,7 +301,8 @@ public actor UsageEventLedger: CostUsageEventSink {
 
         }
 
-        if !rows.isEmpty || legacyCursorEvidence {
+        let rolledCursorEvidence = hasLegacyCursorRollupEvidence(database)
+        if !rows.isEmpty || legacyCursorEvidence || rolledCursorEvidence {
             let floorSQL = """
                 INSERT INTO ledger_meta(key, value)
                      SELECT '\(floorKeyPrefix)cursor', value
@@ -330,6 +331,32 @@ public actor UsageEventLedger: CostUsageEventSink {
               sqlite3_exec(database, "COMMIT", nil, nil, nil) == SQLITE_OK
         else { return rollback() }
         return true
+    }
+
+    /// Legacy Cursor events were rolled up under `.grok`, but their dashboard
+    /// model families remain distinguishable from Grok CLI's own rows.
+    private static func hasLegacyCursorRollupEvidence(_ database: OpaquePointer) -> Bool {
+        var statement: OpaquePointer?
+        guard sqlite3_prepare_v2(
+            database,
+            """
+            SELECT 1 FROM usage_daily_rollups
+             WHERE tool = 'grok'
+               AND (
+                    model LIKE 'cursor-%'
+                 OR model LIKE 'composer-%'
+                 OR model LIKE 'claude-%'
+                 OR model LIKE 'gemini-%'
+                 OR model LIKE 'gpt-%'
+               )
+             LIMIT 1
+            """,
+            -1,
+            &statement,
+            nil
+        ) == SQLITE_OK, let statement else { return false }
+        defer { sqlite3_finalize(statement) }
+        return sqlite3_step(statement) == SQLITE_ROW
     }
 
     private static func storedSchemaVersion(_ database: OpaquePointer) -> Int? {

--- a/Sources/VibeBarCore/Services/UsageEventLedger.swift
+++ b/Sources/VibeBarCore/Services/UsageEventLedger.swift
@@ -237,6 +237,10 @@ public actor UsageEventLedger: CostUsageEventSink {
                  SELECT '\(floorKeyPrefix)cursor', value
                    FROM ledger_meta
                   WHERE key = '\(floorKeyPrefix)grok'
+                    AND EXISTS (
+                        SELECT 1 FROM usage_events
+                         WHERE source_key LIKE 'cursor-event-v1-%'
+                    )
                     AND NOT EXISTS (
                         SELECT 1 FROM ledger_meta WHERE key = '\(cursorToolMigrationKey)'
                     )

--- a/Sources/VibeBarCore/Services/UsageEventLedger.swift
+++ b/Sources/VibeBarCore/Services/UsageEventLedger.swift
@@ -110,8 +110,13 @@ public actor UsageEventLedger: CostUsageEventSink {
             throw UsageLedgerError.open
         }
         sqlite3_busy_timeout(handle, 5_000)
+        let legacyCursorEvidence = url == VibeBarLocalStore.usageEventsLedgerURL
+            && FileManager.default.fileExists(
+                atPath: VibeBarLocalStore.costSnapshotDirectory
+                    .appendingPathComponent("cursor.json").path
+            )
         do {
-            try Self.initialize(handle)
+            try Self.initialize(handle, legacyCursorEvidence: legacyCursorEvidence)
             database = handle
         } catch {
             sqlite3_close_v2(handle)
@@ -125,7 +130,10 @@ public actor UsageEventLedger: CostUsageEventSink {
 
     // MARK: - Schema
 
-    private static func initialize(_ database: OpaquePointer) throws {
+    private static func initialize(
+        _ database: OpaquePointer,
+        legacyCursorEvidence: Bool
+    ) throws {
         let preamble = """
             PRAGMA journal_mode=WAL;
             PRAGMA synchronous=NORMAL;
@@ -200,7 +208,10 @@ public actor UsageEventLedger: CostUsageEventSink {
         guard sqlite3_exec(database, schema, nil, nil, nil) == SQLITE_OK else {
             throw UsageLedgerError.open
         }
-        guard Self.migrateCursorToolRows(database) else {
+        guard Self.migrateCursorToolRows(
+            database,
+            legacyCursorEvidence: legacyCursorEvidence
+        ) else {
             throw UsageLedgerError.open
         }
         var statement: OpaquePointer?
@@ -225,7 +236,10 @@ public actor UsageEventLedger: CostUsageEventSink {
     /// forward. The copied floor prevents the first `.cursor` batch from
     /// backfilling days already folded into inseparable legacy Grok rollups;
     /// the rewritten dedupe key makes newer rows update rather than duplicate.
-    static func migrateCursorToolRows(_ database: OpaquePointer) -> Bool {
+    static func migrateCursorToolRows(
+        _ database: OpaquePointer,
+        legacyCursorEvidence: Bool = false
+    ) -> Bool {
         var marker: OpaquePointer?
         guard sqlite3_prepare_v2(
             database,
@@ -285,6 +299,9 @@ public actor UsageEventLedger: CostUsageEventSink {
                 guard sqlite3_step(update) == SQLITE_DONE else { return rollback() }
             }
 
+        }
+
+        if !rows.isEmpty || legacyCursorEvidence {
             let floorSQL = """
                 INSERT INTO ledger_meta(key, value)
                      SELECT '\(floorKeyPrefix)cursor', value

--- a/Sources/VibeBarCore/Services/UsageEventLedger.swift
+++ b/Sources/VibeBarCore/Services/UsageEventLedger.swift
@@ -78,6 +78,7 @@ public actor UsageEventLedger: CostUsageEventSink {
     static let schemaVersion = 3
     private static let schemaVersionKey = "schema_version"
     private static let cursorToolMigrationKey = "cursor_tool_v1"
+    private static let cursorRollupMigrationKey = "cursor_rollup_tool_v1"
     private static let pricingRevisionKey = "pricing_revision"
     private static let floorKeyPrefix = "detail_floor_day:"
     /// Guard rail on zero-filled trend enumeration: ~135 years of daily
@@ -231,28 +232,33 @@ public actor UsageEventLedger: CostUsageEventSink {
     }
 
     /// v3 originally stored Cursor dashboard detail under `.grok`. Preserve
-    /// every table and historical daily rollup, relabel identifiable request
-    /// rows *and their dedupe identity*, and carry the Grok detail floor
-    /// forward. The copied floor prevents the first `.cursor` batch from
-    /// backfilling days already folded into inseparable legacy Grok rollups;
-    /// the rewritten dedupe key makes newer rows update rather than duplicate.
+    /// every table, relabel identifiable request rows *and their dedupe
+    /// identity*, merge identifiable daily rollups into `.cursor`, and carry
+    /// the Grok detail floor forward. The copied floor prevents the first
+    /// `.cursor` batch from backfilling already-folded days; the rewritten
+    /// dedupe key makes newer rows update rather than duplicate.
     static func migrateCursorToolRows(
         _ database: OpaquePointer,
         legacyCursorEvidence: Bool = false
     ) -> Bool {
-        var marker: OpaquePointer?
-        guard sqlite3_prepare_v2(
-            database,
-            "SELECT 1 FROM ledger_meta WHERE key = ?",
-            -1,
-            &marker,
-            nil
-        ) == SQLITE_OK, let marker else { return false }
         let transient = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
-        sqlite3_bind_text(marker, 1, cursorToolMigrationKey, -1, transient)
-        let alreadyMigrated = sqlite3_step(marker) == SQLITE_ROW
-        sqlite3_finalize(marker)
-        if alreadyMigrated { return true }
+        func hasMarker(_ key: String) -> Bool? {
+            var marker: OpaquePointer?
+            guard sqlite3_prepare_v2(
+                database,
+                "SELECT 1 FROM ledger_meta WHERE key = ?",
+                -1,
+                &marker,
+                nil
+            ) == SQLITE_OK, let marker else { return nil }
+            defer { sqlite3_finalize(marker) }
+            sqlite3_bind_text(marker, 1, key, -1, transient)
+            return sqlite3_step(marker) == SQLITE_ROW
+        }
+        guard let detailAlreadyMigrated = hasMarker(cursorToolMigrationKey),
+              let rollupsAlreadyMigrated = hasMarker(cursorRollupMigrationKey)
+        else { return false }
+        if detailAlreadyMigrated && rollupsAlreadyMigrated { return true }
 
         guard sqlite3_exec(database, "BEGIN IMMEDIATE", nil, nil, nil) == SQLITE_OK else {
             return false
@@ -262,20 +268,22 @@ public actor UsageEventLedger: CostUsageEventSink {
             return false
         }
 
-        var select: OpaquePointer?
-        guard sqlite3_prepare_v2(
-            database,
-            "SELECT id, source_key FROM usage_events WHERE tool = 'grok' AND source_key LIKE 'cursor-event-v1-%'",
-            -1,
-            &select,
-            nil
-        ) == SQLITE_OK, let select else { return rollback() }
         var rows: [(id: Int64, sourceKey: String)] = []
-        while sqlite3_step(select) == SQLITE_ROW {
-            guard let raw = sqlite3_column_text(select, 1) else { continue }
-            rows.append((sqlite3_column_int64(select, 0), String(cString: raw)))
+        if !detailAlreadyMigrated {
+            var select: OpaquePointer?
+            guard sqlite3_prepare_v2(
+                database,
+                "SELECT id, source_key FROM usage_events WHERE tool = 'grok' AND source_key LIKE 'cursor-event-v1-%'",
+                -1,
+                &select,
+                nil
+            ) == SQLITE_OK, let select else { return rollback() }
+            while sqlite3_step(select) == SQLITE_ROW {
+                guard let raw = sqlite3_column_text(select, 1) else { continue }
+                rows.append((sqlite3_column_int64(select, 0), String(cString: raw)))
+            }
+            sqlite3_finalize(select)
         }
-        sqlite3_finalize(select)
 
         if !rows.isEmpty {
             var update: OpaquePointer?
@@ -301,8 +309,13 @@ public actor UsageEventLedger: CostUsageEventSink {
 
         }
 
-        let rolledCursorEvidence = hasLegacyCursorRollupEvidence(database)
-        if !rows.isEmpty || legacyCursorEvidence || rolledCursorEvidence {
+        let rolledCursorEvidence = !rollupsAlreadyMigrated
+            && hasLegacyCursorRollupEvidence(database)
+        let shouldCopyCursorFloor = (
+            !detailAlreadyMigrated
+                && (!rows.isEmpty || legacyCursorEvidence || rolledCursorEvidence)
+        ) || (detailAlreadyMigrated && rolledCursorEvidence)
+        if shouldCopyCursorFloor {
             let floorSQL = """
                 INSERT INTO ledger_meta(key, value)
                      SELECT '\(floorKeyPrefix)cursor', value
@@ -316,6 +329,10 @@ public actor UsageEventLedger: CostUsageEventSink {
             }
         }
 
+        if rolledCursorEvidence && !mergeLegacyCursorRollups(database) {
+            return rollback()
+        }
+
         var insertMarker: OpaquePointer?
         guard sqlite3_prepare_v2(
             database,
@@ -327,7 +344,20 @@ public actor UsageEventLedger: CostUsageEventSink {
         sqlite3_bind_text(insertMarker, 1, cursorToolMigrationKey, -1, transient)
         let markerResult = sqlite3_step(insertMarker)
         sqlite3_finalize(insertMarker)
-        guard markerResult == SQLITE_DONE,
+        guard markerResult == SQLITE_DONE else { return rollback() }
+
+        var insertRollupMarker: OpaquePointer?
+        guard sqlite3_prepare_v2(
+            database,
+            "INSERT INTO ledger_meta(key, value) VALUES(?, '1') ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+            -1,
+            &insertRollupMarker,
+            nil
+        ) == SQLITE_OK, let insertRollupMarker else { return rollback() }
+        sqlite3_bind_text(insertRollupMarker, 1, cursorRollupMigrationKey, -1, transient)
+        let rollupMarkerResult = sqlite3_step(insertRollupMarker)
+        sqlite3_finalize(insertRollupMarker)
+        guard rollupMarkerResult == SQLITE_DONE,
               sqlite3_exec(database, "COMMIT", nil, nil, nil) == SQLITE_OK
         else { return rollback() }
         return true
@@ -357,6 +387,42 @@ public actor UsageEventLedger: CostUsageEventSink {
         ) == SQLITE_OK, let statement else { return false }
         defer { sqlite3_finalize(statement) }
         return sqlite3_step(statement) == SQLITE_ROW
+    }
+
+    /// Move only model families that the legacy Cursor dashboard emitted.
+    /// Insert-before-delete safely folds into an existing `.cursor` row with
+    /// the same `(day, model)` primary key instead of losing either total.
+    private static func mergeLegacyCursorRollups(_ database: OpaquePointer) -> Bool {
+        let predicate = """
+            tool = 'grok'
+            AND (
+                   model LIKE 'cursor-%'
+                OR model LIKE 'composer-%'
+                OR model LIKE 'claude-%'
+                OR model LIKE 'gemini-%'
+                OR model LIKE 'gpt-%'
+            )
+            """
+        let sql = """
+            INSERT INTO usage_daily_rollups(
+                   day, tool, model, requests, fresh_input, output,
+                   cache_read, cache_creation, cost_micros, unpriced
+               )
+               SELECT day, 'cursor', model, requests, fresh_input, output,
+                      cache_read, cache_creation, cost_micros, unpriced
+                 FROM usage_daily_rollups
+                WHERE \(predicate)
+               ON CONFLICT(day, tool, model) DO UPDATE SET
+                   requests = usage_daily_rollups.requests + excluded.requests,
+                   fresh_input = usage_daily_rollups.fresh_input + excluded.fresh_input,
+                   output = usage_daily_rollups.output + excluded.output,
+                   cache_read = usage_daily_rollups.cache_read + excluded.cache_read,
+                   cache_creation = usage_daily_rollups.cache_creation + excluded.cache_creation,
+                   cost_micros = usage_daily_rollups.cost_micros + excluded.cost_micros,
+                   unpriced = usage_daily_rollups.unpriced + excluded.unpriced;
+            DELETE FROM usage_daily_rollups WHERE \(predicate);
+            """
+        return sqlite3_exec(database, sql, nil, nil, nil) == SQLITE_OK
     }
 
     private static func storedSchemaVersion(_ database: OpaquePointer) -> Int? {

--- a/Sources/VibeBarCore/Services/UsageEventLedger.swift
+++ b/Sources/VibeBarCore/Services/UsageEventLedger.swift
@@ -72,11 +72,12 @@ public actor UsageEventLedger: CostUsageEventSink {
     private let calendar: Calendar
     private let dayFormatter: DateFormatter
 
-    /// Bumping this drops and rebuilds every table on the next open.
-    /// v4 preserves Cursor as its own L2 SubProvider in request/detail and
-    /// daily rollup rows. Provider-level queries merge it back into SpaceXAI.
-    static let schemaVersion = 4
+    /// Bumping this drops and rebuilds every table on the next open. Cursor's
+    /// L2 migration is intentionally in-place below so retained rollups are
+    /// never discarded merely to change request-source attribution.
+    static let schemaVersion = 3
     private static let schemaVersionKey = "schema_version"
+    private static let cursorToolMigrationKey = "cursor_tool_v1"
     private static let pricingRevisionKey = "pricing_revision"
     private static let floorKeyPrefix = "detail_floor_day:"
     /// Guard rail on zero-filled trend enumeration: ~135 years of daily
@@ -199,6 +200,9 @@ public actor UsageEventLedger: CostUsageEventSink {
         guard sqlite3_exec(database, schema, nil, nil, nil) == SQLITE_OK else {
             throw UsageLedgerError.open
         }
+        guard Self.migrateCursorToolRows(database) else {
+            throw UsageLedgerError.open
+        }
         var statement: OpaquePointer?
         guard sqlite3_prepare_v2(
             database,
@@ -213,6 +217,24 @@ public actor UsageEventLedger: CostUsageEventSink {
         sqlite3_bind_text(statement, 1, schemaVersionKey, -1, destructor)
         sqlite3_bind_text(statement, 2, String(schemaVersion), -1, destructor)
         guard sqlite3_step(statement) == SQLITE_DONE else { throw UsageLedgerError.open }
+    }
+
+    /// v3 originally stored Cursor dashboard detail under `.grok`. Preserve
+    /// every table and historical daily rollup, but relabel identifiable
+    /// request rows once using their privacy-safe Cursor source key.
+    static func migrateCursorToolRows(_ database: OpaquePointer) -> Bool {
+        let sql = """
+            UPDATE usage_events
+               SET tool = 'cursor'
+             WHERE tool = 'grok'
+               AND source_key LIKE 'cursor-event-v1-%'
+               AND NOT EXISTS (
+                   SELECT 1 FROM ledger_meta WHERE key = '\(cursorToolMigrationKey)'
+               );
+            INSERT INTO ledger_meta(key, value) VALUES('\(cursorToolMigrationKey)', '1')
+               ON CONFLICT(key) DO UPDATE SET value = excluded.value;
+            """
+        return sqlite3_exec(database, sql, nil, nil, nil) == SQLITE_OK
     }
 
     private static func storedSchemaVersion(_ database: OpaquePointer) -> Int? {

--- a/Sources/VibeBarCore/Services/UsageEventLedger.swift
+++ b/Sources/VibeBarCore/Services/UsageEventLedger.swift
@@ -58,7 +58,7 @@ public enum UsageLedgerError: Error, Sendable {
 /// - **Cursor** — dashboard rows report fresh input, cache writes, cache reads,
 ///   output, and authoritative metered cents independently. The fetcher keeps
 ///   those token columns non-overlapping and records them under `.grok`, so the
-///   Workbench final total matches the Grok Build + Cursor product card.
+///   Workbench final total matches the combined SpaceXAI cost card.
 ///
 /// So `cache_creation` is non-zero for Claude and Cursor when their sources
 /// report writes, and the three columns sum to the real token count without
@@ -577,9 +577,9 @@ public actor UsageEventLedger: CostUsageEventSink {
             for row in details {
                 // Cursor dashboard cents are authoritative provider facts,
                 // not estimates from our price table. They are stored under
-                // the Grok product key for final-total consistency, so source
+                // the SpaceXAI provider key for final-total consistency, so source
                 // provenance—not `tool`—must keep repricing from overwriting
-                // them with Grok Build rates.
+                // them with Grok CLI rates.
                 if row.sourceKey?.hasPrefix("cursor-event-v1") == true { continue }
                 let costBinding: Binding = if let micros = costMicros(for: row) {
                     .integer(micros)

--- a/Sources/VibeBarCore/Services/UsageEventLedger.swift
+++ b/Sources/VibeBarCore/Services/UsageEventLedger.swift
@@ -73,7 +73,9 @@ public actor UsageEventLedger: CostUsageEventSink {
     private let dayFormatter: DateFormatter
 
     /// Bumping this drops and rebuilds every table on the next open.
-    static let schemaVersion = 3
+    /// v4 preserves Cursor as its own L2 SubProvider in request/detail and
+    /// daily rollup rows. Provider-level queries merge it back into SpaceXAI.
+    static let schemaVersion = 4
     private static let schemaVersionKey = "schema_version"
     private static let pricingRevisionKey = "pricing_revision"
     private static let floorKeyPrefix = "detail_floor_day:"
@@ -365,7 +367,7 @@ public actor UsageEventLedger: CostUsageEventSink {
                source_key = excluded.source_key
            WHERE
                (
-                   excluded.tool = 'grok'
+                   excluded.tool = 'cursor'
                    AND excluded.source_key LIKE 'cursor-event-v1-%'
                    AND excluded.source_key = usage_events.source_key
                )
@@ -420,7 +422,7 @@ public actor UsageEventLedger: CostUsageEventSink {
                 .joined(separator: "|")
             return PrivacyPreservingHash.fileComponent(prefix: "cm-v3", rawValue: tuple)
         }
-        if tool == .grok,
+        if tool == .cursor,
            let sourceKey = event.sourceKey,
            sourceKey.hasPrefix("cursor-event-v1") {
             return PrivacyPreservingHash.fileComponent(
@@ -576,10 +578,8 @@ public actor UsageEventLedger: CostUsageEventSink {
         do {
             for row in details {
                 // Cursor dashboard cents are authoritative provider facts,
-                // not estimates from our price table. They are stored under
-                // the SpaceXAI provider key for final-total consistency, so source
-                // provenance—not `tool`—must keep repricing from overwriting
-                // them with Grok CLI rates.
+                // not estimates from our price table. Source provenance keeps
+                // repricing from overwriting them with catalog rates.
                 if row.sourceKey?.hasPrefix("cursor-event-v1") == true { continue }
                 let costBinding: Binding = if let micros = costMicros(for: row) {
                     .integer(micros)
@@ -1110,6 +1110,7 @@ public actor UsageEventLedger: CostUsageEventSink {
     public func modelStats(_ filter: UsageQueryFilter) throws -> [UsageModelStat] {
         var totals: [String: (requests: Int, tokens: Int64, cost: Int64)] = [:]
         try forEachGroup(filter, column: "model") { key, requests, tokens, cost in
+            guard !key.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
             totals[key, default: (0, 0, 0)].requests += requests
             totals[key, default: (0, 0, 0)].tokens += tokens
             totals[key, default: (0, 0, 0)].cost += cost
@@ -1138,12 +1139,13 @@ public actor UsageEventLedger: CostUsageEventSink {
     /// date range.
     public func availableModels(tools: [ToolType]? = nil) throws -> [String] {
         if let tools, tools.isEmpty { return [] }
-        var clause = ""
+        var clauses = ["TRIM(model) <> ''"]
         var bindings: [Binding] = []
         if let tools {
-            clause = " WHERE tool IN (\(placeholders(tools.count)))"
+            clauses.append("tool IN (\(placeholders(tools.count)))")
             bindings = tools.map { .text($0.rawValue) }
         }
+        let clause = " WHERE " + clauses.joined(separator: " AND ")
         let statement = try prepare(
             """
             SELECT model FROM usage_events\(clause)
@@ -1159,6 +1161,46 @@ public actor UsageEventLedger: CostUsageEventSink {
             if let model = columnText(statement, 0) { models.append(model) }
         }
         return models
+    }
+
+    /// Earliest retained fact for an optional SubProvider filter. The All
+    /// preset uses this real boundary instead of manufacturing decades of
+    /// empty trend buckets from a distant sentinel date.
+    public func earliestUsageDate(tools: [ToolType]? = nil) throws -> Date? {
+        if let tools, tools.isEmpty { return nil }
+        var clause = ""
+        var bindings: [Binding] = []
+        if let tools {
+            clause = " WHERE tool IN (\(placeholders(tools.count)))"
+            bindings = tools.map { .text($0.rawValue) }
+        }
+
+        let detail = try prepare("SELECT MIN(ts) FROM usage_events\(clause)")
+        defer { sqlite3_finalize(detail) }
+        bindAll(bindings, to: detail)
+        let detailStart: Date? = if sqlite3_step(detail) == SQLITE_ROW,
+                                    sqlite3_column_type(detail, 0) != SQLITE_NULL {
+            Date(timeIntervalSince1970: TimeInterval(sqlite3_column_int64(detail, 0)))
+        } else {
+            nil
+        }
+
+        let rollup = try prepare("SELECT MIN(day) FROM usage_daily_rollups\(clause)")
+        defer { sqlite3_finalize(rollup) }
+        bindAll(bindings, to: rollup)
+        let rollupStart: Date? = if sqlite3_step(rollup) == SQLITE_ROW,
+                                    let raw = columnText(rollup, 0) {
+            dayFormatter.date(from: raw)
+        } else {
+            nil
+        }
+
+        switch (detailStart, rollupStart) {
+        case let (detail?, rollup?): return min(detail, rollup)
+        case let (detail?, nil): return detail
+        case let (nil, rollup?): return rollup
+        case (nil, nil): return nil
+        }
     }
 
     private func forEachGroup(

--- a/Sources/VibeBarCore/Services/UsageEventLedger.swift
+++ b/Sources/VibeBarCore/Services/UsageEventLedger.swift
@@ -220,8 +220,10 @@ public actor UsageEventLedger: CostUsageEventSink {
     }
 
     /// v3 originally stored Cursor dashboard detail under `.grok`. Preserve
-    /// every table and historical daily rollup, but relabel identifiable
-    /// request rows once using their privacy-safe Cursor source key.
+    /// every table and historical daily rollup, relabel identifiable request
+    /// rows, and carry the Grok detail floor forward. The copied floor prevents
+    /// the first `.cursor` batch from backfilling days that are already folded
+    /// into the inseparable legacy Grok rollups.
     static func migrateCursorToolRows(_ database: OpaquePointer) -> Bool {
         let sql = """
             UPDATE usage_events
@@ -231,6 +233,15 @@ public actor UsageEventLedger: CostUsageEventSink {
                AND NOT EXISTS (
                    SELECT 1 FROM ledger_meta WHERE key = '\(cursorToolMigrationKey)'
                );
+            INSERT INTO ledger_meta(key, value)
+                 SELECT '\(floorKeyPrefix)cursor', value
+                   FROM ledger_meta
+                  WHERE key = '\(floorKeyPrefix)grok'
+                    AND NOT EXISTS (
+                        SELECT 1 FROM ledger_meta WHERE key = '\(cursorToolMigrationKey)'
+                    )
+               ON CONFLICT(key) DO UPDATE SET
+                   value = MAX(ledger_meta.value, excluded.value);
             INSERT INTO ledger_meta(key, value) VALUES('\(cursorToolMigrationKey)', '1')
                ON CONFLICT(key) DO UPDATE SET value = excluded.value;
             """

--- a/Sources/VibeBarCore/Services/UsageEventLedger.swift
+++ b/Sources/VibeBarCore/Services/UsageEventLedger.swift
@@ -221,35 +221,98 @@ public actor UsageEventLedger: CostUsageEventSink {
 
     /// v3 originally stored Cursor dashboard detail under `.grok`. Preserve
     /// every table and historical daily rollup, relabel identifiable request
-    /// rows, and carry the Grok detail floor forward. The copied floor prevents
-    /// the first `.cursor` batch from backfilling days that are already folded
-    /// into the inseparable legacy Grok rollups.
+    /// rows *and their dedupe identity*, and carry the Grok detail floor
+    /// forward. The copied floor prevents the first `.cursor` batch from
+    /// backfilling days already folded into inseparable legacy Grok rollups;
+    /// the rewritten dedupe key makes newer rows update rather than duplicate.
     static func migrateCursorToolRows(_ database: OpaquePointer) -> Bool {
-        let sql = """
-            UPDATE usage_events
-               SET tool = 'cursor'
-             WHERE tool = 'grok'
-               AND source_key LIKE 'cursor-event-v1-%'
-               AND NOT EXISTS (
-                   SELECT 1 FROM ledger_meta WHERE key = '\(cursorToolMigrationKey)'
-               );
-            INSERT INTO ledger_meta(key, value)
-                 SELECT '\(floorKeyPrefix)cursor', value
-                   FROM ledger_meta
-                  WHERE key = '\(floorKeyPrefix)grok'
-                    AND EXISTS (
-                        SELECT 1 FROM usage_events
-                         WHERE source_key LIKE 'cursor-event-v1-%'
-                    )
-                    AND NOT EXISTS (
-                        SELECT 1 FROM ledger_meta WHERE key = '\(cursorToolMigrationKey)'
-                    )
-               ON CONFLICT(key) DO UPDATE SET
-                   value = MAX(ledger_meta.value, excluded.value);
-            INSERT INTO ledger_meta(key, value) VALUES('\(cursorToolMigrationKey)', '1')
-               ON CONFLICT(key) DO UPDATE SET value = excluded.value;
-            """
-        return sqlite3_exec(database, sql, nil, nil, nil) == SQLITE_OK
+        var marker: OpaquePointer?
+        guard sqlite3_prepare_v2(
+            database,
+            "SELECT 1 FROM ledger_meta WHERE key = ?",
+            -1,
+            &marker,
+            nil
+        ) == SQLITE_OK, let marker else { return false }
+        let transient = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
+        sqlite3_bind_text(marker, 1, cursorToolMigrationKey, -1, transient)
+        let alreadyMigrated = sqlite3_step(marker) == SQLITE_ROW
+        sqlite3_finalize(marker)
+        if alreadyMigrated { return true }
+
+        guard sqlite3_exec(database, "BEGIN IMMEDIATE", nil, nil, nil) == SQLITE_OK else {
+            return false
+        }
+        func rollback() -> Bool {
+            sqlite3_exec(database, "ROLLBACK", nil, nil, nil)
+            return false
+        }
+
+        var select: OpaquePointer?
+        guard sqlite3_prepare_v2(
+            database,
+            "SELECT id, source_key FROM usage_events WHERE tool = 'grok' AND source_key LIKE 'cursor-event-v1-%'",
+            -1,
+            &select,
+            nil
+        ) == SQLITE_OK, let select else { return rollback() }
+        var rows: [(id: Int64, sourceKey: String)] = []
+        while sqlite3_step(select) == SQLITE_ROW {
+            guard let raw = sqlite3_column_text(select, 1) else { continue }
+            rows.append((sqlite3_column_int64(select, 0), String(cString: raw)))
+        }
+        sqlite3_finalize(select)
+
+        if !rows.isEmpty {
+            var update: OpaquePointer?
+            guard sqlite3_prepare_v2(
+                database,
+                "UPDATE usage_events SET tool = 'cursor', dedupe_key = ? WHERE id = ?",
+                -1,
+                &update,
+                nil
+            ) == SQLITE_OK, let update else { return rollback() }
+            defer { sqlite3_finalize(update) }
+            for row in rows {
+                let dedupe = PrivacyPreservingHash.fileComponent(
+                    prefix: "cursor-ledger-v1",
+                    rawValue: row.sourceKey
+                )
+                sqlite3_reset(update)
+                sqlite3_clear_bindings(update)
+                sqlite3_bind_text(update, 1, dedupe, -1, transient)
+                sqlite3_bind_int64(update, 2, row.id)
+                guard sqlite3_step(update) == SQLITE_DONE else { return rollback() }
+            }
+
+            let floorSQL = """
+                INSERT INTO ledger_meta(key, value)
+                     SELECT '\(floorKeyPrefix)cursor', value
+                       FROM ledger_meta
+                      WHERE key = '\(floorKeyPrefix)grok'
+                   ON CONFLICT(key) DO UPDATE SET
+                       value = MAX(ledger_meta.value, excluded.value)
+                """
+            guard sqlite3_exec(database, floorSQL, nil, nil, nil) == SQLITE_OK else {
+                return rollback()
+            }
+        }
+
+        var insertMarker: OpaquePointer?
+        guard sqlite3_prepare_v2(
+            database,
+            "INSERT INTO ledger_meta(key, value) VALUES(?, '1') ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+            -1,
+            &insertMarker,
+            nil
+        ) == SQLITE_OK, let insertMarker else { return rollback() }
+        sqlite3_bind_text(insertMarker, 1, cursorToolMigrationKey, -1, transient)
+        let markerResult = sqlite3_step(insertMarker)
+        sqlite3_finalize(insertMarker)
+        guard markerResult == SQLITE_DONE,
+              sqlite3_exec(database, "COMMIT", nil, nil, nil) == SQLITE_OK
+        else { return rollback() }
+        return true
     }
 
     private static func storedSchemaVersion(_ database: OpaquePointer) -> Int? {

--- a/Sources/VibeBarCore/Sessions/SessionModels.swift
+++ b/Sources/VibeBarCore/Sessions/SessionModels.swift
@@ -19,7 +19,7 @@ public enum SessionProvider: String, Codable, Sendable, CaseIterable, Hashable {
         case .claude: return "Claude Code"
         case .codex: return "Codex"
         case .grok: return "Grok"
-        case .gemini: return "Gemini"
+        case .gemini: return "Gemini CLI"
         case .antigravity: return "AntiGravity"
         }
     }

--- a/Sources/VibeBarCore/Storage/CostSnapshotCache.swift
+++ b/Sources/VibeBarCore/Storage/CostSnapshotCache.swift
@@ -8,8 +8,9 @@ import Foundation
 /// The full snapshot — heatmap, model breakdowns, daily history, totals, and
 /// the `CostChartWindowPolicy.hourlyRetentionDays`-long hourly window — fits in
 /// well under 1 MB even for heavy users, so we just write the whole blob each
-/// time. CostHistoryStore still owns the canonical max-merged per-day series;
-/// this cache is a snapshot of derived view data.
+/// time. CostHistoryStore still owns the canonical per-day series (max-merged
+/// for local logs, authoritative replacement for Cursor); this cache is a
+/// snapshot of derived view data.
 ///
 /// No schema version of its own: every field the scanner added since is
 /// optional on decode, so an older file loads with the new fields empty and the

--- a/Sources/VibeBarCore/Storage/CostSnapshotCache.swift
+++ b/Sources/VibeBarCore/Storage/CostSnapshotCache.swift
@@ -108,4 +108,8 @@ public actor CostSnapshotCache {
             try? FileManager.default.removeItem(at: fileURL(for: tool))
         }
     }
+
+    public func remove(tool: ToolType) {
+        try? FileManager.default.removeItem(at: fileURL(for: tool))
+    }
 }

--- a/Sources/VibeBarCore/Utilities/UsageModelNaming.swift
+++ b/Sources/VibeBarCore/Utilities/UsageModelNaming.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+/// Canonical Workbench display for model variants learned as human labels.
+/// Google publishes `gemini-3.5-flash` (decimal point, not `3-5`) and exposes
+/// thinking level separately; AntiGravity labels that level in parentheses,
+/// so Vibe Bar appends it as a stable local variant suffix.
+public enum UsageModelNaming {
+    public static func canonicalDisplayName(_ raw: String) -> String {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return "Unknown model" }
+        guard trimmed.lowercased().hasPrefix("gemini ") else {
+            return trimmed
+        }
+
+        let base: String
+        let variant: String?
+        if let open = trimmed.lastIndex(of: "("), trimmed.hasSuffix(")") {
+            base = String(trimmed[..<open]).trimmingCharacters(in: .whitespacesAndNewlines)
+            variant = String(trimmed[trimmed.index(after: open)..<trimmed.index(before: trimmed.endIndex)])
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+        } else {
+            base = trimmed
+            variant = nil
+        }
+
+        let slug = base.lowercased()
+            .split(whereSeparator: { $0.isWhitespace })
+            .joined(separator: "-")
+        guard let variant, !variant.isEmpty else { return slug }
+        let variantSlug = variant.lowercased()
+            .split(whereSeparator: { $0.isWhitespace })
+            .joined(separator: "-")
+        return "\(slug)-\(variantSlug)"
+    }
+}

--- a/Sources/VibeBarCore/Vendored/CostUsage/PricingDataSet.swift
+++ b/Sources/VibeBarCore/Vendored/CostUsage/PricingDataSet.swift
@@ -240,9 +240,9 @@ extension PricingDataSet {
             providers: Providers(
                 codex: .init(displayName: "OpenAI", models: [:]),
                 claude: .init(displayName: "Anthropic", models: [:]),
-                gemini: .init(displayName: "Google", models: [:]),
-                grok: .init(displayName: "xAI", models: [:]),
-                antigravity: .init(displayName: "AntiGravity", models: [:])
+                gemini: .init(displayName: "Google AI", models: [:]),
+                grok: .init(displayName: "SpaceXAI", models: [:]),
+                antigravity: .init(displayName: "Google AI", models: [:])
             )
         )
     }

--- a/Tests/VibeBarCoreTests/AntigravityCLIQuotaFetcherTests.swift
+++ b/Tests/VibeBarCoreTests/AntigravityCLIQuotaFetcherTests.swift
@@ -1,0 +1,52 @@
+import XCTest
+@testable import VibeBarCore
+
+final class AntigravityCLIQuotaFetcherTests: XCTestCase {
+    func testParsesOnlyExactAgyProcessNames() {
+        let output = """
+          101 /Users/example/.local/bin/agy
+          102 /opt/homebrew/bin/antigravity-cli
+          103 /usr/local/bin/antigravity_cli
+          104 /Users/example/bin/agy-helper
+          105 /Applications/Antigravity.app/Contents/MacOS/Antigravity
+        """
+        XCTAssertEqual(AntigravityCLIQuotaFetcher.parseAgyPIDs(output), [101, 102, 103])
+    }
+
+    func testResolvesExecutableFromOverrideBeforeKnownPaths() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("vibebar-agy-binary-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let binary = directory.appendingPathComponent("agy")
+        XCTAssertTrue(FileManager.default.createFile(atPath: binary.path, contents: Data()))
+        try FileManager.default.setAttributes(
+            [.posixPermissions: NSNumber(value: Int16(0o700))],
+            ofItemAtPath: binary.path
+        )
+
+        XCTAssertEqual(
+            AntigravityCLIQuotaFetcher.resolveBinary(
+                environment: ["ANTIGRAVITY_CLI_PATH": binary.path, "PATH": ""],
+                homeDirectory: directory.path
+            ),
+            binary.path
+        )
+    }
+
+    func testCompleteSharedQuotaRequiresAllFourLanes() {
+        func bucket(_ id: String) -> QuotaBucket {
+            QuotaBucket(id: id, title: id, shortLabel: id, usedPercent: 0)
+        }
+        let complete = [
+            bucket("gemini_five_hour"),
+            bucket("gemini_weekly"),
+            bucket("claude_gpt_five_hour"),
+            bucket("claude_gpt_weekly")
+        ]
+        XCTAssertTrue(AntigravityQuotaAdapter.hasCompleteSharedQuota(complete))
+        XCTAssertFalse(AntigravityQuotaAdapter.hasCompleteSharedQuota(
+            complete.filter { $0.id != "claude_gpt_five_hour" }
+        ))
+    }
+}

--- a/Tests/VibeBarCoreTests/AntigravityCLIQuotaFetcherTests.swift
+++ b/Tests/VibeBarCoreTests/AntigravityCLIQuotaFetcherTests.swift
@@ -49,4 +49,31 @@ final class AntigravityCLIQuotaFetcherTests: XCTestCase {
             complete.filter { $0.id != "claude_gpt_five_hour" }
         ))
     }
+
+    func testAgyErrorWinsWhenDesktopProbeIsAbsent() {
+        XCTAssertEqual(
+            AntigravityQuotaAdapter.preferredLocalSourceError(
+                desktopError: .noCredential,
+                cliError: .needsLogin
+            ),
+            .needsLogin
+        )
+        XCTAssertEqual(
+            AntigravityQuotaAdapter.preferredLocalSourceError(
+                desktopError: nil,
+                cliError: .network("loopback unavailable")
+            ),
+            .network("loopback unavailable")
+        )
+    }
+
+    func testSpecificDesktopErrorWinsOverAgyError() {
+        XCTAssertEqual(
+            AntigravityQuotaAdapter.preferredLocalSourceError(
+                desktopError: .parseFailure("desktop response changed"),
+                cliError: .needsLogin
+            ),
+            .parseFailure("desktop response changed")
+        )
+    }
 }

--- a/Tests/VibeBarCoreTests/AntigravityCLIQuotaFetcherTests.swift
+++ b/Tests/VibeBarCoreTests/AntigravityCLIQuotaFetcherTests.swift
@@ -76,4 +76,46 @@ final class AntigravityCLIQuotaFetcherTests: XCTestCase {
             .parseFailure("desktop response changed")
         )
     }
+
+    func testPartialDesktopAndAgyQuotasMergeWithoutLosingRicherLanes() {
+        func bucket(_ id: String, used: Double) -> QuotaBucket {
+            QuotaBucket(id: id, title: id, shortLabel: id, usedPercent: used)
+        }
+        let desktop = AccountQuota(
+            accountId: "antigravity",
+            tool: .antigravity,
+            buckets: [
+                bucket("gemini_five_hour", used: 10),
+                bucket("gemini_weekly", used: 20),
+                bucket("claude_gpt_weekly", used: 30)
+            ],
+            plan: "Desktop",
+            queriedAt: Date(timeIntervalSince1970: 10)
+        )
+        let agy = AccountQuota(
+            accountId: "antigravity",
+            tool: .antigravity,
+            buckets: [
+                bucket("gemini_weekly", used: 99),
+                bucket("claude_gpt_five_hour", used: 40)
+            ],
+            plan: "CLI",
+            queriedAt: Date(timeIntervalSince1970: 20)
+        )
+
+        let merged = AntigravityQuotaAdapter.mergingPartialQuota(
+            primary: desktop,
+            fallback: agy
+        )
+        XCTAssertEqual(merged.buckets.map(\.id), [
+            "gemini_five_hour",
+            "gemini_weekly",
+            "claude_gpt_five_hour",
+            "claude_gpt_weekly"
+        ])
+        XCTAssertEqual(merged.bucket(id: "gemini_weekly")?.usedPercent, 20)
+        XCTAssertEqual(merged.bucket(id: "claude_gpt_five_hour")?.usedPercent, 40)
+        XCTAssertEqual(merged.plan, "Desktop")
+        XCTAssertEqual(merged.queriedAt, Date(timeIntervalSince1970: 20))
+    }
 }

--- a/Tests/VibeBarCoreTests/CostHistoryStoreTests.swift
+++ b/Tests/VibeBarCoreTests/CostHistoryStoreTests.swift
@@ -2,6 +2,92 @@ import XCTest
 @testable import VibeBarCore
 
 final class CostHistoryStoreTests: XCTestCase {
+    func testAuthoritativeReplacementAllowsCursorHistoryToDecreaseAndRemoveDays() async throws {
+        let fileManager = FileManager.default
+        let directory = fileManager.temporaryDirectory
+            .appendingPathComponent("VibeBarCostHistoryCursorReplacement-\(UUID().uuidString)", isDirectory: true)
+        try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: directory) }
+
+        let utc = TimeZone(secondsFromGMT: 0)!
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = utc
+        let now = try XCTUnwrap(calendar.date(from: DateComponents(
+            year: 2026, month: 8, day: 17, hour: 12
+        )))
+        let today = calendar.startOfDay(for: now)
+        let yesterday = try XCTUnwrap(calendar.date(byAdding: .day, value: -1, to: today))
+        let store = CostHistoryStore(
+            fileURL: directory.appendingPathComponent("cost_history.json"),
+            timeZone: utc
+        )
+        let original = CostSnapshot(
+            tool: .cursor,
+            todayCostUSD: 9,
+            last7DaysCostUSD: 13,
+            last30DaysCostUSD: 13,
+            allTimeCostUSD: 13,
+            todayTokens: 900,
+            last7DaysTokens: 1_300,
+            last30DaysTokens: 1_300,
+            allTimeTokens: 1_300,
+            dailyHistory: [
+                DailyCostPoint(date: yesterday, costUSD: 4, totalTokens: 400),
+                DailyCostPoint(date: today, costUSD: 9, totalTokens: 900)
+            ],
+            heatmap: .empty(tool: .cursor),
+            modelBreakdowns: [],
+            jsonlFilesFound: 2,
+            updatedAt: now
+        )
+        _ = await store.replaceAndAugment(
+            original,
+            retentionDays: CostDataSettings.unlimitedRetentionDays
+        )
+        await store.mergeSeries(
+            [DailyCostPoint(date: yesterday, costUSD: 2, totalTokens: 200)],
+            tool: .codex,
+            retentionDays: CostDataSettings.unlimitedRetentionDays
+        )
+
+        let corrected = CostSnapshot(
+            tool: .cursor,
+            todayCostUSD: 3,
+            last7DaysCostUSD: 3,
+            last30DaysCostUSD: 3,
+            allTimeCostUSD: 3,
+            todayTokens: 300,
+            last7DaysTokens: 300,
+            last30DaysTokens: 300,
+            allTimeTokens: 300,
+            dailyHistory: [
+                DailyCostPoint(date: today, costUSD: 3, totalTokens: 300)
+            ],
+            heatmap: .empty(tool: .cursor),
+            modelBreakdowns: [],
+            jsonlFilesFound: 1,
+            updatedAt: now
+        )
+        let replaced = await store.replaceAndAugment(
+            corrected,
+            retentionDays: CostDataSettings.unlimitedRetentionDays
+        )
+
+        XCTAssertEqual(replaced.dailyHistory.count, 1)
+        XCTAssertEqual(replaced.todayCostUSD, 3, accuracy: 0.001)
+        XCTAssertEqual(replaced.todayTokens, 300)
+        XCTAssertEqual(replaced.allTimeCostUSD, 3, accuracy: 0.001)
+        XCTAssertEqual(replaced.allTimeTokens, 300)
+        let codex = await store.history(
+            for: .codex,
+            days: nil,
+            now: now,
+            retentionDays: CostDataSettings.unlimitedRetentionDays
+        )
+        XCTAssertEqual(codex.days.first?.costUSD, 2)
+        XCTAssertEqual(codex.days.first?.totalTokens, 200)
+    }
+
     func testMergeAndAugmentPreservesHourlyHistoryAndModelDetails() async throws {
         let fileManager = FileManager.default
         let directory = fileManager.temporaryDirectory

--- a/Tests/VibeBarCoreTests/CostSnapshotCacheTests.swift
+++ b/Tests/VibeBarCoreTests/CostSnapshotCacheTests.swift
@@ -1,0 +1,21 @@
+import XCTest
+@testable import VibeBarCore
+
+final class CostSnapshotCacheTests: XCTestCase {
+    func testRemovingCursorSnapshotPreventsFutureHydration() async throws {
+        let fileManager = FileManager.default
+        let directory = fileManager.temporaryDirectory
+            .appendingPathComponent("VibeBarCostSnapshotRemoval-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fileManager.removeItem(at: directory) }
+        let cache = CostSnapshotCache(directory: directory)
+        let snapshot = CostSnapshot.empty(tool: .cursor)
+
+        await cache.save(snapshot)
+        let hydrated = await cache.load(tool: .cursor)
+        XCTAssertNotNil(hydrated)
+
+        await cache.remove(tool: .cursor)
+        let removed = await cache.load(tool: .cursor)
+        XCTAssertNil(removed)
+    }
+}

--- a/Tests/VibeBarCoreTests/CostUsageServiceLedgerTests.swift
+++ b/Tests/VibeBarCoreTests/CostUsageServiceLedgerTests.swift
@@ -164,6 +164,25 @@ final class CostUsageServiceLedgerTests: XCTestCase {
         XCTAssertNil(afterEraseCost)
     }
 
+    @MainActor
+    func testPersistedCursorSnapshotHydratesAsDirectRemoteLastKnownData() {
+        let cursor = CostSnapshot.empty(tool: .cursor)
+        let codex = CostSnapshot.empty(tool: .codex)
+        let existingCursor = CostSnapshot.empty(
+            tool: .cursor,
+            now: Date(timeIntervalSince1970: 1)
+        )
+
+        let hydrated = CostUsageService.partitionPersistedSnapshots(
+            [.cursor: cursor, .codex: codex],
+            directRemote: [.cursor: existingCursor]
+        )
+
+        XCTAssertEqual(hydrated.local, [.codex: codex])
+        XCTAssertEqual(hydrated.directRemote, [.cursor: existingCursor])
+        XCTAssertNil(hydrated.local[.cursor], "Cursor must not be combined as a local scan")
+    }
+
     private func codexTokenCountLine(
         timestamp: Date,
         model: String,

--- a/Tests/VibeBarCoreTests/CursorCostUsageFetcherTests.swift
+++ b/Tests/VibeBarCoreTests/CursorCostUsageFetcherTests.swift
@@ -114,7 +114,7 @@ final class CursorCostUsageFetcherTests: XCTestCase {
         XCTAssertEqual(ledgerSummary.cacheCreation, 5)
         XCTAssertEqual(ledgerSummary.cacheRead, 10)
         let ledgerTools = try await ledger.providerStats(filter).map(\.tool)
-        XCTAssertEqual(ledgerTools, [.grok])
+        XCTAssertEqual(ledgerTools, [.cursor])
         _ = try await ledger.prepareForPricingRevision("cursor-authoritative-v1")
         let repricedSummary = try await ledger.summary(filter)
         XCTAssertEqual(repricedSummary.costMicros, ledgerSummary.costMicros)

--- a/Tests/VibeBarCoreTests/CursorCostUsageFetcherTests.swift
+++ b/Tests/VibeBarCoreTests/CursorCostUsageFetcherTests.swift
@@ -221,6 +221,63 @@ final class CursorCostUsageFetcherTests: XCTestCase {
         XCTAssertEqual(snapshot.allTimeCostUSD, 0.25, accuracy: 0.000_001)
     }
 
+    func testPartialFallbackFailurePublishesAndIngestsNothing() async throws {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [CursorCostStubURLProtocol.self]
+        let session = URLSession(configuration: configuration)
+        let now = Date(timeIntervalSince1970: 1_786_968_000)
+        let (ledger, directory) = try UsageLedgerFixtures.makeLedger("cursor-partial-slots")
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let working = MiscCookieResolver.Resolution(
+            slotID: UUID(),
+            header: "WorkosCursorSessionToken=working-slot",
+            sourceLabel: "Working"
+        )
+        let failed = MiscCookieResolver.Resolution(
+            slotID: UUID(),
+            header: "WorkosCursorSessionToken=failed-slot",
+            sourceLabel: "Failed"
+        )
+        let plan = CursorSessionResolutionPlan(preferred: nil, fallbacks: [working, failed])
+
+        CursorCostStubURLProtocol.handler = { request in
+            if request.value(forHTTPHeaderField: "Cookie") == failed.header {
+                return (500, Data())
+            }
+            return Self.response("""
+            {
+              "totalUsageEventsCount": 1,
+              "usageEventsDisplay": [{
+                "timestamp": "1786967900000",
+                "model": "composer-2.5",
+                "tokenUsage": {
+                  "inputTokens": 100,
+                  "outputTokens": 50,
+                  "cacheWriteTokens": 0,
+                  "cacheReadTokens": 0,
+                  "totalCents": 25
+                }
+              }]
+            }
+            """)
+        }
+
+        let outcome = await CursorCostUsageFetcher.fetch(
+            homeDirectory: "/Users/example",
+            now: now,
+            retentionDays: 30,
+            session: session,
+            resolutionPlan: plan,
+            eventSink: ledger
+        )
+        guard case .failed = outcome else {
+            return XCTFail("A partial account set must retain the previous complete snapshot")
+        }
+        let summary = try await ledger.summary(UsageLedgerFixtures.wideFilter(around: now))
+        XCTAssertEqual(summary.requests, 0)
+        XCTAssertEqual(summary.realTotalTokens, 0)
+    }
+
     private static func body(of request: URLRequest) throws -> Data {
         if let body = request.httpBody { return body }
         guard let stream = request.httpBodyStream else { return Data() }

--- a/Tests/VibeBarCoreTests/CursorParserEdgeCasesTests.swift
+++ b/Tests/VibeBarCoreTests/CursorParserEdgeCasesTests.swift
@@ -11,6 +11,7 @@ final class CursorParserEdgeCasesTests: XCTestCase {
         let json = """
         {
           "membershipType": "pro",
+          "billingCycleStart": "2026-05-01T00:00:00Z",
           "billingCycleEnd": "2026-06-01T00:00:00Z",
           "individualUsage": {
             "plan": {
@@ -32,10 +33,11 @@ final class CursorParserEdgeCasesTests: XCTestCase {
             now: now
         )
         XCTAssertEqual(snap.planName, "Pro")
-        XCTAssertEqual(snap.buckets.map(\.title), ["Weekly", "Weekly"])
+        XCTAssertEqual(snap.buckets.map(\.title), ["Monthly", "Monthly"])
         XCTAssertEqual(snap.buckets.map(\.groupTitle), ["Cursor Models", "Other Models"])
         let cursorModels = try XCTUnwrap(snap.buckets.first { $0.id == "models" })
         XCTAssertEqual(cursorModels.usedPercent, 0.20, accuracy: 0.001)
+        XCTAssertEqual(cursorModels.rawWindowSeconds, 2_678_400)
         let otherModels = try XCTUnwrap(snap.buckets.first { $0.id == "other_models" })
         XCTAssertEqual(otherModels.usedPercent, 0.52, accuracy: 0.001)
     }

--- a/Tests/VibeBarCoreTests/CursorServiceStatusTests.swift
+++ b/Tests/VibeBarCoreTests/CursorServiceStatusTests.swift
@@ -48,7 +48,7 @@ final class CursorServiceStatusTests: XCTestCase {
         XCTAssertEqual(snapshot.components.map(\.name), ["Cloud Agents", "IDE"])
         XCTAssertEqual(snapshot.recentIncidents.first?.name, "Cloud Agents degraded")
 
-        let spaceXAI = ServiceStatusSnapshot(
+        let grok = ServiceStatusSnapshot(
             tool: .grok,
             indicator: .none,
             description: "All systems operational",
@@ -60,17 +60,25 @@ final class CursorServiceStatusTests: XCTestCase {
                 status: .operational
             )],
             recentIncidents: []
-        ).mergingSubProvider(
-            snapshot,
-            groupID: "subprovider:cursor",
-            groupName: "Cursor"
         )
+        let spaceXAI = try XCTUnwrap(ServiceStatusSnapshot.mergedSpaceXAI(
+            grok: grok,
+            cursor: snapshot
+        ))
         XCTAssertEqual(spaceXAI.tool, .grok)
         XCTAssertEqual(spaceXAI.indicator, .minor)
         XCTAssertEqual(spaceXAI.groups.last?.name, "Cursor")
         XCTAssertTrue(spaceXAI.components(in: spaceXAI.groups.last).contains {
             $0.name == "Cloud Agents"
         })
+
+        let cursorOnly = try XCTUnwrap(ServiceStatusSnapshot.mergedSpaceXAI(
+            grok: nil,
+            cursor: snapshot
+        ))
+        XCTAssertEqual(cursorOnly.tool, .grok)
+        XCTAssertEqual(cursorOnly.indicator, .minor)
+        XCTAssertEqual(cursorOnly.groups.map(\.name), ["Cursor"])
     }
 }
 

--- a/Tests/VibeBarCoreTests/CursorServiceStatusTests.swift
+++ b/Tests/VibeBarCoreTests/CursorServiceStatusTests.swift
@@ -1,0 +1,101 @@
+import XCTest
+@testable import VibeBarCore
+
+final class CursorServiceStatusTests: XCTestCase {
+    override func tearDown() {
+        CursorStatusURLProtocol.handler = nil
+        super.tearDown()
+    }
+
+    func testFetchesCursorStatuspageGroupsAndIncidents() async throws {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [CursorStatusURLProtocol.self]
+        let session = URLSession(configuration: configuration)
+        CursorStatusURLProtocol.handler = { request in
+            switch request.url?.path {
+            case "/api/v2/summary.json":
+                return Data("""
+                {
+                  "page": {"id":"cursor","name":"Cursor","updated_at":"2026-08-17T08:00:00Z"},
+                  "status": {"indicator":"minor","description":"Degraded Performance"},
+                  "components": [
+                    {"id":"agents","name":"Agents","status":"degraded_performance","group_id":null,"group":true},
+                    {"id":"cloud","name":"Cloud Agents","status":"degraded_performance","group_id":"agents","group":false},
+                    {"id":"ide","name":"IDE","status":"operational","group_id":null,"group":false}
+                  ]
+                }
+                """.utf8)
+            case "/api/v2/incidents.json":
+                return Data("""
+                {"incidents":[{
+                  "id":"incident-1",
+                  "name":"Cloud Agents degraded",
+                  "impact":"minor",
+                  "created_at":"2026-08-17T07:30:00Z",
+                  "resolved_at":null,
+                  "shortlink":"https://status.cursor.com/incidents/incident-1"
+                }]}
+                """.utf8)
+            default:
+                throw URLError(.badURL)
+            }
+        }
+
+        let snapshot = try await ServiceStatusClient(session: session).fetch(tool: .cursor)
+        XCTAssertEqual(snapshot.tool, .cursor)
+        XCTAssertEqual(snapshot.indicator, .minor)
+        XCTAssertEqual(snapshot.groups, [ServiceComponentGroup(id: "agents", name: "Agents")])
+        XCTAssertEqual(snapshot.components.map(\.name), ["Cloud Agents", "IDE"])
+        XCTAssertEqual(snapshot.recentIncidents.first?.name, "Cloud Agents degraded")
+
+        let spaceXAI = ServiceStatusSnapshot(
+            tool: .grok,
+            indicator: .none,
+            description: "All systems operational",
+            updatedAt: Date(timeIntervalSince1970: 1_800_000_000),
+            groups: [],
+            components: [ServiceComponentSummary(
+                id: "grok-web",
+                name: "Grok Web",
+                status: .operational
+            )],
+            recentIncidents: []
+        ).mergingSubProvider(
+            snapshot,
+            groupID: "subprovider:cursor",
+            groupName: "Cursor"
+        )
+        XCTAssertEqual(spaceXAI.tool, .grok)
+        XCTAssertEqual(spaceXAI.indicator, .minor)
+        XCTAssertEqual(spaceXAI.groups.last?.name, "Cursor")
+        XCTAssertTrue(spaceXAI.components(in: spaceXAI.groups.last).contains {
+            $0.name == "Cloud Agents"
+        })
+    }
+}
+
+private final class CursorStatusURLProtocol: URLProtocol {
+    static var handler: ((URLRequest) throws -> Data)?
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        do {
+            let data = try XCTUnwrap(Self.handler)(request)
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "application/json"]
+            )!
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
+}

--- a/Tests/VibeBarCoreTests/CursorServiceStatusTests.swift
+++ b/Tests/VibeBarCoreTests/CursorServiceStatusTests.swift
@@ -83,6 +83,12 @@ final class CursorServiceStatusTests: XCTestCase {
         XCTAssertEqual(cursorOnly.tool, .grok)
         XCTAssertEqual(cursorOnly.indicator, .minor)
         XCTAssertEqual(cursorOnly.groups.map(\.name), ["Cursor"])
+
+        let googleFallback = ServiceStatusSnapshot.preferredGoogleAI(
+            gemini: nil,
+            antigravity: snapshot
+        )
+        XCTAssertEqual(googleFallback, snapshot)
     }
 }
 

--- a/Tests/VibeBarCoreTests/CursorServiceStatusTests.swift
+++ b/Tests/VibeBarCoreTests/CursorServiceStatusTests.swift
@@ -17,7 +17,7 @@ final class CursorServiceStatusTests: XCTestCase {
                 return Data("""
                 {
                   "page": {"id":"cursor","name":"Cursor","updated_at":"2026-08-17T08:00:00Z"},
-                  "status": {"indicator":"minor","description":"Degraded Performance"},
+                  "status": {"indicator":"none","description":"All Systems Operational"},
                   "components": [
                     {"id":"agents","name":"Agents","status":"degraded_performance","group_id":null,"group":true},
                     {"id":"cloud","name":"Cloud Agents","status":"degraded_performance","group_id":"agents","group":false},
@@ -43,7 +43,8 @@ final class CursorServiceStatusTests: XCTestCase {
 
         let snapshot = try await ServiceStatusClient(session: session).fetch(tool: .cursor)
         XCTAssertEqual(snapshot.tool, .cursor)
-        XCTAssertEqual(snapshot.indicator, .minor)
+        XCTAssertEqual(snapshot.indicator, .none)
+        XCTAssertEqual(snapshot.effectiveIndicator, .minor)
         XCTAssertEqual(snapshot.groups, [ServiceComponentGroup(id: "agents", name: "Agents")])
         XCTAssertEqual(snapshot.components.map(\.name), ["Cloud Agents", "IDE"])
         XCTAssertEqual(snapshot.recentIncidents.first?.name, "Cloud Agents degraded")
@@ -67,7 +68,10 @@ final class CursorServiceStatusTests: XCTestCase {
         ))
         XCTAssertEqual(spaceXAI.tool, .grok)
         XCTAssertEqual(spaceXAI.indicator, .minor)
-        XCTAssertEqual(spaceXAI.groups.last?.name, "Cursor")
+        XCTAssertEqual(spaceXAI.groups.map(\.name), ["Grok", "Cursor"])
+        XCTAssertTrue(spaceXAI.components(in: spaceXAI.groups.first).contains {
+            $0.name == "Grok Web"
+        })
         XCTAssertTrue(spaceXAI.components(in: spaceXAI.groups.last).contains {
             $0.name == "Cloud Agents"
         })

--- a/Tests/VibeBarCoreTests/EffectiveModelPricingTests.swift
+++ b/Tests/VibeBarCoreTests/EffectiveModelPricingTests.swift
@@ -1,0 +1,55 @@
+import XCTest
+@testable import VibeBarCore
+
+final class EffectiveModelPricingTests: XCTestCase {
+    func testFlattensResolvedRatesIntoPerMillionRows() throws {
+        let data = PricingDataSet(
+            schemaVersion: PricingDataSet.currentSchemaVersion,
+            updatedAt: "test",
+            calculationVersion: 1,
+            providers: .init(
+                codex: .init(models: [
+                    "gpt-test": .init(
+                        input: 2e-6,
+                        output: 8e-6,
+                        cacheRead: 0.2e-6,
+                        cacheCreation: 2.5e-6,
+                        thresholdTokens: 200_000,
+                        inputAboveThreshold: 4e-6,
+                        outputAboveThreshold: 12e-6,
+                        cacheReadAboveThreshold: 0.4e-6,
+                        cacheCreationAboveThreshold: 5e-6,
+                        fastMultiplier: 2,
+                        displayLabel: "GPT Test"
+                    )
+                ]),
+                claude: .init(models: [:]),
+                gemini: .init(models: [:]),
+                grok: .init(models: [:]),
+                antigravity: .init(models: [:])
+            )
+        )
+
+        let row = try XCTUnwrap(data.effectiveModelPrices.first)
+        XCTAssertEqual(row.id, "codex:gpt-test")
+        XCTAssertEqual(row.normalizedKey, "codex:gpt-test")
+        XCTAssertEqual(row.companyName, "OpenAI")
+        XCTAssertEqual(row.subProviderName, "ChatGPT Agentic")
+        XCTAssertEqual(row.inputPerMillion, 2, accuracy: 0.000_001)
+        XCTAssertEqual(row.outputPerMillion, 8, accuracy: 0.000_001)
+        XCTAssertEqual(row.cacheReadPerMillion ?? -1, 0.2, accuracy: 0.000_001)
+        XCTAssertEqual(row.cacheWritePerMillion ?? -1, 2.5, accuracy: 0.000_001)
+        XCTAssertEqual(row.inputAboveThresholdPerMillion ?? -1, 4, accuracy: 0.000_001)
+        XCTAssertEqual(row.fastMultiplier, 2)
+    }
+
+    func testEffectiveRowsFollowCanonicalSubProviderOrder() {
+        let rows = PricingHardcoded.fallback.effectiveModelPrices
+        XCTAssertFalse(rows.isEmpty)
+        let providers = rows.map(\.provider)
+        XCTAssertEqual(providers, providers.sorted {
+            PricingProviderFamily.allCases.firstIndex(of: $0)!
+                < PricingProviderFamily.allCases.firstIndex(of: $1)!
+        })
+    }
+}

--- a/Tests/VibeBarCoreTests/MenuBarFieldCatalogTests.swift
+++ b/Tests/VibeBarCoreTests/MenuBarFieldCatalogTests.swift
@@ -49,14 +49,14 @@ final class MenuBarFieldCatalogTests: XCTestCase {
         }
     }
 
-    func testCursorFieldsUseGroupedWeeklyLabels() throws {
+    func testCursorFieldsUseMonthlyModelsAndWeeklyBotLabels() throws {
         XCTAssertEqual(
             try XCTUnwrap(MenuBarFieldCatalog.field(id: "cursor.models")).title,
-            "Cursor Models · Weekly"
+            "Cursor Models · Monthly"
         )
         XCTAssertEqual(
             try XCTUnwrap(MenuBarFieldCatalog.field(id: "cursor.other_models")).title,
-            "Other Models · Weekly"
+            "Other Models · Monthly"
         )
         XCTAssertEqual(
             try XCTUnwrap(MenuBarFieldCatalog.field(id: "cursor.grok_bot_weekly")).title,

--- a/Tests/VibeBarCoreTests/PartialPrimaryToolTypeTests.swift
+++ b/Tests/VibeBarCoreTests/PartialPrimaryToolTypeTests.swift
@@ -93,11 +93,11 @@ final class PartialPrimaryToolTypeTests: XCTestCase {
         )
     }
 
-    func testUsageStatsFoldsCursorIntoGrok() {
-        XCTAssertEqual(ToolType.cursor.usageStatsRepresentative, .grok)
+    func testUsageStatsKeepsCursorAsSubProvider() {
+        XCTAssertEqual(ToolType.cursor.usageStatsRepresentative, .cursor)
         XCTAssertEqual(
             ToolType.usageStatsProviders,
-            [.codex, .claude, .gemini, .antigravity, .grok]
+            [.codex, .claude, .gemini, .antigravity, .grok, .cursor]
         )
     }
 

--- a/Tests/VibeBarCoreTests/PartialPrimaryToolTypeTests.swift
+++ b/Tests/VibeBarCoreTests/PartialPrimaryToolTypeTests.swift
@@ -56,9 +56,10 @@ final class PartialPrimaryToolTypeTests: XCTestCase {
         XCTAssertTrue(ToolType.cursor.supportsDedicatedCard)
         XCTAssertTrue(ToolType.cursor.isPartialPrimary)
         XCTAssertTrue(ToolType.cursor.supportsTokenCost)
-        XCTAssertFalse(ToolType.cursor.supportsStatusPage)
+        XCTAssertTrue(ToolType.cursor.supportsStatusPage)
         XCTAssertFalse(ToolType.cursor.isMiscPageProvider)
-        XCTAssertEqual(ToolType.cursor.productName, ToolType.grok.productName)
+        XCTAssertEqual(ToolType.cursor.productName, "Cursor")
+        XCTAssertEqual(ToolType.cursor.vendorName, ToolType.grok.vendorName)
         XCTAssertEqual(ToolType.cursor.toolName, "Cursor")
     }
 
@@ -74,7 +75,7 @@ final class PartialPrimaryToolTypeTests: XCTestCase {
     func testDedicatedStatusProvidersIncludeGrok() {
         XCTAssertEqual(
             ToolType.statusPageProviders,
-            [.codex, .claude, .gemini, .antigravity, .grok]
+            [.codex, .claude, .gemini, .antigravity, .grok, .cursor]
         )
     }
 

--- a/Tests/VibeBarCoreTests/PrimaryProviderRouteHealthTests.swift
+++ b/Tests/VibeBarCoreTests/PrimaryProviderRouteHealthTests.swift
@@ -31,7 +31,7 @@ final class PrimaryProviderRouteHealthTests: XCTestCase {
         XCTAssertTrue(result.output.contains("antigravity language_server_macos"))
     }
 
-    func testAntigravityCachedDataIsHealthyWhileLSPIsOffline() {
+    func testAntigravityCachedDataIsMarkedStaleWithoutLiveSource() {
         let now = Date(timeIntervalSince1970: 1_700_000_000)
         let health = PrimaryProviderRouteHealthChecker.antigravityLocalProbeHealth(
             languageServerRunning: false,
@@ -39,9 +39,22 @@ final class PrimaryProviderRouteHealthTests: XCTestCase {
             now: now
         )
 
-        XCTAssertEqual(health.status, .ok)
-        XCTAssertEqual(health.detail, "Local data available; LSP offline")
+        XCTAssertEqual(health.status, .failed)
+        XCTAssertEqual(health.detail, "Cached data only; live quota unavailable")
         XCTAssertEqual(health.checkedAt, now)
+    }
+
+    func testAntigravityCLIAvailabilityKeepsLiveRouteHealthy() {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let health = PrimaryProviderRouteHealthChecker.antigravityLocalProbeHealth(
+            languageServerRunning: false,
+            cliAvailable: true,
+            hasLocalData: true,
+            now: now
+        )
+
+        XCTAssertEqual(health.status, .ok)
+        XCTAssertEqual(health.detail, "agy CLI available")
     }
 
     func testAntigravityWithoutLSPOrLocalDataNeedsSetup() {

--- a/Tests/VibeBarCoreTests/ProviderPlanDisplayTests.swift
+++ b/Tests/VibeBarCoreTests/ProviderPlanDisplayTests.swift
@@ -99,12 +99,29 @@ final class ProviderPlanDisplayTests: XCTestCase {
             XCTAssertEqual(tool.menuTitle, tool.productName,
                            "menuTitle should equal productName for primary tool \(tool)")
         }
-        // Both Gemini Web and AntiGravity roll up to the Gemini product
-        // under the Google vendor — the dual page relies on this.
+        // Related tools share their L1 owner but remain distinct L2
+        // SubProviders inside the combined owner card.
         XCTAssertEqual(ToolType.gemini.vendorName, ToolType.antigravity.vendorName)
-        XCTAssertEqual(ToolType.gemini.productName, ToolType.antigravity.productName)
-        XCTAssertEqual(ToolType.grok.productName, ToolType.cursor.productName)
-        XCTAssertNotEqual(ToolType.grok.vendorName, ToolType.cursor.vendorName)
+        XCTAssertNotEqual(ToolType.gemini.productName, ToolType.antigravity.productName)
+        XCTAssertNotEqual(ToolType.grok.productName, ToolType.cursor.productName)
+        XCTAssertEqual(ToolType.grok.vendorName, ToolType.cursor.vendorName)
+        XCTAssertEqual(ToolType.codex.vendorName, "OpenAI")
+        XCTAssertEqual(ToolType.claude.vendorName, "Anthropic")
+        XCTAssertEqual(ToolType.gemini.vendorName, "Google AI")
+        XCTAssertEqual(ToolType.grok.vendorName, "SpaceXAI")
+    }
+
+    func testQuotaSubProviderNamesUseOneCanonicalLevel() {
+        XCTAssertEqual(ToolType.codex.quotaSubProviderName(), "ChatGPT Agentic")
+        XCTAssertEqual(ToolType.claude.quotaSubProviderName(), "Claude")
+        XCTAssertEqual(ToolType.gemini.quotaSubProviderName(), "Gemini Web")
+        XCTAssertEqual(ToolType.antigravity.quotaSubProviderName(), "AntiGravity")
+        XCTAssertEqual(ToolType.grok.quotaSubProviderName(), "Grok")
+        XCTAssertEqual(ToolType.cursor.quotaSubProviderName(), "Cursor")
+        XCTAssertEqual(
+            ToolType.cursor.quotaSubProviderName(bucketID: "grok_bot_weekly"),
+            "Grok Bot"
+        )
     }
 
     private func makeJWT(payload: [String: Any]) throws -> String {

--- a/Tests/VibeBarCoreTests/QuotaRefreshSchedulerTests.swift
+++ b/Tests/VibeBarCoreTests/QuotaRefreshSchedulerTests.swift
@@ -239,6 +239,38 @@ final class QuotaRefreshSchedulerTests: XCTestCase {
         }
         XCTAssertNotNil(service.cachedQuota(for: other.id))
     }
+
+    func testBoundaryRefreshRequeuesAccountCompletedEarlierInActiveWalk() async {
+        let first = AccountIdentity(id: "finished-a", tool: .claude, source: .oauthCLI)
+        let blocking = AccountIdentity(id: "blocking-b", tool: .gemini, source: .webCookie)
+        let counter = CountingQuotaAdapter(tool: .claude)
+        let gate = QuotaRefreshGate()
+        let service = QuotaService(
+            adapters: [
+                .claude: counter,
+                .gemini: GatedQuotaAdapter(tool: .gemini, gate: gate)
+            ],
+            mockProvider: { false }
+        )
+        let scheduler = QuotaRefreshScheduler(
+            service: service,
+            accountsProvider: { [first, blocking] },
+            intervalProvider: { 600 }
+        )
+
+        scheduler.triggerRefresh()
+        await gate.waitUntilStarted()
+        XCTAssertEqual(counter.fetchCount, 1)
+
+        scheduler.triggerBoundaryRefresh(accountIds: [first.id])
+        await gate.release()
+        for _ in 0..<40 {
+            if counter.fetchCount == 2 { break }
+            await Task.yield()
+        }
+
+        XCTAssertEqual(counter.fetchCount, 2)
+    }
 }
 
 private final class SequenceAdapter: QuotaAdapter, @unchecked Sendable {
@@ -258,5 +290,63 @@ private final class SequenceAdapter: QuotaAdapter, @unchecked Sendable {
         case .failure(let error):
             throw error
         }
+    }
+}
+
+private final class CountingQuotaAdapter: QuotaAdapter, @unchecked Sendable {
+    let tool: ToolType
+    private let lock = NSLock()
+    private var count = 0
+
+    init(tool: ToolType) {
+        self.tool = tool
+    }
+
+    var fetchCount: Int {
+        lock.withLock { count }
+    }
+
+    func fetch(for account: AccountIdentity) async throws -> AccountQuota {
+        lock.withLock { count += 1 }
+        return AccountQuota(accountId: account.id, tool: tool, buckets: [], queriedAt: Date())
+    }
+}
+
+private actor QuotaRefreshGate {
+    private var started = false
+    private var startWaiters: [CheckedContinuation<Void, Never>] = []
+    private var releaseContinuation: CheckedContinuation<Void, Never>?
+
+    func waitUntilStarted() async {
+        if started { return }
+        await withCheckedContinuation { startWaiters.append($0) }
+    }
+
+    func block() async {
+        started = true
+        let waiters = startWaiters
+        startWaiters = []
+        for waiter in waiters { waiter.resume() }
+        await withCheckedContinuation { releaseContinuation = $0 }
+    }
+
+    func release() {
+        releaseContinuation?.resume()
+        releaseContinuation = nil
+    }
+}
+
+private final class GatedQuotaAdapter: QuotaAdapter, @unchecked Sendable {
+    let tool: ToolType
+    private let gate: QuotaRefreshGate
+
+    init(tool: ToolType, gate: QuotaRefreshGate) {
+        self.tool = tool
+        self.gate = gate
+    }
+
+    func fetch(for account: AccountIdentity) async throws -> AccountQuota {
+        await gate.block()
+        return AccountQuota(accountId: account.id, tool: tool, buckets: [], queriedAt: Date())
     }
 }

--- a/Tests/VibeBarCoreTests/QuotaRefreshSchedulerTests.swift
+++ b/Tests/VibeBarCoreTests/QuotaRefreshSchedulerTests.swift
@@ -178,6 +178,7 @@ final class QuotaRefreshSchedulerTests: XCTestCase {
         )
 
         XCTAssertTrue(scheduler.triggerRefreshForStaleCacheIfNeeded(now: now))
+        XCTAssertFalse(scheduler.triggerRefreshForStaleCacheIfNeeded(now: now))
         for _ in 0..<20 {
             if service.cachedQuota(for: account.id)?.buckets.first?.resetAt == refreshed.resetAt {
                 break

--- a/Tests/VibeBarCoreTests/QuotaRefreshSchedulerTests.swift
+++ b/Tests/VibeBarCoreTests/QuotaRefreshSchedulerTests.swift
@@ -107,6 +107,32 @@ final class QuotaRefreshSchedulerTests: XCTestCase {
         XCTAssertEqual(service.lastErrorByAccount[account.id], .needsLogin)
         XCTAssertEqual(fallback.buckets.count, 1)
     }
+
+    func testExpiredResetMakesFreshCacheRefreshable() async {
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let account = AccountIdentity(id: "expired-reset", tool: .antigravity, source: .localProbe)
+        let service = QuotaService(
+            adapters: [.antigravity: SequenceAdapter(tool: .antigravity, results: [
+                .success(AccountQuota(
+                    accountId: account.id,
+                    tool: .antigravity,
+                    buckets: [QuotaBucket(
+                        id: "gemini_five_hour",
+                        title: "5 Hours",
+                        shortLabel: "5 Hours",
+                        usedPercent: 2,
+                        resetAt: now.addingTimeInterval(-1),
+                        rawWindowSeconds: 18_000
+                    )],
+                    queriedAt: now
+                ))
+            ])],
+            mockProvider: { false }
+        )
+
+        _ = await service.refresh(account)
+        XCTAssertTrue(service.needsRefresh(accountId: account.id, now: now, maxAge: 600))
+    }
 }
 
 private final class SequenceAdapter: QuotaAdapter, @unchecked Sendable {

--- a/Tests/VibeBarCoreTests/QuotaRefreshSchedulerTests.swift
+++ b/Tests/VibeBarCoreTests/QuotaRefreshSchedulerTests.swift
@@ -133,6 +133,63 @@ final class QuotaRefreshSchedulerTests: XCTestCase {
         _ = await service.refresh(account)
         XCTAssertTrue(service.needsRefresh(accountId: account.id, now: now, maxAge: 600))
     }
+
+    func testPopoverStaleCachePathActuallyRefreshesExpiredReset() async throws {
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let account = AccountIdentity(id: "expired-page", tool: .antigravity, source: .localProbe)
+        let expired = QuotaBucket(
+            id: "gemini_five_hour",
+            title: "5 Hours",
+            shortLabel: "5 Hours",
+            usedPercent: 2,
+            resetAt: now.addingTimeInterval(-1),
+            rawWindowSeconds: 18_000
+        )
+        let refreshed = QuotaBucket(
+            id: "gemini_five_hour",
+            title: "5 Hours",
+            shortLabel: "5 Hours",
+            usedPercent: 0,
+            resetAt: now.addingTimeInterval(18_000),
+            rawWindowSeconds: 18_000
+        )
+        let service = QuotaService(
+            adapters: [.antigravity: SequenceAdapter(tool: .antigravity, results: [
+                .success(AccountQuota(
+                    accountId: account.id,
+                    tool: .antigravity,
+                    buckets: [expired],
+                    queriedAt: now
+                )),
+                .success(AccountQuota(
+                    accountId: account.id,
+                    tool: .antigravity,
+                    buckets: [refreshed],
+                    queriedAt: now
+                ))
+            ])],
+            mockProvider: { false }
+        )
+        _ = await service.refresh(account)
+        let scheduler = QuotaRefreshScheduler(
+            service: service,
+            accountsProvider: { [account] },
+            intervalProvider: { 600 }
+        )
+
+        XCTAssertTrue(scheduler.triggerRefreshForStaleCacheIfNeeded(now: now))
+        for _ in 0..<20 {
+            if service.cachedQuota(for: account.id)?.buckets.first?.resetAt == refreshed.resetAt {
+                break
+            }
+            await Task.yield()
+        }
+        XCTAssertEqual(
+            service.cachedQuota(for: account.id)?.buckets.first?.resetAt,
+            refreshed.resetAt
+        )
+        XCTAssertFalse(scheduler.triggerRefreshForStaleCacheIfNeeded(now: now))
+    }
 }
 
 private final class SequenceAdapter: QuotaAdapter, @unchecked Sendable {

--- a/Tests/VibeBarCoreTests/QuotaRefreshSchedulerTests.swift
+++ b/Tests/VibeBarCoreTests/QuotaRefreshSchedulerTests.swift
@@ -191,6 +191,54 @@ final class QuotaRefreshSchedulerTests: XCTestCase {
         )
         XCTAssertFalse(scheduler.triggerRefreshForStaleCacheIfNeeded(now: now))
     }
+
+    func testFullRefreshQueuesAccountsMissingFromActiveStaleWalk() async {
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let stale = AccountIdentity(id: "stale-a", tool: .antigravity, source: .localProbe)
+        let other = AccountIdentity(id: "full-b", tool: .claude, source: .oauthCLI)
+        func quota(_ account: AccountIdentity, reset: Date?) -> AccountQuota {
+            AccountQuota(
+                accountId: account.id,
+                tool: account.tool,
+                buckets: [QuotaBucket(
+                    id: "weekly",
+                    title: "Weekly",
+                    shortLabel: "Weekly",
+                    usedPercent: 1,
+                    resetAt: reset
+                )],
+                queriedAt: now
+            )
+        }
+        let service = QuotaService(
+            adapters: [
+                .antigravity: SequenceAdapter(tool: .antigravity, results: [
+                    .success(quota(stale, reset: now.addingTimeInterval(-1))),
+                    .success(quota(stale, reset: now.addingTimeInterval(600)))
+                ]),
+                .claude: SequenceAdapter(tool: .claude, results: [
+                    .success(quota(other, reset: now.addingTimeInterval(600)))
+                ])
+            ],
+            mockProvider: { false }
+        )
+        _ = await service.refresh(stale)
+        var accounts = [stale]
+        let scheduler = QuotaRefreshScheduler(
+            service: service,
+            accountsProvider: { accounts },
+            intervalProvider: { 600 }
+        )
+
+        XCTAssertTrue(scheduler.triggerRefreshForStaleCacheIfNeeded(now: now))
+        accounts = [stale, other]
+        scheduler.triggerRefresh()
+        for _ in 0..<40 {
+            if service.cachedQuota(for: other.id) != nil { break }
+            await Task.yield()
+        }
+        XCTAssertNotNil(service.cachedQuota(for: other.id))
+    }
 }
 
 private final class SequenceAdapter: QuotaAdapter, @unchecked Sendable {

--- a/Tests/VibeBarCoreTests/UsageEventLedgerTests.swift
+++ b/Tests/VibeBarCoreTests/UsageEventLedgerTests.swift
@@ -265,6 +265,39 @@ final class UsageEventLedgerTests: XCTestCase {
         XCTAssertEqual(String(cString: sqlite3_column_text(query, 0)), "2026-07-17")
     }
 
+    func testCursorToolMigrationRecognizesFullyRolledCursorModelFamilies() throws {
+        var database: OpaquePointer?
+        XCTAssertEqual(sqlite3_open(":memory:", &database), SQLITE_OK)
+        let db = try XCTUnwrap(database)
+        defer { sqlite3_close_v2(db) }
+        XCTAssertEqual(sqlite3_exec(db, """
+            CREATE TABLE ledger_meta(key TEXT PRIMARY KEY, value TEXT);
+            CREATE TABLE usage_events(
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                tool TEXT NOT NULL,
+                source_key TEXT,
+                dedupe_key TEXT NOT NULL UNIQUE
+            );
+            CREATE TABLE usage_daily_rollups(tool TEXT NOT NULL, model TEXT NOT NULL);
+            INSERT INTO ledger_meta VALUES('detail_floor_day:grok', '2026-07-17');
+            INSERT INTO usage_daily_rollups VALUES('grok', 'cursor-grok-4.6-high-fast');
+            """, nil, nil, nil), SQLITE_OK)
+
+        XCTAssertTrue(UsageEventLedger.migrateCursorToolRows(db))
+        var statement: OpaquePointer?
+        XCTAssertEqual(sqlite3_prepare_v2(
+            db,
+            "SELECT value FROM ledger_meta WHERE key = 'detail_floor_day:cursor'",
+            -1,
+            &statement,
+            nil
+        ), SQLITE_OK)
+        let query = try XCTUnwrap(statement)
+        defer { sqlite3_finalize(query) }
+        XCTAssertEqual(sqlite3_step(query), SQLITE_ROW)
+        XCTAssertEqual(String(cString: sqlite3_column_text(query, 0)), "2026-07-17")
+    }
+
     /// A second batch carrying the same `(mtime, size)` fingerprint is
     /// skipped wholesale — proven by handing it *more* events than the
     /// first and watching the extra one never land.

--- a/Tests/VibeBarCoreTests/UsageEventLedgerTests.swift
+++ b/Tests/VibeBarCoreTests/UsageEventLedgerTests.swift
@@ -137,6 +137,7 @@ final class UsageEventLedgerTests: XCTestCase {
         XCTAssertEqual(sqlite3_exec(db, """
             CREATE TABLE ledger_meta(key TEXT PRIMARY KEY, value TEXT);
             CREATE TABLE usage_events(tool TEXT NOT NULL, source_key TEXT);
+            INSERT INTO ledger_meta VALUES('detail_floor_day:grok', '2026-07-17');
             INSERT INTO usage_events VALUES('grok', 'cursor-event-v1-fixture');
             INSERT INTO usage_events VALUES('grok', 'grok-session-fixture');
             """, nil, nil, nil), SQLITE_OK)
@@ -157,6 +158,19 @@ final class UsageEventLedgerTests: XCTestCase {
             tools.append(String(cString: sqlite3_column_text(query, 0)))
         }
         XCTAssertEqual(tools, ["cursor", "grok"])
+
+        var floorStatement: OpaquePointer?
+        XCTAssertEqual(sqlite3_prepare_v2(
+            db,
+            "SELECT value FROM ledger_meta WHERE key = 'detail_floor_day:cursor'",
+            -1,
+            &floorStatement,
+            nil
+        ), SQLITE_OK)
+        let floorQuery = try XCTUnwrap(floorStatement)
+        defer { sqlite3_finalize(floorQuery) }
+        XCTAssertEqual(sqlite3_step(floorQuery), SQLITE_ROW)
+        XCTAssertEqual(String(cString: sqlite3_column_text(floorQuery, 0)), "2026-07-17")
     }
 
     /// A second batch carrying the same `(mtime, size)` fingerprint is

--- a/Tests/VibeBarCoreTests/UsageEventLedgerTests.swift
+++ b/Tests/VibeBarCoreTests/UsageEventLedgerTests.swift
@@ -231,6 +231,40 @@ final class UsageEventLedgerTests: XCTestCase {
         XCTAssertEqual(sqlite3_step(query), SQLITE_DONE)
     }
 
+    func testCursorToolMigrationUsesSnapshotEvidenceForFullyRolledHistory() throws {
+        var database: OpaquePointer?
+        XCTAssertEqual(sqlite3_open(":memory:", &database), SQLITE_OK)
+        let db = try XCTUnwrap(database)
+        defer { sqlite3_close_v2(db) }
+        XCTAssertEqual(sqlite3_exec(db, """
+            CREATE TABLE ledger_meta(key TEXT PRIMARY KEY, value TEXT);
+            CREATE TABLE usage_events(
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                tool TEXT NOT NULL,
+                source_key TEXT,
+                dedupe_key TEXT NOT NULL UNIQUE
+            );
+            INSERT INTO ledger_meta VALUES('detail_floor_day:grok', '2026-07-17');
+            """, nil, nil, nil), SQLITE_OK)
+
+        XCTAssertTrue(UsageEventLedger.migrateCursorToolRows(
+            db,
+            legacyCursorEvidence: true
+        ))
+        var statement: OpaquePointer?
+        XCTAssertEqual(sqlite3_prepare_v2(
+            db,
+            "SELECT value FROM ledger_meta WHERE key = 'detail_floor_day:cursor'",
+            -1,
+            &statement,
+            nil
+        ), SQLITE_OK)
+        let query = try XCTUnwrap(statement)
+        defer { sqlite3_finalize(query) }
+        XCTAssertEqual(sqlite3_step(query), SQLITE_ROW)
+        XCTAssertEqual(String(cString: sqlite3_column_text(query, 0)), "2026-07-17")
+    }
+
     /// A second batch carrying the same `(mtime, size)` fingerprint is
     /// skipped wholesale — proven by handing it *more* events than the
     /// first and watching the extra one never land.

--- a/Tests/VibeBarCoreTests/UsageEventLedgerTests.swift
+++ b/Tests/VibeBarCoreTests/UsageEventLedgerTests.swift
@@ -136,10 +136,17 @@ final class UsageEventLedgerTests: XCTestCase {
         defer { sqlite3_close_v2(db) }
         XCTAssertEqual(sqlite3_exec(db, """
             CREATE TABLE ledger_meta(key TEXT PRIMARY KEY, value TEXT);
-            CREATE TABLE usage_events(tool TEXT NOT NULL, source_key TEXT);
+            CREATE TABLE usage_events(
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                tool TEXT NOT NULL,
+                source_key TEXT,
+                dedupe_key TEXT NOT NULL UNIQUE
+            );
             INSERT INTO ledger_meta VALUES('detail_floor_day:grok', '2026-07-17');
-            INSERT INTO usage_events VALUES('grok', 'cursor-event-v1-fixture');
-            INSERT INTO usage_events VALUES('grok', 'grok-session-fixture');
+            INSERT INTO usage_events(tool, source_key, dedupe_key)
+                VALUES('grok', 'cursor-event-v1-fixture', 'f:legacy-cursor');
+            INSERT INTO usage_events(tool, source_key, dedupe_key)
+                VALUES('grok', 'grok-session-fixture', 'f:grok');
             """, nil, nil, nil), SQLITE_OK)
 
         XCTAssertTrue(UsageEventLedger.migrateCursorToolRows(db))
@@ -158,6 +165,25 @@ final class UsageEventLedgerTests: XCTestCase {
             tools.append(String(cString: sqlite3_column_text(query, 0)))
         }
         XCTAssertEqual(tools, ["cursor", "grok"])
+
+        var dedupeStatement: OpaquePointer?
+        XCTAssertEqual(sqlite3_prepare_v2(
+            db,
+            "SELECT dedupe_key FROM usage_events WHERE tool = 'cursor'",
+            -1,
+            &dedupeStatement,
+            nil
+        ), SQLITE_OK)
+        let dedupeQuery = try XCTUnwrap(dedupeStatement)
+        defer { sqlite3_finalize(dedupeQuery) }
+        XCTAssertEqual(sqlite3_step(dedupeQuery), SQLITE_ROW)
+        XCTAssertEqual(
+            String(cString: sqlite3_column_text(dedupeQuery, 0)),
+            PrivacyPreservingHash.fileComponent(
+                prefix: "cursor-ledger-v1",
+                rawValue: "cursor-event-v1-fixture"
+            )
+        )
 
         var floorStatement: OpaquePointer?
         XCTAssertEqual(sqlite3_prepare_v2(
@@ -180,9 +206,15 @@ final class UsageEventLedgerTests: XCTestCase {
         defer { sqlite3_close_v2(db) }
         XCTAssertEqual(sqlite3_exec(db, """
             CREATE TABLE ledger_meta(key TEXT PRIMARY KEY, value TEXT);
-            CREATE TABLE usage_events(tool TEXT NOT NULL, source_key TEXT);
+            CREATE TABLE usage_events(
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                tool TEXT NOT NULL,
+                source_key TEXT,
+                dedupe_key TEXT NOT NULL UNIQUE
+            );
             INSERT INTO ledger_meta VALUES('detail_floor_day:grok', '2026-07-17');
-            INSERT INTO usage_events VALUES('grok', 'grok-session-fixture');
+            INSERT INTO usage_events(tool, source_key, dedupe_key)
+                VALUES('grok', 'grok-session-fixture', 'f:grok');
             """, nil, nil, nil), SQLITE_OK)
 
         XCTAssertTrue(UsageEventLedger.migrateCursorToolRows(db))

--- a/Tests/VibeBarCoreTests/UsageEventLedgerTests.swift
+++ b/Tests/VibeBarCoreTests/UsageEventLedgerTests.swift
@@ -173,6 +173,32 @@ final class UsageEventLedgerTests: XCTestCase {
         XCTAssertEqual(String(cString: sqlite3_column_text(floorQuery, 0)), "2026-07-17")
     }
 
+    func testCursorToolMigrationDoesNotInventFloorWithoutCursorEvidence() throws {
+        var database: OpaquePointer?
+        XCTAssertEqual(sqlite3_open(":memory:", &database), SQLITE_OK)
+        let db = try XCTUnwrap(database)
+        defer { sqlite3_close_v2(db) }
+        XCTAssertEqual(sqlite3_exec(db, """
+            CREATE TABLE ledger_meta(key TEXT PRIMARY KEY, value TEXT);
+            CREATE TABLE usage_events(tool TEXT NOT NULL, source_key TEXT);
+            INSERT INTO ledger_meta VALUES('detail_floor_day:grok', '2026-07-17');
+            INSERT INTO usage_events VALUES('grok', 'grok-session-fixture');
+            """, nil, nil, nil), SQLITE_OK)
+
+        XCTAssertTrue(UsageEventLedger.migrateCursorToolRows(db))
+        var statement: OpaquePointer?
+        XCTAssertEqual(sqlite3_prepare_v2(
+            db,
+            "SELECT value FROM ledger_meta WHERE key = 'detail_floor_day:cursor'",
+            -1,
+            &statement,
+            nil
+        ), SQLITE_OK)
+        let query = try XCTUnwrap(statement)
+        defer { sqlite3_finalize(query) }
+        XCTAssertEqual(sqlite3_step(query), SQLITE_DONE)
+    }
+
     /// A second batch carrying the same `(mtime, size)` fingerprint is
     /// skipped wholesale — proven by handing it *more* events than the
     /// first and watching the extra one never land.

--- a/Tests/VibeBarCoreTests/UsageEventLedgerTests.swift
+++ b/Tests/VibeBarCoreTests/UsageEventLedgerTests.swift
@@ -129,6 +129,36 @@ final class UsageEventLedgerTests: XCTestCase {
         XCTAssertEqual(sqlite3_step(statement), SQLITE_ROW)
     }
 
+    func testCursorToolMigrationUpdatesOnlyIdentifiableDetailRowsInPlace() throws {
+        var database: OpaquePointer?
+        XCTAssertEqual(sqlite3_open(":memory:", &database), SQLITE_OK)
+        let db = try XCTUnwrap(database)
+        defer { sqlite3_close_v2(db) }
+        XCTAssertEqual(sqlite3_exec(db, """
+            CREATE TABLE ledger_meta(key TEXT PRIMARY KEY, value TEXT);
+            CREATE TABLE usage_events(tool TEXT NOT NULL, source_key TEXT);
+            INSERT INTO usage_events VALUES('grok', 'cursor-event-v1-fixture');
+            INSERT INTO usage_events VALUES('grok', 'grok-session-fixture');
+            """, nil, nil, nil), SQLITE_OK)
+
+        XCTAssertTrue(UsageEventLedger.migrateCursorToolRows(db))
+        var statement: OpaquePointer?
+        XCTAssertEqual(sqlite3_prepare_v2(
+            db,
+            "SELECT tool FROM usage_events ORDER BY source_key",
+            -1,
+            &statement,
+            nil
+        ), SQLITE_OK)
+        let query = try XCTUnwrap(statement)
+        defer { sqlite3_finalize(query) }
+        var tools: [String] = []
+        while sqlite3_step(query) == SQLITE_ROW {
+            tools.append(String(cString: sqlite3_column_text(query, 0)))
+        }
+        XCTAssertEqual(tools, ["cursor", "grok"])
+    }
+
     /// A second batch carrying the same `(mtime, size)` fingerprint is
     /// skipped wholesale — proven by handing it *more* events than the
     /// first and watching the extra one never land.

--- a/Tests/VibeBarCoreTests/UsageEventLedgerTests.swift
+++ b/Tests/VibeBarCoreTests/UsageEventLedgerTests.swift
@@ -278,9 +278,26 @@ final class UsageEventLedgerTests: XCTestCase {
                 source_key TEXT,
                 dedupe_key TEXT NOT NULL UNIQUE
             );
-            CREATE TABLE usage_daily_rollups(tool TEXT NOT NULL, model TEXT NOT NULL);
+            CREATE TABLE usage_daily_rollups(
+                day TEXT NOT NULL,
+                tool TEXT NOT NULL,
+                model TEXT NOT NULL,
+                requests INTEGER NOT NULL DEFAULT 0,
+                fresh_input INTEGER NOT NULL DEFAULT 0,
+                output INTEGER NOT NULL DEFAULT 0,
+                cache_read INTEGER NOT NULL DEFAULT 0,
+                cache_creation INTEGER NOT NULL DEFAULT 0,
+                cost_micros INTEGER NOT NULL DEFAULT 0,
+                unpriced INTEGER NOT NULL DEFAULT 0,
+                PRIMARY KEY(day, tool, model)
+            );
             INSERT INTO ledger_meta VALUES('detail_floor_day:grok', '2026-07-17');
-            INSERT INTO usage_daily_rollups VALUES('grok', 'cursor-grok-4.6-high-fast');
+            INSERT INTO usage_daily_rollups
+                VALUES('2026-07-01', 'grok', 'cursor-grok-4.6-high-fast', 3, 30, 6, 4, 2, 90, 1);
+            INSERT INTO usage_daily_rollups
+                VALUES('2026-07-01', 'cursor', 'cursor-grok-4.6-high-fast', 2, 20, 4, 3, 1, 60, 0);
+            INSERT INTO usage_daily_rollups
+                VALUES('2026-07-01', 'grok', 'grok-4', 7, 70, 14, 8, 3, 210, 0);
             """, nil, nil, nil), SQLITE_OK)
 
         XCTAssertTrue(UsageEventLedger.migrateCursorToolRows(db))
@@ -296,6 +313,97 @@ final class UsageEventLedgerTests: XCTestCase {
         defer { sqlite3_finalize(query) }
         XCTAssertEqual(sqlite3_step(query), SQLITE_ROW)
         XCTAssertEqual(String(cString: sqlite3_column_text(query, 0)), "2026-07-17")
+
+        var rollupStatement: OpaquePointer?
+        XCTAssertEqual(sqlite3_prepare_v2(
+            db,
+            "SELECT tool, model, requests, cost_micros, unpriced FROM usage_daily_rollups ORDER BY tool, model",
+            -1,
+            &rollupStatement,
+            nil
+        ), SQLITE_OK)
+        let rollupQuery = try XCTUnwrap(rollupStatement)
+        defer { sqlite3_finalize(rollupQuery) }
+        var rollups: [(String, String, Int, Int, Int)] = []
+        while sqlite3_step(rollupQuery) == SQLITE_ROW {
+            rollups.append((
+                String(cString: sqlite3_column_text(rollupQuery, 0)),
+                String(cString: sqlite3_column_text(rollupQuery, 1)),
+                Int(sqlite3_column_int(rollupQuery, 2)),
+                Int(sqlite3_column_int(rollupQuery, 3)),
+                Int(sqlite3_column_int(rollupQuery, 4))
+            ))
+        }
+        XCTAssertEqual(rollups.count, 2)
+        XCTAssertEqual(rollups[0].0, "cursor")
+        XCTAssertEqual(rollups[0].1, "cursor-grok-4.6-high-fast")
+        XCTAssertEqual(rollups[0].2, 5)
+        XCTAssertEqual(rollups[0].3, 150)
+        XCTAssertEqual(rollups[0].4, 1)
+        XCTAssertEqual(rollups[1].0, "grok")
+        XCTAssertEqual(rollups[1].1, "grok-4")
+        XCTAssertEqual(rollups[1].2, 7)
+    }
+
+    func testCursorRollupMigrationRunsAfterEarlierDetailMigrationMarker() throws {
+        var database: OpaquePointer?
+        XCTAssertEqual(sqlite3_open(":memory:", &database), SQLITE_OK)
+        let db = try XCTUnwrap(database)
+        defer { sqlite3_close_v2(db) }
+        XCTAssertEqual(sqlite3_exec(db, """
+            CREATE TABLE ledger_meta(key TEXT PRIMARY KEY, value TEXT);
+            CREATE TABLE usage_events(
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                tool TEXT NOT NULL,
+                source_key TEXT,
+                dedupe_key TEXT NOT NULL UNIQUE
+            );
+            CREATE TABLE usage_daily_rollups(
+                day TEXT NOT NULL,
+                tool TEXT NOT NULL,
+                model TEXT NOT NULL,
+                requests INTEGER NOT NULL DEFAULT 0,
+                fresh_input INTEGER NOT NULL DEFAULT 0,
+                output INTEGER NOT NULL DEFAULT 0,
+                cache_read INTEGER NOT NULL DEFAULT 0,
+                cache_creation INTEGER NOT NULL DEFAULT 0,
+                cost_micros INTEGER NOT NULL DEFAULT 0,
+                unpriced INTEGER NOT NULL DEFAULT 0,
+                PRIMARY KEY(day, tool, model)
+            );
+            INSERT INTO ledger_meta VALUES('cursor_tool_v1', '1');
+            INSERT INTO ledger_meta VALUES('detail_floor_day:grok', '2026-07-17');
+            INSERT INTO usage_daily_rollups
+                VALUES('2026-07-01', 'grok', 'gemini-3.5-flash-high', 4, 40, 8, 5, 2, 120, 0);
+            """, nil, nil, nil), SQLITE_OK)
+
+        XCTAssertTrue(UsageEventLedger.migrateCursorToolRows(db))
+
+        var statement: OpaquePointer?
+        XCTAssertEqual(sqlite3_prepare_v2(
+            db,
+            "SELECT tool FROM usage_daily_rollups WHERE model = 'gemini-3.5-flash-high'",
+            -1,
+            &statement,
+            nil
+        ), SQLITE_OK)
+        let query = try XCTUnwrap(statement)
+        defer { sqlite3_finalize(query) }
+        XCTAssertEqual(sqlite3_step(query), SQLITE_ROW)
+        XCTAssertEqual(String(cString: sqlite3_column_text(query, 0)), "cursor")
+
+        var markerStatement: OpaquePointer?
+        XCTAssertEqual(sqlite3_prepare_v2(
+            db,
+            "SELECT value FROM ledger_meta WHERE key = 'cursor_rollup_tool_v1'",
+            -1,
+            &markerStatement,
+            nil
+        ), SQLITE_OK)
+        let markerQuery = try XCTUnwrap(markerStatement)
+        defer { sqlite3_finalize(markerQuery) }
+        XCTAssertEqual(sqlite3_step(markerQuery), SQLITE_ROW)
+        XCTAssertEqual(String(cString: sqlite3_column_text(markerQuery, 0)), "1")
     }
 
     /// A second batch carrying the same `(mtime, size)` fingerprint is

--- a/Tests/VibeBarCoreTests/UsageModelNamingTests.swift
+++ b/Tests/VibeBarCoreTests/UsageModelNamingTests.swift
@@ -1,0 +1,31 @@
+import XCTest
+@testable import VibeBarCore
+
+final class UsageModelNamingTests: XCTestCase {
+    func testCanonicalizesAntiGravityGeminiLabelsWithDecimalVersion() {
+        XCTAssertEqual(
+            UsageModelNaming.canonicalDisplayName("Gemini 3.5 Flash (High)"),
+            "gemini-3.5-flash-high"
+        )
+        XCTAssertEqual(
+            UsageModelNaming.canonicalDisplayName("Gemini 3.6 Flash (Low)"),
+            "gemini-3.6-flash-low"
+        )
+        XCTAssertEqual(
+            UsageModelNaming.canonicalDisplayName("Gemini 3.1 Pro (Medium)"),
+            "gemini-3.1-pro-medium"
+        )
+    }
+
+    func testKeepsAlreadyCanonicalAndNonGeminiNames() {
+        XCTAssertEqual(
+            UsageModelNaming.canonicalDisplayName("gemini-3.5-flash"),
+            "gemini-3.5-flash"
+        )
+        XCTAssertEqual(
+            UsageModelNaming.canonicalDisplayName("claude-sonnet-5"),
+            "claude-sonnet-5"
+        )
+        XCTAssertEqual(UsageModelNaming.canonicalDisplayName("  "), "Unknown model")
+    }
+}

--- a/Tests/VibeBarCoreTests/UsageQueryMetricsTests.swift
+++ b/Tests/VibeBarCoreTests/UsageQueryMetricsTests.swift
@@ -63,18 +63,28 @@ final class UsageQueryMetricsTests: XCTestCase {
     }
 
     func testProviderStatsMergeAtCompanyLevel() {
-        let merged = UsageProviderStat.mergedByCompany([
+        let rows = [
             UsageProviderStat(tool: .gemini, requests: 2, totalTokens: 100, costMicros: 10),
             UsageProviderStat(tool: .antigravity, requests: 3, totalTokens: 200, costMicros: 20),
             UsageProviderStat(tool: .grok, requests: 4, totalTokens: 400, costMicros: 40),
             UsageProviderStat(tool: .cursor, requests: 5, totalTokens: 500, costMicros: 50),
             UsageProviderStat(tool: .codex, requests: 1, totalTokens: 50, costMicros: 5)
-        ])
+        ]
+        let merged = UsageProviderStat.mergedByCompany(rows)
         XCTAssertEqual(merged.map(\.tool), [.grok, .gemini, .codex])
         XCTAssertEqual(merged[0].requests, 9)
         XCTAssertEqual(merged[0].totalTokens, 900)
         XCTAssertEqual(merged[1].requests, 5)
         XCTAssertEqual(merged[1].totalTokens, 300)
+        let summaries = UsageProviderStat.subProviderSummariesByCompany(rows)
+        XCTAssertEqual(summaries[.grok], "Grok + Cursor")
+        XCTAssertEqual(summaries[.gemini], "Gemini Web + AntiGravity")
+        XCTAssertEqual(
+            UsageProviderStat.subProviderSummariesByCompany([
+                UsageProviderStat(tool: .cursor, requests: 1, totalTokens: 10, costMicros: 1)
+            ])[.grok],
+            "Cursor"
+        )
     }
 
     func testEarliestUsageDateUsesActualRowsAndToolFilter() async throws {

--- a/Tests/VibeBarCoreTests/UsageQueryMetricsTests.swift
+++ b/Tests/VibeBarCoreTests/UsageQueryMetricsTests.swift
@@ -62,6 +62,72 @@ final class UsageQueryMetricsTests: XCTestCase {
         XCTAssertEqual(UsageRequestPage(rows: [], totalCount: 0, page: 0, pageSize: 5).pageCount, 0)
     }
 
+    func testProviderStatsMergeAtCompanyLevel() {
+        let merged = UsageProviderStat.mergedByCompany([
+            UsageProviderStat(tool: .gemini, requests: 2, totalTokens: 100, costMicros: 10),
+            UsageProviderStat(tool: .antigravity, requests: 3, totalTokens: 200, costMicros: 20),
+            UsageProviderStat(tool: .grok, requests: 4, totalTokens: 400, costMicros: 40),
+            UsageProviderStat(tool: .cursor, requests: 5, totalTokens: 500, costMicros: 50),
+            UsageProviderStat(tool: .codex, requests: 1, totalTokens: 50, costMicros: 5)
+        ])
+        XCTAssertEqual(merged.map(\.tool), [.grok, .gemini, .codex])
+        XCTAssertEqual(merged[0].requests, 9)
+        XCTAssertEqual(merged[0].totalTokens, 900)
+        XCTAssertEqual(merged[1].requests, 5)
+        XCTAssertEqual(merged[1].totalTokens, 300)
+    }
+
+    func testEarliestUsageDateUsesActualRowsAndToolFilter() async throws {
+        let (ledger, directory) = try UsageLedgerFixtures.makeLedger("MetricsEarliest")
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let old = now.addingTimeInterval(-20 * 86_400)
+        let recent = now.addingTimeInterval(-2 * 86_400)
+        try await ledger.ingest(UsageLedgerFixtures.batch(
+            tool: .claude,
+            path: "/Users/example/.claude/projects/old.jsonl",
+            events: [UsageLedgerFixtures.priced(UsageLedgerFixtures.event(date: old))]
+        ))
+        try await ledger.ingest(UsageLedgerFixtures.batch(
+            tool: .codex,
+            path: "/Users/example/.codex/sessions/recent.jsonl",
+            events: [UsageLedgerFixtures.priced(UsageLedgerFixtures.event(date: recent))]
+        ))
+
+        let allStart = try await ledger.earliestUsageDate()
+        let codexStart = try await ledger.earliestUsageDate(tools: [.codex])
+        let emptyStart = try await ledger.earliestUsageDate(tools: [])
+        XCTAssertEqual(allStart, old)
+        XCTAssertEqual(codexStart, recent)
+        XCTAssertNil(emptyStart)
+    }
+
+    func testBlankLegacyModelRemainsInTotalsButNotModelFiltersOrRows() async throws {
+        let (ledger, directory) = try UsageLedgerFixtures.makeLedger("MetricsBlankModel")
+        defer { try? FileManager.default.removeItem(at: directory) }
+        try await ledger.ingest(UsageLedgerFixtures.batch(events: [
+            UsageLedgerFixtures.priced(
+                UsageLedgerFixtures.event(date: now, model: "", input: 300, output: 30),
+                costUSD: 0.3
+            ),
+            UsageLedgerFixtures.priced(
+                UsageLedgerFixtures.event(
+                    date: now.addingTimeInterval(-60),
+                    model: "gpt-5.5",
+                    input: 700,
+                    output: 70
+                ),
+                costUSD: 0.7
+            )
+        ]))
+        let filter = UsageLedgerFixtures.wideFilter(around: now)
+        let summary = try await ledger.summary(filter)
+        let available = try await ledger.availableModels()
+        let models = try await ledger.modelStats(filter)
+        XCTAssertEqual(summary.requests, 2)
+        XCTAssertEqual(available, ["gpt-5.5"])
+        XCTAssertEqual(models.map(\.model), ["gpt-5.5"])
+    }
+
     // MARK: - Zero-filled trend
 
     func testHourlyTrendZeroFillsEveryBucketInRange() async throws {

--- a/Tests/VibeBarCoreTests/XAIServiceStatusTests.swift
+++ b/Tests/VibeBarCoreTests/XAIServiceStatusTests.swift
@@ -41,5 +41,59 @@ final class XAIServiceStatusTests: XCTestCase {
         XCTAssertEqual(snapshot.components[0].status, .operational)
         XCTAssertEqual(snapshot.recentIncidents.first?.name, "Requests Using grok-imagine Models have Reduced Success Rate")
         XCTAssertEqual(snapshot.recentIncidents.first?.impact, .minor)
+        let incident = try XCTUnwrap(snapshot.recentIncidents.first)
+        XCTAssertEqual(
+            try XCTUnwrap(incident.resolvedAt).timeIntervalSince(incident.createdAt),
+            47 * 60,
+            accuracy: 0.001
+        )
+    }
+
+    func testUnavailableComponentIsNotConfusedWithAvailable() throws {
+        let now = try XCTUnwrap(ServiceStatusClient.parseXAIStatusDate("May 22, 2026, 12:00 PM UTC"))
+        let snapshot = ServiceStatusClient.parseXAIStatusPages(
+            tool: .grok,
+            overviewHTML: "<h3>Incident declared</h3>",
+            componentPages: [(
+                id: "grok-com",
+                name: "Grok (Web)",
+                url: URL(string: "https://status.x.ai/grok-com")!,
+                html: "<h1>Grok (Web)</h1><h3>Service unavailable</h3>"
+            )],
+            dayCount: 30,
+            now: now
+        )
+
+        XCTAssertEqual(snapshot.indicator, .critical)
+        XCTAssertEqual(snapshot.components.first?.status, .majorOutage)
+    }
+
+    func testIncidentDurationMarksEveryAffectedUTCDate() throws {
+        let now = try XCTUnwrap(ServiceStatusClient.parseXAIStatusDate("May 15, 2026, 12:00 PM UTC"))
+        let snapshot = ServiceStatusClient.parseXAIStatusPages(
+            tool: .grok,
+            overviewHTML: "<h3>No incidents declared</h3>",
+            componentPages: [(
+                id: "api-us-east-1",
+                name: "API (us-east-1.api.x.ai)",
+                url: URL(string: "https://status.x.ai/api-us-east-1")!,
+                html: """
+                <h3>Service fully operational</h3>
+                <a>May 13, 2026, 11:30 PM UTC Cross-day incident Resolved · Duration: 2 hours 15 minutes · outage</a>
+                """
+            )],
+            dayCount: 3,
+            now: now
+        )
+
+        let incident = try XCTUnwrap(snapshot.recentIncidents.first)
+        XCTAssertEqual(
+            try XCTUnwrap(incident.resolvedAt).timeIntervalSince(incident.createdAt),
+            2 * 3_600 + 15 * 60,
+            accuracy: 0.001
+        )
+        let affectedDays = try XCTUnwrap(snapshot.components.first).recentDays
+            .filter { $0.worstImpact != nil }
+        XCTAssertEqual(affectedDays.count, 2)
     }
 }

--- a/Tests/VibeBarCoreTests/XAIServiceStatusTests.swift
+++ b/Tests/VibeBarCoreTests/XAIServiceStatusTests.swift
@@ -37,8 +37,11 @@ final class XAIServiceStatusTests: XCTestCase {
         XCTAssertEqual(snapshot.tool, .grok)
         XCTAssertEqual(snapshot.indicator, .none)
         XCTAssertEqual(snapshot.description, "All services operational")
-        XCTAssertEqual(snapshot.components.count, 1)
-        XCTAssertEqual(snapshot.components[0].status, .operational)
+        XCTAssertEqual(snapshot.components.count, 2)
+        XCTAssertEqual(
+            snapshot.components.first { $0.name == "API (us-east-1.api.x.ai)" }?.status,
+            .operational
+        )
         XCTAssertEqual(snapshot.recentIncidents.first?.name, "Requests Using grok-imagine Models have Reduced Success Rate")
         XCTAssertEqual(snapshot.recentIncidents.first?.impact, .minor)
         let incident = try XCTUnwrap(snapshot.recentIncidents.first)
@@ -95,5 +98,35 @@ final class XAIServiceStatusTests: XCTestCase {
         let affectedDays = try XCTUnwrap(snapshot.components.first).recentDays
             .filter { $0.worstImpact != nil }
         XCTAssertEqual(affectedDays.count, 2)
+    }
+
+    func testOverviewBackfillsAComponentWhoseDetailRequestFailed() throws {
+        let now = try XCTUnwrap(ServiceStatusClient.parseXAIStatusDate("May 22, 2026, 12:00 PM UTC"))
+        let snapshot = ServiceStatusClient.parseXAIStatusPages(
+            tool: .grok,
+            overviewHTML: """
+            <a>Grok (Web) unavailable</a>
+            <a>API (us-east-1.api.x.ai) available</a>
+            """,
+            componentPages: [(
+                id: "api-us-east-1",
+                name: "API (us-east-1.api.x.ai)",
+                url: URL(string: "https://status.x.ai/api-us-east-1")!,
+                html: "<h3>Service fully operational</h3>"
+            )],
+            dayCount: 30,
+            now: now
+        )
+
+        XCTAssertEqual(snapshot.components.count, 2)
+        XCTAssertEqual(snapshot.indicator, .critical)
+        XCTAssertEqual(
+            snapshot.components.first { $0.name == "Grok (Web)" }?.status,
+            .majorOutage
+        )
+        XCTAssertEqual(
+            snapshot.components.first { $0.name == "API (us-east-1.api.x.ai)" }?.status,
+            .operational
+        )
     }
 }


### PR DESCRIPTION
## Summary
- recover all four AntiGravity quota lanes through an installed agy local-RPC fallback, expose actionable failures, and refresh reset-expired cache on real page opens
- normalize OpenAI, Anthropic, Google AI, and SpaceXAI across quota, Workbench, sessions, status, and pricing surfaces
- retain company-level filter chips plus individual SubProvider menus for Gemini Web, AntiGravity, Grok, and Cursor
- group Cursor Status under SpaceXAI, merge partial xAI status fetches, parse outage duration/status accurately, keep Grok Bot optional, and correct Cursor Models / Other Models to Monthly
- preserve Cursor as a distinct Workbench source while merging Grok + Cursor into the final SpaceXAI provider total
- persist Cursor usage snapshots, make multi-slot refreshes atomic, retain last-known data across transient failures, clear it on sign-out, relabel identifiable legacy Cursor rollups, and honor authoritative downward corrections without double aggregation
- add a real-data-bounded All range, lazy-load Models / Requests, preserve breakdown state, and coalesce account refresh walks without losing reset-boundary observations
- show the complete effective merged model-pricing table with SubProvider, model, override, and rate filters
- normalize AntiGravity Gemini variants to canonical names such as gemini-3.5-flash-high and suppress blank legacy model rows

## Test plan
- [x] swift build
- [x] swift test (1,492 tests; 1 skipped; 0 failures)
- [x] ./Scripts/build_app.sh release
- [x] codesign -d --entitlements - ".build/Vibe Bar.app"
- [x] codesign --verify --deep --strict ".build/Vibe Bar.app"
- [x] live agy loopback quota probe returned all four AntiGravity lanes without sending a model prompt
- [x] local ledger audit confirmed 1,007 Cursor rows are included in SpaceXAI totals
- [x] all Codex review threads addressed and resolved