### PR TITLE
Serve a local MCP server over a private socket for agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,7 @@ Single SwiftPM package, two product targets and one test target:
 │   │   ├── ClaudeWebLoginController.swift
 │   │   ├── ClaudeRoutineBudgetWebViewFetcher.swift
 │   │   ├── LoginItemController.swift
+│   │   ├── MCPController.swift    # Local MCP server's data source (see § 5.1)
 │   │   ├── ProviderBrandIcon.swift
 │   │   ├── VibeBarApp.swift
 │   │   ├── Controllers/           # SwiftUI host controllers
@@ -73,6 +74,7 @@ Single SwiftPM package, two product targets and one test target:
 │   └── VibeBarCore/               # Pure-Swift testable library
 │       ├── Adapters/              # Provider quota + response parsers
 │       ├── Credentials/           # CLI credential readers + Keychain store
+│       ├── MCP/                   # Local MCP server + stdio bridge (see § 5.1)
 │       ├── Models/                # Plain data types (settings, quotas, cost)
 │       ├── Services/              # Cost scanner, quota refresh, status fetch
 │       ├── Storage/               # Local-store roots, caches, settings
@@ -88,6 +90,11 @@ Single SwiftPM package, two product targets and one test target:
 ├── Scripts/
 │   ├── build_app.sh               # App packaging + nested codesign
 │   └── release_app.sh             # ZIP, checksum, signed Sparkle appcast
+├── docs/
+│   ├── DESIGN.md
+│   └── agent-setup/               # One-line MCP setup an agent runs on itself
+│       ├── prompt.md              # Addressed to the agent, not to a human
+│       └── skill/vibe-bar/SKILL.md
 ├── .github/
 │   ├── ISSUE_TEMPLATE/
 │   └── pull_request_template.md
@@ -297,7 +304,8 @@ Vibe Bar persists derived data under the user's **real** home directory:
 ├── scan_cache/
 ├── service_status.json
 ├── cost_history.json
-└── mini_window_geometry.json
+├── mini_window_geometry.json
+└── mcp.sock          (socket, 0600, only while the app runs — see § 5.1)
 ```
 
 If you are debugging odd behavior, that directory is the place to look.
@@ -351,6 +359,51 @@ adapters open the SQLite stores through
 `Sources/VibeBarCore/Sessions/LiveSQLiteReader.swift`, which only ever
 opens the real file `SQLITE_OPEN_READONLY` and falls back to a private
 temp-directory snapshot it deletes again.
+
+### 5.1 The local MCP server
+
+Vibe Bar exposes its own data to the user's coding agents over MCP. Code
+lives in `Sources/VibeBarCore/MCP/` (protocol, tools, transports) plus
+`Sources/VibeBarApp/MCPController.swift` (the `MCPDataSource`
+implementation over `AppEnvironment`) and
+`Sources/VibeBarApp/Views/MCPSettingsSection.swift`.
+
+**Transport.** A Unix domain socket at `~/.vibebar/mcp.sock`, mode 0600
+inside the 0700 `~/.vibebar/`, speaking newline-delimited JSON-RPC 2.0
+(protocol version `2025-06-18`). **No TCP port and no token file**: the
+filesystem is the whole authentication story, so there is no secret to
+leak and nothing reachable off this Mac. A stale socket is unlinked at
+start; `AppDelegate.applicationShouldTerminate` removes the live one, so
+the socket exists exactly while the app does.
+
+**The bridge.** The same binary run as `VibeBar --mcp-stdio` is a plain
+stdio MCP server that pumps bytes between stdin/stdout and that socket.
+`AppDelegate.applicationDidFinishLaunching` handles the flag *before* any
+UI exists — no status item, no `AppEnvironment`, no window — and the
+process exits with the pump. Missing socket ⇒ exit 1 with
+`Vibe Bar is not running (socket ~/.vibebar/mcp.sock not found). Launch
+"Vibe Bar.app" first.` on stderr. `VIBEBAR_MCP_SOCKET` overrides the path;
+it exists so tests (and a second build) can point at a temporary socket,
+and it is documented rather than hidden for that reason.
+
+**Tools.** `quota.get`, `quota.refresh`, `usage.summary`, `usage.trend`,
+`usage.requests`, `cost.snapshot`, `cost.history`, `sessions.search`,
+`sessions.list`, `status.get`, `pricing.effective`, plus the
+`vibebar://naming-spec` and `vibebar://tools` resources. The naming-spec
+resource is **generated** from `ProviderHierarchyCatalog`, `ToolType` and
+`HarnessCatalog` — never transcribe § 7.1 into it by hand, because a stale
+spec teaches a model a label that no longer exists. `MCPResourceCatalogTests`
+enforces that every harness, company and provider key appears.
+
+**Privacy.** Everything is read-only except `quota.refresh`, which is
+gated on `AppSettings.mcpServer.allowRefreshTools` and throttled to one
+forced refresh per 20 s. Credentials, cookies and organization ids are
+never projected; emails go through `EmailMasker`; `cost.*` respects
+`AppSettings.costData.privacyModeEnabled` the way `CostUsageService` does.
+When adding a tool, add its projection to `MCPDTOs.swift` rather than
+encoding a Core type directly — the DTO layer is where "what may an agent
+see" is decided, and the wire shape is camelCase, pinned by
+`MCPDTOEncodingTests`.
 
 ## 6. Home Directory (and why we no longer sandbox)
 

--- a/README.md
+++ b/README.md
@@ -122,6 +122,30 @@ Plans, and Tencent Hunyuan.
   <img src="Resources/README/misc-providers.png" alt="Vibe Bar miscellaneous coding plan providers" width="860">
 </p>
 
+## Agents (MCP)
+
+Vibe Bar can answer your coding agent's questions about your own usage. While
+the app is running it exposes a read-only MCP server on a Unix domain socket in
+your home directory — no network port, no API key — so Claude Code, Codex CLI,
+Cursor or any other stdio MCP client can ask "how much Claude do I have left?",
+"who burned the most tokens this month?" or "find my session about the parser".
+
+Set it up by pasting this into any agent that can fetch a URL:
+
+```
+Fetch and execute the appropriate instructions to set me up for Vibe Bar from https://raw.githubusercontent.com/AstroQore/vibe-bar/main/docs/agent-setup/prompt.md
+```
+
+Or configure it by hand — every client runs the same command:
+
+```sh
+claude mcp add --scope user vibebar -- "/Applications/Vibe Bar.app/Contents/MacOS/VibeBar" --mcp-stdio
+```
+
+Settings → MCP Server has the switch, the socket path, and a copy button for
+each client. Everything agents can reach is read-only except an opt-in "refresh
+my quota" tool; credentials are never exposed and emails are masked.
+
 ## Settings That Stay Out of the Way
 
 Choose Remaining or Used percentages, refresh on a timer or when the popover
@@ -165,9 +189,12 @@ and audit metadata only. Derived state stays under:
 ├── service_status.json
 ├── remote_core.json
 ├── remote_usage.sqlite3
-└── cost_history.json
+├── cost_history.json
+└── mcp.sock            (only while the app runs, mode 0600)
 ```
 
+- The MCP socket is created 0600 inside the 0700 `~/.vibebar/`, is never bound
+  to a network interface, and is removed when Vibe Bar quits.
 - CLI credential and session files are read-only inputs. The one exception
   is whole-session deletion from the Workbench's Sessions page, performed
   only at your explicit request and never editing a session file's contents.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -114,6 +114,29 @@ OpenCode Go、Ollama Cloud、智谱 GLM、小米 MiMo、Kimi、MiniMax、阿里�
   <img src="Resources/README/misc-providers.png" alt="Vibe Bar 杂项 Coding Plan 服务商" width="860">
 </p>
 
+## Agent 接入（MCP）
+
+Vibe Bar 可以让你的编程 Agent 直接查询你自己的用量。应用运行时，它会在你的 home
+目录下开一个只读的 MCP 服务，走 Unix domain socket——不开网络端口，也没有 API
+Key——Claude Code、Codex CLI、Cursor 以及任何 stdio MCP 客户端都能问「我的 Claude
+还剩多少」「这个月谁烧的 token 最多」「找一下我那个改 parser 的会话」。
+
+把下面这一行粘贴给任意一个能抓取 URL 的 Agent，它会自己完成配置：
+
+```
+Fetch and execute the appropriate instructions to set me up for Vibe Bar from https://raw.githubusercontent.com/AstroQore/vibe-bar/main/docs/agent-setup/prompt.md
+```
+
+也可以手动配置，所有客户端跑的都是同一条命令：
+
+```sh
+claude mcp add --scope user vibebar -- "/Applications/Vibe Bar.app/Contents/MacOS/VibeBar" --mcp-stdio
+```
+
+设置 → MCP Server 里有开关、socket 路径，以及各客户端配置的一键复制。除了一个可
+关闭的「刷新配额」工具外，Agent 能访问的全部是只读数据；凭据不会暴露，邮箱会被
+脱敏。
+
 ## 不打扰工作的设置
 
 在同一个左右分栏窗口中切换 Remaining/Used、定时刷新或打开 Popover 时刷新、
@@ -154,9 +177,12 @@ Vibe Bar 没有遥测管线或托管明文分析后端。本地与远端 Probe �
 ├── service_status.json
 ├── remote_core.json
 ├── remote_usage.sqlite3
-└── cost_history.json
+├── cost_history.json
+└── mcp.sock            （仅在应用运行期间存在，权限 0600）
 ```
 
+- MCP socket 位于权限 0700 的 `~/.vibebar/` 内，自身权限 0600，从不绑定网络
+  接口，Vibe Bar 退出时会一并删除。
 - CLI 凭据和 Session 文件只读，不会被 Vibe Bar 修改。
 - Vibe Bar 自己持有的 Cookie 与 Provider Secret 统一放在一个版本化 Keychain
   Vault 中，不再为每个 Secret 建一个反复弹窗的 Keychain Item。

--- a/Sources/VibeBarApp/AppDelegate.swift
+++ b/Sources/VibeBarApp/AppDelegate.swift
@@ -8,6 +8,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var statusItem: StatusItemController?
 
     func applicationDidFinishLaunching(_ notification: Notification) {
+        if handleMCPStdioCommandLine() { return }
         if handleRemoteCommandLine() { return }
         // Belt-and-braces: Info.plist already sets LSUIElement, but if we are
         // launched from `swift run` (no bundle), force accessory policy here.
@@ -153,11 +154,33 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
         statusItem?.applicationWillTerminate()
+        // First: the socket file has to go before anything else tears down, so
+        // an agent connecting during shutdown gets a clean "not running"
+        // rather than a connection to a half-stopped environment.
+        environment?.mcp?.stop()
         environment?.scheduler.stop()
         environment?.serviceStatus.stop()
         environment?.remoteProbeService.stop()
         CookieRefreshScheduler.shared.stop()
         return .terminateNow
+    }
+
+    /// `--mcp-stdio`: be a plain stdio MCP server that forwards to the running
+    /// app's socket, and nothing else.
+    ///
+    /// This runs before any UI is created, so the process installs no status
+    /// item, opens no window, and builds no `AppEnvironment`. It never returns
+    /// — the pump owns the rest of this process's life — but it still reports
+    /// a `Bool` so the call site reads like `handleRemoteCommandLine()` above.
+    private func handleMCPStdioCommandLine() -> Bool {
+        guard ProcessInfo.processInfo.arguments.contains(MCPStdioBridge.commandLineFlag) else {
+            return false
+        }
+        // Belt and braces against the Dock or the app switcher noticing a
+        // process that is really a pipe.
+        NSApp.setActivationPolicy(.prohibited)
+        let code = MCPStdioBridge.run(socketPath: MCPStdioBridge.socketPath())
+        Darwin.exit(code)
     }
 
     private func handleRemoteCommandLine() -> Bool {

--- a/Sources/VibeBarApp/AppEnvironment.swift
+++ b/Sources/VibeBarApp/AppEnvironment.swift
@@ -19,6 +19,9 @@ final class AppEnvironment: ObservableObject {
     /// cannot be opened — every reader treats that as "no history", so a
     /// broken ledger costs the usage page, not the app.
     let usageLedger: UsageEventLedger?
+    /// Local MCP server. Built here so its lifetime matches the app's; the
+    /// socket itself exists only while `AppSettings.mcpServer.enabled` is on.
+    private(set) var mcp: MCPController!
 
     @Published private(set) var hasClaudeWebCookies: Bool
     @Published private(set) var hasOpenAIWebCookies: Bool
@@ -287,6 +290,13 @@ final class AppEnvironment: ObservableObject {
         scheduler.start()
         serviceStatus.start()
         remoteProbeService.start()
+
+        // Last, and after every service it reads from is live: an agent that
+        // connects the instant the socket appears must not race a half-built
+        // environment.
+        let mcp = MCPController(environment: self)
+        self.mcp = mcp
+        mcp.start(settingsStore: settings)
 
         // Kick off an initial cost scan in the background. Cost data updates
         // slowly compared to live quota, so we re-scan only on app relaunch,

--- a/Sources/VibeBarApp/MCPController.swift
+++ b/Sources/VibeBarApp/MCPController.swift
@@ -1,0 +1,410 @@
+import Combine
+import Foundation
+import VibeBarCore
+
+/// Owns the local MCP server and answers its tools from `AppEnvironment`.
+///
+/// Two jobs, kept in one place on purpose. The lifecycle half starts and stops
+/// the Unix-socket listener as the setting changes, so the socket exists
+/// exactly while the app is running with MCP enabled. The data half is the
+/// `MCPDataSource` implementation: every method hops to the main actor, reads
+/// already-cached state, and hands Core a value to project — no method here
+/// starts a network fetch except `refreshQuota`, which is the one tool that
+/// says it does.
+@MainActor
+final class MCPController: ObservableObject, MCPDataSource {
+    /// Live listener state, for the Settings pane.
+    @Published private(set) var isRunning = false
+    @Published private(set) var connectionCount = 0
+    @Published private(set) var lastClientActivityAt: Date?
+    /// Why the listener is not up, when it should be. Shown in Settings rather
+    /// than only logged: a failed bind is the difference between "agents can
+    /// read my usage" and silence.
+    @Published private(set) var startupError: String?
+
+    let socketPath: String
+
+    private weak var environment: AppEnvironment?
+    private var server: MCPServer?
+    private var socketServer: MCPSocketServer?
+    private var cancellables: Set<AnyCancellable> = []
+
+    /// The session index, opened on the first `sessions.*` call.
+    ///
+    /// Deliberately not built at launch: opening it costs a SQLite file the
+    /// menu-bar-only session never needs, and the Workbench's Sessions page
+    /// keeps its own handle. Two connections to one WAL database with a busy
+    /// timeout is a supported arrangement — the alternative, threading this
+    /// through `SessionManagerModel`, would couple the MCP surface to the
+    /// Workbench's lifecycle for no benefit.
+    private var sessionIndex: SessionIndexService?
+    private var sessionIndexUnavailable = false
+    /// One opportunistic scan per process when the index has never been built.
+    /// Without it, `sessions.search` answers "nothing" until the user happens
+    /// to open the Workbench, which reads as a bug rather than as an empty
+    /// index.
+    private var didAttemptSessionBackfill = false
+
+    init(environment: AppEnvironment, socketPath: String = MCPSocketServer.defaultSocketPath) {
+        self.environment = environment
+        self.socketPath = socketPath
+    }
+
+    // MARK: - Lifecycle
+
+    /// Start listening if the setting says so, and keep following that setting.
+    func start(settingsStore: SettingsStore) {
+        applyEnabled(settingsStore.settings.mcpServer.enabled)
+        settingsStore.$settings
+            .map(\.mcpServer.enabled)
+            .removeDuplicates()
+            .sink { [weak self] enabled in
+                Task { @MainActor in self?.applyEnabled(enabled) }
+            }
+            .store(in: &cancellables)
+    }
+
+    func stop() {
+        socketServer?.stop()
+        socketServer = nil
+        server = nil
+        isRunning = false
+        connectionCount = 0
+    }
+
+    private func applyEnabled(_ enabled: Bool) {
+        guard enabled else {
+            stop()
+            startupError = nil
+            return
+        }
+        guard socketServer == nil else { return }
+        let server = MCPServer(dataSource: self)
+        let socket = MCPSocketServer(server: server, socketPath: socketPath)
+        socket.onConnectionChange = { [weak self] count, at in
+            Task { @MainActor in
+                self?.connectionCount = count
+                self?.lastClientActivityAt = at
+            }
+        }
+        do {
+            try socket.start()
+            self.server = server
+            self.socketServer = socket
+            self.isRunning = true
+            self.startupError = nil
+        } catch let error as MCPSocketError {
+            self.startupError = error.message
+            self.isRunning = false
+            SafeLog.warn("MCP server did not start: \(SafeLog.sanitize(error.message))")
+        } catch {
+            self.startupError = error.localizedDescription
+            self.isRunning = false
+            SafeLog.warn("MCP server did not start: \(SafeLog.sanitize(error.localizedDescription))")
+        }
+    }
+
+    // MARK: - MCPDataSource: identity
+
+    func serverInfo() async -> MCPServerInfo {
+        let info = Bundle.main.infoDictionary
+        let short = info?["CFBundleShortVersionString"] as? String
+        let build = info?["CFBundleVersion"] as? String
+        let version: String
+        switch (short, build) {
+        case let (.some(short), .some(build)): version = "\(short) (\(build))"
+        case let (.some(short), .none):        version = short
+        // `swift run` has no Info.plist at all; saying so beats reporting a
+        // version number that is not in any release.
+        default:                               version = "source build"
+        }
+        return MCPServerInfo(name: "vibebar", version: version)
+    }
+
+    // MARK: - MCPDataSource: quota
+
+    func quotaAccounts(tools: [ToolType]?, includeForecast: Bool) async throws -> [MCPQuotaAccountDTO] {
+        guard let environment else { throw MCPToolFailure("Vibe Bar is shutting down.") }
+        let quotaService = environment.quotaService
+        let wanted = tools.map(Set.init)
+        let identities = environment.accountStore.accounts
+            .filter { wanted?.contains($0.tool) ?? true }
+
+        return identities.map { identity in
+            let quota = quotaService.cachedQuota(for: identity.id)
+                ?? AccountQuota(
+                    accountId: identity.id,
+                    tool: identity.tool,
+                    buckets: [],
+                    plan: identity.plan,
+                    email: identity.email,
+                    queriedAt: Date(timeIntervalSince1970: 0)
+                )
+            var forecasts: [String: QuotaPaceForecast] = [:]
+            if includeForecast {
+                let snapshot = environment.costService.snapshot(for: quota.tool)
+                for bucket in quota.buckets {
+                    forecasts[bucket.id] = quotaService.paceForecast(
+                        accountId: quota.accountId,
+                        bucket: bucket,
+                        activityHeatmap: snapshot?.heatmap,
+                        dailyActivity: snapshot?.dailyHistory ?? []
+                    )
+                }
+            }
+            return MCPQuotaAccountDTO(
+                quota: quota,
+                // A never-refreshed account has no timestamps at all; the
+                // sentinel `queriedAt` above would otherwise read as 1970.
+                lastUpdated: quotaService.lastUpdatedByAccount[identity.id],
+                lastAttempted: quotaService.lastAttemptedByAccount[identity.id],
+                inFlight: quotaService.inFlightAccountIds.contains(identity.id),
+                error: quotaService.lastErrorByAccount[identity.id],
+                forecastsByBucketID: forecasts
+            )
+        }
+    }
+
+    func refreshQuota(tools: [ToolType]?, force: Bool) async throws -> MCPRefreshResultDTO {
+        guard let environment else { throw MCPToolFailure("Vibe Bar is shutting down.") }
+        guard environment.settingsStore.settings.mcpServer.allowRefreshTools else {
+            return MCPRefreshResultDTO(
+                triggered: false,
+                mode: force ? "forced" : "stale-only",
+                message: "Refreshing from agents is switched off in Vibe Bar → Settings → MCP Server. "
+                    + "quota.get still reports the cached numbers and when they were fetched."
+            )
+        }
+
+        if force {
+            if let tools, !tools.isEmpty {
+                for tool in tools { environment.refresh(tool) }
+                return MCPRefreshResultDTO(
+                    triggered: true,
+                    mode: "forced",
+                    message: "Refreshing \(tools.map(\.rawValue).joined(separator: ", ")). "
+                        + "Call quota.get in a few seconds for the new numbers."
+                )
+            }
+            environment.scheduler.triggerRefresh()
+            return MCPRefreshResultDTO(
+                triggered: true,
+                mode: "forced",
+                message: "Refreshing every visible account. Call quota.get in a few seconds for the new numbers."
+            )
+        }
+
+        let triggered = environment.scheduler.triggerRefreshForStaleCacheIfNeeded()
+        return MCPRefreshResultDTO(
+            triggered: triggered,
+            mode: "stale-only",
+            message: triggered
+                ? "Refreshing the accounts whose cache was stale. Call quota.get in a few seconds."
+                : "Nothing was stale — every account is inside its refresh interval. "
+                    + "quota.get already has current numbers."
+        )
+    }
+
+    // MARK: - MCPDataSource: usage ledger
+
+    private func ledger() throws -> UsageEventLedger {
+        guard let ledger = environment?.usageLedger else {
+            throw MCPToolFailure(
+                "The usage ledger is unavailable, so per-request history cannot be queried. "
+                    + "cost.snapshot still reports per-provider totals."
+            )
+        }
+        return ledger
+    }
+
+    func usageSummary(_ filter: UsageQueryFilter) async throws -> UsageSummaryMetrics {
+        try await ledger().summary(filter)
+    }
+
+    func usageGroupRows(
+        _ filter: UsageQueryFilter,
+        groupBy: MCPUsageGrouping
+    ) async throws -> [MCPUsageGroupRowDTO] {
+        let ledger = try ledger()
+        switch groupBy {
+        case .harness:
+            // Fold the ledger's raw (tool, harness) groups first: a migrated
+            // ledger can hold both a backfilled and a freshly stamped group
+            // for one harness, and reporting them as two rows would invent a
+            // harness split that does not exist.
+            return UsageHarnessStat.mergedByHarness(try await ledger.harnessStats(filter)).map { stat in
+                MCPUsageGroupRowDTO(
+                    key: stat.harness.rawValue,
+                    label: stat.harness.displayName,
+                    company: stat.harness.companyName,
+                    requests: stat.requests,
+                    totalTokens: stat.totalTokens,
+                    costMicros: stat.costMicros
+                )
+            }
+        case .provider:
+            return UsageProviderStat.mergedByCompany(try await ledger.providerStats(filter)).map { stat in
+                MCPUsageGroupRowDTO(
+                    key: stat.tool.rawValue,
+                    label: stat.tool.vendorName,
+                    company: stat.tool.vendorName,
+                    requests: stat.requests,
+                    totalTokens: stat.totalTokens,
+                    costMicros: stat.costMicros
+                )
+            }
+        case .model:
+            return try await ledger.modelStats(filter).map { stat in
+                MCPUsageGroupRowDTO(
+                    key: stat.model,
+                    label: UsageModelNaming.canonicalDisplayName(stat.model),
+                    company: nil,
+                    requests: stat.requests,
+                    totalTokens: stat.totalTokens,
+                    costMicros: stat.costMicros
+                )
+            }
+        }
+    }
+
+    func usageTrend(_ filter: UsageQueryFilter, bucket: UsageTrendBucket?) async throws -> UsageTrendSeries {
+        try await ledger().trend(filter, bucket: bucket)
+    }
+
+    func usageRequests(
+        _ filter: UsageQueryFilter,
+        after cursor: UsageRequestCursor?,
+        pageSize: Int
+    ) async throws -> UsageRequestPage {
+        try await ledger().requestPage(filter, after: cursor, pageSize: pageSize)
+    }
+
+    // MARK: - MCPDataSource: cost
+
+    func costSnapshots(tools: [ToolType]?) async throws -> MCPCostSnapshotsDTO {
+        guard let environment else { throw MCPToolFailure("Vibe Bar is shutting down.") }
+        let wanted = tools.map(Set.init)
+        let snapshots = ToolType.costAwareProviders
+            .filter { wanted?.contains($0) ?? true }
+            .compactMap { environment.costService.snapshot(for: $0) }
+        return MCPCostSnapshotsDTO(
+            generatedAt: Date(),
+            privacyModeEnabled: environment.settingsStore.settings.costData.privacyModeEnabled,
+            tools: snapshots.map(MCPCostToolSnapshotDTO.init(snapshot:))
+        )
+    }
+
+    func costHistory(tool: ToolType, timeframe: MCPCostHistoryTimeframe) async throws -> CostHistory {
+        guard let environment else { throw MCPToolFailure("Vibe Bar is shutting down.") }
+        return await environment.costService.costHistory(for: tool, timeframe: timeframe.timeframe)
+    }
+
+    // MARK: - MCPDataSource: sessions
+
+    func searchSessions(
+        query: String,
+        providers: [SessionProvider]?,
+        harnesses: [Harness]?,
+        limit: Int
+    ) async throws -> [SessionSearchHit] {
+        let index = try sessionIndexService()
+        var hits = try await index.search(query, providers: providers, harnesses: harnesses, limit: limit)
+        if hits.isEmpty, await backfillSessionIndexIfNeeded(index) {
+            hits = try await index.search(query, providers: providers, harnesses: harnesses, limit: limit)
+        }
+        return hits
+    }
+
+    func listSessions(
+        providers: [SessionProvider]?,
+        harnesses: [Harness]?,
+        since: Date?,
+        offset: Int,
+        limit: Int
+    ) async throws -> SessionSummaryPage {
+        let index = try sessionIndexService()
+        var page = try await index.summaryPage(
+            providers: providers,
+            harnesses: harnesses,
+            since: since,
+            order: .recentFirst,
+            offset: offset,
+            limit: limit
+        )
+        if page.totalCount == 0, await backfillSessionIndexIfNeeded(index) {
+            page = try await index.summaryPage(
+                providers: providers,
+                harnesses: harnesses,
+                since: since,
+                order: .recentFirst,
+                offset: offset,
+                limit: limit
+            )
+        }
+        return page
+    }
+
+    private func sessionIndexService() throws -> SessionIndexService {
+        if let sessionIndex { return sessionIndex }
+        guard !sessionIndexUnavailable else {
+            throw MCPToolFailure("The session index could not be opened, so sessions cannot be listed.")
+        }
+        let bodies = environment?.settingsStore.settings.sessionBodyIndexingEnabled ?? true
+        do {
+            let store = try SessionIndexStore()
+            let service = SessionIndexService(
+                store: store,
+                registry: SessionProviderRegistry.standard(),
+                bodyIndexing: { bodies }
+            )
+            sessionIndex = service
+            return service
+        } catch {
+            sessionIndexUnavailable = true
+            SafeLog.warn("MCP: opening the session index failed: \(SafeLog.sanitize(error.localizedDescription))")
+            throw MCPToolFailure("The session index could not be opened, so sessions cannot be listed.")
+        }
+    }
+
+    /// Returns true when a scan actually ran, so the caller re-queries.
+    private func backfillSessionIndexIfNeeded(_ index: SessionIndexService) async -> Bool {
+        guard !didAttemptSessionBackfill else { return false }
+        didAttemptSessionBackfill = true
+        await index.refreshIndex()
+        return true
+    }
+
+    // MARK: - MCPDataSource: status and pricing
+
+    func serviceStatus(tools: [ToolType]?) async throws -> MCPServiceStatusDTO {
+        guard let environment else { throw MCPToolFailure("Vibe Bar is shutting down.") }
+        let controller = environment.serviceStatus
+        // Status is an L1 company fact: Google AI covers Gemini + AntiGravity
+        // and SpaceXAI covers Grok + Cursor, so a request naming a member
+        // resolves to the company row that actually has a feed.
+        let wanted = tools.map { Set($0.compactMap { $0.coreProviderRepresentative }) }
+        let rows = ToolType.combinedStatusPageProviders
+            .filter { wanted?.contains($0) ?? true }
+            .map { tool -> MCPServiceStatusRowDTO in
+                let projection = controller.projection(for: tool)
+                return MCPServiceStatusRowDTO(
+                    tool: tool.rawValue,
+                    company: tool.vendorName,
+                    indicator: projection.snapshot?.indicator.rawValue ?? "unknown",
+                    description: projection.snapshot?.description ?? "No status has been read yet.",
+                    updatedAt: projection.snapshot?.updatedAt,
+                    isRefreshing: projection.isRefreshing,
+                    error: projection.error
+                )
+            }
+        return MCPServiceStatusDTO(
+            generatedAt: Date(),
+            lastFetched: controller.lastFetched,
+            companies: rows
+        )
+    }
+
+    func effectivePricing() async throws -> [EffectiveModelPricingRow] {
+        PricingResolver.active.effectiveModelPrices
+    }
+}

--- a/Sources/VibeBarApp/Views/MCPSettingsSection.swift
+++ b/Sources/VibeBarApp/Views/MCPSettingsSection.swift
@@ -1,0 +1,213 @@
+import AppKit
+import SwiftUI
+import VibeBarCore
+
+/// Settings pane for the local MCP server.
+///
+/// The pane's whole job is to get an agent connected in one paste, so the copy
+/// buttons are the primary content and the switches are secondary. Nothing
+/// here can leak: the socket path is not a secret, and there is no token to
+/// show because there is no token — see `MCPSocketServer`.
+struct MCPSettingsSection: View {
+    let density: Theme.Density
+    @ObservedObject var controller: MCPController
+    @EnvironmentObject private var settingsStore: SettingsStore
+
+    @State private var copied: String?
+    @State private var copiedResetTask: Task<Void, Never>?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: density.interSectionSpacing) {
+            statusSection
+            setupSection
+            behaviourSection
+        }
+    }
+
+    // MARK: - Status
+
+    private var statusSection: some View {
+        section("MCP Server") {
+            Text("Vibe Bar can expose this Mac's quota, usage, cost and local agent sessions to your coding agents over MCP. The server listens on a Unix domain socket in your home directory — no network port is opened, and no token is created: the socket's file permissions are the access control.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            Toggle("Enable the local MCP server", isOn: $settingsStore.settings.mcpServer.enabled)
+                .toggleStyle(.switch)
+                .controlSize(.small)
+
+            if settingsStore.settings.mcpServer.enabled {
+                infoRow("Status", controller.isRunning ? "Listening" : "Not listening")
+                infoRow("Socket", controller.socketPath)
+                infoRow("Connected clients", "\(controller.connectionCount)")
+                infoRow("Last client activity", lastActivityText)
+                if let error = controller.startupError {
+                    Text(error)
+                        .font(.caption2)
+                        .foregroundStyle(.orange)
+                        .textSelection(.enabled)
+                }
+                Text("The socket exists only while Vibe Bar is running. Agents configured below report “Vibe Bar is not running” when it is quit, which is the intended behaviour.")
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+            }
+        }
+    }
+
+    private var lastActivityText: String {
+        guard let date = controller.lastClientActivityAt else { return "never" }
+        return date.formatted(date: .abbreviated, time: .shortened)
+    }
+
+    // MARK: - Setup
+
+    private var setupSection: some View {
+        section("Connect an agent") {
+            Text("The quickest path: paste this into any agent and let it configure itself, install the companion skill, and verify the connection.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            copyRow(
+                title: "Agent setup prompt",
+                subtitle: "One line, works in any agent that can fetch a URL.",
+                systemImage: "sparkles",
+                value: MCPClientConfig.agentSetupPrompt
+            )
+
+            Divider()
+
+            Text("Or configure a client by hand. Every client runs the same command — Vibe Bar's own binary with \(MCPStdioBridge.commandLineFlag), which bridges stdin/stdout to the socket above.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            copyRow(
+                title: "Claude Code",
+                subtitle: "Run in a terminal.",
+                systemImage: "terminal",
+                value: MCPClientConfig.claudeCodeCommand(executablePath: executablePath)
+            )
+            copyRow(
+                title: "Codex CLI",
+                subtitle: "Append to ~/.codex/config.toml.",
+                systemImage: "doc.plaintext",
+                value: MCPClientConfig.codexTOML(executablePath: executablePath)
+            )
+            copyRow(
+                title: "Cursor",
+                subtitle: "Merge into ~/.cursor/mcp.json.",
+                systemImage: "curlybraces",
+                value: MCPClientConfig.cursorJSON(executablePath: executablePath)
+            )
+            copyRow(
+                title: "Any other stdio client",
+                subtitle: "One entry for the client's own mcpServers map.",
+                systemImage: "puzzlepiece.extension",
+                value: MCPClientConfig.genericJSON(executablePath: executablePath)
+            )
+
+            if !isInstalledInApplications {
+                Text("Vibe Bar is running from \(executablePath). Move it to /Applications before saving a client config, or the config breaks the next time you rebuild.")
+                    .font(.caption2)
+                    .foregroundStyle(.orange)
+            }
+        }
+    }
+
+    /// The path an agent should actually launch. Prefer the running bundle so
+    /// a config copied from a development build points at that build; fall
+    /// back to the canonical install location when there is no bundle at all.
+    private var executablePath: String {
+        Bundle.main.executableURL?.path ?? MCPClientConfig.canonicalExecutablePath
+    }
+
+    private var isInstalledInApplications: Bool {
+        executablePath == MCPClientConfig.canonicalExecutablePath
+    }
+
+    // MARK: - Behaviour
+
+    private var behaviourSection: some View {
+        section("What agents may do") {
+            Toggle(
+                "Allow agents to refresh quota",
+                isOn: $settingsStore.settings.mcpServer.allowRefreshTools
+            )
+            .toggleStyle(.switch)
+            .controlSize(.small)
+            .disabled(!settingsStore.settings.mcpServer.enabled)
+
+            Text("With this on, an agent can ask Vibe Bar to re-fetch quota from your providers. Forced refreshes are rate-limited to one every \(Int(MCPServer.forcedRefreshMinimumInterval)) seconds. With it off the read-only tools keep working and quota.refresh reports that refreshing is disabled.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            Text("Everything else agents can reach is read-only: quota, token usage, cost, provider status, effective model prices, and the local session index (titles, projects, and — when session body indexing is on — message excerpts). Credentials, cookies and organization ids are never exposed, and email addresses are masked.")
+                .font(.caption2)
+                .foregroundStyle(.tertiary)
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func copyRow(
+        title: String,
+        subtitle: String,
+        systemImage: String,
+        value: String
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(alignment: .firstTextBaseline, spacing: 8) {
+                VStack(alignment: .leading, spacing: 1) {
+                    Text(title)
+                        .font(.caption.weight(.medium))
+                    Text(subtitle)
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer(minLength: 8)
+                Button {
+                    copy(value, label: title)
+                } label: {
+                    Label(copied == title ? "Copied" : "Copy", systemImage: copied == title ? "checkmark" : systemImage)
+                }
+                .controlSize(.small)
+            }
+            Text(value)
+                .font(.caption2.monospaced())
+                .foregroundStyle(.secondary)
+                .textSelection(.enabled)
+                .lineLimit(6)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    private func copy(_ value: String, label: String) {
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(value, forType: .string)
+        copied = label
+        copiedResetTask?.cancel()
+        copiedResetTask = Task { @MainActor in
+            try? await Task.sleep(for: .seconds(2))
+            guard !Task.isCancelled else { return }
+            if copied == label { copied = nil }
+        }
+    }
+
+    private func infoRow(_ label: String, _ value: String) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: 8) {
+            Text(label)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .frame(width: 128, alignment: .leading)
+            Text(value)
+                .font(.caption.monospaced())
+                .textSelection(.enabled)
+        }
+    }
+
+    private func section<Content: View>(
+        _ title: String,
+        @ViewBuilder content: @escaping () -> Content
+    ) -> some View {
+        SettingsSectionCard(title: title, density: density, content: content)
+    }
+}

--- a/Sources/VibeBarApp/Views/SettingsSidebarView.swift
+++ b/Sources/VibeBarApp/Views/SettingsSidebarView.swift
@@ -25,6 +25,7 @@ struct SettingsSidebarView: View {
         .system,
         .costData,
         .pricing,
+        .mcp,
         .remote,
         .privacy,
         .menuBar,

--- a/Sources/VibeBarApp/Views/SettingsView.swift
+++ b/Sources/VibeBarApp/Views/SettingsView.swift
@@ -15,6 +15,7 @@ enum SettingsSectionID: String {
     case pricing
     case privacy
     case remote
+    case mcp
 
     var id: String { rawValue }
 
@@ -33,6 +34,7 @@ enum SettingsSectionID: String {
         case .pricing: "Model Pricing"
         case .privacy: "Privacy"
         case .remote: "Remote Probes"
+        case .mcp: "MCP Server"
         }
     }
 
@@ -51,6 +53,7 @@ enum SettingsSectionID: String {
         case .pricing: "dollarsign.circle"
         case .privacy: "hand.raised.fill"
         case .remote: "antenna.radiowaves.left.and.right"
+        case .mcp: "point.3.connected.trianglepath.dotted"
         }
     }
 }
@@ -611,6 +614,11 @@ struct SettingsView: View {
                     if selectedSection == .remote {
                     RemoteSettingsSection(density: density, service: environment.remoteProbeService)
                         .id(SettingsSectionID.remote.id)
+                    }
+
+                    if selectedSection == .mcp, let mcp = environment.mcp {
+                    MCPSettingsSection(density: density, controller: mcp)
+                        .id(SettingsSectionID.mcp.id)
                     }
 
                     if selectedSection == .privacy {

--- a/Sources/VibeBarCore/MCP/MCPClientConfig.swift
+++ b/Sources/VibeBarCore/MCP/MCPClientConfig.swift
@@ -1,0 +1,61 @@
+import Foundation
+
+/// The client-side setup lines, in one place.
+///
+/// Settings' copy buttons and `docs/agent-setup/prompt.md` have to agree
+/// exactly — a doc that drifts from the button is how someone ends up with a
+/// half-configured client — so the strings live here rather than being typed
+/// twice. Every client gets the same command; only the file format differs.
+public enum MCPClientConfig {
+    /// Where an installed Vibe Bar keeps its executable. Used when the running
+    /// bundle cannot report its own path (a `swift run` build has no bundle).
+    public static let canonicalExecutablePath = "/Applications/Vibe Bar.app/Contents/MacOS/VibeBar"
+
+    /// The one line a user pastes into any agent to have it configure itself.
+    /// Kept verbatim in `MCPSettingsSection` and in the README.
+    public static let agentSetupPrompt =
+        "Fetch and execute the appropriate instructions to set me up for Vibe Bar from "
+        + "https://raw.githubusercontent.com/AstroQore/vibe-bar/main/docs/agent-setup/prompt.md"
+
+    public static let serverName = "vibebar"
+
+    /// `claude mcp add` needs the `--` separator, and the executable path
+    /// contains a space, so it has to stay quoted.
+    public static func claudeCodeCommand(executablePath: String = canonicalExecutablePath) -> String {
+        "claude mcp add --scope user \(serverName) -- \"\(executablePath)\" \(MCPStdioBridge.commandLineFlag)"
+    }
+
+    /// A `[mcp_servers.…]` block for `~/.codex/config.toml`.
+    public static func codexTOML(executablePath: String = canonicalExecutablePath) -> String {
+        """
+        [mcp_servers.\(serverName)]
+        command = "\(executablePath)"
+        args = ["\(MCPStdioBridge.commandLineFlag)"]
+        """
+    }
+
+    /// `~/.cursor/mcp.json`.
+    public static func cursorJSON(executablePath: String = canonicalExecutablePath) -> String {
+        """
+        {
+          "mcpServers": {
+            "\(serverName)": {
+              "command": "\(executablePath)",
+              "args": ["\(MCPStdioBridge.commandLineFlag)"]
+            }
+          }
+        }
+        """
+    }
+
+    /// The `mcpServers` entry on its own, for a client whose config file this
+    /// has to be merged into rather than replace.
+    public static func genericJSON(executablePath: String = canonicalExecutablePath) -> String {
+        """
+        "\(serverName)": {
+          "command": "\(executablePath)",
+          "args": ["\(MCPStdioBridge.commandLineFlag)"]
+        }
+        """
+    }
+}

--- a/Sources/VibeBarCore/MCP/MCPDTOs.swift
+++ b/Sources/VibeBarCore/MCP/MCPDTOs.swift
@@ -1,0 +1,711 @@
+import Foundation
+
+/// Codable projections of the Core types the MCP tools answer with.
+///
+/// Most of those types are deliberately not `Codable` (`UsageQueryFilter`,
+/// `UsageSummaryMetrics`, `SessionSummaryPage`, the pricing rows), and the
+/// ones that are encode a persistence shape rather than a wire shape. Keeping
+/// a projection layer here means the on-disk formats stay free to change
+/// without breaking an agent's parsing, and it is the one place that decides
+/// what an agent is allowed to see.
+///
+/// **Field style is camelCase, everywhere, and it is pinned by
+/// `MCPDTOEncodingTests`.** Money is reported twice — exact `costMicros`
+/// (Int64 micro-USD, what the ledger actually stores) and a rounded `costUSD`
+/// for display — so an agent never has to guess at the unit.
+/// Emails are masked through `EmailMasker`; nothing here can carry a cookie,
+/// a token, or an organization id.
+
+// MARK: - Shared
+
+public enum MCPMoney {
+    /// Micro-USD → USD, rounded to cents. The micros stay alongside it for
+    /// anything that needs to add totals up without drift.
+    public static func usd(_ micros: Int64) -> Double {
+        (Double(micros) / 1_000_000.0 * 100).rounded() / 100
+    }
+}
+
+public struct MCPRangeDTO: Codable, Equatable, Sendable {
+    public let from: Date
+    public let to: Date
+
+    public init(from: Date, to: Date) {
+        self.from = from
+        self.to = to
+    }
+}
+
+// MARK: - quota.get
+
+public struct MCPQuotaForecastDTO: Codable, Equatable, Sendable {
+    public let verdict: String
+    public let confidence: String
+    public let currentUsedPercent: Double
+    public let projectedUsedPercent: Double
+    public let projectedUsedLowerPercent: Double
+    public let projectedUsedUpperPercent: Double
+    public let runOutAt: Date?
+
+    public init(
+        verdict: String,
+        confidence: String,
+        currentUsedPercent: Double,
+        projectedUsedPercent: Double,
+        projectedUsedLowerPercent: Double,
+        projectedUsedUpperPercent: Double,
+        runOutAt: Date?
+    ) {
+        self.verdict = verdict
+        self.confidence = confidence
+        self.currentUsedPercent = currentUsedPercent
+        self.projectedUsedPercent = projectedUsedPercent
+        self.projectedUsedLowerPercent = projectedUsedLowerPercent
+        self.projectedUsedUpperPercent = projectedUsedUpperPercent
+        self.runOutAt = runOutAt
+    }
+}
+
+public struct MCPQuotaBucketDTO: Codable, Equatable, Sendable {
+    public let id: String
+    public let title: String
+    public let shortLabel: String
+    public let groupTitle: String?
+    public let usedPercent: Double
+    public let remainingPercent: Double
+    public let resetAt: Date?
+    public let windowSeconds: Int?
+    public let forecast: MCPQuotaForecastDTO?
+
+    public init(
+        id: String,
+        title: String,
+        shortLabel: String,
+        groupTitle: String?,
+        usedPercent: Double,
+        remainingPercent: Double,
+        resetAt: Date?,
+        windowSeconds: Int?,
+        forecast: MCPQuotaForecastDTO?
+    ) {
+        self.id = id
+        self.title = title
+        self.shortLabel = shortLabel
+        self.groupTitle = groupTitle
+        self.usedPercent = usedPercent
+        self.remainingPercent = remainingPercent
+        self.resetAt = resetAt
+        self.windowSeconds = windowSeconds
+        self.forecast = forecast
+    }
+}
+
+/// One account's live quota, named on the **quota axis**: L1 `company`,
+/// L2 `subProvider`, L3 bucket group / bucket. See `AGENTS.md` § 7.1.
+public struct MCPQuotaAccountDTO: Codable, Equatable, Sendable {
+    public let accountId: String
+    public let tool: String
+    public let company: String
+    public let subProvider: String
+    public let plan: String?
+    /// Masked through `EmailMasker` — never the raw mailbox.
+    public let email: String?
+    public let buckets: [MCPQuotaBucketDTO]
+    public let queriedAt: Date?
+    public let lastUpdated: Date?
+    public let lastAttempted: Date?
+    public let inFlight: Bool
+    public let error: String?
+
+    public init(
+        accountId: String,
+        tool: String,
+        company: String,
+        subProvider: String,
+        plan: String?,
+        email: String?,
+        buckets: [MCPQuotaBucketDTO],
+        queriedAt: Date?,
+        lastUpdated: Date?,
+        lastAttempted: Date?,
+        inFlight: Bool,
+        error: String?
+    ) {
+        self.accountId = accountId
+        self.tool = tool
+        self.company = company
+        self.subProvider = subProvider
+        self.plan = plan
+        self.email = email
+        self.buckets = buckets
+        self.queriedAt = queriedAt
+        self.lastUpdated = lastUpdated
+        self.lastAttempted = lastAttempted
+        self.inFlight = inFlight
+        self.error = error
+    }
+}
+
+public struct MCPQuotaSnapshotDTO: Codable, Equatable, Sendable {
+    public let generatedAt: Date
+    public let accounts: [MCPQuotaAccountDTO]
+
+    public init(generatedAt: Date, accounts: [MCPQuotaAccountDTO]) {
+        self.generatedAt = generatedAt
+        self.accounts = accounts
+    }
+}
+
+extension MCPQuotaForecastDTO {
+    public init(forecast: QuotaPaceForecast) {
+        self.init(
+            verdict: forecast.verdict.rawValue,
+            confidence: forecast.confidence.rawValue,
+            currentUsedPercent: forecast.currentUsedPercent,
+            projectedUsedPercent: forecast.projectedUsedPercent,
+            projectedUsedLowerPercent: forecast.projectedUsedLowerPercent,
+            projectedUsedUpperPercent: forecast.projectedUsedUpperPercent,
+            runOutAt: forecast.runOutAt
+        )
+    }
+}
+
+extension MCPQuotaBucketDTO {
+    public init(bucket: QuotaBucket, forecast: QuotaPaceForecast?) {
+        self.init(
+            id: bucket.id,
+            title: bucket.title,
+            shortLabel: bucket.shortLabel,
+            groupTitle: bucket.groupTitle,
+            usedPercent: bucket.usedPercent,
+            remainingPercent: bucket.remainingPercent,
+            resetAt: bucket.resetAt,
+            windowSeconds: bucket.rawWindowSeconds,
+            forecast: forecast.map(MCPQuotaForecastDTO.init(forecast:))
+        )
+    }
+}
+
+extension MCPQuotaAccountDTO {
+    /// Project one cached account, keyed by bucket id for the optional
+    /// forecasts. This is the only place a quota reaches the wire, so it is
+    /// also the only place the email has to be masked.
+    public init(
+        quota: AccountQuota,
+        lastUpdated: Date?,
+        lastAttempted: Date?,
+        inFlight: Bool,
+        error: QuotaError?,
+        forecastsByBucketID: [String: QuotaPaceForecast] = [:]
+    ) {
+        self.init(
+            accountId: quota.accountId,
+            tool: quota.tool.rawValue,
+            company: quota.tool.vendorName,
+            subProvider: quota.tool.quotaSubProviderName(),
+            plan: quota.plan,
+            email: quota.email.map(EmailMasker.mask),
+            buckets: quota.buckets.map {
+                MCPQuotaBucketDTO(bucket: $0, forecast: forecastsByBucketID[$0.id])
+            },
+            queriedAt: quota.queriedAt,
+            lastUpdated: lastUpdated,
+            lastAttempted: lastAttempted,
+            inFlight: inFlight,
+            error: error?.userFacingMessage
+        )
+    }
+}
+
+// MARK: - quota.refresh
+
+public struct MCPRefreshResultDTO: Codable, Equatable, Sendable {
+    public let triggered: Bool
+    /// `stale-only` or `forced` — which scheduler path ran.
+    public let mode: String
+    public let message: String
+
+    public init(triggered: Bool, mode: String, message: String) {
+        self.triggered = triggered
+        self.mode = mode
+        self.message = message
+    }
+}
+
+// MARK: - usage.summary
+
+public struct MCPUsageFiltersDTO: Codable, Equatable, Sendable {
+    public let tools: [String]?
+    public let harnesses: [String]?
+    public let models: [String]?
+
+    public init(tools: [String]?, harnesses: [String]?, models: [String]?) {
+        self.tools = tools
+        self.harnesses = harnesses
+        self.models = models
+    }
+}
+
+/// One `groupBy` row. `key` is the machine value to filter by next
+/// (`claudeCode`, `claude`, a raw model id); `label` is what a human reads.
+public struct MCPUsageGroupRowDTO: Codable, Equatable, Sendable {
+    public let key: String
+    public let label: String
+    /// L1 company, present for harness and provider rows. Never for models.
+    public let company: String?
+    public let requests: Int
+    public let totalTokens: Int64
+    public let costMicros: Int64
+    public let costUSD: Double
+
+    public init(key: String, label: String, company: String?, requests: Int, totalTokens: Int64, costMicros: Int64) {
+        self.key = key
+        self.label = label
+        self.company = company
+        self.requests = requests
+        self.totalTokens = totalTokens
+        self.costMicros = costMicros
+        self.costUSD = MCPMoney.usd(costMicros)
+    }
+}
+
+public struct MCPUsageSummaryDTO: Codable, Equatable, Sendable {
+    public let generatedAt: Date
+    public let range: MCPRangeDTO
+    public let filters: MCPUsageFiltersDTO
+    public let requests: Int
+    /// Requests whose model had no usable price. They add `0` to the cost, so
+    /// a non-zero count here means the total is a floor, not a total.
+    public let unpricedRequests: Int
+    public let costMicros: Int64?
+    public let costUSD: Double?
+    public let freshInputTokens: Int64
+    public let outputTokens: Int64
+    public let cacheReadTokens: Int64
+    public let cacheCreationTokens: Int64
+    public let totalTokens: Int64
+    public let cacheHitRate: Double?
+    public let groupBy: String?
+    public let rows: [MCPUsageGroupRowDTO]?
+
+    public init(
+        generatedAt: Date,
+        range: MCPRangeDTO,
+        filters: MCPUsageFiltersDTO,
+        metrics: UsageSummaryMetrics,
+        groupBy: String?,
+        rows: [MCPUsageGroupRowDTO]?
+    ) {
+        self.generatedAt = generatedAt
+        self.range = range
+        self.filters = filters
+        self.requests = metrics.requests
+        self.unpricedRequests = metrics.unpricedRequests
+        self.costMicros = metrics.costMicros
+        self.costUSD = metrics.costMicros.map(MCPMoney.usd)
+        self.freshInputTokens = metrics.freshInput
+        self.outputTokens = metrics.output
+        self.cacheReadTokens = metrics.cacheRead
+        self.cacheCreationTokens = metrics.cacheCreation
+        self.totalTokens = metrics.realTotalTokens
+        self.cacheHitRate = metrics.cacheHitRate
+        self.groupBy = groupBy
+        self.rows = rows
+    }
+}
+
+// MARK: - usage.trend
+
+public struct MCPUsageTrendPointDTO: Codable, Equatable, Sendable {
+    public let bucketStart: Date
+    public let freshInputTokens: Int64
+    public let outputTokens: Int64
+    public let cacheReadTokens: Int64
+    public let cacheCreationTokens: Int64
+    public let totalTokens: Int64
+    public let costMicros: Int64
+    public let costUSD: Double
+
+    public init(point: UsageTrendPoint) {
+        self.bucketStart = point.bucketStart
+        self.freshInputTokens = point.freshInput
+        self.outputTokens = point.output
+        self.cacheReadTokens = point.cacheRead
+        self.cacheCreationTokens = point.cacheCreation
+        self.totalTokens = point.totalTokens
+        self.costMicros = point.costMicros
+        self.costUSD = MCPMoney.usd(point.costMicros)
+    }
+}
+
+public struct MCPUsageTrendDTO: Codable, Equatable, Sendable {
+    public let generatedAt: Date
+    public let range: MCPRangeDTO
+    public let filters: MCPUsageFiltersDTO
+    /// The bucket the ledger actually used. An hourly request over a range
+    /// older than the detail window resolves down to `day`, so this can
+    /// differ from what was asked for.
+    public let bucket: String
+    public let points: [MCPUsageTrendPointDTO]
+
+    public init(
+        generatedAt: Date,
+        range: MCPRangeDTO,
+        filters: MCPUsageFiltersDTO,
+        series: UsageTrendSeries
+    ) {
+        self.generatedAt = generatedAt
+        self.range = range
+        self.filters = filters
+        self.bucket = series.bucket.rawValue
+        self.points = series.points.map(MCPUsageTrendPointDTO.init(point:))
+    }
+}
+
+// MARK: - usage.requests
+
+public struct MCPUsageRequestRowDTO: Codable, Equatable, Sendable {
+    public let id: Int64
+    public let date: Date
+    /// Quota-axis tool the request is billed against.
+    public let tool: String
+    /// Usage-axis producer — the CLI or app that made the request.
+    public let harness: String
+    public let harnessName: String
+    public let model: String
+    public let freshInputTokens: Int64
+    public let outputTokens: Int64
+    public let cacheReadTokens: Int64
+    public let cacheCreationTokens: Int64
+    public let totalTokens: Int64
+    public let costMicros: Int64?
+    public let costUSD: Double?
+    public let serviceTier: String?
+    public let sessionId: String?
+
+    public init(row: UsageRequestRow) {
+        self.id = row.id
+        self.date = row.date
+        self.tool = row.tool.rawValue
+        self.harness = row.harness.rawValue
+        self.harnessName = row.harness.displayName
+        self.model = row.model
+        self.freshInputTokens = row.freshInput
+        self.outputTokens = row.output
+        self.cacheReadTokens = row.cacheRead
+        self.cacheCreationTokens = row.cacheCreation
+        self.totalTokens = row.totalTokens
+        self.costMicros = row.costMicros
+        self.costUSD = row.costMicros.map(MCPMoney.usd)
+        self.serviceTier = row.serviceTier
+        self.sessionId = row.sessionId
+    }
+}
+
+public struct MCPUsageRequestsDTO: Codable, Equatable, Sendable {
+    public let generatedAt: Date
+    public let range: MCPRangeDTO
+    public let filters: MCPUsageFiltersDTO
+    public let rows: [MCPUsageRequestRowDTO]
+    public let totalCount: Int?
+    public let pageSize: Int
+    /// Opaque. Pass it back as `cursor` for the next page; absent means the
+    /// sequence ended.
+    public let nextCursor: String?
+
+    public init(
+        generatedAt: Date,
+        range: MCPRangeDTO,
+        filters: MCPUsageFiltersDTO,
+        page: UsageRequestPage
+    ) {
+        self.generatedAt = generatedAt
+        self.range = range
+        self.filters = filters
+        self.rows = page.rows.map(MCPUsageRequestRowDTO.init(row:))
+        self.totalCount = page.totalCount
+        self.pageSize = page.pageSize
+        self.nextCursor = page.nextCursor.map(MCPCursorCoding.encode)
+    }
+}
+
+/// The ledger's keyset cursor as one opaque string.
+///
+/// Agents copy this value between calls; making its two integers visible
+/// would invite hand-editing, and a hand-edited cursor silently skips or
+/// repeats rows rather than failing.
+public enum MCPCursorCoding {
+    public static func encode(_ cursor: UsageRequestCursor) -> String {
+        Data("\(cursor.ts).\(cursor.id)".utf8).base64EncodedString()
+    }
+
+    public static func decode(_ raw: String) -> UsageRequestCursor? {
+        guard let data = Data(base64Encoded: raw) else { return nil }
+        let parts = String(decoding: data, as: UTF8.self).split(separator: ".")
+        guard parts.count == 2,
+              let ts = Int64(parts[0]),
+              let id = Int64(parts[1])
+        else { return nil }
+        return UsageRequestCursor(ts: ts, id: id)
+    }
+}
+
+// MARK: - cost.snapshot
+
+public struct MCPCostWindowDTO: Codable, Equatable, Sendable {
+    public let costUSD: Double
+    public let tokens: Int
+    public let requests: Int
+
+    public init(costUSD: Double, tokens: Int, requests: Int) {
+        self.costUSD = costUSD
+        self.tokens = tokens
+        self.requests = requests
+    }
+}
+
+public struct MCPCostToolSnapshotDTO: Codable, Equatable, Sendable {
+    public let tool: String
+    public let company: String
+    public let subProvider: String
+    public let today: MCPCostWindowDTO
+    public let last7d: MCPCostWindowDTO
+    public let last30d: MCPCostWindowDTO
+    public let allTime: MCPCostWindowDTO
+    public let jsonlFilesFound: Int
+    public let updatedAt: Date
+
+    public init(snapshot: CostSnapshot) {
+        self.tool = snapshot.tool.rawValue
+        self.company = snapshot.tool.vendorName
+        self.subProvider = snapshot.tool.quotaSubProviderName()
+        self.today = MCPCostWindowDTO(
+            costUSD: snapshot.todayCostUSD,
+            tokens: snapshot.todayTokens,
+            requests: snapshot.todayRequests
+        )
+        self.last7d = MCPCostWindowDTO(
+            costUSD: snapshot.last7DaysCostUSD,
+            tokens: snapshot.last7DaysTokens,
+            requests: snapshot.last7DaysRequests
+        )
+        self.last30d = MCPCostWindowDTO(
+            costUSD: snapshot.last30DaysCostUSD,
+            tokens: snapshot.last30DaysTokens,
+            requests: snapshot.last30DaysRequests
+        )
+        self.allTime = MCPCostWindowDTO(
+            costUSD: snapshot.allTimeCostUSD,
+            tokens: snapshot.allTimeTokens,
+            requests: snapshot.allTimeRequests
+        )
+        self.jsonlFilesFound = snapshot.jsonlFilesFound
+        self.updatedAt = snapshot.updatedAt
+    }
+}
+
+public struct MCPCostSnapshotsDTO: Codable, Equatable, Sendable {
+    public let generatedAt: Date
+    /// True when Settings → Cost Data → Privacy mode is on. Every window is
+    /// then empty by design, not because nothing was spent.
+    public let privacyModeEnabled: Bool
+    public let tools: [MCPCostToolSnapshotDTO]
+
+    public init(generatedAt: Date, privacyModeEnabled: Bool, tools: [MCPCostToolSnapshotDTO]) {
+        self.generatedAt = generatedAt
+        self.privacyModeEnabled = privacyModeEnabled
+        self.tools = tools
+    }
+}
+
+// MARK: - cost.history
+
+public struct MCPCostHistoryPointDTO: Codable, Equatable, Sendable {
+    public let date: Date
+    public let costUSD: Double
+    public let totalTokens: Int
+
+    public init(point: DailyCostPoint) {
+        self.date = point.date
+        self.costUSD = point.costUSD
+        self.totalTokens = point.totalTokens
+    }
+}
+
+public struct MCPCostHistoryDTO: Codable, Equatable, Sendable {
+    public let tool: String
+    public let timeframe: String
+    public let updatedAt: Date
+    public let days: [MCPCostHistoryPointDTO]
+
+    public init(timeframe: String, history: CostHistory) {
+        self.tool = history.tool.rawValue
+        self.timeframe = timeframe
+        self.updatedAt = history.updatedAt
+        self.days = history.days.map(MCPCostHistoryPointDTO.init(point:))
+    }
+}
+
+// MARK: - sessions.*
+
+public struct MCPSessionSummaryDTO: Codable, Equatable, Sendable {
+    public let id: String
+    public let sessionId: String
+    /// The on-disk store the session came from.
+    public let provider: String
+    /// Usage-axis label — what the Sessions page shows on the row.
+    public let harness: String
+    public let harnessName: String
+    public let title: String?
+    public let summary: String?
+    public let projectDir: String?
+    /// Raw vendor model id as the log spelled it. `nil` when the log never
+    /// recorded one — never inferred from the provider's usual model.
+    public let model: String?
+    public let createdAt: Date?
+    public let lastActiveAt: Date?
+    public let messageCount: Int?
+    public let sizeBytes: Int64
+    public let sourcePath: String
+    /// Search only: the matched excerpt, with `<b>` markers around the hit.
+    public let snippet: String?
+    public let matchedSeq: Int?
+
+    public init(summary: SessionSummary, snippet: String? = nil, matchedSeq: Int? = nil) {
+        self.id = summary.id
+        self.sessionId = summary.sessionID
+        self.provider = summary.provider.rawValue
+        self.harness = summary.effectiveHarness.rawValue
+        self.harnessName = summary.effectiveHarness.displayName
+        self.title = summary.title
+        self.summary = summary.summary
+        self.projectDir = summary.projectDir
+        self.model = summary.model
+        self.createdAt = summary.createdAt
+        self.lastActiveAt = summary.lastActiveAt
+        self.messageCount = summary.hasKnownMessageCount ? summary.messageCount : nil
+        self.sizeBytes = summary.sizeBytes
+        self.sourcePath = summary.sourcePath
+        self.snippet = snippet
+        self.matchedSeq = matchedSeq
+    }
+}
+
+public struct MCPSessionListDTO: Codable, Equatable, Sendable {
+    public let generatedAt: Date
+    public let sessions: [MCPSessionSummaryDTO]
+    /// Total matching the filter, for `sessions.list`. Search does not count
+    /// past its own limit, so it is absent there.
+    public let totalCount: Int?
+    public let offset: Int?
+    public let limit: Int
+
+    public init(
+        generatedAt: Date,
+        sessions: [MCPSessionSummaryDTO],
+        totalCount: Int?,
+        offset: Int?,
+        limit: Int
+    ) {
+        self.generatedAt = generatedAt
+        self.sessions = sessions
+        self.totalCount = totalCount
+        self.offset = offset
+        self.limit = limit
+    }
+}
+
+// MARK: - status.get
+
+public struct MCPServiceStatusRowDTO: Codable, Equatable, Sendable {
+    public let tool: String
+    public let company: String
+    /// `none` / `minor` / `major` / `critical` / `maintenance`.
+    public let indicator: String
+    public let description: String
+    public let updatedAt: Date?
+    public let isRefreshing: Bool
+    public let error: String?
+
+    public init(
+        tool: String,
+        company: String,
+        indicator: String,
+        description: String,
+        updatedAt: Date?,
+        isRefreshing: Bool,
+        error: String?
+    ) {
+        self.tool = tool
+        self.company = company
+        self.indicator = indicator
+        self.description = description
+        self.updatedAt = updatedAt
+        self.isRefreshing = isRefreshing
+        self.error = error
+    }
+}
+
+public struct MCPServiceStatusDTO: Codable, Equatable, Sendable {
+    public let generatedAt: Date
+    public let lastFetched: Date?
+    public let companies: [MCPServiceStatusRowDTO]
+
+    public init(generatedAt: Date, lastFetched: Date?, companies: [MCPServiceStatusRowDTO]) {
+        self.generatedAt = generatedAt
+        self.lastFetched = lastFetched
+        self.companies = companies
+    }
+}
+
+// MARK: - pricing.effective
+
+public struct MCPPricingRowDTO: Codable, Equatable, Sendable {
+    public let provider: String
+    public let company: String
+    public let subProvider: String
+    public let model: String
+    public let displayLabel: String?
+    public let inputPerMillion: Double
+    public let outputPerMillion: Double
+    public let cacheReadPerMillion: Double?
+    public let cacheWritePerMillion: Double?
+    public let thresholdTokens: Int?
+
+    public init(row: EffectiveModelPricingRow) {
+        self.provider = row.provider.rawValue
+        self.company = row.companyName
+        self.subProvider = row.subProviderName
+        self.model = row.model
+        self.displayLabel = row.displayLabel
+        self.inputPerMillion = row.inputPerMillion
+        self.outputPerMillion = row.outputPerMillion
+        self.cacheReadPerMillion = row.cacheReadPerMillion
+        self.cacheWritePerMillion = row.cacheWritePerMillion
+        self.thresholdTokens = row.thresholdTokens
+    }
+}
+
+public struct MCPPricingDTO: Codable, Equatable, Sendable {
+    public let generatedAt: Date
+    public let unit: String
+    public let rows: [MCPPricingRowDTO]
+
+    public init(generatedAt: Date, rows: [MCPPricingRowDTO]) {
+        self.generatedAt = generatedAt
+        self.unit = "USD per 1M tokens"
+        self.rows = rows
+    }
+}
+
+// MARK: - Server identity
+
+public struct MCPServerInfo: Codable, Equatable, Sendable {
+    public let name: String
+    public let version: String
+
+    public init(name: String, version: String) {
+        self.name = name
+        self.version = version
+    }
+}

--- a/Sources/VibeBarCore/MCP/MCPJSONRPC.swift
+++ b/Sources/VibeBarCore/MCP/MCPJSONRPC.swift
@@ -1,0 +1,311 @@
+import Foundation
+
+/// The small slice of JSON-RPC 2.0 the MCP server speaks, hand-rolled.
+///
+/// MCP's stdio transport is newline-delimited JSON-RPC: one complete JSON
+/// object per line, UTF-8, no embedded newlines. Vibe Bar speaks the same
+/// framing over a Unix domain socket, so the bridge in `MCPStdioBridge` is a
+/// byte pump rather than a re-framer.
+///
+/// There is deliberately no SwiftPM dependency behind this. The surface is
+/// four message shapes and a JSON value type; a package would be more code to
+/// audit than the code it replaces.
+
+// MARK: - JSON value
+
+/// A JSON value that survives a round trip without a concrete Swift type.
+///
+/// Tool arguments arrive untyped and tool schemas are literal JSON, so both
+/// ends of the dispatch table need a value that is `Codable` without a
+/// matching struct. Integers keep their own case: re-encoding `1` as `1.0`
+/// makes a token count look like a measurement.
+public enum MCPJSON: Sendable, Equatable {
+    case null
+    case bool(Bool)
+    case int(Int64)
+    case double(Double)
+    case string(String)
+    case array([MCPJSON])
+    case object([String: MCPJSON])
+}
+
+extension MCPJSON: Codable {
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if container.decodeNil() {
+            self = .null
+        } else if let value = try? container.decode(Bool.self) {
+            self = .bool(value)
+        } else if let value = try? container.decode(Int64.self) {
+            self = .int(value)
+        } else if let value = try? container.decode(Double.self) {
+            self = .double(value)
+        } else if let value = try? container.decode(String.self) {
+            self = .string(value)
+        } else if let value = try? container.decode([MCPJSON].self) {
+            self = .array(value)
+        } else if let value = try? container.decode([String: MCPJSON].self) {
+            self = .object(value)
+        } else {
+            throw DecodingError.dataCorruptedError(
+                in: container,
+                debugDescription: "Unsupported JSON value."
+            )
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .null:            try container.encodeNil()
+        case let .bool(value):   try container.encode(value)
+        case let .int(value):    try container.encode(value)
+        case let .double(value): try container.encode(value)
+        case let .string(value): try container.encode(value)
+        case let .array(value):  try container.encode(value)
+        case let .object(value): try container.encode(value)
+        }
+    }
+}
+
+extension MCPJSON: ExpressibleByStringLiteral,
+                   ExpressibleByIntegerLiteral,
+                   ExpressibleByBooleanLiteral,
+                   ExpressibleByArrayLiteral,
+                   ExpressibleByDictionaryLiteral {
+    public init(stringLiteral value: String) { self = .string(value) }
+    public init(integerLiteral value: Int) { self = .int(Int64(value)) }
+    public init(booleanLiteral value: Bool) { self = .bool(value) }
+    public init(arrayLiteral elements: MCPJSON...) { self = .array(elements) }
+    public init(dictionaryLiteral elements: (String, MCPJSON)...) {
+        self = .object(Dictionary(elements, uniquingKeysWith: { _, last in last }))
+    }
+}
+
+extension MCPJSON {
+    public subscript(key: String) -> MCPJSON? {
+        guard case let .object(fields) = self else { return nil }
+        return fields[key]
+    }
+
+    public var objectValue: [String: MCPJSON]? {
+        guard case let .object(value) = self else { return nil }
+        return value
+    }
+
+    public var arrayValue: [MCPJSON]? {
+        guard case let .array(value) = self else { return nil }
+        return value
+    }
+
+    public var stringValue: String? {
+        guard case let .string(value) = self else { return nil }
+        return value
+    }
+
+    public var boolValue: Bool? {
+        guard case let .bool(value) = self else { return nil }
+        return value
+    }
+
+    /// Whole numbers only. A client that sends `20.0` for a page size means
+    /// twenty, so a `.double` with no fractional part answers here too.
+    public var intValue: Int? {
+        switch self {
+        case let .int(value): return Int(exactly: value)
+        case let .double(value):
+            guard value.isFinite, value == value.rounded() else { return nil }
+            return Int(exactly: value.rounded())
+        default: return nil
+        }
+    }
+
+    public var doubleValue: Double? {
+        switch self {
+        case let .int(value):    return Double(value)
+        case let .double(value): return value
+        default: return nil
+        }
+    }
+
+    public var isNull: Bool {
+        if case .null = self { return true }
+        return false
+    }
+
+    /// A list of strings, tolerating the single-string spelling clients
+    /// reach for when a filter happens to have one element.
+    public var stringListValue: [String]? {
+        switch self {
+        case let .string(value): return [value]
+        case let .array(values): return values.compactMap(\.stringValue)
+        default: return nil
+        }
+    }
+}
+
+// MARK: - Codable bridging
+
+extension MCPJSON {
+    /// One encoder for every payload the server emits, so `structuredContent`
+    /// and the human-readable `text` block can never disagree about a field
+    /// name, a date format, or a rounding.
+    public static func encoder(pretty: Bool) -> JSONEncoder {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = pretty
+            ? [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+            : [.sortedKeys, .withoutEscapingSlashes]
+        return encoder
+    }
+
+    /// Project any `Encodable` payload into a JSON value.
+    public static func encoding<T: Encodable>(_ value: T) throws -> MCPJSON {
+        let data = try encoder(pretty: false).encode(value)
+        return try JSONDecoder().decode(MCPJSON.self, from: data)
+    }
+
+    /// Pretty-printed JSON text for the `content` block agents actually read.
+    public static func prettyText<T: Encodable>(_ value: T) throws -> String {
+        let data = try encoder(pretty: true).encode(value)
+        return String(decoding: data, as: UTF8.self)
+    }
+
+    public func serialized() throws -> Data {
+        try MCPJSON.encoder(pretty: false).encode(self)
+    }
+}
+
+// MARK: - Errors
+
+/// A JSON-RPC error object. Protocol-level failures travel as these; a tool
+/// that ran and failed reports through `isError` on its result instead, which
+/// is what MCP clients surface back to the model.
+public struct MCPRPCError: Error, Sendable, Equatable {
+    public let code: Int
+    public let message: String
+    public let data: MCPJSON?
+
+    public init(code: Int, message: String, data: MCPJSON? = nil) {
+        self.code = code
+        self.message = message
+        self.data = data
+    }
+
+    public static func parseError(_ message: String = "Invalid JSON.") -> MCPRPCError {
+        MCPRPCError(code: -32_700, message: message)
+    }
+
+    public static func invalidRequest(_ message: String) -> MCPRPCError {
+        MCPRPCError(code: -32_600, message: message)
+    }
+
+    public static func methodNotFound(_ method: String) -> MCPRPCError {
+        MCPRPCError(code: -32_601, message: "Unknown method '\(method)'.")
+    }
+
+    public static func invalidParams(_ message: String) -> MCPRPCError {
+        MCPRPCError(code: -32_602, message: message)
+    }
+
+    public static func internalError(_ message: String) -> MCPRPCError {
+        MCPRPCError(code: -32_603, message: message)
+    }
+
+    var json: MCPJSON {
+        var fields: [String: MCPJSON] = [
+            "code": .int(Int64(code)),
+            "message": .string(message)
+        ]
+        if let data { fields["data"] = data }
+        return .object(fields)
+    }
+}
+
+// MARK: - Messages
+
+/// One decoded request or notification.
+///
+/// A notification is exactly a request with no `id`; the caller answers a
+/// request and stays silent for a notification, which is what
+/// `notifications/initialized` needs.
+public struct MCPRequest: Sendable, Equatable {
+    public let id: MCPJSON?
+    public let method: String
+    public let params: MCPJSON?
+
+    public var isNotification: Bool { id == nil }
+
+    public init(id: MCPJSON?, method: String, params: MCPJSON?) {
+        self.id = id
+        self.method = method
+        self.params = params
+    }
+
+    /// Decode one framed line.
+    ///
+    /// Throws `parseError` for bytes that are not JSON at all and
+    /// `invalidRequest` for JSON that is not a JSON-RPC request — the two
+    /// failures a client fixes in different places.
+    public static func decode(line: Data) throws -> MCPRequest {
+        let value: MCPJSON
+        do {
+            value = try JSONDecoder().decode(MCPJSON.self, from: line)
+        } catch {
+            throw MCPRPCError.parseError()
+        }
+        guard let fields = value.objectValue else {
+            throw MCPRPCError.invalidRequest("A request must be a JSON object.")
+        }
+        guard let method = fields["method"]?.stringValue, !method.isEmpty else {
+            throw MCPRPCError.invalidRequest("A request must carry a string 'method'.")
+        }
+        // `"jsonrpc": "2.0"` is required by the spec but not load-bearing here:
+        // rejecting a client that omits it buys nothing, and a client that
+        // sends a *different* version is a real mismatch worth naming.
+        if let version = fields["jsonrpc"]?.stringValue, version != "2.0" {
+            throw MCPRPCError.invalidRequest("Unsupported JSON-RPC version '\(version)'.")
+        }
+        let rawID = fields["id"]
+        return MCPRequest(
+            id: (rawID?.isNull ?? true) ? nil : rawID,
+            method: method,
+            params: fields["params"]
+        )
+    }
+}
+
+/// A response line, ready to frame.
+public struct MCPResponse: Sendable, Equatable {
+    public let id: MCPJSON
+    public let payload: Result<MCPJSON, MCPRPCError>
+
+    public init(id: MCPJSON, result: MCPJSON) {
+        self.id = id
+        self.payload = .success(result)
+    }
+
+    public init(id: MCPJSON, error: MCPRPCError) {
+        self.id = id
+        self.payload = .failure(error)
+    }
+
+    public var json: MCPJSON {
+        var fields: [String: MCPJSON] = ["jsonrpc": .string("2.0"), "id": id]
+        switch payload {
+        case let .success(result): fields["result"] = result
+        case let .failure(error):  fields["error"] = error.json
+        }
+        return .object(fields)
+    }
+
+    /// One line, newline included. Encoding cannot realistically fail — every
+    /// value came from `MCPJSON` — but a failure must still produce a line, or
+    /// the client waits forever for a reply that was silently dropped.
+    public func framed() -> Data {
+        var data = (try? json.serialized())
+            ?? Data(#"{"jsonrpc":"2.0","id":null,"error":{"code":-32603,"message":"Encoding the response failed."}}"#.utf8)
+        data.append(0x0A)
+        return data
+    }
+}

--- a/Sources/VibeBarCore/MCP/MCPResourceCatalog.swift
+++ b/Sources/VibeBarCore/MCP/MCPResourceCatalog.swift
@@ -1,0 +1,211 @@
+import Foundation
+
+/// One resource as `resources/list` renders it.
+public struct MCPResource: Sendable, Equatable {
+    public let uri: String
+    public let name: String
+    public let title: String
+    public let description: String
+    public let mimeType: String
+
+    public init(uri: String, name: String, title: String, description: String, mimeType: String) {
+        self.uri = uri
+        self.name = name
+        self.title = title
+        self.description = description
+        self.mimeType = mimeType
+    }
+
+    var json: MCPJSON {
+        .object([
+            "uri": .string(uri),
+            "name": .string(name),
+            "title": .string(title),
+            "description": .string(description),
+            "mimeType": .string(mimeType)
+        ])
+    }
+}
+
+/// The two documents the server hands out: the naming spec an agent has to
+/// read before it can phrase an answer correctly, and a short guide to which
+/// tool answers what.
+///
+/// The naming spec is **generated** from `ProviderHierarchyCatalog`,
+/// `ToolType` and `HarnessCatalog` rather than transcribed. A hand-written
+/// copy of `AGENTS.md` § 7.1 would drift the first time a provider is added,
+/// and a stale spec is worse than none: it teaches the model a label that no
+/// longer exists.
+public enum MCPResourceCatalog {
+    public static let namingSpecURI = "vibebar://naming-spec"
+    public static let toolsGuideURI = "vibebar://tools"
+
+    public static let all: [MCPResource] = [
+        MCPResource(
+            uri: namingSpecURI,
+            name: "naming-spec",
+            title: "Vibe Bar provider and harness naming",
+            description: "The two naming axes — quota (company / SubProvider / group) and usage "
+                + "(harness) — with the current tables and the model-name rule.",
+            mimeType: "text/markdown"
+        ),
+        MCPResource(
+            uri: toolsGuideURI,
+            name: "tools",
+            title: "Which Vibe Bar tool answers what",
+            description: "A short routing guide from a user's question to the tool that answers it.",
+            mimeType: "text/markdown"
+        )
+    ]
+
+    public static func contents(of uri: String) -> (mimeType: String, text: String)? {
+        switch uri {
+        case namingSpecURI: return ("text/markdown", namingSpec)
+        case toolsGuideURI: return ("text/markdown", toolsGuide)
+        default: return nil
+        }
+    }
+
+    // MARK: - Naming spec
+
+    public static var namingSpec: String {
+        var lines: [String] = []
+        lines.append("# Vibe Bar provider and harness naming")
+        lines.append("")
+        lines.append("Vibe Bar names a provider along **two orthogonal axes**. Pick one axis per")
+        lines.append("answer and stay on it; never mix levels of the two in one list.")
+        lines.append("")
+        lines.append("- **Quota axis** — what an account is billed against. L1 company → L2")
+        lines.append("  SubProvider → L3 quota / model group. This is what `quota.get` and")
+        lines.append("  `status.get` speak.")
+        lines.append("- **Usage / cost axis** — where the tokens were actually spent. The unit is")
+        lines.append("  the local *harness*: the CLI or app that produced the sessions Vibe Bar")
+        lines.append("  scanned. It is neither the company nor the quota SubProvider. This is what")
+        lines.append("  `usage.*` and `sessions.*` speak.")
+        lines.append("")
+        lines.append("Two harnesses can draw on one SubProvider's quota (Claude Code and Claude")
+        lines.append("Cowork both spend Claude's), and one company can own several harnesses that")
+        lines.append("bill against different quotas.")
+        lines.append("")
+        lines.append("## Quota axis")
+        lines.append("")
+        lines.append("| L1 company | L2 SubProvider | tool key |")
+        lines.append("| --- | --- | --- |")
+        for tool in ToolType.dedicatedCardProviders {
+            lines.append("| \(tool.vendorName) | \(tool.quotaSubProviderName()) | `\(tool.rawValue)` |")
+        }
+        lines.append("")
+        lines.append("Grok Bot is a cloud-only SubProvider that shares Cursor's adapter: it appears")
+        lines.append("as the `grok_bot_weekly` bucket under the `cursor` tool.")
+        lines.append("")
+        lines.append("L3 is the bucket: `id`, `title` and `groupTitle` on each entry of")
+        lines.append("`quota.get` → `accounts[].buckets[]`. Examples are \"5 Hours\", \"Weekly\",")
+        lines.append("\"All Models\", and per-model groups such as Sonnet / Opus / Fable.")
+        lines.append("")
+        lines.append("### Misc providers")
+        lines.append("")
+        lines.append("These have quota but no dedicated card, no cost scan and no status page:")
+        lines.append("")
+        lines.append("| Company | SubProvider | tool key |")
+        lines.append("| --- | --- | --- |")
+        for tool in ToolType.miscPageProviders {
+            lines.append("| \(tool.vendorName) | \(tool.productName) | `\(tool.rawValue)` |")
+        }
+        lines.append("")
+        lines.append("## Usage / cost axis")
+        lines.append("")
+        lines.append("| Harness | L1 company | harness key | Local evidence |")
+        lines.append("| --- | --- | --- | --- |")
+        for harness in Harness.allCases {
+            lines.append(
+                "| \(harness.displayName) | \(harness.companyName) | `\(harness.rawValue)` | \(evidence(for: harness)) |"
+            )
+        }
+        lines.append("")
+        lines.append("Consequences worth stating out loud:")
+        lines.append("")
+        lines.append("- \"Gemini Web\" is a quota SubProvider with **no** local usage. The")
+        lines.append("  deprecated CLI's historical tokens are always labelled \"Gemini CLI\".")
+        lines.append("- Cursor's tokens stay remote on purpose: its sessions are listed locally,")
+        lines.append("  but cost comes from the dashboard, so a Cursor session can have real")
+        lines.append("  messages and no local token counters.")
+        lines.append("- The Sessions surface is a **usage** surface. Its rows are labelled with")
+        lines.append("  the harness; only company chips speak L1.")
+        lines.append("")
+        lines.append("## Model names")
+        lines.append("")
+        lines.append("Display always uses the canonical vendor id — `gemini-3.5-flash-high`, not")
+        lines.append("\"Gemini 3.5 Flash (High)\". The ledger, the pricing tables and every `model`")
+        lines.append("field in these tools keep whatever the provider wrote, because rates are")
+        lines.append("matched on those upstream labels. Filter on the raw id; canonicalize only")
+        lines.append("what you print.")
+        lines.append("")
+        lines.append("Where a model is genuinely absent — an aborted Cursor conversation records")
+        lines.append("no model at all, and old Gemini CLI chats predate the per-turn field — the")
+        lines.append("value is `null`. Never infer a model from the provider's \"usual\" one.")
+        return lines.joined(separator: "\n") + "\n"
+    }
+
+    private static func evidence(for harness: Harness) -> String {
+        switch harness {
+        case .codex:        return "`~/.codex/sessions` rollouts"
+        case .chatgptWork:  return "same tree, `originator` == \"codex_work_desktop\""
+        case .claudeCode:   return "`~/.claude/projects`, `~/.config/claude/projects`"
+        case .claudeCowork: return "Claude.app's `local-agent-mode-sessions`"
+        case .geminiCLI:    return "`~/.gemini/tmp/*/chats`, telemetry log"
+        case .antigravity:  return "`~/.gemini/antigravity{,-cli,-ide}/conversations`"
+        case .grokBuild:    return "`~/.grok/sessions/**/updates.jsonl`"
+        case .cursor:       return "`~/.cursor/chats/**/store.db`; cost from the dashboard"
+        }
+    }
+
+    // MARK: - Tool guide
+
+    public static let toolsGuide = """
+        # Which Vibe Bar tool answers what
+
+        Vibe Bar exposes one Mac's local AI usage. Everything is read from the
+        running app's own caches; nothing here calls a provider directly except
+        `quota.refresh`, which asks the app to.
+
+        ## Routing
+
+        | The user asks | Call |
+        | --- | --- |
+        | "how much Codex / Claude / Gemini / Grok / Cursor do I have left?" | `quota.get` |
+        | "when does my 5-hour window reset?" | `quota.get` (`buckets[].resetAt`) |
+        | "am I going to run out before the reset?" | `quota.get` with `includeForecast: true` |
+        | "refresh my usage" | `quota.refresh`, then `quota.get` |
+        | "who used the most tokens this month?" | `usage.summary` with `groupBy: "harness"` |
+        | "what did I spend this week?" | `cost.snapshot`, or `usage.summary` for a custom window |
+        | "how has my spend moved day by day?" | `cost.history` |
+        | "show me my usage over time" | `usage.trend` |
+        | "what were my last N requests?" | `usage.requests` |
+        | "find my session about X" | `sessions.search` |
+        | "what have I been working on?" | `sessions.list` |
+        | "is Anthropic down?" | `status.get` |
+        | "why is this model costing so much?" | `pricing.effective` |
+
+        ## Rules that keep the answer right
+
+        - **Two axes, never mixed.** `quota.*` and `status.*` speak company /
+          SubProvider / bucket. `usage.*` and `sessions.*` speak harnesses. Read
+          `vibebar://naming-spec` before phrasing a comparison across providers.
+        - **Cite `generatedAt`.** Every payload carries it. Quota is a cache — say
+          how old it is rather than implying it is live.
+        - **Refresh sparingly.** `quota.refresh` without `force` only touches
+          accounts that are genuinely stale, and that is the right default. Do not
+          poll; a forced refresh more than once every few minutes is rate-limited
+          and tells the provider nothing new.
+        - **Money has two fields.** `costMicros` is exact micro-USD; `costUSD` is
+          rounded for display. Sum the micros, print the dollars.
+        - **`unpricedRequests > 0` means the total is a floor.** Some model on the
+          window has no rate card. Say so; check `pricing.effective`.
+        - **Privacy mode empties the cost surfaces.** When `cost.snapshot` reports
+          `privacyModeEnabled: true`, report that the user turned cost tracking
+          off — not that they spent nothing.
+        - **Request-level history is about 30 days deep.** Older usage survives as
+          daily totals, visible through `usage.summary` and `usage.trend` but not
+          through `usage.requests`.
+        """
+}

--- a/Sources/VibeBarCore/MCP/MCPServer.swift
+++ b/Sources/VibeBarCore/MCP/MCPServer.swift
@@ -1,0 +1,651 @@
+import Foundation
+
+// MARK: - Vocabulary
+
+public enum MCPUsageGrouping: String, Sendable, CaseIterable {
+    case harness
+    case provider
+    case model
+}
+
+/// The three windows `cost.history` offers, mapped onto `CostTimeframe`.
+/// Deliberately narrower than `CostTimeframe`: "today" and "yesterday" are
+/// one- and two-point series that `cost.snapshot` already answers better.
+public enum MCPCostHistoryTimeframe: String, Sendable, CaseIterable {
+    case sevenDays = "7d"
+    case thirtyDays = "30d"
+    case all
+
+    public var timeframe: CostTimeframe {
+        switch self {
+        case .sevenDays:  return .week
+        case .thirtyDays: return .month
+        case .all:        return .all
+        }
+    }
+}
+
+/// A tool that ran and could not answer. Surfaces as an `isError` result the
+/// model can read and react to, not as a JSON-RPC error the client swallows.
+public struct MCPToolFailure: Error, Sendable, Equatable {
+    public let message: String
+    public init(_ message: String) { self.message = message }
+}
+
+// MARK: - Data source
+
+/// Everything the MCP surface needs from the running app.
+///
+/// Core owns the protocol shape and every projection; the App supplies one
+/// implementation over `AppEnvironment`. That split is what lets the whole
+/// tool surface be tested against a fixture without a menu bar, a home
+/// directory, or a network.
+public protocol MCPDataSource: AnyObject, Sendable {
+    func serverInfo() async -> MCPServerInfo
+
+    func quotaAccounts(tools: [ToolType]?, includeForecast: Bool) async throws -> [MCPQuotaAccountDTO]
+    func refreshQuota(tools: [ToolType]?, force: Bool) async throws -> MCPRefreshResultDTO
+
+    func usageSummary(_ filter: UsageQueryFilter) async throws -> UsageSummaryMetrics
+    func usageGroupRows(_ filter: UsageQueryFilter, groupBy: MCPUsageGrouping) async throws -> [MCPUsageGroupRowDTO]
+    func usageTrend(_ filter: UsageQueryFilter, bucket: UsageTrendBucket?) async throws -> UsageTrendSeries
+    func usageRequests(
+        _ filter: UsageQueryFilter,
+        after cursor: UsageRequestCursor?,
+        pageSize: Int
+    ) async throws -> UsageRequestPage
+
+    func costSnapshots(tools: [ToolType]?) async throws -> MCPCostSnapshotsDTO
+    func costHistory(tool: ToolType, timeframe: MCPCostHistoryTimeframe) async throws -> CostHistory
+
+    func searchSessions(
+        query: String,
+        providers: [SessionProvider]?,
+        harnesses: [Harness]?,
+        limit: Int
+    ) async throws -> [SessionSearchHit]
+    func listSessions(
+        providers: [SessionProvider]?,
+        harnesses: [Harness]?,
+        since: Date?,
+        offset: Int,
+        limit: Int
+    ) async throws -> SessionSummaryPage
+
+    func serviceStatus(tools: [ToolType]?) async throws -> MCPServiceStatusDTO
+    func effectivePricing() async throws -> [EffectiveModelPricingRow]
+}
+
+// MARK: - Server
+
+/// Dispatches one JSON-RPC message at a time against an `MCPDataSource`.
+///
+/// Stateless apart from the forced-refresh throttle, so a second client
+/// connecting does not need a second server — `MCPSocketServer` hands every
+/// connection to the same instance.
+public final class MCPServer: @unchecked Sendable {
+    /// The MCP revision this server implements. Clients that ask for a
+    /// different one still get this; the spec's rule is that the server
+    /// answers with what it actually speaks and the client decides.
+    public static let protocolVersion = "2025-06-18"
+
+    /// Floor between two *forced* refreshes. Stale-only refreshes are already
+    /// self-limiting — they no-op when nothing is stale — but `force: true`
+    /// hits every provider's API, and an agent in a retry loop would otherwise
+    /// turn the user's own tooling into a rate-limit problem.
+    public static let forcedRefreshMinimumInterval: TimeInterval = 20
+
+    private let dataSource: any MCPDataSource
+    private let now: @Sendable () -> Date
+    private let lock = NSLock()
+    private var lastForcedRefreshAt: Date?
+
+    public init(dataSource: any MCPDataSource, now: @escaping @Sendable () -> Date = { Date() }) {
+        self.dataSource = dataSource
+        self.now = now
+    }
+
+    // MARK: Entry points
+
+    /// Handle one framed line. Returns the framed reply, or `nil` for a
+    /// notification (which must produce no output at all).
+    public func handle(line: Data) async -> Data? {
+        let request: MCPRequest
+        do {
+            request = try MCPRequest.decode(line: line)
+        } catch let error as MCPRPCError {
+            return MCPResponse(id: .null, error: error).framed()
+        } catch {
+            return MCPResponse(id: .null, error: .parseError()).framed()
+        }
+        return await respond(to: request)?.framed()
+    }
+
+    public func respond(to request: MCPRequest) async -> MCPResponse? {
+        guard let id = request.id else {
+            // Notifications are fire-and-forget. `notifications/initialized`
+            // is the only one that matters today; unknown ones are ignored
+            // rather than answered, because answering a notification is
+            // itself a protocol violation.
+            return nil
+        }
+        do {
+            return MCPResponse(id: id, result: try await result(for: request))
+        } catch let error as MCPRPCError {
+            return MCPResponse(id: id, error: error)
+        } catch {
+            return MCPResponse(id: id, error: .internalError(SafeLog.sanitize(error.localizedDescription)))
+        }
+    }
+
+    private func result(for request: MCPRequest) async throws -> MCPJSON {
+        switch request.method {
+        case "initialize":
+            return await initializeResult()
+        case "ping":
+            return .object([:])
+        case "tools/list":
+            return .object(["tools": .array(MCPToolCatalog.all.map(\.json))])
+        case "resources/list":
+            return .object(["resources": .array(MCPResourceCatalog.all.map(\.json))])
+        case "resources/templates/list":
+            return .object(["resourceTemplates": .array([])])
+        case "prompts/list":
+            return .object(["prompts": .array([])])
+        case "resources/read":
+            return try readResource(request.params)
+        case "tools/call":
+            return try await callTool(request.params)
+        default:
+            throw MCPRPCError.methodNotFound(request.method)
+        }
+    }
+
+    private func initializeResult() async -> MCPJSON {
+        let info = await dataSource.serverInfo()
+        return .object([
+            "protocolVersion": .string(Self.protocolVersion),
+            "capabilities": .object([
+                "tools": .object(["listChanged": .bool(false)]),
+                "resources": .object(["listChanged": .bool(false), "subscribe": .bool(false)])
+            ]),
+            "serverInfo": .object([
+                "name": .string(info.name),
+                "version": .string(info.version)
+            ]),
+            "instructions": .string(
+                "Vibe Bar reports this Mac's AI subscription quota, token usage, spend and local "
+                    + "agent sessions. Read the vibebar://naming-spec resource before comparing "
+                    + "providers: quota answers use company / SubProvider names, usage answers use "
+                    + "harness names, and the two must never be mixed in one list."
+            )
+        ])
+    }
+
+    // MARK: Resources
+
+    private func readResource(_ params: MCPJSON?) throws -> MCPJSON {
+        guard let uri = params?["uri"]?.stringValue, !uri.isEmpty else {
+            throw MCPRPCError.invalidParams("resources/read needs a string 'uri'.")
+        }
+        guard let contents = MCPResourceCatalog.contents(of: uri) else {
+            throw MCPRPCError.invalidParams("Unknown resource '\(uri)'.")
+        }
+        return .object([
+            "contents": .array([
+                .object([
+                    "uri": .string(uri),
+                    "mimeType": .string(contents.mimeType),
+                    "text": .string(contents.text)
+                ])
+            ])
+        ])
+    }
+
+    // MARK: Tools
+
+    private func callTool(_ params: MCPJSON?) async throws -> MCPJSON {
+        guard let name = params?["name"]?.stringValue, !name.isEmpty else {
+            throw MCPRPCError.invalidParams("tools/call needs a string 'name'.")
+        }
+        guard let tool = MCPToolCatalog.tool(named: name) else {
+            throw MCPRPCError.invalidParams("Unknown tool '\(name)'.")
+        }
+        let arguments = try MCPArguments(tool: tool, raw: params?["arguments"])
+        do {
+            return try Self.successResult(try await invoke(tool: name, arguments: arguments))
+        } catch let failure as MCPToolFailure {
+            return Self.errorResult(failure.message)
+        } catch let error as MCPRPCError {
+            // Argument problems stay JSON-RPC errors: the client, not the
+            // model, is the one that can fix a malformed call.
+            throw error
+        } catch {
+            return Self.errorResult(SafeLog.sanitize(error.localizedDescription))
+        }
+    }
+
+    private func invoke(tool: String, arguments: MCPArguments) async throws -> any Encodable {
+        switch tool {
+        case "quota.get":         return try await quotaGet(arguments)
+        case "quota.refresh":     return try await quotaRefresh(arguments)
+        case "usage.summary":     return try await usageSummary(arguments)
+        case "usage.trend":       return try await usageTrend(arguments)
+        case "usage.requests":    return try await usageRequests(arguments)
+        case "cost.snapshot":     return try await costSnapshot(arguments)
+        case "cost.history":      return try await costHistory(arguments)
+        case "sessions.search":   return try await sessionsSearch(arguments)
+        case "sessions.list":     return try await sessionsList(arguments)
+        case "status.get":        return try await statusGet(arguments)
+        case "pricing.effective": return try await pricingEffective(arguments)
+        default:                  throw MCPRPCError.invalidParams("Unknown tool '\(tool)'.")
+        }
+    }
+
+    // MARK: Tool implementations
+
+    private func quotaGet(_ arguments: MCPArguments) async throws -> MCPQuotaSnapshotDTO {
+        let tools = try arguments.optionalEnumList("tools", ToolType.self)
+        let includeForecast = try arguments.optionalBool("includeForecast") ?? false
+        let accounts = try await dataSource.quotaAccounts(tools: tools, includeForecast: includeForecast)
+        return MCPQuotaSnapshotDTO(generatedAt: now(), accounts: accounts)
+    }
+
+    private func quotaRefresh(_ arguments: MCPArguments) async throws -> MCPRefreshResultDTO {
+        let tools = try arguments.optionalEnumList("tools", ToolType.self)
+        let force = try arguments.optionalBool("force") ?? false
+        if force, let wait = throttledForcedRefreshSeconds() {
+            return MCPRefreshResultDTO(
+                triggered: false,
+                mode: "forced",
+                message: "A forced refresh ran less than "
+                    + "\(Int(Self.forcedRefreshMinimumInterval))s ago. Try again in \(wait)s, "
+                    + "or call quota.get — the cached numbers are almost certainly current."
+            )
+        }
+        let result = try await dataSource.refreshQuota(tools: tools, force: force)
+        if force, result.triggered { markForcedRefresh() }
+        return result
+    }
+
+    private func usageSummary(_ arguments: MCPArguments) async throws -> MCPUsageSummaryDTO {
+        let filter = try arguments.usageFilter(now: now())
+        let grouping = try arguments.optionalEnum("groupBy", MCPUsageGrouping.self)
+        let metrics = try await dataSource.usageSummary(filter)
+        let rows = grouping == nil
+            ? nil
+            : try await dataSource.usageGroupRows(filter, groupBy: grouping!)
+        return MCPUsageSummaryDTO(
+            generatedAt: now(),
+            range: MCPRangeDTO(from: filter.range.start, to: filter.range.end),
+            filters: filter.mcpFilters,
+            metrics: metrics,
+            groupBy: grouping?.rawValue,
+            rows: rows
+        )
+    }
+
+    private func usageTrend(_ arguments: MCPArguments) async throws -> MCPUsageTrendDTO {
+        let filter = try arguments.usageFilter(now: now())
+        let bucket = try arguments.optionalEnum("bucket", UsageTrendBucket.self)
+        let series = try await dataSource.usageTrend(filter, bucket: bucket)
+        return MCPUsageTrendDTO(
+            generatedAt: now(),
+            range: MCPRangeDTO(from: filter.range.start, to: filter.range.end),
+            filters: filter.mcpFilters,
+            series: series
+        )
+    }
+
+    private func usageRequests(_ arguments: MCPArguments) async throws -> MCPUsageRequestsDTO {
+        let filter = try arguments.usageFilter(now: now())
+        let pageSize = try arguments.optionalInt("pageSize", minimum: 1, maximum: 200) ?? 50
+        var cursor: UsageRequestCursor?
+        if let raw = try arguments.optionalString("cursor") {
+            guard let decoded = MCPCursorCoding.decode(raw) else {
+                throw MCPRPCError.invalidParams(
+                    "'cursor' is not a cursor this server issued. Pass back a 'nextCursor' verbatim, or omit it."
+                )
+            }
+            cursor = decoded
+        }
+        let page = try await dataSource.usageRequests(filter, after: cursor, pageSize: pageSize)
+        return MCPUsageRequestsDTO(
+            generatedAt: now(),
+            range: MCPRangeDTO(from: filter.range.start, to: filter.range.end),
+            filters: filter.mcpFilters,
+            page: page
+        )
+    }
+
+    private func costSnapshot(_ arguments: MCPArguments) async throws -> MCPCostSnapshotsDTO {
+        let tools = try arguments.optionalEnumList("tools", ToolType.self)
+        return try await dataSource.costSnapshots(tools: tools)
+    }
+
+    private func costHistory(_ arguments: MCPArguments) async throws -> MCPCostHistoryDTO {
+        let tool = try arguments.requiredEnum("tool", ToolType.self)
+        let timeframe = try arguments.optionalEnum("timeframe", MCPCostHistoryTimeframe.self) ?? .thirtyDays
+        let history = try await dataSource.costHistory(tool: tool, timeframe: timeframe)
+        return MCPCostHistoryDTO(timeframe: timeframe.rawValue, history: history)
+    }
+
+    private func sessionsSearch(_ arguments: MCPArguments) async throws -> MCPSessionListDTO {
+        let query = try arguments.requiredString("query")
+        guard !query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw MCPRPCError.invalidParams("'query' must not be blank.")
+        }
+        let limit = try arguments.optionalInt("limit", minimum: 1, maximum: 50) ?? 20
+        let hits = try await dataSource.searchSessions(
+            query: query,
+            providers: try arguments.optionalEnumList("providers", SessionProvider.self),
+            harnesses: try arguments.optionalEnumList("harnesses", Harness.self),
+            limit: limit
+        )
+        return MCPSessionListDTO(
+            generatedAt: now(),
+            sessions: hits.map {
+                MCPSessionSummaryDTO(summary: $0.summary, snippet: $0.snippet, matchedSeq: $0.matchedSeq)
+            },
+            totalCount: nil,
+            offset: nil,
+            limit: limit
+        )
+    }
+
+    private func sessionsList(_ arguments: MCPArguments) async throws -> MCPSessionListDTO {
+        let offset = try arguments.optionalInt("offset", minimum: 0, maximum: 1_000_000) ?? 0
+        let limit = try arguments.optionalInt("limit", minimum: 1, maximum: 100) ?? 50
+        let page = try await dataSource.listSessions(
+            providers: try arguments.optionalEnumList("providers", SessionProvider.self),
+            harnesses: try arguments.optionalEnumList("harnesses", Harness.self),
+            since: try arguments.optionalDate("since"),
+            offset: offset,
+            limit: limit
+        )
+        return MCPSessionListDTO(
+            generatedAt: now(),
+            sessions: page.summaries.map { MCPSessionSummaryDTO(summary: $0) },
+            totalCount: page.totalCount,
+            offset: page.offset,
+            limit: page.limit
+        )
+    }
+
+    private func statusGet(_ arguments: MCPArguments) async throws -> MCPServiceStatusDTO {
+        try await dataSource.serviceStatus(tools: try arguments.optionalEnumList("tools", ToolType.self))
+    }
+
+    private func pricingEffective(_ arguments: MCPArguments) async throws -> MCPPricingDTO {
+        let family = try arguments.optionalEnum("provider", PricingProviderFamily.self)
+        let needle = try arguments.optionalString("model")?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+        let rows = try await dataSource.effectivePricing()
+            .filter { row in family == nil || row.provider == family }
+            .filter { row in
+                guard let needle else { return true }
+                return row.model.lowercased().contains(needle)
+            }
+        return MCPPricingDTO(generatedAt: now(), rows: rows.map(MCPPricingRowDTO.init(row:)))
+    }
+
+    // MARK: Forced-refresh throttle
+
+    /// Seconds still to wait, or `nil` when a forced refresh may run.
+    private func throttledForcedRefreshSeconds() -> Int? {
+        lock.lock()
+        defer { lock.unlock() }
+        guard let last = lastForcedRefreshAt else { return nil }
+        let elapsed = now().timeIntervalSince(last)
+        guard elapsed < Self.forcedRefreshMinimumInterval else { return nil }
+        return max(1, Int((Self.forcedRefreshMinimumInterval - elapsed).rounded(.up)))
+    }
+
+    private func markForcedRefresh() {
+        lock.lock()
+        lastForcedRefreshAt = now()
+        lock.unlock()
+    }
+
+    // MARK: Result shaping
+
+    /// Every tool answers the same way: pretty JSON in `content` for the model
+    /// to read, and the identical object in `structuredContent` for a client
+    /// that parses. One encode feeds both, so they cannot drift.
+    static func successResult(_ payload: any Encodable) throws -> MCPJSON {
+        let text = try MCPJSON.prettyText(AnyEncodableBox(payload))
+        let structured = try MCPJSON.encoding(AnyEncodableBox(payload))
+        return .object([
+            "content": .array([.object(["type": .string("text"), "text": .string(text)])]),
+            "structuredContent": structured,
+            "isError": .bool(false)
+        ])
+    }
+
+    static func errorResult(_ message: String) -> MCPJSON {
+        .object([
+            "content": .array([.object(["type": .string("text"), "text": .string(message)])]),
+            "isError": .bool(true)
+        ])
+    }
+}
+
+/// Existential `Encodable` cannot be handed to `JSONEncoder` directly.
+private struct AnyEncodableBox: Encodable {
+    let wrapped: any Encodable
+
+    init(_ wrapped: any Encodable) { self.wrapped = wrapped }
+
+    func encode(to encoder: Encoder) throws {
+        try wrapped.encode(to: encoder)
+    }
+}
+
+// MARK: - Argument parsing
+
+/// Typed access to one `tools/call` argument object.
+///
+/// Every failure here is `invalidParams` rather than a tool error, because
+/// the caller sent something the schema already ruled out — an agent fixes
+/// that by re-reading the schema, not by reasoning about the answer.
+struct MCPArguments {
+    private let toolName: String
+    private let fields: [String: MCPJSON]
+
+    init(tool: MCPTool, raw: MCPJSON?) throws {
+        self.toolName = tool.name
+        switch raw {
+        case .none, .some(.null):
+            self.fields = [:]
+        case let .some(value):
+            guard let object = value.objectValue else {
+                throw MCPRPCError.invalidParams("'arguments' for \(tool.name) must be an object.")
+            }
+            self.fields = object
+        }
+        let allowed = Set(tool.inputSchema["properties"]?.objectValue?.keys.map { $0 } ?? [])
+        let unknown = fields.keys.filter { !allowed.contains($0) }.sorted()
+        guard unknown.isEmpty else {
+            throw MCPRPCError.invalidParams(
+                "\(tool.name) does not accept \(unknown.map { "'\($0)'" }.joined(separator: ", "))."
+                    + " Accepted: \(allowed.sorted().map { "'\($0)'" }.joined(separator: ", "))."
+            )
+        }
+    }
+
+    private func present(_ key: String) -> MCPJSON? {
+        guard let value = fields[key], !value.isNull else { return nil }
+        return value
+    }
+
+    func optionalString(_ key: String) throws -> String? {
+        guard let value = present(key) else { return nil }
+        guard let string = value.stringValue else {
+            throw MCPRPCError.invalidParams("\(toolName): '\(key)' must be a string.")
+        }
+        return string
+    }
+
+    func requiredString(_ key: String) throws -> String {
+        guard let value = try optionalString(key) else {
+            throw MCPRPCError.invalidParams("\(toolName): '\(key)' is required.")
+        }
+        return value
+    }
+
+    func optionalBool(_ key: String) throws -> Bool? {
+        guard let value = present(key) else { return nil }
+        guard let flag = value.boolValue else {
+            throw MCPRPCError.invalidParams("\(toolName): '\(key)' must be true or false.")
+        }
+        return flag
+    }
+
+    func optionalInt(_ key: String, minimum: Int, maximum: Int) throws -> Int? {
+        guard let value = present(key) else { return nil }
+        guard let number = value.intValue else {
+            throw MCPRPCError.invalidParams("\(toolName): '\(key)' must be a whole number.")
+        }
+        guard number >= minimum, number <= maximum else {
+            throw MCPRPCError.invalidParams(
+                "\(toolName): '\(key)' must be between \(minimum) and \(maximum); got \(number)."
+            )
+        }
+        return number
+    }
+
+    func optionalDate(_ key: String) throws -> Date? {
+        guard let raw = try optionalString(key) else { return nil }
+        guard let date = MCPDateParsing.parse(raw) else {
+            throw MCPRPCError.invalidParams(
+                "\(toolName): '\(key)' must be an ISO-8601 instant (2026-08-01 or 2026-08-01T09:30:00Z); got '\(raw)'."
+            )
+        }
+        return date
+    }
+
+    func requiredEnum<T: RawRepresentable & CaseIterable>(
+        _ key: String,
+        _ type: T.Type
+    ) throws -> T where T.RawValue == String {
+        guard let value = try optionalEnum(key, type) else {
+            throw MCPRPCError.invalidParams("\(toolName): '\(key)' is required.")
+        }
+        return value
+    }
+
+    func optionalEnum<T: RawRepresentable & CaseIterable>(
+        _ key: String,
+        _ type: T.Type
+    ) throws -> T? where T.RawValue == String {
+        guard let raw = try optionalString(key) else { return nil }
+        guard let value = T(rawValue: raw) else {
+            throw MCPRPCError.invalidParams(
+                "\(toolName): '\(key)' must be one of "
+                    + "\(T.allCases.map { "'\($0.rawValue)'" }.joined(separator: ", ")); got '\(raw)'."
+            )
+        }
+        return value
+    }
+
+    /// A list filter. An explicitly empty list stays empty rather than
+    /// collapsing to `nil`: the ledger reads that as "nothing matches", and
+    /// silently widening it to "everything" would answer a question nobody
+    /// asked.
+    func optionalEnumList<T: RawRepresentable & CaseIterable>(
+        _ key: String,
+        _ type: T.Type
+    ) throws -> [T]? where T.RawValue == String {
+        guard let value = present(key) else { return nil }
+        guard let raws = value.stringListValue else {
+            throw MCPRPCError.invalidParams("\(toolName): '\(key)' must be an array of strings.")
+        }
+        var out: [T] = []
+        for raw in raws {
+            guard let parsed = T(rawValue: raw) else {
+                throw MCPRPCError.invalidParams(
+                    "\(toolName): '\(key)' contains '\(raw)', which is not one of "
+                        + "\(T.allCases.map { "'\($0.rawValue)'" }.joined(separator: ", "))."
+                )
+            }
+            out.append(parsed)
+        }
+        return out
+    }
+
+    func optionalStringList(_ key: String) throws -> [String]? {
+        guard let value = present(key) else { return nil }
+        guard let raws = value.stringListValue else {
+            throw MCPRPCError.invalidParams("\(toolName): '\(key)' must be an array of strings.")
+        }
+        return raws
+    }
+
+    /// `from` / `to` / `days` collapsed into the half-open interval every
+    /// ledger query takes, plus the three list filters.
+    func usageFilter(now: Date) throws -> UsageQueryFilter {
+        let end = try optionalDate("to") ?? now
+        let start: Date
+        if let from = try optionalDate("from") {
+            start = from
+        } else {
+            let days = try optionalInt("days", minimum: 1, maximum: 3_650) ?? 30
+            start = end.addingTimeInterval(-Double(days) * 86_400)
+        }
+        guard start < end else {
+            throw MCPRPCError.invalidParams(
+                "\(toolName): the window is empty — 'from' must be earlier than 'to'."
+            )
+        }
+        return UsageQueryFilter(
+            range: DateInterval(start: start, end: end),
+            tools: try optionalEnumList("tools", ToolType.self),
+            harnesses: try optionalEnumList("harnesses", Harness.self),
+            models: try optionalStringList("models")
+        )
+    }
+}
+
+extension UsageQueryFilter {
+    var mcpFilters: MCPUsageFiltersDTO {
+        MCPUsageFiltersDTO(
+            tools: tools?.map(\.rawValue),
+            harnesses: harnesses?.map(\.rawValue),
+            models: models
+        )
+    }
+}
+
+/// ISO-8601 in the two spellings clients actually send, plus a bare date.
+enum MCPDateParsing {
+    private static let withFractionalSeconds: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter
+    }()
+
+    private static let internetDateTime: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter
+    }()
+
+    /// A bare `YYYY-MM-DD` means midnight *local*: an agent asking for
+    /// "since 2026-08-01" means the user's own first of August, not UTC's.
+    private static let calendarDay: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.calendar = Calendar(identifier: .gregorian)
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter
+    }()
+
+    static func parse(_ raw: String) -> Date? {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        if let date = withFractionalSeconds.date(from: trimmed) { return date }
+        if let date = internetDateTime.date(from: trimmed) { return date }
+        return calendarDay.date(from: trimmed)
+    }
+}

--- a/Sources/VibeBarCore/MCP/MCPSocketServer.swift
+++ b/Sources/VibeBarCore/MCP/MCPSocketServer.swift
@@ -1,0 +1,377 @@
+import Darwin
+import Dispatch
+import Foundation
+
+public enum MCPSocketError: Error, Sendable, Equatable {
+    /// `sockaddr_un.sun_path` is 104 bytes on macOS. A home directory deep
+    /// enough to overflow it is rare but not impossible, and the failure mode
+    /// without this check is a silently truncated path.
+    case pathTooLong(String)
+    case socketCreationFailed(Int32)
+    case bindFailed(Int32)
+    case listenFailed(Int32)
+    case staleSocketNotRemovable(String)
+
+    public var message: String {
+        switch self {
+        case let .pathTooLong(path):
+            return "The socket path is too long for a Unix domain socket: \(path)"
+        case let .socketCreationFailed(code):
+            return "Creating the MCP socket failed (errno \(code))."
+        case let .bindFailed(code):
+            return "Binding the MCP socket failed (errno \(code))."
+        case let .listenFailed(code):
+            return "Listening on the MCP socket failed (errno \(code))."
+        case let .staleSocketNotRemovable(path):
+            return "A stale MCP socket at \(path) could not be removed."
+        }
+    }
+}
+
+/// A newline-delimited JSON-RPC listener on a Unix domain socket.
+///
+/// **No TCP, no port, no token.** The socket lives at `~/.vibebar/mcp.sock`
+/// with mode 0600 inside a 0700 directory, so the filesystem is the whole
+/// authentication story: a process that can open it is already running as the
+/// user, and a token file would only add a secret to leak. Nothing is ever
+/// bound to a network interface.
+///
+/// This is POSIX rather than `Network.framework` on purpose. `NWListener`
+/// can carry `NWEndpoint.unix`, but it owns the socket file's creation, which
+/// makes the "unlink the stale one, bind under a tight umask, chmod" sequence
+/// that guarantees 0600 impossible to state directly.
+public final class MCPSocketServer: @unchecked Sendable {
+    /// Framing cap. A single JSON-RPC line larger than this is a client bug,
+    /// and buffering it would let one connection grow without bound.
+    public static let maximumLineBytes = 4 * 1024 * 1024
+    /// Concurrent clients. Two agents plus a stray bridge is the realistic
+    /// peak; the cap exists so a runaway client cannot exhaust descriptors.
+    public static let maximumConnections = 16
+
+    public let socketPath: String
+
+    private let server: MCPServer
+    private let acceptQueue = DispatchQueue(label: "com.astroqore.VibeBar.mcp.accept")
+    private let stateLock = NSLock()
+
+    private var listenFD: Int32 = -1
+    private var acceptSource: DispatchSourceRead?
+    private var connections: [ObjectIdentifier: Connection] = [:]
+    private var didBindSocketFile = false
+
+    /// Called on the accept queue whenever a client connects or disconnects,
+    /// with the live connection count. The Settings pane uses it to show
+    /// whether anything is attached without polling.
+    public var onConnectionChange: (@Sendable (Int, Date) -> Void)?
+
+    public init(server: MCPServer, socketPath: String = MCPSocketServer.defaultSocketPath) {
+        self.server = server
+        self.socketPath = socketPath
+    }
+
+    deinit {
+        stop()
+    }
+
+    public static var defaultSocketPath: String {
+        VibeBarLocalStore.baseDirectory.appendingPathComponent("mcp.sock").path
+    }
+
+    public var isRunning: Bool {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        return listenFD >= 0
+    }
+
+    public var connectionCount: Int {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        return connections.count
+    }
+
+    // MARK: - Lifecycle
+
+    public func start() throws {
+        stateLock.lock()
+        let alreadyRunning = listenFD >= 0
+        stateLock.unlock()
+        guard !alreadyRunning else { return }
+
+        var address = sockaddr_un()
+        address.sun_family = sa_family_t(AF_UNIX)
+        let pathBytes = Array(socketPath.utf8)
+        // One byte is reserved for the terminating NUL. Checked before
+        // anything touches the filesystem, so an unusable path fails as
+        // itself rather than as whatever the first syscall happened to hit.
+        let capacity = MemoryLayout.size(ofValue: address.sun_path) - 1
+        guard pathBytes.count <= capacity else {
+            throw MCPSocketError.pathTooLong(socketPath)
+        }
+
+        // Only the app's own directory is created (and forced to 0700). A
+        // custom path — tests, the documented `VIBEBAR_MCP_SOCKET` override —
+        // must already have its directory, because chmod-ing someone else's
+        // is not this server's business.
+        if socketPath == Self.defaultSocketPath {
+            try VibeBarLocalStore.ensureBaseDirectory()
+        }
+
+        // A socket file left behind by a crash refuses `bind` with EADDRINUSE
+        // forever. Removing it is safe precisely because a live server holds
+        // no lock on the inode: if another Vibe Bar really is listening, the
+        // `listen` below is what fails, not this.
+        if FileManager.default.fileExists(atPath: socketPath) {
+            do {
+                try FileManager.default.removeItem(atPath: socketPath)
+            } catch {
+                throw MCPSocketError.staleSocketNotRemovable(socketPath)
+            }
+        }
+
+        let fd = socket(AF_UNIX, SOCK_STREAM, 0)
+        guard fd >= 0 else { throw MCPSocketError.socketCreationFailed(errno) }
+
+        withUnsafeMutableBytes(of: &address.sun_path) { raw in
+            guard let base = raw.baseAddress else { return }
+            base.initializeMemory(as: UInt8.self, repeating: 0, count: raw.count)
+            base.copyMemory(from: pathBytes, byteCount: pathBytes.count)
+        }
+        address.sun_len = UInt8(MemoryLayout<sockaddr_un>.size)
+
+        // The window between `bind` (which creates the file) and `chmod` is
+        // the only moment the socket could be group/other-accessible, so the
+        // umask closes it and the chmod makes the final mode explicit rather
+        // than umask-dependent.
+        let previousMask = umask(0o177)
+        let bindResult = withUnsafePointer(to: &address) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockaddrPointer in
+                bind(fd, sockaddrPointer, socklen_t(MemoryLayout<sockaddr_un>.size))
+            }
+        }
+        umask(previousMask)
+        guard bindResult == 0 else {
+            let code = errno
+            close(fd)
+            throw MCPSocketError.bindFailed(code)
+        }
+        chmod(socketPath, 0o600)
+
+        guard listen(fd, 8) == 0 else {
+            let code = errno
+            close(fd)
+            try? FileManager.default.removeItem(atPath: socketPath)
+            throw MCPSocketError.listenFailed(code)
+        }
+
+        Self.setNonBlocking(fd)
+        let source = DispatchSource.makeReadSource(fileDescriptor: fd, queue: acceptQueue)
+        source.setEventHandler { [weak self] in self?.acceptPending() }
+        source.setCancelHandler { close(fd) }
+
+        stateLock.lock()
+        listenFD = fd
+        acceptSource = source
+        didBindSocketFile = true
+        stateLock.unlock()
+
+        source.resume()
+        SafeLog.info("MCP server listening on \(SafeLog.sanitize(socketPath))")
+    }
+
+    public func stop() {
+        stateLock.lock()
+        let source = acceptSource
+        let openConnections = Array(connections.values)
+        let shouldUnlink = didBindSocketFile
+        acceptSource = nil
+        connections = [:]
+        listenFD = -1
+        didBindSocketFile = false
+        stateLock.unlock()
+
+        source?.cancel()
+        for connection in openConnections { connection.close() }
+        // Only remove a socket file this instance actually created: a `stop`
+        // during a failed start must not delete a healthy server's socket.
+        if shouldUnlink {
+            try? FileManager.default.removeItem(atPath: socketPath)
+        }
+    }
+
+    // MARK: - Accept
+
+    private func acceptPending() {
+        while true {
+            var address = sockaddr()
+            var length = socklen_t(MemoryLayout<sockaddr>.size)
+            let clientFD = accept(currentListenFD(), &address, &length)
+            guard clientFD >= 0 else {
+                // EAGAIN/EWOULDBLOCK simply means the backlog drained.
+                return
+            }
+            guard connectionCount < Self.maximumConnections else {
+                close(clientFD)
+                SafeLog.warn("MCP server refused a connection: too many clients.")
+                continue
+            }
+            Self.setNonBlocking(clientFD)
+            open(clientFD: clientFD)
+        }
+    }
+
+    private func currentListenFD() -> Int32 {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        return listenFD
+    }
+
+    private func open(clientFD: Int32) {
+        let connection = Connection(fd: clientFD, server: server)
+        connection.onClose = { [weak self] closed in
+            guard let self else { return }
+            self.stateLock.lock()
+            self.connections.removeValue(forKey: ObjectIdentifier(closed))
+            let remaining = self.connections.count
+            self.stateLock.unlock()
+            self.onConnectionChange?(remaining, Date())
+        }
+
+        stateLock.lock()
+        connections[ObjectIdentifier(connection)] = connection
+        let count = connections.count
+        stateLock.unlock()
+
+        connection.resume()
+        onConnectionChange?(count, Date())
+    }
+
+    static func setNonBlocking(_ fd: Int32) {
+        let flags = fcntl(fd, F_GETFL, 0)
+        _ = fcntl(fd, F_SETFL, flags | O_NONBLOCK)
+    }
+}
+
+// MARK: - One client
+
+/// One accepted client: a read source that reframes bytes into lines, and a
+/// serial queue that both parses and writes, so replies from concurrent
+/// handler tasks can never interleave mid-line.
+private final class Connection: @unchecked Sendable {
+    private let fd: Int32
+    private let server: MCPServer
+    private let queue: DispatchQueue
+    private var source: DispatchSourceRead?
+    private var buffer = Data()
+    private var isClosed = false
+
+    var onClose: (@Sendable (Connection) -> Void)?
+
+    init(fd: Int32, server: MCPServer) {
+        self.fd = fd
+        self.server = server
+        self.queue = DispatchQueue(label: "com.astroqore.VibeBar.mcp.connection.\(fd)")
+    }
+
+    func resume() {
+        let source = DispatchSource.makeReadSource(fileDescriptor: fd, queue: queue)
+        source.setEventHandler { [weak self] in self?.readAvailable() }
+        source.setCancelHandler { [fd] in Darwin.close(fd) }
+        self.source = source
+        source.resume()
+    }
+
+    func close() {
+        queue.async { [weak self] in self?.closeOnQueue() }
+    }
+
+    private func closeOnQueue() {
+        guard !isClosed else { return }
+        isClosed = true
+        source?.cancel()
+        source = nil
+        buffer = Data()
+        onClose?(self)
+    }
+
+    private func readAvailable() {
+        guard !isClosed else { return }
+        var chunk = [UInt8](repeating: 0, count: 64 * 1024)
+        while true {
+            let count = chunk.withUnsafeMutableBytes { read(fd, $0.baseAddress, $0.count) }
+            if count > 0 {
+                buffer.append(contentsOf: chunk[0..<count])
+                if !drainLines() { return }
+                continue
+            }
+            if count == 0 {
+                // Orderly shutdown by the peer.
+                closeOnQueue()
+                return
+            }
+            if errno == EINTR { continue }
+            if errno == EAGAIN || errno == EWOULDBLOCK { return }
+            closeOnQueue()
+            return
+        }
+    }
+
+    /// Returns false when the connection was closed while draining.
+    private func drainLines() -> Bool {
+        while let newline = buffer.firstIndex(of: 0x0A) {
+            let line = Data(buffer[buffer.startIndex..<newline])
+            buffer.removeSubrange(buffer.startIndex...newline)
+            guard !line.isEmpty else { continue }
+            dispatch(line: line)
+            if isClosed { return false }
+        }
+        if buffer.count > MCPSocketServer.maximumLineBytes {
+            // Never parsed, so there is no id to answer under; say so once and
+            // hang up rather than buffering the rest of whatever this is.
+            write(
+                MCPResponse(
+                    id: .null,
+                    error: .invalidRequest(
+                        "A single JSON-RPC line may not exceed \(MCPSocketServer.maximumLineBytes) bytes."
+                    )
+                ).framed()
+            )
+            closeOnQueue()
+            return false
+        }
+        return true
+    }
+
+    private func dispatch(line: Data) {
+        let server = self.server
+        Task { [weak self] in
+            guard let reply = await server.handle(line: line) else { return }
+            self?.queue.async { [weak self] in self?.write(reply) }
+        }
+    }
+
+    private func write(_ data: Data) {
+        guard !isClosed else { return }
+        var remaining = data
+        while !remaining.isEmpty {
+            let written = remaining.withUnsafeBytes { raw -> Int in
+                guard let base = raw.baseAddress else { return 0 }
+                return Darwin.write(fd, base, raw.count)
+            }
+            if written > 0 {
+                remaining = remaining.dropFirst(written)
+                continue
+            }
+            if errno == EINTR { continue }
+            if errno == EAGAIN || errno == EWOULDBLOCK {
+                // The client stopped reading. Wait briefly for room rather
+                // than spinning; a client that never drains gets hung up on.
+                var descriptor = pollfd(fd: fd, events: Int16(POLLOUT), revents: 0)
+                if poll(&descriptor, 1, 5_000) > 0 { continue }
+                closeOnQueue()
+                return
+            }
+            closeOnQueue()
+            return
+        }
+    }
+}

--- a/Sources/VibeBarCore/MCP/MCPStdioBridge.swift
+++ b/Sources/VibeBarCore/MCP/MCPStdioBridge.swift
@@ -1,0 +1,151 @@
+import Darwin
+import Foundation
+
+/// The `--mcp-stdio` mode: the same app binary, run as a plain stdio MCP
+/// server that forwards to the running app's socket.
+///
+/// MCP clients spawn a command and speak newline-delimited JSON-RPC over its
+/// stdin/stdout. Vibe Bar's own transport is the same framing over a Unix
+/// socket, so this is a byte pump rather than a protocol bridge — no parsing,
+/// no reframing, and therefore nothing that can corrupt a message it did not
+/// understand.
+///
+/// One command configures every client:
+///
+/// ```
+/// /Applications/Vibe Bar.app/Contents/MacOS/VibeBar --mcp-stdio
+/// ```
+///
+/// The process installs no status item, opens no window, and touches nothing
+/// under `~/.vibebar` except the socket it connects to.
+public enum MCPStdioBridge {
+    public static let commandLineFlag = "--mcp-stdio"
+
+    /// Test and diagnostic override for the socket path. The smoke test in
+    /// `Tests/` uses it to point a spawned bridge at a temporary socket
+    /// instead of the real one; it is documented rather than hidden because a
+    /// second Vibe Bar build is exactly the case that needs it.
+    public static let socketPathEnvironmentKey = "VIBEBAR_MCP_SOCKET"
+
+    public enum ExitCode {
+        public static let ok: Int32 = 0
+        /// Nothing was listening — almost always "the app is not running".
+        public static let notRunning: Int32 = 1
+    }
+
+    public static func socketPath(
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> String {
+        let override = environment[socketPathEnvironmentKey]?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        if let override, !override.isEmpty { return override }
+        return MCPSocketServer.defaultSocketPath
+    }
+
+    /// Connect, pump both directions, return an exit code.
+    ///
+    /// Returns when either side closes: stdin closing is the client shutting
+    /// the server down, and the socket closing is Vibe Bar quitting. Both are
+    /// ordinary ends of a session, so both exit zero — only a failure to
+    /// connect at all is an error worth a non-zero code.
+    public static func run(
+        socketPath path: String,
+        input: Int32 = STDIN_FILENO,
+        output: Int32 = STDOUT_FILENO,
+        standardError: FileHandle = .standardError
+    ) -> Int32 {
+        guard let socketFD = connect(to: path) else {
+            standardError.write(Data((notRunningMessage(for: path) + "\n").utf8))
+            return ExitCode.notRunning
+        }
+
+        // stdin runs on its own thread with blocking reads. A DispatchSource
+        // would work too, but stdin here is a pipe owned by the MCP client and
+        // a plain blocking read is both simpler and impossible to get subtly
+        // wrong around partial reads.
+        let upstreamFinished = DispatchSemaphore(value: 0)
+        let thread = Thread {
+            pump(from: input, to: socketFD)
+            // Half-close so the app sees EOF and releases the connection while
+            // still being able to flush whatever it was mid-reply on.
+            shutdown(socketFD, SHUT_WR)
+            upstreamFinished.signal()
+        }
+        thread.name = "com.astroqore.VibeBar.mcp.stdio"
+        thread.start()
+
+        pump(from: socketFD, to: output)
+        // The socket closed. Do not wait on the stdin thread: it is parked in
+        // a blocking read the client may never end, and the process exiting is
+        // what the client is waiting for.
+        close(socketFD)
+        return ExitCode.ok
+    }
+
+    static func notRunningMessage(for path: String) -> String {
+        let display = path == MCPSocketServer.defaultSocketPath ? "~/.vibebar/mcp.sock" : path
+        return "Vibe Bar is not running (socket \(display) not found). Launch \"Vibe Bar.app\" first."
+    }
+
+    // MARK: - Plumbing
+
+    private static func connect(to path: String) -> Int32? {
+        var address = sockaddr_un()
+        address.sun_family = sa_family_t(AF_UNIX)
+        let pathBytes = Array(path.utf8)
+        guard pathBytes.count <= MemoryLayout.size(ofValue: address.sun_path) - 1 else { return nil }
+        withUnsafeMutableBytes(of: &address.sun_path) { raw in
+            guard let base = raw.baseAddress else { return }
+            base.initializeMemory(as: UInt8.self, repeating: 0, count: raw.count)
+            base.copyMemory(from: pathBytes, byteCount: pathBytes.count)
+        }
+        address.sun_len = UInt8(MemoryLayout<sockaddr_un>.size)
+
+        let fd = socket(AF_UNIX, SOCK_STREAM, 0)
+        guard fd >= 0 else { return nil }
+        let result = withUnsafePointer(to: &address) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockaddrPointer in
+                Darwin.connect(fd, sockaddrPointer, socklen_t(MemoryLayout<sockaddr_un>.size))
+            }
+        }
+        guard result == 0 else {
+            close(fd)
+            return nil
+        }
+        return fd
+    }
+
+    /// Copy bytes until the source ends. Byte-for-byte: the newline framing
+    /// travels inside the stream, so nothing here needs to know where a
+    /// message starts.
+    private static func pump(from source: Int32, to destination: Int32) {
+        var chunk = [UInt8](repeating: 0, count: 64 * 1024)
+        while true {
+            let count = chunk.withUnsafeMutableBytes { read(source, $0.baseAddress, $0.count) }
+            if count > 0 {
+                guard writeAll(chunk, count: count, to: destination) else { return }
+                continue
+            }
+            if count == 0 { return }
+            if errno == EINTR { continue }
+            return
+        }
+    }
+
+    private static func writeAll(_ bytes: [UInt8], count: Int, to destination: Int32) -> Bool {
+        var offset = 0
+        while offset < count {
+            let written = bytes.withUnsafeBytes { raw -> Int in
+                guard let base = raw.baseAddress else { return -1 }
+                return Darwin.write(destination, base + offset, count - offset)
+            }
+            if written > 0 {
+                offset += written
+                continue
+            }
+            if errno == EINTR { continue }
+            return false
+        }
+        return true
+    }
+}

--- a/Sources/VibeBarCore/MCP/MCPToolCatalog.swift
+++ b/Sources/VibeBarCore/MCP/MCPToolCatalog.swift
@@ -1,0 +1,352 @@
+import Foundation
+
+/// One tool as `tools/list` renders it.
+public struct MCPTool: Sendable, Equatable {
+    public let name: String
+    public let title: String
+    public let description: String
+    public let inputSchema: MCPJSON
+
+    public init(name: String, title: String, description: String, inputSchema: MCPJSON) {
+        self.name = name
+        self.title = title
+        self.description = description
+        self.inputSchema = inputSchema
+    }
+
+    var json: MCPJSON {
+        .object([
+            "name": .string(name),
+            "title": .string(title),
+            "description": .string(description),
+            "inputSchema": inputSchema
+        ])
+    }
+}
+
+/// The tool surface, schemas included.
+///
+/// Descriptions carry the two-axis rule (`AGENTS.md` § 7.1) inline rather
+/// than assuming the agent read the naming-spec resource first: a model
+/// picking a tool from a list reads these strings and nothing else, and
+/// "which provider used the most" has two different right answers depending
+/// on whether the question is about quota or about spend.
+public enum MCPToolCatalog {
+    public static let all: [MCPTool] = [
+        quotaGet,
+        quotaRefresh,
+        usageSummary,
+        usageTrend,
+        usageRequests,
+        costSnapshot,
+        costHistory,
+        sessionsSearch,
+        sessionsList,
+        statusGet,
+        pricingEffective
+    ]
+
+    public static func tool(named name: String) -> MCPTool? {
+        all.first { $0.name == name }
+    }
+
+    // MARK: - Schema helpers
+
+    static func object(
+        properties: [String: MCPJSON],
+        required: [String] = []
+    ) -> MCPJSON {
+        var schema: [String: MCPJSON] = [
+            "type": .string("object"),
+            "properties": .object(properties),
+            // Agents routinely invent plausible-looking extra arguments.
+            // Rejecting them here turns a silently ignored filter into a
+            // visible error instead of a wrong number.
+            "additionalProperties": .bool(false)
+        ]
+        if !required.isEmpty {
+            schema["required"] = .array(required.map { .string($0) })
+        }
+        return .object(schema)
+    }
+
+    static func stringEnumList(_ values: [String], description: String) -> MCPJSON {
+        .object([
+            "type": .string("array"),
+            "description": .string(description),
+            "items": .object([
+                "type": .string("string"),
+                "enum": .array(values.map { .string($0) })
+            ])
+        ])
+    }
+
+    static func string(_ description: String, enumValues: [String]? = nil) -> MCPJSON {
+        var schema: [String: MCPJSON] = [
+            "type": .string("string"),
+            "description": .string(description)
+        ]
+        if let enumValues {
+            schema["enum"] = .array(enumValues.map { .string($0) })
+        }
+        return .object(schema)
+    }
+
+    static func integer(_ description: String, minimum: Int? = nil, maximum: Int? = nil) -> MCPJSON {
+        var schema: [String: MCPJSON] = [
+            "type": .string("integer"),
+            "description": .string(description)
+        ]
+        if let minimum { schema["minimum"] = .int(Int64(minimum)) }
+        if let maximum { schema["maximum"] = .int(Int64(maximum)) }
+        return .object(schema)
+    }
+
+    static func boolean(_ description: String) -> MCPJSON {
+        .object([
+            "type": .string("boolean"),
+            "description": .string(description)
+        ])
+    }
+
+    // MARK: - Shared vocabularies
+
+    public static var toolValues: [String] { ToolType.allCases.map(\.rawValue) }
+    public static var harnessValues: [String] { Harness.allCases.map(\.rawValue) }
+    public static var sessionProviderValues: [String] { SessionProvider.allCases.map(\.rawValue) }
+
+    private static var toolFilter: MCPJSON {
+        stringEnumList(
+            toolValues,
+            description: "Quota-axis providers to keep. Omit for all of them."
+        )
+    }
+
+    private static var harnessFilter: MCPJSON {
+        stringEnumList(
+            harnessValues,
+            description: "Local harnesses (the CLI or app that produced the requests) to keep. "
+                + "Orthogonal to 'tools': Claude Code and Claude Cowork both bill against the 'claude' quota."
+        )
+    }
+
+    private static var rangeProperties: [String: MCPJSON] {
+        [
+            "from": string("Inclusive ISO-8601 start of the window. Overrides 'days' when both are given."),
+            "to": string("Exclusive ISO-8601 end of the window. Defaults to now."),
+            "days": integer(
+                "Window length in days ending now, used when 'from' is absent. Defaults to 30.",
+                minimum: 1,
+                maximum: 3_650
+            ),
+            "tools": toolFilter,
+            "harnesses": harnessFilter,
+            "models": .object([
+                "type": .string("array"),
+                "description": .string(
+                    "Raw vendor model ids to keep, exactly as the provider spelled them "
+                        + "(for example 'claude-opus-4-7', not 'Opus')."
+                ),
+                "items": .object(["type": .string("string")])
+            ])
+        ]
+    }
+
+    // MARK: - Tools
+
+    public static let quotaGet = MCPTool(
+        name: "quota.get",
+        title: "Read subscription quota",
+        description: """
+            Live subscription quota per account, straight from Vibe Bar's cache — no network call. \
+            This is the quota axis: L1 company (OpenAI, Anthropic, Google AI, SpaceXAI), L2 SubProvider \
+            (ChatGPT Agentic, Claude, Gemini Web, AntiGravity, Grok, Cursor), L3 buckets ('5 Hours', \
+            'Weekly', per-model groups). Answers 'how much Codex / Claude / Gemini / Grok / Cursor do I \
+            have left'. Percentages come back both used and remaining. 'lastUpdated' is when the numbers \
+            were fetched; 'lastAttempted' is when a refresh last ran, successful or not — quote \
+            'generatedAt' when reporting. For tokens spent or money, use usage.summary or cost.snapshot \
+            instead: those speak harnesses, not quota.
+            """,
+        inputSchema: object(properties: [
+            "tools": toolFilter,
+            "includeForecast": boolean(
+                "Include Vibe Bar's pace forecast per bucket (projected use at reset, run-out time). Default false."
+            )
+        ])
+    )
+
+    public static let quotaRefresh = MCPTool(
+        name: "quota.refresh",
+        title: "Refresh subscription quota",
+        description: """
+            Ask the running app to re-fetch quota from the providers. Returns as soon as the refresh is \
+            queued — call quota.get afterwards to read the result. Without 'force' this only refreshes \
+            accounts whose cache is actually stale, which is almost always what you want. 'force: true' \
+            refreshes regardless and is rate-limited to once per 20 seconds per server; it also requires \
+            the 'Allow agents to refresh' toggle in Vibe Bar's MCP settings. Do not poll: quota moves on \
+            the provider's clock, not yours.
+            """,
+        inputSchema: object(properties: [
+            "tools": toolFilter,
+            "force": boolean("Refresh even when the cache is fresh. Default false.")
+        ])
+    )
+
+    public static let usageSummary = MCPTool(
+        name: "usage.summary",
+        title: "Summarize token usage and spend",
+        description: """
+            Headline requests, tokens and cost over a window, from the local per-request usage ledger. \
+            This is the usage/cost axis: rows are attributed to the local harness that produced them \
+            (Codex, ChatGPT Work, Claude Code, Claude Cowork, Gemini CLI, AntiGravity, Grok Build, \
+            Cursor). Use groupBy 'harness' for 'who used the most', 'provider' for company-level totals, \
+            'model' for a per-model ranking. Token columns never overlap, so freshInput + output + \
+            cacheRead + cacheCreation is the real total. Cost is exact in 'costMicros' (micro-USD) and \
+            rounded in 'costUSD'; a non-zero 'unpricedRequests' means the total is a floor.
+            """,
+        inputSchema: object(properties: rangeProperties.merging([
+            "groupBy": string(
+                "Break the window down by 'harness' (the CLI or app), 'provider' (L1 company) or 'model'.",
+                enumValues: ["harness", "provider", "model"]
+            )
+        ]) { _, new in new })
+    )
+
+    public static let usageTrend = MCPTool(
+        name: "usage.trend",
+        title: "Token usage over time",
+        description: """
+            A zero-filled time series of tokens and cost over the same window and filters as \
+            usage.summary — every bucket is present, including the empty ones. Hourly buckets only \
+            exist inside the ledger's detail window (the last 30 days); an hourly request over an older \
+            range resolves down to daily, and the response says which bucket was actually used.
+            """,
+        inputSchema: object(properties: rangeProperties.merging([
+            "bucket": string(
+                "Bucket size. Omit to let the ledger pick from the range.",
+                enumValues: UsageTrendBucket.allCases.map(\.rawValue)
+            )
+        ]) { _, new in new })
+    )
+
+    public static let usageRequests = MCPTool(
+        name: "usage.requests",
+        title: "List individual requests",
+        description: """
+            The per-request log, newest first, over the same window and filters as usage.summary. \
+            Only the ledger's detail window (about the last 30 days) has request-level rows; older \
+            history survives as daily totals and is visible through usage.summary and usage.trend only. \
+            Page by passing the previous response's 'nextCursor' back as 'cursor' — the cursor is opaque, \
+            do not construct or edit one.
+            """,
+        inputSchema: object(properties: rangeProperties.merging([
+            "cursor": string("Opaque 'nextCursor' from a previous page. Omit for the first page."),
+            "pageSize": integer("Rows per page, 1–200. Default 50.", minimum: 1, maximum: 200)
+        ]) { _, new in new })
+    )
+
+    public static let costSnapshot = MCPTool(
+        name: "cost.snapshot",
+        title: "Cost and token totals per provider",
+        description: """
+            Today / last 7 days / last 30 days / all-time cost, tokens and request counts per provider, \
+            from Vibe Bar's last cost scan. Cheaper than usage.summary and already aggregated, so prefer \
+            it for 'what have I spent'. When 'privacyModeEnabled' is true every window is empty by \
+            design — say so rather than reporting zero spend.
+            """,
+        inputSchema: object(properties: ["tools": toolFilter])
+    )
+
+    public static let costHistory = MCPTool(
+        name: "cost.history",
+        title: "Daily cost history for one provider",
+        description: """
+            Day-by-day cost and token totals for a single provider. Use it for 'how has my spend moved \
+            this month'; use cost.snapshot for the current totals.
+            """,
+        inputSchema: object(
+            properties: [
+                "tool": string("Provider to report on.", enumValues: toolValues),
+                "timeframe": string(
+                    "How far back to go. Default '30d'.",
+                    enumValues: ["7d", "30d", "all"]
+                )
+            ],
+            required: ["tool"]
+        )
+    )
+
+    public static let sessionsSearch = MCPTool(
+        name: "sessions.search",
+        title: "Full-text search local agent sessions",
+        description: """
+            Search titles, projects and message bodies across every local CLI session Vibe Bar has \
+            indexed. Answers 'find my session about X'. Results carry the matching excerpt with <b> \
+            markers around the hit, plus the on-disk path so the transcript can be opened. Body search \
+            needs Vibe Bar's session body indexing enabled; with it off, titles and projects still match. \
+            Rows are labelled with the harness (the usage axis), not the quota SubProvider.
+            """,
+        inputSchema: object(
+            properties: [
+                "query": string("Text to look for. Substring matching, so partial words and CJK both work."),
+                "harnesses": harnessFilter,
+                "providers": stringEnumList(
+                    sessionProviderValues,
+                    description: "On-disk session stores to search. Prefer 'harnesses' unless you specifically want a store."
+                ),
+                "limit": integer("Maximum hits, 1–50. Default 20.", minimum: 1, maximum: 50)
+            ],
+            required: ["query"]
+        )
+    )
+
+    public static let sessionsList = MCPTool(
+        name: "sessions.list",
+        title: "List local agent sessions",
+        description: """
+            Recent local CLI sessions, newest first, with title, project directory, model, message count \
+            and on-disk path. Use sessions.search when you know what the session was about. Rows are \
+            labelled with the harness (the usage axis).
+            """,
+        inputSchema: object(properties: [
+            "harnesses": harnessFilter,
+            "providers": stringEnumList(
+                sessionProviderValues,
+                description: "On-disk session stores to list. Prefer 'harnesses' unless you specifically want a store."
+            ),
+            "since": string("Only sessions last active at or after this ISO-8601 instant."),
+            "offset": integer("Rows to skip, for paging. Default 0.", minimum: 0),
+            "limit": integer("Rows to return, 1–100. Default 50.", minimum: 1, maximum: 100)
+        ])
+    )
+
+    public static let statusGet = MCPTool(
+        name: "status.get",
+        title: "Provider service status",
+        description: """
+            Each provider company's own status page, as Vibe Bar last read it: indicator \
+            (none / minor / major / critical / maintenance) plus the page's own description. Rows are at \
+            the L1 company level — Google AI covers Gemini and AntiGravity, SpaceXAI covers Grok and \
+            Cursor. Useful when a provider looks broken and you want to know whether it is them or the \
+            local setup.
+            """,
+        inputSchema: object(properties: ["tools": toolFilter])
+    )
+
+    public static let pricingEffective = MCPTool(
+        name: "pricing.effective",
+        title: "Effective model prices",
+        description: """
+            The rate card Vibe Bar is actually costing requests with, including any local overrides — \
+            USD per one million tokens, per model. Use it to explain a cost number or to check whether a \
+            model is priced at all (an unpriced model contributes 0 to every cost total).
+            """,
+        inputSchema: object(properties: [
+            "provider": string(
+                "Pricing family to keep.",
+                enumValues: PricingProviderFamily.allCases.map(\.rawValue)
+            ),
+            "model": string("Case-insensitive substring of the model id.")
+        ])
+    )
+}

--- a/Sources/VibeBarCore/Models/AppSettings.swift
+++ b/Sources/VibeBarCore/Models/AppSettings.swift
@@ -103,6 +103,10 @@ public struct AppSettings: Codable, Equatable, Sendable {
     /// `~/.vibebar/skills.json` next to the registry it describes.
     public var skillsSyncMethod: SkillSyncMethod
 
+    /// The local MCP server: whether it listens, and whether agents reaching it
+    /// may ask for a quota refresh.
+    public var mcpServer: MCPServerSettings
+
     /// Curves the user switched **off** in the Overview's all-providers quota
     /// history chart, as `"<tool>|<accountId>|<bucketId>"`.
     ///
@@ -297,7 +301,8 @@ public struct AppSettings: Codable, Equatable, Sendable {
         menuBarColorBasis: MenuBarColorBasis = .forecast,
         preferredTerminal: PreferredTerminal = .terminal,
         sessionBodyIndexingEnabled: Bool = true,
-        skillsSyncMethod: SkillSyncMethod = .auto
+        skillsSyncMethod: SkillSyncMethod = .auto,
+        mcpServer: MCPServerSettings = .default
     ) {
         self.displayMode = displayMode
         self.refreshIntervalSeconds = refreshIntervalSeconds
@@ -344,6 +349,7 @@ public struct AppSettings: Codable, Equatable, Sendable {
         self.preferredTerminal = preferredTerminal
         self.sessionBodyIndexingEnabled = sessionBodyIndexingEnabled
         self.skillsSyncMethod = skillsSyncMethod
+        self.mcpServer = mcpServer
     }
 
     /// Drops unnamed presets, collapses names that differ only by case (the
@@ -404,6 +410,7 @@ public struct AppSettings: Codable, Equatable, Sendable {
         case preferredTerminal
         case sessionBodyIndexingEnabled
         case skillsSyncMethod
+        case mcpServer
     }
 
     public init(from decoder: Decoder) throws {
@@ -584,6 +591,12 @@ public struct AppSettings: Codable, Equatable, Sendable {
         self.skillsSyncMethod =
             (try? c.decodeIfPresent(SkillSyncMethod.self, forKey: .skillsSyncMethod))
             ?? Self.default.skillsSyncMethod
+        // A settings file written before the MCP server existed enables it,
+        // which is the point: the one-line client setup only works if the
+        // socket is already there when the agent first looks.
+        self.mcpServer =
+            (try? c.decodeIfPresent(MCPServerSettings.self, forKey: .mcpServer))
+            ?? Self.default.mcpServer
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -635,6 +648,7 @@ public struct AppSettings: Codable, Equatable, Sendable {
         try c.encode(preferredTerminal, forKey: .preferredTerminal)
         try c.encode(sessionBodyIndexingEnabled, forKey: .sessionBodyIndexingEnabled)
         try c.encode(skillsSyncMethod, forKey: .skillsSyncMethod)
+        try c.encode(mcpServer, forKey: .mcpServer)
     }
 
     public func menuBarItem(_ kind: MenuBarItemKind) -> MenuBarItemSettings {
@@ -1319,5 +1333,48 @@ public struct CostDataSettings: Codable, Equatable, Sendable {
 
     public static func isUnlimitedRetention(_ days: Int) -> Bool {
         normalizedRetentionDays(days) == unlimitedRetentionDays
+    }
+}
+
+/// The local MCP server's two switches.
+///
+/// Both default to **on**, which is a deliberate choice rather than an
+/// oversight. The whole point of the feature is that configuring a client is
+/// one line and needs no trip through Settings first, and the exposure is
+/// bounded by what the socket already is: a 0600 file inside a 0700 directory,
+/// reachable only by processes already running as this user, never bound to a
+/// network interface, and present only while the app is running. Turning
+/// `enabled` off removes the socket immediately.
+public struct MCPServerSettings: Codable, Equatable, Sendable {
+    public static let `default` = MCPServerSettings()
+
+    /// Whether the app listens on `~/.vibebar/mcp.sock` at all.
+    public var enabled: Bool
+    /// Whether `quota.refresh` may actually trigger a provider fetch. With it
+    /// off the tool still answers — it reports that refreshing is disabled —
+    /// so an agent learns the numbers are cached instead of silently believing
+    /// it just refreshed them.
+    public var allowRefreshTools: Bool
+
+    public init(enabled: Bool = true, allowRefreshTools: Bool = true) {
+        self.enabled = enabled
+        self.allowRefreshTools = allowRefreshTools
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case enabled, allowRefreshTools
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        self.enabled = try c.decodeIfPresent(Bool.self, forKey: .enabled) ?? Self.default.enabled
+        self.allowRefreshTools =
+            try c.decodeIfPresent(Bool.self, forKey: .allowRefreshTools) ?? Self.default.allowRefreshTools
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        try c.encode(enabled, forKey: .enabled)
+        try c.encode(allowRefreshTools, forKey: .allowRefreshTools)
     }
 }

--- a/Tests/VibeBarCoreTests/MCPDTOEncodingTests.swift
+++ b/Tests/VibeBarCoreTests/MCPDTOEncodingTests.swift
@@ -1,0 +1,161 @@
+import XCTest
+@testable import VibeBarCore
+
+/// Pins the wire shape.
+///
+/// Agents and their prompts get written against these key names, so a rename
+/// is a breaking change even though nothing in Swift would notice. The
+/// convention is **camelCase everywhere**, dates are ISO-8601 with a `Z`, and
+/// money appears twice — exact micros plus a rounded USD figure.
+final class MCPDTOEncodingTests: XCTestCase {
+    private func keys(_ value: some Encodable) throws -> Set<String> {
+        let json = try MCPJSON.encoding(value)
+        return Set(try XCTUnwrap(json.objectValue).keys)
+    }
+
+    private func encoded(_ value: some Encodable) throws -> MCPJSON {
+        try MCPJSON.encoding(value)
+    }
+
+    func testDatesEncodeAsISO8601WithZ() throws {
+        let json = try encoded(MCPRangeDTO(
+            from: FakeMCPDataSource.epoch,
+            to: FakeMCPDataSource.epoch.addingTimeInterval(3_661)
+        ))
+        XCTAssertEqual(json["from"]?.stringValue, "2026-01-01T00:00:00Z")
+        XCTAssertEqual(json["to"]?.stringValue, "2026-01-01T01:01:01Z")
+    }
+
+    func testEveryKeyIsCamelCase() throws {
+        let samples: [Set<String>] = [
+            try keys(MCPQuotaAccountDTO(
+                quota: FakeMCPDataSource.claudeQuota,
+                lastUpdated: nil,
+                lastAttempted: nil,
+                inFlight: false,
+                error: nil
+            )),
+            try keys(MCPQuotaBucketDTO(
+                bucket: FakeMCPDataSource.claudeQuota.buckets[0],
+                forecast: nil
+            )),
+            try keys(MCPUsageRequestRowDTO(row: UsageRequestRow(
+                id: 1,
+                date: FakeMCPDataSource.epoch,
+                tool: .claude,
+                harness: .claudeCode,
+                model: "m",
+                freshInput: 1,
+                output: 2,
+                cacheRead: 3,
+                cacheCreation: 4,
+                costMicros: 5,
+                serviceTier: nil,
+                sessionId: nil,
+                sourceKey: nil
+            ))),
+            try keys(MCPCostToolSnapshotDTO(snapshot: FakeMCPDataSource.costSnapshot(for: .claude))),
+            try keys(MCPSessionSummaryDTO(summary: FakeMCPDataSource.sessionSummary))
+        ]
+        for keys in samples {
+            for key in keys {
+                XCTAssertFalse(key.contains("_"), "'\(key)' is snake_case; the wire shape is camelCase.")
+                XCTAssertEqual(
+                    key.first.map { String($0) },
+                    key.first.map { String($0).lowercased() },
+                    "'\(key)' should start lower-case."
+                )
+            }
+        }
+    }
+
+    func testQuotaAccountKeysArePinned() throws {
+        XCTAssertEqual(
+            try keys(MCPQuotaAccountDTO(
+                quota: FakeMCPDataSource.claudeQuota,
+                lastUpdated: FakeMCPDataSource.epoch,
+                lastAttempted: FakeMCPDataSource.epoch,
+                inFlight: true,
+                error: nil
+            )),
+            [
+                "accountId", "tool", "company", "subProvider", "plan", "email",
+                "buckets", "queriedAt", "lastUpdated", "lastAttempted", "inFlight"
+            ]
+        )
+    }
+
+    func testQuotaBucketKeysArePinned() throws {
+        XCTAssertEqual(
+            try keys(MCPQuotaBucketDTO(bucket: FakeMCPDataSource.claudeQuota.buckets[0], forecast: nil)),
+            ["id", "title", "shortLabel", "groupTitle", "usedPercent", "remainingPercent", "resetAt", "windowSeconds"]
+        )
+    }
+
+    /// `nil` fields are omitted rather than encoded as `null`, so an agent can
+    /// test for presence instead of for two kinds of absence.
+    func testAbsentOptionalsAreOmitted() throws {
+        let json = try encoded(MCPQuotaAccountDTO(
+            quota: FakeMCPDataSource.codexQuota,
+            lastUpdated: nil,
+            lastAttempted: nil,
+            inFlight: false,
+            error: nil
+        ))
+        let fields = try XCTUnwrap(json.objectValue)
+        XCTAssertNil(fields["email"], "codex has no email in the fixture.")
+        XCTAssertNil(fields["lastUpdated"])
+        XCTAssertNil(fields["error"])
+        XCTAssertNotNil(fields["plan"])
+    }
+
+    func testMoneyIsReportedInBothUnits() throws {
+        let json = try encoded(MCPUsageGroupRowDTO(
+            key: "claudeCode",
+            label: "Claude Code",
+            company: "Anthropic",
+            requests: 1,
+            totalTokens: 2,
+            costMicros: 1_234_567
+        ))
+        XCTAssertEqual(json["costMicros"]?.intValue, 1_234_567)
+        XCTAssertEqual(json["costUSD"]?.doubleValue, 1.23)
+    }
+
+    func testMicrosRoundHalfUpAndSurviveNegatives() {
+        XCTAssertEqual(MCPMoney.usd(0), 0)
+        XCTAssertEqual(MCPMoney.usd(5_000), 0.01)
+        XCTAssertEqual(MCPMoney.usd(4_999), 0.0)
+        XCTAssertEqual(MCPMoney.usd(-1_500_000), -1.5)
+    }
+
+    /// A session summary that never learned its message count reports the
+    /// field as absent, not as the internal `-1` sentinel.
+    func testUnknownMessageCountIsOmittedRatherThanNegative() throws {
+        let summary = SessionSummary(
+            provider: .cursor,
+            sessionID: "x",
+            sourcePath: "/Users/example/.cursor/chats/x/store.db"
+        )
+        let json = try encoded(MCPSessionSummaryDTO(summary: summary))
+        XCTAssertNil(json.objectValue?["messageCount"])
+        XCTAssertEqual(json["harness"]?.stringValue, "cursor")
+    }
+
+    func testCursorEncodingIsOpaqueAndRoundTrips() {
+        let cursor = UsageRequestCursor(ts: 1_767_225_600, id: 42)
+        let encoded = MCPCursorCoding.encode(cursor)
+        XCTAssertFalse(encoded.contains("1767225600"), "The cursor should not read as editable numbers.")
+        XCTAssertEqual(MCPCursorCoding.decode(encoded), cursor)
+        XCTAssertNil(MCPCursorCoding.decode("not-a-cursor"))
+        XCTAssertNil(MCPCursorCoding.decode(Data("12".utf8).base64EncodedString()))
+    }
+
+    func testJSONValueKeepsIntegersIntegral() throws {
+        let json = try JSONDecoder().decode(MCPJSON.self, from: Data(#"{"n":1,"d":1.5}"#.utf8))
+        XCTAssertEqual(json["n"], .int(1))
+        XCTAssertEqual(json["d"], .double(1.5))
+        let text = String(decoding: try json.serialized(), as: UTF8.self)
+        XCTAssertTrue(text.contains("\"n\":1"), text)
+    }
+}

--- a/Tests/VibeBarCoreTests/MCPFixtures.swift
+++ b/Tests/VibeBarCoreTests/MCPFixtures.swift
@@ -1,0 +1,410 @@
+import Foundation
+@testable import VibeBarCore
+
+/// A deterministic `MCPDataSource`.
+///
+/// Everything is a fixed value: no home directory, no ledger, no network, no
+/// clock. That is what lets the tool tests assert on exact JSON — the point of
+/// the `MCPDataSource` seam is that the whole MCP surface can be exercised
+/// without a running app.
+final class FakeMCPDataSource: MCPDataSource, @unchecked Sendable {
+    /// 2026-01-01T00:00:00Z.
+    static let epoch = Date(timeIntervalSince1970: 1_767_225_600)
+
+    // Recorded calls, so a test can assert what the server passed down.
+    private(set) var lastUsageFilter: UsageQueryFilter?
+    private(set) var lastTrendBucket: UsageTrendBucket?
+    private(set) var lastRequestCursor: UsageRequestCursor?
+    private(set) var lastRequestPageSize: Int?
+    private(set) var lastSessionQuery: String?
+    private(set) var lastSessionLimit: Int?
+    private(set) var refreshCalls: [(tools: [ToolType]?, force: Bool)] = []
+
+    /// Flip to make every ledger-backed tool report the "no ledger" failure.
+    var ledgerAvailable = true
+    /// What `refreshQuota` claims happened.
+    var refreshTriggered = true
+
+    // MARK: Identity
+
+    func serverInfo() async -> MCPServerInfo {
+        MCPServerInfo(name: "vibebar", version: "9.9.9 (42)")
+    }
+
+    // MARK: Quota
+
+    static let claudeQuota = AccountQuota(
+        accountId: "anthropic-primary",
+        tool: .claude,
+        buckets: [
+            QuotaBucket(
+                id: "five_hour",
+                title: "All Models",
+                shortLabel: "5h",
+                usedPercent: 42.5,
+                resetAt: epoch.addingTimeInterval(3_600),
+                rawWindowSeconds: 18_000,
+                groupTitle: "All Models"
+            ),
+            QuotaBucket(
+                id: "weekly",
+                title: "Weekly",
+                shortLabel: "wk",
+                usedPercent: 12,
+                resetAt: epoch.addingTimeInterval(86_400),
+                rawWindowSeconds: 604_800
+            )
+        ],
+        plan: "Max",
+        email: "someone@example.com",
+        queriedAt: epoch
+    )
+
+    static let codexQuota = AccountQuota(
+        accountId: "openai-primary",
+        tool: .codex,
+        buckets: [
+            QuotaBucket(
+                id: "five_hour",
+                title: "All Models",
+                shortLabel: "5h",
+                usedPercent: 7,
+                resetAt: epoch.addingTimeInterval(1_800),
+                rawWindowSeconds: 18_000
+            )
+        ],
+        plan: "Pro",
+        email: nil,
+        queriedAt: epoch
+    )
+
+    func quotaAccounts(tools: [ToolType]?, includeForecast: Bool) async throws -> [MCPQuotaAccountDTO] {
+        let wanted = tools.map(Set.init)
+        return [Self.claudeQuota, Self.codexQuota]
+            .filter { wanted?.contains($0.tool) ?? true }
+            .map { quota in
+                MCPQuotaAccountDTO(
+                    quota: quota,
+                    lastUpdated: Self.epoch,
+                    lastAttempted: Self.epoch.addingTimeInterval(60),
+                    inFlight: false,
+                    error: nil,
+                    forecastsByBucketID: [:]
+                )
+            }
+    }
+
+    func refreshQuota(tools: [ToolType]?, force: Bool) async throws -> MCPRefreshResultDTO {
+        refreshCalls.append((tools, force))
+        return MCPRefreshResultDTO(
+            triggered: refreshTriggered,
+            mode: force ? "forced" : "stale-only",
+            message: force ? "Refreshing everything." : "Refreshing what was stale."
+        )
+    }
+
+    // MARK: Usage
+
+    private func requireLedger() throws {
+        guard ledgerAvailable else { throw MCPToolFailure("The usage ledger is unavailable.") }
+    }
+
+    func usageSummary(_ filter: UsageQueryFilter) async throws -> UsageSummaryMetrics {
+        try requireLedger()
+        lastUsageFilter = filter
+        return UsageSummaryMetrics(
+            requests: 120,
+            unpricedRequests: 3,
+            costMicros: 4_560_000,
+            freshInput: 1_000,
+            output: 2_000,
+            cacheRead: 3_000,
+            cacheCreation: 4_000
+        )
+    }
+
+    func usageGroupRows(
+        _ filter: UsageQueryFilter,
+        groupBy: MCPUsageGrouping
+    ) async throws -> [MCPUsageGroupRowDTO] {
+        try requireLedger()
+        lastUsageFilter = filter
+        switch groupBy {
+        case .harness:
+            return [
+                MCPUsageGroupRowDTO(
+                    key: Harness.claudeCode.rawValue,
+                    label: Harness.claudeCode.displayName,
+                    company: Harness.claudeCode.companyName,
+                    requests: 90,
+                    totalTokens: 9_000,
+                    costMicros: 3_000_000
+                )
+            ]
+        case .provider:
+            return [
+                MCPUsageGroupRowDTO(
+                    key: ToolType.claude.rawValue,
+                    label: ToolType.claude.vendorName,
+                    company: ToolType.claude.vendorName,
+                    requests: 90,
+                    totalTokens: 9_000,
+                    costMicros: 3_000_000
+                )
+            ]
+        case .model:
+            return [
+                MCPUsageGroupRowDTO(
+                    key: "claude-opus-4-7",
+                    label: "claude-opus-4-7",
+                    company: nil,
+                    requests: 90,
+                    totalTokens: 9_000,
+                    costMicros: 3_000_000
+                )
+            ]
+        }
+    }
+
+    func usageTrend(_ filter: UsageQueryFilter, bucket: UsageTrendBucket?) async throws -> UsageTrendSeries {
+        try requireLedger()
+        lastUsageFilter = filter
+        lastTrendBucket = bucket
+        return UsageTrendSeries(
+            bucket: bucket ?? .day,
+            points: [
+                UsageTrendPoint(
+                    bucketStart: Self.epoch,
+                    freshInput: 10,
+                    output: 20,
+                    cacheRead: 30,
+                    cacheCreation: 40,
+                    costMicros: 1_500_000
+                )
+            ]
+        )
+    }
+
+    func usageRequests(
+        _ filter: UsageQueryFilter,
+        after cursor: UsageRequestCursor?,
+        pageSize: Int
+    ) async throws -> UsageRequestPage {
+        try requireLedger()
+        lastUsageFilter = filter
+        lastRequestCursor = cursor
+        lastRequestPageSize = pageSize
+        return UsageRequestPage(
+            rows: [
+                UsageRequestRow(
+                    id: 7,
+                    date: Self.epoch,
+                    tool: .claude,
+                    harness: .claudeCode,
+                    model: "claude-opus-4-7",
+                    freshInput: 10,
+                    output: 20,
+                    cacheRead: 30,
+                    cacheCreation: 40,
+                    costMicros: 250_000,
+                    serviceTier: "standard",
+                    sessionId: "session-1",
+                    sourceKey: "source-key"
+                )
+            ],
+            totalCount: 1,
+            pageSize: pageSize,
+            cursor: cursor,
+            nextCursor: UsageRequestCursor(ts: 1_767_225_600, id: 7)
+        )
+    }
+
+    // MARK: Cost
+
+    func costSnapshots(tools: [ToolType]?) async throws -> MCPCostSnapshotsDTO {
+        let wanted = tools.map(Set.init)
+        let rows = [ToolType.claude, ToolType.codex]
+            .filter { wanted?.contains($0) ?? true }
+            .map { tool in
+                MCPCostToolSnapshotDTO(snapshot: Self.costSnapshot(for: tool))
+            }
+        return MCPCostSnapshotsDTO(
+            generatedAt: Self.epoch,
+            privacyModeEnabled: false,
+            tools: rows
+        )
+    }
+
+    static func costSnapshot(for tool: ToolType) -> CostSnapshot {
+        CostSnapshot(
+            tool: tool,
+            todayCostUSD: 1.25,
+            last7DaysCostUSD: 8.5,
+            last30DaysCostUSD: 30.75,
+            allTimeCostUSD: 120.5,
+            todayTokens: 100,
+            last7DaysTokens: 700,
+            last30DaysTokens: 3_000,
+            allTimeTokens: 12_000,
+            todayRequests: 4,
+            last7DaysRequests: 28,
+            last30DaysRequests: 120,
+            allTimeRequests: 480,
+            dailyHistory: [],
+            heatmap: UsageHeatmap(tool: tool, cells: [], totalTokens: 0),
+            modelBreakdowns: [],
+            jsonlFilesFound: 3,
+            updatedAt: epoch
+        )
+    }
+
+    func costHistory(tool: ToolType, timeframe: MCPCostHistoryTimeframe) async throws -> CostHistory {
+        CostHistory(
+            tool: tool,
+            days: [DailyCostPoint(date: Self.epoch, costUSD: 1.25, totalTokens: 100)],
+            updatedAt: Self.epoch
+        )
+    }
+
+    // MARK: Sessions
+
+    static let sessionSummary = SessionSummary(
+        provider: .claude,
+        sessionID: "abc-123",
+        harness: .claudeCode,
+        model: "claude-opus-4-7",
+        title: "Refactor the socket server",
+        summary: nil,
+        projectDir: "/Users/example/Code/demo",
+        createdAt: epoch,
+        lastActiveAt: epoch.addingTimeInterval(600),
+        sourcePath: "/Users/example/.claude/projects/demo/abc-123.jsonl",
+        sizeBytes: 4_096,
+        messageCount: 12
+    )
+
+    func searchSessions(
+        query: String,
+        providers: [SessionProvider]?,
+        harnesses: [Harness]?,
+        limit: Int
+    ) async throws -> [SessionSearchHit] {
+        lastSessionQuery = query
+        lastSessionLimit = limit
+        return [
+            SessionSearchHit(
+                summary: Self.sessionSummary,
+                snippet: "the <b>socket</b> server",
+                matchedSeq: 4
+            )
+        ]
+    }
+
+    func listSessions(
+        providers: [SessionProvider]?,
+        harnesses: [Harness]?,
+        since: Date?,
+        offset: Int,
+        limit: Int
+    ) async throws -> SessionSummaryPage {
+        SessionSummaryPage(
+            summaries: [Self.sessionSummary],
+            totalCount: 1,
+            offset: offset,
+            limit: limit
+        )
+    }
+
+    // MARK: Status and pricing
+
+    func serviceStatus(tools: [ToolType]?) async throws -> MCPServiceStatusDTO {
+        let wanted = tools.map { Set($0.compactMap { $0.coreProviderRepresentative }) }
+        let rows = ToolType.combinedStatusPageProviders
+            .filter { wanted?.contains($0) ?? true }
+            .map { tool in
+                MCPServiceStatusRowDTO(
+                    tool: tool.rawValue,
+                    company: tool.vendorName,
+                    indicator: "none",
+                    description: "All Systems Operational",
+                    updatedAt: Self.epoch,
+                    isRefreshing: false,
+                    error: nil
+                )
+            }
+        return MCPServiceStatusDTO(generatedAt: Self.epoch, lastFetched: Self.epoch, companies: rows)
+    }
+
+    func effectivePricing() async throws -> [EffectiveModelPricingRow] {
+        [
+            EffectiveModelPricingRow(
+                provider: .claude,
+                model: "claude-opus-4-7",
+                inputPerMillion: 15,
+                outputPerMillion: 75,
+                cacheReadPerMillion: 1.5,
+                cacheWritePerMillion: 18.75
+            ),
+            EffectiveModelPricingRow(
+                provider: .codex,
+                model: "gpt-5-codex",
+                inputPerMillion: 1.25,
+                outputPerMillion: 10
+            )
+        ]
+    }
+}
+
+// MARK: - Helpers shared by the MCP tests
+
+enum MCPTestSupport {
+    /// Build one framed request line.
+    static func line(id: Int?, method: String, params: MCPJSON? = nil) -> Data {
+        var fields: [String: MCPJSON] = [
+            "jsonrpc": .string("2.0"),
+            "method": .string(method)
+        ]
+        if let id { fields["id"] = .int(Int64(id)) }
+        if let params { fields["params"] = params }
+        return (try? MCPJSON.object(fields).serialized()) ?? Data()
+    }
+
+    static func call(id: Int, tool: String, arguments: MCPJSON = .object([:])) -> Data {
+        line(
+            id: id,
+            method: "tools/call",
+            params: .object(["name": .string(tool), "arguments": arguments])
+        )
+    }
+
+    static func decode(_ data: Data?) throws -> MCPJSON {
+        let data = try XCTUnwrapData(data)
+        return try JSONDecoder().decode(MCPJSON.self, from: data)
+    }
+
+    /// The tool result's `structuredContent`, or a readable failure.
+    static func structured(_ response: MCPJSON) throws -> MCPJSON {
+        guard let structured = response["result"]?["structuredContent"] else {
+            throw MCPTestError("No structuredContent in \(response)")
+        }
+        return structured
+    }
+
+    static func isError(_ response: MCPJSON) -> Bool {
+        response["result"]?["isError"]?.boolValue ?? false
+    }
+
+    static func errorText(_ response: MCPJSON) -> String? {
+        response["result"]?["content"]?.arrayValue?.first?["text"]?.stringValue
+    }
+
+    private static func XCTUnwrapData(_ data: Data?) throws -> Data {
+        guard let data else { throw MCPTestError("Expected a response, got none.") }
+        return data
+    }
+}
+
+struct MCPTestError: Error, CustomStringConvertible {
+    let description: String
+    init(_ description: String) { self.description = description }
+}

--- a/Tests/VibeBarCoreTests/MCPJSONRPCTests.swift
+++ b/Tests/VibeBarCoreTests/MCPJSONRPCTests.swift
@@ -1,0 +1,194 @@
+import XCTest
+@testable import VibeBarCore
+
+/// Protocol-level behaviour: framing, dispatch, and the error codes a client
+/// distinguishes on.
+final class MCPJSONRPCTests: XCTestCase {
+    private func makeServer() -> (MCPServer, FakeMCPDataSource) {
+        let source = FakeMCPDataSource()
+        let server = MCPServer(dataSource: source, now: { FakeMCPDataSource.epoch })
+        return (server, source)
+    }
+
+    func testInitializeReportsProtocolVersionAndServerInfo() async throws {
+        let (server, _) = makeServer()
+        let response = try MCPTestSupport.decode(
+            await server.handle(line: MCPTestSupport.line(id: 1, method: "initialize"))
+        )
+        XCTAssertEqual(response["jsonrpc"]?.stringValue, "2.0")
+        XCTAssertEqual(response["id"]?.intValue, 1)
+        let result = try XCTUnwrap(response["result"])
+        XCTAssertEqual(result["protocolVersion"]?.stringValue, "2025-06-18")
+        XCTAssertEqual(result["serverInfo"]?["name"]?.stringValue, "vibebar")
+        XCTAssertEqual(result["serverInfo"]?["version"]?.stringValue, "9.9.9 (42)")
+        XCTAssertNotNil(result["capabilities"]?["tools"])
+        XCTAssertNotNil(result["capabilities"]?["resources"])
+    }
+
+    func testInitializedNotificationProducesNoOutput() async {
+        let (server, _) = makeServer()
+        let reply = await server.handle(
+            line: MCPTestSupport.line(id: nil, method: "notifications/initialized")
+        )
+        XCTAssertNil(reply, "A notification must never be answered.")
+    }
+
+    func testPingAnswersAnEmptyResult() async throws {
+        let (server, _) = makeServer()
+        let response = try MCPTestSupport.decode(
+            await server.handle(line: MCPTestSupport.line(id: 2, method: "ping"))
+        )
+        XCTAssertEqual(response["result"], .object([:]))
+    }
+
+    func testToolsListCarriesEveryToolWithASchema() async throws {
+        let (server, _) = makeServer()
+        let response = try MCPTestSupport.decode(
+            await server.handle(line: MCPTestSupport.line(id: 3, method: "tools/list"))
+        )
+        let tools = try XCTUnwrap(response["result"]?["tools"]?.arrayValue)
+        let names = tools.compactMap { $0["name"]?.stringValue }
+        XCTAssertEqual(
+            names.sorted(),
+            [
+                "cost.history", "cost.snapshot", "pricing.effective", "quota.get", "quota.refresh",
+                "sessions.list", "sessions.search", "status.get", "usage.requests", "usage.summary",
+                "usage.trend"
+            ]
+        )
+        for tool in tools {
+            XCTAssertEqual(tool["inputSchema"]?["type"]?.stringValue, "object", "\(tool)")
+            XCTAssertFalse(tool["description"]?.stringValue?.isEmpty ?? true, "\(tool)")
+        }
+    }
+
+    func testResourcesListAndRead() async throws {
+        let (server, _) = makeServer()
+        let list = try MCPTestSupport.decode(
+            await server.handle(line: MCPTestSupport.line(id: 4, method: "resources/list"))
+        )
+        let uris = try XCTUnwrap(list["result"]?["resources"]?.arrayValue)
+            .compactMap { $0["uri"]?.stringValue }
+        XCTAssertEqual(uris.sorted(), ["vibebar://naming-spec", "vibebar://tools"])
+
+        let read = try MCPTestSupport.decode(
+            await server.handle(
+                line: MCPTestSupport.line(
+                    id: 5,
+                    method: "resources/read",
+                    params: .object(["uri": .string("vibebar://naming-spec")])
+                )
+            )
+        )
+        let contents = try XCTUnwrap(read["result"]?["contents"]?.arrayValue?.first)
+        XCTAssertEqual(contents["mimeType"]?.stringValue, "text/markdown")
+        XCTAssertTrue(contents["text"]?.stringValue?.contains("two orthogonal axes") ?? false)
+    }
+
+    func testUnknownResourceIsInvalidParams() async throws {
+        let (server, _) = makeServer()
+        let response = try MCPTestSupport.decode(
+            await server.handle(
+                line: MCPTestSupport.line(
+                    id: 6,
+                    method: "resources/read",
+                    params: .object(["uri": .string("vibebar://nope")])
+                )
+            )
+        )
+        XCTAssertEqual(response["error"]?["code"]?.intValue, -32_602)
+    }
+
+    func testUnknownMethodIsMethodNotFound() async throws {
+        let (server, _) = makeServer()
+        let response = try MCPTestSupport.decode(
+            await server.handle(line: MCPTestSupport.line(id: 7, method: "sampling/createMessage"))
+        )
+        XCTAssertEqual(response["error"]?["code"]?.intValue, -32_601)
+        XCTAssertEqual(response["id"]?.intValue, 7)
+    }
+
+    func testMalformedJSONIsParseError() async throws {
+        let (server, _) = makeServer()
+        let response = try MCPTestSupport.decode(
+            await server.handle(line: Data("{ this is not json".utf8))
+        )
+        XCTAssertEqual(response["error"]?["code"]?.intValue, -32_700)
+        XCTAssertEqual(response["id"], .null)
+    }
+
+    func testJSONThatIsNotARequestIsInvalidRequest() async throws {
+        let (server, _) = makeServer()
+        let response = try MCPTestSupport.decode(
+            await server.handle(line: Data(#"{"jsonrpc":"2.0","id":9}"#.utf8))
+        )
+        XCTAssertEqual(response["error"]?["code"]?.intValue, -32_600)
+    }
+
+    func testWrongJSONRPCVersionIsRejected() async throws {
+        let (server, _) = makeServer()
+        let response = try MCPTestSupport.decode(
+            await server.handle(line: Data(#"{"jsonrpc":"1.0","id":9,"method":"ping"}"#.utf8))
+        )
+        XCTAssertEqual(response["error"]?["code"]?.intValue, -32_600)
+    }
+
+    func testUnknownToolIsInvalidParams() async throws {
+        let (server, _) = makeServer()
+        let response = try MCPTestSupport.decode(
+            await server.handle(line: MCPTestSupport.call(id: 10, tool: "quota.everything"))
+        )
+        XCTAssertEqual(response["error"]?["code"]?.intValue, -32_602)
+    }
+
+    func testUnknownArgumentIsRejectedRatherThanIgnored() async throws {
+        let (server, _) = makeServer()
+        let response = try MCPTestSupport.decode(
+            await server.handle(
+                line: MCPTestSupport.call(
+                    id: 11,
+                    tool: "quota.get",
+                    arguments: .object(["provider": .string("claude")])
+                )
+            )
+        )
+        XCTAssertEqual(response["error"]?["code"]?.intValue, -32_602)
+        XCTAssertTrue(response["error"]?["message"]?.stringValue?.contains("'provider'") ?? false)
+    }
+
+    func testBadEnumValueNamesTheAcceptedOnes() async throws {
+        let (server, _) = makeServer()
+        let response = try MCPTestSupport.decode(
+            await server.handle(
+                line: MCPTestSupport.call(
+                    id: 12,
+                    tool: "quota.get",
+                    arguments: .object(["tools": .array([.string("anthropic")])])
+                )
+            )
+        )
+        let message = try XCTUnwrap(response["error"]?["message"]?.stringValue)
+        XCTAssertTrue(message.contains("'anthropic'"))
+        XCTAssertTrue(message.contains("'claude'"))
+    }
+
+    /// A tool that ran and failed reports through `isError`, not through a
+    /// JSON-RPC error — the model has to be able to read the reason.
+    func testToolFailureIsAnIsErrorResultNotAnRPCError() async throws {
+        let (server, source) = makeServer()
+        source.ledgerAvailable = false
+        let response = try MCPTestSupport.decode(
+            await server.handle(line: MCPTestSupport.call(id: 13, tool: "usage.summary"))
+        )
+        XCTAssertNil(response["error"])
+        XCTAssertTrue(MCPTestSupport.isError(response))
+        XCTAssertTrue(MCPTestSupport.errorText(response)?.contains("usage ledger") ?? false)
+    }
+
+    func testResponseIDMirrorsAStringID() async throws {
+        let (server, _) = makeServer()
+        let line = Data(#"{"jsonrpc":"2.0","id":"abc","method":"ping"}"#.utf8)
+        let response = try MCPTestSupport.decode(await server.handle(line: line))
+        XCTAssertEqual(response["id"]?.stringValue, "abc")
+    }
+}

--- a/Tests/VibeBarCoreTests/MCPResourceCatalogTests.swift
+++ b/Tests/VibeBarCoreTests/MCPResourceCatalogTests.swift
@@ -1,0 +1,96 @@
+import XCTest
+@testable import VibeBarCore
+
+/// The naming spec is generated from the same catalogs the app renders from,
+/// so these assertions are what stops it silently going stale when a provider
+/// or a harness is added.
+final class MCPResourceCatalogTests: XCTestCase {
+    private let spec = MCPResourceCatalog.namingSpec
+
+    func testEveryHarnessAppearsByDisplayNameAndKey() {
+        for harness in Harness.allCases {
+            XCTAssertTrue(
+                spec.contains(harness.displayName),
+                "The naming spec never mentions the harness '\(harness.displayName)'."
+            )
+            XCTAssertTrue(
+                spec.contains("`\(harness.rawValue)`"),
+                "The naming spec never mentions the harness key '\(harness.rawValue)'."
+            )
+        }
+        XCTAssertEqual(Harness.allCases.count, 8, "A new harness needs a row in the evidence table.")
+    }
+
+    func testEveryL1CompanyAppears() {
+        let companies = Set(ToolType.coreProviderRepresentatives.map(\.vendorName))
+        XCTAssertEqual(companies, ["OpenAI", "Anthropic", "Google AI", "SpaceXAI"])
+        for company in companies {
+            XCTAssertTrue(spec.contains(company), "The naming spec never mentions '\(company)'.")
+        }
+    }
+
+    func testEveryDedicatedSubProviderAppears() {
+        for tool in ToolType.dedicatedCardProviders {
+            XCTAssertTrue(
+                spec.contains(tool.quotaSubProviderName()),
+                "The naming spec never mentions the SubProvider '\(tool.quotaSubProviderName())'."
+            )
+        }
+    }
+
+    func testEveryMiscProviderAppears() {
+        for tool in ToolType.miscPageProviders {
+            XCTAssertTrue(
+                spec.contains("`\(tool.rawValue)`"),
+                "The naming spec never mentions the misc provider key '\(tool.rawValue)'."
+            )
+        }
+    }
+
+    func testTheTwoAxisRuleAndModelRuleAreStated() {
+        XCTAssertTrue(spec.contains("two orthogonal axes"))
+        XCTAssertTrue(spec.contains("Quota axis"))
+        XCTAssertTrue(spec.contains("Usage / cost axis"))
+        XCTAssertTrue(spec.contains("canonical vendor id"))
+        XCTAssertTrue(spec.contains("Gemini Web"))
+    }
+
+    func testTheToolGuideRoutesEveryTool() {
+        let guide = MCPResourceCatalog.toolsGuide
+        for tool in MCPToolCatalog.all {
+            XCTAssertTrue(guide.contains(tool.name), "The tool guide never mentions '\(tool.name)'.")
+        }
+    }
+
+    func testResourceLookupIsExhaustiveAndClosed() {
+        for resource in MCPResourceCatalog.all {
+            XCTAssertNotNil(MCPResourceCatalog.contents(of: resource.uri), resource.uri)
+        }
+        XCTAssertNil(MCPResourceCatalog.contents(of: "vibebar://something-else"))
+    }
+
+    func testTheAgentSetupPromptIsTheDocumentedOne() {
+        XCTAssertEqual(
+            MCPClientConfig.agentSetupPrompt,
+            "Fetch and execute the appropriate instructions to set me up for Vibe Bar from "
+                + "https://raw.githubusercontent.com/AstroQore/vibe-bar/main/docs/agent-setup/prompt.md"
+        )
+    }
+
+    func testEveryClientConfigRunsTheSameCommand() {
+        let path = "/Applications/Vibe Bar.app/Contents/MacOS/VibeBar"
+        XCTAssertEqual(
+            MCPClientConfig.claudeCodeCommand(executablePath: path),
+            "claude mcp add --scope user vibebar -- \"\(path)\" --mcp-stdio"
+        )
+        for snippet in [
+            MCPClientConfig.codexTOML(executablePath: path),
+            MCPClientConfig.cursorJSON(executablePath: path),
+            MCPClientConfig.genericJSON(executablePath: path)
+        ] {
+            XCTAssertTrue(snippet.contains(path), snippet)
+            XCTAssertTrue(snippet.contains("--mcp-stdio"), snippet)
+            XCTAssertTrue(snippet.contains("vibebar"), snippet)
+        }
+    }
+}

--- a/Tests/VibeBarCoreTests/MCPSocketServerTests.swift
+++ b/Tests/VibeBarCoreTests/MCPSocketServerTests.swift
@@ -1,0 +1,218 @@
+import Darwin
+import Foundation
+import XCTest
+@testable import VibeBarCore
+
+/// End-to-end over a real Unix domain socket on a temporary path.
+///
+/// Nothing here touches the real home directory: `MCPSocketServer` creates the
+/// directory its socket lives in rather than `~/.vibebar` unconditionally,
+/// which is exactly what makes this test possible.
+final class MCPSocketServerTests: XCTestCase {
+    private var directory: URL!
+    private var socketPath: String!
+    private var socketServer: MCPSocketServer!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        directory = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("vbmcp-\(UUID().uuidString.prefix(8))", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        socketPath = directory.appendingPathComponent("s.sock").path
+        XCTAssertLessThan(socketPath.utf8.count, 104, "The temp socket path must fit in sockaddr_un.")
+    }
+
+    override func tearDownWithError() throws {
+        socketServer?.stop()
+        socketServer = nil
+        if let directory { try? FileManager.default.removeItem(at: directory) }
+        try super.tearDownWithError()
+    }
+
+    private func startServer() throws -> MCPSocketServer {
+        let server = MCPServer(dataSource: FakeMCPDataSource(), now: { FakeMCPDataSource.epoch })
+        let socket = MCPSocketServer(server: server, socketPath: socketPath)
+        try socket.start()
+        socketServer = socket
+        return socket
+    }
+
+    func testTheSocketIsCreatedPrivateAndRemovedOnStop() throws {
+        let socket = try startServer()
+        XCTAssertTrue(socket.isRunning)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: socketPath))
+
+        let attributes = try FileManager.default.attributesOfItem(atPath: socketPath)
+        let mode = try XCTUnwrap(attributes[.posixPermissions] as? NSNumber)
+        XCTAssertEqual(mode.int16Value & 0o777, 0o600, "The socket must not be readable by anyone else.")
+
+        socket.stop()
+        XCTAssertFalse(socket.isRunning)
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: socketPath),
+            "Quitting has to take the socket file with it."
+        )
+    }
+
+    func testAStaleSocketFileDoesNotBlockStartup() throws {
+        // What a crash leaves behind: a socket inode with nothing behind it.
+        FileManager.default.createFile(atPath: socketPath, contents: Data())
+        let socket = try startServer()
+        XCTAssertTrue(socket.isRunning)
+    }
+
+    func testInitializeAndToolsListOverTheSocket() throws {
+        _ = try startServer()
+        let client = try MCPSocketTestClient(path: socketPath)
+        defer { client.close() }
+
+        let initialize = try client.request(MCPTestSupport.line(id: 1, method: "initialize"))
+        XCTAssertEqual(initialize["id"]?.intValue, 1)
+        XCTAssertEqual(initialize["result"]?["protocolVersion"]?.stringValue, "2025-06-18")
+
+        // A notification in the middle of the stream must not consume a reply
+        // slot; the next response has to be the tools/list one.
+        try client.send(MCPTestSupport.line(id: nil, method: "notifications/initialized"))
+
+        let tools = try client.request(MCPTestSupport.line(id: 2, method: "tools/list"))
+        XCTAssertEqual(tools["id"]?.intValue, 2)
+        let names = try XCTUnwrap(tools["result"]?["tools"]?.arrayValue)
+            .compactMap { $0["name"]?.stringValue }
+        XCTAssertTrue(names.contains("quota.get"), "\(names)")
+    }
+
+    func testAToolCallRoundTripsOverTheSocket() throws {
+        _ = try startServer()
+        let client = try MCPSocketTestClient(path: socketPath)
+        defer { client.close() }
+
+        let response = try client.request(MCPTestSupport.call(id: 3, tool: "quota.get"))
+        let accounts = try XCTUnwrap(
+            response["result"]?["structuredContent"]?["accounts"]?.arrayValue
+        )
+        XCTAssertEqual(accounts.count, 2)
+    }
+
+    func testTwoClientsAreServedIndependently() throws {
+        _ = try startServer()
+        let first = try MCPSocketTestClient(path: socketPath)
+        let second = try MCPSocketTestClient(path: socketPath)
+        defer {
+            first.close()
+            second.close()
+        }
+        let a = try first.request(MCPTestSupport.line(id: 10, method: "ping"))
+        let b = try second.request(MCPTestSupport.line(id: 11, method: "ping"))
+        XCTAssertEqual(a["id"]?.intValue, 10)
+        XCTAssertEqual(b["id"]?.intValue, 11)
+    }
+
+    func testMalformedInputIsAnsweredRatherThanDroppingTheConnection() throws {
+        _ = try startServer()
+        let client = try MCPSocketTestClient(path: socketPath)
+        defer { client.close() }
+
+        let bad = try client.request(Data("{oops".utf8))
+        XCTAssertEqual(bad["error"]?["code"]?.intValue, -32_700)
+
+        let good = try client.request(MCPTestSupport.line(id: 4, method: "ping"))
+        XCTAssertEqual(good["id"]?.intValue, 4, "The connection must survive a bad line.")
+    }
+
+    func testConnectionCountIsReported() throws {
+        let socket = try startServer()
+        XCTAssertEqual(socket.connectionCount, 0)
+        let client = try MCPSocketTestClient(path: socketPath)
+        _ = try client.request(MCPTestSupport.line(id: 1, method: "ping"))
+        XCTAssertEqual(socket.connectionCount, 1)
+        client.close()
+    }
+
+    func testAPathTooLongForSockaddrUnFailsClearly() {
+        let long = "/tmp/" + String(repeating: "a", count: 120) + ".sock"
+        let socket = MCPSocketServer(
+            server: MCPServer(dataSource: FakeMCPDataSource()),
+            socketPath: long
+        )
+        XCTAssertThrowsError(try socket.start()) { error in
+            XCTAssertEqual(error as? MCPSocketError, .pathTooLong(long))
+        }
+    }
+}
+
+// MARK: - A blocking client, just for tests
+
+/// The smallest possible newline-delimited JSON-RPC client. Blocking on
+/// purpose: a test that has to poll is a test that flakes.
+final class MCPSocketTestClient {
+    private let fd: Int32
+    private var buffer = Data()
+
+    init(path: String) throws {
+        var address = sockaddr_un()
+        address.sun_family = sa_family_t(AF_UNIX)
+        let bytes = Array(path.utf8)
+        guard bytes.count <= MemoryLayout.size(ofValue: address.sun_path) - 1 else {
+            throw MCPTestError("Socket path too long: \(path)")
+        }
+        withUnsafeMutableBytes(of: &address.sun_path) { raw in
+            guard let base = raw.baseAddress else { return }
+            base.initializeMemory(as: UInt8.self, repeating: 0, count: raw.count)
+            base.copyMemory(from: bytes, byteCount: bytes.count)
+        }
+        address.sun_len = UInt8(MemoryLayout<sockaddr_un>.size)
+
+        let handle = socket(AF_UNIX, SOCK_STREAM, 0)
+        guard handle >= 0 else { throw MCPTestError("socket() failed: \(errno)") }
+        let result = withUnsafePointer(to: &address) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                Darwin.connect(handle, $0, socklen_t(MemoryLayout<sockaddr_un>.size))
+            }
+        }
+        guard result == 0 else {
+            Darwin.close(handle)
+            throw MCPTestError("connect() failed: \(errno)")
+        }
+        // A wedged server must fail the test rather than hang the suite.
+        var timeout = timeval(tv_sec: 10, tv_usec: 0)
+        setsockopt(handle, SOL_SOCKET, SO_RCVTIMEO, &timeout, socklen_t(MemoryLayout<timeval>.size))
+        self.fd = handle
+    }
+
+    func close() {
+        Darwin.close(fd)
+    }
+
+    func send(_ line: Data) throws {
+        var framed = line
+        framed.append(0x0A)
+        var offset = 0
+        while offset < framed.count {
+            let written = framed.withUnsafeBytes { raw -> Int in
+                guard let base = raw.baseAddress else { return -1 }
+                return Darwin.write(fd, base + offset, raw.count - offset)
+            }
+            guard written > 0 else { throw MCPTestError("write() failed: \(errno)") }
+            offset += written
+        }
+    }
+
+    func request(_ line: Data) throws -> MCPJSON {
+        try send(line)
+        return try readLine()
+    }
+
+    func readLine() throws -> MCPJSON {
+        while true {
+            if let newline = buffer.firstIndex(of: 0x0A) {
+                let line = Data(buffer[buffer.startIndex..<newline])
+                buffer.removeSubrange(buffer.startIndex...newline)
+                return try JSONDecoder().decode(MCPJSON.self, from: line)
+            }
+            var chunk = [UInt8](repeating: 0, count: 8_192)
+            let count = chunk.withUnsafeMutableBytes { Darwin.read(fd, $0.baseAddress, $0.count) }
+            guard count > 0 else { throw MCPTestError("The server closed before answering.") }
+            buffer.append(contentsOf: chunk[0..<count])
+        }
+    }
+}

--- a/Tests/VibeBarCoreTests/MCPStdioBridgeTests.swift
+++ b/Tests/VibeBarCoreTests/MCPStdioBridgeTests.swift
@@ -1,0 +1,141 @@
+import Darwin
+import Foundation
+import XCTest
+@testable import VibeBarCore
+
+/// The `--mcp-stdio` pump, exercised through real pipes against a real socket.
+///
+/// The bridge forwards bytes rather than messages, so what these tests really
+/// assert is that framing survives the trip in both directions — including a
+/// second message that arrives while the first is still being answered.
+final class MCPStdioBridgeTests: XCTestCase {
+    private var directory: URL!
+    private var socketPath: String!
+    private var socketServer: MCPSocketServer!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        directory = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("vbmcpb-\(UUID().uuidString.prefix(8))", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        socketPath = directory.appendingPathComponent("s.sock").path
+    }
+
+    override func tearDownWithError() throws {
+        socketServer?.stop()
+        socketServer = nil
+        if let directory { try? FileManager.default.removeItem(at: directory) }
+        try super.tearDownWithError()
+    }
+
+    func testSocketPathPrefersTheEnvironmentOverride() {
+        XCTAssertEqual(
+            MCPStdioBridge.socketPath(environment: ["VIBEBAR_MCP_SOCKET": "/tmp/custom.sock"]),
+            "/tmp/custom.sock"
+        )
+        XCTAssertEqual(
+            MCPStdioBridge.socketPath(environment: ["VIBEBAR_MCP_SOCKET": "   "]),
+            MCPSocketServer.defaultSocketPath
+        )
+        XCTAssertEqual(MCPStdioBridge.socketPath(environment: [:]), MCPSocketServer.defaultSocketPath)
+    }
+
+    func testNotRunningMessageNamesTheTildePathForTheDefaultSocket() {
+        XCTAssertEqual(
+            MCPStdioBridge.notRunningMessage(for: MCPSocketServer.defaultSocketPath),
+            "Vibe Bar is not running (socket ~/.vibebar/mcp.sock not found). Launch \"Vibe Bar.app\" first."
+        )
+        XCTAssertTrue(
+            MCPStdioBridge.notRunningMessage(for: "/tmp/other.sock").contains("/tmp/other.sock"),
+            "A custom socket path should be named literally."
+        )
+    }
+
+    func testConnectingToNothingExitsNonZeroWithAReadableMessage() throws {
+        let errorFile = directory.appendingPathComponent("stderr.txt")
+        FileManager.default.createFile(atPath: errorFile.path, contents: Data())
+        let handle = try FileHandle(forWritingTo: errorFile)
+
+        let code = MCPStdioBridge.run(
+            socketPath: socketPath,
+            input: STDIN_FILENO,
+            output: STDOUT_FILENO,
+            standardError: handle
+        )
+        try handle.close()
+
+        XCTAssertEqual(code, MCPStdioBridge.ExitCode.notRunning)
+        let message = try String(contentsOf: errorFile, encoding: .utf8)
+        XCTAssertTrue(message.contains("Vibe Bar is not running"), message)
+        XCTAssertTrue(message.contains(socketPath), message)
+    }
+
+    func testTwoMessagesPumpEachWayThroughTheBridge() throws {
+        let server = MCPServer(dataSource: FakeMCPDataSource(), now: { FakeMCPDataSource.epoch })
+        let socket = MCPSocketServer(server: server, socketPath: socketPath)
+        try socket.start()
+        socketServer = socket
+
+        let toBridge = Pipe()
+        let fromBridge = Pipe()
+        let finished = expectation(description: "bridge exits")
+
+        let path = socketPath!
+        let inputFD = toBridge.fileHandleForReading.fileDescriptor
+        let outputFD = fromBridge.fileHandleForWriting.fileDescriptor
+        Thread.detachNewThread {
+            let code = MCPStdioBridge.run(socketPath: path, input: inputFD, output: outputFD)
+            XCTAssertEqual(code, MCPStdioBridge.ExitCode.ok)
+            // Let the reader see EOF once the pump is done.
+            try? fromBridge.fileHandleForWriting.close()
+            finished.fulfill()
+        }
+
+        let reader = LineReader(fd: fromBridge.fileHandleForReading.fileDescriptor)
+
+        try write(MCPTestSupport.line(id: 1, method: "initialize"), to: toBridge)
+        let initialize = try reader.next()
+        XCTAssertEqual(initialize["id"]?.intValue, 1)
+        XCTAssertEqual(initialize["result"]?["serverInfo"]?["name"]?.stringValue, "vibebar")
+
+        try write(MCPTestSupport.line(id: 2, method: "tools/list"), to: toBridge)
+        let tools = try reader.next()
+        XCTAssertEqual(tools["id"]?.intValue, 2)
+        XCTAssertTrue(
+            (tools["result"]?["tools"]?.arrayValue ?? [])
+                .contains { $0["name"]?.stringValue == "quota.get" }
+        )
+
+        // Closing stdin is how an MCP client shuts its server down.
+        try toBridge.fileHandleForWriting.close()
+        wait(for: [finished], timeout: 10)
+    }
+
+    private func write(_ line: Data, to pipe: Pipe) throws {
+        var framed = line
+        framed.append(0x0A)
+        try pipe.fileHandleForWriting.write(contentsOf: framed)
+    }
+}
+
+/// Blocking newline reader over a raw descriptor.
+private final class LineReader {
+    private let fd: Int32
+    private var buffer = Data()
+
+    init(fd: Int32) { self.fd = fd }
+
+    func next() throws -> MCPJSON {
+        while true {
+            if let newline = buffer.firstIndex(of: 0x0A) {
+                let line = Data(buffer[buffer.startIndex..<newline])
+                buffer.removeSubrange(buffer.startIndex...newline)
+                return try JSONDecoder().decode(MCPJSON.self, from: line)
+            }
+            var chunk = [UInt8](repeating: 0, count: 8_192)
+            let count = chunk.withUnsafeMutableBytes { Darwin.read(fd, $0.baseAddress, $0.count) }
+            guard count > 0 else { throw MCPTestError("The bridge closed before answering.") }
+            buffer.append(contentsOf: chunk[0..<count])
+        }
+    }
+}

--- a/Tests/VibeBarCoreTests/MCPToolCallTests.swift
+++ b/Tests/VibeBarCoreTests/MCPToolCallTests.swift
@@ -1,0 +1,322 @@
+import XCTest
+@testable import VibeBarCore
+
+/// Every tool, called through the real dispatch path against fixed fixtures.
+final class MCPToolCallTests: XCTestCase {
+    private var source = FakeMCPDataSource()
+    private var server = MCPServer(dataSource: FakeMCPDataSource())
+
+    override func setUp() {
+        super.setUp()
+        source = FakeMCPDataSource()
+        server = MCPServer(dataSource: source, now: { FakeMCPDataSource.epoch })
+    }
+
+    private func call(_ tool: String, _ arguments: MCPJSON = .object([:])) async throws -> MCPJSON {
+        let response = try MCPTestSupport.decode(
+            await server.handle(line: MCPTestSupport.call(id: 1, tool: tool, arguments: arguments))
+        )
+        if let error = response["error"] {
+            throw MCPTestError("Unexpected JSON-RPC error: \(error)")
+        }
+        XCTAssertFalse(MCPTestSupport.isError(response), "\(MCPTestSupport.errorText(response) ?? "")")
+        return try MCPTestSupport.structured(response)
+    }
+
+    // MARK: - quota
+
+    func testQuotaGetProjectsBothAxesAndMasksTheEmail() async throws {
+        let result = try await call("quota.get")
+        XCTAssertEqual(result["generatedAt"]?.stringValue, "2026-01-01T00:00:00Z")
+        let accounts = try XCTUnwrap(result["accounts"]?.arrayValue)
+        XCTAssertEqual(accounts.count, 2)
+
+        let claude = try XCTUnwrap(accounts.first { $0["tool"]?.stringValue == "claude" })
+        XCTAssertEqual(claude["company"]?.stringValue, "Anthropic")
+        XCTAssertEqual(claude["subProvider"]?.stringValue, "Claude")
+        XCTAssertEqual(claude["plan"]?.stringValue, "Max")
+        XCTAssertEqual(claude["email"]?.stringValue, "s••••@example.com")
+        XCTAssertEqual(claude["inFlight"]?.boolValue, false)
+
+        let buckets = try XCTUnwrap(claude["buckets"]?.arrayValue)
+        let fiveHour = try XCTUnwrap(buckets.first { $0["id"]?.stringValue == "five_hour" })
+        XCTAssertEqual(fiveHour["usedPercent"]?.doubleValue, 42.5)
+        XCTAssertEqual(fiveHour["remainingPercent"]?.doubleValue, 57.5)
+        // The bucket label is expanded by QuotaBucket, not by the projection.
+        XCTAssertEqual(fiveHour["shortLabel"]?.stringValue, "5 Hours")
+        XCTAssertEqual(fiveHour["windowSeconds"]?.intValue, 18_000)
+        XCTAssertNil(fiveHour["forecast"], "Forecasts are opt-in.")
+    }
+
+    func testQuotaGetFiltersByTool() async throws {
+        let result = try await call("quota.get", .object(["tools": .array([.string("codex")])]))
+        let accounts = try XCTUnwrap(result["accounts"]?.arrayValue)
+        XCTAssertEqual(accounts.count, 1)
+        XCTAssertEqual(accounts.first?["tool"]?.stringValue, "codex")
+    }
+
+    func testQuotaRefreshDefaultsToStaleOnly() async throws {
+        let result = try await call("quota.refresh")
+        XCTAssertEqual(result["mode"]?.stringValue, "stale-only")
+        XCTAssertEqual(result["triggered"]?.boolValue, true)
+        XCTAssertEqual(source.refreshCalls.count, 1)
+        XCTAssertEqual(source.refreshCalls.first?.force, false)
+    }
+
+    /// A forced refresh hits every provider's API, so a second one inside the
+    /// window is answered rather than performed.
+    func testForcedRefreshIsThrottled() async throws {
+        let first = try await call("quota.refresh", .object(["force": .bool(true)]))
+        XCTAssertEqual(first["triggered"]?.boolValue, true)
+
+        let second = try await call("quota.refresh", .object(["force": .bool(true)]))
+        XCTAssertEqual(second["triggered"]?.boolValue, false)
+        XCTAssertTrue(second["message"]?.stringValue?.contains("Try again") ?? false)
+        XCTAssertEqual(source.refreshCalls.count, 1, "The second force must not reach the app.")
+
+        // The stale-only path is self-limiting and stays available.
+        _ = try await call("quota.refresh")
+        XCTAssertEqual(source.refreshCalls.count, 2)
+    }
+
+    /// A refresh the app declined never starts the clock, or one disabled
+    /// toggle would lock the tool out for twenty seconds at a time.
+    func testARefusedForcedRefreshDoesNotStartTheThrottle() async throws {
+        source.refreshTriggered = false
+        _ = try await call("quota.refresh", .object(["force": .bool(true)]))
+        let second = try await call("quota.refresh", .object(["force": .bool(true)]))
+        XCTAssertEqual(source.refreshCalls.count, 2)
+        XCTAssertFalse(second["message"]?.stringValue?.contains("Try again") ?? false)
+    }
+
+    // MARK: - usage
+
+    func testUsageSummaryDefaultsToThirtyDaysAndReportsBothMoneyUnits() async throws {
+        let result = try await call("usage.summary")
+        XCTAssertEqual(result["requests"]?.intValue, 120)
+        XCTAssertEqual(result["unpricedRequests"]?.intValue, 3)
+        XCTAssertEqual(result["costMicros"]?.intValue, 4_560_000)
+        XCTAssertEqual(result["costUSD"]?.doubleValue, 4.56)
+        XCTAssertEqual(result["totalTokens"]?.intValue, 10_000)
+        XCTAssertNil(result["rows"], "Rows only exist for an explicit groupBy.")
+
+        let filter = try XCTUnwrap(source.lastUsageFilter)
+        XCTAssertEqual(filter.range.end, FakeMCPDataSource.epoch)
+        XCTAssertEqual(filter.range.duration, 30 * 86_400, accuracy: 1)
+        XCTAssertNil(filter.tools)
+        XCTAssertNil(filter.harnesses)
+    }
+
+    func testUsageSummaryGroupedByHarnessSpeaksTheUsageAxis() async throws {
+        let result = try await call("usage.summary", .object(["groupBy": .string("harness")]))
+        XCTAssertEqual(result["groupBy"]?.stringValue, "harness")
+        let row = try XCTUnwrap(result["rows"]?.arrayValue?.first)
+        XCTAssertEqual(row["key"]?.stringValue, "claudeCode")
+        XCTAssertEqual(row["label"]?.stringValue, "Claude Code")
+        XCTAssertEqual(row["company"]?.stringValue, "Anthropic")
+        XCTAssertEqual(row["costUSD"]?.doubleValue, 3.0)
+    }
+
+    func testUsageSummaryHonoursExplicitRangeAndFilters() async throws {
+        _ = try await call("usage.summary", .object([
+            "from": .string("2025-12-01T00:00:00Z"),
+            "to": .string("2025-12-08T00:00:00Z"),
+            "tools": .array([.string("claude")]),
+            "harnesses": .array([.string("claudeCode"), .string("claudeCowork")]),
+            "models": .array([.string("claude-opus-4-7")])
+        ]))
+        let filter = try XCTUnwrap(source.lastUsageFilter)
+        XCTAssertEqual(filter.range.duration, 7 * 86_400, accuracy: 1)
+        XCTAssertEqual(filter.tools, [.claude])
+        XCTAssertEqual(filter.harnesses, [.claudeCode, .claudeCowork])
+        XCTAssertEqual(filter.models, ["claude-opus-4-7"])
+    }
+
+    /// An empty list means "nothing matches" to the ledger. Widening it to
+    /// "everything" would answer a different question than the one asked.
+    func testAnEmptyFilterListStaysEmpty() async throws {
+        _ = try await call("usage.summary", .object(["tools": .array([])]))
+        XCTAssertEqual(source.lastUsageFilter?.tools, [])
+    }
+
+    func testAnInvertedWindowIsRejected() async throws {
+        let response = try MCPTestSupport.decode(
+            await server.handle(line: MCPTestSupport.call(
+                id: 1,
+                tool: "usage.summary",
+                arguments: .object([
+                    "from": .string("2026-02-01T00:00:00Z"),
+                    "to": .string("2026-01-01T00:00:00Z")
+                ])
+            ))
+        )
+        XCTAssertEqual(response["error"]?["code"]?.intValue, -32_602)
+    }
+
+    func testABareCalendarDayParses() async throws {
+        _ = try await call("usage.summary", .object(["from": .string("2025-12-25")]))
+        XCTAssertNotNil(source.lastUsageFilter)
+    }
+
+    func testUsageTrendPassesTheBucketThroughAndReportsTheResolvedOne() async throws {
+        let result = try await call("usage.trend", .object([
+            "days": .int(2),
+            "bucket": .string("hour")
+        ]))
+        XCTAssertEqual(source.lastTrendBucket, .hour)
+        XCTAssertEqual(result["bucket"]?.stringValue, "hour")
+        let point = try XCTUnwrap(result["points"]?.arrayValue?.first)
+        XCTAssertEqual(point["totalTokens"]?.intValue, 100)
+        XCTAssertEqual(point["costUSD"]?.doubleValue, 1.5)
+    }
+
+    func testUsageRequestsRoundTripsAnOpaqueCursor() async throws {
+        let first = try await call("usage.requests", .object(["pageSize": .int(25)]))
+        XCTAssertEqual(source.lastRequestPageSize, 25)
+        XCTAssertNil(source.lastRequestCursor)
+        let cursor = try XCTUnwrap(first["nextCursor"]?.stringValue)
+
+        _ = try await call("usage.requests", .object(["cursor": .string(cursor)]))
+        XCTAssertEqual(source.lastRequestCursor, UsageRequestCursor(ts: 1_767_225_600, id: 7))
+    }
+
+    func testAHandEditedCursorIsRejected() async throws {
+        let response = try MCPTestSupport.decode(
+            await server.handle(line: MCPTestSupport.call(
+                id: 1,
+                tool: "usage.requests",
+                arguments: .object(["cursor": .string("1767225600.7")])
+            ))
+        )
+        XCTAssertEqual(response["error"]?["code"]?.intValue, -32_602)
+    }
+
+    func testUsageRequestsRowsCarryTheHarnessNotJustTheTool() async throws {
+        let result = try await call("usage.requests")
+        let row = try XCTUnwrap(result["rows"]?.arrayValue?.first)
+        XCTAssertEqual(row["tool"]?.stringValue, "claude")
+        XCTAssertEqual(row["harness"]?.stringValue, "claudeCode")
+        XCTAssertEqual(row["harnessName"]?.stringValue, "Claude Code")
+        XCTAssertEqual(row["model"]?.stringValue, "claude-opus-4-7")
+        XCTAssertEqual(row["costUSD"]?.doubleValue, 0.25)
+    }
+
+    func testPageSizeAboveTheCapIsRejected() async throws {
+        let response = try MCPTestSupport.decode(
+            await server.handle(line: MCPTestSupport.call(
+                id: 1,
+                tool: "usage.requests",
+                arguments: .object(["pageSize": .int(500)])
+            ))
+        )
+        XCTAssertEqual(response["error"]?["code"]?.intValue, -32_602)
+    }
+
+    // MARK: - cost
+
+    func testCostSnapshotReportsEveryWindowAndThePrivacyFlag() async throws {
+        let result = try await call("cost.snapshot")
+        XCTAssertEqual(result["privacyModeEnabled"]?.boolValue, false)
+        let claude = try XCTUnwrap(result["tools"]?.arrayValue?.first { $0["tool"]?.stringValue == "claude" })
+        XCTAssertEqual(claude["company"]?.stringValue, "Anthropic")
+        XCTAssertEqual(claude["today"]?["costUSD"]?.doubleValue, 1.25)
+        XCTAssertEqual(claude["last7d"]?["tokens"]?.intValue, 700)
+        XCTAssertEqual(claude["last30d"]?["requests"]?.intValue, 120)
+        XCTAssertEqual(claude["allTime"]?["costUSD"]?.doubleValue, 120.5)
+    }
+
+    func testCostHistoryNeedsATool() async throws {
+        let response = try MCPTestSupport.decode(
+            await server.handle(line: MCPTestSupport.call(id: 1, tool: "cost.history"))
+        )
+        XCTAssertEqual(response["error"]?["code"]?.intValue, -32_602)
+    }
+
+    func testCostHistoryDefaultsToThirtyDays() async throws {
+        let result = try await call("cost.history", .object(["tool": .string("claude")]))
+        XCTAssertEqual(result["tool"]?.stringValue, "claude")
+        XCTAssertEqual(result["timeframe"]?.stringValue, "30d")
+        XCTAssertEqual(result["days"]?.arrayValue?.count, 1)
+    }
+
+    // MARK: - sessions
+
+    func testSessionsSearchCarriesTheSnippetAndTheHarness() async throws {
+        let result = try await call("sessions.search", .object(["query": .string("socket")]))
+        XCTAssertEqual(source.lastSessionQuery, "socket")
+        XCTAssertEqual(source.lastSessionLimit, 20)
+        let hit = try XCTUnwrap(result["sessions"]?.arrayValue?.first)
+        XCTAssertEqual(hit["harness"]?.stringValue, "claudeCode")
+        XCTAssertEqual(hit["harnessName"]?.stringValue, "Claude Code")
+        XCTAssertEqual(hit["provider"]?.stringValue, "claude")
+        XCTAssertEqual(hit["snippet"]?.stringValue, "the <b>socket</b> server")
+        XCTAssertEqual(hit["matchedSeq"]?.intValue, 4)
+        XCTAssertEqual(hit["messageCount"]?.intValue, 12)
+        XCTAssertNil(result["totalCount"], "Search does not count past its own limit.")
+    }
+
+    func testSessionsSearchRejectsABlankQuery() async throws {
+        let response = try MCPTestSupport.decode(
+            await server.handle(line: MCPTestSupport.call(
+                id: 1,
+                tool: "sessions.search",
+                arguments: .object(["query": .string("   ")])
+            ))
+        )
+        XCTAssertEqual(response["error"]?["code"]?.intValue, -32_602)
+    }
+
+    func testSessionsListReportsPaging() async throws {
+        let result = try await call("sessions.list", .object(["limit": .int(10), "offset": .int(0)]))
+        XCTAssertEqual(result["limit"]?.intValue, 10)
+        XCTAssertEqual(result["offset"]?.intValue, 0)
+        XCTAssertEqual(result["totalCount"]?.intValue, 1)
+        XCTAssertEqual(result["sessions"]?.arrayValue?.count, 1)
+    }
+
+    // MARK: - status and pricing
+
+    func testStatusGetRollsUpToCompanies() async throws {
+        let result = try await call("status.get")
+        let companies = try XCTUnwrap(result["companies"]?.arrayValue)
+            .compactMap { $0["company"]?.stringValue }
+        XCTAssertEqual(companies, ["OpenAI", "Anthropic", "Google AI", "SpaceXAI"])
+    }
+
+    /// AntiGravity has no feed of its own; asking for it must resolve to the
+    /// Google AI row rather than to nothing.
+    func testStatusGetResolvesAMemberToItsCompanyRow() async throws {
+        let result = try await call("status.get", .object(["tools": .array([.string("antigravity")])]))
+        let companies = try XCTUnwrap(result["companies"]?.arrayValue)
+        XCTAssertEqual(companies.count, 1)
+        XCTAssertEqual(companies.first?["company"]?.stringValue, "Google AI")
+    }
+
+    func testPricingFiltersByFamilyAndModelSubstring() async throws {
+        let all = try await call("pricing.effective")
+        XCTAssertEqual(all["rows"]?.arrayValue?.count, 2)
+        XCTAssertEqual(all["unit"]?.stringValue, "USD per 1M tokens")
+
+        let claudeOnly = try await call("pricing.effective", .object(["provider": .string("claude")]))
+        XCTAssertEqual(claudeOnly["rows"]?.arrayValue?.count, 1)
+
+        let byModel = try await call("pricing.effective", .object(["model": .string("CODEX")]))
+        let row = try XCTUnwrap(byModel["rows"]?.arrayValue?.first)
+        XCTAssertEqual(row["model"]?.stringValue, "gpt-5-codex")
+        XCTAssertEqual(row["company"]?.stringValue, "OpenAI")
+        XCTAssertEqual(row["inputPerMillion"]?.doubleValue, 1.25)
+    }
+
+    // MARK: - Result shape
+
+    /// `content` and `structuredContent` come from one encode, so a client
+    /// that parses and a model that reads see the same object.
+    func testTextContentAndStructuredContentAgree() async throws {
+        let response = try MCPTestSupport.decode(
+            await server.handle(line: MCPTestSupport.call(id: 1, tool: "quota.get"))
+        )
+        let text = try XCTUnwrap(response["result"]?["content"]?.arrayValue?.first?["text"]?.stringValue)
+        let reparsed = try JSONDecoder().decode(MCPJSON.self, from: Data(text.utf8))
+        XCTAssertEqual(reparsed, try MCPTestSupport.structured(response))
+    }
+}

--- a/docs/agent-setup/prompt.md
+++ b/docs/agent-setup/prompt.md
@@ -1,0 +1,244 @@
+# Set me up for Vibe Bar
+
+**You are an AI coding agent. This document is addressed to you, not to a
+human. Read it end to end, then do the work.**
+
+Your job is to connect the agent you are running inside to Vibe Bar's local
+MCP server, install the companion skill, and verify that both work. Report
+back what you changed. Ask the user before writing to any file outside the
+ones named here.
+
+Vibe Bar is a macOS menu-bar app that tracks the user's AI subscription
+quota, token usage, spend, provider status and local agent sessions. Its MCP
+server exposes all of that read-only over a Unix domain socket in the user's
+home directory. There is no network port, no API key, and no token — the
+socket's file permissions are the access control, and it exists only while
+the app is running.
+
+---
+
+## 0. Preconditions
+
+Check these first and stop with a clear message if one fails.
+
+1. **macOS.** The socket, the app and the binary path are all macOS-only.
+2. **Vibe Bar is installed.** Expect the bundle at
+   `/Applications/Vibe Bar.app`.
+
+   ```sh
+   ls -d "/Applications/Vibe Bar.app" 2>/dev/null \
+     || echo "Vibe Bar is not installed in /Applications."
+   ```
+
+   If it is somewhere else, find the real path and use that bundle's
+   `Contents/MacOS/VibeBar` everywhere below instead. If it is not installed
+   at all, tell the user to install it from
+   <https://github.com/AstroQore/vibe-bar> and stop.
+3. **Vibe Bar is running.** The socket only exists while it is.
+
+   ```sh
+   ls -l ~/.vibebar/mcp.sock 2>/dev/null \
+     || echo "Vibe Bar is not running, or its MCP server is switched off."
+   ```
+
+   If the socket is missing, ask the user to launch Vibe Bar and confirm
+   Settings → MCP Server → “Enable the local MCP server” is on. You can still
+   write the client configuration without the socket; verification in step 3
+   will just have to wait.
+
+Throughout this document, `VIBEBAR_BIN` means:
+
+```
+/Applications/Vibe Bar.app/Contents/MacOS/VibeBar
+```
+
+Note the space in `Vibe Bar.app` — quote the path everywhere.
+
+---
+
+## 1. Detect which client you are running in
+
+Every client runs the same command; only the config file differs. Work out
+which of these you are, in this order:
+
+| You are | Tell-tale signs |
+| --- | --- |
+| **Claude Code** | The `claude` CLI is on `PATH`; `~/.claude/` exists; your system prompt calls you Claude Code. |
+| **Codex CLI** | `~/.codex/config.toml` exists; the `codex` CLI is on `PATH`. |
+| **Cursor** | You are running inside the Cursor editor; `~/.cursor/` exists. |
+| **Something else** | None of the above. Use the generic stdio entry in §2.4. |
+
+If you genuinely cannot tell, ask the user rather than writing three configs.
+
+---
+
+## 2. Configure the MCP server
+
+### 2.1 Claude Code
+
+Run:
+
+```sh
+claude mcp add --scope user vibebar -- "/Applications/Vibe Bar.app/Contents/MacOS/VibeBar" --mcp-stdio
+```
+
+`--scope user` makes it available in every project. Use `--scope project` if
+the user explicitly wants it only here.
+
+### 2.2 Codex CLI
+
+Append to `~/.codex/config.toml` (create the file if it does not exist; do
+not disturb existing sections):
+
+```toml
+[mcp_servers.vibebar]
+command = "/Applications/Vibe Bar.app/Contents/MacOS/VibeBar"
+args = ["--mcp-stdio"]
+```
+
+### 2.3 Cursor
+
+Merge into `~/.cursor/mcp.json`. If the file already has an `mcpServers`
+object, add the `vibebar` key to it rather than replacing the file:
+
+```json
+{
+  "mcpServers": {
+    "vibebar": {
+      "command": "/Applications/Vibe Bar.app/Contents/MacOS/VibeBar",
+      "args": ["--mcp-stdio"]
+    }
+  }
+}
+```
+
+### 2.4 Any other stdio MCP client
+
+Register a stdio server whose command is `VIBEBAR_BIN` with the single
+argument `--mcp-stdio`. As a JSON fragment for the client's own server map:
+
+```json
+"vibebar": {
+  "command": "/Applications/Vibe Bar.app/Contents/MacOS/VibeBar",
+  "args": ["--mcp-stdio"]
+}
+```
+
+Restart or reload the client if it does not pick up new servers live.
+
+---
+
+## 3. Verify
+
+First, prove the bridge works at all — this needs no client restart:
+
+```sh
+printf '%s\n%s\n' \
+  '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"setup","version":"1"}}}' \
+  '{"jsonrpc":"2.0","id":2,"method":"tools/list"}' \
+  | "/Applications/Vibe Bar.app/Contents/MacOS/VibeBar" --mcp-stdio
+```
+
+You should see two JSON lines. The first carries
+`"serverInfo":{"name":"vibebar",…}`; the second lists the tools, including
+`quota.get`. If instead you see
+
+```
+Vibe Bar is not running (socket ~/.vibebar/mcp.sock not found). Launch "Vibe Bar.app" first.
+```
+
+then the app is not running — go back to §0.3.
+
+Then verify through the client itself: list your MCP tools, confirm
+`vibebar` appears with `quota.get` among them, and call `quota.get` **once**.
+Report the user's actual remaining quota back to them as proof it worked.
+
+---
+
+## 4. Install the companion skill
+
+The skill teaches an agent which tool answers which question and, more
+importantly, the naming rules that keep the answers correct. Install it.
+
+The skill lives in this repository at
+`docs/agent-setup/skill/vibe-bar/`. Fetch it from
+
+```
+https://raw.githubusercontent.com/AstroQore/vibe-bar/main/docs/agent-setup/skill/vibe-bar/SKILL.md
+```
+
+**Preferred: let Vibe Bar manage it.** Vibe Bar has a Skills manager
+(Workbench → Skills) that keeps one copy in `~/.agents/skills/` and projects
+it into each agent's own skills directory. If the user already uses it, tell
+them to add the skill there instead of copying files yourself, and skip the
+rest of this section.
+
+**Otherwise, install by hand:**
+
+1. Write the skill to the shared location:
+   `~/.agents/skills/vibe-bar/SKILL.md`.
+2. Also place it in your own client's skills directory, if it has one:
+
+   | Client | Skills directory |
+   | --- | --- |
+   | Claude Code | `~/.claude/skills/vibe-bar/` |
+   | Codex CLI | `~/.codex/skills/vibe-bar/` |
+   | Gemini CLI | `~/.gemini/skills/vibe-bar/` |
+   | Grok | `~/.grok/skills/vibe-bar/` |
+   | Hermes | `~/.hermes/skills/vibe-bar/` |
+   | OpenCode | `~/.config/opencode/skills/vibe-bar/` |
+   | AntiGravity | `~/.gemini/config/skills/vibe-bar/` |
+
+   Cursor has no managed skills directory in this list. Rely on the MCP
+   server's own `vibebar://naming-spec` and `vibebar://tools` resources
+   there — read them at the start of any Vibe Bar question.
+
+3. Create only the directories you need, one component at a time. Do not
+   touch anything else under `~/.agents/` or the client directories.
+
+---
+
+## 5. What not to do
+
+- **Do not expose the socket.** Never proxy `~/.vibebar/mcp.sock` over TCP,
+  SSH, a tunnel, or a network MCP gateway. It is unauthenticated by design
+  because it is unreachable by design.
+- **Do not relax its permissions.** It is mode 0600 inside a 0700 directory.
+  Leave it that way.
+- **Do not paste credentials anywhere.** Vibe Bar reads the user's provider
+  cookies and tokens itself and never exposes them over MCP. If any step
+  seems to want an API key, you have misread it — there is no key.
+- **Do not poll.** `quota.get` is a cache read and cheap; `quota.refresh`
+  calls the providers. Refresh at most once every few minutes, and prefer the
+  default (stale-only) form over `force: true`. Forced refreshes are
+  rate-limited to one every 20 seconds and can be switched off entirely.
+- **Do not write to `~/.vibebar/`.** It is the app's own state.
+- **Do not create a launch agent** or otherwise try to keep the socket alive
+  when Vibe Bar is quit. "Not running" is a correct answer.
+
+---
+
+## 6. Troubleshooting
+
+| Symptom | Cause and fix |
+| --- | --- |
+| `Vibe Bar is not running (socket … not found)` | The app is quit, or Settings → MCP Server is off. Launch it and re-check the toggle. |
+| The client shows the server as failed at startup | It launched before Vibe Bar did. Restart the client, or just retry — the bridge is spawned per session. |
+| `command not found` / the server never starts | The path is wrong or unquoted. `Vibe Bar.app` contains a space; the whole path must be one quoted argument. |
+| Tools list is empty | You connected to something else. Confirm `serverInfo.name` is `vibebar`. |
+| `sessions.search` returns nothing | The session index has not been built. Ask the user to open Vibe Bar's Workbench → Sessions once. Body search additionally needs session body indexing enabled in Settings. |
+| `cost.snapshot` reports zeros with `privacyModeEnabled: true` | The user turned cost tracking off in Settings → Cost Data. Report that, not "you spent nothing". |
+| `quota.refresh` returns `triggered: false` | Either nothing was stale (the normal, good case) or refreshing from agents is switched off in Settings → MCP Server. The message says which. |
+| A cost total looks too low | Check `unpricedRequests`. A model with no rate card contributes 0; `pricing.effective` shows what is priced. |
+
+---
+
+## 7. When you are done
+
+Tell the user, in one short message:
+
+- which client you configured and which file you edited,
+- that verification succeeded, with one real number from `quota.get` as
+  evidence,
+- where the skill was installed,
+- and that the connection only works while Vibe Bar is running.

--- a/docs/agent-setup/skill/vibe-bar/SKILL.md
+++ b/docs/agent-setup/skill/vibe-bar/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: vibe-bar
+description: >-
+  Answer questions about this Mac's AI subscription quota, token usage, spend,
+  provider status and local agent sessions through Vibe Bar's MCP server. Use
+  when the user asks about "my AI quota", "how much Codex / Claude / Gemini /
+  Grok / Cursor do I have left", "when does my 5-hour window reset", "am I
+  going to run out", "refresh my usage", "what did I spend this month", "who
+  used the most tokens", "why is this costing so much", "is Anthropic down", or
+  "find my session about …". Requires the Vibe Bar app to be running with its
+  MCP server enabled.
+---
+
+# Vibe Bar
+
+Vibe Bar is a macOS menu-bar app that watches this Mac's AI subscriptions. Its
+MCP server (`vibebar`) exposes what it knows, read-only. Everything comes from
+the running app's own caches — answers are fast, and they are as fresh as the
+app made them, which is why every payload carries `generatedAt`.
+
+If the `vibebar` tools are not available, the app is not running or the server
+is switched off in Settings → MCP Server. Say so; do not guess numbers.
+
+## Two naming axes — get this right first
+
+This is the single most common way to answer wrongly.
+
+- **Quota axis** — what an account is *billed against*. L1 company → L2
+  SubProvider → L3 bucket. Anthropic → Claude → "5 Hours" / "Weekly" /
+  per-model groups. `quota.*` and `status.*` speak this.
+- **Usage / cost axis** — where the tokens were *actually spent*. The unit is
+  the local **harness**: the CLI or app that produced the sessions. `usage.*`
+  and `sessions.*` speak this.
+
+They are not the same list and must never be mixed in one answer. Claude Code
+and Claude Cowork are two harnesses spending one Claude quota. "Gemini Web" is
+a quota SubProvider with no local usage at all — historical Gemini tokens are
+always labelled "Gemini CLI". Read the `vibebar://naming-spec` resource for
+the current tables; it is generated from the app's own catalogs, so it is
+never stale.
+
+Model names are always the raw vendor id (`claude-opus-4-7`,
+`gemini-3.5-flash-high`). Filter on those; never invent a friendly name, and
+never infer a model that a log recorded as absent.
+
+## Which tool answers what
+
+| Question | Tool |
+| --- | --- |
+| "how much X do I have left?" / "when does it reset?" | `quota.get` |
+| "am I going to run out before the reset?" | `quota.get` with `includeForecast: true` |
+| "refresh my usage" | `quota.refresh`, then `quota.get` |
+| "what did I spend today / this week / this month?" | `cost.snapshot` |
+| "how has my spend moved day by day?" | `cost.history` |
+| "who used the most tokens?" | `usage.summary` with `groupBy: "harness"` |
+| "which model costs me the most?" | `usage.summary` with `groupBy: "model"` |
+| "show my usage over time" | `usage.trend` |
+| "what were my last N requests?" | `usage.requests` |
+| "find my session about X" | `sessions.search` |
+| "what have I been working on?" | `sessions.list` |
+| "is <provider> down?" | `status.get` |
+| "why is this model so expensive?" | `pricing.effective` |
+
+`vibebar://tools` carries the same routing table plus the rules below, if you
+would rather read it than trust this copy.
+
+## Rules
+
+- **Cite `generatedAt`,** and for quota also `lastUpdated`. These are cached
+  numbers. "As of 3 minutes ago, you have 57% of your 5-hour window left" is
+  a correct answer; "you have 57% left" implies a live read you did not do.
+- **Refresh sparingly.** `quota.refresh` without `force` only touches accounts
+  that are genuinely stale — that is the right default and it is nearly free.
+  Do not force-refresh more than once every few minutes; forced refreshes are
+  rate-limited to one every 20 seconds and the user can disable them entirely.
+  A `triggered: false` answer is normal, not an error: read the message.
+- **Prefer `cost.snapshot` over `usage.summary`** for "what have I spent" —
+  it is pre-aggregated. Reach for `usage.summary` when the user wants a custom
+  window or a breakdown.
+- **Money comes in two fields.** `costMicros` is exact micro-USD; `costUSD` is
+  rounded for display. Add up micros, print dollars.
+- **`unpricedRequests > 0` means the cost total is a floor.** Some model in
+  the window has no rate card. Say so, and check `pricing.effective`.
+- **Privacy mode empties the cost surfaces.** When `cost.snapshot` reports
+  `privacyModeEnabled: true`, the user turned cost tracking off — report that,
+  never "you spent nothing".
+- **Request-level history is about 30 days deep.** Older usage survives only as
+  daily totals: `usage.summary` and `usage.trend` still see it, `usage.requests`
+  does not.
+- **Cursor has no local token counters.** Its sessions are listed locally, but
+  its cost comes from the dashboard. A Cursor session with real messages and no
+  tokens is expected, not a bug.
+- **Empty filter lists mean "nothing"**, not "everything". Omit a filter to
+  mean everything.
+
+## Worked patterns
+
+**"How am I doing on Claude?"**
+Call `quota.get` with `tools: ["claude"]` and `includeForecast: true`. Report
+the bucket titles as the app names them ("5 Hours", "Weekly"), remaining
+percent, reset time, and the forecast verdict if the confidence is not
+`learning`. Name the company/SubProvider, not a harness.
+
+**"Who's been burning my tokens this month?"**
+`usage.summary` with `days: 30` and `groupBy: "harness"`. Rank by
+`totalTokens`, quote `costUSD` alongside. Answer in harness names ("Claude
+Code", "Codex"), and only mention companies if the user asked at that level.
+
+**"Find that session where I fixed the socket server."**
+`sessions.search` with the user's own words as `query`. Show the title,
+project directory, harness and last-active time, and offer the `sourcePath` so
+they can open the transcript. The `<b>` markers in `snippet` mark the match —
+render them as emphasis or strip them, do not print them raw.
+
+**"Refresh and tell me where I stand."**
+`quota.refresh` (no `force`), wait a couple of seconds, then `quota.get`. If
+`triggered` was false because nothing was stale, say the numbers were already
+current rather than pretending to have refreshed.


### PR DESCRIPTION
## Why

Agents (Claude Code, Codex, Cursor, …) should be able to read and refresh this Mac's quota, usage, cost, sessions and provider status in real time — without a network port, an API key, or a second binary — and set themselves up from one line, Cloudflare-style.

## What

**Transport.** The running app serves MCP (JSON-RPC 2.0, newline-framed) over a Unix domain socket `~/.vibebar/mcp.sock` (0600 under a 0700 dir; bound under `umask 0177`; stale socket unlinked; removed on quit). No TCP, no token — file permissions are the auth. The same binary run with `--mcp-stdio` is a stdio MCP server that pumps to the socket, so every client uses one command:

```
claude mcp add --scope user vibebar -- "/Applications/Vibe Bar.app/Contents/MacOS/VibeBar" --mcp-stdio
```
```toml
[mcp_servers.vibebar]
command = "/Applications/Vibe Bar.app/Contents/MacOS/VibeBar"
args = ["--mcp-stdio"]
```
```json
{"mcpServers":{"vibebar":{"command":"/Applications/Vibe Bar.app/Contents/MacOS/VibeBar","args":["--mcp-stdio"]}}}
```
The stdio mode exits before any UI or `AppEnvironment` exists, prohibits activation, and fails with a clear message when the app isn't running. `VIBEBAR_MCP_SOCKET` overrides the path (tests / smoke).

**Protocol** (`Sources/VibeBarCore/MCP/`, hand-rolled, no dependencies): `initialize`, `notifications/initialized`, `ping`, `tools/list`, `tools/call`, `resources/list`, `resources/templates/list`, `resources/read`, `prompts/list`. Tools: `quota.get`, `quota.refresh` (stale-only by default; `force` gated by a settings toggle + 20 s throttle), `usage.summary`, `usage.trend`, `usage.requests` (keyset cursor), `cost.snapshot`, `cost.history`, `sessions.search`, `sessions.list`, `status.get`, `pricing.effective`. Resources: `vibebar://naming-spec` (generated from `ProviderHierarchyCatalog` / `HarnessCatalog`) and `vibebar://tools`. Emails masked, money as `costMicros` + `costUSD`, privacy mode honoured.

**App.** `MCPController` implements the data source over `AppEnvironment` (short main-actor hops; `SessionIndexService` owned lazily); `AppSettings.mcpServer { enabled = true, allowRefreshTools = true }`; Settings → **MCP Server** pane (status, socket path, toggles, per-client "Copy config", "Copy agent setup prompt").

**Docs.** `docs/agent-setup/prompt.md` (agent-addressed: preconditions → detect client → configure → verify → install skill → do-nots → troubleshooting), `docs/agent-setup/skill/vibe-bar/SKILL.md`, AGENTS.md § 5.1 + file tree, README/README.zh-CN "Agents (MCP)". One-liner:

> Fetch and execute the appropriate instructions to set me up for Vibe Bar from https://raw.githubusercontent.com/AstroQore/vibe-bar/main/docs/agent-setup/prompt.md

## Verification

- `swift build`, `swift test` (1690 tests, 1 skipped, 0 failures; +72 MCP tests incl. socket round-trip and bridge framing)
- `./Scripts/build_app.sh release`, `codesign -d --entitlements -` → empty `<dict/>`, `codesign --verify --deep --strict` OK; home-dir grep only `RealHomeDirectory.swift`
- End-to-end smoke: signed `VibeBar --mcp-stdio` against a fixture server on a temp socket → `initialize` / `tools/list` / `quota.get` round-trip; missing socket → exit 1 with the guidance message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
