### PR TITLE
Align every mini layout with the quota hierarchy and the menu bar

### DIFF
--- a/Sources/VibeBarApp/Views/MiniQuotaWindowView.swift
+++ b/Sources/VibeBarApp/Views/MiniQuotaWindowView.swift
@@ -446,7 +446,7 @@ private struct MiniBranchCell: Identifiable {
         case let id where tool == .antigravity && id.contains("high"):
             return "High"
         case let id where tool == .antigravity && id.contains("medium"):
-            return "Med"
+            return "Medium"
         case let id where tool == .antigravity && id.contains("low"):
             return "Low"
         default:
@@ -489,9 +489,9 @@ private struct MiniBranchCell: Identifiable {
         case let id where tool == .antigravity && ["gemini_five_hour", "gemini_weekly"].contains(id):
             return "Gemini"
         case let id where tool == .antigravity && ["claude_gpt_five_hour", "claude_gpt_weekly"].contains(id):
-            return "C+G"
+            return "Claude + GPT"
         case let id where tool == .gemini && id.contains("flash-lite"):
-            return "Lite"
+            return "Flash Lite"
         case let id where tool == .gemini && id.contains("flash"):
             return "Flash"
         case let id where tool == .gemini && id.contains("pro"):
@@ -501,11 +501,11 @@ private struct MiniBranchCell: Identifiable {
         case let id where tool == .antigravity && id.contains("claude"):
             return "Claude"
         case let id where tool == .antigravity && id.contains("flash-lite"):
-            return "G Lite"
+            return "Flash Lite"
         case let id where tool == .antigravity && id.contains("flash"):
-            return "G Flash"
+            return "Flash"
         case let id where tool == .antigravity && id.contains("gemini") && id.contains("pro"):
-            return "G Pro"
+            return "Pro"
         default:
             return (bucket.groupTitle ?? bucket.shortLabel)
                 .replacingOccurrences(of: "GPT-5.3 Codex Spark", with: "Spark")

--- a/Sources/VibeBarApp/Views/MiniWindowAltLayouts.swift
+++ b/Sources/VibeBarApp/Views/MiniWindowAltLayouts.swift
@@ -55,12 +55,15 @@ struct MiniEntry: Identifiable {
             }
             guard let bucket = account?.bucket(id: field.bucketId) else { return nil }
             let subProviderName = field.tool.quotaSubProviderName(bucketID: field.bucketId)
-            let isGrouped = MiniQuotaWindowView.hasQuotaGroup(bucket, tool: field.tool, bucketId: field.bucketId)
+            // Grouped by the shared quota-axis key, so a primary bucket reads
+            // "All · Weekly" here exactly as it sits under the All branch in
+            // the regular layout — bare "Weekly" rows were indistinguishable
+            // once a SubProvider had more than one group.
             var groupLabel: String?
-            if isGrouped {
-                let key = MiniWindowGroupLabelCatalog.groupKey(tool: field.tool, bucketId: field.bucketId)
+            if let key = MiniWindowGroupLabelCatalog.namingGroupKey(for: field) {
                 groupLabel = settings.resolvedGroupLabel(config: config, key: key)
                     ?? MiniWindowGroupLabelCatalog.defaultLabel(for: key)
+                    ?? field.dynamicGroupTitle
                     ?? bucket.groupTitle
             }
             let subProviderKey = MiniWindowGroupLabelCatalog.subProviderKey(tool: field.tool, name: subProviderName)
@@ -135,18 +138,6 @@ private func entryColor(_ entry: MiniEntry, mode: DisplayMode) -> Color {
 /// it to decide which bucket is the most critical.
 private func remainingPercent(_ entry: MiniEntry) -> Double {
     max(0, 100 - entry.bucket.usedPercent)
-}
-
-private func shortCompany(_ tool: ToolType) -> String {
-    switch tool {
-    case .codex:       return "GPT"
-    case .claude:      return "CLD"
-    case .gemini:      return "GEM"
-    case .antigravity: return "AG"
-    case .grok:        return "GRK"
-    case .cursor:      return "CUR"
-    default:           return providerTitle(for: tool)
-    }
 }
 
 private struct MiniEmptyHint: View {
@@ -287,12 +278,19 @@ enum MiniStripMetrics {
     static let trailingPadding: CGFloat = 26
     static let emptyWidth: CGFloat = 200
 
+    /// One cell per selected bucket in every density — the strip mirrors the
+    /// menu bar's own styles (single line / two rows / compact), so nothing
+    /// is summarized away behind a "worst bucket" chip anymore.
     static func chipWidth(_ density: MiniStripDensity) -> CGFloat {
         switch density {
-        case .roomy:   return 104
+        case .roomy:   return 132
         case .twoLine: return pairedColumnWidth
-        case .narrow:  return 40
+        case .narrow:  return 96
         }
+    }
+
+    static func cellFontSize(_ density: MiniStripDensity) -> CGFloat {
+        density == .narrow ? 9.5 : 11.5
     }
 
     /// Two-line density mirrors the menu bar's two-row layout: entries pair
@@ -317,9 +315,9 @@ enum MiniStripMetrics {
 
     static func height(_ density: MiniStripDensity) -> CGFloat {
         switch density {
-        case .roomy:   return 44
+        case .roomy:   return 40
         case .twoLine: return 54
-        case .narrow:  return 40
+        case .narrow:  return 32
         }
     }
 
@@ -336,9 +334,8 @@ enum MiniStripMetrics {
         var width = leadingPadding + trailingPadding
         for (index, company) in companies.enumerated() {
             if index > 0 { width += 2 * companySpacing(density) + dividerThickness }
-            let chips = MiniEntry.subProviderRuns(company).count
-            width += CGFloat(chips) * chipWidth(density)
-                + CGFloat(max(0, chips - 1)) * chipSpacing(density)
+            width += CGFloat(company.count) * chipWidth(density)
+                + CGFloat(max(0, company.count - 1)) * chipSpacing(density)
         }
         return CGSize(width: width, height: height(density))
     }
@@ -364,12 +361,12 @@ struct MiniStripLayout: View {
                         if index > 0 {
                             Rectangle()
                                 .fill(Color.primary.opacity(0.12))
-                                .frame(width: MiniStripMetrics.dividerThickness, height: 18)
+                                .frame(width: MiniStripMetrics.dividerThickness, height: 16)
                                 .padding(.horizontal, MiniStripMetrics.companySpacing(density))
                         }
                         HStack(spacing: MiniStripMetrics.chipSpacing(density)) {
-                            ForEach(Array(MiniEntry.subProviderRuns(company).enumerated()), id: \.offset) { _, run in
-                                chip(for: run)
+                            ForEach(company) { entry in
+                                lineCell(entry)
                             }
                         }
                     }
@@ -420,57 +417,26 @@ struct MiniStripLayout: View {
         .help("\(entry.subProviderDisplayName) — \(entry.rowLabel): \(Int(percent.rounded()))%")
     }
 
-    /// The chip shows the run's most critical bucket — least remaining wins.
-    @ViewBuilder
-    private func chip(for run: [MiniEntry]) -> some View {
+    /// The menu bar's single-line style, one cell per bucket: full label
+    /// beside its colored number. Narrow is the compact variant — the same
+    /// pieces at the menu bar's small size.
+    private func lineCell(_ entry: MiniEntry) -> some View {
         let mode = settingsStore.displayMode
-        let worst = run.min { remainingPercent($0) < remainingPercent($1) } ?? run[0]
-        let percent = entryPercent(worst, mode: mode)
-        let color = entryColor(worst, mode: mode)
-        Group {
-            switch density {
-            // .twoLine never reaches the chip path — it renders pairedColumns
-            // with one cell per entry instead of one chip per run.
-            case .roomy, .twoLine:
-                HStack(spacing: 5) {
-                    brandDot(worst)
-                    number(percent, color: color, size: 13)
-                    Text(worst.rowLabel)
-                        .font(.system(size: 8.5, weight: .medium, design: .rounded))
-                        .foregroundStyle(.secondary)
-                        .lineLimit(1)
-                        .minimumScaleFactor(0.6)
-                }
-                .frame(width: MiniStripMetrics.chipWidth(density), alignment: .leading)
-            case .narrow:
-                HStack(spacing: 4) {
-                    brandDot(worst)
-                    number(percent, color: color, size: 12)
-                }
-                .frame(width: MiniStripMetrics.chipWidth(density), alignment: .leading)
-            }
+        let percent = entryPercent(entry, mode: mode)
+        let color = entryColor(entry, mode: mode)
+        let size = MiniStripMetrics.cellFontSize(density)
+        return HStack(spacing: 5) {
+            Text(entry.rowLabel)
+                .font(.system(size: size, weight: .semibold, design: .rounded))
+                .foregroundStyle(.primary)
+                .lineLimit(1)
+                .minimumScaleFactor(0.6)
+            Text("\(Int(percent.rounded()))%")
+                .font(.system(size: size, weight: .bold, design: .rounded).monospacedDigit())
+                .foregroundStyle(color)
         }
-        .help(helpText(for: run))
-    }
-
-    private func brandDot(_ entry: MiniEntry) -> some View {
-        Circle()
-            .fill(providerAccent(for: entry.tool))
-            .frame(width: 6, height: 6)
-    }
-
-    private func number(_ percent: Double, color: Color, size: CGFloat) -> some View {
-        Text("\(Int(percent.rounded()))")
-            .font(.system(size: size, weight: .bold, design: .rounded).monospacedDigit())
-            .foregroundStyle(color)
-    }
-
-    private func helpText(for run: [MiniEntry]) -> String {
-        let mode = settingsStore.displayMode
-        let lines = run.map { entry in
-            "\(entry.rowLabel): \(Int(entryPercent(entry, mode: mode).rounded()))%"
-        }
-        return "\(run[0].subProviderDisplayName) — \(lines.joined(separator: " · "))"
+        .frame(width: MiniStripMetrics.chipWidth(density), alignment: .leading)
+        .help("\(entry.subProviderDisplayName) — \(entry.rowLabel): \(Int(percent.rounded()))%")
     }
 }
 
@@ -479,7 +445,7 @@ struct MiniStripLayout: View {
 /// A fixed grid, one tile per bucket: big number, thin bar, and a severity
 /// stripe on the leading edge.
 enum MiniTileMetrics {
-    static let tileWidth: CGFloat = 92
+    static let tileWidth: CGFloat = 106
     static let tileHeight: CGFloat = 56
     static let spacing: CGFloat = 7
     static let columns = 4
@@ -544,15 +510,15 @@ struct MiniTileLayout: View {
                     .frame(width: 3)
                     .padding(.vertical, 5)
                 VStack(alignment: .leading, spacing: 1) {
-                    HStack(spacing: 3) {
-                        Text(shortCompany(entry.tool))
-                            .font(.system(size: 7.5, weight: .bold, design: .rounded))
-                            .foregroundStyle(providerAccent(for: entry.tool))
+                    HStack(spacing: 4) {
+                        Circle()
+                            .fill(providerAccent(for: entry.tool))
+                            .frame(width: 5, height: 5)
                         Text(entry.rowLabel)
                             .font(.system(size: 8.5, weight: .medium, design: .rounded))
                             .foregroundStyle(.secondary)
                             .lineLimit(1)
-                            .minimumScaleFactor(0.65)
+                            .minimumScaleFactor(0.6)
                     }
                     Text("\(Int(percent.rounded()))%")
                         .font(.system(size: 16, weight: .bold, design: .rounded).monospacedDigit())
@@ -605,16 +571,19 @@ struct MiniFocusLayout: View {
 
     @ViewBuilder
     private func content(now: Date) -> some View {
-        let pages = MiniEntry.companyGroups(entries)
+        // One page per selected bucket, in the window's own order — Focus
+        // shows exactly the quotas the user picked, not a per-company
+        // "most critical" of its own choosing.
+        let pages = entries
         if pages.isEmpty {
             MiniEmptyHint()
         } else {
             let index = min(pageIndex, pages.count - 1)
-            let page = pages[index]
+            let headline = pages[index]
+            let page = entries.filter {
+                $0.tool == headline.tool && $0.subProviderName == headline.subProviderName
+            }
             let mode = settingsStore.displayMode
-            // The headline is the page's most critical bucket, so the big
-            // number is always the one that needs attention.
-            let headline = page.min { remainingPercent($0) < remainingPercent($1) } ?? page[0]
             let percent = entryPercent(headline, mode: mode)
             let color = entryColor(headline, mode: mode)
             let forecast = miniQuotaForecast(
@@ -629,7 +598,7 @@ struct MiniFocusLayout: View {
                     Circle()
                         .fill(providerAccent(for: headline.tool))
                         .frame(width: 5, height: 5)
-                    Text(page[0].companyName.uppercased())
+                    Text(headline.companyName.uppercased())
                         .font(.system(size: 10, weight: .semibold, design: .rounded))
                         .foregroundStyle(.primary.opacity(0.86))
                 }
@@ -659,16 +628,22 @@ struct MiniFocusLayout: View {
                     .foregroundStyle(miniForecastColor(forecast))
                     .lineLimit(1)
                 HStack(spacing: 6) {
-                    ForEach(0..<pages.count, id: \.self) { dot in
-                        Circle()
-                            .fill(
-                                dot == index
-                                    ? providerAccent(for: pages[dot][0].tool)
-                                    : Color.primary.opacity(0.18)
-                            )
-                            .frame(width: 5, height: 5)
-                            .contentShape(Circle().inset(by: -4))
-                            .onTapGesture { pageIndex = dot }
+                    if pages.count <= 8 {
+                        ForEach(0..<pages.count, id: \.self) { dot in
+                            Circle()
+                                .fill(
+                                    dot == index
+                                        ? providerAccent(for: pages[dot].tool)
+                                        : Color.primary.opacity(0.18)
+                                )
+                                .frame(width: 5, height: 5)
+                                .contentShape(Circle().inset(by: -4))
+                                .onTapGesture { pageIndex = dot }
+                        }
+                    } else {
+                        Text("\(index + 1)/\(pages.count)")
+                            .font(.system(size: 8.5, weight: .semibold, design: .rounded).monospacedDigit())
+                            .foregroundStyle(.secondary)
                     }
                     if pages.count > 1 {
                         Button {
@@ -719,17 +694,17 @@ struct MiniFocusLayout: View {
 
 // MARK: - Rail
 
-/// The next seven days as a horizontal timeline: every bucket sits at its
-/// reset time, so "what refills next" is the leftmost thing on screen.
+/// The next seven days as the same refill lane the popover's Upcoming Resets
+/// card draws: each selected bucket that refills inside the horizon is a slim
+/// column standing on a time axis — height says how much comes back, colour
+/// says how tight the bucket is right now — with the next few refills listed
+/// underneath in full words.
 enum MiniRailMetrics {
-    static let size = CGSize(width: 584, height: 184)
-    static let railWidth: CGFloat = 520
+    static let size = CGSize(width: 584, height: 196)
+    static let railWidth: CGFloat = 536
     static let horizonDays: Double = 7
-    static let ringSize: CGFloat = 28
-    static let laneLift: CGFloat = 34
-    /// Minimum x distance between two bubbles in the same lane; closer ones
-    /// are pushed right into a staircase.
-    static let crowdingThreshold: CGFloat = 46
+    static let laneHeight: CGFloat = 64
+    static let legendRows = 4
 }
 
 struct MiniRailLayout: View {
@@ -738,140 +713,94 @@ struct MiniRailLayout: View {
     @EnvironmentObject var settingsStore: SettingsStore
 
     var body: some View {
-        TimelineView(.periodic(from: .now, by: 30)) { context in
+        TimelineView(.periodic(from: .now, by: 60)) { context in
             content(now: context.date)
         }
         .frame(width: MiniRailMetrics.size.width, height: MiniRailMetrics.size.height)
     }
 
-    private struct Placed: Identifiable {
-        let entry: MiniEntry
-        let x: CGFloat
-        let lane: Int
-        var id: String { entry.id }
+    /// The window's selected buckets as refill events, resolved labels and
+    /// all. The tool raw value stands in for the account id — the mini layer
+    /// folds accounts away, and the pair (tool, bucket) is unique here.
+    private func events(now: Date) -> [UpcomingResetEvent] {
+        entries.compactMap { entry -> UpcomingResetEvent? in
+            guard let resetAt = entry.bucket.resetAt,
+                  resetAt > now,
+                  resetAt.timeIntervalSince(now) <= MiniRailMetrics.horizonDays * 86_400,
+                  entry.bucket.usedPercent >= 1
+            else { return nil }
+            return UpcomingResetEvent(
+                tool: entry.tool,
+                accountId: entry.tool.rawValue,
+                accountLabel: nil,
+                subProviderName: entry.subProviderDisplayName,
+                groupTitle: entry.groupLabel,
+                bucketId: entry.bucket.id,
+                bucketTitle: entry.customLabel ?? entry.bucket.title,
+                remainingPercent: max(0, 100 - entry.bucket.usedPercent),
+                gainPercent: entry.bucket.usedPercent,
+                resetAt: resetAt
+            )
+        }
+        .sorted { $0.resetAt < $1.resetAt }
     }
 
     @ViewBuilder
     private func content(now: Date) -> some View {
-        let placed = place(now: now)
-        if placed.isEmpty {
-            MiniEmptyHint()
-        } else {
-            let mode = settingsStore.displayMode
-            let railWidth = MiniRailMetrics.railWidth
-            let axisY: CGFloat = 128
-            VStack(spacing: 0) {
-                Text("QUOTA RESETS · NEXT \(Int(MiniRailMetrics.horizonDays)) DAYS")
-                    .font(.system(size: 8.5, weight: .semibold, design: .rounded))
+        let events = events(now: now)
+        VStack(spacing: 4) {
+            Text("QUOTA RESETS · NEXT \(Int(MiniRailMetrics.horizonDays)) DAYS")
+                .font(.system(size: 8.5, weight: .semibold, design: .rounded))
+                .foregroundStyle(.secondary)
+                .tracking(1.6)
+                .padding(.top, 12)
+            if events.isEmpty {
+                Text("Nothing selected refills in the next seven days.")
+                    .font(.system(size: 10, weight: .medium, design: .rounded))
                     .foregroundStyle(.secondary)
-                    .tracking(1.6)
-                    .padding(.top, 14)
-                ZStack(alignment: .topLeading) {
-                    // Axis + day ticks.
-                    Rectangle()
-                        .fill(Color.primary.opacity(0.14))
-                        .frame(width: railWidth, height: 1)
-                        .offset(y: axisY)
-                    ForEach(0...Int(MiniRailMetrics.horizonDays), id: \.self) { day in
-                        let x = railWidth * CGFloat(day) / MiniRailMetrics.horizonDays
-                        Rectangle()
-                            .fill(Color.primary.opacity(0.18))
-                            .frame(width: 1, height: 7)
-                            .offset(x: x, y: axisY - 6)
-                        Text(day == 0 ? "now" : "+\(day)d")
-                            .font(.system(size: 7.5, design: .rounded).monospacedDigit())
-                            .foregroundStyle(.tertiary)
-                            .frame(width: 30)
-                            .offset(x: x - 15, y: axisY + 5)
-                    }
-                    ForEach(placed) { item in
-                        bubble(item, mode: mode, axisY: axisY)
+                    .frame(maxHeight: .infinity)
+            } else {
+                ResetLaneView(
+                    events: events,
+                    now: now,
+                    horizonDays: MiniRailMetrics.horizonDays,
+                    laneHeight: MiniRailMetrics.laneHeight
+                )
+                .frame(width: MiniRailMetrics.railWidth)
+                VStack(spacing: 0) {
+                    ForEach(Array(events.prefix(MiniRailMetrics.legendRows))) { event in
+                        legendRow(event, now: now)
                     }
                 }
-                .frame(width: railWidth, height: MiniRailMetrics.size.height - 32, alignment: .topLeading)
+                .frame(width: MiniRailMetrics.railWidth)
+                Spacer(minLength: 0)
             }
-            .frame(maxWidth: .infinity)
         }
+        .frame(maxWidth: .infinity)
+        .padding(.bottom, 8)
     }
 
-    private func bubble(_ item: Placed, mode: DisplayMode, axisY: CGFloat) -> some View {
-        let percent = entryPercent(item.entry, mode: mode)
-        let color = entryColor(item.entry, mode: mode)
-        let ringTop: CGFloat = 22 + (item.lane == 1 ? MiniRailMetrics.laneLift : 0)
-        let ring = MiniRailMetrics.ringSize
-        return ZStack(alignment: .topLeading) {
-            // Stem from ring bottom to axis.
-            Rectangle()
-                .fill(Color.primary.opacity(0.12))
-                .frame(width: 1, height: max(0, axisY - ringTop - ring))
-                .offset(x: item.x, y: ringTop + ring)
-            RingGauge(
-                percent: percent,
-                expected: nil,
-                color: color,
-                size: ring,
-                lineWidth: 3.5
-            ) {
-                Text("\(Int(percent.rounded()))")
-                    .font(.system(size: 8.5, weight: .bold, design: .rounded).monospacedDigit())
-                    .foregroundStyle(color)
-            }
-            .offset(x: item.x - ring / 2, y: ringTop)
-            Text(bubbleLabel(item.entry))
-                .font(.system(size: 7.5, weight: .medium, design: .rounded))
-                .foregroundStyle(.secondary)
+    private func legendRow(_ event: UpcomingResetEvent, now: Date) -> some View {
+        HStack(spacing: 7) {
+            Circle()
+                .fill(Theme.providerAccent(for: event.tool))
+                .frame(width: 5, height: 5)
+            Text(event.label)
+                .font(.system(size: 9.5, weight: .medium, design: .rounded))
+                .foregroundStyle(.primary.opacity(0.88))
                 .lineLimit(1)
                 .minimumScaleFactor(0.7)
-                .frame(width: 60, alignment: .center)
-                .offset(x: item.x - 30, y: ringTop - 11)
+            Spacer(minLength: 6)
+            Text("+\(Int(event.gainPercent.rounded()))%")
+                .font(.system(size: 9.5, weight: .bold, design: .rounded).monospacedDigit())
+                .foregroundStyle(Theme.barColor(percent: event.remainingPercent, mode: .remaining))
+            Text(ResetCountdownFormatter.string(from: event.resetAt, now: now) ?? "—")
+                .font(.system(size: 9, design: .rounded).monospacedDigit())
+                .foregroundStyle(.secondary)
+                .frame(width: 46, alignment: .trailing)
         }
-        .help("\(providerTitle(for: item.entry.tool)) · \(item.entry.rowLabel) — resets \(item.entry.bucket.resetAt.map { ResetCountdownFormatter.string(from: $0, now: Date()) ?? "—" } ?? "—")")
-    }
-
-    private func bubbleLabel(_ entry: MiniEntry) -> String {
-        "\(shortCompany(entry.tool)) \(entry.rowLabel)"
-    }
-
-    /// Sort by reset time, then de-clutter: alternate between the two lanes
-    /// and push a bubble right until its lane has room, so a cluster of
-    /// same-hour resets fans out into a readable staircase instead of a pile.
-    private func place(now: Date) -> [Placed] {
-        let horizon = MiniRailMetrics.horizonDays * 86_400
-        let sorted = entries
-            .compactMap { entry -> (MiniEntry, TimeInterval)? in
-                guard let reset = entry.bucket.resetAt else { return nil }
-                let interval = reset.timeIntervalSince(now)
-                // Dropped, not clamped, outside the window: pinning a
-                // monthly reset to the +7d tick would present it as due this
-                // week.
-                guard interval > -3_600, interval <= horizon else { return nil }
-                return (entry, max(0, interval))
-            }
-            .sorted { $0.1 < $1.1 }
-        var placed: [Placed] = []
-        var lastXByLane: [CGFloat] = [-.greatestFiniteMagnitude, -.greatestFiniteMagnitude]
-        for (index, item) in sorted.enumerated() {
-            let (entry, interval) = item
-            let fraction = min(1, interval / horizon)
-            let rawX = MiniRailMetrics.railWidth * CGFloat(fraction)
-            // Prefer the lane whose last bubble is farther left; break ties by
-            // alternating so a dense cluster zig-zags.
-            let lane: Int
-            if lastXByLane[0] + MiniRailMetrics.crowdingThreshold <= rawX {
-                lane = 0
-            } else if lastXByLane[1] + MiniRailMetrics.crowdingThreshold <= rawX {
-                lane = 1
-            } else {
-                lane = index % 2
-            }
-            let x = min(
-                MiniRailMetrics.railWidth,
-                max(rawX, lastXByLane[lane] + MiniRailMetrics.crowdingThreshold)
-            )
-            placed.append(Placed(entry: entry, x: x, lane: lane))
-            lastXByLane[lane] = x
-        }
-        return placed
+        .frame(height: 17)
+        .help(event.label)
     }
 }
 

--- a/Sources/VibeBarApp/Views/MiniWindowGroupLabelCatalog.swift
+++ b/Sources/VibeBarApp/Views/MiniWindowGroupLabelCatalog.swift
@@ -9,16 +9,16 @@ struct MiniWindowGroupLabelOption: Identifiable, Hashable {
 
 enum MiniWindowGroupLabelCatalog {
     static let all: [MiniWindowGroupLabelOption] = [
-        .init(id: "codex.all-models", title: "CHATGPT · All Models", defaultLabel: "All Models"),
+        .init(id: "codex.all-models", title: "CHATGPT · All Models", defaultLabel: "All"),
         .init(id: "codex.spark", title: "CODEX · Spark", defaultLabel: "Spark"),
-        .init(id: "claude.all-models", title: "CLAUDE · All Models", defaultLabel: "All Models"),
+        .init(id: "claude.all-models", title: "CLAUDE · All Models", defaultLabel: "All"),
         .init(id: "claude.sonnet", title: "CLAUDE · Sonnet", defaultLabel: "Sonnet"),
         .init(id: "claude.design", title: "CLAUDE · Design", defaultLabel: "Design"),
         .init(id: "claude.routine", title: "CLAUDE · Routine", defaultLabel: "Routine"),
         .init(id: "claude.opus", title: "CLAUDE · Opus", defaultLabel: "Opus"),
         .init(id: "claude.fable", title: "CLAUDE · Fable", defaultLabel: "Fable"),
         .init(id: "claude.oauth", title: "CLAUDE · OAuth", defaultLabel: "OAuth"),
-        .init(id: "gemini.all-models", title: "GEMINI WEB · All Models", defaultLabel: "All Models"),
+        .init(id: "gemini.all-models", title: "GEMINI WEB · All Models", defaultLabel: "All"),
         .init(id: "gemini.pro", title: "GEMINI · Pro", defaultLabel: "Pro"),
         .init(id: "gemini.flash", title: "GEMINI · Flash", defaultLabel: "Flash"),
         .init(id: "gemini.flash-lite", title: "GEMINI · Flash Lite", defaultLabel: "Flash Lite"),
@@ -26,13 +26,34 @@ enum MiniWindowGroupLabelCatalog {
         .init(id: "antigravity.claude-gpt-models", title: "ANTIGRAVITY · Claude + GPT Models", defaultLabel: "Claude + GPT"),
         // Stable persisted key (custom labels are stored under it); the
         // wording is the L3 group name from AGENTS.md § 7.1.
-        .init(id: "grok.all-models", title: "GROK · Weekly Credits", defaultLabel: "Weekly Credits"),
-        .init(id: "cursor.models", title: "CURSOR · Cursor Models", defaultLabel: "Cursor Models"),
-        .init(id: "cursor.other-models", title: "CURSOR · Other Models", defaultLabel: "Other Models")
+        .init(id: "grok.all-models", title: "GROK · Weekly Credits", defaultLabel: "All"),
+        .init(id: "cursor.models", title: "CURSOR · Cursor Models", defaultLabel: "Cursor"),
+        .init(id: "cursor.other-models", title: "CURSOR · Other Models", defaultLabel: "Other")
     ]
 
     static func defaultLabel(for id: String) -> String? {
         all.first { $0.id == id }?.defaultLabel
+    }
+
+    /// The L3 group a field belongs to on the quota axis, or nil for a bucket
+    /// that sits directly under its SubProvider (Grok Bot's single Weekly).
+    /// Shared by the settings tree and every mini layout, so a bucket is
+    /// grouped identically wherever it appears.
+    static func namingGroupKey(for option: MenuBarFieldOption) -> String? {
+        if option.tool == .cursor {
+            if option.bucketId == "grok_bot_weekly" { return nil }
+            return groupKey(tool: .cursor, bucketId: option.bucketId)
+        }
+        if MiniQuotaWindowView.isBranchStyleField(option) {
+            return groupKey(tool: option.tool, bucketId: option.bucketId)
+        }
+        switch option.tool {
+        case .codex: return "codex.all-models"
+        case .claude: return "claude.all-models"
+        case .gemini: return "gemini.all-models"
+        case .grok: return "grok.all-models"
+        default: return nil
+        }
     }
 
     static func groupKey(tool: ToolType, bucketId: String) -> String {

--- a/Sources/VibeBarApp/Views/MiniWindowsSettingsSection.swift
+++ b/Sources/VibeBarApp/Views/MiniWindowsSettingsSection.swift
@@ -590,8 +590,8 @@ struct MiniWindowsSettingsSection: View {
         let key = MiniWindowGroupLabelCatalog.subProviderKey(tool: group.tool, name: group.subProviderName)
         return HStack(spacing: 8) {
             Text(subProviderDisplayName(group).uppercased())
-                .font(.system(size: 8.5, weight: .semibold, design: .rounded))
-                .foregroundStyle(.tertiary)
+                .font(.system(size: 9.5, weight: .bold, design: .rounded))
+                .foregroundStyle(.secondary)
                 .tracking(1.0)
             Spacer(minLength: 8)
             nameField(NamingRow(
@@ -599,7 +599,7 @@ struct MiniWindowsSettingsSection: View {
                 title: group.subProviderName, defaultLabel: group.subProviderName
             ))
         }
-        .padding(.leading, 16)
+        .padding(.leading, 14)
     }
 
     private func groupHeader(groupKey: String, run: GroupRun) -> some View {
@@ -611,7 +611,7 @@ struct MiniWindowsSettingsSection: View {
             .resolvedGroupLabel(config: selectedWindow, key: groupKey) ?? defaultLabel
         return HStack(spacing: 8) {
             Text(resolved.uppercased())
-                .font(.system(size: 8, weight: .semibold, design: .rounded))
+                .font(.system(size: 8, weight: .medium, design: .rounded))
                 .foregroundStyle(.tertiary)
                 .tracking(0.8)
             Spacer(minLength: 8)
@@ -620,7 +620,7 @@ struct MiniWindowsSettingsSection: View {
                 title: defaultLabel, defaultLabel: defaultLabel
             ))
         }
-        .padding(.leading, 24)
+        .padding(.leading, 26)
     }
 
     private func nameField(_ row: NamingRow) -> some View {
@@ -811,23 +811,8 @@ struct MiniWindowsSettingsSection: View {
         var id: String { key }
     }
 
-    /// The L3 group a field's gauge renders under, or nil for a bucket that
-    /// sits directly under its SubProvider (Grok Bot's single Weekly).
     private static func namingGroupKey(for option: MenuBarFieldOption) -> String? {
-        if option.tool == .cursor {
-            if option.bucketId == "grok_bot_weekly" { return nil }
-            return MiniWindowGroupLabelCatalog.groupKey(tool: .cursor, bucketId: option.bucketId)
-        }
-        if MiniQuotaWindowView.isBranchStyleField(option) {
-            return MiniWindowGroupLabelCatalog.groupKey(tool: option.tool, bucketId: option.bucketId)
-        }
-        switch option.tool {
-        case .codex: return "codex.all-models"
-        case .claude: return "claude.all-models"
-        case .gemini: return "gemini.all-models"
-        case .grok: return "grok.all-models"
-        default: return nil
-        }
+        MiniWindowGroupLabelCatalog.namingGroupKey(for: option)
     }
 
     private func namingScopeButton(_ scope: NamingScope, label: String) -> some View {

--- a/Sources/VibeBarCore/Models/AppSettings.swift
+++ b/Sources/VibeBarCore/Models/AppSettings.swift
@@ -1182,9 +1182,9 @@ public enum MiniStripDensity: String, Codable, CaseIterable, Identifiable, Senda
 
     public var detail: String {
         switch self {
-        case .roomy:   return "One line, full labels beside each number."
+        case .roomy:   return "The menu bar's single-line style: every bucket, full label beside its number."
         case .twoLine: return "Menu-bar style: buckets pair into stacked columns, label beside each number."
-        case .narrow:  return "Dot and number only; labels on hover."
+        case .narrow:  return "The menu bar's compact style: the same cells at the small size."
         }
     }
 }
@@ -1415,10 +1415,10 @@ public enum MiniWindowDisplayMode: String, Codable, CaseIterable, Identifiable, 
         case .regular: return "Ring gauges grouped company → SubProvider → quota group."
         case .compact: return "The same three tiers as vertical bars, sized for a corner."
         case .ledger:  return "One row per quota bucket — fixed width, grows downward."
-        case .strip:   return "One 40 pt line; each SubProvider shows its most critical bucket."
+        case .strip:   return "A slim line mirroring the menu bar's styles — one cell per bucket."
         case .tile:    return "A grid of tiles with a big number and a severity stripe."
-        case .focus:   return "One company at a time, large — click to cycle."
-        case .rail:    return "The next seven days as a timeline of quota resets."
+        case .focus:   return "One selected bucket at a time, large — click to cycle in your order."
+        case .rail:    return "The next seven days as a refill lane with the coming resets listed."
         }
     }
 


### PR DESCRIPTION
First of three PRs for AQ's mini-window/reset feedback round. This one covers the mini layout modes:

1. **Group-qualified labels everywhere**: `MiniEntry` now resolves an L3 group for every bucket through a shared `MiniWindowGroupLabelCatalog.namingGroupKey` (the same key the settings tree uses), so the ledger/strip/tile/focus label reads "All · Weekly" / "Spark · 5 Hours" instead of four indistinguishable "Weekly" rows.
2. **Default names follow the regular layout's branch names** (AQ's reference): All / Spark / Cursor / Other / Claude + GPT…, and the last reachable fallback abbreviations in `MiniBranchCell` are spelled out ("C+G", "Lite", "G Flash", "G Pro", "Med").
3. **Strip = the menu bar, in all three densities**: roomy mirrors the single-line style, narrow mirrors compact, two-line already mirrored two rows. One cell per selected bucket in window order; the "worst bucket per SubProvider" chip summarization is gone.
4. **Tiles**: brand dot + full group-qualified label; the invented company codes (GPT/CLD/GEM/AG/GRK/CUR) are deleted outright.
5. **Focus follows the selection**: one page per selected bucket in the window's order (dots ≤8, "n/m" beyond), context line shows the same SubProvider's other selected buckets.
6. **Rail rebuilt as the refill lane**: reuses `ResetLaneView` (the popover Upcoming Resets aesthetic — columns on a time axis, height = refill amount, color = how tight the bucket is) plus a legend of the next four refills in full words. The ring-bubble staircase is gone.
7. **Settings tree hierarchy**: SubProvider headers are now visually distinct from group headers (size/weight/indent), fixing "Grok Bot reads like a sibling of the Cursor group".

## Validation
- `swift build` ✓, `swift test` ✓ (1679 tests)
- `./Scripts/build_app.sh release` ✓, empty entitlements ✓, deep signature ✓
- No-pixel demo smoke of the mini surface ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)