### PR TITLE
Prepare Vibe Bar 1.3.0 Dev build 33

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.3.0</string>
 	<key>CFBundleVersion</key>
-	<string>32</string>
+	<string>33</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>26.0</string>
 	<key>LSUIElement</key>


### PR DESCRIPTION
## Why

Cut the next Dev channel build after merging:

- #185 Notch island design proposal (docs only)
- #186 Transcript bubbles backed by NSTextView (fixes the main-thread freeze with a transcript open)
- #187 Workbench Requests / multi-window performance (icon cache, lazy table, breakdown-only load, harness index, keyset paging, ANALYZE)
- #188 Mini window SubProvider tier + harness-primary filter chips
- #189 Session ID under the transcript title
- #190 Claude session ids from the file name (fork/continued sessions) + session index v3
- #191 Local MCP server over a private socket + `--mcp-stdio` bridge + agent-setup docs/skill
- #192 MCP hardening (live privacy flag, throttle reservation, socket conflict probe, tools filter) + flaky ledger test fix

## What

- `Resources/Info.plist`: `CFBundleVersion` 32 → 33. `CFBundleShortVersionString` stays `1.3.0`.

Note for upgraders: first launch rebuilds the session index (v3) in the background and re-parses Codex rollouts once; the MCP socket `~/.vibebar/mcp.sock` appears while the app runs (Settings → MCP Server).

## Verification

- `swift build`, `swift test` (1705 tests, 1 skipped, 0 failures)
- `./Scripts/build_app.sh release`, `codesign -d --entitlements -` → empty `<dict/>`, `codesign --verify --deep --strict` OK; bundle reports build 33

Tag `v1.3.0-dev.33` will be created on the merged commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
