### PR TITLE
Fix chart overflow, align mix legends, add token view to cost history

### DIFF
--- a/Sources/VibeBarApp/Views/CostHistoryView.swift
+++ b/Sources/VibeBarApp/Views/CostHistoryView.swift
@@ -184,12 +184,20 @@ struct CostHistoryView: View {
     @State private var inspectedPoint: CostChartPoint?
     @State private var panBase: ChartTimeWindow?
     @State private var magnifyBase: ChartTimeWindow?
-    @AppStorage("costChart.metric") private var storedMetric: String = CostChartMetric.cost.rawValue
 
     @EnvironmentObject var environment: AppEnvironment
+    @EnvironmentObject var settingsStore: SettingsStore
 
+    /// Persisted through `AppSettings` — the documented state under
+    /// `~/.vibebar/` — not `@AppStorage`, which would leak the choice into
+    /// `UserDefaults` where clearing Vibe Bar's state cannot reach it.
     private var chartMetric: CostChartMetric {
-        CostChartMetric(rawValue: storedMetric) ?? .cost
+        CostChartMetric(rawValue: settingsStore.settings.costChartMetric) ?? .cost
+    }
+
+    private func setMetric(_ metric: CostChartMetric) {
+        guard settingsStore.settings.costChartMetric != metric.rawValue else { return }
+        settingsStore.settings.costChartMetric = metric.rawValue
     }
 
     private static let dayInterval: TimeInterval = 86_400
@@ -312,7 +320,7 @@ struct CostHistoryView: View {
         HStack(spacing: 1) {
             ForEach(CostChartMetric.allCases) { option in
                 Button {
-                    storedMetric = option.rawValue
+                    setMetric(option)
                 } label: {
                     Text(option.label)
                         .font(.system(size: max(9, density.segmentedFontSize - 1), weight: .semibold, design: .rounded))

--- a/Sources/VibeBarApp/Views/CostHistoryView.swift
+++ b/Sources/VibeBarApp/Views/CostHistoryView.swift
@@ -340,6 +340,9 @@ struct CostHistoryView: View {
                 .focusable(false)
                 .help(option.help)
                 .accessibilityLabel(option.help)
+                // The visual fill is the only sighted cue for which measure
+                // is active; VoiceOver needs the selection stated outright.
+                .accessibilityAddTraits(chartMetric == option ? [.isSelected] : [])
             }
         }
         .padding(2)

--- a/Sources/VibeBarApp/Views/CostHistoryView.swift
+++ b/Sources/VibeBarApp/Views/CostHistoryView.swift
@@ -9,6 +9,30 @@ private enum CostGranularityMode: Equatable {
     case manual(CostChartGranularity)
 }
 
+/// Which measure the chart plots. Stored app-wide so every cost history card —
+/// Overview, provider pages, detail popovers — flips together; a per-card
+/// choice would leave two visible cards disagreeing about what a bar means.
+private enum CostChartMetric: String, CaseIterable, Identifiable {
+    case cost
+    case tokens
+
+    var id: String { rawValue }
+
+    var label: String {
+        switch self {
+        case .cost: "$"
+        case .tokens: "Tok"
+        }
+    }
+
+    var help: String {
+        switch self {
+        case .cost: "Plot spend in dollars"
+        case .tokens: "Plot token volume"
+        }
+    }
+}
+
 /// One entry in the granularity segmented control.
 private struct CostGranularityOption: Identifiable, Equatable {
     let mode: CostGranularityMode
@@ -160,8 +184,13 @@ struct CostHistoryView: View {
     @State private var inspectedPoint: CostChartPoint?
     @State private var panBase: ChartTimeWindow?
     @State private var magnifyBase: ChartTimeWindow?
+    @AppStorage("costChart.metric") private var storedMetric: String = CostChartMetric.cost.rawValue
 
     @EnvironmentObject var environment: AppEnvironment
+
+    private var chartMetric: CostChartMetric {
+        CostChartMetric(rawValue: storedMetric) ?? .cost
+    }
 
     private static let dayInterval: TimeInterval = 86_400
     /// Zoom floor. Half a day still shows twelve hourly bars; anything tighter
@@ -227,6 +256,7 @@ struct CostHistoryView: View {
                 Text(titleOverride ?? "Cost History")
                     .font(.system(size: density.bucketTitleFontSize, weight: .semibold))
                 Spacer(minLength: 8)
+                metricToggle
                 SectionRefreshButton(isRefreshing: false) {
                     environment.refreshCostUsage()
                 }
@@ -275,6 +305,42 @@ struct CostHistoryView: View {
         .fixedSize(horizontal: !compressible, vertical: false)
     }
 
+    /// Two-way $ / Tok switch. Lives on the title row rather than with the
+    /// presets: unlike them it changes what the whole card measures, not which
+    /// slice of it is shown.
+    private var metricToggle: some View {
+        HStack(spacing: 1) {
+            ForEach(CostChartMetric.allCases) { option in
+                Button {
+                    storedMetric = option.rawValue
+                } label: {
+                    Text(option.label)
+                        .font(.system(size: max(9, density.segmentedFontSize - 1), weight: .semibold, design: .rounded))
+                        .foregroundStyle(chartMetric == option ? Color.primary : Color.secondary)
+                        .lineLimit(1)
+                        .padding(.horizontal, 7)
+                        .frame(minHeight: 18)
+                        .contentShape(Rectangle())
+                        .background {
+                            if chartMetric == option {
+                                RoundedRectangle(cornerRadius: 5, style: .continuous)
+                                    .fill(Color.primary.opacity(0.12))
+                            }
+                        }
+                }
+                .buttonStyle(.plain)
+                .focusable(false)
+                .help(option.help)
+                .accessibilityLabel(option.help)
+            }
+        }
+        .padding(2)
+        .background(
+            RoundedRectangle(cornerRadius: 6, style: .continuous)
+                .fill(Color.primary.opacity(0.08))
+        )
+    }
+
     private var emptyNote: some View {
         VStack(spacing: 4) {
             Text("Building history…")
@@ -296,10 +362,10 @@ struct CostHistoryView: View {
         let resolved = resolve(window: window)
         let points = visiblePoints(window: window, granularity: resolved.granularity)
         let rendered = ChartSeriesThinning.strided(points, limit: Self.visibleMarkLimit)
-        let total = points.reduce(0) { $0 + $1.costUSD }
+        let total = points.reduce(0) { $0 + metricValue($1) }
         let average = points.isEmpty ? 0 : total / Double(points.count)
-        let peakPoint = points.max { $0.costUSD < $1.costUSD }
-        let peak = peakPoint?.costUSD ?? 0
+        let peakPoint = points.max { metricValue($0) < metricValue($1) }
+        let peak = peakPoint.map(metricValue) ?? 0
 
         VStack(alignment: .leading, spacing: 6) {
             chart(
@@ -362,7 +428,9 @@ struct CostHistoryView: View {
         .frame(height: chartHeight)
         .overlay {
             if points.isEmpty {
-                Text("No cost recorded in this range.")
+                Text(chartMetric == .cost
+                    ? "No cost recorded in this range."
+                    : "No tokens recorded in this range.")
                     .font(.system(size: density.resetCountdownFontSize))
                     .foregroundStyle(.tertiary)
                     .allowsHitTesting(false)
@@ -383,7 +451,7 @@ struct CostHistoryView: View {
                 ForEach(points) { point in
                     AreaMark(
                         x: .value("Hour", point.date, unit: .hour),
-                        y: .value("Cost", point.costUSD)
+                        y: .value(metricSeriesLabel, metricValue(point))
                     )
                     .interpolationMethod(.monotone)
                     .foregroundStyle(
@@ -395,19 +463,19 @@ struct CostHistoryView: View {
                     )
                     LineMark(
                         x: .value("Hour", point.date, unit: .hour),
-                        y: .value("Cost", point.costUSD)
+                        y: .value(metricSeriesLabel, metricValue(point))
                     )
                     .interpolationMethod(.monotone)
                     .foregroundStyle(Color.accentColor)
                     .lineStyle(StrokeStyle(lineWidth: 2, lineCap: .round, lineJoin: .round))
                     .opacity(pointOpacity(point))
-                    if point.costUSD > 0 {
+                    if metricValue(point) > 0 {
                         PointMark(
                             x: .value("Hour", point.date, unit: .hour),
-                            y: .value("Cost", point.costUSD)
+                            y: .value(metricSeriesLabel, metricValue(point))
                         )
                         .symbolSize(24)
-                        .foregroundStyle(point.costUSD > average * 1.5 ? Color.orange : Color.accentColor)
+                        .foregroundStyle(metricValue(point) > average * 1.5 ? Color.orange : Color.accentColor)
                     }
                 }
             } else {
@@ -419,10 +487,10 @@ struct CostHistoryView: View {
                             unit: barUnit(granularity),
                             calendar: Self.barCalendar
                         ),
-                        y: .value("Cost", point.costUSD),
+                        y: .value(metricSeriesLabel, metricValue(point)),
                         width: barWidth
                     )
-                    .foregroundStyle(point.costUSD > average * 1.5 ? Color.orange : Color.accentColor)
+                    .foregroundStyle(metricValue(point) > average * 1.5 ? Color.orange : Color.accentColor)
                     .cornerRadius(2)
                     .opacity(pointOpacity(point))
                 }
@@ -448,7 +516,7 @@ struct CostHistoryView: View {
                 AxisGridLine().foregroundStyle(.secondary.opacity(0.15))
                 AxisValueLabel {
                     if let raw = value.as(Double.self) {
-                        Text(formatAxisCost(raw))
+                        Text(formatAxisValue(raw))
                             .font(.system(size: 9, design: .rounded).monospacedDigit())
                             // Swift Charts insets the plot by whatever the
                             // widest label reports, so a floor here is a floor
@@ -532,7 +600,7 @@ struct CostHistoryView: View {
             snapshot?.dailyHistory ?? [],
             limit: Self.miniMarkLimit
         )
-        let peak = days.map(\.costUSD).max() ?? 0
+        let peak = days.map(dayMetricValue).max() ?? 0
         let width = max(1, min(3, geometry.size.width / CGFloat(max(days.count, 1)) - 0.5))
         return Path { path in
             guard peak > 0 else { return }
@@ -540,7 +608,7 @@ struct CostHistoryView: View {
             for day in days {
                 // Centre the bar on the day it represents, not on its midnight.
                 let x = geometry.x(for: day.date.addingTimeInterval(Self.dayInterval / 2))
-                let top = geometry.y(forFraction: day.costUSD / peak)
+                let top = geometry.y(forFraction: dayMetricValue(day) / peak)
                 path.addRect(
                     CGRect(x: x - width / 2, y: top, width: width, height: max(1, baseline - top))
                 )
@@ -634,13 +702,13 @@ struct CostHistoryView: View {
                 Text(tooltipDate(point.date, granularity: currentGranularity))
                     .font(.system(size: 10, weight: .semibold))
                 Spacer(minLength: 8)
-                Text(formatCost(point.costUSD))
+                Text(formatMetric(metricValue(point)))
                     .font(.system(size: 10, weight: .semibold, design: .rounded).monospacedDigit())
             }
-            Text(formatTokens(point.totalTokens))
+            Text(chartMetric == .cost ? formatTokens(point.totalTokens) : formatCost(point.costUSD))
                 .font(.system(size: 9, design: .rounded).monospacedDigit())
                 .foregroundStyle(.secondary)
-            ForEach(point.models.prefix(3)) { model in
+            ForEach(sortedModels(point.models).prefix(3)) { model in
                 modelRow(model)
             }
             if point.models.count > 3 {
@@ -692,7 +760,7 @@ struct CostHistoryView: View {
                         alignment: .leading,
                         spacing: 4
                     ) {
-                        ForEach(point.models) { model in
+                        ForEach(sortedModels(point.models)) { model in
                             inspectedModelRow(model)
                         }
                     }
@@ -709,9 +777,9 @@ struct CostHistoryView: View {
                 .truncationMode(.middle)
                 .help(model.modelName)
             Spacer(minLength: 4)
-            Text(formatCost(model.costUSD))
+            Text(primaryModelValue(model))
                 .font(.system(size: 9, design: .rounded).monospacedDigit())
-            Text(formatTokens(model.totalTokens))
+            Text(secondaryModelValue(model))
                 .font(.system(size: 8, design: .rounded).monospacedDigit())
                 .foregroundStyle(.secondary)
                 .lineLimit(1)
@@ -726,7 +794,7 @@ struct CostHistoryView: View {
                 .truncationMode(.middle)
                 .help(model.modelName)
             Spacer(minLength: 8)
-            Text(formatCost(model.costUSD))
+            Text(primaryModelValue(model))
                 .font(.system(size: 9, design: .rounded).monospacedDigit())
                 .foregroundStyle(.secondary)
         }
@@ -808,14 +876,14 @@ struct CostHistoryView: View {
         resolved: CostResolvedGranularity
     ) -> some View {
         HStack(alignment: .top, spacing: spacing) {
-            metric(label: "Total", value: formatCost(total))
+            metric(label: "Total", value: formatMetric(total))
             metric(
                 label: "Avg/\(resolved.granularity.displayName.lowercased())",
-                value: formatCost(average)
+                value: formatMetric(average)
             )
             metric(
                 label: "Peak",
-                value: formatCost(peak),
+                value: formatMetric(peak),
                 detail: peakDate.map { peakDetail($0, granularity: resolved.granularity) }
             )
         }
@@ -1371,6 +1439,62 @@ struct CostHistoryView: View {
         if tokens < 1_000_000 { return String(format: "%.1fk tok", Double(tokens) / 1_000) }
         if tokens < 1_000_000_000 { return String(format: "%.2fM tok", Double(tokens) / 1_000_000) }
         return String(format: "%.2fB tok", Double(tokens) / 1_000_000_000)
+    }
+
+    // MARK: - Metric plumbing
+
+    /// The plotted measure of one bucket under the current metric.
+    private func metricValue(_ point: CostChartPoint) -> Double {
+        chartMetric == .cost ? point.costUSD : Double(point.totalTokens)
+    }
+
+    private func dayMetricValue(_ day: DailyCostPoint) -> Double {
+        chartMetric == .cost ? day.costUSD : Double(day.totalTokens)
+    }
+
+    private var metricSeriesLabel: String {
+        chartMetric == .cost ? "Cost" : "Tokens"
+    }
+
+    private func formatMetric(_ value: Double) -> String {
+        chartMetric == .cost ? formatCost(value) : formatTokens(Int(value.rounded()))
+    }
+
+    private func formatAxisValue(_ value: Double) -> String {
+        chartMetric == .cost ? formatAxisCost(value) : formatAxisTokens(value)
+    }
+
+    /// Token axis labels stay as short as the dollar ones so the fixed gutter
+    /// keeps fitting: "500k", "1.2M", "3B".
+    private func formatAxisTokens(_ value: Double) -> String {
+        if value < 1_000 { return String(format: "%.0f", value) }
+        if value < 1_000_000 { return String(format: "%.0fk", value / 1_000) }
+        if value < 1_000_000_000 {
+            let millions = value / 1_000_000
+            return millions < 10
+                ? String(format: "%.1fM", millions)
+                : String(format: "%.0fM", millions)
+        }
+        let billions = value / 1_000_000_000
+        return billions < 10
+            ? String(format: "%.1fB", billions)
+            : String(format: "%.0fB", billions)
+    }
+
+    /// Models re-ranked by the plotted metric so the tooltip's top rows match
+    /// what the bar is showing.
+    private func sortedModels(_ models: [CostSnapshot.ModelBreakdown]) -> [CostSnapshot.ModelBreakdown] {
+        chartMetric == .cost
+            ? models.sorted { $0.costUSD > $1.costUSD }
+            : models.sorted { $0.totalTokens > $1.totalTokens }
+    }
+
+    private func primaryModelValue(_ model: CostSnapshot.ModelBreakdown) -> String {
+        chartMetric == .cost ? formatCost(model.costUSD) : formatTokens(model.totalTokens)
+    }
+
+    private func secondaryModelValue(_ model: CostSnapshot.ModelBreakdown) -> String {
+        chartMetric == .cost ? formatTokens(model.totalTokens) : formatCost(model.costUSD)
     }
 
     private func tooltipDate(_ date: Date, granularity: CostChartGranularity) -> String {

--- a/Sources/VibeBarApp/Views/OverviewQuotaHistoryCard.swift
+++ b/Sources/VibeBarApp/Views/OverviewQuotaHistoryCard.swift
@@ -343,6 +343,12 @@ struct OverviewQuotaHistoryCard: View {
             }
             .chartLegend(.hidden)
             .chartXScale(domain: visible)
+            // Same clip as QuotaHistoryChartView: bridge marks deliberately
+            // carry endpoints outside the visible range, and unclipped they
+            // stroke across whatever sits left of the card.
+            .chartPlotStyle { plotArea in
+                plotArea.clipped()
+            }
             .chartYScale(domain: 0...100)
             .chartYAxis {
                 AxisMarks(position: .leading, values: [0, 25, 50, 75, 100]) { value in

--- a/Sources/VibeBarApp/Views/OverviewUsageMixCard.swift
+++ b/Sources/VibeBarApp/Views/OverviewUsageMixCard.swift
@@ -220,6 +220,11 @@ struct OverviewUsageMixCard: View {
                                           design: .rounded).monospacedDigit())
                             .foregroundStyle(.tertiary)
                     }
+                    // Same rule as the Workbench distribution legend: the
+                    // value column never compresses or wraps — the label is
+                    // the side that truncates.
+                    .lineLimit(1)
+                    .fixedSize(horizontal: true, vertical: false)
                 }
             }
         }

--- a/Sources/VibeBarApp/Views/QuotaHistoryChartView.swift
+++ b/Sources/VibeBarApp/Views/QuotaHistoryChartView.swift
@@ -494,6 +494,15 @@ struct QuotaHistoryChartView: View, Equatable {
                 }
             }
             .chartXScale(domain: visible)
+            // Marks are laid out against the scale, not the plot rect, and the
+            // bridge / clipped-segment marks keep points outside the visible
+            // range on purpose (a dash that spans the window has both ends off
+            // screen and still has to draw). Without the clip those strokes
+            // run past the plot — visibly across the neighbouring column when
+            // the card sits in a right-hand column.
+            .chartPlotStyle { plotArea in
+                plotArea.clipped()
+            }
             .chartYScale(domain: 0...100)
             .chartYAxis {
                 AxisMarks(position: .leading, values: [0, 25, 50, 75, 100]) { value in
@@ -796,13 +805,18 @@ struct QuotaHistoryChartView: View, Equatable {
                    let reading = hoverReading(at: hoverDate, buckets: buckets, primary: primary),
                    let x = proxy.position(forX: reading.time),
                    let plot {
+                    // The reading anchors to the nearest sample, which the
+                    // pointer slop can put just outside the visible range —
+                    // clamp so the crosshair stays inside the plot instead of
+                    // drawing into the axis gutter.
+                    let clampedX = min(max(x, 0), plot.width)
                     Rectangle()
                         .fill(Color.primary.opacity(0.22))
                         .frame(width: 1, height: plot.height)
-                        .offset(x: plotMinX + x, y: plot.minY)
+                        .offset(x: plotMinX + clampedX, y: plot.minY)
                         .allowsHitTesting(false)
                     tooltip(reading, showsBucketTitles: buckets.count > 1)
-                        .offset(x: tooltipX(plotMinX: plotMinX, x: x, width: geometry.size.width))
+                        .offset(x: tooltipX(plotMinX: plotMinX, x: clampedX, width: geometry.size.width))
                         .allowsHitTesting(false)
                 }
             }

--- a/Sources/VibeBarApp/Views/Workbench/UsageDistributionDashboard.swift
+++ b/Sources/VibeBarApp/Views/Workbench/UsageDistributionDashboard.swift
@@ -34,7 +34,7 @@ struct UsageDistributionDashboard: View {
 
     var body: some View {
         LazyVGrid(
-            columns: [GridItem(.adaptive(minimum: 320, maximum: 480), spacing: density.interSectionSpacing)],
+            columns: [GridItem(.adaptive(minimum: 320, maximum: 480), spacing: density.interSectionSpacing, alignment: .top)],
             alignment: .leading,
             spacing: density.interSectionSpacing
         ) {
@@ -199,9 +199,17 @@ private struct DistributionDonutCard: View {
                     legend
                         .frame(maxWidth: .infinity, alignment: .leading)
                 }
+                // Greedy tail: when the grid proposes the row's shared height,
+                // the card surface stretches to it instead of floating shorter
+                // than its neighbours.
+                Spacer(minLength: 0)
             }
         }
     }
+
+    /// Floor for the trailing value column. Shared by every card so "19.38B"
+    /// in one card and "53% $11.6k" in the next start at the same x.
+    private static let valueColumnWidth: CGFloat = 62
 
     private var total: Int64 { max(1, slices.reduce(0) { $0 + $1.tokens }) }
 
@@ -237,23 +245,27 @@ private struct DistributionDonutCard: View {
     private var legend: some View {
         VStack(alignment: .leading, spacing: 5) {
             ForEach(slices) { slice in
-                HStack(alignment: .firstTextBaseline, spacing: 6) {
+                HStack(alignment: .top, spacing: 6) {
                     Circle().fill(slice.color).frame(width: 7, height: 7)
+                        .padding(.top, 3)
                     VStack(alignment: .leading, spacing: 1) {
                         Text(slice.label)
                             .font(.system(size: density.subtitleFontSize, weight: .medium))
                             .lineLimit(1)
+                            .truncationMode(.tail)
+                        // Always laid out, blank when a dimension has no
+                        // detail, so every row is the same two-line height and
+                        // the five cards share one legend rhythm.
+                        Text(slice.detail ?? " ")
+                            .font(.system(size: max(8, density.resetCountdownFontSize - 1)))
+                            .foregroundStyle(.tertiary)
+                            .lineLimit(1)
                             .truncationMode(.middle)
-                        if let detail = slice.detail {
-                            Text(detail)
-                                .font(.system(size: max(8, density.resetCountdownFontSize - 1)))
-                                .foregroundStyle(.tertiary)
-                                .lineLimit(1)
-                                .truncationMode(.middle)
-                        }
+                            .opacity(slice.detail == nil ? 0 : 1)
+                            .accessibilityHidden(slice.detail == nil)
                     }
+                    .frame(maxWidth: .infinity, alignment: .leading)
                     .help(slice.detail ?? slice.label)
-                    Spacer(minLength: 4)
                     VStack(alignment: .trailing, spacing: 1) {
                         Text(UsageFormatting.compactTokens(slice.tokens))
                             .font(.system(size: density.resetCountdownFontSize, weight: .semibold,
@@ -261,13 +273,20 @@ private struct DistributionDonutCard: View {
                         HStack(spacing: 4) {
                             Text(Double(slice.tokens) / Double(total), format: .percent.precision(.fractionLength(0)))
                             if let cost = slice.costMicros {
-                                Text(UsageFormatting.formatMicroUSD(cost))
+                                Text(UsageFormatting.compactUSD(cost))
                             }
                         }
                         .font(.system(size: max(8, density.resetCountdownFontSize - 1),
                                       design: .rounded).monospacedDigit())
                         .foregroundStyle(.tertiary)
                     }
+                    // The values never wrap or compress — the label column is
+                    // the one that truncates. Without this the layout engine
+                    // squeezed "$4803.98" onto two lines while the label kept
+                    // its width.
+                    .lineLimit(1)
+                    .fixedSize(horizontal: true, vertical: false)
+                    .frame(minWidth: Self.valueColumnWidth, alignment: .trailing)
                 }
             }
         }

--- a/Sources/VibeBarCore/Models/AppSettings.swift
+++ b/Sources/VibeBarCore/Models/AppSettings.swift
@@ -119,6 +119,14 @@ public struct AppSettings: Codable, Equatable, Sendable {
     /// own instead of being invisible until the user goes looking for it.
     public var overviewQuotaHistoryHiddenCurveIds: Set<String>
 
+    /// Which measure the cost history charts plot — `"cost"` or `"tokens"`.
+    ///
+    /// A raw string rather than an enum so the UI owns the vocabulary; an
+    /// unrecognized value falls back to cost at the read site. Stored here
+    /// (not `@AppStorage`) so it lives in `~/.vibebar/` with the rest of the
+    /// documented app state instead of leaking into `UserDefaults`.
+    public var costChartMetric: String
+
     /// Per-page card arrangement chosen in Settings → Layout, keyed by
     /// `PageLayoutPageID` raw value (`"overview"`, `"detail:claude"`, …).
     ///
@@ -300,6 +308,7 @@ public struct AppSettings: Codable, Equatable, Sendable {
         modelPricingOverrides: [ModelPricingOverride] = [],
         remoteCostIncludedMachineIDs: Set<String> = [],
         overviewQuotaHistoryHiddenCurveIds: Set<String> = [],
+        costChartMetric: String = "cost",
         pageLayouts: [PageLayoutPageID: StoredPageLayout] = [:],
         pageLayoutPresets: [PageLayoutPageID: [StoredPageLayoutPreset]] = [:],
         miscCookieAutoImportEnabled: Bool = false,
@@ -348,6 +357,7 @@ public struct AppSettings: Codable, Equatable, Sendable {
             remoteCostIncludedMachineIDs.map { $0.lowercased() }
         )
         self.overviewQuotaHistoryHiddenCurveIds = overviewQuotaHistoryHiddenCurveIds
+        self.costChartMetric = costChartMetric
         self.pageLayouts = pageLayouts
         self.pageLayoutPresets = Self.normalizedPageLayoutPresets(pageLayoutPresets)
         self.miscCookieAutoImportEnabled = miscCookieAutoImportEnabled
@@ -410,6 +420,7 @@ public struct AppSettings: Codable, Equatable, Sendable {
         case modelPricingOverrides
         case remoteCostIncludedMachineIDs
         case overviewQuotaHistoryHiddenCurveIds
+        case costChartMetric
         case pageLayouts
         case pageLayoutPresets
         case miscCookieAutoImportEnabled
@@ -560,6 +571,8 @@ public struct AppSettings: Codable, Equatable, Sendable {
         )
         self.overviewQuotaHistoryHiddenCurveIds =
             try c.decodeIfPresent(Set<String>.self, forKey: .overviewQuotaHistoryHiddenCurveIds) ?? []
+        self.costChartMetric =
+            try c.decodeIfPresent(String.self, forKey: .costChartMetric) ?? "cost"
         // `try?` rather than `try`: a layout map mangled by hand should cost
         // the user their card arrangement, not every other setting in the file.
         self.pageLayouts =
@@ -651,6 +664,7 @@ public struct AppSettings: Codable, Equatable, Sendable {
             forKey: .remoteCostIncludedMachineIDs
         )
         try c.encode(overviewQuotaHistoryHiddenCurveIds, forKey: .overviewQuotaHistoryHiddenCurveIds)
+        try c.encode(costChartMetric, forKey: .costChartMetric)
         try c.encode(pageLayouts, forKey: .pageLayouts)
         try c.encode(pageLayoutPresets, forKey: .pageLayoutPresets)
         try c.encode(miscCookieAutoImportEnabled, forKey: .miscCookieAutoImportEnabled)

--- a/Sources/VibeBarCore/Utilities/UsageFormatting.swift
+++ b/Sources/VibeBarCore/Utilities/UsageFormatting.swift
@@ -28,6 +28,21 @@ public enum UsageFormatting {
         return String(format: "$%.\(digits)f", value)
     }
 
+    /// Money at legend width: `$4.80`, `$47.6`, `$594`, `$11.6k`, `$1.2M`.
+    /// Never wider than seven characters, so a trailing value column can pin
+    /// its width instead of wrapping a full-precision amount.
+    public static func compactUSD(_ micros: Int64) -> String {
+        let sign = micros < 0 ? "-" : ""
+        let value = Double(micros.magnitude) / 1_000_000
+        if micros != 0, value < 0.005 { return "\(sign)<$0.01" }
+        if value < 10 { return sign + String(format: "$%.2f", value) }
+        if value < 100 { return sign + String(format: "$%.1f", value) }
+        if value < 1_000 { return sign + String(format: "$%.0f", value) }
+        if value < 100_000 { return sign + String(format: "$%.1fk", value / 1_000) }
+        if value < 1_000_000 { return sign + String(format: "$%.0fk", value / 1_000) }
+        return sign + String(format: "$%.1fM", value / 1_000_000)
+    }
+
     /// `1_234` → `"1.2k"`, `3_400_000` → `"3.40M"`. No unit suffix — the
     /// caller decides whether to append `" tok"`.
     public static func compactTokens(_ tokens: Int64) -> String {

--- a/Tests/VibeBarCoreTests/AppSettingsTests.swift
+++ b/Tests/VibeBarCoreTests/AppSettingsTests.swift
@@ -79,6 +79,25 @@ final class AppSettingsTests: XCTestCase {
         XCTAssertTrue(decoded.miscCookieAutoImportEnabled)
     }
 
+    func testCostChartMetricDefaultsToCostAndRoundTrips() throws {
+        // A settings file written before the $/Tok switch existed must open
+        // on the dollar view every card has always shown.
+        let legacy = try JSONDecoder().decode(
+            AppSettings.self,
+            from: Data(#"{"displayMode":"remaining"}"#.utf8)
+        )
+        XCTAssertEqual(legacy.costChartMetric, "cost")
+        XCTAssertEqual(AppSettings.default.costChartMetric, "cost")
+
+        var settings = AppSettings.default
+        settings.costChartMetric = "tokens"
+        let decoded = try JSONDecoder().decode(
+            AppSettings.self,
+            from: try JSONEncoder().encode(settings)
+        )
+        XCTAssertEqual(decoded.costChartMetric, "tokens")
+    }
+
     func testMenuBarBlockAlertSuppressionDefaultsToOffAndRoundTrips() throws {
         // A settings file written before the self-check existed must leave the
         // check armed — silence about a blocked menu bar item is the failure

--- a/Tests/VibeBarCoreTests/UsageFormattingTests.swift
+++ b/Tests/VibeBarCoreTests/UsageFormattingTests.swift
@@ -21,6 +21,19 @@ final class UsageFormattingTests: XCTestCase {
         XCTAssertEqual(UsageFormatting.formatMicroUSD(5_000), "$0.01")
     }
 
+    func testCompactUSD() {
+        XCTAssertEqual(UsageFormatting.compactUSD(0), "$0.00")
+        XCTAssertEqual(UsageFormatting.compactUSD(1_000), "<$0.01")
+        XCTAssertEqual(UsageFormatting.compactUSD(890_000), "$0.89")
+        XCTAssertEqual(UsageFormatting.compactUSD(4_800_000), "$4.80")
+        XCTAssertEqual(UsageFormatting.compactUSD(47_590_000), "$47.6")
+        XCTAssertEqual(UsageFormatting.compactUSD(593_680_000), "$594")
+        XCTAssertEqual(UsageFormatting.compactUSD(11_588_990_000), "$11.6k")
+        XCTAssertEqual(UsageFormatting.compactUSD(593_680_000_000), "$594k")
+        XCTAssertEqual(UsageFormatting.compactUSD(1_234_000_000_000), "$1.2M")
+        XCTAssertEqual(UsageFormatting.compactUSD(-11_588_990_000), "-$11.6k")
+    }
+
     func testNegativeAmountsKeepTheSignOutsideTheCurrency() {
         XCTAssertEqual(UsageFormatting.formatMicroUSD(-1_500_000), "-$1.50")
     }


### PR DESCRIPTION
Three chart-surface fixes reported together from live use.

## Quota history dashed strokes escaped the plot
Both quota history charts (`QuotaHistoryChartView`, `OverviewQuotaHistoryCard`) deliberately keep marks whose endpoints sit outside the visible range — bridge dashes and clipped-segment edges have to straddle the window to draw correctly. Swift Charts lays marks out against the scale, not the plot rect, so those strokes ran past the plot edge; with the card in a right-hand column they drew across the neighbouring column (in a left column the same overflow fell outside the window, which is why it seemed position-dependent). `CostHistoryView` and `UsageTrendChartView` already clip for exactly this reason — the two quota charts now do the same, and the hover crosshair (whose nearest-sample anchor can also land off-range) is clamped to the plot.

## Distribution legend values wrapped and misaligned
In the Workbench mix cards the trailing value column had no `lineLimit`/`fixedSize`, so the layout engine compressed it and `$4803.98` wrapped mid-number while the label column kept its width. Now:
- the value column never compresses or wraps and has a shared minimum width, so rows and cards align;
- money uses a new compact form `UsageFormatting.compactUSD` (`$11.6k`) sized for a 320 pt card;
- every legend row keeps a two-line height (blank detail line when a dimension has none) so the five cards share one rhythm;
- grid cells top-align and a greedy tail lets card surfaces fill the row height;
- labels truncate at the tail (paths keep middle truncation);
- the Overview usage-mix legend gets the same never-compress rule.

## Cost history can plot tokens
Every cost history card gains a `$` / `Tok` switch on its title row, stored app-wide (`@AppStorage`) so all cards flip together. The axis, average line, peak highlight, footer metrics, tooltip, model ranking, and the brush strip all follow the chosen metric; model lists re-rank by it.

## Verification
- `swift build`, `swift test` (1637 passed), `./Scripts/build_app.sh release`, strict codesign with empty entitlements — all green.
- Demo-mode smoke runs of `popover:overview` (both metrics) and `workbench:usageStats` render cleanly with no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)