### PR TITLE
Give the mini window a SubProvider tier and filter by harness

### DIFF
--- a/Sources/VibeBarApp/Controllers/UsageStatsViewModel.swift
+++ b/Sources/VibeBarApp/Controllers/UsageStatsViewModel.swift
@@ -205,11 +205,24 @@ final class UsageStatsViewModel: ObservableObject {
         return !members.isEmpty && members.allSatisfy(selectedTools.contains)
     }
 
-    /// Harnesses the harness menu offers, narrowed to the companies whose
-    /// chips are lit. A harness filter that could only ever return nothing —
+    /// Harnesses the filter offers, narrowed to the companies whose tools are
+    /// in the query. A harness filter that could only ever return nothing —
     /// because its company is filtered out — should not be offered at all.
+    /// With the chip row as the only writer `selectedTools` stays nil, so this
+    /// degenerates to `knownHarnesses`.
     var harnessOptions: [Harness] {
         knownHarnesses.filter { isCompanySelected($0.company) }
+    }
+
+    /// The harness-primary chip row: one section per company, its known
+    /// harnesses underneath. Derived from `knownCompanyRepresentatives` and
+    /// `knownHarnesses` rather than stored, so it follows the ledger without a
+    /// second piece of state to keep in sync.
+    var harnessChipGroups: [Harness.ChipGroup] {
+        Harness.chipGroups(
+            companies: knownCompanyRepresentatives,
+            harnesses: knownHarnesses
+        )
     }
 
     var range: DateInterval {
@@ -412,6 +425,10 @@ final class UsageStatsViewModel: ObservableObject {
         reload(cascadeModels: true)
     }
 
+    /// The company-axis writer. No chip drives it since the filter row became
+    /// harness-primary — a harness already narrows the tools it belongs to —
+    /// but it stays as the counterpart to `toggleHarnesses` for any surface
+    /// that needs to select whole companies.
     func toggleCompany(_ representative: ToolType) {
         let members = Set(representative.coreProviderMembers.filter { knownTools.contains($0) })
         guard !members.isEmpty else { return }
@@ -433,11 +450,22 @@ final class UsageStatsViewModel: ObservableObject {
     }
 
     func toggleHarness(_ harness: Harness) {
+        toggleHarnesses([harness])
+    }
+
+    /// Toggles a whole company's harnesses in one click — what the muted
+    /// company chip at the head of each chip group does. Turning them all on
+    /// is the same statement as "no harness filter", and saying it that way
+    /// keeps the query unrestricted.
+    func toggleHarnesses(_ harnesses: Set<Harness>) {
+        guard !harnesses.isEmpty else { return }
         let options = harnessOptions
         var next = selectedHarnesses ?? Set(options)
-        if next.contains(harness) { next.remove(harness) } else { next.insert(harness) }
-        // Selecting every offered harness is the same statement as "no
-        // harness filter", and saying it that way keeps the query unrestricted.
+        if harnesses.allSatisfy(next.contains) {
+            next.subtract(harnesses)
+        } else {
+            next.formUnion(harnesses)
+        }
         setSelectedHarnesses(next.count == options.count ? nil : next)
     }
 

--- a/Sources/VibeBarApp/MiniQuotaWindowController.swift
+++ b/Sources/VibeBarApp/MiniQuotaWindowController.swift
@@ -195,12 +195,13 @@ final class MiniQuotaWindowController: NSObject, NSWindowDelegate {
 
     /// Count of primary + branch groups the mini window will render
     /// for `tool` given the selected bucket ids. Mirrors
-    /// `MiniBranchCell.groupKey` so a per-tool sizing decision in the
-    /// AppKit controller stays in sync with the SwiftUI layout
-    /// without having to query the live quota. A primary bucket
-    /// (anything that doesn't match a known branch-group prefix)
-    /// counts as one extra group. Used by `stableContentSize` to
-    /// reserve exactly the right number of `groupDividerReserve` gaps.
+    /// `MiniBranchCell.groupKey` so a sizing decision in the AppKit
+    /// controller stays in sync with the SwiftUI layout without having
+    /// to query the live quota. A primary bucket (anything that doesn't
+    /// match a known branch-group prefix) counts as one extra group.
+    /// `stableContentSize` calls it once per L2 SubProvider — the tier
+    /// that owns the groups — to reserve exactly the right number of
+    /// intra-SubProvider gaps.
     static func miniGroupCount(tool: ToolType, selectedBucketIds: [String]) -> Int {
         var keys: Set<String> = []
         var hasPrimary = false
@@ -260,76 +261,72 @@ final class MiniQuotaWindowController: NSObject, NSWindowDelegate {
         let displayMode = mini.displayMode
         let cellWidth: CGFloat
         let cellSpacing: CGFloat
-        let groupDividerReserve: CGFloat
-        let providerSpacing: CGFloat
+        /// Gap between quota groups inside one SubProvider — spacing only,
+        /// since PR "three-tier" removed the rule at that depth.
+        let groupSpacing: CGFloat
+        /// Gap between two SubProviders: the stack's spacing on both sides of
+        /// the `MiniGroupDivider` plus the hairline itself.
+        let subProviderSpacing: CGFloat
+        /// Same arithmetic for the divider between two company columns.
+        let companySpacing: CGFloat
         let horizontalPadding: CGFloat
         let closeButtonReserve: CGFloat
         let minWidth: CGFloat
         let height: CGFloat
+        let dividerThickness: CGFloat = 0.75
         switch displayMode {
         case .regular:
             cellWidth = 62
             cellSpacing = 8
-            groupDividerReserve = 16.5
-            providerSpacing = 14.75
+            groupSpacing = 14
+            subProviderSpacing = 2 * 10 + dividerThickness
+            companySpacing = 2 * 14 + dividerThickness
             horizontalPadding = 28
             closeButtonReserve = 24
             minWidth = 240
-            height = 166
+            height = 181
         case .compact:
             cellWidth = 40
             cellSpacing = 4
-            groupDividerReserve = 10
-            providerSpacing = 8.75
+            groupSpacing = 9
+            subProviderSpacing = 2 * 6 + dividerThickness
+            companySpacing = 2 * 8 + dividerThickness
             horizontalPadding = 16
             closeButtonReserve = 20
             minWidth = 156
-            height = 134
+            height = 146
         }
 
-        let selected = mini.fieldIds(for: displayMode)
-        var bucketsByTool: [ToolType: [String]] = [:]
-        for fieldId in selected {
-            guard
-                let field = MenuBarFieldCatalog.field(id: fieldId),
-                field.tool.supportsDedicatedCard
-            else { continue }
-            bucketsByTool[field.tool, default: []].append(field.bucketId)
-        }
-
-        // Sizing now mirrors the L2-grouped layout in
-        // `MiniWindowProviderLayout`: consecutive tools sharing the
-        // same L1 vendorName (Gemini Web + AntiGravity → "Google AI",
-        // Grok + Cursor → "SpaceXAI")
-        // share one company column with an internal divider between
-        // SubProviders. Group dividers come from the actual primary +
-        // branch-group count derived from selected bucket ids; the
-        // old `min(count - 1, 4)` heuristic over-counted dividers for
-        // tools with many primary cells (Codex 4 cells reserved space
-        // for 3 dividers when there's really only 1), which left
-        // visible empty padding on the L/R edges of the panel.
+        // Sizing mirrors the three-tier layout in
+        // `MiniWindowProviderLayout` exactly, off the same Core grouping the
+        // SwiftUI side renders: one column per L1 company (Gemini Web +
+        // AntiGravity → "Google AI"; Grok + Cursor + Grok Bot → "SpaceXAI"),
+        // one labelled section per L2 SubProvider inside it, and the L3 quota
+        // groups side by side within a section. Cells only take the cell
+        // spacing *inside* their own group, which is why the group count is
+        // subtracted rather than one.
+        let companies = MenuBarFieldCatalog.subProviderGroups(
+            for: ToolType.dedicatedCardProviders,
+            selectedFieldIds: Set(mini.fieldIds(for: displayMode))
+        )
         var width: CGFloat = 0
-        var visibleProductGroupCount = 0
-        var lastCompanyName: String? = nil
-        for tool in ToolType.dedicatedCardProviders {
-            guard let bucketIds = bucketsByTool[tool], !bucketIds.isEmpty else { continue }
-            let cellCount = bucketIds.count
-            width += CGFloat(cellCount) * cellWidth
-            width += CGFloat(max(0, cellCount - 1)) * cellSpacing
-            let groupCount = Self.miniGroupCount(tool: tool, selectedBucketIds: bucketIds)
-            width += CGFloat(max(0, groupCount - 1)) * groupDividerReserve
-            if lastCompanyName == tool.vendorName {
-                // Same L1 company as the previous tool — adds one
-                // intra-group divider between SubProvider columns.
-                width += groupDividerReserve
-            } else {
-                visibleProductGroupCount += 1
-                lastCompanyName = tool.vendorName
+        for company in companies {
+            for subProvider in company.subProviders {
+                let cellCount = subProvider.fields.count
+                let groupCount = max(
+                    1,
+                    Self.miniGroupCount(
+                        tool: subProvider.tool,
+                        selectedBucketIds: subProvider.bucketIds
+                    )
+                )
+                width += CGFloat(cellCount) * cellWidth
+                width += CGFloat(max(0, cellCount - groupCount)) * cellSpacing
+                width += CGFloat(groupCount - 1) * groupSpacing
             }
+            width += CGFloat(max(0, company.subProviders.count - 1)) * subProviderSpacing
         }
-        if visibleProductGroupCount > 1 {
-            width += CGFloat(visibleProductGroupCount - 1) * providerSpacing
-        }
+        width += CGFloat(max(0, companies.count - 1)) * companySpacing
         width += horizontalPadding + closeButtonReserve
 
         let screenMaxWidth = (NSScreen.main?.visibleFrame.width ?? 900) - 48

--- a/Sources/VibeBarApp/Views/MiniQuotaWindowView.swift
+++ b/Sources/VibeBarApp/Views/MiniQuotaWindowView.swift
@@ -81,7 +81,8 @@ struct MiniQuotaWindowView: View {
                     field.tool == tool
                 else { continue }
                 let liveBucket = environment.quota(for: tool)?.bucket(id: field.bucketId)
-                if liveBucket?.groupTitle != nil || isBranchField(field) {
+                if Self.hasQuotaGroup(liveBucket, tool: tool, bucketId: field.bucketId)
+                    || isBranchField(field) {
                     continue
                 }
                 cells.append(
@@ -103,6 +104,18 @@ struct MiniQuotaWindowView: View {
             if !content.isEmpty { contentByTool[tool] = content }
         }
         return contentByTool
+    }
+
+    /// A live `groupTitle` marks an L3 quota group — unless it merely repeats
+    /// the bucket's own SubProvider name (Cursor's `grok_bot_weekly` carries
+    /// "Grok Bot"), in which case the SubProvider row already says it and the
+    /// bucket is a flat primary cell: SpaceXAI → Grok Bot → Weekly, not
+    /// SpaceXAI → Grok Bot → Grok Bot → Weekly.
+    static func hasQuotaGroup(_ bucket: QuotaBucket?, tool: ToolType, bucketId: String) -> Bool {
+        guard let group = bucket?.groupTitle?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !group.isEmpty
+        else { return false }
+        return group.caseInsensitiveCompare(tool.quotaSubProviderName(bucketID: bucketId)) != .orderedSame
     }
 
     private func isBranchField(_ field: MenuBarFieldOption) -> Bool {
@@ -144,8 +157,7 @@ struct MiniQuotaWindowView: View {
                 selectedFieldIds.contains(fieldId),
                 let field = MenuBarFieldCatalog.field(id: fieldId),
                 !selectedBucketIds.contains(bucket.id),
-                let rawGroup = bucket.groupTitle?.trimmingCharacters(in: .whitespacesAndNewlines),
-                !rawGroup.isEmpty
+                Self.hasQuotaGroup(bucket, tool: tool, bucketId: bucket.id)
             else { return nil }
             return MiniBranchCell(
                 tool: tool,
@@ -369,8 +381,6 @@ private struct MiniBranchCell: Identifiable {
             return "cursor.models"
         case "other_models" where tool == .cursor:
             return "cursor.other-models"
-        case "grok_bot_weekly" where tool == .cursor:
-            return "cursor.grok-bot"
         case let id where tool == .antigravity && ["gemini_five_hour", "gemini_weekly"].contains(id):
             return "antigravity.gemini-models"
         case let id where tool == .antigravity && ["claude_gpt_five_hour", "claude_gpt_weekly"].contains(id):
@@ -604,7 +614,9 @@ private func miniGroupTitle(for cell: MiniBranchCell, settings: MiniWindowSettin
 /// Heading for a SubProvider's primary (flat, ungrouped) buckets. Every
 /// entry resolves to a quota-group name — the SubProvider itself is printed
 /// one tier up by `MiniMemberStack`, so nothing here may name a product.
-/// `gemini.chat` keeps its persisted key and now resolves to "All Models".
+/// Gemini Web has no L3 group at all (its buckets *are* "5 Hours" and
+/// "Weekly", AGENTS.md § 7.1), so it gets no heading rather than an invented
+/// one; Grok's single group is "Weekly Credits".
 private func miniPrimaryGroupTitle(
     for tool: ToolType,
     settings: MiniWindowSettings
@@ -613,8 +625,7 @@ private func miniPrimaryGroupTitle(
     switch tool {
     case .codex: key = "codex.all-models"
     case .claude: key = "claude.all-models"
-    case .gemini: key = "gemini.chat"
-    case .grok: key = "grok.all-models"
+    case .grok: key = "grok.weekly-credits"
     default: return nil
     }
     let custom = settings.groupLabels[key]?.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Sources/VibeBarApp/Views/MiniQuotaWindowView.swift
+++ b/Sources/VibeBarApp/Views/MiniQuotaWindowView.swift
@@ -27,7 +27,8 @@ struct MiniQuotaWindowView: View {
             MiniWindowProviderLayout(
                 displayMode: displayMode,
                 visibleTools: visibleTools,
-                contentByTool: contentByTool
+                contentByTool: contentByTool,
+                selectedFieldIds: miniSelectedFieldIds
             )
             .padding(.horizontal, displayMode == .compact ? 8 : 14)
             .padding(.top, displayMode == .compact ? 16 : 22)
@@ -47,13 +48,24 @@ struct MiniQuotaWindowView: View {
         }
         .frame(
             minWidth: displayMode == .compact ? 156 : 240,
-            minHeight: displayMode == .compact ? 134 : 166,
+            // Three tiers now: company header, SubProvider label, quota
+            // groups. `MiniQuotaWindowController.stableContentSize` reserves
+            // the same extra label row — keep the two in step.
+            minHeight: displayMode == .compact ? 146 : 181,
             alignment: .center
         )
         .glassEffect(
             .regular.interactive(),
             in: .rect(cornerRadius: Theme.miniCornerRadius)
         )
+    }
+
+    /// The field ids selected for the current display mode. Also the input to
+    /// `MenuBarFieldCatalog.subProviderGroups`, which decides the company →
+    /// SubProvider skeleton the layout renders into.
+    private var miniSelectedFieldIds: Set<String> {
+        let mini = settingsStore.settings.miniWindow
+        return Set(mini.fieldIds(for: mini.displayMode))
     }
 
     private var miniContentByTool: [ToolType: MiniToolContent] {
@@ -145,17 +157,22 @@ struct MiniQuotaWindowView: View {
     }
 }
 
-/// Snapshot of a tool's contribution to its L2 product group — the
-/// tool itself plus its primary + branch cells. Used as the unit of
-/// rendering inside a multi-tool group (Gemini Web + AntiGravity).
-private struct MiniL2Member {
+/// One L2 SubProvider inside a company column — its name, the tool whose
+/// adapter produced the buckets, and the primary + branch cells that belong to
+/// it. This is the middle tier of the mini window's company → SubProvider →
+/// quota-group layout, and it is **not** one per `ToolType`: Cursor's adapter
+/// yields both "Cursor" and "Grok Bot" (see `ToolType.quotaSubProviderName`).
+private struct MiniL2Member: Identifiable {
     let tool: ToolType
+    let subProviderName: String
     let content: MiniToolContent
+
+    var id: String { "\(tool.rawValue)/\(subProviderName)" }
 }
 
 /// Tools sharing the same L1 enterprise/brand (e.g. Gemini Web + AntiGravity)
 /// collapse into one super-column with a single company header and one
-/// SubProvider label per tool. The mini window renders one super-column
+/// labelled section per SubProvider. The mini window renders one super-column
 /// per `MiniCompanyGroup`, not one per `ToolType`.
 private struct MiniCompanyGroup: Identifiable {
     let companyName: String
@@ -163,37 +180,46 @@ private struct MiniCompanyGroup: Identifiable {
     let members: [MiniL2Member]
 
     var id: String { companyName }
-    var isMultiTool: Bool { members.count > 1 }
+    var isMultiSubProvider: Bool { members.count > 1 }
 }
 
-/// Walks `visibleTools` in their `dedicatedCardProviders` order and
-/// folds consecutive tools sharing the same `vendorName` into one
-/// `MiniCompanyGroup`. Tools with empty content are skipped.
+/// Fills `MenuBarFieldCatalog.subProviderGroups`' company → SubProvider
+/// skeleton with the live cells built above. The skeleton owns the ordering
+/// (catalog order inside a tool, `visibleTools` order across tools, companies
+/// folded by `vendorName`); this only attaches content and drops whatever the
+/// live quota had nothing for.
 private func miniProductGroups(
     visibleTools: [ToolType],
-    contentByTool: [ToolType: MiniToolContent]
+    contentByTool: [ToolType: MiniToolContent],
+    selectedFieldIds: Set<String>
 ) -> [MiniCompanyGroup] {
+    let skeleton = MenuBarFieldCatalog.subProviderGroups(
+        for: visibleTools,
+        selectedFieldIds: selectedFieldIds
+    )
     var groups: [MiniCompanyGroup] = []
-    for tool in visibleTools {
-        guard let content = contentByTool[tool], !content.isEmpty else { continue }
-        let company = tool.vendorName
-        let member = MiniL2Member(tool: tool, content: content)
-        if let last = groups.last, last.companyName == company {
-            let merged = MiniCompanyGroup(
-                companyName: last.companyName,
-                accentTool: last.accentTool,
-                members: last.members + [member]
-            )
-            groups[groups.count - 1] = merged
-        } else {
-            groups.append(
-                MiniCompanyGroup(
-                    companyName: company,
-                    accentTool: tool,
-                    members: [member]
+    for company in skeleton {
+        var members: [MiniL2Member] = []
+        for subProvider in company.subProviders {
+            guard let content = contentByTool[subProvider.tool] else { continue }
+            let member = MiniL2Member(
+                tool: subProvider.tool,
+                subProviderName: subProvider.name,
+                content: MiniToolContent(
+                    primaryCells: content.primaryCells.filter { $0.subProviderKey == subProvider.id },
+                    branchCells: content.branchCells.filter { $0.subProviderKey == subProvider.id }
                 )
             )
+            if !member.content.isEmpty { members.append(member) }
         }
+        guard !members.isEmpty else { continue }
+        groups.append(
+            MiniCompanyGroup(
+                companyName: company.company,
+                accentTool: company.accentTool,
+                members: members
+            )
+        )
     }
     return groups
 }
@@ -202,13 +228,18 @@ private struct MiniWindowProviderLayout: View {
     let displayMode: MiniWindowDisplayMode
     let visibleTools: [ToolType]
     let contentByTool: [ToolType: MiniToolContent]
+    let selectedFieldIds: Set<String>
 
     var body: some View {
-        let groups = miniProductGroups(visibleTools: visibleTools, contentByTool: contentByTool)
+        let groups = miniProductGroups(
+            visibleTools: visibleTools,
+            contentByTool: contentByTool,
+            selectedFieldIds: selectedFieldIds
+        )
         HStack(alignment: .top, spacing: displayMode == .compact ? 8 : 14) {
             ForEach(Array(groups.enumerated()), id: \.element.id) { index, group in
                 if index > 0 {
-                    MiniProviderDivider(height: displayMode == .compact ? 82 : 116)
+                    MiniProviderDivider(height: displayMode == .compact ? 94 : 131)
                         .padding(.top, 2)
                 }
                 switch displayMode {
@@ -239,6 +270,15 @@ private struct MiniCell: Identifiable {
 
     var id: String { "\(tool.rawValue).\(field.id)" }
 
+    /// L2 SubProvider this bucket bills against. Almost always the tool's own
+    /// product name — Grok Bot is the exception that makes this a per-bucket
+    /// question rather than a per-tool one.
+    var subProviderName: String { tool.quotaSubProviderName(bucketID: field.bucketId) }
+
+    /// Matches `MenuBarSubProviderGroup.id`, so a cell can be routed into the
+    /// SubProvider section the catalog says it belongs to.
+    var subProviderKey: String { "\(tool.rawValue)/\(subProviderName)" }
+
     var resolvedLabel: String {
         if let trimmed = customLabel?.trimmingCharacters(in: .whitespacesAndNewlines), !trimmed.isEmpty {
             return trimmed
@@ -257,6 +297,12 @@ private struct MiniBranchCell: Identifiable {
     let customLabel: String?
 
     var id: String { "\(tool.rawValue).branch.\(bucket.id)" }
+
+    /// See `MiniCell.subProviderName`. Cursor's `grok_bot_weekly` resolves to
+    /// "Grok Bot" here, which is what splits it out of the Cursor section.
+    var subProviderName: String { tool.quotaSubProviderName(bucketID: field.bucketId) }
+
+    var subProviderKey: String { "\(tool.rawValue)/\(subProviderName)" }
 
     var title: String {
         if let trimmed = customLabel?.trimmingCharacters(in: .whitespacesAndNewlines), !trimmed.isEmpty {
@@ -510,6 +556,15 @@ private enum MiniRingMetrics {
     static let labelHeight: CGFloat = 12
     static let paceHeight: CGFloat = 10
     static let resetHeight: CGFloat = 10
+    /// Gap between quota-group columns *inside* one SubProvider. There is no
+    /// rule here on purpose: a divider at this depth read as a SubProvider
+    /// boundary when it was only separating model groups. Their own titles
+    /// plus this gap do the separating.
+    static let groupSpacing: CGFloat = 14
+    /// Gap on each side of the `MiniGroupDivider` that separates SubProviders.
+    static let memberSpacing: CGFloat = 10
+    static let subProviderLabelHeight: CGFloat = 12
+    static let subProviderLabelGap: CGFloat = 3
 }
 
 private struct MiniBranchGroup: Identifiable {
@@ -546,6 +601,10 @@ private func miniGroupTitle(for cell: MiniBranchCell, settings: MiniWindowSettin
     return cell.defaultGroupTitle
 }
 
+/// Heading for a SubProvider's primary (flat, ungrouped) buckets. Every
+/// entry resolves to a quota-group name — the SubProvider itself is printed
+/// one tier up by `MiniMemberStack`, so nothing here may name a product.
+/// `gemini.chat` keeps its persisted key and now resolves to "All Models".
 private func miniPrimaryGroupTitle(
     for tool: ToolType,
     settings: MiniWindowSettings
@@ -565,12 +624,11 @@ private func miniPrimaryGroupTitle(
     return MiniWindowGroupLabelCatalog.defaultLabel(for: key)
 }
 
-/// Renders one L2 product super-column in the regular (ring) layout.
-/// Single-tool groups (ChatGPT / Claude) get a compact L2 header + bucket
-/// rings. Multi-tool groups (Gemini = Gemini Web + AntiGravity; Grok = Grok
-/// Build + Cursor) get the L2 header on top, each L3 tool as a
-/// sub-section beneath with its own small toolName sub-label,
-/// separated by a thin divider.
+/// Renders one L1 company super-column in the regular (ring) layout: the
+/// company header on top, then one `MiniMemberStack` per L2 SubProvider,
+/// separated by a thin divider. A company with a single SubProvider
+/// (OpenAI → ChatGPT Agentic) still gets the SubProvider label, so the three
+/// tiers read the same everywhere.
 private struct MiniCompanyGroupColumn: View {
     let group: MiniCompanyGroup
 
@@ -589,11 +647,11 @@ private struct MiniCompanyGroupColumn: View {
             }
             .frame(width: totalContentWidth, alignment: .center)
 
-            HStack(alignment: .top, spacing: 10) {
-                ForEach(Array(group.members.enumerated()), id: \.element.tool) { index, member in
+            HStack(alignment: .top, spacing: MiniRingMetrics.memberSpacing) {
+                ForEach(Array(group.members.enumerated()), id: \.element.id) { index, member in
                     if index > 0 {
-                        MiniGroupDivider()
-                            .padding(.top, 15)
+                        MiniGroupDivider(height: 112)
+                            .padding(.top, 4)
                     }
                     MiniMemberStack(
                         member: member,
@@ -604,6 +662,10 @@ private struct MiniCompanyGroupColumn: View {
         }
     }
 
+    /// Width of the SubProvider row, so the company header centres over the
+    /// gauges instead of over the column's leading edge. Every gap has to be
+    /// counted exactly: the divider is a layout sibling, so it takes the
+    /// stack's spacing on *both* sides plus its own hairline.
     private var totalContentWidth: CGFloat {
         var width: CGFloat = 0
         for member in group.members {
@@ -613,33 +675,42 @@ private struct MiniCompanyGroupColumn: View {
             )
         }
         if group.members.count > 1 {
-            width += CGFloat(group.members.count - 1) * 10
+            width += CGFloat(group.members.count - 1)
+                * (2 * MiniRingMetrics.memberSpacing + MiniGroupDivider.thickness)
         }
         return width
     }
 }
 
-/// One L3 member inside an L2 super-column. Primary provider quotas get an
-/// explicit group heading: "All Models" for ChatGPT, Claude, and Grok, and
-/// "Gemini Chat" for Gemini Web so it stays distinct from AntiGravity groups.
+/// One L2 SubProvider section: its name, then its L3 quota groups. Primary
+/// provider quotas get an explicit group heading — "All Models" for ChatGPT,
+/// Claude, Gemini Web, and Grok — so the tier below the SubProvider always
+/// names a quota group rather than a product.
 private struct MiniMemberStack: View {
     let member: MiniL2Member
     let settings: MiniWindowSettings
 
     var body: some View {
-        VStack(alignment: .center, spacing: 0) {
-            HStack(alignment: .top, spacing: 8) {
+        VStack(alignment: .center, spacing: MiniRingMetrics.subProviderLabelGap) {
+            Text(member.subProviderName.uppercased())
+                .font(.system(size: 8.5, weight: .semibold, design: .rounded))
+                .foregroundStyle(.secondary)
+                .tracking(1.2)
+                .lineLimit(1)
+                .minimumScaleFactor(0.6)
+                .frame(
+                    width: Self.width(for: member, settings: settings),
+                    height: MiniRingMetrics.subProviderLabelHeight,
+                    alignment: .center
+                )
+            HStack(alignment: .top, spacing: MiniRingMetrics.groupSpacing) {
                 if !member.content.primaryCells.isEmpty {
                     MiniPrimaryRingGroup(
                         cells: member.content.primaryCells,
                         title: primaryGroupTitle
                     )
                 }
-                ForEach(Array(branchGroups.enumerated()), id: \.element.id) { index, group in
-                    if !member.content.primaryCells.isEmpty || index > 0 {
-                        MiniGroupDivider()
-                            .padding(.top, 15)
-                    }
+                ForEach(branchGroups) { group in
                     MiniBranchRingGroup(group: group)
                 }
             }
@@ -672,7 +743,7 @@ private struct MiniMemberStack: View {
             groupCount += 1
         }
         if groupCount > 1 {
-            width += CGFloat(groupCount - 1) * 16.5
+            width += CGFloat(groupCount - 1) * MiniRingMetrics.groupSpacing
         }
         return width
     }
@@ -856,13 +927,17 @@ private struct MiniBranchRingCell: View {
     }
 }
 
+/// The rule between two L2 SubProviders inside one company column. Quota
+/// groups *within* a SubProvider are deliberately undivided.
 private struct MiniGroupDivider: View {
+    static let thickness: CGFloat = 0.75
+
     var height: CGFloat = 92
 
     var body: some View {
         Rectangle()
             .fill(Color.primary.opacity(0.055))
-            .frame(width: 0.75, height: height)
+            .frame(width: Self.thickness, height: height)
     }
 }
 
@@ -1016,11 +1091,17 @@ private enum MiniCompactMetrics {
     static let percentHeight: CGFloat = 12
     static let paceHeight: CGFloat = 8
     static let resetHeight: CGFloat = 8
+    /// See `MiniRingMetrics.groupSpacing` — no rule between quota groups
+    /// inside one SubProvider.
+    static let groupSpacing: CGFloat = 9
+    static let memberSpacing: CGFloat = 6
+    static let subProviderLabelHeight: CGFloat = 10
+    static let subProviderLabelGap: CGFloat = 2
 }
 
-/// Compact-mode counterpart of `MiniCompanyGroupColumn`. Same L1 header
-/// + SubProvider labels + bar cells, sized for the shorter
-/// compact panel.
+/// Compact-mode counterpart of `MiniCompanyGroupColumn`. Same three tiers —
+/// company header, SubProvider label, quota-group bars — sized for the
+/// shorter compact panel.
 private struct MiniCompactL2GroupColumn: View {
     let group: MiniCompanyGroup
 
@@ -1039,11 +1120,11 @@ private struct MiniCompactL2GroupColumn: View {
             }
             .frame(width: totalContentWidth, alignment: .center)
 
-            HStack(alignment: .top, spacing: 6) {
-                ForEach(Array(group.members.enumerated()), id: \.element.tool) { index, member in
+            HStack(alignment: .top, spacing: MiniCompactMetrics.memberSpacing) {
+                ForEach(Array(group.members.enumerated()), id: \.element.id) { index, member in
                     if index > 0 {
-                        MiniGroupDivider(height: 66)
-                            .padding(.top, 12)
+                        MiniGroupDivider(height: 98)
+                            .padding(.top, 3)
                     }
                     MiniCompactMemberStack(
                         member: member,
@@ -1063,7 +1144,8 @@ private struct MiniCompactL2GroupColumn: View {
             )
         }
         if group.members.count > 1 {
-            width += CGFloat(group.members.count - 1) * 6
+            width += CGFloat(group.members.count - 1)
+                * (2 * MiniCompactMetrics.memberSpacing + MiniGroupDivider.thickness)
         }
         return width
     }
@@ -1074,19 +1156,26 @@ private struct MiniCompactMemberStack: View {
     let settings: MiniWindowSettings
 
     var body: some View {
-        VStack(alignment: .center, spacing: 0) {
-            HStack(alignment: .top, spacing: 5) {
+        VStack(alignment: .center, spacing: MiniCompactMetrics.subProviderLabelGap) {
+            Text(member.subProviderName.uppercased())
+                .font(.system(size: 7.5, weight: .semibold, design: .rounded))
+                .foregroundStyle(.secondary)
+                .tracking(1.2)
+                .lineLimit(1)
+                .minimumScaleFactor(0.55)
+                .frame(
+                    width: Self.width(for: member, settings: settings),
+                    height: MiniCompactMetrics.subProviderLabelHeight,
+                    alignment: .center
+                )
+            HStack(alignment: .top, spacing: MiniCompactMetrics.groupSpacing) {
                 if !member.content.primaryCells.isEmpty {
                     MiniCompactPrimaryGroup(
                         cells: member.content.primaryCells,
                         title: primaryGroupTitle
                     )
                 }
-                ForEach(Array(branchGroups.enumerated()), id: \.element.id) { index, group in
-                    if !member.content.primaryCells.isEmpty || index > 0 {
-                        MiniGroupDivider(height: 66)
-                            .padding(.top, 12)
-                    }
+                ForEach(branchGroups) { group in
                     MiniCompactBranchGroup(group: group)
                 }
             }
@@ -1119,7 +1208,7 @@ private struct MiniCompactMemberStack: View {
             groupCount += 1
         }
         if groupCount > 1 {
-            width += CGFloat(groupCount - 1) * 10
+            width += CGFloat(groupCount - 1) * MiniCompactMetrics.groupSpacing
         }
         return width
     }

--- a/Sources/VibeBarApp/Views/MiniQuotaWindowView.swift
+++ b/Sources/VibeBarApp/Views/MiniQuotaWindowView.swift
@@ -295,6 +295,14 @@ private struct MiniCell: Identifiable {
         if let trimmed = customLabel?.trimmingCharacters(in: .whitespacesAndNewlines), !trimmed.isEmpty {
             return trimmed
         }
+        // A bucket whose group title is just its SubProvider (Grok Bot) is
+        // drawn flat under that SubProvider row, so its cell must name the
+        // L3 window ("Weekly"), not repeat "Grok Bot" a third time.
+        if let bucket,
+           let group = bucket.groupTitle,
+           group.caseInsensitiveCompare(subProviderName) == .orderedSame {
+            return bucket.title
+        }
         if let bucket, field.defaultLabel != bucket.shortLabel {
             return bucket.shortLabel
         }
@@ -625,7 +633,7 @@ private func miniPrimaryGroupTitle(
     switch tool {
     case .codex: key = "codex.all-models"
     case .claude: key = "claude.all-models"
-    case .grok: key = "grok.weekly-credits"
+    case .grok: key = "grok.all-models"
     default: return nil
     }
     let custom = settings.groupLabels[key]?.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Sources/VibeBarApp/Views/MiniWindowGroupLabelCatalog.swift
+++ b/Sources/VibeBarApp/Views/MiniWindowGroupLabelCatalog.swift
@@ -17,7 +17,12 @@ enum MiniWindowGroupLabelCatalog {
         .init(id: "claude.opus", title: "CLAUDE · Opus", defaultLabel: "Opus"),
         .init(id: "claude.fable", title: "CLAUDE · Fable", defaultLabel: "Fable"),
         .init(id: "claude.oauth", title: "CLAUDE · OAuth", defaultLabel: "OAuth"),
-        .init(id: "gemini.chat", title: "GEMINI · Gemini Chat", defaultLabel: "Gemini Chat"),
+        // The id is a persisted `groupLabels` key — renaming it would orphan
+        // every custom label. The *label* is what changed: "Gemini Chat" was
+        // an L2-flavoured name sitting in the L3 slot, and now that the mini
+        // window prints "GEMINI WEB" as its own SubProvider row, the group
+        // below it has to name a quota group like every other provider's does.
+        .init(id: "gemini.chat", title: "GEMINI WEB · All Models", defaultLabel: "All Models"),
         .init(id: "gemini.pro", title: "GEMINI · Pro", defaultLabel: "Pro"),
         .init(id: "gemini.flash", title: "GEMINI · Flash", defaultLabel: "Flash"),
         .init(id: "gemini.flash-lite", title: "GEMINI · Flash Lite", defaultLabel: "Lite"),

--- a/Sources/VibeBarApp/Views/MiniWindowGroupLabelCatalog.swift
+++ b/Sources/VibeBarApp/Views/MiniWindowGroupLabelCatalog.swift
@@ -17,21 +17,14 @@ enum MiniWindowGroupLabelCatalog {
         .init(id: "claude.opus", title: "CLAUDE · Opus", defaultLabel: "Opus"),
         .init(id: "claude.fable", title: "CLAUDE · Fable", defaultLabel: "Fable"),
         .init(id: "claude.oauth", title: "CLAUDE · OAuth", defaultLabel: "OAuth"),
-        // The id is a persisted `groupLabels` key — renaming it would orphan
-        // every custom label. The *label* is what changed: "Gemini Chat" was
-        // an L2-flavoured name sitting in the L3 slot, and now that the mini
-        // window prints "GEMINI WEB" as its own SubProvider row, the group
-        // below it has to name a quota group like every other provider's does.
-        .init(id: "gemini.chat", title: "GEMINI WEB · All Models", defaultLabel: "All Models"),
-        .init(id: "gemini.pro", title: "GEMINI · Pro", defaultLabel: "Pro"),
+.init(id: "gemini.pro", title: "GEMINI · Pro", defaultLabel: "Pro"),
         .init(id: "gemini.flash", title: "GEMINI · Flash", defaultLabel: "Flash"),
         .init(id: "gemini.flash-lite", title: "GEMINI · Flash Lite", defaultLabel: "Lite"),
         .init(id: "antigravity.gemini-models", title: "ANTIGRAVITY · Gemini Models", defaultLabel: "Gemini"),
         .init(id: "antigravity.claude-gpt-models", title: "ANTIGRAVITY · Claude + GPT Models", defaultLabel: "C+G"),
-        .init(id: "grok.all-models", title: "GROK · All Models", defaultLabel: "All Models"),
+        .init(id: "grok.weekly-credits", title: "GROK · Weekly Credits", defaultLabel: "Weekly Credits"),
         .init(id: "cursor.models", title: "CURSOR · Cursor Models", defaultLabel: "Cursor Models"),
-        .init(id: "cursor.other-models", title: "CURSOR · Other Models", defaultLabel: "Other Models"),
-        .init(id: "cursor.grok-bot", title: "CURSOR · Grok Bot", defaultLabel: "Grok Bot")
+        .init(id: "cursor.other-models", title: "CURSOR · Other Models", defaultLabel: "Other Models")
     ]
 
     static func defaultLabel(for id: String) -> String? {

--- a/Sources/VibeBarApp/Views/MiniWindowGroupLabelCatalog.swift
+++ b/Sources/VibeBarApp/Views/MiniWindowGroupLabelCatalog.swift
@@ -22,7 +22,9 @@ enum MiniWindowGroupLabelCatalog {
         .init(id: "gemini.flash-lite", title: "GEMINI · Flash Lite", defaultLabel: "Lite"),
         .init(id: "antigravity.gemini-models", title: "ANTIGRAVITY · Gemini Models", defaultLabel: "Gemini"),
         .init(id: "antigravity.claude-gpt-models", title: "ANTIGRAVITY · Claude + GPT Models", defaultLabel: "C+G"),
-        .init(id: "grok.weekly-credits", title: "GROK · Weekly Credits", defaultLabel: "Weekly Credits"),
+        // Stable persisted key (custom labels are stored under it); the
+        // wording is the L3 group name from AGENTS.md § 7.1.
+        .init(id: "grok.all-models", title: "GROK · Weekly Credits", defaultLabel: "Weekly Credits"),
         .init(id: "cursor.models", title: "CURSOR · Cursor Models", defaultLabel: "Cursor Models"),
         .init(id: "cursor.other-models", title: "CURSOR · Other Models", defaultLabel: "Other Models")
     ]

--- a/Sources/VibeBarApp/Views/Workbench/SessionManagerPage.swift
+++ b/Sources/VibeBarApp/Views/Workbench/SessionManagerPage.swift
@@ -27,27 +27,6 @@ extension Harness {
     var brandTool: ToolType { quotaTool }
 }
 
-/// Session chips group by L1 company; the members are harnesses, because a
-/// harness is what a row is labelled with and two harnesses can share one
-/// provider adapter (a Codex rollout is Codex or ChatGPT Work depending on
-/// its `originator`). See AGENTS.md § 7.1.
-private struct SessionCompanyFilter: Identifiable {
-    let representative: ToolType
-    let harnesses: Set<Harness>
-
-    var id: ToolType { representative }
-
-    /// Derived, not restated: a company's chip covers every harness that
-    /// company owns, and a company with none never gets a chip. All eight
-    /// harnesses are indexable today, so all four companies appear.
-    static let all: [SessionCompanyFilter] = ToolType.coreProviderRepresentatives
-        .compactMap { representative in
-            let harnesses = Set(Harness.harnesses(forCompany: representative))
-            guard !harnesses.isEmpty else { return nil }
-            return SessionCompanyFilter(representative: representative, harnesses: harnesses)
-        }
-}
-
 /// The Workbench's Sessions page.
 ///
 /// A split, not a scroll: the list is a place you keep coming back to while
@@ -122,9 +101,14 @@ struct SessionManagerPage: View {
 
 /// Everything that narrows the session list, plus the page's own options.
 ///
-/// Provider chips carry the brand accent for the same reason the usage
-/// filters do — colour is how this app says "provider" — and the rest is
-/// glass menus so a rarely-used control never outweighs the list.
+/// The filter unit is the **harness**, not the company: a row is labelled
+/// with the harness that produced it, and two harnesses can share one adapter
+/// (a Codex rollout is Codex or ChatGPT Work depending on its `originator`).
+/// So each company contributes a muted section-head chip that toggles all of
+/// its harnesses at once, followed by one chip per harness. Chips carry the
+/// brand accent for the same reason the usage filters do — colour is how this
+/// app says "provider" — and the rest is glass menus so a rarely-used control
+/// never outweighs the list. See AGENTS.md § 7.1.
 struct SessionFiltersBar: View {
     let density: Theme.Density
     @ObservedObject var model: SessionManagerModel
@@ -144,10 +128,14 @@ struct SessionFiltersBar: View {
                     }
                     .help("Rescan the session logs on disk")
                     allProvidersChip
-                    ForEach(SessionCompanyFilter.all) { group in
-                        providerChip(group)
+                    ForEach(chipGroups) { group in
+                        HStack(spacing: 4) {
+                            companyChip(group)
+                            ForEach(group.harnesses, id: \.self) { harness in
+                                harnessChip(harness, in: group)
+                            }
+                        }
                     }
-                    sessionSourceMenu
                     rangeMenu
                     sortMenu
                     optionsMenu
@@ -216,13 +204,27 @@ struct SessionFiltersBar: View {
         return shown == 1 ? "1 session" : "\(shown) sessions"
     }
 
-    // MARK: - Providers
+    // MARK: - Harnesses
+
+    /// A company disappears from the row once the index proves it has no
+    /// sessions at all — but only once there *are* counts. Before the first
+    /// page lands, and whenever the index is unavailable, every company shows:
+    /// an empty filter row the user cannot recover from is worse than four
+    /// chips that turn out to be empty.
+    private var chipGroups: [Harness.ChipGroup] {
+        let groups = Harness.chipGroups(companies: ToolType.coreProviderRepresentatives)
+        let counts = model.harnessCounts
+        guard counts.values.contains(where: { $0 > 0 }) else { return groups }
+        return groups.filter { group in
+            group.harnesses.contains { (counts[$0] ?? 0) > 0 }
+        }
+    }
 
     private var allProvidersChip: some View {
         Button {
             model.setHarnessFilter(nil)
         } label: {
-            Text("All providers")
+            Text("All")
                 .font(.system(size: max(10, density.segmentedFontSize - 1), weight: .semibold))
                 .foregroundStyle(model.harnessFilter == nil ? .primary : .secondary)
                 .padding(.horizontal, 10)
@@ -230,20 +232,52 @@ struct SessionFiltersBar: View {
         }
         .buttonStyle(.plain)
         .background(chipBackground(tint: .accentColor, selected: model.harnessFilter == nil))
-        .accessibilityLabel("Show every provider")
+        .help("Show sessions from every harness")
+        .accessibilityLabel("Show every session source")
     }
 
-    private func providerChip(_ group: SessionCompanyFilter) -> some View {
-        let selected = model.harnessFilter.map { selected in
-            group.harnesses.allSatisfy(selected.contains)
-        } ?? true
-        let count = group.harnesses.reduce(0) { $0 + (model.harnessCounts[$1] ?? 0) }
+    /// The company section head. Deliberately quieter than the harness chips
+    /// beside it — smaller, no count, barely any fill — because it is not one
+    /// more thing to filter by, it is a shortcut for the harnesses it covers.
+    private func companyChip(_ group: Harness.ChipGroup) -> some View {
+        let accent = Theme.providerAccent(for: group.company)
+        let selected = isSelected(group)
         return Button {
-            model.toggleHarnesses(group.harnesses)
+            model.toggleHarnesses(group.harnessSet)
+        } label: {
+            HStack(spacing: 4) {
+                ToolBrandIconView(tool: group.company, size: max(9, density.segmentedFontSize - 1))
+                Text(group.company.vendorName)
+                    .font(.system(size: max(9, density.segmentedFontSize - 2), weight: .semibold))
+                    .tracking(0.3)
+                    .lineLimit(1)
+            }
+            .foregroundStyle(.secondary)
+            .padding(.horizontal, 7)
+            .frame(minHeight: 28)
+        }
+        .buttonStyle(.plain)
+        .background(Capsule().fill(accent.opacity(selected ? 0.10 : 0.035)))
+        .opacity(selected ? 1 : 0.65)
+        .saturation(selected ? 1 : 0.50)
+        .help(companyHelp(group))
+        .accessibilityLabel("\(group.company.vendorName), every harness")
+        .accessibilityAddTraits(selected ? [.isSelected] : [])
+    }
+
+    /// One chip per harness — the unit a session row is actually labelled
+    /// with. The icon is the harness's own brand (Cursor's mark, not Grok's,
+    /// matching the badge in the list); the accent is the company's, so a
+    /// group still reads as one block of colour.
+    private func harnessChip(_ harness: Harness, in group: Harness.ChipGroup) -> some View {
+        let selected = model.harnessFilter?.contains(harness) ?? true
+        let count = model.harnessCounts[harness] ?? 0
+        return Button {
+            model.toggleHarness(harness)
         } label: {
             HStack(spacing: 5) {
-                ToolBrandIconView(tool: group.representative, size: density.segmentedFontSize + 1)
-                Text(group.representative.vendorName)
+                ToolBrandIconView(tool: harness.brandTool, size: density.segmentedFontSize + 1)
+                Text(harness.displayName)
                     .font(.system(size: max(10, density.segmentedFontSize - 1), weight: .semibold))
                     .lineLimit(1)
                 if count > 0 {
@@ -257,11 +291,21 @@ struct SessionFiltersBar: View {
             .frame(minHeight: 28)
         }
         .buttonStyle(.plain)
-        .background(chipBackground(tint: Theme.providerAccent(for: group.representative), selected: selected))
+        .background(chipBackground(tint: Theme.providerAccent(for: group.company), selected: selected))
         .opacity(selected ? 1 : 0.70)
         .saturation(selected ? 1 : 0.50)
-        .help(group.representative.vendorName)
+        .help("\(group.company.vendorName) · \(harness.displayName)")
         .accessibilityAddTraits(selected ? [.isSelected] : [])
+    }
+
+    private func isSelected(_ group: Harness.ChipGroup) -> Bool {
+        guard let filter = model.harnessFilter else { return true }
+        return group.harnesses.allSatisfy(filter.contains)
+    }
+
+    private func companyHelp(_ group: Harness.ChipGroup) -> String {
+        let names = group.harnesses.map(\.displayName).joined(separator: " + ")
+        return "\(group.company.vendorName) · \(names)"
     }
 
     private func chipBackground(tint: Color, selected: Bool) -> some View {
@@ -272,35 +316,6 @@ struct SessionFiltersBar: View {
     }
 
     // MARK: - Controls
-
-    /// One row per harness, not per provider: Codex and ChatGPT Work share a
-    /// rollout tree and are only separable here.
-    private var sessionSourceMenu: some View {
-        Menu {
-            Button("All session sources") { model.setHarnessFilter(nil) }
-            Divider()
-            ForEach(SessionCompanyFilter.all) { group in
-                Section(group.representative.vendorName) {
-                    ForEach(Harness.harnesses(forCompany: group.representative), id: \.self) { harness in
-                        Toggle(isOn: sessionSourceBinding(harness)) {
-                            Text(harness.displayName)
-                        }
-                    }
-                }
-            }
-        } label: {
-            menuLabel(
-                systemImage: "square.stack.3d.up",
-                title: "Sources",
-                detail: sessionSourceSummary
-            )
-        }
-        .menuStyle(.button)
-        .buttonStyle(WorkbenchPillButtonStyle())
-        .menuIndicator(.hidden)
-        .fixedSize()
-        .accessibilityLabel("Choose individual session sources")
-    }
 
     private var rangeMenu: some View {
         Menu {
@@ -398,19 +413,6 @@ struct SessionFiltersBar: View {
 
     private var bodyIndexingBinding: Binding<Bool> {
         Binding(get: { model.isBodyIndexingEnabled }, set: { model.setBodyIndexing($0) })
-    }
-
-    private func sessionSourceBinding(_ harness: Harness) -> Binding<Bool> {
-        Binding(
-            get: { model.harnessFilter?.contains(harness) ?? true },
-            set: { _ in model.toggleHarness(harness) }
-        )
-    }
-
-    private var sessionSourceSummary: String {
-        guard let selected = model.harnessFilter else { return "All" }
-        if selected.count == 1, let only = selected.first { return only.displayName }
-        return "\(selected.count) selected"
     }
 
     private func menuLabel(systemImage: String, title: String, detail: String) -> some View {

--- a/Sources/VibeBarApp/Views/Workbench/UsageFiltersBar.swift
+++ b/Sources/VibeBarApp/Views/Workbench/UsageFiltersBar.swift
@@ -1,14 +1,14 @@
 import SwiftUI
 import VibeBarCore
 
-/// Everything that narrows the Usage Stats page: company chips, a harness
-/// picker, a model picker, the date range, and how often the page re-queries.
+/// Everything that narrows the Usage Stats page: harness chips, a model
+/// picker, the date range, and how often the page re-queries.
 ///
-/// The two narrowing axes stay separate on purpose. Companies are chips
-/// because they are the filter users reach for most and because a chip can
-/// carry the brand accent — which is how this app says "provider" everywhere
-/// else. Harnesses are a menu below them: they are the usage axis (which CLI
-/// or app produced the sessions), not another level of the quota hierarchy.
+/// This is a usage surface, so the unit is the **harness** — the CLI or app
+/// that produced the tokens — and the company is supplementary: a muted
+/// section head that toggles its harnesses in one click. Chips, not a menu,
+/// because a chip can carry the brand accent, which is how this app says
+/// "provider" everywhere else. See AGENTS.md § 7.1.
 struct UsageFiltersBar: View {
     let density: Theme.Density
     @ObservedObject var model: UsageStatsViewModel
@@ -34,14 +34,19 @@ struct UsageFiltersBar: View {
         .workbenchToolbarSurface()
     }
 
-    // MARK: - Providers
+    // MARK: - Harnesses
 
     private var providerChips: some View {
         ScrollView(.horizontal) {
-            HStack(spacing: 6) {
-                allProvidersChip
-                ForEach(model.knownCompanyRepresentatives, id: \.self) { representative in
-                    providerChip(representative)
+            HStack(spacing: 7) {
+                allHarnessesChip
+                ForEach(model.harnessChipGroups) { group in
+                    HStack(spacing: 4) {
+                        companyChip(group)
+                        ForEach(group.harnesses, id: \.self) { harness in
+                            harnessChip(harness, in: group)
+                        }
+                    }
                 }
             }
             .padding(.vertical, 1)
@@ -49,30 +54,63 @@ struct UsageFiltersBar: View {
         .scrollIndicators(.never)
     }
 
-    private var allProvidersChip: some View {
-        Button {
-            model.setSelectedTools(nil)
+    private var allHarnessesChip: some View {
+        let selected = model.selectedHarnesses == nil
+        return Button {
+            model.setSelectedHarnesses(nil)
         } label: {
-            Text("All providers")
+            Text("All harnesses")
                 .font(.system(size: max(10, density.segmentedFontSize - 1), weight: .semibold))
-                .foregroundStyle(model.selectedTools == nil ? .primary : .secondary)
+                .foregroundStyle(selected ? .primary : .secondary)
                 .padding(.horizontal, 10)
                 .frame(minHeight: 28)
         }
         .buttonStyle(.plain)
-        .background(chipBackground(tint: .accentColor, selected: model.selectedTools == nil))
-        .accessibilityLabel("Show every provider")
+        .background(chipBackground(tint: .accentColor, selected: selected))
+        .help("Include every harness")
+        .accessibilityLabel("Show every harness")
     }
 
-    private func providerChip(_ tool: ToolType) -> some View {
-        let accent = Theme.providerAccent(for: tool)
-        let selected = model.isCompanySelected(tool)
+    /// The company section head. Quieter than the harness chips beside it —
+    /// smaller, barely any fill — because the company is context here, not
+    /// another level to filter by: clicking it toggles its harnesses.
+    private func companyChip(_ group: Harness.ChipGroup) -> some View {
+        let accent = Theme.providerAccent(for: group.company)
+        let selected = isSelected(group)
         return Button {
-            model.toggleCompany(tool)
+            model.toggleHarnesses(group.harnessSet)
+        } label: {
+            HStack(spacing: 4) {
+                ToolBrandIconView(tool: group.company, size: max(9, density.segmentedFontSize - 1))
+                Text(group.company.vendorName)
+                    .font(.system(size: max(9, density.segmentedFontSize - 2), weight: .semibold))
+                    .tracking(0.3)
+                    .lineLimit(1)
+            }
+            .foregroundStyle(.secondary)
+            .padding(.horizontal, 7)
+            .frame(minHeight: 28)
+        }
+        .buttonStyle(.plain)
+        .background(Capsule().fill(accent.opacity(selected ? 0.10 : 0.035)))
+        .opacity(selected ? 1 : 0.65)
+        .saturation(selected ? 1 : 0.50)
+        .help(companyHelp(group))
+        .accessibilityLabel("\(group.company.vendorName), every harness")
+        .accessibilityAddTraits(selected ? [.isSelected] : [])
+    }
+
+    /// One chip per harness — the axis this page actually groups by. The icon
+    /// is the harness's own brand (Cursor's mark, not Grok's); the accent is
+    /// the company's, so a group still reads as one block of colour.
+    private func harnessChip(_ harness: Harness, in group: Harness.ChipGroup) -> some View {
+        let selected = model.selectedHarnesses?.contains(harness) ?? true
+        return Button {
+            model.toggleHarness(harness)
         } label: {
             HStack(spacing: 5) {
-                ToolBrandIconView(tool: tool, size: density.segmentedFontSize + 1)
-                Text(tool.vendorName)
+                ToolBrandIconView(tool: harness.brandTool, size: density.segmentedFontSize + 1)
+                Text(harness.displayName)
                     .font(.system(size: max(10, density.segmentedFontSize - 1), weight: .semibold))
                     .lineLimit(1)
             }
@@ -80,14 +118,18 @@ struct UsageFiltersBar: View {
             .frame(minHeight: 28)
         }
         .buttonStyle(.plain)
-        .background(chipBackground(tint: accent, selected: selected))
+        .background(chipBackground(tint: Theme.providerAccent(for: group.company), selected: selected))
         // Unselected chips stay legible but recede — the accent is the signal
-        // that a provider is in the query, so an off chip must not wear it.
+        // that a harness is in the query, so an off chip must not wear it.
         .opacity(selected ? 1 : 0.70)
         .saturation(selected ? 1 : 0.50)
-        .help(companyHelp(tool))
-        .accessibilityLabel(tool.vendorName)
+        .help("\(group.company.vendorName) · \(harness.displayName)")
         .accessibilityAddTraits(selected ? [.isSelected] : [])
+    }
+
+    private func isSelected(_ group: Harness.ChipGroup) -> Bool {
+        guard let selected = model.selectedHarnesses else { return true }
+        return group.harnesses.allSatisfy(selected.contains)
     }
 
     private func chipBackground(tint: Color, selected: Bool) -> some View {
@@ -102,15 +144,17 @@ struct UsageFiltersBar: View {
     private var controls: some View {
         HStack(spacing: 8) {
             rangeMenu
-            harnessMenu
             modelMenu
             refreshMenu
             if model.selectedTools != nil
                 || model.selectedHarnesses != nil
                 || model.selectedModels != nil {
                 Button {
-                    model.setSelectedTools(nil)
+                    // Harnesses first: `setSelectedTools` prunes any harness
+                    // whose company just left the query, so clearing tools
+                    // ahead of it would leave a stale, half-applied filter.
                     model.setSelectedHarnesses(nil)
+                    model.setSelectedTools(nil)
                     model.setSelectedModels(nil)
                 } label: {
                     Label("Clear", systemImage: "xmark")
@@ -119,7 +163,7 @@ struct UsageFiltersBar: View {
                         .frame(minHeight: 22)
                 }
                 .buttonStyle(WorkbenchPillButtonStyle())
-                .help("Clear company, harness, and model filters")
+                .help("Clear harness, company, and model filters")
             }
         }
         .fixedSize(horizontal: true, vertical: false)
@@ -202,36 +246,6 @@ struct UsageFiltersBar: View {
         .accessibilityLabel("Choose which models to include")
     }
 
-    /// Harnesses, not SubProviders: usage and cost surfaces speak the local
-    /// tool that produced the sessions. The list follows the lit company
-    /// chips so the menu never offers a combination that returns nothing.
-    private var harnessMenu: some View {
-        Menu {
-            Button("All harnesses") { model.setSelectedHarnesses(nil) }
-            if model.harnessOptions.isEmpty {
-                Text("No harnesses in range")
-            } else {
-                Divider()
-                ForEach(model.harnessOptions, id: \.self) { harness in
-                    Toggle(isOn: harnessBinding(harness)) {
-                        Text("\(harness.companyName) · \(harness.displayName)")
-                    }
-                }
-            }
-        } label: {
-            menuLabel(
-                systemImage: "terminal",
-                title: "Harness",
-                detail: harnessSummary
-            )
-        }
-        .menuStyle(.button)
-        .buttonStyle(WorkbenchPillButtonStyle())
-        .menuIndicator(.hidden)
-        .fixedSize()
-        .accessibilityLabel("Choose which harnesses to include")
-    }
-
     private var refreshMenu: some View {
         Menu {
             Picker("Auto refresh", selection: $model.refreshInterval) {
@@ -282,20 +296,13 @@ struct UsageFiltersBar: View {
         )
     }
 
-    private func harnessBinding(_ harness: Harness) -> Binding<Bool> {
-        Binding(
-            get: { model.selectedHarnesses?.contains(harness) ?? true },
-            set: { _ in model.toggleHarness(harness) }
-        )
-    }
-
-    /// Company chip tooltip: the harnesses that company actually contributes
-    /// to usage, which is the level this page groups by.
-    private func companyHelp(_ tool: ToolType) -> String {
-        let harnesses = Harness.harnesses(forCompany: tool)
-            .map(\.displayName)
-            .joined(separator: " + ")
-        return harnesses.isEmpty ? tool.vendorName : "\(tool.vendorName) · \(harnesses)"
+    /// Company chip tooltip: the harnesses that chip actually toggles, which
+    /// is the level this page groups by.
+    private func companyHelp(_ group: Harness.ChipGroup) -> String {
+        let harnesses = group.harnesses.map(\.displayName).joined(separator: " + ")
+        return harnesses.isEmpty
+            ? group.company.vendorName
+            : "\(group.company.vendorName) · \(harnesses)"
     }
 
     private var rangeSummary: String {
@@ -323,9 +330,4 @@ struct UsageFiltersBar: View {
         return "\(selected.count) selected"
     }
 
-    private var harnessSummary: String {
-        guard let selected = model.selectedHarnesses else { return "All" }
-        if selected.count == 1, let only = selected.first { return only.displayName }
-        return "\(selected.count) selected"
-    }
 }

--- a/Sources/VibeBarCore/Models/Harness.swift
+++ b/Sources/VibeBarCore/Models/Harness.swift
@@ -124,4 +124,48 @@ public enum Harness: String, CaseIterable, Codable, Sendable, Hashable {
         let representative = company.coreProviderRepresentative ?? company
         return allCases.filter { $0.company == representative }
     }
+
+    /// One filter-chip group: an L1 company and the harnesses under it.
+    ///
+    /// The company is context, not a peer of its members. Usage and cost
+    /// surfaces filter by harness — that is the unit a row is labelled with —
+    /// and the company chip exists only to toggle its harnesses in one click.
+    public struct ChipGroup: Equatable, Sendable, Identifiable {
+        public let company: ToolType
+        public let harnesses: [Harness]
+
+        public init(company: ToolType, harnesses: [Harness]) {
+            self.company = company
+            self.harnesses = harnesses
+        }
+
+        public var id: ToolType { company }
+
+        public var harnessSet: Set<Harness> { Set(harnesses) }
+    }
+
+    /// Groups `harnesses` under `companies` for a harness-primary filter row.
+    ///
+    /// Companies are normalized to their representative and de-duplicated, the
+    /// members keep `allCases` declaration order, and a company that
+    /// contributes no harness is dropped — a chip that can only ever narrow to
+    /// nothing should not be drawn. Pass a narrowed `harnesses` list (the ones
+    /// a page actually knows about) to keep the row honest.
+    public static func chipGroups(
+        companies: [ToolType],
+        harnesses: [Harness] = Harness.allCases
+    ) -> [ChipGroup] {
+        let available = Set(harnesses)
+        var seen: Set<ToolType> = []
+        var groups: [ChipGroup] = []
+        for company in companies {
+            let representative = company.coreProviderRepresentative ?? company
+            guard seen.insert(representative).inserted else { continue }
+            let members = Self.harnesses(forCompany: representative)
+                .filter(available.contains)
+            guard !members.isEmpty else { continue }
+            groups.append(ChipGroup(company: representative, harnesses: members))
+        }
+        return groups
+    }
 }

--- a/Sources/VibeBarCore/Models/MenuBarSettings.swift
+++ b/Sources/VibeBarCore/Models/MenuBarSettings.swift
@@ -203,6 +203,48 @@ public struct MenuBarFieldOption: Identifiable, Hashable, Sendable {
     }
 }
 
+/// One L2 SubProvider slice of a company's selected quota fields: the tool
+/// whose adapter produced the buckets, the SubProvider name shown between the
+/// company header and the quota-group titles, and the fields underneath it in
+/// catalog order.
+///
+/// The owning tool is part of the identity because one adapter can serve two
+/// SubProviders — Grok Bot rides Cursor's (see `ToolType.quotaSubProviderName`).
+public struct MenuBarSubProviderGroup: Equatable, Sendable, Identifiable {
+    public let tool: ToolType
+    public let name: String
+    public var fields: [MenuBarFieldOption]
+
+    public init(tool: ToolType, name: String, fields: [MenuBarFieldOption]) {
+        self.tool = tool
+        self.name = name
+        self.fields = fields
+    }
+
+    public var id: String { "\(tool.rawValue)/\(name)" }
+
+    public var fieldIds: [String] { fields.map(\.id) }
+
+    public var bucketIds: [String] { fields.map(\.bucketId) }
+}
+
+/// One L1 company column. Consecutive tools sharing a `vendorName` fold into
+/// a single group (Gemini Web + AntiGravity → Google AI; Grok + Cursor →
+/// SpaceXAI), each contributing one or more SubProviders.
+public struct MenuBarCompanyFieldGroup: Equatable, Sendable, Identifiable {
+    public let company: String
+    public let accentTool: ToolType
+    public var subProviders: [MenuBarSubProviderGroup]
+
+    public init(company: String, accentTool: ToolType, subProviders: [MenuBarSubProviderGroup]) {
+        self.company = company
+        self.accentTool = accentTool
+        self.subProviders = subProviders
+    }
+
+    public var id: String { company }
+}
+
 public enum MenuBarFieldCatalog {
     public static let codexFields: [MenuBarFieldOption] = [
         option(.codex, "five_hour", "5 Hours", "5 Hours"),
@@ -272,6 +314,56 @@ public enum MenuBarFieldCatalog {
 
     public static func fieldId(tool: ToolType, bucketId: String) -> String {
         "\(tool.rawValue).\(bucketId)"
+    }
+
+    /// Buckets the selected quota fields into the three tiers of the quota
+    /// naming axis — L1 company → L2 SubProvider → L3 quota bucket — walking
+    /// `tools` in the order given and `allFields` in catalog order.
+    ///
+    /// This is the shape the mini window renders: one column per company, one
+    /// labelled section per SubProvider, gauges underneath. A single tool can
+    /// contribute more than one SubProvider (Cursor → Cursor + Grok Bot) and
+    /// several tools can share one company (Gemini Web + AntiGravity). Tools
+    /// and SubProviders with nothing selected are dropped, so the result never
+    /// describes an empty column.
+    ///
+    /// Pure and adapter-free on purpose: the SwiftUI layout and the AppKit
+    /// panel-sizing code both need the same grouping, and they must not
+    /// disagree. See `AGENTS.md` § 7.1.
+    public static func subProviderGroups(
+        for tools: [ToolType],
+        selectedFieldIds: Set<String>
+    ) -> [MenuBarCompanyFieldGroup] {
+        var groups: [MenuBarCompanyFieldGroup] = []
+        for tool in tools {
+            var subProviders: [MenuBarSubProviderGroup] = []
+            var indexByName: [String: Int] = [:]
+            for field in allFields
+            where field.tool == tool && selectedFieldIds.contains(field.id) {
+                let name = tool.quotaSubProviderName(bucketID: field.bucketId)
+                if let index = indexByName[name] {
+                    subProviders[index].fields.append(field)
+                } else {
+                    indexByName[name] = subProviders.count
+                    subProviders.append(
+                        MenuBarSubProviderGroup(tool: tool, name: name, fields: [field])
+                    )
+                }
+            }
+            guard !subProviders.isEmpty else { continue }
+            if let last = groups.last, last.company == tool.vendorName {
+                groups[groups.count - 1].subProviders.append(contentsOf: subProviders)
+            } else {
+                groups.append(
+                    MenuBarCompanyFieldGroup(
+                        company: tool.vendorName,
+                        accentTool: tool,
+                        subProviders: subProviders
+                    )
+                )
+            }
+        }
+        return groups
     }
 
     public static func migratedFieldIds(_ ids: [String]) -> [String] {

--- a/Tests/VibeBarCoreTests/HarnessTests.swift
+++ b/Tests/VibeBarCoreTests/HarnessTests.swift
@@ -83,6 +83,48 @@ final class HarnessTests: XCTestCase {
         XCTAssertTrue(Harness.harnesses(forCompany: .warp).isEmpty)
     }
 
+    /// The filter rows on Sessions and Usage Stats are harness-primary: the
+    /// company is a section head that toggles its members, so the group has to
+    /// carry the members in display order.
+    func testChipGroupsCoverEveryCompanyInOrder() {
+        let groups = Harness.chipGroups(companies: ToolType.coreProviderRepresentatives)
+        XCTAssertEqual(groups.map(\.company), [.codex, .claude, .gemini, .grok])
+        XCTAssertEqual(
+            groups.map(\.harnesses),
+            [
+                [.codex, .chatgptWork],
+                [.claudeCode, .claudeCowork],
+                [.geminiCLI, .antigravity],
+                [.grokBuild, .cursor]
+            ]
+        )
+        XCTAssertEqual(groups.flatMap(\.harnesses), Harness.allCases)
+    }
+
+    func testChipGroupsNarrowToTheHarnessesAPageKnowsAbout() {
+        let groups = Harness.chipGroups(
+            companies: ToolType.coreProviderRepresentatives,
+            harnesses: [.cursor, .claudeCode]
+        )
+        XCTAssertEqual(groups.map(\.company), [.claude, .grok])
+        XCTAssertEqual(groups.map(\.harnesses), [[.claudeCode], [.cursor]])
+        XCTAssertTrue(
+            Harness.chipGroups(
+                companies: ToolType.coreProviderRepresentatives,
+                harnesses: []
+            ).isEmpty
+        )
+    }
+
+    /// A non-representative member and a company with no harness at all both
+    /// have to resolve without producing a duplicate or an empty chip.
+    func testChipGroupsNormalizeCompaniesAndDropEmptyOnes() {
+        let groups = Harness.chipGroups(companies: [.cursor, .grok, .warp])
+        XCTAssertEqual(groups.map(\.company), [.grok])
+        XCTAssertEqual(groups.first?.harnesses, [.grokBuild, .cursor])
+        XCTAssertEqual(groups.first?.harnessSet, Set([Harness.grokBuild, .cursor]))
+    }
+
     func testRawValuesAreStableStorageKeys() {
         // These land in SQLite and in the scan cache; renaming one silently
         // orphans every stored row.

--- a/Tests/VibeBarCoreTests/MenuBarFieldCatalogTests.swift
+++ b/Tests/VibeBarCoreTests/MenuBarFieldCatalogTests.swift
@@ -95,6 +95,104 @@ final class MenuBarFieldCatalogTests: XCTestCase {
         XCTAssertEqual(sliced.map(\.id), all)
     }
 
+    // MARK: - SubProvider grouping
+
+    private func allSelectedGroups() -> [MenuBarCompanyFieldGroup] {
+        MenuBarFieldCatalog.subProviderGroups(
+            for: ToolType.dedicatedCardProviders,
+            selectedFieldIds: Set(MenuBarFieldCatalog.allFields.map(\.id))
+        )
+    }
+
+    /// The mini window's middle tier. Companies fold by vendor, and one tool
+    /// can contribute two SubProviders — which is the whole point: Grok Bot
+    /// rides Cursor's adapter but must not sit inside Cursor's section.
+    func testSubProviderGroupsFollowTheQuotaHierarchy() {
+        let groups = allSelectedGroups()
+        XCTAssertEqual(groups.map(\.company), ["OpenAI", "Anthropic", "Google AI", "SpaceXAI"])
+        XCTAssertEqual(
+            groups.map { $0.subProviders.map(\.name) },
+            [
+                ["ChatGPT Agentic"],
+                ["Claude"],
+                ["Gemini Web", "AntiGravity"],
+                ["Grok", "Cursor", "Grok Bot"]
+            ]
+        )
+        XCTAssertEqual(groups.map(\.accentTool), [.codex, .claude, .gemini, .grok])
+    }
+
+    func testSubProviderGroupsCarryTheirBucketsInCatalogOrder() throws {
+        let byName = allSelectedGroups()
+            .flatMap(\.subProviders)
+            .reduce(into: [String: MenuBarSubProviderGroup]()) { $0[$1.name] = $1 }
+
+        XCTAssertEqual(
+            try XCTUnwrap(byName["ChatGPT Agentic"]).bucketIds,
+            ["five_hour", "weekly", "gpt_5_3_codex_spark_five_hour", "gpt_5_3_codex_spark_weekly"]
+        )
+        XCTAssertEqual(
+            try XCTUnwrap(byName["Claude"]).bucketIds,
+            [
+                "five_hour", "weekly", "weekly_sonnet", "weekly_design",
+                "daily_routines", "weekly_opus", "weekly_fable", "weekly_oauth_apps"
+            ]
+        )
+        XCTAssertEqual(try XCTUnwrap(byName["Gemini Web"]).bucketIds, ["five_hour", "weekly"])
+        XCTAssertEqual(
+            try XCTUnwrap(byName["AntiGravity"]).bucketIds,
+            ["gemini_five_hour", "gemini_weekly", "claude_gpt_five_hour", "claude_gpt_weekly"]
+        )
+        XCTAssertEqual(try XCTUnwrap(byName["Grok"]).bucketIds, ["weekly"])
+        XCTAssertEqual(try XCTUnwrap(byName["Cursor"]).bucketIds, ["models", "other_models"])
+        XCTAssertEqual(try XCTUnwrap(byName["Grok Bot"]).bucketIds, ["grok_bot_weekly"])
+
+        // Cursor and Grok Bot share one adapter, so the tool alone can't
+        // identify a section — the id has to carry the SubProvider name.
+        XCTAssertEqual(try XCTUnwrap(byName["Cursor"]).tool, .cursor)
+        XCTAssertEqual(try XCTUnwrap(byName["Grok Bot"]).tool, .cursor)
+        XCTAssertEqual(try XCTUnwrap(byName["Grok Bot"]).id, "cursor/Grok Bot")
+    }
+
+    /// Every selected field lands in exactly one section, and nothing that
+    /// wasn't selected sneaks in — the layout partitions the selection.
+    func testSubProviderGroupsPartitionTheSelection() {
+        let selected: Set<String> = [
+            "codex.weekly",
+            "claude.five_hour",
+            "antigravity.gemini_weekly",
+            "cursor.grok_bot_weekly"
+        ]
+        let groups = MenuBarFieldCatalog.subProviderGroups(
+            for: ToolType.dedicatedCardProviders,
+            selectedFieldIds: selected
+        )
+        XCTAssertEqual(groups.map(\.company), ["OpenAI", "Anthropic", "Google AI", "SpaceXAI"])
+        XCTAssertEqual(
+            groups.map { $0.subProviders.map(\.name) },
+            [["ChatGPT Agentic"], ["Claude"], ["AntiGravity"], ["Grok Bot"]]
+        )
+        let emitted = groups.flatMap { $0.subProviders.flatMap(\.fieldIds) }
+        XCTAssertEqual(Set(emitted), selected)
+        XCTAssertEqual(emitted.count, selected.count)
+    }
+
+    func testSubProviderGroupsDropCompaniesWithNothingSelected() {
+        XCTAssertTrue(
+            MenuBarFieldCatalog.subProviderGroups(
+                for: ToolType.dedicatedCardProviders,
+                selectedFieldIds: []
+            ).isEmpty
+        )
+        let onlyCursor = MenuBarFieldCatalog.subProviderGroups(
+            for: ToolType.dedicatedCardProviders,
+            selectedFieldIds: ["cursor.models"]
+        )
+        XCTAssertEqual(onlyCursor.map(\.company), ["SpaceXAI"])
+        XCTAssertEqual(onlyCursor.first?.accentTool, .cursor)
+        XCTAssertEqual(onlyCursor.flatMap { $0.subProviders.map(\.name) }, ["Cursor"])
+    }
+
     func testGeminiCLIModelIdsMigrateToWebBuckets() {
         // Old Gemini CLI fields no longer have catalog entries; all of
         // them must migrate to the Web parser's `gemini.five_hour`


### PR DESCRIPTION
## Why

- The mini window drew company → gauges with dividers *between models* but no SubProvider tier and no divider between SubProviders (Grok | Cursor | Grok Bot, Gemini Web | AntiGravity), and titled Gemini Web's gauge "GEMINI CHAT".
- Usage Stats and Sessions filtered by company chips with a harness/source menu as an afterthought; per AGENTS.md § 7.1 usage/session surfaces speak **harness**.

## What

- **Mini window three-tier**: `MenuBarFieldCatalog.subProviderGroups(for:selectedFieldIds:)` (Core, pure) buckets company → SubProvider → bucket; `MiniL2Member` is now one per SubProvider; a small-caps SubProvider label row sits between the company header and the gauges; dividers only between companies and between SubProviders; intra-SubProvider dividers removed; `gemini.chat` label id kept but titled "GEMINI WEB · All Models"; `MiniQuotaWindowController.stableContentSize` uses the same grouping (width slightly *smaller* than before in the all-selected case; height +15/+12). Liquid Glass untouched.
- **Harness-primary chips** on Usage Stats and Sessions: "All" + per company a quiet section-head chip (toggles all its harnesses) + one chip per harness (icon by `harness.brandTool`, count on Sessions). `Harness.chipGroups(companies:harnesses:)` in Core. The redundant HARNESS / SOURCES menus are removed. `UsageStatsViewModel` gains `toggleHarnesses` + `harnessChipGroups` only.
- Tests: `MenuBarFieldCatalogTests` +4, `HarnessTests` +3.

## Verification

- `swift build`, `swift test` (1623 tests, 1 skipped, 0 failures)
- `./Scripts/build_app.sh release`, `codesign -d --entitlements -` → empty `<dict/>`, `codesign --verify --deep --strict` OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)
