### PR TITLE
Map only codex_work_desktop rollouts to ChatGPT Work

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -509,8 +509,8 @@ the display names).
 
 | Harness       | L1 company | Local evidence                                      |
 | ------------- | ---------- | --------------------------------------------------- |
-| Codex         | OpenAI     | `~/.codex/sessions`, `originator` ≠ "Codex Desktop"  |
-| ChatGPT Work  | OpenAI     | same tree, `originator` == "Codex Desktop"           |
+| Codex         | OpenAI     | `~/.codex/sessions`, every other `originator` (`Codex Desktop`, `codex-tui`, `codex_cli_rs`, `codex_exec`, `codex_vscode`) |
+| ChatGPT Work  | OpenAI     | same tree, `originator` == "codex_work_desktop"      |
 | Claude Code   | Anthropic  | `~/.claude/projects`, `~/.config/claude/projects`    |
 | Claude Cowork | Anthropic  | `…/Application Support/Claude/local-agent-mode-sessions/**/.claude/projects` |
 | Gemini CLI    | Google AI  | `~/.gemini/tmp/*/chats/session-*.jsonl`, telemetry log |

--- a/Sources/VibeBarCore/Models/Harness.swift
+++ b/Sources/VibeBarCore/Models/Harness.swift
@@ -15,8 +15,8 @@ import Foundation
 ///
 /// | Harness        | L1 company | Local evidence                                              |
 /// | -------------- | ---------- | ----------------------------------------------------------- |
-/// | Codex          | OpenAI     | `~/.codex/sessions` rollouts, `originator` ≠ "Codex Desktop" |
-/// | ChatGPT Work   | OpenAI     | same tree, `originator` == "Codex Desktop"                   |
+/// | Codex          | OpenAI     | `~/.codex/sessions` rollouts, every other `originator` (`Codex Desktop`, `codex-tui`, `codex_cli_rs`, `codex_exec`, `codex_vscode`) |
+/// | ChatGPT Work   | OpenAI     | same tree, `originator` == "codex_work_desktop"              |
 /// | Claude Code    | Anthropic  | `~/.claude/projects`, `~/.config/claude/projects`            |
 /// | Claude Cowork  | Anthropic  | `~/Library/Application Support/Claude/local-agent-mode-sessions/**/.claude/projects` |
 /// | Gemini CLI     | Google AI  | `~/.gemini/tmp/*/chats/session-*.jsonl` (+ telemetry log)    |
@@ -97,9 +97,10 @@ public enum Harness: String, CaseIterable, Codable, Sendable, Hashable {
     /// stamped — used to backfill ledger rows written before the harness
     /// dimension existed, and as a defensive fallback at ingest.
     ///
-    /// Codex maps to `.codex` rather than `.chatgptWork` because the plain CLI
-    /// is the overwhelming majority; a Codex Desktop rollout is recognised
-    /// from its `originator` at scan time and overrides this.
+    /// Codex maps to `.codex` rather than `.chatgptWork` because ordinary Codex
+    /// — CLI, exec, the VS Code extension and the desktop app's Codex tab — is
+    /// the overwhelming majority; a ChatGPT Work rollout is recognised from its
+    /// `originator` at scan time and overrides this.
     public static func defaultHarness(for tool: ToolType) -> Harness? {
         switch tool {
         case .codex:       .codex

--- a/Sources/VibeBarCore/Services/CostUsageScanner.swift
+++ b/Sources/VibeBarCore/Services/CostUsageScanner.swift
@@ -156,16 +156,21 @@ public enum CostUsageScanner {
         let totals: Totals
     }
 
-    /// The ChatGPT desktop app writes its agentic sessions into the same
-    /// `~/.codex/sessions` tree as the CLI and stamps them
-    /// `session_meta.payload.originator = "Codex Desktop"`. Every other
-    /// originator we have seen (`codex_cli_rs`, `codex-tui`, `codex_exec`) is
-    /// the CLI, so anything unrecognised — including a missing header — stays
-    /// on the CLI harness rather than being invented as desktop usage.
-    static let codexDesktopOriginator = "Codex Desktop"
+    /// Every Codex surface writes into the same `~/.codex/sessions` tree, and
+    /// `session_meta.payload.originator` is the only stable thing that tells
+    /// them apart — the instructions, tools, turn context, model and sandbox
+    /// are identical across all of them.
+    ///
+    /// Exactly one originator is *not* Codex: `codex_work_desktop`, written by
+    /// ChatGPT **Work** mode in the desktop app. Everything else we have seen —
+    /// `Codex Desktop` (the desktop app's Codex tab), `codex-tui`,
+    /// `codex_cli_rs`, `codex_exec`, `codex_vscode` — is ordinary Codex, so
+    /// anything unrecognised, including a missing header, stays on the Codex
+    /// harness rather than being invented as ChatGPT Work usage.
+    static let chatgptWorkOriginator = "codex_work_desktop"
 
     static func codexHarness(originator: String?) -> Harness {
-        originator == codexDesktopOriginator ? .chatgptWork : .codex
+        originator == chatgptWorkOriginator ? .chatgptWork : .codex
     }
 
     /// Returns the file's token events plus its `session_meta` originator.

--- a/Sources/VibeBarCore/Services/UsageEventLedger.swift
+++ b/Sources/VibeBarCore/Services/UsageEventLedger.swift
@@ -82,6 +82,9 @@ public actor UsageEventLedger: CostUsageEventSink {
     /// as a second "already ran" signal.
     private static let legacyCursorRollupMigrationKey = "cursor_rollup_tool_v1"
     static let harnessMigrationKey = "harness_v1"
+    /// Undoes the first harness rule, which read `originator == "Codex Desktop"`
+    /// as ChatGPT Work. See `migrateCodexDesktopHarnessRows`.
+    static let codexHarnessFixupKey = "harness_v2"
     private static let pricingRevisionKey = "pricing_revision"
     private static let floorKeyPrefix = "detail_floor_day:"
     /// Guard rail on zero-filled trend enumeration: ~135 years of daily
@@ -209,6 +212,9 @@ public actor UsageEventLedger: CostUsageEventSink {
         // Harness first: the Cursor migration below writes `usage_daily_rollups`
         // through its primary key, and that key only gains `harness` here.
         guard Self.migrateHarnessColumns(database) else {
+            throw UsageLedgerError.open
+        }
+        guard Self.migrateCodexDesktopHarnessRows(database) else {
             throw UsageLedgerError.open
         }
         guard Self.migrateCursorToolRows(database) else {
@@ -355,6 +361,77 @@ public actor UsageEventLedger: CostUsageEventSink {
             -1, &insertMarker, nil
         ) == SQLITE_OK, let insertMarker else { return rollback() }
         sqlite3_bind_text(insertMarker, 1, harnessMigrationKey, -1, transient)
+        let markerResult = sqlite3_step(insertMarker)
+        sqlite3_finalize(insertMarker)
+        guard markerResult == SQLITE_DONE,
+              sqlite3_exec(database, "COMMIT", nil, nil, nil) == SQLITE_OK
+        else { return rollback() }
+        return true
+    }
+
+    /// The first harness rule read `originator == "Codex Desktop"` as ChatGPT
+    /// Work. It is not: that is the Codex tab of the desktop app, and only
+    /// `codex_work_desktop` is ChatGPT Work. Fold the mis-stamped rows back
+    /// into Codex — detail rows in place, rollups summed into whatever Codex
+    /// row already holds the same day and model — then drop Codex's ingest
+    /// fingerprints so the next scan re-stamps every rollout under the
+    /// corrected rule.
+    @discardableResult
+    static func migrateCodexDesktopHarnessRows(_ database: OpaquePointer) -> Bool {
+        let transient = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
+        var marker: OpaquePointer?
+        guard sqlite3_prepare_v2(
+            database, "SELECT 1 FROM ledger_meta WHERE key = ?", -1, &marker, nil
+        ) == SQLITE_OK, let marker else { return false }
+        sqlite3_bind_text(marker, 1, codexHarnessFixupKey, -1, transient)
+        let alreadyMigrated = sqlite3_step(marker) == SQLITE_ROW
+        sqlite3_finalize(marker)
+        if alreadyMigrated { return true }
+
+        guard sqlite3_exec(database, "BEGIN IMMEDIATE", nil, nil, nil) == SQLITE_OK else {
+            return false
+        }
+        func rollback() -> Bool {
+            sqlite3_exec(database, "ROLLBACK", nil, nil, nil)
+            return false
+        }
+
+        let codexTool = ToolType.codex.rawValue
+        let codex = Harness.codex.rawValue
+        let chatgptWork = Harness.chatgptWork.rawValue
+        let sql = """
+            UPDATE usage_events
+               SET harness = '\(codex)'
+             WHERE tool = '\(codexTool)' AND harness = '\(chatgptWork)';
+            INSERT INTO usage_daily_rollups(
+                   day, tool, harness, model, requests, fresh_input, output,
+                   cache_read, cache_creation, cost_micros, unpriced
+               )
+               SELECT day, tool, '\(codex)', model, requests, fresh_input, output,
+                      cache_read, cache_creation, cost_micros, unpriced
+                 FROM usage_daily_rollups
+                WHERE tool = '\(codexTool)' AND harness = '\(chatgptWork)'
+               ON CONFLICT(day, tool, harness, model) DO UPDATE SET
+                   requests = usage_daily_rollups.requests + excluded.requests,
+                   fresh_input = usage_daily_rollups.fresh_input + excluded.fresh_input,
+                   output = usage_daily_rollups.output + excluded.output,
+                   cache_read = usage_daily_rollups.cache_read + excluded.cache_read,
+                   cache_creation = usage_daily_rollups.cache_creation + excluded.cache_creation,
+                   cost_micros = usage_daily_rollups.cost_micros + excluded.cost_micros,
+                   unpriced = usage_daily_rollups.unpriced + excluded.unpriced;
+            DELETE FROM usage_daily_rollups
+             WHERE tool = '\(codexTool)' AND harness = '\(chatgptWork)';
+            DELETE FROM ingested_files WHERE tool = '\(codexTool)';
+            """
+        guard sqlite3_exec(database, sql, nil, nil, nil) == SQLITE_OK else { return rollback() }
+
+        var insertMarker: OpaquePointer?
+        guard sqlite3_prepare_v2(
+            database,
+            "INSERT INTO ledger_meta(key, value) VALUES(?, '1') ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+            -1, &insertMarker, nil
+        ) == SQLITE_OK, let insertMarker else { return rollback() }
+        sqlite3_bind_text(insertMarker, 1, codexHarnessFixupKey, -1, transient)
         let markerResult = sqlite3_step(insertMarker)
         sqlite3_finalize(insertMarker)
         guard markerResult == SQLITE_DONE,
@@ -577,8 +654,9 @@ public actor UsageEventLedger: CostUsageEventSink {
     /// One extra clause exists for the harness backfill. Rows keyed by the
     /// file digest (`f:` prefix — Codex / Gemini / Grok / AntiGravity, where
     /// the same request never appears in two files) accept an update whenever
-    /// the incoming harness differs, so a re-scan that finally reads a Codex
-    /// rollout's `originator` can move it from "Codex" to "ChatGPT Work". The
+    /// the incoming harness differs, so a re-scan that re-reads a Codex
+    /// rollout's `originator` can move it either way between "Codex" and
+    /// "ChatGPT Work" — both directions have been needed in practice. The
     /// Claude tuple key is deliberately excluded: there, two rows sharing a
     /// key really are duplicate copies of one request, and the preference
     /// order below must stay the only thing that decides between them.

--- a/Sources/VibeBarCore/Storage/CostUsageScanCache.swift
+++ b/Sources/VibeBarCore/Storage/CostUsageScanCache.swift
@@ -189,7 +189,13 @@ public struct CostUsageScanCache: Codable, Sendable {
     /// their cached RPC result on this one bump and re-fetch the next time
     /// the language server is reachable; ledger rows already ingested from
     /// them are untouched.
-    public static let currentSchemaVersion = 5
+    /// v6 re-parses again after the Codex originator rule was corrected
+    /// (`Codex Desktop` is Codex; only `codex_work_desktop` is ChatGPT
+    /// Work). Cached v5 events carry the wrong stamp, and the reusable-cache
+    /// path replays them without re-reading `originator`, so the ledger's
+    /// `harness_v2` fixup would be undone on the next scan unless the cache
+    /// is invalidated with it.
+    public static let currentSchemaVersion = 6
 
     public static func fileURL(homeDirectory: String, tool: ToolType) -> URL {
         URL(fileURLWithPath: homeDirectory)

--- a/Tests/VibeBarCoreTests/HarnessScanStampingTests.swift
+++ b/Tests/VibeBarCoreTests/HarnessScanStampingTests.swift
@@ -15,25 +15,35 @@ final class HarnessScanStampingTests: XCTestCase {
 
     // MARK: - Codex vs ChatGPT Work
 
-    func testCodexDesktopOriginatorStampsChatGPTWork() async throws {
-        let events = try await scanCodexRollout(originator: "Codex Desktop")
+    /// ChatGPT Work mode in the desktop app is the *only* originator that is
+    /// not Codex.
+    func testWorkDesktopOriginatorStampsChatGPTWork() async throws {
+        let events = try await scanCodexRollout(originator: "codex_work_desktop")
         XCTAssertFalse(events.isEmpty)
         XCTAssertTrue(events.allSatisfy { $0.event.harness == .chatgptWork })
+        XCTAssertEqual(
+            CostUsageScanner.codexHarness(originator: CostUsageScanner.chatgptWorkOriginator),
+            .chatgptWork
+        )
     }
 
-    func testCodexCLIOriginatorsStampCodex() async throws {
-        for originator in ["codex_cli_rs", "codex-tui", "codex_exec"] {
+    /// Including `Codex Desktop` — the desktop app's Codex tab, which spends
+    /// Codex quota like every other Codex surface.
+    func testEveryOtherCodexOriginatorStampsCodex() async throws {
+        for originator in [
+            "Codex Desktop", "codex-tui", "codex_cli_rs", "codex_exec", "codex_vscode"
+        ] {
             let events = try await scanCodexRollout(originator: originator)
             XCTAssertFalse(events.isEmpty, originator)
             XCTAssertTrue(
                 events.allSatisfy { $0.event.harness == .codex },
-                "\(originator) is the CLI, not the desktop app"
+                "\(originator) is Codex, not ChatGPT Work"
             )
         }
     }
 
-    /// A rollout with no readable header must not be invented as desktop
-    /// usage — the CLI is the overwhelming majority.
+    /// A rollout with no readable header must not be invented as ChatGPT Work
+    /// usage — Codex is the overwhelming majority.
     func testMissingOriginatorFallsBackToCodex() async throws {
         let events = try await scanCodexRollout(originator: nil)
         XCTAssertFalse(events.isEmpty)

--- a/Tests/VibeBarCoreTests/UsageLedgerHarnessTests.swift
+++ b/Tests/VibeBarCoreTests/UsageLedgerHarnessTests.swift
@@ -167,6 +167,73 @@ final class UsageLedgerHarnessTests: XCTestCase {
         )
     }
 
+    /// The v2 fixup: rows stamped ChatGPT Work by the old `Codex Desktop` rule
+    /// go back to Codex, folding into the Codex rollup that already owns the
+    /// same day and model instead of sitting beside it.
+    func testCodexHarnessFixupFoldsChatGPTWorkRowsBackIntoCodex() throws {
+        let db = try makeLegacyDatabase()
+        defer { sqlite3_close_v2(db) }
+        XCTAssertTrue(UsageEventLedger.migrateHarnessColumns(db))
+        XCTAssertEqual(sqlite3_exec(db, """
+            UPDATE usage_events SET harness = 'chatgptWork' WHERE tool = 'codex';
+            INSERT INTO usage_daily_rollups(
+                    day, tool, harness, model, requests, fresh_input, output,
+                    cache_read, cache_creation, cost_micros, unpriced)
+                VALUES('2026-06-01', 'codex', 'chatgptWork', 'gpt-5', 9, 90, 9, 5, 1, 900, 3);
+            INSERT INTO usage_daily_rollups(
+                    day, tool, harness, model, requests, cost_micros)
+                VALUES('2026-06-02', 'codex', 'chatgptWork', 'gpt-5', 1, 100);
+            INSERT INTO ingested_files VALUES('codex', 'file-c', 3.0, 30);
+            """, nil, nil, nil), SQLITE_OK)
+
+        XCTAssertTrue(UsageEventLedger.migrateCodexDesktopHarnessRows(db))
+
+        XCTAssertEqual(
+            try rows(db, "SELECT tool, harness FROM usage_events ORDER BY ts"),
+            [["codex", "codex"], ["claude", "claudeCode"], ["cursor", "cursor"]]
+        )
+        // The colliding day is summed; the day Codex did not already own is
+        // simply relabelled. Nothing is left under chatgptWork.
+        XCTAssertEqual(
+            try rows(db, """
+                SELECT day, harness, requests, fresh_input, cost_micros, unpriced
+                  FROM usage_daily_rollups WHERE tool = 'codex' ORDER BY day
+                """),
+            [
+                ["2026-06-01", "codex", "13", "90", "1300", "3"],
+                ["2026-06-02", "codex", "1", "0", "100", "0"]
+            ]
+        )
+        XCTAssertEqual(
+            try rows(db, "SELECT value FROM ledger_meta WHERE key = 'harness_v2'"),
+            [["1"]]
+        )
+        // Codex's fingerprints are gone so the next scan re-stamps every
+        // rollout; no other tool is asked to re-read anything.
+        XCTAssertEqual(
+            try rows(db, "SELECT tool, file_key FROM ingested_files ORDER BY file_key"),
+            [["claude", "file-b"]]
+        )
+
+        // A second open must not re-run: the fingerprints a completed re-scan
+        // wrote have to survive, and the folded rollups must not double.
+        XCTAssertEqual(sqlite3_exec(
+            db, "INSERT INTO ingested_files VALUES('codex', 'file-d', 4.0, 40)", nil, nil, nil
+        ), SQLITE_OK)
+        XCTAssertTrue(UsageEventLedger.migrateCodexDesktopHarnessRows(db))
+        XCTAssertEqual(
+            try rows(db, "SELECT tool, file_key FROM ingested_files ORDER BY file_key"),
+            [["claude", "file-b"], ["codex", "file-d"]]
+        )
+        XCTAssertEqual(
+            try rows(db, """
+                SELECT requests FROM usage_daily_rollups
+                 WHERE tool = 'codex' AND day = '2026-06-01'
+                """),
+            [["13"]]
+        )
+    }
+
     func testFreshLedgerIsBornMigrated() async throws {
         let (ledger, directory) = try UsageLedgerFixtures.makeLedger("HarnessFresh")
         defer { try? FileManager.default.removeItem(at: directory) }


### PR DESCRIPTION
## Why

#177 mapped `originator == "Codex Desktop"` to the **ChatGPT Work** harness. Comparing five deliberately created sessions shows that is wrong: `Codex Desktop` is the Codex tab of the desktop app (7622 rollouts on the maintainer's machine); ChatGPT **Work** sessions carry `originator == "codex_work_desktop"` (3 rollouts). Everything else in `session_meta` / `turn_context` is identical — `originator` is the only stable discriminator. Project vs non-project is only the cwd (`~/Documents/Codex/<date>/…`), not a harness.

## What

- `CostUsageScanner.codexHarness(originator:)`: `codex_work_desktop` → ChatGPT Work; every other originator (`Codex Desktop`, `codex-tui`, `codex_cli_rs`, `codex_exec`, `codex_vscode`, missing) → Codex.
- `Harness.swift` doc table + `AGENTS.md` §7.1 evidence text corrected.
- `UsageEventLedger`: one-shot `harness_v2` fixup — detail rows relabelled back to `codex`, chatgptWork rollups summed into the codex row for the same (day, model), codex ingest fingerprints dropped so the next scan re-stamps every rollout with the corrected rule.
- Tests updated/added (`HarnessScanStampingTests`, `UsageLedgerHarnessTests` v2 fixup incl. second-pass no-op).

## Verification

- `swift build`, `swift test` (1560 tests, 1 skipped, 0 failures)
- `./Scripts/build_app.sh release`, `codesign -d --entitlements -` → empty `<dict/>`, `codesign --verify --deep --strict` OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)
