### PR TITLE
Decode Chromium localStorage key prefixes

### DIFF
--- a/Sources/VibeBarCore/BrowserCookies/ChromiumLocalStorageCredentialImporter.swift
+++ b/Sources/VibeBarCore/BrowserCookies/ChromiumLocalStorageCredentialImporter.swift
@@ -220,7 +220,7 @@ enum ChromiumLocalStorageCredentialImporter {
         guard let separator = rawKey.firstIndex(of: "\0") else { return nil }
         var serializedOrigin = String(rawKey[..<separator])
         let keyStart = rawKey.index(after: separator)
-        let key = String(rawKey[keyStart...])
+        guard let key = decodeLocalStorageKeyName(rawKey[keyStart...]) else { return nil }
         guard !serializedOrigin.isEmpty, !key.isEmpty, !key.contains("\0") else { return nil }
 
         if serializedOrigin.first == "_" {
@@ -235,6 +235,26 @@ enum ChromiumLocalStorageCredentialImporter {
         }
         guard !serializedOrigin.isEmpty else { return nil }
         return (serializedOrigin, key)
+    }
+
+    /// Chromium stores the key name as its own prefixed string after the
+    /// origin/key NUL separator: `0x01` for Latin-1 or `0x00` for UTF-16LE.
+    /// `readTextEntries` preserves that control marker in the raw-key string,
+    /// so mirror SweetCookieKit's key decoder before exact-key comparison.
+    private static func decodeLocalStorageKeyName(_ rawName: Substring) -> String? {
+        let bytes = Data(rawName.utf8)
+        guard let prefix = bytes.first else { return nil }
+        switch prefix {
+        case 0:
+            return String(data: bytes.dropFirst(), encoding: .utf16LittleEndian)
+        case 1:
+            return String(data: bytes.dropFirst(), encoding: .isoLatin1)
+        default:
+            // Older fixtures and best-effort stores can expose an unprefixed
+            // UTF-8 key. Preserve that compatibility without weakening the
+            // exact origin/key/value provenance gate.
+            return String(rawName)
+        }
     }
 
     private struct ExactOrigin: Equatable {

--- a/Tests/VibeBarCoreTests/ChromiumLocalStorageCredentialImporterTests.swift
+++ b/Tests/VibeBarCoreTests/ChromiumLocalStorageCredentialImporterTests.swift
@@ -11,7 +11,7 @@ final class ChromiumLocalStorageCredentialImporterTests: XCTestCase {
         valueFormat: .jwt(segments: 3, minLength: 16, maxLength: 4_096)
     )
 
-    func testReadsExactOriginAndKeyFromAChromiumProfile() throws {
+    func testReadsExactOriginAndLatin1PrefixedKeyFromAChromiumProfile() throws {
         let root = try makeTemporaryDirectory()
         let defaultProfile = root.appendingPathComponent("Default", isDirectory: true)
         let ignoredProfile = root.appendingPathComponent("System Profile", isDirectory: true)
@@ -41,7 +41,7 @@ final class ChromiumLocalStorageCredentialImporterTests: XCTestCase {
         ])
     }
 
-    func testReadsExactPartitionedOriginWithoutPrefix() throws {
+    func testReadsExactPartitionedOriginWithoutStorageKeyUnderscore() throws {
         let root = try makeTemporaryDirectory()
         let profile = root.appendingPathComponent("Default", isDirectory: true)
         let token = "synthetic-header.synthetic_payload.synthetic-signature"
@@ -51,6 +51,27 @@ final class ChromiumLocalStorageCredentialImporterTests: XCTestCase {
             value: token,
             profile: profile,
             includePrefix: false
+        )
+
+        let sessions = ChromiumLocalStorageCredentialImporter.sessions(
+            credential: credential,
+            roots: [.init(browser: .chrome, url: root)],
+            cache: .init()
+        )
+
+        XCTAssertEqual(sessions.map(\.header), ["session-token=\(token)"])
+    }
+
+    func testReadsUnprefixedKeyNameForCompatibility() throws {
+        let root = try makeTemporaryDirectory()
+        let profile = root.appendingPathComponent("Default", isDirectory: true)
+        let token = "synthetic-header.synthetic_payload.synthetic-signature"
+        try writeLocalStorageLog(
+            origin: credential.origin,
+            key: credential.key,
+            value: token,
+            profile: profile,
+            keyEncodingPrefix: nil
         )
 
         let sessions = ChromiumLocalStorageCredentialImporter.sessions(
@@ -230,7 +251,7 @@ final class ChromiumLocalStorageCredentialImporterTests: XCTestCase {
         let roots = [ChromiumProfileRoot(browser: .chrome, url: root)]
         let cache = ChromiumLocalStorageCredentialImporter.Cache()
         let textEntry = ChromiumLevelDBTextEntry(
-            key: "_\(credential.origin)\0\(credential.key)",
+            key: "_\(credential.origin)\0\u{1}\(credential.key)",
             value: token
         )
         let reader: ChromiumLocalStorageCredentialImporter.EntryReader = { origin, _ in
@@ -272,7 +293,7 @@ final class ChromiumLocalStorageCredentialImporterTests: XCTestCase {
         let counter = LockedCounter()
         let token = "synthetic-header.synthetic_payload.synthetic-signature"
         let textEntry = ChromiumLevelDBTextEntry(
-            key: "_\(credential.origin)\0\(credential.key)",
+            key: "_\(credential.origin)\0\u{1}\(credential.key)",
             value: token
         )
         let reader: ChromiumLocalStorageCredentialImporter.EntryReader = { origin, _ in
@@ -380,7 +401,8 @@ final class ChromiumLocalStorageCredentialImporterTests: XCTestCase {
         key: String,
         value: String,
         profile: URL,
-        includePrefix: Bool = true
+        includePrefix: Bool = true,
+        keyEncodingPrefix: UInt8? = 1
     ) throws {
         let levelDB = try makeEmptyLevelDB(profile: profile)
 
@@ -390,7 +412,14 @@ final class ChromiumLocalStorageCredentialImporterTests: XCTestCase {
         }
         localStorageKey.append(contentsOf: origin.utf8)
         localStorageKey.append(0x00)
-        localStorageKey.append(contentsOf: key.utf8)
+        if let keyEncodingPrefix {
+            localStorageKey.append(keyEncodingPrefix)
+        }
+        if keyEncodingPrefix == 0 {
+            localStorageKey.append(key.data(using: .utf16LittleEndian)!)
+        } else {
+            localStorageKey.append(contentsOf: key.utf8)
+        }
         var localStorageValue = Data([0x01])
         localStorageValue.append(contentsOf: value.utf8)
 


### PR DESCRIPTION
## Summary

- decode Chromium's 0x00/0x01 string marker before exact localStorage key comparison
- make synthetic LevelDB fixtures match Chrome's real Latin-1-prefixed key encoding
- preserve unprefixed compatibility and all existing exact-origin/symlink fail-closed checks

## Root cause

Chrome stores the key as `origin + NUL + 0x01 + access_token`. The Dev 42 provenance check compared the control-prefixed key directly with `access_token`, so a valid signed-in profile was reported as “No signed-in session found.”

## Test plan

- [x] patched importer against the live Chrome Default profile — one session found; only source label/header length/name match emitted
- [x] `swift test` — 1626 tests, 1 skipped, 0 failures
- [x] `./Scripts/build_app.sh release`
- [x] deep code-signature verification
- [x] empty entitlements verification
- [x] confirmed only one installed Vibe Bar UI instance remained running
