### PR TITLE
Keep the strip one line, tier the ledger, scale the calendar

### DIFF
--- a/Sources/VibeBarApp/Views/MiniWindowAltLayouts.swift
+++ b/Sources/VibeBarApp/Views/MiniWindowAltLayouts.swift
@@ -23,18 +23,24 @@ struct MiniEntry: Identifiable {
 
     var id: String { field.id }
 
-    /// Row label for list-style layouts: the custom label wins; otherwise a
-    /// grouped bucket reads "Spark · Weekly" and a primary one reads its
-    /// window. Never an invented abbreviation — "WK" is a name the user can
-    /// choose, not a default they get.
-    var rowLabel: String {
+    /// The bucket-level name: a custom label renames exactly this level.
+    var bucketDisplayName: String {
         if let customLabel, !customLabel.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             return customLabel
         }
-        if let groupLabel {
-            return "\(groupLabel) · \(bucket.title)"
-        }
         return bucket.title
+    }
+
+    /// Row label for list-style layouts: always the quota-axis path, with a
+    /// custom label renaming the bucket level only — "All · Weekly" stays
+    /// "All · <custom>" rather than collapsing to the custom text. Years of
+    /// stored field labels literally say "Weekly"; letting them swallow the
+    /// group made every row identical.
+    var rowLabel: String {
+        if let groupLabel {
+            return "\(groupLabel) · \(bucketDisplayName)"
+        }
+        return bucketDisplayName
     }
 
     static func entries(
@@ -90,6 +96,20 @@ struct MiniEntry: Identifiable {
                 runs[runs.count - 1].append(entry)
             } else {
                 runs.append([entry])
+            }
+        }
+        return runs
+    }
+
+    /// Consecutive entries of one SubProvider run sharing an L3 group label,
+    /// in entry order — the level list layouts print as a subheader.
+    static func groupRuns(_ run: [MiniEntry]) -> [(label: String?, entries: [MiniEntry])] {
+        var runs: [(label: String?, entries: [MiniEntry])] = []
+        for entry in run {
+            if let last = runs.last, last.label == entry.groupLabel {
+                runs[runs.count - 1].entries.append(entry)
+            } else {
+                runs.append((entry.groupLabel, [entry]))
             }
         }
         return runs
@@ -161,6 +181,7 @@ enum MiniLedgerMetrics {
     static let bottomPadding: CGFloat = 12
     static let headerHeight: CGFloat = 16
     static let headerGap: CGFloat = 3
+    static let groupHeaderHeight: CGFloat = 14
     static let rowHeight: CGFloat = 21
     static let groupGap: CGFloat = 7
     static let emptyHeight: CGFloat = 84
@@ -172,6 +193,9 @@ enum MiniLedgerMetrics {
         for (index, run) in runs.enumerated() {
             if index > 0 { height += groupGap }
             height += headerHeight + headerGap + CGFloat(run.count) * rowHeight
+            for group in MiniEntry.groupRuns(run) where group.label != nil {
+                height += groupHeaderHeight
+            }
         }
         return CGSize(width: width, height: height)
     }
@@ -203,8 +227,13 @@ struct MiniLedgerLayout: View {
                     }
                     header(for: run[0])
                     Spacer().frame(height: MiniLedgerMetrics.headerGap)
-                    ForEach(run) { entry in
-                        row(entry, now: now)
+                    ForEach(Array(MiniEntry.groupRuns(run).enumerated()), id: \.offset) { _, group in
+                        if let label = group.label {
+                            groupHeader(label)
+                        }
+                        ForEach(group.entries) { entry in
+                            row(entry, now: now)
+                        }
                     }
                 }
             }
@@ -230,12 +259,22 @@ struct MiniLedgerLayout: View {
         .frame(height: MiniLedgerMetrics.headerHeight, alignment: .bottomLeading)
     }
 
+    private func groupHeader(_ label: String) -> some View {
+        Text(label.uppercased())
+            .font(.system(size: 8, weight: .semibold, design: .rounded))
+            .foregroundStyle(.tertiary)
+            .tracking(0.9)
+            .lineLimit(1)
+            .padding(.leading, 10)
+            .frame(height: MiniLedgerMetrics.groupHeaderHeight, alignment: .bottomLeading)
+    }
+
     private func row(_ entry: MiniEntry, now: Date) -> some View {
         let mode = settingsStore.displayMode
         let percent = entryPercent(entry, mode: mode)
         let color = entryColor(entry, mode: mode)
         return HStack(spacing: 8) {
-            Text(entry.rowLabel)
+            Text(entry.bucketDisplayName)
                 .font(.system(size: 10.5, weight: .medium, design: .rounded))
                 .foregroundStyle(.primary.opacity(0.88))
                 .lineLimit(1)
@@ -323,32 +362,29 @@ enum MiniStripMetrics {
     }
 
     static let rowGap: CGFloat = 2
-    /// The strip never outgrows the screen: past this width, cells wrap into
-    /// further bands. A default selection can hold twenty-plus fields, and an
-    /// unwrapped run of 132-pt cells would put most of the panel off screen.
+    /// The strip is one line by design — it simulates the menu bar. It still
+    /// never outgrows the screen: past this width the cells themselves
+    /// shrink, and their text scales down inside.
     static let maxRowWidth: CGFloat = 1180
 
-    /// Cells per band, and how many bands `count` cells need.
-    static func gridPlan(count: Int, cellWidth: CGFloat, cellSpacing: CGFloat) -> (perRow: Int, rows: Int) {
+    /// The cell width that keeps `count` cells on the single line: the ideal
+    /// width until the line would pass `maxRowWidth`, then evenly shrunk.
+    static func fittedCellWidth(count: Int, ideal: CGFloat, spacing: CGFloat) -> CGFloat {
+        guard count > 0 else { return ideal }
         let available = maxRowWidth - leadingPadding - trailingPadding
-        let perRow = max(1, Int((available + cellSpacing) / (cellWidth + cellSpacing)))
-        let rows = Int(ceil(Double(count) / Double(perRow)))
-        return (perRow, rows)
+            - CGFloat(max(0, count - 1)) * spacing
+        return min(ideal, max(44, available / CGFloat(count)))
     }
 
     static func size(entries: [MiniEntry], density: MiniStripDensity) -> CGSize {
         guard !entries.isEmpty else { return CGSize(width: emptyWidth, height: rowHeight(density)) }
         let cellCount = density == .twoLine ? (entries.count + 1) / 2 : entries.count
-        let cellWidth = chipWidth(density)
         let cellSpacing = density == .twoLine ? pairedColumnSpacing : chipSpacing(density)
-        let plan = gridPlan(count: cellCount, cellWidth: cellWidth, cellSpacing: cellSpacing)
-        let cellsInWidestRow = min(cellCount, plan.perRow)
+        let cellWidth = fittedCellWidth(count: cellCount, ideal: chipWidth(density), spacing: cellSpacing)
         let width = leadingPadding + trailingPadding
-            + CGFloat(cellsInWidestRow) * cellWidth
-            + CGFloat(max(0, cellsInWidestRow - 1)) * cellSpacing
-        let height = CGFloat(plan.rows) * rowHeight(density)
-            + CGFloat(max(0, plan.rows - 1)) * rowGap
-        return CGSize(width: width, height: height)
+            + CGFloat(cellCount) * cellWidth
+            + CGFloat(max(0, cellCount - 1)) * cellSpacing
+        return CGSize(width: width, height: rowHeight(density))
     }
 }
 
@@ -366,21 +402,17 @@ struct MiniStripLayout: View {
             } else if density == .twoLine {
                 pairedColumns
             } else {
-                let plan = MiniStripMetrics.gridPlan(
+                let cellWidth = MiniStripMetrics.fittedCellWidth(
                     count: entries.count,
-                    cellWidth: MiniStripMetrics.chipWidth(density),
-                    cellSpacing: MiniStripMetrics.chipSpacing(density)
+                    ideal: MiniStripMetrics.chipWidth(density),
+                    spacing: MiniStripMetrics.chipSpacing(density)
                 )
-                VStack(alignment: .leading, spacing: MiniStripMetrics.rowGap) {
-                    ForEach(Array(entries.chunked(into: plan.perRow).enumerated()), id: \.offset) { _, band in
-                        HStack(spacing: MiniStripMetrics.chipSpacing(density)) {
-                            ForEach(band) { entry in
-                                lineCell(entry)
-                            }
-                        }
-                        .frame(height: MiniStripMetrics.rowHeight(density))
+                HStack(spacing: MiniStripMetrics.chipSpacing(density)) {
+                    ForEach(entries) { entry in
+                        lineCell(entry, width: cellWidth)
                     }
                 }
+                .frame(height: MiniStripMetrics.rowHeight(density))
                 .padding(.leading, MiniStripMetrics.leadingPadding)
                 .padding(.trailing, MiniStripMetrics.trailingPadding)
             }
@@ -395,27 +427,23 @@ struct MiniStripLayout: View {
         let pairs = stride(from: 0, to: entries.count, by: 2).map { index in
             (top: entries[index], bottom: index + 1 < entries.count ? entries[index + 1] : nil)
         }
-        let plan = MiniStripMetrics.gridPlan(
+        let columnWidth = MiniStripMetrics.fittedCellWidth(
             count: pairs.count,
-            cellWidth: MiniStripMetrics.pairedColumnWidth,
-            cellSpacing: MiniStripMetrics.pairedColumnSpacing
+            ideal: MiniStripMetrics.pairedColumnWidth,
+            spacing: MiniStripMetrics.pairedColumnSpacing
         )
-        return VStack(alignment: .leading, spacing: MiniStripMetrics.rowGap) {
-            ForEach(Array(pairs.chunked(into: plan.perRow).enumerated()), id: \.offset) { _, band in
-                HStack(spacing: MiniStripMetrics.pairedColumnSpacing) {
-                    ForEach(Array(band.enumerated()), id: \.offset) { _, pair in
-                        VStack(alignment: .leading, spacing: MiniStripMetrics.pairedRowSpacing) {
-                            pairedCell(pair.top, mode: mode)
-                            if let bottom = pair.bottom {
-                                pairedCell(bottom, mode: mode)
-                            }
-                        }
-                        .frame(width: MiniStripMetrics.pairedColumnWidth, alignment: .leading)
+        return HStack(spacing: MiniStripMetrics.pairedColumnSpacing) {
+            ForEach(Array(pairs.enumerated()), id: \.offset) { _, pair in
+                VStack(alignment: .leading, spacing: MiniStripMetrics.pairedRowSpacing) {
+                    pairedCell(pair.top, mode: mode)
+                    if let bottom = pair.bottom {
+                        pairedCell(bottom, mode: mode)
                     }
                 }
-                .frame(height: MiniStripMetrics.rowHeight(.twoLine))
+                .frame(width: columnWidth, alignment: .leading)
             }
         }
+        .frame(height: MiniStripMetrics.rowHeight(.twoLine))
         .padding(.leading, MiniStripMetrics.leadingPadding)
         .padding(.trailing, MiniStripMetrics.trailingPadding)
     }
@@ -439,7 +467,7 @@ struct MiniStripLayout: View {
     /// The menu bar's single-line style, one cell per bucket: full label
     /// beside its colored number. Narrow is the compact variant — the same
     /// pieces at the menu bar's small size.
-    private func lineCell(_ entry: MiniEntry) -> some View {
+    private func lineCell(_ entry: MiniEntry, width: CGFloat) -> some View {
         let mode = settingsStore.displayMode
         let percent = entryPercent(entry, mode: mode)
         let color = entryColor(entry, mode: mode)
@@ -449,12 +477,12 @@ struct MiniStripLayout: View {
                 .font(.system(size: size, weight: .semibold, design: .rounded))
                 .foregroundStyle(.primary)
                 .lineLimit(1)
-                .minimumScaleFactor(0.6)
+                .minimumScaleFactor(0.5)
             Text("\(Int(percent.rounded()))%")
                 .font(.system(size: size, weight: .bold, design: .rounded).monospacedDigit())
                 .foregroundStyle(color)
         }
-        .frame(width: MiniStripMetrics.chipWidth(density), alignment: .leading)
+        .frame(width: width, alignment: .leading)
         .help("\(entry.subProviderDisplayName) — \(entry.rowLabel): \(Int(percent.rounded()))%")
     }
 }

--- a/Sources/VibeBarApp/Views/UpcomingResets.swift
+++ b/Sources/VibeBarApp/Views/UpcomingResets.swift
@@ -132,13 +132,18 @@ struct ResetLaneView: View {
                     .fill(Color.primary.opacity(0.35))
                     .frame(width: 2, height: laneHeight - 20)
                     .offset(y: 4)
-                ForEach(1...Int(horizonDays), id: \.self) { day in
-                    let x = width * CGFloat(day) / horizonDays
+                // Day ticks for multi-day horizons; hour ticks when the
+                // lane covers a single day (the sub-daily timeline).
+                let ticks: [(fraction: Double, label: String)] = horizonDays <= 1
+                    ? [0.25, 0.5, 0.75, 1].map { ($0, "+\(Int($0 * horizonDays * 24))h") }
+                    : (1...Int(horizonDays)).map { (Double($0) / horizonDays, "+\($0)d") }
+                ForEach(Array(ticks.enumerated()), id: \.offset) { _, tick in
+                    let x = width * CGFloat(tick.fraction)
                     Rectangle()
                         .fill(Color.primary.opacity(0.18))
                         .frame(width: 1, height: 5)
                         .offset(x: x, y: laneHeight - 18)
-                    Text("+\(day)d")
+                    Text(tick.label)
                         .font(.system(size: 7.5, design: .rounded).monospacedDigit())
                         .foregroundStyle(.tertiary)
                         .frame(width: 30)

--- a/Sources/VibeBarApp/Views/Workbench/ResetsPage.swift
+++ b/Sources/VibeBarApp/Views/Workbench/ResetsPage.swift
@@ -49,6 +49,7 @@ struct ResetsPage: View {
                 HStack(alignment: .top, spacing: 14) {
                     box {
                         calendarHeader(now: now)
+                        subDailyLane(now: now)
                         monthCalendar(now: now)
                     }
                     .frame(maxWidth: .infinity)
@@ -337,6 +338,29 @@ struct ResetsPage: View {
         return calendar.date(byAdding: .month, value: calendarMonthOffset, to: thisMonth) ?? thisMonth
     }
 
+    /// Quotas that cycle inside a day (the five-hour lanes) would reset
+    /// several times per calendar cell; they get their own next-24-hours
+    /// timeline instead, with the same hover cards as the horizon.
+    @ViewBuilder
+    private func subDailyLane(now: Date) -> some View {
+        let events = UpcomingResets.events(environment: environment, now: now, horizonDays: 1)
+            .filter { event in
+                guard let bucket = environment.quotaService.cachedQuota(for: event.accountId)?
+                    .bucket(id: event.bucketId) else { return false }
+                return (bucket.rawWindowSeconds ?? 86_400) < 86_400
+            }
+        if !events.isEmpty {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("NEXT 24 HOURS · SUB-DAILY QUOTAS")
+                    .font(.system(size: 8.5, weight: .semibold, design: .rounded))
+                    .foregroundStyle(.tertiary)
+                    .tracking(1.2)
+                ResetLaneView(events: events, now: now, horizonDays: 1, laneHeight: 52)
+            }
+            .padding(.bottom, 2)
+        }
+    }
+
     private func calendarHeader(now: Date) -> some View {
         let monthStart = displayedMonthStart(now: now)
         return HStack(spacing: 8) {
@@ -388,7 +412,9 @@ struct ResetsPage: View {
             let quota = environment.quotaService.cachedQuota(for: key.accountId)
             for sample in samples {
                 let at = sample.completedAt ?? sample.windowEnd
-                guard at >= monthStart, at < monthEnd, at <= now else { continue }
+                guard at >= monthStart, at < monthEnd, at <= now,
+                      (sample.rawWindowSeconds ?? 86_400) >= 86_400
+                else { continue }
                 let sub = sample.tool.quotaSubProviderName(bucketID: sample.bucketId)
                 let title = quota?.bucket(id: sample.bucketId)?.title
                 let name = title.map { "\(sub) · \($0)" } ?? sub
@@ -403,13 +429,16 @@ struct ResetsPage: View {
                 ))
             }
         }
-        // Future: scheduled resets from the live quotas.
+        // Future: scheduled resets from the live quotas. Sub-daily windows
+        // (the five-hour lanes) reset several times per cell — they live on
+        // the 24-hour timeline above the grid, not in day cells.
         for tool in ToolType.dedicatedCardProviders {
             for account in environment.accountStore.accounts(for: tool) {
                 guard let quota = environment.quotaService.cachedQuota(for: account.id) else { continue }
                 for bucket in quota.buckets {
                     guard let resetAt = bucket.resetAt,
-                          resetAt >= max(monthStart, now), resetAt < monthEnd
+                          resetAt >= max(monthStart, now), resetAt < monthEnd,
+                          (bucket.rawWindowSeconds ?? 86_400) >= 86_400
                     else { continue }
                     let sub = tool.quotaSubProviderName(bucketID: bucket.id)
                     out.append(CalendarEntry(


### PR DESCRIPTION
AQ's feedback on dev.51:

1. **Strip is one line again** (模拟菜单栏): the band-wrapping from #250 read as broken. Cells now shrink evenly (`fittedCellWidth`, floor 44pt) once the line would exceed the 1,180pt cap — single line preserved, still never off-screen. Two-line keeps exactly two rows the same way.
2. **Hierarchy legible in ledger/tiles**: root cause of the bare "Weekly" rows — AQ's stored custom field labels literally say "Weekly"/"5 Hours", and `rowLabel` let a custom label replace the whole path. Custom labels now rename the **bucket level only** (`group · name` always), and the ledger prints the tiers explicitly: company · SubProvider header → group subheader (ALL / SPARK / …) → bucket rows. Tiles inherit the composed label.
3. **Calendar scale**: day cells only show cycles ≥ 1 day; sub-daily quotas move to a "NEXT 24 HOURS" timeline above the grid (same `ResetLaneView`, hour ticks for single-day horizons, hover cards included).

## Validation
- `swift build` ✓, `swift test` ✓ (1698), release bundle + empty entitlements + deep signature ✓
- No-pixel demo smoke ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)