### PR TITLE
Bump build number to 53 for the next Dev release

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.4.1</string>
 	<key>CFBundleVersion</key>
-	<string>52</string>
+	<string>53</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>26.0</string>
 	<key>LSUIElement</key>


### PR DESCRIPTION
Build bump for the Dev-channel release `v1.4.1-dev.53` (version stays 1.4.1).

Ships on top of dev.52 the fix for the recurring silent exits — process-level SIGPIPE ignore (#258) plus agent-session-kit 0.6.3's SO_NOSIGPIPE on every MCP socket (#261) — and the menu bar logo appearance/overflow fixes (#259).

After merge: tag `v1.4.1-dev.53` → workflow → verify draft → publish as prerelease → verify feed Dev head 53.

Validation: `swift build` ✓, `swift test` ✓ (1698 tests), bundle 1.4.1 (53) ✓, empty entitlements ✓, deep signature ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)