### PR TITLE
Cap strip width, cache the menu editor, widen the registry keep set

### DIFF
--- a/Sources/VibeBarApp/AppEnvironment.swift
+++ b/Sources/VibeBarApp/AppEnvironment.swift
@@ -144,13 +144,31 @@ final class AppEnvironment: ObservableObject {
         // that vanishes from a provider's response was never the user's and
         // drops on the next refresh.
         service.registryKeepProvider = { [weak settingsStore] in
-            guard let mini = settingsStore?.settings.miniWindow else { return QuotaFieldKeepSet() }
+            guard let settings = settingsStore?.settings else { return QuotaFieldKeepSet() }
+            let mini = settings.miniWindow
             var fieldIds = Set(mini.customLabels.keys)
             var groupKeys = Set(mini.groupLabels.keys)
             for window in mini.windows {
                 fieldIds.formUnion(window.fieldIds)
                 fieldIds.formUnion(window.customLabels.keys)
                 groupKeys.formUnion(window.groupLabels.keys)
+                // Per-style names claim their targets too — a tile-only
+                // rename must anchor a discovered field exactly like a
+                // window-level one.
+                for labels in window.modeCustomLabels.values {
+                    fieldIds.formUnion(labels.keys)
+                }
+                for labels in window.modeGroupLabels.values {
+                    groupKeys.formUnion(labels.keys)
+                }
+            }
+            // The menu bar selects from the same registry: a discovered
+            // bucket shown only there must survive a response that
+            // temporarily omits it.
+            for kind in MenuBarItemKind.allCases {
+                let item = settings.menuBarItem(kind)
+                fieldIds.formUnion(item.selectedFieldIds)
+                fieldIds.formUnion(item.customLabels.keys)
             }
             return QuotaFieldKeepSet(fieldIds: fieldIds, groupKeys: groupKeys)
         }

--- a/Sources/VibeBarApp/Views/MenuBarFieldsEditor.swift
+++ b/Sources/VibeBarApp/Views/MenuBarFieldsEditor.swift
@@ -13,12 +13,24 @@ struct MenuBarFieldsEditor: View {
     @EnvironmentObject private var settingsStore: SettingsStore
     @EnvironmentObject private var quotaService: QuotaService
 
-    var body: some View {
-        let merged = Dictionary(
+    // Rebuilt when the registry or quota data changes, never per body pass —
+    // every settings publication re-renders this editor, and the merge plus
+    // per-field bucket lookups are O(fields · buckets). Same discipline as
+    // the mini-window editor next door.
+    @State private var mergedOptionsById: [String: MenuBarFieldOption] = [:]
+    @State private var liveIds: Set<String> = []
+
+    private func rebuildCaches() {
+        mergedOptionsById = Dictionary(
             MenuBarFieldCatalog.mergedFields(registry: quotaService.fieldRegistry).map { ($0.id, $0) },
             uniquingKeysWith: { first, _ in first }
         )
-        let live = liveFieldIds(merged: merged)
+        liveIds = liveFieldIds(merged: mergedOptionsById)
+    }
+
+    var body: some View {
+        let merged = mergedOptionsById
+        let live = liveIds
         let item = settingsStore.settings.menuBarItem(kind)
         let shown = item.selectedFieldIds.compactMap { merged[$0] }
         VStack(alignment: .leading, spacing: 10) {
@@ -38,6 +50,11 @@ struct MenuBarFieldsEditor: View {
                 .foregroundStyle(.secondary)
                 .fixedSize(horizontal: false, vertical: true)
             candidateList(merged: merged, live: live, selected: Set(item.selectedFieldIds))
+        }
+        .onAppear { rebuildCaches() }
+        .onChange(of: quotaService.fieldRegistry) { _, _ in rebuildCaches() }
+        .onReceive(quotaService.$lastSuccessByAccount) { _ in
+            liveIds = liveFieldIds(merged: mergedOptionsById)
         }
     }
 
@@ -327,6 +344,9 @@ struct MenuBarFieldsEditor: View {
         for index in settings.miniWindow.windows.indices {
             settings.miniWindow.windows[index].fieldIds.removeAll { $0 == fieldId }
             settings.miniWindow.windows[index].customLabels.removeValue(forKey: fieldId)
+            for mode in settings.miniWindow.windows[index].modeCustomLabels.keys {
+                settings.miniWindow.windows[index].modeCustomLabels[mode]?.removeValue(forKey: fieldId)
+            }
         }
         for kind in MenuBarItemKind.allCases {
             var item = settings.menuBarItem(kind)

--- a/Sources/VibeBarApp/Views/MiniWindowAltLayouts.swift
+++ b/Sources/VibeBarApp/Views/MiniWindowAltLayouts.swift
@@ -313,7 +313,8 @@ enum MiniStripMetrics {
         density == .narrow ? 7 : 9
     }
 
-    static func height(_ density: MiniStripDensity) -> CGFloat {
+    /// Height of one strip band.
+    static func rowHeight(_ density: MiniStripDensity) -> CGFloat {
         switch density {
         case .roomy:   return 40
         case .twoLine: return 54
@@ -321,23 +322,33 @@ enum MiniStripMetrics {
         }
     }
 
+    static let rowGap: CGFloat = 2
+    /// The strip never outgrows the screen: past this width, cells wrap into
+    /// further bands. A default selection can hold twenty-plus fields, and an
+    /// unwrapped run of 132-pt cells would put most of the panel off screen.
+    static let maxRowWidth: CGFloat = 1180
+
+    /// Cells per band, and how many bands `count` cells need.
+    static func gridPlan(count: Int, cellWidth: CGFloat, cellSpacing: CGFloat) -> (perRow: Int, rows: Int) {
+        let available = maxRowWidth - leadingPadding - trailingPadding
+        let perRow = max(1, Int((available + cellSpacing) / (cellWidth + cellSpacing)))
+        let rows = Int(ceil(Double(count) / Double(perRow)))
+        return (perRow, rows)
+    }
+
     static func size(entries: [MiniEntry], density: MiniStripDensity) -> CGSize {
-        guard !entries.isEmpty else { return CGSize(width: emptyWidth, height: height(density)) }
-        if density == .twoLine {
-            let columns = (entries.count + 1) / 2
-            let width = leadingPadding + trailingPadding
-                + CGFloat(columns) * pairedColumnWidth
-                + CGFloat(max(0, columns - 1)) * pairedColumnSpacing
-            return CGSize(width: width, height: height(density))
-        }
-        let companies = MiniEntry.companyRuns(entries)
-        var width = leadingPadding + trailingPadding
-        for (index, company) in companies.enumerated() {
-            if index > 0 { width += 2 * companySpacing(density) + dividerThickness }
-            width += CGFloat(company.count) * chipWidth(density)
-                + CGFloat(max(0, company.count - 1)) * chipSpacing(density)
-        }
-        return CGSize(width: width, height: height(density))
+        guard !entries.isEmpty else { return CGSize(width: emptyWidth, height: rowHeight(density)) }
+        let cellCount = density == .twoLine ? (entries.count + 1) / 2 : entries.count
+        let cellWidth = chipWidth(density)
+        let cellSpacing = density == .twoLine ? pairedColumnSpacing : chipSpacing(density)
+        let plan = gridPlan(count: cellCount, cellWidth: cellWidth, cellSpacing: cellSpacing)
+        let cellsInWidestRow = min(cellCount, plan.perRow)
+        let width = leadingPadding + trailingPadding
+            + CGFloat(cellsInWidestRow) * cellWidth
+            + CGFloat(max(0, cellsInWidestRow - 1)) * cellSpacing
+        let height = CGFloat(plan.rows) * rowHeight(density)
+            + CGFloat(max(0, plan.rows - 1)) * rowGap
+        return CGSize(width: width, height: height)
     }
 }
 
@@ -355,27 +366,25 @@ struct MiniStripLayout: View {
             } else if density == .twoLine {
                 pairedColumns
             } else {
-                let companies = MiniEntry.companyRuns(entries)
-                HStack(spacing: 0) {
-                    ForEach(Array(companies.enumerated()), id: \.offset) { index, company in
-                        if index > 0 {
-                            Rectangle()
-                                .fill(Color.primary.opacity(0.12))
-                                .frame(width: MiniStripMetrics.dividerThickness, height: 16)
-                                .padding(.horizontal, MiniStripMetrics.companySpacing(density))
-                        }
+                let plan = MiniStripMetrics.gridPlan(
+                    count: entries.count,
+                    cellWidth: MiniStripMetrics.chipWidth(density),
+                    cellSpacing: MiniStripMetrics.chipSpacing(density)
+                )
+                VStack(alignment: .leading, spacing: MiniStripMetrics.rowGap) {
+                    ForEach(Array(entries.chunked(into: plan.perRow).enumerated()), id: \.offset) { _, band in
                         HStack(spacing: MiniStripMetrics.chipSpacing(density)) {
-                            ForEach(company) { entry in
+                            ForEach(band) { entry in
                                 lineCell(entry)
                             }
                         }
+                        .frame(height: MiniStripMetrics.rowHeight(density))
                     }
                 }
                 .padding(.leading, MiniStripMetrics.leadingPadding)
                 .padding(.trailing, MiniStripMetrics.trailingPadding)
             }
         }
-        .frame(height: MiniStripMetrics.height(density))
     }
 
     /// The menu bar's two-row layout, as a mini window: entries pair into
@@ -386,15 +395,25 @@ struct MiniStripLayout: View {
         let pairs = stride(from: 0, to: entries.count, by: 2).map { index in
             (top: entries[index], bottom: index + 1 < entries.count ? entries[index + 1] : nil)
         }
-        return HStack(spacing: MiniStripMetrics.pairedColumnSpacing) {
-            ForEach(Array(pairs.enumerated()), id: \.offset) { _, pair in
-                VStack(alignment: .leading, spacing: MiniStripMetrics.pairedRowSpacing) {
-                    pairedCell(pair.top, mode: mode)
-                    if let bottom = pair.bottom {
-                        pairedCell(bottom, mode: mode)
+        let plan = MiniStripMetrics.gridPlan(
+            count: pairs.count,
+            cellWidth: MiniStripMetrics.pairedColumnWidth,
+            cellSpacing: MiniStripMetrics.pairedColumnSpacing
+        )
+        return VStack(alignment: .leading, spacing: MiniStripMetrics.rowGap) {
+            ForEach(Array(pairs.chunked(into: plan.perRow).enumerated()), id: \.offset) { _, band in
+                HStack(spacing: MiniStripMetrics.pairedColumnSpacing) {
+                    ForEach(Array(band.enumerated()), id: \.offset) { _, pair in
+                        VStack(alignment: .leading, spacing: MiniStripMetrics.pairedRowSpacing) {
+                            pairedCell(pair.top, mode: mode)
+                            if let bottom = pair.bottom {
+                                pairedCell(bottom, mode: mode)
+                            }
+                        }
+                        .frame(width: MiniStripMetrics.pairedColumnWidth, alignment: .leading)
                     }
                 }
-                .frame(width: MiniStripMetrics.pairedColumnWidth, alignment: .leading)
+                .frame(height: MiniStripMetrics.rowHeight(.twoLine))
             }
         }
         .padding(.leading, MiniStripMetrics.leadingPadding)

--- a/Sources/VibeBarApp/Views/MiniWindowsSettingsSection.swift
+++ b/Sources/VibeBarApp/Views/MiniWindowsSettingsSection.swift
@@ -499,6 +499,9 @@ struct MiniWindowsSettingsSection: View {
         for index in settings.miniWindow.windows.indices {
             settings.miniWindow.windows[index].fieldIds.removeAll { $0 == fieldId }
             settings.miniWindow.windows[index].customLabels.removeValue(forKey: fieldId)
+            for mode in settings.miniWindow.windows[index].modeCustomLabels.keys {
+                settings.miniWindow.windows[index].modeCustomLabels[mode]?.removeValue(forKey: fieldId)
+            }
         }
         settingsStore.settings = settings
     }


### PR DESCRIPTION
Follow-ups for the post-merge bot threads on #247/#248:

1. **P1 — strip width capped** (#247): roomy/narrow cells and two-line column pairs now wrap into bands at 1,180pt; `MiniStripMetrics.size` accounts for rows, so a 22-field default selection can never produce a ~3,000pt panel.
2. **P1 — MenuBarFieldsEditor derivations cached** (#248): merged catalog + liveness live in `@State` refreshed on registry/quota publishes, mirroring the mini editor's discipline.
3. **P2 — keep set widened** (#248): menu bar `selectedFieldIds`/`customLabels` and all `modeCustomLabels`/`modeGroupLabels` keys anchor registry entries now.
4. **P2 — style-label lifecycle** (#248): both forget paths clear per-style labels.

The remaining #247 P2 (Gemini/Grok "All" groups) is answered in-thread: AQ explicitly requires the renamable All group for Gemini Web and defaults per his reference; declined with rationale.

## Validation
`swift build` ✓, `swift test` ✓ (1682), `./Scripts/build_app.sh release` ✓, empty entitlements ✓, deep signature ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)