### PR TITLE
Unblock quota refreshes and add Kimi monthly usage

### DIFF
--- a/Sources/VibeBarApp/Views/HeaderView.swift
+++ b/Sources/VibeBarApp/Views/HeaderView.swift
@@ -104,7 +104,6 @@ struct PlanBadgeView: View {
                 .background(Capsule().fill(Color.accentColor.opacity(0.18)))
                 .foregroundStyle(Color.accentColor)
                 .lineLimit(1)
-                .minimumScaleFactor(0.72)
                 .fixedSize(horizontal: true, vertical: false)
         }
     }

--- a/Sources/VibeBarApp/Views/SettingsSidebarView.swift
+++ b/Sources/VibeBarApp/Views/SettingsSidebarView.swift
@@ -91,8 +91,11 @@ struct SettingsSidebarView: View {
                         }
                     }
 
-                    if searchText.isEmpty || !filteredMiscProviders.isEmpty {
+                    if miscLandingMatchesSearch || !filteredMiscProviders.isEmpty {
                         sidebarGroup("Misc Providers") {
+                            if miscLandingMatchesSearch {
+                                miscLandingRow
+                            }
                             ForEach(filteredMiscProviders) { instance in
                                 miscProviderRow(instance)
                                     .onDrag {
@@ -150,6 +153,12 @@ struct SettingsSidebarView: View {
                 || title.localizedCaseInsensitiveContains(searchText)
                 || instance.tool.vendorName.localizedCaseInsensitiveContains(searchText)
         }
+    }
+
+    private var miscLandingMatchesSearch: Bool {
+        searchText.isEmpty
+            || "Browser Cookies".localizedCaseInsensitiveContains(searchText)
+            || "Misc Providers".localizedCaseInsensitiveContains(searchText)
     }
 
     private func sidebarGroup<Content: View>(
@@ -215,6 +224,21 @@ struct SettingsSidebarView: View {
                 settingsStore.settings.setMiscProviderInstanceVisible(!enabled, forID: instance.id)
             }
         }
+    }
+
+    private var miscLandingRow: some View {
+        sidebarRow(
+            destination: .page(.miscProviders),
+            title: "Browser Cookies",
+            icon: AnyView(
+                Image(systemName: "safari")
+                    .font(.system(size: 14, weight: .medium))
+                    .frame(width: 20, height: 20)
+            ),
+            enabled: true,
+            showsStatusDot: false,
+            showsDragHandle: false
+        )
     }
 
     private func sidebarRow(

--- a/Sources/VibeBarApp/Views/SettingsView.swift
+++ b/Sources/VibeBarApp/Views/SettingsView.swift
@@ -568,7 +568,7 @@ struct SettingsView: View {
                             MiscProviderSettingsSection(instance: instance)
                         }
                     } else {
-                        settingsSection("Misc Provider") {
+                        settingsSection("Browser Cookies") {
                             MiscProviderLandingView()
                         }
                     }

--- a/Sources/VibeBarCore/Adapters/AntigravityCLIQuotaFetcher.swift
+++ b/Sources/VibeBarCore/Adapters/AntigravityCLIQuotaFetcher.swift
@@ -28,16 +28,22 @@ enum AntigravityCLIQuotaFetcher {
             throw lastError ?? QuotaError.noCredential
         }
         let process = try AntigravityCLIQuotaProcess.launch(binary: binary)
-        defer { process.stop() }
 
         // Start the readiness window only once the launched process exists, so
         // probing stale user-owned `agy` processes above never eats into it.
-        return try await fetch(
-            pid: process.pid,
-            deadline: Date().addingTimeInterval(readinessTimeout),
-            isRunning: { process.isRunning },
-            drainOutput: { process.drainOutput() }
-        )
+        do {
+            let snapshot = try await fetch(
+                pid: process.pid,
+                deadline: Date().addingTimeInterval(readinessTimeout),
+                isRunning: { process.isRunning },
+                drainOutput: { process.drainOutput() }
+            )
+            await process.stop()
+            return snapshot
+        } catch {
+            await process.stop()
+            throw error
+        }
     }
 
     static func parseAgyPIDs(_ output: String) -> [Int] {
@@ -195,21 +201,43 @@ private final class AntigravityCLIQuotaProcess: @unchecked Sendable {
         }
     }
 
-    func stop() {
-        lock.lock()
-        guard !stopped else {
-            lock.unlock()
-            return
+    func stop() async {
+        guard claimStop() else { return }
+        // `stop()` is normally reached from a cancelled quota task. Run the
+        // grace / kill / reap sequence in an unstructured task so inherited
+        // cancellation cannot turn every sleep into an immediate no-op, then
+        // await that cleanup before releasing the account's single-flight gate.
+        let cleanup = Task.detached(priority: .utility) { [self] in
+            await performStop()
         }
-        stopped = true
-        lock.unlock()
-
-        if process.isRunning {
-            process.terminate()
-        }
-        try? primaryHandle.close()
-        try? secondaryHandle.close()
+        await cleanup.value
     }
 
-    deinit { stop() }
+    private func performStop() async {
+        try? primaryHandle.close()
+        try? secondaryHandle.close()
+        if process.isRunning { process.terminate() }
+        try? await Task.sleep(nanoseconds: 500_000_000)
+        if process.isRunning { _ = kill(process.processIdentifier, SIGKILL) }
+        for _ in 0..<10 where process.isRunning {
+            try? await Task.sleep(nanoseconds: 50_000_000)
+        }
+    }
+
+    private func claimStop() -> Bool {
+        lock.withLock {
+            guard !stopped else { return false }
+            stopped = true
+            return true
+        }
+    }
+
+    private func forceStop() {
+        guard claimStop() else { return }
+        try? primaryHandle.close()
+        try? secondaryHandle.close()
+        if process.isRunning { _ = kill(process.processIdentifier, SIGKILL) }
+    }
+
+    deinit { forceStop() }
 }

--- a/Sources/VibeBarCore/Adapters/KimiQuotaAdapter.swift
+++ b/Sources/VibeBarCore/Adapters/KimiQuotaAdapter.swift
@@ -7,15 +7,21 @@ import Foundation
 /// from Chrome/Edge/Brave/Arc/Safari/Firefox, manual paste, or
 /// fully off.
 ///
-/// Endpoint:
+/// Endpoints:
 /// `POST https://www.kimi.com/apiv2/kimi.gateway.billing.v1.BillingService/GetUsages`
 /// with body `{"scope":["FEATURE_CODING"]}`. Headers reproduce the
 /// web app — Bearer token, kimi-auth cookie, browser User-Agent,
 /// connect-protocol-version, plus session / device / traffic IDs
 /// extracted from the JWT payload.
 ///
-/// Output: weekly bucket (primary) + 5-hour rate-limit bucket
-/// (secondary, when present).
+/// `POST https://www.kimi.com/apiv2/kimi.gateway.membership.v2.MembershipService/GetSubscriptionStats`
+/// with body `{}` adds the shared monthly subscription balance shown on
+/// Kimi's Membership → My Quota page. That request is best-effort so a
+/// membership rollout or transient failure cannot erase the established
+/// weekly / five-hour quota.
+///
+/// Output: weekly bucket (primary) + 5-hour rate-limit bucket + monthly
+/// subscription bucket (when present).
 public struct KimiQuotaAdapter: QuotaAdapter {
     public let tool: ToolType = .kimi
 
@@ -28,9 +34,13 @@ public struct KimiQuotaAdapter: QuotaAdapter {
         requiredNames: ["kimi-auth"]
     )
 
-    private static let endpoint = URL(string:
+    private static let usageEndpoint = URL(string:
         "https://www.kimi.com/apiv2/kimi.gateway.billing.v1.BillingService/GetUsages"
     )!
+    private static let membershipStatsEndpoint = URL(string:
+        "https://www.kimi.com/apiv2/kimi.gateway.membership.v2.MembershipService/GetSubscriptionStats"
+    )!
+    private static let membershipStatsWallTimeSeconds: Double = 10
 
     public init(
         session: URLSession = .shared,
@@ -72,15 +82,68 @@ public struct KimiQuotaAdapter: QuotaAdapter {
             throw QuotaError.noCredential
         }
 
-        let session = KimiSessionInfo.fromJWT(authToken)
+        let usageRequest = Self.usageRequest(authToken: authToken)
+        let (data, _) = try await data(for: usageRequest)
+        let snapshot = try KimiResponseParser.parse(data: data, now: queriedAt)
 
-        var request = URLRequest(url: KimiQuotaAdapter.endpoint)
+        var buckets = snapshot.buckets
+        let membershipOutcome = await AsyncTimeout.run(seconds: Self.membershipStatsWallTimeSeconds) {
+            do {
+                let request = Self.membershipStatsRequest(authToken: authToken)
+                let (data, _) = try await self.data(for: request)
+                return KimiMembershipFetchOutcome.data(data)
+            } catch {
+                return KimiMembershipFetchOutcome.failed
+            }
+        }
+        if case let .completed(.data(membershipData)) = membershipOutcome,
+           let monthly = try? KimiResponseParser.parseMonthly(data: membershipData) {
+            buckets.append(monthly)
+        }
+
+        return AccountQuota(
+            accountId: account.id,
+            tool: .kimi,
+            buckets: buckets,
+            plan: nil,
+            email: account.email,
+            queriedAt: queriedAt,
+            error: nil
+        )
+    }
+
+    static func usageRequest(authToken: String) -> URLRequest {
+        makeRequest(
+            url: usageEndpoint,
+            authToken: authToken,
+            referer: "https://www.kimi.com/code/console",
+            body: ["scope": ["FEATURE_CODING"]]
+        )
+    }
+
+    static func membershipStatsRequest(authToken: String) -> URLRequest {
+        makeRequest(
+            url: membershipStatsEndpoint,
+            authToken: authToken,
+            referer: "https://www.kimi.com/membership/subscription?tab=quota",
+            body: [:]
+        )
+    }
+
+    private static func makeRequest(
+        url: URL,
+        authToken: String,
+        referer: String,
+        body: [String: Any]
+    ) -> URLRequest {
+        let session = KimiSessionInfo.fromJWT(authToken)
+        var request = URLRequest(url: url)
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.setValue("Bearer \(authToken)", forHTTPHeaderField: "Authorization")
         request.setValue("kimi-auth=\(authToken)", forHTTPHeaderField: "Cookie")
         request.setValue("https://www.kimi.com", forHTTPHeaderField: "Origin")
-        request.setValue("https://www.kimi.com/code/console", forHTTPHeaderField: "Referer")
+        request.setValue(referer, forHTTPHeaderField: "Referer")
         request.setValue("*/*", forHTTPHeaderField: "Accept")
         request.setValue("en-US,en;q=0.9", forHTTPHeaderField: "Accept-Language")
         request.setValue(
@@ -95,10 +158,11 @@ public struct KimiQuotaAdapter: QuotaAdapter {
         if let sessionId = session.sessionId { request.setValue(sessionId, forHTTPHeaderField: "x-msh-session-id") }
         if let trafficId = session.trafficId { request.setValue(trafficId, forHTTPHeaderField: "x-traffic-id") }
 
-        request.httpBody = try? JSONSerialization.data(
-            withJSONObject: ["scope": ["FEATURE_CODING"]]
-        )
+        request.httpBody = try? JSONSerialization.data(withJSONObject: body)
+        return request
+    }
 
+    private func data(for request: URLRequest) async throws -> (Data, HTTPURLResponse) {
         let (data, response): (Data, URLResponse)
         do {
             (data, response) = try await self.session.data(for: request)
@@ -118,18 +182,13 @@ public struct KimiQuotaAdapter: QuotaAdapter {
             }
             throw QuotaError.network("Kimi returned HTTP \(http.statusCode).")
         }
-
-        let snapshot = try KimiResponseParser.parse(data: data, now: queriedAt)
-        return AccountQuota(
-            accountId: account.id,
-            tool: .kimi,
-            buckets: snapshot.buckets,
-            plan: nil,
-            email: account.email,
-            queriedAt: queriedAt,
-            error: nil
-        )
+        return (data, http)
     }
+}
+
+private enum KimiMembershipFetchOutcome: Sendable {
+    case data(Data)
+    case failed
 }
 
 // MARK: - JWT session info
@@ -207,6 +266,30 @@ enum KimiResponseParser {
         return Snapshot(buckets: buckets)
     }
 
+    static func parseMonthly(data: Data) throws -> QuotaBucket? {
+        let response: KimiMembershipStatsResponse
+        do {
+            response = try JSONDecoder().decode(KimiMembershipStatsResponse.self, from: data)
+        } catch {
+            throw QuotaError.parseFailure("Kimi membership response not parseable: \(error.localizedDescription)")
+        }
+        guard let balance = response.subscriptionBalance,
+              balance.feature == "FEATURE_OMNI",
+              balance.type == "SUBSCRIPTION",
+              let ratio = balance.amountUsedRatio,
+              ratio.isFinite else {
+            return nil
+        }
+        return QuotaBucket(
+            id: "kimi.monthly",
+            title: "Monthly",
+            shortLabel: "Mo",
+            usedPercent: max(0, min(100, ratio * 100)),
+            resetAt: parseResetTime(balance.expireTime),
+            rawWindowSeconds: 30 * 86_400
+        )
+    }
+
     private static func makeBucket(
         id: String,
         title: String,
@@ -266,7 +349,9 @@ struct KimiAPIWindow: Decodable {
     let timeUnit: String
 
     var windowSeconds: Int? {
-        switch timeUnit.uppercased() {
+        let normalized = timeUnit.uppercased()
+            .replacingOccurrences(of: "TIME_UNIT_", with: "")
+        switch normalized {
         case "SECOND", "SECONDS": return duration
         case "MINUTE", "MINUTES": return duration * 60
         case "HOUR", "HOURS":     return duration * 3600
@@ -304,4 +389,15 @@ struct KimiAPIDetail: Decodable {
     let used: String?
     let remaining: String?
     let resetTime: String?
+}
+
+private struct KimiMembershipStatsResponse: Decodable {
+    let subscriptionBalance: KimiSubscriptionBalance?
+}
+
+private struct KimiSubscriptionBalance: Decodable {
+    let feature: String?
+    let type: String?
+    let amountUsedRatio: Double?
+    let expireTime: String?
 }

--- a/Sources/VibeBarCore/Services/QuotaService.swift
+++ b/Sources/VibeBarCore/Services/QuotaService.swift
@@ -26,6 +26,7 @@ public struct QuotaActivityContext: Sendable {
 @MainActor
 public final class QuotaService: ObservableObject {
     public static let credentialFallbackMaxAge: TimeInterval = 30 * 60
+    nonisolated public static let defaultRefreshTimeoutSeconds: Double = 60
     @Published public private(set) var lastSuccessByAccount: [String: AccountQuota] = [:]
     @Published public private(set) var lastErrorByAccount: [String: QuotaError] = [:]
     /// When the *data* currently on screen was fetched. Only a success writes
@@ -55,16 +56,24 @@ public final class QuotaService: ObservableObject {
     private let adapters: [ToolType: any QuotaAdapter]
     private let mockProvider: () -> Bool
     private let retentionProvider: () -> Int
+    private let refreshTimeoutSeconds: Double
+    /// A timed-out adapter may ignore cancellation and keep running. Do not
+    /// start another fetch for that account until the abandoned operation
+    /// actually returns; otherwise each scheduler tick can leak another task
+    /// or provider subprocess.
+    private var timedOutAccountIds: Set<String> = []
 
     public init(
         adapters: [ToolType: any QuotaAdapter],
         mockProvider: @escaping () -> Bool,
         retentionProvider: @escaping () -> Int = { CostDataSettings.defaultRetentionDays },
-        initialAccountIds: [String] = []
+        initialAccountIds: [String] = [],
+        refreshTimeoutSeconds: Double = QuotaService.defaultRefreshTimeoutSeconds
     ) {
         self.adapters = adapters
         self.mockProvider = mockProvider
         self.retentionProvider = retentionProvider
+        self.refreshTimeoutSeconds = max(0.01, refreshTimeoutSeconds)
         let cached = QuotaCacheStore.loadAll(accountIds: initialAccountIds)
         self.lastSuccessByAccount = cached
         self.lastUpdatedByAccount = cached.mapValues(\.queriedAt)
@@ -139,6 +148,9 @@ public final class QuotaService: ObservableObject {
             return lastSuccessByAccount[account.id]
                 ?? AccountQuota(accountId: account.id, tool: account.tool, buckets: [], queriedAt: Date(), error: nil)
         }
+        if timedOutAccountIds.contains(account.id) {
+            return cachedOrEmpty(for: account, error: .network("timeout"))
+        }
         inFlightAccountIds.insert(account.id)
         defer { inFlightAccountIds.remove(account.id) }
 
@@ -161,18 +173,34 @@ public final class QuotaService: ObservableObject {
             return cachedOrEmpty(for: account, error: err)
         }
 
-        do {
-            let quota = try await adapter.fetch(for: account)
+        let completion = QuotaFetchCompletion()
+        let outcome = await AsyncTimeout.run(seconds: refreshTimeoutSeconds) {
+            defer { completion.finish() }
+            do {
+                return QuotaAdapterFetchResult.success(try await adapter.fetch(for: account))
+            } catch let qe as QuotaError {
+                return QuotaAdapterFetchResult.failure(qe)
+            } catch {
+                return QuotaAdapterFetchResult.failure(mapURLError(error))
+            }
+        }
+        switch outcome {
+        case let .completed(.success(quota)):
             store(success: quota)
             return quota
-        } catch let qe as QuotaError {
+        case let .completed(.failure(qe)):
             SafeLog.net("\(account.tool.rawValue) refresh failed: \(qe.userFacingMessage)")
             store(error: qe, for: account)
             return cachedOrEmpty(for: account, error: qe)
-        } catch {
-            let qe = mapURLError(error)
-            SafeLog.net("\(account.tool.rawValue) refresh exception: \(qe.userFacingMessage)")
+        case .timedOut:
+            let qe = QuotaError.network("timeout")
+            SafeLog.net("\(account.tool.rawValue) refresh timed out")
             store(error: qe, for: account)
+            timedOutAccountIds.insert(account.id)
+            Task { @MainActor [weak self] in
+                await completion.wait()
+                self?.timedOutAccountIds.remove(account.id)
+            }
             return cachedOrEmpty(for: account, error: qe)
         }
     }
@@ -424,5 +452,38 @@ public final class QuotaService: ObservableObject {
             queriedAt: Date(),
             error: error
         )
+    }
+}
+
+private enum QuotaAdapterFetchResult: Sendable {
+    case success(AccountQuota)
+    case failure(QuotaError)
+}
+
+private final class QuotaFetchCompletion: @unchecked Sendable {
+    private let lock = NSLock()
+    private var finished = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func wait() async {
+        await withCheckedContinuation { continuation in
+            let resumeImmediately = lock.withLock { () -> Bool in
+                if finished { return true }
+                waiters.append(continuation)
+                return false
+            }
+            if resumeImmediately { continuation.resume() }
+        }
+    }
+
+    func finish() {
+        let pending = lock.withLock { () -> [CheckedContinuation<Void, Never>] in
+            guard !finished else { return [] }
+            finished = true
+            let pending = waiters
+            waiters = []
+            return pending
+        }
+        for waiter in pending { waiter.resume() }
     }
 }

--- a/Sources/VibeBarCore/Utilities/ProcessRunner.swift
+++ b/Sources/VibeBarCore/Utilities/ProcessRunner.swift
@@ -58,53 +58,187 @@ public enum ProcessRunner {
         process.standardError = stderr
         process.standardInput = nil
 
+        let execution = ProcessExecution(process: process, stdout: stdout, stderr: stderr)
+        let collection = ProcessCollectionState()
+        process.terminationHandler = { finished in
+            collection.record(terminationStatus: finished.terminationStatus)
+        }
+
         do {
             try process.run()
         } catch {
             throw Error.launchFailed("\(error)")
         }
 
-        let killTask = Task {
-            try await Task.sleep(nanoseconds: UInt64(timeout * 1_000_000_000))
-            guard process.isRunning else { return }
-            // Ask politely first: a well-behaved child exits on SIGTERM and
-            // closes its pipes, which unblocks the `readPipe` loop below.
-            process.terminate()
-            // If it ignores SIGTERM, escalate to SIGKILL after a short grace
-            // so the kernel force-closes its fds. Without this the read loop
-            // waits for an EOF that never arrives and `run` hangs forever —
-            // exactly how a wedged `lsof` froze the whole cost-refresh loop.
-            try await Task.sleep(nanoseconds: Self.killGraceNanoseconds)
-            if process.isRunning { _ = kill(process.processIdentifier, SIGKILL) }
+        Task.detached(priority: .userInitiated) {
+            collection.record(stdout: Self.readPipe(execution.stdout))
+        }
+        Task.detached(priority: .userInitiated) {
+            collection.record(stderr: Self.readPipe(execution.stderr))
+        }
+        let timeoutTask = Task.detached(priority: .utility) {
+            do {
+                try await Task.sleep(nanoseconds: UInt64(max(0, timeout) * 1_000_000_000))
+            } catch {
+                return
+            }
+            guard collection.beginTermination(.timedOut) else { return }
+            await execution.stop(graceNanoseconds: Self.killGraceNanoseconds)
+            collection.finishTermination(.timedOut)
         }
 
-        let outData = await readPipe(stdout)
-        let errData = await readPipe(stderr)
-        process.waitUntilExit()
-        killTask.cancel()
+        let outcome = await withTaskCancellationHandler {
+            await collection.wait()
+        } onCancel: {
+            guard collection.beginTermination(.cancelled) else { return }
+            Task.detached(priority: .utility) {
+                await execution.stop(graceNanoseconds: Self.killGraceNanoseconds)
+                collection.finishTermination(.cancelled)
+            }
+        }
+        timeoutTask.cancel()
 
-        return Result(
-            stdout: String(data: outData, encoding: .utf8) ?? "",
-            stderr: String(data: errData, encoding: .utf8) ?? "",
-            terminationStatus: process.terminationStatus
-        )
+        switch outcome {
+        case let .completed(stdout, stderr, terminationStatus):
+            return Result(
+                stdout: String(data: stdout, encoding: .utf8) ?? "",
+                stderr: String(data: stderr, encoding: .utf8) ?? "",
+                terminationStatus: terminationStatus
+            )
+        case .timedOut:
+            throw Error.timedOut(label)
+        case .cancelled:
+            throw CancellationError()
+        }
     }
 
-    private static func readPipe(_ pipe: Pipe) async -> Data {
-        await withCheckedContinuation { continuation in
-            DispatchQueue.global(qos: .userInitiated).async {
-                var data = Data()
-                while true {
-                    do {
-                        guard let chunk = try pipe.fileHandleForReading.read(upToCount: 64 * 1024),
-                              !chunk.isEmpty else { break }
-                        data.append(chunk)
-                    } catch {
-                        break
-                    }
-                }
-                continuation.resume(returning: data)
+    private static func readPipe(_ pipe: Pipe) -> Data {
+        var data = Data()
+        while true {
+            do {
+                guard let chunk = try pipe.fileHandleForReading.read(upToCount: 64 * 1024),
+                      !chunk.isEmpty else { break }
+                data.append(chunk)
+            } catch {
+                break
             }
+        }
+        return data
+    }
+}
+
+private final class ProcessExecution: @unchecked Sendable {
+    let process: Process
+    let stdout: Pipe
+    let stderr: Pipe
+
+    init(process: Process, stdout: Pipe, stderr: Pipe) {
+        self.process = process
+        self.stdout = stdout
+        self.stderr = stderr
+    }
+
+    func stop(graceNanoseconds: UInt64) async {
+        closePipes()
+        if process.isRunning { process.terminate() }
+        try? await Task.sleep(nanoseconds: graceNanoseconds)
+        if process.isRunning { _ = kill(process.processIdentifier, SIGKILL) }
+        for _ in 0..<10 where process.isRunning {
+            try? await Task.sleep(nanoseconds: 50_000_000)
+        }
+        closePipes()
+    }
+
+    private func closePipes() {
+        for handle in [
+            stdout.fileHandleForReading,
+            stdout.fileHandleForWriting,
+            stderr.fileHandleForReading,
+            stderr.fileHandleForWriting,
+        ] {
+            try? handle.close()
+        }
+    }
+}
+
+private enum ProcessTerminationIntent: Sendable, Equatable {
+    case timedOut
+    case cancelled
+}
+
+private enum ProcessCollectionOutcome: Sendable {
+    case completed(stdout: Data, stderr: Data, terminationStatus: Int32)
+    case timedOut
+    case cancelled
+}
+
+private final class ProcessCollectionState: @unchecked Sendable {
+    private let lock = NSLock()
+    private var stdout: Data?
+    private var stderr: Data?
+    private var terminationStatus: Int32?
+    private var terminationIntent: ProcessTerminationIntent?
+    private var outcome: ProcessCollectionOutcome?
+    private var continuation: CheckedContinuation<ProcessCollectionOutcome, Never>?
+
+    func record(stdout: Data) {
+        record { self.stdout = stdout }
+    }
+
+    func record(stderr: Data) {
+        record { self.stderr = stderr }
+    }
+
+    func record(terminationStatus: Int32) {
+        record { self.terminationStatus = terminationStatus }
+    }
+
+    private func record(_ update: () -> Void) {
+        let resolved = lock.withLock { () -> (CheckedContinuation<ProcessCollectionOutcome, Never>?, ProcessCollectionOutcome)? in
+            guard outcome == nil, terminationIntent == nil else { return nil }
+            update()
+            guard let stdout, let stderr, let terminationStatus else { return nil }
+            let completed = ProcessCollectionOutcome.completed(
+                stdout: stdout,
+                stderr: stderr,
+                terminationStatus: terminationStatus
+            )
+            outcome = completed
+            let waiter = continuation
+            continuation = nil
+            return (waiter, completed)
+        }
+        if let resolved { resolved.0?.resume(returning: resolved.1) }
+    }
+
+    func beginTermination(_ intent: ProcessTerminationIntent) -> Bool {
+        lock.withLock {
+            guard outcome == nil, terminationIntent == nil else { return false }
+            terminationIntent = intent
+            return true
+        }
+    }
+
+    func finishTermination(_ intent: ProcessTerminationIntent) {
+        let resolved = lock.withLock { () -> (CheckedContinuation<ProcessCollectionOutcome, Never>?, ProcessCollectionOutcome)? in
+            guard outcome == nil, terminationIntent == intent else { return nil }
+            let terminal: ProcessCollectionOutcome = intent == .timedOut ? .timedOut : .cancelled
+            outcome = terminal
+            let waiter = continuation
+            continuation = nil
+            return (waiter, terminal)
+        }
+        if let resolved { resolved.0?.resume(returning: resolved.1) }
+    }
+
+    func wait() async -> ProcessCollectionOutcome {
+        await withCheckedContinuation { continuation in
+            let ready = lock.withLock { () -> ProcessCollectionOutcome? in
+                if let outcome { return outcome }
+                self.continuation = continuation
+                return nil
+            }
+            if let ready { continuation.resume(returning: ready) }
         }
     }
 }

--- a/Tests/VibeBarCoreTests/KimiMiniMaxParserTests.swift
+++ b/Tests/VibeBarCoreTests/KimiMiniMaxParserTests.swift
@@ -106,6 +106,76 @@ final class KimiParserTests: XCTestCase {
         XCTAssertEqual(snap.buckets[1].rawWindowSeconds, 5 * 3600)
     }
 
+    func testPrefixedMinuteWindowResolvesToFiveHours() {
+        let window = KimiAPIWindow(duration: 300, timeUnit: "TIME_UNIT_MINUTE")
+
+        XCTAssertEqual(window.windowSeconds, 5 * 3600)
+        XCTAssertEqual(window.title, "5 Hours")
+        XCTAssertEqual(window.shortLabel, "5h")
+    }
+
+    func testParsesSharedMonthlySubscriptionBalance() throws {
+        let json = """
+        {
+          "subscriptionBalance": {
+            "feature": "FEATURE_OMNI",
+            "type": "SUBSCRIPTION",
+            "amountUsedRatio": 0.42,
+            "kimiCodeUsedRatio": 0.91,
+            "expireTime": "2026-09-02T00:00:00Z"
+          }
+        }
+        """
+
+        let bucket = try XCTUnwrap(
+            KimiResponseParser.parseMonthly(data: Data(json.utf8))
+        )
+        XCTAssertEqual(bucket.id, "kimi.monthly")
+        XCTAssertEqual(bucket.title, "Monthly")
+        XCTAssertEqual(bucket.shortLabel, "Mo")
+        XCTAssertEqual(bucket.usedPercent, 42, accuracy: 0.001)
+        XCTAssertEqual(bucket.rawWindowSeconds, 30 * 86_400)
+        XCTAssertEqual(
+            bucket.resetAt,
+            ISO8601DateFormatter().date(from: "2026-09-02T00:00:00Z")
+        )
+    }
+
+    func testMonthlyIgnoresNonSubscriptionBalance() throws {
+        let json = """
+        {
+          "subscriptionBalance": {
+            "feature": "FEATURE_OMNI",
+            "type": "GIFT",
+            "amountUsedRatio": 0.42,
+            "expireTime": "2026-09-02T00:00:00Z"
+          }
+        }
+        """
+
+        XCTAssertNil(try KimiResponseParser.parseMonthly(data: Data(json.utf8)))
+    }
+
+    func testMembershipStatsRequestUsesQuotaPageContract() throws {
+        let token = "synthetic.header.signature"
+        let request = KimiQuotaAdapter.membershipStatsRequest(authToken: token)
+
+        XCTAssertEqual(request.httpMethod, "POST")
+        XCTAssertEqual(
+            request.url?.absoluteString,
+            "https://www.kimi.com/apiv2/kimi.gateway.membership.v2.MembershipService/GetSubscriptionStats"
+        )
+        XCTAssertEqual(
+            request.value(forHTTPHeaderField: "Referer"),
+            "https://www.kimi.com/membership/subscription?tab=quota"
+        )
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer \(token)")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Cookie"), "kimi-auth=\(token)")
+        let body = try XCTUnwrap(request.httpBody)
+        let object = try XCTUnwrap(JSONSerialization.jsonObject(with: body) as? [String: Any])
+        XCTAssertTrue(object.isEmpty)
+    }
+
     func testNoCodingScopeThrowsParseFailure() {
         let json = """
         {

--- a/Tests/VibeBarCoreTests/ProcessRunnerTests.swift
+++ b/Tests/VibeBarCoreTests/ProcessRunnerTests.swift
@@ -37,16 +37,97 @@ final class ProcessRunnerTests: XCTestCase {
         // the stdout pipe open so `run` never sees EOF. With a 1s timeout,
         // `run` must SIGKILL it and return in ~1-2s, not ~10s.
         let start = Date()
-        _ = try await ProcessRunner.run(
-            binary: perl,
-            arguments: ["-e", "$SIG{TERM}='IGNORE'; sleep 10;"],
-            timeout: 1,
-            label: "ignores-sigterm"
-        )
+        do {
+            _ = try await ProcessRunner.run(
+                binary: perl,
+                arguments: ["-e", "$SIG{TERM}='IGNORE'; sleep 10;"],
+                timeout: 1,
+                label: "ignores-sigterm"
+            )
+            XCTFail("Expected ProcessRunner.Error.timedOut")
+        } catch let error as ProcessRunner.Error {
+            guard case .timedOut("ignores-sigterm") = error else {
+                return XCTFail("Expected timedOut, got \(error)")
+            }
+        }
         let elapsed = Date().timeIntervalSince(start)
         XCTAssertLessThan(
             elapsed, 4,
             "run() did not enforce its timeout against a SIGTERM-ignoring child (took \(elapsed)s)"
         )
+    }
+
+    /// Both streams must be drained at once. Reading stdout to EOF before
+    /// touching stderr deadlocks once the child fills stderr's pipe.
+    func testDrainsLargeStdoutAndStderrConcurrently() async throws {
+        let perl = "/usr/bin/perl"
+        try XCTSkipUnless(
+            FileManager.default.isExecutableFile(atPath: perl),
+            "perl not available to generate large output"
+        )
+
+        let result = try await ProcessRunner.run(
+            binary: perl,
+            arguments: ["-e", "print STDOUT 'o' x 1048576; print STDERR 'e' x 1048576;"],
+            timeout: 5,
+            label: "large-dual-pipes"
+        )
+
+        XCTAssertEqual(result.stdout.utf8.count, 1_048_576)
+        XCTAssertEqual(result.stderr.utf8.count, 1_048_576)
+        XCTAssertEqual(result.terminationStatus, 0)
+    }
+
+    /// The parent can exit while a forked descendant still owns both pipe FDs.
+    /// The timeout must cover collecting the pipes, not just the parent PID.
+    func testTimesOutWhenDescendantKeepsPipesOpen() async throws {
+        let perl = "/usr/bin/perl"
+        try XCTSkipUnless(
+            FileManager.default.isExecutableFile(atPath: perl),
+            "perl not available to fork a pipe-holding descendant"
+        )
+
+        let start = Date()
+        do {
+            _ = try await ProcessRunner.run(
+                binary: perl,
+                arguments: ["-e", "if (fork() == 0) { sleep 2; exit 0; } exit 0;"],
+                timeout: 0.2,
+                label: "descendant-holds-pipes"
+            )
+            XCTFail("Expected ProcessRunner.Error.timedOut")
+        } catch let error as ProcessRunner.Error {
+            guard case .timedOut("descendant-holds-pipes") = error else {
+                return XCTFail("Expected timedOut, got \(error)")
+            }
+        }
+        XCTAssertLessThan(Date().timeIntervalSince(start), 1.5)
+    }
+
+    func testCallerCancellationStopsTheProcessPromptly() async throws {
+        let perl = "/usr/bin/perl"
+        try XCTSkipUnless(
+            FileManager.default.isExecutableFile(atPath: perl),
+            "perl not available to simulate a long-running child"
+        )
+
+        let start = Date()
+        let task = Task {
+            try await ProcessRunner.run(
+                binary: perl,
+                arguments: ["-e", "sleep 10;"],
+                timeout: 10,
+                label: "cancelled-child"
+            )
+        }
+        try await Task.sleep(nanoseconds: 100_000_000)
+        task.cancel()
+        do {
+            _ = try await task.value
+            XCTFail("Expected CancellationError")
+        } catch is CancellationError {
+            // Expected.
+        }
+        XCTAssertLessThan(Date().timeIntervalSince(start), 1.5)
     }
 }

--- a/Tests/VibeBarCoreTests/QuotaRefreshSchedulerTests.swift
+++ b/Tests/VibeBarCoreTests/QuotaRefreshSchedulerTests.swift
@@ -301,6 +301,53 @@ final class QuotaRefreshSchedulerTests: XCTestCase {
 
         XCTAssertEqual(counter.fetchCount, 2)
     }
+
+    func testTimedOutAccountDoesNotBlockFollowingAccount() async {
+        let blocking = AccountIdentity(id: "blocking-antigravity", tool: .antigravity, source: .localProbe)
+        let following = AccountIdentity(id: "following-claude", tool: .claude, source: .oauthCLI)
+        let gate = QuotaRefreshGate()
+        let blockingAdapter = GatedQuotaAdapter(tool: .antigravity, gate: gate)
+        let counter = CountingQuotaAdapter(tool: .claude)
+        let service = QuotaService(
+            adapters: [
+                .antigravity: blockingAdapter,
+                .claude: counter,
+            ],
+            mockProvider: { false },
+            refreshTimeoutSeconds: 0.05
+        )
+        let scheduler = QuotaRefreshScheduler(
+            service: service,
+            accountsProvider: { [blocking, following] },
+            intervalProvider: { 600 }
+        )
+
+        scheduler.triggerRefresh()
+        await gate.waitUntilStarted()
+        for _ in 0..<100 {
+            if counter.fetchCount == 1 { break }
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
+
+        XCTAssertEqual(counter.fetchCount, 1)
+        XCTAssertEqual(service.lastErrorByAccount[blocking.id], .network("timeout"))
+        XCTAssertFalse(service.inFlightAccountIds.contains(blocking.id))
+        XCTAssertNotNil(service.cachedQuota(for: following.id))
+        XCTAssertNil(service.cachedQuota(for: blocking.id))
+
+        _ = await service.refresh(blocking)
+        XCTAssertEqual(
+            blockingAdapter.fetchCount,
+            1,
+            "A timed-out, non-cooperative fetch must stay single-flight until it really finishes."
+        )
+
+        // Let the abandoned adapter finish. Its late success must not overwrite
+        // the timeout state because only the winning parent path may store.
+        await gate.release()
+        for _ in 0..<20 { await Task.yield() }
+        XCTAssertNil(service.cachedQuota(for: blocking.id))
+    }
 }
 
 private final class SequenceAdapter: QuotaAdapter, @unchecked Sendable {
@@ -369,13 +416,20 @@ private actor QuotaRefreshGate {
 private final class GatedQuotaAdapter: QuotaAdapter, @unchecked Sendable {
     let tool: ToolType
     private let gate: QuotaRefreshGate
+    private let lock = NSLock()
+    private var count = 0
 
     init(tool: ToolType, gate: QuotaRefreshGate) {
         self.tool = tool
         self.gate = gate
     }
 
+    var fetchCount: Int {
+        lock.withLock { count }
+    }
+
     func fetch(for account: AccountIdentity) async throws -> AccountQuota {
+        lock.withLock { count += 1 }
         await gate.block()
         return AccountQuota(accountId: account.id, tool: tool, buckets: [], queriedAt: Date())
     }


### PR DESCRIPTION
## Summary
- bound provider refreshes and make subprocess collection cancellation-safe so AntiGravity cannot block the full queue
- add Kimi shared monthly membership quota while preserving Weekly and 5 Hours on membership failures
- expose Browser Cookies in the Misc Providers sidebar and keep plan badge font sizes consistent

## Test plan
- [x] swift build
- [x] swift test (1,584 tests; 1 skipped)
- [x] ./Scripts/build_app.sh release
- [x] codesign --verify --deep --strict .build/Vibe Bar.app
- [x] empty entitlements / app sandbox absent
- [x] demo screenshot: Settings > Misc Providers > Browser Cookies
- [x] demo screenshot: Overview plan badge typography
- [x] live Kimi Membership quota request schema verified in the signed-in browser without recording credentials