### PR TITLE
Make skills wiring transparent and stop faking Cursor toggles

### DIFF
--- a/Sources/VibeBarApp/Controllers/SkillsManagerModel.swift
+++ b/Sources/VibeBarApp/Controllers/SkillsManagerModel.swift
@@ -103,6 +103,17 @@ final class SkillsManagerModel: ObservableObject {
         }
     }
 
+    /// How many skills the harness can actually use: enabled ones plus the
+    /// ones it discovers through a shared or compatibility root. This is the
+    /// header-pill number — counting only `.enabled` made Cursor claim three
+    /// skills while it could see nearly a hundred.
+    func visibleCount(for app: SkillAppTarget) -> Int {
+        skills.count {
+            let state = $0.activationState(for: app)
+            return state == .enabled || state == .coupled
+        }
+    }
+
     func nativeDisabledCount(for app: SkillAppTarget) -> Int {
         skills.count { $0.activationState(for: app) == .disabledInHarness }
     }
@@ -190,20 +201,6 @@ final class SkillsManagerModel: ObservableObject {
 
     // MARK: - Per-skill actions
 
-    func toggle(skill: Skill, app: SkillAppTarget) {
-        let action: SkillActivationAction = switch skill.activationState(for: app) {
-        case .notProjected:
-            .enable
-        case .enabled:
-            app.supportsNativeSkillActivation ? .disableInHarness : .removeProjection
-        case .coupled:
-            app.supportsNativeSkillActivation ? .disableInHarness : .enable
-        case .disabledInHarness, .unknown:
-            .enable
-        }
-        setActivation(skill: skill, app: app, action: action)
-    }
-
     func setActivation(
         skill: Skill,
         app: SkillAppTarget,
@@ -221,6 +218,15 @@ final class SkillsManagerModel: ObservableObject {
             if action == .removeProjection, !changed {
                 toast = "\(skill.name)'s Vibe Bar projection was cleared for \(app.displayName), "
                     + "but the existing folder was left in place."
+            } else if action == .removeProjection, changed, app.discoversSharedSkillRoot {
+                // Removing the link is not an off switch for these harnesses,
+                // and silently letting it look like one is how the old
+                // "click did nothing" confusion started.
+                toast = "Removed the \(app.displayName) link. \(skill.name) stays available "
+                    + "there through the shared skills root."
+            } else if action == .enable, !changed {
+                toast = "\(app.displayName) reads the shared skills root directly — "
+                    + "\(skill.name) is always available there and has no per-skill switch."
             } else if action == .disableInHarness {
                 toast = "Disabled \(skill.name) in \(app.displayName) and kept its projection."
             }

--- a/Sources/VibeBarApp/Views/Workbench/SkillListRow.swift
+++ b/Sources/VibeBarApp/Views/Workbench/SkillListRow.swift
@@ -194,9 +194,14 @@ struct SkillAppToggleRow: View {
         switch state {
         case .notProjected: return .enable
         case .enabled:
-            return app.supportsNativeSkillActivation && showsNativeActions
-                ? .disableInHarness
-                : .removeProjection
+            if app.supportsNativeSkillActivation && showsNativeActions {
+                return .disableInHarness
+            }
+            // A shared-root harness's projection is redundant — deleting it
+            // from a plain click would look like an off switch that doesn't
+            // work (the skill stays discovered). Route the click to the
+            // explanatory no-op and keep removal in the context menu.
+            return app.discoversSharedSkillRoot ? .enable : .removeProjection
         case .coupled:
             return app.supportsNativeSkillActivation && showsNativeActions
                 ? .disableInHarness
@@ -219,9 +224,12 @@ struct SkillAppToggleRow: View {
                 .foregroundStyle(.orange)
                 .background(Circle().fill(.background))
         case .coupled:
+            // Informational, not a warning: the skill *is* available — the
+            // harness reads a root Vibe Bar doesn't gate. Orange is reserved
+            // for the two states that actually need attention.
             Image(systemName: "link.circle.fill")
                 .font(.system(size: 9, weight: .bold))
-                .foregroundStyle(.orange)
+                .foregroundStyle(.secondary)
                 .background(Circle().fill(.background))
         case .enabled, .notProjected:
             EmptyView()
@@ -233,7 +241,7 @@ struct SkillAppToggleRow: View {
         case .notProjected: "Not projected"
         case .enabled: "Enabled"
         case .disabledInHarness: "Projected, disabled in harness"
-        case .coupled: "Enabled through a shared or compatibility root"
+        case .coupled: "Available through a shared or compatibility root"
         case .unknown: "Projected, native state unknown"
         }
     }
@@ -245,12 +253,16 @@ struct SkillAppToggleRow: View {
             return "\(app.displayName) — not projected. Click to enable."
         case .enabled where app.supportsNativeSkillActivation:
             return "\(app.displayName) — projected and enabled. Click to disable in the harness; right-click for projection options."
+        case .enabled where app.discoversSharedSkillRoot:
+            return "\(app.displayName) — has its own link, and also reads the shared skills root directly. There is no per-skill switch; right-click to manage the redundant link."
         case .enabled:
             return "\(app.displayName) — enabled by projection. Click to remove it."
         case .disabledInHarness:
             return "\(app.displayName) — projected, but disabled by its native config. Click to enable."
+        case .coupled where app.discoversSharedSkillRoot:
+            return "\(app.displayName) reads the shared skills root directly, so this skill is always available there. There is no per-skill switch to flip."
         case .coupled:
-            return "\(app.displayName) — still enabled through a shared or compatibility root. Right-click for the available controls."
+            return "\(app.displayName) — visible through the Gemini CLI projection it also reads. Click to give it its own projection."
         case .unknown:
             return "\(app.displayName) — projected, but native config could not be parsed. Click to repair as enabled."
         }
@@ -270,6 +282,7 @@ struct SkillListRow: View {
 
     @State private var confirmingUninstall = false
     @State private var isHovering = false
+    @State private var showingWiring = false
 
     var body: some View {
         HStack(alignment: .top, spacing: 12) {
@@ -353,9 +366,6 @@ struct SkillListRow: View {
         let unknown = SkillAppTarget.managedHarnesses.filter {
             skill.activationState(for: $0) == .unknown
         }
-        let coupled = SkillAppTarget.managedHarnesses.filter {
-            skill.activationState(for: $0) == .coupled
-        }
         if !disabled.isEmpty {
             Text(disabled.map { "\($0.displayName) OFF" }.joined(separator: " · "))
                 .font(.system(size: max(9, density.resetCountdownFontSize - 2), weight: .semibold))
@@ -372,15 +382,12 @@ struct SkillListRow: View {
                 .padding(.vertical, 2)
                 .background(Capsule().fill(Color.orange.opacity(0.12)))
                 .help("The harness configuration could not be parsed safely")
-        } else if !coupled.isEmpty {
-            Text(coupled.map { "\($0.displayName) LINKED" }.joined(separator: " · "))
-                .font(.system(size: max(9, density.resetCountdownFontSize - 2), weight: .semibold))
-                .foregroundStyle(.orange)
-                .padding(.horizontal, 6)
-                .padding(.vertical, 2)
-                .background(Capsule().fill(Color.orange.opacity(0.12)))
-                .help("Still discovered through a shared or compatibility root")
         }
+        // `.coupled` deliberately gets no row capsule: it is the *normal*
+        // state for every skill Cursor sees, and a permanent orange
+        // "Cursor LINKED" on nearly every row read as a problem needing a
+        // click that then did nothing. The circle's small link badge and the
+        // wiring popover carry the information instead.
     }
 
     private var sourceBadge: some View {
@@ -414,6 +421,16 @@ struct SkillListRow: View {
 
     private var overflowMenu: some View {
         Menu {
+            Button("Wiring Details…", systemImage: "point.3.connected.trianglepath.dotted") {
+                showingWiring = true
+            }
+            Button("Reveal in Finder", systemImage: "folder") {
+                NSWorkspace.shared.activateFileViewerSelecting([
+                    SkillAppCatalog.ssotDirectory()
+                        .appendingPathComponent(skill.directory, isDirectory: true)
+                ])
+            }
+            Divider()
             Button("Update from repository", systemImage: "arrow.down.circle") { onUpdate() }
                 .disabled(!skill.id.isRepositoryBacked)
             Divider()
@@ -432,5 +449,8 @@ struct SkillListRow: View {
         .fixedSize()
         .disabled(isBusy)
         .accessibilityLabel("More actions for \(skill.name)")
+        .popover(isPresented: $showingWiring, arrowEdge: .trailing) {
+            SkillWiringPopover(skill: skill, density: density)
+        }
     }
 }

--- a/Sources/VibeBarApp/Views/Workbench/SkillWiringView.swift
+++ b/Sources/VibeBarApp/Views/Workbench/SkillWiringView.swift
@@ -1,0 +1,219 @@
+import AppKit
+import SwiftUI
+import VibeBarCore
+
+/// Per-skill answer to "what exactly did Vibe Bar do on my disk".
+///
+/// The toggle circles compress three mechanisms — shared-root discovery, the
+/// per-app projection, and the harness's native switch — into one colored
+/// state. This popover keeps the layers apart and names every path involved,
+/// so the badge vocabulary (`shared root`, `OFF`, adopted copies) can be
+/// checked against the filesystem instead of taken on faith.
+struct SkillWiringPopover: View {
+    let skill: Skill
+    let density: Theme.Density
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(alignment: .firstTextBaseline, spacing: 8) {
+                Text(skill.name)
+                    .font(.system(size: density.bucketTitleFontSize, weight: .semibold))
+                    .lineLimit(1)
+                Spacer(minLength: 8)
+                Button {
+                    NSWorkspace.shared.activateFileViewerSelecting([
+                        SkillAppCatalog.ssotDirectory()
+                            .appendingPathComponent(skill.directory, isDirectory: true)
+                    ])
+                } label: {
+                    Label("Reveal", systemImage: "folder")
+                        .font(.system(size: max(9, density.resetCountdownFontSize - 1), weight: .semibold))
+                }
+                .buttonStyle(.plain)
+                .foregroundStyle(.secondary)
+                .help("Show the skill's source directory in Finder")
+            }
+
+            wiringRow(
+                title: "Source",
+                lines: [line("One copy of the skill. Every harness below reads this directory or a link to it.")],
+                path: skill.wiring(for: .codex).sourcePath
+            )
+
+            Divider().opacity(0.4)
+
+            ForEach(SkillAppTarget.managedHarnesses, id: \.self) { app in
+                harnessRow(skill.wiring(for: app))
+            }
+
+            Divider().opacity(0.4)
+
+            Text("Vibe Bar writes only inside the skills folders above and the four listed config files, and backs a skill up before uninstalling it.")
+                .font(.system(size: max(8, density.resetCountdownFontSize - 1)))
+                .foregroundStyle(.tertiary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(14)
+        .frame(width: 400)
+    }
+
+    private func harnessRow(_ wiring: SkillHarnessWiring) -> some View {
+        HStack(alignment: .top, spacing: 8) {
+            SkillAppGlyph(app: wiring.app, size: 13)
+                .frame(width: 20, height: 20)
+                .background(Circle().fill(wiring.app.accent.opacity(0.10)))
+            VStack(alignment: .leading, spacing: 2) {
+                HStack(spacing: 6) {
+                    Text(wiring.app.displayName)
+                        .font(.system(size: density.subtitleFontSize, weight: .semibold))
+                    Spacer(minLength: 6)
+                    stateLabel(wiring)
+                }
+                ForEach(mechanismLines(wiring), id: \.self) { text in
+                    line(text)
+                }
+            }
+        }
+    }
+
+    private func wiringRow(title: String, lines: [some View], path: String) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            HStack(spacing: 6) {
+                Text(title)
+                    .font(.system(size: density.subtitleFontSize, weight: .semibold))
+                Spacer(minLength: 6)
+                Text(path)
+                    .font(.system(size: max(9, density.resetCountdownFontSize - 1), design: .monospaced))
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+            }
+            ForEach(Array(lines.enumerated()), id: \.offset) { $0.element }
+        }
+    }
+
+    @ViewBuilder
+    private func stateLabel(_ wiring: SkillHarnessWiring) -> some View {
+        let (text, color): (String, Color) = switch wiring.state {
+        case .enabled: ("On", .green)
+        case .coupled: (wiring.viaGeminiCompatibility ? "On · via Gemini" : "On · shared root", .secondary)
+        case .disabledInHarness: ("Off · native switch", .orange)
+        case .notProjected: ("Off · not linked", .secondary)
+        case .unknown: ("Config unreadable", .orange)
+        }
+        Text(text)
+            .font(.system(size: max(9, density.resetCountdownFontSize - 1), weight: .semibold))
+            .foregroundStyle(color)
+    }
+
+    /// The mechanism, one plain sentence per layer that exists.
+    private func mechanismLines(_ wiring: SkillHarnessWiring) -> [String] {
+        var lines: [String] = []
+        if wiring.viaGeminiCompatibility {
+            lines.append("Also reads the Gemini CLI skills folder, which holds this skill's Gemini projection.")
+        } else if wiring.discoversSharedRoot {
+            lines.append("Scans the shared root itself — no per-app link needed.")
+        }
+        if let projection = wiring.projection {
+            let kind = projection.method == .symlink ? "Symlink" : "Copy"
+            let origin = projection.adopted ? " · adopted from an existing install" : ""
+            lines.append("\(kind) at \(wiring.projectionPath)\(origin)")
+        } else if !wiring.discoversSharedRoot, !wiring.viaGeminiCompatibility {
+            lines.append("No entry at \(wiring.projectionPath) — the harness cannot see this skill.")
+        }
+        if let path = wiring.nativeConfigPath, let key = wiring.nativeConfigKey {
+            lines.append("Per-skill switch: \(key) in \(path)")
+        } else {
+            lines.append("No per-skill switch — whatever is discovered is active.")
+        }
+        return lines
+    }
+
+    private func line(_ text: String) -> some View {
+        Text(text)
+            .font(.system(size: max(8, density.resetCountdownFontSize - 1)))
+            .foregroundStyle(.tertiary)
+            .fixedSize(horizontal: false, vertical: true)
+    }
+}
+
+/// Page-level "how syncing works" — the model in four sentences plus the
+/// per-harness table, so the badges and circles have a legend.
+struct SkillSyncExplainerPopover: View {
+    let density: Theme.Density
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("How skill syncing works")
+                .font(.system(size: density.bucketTitleFontSize, weight: .semibold))
+
+            paragraph(
+                "One source of truth.",
+                "Every skill lives in ~/\(SkillAppCatalog.ssotRelativePath)/<name>. Install, update, and uninstall all happen there and only there."
+            )
+            paragraph(
+                "Projections.",
+                "Claude Code and AntiGravity read only their own skills folders, so Vibe Bar links (or copies) skills into them. Codex, Gemini CLI, Grok Build, and Cursor scan the shared root themselves — no link needed."
+            )
+            paragraph(
+                "Native switches.",
+                "Where a harness has its own per-skill off switch, the circles flip that switch. Cursor has none, so every skill in the shared root is always available to it — that is the \u{201C}shared root\u{201D} badge, and there is nothing to toggle."
+            )
+
+            Divider().opacity(0.4)
+
+            ForEach(SkillAppTarget.managedHarnesses, id: \.self) { app in
+                harnessLine(app)
+            }
+
+            Divider().opacity(0.4)
+
+            Text("Vibe Bar writes only inside ~/\(SkillAppCatalog.ssotRelativePath), the per-harness skills folders, and the config files above.")
+                .font(.system(size: max(8, density.resetCountdownFontSize - 1)))
+                .foregroundStyle(.tertiary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(14)
+        .frame(width: 420)
+    }
+
+    private func paragraph(_ lead: String, _ body: String) -> some View {
+        (Text(lead).fontWeight(.semibold) + Text(" " + body))
+            .font(.system(size: max(10, density.subtitleFontSize - 1)))
+            .foregroundStyle(.secondary)
+            .fixedSize(horizontal: false, vertical: true)
+    }
+
+    private func harnessLine(_ app: SkillAppTarget) -> some View {
+        HStack(alignment: .top, spacing: 8) {
+            SkillAppGlyph(app: app, size: 12)
+                .frame(width: 18, height: 18)
+                .background(Circle().fill(app.accent.opacity(0.10)))
+            VStack(alignment: .leading, spacing: 1) {
+                Text(app.displayName)
+                    .font(.system(size: max(10, density.subtitleFontSize - 1), weight: .semibold))
+                Text(harnessSummary(app))
+                    .font(.system(size: max(8, density.resetCountdownFontSize - 1)))
+                    .foregroundStyle(.tertiary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+    }
+
+    private func harnessSummary(_ app: SkillAppTarget) -> String {
+        var parts: [String] = []
+        parts.append(
+            app.discoversSharedSkillRoot
+                ? "scans ~/\(SkillAppCatalog.ssotRelativePath) directly"
+                : "reads only ~/\(SkillAppCatalog.relativePath(for: app))"
+        )
+        if let key = app.nativeConfigKeyDescription, let path = app.nativeConfigRelativePath {
+            parts.append("per-skill switch \(key) in ~/\(path)")
+        } else if app == .antigravity {
+            parts.append("no per-skill switch; also reads ~/\(SkillAppCatalog.relativePath(for: .gemini))")
+        } else {
+            parts.append("no per-skill switch")
+        }
+        return parts.joined(separator: " · ")
+    }
+}

--- a/Sources/VibeBarApp/Views/Workbench/SkillsManagerPage.swift
+++ b/Sources/VibeBarApp/Views/Workbench/SkillsManagerPage.swift
@@ -210,11 +210,13 @@ struct SkillsManagerPage: View {
                 .overlay(Capsule().stroke(app.accent.opacity(count == 0 ? 0.16 : 0.45), lineWidth: 0.8))
                 .opacity(count == 0 ? 0.5 : 1)
                 .saturation(count == 0 ? 0.2 : 1)
-                .help(
-                    "\(app.displayName) sees \(count) skill\(count == 1 ? "" : "s")"
-                        + (coupled > 0 ? " · \(enabled) enabled + \(coupled) via the shared skills root" : "")
-                        + (nativeDisabled > 0 ? " · \(nativeDisabled) projected but disabled" : "")
-                )
+                .help(appCountHelp(
+                    app: app,
+                    count: count,
+                    enabled: enabled,
+                    coupled: coupled,
+                    nativeDisabled: nativeDisabled
+                ))
                 .accessibilityLabel("\(app.displayName), sees \(count) skills")
             }
             Button {
@@ -238,6 +240,29 @@ struct SkillsManagerPage: View {
                 .foregroundStyle(.tertiary)
                 .lineLimit(1)
         }
+    }
+
+    private func appCountHelp(
+        app: SkillAppTarget,
+        count: Int,
+        enabled: Int,
+        coupled: Int,
+        nativeDisabled: Int
+    ) -> String {
+        var help = "\(app.displayName) sees \(count) skill\(count == 1 ? "" : "s")"
+        if coupled > 0 {
+            // AntiGravity's coupled skills arrive through the Gemini CLI
+            // compatibility root, not the shared root it never scans — name
+            // the mechanism the harness actually uses.
+            let root = app.discoversSharedSkillRoot
+                ? "the shared skills root"
+                : "the Gemini CLI compatibility root"
+            help += " · \(enabled) enabled + \(coupled) via \(root)"
+        }
+        if nativeDisabled > 0 {
+            help += " · \(nativeDisabled) projected but disabled"
+        }
+        return help
     }
 
     private var countSummary: String {

--- a/Sources/VibeBarApp/Views/Workbench/SkillsManagerPage.swift
+++ b/Sources/VibeBarApp/Views/Workbench/SkillsManagerPage.swift
@@ -15,6 +15,7 @@ struct SkillsManagerPage: View {
 
     @State private var showsZipImporter = false
     @State private var toastDismissal: Task<Void, Never>?
+    @State private var showingSyncExplainer = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: density.interSectionSpacing) {
@@ -185,13 +186,16 @@ struct SkillsManagerPage: View {
         .frame(minHeight: 28)
     }
 
-    /// How many skills each agent CLI currently sees. The single number that
-    /// answers "did that toggle actually land", and the reason the row sits
-    /// above the list rather than inside a menu.
+    /// How many skills each agent CLI can actually use right now — enabled
+    /// plus shared-root discoveries, the number that answers "what does this
+    /// harness see", with the enabled/coupled split spelled out in the
+    /// tooltip. The old pill counted only `.enabled`, so Cursor claimed three
+    /// skills while its shared-root scan saw nearly a hundred.
     private var appCountRow: some View {
         HStack(spacing: 6) {
             ForEach(SkillAppTarget.managedHarnesses, id: \.self) { app in
-                let count = model.installedCount(for: app)
+                let count = model.visibleCount(for: app)
+                let enabled = model.installedCount(for: app)
                 let nativeDisabled = model.nativeDisabledCount(for: app)
                 let coupled = model.coupledCount(for: app)
                 HStack(spacing: 4) {
@@ -207,11 +211,25 @@ struct SkillsManagerPage: View {
                 .opacity(count == 0 ? 0.5 : 1)
                 .saturation(count == 0 ? 0.2 : 1)
                 .help(
-                    "\(app.displayName): \(count) enabled skill\(count == 1 ? "" : "s")"
+                    "\(app.displayName) sees \(count) skill\(count == 1 ? "" : "s")"
+                        + (coupled > 0 ? " · \(enabled) enabled + \(coupled) via the shared skills root" : "")
                         + (nativeDisabled > 0 ? " · \(nativeDisabled) projected but disabled" : "")
-                        + (coupled > 0 ? " · \(coupled) visible through another root" : "")
                 )
-                .accessibilityLabel("\(app.displayName), \(count) skills")
+                .accessibilityLabel("\(app.displayName), sees \(count) skills")
+            }
+            Button {
+                showingSyncExplainer = true
+            } label: {
+                Image(systemName: "questionmark.circle")
+                    .font(.system(size: max(10, density.segmentedFontSize), weight: .semibold))
+                    .foregroundStyle(.secondary)
+                    .frame(width: 24, height: 28)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .help("How skill syncing works — roots, links, and native switches")
+            .popover(isPresented: $showingSyncExplainer, arrowEdge: .bottom) {
+                SkillSyncExplainerPopover(density: density)
             }
             Spacer(minLength: 8)
             Text(countSummary)

--- a/Sources/VibeBarCore/Skills/SkillModels.swift
+++ b/Sources/VibeBarCore/Skills/SkillModels.swift
@@ -139,6 +139,31 @@ public enum SkillAppTarget: String, CaseIterable, Codable, Hashable, Sendable {
         case .claude, .hermes, .opencode, .antigravity: false
         }
     }
+
+    /// Home-relative path of the file holding the harness's per-skill switch,
+    /// `nil` when the harness has none. Display metadata for the wiring UI —
+    /// the file is only ever read or patched through
+    /// `SkillHarnessConfigManager`.
+    public var nativeConfigRelativePath: String? {
+        switch self {
+        case .codex: ".codex/config.toml"
+        case .claude: ".claude/settings.json"
+        case .gemini: ".gemini/settings.json"
+        case .grok: ".grok/config.toml"
+        case .hermes, .opencode, .antigravity, .cursor: nil
+        }
+    }
+
+    /// The key inside that file, in the harness's own vocabulary.
+    public var nativeConfigKeyDescription: String? {
+        switch self {
+        case .codex: "[[skills.config]]"
+        case .claude: "skillOverrides"
+        case .gemini: "skills.disabled"
+        case .grok: "[skills] disabled"
+        case .hermes, .opencode, .antigravity, .cursor: nil
+        }
+    }
 }
 
 /// Effective state of one skill in one harness.

--- a/Sources/VibeBarCore/Skills/SkillWiring.swift
+++ b/Sources/VibeBarCore/Skills/SkillWiring.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+/// One harness's complete view of one skill, spelled out for the UI.
+///
+/// `SkillActivationState` compresses three mechanisms — shared-root
+/// discovery, the per-app projection, and the harness's native switch — into
+/// one word, which is right for a badge and wrong for the question "what did
+/// Vibe Bar actually do on my disk". This struct keeps the layers separate
+/// and names the paths, so the Skills page can show its work instead of
+/// asking to be trusted.
+public struct SkillHarnessWiring: Hashable, Sendable {
+    public let app: SkillAppTarget
+    public let state: SkillActivationState
+    /// The harness scans `~/.agents/skills` itself, so the skill is visible
+    /// there with no per-app entry at all.
+    public let discoversSharedRoot: Bool
+    /// The per-app entry Vibe Bar manages, when one exists.
+    public let projection: SkillMaterialization?
+    /// Home-relative location that entry occupies (or would occupy).
+    public let projectionPath: String
+    /// Home-relative SSOT directory every projection points back to.
+    public let sourcePath: String
+    /// Home-relative file holding the harness's per-skill switch, `nil` when
+    /// the harness has none.
+    public let nativeConfigPath: String?
+    /// The key inside that file, in the harness's own vocabulary.
+    public let nativeConfigKey: String?
+    /// AntiGravity only: visible because it also reads the Gemini CLI's
+    /// skills directory, which holds a Gemini projection of this skill.
+    public let viaGeminiCompatibility: Bool
+}
+
+extension Skill {
+    /// Everything the UI needs to explain how `app` currently sees this
+    /// skill. Pure derivation — nothing here touches the filesystem.
+    public func wiring(for app: SkillAppTarget) -> SkillHarnessWiring {
+        SkillHarnessWiring(
+            app: app,
+            state: activationState(for: app),
+            discoversSharedRoot: app.discoversSharedSkillRoot,
+            projection: apps[app],
+            projectionPath: "~/\(SkillAppCatalog.relativePath(for: app))/\(directory)",
+            sourcePath: "~/\(SkillAppCatalog.ssotRelativePath)/\(directory)",
+            nativeConfigPath: app.nativeConfigRelativePath.map { "~/\($0)" },
+            nativeConfigKey: app.nativeConfigKeyDescription,
+            viaGeminiCompatibility: app == .antigravity && apps[app] == nil && isProjected(for: .gemini)
+        )
+    }
+}

--- a/Sources/VibeBarCore/Skills/SkillsService.swift
+++ b/Sources/VibeBarCore/Skills/SkillsService.swift
@@ -249,6 +249,16 @@ public actor SkillsService {
             if action == .disableInHarness, !app.supportsNativeSkillActivation {
                 throw SkillError.nativeActivationUnsupported(app)
             }
+            // A shared-root harness without a native switch (Cursor) has
+            // nothing to change on either layer: discovery comes from the
+            // SSOT itself and there is no per-skill config to write. Report
+            // the no-op honestly so the UI can explain it instead of
+            // pretending the click landed.
+            if action == .enable,
+               app.discoversSharedSkillRoot,
+               !app.supportsNativeSkillActivation {
+                return false
+            }
             let prior = skill.apps[app]
             let materialization: SkillMaterialization?
             if app.discoversSharedSkillRoot {

--- a/Tests/VibeBarCoreTests/SkillWiringTests.swift
+++ b/Tests/VibeBarCoreTests/SkillWiringTests.swift
@@ -1,0 +1,53 @@
+import XCTest
+@testable import VibeBarCore
+
+/// `SkillHarnessWiring` is pure derivation over `Skill` + the catalog tables,
+/// so these tests pin the three shapes the popover distinguishes: shared-root
+/// with no switch (Cursor), projection plus native switch (Claude), and the
+/// AntiGravity-through-Gemini compatibility read.
+final class SkillWiringTests: XCTestCase {
+    private func makeSkill(apps: [SkillAppTarget: SkillMaterialization] = [:]) -> Skill {
+        Skill(
+            id: .local(directory: "pdf"),
+            name: "PDF Tools",
+            directory: "pdf",
+            installedAt: Date(timeIntervalSince1970: 0),
+            apps: apps
+        )
+    }
+
+    func testCursorWiringIsSharedRootWithNoSwitch() {
+        let wiring = makeSkill().wiring(for: .cursor)
+        XCTAssertEqual(wiring.state, .coupled)
+        XCTAssertTrue(wiring.discoversSharedRoot)
+        XCTAssertNil(wiring.projection)
+        XCTAssertNil(wiring.nativeConfigPath)
+        XCTAssertNil(wiring.nativeConfigKey)
+        XCTAssertEqual(wiring.projectionPath, "~/.cursor/skills/pdf")
+        XCTAssertEqual(wiring.sourcePath, "~/.agents/skills/pdf")
+        XCTAssertFalse(wiring.viaGeminiCompatibility)
+    }
+
+    func testClaudeWiringNamesTheProjectionAndSwitch() {
+        let skill = makeSkill(apps: [.claude: SkillMaterialization(method: .symlink)])
+        let wiring = skill.wiring(for: .claude)
+        XCTAssertEqual(wiring.state, .enabled)
+        XCTAssertFalse(wiring.discoversSharedRoot)
+        XCTAssertEqual(wiring.projection?.method, .symlink)
+        XCTAssertEqual(wiring.projectionPath, "~/.claude/skills/pdf")
+        XCTAssertEqual(wiring.nativeConfigPath, "~/.claude/settings.json")
+        XCTAssertEqual(wiring.nativeConfigKey, "skillOverrides")
+    }
+
+    func testAntigravityReportsGeminiCompatibility() {
+        let skill = makeSkill(apps: [.gemini: SkillMaterialization(method: .symlink)])
+        let wiring = skill.wiring(for: .antigravity)
+        XCTAssertEqual(wiring.state, .coupled)
+        XCTAssertTrue(wiring.viaGeminiCompatibility)
+        XCTAssertNil(wiring.nativeConfigPath)
+        // A direct AntiGravity projection would land in its own root, not
+        // Gemini's — the path stays the direct one even while the skill is
+        // only visible through compatibility.
+        XCTAssertEqual(wiring.projectionPath, "~/.gemini/config/skills/pdf")
+    }
+}

--- a/Tests/VibeBarCoreTests/SkillsServiceTests.swift
+++ b/Tests/VibeBarCoreTests/SkillsServiceTests.swift
@@ -206,6 +206,25 @@ final class SkillsServiceTests: XCTestCase {
         XCTAssertEqual(stored?.projectedApps, [])
     }
 
+    func testEnableIsAnHonestNoOpForASharedRootHarnessWithoutANativeSwitch() async throws {
+        let home = try SkillTestHome()
+        let staging = try home.makeSkillDirectory(at: home.url.appendingPathComponent("staging/pdf"))
+        let service = SkillsService(homeDirectory: home.path)
+        let skill = try await service.installLocal(from: staging, name: "pdf")
+
+        // Cursor scans the SSOT itself and has no per-skill config, so there
+        // is no layer for `.enable` to change — the call must say so instead
+        // of reporting success.
+        let changed = try await service.setActivation(skill.id, app: .cursor, action: .enable)
+
+        XCTAssertFalse(changed)
+        XCTAssertFalse(home.exists(home.appDirectory(.cursor).appendingPathComponent("pdf")))
+        let installed = await service.installedSkills()
+        let live = try XCTUnwrap(installed.first)
+        XCTAssertEqual(live.activationState(for: .cursor), .coupled)
+        XCTAssertNil(live.apps[.cursor])
+    }
+
     func testSetEnabledRejectsAnUnknownSkill() async throws {
         let home = try SkillTestHome()
         let service = SkillsService(homeDirectory: home.path)


### PR DESCRIPTION
The Skills page compressed three mechanisms — shared-root discovery, per-app projections, and native switches — into colored circles plus an orange "Cursor LINKED" capsule that sat on nearly every row, could not be clicked away, and read as a fault. Underneath it, enabling a skill for Cursor was a silent no-op that still reported success: Cursor scans `~/.agents/skills` itself and has no per-skill switch, so there was nothing for the click to change, and removing the redundant link was a one-way door.

This PR makes the manager show its work instead of asking to be trusted.

## Explain the wiring
- New `SkillHarnessWiring` + `Skill.wiring(for:)` in Core spell out, per harness: discovery (shared root / own folder / Gemini compatibility), the projection entry (symlink/copy, adopted or not, its path), and the native switch (key + config file path).
- A per-skill **Wiring Details…** popover renders that table with real paths, and the overflow menu gains **Reveal in Finder**.
- A page-level **How skill syncing works** explainer (the ⓘ next to the harness pills) documents the model: one SSOT, projections for Claude Code / AntiGravity, native switches for Codex / Claude / Gemini / Grok, none for Cursor.

## Stop lying about Cursor
- `SkillsService.setActivation` now returns `false` for an `.enable` on a shared-root harness without a native switch instead of upserting an identical record and claiming success; the model surfaces an explanatory toast.
- A plain click on such a harness's circle no longer deletes the redundant link (that looked like an off switch that didn't work — the skill stays discovered); removal stays in the context menu, and actually removing it now says the skill remains available through the shared root.
- New service test pins the honest no-op; new `SkillWiringTests` pin the three wiring shapes.

## Right-size the signal
- `.coupled` stops wearing warning orange: no row capsule (it was the *normal* state for ~everything Cursor sees), a secondary-colored link badge on the circle, and help text that names the actual mechanism.
- Header pills now count what a harness actually sees (enabled + shared-root), with the split in the tooltip — Cursor no longer claims 3 skills while scanning ~90.
- Dead `SkillsManagerModel.toggle` removed.

## Verification
- `swift build`, `swift test` (1640 passed), `./Scripts/build_app.sh release`, strict codesign with empty entitlements — all green.
- Demo-mode smoke run of `workbench:skillsManager` renders cleanly with no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)