### PR TITLE
Refine both reset surfaces: hover cards, group cards, a real calendar

### DIFF
--- a/Sources/VibeBarApp/Views/UpcomingResets.swift
+++ b/Sources/VibeBarApp/Views/UpcomingResets.swift
@@ -17,6 +17,9 @@ struct UpcomingResetEvent: Identifiable {
     /// What the reset gives back — the used share of the window.
     let gainPercent: Double
     let resetAt: Date
+    /// The personal forecast's remaining % at the moment of this reset, when
+    /// one exists — shown in the lane's hover card.
+    var forecastRemainingAtResetPercent: Double? = nil
 
     var id: String { "\(accountId).\(bucketId)" }
 
@@ -47,6 +50,12 @@ enum UpcomingResets {
         let horizon = now.addingTimeInterval(horizonDays * 86_400)
         var out: [UpcomingResetEvent] = []
         let settings = environment.settingsStore.settings
+        // Forecasts run on the page's shared 5-minute clock so the memo in
+        // QuotaService actually hits — a fresh `now` per minute tick would
+        // recompute every bucket's blend for nothing.
+        let forecastNow = Date(
+            timeIntervalSinceReferenceDate: (now.timeIntervalSinceReferenceDate / 300).rounded(.down) * 300
+        )
         for tool in ToolType.dedicatedCardProviders where settings.isCoreProviderVisible(tool) {
             // Every account, not the first one — multi-account providers
             // (Gemini, say) refill per account.
@@ -61,6 +70,15 @@ enum UpcomingResets {
                     else { continue }
                     let subProvider = tool.quotaSubProviderName(bucketID: bucket.id)
                     let group = bucket.groupTitle?.trimmingCharacters(in: .whitespacesAndNewlines)
+                    let snapshot = environment.costService.snapshot(for: tool)
+                    let forecast = environment.quotaService.paceForecast(
+                        accountId: account.id,
+                        bucket: bucket,
+                        activityHeatmap: snapshot?.heatmap,
+                        dailyActivity: snapshot?.dailyHistory ?? [],
+                        now: forecastNow,
+                        allowsPostResetGrace: true
+                    )
                     out.append(UpcomingResetEvent(
                         tool: tool,
                         accountId: account.id,
@@ -72,7 +90,10 @@ enum UpcomingResets {
                         bucketTitle: bucket.title,
                         remainingPercent: max(0, 100 - bucket.usedPercent),
                         gainPercent: bucket.usedPercent,
-                        resetAt: resetAt
+                        resetAt: resetAt,
+                        forecastRemainingAtResetPercent: forecast.map {
+                            max(0, min(100, 100 - $0.projectedUsedPercent))
+                        }
                     ))
                 }
             }
@@ -89,6 +110,15 @@ struct ResetLaneView: View {
     let now: Date
     var horizonDays: Double = 7
     var laneHeight: CGFloat = 64
+
+    @State private var hoveredEventID: String?
+
+    private static let absoluteTimeFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "MMM d, HH:mm"
+        formatter.timeZone = .autoupdatingCurrent
+        return formatter
+    }()
 
     var body: some View {
         GeometryReader { proxy in
@@ -118,9 +148,59 @@ struct ResetLaneView: View {
                 ForEach(events) { event in
                     marker(event, width: width, fanOffset: fanned[event.id] ?? 0)
                 }
+                if let hovered = events.first(where: { $0.id == hoveredEventID }) {
+                    hoverCard(hovered, width: width, fanOffset: fanned[hovered.id] ?? 0)
+                }
             }
         }
         .frame(height: laneHeight)
+    }
+
+    /// The hover legend AQ asked for: what the column is, exactly when it
+    /// resets, how much is left now, how much comes back, and what the
+    /// forecast expects at that moment.
+    private func hoverCard(_ event: UpcomingResetEvent, width: CGFloat, fanOffset: CGFloat) -> some View {
+        let fraction = min(1, event.resetAt.timeIntervalSince(now) / (horizonDays * 86_400))
+        let x = max(4, min(width - 4, width * fraction + fanOffset))
+        let cardWidth: CGFloat = 236
+        let cardX = max(0, min(width - cardWidth, x - cardWidth / 2))
+        return VStack(alignment: .leading, spacing: 3) {
+            HStack(spacing: 5) {
+                Circle()
+                    .fill(Theme.providerAccent(for: event.tool))
+                    .frame(width: 5, height: 5)
+                Text(event.label)
+                    .font(.system(size: 9.5, weight: .semibold))
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.7)
+            }
+            Text("resets \(ResetCountdownFormatter.string(from: event.resetAt, now: now) ?? "—") · \(Self.absoluteTimeFormatter.string(from: event.resetAt))")
+                .font(.system(size: 9, design: .rounded).monospacedDigit())
+                .foregroundStyle(.secondary)
+            Text("\(Int(event.remainingPercent.rounded()))% left now · +\(Int(event.gainPercent.rounded()))% comes back")
+                .font(.system(size: 9, design: .rounded).monospacedDigit())
+                .foregroundStyle(Theme.barColor(percent: event.remainingPercent, mode: .remaining))
+            if let projected = event.forecastRemainingAtResetPercent {
+                Text("forecast \(Int(projected.rounded()))% left at reset")
+                    .font(.system(size: 9, design: .rounded).monospacedDigit())
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 6)
+        .frame(width: cardWidth, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 7, style: .continuous)
+                .fill(.thickMaterial)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 7, style: .continuous)
+                        .stroke(Color.primary.opacity(0.12), lineWidth: 0.7)
+                )
+        )
+        .offset(x: cardX, y: -2)
+        .zIndex(2)
+        .allowsHitTesting(false)
+        .transition(.opacity)
     }
 
     /// Buckets that reset together (Claude's overall and model-scoped
@@ -154,7 +234,23 @@ struct ResetLaneView: View {
         )
         .fill(Theme.barColor(percent: event.remainingPercent, mode: .remaining))
         .frame(width: 7, height: height)
+        .overlay(
+            UnevenRoundedRectangle(
+                topLeadingRadius: 3.5, bottomLeadingRadius: 1,
+                bottomTrailingRadius: 1, topTrailingRadius: 3.5,
+                style: .continuous
+            )
+            .stroke(Color.primary.opacity(hoveredEventID == event.id ? 0.55 : 0), lineWidth: 1)
+        )
         .offset(x: x - 3.5, y: laneHeight - 14 - height)
+        .contentShape(Rectangle().inset(by: -4))
+        .onHover { inside in
+            if inside {
+                hoveredEventID = event.id
+            } else if hoveredEventID == event.id {
+                hoveredEventID = nil
+            }
+        }
         .help("\(event.label) — \(Int(event.remainingPercent.rounded()))% now, +\(Int(event.gainPercent.rounded()))% \(ResetCountdownFormatter.string(from: event.resetAt, now: now) ?? "")")
     }
 }

--- a/Sources/VibeBarApp/Views/Workbench/ResetsPage.swift
+++ b/Sources/VibeBarApp/Views/Workbench/ResetsPage.swift
@@ -11,6 +11,11 @@ struct ResetsPage: View {
     @EnvironmentObject private var settingsStore: SettingsStore
     @EnvironmentObject private var quotaService: QuotaService
 
+    /// Which month the calendar shows, as an offset from the current one.
+    /// Negative pages into recorded history, positive into the forecastable
+    /// future.
+    @State private var calendarMonthOffset = 0
+
     var body: some View {
         // One leaf timer for the whole page: countdown text drifts by the
         // minute; data re-renders arrive with quota refreshes on their own.
@@ -43,8 +48,8 @@ struct ResetsPage: View {
                 cycleGrid(cycles, now: now)
                 HStack(alignment: .top, spacing: 14) {
                     box {
-                        boxHeader("Reset Calendar", detail: "14 days")
-                        calendar(events, now: now)
+                        calendarHeader(now: now)
+                        monthCalendar(now: now)
                     }
                     .frame(maxWidth: .infinity)
                     box {
@@ -60,18 +65,24 @@ struct ResetsPage: View {
 
     // MARK: - Cycle model
 
-    /// One L2 SubProvider's live cycle: its buckets, the headline (longest
-    /// window — the cycle a subscription is priced on), and the forecast.
+    /// One quota group's live cycle — the popover's own granularity: a
+    /// SubProvider's primary buckets are one card ("Chatgpt Agentic"), and
+    /// every model-scoped group (Spark, Reserve, Fable…) is its own card,
+    /// with the headline being that group's longest window.
     private struct SubProviderCycle: Identifiable {
         let tool: ToolType
         let accountId: String
         let accountLabel: String?
-        let name: String
+        /// The SubProvider ("Claude"), always shown.
+        let subProviderName: String
+        /// The quota group inside it ("Fable"), nil for the primary buckets.
+        let groupTitle: String?
         let plan: String?
         let buckets: [QuotaBucket]
         let headline: QuotaBucket
         let forecast: QuotaPaceForecast?
-        var id: String { "\(accountId)/\(name)" }
+        var id: String { "\(accountId)/\(subProviderName)/\(groupTitle ?? "")" }
+        var name: String { groupTitle.map { "\(subProviderName) · \($0)" } ?? subProviderName }
     }
 
     private func subProviderCycles(now: Date) -> [SubProviderCycle] {
@@ -83,15 +94,26 @@ struct ResetsPage: View {
                       !quota.buckets.isEmpty
                 else { continue }
                 let accountLabel = accounts.count > 1 ? account.displayLabel : nil
-                var bySub: [String: [QuotaBucket]] = [:]
+                var byGroup: [String: [QuotaBucket]] = [:]
+                var meta: [String: (sub: String, group: String?)] = [:]
                 var order: [String] = []
                 for bucket in quota.buckets {
                     let sub = tool.quotaSubProviderName(bucketID: bucket.id)
-                    if bySub[sub] == nil { order.append(sub) }
-                    bySub[sub, default: []].append(bucket)
+                    let trimmed = bucket.groupTitle?.trimmingCharacters(in: .whitespacesAndNewlines)
+                    // A group titled after its own SubProvider is the primary
+                    // lane (Grok Bot), not a model group.
+                    let group = (trimmed?.isEmpty ?? true)
+                        || trimmed?.caseInsensitiveCompare(sub) == .orderedSame
+                        ? nil : trimmed
+                    let key = "\(sub)/\(group ?? "")"
+                    if byGroup[key] == nil {
+                        order.append(key)
+                        meta[key] = (sub, group)
+                    }
+                    byGroup[key, default: []].append(bucket)
                 }
-                for sub in order {
-                    guard let buckets = bySub[sub],
+                for key in order {
+                    guard let buckets = byGroup[key], let info = meta[key],
                           let headline = buckets.max(by: {
                               ($0.rawWindowSeconds ?? 0) < ($1.rawWindowSeconds ?? 0)
                           })
@@ -100,7 +122,8 @@ struct ResetsPage: View {
                         tool: tool,
                         accountId: account.id,
                         accountLabel: accountLabel,
-                        name: sub,
+                        subProviderName: info.sub,
+                        groupTitle: info.group,
                         plan: quota.plan,
                         buckets: buckets,
                         headline: headline,
@@ -202,7 +225,7 @@ struct ResetsPage: View {
             ForEach(cycle.buckets.filter { $0.id != cycle.headline.id }, id: \.id) { bucket in
                 let remaining = max(0, 100 - bucket.usedPercent)
                 HStack(spacing: 5) {
-                    Text(bucket.groupTitle.map { "\($0) · \(bucket.title)" } ?? bucket.title)
+                    Text(bucket.title)
                         .font(.system(size: 9.5))
                         .foregroundStyle(.secondary)
                         .lineLimit(1)
@@ -281,48 +304,223 @@ struct ResetsPage: View {
 
     // MARK: - Calendar
 
-    private func calendar(_ events: [UpcomingResetEvent], now: Date) -> some View {
-        let columns = [GridItem(.adaptive(minimum: 96), spacing: 6, alignment: .top)]
+    /// One thing happening on one day: a future reset (from the cached
+    /// quotas) or a recorded one (from the subscription history), with how
+    /// much it gives/gave back.
+    private struct CalendarEntry: Identifiable {
+        let id: String
+        let tool: ToolType
+        let label: String
+        let shortLabel: String
+        let gainPercent: Double
+        let at: Date
+        let isPast: Bool
+    }
+
+    private static let monthTitleFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "MMMM yyyy"
+        formatter.timeZone = .autoupdatingCurrent
+        return formatter
+    }()
+
+    private static let entryTimeFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "MMM d, HH:mm"
+        formatter.timeZone = .autoupdatingCurrent
+        return formatter
+    }()
+
+    private func displayedMonthStart(now: Date) -> Date {
         let calendar = Calendar.current
-        let todayStart = calendar.startOfDay(for: now)
-        return LazyVGrid(columns: columns, alignment: .leading, spacing: 6) {
-            ForEach(0..<14, id: \.self) { offset in
-                // Calendar arithmetic, not fixed 86 400 s — a DST transition
-                // would otherwise shift every later cell off local midnight.
-                let dayStart = calendar.date(byAdding: .day, value: offset, to: todayStart) ?? todayStart
-                let dayEnd = calendar.date(byAdding: .day, value: 1, to: dayStart) ?? dayStart.addingTimeInterval(86_400)
-                let hits = events.filter { $0.resetAt >= max(dayStart, now) && $0.resetAt < dayEnd }
-                VStack(alignment: .leading, spacing: 3) {
-                    Text(offset == 0 ? "Today" : dayStart.formatted(.dateTime.weekday(.abbreviated).day()))
-                        .font(.system(size: 8.5, weight: .semibold))
-                        .foregroundStyle(.tertiary)
-                    ForEach(hits) { event in
-                        HStack(spacing: 3) {
-                            Circle()
-                                .fill(Theme.providerAccent(for: event.tool))
-                                .frame(width: 4, height: 4)
-                            Text("\(event.subProviderName) +\(Int(event.gainPercent.rounded()))%")
-                                .font(.system(size: 8, weight: .semibold, design: .rounded).monospacedDigit())
-                                .foregroundStyle(.secondary)
-                                .lineLimit(1)
-                                .minimumScaleFactor(0.7)
-                        }
-                        .help(event.label)
-                    }
-                    if hits.isEmpty {
-                        Text("—")
-                            .font(.system(size: 8))
-                            .foregroundStyle(.quaternary)
-                    }
+        let thisMonth = calendar.dateInterval(of: .month, for: now)?.start ?? now
+        return calendar.date(byAdding: .month, value: calendarMonthOffset, to: thisMonth) ?? thisMonth
+    }
+
+    private func calendarHeader(now: Date) -> some View {
+        let monthStart = displayedMonthStart(now: now)
+        return HStack(spacing: 8) {
+            Text("Reset Calendar")
+                .font(.system(size: 12, weight: .semibold))
+            Spacer(minLength: 6)
+            Button {
+                calendarMonthOffset -= 1
+            } label: {
+                Image(systemName: "chevron.left")
+                    .font(.system(size: 9, weight: .semibold))
+                    .frame(width: 20, height: 20)
+            }
+            .buttonStyle(.vibeBar)
+            .help("Previous month")
+            Text(Self.monthTitleFormatter.string(from: monthStart))
+                .font(.system(size: 11, weight: .semibold, design: .rounded))
+                .frame(minWidth: 110)
+            Button {
+                calendarMonthOffset += 1
+            } label: {
+                Image(systemName: "chevron.right")
+                    .font(.system(size: 9, weight: .semibold))
+                    .frame(width: 20, height: 20)
+            }
+            .buttonStyle(.vibeBar)
+            .help("Next month")
+            if calendarMonthOffset != 0 {
+                Button("Today") {
+                    calendarMonthOffset = 0
                 }
-                .padding(6)
-                .frame(maxWidth: .infinity, minHeight: 52, alignment: .topLeading)
-                .background(
-                    RoundedRectangle(cornerRadius: 7, style: .continuous)
-                        .fill(Color.primary.opacity(hits.isEmpty ? 0.025 : 0.05))
-                )
+                .font(.system(size: 10, weight: .semibold))
+                .buttonStyle(.vibeBar)
             }
         }
+    }
+
+    /// Everything that lands in the displayed month: recorded cycle ends from
+    /// the subscription history (the past pages) and scheduled resets from
+    /// the cached quotas (the future ones — as far ahead as the providers
+    /// declare their next reset).
+    private func calendarEntries(monthStart: Date, monthEnd: Date, now: Date) -> [CalendarEntry] {
+        var out: [CalendarEntry] = []
+        // Past: completed cycles. Bucket titles come from the account's
+        // current quota when it still carries the bucket; a lane that no
+        // longer exists keeps just its SubProvider name rather than leaking
+        // a raw bucket id into copy.
+        for (key, samples) in quotaService.historyByAccountBucket {
+            let quota = environment.quotaService.cachedQuota(for: key.accountId)
+            for sample in samples {
+                let at = sample.completedAt ?? sample.windowEnd
+                guard at >= monthStart, at < monthEnd, at <= now else { continue }
+                let sub = sample.tool.quotaSubProviderName(bucketID: sample.bucketId)
+                let title = quota?.bucket(id: sample.bucketId)?.title
+                let name = title.map { "\(sub) · \($0)" } ?? sub
+                out.append(CalendarEntry(
+                    id: "past.\(key.accountId).\(sample.bucketId).\(at.timeIntervalSinceReferenceDate)",
+                    tool: sample.tool,
+                    label: "\(name) — reset \(Self.entryTimeFormatter.string(from: at)) at \(Int(sample.lastUsedPercent.rounded()))% used",
+                    shortLabel: sub,
+                    gainPercent: sample.lastUsedPercent,
+                    at: at,
+                    isPast: true
+                ))
+            }
+        }
+        // Future: scheduled resets from the live quotas.
+        for tool in ToolType.dedicatedCardProviders {
+            for account in environment.accountStore.accounts(for: tool) {
+                guard let quota = environment.quotaService.cachedQuota(for: account.id) else { continue }
+                for bucket in quota.buckets {
+                    guard let resetAt = bucket.resetAt,
+                          resetAt >= max(monthStart, now), resetAt < monthEnd
+                    else { continue }
+                    let sub = tool.quotaSubProviderName(bucketID: bucket.id)
+                    out.append(CalendarEntry(
+                        id: "next.\(account.id).\(bucket.id)",
+                        tool: tool,
+                        label: "\(sub) · \(bucket.title) — resets \(Self.entryTimeFormatter.string(from: resetAt)), +\(Int(bucket.usedPercent.rounded()))% back",
+                        shortLabel: sub,
+                        gainPercent: bucket.usedPercent,
+                        at: resetAt,
+                        isPast: false
+                    ))
+                }
+            }
+        }
+        return out.sorted { $0.at < $1.at }
+    }
+
+    private func monthCalendar(now: Date) -> some View {
+        let calendar = Calendar.current
+        let monthStart = displayedMonthStart(now: now)
+        let monthEnd = calendar.date(byAdding: .month, value: 1, to: monthStart) ?? monthStart
+        let entries = calendarEntries(monthStart: monthStart, monthEnd: monthEnd, now: now)
+        var byDay: [Date: [CalendarEntry]] = [:]
+        for entry in entries {
+            byDay[calendar.startOfDay(for: entry.at), default: []].append(entry)
+        }
+        let today = calendar.startOfDay(for: now)
+        // Natural weeks: pad to the calendar's own first weekday.
+        let firstWeekdayOffset = (calendar.component(.weekday, from: monthStart)
+            - calendar.firstWeekday + 7) % 7
+        let dayCount = calendar.range(of: .day, in: .month, for: monthStart)?.count ?? 30
+        let weekdaySymbols = orderedWeekdaySymbols(calendar)
+        let columns = Array(repeating: GridItem(.flexible(), spacing: 4, alignment: .top), count: 7)
+        return VStack(alignment: .leading, spacing: 4) {
+            LazyVGrid(columns: columns, spacing: 4) {
+                ForEach(weekdaySymbols, id: \.self) { symbol in
+                    Text(symbol.uppercased())
+                        .font(.system(size: 9, weight: .semibold))
+                        .foregroundStyle(.tertiary)
+                        .frame(maxWidth: .infinity)
+                }
+                ForEach(0..<firstWeekdayOffset, id: \.self) { blank in
+                    Color.clear
+                        .frame(height: 8)
+                        .id("blank-\(blank)")
+                }
+                ForEach(1...dayCount, id: \.self) { day in
+                    let dayStart = calendar.date(byAdding: .day, value: day - 1, to: monthStart) ?? monthStart
+                    dayCell(
+                        day: day,
+                        dayStart: dayStart,
+                        isToday: dayStart == today,
+                        isPast: dayStart < today,
+                        entries: byDay[dayStart] ?? []
+                    )
+                }
+            }
+        }
+    }
+
+    private func orderedWeekdaySymbols(_ calendar: Calendar) -> [String] {
+        let symbols = calendar.veryShortStandaloneWeekdaySymbols
+        let first = calendar.firstWeekday - 1
+        return Array(symbols[first...] + symbols[..<first])
+    }
+
+    private func dayCell(
+        day: Int,
+        dayStart: Date,
+        isToday: Bool,
+        isPast: Bool,
+        entries: [CalendarEntry]
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 2.5) {
+            Text("\(day)")
+                .font(.system(size: 10.5, weight: isToday ? .bold : .semibold, design: .rounded).monospacedDigit())
+                .foregroundStyle(isToday ? Color.accentColor : (isPast ? Color.secondary : Color.primary))
+            ForEach(entries.prefix(3)) { entry in
+                HStack(spacing: 3) {
+                    Circle()
+                        .fill(Theme.providerAccent(for: entry.tool))
+                        .frame(width: 4.5, height: 4.5)
+                    Text("\(entry.shortLabel) +\(Int(entry.gainPercent.rounded()))%")
+                        .font(.system(size: 9, weight: .semibold, design: .rounded).monospacedDigit())
+                        .foregroundStyle(entry.isPast ? .tertiary : .secondary)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.7)
+                }
+                .help(entry.label)
+            }
+            if entries.count > 3 {
+                Text("+\(entries.count - 3) more")
+                    .font(.system(size: 8.5, weight: .medium))
+                    .foregroundStyle(.tertiary)
+            }
+        }
+        .padding(5)
+        .frame(maxWidth: .infinity, minHeight: 64, alignment: .topLeading)
+        .background(
+            RoundedRectangle(cornerRadius: 7, style: .continuous)
+                .fill(
+                    isToday
+                        ? Color.accentColor.opacity(0.10)
+                        : Color.primary.opacity(entries.isEmpty ? 0.025 : 0.05)
+                )
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 7, style: .continuous)
+                .stroke(isToday ? Color.accentColor.opacity(0.35) : Color.clear, lineWidth: 0.8)
+        )
+        .opacity(isPast ? 0.75 : 1)
     }
 
     // MARK: - Risk


### PR DESCRIPTION
Third of three PRs for AQ's feedback round — the reset surfaces (Workbench Resets page, popover Upcoming Resets card, mini rail; they share one lane component):

1. **Refill-lane hover cards**: every column now answers what it is on hover — full quota-axis label, exact reset moment (absolute time + countdown), what's left now, what comes back, and the personal forecast's remaining-at-reset when one exists. Events carry the memoized forecast on the shared 5-minute clock so the minute tick never recomputes a pace blend; the hovered column gets a highlight stroke. Applies identically to the popover card and the mini rail (同理 refine).
2. **Cycle cards at the popover's model granularity**: one card per (SubProvider, quota group) — ChatGPT Agentic / Spark / Reserve are three cards, each headlined by its group's longest window — instead of one per SubProvider with everything else as fine print.
3. **A real Reset Calendar**: natural weeks and months (locale first-weekday respected), browsable — back through recorded history (completed cycles from the subscription history, titles resolved without leaking bucket ids) and forward as far as providers declare their next reset — with today highlighted and larger, readable type. Replaces the 14-day mini-grid.

## Validation
- `swift build` ✓, `swift test` ✓ (1682 tests, merged with current main post-#248)
- `./Scripts/build_app.sh release` ✓, empty entitlements ✓, deep signature ✓
- No-pixel demo smoke of `workbench:resets` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)