### PR TITLE
Answer in-flight MCP requests after the client half-closes

### DIFF
--- a/Sources/VibeBarApp/AppDelegate.swift
+++ b/Sources/VibeBarApp/AppDelegate.swift
@@ -8,7 +8,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var statusItem: StatusItemController?
 
     func applicationDidFinishLaunching(_ notification: Notification) {
-        if handleMCPStdioCommandLine() { return }
         if handleRemoteCommandLine() { return }
         // Belt-and-braces: Info.plist already sets LSUIElement, but if we are
         // launched from `swift run` (no bundle), force accessory policy here.
@@ -163,24 +162,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         environment?.remoteProbeService.stop()
         CookieRefreshScheduler.shared.stop()
         return .terminateNow
-    }
-
-    /// `--mcp-stdio`: be a plain stdio MCP server that forwards to the running
-    /// app's socket, and nothing else.
-    ///
-    /// This runs before any UI is created, so the process installs no status
-    /// item, opens no window, and builds no `AppEnvironment`. It never returns
-    /// — the pump owns the rest of this process's life — but it still reports
-    /// a `Bool` so the call site reads like `handleRemoteCommandLine()` above.
-    private func handleMCPStdioCommandLine() -> Bool {
-        guard ProcessInfo.processInfo.arguments.contains(MCPStdioBridge.commandLineFlag) else {
-            return false
-        }
-        // Belt and braces against the Dock or the app switcher noticing a
-        // process that is really a pipe.
-        NSApp.setActivationPolicy(.prohibited)
-        let code = MCPStdioBridge.run(socketPath: MCPStdioBridge.socketPath())
-        Darwin.exit(code)
     }
 
     private func handleRemoteCommandLine() -> Bool {

--- a/Sources/VibeBarApp/VibeBarApp.swift
+++ b/Sources/VibeBarApp/VibeBarApp.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 
-@main
+/// Entry is `main.swift`, which handles `--mcp-stdio` before AppKit exists
+/// and otherwise calls `VibeBarApp.main()`.
 struct VibeBarApp: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
 

--- a/Sources/VibeBarApp/main.swift
+++ b/Sources/VibeBarApp/main.swift
@@ -1,0 +1,14 @@
+import Darwin
+import Foundation
+import VibeBarCore
+
+// `--mcp-stdio` must never touch AppKit: MCP clients spawn this binary as a
+// plain child process — sometimes inside a sandbox (Codex's managed sandbox
+// aborted with SIGABRT when NSApplication came up) — and all it has to do is
+// pump stdin/stdout to the running app's socket. Decide that here, before
+// SwiftUI's `App.main()` brings up NSApplication, the Dock, or any window.
+if CommandLine.arguments.dropFirst().contains(MCPStdioBridge.commandLineFlag) {
+    exit(MCPStdioBridge.run(socketPath: MCPStdioBridge.socketPath()))
+}
+
+VibeBarApp.main()

--- a/Sources/VibeBarCore/MCP/MCPSocketServer.swift
+++ b/Sources/VibeBarCore/MCP/MCPSocketServer.swift
@@ -353,6 +353,13 @@ private final class Connection: @unchecked Sendable {
     private var source: DispatchSourceRead?
     private var buffer = Data()
     private var isClosed = false
+    /// Requests handed to `server.handle` whose reply has not been written yet.
+    private var inFlight = 0
+    /// The peer half-closed its side (`shutdown(SHUT_WR)` or EOF). We stop
+    /// reading, but keep the descriptor open until every in-flight reply is
+    /// on the wire — a scripted client that writes `initialize` +
+    /// `tools/list` and closes stdin must still get both answers.
+    private var peerFinished = false
 
     var onClose: (@Sendable (Connection) -> Void)?
 
@@ -365,7 +372,6 @@ private final class Connection: @unchecked Sendable {
     func resume() {
         let source = DispatchSource.makeReadSource(fileDescriptor: fd, queue: queue)
         source.setEventHandler { [weak self] in self?.readAvailable() }
-        source.setCancelHandler { [fd] in Darwin.close(fd) }
         self.source = source
         source.resume()
     }
@@ -374,13 +380,25 @@ private final class Connection: @unchecked Sendable {
         queue.async { [weak self] in self?.closeOnQueue() }
     }
 
+    /// Stop listening for input without closing the descriptor, so replies
+    /// still in flight can be written. `closeOnQueue` owns the descriptor.
+    private func stopReading() {
+        source?.cancel()
+        source = nil
+    }
+
     private func closeOnQueue() {
         guard !isClosed else { return }
         isClosed = true
-        source?.cancel()
-        source = nil
+        stopReading()
+        Darwin.close(fd)
         buffer = Data()
         onClose?(self)
+    }
+
+    /// Close once the peer is done *and* nothing is still being answered.
+    private func closeIfDrained() {
+        if peerFinished, inFlight == 0 { closeOnQueue() }
     }
 
     private func readAvailable() {
@@ -394,8 +412,11 @@ private final class Connection: @unchecked Sendable {
                 continue
             }
             if count == 0 {
-                // Orderly shutdown by the peer.
-                closeOnQueue()
+                // Orderly shutdown by the peer: finish what is in flight
+                // first. Stop the read source now, or EOF keeps it firing.
+                peerFinished = true
+                stopReading()
+                closeIfDrained()
                 return
             }
             if errno == EINTR { continue }
@@ -433,9 +454,15 @@ private final class Connection: @unchecked Sendable {
 
     private func dispatch(line: Data) {
         let server = self.server
+        inFlight += 1
         Task { [weak self] in
-            guard let reply = await server.handle(line: line) else { return }
-            self?.queue.async { [weak self] in self?.write(reply) }
+            let reply = await server.handle(line: line)
+            self?.queue.async { [weak self] in
+                guard let self else { return }
+                if let reply { self.write(reply) }
+                self.inFlight -= 1
+                self.closeIfDrained()
+            }
         }
     }
 

--- a/Sources/VibeBarCore/MCP/MCPSocketServer.swift
+++ b/Sources/VibeBarCore/MCP/MCPSocketServer.swift
@@ -377,7 +377,15 @@ private final class Connection: @unchecked Sendable {
     }
 
     func close() {
-        queue.async { [weak self] in self?.closeOnQueue() }
+        // Strong capture on purpose: `stop()` drops the server's references
+        // right after calling this, and a weakly captured close would let the
+        // connection deallocate with its descriptor still open.
+        queue.async { self.closeOnQueue() }
+    }
+
+    deinit {
+        // Belt and braces: never leak an accepted descriptor.
+        if !isClosed { Darwin.close(fd) }
     }
 
     /// Stop listening for input without closing the descriptor, so replies

--- a/Tests/VibeBarCoreTests/MCPSocketServerTests.swift
+++ b/Tests/VibeBarCoreTests/MCPSocketServerTests.swift
@@ -131,6 +131,27 @@ final class MCPSocketServerTests: XCTestCase {
         XCTAssertTrue(names.contains("quota.get"), "\(names)")
     }
 
+    /// A scripted client (`printf ... | VibeBar --mcp-stdio`) writes its
+    /// requests, half-closes, and expects every answer before the server
+    /// hangs up. Regression for the Dev.33 report where the replies were
+    /// dropped because EOF closed the connection while they were in flight.
+    func testRepliesInFlightAreDeliveredAfterThePeerHalfCloses() throws {
+        _ = try startServer()
+        let client = try MCPSocketTestClient(path: socketPath)
+        defer { client.close() }
+
+        try client.send(MCPTestSupport.line(id: 1, method: "initialize"))
+        try client.send(MCPTestSupport.line(id: nil, method: "notifications/initialized"))
+        try client.send(MCPTestSupport.line(id: 2, method: "tools/list"))
+        client.halfClose()
+
+        let first = try client.readLine()
+        let second = try client.readLine()
+        XCTAssertEqual(Set([first["id"]?.intValue, second["id"]?.intValue]), [1, 2])
+        // …and then the server closes on its own.
+        XCTAssertTrue(client.readUntilEOF(timeoutSeconds: 5))
+    }
+
     func testAToolCallRoundTripsOverTheSocket() throws {
         _ = try startServer()
         let client = try MCPSocketTestClient(path: socketPath)
@@ -231,6 +252,23 @@ final class MCPSocketTestClient {
 
     func close() {
         Darwin.close(fd)
+    }
+
+    /// Signal EOF to the server while keeping our read side open.
+    func halfClose() {
+        Darwin.shutdown(fd, SHUT_WR)
+    }
+
+    /// True when the server closes the connection within the timeout.
+    func readUntilEOF(timeoutSeconds: Int) -> Bool {
+        var timeout = timeval(tv_sec: timeoutSeconds, tv_usec: 0)
+        setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &timeout, socklen_t(MemoryLayout<timeval>.size))
+        var chunk = [UInt8](repeating: 0, count: 1_024)
+        while true {
+            let count = chunk.withUnsafeMutableBytes { Darwin.read(fd, $0.baseAddress, $0.count) }
+            if count == 0 { return true }
+            if count < 0 { return false }
+        }
     }
 
     func send(_ line: Data) throws {

--- a/docs/agent-setup/prompt.md
+++ b/docs/agent-setup/prompt.md
@@ -141,7 +141,10 @@ printf '%s\n%s\n' \
 
 You should see two JSON lines. The first carries
 `"serverInfo":{"name":"vibebar",…}`; the second lists the tools, including
-`quota.get`. If instead you see
+`quota.get`. (On Vibe Bar `1.3.0 (33)` and earlier the app closed the
+connection on stdin EOF before answering, so this printed nothing with exit
+0 — keep stdin open a moment, `{ printf …; sleep 1; } | … --mcp-stdio`, or
+update the app.) If instead you see
 
 ```
 Vibe Bar is not running (socket ~/.vibebar/mcp.sock not found). Launch "Vibe Bar.app" first.


### PR DESCRIPTION
## Why

Codex, following `docs/agent-setup/prompt.md` on 1.3.0 (33), reported the verification command `printf … | VibeBar --mcp-stdio` printing nothing with exit 0 unless stdin was held open ~1 s. Root cause is server-side: `Connection` closed the socket on peer EOF while `initialize` / `tools/list` were still being handled asynchronously, so the replies were dropped (`write` is guarded by `isClosed`). Codex also noted the bridge aborts (134) inside its managed sandbox — NSApplication was coming up before the flag was handled.

## What

- `MCPSocketServer.Connection`: track in-flight requests; on peer EOF stop reading but keep the descriptor open until every reply is written, then close. Regression test: send `initialize` + notification + `tools/list`, half-close, expect both answers and then server-side EOF.
- `--mcp-stdio` is now handled in a new `main.swift` before `VibeBarApp.main()` — no AppKit, no NSApplication, just the pump (`@main` removed from `VibeBarApp`; the delegate helper is gone).
- `docs/agent-setup/prompt.md`: note the 1.3.0 (33) behaviour and the `sleep 1` workaround for older builds.

## Verification

- `swift build`, `swift test` (1706 tests, 1 skipped, 0 failures)
- `./Scripts/build_app.sh release`, `codesign -d --entitlements -` → empty `<dict/>`, `codesign --verify --deep --strict` OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)
