### PR TITLE
Bump build number to 54 for the next Dev release

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.4.1</string>
 	<key>CFBundleVersion</key>
-	<string>53</string>
+	<string>54</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>26.0</string>
 	<key>LSUIElement</key>


### PR DESCRIPTION
Build bump for the Dev-channel release `v1.4.1-dev.54` (version stays 1.4.1).

Ships on top of dev.53 the two-row logo metrics fix (#263): small-font icons at the font size and zero line spacing for logo-bearing columns, so stacked logos no longer read as clipped.

After merge: tag `v1.4.1-dev.54` → workflow → verify draft → publish as prerelease → verify feed Dev head 54.

Validation: `swift build` ✓, `swift test` ✓ (1698 tests), bundle 1.4.1 (54) ✓, empty entitlements ✓, deep signature ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)