### PR TITLE
Bump build number to 50 for the next Dev release

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.4.1</string>
 	<key>CFBundleVersion</key>
-	<string>49</string>
+	<string>50</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>26.0</string>
 	<key>LSUIElement</key>


### PR DESCRIPTION
Build bump for the Dev-channel release `v1.4.1-dev.50` (version stays 1.4.1).

Ships on top of v1.4.1: the mini settings overhaul (#245) — unified field/order/name tree, menu-bar-style two-line strip, product-wide abbreviation purge, and dismissible inactive rows.

After merge: tag `v1.4.1-dev.50` → release workflow (dev channel from the tag) → verify draft (3 assets, ZIP SHA-256, appcast dev channel) → publish as prerelease → verify feed Dev head 50.

Validation: `swift build` ✓, `swift test` ✓ (1679 tests), `./Scripts/build_app.sh release` ✓ (bundle 1.4.1 (50)), empty entitlements ✓, deep signature ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)