### PR TITLE
Bump build number to 51 for the next Dev release

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.4.1</string>
 	<key>CFBundleVersion</key>
-	<string>50</string>
+	<string>51</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>26.0</string>
 	<key>LSUIElement</key>


### PR DESCRIPTION
Build bump for the Dev-channel release `v1.4.1-dev.51` (version stays 1.4.1).

Ships the whole feedback round on top of dev.50: mini layout alignment (#247), menu bar editor + per-style names + double-click cycle + caption typography (#248), reset surfaces refine with hover cards, group cards, and a real calendar (#249), bot follow-ups (#250), per-field menu bar styles (#251), and the session-index bloat fix — 2.5GB → ~1.05GB with bounded indexing (#252).

After merge: tag `v1.4.1-dev.51` → release workflow → verify draft (3 assets, ZIP SHA-256, dev channel) → publish as prerelease → verify feed Dev head 51.

Validation: `swift build` ✓, `swift test` ✓ (1698 tests), bundle 1.4.1 (51) ✓, empty entitlements ✓, deep signature ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)