### PR TITLE
Prepare Vibe Bar 1.3.0 Dev build 32

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.3.0</string>
 	<key>CFBundleVersion</key>
-	<string>31</string>
+	<string>32</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>26.0</string>
 	<key>LSUIElement</key>


### PR DESCRIPTION
## Why

Cut the next Dev channel build after merging:

- #175 Cursor status 90-day uptime history + Grok Bot status group
- #176 Quota freshness aged from the last successful refresh (Gemini Web "Updated just now" / "resets in now")
- #177 Harness axis for usage & cost, Harness Mix, Grok Bot field section, canonical model names, AGENTS.md § 7.1
- #178 Flat Workbench design + Settings as a native page + docs/DESIGN.md
- #179 Harness follow-ups (repricing, request rows, hour floors)
- #180 Strip review-loop cruft from #173 (−324 LOC, Cursor preferred-slot fix)
- #181 Codex originator: only `codex_work_desktop` is ChatGPT Work
- #182 Sessions for every harness (Cowork, Cursor adapters; harness + model on rows)

## What

- `Resources/Info.plist`: `CFBundleVersion` 31 → 32. `CFBundleShortVersionString` stays `1.3.0`.

Note for upgraders: first launch performs a one-time scan-cache re-parse (v6) and ledger fixups (harness_v1/v2, session index v2 rebuild).

## Verification

- `swift build`, `swift test` (1616 tests, 1 skipped, 0 failures)
- `./Scripts/build_app.sh release`, `codesign -d --entitlements -` → empty `<dict/>`, `codesign --verify --deep --strict` OK; bundle reports build 32

Tag `v1.3.0-dev.32` will be created on the merged commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
