### PR TITLE
Prepare Vibe Bar 1.3.0 Dev build 35

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.3.0</string>
 	<key>CFBundleVersion</key>
-	<string>34</string>
+	<string>35</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>26.0</string>
 	<key>LSUIElement</key>


### PR DESCRIPTION
## Why

Cut the next Dev channel build after merging:

- #199 Transcript bubbles as plain Text (fixes the layout-storm freeze from the NSTextView bridge)
- #200 / #201 Settings writes coalesced off the main thread, ordered by sequence, flushed before refresh-triggering edits
- #202 Grok Bot conversations as read-only sessions
- #198 Sessions / harness naming / MCP transport now come from `agent-session-kit` 0.2.0 (statically linked; the release binary carries it whole — no user-visible change)

## What

- `Resources/Info.plist`: `CFBundleVersion` 34 → 35. `CFBundleShortVersionString` stays `1.3.0`.

## Verification

- Clean-resolve `swift build` (kit fetched from GitHub at the exact `0.2.0` pin), `swift test` (1515 tests, 1 skipped, 0 failures — 247 moved to the kit's suite, green there)
- `./Scripts/build_app.sh release`, `codesign -d --entitlements -` → empty `<dict/>`, `codesign --verify --deep --strict` OK; bundle reports build 35
- `nm` on the release binary: 4,498 `AgentSessionKit` symbols, Grok Bot adapter present; `otool -L` shows no kit dylib

Tag `v1.3.0-dev.35` will be created on the merged commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
