### PR TITLE
fix: keep sessions and mini window responsive

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -729,8 +729,8 @@ Consequences worth stating out loud:
   company / SubProvider / group. Usage and cost surfaces (Workbench
   Harness Mix, harness filter, cost cards) speak harnesses, grouped or
   filtered by company. **The Sessions page is a usage surface**: its rows
-  are labelled with the harness, its source menu lists harnesses, and only
-  its company chips speak L1.
+  are labelled with the harness, its Harness menu lists individual sources,
+  and its separate Company menu is the only L1 batch control.
 - "Gemini Web" is a quota SubProvider with **no** local usage; the
   deprecated CLI's historical tokens are always labelled "Gemini CLI".
 - The ledger stores the harness per detail row *and* per daily rollup.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -160,7 +160,7 @@ there, not in the package.
 
 **Where it comes from.** `Package.swift` pins the package to an exact
 tag on GitHub (`.package(url: "https://github.com/AstroQore/agent-session-kit.git",
-exact: "0.3.0")`), so a plain clone builds and a release build resolves the
+exact: "0.4.1")`), so a plain clone builds and a release build resolves the
 same package the developer built against — `Package.resolved` is
 gitignored here, and the exact pin is what stands in for it.
 

--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
         // from a clean checkout with no Package.resolved (it is gitignored),
         // so the pin is the only thing that makes two builds of the same
         // Vibe Bar commit contain the same package. Bump it deliberately.
-        .package(url: "https://github.com/AstroQore/agent-session-kit.git", exact: "0.3.0"),
+        .package(url: "https://github.com/AstroQore/agent-session-kit.git", exact: "0.4.1"),
         // SweetCookieKit encapsulates the Chromium SQLite parsing, "Chrome
         // Safe Storage" Keychain decryption, and Safari binarycookies /
         // Firefox SQLite reads that the misc-providers feature needs.

--- a/Sources/VibeBarApp/Controllers/SessionManagerModel.swift
+++ b/Sources/VibeBarApp/Controllers/SessionManagerModel.swift
@@ -78,6 +78,7 @@ final class SessionManagerModel: ObservableObject {
         let summary: SessionSummary
         let snippet: String?
         let matchedSeq: Int?
+        let reviewCount: Int
 
         var id: String { summary.id }
     }
@@ -115,6 +116,19 @@ final class SessionManagerModel: ObservableObject {
             scheduleSearch()
             refreshRows()
         }
+    }
+    @Published var searchScopes = SessionSearchScope.defaultScopes {
+        didSet {
+            guard oldValue != searchScopes else { return }
+            rerunSearch()
+            refreshRows()
+        }
+    }
+    @Published var directoryIncludeText = "" {
+        didSet { scheduleDirectoryFilter() }
+    }
+    @Published var directoryExcludeText = "" {
+        didSet { scheduleDirectoryFilter() }
     }
 
     /// Which harnesses the list is narrowed to: `nil` for all of them, `[]`
@@ -183,6 +197,7 @@ final class SessionManagerModel: ObservableObject {
     private let bodyIndexing: BodyIndexingFlag
 
     private var searchTask: Task<Void, Never>?
+    private var directoryFilterTask: Task<Void, Never>?
     private var refreshTask: Task<Void, Never>?
     private var toastTask: Task<Void, Never>?
     private var transcriptGeneration: UInt64 = 0
@@ -190,6 +205,7 @@ final class SessionManagerModel: ObservableObject {
     private var summaryGeneration: UInt64 = 0
     private var hasActivated = false
     private var lastScanFinishedAt: Date?
+    private var reviewSummariesByParent: [String: [SessionSummary]] = [:]
 
     /// Floor between two automatic sweeps. A manual refresh ignores it.
     private static let rescanMinimumInterval: TimeInterval = 30
@@ -254,9 +270,11 @@ final class SessionManagerModel: ObservableObject {
 
     func stop() {
         searchTask?.cancel()
+        directoryFilterTask?.cancel()
         refreshTask?.cancel()
         toastTask?.cancel()
         searchTask = nil
+        directoryFilterTask = nil
         refreshTask = nil
         toastTask = nil
     }
@@ -337,11 +355,18 @@ final class SessionManagerModel: ObservableObject {
             let page = try? await service.summaryPage(
                 harnesses: harnesses,
                 since: since,
+                projectIncludes: self?.directoryIncludes ?? [],
+                projectExcludes: self?.directoryExcludes ?? [],
+                excludingProviderVariantPrefix: CodexSessionAdapter.autoReviewVariantPrefix,
                 order: order,
                 offset: offset,
                 limit: Self.summaryPageSize
             )
             let counts = reset ? (try? await service.harnessCounts()) : nil
+            let reviews = reset ? (try? await service.summaries(
+                provider: .codex,
+                providerVariantPrefix: CodexSessionAdapter.autoReviewVariantPrefix
+            )) : nil
             guard let self, generation == self.summaryGeneration else { return }
             self.isLoadingSummaries = false
             guard let page else { return }
@@ -352,7 +377,20 @@ final class SessionManagerModel: ObservableObject {
                 self.summaries.append(contentsOf: page.summaries.filter { !existing.contains($0.id) })
             }
             self.totalSessionCount = page.totalCount
-            if let counts { self.harnessCounts = counts }
+            if var counts {
+                for review in reviews ?? [] {
+                    let harness = review.effectiveHarness
+                    counts[harness] = max(0, (counts[harness] ?? 0) - 1)
+                }
+                self.harnessCounts = counts
+            }
+            if let reviews {
+                self.reviewSummariesByParent = Dictionary(grouping: reviews) {
+                    CodexSessionAdapter.autoReviewParentSessionID(providerVariant: $0.providerVariant) ?? ""
+                }
+                self.reviewSummariesByParent.removeValue(forKey: "")
+                self.refreshRows()
+            }
             self.reconcileSelection()
         }
     }
@@ -395,9 +433,48 @@ final class SessionManagerModel: ObservableObject {
             return
         }
         let harnesses = harnessFilter.map { Array($0).sorted { $0.rawValue < $1.rawValue } }
-        let found = (try? await service.search(needle, harnesses: harnesses, limit: 200)) ?? []
+        let found = (try? await service.search(
+            needle,
+            harnesses: harnesses,
+            scopes: searchScopes,
+            projectIncludes: directoryIncludes,
+            projectExcludes: directoryExcludes,
+            limit: 200
+        )) ?? []
+        var resolved: [SessionSearchHit] = []
+        var seen: Set<String> = []
+        for hit in found {
+            if let parentID = CodexSessionAdapter.autoReviewParentSessionID(
+                providerVariant: hit.summary.providerVariant
+            ), let parent = try? await service.summary(provider: .codex, sessionID: parentID) {
+                guard seen.insert(parent.id).inserted else { continue }
+                resolved.append(SessionSearchHit(summary: parent, snippet: hit.snippet, matchedSeq: nil))
+            } else {
+                guard seen.insert(hit.summary.id).inserted else { continue }
+                resolved.append(hit)
+            }
+        }
         guard generation == searchGeneration else { return }
-        hits = found
+        hits = resolved
+    }
+
+    private func scheduleDirectoryFilter() {
+        directoryFilterTask?.cancel()
+        directoryFilterTask = Task { [weak self] in
+            try? await Task.sleep(for: Self.searchDebounce)
+            guard let self, !Task.isCancelled else { return }
+            self.reloadSummaryPage(reset: true)
+            self.rerunSearch()
+        }
+    }
+
+    private var directoryIncludes: [String] { Self.pathTerms(directoryIncludeText) }
+    private var directoryExcludes: [String] { Self.pathTerms(directoryExcludeText) }
+
+    private static func pathTerms(_ text: String) -> [String] {
+        text.split { $0 == "," || $0 == ";" || $0.isNewline }
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
     }
 
     // MARK: - Rows
@@ -413,10 +490,22 @@ final class SessionManagerModel: ObservableObject {
         let needle = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
         let base: [Row]
         if !needle.isEmpty, !hits.isEmpty {
-            base = hits.map { Row(summary: $0.summary, snippet: $0.snippet, matchedSeq: $0.matchedSeq) }
+            base = hits.map {
+                Row(
+                    summary: $0.summary,
+                    snippet: $0.snippet,
+                    matchedSeq: $0.matchedSeq,
+                    reviewCount: reviewSummariesByParent[$0.summary.sessionID]?.count ?? 0
+                )
+            }
         } else {
             base = filteredSummaries(matching: needle).map {
-                Row(summary: $0, snippet: nil, matchedSeq: nil)
+                Row(
+                    summary: $0,
+                    snippet: nil,
+                    matchedSeq: nil,
+                    reviewCount: reviewSummariesByParent[$0.sessionID]?.count ?? 0
+                )
             }
         }
         rows = needle.isEmpty ? base : sorted(base.filter(passesFilters))
@@ -427,7 +516,7 @@ final class SessionManagerModel: ObservableObject {
         var order: [String] = []
         var buckets: [String: [Row]] = [:]
         for row in rows {
-            let key = projectTitle(row.summary.projectDir)
+            let key = projectTitle(for: row.summary)
             if buckets[key] == nil {
                 buckets[key] = []
                 order.append(key)
@@ -442,16 +531,39 @@ final class SessionManagerModel: ObservableObject {
         return URL(fileURLWithPath: projectDir).lastPathComponent
     }
 
+    static func projectTitle(for summary: SessionSummary) -> String {
+        if summary.provider == .codex, isGeneratedProjectlessPath(summary.projectDir) {
+            return "Projectless"
+        }
+        return projectTitle(summary.projectDir)
+    }
+
+    /// Codex Desktop creates a dated scratch cwd for a projectless task. The
+    /// state database has no `project_id` column, so this stable path shape is
+    /// the only on-disk distinction; the real cwd remains available in Details
+    /// and resume commands.
+    static func isGeneratedProjectlessPath(_ path: String?) -> Bool {
+        guard let path else { return false }
+        let components = URL(fileURLWithPath: path).standardizedFileURL.pathComponents
+        guard let codex = components.lastIndex(of: "Codex"), components.count == codex + 3 else {
+            return false
+        }
+        let date = components[codex + 1].split(separator: "-", omittingEmptySubsequences: false)
+        return date.count == 3 && date[0].count == 4 && date[1].count == 2 && date[2].count == 2
+            && date.allSatisfy { Int($0) != nil }
+    }
+
     private func filteredSummaries(matching needle: String) -> [SessionSummary] {
         guard !needle.isEmpty else { return summaries }
+        guard searchScopes.contains(.title) else { return [] }
         return summaries.filter { Self.matches($0, needle: needle) }
     }
 
-    /// Case- and diacritic-insensitive substring match across everything a
-    /// row shows plus the session id, which is what someone pasting an id
-    /// from a CLI log is searching for.
+    /// Immediate metadata preview while the debounced SQLite query is in
+    /// flight. It obeys the title scope exactly; project paths have their own
+    /// include/exclude controls and transcript roles are answered by FTS.
     static func matches(_ summary: SessionSummary, needle: String) -> Bool {
-        let fields = [summary.title, summary.summary, summary.projectDir, summary.sessionID]
+        let fields = [summary.title, summary.sessionID]
         for field in fields {
             guard let field else { continue }
             if field.range(of: needle, options: [.caseInsensitive, .diacriticInsensitive]) != nil {
@@ -479,7 +591,7 @@ final class SessionManagerModel: ObservableObject {
             // Key first, compare second: a localized comparison inside the
             // predicate would re-derive both project names on every swap.
             return rows
-                .map { (key: Self.projectTitle($0.summary.projectDir), row: $0) }
+                .map { (key: Self.projectTitle(for: $0.summary), row: $0) }
                 .sorted {
                     if $0.key != $1.key {
                         return $0.key.localizedStandardCompare($1.key) == .orderedAscending
@@ -528,6 +640,19 @@ final class SessionManagerModel: ObservableObject {
         harnessFilter = harnesses
     }
 
+    func toggleSearchScope(_ scope: SessionSearchScope) {
+        if searchScopes.contains(scope) {
+            searchScopes.remove(scope)
+        } else {
+            searchScopes.insert(scope)
+        }
+    }
+
+    func clearDirectoryFilters() {
+        directoryIncludeText = ""
+        directoryExcludeText = ""
+    }
+
     // MARK: - Selection
 
     /// Selecting a full-text hit carries the matched message with it, so the
@@ -554,9 +679,10 @@ final class SessionManagerModel: ObservableObject {
         }
         let generation = transcriptGeneration
         let url = URL(fileURLWithPath: summary.sourcePath)
+        let related = reviewSummariesByParent[summary.sessionID] ?? []
         isLoadingTranscript = true
         Task { [weak self] in
-            let parsed = await Self.parse(adapter: adapter, url: url)
+            let parsed = await Self.parse(adapter: adapter, url: url, related: related)
             guard let self, generation == self.transcriptGeneration else { return }
             self.isLoadingTranscript = false
             self.transcript = parsed.document
@@ -577,10 +703,45 @@ final class SessionManagerModel: ObservableObject {
     /// megabytes of JSONL and the window has to stay interactive through it.
     private nonisolated static func parse(
         adapter: any SessionProviderAdapter,
-        url: URL
+        url: URL,
+        related: [SessionSummary]
     ) async -> ParsedTranscript {
         do {
-            return ParsedTranscript(document: try adapter.parseTranscript(fileURL: url), errorMessage: nil)
+            let root = try adapter.parseTranscript(fileURL: url)
+            guard !related.isEmpty else {
+                return ParsedTranscript(document: root, errorMessage: nil)
+            }
+            var messages = root.messages
+            for review in related.sorted(by: {
+                ($0.createdAt ?? .distantPast) < ($1.createdAt ?? .distantPast)
+            }) {
+                guard let document = try? adapter.parseTranscript(
+                    fileURL: URL(fileURLWithPath: review.sourcePath)
+                ) else { continue }
+                messages.append(SessionMessage(
+                    seq: messages.count,
+                    role: .system,
+                    text: "Auto Review",
+                    timestamp: review.createdAt
+                ))
+                messages.append(contentsOf: document.messages)
+            }
+            let resequenced = messages.enumerated().map { index, message in
+                SessionMessage(
+                    seq: index,
+                    role: message.role,
+                    text: message.text,
+                    timestamp: message.timestamp
+                )
+            }
+            return ParsedTranscript(
+                document: TranscriptDocument(
+                    messages: resequenced,
+                    totalMessageCount: resequenced.count,
+                    truncated: false
+                ),
+                errorMessage: nil
+            )
         } catch {
             return ParsedTranscript(
                 document: nil,

--- a/Sources/VibeBarApp/Controllers/SessionManagerModel.swift
+++ b/Sources/VibeBarApp/Controllers/SessionManagerModel.swift
@@ -78,6 +78,7 @@ final class SessionManagerModel: ObservableObject {
         let summary: SessionSummary
         let snippet: String?
         let matchedSeq: Int?
+        let matchedRelated: SessionSummary?
         let reviewCount: Int
 
         var id: String { summary.id }
@@ -206,6 +207,7 @@ final class SessionManagerModel: ObservableObject {
     private var hasActivated = false
     private var lastScanFinishedAt: Date?
     private var reviewSummariesByParent: [String: [SessionSummary]] = [:]
+    private var relatedHitByParent: [String: SessionSummary] = [:]
 
     /// Floor between two automatic sweeps. A manual refresh ignores it.
     private static let rescanMinimumInterval: TimeInterval = 30
@@ -409,6 +411,7 @@ final class SessionManagerModel: ObservableObject {
         searchTask?.cancel()
         let needle = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !needle.isEmpty else {
+            relatedHitByParent = [:]
             hits = []
             return
         }
@@ -443,18 +446,25 @@ final class SessionManagerModel: ObservableObject {
         )) ?? []
         var resolved: [SessionSearchHit] = []
         var seen: Set<String> = []
+        var relatedHits: [String: SessionSummary] = [:]
         for hit in found {
             if let parentID = CodexSessionAdapter.autoReviewParentSessionID(
                 providerVariant: hit.summary.providerVariant
             ), let parent = try? await service.summary(provider: .codex, sessionID: parentID) {
                 guard seen.insert(parent.id).inserted else { continue }
-                resolved.append(SessionSearchHit(summary: parent, snippet: hit.snippet, matchedSeq: nil))
+                relatedHits[parent.id] = hit.summary
+                resolved.append(SessionSearchHit(
+                    summary: parent,
+                    snippet: hit.snippet,
+                    matchedSeq: hit.matchedSeq
+                ))
             } else {
                 guard seen.insert(hit.summary.id).inserted else { continue }
                 resolved.append(hit)
             }
         }
         guard generation == searchGeneration else { return }
+        relatedHitByParent = relatedHits
         hits = resolved
     }
 
@@ -495,6 +505,7 @@ final class SessionManagerModel: ObservableObject {
                     summary: $0.summary,
                     snippet: $0.snippet,
                     matchedSeq: $0.matchedSeq,
+                    matchedRelated: relatedHitByParent[$0.summary.id],
                     reviewCount: reviewSummariesByParent[$0.summary.sessionID]?.count ?? 0
                 )
             }
@@ -504,6 +515,7 @@ final class SessionManagerModel: ObservableObject {
                     summary: $0,
                     snippet: nil,
                     matchedSeq: nil,
+                    matchedRelated: nil,
                     reviewCount: reviewSummariesByParent[$0.sessionID]?.count ?? 0
                 )
             }
@@ -659,10 +671,18 @@ final class SessionManagerModel: ObservableObject {
     /// transcript opens on the line that produced the snippet instead of at
     /// the top of a session the user then has to search again by hand.
     func select(_ row: Row) {
-        select(row.summary, focusSeq: row.matchedSeq)
+        select(
+            row.summary,
+            focusSeq: row.matchedSeq,
+            focusedRelatedID: row.matchedRelated?.id
+        )
     }
 
-    func select(_ summary: SessionSummary?, focusSeq: Int? = nil) {
+    func select(
+        _ summary: SessionSummary?,
+        focusSeq: Int? = nil,
+        focusedRelatedID: String? = nil
+    ) {
         selection = summary
         self.focusSeq = focusSeq
         transcript = nil
@@ -682,9 +702,16 @@ final class SessionManagerModel: ObservableObject {
         let related = reviewSummariesByParent[summary.sessionID] ?? []
         isLoadingTranscript = true
         Task { [weak self] in
-            let parsed = await Self.parse(adapter: adapter, url: url, related: related)
+            let parsed = await Self.parse(
+                adapter: adapter,
+                url: url,
+                related: related,
+                requestedFocusSeq: focusSeq,
+                focusedRelatedID: focusedRelatedID
+            )
             guard let self, generation == self.transcriptGeneration else { return }
             self.isLoadingTranscript = false
+            self.focusSeq = parsed.focusSeq
             self.transcript = parsed.document
             self.transcriptError = parsed.errorMessage
         }
@@ -697,6 +724,7 @@ final class SessionManagerModel: ObservableObject {
     private struct ParsedTranscript: Sendable {
         let document: TranscriptDocument?
         let errorMessage: String?
+        let focusSeq: Int?
     }
 
     /// `nonisolated` so the parse runs off the main actor — a long rollout is
@@ -704,14 +732,17 @@ final class SessionManagerModel: ObservableObject {
     private nonisolated static func parse(
         adapter: any SessionProviderAdapter,
         url: URL,
-        related: [SessionSummary]
+        related: [SessionSummary],
+        requestedFocusSeq: Int?,
+        focusedRelatedID: String?
     ) async -> ParsedTranscript {
         do {
             let root = try adapter.parseTranscript(fileURL: url)
             guard !related.isEmpty else {
-                return ParsedTranscript(document: root, errorMessage: nil)
+                return ParsedTranscript(document: root, errorMessage: nil, focusSeq: requestedFocusSeq)
             }
             var messages = root.messages
+            var translatedFocus = focusedRelatedID == nil ? requestedFocusSeq : nil
             for review in related.sorted(by: {
                 ($0.createdAt ?? .distantPast) < ($1.createdAt ?? .distantPast)
             }) {
@@ -724,7 +755,13 @@ final class SessionManagerModel: ObservableObject {
                     text: "Auto Review",
                     timestamp: review.createdAt
                 ))
+                let childStart = messages.count
                 messages.append(contentsOf: document.messages)
+                if review.id == focusedRelatedID,
+                   let requestedFocusSeq,
+                   let childIndex = document.messages.firstIndex(where: { $0.seq == requestedFocusSeq }) {
+                    translatedFocus = childStart + childIndex
+                }
             }
             let resequenced = messages.enumerated().map { index, message in
                 SessionMessage(
@@ -740,13 +777,15 @@ final class SessionManagerModel: ObservableObject {
                     totalMessageCount: resequenced.count,
                     truncated: false
                 ),
-                errorMessage: nil
+                errorMessage: nil,
+                focusSeq: translatedFocus
             )
         } catch {
             return ParsedTranscript(
                 document: nil,
                 errorMessage: (error as? LocalizedError)?.errorDescription
-                    ?? "This session's log could not be read."
+                    ?? "This session's log could not be read.",
+                focusSeq: nil
             )
         }
     }

--- a/Sources/VibeBarApp/MiniQuotaWindowController.swift
+++ b/Sources/VibeBarApp/MiniQuotaWindowController.swift
@@ -32,6 +32,7 @@ final class MiniQuotaWindowController: NSObject, NSWindowDelegate {
     /// model in Settings left the window the same physical size with
     /// a lot of empty real estate on the right.
     private var settingsCancellable: AnyCancellable?
+    private var quotaCancellable: AnyCancellable?
     /// Last fingerprint we applied content size for, so we can skip
     /// the resize work when an unrelated settings field changes.
     private var lastSizingFingerprint: String?
@@ -64,8 +65,8 @@ final class MiniQuotaWindowController: NSObject, NSWindowDelegate {
         let panel = panel ?? makePanel(environment: environment)
         self.panel = panel
         let settings = environment.settingsStore.settings
-        applyStableContentSize(to: panel, settings: settings, preserveTopRight: false)
-        lastSizingFingerprint = Self.sizingFingerprint(for: settings)
+        applyStableContentSize(to: panel, settings: settings, environment: environment, preserveTopRight: false)
+        lastSizingFingerprint = Self.sizingFingerprint(for: settings, environment: environment)
         applySavedPositionOrDefault(to: panel, settings: settings)
         panel.orderFrontRegardless()
         markWasOpen(true)
@@ -84,20 +85,46 @@ final class MiniQuotaWindowController: NSObject, NSWindowDelegate {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] settings in
                 guard let self, let panel = self.panel, panel.isVisible else { return }
-                let fp = Self.sizingFingerprint(for: settings)
+                let fp = Self.sizingFingerprint(for: settings, environment: environment)
                 guard fp != self.lastSizingFingerprint else { return }
                 self.lastSizingFingerprint = fp
-                self.applyStableContentSize(to: panel, settings: settings, preserveTopRight: true)
+                self.applyStableContentSize(
+                    to: panel,
+                    settings: settings,
+                    environment: environment,
+                    preserveTopRight: true
+                )
+            }
+        quotaCancellable = environment.quotaService.$lastSuccessByAccount
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self, weak environment] _ in
+                guard let self, let environment else { return }
+                // `@Published` emits before the property assignment. Defer one
+                // main-loop turn so `environment.quota(for:)` reads the new map.
+                DispatchQueue.main.async { [weak self, weak environment] in
+                    guard let self, let environment, let panel = self.panel, panel.isVisible else { return }
+                    let settings = environment.settingsStore.settings
+                    let fp = Self.sizingFingerprint(for: settings, environment: environment)
+                    guard fp != self.lastSizingFingerprint else { return }
+                    self.lastSizingFingerprint = fp
+                    self.applyStableContentSize(
+                        to: panel,
+                        settings: settings,
+                        environment: environment,
+                        preserveTopRight: true
+                    )
+                }
             }
     }
 
     /// Stable identifier for everything `stableContentSize` reads.
     /// When this string changes we know we need to re-apply the
     /// content size; otherwise the re-render is a no-op.
-    static func sizingFingerprint(for settings: AppSettings) -> String {
+    static func sizingFingerprint(for settings: AppSettings, environment: AppEnvironment? = nil) -> String {
         let mini = settings.miniWindow
         let mode = mini.displayMode.rawValue
-        let ids = mini.fieldIds(for: mini.displayMode).joined(separator: ",")
+        let ids = visibleSelectedFieldIDs(settings: settings, environment: environment)
+            .sorted().joined(separator: ",")
         return "\(mode)|\(ids)"
     }
 
@@ -116,6 +143,8 @@ final class MiniQuotaWindowController: NSObject, NSWindowDelegate {
         }
         settingsCancellable?.cancel()
         settingsCancellable = nil
+        quotaCancellable?.cancel()
+        quotaCancellable = nil
         lastSizingFingerprint = nil
         panel = nil
     }
@@ -130,7 +159,10 @@ final class MiniQuotaWindowController: NSObject, NSWindowDelegate {
     }
 
     private func makePanel(environment: AppEnvironment) -> NSPanel {
-        let contentSize = Self.stableContentSize(for: environment.settingsStore.settings)
+        let contentSize = Self.stableContentSize(
+            for: environment.settingsStore.settings,
+            environment: environment
+        )
         let panel = NSPanel(
             contentRect: NSRect(origin: .zero, size: contentSize),
             styleMask: [.borderless, .nonactivatingPanel],
@@ -173,8 +205,13 @@ final class MiniQuotaWindowController: NSObject, NSWindowDelegate {
         return panel
     }
 
-    private func applyStableContentSize(to panel: NSPanel, settings: AppSettings, preserveTopRight: Bool) {
-        let contentSize = Self.stableContentSize(for: settings)
+    private func applyStableContentSize(
+        to panel: NSPanel,
+        settings: AppSettings,
+        environment: AppEnvironment,
+        preserveTopRight: Bool
+    ) {
+        let contentSize = Self.stableContentSize(for: settings, environment: environment)
         let current = panel.contentView?.bounds.size ?? panel.frame.size
         guard abs(current.width - contentSize.width) > 0.5 || abs(current.height - contentSize.height) > 0.5 else {
             return
@@ -256,7 +293,10 @@ final class MiniQuotaWindowController: NSObject, NSWindowDelegate {
         return "antigravity.\(bucketId)"
     }
 
-    private static func stableContentSize(for settings: AppSettings) -> NSSize {
+    private static func stableContentSize(
+        for settings: AppSettings,
+        environment: AppEnvironment? = nil
+    ) -> NSSize {
         let mini = settings.miniWindow
         let displayMode = mini.displayMode
         let cellWidth: CGFloat
@@ -307,7 +347,7 @@ final class MiniQuotaWindowController: NSObject, NSWindowDelegate {
         // subtracted rather than one.
         let companies = MenuBarFieldCatalog.subProviderGroups(
             for: ToolType.dedicatedCardProviders,
-            selectedFieldIds: Set(mini.fieldIds(for: displayMode))
+            selectedFieldIds: visibleSelectedFieldIDs(settings: settings, environment: environment)
         )
         var width: CGFloat = 0
         for company in companies {
@@ -334,6 +374,19 @@ final class MiniQuotaWindowController: NSObject, NSWindowDelegate {
             width: max(minWidth, min(width, max(screenMaxWidth, minWidth))),
             height: height
         )
+    }
+
+    private static func visibleSelectedFieldIDs(
+        settings: AppSettings,
+        environment: AppEnvironment?
+    ) -> Set<String> {
+        let mini = settings.miniWindow
+        let selected = mini.fieldIds(for: mini.displayMode)
+        guard let environment else { return Set(selected) }
+        return Set(selected.filter { fieldID in
+            guard let field = MenuBarFieldCatalog.field(id: fieldID) else { return false }
+            return environment.quota(for: field.tool)?.bucket(id: field.bucketId) != nil
+        })
     }
 
     private static func clampedFrame(_ frame: NSRect, preferredScreen: NSScreen?) -> NSRect {
@@ -424,7 +477,12 @@ final class MiniQuotaWindowController: NSObject, NSWindowDelegate {
         settings.miniWindow.toggleDisplayMode()
         environment.settingsStore.settings = settings
         if let panel {
-            applyStableContentSize(to: panel, settings: settings, preserveTopRight: true)
+            applyStableContentSize(
+                to: panel,
+                settings: settings,
+                environment: environment,
+                preserveTopRight: true
+            )
             persistOrigin()
         }
     }

--- a/Sources/VibeBarApp/Views/DebouncedSettingsTextField.swift
+++ b/Sources/VibeBarApp/Views/DebouncedSettingsTextField.swift
@@ -10,9 +10,12 @@ import SwiftUI
 /// Disk writes are already coalesced in `SettingsStore`; this coalesces the
 /// render fan-out the same way.
 ///
-/// The draft is committed on submit, on focus loss, after `idleDelay` of no
-/// typing, and on disappear — so closing the window or switching Settings
-/// section immediately after typing still keeps what was typed.
+/// The draft is committed on submit, after `idleDelay` of no typing, and on
+/// disappear — so closing the window or switching Settings section
+/// immediately after typing still keeps what was typed. Focus loss is
+/// deliberately *not* a synchronous commit: clicking from one of the many
+/// label fields into another must not publish global settings in the middle
+/// of AppKit's first-responder hand-off.
 ///
 /// Value semantics stay entirely with the binding: "" still means "remove the
 /// override", trimming still happens where it happened before. This view only
@@ -50,9 +53,6 @@ struct DebouncedSettingsTextField: View {
                 try? await Task.sleep(for: idleDelay)
                 guard !Task.isCancelled else { return }
                 commit()
-            }
-            .onChange(of: isFocused) { _, focused in
-                if !focused { commit() }
             }
             // An external write — a reset, a migration, another window — may
             // only replace text the user is not currently editing.

--- a/Sources/VibeBarApp/Views/EffectivePricingCatalogView.swift
+++ b/Sources/VibeBarApp/Views/EffectivePricingCatalogView.swift
@@ -52,18 +52,22 @@ struct EffectivePricingCatalogView: View {
                     .fixedSize()
             }
 
-            ScrollView([.horizontal, .vertical]) {
-                LazyVStack(spacing: 0) {
-                    pricingHeader
-                    ForEach(rows) { row in
-                        EffectivePricingRowView(
-                            row: row,
-                            isLocalOverride: localOverrideKeys.contains(row.normalizedKey)
-                        )
-                        Divider().opacity(0.45)
+            GeometryReader { proxy in
+                let columns = PricingColumns(tableWidth: proxy.size.width)
+                ScrollView([.horizontal, .vertical]) {
+                    LazyVStack(spacing: 0) {
+                        pricingHeader(columns: columns)
+                        ForEach(rows) { row in
+                            EffectivePricingRowView(
+                                row: row,
+                                isLocalOverride: localOverrideKeys.contains(row.normalizedKey),
+                                columns: columns
+                            )
+                            Divider().opacity(0.45)
+                        }
                     }
+                    .frame(width: columns.tableWidth, alignment: .topLeading)
                 }
-                .frame(minWidth: PricingColumns.minimumWidth, alignment: .topLeading)
             }
             .frame(height: 420)
             .background(Color.primary.opacity(0.018))
@@ -120,20 +124,25 @@ struct EffectivePricingCatalogView: View {
 
     /// Rendered straight from the column spec the rows use, so a width or an
     /// alignment cannot drift between the header and the table under it.
-    private var pricingHeader: some View {
+    private func pricingHeader(columns: PricingColumns) -> some View {
         HStack(spacing: PricingColumns.spacing) {
-            ForEach(PricingColumns.all) { column in
+            ForEach(columns.all) { column in
                 Text(column.title.uppercased())
-                    .font(.system(size: 9, weight: .semibold))
+                    .font(.system(size: 10, weight: .semibold))
                     .foregroundStyle(.tertiary)
-                    .tracking(0.45)
+                    .tracking(0.55)
                     .lineLimit(1)
                     .frame(width: column.width, alignment: column.frameAlignment)
             }
         }
         .padding(.horizontal, PricingColumns.horizontalInset)
         .frame(minHeight: 30)
-        .background(Color.primary.opacity(0.035))
+        .background(Color.primary.opacity(0.05))
+        .overlay(alignment: .bottom) {
+            Rectangle()
+                .fill(Color.primary.opacity(0.11))
+                .frame(height: 0.7)
+        }
     }
 }
 
@@ -163,34 +172,54 @@ private struct PricingColumn: Identifiable {
     }
 }
 
-private enum PricingColumns {
+private struct PricingColumns {
     static let spacing: CGFloat = 8
     static let horizontalInset: CGFloat = 10
 
-    static let provider = PricingColumn("Provider / SubProvider", 154)
-    static let model = PricingColumn("Model", 242)
-    static let input = PricingColumn("Input / 1M", 84, .trailing)
-    static let output = PricingColumn("Output / 1M", 84, .trailing)
-    static let cacheRead = PricingColumn("Cache read", 84, .trailing)
-    static let cacheWrite = PricingColumn("Cache write", 84, .trailing)
+    static let minimumProviderWidth: CGFloat = 210
+    static let minimumModelWidth: CGFloat = 300
+    static let priceWidth: CGFloat = 96
 
-    static let all: [PricingColumn] = [provider, model, input, output, cacheRead, cacheWrite]
+    let provider: PricingColumn
+    let model: PricingColumn
+    let input = PricingColumn("Input / 1M", Self.priceWidth, .trailing)
+    let output = PricingColumn("Output / 1M", Self.priceWidth, .trailing)
+    let cacheRead = PricingColumn("Cache read", Self.priceWidth, .trailing)
+    let cacheWrite = PricingColumn("Cache write", Self.priceWidth, .trailing)
+
+    init(tableWidth: CGFloat) {
+        let contentWidth = max(
+            Self.minimumContentWidth,
+            tableWidth - Self.horizontalInset * 2 - Self.spacing * 5
+        )
+        let extra = contentWidth - Self.minimumContentWidth
+        provider = PricingColumn(
+            "Provider / SubProvider",
+            Self.minimumProviderWidth + extra * 0.42
+        )
+        model = PricingColumn("Model", Self.minimumModelWidth + extra * 0.58)
+    }
+
+    var all: [PricingColumn] { [provider, model, input, output, cacheRead, cacheWrite] }
 
     /// Where the MODEL column starts. The threshold / override footnote under
     /// a row hangs off this rather than a hand-tuned inset, so it stays on the
     /// grid when a column width changes.
-    static let detailInset: CGFloat = provider.width + spacing
+    var detailInset: CGFloat { provider.width + Self.spacing }
 
     /// Narrower than this and the trailing price column clips, so the scroll
     /// surface never proposes less.
-    static let minimumWidth: CGFloat = all.reduce(
-        horizontalInset * 2 + spacing * CGFloat(all.count - 1)
-    ) { $0 + $1.width }
+    static let minimumContentWidth = minimumProviderWidth + minimumModelWidth + priceWidth * 4
+
+    var tableWidth: CGFloat {
+        all.reduce(Self.horizontalInset * 2 + Self.spacing * 5) { $0 + $1.width }
+    }
 }
 
 private struct EffectivePricingRowView: View {
     let row: EffectiveModelPricingRow
     let isLocalOverride: Bool
+    let columns: PricingColumns
 
     var body: some View {
         VStack(alignment: .leading, spacing: 4) {
@@ -210,8 +239,8 @@ private struct EffectivePricingRowView: View {
                     }
                 }
                 .frame(
-                    width: PricingColumns.provider.width,
-                    alignment: PricingColumns.provider.frameAlignment
+                    width: columns.provider.width,
+                    alignment: columns.provider.frameAlignment
                 )
 
                 VStack(alignment: .leading, spacing: 1) {
@@ -226,14 +255,14 @@ private struct EffectivePricingRowView: View {
                     }
                 }
                 .frame(
-                    width: PricingColumns.model.width,
-                    alignment: PricingColumns.model.frameAlignment
+                    width: columns.model.width,
+                    alignment: columns.model.frameAlignment
                 )
 
-                price(row.inputPerMillion, PricingColumns.input)
-                price(row.outputPerMillion, PricingColumns.output)
-                price(row.cacheReadPerMillion, PricingColumns.cacheRead)
-                price(row.cacheWritePerMillion, PricingColumns.cacheWrite)
+                price(row.inputPerMillion, columns.input)
+                price(row.outputPerMillion, columns.output)
+                price(row.cacheReadPerMillion, columns.cacheRead)
+                price(row.cacheWritePerMillion, columns.cacheWrite)
             }
 
             if let detail = advancedDetail {
@@ -248,12 +277,12 @@ private struct EffectivePricingRowView: View {
                         .foregroundStyle(.tertiary)
                         .lineLimit(1)
                 }
-                .padding(.leading, PricingColumns.detailInset)
+                .padding(.leading, columns.detailInset)
             } else if isLocalOverride {
                 Text("LOCAL OVERRIDE")
                     .font(.system(size: 8, weight: .bold))
                     .foregroundStyle(.blue)
-                    .padding(.leading, PricingColumns.detailInset)
+                    .padding(.leading, columns.detailInset)
             }
         }
         .padding(.horizontal, PricingColumns.horizontalInset)

--- a/Sources/VibeBarApp/Views/MiniQuotaWindowView.swift
+++ b/Sources/VibeBarApp/Views/MiniQuotaWindowView.swift
@@ -80,7 +80,9 @@ struct MiniQuotaWindowView: View {
                     let field = MenuBarFieldCatalog.field(id: fieldId),
                     field.tool == tool
                 else { continue }
-                let liveBucket = environment.quota(for: tool)?.bucket(id: field.bucketId)
+                guard let liveBucket = environment.quota(for: tool)?.bucket(id: field.bucketId) else {
+                    continue
+                }
                 if Self.hasQuotaGroup(liveBucket, tool: tool, bucketId: field.bucketId)
                     || isBranchField(field) {
                     continue
@@ -370,48 +372,7 @@ private struct MiniBranchCell: Identifiable {
     }
 
     var groupKey: String {
-        switch bucket.id {
-        case "gpt_5_3_codex_spark_five_hour", "gpt_5_3_codex_spark_weekly":
-            return "codex.spark"
-        case "weekly_sonnet":
-            return "claude.sonnet"
-        case "weekly_design":
-            return "claude.design"
-        case "daily_routines":
-            return "claude.routine"
-        case "weekly_opus":
-            return "claude.opus"
-        case "weekly_fable":
-            return "claude.fable"
-        case "weekly_oauth_apps":
-            return "claude.oauth"
-        case "models" where tool == .cursor:
-            return "cursor.models"
-        case "other_models" where tool == .cursor:
-            return "cursor.other-models"
-        case let id where tool == .antigravity && ["gemini_five_hour", "gemini_weekly"].contains(id):
-            return "antigravity.gemini-models"
-        case let id where tool == .antigravity && ["claude_gpt_five_hour", "claude_gpt_weekly"].contains(id):
-            return "antigravity.claude-gpt-models"
-        case let id where tool == .gemini && id.contains("flash-lite"):
-            return "gemini.flash-lite"
-        case let id where tool == .gemini && id.contains("flash"):
-            return "gemini.flash"
-        case let id where tool == .gemini && id.contains("pro"):
-            return "gemini.pro"
-        case let id where tool == .antigravity && id.contains("gpt-oss"):
-            return "antigravity.gpt-oss"
-        case let id where tool == .antigravity && id.contains("claude"):
-            return "antigravity.claude"
-        case let id where tool == .antigravity && id.contains("flash-lite"):
-            return "antigravity.gemini-flash-lite"
-        case let id where tool == .antigravity && id.contains("flash"):
-            return "antigravity.gemini-flash"
-        case let id where tool == .antigravity && id.contains("gemini") && id.contains("pro"):
-            return "antigravity.gemini-pro"
-        default:
-            return "\(tool.rawValue).\(field.bucketId)"
-        }
+        MiniWindowGroupLabelCatalog.groupKey(tool: tool, bucketId: bucket.id)
     }
 
     var defaultGroupTitle: String {
@@ -619,6 +580,15 @@ private func miniGroupTitle(for cell: MiniBranchCell, settings: MiniWindowSettin
     return cell.defaultGroupTitle
 }
 
+private func miniSubProviderTitle(for member: MiniL2Member, settings: MiniWindowSettings) -> String {
+    let key = MiniWindowGroupLabelCatalog.subProviderKey(
+        tool: member.tool,
+        name: member.subProviderName
+    )
+    let custom = settings.groupLabels[key]?.trimmingCharacters(in: .whitespacesAndNewlines)
+    return custom.flatMap { $0.isEmpty ? nil : $0 } ?? member.subProviderName
+}
+
 /// Heading for a SubProvider's primary (flat, ungrouped) buckets. Every
 /// entry resolves to a quota-group name — the SubProvider itself is printed
 /// one tier up by `MiniMemberStack`, so nothing here may name a product.
@@ -711,7 +681,7 @@ private struct MiniMemberStack: View {
 
     var body: some View {
         VStack(alignment: .center, spacing: MiniRingMetrics.subProviderLabelGap) {
-            Text(member.subProviderName.uppercased())
+            Text(miniSubProviderTitle(for: member, settings: settings).uppercased())
                 .font(.system(size: 8.5, weight: .semibold, design: .rounded))
                 .foregroundStyle(.secondary)
                 .tracking(1.2)
@@ -1176,7 +1146,7 @@ private struct MiniCompactMemberStack: View {
 
     var body: some View {
         VStack(alignment: .center, spacing: MiniCompactMetrics.subProviderLabelGap) {
-            Text(member.subProviderName.uppercased())
+            Text(miniSubProviderTitle(for: member, settings: settings).uppercased())
                 .font(.system(size: 7.5, weight: .semibold, design: .rounded))
                 .foregroundStyle(.secondary)
                 .tracking(1.2)

--- a/Sources/VibeBarApp/Views/MiniWindowGroupLabelCatalog.swift
+++ b/Sources/VibeBarApp/Views/MiniWindowGroupLabelCatalog.swift
@@ -1,4 +1,5 @@
 import Foundation
+import VibeBarCore
 
 struct MiniWindowGroupLabelOption: Identifiable, Hashable {
     let id: String
@@ -17,7 +18,7 @@ enum MiniWindowGroupLabelCatalog {
         .init(id: "claude.opus", title: "CLAUDE · Opus", defaultLabel: "Opus"),
         .init(id: "claude.fable", title: "CLAUDE · Fable", defaultLabel: "Fable"),
         .init(id: "claude.oauth", title: "CLAUDE · OAuth", defaultLabel: "OAuth"),
-.init(id: "gemini.pro", title: "GEMINI · Pro", defaultLabel: "Pro"),
+        .init(id: "gemini.pro", title: "GEMINI · Pro", defaultLabel: "Pro"),
         .init(id: "gemini.flash", title: "GEMINI · Flash", defaultLabel: "Flash"),
         .init(id: "gemini.flash-lite", title: "GEMINI · Flash Lite", defaultLabel: "Lite"),
         .init(id: "antigravity.gemini-models", title: "ANTIGRAVITY · Gemini Models", defaultLabel: "Gemini"),
@@ -31,5 +32,80 @@ enum MiniWindowGroupLabelCatalog {
 
     static func defaultLabel(for id: String) -> String? {
         all.first { $0.id == id }?.defaultLabel
+    }
+
+    static func groupKey(tool: ToolType, bucketId: String) -> String {
+        switch bucketId {
+        case "gpt_5_3_codex_spark_five_hour", "gpt_5_3_codex_spark_weekly": return "codex.spark"
+        case "weekly_sonnet": return "claude.sonnet"
+        case "weekly_design": return "claude.design"
+        case "daily_routines": return "claude.routine"
+        case "weekly_opus": return "claude.opus"
+        case "weekly_fable": return "claude.fable"
+        case "weekly_oauth_apps": return "claude.oauth"
+        case "models" where tool == .cursor: return "cursor.models"
+        case "other_models" where tool == .cursor: return "cursor.other-models"
+        default: break
+        }
+        let id = bucketId.lowercased()
+        if tool == .gemini {
+            if id.contains("flash-lite") { return "gemini.flash-lite" }
+            if id.contains("flash") { return "gemini.flash" }
+            if id.contains("pro") { return "gemini.pro" }
+        }
+        if tool == .antigravity {
+            if ["gemini_five_hour", "gemini_weekly"].contains(id) {
+                return "antigravity.gemini-models"
+            }
+            if ["claude_gpt_five_hour", "claude_gpt_weekly"].contains(id) {
+                return "antigravity.claude-gpt-models"
+            }
+            if id.contains("gpt-oss") { return "antigravity.gpt-oss" }
+            if id.contains("claude") { return "antigravity.claude" }
+            if id.contains("flash-lite") { return "antigravity.gemini-flash-lite" }
+            if id.contains("flash") { return "antigravity.gemini-flash" }
+            if id.contains("pro") { return "antigravity.gemini-pro" }
+        }
+        return "\(tool.rawValue).\(bucketId)"
+    }
+
+    static func subProviderKey(tool: ToolType, name: String) -> String {
+        "subprovider:\(tool.rawValue)/\(name)"
+    }
+
+    static var subProviderOptions: [MiniWindowGroupLabelOption] {
+        MenuBarFieldCatalog.subProviderGroups(
+            for: ToolType.dedicatedCardProviders,
+            selectedFieldIds: Set(MenuBarFieldCatalog.allFields.map(\.id))
+        ).flatMap { company in
+            company.subProviders.map { subProvider in
+                MiniWindowGroupLabelOption(
+                    id: subProviderKey(tool: subProvider.tool, name: subProvider.name),
+                    title: "\(company.company.uppercased()) · \(subProvider.name)",
+                    defaultLabel: subProvider.name
+                )
+            }
+        }
+    }
+
+    static func options(liveQuotas: [ToolType: AccountQuota]) -> [MiniWindowGroupLabelOption] {
+        var result = all
+        var ids = Set(result.map(\.id))
+        for tool in ToolType.dedicatedCardProviders {
+            for bucket in liveQuotas[tool]?.buckets ?? [] {
+                guard let rawGroup = bucket.groupTitle?.trimmingCharacters(in: .whitespacesAndNewlines),
+                      !rawGroup.isEmpty,
+                      rawGroup.caseInsensitiveCompare(tool.quotaSubProviderName(bucketID: bucket.id)) != .orderedSame
+                else { continue }
+                let id = groupKey(tool: tool, bucketId: bucket.id)
+                guard ids.insert(id).inserted else { continue }
+                result.append(MiniWindowGroupLabelOption(
+                    id: id,
+                    title: "\(tool.quotaSubProviderName(bucketID: bucket.id).uppercased()) · \(rawGroup)",
+                    defaultLabel: rawGroup
+                ))
+            }
+        }
+        return result
     }
 }

--- a/Sources/VibeBarApp/Views/SettingsView.swift
+++ b/Sources/VibeBarApp/Views/SettingsView.swift
@@ -109,6 +109,7 @@ struct SettingsView: View {
 
     @EnvironmentObject var environment: AppEnvironment
     @EnvironmentObject var settingsStore: SettingsStore
+    @EnvironmentObject var quotaService: QuotaService
 
     private let intervalOptions = AppSettings.refreshIntervalOptions
     private let popoverRefreshCooldownOptions: [Int] = [60, 120, 300, 600]
@@ -236,11 +237,19 @@ struct SettingsView: View {
                         }
                         Divider()
                             .padding(.vertical, 2)
-                        Text("Branch group names:")
+                        Text("SubProvider names:")
                             .font(.caption)
                             .foregroundStyle(.secondary)
                         VStack(alignment: .leading, spacing: 8) {
-                            ForEach(MiniWindowGroupLabelCatalog.all) { option in
+                            ForEach(MiniWindowGroupLabelCatalog.subProviderOptions) { option in
+                                miniGroupLabelRow(option)
+                            }
+                        }
+                        Text("Model group names:")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                        VStack(alignment: .leading, spacing: 8) {
+                            ForEach(miniGroupLabelOptions) { option in
                                 miniGroupLabelRow(option)
                             }
                         }
@@ -825,49 +834,36 @@ struct SettingsView: View {
     }
 
     private func miniFieldRow(_ field: MenuBarFieldOption) -> some View {
-        ViewThatFits(in: .horizontal) {
-            fieldRowHorizontal(
-                isOn: miniFieldSelectedBinding(field.id),
-                field: field,
-                label: miniFieldLabelBinding(field)
-            )
-            fieldRowWrapped(
-                isOn: miniFieldSelectedBinding(field.id),
-                field: field,
-                label: miniFieldLabelBinding(field)
-            )
-        }
+        fieldRowHorizontal(
+            isOn: miniFieldSelectedBinding(field.id),
+            field: field,
+            label: miniFieldLabelBinding(field)
+        )
     }
 
     private func miniGroupLabelRow(_ option: MiniWindowGroupLabelOption) -> some View {
-        ViewThatFits(in: .horizontal) {
-            HStack(spacing: 10) {
-                groupLabelText(option)
-                Spacer(minLength: 8)
-                groupLabelTextField(option)
-                    .frame(width: 130)
-            }
-            VStack(alignment: .leading, spacing: 6) {
-                groupLabelText(option)
-                groupLabelTextField(option)
-                    .frame(maxWidth: 180, alignment: .leading)
-            }
+        HStack(spacing: 10) {
+            groupLabelText(option)
+            Spacer(minLength: 8)
+            groupLabelTextField(option)
+                .frame(width: 130)
         }
     }
 
-    private func menuFieldRow(kind: MenuBarItemKind, field: MenuBarFieldOption) -> some View {
-        ViewThatFits(in: .horizontal) {
-            fieldRowHorizontal(
-                isOn: menuFieldSelectedBinding(kind, field.id),
-                field: field,
-                label: menuFieldLabelBinding(kind, field)
-            )
-            fieldRowWrapped(
-                isOn: menuFieldSelectedBinding(kind, field.id),
-                field: field,
-                label: menuFieldLabelBinding(kind, field)
-            )
+    private var miniGroupLabelOptions: [MiniWindowGroupLabelOption] {
+        var quotas: [ToolType: AccountQuota] = [:]
+        for tool in ToolType.dedicatedCardProviders {
+            if let quota = environment.quota(for: tool) { quotas[tool] = quota }
         }
+        return MiniWindowGroupLabelCatalog.options(liveQuotas: quotas)
+    }
+
+    private func menuFieldRow(kind: MenuBarItemKind, field: MenuBarFieldOption) -> some View {
+        fieldRowHorizontal(
+            isOn: menuFieldSelectedBinding(kind, field.id),
+            field: field,
+            label: menuFieldLabelBinding(kind, field)
+        )
     }
 
     /// Field-picker layout for a `MenuBarItemKind`. Overview lists
@@ -943,18 +939,6 @@ struct SettingsView: View {
             fieldToggle(isOn: isOn, field: field)
             Spacer(minLength: 8)
             fieldLabelTextField(field: field, label: label)
-        }
-    }
-
-    private func fieldRowWrapped(
-        isOn: Binding<Bool>,
-        field: MenuBarFieldOption,
-        label: Binding<String>
-    ) -> some View {
-        VStack(alignment: .leading, spacing: 6) {
-            fieldToggle(isOn: isOn, field: field)
-            fieldLabelTextField(field: field, label: label)
-                .frame(maxWidth: 180, alignment: .leading)
         }
     }
 

--- a/Sources/VibeBarApp/Views/Workbench/SessionListView.swift
+++ b/Sources/VibeBarApp/Views/Workbench/SessionListView.swift
@@ -264,7 +264,7 @@ private struct SessionRow: View {
     private var footer: some View {
         HStack(spacing: 6) {
             if let project = summary.projectDir {
-                Label(SessionManagerModel.projectTitle(project), systemImage: "folder")
+                Label(SessionManagerModel.projectTitle(for: summary), systemImage: "folder")
                     .labelStyle(.titleAndIcon)
                     .lineLimit(1)
                     .help(project)
@@ -281,6 +281,10 @@ private struct SessionRow: View {
                     .frame(minHeight: 14)
                     .background(Capsule().fill(Color.primary.opacity(0.07)))
                     .help("\(summary.messageCount) messages")
+            }
+            if row.reviewCount > 0 {
+                Label("\(row.reviewCount)", systemImage: "checkmark.bubble")
+                    .help(row.reviewCount == 1 ? "1 Auto Review merged" : "\(row.reviewCount) Auto Reviews merged")
             }
         }
         .font(.system(size: max(10, density.resetCountdownFontSize - 1)))

--- a/Sources/VibeBarApp/Views/Workbench/SessionManagerPage.swift
+++ b/Sources/VibeBarApp/Views/Workbench/SessionManagerPage.swift
@@ -116,10 +116,11 @@ struct SessionManagerPage: View {
 /// The filter unit is the **harness**, not the company: a row is labelled
 /// with the harness that produced it, and two harnesses can share one adapter
 /// (a Codex rollout is Codex or ChatGPT Work depending on its `originator`).
-/// Company names are intentionally absent from the chip row: they are parents
+/// Company names are intentionally separated from harnesses: they are parents
 /// in the billing hierarchy, not another peer filter beside Codex or Claude
-/// Code. Chips carry each harness's own brand accent; the rest stays in compact
-/// menus so a rarely-used control never outweighs the list. See AGENTS.md § 7.1.
+/// Code. Two compact menus provide company-wide and exact-harness controls
+/// without turning the toolbar into a long strip of mixed-level chips. See
+/// AGENTS.md § 7.1.
 struct SessionFiltersBar: View {
     let density: Theme.Density
     @ObservedObject var model: SessionManagerModel
@@ -142,9 +143,8 @@ struct SessionFiltersBar: View {
                     }
                     .help("Rescan the session logs on disk")
                     allProvidersChip
-                    ForEach(availableHarnesses, id: \.self) { harness in
-                        harnessChip(harness)
-                    }
+                    companyFilterMenu
+                    harnessFilterMenu
                     rangeMenu
                     sortMenu
                     optionsMenu
@@ -301,6 +301,13 @@ struct SessionFiltersBar: View {
         return Harness.allCases.filter { (counts[$0] ?? 0) > 0 }
     }
 
+    private var availableCompanyGroups: [Harness.ChipGroup] {
+        Harness.chipGroups(
+            companies: ToolType.coreProviderRepresentatives,
+            harnesses: availableHarnesses
+        )
+    }
+
     /// The All chip is a switch, not a shortcut: lit means every harness is
     /// listed and clicking it clears the selection outright; anything else
     /// and it puts every harness back.
@@ -322,44 +329,71 @@ struct SessionFiltersBar: View {
         .accessibilityAddTraits(selected ? [.isSelected] : [])
     }
 
-    /// One chip per harness — the unit a session row is actually labelled
-    /// with. The icon is the harness's own brand (Cursor's mark, not Grok's,
-    /// matching the badge in the list); the accent is the company's, so a
-    /// group still reads as one block of colour.
-    ///
-    /// ⌥-click solos, which is the one-click way to ask "just this harness"
-    /// without turning eight other chips off by hand.
-    private func harnessChip(_ harness: Harness) -> some View {
-        let selected = model.harnessFilter?.contains(harness) ?? true
-        let count = model.harnessCounts[harness] ?? 0
-        return Button {
-            if NSEvent.modifierFlags.contains(.option) {
-                model.soloHarness(harness)
-            } else {
-                model.toggleHarness(harness)
+    /// L1 companies and harnesses are separate compact menus: the company
+    /// remains a batch control, while the row no longer pretends OpenAI and
+    /// Codex are peers or consumes the entire toolbar with nine chips.
+    private var companyFilterMenu: some View {
+        Menu {
+            ForEach(availableCompanyGroups) { group in
+                Toggle(group.company.vendorName, isOn: Binding(
+                    get: { isSelected(group) },
+                    set: { _ in model.toggleHarnesses(group.harnessSet) }
+                ))
             }
         } label: {
-            HStack(spacing: 5) {
-                ToolBrandIconView(tool: harness.brandTool, size: density.segmentedFontSize + 1)
-                Text(harness.displayName)
-                    .font(.system(size: max(10, density.segmentedFontSize - 1), weight: .semibold))
-                    .lineLimit(1)
-                if count > 0 {
-                    Text("\(count)")
-                        .font(.system(size: max(8, density.segmentedFontSize - 3), design: .rounded)
-                            .monospacedDigit())
-                        .foregroundStyle(.secondary)
+            menuLabel(
+                systemImage: "building.2",
+                title: "Company",
+                detail: selectedCompanySummary
+            )
+        }
+        .menuStyle(.button)
+        .buttonStyle(WorkbenchPillButtonStyle())
+        .menuIndicator(.hidden)
+        .fixedSize()
+    }
+
+    private var harnessFilterMenu: some View {
+        Menu {
+            ForEach(availableHarnesses, id: \.self) { harness in
+                Toggle(isOn: Binding(
+                    get: { model.harnessFilter?.contains(harness) ?? true },
+                    set: { _ in model.toggleHarness(harness) }
+                )) {
+                    Label {
+                        Text("\(harness.displayName)  \(model.harnessCounts[harness] ?? 0)")
+                    } icon: {
+                        ToolBrandIconView(tool: harness.brandTool, size: 12)
+                    }
                 }
             }
-            .padding(.horizontal, 9)
-            .frame(minHeight: 28)
+        } label: {
+            menuLabel(
+                systemImage: "terminal",
+                title: "Harness",
+                detail: selectedHarnessSummary
+            )
         }
-        .buttonStyle(.plain)
-        .background(chipBackground(tint: Theme.providerAccent(for: harness.brandTool), selected: selected))
-        .opacity(selected ? 1 : 0.70)
-        .saturation(selected ? 1 : 0.50)
-        .help("\(harness.displayName)\nClick to toggle · ⌥-click to solo")
-        .accessibilityAddTraits(selected ? [.isSelected] : [])
+        .menuStyle(.button)
+        .buttonStyle(WorkbenchPillButtonStyle())
+        .menuIndicator(.hidden)
+        .fixedSize()
+    }
+
+    private func isSelected(_ group: Harness.ChipGroup) -> Bool {
+        guard let filter = model.harnessFilter else { return true }
+        return group.harnesses.allSatisfy(filter.contains)
+    }
+
+    private var selectedCompanySummary: String {
+        let selected = availableCompanyGroups.count(where: isSelected)
+        return selected == availableCompanyGroups.count ? "All" : "\(selected)/\(availableCompanyGroups.count)"
+    }
+
+    private var selectedHarnessSummary: String {
+        guard let filter = model.harnessFilter else { return "All" }
+        let count = availableHarnesses.count(where: filter.contains)
+        return count == availableHarnesses.count ? "All" : "\(count)/\(availableHarnesses.count)"
     }
 
     private func chipBackground(tint: Color, selected: Bool) -> some View {

--- a/Sources/VibeBarApp/Views/Workbench/SessionManagerPage.swift
+++ b/Sources/VibeBarApp/Views/Workbench/SessionManagerPage.swift
@@ -116,14 +116,14 @@ struct SessionManagerPage: View {
 /// The filter unit is the **harness**, not the company: a row is labelled
 /// with the harness that produced it, and two harnesses can share one adapter
 /// (a Codex rollout is Codex or ChatGPT Work depending on its `originator`).
-/// So each company contributes a muted section-head chip that toggles all of
-/// its harnesses at once, followed by one chip per harness. Chips carry the
-/// brand accent for the same reason the usage filters do — colour is how this
-/// app says "provider" — and the rest is glass menus so a rarely-used control
-/// never outweighs the list. See AGENTS.md § 7.1.
+/// Company names are intentionally absent from the chip row: they are parents
+/// in the billing hierarchy, not another peer filter beside Codex or Claude
+/// Code. Chips carry each harness's own brand accent; the rest stays in compact
+/// menus so a rarely-used control never outweighs the list. See AGENTS.md § 7.1.
 struct SessionFiltersBar: View {
     let density: Theme.Density
     @ObservedObject var model: SessionManagerModel
+    @State private var showsDirectoryFilters = false
 
     var body: some View {
         Group {
@@ -134,19 +134,16 @@ struct SessionFiltersBar: View {
             ScrollView(.horizontal) {
                 HStack(spacing: 7) {
                     searchField
+                    searchScopeMenu
+                    directoryFilterButton
                     indexStatus
                     SectionRefreshButton(isRefreshing: model.indexProgress != nil) {
                         model.refreshIndex()
                     }
                     .help("Rescan the session logs on disk")
                     allProvidersChip
-                    ForEach(chipGroups) { group in
-                        HStack(spacing: 4) {
-                            companyChip(group)
-                            ForEach(group.harnesses, id: \.self) { harness in
-                                harnessChip(harness, in: group)
-                            }
-                        }
+                    ForEach(availableHarnesses, id: \.self) { harness in
+                        harnessChip(harness)
                     }
                     rangeMenu
                     sortMenu
@@ -169,7 +166,7 @@ struct SessionFiltersBar: View {
             Image(systemName: "magnifyingglass")
                 .font(.system(size: density.segmentedFontSize - 1))
                 .foregroundStyle(.secondary)
-            TextField("Search titles, projects, and message text", text: $model.searchText)
+            TextField("Search sessions", text: $model.searchText)
                 .textFieldStyle(.plain)
                 .font(.system(size: max(12, density.segmentedFontSize)))
             if !model.searchText.isEmpty {
@@ -182,6 +179,83 @@ struct SessionFiltersBar: View {
         .frame(width: 270)
         .frame(minHeight: 30)
         .workbenchFieldSurface(cornerRadius: 15)
+    }
+
+    private var searchScopeMenu: some View {
+        Menu {
+            ForEach(SessionSearchScope.allCases, id: \.self) { scope in
+                Toggle(scopeTitle(scope), isOn: Binding(
+                    get: { model.searchScopes.contains(scope) },
+                    set: { _ in model.toggleSearchScope(scope) }
+                ))
+            }
+            Divider()
+            Text(model.isBodyIndexingEnabled
+                ? "Message text is indexed locally."
+                : "Enable message indexing in Options to search transcript content.")
+        } label: {
+            menuLabel(
+                systemImage: "text.magnifyingglass",
+                title: "Scope",
+                detail: "\(model.searchScopes.count)"
+            )
+        }
+        .menuStyle(.button)
+        .buttonStyle(WorkbenchPillButtonStyle())
+        .menuIndicator(.hidden)
+        .fixedSize()
+    }
+
+    private var directoryFilterButton: some View {
+        let active = !model.directoryIncludeText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            || !model.directoryExcludeText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        return Button {
+            showsDirectoryFilters.toggle()
+        } label: {
+            menuLabel(systemImage: "folder.badge.gearshape", title: "Folders", detail: active ? "Filtered" : "All")
+        }
+        .buttonStyle(WorkbenchPillButtonStyle(prominent: active))
+        .popover(isPresented: $showsDirectoryFilters, arrowEdge: .bottom) {
+            VStack(alignment: .leading, spacing: 12) {
+                Text("Directory filters")
+                    .font(.headline)
+                VStack(alignment: .leading, spacing: 5) {
+                    Text("Include paths containing")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    TextField("/project/a, /project/b", text: $model.directoryIncludeText)
+                        .textFieldStyle(.roundedBorder)
+                }
+                VStack(alignment: .leading, spacing: 5) {
+                    Text("Exclude paths containing")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    TextField("/archive, /vendor", text: $model.directoryExcludeText)
+                        .textFieldStyle(.roundedBorder)
+                }
+                Text("Separate multiple paths with commas, semicolons, or new lines.")
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+                HStack {
+                    Spacer()
+                    Button("Clear") { model.clearDirectoryFilters() }
+                    Button("Done") { showsDirectoryFilters = false }
+                        .buttonStyle(.borderedProminent)
+                }
+            }
+            .padding(16)
+            .frame(width: 360)
+        }
+    }
+
+    private func scopeTitle(_ scope: SessionSearchScope) -> String {
+        switch scope {
+        case .title: "Titles and session IDs"
+        case .user: "User prompts"
+        case .assistant: "Assistant replies"
+        case .system: "System prompts"
+        case .tool: "Tool and file operations"
+        }
     }
 
     @ViewBuilder
@@ -218,18 +292,13 @@ struct SessionFiltersBar: View {
 
     // MARK: - Harnesses
 
-    /// A company disappears from the row once the index proves it has no
-    /// sessions at all — but only once there *are* counts. Before the first
-    /// page lands, and whenever the index is unavailable, every company shows:
-    /// an empty filter row the user cannot recover from is worse than four
-    /// chips that turn out to be empty.
-    private var chipGroups: [Harness.ChipGroup] {
-        let groups = Harness.chipGroups(companies: ToolType.coreProviderRepresentatives)
+    /// Companies are hierarchy labels, not peers of harnesses. The filter row
+    /// therefore contains only the thing it actually filters: one chip per
+    /// harness, in catalog order. Empty harnesses disappear after counts load.
+    private var availableHarnesses: [Harness] {
         let counts = model.harnessCounts
-        guard counts.values.contains(where: { $0 > 0 }) else { return groups }
-        return groups.filter { group in
-            group.harnesses.contains { (counts[$0] ?? 0) > 0 }
-        }
+        guard counts.values.contains(where: { $0 > 0 }) else { return Harness.allCases }
+        return Harness.allCases.filter { (counts[$0] ?? 0) > 0 }
     }
 
     /// The All chip is a switch, not a shortcut: lit means every harness is
@@ -253,35 +322,6 @@ struct SessionFiltersBar: View {
         .accessibilityAddTraits(selected ? [.isSelected] : [])
     }
 
-    /// The company section head. Deliberately quieter than the harness chips
-    /// beside it — smaller, no count, barely any fill — because it is not one
-    /// more thing to filter by, it is a shortcut for the harnesses it covers.
-    private func companyChip(_ group: Harness.ChipGroup) -> some View {
-        let accent = Theme.providerAccent(for: group.company)
-        let selected = isSelected(group)
-        return Button {
-            model.toggleHarnesses(group.harnessSet)
-        } label: {
-            HStack(spacing: 4) {
-                ToolBrandIconView(tool: group.company, size: max(9, density.segmentedFontSize - 1))
-                Text(group.company.vendorName)
-                    .font(.system(size: max(9, density.segmentedFontSize - 2), weight: .semibold))
-                    .tracking(0.3)
-                    .lineLimit(1)
-            }
-            .foregroundStyle(.secondary)
-            .padding(.horizontal, 7)
-            .frame(minHeight: 28)
-        }
-        .buttonStyle(.plain)
-        .background(Capsule().fill(accent.opacity(selected ? 0.10 : 0.035)))
-        .opacity(selected ? 1 : 0.65)
-        .saturation(selected ? 1 : 0.50)
-        .help(companyHelp(group))
-        .accessibilityLabel("\(group.company.vendorName), every harness")
-        .accessibilityAddTraits(selected ? [.isSelected] : [])
-    }
-
     /// One chip per harness — the unit a session row is actually labelled
     /// with. The icon is the harness's own brand (Cursor's mark, not Grok's,
     /// matching the badge in the list); the accent is the company's, so a
@@ -289,7 +329,7 @@ struct SessionFiltersBar: View {
     ///
     /// ⌥-click solos, which is the one-click way to ask "just this harness"
     /// without turning eight other chips off by hand.
-    private func harnessChip(_ harness: Harness, in group: Harness.ChipGroup) -> some View {
+    private func harnessChip(_ harness: Harness) -> some View {
         let selected = model.harnessFilter?.contains(harness) ?? true
         let count = model.harnessCounts[harness] ?? 0
         return Button {
@@ -315,21 +355,11 @@ struct SessionFiltersBar: View {
             .frame(minHeight: 28)
         }
         .buttonStyle(.plain)
-        .background(chipBackground(tint: Theme.providerAccent(for: group.company), selected: selected))
+        .background(chipBackground(tint: Theme.providerAccent(for: harness.brandTool), selected: selected))
         .opacity(selected ? 1 : 0.70)
         .saturation(selected ? 1 : 0.50)
-        .help("\(group.company.vendorName) · \(harness.displayName)\nClick to toggle · ⌥-click to solo")
+        .help("\(harness.displayName)\nClick to toggle · ⌥-click to solo")
         .accessibilityAddTraits(selected ? [.isSelected] : [])
-    }
-
-    private func isSelected(_ group: Harness.ChipGroup) -> Bool {
-        guard let filter = model.harnessFilter else { return true }
-        return group.harnesses.allSatisfy(filter.contains)
-    }
-
-    private func companyHelp(_ group: Harness.ChipGroup) -> String {
-        let names = group.harnesses.map(\.displayName).joined(separator: " + ")
-        return "\(group.company.vendorName) · \(names)"
     }
 
     private func chipBackground(tint: Color, selected: Bool) -> some View {

--- a/Sources/VibeBarApp/Views/Workbench/TranscriptView.swift
+++ b/Sources/VibeBarApp/Views/Workbench/TranscriptView.swift
@@ -305,13 +305,6 @@ struct TranscriptView: View {
                 itemCount: document.messages.count,
                 start: messagePageStart
             )
-        expanded = Set(expanded.filter { seq in
-            guard let index = document.messages.firstIndex(where: { $0.seq == seq }) else { return false }
-            return TranscriptPageWindow.range(
-                itemCount: document.messages.count,
-                start: messagePageStart
-            ).contains(index)
-        })
         Task { @MainActor in
             try? await Task.sleep(for: .milliseconds(30))
             proxy.scrollTo(Self.pageAnchorID, anchor: .top)

--- a/Sources/VibeBarApp/Views/Workbench/TranscriptView.swift
+++ b/Sources/VibeBarApp/Views/Workbench/TranscriptView.swift
@@ -17,6 +17,9 @@ struct TranscriptView: View {
     @State private var expanded: Set<Int> = []
     @State private var highlighted: Int?
     @State private var showsOutline = false
+    @State private var messagePageStart = 0
+
+    private static let pageAnchorID = "transcript-page-anchor"
 
     var body: some View {
         Group {
@@ -62,7 +65,13 @@ struct TranscriptView: View {
                         if document.messages.isEmpty {
                             message("This session's log has no readable messages.", systemImage: "text.alignleft")
                         } else {
-                            ForEach(document.messages) { entry in
+                            transcriptPager(document: document, proxy: proxy)
+                                .id(Self.pageAnchorID)
+                            let range = TranscriptPageWindow.range(
+                                itemCount: document.messages.count,
+                                start: messagePageStart
+                            )
+                            ForEach(document.messages[range]) { entry in
                                 TranscriptMessageCard(
                                     density: density,
                                     message: entry,
@@ -97,12 +106,7 @@ struct TranscriptView: View {
         guard let seq = model.focusSeq, model.transcript != nil else { return }
         model.clearFocus()
         expanded.insert(seq)
-        // One turn of the run loop: the stack is lazy, and scrolling to an id
-        // in the same pass that introduced it lands on nothing.
-        Task {
-            try? await Task.sleep(for: .milliseconds(60))
-            scroll(to: seq, proxy: proxy)
-        }
+        scroll(to: seq, proxy: proxy)
     }
 
     private var placeholder: some View {
@@ -213,12 +217,30 @@ struct TranscriptView: View {
     }
 
     private func scroll(to seq: Int, proxy: ScrollViewProxy) {
-        if reduceMotion {
-            proxy.scrollTo(seq, anchor: .top)
-        } else {
-            withAnimation(.easeOut(duration: 0.2)) {
+        guard let document = model.transcript,
+              let index = document.messages.firstIndex(where: { $0.seq == seq })
+        else { return }
+        let start = TranscriptPageWindow.start(
+            containingItemAt: index,
+            itemCount: document.messages.count
+        )
+        let performScroll = {
+            if reduceMotion {
                 proxy.scrollTo(seq, anchor: .top)
+            } else {
+                withAnimation(.easeOut(duration: 0.2)) {
+                    proxy.scrollTo(seq, anchor: .top)
+                }
             }
+        }
+        if start != messagePageStart {
+            messagePageStart = start
+            Task { @MainActor in
+                try? await Task.sleep(for: .milliseconds(60))
+                performScroll()
+            }
+        } else {
+            performScroll()
         }
         flash(seq)
     }
@@ -245,6 +267,55 @@ struct TranscriptView: View {
         expanded = []
         highlighted = nil
         showsOutline = false
+        messagePageStart = 0
+    }
+
+    private func transcriptPager(document: TranscriptDocument, proxy: ScrollViewProxy) -> some View {
+        let range = TranscriptPageWindow.range(
+            itemCount: document.messages.count,
+            start: messagePageStart
+        )
+        return HStack(spacing: 8) {
+            Text("Messages \(range.lowerBound + 1)–\(range.upperBound) of \(document.messages.count)")
+                .font(.system(size: max(10, density.resetCountdownFontSize), design: .rounded)
+                    .monospacedDigit())
+                .foregroundStyle(.tertiary)
+            Spacer(minLength: 8)
+            Button("Previous") {
+                movePage(direction: -1, document: document, proxy: proxy)
+            }
+            .disabled(range.lowerBound == 0)
+            Button("Next") {
+                movePage(direction: 1, document: document, proxy: proxy)
+            }
+            .disabled(range.upperBound == document.messages.count)
+        }
+        .buttonStyle(.bordered)
+        .controlSize(.small)
+        .padding(.bottom, 2)
+    }
+
+    private func movePage(direction: Int, document: TranscriptDocument, proxy: ScrollViewProxy) {
+        messagePageStart = direction < 0
+            ? TranscriptPageWindow.previousStart(
+                itemCount: document.messages.count,
+                start: messagePageStart
+            )
+            : TranscriptPageWindow.nextStart(
+                itemCount: document.messages.count,
+                start: messagePageStart
+            )
+        expanded = Set(expanded.filter { seq in
+            guard let index = document.messages.firstIndex(where: { $0.seq == seq }) else { return false }
+            return TranscriptPageWindow.range(
+                itemCount: document.messages.count,
+                start: messagePageStart
+            ).contains(index)
+        })
+        Task { @MainActor in
+            try? await Task.sleep(for: .milliseconds(30))
+            proxy.scrollTo(Self.pageAnchorID, anchor: .top)
+        }
     }
 
     // MARK: - Outline
@@ -304,7 +375,7 @@ struct SessionMetadataHeader: View {
     var body: some View {
         VStack(alignment: .leading, spacing: max(7, density.cardSpacing)) {
             HStack(alignment: .center, spacing: 10) {
-                ToolBrandBadge(tool: summary.provider.tool, iconSize: 20, containerSize: 26)
+                ToolBrandBadge(tool: summary.effectiveHarness.brandTool, iconSize: 20, containerSize: 26)
                 VStack(alignment: .leading, spacing: 3) {
                     Text(title)
                         .font(.system(size: density.titleFontSize, weight: .semibold))
@@ -335,7 +406,7 @@ struct SessionMetadataHeader: View {
                 .frame(minHeight: 18)
                 .background(Capsule().fill(summary.provider.accent.opacity(0.16)))
             if let project = summary.projectDir {
-                Label(SessionManagerModel.projectTitle(project), systemImage: "folder")
+                Label(SessionManagerModel.projectTitle(for: summary), systemImage: "folder")
                     .lineLimit(1)
                     .help(project)
             }
@@ -421,9 +492,9 @@ struct SessionMetadataHeader: View {
 
     private var providerLabel: String {
         guard let variant = summary.providerVariant, !variant.isEmpty else {
-            return summary.provider.displayName
+            return summary.effectiveHarness.displayName
         }
-        return "\(summary.provider.displayName) · \(variant)"
+        return "\(summary.effectiveHarness.displayName) · \(variant)"
     }
 
     // MARK: - Facts
@@ -434,7 +505,11 @@ struct SessionMetadataHeader: View {
                 model.copyToClipboard(summary.sessionID, note: "Session ID copied.")
             }
             if let project = summary.projectDir {
-                factRow(label: "CWD", monospaced: true, value: project) {
+                factRow(
+                    label: "CWD",
+                    monospaced: !SessionManagerModel.isGeneratedProjectlessPath(project),
+                    value: SessionManagerModel.isGeneratedProjectlessPath(project) ? "Projectless" : project
+                ) {
                     model.copyToClipboard(project, note: "Working directory copied.")
                 }
             }
@@ -661,10 +736,13 @@ struct TranscriptMessageCard: View {
     /// stack becomes a layout storm. Copy lives on the header button and the
     /// context menu; search hits are still highlighted.
     private func body(text: String) -> some View {
-        Text(TranscriptFormatting.highlighted(text, query: query, accent: accent))
+        let needle = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        let rendered = needle.isEmpty
+            ? Text(text)
+            : Text(TranscriptFormatting.highlighted(text, query: needle, accent: accent))
+        return rendered
             .font(.system(size: density.subtitleFontSize, design: isMonospaced ? .monospaced : .default))
             .foregroundStyle(message.role == .system ? .secondary : .primary)
-            .fixedSize(horizontal: false, vertical: true)
             .frame(maxWidth: .infinity, alignment: .leading)
     }
 

--- a/Sources/VibeBarApp/Views/Workbench/UsageBreakdownTables.swift
+++ b/Sources/VibeBarApp/Views/Workbench/UsageBreakdownTables.swift
@@ -48,7 +48,7 @@ struct UsageBreakdownTables: View {
                             .font(.system(size: 10.5, weight: .semibold))
                             .foregroundStyle(selected ? Color.primary : Color.secondary)
                             .padding(.horizontal, 11)
-                            .frame(minHeight: 27)
+                            .frame(minWidth: 72, minHeight: 28)
                             .background(
                                 RoundedRectangle(cornerRadius: 8, style: .continuous)
                                     .fill(selected
@@ -64,8 +64,10 @@ struct UsageBreakdownTables: View {
                                         lineWidth: Theme.Card.hairlineWidth
                                     )
                             )
+                            .contentShape(Rectangle())
                     }
                     .buttonStyle(.plain)
+                    .contentShape(Rectangle())
                     .accessibilityLabel(value.title)
                     .accessibilityAddTraits(selected ? [.isSelected] : [])
                 }
@@ -187,42 +189,44 @@ struct UsageBreakdownTables: View {
     /// realized more rows, which fired again. Paging is an explicit button
     /// now; nothing chains.
     private var requestsTable: some View {
-        let columns = RequestColumns()
-        return ScrollView([.horizontal, .vertical], showsIndicators: true) {
-            LazyVStack(spacing: 0, pinnedViews: [.sectionHeaders]) {
-                Section {
-                    ForEach(model.requestRows) { row in
-                        let time = timestamp(row.date)
-                        let modelName = UsageModelNaming.canonicalDisplayName(row.model)
-                        PorcelainUsageRow(
-                            accessibilityLabel: requestAccessibilityLabel(
-                                row, time: time, model: modelName
-                            )
-                        ) {
-                            valueCell(time, columns.time, secondary: true)
-                            harnessCell(row.harness, columns.harness)
-                            valueCell(modelName, columns.model, tooltip: row.model)
-                            inputCell(row, columns.input)
-                            numericCell(row.output, columns.output)
-                            optionalMoneyCell(row.costMicros, columns.cost)
-                            valueCell(row.serviceTier ?? "—", columns.tier, secondary: true)
+        GeometryReader { proxy in
+            let columns = RequestColumns(tableWidth: proxy.size.width)
+            ScrollView([.horizontal, .vertical], showsIndicators: true) {
+                LazyVStack(spacing: 0, pinnedViews: [.sectionHeaders]) {
+                    Section {
+                        ForEach(model.requestRows) { row in
+                            let time = timestamp(row.date)
+                            let modelName = UsageModelNaming.canonicalDisplayName(row.model)
+                            PorcelainUsageRow(
+                                accessibilityLabel: requestAccessibilityLabel(
+                                    row, time: time, model: modelName
+                                )
+                            ) {
+                                valueCell(time, columns.time, secondary: true)
+                                harnessCell(row.harness, columns.harness)
+                                valueCell(modelName, columns.model, tooltip: row.model)
+                                inputCell(row, columns.input)
+                                numericCell(row.output, columns.output)
+                                optionalMoneyCell(row.costMicros, columns.cost)
+                                valueCell(row.serviceTier ?? "—", columns.tier, secondary: true)
+                            }
                         }
+                        if model.hasMoreRequests { loadMoreRow }
+                    } header: {
+                        // Same column spec and the same `UsageTableMetrics`
+                        // inset as the rows: a pinned header sits in its own
+                        // layout pass, so nothing else keeps the two in step.
+                        tableHeader(columns.all)
+                            // Opaque: a pinned header floats over the rows it
+                            // labels, and flat surfaces cast no shadow to
+                            // separate them.
+                            .background(WorkbenchPorcelain.overlayFill(for: colorScheme))
                     }
-                    if model.hasMoreRequests { loadMoreRow }
-                } header: {
-                    // Same column spec and the same `UsageTableMetrics`
-                    // inset as the rows: a pinned header sits in its own
-                    // layout pass, so nothing else keeps the two in step.
-                    tableHeader(columns.all)
-                        // Opaque: a pinned header floats over the rows it
-                        // labels, and flat surfaces cast no shadow to
-                        // separate them.
-                        .background(WorkbenchPorcelain.overlayFill(for: colorScheme))
                 }
+                .frame(width: columns.tableWidth, alignment: .leading)
             }
-            .frame(minWidth: columns.minimumWidth, alignment: .leading)
+            .accessibilityLabel("Request usage table")
         }
-        .accessibilityLabel("Request usage table")
         .frame(height: requestsViewportHeight)
     }
 
@@ -706,19 +710,34 @@ private struct ModelColumns {
     var all: [UsageTableColumn] { [model, requests, tokens, cost, average] }
 }
 
-/// Requests is the one fixed-width table — a request carries seven useful
-/// fields and compressing it would erase the model or the tier — so it scrolls
-/// horizontally instead of flexing.
+/// Requests fills the Workbench at ordinary widths and falls back to a
+/// horizontal scroller only when the viewport is narrower than its honest
+/// seven-column minimum. Descriptive columns absorb the extra room; numeric
+/// columns stay stable.
 private struct RequestColumns {
-    let time = UsageTableColumn("Time", 138)
-    let harness = UsageTableColumn("Harness", 138)
-    let model = UsageTableColumn("Model", 220)
+    static let minimumContentWidth: CGFloat = 138 + 138 + 220 + 114 + 88 + 96 + 86
+
+    let time: UsageTableColumn
+    let harness: UsageTableColumn
+    let model: UsageTableColumn
     let input = UsageTableColumn("Input", 114, .trailing)
     let output = UsageTableColumn("Output", 88, .trailing)
     let cost = UsageTableColumn("Cost", 96, .trailing)
-    let tier = UsageTableColumn("Tier", 86)
+    let tier: UsageTableColumn
+
+    init(tableWidth: CGFloat) {
+        let contentWidth = max(
+            Self.minimumContentWidth,
+            tableWidth - UsageTableMetrics.horizontalInset * 2
+        )
+        let extra = contentWidth - Self.minimumContentWidth
+        time = UsageTableColumn("Time", 138 + extra * 0.12)
+        harness = UsageTableColumn("Harness", 138 + extra * 0.20)
+        model = UsageTableColumn("Model", 220 + extra * 0.50)
+        tier = UsageTableColumn("Tier", 86 + extra * 0.18)
+    }
 
     var all: [UsageTableColumn] { [time, harness, model, input, output, cost, tier] }
 
-    var minimumWidth: CGFloat { all.totalWidth }
+    var tableWidth: CGFloat { all.totalWidth }
 }

--- a/Sources/VibeBarCore/Adapters/AntigravityQuotaAdapter.swift
+++ b/Sources/VibeBarCore/Adapters/AntigravityQuotaAdapter.swift
@@ -147,11 +147,20 @@ public struct AntigravityQuotaAdapter: QuotaAdapter {
     static func fetchLocalSnapshot(
         request: (_ path: String, _ body: Data) async throws -> Data
     ) async throws -> AntigravityResponseParser.Snapshot {
-        let quotaData = try await request(
-            Self.quotaSummaryPath,
-            Data(#"{"forceRefresh":true}"#.utf8)
-        )
-        let quotaSnapshot = try AntigravityResponseParser.parseQuotaSummary(data: quotaData)
+        var quotaSnapshot: AntigravityResponseParser.Snapshot?
+        var quotaError: Error?
+        do {
+            let quotaData = try await request(
+                Self.quotaSummaryPath,
+                Data(#"{"forceRefresh":true}"#.utf8)
+            )
+            quotaSnapshot = try AntigravityResponseParser.parseQuotaSummary(data: quotaData)
+        } catch {
+            // When a weekly pool is exhausted some server builds omit the
+            // entire summary group. GetUserStatus can still expose the live
+            // per-model five-hour lane, so do not return before asking it.
+            quotaError = error
+        }
 
         let identitySnapshot: AntigravityResponseParser.Snapshot?
         do {
@@ -161,7 +170,9 @@ public struct AntigravityQuotaAdapter: QuotaAdapter {
             // Quotas remain useful when this older endpoint is unavailable.
             identitySnapshot = nil
         }
-        return quotaSnapshot.merging(identitySnapshot)
+        if let quotaSnapshot { return quotaSnapshot.merging(identitySnapshot) }
+        if let identitySnapshot, !identitySnapshot.buckets.isEmpty { return identitySnapshot }
+        throw quotaError ?? QuotaError.parseFailure("Antigravity returned no usable quota lanes.")
     }
 
     /// Reads the persisted `antigravityUsageMode` setting from disk.

--- a/Sources/VibeBarCore/Models/TranscriptPageWindow.swift
+++ b/Sources/VibeBarCore/Models/TranscriptPageWindow.swift
@@ -1,0 +1,60 @@
+import Foundation
+
+/// Bounds the number of variable-height transcript cards SwiftUI lays out in
+/// one pass. A `LazyVStack` still has to place enough children to resolve its
+/// scroll geometry; feeding it thousands of message rows can pin the main
+/// thread in AttributeGraph even though only a handful are visible.
+public enum TranscriptPageWindow {
+    public static let defaultPageSize = 80
+
+    public static func range(
+        itemCount: Int,
+        start: Int,
+        pageSize: Int = defaultPageSize
+    ) -> Range<Int> {
+        let count = max(0, itemCount)
+        let size = max(1, pageSize)
+        let lower = clampedStart(itemCount: count, start: start, pageSize: size)
+        return lower..<min(count, lower + size)
+    }
+
+    public static func start(
+        containingItemAt index: Int,
+        itemCount: Int,
+        pageSize: Int = defaultPageSize
+    ) -> Int {
+        let count = max(0, itemCount)
+        guard count > 0 else { return 0 }
+        let size = max(1, pageSize)
+        let clampedIndex = min(max(0, index), count - 1)
+        return (clampedIndex / size) * size
+    }
+
+    public static func previousStart(
+        itemCount: Int,
+        start: Int,
+        pageSize: Int = defaultPageSize
+    ) -> Int {
+        let size = max(1, pageSize)
+        let current = clampedStart(itemCount: max(0, itemCount), start: start, pageSize: size)
+        return max(0, current - size)
+    }
+
+    public static func nextStart(
+        itemCount: Int,
+        start: Int,
+        pageSize: Int = defaultPageSize
+    ) -> Int {
+        let count = max(0, itemCount)
+        let size = max(1, pageSize)
+        let current = clampedStart(itemCount: count, start: start, pageSize: size)
+        guard current + size < count else { return current }
+        return current + size
+    }
+
+    private static func clampedStart(itemCount: Int, start: Int, pageSize: Int) -> Int {
+        guard itemCount > 0 else { return 0 }
+        let lastPage = ((itemCount - 1) / pageSize) * pageSize
+        return min(max(0, start), lastPage)
+    }
+}

--- a/Tests/VibeBarCoreTests/AntigravityParserTests.swift
+++ b/Tests/VibeBarCoreTests/AntigravityParserTests.swift
@@ -253,6 +253,32 @@ final class AntigravityParserTests: XCTestCase {
         XCTAssertEqual(snapshot.buckets.last?.usedPercent, 100)
     }
 
+    func testFetchLocalSnapshotKeepsFiveHourWhenExhaustedWeeklySummaryVanishes() async throws {
+        let identity = """
+        {
+          "code": 0,
+          "userStatus": {
+            "cascadeModelConfigData": {
+              "clientModelConfigs": [{
+                "label": "Claude Sonnet 4.6",
+                "modelOrAlias": {"model": "MODEL_PLACEHOLDER_M35"},
+                "quotaInfo": {"remainingFraction": 0.61, "resetTime": "1800018000"}
+              }]
+            }
+          }
+        }
+        """
+        let snapshot = try await AntigravityQuotaAdapter.fetchLocalSnapshot { path, _ in
+            if path.contains("RetrieveUserQuotaSummary") {
+                return Data(#"{"groups":[]}"#.utf8)
+            }
+            return Data(identity.utf8)
+        }
+
+        XCTAssertEqual(snapshot.buckets.map(\.id), ["claude_gpt_five_hour"])
+        XCTAssertEqual(snapshot.buckets.first?.remainingPercent ?? -1, 61, accuracy: 0.001)
+    }
+
     func testUserStatusProvidesIdentityLabelsAndFiveHourFallback() throws {
         let json = """
         {

--- a/Tests/VibeBarCoreTests/TranscriptPageWindowTests.swift
+++ b/Tests/VibeBarCoreTests/TranscriptPageWindowTests.swift
@@ -1,0 +1,28 @@
+import XCTest
+@testable import VibeBarCore
+
+final class TranscriptPageWindowTests: XCTestCase {
+    func testRangeBoundsAndClampsAWindow() {
+        XCTAssertEqual(TranscriptPageWindow.range(itemCount: 0, start: 0), 0..<0)
+        XCTAssertEqual(TranscriptPageWindow.range(itemCount: 200, start: 0), 0..<80)
+        XCTAssertEqual(TranscriptPageWindow.range(itemCount: 200, start: 80), 80..<160)
+        XCTAssertEqual(TranscriptPageWindow.range(itemCount: 200, start: 160), 160..<200)
+        XCTAssertEqual(TranscriptPageWindow.range(itemCount: 200, start: 10_000), 160..<200)
+        XCTAssertEqual(TranscriptPageWindow.range(itemCount: 10, start: -20), 0..<10)
+    }
+
+    func testContainingItemChoosesItsPage() {
+        XCTAssertEqual(TranscriptPageWindow.start(containingItemAt: 0, itemCount: 200), 0)
+        XCTAssertEqual(TranscriptPageWindow.start(containingItemAt: 79, itemCount: 200), 0)
+        XCTAssertEqual(TranscriptPageWindow.start(containingItemAt: 80, itemCount: 200), 80)
+        XCTAssertEqual(TranscriptPageWindow.start(containingItemAt: 199, itemCount: 200), 160)
+        XCTAssertEqual(TranscriptPageWindow.start(containingItemAt: 999, itemCount: 200), 160)
+    }
+
+    func testPreviousAndNextStopAtTheEdges() {
+        XCTAssertEqual(TranscriptPageWindow.previousStart(itemCount: 200, start: 0), 0)
+        XCTAssertEqual(TranscriptPageWindow.previousStart(itemCount: 200, start: 160), 80)
+        XCTAssertEqual(TranscriptPageWindow.nextStart(itemCount: 200, start: 0), 80)
+        XCTAssertEqual(TranscriptPageWindow.nextStart(itemCount: 200, start: 160), 160)
+    }
+}


### PR DESCRIPTION
## Summary
- page transcript rendering to stop SwiftUI layout storms and merge Codex Auto Review runs into their root session
- add Projectless labeling, correct ChatGPT Work identity, recover Cowork project paths, simplify harness chips, and add scoped content plus directory filters
- make AntiGravity metadata bounded and preserve five-hour quota when exhausted weekly summaries disappear
- size mini window from live buckets, allow SubProvider and dynamic group naming, and remove synchronous focus-loss settings writes
- let Requests and Effective Pricing tables fill their cards and make segmented controls fully clickable
- bump agent-session-kit to exact 0.4.1

## Verification
- clean public-tag resolution of agent-session-kit 0.4.1
- full Vibe Bar suite passed: 1,554 tests, 1 existing skip, 0 failures
- Swift app target builds successfully