### PR TITLE
Prepare Vibe Bar 1.3.0 Dev build 36

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.3.0</string>
 	<key>CFBundleVersion</key>
-	<string>35</string>
+	<string>36</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>26.0</string>
 	<key>LSUIElement</key>


### PR DESCRIPTION
## Why

Cut the next Dev channel build after merging #204: debounced Settings label edits (no more per-keystroke settings fan-out), Requests / Effective price tables aligned on one column spec with baseline-aligned rows, and the harness chip row gains All ↔ none toggling plus ⌥-click solo with explicit empty states.

## What

- `Resources/Info.plist`: `CFBundleVersion` 35 → 36. `CFBundleShortVersionString` stays `1.3.0`.

## Verification

- `swift build`, `swift test` (1531 tests, 1 skipped, 0 failures)
- `./Scripts/build_app.sh release`, `codesign -d --entitlements -` → empty `<dict/>`, `codesign --verify --deep --strict` OK; bundle reports build 36

Tag `v1.3.0-dev.36` will be created on the merged commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
