### PR TITLE
Ignore SIGPIPE so a vanished MCP peer cannot kill the app

### DIFF
--- a/Sources/VibeBarApp/main.swift
+++ b/Sources/VibeBarApp/main.swift
@@ -2,6 +2,15 @@ import Darwin
 import Foundation
 import VibeBarCore
 
+// A broken pipe must surface as an EPIPE error on the write that hit it,
+// never as a process-killing signal. The MCP socket server and the stdio
+// bridge both write to peers that can vanish at any moment — an agent
+// session disconnecting mid-reply killed the whole app with SIGPIPE after
+// hours of uptime (launchd: "exited due to SIGPIPE, sent by VibeBar"), and
+// a SIGPIPE death leaves no crash report to find. First thing the process
+// does, before the bridge fork-off below and before AppKit.
+signal(SIGPIPE, SIG_IGN)
+
 // `--mcp-stdio` must never touch AppKit: MCP clients spawn this binary as a
 // plain child process — sometimes inside a sandbox (Codex's managed sandbox
 // aborted with SIGABRT when NSApplication came up) — and all it has to do is


### PR DESCRIPTION
**The "app quits by itself" mystery is solved.** The exit watcher caught it live:

```
launchd: exited due to SIGPIPE | sent by VibeBar[56274], ran for 14111893ms (~3.9h)
```

Root cause chain: the kit's `MCPSocketServer` writes to bridge clients with raw `Darwin.write` and no `SO_NOSIGPIPE`; the process never ignored SIGPIPE; an agent session (MCP bridge) disconnecting mid-reply raises SIGPIPE whose default action kills the process — and a SIGPIPE death leaves **no crash report and no jetsam record**, which is exactly why every earlier investigation came up empty.

Fix: `signal(SIGPIPE, SIG_IGN)` first thing in `main.swift` — before the `--mcp-stdio` bridge fork-off and before AppKit — so a broken pipe surfaces as `EPIPE` on the failing write, which the socket code already handles as a failed write. Covers the GUI process and the bridge children alike.

Follow-up (separate, upstream): add `SO_NOSIGPIPE` to the kit's socket fds as defense in depth.

## Validation
`swift build` ✓, `swift test` ✓ (1698), release bundle + empty entitlements + deep signature ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)