### PR TITLE
Align the menu bar editor with the unified tree and add style scopes

### DIFF
--- a/Sources/VibeBarApp/MiniQuotaWindowController.swift
+++ b/Sources/VibeBarApp/MiniQuotaWindowController.swift
@@ -619,7 +619,7 @@ final class MiniQuotaWindowController: NSObject, NSWindowDelegate {
         guard let environment else { return }
         var settings = environment.settingsStore.settings
         guard let index = settings.miniWindow.windows.firstIndex(where: { $0.id == configID }) else { return }
-        settings.miniWindow.windows[index].displayMode = settings.miniWindow.windows[index].displayMode.next
+        settings.miniWindow.windows[index].displayMode = settings.miniWindow.windows[index].nextDisplayMode()
         environment.settingsStore.settings = settings
         if let state = panels[configID] {
             applyStableContentSize(

--- a/Sources/VibeBarApp/StatusItemController.swift
+++ b/Sources/VibeBarApp/StatusItemController.swift
@@ -775,7 +775,7 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
         var displayed = 0
         for fieldId in itemSettings.selectedFieldIds {
             guard
-                let field = MenuBarFieldCatalog.field(id: fieldId),
+                let field = MenuBarFieldCatalog.field(id: fieldId, registry: environment.quotaService.fieldRegistry),
                 let bucket = environment.quota(for: field.tool)?.bucket(id: field.bucketId)
             else { continue }
             if displayed > 0 {
@@ -825,7 +825,7 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
 
         let entries = itemSettings.selectedFieldIds.compactMap { fieldId -> NSAttributedString? in
             guard
-                let field = MenuBarFieldCatalog.field(id: fieldId),
+                let field = MenuBarFieldCatalog.field(id: fieldId, registry: environment.quotaService.fieldRegistry),
                 let bucket = environment.quota(for: field.tool)?.bucket(id: field.bucketId)
             else { return nil }
             let percent = bucket.displayPercent(settings.displayMode, tool: field.tool)
@@ -896,7 +896,7 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
     private func displayedEntries(for itemSettings: MenuBarItemSettings, settings: AppSettings) -> [NSAttributedString] {
         itemSettings.selectedFieldIds.compactMap { fieldId in
             guard
-                let field = MenuBarFieldCatalog.field(id: fieldId),
+                let field = MenuBarFieldCatalog.field(id: fieldId, registry: environment.quotaService.fieldRegistry),
                 let bucket = environment.quota(for: field.tool)?.bucket(id: field.bucketId)
             else { return nil }
             let percent = bucket.displayPercent(settings.displayMode, tool: field.tool)

--- a/Sources/VibeBarApp/Views/MenuBarFieldsEditor.swift
+++ b/Sources/VibeBarApp/Views/MenuBarFieldsEditor.swift
@@ -1,0 +1,339 @@
+import SwiftUI
+import VibeBarCore
+
+/// The menu bar's field editor, aligned with the mini windows' unified tree:
+/// what's shown is one ordered list grouped by the quota hierarchy with
+/// inline renaming, what isn't is a candidate list underneath — including
+/// runtime-discovered buckets, which the old static checklist never offered
+/// the menu bar at all.
+struct MenuBarFieldsEditor: View {
+    let kind: MenuBarItemKind
+
+    @EnvironmentObject private var environment: AppEnvironment
+    @EnvironmentObject private var settingsStore: SettingsStore
+    @EnvironmentObject private var quotaService: QuotaService
+
+    var body: some View {
+        let merged = Dictionary(
+            MenuBarFieldCatalog.mergedFields(registry: quotaService.fieldRegistry).map { ($0.id, $0) },
+            uniquingKeysWith: { first, _ in first }
+        )
+        let live = liveFieldIds(merged: merged)
+        let item = settingsStore.settings.menuBarItem(kind)
+        let shown = item.selectedFieldIds.compactMap { merged[$0] }
+        VStack(alignment: .leading, spacing: 10) {
+            Text("Shown, in this order — first renders leftmost. Rename any field for the menu bar only; empty inherits the default.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+            if shown.isEmpty {
+                Text("Nothing selected — tick a bucket below.")
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+            } else {
+                shownList(shown, live: live)
+            }
+            Text("Not in the menu bar — tick a bucket to add it. Discovered buckets appear here automatically; a dimmed row is remembered but absent from the current response, and ✕ dismisses it until the provider returns it.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+            candidateList(merged: merged, live: live, selected: Set(item.selectedFieldIds))
+        }
+    }
+
+    private func liveFieldIds(merged: [String: MenuBarFieldOption]) -> Set<String> {
+        var quotas: [ToolType: AccountQuota] = [:]
+        for tool in ToolType.dedicatedCardProviders {
+            if let quota = environment.quota(for: tool) { quotas[tool] = quota }
+        }
+        var live: Set<String> = []
+        for option in merged.values
+        where quotas[option.tool]?.bucket(id: option.bucketId) != nil {
+            live.insert(option.id)
+        }
+        return live
+    }
+
+    // MARK: - Shown
+
+    private struct ShownRun: Identifiable {
+        let companyName: String?
+        let tool: ToolType
+        let subProviderName: String
+        var options: [MenuBarFieldOption]
+        let firstIndex: Int
+        var id: String { "\(firstIndex)" }
+    }
+
+    private func runs(_ shown: [MenuBarFieldOption]) -> [ShownRun] {
+        var runs: [ShownRun] = []
+        var index = 0
+        for option in shown {
+            let sub = option.tool.quotaSubProviderName(bucketID: option.bucketId)
+            let vendor = option.tool.vendorName
+            if var last = runs.last, last.tool == option.tool, last.subProviderName == sub {
+                last.options.append(option)
+                runs[runs.count - 1] = last
+            } else {
+                let previousVendor = runs.last?.tool.vendorName
+                runs.append(ShownRun(
+                    companyName: vendor == previousVendor ? nil : vendor,
+                    tool: option.tool,
+                    subProviderName: sub,
+                    options: [option],
+                    firstIndex: index
+                ))
+            }
+            index += 1
+        }
+        return runs
+    }
+
+    private func shownList(_ shown: [MenuBarFieldOption], live: Set<String>) -> some View {
+        VStack(alignment: .leading, spacing: 3) {
+            ForEach(runs(shown)) { run in
+                if let company = run.companyName {
+                    HStack(spacing: 6) {
+                        ToolBrandIconView(tool: run.tool, size: 12)
+                            .opacity(0.85)
+                        Text(company)
+                            .font(.caption2)
+                            .fontWeight(.semibold)
+                            .foregroundStyle(.secondary)
+                            .textCase(.uppercase)
+                            .tracking(0.4)
+                    }
+                    .padding(.top, run.firstIndex == 0 ? 0 : 5)
+                }
+                Text(run.subProviderName.uppercased())
+                    .font(.system(size: 9, weight: .bold, design: .rounded))
+                    .foregroundStyle(.secondary)
+                    .tracking(1.0)
+                    .padding(.leading, 14)
+                ForEach(Array(run.options.enumerated()), id: \.element.id) { offset, option in
+                    shownRow(option, index: run.firstIndex + offset, count: shown.count, live: live)
+                }
+            }
+        }
+    }
+
+    private func shownRow(_ option: MenuBarFieldOption, index: Int, count: Int, live: Set<String>) -> some View {
+        let isLive = live.contains(option.id)
+        return HStack(spacing: 8) {
+            Circle()
+                .fill(Theme.providerAccent(for: option.tool))
+                .frame(width: 6, height: 6)
+            Text(option.title)
+                .font(.system(size: 11.5, weight: .medium))
+                .lineLimit(1)
+                .minimumScaleFactor(0.75)
+            if !isLive {
+                Text("offline")
+                    .font(.system(size: 8.5, weight: .semibold, design: .rounded))
+                    .foregroundStyle(.tertiary)
+            }
+            Spacer(minLength: 6)
+            DebouncedSettingsTextField(
+                prompt: option.defaultLabel,
+                value: labelBinding(option)
+            )
+            .frame(width: 108)
+            Button {
+                move(option.id, by: -1)
+            } label: {
+                Image(systemName: "chevron.up")
+                    .font(.system(size: 8, weight: .semibold))
+                    .frame(width: 16, height: 16)
+            }
+            .buttonStyle(.vibeBar)
+            .disabled(index == 0)
+            Button {
+                move(option.id, by: 1)
+            } label: {
+                Image(systemName: "chevron.down")
+                    .font(.system(size: 8, weight: .semibold))
+                    .frame(width: 16, height: 16)
+            }
+            .buttonStyle(.vibeBar)
+            .disabled(index >= count - 1)
+            Button {
+                setSelected(option.id, false)
+            } label: {
+                Image(systemName: "xmark")
+                    .font(.system(size: 8, weight: .semibold))
+                    .frame(width: 16, height: 16)
+            }
+            .buttonStyle(.vibeBar)
+            .help("Remove from the menu bar")
+        }
+        .padding(.horizontal, 8)
+        .padding(.leading, 8)
+        .frame(height: 26)
+        .background(
+            RoundedRectangle(cornerRadius: 6, style: .continuous)
+                .fill(Color.primary.opacity(isLive ? 0.05 : 0.03))
+                .padding(.leading, 8)
+        )
+        .opacity(isLive ? 1 : 0.6)
+        .help(option.id)
+    }
+
+    // MARK: - Candidates
+
+    private func candidateList(
+        merged: [String: MenuBarFieldOption],
+        live: Set<String>,
+        selected: Set<String>
+    ) -> some View {
+        let hidden = settingsStore.settings.miniWindow.hiddenStaleFieldIds
+        let registry = quotaService.fieldRegistry
+        let discoveredIds = Set(registry.fields.map(\.id))
+        var sections: [(section: MiniWindowFieldProviderSection, options: [MenuBarFieldOption])] = []
+        for section in MiniWindowFieldProviderSection.all {
+            var options = section.fields.filter { !selected.contains($0.id) }
+            for discovered in registry.fields
+            where discovered.tool == section.tool
+                && MenuBarFieldCatalog.field(id: discovered.id) == nil
+                && !selected.contains(discovered.id)
+                && sections.allSatisfy({ $0.section.tool != section.tool }) {
+                options.append(MenuBarFieldCatalog.option(for: discovered))
+            }
+            options.removeAll { option in
+                !discoveredIds.contains(option.id)
+                    && hidden.contains(option.id)
+                    && !live.contains(option.id)
+            }
+            guard !options.isEmpty else { continue }
+            sections.append((section, options))
+        }
+        return VStack(alignment: .leading, spacing: 12) {
+            if sections.isEmpty {
+                Text("Every known bucket is already in the menu bar.")
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+            }
+            ForEach(Array(sections.enumerated()), id: \.offset) { _, pair in
+                VStack(alignment: .leading, spacing: 6) {
+                    HStack(spacing: 6) {
+                        ToolBrandIconView(tool: pair.section.tool, size: 13)
+                            .opacity(0.85)
+                        Text(pair.section.title)
+                            .font(.caption)
+                            .fontWeight(.semibold)
+                            .foregroundStyle(.secondary)
+                            .textCase(.uppercase)
+                            .tracking(0.4)
+                    }
+                    ForEach(pair.options) { option in
+                        candidateRow(option, live: live, isDiscovered: discoveredIds.contains(option.id))
+                    }
+                }
+            }
+        }
+    }
+
+    private func candidateRow(_ option: MenuBarFieldOption, live: Set<String>, isDiscovered: Bool) -> some View {
+        let isLive = live.contains(option.id)
+        return HStack(spacing: 10) {
+            Toggle(isOn: Binding(
+                get: { settingsStore.settings.menuBarItem(kind).selectedFieldIds.contains(option.id) },
+                set: { setSelected(option.id, $0) }
+            )) {
+                Text(option.title)
+                    .font(.system(size: 12, weight: .medium))
+                    .lineLimit(2)
+            }
+            .help(option.id)
+            Spacer(minLength: 8)
+            if !isLive {
+                Text("not in current response")
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+                    .lineLimit(1)
+                Button {
+                    if isDiscovered {
+                        forgetDiscovered(option.id)
+                    } else {
+                        var settings = settingsStore.settings
+                        settings.miniWindow.hiddenStaleFieldIds.insert(option.id)
+                        settingsStore.settings = settings
+                    }
+                } label: {
+                    Image(systemName: "xmark.circle")
+                        .font(.system(size: 10, weight: .semibold))
+                        .frame(width: 18, height: 18)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.vibeBar)
+                .help(
+                    isDiscovered
+                        ? "Forget this discovered bucket — drops it everywhere it was selected."
+                        : "Dismiss this built-in bucket while the provider is not returning it."
+                )
+            }
+        }
+        .opacity(isLive ? 1 : 0.55)
+    }
+
+    // MARK: - Mutations
+
+    private func updateItem(_ mutate: (inout MenuBarItemSettings) -> Void) {
+        var item = settingsStore.settings.menuBarItem(kind)
+        mutate(&item)
+        settingsStore.settings.setMenuBarItem(item)
+    }
+
+    private func setSelected(_ fieldId: String, _ selected: Bool) {
+        updateItem { item in
+            if selected {
+                if !item.selectedFieldIds.contains(fieldId) {
+                    item.selectedFieldIds.append(fieldId)
+                }
+            } else {
+                item.selectedFieldIds.removeAll { $0 == fieldId }
+            }
+        }
+    }
+
+    private func move(_ fieldId: String, by offset: Int) {
+        updateItem { item in
+            guard let index = item.selectedFieldIds.firstIndex(of: fieldId) else { return }
+            let target = index + offset
+            guard item.selectedFieldIds.indices.contains(target) else { return }
+            item.selectedFieldIds.swapAt(index, target)
+        }
+    }
+
+    private func labelBinding(_ option: MenuBarFieldOption) -> Binding<String> {
+        Binding(
+            get: { settingsStore.settings.menuBarItem(kind).customLabels[option.id] ?? "" },
+            set: { value in
+                let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+                updateItem { item in
+                    if trimmed.isEmpty {
+                        item.customLabels.removeValue(forKey: option.id)
+                    } else {
+                        item.customLabels[option.id] = value
+                    }
+                }
+            }
+        )
+    }
+
+    private func forgetDiscovered(_ fieldId: String) {
+        quotaService.forgetDiscoveredField(id: fieldId)
+        var settings = settingsStore.settings
+        settings.miniWindow.customLabels.removeValue(forKey: fieldId)
+        for index in settings.miniWindow.windows.indices {
+            settings.miniWindow.windows[index].fieldIds.removeAll { $0 == fieldId }
+            settings.miniWindow.windows[index].customLabels.removeValue(forKey: fieldId)
+        }
+        for kind in MenuBarItemKind.allCases {
+            var item = settings.menuBarItem(kind)
+            item.selectedFieldIds.removeAll { $0 == fieldId }
+            item.customLabels.removeValue(forKey: fieldId)
+            settings.setMenuBarItem(item)
+        }
+        settingsStore.settings = settings
+    }
+}

--- a/Sources/VibeBarApp/Views/MiniWindowsSettingsSection.swift
+++ b/Sources/VibeBarApp/Views/MiniWindowsSettingsSection.swift
@@ -35,6 +35,9 @@ struct MiniWindowsSettingsSection: View {
     private enum NamingScope: Hashable {
         case shared
         case window
+        /// The selected window's *current display style* only — a tile can
+        /// carry a terse name while the ledger keeps the full one.
+        case style
     }
 
     private static let arrangeSpace = "vibebar.mini.arrange"
@@ -221,6 +224,12 @@ struct MiniWindowsSettingsSection: View {
                 .foregroundStyle(.secondary)
         }
 
+        Text("Double-click on the window cycles its style. Tap a style to include it — the badge is its turn in the cycle. Nothing selected means every style, in this order.")
+            .font(.caption)
+            .foregroundStyle(.secondary)
+            .fixedSize(horizontal: false, vertical: true)
+        cycleEditor(config)
+
         Text("One tree for the window — grouped exactly as it folds them (company → SubProvider → quota group → bucket). Drag a row to reorder, ✕ to remove, and rename any level in place. First field renders leftmost (or topmost).")
             .font(.caption)
             .foregroundStyle(.secondary)
@@ -228,12 +237,19 @@ struct MiniWindowsSettingsSection: View {
         HStack(spacing: 4) {
             namingScopeButton(.shared, label: "Names: all windows")
             namingScopeButton(.window, label: "Only “\(config.name)”")
+            namingScopeButton(.style, label: "Only \(config.displayMode.label) here")
             Spacer(minLength: 0)
         }
         .padding(3)
         .background(Capsule(style: .continuous).fill(Color.primary.opacity(0.045)))
         if namingScope == .window {
             Text("Name overrides for this window only. An empty field inherits the shared name — shown as the placeholder.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        if namingScope == .style {
+            Text("Overrides for the \(config.displayMode.label) style of this window only. An empty field inherits the window name, then the shared one — shown as the placeholder.")
                 .font(.caption)
                 .foregroundStyle(.secondary)
                 .fixedSize(horizontal: false, vertical: true)
@@ -280,6 +296,54 @@ struct MiniWindowsSettingsSection: View {
                 }
                 .buttonStyle(.vibeBar(cornerRadius: 7))
                 .help(mode.detail)
+            }
+        }
+    }
+
+    private func cycleEditor(_ config: MiniWindowConfig) -> some View {
+        let columns = [GridItem(.adaptive(minimum: 78), spacing: 5)]
+        return LazyVGrid(columns: columns, alignment: .leading, spacing: 5) {
+            ForEach(MiniWindowDisplayMode.allCases) { mode in
+                let position = config.cycleModes.firstIndex(of: mode)
+                Button {
+                    update { cfg in
+                        if let index = cfg.cycleModes.firstIndex(of: mode) {
+                            cfg.cycleModes.remove(at: index)
+                        } else {
+                            cfg.cycleModes.append(mode)
+                        }
+                    }
+                } label: {
+                    HStack(spacing: 5) {
+                        if let position {
+                            Text("\(position + 1)")
+                                .font(.system(size: 8.5, weight: .bold, design: .rounded).monospacedDigit())
+                                .foregroundStyle(Color.accentColor)
+                                .frame(width: 12, height: 12)
+                                .background(Circle().fill(Color.accentColor.opacity(0.16)))
+                        }
+                        Text(mode.label)
+                            .font(.system(size: 10.5, weight: .semibold, design: .rounded))
+                    }
+                    .foregroundStyle(position != nil ? Color.primary : Color.secondary)
+                    .padding(.horizontal, 8)
+                    .frame(height: 21)
+                    .frame(maxWidth: .infinity)
+                    .background(
+                        RoundedRectangle(cornerRadius: 6, style: .continuous)
+                            .fill(position != nil ? Color.accentColor.opacity(0.14) : Color.primary.opacity(0.04))
+                    )
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 6, style: .continuous)
+                            .stroke(
+                                position != nil ? Color.accentColor.opacity(0.3) : Color.primary.opacity(0.08),
+                                lineWidth: 0.7
+                            )
+                    )
+                    .contentShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
+                }
+                .buttonStyle(.vibeBar(cornerRadius: 6))
+                .help("Include \(mode.label) in the double-click cycle")
             }
         }
     }
@@ -843,17 +907,28 @@ struct MiniWindowsSettingsSection: View {
     /// What an empty field falls back to — in window scope that is the shared
     /// name when one is set, so the placeholder always shows what will render.
     private func namingPrompt(_ row: NamingRow) -> String {
+        let mini = settingsStore.settings.miniWindow
         let shared: String?
+        let window: String?
         switch row.kind {
         case .field:
-            shared = settingsStore.settings.miniWindow.customLabels[row.key]
+            shared = mini.customLabels[row.key]
+            window = selectedWindow?.customLabels[row.key]
         case .subProvider, .group:
-            shared = settingsStore.settings.miniWindow.groupLabels[row.key]
+            shared = mini.groupLabels[row.key]
+            window = selectedWindow?.groupLabels[row.key]
         }
-        if namingScope == .window,
-           let trimmed = shared?.trimmingCharacters(in: .whitespacesAndNewlines),
-           !trimmed.isEmpty {
-            return trimmed
+        let candidates: [String?]
+        switch namingScope {
+        case .shared: candidates = []
+        case .window: candidates = [shared]
+        case .style:  candidates = [window, shared]
+        }
+        for candidate in candidates {
+            if let trimmed = candidate?.trimmingCharacters(in: .whitespacesAndNewlines),
+               !trimmed.isEmpty {
+                return trimmed
+            }
         }
         return row.defaultLabel
     }
@@ -864,6 +939,10 @@ struct MiniWindowsSettingsSection: View {
         // it was typed for — same discipline as the window-name editor.
         let scope = namingScope
         let windowID = selectedWindow?.id
+        // The style scope binds to the mode the window showed when the field
+        // was constructed — a debounced commit after a mode switch must land
+        // on the style it was typed for.
+        let modeKey = selectedWindow?.displayMode.rawValue ?? MiniWindowDisplayMode.regular.rawValue
         return Binding(
             get: {
                 let mini = settingsStore.settings.miniWindow
@@ -876,6 +955,10 @@ struct MiniWindowsSettingsSection: View {
                     return windowID.flatMap { mini.config(id: $0)?.customLabels[row.key] } ?? ""
                 case (.window, _):
                     return windowID.flatMap { mini.config(id: $0)?.groupLabels[row.key] } ?? ""
+                case (.style, .field):
+                    return windowID.flatMap { mini.config(id: $0)?.modeCustomLabels[modeKey]?[row.key] } ?? ""
+                case (.style, _):
+                    return windowID.flatMap { mini.config(id: $0)?.modeGroupLabels[modeKey]?[row.key] } ?? ""
                 }
             },
             set: { value in
@@ -912,6 +995,27 @@ struct MiniWindowsSettingsSection: View {
                             } else {
                                 config.groupLabels[row.key] = value
                             }
+                        }
+                    }
+                case .style:
+                    guard let windowID else { return }
+                    update(id: windowID) { config in
+                        if row.kind == .field {
+                            var labels = config.modeCustomLabels[modeKey] ?? [:]
+                            if trimmed.isEmpty {
+                                labels.removeValue(forKey: row.key)
+                            } else {
+                                labels[row.key] = value
+                            }
+                            config.modeCustomLabels[modeKey] = labels.isEmpty ? nil : labels
+                        } else {
+                            var labels = config.modeGroupLabels[modeKey] ?? [:]
+                            if trimmed.isEmpty {
+                                labels.removeValue(forKey: row.key)
+                            } else {
+                                labels[row.key] = value
+                            }
+                            config.modeGroupLabels[modeKey] = labels.isEmpty ? nil : labels
                         }
                     }
                 }

--- a/Sources/VibeBarApp/Views/PopoverRoot.swift
+++ b/Sources/VibeBarApp/Views/PopoverRoot.swift
@@ -2260,12 +2260,15 @@ private struct ProviderBucketRow: View {
                 Text(bucket.title)
                     .font(.system(size: density.bucketTitleFontSize, weight: .semibold))
                 if let resetStatus {
+                    // Same size and scale floor as the primary bucket rows —
+                    // see QuotaGroupCard: mismatched caption sizes read as a
+                    // typography bug.
                     Text(resetStatus.label)
-                        .font(.system(size: resetCountdownFontSize))
+                        .font(.system(size: density.resetCountdownFontSize))
                         .foregroundStyle(.tertiary)
                         .lineLimit(1)
-                        .minimumScaleFactor(tool == .antigravity ? 0.92 : 0.80)
-                        .layoutPriority(tool == .antigravity ? 1 : 0)
+                        .minimumScaleFactor(0.9)
+                        .layoutPriority(1)
                 }
                 Spacer(minLength: 6)
                 Text("\(Int(percent.rounded()))%")
@@ -2328,12 +2331,6 @@ private struct ProviderBucketRow: View {
                 QuotaBarShape(percent: percent, mode: mode, height: density.bucketBarHeight)
             }
         }
-    }
-
-    private var resetCountdownFontSize: CGFloat {
-        tool == .antigravity
-            ? max(density.subtitleFontSize, density.resetCountdownFontSize + 1)
-            : density.resetCountdownFontSize
     }
 
     private func paceForecast(now: Date) -> QuotaPaceForecast? {

--- a/Sources/VibeBarApp/Views/QuotaGroupCard.swift
+++ b/Sources/VibeBarApp/Views/QuotaGroupCard.swift
@@ -413,12 +413,15 @@ struct QuotaGroupCard: View {
                     .font(.system(size: density.bucketTitleFontSize, weight: .semibold))
                     .lineLimit(1)
                 if let resetStatus {
+                    // One size and one scale floor for every provider — the
+                    // per-tool bump and the 0.80 shrink made visually
+                    // different caption sizes from row to row.
                     Text(resetStatus.label)
-                        .font(.system(size: resetCountdownFontSize(for: item.tool)))
+                        .font(.system(size: density.resetCountdownFontSize))
                         .foregroundStyle(.tertiary)
                         .lineLimit(1)
-                        .minimumScaleFactor(item.tool == .antigravity ? 0.92 : 0.80)
-                        .layoutPriority(item.tool == .antigravity ? 1 : 0)
+                        .minimumScaleFactor(0.9)
+                        .layoutPriority(1)
                 }
                 Spacer(minLength: 6)
                 Text(percentLabel(used: used))
@@ -476,12 +479,6 @@ struct QuotaGroupCard: View {
                 forecastExplanation(itemID: item.id, forecast: forecast, pace: pace)
             }
         }
-    }
-
-    private func resetCountdownFontSize(for tool: ToolType) -> CGFloat {
-        tool == .antigravity
-            ? max(density.subtitleFontSize, density.resetCountdownFontSize + 1)
-            : density.resetCountdownFontSize
     }
 
     @ViewBuilder

--- a/Sources/VibeBarApp/Views/SettingsView.swift
+++ b/Sources/VibeBarApp/Views/SettingsView.swift
@@ -821,27 +821,7 @@ struct SettingsView: View {
     @ViewBuilder
     private func menuItemFieldList(for kind: MenuBarItemKind) -> some View {
         if kind == .compact {
-            VStack(alignment: .leading, spacing: 12) {
-                ForEach(MiniWindowFieldProviderSection.all) { section in
-                    VStack(alignment: .leading, spacing: 8) {
-                        HStack(spacing: 6) {
-                            ToolBrandIconView(tool: section.tool, size: 13)
-                                .opacity(0.85)
-                            Text(section.title)
-                                .font(.caption)
-                                .fontWeight(.semibold)
-                                .foregroundStyle(.secondary)
-                                .textCase(.uppercase)
-                                .tracking(0.4)
-                        }
-                        VStack(alignment: .leading, spacing: 6) {
-                            ForEach(section.fields) { field in
-                                menuFieldRow(kind: kind, field: field)
-                            }
-                        }
-                    }
-                }
-            }
+            MenuBarFieldsEditor(kind: kind)
         } else {
             VStack(alignment: .leading, spacing: 6) {
                 ForEach(MenuBarFieldCatalog.fields(for: kind)) { field in

--- a/Sources/VibeBarCore/Models/AppSettings.swift
+++ b/Sources/VibeBarCore/Models/AppSettings.swift
@@ -1115,6 +1115,16 @@ public struct MiniWindowConfig: Codable, Equatable, Sendable, Identifiable {
     /// Density of the strip layout — the one mode whose whole point is its
     /// footprint, so it gets the menu-bar-style choice of three.
     public var stripDensity: MiniStripDensity
+    /// Per-style label overrides: display-mode rawValue → field id → label.
+    /// A style entry wins over the window's own label, which wins over the
+    /// shared one — a tile can carry the terse name while the ledger keeps
+    /// the full one.
+    public var modeCustomLabels: [String: [String: String]]
+    /// Same per-style inheritance for SubProvider / quota-group labels.
+    public var modeGroupLabels: [String: [String: String]]
+    /// The display modes a double-click on the window cycles through, in
+    /// this order. Empty means every mode, in the natural order.
+    public var cycleModes: [MiniWindowDisplayMode]
 
     /// The id every pre-multi-window settings blob migrates onto. It must be
     /// deterministic: the migration runs on every decode until something
@@ -1130,7 +1140,10 @@ public struct MiniWindowConfig: Codable, Equatable, Sendable, Identifiable {
         wasOpen: Bool = false,
         customLabels: [String: String] = [:],
         groupLabels: [String: String] = [:],
-        stripDensity: MiniStripDensity = .roomy
+        stripDensity: MiniStripDensity = .roomy,
+        modeCustomLabels: [String: [String: String]] = [:],
+        modeGroupLabels: [String: [String: String]] = [:],
+        cycleModes: [MiniWindowDisplayMode] = []
     ) {
         self.id = id
         self.name = name
@@ -1140,10 +1153,25 @@ public struct MiniWindowConfig: Codable, Equatable, Sendable, Identifiable {
         self.customLabels = customLabels
         self.groupLabels = groupLabels
         self.stripDensity = stripDensity
+        self.modeCustomLabels = modeCustomLabels
+        self.modeGroupLabels = modeGroupLabels
+        self.cycleModes = cycleModes
+    }
+
+    /// Where a double-click moves next from the current mode. An empty
+    /// cycle means every mode; a mode outside its own cycle enters at the
+    /// cycle's start rather than being stuck.
+    public func nextDisplayMode() -> MiniWindowDisplayMode {
+        let cycle = cycleModes.isEmpty ? Array(MiniWindowDisplayMode.allCases) : cycleModes
+        guard let index = cycle.firstIndex(of: displayMode) else {
+            return cycle.first ?? displayMode
+        }
+        return cycle[(index + 1) % cycle.count]
     }
 
     private enum CodingKeys: String, CodingKey {
         case id, name, displayMode, fieldIds, wasOpen, customLabels, groupLabels, stripDensity
+        case modeCustomLabels, modeGroupLabels, cycleModes
     }
 
     public init(from decoder: Decoder) throws {
@@ -1160,6 +1188,12 @@ public struct MiniWindowConfig: Codable, Equatable, Sendable, Identifiable {
         self.customLabels = try c.decodeIfPresent([String: String].self, forKey: .customLabels) ?? [:]
         self.groupLabels = try c.decodeIfPresent([String: String].self, forKey: .groupLabels) ?? [:]
         self.stripDensity = (try? c.decodeIfPresent(MiniStripDensity.self, forKey: .stripDensity)) ?? .roomy
+        self.modeCustomLabels = try c.decodeIfPresent([String: [String: String]].self, forKey: .modeCustomLabels) ?? [:]
+        self.modeGroupLabels = try c.decodeIfPresent([String: [String: String]].self, forKey: .modeGroupLabels) ?? [:]
+        // Lossy like displayMode: modes a build doesn't know drop out of the
+        // cycle instead of discarding the whole settings blob.
+        let cycleRaw = try c.decodeIfPresent([String].self, forKey: .cycleModes) ?? []
+        self.cycleModes = cycleRaw.compactMap(MiniWindowDisplayMode.init(rawValue:))
     }
 }
 
@@ -1361,13 +1395,15 @@ public struct MiniWindowSettings: Codable, Equatable, Sendable {
     /// The custom field label one window shows: its own override first, the
     /// shared name second, nil when neither is set.
     public func resolvedFieldLabel(config: MiniWindowConfig?, fieldId: String) -> String? {
-        Self.trimmedNonEmpty(config?.customLabels[fieldId])
+        Self.trimmedNonEmpty(config.flatMap { $0.modeCustomLabels[$0.displayMode.rawValue]?[fieldId] })
+            ?? Self.trimmedNonEmpty(config?.customLabels[fieldId])
             ?? Self.trimmedNonEmpty(customLabels[fieldId])
     }
 
     /// Same inheritance for SubProvider and quota-group labels.
     public func resolvedGroupLabel(config: MiniWindowConfig?, key: String) -> String? {
-        Self.trimmedNonEmpty(config?.groupLabels[key])
+        Self.trimmedNonEmpty(config.flatMap { $0.modeGroupLabels[$0.displayMode.rawValue]?[key] })
+            ?? Self.trimmedNonEmpty(config?.groupLabels[key])
             ?? Self.trimmedNonEmpty(groupLabels[key])
     }
 

--- a/Tests/VibeBarCoreTests/MiniWindowConfigTests.swift
+++ b/Tests/VibeBarCoreTests/MiniWindowConfigTests.swift
@@ -26,6 +26,58 @@ final class MiniWindowConfigTests: XCTestCase {
         XCTAssertTrue(settings.hiddenStaleFieldIds.isEmpty)
     }
 
+    func testPerStyleLabelsWinOverWindowAndShared() throws {
+        var settings = MiniWindowSettings(selectedFieldIds: ["claude.weekly"])
+        var config = try XCTUnwrap(settings.windows.first)
+        settings.customLabels["claude.weekly"] = "Shared Name"
+        config.customLabels["claude.weekly"] = "Window Name"
+        config.displayMode = .tile
+        config.modeCustomLabels[MiniWindowDisplayMode.tile.rawValue] = ["claude.weekly": "Tile Name"]
+        settings.upsert(config)
+
+        XCTAssertEqual(settings.resolvedFieldLabel(config: config, fieldId: "claude.weekly"), "Tile Name")
+        // A different style falls back to the window's own name.
+        config.displayMode = .ledger
+        XCTAssertEqual(settings.resolvedFieldLabel(config: config, fieldId: "claude.weekly"), "Window Name")
+        // No window override → shared.
+        config.customLabels.removeValue(forKey: "claude.weekly")
+        XCTAssertEqual(settings.resolvedFieldLabel(config: config, fieldId: "claude.weekly"), "Shared Name")
+    }
+
+    func testDoubleClickCycleHonorsConfiguredOrderAndFallsBackToAll() {
+        var config = MiniWindowConfig(name: "Mini", fieldIds: [])
+        config.displayMode = .regular
+        // Empty cycle: natural order over every mode.
+        XCTAssertEqual(config.nextDisplayMode(), MiniWindowDisplayMode.allCases[1])
+        // Configured cycle wraps in its own order.
+        config.cycleModes = [.ledger, .strip, .regular]
+        XCTAssertEqual(config.nextDisplayMode(), .ledger)
+        config.displayMode = .strip
+        XCTAssertEqual(config.nextDisplayMode(), .regular)
+        config.displayMode = .regular
+        XCTAssertEqual(config.nextDisplayMode(), .ledger)
+        // A mode outside its own cycle enters at the cycle's start.
+        config.displayMode = .focus
+        XCTAssertEqual(config.nextDisplayMode(), .ledger)
+    }
+
+    func testPerStyleAndCycleSurviveRoundTripAndUnknownModesDrop() throws {
+        var config = MiniWindowConfig(name: "Mini", fieldIds: ["codex.weekly"])
+        config.modeGroupLabels[MiniWindowDisplayMode.strip.rawValue] = ["claude/Claude": "CL"]
+        config.cycleModes = [.regular, .tile]
+        let data = try JSONEncoder().encode(config)
+        let decoded = try JSONDecoder().decode(MiniWindowConfig.self, from: data)
+        XCTAssertEqual(decoded.modeGroupLabels["strip"]?["claude/Claude"], "CL")
+        XCTAssertEqual(decoded.cycleModes, [.regular, .tile])
+
+        // A cycle containing a mode this build doesn't know drops just that
+        // mode instead of failing the decode.
+        var json = String(data: data, encoding: .utf8)!
+        json = json.replacingOccurrences(of: "\"regular\",\"tile\"", with: "\"regular\",\"holographic\",\"tile\"")
+        let lossy = try JSONDecoder().decode(MiniWindowConfig.self, from: Data(json.utf8))
+        XCTAssertEqual(lossy.cycleModes, [.regular, .tile])
+    }
+
     func testHiddenStaleFieldIdsSurviveRoundTrip() throws {
         var settings = MiniWindowSettings(selectedFieldIds: ["codex.weekly"])
         settings.hiddenStaleFieldIds = ["claude.weekly_opus", "claude.daily_routines"]


### PR DESCRIPTION
Second of three PRs for AQ's feedback round — the settings side plus one popover typography fix:

1. **Menu bar Fields editor aligned with the unified-tree logic**: new `MenuBarFieldsEditor` — ordered "shown" list grouped company → SubProvider with inline rename/reorder/remove, and a candidate list that includes runtime-discovered buckets with the same stale-dismiss semantics as the mini editor (registry forget for discovered, shared `hiddenStaleFieldIds` for built-ins). `StatusItemController` now resolves fields through the registry (`field(id:registry:)`), fixing discovered buckets silently not rendering in the menu bar.
2. **Per-style names**: third naming scope "Only <Style> here" — overrides keyed by display mode (`modeCustomLabels` / `modeGroupLabels`, decode-compatible), resolution style → window → shared → default. A tile can carry a terse name while the ledger keeps the full one.
3. **Configurable double-click cycle**: `cycleModes: [MiniWindowDisplayMode]` per window with a chip editor (tap to include, badge shows the turn); empty = every style. Unknown modes drop out of a decoded cycle instead of failing the blob.
4. **Reset-caption typography** (AQ's screenshot): the AntiGravity +1pt bump and the 0.80 `minimumScaleFactor` made "resets in …" captions render at visibly different sizes between rows; both render sites now use one size with a 0.9 floor and equal layout priority.

## Validation
- `swift build` ✓, `swift test` ✓ (1682 tests; +3 for style resolution, cycle order, lossy cycle decode)
- `./Scripts/build_app.sh release` ✓, empty entitlements ✓, deep signature ✓
- No-pixel demo smoke of `settings:menuBar` ✓
- Merged with current main (post-#247) cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)