### PR TITLE
Move usage timelines from whole-file JSON to SQLite

### DIFF
--- a/Sources/VibeBarCore/Services/UsageFillTimelineStore.swift
+++ b/Sources/VibeBarCore/Services/UsageFillTimelineStore.swift
@@ -1,4 +1,5 @@
 import Foundation
+import SQLite3
 
 /// Persists quota observations used by reset history and pace forecasting.
 ///
@@ -9,41 +10,46 @@ import Foundation
 /// - Slot size and retention follow the quota window so short rolling limits
 ///   stay detailed without making weekly/monthly history unnecessarily large.
 ///
-/// File: `~/.vibebar/fill_timeline.json` (mode 0600).
+/// Storage is SQLite (`~/.vibebar/fill_timeline.sqlite3`, mode 0600, WAL).
+/// The original whole-file JSON design assumed the timeline would stay small;
+/// real retention grew it to tens of thousands of points, and atomically
+/// rewriting megabytes every save throttle put the app hundreds of KB/s over
+/// the OS disk-write budget. WAL upserts make each refresh cost a few KB —
+/// only the observed slots — no matter how large the history gets. A legacy
+/// `fill_timeline.json` is imported once and removed.
 public actor UsageFillTimelineStore {
-    public static let shared = UsageFillTimelineStore()
+    public static let shared = UsageFillTimelineStore(
+        fileURL: UsageFillTimelineStore.defaultFileURL(),
+        legacyJSONURL: VibeBarLocalStore.fillTimelineURL
+    )
 
-    private struct Storage: Codable {
+    private struct LegacyStorage: Codable {
         var schemaVersion: Int
         var points: [FillTimelinePoint]
-
-        init(
-            schemaVersion: Int = UsageFillTimelineStore.storageSchemaVersion,
-            points: [FillTimelinePoint] = []
-        ) {
-            self.schemaVersion = schemaVersion
-            self.points = points
-        }
     }
 
     private let fileURL: URL
-    private var cachedStorage: Storage?
-    private var lastSavedAt: Date?
-    private var pendingFlushTask: Task<Void, Never>?
-    private var pendingStorage: Storage?
+    private let legacyJSONURL: URL?
+    private var database: TimelineSQLite?
+    private var openAttempted = false
+    private var sidecarPermissionsSet = false
 
-    private static let storageSchemaVersion = 2
-    private static let saveThrottleInterval: TimeInterval = 30
-    private static let maxFileBytes = 24 * 1024 * 1024
+    private static let databaseSchemaVersion: Int32 = 1
+    /// Highest legacy JSON schema this build can import.
+    private static let legacyJSONSchemaVersion = 2
+    /// Defensive cap on the legacy import: a JSON file past this size is
+    /// corrupt, not legitimate history.
+    private static let maxLegacyFileBytes = 24 * 1024 * 1024
     private static let supportedTools: Set<ToolType> = [.codex, .claude, .gemini, .antigravity, .grok, .cursor]
 
-    public init(fileURL: URL = UsageFillTimelineStore.defaultFileURL()) {
+    public init(fileURL: URL = UsageFillTimelineStore.defaultFileURL(), legacyJSONURL: URL? = nil) {
         self.fileURL = fileURL
+        self.legacyJSONURL = legacyJSONURL
     }
 
     public static func defaultFileURL() -> URL {
         try? VibeBarLocalStore.ensureBaseDirectory()
-        return VibeBarLocalStore.fillTimelineURL
+        return VibeBarLocalStore.fillTimelineDatabaseURL
     }
 
     // MARK: - Public API
@@ -54,46 +60,62 @@ public actor UsageFillTimelineStore {
         retentionDays: Int = CostDataSettings.defaultRetentionDays
     ) {
         guard Self.supportedTools.contains(quota.tool) else { return }
+        guard let db = ensureDatabase() else { return }
 
-        var storage = load()
+        let upsert = db.prepare("""
+            INSERT INTO fill_points(
+                account_id, tool, bucket_id, slot_start, used_percent,
+                sampled_at, reset_at, raw_window_seconds
+            ) VALUES(?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(account_id, bucket_id, slot_start) DO UPDATE SET
+                tool = excluded.tool,
+                used_percent = excluded.used_percent,
+                sampled_at = excluded.sampled_at,
+                reset_at = excluded.reset_at,
+                raw_window_seconds = excluded.raw_window_seconds
+            """)
+        guard let upsert else { return }
+        defer { sqlite3_finalize(upsert) }
+
         var dirty = false
+        db.exec("BEGIN IMMEDIATE")
         for bucket in quota.buckets {
             guard bucket.usedPercent.isFinite else { continue }
             let percent = min(100, max(0, bucket.usedPercent))
             let slotStart = Self.slotStart(for: now, windowSeconds: bucket.rawWindowSeconds)
-            if let idx = storage.points.firstIndex(where: {
-                $0.accountId == quota.accountId
-                    && $0.bucketId == bucket.id
-                    && $0.slotStart == slotStart
-            }) {
-                storage.points[idx].usedPercent = percent
-                storage.points[idx].sampledAt = now
-                storage.points[idx].resetAt = bucket.resetAt
-                storage.points[idx].rawWindowSeconds = bucket.rawWindowSeconds
-            } else {
-                storage.points.append(FillTimelinePoint(
-                    accountId: quota.accountId,
-                    tool: quota.tool,
-                    bucketId: bucket.id,
-                    slotStart: slotStart,
-                    usedPercent: percent,
-                    sampledAt: now,
-                    resetAt: bucket.resetAt,
-                    rawWindowSeconds: bucket.rawWindowSeconds
-                ))
-            }
-            dirty = true
+            sqlite3_reset(upsert)
+            db.bindText(upsert, 1, quota.accountId)
+            db.bindText(upsert, 2, quota.tool.rawValue)
+            db.bindText(upsert, 3, bucket.id)
+            db.bindDouble(upsert, 4, slotStart.timeIntervalSince1970)
+            db.bindDouble(upsert, 5, percent)
+            db.bindDouble(upsert, 6, now.timeIntervalSince1970)
+            db.bindOptionalDouble(upsert, 7, bucket.resetAt?.timeIntervalSince1970)
+            db.bindOptionalInt(upsert, 8, bucket.rawWindowSeconds)
+            if sqlite3_step(upsert) == SQLITE_DONE { dirty = true }
         }
-        guard dirty else { return }
-        pruneInPlace(&storage, retentionDays: retentionDays, now: now)
-        save(storage)
+        if dirty {
+            prune(db, retentionDays: retentionDays, now: now)
+        }
+        db.exec("COMMIT")
+        setSidecarPermissionsIfNeeded()
     }
 
     /// Points for one account+bucket, oldest first.
     public func points(accountId: String, bucketId: String) -> [FillTimelinePoint] {
-        load().points
-            .filter { $0.accountId == accountId && $0.bucketId == bucketId }
-            .sorted { $0.slotStart < $1.slotStart }
+        guard let db = ensureDatabase(),
+              let statement = db.prepare("""
+                  SELECT account_id, tool, bucket_id, slot_start, used_percent,
+                         sampled_at, reset_at, raw_window_seconds
+                    FROM fill_points
+                   WHERE account_id = ? AND bucket_id = ?
+                   ORDER BY slot_start
+                  """)
+        else { return [] }
+        defer { sqlite3_finalize(statement) }
+        db.bindText(statement, 1, accountId)
+        db.bindText(statement, 2, bucketId)
+        return readPoints(db, statement)
     }
 
     /// Points for several buckets of one account, oldest first per bucket.
@@ -105,36 +127,52 @@ public actor UsageFillTimelineStore {
     /// Buckets with no recorded points are absent from the result.
     public func points(accountId: String, bucketIds: [String]) -> [String: [FillTimelinePoint]] {
         let wanted = Set(bucketIds)
-        guard !wanted.isEmpty else { return [:] }
+        guard !wanted.isEmpty, let db = ensureDatabase(),
+              let statement = db.prepare("""
+                  SELECT account_id, tool, bucket_id, slot_start, used_percent,
+                         sampled_at, reset_at, raw_window_seconds
+                    FROM fill_points
+                   WHERE account_id = ?
+                   ORDER BY slot_start
+                  """)
+        else { return [:] }
+        defer { sqlite3_finalize(statement) }
+        db.bindText(statement, 1, accountId)
         var grouped: [String: [FillTimelinePoint]] = [:]
-        for point in load().points
-        where point.accountId == accountId && wanted.contains(point.bucketId) {
+        for point in readPoints(db, statement) where wanted.contains(point.bucketId) {
             grouped[point.bucketId, default: []].append(point)
         }
-        return grouped.mapValues { $0.sorted { $0.slotStart < $1.slotStart } }
+        return grouped
     }
 
     public func allPoints() -> [FillTimelinePoint] {
-        load().points
+        guard let db = ensureDatabase(),
+              let statement = db.prepare("""
+                  SELECT account_id, tool, bucket_id, slot_start, used_percent,
+                         sampled_at, reset_at, raw_window_seconds
+                    FROM fill_points
+                   ORDER BY slot_start
+                  """)
+        else { return [] }
+        defer { sqlite3_finalize(statement) }
+        return readPoints(db, statement)
     }
 
     public func eraseAll() {
-        cachedStorage = Storage(points: [])
-        pendingStorage = nil
-        pendingFlushTask?.cancel()
-        pendingFlushTask = nil
-        lastSavedAt = nil
-        try? FileManager.default.removeItem(at: fileURL)
+        database?.close()
+        database = nil
+        openAttempted = false
+        sidecarPermissionsSet = false
+        removeDatabaseFiles()
+        if let legacyJSONURL {
+            try? FileManager.default.removeItem(at: legacyJSONURL)
+        }
     }
 
+    /// Writes are committed per observation now; this folds the WAL back into
+    /// the main file so tests (and privacy-conscious users) see one file.
     public func flushPendingWrites() async {
-        if let storage = pendingStorage {
-            persist(storage)
-            pendingStorage = nil
-            lastSavedAt = Date()
-        }
-        pendingFlushTask?.cancel()
-        pendingFlushTask = nil
+        database?.exec("PRAGMA wal_checkpoint(TRUNCATE)")
     }
 
     // MARK: - Private
@@ -147,77 +185,180 @@ public actor UsageFillTimelineStore {
         UsageTimelineSlotPolicy.slotStart(for: date, windowSeconds: windowSeconds)
     }
 
-    private func load() -> Storage {
-        if let cached = cachedStorage { return cached }
-        if let attrs = try? FileManager.default.attributesOfItem(atPath: fileURL.path),
-           let size = (attrs[.size] as? NSNumber)?.intValue,
-           size > Self.maxFileBytes {
-            let empty = Storage()
-            cachedStorage = empty
-            return empty
-        }
-        guard let data = try? Data(contentsOf: fileURL),
-              let storage = try? JSONDecoder().decode(Storage.self, from: data)
-        else {
-            let empty = Storage()
-            cachedStorage = empty
-            return empty
-        }
-        if storage.schemaVersion > Self.storageSchemaVersion {
-            let empty = Storage()
-            persist(empty)
-            cachedStorage = empty
-            return empty
-        }
-        var migrated = storage
-        if migrated.schemaVersion < Self.storageSchemaVersion {
-            migrated.schemaVersion = Self.storageSchemaVersion
-            persist(migrated)
-        }
-        cachedStorage = migrated
-        return migrated
-    }
+    private func ensureDatabase() -> TimelineSQLite? {
+        if let database { return database }
+        guard !openAttempted else { return nil }
+        openAttempted = true
 
-    private func save(_ storage: Storage) {
-        cachedStorage = storage
-        let now = Date()
-        if let last = lastSavedAt, now.timeIntervalSince(last) < Self.saveThrottleInterval {
-            pendingStorage = storage
-            scheduleFlush(after: Self.saveThrottleInterval - now.timeIntervalSince(last))
-            return
+        var db = TimelineSQLite(url: fileURL)
+        if db == nil || !Self.initializeSchema(db!) {
+            // A corrupt database loads empty and still accepts new points —
+            // same contract the JSON store had for a corrupt file.
+            db?.close()
+            removeDatabaseFiles()
+            db = TimelineSQLite(url: fileURL)
+            guard let retried = db, Self.initializeSchema(retried) else {
+                db?.close()
+                return nil
+            }
         }
-        persist(storage)
-        pendingStorage = nil
-        pendingFlushTask?.cancel()
-        pendingFlushTask = nil
-        lastSavedAt = now
-    }
+        guard let opened = db else { return nil }
 
-    private func persist(_ storage: Storage) {
-        guard let data = try? JSONEncoder().encode(storage) else { return }
-        try? data.write(to: fileURL, options: .atomic)
+        if opened.userVersion > Self.databaseSchemaVersion {
+            // A future build owns this file. Start over rather than guessing
+            // at its schema — mirrors the JSON store's reset-on-future-schema.
+            opened.close()
+            removeDatabaseFiles()
+            guard let fresh = TimelineSQLite(url: fileURL), Self.initializeSchema(fresh) else {
+                return nil
+            }
+            fresh.userVersion = Self.databaseSchemaVersion
+            database = fresh
+        } else {
+            opened.userVersion = Self.databaseSchemaVersion
+            database = opened
+        }
         try? FileManager.default.setAttributes(
             [.posixPermissions: NSNumber(value: Int16(0o600))],
             ofItemAtPath: fileURL.path
         )
+        importLegacyJSONIfPresent()
+        return database
     }
 
-    private func scheduleFlush(after delay: TimeInterval) {
-        if pendingFlushTask != nil { return }
-        let nanoseconds = UInt64(max(0.05, delay) * 1_000_000_000)
-        pendingFlushTask = Task { [weak self] in
-            try? await Task.sleep(nanoseconds: nanoseconds)
-            await self?.flushPendingWrites()
+    private static func initializeSchema(_ db: TimelineSQLite) -> Bool {
+        db.exec("""
+            PRAGMA journal_mode=WAL;
+            PRAGMA synchronous=NORMAL;
+            CREATE TABLE IF NOT EXISTS fill_points (
+                account_id TEXT NOT NULL,
+                tool TEXT NOT NULL,
+                bucket_id TEXT NOT NULL,
+                slot_start REAL NOT NULL,
+                used_percent REAL NOT NULL,
+                sampled_at REAL NOT NULL,
+                reset_at REAL,
+                raw_window_seconds INTEGER,
+                PRIMARY KEY(account_id, bucket_id, slot_start)
+            );
+            """)
+    }
+
+    private func importLegacyJSONIfPresent() {
+        guard let legacyJSONURL, let database,
+              FileManager.default.fileExists(atPath: legacyJSONURL.path)
+        else { return }
+        defer {
+            // One shot either way: a file that failed to decode is corrupt or
+            // from a future build, and leaving it would only re-run this on
+            // every launch. The new database is the source of truth now.
+            try? FileManager.default.removeItem(at: legacyJSONURL)
         }
+        if let attrs = try? FileManager.default.attributesOfItem(atPath: legacyJSONURL.path),
+           let size = (attrs[.size] as? NSNumber)?.intValue,
+           size > Self.maxLegacyFileBytes {
+            return
+        }
+        guard let data = try? Data(contentsOf: legacyJSONURL),
+              let legacy = try? JSONDecoder().decode(LegacyStorage.self, from: data),
+              legacy.schemaVersion <= Self.legacyJSONSchemaVersion
+        else { return }
+        let upsert = database.prepare("""
+            INSERT OR REPLACE INTO fill_points(
+                account_id, tool, bucket_id, slot_start, used_percent,
+                sampled_at, reset_at, raw_window_seconds
+            ) VALUES(?, ?, ?, ?, ?, ?, ?, ?)
+            """)
+        guard let upsert else { return }
+        defer { sqlite3_finalize(upsert) }
+        database.exec("BEGIN IMMEDIATE")
+        for point in legacy.points {
+            sqlite3_reset(upsert)
+            database.bindText(upsert, 1, point.accountId)
+            database.bindText(upsert, 2, point.tool.rawValue)
+            database.bindText(upsert, 3, point.bucketId)
+            database.bindDouble(upsert, 4, point.slotStart.timeIntervalSince1970)
+            database.bindDouble(upsert, 5, point.usedPercent)
+            database.bindDouble(upsert, 6, point.sampledAt.timeIntervalSince1970)
+            database.bindOptionalDouble(upsert, 7, point.resetAt?.timeIntervalSince1970)
+            database.bindOptionalInt(upsert, 8, point.rawWindowSeconds)
+            sqlite3_step(upsert)
+        }
+        database.exec("COMMIT")
+        setSidecarPermissionsIfNeeded()
     }
 
-    private func pruneInPlace(_ storage: inout Storage, retentionDays: Int, now: Date) {
-        storage.points.removeAll { point in
+    private func readPoints(_ db: TimelineSQLite, _ statement: OpaquePointer) -> [FillTimelinePoint] {
+        var points: [FillTimelinePoint] = []
+        while sqlite3_step(statement) == SQLITE_ROW {
+            guard let accountId = db.columnText(statement, 0),
+                  let toolRaw = db.columnText(statement, 1),
+                  let tool = ToolType(rawValue: toolRaw),
+                  let bucketId = db.columnText(statement, 2)
+            else { continue }
+            points.append(FillTimelinePoint(
+                accountId: accountId,
+                tool: tool,
+                bucketId: bucketId,
+                slotStart: Date(timeIntervalSince1970: sqlite3_column_double(statement, 3)),
+                usedPercent: sqlite3_column_double(statement, 4),
+                sampledAt: Date(timeIntervalSince1970: sqlite3_column_double(statement, 5)),
+                resetAt: db.columnOptionalDouble(statement, 6).map(Date.init(timeIntervalSince1970:)),
+                rawWindowSeconds: db.columnOptionalInt(statement, 7)
+            ))
+        }
+        return points
+    }
+
+    /// Window-aware retention, evaluated in SQL. The horizon depends only on
+    /// which of the four slot classes a point's window falls into, so four
+    /// cutoffs bound the whole table — see `UsageTimelineSlotPolicy`.
+    private func prune(_ db: TimelineSQLite, retentionDays: Int, now: Date) {
+        let statement = db.prepare("""
+            DELETE FROM fill_points WHERE slot_start <
+                CASE
+                    WHEN raw_window_seconds IS NOT NULL AND raw_window_seconds <= 21600 THEN ?
+                    WHEN raw_window_seconds IS NOT NULL AND raw_window_seconds <= 691200 THEN ?
+                    WHEN raw_window_seconds IS NOT NULL AND raw_window_seconds <= 3888000 THEN ?
+                    ELSE ?
+                END
+            """)
+        guard let statement else { return }
+        defer { sqlite3_finalize(statement) }
+        for (index, representative) in [21_600, 691_200, 3_888_000, nil as Int?].enumerated() {
             let horizon = UsageTimelineSlotPolicy.retentionHorizonDays(
-                windowSeconds: point.rawWindowSeconds,
+                windowSeconds: representative,
                 retentionDays: retentionDays
             )
-            return point.slotStart < now.addingTimeInterval(-TimeInterval(horizon) * 86_400)
+            db.bindDouble(
+                statement,
+                Int32(index + 1),
+                now.addingTimeInterval(-TimeInterval(horizon) * 86_400).timeIntervalSince1970
+            )
         }
+        sqlite3_step(statement)
+    }
+
+    private func removeDatabaseFiles() {
+        for suffix in ["", "-wal", "-shm"] {
+            try? FileManager.default.removeItem(atPath: fileURL.path + suffix)
+        }
+    }
+
+    private func setSidecarPermissionsIfNeeded() {
+        guard !sidecarPermissionsSet else { return }
+        var allPresentSet = true
+        for suffix in ["-wal", "-shm"] {
+            let path = fileURL.path + suffix
+            guard FileManager.default.fileExists(atPath: path) else {
+                allPresentSet = false
+                continue
+            }
+            try? FileManager.default.setAttributes(
+                [.posixPermissions: NSNumber(value: Int16(0o600))],
+                ofItemAtPath: path
+            )
+        }
+        sidecarPermissionsSet = allPresentSet
     }
 }

--- a/Sources/VibeBarCore/Services/UsageForecastTimelineStore.swift
+++ b/Sources/VibeBarCore/Services/UsageForecastTimelineStore.swift
@@ -1,4 +1,5 @@
 import Foundation
+import SQLite3
 
 /// Persists the pace forecast that was actually shown for each quota bucket.
 ///
@@ -14,44 +15,44 @@ import Foundation
 /// forecast from today's history would quietly launder hindsight into the
 /// projection line, which is exactly what the feature is meant to expose.
 ///
-/// File: `~/.vibebar/forecast_timeline.json` (mode 0600).
+/// Storage is SQLite (`~/.vibebar/forecast_timeline.sqlite3`, mode 0600, WAL)
+/// for the same reason as the fill timeline: whole-file JSON rewrites of a
+/// multi-megabyte history every save throttle blew the OS disk-write budget,
+/// while WAL upserts cost a few KB per refresh. A legacy
+/// `forecast_timeline.json` is imported once and removed.
 public actor UsageForecastTimelineStore {
-    public static let shared = UsageForecastTimelineStore()
+    public static let shared = UsageForecastTimelineStore(
+        fileURL: UsageForecastTimelineStore.defaultFileURL(),
+        legacyJSONURL: VibeBarLocalStore.forecastTimelineURL
+    )
 
-    private struct Storage: Codable {
+    private struct LegacyStorage: Codable {
         var schemaVersion: Int
         var points: [ForecastTimelinePoint]
-
-        init(
-            schemaVersion: Int = UsageForecastTimelineStore.storageSchemaVersion,
-            points: [ForecastTimelinePoint] = []
-        ) {
-            self.schemaVersion = schemaVersion
-            self.points = points
-        }
     }
 
     private let fileURL: URL
-    private var cachedStorage: Storage?
-    private var lastSavedAt: Date?
-    private var pendingFlushTask: Task<Void, Never>?
-    private var pendingStorage: Storage?
+    private let legacyJSONURL: URL?
+    private var database: TimelineSQLite?
+    private var openAttempted = false
+    private var sidecarPermissionsSet = false
 
-    private static let storageSchemaVersion = 1
-    private static let saveThrottleInterval: TimeInterval = 30
-    /// Defensive cap only. Slot cardinality matches the fill timeline and each
-    /// point is roughly twice the payload, so the real file stays far under a
-    /// megabyte; a file past this size is corrupt, not legitimate history.
-    private static let maxFileBytes = 24 * 1024 * 1024
+    private static let databaseSchemaVersion: Int32 = 1
+    /// Highest legacy JSON schema this build can import.
+    private static let legacyJSONSchemaVersion = 1
+    /// Defensive cap on the legacy import: a JSON file past this size is
+    /// corrupt, not legitimate history.
+    private static let maxLegacyFileBytes = 24 * 1024 * 1024
     private static let supportedTools: Set<ToolType> = [.codex, .claude, .gemini, .antigravity, .grok, .cursor]
 
-    public init(fileURL: URL = UsageForecastTimelineStore.defaultFileURL()) {
+    public init(fileURL: URL = UsageForecastTimelineStore.defaultFileURL(), legacyJSONURL: URL? = nil) {
         self.fileURL = fileURL
+        self.legacyJSONURL = legacyJSONURL
     }
 
     public static func defaultFileURL() -> URL {
         try? VibeBarLocalStore.ensureBaseDirectory()
-        return VibeBarLocalStore.forecastTimelineURL
+        return VibeBarLocalStore.forecastTimelineDatabaseURL
     }
 
     // MARK: - Public API
@@ -67,9 +68,28 @@ public actor UsageForecastTimelineStore {
         retentionDays: Int = CostDataSettings.defaultRetentionDays
     ) {
         guard Self.supportedTools.contains(tool), !forecasts.isEmpty else { return }
+        guard let db = ensureDatabase() else { return }
 
-        var storage = load()
+        let upsert = db.prepare("""
+            INSERT INTO forecast_points(
+                account_id, tool, bucket_id, slot_start, sampled_at,
+                projected_used_percent, projected_lower_percent, projected_upper_percent,
+                reset_at, raw_window_seconds
+            ) VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(account_id, bucket_id, slot_start) DO UPDATE SET
+                tool = excluded.tool,
+                sampled_at = excluded.sampled_at,
+                projected_used_percent = excluded.projected_used_percent,
+                projected_lower_percent = excluded.projected_lower_percent,
+                projected_upper_percent = excluded.projected_upper_percent,
+                reset_at = excluded.reset_at,
+                raw_window_seconds = excluded.raw_window_seconds
+            """)
+        guard let upsert else { return }
+        defer { sqlite3_finalize(upsert) }
+
         var dirty = false
+        db.exec("BEGIN IMMEDIATE")
         for forecast in forecasts {
             guard forecast.projectedUsedPercent.isFinite,
                   forecast.projectedUsedLowerPercent.isFinite,
@@ -79,141 +99,258 @@ public actor UsageForecastTimelineStore {
                 for: now,
                 windowSeconds: forecast.rawWindowSeconds
             )
-            if let idx = storage.points.firstIndex(where: {
-                $0.accountId == accountId
-                    && $0.bucketId == forecast.bucketId
-                    && $0.slotStart == slotStart
-            }) {
-                storage.points[idx].sampledAt = now
-                storage.points[idx].projectedUsedPercent = forecast.projectedUsedPercent
-                storage.points[idx].projectedUsedLowerPercent = forecast.projectedUsedLowerPercent
-                storage.points[idx].projectedUsedUpperPercent = forecast.projectedUsedUpperPercent
-                storage.points[idx].resetAt = forecast.resetAt
-                storage.points[idx].rawWindowSeconds = forecast.rawWindowSeconds
-            } else {
-                storage.points.append(ForecastTimelinePoint(
-                    accountId: accountId,
-                    tool: tool,
-                    bucketId: forecast.bucketId,
-                    slotStart: slotStart,
-                    sampledAt: now,
-                    projectedUsedPercent: forecast.projectedUsedPercent,
-                    projectedUsedLowerPercent: forecast.projectedUsedLowerPercent,
-                    projectedUsedUpperPercent: forecast.projectedUsedUpperPercent,
-                    resetAt: forecast.resetAt,
-                    rawWindowSeconds: forecast.rawWindowSeconds
-                ))
-            }
-            dirty = true
+            sqlite3_reset(upsert)
+            db.bindText(upsert, 1, accountId)
+            db.bindText(upsert, 2, tool.rawValue)
+            db.bindText(upsert, 3, forecast.bucketId)
+            db.bindDouble(upsert, 4, slotStart.timeIntervalSince1970)
+            db.bindDouble(upsert, 5, now.timeIntervalSince1970)
+            db.bindDouble(upsert, 6, forecast.projectedUsedPercent)
+            db.bindDouble(upsert, 7, forecast.projectedUsedLowerPercent)
+            db.bindDouble(upsert, 8, forecast.projectedUsedUpperPercent)
+            db.bindOptionalDouble(upsert, 9, forecast.resetAt?.timeIntervalSince1970)
+            db.bindOptionalInt(upsert, 10, forecast.rawWindowSeconds)
+            if sqlite3_step(upsert) == SQLITE_DONE { dirty = true }
         }
-        guard dirty else { return }
-        pruneInPlace(&storage, retentionDays: retentionDays, now: now)
-        save(storage)
+        if dirty {
+            prune(db, retentionDays: retentionDays, now: now)
+        }
+        db.exec("COMMIT")
+        setSidecarPermissionsIfNeeded()
     }
 
     /// Points for one account+bucket, oldest first.
     public func points(accountId: String, bucketId: String) -> [ForecastTimelinePoint] {
-        load().points
-            .filter { $0.accountId == accountId && $0.bucketId == bucketId }
-            .sorted { $0.slotStart < $1.slotStart }
+        guard let db = ensureDatabase(),
+              let statement = db.prepare("""
+                  SELECT account_id, tool, bucket_id, slot_start, sampled_at,
+                         projected_used_percent, projected_lower_percent,
+                         projected_upper_percent, reset_at, raw_window_seconds
+                    FROM forecast_points
+                   WHERE account_id = ? AND bucket_id = ?
+                   ORDER BY slot_start
+                  """)
+        else { return [] }
+        defer { sqlite3_finalize(statement) }
+        db.bindText(statement, 1, accountId)
+        db.bindText(statement, 2, bucketId)
+        return readPoints(db, statement)
     }
 
     public func allPoints() -> [ForecastTimelinePoint] {
-        load().points
+        guard let db = ensureDatabase(),
+              let statement = db.prepare("""
+                  SELECT account_id, tool, bucket_id, slot_start, sampled_at,
+                         projected_used_percent, projected_lower_percent,
+                         projected_upper_percent, reset_at, raw_window_seconds
+                    FROM forecast_points
+                   ORDER BY slot_start
+                  """)
+        else { return [] }
+        defer { sqlite3_finalize(statement) }
+        return readPoints(db, statement)
     }
 
     public func eraseAll() {
-        cachedStorage = Storage(points: [])
-        pendingStorage = nil
-        pendingFlushTask?.cancel()
-        pendingFlushTask = nil
-        lastSavedAt = nil
-        try? FileManager.default.removeItem(at: fileURL)
+        database?.close()
+        database = nil
+        openAttempted = false
+        sidecarPermissionsSet = false
+        removeDatabaseFiles()
+        if let legacyJSONURL {
+            try? FileManager.default.removeItem(at: legacyJSONURL)
+        }
     }
 
+    /// Writes are committed per observation now; this folds the WAL back into
+    /// the main file so tests (and privacy-conscious users) see one file.
     public func flushPendingWrites() async {
-        if let storage = pendingStorage {
-            persist(storage)
-            pendingStorage = nil
-            lastSavedAt = Date()
-        }
-        pendingFlushTask?.cancel()
-        pendingFlushTask = nil
+        database?.exec("PRAGMA wal_checkpoint(TRUNCATE)")
     }
 
     // MARK: - Private
 
-    private func load() -> Storage {
-        if let cached = cachedStorage { return cached }
-        if let attrs = try? FileManager.default.attributesOfItem(atPath: fileURL.path),
-           let size = (attrs[.size] as? NSNumber)?.intValue,
-           size > Self.maxFileBytes {
-            let empty = Storage()
-            cachedStorage = empty
-            return empty
-        }
-        guard let data = try? Data(contentsOf: fileURL),
-              let storage = try? JSONDecoder().decode(Storage.self, from: data)
-        else {
-            let empty = Storage()
-            cachedStorage = empty
-            return empty
-        }
-        if storage.schemaVersion > Self.storageSchemaVersion {
-            let empty = Storage()
-            persist(empty)
-            cachedStorage = empty
-            return empty
-        }
-        var migrated = storage
-        if migrated.schemaVersion < Self.storageSchemaVersion {
-            migrated.schemaVersion = Self.storageSchemaVersion
-            persist(migrated)
-        }
-        cachedStorage = migrated
-        return migrated
-    }
+    private func ensureDatabase() -> TimelineSQLite? {
+        if let database { return database }
+        guard !openAttempted else { return nil }
+        openAttempted = true
 
-    private func save(_ storage: Storage) {
-        cachedStorage = storage
-        let now = Date()
-        if let last = lastSavedAt, now.timeIntervalSince(last) < Self.saveThrottleInterval {
-            pendingStorage = storage
-            scheduleFlush(after: Self.saveThrottleInterval - now.timeIntervalSince(last))
-            return
+        var db = TimelineSQLite(url: fileURL)
+        if db == nil || !Self.initializeSchema(db!) {
+            // A corrupt database loads empty and still accepts new points —
+            // same contract the JSON store had for a corrupt file.
+            db?.close()
+            removeDatabaseFiles()
+            db = TimelineSQLite(url: fileURL)
+            guard let retried = db, Self.initializeSchema(retried) else {
+                db?.close()
+                return nil
+            }
         }
-        persist(storage)
-        pendingStorage = nil
-        pendingFlushTask?.cancel()
-        pendingFlushTask = nil
-        lastSavedAt = now
-    }
+        guard let opened = db else { return nil }
 
-    private func persist(_ storage: Storage) {
-        guard let data = try? JSONEncoder().encode(storage) else { return }
-        try? data.write(to: fileURL, options: .atomic)
+        if opened.userVersion > Self.databaseSchemaVersion {
+            // A future build owns this file. Start over rather than guessing
+            // at its schema — mirrors the JSON store's reset-on-future-schema.
+            opened.close()
+            removeDatabaseFiles()
+            guard let fresh = TimelineSQLite(url: fileURL), Self.initializeSchema(fresh) else {
+                return nil
+            }
+            fresh.userVersion = Self.databaseSchemaVersion
+            database = fresh
+        } else {
+            opened.userVersion = Self.databaseSchemaVersion
+            database = opened
+        }
         try? FileManager.default.setAttributes(
             [.posixPermissions: NSNumber(value: Int16(0o600))],
             ofItemAtPath: fileURL.path
         )
+        importLegacyJSONIfPresent()
+        return database
     }
 
-    private func scheduleFlush(after delay: TimeInterval) {
-        if pendingFlushTask != nil { return }
-        let nanoseconds = UInt64(max(0.05, delay) * 1_000_000_000)
-        pendingFlushTask = Task { [weak self] in
-            try? await Task.sleep(nanoseconds: nanoseconds)
-            await self?.flushPendingWrites()
+    private static func initializeSchema(_ db: TimelineSQLite) -> Bool {
+        db.exec("""
+            PRAGMA journal_mode=WAL;
+            PRAGMA synchronous=NORMAL;
+            CREATE TABLE IF NOT EXISTS forecast_points (
+                account_id TEXT NOT NULL,
+                tool TEXT NOT NULL,
+                bucket_id TEXT NOT NULL,
+                slot_start REAL NOT NULL,
+                sampled_at REAL NOT NULL,
+                projected_used_percent REAL NOT NULL,
+                projected_lower_percent REAL NOT NULL,
+                projected_upper_percent REAL NOT NULL,
+                reset_at REAL,
+                raw_window_seconds INTEGER,
+                PRIMARY KEY(account_id, bucket_id, slot_start)
+            );
+            """)
+    }
+
+    private func importLegacyJSONIfPresent() {
+        guard let legacyJSONURL, let database,
+              FileManager.default.fileExists(atPath: legacyJSONURL.path)
+        else { return }
+        defer {
+            // One shot either way: a file that failed to decode is corrupt or
+            // from a future build, and leaving it would only re-run this on
+            // every launch. The new database is the source of truth now.
+            try? FileManager.default.removeItem(at: legacyJSONURL)
         }
+        if let attrs = try? FileManager.default.attributesOfItem(atPath: legacyJSONURL.path),
+           let size = (attrs[.size] as? NSNumber)?.intValue,
+           size > Self.maxLegacyFileBytes {
+            return
+        }
+        guard let data = try? Data(contentsOf: legacyJSONURL),
+              let legacy = try? JSONDecoder().decode(LegacyStorage.self, from: data),
+              legacy.schemaVersion <= Self.legacyJSONSchemaVersion
+        else { return }
+        let upsert = database.prepare("""
+            INSERT OR REPLACE INTO forecast_points(
+                account_id, tool, bucket_id, slot_start, sampled_at,
+                projected_used_percent, projected_lower_percent, projected_upper_percent,
+                reset_at, raw_window_seconds
+            ) VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """)
+        guard let upsert else { return }
+        defer { sqlite3_finalize(upsert) }
+        database.exec("BEGIN IMMEDIATE")
+        for point in legacy.points {
+            sqlite3_reset(upsert)
+            database.bindText(upsert, 1, point.accountId)
+            database.bindText(upsert, 2, point.tool.rawValue)
+            database.bindText(upsert, 3, point.bucketId)
+            database.bindDouble(upsert, 4, point.slotStart.timeIntervalSince1970)
+            database.bindDouble(upsert, 5, point.sampledAt.timeIntervalSince1970)
+            database.bindDouble(upsert, 6, point.projectedUsedPercent)
+            database.bindDouble(upsert, 7, point.projectedUsedLowerPercent)
+            database.bindDouble(upsert, 8, point.projectedUsedUpperPercent)
+            database.bindOptionalDouble(upsert, 9, point.resetAt?.timeIntervalSince1970)
+            database.bindOptionalInt(upsert, 10, point.rawWindowSeconds)
+            sqlite3_step(upsert)
+        }
+        database.exec("COMMIT")
+        setSidecarPermissionsIfNeeded()
     }
 
-    private func pruneInPlace(_ storage: inout Storage, retentionDays: Int, now: Date) {
-        storage.points.removeAll { point in
+    private func readPoints(_ db: TimelineSQLite, _ statement: OpaquePointer) -> [ForecastTimelinePoint] {
+        var points: [ForecastTimelinePoint] = []
+        while sqlite3_step(statement) == SQLITE_ROW {
+            guard let accountId = db.columnText(statement, 0),
+                  let toolRaw = db.columnText(statement, 1),
+                  let tool = ToolType(rawValue: toolRaw),
+                  let bucketId = db.columnText(statement, 2)
+            else { continue }
+            points.append(ForecastTimelinePoint(
+                accountId: accountId,
+                tool: tool,
+                bucketId: bucketId,
+                slotStart: Date(timeIntervalSince1970: sqlite3_column_double(statement, 3)),
+                sampledAt: Date(timeIntervalSince1970: sqlite3_column_double(statement, 4)),
+                projectedUsedPercent: sqlite3_column_double(statement, 5),
+                projectedUsedLowerPercent: sqlite3_column_double(statement, 6),
+                projectedUsedUpperPercent: sqlite3_column_double(statement, 7),
+                resetAt: db.columnOptionalDouble(statement, 8).map(Date.init(timeIntervalSince1970:)),
+                rawWindowSeconds: db.columnOptionalInt(statement, 9)
+            ))
+        }
+        return points
+    }
+
+    /// Window-aware retention, evaluated in SQL. The horizon depends only on
+    /// which of the four slot classes a point's window falls into, so four
+    /// cutoffs bound the whole table — see `UsageTimelineSlotPolicy`.
+    private func prune(_ db: TimelineSQLite, retentionDays: Int, now: Date) {
+        let statement = db.prepare("""
+            DELETE FROM forecast_points WHERE slot_start <
+                CASE
+                    WHEN raw_window_seconds IS NOT NULL AND raw_window_seconds <= 21600 THEN ?
+                    WHEN raw_window_seconds IS NOT NULL AND raw_window_seconds <= 691200 THEN ?
+                    WHEN raw_window_seconds IS NOT NULL AND raw_window_seconds <= 3888000 THEN ?
+                    ELSE ?
+                END
+            """)
+        guard let statement else { return }
+        defer { sqlite3_finalize(statement) }
+        for (index, representative) in [21_600, 691_200, 3_888_000, nil as Int?].enumerated() {
             let horizon = UsageTimelineSlotPolicy.retentionHorizonDays(
-                windowSeconds: point.rawWindowSeconds,
+                windowSeconds: representative,
                 retentionDays: retentionDays
             )
-            return point.slotStart < now.addingTimeInterval(-TimeInterval(horizon) * 86_400)
+            db.bindDouble(
+                statement,
+                Int32(index + 1),
+                now.addingTimeInterval(-TimeInterval(horizon) * 86_400).timeIntervalSince1970
+            )
         }
+        sqlite3_step(statement)
+    }
+
+    private func removeDatabaseFiles() {
+        for suffix in ["", "-wal", "-shm"] {
+            try? FileManager.default.removeItem(atPath: fileURL.path + suffix)
+        }
+    }
+
+    private func setSidecarPermissionsIfNeeded() {
+        guard !sidecarPermissionsSet else { return }
+        var allPresentSet = true
+        for suffix in ["-wal", "-shm"] {
+            let path = fileURL.path + suffix
+            guard FileManager.default.fileExists(atPath: path) else {
+                allPresentSet = false
+                continue
+            }
+            try? FileManager.default.setAttributes(
+                [.posixPermissions: NSNumber(value: Int16(0o600))],
+                ofItemAtPath: path
+            )
+        }
+        sidecarPermissionsSet = allPresentSet
     }
 }

--- a/Sources/VibeBarCore/Storage/TimelineSQLite.swift
+++ b/Sources/VibeBarCore/Storage/TimelineSQLite.swift
@@ -1,0 +1,98 @@
+import Foundation
+import SQLite3
+
+/// Minimal SQLite plumbing shared by the two usage-timeline stores.
+///
+/// Not an actor: each store actor owns exactly one instance, so all access is
+/// already serialized. The connection is opened with FULLMUTEX anyway so a
+/// stray hop can never corrupt the handle.
+final class TimelineSQLite {
+    let handle: OpaquePointer
+    private let transient = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
+
+    init?(url: URL) {
+        var opened: OpaquePointer?
+        guard sqlite3_open_v2(
+            url.path,
+            &opened,
+            SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_FULLMUTEX,
+            nil
+        ) == SQLITE_OK, let opened else {
+            if opened != nil { sqlite3_close_v2(opened) }
+            return nil
+        }
+        sqlite3_busy_timeout(opened, 5_000)
+        handle = opened
+    }
+
+    func close() {
+        sqlite3_close_v2(handle)
+    }
+
+    @discardableResult
+    func exec(_ sql: String) -> Bool {
+        sqlite3_exec(handle, sql, nil, nil, nil) == SQLITE_OK
+    }
+
+    func prepare(_ sql: String) -> OpaquePointer? {
+        var statement: OpaquePointer?
+        guard sqlite3_prepare_v2(handle, sql, -1, &statement, nil) == SQLITE_OK else {
+            if statement != nil { sqlite3_finalize(statement) }
+            return nil
+        }
+        return statement
+    }
+
+    var userVersion: Int32 {
+        get {
+            guard let statement = prepare("PRAGMA user_version") else { return 0 }
+            defer { sqlite3_finalize(statement) }
+            guard sqlite3_step(statement) == SQLITE_ROW else { return 0 }
+            return sqlite3_column_int(statement, 0)
+        }
+        set {
+            exec("PRAGMA user_version = \(newValue)")
+        }
+    }
+
+    func bindText(_ statement: OpaquePointer, _ index: Int32, _ value: String) {
+        sqlite3_bind_text(statement, index, value, -1, transient)
+    }
+
+    func bindDouble(_ statement: OpaquePointer, _ index: Int32, _ value: Double) {
+        sqlite3_bind_double(statement, index, value)
+    }
+
+    func bindOptionalDouble(_ statement: OpaquePointer, _ index: Int32, _ value: Double?) {
+        if let value {
+            sqlite3_bind_double(statement, index, value)
+        } else {
+            sqlite3_bind_null(statement, index)
+        }
+    }
+
+    func bindOptionalInt(_ statement: OpaquePointer, _ index: Int32, _ value: Int?) {
+        if let value {
+            sqlite3_bind_int64(statement, index, Int64(value))
+        } else {
+            sqlite3_bind_null(statement, index)
+        }
+    }
+
+    func columnText(_ statement: OpaquePointer, _ index: Int32) -> String? {
+        guard let raw = sqlite3_column_text(statement, index) else { return nil }
+        return String(cString: raw)
+    }
+
+    func columnOptionalDouble(_ statement: OpaquePointer, _ index: Int32) -> Double? {
+        sqlite3_column_type(statement, index) == SQLITE_NULL
+            ? nil
+            : sqlite3_column_double(statement, index)
+    }
+
+    func columnOptionalInt(_ statement: OpaquePointer, _ index: Int32) -> Int? {
+        sqlite3_column_type(statement, index) == SQLITE_NULL
+            ? nil
+            : Int(sqlite3_column_int64(statement, index))
+    }
+}

--- a/Sources/VibeBarCore/Storage/VibeBarLocalStore.swift
+++ b/Sources/VibeBarCore/Storage/VibeBarLocalStore.swift
@@ -73,15 +73,27 @@ public enum VibeBarLocalStore {
         baseDirectory.appendingPathComponent("subscription_history.json")
     }
 
+    /// Legacy whole-file JSON fill timeline. Imported once into
+    /// `fillTimelineDatabaseURL` and removed; kept only so the migration can
+    /// find it.
     public static var fillTimelineURL: URL {
         baseDirectory.appendingPathComponent("fill_timeline.json")
     }
 
-    /// Companion to `fillTimelineURL`: what the pace forecast predicted at each
-    /// observation, so the history chart can draw the projection that was
-    /// actually shown instead of recomputing it with hindsight.
+    public static var fillTimelineDatabaseURL: URL {
+        baseDirectory.appendingPathComponent("fill_timeline.sqlite3")
+    }
+
+    /// Companion to `fillTimelineDatabaseURL`: what the pace forecast
+    /// predicted at each observation, so the history chart can draw the
+    /// projection that was actually shown instead of recomputing it with
+    /// hindsight. The `.json` variant is the legacy file, imported once.
     public static var forecastTimelineURL: URL {
         baseDirectory.appendingPathComponent("forecast_timeline.json")
+    }
+
+    public static var forecastTimelineDatabaseURL: URL {
+        baseDirectory.appendingPathComponent("forecast_timeline.sqlite3")
     }
 
     /// Per-page card layout chosen in the layout editor: column ratio, the two

--- a/Tests/VibeBarCoreTests/UsageFillTimelineStoreTests.swift
+++ b/Tests/VibeBarCoreTests/UsageFillTimelineStoreTests.swift
@@ -176,8 +176,9 @@ final class UsageFillTimelineStoreTests: XCTestCase {
         XCTAssertEqual(points.first?.tool, .claude)
     }
 
-    func testSchemaOnePointsMigrateWithoutResetMetadata() async throws {
+    func testLegacyJSONImportsOnceAndIsRemoved() async throws {
         let sampledAt = Date(timeIntervalSince1970: 1_780_000_000)
+        // Schema-1 points lack reset metadata; both legacy schemas import.
         let point = FillTimelinePoint(
             accountId: "acct-legacy",
             tool: .codex,
@@ -190,13 +191,24 @@ final class UsageFillTimelineStoreTests: XCTestCase {
             let schemaVersion = 1
             let points: [FillTimelinePoint]
         }
-        try JSONEncoder().encode(LegacyStorage(points: [point])).write(to: tempURL, options: .atomic)
+        let legacyURL = tempURL.deletingPathExtension().appendingPathExtension("legacy.json")
+        defer { try? FileManager.default.removeItem(at: legacyURL) }
+        try JSONEncoder().encode(LegacyStorage(points: [point])).write(to: legacyURL, options: .atomic)
 
-        let store = UsageFillTimelineStore(fileURL: tempURL)
+        let store = UsageFillTimelineStore(fileURL: tempURL, legacyJSONURL: legacyURL)
         let migrated = await store.points(accountId: "acct-legacy", bucketId: "weekly")
         XCTAssertEqual(migrated.count, 1)
         XCTAssertEqual(migrated.first?.usedPercent, 42)
         XCTAssertNil(migrated.first?.resetAt)
         XCTAssertNil(migrated.first?.rawWindowSeconds)
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: legacyURL.path),
+            "the imported JSON must be removed so it is never rewritten or re-imported"
+        )
+
+        // A reopened store reads the imported history from the database.
+        let reopened = UsageFillTimelineStore(fileURL: tempURL, legacyJSONURL: legacyURL)
+        let persisted = await reopened.points(accountId: "acct-legacy", bucketId: "weekly")
+        XCTAssertEqual(persisted.count, 1)
     }
 }

--- a/Tests/VibeBarCoreTests/UsageForecastTimelineStoreTests.swift
+++ b/Tests/VibeBarCoreTests/UsageForecastTimelineStoreTests.swift
@@ -225,8 +225,9 @@ final class UsageForecastTimelineStoreTests: XCTestCase {
     }
 
     func testOversizedFileIsIgnored() async throws {
-        // A file past the defensive cap is corrupt, not history: it must not
-        // be decoded, and the store has to keep working afterwards.
+        // Garbage past the defensive cap at the database path is corrupt, not
+        // history: the store must recover to a small fresh database and keep
+        // working afterwards.
         try Data(count: 25 * 1024 * 1024).write(to: tempURL, options: .atomic)
         let store = UsageForecastTimelineStore(fileURL: tempURL)
         let initial = await store.allPoints()
@@ -241,10 +242,48 @@ final class UsageForecastTimelineStoreTests: XCTestCase {
 
         let attrs = try FileManager.default.attributesOfItem(atPath: tempURL.path)
         let size = (attrs[.size] as? NSNumber)?.intValue ?? .max
-        XCTAssertLessThan(size, 4_096)
+        XCTAssertLessThan(size, 64 * 1_024)
     }
 
-    func testFutureSchemaVersionResetsStorage() async throws {
+    func testOversizedLegacyJSONIsNotImported() async throws {
+        let legacyURL = tempURL.deletingPathExtension().appendingPathExtension("legacy.json")
+        defer { try? FileManager.default.removeItem(at: legacyURL) }
+        try Data(count: 25 * 1024 * 1024).write(to: legacyURL, options: .atomic)
+
+        let store = UsageForecastTimelineStore(fileURL: tempURL, legacyJSONURL: legacyURL)
+        let points = await store.allPoints()
+        XCTAssertTrue(points.isEmpty)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: legacyURL.path))
+    }
+
+    func testLegacyJSONImportsAndIsRemoved() async throws {
+        let sampledAt = Date(timeIntervalSince1970: 1_780_000_000)
+        let point = ForecastTimelinePoint(
+            accountId: "acct-legacy",
+            tool: .codex,
+            bucketId: "weekly",
+            slotStart: sampledAt,
+            sampledAt: sampledAt,
+            projectedUsedPercent: 61,
+            projectedUsedLowerPercent: 50,
+            projectedUsedUpperPercent: 74
+        )
+        struct LegacyStorage: Encodable {
+            let schemaVersion = 1
+            let points: [ForecastTimelinePoint]
+        }
+        let legacyURL = tempURL.deletingPathExtension().appendingPathExtension("legacy.json")
+        defer { try? FileManager.default.removeItem(at: legacyURL) }
+        try JSONEncoder().encode(LegacyStorage(points: [point])).write(to: legacyURL, options: .atomic)
+
+        let store = UsageForecastTimelineStore(fileURL: tempURL, legacyJSONURL: legacyURL)
+        let migrated = await store.points(accountId: "acct-legacy", bucketId: "weekly")
+        XCTAssertEqual(migrated.count, 1)
+        XCTAssertEqual(migrated.first?.projectedUsedPercent, 61)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: legacyURL.path))
+    }
+
+    func testFutureSchemaLegacyJSONIsDroppedNotImported() async throws {
         struct FutureStorage: Encodable {
             let schemaVersion = 99
             let points: [ForecastTimelinePoint]
@@ -260,9 +299,11 @@ final class UsageForecastTimelineStoreTests: XCTestCase {
             projectedUsedLowerPercent: 50,
             projectedUsedUpperPercent: 74
         )
-        try JSONEncoder().encode(FutureStorage(points: [point])).write(to: tempURL, options: .atomic)
+        let legacyURL = tempURL.deletingPathExtension().appendingPathExtension("legacy.json")
+        defer { try? FileManager.default.removeItem(at: legacyURL) }
+        try JSONEncoder().encode(FutureStorage(points: [point])).write(to: legacyURL, options: .atomic)
 
-        let store = UsageForecastTimelineStore(fileURL: tempURL)
+        let store = UsageForecastTimelineStore(fileURL: tempURL, legacyJSONURL: legacyURL)
         let points = await store.allPoints()
         XCTAssertTrue(points.isEmpty)
     }


### PR DESCRIPTION
## Problem

AQ reported Vibe Bar quitting on its own. Investigation found macOS disk-writes violation reports against the app: **2.1GB dirtied in 74 minutes** (build 48) and **8.6GB overnight** (build 47) — 485–755 KB/s sustained against a 25–99 KB/s OS budget — plus 1.5–1.9GB lifetime-max memory, with the machine's disk near full. The violation report's microstackshots attribute the writes to `QuotaService.store(success:)` → `UsageFillTimelineStore` / `UsageForecastTimelineStore` atomically rewriting their whole JSON files (6.7MB + 9.3MB) on every 30s save throttle.

The stores' own comments assumed "the real file stays far under a megabyte". Window-aware retention legitimately grew them to 34,231 and 31,311 points — the format, not the policy, is what broke.

## Fix

- Both timeline stores now persist to SQLite (`fill_timeline.sqlite3` / `forecast_timeline.sqlite3`, WAL, `synchronous=NORMAL`, mode 0600 including `-wal`/`-shm` sidecars) via a small shared `TimelineSQLite` helper.
- Each refresh upserts only the observed slots (`ON CONFLICT(account_id,bucket_id,slot_start) DO UPDATE`) — a few KB per refresh regardless of history size.
- Window-aware pruning is one `DELETE` with four per-slot-class cutoffs (same `UsageTimelineSlotPolicy` horizons).
- **Public API unchanged** — `observe` / `points` / `allPoints` / `eraseAll` / `flushPendingWrites` keep their signatures, so `QuotaService` and the history chart needed no changes. `flushPendingWrites` now folds the WAL back (`wal_checkpoint(TRUNCATE)`).
- **One-shot migration**: a legacy `*.json` timeline is imported on first open and removed. Real-data dry run: 34,231 + 31,311 points import losslessly in ~0.2s each into ~4.3MB databases.
- Corrupt database → recovers to empty and keeps accepting points (same contract as corrupt JSON); future-schema database or legacy JSON → reset/skip rather than guessed at.

## Validation

- `swift build` ✓, `swift test` ✓ (1678 tests; store suites fully green — behavioral tests carried over unchanged, JSON-era tests adapted to migration semantics, 3 new migration tests)
- Real-data migration dry run against this machine's actual 16MB of timelines ✓ (lossless, ~0.2s per store)
- `./Scripts/build_app.sh release` ✓, `codesign -d --entitlements` empty dict ✓, `codesign --verify --deep --strict` ✓

## Note on the auto-quit report

No crash reports or jetsam kills were recorded for the exits themselves (plausibly because the near-full disk also blocks ReportCrash). This PR removes the app's biggest self-inflicted resource pressure; a live watcher is armed on the machine to capture the next exit with fresh logs if it recurs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)