### PR TITLE
Track Cursor's WAL and retry locked blob reads

### DIFF
--- a/Sources/VibeBarCore/Sessions/CursorSessionAdapter.swift
+++ b/Sources/VibeBarCore/Sessions/CursorSessionAdapter.swift
@@ -243,7 +243,7 @@ public struct CursorSessionAdapter: SessionProviderAdapter {
         while cursor < queue.count, visited < maxBlobsVisited, budgetBytes > 0 {
             let id = queue[cursor]
             cursor += 1
-            guard let data = blob(statement, id: id) else { continue }
+            guard let data = try blob(statement, id: id) else { continue }
             visited += 1
             budgetBytes -= data.count
 
@@ -303,12 +303,19 @@ public struct CursorSessionAdapter: SessionProviderAdapter {
     /// Blob ids are SHA-256, so a reference is exactly 32 bytes.
     static let referenceByteCount = 32
 
-    private static func blob(_ statement: OpaquePointer, id: String) -> Data? {
+    /// `nil` only for a genuinely missing row. A step error (`SQLITE_BUSY`,
+    /// `SQLITE_LOCKED`, …) on Cursor's live handle throws so
+    /// `LiveSQLiteReader.read` abandons this pass and retries on a snapshot
+    /// instead of indexing a silently partial walk.
+    private static func blob(_ statement: OpaquePointer, id: String) throws -> Data? {
         sqlite3_reset(statement)
         sqlite3_clear_bindings(statement)
         sqlite3_bind_text(statement, 1, id, -1, unsafeBitCast(-1, to: sqlite3_destructor_type.self))
-        guard sqlite3_step(statement) == SQLITE_ROW else { return nil }
-        return LiveSQLiteReader.blob(statement, 0)
+        switch sqlite3_step(statement) {
+        case SQLITE_ROW: return LiveSQLiteReader.blob(statement, 0)
+        case SQLITE_DONE: return nil
+        default: throw LiveSQLiteReader.ReadError.statement
+        }
     }
 
     /// A blob that is a message rather than a node. Cheap rejection first:

--- a/Sources/VibeBarCore/Sessions/SessionIndexService.swift
+++ b/Sources/VibeBarCore/Sessions/SessionIndexService.swift
@@ -168,9 +168,22 @@ public actor SessionIndexService {
     /// Nanosecond mtime + size. Second-resolution timestamps are too
     /// coarse: a session file appended to twice inside the same second is
     /// exactly the case an incremental index has to notice.
+    ///
+    /// A live SQLite store in WAL mode commits into `<file>-wal` and leaves
+    /// the main file untouched until a checkpoint, so the journal sibling is
+    /// folded in (latest mtime, summed size) or an active Cursor / AntiGravity
+    /// conversation would look unchanged for as long as it is being written.
     static func fingerprint(_ url: URL) -> (mtimeNanos: Int64, size: Int64)? {
+        guard var result = statFingerprint(url.path) else { return nil }
+        if let wal = statFingerprint(url.path + "-wal") {
+            result = (max(result.mtimeNanos, wal.mtimeNanos), result.size + wal.size)
+        }
+        return result
+    }
+
+    private static func statFingerprint(_ path: String) -> (mtimeNanos: Int64, size: Int64)? {
         var info = stat()
-        guard stat(url.path, &info) == 0 else { return nil }
+        guard stat(path, &info) == 0 else { return nil }
         let seconds = Int64(info.st_mtimespec.tv_sec)
         let nanos = Int64(info.st_mtimespec.tv_nsec)
         return (seconds * 1_000_000_000 + nanos, Int64(info.st_size))


### PR DESCRIPTION
## Why

Two post-merge findings on #182's Cursor session adapter, both real on this machine (every `~/.cursor/chats/*/*/store.db` has a `-wal` sibling):

- The session index fingerprinted only `store.db`, so a WAL-mode conversation looked unchanged between checkpoints and its model / message count / transcript went stale.
- A `SQLITE_BUSY` / `SQLITE_LOCKED` step on Cursor's live handle was treated as a missing blob, so the walk returned a silently partial result and `LiveSQLiteReader`'s snapshot fallback never ran.

## What

- `SessionIndexService.fingerprint`: fold `<file>-wal` into the fingerprint (latest mtime, summed size). Generic — benefits AntiGravity's live stores too.
- `CursorSessionAdapter.blob`: `SQLITE_DONE` ⇒ nil, any other non-row result throws `ReadError.statement`, so the read is retried on a snapshot.

## Verification

- `swift build`, `swift test` (1616 tests, 1 skipped, 0 failures)
- `./Scripts/build_app.sh release`, `codesign -d --entitlements -` → empty `<dict/>`, `codesign --verify --deep --strict` OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)
