### PR TITLE
Cache per-render chart planning and forecast math off the hover path

### DIFF
--- a/Sources/VibeBarApp/Views/CostHistoryView.swift
+++ b/Sources/VibeBarApp/Views/CostHistoryView.swift
@@ -1226,6 +1226,14 @@ struct CostHistoryView: View {
         let snapshot: CostSnapshot?
         let range: ClosedRange<Date>
         let granularity: CostChartGranularity
+        /// Week/month buckets are grouped with `Calendar.current`; a time
+        /// zone or calendar change mid-flight must invalidate the memo, not
+        /// keep serving the old boundaries until the data happens to move.
+        let calendarIdentity: String
+    }
+
+    private static var currentCalendarIdentity: String {
+        "\(Calendar.current.identifier)|\(TimeZone.current.identifier)"
     }
 
     private final class VisiblePointsCache {
@@ -1242,7 +1250,8 @@ struct CostHistoryView: View {
         let key = VisiblePointsKey(
             snapshot: snapshot,
             range: window.visibleRange,
-            granularity: granularity
+            granularity: granularity,
+            calendarIdentity: Self.currentCalendarIdentity
         )
         if let cached = visiblePointsCache.points, visiblePointsCache.key == key {
             // Adopt the newest key: an equal-but-reallocated snapshot should

--- a/Sources/VibeBarApp/Views/CostHistoryView.swift
+++ b/Sources/VibeBarApp/Views/CostHistoryView.swift
@@ -1214,17 +1214,58 @@ struct CostHistoryView: View {
 
     // MARK: - Data shaping
 
+    /// Memo for `visiblePoints`. Hover moves `hoveredDate`, which re-runs
+    /// `body`, which used to rebuild every `CostChartPoint` — including the
+    /// week/month paths that re-aggregate the whole daily history and re-fold
+    /// per-day model breakdowns — once per pointer move. The key holds the
+    /// exact inputs (snapshot equality is an O(1) storage-identity check when
+    /// unchanged), so only a data change, pan, or granularity switch pays for
+    /// a rebuild. A reference box on purpose: filling it during `body` must
+    /// not dirty view state.
+    private struct VisiblePointsKey: Equatable {
+        let snapshot: CostSnapshot?
+        let range: ClosedRange<Date>
+        let granularity: CostChartGranularity
+    }
+
+    private final class VisiblePointsCache {
+        var key: VisiblePointsKey?
+        var points: [CostChartPoint]?
+    }
+
+    @State private var visiblePointsCache = VisiblePointsCache()
+
+    private func visiblePoints(
+        window: ChartTimeWindow,
+        granularity: CostChartGranularity
+    ) -> [CostChartPoint] {
+        let key = VisiblePointsKey(
+            snapshot: snapshot,
+            range: window.visibleRange,
+            granularity: granularity
+        )
+        if let cached = visiblePointsCache.points, visiblePointsCache.key == key {
+            // Adopt the newest key: an equal-but-reallocated snapshot should
+            // keep later compares on the O(1) storage-identity fast path.
+            visiblePointsCache.key = key
+            return cached
+        }
+        let points = computeVisiblePoints(range: key.range, granularity: granularity)
+        visiblePointsCache.key = key
+        visiblePointsCache.points = points
+        return points
+    }
+
     /// Buckets that occupy visible time, oldest first. A bucket straddling an
     /// edge is kept whole: it is a real bar the user can see, and cutting its
     /// total to the visible slice would make the footer disagree with the
     /// chart. A bucket merely *touching* an edge is not visible at all and is
     /// left out — see `CostChartWindowPolicy.bucketOverlaps`.
-    private func visiblePoints(
-        window: ChartTimeWindow,
+    private func computeVisiblePoints(
+        range: ClosedRange<Date>,
         granularity: CostChartGranularity
     ) -> [CostChartPoint] {
         guard let snapshot else { return [] }
-        let range = window.visibleRange
         switch granularity {
         case .hour:
             return clip(hourlyPoints, date: \.date, bucket: clipBucket(.hour), to: range).map { point in

--- a/Sources/VibeBarApp/Views/MiniWindowsSettingsSection.swift
+++ b/Sources/VibeBarApp/Views/MiniWindowsSettingsSection.swift
@@ -332,11 +332,18 @@ struct MiniWindowsSettingsSection: View {
         .opacity(entry.isLive ? 1 : 0.55)
     }
 
-    private func lastSeenCaption(_ entry: PickerEntry) -> String {
-        guard let discovered = entry.discovered else { return "not in current response" }
+    // Static: this caption renders once per dimmed picker row, and the picker
+    // re-renders on every settings or quota publish — a formatter per call is
+    // the classic per-row allocation.
+    private static let lastSeenFormatter: DateFormatter = {
         let formatter = DateFormatter()
         formatter.dateFormat = "MM-dd"
-        return "not returned · last seen \(formatter.string(from: discovered.lastSeen))"
+        return formatter
+    }()
+
+    private func lastSeenCaption(_ entry: PickerEntry) -> String {
+        guard let discovered = entry.discovered else { return "not in current response" }
+        return "not returned · last seen \(Self.lastSeenFormatter.string(from: discovered.lastSeen))"
     }
 
     // MARK: - Arrangement

--- a/Sources/VibeBarApp/Views/MiniWindowsSettingsSection.swift
+++ b/Sources/VibeBarApp/Views/MiniWindowsSettingsSection.swift
@@ -397,6 +397,7 @@ struct MiniWindowsSettingsSection: View {
     private static let lastSeenFormatter: DateFormatter = {
         let formatter = DateFormatter()
         formatter.dateFormat = "MM-dd"
+        formatter.timeZone = .autoupdatingCurrent
         return formatter
     }()
 

--- a/Sources/VibeBarApp/Views/Workbench/UsageTrendChartView.swift
+++ b/Sources/VibeBarApp/Views/Workbench/UsageTrendChartView.swift
@@ -75,6 +75,114 @@ struct UsageTrendChartView: View {
         let providers: [ToolType]
     }
 
+    /// Everything the panes derive from the series at the current window,
+    /// built once per (data, window, legend, metric) change.
+    ///
+    /// These used to be computed properties, which meant every body pass —
+    /// including the one per pointer move that a hover update triggers —
+    /// re-filtered and re-downsampled the whole series and resolved hover
+    /// readings by linear scan. At 30 d × hourly that is ~720 aggregate
+    /// buckets plus one series per provider, per frame. The plan is memoized
+    /// on the exact inputs (array equality hits the COW identity fast path),
+    /// so a hover or tooltip pass costs dictionary lookups and one binary
+    /// search instead.
+    private struct RenderPlan {
+        var aggregateRendered: [UsageTrendPoint] = []
+        var visibleAggregateCount: Int = 0
+        var aggregateByStart: [Date: UsageTrendPoint] = [:]
+        /// Visible bucket starts, ascending — the hover snap works on these.
+        var visibleStarts: [Date] = []
+        var providerRenderedByTool: [ToolType: [UsageTrendPoint]] = [:]
+        var providerByStart: [ToolType: [Date: UsageTrendPoint]] = [:]
+        var navigatorByTool: [ToolType: [UsageTrendPoint]] = [:]
+        var navigationMaximum: Double = 0
+        var visibleTokensTotal: Int64 = 0
+        var visibleCostTotal: Int64 = 0
+    }
+
+    private struct PlanKey: Equatable {
+        let series: UsageTrendSeries
+        let visibleDomain: ClosedRange<Date>
+        let hiddenTools: Set<ToolType>
+        let metric: UsageChartMetric
+    }
+
+    /// Reference box so a memo hit/update during `body` never dirties view
+    /// state; correctness comes from the key, not from invalidation timing.
+    private final class PlanCache {
+        var key: PlanKey?
+        var plan: RenderPlan?
+    }
+
+    @State private var planCache = PlanCache()
+
+    private var plan: RenderPlan {
+        let key = PlanKey(
+            series: series,
+            visibleDomain: visibleDomain,
+            hiddenTools: hiddenTools,
+            metric: metric
+        )
+        if let cached = planCache.plan, planCache.key == key {
+            // Adopt the newest key: a reload can return identical points in
+            // fresh storage, and re-keying keeps later compares on the O(1)
+            // identity fast path instead of walking every element per pass.
+            planCache.key = key
+            return cached
+        }
+        let built = Self.buildPlan(key: key)
+        planCache.key = key
+        planCache.plan = built
+        return built
+    }
+
+    private static func buildPlan(key: PlanKey) -> RenderPlan {
+        let series = key.series
+        let visibleDomain = key.visibleDomain
+        var plan = RenderPlan()
+
+        let visiblePoints = series.points.filter { visibleDomain.contains($0.bucketStart) }
+        plan.visibleAggregateCount = visiblePoints.count
+        plan.visibleStarts = visiblePoints.map(\.bucketStart)
+        plan.aggregateRendered = UsageTrendSeriesDownsampling.points(
+            visiblePoints,
+            limit: max(2, mainMarkBudget / UsageTokenComponent.allCases.count)
+        )
+        plan.aggregateByStart = Dictionary(
+            series.points.map { ($0.bucketStart, $0) },
+            uniquingKeysWith: { first, _ in first }
+        )
+
+        let visibleProviders = series.providerSeries.filter { !key.hiddenTools.contains($0.tool) }
+        let perProvider = max(2, mainMarkBudget / max(1, visibleProviders.count))
+        for provider in visibleProviders {
+            let points = provider.points.filter { visibleDomain.contains($0.bucketStart) }
+            plan.providerRenderedByTool[provider.tool] =
+                UsageTrendSeriesDownsampling.points(points, limit: perProvider)
+            plan.providerByStart[provider.tool] = Dictionary(
+                provider.points.map { ($0.bucketStart, $0) },
+                uniquingKeysWith: { first, _ in first }
+            )
+        }
+
+        let navigatorProviders = key.metric == .tokens ? series.providerSeries : visibleProviders
+        let perNavigator = max(2, navigatorMarkBudget / max(1, visibleProviders.count))
+        for provider in navigatorProviders {
+            plan.navigatorByTool[provider.tool] =
+                UsageTrendSeriesDownsampling.points(provider.points, limit: perNavigator)
+        }
+        plan.navigationMaximum = key.metric == .tokens
+            ? series.points.map { Double($0.totalTokens) }.max() ?? 0
+            : visibleProviders.flatMap(\.points).map { Double($0.costMicros) }.max() ?? 0
+
+        let accessibilityPoints = key.metric == .tokens
+            ? visiblePoints
+            : visibleProviders.flatMap(\.points).filter { visibleDomain.contains($0.bucketStart) }
+        plan.visibleTokensTotal = accessibilityPoints.reduce(Int64(0)) { $0 + $1.totalTokens }
+        plan.visibleCostTotal = accessibilityPoints.reduce(Int64(0)) { $0 + $1.costMicros }
+        return plan
+    }
+
     private var series: UsageTrendSeries { model.trend }
 
     private var visibleProviders: [UsageProviderTrendSeries] {
@@ -127,7 +235,7 @@ struct UsageTrendChartView: View {
 
     private var hoveredPoint: UsageTrendPoint? {
         guard let hoveredDate else { return nil }
-        return series.points.first { $0.bucketStart == hoveredDate }
+        return plan.aggregateByStart[hoveredDate]
     }
 
     var body: some View {
@@ -396,18 +504,11 @@ struct UsageTrendChartView: View {
     /// Keep sparse daily/weekly bars substantial without turning a dense
     /// hourly view into a picket fence of overlapping columns.
     private var tokenBarWidth: CGFloat {
-        let visibleCount = series.points.reduce(into: 0) { count, point in
-            if visibleDomain.contains(point.bucketStart) { count += 1 }
-        }
-        return max(2, min(22, 360 / CGFloat(max(visibleCount, 1))))
+        max(2, min(22, 360 / CGFloat(max(plan.visibleAggregateCount, 1))))
     }
 
     private var renderedAggregatePoints: [UsageTrendPoint] {
-        let points = series.points.filter { visibleDomain.contains($0.bucketStart) }
-        return UsageTrendSeriesDownsampling.points(
-            points,
-            limit: max(2, Self.mainMarkBudget / UsageTokenComponent.allCases.count)
-        )
+        plan.aggregateRendered
     }
 
     private var costPane: some View {
@@ -528,13 +629,14 @@ struct UsageTrendChartView: View {
     }
 
     private func nearestBucket(to date: Date) -> Date? {
-        series.points
-            .filter { visibleDomain.contains($0.bucketStart) }
-            .min { lhs, rhs in
-                abs(lhs.bucketStart.timeIntervalSince(date))
-                    < abs(rhs.bucketStart.timeIntervalSince(date))
-            }?
-            .bucketStart
+        // Runs once per pointer move; the starts are ascending, so binary
+        // search instead of a scan over every visible bucket.
+        ChartSampleSearch.nearest(
+            in: plan.visibleStarts,
+            to: date,
+            tolerance: .greatestFiniteMagnitude,
+            time: { $0 }
+        )
     }
 
     private func tooltip(_ point: UsageTrendPoint) -> some View {
@@ -633,7 +735,7 @@ struct UsageTrendChartView: View {
         for provider: UsageProviderTrendSeries,
         at date: Date
     ) -> UsageTrendPoint? {
-        provider.points.first { $0.bucketStart == date }
+        plan.providerByStart[provider.tool]?[date]
     }
 
     private func visibleCostMicros(at date: Date) -> Int64 {
@@ -643,14 +745,11 @@ struct UsageTrendChartView: View {
     }
 
     private func renderedPoints(for provider: UsageProviderTrendSeries) -> [UsageTrendPoint] {
-        let points = provider.points.filter { visibleDomain.contains($0.bucketStart) }
-        let perProvider = max(2, Self.mainMarkBudget / max(1, visibleProviders.count))
-        return UsageTrendSeriesDownsampling.points(points, limit: perProvider)
+        plan.providerRenderedByTool[provider.tool] ?? []
     }
 
     private func navigatorPoints(for provider: UsageProviderTrendSeries) -> [UsageTrendPoint] {
-        let perProvider = max(2, Self.navigatorMarkBudget / max(1, visibleProviders.count))
-        return UsageTrendSeriesDownsampling.points(provider.points, limit: perProvider)
+        plan.navigatorByTool[provider.tool] ?? []
     }
 
     private func areaGradient(_ color: Color) -> LinearGradient {
@@ -711,10 +810,7 @@ struct UsageTrendChartView: View {
     }
 
     private var navigationMaximum: Double {
-        if metric == .tokens {
-            return series.points.map { Double($0.totalTokens) }.max() ?? 0
-        }
-        return visibleProviders.flatMap(\.points).map { Double($0.costMicros) }.max() ?? 0
+        plan.navigationMaximum
     }
 
     private var navigatorProviders: [UsageProviderTrendSeries] {
@@ -740,13 +836,9 @@ struct UsageTrendChartView: View {
     }
 
     private var chartAccessibilityValue: String {
-        let visiblePoints = metric == .tokens
-            ? series.points.filter { visibleDomain.contains($0.bucketStart) }
-            : visibleProviders.flatMap(\.points).filter { visibleDomain.contains($0.bucketStart) }
-        let totalTokens = visiblePoints.reduce(Int64(0)) { $0 + $1.totalTokens }
-        let totalCost = visiblePoints.reduce(Int64(0)) { $0 + $1.costMicros }
-        return "\(visibleProviders.count) providers, \(UsageFormatting.compactTokens(totalTokens)) tokens, "
-            + "\(UsageFormatting.formatMicroUSD(totalCost))"
+        "\(visibleProviders.count) providers, "
+            + "\(UsageFormatting.compactTokens(plan.visibleTokensTotal)) tokens, "
+            + "\(UsageFormatting.formatMicroUSD(plan.visibleCostTotal))"
     }
 
     /// Automatic first, then every explicit bucket.

--- a/Sources/VibeBarApp/Views/YearlyContributionHeatmapView.swift
+++ b/Sources/VibeBarApp/Views/YearlyContributionHeatmapView.swift
@@ -187,6 +187,9 @@ struct YearlyContributionHeatmapView: View {
         let formatter = DateFormatter()
         formatter.dateFormat = "MMM d, yyyy"
         formatter.locale = Locale(identifier: "en_US_POSIX")
+        // The app runs for weeks; a static formatter must follow a system
+        // time-zone change instead of keeping the one it was born with.
+        formatter.timeZone = .autoupdatingCurrent
         return formatter
     }()
 
@@ -194,6 +197,7 @@ struct YearlyContributionHeatmapView: View {
         let formatter = DateFormatter()
         formatter.locale = Locale(identifier: "en_US_POSIX")
         formatter.dateFormat = "MMM"
+        formatter.timeZone = .autoupdatingCurrent
         return formatter
     }()
 

--- a/Sources/VibeBarApp/Views/YearlyContributionHeatmapView.swift
+++ b/Sources/VibeBarApp/Views/YearlyContributionHeatmapView.swift
@@ -180,16 +180,29 @@ struct YearlyContributionHeatmapView: View {
         )
     }
 
-    private func tooltip(for entry: DailyCostPoint?) -> String {
-        guard let entry else { return "" }
-        let date = entry.date
+    // Static on purpose: `tooltip(for:)` runs once per cell — ~365 times per
+    // body pass — and a fresh `DateFormatter` per call is milliseconds of
+    // pure allocation on every redraw of the card.
+    private static let tooltipFormatter: DateFormatter = {
         let formatter = DateFormatter()
         formatter.dateFormat = "MMM d, yyyy"
         formatter.locale = Locale(identifier: "en_US_POSIX")
+        return formatter
+    }()
+
+    private static let monthLabelFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "MMM"
+        return formatter
+    }()
+
+    private func tooltip(for entry: DailyCostPoint?) -> String {
+        guard let entry else { return "" }
         let cost: String = entry.costUSD < 0.01 ? "$0.00"
             : entry.costUSD < 100 ? String(format: "$%.2f", entry.costUSD)
             : String(format: "$%.0f", entry.costUSD)
-        return "\(formatter.string(from: date)) · \(cost)"
+        return "\(Self.tooltipFormatter.string(from: entry.date)) · \(cost)"
     }
 
     /// Build week columns for the past 365 days, anchored to the most recent
@@ -244,13 +257,13 @@ struct YearlyContributionHeatmapView: View {
         let calendar = Calendar.current
         var markers: [MonthMarker] = []
         var lastMonth: Int = -1
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.dateFormat = "MMM"
         for (idx, column) in columns.enumerated() {
             let month = calendar.component(.month, from: column.weekStart)
             if month != lastMonth {
-                markers.append(MonthMarker(column: idx, label: formatter.string(from: column.weekStart)))
+                markers.append(MonthMarker(
+                    column: idx,
+                    label: Self.monthLabelFormatter.string(from: column.weekStart)
+                ))
                 lastMonth = month
             }
         }

--- a/Sources/VibeBarCore/Services/QuotaService.swift
+++ b/Sources/VibeBarCore/Services/QuotaService.swift
@@ -279,16 +279,91 @@ public final class QuotaService: ObservableObject {
         allowsPostResetGrace: Bool = false
     ) -> QuotaPaceForecast? {
         let key = SubscriptionHistoryKey(accountId: accountId, bucketId: bucket.id)
-        return QuotaPaceForecast.compute(
+        let observations = observationsByAccountBucket[key] ?? []
+        let cycles = historyByAccountBucket[key] ?? []
+        // Render paths ask for this once per bucket per body pass — every
+        // quota-group row, mini-window cell, and the status item — and the
+        // blend walks every stored observation per completed cycle. Between
+        // data changes the inputs are byte-identical (each `TimelineView`
+        // hands every re-render of a tick the same date), so the memo turns
+        // the repeat asks into a handful of COW identity comparisons. Keyed
+        // on the *exact* inputs, never a quantized clock: a hit is provably
+        // the same pure-function call, so behavior cannot drift.
+        if let memos = paceForecastMemo[key] {
+            for memo in memos where memo.matches(
+                bucket: bucket,
+                observations: observations,
+                cycles: cycles,
+                heatmap: activityHeatmap,
+                dailyActivity: dailyActivity,
+                now: now,
+                allowsPostResetGrace: allowsPostResetGrace
+            ) {
+                return memo.result
+            }
+        }
+        let result = QuotaPaceForecast.compute(
             bucket: bucket,
-            observations: observationsByAccountBucket[key] ?? [],
-            cycles: historyByAccountBucket[key] ?? [],
+            observations: observations,
+            cycles: cycles,
             activityHeatmap: activityHeatmap,
             dailyActivity: dailyActivity,
             now: now,
             allowsPostResetGrace: allowsPostResetGrace
         )
+        var memos = paceForecastMemo[key] ?? []
+        memos.append(PaceForecastMemo(
+            bucket: bucket,
+            observations: observations,
+            cycles: cycles,
+            heatmap: activityHeatmap,
+            dailyActivity: dailyActivity,
+            now: now,
+            allowsPostResetGrace: allowsPostResetGrace,
+            result: result
+        ))
+        // Several surfaces (popover, mini windows, status item) tick on
+        // their own 30 s phases, so keep a few entries per bucket rather
+        // than one; the arrays inside are references to storage the service
+        // already retains, so the memo itself is a few dozen words.
+        if memos.count > Self.paceForecastMemoLimit {
+            memos.removeFirst(memos.count - Self.paceForecastMemoLimit)
+        }
+        paceForecastMemo[key] = memos
+        return result
     }
+
+    private struct PaceForecastMemo {
+        let bucket: QuotaBucket
+        let observations: [FillTimelinePoint]
+        let cycles: [SubscriptionWindowSample]
+        let heatmap: UsageHeatmap?
+        let dailyActivity: [DailyCostPoint]
+        let now: Date
+        let allowsPostResetGrace: Bool
+        let result: QuotaPaceForecast?
+
+        func matches(
+            bucket: QuotaBucket,
+            observations: [FillTimelinePoint],
+            cycles: [SubscriptionWindowSample],
+            heatmap: UsageHeatmap?,
+            dailyActivity: [DailyCostPoint],
+            now: Date,
+            allowsPostResetGrace: Bool
+        ) -> Bool {
+            self.now == now
+                && self.allowsPostResetGrace == allowsPostResetGrace
+                && self.bucket == bucket
+                && self.observations == observations
+                && self.cycles == cycles
+                && self.heatmap == heatmap
+                && self.dailyActivity == dailyActivity
+        }
+    }
+
+    private static let paceForecastMemoLimit = 4
+    private var paceForecastMemo: [SubscriptionHistoryKey: [PaceForecastMemo]] = [:]
 
     // MARK: - Private
 

--- a/Sources/VibeBarCore/Services/QuotaService.swift
+++ b/Sources/VibeBarCore/Services/QuotaService.swift
@@ -316,6 +316,21 @@ public final class QuotaService: ObservableObject {
             allowsPostResetGrace: allowsPostResetGrace
         )
         var memos = paceForecastMemo[key] ?? []
+        // A refresh replaces the observation/cycle arrays wholesale, so a
+        // memo from the previous data generation can never match again —
+        // but it would keep retaining those arrays (thousands of points per
+        // bucket) for as long as it sat in the list. Keep only memos of the
+        // current generation; the differently-phased `now` values are what
+        // the multi-entry list is for.
+        memos.removeAll { memo in
+            !memo.matchesData(
+                bucket: bucket,
+                observations: observations,
+                cycles: cycles,
+                heatmap: activityHeatmap,
+                dailyActivity: dailyActivity
+            )
+        }
         memos.append(PaceForecastMemo(
             bucket: bucket,
             observations: observations,
@@ -358,7 +373,24 @@ public final class QuotaService: ObservableObject {
         ) -> Bool {
             self.now == now
                 && self.allowsPostResetGrace == allowsPostResetGrace
-                && self.bucket == bucket
+                && matchesData(
+                    bucket: bucket,
+                    observations: observations,
+                    cycles: cycles,
+                    heatmap: heatmap,
+                    dailyActivity: dailyActivity
+                )
+        }
+
+        /// The time-independent half of `matches` — one data generation.
+        func matchesData(
+            bucket: QuotaBucket,
+            observations: [FillTimelinePoint],
+            cycles: [SubscriptionWindowSample],
+            heatmap: UsageHeatmap?,
+            dailyActivity: [DailyCostPoint]
+        ) -> Bool {
+            self.bucket == bucket
                 && self.observations == observations
                 && self.cycles == cycles
                 && self.heatmap == heatmap


### PR DESCRIPTION
## Summary

Static performance audit of the Overview popover, Settings pages, and the Workbench Usage Stats page (worst case: Hourly granularity), measured against the AGENTS.md § 7 fluency budgets (PR #235). Implemented the four unambiguous wins; everything real but riskier is documented under **Found, not fixed**. No visual behavior or data semantics change.

## Ranked findings

| # | Surface | Location | Cost (static reasoning) | Budget threatened | Outcome |
|---|---------|----------|--------------------------|-------------------|---------|
| 1 | Usage Stats trend chart (Hourly worst) | `Sources/VibeBarApp/Views/Workbench/UsageTrendChartView.swift` (was `renderedAggregatePoints` / `renderedPoints(for:)` / `nearestBucket` / `providerPoint` / `chartAccessibilityValue`) | Every body pass — including one per pointer move — re-filtered + re-downsampled every series (~720 hourly buckets × providers) and resolved hover by linear scans, O(n·m) per frame | Hover/crosshair 1-frame budget; hitch rate ≥ 10 ms/s | **Fixed**: memoized `RenderPlan` keyed on (series, window, legend, metric); hover is now one binary search + dictionary lookups |
| 2 | Popover quota rows, mini windows, status item | `Sources/VibeBarCore/Services/QuotaService.swift` `paceForecast` (called from `QuotaGroupCard:534`, `PopoverRoot:2337`, `MiniQuotaWindowView:537`, `StatusItemController:1050`) | `QuotaPaceForecast.compute` blends every stored observation per completed cycle (O(cycles·observations), thousands of points per bucket), per bucket per body pass and per 30 s tick | Longest main-thread stall ≤ 16 ms; popover open ≤ 100 ms; idle CPU with mini windows | **Fixed**: exact-input memo in `QuotaService` (4 entries/bucket for the differently-phased TimelineViews); a hit is a few COW identity comparisons |
| 3 | Overview / provider Cost History card | `Sources/VibeBarApp/Views/CostHistoryView.swift` (was `visiblePoints(window:granularity:)`) | Hover moved `hoveredDate` → body re-ran → week/month paths re-aggregated the whole daily history and re-folded per-day model breakdowns per pointer move | Hover/crosshair 1-frame budget; hitch rate | **Fixed**: `visiblePoints` memoized on (snapshot, visibleRange, granularity); pan/zoom still rebuilds as it must |
| 4 | Overview / provider Past Year heatmap | `Sources/VibeBarApp/Views/YearlyContributionHeatmapView.swift:186,247` | `DateFormatter()` allocated per cell (~365×) per body pass in `.help(tooltip(for:))`, plus one per pass for month labels | Popover open ≤ 100 ms; hitch rate while scrolling Overview | **Fixed**: static formatters |
| 5 | Settings → Mini Windows picker | `Sources/VibeBarApp/Views/MiniWindowsSettingsSection.swift:337` | `DateFormatter()` per dimmed row per body pass; section re-renders on every settings/quota publish and per pointer move during a drag | Settings section hitch rate | **Fixed**: static formatter |
| 6 | Usage Stats Periods table (Hourly) | `Sources/VibeBarApp/Views/Workbench/UsageBreakdownTables.swift:164` | `periodsTable` hands the page scroller its full content height, so at 30 d × Hourly up to ~720 `LazyVStack` rows realize (and stay realized) while scrolling | Hitch rate ≥ 10 ms/s while scrolling | **Found, not fixed** (see below) |
| 7 | Settings → Model Pricing | `Sources/VibeBarApp/Views/PricingSettingsSection.swift:13,167,205,216,227` | `effectiveModelPrices` merge+sorts rebuilt per body pass; raw `TextField`s in the override editor write `AppSettings` per keystroke → full `$settings` fan-out per keystroke (disk writes stay coalesced by `SettingsStore`) | § 7 "hot paths must debounce or bypass AppSettings"; Settings hitch rate | **Found, not fixed** |
| 8 | Observable fan-out (general) | e.g. `SettingsView`, `PopoverRoot` observing whole `SettingsStore` / `QuotaService` | Any settings write re-diffs every subscriber; worst with a popover + mini windows open. Status item is already throttled (120 ms) | Hitch rate | **Found, not fixed** (architecture) |

### Verified healthy (no action)
- `QuotaHistoryChartView` and `OverviewQuotaHistoryCard` already use `.equatable()`, signature-keyed rebuild caches, `ChartMarkBudget` thinning, and `ChartSampleSearch` binary-search hover.
- `UsageEventLedger` is an actor; every Usage Stats query runs off the main actor and lands as one consolidated `results` publication (`UsageStatsViewModel`).
- `SettingsStore` coalesces disk writes at 250 ms — the ≤ 1/s settings-file write budget is met.
- All other `DateFormatter`s in App views were already static.
- No `TimelineView(.periodic)` in eagerly-instantiated deep trees; existing instances are leaf/page-scoped per § 11.

## Found, not fixed — suggested approaches

1. **`UsageBreakdownTables.swift:164` (periods table height)** — clamp the Periods table to its own scrolling viewport the way `requestsTable` (line 203) already does, or paginate periods like requests. Changes visible layout, so out of scope for a mechanical pass.
2. **`PricingSettingsSection.swift:167,205,216,227`** — move the override editor onto draft state committed on focus loss / debounce (mirror `DebouncedSettingsTextField`), and memoize `effectiveModelPrices` keyed on the pricing refresh stamp. Changes commit timing of user input, so left for a deliberate pass.
3. **`YearlyContributionHeatmapView.swift`** — `makeColumns()` walks 365 days of `Calendar` math per body pass and the grid is ~371 shape views; § 11 prefers one drawing surface for dense grids, but per-cell `.help` tooltips require views. If it shows in a trace: cache columns keyed on `history` and move color fill to `Canvas` with a custom hover tooltip.
4. **`MiniWindowsSettingsSection.swift:246,350,554`** — `pickerSections()` / `arrangeRows()` / `groupLabelOptions` rebuild per body pass and re-query `environment.quota(for:)` per tool. Evaluated per the audit brief: these are dictionary lookups over a ~40–80 row catalog, dominated by SwiftUI diffing rather than data work — the real per-row cost was the formatter (fixed, row 5). Cache keyed on (`fieldRegistry`, quota revisions) only if a trace shows it.
5. **Observable fan-out** — narrowing `$settings` observation needs per-field publishers or an `@Observable` migration; architecture-level, not mechanical.

## Test plan

- `swift build` ✓
- `swift test` — 1660 tests, 1 skipped, 0 failures ✓
- `./Scripts/build_app.sh release` ✓
- `codesign -d --entitlements - ".build/Vibe Bar.app"` → empty dict, no `app-sandbox` ✓
- `codesign --verify --deep --strict ".build/Vibe Bar.app"` ✓
- Home-API grep from AGENTS.md § 6 — no new hits ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)
