### PR TITLE
Bump build number to 47 for the next Dev release

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.3.0</string>
 	<key>CFBundleVersion</key>
-	<string>46</string>
+	<string>47</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>26.0</string>
 	<key>LSUIElement</key>


### PR DESCRIPTION
Version PR for `v1.3.0-dev.47`: `CFBundleVersion` 46 → 47, user-facing version stays 1.3.0.

Ships everything merged since dev.46: multiple mini windows with seven display modes and the dynamic quota-field catalog (#231), agent-session-kit 0.6.1 (#232), and the AntiGravity relative-clock recovery — session-kit 0.6.2, scanner re-parse, ledger re-ingest (#233).

Full validation chain run locally: build, 1660 tests green, release packaging, empty entitlements, strict deep codesign.

🤖 Generated with [Claude Code](https://claude.com/claude-code)