### PR TITLE
Put the refill horizon in the popover and a Resets page in Workbench

### DIFF
--- a/Sources/VibeBarApp/Views/PageModuleCatalog.swift
+++ b/Sources/VibeBarApp/Views/PageModuleCatalog.swift
@@ -38,6 +38,7 @@ enum PageModuleKind: Hashable {
     case overviewCostAll
     case overviewCost(ToolType)
     case overviewUsageMix
+    case overviewUpcomingResets
     case overviewModelRanking
     case overviewYearHeatmap
     case overviewActivityHeatmap
@@ -156,6 +157,18 @@ enum PageModuleCatalog {
                 accent: .neutral,
                 masonryPhase: .summary,
                 fallbackHeight: FallbackHeight.summary
+            )
+        )
+        // Refill horizon — a quota answer, so it sits with the quota band.
+        result.append(
+            PageModuleDescriptor(
+                id: .custom("overview-upcoming-resets"),
+                kind: .overviewUpcomingResets,
+                displayName: "Upcoming Resets",
+                defaultColumn: 1,
+                accent: .neutral,
+                masonryPhase: .quota,
+                fallbackHeight: FallbackHeight.status
             )
         )
         let hasCostData = self.hasCostData(environment: environment, settings: settings)

--- a/Sources/VibeBarApp/Views/PopoverRoot.swift
+++ b/Sources/VibeBarApp/Views/PopoverRoot.swift
@@ -624,6 +624,8 @@ private struct OverviewWaterfall: View {
             }
         case .overviewUsageMix:
             OverviewUsageMixCard(density: density)
+        case .overviewUpcomingResets:
+            UpcomingResetsCard(density: density)
         case .overviewModelRanking:
             ModelRankingList(
                 breakdowns: context.models,
@@ -1787,7 +1789,7 @@ private struct ProviderPageModule: View {
             }
         case .overviewCostSummary, .overviewStatusSummary, .overviewQuota,
              .overviewQuotaHistoryAll, .overviewCostAll, .overviewCost,
-             .overviewUsageMix, .overviewModelRanking,
+             .overviewUsageMix, .overviewUpcomingResets, .overviewModelRanking,
              .overviewYearHeatmap, .overviewActivityHeatmap:
             // Overview families. `PageModuleCatalog` never puts them on a
             // provider page, and a stale identifier is dropped before it gets

--- a/Sources/VibeBarApp/Views/UpcomingResets.swift
+++ b/Sources/VibeBarApp/Views/UpcomingResets.swift
@@ -5,6 +5,10 @@ import VibeBarCore
 /// comes back, and how tight the bucket is right now.
 struct UpcomingResetEvent: Identifiable {
     let tool: ToolType
+    let accountId: String
+    /// Set only when the tool has several accounts, so a single-account
+    /// setup keeps its short labels.
+    let accountLabel: String?
     let subProviderName: String
     let groupTitle: String?
     let bucketId: String
@@ -14,14 +18,20 @@ struct UpcomingResetEvent: Identifiable {
     let gainPercent: Double
     let resetAt: Date
 
-    var id: String { "\(tool.rawValue).\(bucketId)" }
+    var id: String { "\(accountId).\(bucketId)" }
 
     /// "Claude · Fable · Weekly" — canonical quota-axis names, full words.
     var label: String {
+        var base: String
         if let groupTitle {
-            return "\(subProviderName) · \(groupTitle) · \(bucketTitle)"
+            base = "\(subProviderName) · \(groupTitle) · \(bucketTitle)"
+        } else {
+            base = "\(subProviderName) · \(bucketTitle)"
         }
-        return "\(subProviderName) · \(bucketTitle)"
+        if let accountLabel {
+            base += " · \(accountLabel)"
+        }
+        return base
     }
 }
 
@@ -37,25 +47,33 @@ enum UpcomingResets {
         let horizon = now.addingTimeInterval(horizonDays * 86_400)
         var out: [UpcomingResetEvent] = []
         for tool in ToolType.dedicatedCardProviders {
-            guard let quota = environment.quota(for: tool) else { continue }
-            for bucket in quota.buckets {
-                guard let resetAt = bucket.resetAt,
-                      resetAt > now, resetAt <= horizon,
-                      bucket.usedPercent >= 1
-                else { continue }
-                let subProvider = tool.quotaSubProviderName(bucketID: bucket.id)
-                let group = bucket.groupTitle?.trimmingCharacters(in: .whitespacesAndNewlines)
-                out.append(UpcomingResetEvent(
-                    tool: tool,
-                    subProviderName: subProvider,
-                    groupTitle: (group?.isEmpty ?? true) || group?.caseInsensitiveCompare(subProvider) == .orderedSame
-                        ? nil : group,
-                    bucketId: bucket.id,
-                    bucketTitle: bucket.title,
-                    remainingPercent: max(0, 100 - bucket.usedPercent),
-                    gainPercent: bucket.usedPercent,
-                    resetAt: resetAt
-                ))
+            // Every account, not the first one — multi-account providers
+            // (Gemini, say) refill per account.
+            let accounts = environment.accountStore.accounts(for: tool)
+            for account in accounts {
+                guard let quota = environment.quotaService.cachedQuota(for: account.id) else { continue }
+                let accountLabel = accounts.count > 1 ? account.displayLabel : nil
+                for bucket in quota.buckets {
+                    guard let resetAt = bucket.resetAt,
+                          resetAt > now, resetAt <= horizon,
+                          bucket.usedPercent >= 1
+                    else { continue }
+                    let subProvider = tool.quotaSubProviderName(bucketID: bucket.id)
+                    let group = bucket.groupTitle?.trimmingCharacters(in: .whitespacesAndNewlines)
+                    out.append(UpcomingResetEvent(
+                        tool: tool,
+                        accountId: account.id,
+                        accountLabel: accountLabel,
+                        subProviderName: subProvider,
+                        groupTitle: (group?.isEmpty ?? true) || group?.caseInsensitiveCompare(subProvider) == .orderedSame
+                            ? nil : group,
+                        bucketId: bucket.id,
+                        bucketTitle: bucket.title,
+                        remainingPercent: max(0, 100 - bucket.usedPercent),
+                        gainPercent: bucket.usedPercent,
+                        resetAt: resetAt
+                    ))
+                }
             }
         }
         return out.sorted { $0.resetAt < $1.resetAt }

--- a/Sources/VibeBarApp/Views/UpcomingResets.swift
+++ b/Sources/VibeBarApp/Views/UpcomingResets.swift
@@ -46,7 +46,8 @@ enum UpcomingResets {
     ) -> [UpcomingResetEvent] {
         let horizon = now.addingTimeInterval(horizonDays * 86_400)
         var out: [UpcomingResetEvent] = []
-        for tool in ToolType.dedicatedCardProviders {
+        let settings = environment.settingsStore.settings
+        for tool in ToolType.dedicatedCardProviders where settings.isCoreProviderVisible(tool) {
             // Every account, not the first one — multi-account providers
             // (Gemini, say) refill per account.
             let accounts = environment.accountStore.accounts(for: tool)
@@ -113,17 +114,38 @@ struct ResetLaneView: View {
                         .frame(width: 30)
                         .offset(x: x - 15, y: laneHeight - 11)
                 }
+                let fanned = fannedOffsets(width: width)
                 ForEach(events) { event in
-                    marker(event, width: width)
+                    marker(event, width: width, fanOffset: fanned[event.id] ?? 0)
                 }
             }
         }
         .frame(height: laneHeight)
     }
 
-    private func marker(_ event: UpcomingResetEvent, width: CGFloat) -> some View {
+    /// Buckets that reset together (Claude's overall and model-scoped
+    /// weeklies, say) would stack into one indistinguishable column; fan a
+    /// cluster out by a column width per member.
+    private func fannedOffsets(width: CGFloat) -> [String: CGFloat] {
+        var byX: [Int: [String]] = [:]
+        for event in events {
+            let fraction = min(1, event.resetAt.timeIntervalSince(now) / (horizonDays * 86_400))
+            let slot = Int((width * fraction / 9).rounded())
+            byX[slot, default: []].append(event.id)
+        }
+        var offsets: [String: CGFloat] = [:]
+        for ids in byX.values where ids.count > 1 {
+            let span = CGFloat(ids.count - 1) * 9
+            for (index, id) in ids.enumerated() {
+                offsets[id] = CGFloat(index) * 9 - span / 2
+            }
+        }
+        return offsets
+    }
+
+    private func marker(_ event: UpcomingResetEvent, width: CGFloat, fanOffset: CGFloat) -> some View {
         let fraction = min(1, event.resetAt.timeIntervalSince(now) / (horizonDays * 86_400))
-        let x = max(4, min(width - 4, width * fraction))
+        let x = max(4, min(width - 4, width * fraction + fanOffset))
         let height = 6 + (laneHeight - 30) * event.gainPercent / 100
         return UnevenRoundedRectangle(
             topLeadingRadius: 3.5, bottomLeadingRadius: 1,

--- a/Sources/VibeBarApp/Views/UpcomingResets.swift
+++ b/Sources/VibeBarApp/Views/UpcomingResets.swift
@@ -1,0 +1,187 @@
+import SwiftUI
+import VibeBarCore
+
+/// One quota bucket refilling inside the visible horizon: when, how much
+/// comes back, and how tight the bucket is right now.
+struct UpcomingResetEvent: Identifiable {
+    let tool: ToolType
+    let subProviderName: String
+    let groupTitle: String?
+    let bucketId: String
+    let bucketTitle: String
+    let remainingPercent: Double
+    /// What the reset gives back — the used share of the window.
+    let gainPercent: Double
+    let resetAt: Date
+
+    var id: String { "\(tool.rawValue).\(bucketId)" }
+
+    /// "Claude · Fable · Weekly" — canonical quota-axis names, full words.
+    var label: String {
+        if let groupTitle {
+            return "\(subProviderName) · \(groupTitle) · \(bucketTitle)"
+        }
+        return "\(subProviderName) · \(bucketTitle)"
+    }
+}
+
+enum UpcomingResets {
+    /// Every dedicated-provider bucket whose reset lands within `horizonDays`
+    /// and gives anything back, soonest first. Reads only the cached quotas.
+    @MainActor
+    static func events(
+        environment: AppEnvironment,
+        now: Date,
+        horizonDays: Double = 7
+    ) -> [UpcomingResetEvent] {
+        let horizon = now.addingTimeInterval(horizonDays * 86_400)
+        var out: [UpcomingResetEvent] = []
+        for tool in ToolType.dedicatedCardProviders {
+            guard let quota = environment.quota(for: tool) else { continue }
+            for bucket in quota.buckets {
+                guard let resetAt = bucket.resetAt,
+                      resetAt > now, resetAt <= horizon,
+                      bucket.usedPercent >= 1
+                else { continue }
+                let subProvider = tool.quotaSubProviderName(bucketID: bucket.id)
+                let group = bucket.groupTitle?.trimmingCharacters(in: .whitespacesAndNewlines)
+                out.append(UpcomingResetEvent(
+                    tool: tool,
+                    subProviderName: subProvider,
+                    groupTitle: (group?.isEmpty ?? true) || group?.caseInsensitiveCompare(subProvider) == .orderedSame
+                        ? nil : group,
+                    bucketId: bucket.id,
+                    bucketTitle: bucket.title,
+                    remainingPercent: max(0, 100 - bucket.usedPercent),
+                    gainPercent: bucket.usedPercent,
+                    resetAt: resetAt
+                ))
+            }
+        }
+        return out.sorted { $0.resetAt < $1.resetAt }
+    }
+}
+
+/// The horizon as a lane: each refill is a slim column standing on a time
+/// axis — height says how much comes back, colour says how tight the bucket
+/// is right now, the leading hairline is *now*. Deliberately no rings.
+struct ResetLaneView: View {
+    let events: [UpcomingResetEvent]
+    let now: Date
+    var horizonDays: Double = 7
+    var laneHeight: CGFloat = 64
+
+    var body: some View {
+        GeometryReader { proxy in
+            let width = proxy.size.width
+            ZStack(alignment: .topLeading) {
+                Rectangle()
+                    .fill(Color.primary.opacity(0.13))
+                    .frame(width: width, height: 1)
+                    .offset(y: laneHeight - 14)
+                Rectangle()
+                    .fill(Color.primary.opacity(0.35))
+                    .frame(width: 2, height: laneHeight - 20)
+                    .offset(y: 4)
+                ForEach(1...Int(horizonDays), id: \.self) { day in
+                    let x = width * CGFloat(day) / horizonDays
+                    Rectangle()
+                        .fill(Color.primary.opacity(0.18))
+                        .frame(width: 1, height: 5)
+                        .offset(x: x, y: laneHeight - 18)
+                    Text("+\(day)d")
+                        .font(.system(size: 7.5, design: .rounded).monospacedDigit())
+                        .foregroundStyle(.tertiary)
+                        .frame(width: 30)
+                        .offset(x: x - 15, y: laneHeight - 11)
+                }
+                ForEach(events) { event in
+                    marker(event, width: width)
+                }
+            }
+        }
+        .frame(height: laneHeight)
+    }
+
+    private func marker(_ event: UpcomingResetEvent, width: CGFloat) -> some View {
+        let fraction = min(1, event.resetAt.timeIntervalSince(now) / (horizonDays * 86_400))
+        let x = max(4, min(width - 4, width * fraction))
+        let height = 6 + (laneHeight - 30) * event.gainPercent / 100
+        return UnevenRoundedRectangle(
+            topLeadingRadius: 3.5, bottomLeadingRadius: 1,
+            bottomTrailingRadius: 1, topTrailingRadius: 3.5,
+            style: .continuous
+        )
+        .fill(Theme.barColor(percent: event.remainingPercent, mode: .remaining))
+        .frame(width: 7, height: height)
+        .offset(x: x - 3.5, y: laneHeight - 14 - height)
+        .help("\(event.label) — \(Int(event.remainingPercent.rounded()))% now, +\(Int(event.gainPercent.rounded()))% \(ResetCountdownFormatter.string(from: event.resetAt, now: now) ?? "")")
+    }
+}
+
+/// Overview card: the 7-day lane plus the next three refills as rows.
+struct UpcomingResetsCard: View {
+    let density: Theme.Density
+
+    @EnvironmentObject private var environment: AppEnvironment
+    @EnvironmentObject private var quotaService: QuotaService
+
+    var body: some View {
+        // A leaf timer, one minute: the lane's countdowns drift slowly, and
+        // quota refreshes re-render the card on their own.
+        TimelineView(.periodic(from: .now, by: 60)) { context in
+            content(now: context.date)
+        }
+    }
+
+    @ViewBuilder
+    private func content(now: Date) -> some View {
+        let events = UpcomingResets.events(environment: environment, now: now)
+        CardShell(density: density, spacing: 8) {
+            HStack(alignment: .firstTextBaseline, spacing: 8) {
+                Text("Upcoming Resets")
+                    .font(.system(size: density.bucketTitleFontSize, weight: .semibold))
+                Spacer(minLength: 6)
+                Text("next 7 days")
+                    .font(.system(size: density.resetCountdownFontSize))
+                    .foregroundStyle(.tertiary)
+            }
+            if events.isEmpty {
+                Text("Nothing refills in the next seven days.")
+                    .font(.system(size: density.subtitleFontSize))
+                    .foregroundStyle(.tertiary)
+                    .padding(.vertical, 12)
+                    .frame(maxWidth: .infinity)
+            } else {
+                ResetLaneView(events: events, now: now)
+                VStack(spacing: 0) {
+                    ForEach(Array(events.prefix(3))) { event in
+                        row(event, now: now)
+                    }
+                }
+            }
+        }
+    }
+
+    private func row(_ event: UpcomingResetEvent, now: Date) -> some View {
+        HStack(spacing: 8) {
+            Circle()
+                .fill(Theme.providerAccent(for: event.tool))
+                .frame(width: 6, height: 6)
+            Text(event.label)
+                .font(.system(size: density.subtitleFontSize))
+                .foregroundStyle(.primary.opacity(0.88))
+                .lineLimit(1)
+                .minimumScaleFactor(0.75)
+            Spacer(minLength: 6)
+            Text("+\(Int(event.gainPercent.rounded()))%")
+                .font(.system(size: density.subtitleFontSize, weight: .semibold, design: .rounded).monospacedDigit())
+                .foregroundStyle(Theme.barColor(percent: event.remainingPercent, mode: .remaining))
+            Text(ResetCountdownFormatter.string(from: event.resetAt, now: now) ?? "—")
+                .font(.system(size: density.resetCountdownFontSize, design: .rounded).monospacedDigit())
+                .foregroundStyle(.secondary)
+        }
+        .padding(.vertical, 3)
+        .help(event.label)
+    }
+}

--- a/Sources/VibeBarApp/Views/Workbench/ResetsPage.swift
+++ b/Sources/VibeBarApp/Views/Workbench/ResetsPage.swift
@@ -22,7 +22,14 @@ struct ResetsPage: View {
     @ViewBuilder
     private func content(now: Date) -> some View {
         let events = UpcomingResets.events(environment: environment, now: now, horizonDays: 14)
-        let cycles = subProviderCycles(now: now)
+        // Forecasts run on a 5-minute clock: the pace blend over the full
+        // observation history is the expensive part, and QuotaService memoizes
+        // it on exact inputs — a fresh `now` every 60 s tick would defeat
+        // that for every bucket on the page. Countdown strings keep the
+        // minute clock.
+        let cycles = subProviderCycles(now: Date(
+            timeIntervalSinceReferenceDate: (now.timeIntervalSinceReferenceDate / 300).rounded(.down) * 300
+        ))
         ScrollView(.vertical) {
             VStack(alignment: .leading, spacing: 14) {
                 box {
@@ -222,9 +229,9 @@ struct ResetsPage: View {
                 let w = proxy.size.width
                 let h = proxy.size.height
                 Path { path in
-                    for (index, value) in points.enumerated() {
-                        let x = w * CGFloat(index) / CGFloat(points.count - 1)
-                        let y = h - h * CGFloat(value) / 100
+                    for (index, point) in points.enumerated() {
+                        let x = w * CGFloat(point.fraction)
+                        let y = h - h * CGFloat(point.remaining) / 100
                         if index == 0 { path.move(to: CGPoint(x: x, y: y)) }
                         else { path.addLine(to: CGPoint(x: x, y: y)) }
                     }
@@ -239,21 +246,36 @@ struct ResetsPage: View {
         }
     }
 
-    private func cyclePoints(_ cycle: SubProviderCycle) -> [Double] {
+    private struct CyclePoint {
+        /// Position across the cycle window, 0…1 — samples sit where their
+        /// timestamps put them, so a gap (app closed, refreshes off) reads
+        /// as a gap instead of compressing the curve.
+        let fraction: Double
+        let remaining: Double
+    }
+
+    private func cyclePoints(_ cycle: SubProviderCycle) -> [CyclePoint] {
         guard let resetAt = cycle.headline.resetAt,
-              let window = cycle.headline.rawWindowSeconds
+              let window = cycle.headline.rawWindowSeconds, window > 0
         else { return [] }
         let key = SubscriptionHistoryKey(accountId: cycle.accountId, bucketId: cycle.headline.id)
         let cycleStart = resetAt.addingTimeInterval(-Double(window))
         let samples = (quotaService.observationsByAccountBucket[key] ?? [])
             .filter { $0.slotStart >= cycleStart }
-            .map { max(0, 100 - $0.usedPercent) }
+            .map { sample in
+                CyclePoint(
+                    fraction: min(1, max(0, sample.slotStart.timeIntervalSince(cycleStart) / Double(window))),
+                    remaining: max(0, 100 - sample.usedPercent)
+                )
+            }
         guard samples.count > 2 else { return samples }
         // Bounded draw: the chart is 30 pt tall, forty-eight segments is
         // already denser than it can show.
         let stride = max(1, samples.count / 48)
         var thinned = Swift.stride(from: 0, to: samples.count, by: stride).map { samples[$0] }
-        if let last = samples.last, thinned.last != last { thinned.append(last) }
+        if let last = samples.last, thinned.last?.fraction != last.fraction {
+            thinned.append(last)
+        }
         return thinned
     }
 
@@ -349,7 +371,7 @@ struct ResetsPage: View {
                         .background(
                             Capsule().fill(Theme.barColor(percent: remaining, mode: .remaining))
                         )
-                    Text("\(row.cycle.name) · \(row.bucket.groupTitle.map { "\($0) · " } ?? "")\(row.bucket.title)")
+                    Text("\(row.cycle.name)\(row.cycle.accountLabel.map { " · \($0)" } ?? "") · \(row.bucket.groupTitle.map { "\($0) · " } ?? "")\(row.bucket.title)")
                         .font(.system(size: 10))
                         .lineLimit(1)
                         .minimumScaleFactor(0.75)
@@ -364,11 +386,13 @@ struct ResetsPage: View {
     }
 
     private func riskBadge(remaining: Double, forecast: QuotaPaceForecast?) -> String {
+        // OUT means exhausted, full stop; a calm or still-learning bucket
+        // that happens to be low is LOW, and only the forecast may escalate.
         if remaining <= 1 { return "OUT" }
         switch forecast?.verdict {
         case .atRisk: return "RISK"
         case .watch: return "WATCH"
-        default: return remaining <= 5 ? "OUT" : "LOW"
+        default: return "LOW"
         }
     }
 

--- a/Sources/VibeBarApp/Views/Workbench/ResetsPage.swift
+++ b/Sources/VibeBarApp/Views/Workbench/ResetsPage.swift
@@ -10,7 +10,6 @@ struct ResetsPage: View {
     @EnvironmentObject private var environment: AppEnvironment
     @EnvironmentObject private var settingsStore: SettingsStore
     @EnvironmentObject private var quotaService: QuotaService
-    @Environment(\.colorScheme) private var colorScheme
 
     var body: some View {
         // One leaf timer for the whole page: countdown text drifts by the
@@ -58,48 +57,71 @@ struct ResetsPage: View {
     /// window — the cycle a subscription is priced on), and the forecast.
     private struct SubProviderCycle: Identifiable {
         let tool: ToolType
+        let accountId: String
+        let accountLabel: String?
         let name: String
         let plan: String?
         let buckets: [QuotaBucket]
         let headline: QuotaBucket
         let forecast: QuotaPaceForecast?
-        var id: String { "\(tool.rawValue)/\(name)" }
+        var id: String { "\(accountId)/\(name)" }
     }
 
     private func subProviderCycles(now: Date) -> [SubProviderCycle] {
         var out: [SubProviderCycle] = []
         for tool in ToolType.dedicatedCardProviders {
-            guard let quota = environment.quota(for: tool), !quota.buckets.isEmpty else { continue }
-            var bySub: [String: [QuotaBucket]] = [:]
-            var order: [String] = []
-            for bucket in quota.buckets {
-                let sub = tool.quotaSubProviderName(bucketID: bucket.id)
-                if bySub[sub] == nil { order.append(sub) }
-                bySub[sub, default: []].append(bucket)
-            }
-            for sub in order {
-                guard let buckets = bySub[sub],
-                      let headline = buckets.max(by: {
-                          ($0.rawWindowSeconds ?? 0) < ($1.rawWindowSeconds ?? 0)
-                      })
+            let accounts = environment.accountStore.accounts(for: tool)
+            for account in accounts {
+                guard let quota = environment.quotaService.cachedQuota(for: account.id),
+                      !quota.buckets.isEmpty
                 else { continue }
-                out.append(SubProviderCycle(
-                    tool: tool,
-                    name: sub,
-                    plan: quota.plan,
-                    buckets: buckets,
-                    headline: headline,
-                    forecast: miniQuotaForecast(
+                let accountLabel = accounts.count > 1 ? account.displayLabel : nil
+                var bySub: [String: [QuotaBucket]] = [:]
+                var order: [String] = []
+                for bucket in quota.buckets {
+                    let sub = tool.quotaSubProviderName(bucketID: bucket.id)
+                    if bySub[sub] == nil { order.append(sub) }
+                    bySub[sub, default: []].append(bucket)
+                }
+                for sub in order {
+                    guard let buckets = bySub[sub],
+                          let headline = buckets.max(by: {
+                              ($0.rawWindowSeconds ?? 0) < ($1.rawWindowSeconds ?? 0)
+                          })
+                    else { continue }
+                    out.append(SubProviderCycle(
                         tool: tool,
-                        bucket: headline,
-                        environment: environment,
-                        quotaService: quotaService,
-                        now: now
-                    )
-                ))
+                        accountId: account.id,
+                        accountLabel: accountLabel,
+                        name: sub,
+                        plan: quota.plan,
+                        buckets: buckets,
+                        headline: headline,
+                        forecast: forecast(accountId: account.id, tool: tool, bucket: headline, now: now)
+                    ))
+                }
             }
         }
         return out
+    }
+
+    /// Per-account forecast — `miniQuotaForecast` resolves the tool's first
+    /// account, which is wrong the moment a provider has two.
+    private func forecast(
+        accountId: String,
+        tool: ToolType,
+        bucket: QuotaBucket,
+        now: Date
+    ) -> QuotaPaceForecast? {
+        let snapshot = environment.costService.snapshot(for: tool)
+        return quotaService.paceForecast(
+            accountId: accountId,
+            bucket: bucket,
+            activityHeatmap: snapshot?.heatmap,
+            dailyActivity: snapshot?.dailyHistory ?? [],
+            now: now,
+            allowsPostResetGrace: true
+        )
     }
 
     // MARK: - Cycle cards
@@ -128,6 +150,13 @@ struct ResetsPage: View {
                     .font(.system(size: 10, weight: .bold))
                     .tracking(0.4)
                 Spacer(minLength: 6)
+                if let accountLabel = cycle.accountLabel {
+                    Text(accountLabel)
+                        .font(.system(size: 8.5, weight: .medium))
+                        .foregroundStyle(.tertiary)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.7)
+                }
                 if let plan = cycle.plan {
                     Text(plan)
                         .font(.system(size: 9, weight: .semibold))
@@ -211,11 +240,10 @@ struct ResetsPage: View {
     }
 
     private func cyclePoints(_ cycle: SubProviderCycle) -> [Double] {
-        guard let accountId = environment.account(for: cycle.tool)?.id,
-              let resetAt = cycle.headline.resetAt,
+        guard let resetAt = cycle.headline.resetAt,
               let window = cycle.headline.rawWindowSeconds
         else { return [] }
-        let key = SubscriptionHistoryKey(accountId: accountId, bucketId: cycle.headline.id)
+        let key = SubscriptionHistoryKey(accountId: cycle.accountId, bucketId: cycle.headline.id)
         let cycleStart = resetAt.addingTimeInterval(-Double(window))
         let samples = (quotaService.observationsByAccountBucket[key] ?? [])
             .filter { $0.slotStart >= cycleStart }
@@ -234,10 +262,13 @@ struct ResetsPage: View {
     private func calendar(_ events: [UpcomingResetEvent], now: Date) -> some View {
         let columns = [GridItem(.adaptive(minimum: 96), spacing: 6, alignment: .top)]
         let calendar = Calendar.current
+        let todayStart = calendar.startOfDay(for: now)
         return LazyVGrid(columns: columns, alignment: .leading, spacing: 6) {
             ForEach(0..<14, id: \.self) { offset in
-                let dayStart = calendar.startOfDay(for: now).addingTimeInterval(Double(offset) * 86_400)
-                let dayEnd = dayStart.addingTimeInterval(86_400)
+                // Calendar arithmetic, not fixed 86 400 s — a DST transition
+                // would otherwise shift every later cell off local midnight.
+                let dayStart = calendar.date(byAdding: .day, value: offset, to: todayStart) ?? todayStart
+                let dayEnd = calendar.date(byAdding: .day, value: 1, to: dayStart) ?? dayStart.addingTimeInterval(86_400)
                 let hits = events.filter { $0.resetAt >= max(dayStart, now) && $0.resetAt < dayEnd }
                 VStack(alignment: .leading, spacing: 3) {
                     Text(offset == 0 ? "Today" : dayStart.formatted(.dateTime.weekday(.abbreviated).day()))
@@ -279,21 +310,23 @@ struct ResetsPage: View {
         var rows: [(cycle: SubProviderCycle, bucket: QuotaBucket, forecast: QuotaPaceForecast?)] = []
         for cycle in cycles {
             for bucket in cycle.buckets {
-                let forecast = bucket.id == cycle.headline.id
+                let bucketForecast = bucket.id == cycle.headline.id
                     ? cycle.forecast
-                    : miniQuotaForecast(
-                        tool: cycle.tool, bucket: bucket,
-                        environment: environment, quotaService: quotaService, now: now
-                    )
+                    : forecast(accountId: cycle.accountId, tool: cycle.tool, bucket: bucket, now: now)
                 let remaining = max(0, 100 - bucket.usedPercent)
-                let uneasy = forecast.map { $0.verdict == .watch || $0.verdict == .atRisk } ?? false
+                let uneasy = bucketForecast.map { $0.verdict == .watch || $0.verdict == .atRisk } ?? false
                 if uneasy || remaining <= 15 {
-                    rows.append((cycle, bucket, forecast))
+                    rows.append((cycle, bucket, bucketForecast))
                 }
             }
         }
-        rows.sort {
-            (100 - $0.bucket.usedPercent) < (100 - $1.bucket.usedPercent)
+        // The forecast's projected run-out ranks first; buckets it is calm
+        // about sort by what is left.
+        rows.sort { lhs, rhs in
+            let lhsOut = lhs.forecast?.runOutAt ?? Date.distantFuture
+            let rhsOut = rhs.forecast?.runOutAt ?? Date.distantFuture
+            if lhsOut != rhsOut { return lhsOut < rhsOut }
+            return (100 - lhs.bucket.usedPercent) < (100 - rhs.bucket.usedPercent)
         }
         return VStack(alignment: .leading, spacing: 0) {
             if rows.isEmpty {
@@ -305,7 +338,10 @@ struct ResetsPage: View {
             ForEach(Array(rows.enumerated()), id: \.offset) { _, row in
                 let remaining = max(0, 100 - row.bucket.usedPercent)
                 HStack(spacing: 7) {
-                    Text(remaining <= 5 ? "OUT" : "WATCH")
+                    // The badge is the forecast's verdict, not a raw
+                    // threshold: an at-risk bucket with 20% left is the one
+                    // to worry about, and a low-but-stable one is not "out".
+                    Text(riskBadge(remaining: remaining, forecast: row.forecast))
                         .font(.system(size: 8, weight: .heavy, design: .rounded))
                         .foregroundStyle(Color.black.opacity(0.8))
                         .padding(.horizontal, 5)
@@ -327,22 +363,22 @@ struct ResetsPage: View {
         }
     }
 
+    private func riskBadge(remaining: Double, forecast: QuotaPaceForecast?) -> String {
+        if remaining <= 1 { return "OUT" }
+        switch forecast?.verdict {
+        case .atRisk: return "RISK"
+        case .watch: return "WATCH"
+        default: return remaining <= 5 ? "OUT" : "LOW"
+        }
+    }
+
     // MARK: - Chrome
 
-    private func box(@ViewBuilder _ content: () -> some View) -> some View {
-        VStack(alignment: .leading, spacing: 8) {
-            content()
-        }
-        .padding(12)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .background(
-            RoundedRectangle(cornerRadius: 10, style: .continuous)
-                .fill(WorkbenchPorcelain.overlayFill(for: colorScheme))
-        )
-        .overlay(
-            RoundedRectangle(cornerRadius: 10, style: .continuous)
-                .stroke(WorkbenchPorcelain.hairline(for: colorScheme), lineWidth: 1)
-        )
+    /// The shared card surface — same shell as every other Workbench card,
+    /// so the porcelain floors apply here too.
+    private func box(@ViewBuilder _ content: @escaping () -> some View) -> some View {
+        CardShell(density: density, spacing: 8, content: content)
+            .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     private func boxHeader(_ title: String, detail: String) -> some View {

--- a/Sources/VibeBarApp/Views/Workbench/ResetsPage.swift
+++ b/Sources/VibeBarApp/Views/Workbench/ResetsPage.swift
@@ -1,0 +1,358 @@
+import SwiftUI
+import VibeBarCore
+
+/// Workbench · Resets & Subscriptions: every quota cycle on this Mac in one
+/// place — the refill horizon, each SubProvider's cycle with its fill curve
+/// and forecast, a fourteen-day reset calendar, and the run-out ranking.
+struct ResetsPage: View {
+    let density: Theme.Density
+
+    @EnvironmentObject private var environment: AppEnvironment
+    @EnvironmentObject private var settingsStore: SettingsStore
+    @EnvironmentObject private var quotaService: QuotaService
+    @Environment(\.colorScheme) private var colorScheme
+
+    var body: some View {
+        // One leaf timer for the whole page: countdown text drifts by the
+        // minute; data re-renders arrive with quota refreshes on their own.
+        TimelineView(.periodic(from: .now, by: 60)) { context in
+            content(now: context.date)
+        }
+    }
+
+    @ViewBuilder
+    private func content(now: Date) -> some View {
+        let events = UpcomingResets.events(environment: environment, now: now, horizonDays: 14)
+        let cycles = subProviderCycles(now: now)
+        ScrollView(.vertical) {
+            VStack(alignment: .leading, spacing: 14) {
+                box {
+                    boxHeader("Refill Horizon", detail: "next 7 days · column height = how much comes back")
+                    ResetLaneView(
+                        events: events.filter { $0.resetAt.timeIntervalSince(now) <= 7 * 86_400 },
+                        now: now,
+                        laneHeight: 96
+                    )
+                }
+                cycleGrid(cycles, now: now)
+                HStack(alignment: .top, spacing: 14) {
+                    box {
+                        boxHeader("Reset Calendar", detail: "14 days")
+                        calendar(events, now: now)
+                    }
+                    .frame(maxWidth: .infinity)
+                    box {
+                        boxHeader("Run-out Risk", detail: "ranked by the personal forecast")
+                        riskList(cycles, now: now)
+                    }
+                    .frame(width: 320)
+                }
+            }
+            .padding(16)
+        }
+    }
+
+    // MARK: - Cycle model
+
+    /// One L2 SubProvider's live cycle: its buckets, the headline (longest
+    /// window — the cycle a subscription is priced on), and the forecast.
+    private struct SubProviderCycle: Identifiable {
+        let tool: ToolType
+        let name: String
+        let plan: String?
+        let buckets: [QuotaBucket]
+        let headline: QuotaBucket
+        let forecast: QuotaPaceForecast?
+        var id: String { "\(tool.rawValue)/\(name)" }
+    }
+
+    private func subProviderCycles(now: Date) -> [SubProviderCycle] {
+        var out: [SubProviderCycle] = []
+        for tool in ToolType.dedicatedCardProviders {
+            guard let quota = environment.quota(for: tool), !quota.buckets.isEmpty else { continue }
+            var bySub: [String: [QuotaBucket]] = [:]
+            var order: [String] = []
+            for bucket in quota.buckets {
+                let sub = tool.quotaSubProviderName(bucketID: bucket.id)
+                if bySub[sub] == nil { order.append(sub) }
+                bySub[sub, default: []].append(bucket)
+            }
+            for sub in order {
+                guard let buckets = bySub[sub],
+                      let headline = buckets.max(by: {
+                          ($0.rawWindowSeconds ?? 0) < ($1.rawWindowSeconds ?? 0)
+                      })
+                else { continue }
+                out.append(SubProviderCycle(
+                    tool: tool,
+                    name: sub,
+                    plan: quota.plan,
+                    buckets: buckets,
+                    headline: headline,
+                    forecast: miniQuotaForecast(
+                        tool: tool,
+                        bucket: headline,
+                        environment: environment,
+                        quotaService: quotaService,
+                        now: now
+                    )
+                ))
+            }
+        }
+        return out
+    }
+
+    // MARK: - Cycle cards
+
+    private func cycleGrid(_ cycles: [SubProviderCycle], now: Date) -> some View {
+        LazyVGrid(
+            columns: [GridItem(.adaptive(minimum: 270), spacing: 12, alignment: .top)],
+            alignment: .leading,
+            spacing: 12
+        ) {
+            ForEach(cycles) { cycle in
+                cycleCard(cycle, now: now)
+            }
+        }
+    }
+
+    private func cycleCard(_ cycle: SubProviderCycle, now: Date) -> some View {
+        let remaining = max(0, 100 - cycle.headline.usedPercent)
+        let color = Theme.barColor(percent: remaining, mode: .remaining)
+        return box {
+            HStack(spacing: 6) {
+                Circle()
+                    .fill(Theme.providerAccent(for: cycle.tool))
+                    .frame(width: 6, height: 6)
+                Text(cycle.name.uppercased())
+                    .font(.system(size: 10, weight: .bold))
+                    .tracking(0.4)
+                Spacer(minLength: 6)
+                if let plan = cycle.plan {
+                    Text(plan)
+                        .font(.system(size: 9, weight: .semibold))
+                        .foregroundStyle(.tertiary)
+                }
+            }
+            HStack(alignment: .firstTextBaseline, spacing: 6) {
+                Text("\(Int(remaining.rounded()))%")
+                    .font(.system(size: 24, weight: .bold, design: .rounded).monospacedDigit())
+                    .foregroundStyle(color)
+                Text("\(cycle.headline.title) · resets \(ResetCountdownFormatter.string(from: cycle.headline.resetAt, now: now) ?? "—")")
+                    .font(.system(size: 10, design: .rounded).monospacedDigit())
+                    .foregroundStyle(.secondary)
+            }
+            GeometryReader { proxy in
+                ZStack(alignment: .leading) {
+                    Capsule().fill(Color.primary.opacity(0.08))
+                    Capsule()
+                        .fill(color)
+                        .frame(width: max(2, proxy.size.width * remaining / 100))
+                }
+            }
+            .frame(height: 5)
+            bucketLines(cycle, now: now)
+            if let forecast = cycle.forecast {
+                Text(miniForecastLine(forecast, now: now))
+                    .font(.system(size: 10, weight: .semibold, design: .rounded).monospacedDigit())
+                    .foregroundStyle(miniForecastColor(forecast))
+            }
+            fillCurve(cycle)
+        }
+    }
+
+    private func bucketLines(_ cycle: SubProviderCycle, now: Date) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            ForEach(cycle.buckets.filter { $0.id != cycle.headline.id }, id: \.id) { bucket in
+                let remaining = max(0, 100 - bucket.usedPercent)
+                HStack(spacing: 5) {
+                    Text(bucket.groupTitle.map { "\($0) · \(bucket.title)" } ?? bucket.title)
+                        .font(.system(size: 9.5))
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.75)
+                    Spacer(minLength: 4)
+                    Text("\(Int(remaining.rounded()))%")
+                        .font(.system(size: 9.5, weight: .bold, design: .rounded).monospacedDigit())
+                        .foregroundStyle(Theme.barColor(percent: remaining, mode: .remaining))
+                    Text(ResetCountdownFormatter.string(from: bucket.resetAt, now: now) ?? "—")
+                        .font(.system(size: 8.5, design: .rounded).monospacedDigit())
+                        .foregroundStyle(.tertiary)
+                }
+            }
+        }
+    }
+
+    /// The headline bucket's remaining-percent curve across its current
+    /// cycle, from the fill-timeline observations the forecast already keeps.
+    @ViewBuilder
+    private func fillCurve(_ cycle: SubProviderCycle) -> some View {
+        let points = cyclePoints(cycle)
+        if points.count >= 2 {
+            GeometryReader { proxy in
+                let w = proxy.size.width
+                let h = proxy.size.height
+                Path { path in
+                    for (index, value) in points.enumerated() {
+                        let x = w * CGFloat(index) / CGFloat(points.count - 1)
+                        let y = h - h * CGFloat(value) / 100
+                        if index == 0 { path.move(to: CGPoint(x: x, y: y)) }
+                        else { path.addLine(to: CGPoint(x: x, y: y)) }
+                    }
+                }
+                .stroke(
+                    Theme.providerAccent(for: cycle.tool).opacity(0.75),
+                    style: StrokeStyle(lineWidth: 1.5, lineJoin: .round)
+                )
+            }
+            .frame(height: 30)
+            .help("Remaining % across the current \(cycle.headline.title) cycle")
+        }
+    }
+
+    private func cyclePoints(_ cycle: SubProviderCycle) -> [Double] {
+        guard let accountId = environment.account(for: cycle.tool)?.id,
+              let resetAt = cycle.headline.resetAt,
+              let window = cycle.headline.rawWindowSeconds
+        else { return [] }
+        let key = SubscriptionHistoryKey(accountId: accountId, bucketId: cycle.headline.id)
+        let cycleStart = resetAt.addingTimeInterval(-Double(window))
+        let samples = (quotaService.observationsByAccountBucket[key] ?? [])
+            .filter { $0.slotStart >= cycleStart }
+            .map { max(0, 100 - $0.usedPercent) }
+        guard samples.count > 2 else { return samples }
+        // Bounded draw: the chart is 30 pt tall, forty-eight segments is
+        // already denser than it can show.
+        let stride = max(1, samples.count / 48)
+        var thinned = Swift.stride(from: 0, to: samples.count, by: stride).map { samples[$0] }
+        if let last = samples.last, thinned.last != last { thinned.append(last) }
+        return thinned
+    }
+
+    // MARK: - Calendar
+
+    private func calendar(_ events: [UpcomingResetEvent], now: Date) -> some View {
+        let columns = [GridItem(.adaptive(minimum: 96), spacing: 6, alignment: .top)]
+        let calendar = Calendar.current
+        return LazyVGrid(columns: columns, alignment: .leading, spacing: 6) {
+            ForEach(0..<14, id: \.self) { offset in
+                let dayStart = calendar.startOfDay(for: now).addingTimeInterval(Double(offset) * 86_400)
+                let dayEnd = dayStart.addingTimeInterval(86_400)
+                let hits = events.filter { $0.resetAt >= max(dayStart, now) && $0.resetAt < dayEnd }
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(offset == 0 ? "Today" : dayStart.formatted(.dateTime.weekday(.abbreviated).day()))
+                        .font(.system(size: 8.5, weight: .semibold))
+                        .foregroundStyle(.tertiary)
+                    ForEach(hits) { event in
+                        HStack(spacing: 3) {
+                            Circle()
+                                .fill(Theme.providerAccent(for: event.tool))
+                                .frame(width: 4, height: 4)
+                            Text("\(event.subProviderName) +\(Int(event.gainPercent.rounded()))%")
+                                .font(.system(size: 8, weight: .semibold, design: .rounded).monospacedDigit())
+                                .foregroundStyle(.secondary)
+                                .lineLimit(1)
+                                .minimumScaleFactor(0.7)
+                        }
+                        .help(event.label)
+                    }
+                    if hits.isEmpty {
+                        Text("—")
+                            .font(.system(size: 8))
+                            .foregroundStyle(.quaternary)
+                    }
+                }
+                .padding(6)
+                .frame(maxWidth: .infinity, minHeight: 52, alignment: .topLeading)
+                .background(
+                    RoundedRectangle(cornerRadius: 7, style: .continuous)
+                        .fill(Color.primary.opacity(hits.isEmpty ? 0.025 : 0.05))
+                )
+            }
+        }
+    }
+
+    // MARK: - Risk
+
+    private func riskList(_ cycles: [SubProviderCycle], now: Date) -> some View {
+        // Every bucket whose forecast is uneasy, or that is simply low now.
+        var rows: [(cycle: SubProviderCycle, bucket: QuotaBucket, forecast: QuotaPaceForecast?)] = []
+        for cycle in cycles {
+            for bucket in cycle.buckets {
+                let forecast = bucket.id == cycle.headline.id
+                    ? cycle.forecast
+                    : miniQuotaForecast(
+                        tool: cycle.tool, bucket: bucket,
+                        environment: environment, quotaService: quotaService, now: now
+                    )
+                let remaining = max(0, 100 - bucket.usedPercent)
+                let uneasy = forecast.map { $0.verdict == .watch || $0.verdict == .atRisk } ?? false
+                if uneasy || remaining <= 15 {
+                    rows.append((cycle, bucket, forecast))
+                }
+            }
+        }
+        rows.sort {
+            (100 - $0.bucket.usedPercent) < (100 - $1.bucket.usedPercent)
+        }
+        return VStack(alignment: .leading, spacing: 0) {
+            if rows.isEmpty {
+                Text("Every bucket is projected to last its cycle.")
+                    .font(.system(size: 10.5))
+                    .foregroundStyle(.tertiary)
+                    .padding(.vertical, 8)
+            }
+            ForEach(Array(rows.enumerated()), id: \.offset) { _, row in
+                let remaining = max(0, 100 - row.bucket.usedPercent)
+                HStack(spacing: 7) {
+                    Text(remaining <= 5 ? "OUT" : "WATCH")
+                        .font(.system(size: 8, weight: .heavy, design: .rounded))
+                        .foregroundStyle(Color.black.opacity(0.8))
+                        .padding(.horizontal, 5)
+                        .padding(.vertical, 1.5)
+                        .background(
+                            Capsule().fill(Theme.barColor(percent: remaining, mode: .remaining))
+                        )
+                    Text("\(row.cycle.name) · \(row.bucket.groupTitle.map { "\($0) · " } ?? "")\(row.bucket.title)")
+                        .font(.system(size: 10))
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.75)
+                    Spacer(minLength: 4)
+                    Text("\(Int(remaining.rounded()))% · refills \(ResetCountdownFormatter.string(from: row.bucket.resetAt, now: now) ?? "—")")
+                        .font(.system(size: 9, design: .rounded).monospacedDigit())
+                        .foregroundStyle(.secondary)
+                }
+                .padding(.vertical, 4)
+            }
+        }
+    }
+
+    // MARK: - Chrome
+
+    private func box(@ViewBuilder _ content: () -> some View) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            content()
+        }
+        .padding(12)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                .fill(WorkbenchPorcelain.overlayFill(for: colorScheme))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                .stroke(WorkbenchPorcelain.hairline(for: colorScheme), lineWidth: 1)
+        )
+    }
+
+    private func boxHeader(_ title: String, detail: String) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: 8) {
+            Text(title)
+                .font(.system(size: 12, weight: .semibold))
+            Spacer(minLength: 6)
+            Text(detail)
+                .font(.system(size: 9.5))
+                .foregroundStyle(.tertiary)
+        }
+    }
+}

--- a/Sources/VibeBarApp/Views/Workbench/WorkbenchPlaceholderPage.swift
+++ b/Sources/VibeBarApp/Views/Workbench/WorkbenchPlaceholderPage.swift
@@ -28,6 +28,8 @@ struct WorkbenchPlaceholderPage: View {
         switch page {
         case .usageStats:
             "Full-window usage and cost analytics are on their way."
+        case .resets:
+            "Cycle, refill and forecast views are on their way."
         case .sessionManager:
             "Browsing and searching local Codex and Claude Code sessions is on its way."
         case .skillsManager:

--- a/Sources/VibeBarApp/Views/Workbench/WorkbenchRootView.swift
+++ b/Sources/VibeBarApp/Views/Workbench/WorkbenchRootView.swift
@@ -4,6 +4,7 @@ import VibeBarCore
 enum WorkbenchPage: String, CaseIterable, Identifiable {
     case usageStats
     case sessionManager
+    case resets
     case skillsManager
     case settings
 
@@ -13,6 +14,7 @@ enum WorkbenchPage: String, CaseIterable, Identifiable {
         switch self {
         case .usageStats: "Usage Stats"
         case .sessionManager: "Sessions"
+        case .resets: "Resets"
         case .skillsManager: "Skills"
         case .settings: "Settings"
         }
@@ -22,6 +24,7 @@ enum WorkbenchPage: String, CaseIterable, Identifiable {
         switch self {
         case .usageStats: "chart.xyaxis.line"
         case .sessionManager: "bubble.left.and.text.bubble.right"
+        case .resets: "clock.arrow.circlepath"
         case .skillsManager: "puzzlepiece.extension"
         case .settings: "gearshape"
         }
@@ -33,6 +36,7 @@ enum WorkbenchPage: String, CaseIterable, Identifiable {
         switch self {
         case .usageStats: "Local per-request ledger · all providers"
         case .sessionManager: "Search and resume local agent sessions"
+        case .resets: "Cycles, refills, and run-out forecasts"
         case .skillsManager: "One shared skill library · every agent CLI"
         case .settings: "Appearance, providers, data, privacy, and sync"
         }
@@ -159,6 +163,12 @@ struct WorkbenchRootView: View {
         case .sessionManager:
             let count = workbench.sessions.totalSessionCount
             return count == 0 ? "local index" : "\(count.formatted()) indexed"
+        case .resets:
+            let next = UpcomingResets.events(environment: environment, now: Date(), horizonDays: 7).first
+            guard let next,
+                  let countdown = ResetCountdownFormatter.string(from: next.resetAt, now: Date())
+            else { return "cached quotas" }
+            return "next refill \(countdown)"
         case .skillsManager:
             let count = workbench.skills.skills.count
             return count == 0 ? "shared library" : "\(count.formatted()) installed"
@@ -175,6 +185,7 @@ struct WorkbenchRootView: View {
         switch page {
         case .usageStats: workbench.usageStats.refresh()
         case .sessionManager: workbench.sessions.refreshIndex()
+        case .resets: environment.refreshAll()
         case .skillsManager: workbench.skills.refresh()
         case .settings: break
         }
@@ -194,6 +205,8 @@ struct WorkbenchRootView: View {
             UsageStatsPage(density: density, model: workbench.usageStats)
         case .sessionManager:
             SessionManagerPage(density: density, model: workbench.sessions)
+        case .resets:
+            ResetsPage(density: density)
         case .skillsManager:
             SkillsManagerPage(density: density, model: workbench.skills)
         case .settings:
@@ -206,7 +219,7 @@ private struct WorkbenchSidebar: View {
     @Binding var selection: WorkbenchPage?
     @Environment(\.colorScheme) private var colorScheme
     @State private var hoveredPage: WorkbenchPage?
-    private let primaryPages: [WorkbenchPage] = [.usageStats, .sessionManager, .skillsManager]
+    private let primaryPages: [WorkbenchPage] = [.usageStats, .sessionManager, .resets, .skillsManager]
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -272,6 +285,7 @@ private struct WorkbenchSidebar: View {
         switch page {
         case .usageStats: WorkbenchPorcelain.accent
         case .sessionManager: Color(red: 20 / 255, green: 169 / 255, blue: 124 / 255)
+        case .resets: Color(red: 88 / 255, green: 134 / 255, blue: 220 / 255)
         case .skillsManager: Color(red: 217 / 255, green: 137 / 255, blue: 11 / 255)
         case .settings: .secondary
         }


### PR DESCRIPTION
Implements the two surfaces AQ approved from the [Arrangement & Resets Lab](https://claude.ai/code/artifact/31a456c1-9f94-45b7-9ce7-2c933bf11a6e) board (sections D and E), replacing the rail's rings with the slim-column lane design.

## What

- **Shared model** — `UpcomingResets.events(environment:now:horizonDays:)`: every dedicated-provider bucket refilling inside the horizon, from the cached quotas only.
- **`ResetLaneView`** — the horizon as a lane: each refill is a slim column on a time axis (height = refill size, colour = current tightness via `Theme.barColor`, hairline = now), day ticks, `.help` tooltips. No rings.
- **Popover: Upcoming Resets card** (`overviewUpcomingResets` module) — lane + next-three list with `+N%` gain and countdown. Registered in `PageModuleCatalog` (quota band, column 1), so Layout can arrange or hide it.
- **Workbench: Resets page** (fourth primary page, `workbench:resets` demo surface for free) — enlarged lane; per-SubProvider cycle cards (headline = longest window, all bucket lines, forecast verdict via the shared pace-forecast path, current-cycle remaining curve from `observationsByAccountBucket`, ≤48 segments drawn); 14-day reset calendar; run-out ranking (forecast watch/atRisk or ≤15% remaining).

## Fluency

One 60 s leaf `TimelineView` per surface; everything else re-renders only when a quota refresh publishes. The fill curve thins to ≤48 segments before drawing. No settings writes anywhere on these paths.

## Verification

`swift build` clean · 1660 tests green · release packaging + strict deep codesign (empty entitlements) · demo smoke: `workbench:resets` and `popover:overview` both build with zero errors. Pixel captures remain TCC-blocked in this session (pending app restart); layout follows the approved board sketch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)