### PR TITLE
Bump version to 1.4.1 (build 49) for the stable release

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -19,9 +19,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.4.0</string>
+	<string>1.4.1</string>
 	<key>CFBundleVersion</key>
-	<string>48</string>
+	<string>49</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>26.0</string>
 	<key>LSUIElement</key>


### PR DESCRIPTION
Version bump for the stable (Main channel) 1.4.1 release: 1.4.0 → 1.4.1, build 48 → 49.

Ships the disk-writes fix on top of v1.4.0: usage timelines move from whole-file JSON rewrites (16MB every 30s, 485–755 KB/s sustained — the resource violation macOS flagged on builds 47/48) to SQLite WAL upserts of a few KB per refresh, with a lossless one-shot migration of existing history (#243).

After merge: tag `v1.4.1`, verify the draft (3 assets, independent ZIP SHA-256, Main channel, NOT prerelease), publish as latest, verify the feed shows Main head 49.

Validation on this branch:
- `swift build` ✓, `swift test` ✓ (1678 tests, 0 failures)
- `./Scripts/build_app.sh release` ✓ — bundle reports 1.4.1 (49)
- `codesign -d --entitlements` empty dict ✓, `codesign --verify --deep --strict` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)