### PR TITLE
Prepare 1.3.0 dev build 44

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.3.0</string>
 	<key>CFBundleVersion</key>
-	<string>43</string>
+	<string>44</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>26.0</string>
 	<key>LSUIElement</key>


### PR DESCRIPTION
## Summary
- bump CFBundleVersion from 43 to 44
- prepare Dev release containing the Kimi browser token refresh fix from PR #222

## Verification
- Info.plist validates
- CFBundleShortVersionString is 1.3.0
- CFBundleVersion is 44
- full tests and release bundle verification passed on the merged fix before the version-only bump