### PR TITLE
Carry the harness through repricing, requests and hour floors

### DIFF
--- a/Sources/VibeBarApp/Views/Workbench/UsageBreakdownTables.swift
+++ b/Sources/VibeBarApp/Views/Workbench/UsageBreakdownTables.swift
@@ -185,7 +185,7 @@ struct UsageBreakdownTables: View {
             VStack(spacing: 0) {
                 tableHeader {
                     headerCell("Time", width: 138)
-                    headerCell("SubProvider", width: 138)
+                    headerCell("Harness", width: 138)
                     headerCell("Model", width: 220)
                     headerCell("Input", width: 114, alignment: .trailing)
                     headerCell("Output", width: 88, alignment: .trailing)
@@ -196,7 +196,7 @@ struct UsageBreakdownTables: View {
                     ForEach(model.requestRows) { row in
                         PorcelainUsageRow(accessibilityLabel: requestAccessibilityLabel(row)) {
                             valueCell(timestamp(row.date), width: 138, secondary: true, tooltip: timestamp(row.date))
-                            subProviderCell(row.tool, width: 138)
+                            harnessCell(row.harness, width: 138)
                             valueCell(
                                 UsageModelNaming.canonicalDisplayName(row.model),
                                 width: 220,
@@ -319,15 +319,18 @@ struct UsageBreakdownTables: View {
             .help(tooltip ?? value)
     }
 
-    private func subProviderCell(_ tool: ToolType, width: CGFloat) -> some View {
+    /// A request row is usage, so it names the harness that produced it, not
+    /// the quota SubProvider it bills against (AGENTS.md § 7.1). The badge
+    /// still follows the L1 company, matching the Harness Mix card.
+    private func harnessCell(_ harness: Harness, width: CGFloat) -> some View {
         HStack(spacing: 7) {
-            ToolBrandBadge(tool: tool, iconSize: 13, containerSize: 16)
-            Text(tool.productName)
+            ToolBrandBadge(tool: harness.company, iconSize: 13, containerSize: 16)
+            Text(harness.displayName)
                 .font(bodyFont)
                 .lineLimit(1)
         }
         .frame(width: width, alignment: .leading)
-        .help("\(tool.vendorName) · \(tool.productName)")
+        .help("\(harness.companyName) · \(harness.displayName)")
     }
 
     private func companyCell(_ tool: ToolType, width: CGFloat) -> some View {
@@ -479,7 +482,7 @@ struct UsageBreakdownTables: View {
     }
 
     private func requestAccessibilityLabel(_ row: UsageRequestRow) -> String {
-        "\(timestamp(row.date)), \(row.tool.productName), \(UsageModelNaming.canonicalDisplayName(row.model)), \(UsageFormatting.formatTokens(row.totalTokens)), \(row.costMicros.map { UsageFormatting.formatMicroUSD($0) } ?? "unpriced")"
+        "\(timestamp(row.date)), \(row.harness.displayName), \(UsageModelNaming.canonicalDisplayName(row.model)), \(UsageFormatting.formatTokens(row.totalTokens)), \(row.costMicros.map { UsageFormatting.formatMicroUSD($0) } ?? "unpriced")"
     }
 
     private func providerAccessibilityLabel(_ stat: UsageProviderStat) -> String {

--- a/Sources/VibeBarCore/Models/UsageQueryModels.swift
+++ b/Sources/VibeBarCore/Models/UsageQueryModels.swift
@@ -211,7 +211,11 @@ public struct UsageTrendSeries: Sendable, Equatable {
 public struct UsageRequestRow: Sendable, Equatable, Identifiable {
     public let id: Int64
     public let date: Date
+    /// Quota-axis tool the request is billed against.
     public let tool: ToolType
+    /// Usage-axis producer: the CLI or app the request came from. Request
+    /// surfaces name this one, because a request log is usage, not quota.
+    public let harness: Harness
     public let model: String
     public let freshInput: Int64
     public let output: Int64
@@ -226,6 +230,7 @@ public struct UsageRequestRow: Sendable, Equatable, Identifiable {
         id: Int64,
         date: Date,
         tool: ToolType,
+        harness: Harness,
         model: String,
         freshInput: Int64,
         output: Int64,
@@ -239,6 +244,7 @@ public struct UsageRequestRow: Sendable, Equatable, Identifiable {
         self.id = id
         self.date = date
         self.tool = tool
+        self.harness = harness
         self.model = model
         self.freshInput = freshInput
         self.output = output

--- a/Sources/VibeBarCore/Services/UsageEventLedger.swift
+++ b/Sources/VibeBarCore/Services/UsageEventLedger.swift
@@ -970,15 +970,21 @@ public actor UsageEventLedger: CostUsageEventSink {
                     continue
                 }
                 guard let micros = costMicros(for: row) else { continue }
+                // `harness` is part of the rollup's primary key, so it has to
+                // be part of the predicate too: two harnesses can hold fully
+                // unpriced rows for the same day/tool/model, and matching on
+                // the narrower key would stamp the first row's cost onto both.
                 try run(
                     """
                     UPDATE usage_daily_rollups
                        SET cost_micros = ?, unpriced = 0
-                     WHERE day = ? AND tool = ? AND model = ? AND unpriced = requests
+                     WHERE day = ? AND tool = ? AND harness = ? AND model = ?
+                       AND unpriced = requests
                     """,
                     [
                         .integer(micros), .text(row.day),
-                        .text(row.tool.rawValue), .text(row.model)
+                        .text(row.tool.rawValue), .text(row.harness ?? ""),
+                        .text(row.model)
                     ]
                 )
             }
@@ -1001,6 +1007,10 @@ public actor UsageEventLedger: CostUsageEventSink {
         let id: Int64
         let day: String
         let tool: ToolType
+        /// Raw stored harness. `nil` on detail rows, which are updated by
+        /// `id`; rollup rows always carry one because it is part of their
+        /// primary key (`''` is the pre-dimension sentinel).
+        let harness: String?
         let model: String
         let freshInput: Int64
         let output: Int64
@@ -1030,6 +1040,7 @@ public actor UsageEventLedger: CostUsageEventSink {
                 id: sqlite3_column_int64(statement, 0),
                 day: day,
                 tool: tool,
+                harness: nil,
                 model: model,
                 freshInput: sqlite3_column_int64(statement, 4),
                 output: sqlite3_column_int64(statement, 5),
@@ -1045,7 +1056,8 @@ public actor UsageEventLedger: CostUsageEventSink {
     private func fullyUnpricedRollupRows() throws -> [RepricingRow] {
         let statement = try prepare(
             """
-            SELECT day, tool, model, fresh_input, output, cache_read, cache_creation
+            SELECT day, tool, harness, model, fresh_input, output,
+                   cache_read, cache_creation
               FROM usage_daily_rollups WHERE unpriced > 0 AND unpriced = requests
             """
         )
@@ -1055,17 +1067,18 @@ public actor UsageEventLedger: CostUsageEventSink {
             guard let day = columnText(statement, 0),
                   let rawTool = columnText(statement, 1),
                   let tool = ToolType(rawValue: rawTool),
-                  let model = columnText(statement, 2)
+                  let model = columnText(statement, 3)
             else { continue }
             rows.append(RepricingRow(
                 id: 0,
                 day: day,
                 tool: tool,
+                harness: columnText(statement, 2) ?? "",
                 model: model,
-                freshInput: sqlite3_column_int64(statement, 3),
-                output: sqlite3_column_int64(statement, 4),
-                cacheRead: sqlite3_column_int64(statement, 5),
-                cacheCreation: sqlite3_column_int64(statement, 6),
+                freshInput: sqlite3_column_int64(statement, 4),
+                output: sqlite3_column_int64(statement, 5),
+                cacheRead: sqlite3_column_int64(statement, 6),
+                cacheCreation: sqlite3_column_int64(statement, 7),
                 serviceTier: nil,
                 sourceKey: nil
             ))
@@ -1365,12 +1378,10 @@ public actor UsageEventLedger: CostUsageEventSink {
     ) throws -> UsageTrendBucket {
         guard requested == .hour else { return requested }
 
-        let tools: [ToolType]
-        if let filteredTools = filter.tools {
-            tools = filteredTools
-        } else {
-            tools = try ingestedTools()
-        }
+        let selected = Self.floorCheckTools(
+            tools: filter.tools, harnesses: filter.harnesses
+        )
+        let tools = try selected ?? ingestedTools()
         for tool in tools {
             guard let floor = try detailFloorDay(for: tool),
                   let floorDay = dayFormatter.date(from: floor),
@@ -1381,6 +1392,31 @@ public actor UsageEventLedger: CostUsageEventSink {
             }
         }
         return .hour
+    }
+
+    /// Tools whose detail floor may veto an hourly chart for a filter, or
+    /// `nil` when the answer is "every tool this ledger has ingested".
+    ///
+    /// A harness selection narrows the quota-side tool just as surely as a
+    /// company chip does — filtering to Claude Code cannot surface a single
+    /// Codex row. Ignoring `harnesses` here let an unrelated provider's old
+    /// rollups drag a harness-only chart down from hourly to daily. When both
+    /// axes are set the filter matches their intersection, so the floor check
+    /// does too; an empty intersection matches nothing and vetoes nothing.
+    static func floorCheckTools(
+        tools: [ToolType]?,
+        harnesses: [Harness]?
+    ) -> [ToolType]? {
+        let fromTools = tools.map(Set.init)
+        let fromHarnesses = harnesses.map { Set($0.map(\.quotaTool)) }
+        let selected: Set<ToolType>? = switch (fromTools, fromHarnesses) {
+        case let (explicit?, derived?): explicit.intersection(derived)
+        case let (explicit?, nil): explicit
+        case let (nil, derived?): derived
+        case (nil, nil): nil
+        }
+        // Rebuild in declaration order so the check is deterministic.
+        return selected.map { set in ToolType.allCases.filter(set.contains) }
     }
 
     /// Whether every selected provider still has request-level evidence for
@@ -1419,7 +1455,7 @@ public actor UsageEventLedger: CostUsageEventSink {
         let statement = try prepare(
             """
             SELECT id, tool, ts, model, fresh_input, output, cache_read, cache_creation,
-                   cost_micros, service_tier, session_id, source_key
+                   cost_micros, service_tier, session_id, source_key, harness
               FROM usage_events WHERE \(detail.sql)
              ORDER BY ts DESC, id DESC LIMIT ? OFFSET ?
             """
@@ -1432,15 +1468,22 @@ public actor UsageEventLedger: CostUsageEventSink {
 
         var rows: [UsageRequestRow] = []
         while sqlite3_step(statement) == SQLITE_ROW {
+            // A row written before the harness dimension existed has a NULL
+            // harness; the tool's default is the same value the migration
+            // would have backfilled. Only the misc providers have no harness
+            // at all, and they never reach this ledger.
             guard let rawTool = columnText(statement, 1),
                   let tool = ToolType(rawValue: rawTool),
-                  let model = columnText(statement, 3)
+                  let model = columnText(statement, 3),
+                  let harness = columnText(statement, 12).flatMap(Harness.init(rawValue:))
+                    ?? Harness.defaultHarness(for: tool)
             else { continue }
             rows.append(
                 UsageRequestRow(
                     id: sqlite3_column_int64(statement, 0),
                     date: Date(timeIntervalSince1970: TimeInterval(sqlite3_column_int64(statement, 2))),
                     tool: tool,
+                    harness: harness,
                     model: model,
                     freshInput: sqlite3_column_int64(statement, 4),
                     output: sqlite3_column_int64(statement, 5),

--- a/Tests/VibeBarCoreTests/UsageLedgerHarnessTests.swift
+++ b/Tests/VibeBarCoreTests/UsageLedgerHarnessTests.swift
@@ -285,6 +285,191 @@ final class UsageLedgerHarnessTests: XCTestCase {
         XCTAssertEqual(requests, 1, "corrected, not duplicated")
     }
 
+    func testRequestRowsCarryTheProducingHarness() async throws {
+        let (ledger, directory) = try UsageLedgerFixtures.makeLedger("HarnessRequestRows")
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        try await ledger.ingest(UsageLedgerFixtures.batch(
+            path: "/Users/example/.codex/sessions/desktop.jsonl",
+            events: [
+                UsageLedgerFixtures.priced(
+                    UsageLedgerFixtures.event(
+                        date: now, input: 4_000, output: 400, harness: .chatgptWork
+                    )
+                )
+            ]
+        ))
+        // Nothing stamped: the row still has to resolve through the tool's
+        // default, the same value the migration would have backfilled.
+        try await ledger.ingest(UsageLedgerFixtures.batch(
+            tool: .claude,
+            path: "/Users/example/.claude/projects/demo/session.jsonl",
+            events: [
+                UsageLedgerFixtures.priced(
+                    UsageLedgerFixtures.event(
+                        date: now.addingTimeInterval(-60),
+                        model: "claude-sonnet-4-5", input: 1_000, output: 100
+                    )
+                )
+            ]
+        ))
+
+        let page = try await ledger.requestPage(
+            UsageLedgerFixtures.wideFilter(around: now), page: 0, pageSize: 10
+        )
+        XCTAssertEqual(page.rows.map(\.harness), [.chatgptWork, .claudeCode])
+        // The quota-side tool is unchanged: the two axes coexist on one row.
+        XCTAssertEqual(page.rows.map(\.tool), [.codex, .claude])
+    }
+
+    /// Two fully unpriced rollups can share a day, tool and model and differ
+    /// only by harness. Repricing has to match the whole primary key, or the
+    /// first row's cost is written onto both and both are marked priced.
+    func testRepricingPricesEachHarnessRollupSeparately() async throws {
+        let (ledger, directory) = try UsageLedgerFixtures.makeLedger("HarnessRepricing")
+        defer { try? FileManager.default.removeItem(at: directory) }
+        defer { PricingResolver.testOverride = nil }
+
+        let base = PricingHardcoded.fallback
+        var codexModels = base.providers.codex.models
+        codexModels["linear-test"] = .init(input: 2e-6, output: 6e-6, cacheRead: nil)
+        PricingResolver.testOverride = PricingDataSet(
+            schemaVersion: base.schemaVersion,
+            updatedAt: "test-harness-repricing",
+            calculationVersion: base.calculationVersion,
+            providers: .init(
+                codex: .init(displayName: "OpenAI", models: codexModels),
+                claude: base.providers.claude,
+                gemini: base.providers.gemini,
+                grok: base.providers.grok,
+                antigravity: base.providers.antigravity
+            )
+        )
+
+        let old = now.addingTimeInterval(-60 * 86_400)
+        let seeds: [(path: String, harness: Harness, input: Int, output: Int)] = [
+            ("/Users/example/.codex/sessions/cli.jsonl", .codex, 1_000_000, 100_000),
+            ("/Users/example/.codex/sessions/desktop.jsonl", .chatgptWork, 2_000_000, 200_000)
+        ]
+        for seed in seeds {
+            try await ledger.ingest(UsageLedgerFixtures.batch(
+                path: seed.path,
+                events: [
+                    UsageLedgerFixtures.priced(
+                        UsageLedgerFixtures.event(
+                            date: old, model: "linear-test",
+                            input: seed.input, output: seed.output, harness: seed.harness
+                        ),
+                        costUSD: nil
+                    )
+                ]
+            ))
+        }
+        try await ledger.rollupAndPrune(now: now, detailDays: 30, retentionDays: 90)
+
+        let filter = UsageLedgerFixtures.wideFilter(around: now)
+        let before = try await ledger.summary(filter)
+        XCTAssertEqual(before.requests, 2)
+        XCTAssertEqual(before.unpricedRequests, 2)
+
+        let prepared = try await ledger.prepareForPricingRevision("pricing-harness")
+        XCTAssertTrue(prepared)
+
+        let stats = try await ledger.harnessStats(filter)
+        XCTAssertEqual(stats.map(\.harness), [.chatgptWork, .codex])
+        XCTAssertEqual(stats[0].costMicros, 5_200_000)
+        XCTAssertEqual(stats[1].costMicros, 2_600_000)
+        let after = try await ledger.summary(filter)
+        XCTAssertEqual(after.unpricedRequests, 0)
+        XCTAssertEqual(after.costMicros, 7_800_000)
+    }
+
+    // MARK: - Hourly floor
+
+    func testFloorCheckToolsDerivesToolsFromTheHarnessFilter() {
+        XCTAssertNil(UsageEventLedger.floorCheckTools(tools: nil, harnesses: nil))
+        XCTAssertEqual(
+            UsageEventLedger.floorCheckTools(tools: nil, harnesses: [.claudeCode, .claudeCowork]),
+            [.claude]
+        )
+        XCTAssertEqual(
+            UsageEventLedger.floorCheckTools(tools: nil, harnesses: [.codex, .grokBuild]),
+            [.codex, .grok]
+        )
+        XCTAssertEqual(
+            UsageEventLedger.floorCheckTools(tools: [.codex, .claude], harnesses: [.claudeCode]),
+            [.claude]
+        )
+        XCTAssertEqual(
+            UsageEventLedger.floorCheckTools(tools: [.grok], harnesses: nil),
+            [.grok]
+        )
+        // Disjoint axes match no row at all, so no floor can veto anything.
+        XCTAssertEqual(
+            UsageEventLedger.floorCheckTools(tools: [.codex], harnesses: [.claudeCode]),
+            []
+        )
+    }
+
+    /// A harness-only selection must be checked against *its* tool's floor.
+    /// Codex has folded history here and Claude Code does not, so the Hourly
+    /// picker has to stay available once the filter excludes Codex.
+    func testHarnessFilterKeepsHourlyDespiteAnotherToolsDetailFloor() async throws {
+        let (ledger, directory) = try UsageLedgerFixtures.makeLedger("HarnessHourlyFloor")
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        try await ledger.ingest(UsageLedgerFixtures.batch(
+            path: "/Users/example/.codex/sessions/cli.jsonl",
+            events: [
+                UsageLedgerFixtures.priced(
+                    UsageLedgerFixtures.event(date: now.addingTimeInterval(-5 * 86_400))
+                )
+            ]
+        ))
+        // Only Codex is ingested at this point, so only Codex gains a floor.
+        try await ledger.rollupAndPrune(now: now, detailDays: 1, retentionDays: 0)
+        try await ledger.ingest(UsageLedgerFixtures.batch(
+            tool: .claude,
+            path: "/Users/example/.claude/projects/demo/session.jsonl",
+            events: [
+                UsageLedgerFixtures.priced(
+                    UsageLedgerFixtures.event(
+                        date: now.addingTimeInterval(-2 * 3_600), model: "claude-sonnet-4-5"
+                    )
+                )
+            ]
+        ))
+        let codexFloor = try await ledger.detailFloorDay(for: .codex)
+        XCTAssertNotNil(codexFloor)
+        let claudeFloor = try await ledger.detailFloorDay(for: .claude)
+        XCTAssertNil(claudeFloor)
+
+        var filter = UsageQueryFilter(
+            range: DateInterval(
+                start: now.addingTimeInterval(-3 * 86_400),
+                end: now.addingTimeInterval(3_600)
+            )
+        )
+        let unfiltered = try await ledger.supportsHourlyTrend(filter)
+        XCTAssertFalse(unfiltered)
+
+        filter.harnesses = [.claudeCode]
+        let claudeCodeOnly = try await ledger.supportsHourlyTrend(filter)
+        XCTAssertTrue(claudeCodeOnly)
+        let bucket = try await ledger.trend(filter, bucket: .hour).bucket
+        XCTAssertEqual(bucket, .hour)
+
+        // Disagreeing axes match nothing, so no floor is left to veto.
+        filter.tools = [.codex]
+        let disjoint = try await ledger.supportsHourlyTrend(filter)
+        XCTAssertTrue(disjoint)
+
+        // Codex alone is still vetoed by its own floor.
+        filter.harnesses = nil
+        let codexOnly = try await ledger.supportsHourlyTrend(filter)
+        XCTAssertFalse(codexOnly)
+    }
+
     func testRollupKeepsHarnessesApartBelowTheDetailFloor() async throws {
         let (ledger, directory) = try UsageLedgerFixtures.makeLedger("HarnessRollup")
         defer { try? FileManager.default.removeItem(at: directory) }


### PR DESCRIPTION
## Why

Follow-up to #177 (harness axis) for the three review findings that landed after auto-merge:

- **P1** — rollup repricing keyed on `(day, tool, model)` only, so two harness rows sharing those values got the first row's cost written to both.
- **P2** — `UsageRequestRow` had no harness, so the Requests table still labelled ChatGPT Work / Claude Cowork rows with the quota SubProvider.
- **P2** — the hourly-detail-floor check ignored a harness-only filter and could force a harness chart from hourly to daily because of an unrelated tool's old rollups.

## What

- `RepricingRow` / SELECT / UPDATE carry `harness`; regression test with two harness rollups on the same day/tool/model.
- `UsageRequestRow.harness` (persisted value, `defaultHarness(for:)` fallback); Requests table column "SubProvider" → "Harness", showing `harness.displayName` with the company badge.
- `UsageEventLedger.floorCheckTools(tools:harnesses:)` derives the floor-check tools from selected harnesses ∩ explicit tools; `resolvedTrendBucket` uses it. Tests for the helper and the hourly-preserved case.

## Verification

- `swift build`, `swift test` (1560 tests, 1 skipped, 0 failures)
- `./Scripts/build_app.sh release`, `codesign -d --entitlements -` → empty `<dict/>`, `codesign --verify --deep --strict` OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)
