### PR TITLE
Never collapse the shown popover to a transient minimum-height report

### DIFF
--- a/Sources/VibeBarApp/StatusItemController.swift
+++ b/Sources/VibeBarApp/StatusItemController.swift
@@ -166,6 +166,11 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
                 initialPage: controller.popoverInitialPage
             )
                 .vibeBarNoInitialFocus()
+                // While a shrink waits out its settle window the hosting view
+                // is briefly taller than the content; without an explicit top
+                // anchor NSHostingView centers the shorter content and the
+                // whole page appears to hop.
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
                 .environmentObject(environment)
                 .environmentObject(environment.accountStore)
                 .environmentObject(environment.settingsStore)
@@ -322,8 +327,46 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
     /// one trailing resize, which lands on the final height.
     private static let popoverResizeCoalesceWindow: TimeInterval = 0.1
 
+    /// A *shrink* is additionally never applied while the popover is on
+    /// screen until it has survived this window. Reopening the popover or
+    /// switching pages makes SwiftUI's first layout pass report a transiently
+    /// tiny height — the cards have not measured yet — and applying that
+    /// report snapped the visible popover down to `minimumPopoverHeight`
+    /// before the settled height arrived a beat later: the "page reflows to
+    /// minimum height" bounce. A transient dip is superseded by its recovery
+    /// report inside this window and never touches the frame; a real shrink
+    /// survives it and lands once, at the settled value.
+    private static let popoverShrinkSettleWindow: TimeInterval = 0.35
+
     private func resizePopover(kind: MenuBarItemKind, toContentHeight height: CGFloat) {
         guard height.isFinite, height > 0 else { return }
+        if let popover = popovers[kind], popover.isShown {
+            let target = resolvedPopoverHeight(
+                forContentHeight: height,
+                maxHeight: maxPopoverHeight(for: popover)
+            )
+            let current = popover.contentSize
+            switch PopoverResizeGate.verdict(
+                currentHeight: current.height,
+                targetHeight: target,
+                currentWidth: current.width,
+                targetWidth: currentPopoverWidth(for: kind)
+            ) {
+            case .ignore:
+                // The content walked back to the on-screen size — nothing to
+                // change, and nothing a stale trailing task may restore.
+                popoverResizeTasks.removeValue(forKey: kind)?.cancel()
+                pendingPopoverHeights.removeValue(forKey: kind)
+                return
+            case .holdForSettle:
+                popoverResizeTasks.removeValue(forKey: kind)?.cancel()
+                pendingPopoverHeights[kind] = height
+                scheduleCoalescedResize(kind: kind, after: Self.popoverShrinkSettleWindow)
+                return
+            case .applyNow:
+                break
+            }
+        }
         let sinceLast = lastPopoverResizeAt[kind].map { Date().timeIntervalSince($0) }
         if let sinceLast, sinceLast < Self.popoverResizeCoalesceWindow {
             pendingPopoverHeights[kind] = height
@@ -356,13 +399,21 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
         }
     }
 
+    /// One resolution for both the gate and the apply, so the two can never
+    /// disagree about what a content height means for the visible frame.
+    private func resolvedPopoverHeight(forContentHeight height: CGFloat, maxHeight: CGFloat) -> CGFloat {
+        let resolved = min(max(height + Self.popoverHeightPadding, Self.minimumPopoverHeight), maxHeight)
+        return (resolved / 2).rounded() * 2
+    }
+
     private func applyPopoverResize(kind: MenuBarItemKind, toContentHeight height: CGFloat) {
         lastPopoverResizeAt[kind] = Date()
         guard let popover = popovers[kind] else { return }
         guard height.isFinite, height > 0 else { return }
-        let maxHeight = maxPopoverHeight(for: popover)
-        let resolvedHeight = min(max(height + Self.popoverHeightPadding, Self.minimumPopoverHeight), maxHeight)
-        let targetHeight = (resolvedHeight / 2).rounded() * 2
+        let targetHeight = resolvedPopoverHeight(
+            forContentHeight: height,
+            maxHeight: maxPopoverHeight(for: popover)
+        )
         let width = currentPopoverWidth(for: kind)
         let current = popover.contentSize
         guard abs(current.height - targetHeight) > 1 || abs(current.width - width) > 1 else {

--- a/Sources/VibeBarApp/StatusItemController.swift
+++ b/Sources/VibeBarApp/StatusItemController.swift
@@ -338,6 +338,11 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
     /// survives it and lands once, at the settled value.
     private static let popoverShrinkSettleWindow: TimeInterval = 0.35
 
+    /// Kinds whose pending resize task is a shrink hold (as opposed to an
+    /// ordinary trailing coalesce): a growth report cancels these instead of
+    /// waiting out their longer deadline.
+    private var popoverShrinkHoldKinds: Set<MenuBarItemKind> = []
+
     private func resizePopover(kind: MenuBarItemKind, toContentHeight height: CGFloat) {
         guard height.isFinite, height > 0 else { return }
         if let popover = popovers[kind], popover.isShown {
@@ -355,16 +360,23 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
             case .ignore:
                 // The content walked back to the on-screen size — nothing to
                 // change, and nothing a stale trailing task may restore.
-                popoverResizeTasks.removeValue(forKey: kind)?.cancel()
-                pendingPopoverHeights.removeValue(forKey: kind)
+                cancelPendingPopoverResize(kind: kind)
                 return
             case .holdForSettle:
-                popoverResizeTasks.removeValue(forKey: kind)?.cancel()
+                cancelPendingPopoverResize(kind: kind)
+                popoverShrinkHoldKinds.insert(kind)
                 pendingPopoverHeights[kind] = height
                 scheduleCoalescedResize(kind: kind, after: Self.popoverShrinkSettleWindow)
                 return
             case .applyNow:
-                break
+                // A held shrink must not outlive the growth that supersedes
+                // it: left in place, its 350ms task would swallow this report
+                // into its own deadline and the popover would sit undersized
+                // for the rest of the hold. Cancel it so the growth goes
+                // through the ordinary burst path below.
+                if popoverShrinkHoldKinds.contains(kind) {
+                    cancelPendingPopoverResize(kind: kind)
+                }
             }
         }
         let sinceLast = lastPopoverResizeAt[kind].map { Date().timeIntervalSince($0) }
@@ -380,9 +392,14 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
         // busy main actor it can wake after its deadline, land here *after*
         // this newer report, and resize the popover back to the stale height
         // it captured. Supersede both the task and its pending height.
+        cancelPendingPopoverResize(kind: kind)
+        applyPopoverResize(kind: kind, toContentHeight: height)
+    }
+
+    private func cancelPendingPopoverResize(kind: MenuBarItemKind) {
         popoverResizeTasks.removeValue(forKey: kind)?.cancel()
         pendingPopoverHeights.removeValue(forKey: kind)
-        applyPopoverResize(kind: kind, toContentHeight: height)
+        popoverShrinkHoldKinds.remove(kind)
     }
 
     private func scheduleCoalescedResize(kind: MenuBarItemKind, after delay: TimeInterval) {
@@ -394,6 +411,7 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
             // bookkeeping a cancelled sleeper must not clobber.
             guard let self, !Task.isCancelled else { return }
             self.popoverResizeTasks[kind] = nil
+            self.popoverShrinkHoldKinds.remove(kind)
             guard let height = self.pendingPopoverHeights.removeValue(forKey: kind) else { return }
             self.applyPopoverResize(kind: kind, toContentHeight: height)
         }

--- a/Sources/VibeBarCore/Services/PopoverResizeGate.swift
+++ b/Sources/VibeBarCore/Services/PopoverResizeGate.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+/// Decides how a content-height report may touch a popover that is on
+/// screen. Growth applies immediately — an opening popover must reach its
+/// content height without a visible delay. A shrink never applies
+/// immediately: SwiftUI's first layout pass after reopening or switching
+/// pages reports a transiently tiny height before the cards have measured,
+/// and applying it snapped the visible popover down to its minimum height
+/// for a beat ("the page reflows to minimum height"). The caller holds a
+/// shrink for a settle window instead and applies it only if no larger
+/// report supersedes it.
+///
+/// Only the decision lives here so it can be tested; the windows, the
+/// coalescing, and the actual frame write stay with the AppKit controller.
+public enum PopoverResizeGate {
+    public enum Verdict: Equatable {
+        /// Growth, or a width change that must stay in sync: apply now.
+        case applyNow
+        /// Lower than what is on screen: hold for the settle window.
+        case holdForSettle
+        /// No meaningful change from what is on screen.
+        case ignore
+    }
+
+    public static func verdict(
+        currentHeight: CGFloat,
+        targetHeight: CGFloat,
+        currentWidth: CGFloat,
+        targetWidth: CGFloat
+    ) -> Verdict {
+        let widthChanged = abs(currentWidth - targetWidth) > 1
+        let heightDelta = targetHeight - currentHeight
+        if abs(heightDelta) <= 1 {
+            return widthChanged ? .applyNow : .ignore
+        }
+        if heightDelta < 0, !widthChanged {
+            return .holdForSettle
+        }
+        return .applyNow
+    }
+}

--- a/Tests/VibeBarCoreTests/PopoverResizeGateTests.swift
+++ b/Tests/VibeBarCoreTests/PopoverResizeGateTests.swift
@@ -1,0 +1,59 @@
+import XCTest
+@testable import VibeBarCore
+
+final class PopoverResizeGateTests: XCTestCase {
+    func testGrowthAppliesImmediately() {
+        XCTAssertEqual(
+            PopoverResizeGate.verdict(
+                currentHeight: 720, targetHeight: 900,
+                currentWidth: 420, targetWidth: 420
+            ),
+            .applyNow
+        )
+    }
+
+    func testTransientDipIsHeldInsteadOfCollapsingTheFrame() {
+        // The reopen bounce: content momentarily measures tiny, the resolved
+        // target lands on the minimum height, and applying it snapped the
+        // visible popover down before the settled height arrived.
+        XCTAssertEqual(
+            PopoverResizeGate.verdict(
+                currentHeight: 900, targetHeight: 460,
+                currentWidth: 420, targetWidth: 420
+            ),
+            .holdForSettle
+        )
+    }
+
+    func testSettledSameHeightIsIgnored() {
+        // Recovery report after a held dip: nothing to change (the caller
+        // also drops the pending shrink on this verdict).
+        XCTAssertEqual(
+            PopoverResizeGate.verdict(
+                currentHeight: 900, targetHeight: 900.4,
+                currentWidth: 420, targetWidth: 420
+            ),
+            .ignore
+        )
+    }
+
+    func testWidthChangeAppliesEvenWithoutHeightChange() {
+        XCTAssertEqual(
+            PopoverResizeGate.verdict(
+                currentHeight: 900, targetHeight: 900,
+                currentWidth: 420, targetWidth: 460
+            ),
+            .applyNow
+        )
+    }
+
+    func testShrinkWithWidthChangeStaysImmediateToKeepFrameInSync() {
+        XCTAssertEqual(
+            PopoverResizeGate.verdict(
+                currentHeight: 900, targetHeight: 700,
+                currentWidth: 420, targetWidth: 460
+            ),
+            .applyNow
+        )
+    }
+}


### PR DESCRIPTION
## Problem

AQ reported the popover "reflows to minimum height" on open — not refresh-driven: the page visibly collapses and re-expands.

Mechanism: height reports arrive per layout pass via `readHeight`, and `resizePopover` applies the **first report of a burst immediately**. On reopen / page switch, SwiftUI's first pass reports a transiently tiny height (cards not yet measured). That report resolves to `minimumPopoverHeight` (460) and gets written to `popover.contentSize` at once — the shown popover snaps down, then bounces back when the settled height arrives one pass later.

## Fix

- New `PopoverResizeGate` (VibeBarCore, pure + unit-tested): for a **shown** popover, growth and width syncs apply immediately; a **shrink is held** for a 350ms settle window and only lands if no larger report supersedes it. Transient dips are swallowed by their own recovery report and never touch the frame; a genuinely shorter page still shrinks — once, at the settled value.
- A report matching the on-screen size drops any pending shrink, so a stale trailing task can't restore a dip.
- The hosting root is top-anchored: during a pending shrink the hosting view is briefly taller than the content, and without the anchor NSHostingView centers the shorter content (a visible hop).
- Hidden popovers keep the existing immediate+coalesced behavior unchanged; height resolution (padding/min/max/rounding) is factored into one helper used by both the gate and the apply, so they can't disagree.

## Validation

- `swift build` ✓, `swift test` ✓ (1669 tests, 5 new gate tests)
- `./Scripts/build_app.sh release` ✓, `codesign -d --entitlements` empty dict ✓, `codesign --verify --deep --strict` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)