### PR TITLE
Take Claude session ids from the file name, not inherited lines

### DIFF
--- a/Sources/VibeBarCore/Sessions/ClaudeSessionAdapter.swift
+++ b/Sources/VibeBarCore/Sessions/ClaudeSessionAdapter.swift
@@ -52,11 +52,18 @@ public struct ClaudeSessionAdapter: SessionProviderAdapter {
             throw SessionParseError.unreadable(fileURL.lastPathComponent)
         }
 
+        // The file name is the session id `claude --resume` accepts. The
+        // per-line `sessionId` field is *not* authoritative: a forked or
+        // "continued" session keeps its ancestors' lines (their ids
+        // included) ahead of its own, so reading the first line's field
+        // resumed the parent — a different transcript with a different tail.
         let stem = fileURL.deletingPathExtension().lastPathComponent
-        let sessionID = SessionParsing.firstString(
-            head.compactMap { $0["sessionId"] }.first,
-            tail.compactMap { $0["sessionId"] }.first
-        ) ?? stem
+        let sessionID = CodexSessionAdapter.isUUIDShaped(stem)
+            ? stem
+            : SessionParsing.firstString(
+                tail.compactMap { $0["sessionId"] }.last,
+                head.compactMap { $0["sessionId"] }.first
+            ) ?? stem
 
         let projectDir = SessionParsing.firstString(
             head.compactMap { $0["cwd"] }.first,

--- a/Sources/VibeBarCore/Sessions/SessionIndexStore.swift
+++ b/Sources/VibeBarCore/Sessions/SessionIndexStore.swift
@@ -57,7 +57,12 @@ public actor SessionIndexStore {
     /// v2 added `sessions.harness` and `sessions.model`. There is no ALTER
     /// path on purpose: every row is reconstructible from the CLIs' own
     /// logs, and a rebuild is what fills the new columns anyway.
-    static let schemaVersion = 2
+    ///
+    /// v3 changes no columns; it forces a re-index because Claude Code rows
+    /// carried the inherited per-line `sessionId` of forked / continued
+    /// sessions instead of the file's own UUID, and a fingerprint-driven
+    /// incremental pass would never revisit those unchanged files.
+    static let schemaVersion = 3
 
     public init(url: URL = VibeBarLocalStore.sessionIndexURL) throws {
         if url == VibeBarLocalStore.sessionIndexURL {

--- a/Tests/VibeBarCoreTests/ClaudeSessionAdapterTests.swift
+++ b/Tests/VibeBarCoreTests/ClaudeSessionAdapterTests.swift
@@ -100,6 +100,19 @@ final class ClaudeSessionAdapterTests: XCTestCase {
         XCTAssertEqual(summary.createdAt, ISO8601DateFormatter.vibeBarTest.date(from: "2026-01-01T00:00:01.000Z"))
     }
 
+    /// A forked / "continued" session keeps its ancestors' lines — with the
+    /// ancestors' `sessionId` — ahead of its own. `claude --resume` takes the
+    /// file's UUID, so that is the id the row must carry.
+    func testForkedSessionUsesTheFileNameNotTheInheritedSessionIdField() throws {
+        let forkID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+        let url = try writeSession(lines: conversationLines, fileName: "\(forkID).jsonl")
+        let summary = try adapter.extractMetadata(fileURL: url)
+
+        XCTAssertEqual(summary.sessionID, forkID)
+        XCTAssertNotEqual(summary.sessionID, sessionID)
+        XCTAssertEqual(summary.id, "claude:\(forkID):\(url.path)")
+    }
+
     func testPinnedCustomTitleWinsOverTheFirstUserPrompt() throws {
         let url = try writeSession(lines: conversationLines + [customTitleLine("Pinned title")])
         XCTAssertEqual(try adapter.extractMetadata(fileURL: url).title, "Pinned title")

--- a/Tests/VibeBarCoreTests/SessionIndexStoreTests.swift
+++ b/Tests/VibeBarCoreTests/SessionIndexStoreTests.swift
@@ -546,9 +546,9 @@ final class SessionIndexStoreTests: XCTestCase {
 
         let rebuilt = try makeStore()
         let remaining = try await rebuilt.sessionCount()
-        XCTAssertEqual(SessionIndexStore.schemaVersion, 2)
+        XCTAssertEqual(SessionIndexStore.schemaVersion, 3)
         XCTAssertEqual(remaining, 0)
-        XCTAssertEqual(try userVersion(), 2)
+        XCTAssertEqual(try userVersion(), 3)
 
         try await rebuilt.upsertSession(summary(harness: .claudeCode, model: "claude-fable-5"))
         let model = try await rebuilt.allSummaries().first?.model


### PR DESCRIPTION
## Why

A Claude Code session row showed id `1f900ea9-…` while its source file was `c31f076c-….jsonl`; `claude --resume 1f900ea9-…` opened a different transcript. Forked / "continued" sessions keep their ancestors' lines (with the ancestors' per-line `sessionId`) ahead of their own — the sampled file carried three different `sessionId` values — and `ClaudeSessionAdapter` read the first line's field.

## What

- `ClaudeSessionAdapter.extractMetadata`: the session id is the file's UUID stem (what `claude --resume` accepts); the in-file field is only a fallback for non-UUID names. Cowork rows share the parser.
- `SessionIndexStore.schemaVersion` 2 → 3 to force a re-index so already-indexed rows are corrected (a fingerprint-driven pass would never revisit unchanged files).
- Test: forked file with inherited ids ⇒ row id == file UUID.

## Verification

- `swift build`, `swift test` (1619 tests, 1 skipped, 0 failures)
- `./Scripts/build_app.sh release`, `codesign -d --entitlements -` → empty `<dict/>`, `codesign --verify --deep --strict` OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)
