### PR TITLE
Serialize settings writes and flush before refresh-triggering edits

### DIFF
--- a/Sources/VibeBarApp/AppEnvironment.swift
+++ b/Sources/VibeBarApp/AppEnvironment.swift
@@ -190,6 +190,10 @@ final class AppEnvironment: ObservableObject {
                     && $0.miscProviderInstances == $1.miscProviderInstances
             }
             .sink { [weak self] settings in
+                // Adapters resolve usage modes and misc-provider plans from
+                // settings.json on disk; make sure the edit is there before
+                // the refresh this sink triggers reads it.
+                self?.settingsStore.flush()
                 self?.accountStore.reload(
                     codexUsageMode: settings.codexUsageMode,
                     claudeUsageMode: settings.claudeUsageMode,

--- a/Sources/VibeBarApp/AppEnvironment.swift
+++ b/Sources/VibeBarApp/AppEnvironment.swift
@@ -192,8 +192,9 @@ final class AppEnvironment: ObservableObject {
             .sink { [weak self] settings in
                 // Adapters resolve usage modes and misc-provider plans from
                 // settings.json on disk; make sure the edit is there before
-                // the refresh this sink triggers reads it.
-                self?.settingsStore.flush()
+                // the refresh this sink triggers reads it. `@Published` emits
+                // during willSet, so flush the emitted value, not the store's.
+                self?.settingsStore.flush(settings)
                 self?.accountStore.reload(
                     codexUsageMode: settings.codexUsageMode,
                     claudeUsageMode: settings.claudeUsageMode,

--- a/Sources/VibeBarCore/Storage/SettingsStore.swift
+++ b/Sources/VibeBarCore/Storage/SettingsStore.swift
@@ -12,35 +12,44 @@ public final class SettingsStore: ObservableObject {
     /// Settings edits arrive one keystroke / one toggle at a time, and every
     /// one used to encode and atomically rewrite the file on the main thread
     /// before the view could redraw. Coalesce: one write per burst, off the
-    /// main actor. `flush()` writes synchronously and is what quit calls.
+    /// main actor; `flush()` writes synchronously (quit, refresh triggers).
+    ///
+    /// Every snapshot carries a sequence number and the writer only applies a
+    /// snapshot newer than the last one it wrote, so a coalesced task that
+    /// resumes late can never overwrite a `flush()` that beat it.
     private var pendingPersist: Task<Void, Never>?
+    private var persistSequence: UInt64 = 0
     private static let persistCoalesceNanoseconds: UInt64 = 250_000_000
-    /// All file writes go through one serial queue so a coalesced write that
-    /// already started can never race a later `flush()`: the flush is queued
-    /// behind it and, being newer, wins.
     private static let writeQueue = DispatchQueue(
         label: "com.astroqore.VibeBar.settings.persist", qos: .utility
     )
+    /// Only ever touched on `writeQueue`.
+    private nonisolated(unsafe) static var lastWrittenSequence: UInt64 = 0
 
     private func schedulePersist() {
         pendingPersist?.cancel()
+        persistSequence += 1
+        let sequence = persistSequence
         let snapshot = settings
         pendingPersist = Task.detached(priority: .utility) {
             try? await Task.sleep(nanoseconds: Self.persistCoalesceNanoseconds)
             guard !Task.isCancelled else { return }
-            Self.writeQueue.async { Self.write(snapshot) }
+            Self.writeQueue.async { Self.write(snapshot, sequence: sequence) }
         }
     }
 
-    /// Write the current settings now, ordered after any write already in
-    /// flight. Callers that hand the settings to something reading
-    /// `settings.json` from disk (adapters resolving usage modes, quit) use
-    /// this; ordinary edits stay coalesced.
-    public func flush() {
+    /// Write `snapshot` (default: the current settings) now, ordered after
+    /// any write already in flight and ahead of any stale coalesced task.
+    /// Callers that hand settings to something reading `settings.json` from
+    /// disk pass the value they were just given — `@Published` emits during
+    /// `willSet`, so `self.settings` may still be the previous value there.
+    public func flush(_ snapshot: AppSettings? = nil) {
         pendingPersist?.cancel()
         pendingPersist = nil
-        let snapshot = settings
-        Self.writeQueue.sync { Self.write(snapshot) }
+        persistSequence += 1
+        let sequence = persistSequence
+        let value = snapshot ?? settings
+        Self.writeQueue.sync { Self.write(value, sequence: sequence) }
     }
 
     public init(userDefaults: UserDefaults = .standard) {
@@ -65,10 +74,15 @@ public final class SettingsStore: ObservableObject {
     }
 
     private func persist() {
-        Self.write(settings)
+        Self.write(settings, sequence: nil)
     }
 
-    private nonisolated static func write(_ settings: AppSettings) {
+    /// `sequence == nil` (load-time migration writes) always applies.
+    private nonisolated static func write(_ settings: AppSettings, sequence: UInt64?) {
+        if let sequence {
+            guard sequence > lastWrittenSequence else { return }
+            lastWrittenSequence = sequence
+        }
         do {
             try VibeBarLocalStore.writeJSON(settings, to: VibeBarLocalStore.settingsURL)
         } catch {

--- a/Sources/VibeBarCore/Storage/SettingsStore.swift
+++ b/Sources/VibeBarCore/Storage/SettingsStore.swift
@@ -15,6 +15,12 @@ public final class SettingsStore: ObservableObject {
     /// main actor. `flush()` writes synchronously and is what quit calls.
     private var pendingPersist: Task<Void, Never>?
     private static let persistCoalesceNanoseconds: UInt64 = 250_000_000
+    /// All file writes go through one serial queue so a coalesced write that
+    /// already started can never race a later `flush()`: the flush is queued
+    /// behind it and, being newer, wins.
+    private static let writeQueue = DispatchQueue(
+        label: "com.astroqore.VibeBar.settings.persist", qos: .utility
+    )
 
     private func schedulePersist() {
         pendingPersist?.cancel()
@@ -22,16 +28,19 @@ public final class SettingsStore: ObservableObject {
         pendingPersist = Task.detached(priority: .utility) {
             try? await Task.sleep(nanoseconds: Self.persistCoalesceNanoseconds)
             guard !Task.isCancelled else { return }
-            Self.write(snapshot)
+            Self.writeQueue.async { Self.write(snapshot) }
         }
     }
 
-    /// Write whatever is pending right now. Cheap when nothing is pending.
+    /// Write the current settings now, ordered after any write already in
+    /// flight. Callers that hand the settings to something reading
+    /// `settings.json` from disk (adapters resolving usage modes, quit) use
+    /// this; ordinary edits stay coalesced.
     public func flush() {
-        guard let pending = pendingPersist else { return }
-        pending.cancel()
+        pendingPersist?.cancel()
         pendingPersist = nil
-        Self.write(settings)
+        let snapshot = settings
+        Self.writeQueue.sync { Self.write(snapshot) }
     }
 
     public init(userDefaults: UserDefaults = .standard) {


### PR DESCRIPTION
## Why

Two post-merge findings on #200: adapters that read `settings.json` from disk could see a pre-edit file when a settings change triggers a refresh; and `flush()` could race a coalesced write already in flight.

## What

- `SettingsStore`: all writes go through one serial queue; `flush()` is queued behind any in-flight write (`sync`), so the newest snapshot always lands last.
- `AppEnvironment`: the refresh-triggering settings sink calls `settingsStore.flush()` first.

## Verification

- `swift build`, `swift test` (1727 tests, 1 skipped, 0 failures)
- `./Scripts/build_app.sh release`, `codesign --verify --deep --strict` OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)
