### PR TITLE
Harden the MCP server against races and a second instance

### DIFF
--- a/Sources/VibeBarApp/Controllers/BodyIndexingFlag.swift
+++ b/Sources/VibeBarApp/Controllers/BodyIndexingFlag.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+/// `AppSettings.sessionBodyIndexingEnabled`, readable from the session index
+/// actor's executor.
+///
+/// The setting lives on the main actor and `SessionIndexService` does not, so
+/// every owner of an index mirrors the value here rather than hopping mid-pass
+/// or — worse — snapshotting it once at construction. Snapshotting is the bug
+/// this type exists to prevent: the switch is a privacy control, so a scan
+/// started after the user turned bodies off must see "off", whether it was the
+/// Workbench or an agent over MCP that asked for it.
+final class BodyIndexingFlag: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value: Bool
+
+    init(_ value: Bool) { self.value = value }
+
+    var current: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return value
+    }
+
+    func set(_ newValue: Bool) {
+        lock.lock()
+        value = newValue
+        lock.unlock()
+    }
+}

--- a/Sources/VibeBarApp/Controllers/SessionManagerModel.swift
+++ b/Sources/VibeBarApp/Controllers/SessionManagerModel.swift
@@ -205,28 +205,6 @@ final class SessionManagerModel: ObservableObject {
         summaries.count < totalSessionCount
     }
 
-    /// `AppSettings.sessionBodyIndexingEnabled`, readable from the index
-    /// actor's executor. The setting lives on the main actor and the scan
-    /// does not, so the value is mirrored instead of hopping mid-pass.
-    private final class BodyIndexingFlag: @unchecked Sendable {
-        private let lock = NSLock()
-        private var value: Bool
-
-        init(_ value: Bool) { self.value = value }
-
-        var current: Bool {
-            lock.lock()
-            defer { lock.unlock() }
-            return value
-        }
-
-        func set(_ newValue: Bool) {
-            lock.lock()
-            value = newValue
-            lock.unlock()
-        }
-    }
-
     init(settingsStore: SettingsStore, homeDirectory: String = RealHomeDirectory.path) {
         let registry = SessionProviderRegistry.standard(homeDirectory: homeDirectory)
         self.settingsStore = settingsStore

--- a/Sources/VibeBarApp/MCPController.swift
+++ b/Sources/VibeBarApp/MCPController.swift
@@ -44,10 +44,19 @@ final class MCPController: ObservableObject, MCPDataSource {
     /// to open the Workbench, which reads as a bug rather than as an empty
     /// index.
     private var didAttemptSessionBackfill = false
+    /// The privacy switch, mirrored so the index actor can read it without a
+    /// main-actor hop — and, unlike a captured `Bool`, re-read on every pass.
+    /// Toggling "Index message text" off has to reach the MCP surface too, or
+    /// an agent's `sessions.search` would keep hitting (and re-populating) an
+    /// index the user just disabled.
+    private let bodyIndexing: BodyIndexingFlag
 
     init(environment: AppEnvironment, socketPath: String = MCPSocketServer.defaultSocketPath) {
         self.environment = environment
         self.socketPath = socketPath
+        self.bodyIndexing = BodyIndexingFlag(
+            environment.settingsStore.settings.sessionBodyIndexingEnabled
+        )
     }
 
     // MARK: - Lifecycle
@@ -61,6 +70,14 @@ final class MCPController: ObservableObject, MCPDataSource {
             .sink { [weak self] enabled in
                 Task { @MainActor in self?.applyEnabled(enabled) }
             }
+            .store(in: &cancellables)
+
+        // Follow the body-indexing switch for as long as the app runs, not
+        // just until the first `sessions.*` call opened the index.
+        settingsStore.$settings
+            .map(\.sessionBodyIndexingEnabled)
+            .removeDuplicates()
+            .sink { [bodyIndexing] enabled in bodyIndexing.set(enabled) }
             .store(in: &cancellables)
     }
 
@@ -194,13 +211,23 @@ final class MCPController: ObservableObject, MCPDataSource {
             )
         }
 
-        let triggered = environment.scheduler.triggerRefreshForStaleCacheIfNeeded()
+        // The same `tools` filter the forced path honours. Without it a
+        // narrowly-scoped call would quietly refresh every provider — and an
+        // explicitly empty list, which the argument parser preserves on
+        // purpose, would widen to "everything" instead of matching nothing.
+        let triggered = environment.scheduler.triggerRefreshForStaleCacheIfNeeded(tools: tools)
+        let scope = tools.map { $0.map(\.rawValue).joined(separator: ", ") }
         return MCPRefreshResultDTO(
             triggered: triggered,
             mode: "stale-only",
             message: triggered
                 ? "Refreshing the accounts whose cache was stale. Call quota.get in a few seconds."
-                : "Nothing was stale — every account is inside its refresh interval. "
+                : scope.map {
+                    $0.isEmpty
+                        ? "'tools' was empty, so nothing was selected to refresh."
+                        : "Nothing was stale for \($0) — it is inside its refresh interval. "
+                            + "quota.get already has current numbers."
+                } ?? "Nothing was stale — every account is inside its refresh interval. "
                     + "quota.get already has current numbers."
         )
     }
@@ -349,13 +376,12 @@ final class MCPController: ObservableObject, MCPDataSource {
         guard !sessionIndexUnavailable else {
             throw MCPToolFailure("The session index could not be opened, so sessions cannot be listed.")
         }
-        let bodies = environment?.settingsStore.settings.sessionBodyIndexingEnabled ?? true
         do {
             let store = try SessionIndexStore()
             let service = SessionIndexService(
                 store: store,
                 registry: SessionProviderRegistry.standard(),
-                bodyIndexing: { bodies }
+                bodyIndexing: { [bodyIndexing] in bodyIndexing.current }
             )
             sessionIndex = service
             return service

--- a/Sources/VibeBarCore/MCP/MCPServer.swift
+++ b/Sources/VibeBarCore/MCP/MCPServer.swift
@@ -254,18 +254,34 @@ public final class MCPServer: @unchecked Sendable {
     private func quotaRefresh(_ arguments: MCPArguments) async throws -> MCPRefreshResultDTO {
         let tools = try arguments.optionalEnumList("tools", ToolType.self)
         let force = try arguments.optionalBool("force") ?? false
-        if force, let wait = throttledForcedRefreshSeconds() {
-            return MCPRefreshResultDTO(
-                triggered: false,
-                mode: "forced",
-                message: "A forced refresh ran less than "
-                    + "\(Int(Self.forcedRefreshMinimumInterval))s ago. Try again in \(wait)s, "
-                    + "or call quota.get — the cached numbers are almost certainly current."
-            )
+
+        var reservation: ForcedRefreshReservation?
+        if force {
+            switch admitForcedRefresh() {
+            case let .throttled(wait):
+                return MCPRefreshResultDTO(
+                    triggered: false,
+                    mode: "forced",
+                    message: "A forced refresh ran less than "
+                        + "\(Int(Self.forcedRefreshMinimumInterval))s ago. Try again in \(wait)s, "
+                        + "or call quota.get — the cached numbers are almost certainly current."
+                )
+            case let .admitted(slot):
+                reservation = slot
+            }
         }
-        let result = try await dataSource.refreshQuota(tools: tools, force: force)
-        if force, result.triggered { markForcedRefresh() }
-        return result
+
+        do {
+            let result = try await dataSource.refreshQuota(tools: tools, force: force)
+            // The app declined (the toggle is off, or it is shutting down):
+            // give the window back rather than charging the caller for a
+            // refresh that never happened.
+            if let reservation, !result.triggered { release(reservation) }
+            return result
+        } catch {
+            if let reservation { release(reservation) }
+            throw error
+        }
     }
 
     private func usageSummary(_ arguments: MCPArguments) async throws -> MCPUsageSummaryDTO {
@@ -392,19 +408,49 @@ public final class MCPServer: @unchecked Sendable {
 
     // MARK: Forced-refresh throttle
 
-    /// Seconds still to wait, or `nil` when a forced refresh may run.
-    private func throttledForcedRefreshSeconds() -> Int? {
-        lock.lock()
-        defer { lock.unlock() }
-        guard let last = lastForcedRefreshAt else { return nil }
-        let elapsed = now().timeIntervalSince(last)
-        guard elapsed < Self.forcedRefreshMinimumInterval else { return nil }
-        return max(1, Int((Self.forcedRefreshMinimumInterval - elapsed).rounded(.up)))
+    /// A claimed forced-refresh window, and what to put back if it is released.
+    private struct ForcedRefreshReservation {
+        let claimedAt: Date
+        let previous: Date?
     }
 
-    private func markForcedRefresh() {
+    private enum ForcedRefreshAdmission {
+        case admitted(ForcedRefreshReservation)
+        case throttled(seconds: Int)
+    }
+
+    /// Claim the forced-refresh window, or report the seconds still to wait.
+    ///
+    /// Checking and stamping have to happen under one lock hold. Two clients
+    /// calling `quota.refresh {force:true}` at the same instant would otherwise
+    /// both read an expired timestamp, both pass, and both suspend on the data
+    /// source before either of them marked anything — which is exactly the
+    /// double API hit the throttle exists to prevent.
+    private func admitForcedRefresh() -> ForcedRefreshAdmission {
         lock.lock()
-        lastForcedRefreshAt = now()
+        defer { lock.unlock() }
+        let current = now()
+        if let last = lastForcedRefreshAt {
+            let elapsed = current.timeIntervalSince(last)
+            if elapsed < Self.forcedRefreshMinimumInterval {
+                return .throttled(seconds: max(1, Int((Self.forcedRefreshMinimumInterval - elapsed).rounded(.up))))
+            }
+        }
+        let reservation = ForcedRefreshReservation(claimedAt: current, previous: lastForcedRefreshAt)
+        lastForcedRefreshAt = current
+        return .admitted(reservation)
+    }
+
+    /// Roll a reservation back, so a refusal does not burn the window.
+    ///
+    /// Only the reservation still on record is rolled back: while it stands,
+    /// every other forced call is throttled, so a mismatch can only mean the
+    /// window already moved on and is not ours to undo.
+    private func release(_ reservation: ForcedRefreshReservation) {
+        lock.lock()
+        if lastForcedRefreshAt == reservation.claimedAt {
+            lastForcedRefreshAt = reservation.previous
+        }
         lock.unlock()
     }
 

--- a/Sources/VibeBarCore/MCP/MCPSocketServer.swift
+++ b/Sources/VibeBarCore/MCP/MCPSocketServer.swift
@@ -312,7 +312,9 @@ public final class MCPSocketServer: @unchecked Sendable {
         var info = stat()
         if stat(path, &info) == 0, (info.st_mode & S_IFMT) != S_IFSOCK { return false }
         let fd = socket(AF_UNIX, SOCK_STREAM, 0)
-        guard fd >= 0 else { return false }
+        // Cannot even make a probe socket (EMFILE, ENOBUFS…): we know nothing,
+        // so leave the path alone rather than unlink a possibly live listener.
+        guard fd >= 0 else { return true }
         defer { close(fd) }
         setNonBlocking(fd)
 

--- a/Sources/VibeBarCore/MCP/MCPSocketServer.swift
+++ b/Sources/VibeBarCore/MCP/MCPSocketServer.swift
@@ -307,6 +307,10 @@ public final class MCPSocketServer: @unchecked Sendable {
     /// live peer — `poll` bounds that wait.
     static func isAnyoneListening(atPath path: String, timeoutMilliseconds: Int32 = 250) -> Bool {
         guard var address = unixAddress(for: path) else { return false }
+        // Not a socket at all (a plain file left at the path) can never be a
+        // live listener; that is the one shape safe to call stale up front.
+        var info = stat()
+        if stat(path, &info) == 0, (info.st_mode & S_IFMT) != S_IFSOCK { return false }
         let fd = socket(AF_UNIX, SOCK_STREAM, 0)
         guard fd >= 0 else { return false }
         defer { close(fd) }
@@ -318,14 +322,20 @@ public final class MCPSocketServer: @unchecked Sendable {
             }
         }
         if result == 0 { return true }
-        guard errno == EINPROGRESS || errno == EAGAIN || errno == EALREADY else { return false }
+        // Only a definitive refusal / vanished path proves the inode is stale.
+        // Anything still pending after the timeout, or any probe error, is
+        // treated as occupied: a slow or busy peer is a live peer, and
+        // guessing wrong here would unlink a socket agents are attached to.
+        guard errno == EINPROGRESS || errno == EAGAIN || errno == EALREADY else {
+            return !(errno == ECONNREFUSED || errno == ENOENT)
+        }
 
         var descriptor = pollfd(fd: fd, events: Int16(POLLOUT), revents: 0)
-        guard poll(&descriptor, 1, timeoutMilliseconds) > 0 else { return false }
+        guard poll(&descriptor, 1, timeoutMilliseconds) > 0 else { return true }
         var pending: Int32 = 0
         var length = socklen_t(MemoryLayout<Int32>.size)
-        guard getsockopt(fd, SOL_SOCKET, SO_ERROR, &pending, &length) == 0 else { return false }
-        return pending == 0
+        guard getsockopt(fd, SOL_SOCKET, SO_ERROR, &pending, &length) == 0 else { return true }
+        return !(pending == ECONNREFUSED || pending == ENOENT)
     }
 }
 

--- a/Sources/VibeBarCore/MCP/MCPSocketServer.swift
+++ b/Sources/VibeBarCore/MCP/MCPSocketServer.swift
@@ -11,6 +11,9 @@ public enum MCPSocketError: Error, Sendable, Equatable {
     case bindFailed(Int32)
     case listenFailed(Int32)
     case staleSocketNotRemovable(String)
+    /// Something is already answering on this path — almost always a second
+    /// copy of Vibe Bar (a source build alongside the installed one).
+    case socketOwnedByAnotherInstance(String)
 
     public var message: String {
         switch self {
@@ -24,8 +27,21 @@ public enum MCPSocketError: Error, Sendable, Equatable {
             return "Listening on the MCP socket failed (errno \(code))."
         case let .staleSocketNotRemovable(path):
             return "A stale MCP socket at \(path) could not be removed."
+        case let .socketOwnedByAnotherInstance(path):
+            return "Another instance of Vibe Bar already owns the MCP socket at \(path). "
+                + "Quit the other copy — agents are still being served by it."
         }
     }
+}
+
+/// What the listener is doing, for the Settings pane.
+public enum MCPSocketServerStatus: String, Sendable, Equatable {
+    case stopped
+    case listening
+    /// Another live server holds the path, so this one deliberately did not
+    /// bind: unlinking a socket someone is answering on would silently cut
+    /// every agent attached to the other instance.
+    case conflict
 }
 
 /// A newline-delimited JSON-RPC listener on a Unix domain socket.
@@ -58,6 +74,7 @@ public final class MCPSocketServer: @unchecked Sendable {
     private var acceptSource: DispatchSourceRead?
     private var connections: [ObjectIdentifier: Connection] = [:]
     private var didBindSocketFile = false
+    private var statusValue: MCPSocketServerStatus = .stopped
 
     /// Called on the accept queue whenever a client connects or disconnects,
     /// with the live connection count. The Settings pane uses it to show
@@ -83,6 +100,15 @@ public final class MCPSocketServer: @unchecked Sendable {
         return listenFD >= 0
     }
 
+    /// `.conflict` outlives the failed `start()` on purpose: it is the one
+    /// failure the user can act on, and the Settings pane reads it to say who
+    /// actually owns the socket.
+    public var status: MCPSocketServerStatus {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        return statusValue
+    }
+
     public var connectionCount: Int {
         stateLock.lock()
         defer { stateLock.unlock() }
@@ -97,14 +123,10 @@ public final class MCPSocketServer: @unchecked Sendable {
         stateLock.unlock()
         guard !alreadyRunning else { return }
 
-        var address = sockaddr_un()
-        address.sun_family = sa_family_t(AF_UNIX)
-        let pathBytes = Array(socketPath.utf8)
         // One byte is reserved for the terminating NUL. Checked before
         // anything touches the filesystem, so an unusable path fails as
         // itself rather than as whatever the first syscall happened to hit.
-        let capacity = MemoryLayout.size(ofValue: address.sun_path) - 1
-        guard pathBytes.count <= capacity else {
+        guard var address = Self.unixAddress(for: socketPath) else {
             throw MCPSocketError.pathTooLong(socketPath)
         }
 
@@ -117,10 +139,20 @@ public final class MCPSocketServer: @unchecked Sendable {
         }
 
         // A socket file left behind by a crash refuses `bind` with EADDRINUSE
-        // forever. Removing it is safe precisely because a live server holds
-        // no lock on the inode: if another Vibe Bar really is listening, the
-        // `listen` below is what fails, not this.
+        // forever, so it has to go — but a *live* server's socket looks
+        // identical on disk, and unlinking that one would leave the other
+        // instance accepting on an inode no client can reach any more. Ask
+        // first: a connect that succeeds means someone is answering.
         if FileManager.default.fileExists(atPath: socketPath) {
+            guard !Self.isAnyoneListening(atPath: socketPath) else {
+                stateLock.lock()
+                statusValue = .conflict
+                stateLock.unlock()
+                SafeLog.warn(
+                    "MCP server did not start: \(SafeLog.sanitize(socketPath)) is served by another instance."
+                )
+                throw MCPSocketError.socketOwnedByAnotherInstance(socketPath)
+            }
             do {
                 try FileManager.default.removeItem(atPath: socketPath)
             } catch {
@@ -130,13 +162,6 @@ public final class MCPSocketServer: @unchecked Sendable {
 
         let fd = socket(AF_UNIX, SOCK_STREAM, 0)
         guard fd >= 0 else { throw MCPSocketError.socketCreationFailed(errno) }
-
-        withUnsafeMutableBytes(of: &address.sun_path) { raw in
-            guard let base = raw.baseAddress else { return }
-            base.initializeMemory(as: UInt8.self, repeating: 0, count: raw.count)
-            base.copyMemory(from: pathBytes, byteCount: pathBytes.count)
-        }
-        address.sun_len = UInt8(MemoryLayout<sockaddr_un>.size)
 
         // The window between `bind` (which creates the file) and `chmod` is
         // the only moment the socket could be group/other-accessible, so the
@@ -172,6 +197,7 @@ public final class MCPSocketServer: @unchecked Sendable {
         listenFD = fd
         acceptSource = source
         didBindSocketFile = true
+        statusValue = .listening
         stateLock.unlock()
 
         source.resume()
@@ -187,6 +213,7 @@ public final class MCPSocketServer: @unchecked Sendable {
         connections = [:]
         listenFD = -1
         didBindSocketFile = false
+        statusValue = .stopped
         stateLock.unlock()
 
         source?.cancel()
@@ -248,6 +275,57 @@ public final class MCPSocketServer: @unchecked Sendable {
     static func setNonBlocking(_ fd: Int32) {
         let flags = fcntl(fd, F_GETFL, 0)
         _ = fcntl(fd, F_SETFL, flags | O_NONBLOCK)
+    }
+
+    // MARK: - Address + liveness
+
+    /// `nil` when the path cannot fit in `sun_path`.
+    private static func unixAddress(for path: String) -> sockaddr_un? {
+        var address = sockaddr_un()
+        address.sun_family = sa_family_t(AF_UNIX)
+        let bytes = Array(path.utf8)
+        guard bytes.count <= MemoryLayout.size(ofValue: address.sun_path) - 1 else { return nil }
+        withUnsafeMutableBytes(of: &address.sun_path) { raw in
+            guard let base = raw.baseAddress else { return }
+            base.initializeMemory(as: UInt8.self, repeating: 0, count: raw.count)
+            base.copyMemory(from: bytes, byteCount: bytes.count)
+        }
+        address.sun_len = UInt8(MemoryLayout<sockaddr_un>.size)
+        return address
+    }
+
+    /// Is a server actually accepting on this path?
+    ///
+    /// The filesystem cannot answer this — a socket inode looks the same
+    /// whether its server is alive or was killed — so ask the kernel with a
+    /// throwaway connect. `ECONNREFUSED` (nobody is listening) and `ENOENT`
+    /// (the file went away underneath us) both mean the inode is stale and
+    /// safe to unlink; a completed handshake means it is not.
+    ///
+    /// Non-blocking, because an `AF_UNIX` connect against a server whose
+    /// backlog is full parks until a slot opens, and a busy peer is still a
+    /// live peer — `poll` bounds that wait.
+    static func isAnyoneListening(atPath path: String, timeoutMilliseconds: Int32 = 250) -> Bool {
+        guard var address = unixAddress(for: path) else { return false }
+        let fd = socket(AF_UNIX, SOCK_STREAM, 0)
+        guard fd >= 0 else { return false }
+        defer { close(fd) }
+        setNonBlocking(fd)
+
+        let result = withUnsafePointer(to: &address) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockaddrPointer in
+                Darwin.connect(fd, sockaddrPointer, socklen_t(MemoryLayout<sockaddr_un>.size))
+            }
+        }
+        if result == 0 { return true }
+        guard errno == EINPROGRESS || errno == EAGAIN || errno == EALREADY else { return false }
+
+        var descriptor = pollfd(fd: fd, events: Int16(POLLOUT), revents: 0)
+        guard poll(&descriptor, 1, timeoutMilliseconds) > 0 else { return false }
+        var pending: Int32 = 0
+        var length = socklen_t(MemoryLayout<Int32>.size)
+        guard getsockopt(fd, SOL_SOCKET, SO_ERROR, &pending, &length) == 0 else { return false }
+        return pending == 0
     }
 }
 

--- a/Sources/VibeBarCore/Services/QuotaRefreshScheduler.swift
+++ b/Sources/VibeBarCore/Services/QuotaRefreshScheduler.swift
@@ -126,11 +126,21 @@ public final class QuotaRefreshScheduler {
     /// actually missing/stale/expired cache must not remain silently visible.
     /// This path refreshes only the affected accounts and does not trigger a
     /// full cost scan.
+    ///
+    /// `tools` narrows it further, for callers that asked about a named
+    /// provider — the MCP `quota.refresh` tool, mainly. `nil` means every
+    /// visible account; an explicitly empty list matches nothing, the same
+    /// way every other list filter in the app reads it.
     @discardableResult
-    public func triggerRefreshForStaleCacheIfNeeded(now: Date = Date()) -> Bool {
+    public func triggerRefreshForStaleCacheIfNeeded(
+        tools: [ToolType]? = nil,
+        now: Date = Date()
+    ) -> Bool {
+        let wanted = tools.map(Set.init)
         let maxAge = TimeInterval(max(60, intervalProvider()))
         let accounts = accountsProvider().filter { account in
-            !isQueued(account.id)
+            (wanted?.contains(account.tool) ?? true)
+                && !isQueued(account.id)
                 && !service.inFlightAccountIds.contains(account.id)
                 && service.needsRefresh(accountId: account.id, now: now, maxAge: maxAge)
         }

--- a/Tests/VibeBarCoreTests/MCPFixtures.swift
+++ b/Tests/VibeBarCoreTests/MCPFixtures.swift
@@ -18,12 +18,25 @@ final class FakeMCPDataSource: MCPDataSource, @unchecked Sendable {
     private(set) var lastRequestPageSize: Int?
     private(set) var lastSessionQuery: String?
     private(set) var lastSessionLimit: Int?
-    private(set) var refreshCalls: [(tools: [ToolType]?, force: Bool)] = []
+
+    /// `refreshQuota` is the one method a test drives from two tasks at once,
+    /// so its recording is the one that needs a lock.
+    private let refreshLock = NSLock()
+    private var recordedRefreshCalls: [(tools: [ToolType]?, force: Bool)] = []
+    var refreshCalls: [(tools: [ToolType]?, force: Bool)] {
+        refreshLock.lock()
+        defer { refreshLock.unlock() }
+        return recordedRefreshCalls
+    }
 
     /// Flip to make every ledger-backed tool report the "no ledger" failure.
     var ledgerAvailable = true
     /// What `refreshQuota` claims happened.
     var refreshTriggered = true
+    /// How long `refreshQuota` stays inside the data source. Non-nil keeps two
+    /// concurrent calls overlapping long enough to expose a throttle that
+    /// admits before it marks.
+    var refreshDuration: Duration?
 
     // MARK: Identity
 
@@ -95,7 +108,11 @@ final class FakeMCPDataSource: MCPDataSource, @unchecked Sendable {
     }
 
     func refreshQuota(tools: [ToolType]?, force: Bool) async throws -> MCPRefreshResultDTO {
-        refreshCalls.append((tools, force))
+        refreshLock.lock()
+        recordedRefreshCalls.append((tools, force))
+        let duration = refreshDuration
+        refreshLock.unlock()
+        if let duration { try? await Task.sleep(for: duration) }
         return MCPRefreshResultDTO(
             triggered: refreshTriggered,
             mode: force ? "forced" : "stale-only",

--- a/Tests/VibeBarCoreTests/MCPSocketServerTests.swift
+++ b/Tests/VibeBarCoreTests/MCPSocketServerTests.swift
@@ -59,6 +59,56 @@ final class MCPSocketServerTests: XCTestCase {
         FileManager.default.createFile(atPath: socketPath, contents: Data())
         let socket = try startServer()
         XCTAssertTrue(socket.isRunning)
+        XCTAssertEqual(socket.status, .listening)
+    }
+
+    /// A second Vibe Bar — the usual case is a source build launched next to
+    /// the installed app — must not unlink a socket that is being served. The
+    /// file looks identical either way, so the check is a probe connect.
+    func testASecondServerReportsAConflictInsteadOfStealingTheSocket() throws {
+        let first = try startServer()
+        XCTAssertEqual(first.status, .listening)
+
+        let second = MCPSocketServer(
+            server: MCPServer(dataSource: FakeMCPDataSource()),
+            socketPath: socketPath
+        )
+        defer { second.stop() }
+        XCTAssertThrowsError(try second.start()) { error in
+            XCTAssertEqual(error as? MCPSocketError, .socketOwnedByAnotherInstance(socketPath))
+        }
+        XCTAssertEqual(second.status, .conflict)
+        XCTAssertFalse(second.isRunning)
+
+        // The point of the whole exercise: the first server is still there.
+        XCTAssertTrue(first.isRunning)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: socketPath))
+        let client = try MCPSocketTestClient(path: socketPath)
+        defer { client.close() }
+        let pong = try client.request(MCPTestSupport.line(id: 7, method: "ping"))
+        XCTAssertEqual(pong["id"]?.intValue, 7)
+    }
+
+    /// The conflicting server never bound, so stopping it must leave the live
+    /// server's socket file alone.
+    func testStoppingAConflictedServerDoesNotRemoveTheLiveSocket() throws {
+        let first = try startServer()
+        let second = MCPSocketServer(
+            server: MCPServer(dataSource: FakeMCPDataSource()),
+            socketPath: socketPath
+        )
+        XCTAssertThrowsError(try second.start())
+        second.stop()
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: socketPath))
+        XCTAssertTrue(first.isRunning)
+    }
+
+    func testTheLivenessProbeReadsAStaleInodeAsFree() throws {
+        FileManager.default.createFile(atPath: socketPath, contents: Data())
+        XCTAssertFalse(MCPSocketServer.isAnyoneListening(atPath: socketPath))
+        _ = try startServer()
+        XCTAssertTrue(MCPSocketServer.isAnyoneListening(atPath: socketPath))
     }
 
     func testInitializeAndToolsListOverTheSocket() throws {

--- a/Tests/VibeBarCoreTests/MCPToolCallTests.swift
+++ b/Tests/VibeBarCoreTests/MCPToolCallTests.swift
@@ -89,6 +89,45 @@ final class MCPToolCallTests: XCTestCase {
         XCTAssertFalse(second["message"]?.stringValue?.contains("Try again") ?? false)
     }
 
+    /// Two agents can call `quota.refresh {force:true}` at the same instant.
+    /// Admission has to be decided before the data source is awaited, or both
+    /// read an expired timestamp, both pass, and every provider's API is hit
+    /// twice — the exact thing the throttle exists to prevent.
+    func testConcurrentForcedRefreshesAdmitExactlyOne() async throws {
+        source.refreshDuration = .milliseconds(200)
+        async let first = call("quota.refresh", .object(["force": .bool(true)]))
+        async let second = call("quota.refresh", .object(["force": .bool(true)]))
+        let results = try await [first, second]
+
+        XCTAssertEqual(
+            results.filter { $0["triggered"]?.boolValue == true }.count,
+            1,
+            "Exactly one of two simultaneous forced refreshes may trigger."
+        )
+        XCTAssertEqual(source.refreshCalls.count, 1, "The loser must not reach the app at all.")
+        XCTAssertTrue(
+            results.contains { $0["message"]?.stringValue?.contains("Try again") ?? false },
+            "The loser is told when to retry."
+        )
+    }
+
+    /// The stale-only path takes the same `tools` filter as the forced one:
+    /// asking about one provider must not refresh the rest.
+    func testStaleOnlyRefreshPassesTheToolsFilterThrough() async throws {
+        let result = try await call("quota.refresh", .object(["tools": .array([.string("codex")])]))
+        XCTAssertEqual(result["mode"]?.stringValue, "stale-only")
+        XCTAssertEqual(source.refreshCalls.count, 1)
+        XCTAssertEqual(source.refreshCalls.first?.tools, [.codex])
+        XCTAssertEqual(source.refreshCalls.first?.force, false)
+    }
+
+    /// An explicitly empty list is a no-op rather than "everything", the same
+    /// rule `optionalEnumList` applies everywhere else.
+    func testStaleOnlyRefreshKeepsAnEmptyToolsListEmpty() async throws {
+        _ = try await call("quota.refresh", .object(["tools": .array([])]))
+        XCTAssertEqual(source.refreshCalls.first?.tools, [])
+    }
+
     // MARK: - usage
 
     func testUsageSummaryDefaultsToThirtyDaysAndReportsBothMoneyUnits() async throws {

--- a/Tests/VibeBarCoreTests/QuotaRefreshSchedulerTests.swift
+++ b/Tests/VibeBarCoreTests/QuotaRefreshSchedulerTests.swift
@@ -240,6 +240,36 @@ final class QuotaRefreshSchedulerTests: XCTestCase {
         XCTAssertNotNil(service.cachedQuota(for: other.id))
     }
 
+    /// `quota.refresh {tools:[...]}` without `force` reaches this method, so a
+    /// scoped ask must not sweep the providers the caller did not name — and
+    /// an explicitly empty list must select nothing rather than everything.
+    func testStaleCacheRefreshHonorsTheToolsFilter() async {
+        let claude = AccountIdentity(id: "scoped-claude", tool: .claude, source: .oauthCLI)
+        let gemini = AccountIdentity(id: "scoped-gemini", tool: .gemini, source: .webCookie)
+        let claudeAdapter = CountingQuotaAdapter(tool: .claude)
+        let geminiAdapter = CountingQuotaAdapter(tool: .gemini)
+        let service = QuotaService(
+            adapters: [.claude: claudeAdapter, .gemini: geminiAdapter],
+            mockProvider: { false }
+        )
+        let scheduler = QuotaRefreshScheduler(
+            service: service,
+            accountsProvider: { [claude, gemini] },
+            intervalProvider: { 600 }
+        )
+
+        // Nothing has ever been fetched, so both accounts are stale.
+        XCTAssertFalse(scheduler.triggerRefreshForStaleCacheIfNeeded(tools: []))
+        XCTAssertTrue(scheduler.triggerRefreshForStaleCacheIfNeeded(tools: [.claude]))
+        for _ in 0..<40 {
+            if claudeAdapter.fetchCount == 1 { break }
+            await Task.yield()
+        }
+
+        XCTAssertEqual(claudeAdapter.fetchCount, 1)
+        XCTAssertEqual(geminiAdapter.fetchCount, 0, "A scoped refresh must leave the others alone.")
+    }
+
     func testBoundaryRefreshRequeuesAccountCompletedEarlierInActiveWalk() async {
         let first = AccountIdentity(id: "finished-a", tool: .claude, source: .oauthCLI)
         let blocking = AccountIdentity(id: "blocking-b", tool: .gemini, source: .webCookie)

--- a/Tests/VibeBarCoreTests/UsageEventLedgerTests.swift
+++ b/Tests/VibeBarCoreTests/UsageEventLedgerTests.swift
@@ -106,9 +106,13 @@ final class UsageEventLedgerTests: XCTestCase {
         )
     }
 
-    func testInitCreatesTimeOrderedRequestIndex() throws {
-        let (_, directory) = try UsageLedgerFixtures.makeLedger("LedgerTimeIndex")
+    func testInitCreatesTimeOrderedRequestIndex() async throws {
+        let (ledger, directory) = try UsageLedgerFixtures.makeLedger("LedgerTimeIndex")
         defer { try? FileManager.default.removeItem(at: directory) }
+        // `init` schedules storage upkeep (index build + ANALYZE) on the actor;
+        // opening the file read-only while that write is in flight returns
+        // SQLITE_BUSY. Await it so the assertion is deterministic.
+        await ledger.optimizeStorage()
         let url = directory.appendingPathComponent("usage_events.sqlite3")
         var database: OpaquePointer?
         XCTAssertEqual(


### PR DESCRIPTION
## Why

Four post-merge review findings on #191 (local MCP server), all real:

- the session body-indexing privacy flag was captured once at first use, so toggling it later did nothing for MCP;
- two concurrent `quota.refresh {force:true}` calls could both pass the 20 s throttle;
- a live socket owned by another Vibe Bar instance (e.g. a source build) was unlinked as "stale", silently cutting its agents off;
- stale-only refreshes ignored the `tools` filter.

## What

- `BodyIndexingFlag` (thread-safe live accessor) shared by `SessionManagerModel` and `MCPController`.
- `MCPServer`: `admitForcedRefresh()` reserves the slot before awaiting; released if the app declines or throws. Test: two concurrent forced calls → one triggers.
- `MCPSocketServer`: probe with `connect()` before unlinking; a live listener → `.conflict` status + `socketOwnedByAnotherInstance` (Settings pane shows it). Test: second server on the same path reports conflict, first still serves.
- `QuotaRefreshScheduler.triggerRefreshForStaleCacheIfNeeded(tools:)`; `MCPController` passes the filter (empty list = no-op).

## Verification

- `swift build`, `swift test` (1697 tests, 1 skipped, 0 failures)
- `./Scripts/build_app.sh release`, `codesign -d --entitlements -` → empty `<dict/>`, `codesign --verify --deep --strict` OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)
