### PR TITLE
Prepare Vibe Bar 1.3.0 Dev build 42

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.3.0</string>
 	<key>CFBundleVersion</key>
-	<string>41</string>
+	<string>42</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>26.0</string>
 	<key>LSUIElement</key>


### PR DESCRIPTION
## Summary

- bump CFBundleVersion from 41 to 42
- keep CFBundleShortVersionString at 1.3.0 for the Dev channel

## Test plan

- [x] `swift test` — 1625 tests, 1 skipped, 0 failures
- [x] `./Scripts/build_app.sh release`
- [x] deep code-signature verification
- [x] empty entitlements verification
- [x] packaged bundle reports 1.3.0 (42)
