### PR TITLE
Prepare Vibe Bar 1.3.0

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.3.0</string>
 	<key>CFBundleVersion</key>
-	<string>36</string>
+	<string>37</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>26.0</string>
 	<key>LSUIElement</key>


### PR DESCRIPTION
## Why

Promote the 1.3.0 Dev line to the **Main (stable) channel**. The last stable release is v1.2.0; the Dev channel has run 1.3.0 dev.1 → dev.36 since. Main at `e0fb4d0` is the state to ship.

## What

- `Resources/Info.plist`: `CFBundleVersion` 36 → 37 (must exceed every Dev build so Sparkle never sees a downgrade); `CFBundleShortVersionString` stays `1.3.0`. Tag will be `v1.3.0` (Main = `v` + short version).

## Highlights since 1.2.0 (see the Dev release notes for the full trail)

- Provider hierarchy: company → SubProvider → group; Grok Bot, Cursor quotas; AntiGravity live quota fallback; stale/freshness labels
- Usage & cost attributed to the producing **harness** (Codex, ChatGPT Work, Claude Code, Claude Cowork, Gemini CLI, AntiGravity, Grok Build, Cursor); Harness Mix, canonical model names, pricing table
- Sessions for every harness incl. Cowork, Cursor, Grok Bot (read-only), session ids from file names, harness/model on rows
- Local MCP server over a private socket + `--mcp-stdio` bridge, `skills.install`, agent-setup prompt and skill
- Workbench flat design, Settings as a native page, performance work (Requests table, icon cache, settings writes), transcript freeze fixes
- Sessions / MCP transport now from `agent-session-kit` 0.3.0 (statically linked; bundled version visible in Settings → System → Components)

## Verification

- `swift build`, `swift test` (1550 tests, 1 skipped, 0 failures)
- `./Scripts/build_app.sh release`, `codesign -d --entitlements -` → empty `<dict/>`, `codesign --verify --deep --strict` OK; bundle reports `1.3.0 (37)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
