### PR TITLE
Let each menu bar field choose label, logo, or both beside its percent

### DIFF
--- a/Sources/VibeBarApp/StatusItemController.swift
+++ b/Sources/VibeBarApp/StatusItemController.swift
@@ -53,6 +53,9 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
     private var blockWatchdog: MenuBarBlockWatchdog?
     /// Tab the next popover is built on. Overview outside demo mode.
     private var popoverInitialPage: OverviewPage = .overview
+    /// Rendered brand-logo images keyed by tool, point size, and appearance —
+    /// see `brandAttachment(for:fontSize:font:)`.
+    private var brandAttachmentImages: [String: NSImage?] = [:]
 
     init(environment: AppEnvironment) {
         self.environment = environment
@@ -833,7 +836,9 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
                 label: label(for: field, bucket: bucket, itemSettings: itemSettings),
                 percent: percent,
                 color: percentColor(for: field, bucket: bucket, settings: settings),
-                fontSize: fontSize
+                fontSize: fontSize,
+                style: itemSettings.style(for: field.id),
+                tool: field.tool
             )
         }
 
@@ -904,7 +909,9 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
                 label: label(for: field, bucket: bucket, itemSettings: itemSettings),
                 percent: percent,
                 color: percentColor(for: field, bucket: bucket, settings: settings),
-                fontSize: MenuBarStatusMetrics.twoRowFontSize
+                fontSize: MenuBarStatusMetrics.twoRowFontSize,
+                style: itemSettings.style(for: field.id),
+                tool: field.tool
             )
         }
     }
@@ -941,16 +948,33 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
         menuTextPiece(label: label, percent: percent, color: color, fontSize: fontSize)
     }
 
-    private func menuTextPiece(label: String, percent: Double?, color: NSColor, fontSize: CGFloat) -> NSAttributedString {
+    private func menuTextPiece(
+        label: String,
+        percent: Double?,
+        color: NSColor,
+        fontSize: CGFloat,
+        style: MenuBarFieldStyle = .labelAndPercent,
+        tool: ToolType? = nil
+    ) -> NSAttributedString {
         let baseFont = NSFont.systemFont(ofSize: fontSize, weight: .medium)
         let chunk = NSMutableAttributedString()
-        chunk.append(NSAttributedString(
-            string: "\(label) ",
-            attributes: [
-                .foregroundColor: NSColor.labelColor,
-                .font: baseFont
-            ]
-        ))
+        if style != .labelAndPercent, let tool,
+           let attachment = brandAttachment(for: tool, fontSize: fontSize, font: baseFont) {
+            chunk.append(attachment)
+            chunk.append(NSAttributedString(
+                string: " ",
+                attributes: [.font: NSFont.systemFont(ofSize: fontSize * 0.4)]
+            ))
+        }
+        if style != .logoAndPercent {
+            chunk.append(NSAttributedString(
+                string: "\(label) ",
+                attributes: [
+                    .foregroundColor: NSColor.labelColor,
+                    .font: baseFont
+                ]
+            ))
+        }
         if let percent {
             chunk.append(NSAttributedString(
                 string: "\(Int(percent.rounded()))%",
@@ -961,6 +985,34 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
             ))
         }
         return chunk
+    }
+
+    /// Brand-logo run for a text piece, vertically centered on the font's
+    /// cap height. Cached per (tool, point size, appearance) — the status
+    /// item re-renders on every quota publish and must not rasterize icons
+    /// per tick.
+    private func brandAttachment(for tool: ToolType, fontSize: CGFloat, font: NSFont) -> NSAttributedString? {
+        let side = (fontSize + 3).rounded()
+        let appearanceName = NSApp.effectiveAppearance.name.rawValue
+        let key = "\(tool.rawValue).\(side).\(appearanceName)"
+        let image: NSImage?
+        if let cached = brandAttachmentImages[key] {
+            image = cached
+        } else {
+            image = ProviderBrandIcon.image(
+                for: tool,
+                size: NSSize(width: side, height: side),
+                tint: NSColor.labelColor,
+                appearance: NSApp.effectiveAppearance
+            )
+            brandAttachmentImages[key] = image
+        }
+        guard let image else { return nil }
+        let attachment = NSTextAttachment()
+        attachment.image = image
+        let yOffset = (font.capHeight - side) / 2
+        attachment.bounds = CGRect(x: 0, y: yOffset, width: side, height: side)
+        return NSAttributedString(attachment: attachment)
     }
 
     private func installIconOnlyContent(

--- a/Sources/VibeBarApp/Views/MenuBarFieldsEditor.swift
+++ b/Sources/VibeBarApp/Views/MenuBarFieldsEditor.swift
@@ -150,6 +150,15 @@ struct MenuBarFieldsEditor: View {
                     .foregroundStyle(.tertiary)
             }
             Spacer(minLength: 6)
+            Picker("", selection: styleBinding(option)) {
+                ForEach(MenuBarFieldStyle.allCases) { style in
+                    Text(style.label).tag(style)
+                }
+            }
+            .pickerStyle(.menu)
+            .labelsHidden()
+            .frame(width: 108)
+            .help("How this field draws on the menu bar: its label, the provider's logo, or both — each beside the percent.")
             DebouncedSettingsTextField(
                 prompt: option.defaultLabel,
                 value: labelBinding(option)
@@ -319,6 +328,21 @@ struct MenuBarFieldsEditor: View {
             guard item.selectedFieldIds.indices.contains(target) else { return }
             item.selectedFieldIds.swapAt(index, target)
         }
+    }
+
+    private func styleBinding(_ option: MenuBarFieldOption) -> Binding<MenuBarFieldStyle> {
+        Binding(
+            get: { settingsStore.settings.menuBarItem(kind).style(for: option.id) },
+            set: { style in
+                updateItem { item in
+                    if style == .labelAndPercent {
+                        item.fieldStyles.removeValue(forKey: option.id)
+                    } else {
+                        item.fieldStyles[option.id] = style
+                    }
+                }
+            }
+        )
     }
 
     private func labelBinding(_ option: MenuBarFieldOption) -> Binding<String> {

--- a/Sources/VibeBarCore/Models/MenuBarSettings.swift
+++ b/Sources/VibeBarCore/Models/MenuBarSettings.swift
@@ -124,6 +124,34 @@ public enum MenuBarPercentColor: Equatable, Sendable {
     }
 }
 
+/// How one selected field draws itself on the status item: its label beside
+/// the percent (the default), the provider's logo instead of the label, or
+/// both. Chosen per field, so a crowded bar can shorten some quotas to a
+/// logo while the ambiguous ones keep their words.
+public enum MenuBarFieldStyle: String, Codable, CaseIterable, Identifiable, Sendable {
+    case labelAndPercent
+    case logoAndPercent
+    case logoLabelAndPercent
+
+    public var id: String { rawValue }
+
+    public var label: String {
+        switch self {
+        case .labelAndPercent: return "Label"
+        case .logoAndPercent: return "Logo"
+        case .logoLabelAndPercent: return "Logo and label"
+        }
+    }
+
+    public var detail: String {
+        switch self {
+        case .labelAndPercent: return "The field's name beside its percent."
+        case .logoAndPercent: return "The provider's logo beside the percent — no text."
+        case .logoLabelAndPercent: return "Logo, name, and percent."
+        }
+    }
+}
+
 public struct MenuBarItemSettings: Codable, Equatable, Identifiable, Sendable {
     public var kind: MenuBarItemKind
     public var isVisible: Bool
@@ -131,6 +159,8 @@ public struct MenuBarItemSettings: Codable, Equatable, Identifiable, Sendable {
     public var layout: MenuBarLayout
     public var selectedFieldIds: [String]
     public var customLabels: [String: String]
+    /// Per-field display style; a missing entry is `.labelAndPercent`.
+    public var fieldStyles: [String: MenuBarFieldStyle]
 
     public var id: MenuBarItemKind { kind }
 
@@ -140,7 +170,8 @@ public struct MenuBarItemSettings: Codable, Equatable, Identifiable, Sendable {
         showTitle: Bool,
         layout: MenuBarLayout = .singleLine,
         selectedFieldIds: [String],
-        customLabels: [String: String] = [:]
+        customLabels: [String: String] = [:],
+        fieldStyles: [String: MenuBarFieldStyle] = [:]
     ) {
         self.kind = kind
         self.isVisible = isVisible
@@ -148,6 +179,11 @@ public struct MenuBarItemSettings: Codable, Equatable, Identifiable, Sendable {
         self.layout = layout
         self.selectedFieldIds = selectedFieldIds
         self.customLabels = customLabels
+        self.fieldStyles = fieldStyles
+    }
+
+    public func style(for fieldId: String) -> MenuBarFieldStyle {
+        fieldStyles[fieldId] ?? .labelAndPercent
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -157,6 +193,7 @@ public struct MenuBarItemSettings: Codable, Equatable, Identifiable, Sendable {
         case layout
         case selectedFieldIds
         case customLabels
+        case fieldStyles
     }
 
     public init(from decoder: Decoder) throws {
@@ -168,6 +205,10 @@ public struct MenuBarItemSettings: Codable, Equatable, Identifiable, Sendable {
             ?? (kind == .compact ? .iconOnly : .singleLine)
         self.selectedFieldIds = try c.decodeIfPresent([String].self, forKey: .selectedFieldIds) ?? []
         self.customLabels = try c.decodeIfPresent([String: String].self, forKey: .customLabels) ?? [:]
+        // Lossy per entry: a style this build doesn't know falls back to the
+        // default instead of discarding the settings blob.
+        let rawStyles = try c.decodeIfPresent([String: String].self, forKey: .fieldStyles) ?? [:]
+        self.fieldStyles = rawStyles.compactMapValues(MenuBarFieldStyle.init(rawValue:))
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -178,6 +219,7 @@ public struct MenuBarItemSettings: Codable, Equatable, Identifiable, Sendable {
         try c.encode(layout, forKey: .layout)
         try c.encode(selectedFieldIds, forKey: .selectedFieldIds)
         try c.encode(customLabels, forKey: .customLabels)
+        try c.encode(fieldStyles, forKey: .fieldStyles)
     }
 }
 

--- a/Tests/VibeBarCoreTests/MenuBarSettingsTests.swift
+++ b/Tests/VibeBarCoreTests/MenuBarSettingsTests.swift
@@ -1,0 +1,39 @@
+import XCTest
+@testable import VibeBarCore
+
+final class MenuBarSettingsTests: XCTestCase {
+    func testFieldStylesRoundTripAndDefaultToLabel() throws {
+        var item = MenuBarItemSettings(
+            kind: .compact,
+            isVisible: true,
+            showTitle: false,
+            selectedFieldIds: ["claude.five_hour", "codex.weekly"]
+        )
+        item.fieldStyles["claude.five_hour"] = .logoAndPercent
+        let data = try JSONEncoder().encode(item)
+        let decoded = try JSONDecoder().decode(MenuBarItemSettings.self, from: data)
+        XCTAssertEqual(decoded.style(for: "claude.five_hour"), .logoAndPercent)
+        // A field with no entry draws the default label-and-percent style.
+        XCTAssertEqual(decoded.style(for: "codex.weekly"), .labelAndPercent)
+    }
+
+    func testUnknownFieldStyleFallsBackInsteadOfFailingDecode() throws {
+        let json = """
+        {"kind":"compact","isVisible":true,"showTitle":false,"layout":"singleLine",
+         "selectedFieldIds":["claude.five_hour"],"customLabels":{},
+         "fieldStyles":{"claude.five_hour":"holographic","codex.weekly":"logoAndPercent"}}
+        """
+        let decoded = try JSONDecoder().decode(MenuBarItemSettings.self, from: Data(json.utf8))
+        XCTAssertEqual(decoded.style(for: "claude.five_hour"), .labelAndPercent)
+        XCTAssertEqual(decoded.style(for: "codex.weekly"), .logoAndPercent)
+    }
+
+    func testPreStyleSettingsDecodeWithEmptyStyles() throws {
+        let json = """
+        {"kind":"compact","isVisible":true,"showTitle":true,"layout":"twoRows",
+         "selectedFieldIds":["claude.five_hour"],"customLabels":{}}
+        """
+        let decoded = try JSONDecoder().decode(MenuBarItemSettings.self, from: Data(json.utf8))
+        XCTAssertTrue(decoded.fieldStyles.isEmpty)
+    }
+}


### PR DESCRIPTION
AQ's request: the real menu bar's fields are all "label + percent" — make the display style a per-quota choice.

- New `MenuBarFieldStyle` per field id on `MenuBarItemSettings` (decode-compatible; unknown styles fall back per entry): **Label** (default) / **Logo** (provider logo + percent, no text) / **Logo and label**.
- All three text layouts (single line, two rows, compact) honor it; icon-only is unaffected.
- Logos render as `NSTextAttachment` runs vertically centered on the cap height, rasterized once per (tool, point size, appearance) and cached — the status item re-renders per quota publish.
- The Fields editor's shown rows gain a per-row style picker beside the rename field.

## Validation
- `swift build` ✓, `swift test` ✓ (1685 tests; +3 for round-trip, unknown-style fallback, pre-style decode)
- `./Scripts/build_app.sh release` ✓, empty entitlements ✓, deep signature ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)