### PR TITLE
One tree for mini window fields, order, and names

### DIFF
--- a/Sources/VibeBarApp/Views/MiniWindowAltLayouts.swift
+++ b/Sources/VibeBarApp/Views/MiniWindowAltLayouts.swift
@@ -290,10 +290,18 @@ enum MiniStripMetrics {
     static func chipWidth(_ density: MiniStripDensity) -> CGFloat {
         switch density {
         case .roomy:   return 104
-        case .twoLine: return 62
+        case .twoLine: return pairedColumnWidth
         case .narrow:  return 40
         }
     }
+
+    /// Two-line density mirrors the menu bar's two-row layout: entries pair
+    /// into stacked columns, every cell carrying its full label — so the
+    /// column must fit "Claude + GPT Weekly 100%"-class text, scaled down
+    /// rather than abbreviated.
+    static let pairedColumnWidth: CGFloat = 128
+    static let pairedColumnSpacing: CGFloat = 12
+    static let pairedRowSpacing: CGFloat = 2
 
     static func chipSpacing(_ density: MiniStripDensity) -> CGFloat {
         switch density {
@@ -317,6 +325,13 @@ enum MiniStripMetrics {
 
     static func size(entries: [MiniEntry], density: MiniStripDensity) -> CGSize {
         guard !entries.isEmpty else { return CGSize(width: emptyWidth, height: height(density)) }
+        if density == .twoLine {
+            let columns = (entries.count + 1) / 2
+            let width = leadingPadding + trailingPadding
+                + CGFloat(columns) * pairedColumnWidth
+                + CGFloat(max(0, columns - 1)) * pairedColumnSpacing
+            return CGSize(width: width, height: height(density))
+        }
         let companies = MiniEntry.companyRuns(entries)
         var width = leadingPadding + trailingPadding
         for (index, company) in companies.enumerated() {
@@ -340,6 +355,8 @@ struct MiniStripLayout: View {
             if entries.isEmpty {
                 MiniEmptyHint()
                     .frame(width: MiniStripMetrics.emptyWidth)
+            } else if density == .twoLine {
+                pairedColumns
             } else {
                 let companies = MiniEntry.companyRuns(entries)
                 HStack(spacing: 0) {
@@ -364,6 +381,45 @@ struct MiniStripLayout: View {
         .frame(height: MiniStripMetrics.height(density))
     }
 
+    /// The menu bar's two-row layout, as a mini window: entries pair into
+    /// stacked columns in window order — every entry gets a cell, label
+    /// beside its colored number, nothing summarized away.
+    private var pairedColumns: some View {
+        let mode = settingsStore.displayMode
+        let pairs = stride(from: 0, to: entries.count, by: 2).map { index in
+            (top: entries[index], bottom: index + 1 < entries.count ? entries[index + 1] : nil)
+        }
+        return HStack(spacing: MiniStripMetrics.pairedColumnSpacing) {
+            ForEach(Array(pairs.enumerated()), id: \.offset) { _, pair in
+                VStack(alignment: .leading, spacing: MiniStripMetrics.pairedRowSpacing) {
+                    pairedCell(pair.top, mode: mode)
+                    if let bottom = pair.bottom {
+                        pairedCell(bottom, mode: mode)
+                    }
+                }
+                .frame(width: MiniStripMetrics.pairedColumnWidth, alignment: .leading)
+            }
+        }
+        .padding(.leading, MiniStripMetrics.leadingPadding)
+        .padding(.trailing, MiniStripMetrics.trailingPadding)
+    }
+
+    private func pairedCell(_ entry: MiniEntry, mode: DisplayMode) -> some View {
+        let percent = entryPercent(entry, mode: mode)
+        let color = entryColor(entry, mode: mode)
+        return HStack(spacing: 5) {
+            Text(entry.rowLabel)
+                .font(.system(size: 10.5, weight: .semibold, design: .rounded))
+                .foregroundStyle(.primary)
+                .lineLimit(1)
+                .minimumScaleFactor(0.6)
+            Text("\(Int(percent.rounded()))%")
+                .font(.system(size: 10.5, weight: .bold, design: .rounded).monospacedDigit())
+                .foregroundStyle(color)
+        }
+        .help("\(entry.subProviderDisplayName) — \(entry.rowLabel): \(Int(percent.rounded()))%")
+    }
+
     /// The chip shows the run's most critical bucket — least remaining wins.
     @ViewBuilder
     private func chip(for run: [MiniEntry]) -> some View {
@@ -373,7 +429,9 @@ struct MiniStripLayout: View {
         let color = entryColor(worst, mode: mode)
         Group {
             switch density {
-            case .roomy:
+            // .twoLine never reaches the chip path — it renders pairedColumns
+            // with one cell per entry instead of one chip per run.
+            case .roomy, .twoLine:
                 HStack(spacing: 5) {
                     brandDot(worst)
                     number(percent, color: color, size: 13)
@@ -384,20 +442,6 @@ struct MiniStripLayout: View {
                         .minimumScaleFactor(0.6)
                 }
                 .frame(width: MiniStripMetrics.chipWidth(density), alignment: .leading)
-            case .twoLine:
-                VStack(spacing: 1) {
-                    HStack(spacing: 4) {
-                        brandDot(worst)
-                        number(percent, color: color, size: 13)
-                    }
-                    Text(worst.rowLabel)
-                        .font(.system(size: 8, weight: .medium, design: .rounded))
-                        .foregroundStyle(.secondary)
-                        .lineLimit(1)
-                        .minimumScaleFactor(0.6)
-                        .frame(maxWidth: .infinity)
-                }
-                .frame(width: MiniStripMetrics.chipWidth(density))
             case .narrow:
                 HStack(spacing: 4) {
                     brandDot(worst)

--- a/Sources/VibeBarApp/Views/MiniWindowGroupLabelCatalog.swift
+++ b/Sources/VibeBarApp/Views/MiniWindowGroupLabelCatalog.swift
@@ -21,9 +21,9 @@ enum MiniWindowGroupLabelCatalog {
         .init(id: "gemini.all-models", title: "GEMINI WEB · All Models", defaultLabel: "All Models"),
         .init(id: "gemini.pro", title: "GEMINI · Pro", defaultLabel: "Pro"),
         .init(id: "gemini.flash", title: "GEMINI · Flash", defaultLabel: "Flash"),
-        .init(id: "gemini.flash-lite", title: "GEMINI · Flash Lite", defaultLabel: "Lite"),
+        .init(id: "gemini.flash-lite", title: "GEMINI · Flash Lite", defaultLabel: "Flash Lite"),
         .init(id: "antigravity.gemini-models", title: "ANTIGRAVITY · Gemini Models", defaultLabel: "Gemini"),
-        .init(id: "antigravity.claude-gpt-models", title: "ANTIGRAVITY · Claude + GPT Models", defaultLabel: "C+G"),
+        .init(id: "antigravity.claude-gpt-models", title: "ANTIGRAVITY · Claude + GPT Models", defaultLabel: "Claude + GPT"),
         // Stable persisted key (custom labels are stored under it); the
         // wording is the L3 group name from AGENTS.md § 7.1.
         .init(id: "grok.all-models", title: "GROK · Weekly Credits", defaultLabel: "Weekly Credits"),

--- a/Sources/VibeBarApp/Views/MiniWindowsSettingsSection.swift
+++ b/Sources/VibeBarApp/Views/MiniWindowsSettingsSection.swift
@@ -27,7 +27,6 @@ struct MiniWindowsSettingsSection: View {
     /// never during a body render — a debounced name edit republishes
     /// AppSettings and re-renders this whole section, and rebuilding the
     /// merged catalog tree on each of those violates the fluency budget.
-    @State private var cachedCompanies: [NamingCompany] = []
     @State private var cachedSections: [PickerSection] = []
     @State private var mergedOptionsById: [String: MenuBarFieldOption] = [:]
     /// Field ids whose bucket the live quota cache currently returns.
@@ -65,9 +64,6 @@ struct MiniWindowsSettingsSection: View {
             if let config = selectedWindow {
                 windowDetail(config)
             }
-            Divider()
-                .padding(.vertical, 2)
-            sharedNameEditors()
         }
         .onAppear {
             rebuildRegistryCaches()
@@ -83,7 +79,6 @@ struct MiniWindowsSettingsSection: View {
     }
 
     private func rebuildRegistryCaches() {
-        cachedCompanies = namingCompanies()
         cachedSections = pickerSections()
         mergedOptionsById = Dictionary(
             MenuBarFieldCatalog.mergedFields(registry: quotaService.fieldRegistry).map { ($0.id, $0) },
@@ -226,16 +221,30 @@ struct MiniWindowsSettingsSection: View {
                 .foregroundStyle(.secondary)
         }
 
-        Text("Fields shown in “\(config.name)”. Buckets the adapters discover at runtime appear here automatically; a dimmed row is remembered but not in the account's current response.")
+        Text("One tree for the window — grouped exactly as it folds them (company → SubProvider → quota group → bucket). Drag a row to reorder, ✕ to remove, and rename any level in place. First field renders leftmost (or topmost).")
             .font(.caption)
             .foregroundStyle(.secondary)
             .fixedSize(horizontal: false, vertical: true)
-        fieldPicker(config)
+        HStack(spacing: 4) {
+            namingScopeButton(.shared, label: "Names: all windows")
+            namingScopeButton(.window, label: "Only “\(config.name)”")
+            Spacer(minLength: 0)
+        }
+        .padding(3)
+        .background(Capsule(style: .continuous).fill(Color.primary.opacity(0.045)))
+        if namingScope == .window {
+            Text("Name overrides for this window only. An empty field inherits the shared name — shown as the placeholder.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        arrangementList(config)
 
-        Text("Arrangement — grouped exactly as the window folds them (company → SubProvider). Drag a row to reorder; dragging across a group moves the field into it. First field renders leftmost (or topmost).")
+        Text("Not in “\(config.name)” — tick a bucket to add it. Buckets the adapters discover at runtime appear here automatically; a dimmed row is remembered but not in the account's current response, and ✕ dismisses it until the provider returns it.")
             .font(.caption)
             .foregroundStyle(.secondary)
-        arrangementList(config)
+            .fixedSize(horizontal: false, vertical: true)
+        notShownList(config)
     }
 
     private func modePicker(_ config: MiniWindowConfig) -> some View {
@@ -322,9 +331,33 @@ struct MiniWindowsSettingsSection: View {
         return sections
     }
 
-    private func fieldPicker(_ config: MiniWindowConfig) -> some View {
-        VStack(alignment: .leading, spacing: 12) {
-            ForEach(cachedSections) { section in
+    /// The unified tree above holds everything the window shows; this list is
+    /// only what it does not — candidates to tick in, and remembered-but-gone
+    /// rows to dismiss.
+    private func notShownList(_ config: MiniWindowConfig) -> some View {
+        let hidden = settingsStore.settings.miniWindow.hiddenStaleFieldIds
+        let sections: [PickerSection] = cachedSections.compactMap { section in
+            let remaining = section.entries.filter { entry in
+                guard !config.fieldIds.contains(entry.option.id) else { return false }
+                // A dismissed built-in row stays out only while the provider
+                // is not returning it.
+                if entry.discovered == nil,
+                   hidden.contains(entry.option.id),
+                   !liveFieldIds.contains(entry.option.id) {
+                    return false
+                }
+                return true
+            }
+            guard !remaining.isEmpty else { return nil }
+            return PickerSection(tool: section.tool, title: section.title, entries: remaining)
+        }
+        return VStack(alignment: .leading, spacing: 12) {
+            if sections.isEmpty {
+                Text("Every known bucket is already in this window.")
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+            }
+            ForEach(sections) { section in
                 VStack(alignment: .leading, spacing: 8) {
                     HStack(spacing: 6) {
                         ToolBrandIconView(tool: section.tool, size: 13)
@@ -361,21 +394,36 @@ struct MiniWindowsSettingsSection: View {
                     .font(.caption2)
                     .foregroundStyle(.tertiary)
                     .lineLimit(1)
-                if entry.discovered != nil {
-                    Button {
+                Button {
+                    if entry.discovered != nil {
                         forgetDiscoveredField(entry.option.id)
-                    } label: {
-                        Image(systemName: "xmark.circle")
-                            .font(.system(size: 10, weight: .semibold))
-                            .frame(width: 18, height: 18)
-                            .contentShape(Rectangle())
+                    } else {
+                        hideStaleField(entry.option.id)
                     }
-                    .buttonStyle(.vibeBar)
-                    .help("Forget this discovered bucket — drops it from the list and from every window that selected it.")
+                } label: {
+                    Image(systemName: "xmark.circle")
+                        .font(.system(size: 10, weight: .semibold))
+                        .frame(width: 18, height: 18)
+                        .contentShape(Rectangle())
                 }
+                .buttonStyle(.vibeBar)
+                .help(
+                    entry.discovered != nil
+                        ? "Forget this discovered bucket — drops it from the list and from every window that selected it."
+                        : "Dismiss this built-in bucket while the provider is not returning it. It comes back the moment the provider does."
+                )
             }
         }
         .opacity(isLive ? 1 : 0.55)
+    }
+
+    /// Dismiss a built-in catalog bucket while its provider is not returning
+    /// it. Selection state is untouched — the row only leaves the candidate
+    /// list, and returns on its own once the bucket goes live again.
+    private func hideStaleField(_ fieldId: String) {
+        var settings = settingsStore.settings
+        settings.miniWindow.hiddenStaleFieldIds.insert(fieldId)
+        settingsStore.settings = settings
     }
 
     /// Forget a discovered bucket the provider no longer returns: registry
@@ -486,14 +534,15 @@ struct MiniWindowsSettingsSection: View {
                         }
                         .padding(.top, group.firstIndex == 0 ? 0 : 5)
                     }
-                    Text(subProviderDisplayName(group).uppercased())
-                        .font(.system(size: 8.5, weight: .semibold, design: .rounded))
-                        .foregroundStyle(.tertiary)
-                        .tracking(1.0)
-                        .padding(.leading, 16)
-                    ForEach(Array(group.rows.enumerated()), id: \.element.id) { offset, row in
-                        arrangeRowView(row, index: group.firstIndex + offset, count: rows.count)
-                            .opacity(drag?.engaged == true && drag?.fieldID == row.id ? 0.3 : 1)
+                    subProviderHeader(group)
+                    ForEach(groupRuns(group)) { run in
+                        if let groupKey = run.groupKey {
+                            groupHeader(groupKey: groupKey, run: run)
+                        }
+                        ForEach(Array(run.rows.enumerated()), id: \.element.id) { offset, row in
+                            arrangeRowView(row, index: run.firstIndex + offset, count: rows.count)
+                                .opacity(drag?.engaged == true && drag?.fieldID == row.id ? 0.3 : 1)
+                        }
                     }
                 }
             }
@@ -508,6 +557,76 @@ struct MiniWindowsSettingsSection: View {
                 }
             }
         }
+    }
+
+    /// One consecutive run of buckets sharing an L3 quota group inside a
+    /// SubProvider run — the level between the SubProvider header and its
+    /// bucket rows. `nil` groupKey buckets (Grok Bot's single Weekly) render
+    /// without the extra header.
+    private struct GroupRun: Identifiable {
+        let groupKey: String?
+        var rows: [ArrangeRow]
+        let firstIndex: Int
+        var id: String { "\(firstIndex)" }
+    }
+
+    private func groupRuns(_ group: ArrangeGroup) -> [GroupRun] {
+        var runs: [GroupRun] = []
+        var index = group.firstIndex
+        for row in group.rows {
+            let key = Self.namingGroupKey(for: row.option)
+            if var last = runs.last, last.groupKey == key {
+                last.rows.append(row)
+                runs[runs.count - 1] = last
+            } else {
+                runs.append(GroupRun(groupKey: key, rows: [row], firstIndex: index))
+            }
+            index += 1
+        }
+        return runs
+    }
+
+    private func subProviderHeader(_ group: ArrangeGroup) -> some View {
+        let key = MiniWindowGroupLabelCatalog.subProviderKey(tool: group.tool, name: group.subProviderName)
+        return HStack(spacing: 8) {
+            Text(subProviderDisplayName(group).uppercased())
+                .font(.system(size: 8.5, weight: .semibold, design: .rounded))
+                .foregroundStyle(.tertiary)
+                .tracking(1.0)
+            Spacer(minLength: 8)
+            nameField(NamingRow(
+                kind: .subProvider, key: key,
+                title: group.subProviderName, defaultLabel: group.subProviderName
+            ))
+        }
+        .padding(.leading, 16)
+    }
+
+    private func groupHeader(groupKey: String, run: GroupRun) -> some View {
+        let fallback = run.rows.first.map { row in
+            row.option.dynamicGroupTitle ?? MenuBarFieldCatalog.bucketGroupStem(row.option.bucketId)
+        } ?? groupKey
+        let defaultLabel = MiniWindowGroupLabelCatalog.defaultLabel(for: groupKey) ?? fallback
+        let resolved = settingsStore.settings.miniWindow
+            .resolvedGroupLabel(config: selectedWindow, key: groupKey) ?? defaultLabel
+        return HStack(spacing: 8) {
+            Text(resolved.uppercased())
+                .font(.system(size: 8, weight: .semibold, design: .rounded))
+                .foregroundStyle(.tertiary)
+                .tracking(0.8)
+            Spacer(minLength: 8)
+            nameField(NamingRow(
+                kind: .group, key: groupKey,
+                title: defaultLabel, defaultLabel: defaultLabel
+            ))
+        }
+        .padding(.leading, 24)
+    }
+
+    private func nameField(_ row: NamingRow) -> some View {
+        DebouncedSettingsTextField(prompt: namingPrompt(row), value: namingBinding(row))
+            .frame(width: 108)
+            .help(row.key)
     }
 
     private func subProviderDisplayName(_ group: ArrangeGroup) -> String {
@@ -539,6 +658,10 @@ struct MiniWindowsSettingsSection: View {
                     .foregroundStyle(.tertiary)
             }
             Spacer(minLength: 6)
+            nameField(NamingRow(
+                kind: .field, key: row.id,
+                title: row.option.title, defaultLabel: row.option.defaultLabel
+            ))
             if let percent {
                 Text("\(Int(percent.rounded()))%")
                     .font(.system(size: 10.5, weight: .bold, design: .rounded).monospacedDigit())
@@ -686,20 +809,6 @@ struct MiniWindowsSettingsSection: View {
         let title: String
         let defaultLabel: String
         var id: String { key }
-        var indent: CGFloat {
-            switch kind {
-            case .subProvider: return 0
-            case .group: return 16
-            case .field: return 32
-            }
-        }
-    }
-
-    private struct NamingCompany: Identifiable {
-        let name: String
-        let tool: ToolType
-        var rows: [NamingRow]
-        var id: String { name }
     }
 
     /// The L3 group a field's gauge renders under, or nil for a bucket that
@@ -718,89 +827,6 @@ struct MiniWindowsSettingsSection: View {
         case .gemini: return "gemini.all-models"
         case .grok: return "grok.all-models"
         default: return nil
-        }
-    }
-
-    private func namingCompanies() -> [NamingCompany] {
-        let merged = MenuBarFieldCatalog.mergedFields(registry: quotaService.fieldRegistry)
-        var companies: [NamingCompany] = []
-        var companyIndex: [String: Int] = [:]
-        var seenSubKeys: Set<String> = []
-        var seenGroupKeys: Set<String> = []
-        for tool in ToolType.dedicatedCardProviders {
-            for option in merged where option.tool == tool {
-                let vendor = tool.vendorName
-                let company: Int
-                if let index = companyIndex[vendor] {
-                    company = index
-                } else {
-                    company = companies.count
-                    companyIndex[vendor] = company
-                    companies.append(NamingCompany(name: vendor, tool: tool, rows: []))
-                }
-                let subName = tool.quotaSubProviderName(bucketID: option.bucketId)
-                let subKey = MiniWindowGroupLabelCatalog.subProviderKey(tool: tool, name: subName)
-                if seenSubKeys.insert(subKey).inserted {
-                    companies[company].rows.append(NamingRow(
-                        kind: .subProvider, key: subKey, title: subName, defaultLabel: subName
-                    ))
-                }
-                if let groupKey = Self.namingGroupKey(for: option),
-                   seenGroupKeys.insert(groupKey).inserted {
-                    let fallback = option.dynamicGroupTitle
-                        ?? MenuBarFieldCatalog.bucketGroupStem(option.bucketId)
-                    let label = MiniWindowGroupLabelCatalog.defaultLabel(for: groupKey) ?? fallback
-                    companies[company].rows.append(NamingRow(
-                        kind: .group, key: groupKey, title: label, defaultLabel: label
-                    ))
-                }
-                companies[company].rows.append(NamingRow(
-                    kind: .field, key: option.id, title: option.title, defaultLabel: option.defaultLabel
-                ))
-            }
-        }
-        return companies
-    }
-
-    @ViewBuilder
-    private func sharedNameEditors() -> some View {
-        Text("Names")
-            .font(.caption)
-            .fontWeight(.semibold)
-            .foregroundStyle(.secondary)
-        HStack(spacing: 4) {
-            namingScopeButton(.shared, label: "All windows")
-            namingScopeButton(.window, label: "Only “\(selectedWindow?.name ?? "this window")”")
-            Spacer(minLength: 0)
-        }
-        .padding(3)
-        .background(Capsule(style: .continuous).fill(Color.primary.opacity(0.045)))
-        Text(
-            namingScope == .shared
-                ? "One tree, the levels quotas actually have: company → SubProvider → quota group → bucket. Names set here apply to every mini window."
-                : "Overrides for this window only. An empty field inherits the shared name — shown as the placeholder."
-        )
-        .font(.caption)
-        .foregroundStyle(.secondary)
-        .fixedSize(horizontal: false, vertical: true)
-        VStack(alignment: .leading, spacing: 10) {
-            ForEach(cachedCompanies) { company in
-                VStack(alignment: .leading, spacing: 5) {
-                    HStack(spacing: 6) {
-                        ToolBrandIconView(tool: company.tool, size: 13)
-                            .opacity(0.85)
-                        Text(company.name)
-                            .font(.caption)
-                            .fontWeight(.semibold)
-                            .foregroundStyle(.secondary)
-                            .textCase(.uppercase)
-                            .tracking(0.4)
-                    }
-                    ForEach(company.rows) { row in
-                        namingRow(row)
-                    }
-                }
-            }
         }
     }
 
@@ -827,27 +853,6 @@ struct MiniWindowsSettingsSection: View {
                 .contentShape(Capsule(style: .continuous))
         }
         .buttonStyle(.vibeBar(cornerRadius: 11))
-    }
-
-    private func namingRow(_ row: NamingRow) -> some View {
-        HStack(spacing: 8) {
-            Text(row.title)
-                .font(.system(
-                    size: row.kind == .field ? 11.5 : 12,
-                    weight: row.kind == .field ? .regular : .medium
-                ))
-                .foregroundStyle(row.kind == .field ? Color.secondary : Color.primary)
-                .lineLimit(1)
-                .minimumScaleFactor(0.75)
-            Spacer(minLength: 8)
-            DebouncedSettingsTextField(
-                prompt: namingPrompt(row),
-                value: namingBinding(row)
-            )
-            .frame(width: 130)
-        }
-        .padding(.leading, row.indent)
-        .help(row.key)
     }
 
     /// What an empty field falls back to — in window scope that is the shared

--- a/Sources/VibeBarCore/Adapters/AntigravityQuotaAdapter.swift
+++ b/Sources/VibeBarCore/Adapters/AntigravityQuotaAdapter.swift
@@ -462,10 +462,10 @@ private struct QuotaSummarySlot: Hashable {
 
     var shortLabel: String {
         switch (group, cadence) {
-        case (.gemini, .fiveHour): return "G 5h"
-        case (.gemini, .weekly): return "G wk"
-        case (.claudeGPT, .fiveHour): return "C+G 5h"
-        case (.claudeGPT, .weekly): return "C+G wk"
+        case (.gemini, .fiveHour): return "Gemini 5 Hours"
+        case (.gemini, .weekly): return "Gemini Weekly"
+        case (.claudeGPT, .fiveHour): return "Claude + GPT 5 Hours"
+        case (.claudeGPT, .weekly): return "Claude + GPT Weekly"
         }
     }
 }

--- a/Sources/VibeBarCore/Models/AppSettings.swift
+++ b/Sources/VibeBarCore/Models/AppSettings.swift
@@ -1203,6 +1203,13 @@ public struct MiniWindowSettings: Codable, Equatable, Sendable {
     public var windows: [MiniWindowConfig]
     public var customLabels: [String: String]
     public var groupLabels: [String: String]
+    /// Built-in catalog fields the user dismissed while the provider was not
+    /// returning them. A hidden field stays out of the settings tree only
+    /// while it is absent from the account's current response — the moment
+    /// the provider returns it again, it reappears. Discovered fields are
+    /// forgotten through the registry instead; this set is for the static
+    /// catalog rows that have no registry entry to forget.
+    public var hiddenStaleFieldIds: Set<String>
     /// Whether the mini window was open last time the app quit. Restored on
     /// launch so the user doesn't have to re-toggle every session.
     public var wasOpen: Bool
@@ -1223,6 +1230,7 @@ public struct MiniWindowSettings: Codable, Equatable, Sendable {
         windows: [MiniWindowConfig]? = nil,
         customLabels: [String: String] = [:],
         groupLabels: [String: String] = [:],
+        hiddenStaleFieldIds: Set<String> = [],
         wasOpen: Bool = false,
         savedOriginX: Double? = nil,
         savedOriginY: Double? = nil,
@@ -1246,6 +1254,7 @@ public struct MiniWindowSettings: Codable, Equatable, Sendable {
         ]
         self.customLabels = customLabels
         self.groupLabels = groupLabels
+        self.hiddenStaleFieldIds = hiddenStaleFieldIds
         self.wasOpen = wasOpen
         self.savedOriginX = savedOriginX
         self.savedOriginY = savedOriginY
@@ -1255,7 +1264,8 @@ public struct MiniWindowSettings: Codable, Equatable, Sendable {
     }
 
     private enum CodingKeys: String, CodingKey {
-        case displayMode, selectedFieldIds, compactSelectedFieldIds, windows, customLabels, groupLabels, wasOpen
+        case displayMode, selectedFieldIds, compactSelectedFieldIds, windows, customLabels, groupLabels
+        case hiddenStaleFieldIds, wasOpen
         case savedOriginX, savedOriginY, savedPixelOriginX, savedPixelOriginY, savedScreenScale
     }
 
@@ -1272,6 +1282,7 @@ public struct MiniWindowSettings: Codable, Equatable, Sendable {
         let decodedLabels = try c.decodeIfPresent([String: String].self, forKey: .customLabels) ?? [:]
         self.customLabels = MenuBarFieldCatalog.migratedCustomLabels(decodedLabels)
         self.groupLabels = try c.decodeIfPresent([String: String].self, forKey: .groupLabels) ?? [:]
+        self.hiddenStaleFieldIds = try c.decodeIfPresent(Set<String>.self, forKey: .hiddenStaleFieldIds) ?? []
         self.wasOpen = try c.decodeIfPresent(Bool.self, forKey: .wasOpen) ?? false
         self.savedOriginX = try c.decodeIfPresent(Double.self, forKey: .savedOriginX)
         self.savedOriginY = try c.decodeIfPresent(Double.self, forKey: .savedOriginY)
@@ -1307,6 +1318,7 @@ public struct MiniWindowSettings: Codable, Equatable, Sendable {
         try c.encode(windows, forKey: .windows)
         try c.encode(customLabels, forKey: .customLabels)
         try c.encode(groupLabels, forKey: .groupLabels)
+        try c.encode(hiddenStaleFieldIds, forKey: .hiddenStaleFieldIds)
         try c.encode(first?.wasOpen ?? wasOpen, forKey: .wasOpen)
         try c.encodeIfPresent(savedOriginX, forKey: .savedOriginX)
         try c.encodeIfPresent(savedOriginY, forKey: .savedOriginY)

--- a/Sources/VibeBarCore/Models/AppSettings.swift
+++ b/Sources/VibeBarCore/Models/AppSettings.swift
@@ -1183,7 +1183,7 @@ public enum MiniStripDensity: String, Codable, CaseIterable, Identifiable, Senda
     public var detail: String {
         switch self {
         case .roomy:   return "One line, full labels beside each number."
-        case .twoLine: return "Number over its label — narrower per bucket."
+        case .twoLine: return "Menu-bar style: buckets pair into stacked columns, label beside each number."
         case .narrow:  return "Dot and number only; labels on hover."
         }
     }

--- a/Sources/VibeBarCore/Models/MenuBarSettings.swift
+++ b/Sources/VibeBarCore/Models/MenuBarSettings.swift
@@ -288,10 +288,10 @@ public enum MenuBarFieldCatalog {
     ]
 
     public static let antigravityFields: [MenuBarFieldOption] = [
-        option(.antigravity, "gemini_five_hour", "Gemini Models · 5 Hours", "G 5 Hours"),
-        option(.antigravity, "gemini_weekly", "Gemini Models · Weekly", "G Weekly"),
-        option(.antigravity, "claude_gpt_five_hour", "Claude and GPT Models · 5 Hours", "C+G 5 Hours"),
-        option(.antigravity, "claude_gpt_weekly", "Claude and GPT Models · Weekly", "C+G Weekly")
+        option(.antigravity, "gemini_five_hour", "Gemini Models · 5 Hours", "Gemini 5 Hours"),
+        option(.antigravity, "gemini_weekly", "Gemini Models · Weekly", "Gemini Weekly"),
+        option(.antigravity, "claude_gpt_five_hour", "Claude and GPT Models · 5 Hours", "Claude + GPT 5 Hours"),
+        option(.antigravity, "claude_gpt_weekly", "Claude and GPT Models · Weekly", "Claude + GPT Weekly")
     ]
 
     public static let grokFields: [MenuBarFieldOption] = [

--- a/Sources/VibeBarCore/Models/QuotaBucket.swift
+++ b/Sources/VibeBarCore/Models/QuotaBucket.swift
@@ -82,6 +82,7 @@ public struct QuotaBucket: Codable, Identifiable, Hashable, Sendable {
                 switch component.lowercased() {
                 case "5h": return "5 Hours"
                 case "wk": return "Weekly"
+                case "mo", "month": return "Monthly"
                 default: return String(component)
                 }
             }

--- a/Sources/VibeBarCore/Services/MockDataProvider.swift
+++ b/Sources/VibeBarCore/Services/MockDataProvider.swift
@@ -243,10 +243,10 @@ public enum MockDataProvider {
                             shortLabel: "G wk", usedPercent: 17, resetAt: weeklyReset,
                             rawWindowSeconds: 604_800, groupTitle: "Gemini Models"),
                 QuotaBucket(id: "claude_gpt_five_hour", title: "5 Hours",
-                            shortLabel: "C+G 5h", usedPercent: 71, resetAt: fiveHourReset,
+                            shortLabel: "Claude + GPT 5 Hours", usedPercent: 71, resetAt: fiveHourReset,
                             rawWindowSeconds: 18_000, groupTitle: "Claude and GPT Models"),
                 QuotaBucket(id: "claude_gpt_weekly", title: "Weekly",
-                            shortLabel: "C+G wk", usedPercent: 28, resetAt: weeklyReset,
+                            shortLabel: "Claude + GPT Weekly", usedPercent: 28, resetAt: weeklyReset,
                             rawWindowSeconds: 604_800, groupTitle: "Claude and GPT Models")
             ]
         case .grok:

--- a/Tests/VibeBarCoreTests/AlibabaTokenPlanParserTests.swift
+++ b/Tests/VibeBarCoreTests/AlibabaTokenPlanParserTests.swift
@@ -63,7 +63,7 @@ final class AlibabaTokenPlanParserTests: XCTestCase {
         let bucket = snap.buckets[0]
         XCTAssertEqual(bucket.id, "alibabaTokenPlan.\(cnProductCode).standard")
         XCTAssertEqual(bucket.title, "Monthly")
-        XCTAssertEqual(bucket.shortLabel, "Month")
+        XCTAssertEqual(bucket.shortLabel, "Monthly")
         XCTAssertEqual(bucket.rawWindowSeconds, 30 * 86_400)
         XCTAssertEqual(bucket.groupTitle, "Team · Standard")
         XCTAssertEqual(snap.planName, "Token Plan · Team · Standard")

--- a/Tests/VibeBarCoreTests/AntigravityParserTests.swift
+++ b/Tests/VibeBarCoreTests/AntigravityParserTests.swift
@@ -54,7 +54,7 @@ final class AntigravityParserTests: XCTestCase {
             "claude_gpt_weekly"
         ])
         XCTAssertEqual(snap.buckets.map(\.title), ["5 Hours", "Weekly", "5 Hours", "Weekly"])
-        XCTAssertEqual(snap.buckets.map(\.shortLabel), ["G 5 Hours", "G Weekly", "C+G 5 Hours", "C+G Weekly"])
+        XCTAssertEqual(snap.buckets.map(\.shortLabel), ["Gemini 5 Hours", "Gemini Weekly", "Claude + GPT 5 Hours", "Claude + GPT Weekly"])
         XCTAssertEqual(snap.buckets.map(\.groupTitle), [
             "Gemini Models",
             "Gemini Models",

--- a/Tests/VibeBarCoreTests/KimiMiniMaxParserTests.swift
+++ b/Tests/VibeBarCoreTests/KimiMiniMaxParserTests.swift
@@ -132,7 +132,7 @@ final class KimiParserTests: XCTestCase {
         )
         XCTAssertEqual(bucket.id, "kimi.monthly")
         XCTAssertEqual(bucket.title, "Monthly")
-        XCTAssertEqual(bucket.shortLabel, "Mo")
+        XCTAssertEqual(bucket.shortLabel, "Monthly")
         XCTAssertEqual(bucket.usedPercent, 42, accuracy: 0.001)
         XCTAssertEqual(bucket.rawWindowSeconds, 30 * 86_400)
         XCTAssertEqual(

--- a/Tests/VibeBarCoreTests/MiniWindowConfigTests.swift
+++ b/Tests/VibeBarCoreTests/MiniWindowConfigTests.swift
@@ -22,6 +22,16 @@ final class MiniWindowConfigTests: XCTestCase {
         XCTAssertTrue(window.wasOpen)
         // Shared labels stay on the settings struct.
         XCTAssertEqual(settings.customLabels["codex.weekly"], "Wk")
+        // Pre-dismissal settings decode to an empty dismissed set.
+        XCTAssertTrue(settings.hiddenStaleFieldIds.isEmpty)
+    }
+
+    func testHiddenStaleFieldIdsSurviveRoundTrip() throws {
+        var settings = MiniWindowSettings(selectedFieldIds: ["codex.weekly"])
+        settings.hiddenStaleFieldIds = ["claude.weekly_opus", "claude.daily_routines"]
+        let data = try JSONEncoder().encode(settings)
+        let decoded = try JSONDecoder().decode(MiniWindowSettings.self, from: data)
+        XCTAssertEqual(decoded.hiddenStaleFieldIds, ["claude.weekly_opus", "claude.daily_routines"])
     }
 
     func testUnknownDisplayModeFallsBackInsteadOfFailingDecode() throws {

--- a/Tests/VibeBarCoreTests/TencentTokenPlanParserTests.swift
+++ b/Tests/VibeBarCoreTests/TencentTokenPlanParserTests.swift
@@ -75,7 +75,7 @@ final class TencentTokenPlanParserTests: XCTestCase {
         let bucket = snap.buckets[0]
         XCTAssertEqual(bucket.id, "tencentTokenPlan.generic.tp_standard")
         XCTAssertEqual(bucket.title, "Monthly")
-        XCTAssertEqual(bucket.shortLabel, "Month")
+        XCTAssertEqual(bucket.shortLabel, "Monthly")
         XCTAssertEqual(bucket.rawWindowSeconds, 30 * 86_400)
         XCTAssertEqual(bucket.groupTitle, "Standard")
         // 51 / 100_000_000 * 100 ≈ 0.000051

--- a/Tests/VibeBarCoreTests/ZaiParserTests.swift
+++ b/Tests/VibeBarCoreTests/ZaiParserTests.swift
@@ -104,7 +104,7 @@ final class ZaiParserTests: XCTestCase {
         let mcp = snap.buckets[2]
         XCTAssertEqual(mcp.id, "zai.time")
         XCTAssertEqual(mcp.title, "MCP Monthly")
-        XCTAssertEqual(mcp.shortLabel, "Month")
+        XCTAssertEqual(mcp.shortLabel, "Monthly")
         XCTAssertEqual(mcp.rawWindowSeconds, 30 * 86_400)
         XCTAssertEqual(mcp.usedPercent, 0.0, accuracy: 0.01)
     }


### PR DESCRIPTION
Four pieces of AQ feedback on the mini window settings, in three commits:

## 1. Abbreviation purge (product-wide rule: no abbreviations in system copy)
"C+G" kept resurfacing because the AntiGravity adapter fabricates shortLabels ("G 5h", "C+G wk") and adapter shortLabels override catalog defaults on the menu bar and in mini windows. Spelled out at the source ("Gemini 5 Hours", "Claude + GPT Weekly"), taught the central `QuotaBucket` expander "Mo"/"Month" → "Monthly" for misc providers, and fixed the last abbreviated defaults in the menu bar field catalog and mini group-label catalog ("C+G" → "Claude + GPT", "Lite" → "Flash Lite").

## 2. Strip two-line density = the menu bar's two rows
It previously summarized each SubProvider run into one stacked chip (most buckets never appeared). Now it mirrors the menu bar layout exactly: entries pair into stacked columns in window order, one cell per bucket, full label beside its colored number. Window sizing follows the column count.

## 3. Three editors → one tree
Enable (checkboxes), order (arrangement), and names (naming tree) were three near-identical traversals. Now one tree, grouped exactly as the window folds (company → SubProvider → quota group → bucket): drag to reorder, ✕ to remove, inline rename field on every level, name scope pill (all windows / this window) preserved.

## 4. Visible dismiss for inactive rows
The forget ✕ existed only for runtime-discovered buckets; the built-in catalog rows in AQ's screenshot had nothing. The candidate list below the tree now gives every remembered-but-absent row a dismiss: discovered → registry forget (as before); built-in → new `hiddenStaleFieldIds` (decode-compatible), which hides the row only while the provider isn't returning it — it reappears by itself the moment the bucket is live again.

## Validation
- `swift build` ✓, `swift test` ✓ (1679 tests; +1 round-trip test for the dismissed set)
- `./Scripts/build_app.sh release` ✓, empty entitlements ✓, deep signature ✓
- No-pixel demo smoke of `settings:miniWindow` ✓ (UI builds, no error output)

🤖 Generated with [Claude Code](https://claude.com/claude-code)