### PR TITLE
Close out the jank audit's found-not-fixed list

### DIFF
--- a/Sources/VibeBarApp/Views/PricingSettingsSection.swift
+++ b/Sources/VibeBarApp/Views/PricingSettingsSection.swift
@@ -189,6 +189,11 @@ private struct PricingOverrideEditor: View {
     /// `$settings` subscriber (§ 7's hot-path rule).
     @State private var draft: ModelPricingOverride
     @State private var commitTask: Task<Void, Never>?
+    /// Set when this editor's own trash button removed the element: the
+    /// `ForEach` binding is stale from that moment, and a flush through it
+    /// would overwrite whichever row shifted into this index — or trap on
+    /// the last row.
+    @State private var isDeleted = false
 
     init(override: Binding<ModelPricingOverride>, delete: @escaping () -> Void) {
         _override = override
@@ -200,7 +205,7 @@ private struct PricingOverrideEditor: View {
         commitTask?.cancel()
         commitTask = Task { @MainActor in
             try? await Task.sleep(nanoseconds: 400_000_000)
-            guard !Task.isCancelled else { return }
+            guard !Task.isCancelled, !isDeleted else { return }
             if override != draft { override = draft }
             commitTask = nil
         }
@@ -216,7 +221,12 @@ private struct PricingOverrideEditor: View {
                 }
                 TextField("Exact model name", text: $draft.model)
                     .textFieldStyle(.roundedBorder)
-                Button(role: .destructive, action: delete) {
+                Button(role: .destructive) {
+                    commitTask?.cancel()
+                    commitTask = nil
+                    isDeleted = true
+                    delete()
+                } label: {
                     Image(systemName: "trash")
                 }
                 .buttonStyle(.borderless)
@@ -260,6 +270,7 @@ private struct PricingOverrideEditor: View {
         .onDisappear {
             commitTask?.cancel()
             commitTask = nil
+            guard !isDeleted else { return }
             if override != draft { override = draft }
         }
     }

--- a/Sources/VibeBarApp/Views/PricingSettingsSection.swift
+++ b/Sources/VibeBarApp/Views/PricingSettingsSection.swift
@@ -7,10 +7,38 @@ struct PricingSettingsSection: View {
     @EnvironmentObject private var environment: AppEnvironment
     @EnvironmentObject private var settingsStore: SettingsStore
 
+    /// The merged price table, rebuilt when a catalog refresh lands or the
+    /// overrides change — not on every body pass; the merge + sort spans
+    /// every known model. A reference box so filling it in `body` cannot
+    /// dirty view state.
+    private final class PriceTableCache {
+        var stamp: PriceStamp?
+        var rows: [EffectiveModelPricingRow] = []
+    }
+
+    private struct PriceStamp: Equatable {
+        let mergedAt: Date?
+        let overrides: [ModelPricingOverride]
+    }
+
+    @State private var priceTableCache = PriceTableCache()
+
+    private func cachedModelPrices() -> [EffectiveModelPricingRow] {
+        let stamp = PriceStamp(
+            mergedAt: environment.pricingRefreshStatus.mergedAt,
+            overrides: settingsStore.settings.modelPricingOverrides
+        )
+        if priceTableCache.stamp == stamp {
+            return priceTableCache.rows
+        }
+        let rows = PricingResolver.active.effectiveModelPrices
+        priceTableCache.stamp = stamp
+        priceTableCache.rows = rows
+        return rows
+    }
+
     var body: some View {
-        // One build of the merged price table per body pass, shared with the
-        // catalog below.
-        let modelPrices = PricingResolver.active.effectiveModelPrices
+        let modelPrices = cachedModelPrices()
         return VStack(alignment: .leading, spacing: density.interSectionSpacing) {
             settingsSection("Model Pricing") {
                 Text("Catalogs refresh in the background. Higher entries win when the same provider and model name appears more than once.")
@@ -156,15 +184,37 @@ private struct PricingOverrideEditor: View {
     @Binding var override: ModelPricingOverride
     let delete: () -> Void
 
+    /// Fields edit this draft; the settings write happens once per pause,
+    /// not per keystroke — every `AppSettings` write fans out to every
+    /// `$settings` subscriber (§ 7's hot-path rule).
+    @State private var draft: ModelPricingOverride
+    @State private var commitTask: Task<Void, Never>?
+
+    init(override: Binding<ModelPricingOverride>, delete: @escaping () -> Void) {
+        _override = override
+        self.delete = delete
+        _draft = State(initialValue: override.wrappedValue)
+    }
+
+    private func scheduleCommit() {
+        commitTask?.cancel()
+        commitTask = Task { @MainActor in
+            try? await Task.sleep(nanoseconds: 400_000_000)
+            guard !Task.isCancelled else { return }
+            if override != draft { override = draft }
+            commitTask = nil
+        }
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
             HStack {
-                Picker("Provider", selection: $override.provider) {
+                Picker("Provider", selection: $draft.provider) {
                     ForEach(PricingProviderFamily.allCases) { provider in
                         Text(provider.label).tag(provider)
                     }
                 }
-                TextField("Exact model name", text: $override.model)
+                TextField("Exact model name", text: $draft.model)
                     .textFieldStyle(.roundedBorder)
                 Button(role: .destructive, action: delete) {
                     Image(systemName: "trash")
@@ -174,8 +224,8 @@ private struct PricingOverrideEditor: View {
             }
 
             HStack {
-                rateField("Input", value: $override.inputPerMillion)
-                rateField("Output", value: $override.outputPerMillion)
+                rateField("Input", value: $draft.inputPerMillion)
+                rateField("Output", value: $draft.outputPerMillion)
                 optionalRateField("Cache read", keyPath: \.cacheReadPerMillion)
                 optionalRateField("Cache write", keyPath: \.cacheWritePerMillion)
             }
@@ -196,6 +246,21 @@ private struct PricingOverrideEditor: View {
                 .padding(.top, 6)
             }
             .font(.caption)
+        }
+        .onChange(of: draft) { _, _ in
+            scheduleCommit()
+        }
+        .onChange(of: override) { _, newValue in
+            // An external change (delete/re-add, another surface) adopts,
+            // unless a local draft is still waiting to commit.
+            if commitTask == nil, draft != newValue {
+                draft = newValue
+            }
+        }
+        .onDisappear {
+            commitTask?.cancel()
+            commitTask = nil
+            if override != draft { override = draft }
         }
     }
 
@@ -234,12 +299,12 @@ private struct PricingOverrideEditor: View {
     ) -> Binding<String> {
         Binding(
             get: {
-                guard let value = override[keyPath: keyPath] else { return "" }
+                guard let value = draft[keyPath: keyPath] else { return "" }
                 return String(value)
             },
             set: { raw in
                 let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
-                override[keyPath: keyPath] = trimmed.isEmpty ? nil : Double(trimmed)
+                draft[keyPath: keyPath] = trimmed.isEmpty ? nil : Double(trimmed)
             }
         )
     }
@@ -248,10 +313,10 @@ private struct PricingOverrideEditor: View {
         _ keyPath: WritableKeyPath<ModelPricingOverride, Int?>
     ) -> Binding<String> {
         Binding(
-            get: { override[keyPath: keyPath].map(String.init) ?? "" },
+            get: { draft[keyPath: keyPath].map(String.init) ?? "" },
             set: { raw in
                 let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
-                override[keyPath: keyPath] = trimmed.isEmpty ? nil : Int(trimmed)
+                draft[keyPath: keyPath] = trimmed.isEmpty ? nil : Int(trimmed)
             }
         )
     }

--- a/Sources/VibeBarApp/Views/Workbench/UsageBreakdownTables.swift
+++ b/Sources/VibeBarApp/Views/Workbench/UsageBreakdownTables.swift
@@ -206,10 +206,20 @@ struct UsageBreakdownTables: View {
             }
         }
         .frame(height: tableHeight(for: visiblePeriodRowCount))
-        // A new bucket size is a different series; the viewport starts over.
-        .onChange(of: model.trend.bucket) { _, _ in
+        // Any new result series — bucket size, range, window, or filter
+        // change — starts the viewport over; an expanded limit must not
+        // carry into a different series.
+        .onChange(of: periodSeriesIdentity) { _, _ in
             visiblePeriodLimit = Self.periodPageSize
         }
+    }
+
+    /// Cheap identity for the trend series: the controls that replace it
+    /// change at least one of these.
+    private var periodSeriesIdentity: String {
+        let first = model.trend.points.first?.bucketStart.timeIntervalSince1970 ?? 0
+        let last = model.trend.points.last?.bucketStart.timeIntervalSince1970 ?? 0
+        return "\(model.trend.bucket)|\(model.trend.points.count)|\(first)|\(last)"
     }
 
     /// Rows the clamped table actually shows, load-more row included.

--- a/Sources/VibeBarApp/Views/Workbench/UsageBreakdownTables.swift
+++ b/Sources/VibeBarApp/Views/Workbench/UsageBreakdownTables.swift
@@ -29,6 +29,12 @@ struct UsageBreakdownTables: View {
         Array(model.trend.points.filter { $0.totalTokens > 0 || $0.costMicros != 0 }.reversed())
     }
 
+    /// Hourly over a month is ~720 rows; realizing them all makes the page
+    /// scroller diff every one on each pass. The table shows a viewport and
+    /// grows on request. Reset when the underlying series identity changes.
+    private static let periodPageSize = 120
+    @State private var visiblePeriodLimit = UsageBreakdownTables.periodPageSize
+
     var body: some View {
         CardShell(density: density, spacing: 12) {
             header
@@ -170,7 +176,7 @@ struct UsageBreakdownTables: View {
             VStack(spacing: 0) {
                 tableHeader(columns.all)
                 LazyVStack(spacing: 0) {
-                    ForEach(populatedPeriods, id: \.bucketStart) { point in
+                    ForEach(populatedPeriods.prefix(visiblePeriodLimit), id: \.bucketStart) { point in
                         let label = period(point.bucketStart)
                         PorcelainUsageRow(
                             accessibilityLabel: periodAccessibilityLabel(point, label: label)
@@ -183,10 +189,33 @@ struct UsageBreakdownTables: View {
                             moneyCell(point.costMicros, columns.cost, emphasis: true)
                         }
                     }
+                    if populatedPeriods.count > visiblePeriodLimit {
+                        Button {
+                            visiblePeriodLimit += Self.periodPageSize
+                        } label: {
+                            Text("Show \(min(Self.periodPageSize, populatedPeriods.count - visiblePeriodLimit)) more of \(populatedPeriods.count) periods")
+                                .font(.system(size: 11, weight: .medium))
+                                .foregroundStyle(.secondary)
+                                .frame(maxWidth: .infinity)
+                                .frame(height: 34)
+                                .contentShape(Rectangle())
+                        }
+                        .buttonStyle(.vibeBar)
+                    }
                 }
             }
         }
-        .frame(height: tableHeight(for: populatedPeriods.count))
+        .frame(height: tableHeight(for: visiblePeriodRowCount))
+        // A new bucket size is a different series; the viewport starts over.
+        .onChange(of: model.trend.bucket) { _, _ in
+            visiblePeriodLimit = Self.periodPageSize
+        }
+    }
+
+    /// Rows the clamped table actually shows, load-more row included.
+    private var visiblePeriodRowCount: Int {
+        let shown = min(populatedPeriods.count, visiblePeriodLimit)
+        return shown + (populatedPeriods.count > visiblePeriodLimit ? 1 : 0)
     }
 
     /// Requests intentionally retain a horizontal scroll surface: a request

--- a/Sources/VibeBarApp/Views/YearlyContributionHeatmapView.swift
+++ b/Sources/VibeBarApp/Views/YearlyContributionHeatmapView.swift
@@ -35,6 +35,9 @@ struct YearlyContributionHeatmapView: View {
     private struct GridStamp: Equatable {
         let history: [DailyCostPoint]
         let today: Date
+        /// The walk groups by `Calendar.current`; a calendar or zone change
+        /// mid-flight must invalidate even when today's start looks equal.
+        let calendarIdentity: String
     }
 
     @State private var gridCache = GridCache()
@@ -42,7 +45,8 @@ struct YearlyContributionHeatmapView: View {
     private func cachedGrid() -> (columns: [WeekColumn], markers: [MonthMarker]) {
         let stamp = GridStamp(
             history: history,
-            today: Calendar.current.startOfDay(for: Date())
+            today: Calendar.current.startOfDay(for: Date()),
+            calendarIdentity: "\(Calendar.current.identifier)|\(TimeZone.current.identifier)"
         )
         if gridCache.historyStamp == stamp {
             return (gridCache.columns, gridCache.markers)

--- a/Sources/VibeBarApp/Views/YearlyContributionHeatmapView.swift
+++ b/Sources/VibeBarApp/Views/YearlyContributionHeatmapView.swift
@@ -23,14 +23,45 @@ struct YearlyContributionHeatmapView: View {
     @State private var measuredGridWidth: CGFloat = 0
     @EnvironmentObject var environment: AppEnvironment
 
-    var body: some View {
-        // Compute these ONCE per body. `thresholds` does a sort on the year's
-        // non-zero days, and `cell(...)` is invoked ~365 times — without
-        // hoisting, we'd re-sort the entire history per cell on every redraw.
+    /// The 365-day walk and the month markers rebuilt only when the history
+    /// (or the day) changes — not on every redraw of the card. A reference
+    /// box on purpose: filling it during `body` must not dirty view state.
+    private final class GridCache {
+        var historyStamp: GridStamp?
+        var columns: [WeekColumn] = []
+        var markers: [MonthMarker] = []
+    }
+
+    private struct GridStamp: Equatable {
+        let history: [DailyCostPoint]
+        let today: Date
+    }
+
+    @State private var gridCache = GridCache()
+
+    private func cachedGrid() -> (columns: [WeekColumn], markers: [MonthMarker]) {
+        let stamp = GridStamp(
+            history: history,
+            today: Calendar.current.startOfDay(for: Date())
+        )
+        if gridCache.historyStamp == stamp {
+            return (gridCache.columns, gridCache.markers)
+        }
         let columns = makeColumns()
+        let markers = monthLabelPositions(columns: columns)
+        gridCache.historyStamp = stamp
+        gridCache.columns = columns
+        gridCache.markers = markers
+        return (columns, markers)
+    }
+
+    var body: some View {
+        // `thresholds` does a sort on the year's non-zero days, and
+        // `cell(...)` is invoked ~365 times — hoisted once per body; the
+        // grid itself is memoized across bodies on the history generation.
+        let (columns, cachedMonthMarkers) = cachedGrid()
         let metrics = gridMetrics(columnCount: columns.count, measuredWidth: measuredGridWidth)
         let cachedThresholds = thresholds
-        let cachedMonthMarkers = monthLabelPositions(columns: columns)
 
         VStack(alignment: .leading, spacing: density.cardSpacing) {
             HStack(alignment: .firstTextBaseline) {


### PR DESCRIPTION
Finishes the three "Found, not fixed" items from #237, against the AGENTS.md § 7 budgets:

- **Model Pricing** — override edits go through a local draft committed after a 400 ms pause (flush on disappear), so a keystroke no longer fans out through every `$settings` subscriber (§ 7: "settings writes ≤ 1/s, debounced"); `effectiveModelPrices` is memoized on (merge stamp, overrides).
- **Usage Stats · Periods table** — 120-row viewport + "Show N more" row instead of ~720 realized Hourly rows; resets on bucket-size change.
- **Year heatmap** — the 365-day grid walk + month markers memoize on (history, day); `.help` tooltips preserved (no Canvas rewrite).

`swift build` clean · 1664 tests green · release packaging + strict deep codesign (empty entitlements).

🤖 Generated with [Claude Code](https://claude.com/claude-code)