### PR TITLE
Prepare Vibe Bar 1.3.0 Dev build 38

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.3.0</string>
 	<key>CFBundleVersion</key>
-	<string>37</string>
+	<string>38</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>26.0</string>
 	<key>LSUIElement</key>


### PR DESCRIPTION
## Summary
- bump CFBundleVersion from 37 to 38 for the next Dev channel release
- keep CFBundleShortVersionString at 1.3.0

## Verification
- combined main suite passed: 1,563 tests, 1 existing skip, 0 failures
- release bundle built and strict deep signature verification passed
- no app sandbox entitlement
- packaged Info.plist reads 1.3.0 build 38
- bundled pricing resource present