### PR TITLE
Make skills discovery cancellable and add a skills.install MCP tool

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -388,17 +388,26 @@ and it is documented rather than hidden for that reason.
 
 **Tools.** `quota.get`, `quota.refresh`, `usage.summary`, `usage.trend`,
 `usage.requests`, `cost.snapshot`, `cost.history`, `sessions.search`,
-`sessions.list`, `status.get`, `pricing.effective`, plus the
+`sessions.list`, `status.get`, `pricing.effective`, `skills.install`, plus the
 `vibebar://naming-spec` and `vibebar://tools` resources. The naming-spec
 resource is **generated** from `ProviderHierarchyCatalog`, `ToolType` and
 `HarnessCatalog` — never transcribe § 7.1 into it by hand, because a stale
 spec teaches a model a label that no longer exists. `MCPResourceCatalogTests`
 enforces that every harness, company and provider key appears.
 
-**Privacy.** Everything is read-only except `quota.refresh`, which is
-gated on `AppSettings.mcpServer.allowRefreshTools` and throttled to one
-forced refresh per 20 s. Credentials, cookies and organization ids are
-never projected; emails go through `EmailMasker`; `cost.*` respects
+**Privacy.** Everything is read-only except two tools. `quota.refresh`
+is gated on `AppSettings.mcpServer.allowRefreshTools` and throttled to
+one forced refresh per 20 s. `skills.install` is gated on
+`AppSettings.mcpServer.allowSkillInstall` and is the only tool that
+writes: it parses its `source` into a `SkillInstallSource` (a
+`SkillRepoRef` or an absolute local directory — a github.com URL is
+folded into the former, never fetched as an arbitrary file) and hands it
+to the app-wide `SkillsService`, so the § 7 write allowlist holds for
+agents exactly as it does for the Workbench. That service lives on
+`AppEnvironment` and is shared with the Skills page: two instances would
+each read-modify-write `~/.vibebar/skills.json`. Credentials, cookies and
+organization ids are never projected; emails go through `EmailMasker`;
+`cost.*` respects
 `AppSettings.costData.privacyModeEnabled` the way `CostUsageService` does.
 When adding a tool, add its projection to `MCPDTOs.swift` rather than
 encoding a Core type directly — the DTO layer is where "what may an agent
@@ -545,6 +554,12 @@ Tests keep working because they pass an explicit value.
   AntiGravity's customization root, not the Gemini CLI's — nothing else
   under `~/.gemini/config/` may be touched. New code that needs a skills
   path goes through those two types; do not add a second write path.
+  That includes the MCP surface: `skills.install` (§ 5.1) resolves its
+  `source` to a repository ref or a local directory and then calls
+  `SkillsService.install(from:enableFor:method:)`, which reuses the same
+  discovery, SSOT copy, and materialization the Workbench uses. An agent
+  can therefore reach no path a user could not, and the gate on it is a
+  settings toggle, not a second implementation.
 - **Performance.** Avoid `TimelineView(.periodic(...))` in deep view
   trees that may be eagerly instantiated; prefer scoping to the visible
   surface. The mini window's screen position is persisted to its own
@@ -884,6 +899,16 @@ Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
   and a round-trip test. Migrations must be one-time and evidence-based; never
   rewrite a currently selectable value (such as a refresh interval) on every
   launch.
+- **A URLSession request timeout is an idle timer, not a deadline.**
+  `timeoutIntervalForRequest` fires only when *nothing* arrives for that
+  long, so a slow trickle holds a download open forever. Anything a user
+  waits on needs a wall-clock budget of its own
+  (`timeoutIntervalForResource`, or a deadline recomputed across
+  retries — see `SkillRepoFetcher.maxWallTime`) **and** a way out:
+  `BoundedDownloader` fails with `CancellationError` when its task is
+  cancelled. A long-running action in a view model should hold its
+  `Task` so the button can become Cancel, and should say what it is
+  doing while it runs.
 - **Mini-window geometry stays in `mini_window_geometry.json`.** Do not
   fold it back into `AppSettings` — every settings write fans out to
   every Combine subscriber.

--- a/Sources/VibeBarApp/AppEnvironment.swift
+++ b/Sources/VibeBarApp/AppEnvironment.swift
@@ -22,6 +22,12 @@ final class AppEnvironment: ObservableObject {
     /// Local MCP server. Built here so its lifetime matches the app's; the
     /// socket itself exists only while `AppSettings.mcpServer.enabled` is on.
     private(set) var mcp: MCPController!
+    /// One skills actor for the whole process, shared by the Workbench's
+    /// Skills page and the MCP `skills.install` tool. Two instances would mean
+    /// two writers doing read-modify-write on `~/.vibebar/skills.json`, so an
+    /// agent installing a skill while the page is open could drop a record.
+    /// Free to hold: the registry file is read lazily on first access.
+    let skillsService = SkillsService()
 
     @Published private(set) var hasClaudeWebCookies: Bool
     @Published private(set) var hasOpenAIWebCookies: Bool
@@ -573,7 +579,8 @@ final class AppEnvironment: ObservableObject {
         let services = WorkbenchServices(
             usageLedger: usageLedger,
             costService: costService,
-            settingsStore: settingsStore
+            settingsStore: settingsStore,
+            skillsService: skillsService
         )
         workbenchServicesStorage = services
         return services

--- a/Sources/VibeBarApp/Controllers/SkillsManagerModel.swift
+++ b/Sources/VibeBarApp/Controllers/SkillsManagerModel.swift
@@ -48,6 +48,14 @@ final class SkillsManagerModel: ObservableObject {
 
     @Published private(set) var repoList: [String] = []
     @Published private(set) var discoverResults: [DiscoveredSkill] = []
+    /// What the running scan is doing, shown under the button. A repository
+    /// zipball is megabytes over someone else's network; without this the
+    /// sheet is a spinner with no story.
+    @Published private(set) var discoverPhase: String?
+    /// One line per repository the scan could not read, kept on screen after
+    /// the scan ends — a toast that has already faded cannot explain an empty
+    /// results list.
+    @Published private(set) var discoverFailures: [String] = []
     /// What produced `discoverResults`. Shown in the sheet because a single
     /// staging directory backs them: scanning the configured repos and
     /// installing a skills.sh hit are the same operation underneath, and the
@@ -60,6 +68,9 @@ final class SkillsManagerModel: ObservableObject {
     private let service: SkillsService
     private let searchClient: SkillsSearchClient
     private var searchTask: Task<Void, Never>?
+    /// Held so "Scan repos" can become "Cancel". Discovery is the one action
+    /// here that can legitimately run for a minute.
+    private var discoverTask: Task<Void, Never>?
     private var hasActivated = false
 
     init(
@@ -207,8 +218,12 @@ final class SkillsManagerModel: ObservableObject {
 
     // MARK: - Discovery
 
+    var isDiscovering: Bool { isBusy(BusyKey.discover) }
+
     func discover() {
-        perform(BusyKey.discover) { [self] in
+        discoverFailures = []
+        discoverPhase = nil
+        discoverTask = perform(BusyKey.discover) { [self] in
             let refs = await service.discoverRepoRefs()
             guard !refs.isEmpty else {
                 discoverResults = []
@@ -216,11 +231,43 @@ final class SkillsManagerModel: ObservableObject {
                 toast = "Add a repository first."
                 return
             }
-            discoverResults = await service.discoverSkills(from: refs)
+            // The phases arrive from the download tasks; the hop back is what
+            // keeps `@Published` on the main actor.
+            let result = await service.discover(from: refs) { [weak self] phase in
+                Task { @MainActor in self?.discoverPhase = Self.text(for: phase) }
+            }
+            discoverPhase = nil
+            discoverResults = result.skills
             discoverSource = "Configured repositories"
-            if discoverResults.isEmpty {
+            discoverFailures = result.failures.map(\.displayText)
+            if result.wasCancelled {
+                toast = "Stopped scanning."
+            } else if !result.failures.isEmpty {
+                toast = result.failures.count == 1
+                    ? result.failures[0].displayText
+                    : "\(result.failures.count) repositories could not be read."
+            } else if result.skills.isEmpty {
                 toast = "No skills were found in the configured repositories."
             }
+        }
+    }
+
+    /// Stops an in-flight scan. The service returns what it already had, so
+    /// the results list keeps any repository that finished first.
+    func cancelDiscover() {
+        discoverTask?.cancel()
+    }
+
+    private static func text(for phase: SkillDiscoveryPhase) -> String {
+        switch phase {
+        case let .downloading(slug):
+            return "Downloading \(slug)…"
+        case let .scanning(slug):
+            return "Scanning \(slug)…"
+        case let .repositoryFinished(_, completed, total):
+            return total == 1
+                ? "Downloaded 1 repository"
+                : "Downloaded \(completed) of \(total) repositories"
         }
     }
 
@@ -230,6 +277,10 @@ final class SkillsManagerModel: ObservableObject {
     func discoverSheetDismissed() {
         searchTask?.cancel()
         searchTask = nil
+        discoverTask?.cancel()
+        discoverTask = nil
+        discoverPhase = nil
+        discoverFailures = []
         Task { [service] in await service.clearDiscoveryStaging() }
         discoverResults = []
         discoverSource = nil
@@ -415,12 +466,22 @@ final class SkillsManagerModel: ObservableObject {
 
     /// Runs one mutating action: guards re-entry on `key`, reloads the
     /// registry when it finishes, and routes any error to `toast`.
-    private func perform(_ key: String, _ body: @MainActor @escaping () async throws -> Void) {
-        guard !busy.contains(key) else { return }
+    ///
+    /// Returns the task so a long-running action can be cancelled later; `nil`
+    /// means the key was already busy and nothing new was started.
+    @discardableResult
+    private func perform(
+        _ key: String,
+        _ body: @MainActor @escaping () async throws -> Void
+    ) -> Task<Void, Never>? {
+        guard !busy.contains(key) else { return nil }
         busy.insert(key)
-        Task {
+        return Task {
             do {
                 try await body()
+            } catch is CancellationError {
+                // The user asked for it; the action that was cancelled says
+                // what happened, if anything needs saying at all.
             } catch {
                 toast = error.localizedDescription
             }

--- a/Sources/VibeBarApp/Controllers/WorkbenchServices.swift
+++ b/Sources/VibeBarApp/Controllers/WorkbenchServices.swift
@@ -13,11 +13,18 @@ final class WorkbenchServices: ObservableObject {
     private let usageLedger: UsageEventLedger?
     private let costService: CostUsageService
     private let settingsStore: SettingsStore
+    private let skillsService: SkillsService
 
-    init(usageLedger: UsageEventLedger?, costService: CostUsageService, settingsStore: SettingsStore) {
+    init(
+        usageLedger: UsageEventLedger?,
+        costService: CostUsageService,
+        settingsStore: SettingsStore,
+        skillsService: SkillsService
+    ) {
         self.usageLedger = usageLedger
         self.costService = costService
         self.settingsStore = settingsStore
+        self.skillsService = skillsService
     }
 
     lazy var usageStats = UsageStatsViewModel(
@@ -29,6 +36,7 @@ final class WorkbenchServices: ObservableObject {
 
     /// Lazy for the same reason as the usage page, and more so: building it
     /// opens `~/.vibebar/skills.json` and, on first activation, walks every
-    /// agent CLI's skills directory.
-    lazy var skills = SkillsManagerModel(settingsStore: settingsStore)
+    /// agent CLI's skills directory. The service behind it is the app-wide
+    /// one, shared with MCP's `skills.install`.
+    lazy var skills = SkillsManagerModel(settingsStore: settingsStore, service: skillsService)
 }

--- a/Sources/VibeBarApp/MCPController.swift
+++ b/Sources/VibeBarApp/MCPController.swift
@@ -433,4 +433,34 @@ final class MCPController: ObservableObject, MCPDataSource {
     func effectivePricing() async throws -> [EffectiveModelPricingRow] {
         PricingResolver.active.effectiveModelPrices
     }
+
+    // MARK: - MCPDataSource: skills
+
+    /// The only tool that writes, and it writes nothing this app could not
+    /// already write: `SkillsService` owns the SSOT copy, the per-app
+    /// projection, and the write allowlist (`AGENTS.md` § 7). Everything here
+    /// is the gate and the hand-off.
+    func installSkill(
+        source: SkillInstallSource,
+        apps: [SkillAppTarget],
+        method: SkillSyncMethod
+    ) async throws -> MCPSkillInstallDTO {
+        guard let environment else { throw MCPToolFailure("Vibe Bar is shutting down.") }
+        guard environment.settingsStore.settings.mcpServer.allowSkillInstall else {
+            throw MCPToolFailure(
+                "Installing skills from agents is switched off in Vibe Bar → Settings → MCP Server. "
+                    + "The user can install it themselves from Workbench → Skills → Discover."
+            )
+        }
+        let outcome = try await environment.skillsService.install(
+            from: source,
+            enableFor: apps,
+            method: method
+        )
+        // Directory names only: the source can be a path under the user's home.
+        SafeLog.info(
+            "MCP: installed \(outcome.installed.map(\.skill.directory).joined(separator: ", "))"
+        )
+        return MCPSkillInstallDTO(outcome: outcome)
+    }
 }

--- a/Sources/VibeBarApp/Views/MCPSettingsSection.swift
+++ b/Sources/VibeBarApp/Views/MCPSettingsSection.swift
@@ -140,6 +140,18 @@ struct MCPSettingsSection: View {
                 .font(.caption)
                 .foregroundStyle(.secondary)
 
+            Toggle(
+                "Allow agents to install skills",
+                isOn: $settingsStore.settings.mcpServer.allowSkillInstall
+            )
+            .toggleStyle(.switch)
+            .controlSize(.small)
+            .disabled(!settingsStore.settings.mcpServer.enabled)
+
+            Text("With this on, an agent can call skills.install to add a skill from a GitHub repository or a local folder. It goes through the same Skills manager as Workbench → Skills, so it writes only to ~/.agents/skills and the agent skills directories Vibe Bar manages — never over a folder a different skill already holds. With it off the tool reports that installing is disabled.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
             Text("Everything else agents can reach is read-only: quota, token usage, cost, provider status, effective model prices, and the local session index (titles, projects, and — when session body indexing is on — message excerpts). Credentials, cookies and organization ids are never exposed, and email addresses are masked.")
                 .font(.caption2)
                 .foregroundStyle(.tertiary)

--- a/Sources/VibeBarApp/Views/Workbench/SkillDiscoverSheet.swift
+++ b/Sources/VibeBarApp/Views/Workbench/SkillDiscoverSheet.swift
@@ -71,23 +71,48 @@ struct SkillDiscoverSheet: View {
                 sectionTitle("Configured repositories")
                 Spacer(minLength: 8)
                 Button {
-                    model.discover()
+                    if model.isDiscovering {
+                        model.cancelDiscover()
+                    } else {
+                        model.discover()
+                    }
                 } label: {
                     HStack(spacing: 5) {
-                        if model.isBusy(SkillsManagerModel.BusyKey.discover) {
+                        if model.isDiscovering {
                             ProgressView().controlSize(.small).scaleEffect(0.7)
                                 .frame(width: 12, height: 12)
                         } else {
                             Image(systemName: "arrow.down.circle")
                                 .font(.system(size: max(9, density.segmentedFontSize - 1), weight: .semibold))
                         }
-                        Text("Scan repos")
+                        // A download nobody can stop is the whole complaint
+                        // this button answers.
+                        Text(model.isDiscovering ? "Cancel" : "Scan repos")
                             .font(.system(size: density.segmentedFontSize - 1, weight: .semibold))
                     }
                     .frame(minHeight: 22)
                 }
                 .buttonStyle(.bordered)
-                .disabled(model.repoList.isEmpty)
+                .disabled(model.repoList.isEmpty && !model.isDiscovering)
+                .help(model.isDiscovering ? "Stop the running scan" : "Download every configured repository")
+            }
+
+            if let phase = model.discoverPhase {
+                Text(phase)
+                    .font(.system(size: max(9, density.resetCountdownFontSize)))
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+
+            ForEach(model.discoverFailures, id: \.self) { failure in
+                HStack(alignment: .firstTextBaseline, spacing: 5) {
+                    Image(systemName: "exclamationmark.triangle")
+                        .font(.system(size: max(8, density.resetCountdownFontSize - 1)))
+                    Text(failure)
+                        .font(.system(size: max(9, density.resetCountdownFontSize)))
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                .foregroundStyle(.orange)
             }
 
             if model.repoList.isEmpty {

--- a/Sources/VibeBarCore/MCP/MCPDTOs.swift
+++ b/Sources/VibeBarCore/MCP/MCPDTOs.swift
@@ -698,6 +698,75 @@ public struct MCPPricingDTO: Codable, Equatable, Sendable {
     }
 }
 
+// MARK: - skills.install
+
+public struct MCPInstalledSkillDTO: Codable, Equatable, Sendable {
+    public let id: String
+    public let name: String
+    public let description: String?
+    /// SSOT directory name — what every agent CLI sees the skill as.
+    public let directory: String
+    public let branch: String?
+    /// Where the payload lives: `~/.agents/skills/<directory>`.
+    public let path: String
+    /// App key → the directory the skill was projected into. Empty when the
+    /// caller installed without naming any app, which is a valid outcome:
+    /// the skill is on the machine, switched on for nobody.
+    public let projectedTo: [String: String]
+
+    public init(installed: SkillInstallOutcome.Installed) {
+        self.id = installed.skill.id.rawValue
+        self.name = installed.skill.name
+        self.description = installed.skill.description
+        self.directory = installed.skill.directory
+        self.branch = installed.skill.repoBranch
+        self.path = installed.path
+        self.projectedTo = Dictionary(
+            uniqueKeysWithValues: installed.projectedTo.map { ($0.key.rawValue, $0.value) }
+        )
+    }
+}
+
+public struct MCPSkippedSkillDTO: Codable, Equatable, Sendable {
+    public let name: String
+    public let reason: String
+
+    public init(skipped: SkillInstallOutcome.Skipped) {
+        self.name = skipped.name
+        self.reason = skipped.reason
+    }
+}
+
+public struct MCPSkillInstallDTO: Codable, Equatable, Sendable {
+    public let source: String
+    public let installed: [MCPInstalledSkillDTO]
+    public let skipped: [MCPSkippedSkillDTO]
+    /// A sentence the agent can repeat to the user. Built here rather than in
+    /// the caller so every transport says the same thing.
+    public let message: String
+
+    public init(outcome: SkillInstallOutcome) {
+        self.source = outcome.source
+        self.installed = outcome.installed.map(MCPInstalledSkillDTO.init(installed:))
+        self.skipped = outcome.skipped.map(MCPSkippedSkillDTO.init(skipped:))
+        self.message = Self.message(for: outcome)
+    }
+
+    private static func message(for outcome: SkillInstallOutcome) -> String {
+        guard let first = outcome.installed.first else {
+            return "Nothing was installed from \(outcome.source)."
+        }
+        let names = outcome.installed.map(\.skill.name).joined(separator: ", ")
+        let apps = first.projectedTo.keys.map(\.displayName).sorted()
+        if apps.isEmpty {
+            return "Installed \(names) into \(first.path). No agent has it switched on yet — "
+                + "pass 'apps' to project it into an agent's skills directory."
+        }
+        return "Installed \(names) into \(first.path) and projected it into "
+            + "\(apps.joined(separator: ", "))."
+    }
+}
+
 // MARK: - Server identity
 
 public struct MCPServerInfo: Codable, Equatable, Sendable {

--- a/Sources/VibeBarCore/MCP/MCPResourceCatalog.swift
+++ b/Sources/VibeBarCore/MCP/MCPResourceCatalog.swift
@@ -166,7 +166,8 @@ public enum MCPResourceCatalog {
 
         Vibe Bar exposes one Mac's local AI usage. Everything is read from the
         running app's own caches; nothing here calls a provider directly except
-        `quota.refresh`, which asks the app to.
+        `quota.refresh`, which asks the app to. `skills.install` is the one tool
+        that writes, and only inside the skills directories Vibe Bar manages.
 
         ## Routing
 
@@ -185,6 +186,7 @@ public enum MCPResourceCatalog {
         | "what have I been working on?" | `sessions.list` |
         | "is Anthropic down?" | `status.get` |
         | "why is this model costing so much?" | `pricing.effective` |
+        | "install the Vibe Bar skill" / "add this skill" | `skills.install` |
 
         ## Rules that keep the answer right
 
@@ -207,5 +209,12 @@ public enum MCPResourceCatalog {
         - **Request-level history is about 30 days deep.** Older usage survives as
           daily totals, visible through `usage.summary` and `usage.trend` but not
           through `usage.requests`.
+        - **`skills.install` installs; it does not browse.** Name a source —
+          `owner/repo`, `owner/repo@branch`, either plus `#<skill>` when the
+          repository holds several, a github.com URL, or an absolute local
+          directory — and pass `apps` for the agent CLIs that should get it.
+          Without `apps` the skill lands in `~/.agents/skills/` switched on for
+          nobody. It can be switched off in Settings → MCP Server, in which case
+          the tool says so rather than failing silently.
         """
 }

--- a/Sources/VibeBarCore/MCP/MCPServer.swift
+++ b/Sources/VibeBarCore/MCP/MCPServer.swift
@@ -74,6 +74,16 @@ public protocol MCPDataSource: AnyObject, Sendable {
 
     func serviceStatus(tools: [ToolType]?) async throws -> MCPServiceStatusDTO
     func effectivePricing() async throws -> [EffectiveModelPricingRow]
+
+    /// The one tool that writes. Implementations gate it on
+    /// `AppSettings.mcpServer.allowSkillInstall` and route it through
+    /// `SkillsService`, so the write allowlist in `AGENTS.md` § 7 holds for
+    /// agents exactly as it does for the Workbench.
+    func installSkill(
+        source: SkillInstallSource,
+        apps: [SkillAppTarget],
+        method: SkillSyncMethod
+    ) async throws -> MCPSkillInstallDTO
 }
 
 // MARK: - Server
@@ -238,6 +248,7 @@ public final class MCPServer: @unchecked Sendable {
         case "sessions.list":     return try await sessionsList(arguments)
         case "status.get":        return try await statusGet(arguments)
         case "pricing.effective": return try await pricingEffective(arguments)
+        case "skills.install":    return try await skillsInstall(arguments)
         default:                  throw MCPRPCError.invalidParams("Unknown tool '\(tool)'.")
         }
     }
@@ -404,6 +415,30 @@ public final class MCPServer: @unchecked Sendable {
                 return row.model.lowercased().contains(needle)
             }
         return MCPPricingDTO(generatedAt: now(), rows: rows.map(MCPPricingRowDTO.init(row:)))
+    }
+
+    /// The source string is parsed here, before the app is involved: a typo or
+    /// an off-allowlist host is the caller's to fix, and saying so as
+    /// `invalidParams` keeps it out of the Skills manager entirely.
+    private func skillsInstall(_ arguments: MCPArguments) async throws -> MCPSkillInstallDTO {
+        let raw = try arguments.requiredString("source")
+        let source: SkillInstallSource
+        do {
+            source = try SkillInstallSource(raw)
+        } catch {
+            throw MCPRPCError.invalidParams("skills.install: \(error.localizedDescription)")
+        }
+        let apps = try arguments.optionalEnumList("apps", SkillAppTarget.self) ?? []
+        var method = SkillSyncMethod.auto
+        if let requested = try arguments.optionalEnum("method", SkillSyncMethod.self) {
+            guard requested != .auto else {
+                throw MCPRPCError.invalidParams(
+                    "skills.install: 'method' must be 'symlink' or 'copy'; omit it for the default."
+                )
+            }
+            method = requested
+        }
+        return try await dataSource.installSkill(source: source, apps: apps, method: method)
     }
 
     // MARK: Forced-refresh throttle

--- a/Sources/VibeBarCore/MCP/MCPToolCatalog.swift
+++ b/Sources/VibeBarCore/MCP/MCPToolCatalog.swift
@@ -43,7 +43,8 @@ public enum MCPToolCatalog {
         sessionsSearch,
         sessionsList,
         statusGet,
-        pricingEffective
+        pricingEffective,
+        skillsInstall
     ]
 
     public static func tool(named name: String) -> MCPTool? {
@@ -348,5 +349,37 @@ public enum MCPToolCatalog {
             ),
             "model": string("Case-insensitive substring of the model id.")
         ])
+    )
+
+    public static let skillsInstall = MCPTool(
+        name: "skills.install",
+        title: "Install an agent skill",
+        description: """
+            Install a skill through Vibe Bar's Skills manager: one copy in ~/.agents/skills/, projected \
+            into whichever agent CLIs you name. This is the non-UI equivalent of Workbench → Skills → \
+            Install, and the only write tool here. 'source' is 'owner/repo', 'owner/repo@branch', either \
+            with '#<skill>' when the repository holds more than one (the error lists them), a github.com \
+            repository / branch / archive URL, or an absolute path to a local directory containing \
+            SKILL.md. Installing without 'apps' puts the skill on the machine without switching it on for \
+            anyone — pass 'apps' to project it. Re-installing something already installed just enables the \
+            extra apps; it never overwrites the local copy. Vibe Bar's own companion skill is \
+            'AstroQore/vibe-bar'.
+            """,
+        inputSchema: object(
+            properties: [
+                "source": string(
+                    "owner/repo[@branch][#skill], a github.com URL, or an absolute local directory."
+                ),
+                "apps": stringEnumList(
+                    SkillAppTarget.allCases.map(\.rawValue),
+                    description: "Agent CLIs to project the skill into. Omit to install without enabling it anywhere."
+                ),
+                "method": string(
+                    "How to project it: 'symlink' (default, one copy) or 'copy' (independent per app).",
+                    enumValues: [SkillSyncMethod.symlink.rawValue, SkillSyncMethod.copy.rawValue]
+                )
+            ],
+            required: ["source"]
+        )
     )
 }

--- a/Sources/VibeBarCore/Models/AppSettings.swift
+++ b/Sources/VibeBarCore/Models/AppSettings.swift
@@ -1336,9 +1336,9 @@ public struct CostDataSettings: Codable, Equatable, Sendable {
     }
 }
 
-/// The local MCP server's two switches.
+/// The local MCP server's three switches.
 ///
-/// Both default to **on**, which is a deliberate choice rather than an
+/// All default to **on**, which is a deliberate choice rather than an
 /// oversight. The whole point of the feature is that configuring a client is
 /// one line and needs no trip through Settings first, and the exposure is
 /// bounded by what the socket already is: a 0600 file inside a 0700 directory,
@@ -1355,14 +1355,24 @@ public struct MCPServerSettings: Codable, Equatable, Sendable {
     /// so an agent learns the numbers are cached instead of silently believing
     /// it just refreshed them.
     public var allowRefreshTools: Bool
+    /// Whether `skills.install` may write. On by default because it writes
+    /// only where the Skills manager already may — `~/.agents/skills/` and the
+    /// managed app skills directories — through the same `SkillsService`, and
+    /// because the agent asking is one the user already gave a shell.
+    public var allowSkillInstall: Bool
 
-    public init(enabled: Bool = true, allowRefreshTools: Bool = true) {
+    public init(
+        enabled: Bool = true,
+        allowRefreshTools: Bool = true,
+        allowSkillInstall: Bool = true
+    ) {
         self.enabled = enabled
         self.allowRefreshTools = allowRefreshTools
+        self.allowSkillInstall = allowSkillInstall
     }
 
     private enum CodingKeys: String, CodingKey {
-        case enabled, allowRefreshTools
+        case enabled, allowRefreshTools, allowSkillInstall
     }
 
     public init(from decoder: Decoder) throws {
@@ -1370,11 +1380,14 @@ public struct MCPServerSettings: Codable, Equatable, Sendable {
         self.enabled = try c.decodeIfPresent(Bool.self, forKey: .enabled) ?? Self.default.enabled
         self.allowRefreshTools =
             try c.decodeIfPresent(Bool.self, forKey: .allowRefreshTools) ?? Self.default.allowRefreshTools
+        self.allowSkillInstall =
+            try c.decodeIfPresent(Bool.self, forKey: .allowSkillInstall) ?? Self.default.allowSkillInstall
     }
 
     public func encode(to encoder: Encoder) throws {
         var c = encoder.container(keyedBy: CodingKeys.self)
         try c.encode(enabled, forKey: .enabled)
         try c.encode(allowRefreshTools, forKey: .allowRefreshTools)
+        try c.encode(allowSkillInstall, forKey: .allowSkillInstall)
     }
 }

--- a/Sources/VibeBarCore/Skills/SkillInstallSource.swift
+++ b/Sources/VibeBarCore/Skills/SkillInstallSource.swift
@@ -1,0 +1,212 @@
+import Foundation
+
+/// Where a one-shot skill install is being asked to read from.
+///
+/// This is the non-UI entry point into the Skills manager: an agent naming a
+/// skill in one string, the way a person would write it in chat. Three
+/// spellings reach the same two cases —
+///
+/// - `owner/repo`, `owner/repo@branch`, either plus `#directory`;
+/// - a GitHub URL on `SkillRepoFetcher.allowedHosts` (the repository page, a
+///   `/tree/<branch>` page, or an `/archive/….zip`), which is folded back into
+///   the first case rather than downloaded as an arbitrary file;
+/// - an absolute local directory holding `SKILL.md`.
+///
+/// Folding URLs into `SkillRepoRef` is the security-relevant part: nothing
+/// here can turn into "download whatever this URL points at". A host outside
+/// the allowlist is refused during parsing, before any network call, and the
+/// download still goes through `SkillRepoFetching` with its size cap and
+/// redirect allowlist.
+public enum SkillInstallSource: Sendable, Equatable {
+    /// A GitHub repository, optionally narrowed to one skill directory inside
+    /// it. `skillDirectory` is required when the repository holds several.
+    case repository(ref: SkillRepoRef, skillDirectory: String?)
+    /// A directory on this Mac that is itself a skill.
+    case localDirectory(URL)
+
+    /// How the source was written, for echoing back in a result.
+    public var descriptor: String {
+        switch self {
+        case let .repository(ref, skillDirectory):
+            return skillDirectory.map { "\(ref.descriptor)#\($0)" } ?? ref.descriptor
+        case let .localDirectory(url):
+            return url.path
+        }
+    }
+
+    public init(_ raw: String, homeDirectory: String = RealHomeDirectory.path) throws {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { throw SkillInstallSourceError.unrecognized(raw) }
+
+        if trimmed.hasPrefix("/") {
+            self = .localDirectory(URL(fileURLWithPath: trimmed, isDirectory: true))
+            return
+        }
+        if trimmed == "~" || trimmed.hasPrefix("~/") {
+            // Expanded here rather than by Foundation, so the one helper that
+            // owns "the user's real home" stays the only one that answers it.
+            let relative = String(trimmed.dropFirst(2))
+            let home = URL(fileURLWithPath: homeDirectory, isDirectory: true)
+            self = .localDirectory(
+                relative.isEmpty ? home : home.appendingPathComponent(relative, isDirectory: true)
+            )
+            return
+        }
+        if trimmed.lowercased().hasPrefix("http://") || trimmed.lowercased().hasPrefix("https://") {
+            self = try Self.parseURL(trimmed)
+            return
+        }
+        if trimmed.hasPrefix(".") || trimmed.contains("\\") {
+            throw SkillInstallSourceError.notAbsolutePath(trimmed)
+        }
+        self = try Self.parseSlug(trimmed)
+    }
+
+    // MARK: - Internals
+
+    private static func parseSlug(_ raw: String) throws -> SkillInstallSource {
+        var body = raw
+        var directory: String?
+        if let marker = body.firstIndex(of: "#") {
+            directory = String(body[body.index(after: marker)...])
+            body = String(body[body.startIndex..<marker])
+        }
+        guard let ref = SkillRepoRef(body) else {
+            throw SkillInstallSourceError.unrecognized(raw)
+        }
+        if let directory {
+            guard SkillPathValidator.isValid(directory) else {
+                throw SkillInstallSourceError.invalidSkillDirectory(directory)
+            }
+        }
+        return .repository(ref: ref, skillDirectory: directory)
+    }
+
+    /// GitHub spellings an agent plausibly pastes, all resolved to a ref. The
+    /// host check happens first: an off-allowlist URL is refused here, not
+    /// followed and then rejected.
+    private static func parseURL(_ raw: String) throws -> SkillInstallSource {
+        guard let url = URL(string: raw), let host = url.host?.lowercased() else {
+            throw SkillInstallSourceError.unrecognized(raw)
+        }
+        guard url.scheme?.lowercased() == "https" else {
+            throw SkillInstallSourceError.insecureURL(raw)
+        }
+        guard SkillRepoFetcher.allowedHosts.contains(host) else {
+            throw SkillInstallSourceError.hostNotAllowed(host)
+        }
+        var components = url.path.split(separator: "/").map(String.init)
+        guard components.count >= 2 else { throw SkillInstallSourceError.unsupportedURL(raw) }
+        let owner = components.removeFirst()
+        var repo = components.removeFirst()
+        if repo.hasSuffix(".git") { repo = String(repo.dropLast(4)) }
+
+        var branch: String?
+        if let kind = components.first {
+            var rest = Array(components.dropFirst())
+            // `/refs/heads/<branch>` and a bare `<branch>` are both in the
+            // wild; so is `.zip` on the end of either.
+            if rest.first == "refs", rest.dropFirst().first == "heads" { rest = Array(rest.dropFirst(2)) }
+            switch kind {
+            case "archive", "zip", "tree", "blob":
+                guard var last = rest.last else { throw SkillInstallSourceError.unsupportedURL(raw) }
+                if last.hasSuffix(".zip") { last = String(last.dropLast(4)) }
+                branch = last
+            default:
+                throw SkillInstallSourceError.unsupportedURL(raw)
+            }
+        }
+        guard let ref = SkillRepoRef(owner: owner, repo: repo, branch: branch) else {
+            throw SkillInstallSourceError.unrecognized(raw)
+        }
+        var directory: String?
+        if let fragment = url.fragment, !fragment.isEmpty {
+            guard SkillPathValidator.isValid(fragment) else {
+                throw SkillInstallSourceError.invalidSkillDirectory(fragment)
+            }
+            directory = fragment
+        }
+        return .repository(ref: ref, skillDirectory: directory)
+    }
+}
+
+public enum SkillInstallSourceError: Error, Equatable, Sendable {
+    case unrecognized(String)
+    case notAbsolutePath(String)
+    case insecureURL(String)
+    case hostNotAllowed(String)
+    case unsupportedURL(String)
+    case invalidSkillDirectory(String)
+    case noSkillsFound(String)
+    case ambiguous(source: String, available: [String])
+    case skillNotFound(name: String, source: String, available: [String])
+}
+
+extension SkillInstallSourceError: LocalizedError {
+    public var errorDescription: String? {
+        switch self {
+        case let .unrecognized(raw):
+            return "\"\(raw)\" is not owner/repo[@branch][#skill], a github.com URL, "
+                + "or an absolute path to a skill directory."
+        case let .notAbsolutePath(raw):
+            return "\"\(raw)\" is a relative path. Local sources must be absolute."
+        case let .insecureURL(raw):
+            return "\"\(raw)\" is not https."
+        case let .hostNotAllowed(host):
+            return "Skills can only be installed from \(SkillRepoFetcher.allowedHosts.sorted().joined(separator: " and "))"
+                + ", not \"\(host)\"."
+        case let .unsupportedURL(raw):
+            return "\"\(raw)\" is not a repository, branch, or archive URL. "
+                + "Use owner/repo[@branch] instead."
+        case let .invalidSkillDirectory(name):
+            return "\"\(name)\" is not a usable skill directory name."
+        case let .noSkillsFound(source):
+            return "No SKILL.md was found in \(source)."
+        case let .ambiguous(source, available):
+            return "\(source) holds several skills. Name one with "
+                + "'\(source)#<skill>': \(available.joined(separator: ", "))."
+        case let .skillNotFound(name, source, available):
+            return "\(source) has no skill called \"\(name)\". It has: "
+                + "\(available.joined(separator: ", "))."
+        }
+    }
+}
+
+/// What one `install(from:enableFor:method:)` call did.
+public struct SkillInstallOutcome: Sendable {
+    public struct Installed: Sendable {
+        public let skill: Skill
+        /// The SSOT directory the payload now lives in.
+        public let path: String
+        /// Per app, where the skill was projected to.
+        public let projectedTo: [SkillAppTarget: String]
+
+        public init(skill: Skill, path: String, projectedTo: [SkillAppTarget: String]) {
+            self.skill = skill
+            self.path = path
+            self.projectedTo = projectedTo
+        }
+    }
+
+    /// A skill that was found but not installed — a name already held by a
+    /// different skill, most often.
+    public struct Skipped: Sendable {
+        public let name: String
+        public let reason: String
+
+        public init(name: String, reason: String) {
+            self.name = name
+            self.reason = reason
+        }
+    }
+
+    public let source: String
+    public let installed: [Installed]
+    public let skipped: [Skipped]
+
+    public init(source: String, installed: [Installed], skipped: [Skipped]) {
+        self.source = source
+        self.installed = installed
+        self.skipped = skipped
+    }
+}

--- a/Sources/VibeBarCore/Skills/SkillRepoFetcher.swift
+++ b/Sources/VibeBarCore/Skills/SkillRepoFetcher.swift
@@ -126,6 +126,7 @@ public enum SkillRepoError: Error, Equatable, Sendable {
     case invalidRepositoryReference(String)
     case branchNotFound(slug: String, tried: [String])
     case malformedArchive(String)
+    case timedOut(slug: String, seconds: Int)
 }
 
 extension SkillRepoError: LocalizedError {
@@ -134,9 +135,11 @@ extension SkillRepoError: LocalizedError {
         case let .invalidRepositoryReference(raw):
             return "\"\(raw)\" is not a valid owner/repo reference."
         case let .branchNotFound(slug, tried):
-            return "Could not download \(slug) (tried \(tried.joined(separator: ", "))))."
+            return "Could not download \(slug) (tried \(tried.joined(separator: ", ")))."
         case let .malformedArchive(detail):
             return "The repository archive was not laid out as expected (\(detail))."
+        case let .timedOut(slug, seconds):
+            return "Downloading \(slug) timed out after \(seconds) s."
         }
     }
 }
@@ -168,26 +171,39 @@ public protocol SkillRepoFetching: Sendable {
 /// `[requested, main, master]`: a 404 is a normal outcome for `main` on older
 /// repositories, not an error worth surfacing. Only when every candidate fails
 /// does this report `branchNotFound`, naming what it tried.
+///
+/// One repository gets `maxWallTime` in total, spread across every candidate
+/// branch it tries. `timeout` alone cannot bound this: it is an idle timer per
+/// request, so three candidates each dribbling bytes could hold a "Scan repos"
+/// spinner open indefinitely. The remaining budget is recomputed before each
+/// candidate and handed to the downloader as its resource ceiling.
 public struct SkillRepoFetcher: SkillRepoFetching {
     /// A GitHub zipball of a skills repository is a few hundred KB; 128 MiB is
     /// a hard stop for something that has gone wrong, not a working budget.
     public static let maxArchiveBytes: Int64 = 128 * 1024 * 1024
     public static let defaultTimeout: TimeInterval = 60
+    /// Wall-clock ceiling for one repository, every branch candidate included.
+    /// A `vibe-bar`-sized zipball (8 MB) lands in about four seconds, so this
+    /// is a "something is wrong" stop, not a working budget.
+    public static let maxWallTime: TimeInterval = 120
     public static let allowedHosts: Set<String> = ["github.com", "codeload.github.com"]
     public static let fallbackBranches = ["main", "master"]
 
     private let downloader: BoundedDownloader
     private let maxArchiveBytes: Int64
     private let timeout: TimeInterval
+    private let maxWallTime: TimeInterval
 
     public init(
         downloader: BoundedDownloader = BoundedDownloader(),
         maxArchiveBytes: Int64 = SkillRepoFetcher.maxArchiveBytes,
-        timeout: TimeInterval = SkillRepoFetcher.defaultTimeout
+        timeout: TimeInterval = SkillRepoFetcher.defaultTimeout,
+        maxWallTime: TimeInterval = SkillRepoFetcher.maxWallTime
     ) {
         self.downloader = downloader
         self.maxArchiveBytes = maxArchiveBytes
         self.timeout = timeout
+        self.maxWallTime = maxWallTime
     }
 
     public static func archiveURL(owner: String, repo: String, branch: String) -> URL? {
@@ -200,9 +216,14 @@ public struct SkillRepoFetcher: SkillRepoFetching {
     ) async throws -> (root: URL, resolvedBranch: String) {
         let candidates = Self.branchCandidates(for: ref)
         try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        let deadline = Date().addingTimeInterval(maxWallTime)
+        let expired = SkillRepoError.timedOut(slug: ref.slug, seconds: Int(maxWallTime.rounded()))
 
         var lastError: Error?
         for branch in candidates {
+            try Task.checkCancellation()
+            let remaining = deadline.timeIntervalSinceNow
+            guard remaining > 0 else { throw expired }
             guard let url = Self.archiveURL(owner: ref.owner, repo: ref.repo, branch: branch) else { continue }
             let zipURL = tempDir.appendingPathComponent("\(ref.repo)-\(branch).zip")
             do {
@@ -210,8 +231,9 @@ public struct SkillRepoFetcher: SkillRepoFetching {
                     from: url,
                     to: zipURL,
                     maxBytes: maxArchiveBytes,
-                    timeout: timeout,
-                    allowedHosts: Self.allowedHosts
+                    timeout: min(timeout, remaining),
+                    allowedHosts: Self.allowedHosts,
+                    resourceTimeout: remaining
                 )
             } catch let error as BoundedDownloader.DownloadError {
                 // A redirect off the allowlist is a security signal, not a
@@ -219,11 +241,18 @@ public struct SkillRepoFetcher: SkillRepoFetching {
                 if case .redirectHostNotAllowed = error { throw error }
                 lastError = error
                 continue
+            } catch is CancellationError {
+                throw CancellationError()
+            } catch let error as URLError where error.code == .timedOut {
+                // The budget is per repository, not per branch: a candidate
+                // that ran out of clock means the next one has none either.
+                throw expired
             } catch {
                 lastError = error
                 continue
             }
             defer { try? FileManager.default.removeItem(at: zipURL) }
+            try Task.checkCancellation()
             let extraction = tempDir.appendingPathComponent("extract-\(branch)", isDirectory: true)
             try? FileManager.default.removeItem(at: extraction)
             try SkillArchiveExtractor.extract(zipFileURL: zipURL, into: extraction)

--- a/Sources/VibeBarCore/Skills/SkillsService+Repositories.swift
+++ b/Sources/VibeBarCore/Skills/SkillsService+Repositories.swift
@@ -17,6 +17,54 @@ public struct SkillUpdateState: Sendable, Hashable, Identifiable {
     }
 }
 
+/// One repository a discovery pass could not read.
+///
+/// Discovery is a browser, not a transaction, so a repository that 404s or
+/// times out must not take the others down with it — but it must not vanish
+/// either. This is what the UI shows instead of an empty list with no
+/// explanation.
+public struct SkillDiscoveryFailure: Sendable, Hashable, Identifiable {
+    public let slug: String
+    public let message: String
+    /// True when the user (or the surrounding task) called it off, which is
+    /// not a failure worth an error style in the UI.
+    public let wasCancelled: Bool
+
+    public var id: String { slug }
+
+    public init(slug: String, message: String, wasCancelled: Bool) {
+        self.slug = slug
+        self.message = message
+        self.wasCancelled = wasCancelled
+    }
+
+    /// `AstroQore/vibe-bar: timed out after 120 s.`
+    public var displayText: String { "\(slug): \(message)" }
+}
+
+public struct SkillDiscoveryResult: Sendable {
+    public let skills: [DiscoveredSkill]
+    public let failures: [SkillDiscoveryFailure]
+    public let wasCancelled: Bool
+
+    public init(skills: [DiscoveredSkill], failures: [SkillDiscoveryFailure], wasCancelled: Bool) {
+        self.skills = skills
+        self.failures = failures
+        self.wasCancelled = wasCancelled
+    }
+}
+
+/// What a discovery pass is doing right now.
+///
+/// Downloading a repository zipball is seconds of silence at best and a stuck
+/// spinner at worst, so the pass narrates itself. The phases carry data, not
+/// sentences: the wording belongs to the surface that shows it.
+public enum SkillDiscoveryPhase: Sendable, Equatable {
+    case downloading(slug: String)
+    case scanning(slug: String)
+    case repositoryFinished(slug: String, completed: Int, total: Int)
+}
+
 /// The repository-facing half of `SkillsService`: browse, install, check, and
 /// update.
 ///
@@ -62,46 +110,136 @@ extension SkillsService {
 
     /// Downloads `repos` in parallel and lists the skills in them.
     ///
+    /// Convenience over `discover(from:progress:)` for callers that only want
+    /// the skills; per-repository failures are logged and dropped.
+    public func discoverSkills(from repos: [SkillRepoRef]) async -> [DiscoveredSkill] {
+        await discover(from: repos).skills
+    }
+
+    /// Downloads `repos` in parallel, lists the skills in them, and reports
+    /// what each repository is doing while it happens.
+    ///
     /// The results point into a staging directory this actor owns; it survives
     /// until the next discovery pass or `clearDiscoveryStaging()`, which is
     /// what makes `install(_:enableFor:)` able to copy from them later.
-    public func discoverSkills(from repos: [SkillRepoRef]) async -> [DiscoveredSkill] {
-        guard !repos.isEmpty else { return [] }
+    ///
+    /// Cancellable: cancelling the calling task cancels every in-flight
+    /// download, and the pass returns whatever finished plus a `wasCancelled`
+    /// failure for each repository that did not. `progress` is called from the
+    /// download tasks, so it must be safe to call from any thread.
+    public func discover(
+        from repos: [SkillRepoRef],
+        progress: (@Sendable (SkillDiscoveryPhase) -> Void)? = nil
+    ) async -> SkillDiscoveryResult {
+        guard !repos.isEmpty else {
+            return SkillDiscoveryResult(skills: [], failures: [], wasCancelled: false)
+        }
         clearDiscoveryStaging()
         let staging = Self.temporaryDirectory(prefix: "discover")
         do {
             try FileManager.default.createDirectory(at: staging, withIntermediateDirectories: true)
         } catch {
             SafeLog.warn("Skills discovery: no staging directory")
-            return []
+            return SkillDiscoveryResult(
+                skills: [],
+                failures: repos.map {
+                    SkillDiscoveryFailure(
+                        slug: $0.slug,
+                        message: "no staging directory could be created",
+                        wasCancelled: false
+                    )
+                },
+                wasCancelled: false
+            )
         }
         discoveryStaging = staging
 
         let fetcher = self.fetcher
-        let discovered = await withTaskGroup(of: [DiscoveredSkill].self) { group in
+        let total = repos.count
+        let outcomes = await withTaskGroup(of: RepositoryOutcome.self) { group in
             for (index, ref) in repos.enumerated() {
                 let directory = staging.appendingPathComponent("repo-\(index)", isDirectory: true)
                 group.addTask {
                     do {
+                        progress?(.downloading(slug: ref.slug))
                         let (root, branch) = try await fetcher.downloadRepo(ref, into: directory)
-                        return try fetcher.scanSkills(inRepoRoot: root, ref: ref, resolvedBranch: branch)
+                        progress?(.scanning(slug: ref.slug))
+                        return .found(try fetcher.scanSkills(inRepoRoot: root, ref: ref, resolvedBranch: branch))
                     } catch {
                         SafeLog.warn(
                             "Skills discovery skipped \(ref.slug): \(SafeLog.sanitize(error.localizedDescription))"
                         )
-                        return []
+                        return .failed(Self.failure(for: error, slug: ref.slug))
                     }
                 }
             }
-            var all: [DiscoveredSkill] = []
-            for await batch in group { all.append(contentsOf: batch) }
-            return all
+            var collected: [RepositoryOutcome] = []
+            for await outcome in group {
+                collected.append(outcome)
+                progress?(
+                    .repositoryFinished(
+                        slug: outcome.slug ?? "",
+                        completed: collected.count,
+                        total: total
+                    )
+                )
+            }
+            return collected
         }
 
+        var discovered: [DiscoveredSkill] = []
+        var failures: [SkillDiscoveryFailure] = []
+        for outcome in outcomes {
+            switch outcome {
+            case let .found(skills): discovered.append(contentsOf: skills)
+            case let .failed(failure): failures.append(failure)
+            }
+        }
         var seen = Set<SkillID>()
-        return discovered
-            .filter { seen.insert($0.id).inserted }
-            .sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+        return SkillDiscoveryResult(
+            skills: discovered
+                .filter { seen.insert($0.id).inserted }
+                .sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending },
+            failures: failures.sorted { $0.slug.localizedCaseInsensitiveCompare($1.slug) == .orderedAscending },
+            wasCancelled: Task.isCancelled || failures.contains { $0.wasCancelled }
+        )
+    }
+
+    private enum RepositoryOutcome: Sendable {
+        case found([DiscoveredSkill])
+        case failed(SkillDiscoveryFailure)
+
+        var slug: String? {
+            switch self {
+            case let .found(skills): return skills.first?.repositorySlug
+            case let .failed(failure): return failure.slug
+            }
+        }
+    }
+
+    /// Cancellation reaches here in two spellings — `CancellationError` from
+    /// the cooperative checks, and `URLError.cancelled` from a URLSession task
+    /// that was already in flight — and neither should read as a broken
+    /// repository.
+    ///
+    /// The timeout is re-phrased rather than quoted: `displayText` already
+    /// prefixes the slug, and the error's own description names it too.
+    static func failure(for error: Error, slug: String) -> SkillDiscoveryFailure {
+        if error is CancellationError || (error as? URLError)?.code == .cancelled {
+            return SkillDiscoveryFailure(slug: slug, message: "cancelled", wasCancelled: true)
+        }
+        if let repoError = error as? SkillRepoError, case let .timedOut(_, seconds) = repoError {
+            return SkillDiscoveryFailure(
+                slug: slug,
+                message: "timed out after \(seconds) s",
+                wasCancelled: false
+            )
+        }
+        return SkillDiscoveryFailure(
+            slug: slug,
+            message: error.localizedDescription,
+            wasCancelled: false
+        )
     }
 
     /// Drops the extracted repositories the last discovery pass left behind.

--- a/Sources/VibeBarCore/Skills/SkillsService+Repositories.swift
+++ b/Sources/VibeBarCore/Skills/SkillsService+Repositories.swift
@@ -513,7 +513,10 @@ extension SkillsService {
 
     /// Installs one already-extracted skill directory as a `.local` skill and
     /// enables the requested apps. Filesystem first, store second.
-    private func installLocalDirectory(
+    ///
+    /// Internal rather than private: `SkillsService+SourceInstall` installs a
+    /// directory the user pointed at through the same path.
+    func installLocalDirectory(
         at source: URL,
         directoryName: String,
         enableFor apps: [SkillAppTarget],

--- a/Sources/VibeBarCore/Skills/SkillsService+SourceInstall.swift
+++ b/Sources/VibeBarCore/Skills/SkillsService+SourceInstall.swift
@@ -1,0 +1,160 @@
+import Foundation
+
+/// One-shot install from a source someone named, rather than one they picked
+/// out of a discovery list.
+///
+/// This is what the MCP `skills.install` tool calls, and it deliberately goes
+/// through the *same* `install(_:enableFor:method:)` and
+/// `installLocalDirectory(...)` the Workbench uses: same SSOT copy, same
+/// `SkillSyncEngine` materialization, same write allowlist. Nothing here
+/// touches the filesystem itself, so there is exactly one place where a skill
+/// can land on disk.
+///
+/// It does not share the discovery staging directory. The Workbench keeps that
+/// alive so its rows stay installable, and an agent installing a skill in the
+/// background must not delete the tree the user is looking at — so this owns a
+/// temporary directory for the length of the call and removes it.
+extension SkillsService {
+    @discardableResult
+    public func install(
+        from source: SkillInstallSource,
+        enableFor apps: [SkillAppTarget] = [],
+        method: SkillSyncMethod = .auto
+    ) async throws -> SkillInstallOutcome {
+        switch source {
+        case let .repository(ref, skillDirectory):
+            return try await installFromRepository(
+                ref: ref,
+                skillDirectory: skillDirectory,
+                descriptor: source.descriptor,
+                apps: apps,
+                method: method
+            )
+        case let .localDirectory(url):
+            return try await installFromLocalPath(at: url, apps: apps, method: method)
+        }
+    }
+
+    // MARK: - Repository
+
+    private func installFromRepository(
+        ref: SkillRepoRef,
+        skillDirectory: String?,
+        descriptor: String,
+        apps: [SkillAppTarget],
+        method: SkillSyncMethod
+    ) async throws -> SkillInstallOutcome {
+        let staging = Self.temporaryDirectory(prefix: "mcp-install")
+        defer { try? FileManager.default.removeItem(at: staging) }
+        try FileManager.default.createDirectory(at: staging, withIntermediateDirectories: true)
+
+        let (root, branch) = try await fetcher.downloadRepo(ref, into: staging)
+        let discovered = try fetcher.scanSkills(inRepoRoot: root, ref: ref, resolvedBranch: branch)
+        guard !discovered.isEmpty else {
+            throw SkillInstallSourceError.noSkillsFound(ref.slug)
+        }
+
+        let target: DiscoveredSkill
+        if let skillDirectory {
+            // A repository lays a skill out under a directory but names it in
+            // frontmatter; an agent will have read either one.
+            guard let match = Self.match(directory: skillDirectory, in: discovered)
+                ?? discovered.first(where: { $0.name.caseInsensitiveCompare(skillDirectory) == .orderedSame })
+            else {
+                throw SkillInstallSourceError.skillNotFound(
+                    name: skillDirectory,
+                    source: ref.slug,
+                    available: discovered.map(\.directory)
+                )
+            }
+            target = match
+        } else if discovered.count == 1 {
+            target = discovered[0]
+        } else {
+            // Installing all of them is not a reasonable guess: a skills
+            // collection can hold dozens, and each one is a directory in
+            // every enabled agent CLI.
+            throw SkillInstallSourceError.ambiguous(
+                source: ref.descriptor,
+                available: discovered.map(\.directory)
+            )
+        }
+
+        let skill = try await install(target, enableFor: apps, method: method)
+        return SkillInstallOutcome(
+            source: descriptor,
+            installed: [record(skill)],
+            skipped: []
+        )
+    }
+
+    // MARK: - Local directory
+
+    /// The local half is deliberately narrow: one directory that is itself a
+    /// skill. `kind(of:)` lstats, so a symlink is refused rather than followed
+    /// — a link is an invitation to copy from somewhere the caller never
+    /// named.
+    private func installFromLocalPath(
+        at url: URL,
+        apps: [SkillAppTarget],
+        method: SkillSyncMethod
+    ) async throws -> SkillInstallOutcome {
+        let source = url.standardizedFileURL
+        guard SkillFileSystem.kind(of: source) == .directory else {
+            throw SkillError.sourceNotADirectory(source.path)
+        }
+        let directoryName = source.lastPathComponent
+        try SkillPathValidator.validate(directoryName: directoryName)
+        guard SkillTreeScanner.isSkillDirectory(source) else {
+            throw SkillError.missingSkillMD(directoryName)
+        }
+
+        // Re-pointing at a directory that is already installed is an enable,
+        // matching what `install(_:enableFor:)` does for a repository skill.
+        if let existing = await store.skill(directory: directoryName) {
+            guard existing.id == .local(directory: directoryName) else {
+                throw SkillError.directoryConflict(directoryName)
+            }
+            var skill = existing
+            for app in apps {
+                skill.apps[app] = try engine.materialize(
+                    skillDirectoryName: skill.directory,
+                    into: app,
+                    method: method,
+                    recorded: skill.apps[app]
+                )
+            }
+            try await store.upsert(skill)
+            return SkillInstallOutcome(
+                source: source.path,
+                installed: [record(skill)],
+                skipped: [SkillInstallOutcome.Skipped(name: directoryName, reason: "already installed")]
+            )
+        }
+
+        let skill = try await installLocalDirectory(
+            at: source,
+            directoryName: directoryName,
+            enableFor: apps,
+            method: method
+        )
+        return SkillInstallOutcome(source: source.path, installed: [record(skill)], skipped: [])
+    }
+
+    // MARK: - Internals
+
+    private func record(_ skill: Skill) -> SkillInstallOutcome.Installed {
+        var projected: [SkillAppTarget: String] = [:]
+        for app in skill.enabledApps {
+            projected[app] = SkillAppCatalog
+                .skillsDirectory(for: app, homeDirectory: homeDirectory)
+                .appendingPathComponent(skill.directory, isDirectory: true)
+                .path
+        }
+        return SkillInstallOutcome.Installed(
+            skill: skill,
+            path: ssotDirectory(for: skill.directory).path,
+            projectedTo: projected
+        )
+    }
+}

--- a/Sources/VibeBarCore/Utilities/BoundedDownloader.swift
+++ b/Sources/VibeBarCore/Utilities/BoundedDownloader.swift
@@ -23,6 +23,17 @@ import Foundation
 /// The session is created per download from a caller-supplied configuration —
 /// ephemeral by default, so nothing is cached, and injectable so tests can
 /// stub `URLProtocol`.
+///
+/// Two clocks, because they answer different questions. `timeout` is
+/// `timeoutIntervalForRequest` — an *idle* timer that only fires when nothing
+/// arrives for that long, so a server dribbling one byte a second can hold a
+/// download open forever. `resourceTimeout` is the wall-clock ceiling on the
+/// whole transfer, redirects included. A user watching a spinner cares about
+/// the second one.
+///
+/// Cancellation is cooperative: cancelling the surrounding `Task` cancels the
+/// URLSession task and fails the call with `CancellationError`, partial file
+/// removed, rather than leaving the caller awaiting a body nobody wants.
 public struct BoundedDownloader: Sendable {
     public typealias ConfigurationProvider = @Sendable () -> URLSessionConfiguration
 
@@ -46,14 +57,17 @@ public struct BoundedDownloader: Sendable {
     ///
     /// Throws before touching the network on a non-https URL or a host outside
     /// `allowedHosts`; throws mid-stream once more than `maxBytes` have
-    /// arrived. `fileURL` only exists when this returns normally.
+    /// arrived, once `resourceTimeout` elapses, or once the calling `Task` is
+    /// cancelled. `fileURL` only exists when this returns normally.
     public func download(
         from url: URL,
         to fileURL: URL,
         maxBytes: Int64,
         timeout: TimeInterval,
-        allowedHosts: Set<String>
+        allowedHosts: Set<String>,
+        resourceTimeout: TimeInterval? = nil
     ) async throws {
+        try Task.checkCancellation()
         let hosts = Set(allowedHosts.map { $0.lowercased() })
         try Self.validate(url: url, allowedHosts: hosts)
 
@@ -75,6 +89,9 @@ public struct BoundedDownloader: Sendable {
 
         let configuration = makeConfiguration()
         configuration.timeoutIntervalForRequest = timeout
+        if let resourceTimeout, resourceTimeout > 0 {
+            configuration.timeoutIntervalForResource = resourceTimeout
+        }
         configuration.requestCachePolicy = .reloadIgnoringLocalCacheData
         let queue = OperationQueue()
         queue.maxConcurrentOperationCount = 1
@@ -83,9 +100,23 @@ public struct BoundedDownloader: Sendable {
         defer { session.invalidateAndCancel() }
 
         do {
-            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
-                sink.onFinish = { continuation.resume(with: $0) }
-                session.dataTask(with: request).resume()
+            let task = session.dataTask(with: request)
+            try await withTaskCancellationHandler {
+                try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+                    sink.setFinish { continuation.resume(with: $0) }
+                    // Cancellation between the handler being installed and the
+                    // task starting would otherwise wait on a body that is
+                    // never requested.
+                    guard !Task.isCancelled else {
+                        sink.cancelByCaller()
+                        sink.complete(.failure(CancellationError()))
+                        return
+                    }
+                    task.resume()
+                }
+            } onCancel: {
+                sink.cancelByCaller()
+                task.cancel()
             }
         } catch {
             try? handle.close()
@@ -112,10 +143,11 @@ public struct BoundedDownloader: Sendable {
         "\(url.host ?? "?")\(url.path)"
     }
 
-    /// Owns the byte budget for one download. Every callback lands on the
-    /// session's serial delegate queue, so the counters need no locking; the
-    /// one cross-thread hand-off (`onFinish`) is installed before the task is
-    /// resumed and read only from that queue.
+    /// Owns the byte budget for one download. The counters are touched only on
+    /// the session's serial delegate queue, so they need no locking; the two
+    /// cross-thread facts — the continuation hand-off and the caller's cancel
+    /// flag — are guarded, because cancellation arrives from whatever thread
+    /// cancelled the `Task`.
     private final class Sink: NSObject, URLSessionDataDelegate, @unchecked Sendable {
         private let handle: FileHandle
         private let maxBytes: Int64
@@ -123,12 +155,41 @@ public struct BoundedDownloader: Sendable {
         private var received: Int64 = 0
         private var failure: Error?
 
-        var onFinish: ((Result<Void, Error>) -> Void)?
+        private let lock = NSLock()
+        private var finish: ((Result<Void, Error>) -> Void)?
+        private var cancelledByCaller = false
 
         init(handle: FileHandle, maxBytes: Int64, allowedHosts: Set<String>) {
             self.handle = handle
             self.maxBytes = maxBytes
             self.allowedHosts = allowedHosts
+        }
+
+        func setFinish(_ handler: @escaping (Result<Void, Error>) -> Void) {
+            lock.lock()
+            finish = handler
+            lock.unlock()
+        }
+
+        /// Resumes the continuation exactly once, whoever gets here first.
+        func complete(_ result: Result<Void, Error>) {
+            lock.lock()
+            let handler = finish
+            finish = nil
+            lock.unlock()
+            handler?(result)
+        }
+
+        func cancelByCaller() {
+            lock.lock()
+            cancelledByCaller = true
+            lock.unlock()
+        }
+
+        var wasCancelledByCaller: Bool {
+            lock.lock()
+            defer { lock.unlock() }
+            return cancelledByCaller
         }
 
         func urlSession(
@@ -157,6 +218,11 @@ public struct BoundedDownloader: Sendable {
 
         func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {
             guard failure == nil else { return }
+            // A caller that has walked away is not owed the rest of the body.
+            guard !wasCancelledByCaller else {
+                dataTask.cancel()
+                return
+            }
             received += Int64(data.count)
             if received > maxBytes {
                 failure = DownloadError.tooLarge(limit: maxBytes)
@@ -193,14 +259,17 @@ public struct BoundedDownloader: Sendable {
         }
 
         func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
-            let finish = onFinish
-            onFinish = nil
-            if let failure {
-                finish?(.failure(failure))
+            // The caller's cancellation wins over whatever URLSession reports
+            // for the task it just cancelled, so the caller sees the reason it
+            // asked for rather than `NSURLErrorCancelled`.
+            if wasCancelledByCaller {
+                complete(.failure(CancellationError()))
+            } else if let failure {
+                complete(.failure(failure))
             } else if let error {
-                finish?(.failure(error))
+                complete(.failure(error))
             } else {
-                finish?(.success(()))
+                complete(.success(()))
             }
         }
     }

--- a/Tests/VibeBarCoreTests/AppSettingsTests.swift
+++ b/Tests/VibeBarCoreTests/AppSettingsTests.swift
@@ -193,6 +193,28 @@ final class AppSettingsTests: XCTestCase {
         XCTAssertEqual(unknown.displayMode, .used)
     }
 
+    func testMCPSkillInstallDefaultsToOnAndRoundTrips() throws {
+        // A settings file written before `skills.install` existed must decode
+        // to the same "on" the feature ships with, not to a switch the user
+        // never saw and cannot explain.
+        let legacy = try JSONDecoder().decode(
+            AppSettings.self,
+            from: Data(#"{"displayMode":"remaining","mcpServer":{"enabled":true}}"#.utf8)
+        )
+        XCTAssertTrue(legacy.mcpServer.allowSkillInstall)
+        XCTAssertTrue(legacy.mcpServer.allowRefreshTools)
+        XCTAssertTrue(AppSettings.default.mcpServer.allowSkillInstall)
+
+        var settings = AppSettings.default
+        settings.mcpServer.allowSkillInstall = false
+        let decoded = try JSONDecoder().decode(
+            AppSettings.self,
+            from: try JSONEncoder().encode(settings)
+        )
+        XCTAssertFalse(decoded.mcpServer.allowSkillInstall)
+        XCTAssertTrue(decoded.mcpServer.enabled)
+    }
+
     func testOverviewQuotaHistoryHiddenCurvesDefaultToNoneAndRoundTrip() throws {
         // Stored as *hidden* ids, so a settings file written before the
         // Overview chart existed has to mean "show everything" — not "show

--- a/Tests/VibeBarCoreTests/MCPFixtures.swift
+++ b/Tests/VibeBarCoreTests/MCPFixtures.swift
@@ -352,6 +352,38 @@ final class FakeMCPDataSource: MCPDataSource, @unchecked Sendable {
         return MCPServiceStatusDTO(generatedAt: Self.epoch, lastFetched: Self.epoch, companies: rows)
     }
 
+    // MARK: Skills
+
+    /// Set to install for real into a temporary home. Left `nil`, the tool
+    /// behaves like an app that cannot reach its Skills manager.
+    var skillsService: SkillsService?
+    /// Stands in for `AppSettings.mcpServer.allowSkillInstall`.
+    var allowSkillInstall = true
+    private(set) var lastSkillSource: SkillInstallSource?
+    private(set) var lastSkillApps: [SkillAppTarget]?
+    private(set) var lastSkillMethod: SkillSyncMethod?
+
+    func installSkill(
+        source: SkillInstallSource,
+        apps: [SkillAppTarget],
+        method: SkillSyncMethod
+    ) async throws -> MCPSkillInstallDTO {
+        lastSkillSource = source
+        lastSkillApps = apps
+        lastSkillMethod = method
+        guard allowSkillInstall else {
+            throw MCPToolFailure(
+                "Installing skills from agents is switched off in Vibe Bar → Settings → MCP Server."
+            )
+        }
+        guard let skillsService else {
+            throw MCPToolFailure("Vibe Bar is shutting down.")
+        }
+        return MCPSkillInstallDTO(
+            outcome: try await skillsService.install(from: source, enableFor: apps, method: method)
+        )
+    }
+
     func effectivePricing() async throws -> [EffectiveModelPricingRow] {
         [
             EffectiveModelPricingRow(

--- a/Tests/VibeBarCoreTests/MCPJSONRPCTests.swift
+++ b/Tests/VibeBarCoreTests/MCPJSONRPCTests.swift
@@ -52,8 +52,8 @@ final class MCPJSONRPCTests: XCTestCase {
             names.sorted(),
             [
                 "cost.history", "cost.snapshot", "pricing.effective", "quota.get", "quota.refresh",
-                "sessions.list", "sessions.search", "status.get", "usage.requests", "usage.summary",
-                "usage.trend"
+                "sessions.list", "sessions.search", "skills.install", "status.get", "usage.requests",
+                "usage.summary", "usage.trend"
             ]
         )
         for tool in tools {

--- a/Tests/VibeBarCoreTests/MCPSkillInstallTests.swift
+++ b/Tests/VibeBarCoreTests/MCPSkillInstallTests.swift
@@ -1,0 +1,281 @@
+import XCTest
+@testable import VibeBarCore
+
+/// `skills.install` end to end: the source string an agent types, the real
+/// `SkillsService` install path behind it, and a disposable home directory in
+/// place of the user's. Nothing here touches the machine's `~/.agents`.
+final class MCPSkillInstallTests: XCTestCase {
+    private var home: SkillTestHome!
+    private var fetcher: FakeRepoFetcher!
+    private var source: FakeMCPDataSource!
+    private var server: MCPServer!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        home = try SkillTestHome()
+        fetcher = FakeRepoFetcher()
+        fetcher.repos["AstroQore/vibe-bar"] = FakeRepoFetcher.Repo(
+            branch: "main",
+            skills: ["docs/agent-setup/skill/vibe-bar": [
+                "SKILL.md": "---\nname: vibe-bar\ndescription: Reads Vibe Bar\n---\n\n# vibe-bar\n"
+            ]]
+        )
+        fetcher.repos["acme/many"] = FakeRepoFetcher.Repo(
+            branch: "main",
+            skills: [
+                "skills/alpha": ["SKILL.md": "---\nname: Alpha\n---\n"],
+                "skills/beta": ["SKILL.md": "---\nname: Beta\n---\n"]
+            ]
+        )
+        source = FakeMCPDataSource()
+        source.skillsService = SkillsService(homeDirectory: home.path, fetcher: fetcher)
+        server = MCPServer(dataSource: source, now: { FakeMCPDataSource.epoch })
+    }
+
+    override func tearDown() {
+        home = nil
+        super.tearDown()
+    }
+
+    // MARK: - Happy paths
+
+    func testInstallsARepositorySkillAndProjectsItIntoTheNamedApps() async throws {
+        let result = try await call([
+            "source": .string("AstroQore/vibe-bar"),
+            "apps": .array([.string("claude"), .string("codex")])
+        ])
+
+        let installed = try XCTUnwrap(result["installed"]?.arrayValue)
+        XCTAssertEqual(installed.count, 1)
+        XCTAssertEqual(installed[0]["id"]?.stringValue, "AstroQore/vibe-bar:vibe-bar")
+        XCTAssertEqual(installed[0]["name"]?.stringValue, "vibe-bar")
+        XCTAssertEqual(installed[0]["description"]?.stringValue, "Reads Vibe Bar")
+        XCTAssertEqual(installed[0]["directory"]?.stringValue, "vibe-bar")
+        XCTAssertEqual(installed[0]["branch"]?.stringValue, "main")
+        XCTAssertEqual(
+            installed[0]["path"]?.stringValue,
+            home.ssot.appendingPathComponent("vibe-bar").path
+        )
+
+        let projected = try XCTUnwrap(installed[0]["projectedTo"]?.objectValue)
+        XCTAssertEqual(Set(projected.keys), ["claude", "codex"])
+        XCTAssertEqual(
+            projected["claude"]?.stringValue,
+            home.appDirectory(.claude).appendingPathComponent("vibe-bar").path
+        )
+        XCTAssertTrue(result["message"]?.stringValue?.contains("Claude Code, Codex") ?? false)
+
+        // The payload really landed, and the app entry is a link into it.
+        XCTAssertTrue(home.exists(home.ssot.appendingPathComponent("vibe-bar/SKILL.md")))
+        XCTAssertEqual(
+            SkillFileSystem.kind(of: home.appDirectory(.claude).appendingPathComponent("vibe-bar")),
+            .symlink
+        )
+        XCTAssertEqual(source.lastSkillApps, [.claude, .codex])
+        XCTAssertEqual(source.lastSkillMethod, .auto)
+    }
+
+    func testInstallingWithoutAppsSaysNobodyHasItYet() async throws {
+        let result = try await call(["source": .string("AstroQore/vibe-bar@main")])
+
+        let installed = try XCTUnwrap(result["installed"]?.arrayValue)
+        XCTAssertEqual(installed[0]["projectedTo"]?.objectValue?.isEmpty, true)
+        XCTAssertTrue(
+            result["message"]?.stringValue?.contains("No agent has it switched on yet") ?? false,
+            result["message"]?.stringValue ?? ""
+        )
+        for app in SkillAppTarget.allCases {
+            XCTAssertFalse(home.exists(home.appDirectory(app).appendingPathComponent("vibe-bar")))
+        }
+    }
+
+    /// A GitHub URL is folded back into owner/repo rather than downloaded as
+    /// an arbitrary file, so the archive path stays the only network shape.
+    func testAcceptsAGitHubURLAndAFragment() async throws {
+        let result = try await call([
+            "source": .string("https://github.com/acme/many/tree/main#beta")
+        ])
+        XCTAssertEqual(result["installed"]?.arrayValue?.first?["name"]?.stringValue, "Beta")
+        XCTAssertEqual(
+            source.lastSkillSource,
+            .repository(ref: SkillRepoRef("acme/many@main")!, skillDirectory: "beta")
+        )
+    }
+
+    func testInstallsALocalDirectory() async throws {
+        let local = try home.makeSkillDirectory(
+            at: home.url.appendingPathComponent("elsewhere/notes"),
+            name: "Notes"
+        )
+        let result = try await call([
+            "source": .string(local.path),
+            "apps": .array([.string("grok")]),
+            "method": .string("copy")
+        ])
+
+        let installed = try XCTUnwrap(result["installed"]?.arrayValue)
+        XCTAssertEqual(installed[0]["id"]?.stringValue, "local:notes")
+        XCTAssertEqual(installed[0]["name"]?.stringValue, "Notes")
+        XCTAssertEqual(source.lastSkillMethod, .copy)
+        XCTAssertEqual(
+            SkillFileSystem.kind(of: home.appDirectory(.grok).appendingPathComponent("notes")),
+            .directory
+        )
+    }
+
+    // MARK: - Refusals
+
+    func testRefusesAHostOutsideTheAllowList() async throws {
+        let response = try await raw(["source": .string("https://evil.example.com/skills.zip")])
+        let message = try XCTUnwrap(response["error"]?["message"]?.stringValue)
+        XCTAssertTrue(message.contains("evil.example.com"), message)
+        XCTAssertNil(source.lastSkillSource, "A bad host must not reach the Skills manager")
+    }
+
+    func testRefusesARelativeLocalPath() async throws {
+        let response = try await raw(["source": .string("./skills/vibe-bar")])
+        XCTAssertTrue(
+            (response["error"]?["message"]?.stringValue ?? "").contains("relative"),
+            response["error"]?["message"]?.stringValue ?? ""
+        )
+        XCTAssertNil(source.lastSkillSource)
+    }
+
+    func testRefusesALocalPathThatIsNotADirectory() async throws {
+        let file = home.url.appendingPathComponent("loose/SKILL.md")
+        try home.write("---\nname: Loose\n---\n", to: file)
+
+        let response = try await raw(["source": .string(file.path)])
+        XCTAssertTrue(MCPTestSupport.isError(response))
+        XCTAssertTrue(
+            (MCPTestSupport.errorText(response) ?? "").contains("is not a directory"),
+            MCPTestSupport.errorText(response) ?? ""
+        )
+    }
+
+    func testRefusesADirectoryWithoutSkillMD() async throws {
+        let empty = try home.makeDirectory(home.url.appendingPathComponent("elsewhere/blank"))
+
+        let response = try await raw(["source": .string(empty.path)])
+        XCTAssertTrue(MCPTestSupport.isError(response))
+        XCTAssertTrue(
+            (MCPTestSupport.errorText(response) ?? "").contains("no SKILL.md"),
+            MCPTestSupport.errorText(response) ?? ""
+        )
+        XCTAssertFalse(home.exists(home.ssot.appendingPathComponent("blank")))
+    }
+
+    /// A collection repository is not installed wholesale on a guess; the
+    /// error is the menu.
+    func testAsksWhichSkillWhenTheRepositoryHasSeveral() async throws {
+        let response = try await raw(["source": .string("acme/many")])
+        let text = try XCTUnwrap(MCPTestSupport.errorText(response))
+        XCTAssertTrue(MCPTestSupport.isError(response))
+        XCTAssertTrue(text.contains("alpha"), text)
+        XCTAssertTrue(text.contains("beta"), text)
+        let installed = await source.skillsService?.installedSkills() ?? []
+        XCTAssertTrue(installed.isEmpty)
+    }
+
+    func testNamesTheAvailableSkillsWhenTheFragmentIsWrong() async throws {
+        let response = try await raw(["source": .string("acme/many#gamma")])
+        let text = try XCTUnwrap(MCPTestSupport.errorText(response))
+        XCTAssertTrue(text.contains("gamma"), text)
+        XCTAssertTrue(text.contains("alpha, beta"), text)
+    }
+
+    func testReportsThatInstallingIsSwitchedOff() async throws {
+        source.allowSkillInstall = false
+
+        let response = try await raw(["source": .string("AstroQore/vibe-bar")])
+        XCTAssertTrue(MCPTestSupport.isError(response))
+        XCTAssertTrue(
+            (MCPTestSupport.errorText(response) ?? "").contains("switched off"),
+            MCPTestSupport.errorText(response) ?? ""
+        )
+        XCTAssertFalse(home.exists(home.ssot.appendingPathComponent("vibe-bar")))
+    }
+
+    func testRejectsAnInventedArgument() async throws {
+        let response = try await raw([
+            "source": .string("AstroQore/vibe-bar"),
+            "force": .bool(true)
+        ])
+        XCTAssertNotNil(response["error"])
+        XCTAssertNil(source.lastSkillSource)
+    }
+
+    func testRejectsAutoAsAnExplicitMethod() async throws {
+        let response = try await raw([
+            "source": .string("AstroQore/vibe-bar"),
+            "method": .string("auto")
+        ])
+        XCTAssertTrue(
+            (response["error"]?["message"]?.stringValue ?? "").contains("'symlink' or 'copy'"),
+            response["error"]?["message"]?.stringValue ?? ""
+        )
+    }
+
+    // MARK: - Source parsing
+
+    func testSourceParsingCoversTheSpellingsAgentsUse() throws {
+        let ref = SkillRepoRef("AstroQore/vibe-bar")!
+        XCTAssertEqual(
+            try SkillInstallSource("AstroQore/vibe-bar"),
+            .repository(ref: ref, skillDirectory: nil)
+        )
+        XCTAssertEqual(
+            try SkillInstallSource("AstroQore/vibe-bar#vibe-bar"),
+            .repository(ref: ref, skillDirectory: "vibe-bar")
+        )
+        XCTAssertEqual(
+            try SkillInstallSource("https://github.com/AstroQore/vibe-bar"),
+            .repository(ref: ref, skillDirectory: nil)
+        )
+        XCTAssertEqual(
+            try SkillInstallSource("https://github.com/AstroQore/vibe-bar.git"),
+            .repository(ref: ref, skillDirectory: nil)
+        )
+        XCTAssertEqual(
+            try SkillInstallSource("https://github.com/AstroQore/vibe-bar/archive/refs/heads/dev.zip"),
+            .repository(ref: SkillRepoRef("AstroQore/vibe-bar@dev")!, skillDirectory: nil)
+        )
+        XCTAssertEqual(
+            try SkillInstallSource("https://codeload.github.com/AstroQore/vibe-bar/zip/refs/heads/dev"),
+            .repository(ref: SkillRepoRef("AstroQore/vibe-bar@dev")!, skillDirectory: nil)
+        )
+        XCTAssertEqual(
+            try SkillInstallSource("~/skills/mine", homeDirectory: "/Users/example"),
+            .localDirectory(URL(fileURLWithPath: "/Users/example/skills/mine", isDirectory: true))
+        )
+
+        // `skills/mine` is deliberately absent from this list: a bare
+        // `owner/repo` shape is read as a repository, never as a relative
+        // path, and a relative path is refused outright.
+        for bad in ["", "vibe-bar", "a/b/c", "http://github.com/a/b", "../mine", "./mine"] {
+            XCTAssertThrowsError(try SkillInstallSource(bad), "\"\(bad)\" must not parse")
+        }
+        XCTAssertThrowsError(try SkillInstallSource("acme/many#../escape")) { error in
+            XCTAssertEqual(error as? SkillInstallSourceError, .invalidSkillDirectory("../escape"))
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func raw(_ arguments: [String: MCPJSON]) async throws -> MCPJSON {
+        try MCPTestSupport.decode(
+            await server.handle(
+                line: MCPTestSupport.call(id: 1, tool: "skills.install", arguments: .object(arguments))
+            )
+        )
+    }
+
+    private func call(_ arguments: [String: MCPJSON]) async throws -> MCPJSON {
+        let response = try await raw(arguments)
+        if let error = response["error"] {
+            throw MCPTestError("Unexpected JSON-RPC error: \(error)")
+        }
+        XCTAssertFalse(MCPTestSupport.isError(response), "\(MCPTestSupport.errorText(response) ?? "")")
+        return try MCPTestSupport.structured(response)
+    }
+}

--- a/Tests/VibeBarCoreTests/SkillRepoFetcherTests.swift
+++ b/Tests/VibeBarCoreTests/SkillRepoFetcherTests.swift
@@ -286,6 +286,83 @@ final class SkillRepoFetcherTests: XCTestCase {
         }
     }
 
+    /// The complaint this whole path exists to answer: a download that never
+    /// finishes must end when the user says so, not when the server does.
+    func testDownloaderFailsWithCancellationWhenTheTaskIsCancelled() async throws {
+        StubURLProtocol.replies["https://github.com/a/b.zip"] = .init(hangs: true)
+        let destination = workspace.appendingPathComponent("out.zip")
+        let downloader = Self.stubbedDownloader()
+
+        let download = Task {
+            try await downloader.download(
+                from: URL(string: "https://github.com/a/b.zip")!,
+                to: destination,
+                maxBytes: 1_000_000,
+                timeout: 30,
+                allowedHosts: ["github.com"]
+            )
+        }
+        try await Self.waitUntil { StubURLProtocol.requested.contains("https://github.com/a/b.zip") }
+        download.cancel()
+
+        do {
+            try await download.value
+            XCTFail("Expected the cancelled download to throw")
+        } catch {
+            XCTAssertTrue(error is CancellationError, "Got \(error)")
+        }
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: destination.path),
+            "The partial download must be deleted"
+        )
+    }
+
+    /// `timeout` is an idle timer, so a repository budget needs its own clock.
+    func testDownloadRepoGivesUpOnceTheWallClockBudgetIsSpent() async {
+        StubURLProtocol.replies[Self.archive("acme", "slow", "main")] = .init(hangs: true)
+        StubURLProtocol.replies[Self.archive("acme", "slow", "master")] = .init(hangs: true)
+
+        let fetcher = SkillRepoFetcher(
+            downloader: Self.stubbedDownloader(),
+            timeout: 30,
+            maxWallTime: 0.4
+        )
+        let started = Date()
+        do {
+            _ = try await fetcher.downloadRepo(
+                SkillRepoRef("acme/slow")!,
+                into: workspace.appendingPathComponent("dl", isDirectory: true)
+            )
+            XCTFail("Expected timedOut")
+        } catch let error as SkillRepoError {
+            XCTAssertEqual(error, .timedOut(slug: "acme/slow", seconds: 0))
+        } catch {
+            XCTFail("Unexpected error \(error)")
+        }
+        XCTAssertLessThan(
+            Date().timeIntervalSince(started),
+            20,
+            "The budget must bound the whole repository, not each branch candidate"
+        )
+    }
+
+    func testDownloadRepoIsCancellable() async {
+        StubURLProtocol.replies[Self.archive("acme", "slow", "main")] = .init(hangs: true)
+        let fetcher = SkillRepoFetcher(downloader: Self.stubbedDownloader())
+        let directory = workspace.appendingPathComponent("dl", isDirectory: true)
+
+        let download = Task { try await fetcher.downloadRepo(SkillRepoRef("acme/slow@main")!, into: directory) }
+        try? await Self.waitUntil { !StubURLProtocol.requested.isEmpty }
+        download.cancel()
+
+        do {
+            _ = try await download.value
+            XCTFail("Expected the cancelled fetch to throw")
+        } catch {
+            XCTAssertTrue(error is CancellationError, "Got \(error)")
+        }
+    }
+
     func testDownloaderWritesTheBodyItWasGiven() async throws {
         let payload = Data(repeating: 0x5A, count: 12_345)
         StubURLProtocol.replies["https://github.com/a/b.zip"] = .init(body: payload)
@@ -303,6 +380,19 @@ final class SkillRepoFetcherTests: XCTestCase {
     }
 
     // MARK: - Helpers
+
+    /// Polls until `condition` holds, so a cancellation test cancels something
+    /// that is actually in flight rather than a task that has not started.
+    private static func waitUntil(
+        timeout: TimeInterval = 5,
+        _ condition: @Sendable () -> Bool
+    ) async throws {
+        let deadline = Date().addingTimeInterval(timeout)
+        while !condition() {
+            guard Date() < deadline else { throw MCPTestError("Timed out waiting for the condition") }
+            try await Task.sleep(for: .milliseconds(5))
+        }
+    }
 
     private static func stubbedDownloader() -> BoundedDownloader {
         BoundedDownloader {
@@ -354,6 +444,9 @@ final class StubURLProtocol: URLProtocol {
         var body: Data?
         var redirectTo: URL?
         var includeContentLength = true
+        /// Accepts the request and never answers, standing in for the server
+        /// that made "Scan repos" spin for twenty seconds.
+        var hangs = false
     }
 
     nonisolated(unsafe) static var replies: [String: Reply] = [:]
@@ -375,6 +468,8 @@ final class StubURLProtocol: URLProtocol {
         }
         Self.requested.append(url.absoluteString)
         let reply = Self.replies[url.absoluteString] ?? Reply(statusCode: 404)
+
+        if reply.hangs { return }
 
         if let redirect = reply.redirectTo {
             let response = HTTPURLResponse(

--- a/Tests/VibeBarCoreTests/SkillsServiceNetworkTests.swift
+++ b/Tests/VibeBarCoreTests/SkillsServiceNetworkTests.swift
@@ -191,6 +191,69 @@ final class SkillsServiceNetworkTests: XCTestCase {
         XCTAssertFalse(FileManager.default.fileExists(atPath: discovered[0].sourceRoot.path))
     }
 
+    /// The bug this exists for: a repository that never answers used to leave
+    /// the sheet spinning with nothing to say and no way out.
+    func testDiscoveryReportsWhichRepositoryFailedInsteadOfReturningNothing() async throws {
+        let home = try SkillTestHome()
+        let fetcher = FakeRepoFetcher()
+        fetcher.repos["acme/good"] = FakeRepoFetcher.Repo(
+            branch: "main",
+            skills: ["skills/alpha": ["SKILL.md": Self.frontmatter(name: "Alpha")]]
+        )
+        let service = SkillsService(homeDirectory: home.path, fetcher: fetcher)
+
+        let result = await service.discover(from: [
+            SkillRepoRef("acme/good")!,
+            SkillRepoRef("acme/missing")!
+        ])
+
+        XCTAssertEqual(result.skills.map(\.directory), ["alpha"])
+        XCTAssertFalse(result.wasCancelled)
+        XCTAssertEqual(result.failures.map(\.slug), ["acme/missing"])
+        XCTAssertFalse(result.failures[0].wasCancelled)
+        XCTAssertTrue(
+            result.failures[0].displayText.hasPrefix("acme/missing: Could not download acme/missing"),
+            result.failures[0].displayText
+        )
+    }
+
+    func testDiscoveryReportsPhasesForEveryRepository() async throws {
+        let home = try SkillTestHome()
+        let fetcher = FakeRepoFetcher()
+        fetcher.repos["acme/one"] = FakeRepoFetcher.Repo(
+            branch: "main",
+            skills: ["skills/alpha": ["SKILL.md": Self.frontmatter(name: "Alpha")]]
+        )
+        let service = SkillsService(homeDirectory: home.path, fetcher: fetcher)
+        let recorder = PhaseRecorder()
+
+        _ = await service.discover(from: [SkillRepoRef("acme/one")!]) { recorder.record($0) }
+
+        XCTAssertEqual(recorder.phases, [
+            .downloading(slug: "acme/one"),
+            .scanning(slug: "acme/one"),
+            .repositoryFinished(slug: "acme/one", completed: 1, total: 1)
+        ])
+    }
+
+    /// Cancelling has to resolve the call — the point of the Cancel button is
+    /// that the caller stops waiting, not that the download is asked nicely.
+    func testDiscoveryCancellationResolvesWithACancelledFailure() async throws {
+        let home = try SkillTestHome()
+        let fetcher = HangingRepoFetcher()
+        let service = SkillsService(homeDirectory: home.path, fetcher: fetcher)
+
+        let discovery = Task { await service.discover(from: [SkillRepoRef("acme/slow")!]) }
+        try await fetcher.waitUntilStarted()
+        discovery.cancel()
+
+        let result = await discovery.value
+        XCTAssertTrue(result.skills.isEmpty)
+        XCTAssertTrue(result.wasCancelled)
+        XCTAssertEqual(result.failures.map(\.displayText), ["acme/slow: cancelled"])
+        XCTAssertTrue(result.failures[0].wasCancelled)
+    }
+
     func testDiscoveryDedupesAndSortsByName() async throws {
         let home = try SkillTestHome()
         let fetcher = FakeRepoFetcher()
@@ -445,5 +508,47 @@ final class FakeRepoFetcher: SkillRepoFetching, @unchecked Sendable {
         resolvedBranch: String
     ) throws -> [DiscoveredSkill] {
         try SkillRepoFetcher().scanSkills(inRepoRoot: root, ref: ref, resolvedBranch: resolvedBranch)
+    }
+}
+
+/// A fetcher whose download never lands, standing in for the slow network the
+/// Cancel button exists for. `Task.sleep` is the cooperative check: it throws
+/// `CancellationError` the moment the surrounding task is cancelled.
+final class HangingRepoFetcher: SkillRepoFetching, @unchecked Sendable {
+    private let lock = NSLock()
+    private var started = false
+
+    func downloadRepo(_ ref: SkillRepoRef, into tempDir: URL) async throws -> (root: URL, resolvedBranch: String) {
+        lock.withLock { started = true }
+        try await Task.sleep(for: .seconds(600))
+        throw SkillRepoError.branchNotFound(slug: ref.slug, tried: ["main"])
+    }
+
+    func scanSkills(
+        inRepoRoot root: URL,
+        ref: SkillRepoRef,
+        resolvedBranch: String
+    ) throws -> [DiscoveredSkill] {
+        []
+    }
+
+    func waitUntilStarted(timeout: TimeInterval = 5) async throws {
+        let deadline = Date().addingTimeInterval(timeout)
+        while !lock.withLock({ started }) {
+            guard Date() < deadline else { throw MCPTestError("The download never started") }
+            try await Task.sleep(for: .milliseconds(5))
+        }
+    }
+}
+
+/// Collects discovery phases from whatever thread emits them.
+final class PhaseRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var recorded: [SkillDiscoveryPhase] = []
+
+    var phases: [SkillDiscoveryPhase] { lock.withLock { recorded } }
+
+    func record(_ phase: SkillDiscoveryPhase) {
+        lock.withLock { recorded.append(phase) }
     }
 }

--- a/docs/agent-setup/prompt.md
+++ b/docs/agent-setup/prompt.md
@@ -163,20 +163,39 @@ Report the user's actual remaining quota back to them as proof it worked.
 The skill teaches an agent which tool answers which question and, more
 importantly, the naming rules that keep the answers correct. Install it.
 
-The skill lives in this repository at
-`docs/agent-setup/skill/vibe-bar/`. Fetch it from
+The skill lives in this repository at `docs/agent-setup/skill/vibe-bar/`.
+
+**Preferred: ask Vibe Bar to install it.** Vibe Bar's Skills manager keeps one
+copy in `~/.agents/skills/` and projects it into each agent's own skills
+directory, and it is reachable over MCP — so this is one call:
+
+```json
+{"name": "skills.install",
+ "arguments": {"source": "AstroQore/vibe-bar", "apps": ["claude"]}}
+```
+
+Put the agent CLIs the user actually wants it in into `apps` — `claude`,
+`codex`, `gemini`, `grok`, `hermes`, `opencode`, `antigravity` — starting with
+your own. Omitting `apps` installs the skill without switching it on for
+anyone. The result carries the SSOT `path` and a `projectedTo` map; report the
+path. If the tool answers that installing is switched off, the user turned it
+off in Settings → MCP Server — ask them, or fall back to the manual steps
+below. If `skills.install` is not in the tool list at all, the installed app
+predates it; use the UI or the manual steps.
+
+Doing it through the app's own UI works too: Workbench → Skills → Discover,
+add `AstroQore/vibe-bar`, **Scan repos**, then press **Install** on the
+`vibe-bar` row. Scanning only *lists* what a repository contains — it downloads
+the zipball and shows the skills in it. Nothing is installed until Install is
+pressed, so "I scanned the repo" is not "I installed the skill".
+
+**Otherwise, install by hand.** Fetch it from
 
 ```
 https://raw.githubusercontent.com/AstroQore/vibe-bar/main/docs/agent-setup/skill/vibe-bar/SKILL.md
 ```
 
-**Preferred: let Vibe Bar manage it.** Vibe Bar has a Skills manager
-(Workbench → Skills) that keeps one copy in `~/.agents/skills/` and projects
-it into each agent's own skills directory. If the user already uses it, tell
-them to add the skill there instead of copying files yourself, and skip the
-rest of this section.
-
-**Otherwise, install by hand:**
+and then:
 
 1. Write the skill to the shared location:
    `~/.agents/skills/vibe-bar/SKILL.md`.

--- a/docs/agent-setup/skill/vibe-bar/SKILL.md
+++ b/docs/agent-setup/skill/vibe-bar/SKILL.md
@@ -7,16 +7,19 @@ description: >-
   Grok / Cursor do I have left", "when does my 5-hour window reset", "am I
   going to run out", "refresh my usage", "what did I spend this month", "who
   used the most tokens", "why is this costing so much", "is Anthropic down", or
-  "find my session about …". Requires the Vibe Bar app to be running with its
-  MCP server enabled.
+  "find my session about …". Also installs agent skills through Vibe Bar's
+  Skills manager ("install this skill", "set me up with the Vibe Bar skill").
+  Requires the Vibe Bar app to be running with its MCP server enabled.
 ---
 
 # Vibe Bar
 
 Vibe Bar is a macOS menu-bar app that watches this Mac's AI subscriptions. Its
-MCP server (`vibebar`) exposes what it knows, read-only. Everything comes from
+MCP server (`vibebar`) exposes what it knows. Everything it reports comes from
 the running app's own caches — answers are fast, and they are as fresh as the
-app made them, which is why every payload carries `generatedAt`.
+app made them, which is why every payload carries `generatedAt`. Every tool is
+read-only except `skills.install`, which writes only inside the skills
+directories Vibe Bar manages.
 
 If the `vibebar` tools are not available, the app is not running or the server
 is switched off in Settings → MCP Server. Say so; do not guess numbers.
@@ -60,6 +63,7 @@ never infer a model that a log recorded as absent.
 | "what have I been working on?" | `sessions.list` |
 | "is <provider> down?" | `status.get` |
 | "why is this model so expensive?" | `pricing.effective` |
+| "install this skill" / "set me up with the Vibe Bar skill" | `skills.install` |
 
 `vibebar://tools` carries the same routing table plus the rules below, if you
 would rather read it than trust this copy.
@@ -92,6 +96,11 @@ would rather read it than trust this copy.
   tokens is expected, not a bug.
 - **Empty filter lists mean "nothing"**, not "everything". Omit a filter to
   mean everything.
+- **`skills.install` is the only tool that writes.** It installs into
+  `~/.agents/skills/` and projects into the agent CLIs named in `apps` —
+  nowhere else, and never over a folder a different skill already holds. Pass
+  `apps` or the skill is on the machine switched on for nobody. It can be
+  turned off in Settings → MCP Server, in which case it says so.
 
 ## Worked patterns
 
@@ -116,3 +125,10 @@ render them as emphasis or strip them, do not print them raw.
 `quota.refresh` (no `force`), wait a couple of seconds, then `quota.get`. If
 `triggered` was false because nothing was stale, say the numbers were already
 current rather than pretending to have refreshed.
+
+**"Install the Vibe Bar skill for me."**
+`skills.install` with `source: "AstroQore/vibe-bar"` and `apps` set to the
+agent CLIs the user wants it in — yours at minimum. Report the `path` it came
+back with. Do not copy files by hand while this tool is available: the app
+keeps one copy and the projections in step, and a hand-made folder is one it
+will refuse to manage later.


### PR DESCRIPTION
## Why

Codex, following `docs/agent-setup/prompt.md` on 1.3.0 (33), hit "Scan repos" spinning for 20 s+ with no feedback and no cancel, and no `.skill-lock.json` entry afterwards. Reproduced offline: the app's own fetcher downloads+extracts+scans `AstroQore/vibe-bar` (8.5 MB, 598 files) in ~4 s and *does* find the skill — the pipeline works; the UX is a slow, silent, un-cancellable download, and "scan" never installs (agents assume it does). Agents also need a way to install without driving the UI.

## What

- **Discovery is cancellable, bounded, and narrated.** `BoundedDownloader` gets a resource timeout and cooperative cancellation; `SkillRepoFetcher.maxWallTime` (120 s per repo) with `SkillRepoError.timedOut`; `SkillsService.discover(from:progress:)` returns per-repo failures + phases; the Discover sheet's button becomes **Cancel** while busy, shows phase text ("Downloading AstroQore/vibe-bar…"), and lists per-repo failures inline instead of swallowing them.
- **`skills.install` MCP tool** — `{source, apps?, method?}` where `source` is `owner/repo[@branch][#skill]`, a github.com/codeload URL (folded back into a repo ref; off-allowlist hosts refused at parse time), or an absolute/`~` local directory containing `SKILL.md` (lstat-checked, symlinks refused). Routes through the same `SkillsService` install path as the UI (writes only under `~/.agents/skills/` + managed app dirs); a multi-skill repo without `#skill` errors with the list rather than installing everything. Gated by `MCPServerSettings.allowSkillInstall` (default on) with a Settings toggle. `AppEnvironment` now owns one process-wide `SkillsService` shared by the Workbench and MCP.
- **Docs**: prompt.md §4 leads with `skills.install AstroQore/vibe-bar` and explains scan ≠ install; AGENTS.md §5.1/§7/§11 (URLSession request timeout is an idle timer); SKILL.md routing row.

## Verification

- `swift build`, `swift test` (1727 tests, 1 skipped, 0 failures; +21 incl. `MCPSkillInstallTests`, downloader/fetcher cancellation, discovery phases)
- `./Scripts/build_app.sh release`, `codesign -d --entitlements -` → empty `<dict/>`, `codesign --verify --deep --strict` OK; home-dir grep only `RealHomeDirectory.swift`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
