### PR TITLE
Debounce label edits, align the tables, and let All clear the chips

### DIFF
--- a/Sources/VibeBarApp/Controllers/SessionManagerModel.swift
+++ b/Sources/VibeBarApp/Controllers/SessionManagerModel.swift
@@ -117,7 +117,8 @@ final class SessionManagerModel: ObservableObject {
         }
     }
 
-    /// Which harnesses the list is narrowed to, or `nil` for all of them.
+    /// Which harnesses the list is narrowed to: `nil` for all of them, `[]`
+    /// for none — see `HarnessSelection`, which owns the chip arithmetic.
     ///
     /// The filter axis is the harness rather than the `SessionProvider`,
     /// because a Codex rollout tree holds both Codex and ChatGPT Work
@@ -313,6 +314,15 @@ final class SessionManagerModel: ObservableObject {
         guard let service else { return }
         summaryGeneration &+= 1
         let generation = summaryGeneration
+        // No harness selected queries nothing. Asking the index for an empty
+        // harness list would be reading its "no filter" convention as the
+        // opposite of what the user just said.
+        if HarnessSelection.isNothing(harnessFilter) {
+            summaries = []
+            isLoadingSummaries = false
+            reconcileSelection()
+            return
+        }
         let offset = reset ? 0 : summaries.count
         let harnesses = harnessFilter.map { Array($0).sorted { $0.rawValue < $1.rawValue } }
         let since = dateRange.start()
@@ -380,6 +390,10 @@ final class SessionManagerModel: ObservableObject {
 
     private func runSearch(_ needle: String, generation: UInt64) async {
         guard let service else { return }
+        guard !HarnessSelection.isNothing(harnessFilter) else {
+            if generation == searchGeneration { hits = [] }
+            return
+        }
         let harnesses = harnessFilter.map { Array($0).sorted { $0.rawValue < $1.rawValue } }
         let found = (try? await service.search(needle, harnesses: harnesses, limit: 200)) ?? []
         guard generation == searchGeneration else { return }
@@ -486,21 +500,32 @@ final class SessionManagerModel: ObservableObject {
         toggleHarnesses([harness])
     }
 
-    func toggleHarnesses(_ harnesses: Set<Harness>) {
-        guard !harnesses.isEmpty else { return }
-        var next = harnessFilter ?? Set(Harness.allCases)
-        if harnesses.allSatisfy(next.contains) {
-            next.subtract(harnesses)
-        } else {
-            next.formUnion(harnesses)
-        }
-        // Everything selected is the same statement as no filter, and saying
-        // it that way keeps the chip row and the FTS query in agreement.
-        setHarnessFilter(next.count == Harness.allCases.count ? nil : next)
+    /// ⌥-click on a harness chip: narrow the list to that harness alone.
+    func soloHarness(_ harness: Harness) {
+        setHarnessFilter(HarnessSelection.solo(harness, options: Harness.allCases))
     }
 
+    /// What the "All" chip does: everything lit turns everything off,
+    /// anything else turns everything back on.
+    func toggleAllHarnesses() {
+        setHarnessFilter(
+            HarnessSelection.toggleAll(harnessFilter, options: Harness.allCases)
+        )
+    }
+
+    func toggleHarnesses(_ harnesses: Set<Harness>) {
+        setHarnessFilter(
+            HarnessSelection.toggle(
+                harnesses, in: harnessFilter, options: Harness.allCases
+            )
+        )
+    }
+
+    /// `nil` lists every harness; `[]` lists none. Both are real states — the
+    /// All chip toggles between them — so an empty set is no longer folded
+    /// back into "unfiltered".
     func setHarnessFilter(_ harnesses: Set<Harness>?) {
-        harnessFilter = (harnesses?.isEmpty ?? true) ? nil : harnesses
+        harnessFilter = harnesses
     }
 
     // MARK: - Selection

--- a/Sources/VibeBarApp/Controllers/UsageStatsViewModel.swift
+++ b/Sources/VibeBarApp/Controllers/UsageStatsViewModel.swift
@@ -149,9 +149,10 @@ final class UsageStatsViewModel: ObservableObject {
     /// lit should read as unfiltered, not as an empty page. Only whole
     /// companies are ever selected here; the chips are the only writer.
     @Published private(set) var selectedTools: Set<ToolType>?
-    /// `nil` means "every harness". Orthogonal to `selectedTools`: the chips
-    /// pick companies on the quota axis, this picks the CLI / app the usage
-    /// actually came from.
+    /// `nil` means "every harness", `[]` means **none** — see
+    /// `HarnessSelection`, which owns the chip arithmetic. Orthogonal to
+    /// `selectedTools`: the chips pick companies on the quota axis, this
+    /// picks the CLI / app the usage actually came from.
     @Published private(set) var selectedHarnesses: Set<Harness>?
     @Published private(set) var selectedModels: Set<String>?
     @Published private(set) var activeBreakdown: Breakdown = .periods
@@ -429,8 +430,10 @@ final class UsageStatsViewModel: ObservableObject {
         if rangePreset == .all { allTimeStart = nil }
         // A company chip going dark can strand a harness selection whose
         // company is no longer in the query; drop those so the harness menu
-        // and the results describe the same thing.
-        if let selectedHarnesses {
+        // and the results describe the same thing. An explicit empty
+        // selection is left alone — the user asked for nothing, and pruning
+        // nothing must not silently mean everything.
+        if let selectedHarnesses, !selectedHarnesses.isEmpty {
             let kept = selectedHarnesses.filter { harness in
                 normalized?.contains(harness.quotaTool) ?? true
             }
@@ -455,10 +458,13 @@ final class UsageStatsViewModel: ObservableObject {
         setSelectedTools(next.count == knownTools.count ? nil : next)
     }
 
+    /// `nil` selects every harness; `[]` selects none. Both are real states —
+    /// the All chip toggles between them — so an empty set is no longer
+    /// folded back into "unfiltered". The ledger already reads an empty
+    /// filter list as "match nothing".
     func setSelectedHarnesses(_ harnesses: Set<Harness>?) {
-        let normalized = (harnesses?.isEmpty ?? true) ? nil : harnesses
-        guard normalized != selectedHarnesses else { return }
-        selectedHarnesses = normalized
+        guard harnesses != selectedHarnesses else { return }
+        selectedHarnesses = harnesses
         if rangePreset == .all { allTimeStart = nil }
         reload(cascadeModels: true)
     }
@@ -467,20 +473,27 @@ final class UsageStatsViewModel: ObservableObject {
         toggleHarnesses([harness])
     }
 
+    /// ⌥-click on a harness chip: narrow to that harness alone.
+    func soloHarness(_ harness: Harness) {
+        setSelectedHarnesses(HarnessSelection.solo(harness, options: harnessOptions))
+    }
+
+    /// What the "All harnesses" chip does: everything lit turns everything
+    /// off, anything else turns everything back on.
+    func toggleAllHarnesses() {
+        setSelectedHarnesses(
+            HarnessSelection.toggleAll(selectedHarnesses, options: harnessOptions)
+        )
+    }
+
     /// Toggles a whole company's harnesses in one click — what the muted
-    /// company chip at the head of each chip group does. Turning them all on
-    /// is the same statement as "no harness filter", and saying it that way
-    /// keeps the query unrestricted.
+    /// company chip at the head of each chip group does.
     func toggleHarnesses(_ harnesses: Set<Harness>) {
-        guard !harnesses.isEmpty else { return }
-        let options = harnessOptions
-        var next = selectedHarnesses ?? Set(options)
-        if harnesses.allSatisfy(next.contains) {
-            next.subtract(harnesses)
-        } else {
-            next.formUnion(harnesses)
-        }
-        setSelectedHarnesses(next.count == options.count ? nil : next)
+        setSelectedHarnesses(
+            HarnessSelection.toggle(
+                harnesses, in: selectedHarnesses, options: harnessOptions
+            )
+        )
     }
 
     func setSelectedModels(_ models: Set<String>?) {
@@ -669,8 +682,11 @@ final class UsageStatsViewModel: ObservableObject {
             guard !Task.isCancelled, generation == self.generation else { return }
             // Models first: a narrowed provider set can strand a model that no
             // longer exists in the picker, and querying with it would report
-            // an empty page the user has no control to clear.
-            if cascadeModels {
+            // an empty page the user has no control to clear. An empty harness
+            // selection is exempt: it says nothing about which models exist,
+            // so pruning against its empty list would quietly discard a model
+            // filter the user still wants when the harnesses come back.
+            if cascadeModels, !HarnessSelection.isNothing(self.selectedHarnesses) {
                 self.pruneSelectedModels(to: models)
             }
             let resolved = self.filter

--- a/Sources/VibeBarApp/Views/DebouncedSettingsTextField.swift
+++ b/Sources/VibeBarApp/Views/DebouncedSettingsTextField.swift
@@ -1,0 +1,71 @@
+import SwiftUI
+
+/// A Settings text field that types into its own draft and writes back later.
+///
+/// The label editors used to bind straight at `AppSettings`. Every character
+/// therefore mutated the settings value, and every mutation fans a
+/// `@Published` change out to every settings observer that is currently
+/// alive — the popover, the mini window, the status-item render pipeline, and
+/// this page's own long field list — before the next keystroke could be drawn.
+/// Disk writes are already coalesced in `SettingsStore`; this coalesces the
+/// render fan-out the same way.
+///
+/// The draft is committed on submit, on focus loss, after `idleDelay` of no
+/// typing, and on disappear — so closing the window or switching Settings
+/// section immediately after typing still keeps what was typed.
+///
+/// Value semantics stay entirely with the binding: "" still means "remove the
+/// override", trimming still happens where it happened before. This view only
+/// decides *when* the binding is written.
+struct DebouncedSettingsTextField: View {
+    let prompt: String
+    @Binding var value: String
+    /// How long the field waits after the last keystroke before writing.
+    let idleDelay: Duration
+
+    @FocusState private var isFocused: Bool
+    @State private var draft: String = ""
+
+    init(
+        prompt: String,
+        value: Binding<String>,
+        idleDelay: Duration = .milliseconds(400)
+    ) {
+        self.prompt = prompt
+        self._value = value
+        self.idleDelay = idleDelay
+    }
+
+    var body: some View {
+        TextField(prompt, text: $draft)
+            .textFieldStyle(.roundedBorder)
+            .focused($isFocused)
+            .onAppear { draft = value }
+            .onSubmit(commit)
+            // One timer per idle window: `task(id:)` cancels the pending
+            // commit when another character arrives, and again when the field
+            // leaves the view tree.
+            .task(id: draft) {
+                guard draft != value else { return }
+                try? await Task.sleep(for: idleDelay)
+                guard !Task.isCancelled else { return }
+                commit()
+            }
+            .onChange(of: isFocused) { _, focused in
+                if !focused { commit() }
+            }
+            // An external write — a reset, a migration, another window — may
+            // only replace text the user is not currently editing.
+            .onChange(of: value) { _, newValue in
+                if !isFocused, newValue != draft { draft = newValue }
+            }
+            .onDisappear(perform: commit)
+    }
+
+    private func commit() {
+        if draft != value { value = draft }
+        // The binding may normalize what it stored (trim, drop an override).
+        // Once the field is no longer being edited, show what was kept.
+        if !isFocused, draft != value { draft = value }
+    }
+}

--- a/Sources/VibeBarApp/Views/EffectivePricingCatalogView.swift
+++ b/Sources/VibeBarApp/Views/EffectivePricingCatalogView.swift
@@ -63,7 +63,7 @@ struct EffectivePricingCatalogView: View {
                         Divider().opacity(0.45)
                     }
                 }
-                .frame(minWidth: 780, alignment: .topLeading)
+                .frame(minWidth: PricingColumns.minimumWidth, alignment: .topLeading)
             }
             .frame(height: 420)
             .background(Color.primary.opacity(0.018))
@@ -118,31 +118,74 @@ struct EffectivePricingCatalogView: View {
         }
     }
 
+    /// Rendered straight from the column spec the rows use, so a width or an
+    /// alignment cannot drift between the header and the table under it.
     private var pricingHeader: some View {
-        HStack(spacing: 8) {
-            headerCell("Provider / SubProvider", width: 154)
-            headerCell("Model", width: 242)
-            headerCell("Input / 1M", width: 84, alignment: .trailing)
-            headerCell("Output / 1M", width: 84, alignment: .trailing)
-            headerCell("Cache read", width: 84, alignment: .trailing)
-            headerCell("Cache write", width: 84, alignment: .trailing)
+        HStack(spacing: PricingColumns.spacing) {
+            ForEach(PricingColumns.all) { column in
+                Text(column.title.uppercased())
+                    .font(.system(size: 9, weight: .semibold))
+                    .foregroundStyle(.tertiary)
+                    .tracking(0.45)
+                    .lineLimit(1)
+                    .frame(width: column.width, alignment: column.frameAlignment)
+            }
         }
-        .padding(.horizontal, 10)
+        .padding(.horizontal, PricingColumns.horizontalInset)
         .frame(minHeight: 30)
         .background(Color.primary.opacity(0.035))
     }
+}
 
-    private func headerCell(
-        _ text: String,
-        width: CGFloat,
-        alignment: Alignment = .leading
-    ) -> some View {
-        Text(text.uppercased())
-            .font(.system(size: 9, weight: .semibold))
-            .foregroundStyle(.tertiary)
-            .tracking(0.45)
-            .frame(width: width, alignment: alignment)
+// MARK: - Column spec
+
+/// One column of the effective-price table. The header cell and every row
+/// cell beneath it read their width and horizontal alignment from the same
+/// value, which is the only thing that keeps the two in step — the header and
+/// the rows are separate views with no layout relationship at all.
+private struct PricingColumn: Identifiable {
+    let title: String
+    let width: CGFloat
+    let alignment: HorizontalAlignment
+
+    init(_ title: String, _ width: CGFloat, _ alignment: HorizontalAlignment = .leading) {
+        self.title = title
+        self.width = width
+        self.alignment = alignment
     }
+
+    var id: String { title }
+
+    /// Vertical placement belongs to the row (`.firstTextBaseline`), so a
+    /// cell's own frame only carries the horizontal axis.
+    var frameAlignment: Alignment {
+        Alignment(horizontal: alignment, vertical: .center)
+    }
+}
+
+private enum PricingColumns {
+    static let spacing: CGFloat = 8
+    static let horizontalInset: CGFloat = 10
+
+    static let provider = PricingColumn("Provider / SubProvider", 154)
+    static let model = PricingColumn("Model", 242)
+    static let input = PricingColumn("Input / 1M", 84, .trailing)
+    static let output = PricingColumn("Output / 1M", 84, .trailing)
+    static let cacheRead = PricingColumn("Cache read", 84, .trailing)
+    static let cacheWrite = PricingColumn("Cache write", 84, .trailing)
+
+    static let all: [PricingColumn] = [provider, model, input, output, cacheRead, cacheWrite]
+
+    /// Where the MODEL column starts. The threshold / override footnote under
+    /// a row hangs off this rather than a hand-tuned inset, so it stays on the
+    /// grid when a column width changes.
+    static let detailInset: CGFloat = provider.width + spacing
+
+    /// Narrower than this and the trailing price column clips, so the scroll
+    /// surface never proposes less.
+    static let minimumWidth: CGFloat = all.reduce(
+        horizontalInset * 2 + spacing * CGFloat(all.count - 1)
+    ) { $0 + $1.width }
 }
 
 private struct EffectivePricingRowView: View {
@@ -151,7 +194,11 @@ private struct EffectivePricingRowView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 4) {
-            HStack(spacing: 8) {
+            // `.firstTextBaseline`, not the default centre: PROVIDER and
+            // MODEL are two-line cells, and centring made each single-line
+            // price float to their midpoint instead of sitting on the line
+            // the header labels.
+            HStack(alignment: .firstTextBaseline, spacing: PricingColumns.spacing) {
                 HStack(spacing: 6) {
                     ToolBrandIconView(tool: row.tool, size: 13)
                     VStack(alignment: .leading, spacing: 1) {
@@ -162,7 +209,10 @@ private struct EffectivePricingRowView: View {
                             .foregroundStyle(.secondary)
                     }
                 }
-                .frame(width: 154, alignment: .leading)
+                .frame(
+                    width: PricingColumns.provider.width,
+                    alignment: PricingColumns.provider.frameAlignment
+                )
 
                 VStack(alignment: .leading, spacing: 1) {
                     Text(row.displayLabel ?? row.model)
@@ -175,12 +225,15 @@ private struct EffectivePricingRowView: View {
                             .lineLimit(1)
                     }
                 }
-                .frame(width: 242, alignment: .leading)
+                .frame(
+                    width: PricingColumns.model.width,
+                    alignment: PricingColumns.model.frameAlignment
+                )
 
-                price(row.inputPerMillion)
-                price(row.outputPerMillion)
-                price(row.cacheReadPerMillion)
-                price(row.cacheWritePerMillion)
+                price(row.inputPerMillion, PricingColumns.input)
+                price(row.outputPerMillion, PricingColumns.output)
+                price(row.cacheReadPerMillion, PricingColumns.cacheRead)
+                price(row.cacheWritePerMillion, PricingColumns.cacheWrite)
             }
 
             if let detail = advancedDetail {
@@ -195,24 +248,24 @@ private struct EffectivePricingRowView: View {
                         .foregroundStyle(.tertiary)
                         .lineLimit(1)
                 }
-                .padding(.leading, 168)
+                .padding(.leading, PricingColumns.detailInset)
             } else if isLocalOverride {
                 Text("LOCAL OVERRIDE")
                     .font(.system(size: 8, weight: .bold))
                     .foregroundStyle(.blue)
-                    .padding(.leading, 168)
+                    .padding(.leading, PricingColumns.detailInset)
             }
         }
-        .padding(.horizontal, 10)
+        .padding(.horizontal, PricingColumns.horizontalInset)
         .padding(.vertical, 7)
     }
 
-    private func price(_ value: Double?) -> some View {
+    private func price(_ value: Double?, _ column: PricingColumn) -> some View {
         Text(value.map(Self.formatPrice) ?? "—")
             .font(.system(size: 9.5, weight: .medium, design: .rounded).monospacedDigit())
             .foregroundStyle(value == nil ? Color.secondary : Color.primary)
             .opacity(value == nil ? 0.65 : 1)
-            .frame(width: 84, alignment: .trailing)
+            .frame(width: column.width, alignment: column.frameAlignment)
     }
 
     private var advancedDetail: String? {

--- a/Sources/VibeBarApp/Views/SettingsView.swift
+++ b/Sources/VibeBarApp/Views/SettingsView.swift
@@ -839,14 +839,12 @@ struct SettingsView: View {
             HStack(spacing: 10) {
                 groupLabelText(option)
                 Spacer(minLength: 8)
-                TextField(option.defaultLabel, text: miniGroupLabelBinding(option))
-                    .textFieldStyle(.roundedBorder)
+                groupLabelTextField(option)
                     .frame(width: 130)
             }
             VStack(alignment: .leading, spacing: 6) {
                 groupLabelText(option)
-                TextField(option.defaultLabel, text: miniGroupLabelBinding(option))
-                    .textFieldStyle(.roundedBorder)
+                groupLabelTextField(option)
                     .frame(maxWidth: 180, alignment: .leading)
             }
         }
@@ -919,9 +917,11 @@ struct SettingsView: View {
                     .foregroundStyle(.tertiary)
             }
             Spacer(minLength: 8)
-            TextField("Auto", text: providerPlanLabelBinding(tool))
-                .textFieldStyle(.roundedBorder)
-                .frame(width: 130)
+            DebouncedSettingsTextField(
+                prompt: "Auto",
+                value: providerPlanLabelBinding(tool)
+            )
+            .frame(width: 130)
         }
     }
 
@@ -964,10 +964,19 @@ struct SettingsView: View {
         .help(field.id)
     }
 
+    /// Label editors never write per keystroke. See
+    /// `DebouncedSettingsTextField`: a settings mutation fans out to every
+    /// open surface, and this page alone shows two dozen of these fields.
     private func fieldLabelTextField(field: MenuBarFieldOption, label: Binding<String>) -> some View {
-        TextField(field.defaultLabel, text: label)
-            .textFieldStyle(.roundedBorder)
+        DebouncedSettingsTextField(prompt: field.defaultLabel, value: label)
             .frame(width: 110)
+    }
+
+    private func groupLabelTextField(_ option: MiniWindowGroupLabelOption) -> some View {
+        DebouncedSettingsTextField(
+            prompt: option.defaultLabel,
+            value: miniGroupLabelBinding(option)
+        )
     }
 
     private func groupLabelText(_ option: MiniWindowGroupLabelOption) -> some View {

--- a/Sources/VibeBarApp/Views/Workbench/SessionListView.swift
+++ b/Sources/VibeBarApp/Views/Workbench/SessionListView.swift
@@ -85,11 +85,12 @@ struct SessionListView: View {
 
     private var emptyState: some View {
         CardShell(density: density, alignment: .center) {
-            Image(systemName: model.isIndexAvailable ? "bubble.left.and.text.bubble.right" : "externaldrive.badge.exclamationmark")
+            Image(systemName: emptySymbol)
                 .font(.system(size: 26, weight: .light))
                 .foregroundStyle(.secondary)
-            Text(model.isIndexAvailable ? "No sessions match" : "Session index unavailable")
+            Text(emptyTitle)
                 .font(.system(size: density.titleFontSize, weight: .semibold))
+                .multilineTextAlignment(.center)
             Text(emptyDetail)
                 .font(.system(size: density.subtitleFontSize))
                 .foregroundStyle(.secondary)
@@ -100,9 +101,30 @@ struct SessionListView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
     }
 
+    private var hasNoHarnessSelected: Bool {
+        HarnessSelection.isNothing(model.harnessFilter)
+    }
+
+    private var emptySymbol: String {
+        guard model.isIndexAvailable else { return "externaldrive.badge.exclamationmark" }
+        return hasNoHarnessSelected
+            ? "line.3.horizontal.decrease.circle"
+            : "bubble.left.and.text.bubble.right"
+    }
+
+    /// The explicit empty selection the All chip can reach is its own state:
+    /// "no sessions match" would blame the data for a filter the user set.
+    private var emptyTitle: String {
+        guard model.isIndexAvailable else { return "Session index unavailable" }
+        return hasNoHarnessSelected ? "No harness selected — pick one above" : "No sessions match"
+    }
+
     private var emptyDetail: String {
         guard model.isIndexAvailable else {
             return "The index under ~/.vibebar could not be opened, so sessions cannot be listed this session."
+        }
+        if hasNoHarnessSelected {
+            return "The All chip is a switch: click it again to list every harness."
         }
         if model.indexProgress != nil { return "Still scanning the session logs on disk." }
         if !model.searchText.isEmpty { return "Nothing in the indexed sessions matches that search." }

--- a/Sources/VibeBarApp/Views/Workbench/SessionManagerPage.swift
+++ b/Sources/VibeBarApp/Views/Workbench/SessionManagerPage.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 import VibeBarCore
 
@@ -231,20 +232,25 @@ struct SessionFiltersBar: View {
         }
     }
 
+    /// The All chip is a switch, not a shortcut: lit means every harness is
+    /// listed and clicking it clears the selection outright; anything else
+    /// and it puts every harness back.
     private var allProvidersChip: some View {
-        Button {
-            model.setHarnessFilter(nil)
+        let selected = model.harnessFilter == nil
+        return Button {
+            model.toggleAllHarnesses()
         } label: {
             Text("All")
                 .font(.system(size: max(10, density.segmentedFontSize - 1), weight: .semibold))
-                .foregroundStyle(model.harnessFilter == nil ? .primary : .secondary)
+                .foregroundStyle(selected ? .primary : .secondary)
                 .padding(.horizontal, 10)
                 .frame(minHeight: 28)
         }
         .buttonStyle(.plain)
-        .background(chipBackground(tint: .accentColor, selected: model.harnessFilter == nil))
-        .help("Show sessions from every harness")
-        .accessibilityLabel("Show every session source")
+        .background(chipBackground(tint: .accentColor, selected: selected))
+        .help(selected ? "Click to select no harness" : "Click to show sessions from every harness")
+        .accessibilityLabel(selected ? "Select no harness" : "Show every session source")
+        .accessibilityAddTraits(selected ? [.isSelected] : [])
     }
 
     /// The company section head. Deliberately quieter than the harness chips
@@ -280,11 +286,18 @@ struct SessionFiltersBar: View {
     /// with. The icon is the harness's own brand (Cursor's mark, not Grok's,
     /// matching the badge in the list); the accent is the company's, so a
     /// group still reads as one block of colour.
+    ///
+    /// ⌥-click solos, which is the one-click way to ask "just this harness"
+    /// without turning eight other chips off by hand.
     private func harnessChip(_ harness: Harness, in group: Harness.ChipGroup) -> some View {
         let selected = model.harnessFilter?.contains(harness) ?? true
         let count = model.harnessCounts[harness] ?? 0
         return Button {
-            model.toggleHarness(harness)
+            if NSEvent.modifierFlags.contains(.option) {
+                model.soloHarness(harness)
+            } else {
+                model.toggleHarness(harness)
+            }
         } label: {
             HStack(spacing: 5) {
                 ToolBrandIconView(tool: harness.brandTool, size: density.segmentedFontSize + 1)
@@ -305,7 +318,7 @@ struct SessionFiltersBar: View {
         .background(chipBackground(tint: Theme.providerAccent(for: group.company), selected: selected))
         .opacity(selected ? 1 : 0.70)
         .saturation(selected ? 1 : 0.50)
-        .help("\(group.company.vendorName) · \(harness.displayName)")
+        .help("\(group.company.vendorName) · \(harness.displayName)\nClick to toggle · ⌥-click to solo")
         .accessibilityAddTraits(selected ? [.isSelected] : [])
     }
 

--- a/Sources/VibeBarApp/Views/Workbench/UsageBreakdownTables.swift
+++ b/Sources/VibeBarApp/Views/Workbench/UsageBreakdownTables.swift
@@ -149,29 +149,24 @@ struct UsageBreakdownTables: View {
     /// ordinary Workbench width; only their descriptive leading column flexes.
     private var periodsTable: some View {
         GeometryReader { proxy in
-            let contentWidth = proxy.size.width - UsageTableMetrics.horizontalInset * 2
-            let periodWidth = max(170, contentWidth - 5 * 108)
+            let columns = PeriodColumns(
+                title: periodColumnTitle,
+                contentWidth: proxy.size.width - UsageTableMetrics.horizontalInset * 2
+            )
             VStack(spacing: 0) {
-                tableHeader {
-                    headerCell(periodColumnTitle, width: periodWidth)
-                    headerCell("Input", width: 108, alignment: .trailing)
-                    headerCell("Output", width: 108, alignment: .trailing)
-                    headerCell("Cache", width: 108, alignment: .trailing)
-                    headerCell("Tokens", width: 108, alignment: .trailing)
-                    headerCell("Cost", width: 108, alignment: .trailing)
-                }
+                tableHeader(columns.all)
                 LazyVStack(spacing: 0) {
                     ForEach(populatedPeriods, id: \.bucketStart) { point in
                         let label = period(point.bucketStart)
                         PorcelainUsageRow(
                             accessibilityLabel: periodAccessibilityLabel(point, label: label)
                         ) {
-                            valueCell(label, width: periodWidth, tooltip: label)
-                            numericCell(point.freshInput, width: 108)
-                            numericCell(point.output, width: 108)
-                            numericCell(point.cacheRead + point.cacheCreation, width: 108)
-                            numericCell(point.totalTokens, width: 108, emphasis: true)
-                            moneyCell(point.costMicros, width: 108, emphasis: true)
+                            valueCell(label, columns.period, tooltip: label)
+                            numericCell(point.freshInput, columns.input)
+                            numericCell(point.output, columns.output)
+                            numericCell(point.cacheRead + point.cacheCreation, columns.cache)
+                            numericCell(point.totalTokens, columns.tokens, emphasis: true)
+                            moneyCell(point.costMicros, columns.cost, emphasis: true)
                         }
                     }
                 }
@@ -192,7 +187,8 @@ struct UsageBreakdownTables: View {
     /// realized more rows, which fired again. Paging is an explicit button
     /// now; nothing chains.
     private var requestsTable: some View {
-        ScrollView([.horizontal, .vertical], showsIndicators: true) {
+        let columns = RequestColumns()
+        return ScrollView([.horizontal, .vertical], showsIndicators: true) {
             LazyVStack(spacing: 0, pinnedViews: [.sectionHeaders]) {
                 Section {
                     ForEach(model.requestRows) { row in
@@ -203,32 +199,28 @@ struct UsageBreakdownTables: View {
                                 row, time: time, model: modelName
                             )
                         ) {
-                            valueCell(time, width: 138, secondary: true)
-                            harnessCell(row.harness, width: 138)
-                            valueCell(modelName, width: 220, tooltip: row.model)
-                            inputCell(row, width: 114)
-                            numericCell(row.output, width: 88)
-                            optionalMoneyCell(row.costMicros, width: 96)
-                            valueCell(row.serviceTier ?? "—", width: 86, secondary: true)
+                            valueCell(time, columns.time, secondary: true)
+                            harnessCell(row.harness, columns.harness)
+                            valueCell(modelName, columns.model, tooltip: row.model)
+                            inputCell(row, columns.input)
+                            numericCell(row.output, columns.output)
+                            optionalMoneyCell(row.costMicros, columns.cost)
+                            valueCell(row.serviceTier ?? "—", columns.tier, secondary: true)
                         }
                     }
                     if model.hasMoreRequests { loadMoreRow }
                 } header: {
-                    tableHeader {
-                        headerCell("Time", width: 138)
-                        headerCell("Harness", width: 138)
-                        headerCell("Model", width: 220)
-                        headerCell("Input", width: 114, alignment: .trailing)
-                        headerCell("Output", width: 88, alignment: .trailing)
-                        headerCell("Cost", width: 96, alignment: .trailing)
-                        headerCell("Tier", width: 86)
-                    }
-                    // Opaque: a pinned header floats over the rows it labels,
-                    // and flat surfaces cast no shadow to separate them.
-                    .background(WorkbenchPorcelain.overlayFill(for: colorScheme))
+                    // Same column spec and the same `UsageTableMetrics`
+                    // inset as the rows: a pinned header sits in its own
+                    // layout pass, so nothing else keeps the two in step.
+                    tableHeader(columns.all)
+                        // Opaque: a pinned header floats over the rows it
+                        // labels, and flat surfaces cast no shadow to
+                        // separate them.
+                        .background(WorkbenchPorcelain.overlayFill(for: colorScheme))
                 }
             }
-            .frame(minWidth: 898, alignment: .leading)
+            .frame(minWidth: columns.minimumWidth, alignment: .leading)
         }
         .accessibilityLabel("Request usage table")
         .frame(height: requestsViewportHeight)
@@ -273,25 +265,21 @@ struct UsageBreakdownTables: View {
 
     private var providersTable: some View {
         GeometryReader { proxy in
-            let contentWidth = proxy.size.width - UsageTableMetrics.horizontalInset * 2
-            let providerWidth = max(180, contentWidth - 112 - 132 - 120)
+            let columns = ProviderColumns(
+                contentWidth: proxy.size.width - UsageTableMetrics.horizontalInset * 2
+            )
             VStack(spacing: 0) {
-                tableHeader {
-                    headerCell("Provider", width: providerWidth)
-                    headerCell("Requests", width: 112, alignment: .trailing)
-                    headerCell("Tokens", width: 132, alignment: .trailing)
-                    headerCell("Cost", width: 120, alignment: .trailing)
-                }
+                tableHeader(columns.all)
                 LazyVStack(spacing: 0) {
                     ForEach(sortedProviders) { stat in
                         let vendor = stat.tool.vendorName
                         PorcelainUsageRow(
                             accessibilityLabel: providerAccessibilityLabel(stat, vendor: vendor)
                         ) {
-                            companyCell(stat.tool, name: vendor, width: providerWidth)
-                            countCell(stat.requests, width: 112)
-                            numericCell(stat.totalTokens, width: 132, emphasis: true)
-                            moneyCell(stat.costMicros, width: 120, emphasis: true)
+                            companyCell(stat.tool, name: vendor, columns.provider)
+                            countCell(stat.requests, columns.requests)
+                            numericCell(stat.totalTokens, columns.tokens, emphasis: true)
+                            moneyCell(stat.costMicros, columns.cost, emphasis: true)
                         }
                     }
                 }
@@ -302,27 +290,22 @@ struct UsageBreakdownTables: View {
 
     private var modelsTable: some View {
         GeometryReader { proxy in
-            let contentWidth = proxy.size.width - UsageTableMetrics.horizontalInset * 2
-            let modelWidth = max(200, contentWidth - 112 - 132 - 120 - 128)
+            let columns = ModelColumns(
+                contentWidth: proxy.size.width - UsageTableMetrics.horizontalInset * 2
+            )
             VStack(spacing: 0) {
-                tableHeader {
-                    headerCell("Model", width: modelWidth)
-                    headerCell("Requests", width: 112, alignment: .trailing)
-                    headerCell("Tokens", width: 132, alignment: .trailing)
-                    headerCell("Cost", width: 120, alignment: .trailing)
-                    headerCell("Avg/req", width: 128, alignment: .trailing)
-                }
+                tableHeader(columns.all)
                 LazyVStack(spacing: 0) {
                     ForEach(sortedModels) { stat in
                         let name = UsageModelNaming.canonicalDisplayName(stat.model)
                         PorcelainUsageRow(
                             accessibilityLabel: modelAccessibilityLabel(stat, name: name)
                         ) {
-                            valueCell(name, width: modelWidth, tooltip: stat.model)
-                            countCell(stat.requests, width: 112)
-                            numericCell(stat.totalTokens, width: 132, emphasis: true)
-                            moneyCell(stat.costMicros, width: 120, emphasis: true)
-                            moneyCell(stat.avgCostMicrosPerRequest, width: 128, secondary: true)
+                            valueCell(name, columns.model, tooltip: stat.model)
+                            countCell(stat.requests, columns.requests)
+                            numericCell(stat.totalTokens, columns.tokens, emphasis: true)
+                            moneyCell(stat.costMicros, columns.cost, emphasis: true)
+                            moneyCell(stat.avgCostMicrosPerRequest, columns.average, secondary: true)
                         }
                     }
                 }
@@ -333,9 +316,18 @@ struct UsageBreakdownTables: View {
 
     // MARK: - Cells
 
-    private func tableHeader<Content: View>(@ViewBuilder content: () -> Content) -> some View {
+    /// The header renders straight from the column spec the rows beneath it
+    /// use, so a width or an alignment cannot drift between the two.
+    private func tableHeader(_ columns: [UsageTableColumn]) -> some View {
         HStack(spacing: 0) {
-            content()
+            ForEach(columns) { column in
+                Text(column.title.uppercased())
+                    .font(.system(size: 10, weight: .semibold))
+                    .kerning(0.65)
+                    .foregroundStyle(.tertiary)
+                    .lineLimit(1)
+                    .frame(width: column.width, alignment: column.frameAlignment)
+            }
         }
         .frame(minHeight: 27)
         .padding(.horizontal, UsageTableMetrics.horizontalInset)
@@ -347,26 +339,13 @@ struct UsageBreakdownTables: View {
         .accessibilityHidden(true)
     }
 
-    private func headerCell(
-        _ text: String,
-        width: CGFloat,
-        alignment: Alignment = .leading
-    ) -> some View {
-        Text(text.uppercased())
-            .font(.system(size: 10, weight: .semibold))
-            .kerning(0.65)
-            .foregroundStyle(.tertiary)
-            .lineLimit(1)
-            .frame(width: width, alignment: alignment)
-    }
-
     /// `.help` installs a tracking area, so seven per row across fifty rows
     /// is three hundred and fifty of them for one table. It is opt-in here
     /// and reserved for cells that can truncate — passing the cell's own
     /// visible text back as its tooltip bought nothing.
     private func valueCell(
         _ value: String,
-        width: CGFloat,
+        _ column: UsageTableColumn,
         secondary: Bool = false,
         tooltip: String? = nil
     ) -> some View {
@@ -375,36 +354,44 @@ struct UsageBreakdownTables: View {
             .foregroundStyle(secondary ? Color.secondary : Color.primary)
             .lineLimit(1)
             .truncationMode(.middle)
-            .frame(width: width, alignment: .leading)
+            .frame(width: column.width, alignment: column.frameAlignment)
             .modifier(OptionalHelp(tooltip))
     }
 
     /// A request row is usage, so it names the harness that produced it, not
     /// the quota SubProvider it bills against (AGENTS.md § 7.1). The badge
     /// still follows the L1 company, matching the Harness Mix card.
-    private func harnessCell(_ harness: Harness, width: CGFloat) -> some View {
+    private func harnessCell(_ harness: Harness, _ column: UsageTableColumn) -> some View {
         HStack(spacing: 7) {
             ToolBrandBadge(tool: harness.company, iconSize: 13, containerSize: 16)
             Text(harness.displayName)
                 .font(bodyFont)
                 .lineLimit(1)
         }
-        .frame(width: width, alignment: .leading)
+        .frame(width: column.width, alignment: column.frameAlignment)
         .help("\(harness.companyName) · \(harness.displayName)")
     }
 
-    private func companyCell(_ tool: ToolType, name: String, width: CGFloat) -> some View {
+    private func companyCell(
+        _ tool: ToolType,
+        name: String,
+        _ column: UsageTableColumn
+    ) -> some View {
         HStack(spacing: 7) {
             ToolBrandBadge(tool: tool, iconSize: 13, containerSize: 16)
             Text(name)
                 .font(bodyFont)
                 .lineLimit(1)
         }
-        .frame(width: width, alignment: .leading)
+        .frame(width: column.width, alignment: column.frameAlignment)
     }
 
-    private func inputCell(_ row: UsageRequestRow, width: CGFloat) -> some View {
-        VStack(alignment: .trailing, spacing: 1) {
+    /// The one two-line cell in the four tables. Its first line carries the
+    /// column's number, which is why the row aligns on `.firstTextBaseline`:
+    /// otherwise every single-line cell in the row floats to the midpoint of
+    /// this one and nothing lines up with the header above it.
+    private func inputCell(_ row: UsageRequestRow, _ column: UsageTableColumn) -> some View {
+        VStack(alignment: column.alignment, spacing: 1) {
             Text(UsageFormatting.compactTokens(row.freshInput))
                 .font(numericFont)
             if row.cacheRead > 0 || row.cacheCreation > 0 {
@@ -414,31 +401,31 @@ struct UsageBreakdownTables: View {
                     .lineLimit(1)
             }
         }
-        .frame(width: width, alignment: .trailing)
+        .frame(width: column.width, alignment: column.frameAlignment)
         .help("Fresh input: \(UsageFormatting.formatTokens(row.freshInput))\nCache read: \(UsageFormatting.formatTokens(row.cacheRead))\nCache write: \(UsageFormatting.formatTokens(row.cacheCreation))")
     }
 
     private func numericCell(
         _ value: Int64,
-        width: CGFloat,
+        _ column: UsageTableColumn,
         emphasis: Bool = false
     ) -> some View {
         Text(UsageFormatting.compactTokens(value))
             .font(numericFont)
             .fontWeight(emphasis ? .semibold : .regular)
-            .frame(width: width, alignment: .trailing)
+            .frame(width: column.width, alignment: column.frameAlignment)
             .help(UsageFormatting.formatTokens(value))
     }
 
-    private func countCell(_ value: Int, width: CGFloat) -> some View {
+    private func countCell(_ value: Int, _ column: UsageTableColumn) -> some View {
         Text(value.formatted(.number.grouping(.automatic)))
             .font(numericFont)
-            .frame(width: width, alignment: .trailing)
+            .frame(width: column.width, alignment: column.frameAlignment)
     }
 
     private func moneyCell(
         _ micros: Int64,
-        width: CGFloat,
+        _ column: UsageTableColumn,
         emphasis: Bool = false,
         secondary: Bool = false
     ) -> some View {
@@ -446,19 +433,19 @@ struct UsageBreakdownTables: View {
             .font(numericFont)
             .fontWeight(emphasis ? .semibold : .regular)
             .foregroundStyle(secondary ? Color.secondary : Color.primary)
-            .frame(width: width, alignment: .trailing)
+            .frame(width: column.width, alignment: column.frameAlignment)
             .help(UsageFormatting.formatMicroUSD(micros, precision: 6))
     }
 
-    private func optionalMoneyCell(_ micros: Int64?, width: CGFloat) -> some View {
+    private func optionalMoneyCell(_ micros: Int64?, _ column: UsageTableColumn) -> some View {
         Group {
             if let micros {
-                moneyCell(micros, width: width)
+                moneyCell(micros, column)
             } else {
                 Text("unpriced")
                     .font(.system(size: 10, weight: .medium))
                     .foregroundStyle(.tertiary)
-                    .frame(width: width, alignment: .trailing)
+                    .frame(width: column.width, alignment: column.frameAlignment)
                     .help("No price was available for this request")
             }
         }
@@ -592,7 +579,12 @@ private struct PorcelainUsageRow<Content: View>: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            HStack(spacing: 0) {
+            // `.firstTextBaseline`, not the default centre: the Requests
+            // table's INPUT cell is two lines, and centring made every
+            // single-line cell in that row sit between them instead of on
+            // the line the header labels. Single-line rows are unaffected —
+            // one shared baseline is the same placement as one shared centre.
+            HStack(alignment: .firstTextBaseline, spacing: 0) {
                 content()
             }
             .frame(minHeight: 33)
@@ -631,4 +623,102 @@ private struct OptionalHelp: ViewModifier {
 
 private enum UsageTableMetrics {
     static let horizontalInset: CGFloat = 9
+}
+
+// MARK: - Column specs
+
+/// One column of a usage table.
+///
+/// The header cell and every row cell beneath it read their width and their
+/// horizontal alignment from the same value. Seven hand-repeated
+/// `.frame(width:alignment:)` pairs per table is how a header and its rows
+/// drift apart; one spec consumed twice cannot.
+private struct UsageTableColumn: Identifiable {
+    let title: String
+    let width: CGFloat
+    let alignment: HorizontalAlignment
+
+    init(_ title: String, _ width: CGFloat, _ alignment: HorizontalAlignment = .leading) {
+        self.title = title
+        self.width = width
+        self.alignment = alignment
+    }
+
+    var id: String { title }
+
+    /// Vertical placement belongs to the row (`.firstTextBaseline`), so a
+    /// cell's own frame only carries the horizontal axis.
+    var frameAlignment: Alignment {
+        Alignment(horizontal: alignment, vertical: .center)
+    }
+}
+
+private extension Array where Element == UsageTableColumn {
+    /// Header and rows are laid out inside the same inset, so a fixed-width
+    /// table's scroll surface has to be at least this wide.
+    var totalWidth: CGFloat {
+        reduce(UsageTableMetrics.horizontalInset * 2) { $0 + $1.width }
+    }
+}
+
+/// Period, Provider and Model borrow the card's available width: their
+/// trailing values keep a width that never hides behind a scroller at the
+/// ordinary Workbench width, and only the descriptive leading column flexes.
+private struct PeriodColumns {
+    let period: UsageTableColumn
+    let input = UsageTableColumn("Input", 108, .trailing)
+    let output = UsageTableColumn("Output", 108, .trailing)
+    let cache = UsageTableColumn("Cache", 108, .trailing)
+    let tokens = UsageTableColumn("Tokens", 108, .trailing)
+    let cost = UsageTableColumn("Cost", 108, .trailing)
+
+    init(title: String, contentWidth: CGFloat) {
+        period = UsageTableColumn(title, Swift.max(170, contentWidth - 5 * 108))
+    }
+
+    var all: [UsageTableColumn] { [period, input, output, cache, tokens, cost] }
+}
+
+private struct ProviderColumns {
+    let provider: UsageTableColumn
+    let requests = UsageTableColumn("Requests", 112, .trailing)
+    let tokens = UsageTableColumn("Tokens", 132, .trailing)
+    let cost = UsageTableColumn("Cost", 120, .trailing)
+
+    init(contentWidth: CGFloat) {
+        provider = UsageTableColumn("Provider", Swift.max(180, contentWidth - 112 - 132 - 120))
+    }
+
+    var all: [UsageTableColumn] { [provider, requests, tokens, cost] }
+}
+
+private struct ModelColumns {
+    let model: UsageTableColumn
+    let requests = UsageTableColumn("Requests", 112, .trailing)
+    let tokens = UsageTableColumn("Tokens", 132, .trailing)
+    let cost = UsageTableColumn("Cost", 120, .trailing)
+    let average = UsageTableColumn("Avg/req", 128, .trailing)
+
+    init(contentWidth: CGFloat) {
+        model = UsageTableColumn("Model", Swift.max(200, contentWidth - 112 - 132 - 120 - 128))
+    }
+
+    var all: [UsageTableColumn] { [model, requests, tokens, cost, average] }
+}
+
+/// Requests is the one fixed-width table — a request carries seven useful
+/// fields and compressing it would erase the model or the tier — so it scrolls
+/// horizontally instead of flexing.
+private struct RequestColumns {
+    let time = UsageTableColumn("Time", 138)
+    let harness = UsageTableColumn("Harness", 138)
+    let model = UsageTableColumn("Model", 220)
+    let input = UsageTableColumn("Input", 114, .trailing)
+    let output = UsageTableColumn("Output", 88, .trailing)
+    let cost = UsageTableColumn("Cost", 96, .trailing)
+    let tier = UsageTableColumn("Tier", 86)
+
+    var all: [UsageTableColumn] { [time, harness, model, input, output, cost, tier] }
+
+    var minimumWidth: CGFloat { all.totalWidth }
 }

--- a/Sources/VibeBarApp/Views/Workbench/UsageFiltersBar.swift
+++ b/Sources/VibeBarApp/Views/Workbench/UsageFiltersBar.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 import VibeBarCore
 
@@ -54,10 +55,13 @@ struct UsageFiltersBar: View {
         .scrollIndicators(.never)
     }
 
+    /// The All chip is a switch, not a shortcut: lit means every harness is
+    /// in the query and clicking it clears the selection outright; anything
+    /// else and it puts every harness back.
     private var allHarnessesChip: some View {
         let selected = model.selectedHarnesses == nil
         return Button {
-            model.setSelectedHarnesses(nil)
+            model.toggleAllHarnesses()
         } label: {
             Text("All harnesses")
                 .font(.system(size: max(10, density.segmentedFontSize - 1), weight: .semibold))
@@ -67,8 +71,9 @@ struct UsageFiltersBar: View {
         }
         .buttonStyle(.plain)
         .background(chipBackground(tint: .accentColor, selected: selected))
-        .help("Include every harness")
-        .accessibilityLabel("Show every harness")
+        .help(selected ? "Click to select no harness" : "Click to include every harness")
+        .accessibilityLabel(selected ? "Select no harness" : "Show every harness")
+        .accessibilityAddTraits(selected ? [.isSelected] : [])
     }
 
     /// The company section head. Quieter than the harness chips beside it —
@@ -103,10 +108,17 @@ struct UsageFiltersBar: View {
     /// One chip per harness — the axis this page actually groups by. The icon
     /// is the harness's own brand (Cursor's mark, not Grok's); the accent is
     /// the company's, so a group still reads as one block of colour.
+    ///
+    /// ⌥-click solos, which is the one-click way to ask "just this harness"
+    /// without turning eight other chips off by hand.
     private func harnessChip(_ harness: Harness, in group: Harness.ChipGroup) -> some View {
         let selected = model.selectedHarnesses?.contains(harness) ?? true
         return Button {
-            model.toggleHarness(harness)
+            if NSEvent.modifierFlags.contains(.option) {
+                model.soloHarness(harness)
+            } else {
+                model.toggleHarness(harness)
+            }
         } label: {
             HStack(spacing: 5) {
                 ToolBrandIconView(tool: harness.brandTool, size: density.segmentedFontSize + 1)
@@ -123,7 +135,7 @@ struct UsageFiltersBar: View {
         // that a harness is in the query, so an off chip must not wear it.
         .opacity(selected ? 1 : 0.70)
         .saturation(selected ? 1 : 0.50)
-        .help("\(group.company.vendorName) · \(harness.displayName)")
+        .help("\(group.company.vendorName) · \(harness.displayName)\nClick to toggle · ⌥-click to solo")
         .accessibilityAddTraits(selected ? [.isSelected] : [])
     }
 

--- a/Sources/VibeBarApp/Views/Workbench/UsageStatsPage.swift
+++ b/Sources/VibeBarApp/Views/Workbench/UsageStatsPage.swift
@@ -21,12 +21,14 @@ struct UsageStatsPage: View {
 
             ScrollView {
                 VStack(alignment: .leading, spacing: density.interSectionSpacing) {
-                    if model.isLedgerAvailable {
+                    if !model.isLedgerAvailable {
+                        unavailableCard
+                    } else if HarnessSelection.isNothing(model.selectedHarnesses) {
+                        noHarnessCard
+                    } else {
                         UsageHeroCards(density: density, summary: model.summary)
                         trendAndProviderMix
                         UsageBreakdownTables(density: density, model: model)
-                    } else {
-                        unavailableCard
                     }
                 }
                 .padding(.horizontal, density.popoverPaddingH)
@@ -63,6 +65,27 @@ struct UsageStatsPage: View {
                 )
             }
         }
+    }
+
+    /// The explicit empty selection the All chip can reach. Every number on
+    /// this page would be a zero, and a page of zeroes reads as "you used
+    /// nothing" rather than "you asked for nothing".
+    private var noHarnessCard: some View {
+        CardShell(density: density, alignment: .center) {
+            Image(systemName: "line.3.horizontal.decrease.circle")
+                .font(.system(size: 26, weight: .light))
+                .foregroundStyle(.secondary)
+            Text("No harness selected — pick one above")
+                .font(.system(size: density.titleFontSize, weight: .semibold))
+                .multilineTextAlignment(.center)
+            Text("The All harnesses chip is a switch: click it again to put "
+                + "every harness back in the query.")
+                .font(.system(size: density.subtitleFontSize))
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: 420)
+        }
+        .frame(maxWidth: .infinity)
     }
 
     private var unavailableCard: some View {

--- a/Sources/VibeBarCore/Models/HarnessSelection.swift
+++ b/Sources/VibeBarCore/Models/HarnessSelection.swift
@@ -1,0 +1,77 @@
+import Foundation
+
+/// What a click on a harness filter chip means, as pure arithmetic.
+///
+/// Usage Stats and Sessions both draw the same harness-primary chip row (an
+/// "All" chip, then one muted company section head per group followed by its
+/// harnesses) and both used to re-implement the toggle rules on their own
+/// view model. The rules live here instead, so the two surfaces cannot drift
+/// and the behaviour is testable without a window.
+///
+/// The selection is `Set<Harness>?`:
+///
+/// - `nil` — **every** harness. The unfiltered query.
+/// - `[]`  — **no** harness. An explicit state the user reaches by clicking
+///   "All" while everything is already lit, or by turning the last chip off.
+///   It queries nothing, and the page says so rather than showing zeroes.
+/// - anything else — exactly those harnesses.
+///
+/// Empty used to be folded back into `nil`, which made "deselect everything"
+/// unsayable: the last chip going dark silently re-selected all of them.
+public enum HarnessSelection {
+    /// True when `selection` covers every option — either because it is `nil`
+    /// or because it happens to contain all of them.
+    public static func isEverything(_ selection: Set<Harness>?, options: [Harness]) -> Bool {
+        guard let selection else { return true }
+        guard !options.isEmpty else { return false }
+        return options.allSatisfy(selection.contains)
+    }
+
+    /// True for the explicit empty selection — the state that queries nothing.
+    public static func isNothing(_ selection: Set<Harness>?) -> Bool {
+        selection?.isEmpty ?? false
+    }
+
+    /// What the "All" chip does: everything selected turns everything off,
+    /// anything else (a partial selection, or nothing at all) turns
+    /// everything back on.
+    public static func toggleAll(_ selection: Set<Harness>?, options: [Harness]) -> Set<Harness>? {
+        isEverything(selection, options: options) ? [] : nil
+    }
+
+    /// ⌥-click on a harness chip: keep only that one.
+    public static func solo(_ harness: Harness, options: [Harness]) -> Set<Harness>? {
+        normalized([harness], options: options)
+    }
+
+    /// A plain click on one chip, or on the company section head that stands
+    /// for several: present in full means turn them off, otherwise turn them
+    /// on. The company chips keep this toggle-group behaviour unchanged.
+    public static func toggle(
+        _ harnesses: Set<Harness>,
+        in selection: Set<Harness>?,
+        options: [Harness]
+    ) -> Set<Harness>? {
+        guard !harnesses.isEmpty else { return selection }
+        var next = selection ?? Set(options)
+        if harnesses.allSatisfy(next.contains) {
+            next.subtract(harnesses)
+        } else {
+            next.formUnion(harnesses)
+        }
+        return normalized(next, options: options)
+    }
+
+    /// Everything selected is the same statement as "no filter", and saying
+    /// it that way keeps the chip row and the query in agreement. An empty
+    /// result stays empty, because none-selected is now a state the user can
+    /// actually mean.
+    public static func normalized(
+        _ selection: Set<Harness>?,
+        options: [Harness]
+    ) -> Set<Harness>? {
+        guard let selection else { return nil }
+        if selection.isEmpty { return [] }
+        return isEverything(selection, options: options) ? nil : selection
+    }
+}

--- a/Tests/VibeBarCoreTests/HarnessSelectionTests.swift
+++ b/Tests/VibeBarCoreTests/HarnessSelectionTests.swift
@@ -1,0 +1,147 @@
+import XCTest
+@testable import VibeBarCore
+
+/// The harness filter-chip arithmetic shared by Usage Stats and Sessions.
+///
+/// Both pages draw the same chip row, and both used to re-implement these
+/// rules on their own view model. They call `HarnessSelection` now, so this
+/// is where the behaviour is pinned: `nil` means every harness, `[]` means
+/// none, and the All chip is a switch between the two.
+final class HarnessSelectionTests: XCTestCase {
+    private let options = Harness.allCases
+
+    // MARK: - States
+
+    func testNilIsEverythingAndEmptyIsNothing() {
+        XCTAssertTrue(HarnessSelection.isEverything(nil, options: options))
+        XCTAssertFalse(HarnessSelection.isNothing(nil))
+
+        XCTAssertFalse(HarnessSelection.isEverything([], options: options))
+        XCTAssertTrue(HarnessSelection.isNothing([]))
+
+        XCTAssertTrue(HarnessSelection.isEverything(Set(options), options: options))
+        XCTAssertFalse(HarnessSelection.isNothing(Set(options)))
+
+        XCTAssertFalse(HarnessSelection.isEverything([.codex], options: options))
+        XCTAssertFalse(HarnessSelection.isNothing([.codex]))
+    }
+
+    // MARK: - The All chip
+
+    /// The whole point of the change: clicking All while everything is lit
+    /// has to be able to say "none", which an empty-means-unfiltered model
+    /// could not express.
+    func testAllChipTogglesBetweenEverythingAndNothing() {
+        XCTAssertEqual(HarnessSelection.toggleAll(nil, options: options), [])
+        XCTAssertEqual(HarnessSelection.toggleAll([], options: options), nil)
+    }
+
+    /// A set that happens to hold every option is the same statement as
+    /// `nil`, so All has to clear it rather than "select all" again.
+    func testAllChipClearsAnExplicitlyCompleteSelection() {
+        XCTAssertEqual(HarnessSelection.toggleAll(Set(options), options: options), [])
+    }
+
+    func testAllChipRestoresEverythingFromAPartialSelection() {
+        XCTAssertEqual(
+            HarnessSelection.toggleAll([.codex, .claudeCode], options: options),
+            nil
+        )
+    }
+
+    /// Two clicks land back where they started, in both directions.
+    func testAllChipRoundTrips() {
+        let cleared = HarnessSelection.toggleAll(nil, options: options)
+        XCTAssertEqual(HarnessSelection.toggleAll(cleared, options: options), nil)
+
+        let restored = HarnessSelection.toggleAll([.cursor], options: options)
+        XCTAssertEqual(HarnessSelection.toggleAll(restored, options: options), [])
+    }
+
+    // MARK: - Solo
+
+    func testSoloKeepsOnlyTheClickedHarness() {
+        XCTAssertEqual(HarnessSelection.solo(.cursor, options: options), [.cursor])
+        XCTAssertEqual(HarnessSelection.solo(.codex, options: options), [.codex])
+    }
+
+    /// On a page that only knows one harness, soloing it *is* "everything",
+    /// and everything is spelled `nil`.
+    func testSoloOnTheOnlyOptionCollapsesToUnfiltered() {
+        XCTAssertEqual(HarnessSelection.solo(.codex, options: [.codex]), nil)
+    }
+
+    // MARK: - Plain toggling
+
+    func testToggleTurnsOneHarnessOffFromEverything() {
+        let next = HarnessSelection.toggle([.cursor], in: nil, options: options)
+        XCTAssertEqual(next, Set(options).subtracting([.cursor]))
+    }
+
+    func testToggleTurnsOneHarnessBackOn() {
+        let next = HarnessSelection.toggle([.cursor], in: [.codex], options: options)
+        XCTAssertEqual(next, [.codex, .cursor])
+    }
+
+    /// Turning the last lit chip off lands in the explicit empty state rather
+    /// than silently re-selecting everything.
+    func testTurningOffTheLastHarnessSelectsNothing() {
+        XCTAssertEqual(HarnessSelection.toggle([.codex], in: [.codex], options: options), [])
+    }
+
+    /// …and turning the last dark chip on collapses back to unfiltered, so
+    /// the All chip lights up again.
+    func testTurningOnTheLastHarnessCollapsesToUnfiltered() {
+        let missingOne = Set(options).subtracting([.grokBot])
+        XCTAssertEqual(
+            HarnessSelection.toggle([.grokBot], in: missingOne, options: options),
+            nil
+        )
+    }
+
+    /// The company section head keeps its toggle-group behaviour: it moves
+    /// its whole group, and only its whole group.
+    func testCompanyGroupTogglesAsOneUnit() {
+        let anthropic: Set<Harness> = [.claudeCode, .claudeCowork]
+
+        let off = HarnessSelection.toggle(anthropic, in: nil, options: options)
+        XCTAssertEqual(off, Set(options).subtracting(anthropic))
+
+        let backOn = HarnessSelection.toggle(anthropic, in: off, options: options)
+        XCTAssertEqual(backOn, nil)
+    }
+
+    /// A partially lit group turns fully on, not off — otherwise clicking the
+    /// section head of a group with one chip lit would appear to do nothing.
+    func testPartiallySelectedCompanyGroupTurnsFullyOn() {
+        let openAI: Set<Harness> = [.codex, .chatgptWork]
+        let next = HarnessSelection.toggle(openAI, in: [.codex], options: options)
+        XCTAssertEqual(next, openAI)
+    }
+
+    func testTogglingNothingIsANoOp() {
+        XCTAssertEqual(HarnessSelection.toggle([], in: [.codex], options: options), [.codex])
+        XCTAssertEqual(HarnessSelection.toggle([], in: nil, options: options), nil)
+    }
+
+    // MARK: - Normalization
+
+    func testNormalizationFoldsACompleteSetButKeepsAnEmptyOne() {
+        XCTAssertEqual(HarnessSelection.normalized(Set(options), options: options), nil)
+        XCTAssertEqual(HarnessSelection.normalized([], options: options), [])
+        XCTAssertEqual(HarnessSelection.normalized(nil, options: options), nil)
+        XCTAssertEqual(HarnessSelection.normalized([.codex], options: options), [.codex])
+    }
+
+    /// Usage Stats narrows the options to the harnesses its ledger has
+    /// actually seen, so "everything" is relative to that list.
+    func testCompletenessIsRelativeToTheOfferedOptions() {
+        let offered: [Harness] = [.codex, .claudeCode]
+        XCTAssertTrue(HarnessSelection.isEverything([.codex, .claudeCode], options: offered))
+        XCTAssertEqual(
+            HarnessSelection.toggle([.codex], in: [.claudeCode], options: offered),
+            nil
+        )
+        XCTAssertEqual(HarnessSelection.toggleAll(nil, options: offered), [])
+    }
+}


### PR DESCRIPTION
## Why

Three things AQ hit on 1.3.0 (35):
1. Typing in the Settings → Menu Bar / Mini Window custom-label fields was very laggy — each keystroke mutated `AppSettings` and fanned out to every settings observer in every window.
2. The Requests table and the Effective price table had headers and rows that did not line up: two-line cells (INPUT "2 / R 404.8k · W 640", PROVIDER/SUBPROVIDER) pushed single-line cells to the row's vertical centre, and the price table's `minWidth` (780) was smaller than its columns (792).
3. The harness chip row had no way to "deselect all"; the All chip only selected all.

## What

- **`DebouncedSettingsTextField`**: local draft, committed on submit / focus loss / ~400 ms idle / disappear; used by the field-label, group-label, and provider plan-label editors. Empty-string-removes-override semantics unchanged.
- **One column spec per table** (`UsageTableColumn` + `RequestColumns`/…, `PricingColumn` + `PricingColumns`): header and rows render from the same widths/alignments; rows align on `.firstTextBaseline`; `minWidth` derived from the spec (price table 780 → 792; magic `.padding(.leading, 168)` → `detailInset` 162).
- **`HarnessSelection`** (Core, pure): `nil` = all, `[]` = explicit none; All chip toggles all ↔ none; ⌥-click solos a harness; Usage Stats shows a "No harness selected — pick one above" card, Sessions shows the matching empty state and `0 of N`. Query side: the ledger already treats an empty filter as match-nothing; Sessions short-circuits before hitting the index. Model-filter pruning and tool-based pruning skip the explicit-empty state. 16 new tests.

## Verification

- `swift build`, `swift test` (1531 tests, 1 skipped, 0 failures)
- `./Scripts/build_app.sh release`, `codesign -d --entitlements -` → empty `<dict/>`, `codesign --verify --deep --strict` OK
- Not visually run (production instance occupies the status item); baseline alignment reasoned from metrics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
