### PR TITLE
Fix Kimi browser token refresh

### DIFF
--- a/Sources/VibeBarCore/Adapters/KimiQuotaAdapter.swift
+++ b/Sources/VibeBarCore/Adapters/KimiQuotaAdapter.swift
@@ -2,10 +2,11 @@ import Foundation
 
 /// Moonshot / Kimi (kimi.com) usage adapter.
 ///
-/// Auth: a Kimi bearer JWT. The shared Browser Cookies importer reads the
-/// current `localStorage.access_token` from Chromium profiles and stores it as
-/// the same synthetic `kimi-auth=<token>` Keychain slot used by legacy browser
-/// cookies and manual headers.
+/// Auth: Kimi access + refresh JWTs. The shared Browser Cookies importer reads
+/// both exact localStorage fields from one Chromium profile and stores them in
+/// the same cookie-shaped Keychain slot used by legacy browser cookies and
+/// manual headers. The adapter mirrors the website's one refresh + retry when
+/// the short-lived access token expires.
 ///
 /// `POST https://www.kimi.com/apiv2/kimi.gateway.membership.v2.MembershipService/GetSubscriptionStats`
 /// with body `{}` is the primary source for the weekly, five-hour and
@@ -25,18 +26,28 @@ public struct KimiQuotaAdapter: QuotaAdapter {
     private let session: URLSession
     private let now: @Sendable () -> Date
 
-    private static let accessTokenCredential = ChromiumLocalStorageCredential(
+    fileprivate static let accessTokenCredential = ChromiumLocalStorageCredential(
         origin: "https://www.kimi.com",
         key: "access_token",
         syntheticCookieName: "kimi-auth",
+        valueFormat: .jwt(segments: 3, minLength: 16, maxLength: 4_096)
+    )
+    fileprivate static let refreshTokenCredential = ChromiumLocalStorageCredential(
+        origin: "https://www.kimi.com",
+        key: "refresh_token",
+        syntheticCookieName: "kimi-refresh",
         valueFormat: .jwt(segments: 3, minLength: 16, maxLength: 4_096)
     )
 
     public static let cookieSpec = MiscCookieResolver.Spec(
         tool: .kimi,
         domains: ["www.kimi.com", "kimi.com"],
-        requiredNames: ["kimi-auth"],
-        browserCredentialSource: .chromiumLocalStorage(accessTokenCredential)
+        requiredNames: ["kimi-auth", "kimi-refresh"],
+        credentialNames: ["kimi-auth"],
+        browserCredentialSource: .chromiumLocalStorageFields([
+            accessTokenCredential,
+            refreshTokenCredential
+        ])
     )
 
     private static let usageEndpoint = URL(string:
@@ -44,6 +55,9 @@ public struct KimiQuotaAdapter: QuotaAdapter {
     )!
     private static let membershipStatsEndpoint = URL(string:
         "https://www.kimi.com/apiv2/kimi.gateway.membership.v2.MembershipService/GetSubscriptionStats"
+    )!
+    private static let refreshEndpoint = URL(string:
+        "https://auth.kimi.com/api/account.gateway.v1.AuthService/RefreshToken"
     )!
     private static let membershipStatsWallTimeSeconds: Double = 10
 
@@ -82,30 +96,123 @@ public struct KimiQuotaAdapter: QuotaAdapter {
         account: AccountIdentity,
         queriedAt: Date
     ) async throws -> AccountQuota {
-        // Pull the kimi-auth cookie value out of the resolved header.
-        let pairs = CookieHeaderNormalizer.pairs(from: resolution.header)
-        guard let authToken = pairs.first(where: { $0.name == "kimi-auth" })?.value,
-              !authToken.isEmpty else {
+        guard let credential = KimiCredential(cookieHeader: resolution.header) else {
             throw QuotaError.noCredential
         }
 
-        let snapshot = try await Self.fetchSnapshot(
-            authToken: authToken,
+        let result = try await Self.fetchSnapshotRefreshingCredential(
+            credential: credential,
             queriedAt: queriedAt
         ) { request in
             let (data, _) = try await self.data(for: request)
             return data
         }
+        if result.didRefresh, let slotID = resolution.slotID {
+            let instanceID = AccountStore.miscInstanceID(
+                fromAccountID: account.id,
+                fallbackTool: .kimi
+            )
+            let saved = MiscCookieSlotStore.updateHeader(
+                slotID: slotID,
+                for: .kimi,
+                instanceID: instanceID,
+                header: result.credential.cookieHeader,
+                importedAt: queriedAt
+            )
+            if !saved {
+                SafeLog.warn("Kimi refreshed credential could not be persisted for slot=\(slotID.uuidString.prefix(8))")
+            }
+        }
 
         return AccountQuota(
             accountId: account.id,
             tool: .kimi,
-            buckets: snapshot.buckets,
+            buckets: result.snapshot.buckets,
             plan: nil,
             email: account.email,
             queriedAt: queriedAt,
             error: nil
         )
+    }
+
+    struct AuthenticatedSnapshot: Sendable {
+        let snapshot: KimiResponseParser.Snapshot
+        let credential: KimiCredential
+        let didRefresh: Bool
+    }
+
+    /// Match the web client: try the stored access token, refresh once only on
+    /// a credential-shaped failure, then retry the quota request once with the
+    /// new pair. Manual access-token-only headers preserve their old behavior.
+    static func fetchSnapshotRefreshingCredential(
+        credential: KimiCredential,
+        queriedAt: Date,
+        membershipTimeoutSeconds: Double = Self.membershipStatsWallTimeSeconds,
+        request: @escaping @Sendable (URLRequest) async throws -> Data
+    ) async throws -> AuthenticatedSnapshot {
+        do {
+            let snapshot = try await fetchSnapshot(
+                authToken: credential.accessToken,
+                queriedAt: queriedAt,
+                membershipTimeoutSeconds: membershipTimeoutSeconds,
+                request: request
+            )
+            return AuthenticatedSnapshot(
+                snapshot: snapshot,
+                credential: credential,
+                didRefresh: false
+            )
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch let error as URLError where error.code == .cancelled {
+            throw error
+        } catch let error as QuotaError where error.isCredentialState {
+            guard let refreshToken = credential.refreshToken else { throw error }
+            try Task.checkCancellation()
+            let refreshed = try await refreshCredential(
+                accessToken: credential.accessToken,
+                refreshToken: refreshToken,
+                request: request
+            )
+            try Task.checkCancellation()
+            let snapshot = try await fetchSnapshot(
+                authToken: refreshed.accessToken,
+                queriedAt: queriedAt,
+                membershipTimeoutSeconds: membershipTimeoutSeconds,
+                request: request
+            )
+            return AuthenticatedSnapshot(
+                snapshot: snapshot,
+                credential: refreshed,
+                didRefresh: true
+            )
+        }
+    }
+
+    static func refreshCredential(
+        accessToken: String,
+        refreshToken: String,
+        request: @escaping @Sendable (URLRequest) async throws -> Data
+    ) async throws -> KimiCredential {
+        let data = try await request(refreshRequest(
+            accessToken: accessToken,
+            refreshToken: refreshToken
+        ))
+        let response: KimiRefreshTokenResponse
+        do {
+            response = try JSONDecoder().decode(KimiRefreshTokenResponse.self, from: data)
+        } catch {
+            throw QuotaError.parseFailure(
+                "Kimi refresh response not parseable: \(error.localizedDescription)"
+            )
+        }
+        guard let credential = KimiCredential(
+            accessToken: response.accessToken,
+            refreshToken: response.refreshToken
+        ) else {
+            throw QuotaError.parseFailure("Kimi refresh response had invalid tokens.")
+        }
+        return credential
     }
 
     static func fetchSnapshot(
@@ -248,6 +355,37 @@ public struct KimiQuotaAdapter: QuotaAdapter {
         )
     }
 
+    static func refreshRequest(accessToken: String, refreshToken: String) -> URLRequest {
+        let session = KimiSessionInfo.fromJWT(accessToken)
+        var request = URLRequest(url: refreshEndpoint)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.setValue("https://www.kimi.com", forHTTPHeaderField: "Origin")
+        request.setValue("https://www.kimi.com/", forHTTPHeaderField: "Referer")
+        request.setValue(
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Safari/537.36",
+            forHTTPHeaderField: "User-Agent"
+        )
+        request.setValue("1", forHTTPHeaderField: "connect-protocol-version")
+        request.setValue("web", forHTTPHeaderField: "x-msh-platform")
+        request.setValue("2.0.0", forHTTPHeaderField: "x-msh-version")
+        request.setValue(TimeZone.current.identifier, forHTTPHeaderField: "r-timezone")
+        if let deviceId = session.deviceId {
+            request.setValue(deviceId, forHTTPHeaderField: "x-msh-device-id")
+        }
+        if let sessionId = session.sessionId {
+            request.setValue(sessionId, forHTTPHeaderField: "x-msh-session-id")
+        }
+        if let trafficId = session.trafficId {
+            request.setValue(trafficId, forHTTPHeaderField: "x-traffic-id")
+        }
+        request.httpBody = try? JSONSerialization.data(withJSONObject: [
+            "refresh_token": refreshToken
+        ])
+        return request
+    }
+
     private static func makeRequest(
         url: URL,
         authToken: String,
@@ -312,6 +450,52 @@ private enum KimiMembershipFetchOutcome: Sendable {
     case snapshot(KimiResponseParser.Snapshot)
     case failed(QuotaError)
     case cancelled
+}
+
+struct KimiCredential: Sendable, Equatable {
+    let accessToken: String
+    let refreshToken: String?
+
+    init?(cookieHeader: String) {
+        let pairs = CookieHeaderNormalizer.pairs(from: cookieHeader)
+        guard let accessToken = pairs.first(where: { $0.name == "kimi-auth" })?.value else {
+            return nil
+        }
+        self.init(
+            accessToken: accessToken,
+            refreshToken: pairs.first(where: { $0.name == "kimi-refresh" })?.value
+        )
+    }
+
+    init?(accessToken: String, refreshToken: String?) {
+        guard let accessToken = KimiQuotaAdapter.accessTokenCredential
+            .valueFormat.normalizedValue(accessToken) else {
+            return nil
+        }
+        if let refreshToken {
+            guard let normalized = KimiQuotaAdapter.refreshTokenCredential
+                .valueFormat.normalizedValue(refreshToken) else {
+                return nil
+            }
+            self.refreshToken = normalized
+        } else {
+            self.refreshToken = nil
+        }
+        self.accessToken = accessToken
+    }
+
+    var cookieHeader: String {
+        var pairs = ["kimi-auth=\(accessToken)"]
+        if let refreshToken {
+            pairs.append("kimi-refresh=\(refreshToken)")
+        }
+        return pairs.joined(separator: "; ")
+    }
+}
+
+private struct KimiRefreshTokenResponse: Decodable {
+    let accessToken: String
+    let refreshToken: String
 }
 
 // MARK: - JWT session info

--- a/Sources/VibeBarCore/BrowserCookies/BrowserCredentialSource.swift
+++ b/Sources/VibeBarCore/BrowserCookies/BrowserCredentialSource.swift
@@ -8,6 +8,31 @@ public enum BrowserCredentialSource: Sendable, Hashable {
     case cookieJar
     /// One exact first-party localStorage field in Chromium profiles.
     case chromiumLocalStorage(ChromiumLocalStorageCredential)
+    /// Multiple exact first-party localStorage fields that must come from the
+    /// same Chromium profile. Each field becomes one synthetic cookie pair in
+    /// the existing Keychain slot, so provider adapters can keep consuming the
+    /// shared cookie-shaped credential boundary.
+    case chromiumLocalStorageFields([ChromiumLocalStorageCredential])
+
+    var chromiumLocalStorageCredentials: [ChromiumLocalStorageCredential]? {
+        switch self {
+        case .cookieJar:
+            nil
+        case let .chromiumLocalStorage(credential):
+            [credential]
+        case let .chromiumLocalStorageFields(credentials):
+            credentials
+        }
+    }
+
+    func hasCompleteBrowserCredential(in header: String) -> Bool {
+        guard let credentials = chromiumLocalStorageCredentials,
+              !credentials.isEmpty else {
+            return true
+        }
+        let names = Set(CookieHeaderNormalizer.pairs(from: header).map(\.name))
+        return credentials.allSatisfy { names.contains($0.syntheticCookieName) }
+    }
 }
 
 /// Declarative mapping from one Chromium localStorage value to the synthetic

--- a/Sources/VibeBarCore/BrowserCookies/ChromiumLocalStorageCredentialImporter.swift
+++ b/Sources/VibeBarCore/BrowserCookies/ChromiumLocalStorageCredentialImporter.swift
@@ -17,7 +17,7 @@ enum ChromiumLocalStorageCredentialImporter {
 
     final class Cache: @unchecked Sendable {
         private struct Key: Hashable {
-            let credential: ChromiumLocalStorageCredential
+            let credentials: [ChromiumLocalStorageCredential]
             let rootPaths: [String]
             let maxSessions: Int?
         }
@@ -27,13 +27,13 @@ enum ChromiumLocalStorageCredentialImporter {
         )
 
         func sessions(
-            credential: ChromiumLocalStorageCredential,
+            credentials: [ChromiumLocalStorageCredential],
             roots: [ChromiumProfileRoot],
             maxSessions: Int?,
             load: () -> [ChromiumLocalStorageBrowserSession]
         ) -> [ChromiumLocalStorageBrowserSession] {
             let key = Key(
-                credential: credential,
+                credentials: credentials,
                 rootPaths: roots.map { $0.url.standardizedFileURL.path },
                 maxSessions: maxSessions
             )
@@ -55,9 +55,33 @@ enum ChromiumLocalStorageCredentialImporter {
         readEntries: @escaping EntryReader = Self.liveReadEntries,
         readTextEntries: @escaping TextEntryReader = Self.liveReadTextEntries
     ) -> [ChromiumLocalStorageBrowserSession] {
-        cache.sessions(credential: credential, roots: roots, maxSessions: maxSessions) {
+        sessions(
+            credentials: [credential],
+            roots: roots,
+            cache: cache,
+            maxSessions: maxSessions,
+            directoryContents: directoryContents,
+            readEntries: readEntries,
+            readTextEntries: readTextEntries
+        )
+    }
+
+    static func sessions(
+        credentials: [ChromiumLocalStorageCredential],
+        roots: [ChromiumProfileRoot],
+        cache: Cache,
+        maxSessions: Int? = nil,
+        directoryContents: @escaping DirectoryContents = Self.liveDirectoryContents,
+        readEntries: @escaping EntryReader = Self.liveReadEntries,
+        readTextEntries: @escaping TextEntryReader = Self.liveReadTextEntries
+    ) -> [ChromiumLocalStorageBrowserSession] {
+        guard !credentials.isEmpty,
+              Set(credentials.map(\.syntheticCookieName)).count == credentials.count else {
+            return []
+        }
+        return cache.sessions(credentials: credentials, roots: roots, maxSessions: maxSessions) {
             loadSessions(
-                credential: credential,
+                credentials: credentials,
                 roots: roots,
                 maxSessions: maxSessions,
                 directoryContents: directoryContents,
@@ -68,7 +92,7 @@ enum ChromiumLocalStorageCredentialImporter {
     }
 
     private static func loadSessions(
-        credential: ChromiumLocalStorageCredential,
+        credentials: [ChromiumLocalStorageCredential],
         roots: [ChromiumProfileRoot],
         maxSessions: Int?,
         directoryContents: DirectoryContents,
@@ -90,23 +114,44 @@ enum ChromiumLocalStorageCredentialImporter {
                     continue
                 }
 
-                let candidates = readEntries(credential.origin, levelDB)
-                guard hasOnlyRealLevelDBFiles(levelDB) else { continue }
                 let textEntries = readTextEntries(levelDB)
-                guard hasOnlyRealLevelDBFiles(levelDB),
-                      let entry = candidates.first(where: {
-                          $0.key == credential.key
-                              && hasExactProvenance(
-                                  candidate: $0,
-                                  credential: credential,
-                                  textEntries: textEntries
-                              )
-                      }),
-                      let header = credential.cookieHeader(from: entry.value) else {
+                guard hasOnlyRealLevelDBFiles(levelDB) else { continue }
+
+                var candidatesByOrigin: [String: [ChromiumLocalStorageEntry]] = [:]
+                var headerPairs: [String] = []
+                var complete = true
+                for credential in credentials {
+                    let candidates: [ChromiumLocalStorageEntry]
+                    if let cached = candidatesByOrigin[credential.origin] {
+                        candidates = cached
+                    } else {
+                        let loaded = readEntries(credential.origin, levelDB)
+                        guard hasOnlyRealLevelDBFiles(levelDB) else {
+                            complete = false
+                            break
+                        }
+                        candidatesByOrigin[credential.origin] = loaded
+                        candidates = loaded
+                    }
+                    guard let entry = candidates.first(where: {
+                        $0.key == credential.key
+                            && hasExactProvenance(
+                                candidate: $0,
+                                credential: credential,
+                                textEntries: textEntries
+                            )
+                    }),
+                    let pair = credential.cookieHeader(from: entry.value) else {
+                        complete = false
+                        break
+                    }
+                    headerPairs.append(pair)
+                }
+                guard complete, headerPairs.count == credentials.count else {
                     continue
                 }
                 sessions.append(ChromiumLocalStorageBrowserSession(
-                    header: header,
+                    header: headerPairs.joined(separator: "; "),
                     sourceLabel: "\(root.labelPrefix) \(profile.lastPathComponent)"
                 ))
                 if let maxSessions, sessions.count >= maxSessions {

--- a/Sources/VibeBarCore/BrowserCookies/MiscCookieResolver.swift
+++ b/Sources/VibeBarCore/BrowserCookies/MiscCookieResolver.swift
@@ -16,6 +16,12 @@ import SweetCookieKit
 /// cache. The legacy single-cookie state is migrated into slots on
 /// first read; see `LegacyCookieMigration`.
 public enum MiscCookieResolver {
+    /// Browser-credential schema completion is attempted once per slot per app
+    /// run. A signed-out or unavailable profile must not turn every scheduled
+    /// quota refresh into another full localStorage scan.
+    private static let browserCredentialCompletionAttempts =
+        OSAllocatedUnfairLock<Set<UUID>>(initialState: [])
+
     /// Per-provider description of which cookies matter and where
     /// to look for them. Adapters declare this as a constant.
     public struct Spec {
@@ -148,7 +154,31 @@ public enum MiscCookieResolver {
         let filter = SlotFilter(settings: settings)
         guard filter != .none else { return [] }
 
-        return MiscCookieSlotStore.slots(for: spec.tool, instanceID: instanceID).compactMap { slot in
+        var slots = MiscCookieSlotStore.slots(for: spec.tool, instanceID: instanceID)
+        // A browser-owned slot imported by an older build can be missing a
+        // newly declared localStorage field. Complete that one-time schema
+        // migration from the same profile without a Keychain prompt. Manual
+        // headers remain fully user-owned and are never touched here.
+        let incompleteSlotIDs = Set(slots.compactMap { slot -> UUID? in
+            guard slot.origin != .manual,
+                  !spec.browserCredentialSource.hasCompleteBrowserCredential(
+                      in: slot.cookieHeader
+                  ) else {
+                return nil
+            }
+            return slot.id
+        })
+        let shouldAttemptCompletion = browserCredentialCompletionAttempts.withLock { attempted in
+            let unseen = incompleteSlotIDs.subtracting(attempted)
+            attempted.formUnion(incompleteSlotIDs)
+            return !unseen.isEmpty
+        }
+        if shouldAttemptCompletion {
+            _ = silentReimport(spec: spec, instanceID: instanceID)
+            slots = MiscCookieSlotStore.slots(for: spec.tool, instanceID: instanceID)
+        }
+
+        return slots.compactMap { slot in
             guard filter.allows(slot) else { return nil }
             guard let header = spec.minimizedHeader(from: slot.cookieHeader),
                   !header.isEmpty else { return nil }
@@ -529,24 +559,48 @@ public enum MiscCookieResolver {
                 maxSessions: maxSessions
             )
         case let .chromiumLocalStorage(credential):
-            let candidates = preferred
-                .filter(\.usesChromiumProfileStore)
-                .browsersWithProfileData(using: context.detection)
-            guard !candidates.isEmpty else { return [] }
-            let roots = ChromiumProfileLocator.roots(
-                for: candidates,
-                homeDirectories: [context.homeDirectory]
-            )
-            let sessions = ChromiumLocalStorageCredentialImporter.sessions(
-                credential: credential,
-                roots: roots,
-                cache: context.localStorageCache,
+            return chromiumLocalStorageBrowserSessions(
+                credentials: [credential],
+                spec: spec,
+                preferred: preferred,
+                context: context,
                 maxSessions: maxSessions
             )
-            return sessions.compactMap {
-                guard let header = spec.minimizedHeader(from: $0.header) else { return nil }
-                return BrowserImportResult(header: header, sourceLabel: $0.sourceLabel)
-            }
+        case let .chromiumLocalStorageFields(credentials):
+            return chromiumLocalStorageBrowserSessions(
+                credentials: credentials,
+                spec: spec,
+                preferred: preferred,
+                context: context,
+                maxSessions: maxSessions
+            )
+        }
+    }
+
+    private static func chromiumLocalStorageBrowserSessions(
+        credentials: [ChromiumLocalStorageCredential],
+        spec: Spec,
+        preferred: [Browser],
+        context: BrowserImportContext,
+        maxSessions: Int?
+    ) -> [BrowserImportResult] {
+        let candidates = preferred
+            .filter(\.usesChromiumProfileStore)
+            .browsersWithProfileData(using: context.detection)
+        guard !candidates.isEmpty else { return [] }
+        let roots = ChromiumProfileLocator.roots(
+            for: candidates,
+            homeDirectories: [context.homeDirectory]
+        )
+        let sessions = ChromiumLocalStorageCredentialImporter.sessions(
+            credentials: credentials,
+            roots: roots,
+            cache: context.localStorageCache,
+            maxSessions: maxSessions
+        )
+        return sessions.compactMap {
+            guard let header = spec.minimizedHeader(from: $0.header) else { return nil }
+            return BrowserImportResult(header: header, sourceLabel: $0.sourceLabel)
         }
     }
 

--- a/Tests/VibeBarCoreTests/BrowserCredentialSourceTests.swift
+++ b/Tests/VibeBarCoreTests/BrowserCredentialSourceTests.swift
@@ -50,4 +50,23 @@ final class BrowserCredentialSourceTests: XCTestCase {
         )
         XCTAssertNil(invalid.cookieHeader(from: "value"))
     }
+
+    func testCompositeSourceDetectsAnOlderIncompleteHeader() {
+        let source = BrowserCredentialSource.chromiumLocalStorageFields([
+            credential,
+            ChromiumLocalStorageCredential(
+                origin: "https://example.com",
+                key: "refresh_token",
+                syntheticCookieName: "refresh-token",
+                valueFormat: .jwt(segments: 3, minLength: 16, maxLength: 4_096)
+            )
+        ])
+
+        XCTAssertFalse(source.hasCompleteBrowserCredential(
+            in: "session-token=synthetic.header.signature"
+        ))
+        XCTAssertTrue(source.hasCompleteBrowserCredential(
+            in: "session-token=synthetic.header.signature; refresh-token=refresh.header.signature"
+        ))
+    }
 }

--- a/Tests/VibeBarCoreTests/ChromiumLocalStorageCredentialImporterTests.swift
+++ b/Tests/VibeBarCoreTests/ChromiumLocalStorageCredentialImporterTests.swift
@@ -325,10 +325,17 @@ final class ChromiumLocalStorageCredentialImporterTests: XCTestCase {
             .appendingPathComponent("Library/Application Support/Google/Chrome", isDirectory: true)
             .appendingPathComponent("Default", isDirectory: true)
         let token = "synthetic-header.synthetic_payload.synthetic-signature"
+        let refreshToken = "refresh-header.refresh_payload.refresh-signature"
         try writeLocalStorageLog(
             origin: "https://www.kimi.com",
             key: "access_token",
             value: token,
+            profile: profile
+        )
+        try writeLocalStorageLog(
+            origin: "https://www.kimi.com",
+            key: "refresh_token",
+            value: refreshToken,
             profile: profile
         )
         let context = MiscCookieResolver.BrowserImportContext(
@@ -347,7 +354,10 @@ final class ChromiumLocalStorageCredentialImporterTests: XCTestCase {
 
         XCTAssertEqual(sessions.count, 1)
         XCTAssertEqual(sessions[0].sourceLabel, "Chrome Default")
-        XCTAssertEqual(sessions[0].header, "kimi-auth=\(token)")
+        XCTAssertEqual(
+            sessions[0].header,
+            "kimi-auth=\(token); kimi-refresh=\(refreshToken)"
+        )
     }
 
     func testMiscBrowserSessionsRejectsHeaderThatDoesNotMatchTheSpec() throws {
@@ -435,7 +445,10 @@ final class ChromiumLocalStorageCredentialImporterTests: XCTestCase {
         record.append(contentsOf: littleEndianBytes(UInt16(batch.count)))
         record.append(0x01)
         record.append(batch)
-        try record.write(to: levelDB.appendingPathComponent("000003.log"))
+        let log = levelDB.appendingPathComponent("000003.log")
+        var existing = (try? Data(contentsOf: log)) ?? Data()
+        existing.append(record)
+        try existing.write(to: log)
     }
 
     @discardableResult

--- a/Tests/VibeBarCoreTests/KimiMiniMaxParserTests.swift
+++ b/Tests/VibeBarCoreTests/KimiMiniMaxParserTests.swift
@@ -169,6 +169,69 @@ final class KimiParserTests: XCTestCase {
         ])
     }
 
+    func testRefreshRequestMatchesTheWebClientProtocol() throws {
+        let request = KimiQuotaAdapter.refreshRequest(
+            accessToken: "synthetic.header.signature",
+            refreshToken: "refresh.header.signature"
+        )
+
+        XCTAssertEqual(
+            request.url?.absoluteString,
+            "https://auth.kimi.com/api/account.gateway.v1.AuthService/RefreshToken"
+        )
+        XCTAssertEqual(request.httpMethod, "POST")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "application/json")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "connect-protocol-version"), "1")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "x-msh-platform"), "web")
+        XCTAssertNil(request.value(forHTTPHeaderField: "Authorization"))
+        let body = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: XCTUnwrap(request.httpBody)) as? [String: String]
+        )
+        XCTAssertEqual(body, ["refresh_token": "refresh.header.signature"])
+    }
+
+    func testCredentialFailureRefreshesOnceAndRetriesQuota() async throws {
+        let membershipPath = "/apiv2/kimi.gateway.membership.v2.MembershipService/GetSubscriptionStats"
+        let legacyPath = "/apiv2/kimi.gateway.billing.v1.BillingService/GetUsages"
+        let refreshPath = "/api/account.gateway.v1.AuthService/RefreshToken"
+        let refreshedAccess = "refreshed.header.signature"
+        let refreshedToken = "renewed.header.signature"
+        let refreshJSON = Data("""
+        {"accessToken":"\(refreshedAccess)","refreshToken":"\(refreshedToken)"}
+        """.utf8)
+        let queue = KimiRequestQueue([
+            (membershipPath, .failure(.needsLogin)),
+            (legacyPath, .failure(.needsLogin)),
+            (refreshPath, .success(refreshJSON)),
+            (membershipPath, .success(membershipStatsJSON))
+        ])
+        let credential = try XCTUnwrap(KimiCredential(
+            accessToken: "expired.header.signature",
+            refreshToken: "refresh.header.signature"
+        ))
+
+        let result = try await KimiQuotaAdapter.fetchSnapshotRefreshingCredential(
+            credential: credential,
+            queriedAt: now,
+            request: { request in try await queue.data(for: request) }
+        )
+
+        XCTAssertTrue(result.didRefresh)
+        XCTAssertEqual(result.credential.accessToken, refreshedAccess)
+        XCTAssertEqual(result.credential.refreshToken, refreshedToken)
+        XCTAssertEqual(
+            result.snapshot.buckets.map(\.id),
+            ["kimi.weekly", "kimi.rate", "kimi.monthly"]
+        )
+        let requestedPaths = await queue.requestedPaths()
+        XCTAssertEqual(requestedPaths, [
+            membershipPath,
+            legacyPath,
+            refreshPath,
+            membershipPath
+        ])
+    }
+
     func testPartialMembershipUsesLegacyToFillMissingFiveHourWindow() async throws {
         let recorder = KimiRequestRecorder(responses: [
             "/apiv2/kimi.gateway.membership.v2.MembershipService/GetSubscriptionStats": .success(partialMembershipStatsJSON),
@@ -540,6 +603,30 @@ private actor KimiRequestRecorder {
             throw QuotaError.unknown("unexpected Kimi request")
         }
         return try response.get()
+    }
+
+    func requestedPaths() -> [String] { paths }
+}
+
+private actor KimiRequestQueue {
+    private var responses: [(String, Result<Data, QuotaError>)]
+    private var paths: [String] = []
+
+    init(_ responses: [(String, Result<Data, QuotaError>)]) {
+        self.responses = responses
+    }
+
+    func data(for request: URLRequest) throws -> Data {
+        let path = request.url?.path ?? ""
+        paths.append(path)
+        guard !responses.isEmpty else {
+            throw QuotaError.unknown("unexpected Kimi request")
+        }
+        let next = responses.removeFirst()
+        guard next.0 == path else {
+            throw QuotaError.unknown("expected \(next.0), got \(path)")
+        }
+        return try next.1.get()
     }
 
     func requestedPaths() -> [String] { paths }

--- a/Tests/VibeBarCoreTests/MiscCookieSpecCatalogTests.swift
+++ b/Tests/VibeBarCoreTests/MiscCookieSpecCatalogTests.swift
@@ -97,14 +97,20 @@ final class MiscCookieSpecCatalogTests: XCTestCase {
     }
 
     func testKimiUsesTheGenericChromiumLocalStorageSource() {
-        let expected = BrowserCredentialSource.chromiumLocalStorage(
+        let expected = BrowserCredentialSource.chromiumLocalStorageFields([
             ChromiumLocalStorageCredential(
                 origin: "https://www.kimi.com",
                 key: "access_token",
                 syntheticCookieName: "kimi-auth",
                 valueFormat: .jwt(segments: 3, minLength: 16, maxLength: 4_096)
+            ),
+            ChromiumLocalStorageCredential(
+                origin: "https://www.kimi.com",
+                key: "refresh_token",
+                syntheticCookieName: "kimi-refresh",
+                valueFormat: .jwt(segments: 3, minLength: 16, maxLength: 4_096)
             )
-        )
+        ])
         XCTAssertEqual(KimiQuotaAdapter.cookieSpec.browserCredentialSource, expected)
 
         for spec in MiscCookieSpecCatalog.allSpecs {


### PR DESCRIPTION
## Summary
- import Kimi access and refresh tokens atomically through the shared Chromium localStorage credential source
- mirror Kimi web token refresh on authentication failure, retry quota once, and persist the refreshed pair
- silently complete older browser-import slots that only contain kimi-auth without adding a Kimi-specific UI flow

## Verification
- swift test: 1629 tests passed, 1 skipped
- Scripts/build_app.sh release
- codesign deep strict verification passed
- release entitlements are empty
- live sanitized Chrome Default probe found both token fields in one shared importer result; no credential values were printed
- live sanitized official refresh endpoint probe returned HTTP 200 with valid replacement access and refresh token shapes