### PR TITLE
Bump build number to 55 for the next Dev release

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.4.1</string>
 	<key>CFBundleVersion</key>
-	<string>54</string>
+	<string>55</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>26.0</string>
 	<key>LSUIElement</key>


### PR DESCRIPTION
Build bump for the Dev-channel release `v1.4.1-dev.55` (version stays 1.4.1).

Ships on top of dev.54 the two-row logo canvas fix (#265): two-row logos are drawn by hand instead of via attachments, so stacked logos render on the canvas they actually get.

After merge: tag `v1.4.1-dev.55` → workflow → verify draft → publish as prerelease → verify feed Dev head 55.

Validation: `swift build` ✓, `swift test` ✓ (1698 tests), bundle 1.4.1 (55) ✓, empty entitlements ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)