### PR TITLE
Bump build number to 56 for the next Dev release

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.4.1</string>
 	<key>CFBundleVersion</key>
-	<string>55</string>
+	<string>56</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>26.0</string>
 	<key>LSUIElement</key>


### PR DESCRIPTION
Build bump for the Dev-channel release `v1.4.1-dev.56` (version stays 1.4.1).

Ships on top of dev.55 the mini-layout tiering round (#267): strip wraps past 1180pt again, tiles carry a two-tone provenance caption, and the ledger splits its company/SubProvider header into real tiers with a fixed indent ladder.

After merge: tag `v1.4.1-dev.56` → workflow → verify draft → publish as prerelease → verify feed Dev head 56.

Validation: `swift build` ✓, `swift test` ✓ (1698 tests), bundle 1.4.1 (56) ✓, empty entitlements ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)