### PR TITLE
Bump version to 1.4.0 (build 48) for the stable release

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -19,9 +19,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.3.0</string>
+	<string>1.4.0</string>
 	<key>CFBundleVersion</key>
-	<string>47</string>
+	<string>48</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>26.0</string>
 	<key>LSUIElement</key>


### PR DESCRIPTION
Version bump for the stable (Main channel) 1.4.0 release: CFBundleShortVersionString 1.3.0 → 1.4.0, CFBundleVersion 47 → 48.

Ships everything merged since v1.3.0 (build 37), including today's batch: multi mini windows + 7 display modes + dynamic quota field registry, hierarchical naming, AntiGravity cost recovery (session-kit 0.6.2 + ledger re-ingest), per-day model mix persistence with ledger backfill (#240), reset surfaces (popover card + Workbench page), hitbox and performance sweeps, and the popover minimum-height reflow fix (#241).

After merge: tag `v1.4.0`, run the release workflow, verify the draft (3 assets, independent ZIP SHA-256, appcast Main channel, NOT prerelease), publish, and verify the feed shows Main head 48.

Validation on this branch (merged with current main):
- `swift build` ✓, `swift test` ✓ (1676 tests, 0 failures)
- `./Scripts/build_app.sh release` ✓ — bundle reports 1.4.0 (48)
- `codesign -d --entitlements` empty dict ✓, `codesign --verify --deep --strict` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)