### PR TITLE
Keep skill harness state in sync with disk

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -650,10 +650,16 @@ Tests keep working because they pass an explicit value.
 - **The Skills manager is a narrow, documented exception to that write
   scope.** It writes to exactly two things: `~/.agents/skills/` — the
   single source of truth every agent CLI is projected from — and the
-  seven managed app skills directories (`~/.claude/skills`,
-  `~/.codex/skills`, `~/.gemini/skills`, `~/.grok/skills`,
-  `~/.hermes/skills`, `~/.config/opencode/skills`,
-  `~/.gemini/config/skills`). Nothing else, and never directly: every
+  allowlisted app skills directories. New management is shown only for the
+  locally controllable core harnesses: Codex (`~/.codex/skills`), Claude Code
+  (`~/.claude/skills`), AntiGravity (`~/.gemini/config/skills`), Grok Build
+  (`~/.grok/skills`), and Cursor (`~/.cursor/skills`). The older Gemini CLI,
+  Hermes, and OpenCode roots remain in the allowlist only so an existing
+  `skills.json` can be decoded and safely cleaned up; they are not offered for
+  new scans, installs, or toggles. ChatGPT Work, Claude Cowork, and Grok Bot do
+  not expose an independent, stable local skill directory that this feature
+  can safely write, so Vibe Bar does not display fake filesystem toggles for
+  them. Nothing else is touched, and never directly: every
   create, link, copy, and delete goes through `SkillSyncEngine` /
   `SkillsService`, which validate each directory name as a single safe
   path segment, refuse any resolved path outside those roots, require a
@@ -667,6 +673,9 @@ Tests keep working because they pass an explicit value.
   AntiGravity's customization root, not the Gemini CLI's — nothing else
   under `~/.gemini/config/` may be touched. New code that needs a skills
   path goes through those two types; do not add a second write path.
+  The visible Skills page also re-reads recorded app projections while it is
+  open; a missing or replaced symlink must clear the enabled state instead of
+  trusting stale registry metadata.
   That includes the MCP surface: `skills.install` (§ 5.1) resolves its
   `source` to a repository ref or a local directory and then calls
   `SkillsService.install(from:enableFor:method:)`, which reuses the same

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,7 +89,7 @@ See `AGENTS.md` § 6 for the full reasoning.
   `SessionDeleter`, performed only at the user's explicit request and on
   the containment / symlink / re-parsed-session-id terms `AGENTS.md` § 5
   sets out; and the Skills manager, which writes only to
-  `~/.agents/skills/` and the seven managed app skills directories, and
+  `~/.agents/skills/` and the allowlisted app skills directories, and
   only through `SkillSyncEngine` / `SkillsService` (`AGENTS.md` § 7).
 
 ## Implementation Notes

--- a/Sources/VibeBarApp/Controllers/SkillsManagerModel.swift
+++ b/Sources/VibeBarApp/Controllers/SkillsManagerModel.swift
@@ -204,8 +204,7 @@ final class SkillsManagerModel: ObservableObject {
         perform(BusyKey.skill(id)) { [self] in
             let result = try await service.uninstall(id)
             updateStates[id] = nil
-            let kept = skill.enabledApps
-                .filter { skill.isEnabled(for: $0) && result.removedByApp[$0] == false }
+            let kept = result.retainedApps
             toast = kept.isEmpty
                 ? "Uninstalled \(skill.name). A backup was saved."
                 : "Uninstalled \(skill.name). Left in place for "

--- a/Sources/VibeBarApp/Controllers/SkillsManagerModel.swift
+++ b/Sources/VibeBarApp/Controllers/SkillsManagerModel.swift
@@ -163,6 +163,23 @@ final class SkillsManagerModel: ObservableObject {
         Task { await reloadSkills() }
     }
 
+    /// Keeps the visible toggles tied to the filesystem rather than the last
+    /// registry write. SwiftUI cancels the page task when Skills is no longer
+    /// visible, so this inexpensive lstat-only pass runs only while it can
+    /// change something the user sees.
+    func monitorFilesystem() async {
+        await reloadSkills()
+        while !Task.isCancelled {
+            do {
+                try await Task.sleep(for: .seconds(2))
+            } catch {
+                return
+            }
+            guard !Task.isCancelled else { return }
+            await reloadSkills()
+        }
+    }
+
     // MARK: - Per-skill actions
 
     func toggle(skill: Skill, app: SkillAppTarget) {
@@ -187,7 +204,7 @@ final class SkillsManagerModel: ObservableObject {
         perform(BusyKey.skill(id)) { [self] in
             let result = try await service.uninstall(id)
             updateStates[id] = nil
-            let kept = SkillAppTarget.allCases
+            let kept = SkillAppTarget.managedHarnesses
                 .filter { skill.isEnabled(for: $0) && result.removedByApp[$0] == false }
             toast = kept.isEmpty
                 ? "Uninstalled \(skill.name). A backup was saved."
@@ -503,7 +520,8 @@ final class SkillsManagerModel: ObservableObject {
     }
 
     private func reloadSkills() async {
-        skills = await service.installedSkills()
+        let latest = await service.installedSkills()
+        if latest != skills { skills = latest }
     }
 
     /// `scanForImport` and `listBackups` are `nonisolated` on the service —

--- a/Sources/VibeBarApp/Controllers/SkillsManagerModel.swift
+++ b/Sources/VibeBarApp/Controllers/SkillsManagerModel.swift
@@ -204,7 +204,7 @@ final class SkillsManagerModel: ObservableObject {
         perform(BusyKey.skill(id)) { [self] in
             let result = try await service.uninstall(id)
             updateStates[id] = nil
-            let kept = SkillAppTarget.managedHarnesses
+            let kept = skill.enabledApps
                 .filter { skill.isEnabled(for: $0) && result.removedByApp[$0] == false }
             toast = kept.isEmpty
                 ? "Uninstalled \(skill.name). A backup was saved."

--- a/Sources/VibeBarApp/Views/Workbench/SkillDiscoverSheet.swift
+++ b/Sources/VibeBarApp/Views/Workbench/SkillDiscoverSheet.swift
@@ -18,7 +18,7 @@ struct SkillDiscoverSheet: View {
     @State private var query = ""
     /// Apps a row installs into when it has not been touched. Empty by
     /// design: installing is about getting the skill onto the machine, and
-    /// silently switching it on for seven agent CLIs is not that.
+    /// silently switching it on for every managed harness is not that.
     @State private var defaultApps: Set<SkillAppTarget> = []
     @State private var overrides: [String: Set<SkillAppTarget>] = [:]
 
@@ -47,10 +47,10 @@ struct SkillDiscoverSheet: View {
             Text("Discover Skills")
                 .font(.system(size: density.titleFontSize, weight: .semibold))
             Spacer(minLength: 8)
-            Button(defaultApps.count == SkillAppTarget.allCases.count ? "Select none" : "Select all") {
-                defaultApps = defaultApps.count == SkillAppTarget.allCases.count
+            Button(defaultApps.count == SkillAppTarget.managedHarnesses.count ? "Select none" : "Select all") {
+                defaultApps = defaultApps.count == SkillAppTarget.managedHarnesses.count
                     ? []
-                    : Set(SkillAppTarget.allCases)
+                    : Set(SkillAppTarget.managedHarnesses)
                 overrides.removeAll()
             }
             .buttonStyle(.bordered)

--- a/Sources/VibeBarApp/Views/Workbench/SkillListRow.swift
+++ b/Sources/VibeBarApp/Views/Workbench/SkillListRow.swift
@@ -4,15 +4,16 @@ import VibeBarCore
 
 extension SkillAppTarget {
     /// The provider this agent CLI shares a brand mark with, when there is
-    /// one. Five of the seven targets are also usage providers, so their rows
-    /// wear the same glyph and accent they wear everywhere else in the app.
+    /// one. Every visible managed harness has a real provider asset, so the
+    /// toggle row never falls back to an empty or unrelated glyph.
     var brandTool: ToolType? { ToolType(rawValue: rawValue) }
 
     var fallbackSystemImage: String {
         switch self {
         case .hermes: return "cross.case"
         case .opencode: return "chevron.left.forwardslash.chevron.right"
-        case .claude, .codex, .gemini, .grok, .antigravity: return "puzzlepiece.extension"
+        case .claude, .codex, .gemini, .grok, .antigravity, .cursor:
+            return "puzzlepiece.extension"
         }
     }
 
@@ -70,7 +71,7 @@ struct SkillAppGlyph: View {
     }
 }
 
-/// The seven-app row: one circular brand button per agent CLI.
+/// One circular brand button per locally manageable core harness.
 ///
 /// Used both as a live control (an installed skill's enable bits) and as a
 /// selection (which apps a pending install should be enabled for) — the two
@@ -87,7 +88,7 @@ struct SkillAppToggleRow: View {
 
     var body: some View {
         HStack(spacing: spacing) {
-            ForEach(SkillAppTarget.allCases, id: \.self) { app in
+            ForEach(SkillAppTarget.managedHarnesses, id: \.self) { app in
                 button(for: app)
             }
         }

--- a/Sources/VibeBarApp/Views/Workbench/SkillsManagerPage.swift
+++ b/Sources/VibeBarApp/Views/Workbench/SkillsManagerPage.swift
@@ -25,7 +25,10 @@ struct SkillsManagerPage: View {
         .padding(.vertical, density.popoverPaddingV)
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .overlay(alignment: .bottom) { toastBanner }
-        .task { model.activate() }
+        .task {
+            model.activate()
+            await model.monitorFilesystem()
+        }
         .onChange(of: model.toast) { _, newValue in
             toastDismissal?.cancel()
             guard newValue != nil else { return }
@@ -187,7 +190,7 @@ struct SkillsManagerPage: View {
     /// above the list rather than inside a menu.
     private var appCountRow: some View {
         HStack(spacing: 6) {
-            ForEach(SkillAppTarget.allCases, id: \.self) { app in
+            ForEach(SkillAppTarget.managedHarnesses, id: \.self) { app in
                 let count = model.installedCount(for: app)
                 HStack(spacing: 4) {
                     SkillAppGlyph(app: app, size: density.segmentedFontSize)

--- a/Sources/VibeBarCore/MCP/MCPServer.swift
+++ b/Sources/VibeBarCore/MCP/MCPServer.swift
@@ -422,6 +422,17 @@ public final class MCPServer: @unchecked Sendable {
             throw MCPRPCError.invalidParams("skills.install: \(error.localizedDescription)")
         }
         let apps = try arguments.optionalEnumList("apps", SkillAppTarget.self) ?? []
+        let managed = Set(SkillAppTarget.managedHarnesses)
+        let unsupported = apps.filter { !managed.contains($0) }
+        guard unsupported.isEmpty else {
+            throw MCPRPCError.invalidParams(
+                "skills.install: unsupported app(s): "
+                    + unsupported.map(\.rawValue).joined(separator: ", ")
+                    + ". Managed apps: "
+                    + SkillAppTarget.managedHarnesses.map(\.rawValue).joined(separator: ", ")
+                    + "."
+            )
+        }
         var method = SkillSyncMethod.auto
         if let requested = try arguments.optionalEnum("method", SkillSyncMethod.self) {
             guard requested != .auto else {

--- a/Sources/VibeBarCore/MCP/MCPToolCatalog.swift
+++ b/Sources/VibeBarCore/MCP/MCPToolCatalog.swift
@@ -349,7 +349,7 @@ public enum MCPToolCatalog {
                     "owner/repo[@branch][#skill], a github.com URL, or an absolute local directory."
                 ),
                 "apps": stringEnumList(
-                    SkillAppTarget.allCases.map(\.rawValue),
+                    SkillAppTarget.managedHarnesses.map(\.rawValue),
                     description: "Agent CLIs to project the skill into. Omit to install without enabling it anywhere."
                 ),
                 "method": string(

--- a/Sources/VibeBarCore/Skills/SkillAppCatalog.swift
+++ b/Sources/VibeBarCore/Skills/SkillAppCatalog.swift
@@ -27,6 +27,7 @@ public enum SkillAppCatalog {
         case .hermes: return ".hermes/skills"
         case .opencode: return ".config/opencode/skills"
         case .antigravity: return ".gemini/config/skills"
+        case .cursor: return ".cursor/skills"
         }
     }
 

--- a/Sources/VibeBarCore/Skills/SkillDirectoryHasher.swift
+++ b/Sources/VibeBarCore/Skills/SkillDirectoryHasher.swift
@@ -39,6 +39,31 @@ public enum SkillDirectoryHasher {
         return hasher.finalize().map { String(format: "%02x", $0) }.joined()
     }
 
+    /// Cheap tree-change stamp for polling. It walks names and metadata but
+    /// never reads file payloads; callers can reuse a previously verified
+    /// content hash while this stamp is unchanged.
+    public static func metadataStamp(directory: URL) throws -> String {
+        var entries: [(path: String, url: URL, isSymlink: Bool)] = []
+        try collect(directory: directory, relativePath: "", into: &entries)
+        entries.sort { $0.path.utf8.lexicographicallyPrecedes($1.path.utf8) }
+
+        var hasher = SHA256()
+        let separator = Data([0])
+        for entry in entries {
+            let attributes = try FileManager.default.attributesOfItem(atPath: entry.url.path)
+            let size = (attributes[.size] as? NSNumber)?.uint64Value ?? 0
+            let modified = (attributes[.modificationDate] as? Date)?.timeIntervalSince1970 ?? 0
+            let inode = (attributes[.systemFileNumber] as? NSNumber)?.uint64Value ?? 0
+            let target = entry.isSymlink
+                ? (try? FileManager.default.destinationOfSymbolicLink(atPath: entry.url.path)) ?? ""
+                : ""
+            let record = "\(entry.path)\0\(size)\0\(modified.bitPattern)\0\(inode)\0\(target)"
+            hasher.update(data: Data(record.utf8))
+            hasher.update(data: separator)
+        }
+        return hasher.finalize().map { String(format: "%02x", $0) }.joined()
+    }
+
     private static func collect(
         directory: URL,
         relativePath: String,

--- a/Sources/VibeBarCore/Skills/SkillImportScanner.swift
+++ b/Sources/VibeBarCore/Skills/SkillImportScanner.swift
@@ -99,7 +99,7 @@ public enum SkillImportScanner {
         var unmanagedSample: [String: URL] = [:]
         var conflicts: [SkillImportConflict] = []
 
-        for app in SkillAppTarget.allCases {
+        for app in SkillAppTarget.managedHarnesses {
             let appDirectory = SkillAppCatalog.skillsDirectory(for: app, homeDirectory: homeDirectory)
             for name in directoryEntries(at: appDirectory) {
                 let entry = appDirectory.appendingPathComponent(name, isDirectory: true)

--- a/Sources/VibeBarCore/Skills/SkillModels.swift
+++ b/Sources/VibeBarCore/Skills/SkillModels.swift
@@ -91,16 +91,34 @@ public enum SkillAppTarget: String, CaseIterable, Codable, Hashable, Sendable {
     case hermes
     case opencode
     case antigravity
+    case cursor
+
+    /// Harnesses Vibe Bar can actually project a local skill directory into.
+    ///
+    /// ChatGPT Work, Claude Cowork, and Grok Bot do not expose an independent,
+    /// stable local skills root that this filesystem feature can safely write.
+    /// They therefore stay out of the toggle row instead of pretending a link
+    /// can enable them. Gemini CLI, Hermes, and OpenCode remain decodable for
+    /// old `skills.json` files and safe uninstall cleanup, but new management
+    /// is intentionally limited to AQ's core harnesses below.
+    public static let managedHarnesses: [SkillAppTarget] = [
+        .codex,
+        .claude,
+        .antigravity,
+        .grok,
+        .cursor,
+    ]
 
     public var displayName: String {
         switch self {
         case .claude: return "Claude Code"
         case .codex: return "Codex"
         case .gemini: return "Gemini CLI"
-        case .grok: return "Grok"
+        case .grok: return "Grok Build"
         case .hermes: return "Hermes"
         case .opencode: return "OpenCode"
         case .antigravity: return "AntiGravity"
+        case .cursor: return "Cursor"
         }
     }
 }

--- a/Sources/VibeBarCore/Skills/SkillSyncEngine.swift
+++ b/Sources/VibeBarCore/Skills/SkillSyncEngine.swift
@@ -270,22 +270,27 @@ public struct SkillSyncEngine: Sendable {
     public func liveMaterialization(
         skillDirectoryName: String,
         app: SkillAppTarget,
-        recorded: SkillMaterialization
+        recorded: SkillMaterialization,
+        currentCopyHash: String? = nil
     ) -> SkillMaterialization? {
         guard SkillPathValidator.isValid(skillDirectoryName) else { return nil }
         let destination = destination(for: skillDirectoryName, app: app)
         switch SkillFileSystem.kind(of: destination) {
         case .symlink:
+            let source = sourceDirectory(for: skillDirectoryName).standardizedFileURL
             guard
                 let resolved = SkillFileSystem.lexicalSymlinkTarget(of: destination),
-                resolved.path == sourceDirectory(for: skillDirectoryName).standardizedFileURL.path
+                resolved.path == source.path,
+                SkillFileSystem.kind(of: source) == .directory,
+                FileManager.default.fileExists(atPath: source.appendingPathComponent("SKILL.md").path)
             else { return nil }
             return SkillMaterialization(method: .symlink, adopted: recorded.adopted)
         case .directory:
             guard
                 recorded.method == .copy,
                 let recordedHash = recorded.contentHashAtCopy,
-                let currentHash = try? SkillDirectoryHasher.hash(directory: destination),
+                let currentHash = currentCopyHash
+                    ?? (try? SkillDirectoryHasher.hash(directory: destination)),
                 currentHash == recordedHash
             else { return nil }
             return recorded

--- a/Sources/VibeBarCore/Skills/SkillSyncEngine.swift
+++ b/Sources/VibeBarCore/Skills/SkillSyncEngine.swift
@@ -259,6 +259,41 @@ public struct SkillSyncEngine: Sendable {
         return SkillMaterialization(method: .symlink, adopted: true)
     }
 
+    /// Re-reads one recorded projection from disk without changing it.
+    ///
+    /// The registry is only the last state Vibe Bar wrote. A user or another
+    /// installer can remove or replace an app-side entry while the Workbench
+    /// is open, so the UI must not treat that cached record as proof that the
+    /// skill is still enabled. Symlinks must still point to this skill's SSOT
+    /// directory; copies must still be real skill directories. Foreign links,
+    /// replaced directories, regular files, and missing entries are all stale.
+    public func liveMaterialization(
+        skillDirectoryName: String,
+        app: SkillAppTarget,
+        recorded: SkillMaterialization
+    ) -> SkillMaterialization? {
+        guard SkillPathValidator.isValid(skillDirectoryName) else { return nil }
+        let destination = destination(for: skillDirectoryName, app: app)
+        switch SkillFileSystem.kind(of: destination) {
+        case .symlink:
+            guard
+                let resolved = SkillFileSystem.lexicalSymlinkTarget(of: destination),
+                resolved.path == sourceDirectory(for: skillDirectoryName).standardizedFileURL.path
+            else { return nil }
+            return SkillMaterialization(method: .symlink, adopted: recorded.adopted)
+        case .directory:
+            guard
+                recorded.method == .copy,
+                FileManager.default.fileExists(
+                    atPath: destination.appendingPathComponent("SKILL.md").path
+                )
+            else { return nil }
+            return recorded
+        case .missing, .regularFile, .other:
+            return nil
+        }
+    }
+
     // MARK: - Internals
 
     var homeURL: URL { URL(fileURLWithPath: homeDirectory, isDirectory: true) }

--- a/Sources/VibeBarCore/Skills/SkillSyncEngine.swift
+++ b/Sources/VibeBarCore/Skills/SkillSyncEngine.swift
@@ -284,9 +284,9 @@ public struct SkillSyncEngine: Sendable {
         case .directory:
             guard
                 recorded.method == .copy,
-                FileManager.default.fileExists(
-                    atPath: destination.appendingPathComponent("SKILL.md").path
-                )
+                let recordedHash = recorded.contentHashAtCopy,
+                let currentHash = try? SkillDirectoryHasher.hash(directory: destination),
+                currentHash == recordedHash
             else { return nil }
             return recorded
         case .missing, .regularFile, .other:

--- a/Sources/VibeBarCore/Skills/SkillSyncEngine.swift
+++ b/Sources/VibeBarCore/Skills/SkillSyncEngine.swift
@@ -171,6 +171,9 @@ public struct SkillSyncEngine: Sendable {
                 try fm.removeItem(at: destination)
                 return try link(source: source, destination: destination)
             case .directory:
+                guard try isVibeBarCopy(destination: destination, source: source, recorded: recorded) else {
+                    throw SkillError.directoryConflict(skillDirectoryName)
+                }
                 return try copy(source: source, destination: destination)
             default:
                 throw SkillError.directoryConflict(skillDirectoryName)
@@ -194,8 +197,12 @@ public struct SkillSyncEngine: Sendable {
 
         case .copy:
             switch existing {
-            case .missing, .directory:
+            case .missing:
                 break
+            case .directory:
+                guard try isVibeBarCopy(destination: destination, source: source, recorded: recorded) else {
+                    throw SkillError.directoryConflict(skillDirectoryName)
+                }
             case .symlink:
                 try fm.removeItem(at: destination)
             default:

--- a/Sources/VibeBarCore/Skills/SkillsService.swift
+++ b/Sources/VibeBarCore/Skills/SkillsService.swift
@@ -32,6 +32,11 @@ public actor SkillsService {
     /// call that produced it; it is replaced on the next discovery pass and can
     /// be dropped explicitly once the user closes the browser.
     var discoveryStaging: URL?
+    private struct CopyVerification: Sendable {
+        let metadataStamp: String
+        let contentHash: String
+    }
+    private var copyVerificationCache: [String: CopyVerification] = [:]
 
     public init(
         homeDirectory: String = RealHomeDirectory.path,
@@ -51,15 +56,26 @@ public actor SkillsService {
     public func installedSkills() async -> [Skill] {
         let snapshots = await store.all()
         var result: [Skill] = []
+        var liveCopyKeys: Set<String> = []
         result.reserveCapacity(snapshots.count)
         for snapshot in snapshots {
             var reconciled = snapshot
             let recordedApps = snapshot.apps
             for (app, recorded) in recordedApps {
+                let currentCopyHash: String?
+                if recorded.method == .copy {
+                    let destination = engine.destination(for: snapshot.directory, app: app)
+                    let key = destination.standardizedFileURL.path
+                    liveCopyKeys.insert(key)
+                    currentCopyHash = verifiedCopyHash(at: destination, key: key)
+                } else {
+                    currentCopyHash = nil
+                }
                 if let live = engine.liveMaterialization(
                     skillDirectoryName: snapshot.directory,
                     app: app,
-                    recorded: recorded
+                    recorded: recorded,
+                    currentCopyHash: currentCopyHash
                 ) {
                     reconciled.apps[app] = live
                 } else {
@@ -84,7 +100,24 @@ public actor SkillsService {
                 result.append(reconciled)
             }
         }
+        copyVerificationCache = copyVerificationCache.filter { liveCopyKeys.contains($0.key) }
         return result
+    }
+
+    private func verifiedCopyHash(at directory: URL, key: String) -> String? {
+        guard let stamp = try? SkillDirectoryHasher.metadataStamp(directory: directory) else {
+            copyVerificationCache[key] = nil
+            return nil
+        }
+        if let cached = copyVerificationCache[key], cached.metadataStamp == stamp {
+            return cached.contentHash
+        }
+        guard let hash = try? SkillDirectoryHasher.hash(directory: directory) else {
+            copyVerificationCache[key] = nil
+            return nil
+        }
+        copyVerificationCache[key] = CopyVerification(metadataStamp: stamp, contentHash: hash)
+        return hash
     }
 
     public func skill(with id: SkillID) async -> Skill? {

--- a/Sources/VibeBarCore/Skills/SkillsService.swift
+++ b/Sources/VibeBarCore/Skills/SkillsService.swift
@@ -18,6 +18,10 @@ public actor SkillsService {
         /// Per app: whether the app-side entry was actually removed. `false`
         /// means something the user could have authored was left in place.
         public let removedByApp: [SkillAppTarget: Bool]
+
+        public var retainedApps: [SkillAppTarget] {
+            SkillAppTarget.allCases.filter { removedByApp[$0] == false }
+        }
     }
 
     // Internal rather than private: the repository-facing half of this actor

--- a/Sources/VibeBarCore/Skills/SkillsService.swift
+++ b/Sources/VibeBarCore/Skills/SkillsService.swift
@@ -58,9 +58,11 @@ public actor SkillsService {
     }
 
     public func installedSkills() async -> [Skill] {
-        let snapshots = await store.all()
+        let storeSnapshot = await store.snapshot()
+        let snapshots = storeSnapshot.skills
         var result: [Skill] = []
         var liveCopyKeys: Set<String> = []
+        var reconciledApps: [SkillID: [SkillAppTarget: SkillMaterialization]] = [:]
         result.reserveCapacity(snapshots.count)
         for snapshot in snapshots {
             var reconciled = snapshot
@@ -90,22 +92,20 @@ public actor SkillsService {
                 result.append(snapshot)
                 continue
             }
-            do {
-                // One store-actor call owns read + compare + write. Splitting
-                // those into a `skill` await and an `upsert` await reopens the
-                // exact lost-update race this reconciliation is preventing.
-                guard let merged = try await store.mergeReconciledApps(
-                    snapshot: snapshot,
-                    reconciled: reconciled
-                ) else { continue }
-                result.append(merged)
-            } catch {
-                SafeLog.warn("Persisting reconciled skill state failed.")
-                result.append(reconciled)
-            }
+            reconciledApps[snapshot.id] = reconciled.apps
+            result.append(reconciled)
         }
         copyVerificationCache = copyVerificationCache.filter { liveCopyKeys.contains($0.key) }
-        return result
+        guard !reconciledApps.isEmpty else { return result }
+        do {
+            return try await store.applyReconciliation(
+                expectedRevision: storeSnapshot.revision,
+                appsBySkill: reconciledApps
+            )
+        } catch {
+            SafeLog.warn("Persisting reconciled skill state failed.")
+            return result
+        }
     }
 
     private func verifiedCopyHash(at directory: URL, key: String) -> String? {

--- a/Sources/VibeBarCore/Skills/SkillsService.swift
+++ b/Sources/VibeBarCore/Skills/SkillsService.swift
@@ -70,32 +70,21 @@ public actor SkillsService {
                 result.append(snapshot)
                 continue
             }
-            // `await store.all()` above makes this actor reentrant. Re-read
-            // before writing and apply only app entries that still equal the
-            // snapshot we inspected, preserving a concurrent enable/install
-            // and every newer metadata field.
-            guard let current = await store.skill(with: snapshot.id) else { continue }
-            let merged = Self.mergeReconciledApps(
-                snapshot: snapshot,
-                reconciled: reconciled,
-                current: current
-            )
             do {
-                try await store.upsert(merged)
+                // One store-actor call owns read + compare + write. Splitting
+                // those into a `skill` await and an `upsert` await reopens the
+                // exact lost-update race this reconciliation is preventing.
+                guard let merged = try await store.mergeReconciledApps(
+                    snapshot: snapshot,
+                    reconciled: reconciled
+                ) else { continue }
+                result.append(merged)
             } catch {
                 SafeLog.warn("Persisting reconciled skill state failed.")
+                result.append(reconciled)
             }
-            result.append(merged)
         }
         return result
-    }
-
-    static func mergeReconciledApps(snapshot: Skill, reconciled: Skill, current: Skill) -> Skill {
-        var merged = current
-        for (app, recorded) in snapshot.apps where current.apps[app] == recorded {
-            merged.apps[app] = reconciled.apps[app]
-        }
-        return merged
     }
 
     public func skill(with id: SkillID) async -> Skill? {

--- a/Sources/VibeBarCore/Skills/SkillsService.swift
+++ b/Sources/VibeBarCore/Skills/SkillsService.swift
@@ -49,7 +49,30 @@ public actor SkillsService {
     }
 
     public func installedSkills() async -> [Skill] {
-        await store.all()
+        var skills = await store.all()
+        for index in skills.indices {
+            var skill = skills[index]
+            let recordedApps = skill.apps
+            for (app, recorded) in recordedApps {
+                if let live = engine.liveMaterialization(
+                    skillDirectoryName: skill.directory,
+                    app: app,
+                    recorded: recorded
+                ) {
+                    skill.apps[app] = live
+                } else {
+                    skill.apps[app] = nil
+                }
+            }
+            guard skill.apps != recordedApps else { continue }
+            do {
+                try await store.upsert(skill)
+            } catch {
+                SafeLog.warn("Persisting reconciled skill state failed.")
+            }
+            skills[index] = skill
+        }
+        return skills
     }
 
     public func skill(with id: SkillID) async -> Skill? {
@@ -119,7 +142,7 @@ public actor SkillsService {
     @discardableResult
     public func importAdopted(
         _ report: SkillImportReport,
-        apps: [SkillAppTarget] = SkillAppTarget.allCases
+        apps: [SkillAppTarget] = SkillAppTarget.managedHarnesses
     ) async throws -> [Skill] {
         let allowed = Set(apps)
         var imported: [Skill] = []

--- a/Sources/VibeBarCore/Skills/SkillsService.swift
+++ b/Sources/VibeBarCore/Skills/SkillsService.swift
@@ -49,30 +49,53 @@ public actor SkillsService {
     }
 
     public func installedSkills() async -> [Skill] {
-        var skills = await store.all()
-        for index in skills.indices {
-            var skill = skills[index]
-            let recordedApps = skill.apps
+        let snapshots = await store.all()
+        var result: [Skill] = []
+        result.reserveCapacity(snapshots.count)
+        for snapshot in snapshots {
+            var reconciled = snapshot
+            let recordedApps = snapshot.apps
             for (app, recorded) in recordedApps {
                 if let live = engine.liveMaterialization(
-                    skillDirectoryName: skill.directory,
+                    skillDirectoryName: snapshot.directory,
                     app: app,
                     recorded: recorded
                 ) {
-                    skill.apps[app] = live
+                    reconciled.apps[app] = live
                 } else {
-                    skill.apps[app] = nil
+                    reconciled.apps[app] = nil
                 }
             }
-            guard skill.apps != recordedApps else { continue }
+            guard reconciled.apps != recordedApps else {
+                result.append(snapshot)
+                continue
+            }
+            // `await store.all()` above makes this actor reentrant. Re-read
+            // before writing and apply only app entries that still equal the
+            // snapshot we inspected, preserving a concurrent enable/install
+            // and every newer metadata field.
+            guard let current = await store.skill(with: snapshot.id) else { continue }
+            let merged = Self.mergeReconciledApps(
+                snapshot: snapshot,
+                reconciled: reconciled,
+                current: current
+            )
             do {
-                try await store.upsert(skill)
+                try await store.upsert(merged)
             } catch {
                 SafeLog.warn("Persisting reconciled skill state failed.")
             }
-            skills[index] = skill
+            result.append(merged)
         }
-        return skills
+        return result
+    }
+
+    static func mergeReconciledApps(snapshot: Skill, reconciled: Skill, current: Skill) -> Skill {
+        var merged = current
+        for (app, recorded) in snapshot.apps where current.apps[app] == recorded {
+            merged.apps[app] = reconciled.apps[app]
+        }
+        return merged
     }
 
     public func skill(with id: SkillID) async -> Skill? {

--- a/Sources/VibeBarCore/Skills/SkillsStore.swift
+++ b/Sources/VibeBarCore/Skills/SkillsStore.swift
@@ -145,6 +145,24 @@ public actor SkillsStore {
         try save(storage)
     }
 
+    /// Atomically applies a disk reconciliation to the app mappings that have
+    /// not changed since `snapshot`. Keeping the read, compare, and write in
+    /// this actor prevents a concurrent enable/install from landing between a
+    /// service-side re-read and upsert.
+    public func mergeReconciledApps(snapshot: Skill, reconciled: Skill) throws -> Skill? {
+        var storage = loaded()
+        guard let index = storage.skills.firstIndex(where: { $0.id == snapshot.id }) else {
+            return nil
+        }
+        var merged = storage.skills[index]
+        for (app, recorded) in snapshot.apps where merged.apps[app] == recorded {
+            merged.apps[app] = reconciled.apps[app]
+        }
+        storage.skills[index] = merged
+        try save(storage)
+        return merged
+    }
+
     @discardableResult
     public func remove(id: SkillID) throws -> Bool {
         var storage = loaded()

--- a/Sources/VibeBarCore/Skills/SkillsStore.swift
+++ b/Sources/VibeBarCore/Skills/SkillsStore.swift
@@ -67,6 +67,12 @@ public actor SkillsStore {
     private let fileURL: URL
     private let baseDirectory: URL
     private var cache: Storage?
+    private var mutationRevision: UInt64 = 0
+
+    public struct Snapshot: Sendable {
+        public let skills: [Skill]
+        public let revision: UInt64
+    }
 
     public init(homeDirectory: String = RealHomeDirectory.path) {
         self.fileURL = VibeBarLocalStore.skillsStoreURL(homeDirectory: homeDirectory)
@@ -75,6 +81,10 @@ public actor SkillsStore {
 
     public func all() -> [Skill] {
         loaded().skills
+    }
+
+    public func snapshot() -> Snapshot {
+        Snapshot(skills: loaded().skills, revision: mutationRevision)
     }
 
     // MARK: - Discovery repositories
@@ -145,22 +155,23 @@ public actor SkillsStore {
         try save(storage)
     }
 
-    /// Atomically applies a disk reconciliation to the app mappings that have
-    /// not changed since `snapshot`. Keeping the read, compare, and write in
-    /// this actor prevents a concurrent enable/install from landing between a
-    /// service-side re-read and upsert.
-    public func mergeReconciledApps(snapshot: Skill, reconciled: Skill) throws -> Skill? {
+    /// Atomically applies one filesystem poll. Any store mutation since the
+    /// poll's snapshot — even an ABA write of an equal materialization — makes
+    /// the whole proposal stale; the caller gets current rows and retries from
+    /// fresh disk evidence on its next pass.
+    public func applyReconciliation(
+        expectedRevision: UInt64,
+        appsBySkill: [SkillID: [SkillAppTarget: SkillMaterialization]]
+    ) throws -> [Skill] {
         var storage = loaded()
-        guard let index = storage.skills.firstIndex(where: { $0.id == snapshot.id }) else {
-            return nil
+        guard mutationRevision == expectedRevision else { return storage.skills }
+        for index in storage.skills.indices {
+            let id = storage.skills[index].id
+            if let apps = appsBySkill[id] { storage.skills[index].apps = apps }
         }
-        var merged = storage.skills[index]
-        for (app, recorded) in snapshot.apps where merged.apps[app] == recorded {
-            merged.apps[app] = reconciled.apps[app]
-        }
-        storage.skills[index] = merged
+        guard !appsBySkill.isEmpty else { return storage.skills }
         try save(storage)
-        return merged
+        return storage.skills
     }
 
     @discardableResult
@@ -182,6 +193,7 @@ public actor SkillsStore {
     /// needed when something outside this actor rewrote it.
     public func invalidate() {
         cache = nil
+        mutationRevision &+= 1
     }
 
     private func loaded() -> Storage {
@@ -197,6 +209,7 @@ public actor SkillsStore {
         next.skills.sort { $0.directory.utf8.lexicographicallyPrecedes($1.directory.utf8) }
         try VibeBarLocalStore.writeJSON(next, to: fileURL, base: baseDirectory)
         cache = next
+        mutationRevision &+= 1
     }
 
     private static func load(from url: URL) -> Storage {

--- a/Tests/VibeBarCoreTests/MCPSkillInstallTests.swift
+++ b/Tests/VibeBarCoreTests/MCPSkillInstallTests.swift
@@ -216,6 +216,19 @@ final class MCPSkillInstallTests: XCTestCase {
         )
     }
 
+    func testRejectsLegacyAppsAtExecutionTime() async throws {
+        for app in [SkillAppTarget.gemini, .hermes, .opencode] {
+            let response = try await raw([
+                "source": .string("AstroQore/vibe-bar"),
+                "apps": .array([.string(app.rawValue)])
+            ])
+            let message = response["error"]?["message"]?.stringValue ?? ""
+            XCTAssertTrue(message.contains("unsupported app"), message)
+            XCTAssertNil(source.lastSkillSource)
+            XCTAssertFalse(home.exists(home.ssot.appendingPathComponent("vibe-bar")))
+        }
+    }
+
     // MARK: - Source parsing
 
     func testSourceParsingCoversTheSpellingsAgentsUse() throws {

--- a/Tests/VibeBarCoreTests/SkillDirectoryHasherTests.swift
+++ b/Tests/VibeBarCoreTests/SkillDirectoryHasherTests.swift
@@ -91,4 +91,14 @@ final class SkillDirectoryHasherTests: XCTestCase {
             try SkillDirectoryHasher.hash(directory: directory)
         )
     }
+
+    func testMetadataStampIsStableAndMovesWhenTheTreeChanges() throws {
+        let home = try SkillTestHome()
+        let directory = try home.makeSSOTSkill("stamped", extraFiles: ["a.md": "one"])
+        let before = try SkillDirectoryHasher.metadataStamp(directory: directory)
+        XCTAssertEqual(before, try SkillDirectoryHasher.metadataStamp(directory: directory))
+
+        try home.write("second", to: directory.appendingPathComponent("nested/b.md"))
+        XCTAssertNotEqual(before, try SkillDirectoryHasher.metadataStamp(directory: directory))
+    }
 }

--- a/Tests/VibeBarCoreTests/SkillImportScannerTests.swift
+++ b/Tests/VibeBarCoreTests/SkillImportScannerTests.swift
@@ -36,8 +36,8 @@ final class SkillImportScannerTests: XCTestCase {
             description: "hand written"
         )
 
-        try home.makeAbsoluteSymlink("alpha", in: .gemini, toSSOT: "alpha")
-        try home.makeSkillDirectory(at: home.appDirectory(.gemini).appendingPathComponent("beta"))
+        try home.makeAbsoluteSymlink("alpha", in: .cursor, toSSOT: "alpha")
+        try home.makeSkillDirectory(at: home.appDirectory(.cursor).appendingPathComponent("beta"))
 
         try home.makeAbsoluteSymlink("alpha", in: .antigravity, toSSOT: "alpha")
 
@@ -59,7 +59,7 @@ final class SkillImportScannerTests: XCTestCase {
             ["alpha", "beta", "delta", "epsilon", "eta", "gamma", "theta", "zeta"]
         )
         XCTAssertEqual(report.unrecognized, ["notaskill"])
-        XCTAssertEqual(report.conflicts, [SkillImportConflict(directoryName: "beta", app: .gemini)])
+        XCTAssertEqual(report.conflicts, [SkillImportConflict(directoryName: "beta", app: .cursor)])
         XCTAssertEqual(report.unmanagedDirectories.count, 1)
         let unmanaged = try XCTUnwrap(report.unmanagedDirectories.first)
         XCTAssertEqual(unmanaged.directoryName, "legacy-helper")
@@ -74,8 +74,8 @@ final class SkillImportScannerTests: XCTestCase {
         let byDirectory = Dictionary(uniqueKeysWithValues: report.adopted.map { ($0.directory, $0) })
 
         // Absolute links in three different app dirs, including AntiGravity's
-        // ~/.gemini/config/skills, which is distinct from the Gemini CLI's.
-        XCTAssertEqual(byDirectory["alpha"]?.enabledApps, [.claude, .gemini, .antigravity])
+        // ~/.gemini/config/skills and Cursor's ~/.cursor/skills.
+        XCTAssertEqual(byDirectory["alpha"]?.enabledApps, [.claude, .antigravity, .cursor])
         XCTAssertEqual(byDirectory["alpha"]?.apps[.claude], SkillMaterialization(method: .symlink, adopted: true))
         XCTAssertEqual(byDirectory["alpha"]?.name, "alpha-skill")
         XCTAssertEqual(byDirectory["alpha"]?.description, "Alpha does things")
@@ -83,7 +83,7 @@ final class SkillImportScannerTests: XCTestCase {
 
         // A relative link resolves the same way an absolute one does.
         XCTAssertEqual(byDirectory["gamma"]?.enabledApps, [.claude])
-        // The Gemini side of beta is a real directory: a conflict, not evidence.
+        // The Cursor side of beta is a real directory: a conflict, not evidence.
         XCTAssertEqual(byDirectory["beta"]?.enabledApps, [.claude])
         // Never linked anywhere.
         XCTAssertEqual(byDirectory["delta"]?.enabledApps, [])

--- a/Tests/VibeBarCoreTests/SkillSyncEngineTests.swift
+++ b/Tests/VibeBarCoreTests/SkillSyncEngineTests.swift
@@ -75,6 +75,42 @@ final class SkillSyncEngineTests: XCTestCase {
         XCTAssertEqual(target, home.ssot.appendingPathComponent("alpha").path)
     }
 
+    func testLiveMaterializationRejectsAnEditedOrReplacedCopy() throws {
+        let home = try SkillTestHome()
+        try home.makeSSOTSkill("alpha", extraFiles: ["ref.md": "original"])
+        let engine = SkillSyncEngine(homeDirectory: home.path)
+        let recorded = try engine.materialize(
+            skillDirectoryName: "alpha",
+            into: .claude,
+            method: .copy
+        )
+
+        XCTAssertEqual(
+            engine.liveMaterialization(
+                skillDirectoryName: "alpha",
+                app: .claude,
+                recorded: recorded
+            ),
+            recorded
+        )
+
+        let destination = home.appDirectory(.claude).appendingPathComponent("alpha")
+        try home.write("edited", to: destination.appendingPathComponent("ref.md"))
+        XCTAssertNil(engine.liveMaterialization(
+            skillDirectoryName: "alpha",
+            app: .claude,
+            recorded: recorded
+        ))
+
+        try FileManager.default.removeItem(at: destination)
+        try home.makeSkillDirectory(at: destination, extraFiles: ["ref.md": "replacement"])
+        XCTAssertNil(engine.liveMaterialization(
+            skillDirectoryName: "alpha",
+            app: .claude,
+            recorded: recorded
+        ))
+    }
+
     func testSymlinkMethodRefusesAForeignDirectoryButReplacesAFaithfulCopy() throws {
         let home = try SkillTestHome()
         try home.makeSSOTSkill("alpha", extraFiles: ["ref.md": "fresh"])

--- a/Tests/VibeBarCoreTests/SkillSyncEngineTests.swift
+++ b/Tests/VibeBarCoreTests/SkillSyncEngineTests.swift
@@ -175,13 +175,13 @@ final class SkillSyncEngineTests: XCTestCase {
 
     func testWriteRootsCoverTheSSOTAndEveryAppDirectoryOnly() throws {
         let home = try SkillTestHome()
-        XCTAssertEqual(SkillAppCatalog.allowedWriteRoots(homeDirectory: home.path).count, 8)
+        XCTAssertEqual(SkillAppCatalog.allowedWriteRoots(homeDirectory: home.path).count, 9)
         XCTAssertTrue(SkillAppCatalog.isWriteAllowed(
             home.ssot.appendingPathComponent("alpha"),
             homeDirectory: home.path
         ))
         XCTAssertTrue(SkillAppCatalog.isWriteAllowed(
-            home.appDirectory(.opencode).appendingPathComponent("alpha"),
+            home.appDirectory(.cursor).appendingPathComponent("alpha"),
             homeDirectory: home.path
         ))
         XCTAssertFalse(SkillAppCatalog.isWriteAllowed(
@@ -192,6 +192,17 @@ final class SkillSyncEngineTests: XCTestCase {
             home.url.appendingPathComponent(".claude/settings.json"),
             homeDirectory: home.path
         ))
+    }
+
+    func testManagedHarnessTargetsExcludeUnmanageableAndLegacySurfaces() {
+        XCTAssertEqual(
+            SkillAppTarget.managedHarnesses,
+            [.codex, .claude, .antigravity, .grok, .cursor]
+        )
+        XCTAssertEqual(SkillAppCatalog.relativePath(for: .cursor), ".cursor/skills")
+        XCTAssertFalse(SkillAppTarget.managedHarnesses.contains(.gemini))
+        XCTAssertFalse(SkillAppTarget.managedHarnesses.contains(.hermes))
+        XCTAssertFalse(SkillAppTarget.managedHarnesses.contains(.opencode))
     }
 
     func testUnmaterializeRemovesAnSSOTSymlinkAndIsIdempotent() throws {

--- a/Tests/VibeBarCoreTests/SkillSyncEngineTests.swift
+++ b/Tests/VibeBarCoreTests/SkillSyncEngineTests.swift
@@ -111,6 +111,28 @@ final class SkillSyncEngineTests: XCTestCase {
         ))
     }
 
+    func testLiveMaterializationRejectsADanglingSSOTLink() throws {
+        let home = try SkillTestHome()
+        let source = try home.makeSSOTSkill("alpha")
+        let engine = SkillSyncEngine(homeDirectory: home.path)
+        let recorded = try engine.materialize(
+            skillDirectoryName: "alpha",
+            into: .claude,
+            method: .symlink
+        )
+        try FileManager.default.removeItem(at: source)
+
+        XCTAssertNil(engine.liveMaterialization(
+            skillDirectoryName: "alpha",
+            app: .claude,
+            recorded: recorded
+        ))
+        XCTAssertEqual(
+            SkillFileSystem.kind(of: home.appDirectory(.claude).appendingPathComponent("alpha")),
+            .symlink
+        )
+    }
+
     func testSymlinkMethodRefusesAForeignDirectoryButReplacesAFaithfulCopy() throws {
         let home = try SkillTestHome()
         try home.makeSSOTSkill("alpha", extraFiles: ["ref.md": "fresh"])

--- a/Tests/VibeBarCoreTests/SkillSyncEngineTests.swift
+++ b/Tests/VibeBarCoreTests/SkillSyncEngineTests.swift
@@ -2,7 +2,7 @@ import XCTest
 @testable import VibeBarCore
 
 final class SkillSyncEngineTests: XCTestCase {
-    func testAutoOverRealDirectoryReplacesItWithACopyAndRecordsTheHash() throws {
+    func testAutoOverForeignDirectoryRefusesToReplaceIt() throws {
         let home = try SkillTestHome()
         let source = try home.makeSSOTSkill("alpha", extraFiles: ["ref.md": "fresh"])
         let destination = home.appDirectory(.claude).appendingPathComponent("alpha")
@@ -10,25 +10,15 @@ final class SkillSyncEngineTests: XCTestCase {
         try home.write("leftover", to: destination.appendingPathComponent("orphan.md"))
 
         let engine = SkillSyncEngine(homeDirectory: home.path)
-        let materialization = try engine.materialize(
-            skillDirectoryName: "alpha",
-            into: .claude,
-            method: .auto
-        )
-
-        XCTAssertEqual(materialization.method, .copy)
-        XCTAssertFalse(materialization.adopted)
+        XCTAssertThrowsError(try engine.materialize(
+            skillDirectoryName: "alpha", into: .claude, method: .auto
+        )) { error in
+            XCTAssertEqual(error as? SkillError, .directoryConflict("alpha"))
+        }
         XCTAssertEqual(SkillFileSystem.kind(of: destination), .directory)
-        XCTAssertEqual(home.contents(of: destination.appendingPathComponent("ref.md")), "fresh")
-        // Replaced as a unit, not merged into: the stale file is gone.
-        XCTAssertFalse(home.exists(destination.appendingPathComponent("orphan.md")))
-        XCTAssertEqual(materialization.contentHashAtCopy, try SkillDirectoryHasher.hash(directory: destination))
-        XCTAssertEqual(materialization.contentHashAtCopy, try SkillDirectoryHasher.hash(directory: source))
-        // No staging directory survives the swap.
-        let leftovers = try FileManager.default
-            .contentsOfDirectory(atPath: home.appDirectory(.claude).path)
-            .filter { $0.hasPrefix(".alpha.tmp-") }
-        XCTAssertEqual(leftovers, [])
+        XCTAssertEqual(home.contents(of: destination.appendingPathComponent("ref.md")), "stale")
+        XCTAssertEqual(home.contents(of: destination.appendingPathComponent("orphan.md")), "leftover")
+        XCTAssertTrue(home.exists(source.appendingPathComponent("SKILL.md")))
     }
 
     func testAutoOverStaleSymlinkRelinksIntoTheSSOT() throws {
@@ -111,6 +101,26 @@ final class SkillSyncEngineTests: XCTestCase {
         ))
     }
 
+    func testReenableRefusesAnEditedCopyAfterItsRecordWasCleared() throws {
+        let home = try SkillTestHome()
+        try home.makeSSOTSkill("alpha", extraFiles: ["ref.md": "original"])
+        let engine = SkillSyncEngine(homeDirectory: home.path)
+        _ = try engine.materialize(
+            skillDirectoryName: "alpha", into: .claude, method: .copy
+        )
+        let destination = home.appDirectory(.claude).appendingPathComponent("alpha")
+        try home.write("user edit", to: destination.appendingPathComponent("ref.md"))
+
+        for method in [SkillSyncMethod.auto, .copy] {
+            XCTAssertThrowsError(try engine.materialize(
+                skillDirectoryName: "alpha", into: .claude, method: method, recorded: nil
+            )) { error in
+                XCTAssertEqual(error as? SkillError, .directoryConflict("alpha"))
+            }
+            XCTAssertEqual(home.contents(of: destination.appendingPathComponent("ref.md")), "user edit")
+        }
+    }
+
     func testLiveMaterializationRejectsADanglingSSOTLink() throws {
         let home = try SkillTestHome()
         let source = try home.makeSSOTSkill("alpha")
@@ -148,6 +158,9 @@ final class SkillSyncEngineTests: XCTestCase {
         XCTAssertEqual(SkillFileSystem.kind(of: destination), .directory)
         XCTAssertEqual(home.contents(of: destination.appendingPathComponent("ref.md")), "hand-edited")
 
+        // Once the foreign directory is removed by its owner, Vibe Bar can
+        // create and later replace its own verified copy.
+        try FileManager.default.removeItem(at: destination)
         let copied = try engine.materialize(skillDirectoryName: "alpha", into: .claude, method: .copy)
         XCTAssertEqual(copied.method, .copy)
         let linked = try engine.materialize(

--- a/Tests/VibeBarCoreTests/SkillsServiceTests.swift
+++ b/Tests/VibeBarCoreTests/SkillsServiceTests.swift
@@ -248,6 +248,7 @@ final class SkillsServiceTests: XCTestCase {
         let result = try await service.uninstall(skill.id)
 
         XCTAssertEqual(result.removedByApp[.hermes], false)
+        XCTAssertEqual(result.retainedApps, [.hermes])
         XCTAssertEqual(home.contents(of: foreign.appendingPathComponent("ref.md")), "hand written")
         XCTAssertFalse(home.exists(home.ssot.appendingPathComponent("alpha")))
     }

--- a/Tests/VibeBarCoreTests/SkillsServiceTests.swift
+++ b/Tests/VibeBarCoreTests/SkillsServiceTests.swift
@@ -80,6 +80,38 @@ final class SkillsServiceTests: XCTestCase {
         XCTAssertEqual(afterDisable.first?.enabledApps, [])
     }
 
+    func testInstalledSkillsClearsARecordedSymlinkRemovedOutsideVibeBar() async throws {
+        let home = try SkillTestHome()
+        let staging = try home.makeSkillDirectory(at: home.url.appendingPathComponent("Downloads/alpha"))
+        let service = SkillsService(homeDirectory: home.path)
+        let skill = try await service.installLocal(from: staging, name: "alpha")
+        _ = try await service.setEnabled(skill.id, app: .claude, enabled: true, method: .symlink)
+
+        let destination = home.appDirectory(.claude).appendingPathComponent("alpha")
+        try FileManager.default.removeItem(at: destination)
+
+        let live = await service.installedSkills()
+        XCTAssertFalse(try XCTUnwrap(live.first).isEnabled(for: .claude))
+        let persisted = await SkillsStore(homeDirectory: home.path).all()
+        XCTAssertFalse(try XCTUnwrap(persisted.first).isEnabled(for: .claude))
+    }
+
+    func testInstalledSkillsRejectsARecordedLinkReplacedByAForeignDirectory() async throws {
+        let home = try SkillTestHome()
+        let staging = try home.makeSkillDirectory(at: home.url.appendingPathComponent("Downloads/alpha"))
+        let service = SkillsService(homeDirectory: home.path)
+        let skill = try await service.installLocal(from: staging, name: "alpha")
+        _ = try await service.setEnabled(skill.id, app: .claude, enabled: true, method: .symlink)
+
+        let destination = home.appDirectory(.claude).appendingPathComponent("alpha")
+        try FileManager.default.removeItem(at: destination)
+        try home.makeSkillDirectory(at: destination, extraFiles: ["owner.txt": "user"])
+
+        let live = await service.installedSkills()
+        XCTAssertFalse(try XCTUnwrap(live.first).isEnabled(for: .claude))
+        XCTAssertEqual(home.contents(of: destination.appendingPathComponent("owner.txt")), "user")
+    }
+
     func testFailedMaterializeLeavesTheStoreUntouched() async throws {
         let home = try SkillTestHome()
         let staging = try home.makeSkillDirectory(at: home.url.appendingPathComponent("Downloads/alpha"))
@@ -189,7 +221,7 @@ final class SkillsServiceTests: XCTestCase {
         try home.makeSSOTSkill("alpha", name: "alpha-skill")
         try home.makeSSOTSkill("beta")
         try home.makeAbsoluteSymlink("alpha", in: .claude, toSSOT: "alpha")
-        try home.makeAbsoluteSymlink("alpha", in: .gemini, toSSOT: "alpha")
+        try home.makeAbsoluteSymlink("alpha", in: .cursor, toSSOT: "alpha")
         let service = SkillsService(homeDirectory: home.path)
 
         let report = service.scanForImport()
@@ -203,14 +235,14 @@ final class SkillsServiceTests: XCTestCase {
         XCTAssertEqual(persisted.first?.apps[.claude]?.adopted, true)
         // Import changed nothing on disk.
         XCTAssertEqual(
-            SkillFileSystem.kind(of: home.appDirectory(.gemini).appendingPathComponent("alpha")),
+            SkillFileSystem.kind(of: home.appDirectory(.cursor).appendingPathComponent("alpha")),
             .symlink
         )
 
         // A second import with another app selected keeps what was known.
-        _ = try await service.importAdopted(report, apps: [.gemini])
+        _ = try await service.importAdopted(report, apps: [.cursor])
         let merged = await SkillsStore(homeDirectory: home.path).all()
-        XCTAssertEqual(merged.first?.enabledApps, [.claude, .gemini])
+        XCTAssertEqual(merged.first?.enabledApps, [.claude, .cursor])
     }
 
     func testAdoptUnmanagedCopiesIntoTheSSOTThenMaterializes() async throws {

--- a/Tests/VibeBarCoreTests/SkillsServiceTests.swift
+++ b/Tests/VibeBarCoreTests/SkillsServiceTests.swift
@@ -112,7 +112,7 @@ final class SkillsServiceTests: XCTestCase {
         XCTAssertEqual(home.contents(of: destination.appendingPathComponent("owner.txt")), "user")
     }
 
-    func testAtomicStoreReconciliationPreservesConcurrentAppChanges() async throws {
+    func testStoreRevisionRejectsConcurrentAndSameValueABAReconciliation() async throws {
         let home = try SkillTestHome()
         let store = SkillsStore(homeDirectory: home.path)
         let original = SkillMaterialization(method: .symlink)
@@ -129,23 +129,37 @@ final class SkillsServiceTests: XCTestCase {
         reconciled.apps[.claude] = nil
         var current = snapshot
         current.apps[.cursor] = cursor
-        try await store.upsert(current)
-
-        let merged = try await store.mergeReconciledApps(
-            snapshot: snapshot,
-            reconciled: reconciled
+        try await store.upsert(snapshot)
+        let stale = await store.snapshot()
+        // Same-value write: semantically a reinstall even though the mapping
+        // compares equal to the old snapshot.
+        try await store.upsert(snapshot)
+        let afterABA = try await store.applyReconciliation(
+            expectedRevision: stale.revision,
+            appsBySkill: [snapshot.id: reconciled.apps]
         )
-        XCTAssertNil(merged?.apps[.claude])
-        XCTAssertEqual(merged?.apps[.cursor], cursor)
+        XCTAssertEqual(afterABA.first?.apps[.claude], original)
+
+        let fresh = await store.snapshot()
+        try await store.upsert(current)
+        let afterConcurrent = try await store.applyReconciliation(
+            expectedRevision: fresh.revision,
+            appsBySkill: [snapshot.id: reconciled.apps]
+        )
+        XCTAssertEqual(afterConcurrent.first?.apps[.claude], original)
+        XCTAssertEqual(afterConcurrent.first?.apps[.cursor], cursor)
 
         current.apps[.claude] = replacement
         try await store.upsert(current)
-        let changed = try await store.mergeReconciledApps(
-            snapshot: snapshot,
-            reconciled: reconciled
+        let changed = await store.snapshot()
+        var removeClaude = current.apps
+        removeClaude[.claude] = nil
+        let applied = try await store.applyReconciliation(
+            expectedRevision: changed.revision,
+            appsBySkill: [snapshot.id: removeClaude]
         )
-        XCTAssertEqual(changed?.apps[.claude], replacement)
-        XCTAssertEqual(changed?.apps[.cursor], cursor)
+        XCTAssertNil(applied.first?.apps[.claude])
+        XCTAssertEqual(applied.first?.apps[.cursor], cursor)
     }
 
     func testFailedMaterializeLeavesTheStoreUntouched() async throws {

--- a/Tests/VibeBarCoreTests/SkillsServiceTests.swift
+++ b/Tests/VibeBarCoreTests/SkillsServiceTests.swift
@@ -112,6 +112,40 @@ final class SkillsServiceTests: XCTestCase {
         XCTAssertEqual(home.contents(of: destination.appendingPathComponent("owner.txt")), "user")
     }
 
+    func testReconciliationPreservesConcurrentAppChanges() {
+        let original = SkillMaterialization(method: .symlink)
+        let replacement = SkillMaterialization(method: .copy, contentHashAtCopy: "new")
+        let cursor = SkillMaterialization(method: .symlink)
+        let snapshot = Skill(
+            id: .local(directory: "alpha"),
+            name: "Alpha",
+            directory: "alpha",
+            installedAt: Date(timeIntervalSince1970: 1),
+            apps: [.claude: original]
+        )
+        var reconciled = snapshot
+        reconciled.apps[.claude] = nil
+        var current = snapshot
+        current.apps[.cursor] = cursor
+
+        let merged = SkillsService.mergeReconciledApps(
+            snapshot: snapshot,
+            reconciled: reconciled,
+            current: current
+        )
+        XCTAssertNil(merged.apps[.claude])
+        XCTAssertEqual(merged.apps[.cursor], cursor)
+
+        current.apps[.claude] = replacement
+        let changed = SkillsService.mergeReconciledApps(
+            snapshot: snapshot,
+            reconciled: reconciled,
+            current: current
+        )
+        XCTAssertEqual(changed.apps[.claude], replacement)
+        XCTAssertEqual(changed.apps[.cursor], cursor)
+    }
+
     func testFailedMaterializeLeavesTheStoreUntouched() async throws {
         let home = try SkillTestHome()
         let staging = try home.makeSkillDirectory(at: home.url.appendingPathComponent("Downloads/alpha"))

--- a/Tests/VibeBarCoreTests/SkillsServiceTests.swift
+++ b/Tests/VibeBarCoreTests/SkillsServiceTests.swift
@@ -112,7 +112,9 @@ final class SkillsServiceTests: XCTestCase {
         XCTAssertEqual(home.contents(of: destination.appendingPathComponent("owner.txt")), "user")
     }
 
-    func testReconciliationPreservesConcurrentAppChanges() {
+    func testAtomicStoreReconciliationPreservesConcurrentAppChanges() async throws {
+        let home = try SkillTestHome()
+        let store = SkillsStore(homeDirectory: home.path)
         let original = SkillMaterialization(method: .symlink)
         let replacement = SkillMaterialization(method: .copy, contentHashAtCopy: "new")
         let cursor = SkillMaterialization(method: .symlink)
@@ -127,23 +129,23 @@ final class SkillsServiceTests: XCTestCase {
         reconciled.apps[.claude] = nil
         var current = snapshot
         current.apps[.cursor] = cursor
+        try await store.upsert(current)
 
-        let merged = SkillsService.mergeReconciledApps(
+        let merged = try await store.mergeReconciledApps(
             snapshot: snapshot,
-            reconciled: reconciled,
-            current: current
+            reconciled: reconciled
         )
-        XCTAssertNil(merged.apps[.claude])
-        XCTAssertEqual(merged.apps[.cursor], cursor)
+        XCTAssertNil(merged?.apps[.claude])
+        XCTAssertEqual(merged?.apps[.cursor], cursor)
 
         current.apps[.claude] = replacement
-        let changed = SkillsService.mergeReconciledApps(
+        try await store.upsert(current)
+        let changed = try await store.mergeReconciledApps(
             snapshot: snapshot,
-            reconciled: reconciled,
-            current: current
+            reconciled: reconciled
         )
-        XCTAssertEqual(changed.apps[.claude], replacement)
-        XCTAssertEqual(changed.apps[.cursor], cursor)
+        XCTAssertEqual(changed?.apps[.claude], replacement)
+        XCTAssertEqual(changed?.apps[.cursor], cursor)
     }
 
     func testFailedMaterializeLeavesTheStoreUntouched() async throws {


### PR DESCRIPTION
## Summary
- show only locally manageable core harnesses in Skills and add Cursor
- remove legacy Gemini CLI, Hermes, and OpenCode toggles while preserving cleanup compatibility
- reconcile recorded links and copies against disk every two seconds while the Skills page is visible
- clear stale enabled state when an external tool removes or replaces a managed link

## Verification
- swift test: 1553 tests, 1 skipped, 0 failures
- release app bundle built successfully
- strict deep codesign verification passed
- entitlements plist is empty and app sandbox is absent