### PR TITLE
Show which agent-session-kit a build carries

### DIFF
--- a/.github/workflows/bump-agent-session-kit.yml
+++ b/.github/workflows/bump-agent-session-kit.yml
@@ -1,0 +1,161 @@
+name: Bump agent-session-kit
+
+# `agent-session-kit` is a separate repository with its own releases, pinned
+# here to an exact tag and compiled statically into the app. Nothing about a
+# kit release reaches a user on its own: this workflow's whole job is to
+# notice one and open the pull request that starts the process. It never
+# merges, never tags, and never touches a release.
+on:
+  workflow_dispatch:
+  schedule:
+    # 07:20 UTC daily. Off the hour so it does not queue behind everything
+    # else that runs at :00.
+    - cron: '20 7 * * *'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: bump-agent-session-kit
+  cancel-in-progress: false
+
+jobs:
+  bump:
+    name: Open a pin bump when the kit has a newer release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v4
+        with:
+          # `VIBEBAR_BOT_TOKEN` is a PAT (contents:write, pull_requests:write).
+          # Without it, the default GITHUB_TOKEN still opens the pull request,
+          # but GitHub deliberately does not run workflows on a PR that a
+          # GITHUB_TOKEN push created — see the PR body this writes.
+          token: ${{ secrets.VIBEBAR_BOT_TOKEN || secrets.GITHUB_TOKEN }}
+
+      - name: Read the current pin and the newest kit release
+        id: versions
+        env:
+          GH_TOKEN: ${{ secrets.VIBEBAR_BOT_TOKEN || secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          current="$(sed -n 's|.*agent-session-kit\.git", exact: "\([0-9][^"]*\)".*|\1|p' Package.swift | head -n 1)"
+          if [ -z "$current" ]; then
+            echo "::error::Could not read the agent-session-kit pin out of Package.swift."
+            exit 1
+          fi
+
+          latest="$(gh api repos/AstroQore/agent-session-kit/releases/latest --jq '.tag_name' 2>/dev/null || true)"
+          latest="${latest#v}"
+          if [ -z "$latest" ]; then
+            echo "::notice::agent-session-kit has no published release to read. Nothing to do."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "current=$current" >> "$GITHUB_OUTPUT"
+          echo "latest=$latest" >> "$GITHUB_OUTPUT"
+          echo "Pinned: $current   Newest release: $latest"
+
+          if [ "$current" = "$latest" ]; then
+            echo "::notice::Already pinned to $latest."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Sort -V decides "newer", so a pin that is deliberately ahead of
+          # the newest release (between a kit merge and its tag) is left alone
+          # rather than rolled backwards.
+          newest="$(printf '%s\n%s\n' "$current" "$latest" | sort -V | tail -n 1)"
+          if [ "$newest" != "$latest" ]; then
+            echo "::notice::Pinned $current is already ahead of the newest release $latest."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+
+      - name: Skip when a pull request for this version is already open
+        id: existing
+        if: steps.versions.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.VIBEBAR_BOT_TOKEN || secrets.GITHUB_TOKEN }}
+          BRANCH: chore/bump-agent-session-kit-${{ steps.versions.outputs.latest }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          open_pr="$(gh pr list --repo "$GITHUB_REPOSITORY" --head "$BRANCH" --state open --json number --jq '.[0].number' || true)"
+          if [ -n "$open_pr" ]; then
+            echo "::notice::PR #${open_pr} already proposes ${BRANCH}."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Rewrite the pin and open the pull request
+        if: steps.versions.outputs.skip != 'true' && steps.existing.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.VIBEBAR_BOT_TOKEN || secrets.GITHUB_TOKEN }}
+          CURRENT: ${{ steps.versions.outputs.current }}
+          LATEST: ${{ steps.versions.outputs.latest }}
+          USING_PAT: ${{ secrets.VIBEBAR_BOT_TOKEN != '' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          branch="chore/bump-agent-session-kit-${LATEST}"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$branch"
+
+          # The pin itself, and the copy of it AGENTS.md § 2.1 quotes. Both
+          # are exact-match rewrites: a miss is a failure, not a silent no-op.
+          perl -0pi -e "s{(agent-session-kit\.git\", exact: \")\Q${CURRENT}\E(\")}{\${1}${LATEST}\${2}}g" Package.swift
+          perl -0pi -e "s{(exact: \")\Q${CURRENT}\E(\"\)\`)}{\${1}${LATEST}\${2}}g" AGENTS.md
+
+          if ! grep -q "agent-session-kit.git\", exact: \"${LATEST}\"" Package.swift; then
+            echo "::error::Package.swift still does not name ${LATEST}."
+            exit 1
+          fi
+          if git diff --quiet; then
+            echo "::error::Nothing changed; the pin rewrite matched nothing."
+            exit 1
+          fi
+          git --no-pager diff --stat
+
+          git commit -am "Bump agent-session-kit to ${LATEST}"
+          git push origin "$branch"
+
+          notes_url="https://github.com/AstroQore/agent-session-kit/releases/tag/${LATEST}"
+          {
+            echo "\`agent-session-kit\` published **${LATEST}**; this repository pinned ${CURRENT}."
+            echo
+            echo "- Release notes: ${notes_url}"
+            echo "- Changelog: https://github.com/AstroQore/agent-session-kit/blob/${LATEST}/CHANGELOG.md"
+            echo
+            echo "Opened automatically by \`.github/workflows/bump-agent-session-kit.yml\`. Nothing is merged for you."
+            echo
+            echo "### Before merging"
+            echo
+            echo "- [ ] Read the release notes for anything that needs a call-site change."
+            echo "- [ ] \`swift build\` and \`swift test\` locally (AGENTS.md § 9.3 in full for anything beyond a clean bump)."
+            echo "- [ ] \`THIRD_PARTY_NOTICES.md\` still describes the dependency correctly."
+            echo
+            echo "### After merging"
+            echo
+            echo "A kit tag is **not** a Vibe Bar release. The kit is linked statically, so ${LATEST} reaches a user only once a Vibe Bar build ships with this pin — cut a dev build (AGENTS.md § 12). Settings › System › Components shows the version actually compiled into a build."
+            if [ "$USING_PAT" != "true" ]; then
+              echo
+              echo "> **CI will not have run on this pull request.** It was pushed with the default \`GITHUB_TOKEN\`, and GitHub does not trigger workflows from those pushes. Close and reopen this PR, or push an empty commit, to get the checks. Adding a \`VIBEBAR_BOT_TOKEN\` repository secret (a PAT with \`contents:write\` and \`pull_requests:write\`) removes this step."
+            fi
+          } > "$RUNNER_TEMP/pr-body.md"
+
+          gh pr create \
+            --repo "$GITHUB_REPOSITORY" \
+            --base main \
+            --head "$branch" \
+            --title "Bump agent-session-kit to ${LATEST}" \
+            --body-file "$RUNNER_TEMP/pr-body.md"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -144,13 +144,68 @@ host: `~/.vibebar/mcp.sock`, the `--mcp-stdio` flag, `VIBEBAR_MCP_SOCKET`
 and the "Vibe Bar is not running" message. Add host-shaped defaults
 there, not in the package.
 
+**Who owns which side of the line.**
+
+| Concern | Lives in | Why |
+| ------- | -------- | --- |
+| Session discovery, per-harness adapters, transcript parsing | kit | Provider-agnostic, testable without a network, useful to any host. |
+| `SessionIndexStore` / `SessionIndexService` (SQLite + FTS5) | kit | Same. The index location is a parameter, never a constant. |
+| `SessionDeleter`, deletion planning, `LiveSQLiteReader` | kit | The containment and symlink rules belong next to the adapters that define the roots. |
+| `Harness`, `HarnessCatalog` — the **usage** axis | kit | Naming a CLI is not naming a billing plan. |
+| MCP transports + JSON-RPC primitives | kit | A socket and a byte pump have no opinions about Vibe Bar. |
+| `RealHomeDirectory`, `JSONLLineScanner`, `JSONLHeadTail`, `Base32` | kit | Shared primitives with the same invariants on both sides. |
+| `MCPServer`, its tool catalog, DTOs, resource catalog | here | Vibe Bar's own dispatch, over the kit's transport. |
+| `Harness+Quota.swift`, `CostUsageScanner`, everything quota-shaped | here | The **billing** axis — plans, prices, companies, windows. |
+| The `~/.vibebar/mcp.sock` default, `--mcp-stdio`, the "not running" message | here | Host-shaped defaults the package refuses to invent. |
+
 **Where it comes from.** `Package.swift` pins the package to an exact
 tag on GitHub (`.package(url: "https://github.com/AstroQore/agent-session-kit.git",
-exact: "0.2.0")`), so a plain clone builds and a release build resolves the
+exact: "0.3.0")`), so a plain clone builds and a release build resolves the
 same package the developer built against — `Package.resolved` is
-gitignored here, and the exact pin is what stands in for it. Bumping the
-kit is a one-line change to that pin plus a `THIRD_PARTY_NOTICES.md`
-check, done deliberately and reviewed like any other dependency bump.
+gitignored here, and the exact pin is what stands in for it.
+
+**It is linked statically.** The kit is compiled into `Vibe Bar.app`'s
+executable. There is no framework in `Contents/Frameworks/`, no dylib, and
+nothing on disk to swap. Two consequences that matter more than they look:
+
+- The only way to know which kit is inside a build is
+  `AgentSessionKitInfo.version`, a constant the package pins to its own
+  changelog with a test.
+- **A kit tag is not a Vibe Bar release.** Tagging `0.4.0` over there
+  changes nothing for a single user until this repository bumps the pin
+  *and* ships a build. After merging a bump, cut a dev build (§ 12) —
+  otherwise the newest kit exists only in `main`.
+
+**Bumping the pin.**
+
+- *By hand:* edit the one line in `Package.swift`, edit the version named
+  in this section, read the kit's release notes for anything that needs a
+  call-site change, check `THIRD_PARTY_NOTICES.md` still describes it
+  correctly, then run the full § 9.3 check list. Commit subject
+  `Bump agent-session-kit to X.Y.Z`.
+- *By workflow:* `.github/workflows/bump-agent-session-kit.yml` runs daily
+  and on demand. It reads the current pin, asks GitHub for the kit's newest
+  release, and — when that release is newer — opens
+  `chore/bump-agent-session-kit-X.Y.Z` with both edits and the release
+  notes linked in the body. It never merges anything.
+
+  With the default `GITHUB_TOKEN`, GitHub **will not run CI on a
+  bot-opened PR** (a deliberate loop-prevention rule). Close and reopen the
+  PR, or push an empty commit to it, to get the checks. Adding a
+  `VIBEBAR_BOT_TOKEN` repository secret — a PAT with `contents:write` and
+  `pull_requests:write` — removes that step; the workflow prefers it when
+  present.
+
+**Where a user sees it.** Settings › System › **Components** shows
+`agent-session-kit` with the bundled `AgentSessionKitInfo.version`, a
+"bundled" badge, links to that release's notes and the repository, and a
+**Check for kit updates** button. The button is the only thing that opens a
+connection — no launch check, no timer, no check-when-the-pane-appears —
+and `ComponentUpdateChecker` caches the answer in memory for six hours.
+When a newer kit exists the row reads *"Newer kit X.Y.Z available — ships
+with the next Vibe Bar build"*. Keep that phrasing, or an equivalent one
+that is equally clear: the app cannot install a kit release, and a row that
+sounds like it can is a bug in the copy.
 
 **Working on both at once.** To build Vibe Bar against a local checkout of
 the package (say, to try a kit change before it is tagged), use SwiftPM's
@@ -163,7 +218,14 @@ swift package unedit agent-session-kit
 ```
 
 `swift package edit` records the override in `.swiftpm/` (gitignored), so
-it never reaches a commit, and `unedit` returns to the pinned tag.
+it never reaches a commit, and `unedit` returns to the pinned tag. Never
+commit a `Package.swift` that points at a local path or an untagged branch:
+a release build resolves from a clean checkout and would fail, or worse,
+silently resolve something else.
+
+The kit's own conventions — conventional-commit subjects, Keep a Changelog,
+bare `X.Y.Z` tags, and `RELEASING.md` — are that repository's, not this
+one's. Use them when working there.
 
 ## 3. Toolchain Prerequisites
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,6 +46,17 @@ Vibe Bar is a Swift package with two main targets:
 - `VibeBarCore`: parsers, storage, privacy helpers, adapters, and usage logic.
 - `VibeBarApp`: AppKit/SwiftUI menu-bar app, windows, and UI glue.
 
+Session reading — discovery, per-harness parsing, the FTS5 session index,
+deletion planning, harness naming, and the MCP transport — lives in
+[`agent-session-kit`](https://github.com/AstroQore/agent-session-kit), a
+separate repository with its own releases, pinned here to an exact tag in
+`Package.swift` and linked statically. A change there is a change over
+there: cut a kit release, then bump the pin. `AGENTS.md` § 2.1 has the
+table of what lives where, the bump procedure (by hand and by the daily
+`bump-agent-session-kit` workflow), and `swift package edit` for working on
+both at once. A kit tag is not a Vibe Bar release — it reaches users only
+in a Vibe Bar build.
+
 Before opening a pull request, run:
 
 ```sh

--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
         // from a clean checkout with no Package.resolved (it is gitignored),
         // so the pin is the only thing that makes two builds of the same
         // Vibe Bar commit contain the same package. Bump it deliberately.
-        .package(url: "https://github.com/AstroQore/agent-session-kit.git", exact: "0.2.0"),
+        .package(url: "https://github.com/AstroQore/agent-session-kit.git", exact: "0.3.0"),
         // SweetCookieKit encapsulates the Chromium SQLite parsing, "Chrome
         // Safe Storage" Keychain decryption, and Safari binarycookies /
         // Firefox SQLite reads that the misc-providers feature needs.

--- a/README.md
+++ b/README.md
@@ -170,6 +170,38 @@ Provider contracts can change without notice. Vibe Bar keeps refresh errors
 visible, preserves the last known good snapshot, and avoids presenting stale
 data as a successful update.
 
+## Architecture
+
+Vibe Bar is one app built from two SwiftPM targets plus one package of its
+own that lives in a separate repository.
+
+| Piece | What it is | Where it lives |
+| --- | --- | --- |
+| `VibeBarApp` | The menu-bar item, the popover, the Mini Window, the Workbench, Settings. AppKit + SwiftUI. | This repository |
+| `VibeBarCore` | Quota, usage, cost, pricing, forecasting, provider adapters, remote sync — everything testable without a window. | This repository |
+| [`agent-session-kit`](https://github.com/AstroQore/agent-session-kit) | Reading what the coding agents left on disk: session discovery and parsing per harness, the full-text session index, deletion planning, harness naming, and the local MCP Unix-socket / stdio transport. | Separate public repository |
+
+The kit was extracted from this repository so that the "what did my agents
+actually do" half is usable — and auditable — on its own. It knows nothing
+about quotas, plans, or prices; that vocabulary stays in `VibeBarCore`. It
+has no third-party dependencies of its own, and it is AGPL-3.0-only, same as
+Vibe Bar.
+
+**How a kit release reaches you.** `Package.swift` pins the kit to an exact
+tag, and SwiftPM links it **statically** — it is compiled into the app's
+executable, not shipped as a framework you could swap. So a new kit release
+changes nothing on your Mac until Vibe Bar bumps that pin and ships a build.
+There is no separate component to update, and Vibe Bar will never offer to
+update one.
+
+**Seeing which one you have.** Settings › System › **Components** shows the
+`agent-session-kit` version compiled into the build you are running, with
+links to that release's notes and the repository, and a *Check for kit
+updates* button. The button is the only thing that contacts GitHub — there is
+no check at launch and none on a timer — and when a newer kit exists the row
+says it *ships with the next Vibe Bar build*, because that is the only way
+it can arrive.
+
 ## Privacy and Local Data
 
 Vibe Bar has no telemetry pipeline or hosted plaintext analytics backend.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -159,6 +159,32 @@ claude mcp add --scope user vibebar -- "/Applications/Vibe Bar.app/Contents/MacO
 服务商的私有接口随时可能变化。Vibe Bar 会明确显示刷新错误，保留上一次成功
 快照，并避免把陈旧数据伪装成一次成功更新。
 
+## 架构
+
+Vibe Bar 是一个 App，由两个 SwiftPM target 加一个独立仓库的自有 package 组成。
+
+| 组成 | 职责 | 所在仓库 |
+| --- | --- | --- |
+| `VibeBarApp` | 菜单栏图标、Popover、迷你浮窗、Workbench、设置界面。AppKit + SwiftUI。 | 本仓库 |
+| `VibeBarCore` | 配额、用量、成本、价格、预测、Provider 适配器、远端同步——所有不需要窗口就能测试的部分。 | 本仓库 |
+| [`agent-session-kit`](https://github.com/AstroQore/agent-session-kit) | 读取各家 Coding Agent 留在磁盘上的会话：按 harness 的会话发现与解析、全文会话索引、删除计划、harness 命名，以及本地 MCP Unix socket / stdio 传输。 | 独立公开仓库 |
+
+这个 kit 是从本仓库拆出去的，目的是让“我的 agent 到底做了什么”这一半可以被单独
+使用、也被单独审计。它不认识配额、套餐和价格，这套词汇留在 `VibeBarCore` 里。它
+自身没有任何第三方依赖，许可证同样是 AGPL-3.0-only。
+
+**一个 kit release 怎么到你手上。** `Package.swift` 把 kit 钉在一个确切的 tag 上，
+SwiftPM 采用**静态链接**——它被编译进 App 的可执行文件，而不是作为一个可以替换的
+framework 分发。所以 kit 发布新版本，在 Vibe Bar 更新这个 pin 并发出新构建之前，
+对你的 Mac 没有任何影响。这里不存在可以单独升级的组件，Vibe Bar 也永远不会提示你
+去升级它。
+
+**在哪里看到当前版本。** 设置 › System › **Components** 会显示当前这个构建里编译
+进去的 `agent-session-kit` 版本，附带该版本的 Release Notes 与仓库链接，以及一个
+*Check for kit updates* 按钮。只有这个按钮会去访问 GitHub——启动时不查，也没有定时
+任务。当存在更新的 kit 时，这一行会写明它「ships with the next Vibe Bar build」
+（随下一个 Vibe Bar 构建一起到达），因为那是它唯一的到达方式。
+
 ## 隐私与本地数据
 
 Vibe Bar 没有遥测管线或托管明文分析后端。本地与远端 Probe 用量分析都留在当前

--- a/Sources/VibeBarApp/Views/SettingsView.swift
+++ b/Sources/VibeBarApp/Views/SettingsView.swift
@@ -183,6 +183,11 @@ struct SettingsView: View {
                         UpdateSettingsRow(updateController: environment.updateController)
                     }
                     .id("updates")
+
+                    settingsSection("Components") {
+                        AgentSessionKitComponentRow()
+                    }
+                    .id("components")
                     }
 
                     if selectedSection == .menuBar {
@@ -1173,6 +1178,120 @@ struct SettingsView: View {
         case 365: return "1 year"
         case 365 * 3: return "3 years"
         default: return "\(days) days"
+        }
+    }
+}
+
+/// What is *inside* this build, as opposed to what build it is.
+///
+/// `agent-session-kit` is a separate public repository with its own tags and
+/// its own release notes, pinned to an exact version in `Package.swift` and
+/// compiled — statically — into this binary. So the version below is a fact
+/// about the app you are running, and a newer kit release is not something
+/// this pane can install. The wording says "ships with the next Vibe Bar
+/// build" for that reason; anything that sounds like an available download
+/// would be a lie.
+///
+/// The check is manual. Nothing here fires on launch, on a timer, or when
+/// this pane appears — the button is the only thing that opens a connection,
+/// and `ComponentUpdateChecker` remembers the answer for six hours so a
+/// second press costs nothing.
+private struct AgentSessionKitComponentRow: View {
+    @State private var status: ComponentUpdateStatus?
+    @State private var isChecking = false
+
+    private let checker = ComponentUpdateChecker.shared
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(alignment: .firstTextBaseline, spacing: 8) {
+                Text("agent-session-kit")
+                    .font(.callout)
+                Text(AgentSessionKitInfo.version)
+                    .font(.system(.callout, design: .monospaced))
+                    .foregroundStyle(.secondary)
+                bundledBadge
+                Spacer(minLength: 12)
+                Button {
+                    check()
+                } label: {
+                    Label("Check for kit updates", systemImage: "arrow.triangle.2.circlepath")
+                }
+                .disabled(isChecking)
+            }
+
+            Text("Session discovery, harness naming, and the MCP transport. A separate repository, pinned to an exact tag and compiled into this build.")
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+
+            statusLine
+
+            HStack(spacing: 12) {
+                Link("Release notes", destination: AgentSessionKitInfo.bundledReleaseNotesURL)
+                Link("Repository", destination: AgentSessionKitInfo.repositoryURL)
+            }
+            .font(.caption2)
+        }
+        .task {
+            // Only ever reads what a previous button press already learned;
+            // never opens a connection of its own.
+            status = await checker.cachedAgentSessionKitStatus()
+        }
+    }
+
+    private var bundledBadge: some View {
+        Text("bundled")
+            .font(.system(size: 9, weight: .semibold))
+            .foregroundStyle(.secondary)
+            .padding(.horizontal, 7)
+            .padding(.vertical, 3)
+            .background(Capsule().fill(Color.secondary.opacity(0.12)))
+    }
+
+    @ViewBuilder
+    private var statusLine: some View {
+        if isChecking {
+            HStack(spacing: 6) {
+                ProgressView().controlSize(.small)
+                Text("Checking github.com for the newest release…")
+            }
+            .font(.caption2)
+            .foregroundStyle(.secondary)
+        } else if let status {
+            VStack(alignment: .leading, spacing: 3) {
+                Text(status.message)
+                    .font(.caption2)
+                    .foregroundStyle(statusColor(status))
+                if let url = status.releaseNotesURL {
+                    Link("What changed in \(url.lastPathComponent)", destination: url)
+                        .font(.caption2)
+                }
+            }
+        } else {
+            Text("Not checked. Nothing is fetched until you ask.")
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private func statusColor(_ status: ComponentUpdateStatus) -> Color {
+        switch status {
+        case .upToDate: return .secondary
+        case .updateAvailable: return .accentColor
+        case .aheadOfLatestRelease: return .secondary
+        case .failed: return .orange
+        }
+    }
+
+    private func check() {
+        guard !isChecking else { return }
+        isChecking = true
+        Task {
+            let result = await checker.checkAgentSessionKit(force: true)
+            await MainActor.run {
+                status = result
+                isChecking = false
+            }
         }
     }
 }

--- a/Sources/VibeBarApp/Views/SettingsView.swift
+++ b/Sources/VibeBarApp/Views/SettingsView.swift
@@ -1287,7 +1287,12 @@ private struct AgentSessionKitComponentRow: View {
         guard !isChecking else { return }
         isChecking = true
         Task {
-            let result = await checker.checkAgentSessionKit(force: true)
+            // Not forced: a second press inside the six-hour window reuses
+            // the answer already in memory rather than asking GitHub again.
+            // Six hours is far shorter than the interval at which a kit
+            // release could matter here — it cannot arrive without a new
+            // build of this app anyway.
+            let result = await checker.checkAgentSessionKit()
             await MainActor.run {
                 status = result
                 isChecking = false

--- a/Sources/VibeBarCore/Services/ComponentUpdateChecker.swift
+++ b/Sources/VibeBarCore/Services/ComponentUpdateChecker.swift
@@ -1,0 +1,316 @@
+import Foundation
+
+/// A dotted version, compared the way semver says to.
+///
+/// Small on purpose: `agent-session-kit` tags are bare `X.Y.Z`, and the only
+/// question anyone asks here is "is the tag on GitHub newer than the one
+/// compiled into this binary?". Pre-release identifiers are parsed rather
+/// than rejected — a `0.4.0-rc.1` tag would otherwise compare as newer than
+/// `0.4.0`, which is exactly backwards.
+public struct ComponentVersion: Sendable, Equatable, Comparable, CustomStringConvertible {
+    public let major: Int
+    public let minor: Int
+    public let patch: Int
+    /// The `-` suffix, split on `.`. Empty means a final release.
+    public let prerelease: [String]
+
+    public init(major: Int, minor: Int, patch: Int, prerelease: [String] = []) {
+        self.major = major
+        self.minor = minor
+        self.patch = patch
+        self.prerelease = prerelease
+    }
+
+    /// Parses `1.2.3`, `v1.2.3`, `1.2.3-rc.1`, `1.2.3+build`. Returns nil for
+    /// anything else — an unparseable tag is reported as an error, never
+    /// silently treated as "no update".
+    public init?(_ raw: String) {
+        var text = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        if text.count > 1, text.hasPrefix("v") || text.hasPrefix("V") {
+            let rest = text.dropFirst()
+            if rest.first?.isNumber == true { text = String(rest) }
+        }
+        // Build metadata is not part of precedence; drop it.
+        if let plus = text.firstIndex(of: "+") { text = String(text[text.startIndex..<plus]) }
+        var prereleasePart: [String] = []
+        if let dash = text.firstIndex(of: "-") {
+            let suffix = text[text.index(after: dash)...]
+            text = String(text[text.startIndex..<dash])
+            guard !suffix.isEmpty else { return nil }
+            prereleasePart = suffix.split(separator: ".").map(String.init)
+            guard !prereleasePart.contains(where: \.isEmpty) else { return nil }
+        }
+        let parts = text.split(separator: ".", omittingEmptySubsequences: false)
+        guard parts.count == 3 else { return nil }
+        var numbers: [Int] = []
+        for part in parts {
+            guard !part.isEmpty, part.allSatisfy(\.isNumber), let value = Int(part) else { return nil }
+            numbers.append(value)
+        }
+        self.init(major: numbers[0], minor: numbers[1], patch: numbers[2], prerelease: prereleasePart)
+    }
+
+    public var description: String {
+        let core = "\(major).\(minor).\(patch)"
+        return prerelease.isEmpty ? core : core + "-" + prerelease.joined(separator: ".")
+    }
+
+    public static func < (lhs: ComponentVersion, rhs: ComponentVersion) -> Bool {
+        if lhs.major != rhs.major { return lhs.major < rhs.major }
+        if lhs.minor != rhs.minor { return lhs.minor < rhs.minor }
+        if lhs.patch != rhs.patch { return lhs.patch < rhs.patch }
+        // A pre-release always precedes the release it leads to.
+        if lhs.prerelease.isEmpty != rhs.prerelease.isEmpty { return !lhs.prerelease.isEmpty }
+        for (left, right) in zip(lhs.prerelease, rhs.prerelease) where left != right {
+            switch (Int(left), Int(right)) {
+            case let (l?, r?): return l < r
+            case (_?, nil): return true       // numeric identifiers rank lower
+            case (nil, _?): return false
+            case (nil, nil): return left < right
+            }
+        }
+        return lhs.prerelease.count < rhs.prerelease.count
+    }
+}
+
+/// What a component-version check concluded. `message` is the sentence the
+/// Settings row shows, kept here rather than in the view so the wording is
+/// testable — and so the one thing that must never be implied has exactly
+/// one place to go wrong.
+public enum ComponentUpdateStatus: Sendable, Equatable {
+    /// The newest release is the one compiled in.
+    case upToDate(bundled: String)
+    /// A newer release exists. It is *not* installable: this package is
+    /// linked statically, so it arrives with the next build of the app.
+    case updateAvailable(bundled: String, latest: String, releaseNotesURL: URL)
+    /// The bundled build is ahead of the newest published release — normal
+    /// while developing against an unreleased kit, or between a merge and
+    /// its tag.
+    case aheadOfLatestRelease(bundled: String, latest: String)
+    /// The check did not complete. Never cached.
+    case failed(reason: String)
+
+    public var message: String {
+        switch self {
+        case .upToDate(let bundled):
+            return "Up to date (\(bundled))"
+        case .updateAvailable(_, let latest, _):
+            return "Newer kit \(latest) available — ships with the next Vibe Bar build"
+        case .aheadOfLatestRelease(let bundled, let latest):
+            return "Bundled \(bundled) is ahead of the newest release (\(latest))"
+        case .failed(let reason):
+            return "Could not check for kit updates: \(reason)"
+        }
+    }
+
+    public var isFailure: Bool {
+        if case .failed = self { return true }
+        return false
+    }
+
+    /// The release to link to, when there is a newer one worth reading about.
+    public var releaseNotesURL: URL? {
+        if case .updateAvailable(_, _, let url) = self { return url }
+        return nil
+    }
+}
+
+public enum ComponentUpdateCheckError: Error, Sendable, Equatable {
+    case notHTTP
+    case noPublishedRelease
+    case httpStatus(Int)
+    case malformedResponse
+    case unparseableTag
+
+    /// Short, non-leaking, and safe to show in the Settings pane.
+    public var displayReason: String {
+        switch self {
+        case .notHTTP: return "unexpected response"
+        case .noPublishedRelease: return "no published release yet"
+        case .httpStatus(let code): return "GitHub answered HTTP \(code)"
+        case .malformedResponse: return "unreadable response"
+        case .unparseableTag: return "unrecognised tag"
+        }
+    }
+}
+
+/// Asks GitHub what the newest `agent-session-kit` release is, so Settings
+/// can say whether the version compiled into this app is the current one.
+///
+/// Three deliberate limits:
+///
+/// - **Manual only.** Nothing calls this on launch, on a timer, or when a
+///   pane appears. A quota refresh is something the user asked for by
+///   running the app; a version check is not, and a menu-bar app that
+///   quietly talks to github.com every launch is a surprise. The Settings
+///   button is the only trigger.
+/// - **Unauthenticated.** No token, ever. The endpoint is public and the
+///   answer is public; sending credentials to read a release number would
+///   be strictly worse.
+/// - **It cannot install anything.** `agent-session-kit` is linked
+///   *statically* into this binary. A newer release reaches a user when
+///   Vibe Bar bumps its pin and ships a build — never in place, never at
+///   runtime. `ComponentUpdateStatus.message` says so in those words; do
+///   not reword it into something that sounds like an available download.
+///
+/// The answer is cached in memory for six hours. Failures are not cached,
+/// so a flaky network does not lock the row for the rest of the session,
+/// and nothing is written to disk: this is a fact about the running binary,
+/// not user state.
+public actor ComponentUpdateChecker {
+    public static let shared = ComponentUpdateChecker()
+
+    /// `releases/latest` is the newest *published, non-prerelease* release —
+    /// exactly what a consumer should be pinning to. Drafts never appear.
+    public static let agentSessionKitLatestReleaseURL = URL(
+        string: "https://api.github.com/repos/AstroQore/agent-session-kit/releases/latest"
+    )!
+    public static let defaultTimeout: TimeInterval = 15
+    public static let defaultCacheLifetime: TimeInterval = 6 * 60 * 60
+    /// A release payload is a few kilobytes of JSON. The cap is defense in
+    /// depth, not a tuning knob.
+    public static let maxResponseBytes = 1024 * 1024
+
+    private let session: URLSession
+    private let endpoint: URL
+    private let timeout: TimeInterval
+    private let cacheLifetime: TimeInterval
+    private let now: @Sendable () -> Date
+
+    private var cachedStatus: ComponentUpdateStatus?
+    private var cachedAt: Date?
+
+    public init(
+        session: URLSession? = nil,
+        endpoint: URL = ComponentUpdateChecker.agentSessionKitLatestReleaseURL,
+        timeout: TimeInterval = ComponentUpdateChecker.defaultTimeout,
+        cacheLifetime: TimeInterval = ComponentUpdateChecker.defaultCacheLifetime,
+        now: @escaping @Sendable () -> Date = { Date() }
+    ) {
+        self.session = session ?? ComponentUpdateChecker.makeSession()
+        self.endpoint = endpoint
+        self.timeout = timeout
+        self.cacheLifetime = cacheLifetime
+        self.now = now
+    }
+
+    /// Same posture as the remote-sync clients: ephemeral, no cache, no
+    /// cookies, and redirects refused outright. A redirect off api.github.com
+    /// is not something this request has any reason to follow.
+    private static func makeSession() -> URLSession {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.requestCachePolicy = .reloadIgnoringLocalCacheData
+        configuration.urlCache = nil
+        configuration.httpCookieStorage = nil
+        configuration.httpShouldSetCookies = false
+        configuration.timeoutIntervalForRequest = ComponentUpdateChecker.defaultTimeout
+        return URLSession(
+            configuration: configuration,
+            delegate: RemoteNoRedirectDelegate(),
+            delegateQueue: nil
+        )
+    }
+
+    /// The newest published `agent-session-kit` release tag, normalised to a
+    /// bare `X.Y.Z`.
+    public func latestKitVersion() async throws -> String {
+        var request = URLRequest(url: endpoint)
+        request.httpMethod = "GET"
+        request.timeoutInterval = timeout
+        request.cachePolicy = .reloadIgnoringLocalCacheData
+        request.httpShouldHandleCookies = false
+        request.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
+        request.setValue("VibeBar", forHTTPHeaderField: "User-Agent")
+        request.setValue("2022-11-28", forHTTPHeaderField: "X-GitHub-Api-Version")
+
+        let (data, response) = try await HTTPResponseLimit.boundedData(
+            from: session,
+            for: request,
+            maxBytes: Self.maxResponseBytes
+        )
+        guard let http = response as? HTTPURLResponse else {
+            throw ComponentUpdateCheckError.notHTTP
+        }
+        // A repository with tags but no Releases answers 404 here. That is a
+        // fact, not a failure of ours, so it gets its own reason.
+        if http.statusCode == 404 { throw ComponentUpdateCheckError.noPublishedRelease }
+        guard http.statusCode == 200 else {
+            throw ComponentUpdateCheckError.httpStatus(http.statusCode)
+        }
+        return try Self.parseTagName(from: data)
+    }
+
+    /// Decodes just the field this feature needs. GitHub's payload is large
+    /// and mostly about assets and authors; none of it is stored.
+    static func parseTagName(from data: Data) throws -> String {
+        struct Release: Decodable { let tagName: String? }
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        guard let release = try? decoder.decode(Release.self, from: data) else {
+            throw ComponentUpdateCheckError.malformedResponse
+        }
+        guard let raw = release.tagName else { throw ComponentUpdateCheckError.malformedResponse }
+        let tag = AgentSessionKitInfo.normalizedTag(raw)
+        guard ComponentVersion(tag) != nil else { throw ComponentUpdateCheckError.unparseableTag }
+        return tag
+    }
+
+    /// Compares a fetched tag against the version compiled into this binary.
+    /// Pure, so the three sentences the Settings row can show are testable
+    /// without a network.
+    public static func status(bundled: String, latest: String) -> ComponentUpdateStatus {
+        guard let bundledVersion = ComponentVersion(bundled),
+              let latestVersion = ComponentVersion(latest) else {
+            return .failed(reason: ComponentUpdateCheckError.unparseableTag.displayReason)
+        }
+        if bundledVersion < latestVersion {
+            return .updateAvailable(
+                bundled: bundled,
+                latest: latest,
+                releaseNotesURL: AgentSessionKitInfo.releaseNotesURL(for: latest)
+            )
+        }
+        if latestVersion < bundledVersion {
+            return .aheadOfLatestRelease(bundled: bundled, latest: latest)
+        }
+        return .upToDate(bundled: bundled)
+    }
+
+    /// The Settings button's entry point. Returns the cached answer when it
+    /// is under six hours old, unless the caller explicitly asks again.
+    @discardableResult
+    public func checkAgentSessionKit(force: Bool = false) async -> ComponentUpdateStatus {
+        if !force, let cachedStatus, let cachedAt, now().timeIntervalSince(cachedAt) < cacheLifetime {
+            return cachedStatus
+        }
+        do {
+            let latest = try await latestKitVersion()
+            let status = Self.status(bundled: AgentSessionKitInfo.version, latest: latest)
+            // Only a real answer is worth remembering for six hours.
+            if !status.isFailure {
+                cachedStatus = status
+                cachedAt = now()
+            }
+            return status
+        } catch let error as ComponentUpdateCheckError {
+            return .failed(reason: error.displayReason)
+        } catch let error as HTTPResponseLimit.BoundedError {
+            _ = error
+            return .failed(reason: "response too large")
+        } catch is CancellationError {
+            return .failed(reason: "cancelled")
+        } catch {
+            // URLError and friends: report the class of failure, never the
+            // URL or anything the system put in the description.
+            let reason = (error as? URLError).map { "network error \($0.errorCode)" } ?? "network error"
+            return .failed(reason: reason)
+        }
+    }
+
+    /// The answer already in hand, if any, without touching the network.
+    public func cachedAgentSessionKitStatus() -> ComponentUpdateStatus? {
+        guard let cachedStatus, let cachedAt,
+              now().timeIntervalSince(cachedAt) < cacheLifetime else { return nil }
+        return cachedStatus
+    }
+}

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -21,17 +21,28 @@ interoperability references.
 The complete copyright and permission notice covering the adapted CodexBar
 portions is included in this repository at the local license link above.
 
-## Direct dependencies
+## In-house packages
 
 ### agent-session-kit
 
 - Project:
   [AstroQore/agent-session-kit](https://github.com/AstroQore/agent-session-kit)
+- Relationship: maintained by AstroQore, the same organization that
+  maintains Vibe Bar. Extracted from this repository, and developed as a
+  standalone public package with its own changelog, semver tags, and
+  releases.
 - Use in Vibe Bar: local coding-agent session discovery, parsing, the
-  full-text session index, session deletion planning, and the local MCP
-  Unix-socket / stdio transport. Extracted from this repository.
+  full-text session index, session deletion planning, harness naming, and
+  the local MCP Unix-socket / stdio transport.
+- How it is consumed: pinned to an exact tag in `Package.swift` and linked
+  statically into `Vibe Bar.app`'s executable — there is no separate
+  framework or dylib in the bundle. The version compiled into a build is
+  `AgentSessionKitInfo.version`, shown in Settings › System › Components.
 - License: AGPL-3.0-only — the same license as Vibe Bar, so no separate
   notice file is bundled.
+- Third-party code: none. The package has no dependencies of its own.
+
+## Direct dependencies
 
 ### SweetCookieKit 0.4.0 or later compatible releases
 

--- a/Tests/VibeBarCoreTests/ComponentUpdateCheckerTests.swift
+++ b/Tests/VibeBarCoreTests/ComponentUpdateCheckerTests.swift
@@ -1,0 +1,323 @@
+import XCTest
+@testable import VibeBarCore
+
+final class ComponentVersionTests: XCTestCase {
+    func testParsesBareAndPrefixedTags() {
+        XCTAssertEqual(ComponentVersion("0.3.0"), ComponentVersion(major: 0, minor: 3, patch: 0))
+        XCTAssertEqual(ComponentVersion("v1.2.3"), ComponentVersion(major: 1, minor: 2, patch: 3))
+        XCTAssertEqual(ComponentVersion("  0.3.0\n"), ComponentVersion(major: 0, minor: 3, patch: 0))
+        // Build metadata does not participate in precedence.
+        XCTAssertEqual(ComponentVersion("0.3.0+deadbeef"), ComponentVersion(major: 0, minor: 3, patch: 0))
+    }
+
+    func testRejectsAnythingThatIsNotThreeNumbers() {
+        for bad in ["", "1", "1.2", "1.2.3.4", "1.2.x", "one.two.three", "1.2.-3", "v", "1.2.3-"] {
+            XCTAssertNil(ComponentVersion(bad), bad)
+        }
+    }
+
+    func testOrdersByMajorThenMinorThenPatch() {
+        let ascending = ["0.1.0", "0.2.0", "0.2.1", "0.3.0", "0.10.0", "1.0.0", "1.0.1", "2.0.0"]
+            .map { ComponentVersion($0)! }
+        for (lower, higher) in zip(ascending, ascending.dropFirst()) {
+            XCTAssertLessThan(lower, higher, "\(lower) should precede \(higher)")
+        }
+        // The one a string comparison gets wrong.
+        XCTAssertLessThan(ComponentVersion("0.9.0")!, ComponentVersion("0.10.0")!)
+    }
+
+    func testAPreReleasePrecedesItsRelease() {
+        XCTAssertLessThan(ComponentVersion("0.4.0-rc.1")!, ComponentVersion("0.4.0")!)
+        XCTAssertLessThan(ComponentVersion("0.4.0-rc.1")!, ComponentVersion("0.4.0-rc.2")!)
+        XCTAssertLessThan(ComponentVersion("0.4.0-alpha")!, ComponentVersion("0.4.0-beta")!)
+        // Numeric identifiers rank below alphanumeric ones (semver § 11.4.3).
+        XCTAssertLessThan(ComponentVersion("0.4.0-1")!, ComponentVersion("0.4.0-alpha")!)
+        // A pre-release of a higher version still wins on the numbers.
+        XCTAssertLessThan(ComponentVersion("0.3.0")!, ComponentVersion("0.4.0-rc.1")!)
+    }
+
+    func testDescriptionRoundTrips() {
+        XCTAssertEqual(ComponentVersion("0.3.0")!.description, "0.3.0")
+        XCTAssertEqual(ComponentVersion("v0.4.0-rc.1")!.description, "0.4.0-rc.1")
+    }
+}
+
+final class ComponentUpdateStatusTests: XCTestCase {
+    func testEqualVersionsReadAsUpToDate() {
+        let status = ComponentUpdateChecker.status(bundled: "0.3.0", latest: "0.3.0")
+        XCTAssertEqual(status, .upToDate(bundled: "0.3.0"))
+        XCTAssertEqual(status.message, "Up to date (0.3.0)")
+        XCTAssertNil(status.releaseNotesURL)
+    }
+
+    /// The sentence that must never imply an in-place update: the kit is
+    /// linked statically, so a newer release arrives with the next build.
+    func testANewerReleaseShipsWithTheNextBuild() {
+        let status = ComponentUpdateChecker.status(bundled: "0.3.0", latest: "0.4.0")
+        XCTAssertEqual(
+            status,
+            .updateAvailable(
+                bundled: "0.3.0",
+                latest: "0.4.0",
+                releaseNotesURL: URL(string: "https://github.com/AstroQore/agent-session-kit/releases/tag/0.4.0")!
+            )
+        )
+        XCTAssertEqual(
+            status.message,
+            "Newer kit 0.4.0 available — ships with the next Vibe Bar build"
+        )
+        XCTAssertEqual(
+            status.releaseNotesURL?.absoluteString,
+            "https://github.com/AstroQore/agent-session-kit/releases/tag/0.4.0"
+        )
+        XCTAssertFalse(status.message.lowercased().contains("install"))
+        XCTAssertFalse(status.message.lowercased().contains("download"))
+        XCTAssertFalse(status.message.lowercased().contains("update now"))
+    }
+
+    /// Normal between a kit merge and its tag, or while developing against
+    /// an unreleased kit through `swift package edit`.
+    func testABundledVersionAheadOfTheNewestReleaseSaysSo() {
+        let status = ComponentUpdateChecker.status(bundled: "0.4.0", latest: "0.3.0")
+        XCTAssertEqual(status, .aheadOfLatestRelease(bundled: "0.4.0", latest: "0.3.0"))
+        XCTAssertEqual(status.message, "Bundled 0.4.0 is ahead of the newest release (0.3.0)")
+    }
+
+    func testAnUnparseableTagIsAFailureRatherThanAQuietUpToDate() {
+        let status = ComponentUpdateChecker.status(bundled: "0.3.0", latest: "latest")
+        XCTAssertTrue(status.isFailure)
+        XCTAssertEqual(status.message, "Could not check for kit updates: unrecognised tag")
+    }
+
+    /// The version actually compiled into this build is what the row shows,
+    /// and it has to be readable as a version.
+    func testTheBundledKitVersionIsAVersion() {
+        XCTAssertNotNil(ComponentVersion(AgentSessionKitInfo.version))
+        XCTAssertEqual(
+            AgentSessionKitInfo.bundledReleaseNotesURL.absoluteString,
+            "https://github.com/AstroQore/agent-session-kit/releases/tag/\(AgentSessionKitInfo.version)"
+        )
+    }
+}
+
+final class ComponentUpdateCheckerTests: XCTestCase {
+    override func tearDown() {
+        KitReleaseStubURLProtocol.reset()
+        super.tearDown()
+    }
+
+    private func makeChecker(
+        cacheLifetime: TimeInterval = ComponentUpdateChecker.defaultCacheLifetime,
+        now: @escaping @Sendable () -> Date = { Date() }
+    ) -> ComponentUpdateChecker {
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [KitReleaseStubURLProtocol.self]
+        return ComponentUpdateChecker(
+            session: URLSession(configuration: config),
+            endpoint: URL(string: "https://api.github.test/repos/AstroQore/agent-session-kit/releases/latest")!,
+            cacheLifetime: cacheLifetime,
+            now: now
+        )
+    }
+
+    func testReadsTheTagOutOfAReleasePayload() async throws {
+        KitReleaseStubURLProtocol.reset()
+        KitReleaseStubURLProtocol.handler = { request in
+            XCTAssertEqual(request.httpMethod, "GET")
+            XCTAssertEqual(request.value(forHTTPHeaderField: "Accept"), "application/vnd.github+json")
+            XCTAssertEqual(request.value(forHTTPHeaderField: "User-Agent"), "VibeBar")
+            // Unauthenticated, always.
+            XCTAssertNil(request.value(forHTTPHeaderField: "Authorization"))
+            XCTAssertEqual(request.httpShouldHandleCookies, false)
+            return (Self.ok(request), Data(#"""
+            {"tag_name":"0.4.0","name":"agent-session-kit 0.4.0","draft":false,
+             "prerelease":false,"html_url":"https://github.com/AstroQore/agent-session-kit/releases/tag/0.4.0",
+             "body":"notes","assets":[]}
+            """#.utf8))
+        }
+        let version = try await makeChecker().latestKitVersion()
+        XCTAssertEqual(version, "0.4.0")
+        XCTAssertEqual(KitReleaseStubURLProtocol.requestCount.value, 1)
+    }
+
+    func testNormalisesAVPrefixedTag() async throws {
+        KitReleaseStubURLProtocol.reset()
+        KitReleaseStubURLProtocol.handler = { request in
+            (Self.ok(request), Data(#"{"tag_name":"v1.0.0"}"#.utf8))
+        }
+        let version = try await makeChecker().latestKitVersion()
+        XCTAssertEqual(version, "1.0.0")
+    }
+
+    func testARepositoryWithNoPublishedReleaseIsItsOwnReason() async {
+        KitReleaseStubURLProtocol.reset()
+        KitReleaseStubURLProtocol.handler = { request in
+            (Self.status(404, request), Data(#"{"message":"Not Found"}"#.utf8))
+        }
+        let status = await makeChecker().checkAgentSessionKit()
+        XCTAssertEqual(status, .failed(reason: "no published release yet"))
+    }
+
+    func testAnErrorStatusIsReportedWithItsCode() async {
+        KitReleaseStubURLProtocol.reset()
+        KitReleaseStubURLProtocol.handler = { request in
+            (Self.status(503, request), Data())
+        }
+        let status = await makeChecker().checkAgentSessionKit()
+        XCTAssertEqual(status, .failed(reason: "GitHub answered HTTP 503"))
+    }
+
+    func testGarbageAndMissingFieldsAreRefusedRatherThanGuessed() async {
+        for body in ["not json", "{}", #"{"tag_name":"nightly"}"#, "[]"] {
+            KitReleaseStubURLProtocol.reset()
+            KitReleaseStubURLProtocol.handler = { request in
+                (Self.ok(request), Data(body.utf8))
+            }
+            let status = await makeChecker().checkAgentSessionKit()
+            XCTAssertTrue(status.isFailure, body)
+        }
+    }
+
+    /// Six hours in memory, so pressing the button twice in a session costs
+    /// one request — and `force` is what the button actually passes.
+    func testTheAnswerIsCachedAndForceBypassesIt() async {
+        KitReleaseStubURLProtocol.reset()
+        KitReleaseStubURLProtocol.handler = { request in
+            (Self.ok(request), Data(#"{"tag_name":"0.4.0"}"#.utf8))
+        }
+        let checker = makeChecker()
+        _ = await checker.checkAgentSessionKit(force: true)
+        XCTAssertEqual(KitReleaseStubURLProtocol.requestCount.value, 1)
+        _ = await checker.checkAgentSessionKit()
+        XCTAssertEqual(KitReleaseStubURLProtocol.requestCount.value, 1, "a fresh answer should not refetch")
+        _ = await checker.checkAgentSessionKit(force: true)
+        XCTAssertEqual(KitReleaseStubURLProtocol.requestCount.value, 2)
+    }
+
+    func testTheCacheExpires() async {
+        KitReleaseStubURLProtocol.reset()
+        KitReleaseStubURLProtocol.handler = { request in
+            (Self.ok(request), Data(#"{"tag_name":"0.4.0"}"#.utf8))
+        }
+        let clock = MutableClock(Date(timeIntervalSince1970: 1_000_000))
+        let checker = makeChecker(cacheLifetime: 6 * 60 * 60, now: { clock.now })
+        _ = await checker.checkAgentSessionKit()
+        XCTAssertEqual(KitReleaseStubURLProtocol.requestCount.value, 1)
+        clock.advance(by: 5 * 60 * 60)
+        _ = await checker.checkAgentSessionKit()
+        XCTAssertEqual(KitReleaseStubURLProtocol.requestCount.value, 1)
+        let cachedWhileFresh = await checker.cachedAgentSessionKitStatus()
+        XCTAssertNotNil(cachedWhileFresh)
+        clock.advance(by: 2 * 60 * 60)
+        let cachedWhenStale = await checker.cachedAgentSessionKitStatus()
+        XCTAssertNil(cachedWhenStale, "a stale answer is not an answer")
+        _ = await checker.checkAgentSessionKit()
+        XCTAssertEqual(KitReleaseStubURLProtocol.requestCount.value, 2)
+    }
+
+    /// A flaky network must not lock the row for six hours.
+    func testFailuresAreNotCached() async {
+        KitReleaseStubURLProtocol.reset()
+        KitReleaseStubURLProtocol.handler = { request in
+            (Self.status(500, request), Data())
+        }
+        let checker = makeChecker()
+        let first = await checker.checkAgentSessionKit()
+        XCTAssertTrue(first.isFailure)
+        let cachedAfterFailure = await checker.cachedAgentSessionKitStatus()
+        XCTAssertNil(cachedAfterFailure)
+        _ = await checker.checkAgentSessionKit()
+        XCTAssertEqual(KitReleaseStubURLProtocol.requestCount.value, 2)
+    }
+
+    /// Nothing on this path should ever be able to hand a caller a status
+    /// that claims to be up to date when the request never landed.
+    func testATransportFailureIsAFailureLine() async {
+        KitReleaseStubURLProtocol.reset()
+        KitReleaseStubURLProtocol.error = URLError(.notConnectedToInternet)
+        let status = await makeChecker().checkAgentSessionKit()
+        XCTAssertTrue(status.isFailure)
+        XCTAssertTrue(status.message.hasPrefix("Could not check for kit updates:"), status.message)
+    }
+
+    private static func ok(_ request: URLRequest) -> HTTPURLResponse { status(200, request) }
+
+    private static func status(_ code: Int, _ request: URLRequest) -> HTTPURLResponse {
+        HTTPURLResponse(
+            url: request.url!,
+            statusCode: code,
+            httpVersion: nil,
+            headerFields: ["Content-Type": "application/json"]
+        )!
+    }
+}
+
+/// A tiny settable clock, so the six-hour cache is tested by arithmetic
+/// rather than by waiting.
+private final class MutableClock: @unchecked Sendable {
+    private let lock = NSLock()
+    private var current: Date
+
+    init(_ start: Date) { current = start }
+
+    var now: Date {
+        lock.lock(); defer { lock.unlock() }
+        return current
+    }
+
+    func advance(by interval: TimeInterval) {
+        lock.lock(); defer { lock.unlock() }
+        current = current.addingTimeInterval(interval)
+    }
+}
+
+private final class KitReleaseStubURLProtocol: URLProtocol {
+    nonisolated(unsafe) static var handler: (@Sendable (URLRequest) -> (HTTPURLResponse, Data))?
+    nonisolated(unsafe) static var error: Error?
+    static let requestCount = Counter()
+
+    final class Counter: @unchecked Sendable {
+        private let lock = NSLock()
+        private var count = 0
+        var value: Int {
+            lock.lock(); defer { lock.unlock() }
+            return count
+        }
+        func increment() {
+            lock.lock(); defer { lock.unlock() }
+            count += 1
+        }
+        func reset() {
+            lock.lock(); defer { lock.unlock() }
+            count = 0
+        }
+    }
+
+    static func reset() {
+        handler = nil
+        error = nil
+        requestCount.reset()
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        Self.requestCount.increment()
+        if let error = Self.error {
+            client?.urlProtocol(self, didFailWithError: error)
+            return
+        }
+        guard let handler = Self.handler else {
+            client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
+            return
+        }
+        let (response, data) = handler(request)
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: data)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+}


### PR DESCRIPTION
## Why

`agent-session-kit` is a separate public repository — its own tags, its own
changelog, its own releases — pinned here to an exact version and linked
**statically** into `Vibe Bar.app`'s executable. Nothing in the app said
which one was compiled in, and nothing anywhere said what a kit release
means for a user. That last part is the one that is easy to imply wrongly:
it means *nothing* until Vibe Bar bumps the pin and ships a build. There is
no framework in the bundle to swap and no runtime update to offer.

The kit side of this landed as
[agent-session-kit#2](https://github.com/AstroQore/agent-session-kit/pull/2)
and is released as
[0.3.0](https://github.com/AstroQore/agent-session-kit/releases/tag/0.3.0) —
the first kit tag with a published GitHub Release, cut by its new release
workflow.

## What

**Settings › System › Components.** One row: `agent-session-kit`, the
bundled `AgentSessionKitInfo.version`, a `bundled` badge, links to that
release's notes and the repository, and a **Check for kit updates** button.
Three states, all asserted in tests:

| State | Row reads |
| --- | --- |
| Not pressed yet | `Not checked. Nothing is fetched until you ask.` |
| Newest release is the bundled one | `Up to date (0.3.0)` |
| A newer release exists | `Newer kit 0.4.0 available — ships with the next Vibe Bar build`, plus a *What changed in 0.4.0* link to that release |
| Bundled is ahead (between a kit merge and its tag, or `swift package edit`) | `Bundled 0.4.0 is ahead of the newest release (0.3.0)` |
| Anything went wrong | `Could not check for kit updates: <short reason>` in orange |

**`ComponentUpdateChecker`** (new, `VibeBarCore/Services`). `GET
api.github.com/repos/AstroQore/agent-session-kit/releases/latest` —
unauthenticated, `Accept: application/vnd.github+json`, `User-Agent:
VibeBar`, 15 s, redirects refused via the same `RemoteNoRedirectDelegate`
the Relay client uses, response bounded through `HTTPResponseLimit`,
ephemeral session with no cache and no cookies.

- **Manual only.** Nothing fires on launch, on a timer, or when the pane
  appears. The button is the sole trigger; the view's `.task` reads the
  in-memory cache and never opens a connection.
- The answer is cached **in memory for six hours**; failures are never
  cached, so a flaky network cannot lock the row for the session. Nothing
  is written to disk — this is a fact about the running binary, not user
  state.
- The release link is derived locally from the tag rather than taken from
  the response, so a compromised or surprising payload cannot point the
  user somewhere else.
- `ComponentVersion` is the semver comparison, including the pre-release
  ordering that would otherwise rank `0.4.0-rc.1` above `0.4.0`, and the
  `0.9.0 < 0.10.0` case a string compare gets wrong.

**Bump automation.** `.github/workflows/bump-agent-session-kit.yml`:
`workflow_dispatch` + daily cron. Reads the pin, asks GitHub for the kit's
newest release, and when it is newer opens
`chore/bump-agent-session-kit-<ver>` rewriting `Package.swift` and the copy
of the pin quoted in `AGENTS.md` § 2.1, with the release notes linked in the
body. Skips when already pinned, when the pin is deliberately *ahead*, and
when a PR for that version is already open. It never merges anything.

It uses `secrets.VIBEBAR_BOT_TOKEN || secrets.GITHUB_TOKEN`. With the
default token GitHub does not run workflows on the PR it opens; the PR body
says so and names the two workarounds (close+reopen, or an empty commit),
and `AGENTS.md` § 2.1 records that adding a `VIBEBAR_BOT_TOKEN` PAT removes
the step. **No secret is required for this PR to be correct** — the
workflow degrades to "opens the PR, CI needs a nudge".

**Docs.** `README.md` and `README.zh-CN.md` gain an Architecture section
(app targets vs. the kit, how a kit release reaches a user, where the
bundled version is shown). `AGENTS.md` § 2.1 becomes the full story: a table
of what lives where, the pin, the static-link consequences, both bump
procedures, the release-coupling rule (*a kit tag is not a Vibe Bar
release — ship a dev build after bumping*), `swift package edit`, and the
Settings visibility including the required phrasing.
`THIRD_PARTY_NOTICES.md` moves the kit into its own **In-house packages**
section (same org, AGPL-3.0-only, no dependencies of its own, pinned exact,
statically linked). `CONTRIBUTING.md` points at § 2.1.

## Verification

```
swift build                                  # Build complete
swift test                                   # 1550 tests, 1 skipped, 0 failures
./Scripts/build_app.sh release               # packaged + ad-hoc signed
codesign -d --entitlements :- …              # <plist><dict></dict></plist>
codesign --verify --deep --strict …          # passes
nm …/MacOS/VibeBar | grep -c AgentSessionKit # 4847
otool -L …/MacOS/VibeBar                     # no kit dylib — statically linked
grep -rE 'NSHomeDirectory\(\)|homeDirectoryForCurrentUser|…' Sources/   # no hits
ls ~/Library/Containers/com.astroqore.VibeBar/Data/                     # No such file or directory
```

The bundle was built and verified but not launched: an installed Vibe Bar is
running on this machine and owns `~/.vibebar/mcp.sock`, so a second instance
from the worktree would have fought it for the socket and the menu-bar item.

No release or tag is cut here. Per `AGENTS.md` § 2.1, kit 0.3.0 reaches
users when a Vibe Bar build ships with this pin.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
