### PR TITLE
Prepare Vibe Bar 1.3.0 Dev build 40

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.3.0</string>
 	<key>CFBundleVersion</key>
-	<string>39</string>
+	<string>40</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>26.0</string>
 	<key>LSUIElement</key>


### PR DESCRIPTION
## Summary
- bump CFBundleVersion from 39 to 40 for the next Dev channel release
- keep CFBundleShortVersionString at 1.3.0 as required by the Dev tag contract

## Test plan
- [x] swift build
- [x] swift test (1,584 tests; 1 skipped)
- [x] ./Scripts/build_app.sh release
- [x] codesign --verify --deep --strict .build/Vibe Bar.app
- [x] empty entitlements / app sandbox absent
- [x] packaged app reports 1.3.0 (40)