### PR TITLE
Bound the session index and compact its 2.5GB of accumulated bloat

### DIFF
--- a/Sources/VibeBarApp/AppDelegate.swift
+++ b/Sources/VibeBarApp/AppDelegate.swift
@@ -48,6 +48,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         CookieRefreshScheduler.shared.start()
         observeCookieRefreshes(environment: env)
 
+        // Session-index maintenance (excerpt trims, FTS merge, vacuum) runs
+        // off the launch path: the Workbench may never open on a headless
+        // MCP-only day, so launch is the trigger that always exists. The
+        // compactor throttles itself to one completed pass per day.
+        Task.detached(priority: .utility) {
+            try? await Task.sleep(for: .seconds(60))
+            await SessionIndexCompactor.standard.compactIfDue()
+        }
+
         SafeLog.info("Vibe Bar started")
     }
 

--- a/Sources/VibeBarApp/Controllers/SessionManagerModel.swift
+++ b/Sources/VibeBarApp/Controllers/SessionManagerModel.swift
@@ -248,7 +248,16 @@ final class SessionManagerModel: ObservableObject {
             SessionIndexService(
                 homeDirectory: homeDirectory,
                 store: $0,
-                registry: registry,
+                // The indexer gets the bounded adapters: oversized rollouts
+                // are parsed from a head copy (memory) and excerpts are
+                // pre-trimmed to the host policy (index size). The raw
+                // `registry` stays for the transcript viewer and the
+                // deleter, which must see whole sessions.
+                registry: SessionIndexingBounds.boundedRegistry(
+                    registry,
+                    scratchDirectory: VibeBarLocalStore
+                        .sessionIndexScratchDirectoryURL(homeDirectory: homeDirectory)
+                ),
                 bodyIndexing: { flag.current }
             )
         }
@@ -302,6 +311,12 @@ final class SessionManagerModel: ObservableObject {
             self.lastScanFinishedAt = Date()
             self.reloadSummaryPage(reset: true)
             self.rerunSearch()
+            // A refresh is when churn lands in the index, so it is the
+            // natural moment to ask for maintenance. The compactor
+            // throttles itself; most calls return without touching SQLite.
+            Task.detached(priority: .utility) {
+                await SessionIndexCompactor.standard.compactIfDue()
+            }
         }
     }
 

--- a/Sources/VibeBarApp/MCPController.swift
+++ b/Sources/VibeBarApp/MCPController.swift
@@ -393,7 +393,13 @@ final class MCPController: ObservableObject, MCPDataSource {
             let service = SessionIndexService(
                 homeDirectory: home,
                 store: store,
-                registry: SessionProviderRegistry.standard(homeDirectory: home),
+                // Bounded like the Workbench's indexer: MCP-triggered
+                // backfills hit the same multi-hundred-MB rollouts.
+                registry: SessionIndexingBounds.boundedRegistry(
+                    SessionProviderRegistry.standard(homeDirectory: home),
+                    scratchDirectory: VibeBarLocalStore
+                        .sessionIndexScratchDirectoryURL(homeDirectory: home)
+                ),
                 bodyIndexing: { [bodyIndexing] in bodyIndexing.current }
             )
             sessionIndex = service

--- a/Sources/VibeBarCore/Services/SessionIndexCompactor.swift
+++ b/Sources/VibeBarCore/Services/SessionIndexCompactor.swift
@@ -95,6 +95,12 @@ public final class SessionIndexCompactor: @unchecked Sendable {
         }
     }
 
+    /// Test seam for the scratch sweep's containment rules — the sweep is
+    /// otherwise only reachable through a full pass over a live database.
+    public func sweepScratchForTesting(now: Date = Date()) {
+        sweepScratch(now: now)
+    }
+
     /// Runs a pass unconditionally (except for a missing database).
     public func compact(now: Date = Date()) async -> Outcome? {
         await onQueue { [self] in performCompact(now: now) }
@@ -345,16 +351,42 @@ public final class SessionIndexCompactor: @unchecked Sendable {
 
     /// Head copies are deleted by their creator; anything still here is a
     /// crash leftover once it is a day old.
+    ///
+    /// Containment before deletion, same discipline as `SessionDeleter`
+    /// (AGENTS.md § 5): an unsandboxed sweep must never follow a symlinked
+    /// scratch root into an arbitrary directory. The root has to be a real
+    /// directory — a symlink in its place is removed as a link and never
+    /// traversed — and enumerated entries are deleted only when they are
+    /// not themselves symlinks out of the scratch tree.
     private func sweepScratch(now: Date) {
         let fileManager = FileManager.default
+        let rootPath = scratchDirectoryURL.path
+        guard let rootType = (try? fileManager.attributesOfItem(atPath: rootPath))?[.type] as? FileAttributeType else {
+            return
+        }
+        guard rootType == .typeDirectory else {
+            // Whatever sits at the scratch path, it is not our directory —
+            // drop a symlink (the link itself, never its target) and refuse
+            // anything else.
+            if rootType == .typeSymbolicLink {
+                try? fileManager.removeItem(at: scratchDirectoryURL)
+            }
+            return
+        }
         guard let entries = try? fileManager.contentsOfDirectory(
             at: scratchDirectoryURL,
-            includingPropertiesForKeys: [.contentModificationDateKey],
+            includingPropertiesForKeys: [.contentModificationDateKey, .isSymbolicLinkKey],
             options: [.skipsHiddenFiles]
         ) else { return }
         for entry in entries {
-            let modified = (try? entry.resourceValues(forKeys: [.contentModificationDateKey]))?
-                .contentModificationDate ?? .distantPast
+            let values = try? entry.resourceValues(forKeys: [.contentModificationDateKey, .isSymbolicLinkKey])
+            if values?.isSymbolicLink == true {
+                // A planted link could point anywhere; removing it removes
+                // the link only, which is exactly what a sweep should do.
+                try? fileManager.removeItem(at: entry)
+                continue
+            }
+            let modified = values?.contentModificationDate ?? .distantPast
             if now.timeIntervalSince(modified) > 24 * 60 * 60 {
                 try? fileManager.removeItem(at: entry)
             }

--- a/Sources/VibeBarCore/Services/SessionIndexCompactor.swift
+++ b/Sources/VibeBarCore/Services/SessionIndexCompactor.swift
@@ -1,0 +1,459 @@
+import Foundation
+import SQLite3
+
+/// Keeps `~/.vibebar/session_index.sqlite3` at the size its content
+/// deserves.
+///
+/// Three things made the index grow to 2.5 GB on a busy machine, and each
+/// gets its own pass here:
+///
+/// 1. **Over-long excerpts.** The kit indexes up to 2 000 characters per
+///    message and 512 KiB per session; three quarters of that text was
+///    tool output. The *trim* pass re-asserts
+///    `SessionIndexExcerptPolicy` over rows already in the database —
+///    delete + re-insert, never `UPDATE`, because the FTS5 external-content
+///    table is synced by insert/delete triggers only.
+/// 2. **Stale FTS doclists.** Every append to a live session re-indexes it
+///    as delete-all + insert-all, and FTS5 keeps the superseded postings
+///    until segments merge. Nothing ever asked for a merge, so a third of
+///    the index was dead weight. The *merge* pass runs FTS5's documented
+///    incremental merge — one bounded transaction per step — until the
+///    index is a single segment.
+/// 3. **No reclamation.** The database predates `auto_vacuum`, so freed
+///    pages could never return to the filesystem. The first pass converts
+///    it with `auto_vacuum=INCREMENTAL` + one `VACUUM`; every later pass
+///    just runs bounded `incremental_vacuum` steps.
+///
+/// The index is derived data and this class only ever *removes* content
+/// the policy says is over budget, so a half-finished pass is harmless:
+/// the victim query is idempotent and the next pass continues where this
+/// one stopped. All work happens on a utility-QoS serial queue — never on
+/// the caller's executor — and every step is bounded so the kit's own
+/// writers only ever wait on a short transaction.
+public final class SessionIndexCompactor: @unchecked Sendable {
+    public struct Outcome: Sendable, Equatable {
+        public var sessionsTrimmed = 0
+        public var messagesDropped = 0
+        public var messagesTrimmed = 0
+        public var mergeSteps = 0
+        public var ranFullVacuum = false
+        public var bytesBefore: Int64 = 0
+        public var bytesAfter: Int64 = 0
+        /// `false` when the time budget ran out or a step hit a busy
+        /// database; the stamp is not written, so the next trigger retries.
+        public var completed = false
+    }
+
+    /// One compactor for the production database. Both trigger sites (app
+    /// launch and the Sessions page's refresh completion) share it, and the
+    /// serial queue underneath makes overlapping triggers wait, not race.
+    public static let standard = SessionIndexCompactor()
+
+    private let databaseURL: URL
+    private let stampURL: URL
+    private let scratchDirectoryURL: URL
+    private let policy: SessionIndexExcerptPolicy
+    private let queue: DispatchQueue
+
+    /// Floor between two completed passes. A policy-version change ignores it.
+    private let interval: TimeInterval
+    /// Wall-clock budget for one pass. The one-time migration of a
+    /// years-grown database fits (measured ≈ 6 minutes for 2.5 GB); a
+    /// steady-state pass uses seconds of it.
+    private let timeBudget: TimeInterval
+
+    /// The kit schema this class knows how to trim
+    /// (`SessionIndexStore.schemaVersion`). Any other version means the kit
+    /// has rebuilt or is about to rebuild the tables, and the only safe
+    /// move is to do nothing.
+    private static let supportedKitSchemaVersion: Int32 = 5
+
+    public init(
+        databaseURL: URL = VibeBarLocalStore.sessionIndexURL,
+        stampURL: URL = VibeBarLocalStore.sessionIndexMaintenanceStampURL,
+        scratchDirectoryURL: URL = VibeBarLocalStore.sessionIndexScratchDirectoryURL,
+        policy: SessionIndexExcerptPolicy = .standard,
+        interval: TimeInterval = 24 * 60 * 60,
+        timeBudget: TimeInterval = 10 * 60
+    ) {
+        self.databaseURL = databaseURL
+        self.stampURL = stampURL
+        self.scratchDirectoryURL = scratchDirectoryURL
+        self.policy = policy
+        self.interval = interval
+        self.timeBudget = timeBudget
+        self.queue = DispatchQueue(label: "vibebar.session-index-compactor", qos: .utility)
+    }
+
+    /// Runs a pass when the stamp says one is due; returns `nil` otherwise
+    /// (also when the database does not exist yet). Safe to call from
+    /// several places — calls serialize on the compactor's queue.
+    public func compactIfDue(now: Date = Date()) async -> Outcome? {
+        await onQueue { [self] in
+            guard isDue(now: now) else { return nil }
+            return performCompact(now: now)
+        }
+    }
+
+    /// Runs a pass unconditionally (except for a missing database).
+    public func compact(now: Date = Date()) async -> Outcome? {
+        await onQueue { [self] in performCompact(now: now) }
+    }
+
+    private func onQueue<T: Sendable>(_ work: @escaping @Sendable () -> T) async -> T {
+        await withCheckedContinuation { continuation in
+            queue.async { continuation.resume(returning: work()) }
+        }
+    }
+
+    // MARK: - Stamp
+
+    private struct Stamp: Codable {
+        var lastCompletedAt: Date
+        var policyVersion: Int
+    }
+
+    private func isDue(now: Date) -> Bool {
+        guard let data = try? Data(contentsOf: stampURL),
+              let stamp = try? JSONDecoder().decode(Stamp.self, from: data)
+        else { return true }
+        if stamp.policyVersion != SessionIndexExcerptPolicy.version { return true }
+        return now.timeIntervalSince(stamp.lastCompletedAt) >= interval
+    }
+
+    private func writeStamp(now: Date) {
+        let stamp = Stamp(lastCompletedAt: now, policyVersion: SessionIndexExcerptPolicy.version)
+        guard let data = try? JSONEncoder().encode(stamp) else { return }
+        try? FileManager.default.createDirectory(
+            at: stampURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700]
+        )
+        try? data.write(to: stampURL, options: [.atomic])
+        try? FileManager.default.setAttributes(
+            [.posixPermissions: 0o600], ofItemAtPath: stampURL.path
+        )
+    }
+
+    // MARK: - The pass
+
+    private func performCompact(now: Date) -> Outcome? {
+        sweepScratch(now: now)
+        guard FileManager.default.fileExists(atPath: databaseURL.path) else { return nil }
+        guard let db = Connection(url: databaseURL) else { return nil }
+        defer { db.close() }
+
+        var outcome = Outcome()
+        outcome.bytesBefore = db.int("PRAGMA page_count") * db.int("PRAGMA page_size")
+        let deadline = Date().addingTimeInterval(timeBudget)
+
+        guard db.int("PRAGMA user_version") == Int64(Self.supportedKitSchemaVersion),
+              db.hasTable("session_messages"), db.hasTable("session_fts")
+        else {
+            // Unknown schema: the kit owns it now. Leave the rows alone and
+            // do not stamp, so a pass runs once a supported schema is back.
+            return nil
+        }
+
+        let trimmedFully = trimPass(db, outcome: &outcome, deadline: deadline)
+        let mergedFully = trimmedFully && mergePass(db, outcome: &outcome, deadline: deadline)
+        let reclaimedFully = mergedFully && reclaimPass(db, outcome: &outcome, deadline: deadline)
+        db.exec("PRAGMA wal_checkpoint(TRUNCATE)")
+
+        outcome.bytesAfter = db.int("PRAGMA page_count") * db.int("PRAGMA page_size")
+        outcome.completed = reclaimedFully
+        if outcome.completed {
+            writeStamp(now: now)
+        }
+        SafeLog.info(
+            "Session index maintenance: trimmed \(outcome.sessionsTrimmed) sessions "
+                + "(-\(outcome.messagesDropped) rows, \(outcome.messagesTrimmed) shortened), "
+                + "\(outcome.mergeSteps) merge steps, "
+                + "\(outcome.ranFullVacuum ? "full" : "incremental") vacuum, "
+                + "\(outcome.bytesBefore / 1_048_576) MB -> \(outcome.bytesAfter / 1_048_576) MB"
+                + (outcome.completed ? "." : " (will resume).")
+        )
+        return outcome
+    }
+
+    // MARK: - Trim
+
+    /// Sessions per transaction. Small enough that the kit's own writers
+    /// (5-second busy timeout) never wait long, large enough to amortize
+    /// the commit.
+    private static let trimBatchSessions = 32
+
+    private func trimPass(_ db: Connection, outcome: inout Outcome, deadline: Date) -> Bool {
+        // Over-selection is fine (a compliant session is read and left
+        // alone); under-selection is not, so the predicates mirror the trim
+        // exactly: characters per role (+1 for the truncation ellipsis),
+        // UTF-8 bytes per session.
+        let victims = db.column(
+            """
+            SELECT session_row FROM session_messages
+             GROUP BY session_row
+             HAVING SUM(LENGTH(CAST(excerpt AS BLOB))) > ?1
+                 OR MAX(CASE WHEN role IN ('tool','system') THEN LENGTH(excerpt) ELSE 0 END) > ?2
+                 OR MAX(CASE WHEN role NOT IN ('tool','system') THEN LENGTH(excerpt) ELSE 0 END) > ?3
+            """,
+            binds: [
+                Int64(policy.sessionExcerptBytes),
+                Int64(policy.toolExcerptCharacters + 1),
+                Int64(policy.proseExcerptCharacters + 1)
+            ]
+        )
+        guard !victims.isEmpty else { return true }
+
+        for batch in stride(from: 0, to: victims.count, by: Self.trimBatchSessions) {
+            guard Date() < deadline else { return false }
+            let slice = victims[batch..<min(batch + Self.trimBatchSessions, victims.count)]
+            guard db.exec("BEGIN IMMEDIATE") else { return false }
+            var ok = true
+            for sessionRow in slice where ok {
+                ok = trim(sessionRow: sessionRow, in: db, outcome: &outcome)
+            }
+            guard ok, db.exec("COMMIT") else {
+                db.exec("ROLLBACK")
+                return false
+            }
+        }
+        return true
+    }
+
+    private struct MessageRow {
+        let id: Int64
+        let sessionRow: Int64
+        let seq: Int64
+        let role: String
+        let excerpt: String
+    }
+
+    private func trim(sessionRow: Int64, in db: Connection, outcome: inout Outcome) -> Bool {
+        // Re-read inside the transaction: the kit may have re-indexed this
+        // session (new row ids) between the victim query and now.
+        var rows: [MessageRow] = []
+        let read = db.query(
+            "SELECT id, session_row, seq, role, excerpt FROM session_messages WHERE session_row = ?1 ORDER BY seq, id",
+            binds: [sessionRow]
+        ) { statement in
+            rows.append(MessageRow(
+                id: sqlite3_column_int64(statement, 0),
+                sessionRow: sqlite3_column_int64(statement, 1),
+                seq: sqlite3_column_int64(statement, 2),
+                role: sqlite3_column_text(statement, 3).map { String(cString: $0) } ?? "",
+                excerpt: sqlite3_column_text(statement, 4).map { String(cString: $0) } ?? ""
+            ))
+        }
+        guard read else { return false }
+
+        var budget = policy.sessionExcerptBytes
+        var dropFrom: Int? = nil
+        var trims: [(row: MessageRow, text: String)] = []
+        for (index, row) in rows.enumerated() {
+            let role = SessionRole(rawValue: row.role) ?? .system
+            let cap = policy.excerptCharacters(for: role)
+            // `+ 1` for the ellipsis `truncate` appends: a row the kit (or a
+            // previous pass) already truncated to exactly cap+1 characters
+            // is compliant and must not be rewritten every day.
+            let needsTrim = row.excerpt.count > cap + 1
+            let text = needsTrim ? SessionParsing.truncate(row.excerpt, limit: cap) : row.excerpt
+            let cost = text.utf8.count
+            if cost > budget {
+                dropFrom = index
+                break
+            }
+            budget -= cost
+            if needsTrim { trims.append((row, text)) }
+        }
+
+        let dropped = dropFrom.map { Array(rows[$0...]) } ?? []
+        guard !dropped.isEmpty || !trims.isEmpty else { return true }
+
+        for row in dropped {
+            guard db.run("DELETE FROM session_messages WHERE id = ?1", binds: [row.id]) else { return false }
+        }
+        for (row, text) in trims {
+            // Delete + insert so the FTS triggers fire; an UPDATE would
+            // silently desynchronize the external-content index.
+            guard db.run("DELETE FROM session_messages WHERE id = ?1", binds: [row.id]),
+                  db.run(
+                    "INSERT INTO session_messages(id, session_row, seq, role, excerpt) VALUES(?1, ?2, ?3, ?4, ?5)",
+                    binds: [row.id, row.sessionRow, row.seq, row.role, text]
+                  )
+            else { return false }
+        }
+        outcome.sessionsTrimmed += 1
+        outcome.messagesDropped += dropped.count
+        outcome.messagesTrimmed += trims.count
+        return true
+    }
+
+    // MARK: - Merge
+
+    /// FTS5's incremental optimize: a negative argument schedules a merge
+    /// of *all* segments, then each positive call does about that many
+    /// pages of work in its own transaction. Done when a step changes
+    /// fewer than two rows.
+    private func mergePass(_ db: Connection, outcome: inout Outcome, deadline: Date) -> Bool {
+        guard db.exec("INSERT INTO session_fts(session_fts, rank) VALUES('merge', -500)") else {
+            return false
+        }
+        while outcome.mergeSteps < 100_000 {
+            guard Date() < deadline else { return false }
+            let before = db.totalChanges
+            guard db.exec("INSERT INTO session_fts(session_fts, rank) VALUES('merge', 500)") else {
+                return false
+            }
+            outcome.mergeSteps += 1
+            if db.totalChanges - before < 2 { return true }
+        }
+        return true
+    }
+
+    // MARK: - Reclaim
+
+    private func reclaimPass(_ db: Connection, outcome: inout Outcome, deadline: Date) -> Bool {
+        let pageSize = db.int("PRAGMA page_size")
+        if db.int("PRAGMA auto_vacuum") != 2 {
+            // One-time conversion. VACUUM rewrites the file, so demand the
+            // live bytes plus margin in free space, and accept that a busy
+            // writer can bounce it — the stamp stays unwritten and the next
+            // pass tries again.
+            let liveBytes = (db.int("PRAGMA page_count") - db.int("PRAGMA freelist_count")) * pageSize
+            guard freeDiskBytes() > liveBytes + 512 * 1_048_576 else { return false }
+            guard db.exec("PRAGMA auto_vacuum = INCREMENTAL"), db.exec("VACUUM") else {
+                return false
+            }
+            outcome.ranFullVacuum = true
+            return true
+        }
+        // 8 192 pages ≈ 32 MB returned per bounded step.
+        while db.int("PRAGMA freelist_count") > 1_024 {
+            guard Date() < deadline else { return false }
+            guard db.exec("PRAGMA incremental_vacuum(8192)") else { return false }
+        }
+        return true
+    }
+
+    private func freeDiskBytes() -> Int64 {
+        let values = try? databaseURL.deletingLastPathComponent()
+            .resourceValues(forKeys: [.volumeAvailableCapacityForImportantUsageKey])
+        return values?.volumeAvailableCapacityForImportantUsage ?? 0
+    }
+
+    // MARK: - Scratch sweep
+
+    /// Head copies are deleted by their creator; anything still here is a
+    /// crash leftover once it is a day old.
+    private func sweepScratch(now: Date) {
+        let fileManager = FileManager.default
+        guard let entries = try? fileManager.contentsOfDirectory(
+            at: scratchDirectoryURL,
+            includingPropertiesForKeys: [.contentModificationDateKey],
+            options: [.skipsHiddenFiles]
+        ) else { return }
+        for entry in entries {
+            let modified = (try? entry.resourceValues(forKeys: [.contentModificationDateKey]))?
+                .contentModificationDate ?? .distantPast
+            if now.timeIntervalSince(modified) > 24 * 60 * 60 {
+                try? fileManager.removeItem(at: entry)
+            }
+        }
+    }
+}
+
+// MARK: - SQLite plumbing
+
+/// Minimal wrapper over one read-write connection. Not shared with
+/// `TimelineSQLite` because this one must *not* create a missing database:
+/// no index means nothing to maintain.
+private final class Connection {
+    private let handle: OpaquePointer
+    private let transient = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
+
+    init?(url: URL) {
+        var opened: OpaquePointer?
+        guard sqlite3_open_v2(
+            url.path, &opened, SQLITE_OPEN_READWRITE | SQLITE_OPEN_FULLMUTEX, nil
+        ) == SQLITE_OK, let opened else {
+            if opened != nil { sqlite3_close_v2(opened) }
+            return nil
+        }
+        sqlite3_busy_timeout(opened, 5_000)
+        sqlite3_exec(opened, "PRAGMA journal_mode=WAL", nil, nil, nil)
+        sqlite3_exec(opened, "PRAGMA synchronous=NORMAL", nil, nil, nil)
+        handle = opened
+    }
+
+    func close() {
+        sqlite3_close_v2(handle)
+    }
+
+    var totalChanges: Int64 {
+        sqlite3_total_changes64(handle)
+    }
+
+    @discardableResult
+    func exec(_ sql: String) -> Bool {
+        sqlite3_exec(handle, sql, nil, nil, nil) == SQLITE_OK
+    }
+
+    func hasTable(_ name: String) -> Bool {
+        int("SELECT COUNT(*) FROM sqlite_schema WHERE name = '\(name)'") > 0
+    }
+
+    /// First column of the first row, or 0.
+    func int(_ sql: String) -> Int64 {
+        var statement: OpaquePointer?
+        guard sqlite3_prepare_v2(handle, sql, -1, &statement, nil) == SQLITE_OK, let statement else {
+            return 0
+        }
+        defer { sqlite3_finalize(statement) }
+        guard sqlite3_step(statement) == SQLITE_ROW else { return 0 }
+        return sqlite3_column_int64(statement, 0)
+    }
+
+    /// First column of every row.
+    func column(_ sql: String, binds: [Int64]) -> [Int64] {
+        var out: [Int64] = []
+        _ = query(sql, binds: binds) { out.append(sqlite3_column_int64($0, 0)) }
+        return out
+    }
+
+    func query(_ sql: String, binds: [Int64], row: (OpaquePointer) -> Void) -> Bool {
+        var statement: OpaquePointer?
+        guard sqlite3_prepare_v2(handle, sql, -1, &statement, nil) == SQLITE_OK, let statement else {
+            return false
+        }
+        defer { sqlite3_finalize(statement) }
+        for (index, value) in binds.enumerated() {
+            sqlite3_bind_int64(statement, Int32(index + 1), value)
+        }
+        while true {
+            switch sqlite3_step(statement) {
+            case SQLITE_ROW: row(statement)
+            case SQLITE_DONE: return true
+            default: return false
+            }
+        }
+    }
+
+    /// Mixed-type binds for the trim writes.
+    @discardableResult
+    func run(_ sql: String, binds: [Any]) -> Bool {
+        var statement: OpaquePointer?
+        guard sqlite3_prepare_v2(handle, sql, -1, &statement, nil) == SQLITE_OK, let statement else {
+            return false
+        }
+        defer { sqlite3_finalize(statement) }
+        for (index, value) in binds.enumerated() {
+            let position = Int32(index + 1)
+            switch value {
+            case let number as Int64: sqlite3_bind_int64(statement, position, number)
+            case let text as String: sqlite3_bind_text(statement, position, text, -1, transient)
+            default: sqlite3_bind_null(statement, position)
+            }
+        }
+        return sqlite3_step(statement) == SQLITE_DONE
+    }
+}

--- a/Sources/VibeBarCore/Services/SessionIndexExcerptPolicy.swift
+++ b/Sources/VibeBarCore/Services/SessionIndexExcerptPolicy.swift
@@ -1,0 +1,73 @@
+import Foundation
+
+/// How much of a transcript the session index is allowed to keep.
+///
+/// The index's schema and its 512 KiB / 2 000-character ceilings live in
+/// `agent-session-kit`; this policy is Vibe Bar's tighter, host-side budget
+/// on top of them. It exists because the FTS5 `trigram` tokenizer — the one
+/// tokenizer that makes CJK and identifier substring search work — costs
+/// roughly 3 bytes of index per character of text. At the kit's ceilings a
+/// year of heavy agent use produced a 2.5 GB `session_index.sqlite3` whose
+/// bulk was tool output: command dumps, file listings, build logs.
+///
+/// Two components enforce the same numbers:
+/// - `SessionIndexingBounds` trims transcripts on their way *into* the
+///   index (and caps how much of a multi-hundred-MB rollout is parsed at
+///   all, which is what bounds the indexer's memory);
+/// - `SessionIndexCompactor` re-asserts the caps over rows already *in*
+///   the index, so tightening a number here shrinks the existing database
+///   on the next maintenance pass instead of only affecting new sessions.
+public struct SessionIndexExcerptPolicy: Sendable, Equatable {
+    /// Characters kept of a tool or system excerpt. Tool output is three
+    /// quarters of all indexed text but almost never what a search is *for*;
+    /// 600 characters keeps the command line and the head of its output —
+    /// the part that identifies it — without indexing the whole dump.
+    public var toolExcerptCharacters: Int
+
+    /// Characters kept of a user or assistant excerpt. Matches the kit's
+    /// own per-message cap: prose is what searches target, so it is not
+    /// tightened here.
+    public var proseExcerptCharacters: Int
+
+    /// UTF-8 bytes of excerpt text kept per session, counted in message
+    /// order and stopping at the first message that does not fit — the same
+    /// stop-at-overflow shape as the kit's 512 KiB budget, just lower.
+    public var sessionExcerptBytes: Int
+
+    /// Transcripts larger than this are body-indexed from a copy of their
+    /// first `headParseByteLimit` bytes instead of the whole file. The
+    /// kit's parser materializes every message of a rollout before the
+    /// excerpt budget is applied, so parsing a 1.6 GB rollout means
+    /// gigabytes of transient strings; the session budget above is filled
+    /// by the first few hundred KiB anyway.
+    public var headParseByteLimit: Int64
+
+    public init(
+        toolExcerptCharacters: Int = 600,
+        proseExcerptCharacters: Int = 2_000,
+        sessionExcerptBytes: Int = 128 * 1024,
+        headParseByteLimit: Int64 = 64 * 1024 * 1024
+    ) {
+        self.toolExcerptCharacters = toolExcerptCharacters
+        self.proseExcerptCharacters = proseExcerptCharacters
+        self.sessionExcerptBytes = sessionExcerptBytes
+        self.headParseByteLimit = headParseByteLimit
+    }
+
+    public static let standard = SessionIndexExcerptPolicy()
+
+    /// Bump when the standard caps tighten (or loosen) so
+    /// `SessionIndexCompactor` re-runs its trim pass over existing rows
+    /// regardless of the daily throttle.
+    public static let version = 1
+
+    /// The excerpt cap for one message, by the role the index stores.
+    /// `.other` gets the tool cap because the kit files it as `system`
+    /// when it writes the row.
+    public func excerptCharacters(for role: SessionRole) -> Int {
+        switch role {
+        case .tool, .system, .other: return toolExcerptCharacters
+        case .user, .assistant: return proseExcerptCharacters
+        }
+    }
+}

--- a/Sources/VibeBarCore/Services/SessionIndexingBounds.swift
+++ b/Sources/VibeBarCore/Services/SessionIndexingBounds.swift
@@ -51,7 +51,8 @@ public enum SessionIndexingBounds {
     static func trimmed(
         _ document: TranscriptDocument,
         policy: SessionIndexExcerptPolicy,
-        headTruncated: Bool
+        headTruncated: Bool,
+        provider: SessionProvider
     ) -> TranscriptDocument {
         var kept: [SessionMessage] = []
         kept.reserveCapacity(document.messages.count)
@@ -59,8 +60,21 @@ public enum SessionIndexingBounds {
         var changed = false
         for message in document.messages {
             let cap = policy.excerptCharacters(for: message.role)
-            let text = SessionParsing.truncate(message.text, limit: cap)
+            // Provider envelopes come off before any cap. A Codex IDE
+            // prompt puts kilobytes of editor context ahead of the
+            // "## My request for Codex:" marker; truncating the raw text
+            // first would cut the marker and the actual request away, and
+            // the kit's own later normalization could then only index the
+            // context prefix. Same call the kit makes at index time.
+            var source = message.text
+            if provider == .codex {
+                source = CodexSessionAdapter.strippingIDEEnvelope(source)
+            }
+            let text = SessionParsing.truncate(source, limit: cap)
             if text != message.text { changed = true }
+            // `changed` compares against the raw message on purpose: an
+            // envelope strip with no truncation still needs a rebuilt
+            // document so the indexed text matches what was budgeted.
             let cost = text.utf8.count
             guard cost <= budget else {
                 changed = true
@@ -121,7 +135,7 @@ struct BoundedSessionAdapter: SessionProviderAdapter {
         } else {
             document = try inner.parseTranscript(fileURL: fileURL, range: nil)
         }
-        return SessionIndexingBounds.trimmed(document, policy: policy, headTruncated: headTruncated)
+        return SessionIndexingBounds.trimmed(document, policy: policy, headTruncated: headTruncated, provider: inner.provider)
     }
 
     /// Streams the first `headParseByteLimit` bytes into a scratch file.

--- a/Sources/VibeBarCore/Services/SessionIndexingBounds.swift
+++ b/Sources/VibeBarCore/Services/SessionIndexingBounds.swift
@@ -1,0 +1,156 @@
+import Foundation
+
+/// Bounds what `SessionIndexService` reads and keeps, per provider.
+///
+/// The kit's indexer asks an adapter for the *whole* transcript and only
+/// then applies its excerpt budget. Two costs follow at real-world sizes:
+///
+/// - **Memory.** `parseTranscript` materializes every message of the file
+///   before a single excerpt is taken. Codex rollouts on a busy machine
+///   exceed a gigabyte, and parsing one put the app's lifetime peak at
+///   1.5–1.9 GB. The excerpt budget is filled by the head of the
+///   transcript, so for oversized JSONL files the wrapper parses a copy of
+///   the head instead of the original.
+/// - **Index size.** Full-length tool output dominated a 2.5 GB index.
+///   The wrapper pre-trims every message to `SessionIndexExcerptPolicy`
+///   before the kit's own (looser) budget runs.
+///
+/// Only the *indexing* services get wrapped adapters. The transcript
+/// viewer and the deleter keep the raw registry: reading a session on
+/// screen should show all of it, and deletion plans must come from the
+/// adapter that owns the files.
+public enum SessionIndexingBounds {
+    /// Providers whose discovered session file is a JSONL log that can be
+    /// parsed from a byte-truncated copy (a partial trailing line is
+    /// skipped by the kit's line scanner). Grok's transcript lives in a
+    /// sibling file of the discovered one and the SQLite/protobuf-backed
+    /// providers cannot be truncated at a byte offset, so they are listed
+    /// out.
+    static let headTruncatableProviders: Set<SessionProvider> = [
+        .codex, .claude, .claudeCowork
+    ]
+
+    /// `registry`, with every adapter wrapped in the indexing bounds.
+    public static func boundedRegistry(
+        _ registry: SessionProviderRegistry,
+        policy: SessionIndexExcerptPolicy = .standard,
+        scratchDirectory: URL = VibeBarLocalStore.sessionIndexScratchDirectoryURL
+    ) -> SessionProviderRegistry {
+        SessionProviderRegistry(adapters: registry.adapters.map {
+            BoundedSessionAdapter(inner: $0, policy: policy, scratchDirectory: scratchDirectory)
+        })
+    }
+
+    // MARK: - Transcript trimming
+
+    /// `document` with the excerpt policy applied: per-message character
+    /// caps by role, then the per-session byte budget, stopping at the
+    /// first message that does not fit — the same stop-at-overflow shape
+    /// as the kit's own budget so search results stay a prefix of the
+    /// transcript.
+    static func trimmed(
+        _ document: TranscriptDocument,
+        policy: SessionIndexExcerptPolicy,
+        headTruncated: Bool
+    ) -> TranscriptDocument {
+        var kept: [SessionMessage] = []
+        kept.reserveCapacity(document.messages.count)
+        var budget = policy.sessionExcerptBytes
+        var changed = false
+        for message in document.messages {
+            let cap = policy.excerptCharacters(for: message.role)
+            let text = SessionParsing.truncate(message.text, limit: cap)
+            if text != message.text { changed = true }
+            let cost = text.utf8.count
+            guard cost <= budget else {
+                changed = true
+                break
+            }
+            budget -= cost
+            kept.append(text == message.text
+                ? message
+                : SessionMessage(seq: message.seq, role: message.role, text: text, timestamp: message.timestamp))
+        }
+        guard changed || headTruncated else { return document }
+        return TranscriptDocument(
+            messages: kept,
+            totalMessageCount: document.totalMessageCount,
+            truncated: document.truncated || headTruncated || kept.count < document.messages.count
+        )
+    }
+}
+
+/// One adapter, bounded. Everything except `parseTranscript` forwards.
+struct BoundedSessionAdapter: SessionProviderAdapter {
+    let inner: any SessionProviderAdapter
+    let policy: SessionIndexExcerptPolicy
+    let scratchDirectory: URL
+
+    var provider: SessionProvider { inner.provider }
+
+    func roots(homeDirectory: String) -> [URL] {
+        inner.roots(homeDirectory: homeDirectory)
+    }
+
+    func discoverSessionFiles(homeDirectory: String) -> [URL] {
+        inner.discoverSessionFiles(homeDirectory: homeDirectory)
+    }
+
+    func extractMetadata(fileURL: URL) throws -> SessionSummary {
+        try inner.extractMetadata(fileURL: fileURL)
+    }
+
+    func deletionPlan(for summary: SessionSummary, homeDirectory: String) throws -> SessionDeletionPlan {
+        try inner.deletionPlan(for: summary, homeDirectory: homeDirectory)
+    }
+
+    func parseTranscript(fileURL: URL, range: Range<Int>?) throws -> TranscriptDocument {
+        // An explicit range is a viewer-shaped read; only the indexer's
+        // whole-document read is bounded.
+        guard range == nil else {
+            return try inner.parseTranscript(fileURL: fileURL, range: range)
+        }
+        var headTruncated = false
+        var document: TranscriptDocument
+        if SessionIndexingBounds.headTruncatableProviders.contains(inner.provider),
+           SessionParsing.fileSize(fileURL) > policy.headParseByteLimit {
+            let head = try copyHead(of: fileURL)
+            defer { try? FileManager.default.removeItem(at: head) }
+            document = try inner.parseTranscript(fileURL: head, range: nil)
+            headTruncated = true
+        } else {
+            document = try inner.parseTranscript(fileURL: fileURL, range: nil)
+        }
+        return SessionIndexingBounds.trimmed(document, policy: policy, headTruncated: headTruncated)
+    }
+
+    /// Streams the first `headParseByteLimit` bytes into a scratch file.
+    /// Constant memory; the caller deletes the copy after parsing. Scratch
+    /// lives under `~/.vibebar` because that directory is the only place
+    /// the app writes; `SessionIndexCompactor` sweeps anything a crash
+    /// leaves behind.
+    private func copyHead(of fileURL: URL) throws -> URL {
+        try FileManager.default.createDirectory(
+            at: scratchDirectory,
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700]
+        )
+        let destination = scratchDirectory
+            .appendingPathComponent("head-\(UUID().uuidString).\(fileURL.pathExtension)")
+        let source = try FileHandle(forReadingFrom: fileURL)
+        defer { try? source.close() }
+        FileManager.default.createFile(atPath: destination.path, contents: nil, attributes: [.posixPermissions: 0o600])
+        let sink = try FileHandle(forWritingTo: destination)
+        defer { try? sink.close() }
+
+        var remaining = policy.headParseByteLimit
+        let chunk = 4 * 1024 * 1024
+        while remaining > 0 {
+            let want = Int(min(Int64(chunk), remaining))
+            guard let data = try source.read(upToCount: want), !data.isEmpty else { break }
+            try sink.write(contentsOf: data)
+            remaining -= Int64(data.count)
+        }
+        return destination
+    }
+}

--- a/Sources/VibeBarCore/Storage/VibeBarLocalStore.swift
+++ b/Sources/VibeBarCore/Storage/VibeBarLocalStore.swift
@@ -146,6 +146,28 @@ public enum VibeBarLocalStore {
         baseDirectory.appendingPathComponent("session_index.sqlite3")
     }
 
+    /// `SessionIndexCompactor`'s throttle stamp: when the last maintenance
+    /// pass over `session_index.sqlite3` completed and under which
+    /// `SessionIndexExcerptPolicy.version`. Its own file so maintenance
+    /// never rewrites the settings blob.
+    public static var sessionIndexMaintenanceStampURL: URL {
+        baseDirectory.appendingPathComponent("session_index_maintenance.json")
+    }
+
+    /// Scratch directory for `SessionIndexingBounds`' head copies of
+    /// oversized rollouts. Under `~/.vibebar` because that is the only
+    /// directory the app writes; the compactor sweeps leftovers.
+    public static var sessionIndexScratchDirectoryURL: URL {
+        sessionIndexScratchDirectoryURL(homeDirectory: RealHomeDirectory.path)
+    }
+
+    /// Explicit-home variant, so a caller built around a synthetic home
+    /// (tests, demo trees) never scratches in the real one.
+    public static func sessionIndexScratchDirectoryURL(homeDirectory: String) -> URL {
+        baseDirectory(homeDirectory: homeDirectory)
+            .appendingPathComponent("session_index_scratch", isDirectory: true)
+    }
+
     /// Skills manager registry: which skills are installed in the SSOT
     /// (`~/.agents/skills`) and how each one is materialized per agent CLI.
     /// The skill payloads themselves live in the SSOT, not here.

--- a/Tests/VibeBarCoreTests/SessionIndexCompactorTests.swift
+++ b/Tests/VibeBarCoreTests/SessionIndexCompactorTests.swift
@@ -1,0 +1,156 @@
+import SQLite3
+import XCTest
+@testable import VibeBarCore
+
+final class SessionIndexCompactorTests: XCTestCase {
+    private var directory: URL!
+
+    override func setUpWithError() throws {
+        directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("VibeBarSessionIndexCompactor-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: directory)
+    }
+
+    private var databaseURL: URL { directory.appendingPathComponent("session_index.sqlite3") }
+    private var stampURL: URL { directory.appendingPathComponent("stamp.json") }
+    private var scratchURL: URL { directory.appendingPathComponent("scratch", isDirectory: true) }
+
+    private func makeCompactor(
+        policy: SessionIndexExcerptPolicy = SessionIndexExcerptPolicy(
+            toolExcerptCharacters: 100,
+            proseExcerptCharacters: 200,
+            sessionExcerptBytes: 4_096
+        )
+    ) -> SessionIndexCompactor {
+        SessionIndexCompactor(
+            databaseURL: databaseURL,
+            stampURL: stampURL,
+            scratchDirectoryURL: scratchURL,
+            policy: policy
+        )
+    }
+
+    private func seedStore() async throws -> SessionIndexStore {
+        let store = try SessionIndexStore(url: databaseURL)
+        let summary = SessionSummary(
+            provider: .codex,
+            sessionID: "0000-test",
+            sourcePath: "/Users/example/.codex/sessions/rollout-test.jsonl"
+        )
+        let row = try await store.upsertSession(summary)
+        // One over-long tool excerpt carrying a unique marker beyond the
+        // 100-character cap, one compliant user excerpt, and a run of tool
+        // excerpts that blows the 4 KiB per-session budget.
+        var excerpts: [SessionIndexStore.MessageExcerpt] = [
+            .init(seq: 0, role: .user, excerpt: "please summarize the zebra migration"),
+            .init(
+                seq: 1,
+                role: .tool,
+                excerpt: String(repeating: "x", count: 300) + " QUAGGAMARKER tail"
+            )
+        ]
+        for seq in 2..<60 {
+            excerpts.append(.init(seq: seq, role: .tool, excerpt: String(repeating: "y", count: 90)))
+        }
+        try await store.replaceMessages(sessionRow: row, excerpts: excerpts)
+        return store
+    }
+
+    func testCompactTrimsMergesAndVacuums() async throws {
+        let store = try await seedStore()
+        let compactor = makeCompactor()
+
+        let maybeOutcome = await compactor.compact()
+        let outcome = try XCTUnwrap(maybeOutcome)
+        XCTAssertTrue(outcome.completed)
+        XCTAssertEqual(outcome.sessionsTrimmed, 1)
+        XCTAssertEqual(outcome.messagesTrimmed, 1, "only the 300-char tool excerpt exceeds its cap")
+        XCTAssertGreaterThan(outcome.messagesDropped, 0, "the budget stop drops the tail")
+        XCTAssertTrue(outcome.ranFullVacuum, "first pass converts the database to auto_vacuum")
+        XCTAssertGreaterThan(outcome.mergeSteps, 0)
+
+        // Content within the caps stays searchable; content beyond them is gone.
+        let kept = try await store.search(text: "zebra migration")
+        XCTAssertEqual(kept.count, 1)
+        let trimmedAway = try await store.search(text: "QUAGGAMARKER", scopes: [.tool])
+        XCTAssertTrue(trimmedAway.isEmpty, "text beyond the tool cap must leave the index")
+
+        // The budget stop keeps a prefix: total stored bytes obey the budget.
+        let remaining = try await store.messageCount()
+        XCTAssertLessThan(remaining, 60)
+        XCTAssertGreaterThan(remaining, 0)
+
+        // A second pass finds nothing to do.
+        let maybeSecond = await compactor.compact()
+        let second = try XCTUnwrap(maybeSecond)
+        XCTAssertTrue(second.completed)
+        XCTAssertEqual(second.sessionsTrimmed, 0)
+        XCTAssertEqual(second.messagesDropped, 0)
+        XCTAssertEqual(second.messagesTrimmed, 0)
+        XCTAssertFalse(second.ranFullVacuum, "auto_vacuum is already incremental")
+    }
+
+    func testCompactIfDueHonorsStamp() async throws {
+        _ = try await seedStore()
+        let compactor = makeCompactor()
+
+        let first = await compactor.compactIfDue()
+        XCTAssertNotNil(first)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: stampURL.path))
+
+        let throttled = await compactor.compactIfDue()
+        XCTAssertNil(throttled, "a completed pass parks the compactor for the interval")
+
+        // A stale stamp (or a bumped policy version) makes it due again.
+        try FileManager.default.removeItem(at: stampURL)
+        let rerun = await compactor.compactIfDue()
+        XCTAssertNotNil(rerun)
+    }
+
+    func testMissingDatabaseDoesNothing() async {
+        let compactor = makeCompactor()
+        let outcome = await compactor.compact()
+        XCTAssertNil(outcome)
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: databaseURL.path),
+            "maintenance must never create the database"
+        )
+    }
+
+    func testUnsupportedSchemaVersionLeavesRowsAlone() async throws {
+        let store = try await seedStore()
+        let before = try await store.messageCount()
+
+        var handle: OpaquePointer?
+        XCTAssertEqual(sqlite3_open(databaseURL.path, &handle), SQLITE_OK)
+        XCTAssertEqual(sqlite3_exec(handle, "PRAGMA user_version = 99", nil, nil, nil), SQLITE_OK)
+        sqlite3_close_v2(handle)
+
+        let outcome = await makeCompactor().compact()
+        XCTAssertNil(outcome, "an unknown kit schema is not ours to rewrite")
+        let after = try await store.messageCount()
+        XCTAssertEqual(before, after)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: stampURL.path))
+    }
+
+    func testSweepRemovesStaleScratchFiles() async throws {
+        _ = try await seedStore()
+        try FileManager.default.createDirectory(at: scratchURL, withIntermediateDirectories: true)
+        let stale = scratchURL.appendingPathComponent("head-old.jsonl")
+        let fresh = scratchURL.appendingPathComponent("head-new.jsonl")
+        try Data("old".utf8).write(to: stale)
+        try Data("new".utf8).write(to: fresh)
+        try FileManager.default.setAttributes(
+            [.modificationDate: Date().addingTimeInterval(-3 * 24 * 60 * 60)],
+            ofItemAtPath: stale.path
+        )
+
+        _ = await makeCompactor().compact()
+        XCTAssertFalse(FileManager.default.fileExists(atPath: stale.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: fresh.path))
+    }
+}

--- a/Tests/VibeBarCoreTests/SessionIndexCompactorTests.swift
+++ b/Tests/VibeBarCoreTests/SessionIndexCompactorTests.swift
@@ -153,4 +153,53 @@ final class SessionIndexCompactorTests: XCTestCase {
         XCTAssertFalse(FileManager.default.fileExists(atPath: stale.path))
         XCTAssertTrue(FileManager.default.fileExists(atPath: fresh.path))
     }
+    func testScratchSweepRefusesSymlinkedRootAndSkipsSymlinkedEntries() throws {
+        let fileManager = FileManager.default
+        let base = fileManager.temporaryDirectory
+            .appendingPathComponent("VibeBarScratchSymlink-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fileManager.removeItem(at: base) }
+        let home = base.appendingPathComponent("home", isDirectory: true)
+        let victim = base.appendingPathComponent("victim", isDirectory: true)
+        try fileManager.createDirectory(
+            at: home.appendingPathComponent(".vibebar", isDirectory: true),
+            withIntermediateDirectories: true
+        )
+        try fileManager.createDirectory(at: victim, withIntermediateDirectories: true)
+        let victimFile = victim.appendingPathComponent("keep.txt")
+        try Data("precious".utf8).write(to: victimFile)
+        try fileManager.setAttributes(
+            [.modificationDate: Date(timeIntervalSinceNow: -3 * 86_400)],
+            ofItemAtPath: victimFile.path
+        )
+
+        // A symlink planted where the scratch root should be must be removed
+        // as a link — its target untouched.
+        let scratch = VibeBarLocalStore.sessionIndexScratchDirectoryURL(homeDirectory: home.path)
+        try fileManager.createSymbolicLink(at: scratch, withDestinationURL: victim)
+        let compactor = SessionIndexCompactor(
+            databaseURL: base.appendingPathComponent("absent.sqlite3"),
+            stampURL: base.appendingPathComponent("stamp.json"),
+            scratchDirectoryURL: scratch
+        )
+        compactor.sweepScratchForTesting(now: Date())
+        XCTAssertTrue(fileManager.fileExists(atPath: victimFile.path), "the sweep must never follow a symlinked root")
+        var isDirectory: ObjCBool = false
+        XCTAssertFalse(
+            fileManager.fileExists(atPath: scratch.path, isDirectory: &isDirectory)
+                && !isDirectory.boolValue,
+            "the planted link itself should be gone"
+        )
+
+        // A symlinked entry inside a real scratch root is dropped as a link.
+        try fileManager.createDirectory(at: scratch, withIntermediateDirectories: true)
+        let plantedLink = scratch.appendingPathComponent("escape")
+        try fileManager.createSymbolicLink(at: plantedLink, withDestinationURL: victim)
+        try fileManager.setAttributes(
+            [.modificationDate: Date(timeIntervalSinceNow: -3 * 86_400)],
+            ofItemAtPath: plantedLink.path
+        )
+        compactor.sweepScratchForTesting(now: Date())
+        XCTAssertTrue(fileManager.fileExists(atPath: victimFile.path))
+        XCTAssertNil(try? fileManager.destinationOfSymbolicLink(atPath: plantedLink.path))
+    }
 }

--- a/Tests/VibeBarCoreTests/SessionIndexingBoundsTests.swift
+++ b/Tests/VibeBarCoreTests/SessionIndexingBoundsTests.swift
@@ -35,7 +35,7 @@ final class SessionIndexingBoundsTests: XCTestCase {
             truncated: false
         )
 
-        let trimmed = SessionIndexingBounds.trimmed(document, policy: policy, headTruncated: false)
+        let trimmed = SessionIndexingBounds.trimmed(document, policy: policy, headTruncated: false, provider: .claude)
         // user 40→21 ("…" included), tool 40→11, assistant 5; the fourth
         // message (21 bytes… the ellipsis is 3 UTF-8 bytes, so 20+3=23)
         // would push past the 60-byte budget and everything stops there.
@@ -57,7 +57,7 @@ final class SessionIndexingBoundsTests: XCTestCase {
             totalMessageCount: 2,
             truncated: false
         )
-        let trimmed = SessionIndexingBounds.trimmed(document, policy: .standard, headTruncated: false)
+        let trimmed = SessionIndexingBounds.trimmed(document, policy: .standard, headTruncated: false, provider: .claude)
         XCTAssertEqual(trimmed, document)
     }
 
@@ -145,5 +145,25 @@ final class SessionIndexingBoundsTests: XCTestCase {
         )
         XCTAssertEqual(bounded.providers, registry.providers)
         XCTAssertTrue(bounded.adapters.allSatisfy { $0 is BoundedSessionAdapter })
+    }
+    func testCodexIDEEnvelopeIsStrippedBeforeTheCap() {
+        // Kilobytes of editor context ahead of the marker: a raw-text cap
+        // would cut both the marker and the request away and the index
+        // would only ever see the context prefix.
+        let context = "# Context from my IDE setup:\n" + String(repeating: "x", count: 5_000)
+        let raw = context + "\n## My request for Codex:\nfind the flaky retry test"
+        let document = TranscriptDocument(
+            messages: [SessionMessage(seq: 0, role: .user, text: raw, timestamp: nil)],
+            totalMessageCount: 1,
+            truncated: false
+        )
+        let trimmed = SessionIndexingBounds.trimmed(
+            document, policy: .standard, headTruncated: false, provider: .codex
+        )
+        XCTAssertTrue(
+            trimmed.messages.first?.text.contains("find the flaky retry test") ?? false,
+            "the user's actual request must survive the excerpt cap"
+        )
+        XCTAssertFalse(trimmed.messages.first?.text.hasPrefix("xxxx") ?? true)
     }
 }

--- a/Tests/VibeBarCoreTests/SessionIndexingBoundsTests.swift
+++ b/Tests/VibeBarCoreTests/SessionIndexingBoundsTests.swift
@@ -1,0 +1,149 @@
+import XCTest
+@testable import VibeBarCore
+
+final class SessionIndexingBoundsTests: XCTestCase {
+    private var directory: URL!
+
+    override func setUpWithError() throws {
+        directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("VibeBarSessionIndexingBounds-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: directory)
+    }
+
+    private var scratchURL: URL { directory.appendingPathComponent("scratch", isDirectory: true) }
+
+    // MARK: - Document trimming
+
+    func testTrimmedCapsMessagesByRoleAndStopsAtBudget() {
+        let policy = SessionIndexExcerptPolicy(
+            toolExcerptCharacters: 10,
+            proseExcerptCharacters: 20,
+            sessionExcerptBytes: 60
+        )
+        let document = TranscriptDocument(
+            messages: [
+                SessionMessage(seq: 0, role: .user, text: String(repeating: "u", count: 40), timestamp: nil),
+                SessionMessage(seq: 1, role: .tool, text: String(repeating: "t", count: 40), timestamp: nil),
+                SessionMessage(seq: 2, role: .assistant, text: "short", timestamp: nil),
+                SessionMessage(seq: 3, role: .user, text: String(repeating: "z", count: 40), timestamp: nil)
+            ],
+            totalMessageCount: 4,
+            truncated: false
+        )
+
+        let trimmed = SessionIndexingBounds.trimmed(document, policy: policy, headTruncated: false)
+        // user 40→21 ("…" included), tool 40→11, assistant 5; the fourth
+        // message (21 bytes… the ellipsis is 3 UTF-8 bytes, so 20+3=23)
+        // would push past the 60-byte budget and everything stops there.
+        XCTAssertEqual(trimmed.messages.count, 3)
+        XCTAssertEqual(trimmed.messages[0].text.count, 21)
+        XCTAssertTrue(trimmed.messages[0].text.hasSuffix("…"))
+        XCTAssertEqual(trimmed.messages[1].text.count, 11)
+        XCTAssertEqual(trimmed.messages[2].text, "short")
+        XCTAssertTrue(trimmed.truncated)
+        XCTAssertEqual(trimmed.totalMessageCount, 4)
+    }
+
+    func testTrimmedLeavesCompliantDocumentAlone() {
+        let document = TranscriptDocument(
+            messages: [
+                SessionMessage(seq: 0, role: .user, text: "hello", timestamp: nil),
+                SessionMessage(seq: 1, role: .tool, text: "[Tool: ls]", timestamp: nil)
+            ],
+            totalMessageCount: 2,
+            truncated: false
+        )
+        let trimmed = SessionIndexingBounds.trimmed(document, policy: .standard, headTruncated: false)
+        XCTAssertEqual(trimmed, document)
+    }
+
+    // MARK: - Head-bounded parsing
+
+    private func codexLine(role: String, text: String) -> String {
+        let payload: [String: Any] = [
+            "type": "message",
+            "role": role,
+            "content": [["type": "input_text", "text": text]]
+        ]
+        let object: [String: Any] = ["type": "response_item", "payload": payload]
+        let data = try! JSONSerialization.data(withJSONObject: object)
+        return String(data: data, encoding: .utf8)!
+    }
+
+    func testOversizedCodexRolloutParsesHeadOnly() throws {
+        // Two real messages; a head limit that ends inside the second line,
+        // so only the first survives (the partial trailing line is skipped).
+        let first = codexLine(role: "user", text: "alpha bravo charlie")
+        let second = codexLine(role: "assistant", text: "delta echo foxtrot")
+        let fileURL = directory.appendingPathComponent("rollout-big.jsonl")
+        try Data((first + "\n" + second + "\n").utf8).write(to: fileURL)
+
+        var policy = SessionIndexExcerptPolicy.standard
+        policy.headParseByteLimit = Int64(first.utf8.count + 10)
+        let adapter = BoundedSessionAdapter(
+            inner: CodexSessionAdapter(homeDirectory: directory.path),
+            policy: policy,
+            scratchDirectory: scratchURL
+        )
+
+        let document = try adapter.parseTranscript(fileURL: fileURL, range: nil)
+        XCTAssertEqual(document.messages.map(\.text), ["alpha bravo charlie"])
+        XCTAssertTrue(document.truncated)
+
+        // The head copy is scratch, and it must not outlive the parse.
+        let leftovers = (try? FileManager.default.contentsOfDirectory(atPath: scratchURL.path)) ?? []
+        XCTAssertTrue(leftovers.isEmpty)
+    }
+
+    func testSmallRolloutParsesWholeFile() throws {
+        let first = codexLine(role: "user", text: "alpha bravo charlie")
+        let second = codexLine(role: "assistant", text: "delta echo foxtrot")
+        let fileURL = directory.appendingPathComponent("rollout-small.jsonl")
+        try Data((first + "\n" + second + "\n").utf8).write(to: fileURL)
+
+        let adapter = BoundedSessionAdapter(
+            inner: CodexSessionAdapter(homeDirectory: directory.path),
+            policy: .standard,
+            scratchDirectory: scratchURL
+        )
+        let document = try adapter.parseTranscript(fileURL: fileURL, range: nil)
+        XCTAssertEqual(
+            document.messages.map(\.text),
+            ["alpha bravo charlie", "delta echo foxtrot"]
+        )
+        XCTAssertFalse(document.truncated)
+    }
+
+    func testExplicitRangeBypassesTheBounds() throws {
+        // A viewer-shaped read (range != nil) must see the full text even
+        // when it exceeds every indexing cap.
+        let long = String(repeating: "verbose tool output ", count: 500)
+        let line = codexLine(role: "assistant", text: long)
+        let fileURL = directory.appendingPathComponent("rollout-view.jsonl")
+        try Data((line + "\n").utf8).write(to: fileURL)
+
+        var policy = SessionIndexExcerptPolicy.standard
+        policy.proseExcerptCharacters = 10
+        let adapter = BoundedSessionAdapter(
+            inner: CodexSessionAdapter(homeDirectory: directory.path),
+            policy: policy,
+            scratchDirectory: scratchURL
+        )
+        let document = try adapter.parseTranscript(fileURL: fileURL, range: 0..<1)
+        XCTAssertEqual(document.messages.first?.text, long)
+    }
+
+    func testBoundedRegistryKeepsProvidersAndOrder() {
+        let registry = SessionProviderRegistry.standard(homeDirectory: directory.path)
+        let bounded = SessionIndexingBounds.boundedRegistry(
+            registry,
+            scratchDirectory: scratchURL
+        )
+        XCTAssertEqual(bounded.providers, registry.providers)
+        XCTAssertTrue(bounded.adapters.allSatisfy { $0 is BoundedSessionAdapter })
+    }
+}


### PR DESCRIPTION
Closes the session-index investigation: `~/.vibebar/session_index.sqlite3` had reached **2.5GB** on AQ's machine and the app's memory peaked at 1.5–1.9GB.

## Root cause (measured on the real DB, read-only)
- `session_fts_data` = 1,771MB (70%): FTS5 **trigram** index ≈3 bytes per char — the price of CJK/identifier substring search (kept; changing the tokenizer breaks the kit's MATCH queries).
- 75% of indexed text is **tool output** (306MB of 409MB) under generous per-message caps.
- Appends re-index whole sessions as delete-all+insert-all and nothing ever merged: ~600MB of superseded doclists (`optimize` alone freed 594MB); `auto_vacuum` was 0 so pages never returned to the filesystem. Zero orphan rows — pruning was fine.
- Memory: parsing oversized JSONL rollouts (one is 1.6GB; 75 files >64MB) materializes the whole transcript.

## Fix (host-side; pinned agent-session-kit untouched)
- **SessionIndexExcerptPolicy** (versioned): tool/system 600 chars, user/assistant 2,000, 128KiB/session, 64MB head-parse limit.
- **SessionIndexingBounds**: decorator used only by the indexing services — streamed head copies for oversized rollouts (indexer memory bounded) + policy pre-trim. Viewer/deleter keep full-fidelity reads.
- **SessionIndexCompactor**: daily, own utility-QoS connection — policy trim over existing rows (delete+reinsert in 32-session transactions; FTS sync is trigger-based), bounded FTS5 `merge` steps, one-time `auto_vacuum=INCREMENTAL`+`VACUUM` (disk-headroom-gated), `incremental_vacuum` thereafter; time-budgeted, resume-safe, unknown-schema-guarded, stamped in `session_index_maintenance.json`. Triggered ~60s after launch and after index refreshes.

## Validation (agent-implemented, orchestrator re-verified independently)
- `swift build` ✓, `swift test` ✓ (**1693 tests**, 11 compactor + bounds tests new), release bundle + empty entitlements + deep signature ✓.
- **Dry run of the production compactor against a `VACUUM INTO` copy of the real DB**: 2,529MB → 1,051MB (−58%) in one 200s pass; `integrity_check` ok, FTS integrity ok, all 12,852 sessions retained, search verified. The bloated production file migrates in place on first run — no re-parse, no launch blocking.
- Writes stay inside `~/.vibebar/` (stamp + scratch dir, swept); real-home access via `RealHomeDirectory` routing only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)