### PR TITLE
Restore keyboard navigation with neutral initial focus

### DIFF
--- a/Sources/VibeBarApp/Controllers/WorkbenchWindowController.swift
+++ b/Sources/VibeBarApp/Controllers/WorkbenchWindowController.swift
@@ -33,6 +33,9 @@ final class WorkbenchWindowController: NSObject {
                 window.deminiaturize(nil)
             }
             window.makeKeyAndOrderFront(nil)
+            // Reopening the retained window is a presentation the probe
+            // cannot see — no view appears, so its one-shot never re-arms.
+            InitialFocusPolicy.clearOnReopen(of: window)
             NSApp.activate(ignoringOtherApps: true)
             return
         }
@@ -103,6 +106,7 @@ final class WorkbenchWindowController: NSObject {
         guard let window, window.isVisible else { return false }
         DockActivationController.shared.acquire(.workbench)
         window.makeKeyAndOrderFront(nil)
+        InitialFocusPolicy.clearOnReopen(of: window)
         NSApp.activate(ignoringOtherApps: true)
         return true
     }

--- a/Sources/VibeBarApp/Controllers/WorkbenchWindowController.swift
+++ b/Sources/VibeBarApp/Controllers/WorkbenchWindowController.swift
@@ -39,6 +39,7 @@ final class WorkbenchWindowController: NSObject {
 
         let hosting = NSHostingController(
             rootView: WorkbenchRootView(initialPage: page, navigation: navigation)
+                .vibeBarNoInitialFocus()
                 .environmentObject(environment)
                 .environmentObject(environment.accountStore)
                 .environmentObject(environment.settingsStore)

--- a/Sources/VibeBarApp/StatusItemController.swift
+++ b/Sources/VibeBarApp/StatusItemController.swift
@@ -148,6 +148,7 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
                 onToggleMiniWindow: { [weak controller] in controller?.toggleMiniWindow() },
                 initialPage: controller.popoverInitialPage
             )
+                .vibeBarNoInitialFocus()
                 .environmentObject(environment)
                 .environmentObject(environment.accountStore)
                 .environmentObject(environment.settingsStore)
@@ -400,10 +401,10 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
         popover.behavior = .applicationDefined
         environment.setPopoverVisible(true)
         popover.show(relativeTo: target.rect, of: target.view, preferredEdge: .minY)
+        // Key status would hand keyboard focus to the first button;
+        // `vibeBarNoInitialFocus()` on the popover root clears that initial
+        // selection in demo and production alike.
         popover.contentViewController?.view.window?.makeKey()
-        // Key status hands keyboard focus to the first button, which draws
-        // a focus ring nobody clicked for.
-        popover.contentViewController?.view.window?.makeFirstResponder(nil)
     }
 
     /// Show the mini window in `mode`. Demo mode only.

--- a/Sources/VibeBarApp/Views/BorderlessIconButton.swift
+++ b/Sources/VibeBarApp/Views/BorderlessIconButton.swift
@@ -4,7 +4,7 @@ import SwiftUI
 ///
 /// A real `Button`, not a tap gesture: a gesture-based lookalike can never be
 /// activated from the key-view loop or by VoiceOver, however many traits it
-/// declares. Plain `Button { … }.buttonStyle(.plain)` on macOS can still
+/// declares. Plain `Button { … }.buttonStyle(.vibeBar)` on macOS can still
 /// render a rounded blue selection background after click, which is why the
 /// style here is ``VibeBarButtonStyle`` — it draws no background at all,
 /// only the app's own accent hairline when keyboard focus actually reaches

--- a/Sources/VibeBarApp/Views/BorderlessIconButton.swift
+++ b/Sources/VibeBarApp/Views/BorderlessIconButton.swift
@@ -2,9 +2,13 @@ import SwiftUI
 
 /// Borderless icon button without focus chrome.
 ///
-/// Plain `Button { … }.buttonStyle(.plain)` on macOS can still render a
-/// rounded blue selection background after click. This clickable icon keeps
-/// the same hit area without becoming key-view focus chrome.
+/// A real `Button`, not a tap gesture: a gesture-based lookalike can never be
+/// activated from the key-view loop or by VoiceOver, however many traits it
+/// declares. Plain `Button { … }.buttonStyle(.plain)` on macOS can still
+/// render a rounded blue selection background after click, which is why the
+/// style here is ``VibeBarButtonStyle`` — it draws no background at all,
+/// only the app's own accent hairline when keyboard focus actually reaches
+/// the control.
 ///
 /// Optional `rotation` lets callers animate the glyph (used by the header's
 /// refresh button).
@@ -18,20 +22,18 @@ struct BorderlessIconButton: View {
     @Environment(\.isEnabled) private var isEnabled
 
     var body: some View {
-        Image(systemName: systemImage)
-            .font(.system(size: size, weight: .semibold))
-            .rotationEffect(.degrees(rotation))
-            .foregroundStyle(isEnabled ? .secondary : .tertiary)
-            .padding(4)
-            .frame(width: 22, height: 22)
-            .contentShape(Rectangle())
-            .onTapGesture {
-                guard isEnabled else { return }
-                action()
-            }
-            .help(help)
-            .accessibilityLabel(help)
-            .accessibilityAddTraits(.isButton)
+        Button(action: action) {
+            Image(systemName: systemImage)
+                .font(.system(size: size, weight: .semibold))
+                .rotationEffect(.degrees(rotation))
+                .foregroundStyle(isEnabled ? .secondary : .tertiary)
+                .padding(4)
+                .frame(width: 22, height: 22)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.vibeBar)
+        .help(help)
+        .accessibilityLabel(help)
     }
 }
 
@@ -39,20 +41,16 @@ struct BorderlessRowButton<Content: View>: View {
     let action: () -> Void
     let content: () -> Content
 
-    @Environment(\.isEnabled) private var isEnabled
-
     init(action: @escaping () -> Void, @ViewBuilder content: @escaping () -> Content) {
         self.action = action
         self.content = content
     }
 
     var body: some View {
-        content()
-            .contentShape(Rectangle())
-            .onTapGesture {
-                guard isEnabled else { return }
-                action()
-            }
-            .accessibilityAddTraits(.isButton)
+        Button(action: action) {
+            content()
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.vibeBar)
     }
 }

--- a/Sources/VibeBarApp/Views/ChartBrushNavigator.swift
+++ b/Sources/VibeBarApp/Views/ChartBrushNavigator.swift
@@ -434,8 +434,7 @@ struct ChartRangePills: View {
                             .frame(minHeight: 20)
                             .contentShape(Rectangle())
                     }
-                    .buttonStyle(.plain)
-                    .focusable(false)
+                    .buttonStyle(.vibeBar)
                     .background {
                         if option.isSelected {
                             RoundedRectangle(cornerRadius: 6, style: .continuous)

--- a/Sources/VibeBarApp/Views/ControlFocus.swift
+++ b/Sources/VibeBarApp/Views/ControlFocus.swift
@@ -1,0 +1,89 @@
+import SwiftUI
+
+/// The app's own button style: no chrome, no system focus ring, and a 1 pt
+/// accent hairline on whichever control keyboard focus actually reaches.
+///
+/// Most controls in the popover, the Workbench, and the Layout editor are
+/// drawn by hand — pills, segments, icon buttons, sidebar rows. As plain
+/// buttons they kept the *system* focus effect, which draws a bright
+/// system-accent rectangle around the control's bounding box: on a 22 pt
+/// icon the ring is larger than the glyph, and it lights up after an
+/// ordinary click, pointing at whatever was pressed last rather than at
+/// anything the user needs. The old answer was marking each control
+/// non-focusable, which silenced the ring by taking the control out of
+/// keyboard navigation entirely.
+///
+/// This style replaces the ring instead of removing the control from the
+/// loop. The containers switch the system effect off wholesale — see
+/// ``SwiftUI/View/vibeBarControlFocus()`` — and this style draws its own
+/// hairline in the app accent, following the control's real shape. Tab
+/// order works, arrow keys work, and a keyboard user still sees exactly
+/// where they are.
+struct VibeBarButtonStyle: ButtonStyle {
+    /// The corner the focus hairline follows. Should match the control's own
+    /// background shape; defaults to the small-control radius used by the
+    /// segment pills and icon buttons.
+    var cornerRadius: CGFloat = 6
+
+    func makeBody(configuration: Configuration) -> some View {
+        FocusRing(cornerRadius: cornerRadius) { configuration.label }
+            .opacity(configuration.isPressed ? 0.72 : 1)
+    }
+
+    /// The label, with the accent hairline around it while it has focus.
+    ///
+    /// A view of its own because `isFocused` is an environment value and a
+    /// `ButtonStyle` is not a view — reading it needs something with a body,
+    /// and that something has to sit *inside* the style so the answer is
+    /// about this button rather than about its container.
+    private struct FocusRing<Label: View>: View {
+        let cornerRadius: CGFloat
+        @ViewBuilder let label: Label
+
+        @Environment(\.isFocused) private var isFocused
+
+        var body: some View {
+            label.overlay {
+                if isFocused {
+                    RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                        .strokeBorder(Color.accentColor, lineWidth: 1)
+                }
+            }
+        }
+    }
+}
+
+extension ButtonStyle where Self == VibeBarButtonStyle {
+    /// The app's button: no chrome, no system focus ring, an accent hairline
+    /// where keyboard focus lands.
+    static var vibeBar: VibeBarButtonStyle { VibeBarButtonStyle() }
+
+    /// The same, following a control whose corner is not the default 6 pt.
+    static func vibeBar(cornerRadius: CGFloat) -> VibeBarButtonStyle {
+        VibeBarButtonStyle(cornerRadius: cornerRadius)
+    }
+}
+
+extension View {
+    /// Switches the system focus effect off for a region of hand-drawn
+    /// controls.
+    ///
+    /// Applied to the surface roots rather than to each button, because
+    /// `isFocusEffectDisabled` is an environment value and the system ring
+    /// is drawn by the button *around* its style — switching it off from
+    /// inside a `ButtonStyle` cannot work, and switching it off once per
+    /// surface cannot be forgotten by the next control somebody adds.
+    func vibeBarControlFocus() -> some View {
+        focusEffectDisabled()
+    }
+
+    /// Puts the system focus effect back, inside a region that switched it
+    /// off.
+    ///
+    /// For the areas made of AppKit's own controls — Settings toggles,
+    /// pickers, and text fields, the form sheets and popovers — which draw
+    /// nothing of their own to say where keyboard focus is.
+    func vibeBarSystemControlFocus() -> some View {
+        focusEffectDisabled(false)
+    }
+}

--- a/Sources/VibeBarApp/Views/CostHistoryView.swift
+++ b/Sources/VibeBarApp/Views/CostHistoryView.swift
@@ -751,7 +751,7 @@ struct CostHistoryView: View {
                     } label: {
                         Image(systemName: "xmark.circle.fill")
                     }
-                    .buttonStyle(.plain)
+                    .buttonStyle(.vibeBar)
                     .foregroundStyle(.secondary)
                     .help("Clear model selection")
                 }

--- a/Sources/VibeBarApp/Views/CostHistoryView.swift
+++ b/Sources/VibeBarApp/Views/CostHistoryView.swift
@@ -336,8 +336,7 @@ struct CostHistoryView: View {
                             }
                         }
                 }
-                .buttonStyle(.plain)
-                .focusable(false)
+                .buttonStyle(.vibeBar(cornerRadius: 5))
                 .help(option.help)
                 .accessibilityLabel(option.help)
                 // The visual fill is the only sighted cue for which measure

--- a/Sources/VibeBarApp/Views/CostHistoryView.swift
+++ b/Sources/VibeBarApp/Views/CostHistoryView.swift
@@ -1007,8 +1007,7 @@ struct CostHistoryView: View {
                         enabled: enabled
                     )
                 }
-                .buttonStyle(.plain)
-                .focusable(false)
+                .buttonStyle(.vibeBar)
                 .disabled(!enabled)
                 .help(
                     enabled
@@ -1431,8 +1430,7 @@ private struct CostRangePresetBar: View {
                         .frame(minHeight: 22)
                         .contentShape(Rectangle())
                 }
-                .buttonStyle(.plain)
-                .focusable(false)
+                .buttonStyle(.vibeBar)
                 .background {
                     if active == preset {
                         RoundedRectangle(cornerRadius: 6, style: .continuous)

--- a/Sources/VibeBarApp/Views/InitialFocusPolicy.swift
+++ b/Sources/VibeBarApp/Views/InitialFocusPolicy.swift
@@ -10,6 +10,31 @@ import SwiftUI
 /// the first responder once removes that accidental selection without
 /// touching the key-view loop itself: Tab and arrow keys still enter
 /// keyboard navigation normally, and their focus feedback stays visible.
+/// The one entry point the policy has outside a SwiftUI presentation: a
+/// retained window being reordered front.
+enum InitialFocusPolicy {
+    /// Applies the neutral-focus pass to a window whose SwiftUI hierarchy
+    /// stays mounted across close/reopen. The Workbench window is retained
+    /// (`isReleasedWhenClosed = false`) and comes back via
+    /// `makeKeyAndOrderFront`, so no `onAppear` fires and the probe's
+    /// one-shot token was consumed on the first presentation — without this,
+    /// AppKit would restore or re-pick a first responder on every reopen.
+    /// Same two main-queue turns as the probe, then a single clear if a
+    /// control holds focus.
+    @MainActor
+    static func clearOnReopen(of window: NSWindow) {
+        DispatchQueue.main.async {
+            DispatchQueue.main.async { [weak window] in
+                guard let window else { return }
+                if window.firstResponder === window || window.firstResponder == nil {
+                    return
+                }
+                window.makeFirstResponder(nil)
+            }
+        }
+    }
+}
+
 struct InitialFocusProbe: NSViewRepresentable {
     let presentationID: UUID
 

--- a/Sources/VibeBarApp/Views/InitialFocusPolicy.swift
+++ b/Sources/VibeBarApp/Views/InitialFocusPolicy.swift
@@ -1,0 +1,181 @@
+import AppKit
+import SwiftUI
+
+/// Starts a newly presented surface with no control selected.
+///
+/// macOS picks the first eligible control the moment a window, sheet, or
+/// popover becomes key. In a form that is a feature; in Vibe Bar it paints a
+/// focus ring on whichever compact button happens to sit first in the
+/// key-view loop of a surface most people only ever click or read. Clearing
+/// the first responder once removes that accidental selection without
+/// touching the key-view loop itself: Tab and arrow keys still enter
+/// keyboard navigation normally, and their focus feedback stays visible.
+struct InitialFocusProbe: NSViewRepresentable {
+    let presentationID: UUID
+
+    func makeNSView(context: Context) -> InitialFocusProbeView {
+        InitialFocusProbeView(presentationID: presentationID)
+    }
+
+    func updateNSView(_ view: InitialFocusProbeView, context: Context) {
+        view.beginPresentation(presentationID)
+    }
+}
+
+/// The AppKit seam behind ``InitialFocusProbe``.
+///
+/// It reacts only to the probe entering a window or receiving a fresh
+/// presentation token; it deliberately does not observe key-window changes,
+/// so switching to another app and back can never erase a text field the
+/// user is in the middle of editing.
+@MainActor
+final class InitialFocusController {
+    private weak var window: NSWindow?
+    private var presentationID: UUID?
+    private var state = InitialFocusState()
+    private var isScheduled = false
+
+    func attach(to newWindow: NSWindow?, presentationID newPresentationID: UUID) {
+        guard window !== newWindow || presentationID != newPresentationID else {
+            scheduleIfNeeded()
+            return
+        }
+
+        window = newWindow
+        presentationID = newPresentationID
+        state.attach(to: newWindow)
+        isScheduled = false
+
+        scheduleIfNeeded()
+    }
+
+    /// Clears the initial responder once for the current presentation.
+    ///
+    /// Returning whether the call consumed the one-shot keeps the contract
+    /// testable. A focus the user has since established by keyboard or
+    /// pointer is deliberately left alone.
+    @discardableResult
+    func clearInitialFocus(in candidate: NSWindow) -> Bool {
+        state.consumeClear(for: candidate) {
+            if candidate.firstResponder === candidate || candidate.firstResponder == nil {
+                return true
+            }
+            return candidate.makeFirstResponder(nil)
+        }
+    }
+
+    /// Two main-queue turns let SwiftUI and AppKit finish choosing their
+    /// default first responder before the one-shot clear runs. The delay is
+    /// scheduling, not a timer, so presentation animation never waits on it.
+    private func scheduleIfNeeded() {
+        guard let window,
+              state.needsClear(for: window),
+              !isScheduled
+        else { return }
+
+        isScheduled = true
+        let scheduledPresentation = presentationID
+        DispatchQueue.main.async { [weak self, weak window] in
+            DispatchQueue.main.async { [weak self, weak window] in
+                guard let self else { return }
+                self.isScheduled = false
+                guard let window,
+                      self.window === window,
+                      self.presentationID == scheduledPresentation
+                else { return }
+                self.clearInitialFocus(in: window)
+            }
+        }
+    }
+}
+
+/// The pure one-shot decision behind the AppKit controller.
+///
+/// Kept independent of `NSWindow` so the invariant can be exercised without
+/// starting a second AppKit application inside SwiftPM's test host.
+struct InitialFocusState {
+    private var presentationID: ObjectIdentifier?
+    private var didClear = false
+
+    mutating func attach(to presentation: AnyObject?) {
+        presentationID = presentation.map(ObjectIdentifier.init)
+        didClear = false
+    }
+
+    func needsClear(for presentation: AnyObject) -> Bool {
+        presentationID == ObjectIdentifier(presentation) && !didClear
+    }
+
+    @discardableResult
+    mutating func consumeClear(
+        for presentation: AnyObject,
+        perform: () -> Bool
+    ) -> Bool {
+        guard needsClear(for: presentation), perform() else { return false }
+        didClear = true
+        return true
+    }
+}
+
+/// A zero-area participant in SwiftUI's tree that can discover the hosting
+/// window without taking layout space, a click, or an accessibility stop.
+@MainActor
+final class InitialFocusProbeView: NSView {
+    private let controller = InitialFocusController()
+    private var presentationID: UUID
+
+    init(presentationID: UUID) {
+        self.presentationID = presentationID
+        super.init(frame: .zero)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) is unavailable")
+    }
+
+    override var acceptsFirstResponder: Bool { false }
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        controller.attach(to: window, presentationID: presentationID)
+    }
+
+    func beginPresentation(_ id: UUID) {
+        presentationID = id
+        controller.attach(to: window, presentationID: id)
+    }
+}
+
+/// Supplies a fresh token whenever SwiftUI presents a reusable hosting view.
+/// `onAppear` is deliberately the trigger: app activation does not make an
+/// already-visible root appear again, while reopening the popover, the
+/// Workbench, or a sheet does — and each of those reopenings deserves
+/// exactly one new clear.
+private struct NoInitialFocusModifier: ViewModifier {
+    @State private var presentationID = UUID()
+
+    func body(content: Content) -> some View {
+        content
+            .background {
+                InitialFocusProbe(presentationID: presentationID)
+                    .frame(width: 0, height: 0)
+                    .accessibilityHidden(true)
+                    .allowsHitTesting(false)
+            }
+            .onAppear { presentationID = UUID() }
+    }
+}
+
+extension View {
+    /// Makes this window, sheet, or popover start with no selected control.
+    ///
+    /// This is intentionally unrelated to `focusEffectDisabled`: it changes
+    /// only the presentation's initial responder. Once the user presses Tab
+    /// or an arrow key, native controls keep normal macOS focus feedback and
+    /// Vibe Bar's own buttons draw their accent hairline — see
+    /// ``VibeBarButtonStyle``.
+    func vibeBarNoInitialFocus() -> some View {
+        modifier(NoInitialFocusModifier())
+    }
+}

--- a/Sources/VibeBarApp/Views/LayoutEditorView.swift
+++ b/Sources/VibeBarApp/Views/LayoutEditorView.swift
@@ -148,6 +148,11 @@ struct LayoutEditorView: View {
             }
         }
         .coordinateSpace(.named(Self.space))
+        // The editor sits inside the Settings pane, which restores the
+        // system focus ring for its native controls — but everything in here
+        // is hand-drawn pills and icon buttons, so the ring goes off again
+        // and `VibeBarButtonStyle` marks keyboard focus instead.
+        .vibeBarControlFocus()
         .onChange(of: page) { _, newValue in
             // A provider hidden from the popover takes its page with it.
             if selectedPage != newValue { selectedPage = newValue }
@@ -200,8 +205,8 @@ struct LayoutEditorView: View {
                     }
                     .contentShape(Capsule(style: .continuous))
                 }
-                .buttonStyle(.plain)
-                .focusable(false)
+                // The ring radius matches the 24 pt capsule the label draws.
+                .buttonStyle(.vibeBar(cornerRadius: 12))
                 .help(layoutModel.hasSavedIntent(entry.page) ? "\(entry.title) — customized" : entry.title)
             }
             Spacer(minLength: 0)
@@ -280,8 +285,7 @@ struct LayoutEditorView: View {
             }
             .contentShape(Capsule(style: .continuous))
         }
-        .buttonStyle(.plain)
-        .focusable(false)
+        .buttonStyle(.vibeBar(cornerRadius: 12))
         .help(modeHelp(mode, page: page))
     }
 
@@ -351,6 +355,10 @@ struct LayoutEditorView: View {
         )
         .popover(isPresented: $isNamingPreset, arrowEdge: .bottom) {
             presetNameForm(page: page, arrangement: arrangement, descriptors: descriptors)
+                // A native form: no initial selection, but the system focus
+                // ring comes back for its text field and buttons.
+                .vibeBarNoInitialFocus()
+                .vibeBarSystemControlFocus()
         }
     }
 
@@ -503,8 +511,7 @@ struct LayoutEditorView: View {
             )
             .contentShape(RoundedRectangle(cornerRadius: 7, style: .continuous))
         }
-        .buttonStyle(.plain)
-        .focusable(false)
+        .buttonStyle(.vibeBar(cornerRadius: 7))
     }
 
     private func ratioIcon(_ ratio: PageColumnRatio) -> some View {
@@ -871,8 +878,7 @@ struct LayoutEditorView: View {
                 .font(.system(size: 9, weight: .semibold))
                 .frame(width: 16, height: 16)
         }
-        .buttonStyle(.plain)
-        .focusable(false)
+        .buttonStyle(.vibeBar)
         .foregroundStyle(.secondary)
         .help(help)
     }
@@ -930,8 +936,7 @@ struct LayoutEditorView: View {
                 .frame(width: 20, height: 20)
                 .contentShape(Rectangle())
         }
-        .buttonStyle(.plain)
-        .focusable(false)
+        .buttonStyle(.vibeBar)
         .help(
             isHidden
                 ? "Show “\(block.descriptor.displayName)” on this page"

--- a/Sources/VibeBarApp/Views/MiniQuotaWindowView.swift
+++ b/Sources/VibeBarApp/Views/MiniQuotaWindowView.swift
@@ -58,6 +58,10 @@ struct MiniQuotaWindowView: View {
             .regular.interactive(),
             in: .rect(cornerRadius: Theme.miniCornerRadius)
         )
+        // The panel is borderless and non-activating, so it never becomes
+        // key — but the close button would still draw a system focus ring
+        // after a click without this.
+        .vibeBarControlFocus()
     }
 
     /// The field ids selected for the current display mode. Also the input to

--- a/Sources/VibeBarApp/Views/MiniQuotaWindowView.swift
+++ b/Sources/VibeBarApp/Views/MiniQuotaWindowView.swift
@@ -42,7 +42,7 @@ struct MiniQuotaWindowView: View {
                     .font(.system(size: 13, weight: .semibold))
                     .foregroundStyle(.secondary)
             }
-            .buttonStyle(.plain)
+            .buttonStyle(.vibeBar)
             .padding(.top, 6)
             .padding(.trailing, 8)
         }

--- a/Sources/VibeBarApp/Views/OverviewUsageMixCard.swift
+++ b/Sources/VibeBarApp/Views/OverviewUsageMixCard.swift
@@ -125,7 +125,7 @@ struct OverviewUsageMixCard: View {
                             )
                         )
                 }
-                .buttonStyle(.plain)
+                .buttonStyle(.vibeBar)
             }
         }
     }

--- a/Sources/VibeBarApp/Views/PopoverRoot.swift
+++ b/Sources/VibeBarApp/Views/PopoverRoot.swift
@@ -64,6 +64,10 @@ struct PopoverRoot: View {
         .padding(.vertical, shellDensity.popoverPaddingV)
         .frame(width: width, alignment: .topLeading)
         .fixedSize(horizontal: false, vertical: true)
+        // Every control in the popover is hand-drawn; the system focus ring
+        // is switched off once here and `VibeBarButtonStyle` draws its own
+        // accent hairline where keyboard focus lands.
+        .vibeBarControlFocus()
         .readHeight(onContentHeightChange)
         .onAppear {
             if !hasAppliedInitialPage {
@@ -1479,8 +1483,7 @@ private struct OverviewCostCard: View {
                         Image(systemName: "rectangle.expand.vertical")
                             .font(.system(size: 11, weight: .semibold))
                     }
-                    .buttonStyle(.plain)
-                    .focusable(false)
+                    .buttonStyle(.vibeBar)
                     .foregroundStyle(.secondary)
                     .help("Open full charts")
                     .popover(isPresented: $detailPresented, arrowEdge: .trailing) {
@@ -1493,6 +1496,7 @@ private struct OverviewCostCard: View {
                             heatmapTitleOverride: heatmapTitleOverride
                         )
                             .frame(width: max(660, density.popoverWidth * 0.70), height: 660)
+                            .vibeBarNoInitialFocus()
                     }
                 }
             }

--- a/Sources/VibeBarApp/Views/QuotaGroupCard.swift
+++ b/Sources/VibeBarApp/Views/QuotaGroupCard.swift
@@ -687,7 +687,7 @@ struct QuotaGroupCard: View {
                 .foregroundStyle(.secondary)
                 .contentShape(Rectangle())
             }
-            .buttonStyle(.plain)
+            .buttonStyle(.vibeBar)
             .accessibilityLabel(isExpanded ? "Hide forecast calculation" : "Show forecast calculation")
 
             if isExpanded {

--- a/Sources/VibeBarApp/Views/RemoteMachinesPage.swift
+++ b/Sources/VibeBarApp/Views/RemoteMachinesPage.swift
@@ -310,7 +310,7 @@ struct RemoteMachinesPage: View {
                             .fill(Color.orange.opacity(0.12))
                     )
             }
-            .buttonStyle(.plain)
+            .buttonStyle(.vibeBar)
             .disabled(service.isRefreshing)
         }
         .font(.system(size: density.subtitleFontSize))

--- a/Sources/VibeBarApp/Views/SettingsSidebarView.swift
+++ b/Sources/VibeBarApp/Views/SettingsSidebarView.swift
@@ -45,6 +45,9 @@ struct SettingsSidebarView: View {
             .padding(.horizontal, 10)
             .frame(height: 31)
             .workbenchFieldSurface(cornerRadius: 8)
+            // The search field is the sidebar's one native control; give it
+            // back the system focus ring the rail switches off.
+            .vibeBarSystemControlFocus()
             .padding(.horizontal, 14)
             .padding(.top, 16)
             .padding(.bottom, 12)
@@ -133,6 +136,9 @@ struct SettingsSidebarView: View {
             }
         }
         .frame(width: Self.width)
+        // A rail of hand-drawn rows: the system focus ring stays off and
+        // each row's `VibeBarButtonStyle` hairline marks keyboard focus.
+        .vibeBarControlFocus()
     }
 
     private var filteredBasicPages: [SettingsSectionID] {
@@ -290,8 +296,7 @@ struct SettingsSidebarView: View {
             }
             .contentShape(Rectangle())
         }
-        .buttonStyle(.plain)
-        .focusable(false)
+        .buttonStyle(.vibeBar(cornerRadius: 7))
         .opacity(enabled || selected ? 1 : 0.62)
     }
 

--- a/Sources/VibeBarApp/Views/SettingsView.swift
+++ b/Sources/VibeBarApp/Views/SettingsView.swift
@@ -665,6 +665,12 @@ struct SettingsView: View {
                         .frame(maxWidth: .infinity, alignment: .topLeading)
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
+            // The detail pane is native toggles, pickers, and text fields:
+            // their system focus ring is the only thing telling a keyboard
+            // user where they are, so the window-wide switch-off is undone
+            // here. Hand-drawn regions inside (the Layout editor) switch it
+            // off again for themselves.
+            .vibeBarSystemControlFocus()
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .onAppear(perform: refreshLaunchAtLoginState)

--- a/Sources/VibeBarApp/Views/Workbench/SessionListView.swift
+++ b/Sources/VibeBarApp/Views/Workbench/SessionListView.swift
@@ -195,7 +195,7 @@ private struct SessionRow: View {
             )
             .contentShape(Rectangle())
         }
-        .buttonStyle(.plain)
+        .buttonStyle(.vibeBar)
         .onHover { isHovering = $0 }
         .animation(reduceMotion ? nil : .easeOut(duration: 0.14), value: isHovering)
         .accessibilityElement(children: .combine)

--- a/Sources/VibeBarApp/Views/Workbench/SessionManagerPage.swift
+++ b/Sources/VibeBarApp/Views/Workbench/SessionManagerPage.swift
@@ -169,6 +169,9 @@ struct SessionFiltersBar: View {
             TextField("Search sessions", text: $model.searchText)
                 .textFieldStyle(.plain)
                 .font(.system(size: max(12, density.segmentedFontSize)))
+                // A text field draws nothing of its own to say keyboard focus
+                // arrived; the system ring comes back for it alone.
+                .vibeBarSystemControlFocus()
             if !model.searchText.isEmpty {
                 BorderlessIconButton(systemImage: "xmark.circle.fill", help: "Clear the search") {
                     model.searchText = ""
@@ -326,7 +329,7 @@ struct SessionFiltersBar: View {
                 .padding(.horizontal, 10)
                 .frame(minHeight: 28)
         }
-        .buttonStyle(.plain)
+        .buttonStyle(.vibeBar)
         .background(chipBackground(tint: .accentColor, selected: selected))
         .help(selected ? "Click to select no harness" : "Click to show sessions from every harness")
         .accessibilityLabel(selected ? "Select no harness" : "Show every session source")

--- a/Sources/VibeBarApp/Views/Workbench/SessionManagerPage.swift
+++ b/Sources/VibeBarApp/Views/Workbench/SessionManagerPage.swift
@@ -245,6 +245,10 @@ struct SessionFiltersBar: View {
             }
             .padding(16)
             .frame(width: 360)
+            // A native form: no initial selection, but the system focus ring
+            // comes back for its text fields and buttons.
+            .vibeBarNoInitialFocus()
+            .vibeBarSystemControlFocus()
         }
     }
 

--- a/Sources/VibeBarApp/Views/Workbench/SkillBackupsSheet.swift
+++ b/Sources/VibeBarApp/Views/Workbench/SkillBackupsSheet.swift
@@ -114,7 +114,7 @@ struct SkillBackupsSheet: View {
                 Image(systemName: "trash")
                     .foregroundStyle(.secondary)
             }
-            .buttonStyle(.plain)
+            .buttonStyle(.vibeBar)
             .disabled(busy)
             .accessibilityLabel("Delete this backup")
         }

--- a/Sources/VibeBarApp/Views/Workbench/SkillDiscoverSheet.swift
+++ b/Sources/VibeBarApp/Views/Workbench/SkillDiscoverSheet.swift
@@ -135,7 +135,7 @@ struct SkillDiscoverSheet: View {
                             Image(systemName: "minus.circle")
                                 .foregroundStyle(.secondary)
                         }
-                        .buttonStyle(.plain)
+                        .buttonStyle(.vibeBar)
                         .help("Stop scanning \(repo)")
                         .accessibilityLabel("Remove \(repo)")
                     }

--- a/Sources/VibeBarApp/Views/Workbench/SkillListRow.swift
+++ b/Sources/VibeBarApp/Views/Workbench/SkillListRow.swift
@@ -451,6 +451,7 @@ struct SkillListRow: View {
         .accessibilityLabel("More actions for \(skill.name)")
         .popover(isPresented: $showingWiring, arrowEdge: .trailing) {
             SkillWiringPopover(skill: skill, density: density)
+                .vibeBarNoInitialFocus()
         }
     }
 }

--- a/Sources/VibeBarApp/Views/Workbench/SkillListRow.swift
+++ b/Sources/VibeBarApp/Views/Workbench/SkillListRow.swift
@@ -157,7 +157,7 @@ struct SkillAppToggleRow: View {
                         .offset(x: 2, y: -2)
                 }
         }
-        .buttonStyle(.plain)
+        .buttonStyle(.vibeBar)
         // An off app has to stay readable — the user is picking from these —
         // but must not wear the accent, which is the only signal that says
         // "this skill is live here".

--- a/Sources/VibeBarApp/Views/Workbench/SkillWiringView.swift
+++ b/Sources/VibeBarApp/Views/Workbench/SkillWiringView.swift
@@ -29,7 +29,7 @@ struct SkillWiringPopover: View {
                     Label("Reveal", systemImage: "folder")
                         .font(.system(size: max(9, density.resetCountdownFontSize - 1), weight: .semibold))
                 }
-                .buttonStyle(.plain)
+                .buttonStyle(.vibeBar)
                 .foregroundStyle(.secondary)
                 .help("Show the skill's source directory in Finder")
             }

--- a/Sources/VibeBarApp/Views/Workbench/SkillsManagerPage.swift
+++ b/Sources/VibeBarApp/Views/Workbench/SkillsManagerPage.swift
@@ -241,6 +241,7 @@ struct SkillsManagerPage: View {
             .help("How skill syncing works — roots, links, and native switches")
             .popover(isPresented: $showingSyncExplainer, arrowEdge: .bottom) {
                 SkillSyncExplainerPopover(density: density)
+                    .vibeBarNoInitialFocus()
             }
             Spacer(minLength: 8)
             Text(countSummary)

--- a/Sources/VibeBarApp/Views/Workbench/SkillsManagerPage.swift
+++ b/Sources/VibeBarApp/Views/Workbench/SkillsManagerPage.swift
@@ -103,6 +103,9 @@ struct SkillsManagerPage: View {
             TextField("Filter installed skills", text: $model.searchText)
                 .textFieldStyle(.plain)
                 .font(.system(size: max(12, density.segmentedFontSize)))
+                // A text field draws nothing of its own to say keyboard focus
+                // arrived; the system ring comes back for it alone.
+                .vibeBarSystemControlFocus()
             if !model.searchText.isEmpty {
                 Button {
                     model.searchText = ""
@@ -110,7 +113,7 @@ struct SkillsManagerPage: View {
                     Image(systemName: "xmark.circle.fill")
                         .foregroundStyle(.tertiary)
                 }
-                .buttonStyle(.plain)
+                .buttonStyle(.vibeBar)
                 .accessibilityLabel("Clear the filter")
             }
         }
@@ -133,7 +136,7 @@ struct SkillsManagerPage: View {
                     busy: model.isBusy(SkillsManagerModel.BusyKey.updates)
                 )
             }
-            .buttonStyle(.plain)
+            .buttonStyle(.vibeBar)
             .porcelainToolbarButton()
             .disabled(model.isBusy(SkillsManagerModel.BusyKey.updates))
 
@@ -146,7 +149,7 @@ struct SkillsManagerPage: View {
                     busy: model.isBusy(SkillsManagerModel.BusyKey.zip)
                 )
             }
-            .buttonStyle(.plain)
+            .buttonStyle(.vibeBar)
             .porcelainToolbarButton()
 
             Button {
@@ -158,7 +161,7 @@ struct SkillsManagerPage: View {
                     busy: model.isBusy(SkillsManagerModel.BusyKey.importing)
                 )
             }
-            .buttonStyle(.plain)
+            .buttonStyle(.vibeBar)
             .porcelainToolbarButton()
 
             Button {
@@ -166,7 +169,7 @@ struct SkillsManagerPage: View {
             } label: {
                 buttonLabel(systemImage: "clock.arrow.circlepath", title: "Backups", busy: false)
             }
-            .buttonStyle(.plain)
+            .buttonStyle(.vibeBar)
             .porcelainToolbarButton()
 
             Button {
@@ -174,7 +177,7 @@ struct SkillsManagerPage: View {
             } label: {
                 buttonLabel(systemImage: "sparkle.magnifyingglass", title: "Discover", busy: false)
             }
-            .buttonStyle(.plain)
+            .buttonStyle(.vibeBar)
             .porcelainToolbarButton(prominent: true)
             .help("Browse configured repositories and the skills.sh index")
         }
@@ -237,7 +240,7 @@ struct SkillsManagerPage: View {
                     .frame(width: 24, height: 28)
                     .contentShape(Rectangle())
             }
-            .buttonStyle(.plain)
+            .buttonStyle(.vibeBar)
             .help("How skill syncing works — roots, links, and native switches")
             .popover(isPresented: $showingSyncExplainer, arrowEdge: .bottom) {
                 SkillSyncExplainerPopover(density: density)
@@ -361,7 +364,7 @@ struct SkillsManagerPage: View {
                     Image(systemName: "xmark")
                         .font(.system(size: density.subtitleFontSize - 2, weight: .semibold))
                 }
-                .buttonStyle(.plain)
+                .buttonStyle(.vibeBar)
                 .accessibilityLabel("Dismiss")
             }
             .padding(.horizontal, 14)

--- a/Sources/VibeBarApp/Views/Workbench/SkillsManagerPage.swift
+++ b/Sources/VibeBarApp/Views/Workbench/SkillsManagerPage.swift
@@ -54,14 +54,23 @@ struct SkillsManagerPage: View {
                 model.toast = error.localizedDescription
             }
         }
+        // The sheets are native forms: no initial selection, but the system
+        // focus ring the Workbench window switches off comes back for their
+        // fields, toggles, and default-styled buttons.
         .sheet(isPresented: $model.isDiscoverSheetPresented, onDismiss: model.discoverSheetDismissed) {
             SkillDiscoverSheet(density: density, model: model)
+                .vibeBarNoInitialFocus()
+                .vibeBarSystemControlFocus()
         }
         .sheet(isPresented: $model.isImportSheetPresented) {
             SkillImportSheet(density: density, model: model)
+                .vibeBarNoInitialFocus()
+                .vibeBarSystemControlFocus()
         }
         .sheet(isPresented: $model.isBackupsSheetPresented) {
             SkillBackupsSheet(density: density, model: model)
+                .vibeBarNoInitialFocus()
+                .vibeBarSystemControlFocus()
         }
     }
 

--- a/Sources/VibeBarApp/Views/Workbench/TranscriptView.swift
+++ b/Sources/VibeBarApp/Views/Workbench/TranscriptView.swift
@@ -334,6 +334,7 @@ struct TranscriptView: View {
                     scroll(to: seq, proxy: proxy)
                 }
             )
+            .vibeBarNoInitialFocus()
         }
     }
 

--- a/Sources/VibeBarApp/Views/Workbench/TranscriptView.swift
+++ b/Sources/VibeBarApp/Views/Workbench/TranscriptView.swift
@@ -162,6 +162,9 @@ struct TranscriptView: View {
                 .textFieldStyle(.plain)
                 .font(.system(size: density.segmentedFontSize))
                 .onSubmit { step(by: 1, proxy: proxy) }
+                // A text field draws nothing of its own to say keyboard focus
+                // arrived; the system ring comes back for it alone.
+                .vibeBarSystemControlFocus()
             if !query.isEmpty {
                 Text(matches.isEmpty ? "none" : "\(matchIndex + 1)/\(matches.count)")
                     .font(.system(size: max(9, density.resetCountdownFontSize - 1), design: .rounded)
@@ -436,7 +439,7 @@ struct SessionMetadataHeader: View {
                     .fill(Color.primary.opacity(0.05))
             )
         }
-        .buttonStyle(.plain)
+        .buttonStyle(.vibeBar)
         .help("Copy session ID")
         .accessibilityLabel("Session ID \(summary.sessionID). Copy")
     }
@@ -664,7 +667,7 @@ struct TranscriptMessageCard: View {
                     Button(isExpanded ? "Show less" : "Show more (\(message.text.count) chars)") {
                         onToggleExpanded()
                     }
-                    .buttonStyle(.plain)
+                    .buttonStyle(.vibeBar)
                     .font(.system(size: max(9, density.resetCountdownFontSize), weight: .semibold))
                     .foregroundStyle(accent)
                 }
@@ -713,7 +716,7 @@ struct TranscriptMessageCard: View {
                     .frame(width: 26, height: 26)
                     .background(Circle().fill(Color.primary.opacity(isHovering ? 0.09 : 0)))
             }
-            .buttonStyle(.plain)
+            .buttonStyle(.vibeBar)
             .foregroundStyle(isHovering ? .secondary : .tertiary)
             .opacity(isHovering ? 1 : 0.42)
             .help("Copy this message")

--- a/Sources/VibeBarApp/Views/Workbench/UsageBreakdownTables.swift
+++ b/Sources/VibeBarApp/Views/Workbench/UsageBreakdownTables.swift
@@ -70,7 +70,7 @@ struct UsageBreakdownTables: View {
                             )
                             .contentShape(Rectangle())
                     }
-                    .buttonStyle(.plain)
+                    .buttonStyle(.vibeBar)
                     .contentShape(Rectangle())
                     .accessibilityLabel(value.title)
                     .accessibilityAddTraits(selected ? [.isSelected] : [])
@@ -266,7 +266,7 @@ struct UsageBreakdownTables: View {
             .frame(maxWidth: .infinity, minHeight: 33)
             .contentShape(Rectangle())
         }
-        .buttonStyle(.plain)
+        .buttonStyle(.vibeBar)
         .disabled(model.isLoadingMore)
     }
 

--- a/Sources/VibeBarApp/Views/Workbench/UsageFiltersBar.swift
+++ b/Sources/VibeBarApp/Views/Workbench/UsageFiltersBar.swift
@@ -69,7 +69,7 @@ struct UsageFiltersBar: View {
                 .padding(.horizontal, 10)
                 .frame(minHeight: 28)
         }
-        .buttonStyle(.plain)
+        .buttonStyle(.vibeBar)
         .background(chipBackground(tint: .accentColor, selected: selected))
         .help(selected ? "Click to select no harness" : "Click to include every harness")
         .accessibilityLabel(selected ? "Select no harness" : "Show every harness")
@@ -96,7 +96,7 @@ struct UsageFiltersBar: View {
             .padding(.horizontal, 7)
             .frame(minHeight: 28)
         }
-        .buttonStyle(.plain)
+        .buttonStyle(.vibeBar)
         .background(Capsule().fill(accent.opacity(selected ? 0.10 : 0.035)))
         .opacity(selected ? 1 : 0.65)
         .saturation(selected ? 1 : 0.50)
@@ -129,7 +129,7 @@ struct UsageFiltersBar: View {
             .padding(.horizontal, 9)
             .frame(minHeight: 28)
         }
-        .buttonStyle(.plain)
+        .buttonStyle(.vibeBar)
         .background(chipBackground(tint: Theme.providerAccent(for: group.company), selected: selected))
         // Unselected chips stay legible but recede — the accent is the signal
         // that a harness is in the query, so an off chip must not wear it.

--- a/Sources/VibeBarApp/Views/Workbench/UsageFiltersBar.swift
+++ b/Sources/VibeBarApp/Views/Workbench/UsageFiltersBar.swift
@@ -205,6 +205,10 @@ struct UsageFiltersBar: View {
         .fixedSize()
         .popover(isPresented: $showsCustomRange, arrowEdge: .bottom) {
             customRangeEditor
+                // A native form: no initial selection, but the system focus
+                // ring comes back for its date pickers.
+                .vibeBarNoInitialFocus()
+                .vibeBarSystemControlFocus()
         }
         .accessibilityLabel("Choose the date range")
     }

--- a/Sources/VibeBarApp/Views/Workbench/UsageTrendChartView.swift
+++ b/Sources/VibeBarApp/Views/Workbench/UsageTrendChartView.swift
@@ -214,7 +214,7 @@ struct UsageTrendChartView: View {
                         .padding(.horizontal, 9)
                         .frame(minHeight: 24)
                 }
-                .buttonStyle(.plain)
+                .buttonStyle(.vibeBar)
                 .background(
                     RoundedRectangle(cornerRadius: 7, style: .continuous)
                         .fill(selected ? Color.accentColor.opacity(0.16) : Color.clear)
@@ -298,7 +298,7 @@ struct UsageTrendChartView: View {
                     .padding(.horizontal, 7)
                     .frame(minHeight: 20)
                 }
-                .buttonStyle(.plain)
+                .buttonStyle(.vibeBar)
                 .background(
                     Capsule().fill(color.opacity(visible ? 0.14 : 0.04))
                 )

--- a/Sources/VibeBarApp/Views/Workbench/WorkbenchPorcelainStyle.swift
+++ b/Sources/VibeBarApp/Views/Workbench/WorkbenchPorcelainStyle.swift
@@ -146,24 +146,47 @@ struct WorkbenchPillButtonStyle: ButtonStyle {
     var prominent = false
     var tint = WorkbenchPorcelain.accent
 
-    @Environment(\.colorScheme) private var colorScheme
-
     func makeBody(configuration: Configuration) -> some View {
-        configuration.label
-            .padding(.horizontal, 10)
-            .frame(minHeight: 26)
-            .foregroundStyle(prominent ? Color.white : Color.primary)
-            .background(
-                RoundedRectangle(cornerRadius: 13, style: .continuous)
-                    .fill(prominent ? tint : WorkbenchPorcelain.toolbarFill(for: colorScheme))
-            )
-            .overlay(
-                RoundedRectangle(cornerRadius: 13, style: .continuous)
-                    .stroke(
-                        prominent ? tint.opacity(0.72) : WorkbenchPorcelain.hairline(for: colorScheme),
-                        lineWidth: Theme.Card.hairlineWidth
-                    )
-            )
-            .opacity(configuration.isPressed ? 0.74 : 1)
+        Pill(
+            prominent: prominent,
+            tint: tint,
+            pressed: configuration.isPressed,
+            label: configuration.label
+        )
+    }
+
+    /// A view of its own for the same reason `VibeBarButtonStyle` has one:
+    /// `isFocused` is an environment value, and only a nested view can read
+    /// it about this button rather than about its container. The Workbench
+    /// root switches the system focus ring off, so the pill draws its own.
+    private struct Pill<Label: View>: View {
+        let prominent: Bool
+        let tint: Color
+        let pressed: Bool
+        let label: Label
+
+        @Environment(\.colorScheme) private var colorScheme
+        @Environment(\.isFocused) private var isFocused
+
+        var body: some View {
+            label
+                .padding(.horizontal, 10)
+                .frame(minHeight: 26)
+                .foregroundStyle(prominent ? Color.white : Color.primary)
+                .background(
+                    RoundedRectangle(cornerRadius: 13, style: .continuous)
+                        .fill(prominent ? tint : WorkbenchPorcelain.toolbarFill(for: colorScheme))
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: 13, style: .continuous)
+                        .stroke(
+                            isFocused
+                                ? Color.accentColor
+                                : prominent ? tint.opacity(0.72) : WorkbenchPorcelain.hairline(for: colorScheme),
+                            lineWidth: isFocused ? 1 : Theme.Card.hairlineWidth
+                        )
+                )
+                .opacity(pressed ? 0.74 : 1)
+        }
     }
 }

--- a/Sources/VibeBarApp/Views/Workbench/WorkbenchRootView.swift
+++ b/Sources/VibeBarApp/Views/Workbench/WorkbenchRootView.swift
@@ -125,6 +125,12 @@ struct WorkbenchRootView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(WorkbenchPorcelain.windowFill(for: colorScheme))
         .workbenchPorcelain()
+        // The whole window is hand-drawn controls; the system focus ring is
+        // switched off here, once, and every custom button style draws its
+        // own accent hairline instead. Regions made of native controls —
+        // Settings' toggles and fields, the form sheets and popovers — put
+        // the system effect back locally with `vibeBarSystemControlFocus()`.
+        .vibeBarControlFocus()
         .preferredColorScheme(appearanceOverride)
         .onAppear {
             if navigation.selectedPage == nil {
@@ -259,7 +265,6 @@ private struct WorkbenchSidebar: View {
         .onHover { hovering in
             hoveredPage = hovering ? page : (hoveredPage == page ? nil : hoveredPage)
         }
-        .focusEffectDisabled()
         .accessibilityAddTraits(selection == page ? [.isSelected] : [])
     }
 
@@ -282,28 +287,47 @@ private struct WorkbenchSidebarRowStyle: ButtonStyle {
     let isSelected: Bool
     let isHovered: Bool
 
-    @Environment(\.colorScheme) private var colorScheme
-
     func makeBody(configuration: Configuration) -> some View {
-        configuration.label
-            .background(
-                RoundedRectangle(cornerRadius: 9, style: .continuous)
-                    .fill(backgroundFill)
-            )
-            .overlay(
-                RoundedRectangle(cornerRadius: 9, style: .continuous)
-                    .stroke(
-                        isSelected ? WorkbenchPorcelain.hairline(for: colorScheme) : Color.clear,
-                        lineWidth: Theme.Card.hairlineWidth
-                    )
-            )
+        Row(isSelected: isSelected, isHovered: isHovered) { configuration.label }
             .opacity(configuration.isPressed ? 0.72 : 1)
     }
 
-    private var backgroundFill: Color {
-        if isSelected { return WorkbenchPorcelain.selectedNavigationFill(for: colorScheme) }
-        if isHovered { return WorkbenchPorcelain.hoverFill(for: colorScheme) }
-        return .clear
+    /// A nested view rather than the style itself, because `isFocused` is an
+    /// environment value and a `ButtonStyle` has no body to read it from.
+    /// The focused hairline replaces the system focus ring the window
+    /// switches off; it sits over the row's selected/hovered fill, and being
+    /// the app accent rather than the porcelain hairline it stays legible on
+    /// a selected row.
+    private struct Row<Label: View>: View {
+        let isSelected: Bool
+        let isHovered: Bool
+        @ViewBuilder let label: Label
+
+        @Environment(\.colorScheme) private var colorScheme
+        @Environment(\.isFocused) private var isFocused
+
+        var body: some View {
+            label
+                .background(
+                    RoundedRectangle(cornerRadius: 9, style: .continuous)
+                        .fill(backgroundFill)
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: 9, style: .continuous)
+                        .strokeBorder(
+                            isFocused
+                                ? Color.accentColor
+                                : (isSelected ? WorkbenchPorcelain.hairline(for: colorScheme) : Color.clear),
+                            lineWidth: isFocused ? 1 : Theme.Card.hairlineWidth
+                        )
+                )
+        }
+
+        private var backgroundFill: Color {
+            if isSelected { return WorkbenchPorcelain.selectedNavigationFill(for: colorScheme) }
+            if isHovered { return WorkbenchPorcelain.hoverFill(for: colorScheme) }
+            return .clear
+        }
     }
 }
 
@@ -379,8 +403,8 @@ private struct WorkbenchHeaderIconButton: View {
                     )
                 )
         }
-        .buttonStyle(.plain)
-        .focusEffectDisabled()
+        // 14 pt on the 28 pt circle keeps the focus hairline circular.
+        .buttonStyle(.vibeBar(cornerRadius: 14))
         .onHover { isHovering = $0 }
         .help(help)
         .accessibilityLabel(help)

--- a/Tests/VibeBarCoreTests/KeyboardFocusPolicyTests.swift
+++ b/Tests/VibeBarCoreTests/KeyboardFocusPolicyTests.swift
@@ -1,0 +1,113 @@
+import XCTest
+
+/// Source-level checks for the keyboard focus policy in `VibeBarApp`.
+///
+/// The App target is an executable, so its views cannot be imported here;
+/// these tests read the sources instead. What they pin down:
+///
+/// 1. Every presentation — the two hosting roots plus every `.sheet` and
+///    `.popover` — opts into `vibeBarNoInitialFocus()`, so no surface opens
+///    with a control pre-selected. Adding a presentation without the policy
+///    breaks the count on purpose.
+/// 2. The policy clears only the initial responder. It must never reorder
+///    or rebuild the key-view loop, and never watch key-window changes —
+///    that is what keeps Tab/arrow navigation intact and keeps an app
+///    switch from erasing a text field the user is editing.
+/// 3. No product control opts out of keyboard navigation with
+///    `.focusable(false)`. Suppressing the system focus ring is the job of
+///    the container-level `vibeBarControlFocus()` plus the focus hairline
+///    in `VibeBarButtonStyle`, not of removing controls from the loop.
+final class KeyboardFocusPolicyTests: XCTestCase {
+    func testEveryPresentationOptsIntoTheInitialFocusPolicy() throws {
+        let sources = try appSources()
+
+        let presentationCount = sources.values.reduce(into: 0) { count, source in
+            count += source.numberOfOccurrences(of: ".sheet(isPresented")
+            count += source.numberOfOccurrences(of: ".popover(isPresented")
+        }
+
+        // The two AppKit hosting roots that can become key: the menu-bar
+        // popover and the Workbench window. The mini window's hosting root
+        // is deliberately absent — its panel is borderless and
+        // non-activating, so it never receives an initial responder.
+        let popoverHost = try XCTUnwrap(sources["StatusItemController.swift"])
+        let workbenchHost = try XCTUnwrap(sources["WorkbenchWindowController.swift"])
+        let miniWindowHost = try XCTUnwrap(sources["MiniQuotaWindowController.swift"])
+        XCTAssertEqual(popoverHost.numberOfOccurrences(of: ".vibeBarNoInitialFocus()"), 1)
+        XCTAssertEqual(workbenchHost.numberOfOccurrences(of: ".vibeBarNoInitialFocus()"), 1)
+        XCTAssertEqual(miniWindowHost.numberOfOccurrences(of: ".vibeBarNoInitialFocus()"), 0)
+        let hostingRootCount = 2
+
+        let policyCount = sources.values.reduce(0) {
+            $0 + $1.numberOfOccurrences(of: ".vibeBarNoInitialFocus()")
+        }
+
+        XCTAssertEqual(
+            policyCount,
+            presentationCount + hostingRootCount,
+            "Every hosting root, sheet, and popover must attach .vibeBarNoInitialFocus() "
+                + "to its content (and nothing else should)."
+        )
+    }
+
+    func testPolicyClearsOnlyTheResponderAndLeavesTraversalIntact() throws {
+        let sources = try appSources()
+        let source = try XCTUnwrap(sources["InitialFocusPolicy.swift"])
+
+        XCTAssertTrue(source.contains("makeFirstResponder(nil)"))
+        XCTAssertFalse(source.contains("initialFirstResponder"))
+        XCTAssertFalse(source.contains("nextKeyView"))
+        XCTAssertFalse(source.contains("didBecomeKeyNotification"))
+    }
+
+    func testNoProductControlOptsOutOfKeyboardNavigation() throws {
+        let root = try repoRoot().appendingPathComponent("Sources", isDirectory: true)
+        for (file, source) in try swiftSources(under: root) {
+            XCTAssertEqual(
+                source.numberOfOccurrences(of: ".focusable(false)"),
+                0,
+                "\(file) removes a control from keyboard navigation; use the "
+                    + "container-level vibeBarControlFocus() and VibeBarButtonStyle instead."
+            )
+        }
+    }
+
+    // MARK: - Source loading
+
+    private func appSources() throws -> [String: String] {
+        let root = try repoRoot().appendingPathComponent("Sources/VibeBarApp", isDirectory: true)
+        return try swiftSources(under: root)
+    }
+
+    private func swiftSources(under root: URL) throws -> [String: String] {
+        let files = try FileManager.default.subpathsOfDirectory(atPath: root.path)
+            .filter { $0.hasSuffix(".swift") }
+        XCTAssertFalse(files.isEmpty, "No Swift sources under \(root.path)")
+        return try Dictionary(uniqueKeysWithValues: files.map { relative in
+            let url = root.appendingPathComponent(relative)
+            return (url.lastPathComponent, try String(contentsOf: url, encoding: .utf8))
+        })
+    }
+
+    private func repoRoot() throws -> URL {
+        var dir = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
+        for _ in 0..<12 {
+            let candidate = dir.appendingPathComponent("Package.swift")
+            if FileManager.default.fileExists(atPath: candidate.path) {
+                return dir
+            }
+            dir.deleteLastPathComponent()
+        }
+        throw NSError(
+            domain: "KeyboardFocusPolicyTests",
+            code: 1,
+            userInfo: [NSLocalizedDescriptionKey: "Could not locate repo root from \(#filePath)"]
+        )
+    }
+}
+
+private extension String {
+    func numberOfOccurrences(of needle: String) -> Int {
+        components(separatedBy: needle).count - 1
+    }
+}


### PR DESCRIPTION
The app suppressed unwanted focus rings by destroying keyboard access: ten controls opted out with `.focusable(false)`, and the two `BorderlessIconButton` types (32 call sites) were tap gestures that neither Tab nor VoiceOver could ever activate. Meanwhile every popover and window still opened with macOS's default first-responder pick — the ring nobody clicked for — which is what the suppression was trying to hide (a `makeFirstResponder(nil)` fix existed, but only on the demo screenshot path).

This PR separates the two concerns the old code conflated: *who* has focus when a surface opens, and *how* focus looks once the user asks for it.

## Neutral initial focus
`InitialFocusPolicy.swift` adds a zero-area probe that clears the first responder once per presentation (two main-queue hops after the window becomes key, one-shot per presentation token). The key-view loop is untouched — Tab and arrow keys enter navigation normally — and the policy deliberately never observes key-window changes, so app-switching cannot erase a text field being edited. Attached via `.vibeBarNoInitialFocus()` at both hosting roots (menu-bar popover, Workbench window) and all eight nested sheets/popovers; the demo-only `makeFirstResponder(nil)` special case is deleted, since the policy now covers production and demo alike. The mini window's borderless non-activating panel never becomes key, so it opts out by construction.

## Visible focus, app-drawn
`ControlFocus.swift` adds `VibeBarButtonStyle(cornerRadius:)`, which draws a 1 pt accent hairline on whichever control actually has keyboard focus, plus a container-level `vibeBarControlFocus()` (`focusEffectDisabled()`) applied once per surface so the system ring stays off without each control opting out individually. Native-control regions (Settings forms, text fields) restore the system ring locally with `vibeBarSystemControlFocus()`. All ten `.focusable(false)` sites are gone, both borderless-button types are real `Button`s now (fixing VoiceOver activation too), and `WorkbenchSidebarRowStyle` gained a focused branch.

## Pinned by tests
`KeyboardFocusPolicyTests` reads the App sources and asserts: every hosting root, sheet, and popover carries the policy (count equality — adding a presentation without it fails); the policy file uses `makeFirstResponder(nil)` and none of the loop-rebuilding APIs; and `.focusable(false)` stays at zero across product code. The post-merge commit folds in the surfaces that landed via #227/#228 (the $/Tok switch, the two skills popovers) — caught by exactly these tests.

## Verification
- `swift build`, `swift test` (1645 passed), `./Scripts/build_app.sh release`, strict codesign with empty entitlements — all green.
- Demo-mode smoke runs of `popover:overview`, `workbench:skillsManager`, `mini:regular`, `settings:layout` render cleanly with no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
