### PR TITLE
Bump build number to 46 for the next Dev release

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.3.0</string>
 	<key>CFBundleVersion</key>
-	<string>45</string>
+	<string>46</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>26.0</string>
 	<key>LSUIElement</key>


### PR DESCRIPTION
Version-only PR for the next Dev prerelease, per RELEASING.md: `CFBundleShortVersionString` stays `1.3.0`, `CFBundleVersion` goes 45 → 46. After merge the release commit gets tagged `v1.3.0-dev.46`, which triggers the tag workflow (tests → signed build → ZIP + SHA-256 + Sparkle-signed dev appcast item → draft prerelease).

Carries to Dev: chart overflow/legend/token-view fixes (#227), skills wiring transparency (#228), keyboard navigation with neutral initial focus (#229).

Local validation on this commit: `swift build`, `swift test` (1645 passed), `./Scripts/build_app.sh release`, `codesign -d --entitlements` (empty `<dict/>`), `codesign --verify --deep --strict`, packaged bundle reads `1.3.0 (46)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)