### PR TITLE
Prepare Vibe Bar 1.3.0 Dev build 34

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.3.0</string>
 	<key>CFBundleVersion</key>
-	<string>33</string>
+	<string>34</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>26.0</string>
 	<key>LSUIElement</key>


### PR DESCRIPTION
## Why

Cut the next Dev channel build after merging the Codex agent-setup feedback:

- #194 MCP server answers in-flight requests after the client half-closes; `--mcp-stdio` handled in `main.swift` before AppKit (fixes empty output from `printf … | VibeBar --mcp-stdio` and the sandboxed-client abort)
- #195 Skills discovery is cancellable, bounded and narrated; new `skills.install` MCP tool + `allowSkillInstall`; agent-setup docs prefer `skills.install`
- #196 Follow-ups: tree-URL ambiguity, cancellation inside extraction, discovery phase generation

## What

- `Resources/Info.plist`: `CFBundleVersion` 33 → 34. `CFBundleShortVersionString` stays `1.3.0`.

## Verification

- `swift build`, `swift test` (1727 tests, 1 skipped, 0 failures)
- `./Scripts/build_app.sh release`, `codesign -d --entitlements -` → empty `<dict/>`, `codesign --verify --deep --strict` OK; bundle reports build 34

Tag `v1.3.0-dev.34` will be created on the merged commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
