### PR TITLE
Speed up the Workbench Requests tab and multi-window rendering

### DIFF
--- a/Sources/VibeBarApp/Controllers/UsageStatsViewModel.swift
+++ b/Sources/VibeBarApp/Controllers/UsageStatsViewModel.swift
@@ -527,7 +527,7 @@ final class UsageStatsViewModel: ObservableObject {
         case .requests:
             guard let requests else { return }
             updated.requestRows = requests.rows
-            updated.requestTotalCount = requests.totalCount
+            updated.requestTotalCount = requests.totalCount ?? 0
             updated.nextRequestCursor = requests.nextCursor
         }
         results = updated
@@ -552,7 +552,7 @@ final class UsageStatsViewModel: ObservableObject {
         isLoadingMore = true
         Task { [weak self] in
             let result = try? await ledger.requestPage(
-                filter, after: cursor, pageSize: Self.requestPageSize
+                filter, after: cursor, pageSize: Self.requestPageSize, includeTotal: false
             )
             guard let self, generation == self.generation else { return }
             self.isLoadingMore = false
@@ -682,7 +682,7 @@ final class UsageStatsViewModel: ObservableObject {
             harnessStats: snapshot.harnesses,
             modelStats: snapshot.models,
             requestRows: snapshot.requests.rows,
-            requestTotalCount: snapshot.requests.totalCount,
+            requestTotalCount: snapshot.requests.totalCount ?? 0,
             nextRequestCursor: snapshot.requests.nextCursor
         )
         // Key off the breakdown the snapshot was *queried* for: the user can
@@ -729,7 +729,9 @@ final class UsageStatsViewModel: ObservableObject {
         guard page.cursor == results.nextRequestCursor else { return }
         var updated = results
         updated.requestRows.append(contentsOf: page.rows)
-        updated.requestTotalCount = page.totalCount
+        // A continuation page does not recount; the pinned filter means the
+        // number the first page reported is still the right one.
+        if let totalCount = page.totalCount { updated.requestTotalCount = totalCount }
         updated.nextRequestCursor = page.nextCursor
         results = updated
     }

--- a/Sources/VibeBarApp/Controllers/UsageStatsViewModel.swift
+++ b/Sources/VibeBarApp/Controllers/UsageStatsViewModel.swift
@@ -332,6 +332,14 @@ final class UsageStatsViewModel: ObservableObject {
     private let costService: CostUsageService
 
     private var reloadTask: Task<Void, Never>?
+    /// A deferred Models / Requests fetch that fills one tab without redoing
+    /// the whole query set. Separate from `reloadTask` so a tab switch never
+    /// cancels the reload that produced the numbers it is merging into.
+    private var breakdownTask: Task<Void, Never>?
+    /// The deferred breakdowns whose contents in `results` belong to
+    /// `activeFilter`. Cleared by every reload, so a filter or range change
+    /// re-fetches rather than showing a tab's stale rows.
+    private var loadedBreakdowns: Set<Breakdown> = []
     private var tickTask: Task<Void, Never>?
     private var lastCostRefreshAt: Date?
     private var loadedRequestPages = 0
@@ -391,6 +399,8 @@ final class UsageStatsViewModel: ObservableObject {
         tickTask = nil
         reloadTask?.cancel()
         reloadTask = nil
+        breakdownTask?.cancel()
+        breakdownTask = nil
     }
 
     // MARK: - Filter mutation
@@ -461,9 +471,68 @@ final class UsageStatsViewModel: ObservableObject {
         // queries. Models and Requests are intentionally loaded only when the
         // user opens those tabs, avoiding two full 30-day scans on every range
         // change.
-        if breakdown == .models || breakdown == .requests {
-            reload(cascadeModels: false)
+        switch breakdown {
+        case .periods, .providers:
+            break
+        case .models, .requests:
+            guard !loadedBreakdowns.contains(breakdown) else { break }
+            loadDeferredBreakdown(breakdown)
         }
+    }
+
+    /// Fetch only what a newly opened tab needs, against the filter the
+    /// visible results were already produced with.
+    ///
+    /// Opening a tab used to call `reload`, which re-ran the whole analytic
+    /// set — up to nine sequential ledger round trips, including the day × tool
+    /// trend GROUP BY that dominates the query at 30 days — to redraw numbers
+    /// that had not changed and were already on screen. Filter, range and
+    /// refresh changes still take the full path; this one only fills the hole.
+    private func loadDeferredBreakdown(_ breakdown: Breakdown) {
+        guard let ledger, let filter = activeFilter, !isLoading else {
+            // No settled filter to reuse (first load still in flight, or the
+            // ledger is unavailable): the full path is the only correct one.
+            reload(cascadeModels: false)
+            return
+        }
+        breakdownTask?.cancel()
+        let generation = self.generation
+        isLoadingMore = true
+        breakdownTask = Task { [weak self] in
+            let models: [UsageModelStat] = breakdown == .models
+                ? ((try? await ledger.modelStats(filter)) ?? [])
+                : []
+            let requests: UsageRequestPage? = breakdown == .requests
+                ? (try? await ledger.requestPage(
+                    filter, page: 0, pageSize: UsageStatsViewModel.requestPageSize
+                ))
+                : nil
+            guard let self, !Task.isCancelled, generation == self.generation else { return }
+            self.isLoadingMore = false
+            self.applyDeferred(breakdown, models: models, requests: requests)
+        }
+    }
+
+    private func applyDeferred(
+        _ breakdown: Breakdown,
+        models: [UsageModelStat],
+        requests: UsageRequestPage?
+    ) {
+        guard activeBreakdown == breakdown else { return }
+        var updated = results
+        switch breakdown {
+        case .periods, .providers:
+            return
+        case .models:
+            updated.modelStats = models
+        case .requests:
+            guard let requests else { return }
+            updated.requestRows = requests.rows
+            updated.requestTotalCount = requests.totalCount
+            loadedRequestPages = 1
+        }
+        results = updated
+        loadedBreakdowns.insert(breakdown)
     }
 
     // MARK: - Queries
@@ -509,6 +578,8 @@ final class UsageStatsViewModel: ObservableObject {
         generation &+= 1
         let generation = self.generation
         reloadTask?.cancel()
+        breakdownTask?.cancel()
+        loadedBreakdowns.removeAll()
         loadedRequestPages = 0
         activeFilter = nil
         // A page still in flight is now for a filter nobody is looking at; it
@@ -615,7 +686,13 @@ final class UsageStatsViewModel: ObservableObject {
             requestRows: snapshot.requests.rows,
             requestTotalCount: snapshot.requests.totalCount
         )
-        loadedRequestPages = activeBreakdown == .requests ? 1 : 0
+        // Key off the breakdown the snapshot was *queried* for: the user can
+        // open a different tab while the query is in flight, and claiming that
+        // tab is loaded would leave it permanently empty.
+        loadedRequestPages = snapshot.breakdown == .requests ? 1 : 0
+        loadedBreakdowns = snapshot.breakdown == .models || snapshot.breakdown == .requests
+            ? [snapshot.breakdown]
+            : []
         observedTools.formUnion(snapshot.providers.map(\.tool))
         observedTools.formUnion(selectedTools ?? [])
         knownTools = ToolType.allCases.filter {
@@ -693,6 +770,8 @@ final class UsageStatsViewModel: ObservableObject {
         let harnesses: [UsageHarnessStat]
         let models: [UsageModelStat]
         let requests: UsageRequestPage
+        /// Which deferred tab this snapshot actually answered for.
+        let breakdown: Breakdown
     }
 
     private struct UsageResults {
@@ -740,7 +819,8 @@ final class UsageStatsViewModel: ObservableObject {
             providers: providers,
             harnesses: harnesses,
             models: models,
-            requests: requests
+            requests: requests,
+            breakdown: breakdown
         )
     }
 }

--- a/Sources/VibeBarApp/Controllers/UsageStatsViewModel.swift
+++ b/Sources/VibeBarApp/Controllers/UsageStatsViewModel.swift
@@ -189,9 +189,9 @@ final class UsageStatsViewModel: ObservableObject {
 
     let isLedgerAvailable: Bool
 
-    var hasMoreRequests: Bool {
-        requestRows.count < requestTotalCount
-    }
+    /// The ledger reports where the loaded run stops, so this no longer has
+    /// to infer "more exist" from a count that a concurrent scan can move.
+    var hasMoreRequests: Bool { results.nextRequestCursor != nil }
 
     var knownCompanyRepresentatives: [ToolType] {
         ToolType.coreProviderRepresentatives.filter { representative in
@@ -342,7 +342,6 @@ final class UsageStatsViewModel: ObservableObject {
     private var loadedBreakdowns: Set<Breakdown> = []
     private var tickTask: Task<Void, Never>?
     private var lastCostRefreshAt: Date?
-    private var loadedRequestPages = 0
     private var lastAvailableModelsRevision: UInt64?
     private var generation: UInt64 = 0
     private var hasLoadedOnce = false
@@ -504,7 +503,7 @@ final class UsageStatsViewModel: ObservableObject {
                 : []
             let requests: UsageRequestPage? = breakdown == .requests
                 ? (try? await ledger.requestPage(
-                    filter, page: 0, pageSize: UsageStatsViewModel.requestPageSize
+                    filter, pageSize: UsageStatsViewModel.requestPageSize
                 ))
                 : nil
             guard let self, !Task.isCancelled, generation == self.generation else { return }
@@ -529,7 +528,7 @@ final class UsageStatsViewModel: ObservableObject {
             guard let requests else { return }
             updated.requestRows = requests.rows
             updated.requestTotalCount = requests.totalCount
-            loadedRequestPages = 1
+            updated.nextRequestCursor = requests.nextCursor
         }
         results = updated
         loadedBreakdowns.insert(breakdown)
@@ -541,19 +540,19 @@ final class UsageStatsViewModel: ObservableObject {
         reload(cascadeModels: true)
     }
 
-    /// Next zero-based page of request rows, appended to what is already on
-    /// screen. Pages from a superseded filter are dropped on arrival.
+    /// The next run of request rows, appended to what is already on screen.
+    /// Pages from a superseded filter are dropped on arrival.
     func loadMoreRequests() {
         guard let ledger, let filter = activeFilter,
+              let cursor = results.nextRequestCursor,
               activeBreakdown == .requests,
-              !isLoadingMore, !isLoading, hasMoreRequests
+              !isLoadingMore, !isLoading
         else { return }
         let generation = self.generation
-        let page = loadedRequestPages
         isLoadingMore = true
         Task { [weak self] in
             let result = try? await ledger.requestPage(
-                filter, page: page, pageSize: Self.requestPageSize
+                filter, after: cursor, pageSize: Self.requestPageSize
             )
             guard let self, generation == self.generation else { return }
             self.isLoadingMore = false
@@ -580,7 +579,6 @@ final class UsageStatsViewModel: ObservableObject {
         reloadTask?.cancel()
         breakdownTask?.cancel()
         loadedBreakdowns.removeAll()
-        loadedRequestPages = 0
         activeFilter = nil
         // A page still in flight is now for a filter nobody is looking at; it
         // drops itself on the generation check and never clears this, so the
@@ -684,12 +682,12 @@ final class UsageStatsViewModel: ObservableObject {
             harnessStats: snapshot.harnesses,
             modelStats: snapshot.models,
             requestRows: snapshot.requests.rows,
-            requestTotalCount: snapshot.requests.totalCount
+            requestTotalCount: snapshot.requests.totalCount,
+            nextRequestCursor: snapshot.requests.nextCursor
         )
         // Key off the breakdown the snapshot was *queried* for: the user can
         // open a different tab while the query is in flight, and claiming that
         // tab is loaded would leave it permanently empty.
-        loadedRequestPages = snapshot.breakdown == .requests ? 1 : 0
         loadedBreakdowns = snapshot.breakdown == .models || snapshot.breakdown == .requests
             ? [snapshot.breakdown]
             : []
@@ -717,20 +715,23 @@ final class UsageStatsViewModel: ObservableObject {
             harnessStats: [],
             modelStats: [],
             requestRows: [],
-            requestTotalCount: 0
+            requestTotalCount: 0,
+            nextRequestCursor: nil
         )
         availableModels = []
         isLoading = false
     }
 
+    /// A keyset page starts strictly after the cursor it was asked for, so
+    /// the rows can never overlap what is already on screen — as long as this
+    /// really is the page that continues from where the list currently ends.
     private func append(_ page: UsageRequestPage) {
-        guard page.page == loadedRequestPages else { return }
-        let known = Set(requestRows.map(\.id))
+        guard page.cursor == results.nextRequestCursor else { return }
         var updated = results
-        updated.requestRows.append(contentsOf: page.rows.filter { !known.contains($0.id) })
+        updated.requestRows.append(contentsOf: page.rows)
         updated.requestTotalCount = page.totalCount
+        updated.nextRequestCursor = page.nextCursor
         results = updated
-        loadedRequestPages = page.page + 1
     }
 
     // MARK: - Polling
@@ -782,6 +783,9 @@ final class UsageStatsViewModel: ObservableObject {
         var modelStats: [UsageModelStat]
         var requestRows: [UsageRequestRow]
         var requestTotalCount: Int
+        /// Where the loaded run stops. `nil` means the range holds nothing
+        /// more, so paging is finished rather than merely not started.
+        var nextRequestCursor: UsageRequestCursor?
 
         static let empty = UsageResults(
             summary: .empty,
@@ -790,7 +794,8 @@ final class UsageStatsViewModel: ObservableObject {
             harnessStats: [],
             modelStats: [],
             requestRows: [],
-            requestTotalCount: 0
+            requestTotalCount: 0,
+            nextRequestCursor: nil
         )
     }
 
@@ -810,9 +815,9 @@ final class UsageStatsViewModel: ObservableObject {
             ? ((try? await ledger.modelStats(filter)) ?? [])
             : []
         let requests = breakdown == .requests
-            ? ((try? await ledger.requestPage(filter, page: 0, pageSize: requestPageSize))
-                ?? UsageRequestPage(rows: [], totalCount: 0, page: 0, pageSize: requestPageSize))
-            : UsageRequestPage(rows: [], totalCount: 0, page: 0, pageSize: requestPageSize)
+            ? ((try? await ledger.requestPage(filter, pageSize: requestPageSize))
+                ?? UsageRequestPage(rows: [], totalCount: 0, pageSize: requestPageSize))
+            : UsageRequestPage(rows: [], totalCount: 0, pageSize: requestPageSize)
         return LoadedUsage(
             summary: summary,
             trend: trend,

--- a/Sources/VibeBarApp/Controllers/UsageStatsViewModel.swift
+++ b/Sources/VibeBarApp/Controllers/UsageStatsViewModel.swift
@@ -172,7 +172,12 @@ final class UsageStatsViewModel: ObservableObject {
     var modelStats: [UsageModelStat] { results.modelStats }
     var requestRows: [UsageRequestRow] { results.requestRows }
     var requestTotalCount: Int { results.requestTotalCount }
-    @Published private(set) var availableModels: [String] = []
+    /// Both of these used to be their own `@Published`, written mid-reload
+    /// at two different await points — so a single query rebuilt the whole
+    /// analytics tree three times: once for the model list, once for the
+    /// hourly flag, once for the results they describe. They travel with the
+    /// snapshot now and land in the same publication.
+    var availableModels: [String] { results.availableModels }
     /// Tools behind the company chips: the cost-aware set, widened by any
     /// tool the ledger actually has rows for.
     @Published private(set) var knownTools: [ToolType] = ToolType.usageStatsProviders
@@ -185,7 +190,7 @@ final class UsageStatsViewModel: ObservableObject {
     /// True only when the current filter lies wholly above every selected
     /// provider's ledger detail floor. This drives the Hourly menu state and
     /// is refreshed alongside the query it describes.
-    @Published private(set) var isHourlyTrendAvailable = true
+    var isHourlyTrendAvailable: Bool { results.isHourlyTrendAvailable }
 
     let isLedgerAvailable: Bool
 
@@ -640,14 +645,9 @@ final class UsageStatsViewModel: ObservableObject {
             if cascadeModels {
                 self.pruneSelectedModels(to: models)
             }
-            self.availableModels = models
-            if let refreshedModelsRevision {
-                self.lastAvailableModelsRevision = refreshedModelsRevision
-            }
             let resolved = self.filter
             let supportsHourly = (try? await ledger.supportsHourlyTrend(resolved)) ?? false
             guard !Task.isCancelled, generation == self.generation else { return }
-            self.isHourlyTrendAvailable = supportsHourly
             if self.trendGranularity == .hour, !supportsHourly {
                 // Keep the Picker's intent and the returned series aligned.
                 // `trend` also falls back defensively in case the floor moves
@@ -664,7 +664,12 @@ final class UsageStatsViewModel: ObservableObject {
             )
             guard !Task.isCancelled, generation == self.generation else { return }
             self.activeFilter = resolved
-            self.apply(snapshot)
+            if let refreshedModelsRevision {
+                self.lastAvailableModelsRevision = refreshedModelsRevision
+            }
+            self.apply(
+                snapshot, availableModels: models, isHourlyTrendAvailable: supportsHourly
+            )
         }
     }
 
@@ -674,7 +679,11 @@ final class UsageStatsViewModel: ObservableObject {
         self.selectedModels = kept.isEmpty ? nil : kept
     }
 
-    private func apply(_ snapshot: LoadedUsage) {
+    private func apply(
+        _ snapshot: LoadedUsage,
+        availableModels: [String],
+        isHourlyTrendAvailable: Bool
+    ) {
         results = UsageResults(
             summary: snapshot.summary,
             trend: snapshot.trend,
@@ -683,7 +692,9 @@ final class UsageStatsViewModel: ObservableObject {
             modelStats: snapshot.models,
             requestRows: snapshot.requests.rows,
             requestTotalCount: snapshot.requests.totalCount ?? 0,
-            nextRequestCursor: snapshot.requests.nextCursor
+            nextRequestCursor: snapshot.requests.nextCursor,
+            availableModels: availableModels,
+            isHourlyTrendAvailable: isHourlyTrendAvailable
         )
         // Key off the breakdown the snapshot was *queried* for: the user can
         // open a different tab while the query is in flight, and claiming that
@@ -716,9 +727,10 @@ final class UsageStatsViewModel: ObservableObject {
             modelStats: [],
             requestRows: [],
             requestTotalCount: 0,
-            nextRequestCursor: nil
+            nextRequestCursor: nil,
+            availableModels: [],
+            isHourlyTrendAvailable: isHourlyTrendAvailable
         )
-        availableModels = []
         isLoading = false
     }
 
@@ -788,6 +800,8 @@ final class UsageStatsViewModel: ObservableObject {
         /// Where the loaded run stops. `nil` means the range holds nothing
         /// more, so paging is finished rather than merely not started.
         var nextRequestCursor: UsageRequestCursor?
+        var availableModels: [String]
+        var isHourlyTrendAvailable: Bool
 
         static let empty = UsageResults(
             summary: .empty,
@@ -797,7 +811,9 @@ final class UsageStatsViewModel: ObservableObject {
             modelStats: [],
             requestRows: [],
             requestTotalCount: 0,
-            nextRequestCursor: nil
+            nextRequestCursor: nil,
+            availableModels: [],
+            isHourlyTrendAvailable: true
         )
     }
 

--- a/Sources/VibeBarApp/ProviderBrandIcon.swift
+++ b/Sources/VibeBarApp/ProviderBrandIcon.swift
@@ -4,13 +4,62 @@ import VibeBarCore
 
 @MainActor
 enum ProviderBrandIcon {
+    /// Finished glyphs, keyed by everything that can change one.
+    ///
+    /// Every brand mark used to be re-read from disk (or re-parsed from the
+    /// inline SVG), resized, and composited through an off-screen
+    /// `lockFocus` pass on *every* SwiftUI body evaluation. A Workbench
+    /// Requests page draws one badge per row, so scrolling a 30-day ledger
+    /// meant a hundred `NSImage(contentsOf:)` calls per frame. The assets are
+    /// static, so the result of that pipeline is a pure function of the key
+    /// below and can be memoized for the life of the process.
+    private static var renderCache: [RenderKey: NSImage] = [:]
+    /// Decoded, resized source marks. Never handed to a caller — the tinted
+    /// path only uses them as a draw source, and the untinted path vends a
+    /// copy so a caller's `isTemplate` never leaks back into the cache.
+    private static var sourceCache: [SourceKey: NSImage] = [:]
+    /// Sizes come from layout, so a pathological caller could feed fractional
+    /// values forever. Dropping the whole cache past this many entries keeps
+    /// the memoization bounded without pretending to be an LRU.
+    private static let cacheLimit = 512
+
+    private struct SourceKey: Hashable {
+        let tool: ToolType
+        let width: CGFloat
+        let height: CGFloat
+    }
+
+    private struct RenderKey: Hashable {
+        /// `nil` is the Vibe Bar glyph drawn for a `MenuBarItemKind`, which
+        /// ignores the kind itself.
+        let tool: ToolType?
+        let width: CGFloat
+        let height: CGFloat
+        let tint: NSColor?
+        let appearance: String?
+        let includeStatusDot: Bool
+    }
+
     static func image(
         for kind: MenuBarItemKind,
         size: NSSize = NSSize(width: 16, height: 16),
         tint: NSColor? = nil,
         appearance: NSAppearance? = nil
     ) -> NSImage? {
-        vibeBarGlyphImage(size: size, tint: tint, appearance: appearance, includeStatusDot: false)
+        let key = RenderKey(
+            tool: nil,
+            width: size.width,
+            height: size.height,
+            tint: tint,
+            appearance: appearance?.name.rawValue,
+            includeStatusDot: false
+        )
+        if let cached = renderCache[key] { return cached }
+        let image = vibeBarGlyphImage(
+            size: size, tint: tint, appearance: appearance, includeStatusDot: false
+        )
+        if let image { store(image, for: key) }
+        return image
     }
 
     static func image(
@@ -19,12 +68,25 @@ enum ProviderBrandIcon {
         tint: NSColor? = nil,
         appearance: NSAppearance? = nil
     ) -> NSImage? {
+        let key = RenderKey(
+            tool: tool,
+            width: size.width,
+            height: size.height,
+            tint: tint,
+            appearance: appearance?.name.rawValue,
+            includeStatusDot: false
+        )
+        if let cached = renderCache[key] { return cached }
         guard let source = sourceImage(for: tool, size: size) else { return nil }
         guard let tint else {
-            source.isTemplate = true
-            return source
+            // The cached source stays untouched: `isTemplate` is a property of
+            // the image object, and the tinted path draws from the same one.
+            let template = (source.copy() as? NSImage) ?? source
+            template.isTemplate = true
+            store(template, for: key)
+            return template
         }
-        return drawWithAppearance(appearance) {
+        let image = drawWithAppearance(appearance) {
             let image = NSImage(size: size)
             image.lockFocus()
             let rect = NSRect(origin: .zero, size: size)
@@ -38,6 +100,13 @@ enum ProviderBrandIcon {
             image.isTemplate = false
             return image
         }
+        store(image, for: key)
+        return image
+    }
+
+    private static func store(_ image: NSImage, for key: RenderKey) {
+        if renderCache.count >= cacheLimit { renderCache.removeAll(keepingCapacity: true) }
+        renderCache[key] = image
     }
 
     static func fallbackSystemImage(for kind: MenuBarItemKind) -> String {
@@ -139,6 +208,15 @@ enum ProviderBrandIcon {
     }
 
     private static func sourceImage(for tool: ToolType, size: NSSize) -> NSImage? {
+        let key = SourceKey(tool: tool, width: size.width, height: size.height)
+        if let cached = sourceCache[key] { return cached }
+        guard let image = decodeSourceImage(for: tool, size: size) else { return nil }
+        if sourceCache.count >= cacheLimit { sourceCache.removeAll(keepingCapacity: true) }
+        sourceCache[key] = image
+        return image
+    }
+
+    private static func decodeSourceImage(for tool: ToolType, size: NSSize) -> NSImage? {
         if let url = providerIconURL(for: tool),
            let image = NSImage(contentsOf: url) {
             image.size = size
@@ -156,7 +234,19 @@ enum ProviderBrandIcon {
         return image
     }
 
+    /// Resolving a bundle resource hits the filesystem, so the answer is
+    /// memoized alongside the decoded marks: `Bundle.main.url(forResource:)`
+    /// used to run once per row per render.
+    private static var iconURLCache: [ToolType: URL?] = [:]
+
     private static func providerIconURL(for tool: ToolType) -> URL? {
+        if let cached = iconURLCache[tool] { return cached }
+        let resolved = resolveProviderIconURL(for: tool)
+        iconURLCache[tool] = resolved
+        return resolved
+    }
+
+    private static func resolveProviderIconURL(for tool: ToolType) -> URL? {
         let name = tool.providerIconResourceName
         if let url = Bundle.main.url(
             forResource: name,

--- a/Sources/VibeBarApp/Views/Workbench/UsageBreakdownTables.swift
+++ b/Sources/VibeBarApp/Views/Workbench/UsageBreakdownTables.swift
@@ -179,20 +179,19 @@ struct UsageBreakdownTables: View {
 
     /// Requests intentionally retain a horizontal scroll surface: a request
     /// carries seven useful fields and compressing it would erase the model or
-    /// tier. The last realized row remains the paging trigger.
+    /// tier.
+    ///
+    /// Unlike the other three tables this one owns its vertical scrolling too,
+    /// clamped to `requestsMaxViewportHeight`. A `LazyVStack` only culls what
+    /// its enclosing scroll view clips, and the table used to hand the parent
+    /// scroller its full content height — so every loaded row realized, and
+    /// the last row's `onAppear` immediately asked for the next page, which
+    /// realized more rows, which fired again. Paging is an explicit button
+    /// now; nothing chains.
     private var requestsTable: some View {
-        ScrollView(.horizontal, showsIndicators: false) {
-            VStack(spacing: 0) {
-                tableHeader {
-                    headerCell("Time", width: 138)
-                    headerCell("Harness", width: 138)
-                    headerCell("Model", width: 220)
-                    headerCell("Input", width: 114, alignment: .trailing)
-                    headerCell("Output", width: 88, alignment: .trailing)
-                    headerCell("Cost", width: 96, alignment: .trailing)
-                    headerCell("Tier", width: 86)
-                }
-                LazyVStack(spacing: 0) {
+        ScrollView([.horizontal, .vertical], showsIndicators: true) {
+            LazyVStack(spacing: 0, pinnedViews: [.sectionHeaders]) {
+                Section {
                     ForEach(model.requestRows) { row in
                         PorcelainUsageRow(accessibilityLabel: requestAccessibilityLabel(row)) {
                             valueCell(timestamp(row.date), width: 138, secondary: true, tooltip: timestamp(row.date))
@@ -207,14 +206,64 @@ struct UsageBreakdownTables: View {
                             optionalMoneyCell(row.costMicros, width: 96)
                             valueCell(row.serviceTier ?? "—", width: 86, secondary: true, tooltip: row.serviceTier)
                         }
-                        .onAppear { loadMoreIfLast(row) }
                     }
+                    if model.hasMoreRequests { loadMoreRow }
+                } header: {
+                    tableHeader {
+                        headerCell("Time", width: 138)
+                        headerCell("Harness", width: 138)
+                        headerCell("Model", width: 220)
+                        headerCell("Input", width: 114, alignment: .trailing)
+                        headerCell("Output", width: 88, alignment: .trailing)
+                        headerCell("Cost", width: 96, alignment: .trailing)
+                        headerCell("Tier", width: 86)
+                    }
+                    // Opaque: a pinned header floats over the rows it labels,
+                    // and flat surfaces cast no shadow to separate them.
+                    .background(WorkbenchPorcelain.overlayFill(for: colorScheme))
                 }
             }
             .frame(minWidth: 898, alignment: .leading)
         }
         .accessibilityLabel("Request usage table")
-        .frame(height: tableHeight(for: model.requestRows.count))
+        .frame(height: requestsViewportHeight)
+    }
+
+    /// Explicit paging. An `onAppear` sentinel on the last row cannot tell
+    /// "the user scrolled to the end" from "SwiftUI realized the row", and the
+    /// second reading walks the whole ledger one 50-row publish at a time.
+    private var loadMoreRow: some View {
+        let remaining = max(0, model.requestTotalCount - model.requestRows.count)
+        return Button {
+            model.loadMoreRequests()
+        } label: {
+            HStack(spacing: 6) {
+                if model.isLoadingMore {
+                    ProgressView().controlSize(.small)
+                } else {
+                    Image(systemName: "arrow.down.circle")
+                        .font(.system(size: 11, weight: .medium))
+                }
+                Text(model.isLoadingMore
+                    ? "Loading more requests…"
+                    : "Load more (\(remaining.formatted(.number.grouping(.automatic))) remaining)")
+                    .font(.system(size: 11, weight: .medium))
+            }
+            .foregroundStyle(.secondary)
+            .frame(maxWidth: .infinity, minHeight: 33)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .disabled(model.isLoadingMore)
+    }
+
+    /// Enough rows to read a burst of activity without handing SwiftUI a
+    /// viewport tall enough to realize a whole page at once.
+    private static let requestsMaxViewportHeight: CGFloat = 27 + 34 * 15
+
+    private var requestsViewportHeight: CGFloat {
+        let rows = model.requestRows.count + (model.hasMoreRequests ? 1 : 0)
+        return min(tableHeight(for: rows), Self.requestsMaxViewportHeight)
     }
 
     private var providersTable: some View {
@@ -427,14 +476,9 @@ struct UsageBreakdownTables: View {
         .accessibilityElement(children: .combine)
     }
 
-    private func loadMoreIfLast(_ row: UsageRequestRow) {
-        guard row.id == model.requestRows.last?.id else { return }
-        model.loadMoreRequests()
-    }
-
-    /// Header plus 34-point rows, instead of a density-dependent empty pane.
-    /// The parent Usage Stats scroller owns vertical scrolling, so this is
-    /// deliberately the real content height rather than a fixed viewport.
+    /// Header plus 34-point rows. Periods / Providers / Models hand this to
+    /// the parent Usage Stats scroller as their real content height; Requests
+    /// clamps it into its own viewport so its `LazyVStack` can cull.
     private func tableHeight(for rowCount: Int) -> CGFloat {
         CGFloat(max(rowCount, 1)) * 34 + 27
     }

--- a/Sources/VibeBarApp/Views/Workbench/UsageBreakdownTables.swift
+++ b/Sources/VibeBarApp/Views/Workbench/UsageBreakdownTables.swift
@@ -162,8 +162,11 @@ struct UsageBreakdownTables: View {
                 }
                 LazyVStack(spacing: 0) {
                     ForEach(populatedPeriods, id: \.bucketStart) { point in
-                        PorcelainUsageRow(accessibilityLabel: periodAccessibilityLabel(point)) {
-                            valueCell(period(point.bucketStart), width: periodWidth, tooltip: period(point.bucketStart))
+                        let label = period(point.bucketStart)
+                        PorcelainUsageRow(
+                            accessibilityLabel: periodAccessibilityLabel(point, label: label)
+                        ) {
+                            valueCell(label, width: periodWidth, tooltip: label)
                             numericCell(point.freshInput, width: 108)
                             numericCell(point.output, width: 108)
                             numericCell(point.cacheRead + point.cacheCreation, width: 108)
@@ -193,18 +196,20 @@ struct UsageBreakdownTables: View {
             LazyVStack(spacing: 0, pinnedViews: [.sectionHeaders]) {
                 Section {
                     ForEach(model.requestRows) { row in
-                        PorcelainUsageRow(accessibilityLabel: requestAccessibilityLabel(row)) {
-                            valueCell(timestamp(row.date), width: 138, secondary: true, tooltip: timestamp(row.date))
-                            harnessCell(row.harness, width: 138)
-                            valueCell(
-                                UsageModelNaming.canonicalDisplayName(row.model),
-                                width: 220,
-                                tooltip: row.model
+                        let time = timestamp(row.date)
+                        let modelName = UsageModelNaming.canonicalDisplayName(row.model)
+                        PorcelainUsageRow(
+                            accessibilityLabel: requestAccessibilityLabel(
+                                row, time: time, model: modelName
                             )
+                        ) {
+                            valueCell(time, width: 138, secondary: true)
+                            harnessCell(row.harness, width: 138)
+                            valueCell(modelName, width: 220, tooltip: row.model)
                             inputCell(row, width: 114)
                             numericCell(row.output, width: 88)
                             optionalMoneyCell(row.costMicros, width: 96)
-                            valueCell(row.serviceTier ?? "—", width: 86, secondary: true, tooltip: row.serviceTier)
+                            valueCell(row.serviceTier ?? "—", width: 86, secondary: true)
                         }
                     }
                     if model.hasMoreRequests { loadMoreRow }
@@ -279,8 +284,11 @@ struct UsageBreakdownTables: View {
                 }
                 LazyVStack(spacing: 0) {
                     ForEach(sortedProviders) { stat in
-                        PorcelainUsageRow(accessibilityLabel: providerAccessibilityLabel(stat)) {
-                            companyCell(stat.tool, width: providerWidth)
+                        let vendor = stat.tool.vendorName
+                        PorcelainUsageRow(
+                            accessibilityLabel: providerAccessibilityLabel(stat, vendor: vendor)
+                        ) {
+                            companyCell(stat.tool, name: vendor, width: providerWidth)
                             countCell(stat.requests, width: 112)
                             numericCell(stat.totalTokens, width: 132, emphasis: true)
                             moneyCell(stat.costMicros, width: 120, emphasis: true)
@@ -306,12 +314,11 @@ struct UsageBreakdownTables: View {
                 }
                 LazyVStack(spacing: 0) {
                     ForEach(sortedModels) { stat in
-                        PorcelainUsageRow(accessibilityLabel: modelAccessibilityLabel(stat)) {
-                            valueCell(
-                                UsageModelNaming.canonicalDisplayName(stat.model),
-                                width: modelWidth,
-                                tooltip: stat.model
-                            )
+                        let name = UsageModelNaming.canonicalDisplayName(stat.model)
+                        PorcelainUsageRow(
+                            accessibilityLabel: modelAccessibilityLabel(stat, name: name)
+                        ) {
+                            valueCell(name, width: modelWidth, tooltip: stat.model)
                             countCell(stat.requests, width: 112)
                             numericCell(stat.totalTokens, width: 132, emphasis: true)
                             moneyCell(stat.costMicros, width: 120, emphasis: true)
@@ -353,6 +360,10 @@ struct UsageBreakdownTables: View {
             .frame(width: width, alignment: alignment)
     }
 
+    /// `.help` installs a tracking area, so seven per row across fifty rows
+    /// is three hundred and fifty of them for one table. It is opt-in here
+    /// and reserved for cells that can truncate — passing the cell's own
+    /// visible text back as its tooltip bought nothing.
     private func valueCell(
         _ value: String,
         width: CGFloat,
@@ -365,7 +376,7 @@ struct UsageBreakdownTables: View {
             .lineLimit(1)
             .truncationMode(.middle)
             .frame(width: width, alignment: .leading)
-            .help(tooltip ?? value)
+            .modifier(OptionalHelp(tooltip))
     }
 
     /// A request row is usage, so it names the harness that produced it, not
@@ -382,15 +393,14 @@ struct UsageBreakdownTables: View {
         .help("\(harness.companyName) · \(harness.displayName)")
     }
 
-    private func companyCell(_ tool: ToolType, width: CGFloat) -> some View {
+    private func companyCell(_ tool: ToolType, name: String, width: CGFloat) -> some View {
         HStack(spacing: 7) {
             ToolBrandBadge(tool: tool, iconSize: 13, containerSize: 16)
-            Text(tool.vendorName)
+            Text(name)
                 .font(bodyFont)
                 .lineLimit(1)
         }
         .frame(width: width, alignment: .leading)
-        .help(tool.vendorName)
     }
 
     private func inputCell(_ row: UsageRequestRow, width: CGFloat) -> some View {
@@ -424,7 +434,6 @@ struct UsageBreakdownTables: View {
         Text(value.formatted(.number.grouping(.automatic)))
             .font(numericFont)
             .frame(width: width, alignment: .trailing)
-            .help("\(value.formatted(.number.grouping(.automatic))) requests")
     }
 
     private func moneyCell(
@@ -521,20 +530,24 @@ struct UsageBreakdownTables: View {
         }
     }
 
-    private func periodAccessibilityLabel(_ point: UsageTrendPoint) -> String {
-        "\(period(point.bucketStart)), \(UsageFormatting.formatTokens(point.totalTokens)), \(UsageFormatting.formatMicroUSD(point.costMicros))"
+    private func periodAccessibilityLabel(_ point: UsageTrendPoint, label: String) -> String {
+        "\(label), \(UsageFormatting.formatTokens(point.totalTokens)), \(UsageFormatting.formatMicroUSD(point.costMicros))"
     }
 
-    private func requestAccessibilityLabel(_ row: UsageRequestRow) -> String {
-        "\(timestamp(row.date)), \(row.harness.displayName), \(UsageModelNaming.canonicalDisplayName(row.model)), \(UsageFormatting.formatTokens(row.totalTokens)), \(row.costMicros.map { UsageFormatting.formatMicroUSD($0) } ?? "unpriced")"
+    private func requestAccessibilityLabel(
+        _ row: UsageRequestRow,
+        time: String,
+        model: String
+    ) -> String {
+        "\(time), \(row.harness.displayName), \(model), \(UsageFormatting.formatTokens(row.totalTokens)), \(row.costMicros.map { UsageFormatting.formatMicroUSD($0) } ?? "unpriced")"
     }
 
-    private func providerAccessibilityLabel(_ stat: UsageProviderStat) -> String {
-        "\(stat.tool.vendorName), \(stat.requests) requests, \(UsageFormatting.formatTokens(stat.totalTokens)), \(UsageFormatting.formatMicroUSD(stat.costMicros))"
+    private func providerAccessibilityLabel(_ stat: UsageProviderStat, vendor: String) -> String {
+        "\(vendor), \(stat.requests) requests, \(UsageFormatting.formatTokens(stat.totalTokens)), \(UsageFormatting.formatMicroUSD(stat.costMicros))"
     }
 
-    private func modelAccessibilityLabel(_ stat: UsageModelStat) -> String {
-        "\(UsageModelNaming.canonicalDisplayName(stat.model)), \(stat.requests) requests, \(UsageFormatting.formatTokens(stat.totalTokens)), \(UsageFormatting.formatMicroUSD(stat.costMicros))"
+    private func modelAccessibilityLabel(_ stat: UsageModelStat, name: String) -> String {
+        "\(name), \(stat.requests) requests, \(UsageFormatting.formatTokens(stat.totalTokens)), \(UsageFormatting.formatMicroUSD(stat.costMicros))"
     }
 
     /// Cached: request rows can be formatted while scrolling a long ledger.
@@ -595,6 +608,24 @@ private struct PorcelainUsageRow<Content: View>: View {
         }
         .accessibilityElement(children: .combine)
         .accessibilityLabel(accessibilityLabel)
+    }
+}
+
+/// `.help` unconditionally installs a tracking area, so the cheapest tooltip
+/// is the one that is never attached. Whether a given cell has one is decided
+/// by its call site and never by its data, so the branch is stable and cannot
+/// churn view identity while scrolling.
+private struct OptionalHelp: ViewModifier {
+    let tooltip: String?
+
+    init(_ tooltip: String?) { self.tooltip = tooltip }
+
+    func body(content: Content) -> some View {
+        if let tooltip {
+            content.help(tooltip)
+        } else {
+            content
+        }
     }
 }
 

--- a/Sources/VibeBarCore/Models/UsageQueryModels.swift
+++ b/Sources/VibeBarCore/Models/UsageQueryModels.swift
@@ -253,25 +253,49 @@ public struct UsageRequestRow: Sendable, Equatable, Identifiable {
     }
 }
 
-/// One page of the request log. `page` is **zero-based**; a page past the
-/// end is not an error, it just comes back with no rows and the real
+/// A position in the request log's `ts DESC, id DESC` ordering.
+///
+/// Paging by `LIMIT`/`OFFSET` makes SQLite re-walk and re-skip everything
+/// ahead of the page, and it silently drops or repeats rows when the ledger
+/// gains events between two pages. A cursor names the last row of the page
+/// the caller already has, so the next page is a range scan that starts
+/// exactly where the previous one stopped. `id` breaks the tie between
+/// events that share a second.
+public struct UsageRequestCursor: Sendable, Equatable, Hashable {
+    public let ts: Int64
+    public let id: Int64
+
+    public init(ts: Int64, id: Int64) {
+        self.ts = ts
+        self.id = id
+    }
+}
+
+/// One page of the request log, newest first. A page past the end is not an
+/// error: it comes back with no rows, no `nextCursor`, and the real
 /// `totalCount`.
 public struct UsageRequestPage: Sendable, Equatable {
     public let rows: [UsageRequestRow]
     public let totalCount: Int
-    public let page: Int
     public let pageSize: Int
+    /// The cursor this page continued from — `nil` for the first page. Lets a
+    /// caller drop a page that answers a position it has already moved past.
+    public let cursor: UsageRequestCursor?
+    /// Pass as `after:` to fetch the next page. `nil` ends the sequence.
+    public let nextCursor: UsageRequestCursor?
 
-    public init(rows: [UsageRequestRow], totalCount: Int, page: Int, pageSize: Int) {
+    public init(
+        rows: [UsageRequestRow],
+        totalCount: Int,
+        pageSize: Int,
+        cursor: UsageRequestCursor? = nil,
+        nextCursor: UsageRequestCursor? = nil
+    ) {
         self.rows = rows
         self.totalCount = totalCount
-        self.page = page
         self.pageSize = pageSize
-    }
-
-    public var pageCount: Int {
-        guard pageSize > 0 else { return 0 }
-        return (totalCount + pageSize - 1) / pageSize
+        self.cursor = cursor
+        self.nextCursor = nextCursor
     }
 }
 

--- a/Sources/VibeBarCore/Models/UsageQueryModels.swift
+++ b/Sources/VibeBarCore/Models/UsageQueryModels.swift
@@ -276,7 +276,11 @@ public struct UsageRequestCursor: Sendable, Equatable, Hashable {
 /// `totalCount`.
 public struct UsageRequestPage: Sendable, Equatable {
     public let rows: [UsageRequestRow]
-    public let totalCount: Int
+    /// Detail rows matching the filter, or `nil` when the caller asked not to
+    /// recount. The count is a full scan of the matched set and it cannot
+    /// change while the filter is pinned, so continuing a run re-uses the
+    /// number the first page already reported.
+    public let totalCount: Int?
     public let pageSize: Int
     /// The cursor this page continued from — `nil` for the first page. Lets a
     /// caller drop a page that answers a position it has already moved past.
@@ -286,7 +290,7 @@ public struct UsageRequestPage: Sendable, Equatable {
 
     public init(
         rows: [UsageRequestRow],
-        totalCount: Int,
+        totalCount: Int?,
         pageSize: Int,
         cursor: UsageRequestCursor? = nil,
         nextCursor: UsageRequestCursor? = nil

--- a/Sources/VibeBarCore/Services/CostUsageService.swift
+++ b/Sources/VibeBarCore/Services/CostUsageService.swift
@@ -198,6 +198,7 @@ public final class CostUsageService: ObservableObject {
 
         var results: [ToolType: CostSnapshot] = [:]
         var directRemoteResults = directRemoteSnapshots
+        var ledgerDidIngest = false
         let home = homeDirectory
         // Privacy mode is already handled above (it erases and returns), so
         // reaching here means the ledger is allowed to record.
@@ -230,11 +231,7 @@ public final class CostUsageService: ObservableObject {
                     // Cursor dashboard events now feed the same request ledger
                     // as local scanners, so Workbench and the outer Grok cost
                     // surface share one set of token/cost facts.
-                    try? await usageLedger?.rollupAndPrune(
-                        now: now,
-                        detailDays: Self.ledgerDetailDays,
-                        retentionDays: retentionDays
-                    )
+                    ledgerDidIngest = true
                 case .completed(.unavailable):
                     directRemoteResults.removeValue(forKey: .cursor)
                     // Match the in-memory decision on the next launch: once
@@ -288,20 +285,28 @@ public final class CostUsageService: ObservableObject {
                 // Persist the post-merge snapshot so a future launch can show
                 // these numbers without waiting for a fresh scan.
                 await CostSnapshotCache.shared.save(merged, retentionDays: retentionDays)
-                // Fold this tool's freshly ingested history down to daily
-                // rollups past the detail window and apply retention. Done
-                // per tool rather than once at the end so a long pass never
-                // leaves the ledger holding an unbounded detail table.
-                try? await usageLedger?.rollupAndPrune(
-                    now: now,
-                    detailDays: Self.ledgerDetailDays,
-                    retentionDays: retentionDays
-                )
+                ledgerDidIngest = true
             }
         }
         localSnapshots = results
         directRemoteSnapshots = directRemoteResults
         publishMergedSnapshots()
+        // Fold everything ingested this pass down to daily rollups past the
+        // detail window and apply retention — once, at the end.
+        //
+        // This used to run inside the loop, per tool. `rollupAndPrune` opens a
+        // BEGIN IMMEDIATE transaction and aggregates the whole detail table,
+        // and it holds the ledger actor while it does: with ~20 scannable
+        // tools, a single refresh took that write lock twenty times, and every
+        // Workbench query issued during the pass queued behind whichever one
+        // was running. One call folds exactly the same rows.
+        if ledgerDidIngest {
+            try? await usageLedger?.rollupAndPrune(
+                now: now,
+                detailDays: Self.ledgerDetailDays,
+                retentionDays: retentionDays
+            )
+        }
         // Extras (credits / overage) display was removed from the UI — see the
         // user-feedback round that turned them off because the loaders weren't
         // reliable. Parsing infrastructure for Claude.providerExtras is kept

--- a/Sources/VibeBarCore/Services/UsageEventLedger.swift
+++ b/Sources/VibeBarCore/Services/UsageEventLedger.swift
@@ -68,6 +68,8 @@ public actor UsageEventLedger: CostUsageEventSink {
     /// In-process change token for cheap view-model cache invalidation. It
     /// advances only after a batch mutation or erase commits successfully.
     private var contentRevisionValue: UInt64 = 0
+    /// See `optimizeStorage`.
+    private var didOptimizeStorage = false
     private let transient = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
     private let calendar: Calendar
     private let dayFormatter: DateFormatter
@@ -126,10 +128,28 @@ public actor UsageEventLedger: CostUsageEventSink {
             sqlite3_close_v2(handle)
             throw error
         }
+        Task { await self.optimizeStorage() }
     }
 
     deinit {
         if let database { sqlite3_close_v2(database) }
+    }
+
+    /// One-time storage upkeep the query planner needs and correctness does
+    /// not: building the harness index on an established ledger, and
+    /// refreshing `sqlite_stat1`.
+    ///
+    /// Deliberately outside `initialize`. That runs synchronously inside
+    /// `init`, which `AppEnvironment` calls on the main thread before the
+    /// status item is installed — and on a 144k-row ledger this work measured
+    /// ~750 ms the first time it ran. It happens on the actor's own executor
+    /// instead, so a launch never waits on it. A query that somehow arrives
+    /// first performs it inline rather than running unindexed.
+    public func optimizeStorage() {
+        guard !didOptimizeStorage, let database else { return }
+        didOptimizeStorage = true
+        _ = sqlite3_exec(database, Self.harnessIndexSQL, nil, nil, nil)
+        Self.refreshStatisticsIfStale(database)
     }
 
     // MARK: - Schema
@@ -186,12 +206,6 @@ public actor UsageEventLedger: CostUsageEventSink {
             CREATE INDEX IF NOT EXISTS usage_events_ts_id_idx ON usage_events(ts DESC, id DESC);
             CREATE INDEX IF NOT EXISTS usage_events_day_idx ON usage_events(day);
             CREATE INDEX IF NOT EXISTS usage_events_model_idx ON usage_events(model);
-            -- The harness filter had no index at all: filtering by one meant
-            -- walking usage_events_ts_id_idx and fetching every row in range
-            -- to test it. Ordered like the page so a narrow harness is a
-            -- range scan, and covering for the matching COUNT(*).
-            CREATE INDEX IF NOT EXISTS usage_events_harness_ts_idx
-                ON usage_events(harness, ts DESC, id DESC);
             CREATE TABLE IF NOT EXISTS usage_daily_rollups (
                 day TEXT NOT NULL,
                 tool TEXT NOT NULL,
@@ -228,7 +242,6 @@ public actor UsageEventLedger: CostUsageEventSink {
         guard Self.migrateCursorToolRows(database) else {
             throw UsageLedgerError.open
         }
-        refreshStatisticsIfStale(database)
         var statement: OpaquePointer?
         guard sqlite3_prepare_v2(
             database,
@@ -526,6 +539,15 @@ public actor UsageEventLedger: CostUsageEventSink {
         else { return rollback() }
         return true
     }
+
+    /// The harness filter has no index of its own without this: filtering by
+    /// one means walking `usage_events_ts_id_idx` and fetching every row in
+    /// range to test it. Ordered like the request page so a narrow harness is
+    /// a range scan, and covering for the matching `COUNT(*)`.
+    private static let harnessIndexSQL = """
+        CREATE INDEX IF NOT EXISTS usage_events_harness_ts_idx
+            ON usage_events(harness, ts DESC, id DESC)
+        """
 
     /// Rebuild `sqlite_stat1` when the table's magnitude has moved.
     ///
@@ -1476,6 +1498,9 @@ public actor UsageEventLedger: CostUsageEventSink {
         pageSize: Int,
         includeTotal: Bool = true
     ) throws -> UsageRequestPage {
+        // The page this answers is exactly what the harness index and the
+        // statistics exist for, so never serve one without them.
+        optimizeStorage()
         let size = min(max(1, pageSize), 1_000)
         let detail = detailPredicate(filter)
 

--- a/Sources/VibeBarCore/Services/UsageEventLedger.swift
+++ b/Sources/VibeBarCore/Services/UsageEventLedger.swift
@@ -86,6 +86,8 @@ public actor UsageEventLedger: CostUsageEventSink {
     /// as ChatGPT Work. See `migrateCodexDesktopHarnessRows`.
     static let codexHarnessFixupKey = "harness_v2"
     private static let pricingRevisionKey = "pricing_revision"
+    /// Row count at the last `ANALYZE`. See `refreshStatisticsIfStale`.
+    private static let analyzeRowCountKey = "analyze_rows"
     private static let floorKeyPrefix = "detail_floor_day:"
     /// Guard rail on zero-filled trend enumeration: ~135 years of daily
     /// buckets. A filter wider than this is a caller bug, not a chart.
@@ -184,6 +186,12 @@ public actor UsageEventLedger: CostUsageEventSink {
             CREATE INDEX IF NOT EXISTS usage_events_ts_id_idx ON usage_events(ts DESC, id DESC);
             CREATE INDEX IF NOT EXISTS usage_events_day_idx ON usage_events(day);
             CREATE INDEX IF NOT EXISTS usage_events_model_idx ON usage_events(model);
+            -- The harness filter had no index at all: filtering by one meant
+            -- walking usage_events_ts_id_idx and fetching every row in range
+            -- to test it. Ordered like the page so a narrow harness is a
+            -- range scan, and covering for the matching COUNT(*).
+            CREATE INDEX IF NOT EXISTS usage_events_harness_ts_idx
+                ON usage_events(harness, ts DESC, id DESC);
             CREATE TABLE IF NOT EXISTS usage_daily_rollups (
                 day TEXT NOT NULL,
                 tool TEXT NOT NULL,
@@ -220,6 +228,7 @@ public actor UsageEventLedger: CostUsageEventSink {
         guard Self.migrateCursorToolRows(database) else {
             throw UsageLedgerError.open
         }
+        refreshStatisticsIfStale(database)
         var statement: OpaquePointer?
         guard sqlite3_prepare_v2(
             database,
@@ -516,6 +525,78 @@ public actor UsageEventLedger: CostUsageEventSink {
               sqlite3_exec(database, "COMMIT", nil, nil, nil) == SQLITE_OK
         else { return rollback() }
         return true
+    }
+
+    /// Rebuild `sqlite_stat1` when the table's magnitude has moved.
+    ///
+    /// Without statistics SQLite assumes an equality test on an indexed
+    /// column is selective. `tool`, `model` and `harness` are not: a few
+    /// dozen distinct values spread over a hundred thousand rows. So the
+    /// planner chose `usage_events_tool_ts_idx` (or `..._model_idx`) for a
+    /// filtered request page and then sorted the *entire* matched set
+    /// through a temp B-tree, instead of walking `usage_events_ts_id_idx`,
+    /// which is already in the page's order and stops after one page.
+    /// Real statistics make it pick the ordered index — measured on a
+    /// 144k-row ledger, a two-model filter went from 12.3 ms to 0.4 ms and
+    /// a narrow harness filter from 30.2 ms to 0.7 ms.
+    ///
+    /// `ANALYZE` costs ~40 ms there, so it is not something to run on every
+    /// open. The ratios it records are stable while the table stays the same
+    /// order of magnitude, which is what the planner actually consumes.
+    private static func refreshStatisticsIfStale(_ database: OpaquePointer) {
+        let rows = scalarInt(database, "SELECT COUNT(*) FROM usage_events") ?? 0
+        let previous = storedMetaValue(database, analyzeRowCountKey).flatMap(Int.init)
+        guard let previous else {
+            runAnalyze(database, rows: rows)
+            return
+        }
+        // Doubled or halved: everything in between leaves the planner's
+        // choices unchanged, and re-running ANALYZE would just be a tax on
+        // every launch.
+        guard rows > previous * 2 || rows * 2 < previous else { return }
+        runAnalyze(database, rows: rows)
+    }
+
+    private static func runAnalyze(_ database: OpaquePointer, rows: Int) {
+        guard sqlite3_exec(database, "ANALYZE", nil, nil, nil) == SQLITE_OK else { return }
+        var statement: OpaquePointer?
+        guard sqlite3_prepare_v2(
+            database,
+            """
+            INSERT INTO ledger_meta(key, value) VALUES(?, ?)
+               ON CONFLICT(key) DO UPDATE SET value = excluded.value
+            """,
+            -1, &statement, nil
+        ) == SQLITE_OK, let statement else { return }
+        defer { sqlite3_finalize(statement) }
+        let destructor = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
+        sqlite3_bind_text(statement, 1, analyzeRowCountKey, -1, destructor)
+        sqlite3_bind_text(statement, 2, String(rows), -1, destructor)
+        _ = sqlite3_step(statement)
+    }
+
+    private static func scalarInt(_ database: OpaquePointer, _ sql: String) -> Int? {
+        var statement: OpaquePointer?
+        guard sqlite3_prepare_v2(database, sql, -1, &statement, nil) == SQLITE_OK,
+              let statement
+        else { return nil }
+        defer { sqlite3_finalize(statement) }
+        guard sqlite3_step(statement) == SQLITE_ROW else { return nil }
+        return Int(sqlite3_column_int64(statement, 0))
+    }
+
+    private static func storedMetaValue(_ database: OpaquePointer, _ key: String) -> String? {
+        var statement: OpaquePointer?
+        guard sqlite3_prepare_v2(
+            database, "SELECT value FROM ledger_meta WHERE key = ?", -1, &statement, nil
+        ) == SQLITE_OK, let statement else { return nil }
+        defer { sqlite3_finalize(statement) }
+        let destructor = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
+        sqlite3_bind_text(statement, 1, key, -1, destructor)
+        guard sqlite3_step(statement) == SQLITE_ROW,
+              let raw = sqlite3_column_text(statement, 0)
+        else { return nil }
+        return String(cString: raw)
     }
 
     private static func storedSchemaVersion(_ database: OpaquePointer) -> Int? {
@@ -1381,14 +1462,20 @@ public actor UsageEventLedger: CostUsageEventSink {
     /// older history has been folded into `usage_daily_rollups` and can no
     /// longer be enumerated per request. `totalCount` therefore counts the
     /// detail rows in range, not the summary's request count.
-    /// `page` is zero-based; a page past the end returns no rows.
+    ///
+    /// Pass the previous page's `nextCursor` as `after` to continue; `nil`
+    /// starts at the newest row. This is a keyset scan rather than
+    /// `LIMIT`/`OFFSET`: the old form made SQLite walk and discard every row
+    /// ahead of the page, so page *n* cost *n* times page 0, and an event
+    /// ingested between two pages shifted every later offset by one — a row
+    /// the caller already had would come back, or one it never saw would be
+    /// skipped.
     public func requestPage(
         _ filter: UsageQueryFilter,
-        page: Int,
+        after cursor: UsageRequestCursor? = nil,
         pageSize: Int
     ) throws -> UsageRequestPage {
         let size = min(max(1, pageSize), 1_000)
-        let index = max(0, page)
         let detail = detailPredicate(filter)
 
         let countStatement = try prepare(
@@ -1401,22 +1488,41 @@ public actor UsageEventLedger: CostUsageEventSink {
             total = Int(sqlite3_column_int64(countStatement, 0))
         }
 
+        // Row values compare left to right, which is exactly the page's
+        // ordering — so this stays a range scan on an index that already
+        // sorts by (ts DESC, id DESC) instead of a filter applied after one.
+        let keyset = cursor == nil ? "" : " AND (ts, id) < (?, ?)"
         let statement = try prepare(
             """
             SELECT id, tool, ts, model, fresh_input, output, cache_read, cache_creation,
                    cost_micros, service_tier, session_id, source_key, harness
-              FROM usage_events WHERE \(detail.sql)
-             ORDER BY ts DESC, id DESC LIMIT ? OFFSET ?
+              FROM usage_events WHERE \(detail.sql)\(keyset)
+             ORDER BY ts DESC, id DESC LIMIT ?
             """
         )
         defer { sqlite3_finalize(statement) }
         bindAll(detail.bindings, to: statement)
-        let offset = Int32(detail.bindings.count)
-        bind(.integer(Int64(size)), at: offset + 1, to: statement)
-        bind(.integer(Int64(index) * Int64(size)), at: offset + 2, to: statement)
+        var next = Int32(detail.bindings.count)
+        if let cursor {
+            bind(.integer(cursor.ts), at: next + 1, to: statement)
+            bind(.integer(cursor.id), at: next + 2, to: statement)
+            next += 2
+        }
+        bind(.integer(Int64(size)), at: next + 1, to: statement)
 
         var rows: [UsageRequestRow] = []
+        // Counted separately from `rows`: a row whose tool or harness no
+        // longer decodes is skipped, but it still consumed one of the LIMIT
+        // slots and must still advance the cursor, or the next page would
+        // start on top of it forever.
+        var stepped = 0
+        var lastKey: UsageRequestCursor?
         while sqlite3_step(statement) == SQLITE_ROW {
+            stepped += 1
+            lastKey = UsageRequestCursor(
+                ts: sqlite3_column_int64(statement, 2),
+                id: sqlite3_column_int64(statement, 0)
+            )
             // A row written before the harness dimension existed has a NULL
             // harness; the tool's default is the same value the migration
             // would have backfilled. Only the misc providers have no harness
@@ -1446,7 +1552,14 @@ public actor UsageEventLedger: CostUsageEventSink {
                 )
             )
         }
-        return UsageRequestPage(rows: rows, totalCount: total, page: index, pageSize: size)
+        return UsageRequestPage(
+            rows: rows,
+            totalCount: total,
+            pageSize: size,
+            cursor: cursor,
+            // A short page is the end of the sequence; a full one may not be.
+            nextCursor: stepped == size ? lastKey : nil
+        )
     }
 
     /// Per-provider totals, detail ∪ rollups, heaviest first.

--- a/Sources/VibeBarCore/Services/UsageEventLedger.swift
+++ b/Sources/VibeBarCore/Services/UsageEventLedger.swift
@@ -1473,19 +1473,27 @@ public actor UsageEventLedger: CostUsageEventSink {
     public func requestPage(
         _ filter: UsageQueryFilter,
         after cursor: UsageRequestCursor? = nil,
-        pageSize: Int
+        pageSize: Int,
+        includeTotal: Bool = true
     ) throws -> UsageRequestPage {
         let size = min(max(1, pageSize), 1_000)
         let detail = detailPredicate(filter)
 
-        let countStatement = try prepare(
-            "SELECT COUNT(*) FROM usage_events WHERE \(detail.sql)"
-        )
-        defer { sqlite3_finalize(countStatement) }
-        bindAll(detail.bindings, to: countStatement)
-        var total = 0
-        if sqlite3_step(countStatement) == SQLITE_ROW {
-            total = Int(sqlite3_column_int64(countStatement, 0))
+        // COUNT(*) has to visit every matched row, so it costs the same
+        // whether it answers for page 0 or page 40 — and it answers the same
+        // thing, because the filter a run pages through is pinned. Callers
+        // continuing a run pass `includeTotal: false` and keep the number the
+        // first page gave them.
+        var total: Int?
+        if includeTotal {
+            let countStatement = try prepare(
+                "SELECT COUNT(*) FROM usage_events WHERE \(detail.sql)"
+            )
+            defer { sqlite3_finalize(countStatement) }
+            bindAll(detail.bindings, to: countStatement)
+            total = sqlite3_step(countStatement) == SQLITE_ROW
+                ? Int(sqlite3_column_int64(countStatement, 0))
+                : 0
         }
 
         // Row values compare left to right, which is exactly the page's

--- a/Tests/VibeBarCoreTests/CostUsageServiceLedgerTests.swift
+++ b/Tests/VibeBarCoreTests/CostUsageServiceLedgerTests.swift
@@ -86,7 +86,7 @@ final class CostUsageServiceLedgerTests: XCTestCase {
         let models = try await ledger.modelStats(filter)
         XCTAssertEqual(Set(models.map(\.model)), ["gpt-5", "gpt-5-mini"])
 
-        let page = try await ledger.requestPage(filter, page: 0, pageSize: 10)
+        let page = try await ledger.requestPage(filter, pageSize: 10)
         XCTAssertEqual(page.totalCount, snapshot.allTimeRequests)
         XCTAssertEqual(page.rows.first?.model, "gpt-5-mini")
     }

--- a/Tests/VibeBarCoreTests/UsageEventLedgerTests.swift
+++ b/Tests/VibeBarCoreTests/UsageEventLedgerTests.swift
@@ -673,16 +673,18 @@ final class UsageEventLedgerTests: XCTestCase {
                 UsageLedgerFixtures.event(date: now, harness: .claudeCode)
             )
         ]))
+        await ledger.optimizeStorage()
         XCTAssertTrue(try Self.indexNames(at: url).contains("usage_events_harness_ts_idx"))
 
         try Self.execute("DROP INDEX usage_events_harness_ts_idx", at: url)
         XCTAssertFalse(try Self.indexNames(at: url).contains("usage_events_harness_ts_idx"))
 
+        // A page has to arrive indexed even if the background upkeep the
+        // initializer schedules has not landed yet.
         let reopened = try UsageEventLedger(url: url)
-        XCTAssertTrue(try Self.indexNames(at: url).contains("usage_events_harness_ts_idx"))
-
         let filter = UsageLedgerFixtures.wideFilter(around: now)
         let retained = try await reopened.requestPage(filter, pageSize: 10)
+        XCTAssertTrue(try Self.indexNames(at: url).contains("usage_events_harness_ts_idx"))
         XCTAssertEqual(retained.rows.count, 1)
     }
 

--- a/Tests/VibeBarCoreTests/UsageEventLedgerTests.swift
+++ b/Tests/VibeBarCoreTests/UsageEventLedgerTests.swift
@@ -321,7 +321,7 @@ final class UsageEventLedgerTests: XCTestCase {
         XCTAssertEqual(repriced.costMicros, 5_200_000)
         let detailFloor = try await ledger.detailFloorDay(for: .grok)
         XCTAssertNotNil(detailFloor)
-        let detailPage = try await ledger.requestPage(filter, page: 0, pageSize: 10)
+        let detailPage = try await ledger.requestPage(filter, pageSize: 10)
         XCTAssertEqual(detailPage.totalCount, 1)
         let modelStats = try await ledger.modelStats(filter)
         XCTAssertEqual(modelStats.first?.costMicros, 5_200_000)
@@ -652,5 +652,73 @@ final class UsageEventLedgerTests: XCTestCase {
         XCTAssertEqual(claudeModels, ["claude-sonnet-4-5"])
         let noToolModels = try await ledger.availableModels(tools: [])
         XCTAssertEqual(noToolModels, [])
+    }
+
+    // MARK: - Schema upkeep
+
+    /// A ledger created before the harness index existed must gain it on the
+    /// next open — the whole point of `CREATE INDEX IF NOT EXISTS` running on
+    /// every open rather than only at create time. Dropping the index from an
+    /// otherwise current database is exactly that shape, and it also proves
+    /// the retained rows survive: adding an index must not take the
+    /// drop-and-recreate path that a schema-version bump does.
+    func testOpeningAnIndexlessDatabaseRestoresTheHarnessIndex() async throws {
+        let (ledger, directory) = try UsageLedgerFixtures.makeLedger("HarnessIndex")
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let url = directory.appendingPathComponent("usage_events.sqlite3")
+
+        let now = Date(timeIntervalSince1970: 1_762_339_200)
+        try await ledger.ingest(UsageLedgerFixtures.batch(events: [
+            UsageLedgerFixtures.priced(
+                UsageLedgerFixtures.event(date: now, harness: .claudeCode)
+            )
+        ]))
+        XCTAssertTrue(try Self.indexNames(at: url).contains("usage_events_harness_ts_idx"))
+
+        try Self.execute("DROP INDEX usage_events_harness_ts_idx", at: url)
+        XCTAssertFalse(try Self.indexNames(at: url).contains("usage_events_harness_ts_idx"))
+
+        let reopened = try UsageEventLedger(url: url)
+        XCTAssertTrue(try Self.indexNames(at: url).contains("usage_events_harness_ts_idx"))
+
+        let filter = UsageLedgerFixtures.wideFilter(around: now)
+        let retained = try await reopened.requestPage(filter, pageSize: 10)
+        XCTAssertEqual(retained.rows.count, 1)
+    }
+
+    /// Index names on `usage_events`, read through a connection of the test's
+    /// own so nothing has to be exposed from the actor for the assertion.
+    private static func indexNames(at url: URL) throws -> [String] {
+        var handle: OpaquePointer?
+        guard sqlite3_open_v2(url.path, &handle, SQLITE_OPEN_READONLY, nil) == SQLITE_OK,
+              let handle
+        else { throw UsageLedgerError.open }
+        defer { sqlite3_close_v2(handle) }
+        var statement: OpaquePointer?
+        guard sqlite3_prepare_v2(
+            handle,
+            "SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = 'usage_events'",
+            -1, &statement, nil
+        ) == SQLITE_OK, let statement else { throw UsageLedgerError.statement }
+        defer { sqlite3_finalize(statement) }
+        var names: [String] = []
+        while sqlite3_step(statement) == SQLITE_ROW {
+            if let raw = sqlite3_column_text(statement, 0) {
+                names.append(String(cString: raw))
+            }
+        }
+        return names
+    }
+
+    private static func execute(_ sql: String, at url: URL) throws {
+        var handle: OpaquePointer?
+        guard sqlite3_open_v2(url.path, &handle, SQLITE_OPEN_READWRITE, nil) == SQLITE_OK,
+              let handle
+        else { throw UsageLedgerError.open }
+        defer { sqlite3_close_v2(handle) }
+        sqlite3_busy_timeout(handle, 5_000)
+        guard sqlite3_exec(handle, sql, nil, nil, nil) == SQLITE_OK else {
+            throw UsageLedgerError.statement
+        }
     }
 }

--- a/Tests/VibeBarCoreTests/UsageLedgerHarnessTests.swift
+++ b/Tests/VibeBarCoreTests/UsageLedgerHarnessTests.swift
@@ -382,7 +382,7 @@ final class UsageLedgerHarnessTests: XCTestCase {
         ))
 
         let page = try await ledger.requestPage(
-            UsageLedgerFixtures.wideFilter(around: now), page: 0, pageSize: 10
+            UsageLedgerFixtures.wideFilter(around: now), pageSize: 10
         )
         XCTAssertEqual(page.rows.map(\.harness), [.chatgptWork, .claudeCode])
         // The quota-side tool is unchanged: the two axes coexist on one row.
@@ -565,7 +565,7 @@ final class UsageLedgerHarnessTests: XCTestCase {
 
         let filter = UsageLedgerFixtures.wideFilter(around: now)
         // Detail rows are gone; these totals can only come from the rollups.
-        let detailCount = try await ledger.requestPage(filter, page: 0, pageSize: 50).totalCount
+        let detailCount = try await ledger.requestPage(filter, pageSize: 50).totalCount
         XCTAssertEqual(detailCount, 0)
         let stats = try await ledger.harnessStats(filter)
         XCTAssertEqual(stats.map(\.harness), [.chatgptWork, .codex])

--- a/Tests/VibeBarCoreTests/UsageLedgerRollupTests.swift
+++ b/Tests/VibeBarCoreTests/UsageLedgerRollupTests.swift
@@ -39,7 +39,7 @@ final class UsageLedgerRollupTests: XCTestCase {
         let before = try await ledger.summary(fullRange)
         XCTAssertEqual(before.requests, 4)
         XCTAssertEqual(before.costMicros, 4_000_000)
-        let seededPage = try await ledger.requestPage(fullRange, page: 0, pageSize: 50)
+        let seededPage = try await ledger.requestPage(fullRange, pageSize: 50)
         XCTAssertEqual(seededPage.totalCount, 4)
 
         try await ledger.rollupAndPrune(now: now, detailDays: 30, retentionDays: 0)
@@ -49,7 +49,7 @@ final class UsageLedgerRollupTests: XCTestCase {
         XCTAssertEqual(after.requests, 4)
         XCTAssertEqual(after.costMicros, 4_000_000)
         XCTAssertEqual(after.realTotalTokens, before.realTotalTokens)
-        let foldedPage = try await ledger.requestPage(fullRange, page: 0, pageSize: 50)
+        let foldedPage = try await ledger.requestPage(fullRange, pageSize: 50)
         XCTAssertEqual(foldedPage.totalCount, 2)
 
         // Running it again must not double count the rows it already folded.
@@ -76,7 +76,7 @@ final class UsageLedgerRollupTests: XCTestCase {
         let summary = try await ledger.summary(fullRange)
         XCTAssertEqual(summary.requests, 4)
         XCTAssertEqual(summary.costMicros, 4_000_000)
-        let reconsumedPage = try await ledger.requestPage(fullRange, page: 0, pageSize: 50)
+        let reconsumedPage = try await ledger.requestPage(fullRange, pageSize: 50)
         XCTAssertEqual(reconsumedPage.totalCount, 2)
     }
 

--- a/Tests/VibeBarCoreTests/UsageQueryMetricsTests.swift
+++ b/Tests/VibeBarCoreTests/UsageQueryMetricsTests.swift
@@ -56,11 +56,6 @@ final class UsageQueryMetricsTests: XCTestCase {
         )
     }
 
-    func testRequestPageCountReportsWholePages() {
-        XCTAssertEqual(UsageRequestPage(rows: [], totalCount: 10, page: 0, pageSize: 5).pageCount, 2)
-        XCTAssertEqual(UsageRequestPage(rows: [], totalCount: 11, page: 0, pageSize: 5).pageCount, 3)
-        XCTAssertEqual(UsageRequestPage(rows: [], totalCount: 0, page: 0, pageSize: 5).pageCount, 0)
-    }
 
     func testProviderStatsMergeAtCompanyLevel() {
         let rows = [
@@ -383,7 +378,7 @@ final class UsageQueryMetricsTests: XCTestCase {
 
     // MARK: - Pagination
 
-    func testRequestPageBoundaries() async throws {
+    func testRequestPageWalksTheWholeRunByCursor() async throws {
         let (ledger, directory) = try UsageLedgerFixtures.makeLedger("MetricsPaging")
         defer { try? FileManager.default.removeItem(at: directory) }
 
@@ -399,35 +394,85 @@ final class UsageQueryMetricsTests: XCTestCase {
         try await ledger.ingest(UsageLedgerFixtures.batch(events: events))
         let filter = UsageLedgerFixtures.wideFilter(around: now)
 
-        let first = try await ledger.requestPage(filter, page: 0, pageSize: 5)
+        let first = try await ledger.requestPage(filter, pageSize: 5)
         XCTAssertEqual(first.totalCount, 10)
         XCTAssertEqual(first.rows.count, 5)
-        XCTAssertEqual(first.pageCount, 2)
+        XCTAssertNil(first.cursor)
         // Newest first.
         XCTAssertEqual(first.rows.first?.date, now)
         XCTAssertEqual(first.rows.first?.freshInput, 100)
         XCTAssertEqual(first.rows.first?.tool, .codex)
         XCTAssertEqual(first.rows.first?.costMicros, 10_000)
 
-        let second = try await ledger.requestPage(filter, page: 1, pageSize: 5)
+        let firstCursor = try XCTUnwrap(first.nextCursor)
+        XCTAssertEqual(firstCursor.ts, Int64(first.rows.last!.date.timeIntervalSince1970))
+        XCTAssertEqual(firstCursor.id, first.rows.last?.id)
+
+        let second = try await ledger.requestPage(filter, after: firstCursor, pageSize: 5)
+        XCTAssertEqual(second.cursor, firstCursor)
         XCTAssertEqual(second.rows.count, 5)
         XCTAssertEqual(second.rows.last?.freshInput, 109)
 
-        // Exact multiple: the page right after the last full one is empty
-        // but still reports the real total.
-        let past = try await ledger.requestPage(filter, page: 2, pageSize: 5)
+        // Full run, in order, with nothing repeated or missed.
+        XCTAssertEqual(
+            (first.rows + second.rows).map(\.freshInput),
+            (0..<10).map { Int64(100 + $0) }
+        )
+
+        // The page after the last full one is empty but still reports the
+        // real total, and ends the sequence.
+        let past = try await ledger.requestPage(
+            filter, after: try XCTUnwrap(second.nextCursor), pageSize: 5
+        )
         XCTAssertTrue(past.rows.isEmpty)
         XCTAssertEqual(past.totalCount, 10)
-        XCTAssertEqual(past.page, 2)
+        XCTAssertNil(past.nextCursor)
 
-        let wayPast = try await ledger.requestPage(filter, page: 99, pageSize: 5)
-        XCTAssertTrue(wayPast.rows.isEmpty)
-        XCTAssertEqual(wayPast.totalCount, 10)
-
-        // Negative page and zero page size are clamped, never fatal.
-        let clamped = try await ledger.requestPage(filter, page: -3, pageSize: 0)
-        XCTAssertEqual(clamped.page, 0)
+        // A zero page size is clamped, never fatal.
+        let clamped = try await ledger.requestPage(filter, pageSize: 0)
         XCTAssertEqual(clamped.pageSize, 1)
         XCTAssertEqual(clamped.rows.count, 1)
     }
+
+    /// Ten events in the same second. `ts` alone cannot order them, so a
+    /// cursor that only carried the timestamp would either re-serve the whole
+    /// second on every page or skip the rest of it.
+    func testRequestPagingIsStableAcrossRowsSharingOneTimestamp() async throws {
+        let (ledger, directory) = try UsageLedgerFixtures.makeLedger("MetricsPagingTies")
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        // Distinct `input` values give each row an identity; identical dates
+        // force every tie-break through `id`.
+        let events = (0..<10).map { index in
+            UsageLedgerFixtures.priced(
+                UsageLedgerFixtures.event(
+                    date: now, input: 500 + index, output: 1,
+                    messageId: "tie-\(index)"
+                ),
+                costUSD: 0.01
+            )
+        }
+        try await ledger.ingest(UsageLedgerFixtures.batch(events: events))
+        let filter = UsageLedgerFixtures.wideFilter(around: now)
+
+        var collected: [UsageRequestRow] = []
+        var cursor: UsageRequestCursor?
+        for _ in 0..<10 {
+            let page = try await ledger.requestPage(filter, after: cursor, pageSize: 3)
+            collected.append(contentsOf: page.rows)
+            guard let next = page.nextCursor else { break }
+            cursor = next
+        }
+
+        XCTAssertEqual(collected.count, 10)
+        XCTAssertEqual(Set(collected.map(\.id)).count, 10, "no row served twice")
+        XCTAssertEqual(
+            Set(collected.map(\.freshInput)),
+            Set((0..<10).map { Int64(500 + $0) },
+            ), "no row skipped"
+        )
+        // Every row shares the second, so the run must descend by id.
+        XCTAssertEqual(collected.map(\.id), collected.map(\.id).sorted(by: >))
+    }
+
 }

--- a/Tests/VibeBarCoreTests/UsageQueryMetricsTests.swift
+++ b/Tests/VibeBarCoreTests/UsageQueryMetricsTests.swift
@@ -434,6 +434,41 @@ final class UsageQueryMetricsTests: XCTestCase {
         XCTAssertEqual(clamped.rows.count, 1)
     }
 
+    /// COUNT(*) visits every matched row, so it costs the same on page 40 as
+    /// on page 0 — and returns the same number, because the filter a run
+    /// pages through is pinned. Continuing a run must be able to skip it.
+    func testRequestPageOmitsTheTotalWhenTheCallerDeclinesIt() async throws {
+        let (ledger, directory) = try UsageLedgerFixtures.makeLedger("MetricsCountOnce")
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let events = (0..<10).map { index in
+            UsageLedgerFixtures.priced(
+                UsageLedgerFixtures.event(
+                    date: now.addingTimeInterval(TimeInterval(-60 * index)),
+                    input: 100 + index, output: 1
+                ),
+                costUSD: 0.01
+            )
+        }
+        try await ledger.ingest(UsageLedgerFixtures.batch(events: events))
+        let filter = UsageLedgerFixtures.wideFilter(around: now)
+
+        let counted = try await ledger.requestPage(filter, pageSize: 4)
+        XCTAssertEqual(counted.totalCount, 10)
+
+        let cursor = try XCTUnwrap(counted.nextCursor)
+        let uncounted = try await ledger.requestPage(
+            filter, after: cursor, pageSize: 4, includeTotal: false
+        )
+        XCTAssertNil(uncounted.totalCount, "the caller kept the first page's number")
+
+        // Skipping the count changes nothing else about the page.
+        let recounted = try await ledger.requestPage(filter, after: cursor, pageSize: 4)
+        XCTAssertEqual(recounted.totalCount, 10)
+        XCTAssertEqual(uncounted.rows.map(\.id), recounted.rows.map(\.id))
+        XCTAssertEqual(uncounted.nextCursor, recounted.nextCursor)
+    }
+
     /// Ten events in the same second. `ts` alone cannot order them, so a
     /// cursor that only carried the timestamp would either re-serve the whole
     /// second on every page or skip the rest of it.


### PR DESCRIPTION
## Why

Workbench lag with several windows open, worst on the Requests tab. Profiling on the real ledger (144k rows) found: brand icons re-decoded from disk and re-rasterized on every row/render with no cache; the Requests `LazyVStack` had no vertical clip so every row realized and the last-row `onAppear` sentinel auto-chained pages toward 69k rows; clicking Requests re-ran the whole 30-day analytic set (~0.6 s of ledger time for a 10 ms page); `rollupAndPrune` took `BEGIN IMMEDIATE` ~20× per refresh on the same actor UI reads wait on; multi-tool/model/harness filters sorted the whole matched set (`USE TEMP B-TREE FOR ORDER BY`), no `harness` index, and no `ANALYZE` statistics; `COUNT(*)` on every page; extra publishes per reload.

## What (one commit each)

1. `ProviderBrandIcon` memo caches (final image by tool/size/tint/appearance; decoded source; bundle URL), bounded.
2. Requests table: bounded two-axis scroller with pinned header so `LazyVStack` culls; last-row sentinel → explicit "Load more (N remaining)".
3. `setActiveBreakdown` → breakdown-only load (`requestPage` / `modelStats`) merged into `results`; full `reload` only on filter/range/revision change.
4. `rollupAndPrune` once after the scan loop instead of per tool (read-only second connection deferred — noted in commit).
5. `usage_events_harness_ts_idx(harness, ts DESC, id DESC)` + magnitude-gated `ANALYZE`; `LIMIT/OFFSET` → `(ts,id)` keyset cursor (`UsageRequestCursor`). EXPLAIN: temp b-tree sorts gone; harness `COUNT(*)` uses a covering index. Timings: two-model filter 12.3 → 0.4 ms; harness page 30.2 → 0.7 ms.
6. Count once per (filter, revision).
7. `availableModels` / `isHourlyTrendAvailable` travel with the final snapshot (two fewer full renders per query).
8. Per-row: formatter/name computed once; `.help` only where it reveals hidden data.
9. Index build + ANALYZE moved off the synchronous `init` path (was ~750 ms on the main thread at launch after upgrade) into an actor-scheduled `optimizeStorage()`.

Tests: 1616 → 1618 (keyset walk, equal-timestamp tie-break, count-once, harness index restored on open).

## Verification

- `swift build`, `swift test` (1618 tests, 1 skipped, 0 failures)
- `./Scripts/build_app.sh release`, `codesign -d --entitlements -` → empty `<dict/>`, `codesign --verify --deep --strict` OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)
