### PR TITLE
Prepare Vibe Bar 1.3.0 Dev build 31

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.3.0</string>
 	<key>CFBundleVersion</key>
-	<string>30</string>
+	<string>31</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>26.0</string>
 	<key>LSUIElement</key>


### PR DESCRIPTION
## Why

Cut the next Dev channel build after merging:

- #173 — Unify provider hierarchy and refresh live quotas (SubProvider naming, agy live quota fallback, stale hints, Cursor Monthly cadence, Workbench All range and perf, Model Pricing list, Cursor cost persistence)
- #167 — Detect when macOS hides the menu bar item

## What

- `Resources/Info.plist`: `CFBundleVersion` 30 → 31. `CFBundleShortVersionString` stays `1.3.0`.

## Verification

- `swift build`, `swift test` (1507 tests, 1 skipped, 0 failures)
- `./Scripts/build_app.sh release`, `codesign -d --entitlements -` → empty `<dict/>`, `codesign --verify --deep --strict` OK
- Bundle reports build 31

Tag `v1.3.0-dev.31` will be created on the merged commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)