### PR TITLE
Persist per-day model mix in cost history and backfill from ledger

### DIFF
--- a/Sources/VibeBarCore/Services/CostHistoryStore.swift
+++ b/Sources/VibeBarCore/Services/CostHistoryStore.swift
@@ -389,9 +389,19 @@ public actor CostHistoryStore {
             .map(\.date)
     }
 
+    /// A backfill candidate must account for at least this share of the
+    /// day's persisted tokens (or cost, for token-less days). The ledger can
+    /// hold only part of a day — rows ingested before the source rotated, or
+    /// dropped by a since-fixed bug — and presenting a partial mix as the
+    /// whole day's breakdown would misstate it. An under-covered day stays
+    /// unfilled, so it remains repairable by a later re-ingest.
+    private static let backfillCoverageFraction = 0.9
+
     /// One-way backfill from request-level evidence (the usage ledger):
     /// fills only entries that have no model mix yet, never overwriting one
-    /// a scan persisted. Day keys use this store's `yyyy-MM-dd` format.
+    /// a scan persisted, and only when the evidence covers the day — see
+    /// `backfillCoverageFraction`. Day keys use this store's `yyyy-MM-dd`
+    /// format.
     public func backfillDayModels(
         tool: ToolType,
         modelsByDay: [String: [CostSnapshot.ModelBreakdown]]
@@ -404,8 +414,20 @@ public actor CostHistoryStore {
             let entry = storage.entries[idx]
             guard entry.tool == toolKey,
                   entry.models?.isEmpty ?? true,
-                  let fill = Self.persistedModels(from: modelsByDay[entry.date])
+                  let candidate = modelsByDay[entry.date]
             else { continue }
+            let coveredTokens = candidate.reduce(0) { $0 + $1.totalTokens }
+            let coveredCost = candidate.reduce(0.0) { $0 + $1.costUSD }
+            let covered: Bool
+            if entry.totalTokens > 0 {
+                covered = Double(coveredTokens)
+                    >= Double(entry.totalTokens) * Self.backfillCoverageFraction
+            } else if entry.costUSD > 0 {
+                covered = coveredCost >= entry.costUSD * Self.backfillCoverageFraction
+            } else {
+                covered = true
+            }
+            guard covered, let fill = Self.persistedModels(from: candidate) else { continue }
             storage.entries[idx].models = fill
             changed = true
         }

--- a/Sources/VibeBarCore/Services/CostHistoryStore.swift
+++ b/Sources/VibeBarCore/Services/CostHistoryStore.swift
@@ -25,6 +25,34 @@ public actor CostHistoryStore {
         let date: String      // YYYY-MM-DD
         var costUSD: Double
         var totalTokens: Int
+        /// Top models for the day, by cost. Optional so pre-v3 files decode;
+        /// nil on days recorded before the field existed. Persisted so the
+        /// chart's day inspector keeps its model mix after the source logs
+        /// rotate away — AntiGravity keeps ~9 days of conversations, and
+        /// "Model detail is unavailable" for anything older was this.
+        var models: [ModelEntry]?
+    }
+
+    struct ModelEntry: Codable, Equatable {
+        let name: String
+        var costUSD: Double
+        var totalTokens: Int
+    }
+
+    /// Per-day cap: the inspector lists a handful, and eight covers every
+    /// real mix seen so far without letting the file grow per model ever
+    /// used on one day.
+    private static let maxPersistedModelsPerDay = 8
+
+    private static func persistedModels(
+        from breakdowns: [CostSnapshot.ModelBreakdown]?
+    ) -> [ModelEntry]? {
+        guard let breakdowns, !breakdowns.isEmpty else { return nil }
+        let capped = breakdowns
+            .sorted { $0.costUSD > $1.costUSD }
+            .prefix(maxPersistedModelsPerDay)
+            .map { ModelEntry(name: $0.modelName, costUSD: $0.costUSD, totalTokens: $0.totalTokens) }
+        return capped.isEmpty ? nil : Array(capped)
     }
     private struct Storage: Codable {
         var schemaVersion: Int
@@ -128,19 +156,37 @@ public actor CostHistoryStore {
     public func mergeSeries(
         _ series: [DailyCostPoint],
         tool: ToolType,
-        retentionDays: Int = CostDataSettings.defaultRetentionDays
+        retentionDays: Int = CostDataSettings.defaultRetentionDays,
+        dailyModels: [Date: [CostSnapshot.ModelBreakdown]] = [:]
     ) {
         var storage = load()
         let toolKey = tool.rawValue
         let cutoffKey = retentionCutoffKey(retentionDays: retentionDays)
+        var modelsByKey: [String: [CostSnapshot.ModelBreakdown]] = [:]
+        for (day, breakdowns) in dailyModels {
+            modelsByKey[dateFormatter.string(from: day)] = breakdowns
+        }
         for point in series {
             let key = dateFormatter.string(from: point.date)
             if let cutoffKey, key < cutoffKey { continue }
             if let idx = storage.entries.firstIndex(where: { $0.tool == toolKey && $0.date == key }) {
+                // The models follow whichever side won the token max: a
+                // fresh scan that saw at least as much of the day is the
+                // better witness; a rotated-away day keeps its stored mix.
+                let freshWins = point.totalTokens >= storage.entries[idx].totalTokens
                 storage.entries[idx].costUSD = max(storage.entries[idx].costUSD, point.costUSD)
                 storage.entries[idx].totalTokens = max(storage.entries[idx].totalTokens, point.totalTokens)
+                if freshWins, let fresh = Self.persistedModels(from: modelsByKey[key]) {
+                    storage.entries[idx].models = fresh
+                }
             } else if point.costUSD > 0 || point.totalTokens > 0 {
-                storage.entries.append(Entry(tool: toolKey, date: key, costUSD: point.costUSD, totalTokens: point.totalTokens))
+                storage.entries.append(Entry(
+                    tool: toolKey,
+                    date: key,
+                    costUSD: point.costUSD,
+                    totalTokens: point.totalTokens,
+                    models: Self.persistedModels(from: modelsByKey[key])
+                ))
             }
         }
         prune(&storage, retentionDays: retentionDays)
@@ -153,7 +199,12 @@ public actor CostHistoryStore {
         _ snapshot: CostSnapshot,
         retentionDays: Int = CostDataSettings.defaultRetentionDays
     ) -> CostSnapshot {
-        mergeSeries(snapshot.dailyHistory, tool: snapshot.tool, retentionDays: retentionDays)
+        mergeSeries(
+            snapshot.dailyHistory,
+            tool: snapshot.tool,
+            retentionDays: retentionDays,
+            dailyModels: snapshot.dailyModelBreakdown
+        )
         return augmentedSnapshot(snapshot, retentionDays: retentionDays)
     }
 
@@ -169,7 +220,8 @@ public actor CostHistoryStore {
             snapshot.dailyHistory,
             tool: snapshot.tool,
             now: snapshot.updatedAt,
-            retentionDays: retentionDays
+            retentionDays: retentionDays,
+            dailyModels: snapshot.dailyModelBreakdown
         )
         return augmentedSnapshot(snapshot, retentionDays: retentionDays)
     }
@@ -178,11 +230,16 @@ public actor CostHistoryStore {
         _ series: [DailyCostPoint],
         tool: ToolType,
         now: Date,
-        retentionDays: Int
+        retentionDays: Int,
+        dailyModels: [Date: [CostSnapshot.ModelBreakdown]] = [:]
     ) {
         var storage = load()
         let toolKey = tool.rawValue
         let cutoffKey = retentionCutoffKey(now: now, retentionDays: retentionDays)
+        var modelsByKey: [String: [CostSnapshot.ModelBreakdown]] = [:]
+        for (day, breakdowns) in dailyModels {
+            modelsByKey[dateFormatter.string(from: day)] = breakdowns
+        }
         var replacements: [String: Entry] = [:]
         for point in series {
             let key = dateFormatter.string(from: point.date)
@@ -192,7 +249,8 @@ public actor CostHistoryStore {
                 tool: toolKey,
                 date: key,
                 costUSD: point.costUSD,
-                totalTokens: point.totalTokens
+                totalTokens: point.totalTokens,
+                models: Self.persistedModels(from: modelsByKey[key])
             )
         }
         storage.entries.removeAll { $0.tool == toolKey }
@@ -216,6 +274,7 @@ public actor CostHistoryStore {
         var monthCost = 0.0, monthTokens = 0
         var allCost = 0.0, allTokens = 0
         var dailyPoints: [DailyCostPoint] = []
+        var persistedDayModels: [Date: [CostSnapshot.ModelBreakdown]] = [:]
         let cutoffKey = retentionCutoffKey(now: snapshot.updatedAt, retentionDays: retentionDays)
         for entry in storage.entries where entry.tool == toolKey {
             if let cutoffKey, entry.date < cutoffKey { continue }
@@ -223,6 +282,11 @@ public actor CostHistoryStore {
             let normalizedDay = calendar.startOfDay(for: day)
             guard normalizedDay <= today else { continue }
             dailyPoints.append(DailyCostPoint(date: normalizedDay, costUSD: entry.costUSD, totalTokens: entry.totalTokens))
+            if let models = entry.models, !models.isEmpty {
+                persistedDayModels[normalizedDay] = models.map {
+                    CostSnapshot.ModelBreakdown(modelName: $0.name, costUSD: $0.costUSD, totalTokens: $0.totalTokens)
+                }
+            }
             allCost += entry.costUSD
             allTokens += entry.totalTokens
             if calendar.isDate(normalizedDay, inSameDayAs: snapshot.updatedAt) {
@@ -258,9 +322,13 @@ public actor CostHistoryStore {
             heatmap: snapshot.heatmap,
             modelBreakdowns: snapshot.modelBreakdowns,
             last7DaysModelBreakdowns: snapshot.last7DaysModelBreakdowns,
-            // Per-day model breakdown is in-memory only; preserve whatever
-            // the live scan produced. Persisted historical days won't have it.
-            dailyModelBreakdown: snapshot.dailyModelBreakdown,
+            // The live scan's per-day mix wins for the days it actually saw;
+            // days whose source logs rotated away fall back to the top-8 mix
+            // persisted alongside their totals.
+            dailyModelBreakdown: persistedDayModels.merging(
+                snapshot.dailyModelBreakdown,
+                uniquingKeysWith: { _, live in live }
+            ),
             hourlyModelBreakdown: snapshot.hourlyModelBreakdown,
             jsonlFilesFound: snapshot.jsonlFilesFound,
             updatedAt: snapshot.updatedAt
@@ -308,6 +376,40 @@ public actor CostHistoryStore {
             }
         }
         return CostHistory(tool: tool, days: points, updatedAt: now)
+    }
+
+    /// Day keys (this store's `yyyy-MM-dd` format) for `tool` whose
+    /// persisted entries carry totals but no model mix — days recorded
+    /// before per-day models were persisted, or merged from a scan that had
+    /// no per-model detail for them.
+    public func daysMissingModels(tool: ToolType) -> [String] {
+        let toolKey = tool.rawValue
+        return load().entries
+            .filter { $0.tool == toolKey && ($0.models?.isEmpty ?? true) }
+            .map(\.date)
+    }
+
+    /// One-way backfill from request-level evidence (the usage ledger):
+    /// fills only entries that have no model mix yet, never overwriting one
+    /// a scan persisted. Day keys use this store's `yyyy-MM-dd` format.
+    public func backfillDayModels(
+        tool: ToolType,
+        modelsByDay: [String: [CostSnapshot.ModelBreakdown]]
+    ) {
+        guard !modelsByDay.isEmpty else { return }
+        var storage = load()
+        let toolKey = tool.rawValue
+        var changed = false
+        for idx in storage.entries.indices {
+            let entry = storage.entries[idx]
+            guard entry.tool == toolKey,
+                  entry.models?.isEmpty ?? true,
+                  let fill = Self.persistedModels(from: modelsByDay[entry.date])
+            else { continue }
+            storage.entries[idx].models = fill
+            changed = true
+        }
+        if changed { save(storage) }
     }
 
     public func prune(retentionDays: Int) {

--- a/Sources/VibeBarCore/Services/CostUsageService.swift
+++ b/Sources/VibeBarCore/Services/CostUsageService.swift
@@ -49,6 +49,9 @@ public final class CostUsageService: ObservableObject {
     /// history without re-walking the JSONL. Nil keeps the scan pipeline
     /// byte-identical to the pre-ledger behaviour.
     private let usageLedger: UsageEventLedger?
+    /// Tools whose persisted history has been offered a ledger model-mix
+    /// backfill this launch — see the block in `refresh()`.
+    private var dayModelBackfillAttempted: Set<ToolType> = []
     /// Keep authoritative local and selected-remote sources separate. Only the
     /// merged dictionary is published, so remote facts are never written into
     /// the local scan cache/history and cannot be counted again after relaunch.
@@ -211,6 +214,27 @@ public final class CostUsageService: ObservableObject {
         // catalog (including local overrides) changes so both surfaces can
         // adopt newly covered models without losing rotated history.
         _ = try? await usageLedger?.prepareForPricingRevision(PricingResolver.activeRevision)
+
+        // Historical days persisted before per-day models existed — or whose
+        // source logs had already rotated away when the day was recorded —
+        // can still be described by the request ledger. Fill them before the
+        // scans so the snapshots merged below already carry the recovered
+        // mix. Once per tool per launch: old days only gain new ledger
+        // evidence through rare re-ingest migrations, never a routine pass.
+        if let ledger = usageLedger {
+            for tool in ToolType.allCases
+            where tool.supportsTokenCost && !dayModelBackfillAttempted.contains(tool) {
+                dayModelBackfillAttempted.insert(tool)
+                let missing = await CostHistoryStore.shared.daysMissingModels(tool: tool)
+                guard !missing.isEmpty,
+                      let recovered = try? await ledger.dayModelBreakdowns(
+                          tool: tool, days: Set(missing)
+                      ),
+                      !recovered.isEmpty
+                else { continue }
+                await CostHistoryStore.shared.backfillDayModels(tool: tool, modelsByDay: recovered)
+            }
+        }
 
         var results: [ToolType: CostSnapshot] = [:]
         var directRemoteResults = directRemoteSnapshots

--- a/Sources/VibeBarCore/Services/UsageEventLedger.swift
+++ b/Sources/VibeBarCore/Services/UsageEventLedger.swift
@@ -1847,6 +1847,52 @@ public actor UsageEventLedger: CostUsageEventSink {
             }
     }
 
+    /// Per-day per-model totals for one tool, detail rows and daily rollups
+    /// combined, restricted to the given day keys (this ledger's own
+    /// `yyyy-MM-dd` local-day format — the same format `CostHistoryStore`
+    /// uses, see `dayString(for:)`). Used to backfill the model mix of
+    /// persisted history days whose source logs have already rotated away.
+    public func dayModelBreakdowns(
+        tool: ToolType,
+        days: Set<String>
+    ) throws -> [String: [CostSnapshot.ModelBreakdown]] {
+        guard !days.isEmpty else { return [:] }
+        var totals: [String: [String: (tokens: Int64, costMicros: Int64)]] = [:]
+        for table in ["usage_events", "usage_daily_rollups"] {
+            let statement = try prepare(
+                """
+                SELECT day, model,
+                       COALESCE(SUM(fresh_input + output + cache_read + cache_creation), 0),
+                       COALESCE(SUM(cost_micros), 0)
+                  FROM \(table)
+                 WHERE tool = ? AND TRIM(model) <> ''
+                 GROUP BY day, model
+                """
+            )
+            defer { sqlite3_finalize(statement) }
+            bindAll([.text(tool.rawValue)], to: statement)
+            while sqlite3_step(statement) == SQLITE_ROW {
+                guard let day = columnText(statement, 0), days.contains(day),
+                      let model = columnText(statement, 1) else { continue }
+                var entry = totals[day, default: [:]][model] ?? (0, 0)
+                entry.tokens += sqlite3_column_int64(statement, 2)
+                entry.costMicros += sqlite3_column_int64(statement, 3)
+                totals[day, default: [:]][model] = entry
+            }
+        }
+        return totals.mapValues { models in
+            models
+                .map {
+                    CostSnapshot.ModelBreakdown(
+                        modelName: $0.key,
+                        costUSD: Double($0.value.costMicros) / 1_000_000,
+                        totalTokens: Int($0.value.tokens)
+                    )
+                }
+                .sorted { $0.costUSD > $1.costUSD }
+        }
+    }
+
     /// Per-project totals from request-level evidence, heaviest first.
     ///
     /// Daily rollups intentionally do not carry a project dimension: project

--- a/Sources/VibeBarCore/Services/UsageEventLedger.swift
+++ b/Sources/VibeBarCore/Services/UsageEventLedger.swift
@@ -1858,26 +1858,38 @@ public actor UsageEventLedger: CostUsageEventSink {
     ) throws -> [String: [CostSnapshot.ModelBreakdown]] {
         guard !days.isEmpty else { return [:] }
         var totals: [String: [String: (tokens: Int64, costMicros: Int64)]] = [:]
+        // The day keys go into the SQL predicate so the database aggregates
+        // only the missing days — this runs on every launch while any day
+        // stays unfillable, and a whole-tool scan would hold the ledger
+        // actor against Workbench queries for nothing. Chunked to stay far
+        // below SQLite's bound-variable limit.
+        let sortedDays = days.sorted()
+        let dayChunks = stride(from: 0, to: sortedDays.count, by: 500).map {
+            Array(sortedDays[$0..<min($0 + 500, sortedDays.count)])
+        }
         for table in ["usage_events", "usage_daily_rollups"] {
-            let statement = try prepare(
-                """
-                SELECT day, model,
-                       COALESCE(SUM(fresh_input + output + cache_read + cache_creation), 0),
-                       COALESCE(SUM(cost_micros), 0)
-                  FROM \(table)
-                 WHERE tool = ? AND TRIM(model) <> ''
-                 GROUP BY day, model
-                """
-            )
-            defer { sqlite3_finalize(statement) }
-            bindAll([.text(tool.rawValue)], to: statement)
-            while sqlite3_step(statement) == SQLITE_ROW {
-                guard let day = columnText(statement, 0), days.contains(day),
-                      let model = columnText(statement, 1) else { continue }
-                var entry = totals[day, default: [:]][model] ?? (0, 0)
-                entry.tokens += sqlite3_column_int64(statement, 2)
-                entry.costMicros += sqlite3_column_int64(statement, 3)
-                totals[day, default: [:]][model] = entry
+            for chunk in dayChunks {
+                let placeholders = Array(repeating: "?", count: chunk.count).joined(separator: ",")
+                let statement = try prepare(
+                    """
+                    SELECT day, model,
+                           COALESCE(SUM(fresh_input + output + cache_read + cache_creation), 0),
+                           COALESCE(SUM(cost_micros), 0)
+                      FROM \(table)
+                     WHERE tool = ? AND TRIM(model) <> '' AND day IN (\(placeholders))
+                     GROUP BY day, model
+                    """
+                )
+                defer { sqlite3_finalize(statement) }
+                bindAll([.text(tool.rawValue)] + chunk.map { .text($0) }, to: statement)
+                while sqlite3_step(statement) == SQLITE_ROW {
+                    guard let day = columnText(statement, 0),
+                          let model = columnText(statement, 1) else { continue }
+                    var entry = totals[day, default: [:]][model] ?? (0, 0)
+                    entry.tokens += sqlite3_column_int64(statement, 2)
+                    entry.costMicros += sqlite3_column_int64(statement, 3)
+                    totals[day, default: [:]][model] = entry
+                }
             }
         }
         return totals.mapValues { models in

--- a/Tests/VibeBarCoreTests/CostHistoryStoreTests.swift
+++ b/Tests/VibeBarCoreTests/CostHistoryStoreTests.swift
@@ -640,6 +640,58 @@ final class CostHistoryStoreTests: XCTestCase {
         XCTAssertTrue(stillMissing.isEmpty)
     }
 
+    func testBackfillRejectsPartialLedgerCoverageAndLeavesTheDayRepairable() async throws {
+        let fileManager = FileManager.default
+        let directory = fileManager.temporaryDirectory
+            .appendingPathComponent("VibeBarCostHistoryDayModelsCoverage-\(UUID().uuidString)", isDirectory: true)
+        try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: directory) }
+
+        let calendar = Calendar.current
+        let now = Date()
+        let today = calendar.startOfDay(for: now)
+        let day = try XCTUnwrap(calendar.date(byAdding: .day, value: -10, to: today))
+        let store = CostHistoryStore(fileURL: directory.appendingPathComponent("cost_history.json"))
+
+        _ = await store.mergeAndAugment(
+            snapshot(
+                tool: .antigravity,
+                dailyHistory: [DailyCostPoint(date: day, costUSD: 10, totalTokens: 10_000)],
+                dailyModels: [:],
+                now: now
+            ),
+            retentionDays: CostDataSettings.unlimitedRetentionDays
+        )
+
+        let formatter = DateFormatter()
+        formatter.calendar = calendar
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "yyyy-MM-dd"
+        let key = formatter.string(from: day)
+
+        // The ledger only saw 40% of the day (rows dropped before ingest, or
+        // rotated away first) — presenting that as the day's mix would
+        // misstate it, so the day must stay unfilled and repairable.
+        await store.backfillDayModels(tool: .antigravity, modelsByDay: [
+            key: [CostSnapshot.ModelBreakdown(modelName: "model-partial", costUSD: 4, totalTokens: 4_000)]
+        ])
+        var missing = await store.daysMissingModels(tool: .antigravity)
+        XCTAssertEqual(missing, [key], "an under-covered day must not be marked as filled")
+
+        // A later re-ingest recovers the rest: now the evidence covers the
+        // day and the same entry accepts the fill.
+        await store.backfillDayModels(tool: .antigravity, modelsByDay: [
+            key: [CostSnapshot.ModelBreakdown(modelName: "model-full", costUSD: 10, totalTokens: 9_500)]
+        ])
+        missing = await store.daysMissingModels(tool: .antigravity)
+        XCTAssertTrue(missing.isEmpty)
+        let augmented = await store.mergeAndAugment(
+            snapshot(tool: .antigravity, dailyHistory: [], dailyModels: [:], now: now),
+            retentionDays: CostDataSettings.unlimitedRetentionDays
+        )
+        XCTAssertEqual(augmented.topModels(for: day, limit: .max).map(\.modelName), ["model-full"])
+    }
+
     func testEntriesWithoutModelsStillDecode() async throws {
         let fileManager = FileManager.default
         let directory = fileManager.temporaryDirectory

--- a/Tests/VibeBarCoreTests/CostHistoryStoreTests.swift
+++ b/Tests/VibeBarCoreTests/CostHistoryStoreTests.swift
@@ -410,4 +410,256 @@ final class CostHistoryStoreTests: XCTestCase {
         let history = await store.history(for: .claude, days: nil, retentionDays: 30)
         XCTAssertTrue(history.days.isEmpty)
     }
+
+    // MARK: - Per-day model persistence
+
+    private func snapshot(
+        tool: ToolType,
+        dailyHistory: [DailyCostPoint],
+        dailyModels: [Date: [CostSnapshot.ModelBreakdown]],
+        now: Date
+    ) -> CostSnapshot {
+        let cost = dailyHistory.reduce(0) { $0 + $1.costUSD }
+        let tokens = dailyHistory.reduce(0) { $0 + $1.totalTokens }
+        return CostSnapshot(
+            tool: tool,
+            todayCostUSD: dailyHistory.last?.costUSD ?? 0,
+            last7DaysCostUSD: cost,
+            last30DaysCostUSD: cost,
+            allTimeCostUSD: cost,
+            todayTokens: dailyHistory.last?.totalTokens ?? 0,
+            last7DaysTokens: tokens,
+            last30DaysTokens: tokens,
+            allTimeTokens: tokens,
+            dailyHistory: dailyHistory,
+            heatmap: .empty(tool: tool),
+            modelBreakdowns: [],
+            dailyModelBreakdown: dailyModels,
+            jsonlFilesFound: 1,
+            updatedAt: now
+        )
+    }
+
+    func testPersistedDayModelsBackfillDaysTheLiveScanNoLongerSees() async throws {
+        let fileManager = FileManager.default
+        let directory = fileManager.temporaryDirectory
+            .appendingPathComponent("VibeBarCostHistoryDayModels-\(UUID().uuidString)", isDirectory: true)
+        try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: directory) }
+
+        let calendar = Calendar.current
+        let now = Date()
+        let today = calendar.startOfDay(for: now)
+        let yesterday = try XCTUnwrap(calendar.date(byAdding: .day, value: -1, to: today))
+        let yesterdayModels = [
+            CostSnapshot.ModelBreakdown(modelName: "Gemini 3.7 Flash (High)", costUSD: 2.5, totalTokens: 2_500)
+        ]
+        let todayModels = [
+            CostSnapshot.ModelBreakdown(modelName: "Gemini 3.7 Pro", costUSD: 1.5, totalTokens: 1_500)
+        ]
+        let url = directory.appendingPathComponent("cost_history.json")
+        let store = CostHistoryStore(fileURL: url)
+
+        _ = await store.mergeAndAugment(
+            snapshot(
+                tool: .antigravity,
+                dailyHistory: [
+                    DailyCostPoint(date: yesterday, costUSD: 2.5, totalTokens: 2_500),
+                    DailyCostPoint(date: today, costUSD: 1.5, totalTokens: 1_500)
+                ],
+                dailyModels: [yesterday: yesterdayModels, today: todayModels],
+                now: now
+            ),
+            retentionDays: CostDataSettings.unlimitedRetentionDays
+        )
+        await store.flushPendingWrites()
+
+        // Second launch: the source logs for yesterday rotated away, so the
+        // live scan only knows about today. A fresh store instance forces the
+        // models through the encode/decode round trip.
+        let reopened = CostHistoryStore(fileURL: url)
+        let merged = await reopened.mergeAndAugment(
+            snapshot(
+                tool: .antigravity,
+                dailyHistory: [DailyCostPoint(date: today, costUSD: 1.6, totalTokens: 1_600)],
+                dailyModels: [today: [
+                    CostSnapshot.ModelBreakdown(modelName: "Gemini 3.7 Pro", costUSD: 1.6, totalTokens: 1_600)
+                ]],
+                now: now
+            ),
+            retentionDays: CostDataSettings.unlimitedRetentionDays
+        )
+
+        XCTAssertEqual(merged.topModels(for: yesterday, limit: .max), yesterdayModels)
+        XCTAssertEqual(merged.topModels(for: today, limit: .max).first?.costUSD ?? 0, 1.6, accuracy: 0.001)
+    }
+
+    func testDayModelsFollowWhicheverScanWinsTheTokenMax() async throws {
+        let fileManager = FileManager.default
+        let directory = fileManager.temporaryDirectory
+            .appendingPathComponent("VibeBarCostHistoryDayModelsMax-\(UUID().uuidString)", isDirectory: true)
+        try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: directory) }
+
+        let calendar = Calendar.current
+        let now = Date()
+        let today = calendar.startOfDay(for: now)
+        let store = CostHistoryStore(fileURL: directory.appendingPathComponent("cost_history.json"))
+        let fullView = [
+            CostSnapshot.ModelBreakdown(modelName: "model-full", costUSD: 3, totalTokens: 3_000)
+        ]
+
+        _ = await store.mergeAndAugment(
+            snapshot(
+                tool: .antigravity,
+                dailyHistory: [DailyCostPoint(date: today, costUSD: 3, totalTokens: 3_000)],
+                dailyModels: [today: fullView],
+                now: now
+            ),
+            retentionDays: CostDataSettings.unlimitedRetentionDays
+        )
+        // A later partial scan (some files already rotated) loses the token
+        // max, so its thinner model mix must not overwrite the stored one.
+        let afterPartial = await store.mergeAndAugment(
+            snapshot(
+                tool: .antigravity,
+                dailyHistory: [DailyCostPoint(date: today, costUSD: 1, totalTokens: 1_000)],
+                dailyModels: [today: [
+                    CostSnapshot.ModelBreakdown(modelName: "model-partial", costUSD: 1, totalTokens: 1_000)
+                ]],
+                now: now
+            ),
+            retentionDays: CostDataSettings.unlimitedRetentionDays
+        )
+
+        XCTAssertEqual(afterPartial.topModels(for: today, limit: .max).map(\.modelName), ["model-partial"])
+        // The augmented snapshot keeps the live scan's view for days it saw;
+        // the persisted entry is what must still hold the full mix.
+        let reopened = await store.mergeAndAugment(
+            snapshot(tool: .antigravity, dailyHistory: [], dailyModels: [:], now: now),
+            retentionDays: CostDataSettings.unlimitedRetentionDays
+        )
+        XCTAssertEqual(reopened.topModels(for: today, limit: .max), fullView)
+    }
+
+    func testReplaceSeriesCarriesDayModelsAndCapsThem() async throws {
+        let fileManager = FileManager.default
+        let directory = fileManager.temporaryDirectory
+            .appendingPathComponent("VibeBarCostHistoryDayModelsCap-\(UUID().uuidString)", isDirectory: true)
+        try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: directory) }
+
+        let calendar = Calendar.current
+        let now = Date()
+        let today = calendar.startOfDay(for: now)
+        let manyModels = (0..<12).map {
+            CostSnapshot.ModelBreakdown(modelName: "model-\($0)", costUSD: Double(12 - $0), totalTokens: 100)
+        }
+        let url = directory.appendingPathComponent("cost_history.json")
+        let store = CostHistoryStore(fileURL: url)
+
+        _ = await store.replaceAndAugment(
+            snapshot(
+                tool: .cursor,
+                dailyHistory: [DailyCostPoint(date: today, costUSD: 78, totalTokens: 1_200)],
+                dailyModels: [today: manyModels],
+                now: now
+            ),
+            retentionDays: CostDataSettings.unlimitedRetentionDays
+        )
+        await store.flushPendingWrites()
+
+        let reopened = CostHistoryStore(fileURL: url)
+        let augmented = await reopened.mergeAndAugment(
+            snapshot(tool: .cursor, dailyHistory: [], dailyModels: [:], now: now),
+            retentionDays: CostDataSettings.unlimitedRetentionDays
+        )
+        let models = augmented.topModels(for: today, limit: .max)
+        XCTAssertEqual(models.count, 8, "persisted per-day models should be capped")
+        XCTAssertEqual(models.map(\.modelName), (0..<8).map { "model-\($0)" }, "cap keeps the top models by cost")
+    }
+
+    func testBackfillFillsOnlyDaysWithoutModels() async throws {
+        let fileManager = FileManager.default
+        let directory = fileManager.temporaryDirectory
+            .appendingPathComponent("VibeBarCostHistoryDayModelsBackfill-\(UUID().uuidString)", isDirectory: true)
+        try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: directory) }
+
+        let calendar = Calendar.current
+        let now = Date()
+        let today = calendar.startOfDay(for: now)
+        let bareDay = try XCTUnwrap(calendar.date(byAdding: .day, value: -20, to: today))
+        let scannedModels = [
+            CostSnapshot.ModelBreakdown(modelName: "model-scanned", costUSD: 1.5, totalTokens: 1_500)
+        ]
+        let store = CostHistoryStore(fileURL: directory.appendingPathComponent("cost_history.json"))
+
+        // One day with a scanned mix, one recorded before models existed.
+        _ = await store.mergeAndAugment(
+            snapshot(
+                tool: .antigravity,
+                dailyHistory: [
+                    DailyCostPoint(date: bareDay, costUSD: 4, totalTokens: 4_000),
+                    DailyCostPoint(date: today, costUSD: 1.5, totalTokens: 1_500)
+                ],
+                dailyModels: [today: scannedModels],
+                now: now
+            ),
+            retentionDays: CostDataSettings.unlimitedRetentionDays
+        )
+
+        let formatter = DateFormatter()
+        formatter.calendar = calendar
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "yyyy-MM-dd"
+        let bareKey = formatter.string(from: bareDay)
+        let todayKey = formatter.string(from: today)
+
+        let missing = await store.daysMissingModels(tool: .antigravity)
+        XCTAssertEqual(missing, [bareKey], "only the pre-models day should report as missing")
+
+        await store.backfillDayModels(tool: .antigravity, modelsByDay: [
+            bareKey: [CostSnapshot.ModelBreakdown(modelName: "model-ledger", costUSD: 4, totalTokens: 4_000)],
+            todayKey: [CostSnapshot.ModelBreakdown(modelName: "model-wrong", costUSD: 9, totalTokens: 9_000)]
+        ])
+
+        let augmented = await store.mergeAndAugment(
+            snapshot(tool: .antigravity, dailyHistory: [], dailyModels: [:], now: now),
+            retentionDays: CostDataSettings.unlimitedRetentionDays
+        )
+        XCTAssertEqual(
+            augmented.topModels(for: bareDay, limit: .max).map(\.modelName),
+            ["model-ledger"]
+        )
+        XCTAssertEqual(
+            augmented.topModels(for: today, limit: .max), scannedModels,
+            "backfill must never overwrite a scanned mix"
+        )
+        let stillMissing = await store.daysMissingModels(tool: .antigravity)
+        XCTAssertTrue(stillMissing.isEmpty)
+    }
+
+    func testEntriesWithoutModelsStillDecode() async throws {
+        let fileManager = FileManager.default
+        let directory = fileManager.temporaryDirectory
+            .appendingPathComponent("VibeBarCostHistoryDayModelsLegacy-\(UUID().uuidString)", isDirectory: true)
+        try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: directory) }
+
+        let url = directory.appendingPathComponent("cost_history.json")
+        let json = """
+        {"schemaVersion":2,"calculationVersion":\(CostUsagePricing.calculationVersion),"historyCorrectionVersion":2,"entries":[\
+        {"tool":"codex","date":"2026-05-28","costUSD":1.5,"totalTokens":1000}]}
+        """
+        try json.write(to: url, atomically: true, encoding: .utf8)
+
+        let store = CostHistoryStore(fileURL: url)
+        let history = await store.history(
+            for: .codex, days: nil, retentionDays: CostDataSettings.unlimitedRetentionDays
+        )
+
+        XCTAssertEqual(history.days.count, 1)
+        XCTAssertEqual(history.days.first?.totalTokens, 1000)
+    }
 }

--- a/Tests/VibeBarCoreTests/UsageLedgerRollupTests.swift
+++ b/Tests/VibeBarCoreTests/UsageLedgerRollupTests.swift
@@ -59,6 +59,52 @@ final class UsageLedgerRollupTests: XCTestCase {
         XCTAssertEqual(again.costMicros, 4_000_000)
     }
 
+    func testDayModelBreakdownsCombineDetailAndRollupsForRequestedDays() async throws {
+        let (ledger, directory) = try UsageLedgerFixtures.makeLedger("RollupDayModels")
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let foldedDay = try day(-40)
+        let liveDay = try day(-5)
+        try await ledger.ingest(UsageLedgerFixtures.batch(events: [
+            UsageLedgerFixtures.priced(
+                UsageLedgerFixtures.event(date: foldedDay, model: "model-a", input: 1_000, output: 100),
+                costUSD: 2.0
+            ),
+            UsageLedgerFixtures.priced(
+                UsageLedgerFixtures.event(date: foldedDay, model: "model-b", input: 500, output: 50),
+                costUSD: 0.5
+            ),
+            UsageLedgerFixtures.priced(
+                UsageLedgerFixtures.event(date: liveDay, model: "model-a", input: 300, output: 30),
+                costUSD: 1.0
+            )
+        ]))
+        try await ledger.rollupAndPrune(now: now, detailDays: 30, retentionDays: 0)
+
+        let formatter = DateFormatter()
+        formatter.calendar = UsageLedgerFixtures.calendar
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "yyyy-MM-dd"
+        let foldedKey = formatter.string(from: foldedDay)
+        let liveKey = formatter.string(from: liveDay)
+
+        let breakdowns = try await ledger.dayModelBreakdowns(
+            tool: .codex, days: [foldedKey, liveKey]
+        )
+
+        // The folded day comes out of the rollup table, cost-sorted.
+        XCTAssertEqual(breakdowns[foldedKey]?.map(\.modelName), ["model-a", "model-b"])
+        XCTAssertEqual(breakdowns[foldedKey]?.first?.costUSD ?? 0, 2.0, accuracy: 0.0001)
+        XCTAssertEqual(breakdowns[foldedKey]?.first?.totalTokens, 1_100)
+        // The recent day still lives in the detail table.
+        XCTAssertEqual(breakdowns[liveKey]?.map(\.modelName), ["model-a"])
+        XCTAssertEqual(breakdowns[liveKey]?.first?.totalTokens, 330)
+        // Days not asked for stay out, and an unknown tool yields nothing.
+        XCTAssertEqual(breakdowns.count, 2)
+        let none = try await ledger.dayModelBreakdowns(tool: .antigravity, days: [foldedKey])
+        XCTAssertTrue(none.isEmpty)
+    }
+
     func testReconsumingPreFloorEventsIsDropped() async throws {
         let (ledger, directory) = try UsageLedgerFixtures.makeLedger("RollupFloor")
         defer { try? FileManager.default.removeItem(at: directory) }


### PR DESCRIPTION
## Problem

AQ reported: AntiGravity has plenty of historical cost data, but historical days show no model mapping ("Model detail is unavailable for this historical period") in the Cost History day inspector.

Root cause: `CostSnapshot.dailyModelBreakdown` was live-scan, in-memory only. `CostHistoryStore` persisted day totals but not the model mix, so once AntiGravity rotated its conversation files (~9 days), every older day lost its models even though the ledger and label store still had the full per-request evidence.

## Fix

- **Persist the mix**: each `cost_history.json` entry now carries an optional `models` array (top 8 by cost). Optional → pre-existing files decode unchanged.
- **Merge semantics**: on max-merge, models follow whichever side won the day's token max (a fresh scan that saw at least as much of the day replaces; a rotated-away day keeps its stored mix). Authoritative replacement (`replaceSeries`, e.g. Cursor) carries the fresh mix outright.
- **Snapshot augmentation**: `augmentedSnapshot` fills `dailyModelBreakdown` from persistence for days the live scan lacks; the live view wins for days it saw.
- **Backfill for existing history**: new `UsageEventLedger.dayModelBreakdowns(tool:days:)` (detail ∪ daily rollups, both keep the model dimension) feeds `CostHistoryStore.backfillDayModels`, which fills only entries with no mix yet. Runs once per tool per launch, before the scan loop, so the same pass already publishes the recovered mix.

## Real-data dry run

Against the live ledger + history on this machine: 35 of 64 persisted AntiGravity days gain a model mix (May 20 – Jul 3 from rollups, Aug 2+ from detail). The Jul 4 – Aug 1 gap has no request-level evidence anywhere (empty-batch-era drops + rotated files) and stays honestly unlabeled.

## Validation

- `swift build` ✓, `swift test` ✓ (5 new tests: rotation fallback, token-max model semantics, replace + top-8 cap round trip, legacy decode, ledger detail∪rollup query, backfill fills-only-missing)
- `./Scripts/build_app.sh release` ✓, `codesign -d --entitlements` empty dict ✓, `codesign --verify --deep --strict` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)