### PR TITLE
List Grok Bot conversations as read-only sessions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -339,15 +339,16 @@ summary cannot delete a different session. Vibe Bar never edits the
 *contents* of a session file, never deletes a credential file at all, and
 no other code path may remove anything outside `~/.vibebar/`.
 
-**Three providers are listed and readable but never deletable**, because
-another running app owns the store and removing from underneath it
-corrupts rather than cleans:
+**Four providers are listed and readable but never deletable**, because
+another app owns the store and removing from underneath it corrupts
+rather than cleans:
 
 | Provider        | Store                                              | Why it is refused                               |
 | --------------- | -------------------------------------------------- | ----------------------------------------------- |
 | `antigravity`   | `~/.gemini/antigravity{,-cli,-ide}/conversations`   | The CLI and IDE hold live WAL handles.          |
 | `cursor`        | `~/.cursor/chats/**/store.db`                       | Cursor keeps the agent store open.              |
 | `claudeCowork`  | `…/Application Support/Claude/local-agent-mode-sessions` | The files are inside Claude.app's own container. |
+| `grokBot`       | `…/Application Support/Grok Bot/sand-client-persistence` | It is Grok Bot's own cache of conversations that live on xAI's servers. |
 
 `SessionProvider.supportsDeletion` is the single source of truth: those
 adapters throw `SessionDeleteError.providerIsReadOnly(provider)` — which
@@ -606,6 +607,7 @@ the display names).
 | AntiGravity   | Google AI  | `~/.gemini/antigravity{,-cli,-ide}/conversations`    |
 | Grok Build    | SpaceXAI   | `~/.grok/sessions/**/updates.jsonl`                  |
 | Cursor        | SpaceXAI   | `~/.cursor/chats/**/store.db` for sessions; dashboard events for cost |
+| Grok Bot      | SpaceXAI   | `~/Library/Application Support/Grok Bot/sand-client-persistence` — sessions only; quota rides in on Cursor's `grok_bot_weekly` bucket |
 
 Consequences worth stating out loud:
 
@@ -639,6 +641,7 @@ Sessions page; "Delete" is § 5's read-only rule.
 | AntiGravity   | ✅ `gen_metadata` turn             | ✅ conversation databases | ✅ `AntigravitySessionAdapter` | ❌ live WAL handles |
 | Grok Build    | ✅ `current_model_id`              | ✅ local session state    | ✅ `GrokSessionAdapter`      | ✅ |
 | Cursor        | ⚠️ when a turn recorded one        | ☁️ dashboard events only  | ✅ `CursorSessionAdapter`    | ❌ store stays open |
+| Grok Bot      | ❌ never recorded locally          | ❌ cloud-only             | ✅ `GrokBotSessionAdapter`, read-only | ❌ the app's own cloud cache |
 
 Where a ⚠️ appears the log genuinely does not carry the value — an aborted
 Cursor conversation records no `modelName` at all, and old Gemini CLI
@@ -651,6 +654,20 @@ its blobs is context-window bookkeeping, not billable usage, so the
 Sessions page lists Cursor conversations while the cost cards keep
 sourcing Cursor from the dashboard — do not "fix" that by inventing local
 counters.
+
+Grok Bot is a **cloud cache**, and the coverage matrix means it
+literally. The conversations run on xAI's servers; the directory is only
+what the client happened to replicate, so history may be partial, may be
+pruned, and may change underneath a scan. One `<base32>.blob` per key:
+the `roster.last-roster` slice holds the bot names (its `title` field is
+always empty and its `path` is a directory inside the *remote* sandbox),
+and one `transcript.replicas.<uuid>` slice per bot is the session.
+Entries carry no model, no token counts and no cost, so the provider
+touches neither the ledger nor the cost scan — Grok Bot's contribution to
+the quota axis stays exactly where it was, as Cursor's `grok_bot_weekly`
+bucket. Roles are read from the transcript owner's point of view; the
+mapping, including why an agent-to-agent turn stays `.user` / `.assistant`
+rather than `.other`, is documented on `GrokBotSessionAdapter.message`.
 
 **Model names.** Display always uses the canonical vendor id —
 `gemini-3.5-flash-high`, not "Gemini 3.5 Flash (High)". Route every

--- a/Sources/VibeBarApp/Views/SettingsView.swift
+++ b/Sources/VibeBarApp/Views/SettingsView.swift
@@ -466,7 +466,7 @@ struct SettingsView: View {
                         coreProviderPlanBadgeRows(for: [.grok, .cursor])
                         Divider()
                             .padding(.vertical, 2)
-                        Text("The SpaceXAI page combines Grok with Cursor. Grok reads `~/.grok/auth.json` or grok.com cookies; Cursor reads Cursor.app first, then cursor.com cookie slots. Grok Bot contributes quota only — its cloud runs do not add token/cost rows.")
+                        Text("The SpaceXAI page combines Grok with Cursor. Grok reads `~/.grok/auth.json` or grok.com cookies; Cursor reads Cursor.app first, then cursor.com cookie slots. Grok Bot contributes quota, plus read-only sessions from its local cache — its cloud runs still add no token/cost rows.")
                             .font(.caption)
                             .foregroundStyle(.secondary)
 

--- a/Sources/VibeBarApp/Views/Workbench/SessionManagerPage.swift
+++ b/Sources/VibeBarApp/Views/Workbench/SessionManagerPage.swift
@@ -13,6 +13,9 @@ extension SessionProvider {
         case .cursor:                .cursor
         case .gemini:                .gemini
         case .antigravity:           .antigravity
+        // Grok Bot is xAI's own app; it borrows Cursor's *quota* plumbing,
+        // never its brand. See `Harness.brandTool`.
+        case .grokBot:               .grok
         }
     }
 
@@ -24,7 +27,15 @@ extension Harness {
     /// company. Cursor gets the Cursor mark rather than Grok's, and
     /// AntiGravity its own rather than Gemini's, while the *chip* that
     /// groups them still says "SpaceXAI" / "Google AI".
-    var brandTool: ToolType { quotaTool }
+    ///
+    /// Grok Bot is the one harness whose quota tool is the wrong answer: its
+    /// weekly bucket rides in on Cursor's adapter, but a Grok Bot session was
+    /// produced by an xAI app and drawing it with Cursor's mark would say it
+    /// came from Cursor. There is no Grok Bot asset in `Resources/ProviderIcons`,
+    /// so it wears the Grok mark — the nearest brand that is actually true.
+    var brandTool: ToolType {
+        self == .grokBot ? .grok : quotaTool
+    }
 }
 
 /// The Workbench's Sessions page.

--- a/Sources/VibeBarCore/MCP/MCPResourceCatalog.swift
+++ b/Sources/VibeBarCore/MCP/MCPResourceCatalog.swift
@@ -96,7 +96,9 @@ public enum MCPResourceCatalog {
         }
         lines.append("")
         lines.append("Grok Bot is a cloud-only SubProvider that shares Cursor's adapter: it appears")
-        lines.append("as the `grok_bot_weekly` bucket under the `cursor` tool.")
+        lines.append("as the `grok_bot_weekly` bucket under the `cursor` tool. Its conversations")
+        lines.append("are listed as sessions from the app's own local cache, but its runs happen")
+        lines.append("server-side, so they never carry a model, tokens, or cost.")
         lines.append("")
         lines.append("L3 is the bucket: `id`, `title` and `groupTitle` on each entry of")
         lines.append("`quota.get` → `accounts[].buckets[]`. Examples are \"5 Hours\", \"Weekly\",")
@@ -156,6 +158,8 @@ public enum MCPResourceCatalog {
         case .antigravity:  return "`~/.gemini/antigravity{,-cli,-ide}/conversations`"
         case .grokBuild:    return "`~/.grok/sessions/**/updates.jsonl`"
         case .cursor:       return "`~/.cursor/chats/**/store.db`; cost from the dashboard"
+        case .grokBot:      return "`~/Library/Application Support/Grok Bot/"
+            + "sand-client-persistence`; sessions only, no tokens"
         }
     }
 

--- a/Sources/VibeBarCore/Models/Harness.swift
+++ b/Sources/VibeBarCore/Models/Harness.swift
@@ -23,6 +23,7 @@ import Foundation
 /// | AntiGravity    | Google AI  | `~/.gemini/antigravity{,-cli,-ide}/conversations`            |
 /// | Grok Build     | SpaceXAI   | `~/.grok/sessions/**/updates.jsonl`                          |
 /// | Cursor         | SpaceXAI   | `~/.cursor/chats/**/store.db` for sessions; dashboard remote events for cost (no local token counters) |
+/// | Grok Bot       | SpaceXAI   | `~/Library/Application Support/Grok Bot/sand-client-persistence` — a cloud cache: sessions only, no model, no local tokens |
 ///
 /// Renaming a harness is one edit here, not a hunt across the UI.
 /// `AGENTS.md` § 7.1 carries the coverage matrix — which of model, cost,
@@ -39,6 +40,9 @@ public enum HarnessCatalog {
     public static let antigravity = "AntiGravity"
     public static let grokBuild = "Grok Build"
     public static let cursor = "Cursor"
+    /// xAI's standalone cloud-bot app, not Grok Build. Its runs happen
+    /// server-side, so it contributes sessions and quota but never tokens.
+    public static let grokBot = "Grok Bot"
 }
 
 /// The local harness a usage event came from — the unit every usage and cost
@@ -56,6 +60,7 @@ public enum Harness: String, CaseIterable, Codable, Sendable, Hashable {
     case antigravity
     case grokBuild
     case cursor
+    case grokBot
 
     public var displayName: String {
         switch self {
@@ -67,6 +72,7 @@ public enum Harness: String, CaseIterable, Codable, Sendable, Hashable {
         case .antigravity:  HarnessCatalog.antigravity
         case .grokBuild:    HarnessCatalog.grokBuild
         case .cursor:       HarnessCatalog.cursor
+        case .grokBot:      HarnessCatalog.grokBot
         }
     }
 
@@ -81,6 +87,11 @@ public enum Harness: String, CaseIterable, Codable, Sendable, Hashable {
         case .antigravity:              .antigravity
         case .grokBuild:                .grok
         case .cursor:                   .cursor
+        // Grok Bot has no tool of its own: its quota arrives as Cursor's
+        // `grok_bot_weekly` bucket, which is also where the L1 company comes
+        // from. The Sessions badge deliberately draws the Grok mark instead
+        // — see `Harness.brandTool`.
+        case .grokBot:                  .cursor
         }
     }
 

--- a/Sources/VibeBarCore/Sessions/GrokBotSessionAdapter.swift
+++ b/Sources/VibeBarCore/Sessions/GrokBotSessionAdapter.swift
@@ -1,0 +1,425 @@
+import Foundation
+
+/// Grok Bot conversations: the local cache the standalone `Grok Bot.app`
+/// keeps at
+/// `~/Library/Application Support/Grok Bot/sand-client-persistence/`.
+///
+/// This is xAI's cloud-bot client, **not** Grok Build — the two share a
+/// company and nothing else. Every file in the directory is named
+/// `<base32>.blob`, where the stem is the lowercase, unpadded RFC 4648
+/// base32 of the key it holds, so `Base32` is how discovery decides whether
+/// a file is one of ours. Two keys matter:
+///
+/// - `sand.client.slice.account.<account>.roster.last-roster` — one row per
+///   bot: `id`, `name`, `description`, `createdAt`, `lastActivityAt`. The
+///   row is the only place a conversation's *name* exists; the transcript
+///   does not carry one. (Its `title` field is present but always empty, and
+///   its `path` is a path inside the remote sandbox — never local.)
+/// - `sand.client.slice.account.<account>.transcript.replicas.<bot uuid>` —
+///   the conversation itself, one file per bot. That file is the session.
+///
+/// Everything else under the prefix (`ui-layout`, `composer-drafts`,
+/// `send-journal`, …) is client state and is ignored. There can be more than
+/// one account; the roster is resolved per account.
+///
+/// **A cloud cache, so read-only and partial by nature.** The conversations
+/// live on xAI's servers; this directory is what the client happened to
+/// replicate, which means history may be incomplete and the app rewrites it
+/// underneath us. `deletionPlan` fails closed (AGENTS.md § 5), there is no
+/// resume command, and nothing here feeds the cost ledger — the entries
+/// carry no model, no token counts and no cost at all.
+public struct GrokBotSessionAdapter: SessionProviderAdapter {
+    public let provider: SessionProvider = .grokBot
+
+    /// One parsed roster per adapter instance, invalidated by the roster
+    /// file's own mtime + size. A scan calls `extractMetadata` once per bot
+    /// and every one of those calls wants the same ~50 KB file; the registry
+    /// builds one adapter and reuses it, so the cache is scan-scoped without
+    /// any global state.
+    private let rosters = RosterCache()
+
+    public init() {}
+
+    /// Deliberately not `FileManager.applicationSupportDirectory`: real-home
+    /// reads route through the caller's `homeDirectory` (AGENTS.md § 6), and
+    /// production passes `RealHomeDirectory.path`.
+    static let storeRelativePath = "Library/Application Support/Grok Bot/sand-client-persistence"
+
+    public func roots(homeDirectory: String) -> [URL] {
+        [URL(fileURLWithPath: homeDirectory).appendingPathComponent(Self.storeRelativePath)]
+    }
+
+    public func discoverSessionFiles(homeDirectory: String) -> [URL] {
+        roots(homeDirectory: homeDirectory).flatMap { root in
+            SessionParsing.collectFiles(under: root) { Self.transcriptKey(at: $0) != nil }
+        }
+    }
+
+    // MARK: - Keys
+
+    /// The account and bot a transcript blob belongs to.
+    struct TranscriptKey: Equatable {
+        let accountID: String
+        let botID: String
+    }
+
+    static let blobExtension = "blob"
+    static let accountKeyPrefix = "sand.client.slice.account."
+    static let transcriptInfix = ".transcript.replicas."
+    static let rosterSuffix = ".roster.last-roster"
+    static let variant = "bot"
+
+    /// Longest filename stem we will even try to decode, and the largest
+    /// blob we will read. Both are far above what the client writes (keys
+    /// are ~100 characters, the biggest transcript here is ~110 KB) and exist
+    /// so a junk file in the directory costs nothing.
+    static let maxStemLength = 512
+    static let maxBlobBytes: Int64 = 32 * 1024 * 1024
+
+    /// The key a `.blob` filename encodes, or `nil` for anything that is not
+    /// one of this store's account slices.
+    static func decodedKey(at url: URL) -> String? {
+        guard url.pathExtension == blobExtension else { return nil }
+        let stem = url.deletingPathExtension().lastPathComponent
+        guard !stem.isEmpty, stem.count <= maxStemLength else { return nil }
+        guard let key = Base32.decodeToString(stem), key.hasPrefix(accountKeyPrefix) else { return nil }
+        return key
+    }
+
+    static func transcriptKey(at url: URL) -> TranscriptKey? {
+        guard let key = decodedKey(at: url) else { return nil }
+        return transcriptKey(decoded: key)
+    }
+
+    static func transcriptKey(decoded key: String) -> TranscriptKey? {
+        guard key.hasPrefix(accountKeyPrefix) else { return nil }
+        let tail = key.dropFirst(accountKeyPrefix.count)
+        guard let infix = tail.range(of: transcriptInfix) else { return nil }
+        let accountID = String(tail[..<infix.lowerBound])
+        let botID = String(tail[infix.upperBound...])
+        // The account id is only ever compared against other decoded keys, so
+        // it needs no charset beyond "plausible" — this store's ids contain
+        // `%`. The bot id becomes the session id and travels much further, so
+        // it is held to the conservative identifier charset.
+        guard !accountID.isEmpty, accountID.count <= maxStemLength,
+              !accountID.contains("/"), !accountID.contains("."),
+              isIdentifier(botID)
+        else { return nil }
+        return TranscriptKey(accountID: accountID, botID: botID)
+    }
+
+    static func rosterKey(accountID: String) -> String {
+        accountKeyPrefix + accountID + rosterSuffix
+    }
+
+    static func isIdentifier(_ value: String) -> Bool {
+        guard !value.isEmpty, value.count <= 200 else { return false }
+        return value.unicodeScalars.allSatisfy(identifierScalars.contains)
+    }
+
+    private static let identifierScalars = CharacterSet(charactersIn:
+        "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_-"
+    )
+
+    // MARK: - Metadata
+
+    public func extractMetadata(fileURL: URL) throws -> SessionSummary {
+        guard let key = Self.transcriptKey(at: fileURL) else {
+            throw SessionParseError.invalidFormat(
+                "\(fileURL.lastPathComponent): not a Grok Bot transcript blob"
+            )
+        }
+        guard let entries = Self.entries(at: fileURL) else {
+            throw SessionParseError.unreadable(fileURL.lastPathComponent)
+        }
+        let transcript = Self.transcript(from: entries)
+        let row = rosterRow(for: key, in: fileURL.deletingLastPathComponent())
+
+        let firstPrompt = transcript.messages.first { $0.role == .user }?.text
+        let lastText = transcript.messages.last?.text
+
+        return SessionSummary(
+            provider: .grokBot,
+            sessionID: key.botID,
+            providerVariant: Self.variant,
+            harness: .grokBot,
+            // Cloud-side inference: the client never records which model
+            // answered, and guessing one would be wrong at pricing time too.
+            model: nil,
+            title: SessionParsing.display(row?.name ?? firstPrompt, limit: SessionParsing.titleLimit),
+            summary: SessionParsing.display(lastText ?? row?.description, limit: SessionParsing.summaryLimit),
+            // The roster's `path` is a directory inside the remote sandbox
+            // (`/home/box/…`), not anything on this Mac.
+            projectDir: nil,
+            createdAt: row?.createdAt ?? transcript.firstStamp,
+            // The roster row and the transcript disagree in both directions —
+            // the roster can lag a live conversation, and it also records
+            // activity (a rename, an automation) that leaves no entry.
+            lastActiveAt: Self.latest(transcript.lastStamp, row?.lastActivityAt),
+            sourcePath: fileURL.path,
+            sizeBytes: SessionParsing.fileSize(fileURL),
+            messageCount: transcript.entryCount
+        )
+    }
+
+    static func latest(_ dates: Date?...) -> Date? {
+        dates.compactMap { $0 }.max()
+    }
+
+    // MARK: - Transcript
+
+    public func parseTranscript(fileURL: URL, range: Range<Int>?) throws -> TranscriptDocument {
+        guard let entries = Self.entries(at: fileURL) else {
+            throw SessionParseError.unreadable(fileURL.lastPathComponent)
+        }
+        return SessionTranscriptSlicing.document(
+            messages: Self.transcript(from: entries).messages,
+            range: range
+        )
+    }
+
+    /// The replica's `value.entries`, in the order the client wrote them.
+    ///
+    /// File order rather than timestamp order on purpose: a couple of
+    /// conversations here have entries whose `timestampMs` runs backwards
+    /// (a reply persisted before the message it answers), and the array is
+    /// the client's own idea of the conversation.
+    static func entries(at url: URL) -> [[String: Any]]? {
+        guard SessionParsing.fileSize(url) <= maxBlobBytes else { return nil }
+        guard let object = SessionParsing.jsonObject(at: url),
+              let value = object["value"] as? [String: Any],
+              let entries = value["entries"] as? [[String: Any]]
+        else { return nil }
+        return entries
+    }
+
+    struct Transcript {
+        let messages: [SessionMessage]
+        /// Conversation entries — `message` and `send-message` — whether or
+        /// not they carried displayable text. This is what the list row
+        /// counts, so a widget or a secret prompt still registers as a turn.
+        let entryCount: Int
+        let firstStamp: Date?
+        let lastStamp: Date?
+    }
+
+    static func transcript(from entries: [[String: Any]]) -> Transcript {
+        var messages: [SessionMessage] = []
+        var entryCount = 0
+        var first: Date?
+        var last: Date?
+
+        for entry in entries {
+            let kind = SessionParsing.string(entry["kind"])
+            guard kind == messageKind || kind == sendMessageKind else { continue }
+            entryCount += 1
+            let stamp = SessionParsing.date(entry["timestampMs"])
+            if let stamp {
+                first = min(first ?? stamp, stamp)
+                last = max(last ?? stamp, stamp)
+            }
+            guard let message = self.message(from: entry, kind: kind, seq: messages.count, stamp: stamp) else {
+                continue
+            }
+            messages.append(message)
+        }
+        return Transcript(messages: messages, entryCount: entryCount, firstStamp: first, lastStamp: last)
+    }
+
+    static let messageKind = "message"
+    static let sendMessageKind = "send-message"
+
+    /// One entry as a transcript bubble, read from the transcript owner's —
+    /// the bot's — point of view.
+    ///
+    /// - `send-message` is the bot's own outbound turn to the human, so it is
+    ///   the assistant.
+    /// - `message` with `role: "user"` and no `fromAgent` is the human.
+    /// - `message` with `role: "user"` and a `fromAgent` is *another bot*
+    ///   talking to this one. Still an inbound turn, so still `.user` — the
+    ///   sender's name is prefixed because `SessionRole` has no case for
+    ///   "someone else's agent", and because `.user` is what the search index
+    ///   and the transcript's prompt list actually keep.
+    /// - `message` with `role: "assistant"` and a `toAgent` is this bot
+    ///   answering *that* other bot. It is the bot's own text — the same
+    ///   string appears in the other bot's replica as an inbound `fromAgent`
+    ///   message — so it is the assistant, marked with the addressee.
+    ///
+    /// `event` (renames, automation changes) and `user-attachment` are not
+    /// conversation and are dropped.
+    static func message(
+        from entry: [String: Any],
+        kind: String?,
+        seq: Int,
+        stamp: Date?
+    ) -> SessionMessage? {
+        if kind == sendMessageKind {
+            guard let payload = entry["message"] as? [String: Any] else { return nil }
+            // Non-text payloads (a rendered widget, a secret request, a bare
+            // attachment) have no content field; they still counted as turns.
+            let text = SessionParsing.firstNonEmptyText(payload["content"])
+            guard !text.isEmpty else { return nil }
+            return SessionMessage(seq: seq, role: .assistant, text: text, timestamp: stamp)
+        }
+
+        let text = SessionParsing.firstNonEmptyText(entry["content"])
+        guard !text.isEmpty else { return nil }
+        switch SessionParsing.string(entry["role"]) {
+        case "user":
+            return SessionMessage(
+                seq: seq,
+                role: .user,
+                text: prefixed(text, with: agentName(entry["fromAgent"]), arrow: false),
+                timestamp: stamp
+            )
+        case "assistant":
+            return SessionMessage(
+                seq: seq,
+                role: .assistant,
+                text: prefixed(text, with: agentName(entry["toAgent"]), arrow: true),
+                timestamp: stamp
+            )
+        default:
+            return nil
+        }
+    }
+
+    /// `Name: …` for an inbound agent turn, `→ Name: …` for an outbound one.
+    /// Without an agent the text is its own.
+    static func prefixed(_ text: String, with name: String?, arrow: Bool) -> String {
+        guard let name else { return text }
+        return (arrow ? "→ " : "") + name + ": " + text
+    }
+
+    static func agentName(_ value: Any?) -> String? {
+        guard let agent = value as? [String: Any] else { return nil }
+        return SessionParsing.display(SessionParsing.string(agent["name"]), limit: agentNameLimit)
+    }
+
+    static let agentNameLimit = 60
+
+    // MARK: - Roster
+
+    struct RosterRow: Equatable {
+        let id: String
+        let name: String?
+        let description: String?
+        let createdAt: Date?
+        let lastActivityAt: Date?
+    }
+
+    func rosterRow(for key: TranscriptKey, in directory: URL) -> RosterRow? {
+        rosters.rows(forAccount: key.accountID, in: directory)[key.botID]
+    }
+
+    /// Every bot the roster for `accountID` knows about, keyed by id.
+    ///
+    /// A missing or unparseable roster is an empty map, not a failure: the
+    /// transcripts are still readable, they just list without their names.
+    static func rosterRows(forAccount accountID: String, in directory: URL) -> (URL, [String: RosterRow])? {
+        guard let url = rosterURL(forAccount: accountID, in: directory) else { return nil }
+        return (url, rosterRows(at: url))
+    }
+
+    /// The store is flat and small (a couple of dozen files), so finding the
+    /// roster means decoding the stems until one is the roster key for this
+    /// account. The result is cached against the file's own stamp, so this
+    /// runs once per scan rather than once per bot.
+    static func rosterURL(forAccount accountID: String, in directory: URL) -> URL? {
+        let wanted = rosterKey(accountID: accountID)
+        let contents = (try? FileManager.default.contentsOfDirectory(
+            at: directory,
+            includingPropertiesForKeys: [.isRegularFileKey],
+            options: [.skipsSubdirectoryDescendants]
+        )) ?? []
+        return contents.first { decodedKey(at: $0) == wanted }
+    }
+
+    static func rosterRows(at url: URL) -> [String: RosterRow] {
+        guard SessionParsing.fileSize(url) <= maxBlobBytes,
+              let object = SessionParsing.jsonObject(at: url),
+              let value = object["value"] as? [String: Any],
+              let rows = value["rows"] as? [[String: Any]]
+        else { return [:] }
+
+        var out: [String: RosterRow] = [:]
+        for row in rows {
+            guard let id = SessionParsing.string(row["id"]) else { continue }
+            out[id] = RosterRow(
+                id: id,
+                // `title` exists on every row and is always empty; `name` is
+                // the one the client shows in its sidebar.
+                name: SessionParsing.firstString(row["name"], row["title"]),
+                description: SessionParsing.string(row["description"]),
+                createdAt: SessionParsing.date(row["createdAt"]),
+                lastActivityAt: SessionParsing.firstDate(row["lastActivityAt"], row["updatedAt"])
+            )
+        }
+        return out
+    }
+
+    // MARK: - Deletion
+
+    public func deletionPlan(for summary: SessionSummary, homeDirectory: String) throws -> SessionDeletionPlan {
+        throw SessionDeleteError.providerIsReadOnly(.grokBot)
+    }
+}
+
+/// One roster per account, invalidated by the roster file's own stamp.
+///
+/// Reference type so a `Sendable` value-type adapter can still keep a
+/// scan-scoped cache; the lock is what makes that honest, since the index
+/// fans its per-file work out across tasks.
+private final class RosterCache: @unchecked Sendable {
+    private struct Entry {
+        let url: URL
+        let stamp: Stamp
+        let rows: [String: GrokBotSessionAdapter.RosterRow]
+    }
+
+    struct Stamp: Equatable {
+        let modified: Date?
+        let size: Int64
+
+        static func of(_ url: URL) -> Stamp? {
+            guard let values = try? url.resourceValues(
+                forKeys: [.contentModificationDateKey, .fileSizeKey]
+            ) else { return nil }
+            return Stamp(modified: values.contentModificationDate, size: Int64(values.fileSize ?? 0))
+        }
+    }
+
+    /// One account is the norm and a handful is the realistic maximum; past
+    /// that the map is cleared rather than evicted one by one, because this
+    /// is a scan-lifetime cache and not a long-lived one.
+    private static let maxAccounts = 8
+
+    private let lock = NSLock()
+    private var entries: [String: Entry] = [:]
+
+    func rows(
+        forAccount accountID: String,
+        in directory: URL
+    ) -> [String: GrokBotSessionAdapter.RosterRow] {
+        let cacheKey = directory.path + "\u{0}" + accountID
+        lock.lock()
+        let cached = entries[cacheKey]
+        lock.unlock()
+
+        // A single stat re-validates the hit; only a miss pays for the
+        // directory listing that locates the roster again.
+        if let cached, Stamp.of(cached.url) == cached.stamp {
+            return cached.rows
+        }
+
+        guard let (url, rows) = GrokBotSessionAdapter.rosterRows(
+            forAccount: accountID, in: directory
+        ) else { return [:] }
+
+        lock.lock()
+        if entries.count >= Self.maxAccounts { entries.removeAll() }
+        entries[cacheKey] = Entry(url: url, stamp: Stamp.of(url) ?? Stamp(modified: nil, size: 0), rows: rows)
+        lock.unlock()
+        return rows
+    }
+}

--- a/Sources/VibeBarCore/Sessions/SessionModels.swift
+++ b/Sources/VibeBarCore/Sessions/SessionModels.swift
@@ -8,7 +8,7 @@ import Foundation
 /// ChatGPT Work depending on its `originator`), which is why every summary
 /// also carries a `harness`. See `AGENTS.md` § 7.1.
 ///
-/// Three providers are listed and readable but never deletable, because
+/// Four providers are listed and readable but never deletable, because
 /// another running app owns the store — see `supportsDeletion`.
 public enum SessionProvider: String, Codable, Sendable, CaseIterable, Hashable {
     case claude
@@ -18,6 +18,7 @@ public enum SessionProvider: String, Codable, Sendable, CaseIterable, Hashable {
     case cursor
     case gemini
     case antigravity
+    case grokBot
 
     public var displayName: String {
         switch self {
@@ -28,6 +29,7 @@ public enum SessionProvider: String, Codable, Sendable, CaseIterable, Hashable {
         case .cursor: return HarnessCatalog.cursor
         case .gemini: return HarnessCatalog.geminiCLI
         case .antigravity: return HarnessCatalog.antigravity
+        case .grokBot: return HarnessCatalog.grokBot
         }
     }
 
@@ -43,6 +45,7 @@ public enum SessionProvider: String, Codable, Sendable, CaseIterable, Hashable {
         case .cursor: return .cursor
         case .gemini: return .geminiCLI
         case .antigravity: return .antigravity
+        case .grokBot: return .grokBot
         }
     }
 
@@ -50,15 +53,16 @@ public enum SessionProvider: String, Codable, Sendable, CaseIterable, Hashable {
     ///
     /// `false` means another running app owns the store and removing from
     /// underneath it is how a store gets corrupted rather than emptied —
-    /// AntiGravity's live WAL handles, Cursor's open agent database, and
-    /// Cowork's transcripts inside Claude.app's own container (AGENTS.md
-    /// § 5). The adapters fail closed with
+    /// AntiGravity's live WAL handles, Cursor's open agent database,
+    /// Cowork's transcripts inside Claude.app's own container, and Grok
+    /// Bot's replica of conversations that actually live in the cloud
+    /// (AGENTS.md § 5). The adapters fail closed with
     /// `SessionDeleteError.providerIsReadOnly`; this is the same fact
     /// stated where a UI can ask it before offering the action.
     public var supportsDeletion: Bool {
         switch self {
         case .claude, .codex, .grok, .gemini: return true
-        case .claudeCowork, .cursor, .antigravity: return false
+        case .claudeCowork, .cursor, .antigravity, .grokBot: return false
         }
     }
 }
@@ -277,6 +281,8 @@ public enum SessionDeleteError: Error, Hashable, Codable, Sendable {
                 return "Cowork sessions live inside Claude.app's container and are never removed by Vibe Bar."
             case .cursor:
                 return "Cursor keeps its session store open; delete from Cursor itself."
+            case .grokBot:
+                return "Grok Bot sessions are the app's own cloud cache; manage them in Grok Bot."
             case .claude, .codex, .grok, .gemini:
                 return "Deleting sessions is not supported for this provider."
             }

--- a/Sources/VibeBarCore/Sessions/SessionProviderAdapter.swift
+++ b/Sources/VibeBarCore/Sessions/SessionProviderAdapter.swift
@@ -85,9 +85,9 @@ public struct SessionProviderRegistry: Sendable {
 
     /// The adapters shipped today, one per `SessionProvider`.
     ///
-    /// AntiGravity, Claude Cowork, and Cursor list and read like the rest but
-    /// refuse to plan a delete, because another running app owns those stores
-    /// — see `SessionProvider.supportsDeletion`.
+    /// AntiGravity, Claude Cowork, Cursor, and Grok Bot list and read like the
+    /// rest but refuse to plan a delete, because another running app owns
+    /// those stores — see `SessionProvider.supportsDeletion`.
     public static func standard(homeDirectory: String = RealHomeDirectory.path) -> SessionProviderRegistry {
         SessionProviderRegistry(adapters: [
             ClaudeSessionAdapter(),
@@ -96,7 +96,8 @@ public struct SessionProviderRegistry: Sendable {
             GrokSessionAdapter(),
             CursorSessionAdapter(),
             GeminiSessionAdapter(),
-            AntigravitySessionAdapter()
+            AntigravitySessionAdapter(),
+            GrokBotSessionAdapter()
         ])
     }
 

--- a/Sources/VibeBarCore/Sessions/SessionResumeCommandBuilder.swift
+++ b/Sources/VibeBarCore/Sessions/SessionResumeCommandBuilder.swift
@@ -47,11 +47,12 @@ public enum SessionResumeCommandBuilder {
             // sessions have no documented command-line entry point.
             guard variant == antigravityCLIVariant else { throw SessionResumeError.resumeUnavailable }
             return "agy --conversation \(id)"
-        case .claudeCowork, .cursor:
+        case .claudeCowork, .cursor, .grokBot:
             // Cowork runs inside Claude.app and Cursor's agents inside
             // Cursor; neither publishes a "reopen this conversation"
             // command, and inventing one would hand the user a line that
-            // silently starts a *new* session.
+            // silently starts a *new* session. Grok Bot goes further: the
+            // conversation runs on xAI's servers and there is no CLI at all.
             throw SessionResumeError.resumeUnavailable
         }
     }
@@ -78,7 +79,7 @@ public enum SessionResumeCommandBuilder {
     static func isValid(_ id: String, for provider: SessionProvider) -> Bool {
         guard !id.isEmpty, id.count <= maxSessionIDLength else { return false }
         switch provider {
-        case .claude, .claudeCowork, .codex, .cursor, .antigravity:
+        case .claude, .claudeCowork, .codex, .cursor, .antigravity, .grokBot:
             return id.unicodeScalars.allSatisfy { uuidCharacters.contains($0) }
         case .grok, .gemini:
             return id.unicodeScalars.allSatisfy { looseCharacters.contains($0) }

--- a/Sources/VibeBarCore/Utilities/Base32.swift
+++ b/Sources/VibeBarCore/Utilities/Base32.swift
@@ -1,0 +1,62 @@
+import Foundation
+
+/// RFC 4648 base32, decode only.
+///
+/// Grok Bot names every file in its persistence directory after the base32
+/// of the key it stores — lowercase and unpadded — so reading that store at
+/// all means decoding a filename back into
+/// `sand.client.slice.account.<id>.transcript.replicas.<uuid>`. Foundation
+/// ships base64 and nothing else, hence this.
+///
+/// Deliberately total and strict in equal measure: a character outside the
+/// alphabet, padding in the middle, a truncated group, or a final group whose
+/// unused bits are not zero all yield `nil` rather than a best-effort prefix.
+/// The caller is deciding whether an arbitrary filename is one of its own, so
+/// "almost decodes" has to read as "not mine".
+public enum Base32 {
+    /// `A-Z2-7`, case-insensitive. `=` is accepted as trailing padding and
+    /// otherwise rejected — the encoder Grok Bot uses omits it entirely.
+    public static func decode(_ text: String) -> Data? {
+        var out = Data()
+        out.reserveCapacity(text.unicodeScalars.count * 5 / 8)
+        var buffer: UInt32 = 0
+        var bits: UInt32 = 0
+        var sawPadding = false
+
+        for scalar in text.unicodeScalars {
+            if scalar == "=" {
+                sawPadding = true
+                continue
+            }
+            // Padding only ever ends a stream; a symbol after it means the
+            // string was concatenated or corrupted.
+            guard !sawPadding, let value = self.value(of: scalar) else { return nil }
+            buffer = (buffer << 5) | UInt32(value)
+            bits += 5
+            if bits >= 8 {
+                bits -= 8
+                out.append(UInt8((buffer >> bits) & 0xFF))
+            }
+        }
+
+        // A whole leftover group (5+ bits) is a truncated encoding, and the
+        // bits left over from a valid one are defined to be zero.
+        guard bits < 5, buffer & ((1 << bits) - 1) == 0 else { return nil }
+        return out
+    }
+
+    /// Convenience for the common case: base32 of UTF-8 text.
+    public static func decodeToString(_ text: String) -> String? {
+        guard let data = decode(text) else { return nil }
+        return String(data: data, encoding: .utf8)
+    }
+
+    private static func value(of scalar: Unicode.Scalar) -> UInt8? {
+        switch scalar {
+        case "A"..."Z": return UInt8(scalar.value - 65)
+        case "a"..."z": return UInt8(scalar.value - 97)
+        case "2"..."7": return UInt8(scalar.value - 50 + 26)
+        default: return nil
+        }
+    }
+}

--- a/Tests/VibeBarCoreTests/Base32Tests.swift
+++ b/Tests/VibeBarCoreTests/Base32Tests.swift
@@ -1,0 +1,101 @@
+import XCTest
+@testable import VibeBarCore
+
+final class Base32Tests: XCTestCase {
+    /// RFC 4648 § 10's own vectors, which pin the alphabet and every
+    /// remainder length (0, 2, 4, 5, and 7 symbols in the last group).
+    func testRFC4648TestVectors() {
+        let vectors: [(String, String)] = [
+            ("", ""),
+            ("MY======", "f"),
+            ("MZXQ====", "fo"),
+            ("MZXW6===", "foo"),
+            ("MZXW6YQ=", "foob"),
+            ("MZXW6YTB", "fooba"),
+            ("MZXW6YTBOI======", "foobar")
+        ]
+        for (encoded, expected) in vectors {
+            XCTAssertEqual(Base32.decodeToString(encoded), expected, encoded)
+        }
+    }
+
+    /// Grok Bot writes its filenames lowercase and without padding, so both
+    /// have to decode to the same bytes as the canonical form.
+    func testLowercaseAndUnpaddedDecodeTheSame() {
+        XCTAssertEqual(Base32.decodeToString("mzxw6ytboi"), "foobar")
+        XCTAssertEqual(Base32.decodeToString("MZXW6YTBOI"), "foobar")
+        XCTAssertEqual(Base32.decodeToString("mZxW6yTb"), "fooba")
+        XCTAssertEqual(Base32.decodeToString("my"), "f")
+    }
+
+    func testDecodesARealisticPersistenceKey() {
+        let key = "sand.client.slice.account.acct-1.transcript.replicas."
+            + "11111111-2222-3333-4444-555555555555"
+        let encoded = Base32TestEncoder.encode(key)
+        XCTAssertEqual(Base32.decodeToString(encoded), key)
+        XCTAssertEqual(Base32.decodeToString(encoded.uppercased()), key)
+    }
+
+    func testRejectsSymbolsOutsideTheAlphabet() {
+        // 0/1/8/9 and separators are exactly the characters base32 drops to
+        // stay unambiguous, so a hex or base64 string must not decode.
+        for bad in ["mzxw6ytb0i", "mzxw6ytb1i", "mzxw6ytb8i", "MZXW-YTB", "mzxw ytb", "!", "mzxw6ytb+"] {
+            XCTAssertNil(Base32.decode(bad), bad)
+        }
+    }
+
+    func testRejectsPaddingThatIsNotTrailing() {
+        XCTAssertNil(Base32.decode("MZ=XW6YTB"))
+        XCTAssertNil(Base32.decode("=MY"))
+    }
+
+    /// A single leftover symbol carries five bits, which cannot complete a
+    /// byte — that is a truncated encoding, not a short one.
+    func testRejectsATruncatedFinalGroup() {
+        XCTAssertNil(Base32.decode("M"))
+        XCTAssertNil(Base32.decode("MZXW6Y"))
+    }
+
+    /// The unused low bits of a final group are defined to be zero. Accepting
+    /// non-zero ones would make several distinct strings decode alike, and
+    /// filenames are identity here.
+    func testRejectsNonZeroPaddingBits() {
+        XCTAssertEqual(Base32.decodeToString("MY"), "f")
+        XCTAssertNil(Base32.decode("MZ"))
+    }
+
+    func testDecodesEveryByteValue() {
+        let bytes = Data((0...255).map(UInt8.init))
+        XCTAssertEqual(Base32.decode(Base32TestEncoder.encode(bytes)), bytes)
+    }
+}
+
+/// The other half of the codec, for fixtures only.
+///
+/// Lowercase and unpadded — the shape Grok Bot writes its filenames in. Tests
+/// need it to build a synthetic store; product code only ever decodes, so
+/// this deliberately lives in the test target.
+enum Base32TestEncoder {
+    static func encode(_ text: String) -> String {
+        encode(Data(text.utf8))
+    }
+
+    static func encode(_ data: Data) -> String {
+        let alphabet = Array("abcdefghijklmnopqrstuvwxyz234567")
+        var out = ""
+        var buffer = 0
+        var bits = 0
+        for byte in data {
+            buffer = (buffer << 8) | Int(byte)
+            bits += 8
+            while bits >= 5 {
+                bits -= 5
+                out.append(alphabet[(buffer >> bits) & 0x1F])
+            }
+        }
+        if bits > 0 {
+            out.append(alphabet[(buffer << (5 - bits)) & 0x1F])
+        }
+        return out
+    }
+}

--- a/Tests/VibeBarCoreTests/GrokBotSessionAdapterTests.swift
+++ b/Tests/VibeBarCoreTests/GrokBotSessionAdapterTests.swift
@@ -1,0 +1,411 @@
+import XCTest
+@testable import VibeBarCore
+
+final class GrokBotSessionAdapterTests: XCTestCase {
+    private var home: URL!
+    private let adapter = GrokBotSessionAdapter()
+
+    /// A `%` on purpose: the real client's account ids are not plain
+    /// identifiers, and the key parser has to keep accepting them.
+    private let account = "acct%SYNTHETIC1"
+    private let scout = "11111111-2222-3333-4444-555555555555"
+    private let archivist = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+    private let orphan = "99999999-8888-7777-6666-555555555555"
+
+    override func setUpWithError() throws {
+        home = FileManager.default.temporaryDirectory
+            .appendingPathComponent("VibeBarGrokBotAdapterTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: storeDirectory, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: home)
+    }
+
+    private var storeDirectory: URL {
+        home.appendingPathComponent(GrokBotSessionAdapter.storeRelativePath, isDirectory: true)
+    }
+
+    // MARK: - Fixtures
+
+    /// Writes a blob under the base32 of `key`, the way the client names it.
+    @discardableResult
+    private func writeBlob(key: String, json: String) throws -> URL {
+        let url = storeDirectory
+            .appendingPathComponent(Base32TestEncoder.encode(key))
+            .appendingPathExtension("blob")
+        try json.write(to: url, atomically: true, encoding: .utf8)
+        return url
+    }
+
+    private func transcriptKey(_ botID: String) -> String {
+        "sand.client.slice.account.\(account).transcript.replicas.\(botID)"
+    }
+
+    @discardableResult
+    private func writeRoster() throws -> URL {
+        let json = """
+        {"schemaVersion":2,"value":{"rows":[
+        {"id":"\(scout)","name":"Scout","title":"","description":"Watches the release feed.",
+         "createdAt":1767225600000,"updatedAt":1767229200000,"lastActivityAt":1767229200000,
+         "lastViewedAt":1767229200000,"path":"/home/box/sand-data/agents/\(scout)/state",
+         "isGroup":false,"memberIds":[],"conversationPartnerIds":["\(archivist)"],
+         "origin":"user","hasUnread":false,"unreadCount":0,"isHiddenFromSidebar":false},
+        {"id":"\(archivist)","name":"Archivist","title":"","description":"",
+         "createdAt":1767139200000,"updatedAt":1767142800000,"lastActivityAt":1767142800000,
+         "path":"/home/box/sand-data/agents/\(archivist)/state","isGroup":false,
+         "memberIds":[],"conversationPartnerIds":["\(scout)"],"origin":"user"},
+        {"id":"cccccccc-dddd-eeee-ffff-000000000000","name":"Never Opened","title":"",
+         "description":"","createdAt":1767000000000,"lastActivityAt":1767000000000,
+         "path":"/home/box/sand-data/agents/x/state","origin":"user"}
+        ]}}
+        """
+        return try writeBlob(key: "sand.client.slice.account.\(account).roster.last-roster", json: json)
+    }
+
+    /// Scout's replica: one of every entry kind the client writes.
+    @discardableResult
+    private func writeScoutReplica() throws -> URL {
+        let json = """
+        {"schemaVersion":1,"value":{"persistedAt":1767229200000,"epochHint":3,
+        "acceptedSequenceHint":9,"entries":[
+        {"kind":"message","id":"t1u","role":"user","content":"Summarize today's releases.",
+         "isStreaming":false,"timestampMs":1767225660000},
+        {"kind":"send-message","id":"t1s1","timestampMs":1767225720000,
+         "message":{"type":"text","content":"Three releases landed."}},
+        {"kind":"message","id":"t2u","role":"user","content":"Anything for the changelog?",
+         "isStreaming":false,"timestampMs":1767225780000,
+         "fromAgent":{"id":"\(archivist)","name":"Archivist"}},
+        {"kind":"message","id":"t2a","role":"assistant","content":"Only the release notes.",
+         "isStreaming":false,"timestampMs":1767225840000,
+         "toAgent":{"id":"\(archivist)","name":"Archivist","kind":"agent"}},
+        {"kind":"event","id":"event-1","timestampMs":1767225900000,
+         "event":{"type":"name-changed","from":"Watcher","to":"Scout"}},
+        {"kind":"user-attachment","id":"att-1","file_name":"notes.png","file_path":"/tmp/notes.png",
+         "width":10,"height":10,"byteSize":42},
+        {"kind":"send-message","id":"t3s","timestampMs":1767225960000,
+         "message":{"type":"widget","widget":{"kind":"poll"}}}
+        ]}}
+        """
+        return try writeBlob(key: transcriptKey(scout), json: json)
+    }
+
+    @discardableResult
+    private func writeArchivistReplica() throws -> URL {
+        let json = """
+        {"schemaVersion":1,"value":{"persistedAt":1767142800000,"entries":[
+        {"kind":"message","id":"a1u","role":"user","content":"Index the archive.",
+         "isStreaming":false,"timestampMs":1767139260000},
+        {"kind":"send-message","id":"a1s","timestampMs":1767139320000,
+         "message":{"type":"text","content":"Indexed 40 documents."}}
+        ]}}
+        """
+        return try writeBlob(key: transcriptKey(archivist), json: json)
+    }
+
+    /// A replica whose bot the roster never mentions, plus the two files the
+    /// scan has to walk past: client state under the same prefix, and a
+    /// transcript blob holding something that is not a replica.
+    private func writeNoise() throws {
+        try writeBlob(
+            key: transcriptKey(orphan),
+            json: """
+            {"schemaVersion":1,"value":{"entries":[
+            {"kind":"message","id":"o1","role":"user","content":"Who am I talking to?",
+             "isStreaming":false,"timestampMs":1767300000000}]}}
+            """
+        )
+        try writeBlob(
+            key: "sand.client.slice.account.\(account).ui-layout",
+            json: #"{"schemaVersion":1,"value":{"sidebarWidth":320}}"#
+        )
+        try writeBlob(key: transcriptKey("77777777-6666-5555-4444-333333333333"), json: "not json {")
+        // The client leaves a non-base32 marker file in the same directory.
+        try Data().write(to: storeDirectory.appendingPathComponent(".migrated-from-local-storage"))
+    }
+
+    private func summary(for botID: String) throws -> SessionSummary {
+        let summaries = adapter.discoverSessions(homeDirectory: home.path)
+        return try XCTUnwrap(summaries.first { $0.sessionID == botID })
+    }
+
+    // MARK: - Discovery
+
+    func testDiscoveryFindsOneSessionPerTranscriptReplica() throws {
+        try writeRoster()
+        try writeScoutReplica()
+        try writeArchivistReplica()
+        try writeNoise()
+
+        // Four blobs decode to a transcript key, so four are candidates: the
+        // roster, the layout slice and the marker file never were.
+        XCTAssertEqual(adapter.discoverSessionFiles(homeDirectory: home.path).count, 4)
+        // The one holding invalid JSON drops out here rather than sinking the
+        // sweep.
+        let summaries = adapter.discoverSessions(homeDirectory: home.path)
+        XCTAssertEqual(Set(summaries.map(\.sessionID)), [scout, archivist, orphan])
+    }
+
+    func testAMissingStoreIsEmptyRatherThanAFailure() throws {
+        try FileManager.default.removeItem(at: storeDirectory)
+        XCTAssertEqual(adapter.roots(homeDirectory: home.path).count, 1)
+        XCTAssertTrue(adapter.discoverSessionFiles(homeDirectory: home.path).isEmpty)
+        XCTAssertTrue(adapter.discoverSessions(homeDirectory: home.path).isEmpty)
+    }
+
+    func testTheStoreRootIsTheGrokBotApplicationSupportDirectory() {
+        let root = adapter.roots(homeDirectory: "/Users/example").first
+        XCTAssertEqual(
+            root?.path,
+            "/Users/example/Library/Application Support/Grok Bot/sand-client-persistence"
+        )
+    }
+
+    // MARK: - Keys
+
+    func testOnlyTranscriptKeysAreClaimed() {
+        let url = { (key: String) in
+            URL(fileURLWithPath: "/store/\(Base32TestEncoder.encode(key)).blob")
+        }
+        XCTAssertEqual(
+            GrokBotSessionAdapter.transcriptKey(at: url(transcriptKey(scout))),
+            GrokBotSessionAdapter.TranscriptKey(accountID: account, botID: scout)
+        )
+        for other in [
+            "sand.client.slice.account.\(account).roster.last-roster",
+            "sand.client.slice.account.\(account).composer-drafts",
+            "sand.client.slice.ui-layout",
+            "sand.client.slice.account.\(account).transcript.replicas.",
+            // A bot id that is not an identifier never becomes a session id.
+            "sand.client.slice.account.\(account).transcript.replicas.../../etc/passwd"
+        ] {
+            XCTAssertNil(GrokBotSessionAdapter.transcriptKey(at: url(other)), other)
+        }
+        // Not base32 at all, and base32 of something else entirely.
+        XCTAssertNil(GrokBotSessionAdapter.transcriptKey(
+            at: URL(fileURLWithPath: "/store/not-base32!.blob")
+        ))
+        XCTAssertNil(GrokBotSessionAdapter.transcriptKey(at: url(transcriptKey(scout))
+            .deletingPathExtension()))
+    }
+
+    // MARK: - Metadata
+
+    func testMetadataTakesItsNameAndClocksFromTheRosterRow() throws {
+        try writeRoster()
+        try writeScoutReplica()
+        let summary = try summary(for: scout)
+
+        XCTAssertEqual(summary.provider, .grokBot)
+        XCTAssertEqual(summary.harness, .grokBot)
+        XCTAssertEqual(summary.effectiveHarness.displayName, "Grok Bot")
+        XCTAssertEqual(summary.providerVariant, "bot")
+        XCTAssertEqual(summary.title, "Scout")
+        XCTAssertEqual(summary.summary, "→ Archivist: Only the release notes.")
+        XCTAssertEqual(summary.createdAt, Date(timeIntervalSince1970: 1_767_225_600))
+        // Five conversation entries — four with text plus the widget turn
+        // that carries none. The rename event and the attachment are not
+        // conversation and do not count.
+        XCTAssertEqual(summary.messageCount, 5)
+        // Cloud-side: no model, and the roster's `path` is remote.
+        XCTAssertNil(summary.model)
+        XCTAssertNil(summary.projectDir)
+        XCTAssertGreaterThan(summary.sizeBytes, 0)
+    }
+
+    /// The roster and the transcript are two clocks that disagree in both
+    /// directions — the roster lags a live conversation, and it also records
+    /// activity (a rename) that leaves no entry behind.
+    func testLastActiveTakesWhicheverClockIsLater() throws {
+        try writeRoster()
+        try writeScoutReplica()
+        try writeArchivistReplica()
+        // Roster: 1767229200000. Newest entry: 1767225960000.
+        XCTAssertEqual(
+            try summary(for: scout).lastActiveAt,
+            Date(timeIntervalSince1970: 1_767_229_200)
+        )
+        // Archivist's roster row stops at 1767142800000 while its newest
+        // entry is older still, so the roster wins there too.
+        XCTAssertEqual(
+            try summary(for: archivist).lastActiveAt,
+            Date(timeIntervalSince1970: 1_767_142_800)
+        )
+    }
+
+    func testASessionWithNoRosterRowFallsBackToItsFirstPrompt() throws {
+        try writeRoster()
+        try writeNoise()
+        let summary = try summary(for: orphan)
+
+        XCTAssertEqual(summary.title, "Who am I talking to?")
+        XCTAssertEqual(summary.createdAt, Date(timeIntervalSince1970: 1_767_300_000))
+        XCTAssertEqual(summary.lastActiveAt, Date(timeIntervalSince1970: 1_767_300_000))
+    }
+
+    /// No roster at all is a store that still lists — the names are simply
+    /// missing.
+    func testAMissingRosterDoesNotSinkTheScan() throws {
+        try writeScoutReplica()
+        let summary = try summary(for: scout)
+        XCTAssertEqual(summary.title, "Summarize today's releases.")
+    }
+
+    func testAMalformedReplicaIsRejectedRatherThanReturnedEmpty() throws {
+        let url = try writeBlob(key: transcriptKey(scout), json: "not json {")
+        XCTAssertThrowsError(try adapter.extractMetadata(fileURL: url))
+        XCTAssertThrowsError(try adapter.parseTranscript(fileURL: url, range: nil))
+    }
+
+    func testAFileOutsideTheKeyNamespaceIsRejectedAsTheWrongFormat() throws {
+        let url = try writeBlob(
+            key: "sand.client.slice.account.\(account).ui-layout",
+            json: #"{"schemaVersion":1,"value":{"entries":[]}}"#
+        )
+        XCTAssertThrowsError(try adapter.extractMetadata(fileURL: url)) { error in
+            guard case .invalidFormat = error as? SessionParseError else {
+                return XCTFail("expected invalidFormat, got \(error)")
+            }
+        }
+    }
+
+    // MARK: - Transcript
+
+    /// Read from the transcript owner's point of view: `send-message` is the
+    /// bot talking, an inbound `fromAgent` turn is another bot prompting it,
+    /// and an `assistant` turn with a `toAgent` is this bot answering that
+    /// other bot — the same string the other bot's replica stores inbound.
+    func testTranscriptRolesFollowTheBotsPointOfView() throws {
+        try writeRoster()
+        let url = try writeScoutReplica()
+        let document = try adapter.parseTranscript(fileURL: url, range: nil)
+
+        XCTAssertEqual(document.messages.map(\.role), [.user, .assistant, .user, .assistant])
+        XCTAssertEqual(document.messages.map(\.text), [
+            "Summarize today's releases.",
+            "Three releases landed.",
+            "Archivist: Anything for the changelog?",
+            "→ Archivist: Only the release notes."
+        ])
+        XCTAssertEqual(document.messages.map(\.seq), [0, 1, 2, 3])
+        XCTAssertEqual(document.totalMessageCount, 4)
+        XCTAssertFalse(document.truncated)
+        XCTAssertEqual(
+            document.messages.first?.timestamp,
+            Date(timeIntervalSince1970: 1_767_225_660)
+        )
+    }
+
+    /// Both halves of an agent-to-agent exchange are `.user` / `.assistant`
+    /// rather than `.other`, because those are the only two roles the search
+    /// index keeps — a cross-bot conversation that could not be searched
+    /// would be the largest silent hole in this provider.
+    func testAgentTurnsSurviveTheSearchExcerptFilter() throws {
+        let url = try writeScoutReplica()
+        let document = try adapter.parseTranscript(fileURL: url, range: nil)
+        let excerpts = SessionIndexService.excerpts(from: document, provider: .grokBot)
+
+        XCTAssertEqual(excerpts.count, 4)
+        XCTAssertTrue(excerpts.contains { $0.excerpt.contains("Anything for the changelog?") })
+        XCTAssertTrue(excerpts.contains { $0.excerpt.contains("Only the release notes.") })
+    }
+
+    func testTranscriptSlicesByRange() throws {
+        let url = try writeScoutReplica()
+        let document = try adapter.parseTranscript(fileURL: url, range: 1..<3)
+
+        XCTAssertEqual(document.messages.map(\.seq), [1, 2])
+        XCTAssertEqual(document.totalMessageCount, 4)
+        XCTAssertTrue(document.truncated)
+    }
+
+    // MARK: - Read-only
+
+    func testDeletionIsRefusedWithAMessageNamingTheOwningApp() throws {
+        try writeRoster()
+        try writeScoutReplica()
+        let summary = try summary(for: scout)
+        let registry = SessionProviderRegistry.standard(homeDirectory: home.path)
+
+        XCTAssertFalse(SessionProvider.grokBot.supportsDeletion)
+        XCTAssertThrowsError(try adapter.deletionPlan(for: summary, homeDirectory: home.path)) { error in
+            XCTAssertEqual(error as? SessionDeleteError, .providerIsReadOnly(.grokBot))
+        }
+
+        let outcomes = SessionDeleter(homeDirectory: home.path).delete([summary], registry: registry)
+        XCTAssertEqual(outcomes.first?.success, false)
+        XCTAssertEqual(outcomes.first?.failureReason, .providerIsReadOnly(.grokBot))
+        XCTAssertEqual(
+            SessionDeleteError.providerIsReadOnly(.grokBot).message,
+            "Grok Bot sessions are the app's own cloud cache; manage them in Grok Bot."
+        )
+        // Refused means untouched.
+        XCTAssertTrue(FileManager.default.fileExists(atPath: summary.sourcePath))
+    }
+
+    func testThereIsNoResumeCommand() {
+        XCTAssertThrowsError(
+            try SessionResumeCommandBuilder.command(provider: .grokBot, sessionID: scout)
+        ) { error in
+            XCTAssertEqual(error as? SessionResumeError, .resumeUnavailable)
+        }
+    }
+
+    // MARK: - Wiring
+
+    func testTheStandardRegistryCarriesTheAdapter() {
+        let registry = SessionProviderRegistry.standard(homeDirectory: home.path)
+        XCTAssertTrue(registry.adapter(for: .grokBot) is GrokBotSessionAdapter)
+        XCTAssertEqual(SessionProvider.grokBot.defaultHarness, .grokBot)
+        XCTAssertEqual(SessionProvider.grokBot.displayName, "Grok Bot")
+    }
+
+    /// The Sessions filter row groups harnesses under their L1 company, and
+    /// Grok Bot belongs to SpaceXAI — after Cursor, the harness whose quota
+    /// bucket it rides in on.
+    func testGrokBotJoinsTheSpaceXAIChipGroupAfterCursor() {
+        let group = Harness.chipGroups(companies: ToolType.coreProviderRepresentatives)
+            .first { $0.company == .grok }
+        XCTAssertEqual(group?.harnesses, [.grokBuild, .cursor, .grokBot])
+        XCTAssertEqual(Harness.grokBot.companyName, "SpaceXAI")
+    }
+
+    /// End to end through the index the MCP `sessions.*` tools read from:
+    /// a Grok Bot conversation lists, counts, and is full-text searchable —
+    /// including the half of it that another bot said.
+    func testTheIndexListsCountsAndSearchesGrokBotSessions() async throws {
+        try writeRoster()
+        try writeScoutReplica()
+        try writeArchivistReplica()
+
+        let store = try SessionIndexStore(url: home.appendingPathComponent("session_index.sqlite3"))
+        let service = SessionIndexService(
+            homeDirectory: home.path,
+            store: store,
+            registry: SessionProviderRegistry.standard(homeDirectory: home.path),
+            bodyIndexing: { true }
+        )
+        await service.refreshIndex()
+
+        let summaries = try await store.allSummaries()
+        XCTAssertEqual(Set(summaries.map(\.provider)), [.grokBot])
+        let providerCounts = try await store.providerCounts()
+        let harnessCounts = try await store.harnessCounts()
+        let page = try await store.summaryPage(harnesses: [.grokBot])
+        XCTAssertEqual(providerCounts[.grokBot], 2)
+        XCTAssertEqual(harnessCounts[.grokBot], 2)
+        XCTAssertEqual(page.summaries.compactMap(\.title).sorted(), ["Archivist", "Scout"])
+
+        let hits = try await store.search(text: "changelog", providers: [.grokBot])
+        XCTAssertEqual(hits.map(\.summary.sessionID), [scout])
+        XCTAssertEqual(hits.first?.summary.effectiveHarness, .grokBot)
+    }
+
+    /// Grok Bot has no local tokens at all, so it must not become a default
+    /// harness for any tool the cost scanner writes rows for.
+    func testGrokBotIsNeverADefaultCostHarness() {
+        for tool in ToolType.allCases {
+            XCTAssertNotEqual(Harness.defaultHarness(for: tool), .grokBot, "\(tool)")
+        }
+    }
+}

--- a/Tests/VibeBarCoreTests/HarnessTests.swift
+++ b/Tests/VibeBarCoreTests/HarnessTests.swift
@@ -13,7 +13,8 @@ final class HarnessTests: XCTestCase {
                 "Gemini CLI",
                 "AntiGravity",
                 "Grok Build",
-                "Cursor"
+                "Cursor",
+                "Grok Bot"
             ]
         )
     }
@@ -35,7 +36,10 @@ final class HarnessTests: XCTestCase {
             .geminiCLI:    (.gemini, .gemini),
             .antigravity:  (.antigravity, .gemini),
             .grokBuild:    (.grok, .grok),
-            .cursor:       (.cursor, .grok)
+            .cursor:       (.cursor, .grok),
+            // Grok Bot has no tool of its own — its weekly bucket arrives on
+            // Cursor's adapter, so that is also where its company comes from.
+            .grokBot:      (.cursor, .grok)
         ]
         XCTAssertEqual(expected.count, Harness.allCases.count)
         for harness in Harness.allCases {
@@ -46,6 +50,7 @@ final class HarnessTests: XCTestCase {
             XCTAssertEqual(harness.company, pair.1, "\(harness) company")
         }
         XCTAssertEqual(Harness.chatgptWork.companyName, "OpenAI")
+        XCTAssertEqual(Harness.grokBot.companyName, "SpaceXAI")
         XCTAssertEqual(Harness.antigravity.companyName, "Google AI")
         XCTAssertEqual(Harness.cursor.companyName, "SpaceXAI")
     }
@@ -74,7 +79,7 @@ final class HarnessTests: XCTestCase {
         XCTAssertEqual(Harness.harnesses(forCompany: .codex), [.codex, .chatgptWork])
         XCTAssertEqual(Harness.harnesses(forCompany: .claude), [.claudeCode, .claudeCowork])
         XCTAssertEqual(Harness.harnesses(forCompany: .gemini), [.geminiCLI, .antigravity])
-        XCTAssertEqual(Harness.harnesses(forCompany: .grok), [.grokBuild, .cursor])
+        XCTAssertEqual(Harness.harnesses(forCompany: .grok), [.grokBuild, .cursor, .grokBot])
         // A non-representative member resolves to the same company list.
         XCTAssertEqual(
             Harness.harnesses(forCompany: .cursor),
@@ -95,7 +100,7 @@ final class HarnessTests: XCTestCase {
                 [.codex, .chatgptWork],
                 [.claudeCode, .claudeCowork],
                 [.geminiCLI, .antigravity],
-                [.grokBuild, .cursor]
+                [.grokBuild, .cursor, .grokBot]
             ]
         )
         XCTAssertEqual(groups.flatMap(\.harnesses), Harness.allCases)
@@ -121,8 +126,8 @@ final class HarnessTests: XCTestCase {
     func testChipGroupsNormalizeCompaniesAndDropEmptyOnes() {
         let groups = Harness.chipGroups(companies: [.cursor, .grok, .warp])
         XCTAssertEqual(groups.map(\.company), [.grok])
-        XCTAssertEqual(groups.first?.harnesses, [.grokBuild, .cursor])
-        XCTAssertEqual(groups.first?.harnessSet, Set([Harness.grokBuild, .cursor]))
+        XCTAssertEqual(groups.first?.harnesses, [.grokBuild, .cursor, .grokBot])
+        XCTAssertEqual(groups.first?.harnessSet, Set([Harness.grokBuild, .cursor, .grokBot]))
     }
 
     func testRawValuesAreStableStorageKeys() {
@@ -132,7 +137,7 @@ final class HarnessTests: XCTestCase {
             Harness.allCases.map(\.rawValue),
             [
                 "codex", "chatgptWork", "claudeCode", "claudeCowork",
-                "geminiCLI", "antigravity", "grokBuild", "cursor"
+                "geminiCLI", "antigravity", "grokBuild", "cursor", "grokBot"
             ]
         )
     }

--- a/Tests/VibeBarCoreTests/MCPResourceCatalogTests.swift
+++ b/Tests/VibeBarCoreTests/MCPResourceCatalogTests.swift
@@ -18,7 +18,7 @@ final class MCPResourceCatalogTests: XCTestCase {
                 "The naming spec never mentions the harness key '\(harness.rawValue)'."
             )
         }
-        XCTAssertEqual(Harness.allCases.count, 8, "A new harness needs a row in the evidence table.")
+        XCTAssertEqual(Harness.allCases.count, 9, "A new harness needs a row in the evidence table.")
     }
 
     func testEveryL1CompanyAppears() {

--- a/Tests/VibeBarCoreTests/SessionDeleterTests.swift
+++ b/Tests/VibeBarCoreTests/SessionDeleterTests.swift
@@ -166,15 +166,16 @@ final class SessionDeleterTests: XCTestCase {
         XCTAssertTrue(exists(url))
     }
 
-    /// The three providers whose stores belong to another running app never
-    /// reach the containment fence at all — their adapters refuse first, and
-    /// each says which app to delete from instead.
+    /// The four providers whose stores belong to another running app — or, for
+    /// Grok Bot, to a server — never reach the containment fence at all: their
+    /// adapters refuse first, and each says which app to delete from instead.
     func testProvidersWhoseStoreAnotherAppOwnsAreRefused() {
         let paths: [SessionProvider: String] = [
             .antigravity: ".gemini/antigravity/conversations/\(sessionID).db",
             .cursor: ".cursor/chats/workspace/\(sessionID)/store.db",
             .claudeCowork: "Library/Application Support/Claude/local-agent-mode-sessions/"
-                + "space/x/local_\(sessionID)/.claude/projects/-Users-example-proj/\(sessionID).jsonl"
+                + "space/x/local_\(sessionID)/.claude/projects/-Users-example-proj/\(sessionID).jsonl",
+            .grokBot: "Library/Application Support/Grok Bot/sand-client-persistence/\(sessionID).blob"
         ]
         for (provider, path) in paths {
             XCTAssertFalse(provider.supportsDeletion, "\(provider) must not be deletable")
@@ -198,7 +199,7 @@ final class SessionDeleterTests: XCTestCase {
         }
         XCTAssertEqual(
             Set(SessionProvider.allCases.filter { !$0.supportsDeletion }),
-            [.antigravity, .cursor, .claudeCowork]
+            [.antigravity, .cursor, .claudeCowork, .grokBot]
         )
     }
 

--- a/Tests/VibeBarCoreTests/SessionResumeCommandBuilderTests.swift
+++ b/Tests/VibeBarCoreTests/SessionResumeCommandBuilderTests.swift
@@ -35,9 +35,10 @@ final class SessionResumeCommandBuilderTests: XCTestCase {
 
     /// Neither Cowork nor Cursor publishes a "reopen this conversation"
     /// command; inventing one would hand the user a line that quietly starts
-    /// a *new* session in the wrong app.
-    func testCoworkAndCursorHaveNoResumeCommandOnAnyVariant() {
-        for provider in [SessionProvider.claudeCowork, .cursor] {
+    /// a *new* session in the wrong app. Grok Bot has no CLI at all — the
+    /// conversation only exists on xAI's servers.
+    func testCoworkCursorAndGrokBotHaveNoResumeCommandOnAnyVariant() {
+        for provider in [SessionProvider.claudeCowork, .cursor, .grokBot] {
             for variant in [nil, "cli", "default"] {
                 assertThrows(.resumeUnavailable) {
                     try SessionResumeCommandBuilder.command(


### PR DESCRIPTION
## Why

Grok Bot (the standalone `Grok Bot.app`, xAI's cloud bots — not Grok Build) keeps a local cache of every bot conversation under `~/Library/Application Support/Grok Bot/sand-client-persistence/`. AQ wants those in the Sessions page as a read-only source (list, transcript, full-text search). It has no token/model/cost fields, so it stays out of usage/cost.

## What

- `Base32` decoder (Core, RFC 4648, decode-only) — blob file stems are base32 of keys like `sand.client.slice.account.<id>.roster.last-roster` / `…transcript.replicas.<botUUID>`.
- `GrokBotSessionAdapter`: one session per bot (roster row + transcript replica). Title/description/created/lastActivity from the roster; transcript from entries: `send-message` → assistant, `message role=user` → user (name-prefixed when from another bot), `message role=assistant`+`toAgent` → assistant (verified to be the bot's own outbound turn), events/attachments counted but not shown. File order preserved; `lastActiveAt = max(newest entry, roster.lastActivityAt)`. Read-only: no delete, no resume.
- `SessionProvider.grokBot`, `Harness.grokBot` (SpaceXAI, quota via Cursor's `grok_bot_weekly`, Grok brand mark), chip ordering after Cursor; MCP `sessions.*` and naming-spec resource pick it up through the same index.
- Docs: AGENTS.md §5 read-only providers, §7.1 harness table + coverage matrix, cloud-cache caveat (history may be partial).

## Verification

- `swift build`, `swift test` (1754 tests, 1 skipped, 0 failures; +27)
- `./Scripts/build_app.sh release`, `codesign -d --entitlements -` → empty `<dict/>`, `codesign --verify --deep --strict` OK; home-dir grep only `RealHomeDirectory.swift`
- Read-only smoke on the real store: 12 sessions parsed, 433 messages, all titled/dated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
