### PR TITLE
Restore browser-backed credential imports

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -22,10 +22,10 @@ let package = Package(
         // so the pin is the only thing that makes two builds of the same
         // Vibe Bar commit contain the same package. Bump it deliberately.
         .package(url: "https://github.com/AstroQore/agent-session-kit.git", exact: "0.4.2"),
-        // SweetCookieKit encapsulates the Chromium SQLite parsing, "Chrome
-        // Safe Storage" Keychain decryption, and Safari binarycookies /
-        // Firefox SQLite reads that the misc-providers feature needs.
-        .package(url: "https://github.com/steipete/SweetCookieKit", from: "0.4.0"),
+        // SweetCookieKit encapsulates Chromium cookie + localStorage parsing,
+        // "Chrome Safe Storage" Keychain decryption, and Safari
+        // binarycookies / Firefox SQLite reads used by misc providers.
+        .package(url: "https://github.com/steipete/SweetCookieKit", exact: "0.5.2"),
         // Sparkle is the standard update framework for independently
         // distributed macOS applications. Pin the exact reviewed release:
         // update verification and installation are security-sensitive.

--- a/Sources/VibeBarApp/AppEnvironment.swift
+++ b/Sources/VibeBarApp/AppEnvironment.swift
@@ -645,11 +645,11 @@ final class AppEnvironment: ObservableObject {
         }
     }
 
-    /// Open the in-app WebView login flow for a misc provider whose current
-    /// credential cannot be imported from the user's main browser (for
-    /// example Chrome v11 cookies or Kimi's localStorage bearer token). After
-    /// save, kicks a one-shot quota refresh so the misc card leaves its setup
-    /// or re-login state.
+    /// Open the in-app WebView login flow for a misc provider whose
+    /// cookies can't be auto-imported from the user's main browser
+    /// (typically because of Chrome v11/app-bound cookie encryption,
+    /// which SweetCookieKit doesn't read). After save, kicks a one-shot
+    /// quota refresh so the misc card flips out of "Set up" state.
     func openMiscWebLogin(for tool: ToolType) {
         openMiscWebLogin(for: tool, instanceID: tool.rawValue)
     }

--- a/Sources/VibeBarApp/HiddenCookieRefresher.swift
+++ b/Sources/VibeBarApp/HiddenCookieRefresher.swift
@@ -143,9 +143,10 @@ final class HiddenCookieRefresher {
     private var pinnedDataStores: [ObjectIdentifier: WKWebsiteDataStore] = [:]
 
     /// Trigger a silent refresh for `tool`. Iterates the user's
-    /// system-browser-origin cookie slots and refreshes each one. Manual and
-    /// bearer-token WebView slots are skipped — they require an explicit user
-    /// action. Returns true if at least one slot's header changed.
+    /// browser-origin cookie slots and refreshes each one. Manual
+    /// slots are skipped — auto-refresh only re-runs a session the
+    /// user originally captured via browser import or the in-app web
+    /// login. Returns true if at least one slot's header changed.
     /// Concurrent refreshes for the same tool are coalesced.
     @discardableResult
     func refresh(_ tool: ToolType) async -> Bool {
@@ -170,7 +171,7 @@ final class HiddenCookieRefresher {
             .filter { $0.tool == config.tool }
             .flatMap { instance in
                 MiscCookieSlotStore.slots(for: config.tool, instanceID: instance.id)
-                    .filter(\.isSystemBrowserRefreshable)
+                    .filter { $0.origin != .manual }
                     .map { RefreshTarget(instanceID: instance.id, slot: $0) }
             }
         guard !targets.isEmpty else {
@@ -301,7 +302,6 @@ final class HiddenCookieRefresher {
             for: config.tool,
             instanceID: instanceID,
             header: header,
-            sourceLabel: "Auto-refresh",
             origin: .autoRefresh
         )
     }

--- a/Sources/VibeBarApp/MiscWebLoginController.swift
+++ b/Sources/VibeBarApp/MiscWebLoginController.swift
@@ -2,16 +2,18 @@ import AppKit
 import WebKit
 import VibeBarCore
 
-/// In-app WebView login flow for misc providers whose live credential cannot
-/// be lifted out of the user's main browser (typically Chrome `v11` cookies,
-/// or a bearer token kept in first-party localStorage).
+/// In-app WebView login flow for browser-cookie misc providers whose
+/// cookies can't be lifted out of the user's main browser (typically
+/// because Chrome on macOS encrypted them with `v11` / app-bound
+/// encryption, which our SweetCookieKit dependency can't read).
 ///
 /// Pattern mirrors `ClaudeWebLoginController`:
 /// 1. Open a window with a `WKWebView` pointed at the provider's
 ///    login URL.
 /// 2. Let the user sign in (handles password + SSO + popup flows).
-/// 3. Capture either the spec's required cookies or an explicitly configured
-///    first-party localStorage token, and append a Keychain-backed slot.
+/// 3. Watch the cookie store; once the spec's required cookies are
+///    present, minimise them to `name=value; …` form and append a new
+///    slot to `MiscCookieSlotStore`.
 /// 4. Fire the `onSaved` callback so the caller can kick a refresh.
 ///
 /// Generic on `ToolType` via `Config` — one instance per tool. Use
@@ -19,13 +21,6 @@ import VibeBarCore
 /// across SwiftUI re-renders.
 @MainActor
 final class MiscWebLoginController: NSObject, NSWindowDelegate, WKNavigationDelegate, WKUIDelegate {
-    struct LocalStorageTokenCapture {
-        let storageKey: String
-        let cookieName: String
-        let allowedHostSuffixes: [String]
-        let sourceLabel: String
-    }
-
     struct Config {
         let tool: ToolType
         let loginURL: URL
@@ -42,16 +37,6 @@ final class MiscWebLoginController: NSObject, NSWindowDelegate, WKNavigationDele
         let windowTitle: String
         let savedConfirmation: String
         let setupHint: String
-        /// Some current web apps authenticate API calls from a bearer token
-        /// in localStorage instead of an HTTP cookie. When configured, the
-        /// login flow captures that token only from a trusted first-party
-        /// page and stores it as a cookie-shaped Keychain slot so the existing
-        /// adapter/resolver boundary remains unchanged.
-        var localStorageTokenCapture: LocalStorageTokenCapture? = nil
-        /// Password capture/autofill is useful for cookie login flows, but a
-        /// bearer-token-only flow such as Kimi neither needs nor should expose
-        /// that bridge.
-        var enablesFormAutofill = true
     }
 
     private let config: Config
@@ -62,7 +47,7 @@ final class MiscWebLoginController: NSObject, NSWindowDelegate, WKNavigationDele
     private var popupWebView: WKWebView?
     private var statusLabel: NSTextField?
     private var onSaved: (() -> Void)?
-    private var didSaveCredentialForCurrentWindow = false
+    private var didSaveCookiesForCurrentWindow = false
     private let websiteDataStore = WKWebsiteDataStore.default()
     private var autofillBridges: [MiscWebLoginAutofillBridge] = []
 
@@ -95,7 +80,7 @@ final class MiscWebLoginController: NSObject, NSWindowDelegate, WKNavigationDele
         browserButton.bezelStyle = .rounded
 
         let saveButton = NSButton(
-            title: config.localStorageTokenCapture == nil ? "Save Cookies" : "Save Session",
+            title: "Save Cookies",
             target: self,
             action: #selector(saveCookies(_:))
         )
@@ -113,14 +98,7 @@ final class MiscWebLoginController: NSObject, NSWindowDelegate, WKNavigationDele
         statusLabel.font = .systemFont(ofSize: NSFont.smallSystemFontSize)
         self.statusLabel = statusLabel
 
-        var buttonViews: [NSView] = [statusLabel, NSView()]
-        // A system browser has a different localStorage partition from this
-        // WKWebView, so that escape hatch cannot complete a token-capture flow.
-        if config.localStorageTokenCapture == nil {
-            buttonViews.append(browserButton)
-        }
-        buttonViews.append(contentsOf: [reloadButton, saveButton])
-        let buttonRow = NSStackView(views: buttonViews)
+        let buttonRow = NSStackView(views: [statusLabel, NSView(), browserButton, reloadButton, saveButton])
         buttonRow.orientation = .horizontal
         buttonRow.alignment = .centerY
         buttonRow.spacing = 10
@@ -169,74 +147,10 @@ final class MiscWebLoginController: NSObject, NSWindowDelegate, WKNavigationDele
     }
 
     @objc private func saveCookies(_ sender: Any?) {
-        persistAvailableCredential(manual: true)
-    }
-
-    private func persistAvailableCredential(manual: Bool) {
-        guard let webView else { return }
-        if let capture = config.localStorageTokenCapture {
-            persistLocalStorageToken(from: webView, capture: capture, manual: manual)
-            return
-        }
+        guard webView != nil else { return }
         websiteDataStore.httpCookieStore.getAllCookies { [weak self] cookies in
             Task { @MainActor in
-                self?.persistCookies(cookies, manual: manual)
-            }
-        }
-    }
-
-    private func persistLocalStorageToken(
-        from webView: WKWebView,
-        capture: LocalStorageTokenCapture,
-        manual: Bool
-    ) {
-        guard HostSuffixMatcher.matches(
-            webView.url?.host,
-            allowedSuffixes: capture.allowedHostSuffixes
-        ) else {
-            if manual {
-                showAlert(message: "Open the \(config.tool.menuTitle) page in this window before saving.")
-            }
-            return
-        }
-        guard let keyData = try? JSONEncoder().encode(capture.storageKey),
-              let keyLiteral = String(data: keyData, encoding: .utf8) else {
-            return
-        }
-        let script = """
-        (function() {
-            try { return window.localStorage.getItem(\(keyLiteral)); }
-            catch (_) { return null; }
-        })();
-        """
-        webView.evaluateJavaScript(script) { [weak self] value, _ in
-            Task { @MainActor in
-                guard let self else { return }
-                let token = (value as? String) ?? ""
-                let header: String? = switch self.config.tool {
-                case .kimi:
-                    KimiQuotaAdapter.cookieHeader(fromAccessToken: token)
-                default:
-                    nil
-                }
-                guard let header,
-                      CookieHeaderNormalizer.pairs(from: header).contains(where: {
-                          $0.name == capture.cookieName && !$0.value.isEmpty
-                      }) else {
-                    if manual {
-                        self.showAlert(
-                            message: "No active \(self.config.tool.menuTitle) session found yet. Finish login in this window, then try again."
-                        )
-                    }
-                    return
-                }
-                self.persistHeader(
-                    header,
-                    sourceLabel: capture.sourceLabel,
-                    origin: .manual,
-                    captureKind: .webLogin,
-                    manual: manual
-                )
+                self?.persistCookies(cookies, manual: true)
             }
         }
     }
@@ -248,37 +162,20 @@ final class MiscWebLoginController: NSObject, NSWindowDelegate, WKNavigationDele
             }
             return
         }
-        persistHeader(
-            header,
-            sourceLabel: "WebView login",
-            origin: .browserImport,
-            captureKind: nil,
-            manual: manual
-        )
-    }
-
-    private func persistHeader(
-        _ header: String,
-        sourceLabel: String,
-        origin: MiscCookieSlot.Origin,
-        captureKind: MiscCookieSlot.CaptureKind?,
-        manual: Bool
-    ) {
         let slot = MiscCookieSlot(
             cookieHeader: header,
-            sourceLabel: sourceLabel,
+            sourceLabel: "WebView login",
             importedAt: Date(),
-            origin: origin,
-            captureKind: captureKind
+            origin: .browserImport
         )
         let stored = MiscCookieSlotStore.append(slot, for: config.tool, instanceID: instanceID)
         guard stored else {
             if manual {
-                showAlert(message: "Could not save the \(config.tool.menuTitle) credential to Keychain.")
+                showAlert(message: "Could not save \(config.tool.menuTitle) cookies to Keychain.")
             }
             return
         }
-        didSaveCredentialForCurrentWindow = true
+        didSaveCookiesForCurrentWindow = true
         statusLabel?.stringValue = config.savedConfirmation
         if manual {
             showAlert(message: config.savedConfirmation)
@@ -286,17 +183,11 @@ final class MiscWebLoginController: NSObject, NSWindowDelegate, WKNavigationDele
         onSaved?()
     }
 
-    private func persistCredentialSilentlyIfAvailable() {
-        guard !didSaveCredentialForCurrentWindow else { return }
-        // Bearer tokens are more sensitive and WebKit may retain an expired
-        // localStorage value from an earlier login. Capture only on the user's
-        // explicit Save Session click after they can see the signed-in page.
-        if config.localStorageTokenCapture != nil {
-            return
-        }
+    private func persistCookiesSilentlyIfAvailable() {
+        guard !didSaveCookiesForCurrentWindow else { return }
         websiteDataStore.httpCookieStore.getAllCookies { [weak self] cookies in
             Task { @MainActor in
-                guard let self, !self.didSaveCredentialForCurrentWindow else { return }
+                guard let self, !self.didSaveCookiesForCurrentWindow else { return }
                 self.persistCookies(cookies, manual: false)
             }
         }
@@ -363,17 +254,15 @@ final class MiscWebLoginController: NSObject, NSWindowDelegate, WKNavigationDele
         configuration.defaultWebpagePreferences.allowsContentJavaScript = true
 
         let userContent = WKUserContentController()
-        if config.enablesFormAutofill {
-            userContent.addUserScript(WKUserScript(
-                source: MiscWebLoginController.formAutofillScript,
-                injectionTime: .atDocumentEnd,
-                forMainFrameOnly: false
-            ))
-            let bridge = MiscWebLoginAutofillBridge(controller: self)
-            userContent.add(bridge, name: MiscWebLoginController.formAutofillMessageName)
-            autofillBridges.append(bridge)
-        }
+        userContent.addUserScript(WKUserScript(
+            source: MiscWebLoginController.formAutofillScript,
+            injectionTime: .atDocumentEnd,
+            forMainFrameOnly: false
+        ))
+        let bridge = MiscWebLoginAutofillBridge(controller: self)
+        userContent.add(bridge, name: MiscWebLoginController.formAutofillMessageName)
         configuration.userContentController = userContent
+        autofillBridges.append(bridge)
         return configuration
     }
 
@@ -570,7 +459,7 @@ final class MiscWebLoginController: NSObject, NSWindowDelegate, WKNavigationDele
         statusLabel = nil
         window = nil
         onSaved = nil
-        didSaveCredentialForCurrentWindow = false
+        didSaveCookiesForCurrentWindow = false
         for bridge in autofillBridges {
             bridge.detach()
         }
@@ -583,7 +472,7 @@ final class MiscWebLoginController: NSObject, NSWindowDelegate, WKNavigationDele
 
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
         statusLabel?.stringValue = config.setupHint
-        persistCredentialSilentlyIfAvailable()
+        persistCookiesSilentlyIfAvailable()
     }
 
     func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
@@ -673,7 +562,7 @@ final class MiscWebLoginController: NSObject, NSWindowDelegate, WKNavigationDele
 extension MiscWebLoginController: WKHTTPCookieStoreObserver {
     nonisolated func cookiesDidChange(in cookieStore: WKHTTPCookieStore) {
         Task { @MainActor in
-            self.persistCredentialSilentlyIfAvailable()
+            self.persistCookiesSilentlyIfAvailable()
         }
     }
 }
@@ -743,24 +632,6 @@ final class MiscWebLoginRegistry {
 
     private static func config(for tool: ToolType) -> MiscWebLoginController.Config? {
         switch tool {
-        case .kimi:
-            return MiscWebLoginController.Config(
-                tool: .kimi,
-                loginURL: URL(string: "https://www.kimi.com/membership/subscription?tab=quota")!,
-                cookieDomainSuffixes: ["kimi.com"],
-                requiredCookieNames: KimiQuotaAdapter.cookieSpec.requiredNames,
-                trustedAuthHostSuffixes: ["kimi.com"],
-                windowTitle: "Kimi Login",
-                savedConfirmation: "Kimi session saved.",
-                setupHint: "Sign in to Kimi and open My Quota, then click Save Session.",
-                localStorageTokenCapture: MiscWebLoginController.LocalStorageTokenCapture(
-                    storageKey: "access_token",
-                    cookieName: "kimi-auth",
-                    allowedHostSuffixes: ["kimi.com"],
-                    sourceLabel: "Kimi Web login"
-                ),
-                enablesFormAutofill: false
-            )
         case .mimo:
             return MiscWebLoginController.Config(
                 tool: .mimo,

--- a/Sources/VibeBarApp/Views/MiscProviderLandingView.swift
+++ b/Sources/VibeBarApp/Views/MiscProviderLandingView.swift
@@ -27,10 +27,6 @@ struct MiscProviderLandingView: View {
                 .font(.system(size: 12, weight: .semibold))
                 .foregroundStyle(.secondary)
 
-            Text("Kimi is configured from its provider page: current quota auth lives in browser local storage, not Chrome's cookie database.")
-                .font(.caption2)
-                .foregroundStyle(.tertiary)
-
             if cookieTargets.isEmpty {
                 Text("No cookie-based providers are configured.")
                     .font(.caption)
@@ -39,7 +35,7 @@ struct MiscProviderLandingView: View {
                 HStack(spacing: 8) {
                     Button(action: importAll) {
                         Label(
-                            "Import Browser Cookies for Supported Providers",
+                            "Import Browser Cookies for All Providers",
                             systemImage: "safari"
                         )
                     }
@@ -49,9 +45,10 @@ struct MiscProviderLandingView: View {
                             .controlSize(.small)
                     }
                 }
-                Text("Reads your browsers once for all \(cookieTargets.count) cookie-based providers and adds a slot to each. Existing cookies stay; quotas are averaged across slots. macOS may ask for your login-keychain password once per Chromium-family browser involved.")
+                Text("Reads your browsers once for all \(cookieTargets.count) cookie-based providers and adds or refreshes the first signed-in profile found for each. Existing slots from other profiles stay stacked; quotas are averaged across them. macOS may ask for your login-keychain password once per Chromium-family browser involved.")
                     .font(.caption2)
                     .foregroundStyle(.tertiary)
+
                 if isImporting {
                     Text("Importing…")
                         .font(.caption)
@@ -92,7 +89,6 @@ struct MiscProviderLandingView: View {
     private var cookieTargets: [MiscCookieResolver.BatchImportTarget] {
         settingsStore.settings.miscProviderInstances.compactMap { instance in
             guard let spec = MiscCookieSpecCatalog.spec(for: instance.tool) else { return nil }
-            guard spec.supportsSystemBrowserImport else { return nil }
             return MiscCookieResolver.BatchImportTarget(spec: spec, instanceID: instance.id)
         }
     }
@@ -151,7 +147,6 @@ private struct OutcomeRow: View {
         case .noSessionFound:  return "minus.circle"
         case .cookiesDisabled: return "slash.circle"
         case .saveFailed:      return "exclamationmark.triangle"
-        case .browserImportUnsupported: return "info.circle"
         }
     }
 
@@ -159,7 +154,6 @@ private struct OutcomeRow: View {
         switch outcome {
         case .imported:                        return .green
         case .noSessionFound, .cookiesDisabled: return .secondary
-        case .browserImportUnsupported:         return .secondary
         case .saveFailed:                      return .orange
         }
     }
@@ -174,8 +168,6 @@ private struct OutcomeRow: View {
             return "Cookies disabled for this provider"
         case .saveFailed:
             return "Could not save to Keychain"
-        case .browserImportUnsupported:
-            return "Use this provider's setup page"
         }
     }
 }

--- a/Sources/VibeBarApp/Views/MiscProviderSettingsSection.swift
+++ b/Sources/VibeBarApp/Views/MiscProviderSettingsSection.swift
@@ -165,18 +165,11 @@ struct MiscProviderSettingsSection: View {
                 MiniMaxRegionPicker(instanceID: instanceID)
             }
         case .kimi:
-            VStack(alignment: .leading, spacing: 4) {
-                MiscWebLoginRow(
-                    tool: .kimi,
-                    instanceID: instanceID,
-                    helpText: "Kimi's current quota API uses a browser-local access token; Chrome cookie import can be stale. Sign in here once to save it securely."
-                )
-                CookieSourceControls(
-                    tool: .kimi,
-                    instanceID: instanceID,
-                    manualPrompt: "Paste the current Kimi access token as kimi-auth=eyJ..."
-                )
-            }
+            CookieSourceControls(
+                tool: .kimi,
+                instanceID: instanceID,
+                manualPrompt: "Paste www.kimi.com Cookie header (kimi-auth=eyJ...)"
+            )
         case .cursor:
             CookieSourceControls(
                 tool: .cursor,
@@ -744,8 +737,8 @@ struct KiroStatusRow: View {
 ///
 /// Each provider can stack multiple cookie sessions — one per account.
 /// The section shows the current list of imported slots (with source
-/// label, import time, and a delete button) plus a manual paste field and,
-/// when the provider supports it, "Import from browser". Quota
+/// label, import time, and a delete button) plus two additive entry
+/// points: "Import from browser" and a manual paste field. Quota
 /// queries fan out across every slot and the bucket percentages are
 /// averaged; see `MiscQuotaAggregator`.
 struct CookieSourceControls: View {
@@ -769,10 +762,6 @@ struct CookieSourceControls: View {
         MiscCookieSpecCatalog.spec(for: tool)
     }
 
-    private var allowsBrowserImport: Bool {
-        spec?.supportsSystemBrowserImport ?? false
-    }
-
     var body: some View {
         if spec == nil {
             Text("No cookie spec is registered for \(tool.menuTitle).")
@@ -786,11 +775,7 @@ struct CookieSourceControls: View {
     private var controls: some View {
         VStack(alignment: .leading, spacing: 6) {
             if slots.isEmpty {
-                Text(
-                    allowsBrowserImport
-                        ? "No cookies imported yet — import from your browser or paste below."
-                        : "No saved session yet — use Sign in via Web or paste the current token below."
-                )
+                Text("No cookies imported yet — import from your browser or paste below.")
                     .font(.caption)
                     .foregroundStyle(.tertiary)
             } else {
@@ -800,15 +785,13 @@ struct CookieSourceControls: View {
                     }
                 }
             }
-            if allowsBrowserImport {
-                HStack(spacing: 6) {
-                    Button("Import from browser", action: importNow)
-                        .buttonStyle(.bordered)
-                        .controlSize(.small)
-                    Text("Adds a new slot. Existing cookies stay; quotas are averaged across all slots.")
-                        .font(.caption)
-                        .foregroundStyle(.tertiary)
-                }
+            HStack(spacing: 6) {
+                Button("Import from browser", action: importNow)
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+                Text("Adds or refreshes the first signed-in browser profile found. Existing profiles stay stacked.")
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
             }
             HStack(spacing: 6) {
                 SecureField(manualPrompt, text: $manualDraft)
@@ -974,9 +957,6 @@ private struct CookieSlotRow: View {
     }
 
     private var icon: String {
-        if slot.captureKind == .webLogin {
-            return "person.crop.circle.badge.key"
-        }
         switch slot.origin {
         case .manual:         return "doc.on.clipboard"
         case .browserImport:  return "safari"

--- a/Sources/VibeBarCore/Adapters/KimiQuotaAdapter.swift
+++ b/Sources/VibeBarCore/Adapters/KimiQuotaAdapter.swift
@@ -2,11 +2,10 @@ import Foundation
 
 /// Moonshot / Kimi (kimi.com) usage adapter.
 ///
-/// Auth: a Kimi bearer JWT. Current Kimi Web keeps it in
-/// `localStorage.access_token`; Vibe Bar's explicit Web login stores it as a
-/// synthetic `kimi-auth=<token>` Keychain slot. Legacy browser cookies and
-/// manual headers use that same slot shape, so source resolution continues to
-/// flow through `MiscCookieResolver`.
+/// Auth: a Kimi bearer JWT. The shared Browser Cookies importer reads the
+/// current `localStorage.access_token` from Chromium profiles and stores it as
+/// the same synthetic `kimi-auth=<token>` Keychain slot used by legacy browser
+/// cookies and manual headers.
 ///
 /// `POST https://www.kimi.com/apiv2/kimi.gateway.membership.v2.MembershipService/GetSubscriptionStats`
 /// with body `{}` is the primary source for the weekly, five-hour and
@@ -26,34 +25,19 @@ public struct KimiQuotaAdapter: QuotaAdapter {
     private let session: URLSession
     private let now: @Sendable () -> Date
 
+    private static let accessTokenCredential = ChromiumLocalStorageCredential(
+        origin: "https://www.kimi.com",
+        key: "access_token",
+        syntheticCookieName: "kimi-auth",
+        valueFormat: .jwt(segments: 3, minLength: 16, maxLength: 4_096)
+    )
+
     public static let cookieSpec = MiscCookieResolver.Spec(
         tool: .kimi,
         domains: ["www.kimi.com", "kimi.com"],
         requiredNames: ["kimi-auth"],
-        supportsSystemBrowserImport: false
+        browserCredentialSource: .chromiumLocalStorage(accessTokenCredential)
     )
-
-    /// Convert the current Kimi Web `localStorage.access_token` JWT into the
-    /// cookie-shaped Keychain slot already consumed by this adapter. Keeping
-    /// the validation in Core prevents a WebView value containing separators
-    /// or control characters from being persisted as a malformed header.
-    public static func cookieHeader(fromAccessToken raw: String) -> String? {
-        let token = raw.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard token.count >= 16, token.count <= 4_096 else { return nil }
-        let segments = token.split(separator: ".", omittingEmptySubsequences: false)
-        guard segments.count == 3, segments.allSatisfy({ !$0.isEmpty }) else { return nil }
-        guard segments.allSatisfy({ segment in
-            segment.utf8.allSatisfy { byte in
-                (48...57).contains(byte) ||
-                    (65...90).contains(byte) ||
-                    (97...122).contains(byte) ||
-                    byte == 45 || byte == 95
-            }
-        }) else {
-            return nil
-        }
-        return "kimi-auth=\(token)"
-    }
 
     private static let usageEndpoint = URL(string:
         "https://www.kimi.com/apiv2/kimi.gateway.billing.v1.BillingService/GetUsages"

--- a/Sources/VibeBarCore/BrowserCookies/BrowserCredentialSource.swift
+++ b/Sources/VibeBarCore/BrowserCookies/BrowserCredentialSource.swift
@@ -1,0 +1,100 @@
+import Foundation
+
+/// Where a browser-backed misc-provider credential is persisted by the
+/// browser. Every source still resolves to the same cookie-shaped Keychain
+/// slot consumed by the existing adapters.
+public enum BrowserCredentialSource: Sendable, Hashable {
+    /// Regular HTTP cookies read through `BrowserCookieClient`.
+    case cookieJar
+    /// One exact first-party localStorage field in Chromium profiles.
+    case chromiumLocalStorage(ChromiumLocalStorageCredential)
+}
+
+/// Declarative mapping from one Chromium localStorage value to the synthetic
+/// cookie header already understood by a provider adapter.
+public struct ChromiumLocalStorageCredential: Sendable, Hashable {
+    public let origin: String
+    public let key: String
+    public let syntheticCookieName: String
+    public let valueFormat: BrowserCredentialValueFormat
+
+    public init(
+        origin: String,
+        key: String,
+        syntheticCookieName: String,
+        valueFormat: BrowserCredentialValueFormat
+    ) {
+        self.origin = origin
+        self.key = key
+        self.syntheticCookieName = syntheticCookieName
+        self.valueFormat = valueFormat
+    }
+
+    public func cookieHeader(from rawValue: String) -> String? {
+        guard Self.isValidCookieName(syntheticCookieName),
+              let value = valueFormat.normalizedValue(rawValue) else {
+            return nil
+        }
+        return "\(syntheticCookieName)=\(value)"
+    }
+
+    private static func isValidCookieName(_ name: String) -> Bool {
+        guard !name.isEmpty else { return false }
+        return name.utf8.allSatisfy { byte in
+            (48...57).contains(byte) ||
+                (65...90).contains(byte) ||
+                (97...122).contains(byte) ||
+                [33, 35, 36, 37, 38, 39, 42, 43, 45, 46, 94, 95, 96, 124, 126].contains(byte)
+        }
+    }
+}
+
+public enum BrowserCredentialValueFormat: Sendable, Hashable {
+    /// Opaque single-header value with separators and control characters
+    /// rejected before it reaches Keychain.
+    case opaque(minLength: Int, maxLength: Int)
+    /// ASCII base64url JWT-like value with an exact segment count.
+    case jwt(segments: Int, minLength: Int, maxLength: Int)
+
+    func normalizedValue(_ rawValue: String) -> String? {
+        let value = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        let bounds: (minimum: Int, maximum: Int) = switch self {
+        case let .opaque(minimum, maximum), let .jwt(_, minimum, maximum):
+            (minimum, maximum)
+        }
+        guard bounds.minimum >= 0,
+              bounds.maximum >= bounds.minimum,
+              value.count >= bounds.minimum,
+              value.count <= bounds.maximum else {
+            return nil
+        }
+
+        switch self {
+        case .opaque:
+            guard value.utf8.allSatisfy({ byte in
+                !byte.isASCIIControl && byte != 59
+            }) else { return nil }
+        case let .jwt(segmentCount, _, _):
+            let parts = value.split(separator: ".", omittingEmptySubsequences: false)
+            guard segmentCount > 0,
+                  parts.count == segmentCount,
+                  parts.allSatisfy({ !$0.isEmpty && $0.utf8.allSatisfy(\.isBase64URL) }) else {
+                return nil
+            }
+        }
+        return value
+    }
+}
+
+private extension UInt8 {
+    var isASCIIControl: Bool {
+        self < 32 || self == 127
+    }
+
+    var isBase64URL: Bool {
+        (48...57).contains(self) ||
+            (65...90).contains(self) ||
+            (97...122).contains(self) ||
+            self == 45 || self == 95
+    }
+}

--- a/Sources/VibeBarCore/BrowserCookies/ChromiumLocalStorageCredentialImporter.swift
+++ b/Sources/VibeBarCore/BrowserCookies/ChromiumLocalStorageCredentialImporter.swift
@@ -1,0 +1,278 @@
+import Foundation
+import os.lock
+import SweetCookieKit
+
+struct ChromiumLocalStorageBrowserSession: Sendable, Equatable {
+    let header: String
+    let sourceLabel: String
+}
+
+/// Generic Chromium-profile credential reader used by the Browser Cookies
+/// pipeline. Provider adapters only declare origin/key/header mapping in their
+/// `MiscCookieResolver.Spec`; profile discovery and storage parsing live here.
+enum ChromiumLocalStorageCredentialImporter {
+    typealias DirectoryContents = @Sendable (URL) -> [URL]
+    typealias EntryReader = @Sendable (String, URL) -> [ChromiumLocalStorageEntry]
+    typealias TextEntryReader = @Sendable (URL) -> [ChromiumLevelDBTextEntry]
+
+    final class Cache: @unchecked Sendable {
+        private struct Key: Hashable {
+            let credential: ChromiumLocalStorageCredential
+            let rootPaths: [String]
+            let maxSessions: Int?
+        }
+
+        private let lock = OSAllocatedUnfairLock<[Key: [ChromiumLocalStorageBrowserSession]]>(
+            initialState: [:]
+        )
+
+        func sessions(
+            credential: ChromiumLocalStorageCredential,
+            roots: [ChromiumProfileRoot],
+            maxSessions: Int?,
+            load: () -> [ChromiumLocalStorageBrowserSession]
+        ) -> [ChromiumLocalStorageBrowserSession] {
+            let key = Key(
+                credential: credential,
+                rootPaths: roots.map { $0.url.standardizedFileURL.path },
+                maxSessions: maxSessions
+            )
+            if let cached = lock.withLock({ $0[key] }) {
+                return cached
+            }
+            let loaded = load()
+            lock.withLock { $0[key] = loaded }
+            return loaded
+        }
+    }
+
+    static func sessions(
+        credential: ChromiumLocalStorageCredential,
+        roots: [ChromiumProfileRoot],
+        cache: Cache,
+        maxSessions: Int? = nil,
+        directoryContents: @escaping DirectoryContents = Self.liveDirectoryContents,
+        readEntries: @escaping EntryReader = Self.liveReadEntries,
+        readTextEntries: @escaping TextEntryReader = Self.liveReadTextEntries
+    ) -> [ChromiumLocalStorageBrowserSession] {
+        cache.sessions(credential: credential, roots: roots, maxSessions: maxSessions) {
+            loadSessions(
+                credential: credential,
+                roots: roots,
+                maxSessions: maxSessions,
+                directoryContents: directoryContents,
+                readEntries: readEntries,
+                readTextEntries: readTextEntries
+            )
+        }
+    }
+
+    private static func loadSessions(
+        credential: ChromiumLocalStorageCredential,
+        roots: [ChromiumProfileRoot],
+        maxSessions: Int?,
+        directoryContents: DirectoryContents,
+        readEntries: EntryReader,
+        readTextEntries: TextEntryReader
+    ) -> [ChromiumLocalStorageBrowserSession] {
+        var sessions: [ChromiumLocalStorageBrowserSession] = []
+        for root in roots {
+            let rootURL = root.url.standardizedFileURL
+            guard isRealDirectory(rootURL) else { continue }
+
+            let profiles = directoryContents(rootURL)
+                .map(\.standardizedFileURL)
+                .filter { isChromiumProfileDirectory($0, under: rootURL) }
+                .sorted { $0.lastPathComponent < $1.lastPathComponent }
+            for profile in profiles {
+                guard let levelDB = validatedLevelDBDirectory(profile: profile, root: rootURL),
+                      hasOnlyRealLevelDBFiles(levelDB) else {
+                    continue
+                }
+
+                let candidates = readEntries(credential.origin, levelDB)
+                guard hasOnlyRealLevelDBFiles(levelDB) else { continue }
+                let textEntries = readTextEntries(levelDB)
+                guard hasOnlyRealLevelDBFiles(levelDB),
+                      let entry = candidates.first(where: {
+                          $0.key == credential.key
+                              && hasExactProvenance(
+                                  candidate: $0,
+                                  credential: credential,
+                                  textEntries: textEntries
+                              )
+                      }),
+                      let header = credential.cookieHeader(from: entry.value) else {
+                    continue
+                }
+                sessions.append(ChromiumLocalStorageBrowserSession(
+                    header: header,
+                    sourceLabel: "\(root.labelPrefix) \(profile.lastPathComponent)"
+                ))
+                if let maxSessions, sessions.count >= maxSessions {
+                    return sessions
+                }
+            }
+        }
+        return sessions
+    }
+
+    private static func isChromiumProfileDirectory(_ url: URL, under root: URL) -> Bool {
+        guard isImmediateChild(url, of: root), isRealDirectory(url) else { return false }
+        let name = url.lastPathComponent
+        return name == "Default" || name.hasPrefix("Profile ") || name.hasPrefix("user-")
+    }
+
+    private static func validatedLevelDBDirectory(profile: URL, root: URL) -> URL? {
+        guard isImmediateChild(profile, of: root), isRealDirectory(profile) else { return nil }
+
+        let localStorage = profile
+            .appendingPathComponent("Local Storage", isDirectory: true)
+            .standardizedFileURL
+        guard isImmediateChild(localStorage, of: profile), isRealDirectory(localStorage) else {
+            return nil
+        }
+
+        let levelDB = localStorage
+            .appendingPathComponent("leveldb", isDirectory: true)
+            .standardizedFileURL
+        guard isImmediateChild(levelDB, of: localStorage), isRealDirectory(levelDB) else {
+            return nil
+        }
+        return levelDB
+    }
+
+    private static func isImmediateChild(_ child: URL, of parent: URL) -> Bool {
+        let standardizedChild = child.standardizedFileURL
+        let standardizedParent = parent.standardizedFileURL
+        guard standardizedChild
+            .deletingLastPathComponent()
+            .standardizedFileURL.path == standardizedParent.path else {
+            return false
+        }
+
+        let resolvedChild = standardizedChild.resolvingSymlinksInPath()
+        let resolvedParent = standardizedParent.resolvingSymlinksInPath()
+        return resolvedChild
+            .deletingLastPathComponent()
+            .standardizedFileURL.path == resolvedParent.standardizedFileURL.path
+    }
+
+    private static func isRealDirectory(_ url: URL) -> Bool {
+        guard let values = try? url.resourceValues(forKeys: [.isDirectoryKey, .isSymbolicLinkKey]) else {
+            return false
+        }
+        return values.isDirectory == true && values.isSymbolicLink == false
+    }
+
+    /// SweetCookieKit follows `.log` / `.ldb` URLs while parsing. Reject any
+    /// store whose data files cannot be proven to be regular, direct children
+    /// so browser-controlled symlinks cannot redirect the credential scan.
+    private static func hasOnlyRealLevelDBFiles(_ levelDB: URL) -> Bool {
+        guard isRealDirectory(levelDB),
+              let children = try? FileManager.default.contentsOfDirectory(
+                  at: levelDB,
+                  includingPropertiesForKeys: [.isRegularFileKey, .isSymbolicLinkKey],
+                  options: [.skipsHiddenFiles]
+              ) else {
+            return false
+        }
+
+        for child in children {
+            let file = child.standardizedFileURL
+            let fileExtension = file.pathExtension.lowercased()
+            guard fileExtension == "log" || fileExtension == "ldb" else { continue }
+            guard isImmediateChild(file, of: levelDB),
+                  let values = try? file.resourceValues(
+                      forKeys: [.isRegularFileKey, .isSymbolicLinkKey]
+                  ),
+                  values.isRegularFile == true,
+                  values.isSymbolicLink == false else {
+                return false
+            }
+        }
+        return true
+    }
+
+    /// `ChromiumLocalStorageReader.readEntries(for:)` intentionally accepts
+    /// host-equivalent origins and reports the requested origin on its result.
+    /// That is useful for discovery but too broad for credentials. Require a
+    /// second, raw-key view of the same exact origin/key/value before use.
+    private static func hasExactProvenance(
+        candidate: ChromiumLocalStorageEntry,
+        credential: ChromiumLocalStorageCredential,
+        textEntries: [ChromiumLevelDBTextEntry]
+    ) -> Bool {
+        guard let expectedOrigin = exactOrigin(from: credential.origin) else { return false }
+        return textEntries.contains { entry in
+            guard entry.value == candidate.value,
+                  let parsed = parseLocalStorageKey(entry.key),
+                  parsed.key == credential.key,
+                  let actualOrigin = exactOrigin(from: parsed.serializedOrigin)
+            else { return false }
+            return actualOrigin == expectedOrigin
+        }
+    }
+
+    private static func parseLocalStorageKey(
+        _ rawKey: String
+    ) -> (serializedOrigin: String, key: String)? {
+        guard let separator = rawKey.firstIndex(of: "\0") else { return nil }
+        var serializedOrigin = String(rawKey[..<separator])
+        let keyStart = rawKey.index(after: separator)
+        let key = String(rawKey[keyStart...])
+        guard !serializedOrigin.isEmpty, !key.isEmpty, !key.contains("\0") else { return nil }
+
+        if serializedOrigin.first == "_" {
+            serializedOrigin.removeFirst()
+        }
+        guard !serializedOrigin.isEmpty else { return nil }
+
+        // StorageKey::SerializeForLocalStorage may append a caret partition
+        // suffix. The origin before the first caret remains authoritative.
+        if let caret = serializedOrigin.firstIndex(of: "^") {
+            serializedOrigin = String(serializedOrigin[..<caret])
+        }
+        guard !serializedOrigin.isEmpty else { return nil }
+        return (serializedOrigin, key)
+    }
+
+    private struct ExactOrigin: Equatable {
+        let scheme: String
+        let host: String
+        let port: Int?
+    }
+
+    /// Canonicalize only URL-origin trivia: scheme/host case and one optional
+    /// trailing slash. Scheme and explicit port remain part of the identity.
+    private static func exactOrigin(from serializedOrigin: String) -> ExactOrigin? {
+        let trimmed = serializedOrigin.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let components = URLComponents(string: trimmed),
+              let scheme = components.scheme?.lowercased(), !scheme.isEmpty,
+              let host = components.host?.lowercased(), !host.isEmpty,
+              components.user == nil,
+              components.password == nil,
+              components.query == nil,
+              components.fragment == nil,
+              components.path.isEmpty || components.path == "/" else {
+            return nil
+        }
+        return ExactOrigin(scheme: scheme, host: host, port: components.port)
+    }
+
+    private static let liveDirectoryContents: DirectoryContents = { root in
+        (try? FileManager.default.contentsOfDirectory(
+            at: root,
+            includingPropertiesForKeys: [.isDirectoryKey, .isSymbolicLinkKey],
+            options: [.skipsHiddenFiles]
+        )) ?? []
+    }
+
+    private static let liveReadEntries: EntryReader = { origin, levelDB in
+        ChromiumLocalStorageReader.readEntries(for: origin, in: levelDB, logger: nil)
+    }
+
+    private static let liveReadTextEntries: TextEntryReader = { levelDB in
+        ChromiumLevelDBReader.readTextEntries(in: levelDB, logger: nil)
+    }
+}

--- a/Sources/VibeBarCore/BrowserCookies/MiscCookieResolver.swift
+++ b/Sources/VibeBarCore/BrowserCookies/MiscCookieResolver.swift
@@ -34,10 +34,10 @@ public enum MiscCookieResolver {
         /// Default browser-import order if the user hasn't picked
         /// `MiscProviderSettings.preferredBrowser`.
         public let importOrder: BrowserCookieImportOrder
-        /// Whether the live credential still exists in browser cookie stores.
-        /// Kimi now uses localStorage and must go through its explicit Web
-        /// login instead of reporting a stale cookie as a successful import.
-        public let supportsSystemBrowserImport: Bool
+        /// Browser persistence surface holding the live credential. Cookie
+        /// jars remain the default; providers can declaratively map one exact
+        /// Chromium localStorage field into the same cookie-shaped slot.
+        public let browserCredentialSource: BrowserCredentialSource
 
         public init(
             tool: ToolType,
@@ -45,14 +45,14 @@ public enum MiscCookieResolver {
             requiredNames: Set<String>,
             credentialNames: Set<String> = [],
             importOrder: BrowserCookieImportOrder = BrowserCookieDefaults.importOrder,
-            supportsSystemBrowserImport: Bool = true
+            browserCredentialSource: BrowserCredentialSource = .cookieJar
         ) {
             self.tool = tool
             self.domains = domains
             self.requiredNames = requiredNames
             self.credentialNames = credentialNames
             self.importOrder = importOrder
-            self.supportsSystemBrowserImport = supportsSystemBrowserImport
+            self.browserCredentialSource = browserCredentialSource
         }
 
         public func minimizedHeader(from raw: String?) -> String? {
@@ -119,11 +119,8 @@ public enum MiscCookieResolver {
             case .all:
                 return true
             case .browserOnly:
-                return slot.origin != .manual || slot.captureKind == .webLogin
+                return slot.origin != .manual
             case .manualOnly:
-                // A WebView login is an explicit user action rather than a
-                // passive system-browser import, so keep it usable even when
-                // the user selected the manual credential lane.
                 return slot.origin == .manual
             case .none:
                 return false
@@ -173,8 +170,8 @@ public enum MiscCookieResolver {
         resolveAll(for: spec, account: account).first
     }
 
-    /// Run the SweetCookieKit browser-import dance and append the
-    /// captured header as a new slot. Returns the appended slot's
+    /// Run the SweetCookieKit browser-import dance and add or refresh the
+    /// captured browser-profile slot. Returns the stored slot's
     /// Resolution on success, or `nil` if no browser session was
     /// found (or the source mode bans cookies).
     public static func appendBrowserImport(for spec: Spec) -> Resolution? {
@@ -182,7 +179,6 @@ public enum MiscCookieResolver {
     }
 
     public static func appendBrowserImport(for spec: Spec, instanceID: String) -> Resolution? {
-        guard spec.supportsSystemBrowserImport else { return nil }
         let settings = currentSettings(for: spec.tool, instanceID: instanceID)
         guard SlotFilter(settings: settings) != .none else { return nil }
         guard let imported = importFromBrowsers(
@@ -198,17 +194,20 @@ public enum MiscCookieResolver {
             importedAt: Date(),
             origin: .browserImport
         )
-        guard MiscCookieSlotStore.append(slot, for: spec.tool, instanceID: instanceID) else { return nil }
+        guard let stored = MiscCookieSlotStore.upsertBrowserImport(
+            slot,
+            for: spec.tool,
+            instanceID: instanceID
+        ) else { return nil }
         return Resolution(
-            slotID: slot.id,
+            slotID: stored.id,
             header: imported.header,
             sourceLabel: imported.sourceLabel
         )
     }
 
     /// Legacy alias for callers that haven't migrated to
-    /// `appendBrowserImport`. Slot semantics are identical — every
-    /// invocation appends a new slot rather than replacing one.
+    /// `appendBrowserImport`. Slot semantics are identical.
     public static func forceBrowserImport(for spec: Spec) -> Resolution? {
         appendBrowserImport(for: spec)
     }
@@ -245,9 +244,6 @@ public enum MiscCookieResolver {
             case cookiesDisabled
             /// A session was found but the Keychain write failed.
             case saveFailed
-            /// The provider's live credential is not stored as a browser
-            /// cookie and must use its provider-specific setup flow.
-            case browserImportUnsupported
         }
 
         public let tool: ToolType
@@ -288,13 +284,6 @@ public enum MiscCookieResolver {
     ) -> [BatchImportOutcome] {
         let context = BrowserImportContext()
         return targets.map { target in
-            guard target.spec.supportsSystemBrowserImport else {
-                return BatchImportOutcome(
-                    tool: target.tool,
-                    instanceID: target.instanceID,
-                    result: .browserImportUnsupported
-                )
-            }
             let settings = currentSettings(for: target.tool, instanceID: target.instanceID)
             guard SlotFilter(settings: settings) != .none else {
                 return BatchImportOutcome(
@@ -321,11 +310,11 @@ public enum MiscCookieResolver {
                 importedAt: Date(),
                 origin: .browserImport
             )
-            guard MiscCookieSlotStore.append(
+            guard MiscCookieSlotStore.upsertBrowserImport(
                 slot,
                 for: target.tool,
                 instanceID: target.instanceID
-            ) else {
+            ) != nil else {
                 return BatchImportOutcome(
                     tool: target.tool,
                     instanceID: target.instanceID,
@@ -347,9 +336,9 @@ public enum MiscCookieResolver {
     ///
     /// Used by `MiscCookieAutoImporter` when a fetch came back
     /// `needsLogin`. Slots are replaced **in place** with origin
-    /// `.autoRefresh`; manual and WebView-login slots are left alone.
-    /// Those credentials came from an explicit user action and must not be
-    /// overwritten by a stale cookie from the system browser.
+    /// `.autoRefresh`; `origin == .manual` slots are left alone, the
+    /// same policy `HiddenCookieRefresher` follows — a cookie the user
+    /// pasted by hand is theirs to manage.
     ///
     /// Returns `true` when at least one slot's header actually changed,
     /// which is the caller's signal that a retry is worth a round-trip.
@@ -370,7 +359,7 @@ public enum MiscCookieResolver {
 
         let refreshable = MiscCookieSlotStore
             .slots(for: spec.tool, instanceID: instanceID)
-            .filter(\.isSystemBrowserRefreshable)
+            .filter { $0.origin != .manual }
         guard !refreshable.isEmpty else { return false }
 
         let sessions = browserSessions(
@@ -467,17 +456,24 @@ public enum MiscCookieResolver {
 
     /// Shared browser-access objects. Building one per import is the
     /// wrong shape for a batch: `BrowserDetection`'s probe cache and
-    /// SweetCookieKit's decrypted-key state both live on the instance.
+    /// SweetCookieKit's decrypted-key state both live on the instance, while
+    /// the localStorage cache prevents duplicate full-profile scans for clones.
     struct BrowserImportContext {
         let detection: BrowserDetection
         let client: BrowserCookieClient
+        let localStorageCache: ChromiumLocalStorageCredentialImporter.Cache
+        let homeDirectory: URL
 
         init(
             detection: BrowserDetection = BrowserDetection(),
-            client: BrowserCookieClient = BrowserCookieClient()
+            client: BrowserCookieClient = BrowserCookieClient(),
+            localStorageCache: ChromiumLocalStorageCredentialImporter.Cache = .init(),
+            homeDirectory: URL = RealHomeDirectory.url
         ) {
             self.detection = detection
             self.client = client
+            self.localStorageCache = localStorageCache
+            self.homeDirectory = homeDirectory
         }
     }
 
@@ -509,7 +505,7 @@ public enum MiscCookieResolver {
     /// didn't need to. Pass `nil` only when the caller genuinely needs
     /// the full list (the silent re-import matches sessions to slots by
     /// label).
-    private static func browserSessions(
+    static func browserSessions(
         spec: Spec,
         settings: MiscProviderSettings,
         allowKeychainPrompt: Bool,
@@ -522,6 +518,45 @@ public enum MiscCookieResolver {
         } else {
             preferred = spec.importOrder
         }
+
+        switch spec.browserCredentialSource {
+        case .cookieJar:
+            return cookieBrowserSessions(
+                spec: spec,
+                preferred: preferred,
+                allowKeychainPrompt: allowKeychainPrompt,
+                context: context,
+                maxSessions: maxSessions
+            )
+        case let .chromiumLocalStorage(credential):
+            let candidates = preferred
+                .filter(\.usesChromiumProfileStore)
+                .browsersWithProfileData(using: context.detection)
+            guard !candidates.isEmpty else { return [] }
+            let roots = ChromiumProfileLocator.roots(
+                for: candidates,
+                homeDirectories: [context.homeDirectory]
+            )
+            let sessions = ChromiumLocalStorageCredentialImporter.sessions(
+                credential: credential,
+                roots: roots,
+                cache: context.localStorageCache,
+                maxSessions: maxSessions
+            )
+            return sessions.compactMap {
+                guard let header = spec.minimizedHeader(from: $0.header) else { return nil }
+                return BrowserImportResult(header: header, sourceLabel: $0.sourceLabel)
+            }
+        }
+    }
+
+    private static func cookieBrowserSessions(
+        spec: Spec,
+        preferred: [Browser],
+        allowKeychainPrompt: Bool,
+        context: BrowserImportContext,
+        maxSessions: Int?
+    ) -> [BrowserImportResult] {
         let warm = allowKeychainPrompt ? [] : warmKeychainBrowserIDs
         let candidates = preferred.cookieImportCandidates(
             using: context.detection,

--- a/Sources/VibeBarCore/Credentials/MiscCookieSlotStore.swift
+++ b/Sources/VibeBarCore/Credentials/MiscCookieSlotStore.swift
@@ -12,19 +12,11 @@ public struct MiscCookieSlot: Codable, Equatable, Sendable, Identifiable {
         /// Pasted by the user via the Settings cookie field.
         case manual
         /// Snapshotted from a browser's cookie store (SweetCookieKit) or
-        /// a cookie-based in-app `MiscWebLoginController` web view.
+        /// captured by the in-app `MiscWebLoginController` web view.
         case browserImport
         /// Replaced in place by `HiddenCookieRefresher` after a silent
         /// console keepalive load.
         case autoRefresh
-    }
-
-    /// Additive metadata intentionally separate from `Origin`. Older builds
-    /// ignore this unknown optional JSON field while still decoding the slot's
-    /// wire-compatible `.manual` origin, so downgrading cannot make the whole
-    /// Keychain array unreadable and overwrite it on the next append.
-    public enum CaptureKind: String, Codable, Sendable, Equatable {
-        case webLogin
     }
 
     public let id: UUID
@@ -32,27 +24,57 @@ public struct MiscCookieSlot: Codable, Equatable, Sendable, Identifiable {
     public var sourceLabel: String
     public var importedAt: Date
     public var origin: Origin
-    public var captureKind: CaptureKind?
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case cookieHeader
+        case sourceLabel
+        case importedAt
+        case origin
+        /// A short-lived older build wrote Web login captures as
+        /// `origin = manual` plus this additive marker. Keep the key only at
+        /// the decoding boundary so those browser-owned sessions rejoin the
+        /// normal browser refresh path; new data never writes it again.
+        case captureKind
+    }
 
     public init(
         id: UUID = UUID(),
         cookieHeader: String,
         sourceLabel: String,
         importedAt: Date = Date(),
-        origin: Origin,
-        captureKind: CaptureKind? = nil
+        origin: Origin
     ) {
         self.id = id
         self.cookieHeader = cookieHeader
         self.sourceLabel = sourceLabel
         self.importedAt = importedAt
         self.origin = origin
-        self.captureKind = captureKind
     }
 
-    public var isSystemBrowserRefreshable: Bool {
-        guard captureKind != .webLogin else { return false }
-        return origin == .browserImport || origin == .autoRefresh
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.id = try container.decode(UUID.self, forKey: .id)
+        self.cookieHeader = try container.decode(String.self, forKey: .cookieHeader)
+        self.sourceLabel = try container.decode(String.self, forKey: .sourceLabel)
+        self.importedAt = try container.decode(Date.self, forKey: .importedAt)
+
+        let decodedOrigin = try container.decode(Origin.self, forKey: .origin)
+        let legacyCaptureKind = try container.decodeIfPresent(String.self, forKey: .captureKind)
+        if decodedOrigin == .manual, legacyCaptureKind == "webLogin" {
+            self.origin = .browserImport
+        } else {
+            self.origin = decodedOrigin
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(id, forKey: .id)
+        try container.encode(cookieHeader, forKey: .cookieHeader)
+        try container.encode(sourceLabel, forKey: .sourceLabel)
+        try container.encode(importedAt, forKey: .importedAt)
+        try container.encode(origin, forKey: .origin)
     }
 }
 
@@ -126,11 +148,60 @@ public enum MiscCookieSlotStore {
             list[existing].importedAt = slot.importedAt
             list[existing].sourceLabel = slot.sourceLabel
             list[existing].origin = slot.origin
-            list[existing].captureKind = slot.captureKind
         } else {
             list.append(slot)
         }
         return writeRaw(list, for: tool, instanceID: instanceID)
+    }
+
+    /// Insert a system-browser session, replacing the prior snapshot from the
+    /// same browser profile in place. Different profile labels still stack,
+    /// while manual and WebView-labelled slots are never overwritten.
+    @discardableResult
+    public static func upsertBrowserImport(
+        _ slot: MiscCookieSlot,
+        for tool: ToolType,
+        instanceID: String
+    ) -> MiscCookieSlot? {
+        guard tool.isMisc else { return nil }
+        let merged = mergingBrowserImport(slot, into: slots(for: tool, instanceID: instanceID))
+        guard writeRaw(merged.slots, for: tool, instanceID: instanceID) else { return nil }
+        return merged.stored
+    }
+
+    static func mergingBrowserImport(
+        _ incoming: MiscCookieSlot,
+        into existing: [MiscCookieSlot]
+    ) -> (slots: [MiscCookieSlot], stored: MiscCookieSlot) {
+        var slots = existing
+        if let index = slots.firstIndex(where: {
+            $0.origin != .manual && $0.sourceLabel == incoming.sourceLabel
+        }) {
+            slots[index].cookieHeader = incoming.cookieHeader
+            slots[index].sourceLabel = incoming.sourceLabel
+            slots[index].importedAt = incoming.importedAt
+            slots[index].origin = .browserImport
+            return (slots, slots[index])
+        }
+        // Older HiddenCookieRefresher builds replaced the browser profile
+        // label with the generic "Auto-refresh" marker. Reclaim that slot
+        // only when it is the sole non-manual candidate; with two or more
+        // browser slots there is no safe way to know which profile it came
+        // from, so the incoming profile must stay stacked instead.
+        let browserSlotIndices = slots.indices.filter { slots[$0].origin != .manual }
+        if browserSlotIndices.count == 1,
+           let index = browserSlotIndices.first,
+           slots[index].origin == .autoRefresh,
+           slots[index].sourceLabel == "Auto-refresh"
+        {
+            slots[index].cookieHeader = incoming.cookieHeader
+            slots[index].sourceLabel = incoming.sourceLabel
+            slots[index].importedAt = incoming.importedAt
+            slots[index].origin = .browserImport
+            return (slots, slots[index])
+        }
+        slots.append(incoming)
+        return (slots, incoming)
     }
 
     @discardableResult

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -44,12 +44,13 @@ portions is included in this repository at the local license link above.
 
 ## Direct dependencies
 
-### SweetCookieKit 0.4.0 or later compatible releases
+### SweetCookieKit 0.5.2
 
 - Project: [steipete/SweetCookieKit](https://github.com/steipete/SweetCookieKit)
-- Use in Vibe Bar: local Safari, Chromium, and Firefox cookie access.
+- Use in Vibe Bar: local Safari, Chromium, and Firefox cookie access, plus
+  exact-field Chromium localStorage reads for browser-backed credentials.
 - License: [MIT](Resources/ThirdPartyLicenses/SweetCookieKit.txt)
-  ([upstream](https://github.com/steipete/SweetCookieKit/blob/0.4.0/LICENSE))
+  ([upstream](https://github.com/steipete/SweetCookieKit/blob/v0.5.2/LICENSE))
 
 ### Sparkle 2.9.4
 

--- a/Tests/VibeBarCoreTests/BrowserCredentialSourceTests.swift
+++ b/Tests/VibeBarCoreTests/BrowserCredentialSourceTests.swift
@@ -1,0 +1,53 @@
+import XCTest
+@testable import VibeBarCore
+
+final class BrowserCredentialSourceTests: XCTestCase {
+    private let credential = ChromiumLocalStorageCredential(
+        origin: "https://example.com",
+        key: "access_token",
+        syntheticCookieName: "session-token",
+        valueFormat: .jwt(segments: 3, minLength: 16, maxLength: 4_096)
+    )
+
+    func testJWTValueBecomesCookieShapedHeader() {
+        let token = "synthetic-header.synthetic_payload.synthetic-signature"
+        XCTAssertEqual(
+            credential.cookieHeader(from: "  \(token)\n"),
+            "session-token=\(token)"
+        )
+    }
+
+    func testJWTValidationRejectsMalformedOrInjectableValues() {
+        XCTAssertNil(credential.cookieHeader(from: "not-a-jwt"))
+        XCTAssertNil(credential.cookieHeader(from: "aaa..ccc"))
+        XCTAssertNil(credential.cookieHeader(from: "aaa.bbb.ccc;other=value"))
+        XCTAssertNil(credential.cookieHeader(from: "aaa.bbb.ccc\r\nInjected:value"))
+        XCTAssertNil(credential.cookieHeader(from: "aaa.bébé.ccc"))
+        XCTAssertNil(credential.cookieHeader(
+            from: "aaa.\(String(repeating: "b", count: 4_100)).ccc"
+        ))
+    }
+
+    func testOpaqueValueStillRejectsHeaderSeparatorsAndControls() {
+        let opaque = ChromiumLocalStorageCredential(
+            origin: "https://example.com",
+            key: "session",
+            syntheticCookieName: "session",
+            valueFormat: .opaque(minLength: 3, maxLength: 20)
+        )
+
+        XCTAssertEqual(opaque.cookieHeader(from: "abc=123"), "session=abc=123")
+        XCTAssertNil(opaque.cookieHeader(from: "abc;other=value"))
+        XCTAssertNil(opaque.cookieHeader(from: "abc\nvalue"))
+    }
+
+    func testInvalidSyntheticCookieNameIsRejected() {
+        let invalid = ChromiumLocalStorageCredential(
+            origin: "https://example.com",
+            key: "access_token",
+            syntheticCookieName: "bad name",
+            valueFormat: .opaque(minLength: 1, maxLength: 20)
+        )
+        XCTAssertNil(invalid.cookieHeader(from: "value"))
+    }
+}

--- a/Tests/VibeBarCoreTests/ChromiumLocalStorageCredentialImporterTests.swift
+++ b/Tests/VibeBarCoreTests/ChromiumLocalStorageCredentialImporterTests.swift
@@ -1,0 +1,455 @@
+import Foundation
+import SweetCookieKit
+import XCTest
+@testable import VibeBarCore
+
+final class ChromiumLocalStorageCredentialImporterTests: XCTestCase {
+    private let credential = ChromiumLocalStorageCredential(
+        origin: "https://example.com",
+        key: "access_token",
+        syntheticCookieName: "session-token",
+        valueFormat: .jwt(segments: 3, minLength: 16, maxLength: 4_096)
+    )
+
+    func testReadsExactOriginAndKeyFromAChromiumProfile() throws {
+        let root = try makeTemporaryDirectory()
+        let defaultProfile = root.appendingPathComponent("Default", isDirectory: true)
+        let ignoredProfile = root.appendingPathComponent("System Profile", isDirectory: true)
+        try FileManager.default.createDirectory(at: ignoredProfile, withIntermediateDirectories: true)
+        let token = "synthetic-header.synthetic_payload.synthetic-signature"
+        try writeLocalStorageLog(
+            origin: credential.origin,
+            key: credential.key,
+            value: token,
+            profile: defaultProfile
+        )
+        try writeLocalStorageLog(
+            origin: credential.origin,
+            key: credential.key,
+            value: "ignored-header.ignored_payload.ignored-signature",
+            profile: ignoredProfile
+        )
+
+        let sessions = ChromiumLocalStorageCredentialImporter.sessions(
+            credential: credential,
+            roots: [.init(browser: .chrome, url: root)],
+            cache: .init()
+        )
+
+        XCTAssertEqual(sessions, [
+            .init(header: "session-token=\(token)", sourceLabel: "Chrome Default")
+        ])
+    }
+
+    func testReadsExactPartitionedOriginWithoutPrefix() throws {
+        let root = try makeTemporaryDirectory()
+        let profile = root.appendingPathComponent("Default", isDirectory: true)
+        let token = "synthetic-header.synthetic_payload.synthetic-signature"
+        try writeLocalStorageLog(
+            origin: "https://example.com/^0https://top.example",
+            key: credential.key,
+            value: token,
+            profile: profile,
+            includePrefix: false
+        )
+
+        let sessions = ChromiumLocalStorageCredentialImporter.sessions(
+            credential: credential,
+            roots: [.init(browser: .chrome, url: root)],
+            cache: .init()
+        )
+
+        XCTAssertEqual(sessions.map(\.header), ["session-token=\(token)"])
+    }
+
+    func testRejectsHTTPValueForHTTPSOriginOnTheSameHost() throws {
+        let root = try makeTemporaryDirectory()
+        let profile = root.appendingPathComponent("Default", isDirectory: true)
+        try writeLocalStorageLog(
+            origin: "http://example.com",
+            key: credential.key,
+            value: "synthetic-header.synthetic_payload.synthetic-signature",
+            profile: profile
+        )
+
+        let sessions = ChromiumLocalStorageCredentialImporter.sessions(
+            credential: credential,
+            roots: [.init(browser: .chrome, url: root)],
+            cache: .init()
+        )
+
+        XCTAssertTrue(sessions.isEmpty)
+    }
+
+    func testRejectsValueFromADifferentExplicitPort() throws {
+        let root = try makeTemporaryDirectory()
+        let profile = root.appendingPathComponent("Default", isDirectory: true)
+        try writeLocalStorageLog(
+            origin: "https://example.com:8443",
+            key: credential.key,
+            value: "synthetic-header.synthetic_payload.synthetic-signature",
+            profile: profile
+        )
+        let portCredential = ChromiumLocalStorageCredential(
+            origin: "https://example.com:9443/",
+            key: credential.key,
+            syntheticCookieName: "session-token",
+            valueFormat: .jwt(segments: 3, minLength: 16, maxLength: 4_096)
+        )
+
+        let sessions = ChromiumLocalStorageCredentialImporter.sessions(
+            credential: portCredential,
+            roots: [.init(browser: .chrome, url: root)],
+            cache: .init()
+        )
+
+        XCTAssertTrue(sessions.isEmpty)
+    }
+
+    func testRejectsWrongKeyAndMalformedValue() throws {
+        let root = try makeTemporaryDirectory()
+        let profile = root.appendingPathComponent("Default", isDirectory: true)
+        try writeLocalStorageLog(
+            origin: credential.origin,
+            key: "other_key",
+            value: "synthetic-header.synthetic_payload.synthetic-signature",
+            profile: profile
+        )
+
+        let sessions = ChromiumLocalStorageCredentialImporter.sessions(
+            credential: credential,
+            roots: [.init(browser: .chrome, url: root)],
+            cache: .init()
+        )
+
+        XCTAssertTrue(sessions.isEmpty)
+    }
+
+    func testRejectsSymlinkedProfileDirectory() throws {
+        let root = try makeTemporaryDirectory()
+        let target = try makeTemporaryDirectory()
+        let token = "synthetic-header.synthetic_payload.synthetic-signature"
+        try writeLocalStorageLog(
+            origin: credential.origin,
+            key: credential.key,
+            value: token,
+            profile: target
+        )
+        try FileManager.default.createSymbolicLink(
+            at: root.appendingPathComponent("Default", isDirectory: true),
+            withDestinationURL: target
+        )
+
+        let sessions = ChromiumLocalStorageCredentialImporter.sessions(
+            credential: credential,
+            roots: [.init(browser: .chrome, url: root)],
+            cache: .init()
+        )
+
+        XCTAssertTrue(sessions.isEmpty)
+    }
+
+    func testRejectsSymlinkedRootDirectory() throws {
+        let parent = try makeTemporaryDirectory()
+        let targetRoot = try makeTemporaryDirectory()
+        let targetProfile = targetRoot.appendingPathComponent("Default", isDirectory: true)
+        try writeLocalStorageLog(
+            origin: credential.origin,
+            key: credential.key,
+            value: "synthetic-header.synthetic_payload.synthetic-signature",
+            profile: targetProfile
+        )
+        let linkedRoot = parent.appendingPathComponent("Chrome", isDirectory: true)
+        try FileManager.default.createSymbolicLink(at: linkedRoot, withDestinationURL: targetRoot)
+
+        let sessions = ChromiumLocalStorageCredentialImporter.sessions(
+            credential: credential,
+            roots: [.init(browser: .chrome, url: linkedRoot)],
+            cache: .init()
+        )
+
+        XCTAssertTrue(sessions.isEmpty)
+    }
+
+    func testRejectsSymlinkedLevelDBDirectory() throws {
+        let root = try makeTemporaryDirectory()
+        let profile = root.appendingPathComponent("Default", isDirectory: true)
+        let localStorage = profile.appendingPathComponent("Local Storage", isDirectory: true)
+        try FileManager.default.createDirectory(at: localStorage, withIntermediateDirectories: true)
+
+        let targetProfile = try makeTemporaryDirectory()
+        try writeLocalStorageLog(
+            origin: credential.origin,
+            key: credential.key,
+            value: "synthetic-header.synthetic_payload.synthetic-signature",
+            profile: targetProfile
+        )
+        let targetLevelDB = targetProfile
+            .appendingPathComponent("Local Storage", isDirectory: true)
+            .appendingPathComponent("leveldb", isDirectory: true)
+        try FileManager.default.createSymbolicLink(
+            at: localStorage.appendingPathComponent("leveldb", isDirectory: true),
+            withDestinationURL: targetLevelDB
+        )
+
+        let sessions = ChromiumLocalStorageCredentialImporter.sessions(
+            credential: credential,
+            roots: [.init(browser: .chrome, url: root)],
+            cache: .init()
+        )
+
+        XCTAssertTrue(sessions.isEmpty)
+    }
+
+    func testRejectsSymlinkedLevelDBDataFile() throws {
+        let root = try makeTemporaryDirectory()
+        let profile = root.appendingPathComponent("Default", isDirectory: true)
+        let levelDB = try makeEmptyLevelDB(profile: profile)
+        let targetFile = try makeTemporaryDirectory().appendingPathComponent("source.log")
+        try Data([0]).write(to: targetFile)
+        try FileManager.default.createSymbolicLink(
+            at: levelDB.appendingPathComponent("000003.log"),
+            withDestinationURL: targetFile
+        )
+
+        let sessions = ChromiumLocalStorageCredentialImporter.sessions(
+            credential: credential,
+            roots: [.init(browser: .chrome, url: root)],
+            cache: .init()
+        )
+
+        XCTAssertTrue(sessions.isEmpty)
+    }
+
+    func testSharedBatchCacheReadsEachProfileOnlyOnce() throws {
+        let root = try makeTemporaryDirectory()
+        let profile = root.appendingPathComponent("Default", isDirectory: true)
+        try makeEmptyLevelDB(profile: profile)
+        let counter = LockedCounter()
+        let token = "synthetic-header.synthetic_payload.synthetic-signature"
+        let roots = [ChromiumProfileRoot(browser: .chrome, url: root)]
+        let cache = ChromiumLocalStorageCredentialImporter.Cache()
+        let textEntry = ChromiumLevelDBTextEntry(
+            key: "_\(credential.origin)\0\(credential.key)",
+            value: token
+        )
+        let reader: ChromiumLocalStorageCredentialImporter.EntryReader = { origin, _ in
+            counter.increment()
+            return [ChromiumLocalStorageEntry(
+                origin: origin,
+                key: "access_token",
+                value: token,
+                rawValueLength: token.utf8.count + 1
+            )]
+        }
+
+        let first = ChromiumLocalStorageCredentialImporter.sessions(
+            credential: credential,
+            roots: roots,
+            cache: cache,
+            readEntries: reader,
+            readTextEntries: { _ in [textEntry] }
+        )
+        let second = ChromiumLocalStorageCredentialImporter.sessions(
+            credential: credential,
+            roots: roots,
+            cache: cache,
+            readEntries: reader,
+            readTextEntries: { _ in [textEntry] }
+        )
+
+        XCTAssertEqual(first, second)
+        XCTAssertEqual(counter.value, 1)
+    }
+
+    func testSingleImportStopsAfterTheFirstUsableProfile() throws {
+        let root = try makeTemporaryDirectory()
+        for name in ["Default", "Profile 1"] {
+            try makeEmptyLevelDB(
+                profile: root.appendingPathComponent(name, isDirectory: true)
+            )
+        }
+        let counter = LockedCounter()
+        let token = "synthetic-header.synthetic_payload.synthetic-signature"
+        let textEntry = ChromiumLevelDBTextEntry(
+            key: "_\(credential.origin)\0\(credential.key)",
+            value: token
+        )
+        let reader: ChromiumLocalStorageCredentialImporter.EntryReader = { origin, _ in
+            counter.increment()
+            return [ChromiumLocalStorageEntry(
+                origin: origin,
+                key: "access_token",
+                value: token,
+                rawValueLength: token.utf8.count + 1
+            )]
+        }
+
+        let sessions = ChromiumLocalStorageCredentialImporter.sessions(
+            credential: credential,
+            roots: [.init(browser: .chrome, url: root)],
+            cache: .init(),
+            maxSessions: 1,
+            readEntries: reader,
+            readTextEntries: { _ in [textEntry] }
+        )
+
+        XCTAssertEqual(sessions.map(\.sourceLabel), ["Chrome Default"])
+        XCTAssertEqual(counter.value, 1)
+    }
+
+    func testMiscBrowserSessionsUsesTheDeclaredLocalStorageSource() throws {
+        let home = try makeTemporaryDirectory()
+        let profile = home
+            .appendingPathComponent("Library/Application Support/Google/Chrome", isDirectory: true)
+            .appendingPathComponent("Default", isDirectory: true)
+        let token = "synthetic-header.synthetic_payload.synthetic-signature"
+        try writeLocalStorageLog(
+            origin: "https://www.kimi.com",
+            key: "access_token",
+            value: token,
+            profile: profile
+        )
+        let context = MiscCookieResolver.BrowserImportContext(
+            detection: BrowserDetection(homeDirectory: home.path),
+            homeDirectory: home
+        )
+        let settings = MiscProviderSettings(preferredBrowser: .chrome)
+
+        let sessions = MiscCookieResolver.browserSessions(
+            spec: KimiQuotaAdapter.cookieSpec,
+            settings: settings,
+            allowKeychainPrompt: false,
+            context: context,
+            maxSessions: 1
+        )
+
+        XCTAssertEqual(sessions.count, 1)
+        XCTAssertEqual(sessions[0].sourceLabel, "Chrome Default")
+        XCTAssertEqual(sessions[0].header, "kimi-auth=\(token)")
+    }
+
+    func testMiscBrowserSessionsRejectsHeaderThatDoesNotMatchTheSpec() throws {
+        let home = try makeTemporaryDirectory()
+        let profile = home
+            .appendingPathComponent("Library/Application Support/Google/Chrome", isDirectory: true)
+            .appendingPathComponent("Default", isDirectory: true)
+        let token = "synthetic-header.synthetic_payload.synthetic-signature"
+        try writeLocalStorageLog(
+            origin: "https://example.com",
+            key: "access_token",
+            value: token,
+            profile: profile
+        )
+        let mismatched = MiscCookieResolver.Spec(
+            tool: .kimi,
+            domains: ["example.com"],
+            requiredNames: ["expected-cookie"],
+            browserCredentialSource: .chromiumLocalStorage(.init(
+                origin: "https://example.com",
+                key: "access_token",
+                syntheticCookieName: "different-cookie",
+                valueFormat: .jwt(segments: 3, minLength: 16, maxLength: 4_096)
+            ))
+        )
+
+        let sessions = MiscCookieResolver.browserSessions(
+            spec: mismatched,
+            settings: MiscProviderSettings(preferredBrowser: .chrome),
+            allowKeychainPrompt: false,
+            context: .init(
+                detection: BrowserDetection(homeDirectory: home.path),
+                homeDirectory: home
+            ),
+            maxSessions: 1
+        )
+
+        XCTAssertTrue(sessions.isEmpty)
+    }
+
+    private func makeTemporaryDirectory() throws -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("vibebar-chromium-storage-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(at: directory) }
+        return directory
+    }
+
+    private func writeLocalStorageLog(
+        origin: String,
+        key: String,
+        value: String,
+        profile: URL,
+        includePrefix: Bool = true
+    ) throws {
+        let levelDB = try makeEmptyLevelDB(profile: profile)
+
+        var localStorageKey = Data()
+        if includePrefix {
+            localStorageKey.append(0x5F)
+        }
+        localStorageKey.append(contentsOf: origin.utf8)
+        localStorageKey.append(0x00)
+        localStorageKey.append(contentsOf: key.utf8)
+        var localStorageValue = Data([0x01])
+        localStorageValue.append(contentsOf: value.utf8)
+
+        var batch = Data(Array(repeating: UInt8(0), count: 8))
+        batch.append(contentsOf: littleEndianBytes(UInt32(1)))
+        batch.append(0x01)
+        batch.append(varint32(localStorageKey.count))
+        batch.append(localStorageKey)
+        batch.append(varint32(localStorageValue.count))
+        batch.append(localStorageValue)
+
+        var record = Data(Array(repeating: UInt8(0), count: 4))
+        record.append(contentsOf: littleEndianBytes(UInt16(batch.count)))
+        record.append(0x01)
+        record.append(batch)
+        try record.write(to: levelDB.appendingPathComponent("000003.log"))
+    }
+
+    @discardableResult
+    private func makeEmptyLevelDB(profile: URL) throws -> URL {
+        let levelDB = profile
+            .appendingPathComponent("Local Storage", isDirectory: true)
+            .appendingPathComponent("leveldb", isDirectory: true)
+        try FileManager.default.createDirectory(at: levelDB, withIntermediateDirectories: true)
+        return levelDB
+    }
+
+    private func varint32(_ value: Int) -> Data {
+        var remaining = UInt32(value)
+        var data = Data()
+        while true {
+            if remaining & ~0x7F == 0 {
+                data.append(UInt8(remaining))
+                return data
+            }
+            data.append(UInt8((remaining & 0x7F) | 0x80))
+            remaining >>= 7
+        }
+    }
+
+    private func littleEndianBytes(_ value: some FixedWidthInteger) -> [UInt8] {
+        var copy = value.littleEndian
+        return withUnsafeBytes(of: &copy) { Array($0) }
+    }
+}
+
+private final class LockedCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var count = 0
+
+    func increment() {
+        lock.lock()
+        count += 1
+        lock.unlock()
+    }
+
+    var value: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return count
+    }
+}

--- a/Tests/VibeBarCoreTests/KimiMiniMaxParserTests.swift
+++ b/Tests/VibeBarCoreTests/KimiMiniMaxParserTests.swift
@@ -4,27 +4,6 @@ import XCTest
 final class KimiParserTests: XCTestCase {
     private let now = Date(timeIntervalSince1970: 1_715_000_000)
 
-    func testKimiAccessTokenBecomesCookieShapedHeader() {
-        let token = "synthetic-header.synthetic_payload.synthetic-signature"
-        XCTAssertEqual(
-            KimiQuotaAdapter.cookieHeader(fromAccessToken: "  \(token)\n"),
-            "kimi-auth=\(token)"
-        )
-    }
-
-    func testKimiAccessTokenRejectsMalformedOrInjectableValues() {
-        XCTAssertNil(KimiQuotaAdapter.cookieHeader(fromAccessToken: "not-a-jwt"))
-        XCTAssertNil(KimiQuotaAdapter.cookieHeader(fromAccessToken: "a..c"))
-        XCTAssertNil(KimiQuotaAdapter.cookieHeader(fromAccessToken: "aaa.bbb.ccc;other=value"))
-        XCTAssertNil(KimiQuotaAdapter.cookieHeader(fromAccessToken: "aaa.bbb.ccc\r\nInjected: value"))
-        XCTAssertNil(KimiQuotaAdapter.cookieHeader(fromAccessToken: "aaa.bébé.ccc"))
-        XCTAssertNil(
-            KimiQuotaAdapter.cookieHeader(
-                fromAccessToken: "aaa.\(String(repeating: "b", count: 4_100)).ccc"
-            )
-        )
-    }
-
     func testParsesWeeklyAndRateLimit() throws {
         let json = """
         {

--- a/Tests/VibeBarCoreTests/MiscCookieSlotTests.swift
+++ b/Tests/VibeBarCoreTests/MiscCookieSlotTests.swift
@@ -38,27 +38,64 @@ final class MiscCookieSlotTests: XCTestCase {
         XCTAssertEqual(slot.cookieHeader, "foo=bar")
     }
 
-    func testWebLoginCaptureKindRoundTripsWithLegacyOrigin() throws {
-        let slot = MiscCookieSlot(
-            cookieHeader: "kimi-auth=synthetic.header.signature",
-            sourceLabel: "Kimi Web login",
-            importedAt: Date(timeIntervalSince1970: 1_700_000_000),
-            origin: .manual,
-            captureKind: .webLogin
-        )
+    func testLegacyWebLoginManualSlotDecodesAsBrowserImport() throws {
+        let raw = """
+        {
+          "id": "22222222-2222-2222-2222-222222222222",
+          "cookieHeader": "session=synthetic",
+          "sourceLabel": "Web login",
+          "importedAt": "2026-08-23T10:00:00Z",
+          "origin": "manual",
+          "captureKind": "webLogin"
+        }
+        """
 
-        XCTAssertEqual(try JSONDecoder().decode(MiscCookieSlot.self, from: JSONEncoder().encode(slot)), slot)
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let slot = try decoder.decode(MiscCookieSlot.self, from: Data(raw.utf8))
+
+        XCTAssertEqual(slot.origin, .browserImport)
+        XCTAssertEqual(slot.sourceLabel, "Web login")
     }
 
-    func testDev40DecoderCanReadWebLoginSlotWithoutDroppingTheArray() throws {
-        let slot = webLoginSlot()
-        let data = try JSONEncoder().encode([slot])
+    func testLegacyCaptureKindIsNotReencoded() throws {
+        let raw = """
+        {
+          "id": "33333333-3333-3333-3333-333333333333",
+          "cookieHeader": "session=synthetic",
+          "sourceLabel": "Web login",
+          "importedAt": "2026-08-23T10:00:00Z",
+          "origin": "manual",
+          "captureKind": "webLogin"
+        }
+        """
 
-        let legacy = try JSONDecoder().decode([Dev40MiscCookieSlot].self, from: data)
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let slot = try decoder.decode(MiscCookieSlot.self, from: Data(raw.utf8))
 
-        XCTAssertEqual(legacy.count, 1)
-        XCTAssertEqual(legacy[0].cookieHeader, slot.cookieHeader)
-        XCTAssertEqual(legacy[0].origin, .manual)
+        let encoded = try JSONEncoder().encode(slot)
+        let object = try XCTUnwrap(JSONSerialization.jsonObject(with: encoded) as? [String: Any])
+        XCTAssertNil(object["captureKind"])
+        XCTAssertEqual(object["origin"] as? String, "browserImport")
+    }
+
+    func testOrdinaryManualSlotStaysManual() throws {
+        let raw = """
+        {
+          "id": "44444444-4444-4444-4444-444444444444",
+          "cookieHeader": "session=synthetic",
+          "sourceLabel": "Manual paste",
+          "importedAt": "2026-08-23T10:00:00Z",
+          "origin": "manual"
+        }
+        """
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let slot = try decoder.decode(MiscCookieSlot.self, from: Data(raw.utf8))
+
+        XCTAssertEqual(slot.origin, .manual)
     }
 
     func testSlotFilterFromSettings() {
@@ -69,7 +106,6 @@ final class MiscCookieSlotTests: XCTestCase {
         XCTAssertEqual(auto, .all)
         XCTAssertTrue(auto.allows(slot(origin: .manual)))
         XCTAssertTrue(auto.allows(slot(origin: .browserImport)))
-        XCTAssertTrue(auto.allows(webLoginSlot()))
         XCTAssertTrue(auto.allows(slot(origin: .autoRefresh)))
 
         // Auto with cookieSource = manual collapses to manualOnly.
@@ -78,7 +114,6 @@ final class MiscCookieSlotTests: XCTestCase {
         )
         XCTAssertEqual(manualViaCookieSource, .manualOnly)
         XCTAssertTrue(manualViaCookieSource.allows(slot(origin: .manual)))
-        XCTAssertTrue(manualViaCookieSource.allows(webLoginSlot()))
         XCTAssertFalse(manualViaCookieSource.allows(slot(origin: .browserImport)))
 
         // Explicit browserOnly source mode.
@@ -88,7 +123,6 @@ final class MiscCookieSlotTests: XCTestCase {
         XCTAssertEqual(browser, .browserOnly)
         XCTAssertFalse(browser.allows(slot(origin: .manual)))
         XCTAssertTrue(browser.allows(slot(origin: .browserImport)))
-        XCTAssertTrue(browser.allows(webLoginSlot()))
         XCTAssertTrue(browser.allows(slot(origin: .autoRefresh)))
 
         // apiOnly / off shut every slot out.
@@ -104,11 +138,101 @@ final class MiscCookieSlotTests: XCTestCase {
         XCTAssertEqual(off, .none)
     }
 
-    func testOnlySystemBrowserOriginsCanBeSilentlyReimported() {
-        XCTAssertFalse(slot(origin: .manual).isSystemBrowserRefreshable)
-        XCTAssertTrue(slot(origin: .browserImport).isSystemBrowserRefreshable)
-        XCTAssertTrue(slot(origin: .autoRefresh).isSystemBrowserRefreshable)
-        XCTAssertFalse(webLoginSlot().isSystemBrowserRefreshable)
+    func testBrowserImportRefreshesTheSameProfileInPlace() {
+        let id = UUID()
+        let old = MiscCookieSlot(
+            id: id,
+            cookieHeader: "session=stale",
+            sourceLabel: "Chrome Default",
+            importedAt: Date(timeIntervalSince1970: 100),
+            origin: .autoRefresh
+        )
+        let fresh = MiscCookieSlot(
+            cookieHeader: "session=fresh",
+            sourceLabel: "Chrome Default",
+            importedAt: Date(timeIntervalSince1970: 200),
+            origin: .browserImport
+        )
+
+        let merged = MiscCookieSlotStore.mergingBrowserImport(fresh, into: [old])
+
+        XCTAssertEqual(merged.slots.count, 1)
+        XCTAssertEqual(merged.stored.id, id)
+        XCTAssertEqual(merged.stored.cookieHeader, "session=fresh")
+        XCTAssertEqual(merged.stored.origin, .browserImport)
+        XCTAssertEqual(merged.stored.importedAt, fresh.importedAt)
+    }
+
+    func testBrowserImportKeepsDifferentProfilesStacked() {
+        let existing = MiscCookieSlot(
+            cookieHeader: "session=shared",
+            sourceLabel: "Chrome Profile 1",
+            origin: .browserImport
+        )
+        let incoming = MiscCookieSlot(
+            cookieHeader: "session=shared",
+            sourceLabel: "Chrome Default",
+            origin: .browserImport
+        )
+
+        let merged = MiscCookieSlotStore.mergingBrowserImport(incoming, into: [existing])
+
+        XCTAssertEqual(merged.slots.map(\.sourceLabel), ["Chrome Profile 1", "Chrome Default"])
+        XCTAssertEqual(merged.stored.id, incoming.id)
+    }
+
+    func testBrowserImportReclaimsSingleLegacyAutoRefreshSlot() {
+        let manual = MiscCookieSlot(
+            cookieHeader: "session=manual",
+            sourceLabel: "Manual paste",
+            origin: .manual
+        )
+        let legacyID = UUID()
+        let legacy = MiscCookieSlot(
+            id: legacyID,
+            cookieHeader: "session=stale",
+            sourceLabel: "Auto-refresh",
+            importedAt: Date(timeIntervalSince1970: 100),
+            origin: .autoRefresh
+        )
+        let incoming = MiscCookieSlot(
+            cookieHeader: "session=fresh",
+            sourceLabel: "Chrome Default",
+            importedAt: Date(timeIntervalSince1970: 200),
+            origin: .browserImport
+        )
+
+        let merged = MiscCookieSlotStore.mergingBrowserImport(
+            incoming,
+            into: [manual, legacy]
+        )
+
+        XCTAssertEqual(merged.slots.count, 2)
+        XCTAssertEqual(merged.slots[0], manual)
+        XCTAssertEqual(merged.stored.id, legacyID)
+        XCTAssertEqual(merged.stored.cookieHeader, "session=fresh")
+        XCTAssertEqual(merged.stored.sourceLabel, "Chrome Default")
+        XCTAssertEqual(merged.stored.origin, .browserImport)
+        XCTAssertEqual(merged.stored.importedAt, incoming.importedAt)
+    }
+
+    func testBrowserImportNeverOverwritesManualSlot() {
+        let manual = MiscCookieSlot(
+            cookieHeader: "session=same",
+            sourceLabel: "Chrome Default",
+            origin: .manual
+        )
+        let incoming = MiscCookieSlot(
+            cookieHeader: "session=same",
+            sourceLabel: "Chrome Default",
+            origin: .browserImport
+        )
+
+        let merged = MiscCookieSlotStore.mergingBrowserImport(incoming, into: [manual])
+
+        XCTAssertEqual(merged.slots.count, 2)
+        XCTAssertEqual(merged.slots.first, manual)
+        XCTAssertEqual(merged.stored.id, incoming.id)
     }
 
     private func slot(origin: MiscCookieSlot.Origin) -> MiscCookieSlot {
@@ -119,30 +243,4 @@ final class MiscCookieSlotTests: XCTestCase {
             origin: origin
         )
     }
-
-    private func webLoginSlot() -> MiscCookieSlot {
-        MiscCookieSlot(
-            cookieHeader: "kimi-auth=synthetic.header.signature",
-            sourceLabel: "Kimi Web login",
-            importedAt: Date(),
-            origin: .manual,
-            captureKind: .webLogin
-        )
-    }
-}
-
-/// Exact wire shape shipped in Dev 40. Unknown additive object fields are
-/// ignored by synthesized Decodable, but unknown enum raw values are not.
-private struct Dev40MiscCookieSlot: Decodable {
-    enum Origin: String, Decodable {
-        case manual
-        case browserImport
-        case autoRefresh
-    }
-
-    let id: UUID
-    let cookieHeader: String
-    let sourceLabel: String
-    let importedAt: Date
-    let origin: Origin
 }

--- a/Tests/VibeBarCoreTests/MiscCookieSpecCatalogTests.swift
+++ b/Tests/VibeBarCoreTests/MiscCookieSpecCatalogTests.swift
@@ -89,29 +89,28 @@ final class MiscCookieSpecCatalogTests: XCTestCase {
                 "\(tool.rawValue) credentialNames"
             )
             XCTAssertEqual(
-                catalogSpec.supportsSystemBrowserImport,
-                adapterSpec.supportsSystemBrowserImport,
-                "\(tool.rawValue) browser-import capability"
+                catalogSpec.browserCredentialSource,
+                adapterSpec.browserCredentialSource,
+                "\(tool.rawValue) browser credential source"
             )
         }
     }
 
-    func testOnlyKimiRequiresProviderSpecificWebLogin() {
+    func testKimiUsesTheGenericChromiumLocalStorageSource() {
+        let expected = BrowserCredentialSource.chromiumLocalStorage(
+            ChromiumLocalStorageCredential(
+                origin: "https://www.kimi.com",
+                key: "access_token",
+                syntheticCookieName: "kimi-auth",
+                valueFormat: .jwt(segments: 3, minLength: 16, maxLength: 4_096)
+            )
+        )
+        XCTAssertEqual(KimiQuotaAdapter.cookieSpec.browserCredentialSource, expected)
+
         for spec in MiscCookieSpecCatalog.allSpecs {
-            XCTAssertEqual(
-                spec.supportsSystemBrowserImport,
-                spec.tool != .kimi,
-                "\(spec.tool.rawValue) browser-import capability"
-            )
+            guard spec.tool != .kimi else { continue }
+            XCTAssertEqual(spec.browserCredentialSource, .cookieJar, spec.tool.rawValue)
         }
-    }
-
-    func testKimiBrowserImportIsRejectedBeforeBrowserOrKeychainAccess() {
-        XCTAssertNil(MiscCookieResolver.appendBrowserImport(for: KimiQuotaAdapter.cookieSpec))
-        let outcomes = MiscCookieResolver.appendBrowserImports(for: [
-            .init(spec: KimiQuotaAdapter.cookieSpec, instanceID: "kimi")
-        ])
-        XCTAssertEqual(outcomes.map(\.result), [.browserImportUnsupported])
     }
 
     func testNonCookieProvidersHaveNoSpec() {


### PR DESCRIPTION
## Summary

- model browser-backed misc credentials as one generic source, including exact Chromium localStorage fields
- restore Kimi to the shared single/batch/silent Browser Cookies path and remove its provider-specific WebView flow
- migrate Dev 41 Web-login slots back to browser ownership while preserving manual slots and per-profile stacking
- fail closed on scheme/port mismatches and symlink/containment ambiguity; pin SweetCookieKit 0.5.2

## Test plan

- [x] `swift test` — 1625 tests, 1 skipped, 0 failures
- [x] `./Scripts/build_app.sh release`
- [x] deep code-signature verification
- [x] empty entitlements verification
- [x] exact-origin and root/profile/leveldb/data-file symlink tests
- [x] independent final diff audit — no P0/P1/P2
- [ ] single-instance installed-app smoke test after the Dev release update (no second ad-hoc instance, per user request)
