### PR TITLE
Recover AntiGravity cost data with session-kit 0.6.2

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -163,7 +163,7 @@ there, not in the package.
 
 **Where it comes from.** `Package.swift` pins the package to an exact
 tag on GitHub (`.package(url: "https://github.com/AstroQore/agent-session-kit.git",
-exact: "0.6.1")`), so a plain clone builds and a release build resolves the
+exact: "0.6.2")`), so a plain clone builds and a release build resolves the
 same package the developer built against — `Package.resolved` is
 gitignored here, and the exact pin is what stands in for it.
 

--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
         // from a clean checkout with no Package.resolved (it is gitignored),
         // so the pin is the only thing that makes two builds of the same
         // Vibe Bar commit contain the same package. Bump it deliberately.
-        .package(url: "https://github.com/AstroQore/agent-session-kit.git", exact: "0.6.1"),
+        .package(url: "https://github.com/AstroQore/agent-session-kit.git", exact: "0.6.2"),
         // SweetCookieKit encapsulates Chromium cookie + localStorage parsing,
         // "Chrome Safe Storage" Keychain decryption, and Safari
         // binarycookies / Firefox SQLite reads used by misc providers.

--- a/Sources/VibeBarCore/Services/CostUsageScanner.swift
+++ b/Sources/VibeBarCore/Services/CostUsageScanner.swift
@@ -982,7 +982,15 @@ public enum CostUsageScanner {
     /// `model_enum`) instead of grouping every routed field-19 alias such as
     /// `gemini-default`. The scan cache keeps this independent of its global
     /// schema so only `.db` events are reparsed once; `.pb` RPC events survive.
-    private static let antigravityDBParserVersion = 2
+    ///
+    /// v3 re-parses for agent-session-kit 0.6.2: agy CLI ~1.1.18 moved the
+    /// per-turn wall clock to a relative offset, and stores scanned while the
+    /// reader only understood the absolute form were cached as empty. The
+    /// reader now resolves offset turns against the trajectory's own start
+    /// time, so one re-parse recovers the usage those caches dropped.
+    /// Internal (not private) so the migration tests assert against the
+    /// constant itself instead of a literal that goes stale on every bump.
+    static let antigravityDBParserVersion = 3
 
     private static func scanAntigravity(
         homeDirectory: String,

--- a/Sources/VibeBarCore/Services/UsageEventLedger.swift
+++ b/Sources/VibeBarCore/Services/UsageEventLedger.swift
@@ -90,6 +90,9 @@ public actor UsageEventLedger: CostUsageEventSink {
     /// Undoes the first harness rule, which read `originator == "Codex Desktop"`
     /// as ChatGPT Work. See `migrateCodexDesktopHarnessRows`.
     static let codexHarnessFixupKey = "harness_v2"
+    /// One-time re-ingest for the AntiGravity relative-clock recovery. See
+    /// `migrateAntigravityRelativeClockReingest`.
+    static let antigravityReclockKey = "antigravity_reclock_v1"
     private static let pricingRevisionKey = "pricing_revision"
     /// Row count at the last `ANALYZE`. See `refreshStatisticsIfStale`.
     private static let analyzeRowCountKey = "analyze_rows"
@@ -252,6 +255,9 @@ public actor UsageEventLedger: CostUsageEventSink {
             throw UsageLedgerError.open
         }
         guard Self.migrateCursorToolRows(database) else {
+            throw UsageLedgerError.open
+        }
+        guard Self.migrateAntigravityRelativeClockReingest(database) else {
             throw UsageLedgerError.open
         }
         var statement: OpaquePointer?
@@ -495,6 +501,54 @@ public actor UsageEventLedger: CostUsageEventSink {
             -1, &insertMarker, nil
         ) == SQLITE_OK, let insertMarker else { return rollback() }
         sqlite3_bind_text(insertMarker, 1, codexHarnessFixupKey, -1, transient)
+        let markerResult = sqlite3_step(insertMarker)
+        sqlite3_finalize(insertMarker)
+        guard markerResult == SQLITE_DONE,
+              sqlite3_exec(database, "COMMIT", nil, nil, nil) == SQLITE_OK
+        else { return rollback() }
+        return true
+    }
+
+    /// AntiGravity stores scanned while the reader only understood absolute
+    /// wall clocks (agent-session-kit <= 0.6.1, agy >= ~1.1.18 stores) emitted
+    /// *empty* batches, and `ingest` recorded their fingerprints anyway. The
+    /// scanner's parser-version bump makes those databases re-parse — but a
+    /// re-emitted batch with an unchanged fingerprint short-circuits at the
+    /// top of `ingest`, so the recovered request rows would never reach this
+    /// ledger. Drop AntiGravity's ingest fingerprints once; rows that do
+    /// exist survive and update in place on `dedupe_key`.
+    @discardableResult
+    static func migrateAntigravityRelativeClockReingest(_ database: OpaquePointer) -> Bool {
+        let transient = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
+        var marker: OpaquePointer?
+        guard sqlite3_prepare_v2(
+            database, "SELECT 1 FROM ledger_meta WHERE key = ?", -1, &marker, nil
+        ) == SQLITE_OK, let marker else { return false }
+        sqlite3_bind_text(marker, 1, antigravityReclockKey, -1, transient)
+        let alreadyMigrated = sqlite3_step(marker) == SQLITE_ROW
+        sqlite3_finalize(marker)
+        if alreadyMigrated { return true }
+
+        guard sqlite3_exec(database, "BEGIN IMMEDIATE", nil, nil, nil) == SQLITE_OK else {
+            return false
+        }
+        func rollback() -> Bool {
+            sqlite3_exec(database, "ROLLBACK", nil, nil, nil)
+            return false
+        }
+        guard sqlite3_exec(
+            database,
+            "DELETE FROM ingested_files WHERE tool = '\(ToolType.antigravity.rawValue)'",
+            nil, nil, nil
+        ) == SQLITE_OK else { return rollback() }
+
+        var insertMarker: OpaquePointer?
+        guard sqlite3_prepare_v2(
+            database,
+            "INSERT INTO ledger_meta(key, value) VALUES(?, '1') ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+            -1, &insertMarker, nil
+        ) == SQLITE_OK, let insertMarker else { return rollback() }
+        sqlite3_bind_text(insertMarker, 1, antigravityReclockKey, -1, transient)
         let markerResult = sqlite3_step(insertMarker)
         sqlite3_finalize(insertMarker)
         guard markerResult == SQLITE_DONE,

--- a/Tests/VibeBarCoreTests/AntigravityCostScannerTests.swift
+++ b/Tests/VibeBarCoreTests/AntigravityCostScannerTests.swift
@@ -553,7 +553,10 @@ final class AntigravityCostScannerTests: XCTestCase {
         )
 
         XCTAssertEqual(snap.modelBreakdowns.map(\.modelName), ["Gemini 3.5 Flash (High)"])
-        XCTAssertEqual(migratedCache.antigravityDBParserVersion, 2)
+        XCTAssertEqual(
+            migratedCache.antigravityDBParserVersion,
+            CostUsageScanner.antigravityDBParserVersion
+        )
     }
 
     func testModelParserMigrationRetriesDatabaseAfterTemporaryReadFailure() async throws {
@@ -627,7 +630,7 @@ final class AntigravityCostScannerTests: XCTestCase {
         XCTAssertEqual(
             CostUsageScanCache.load(homeDirectory: home.path, tool: .antigravity)
                 .antigravityDBParserVersion,
-            2
+            CostUsageScanner.antigravityDBParserVersion
         )
     }
 

--- a/Tests/VibeBarCoreTests/UsageEventLedgerTests.swift
+++ b/Tests/VibeBarCoreTests/UsageEventLedgerTests.swift
@@ -220,6 +220,63 @@ final class UsageEventLedgerTests: XCTestCase {
         XCTAssertEqual(sqlite3_step(query), SQLITE_DONE)
     }
 
+    /// The relative-clock recovery re-parses AntiGravity databases that were
+    /// cached as empty — but their fingerprints were recorded by the empty
+    /// ingest, so without this migration the recovered batches would
+    /// short-circuit. It drops exactly AntiGravity's fingerprints, once.
+    func testAntigravityReclockMigrationDropsOnlyAntigravityFingerprints() throws {
+        var database: OpaquePointer?
+        XCTAssertEqual(sqlite3_open(":memory:", &database), SQLITE_OK)
+        let db = try XCTUnwrap(database)
+        defer { sqlite3_close_v2(db) }
+        XCTAssertEqual(sqlite3_exec(db, """
+            CREATE TABLE ledger_meta(key TEXT PRIMARY KEY, value TEXT);
+            CREATE TABLE ingested_files(
+                tool TEXT NOT NULL,
+                file_key TEXT NOT NULL,
+                mtime REAL NOT NULL,
+                size INTEGER NOT NULL,
+                PRIMARY KEY(tool, file_key)
+            );
+            INSERT INTO ingested_files VALUES('antigravity', 'conv-a.db', 1.0, 10);
+            INSERT INTO ingested_files VALUES('antigravity', 'conv-b.db', 2.0, 20);
+            INSERT INTO ingested_files VALUES('codex', 'rollout.jsonl', 3.0, 30);
+            """, nil, nil, nil), SQLITE_OK)
+
+        XCTAssertTrue(UsageEventLedger.migrateAntigravityRelativeClockReingest(db))
+
+        var statement: OpaquePointer?
+        XCTAssertEqual(sqlite3_prepare_v2(
+            db, "SELECT tool FROM ingested_files ORDER BY tool", -1, &statement, nil
+        ), SQLITE_OK)
+        let query = try XCTUnwrap(statement)
+        defer { sqlite3_finalize(query) }
+        var tools: [String] = []
+        while sqlite3_step(query) == SQLITE_ROW {
+            tools.append(String(cString: sqlite3_column_text(query, 0)))
+        }
+        XCTAssertEqual(tools, ["codex"])
+
+        // Second run is a marker-guarded no-op: a fingerprint recorded after
+        // the migration must survive later launches.
+        XCTAssertEqual(sqlite3_exec(
+            db,
+            "INSERT INTO ingested_files VALUES('antigravity', 'conv-c.db', 4.0, 40)",
+            nil, nil, nil
+        ), SQLITE_OK)
+        XCTAssertTrue(UsageEventLedger.migrateAntigravityRelativeClockReingest(db))
+        var recheck: OpaquePointer?
+        XCTAssertEqual(sqlite3_prepare_v2(
+            db,
+            "SELECT COUNT(*) FROM ingested_files WHERE tool = 'antigravity'",
+            -1, &recheck, nil
+        ), SQLITE_OK)
+        let countQuery = try XCTUnwrap(recheck)
+        defer { sqlite3_finalize(countQuery) }
+        XCTAssertEqual(sqlite3_step(countQuery), SQLITE_ROW)
+        XCTAssertEqual(sqlite3_column_int64(countQuery, 0), 1)
+    }
+
     /// A second batch carrying the same `(mtime, size)` fingerprint is
     /// skipped wholesale — proven by handing it *more* events than the
     /// first and watching the extra one never land.


### PR DESCRIPTION
## What

Companion to [agent-session-kit#11](https://github.com/AstroQore/agent-session-kit/pull/11) / release [0.6.2](https://github.com/AstroQore/agent-session-kit/releases/tag/0.6.2): agy CLI ~1.1.18 moved the per-turn wall clock from `gen_metadata` `1.9.4` to an elapsed-milliseconds offset (`1.9.10.1`, base in `trajectory_metadata_blob` path `2.1`), which flatlined the AntiGravity cost lane from 2026-08-19 (community sighting: junhoyeo/tokscale#1184).

- Pin bumped 0.6.1 → **0.6.2** (the reader now resolves offset turns itself — no scanner code changes needed).
- `antigravityDBParserVersion` 2 → **3**, so `.db` caches written as empty while the reader only understood absolute clocks re-parse once; opaque `.pb` RPC caches survive (existing mechanism).
- The two migration tests assert against the constant instead of a stale literal.
- AGENTS.md documented pin kept in step.

## Verification

- `swift build` clean; `swift test` — 1659 tests, 0 failures; `./Scripts/build_app.sh release` + `codesign -d --entitlements` (empty `<dict/>`) + strict deep verify OK.
- End-to-end: `CostUsageScanner.scan(tool: .antigravity, homeDirectory:)` against a fake home containing copies of two real 2026-08-28 stores (new format) bills **179,726 tokens / \$0.06 to the correct local day**; the same scan produced zero events on 0.6.1. A May–Jul store decodes unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)