### PR TITLE
Tighten skills install URLs, cancellation and phase text

### DIFF
--- a/Sources/VibeBarApp/Controllers/SkillsManagerModel.swift
+++ b/Sources/VibeBarApp/Controllers/SkillsManagerModel.swift
@@ -220,9 +220,15 @@ final class SkillsManagerModel: ObservableObject {
 
     var isDiscovering: Bool { isBusy(BusyKey.discover) }
 
+    /// Bumped per discovery so a phase update still queued on the main actor
+    /// when a run ends (or is cancelled) cannot resurrect stale text.
+    private var discoverGeneration = 0
+
     func discover() {
         discoverFailures = []
         discoverPhase = nil
+        discoverGeneration += 1
+        let generation = discoverGeneration
         discoverTask = perform(BusyKey.discover) { [self] in
             let refs = await service.discoverRepoRefs()
             guard !refs.isEmpty else {
@@ -234,8 +240,12 @@ final class SkillsManagerModel: ObservableObject {
             // The phases arrive from the download tasks; the hop back is what
             // keeps `@Published` on the main actor.
             let result = await service.discover(from: refs) { [weak self] phase in
-                Task { @MainActor in self?.discoverPhase = Self.text(for: phase) }
+                Task { @MainActor in
+                    guard let self, self.discoverGeneration == generation, self.isDiscovering else { return }
+                    self.discoverPhase = Self.text(for: phase)
+                }
             }
+            discoverGeneration += 1
             discoverPhase = nil
             discoverResults = result.skills
             discoverSource = "Configured repositories"

--- a/Sources/VibeBarApp/Controllers/SkillsManagerModel.swift
+++ b/Sources/VibeBarApp/Controllers/SkillsManagerModel.swift
@@ -265,6 +265,7 @@ final class SkillsManagerModel: ObservableObject {
     /// Stops an in-flight scan. The service returns what it already had, so
     /// the results list keeps any repository that finished first.
     func cancelDiscover() {
+        discoverGeneration += 1
         discoverTask?.cancel()
     }
 
@@ -287,6 +288,7 @@ final class SkillsManagerModel: ObservableObject {
     func discoverSheetDismissed() {
         searchTask?.cancel()
         searchTask = nil
+        discoverGeneration += 1
         discoverTask?.cancel()
         discoverTask = nil
         discoverPhase = nil

--- a/Sources/VibeBarCore/Skills/SkillArchiveExtractor.swift
+++ b/Sources/VibeBarCore/Skills/SkillArchiveExtractor.swift
@@ -114,6 +114,9 @@ public struct SkillArchiveExtractor {
         var written = 0
         var produced: Int64 = 0
         for entry in directory {
+            // Cooperative: a Cancel that lands after the download must not
+            // have to wait for a large archive to finish inflating.
+            if Task.isCancelled { throw CancellationError() }
             let target = try resolve(components: entry.components, under: destination)
             if entry.isDirectory {
                 try FileManager.default.createDirectory(at: target, withIntermediateDirectories: true)

--- a/Sources/VibeBarCore/Skills/SkillInstallSource.swift
+++ b/Sources/VibeBarCore/Skills/SkillInstallSource.swift
@@ -109,7 +109,15 @@ public enum SkillInstallSource: Sendable, Equatable {
             if rest.first == "refs", rest.dropFirst().first == "heads" { rest = Array(rest.dropFirst(2)) }
             switch kind {
             case "archive", "zip", "tree", "blob":
-                guard var last = rest.last else { throw SkillInstallSourceError.unsupportedURL(raw) }
+                // Exactly one component may follow: the branch. A slash-qualified
+                // branch (`/tree/feature/foo`) and a path below the branch
+                // (`/tree/main/skills/x`) are indistinguishable here, and
+                // guessing would let the fetcher fall back to main/master and
+                // silently install a different revision. Ask for the
+                // `owner/repo@branch#skill` form instead.
+                guard rest.count == 1, var last = rest.first else {
+                    throw SkillInstallSourceError.unsupportedURL(raw)
+                }
                 if last.hasSuffix(".zip") { last = String(last.dropLast(4)) }
                 branch = last
             default:


### PR DESCRIPTION
## Why

Three post-merge review findings on #195.

## What

- `SkillInstallSource`: GitHub tree/blob/archive URLs must have exactly one component after the marker (the branch); slash-qualified branches or in-repo paths are rejected with guidance to use `owner/repo@branch#skill`.
- `SkillArchiveExtractor`: `Task.isCancelled` checked per entry so Cancel works after the download completes.
- `SkillsManagerModel`: a discovery generation counter drops phase updates that land after the run ended.

## Verification

- `swift build`, `swift test` (1727 tests, 1 skipped, 0 failures)
- `./Scripts/build_app.sh release`, `codesign --verify --deep --strict` OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)
