### PR TITLE
Bump build number to 52 for the next Dev release

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.4.1</string>
 	<key>CFBundleVersion</key>
-	<string>51</string>
+	<string>52</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>26.0</string>
 	<key>LSUIElement</key>


### PR DESCRIPTION
Build bump for the Dev-channel release `v1.4.1-dev.52` (version stays 1.4.1).

Ships on top of dev.51: the strip back to one menu-bar-style line with shrink-to-fit cells, level-scoped custom labels with an explicitly tiered ledger, and the day-scale reset calendar with the sub-daily 24-hour timeline (#254).

After merge: tag `v1.4.1-dev.52` → release workflow → verify draft → publish as prerelease → verify feed Dev head 52.

Validation: `swift build` ✓, `swift test` ✓ (1698 tests), bundle 1.4.1 (52) ✓, empty entitlements ✓, deep signature ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)