### PR TITLE
Adopt agent-session-kit 0.6.3 for the SO_NOSIGPIPE sockets

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -163,7 +163,7 @@ there, not in the package.
 
 **Where it comes from.** `Package.swift` pins the package to an exact
 tag on GitHub (`.package(url: "https://github.com/AstroQore/agent-session-kit.git",
-exact: "0.6.2")`), so a plain clone builds and a release build resolves the
+exact: "0.6.3")`), so a plain clone builds and a release build resolves the
 same package the developer built against — `Package.resolved` is
 gitignored here, and the exact pin is what stands in for it.
 

--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
         // from a clean checkout with no Package.resolved (it is gitignored),
         // so the pin is the only thing that makes two builds of the same
         // Vibe Bar commit contain the same package. Bump it deliberately.
-        .package(url: "https://github.com/AstroQore/agent-session-kit.git", exact: "0.6.2"),
+        .package(url: "https://github.com/AstroQore/agent-session-kit.git", exact: "0.6.3"),
         // SweetCookieKit encapsulates Chromium cookie + localStorage parsing,
         // "Chrome Safe Storage" Keychain decryption, and Safari
         // binarycookies / Firefox SQLite reads used by misc providers.


### PR DESCRIPTION
Pin bump 0.6.2 → 0.6.3 (AstroQore/agent-session-kit#13): every MCP socket descriptor carries `SO_NOSIGPIPE` inside the kit — defense in depth under the process-level `SIG_IGN` from #258.

Validation: `swift build` ✓, `swift test` ✓ (1698), release bundle + empty entitlements + deep signature ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)