### PR TITLE
Make every hand-drawn control clickable across its full visual area

### DIFF
--- a/Sources/VibeBarApp/Views/ControlFocus.swift
+++ b/Sources/VibeBarApp/Views/ControlFocus.swift
@@ -27,6 +27,12 @@ struct VibeBarButtonStyle: ButtonStyle {
 
     func makeBody(configuration: Configuration) -> some View {
         FocusRing(cornerRadius: cornerRadius) { configuration.label }
+            // Without an explicit content shape a hand-drawn label hit-tests
+            // only its opaque pixels: a padded pill whose fill is conditional
+            // (or absent) responds to clicks on the text but not the padding.
+            // The shape follows the label's full bounds so every .vibeBar
+            // control is clickable across the whole area it draws.
+            .contentShape(RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
             .opacity(configuration.isPressed ? 0.72 : 1)
     }
 

--- a/Sources/VibeBarApp/Views/Workbench/SkillsManagerPage.swift
+++ b/Sources/VibeBarApp/Views/Workbench/SkillsManagerPage.swift
@@ -123,6 +123,9 @@ struct SkillsManagerPage: View {
         .workbenchFieldSurface(cornerRadius: 15)
     }
 
+    // The porcelain pill is part of each button's label, not decoration
+    // around it: applied outside the Button its 11 pt side padding sat
+    // outside the clickable area, so the pill's edges ignored clicks.
     private var actionButtons: some View {
         HStack(spacing: 6) {
             Button {
@@ -135,9 +138,9 @@ struct SkillsManagerPage: View {
                         : "Check Updates",
                     busy: model.isBusy(SkillsManagerModel.BusyKey.updates)
                 )
+                .porcelainToolbarButton()
             }
-            .buttonStyle(.vibeBar)
-            .porcelainToolbarButton()
+            .buttonStyle(.vibeBar(cornerRadius: 11))
             .disabled(model.isBusy(SkillsManagerModel.BusyKey.updates))
 
             Button {
@@ -148,9 +151,9 @@ struct SkillsManagerPage: View {
                     title: "Install from ZIP",
                     busy: model.isBusy(SkillsManagerModel.BusyKey.zip)
                 )
+                .porcelainToolbarButton()
             }
-            .buttonStyle(.vibeBar)
-            .porcelainToolbarButton()
+            .buttonStyle(.vibeBar(cornerRadius: 11))
 
             Button {
                 model.presentImportSheet()
@@ -160,25 +163,25 @@ struct SkillsManagerPage: View {
                     title: "Import Existing",
                     busy: model.isBusy(SkillsManagerModel.BusyKey.importing)
                 )
+                .porcelainToolbarButton()
             }
-            .buttonStyle(.vibeBar)
-            .porcelainToolbarButton()
+            .buttonStyle(.vibeBar(cornerRadius: 11))
 
             Button {
                 model.presentBackupsSheet()
             } label: {
                 buttonLabel(systemImage: "clock.arrow.circlepath", title: "Backups", busy: false)
+                    .porcelainToolbarButton()
             }
-            .buttonStyle(.vibeBar)
-            .porcelainToolbarButton()
+            .buttonStyle(.vibeBar(cornerRadius: 11))
 
             Button {
                 model.isDiscoverSheetPresented = true
             } label: {
                 buttonLabel(systemImage: "sparkle.magnifyingglass", title: "Discover", busy: false)
+                    .porcelainToolbarButton(prominent: true)
             }
-            .buttonStyle(.vibeBar)
-            .porcelainToolbarButton(prominent: true)
+            .buttonStyle(.vibeBar(cornerRadius: 11))
             .help("Browse configured repositories and the skills.sh index")
         }
     }

--- a/Sources/VibeBarApp/Views/Workbench/WorkbenchPorcelainStyle.swift
+++ b/Sources/VibeBarApp/Views/Workbench/WorkbenchPorcelainStyle.swift
@@ -186,6 +186,9 @@ struct WorkbenchPillButtonStyle: ButtonStyle {
                             lineWidth: isFocused ? 1 : Theme.Card.hairlineWidth
                         )
                 )
+                // The neutral fill is nearly transparent in dark mode; an
+                // explicit shape keeps the whole pill clickable regardless.
+                .contentShape(RoundedRectangle(cornerRadius: 13, style: .continuous))
                 .opacity(pressed ? 0.74 : 1)
         }
     }


### PR DESCRIPTION
## Summary

AQ reported that many buttons in the popover and the Workbench only respond to clicks on their text, not their full visual area. Root cause: SwiftUI hit-tests a custom button label's opaque pixels only, so hand-drawn controls whose background fill is conditional (drawn only when selected), nearly transparent, or applied outside the `Button` left their padded area dead.

Audited every interactive control in `Sources/VibeBarApp` (popover cards, Workbench pages, Settings incl. Mini Windows + Layout editor, header views, mini windows) and fixed the hit areas centrally in the two shared button styles, plus one page whose pill chrome sat outside its buttons.

## Files touched and the pattern fixed

- **`Sources/VibeBarApp/Views/ControlFocus.swift`** — `VibeBarButtonStyle.makeBody` now applies `.contentShape(RoundedRectangle(cornerRadius:))` over the label's full bounds. This fixes every `.vibeBar` call site whose label carries padding/frame but no unconditional fill and no per-site `contentShape`: the Usage Stats filter chips (All harnesses / company / harness), the Sessions "All" chip, the trend-chart metric segments and provider-legend chips, the mini-window field-arrangement arrows (up/down/remove) and the "+" add-window button, the layout editor's segment icon controls, the transcript per-message copy button, and the small glyph-only buttons (expand charts, toast dismiss, repo remove, backup trash, page chevron, mini-window close). The shape follows the style's `cornerRadius`, which call sites already match to their label shape.
- **`Sources/VibeBarApp/Views/Workbench/WorkbenchPorcelainStyle.swift`** — `WorkbenchPillButtonStyle` (all Workbench toolbar menus/pills) gets the matching `.contentShape(RoundedRectangle(cornerRadius: 13))` so the pill stays clickable even where its neutral fill is nearly transparent (dark mode `0.046` opacity).
- **`Sources/VibeBarApp/Views/Workbench/SkillsManagerPage.swift`** — the five toolbar buttons (Check Updates / Install from ZIP / Import Existing / Backups / Discover) applied `.porcelainToolbarButton()` *outside* the `Button`, so the pill's 11 pt side padding was entirely outside the clickable area. Moved the modifier inside each label and matched the focus hairline with `.vibeBar(cornerRadius: 11)`.

## Controls deliberately left alone

- Controls that already carry a correct `contentShape` on their padded label (chart-brush presets, cost-range presets, granularity segments, quota-forecast disclosure, sidebar rows in Settings and Workbench, session list rows, breakdown segment pills, load-more row, `BorderlessIconButton`/`BorderlessRowButton`) — already correct; the style change is a no-op for them.
- System-styled buttons and menus (`.bordered`, `.borderedProminent`, `.borderless`, `ControlGroup`, `Menu` with `.menuStyle(.button)`) — AppKit-backed bezels already hit-test their full bounds.
- Bare-glyph `.borderless`/`.vibeBar` icon buttons with no padded background (e.g. cookie-slot trash cans): their visual area *is* the glyph, so the hit area already equals the visual area; enlarging it would go beyond this fix's "hit areas only" scope.
- Chart `onTapGesture` surfaces (cost/quota history, mini-window double-tap) — already backed by `contentShape(Rectangle())` on the plot area.
- Layout editor drag gestures: unchanged. The per-block eye toggle already had its own `contentShape`, the drag gesture lives on the block body underneath, and the arrangement-row drag grip keeps its own dedicated `contentShape` + gesture.

## Test plan

- [x] `swift build`
- [x] `swift test` — 1660 tests, 0 failures (1 skipped)
- [x] `./Scripts/build_app.sh release`
- [x] `codesign -d --entitlements - ".build/Vibe Bar.app"` → empty `<dict/>`, no `app-sandbox` key
- [x] `codesign --verify --deep --strict ".build/Vibe Bar.app"` → OK

No visual change intended: `contentShape` affects hit testing only, and the Skills toolbar pills render identically with the chrome inside the label (the press-state dim now covers the pill fill, matching `WorkbenchPillButtonStyle` behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)