### PR TITLE
Prepare Vibe Bar 1.3.0 Dev build 41

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.3.0</string>
 	<key>CFBundleVersion</key>
-	<string>40</string>
+	<string>41</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>26.0</string>
 	<key>LSUIElement</key>


### PR DESCRIPTION
## Summary

- bump `CFBundleVersion` from 40 to 41 for the next Dev release
- release the Kimi authentication/quota refresh fix merged in #216

## Verification

- `plutil -lint Resources/Info.plist`
- `swift test`: 1607 tests, 1 skipped, 0 failures
- `./Scripts/build_app.sh release`
- packaged app reports `1.3.0 (41)`
- strict deep codesign passes; entitlements are an empty dictionary