### PR TITLE
Add the native settings file transaction

### DIFF
--- a/Sources/VibeBarCore/Storage/SharedStoreLease.swift
+++ b/Sources/VibeBarCore/Storage/SharedStoreLease.swift
@@ -170,21 +170,21 @@ public final class SharedStoreLeaseBatch: @unchecked Sendable {
     _ body: (Int32) throws -> T
   ) throws -> T {
     state.lock()
+    defer { state.unlock() }
     guard stores == self.stores, role == self.role, let rootFD else {
-      state.unlock()
       throw RootAccessError.unauthorized
     }
     // The path is only an identity label; all I/O uses the duplicated
     // descriptor retained from acquisition, so path replacement cannot
     // redirect the write.
     guard dataRootURL.standardizedFileURL.path == rootPath else {
-      state.unlock()
       throw RootAccessError.unauthorized
     }
     let duplicate = Darwin.dup(rootFD)
-    state.unlock()
     guard duplicate >= 0 else { throw RootAccessError.duplicateFailed(errno) }
     defer { Darwin.close(duplicate) }
+    // Hold the state lock until authorized I/O finishes so release() cannot
+    // drop the filesystem lease while this capability is still in use.
     return try body(duplicate)
   }
 

--- a/Sources/VibeBarCore/Storage/SharedStoreLease.swift
+++ b/Sources/VibeBarCore/Storage/SharedStoreLease.swift
@@ -31,20 +31,32 @@ public enum SharedStoreLeaseError: Error, Equatable, Sendable {
 /// Batch RAII lease. A writer holds the global barrier shared plus sorted
 /// per-store exclusive locks; maintenance holds the barrier exclusive first.
 public final class SharedStoreLeaseBatch: @unchecked Sendable {
+  enum RootAccessError: Error, Equatable {
+    case unauthorized
+    case duplicateFailed(Int32)
+  }
+
   public let stores: [SharedStoreID]
   public let role: SharedStoreLeaseRole
+  private let rootIdentity: (UInt64, UInt64)
+  private let rootPath: String
   private let state = NSLock()
   private var locks: [LockHandle]?
   private var runFD: Int32?
+  private var rootFD: Int32?
   private static let heldLock = NSLock()
   private nonisolated(unsafe) static var heldExclusive: Set<String> = []
 
   private init(
-    stores: [SharedStoreID], role: SharedStoreLeaseRole, runFD: Int32, locks: [LockHandle]
+    stores: [SharedStoreID], role: SharedStoreLeaseRole, runFD: Int32, locks: [LockHandle],
+    rootIdentity: (UInt64, UInt64), rootFD: Int32, rootPath: String
   ) {
     self.stores = stores
     self.role = role
+    self.rootIdentity = rootIdentity
+    self.rootPath = rootPath
     self.runFD = runFD
+    self.rootFD = rootFD
     self.locks = locks
   }
   deinit { release() }
@@ -58,8 +70,21 @@ public final class SharedStoreLeaseBatch: @unchecked Sendable {
     throw SharedStoreLeaseError.notEligible(first)
   }
 
-  /// Test-only raw protocol seam. Product code must use `acquireWriter`.
-  static func acquireForTesting(
+  /// Native's first internal shared-store writer. Kept separate from the
+  /// public API until the cross-client contract changes eligibility.
+  static func acquireNativeWriter(
+    dataRootURL: URL, clientID: String
+  ) throws -> SharedStoreLeaseBatch {
+    try acquireInternal(
+      dataRootURL: dataRootURL,
+      stores: [.settings],
+      role: .settingsEditor,
+      maintenance: false,
+      clientID: clientID
+    )
+  }
+
+  private static func acquireInternal(
     dataRootURL: URL, stores: [SharedStoreID], role: SharedStoreLeaseRole, maintenance: Bool,
     clientID: String, pid: Int32 = getpid(), startedAt: Date = Date()
   ) throws -> SharedStoreLeaseBatch {
@@ -80,12 +105,24 @@ public final class SharedStoreLeaseBatch: @unchecked Sendable {
     }
     let rootFD = vb_open_directory_nofollow(dataRootURL.path)
     guard rootFD >= 0 else { throw error("open_data_root") }
-    defer { Darwin.close(rootFD) }
-    guard vb_mkdirat_private(rootFD, "run") == 0 else { throw error("mkdirat_run") }
+    var rootDevice: UInt64 = 0
+    var rootInode: UInt64 = 0
+    guard vb_fd_identity(rootFD, &rootDevice, &rootInode) == 0 else {
+      Darwin.close(rootFD)
+      throw error("fstat_data_root")
+    }
+    guard vb_mkdirat_private(rootFD, "run") == 0 else {
+      Darwin.close(rootFD)
+      throw error("mkdirat_run")
+    }
     let runFD = vb_openat_directory_nofollow(rootFD, "run")
-    guard runFD >= 0 else { throw error("openat_run") }
+    guard runFD >= 0 else {
+      Darwin.close(rootFD)
+      throw error("openat_run")
+    }
     guard vb_fchmod_directory(runFD) == 0 else {
       Darwin.close(runFD)
+      Darwin.close(rootFD)
       throw error("chmod_run")
     }
 
@@ -103,23 +140,73 @@ public final class SharedStoreLeaseBatch: @unchecked Sendable {
         acquired.append(
           try acquireLock(runFD: runFD, name: store.rawValue, mode: .exclusive, record: record))
       }
-      return SharedStoreLeaseBatch(stores: sorted, role: role, runFD: runFD, locks: acquired)
+      return SharedStoreLeaseBatch(
+        stores: sorted, role: role, runFD: runFD, locks: acquired,
+        rootIdentity: (rootDevice, rootInode), rootFD: rootFD,
+        rootPath: dataRootURL.standardizedFileURL.path)
     } catch {
       for name in acquired.compactMap(\.recordName) {
         _ = name.withCString { vb_unlinkat_file(runFD, $0) }
       }
       for lock in acquired.reversed() { lock.release() }
       Darwin.close(runFD)
+      Darwin.close(rootFD)
       throw error
     }
+  }
+
+  func authorizes(dataRootURL: URL, stores: [SharedStoreID], role: SharedStoreLeaseRole) -> Bool {
+    guard stores == self.stores, role == self.role else { return false }
+    let fd = vb_open_directory_nofollow(dataRootURL.path)
+    guard fd >= 0 else { return false }
+    defer { Darwin.close(fd) }
+    var device: UInt64 = 0
+    var inode: UInt64 = 0
+    return vb_fd_identity(fd, &device, &inode) == 0 && (device, inode) == rootIdentity
+  }
+
+  func withAuthorizedRootFD<T>(
+    dataRootURL: URL, stores: [SharedStoreID], role: SharedStoreLeaseRole,
+    _ body: (Int32) throws -> T
+  ) throws -> T {
+    state.lock()
+    guard stores == self.stores, role == self.role, let rootFD else {
+      state.unlock()
+      throw RootAccessError.unauthorized
+    }
+    // The path is only an identity label; all I/O uses the duplicated
+    // descriptor retained from acquisition, so path replacement cannot
+    // redirect the write.
+    guard dataRootURL.standardizedFileURL.path == rootPath else {
+      state.unlock()
+      throw RootAccessError.unauthorized
+    }
+    let duplicate = Darwin.dup(rootFD)
+    state.unlock()
+    guard duplicate >= 0 else { throw RootAccessError.duplicateFailed(errno) }
+    defer { Darwin.close(duplicate) }
+    return try body(duplicate)
+  }
+
+  /// Test-only raw protocol seam.
+  static func acquireForTesting(
+    dataRootURL: URL, stores: [SharedStoreID], role: SharedStoreLeaseRole, maintenance: Bool,
+    clientID: String, pid: Int32 = getpid(), startedAt: Date = Date()
+  ) throws -> SharedStoreLeaseBatch {
+    try acquireInternal(
+      dataRootURL: dataRootURL, stores: stores, role: role, maintenance: maintenance,
+      clientID: clientID, pid: pid, startedAt: startedAt
+    )
   }
 
   public func release() {
     state.lock()
     let held = locks
     let directory = runFD
+    let root = rootFD
     locks = nil
     runFD = nil
+    rootFD = nil
     state.unlock()
     if let directory, let held {
       for name in held.compactMap(\.recordName) {
@@ -130,6 +217,7 @@ public final class SharedStoreLeaseBatch: @unchecked Sendable {
       for lock in held.reversed() { lock.release() }
     }
     if let directory { _ = Darwin.close(directory) }
+    if let root { _ = Darwin.close(root) }
   }
 
   private enum Mode { case shared, exclusive }

--- a/Sources/VibeBarCore/Storage/VibeBarLocalStore.swift
+++ b/Sources/VibeBarCore/Storage/VibeBarLocalStore.swift
@@ -1,4 +1,6 @@
+import Darwin
 import Foundation
+import VibeBarPOSIX
 
 public enum VibeBarLocalStore {
     public static let directoryName = ".vibebar"
@@ -247,6 +249,83 @@ public enum VibeBarLocalStore {
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
         let data = try encoder.encode(value)
         try writeData(data, to: url, base: base)
+    }
+
+    enum SettingsFileStoreError: Error, Equatable {
+        case invalidDestination
+        case tooLarge
+        case leaseRequired
+        case precommit(operation: String, code: Int32)
+        case postRenameUnconfirmed(operation: String, code: Int32)
+    }
+
+    /// Durable same-directory replacement for the lease-aware settings writer.
+    static func writeSettingsData(
+        _ data: Data, to url: URL, base: URL, lease: SharedStoreLeaseBatch
+    ) throws {
+        guard data.count <= 8 * 1024 * 1024 else { throw SettingsFileStoreError.tooLarge }
+        guard url.path == base.appendingPathComponent("settings.json").path else {
+            throw SettingsFileStoreError.invalidDestination
+        }
+        do {
+            try lease.withAuthorizedRootFD(
+                dataRootURL: base, stores: [.settings], role: .settingsEditor
+            ) { directoryFD in
+                let symlink = "settings.json".withCString {
+                    vb_is_symlink_at(directoryFD, $0)
+                }
+                guard symlink == 0 || (symlink == -1 && errno == ENOENT) else {
+                    throw SettingsFileStoreError.precommit(
+                        operation: "inspect_destination", code: errno)
+                }
+                let tempName = ".settings.\(UUID().uuidString).tmp"
+                let fd = tempName.withCString { vb_openat_new_private(directoryFD, $0) }
+                guard fd >= 0 else {
+                    throw SettingsFileStoreError.precommit(operation: "open_temp", code: errno)
+                }
+                defer {
+                    tempName.withCString { _ = vb_unlinkat_file(directoryFD, $0) }
+                    close(fd)
+                }
+                guard vb_fchmod_private(fd) == 0 else {
+                    throw SettingsFileStoreError.precommit(operation: "chmod_temp", code: errno)
+                }
+                try data.withUnsafeBytes { bytes in
+                    var offset = 0
+                    while offset < bytes.count {
+                        let chunk = min(bytes.count - offset, Int(Int32.max))
+                        let wrote = vb_write_bytes(
+                            fd, bytes.baseAddress!.advanced(by: offset), Int32(chunk))
+                        if wrote < 0 && errno == EINTR { continue }
+                        guard wrote > 0 else {
+                            throw SettingsFileStoreError.precommit(
+                                operation: "write_temp", code: errno)
+                        }
+                        offset += Int(wrote)
+                    }
+                }
+                guard vb_fsync_fd(fd) == 0 else {
+                    throw SettingsFileStoreError.precommit(operation: "fsync_temp", code: errno)
+                }
+                let name = url.lastPathComponent
+                guard tempName.withCString({ from in
+                    name.withCString { to in
+                        vb_renameat_same_directory(directoryFD, from, to)
+                    }
+                }) == 0 else {
+                    throw SettingsFileStoreError.precommit(
+                        operation: "rename_settings", code: errno)
+                }
+                guard vb_fsync_fd(directoryFD) == 0 else {
+                    throw SettingsFileStoreError.postRenameUnconfirmed(
+                        operation: "fsync_directory", code: errno)
+                }
+            }
+        } catch SharedStoreLeaseBatch.RootAccessError.unauthorized {
+            throw SettingsFileStoreError.leaseRequired
+        } catch SharedStoreLeaseBatch.RootAccessError.duplicateFailed(let code) {
+            throw SettingsFileStoreError.precommit(operation: "dup_data_root", code: code)
+        }
     }
 
     public static func deleteFile(at url: URL) throws {

--- a/Sources/VibeBarPOSIX/VibeBarPOSIX.c
+++ b/Sources/VibeBarPOSIX/VibeBarPOSIX.c
@@ -65,6 +65,10 @@ int vb_openat_lock_nofollow(int parent_fd, const char *name) {
                 0600);
 }
 
+int vb_openat_read_nofollow(int parent_fd, const char *name) {
+  return openat(parent_fd, name, O_RDONLY | O_CLOEXEC | O_NOFOLLOW);
+}
+
 int vb_openat_new_private(int parent_fd, const char *name) {
   return openat(parent_fd, name,
                 O_WRONLY | O_CREAT | O_EXCL | O_CLOEXEC | O_NOFOLLOW, 0600);

--- a/Sources/VibeBarPOSIX/include/VibeBarPOSIX.h
+++ b/Sources/VibeBarPOSIX/include/VibeBarPOSIX.h
@@ -9,6 +9,7 @@ int vb_open_directory_nofollow(const char *absolute_path);
 int vb_mkdirat_private(int parent_fd, const char *name);
 int vb_openat_directory_nofollow(int parent_fd, const char *name);
 int vb_openat_lock_nofollow(int parent_fd, const char *name);
+int vb_openat_read_nofollow(int parent_fd, const char *name);
 int vb_openat_new_private(int parent_fd, const char *name);
 int vb_flock_shared_nonblocking(int fd);
 int vb_flock_exclusive_nonblocking(int fd);

--- a/Tests/VibeBarCoreTests/SettingsFileStoreTests.swift
+++ b/Tests/VibeBarCoreTests/SettingsFileStoreTests.swift
@@ -83,6 +83,36 @@ final class SettingsFileStoreTests: XCTestCase {
     ) { XCTAssertEqual($0 as? VibeBarLocalStore.SettingsFileStoreError, .leaseRequired) }
   }
 
+  func testReleaseWaitsForAuthorizedIOToFinish() throws {
+    let root = try syntheticRoot()
+    let lease = try SharedStoreLeaseBatch.acquireNativeWriter(dataRootURL: root, clientID: "test")
+    let entered = DispatchSemaphore(value: 0)
+    let resume = DispatchSemaphore(value: 0)
+    let releaseFinished = DispatchSemaphore(value: 0)
+
+    DispatchQueue.global().async {
+      try! lease.withAuthorizedRootFD(
+        dataRootURL: root, stores: [.settings], role: .settingsEditor
+      ) { _ in
+        entered.signal()
+        resume.wait()
+      }
+    }
+    XCTAssertEqual(entered.wait(timeout: .now() + 1), .success)
+    DispatchQueue.global().async {
+      lease.release()
+      releaseFinished.signal()
+    }
+    XCTAssertEqual(releaseFinished.wait(timeout: .now() + 0.05), .timedOut)
+    XCTAssertThrowsError(
+      try SharedStoreLeaseBatch.acquireNativeWriter(dataRootURL: root, clientID: "other")
+    ) { XCTAssertEqual($0 as? SharedStoreLeaseError, .busy) }
+
+    resume.signal()
+    XCTAssertEqual(releaseFinished.wait(timeout: .now() + 1), .success)
+    try SharedStoreLeaseBatch.acquireNativeWriter(dataRootURL: root, clientID: "other").release()
+  }
+
   func testPrecommitFailureLeavesNoSettingsTempFiles() throws {
     let root = try syntheticRoot()
     let lease = try SharedStoreLeaseBatch.acquireNativeWriter(dataRootURL: root, clientID: "test")

--- a/Tests/VibeBarCoreTests/SettingsFileStoreTests.swift
+++ b/Tests/VibeBarCoreTests/SettingsFileStoreTests.swift
@@ -1,0 +1,123 @@
+import Darwin
+import Foundation
+import VibeBarPOSIX
+import XCTest
+
+@testable import VibeBarCore
+
+final class SettingsFileStoreTests: XCTestCase {
+  func testLeaseRequiredAndRawBytesAreWrittenWithPrivateMode() throws {
+    let root = try syntheticRoot()
+    let base = root
+    let url = base.appendingPathComponent("settings.json")
+    let bytes = Data("{\"unknown\":123456789012345678901234567890}".utf8)
+    let lease = try SharedStoreLeaseBatch.acquireNativeWriter(dataRootURL: base, clientID: "test")
+    try VibeBarLocalStore.writeSettingsData(bytes, to: url, base: base, lease: lease)
+    XCTAssertEqual(try Data(contentsOf: url), bytes)
+    XCTAssertEqual(
+      try FileManager.default.attributesOfItem(atPath: url.path)[.posixPermissions] as? Int, 0o600)
+  }
+
+  func testSymlinkDestinationFailsClosedAndHardlinkReplacementLeavesExternalFile() throws {
+    let root = try syntheticRoot()
+    let base = root
+    let lease = try SharedStoreLeaseBatch.acquireNativeWriter(dataRootURL: base, clientID: "test")
+    let url = base.appendingPathComponent("settings.json")
+    let external = root.appendingPathComponent("external.json")
+    try Data("external".utf8).write(to: external)
+    try FileManager.default.createSymbolicLink(at: url, withDestinationURL: external)
+    XCTAssertThrowsError(
+      try VibeBarLocalStore.writeSettingsData(Data("new".utf8), to: url, base: base, lease: lease))
+    try FileManager.default.removeItem(at: url)
+    try Data("old".utf8).write(to: url)
+    let hardTarget = root.appendingPathComponent("hard-target.json")
+    XCTAssertEqual(
+      url.path.withCString { source in
+        hardTarget.path.withCString { target in link(source, target) }
+      }, 0)
+    try VibeBarLocalStore.writeSettingsData(
+      Data("replacement".utf8), to: url, base: base, lease: lease)
+    XCTAssertEqual(try Data(contentsOf: hardTarget), Data("old".utf8))
+  }
+
+  func testFsyncErrorsAreClassifiedBeforeAndAfterRename() throws {
+    let root = try syntheticRoot()
+    let base = root
+    let lease = try SharedStoreLeaseBatch.acquireNativeWriter(dataRootURL: base, clientID: "test")
+    let url = base.appendingPathComponent("settings.json")
+    try Data("old".utf8).write(to: url)
+    vb_test_fail_fsync_after(1)
+    XCTAssertThrowsError(
+      try VibeBarLocalStore.writeSettingsData(Data("new".utf8), to: url, base: base, lease: lease)
+    ) { error in
+      XCTAssertTrue(error is VibeBarLocalStore.SettingsFileStoreError)
+    }
+    XCTAssertEqual(try Data(contentsOf: url), Data("old".utf8))
+    vb_test_fail_fsync_after(2)
+    XCTAssertThrowsError(
+      try VibeBarLocalStore.writeSettingsData(Data("new".utf8), to: url, base: base, lease: lease)
+    ) { error in
+      guard case .postRenameUnconfirmed = error as? VibeBarLocalStore.SettingsFileStoreError else {
+        return XCTFail("expected post-rename uncertainty, got \(error)")
+      }
+    }
+    XCTAssertEqual(try Data(contentsOf: url), Data("new".utf8))
+  }
+
+  func testLeaseCannotAuthorizeAnotherRootOrWrongDestination() throws {
+    let rootA = try syntheticRoot()
+    let rootB = try syntheticRoot()
+    let lease = try SharedStoreLeaseBatch.acquireNativeWriter(dataRootURL: rootA, clientID: "test")
+    XCTAssertThrowsError(
+      try VibeBarLocalStore.writeSettingsData(
+        Data("x".utf8), to: rootB.appendingPathComponent("settings.json"), base: rootB, lease: lease
+      )
+    ) { XCTAssertEqual($0 as? VibeBarLocalStore.SettingsFileStoreError, .leaseRequired) }
+    let wrong = try SharedStoreLeaseBatch.acquireForTesting(
+      dataRootURL: rootA, stores: [.quotaCache], role: .quotaCollector, maintenance: false,
+      clientID: "test")
+    XCTAssertThrowsError(
+      try VibeBarLocalStore.writeSettingsData(
+        Data("x".utf8), to: rootA.appendingPathComponent("settings.json"), base: rootA, lease: wrong
+      )
+    ) { XCTAssertEqual($0 as? VibeBarLocalStore.SettingsFileStoreError, .leaseRequired) }
+  }
+
+  func testPrecommitFailureLeavesNoSettingsTempFiles() throws {
+    let root = try syntheticRoot()
+    let lease = try SharedStoreLeaseBatch.acquireNativeWriter(dataRootURL: root, clientID: "test")
+    vb_test_fail_fsync_after(1)
+    XCTAssertThrowsError(
+      try VibeBarLocalStore.writeSettingsData(
+        Data("x".utf8), to: root.appendingPathComponent("settings.json"), base: root, lease: lease))
+    let names = try FileManager.default.contentsOfDirectory(atPath: root.path)
+    XCTAssertFalse(names.contains { $0.hasPrefix(".settings.") && $0.hasSuffix(".tmp") })
+  }
+
+  func testReplacementAfterLeaseCannotRedirectStableRootDescriptor() throws {
+    let root = try syntheticRoot()
+    let replacement = try syntheticRoot()
+    let lease = try SharedStoreLeaseBatch.acquireNativeWriter(dataRootURL: root, clientID: "test")
+    let moved = root.deletingLastPathComponent().appendingPathComponent(
+      "moved-\(UUID().uuidString)")
+    try FileManager.default.moveItem(at: root, to: moved)
+    try FileManager.default.createSymbolicLink(at: root, withDestinationURL: replacement)
+    try VibeBarLocalStore.writeSettingsData(
+      Data("original".utf8), to: root.appendingPathComponent("settings.json"), base: root,
+      lease: lease)
+    XCTAssertEqual(
+      try Data(contentsOf: moved.appendingPathComponent("settings.json")), Data("original".utf8))
+    XCTAssertFalse(
+      FileManager.default.fileExists(
+        atPath: replacement.appendingPathComponent("settings.json").path))
+  }
+
+  private func syntheticRoot() throws -> URL {
+    let temporaryPath = FileManager.default.temporaryDirectory.path
+    let physicalPath = temporaryPath.hasPrefix("/var/") ? "/private" + temporaryPath : temporaryPath
+    let root = URL(fileURLWithPath: physicalPath).appendingPathComponent(
+      "VibeBarLease-\(UUID().uuidString)")
+    try FileManager.default.createDirectory(at: root, withIntermediateDirectories: false)
+    return root
+  }
+}


### PR DESCRIPTION
Stacked on #257. This isolates the native file-transaction layer before SettingsStore integration.

## Summary

- retain the leased data-root file descriptor and bind authorization to its inode
- add private same-directory settings replacement with file and directory fsync
- classify precommit failures separately from post-rename uncertainty
- cover root replacement, cross-root lease rejection, symlink, hard link, mode, and failure cleanup

## Safety boundary

The public cross-client writer remains disabled and the manifest stays legacy_unsafe. This PR does not route SettingsStore through the new transaction yet.

## Verification

- SettingsFileStoreTests: 6 passed
- SettingsDocumentTests: 14 passed
- SharedStoreLeaseTests: 15 passed with 1 optional probe skip