### PR TITLE
Fix Kimi web authentication and quota refresh

### DIFF
--- a/Sources/VibeBarApp/AppEnvironment.swift
+++ b/Sources/VibeBarApp/AppEnvironment.swift
@@ -645,11 +645,11 @@ final class AppEnvironment: ObservableObject {
         }
     }
 
-    /// Open the in-app WebView login flow for a misc provider whose
-    /// cookies can't be auto-imported from the user's main browser
-    /// (typically because of Chrome v11/app-bound cookie encryption,
-    /// which SweetCookieKit doesn't read). After save, kicks a one-shot
-    /// quota refresh so the misc card flips out of "Set up" state.
+    /// Open the in-app WebView login flow for a misc provider whose current
+    /// credential cannot be imported from the user's main browser (for
+    /// example Chrome v11 cookies or Kimi's localStorage bearer token). After
+    /// save, kicks a one-shot quota refresh so the misc card leaves its setup
+    /// or re-login state.
     func openMiscWebLogin(for tool: ToolType) {
         openMiscWebLogin(for: tool, instanceID: tool.rawValue)
     }

--- a/Sources/VibeBarApp/HiddenCookieRefresher.swift
+++ b/Sources/VibeBarApp/HiddenCookieRefresher.swift
@@ -143,10 +143,9 @@ final class HiddenCookieRefresher {
     private var pinnedDataStores: [ObjectIdentifier: WKWebsiteDataStore] = [:]
 
     /// Trigger a silent refresh for `tool`. Iterates the user's
-    /// browser-origin cookie slots and refreshes each one. Manual
-    /// slots are skipped — auto-refresh only re-runs a session the
-    /// user originally captured via browser import or the in-app web
-    /// login. Returns true if at least one slot's header changed.
+    /// system-browser-origin cookie slots and refreshes each one. Manual and
+    /// bearer-token WebView slots are skipped — they require an explicit user
+    /// action. Returns true if at least one slot's header changed.
     /// Concurrent refreshes for the same tool are coalesced.
     @discardableResult
     func refresh(_ tool: ToolType) async -> Bool {
@@ -171,7 +170,7 @@ final class HiddenCookieRefresher {
             .filter { $0.tool == config.tool }
             .flatMap { instance in
                 MiscCookieSlotStore.slots(for: config.tool, instanceID: instance.id)
-                    .filter { $0.origin != .manual }
+                    .filter(\.isSystemBrowserRefreshable)
                     .map { RefreshTarget(instanceID: instance.id, slot: $0) }
             }
         guard !targets.isEmpty else {

--- a/Sources/VibeBarApp/MiscWebLoginController.swift
+++ b/Sources/VibeBarApp/MiscWebLoginController.swift
@@ -2,18 +2,16 @@ import AppKit
 import WebKit
 import VibeBarCore
 
-/// In-app WebView login flow for browser-cookie misc providers whose
-/// cookies can't be lifted out of the user's main browser (typically
-/// because Chrome on macOS encrypted them with `v11` / app-bound
-/// encryption, which our SweetCookieKit dependency can't read).
+/// In-app WebView login flow for misc providers whose live credential cannot
+/// be lifted out of the user's main browser (typically Chrome `v11` cookies,
+/// or a bearer token kept in first-party localStorage).
 ///
 /// Pattern mirrors `ClaudeWebLoginController`:
 /// 1. Open a window with a `WKWebView` pointed at the provider's
 ///    login URL.
 /// 2. Let the user sign in (handles password + SSO + popup flows).
-/// 3. Watch the cookie store; once the spec's required cookies are
-///    present, minimise them to `name=value; …` form and append a new
-///    slot to `MiscCookieSlotStore`.
+/// 3. Capture either the spec's required cookies or an explicitly configured
+///    first-party localStorage token, and append a Keychain-backed slot.
 /// 4. Fire the `onSaved` callback so the caller can kick a refresh.
 ///
 /// Generic on `ToolType` via `Config` — one instance per tool. Use
@@ -21,6 +19,13 @@ import VibeBarCore
 /// across SwiftUI re-renders.
 @MainActor
 final class MiscWebLoginController: NSObject, NSWindowDelegate, WKNavigationDelegate, WKUIDelegate {
+    struct LocalStorageTokenCapture {
+        let storageKey: String
+        let cookieName: String
+        let allowedHostSuffixes: [String]
+        let sourceLabel: String
+    }
+
     struct Config {
         let tool: ToolType
         let loginURL: URL
@@ -37,6 +42,16 @@ final class MiscWebLoginController: NSObject, NSWindowDelegate, WKNavigationDele
         let windowTitle: String
         let savedConfirmation: String
         let setupHint: String
+        /// Some current web apps authenticate API calls from a bearer token
+        /// in localStorage instead of an HTTP cookie. When configured, the
+        /// login flow captures that token only from a trusted first-party
+        /// page and stores it as a cookie-shaped Keychain slot so the existing
+        /// adapter/resolver boundary remains unchanged.
+        var localStorageTokenCapture: LocalStorageTokenCapture? = nil
+        /// Password capture/autofill is useful for cookie login flows, but a
+        /// bearer-token-only flow such as Kimi neither needs nor should expose
+        /// that bridge.
+        var enablesFormAutofill = true
     }
 
     private let config: Config
@@ -47,7 +62,7 @@ final class MiscWebLoginController: NSObject, NSWindowDelegate, WKNavigationDele
     private var popupWebView: WKWebView?
     private var statusLabel: NSTextField?
     private var onSaved: (() -> Void)?
-    private var didSaveCookiesForCurrentWindow = false
+    private var didSaveCredentialForCurrentWindow = false
     private let websiteDataStore = WKWebsiteDataStore.default()
     private var autofillBridges: [MiscWebLoginAutofillBridge] = []
 
@@ -80,7 +95,7 @@ final class MiscWebLoginController: NSObject, NSWindowDelegate, WKNavigationDele
         browserButton.bezelStyle = .rounded
 
         let saveButton = NSButton(
-            title: "Save Cookies",
+            title: config.localStorageTokenCapture == nil ? "Save Cookies" : "Save Session",
             target: self,
             action: #selector(saveCookies(_:))
         )
@@ -98,7 +113,14 @@ final class MiscWebLoginController: NSObject, NSWindowDelegate, WKNavigationDele
         statusLabel.font = .systemFont(ofSize: NSFont.smallSystemFontSize)
         self.statusLabel = statusLabel
 
-        let buttonRow = NSStackView(views: [statusLabel, NSView(), browserButton, reloadButton, saveButton])
+        var buttonViews: [NSView] = [statusLabel, NSView()]
+        // A system browser has a different localStorage partition from this
+        // WKWebView, so that escape hatch cannot complete a token-capture flow.
+        if config.localStorageTokenCapture == nil {
+            buttonViews.append(browserButton)
+        }
+        buttonViews.append(contentsOf: [reloadButton, saveButton])
+        let buttonRow = NSStackView(views: buttonViews)
         buttonRow.orientation = .horizontal
         buttonRow.alignment = .centerY
         buttonRow.spacing = 10
@@ -147,10 +169,74 @@ final class MiscWebLoginController: NSObject, NSWindowDelegate, WKNavigationDele
     }
 
     @objc private func saveCookies(_ sender: Any?) {
-        guard webView != nil else { return }
+        persistAvailableCredential(manual: true)
+    }
+
+    private func persistAvailableCredential(manual: Bool) {
+        guard let webView else { return }
+        if let capture = config.localStorageTokenCapture {
+            persistLocalStorageToken(from: webView, capture: capture, manual: manual)
+            return
+        }
         websiteDataStore.httpCookieStore.getAllCookies { [weak self] cookies in
             Task { @MainActor in
-                self?.persistCookies(cookies, manual: true)
+                self?.persistCookies(cookies, manual: manual)
+            }
+        }
+    }
+
+    private func persistLocalStorageToken(
+        from webView: WKWebView,
+        capture: LocalStorageTokenCapture,
+        manual: Bool
+    ) {
+        guard HostSuffixMatcher.matches(
+            webView.url?.host,
+            allowedSuffixes: capture.allowedHostSuffixes
+        ) else {
+            if manual {
+                showAlert(message: "Open the \(config.tool.menuTitle) page in this window before saving.")
+            }
+            return
+        }
+        guard let keyData = try? JSONEncoder().encode(capture.storageKey),
+              let keyLiteral = String(data: keyData, encoding: .utf8) else {
+            return
+        }
+        let script = """
+        (function() {
+            try { return window.localStorage.getItem(\(keyLiteral)); }
+            catch (_) { return null; }
+        })();
+        """
+        webView.evaluateJavaScript(script) { [weak self] value, _ in
+            Task { @MainActor in
+                guard let self else { return }
+                let token = (value as? String) ?? ""
+                let header: String? = switch self.config.tool {
+                case .kimi:
+                    KimiQuotaAdapter.cookieHeader(fromAccessToken: token)
+                default:
+                    nil
+                }
+                guard let header,
+                      CookieHeaderNormalizer.pairs(from: header).contains(where: {
+                          $0.name == capture.cookieName && !$0.value.isEmpty
+                      }) else {
+                    if manual {
+                        self.showAlert(
+                            message: "No active \(self.config.tool.menuTitle) session found yet. Finish login in this window, then try again."
+                        )
+                    }
+                    return
+                }
+                self.persistHeader(
+                    header,
+                    sourceLabel: capture.sourceLabel,
+                    origin: .manual,
+                    captureKind: .webLogin,
+                    manual: manual
+                )
             }
         }
     }
@@ -162,20 +248,37 @@ final class MiscWebLoginController: NSObject, NSWindowDelegate, WKNavigationDele
             }
             return
         }
+        persistHeader(
+            header,
+            sourceLabel: "WebView login",
+            origin: .browserImport,
+            captureKind: nil,
+            manual: manual
+        )
+    }
+
+    private func persistHeader(
+        _ header: String,
+        sourceLabel: String,
+        origin: MiscCookieSlot.Origin,
+        captureKind: MiscCookieSlot.CaptureKind?,
+        manual: Bool
+    ) {
         let slot = MiscCookieSlot(
             cookieHeader: header,
-            sourceLabel: "WebView login",
+            sourceLabel: sourceLabel,
             importedAt: Date(),
-            origin: .browserImport
+            origin: origin,
+            captureKind: captureKind
         )
         let stored = MiscCookieSlotStore.append(slot, for: config.tool, instanceID: instanceID)
         guard stored else {
             if manual {
-                showAlert(message: "Could not save \(config.tool.menuTitle) cookies to Keychain.")
+                showAlert(message: "Could not save the \(config.tool.menuTitle) credential to Keychain.")
             }
             return
         }
-        didSaveCookiesForCurrentWindow = true
+        didSaveCredentialForCurrentWindow = true
         statusLabel?.stringValue = config.savedConfirmation
         if manual {
             showAlert(message: config.savedConfirmation)
@@ -183,11 +286,17 @@ final class MiscWebLoginController: NSObject, NSWindowDelegate, WKNavigationDele
         onSaved?()
     }
 
-    private func persistCookiesSilentlyIfAvailable() {
-        guard !didSaveCookiesForCurrentWindow else { return }
+    private func persistCredentialSilentlyIfAvailable() {
+        guard !didSaveCredentialForCurrentWindow else { return }
+        // Bearer tokens are more sensitive and WebKit may retain an expired
+        // localStorage value from an earlier login. Capture only on the user's
+        // explicit Save Session click after they can see the signed-in page.
+        if config.localStorageTokenCapture != nil {
+            return
+        }
         websiteDataStore.httpCookieStore.getAllCookies { [weak self] cookies in
             Task { @MainActor in
-                guard let self, !self.didSaveCookiesForCurrentWindow else { return }
+                guard let self, !self.didSaveCredentialForCurrentWindow else { return }
                 self.persistCookies(cookies, manual: false)
             }
         }
@@ -254,15 +363,17 @@ final class MiscWebLoginController: NSObject, NSWindowDelegate, WKNavigationDele
         configuration.defaultWebpagePreferences.allowsContentJavaScript = true
 
         let userContent = WKUserContentController()
-        userContent.addUserScript(WKUserScript(
-            source: MiscWebLoginController.formAutofillScript,
-            injectionTime: .atDocumentEnd,
-            forMainFrameOnly: false
-        ))
-        let bridge = MiscWebLoginAutofillBridge(controller: self)
-        userContent.add(bridge, name: MiscWebLoginController.formAutofillMessageName)
+        if config.enablesFormAutofill {
+            userContent.addUserScript(WKUserScript(
+                source: MiscWebLoginController.formAutofillScript,
+                injectionTime: .atDocumentEnd,
+                forMainFrameOnly: false
+            ))
+            let bridge = MiscWebLoginAutofillBridge(controller: self)
+            userContent.add(bridge, name: MiscWebLoginController.formAutofillMessageName)
+            autofillBridges.append(bridge)
+        }
         configuration.userContentController = userContent
-        autofillBridges.append(bridge)
         return configuration
     }
 
@@ -438,12 +549,7 @@ final class MiscWebLoginController: NSObject, NSWindowDelegate, WKNavigationDele
     }
 
     private func isTrustedAuthHost(_ host: String?) -> Bool {
-        guard let host = host?.lowercased(), !host.isEmpty else { return false }
-        return config.trustedAuthHostSuffixes.contains { rawSuffix in
-            let suffix = rawSuffix.lowercased()
-            let normalized = suffix.hasPrefix(".") ? String(suffix.dropFirst()) : suffix
-            return host == normalized || host.hasSuffix("." + normalized)
-        }
+        HostSuffixMatcher.matches(host, allowedSuffixes: config.trustedAuthHostSuffixes)
     }
 
     func windowWillClose(_ notification: Notification) {
@@ -464,7 +570,7 @@ final class MiscWebLoginController: NSObject, NSWindowDelegate, WKNavigationDele
         statusLabel = nil
         window = nil
         onSaved = nil
-        didSaveCookiesForCurrentWindow = false
+        didSaveCredentialForCurrentWindow = false
         for bridge in autofillBridges {
             bridge.detach()
         }
@@ -477,7 +583,7 @@ final class MiscWebLoginController: NSObject, NSWindowDelegate, WKNavigationDele
 
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
         statusLabel?.stringValue = config.setupHint
-        persistCookiesSilentlyIfAvailable()
+        persistCredentialSilentlyIfAvailable()
     }
 
     func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
@@ -567,7 +673,7 @@ final class MiscWebLoginController: NSObject, NSWindowDelegate, WKNavigationDele
 extension MiscWebLoginController: WKHTTPCookieStoreObserver {
     nonisolated func cookiesDidChange(in cookieStore: WKHTTPCookieStore) {
         Task { @MainActor in
-            self.persistCookiesSilentlyIfAvailable()
+            self.persistCredentialSilentlyIfAvailable()
         }
     }
 }
@@ -637,6 +743,24 @@ final class MiscWebLoginRegistry {
 
     private static func config(for tool: ToolType) -> MiscWebLoginController.Config? {
         switch tool {
+        case .kimi:
+            return MiscWebLoginController.Config(
+                tool: .kimi,
+                loginURL: URL(string: "https://www.kimi.com/membership/subscription?tab=quota")!,
+                cookieDomainSuffixes: ["kimi.com"],
+                requiredCookieNames: KimiQuotaAdapter.cookieSpec.requiredNames,
+                trustedAuthHostSuffixes: ["kimi.com"],
+                windowTitle: "Kimi Login",
+                savedConfirmation: "Kimi session saved.",
+                setupHint: "Sign in to Kimi and open My Quota, then click Save Session.",
+                localStorageTokenCapture: MiscWebLoginController.LocalStorageTokenCapture(
+                    storageKey: "access_token",
+                    cookieName: "kimi-auth",
+                    allowedHostSuffixes: ["kimi.com"],
+                    sourceLabel: "Kimi Web login"
+                ),
+                enablesFormAutofill: false
+            )
         case .mimo:
             return MiscWebLoginController.Config(
                 tool: .mimo,

--- a/Sources/VibeBarApp/Views/MiscProviderLandingView.swift
+++ b/Sources/VibeBarApp/Views/MiscProviderLandingView.swift
@@ -27,6 +27,10 @@ struct MiscProviderLandingView: View {
                 .font(.system(size: 12, weight: .semibold))
                 .foregroundStyle(.secondary)
 
+            Text("Kimi is configured from its provider page: current quota auth lives in browser local storage, not Chrome's cookie database.")
+                .font(.caption2)
+                .foregroundStyle(.tertiary)
+
             if cookieTargets.isEmpty {
                 Text("No cookie-based providers are configured.")
                     .font(.caption)
@@ -35,7 +39,7 @@ struct MiscProviderLandingView: View {
                 HStack(spacing: 8) {
                     Button(action: importAll) {
                         Label(
-                            "Import Browser Cookies for All Providers",
+                            "Import Browser Cookies for Supported Providers",
                             systemImage: "safari"
                         )
                     }
@@ -48,7 +52,6 @@ struct MiscProviderLandingView: View {
                 Text("Reads your browsers once for all \(cookieTargets.count) cookie-based providers and adds a slot to each. Existing cookies stay; quotas are averaged across slots. macOS may ask for your login-keychain password once per Chromium-family browser involved.")
                     .font(.caption2)
                     .foregroundStyle(.tertiary)
-
                 if isImporting {
                     Text("Importing…")
                         .font(.caption)
@@ -89,6 +92,7 @@ struct MiscProviderLandingView: View {
     private var cookieTargets: [MiscCookieResolver.BatchImportTarget] {
         settingsStore.settings.miscProviderInstances.compactMap { instance in
             guard let spec = MiscCookieSpecCatalog.spec(for: instance.tool) else { return nil }
+            guard spec.supportsSystemBrowserImport else { return nil }
             return MiscCookieResolver.BatchImportTarget(spec: spec, instanceID: instance.id)
         }
     }
@@ -147,6 +151,7 @@ private struct OutcomeRow: View {
         case .noSessionFound:  return "minus.circle"
         case .cookiesDisabled: return "slash.circle"
         case .saveFailed:      return "exclamationmark.triangle"
+        case .browserImportUnsupported: return "info.circle"
         }
     }
 
@@ -154,6 +159,7 @@ private struct OutcomeRow: View {
         switch outcome {
         case .imported:                        return .green
         case .noSessionFound, .cookiesDisabled: return .secondary
+        case .browserImportUnsupported:         return .secondary
         case .saveFailed:                      return .orange
         }
     }
@@ -168,6 +174,8 @@ private struct OutcomeRow: View {
             return "Cookies disabled for this provider"
         case .saveFailed:
             return "Could not save to Keychain"
+        case .browserImportUnsupported:
+            return "Use this provider's setup page"
         }
     }
 }

--- a/Sources/VibeBarApp/Views/MiscProviderSettingsSection.swift
+++ b/Sources/VibeBarApp/Views/MiscProviderSettingsSection.swift
@@ -165,11 +165,18 @@ struct MiscProviderSettingsSection: View {
                 MiniMaxRegionPicker(instanceID: instanceID)
             }
         case .kimi:
-            CookieSourceControls(
-                tool: .kimi,
-                instanceID: instanceID,
-                manualPrompt: "Paste www.kimi.com Cookie header (kimi-auth=eyJ...)"
-            )
+            VStack(alignment: .leading, spacing: 4) {
+                MiscWebLoginRow(
+                    tool: .kimi,
+                    instanceID: instanceID,
+                    helpText: "Kimi's current quota API uses a browser-local access token; Chrome cookie import can be stale. Sign in here once to save it securely."
+                )
+                CookieSourceControls(
+                    tool: .kimi,
+                    instanceID: instanceID,
+                    manualPrompt: "Paste the current Kimi access token as kimi-auth=eyJ..."
+                )
+            }
         case .cursor:
             CookieSourceControls(
                 tool: .cursor,
@@ -737,8 +744,8 @@ struct KiroStatusRow: View {
 ///
 /// Each provider can stack multiple cookie sessions — one per account.
 /// The section shows the current list of imported slots (with source
-/// label, import time, and a delete button) plus two additive entry
-/// points: "Import from browser" and a manual paste field. Quota
+/// label, import time, and a delete button) plus a manual paste field and,
+/// when the provider supports it, "Import from browser". Quota
 /// queries fan out across every slot and the bucket percentages are
 /// averaged; see `MiscQuotaAggregator`.
 struct CookieSourceControls: View {
@@ -762,6 +769,10 @@ struct CookieSourceControls: View {
         MiscCookieSpecCatalog.spec(for: tool)
     }
 
+    private var allowsBrowserImport: Bool {
+        spec?.supportsSystemBrowserImport ?? false
+    }
+
     var body: some View {
         if spec == nil {
             Text("No cookie spec is registered for \(tool.menuTitle).")
@@ -775,7 +786,11 @@ struct CookieSourceControls: View {
     private var controls: some View {
         VStack(alignment: .leading, spacing: 6) {
             if slots.isEmpty {
-                Text("No cookies imported yet — import from your browser or paste below.")
+                Text(
+                    allowsBrowserImport
+                        ? "No cookies imported yet — import from your browser or paste below."
+                        : "No saved session yet — use Sign in via Web or paste the current token below."
+                )
                     .font(.caption)
                     .foregroundStyle(.tertiary)
             } else {
@@ -785,13 +800,15 @@ struct CookieSourceControls: View {
                     }
                 }
             }
-            HStack(spacing: 6) {
-                Button("Import from browser", action: importNow)
-                    .buttonStyle(.bordered)
-                    .controlSize(.small)
-                Text("Adds a new slot. Existing cookies stay; quotas are averaged across all slots.")
-                    .font(.caption)
-                    .foregroundStyle(.tertiary)
+            if allowsBrowserImport {
+                HStack(spacing: 6) {
+                    Button("Import from browser", action: importNow)
+                        .buttonStyle(.bordered)
+                        .controlSize(.small)
+                    Text("Adds a new slot. Existing cookies stay; quotas are averaged across all slots.")
+                        .font(.caption)
+                        .foregroundStyle(.tertiary)
+                }
             }
             HStack(spacing: 6) {
                 SecureField(manualPrompt, text: $manualDraft)
@@ -957,6 +974,9 @@ private struct CookieSlotRow: View {
     }
 
     private var icon: String {
+        if slot.captureKind == .webLogin {
+            return "person.crop.circle.badge.key"
+        }
         switch slot.origin {
         case .manual:         return "doc.on.clipboard"
         case .browserImport:  return "safari"

--- a/Sources/VibeBarCore/Adapters/KimiQuotaAdapter.swift
+++ b/Sources/VibeBarCore/Adapters/KimiQuotaAdapter.swift
@@ -2,23 +2,21 @@ import Foundation
 
 /// Moonshot / Kimi (kimi.com) usage adapter.
 ///
-/// Auth: the `kimi-auth` JWT cookie. Source resolution flows through
-/// `MiscCookieResolver` so the user can choose between auto-import
-/// from Chrome/Edge/Brave/Arc/Safari/Firefox, manual paste, or
-/// fully off.
-///
-/// Endpoints:
-/// `POST https://www.kimi.com/apiv2/kimi.gateway.billing.v1.BillingService/GetUsages`
-/// with body `{"scope":["FEATURE_CODING"]}`. Headers reproduce the
-/// web app — Bearer token, kimi-auth cookie, browser User-Agent,
-/// connect-protocol-version, plus session / device / traffic IDs
-/// extracted from the JWT payload.
+/// Auth: a Kimi bearer JWT. Current Kimi Web keeps it in
+/// `localStorage.access_token`; Vibe Bar's explicit Web login stores it as a
+/// synthetic `kimi-auth=<token>` Keychain slot. Legacy browser cookies and
+/// manual headers use that same slot shape, so source resolution continues to
+/// flow through `MiscCookieResolver`.
 ///
 /// `POST https://www.kimi.com/apiv2/kimi.gateway.membership.v2.MembershipService/GetSubscriptionStats`
-/// with body `{}` adds the shared monthly subscription balance shown on
-/// Kimi's Membership → My Quota page. That request is best-effort so a
-/// membership rollout or transient failure cannot erase the established
-/// weekly / five-hour quota.
+/// with body `{}` is the primary source for the weekly, five-hour and
+/// shared monthly balances shown on Kimi's Membership → My Quota page.
+/// Older deployments fall back to
+/// `POST https://www.kimi.com/apiv2/kimi.gateway.billing.v1.BillingService/GetUsages`
+/// with body `{"scope":["FEATURE_CODING"]}` for weekly / five-hour data.
+/// Headers reproduce the web app — Bearer token, kimi-auth cookie, browser
+/// User-Agent, connect-protocol-version, plus session / device / traffic IDs
+/// extracted from the JWT payload.
 ///
 /// Output: weekly bucket (primary) + 5-hour rate-limit bucket + monthly
 /// subscription bucket (when present).
@@ -31,8 +29,31 @@ public struct KimiQuotaAdapter: QuotaAdapter {
     public static let cookieSpec = MiscCookieResolver.Spec(
         tool: .kimi,
         domains: ["www.kimi.com", "kimi.com"],
-        requiredNames: ["kimi-auth"]
+        requiredNames: ["kimi-auth"],
+        supportsSystemBrowserImport: false
     )
+
+    /// Convert the current Kimi Web `localStorage.access_token` JWT into the
+    /// cookie-shaped Keychain slot already consumed by this adapter. Keeping
+    /// the validation in Core prevents a WebView value containing separators
+    /// or control characters from being persisted as a malformed header.
+    public static func cookieHeader(fromAccessToken raw: String) -> String? {
+        let token = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard token.count >= 16, token.count <= 4_096 else { return nil }
+        let segments = token.split(separator: ".", omittingEmptySubsequences: false)
+        guard segments.count == 3, segments.allSatisfy({ !$0.isEmpty }) else { return nil }
+        guard segments.allSatisfy({ segment in
+            segment.utf8.allSatisfy { byte in
+                (48...57).contains(byte) ||
+                    (65...90).contains(byte) ||
+                    (97...122).contains(byte) ||
+                    byte == 45 || byte == 95
+            }
+        }) else {
+            return nil
+        }
+        return "kimi-auth=\(token)"
+    }
 
     private static let usageEndpoint = URL(string:
         "https://www.kimi.com/apiv2/kimi.gateway.billing.v1.BillingService/GetUsages"
@@ -62,12 +83,14 @@ public struct KimiQuotaAdapter: QuotaAdapter {
         ) { resolution in
             try await self.fetchOneSlot(resolution, account: account, queriedAt: queriedAt)
         }
-        return MiscQuotaAggregator.aggregate(
+        var aggregated = MiscQuotaAggregator.aggregate(
             tool: .kimi,
             account: account,
             results: results,
             queriedAt: queriedAt
         )
+        aggregated.buckets = KimiResponseParser.canonicalBucketOrder(aggregated.buckets)
+        return aggregated
     }
 
     private func fetchOneSlot(
@@ -82,34 +105,145 @@ public struct KimiQuotaAdapter: QuotaAdapter {
             throw QuotaError.noCredential
         }
 
-        let usageRequest = Self.usageRequest(authToken: authToken)
-        let (data, _) = try await data(for: usageRequest)
-        let snapshot = try KimiResponseParser.parse(data: data, now: queriedAt)
-
-        var buckets = snapshot.buckets
-        let membershipOutcome = await AsyncTimeout.run(seconds: Self.membershipStatsWallTimeSeconds) {
-            do {
-                let request = Self.membershipStatsRequest(authToken: authToken)
-                let (data, _) = try await self.data(for: request)
-                return KimiMembershipFetchOutcome.data(data)
-            } catch {
-                return KimiMembershipFetchOutcome.failed
-            }
-        }
-        if case let .completed(.data(membershipData)) = membershipOutcome,
-           let monthly = try? KimiResponseParser.parseMonthly(data: membershipData) {
-            buckets.append(monthly)
+        let snapshot = try await Self.fetchSnapshot(
+            authToken: authToken,
+            queriedAt: queriedAt
+        ) { request in
+            let (data, _) = try await self.data(for: request)
+            return data
         }
 
         return AccountQuota(
             accountId: account.id,
             tool: .kimi,
-            buckets: buckets,
+            buckets: snapshot.buckets,
             plan: nil,
             email: account.email,
             queriedAt: queriedAt,
             error: nil
         )
+    }
+
+    static func fetchSnapshot(
+        authToken: String,
+        queriedAt: Date,
+        membershipTimeoutSeconds: Double = Self.membershipStatsWallTimeSeconds,
+        request: @escaping @Sendable (URLRequest) async throws -> Data
+    ) async throws -> KimiResponseParser.Snapshot {
+        let membershipOutcome = await AsyncTimeout.run(seconds: membershipTimeoutSeconds) {
+            do {
+                let data = try await request(Self.membershipStatsRequest(authToken: authToken))
+                return KimiMembershipFetchOutcome.snapshot(
+                    try KimiResponseParser.parseMembership(data: data)
+                )
+            } catch is CancellationError {
+                return KimiMembershipFetchOutcome.cancelled
+            } catch let error as URLError where error.code == .cancelled {
+                return KimiMembershipFetchOutcome.cancelled
+            } catch let error as QuotaError {
+                return KimiMembershipFetchOutcome.failed(error)
+            } catch {
+                return KimiMembershipFetchOutcome.failed(mapURLError(error))
+            }
+        }
+        try Task.checkCancellation()
+
+        switch membershipOutcome {
+        case let .completed(.snapshot(membership)):
+            return try await supplementMembershipIfNeeded(
+                membership,
+                authToken: authToken,
+                queriedAt: queriedAt,
+                request: request
+            )
+        case .completed(.cancelled):
+            throw CancellationError()
+        case let .completed(.failed(primaryError)):
+            // Older Kimi deployments expose only BillingService/GetUsages.
+            // Keep that as a compatibility fallback, but never make the old
+            // endpoint a prerequisite for the current Membership page data.
+            // Membership non-200 responses are not authoritative credential
+            // failures: Kimi's current web client can reject this optional
+            // surface while the same token still works for BillingService.
+            return try await legacySnapshot(
+                authToken: authToken,
+                queriedAt: queriedAt,
+                primaryError: primaryError,
+                request: request
+            )
+        case .timedOut:
+            return try await legacySnapshot(
+                authToken: authToken,
+                queriedAt: queriedAt,
+                primaryError: .network("timeout"),
+                request: request
+            )
+        }
+    }
+
+    /// Membership is authoritative for every bucket it returns, but rollouts
+    /// can temporarily omit one coding window. Fill only missing weekly/5h
+    /// lanes from Billing; a failed supplement must not erase valid monthly or
+    /// weekly Membership data.
+    private static func supplementMembershipIfNeeded(
+        _ membership: KimiResponseParser.Snapshot,
+        authToken: String,
+        queriedAt: Date,
+        request: @escaping @Sendable (URLRequest) async throws -> Data
+    ) async throws -> KimiResponseParser.Snapshot {
+        let ids = Set(membership.buckets.map(\.id))
+        guard !ids.contains("kimi.weekly") || !ids.contains("kimi.rate") else {
+            return membership
+        }
+        try Task.checkCancellation()
+        do {
+            let data = try await request(Self.usageRequest(authToken: authToken))
+            let legacy = try KimiResponseParser.parse(data: data, now: queriedAt)
+            return KimiResponseParser.merging(preferred: membership, fallback: legacy)
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch let error as URLError where error.code == .cancelled {
+            throw CancellationError()
+        } catch {
+            try Task.checkCancellation()
+            return membership
+        }
+    }
+
+    private static func legacySnapshot(
+        authToken: String,
+        queriedAt: Date,
+        primaryError: QuotaError,
+        request: @escaping @Sendable (URLRequest) async throws -> Data
+    ) async throws -> KimiResponseParser.Snapshot {
+        try Task.checkCancellation()
+        do {
+            let data = try await request(Self.usageRequest(authToken: authToken))
+            return try KimiResponseParser.parse(data: data, now: queriedAt)
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch let error as URLError where error.code == .cancelled {
+            throw CancellationError()
+        } catch let fallbackError as QuotaError {
+            throw mergedFailure(primary: primaryError, fallback: fallbackError)
+        } catch {
+            throw primaryError
+        }
+    }
+
+    /// The Membership endpoint is optional and can reject a token that the
+    /// Billing endpoint still accepts, so one credential-shaped error is not
+    /// enough to tell the user to log in again. The same rule keeps a single
+    /// endpoint's rate limit from hiding a more useful error from the other.
+    private static func mergedFailure(primary: QuotaError, fallback: QuotaError) -> QuotaError {
+        if primary.isCredentialState, fallback.isCredentialState {
+            return .needsLogin
+        }
+        if primary.isCredentialState { return fallback }
+        if fallback.isCredentialState { return primary }
+        if primary == .rateLimited, fallback != .rateLimited { return fallback }
+        if fallback == .rateLimited, primary != .rateLimited { return primary }
+        return primary
     }
 
     static func usageRequest(authToken: String) -> URLRequest {
@@ -166,6 +300,10 @@ public struct KimiQuotaAdapter: QuotaAdapter {
         let (data, response): (Data, URLResponse)
         do {
             (data, response) = try await self.session.data(for: request)
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch let error as URLError where error.code == .cancelled {
+            throw error
         } catch {
             throw QuotaError.network("Kimi network error: \(error.localizedDescription)")
         }
@@ -187,8 +325,9 @@ public struct KimiQuotaAdapter: QuotaAdapter {
 }
 
 private enum KimiMembershipFetchOutcome: Sendable {
-    case data(Data)
-    case failed
+    case snapshot(KimiResponseParser.Snapshot)
+    case failed(QuotaError)
+    case cancelled
 }
 
 // MARK: - JWT session info
@@ -221,7 +360,7 @@ struct KimiSessionInfo {
 // MARK: - Response parsing
 
 enum KimiResponseParser {
-    struct Snapshot {
+    struct Snapshot: Sendable {
         var buckets: [QuotaBucket]
     }
 
@@ -267,13 +406,74 @@ enum KimiResponseParser {
     }
 
     static func parseMonthly(data: Data) throws -> QuotaBucket? {
+        makeMonthlyBucket(from: try decodeMembership(data: data).subscriptionBalance)
+    }
+
+    static func parseMembership(data: Data) throws -> Snapshot {
+        let response = try decodeMembership(data: data)
+        var buckets: [QuotaBucket] = []
+
+        if let weekly = makeRateBucket(
+            id: "kimi.weekly",
+            title: "Weekly",
+            shortLabel: "Wk",
+            from: response.ratelimitCode7d,
+            windowSeconds: 7 * 86_400
+        ) {
+            buckets.append(weekly)
+        }
+        if let fiveHour = makeRateBucket(
+            id: "kimi.rate",
+            title: "5 Hours",
+            shortLabel: "5h",
+            from: response.ratelimitCode5h,
+            windowSeconds: 5 * 3600
+        ) {
+            buckets.append(fiveHour)
+        }
+        if let monthly = makeMonthlyBucket(from: response.subscriptionBalance) {
+            buckets.append(monthly)
+        }
+
+        guard !buckets.isEmpty else {
+            throw QuotaError.parseFailure("Kimi membership response had no usable usage windows.")
+        }
+        return Snapshot(buckets: buckets)
+    }
+
+    static func canonicalBucketOrder(_ buckets: [QuotaBucket]) -> [QuotaBucket] {
+        let rank = ["kimi.weekly", "kimi.rate", "kimi.monthly"]
+        return buckets.sorted { lhs, rhs in
+            let left = rank.firstIndex(of: lhs.id) ?? rank.count
+            let right = rank.firstIndex(of: rhs.id) ?? rank.count
+            return left == right ? lhs.id < rhs.id : left < right
+        }
+    }
+
+    static func merging(preferred: Snapshot, fallback: Snapshot) -> Snapshot {
+        var buckets = fallback.buckets
+        for bucket in preferred.buckets {
+            if let index = buckets.firstIndex(where: { $0.id == bucket.id }) {
+                buckets[index] = bucket
+            } else {
+                buckets.append(bucket)
+            }
+        }
+        return Snapshot(buckets: canonicalBucketOrder(buckets))
+    }
+
+    private static func decodeMembership(data: Data) throws -> KimiMembershipStatsResponse {
         let response: KimiMembershipStatsResponse
         do {
             response = try JSONDecoder().decode(KimiMembershipStatsResponse.self, from: data)
         } catch {
             throw QuotaError.parseFailure("Kimi membership response not parseable: \(error.localizedDescription)")
         }
-        guard let balance = response.subscriptionBalance,
+        return response
+    }
+
+    private static func makeMonthlyBucket(from balance: KimiSubscriptionBalance?) -> QuotaBucket? {
+        guard let balance,
               balance.feature == "FEATURE_OMNI",
               balance.type == "SUBSCRIPTION",
               let ratio = balance.amountUsedRatio,
@@ -287,6 +487,29 @@ enum KimiResponseParser {
             usedPercent: max(0, min(100, ratio * 100)),
             resetAt: parseResetTime(balance.expireTime),
             rawWindowSeconds: 30 * 86_400
+        )
+    }
+
+    private static func makeRateBucket(
+        id: String,
+        title: String,
+        shortLabel: String,
+        from limit: KimiMembershipRateLimit?,
+        windowSeconds: Int
+    ) -> QuotaBucket? {
+        guard let limit,
+              limit.enabled != false,
+              let ratio = limit.ratio,
+              ratio.isFinite else {
+            return nil
+        }
+        return QuotaBucket(
+            id: id,
+            title: title,
+            shortLabel: shortLabel,
+            usedPercent: max(0, min(100, ratio * 100)),
+            resetAt: parseResetTime(limit.resetTime),
+            rawWindowSeconds: windowSeconds
         )
     }
 
@@ -392,7 +615,15 @@ struct KimiAPIDetail: Decodable {
 }
 
 private struct KimiMembershipStatsResponse: Decodable {
+    let ratelimitCode5h: KimiMembershipRateLimit?
+    let ratelimitCode7d: KimiMembershipRateLimit?
     let subscriptionBalance: KimiSubscriptionBalance?
+}
+
+private struct KimiMembershipRateLimit: Decodable {
+    let ratio: Double?
+    let enabled: Bool?
+    let resetTime: String?
 }
 
 private struct KimiSubscriptionBalance: Decodable {

--- a/Sources/VibeBarCore/BrowserCookies/MiscCookieResolver.swift
+++ b/Sources/VibeBarCore/BrowserCookies/MiscCookieResolver.swift
@@ -34,19 +34,25 @@ public enum MiscCookieResolver {
         /// Default browser-import order if the user hasn't picked
         /// `MiscProviderSettings.preferredBrowser`.
         public let importOrder: BrowserCookieImportOrder
+        /// Whether the live credential still exists in browser cookie stores.
+        /// Kimi now uses localStorage and must go through its explicit Web
+        /// login instead of reporting a stale cookie as a successful import.
+        public let supportsSystemBrowserImport: Bool
 
         public init(
             tool: ToolType,
             domains: [String],
             requiredNames: Set<String>,
             credentialNames: Set<String> = [],
-            importOrder: BrowserCookieImportOrder = BrowserCookieDefaults.importOrder
+            importOrder: BrowserCookieImportOrder = BrowserCookieDefaults.importOrder,
+            supportsSystemBrowserImport: Bool = true
         ) {
             self.tool = tool
             self.domains = domains
             self.requiredNames = requiredNames
             self.credentialNames = credentialNames
             self.importOrder = importOrder
+            self.supportsSystemBrowserImport = supportsSystemBrowserImport
         }
 
         public func minimizedHeader(from raw: String?) -> String? {
@@ -113,8 +119,11 @@ public enum MiscCookieResolver {
             case .all:
                 return true
             case .browserOnly:
-                return slot.origin != .manual
+                return slot.origin != .manual || slot.captureKind == .webLogin
             case .manualOnly:
+                // A WebView login is an explicit user action rather than a
+                // passive system-browser import, so keep it usable even when
+                // the user selected the manual credential lane.
                 return slot.origin == .manual
             case .none:
                 return false
@@ -173,6 +182,7 @@ public enum MiscCookieResolver {
     }
 
     public static func appendBrowserImport(for spec: Spec, instanceID: String) -> Resolution? {
+        guard spec.supportsSystemBrowserImport else { return nil }
         let settings = currentSettings(for: spec.tool, instanceID: instanceID)
         guard SlotFilter(settings: settings) != .none else { return nil }
         guard let imported = importFromBrowsers(
@@ -235,6 +245,9 @@ public enum MiscCookieResolver {
             case cookiesDisabled
             /// A session was found but the Keychain write failed.
             case saveFailed
+            /// The provider's live credential is not stored as a browser
+            /// cookie and must use its provider-specific setup flow.
+            case browserImportUnsupported
         }
 
         public let tool: ToolType
@@ -275,6 +288,13 @@ public enum MiscCookieResolver {
     ) -> [BatchImportOutcome] {
         let context = BrowserImportContext()
         return targets.map { target in
+            guard target.spec.supportsSystemBrowserImport else {
+                return BatchImportOutcome(
+                    tool: target.tool,
+                    instanceID: target.instanceID,
+                    result: .browserImportUnsupported
+                )
+            }
             let settings = currentSettings(for: target.tool, instanceID: target.instanceID)
             guard SlotFilter(settings: settings) != .none else {
                 return BatchImportOutcome(
@@ -327,9 +347,9 @@ public enum MiscCookieResolver {
     ///
     /// Used by `MiscCookieAutoImporter` when a fetch came back
     /// `needsLogin`. Slots are replaced **in place** with origin
-    /// `.autoRefresh`; `origin == .manual` slots are left alone, the
-    /// same policy `HiddenCookieRefresher` follows — a cookie the user
-    /// pasted by hand is theirs to manage.
+    /// `.autoRefresh`; manual and WebView-login slots are left alone.
+    /// Those credentials came from an explicit user action and must not be
+    /// overwritten by a stale cookie from the system browser.
     ///
     /// Returns `true` when at least one slot's header actually changed,
     /// which is the caller's signal that a retry is worth a round-trip.
@@ -350,7 +370,7 @@ public enum MiscCookieResolver {
 
         let refreshable = MiscCookieSlotStore
             .slots(for: spec.tool, instanceID: instanceID)
-            .filter { $0.origin != .manual }
+            .filter(\.isSystemBrowserRefreshable)
         guard !refreshable.isEmpty else { return false }
 
         let sessions = browserSessions(

--- a/Sources/VibeBarCore/Credentials/MiscCookieSlotStore.swift
+++ b/Sources/VibeBarCore/Credentials/MiscCookieSlotStore.swift
@@ -12,11 +12,19 @@ public struct MiscCookieSlot: Codable, Equatable, Sendable, Identifiable {
         /// Pasted by the user via the Settings cookie field.
         case manual
         /// Snapshotted from a browser's cookie store (SweetCookieKit) or
-        /// captured by the in-app `MiscWebLoginController` web view.
+        /// a cookie-based in-app `MiscWebLoginController` web view.
         case browserImport
         /// Replaced in place by `HiddenCookieRefresher` after a silent
         /// console keepalive load.
         case autoRefresh
+    }
+
+    /// Additive metadata intentionally separate from `Origin`. Older builds
+    /// ignore this unknown optional JSON field while still decoding the slot's
+    /// wire-compatible `.manual` origin, so downgrading cannot make the whole
+    /// Keychain array unreadable and overwrite it on the next append.
+    public enum CaptureKind: String, Codable, Sendable, Equatable {
+        case webLogin
     }
 
     public let id: UUID
@@ -24,19 +32,27 @@ public struct MiscCookieSlot: Codable, Equatable, Sendable, Identifiable {
     public var sourceLabel: String
     public var importedAt: Date
     public var origin: Origin
+    public var captureKind: CaptureKind?
 
     public init(
         id: UUID = UUID(),
         cookieHeader: String,
         sourceLabel: String,
         importedAt: Date = Date(),
-        origin: Origin
+        origin: Origin,
+        captureKind: CaptureKind? = nil
     ) {
         self.id = id
         self.cookieHeader = cookieHeader
         self.sourceLabel = sourceLabel
         self.importedAt = importedAt
         self.origin = origin
+        self.captureKind = captureKind
+    }
+
+    public var isSystemBrowserRefreshable: Bool {
+        guard captureKind != .webLogin else { return false }
+        return origin == .browserImport || origin == .autoRefresh
     }
 }
 
@@ -110,6 +126,7 @@ public enum MiscCookieSlotStore {
             list[existing].importedAt = slot.importedAt
             list[existing].sourceLabel = slot.sourceLabel
             list[existing].origin = slot.origin
+            list[existing].captureKind = slot.captureKind
         } else {
             list.append(slot)
         }

--- a/Sources/VibeBarCore/Services/QuotaService.swift
+++ b/Sources/VibeBarCore/Services/QuotaService.swift
@@ -177,7 +177,11 @@ public final class QuotaService: ObservableObject {
         let outcome = await AsyncTimeout.run(seconds: refreshTimeoutSeconds) {
             defer { completion.finish() }
             do {
-                return QuotaAdapterFetchResult.success(try await adapter.fetch(for: account))
+                let quota = try await adapter.fetch(for: account)
+                if let error = quota.error {
+                    return QuotaAdapterFetchResult.failure(error)
+                }
+                return QuotaAdapterFetchResult.success(quota)
             } catch let qe as QuotaError {
                 return QuotaAdapterFetchResult.failure(qe)
             } catch {

--- a/Sources/VibeBarCore/Utilities/HostSuffixMatcher.swift
+++ b/Sources/VibeBarCore/Utilities/HostSuffixMatcher.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+/// Exact-or-subdomain matching for trusted web-login origins.
+///
+/// Requiring the dot boundary keeps lookalikes such as `evilkimi.com`
+/// outside a `kimi.com` allowlist.
+public enum HostSuffixMatcher {
+    public static func matches(_ rawHost: String?, allowedSuffixes: [String]) -> Bool {
+        guard let host = rawHost?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased(),
+              !host.isEmpty else {
+            return false
+        }
+        return allowedSuffixes.contains { rawSuffix in
+            let lowered = rawSuffix.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+            let suffix = lowered.hasPrefix(".") ? String(lowered.dropFirst()) : lowered
+            guard !suffix.isEmpty else { return false }
+            return host == suffix || host.hasSuffix("." + suffix)
+        }
+    }
+}

--- a/Tests/VibeBarCoreTests/HostSuffixMatcherTests.swift
+++ b/Tests/VibeBarCoreTests/HostSuffixMatcherTests.swift
@@ -1,0 +1,14 @@
+import XCTest
+@testable import VibeBarCore
+
+final class HostSuffixMatcherTests: XCTestCase {
+    func testMatchesExactHostAndSubdomainsOnly() {
+        XCTAssertTrue(HostSuffixMatcher.matches("kimi.com", allowedSuffixes: ["kimi.com"]))
+        XCTAssertTrue(HostSuffixMatcher.matches("www.kimi.com", allowedSuffixes: ["kimi.com"]))
+        XCTAssertTrue(HostSuffixMatcher.matches("WWW.KIMI.COM", allowedSuffixes: [".kimi.com"]))
+        XCTAssertFalse(HostSuffixMatcher.matches("evilkimi.com", allowedSuffixes: ["kimi.com"]))
+        XCTAssertFalse(HostSuffixMatcher.matches("moonshot.cn", allowedSuffixes: ["kimi.com"]))
+        XCTAssertFalse(HostSuffixMatcher.matches(nil, allowedSuffixes: ["kimi.com"]))
+        XCTAssertFalse(HostSuffixMatcher.matches("kimi.com", allowedSuffixes: [""]))
+    }
+}

--- a/Tests/VibeBarCoreTests/KimiMiniMaxParserTests.swift
+++ b/Tests/VibeBarCoreTests/KimiMiniMaxParserTests.swift
@@ -4,6 +4,27 @@ import XCTest
 final class KimiParserTests: XCTestCase {
     private let now = Date(timeIntervalSince1970: 1_715_000_000)
 
+    func testKimiAccessTokenBecomesCookieShapedHeader() {
+        let token = "synthetic-header.synthetic_payload.synthetic-signature"
+        XCTAssertEqual(
+            KimiQuotaAdapter.cookieHeader(fromAccessToken: "  \(token)\n"),
+            "kimi-auth=\(token)"
+        )
+    }
+
+    func testKimiAccessTokenRejectsMalformedOrInjectableValues() {
+        XCTAssertNil(KimiQuotaAdapter.cookieHeader(fromAccessToken: "not-a-jwt"))
+        XCTAssertNil(KimiQuotaAdapter.cookieHeader(fromAccessToken: "a..c"))
+        XCTAssertNil(KimiQuotaAdapter.cookieHeader(fromAccessToken: "aaa.bbb.ccc;other=value"))
+        XCTAssertNil(KimiQuotaAdapter.cookieHeader(fromAccessToken: "aaa.bbb.ccc\r\nInjected: value"))
+        XCTAssertNil(KimiQuotaAdapter.cookieHeader(fromAccessToken: "aaa.bébé.ccc"))
+        XCTAssertNil(
+            KimiQuotaAdapter.cookieHeader(
+                fromAccessToken: "aaa.\(String(repeating: "b", count: 4_100)).ccc"
+            )
+        )
+    }
+
     func testParsesWeeklyAndRateLimit() throws {
         let json = """
         {
@@ -141,6 +162,252 @@ final class KimiParserTests: XCTestCase {
         )
     }
 
+    func testParsesMembershipStatsInStableBucketOrder() throws {
+        let snap = try KimiResponseParser.parseMembership(data: membershipStatsJSON)
+
+        XCTAssertEqual(snap.buckets.map(\.id), ["kimi.weekly", "kimi.rate", "kimi.monthly"])
+        XCTAssertEqual(snap.buckets[0].usedPercent, 34, accuracy: 0.001)
+        XCTAssertEqual(snap.buckets[1].usedPercent, 12, accuracy: 0.001)
+        XCTAssertEqual(snap.buckets[2].usedPercent, 56, accuracy: 0.001)
+        XCTAssertEqual(snap.buckets.map(\.rawWindowSeconds), [7 * 86_400, 5 * 3_600, 30 * 86_400])
+    }
+
+    func testMembershipPrimaryDoesNotCallLegacy() async throws {
+        let recorder = KimiRequestRecorder(responses: [
+            "/apiv2/kimi.gateway.membership.v2.MembershipService/GetSubscriptionStats": .success(membershipStatsJSON)
+        ])
+
+        let snap = try await KimiQuotaAdapter.fetchSnapshot(
+            authToken: "synthetic.header.signature",
+            queriedAt: now,
+            request: { request in try await recorder.data(for: request) }
+        )
+
+        XCTAssertEqual(snap.buckets.map(\.id), ["kimi.weekly", "kimi.rate", "kimi.monthly"])
+        let requestedPaths = await recorder.requestedPaths()
+        XCTAssertEqual(requestedPaths, [
+            "/apiv2/kimi.gateway.membership.v2.MembershipService/GetSubscriptionStats"
+        ])
+    }
+
+    func testPartialMembershipUsesLegacyToFillMissingFiveHourWindow() async throws {
+        let recorder = KimiRequestRecorder(responses: [
+            "/apiv2/kimi.gateway.membership.v2.MembershipService/GetSubscriptionStats": .success(partialMembershipStatsJSON),
+            "/apiv2/kimi.gateway.billing.v1.BillingService/GetUsages": .success(legacyUsageJSON)
+        ])
+
+        let snap = try await KimiQuotaAdapter.fetchSnapshot(
+            authToken: "synthetic.header.signature",
+            queriedAt: now,
+            request: { request in try await recorder.data(for: request) }
+        )
+
+        XCTAssertEqual(snap.buckets.map(\.id), ["kimi.weekly", "kimi.rate", "kimi.monthly"])
+        XCTAssertEqual(snap.buckets[0].usedPercent, 34, accuracy: 0.001)
+        XCTAssertEqual(snap.buckets[1].usedPercent, 12, accuracy: 0.001)
+        XCTAssertEqual(snap.buckets[2].usedPercent, 56, accuracy: 0.001)
+        let requestedPaths = await recorder.requestedPaths()
+        XCTAssertEqual(requestedPaths, [
+            "/apiv2/kimi.gateway.membership.v2.MembershipService/GetSubscriptionStats",
+            "/apiv2/kimi.gateway.billing.v1.BillingService/GetUsages"
+        ])
+    }
+
+    func testPartialMembershipSurvivesFailedLegacySupplement() async throws {
+        let recorder = KimiRequestRecorder(responses: [
+            "/apiv2/kimi.gateway.membership.v2.MembershipService/GetSubscriptionStats": .success(partialMembershipStatsJSON),
+            "/apiv2/kimi.gateway.billing.v1.BillingService/GetUsages": .failure(.needsLogin)
+        ])
+
+        let snap = try await KimiQuotaAdapter.fetchSnapshot(
+            authToken: "synthetic.header.signature",
+            queriedAt: now,
+            request: { request in try await recorder.data(for: request) }
+        )
+
+        XCTAssertEqual(snap.buckets.map(\.id), ["kimi.weekly", "kimi.monthly"])
+        XCTAssertEqual(snap.buckets[0].usedPercent, 34, accuracy: 0.001)
+        XCTAssertEqual(snap.buckets[1].usedPercent, 56, accuracy: 0.001)
+    }
+
+    func testPartialMembershipSupplementCancellationPropagates() async throws {
+        let membershipPath = "/apiv2/kimi.gateway.membership.v2.MembershipService/GetSubscriptionStats"
+        let legacyPath = "/apiv2/kimi.gateway.billing.v1.BillingService/GetUsages"
+        let recorder = KimiRequestRecorder(
+            responses: [membershipPath: .success(partialMembershipStatsJSON)],
+            cancelledPaths: [legacyPath]
+        )
+
+        do {
+            _ = try await KimiQuotaAdapter.fetchSnapshot(
+                authToken: "synthetic.header.signature",
+                queriedAt: now,
+                request: { request in try await recorder.data(for: request) }
+            )
+            XCTFail("Expected cancellation")
+        } catch {
+            XCTAssertTrue(error is CancellationError, "Expected CancellationError, got \(error)")
+        }
+    }
+
+    func testMembershipParseFailureFallsBackToLegacyUsage() async throws {
+        let recorder = KimiRequestRecorder(responses: [
+            "/apiv2/kimi.gateway.membership.v2.MembershipService/GetSubscriptionStats": .success(Data("{}".utf8)),
+            "/apiv2/kimi.gateway.billing.v1.BillingService/GetUsages": .success(legacyUsageJSON)
+        ])
+
+        let snap = try await KimiQuotaAdapter.fetchSnapshot(
+            authToken: "synthetic.header.signature",
+            queriedAt: now,
+            request: { request in try await recorder.data(for: request) }
+        )
+
+        XCTAssertEqual(snap.buckets.map(\.id), ["kimi.weekly", "kimi.rate"])
+        let requestedPaths = await recorder.requestedPaths()
+        XCTAssertEqual(requestedPaths, [
+            "/apiv2/kimi.gateway.membership.v2.MembershipService/GetSubscriptionStats",
+            "/apiv2/kimi.gateway.billing.v1.BillingService/GetUsages"
+        ])
+    }
+
+    func testMembershipCredentialFailureFallsBackToLegacyUsage() async throws {
+        let recorder = KimiRequestRecorder(responses: [
+            "/apiv2/kimi.gateway.membership.v2.MembershipService/GetSubscriptionStats": .failure(.needsLogin),
+            "/apiv2/kimi.gateway.billing.v1.BillingService/GetUsages": .success(legacyUsageJSON)
+        ])
+
+        let snap = try await KimiQuotaAdapter.fetchSnapshot(
+            authToken: "synthetic.header.signature",
+            queriedAt: now,
+            request: { request in try await recorder.data(for: request) }
+        )
+
+        XCTAssertEqual(snap.buckets.map(\.id), ["kimi.weekly", "kimi.rate"])
+        let requestedPaths = await recorder.requestedPaths()
+        XCTAssertEqual(requestedPaths, [
+            "/apiv2/kimi.gateway.membership.v2.MembershipService/GetSubscriptionStats",
+            "/apiv2/kimi.gateway.billing.v1.BillingService/GetUsages"
+        ])
+    }
+
+    func testBothKimiEndpointsRejectCredentialAsNeedsLogin() async throws {
+        let recorder = KimiRequestRecorder(responses: [
+            "/apiv2/kimi.gateway.membership.v2.MembershipService/GetSubscriptionStats": .failure(.needsLogin),
+            "/apiv2/kimi.gateway.billing.v1.BillingService/GetUsages": .failure(.needsLogin)
+        ])
+
+        do {
+            _ = try await KimiQuotaAdapter.fetchSnapshot(
+                authToken: "synthetic.header.signature",
+                queriedAt: now,
+                request: { request in try await recorder.data(for: request) }
+            )
+            XCTFail("Expected needsLogin")
+        } catch let error as QuotaError {
+            XCTAssertEqual(error, .needsLogin)
+        }
+    }
+
+    func testMembershipCredentialErrorDoesNotMaskLegacyNetworkError() async throws {
+        let recorder = KimiRequestRecorder(responses: [
+            "/apiv2/kimi.gateway.membership.v2.MembershipService/GetSubscriptionStats": .failure(.needsLogin),
+            "/apiv2/kimi.gateway.billing.v1.BillingService/GetUsages": .failure(.network("legacy unavailable"))
+        ])
+
+        do {
+            _ = try await KimiQuotaAdapter.fetchSnapshot(
+                authToken: "synthetic.header.signature",
+                queriedAt: now,
+                request: { request in try await recorder.data(for: request) }
+            )
+            XCTFail("Expected network error")
+        } catch let error as QuotaError {
+            XCTAssertEqual(error, .network("legacy unavailable"))
+        }
+    }
+
+    func testLegacyCredentialErrorDoesNotMaskMembershipParseError() async throws {
+        let parseError = QuotaError.parseFailure("membership changed")
+        let recorder = KimiRequestRecorder(responses: [
+            "/apiv2/kimi.gateway.membership.v2.MembershipService/GetSubscriptionStats": .failure(parseError),
+            "/apiv2/kimi.gateway.billing.v1.BillingService/GetUsages": .failure(.needsLogin)
+        ])
+
+        do {
+            _ = try await KimiQuotaAdapter.fetchSnapshot(
+                authToken: "synthetic.header.signature",
+                queriedAt: now,
+                request: { request in try await recorder.data(for: request) }
+            )
+            XCTFail("Expected parse error")
+        } catch let error as QuotaError {
+            XCTAssertEqual(error, parseError)
+        }
+    }
+
+    func testMembershipRateLimitStillFallsBackToLegacyUsage() async throws {
+        let recorder = KimiRequestRecorder(responses: [
+            "/apiv2/kimi.gateway.membership.v2.MembershipService/GetSubscriptionStats": .failure(.rateLimited),
+            "/apiv2/kimi.gateway.billing.v1.BillingService/GetUsages": .success(legacyUsageJSON)
+        ])
+
+        let snap = try await KimiQuotaAdapter.fetchSnapshot(
+            authToken: "synthetic.header.signature",
+            queriedAt: now,
+            request: { request in try await recorder.data(for: request) }
+        )
+
+        XCTAssertEqual(snap.buckets.map(\.id), ["kimi.weekly", "kimi.rate"])
+    }
+
+    func testMembershipTimeoutPreservesPrimaryErrorWhenLegacyAlsoFails() async throws {
+        let membershipPath = "/apiv2/kimi.gateway.membership.v2.MembershipService/GetSubscriptionStats"
+        let legacyPath = "/apiv2/kimi.gateway.billing.v1.BillingService/GetUsages"
+        let recorder = KimiRequestRecorder(
+            responses: [
+                membershipPath: .success(membershipStatsJSON),
+                legacyPath: .failure(.network("legacy unavailable"))
+            ],
+            delayNanoseconds: [membershipPath: 50_000_000]
+        )
+
+        do {
+            _ = try await KimiQuotaAdapter.fetchSnapshot(
+                authToken: "synthetic.header.signature",
+                queriedAt: now,
+                membershipTimeoutSeconds: 0.001,
+                request: { request in try await recorder.data(for: request) }
+            )
+            XCTFail("Expected timeout")
+        } catch let error as QuotaError {
+            XCTAssertEqual(error, .network("timeout"))
+        }
+        let requestedPaths = await recorder.requestedPaths()
+        XCTAssertEqual(requestedPaths, [membershipPath, legacyPath])
+    }
+
+    func testMembershipCancellationDoesNotCallLegacy() async throws {
+        let membershipPath = "/apiv2/kimi.gateway.membership.v2.MembershipService/GetSubscriptionStats"
+        let legacyPath = "/apiv2/kimi.gateway.billing.v1.BillingService/GetUsages"
+        let recorder = KimiRequestRecorder(
+            responses: [legacyPath: .success(legacyUsageJSON)],
+            cancelledPaths: [membershipPath]
+        )
+
+        do {
+            _ = try await KimiQuotaAdapter.fetchSnapshot(
+                authToken: "synthetic.header.signature",
+                queriedAt: now,
+                request: { request in try await recorder.data(for: request) }
+            )
+            XCTFail("Expected cancellation")
+        } catch {
+            XCTAssertTrue(error is CancellationError, "Expected CancellationError, got \(error)")
+        }
+        let requestedPaths = await recorder.requestedPaths()
+        XCTAssertEqual(requestedPaths, [membershipPath])
+    }
+
     func testMonthlyIgnoresNonSubscriptionBalance() throws {
         let json = """
         {
@@ -206,6 +473,97 @@ final class KimiParserTests: XCTestCase {
         XCTAssertEqual(KimiSessionInfo.fromJWT("garbage").deviceId, nil)
         XCTAssertEqual(KimiSessionInfo.fromJWT("a.b").sessionId, nil)
     }
+
+    private var membershipStatsJSON: Data {
+        Data("""
+        {
+          "ratelimitCode5h": {
+            "ratio": 0.12,
+            "enabled": true,
+            "resetTime": "2026-08-24T01:47:00Z"
+          },
+          "ratelimitCode7d": {
+            "ratio": 0.34,
+            "enabled": true,
+            "resetTime": "2026-08-30T00:46:59Z"
+          },
+          "subscriptionBalance": {
+            "feature": "FEATURE_OMNI",
+            "type": "SUBSCRIPTION",
+            "amountUsedRatio": 0.56,
+            "kimiCodeUsedRatio": 0.20,
+            "expireTime": "2026-09-02T00:00:00Z"
+          }
+        }
+        """.utf8)
+    }
+
+    private var partialMembershipStatsJSON: Data {
+        Data("""
+        {
+          "ratelimitCode7d": {
+            "ratio": 0.34,
+            "enabled": true,
+            "resetTime": "2026-08-30T00:46:59Z"
+          },
+          "subscriptionBalance": {
+            "feature": "FEATURE_OMNI",
+            "type": "SUBSCRIPTION",
+            "amountUsedRatio": 0.56,
+            "expireTime": "2026-09-02T00:00:00Z"
+          }
+        }
+        """.utf8)
+    }
+
+    private var legacyUsageJSON: Data {
+        Data("""
+        {
+          "usages": [{
+            "scope": "FEATURE_CODING",
+            "detail": {"limit":"1000","used":"234","remaining":"766"},
+            "limits": [{
+              "window": {"duration":300,"timeUnit":"TIME_UNIT_MINUTE"},
+              "detail": {"limit":"100","used":"12","remaining":"88"}
+            }]
+          }]
+        }
+        """.utf8)
+    }
+}
+
+private actor KimiRequestRecorder {
+    private let responses: [String: Result<Data, QuotaError>]
+    private let cancelledPaths: Set<String>
+    private let delayNanoseconds: [String: UInt64]
+    private var paths: [String] = []
+
+    init(
+        responses: [String: Result<Data, QuotaError>],
+        cancelledPaths: Set<String> = [],
+        delayNanoseconds: [String: UInt64] = [:]
+    ) {
+        self.responses = responses
+        self.cancelledPaths = cancelledPaths
+        self.delayNanoseconds = delayNanoseconds
+    }
+
+    func data(for request: URLRequest) async throws -> Data {
+        let path = request.url?.path ?? ""
+        paths.append(path)
+        if let delay = delayNanoseconds[path] {
+            try await Task.sleep(nanoseconds: delay)
+        }
+        if cancelledPaths.contains(path) {
+            throw CancellationError()
+        }
+        guard let response = responses[path] else {
+            throw QuotaError.unknown("unexpected Kimi request")
+        }
+        return try response.get()
+    }
+
+    func requestedPaths() -> [String] { paths }
 }
 
 final class MiniMaxParserTests: XCTestCase {

--- a/Tests/VibeBarCoreTests/MiscCookieSlotTests.swift
+++ b/Tests/VibeBarCoreTests/MiscCookieSlotTests.swift
@@ -38,6 +38,29 @@ final class MiscCookieSlotTests: XCTestCase {
         XCTAssertEqual(slot.cookieHeader, "foo=bar")
     }
 
+    func testWebLoginCaptureKindRoundTripsWithLegacyOrigin() throws {
+        let slot = MiscCookieSlot(
+            cookieHeader: "kimi-auth=synthetic.header.signature",
+            sourceLabel: "Kimi Web login",
+            importedAt: Date(timeIntervalSince1970: 1_700_000_000),
+            origin: .manual,
+            captureKind: .webLogin
+        )
+
+        XCTAssertEqual(try JSONDecoder().decode(MiscCookieSlot.self, from: JSONEncoder().encode(slot)), slot)
+    }
+
+    func testDev40DecoderCanReadWebLoginSlotWithoutDroppingTheArray() throws {
+        let slot = webLoginSlot()
+        let data = try JSONEncoder().encode([slot])
+
+        let legacy = try JSONDecoder().decode([Dev40MiscCookieSlot].self, from: data)
+
+        XCTAssertEqual(legacy.count, 1)
+        XCTAssertEqual(legacy[0].cookieHeader, slot.cookieHeader)
+        XCTAssertEqual(legacy[0].origin, .manual)
+    }
+
     func testSlotFilterFromSettings() {
         // Auto mode: all origins pass.
         let auto = MiscCookieResolver.SlotFilter(
@@ -46,6 +69,7 @@ final class MiscCookieSlotTests: XCTestCase {
         XCTAssertEqual(auto, .all)
         XCTAssertTrue(auto.allows(slot(origin: .manual)))
         XCTAssertTrue(auto.allows(slot(origin: .browserImport)))
+        XCTAssertTrue(auto.allows(webLoginSlot()))
         XCTAssertTrue(auto.allows(slot(origin: .autoRefresh)))
 
         // Auto with cookieSource = manual collapses to manualOnly.
@@ -54,6 +78,7 @@ final class MiscCookieSlotTests: XCTestCase {
         )
         XCTAssertEqual(manualViaCookieSource, .manualOnly)
         XCTAssertTrue(manualViaCookieSource.allows(slot(origin: .manual)))
+        XCTAssertTrue(manualViaCookieSource.allows(webLoginSlot()))
         XCTAssertFalse(manualViaCookieSource.allows(slot(origin: .browserImport)))
 
         // Explicit browserOnly source mode.
@@ -63,6 +88,7 @@ final class MiscCookieSlotTests: XCTestCase {
         XCTAssertEqual(browser, .browserOnly)
         XCTAssertFalse(browser.allows(slot(origin: .manual)))
         XCTAssertTrue(browser.allows(slot(origin: .browserImport)))
+        XCTAssertTrue(browser.allows(webLoginSlot()))
         XCTAssertTrue(browser.allows(slot(origin: .autoRefresh)))
 
         // apiOnly / off shut every slot out.
@@ -78,6 +104,13 @@ final class MiscCookieSlotTests: XCTestCase {
         XCTAssertEqual(off, .none)
     }
 
+    func testOnlySystemBrowserOriginsCanBeSilentlyReimported() {
+        XCTAssertFalse(slot(origin: .manual).isSystemBrowserRefreshable)
+        XCTAssertTrue(slot(origin: .browserImport).isSystemBrowserRefreshable)
+        XCTAssertTrue(slot(origin: .autoRefresh).isSystemBrowserRefreshable)
+        XCTAssertFalse(webLoginSlot().isSystemBrowserRefreshable)
+    }
+
     private func slot(origin: MiscCookieSlot.Origin) -> MiscCookieSlot {
         MiscCookieSlot(
             cookieHeader: "name=value",
@@ -86,4 +119,30 @@ final class MiscCookieSlotTests: XCTestCase {
             origin: origin
         )
     }
+
+    private func webLoginSlot() -> MiscCookieSlot {
+        MiscCookieSlot(
+            cookieHeader: "kimi-auth=synthetic.header.signature",
+            sourceLabel: "Kimi Web login",
+            importedAt: Date(),
+            origin: .manual,
+            captureKind: .webLogin
+        )
+    }
+}
+
+/// Exact wire shape shipped in Dev 40. Unknown additive object fields are
+/// ignored by synthesized Decodable, but unknown enum raw values are not.
+private struct Dev40MiscCookieSlot: Decodable {
+    enum Origin: String, Decodable {
+        case manual
+        case browserImport
+        case autoRefresh
+    }
+
+    let id: UUID
+    let cookieHeader: String
+    let sourceLabel: String
+    let importedAt: Date
+    let origin: Origin
 }

--- a/Tests/VibeBarCoreTests/MiscCookieSpecCatalogTests.swift
+++ b/Tests/VibeBarCoreTests/MiscCookieSpecCatalogTests.swift
@@ -88,7 +88,30 @@ final class MiscCookieSpecCatalogTests: XCTestCase {
                 adapterSpec.credentialNames,
                 "\(tool.rawValue) credentialNames"
             )
+            XCTAssertEqual(
+                catalogSpec.supportsSystemBrowserImport,
+                adapterSpec.supportsSystemBrowserImport,
+                "\(tool.rawValue) browser-import capability"
+            )
         }
+    }
+
+    func testOnlyKimiRequiresProviderSpecificWebLogin() {
+        for spec in MiscCookieSpecCatalog.allSpecs {
+            XCTAssertEqual(
+                spec.supportsSystemBrowserImport,
+                spec.tool != .kimi,
+                "\(spec.tool.rawValue) browser-import capability"
+            )
+        }
+    }
+
+    func testKimiBrowserImportIsRejectedBeforeBrowserOrKeychainAccess() {
+        XCTAssertNil(MiscCookieResolver.appendBrowserImport(for: KimiQuotaAdapter.cookieSpec))
+        let outcomes = MiscCookieResolver.appendBrowserImports(for: [
+            .init(spec: KimiQuotaAdapter.cookieSpec, instanceID: "kimi")
+        ])
+        XCTAssertEqual(outcomes.map(\.result), [.browserImportUnsupported])
     }
 
     func testNonCookieProvidersHaveNoSpec() {

--- a/Tests/VibeBarCoreTests/QuotaServiceFreshnessTests.swift
+++ b/Tests/VibeBarCoreTests/QuotaServiceFreshnessTests.swift
@@ -97,6 +97,68 @@ final class QuotaServiceFreshnessTests: XCTestCase {
         XCTAssertGreaterThanOrEqual(attempted, queriedAt)
     }
 
+    func testErrorBearingQuotaPreservesTheLastSuccessfulCache() async throws {
+        let account = AccountIdentity(id: "embedded-error-cache", tool: .kimi, source: .browserCookie)
+        let queriedAt = Date().addingTimeInterval(-8 * 3_600)
+        let cachedBucket = QuotaBucket(
+            id: "kimi.weekly",
+            title: "Weekly",
+            shortLabel: "Wk",
+            usedPercent: 25
+        )
+        let service = QuotaService(
+            adapters: [.kimi: FreshnessSequenceAdapter(tool: .kimi, results: [
+                .success(AccountQuota(
+                    accountId: account.id,
+                    tool: .kimi,
+                    buckets: [cachedBucket],
+                    queriedAt: queriedAt
+                )),
+                .success(AccountQuota(
+                    accountId: account.id,
+                    tool: .kimi,
+                    buckets: [],
+                    queriedAt: Date(),
+                    error: .network("upstream")
+                ))
+            ])],
+            mockProvider: { false }
+        )
+
+        _ = await service.refresh(account)
+        let returned = await service.refresh(account)
+
+        XCTAssertEqual(returned.buckets, [cachedBucket])
+        XCTAssertEqual(returned.error, .network("upstream"))
+        XCTAssertEqual(service.cachedQuota(for: account.id)?.buckets, [cachedBucket])
+        XCTAssertEqual(service.lastUpdatedByAccount[account.id], queriedAt)
+        XCTAssertEqual(service.lastErrorByAccount[account.id], .network("upstream"))
+    }
+
+    func testErrorBearingQuotaWithoutCacheDoesNotBecomeASuccess() async {
+        let account = AccountIdentity(id: "embedded-error-empty", tool: .kimi, source: .browserCookie)
+        let service = QuotaService(
+            adapters: [.kimi: FreshnessSequenceAdapter(tool: .kimi, results: [
+                .success(AccountQuota(
+                    accountId: account.id,
+                    tool: .kimi,
+                    buckets: [],
+                    queriedAt: Date(),
+                    error: .needsLogin
+                ))
+            ])],
+            mockProvider: { false }
+        )
+
+        let returned = await service.refresh(account)
+
+        XCTAssertTrue(returned.buckets.isEmpty)
+        XCTAssertEqual(returned.error, .needsLogin)
+        XCTAssertNil(service.cachedQuota(for: account.id))
+        XCTAssertNil(service.lastUpdatedByAccount[account.id])
+        XCTAssertEqual(service.lastErrorByAccount[account.id], .needsLogin)
+    }
+
     func testClearingAnAccountDropsBothTimestamps() async {
         let account = AccountIdentity(id: "freshness-clear", tool: .gemini, source: .webCookie)
         let service = QuotaService(


### PR DESCRIPTION
## Summary

- read Kimi's current weekly, 5-hour, and monthly quota from `MembershipService/GetSubscriptionStats`, with the legacy Billing endpoint used only for failure or missing-window supplementation
- add an explicit `Sign in via Web` flow that captures Kimi's current `localStorage.access_token` only from `kimi.com`, validates it as a JWT, and stores it in the existing Keychain slot model
- stop browser-cookie import from claiming Kimi's stale `kimi-auth` cookie, while keeping Web-login slots safe from silent Chrome overwrite and backward-compatible with Dev 40 decoders
- treat error-bearing quota snapshots as failed refreshes so stale data and timestamps are preserved instead of rendering `Not configured`

## Verification

- `swift test`: 1607 tests, 1 skipped, 0 failures
- `./Scripts/build_app.sh release`
- `codesign --verify --deep --strict ".build/Vibe Bar.app"`
- entitlements: empty dictionary, App Sandbox absent
- `git diff --check` and credential/privacy scan
- read-only Chrome verification: the signed-in Kimi page returned HTTP 200 with the expected 5-hour, 7-day, and subscription-balance fields; no token value was logged or committed