### PR TITLE
fix(session-index): bound rebuild memory

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -160,7 +160,7 @@ there, not in the package.
 
 **Where it comes from.** `Package.swift` pins the package to an exact
 tag on GitHub (`.package(url: "https://github.com/AstroQore/agent-session-kit.git",
-exact: "0.4.1")`), so a plain clone builds and a release build resolves the
+exact: "0.4.2")`), so a plain clone builds and a release build resolves the
 same package the developer built against — `Package.resolved` is
 gitignored here, and the exact pin is what stands in for it.
 

--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
         // from a clean checkout with no Package.resolved (it is gitignored),
         // so the pin is the only thing that makes two builds of the same
         // Vibe Bar commit contain the same package. Bump it deliberately.
-        .package(url: "https://github.com/AstroQore/agent-session-kit.git", exact: "0.4.1"),
+        .package(url: "https://github.com/AstroQore/agent-session-kit.git", exact: "0.4.2"),
         // SweetCookieKit encapsulates the Chromium SQLite parsing, "Chrome
         // Safe Storage" Keychain decryption, and Safari binarycookies /
         // Firefox SQLite reads that the misc-providers feature needs.


### PR DESCRIPTION
## Summary
- bump the exact agent-session-kit pin from 0.4.1 to 0.4.2
- rebuild the complete schema-v5 FTS session index in bounded 4 MiB / 128-session transactions
- preserve all existing title, user, assistant, system, tool, file-operation, snippet, and jump semantics

## Incident evidence
- build 38 reached a 22.8 GiB physical-footprint peak while SessionIndexStore.replaceMessages was flushing/merging FTS5 segments
- the derived index had 10,649 sessions and 667,234 message excerpts; one transaction per session created the pathological merge layout

## Verification
- agent-session-kit: 567 tests across 81 suites passed
- Vibe Bar: 1,563 tests passed, 1 skipped, 0 failures
- Release app built with bundled kit version 0.4.2
- strict deep codesign passed; entitlement dictionary is empty
- pricing resource is present
- Vibe Bar remained closed throughout validation