### PR TITLE
chore: prepare Vibe Bar 1.3.0 Dev build 39

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.3.0</string>
 	<key>CFBundleVersion</key>
-	<string>38</string>
+	<string>39</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>26.0</string>
 	<key>LSUIElement</key>


### PR DESCRIPTION
## Summary
- bump CFBundleVersion from 38 to 39 for the bounded session-index memory hotfix
- keep CFBundleShortVersionString at 1.3.0 and publish through the Dev Sparkle channel

## Verification
- full Vibe Bar suite: 1,563 tests passed, 1 skipped, 0 failures
- Release app embeds agent-session-kit 0.4.2
- bundle version is 1.3.0 (39)
- strict deep codesign passed; entitlement dictionary is empty
- bundled pricing resource is present
- Vibe Bar remains closed