### PR TITLE
Give mini-window names their hierarchy, densities, and hygiene

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -716,6 +716,27 @@ capture against § 8 before committing it — a screenshot is source content.
   Before merging UI work, exercise the surface it touches — scroll it,
   drag it, hover it — and treat any visible hitch as a blocker, not a
   follow-up.
+
+  The budgets that make "fluent" testable:
+
+  | Metric | Target | Blocker |
+  |--------|--------|---------|
+  | Hitch rate during interaction (Instruments "Animation Hitches", ms of hitch per second while scrolling/dragging/hovering the surface) | < 5 ms/s | ≥ 10 ms/s |
+  | Longest synchronous main-thread stall on an interaction path | ≤ 16 ms | ≥ 100 ms |
+  | Popover open, click → first frame from cached data | ≤ 100 ms | ≥ 250 ms |
+  | Workbench page switch / Settings section switch | ≤ 150 ms | ≥ 300 ms |
+  | Chart first paint at the largest retained dataset (30 d × hourly) | ≤ 100 ms | ≥ 250 ms |
+  | Hover / crosshair update on any chart | 1 frame (≤ 8.3 ms @ 120 Hz) | > 2 frames |
+  | Marks actually drawn per chart after downsampling | ≤ ~1 000 | unbounded raw series |
+  | Idle CPU, popover closed / mini windows open | < 0.5 % / < 2 % | sustained ≥ 5 % |
+  | Sustained settings-file write rate from any interaction | ≤ 1/s (debounced) | per-tick writes |
+
+  How to measure: demo mode (§ 6.5) makes every surface reproducible;
+  profile it with Instruments — *Animation Hitches* for the hitch rate,
+  *Time Profiler* for stalls — or, minimally, `sample VibeBar` during
+  the jank and Activity Monitor for idle CPU. When a budget cannot be
+  met, the PR says which one and why rather than shipping the hitch
+  silently.
 - **Swift package**, two targets: `VibeBarCore` (testable, pure) and
   `VibeBarApp` (AppKit/SwiftUI menu-bar app). Heavy logic lives in Core;
   UI glue in App.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -700,6 +700,22 @@ capture against § 8 before committing it — a screenshot is source content.
 
 ## 7. Code Conventions
 
+- **UI fluency is a requirement, not a nice-to-have.** Vibe Bar is a
+  glanceable utility that sits in the user's peripheral vision all day;
+  a stuttering popover, settings page, or chart is a bug on the same
+  level as a wrong number. Every change to an interactive surface must
+  keep interaction paths free of main-thread stalls: no file I/O,
+  scanning, or O(n·m) recomputation inside a SwiftUI `body` or a
+  binding getter; expensive derivations are computed once per data
+  change (cached, or moved into Core and memoized), not once per
+  render; charts downsample before drawing (`ChartSeriesPlanning`
+  exists for this); `TimelineView` timers stay scoped to visible leaf
+  surfaces; and a settings write fans out to every `$settings`
+  subscriber, so hot paths (drags, hovers, keystrokes) must debounce or
+  bypass `AppSettings` (see the mini-window geometry rule in § 11).
+  Before merging UI work, exercise the surface it touches — scroll it,
+  drag it, hover it — and treat any visible hitch as a blocker, not a
+  follow-up.
 - **Swift package**, two targets: `VibeBarCore` (testable, pure) and
   `VibeBarApp` (AppKit/SwiftUI menu-bar app). Heavy logic lives in Core;
   UI glue in App.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,14 @@ default to.
 These rules cause silent failures or public-repo accidents if
 ignored. The full reasoning and grep recipes live in `AGENTS.md`.
 
+0. **UI fluency is a requirement.** Any change to an interactive
+   surface (popover, Workbench, Settings, mini windows) must keep it
+   smooth: no heavy work in SwiftUI `body` or binding getters, cache
+   per-data-change derivations, downsample charts, scope `TimelineView`
+   timers, and never let hot paths write `AppSettings` per tick. A
+   visible hitch is a blocker, not a follow-up. See `AGENTS.md` § 7,
+   first bullet.
+
 1. **Real-home routing.** Any path under the user's real home
    (`~/.codex/`, `~/.claude/`, `~/.config/claude/`, `~/.vibebar/`,
    `~/.gemini/`) must resolve through `RealHomeDirectory`

--- a/Sources/VibeBarApp/AppEnvironment.swift
+++ b/Sources/VibeBarApp/AppEnvironment.swift
@@ -138,6 +138,19 @@ final class AppEnvironment: ObservableObject {
                 dailyActivity: snapshot.dailyHistory
             )
         }
+        // What the discovered-field registry must not forget: every field a
+        // mini window selects, and every field the user has named — shared
+        // or per-window. Anything else that vanishes from a provider's
+        // response was never the user's and drops on the next refresh.
+        service.registryKeepFieldIdsProvider = { [weak settingsStore] in
+            guard let mini = settingsStore?.settings.miniWindow else { return [] }
+            var keep = Set(mini.customLabels.keys)
+            for window in mini.windows {
+                keep.formUnion(window.fieldIds)
+                keep.formUnion(window.customLabels.keys)
+            }
+            return keep
+        }
 
         if isDemo {
             // No Keychain in demo mode. A web-sourced demo account stands in

--- a/Sources/VibeBarApp/AppEnvironment.swift
+++ b/Sources/VibeBarApp/AppEnvironment.swift
@@ -139,17 +139,20 @@ final class AppEnvironment: ObservableObject {
             )
         }
         // What the discovered-field registry must not forget: every field a
-        // mini window selects, and every field the user has named — shared
-        // or per-window. Anything else that vanishes from a provider's
-        // response was never the user's and drops on the next refresh.
-        service.registryKeepFieldIdsProvider = { [weak settingsStore] in
-            guard let mini = settingsStore?.settings.miniWindow else { return [] }
-            var keep = Set(mini.customLabels.keys)
+        // mini window selects, every field the user has named, and every
+        // *group* the user has named — shared or per-window. Anything else
+        // that vanishes from a provider's response was never the user's and
+        // drops on the next refresh.
+        service.registryKeepProvider = { [weak settingsStore] in
+            guard let mini = settingsStore?.settings.miniWindow else { return QuotaFieldKeepSet() }
+            var fieldIds = Set(mini.customLabels.keys)
+            var groupKeys = Set(mini.groupLabels.keys)
             for window in mini.windows {
-                keep.formUnion(window.fieldIds)
-                keep.formUnion(window.customLabels.keys)
+                fieldIds.formUnion(window.fieldIds)
+                fieldIds.formUnion(window.customLabels.keys)
+                groupKeys.formUnion(window.groupLabels.keys)
             }
-            return keep
+            return QuotaFieldKeepSet(fieldIds: fieldIds, groupKeys: groupKeys)
         }
 
         if isDemo {

--- a/Sources/VibeBarApp/MiniQuotaWindowController.swift
+++ b/Sources/VibeBarApp/MiniQuotaWindowController.swift
@@ -198,7 +198,7 @@ final class MiniQuotaWindowController: NSObject, NSWindowDelegate {
     /// in order, not sorted.
     static func sizingFingerprint(config: MiniWindowConfig, environment: AppEnvironment? = nil) -> String {
         let ids = visibleOrderedFieldIDs(config: config, environment: environment).joined(separator: ",")
-        return "\(config.displayMode.rawValue)|\(ids)"
+        return "\(config.displayMode.rawValue)|\(config.stripDensity.rawValue)|\(ids)"
     }
 
     // MARK: - Window delegate
@@ -400,7 +400,10 @@ final class MiniQuotaWindowController: NSObject, NSWindowDelegate {
             let size = MiniLedgerMetrics.size(entries: entries(config: config, environment: environment))
             return NSSize(width: size.width, height: size.height)
         case .strip:
-            let size = MiniStripMetrics.size(entries: entries(config: config, environment: environment))
+            let size = MiniStripMetrics.size(
+                entries: entries(config: config, environment: environment),
+                density: config.stripDensity
+            )
             return NSSize(width: size.width, height: size.height)
         case .tile:
             let size = MiniTileMetrics.size(entries: entries(config: config, environment: environment))

--- a/Sources/VibeBarApp/Views/MiniQuotaWindowView.swift
+++ b/Sources/VibeBarApp/Views/MiniQuotaWindowView.swift
@@ -1,6 +1,21 @@
 import SwiftUI
 import VibeBarCore
 
+/// Label resolution for one mini window: the window's own overrides win,
+/// the shared names second, catalog defaults last (at the call sites).
+struct MiniLabelContext {
+    let settings: MiniWindowSettings
+    let config: MiniWindowConfig?
+
+    func fieldLabel(_ fieldId: String) -> String? {
+        settings.resolvedFieldLabel(config: config, fieldId: fieldId)
+    }
+
+    func groupLabel(_ key: String) -> String? {
+        settings.resolvedGroupLabel(config: config, key: key)
+    }
+}
+
 struct MiniQuotaWindowView: View {
     /// Which `MiniWindowConfig` this panel renders. Every panel gets its own
     /// hosting view; the config is re-read from settings on each render so
@@ -35,7 +50,7 @@ struct MiniQuotaWindowView: View {
                 case .ledger:
                     MiniLedgerLayout(entries: miniEntries(config: config))
                 case .strip:
-                    MiniStripLayout(entries: miniEntries(config: config))
+                    MiniStripLayout(entries: miniEntries(config: config), density: config.stripDensity)
                 case .tile:
                     MiniTileLayout(entries: miniEntries(config: config))
                 case .focus:
@@ -74,7 +89,8 @@ struct MiniQuotaWindowView: View {
             displayMode: displayMode,
             orderedFieldIds: visibleOrderedFieldIds(config: config, contentByTool: contentByTool),
             contentByTool: contentByTool,
-            registry: quotaService.fieldRegistry
+            registry: quotaService.fieldRegistry,
+            labels: MiniLabelContext(settings: settingsStore.settings.miniWindow, config: config)
         )
         .padding(.horizontal, displayMode == .compact ? 8 : 14)
         .padding(.top, displayMode == .compact ? 16 : 22)
@@ -117,6 +133,7 @@ struct MiniQuotaWindowView: View {
         let selected = config.fieldIds
         let selectedFieldIds = Set(selected)
         let registry = quotaService.fieldRegistry
+        let labels = MiniLabelContext(settings: settingsStore.settings.miniWindow, config: config)
         var contentByTool: [ToolType: MiniToolContent] = [:]
         for tool in ToolType.dedicatedCardProviders {
             var cells: [MiniCell] = []
@@ -137,7 +154,7 @@ struct MiniQuotaWindowView: View {
                         tool: tool,
                         field: field,
                         bucket: liveBucket,
-                        customLabel: settingsStore.settings.miniWindow.customLabels[field.id]
+                        customLabel: labels.fieldLabel(field.id)
                     )
                 )
             }
@@ -146,6 +163,7 @@ struct MiniQuotaWindowView: View {
                 for: tool,
                 orderedFieldIds: selected,
                 registry: registry,
+                labels: labels,
                 excluding: selectedBucketIds
             )
             let content = MiniToolContent(primaryCells: cells, branchCells: branchCells)
@@ -167,6 +185,12 @@ struct MiniQuotaWindowView: View {
     }
 
     private func isBranchField(_ field: MenuBarFieldOption) -> Bool {
+        Self.isBranchStyleField(field)
+    }
+
+    /// Static classification shared with the Settings naming tree, which
+    /// needs the same grouped/flat answer without a live bucket in hand.
+    static func isBranchStyleField(_ field: MenuBarFieldOption) -> Bool {
         // Antigravity rows are branch-style because its four quota
         // lanes are split across the Gemini and Claude/GPT groups.
         // Gemini USED to be in this carve-out too — that
@@ -204,6 +228,7 @@ struct MiniQuotaWindowView: View {
         for tool: ToolType,
         orderedFieldIds: [String],
         registry: QuotaFieldRegistry,
+        labels: MiniLabelContext,
         excluding selectedBucketIds: Set<String>
     ) -> [MiniBranchCell] {
         guard let quota = environment.quota(for: tool) else { return [] }
@@ -219,7 +244,7 @@ struct MiniQuotaWindowView: View {
                 tool: tool,
                 field: field,
                 bucket: bucket,
-                customLabel: settingsStore.settings.miniWindow.customLabels[field.id]
+                customLabel: labels.fieldLabel(field.id)
             )
         }
     }
@@ -297,6 +322,7 @@ private struct MiniWindowProviderLayout: View {
     let orderedFieldIds: [String]
     let contentByTool: [ToolType: MiniToolContent]
     let registry: QuotaFieldRegistry
+    let labels: MiniLabelContext
 
     var body: some View {
         let groups = miniProductGroups(
@@ -316,11 +342,11 @@ private struct MiniWindowProviderLayout: View {
                 }
                 switch displayMode {
                 case .compact:
-                    MiniCompactL2GroupColumn(group: group)
+                    MiniCompactL2GroupColumn(group: group, labels: labels)
                 default:
                     // Only regular and compact reach this layout; the
                     // alternative modes render their own views.
-                    MiniCompanyGroupColumn(group: group)
+                    MiniCompanyGroupColumn(group: group, labels: labels)
                 }
             }
         }
@@ -614,13 +640,13 @@ private struct MiniBranchGroup: Identifiable {
 
 private func miniBranchGroups(
     from branchCells: [MiniBranchCell],
-    settings: MiniWindowSettings
+    labels: MiniLabelContext
 ) -> [MiniBranchGroup] {
     var groups: [MiniBranchGroup] = []
     var indexByKey: [String: Int] = [:]
     for cell in branchCells {
         let key = cell.groupKey
-        let title = miniGroupTitle(for: cell, settings: settings).trimmingCharacters(in: .whitespacesAndNewlines)
+        let title = miniGroupTitle(for: cell, labels: labels).trimmingCharacters(in: .whitespacesAndNewlines)
         guard !title.isEmpty else { continue }
         if let index = indexByKey[key] {
             groups[index].cells.append(cell)
@@ -632,45 +658,37 @@ private func miniBranchGroups(
     return groups
 }
 
-private func miniGroupTitle(for cell: MiniBranchCell, settings: MiniWindowSettings) -> String {
-    let custom = settings.groupLabels[cell.groupKey]?.trimmingCharacters(in: .whitespacesAndNewlines)
-    if let custom, !custom.isEmpty {
-        return custom
-    }
-    return cell.defaultGroupTitle
+private func miniGroupTitle(for cell: MiniBranchCell, labels: MiniLabelContext) -> String {
+    labels.groupLabel(cell.groupKey) ?? cell.defaultGroupTitle
 }
 
-private func miniSubProviderTitle(for member: MiniL2Member, settings: MiniWindowSettings) -> String {
+private func miniSubProviderTitle(for member: MiniL2Member, labels: MiniLabelContext) -> String {
     let key = MiniWindowGroupLabelCatalog.subProviderKey(
         tool: member.tool,
         name: member.subProviderName
     )
-    let custom = settings.groupLabels[key]?.trimmingCharacters(in: .whitespacesAndNewlines)
-    return custom.flatMap { $0.isEmpty ? nil : $0 } ?? member.subProviderName
+    return labels.groupLabel(key) ?? member.subProviderName
 }
 
 /// Heading for a SubProvider's primary (flat, ungrouped) buckets. Every
 /// entry resolves to a quota-group name — the SubProvider itself is printed
 /// one tier up by `MiniMemberStack`, so nothing here may name a product.
-/// Gemini Web has no L3 group at all (its buckets *are* "5 Hours" and
-/// "Weekly", AGENTS.md § 7.1), so it gets no heading rather than an invented
-/// one; Grok's single group is "Weekly Credits".
+/// Gemini Web's two anonymous buckets get the same "All Models" heading as
+/// the other headline groups: the row is reserved either way, and a blank
+/// there read as a rendering bug rather than a design choice.
 private func miniPrimaryGroupTitle(
     for tool: ToolType,
-    settings: MiniWindowSettings
+    labels: MiniLabelContext
 ) -> String? {
     let key: String
     switch tool {
     case .codex: key = "codex.all-models"
     case .claude: key = "claude.all-models"
+    case .gemini: key = "gemini.all-models"
     case .grok: key = "grok.all-models"
     default: return nil
     }
-    let custom = settings.groupLabels[key]?.trimmingCharacters(in: .whitespacesAndNewlines)
-    if let custom, !custom.isEmpty {
-        return custom
-    }
-    return MiniWindowGroupLabelCatalog.defaultLabel(for: key)
+    return labels.groupLabel(key) ?? MiniWindowGroupLabelCatalog.defaultLabel(for: key)
 }
 
 /// Renders one L1 company super-column in the regular (ring) layout: the
@@ -680,8 +698,7 @@ private func miniPrimaryGroupTitle(
 /// tiers read the same everywhere.
 private struct MiniCompanyGroupColumn: View {
     let group: MiniCompanyGroup
-
-    @EnvironmentObject var settingsStore: SettingsStore
+    let labels: MiniLabelContext
 
     var body: some View {
         VStack(alignment: .center, spacing: 7) {
@@ -702,10 +719,7 @@ private struct MiniCompanyGroupColumn: View {
                         MiniGroupDivider(height: 112)
                             .padding(.top, 4)
                     }
-                    MiniMemberStack(
-                        member: member,
-                        settings: settingsStore.settings.miniWindow
-                    )
+                    MiniMemberStack(member: member, labels: labels)
                 }
             }
         }
@@ -718,10 +732,7 @@ private struct MiniCompanyGroupColumn: View {
     private var totalContentWidth: CGFloat {
         var width: CGFloat = 0
         for member in group.members {
-            width += MiniMemberStack.width(
-                for: member,
-                settings: settingsStore.settings.miniWindow
-            )
+            width += MiniMemberStack.width(for: member, labels: labels)
         }
         if group.members.count > 1 {
             width += CGFloat(group.members.count - 1)
@@ -737,18 +748,18 @@ private struct MiniCompanyGroupColumn: View {
 /// names a quota group rather than a product.
 private struct MiniMemberStack: View {
     let member: MiniL2Member
-    let settings: MiniWindowSettings
+    let labels: MiniLabelContext
 
     var body: some View {
         VStack(alignment: .center, spacing: MiniRingMetrics.subProviderLabelGap) {
-            Text(miniSubProviderTitle(for: member, settings: settings).uppercased())
+            Text(miniSubProviderTitle(for: member, labels: labels).uppercased())
                 .font(.system(size: 8.5, weight: .semibold, design: .rounded))
                 .foregroundStyle(.secondary)
                 .tracking(1.2)
                 .lineLimit(1)
                 .minimumScaleFactor(0.6)
                 .frame(
-                    width: Self.width(for: member, settings: settings),
+                    width: Self.width(for: member, labels: labels),
                     height: MiniRingMetrics.subProviderLabelHeight,
                     alignment: .center
                 )
@@ -767,16 +778,16 @@ private struct MiniMemberStack: View {
     }
 
     private var branchGroups: [MiniBranchGroup] {
-        miniBranchGroups(from: member.content.branchCells, settings: settings)
+        miniBranchGroups(from: member.content.branchCells, labels: labels)
     }
 
     private var primaryGroupTitle: String? {
-        miniPrimaryGroupTitle(for: member.tool, settings: settings)
+        miniPrimaryGroupTitle(for: member.tool, labels: labels)
     }
 
     static func width(
         for member: MiniL2Member,
-        settings: MiniWindowSettings
+        labels: MiniLabelContext
     ) -> CGFloat {
         var width: CGFloat = 0
         var groupCount = 0
@@ -785,7 +796,7 @@ private struct MiniMemberStack: View {
                 + CGFloat(max(0, member.content.primaryCells.count - 1)) * MiniRingMetrics.ringSpacing
             groupCount += 1
         }
-        let branchGroups = miniBranchGroups(from: member.content.branchCells, settings: settings)
+        let branchGroups = miniBranchGroups(from: member.content.branchCells, labels: labels)
         for group in branchGroups {
             width += CGFloat(group.cells.count) * MiniRingMetrics.cellWidth
                 + CGFloat(max(0, group.cells.count - 1)) * MiniRingMetrics.ringSpacing
@@ -1153,8 +1164,7 @@ private enum MiniCompactMetrics {
 /// shorter compact panel.
 private struct MiniCompactL2GroupColumn: View {
     let group: MiniCompanyGroup
-
-    @EnvironmentObject var settingsStore: SettingsStore
+    let labels: MiniLabelContext
 
     var body: some View {
         VStack(alignment: .center, spacing: 5) {
@@ -1175,10 +1185,7 @@ private struct MiniCompactL2GroupColumn: View {
                         MiniGroupDivider(height: 98)
                             .padding(.top, 3)
                     }
-                    MiniCompactMemberStack(
-                        member: member,
-                        settings: settingsStore.settings.miniWindow
-                    )
+                    MiniCompactMemberStack(member: member, labels: labels)
                 }
             }
         }
@@ -1187,10 +1194,7 @@ private struct MiniCompactL2GroupColumn: View {
     private var totalContentWidth: CGFloat {
         var width: CGFloat = 0
         for member in group.members {
-            width += MiniCompactMemberStack.width(
-                for: member,
-                settings: settingsStore.settings.miniWindow
-            )
+            width += MiniCompactMemberStack.width(for: member, labels: labels)
         }
         if group.members.count > 1 {
             width += CGFloat(group.members.count - 1)
@@ -1202,18 +1206,18 @@ private struct MiniCompactL2GroupColumn: View {
 
 private struct MiniCompactMemberStack: View {
     let member: MiniL2Member
-    let settings: MiniWindowSettings
+    let labels: MiniLabelContext
 
     var body: some View {
         VStack(alignment: .center, spacing: MiniCompactMetrics.subProviderLabelGap) {
-            Text(miniSubProviderTitle(for: member, settings: settings).uppercased())
+            Text(miniSubProviderTitle(for: member, labels: labels).uppercased())
                 .font(.system(size: 7.5, weight: .semibold, design: .rounded))
                 .foregroundStyle(.secondary)
                 .tracking(1.2)
                 .lineLimit(1)
                 .minimumScaleFactor(0.55)
                 .frame(
-                    width: Self.width(for: member, settings: settings),
+                    width: Self.width(for: member, labels: labels),
                     height: MiniCompactMetrics.subProviderLabelHeight,
                     alignment: .center
                 )
@@ -1232,16 +1236,16 @@ private struct MiniCompactMemberStack: View {
     }
 
     private var branchGroups: [MiniBranchGroup] {
-        miniBranchGroups(from: member.content.branchCells, settings: settings)
+        miniBranchGroups(from: member.content.branchCells, labels: labels)
     }
 
     private var primaryGroupTitle: String? {
-        miniPrimaryGroupTitle(for: member.tool, settings: settings)
+        miniPrimaryGroupTitle(for: member.tool, labels: labels)
     }
 
     static func width(
         for member: MiniL2Member,
-        settings: MiniWindowSettings
+        labels: MiniLabelContext
     ) -> CGFloat {
         var width: CGFloat = 0
         var groupCount = 0
@@ -1250,7 +1254,7 @@ private struct MiniCompactMemberStack: View {
                 + CGFloat(max(0, member.content.primaryCells.count - 1)) * MiniCompactMetrics.ringSpacing
             groupCount += 1
         }
-        let branchGroups = miniBranchGroups(from: member.content.branchCells, settings: settings)
+        let branchGroups = miniBranchGroups(from: member.content.branchCells, labels: labels)
         for group in branchGroups {
             width += CGFloat(group.cells.count) * MiniCompactMetrics.cellWidth
                 + CGFloat(max(0, group.cells.count - 1)) * MiniCompactMetrics.ringSpacing

--- a/Sources/VibeBarApp/Views/MiniWindowAltLayouts.swift
+++ b/Sources/VibeBarApp/Views/MiniWindowAltLayouts.swift
@@ -19,25 +19,16 @@ struct MiniEntry: Identifiable {
 
     var id: String { field.id }
 
-    /// "5h" / "Wk" style shorthand for the bucket's window.
-    var windowShort: String {
-        switch bucket.title {
-        case "5 Hours": return "5h"
-        case "Weekly":  return "Wk"
-        case "Monthly": return "Mo"
-        case "Daily":   return "Day"
-        default:        return bucket.title
-        }
-    }
-
     /// Row label for list-style layouts: the custom label wins; otherwise a
-    /// grouped bucket reads "Spark · Wk" and a primary one reads its window.
+    /// grouped bucket reads "Spark · Weekly" and a primary one reads its
+    /// window. Never an invented abbreviation — "WK" is a name the user can
+    /// choose, not a default they get.
     var rowLabel: String {
         if let customLabel, !customLabel.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             return customLabel
         }
         if let groupLabel {
-            return "\(groupLabel) · \(windowShort)"
+            return "\(groupLabel) · \(bucket.title)"
         }
         return bucket.title
     }
@@ -64,25 +55,19 @@ struct MiniEntry: Identifiable {
             var groupLabel: String?
             if isGrouped {
                 let key = MiniWindowGroupLabelCatalog.groupKey(tool: field.tool, bucketId: field.bucketId)
-                let custom = settings.groupLabels[key]?.trimmingCharacters(in: .whitespacesAndNewlines)
-                if let custom, !custom.isEmpty {
-                    groupLabel = custom
-                } else if let catalogDefault = MiniWindowGroupLabelCatalog.defaultLabel(for: key) {
-                    groupLabel = catalogDefault
-                } else {
-                    groupLabel = bucket.groupTitle
-                }
+                groupLabel = settings.resolvedGroupLabel(config: config, key: key)
+                    ?? MiniWindowGroupLabelCatalog.defaultLabel(for: key)
+                    ?? bucket.groupTitle
             }
             let subProviderKey = MiniWindowGroupLabelCatalog.subProviderKey(tool: field.tool, name: subProviderName)
-            let customSub = settings.groupLabels[subProviderKey]?.trimmingCharacters(in: .whitespacesAndNewlines)
             return MiniEntry(
                 tool: field.tool,
                 field: field,
                 bucket: bucket,
-                subProviderName: (customSub?.isEmpty ?? true) ? subProviderName : customSub!,
+                subProviderName: settings.resolvedGroupLabel(config: config, key: subProviderKey) ?? subProviderName,
                 companyName: field.tool.vendorName,
                 groupLabel: groupLabel,
-                customLabel: settings.customLabels[field.id]
+                customLabel: settings.resolvedFieldLabel(config: config, fieldId: field.id)
             )
         }
     }
@@ -288,32 +273,60 @@ struct MiniLedgerLayout: View {
 // MARK: - Strip
 
 /// A one-line HUD: each SubProvider shows its most critical bucket only.
-/// Hovering a chip lists every selected bucket of that SubProvider.
+/// Hovering a chip lists every selected bucket of that SubProvider. Three
+/// densities, chosen per window: roomy (number beside its label), two-line
+/// (number over its label), narrow (dot and number only).
 enum MiniStripMetrics {
-    static let height: CGFloat = 44
-    static let chipWidth: CGFloat = 64
-    static let chipSpacing: CGFloat = 6
-    static let companySpacing: CGFloat = 9
     static let dividerThickness: CGFloat = 1
     static let leadingPadding: CGFloat = 14
     static let trailingPadding: CGFloat = 26
     static let emptyWidth: CGFloat = 200
 
-    static func size(entries: [MiniEntry]) -> CGSize {
-        guard !entries.isEmpty else { return CGSize(width: emptyWidth, height: height) }
+    static func chipWidth(_ density: MiniStripDensity) -> CGFloat {
+        switch density {
+        case .roomy:   return 104
+        case .twoLine: return 62
+        case .narrow:  return 40
+        }
+    }
+
+    static func chipSpacing(_ density: MiniStripDensity) -> CGFloat {
+        switch density {
+        case .roomy:   return 8
+        case .twoLine: return 6
+        case .narrow:  return 4
+        }
+    }
+
+    static func companySpacing(_ density: MiniStripDensity) -> CGFloat {
+        density == .narrow ? 7 : 9
+    }
+
+    static func height(_ density: MiniStripDensity) -> CGFloat {
+        switch density {
+        case .roomy:   return 44
+        case .twoLine: return 54
+        case .narrow:  return 40
+        }
+    }
+
+    static func size(entries: [MiniEntry], density: MiniStripDensity) -> CGSize {
+        guard !entries.isEmpty else { return CGSize(width: emptyWidth, height: height(density)) }
         let companies = MiniEntry.companyRuns(entries)
         var width = leadingPadding + trailingPadding
         for (index, company) in companies.enumerated() {
-            if index > 0 { width += 2 * companySpacing + dividerThickness }
+            if index > 0 { width += 2 * companySpacing(density) + dividerThickness }
             let chips = MiniEntry.subProviderRuns(company).count
-            width += CGFloat(chips) * chipWidth + CGFloat(max(0, chips - 1)) * chipSpacing
+            width += CGFloat(chips) * chipWidth(density)
+                + CGFloat(max(0, chips - 1)) * chipSpacing(density)
         }
-        return CGSize(width: width, height: height)
+        return CGSize(width: width, height: height(density))
     }
 }
 
 struct MiniStripLayout: View {
     let entries: [MiniEntry]
+    let density: MiniStripDensity
 
     @EnvironmentObject var settingsStore: SettingsStore
 
@@ -330,9 +343,9 @@ struct MiniStripLayout: View {
                             Rectangle()
                                 .fill(Color.primary.opacity(0.12))
                                 .frame(width: MiniStripMetrics.dividerThickness, height: 18)
-                                .padding(.horizontal, MiniStripMetrics.companySpacing)
+                                .padding(.horizontal, MiniStripMetrics.companySpacing(density))
                         }
-                        HStack(spacing: MiniStripMetrics.chipSpacing) {
+                        HStack(spacing: MiniStripMetrics.chipSpacing(density)) {
                             ForEach(Array(MiniEntry.subProviderRuns(company).enumerated()), id: \.offset) { _, run in
                                 chip(for: run)
                             }
@@ -343,36 +356,64 @@ struct MiniStripLayout: View {
                 .padding(.trailing, MiniStripMetrics.trailingPadding)
             }
         }
-        .frame(height: MiniStripMetrics.height)
+        .frame(height: MiniStripMetrics.height(density))
     }
 
     /// The chip shows the run's most critical bucket — least remaining wins.
+    @ViewBuilder
     private func chip(for run: [MiniEntry]) -> some View {
         let mode = settingsStore.displayMode
         let worst = run.min { remainingPercent($0) < remainingPercent($1) } ?? run[0]
         let percent = entryPercent(worst, mode: mode)
         let color = entryColor(worst, mode: mode)
-        let unit: String = {
-            if let group = worst.groupLabel {
-                return "\(group) \(worst.windowShort)"
+        Group {
+            switch density {
+            case .roomy:
+                HStack(spacing: 5) {
+                    brandDot(worst)
+                    number(percent, color: color, size: 13)
+                    Text(worst.rowLabel)
+                        .font(.system(size: 8.5, weight: .medium, design: .rounded))
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.6)
+                }
+                .frame(width: MiniStripMetrics.chipWidth(density), alignment: .leading)
+            case .twoLine:
+                VStack(spacing: 1) {
+                    HStack(spacing: 4) {
+                        brandDot(worst)
+                        number(percent, color: color, size: 13)
+                    }
+                    Text(worst.rowLabel)
+                        .font(.system(size: 8, weight: .medium, design: .rounded))
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.6)
+                        .frame(maxWidth: .infinity)
+                }
+                .frame(width: MiniStripMetrics.chipWidth(density))
+            case .narrow:
+                HStack(spacing: 4) {
+                    brandDot(worst)
+                    number(percent, color: color, size: 12)
+                }
+                .frame(width: MiniStripMetrics.chipWidth(density), alignment: .leading)
             }
-            return worst.windowShort
-        }()
-        return HStack(spacing: 4) {
-            Circle()
-                .fill(providerAccent(for: worst.tool))
-                .frame(width: 6, height: 6)
-            Text("\(Int(percent.rounded()))")
-                .font(.system(size: 13, weight: .bold, design: .rounded).monospacedDigit())
-                .foregroundStyle(color)
-            Text(unit.uppercased())
-                .font(.system(size: 7, weight: .semibold, design: .rounded))
-                .foregroundStyle(.secondary)
-                .lineLimit(1)
-                .minimumScaleFactor(0.6)
         }
-        .frame(width: MiniStripMetrics.chipWidth, alignment: .leading)
         .help(helpText(for: run))
+    }
+
+    private func brandDot(_ entry: MiniEntry) -> some View {
+        Circle()
+            .fill(providerAccent(for: entry.tool))
+            .frame(width: 6, height: 6)
+    }
+
+    private func number(_ percent: Double, color: Color, size: CGFloat) -> some View {
+        Text("\(Int(percent.rounded()))")
+            .font(.system(size: size, weight: .bold, design: .rounded).monospacedDigit())
+            .foregroundStyle(color)
     }
 
     private func helpText(for run: [MiniEntry]) -> String {
@@ -738,13 +779,8 @@ struct MiniRailLayout: View {
         .help("\(providerTitle(for: item.entry.tool)) · \(item.entry.rowLabel) — resets \(item.entry.bucket.resetAt.map { ResetCountdownFormatter.string(from: $0, now: Date()) ?? "—" } ?? "—")")
     }
 
-    /// Compact on purpose — a custom label tuned for the ring layout can be
-    /// long, and the rail has 60 pt per bubble.
     private func bubbleLabel(_ entry: MiniEntry) -> String {
-        var parts = [shortCompany(entry.tool)]
-        if let group = entry.groupLabel { parts.append(group) }
-        parts.append(entry.windowShort)
-        return parts.joined(separator: " ")
+        "\(shortCompany(entry.tool)) \(entry.rowLabel)"
     }
 
     /// Sort by reset time, then de-clutter: alternate between the two lanes

--- a/Sources/VibeBarApp/Views/MiniWindowAltLayouts.swift
+++ b/Sources/VibeBarApp/Views/MiniWindowAltLayouts.swift
@@ -10,7 +10,11 @@ struct MiniEntry: Identifiable {
     let tool: ToolType
     let field: MenuBarFieldOption
     let bucket: QuotaBucket
+    /// Canonical L2 identity (`ToolType.quotaSubProviderName`) — what runs
+    /// group by. Renaming two SubProviders identically must not merge them.
     let subProviderName: String
+    /// The resolved label a human sees; identity above, display here.
+    let subProviderDisplayName: String
     let companyName: String
     /// Resolved L3 quota-group label (custom name applied); nil for a primary
     /// bucket like Gemini Web's "5 Hours".
@@ -64,7 +68,8 @@ struct MiniEntry: Identifiable {
                 tool: field.tool,
                 field: field,
                 bucket: bucket,
-                subProviderName: settings.resolvedGroupLabel(config: config, key: subProviderKey) ?? subProviderName,
+                subProviderName: subProviderName,
+                subProviderDisplayName: settings.resolvedGroupLabel(config: config, key: subProviderKey) ?? subProviderName,
                 companyName: field.tool.vendorName,
                 groupLabel: groupLabel,
                 customLabel: settings.resolvedFieldLabel(config: config, fieldId: field.id)
@@ -223,7 +228,7 @@ struct MiniLedgerLayout: View {
             Circle()
                 .fill(providerAccent(for: entry.tool))
                 .frame(width: 5, height: 5)
-            Text("\(entry.companyName.uppercased()) · \(entry.subProviderName.uppercased())")
+            Text("\(entry.companyName.uppercased()) · \(entry.subProviderDisplayName.uppercased())")
                 .font(.system(size: 8.5, weight: .semibold, design: .rounded))
                 .foregroundStyle(.secondary)
                 .tracking(0.8)
@@ -266,7 +271,7 @@ struct MiniLedgerLayout: View {
                 .frame(width: 40, alignment: .trailing)
         }
         .frame(height: MiniLedgerMetrics.rowHeight)
-        .help("\(providerTitle(for: entry.tool)) · \(entry.bucket.groupTitle ?? entry.subProviderName) · \(entry.bucket.title)")
+        .help("\(providerTitle(for: entry.tool)) · \(entry.bucket.groupTitle ?? entry.subProviderDisplayName) · \(entry.bucket.title)")
     }
 }
 
@@ -421,7 +426,7 @@ struct MiniStripLayout: View {
         let lines = run.map { entry in
             "\(entry.rowLabel): \(Int(entryPercent(entry, mode: mode).rounded()))%"
         }
-        return "\(run[0].subProviderName) — \(lines.joined(separator: " · "))"
+        return "\(run[0].subProviderDisplayName) — \(lines.joined(separator: " · "))"
     }
 }
 
@@ -584,7 +589,7 @@ struct MiniFocusLayout: View {
                         .font(.system(size: 10, weight: .semibold, design: .rounded))
                         .foregroundStyle(.primary.opacity(0.86))
                 }
-                Text("\(headline.subProviderName.uppercased()) · \(headline.rowLabel.uppercased())")
+                Text("\(headline.subProviderDisplayName.uppercased()) · \(headline.rowLabel.uppercased())")
                     .font(.system(size: 8, weight: .semibold, design: .rounded))
                     .foregroundStyle(.secondary)
                     .tracking(1.2)

--- a/Sources/VibeBarApp/Views/MiniWindowGroupLabelCatalog.swift
+++ b/Sources/VibeBarApp/Views/MiniWindowGroupLabelCatalog.swift
@@ -18,6 +18,7 @@ enum MiniWindowGroupLabelCatalog {
         .init(id: "claude.opus", title: "CLAUDE · Opus", defaultLabel: "Opus"),
         .init(id: "claude.fable", title: "CLAUDE · Fable", defaultLabel: "Fable"),
         .init(id: "claude.oauth", title: "CLAUDE · OAuth", defaultLabel: "OAuth"),
+        .init(id: "gemini.all-models", title: "GEMINI WEB · All Models", defaultLabel: "All Models"),
         .init(id: "gemini.pro", title: "GEMINI · Pro", defaultLabel: "Pro"),
         .init(id: "gemini.flash", title: "GEMINI · Flash", defaultLabel: "Flash"),
         .init(id: "gemini.flash-lite", title: "GEMINI · Flash Lite", defaultLabel: "Lite"),

--- a/Sources/VibeBarApp/Views/MiniWindowsSettingsSection.swift
+++ b/Sources/VibeBarApp/Views/MiniWindowsSettingsSection.swift
@@ -20,6 +20,14 @@ struct MiniWindowsSettingsSection: View {
     @State private var selectedWindowID: UUID?
     @State private var arrangeFrames: [String: CGRect] = [:]
     @State private var drag: DragState?
+    /// Whether name edits below write the shared names or this window's
+    /// overrides. Overrides fall back to the shared name when empty.
+    @State private var namingScope: NamingScope = .shared
+
+    private enum NamingScope: Hashable {
+        case shared
+        case window
+    }
 
     private static let arrangeSpace = "vibebar.mini.arrange"
     private static let dragThreshold: CGFloat = 5
@@ -161,6 +169,20 @@ struct MiniWindowsSettingsSection: View {
         Text(config.displayMode.detail)
             .font(.caption)
             .foregroundStyle(.secondary)
+        if config.displayMode == .strip {
+            Picker("Strip density", selection: Binding(
+                get: { selectedWindow?.stripDensity ?? .roomy },
+                set: { value in update { $0.stripDensity = value } }
+            )) {
+                ForEach(MiniStripDensity.allCases) { density in
+                    Text(density.label).tag(density)
+                }
+            }
+            .pickerStyle(.segmented)
+            Text((selectedWindow?.stripDensity ?? .roomy).detail)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
 
         Text("Fields shown in “\(config.name)”. Buckets the adapters discover at runtime appear here automatically; a dimmed row is remembered but not in the account's current response.")
             .font(.caption)
@@ -230,10 +252,6 @@ struct MiniWindowsSettingsSection: View {
         let discovered: DiscoveredQuotaField?
         let isLive: Bool
         var id: String { option.id }
-        var isNew: Bool {
-            guard let discovered else { return false }
-            return Date().timeIntervalSince(discovered.firstSeen) < 14 * 86_400
-        }
     }
 
     private struct PickerSection: Identifiable {
@@ -301,19 +319,9 @@ struct MiniWindowsSettingsSection: View {
     private func pickerRow(_ entry: PickerEntry, config: MiniWindowConfig) -> some View {
         HStack(spacing: 10) {
             Toggle(isOn: fieldSelectedBinding(entry.option.id)) {
-                HStack(spacing: 6) {
-                    Text(entry.option.title)
-                        .font(.system(size: 12, weight: .medium))
-                        .lineLimit(2)
-                    if entry.isNew {
-                        Text("NEW")
-                            .font(.system(size: 8, weight: .bold, design: .rounded))
-                            .foregroundStyle(Color.black.opacity(0.8))
-                            .padding(.horizontal, 4)
-                            .padding(.vertical, 1)
-                            .background(Capsule().fill(Color.orange.opacity(0.85)))
-                    }
-                }
+                Text(entry.option.title)
+                    .font(.system(size: 12, weight: .medium))
+                    .lineLimit(2)
             }
             .help(entry.option.id)
             Spacer(minLength: 8)
@@ -322,14 +330,34 @@ struct MiniWindowsSettingsSection: View {
                     .font(.caption2)
                     .foregroundStyle(.tertiary)
                     .lineLimit(1)
+                if entry.discovered != nil {
+                    Button {
+                        forgetDiscoveredField(entry.option.id)
+                    } label: {
+                        Image(systemName: "xmark.circle")
+                            .font(.system(size: 10, weight: .semibold))
+                            .frame(width: 18, height: 18)
+                            .contentShape(Rectangle())
+                    }
+                    .buttonStyle(.vibeBar)
+                    .help("Forget this discovered bucket — drops it from the list and from every window that selected it.")
+                }
             }
-            DebouncedSettingsTextField(
-                prompt: entry.option.defaultLabel,
-                value: fieldLabelBinding(entry.option)
-            )
-            .frame(width: 110)
         }
         .opacity(entry.isLive ? 1 : 0.55)
+    }
+
+    /// Forget a discovered bucket the provider no longer returns: registry
+    /// entry, every window's selection of it, and any names it was given.
+    private func forgetDiscoveredField(_ fieldId: String) {
+        quotaService.forgetDiscoveredField(id: fieldId)
+        var settings = settingsStore.settings
+        settings.miniWindow.customLabels.removeValue(forKey: fieldId)
+        for index in settings.miniWindow.windows.indices {
+            settings.miniWindow.windows[index].fieldIds.removeAll { $0 == fieldId }
+            settings.miniWindow.windows[index].customLabels.removeValue(forKey: fieldId)
+        }
+        settingsStore.settings = settings
     }
 
     private func lastSeenCaption(_ entry: PickerEntry) -> String {
@@ -345,6 +373,11 @@ struct MiniWindowsSettingsSection: View {
         let option: MenuBarFieldOption
         let isLive: Bool
         var id: String { option.id }
+        /// "ChatGPT Agentic" / "Grok Bot" — the L2 the bucket bills against,
+        /// so ten rows named "Weekly" stop being interchangeable.
+        var subProviderName: String {
+            option.tool.quotaSubProviderName(bucketID: option.bucketId)
+        }
     }
 
     private func arrangeRows(_ config: MiniWindowConfig) -> [ArrangeRow] {
@@ -398,9 +431,15 @@ struct MiniWindowsSettingsSection: View {
                 .frame(width: 16, height: 20)
                 .contentShape(Rectangle())
                 .gesture(dragGesture(fieldID: row.id))
-            Circle()
-                .fill(Theme.providerAccent(for: row.option.tool))
-                .frame(width: 6, height: 6)
+            ToolBrandIconView(tool: row.option.tool, size: 12)
+                .opacity(0.9)
+            Text(row.subProviderName)
+                .font(.system(size: 10.5, weight: .semibold))
+                .foregroundStyle(Theme.providerAccent(for: row.option.tool))
+                .lineLimit(1)
+                .minimumScaleFactor(0.7)
+                .frame(maxWidth: 118, alignment: .leading)
+                .fixedSize(horizontal: true, vertical: false)
             Text(row.option.title)
                 .font(.system(size: 11.5, weight: .medium))
                 .lineLimit(1)
@@ -529,52 +568,255 @@ struct MiniWindowsSettingsSection: View {
         }
     }
 
-    // MARK: - Shared name editors
+    // MARK: - Names, as the hierarchy they belong to
+
+    /// One renamable thing in the L1 → L2 → L3 → bucket tree.
+    private struct NamingRow: Identifiable {
+        enum Kind {
+            case subProvider
+            case group
+            case field
+        }
+        let kind: Kind
+        /// `groupLabels` key for sub-providers and groups; field id for fields.
+        let key: String
+        let title: String
+        let defaultLabel: String
+        var id: String { key }
+        var indent: CGFloat {
+            switch kind {
+            case .subProvider: return 0
+            case .group: return 16
+            case .field: return 32
+            }
+        }
+    }
+
+    private struct NamingCompany: Identifiable {
+        let name: String
+        let tool: ToolType
+        var rows: [NamingRow]
+        var id: String { name }
+    }
+
+    /// The L3 group a field's gauge renders under, or nil for a bucket that
+    /// sits directly under its SubProvider (Grok Bot's single Weekly).
+    private static func namingGroupKey(for option: MenuBarFieldOption) -> String? {
+        if option.tool == .cursor {
+            if option.bucketId == "grok_bot_weekly" { return nil }
+            return MiniWindowGroupLabelCatalog.groupKey(tool: .cursor, bucketId: option.bucketId)
+        }
+        if MiniQuotaWindowView.isBranchStyleField(option) {
+            return MiniWindowGroupLabelCatalog.groupKey(tool: option.tool, bucketId: option.bucketId)
+        }
+        switch option.tool {
+        case .codex: return "codex.all-models"
+        case .claude: return "claude.all-models"
+        case .gemini: return "gemini.all-models"
+        case .grok: return "grok.all-models"
+        default: return nil
+        }
+    }
+
+    private func namingCompanies() -> [NamingCompany] {
+        let merged = MenuBarFieldCatalog.mergedFields(registry: quotaService.fieldRegistry)
+        var companies: [NamingCompany] = []
+        var companyIndex: [String: Int] = [:]
+        var seenSubKeys: Set<String> = []
+        var seenGroupKeys: Set<String> = []
+        for tool in ToolType.dedicatedCardProviders {
+            for option in merged where option.tool == tool {
+                let vendor = tool.vendorName
+                let company: Int
+                if let index = companyIndex[vendor] {
+                    company = index
+                } else {
+                    company = companies.count
+                    companyIndex[vendor] = company
+                    companies.append(NamingCompany(name: vendor, tool: tool, rows: []))
+                }
+                let subName = tool.quotaSubProviderName(bucketID: option.bucketId)
+                let subKey = MiniWindowGroupLabelCatalog.subProviderKey(tool: tool, name: subName)
+                if seenSubKeys.insert(subKey).inserted {
+                    companies[company].rows.append(NamingRow(
+                        kind: .subProvider, key: subKey, title: subName, defaultLabel: subName
+                    ))
+                }
+                if let groupKey = Self.namingGroupKey(for: option),
+                   seenGroupKeys.insert(groupKey).inserted {
+                    let fallback = option.dynamicGroupTitle
+                        ?? MenuBarFieldCatalog.bucketGroupStem(option.bucketId)
+                    let label = MiniWindowGroupLabelCatalog.defaultLabel(for: groupKey) ?? fallback
+                    companies[company].rows.append(NamingRow(
+                        kind: .group, key: groupKey, title: label, defaultLabel: label
+                    ))
+                }
+                companies[company].rows.append(NamingRow(
+                    kind: .field, key: option.id, title: option.title, defaultLabel: option.defaultLabel
+                ))
+            }
+        }
+        return companies
+    }
 
     @ViewBuilder
     private func sharedNameEditors() -> some View {
-        Text("SubProvider names:")
+        Text("Names")
             .font(.caption)
+            .fontWeight(.semibold)
             .foregroundStyle(.secondary)
-        VStack(alignment: .leading, spacing: 8) {
-            ForEach(MiniWindowGroupLabelCatalog.subProviderOptions) { option in
-                groupLabelRow(option)
-            }
+        HStack(spacing: 4) {
+            namingScopeButton(.shared, label: "All windows")
+            namingScopeButton(.window, label: "Only “\(selectedWindow?.name ?? "this window")”")
+            Spacer(minLength: 0)
         }
-        Text("Model group names:")
-            .font(.caption)
-            .foregroundStyle(.secondary)
-        VStack(alignment: .leading, spacing: 8) {
-            ForEach(groupLabelOptions) { option in
-                groupLabelRow(option)
+        .padding(3)
+        .background(Capsule(style: .continuous).fill(Color.primary.opacity(0.045)))
+        Text(
+            namingScope == .shared
+                ? "One tree, the levels quotas actually have: company → SubProvider → quota group → bucket. Names set here apply to every mini window."
+                : "Overrides for this window only. An empty field inherits the shared name — shown as the placeholder."
+        )
+        .font(.caption)
+        .foregroundStyle(.secondary)
+        .fixedSize(horizontal: false, vertical: true)
+        VStack(alignment: .leading, spacing: 10) {
+            ForEach(namingCompanies()) { company in
+                VStack(alignment: .leading, spacing: 5) {
+                    HStack(spacing: 6) {
+                        ToolBrandIconView(tool: company.tool, size: 13)
+                            .opacity(0.85)
+                        Text(company.name)
+                            .font(.caption)
+                            .fontWeight(.semibold)
+                            .foregroundStyle(.secondary)
+                            .textCase(.uppercase)
+                            .tracking(0.4)
+                    }
+                    ForEach(company.rows) { row in
+                        namingRow(row)
+                    }
+                }
             }
         }
     }
 
-    private var groupLabelOptions: [MiniWindowGroupLabelOption] {
-        var quotas: [ToolType: AccountQuota] = [:]
-        for tool in ToolType.dedicatedCardProviders {
-            if let quota = environment.quota(for: tool) { quotas[tool] = quota }
+    private func namingScopeButton(_ scope: NamingScope, label: String) -> some View {
+        let isSelected = namingScope == scope
+        return Button {
+            namingScope = scope
+        } label: {
+            Text(label)
+                .font(.system(size: 11, weight: .semibold, design: .rounded))
+                .foregroundStyle(isSelected ? Color.primary : Color.secondary)
+                .padding(.horizontal, 11)
+                .frame(height: 22)
+                .background {
+                    if isSelected {
+                        Capsule(style: .continuous)
+                            .fill(Color.accentColor.opacity(0.20))
+                            .overlay(
+                                Capsule(style: .continuous)
+                                    .stroke(Color.accentColor.opacity(0.34), lineWidth: 0.7)
+                            )
+                    }
+                }
+                .contentShape(Capsule(style: .continuous))
         }
-        return MiniWindowGroupLabelCatalog.options(liveQuotas: quotas)
+        .buttonStyle(.vibeBar(cornerRadius: 11))
     }
 
-    private func groupLabelRow(_ option: MiniWindowGroupLabelOption) -> some View {
-        HStack(spacing: 10) {
-            VStack(alignment: .leading, spacing: 2) {
-                Text(option.title)
-                    .font(.system(size: 12, weight: .medium))
-                Text(option.id)
-                    .font(.caption2)
-                    .foregroundStyle(.tertiary)
-            }
+    private func namingRow(_ row: NamingRow) -> some View {
+        HStack(spacing: 8) {
+            Text(row.title)
+                .font(.system(
+                    size: row.kind == .field ? 11.5 : 12,
+                    weight: row.kind == .field ? .regular : .medium
+                ))
+                .foregroundStyle(row.kind == .field ? Color.secondary : Color.primary)
+                .lineLimit(1)
+                .minimumScaleFactor(0.75)
             Spacer(minLength: 8)
             DebouncedSettingsTextField(
-                prompt: option.defaultLabel,
-                value: groupLabelBinding(option)
+                prompt: namingPrompt(row),
+                value: namingBinding(row)
             )
             .frame(width: 130)
         }
+        .padding(.leading, row.indent)
+        .help(row.key)
+    }
+
+    /// What an empty field falls back to — in window scope that is the shared
+    /// name when one is set, so the placeholder always shows what will render.
+    private func namingPrompt(_ row: NamingRow) -> String {
+        let shared: String?
+        switch row.kind {
+        case .field:
+            shared = settingsStore.settings.miniWindow.customLabels[row.key]
+        case .subProvider, .group:
+            shared = settingsStore.settings.miniWindow.groupLabels[row.key]
+        }
+        if namingScope == .window,
+           let trimmed = shared?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !trimmed.isEmpty {
+            return trimmed
+        }
+        return row.defaultLabel
+    }
+
+    private func namingBinding(_ row: NamingRow) -> Binding<String> {
+        Binding(
+            get: {
+                switch (namingScope, row.kind) {
+                case (.shared, .field):
+                    return settingsStore.settings.miniWindow.customLabels[row.key] ?? ""
+                case (.shared, _):
+                    return settingsStore.settings.miniWindow.groupLabels[row.key] ?? ""
+                case (.window, .field):
+                    return selectedWindow?.customLabels[row.key] ?? ""
+                case (.window, _):
+                    return selectedWindow?.groupLabels[row.key] ?? ""
+                }
+            },
+            set: { value in
+                let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+                switch namingScope {
+                case .shared:
+                    var mini = settingsStore.settings.miniWindow
+                    if row.kind == .field {
+                        if trimmed.isEmpty {
+                            mini.customLabels.removeValue(forKey: row.key)
+                        } else {
+                            mini.customLabels[row.key] = value
+                        }
+                    } else {
+                        if trimmed.isEmpty {
+                            mini.groupLabels.removeValue(forKey: row.key)
+                        } else {
+                            mini.groupLabels[row.key] = value
+                        }
+                    }
+                    settingsStore.settings.miniWindow = mini
+                case .window:
+                    update { config in
+                        if row.kind == .field {
+                            if trimmed.isEmpty {
+                                config.customLabels.removeValue(forKey: row.key)
+                            } else {
+                                config.customLabels[row.key] = value
+                            }
+                        } else {
+                            if trimmed.isEmpty {
+                                config.groupLabels.removeValue(forKey: row.key)
+                            } else {
+                                config.groupLabels[row.key] = value
+                            }
+                        }
+                    }
+                }
+            }
+        )
     }
 
     // MARK: - Bindings
@@ -621,35 +863,4 @@ struct MiniWindowsSettingsSection: View {
         }
     }
 
-    private func fieldLabelBinding(_ field: MenuBarFieldOption) -> Binding<String> {
-        Binding(
-            get: { settingsStore.settings.miniWindow.customLabels[field.id] ?? "" },
-            set: { value in
-                var mini = settingsStore.settings.miniWindow
-                let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
-                if trimmed.isEmpty {
-                    mini.customLabels.removeValue(forKey: field.id)
-                } else {
-                    mini.customLabels[field.id] = value
-                }
-                settingsStore.settings.miniWindow = mini
-            }
-        )
-    }
-
-    private func groupLabelBinding(_ option: MiniWindowGroupLabelOption) -> Binding<String> {
-        Binding(
-            get: { settingsStore.settings.miniWindow.groupLabels[option.id] ?? "" },
-            set: { value in
-                var mini = settingsStore.settings.miniWindow
-                let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
-                if trimmed.isEmpty {
-                    mini.groupLabels.removeValue(forKey: option.id)
-                } else {
-                    mini.groupLabels[option.id] = value
-                }
-                settingsStore.settings.miniWindow = mini
-            }
-        )
-    }
 }

--- a/Sources/VibeBarApp/Views/MiniWindowsSettingsSection.swift
+++ b/Sources/VibeBarApp/Views/MiniWindowsSettingsSection.swift
@@ -23,6 +23,15 @@ struct MiniWindowsSettingsSection: View {
     /// Whether name edits below write the shared names or this window's
     /// overrides. Overrides fall back to the shared name when empty.
     @State private var namingScope: NamingScope = .shared
+    /// Registry-derived structures are rebuilt when the registry changes,
+    /// never during a body render — a debounced name edit republishes
+    /// AppSettings and re-renders this whole section, and rebuilding the
+    /// merged catalog tree on each of those violates the fluency budget.
+    @State private var cachedCompanies: [NamingCompany] = []
+    @State private var cachedSections: [PickerSection] = []
+    @State private var mergedOptionsById: [String: MenuBarFieldOption] = [:]
+    /// Field ids whose bucket the live quota cache currently returns.
+    @State private var liveFieldIds: Set<String> = []
 
     private enum NamingScope: Hashable {
         case shared
@@ -60,6 +69,39 @@ struct MiniWindowsSettingsSection: View {
                 .padding(.vertical, 2)
             sharedNameEditors()
         }
+        .onAppear {
+            rebuildRegistryCaches()
+            rebuildLiveness()
+        }
+        .onChange(of: quotaService.fieldRegistry) { _, _ in
+            rebuildRegistryCaches()
+            rebuildLiveness()
+        }
+        .onReceive(quotaService.$lastSuccessByAccount) { _ in
+            rebuildLiveness()
+        }
+    }
+
+    private func rebuildRegistryCaches() {
+        cachedCompanies = namingCompanies()
+        cachedSections = pickerSections()
+        mergedOptionsById = Dictionary(
+            MenuBarFieldCatalog.mergedFields(registry: quotaService.fieldRegistry).map { ($0.id, $0) },
+            uniquingKeysWith: { first, _ in first }
+        )
+    }
+
+    private func rebuildLiveness() {
+        var quotas: [ToolType: AccountQuota] = [:]
+        for tool in ToolType.dedicatedCardProviders {
+            if let quota = environment.quota(for: tool) { quotas[tool] = quota }
+        }
+        var live: Set<String> = []
+        for option in mergedOptionsById.values
+        where quotas[option.tool]?.bucket(id: option.bucketId) != nil {
+            live.insert(option.id)
+        }
+        liveFieldIds = live
     }
 
     // MARK: - Window list
@@ -190,7 +232,7 @@ struct MiniWindowsSettingsSection: View {
             .fixedSize(horizontal: false, vertical: true)
         fieldPicker(config)
 
-        Text("Arrangement — drag to reorder. The order decides the layout: first field leftmost (or topmost).")
+        Text("Arrangement — grouped exactly as the window folds them (company → SubProvider). Drag a row to reorder; dragging across a group moves the field into it. First field renders leftmost (or topmost).")
             .font(.caption)
             .foregroundStyle(.secondary)
         arrangementList(config)
@@ -250,7 +292,6 @@ struct MiniWindowsSettingsSection: View {
     private struct PickerEntry: Identifiable {
         let option: MenuBarFieldOption
         let discovered: DiscoveredQuotaField?
-        let isLive: Bool
         var id: String { option.id }
     }
 
@@ -263,20 +304,11 @@ struct MiniWindowsSettingsSection: View {
 
     private func pickerSections() -> [PickerSection] {
         let registry = quotaService.fieldRegistry
-        var quotas: [ToolType: AccountQuota] = [:]
-        for tool in ToolType.dedicatedCardProviders {
-            if let quota = environment.quota(for: tool) { quotas[tool] = quota }
-        }
-        func isLive(_ option: MenuBarFieldOption) -> Bool {
-            quotas[option.tool]?.bucket(id: option.bucketId) != nil
-        }
         var sections = MiniWindowFieldProviderSection.all.map { section in
             PickerSection(
                 tool: section.tool,
                 title: section.title,
-                entries: section.fields.map {
-                    PickerEntry(option: $0, discovered: nil, isLive: isLive($0))
-                }
+                entries: section.fields.map { PickerEntry(option: $0, discovered: nil) }
             )
         }
         // Runtime-discovered fields join the first section of their tool. A
@@ -285,16 +317,14 @@ struct MiniWindowsSettingsSection: View {
         for discovered in registry.fields where MenuBarFieldCatalog.field(id: discovered.id) == nil {
             let option = MenuBarFieldCatalog.option(for: discovered)
             guard let index = sections.firstIndex(where: { $0.tool == discovered.tool }) else { continue }
-            sections[index].entries.append(
-                PickerEntry(option: option, discovered: discovered, isLive: isLive(option))
-            )
+            sections[index].entries.append(PickerEntry(option: option, discovered: discovered))
         }
         return sections
     }
 
     private func fieldPicker(_ config: MiniWindowConfig) -> some View {
         VStack(alignment: .leading, spacing: 12) {
-            ForEach(pickerSections()) { section in
+            ForEach(cachedSections) { section in
                 VStack(alignment: .leading, spacing: 8) {
                     HStack(spacing: 6) {
                         ToolBrandIconView(tool: section.tool, size: 13)
@@ -317,7 +347,8 @@ struct MiniWindowsSettingsSection: View {
     }
 
     private func pickerRow(_ entry: PickerEntry, config: MiniWindowConfig) -> some View {
-        HStack(spacing: 10) {
+        let isLive = liveFieldIds.contains(entry.option.id)
+        return HStack(spacing: 10) {
             Toggle(isOn: fieldSelectedBinding(entry.option.id)) {
                 Text(entry.option.title)
                     .font(.system(size: 12, weight: .medium))
@@ -325,7 +356,7 @@ struct MiniWindowsSettingsSection: View {
             }
             .help(entry.option.id)
             Spacer(minLength: 8)
-            if !entry.isLive {
+            if !isLive {
                 Text(lastSeenCaption(entry))
                     .font(.caption2)
                     .foregroundStyle(.tertiary)
@@ -344,7 +375,7 @@ struct MiniWindowsSettingsSection: View {
                 }
             }
         }
-        .opacity(entry.isLive ? 1 : 0.55)
+        .opacity(isLive ? 1 : 0.55)
     }
 
     /// Forget a discovered bucket the provider no longer returns: registry
@@ -371,28 +402,55 @@ struct MiniWindowsSettingsSection: View {
 
     private struct ArrangeRow: Identifiable {
         let option: MenuBarFieldOption
-        let isLive: Bool
         var id: String { option.id }
-        /// "ChatGPT Agentic" / "Grok Bot" — the L2 the bucket bills against,
-        /// so ten rows named "Weekly" stop being interchangeable.
+        /// Canonical L2 identity — what the tree groups by. Display names
+        /// come from the label chain at render time.
         var subProviderName: String {
             option.tool.quotaSubProviderName(bucketID: option.bucketId)
         }
     }
 
+    /// One consecutive run of fields billing the same SubProvider, under a
+    /// company header when the vendor changes — the same folding the mini
+    /// window itself performs, so the editor's grouping is the layout's.
+    private struct ArrangeGroup: Identifiable {
+        let companyName: String?
+        let tool: ToolType
+        let subProviderName: String
+        var rows: [ArrangeRow]
+        let firstIndex: Int
+        var id: String { "\(firstIndex)" }
+    }
+
     private func arrangeRows(_ config: MiniWindowConfig) -> [ArrangeRow] {
-        let registry = quotaService.fieldRegistry
-        var quotas: [ToolType: AccountQuota] = [:]
-        for tool in ToolType.dedicatedCardProviders {
-            if let quota = environment.quota(for: tool) { quotas[tool] = quota }
+        config.fieldIds.compactMap { fieldId in
+            mergedOptionsById[fieldId].map { ArrangeRow(option: $0) }
         }
-        return config.fieldIds.compactMap { fieldId in
-            guard let option = MenuBarFieldCatalog.field(id: fieldId, registry: registry) else { return nil }
-            return ArrangeRow(
-                option: option,
-                isLive: quotas[option.tool]?.bucket(id: option.bucketId) != nil
-            )
+    }
+
+    private func arrangeGroups(_ rows: [ArrangeRow]) -> [ArrangeGroup] {
+        var groups: [ArrangeGroup] = []
+        var index = 0
+        for row in rows {
+            let vendor = row.option.tool.vendorName
+            if var last = groups.last,
+               last.tool == row.option.tool,
+               last.subProviderName == row.subProviderName {
+                last.rows.append(row)
+                groups[groups.count - 1] = last
+            } else {
+                let previousVendor = groups.last?.tool.vendorName
+                groups.append(ArrangeGroup(
+                    companyName: vendor == previousVendor ? nil : vendor,
+                    tool: row.option.tool,
+                    subProviderName: row.subProviderName,
+                    rows: [row],
+                    firstIndex: index
+                ))
+            }
+            index += 1
         }
+        return groups
     }
 
     @ViewBuilder
@@ -403,11 +461,32 @@ struct MiniWindowsSettingsSection: View {
                 .font(.caption)
                 .foregroundStyle(.tertiary)
         } else {
+            let groups = arrangeGroups(rows)
             let insertion = insertionIndex(rows: rows)
-            VStack(spacing: 3) {
-                ForEach(Array(rows.enumerated()), id: \.element.id) { index, row in
-                    arrangeRowView(row, index: index, count: rows.count)
-                        .opacity(drag?.engaged == true && drag?.fieldID == row.id ? 0.3 : 1)
+            VStack(alignment: .leading, spacing: 3) {
+                ForEach(groups) { group in
+                    if let company = group.companyName {
+                        HStack(spacing: 6) {
+                            ToolBrandIconView(tool: group.tool, size: 12)
+                                .opacity(0.85)
+                            Text(company)
+                                .font(.caption2)
+                                .fontWeight(.semibold)
+                                .foregroundStyle(.secondary)
+                                .textCase(.uppercase)
+                                .tracking(0.4)
+                        }
+                        .padding(.top, group.firstIndex == 0 ? 0 : 5)
+                    }
+                    Text(subProviderDisplayName(group).uppercased())
+                        .font(.system(size: 8.5, weight: .semibold, design: .rounded))
+                        .foregroundStyle(.tertiary)
+                        .tracking(1.0)
+                        .padding(.leading, 16)
+                    ForEach(Array(group.rows.enumerated()), id: \.element.id) { offset, row in
+                        arrangeRowView(row, index: group.firstIndex + offset, count: rows.count)
+                            .opacity(drag?.engaged == true && drag?.fieldID == row.id ? 0.3 : 1)
+                    }
                 }
             }
             .coordinateSpace(.named(Self.arrangeSpace))
@@ -423,33 +502,40 @@ struct MiniWindowsSettingsSection: View {
         }
     }
 
+    private func subProviderDisplayName(_ group: ArrangeGroup) -> String {
+        let key = MiniWindowGroupLabelCatalog.subProviderKey(tool: group.tool, name: group.subProviderName)
+        return settingsStore.settings.miniWindow.resolvedGroupLabel(config: selectedWindow, key: key)
+            ?? group.subProviderName
+    }
+
     private func arrangeRowView(_ row: ArrangeRow, index: Int, count: Int) -> some View {
-        HStack(spacing: 8) {
+        let isLive = liveFieldIds.contains(row.id)
+        let percent = livePercent(row)
+        return HStack(spacing: 8) {
             Image(systemName: "line.3.horizontal")
                 .font(.system(size: 9, weight: .medium))
                 .foregroundStyle(.tertiary)
                 .frame(width: 16, height: 20)
                 .contentShape(Rectangle())
                 .gesture(dragGesture(fieldID: row.id))
-            ToolBrandIconView(tool: row.option.tool, size: 12)
-                .opacity(0.9)
-            Text(row.subProviderName)
-                .font(.system(size: 10.5, weight: .semibold))
-                .foregroundStyle(Theme.providerAccent(for: row.option.tool))
-                .lineLimit(1)
-                .minimumScaleFactor(0.7)
-                .frame(maxWidth: 118, alignment: .leading)
-                .fixedSize(horizontal: true, vertical: false)
+            Circle()
+                .fill(Theme.providerAccent(for: row.option.tool))
+                .frame(width: 6, height: 6)
             Text(row.option.title)
                 .font(.system(size: 11.5, weight: .medium))
                 .lineLimit(1)
                 .minimumScaleFactor(0.75)
-            if !row.isLive {
+            if !isLive {
                 Text("offline")
                     .font(.system(size: 8.5, weight: .semibold, design: .rounded))
                     .foregroundStyle(.tertiary)
             }
             Spacer(minLength: 6)
+            if let percent {
+                Text("\(Int(percent.rounded()))%")
+                    .font(.system(size: 10.5, weight: .bold, design: .rounded).monospacedDigit())
+                    .foregroundStyle(Theme.barColor(percent: percent, mode: settingsStore.displayMode))
+            }
             Button {
                 moveField(row.id, by: -1)
             } label: {
@@ -479,17 +565,26 @@ struct MiniWindowsSettingsSection: View {
             .help("Remove from this window")
         }
         .padding(.horizontal, 8)
+        .padding(.leading, 8)
         .frame(height: 26)
         .background(
             RoundedRectangle(cornerRadius: 6, style: .continuous)
-                .fill(Color.primary.opacity(row.isLive ? 0.05 : 0.03))
+                .fill(Color.primary.opacity(isLive ? 0.05 : 0.03))
+                .padding(.leading, 8)
         )
-        .opacity(row.isLive ? 1 : 0.6)
+        .opacity(isLive ? 1 : 0.6)
         .onGeometryChange(for: CGRect.self) { proxy in
             proxy.frame(in: .named(Self.arrangeSpace))
         } action: { frame in
             arrangeFrames[row.id] = frame
         }
+    }
+
+    private func livePercent(_ row: ArrangeRow) -> Double? {
+        guard liveFieldIds.contains(row.id),
+              let bucket = environment.quota(for: row.option.tool)?.bucket(id: row.option.bucketId)
+        else { return nil }
+        return bucket.displayPercent(settingsStore.displayMode, tool: row.option.tool)
     }
 
     private func dragGesture(fieldID: String) -> some Gesture {
@@ -681,7 +776,7 @@ struct MiniWindowsSettingsSection: View {
         .foregroundStyle(.secondary)
         .fixedSize(horizontal: false, vertical: true)
         VStack(alignment: .leading, spacing: 10) {
-            ForEach(namingCompanies()) { company in
+            ForEach(cachedCompanies) { company in
                 VStack(alignment: .leading, spacing: 5) {
                     HStack(spacing: 6) {
                         ToolBrandIconView(tool: company.tool, size: 13)
@@ -766,22 +861,28 @@ struct MiniWindowsSettingsSection: View {
     }
 
     private func namingBinding(_ row: NamingRow) -> Binding<String> {
-        Binding(
+        // Captured at construction: a debounced commit may fire after the
+        // user switches scope or window, and the draft belongs to the target
+        // it was typed for — same discipline as the window-name editor.
+        let scope = namingScope
+        let windowID = selectedWindow?.id
+        return Binding(
             get: {
-                switch (namingScope, row.kind) {
+                let mini = settingsStore.settings.miniWindow
+                switch (scope, row.kind) {
                 case (.shared, .field):
-                    return settingsStore.settings.miniWindow.customLabels[row.key] ?? ""
+                    return mini.customLabels[row.key] ?? ""
                 case (.shared, _):
-                    return settingsStore.settings.miniWindow.groupLabels[row.key] ?? ""
+                    return mini.groupLabels[row.key] ?? ""
                 case (.window, .field):
-                    return selectedWindow?.customLabels[row.key] ?? ""
+                    return windowID.flatMap { mini.config(id: $0)?.customLabels[row.key] } ?? ""
                 case (.window, _):
-                    return selectedWindow?.groupLabels[row.key] ?? ""
+                    return windowID.flatMap { mini.config(id: $0)?.groupLabels[row.key] } ?? ""
                 }
             },
             set: { value in
                 let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
-                switch namingScope {
+                switch scope {
                 case .shared:
                     var mini = settingsStore.settings.miniWindow
                     if row.kind == .field {
@@ -799,7 +900,8 @@ struct MiniWindowsSettingsSection: View {
                     }
                     settingsStore.settings.miniWindow = mini
                 case .window:
-                    update { config in
+                    guard let windowID else { return }
+                    update(id: windowID) { config in
                         if row.kind == .field {
                             if trimmed.isEmpty {
                                 config.customLabels.removeValue(forKey: row.key)

--- a/Sources/VibeBarCore/Models/AppSettings.swift
+++ b/Sources/VibeBarCore/Models/AppSettings.swift
@@ -1105,6 +1105,16 @@ public struct MiniWindowConfig: Codable, Equatable, Sendable, Identifiable {
     public var fieldIds: [String]
     /// Whether this window was open last time the app quit; restored on launch.
     public var wasOpen: Bool
+    /// Per-window overrides for field labels. Empty by default — a window
+    /// inherits the shared `MiniWindowSettings.customLabels`, and an entry
+    /// here wins over the shared name for this window only.
+    public var customLabels: [String: String]
+    /// Per-window overrides for SubProvider / quota-group labels, same
+    /// inheritance: window entry → shared `groupLabels` → catalog default.
+    public var groupLabels: [String: String]
+    /// Density of the strip layout — the one mode whose whole point is its
+    /// footprint, so it gets the menu-bar-style choice of three.
+    public var stripDensity: MiniStripDensity
 
     /// The id every pre-multi-window settings blob migrates onto. It must be
     /// deterministic: the migration runs on every decode until something
@@ -1117,17 +1127,23 @@ public struct MiniWindowConfig: Codable, Equatable, Sendable, Identifiable {
         name: String,
         displayMode: MiniWindowDisplayMode = .regular,
         fieldIds: [String],
-        wasOpen: Bool = false
+        wasOpen: Bool = false,
+        customLabels: [String: String] = [:],
+        groupLabels: [String: String] = [:],
+        stripDensity: MiniStripDensity = .roomy
     ) {
         self.id = id
         self.name = name
         self.displayMode = displayMode
         self.fieldIds = fieldIds
         self.wasOpen = wasOpen
+        self.customLabels = customLabels
+        self.groupLabels = groupLabels
+        self.stripDensity = stripDensity
     }
 
     private enum CodingKeys: String, CodingKey {
-        case id, name, displayMode, fieldIds, wasOpen
+        case id, name, displayMode, fieldIds, wasOpen, customLabels, groupLabels, stripDensity
     }
 
     public init(from decoder: Decoder) throws {
@@ -1141,6 +1157,35 @@ public struct MiniWindowConfig: Codable, Equatable, Sendable, Identifiable {
         let decoded = try c.decodeIfPresent([String].self, forKey: .fieldIds) ?? []
         self.fieldIds = MenuBarFieldCatalog.migratedFieldIds(decoded)
         self.wasOpen = try c.decodeIfPresent(Bool.self, forKey: .wasOpen) ?? false
+        self.customLabels = try c.decodeIfPresent([String: String].self, forKey: .customLabels) ?? [:]
+        self.groupLabels = try c.decodeIfPresent([String: String].self, forKey: .groupLabels) ?? [:]
+        self.stripDensity = (try? c.decodeIfPresent(MiniStripDensity.self, forKey: .stripDensity)) ?? .roomy
+    }
+}
+
+/// The strip layout's three footprints, mirroring the menu bar's density
+/// choice: one roomy line, a two-line stack, or the narrowest dot + number.
+public enum MiniStripDensity: String, Codable, CaseIterable, Identifiable, Sendable {
+    case roomy
+    case twoLine
+    case narrow
+
+    public var id: String { rawValue }
+
+    public var label: String {
+        switch self {
+        case .roomy:   return "Roomy"
+        case .twoLine: return "Two Lines"
+        case .narrow:  return "Narrow"
+        }
+    }
+
+    public var detail: String {
+        switch self {
+        case .roomy:   return "One line, full labels beside each number."
+        case .twoLine: return "Number over its label — narrower per bucket."
+        case .narrow:  return "Dot and number only; labels on hover."
+        }
     }
 }
 
@@ -1292,6 +1337,26 @@ public struct MiniWindowSettings: Codable, Equatable, Sendable {
         case .compact: return compactSelectedFieldIds
         default: return selectedFieldIds
         }
+    }
+
+    private static func trimmedNonEmpty(_ raw: String?) -> String? {
+        guard let value = raw?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !value.isEmpty
+        else { return nil }
+        return value
+    }
+
+    /// The custom field label one window shows: its own override first, the
+    /// shared name second, nil when neither is set.
+    public func resolvedFieldLabel(config: MiniWindowConfig?, fieldId: String) -> String? {
+        Self.trimmedNonEmpty(config?.customLabels[fieldId])
+            ?? Self.trimmedNonEmpty(customLabels[fieldId])
+    }
+
+    /// Same inheritance for SubProvider and quota-group labels.
+    public func resolvedGroupLabel(config: MiniWindowConfig?, key: String) -> String? {
+        Self.trimmedNonEmpty(config?.groupLabels[key])
+            ?? Self.trimmedNonEmpty(groupLabels[key])
     }
 
     public mutating func setFieldIds(_ ids: [String], for mode: MiniWindowDisplayMode) {

--- a/Sources/VibeBarCore/Models/QuotaFieldRegistry.swift
+++ b/Sources/VibeBarCore/Models/QuotaFieldRegistry.swift
@@ -117,6 +117,34 @@ public struct QuotaFieldRegistry: Codable, Equatable, Sendable {
     public func isLive(_ field: DiscoveredQuotaField, in quotas: [ToolType: AccountQuota]) -> Bool {
         quotas[field.tool]?.bucket(id: field.bucketId) != nil
     }
+
+    /// Forget `tool`'s entries the provider stopped returning that nothing
+    /// references — not selected in any mini window and never given a name.
+    /// A referenced entry stays (dimmed in the picker) so a selection
+    /// survives a provider hiccup; an unreferenced one was never the user's
+    /// and does not need remembering. Returns true when anything dropped.
+    @discardableResult
+    public mutating func prune(
+        tool: ToolType,
+        liveBucketIds: Set<String>,
+        keeping referencedFieldIds: Set<String>
+    ) -> Bool {
+        let before = fields.count
+        fields.removeAll { field in
+            field.tool == tool
+                && !liveBucketIds.contains(field.bucketId)
+                && !referencedFieldIds.contains(field.id)
+        }
+        return fields.count != before
+    }
+
+    /// Drop one entry outright — the picker's explicit "forget" control.
+    @discardableResult
+    public mutating func forget(id: String) -> Bool {
+        let before = fields.count
+        fields.removeAll { $0.id == id }
+        return fields.count != before
+    }
 }
 
 public extension MenuBarFieldCatalog {

--- a/Sources/VibeBarCore/Models/QuotaFieldRegistry.swift
+++ b/Sources/VibeBarCore/Models/QuotaFieldRegistry.swift
@@ -119,21 +119,27 @@ public struct QuotaFieldRegistry: Codable, Equatable, Sendable {
     }
 
     /// Forget `tool`'s entries the provider stopped returning that nothing
-    /// references — not selected in any mini window and never given a name.
-    /// A referenced entry stays (dimmed in the picker) so a selection
-    /// survives a provider hiccup; an unreferenced one was never the user's
-    /// and does not need remembering. Returns true when anything dropped.
+    /// references — not selected in any mini window and never given a name,
+    /// where "a name" includes a custom label on the field itself *or* on
+    /// its quota group (a discovered group's label key is
+    /// `<tool>.<bucket-id stem>`). A referenced entry stays (dimmed in the
+    /// picker) so a selection survives a provider hiccup; an unreferenced
+    /// one was never the user's and does not need remembering. Returns true
+    /// when anything dropped.
     @discardableResult
     public mutating func prune(
         tool: ToolType,
         liveBucketIds: Set<String>,
-        keeping referencedFieldIds: Set<String>
+        keeping keep: QuotaFieldKeepSet
     ) -> Bool {
         let before = fields.count
         fields.removeAll { field in
-            field.tool == tool
-                && !liveBucketIds.contains(field.bucketId)
-                && !referencedFieldIds.contains(field.id)
+            guard field.tool == tool,
+                  !liveBucketIds.contains(field.bucketId),
+                  !keep.fieldIds.contains(field.id)
+            else { return false }
+            let groupKey = "\(field.tool.rawValue).\(MenuBarFieldCatalog.bucketGroupStem(field.bucketId))"
+            return !keep.groupKeys.contains(groupKey)
         }
         return fields.count != before
     }
@@ -144,6 +150,19 @@ public struct QuotaFieldRegistry: Codable, Equatable, Sendable {
         let before = fields.count
         fields.removeAll { $0.id == id }
         return fields.count != before
+    }
+}
+
+/// What the registry must not forget: field ids a mini window selects or the
+/// user labelled, plus group-label keys — naming a discovered bucket's group
+/// is as much a claim on it as naming the bucket itself.
+public struct QuotaFieldKeepSet: Sendable {
+    public var fieldIds: Set<String>
+    public var groupKeys: Set<String>
+
+    public init(fieldIds: Set<String> = [], groupKeys: Set<String> = []) {
+        self.fieldIds = fieldIds
+        self.groupKeys = groupKeys
     }
 }
 

--- a/Sources/VibeBarCore/Services/QuotaService.swift
+++ b/Sources/VibeBarCore/Services/QuotaService.swift
@@ -58,6 +58,10 @@ public final class QuotaService: ObservableObject {
     /// each refresh. Optional: Core works without it, the App sets it once at
     /// wiring time.
     public var activityContextProvider: ((ToolType) -> QuotaActivityContext)?
+    /// Field ids the registry must keep even when the provider stops
+    /// returning their buckets — selections and named fields. Wired by the
+    /// App from settings; nil keeps everything (prune disabled).
+    public var registryKeepFieldIdsProvider: (() -> Set<String>)?
 
     private let adapters: [ToolType: any QuotaAdapter]
     private let mockProvider: () -> Bool
@@ -290,6 +294,16 @@ public final class QuotaService: ObservableObject {
         )
     }
 
+    /// The picker's explicit "forget": drop one discovered field from the
+    /// registry and persist. The caller removes its own references
+    /// (selections, labels) — this only owns the registry file.
+    public func forgetDiscoveredField(id: String) {
+        var registry = fieldRegistry
+        guard registry.forget(id: id) else { return }
+        fieldRegistry = registry
+        try? VibeBarLocalStore.writeJSON(registry, to: VibeBarLocalStore.quotaFieldRegistryURL)
+    }
+
     // MARK: - Private
 
     private func store(success: AccountQuota, now: Date = Date()) {
@@ -301,7 +315,15 @@ public final class QuotaService: ObservableObject {
         // Mock-mode buckets must not be remembered as real discoveries.
         if !mockProvider(), ToolType.dedicatedCardProviders.contains(success.tool) {
             var registry = fieldRegistry
-            if registry.record(tool: success.tool, buckets: success.buckets, now: now) {
+            var changed = registry.record(tool: success.tool, buckets: success.buckets, now: now)
+            if let keep = registryKeepFieldIdsProvider?() {
+                changed = registry.prune(
+                    tool: success.tool,
+                    liveBucketIds: Set(success.buckets.map(\.id)),
+                    keeping: keep
+                ) || changed
+            }
+            if changed {
                 fieldRegistry = registry
                 try? VibeBarLocalStore.writeJSON(registry, to: VibeBarLocalStore.quotaFieldRegistryURL)
             }

--- a/Sources/VibeBarCore/Services/QuotaService.swift
+++ b/Sources/VibeBarCore/Services/QuotaService.swift
@@ -58,10 +58,10 @@ public final class QuotaService: ObservableObject {
     /// each refresh. Optional: Core works without it, the App sets it once at
     /// wiring time.
     public var activityContextProvider: ((ToolType) -> QuotaActivityContext)?
-    /// Field ids the registry must keep even when the provider stops
-    /// returning their buckets — selections and named fields. Wired by the
-    /// App from settings; nil keeps everything (prune disabled).
-    public var registryKeepFieldIdsProvider: (() -> Set<String>)?
+    /// What the registry must keep even when the provider stops returning
+    /// the buckets — selections, named fields, and named groups. Wired by
+    /// the App from settings; nil keeps everything (prune disabled).
+    public var registryKeepProvider: (() -> QuotaFieldKeepSet)?
 
     private let adapters: [ToolType: any QuotaAdapter]
     private let mockProvider: () -> Bool
@@ -316,7 +316,7 @@ public final class QuotaService: ObservableObject {
         if !mockProvider(), ToolType.dedicatedCardProviders.contains(success.tool) {
             var registry = fieldRegistry
             var changed = registry.record(tool: success.tool, buckets: success.buckets, now: now)
-            if let keep = registryKeepFieldIdsProvider?() {
+            if let keep = registryKeepProvider?() {
                 changed = registry.prune(
                     tool: success.tool,
                     liveBucketIds: Set(success.buckets.map(\.id)),

--- a/Tests/VibeBarCoreTests/MiniWindowConfigTests.swift
+++ b/Tests/VibeBarCoreTests/MiniWindowConfigTests.swift
@@ -52,6 +52,37 @@ final class MiniWindowConfigTests: XCTestCase {
         XCTAssertFalse(decoded.wasOpen)
     }
 
+    func testPerWindowOverridesAndDensitySurviveRoundTrip() throws {
+        var settings = AppSettings.default
+        settings.miniWindow.windows[0].displayMode = .strip
+        settings.miniWindow.windows[0].stripDensity = .twoLine
+        settings.miniWindow.windows[0].customLabels = ["codex.weekly": "Wk (mine)"]
+        settings.miniWindow.windows[0].groupLabels = [
+            "codex.all-models": "Everything",
+            "subprovider:codex/ChatGPT Agentic": "GPT"
+        ]
+        settings.miniWindow.customLabels["codex.weekly"] = "Shared Wk"
+
+        let data = try JSONEncoder().encode(settings)
+        let decoded = try JSONDecoder().decode(AppSettings.self, from: data)
+        let window = try XCTUnwrap(decoded.miniWindow.windows.first)
+
+        XCTAssertEqual(window.stripDensity, .twoLine)
+        XCTAssertEqual(window.customLabels["codex.weekly"], "Wk (mine)")
+        XCTAssertEqual(window.groupLabels["codex.all-models"], "Everything")
+        XCTAssertEqual(window.groupLabels["subprovider:codex/ChatGPT Agentic"], "GPT")
+        // Resolution order: window override → shared → nil.
+        XCTAssertEqual(
+            decoded.miniWindow.resolvedFieldLabel(config: window, fieldId: "codex.weekly"),
+            "Wk (mine)"
+        )
+        XCTAssertEqual(
+            decoded.miniWindow.resolvedFieldLabel(config: nil, fieldId: "codex.weekly"),
+            "Shared Wk"
+        )
+        XCTAssertNil(decoded.miniWindow.resolvedGroupLabel(config: window, key: "claude.all-models"))
+    }
+
     func testDisplayModeCycleVisitsEveryModeOnce() {
         var seen: [MiniWindowDisplayMode] = []
         var mode = MiniWindowDisplayMode.regular

--- a/Tests/VibeBarCoreTests/QuotaFieldRegistryTests.swift
+++ b/Tests/VibeBarCoreTests/QuotaFieldRegistryTests.swift
@@ -98,7 +98,7 @@ final class QuotaFieldRegistryTests: XCTestCase {
         let changed = registry.prune(
             tool: .codex,
             liveBucketIds: ["gpt_reserve_weekly"],
-            keeping: ["codex.named_gone"]
+            keeping: QuotaFieldKeepSet(fieldIds: ["codex.named_gone"])
         )
         XCTAssertTrue(changed)
         XCTAssertNotNil(registry.field(id: "codex.gpt_reserve_weekly"), "live entry stays")
@@ -109,10 +109,27 @@ final class QuotaFieldRegistryTests: XCTestCase {
             registry.prune(
                 tool: .codex,
                 liveBucketIds: ["gpt_reserve_weekly"],
-                keeping: ["codex.named_gone"]
+                keeping: QuotaFieldKeepSet(fieldIds: ["codex.named_gone"])
             ),
             "second prune is a no-op"
         )
+    }
+
+    func testPruneKeepsEntriesWhoseGroupWasNamed() {
+        var registry = QuotaFieldRegistry()
+        registry.record(tool: .codex, buckets: [reserveBucket()], now: now)
+        // The user named only the quota group ("codex.gpt_reserve"), not the
+        // field — that claim keeps the entry through a provider hiccup.
+        let kept = registry.prune(
+            tool: .codex,
+            liveBucketIds: [],
+            keeping: QuotaFieldKeepSet(groupKeys: ["codex.gpt_reserve"])
+        )
+        XCTAssertFalse(kept)
+        XCTAssertNotNil(registry.field(id: "codex.gpt_reserve_weekly"))
+        // Without the group claim it drops.
+        XCTAssertTrue(registry.prune(tool: .codex, liveBucketIds: [], keeping: QuotaFieldKeepSet()))
+        XCTAssertNil(registry.field(id: "codex.gpt_reserve_weekly"))
     }
 
     func testForgetDropsOneEntry() {

--- a/Tests/VibeBarCoreTests/QuotaFieldRegistryTests.swift
+++ b/Tests/VibeBarCoreTests/QuotaFieldRegistryTests.swift
@@ -84,6 +84,45 @@ final class QuotaFieldRegistryTests: XCTestCase {
         XCTAssertNil(registry.field(id: "codex.invented_0"))
     }
 
+    func testPruneForgetsOnlyUnreferencedDeadEntries() {
+        var registry = QuotaFieldRegistry()
+        registry.record(tool: .codex, buckets: [reserveBucket()], now: now)
+        let dead = QuotaBucket(id: "gone_bucket", title: "Weekly", shortLabel: "wk", usedPercent: 0)
+        registry.record(tool: .codex, buckets: [dead], now: now)
+        let named = QuotaBucket(id: "named_gone", title: "Weekly", shortLabel: "wk", usedPercent: 0)
+        registry.record(tool: .codex, buckets: [named], now: now)
+        // Another tool's entry is out of scope for this tool's prune.
+        let other = QuotaBucket(id: "ag_extra", title: "Weekly", shortLabel: "wk", usedPercent: 0)
+        registry.record(tool: .antigravity, buckets: [other], now: now)
+
+        let changed = registry.prune(
+            tool: .codex,
+            liveBucketIds: ["gpt_reserve_weekly"],
+            keeping: ["codex.named_gone"]
+        )
+        XCTAssertTrue(changed)
+        XCTAssertNotNil(registry.field(id: "codex.gpt_reserve_weekly"), "live entry stays")
+        XCTAssertNotNil(registry.field(id: "codex.named_gone"), "referenced entry stays")
+        XCTAssertNil(registry.field(id: "codex.gone_bucket"), "unreferenced dead entry drops")
+        XCTAssertNotNil(registry.field(id: "antigravity.ag_extra"), "other tools untouched")
+        XCTAssertFalse(
+            registry.prune(
+                tool: .codex,
+                liveBucketIds: ["gpt_reserve_weekly"],
+                keeping: ["codex.named_gone"]
+            ),
+            "second prune is a no-op"
+        )
+    }
+
+    func testForgetDropsOneEntry() {
+        var registry = QuotaFieldRegistry()
+        registry.record(tool: .codex, buckets: [reserveBucket()], now: now)
+        XCTAssertTrue(registry.forget(id: "codex.gpt_reserve_weekly"))
+        XCTAssertNil(registry.field(id: "codex.gpt_reserve_weekly"))
+        XCTAssertFalse(registry.forget(id: "codex.gpt_reserve_weekly"))
+    }
+
     func testMergedFieldsAppendDynamicOptionsWithComposedTitle() {
         var registry = QuotaFieldRegistry()
         registry.record(tool: .codex, buckets: [reserveBucket()], now: now)


### PR DESCRIPTION
Follow-ups from AQ using dev.47's mini windows, plus one standing rule.

## What

- **Arrangement rows get context.** Brand icon + L2 SubProvider name lead every row — ten rows named "Weekly" are no longer interchangeable.
- **One naming tree, shaped like the quota axis**: company → SubProvider → quota group → bucket, each level renamed in place (replaces the flat "SubProvider names" / "Model group names" lists and the per-row label fields in the picker). A scope picker targets the shared names or the selected window's overrides; per-window overrides (`MiniWindowConfig.customLabels`/`groupLabels`) inherit the shared name when empty — the placeholder shows what will render.
- **Gemini Web gains its `gemini.all-models` headline group** — the reserved heading row rendered blank before; now it says All Models and is renamable like the others.
- **No abbreviation defaults.** Strip/ledger/rail labels derive from the bucket's real title (`Weekly`, `5 Hours`) rather than `WK`/`5H`; short forms are for the user to choose.
- **Strip density per window** — Roomy / Two Lines / Narrow, menu-bar style; metrics, panel sizing and the resize fingerprint follow.
- **NEW badge removed.**
- **Registry hygiene**: unreferenced discovered buckets are pruned when the provider stops returning them (`QuotaFieldRegistry.prune`, keep-set = selections + named fields wired from settings); referenced dead rows stay dimmed and gain an explicit forget control that clears the registry entry plus its selections and names.
- **AGENTS.md § 7 + CLAUDE.md now state the standing rule AQ set**: UI fluency is a requirement — heavy work stays out of `body`/binding getters, derivations cache per data change, charts downsample, timers stay scoped, hot paths never write `AppSettings` per tick; a visible hitch is a blocker.

## Verification

`swift build` clean · **1662 tests, 0 failures** (new: registry prune keep-set semantics, forget idempotence) · release packaging + strict deep codesign, empty entitlements · per-surface demo smoke (settings/miniWindow, mini regular / strip / ledger build with zero errors; ledger reports its fixed 272 pt width). Pixel captures were TCC-blocked in this session (known runbook limitation) — the smoke fallback from the runbook was used instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)