### PR TITLE
Prepare 1.3.0 dev build 45

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.3.0</string>
 	<key>CFBundleVersion</key>
-	<string>44</string>
+	<string>45</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>26.0</string>
 	<key>LSUIElement</key>


### PR DESCRIPTION
## Summary
- bump `CFBundleVersion` from 44 to 45
- keep `CFBundleShortVersionString` at 1.3.0
- prepare tag `v1.3.0-dev.45` for the Dev Sparkle channel

## Validation
- feature PR #224 passed the full CI suite
- release workflow will rebuild, test, sign, and verify the tagged source before drafting assets