### PR TITLE
Coalesce settings writes off the main thread

### DIFF
--- a/Sources/VibeBarApp/AppDelegate.swift
+++ b/Sources/VibeBarApp/AppDelegate.swift
@@ -157,6 +157,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // an agent connecting during shutdown gets a clean "not running"
         // rather than a connection to a half-stopped environment.
         environment?.mcp?.stop()
+        environment?.settingsStore.flush()
         environment?.scheduler.stop()
         environment?.serviceStatus.stop()
         environment?.remoteProbeService.stop()

--- a/Sources/VibeBarCore/Storage/SettingsStore.swift
+++ b/Sources/VibeBarCore/Storage/SettingsStore.swift
@@ -4,10 +4,35 @@ import Combine
 @MainActor
 public final class SettingsStore: ObservableObject {
     @Published public var settings: AppSettings {
-        didSet { persist() }
+        didSet { schedulePersist() }
     }
 
     private let defaultsKey = "VibeBar.settings.v1"
+
+    /// Settings edits arrive one keystroke / one toggle at a time, and every
+    /// one used to encode and atomically rewrite the file on the main thread
+    /// before the view could redraw. Coalesce: one write per burst, off the
+    /// main actor. `flush()` writes synchronously and is what quit calls.
+    private var pendingPersist: Task<Void, Never>?
+    private static let persistCoalesceNanoseconds: UInt64 = 250_000_000
+
+    private func schedulePersist() {
+        pendingPersist?.cancel()
+        let snapshot = settings
+        pendingPersist = Task.detached(priority: .utility) {
+            try? await Task.sleep(nanoseconds: Self.persistCoalesceNanoseconds)
+            guard !Task.isCancelled else { return }
+            Self.write(snapshot)
+        }
+    }
+
+    /// Write whatever is pending right now. Cheap when nothing is pending.
+    public func flush() {
+        guard let pending = pendingPersist else { return }
+        pending.cancel()
+        pendingPersist = nil
+        Self.write(settings)
+    }
 
     public init(userDefaults: UserDefaults = .standard) {
         if
@@ -31,6 +56,10 @@ public final class SettingsStore: ObservableObject {
     }
 
     private func persist() {
+        Self.write(settings)
+    }
+
+    private nonisolated static func write(_ settings: AppSettings) {
         do {
             try VibeBarLocalStore.writeJSON(settings, to: VibeBarLocalStore.settingsURL)
         } catch {


### PR DESCRIPTION
## Why

Settings pages feel laggy: every edit (each keystroke in a label field, each toggle) encoded `AppSettings` and atomically rewrote `~/.vibebar/settings.json` on the main thread inside `didSet`, before SwiftUI could redraw — on top of the fan-out to every settings observer in every open window.

## What

- `SettingsStore`: `didSet` schedules a coalesced write (250 ms) on a utility task; `flush()` writes synchronously and is called from `applicationShouldTerminate`. Load/migration paths still write immediately.

## Verification

- `swift build`, `swift test` (1727 tests, 1 skipped, 0 failures)
- `./Scripts/build_app.sh release`, `codesign --verify --deep --strict` OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)
