### PR TITLE
Say that Vibe Bar now has a second client

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,25 @@ written for the occasion. [`Scripts/capture_demo_screenshots.sh`](Scripts/captur
 opens each surface in both appearances and captures it over a flat backdrop;
 `DemoMode.swift` is the switch.
 
+## One product, two clients
+
+Vibe Bar is a macOS-native app and intends to stay one: the menu bar, the
+Liquid Glass Mini Window, and the Workbench are built directly on AppKit and
+SwiftUI, not approximated through a web view.
+
+For Windows and Linux there is a second client,
+[**Vibe Bar Desktop**](https://github.com/AstroQore/vibe-bar-desktop) — Tauri
+and Rust, same product, same data. It reads the same `~/.vibebar` data root on
+a Mac where both are installed, so the two never disagree about your quota or
+your settings, and it runs standalone on a machine that has never had the
+native app.
+
+Desktop is still being built up to this app and carries its own `0.x` version
+until it gets there. At parity the two adopt one shared
+`MAJOR.MINOR.PATCH` and every feature release ships from both repositories
+together. Nothing about that client changes this one: this repository is the
+complete implementation and the reference for what parity means.
+
 ## Architecture
 
 Vibe Bar is one app built from two SwiftPM targets plus one package of its
@@ -330,6 +349,12 @@ The kit was extracted from this repository so that the "what did my agents
 actually do" half is usable — and auditable — on its own. It knows nothing
 about quotas, plans or prices; that vocabulary stays in `VibeBarCore`. It has
 no third-party dependencies and is AGPL-3.0-only, same as Vibe Bar.
+
+The kit now ships two implementation lanes: the Swift package this app links,
+and a Rust crate that Vibe Bar Desktop links. They are peers rather than a
+port — anything both must agree on, such as the session index schema, lives in
+the kit's `contracts/` directory with a test on each side, so the two clients
+cannot drift into reading the same file differently.
 
 **How a kit release reaches you.** `Package.swift` pins the kit to an exact
 tag and SwiftPM links it statically — it is compiled into the executable, not

--- a/README.md
+++ b/README.md
@@ -323,10 +323,16 @@ SwiftUI, not approximated through a web view.
 
 For Windows and Linux there is a second client,
 [**Vibe Bar Desktop**](https://github.com/AstroQore/vibe-bar-desktop) — Tauri
-and Rust, same product, same data. It reads the same `~/.vibebar` data root on
-a Mac where both are installed, so the two never disagree about your quota or
-your settings, and it runs standalone on a machine that has never had the
-native app.
+and Rust, same product, same data. On a Mac where both are installed it reads
+the same `~/.vibebar` data root — one set of provider accounts, one set of
+settings, no second copy to maintain — and it runs standalone on a machine
+that has never had the native app.
+
+Desktop writes only inside its own `client/desktop/` namespace today, so it
+never edits what this app owns. Both clients holding the shared root open for
+writing is a separate piece of work: this app loads `settings.json` once at
+launch and rewrites it whole, so it would neither see nor merge another
+client's edit.
 
 Desktop is still being built up to this app and carries its own `0.x` version
 until it gets there. At parity the two adopt one shared

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -279,6 +279,21 @@ systemd 的 Linux 机器上受支持的 CLI 日志，无需开放入站端口。
 [`Scripts/capture_demo_screenshots.sh`](Scripts/capture_demo_screenshots.sh)
 在两种外观下逐个打开每个界面，在纯色背景上抓图；`DemoMode.swift` 是那个开关。
 
+## 一个产品，两个客户端
+
+Vibe Bar 是一个 macOS 原生 App，并且会一直是：菜单栏、Liquid Glass 迷你浮窗和
+Workbench 都直接构建在 AppKit 与 SwiftUI 之上，而不是用 Web 视图去近似。
+
+Windows 与 Linux 由第二个客户端覆盖：
+[**Vibe Bar Desktop**](https://github.com/AstroQore/vibe-bar-desktop)——Tauri +
+Rust，同一个产品，同一份数据。两者都装在同一台 Mac 上时，它读取同一个
+`~/.vibebar` 数据根，所以不会在配额或设置上各说各话；在从未装过原生版的机器上，
+它也能独立运行。
+
+Desktop 仍在向本 App 对齐，在达成之前使用自己的 `0.x` 版本号。对齐之后两者共用
+同一个 `MAJOR.MINOR.PATCH`，每次 feature release 由两个仓库同时发布。这不改变本
+仓库的地位：这里是完整实现，也是"对齐"这件事的参照标准。
+
 ## 架构
 
 Vibe Bar 是一个 App，由两个 SwiftPM target 加一个独立仓库的自有 package 组成。

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -287,8 +287,12 @@ Workbench 都直接构建在 AppKit 与 SwiftUI 之上，而不是用 Web 视图
 Windows 与 Linux 由第二个客户端覆盖：
 [**Vibe Bar Desktop**](https://github.com/AstroQore/vibe-bar-desktop)——Tauri +
 Rust，同一个产品，同一份数据。两者都装在同一台 Mac 上时，它读取同一个
-`~/.vibebar` 数据根，所以不会在配额或设置上各说各话；在从未装过原生版的机器上，
-它也能独立运行。
+`~/.vibebar` 数据根——一套 Provider 账号、一套设置，不需要维护第二份；在从未装过
+原生版的机器上，它也能独立运行。
+
+目前 Desktop 只写自己的 `client/desktop/` 命名空间，不会改动本 App 拥有的数据。
+让两个客户端同时对共享数据根写入是另一件事：本 App 在启动时读一次
+`settings.json` 并整文件覆盖写，既不会察觉也不会合并另一个客户端的修改。
 
 Desktop 仍在向本 App 对齐，在达成之前使用自己的 `0.x` 版本号。对齐之后两者共用
 同一个 `MAJOR.MINOR.PATCH`，每次 feature release 由两个仓库同时发布。这不改变本


### PR DESCRIPTION
## Summary

[Vibe Bar Desktop](https://github.com/AstroQore/vibe-bar-desktop) is public and reads this app's `~/.vibebar` data root, so the README should say so instead of leaving a reader to discover it.

- New **One product, two clients** section in both `README.md` and `README.zh-CN.md`, placed just before Architecture. It is explicit that this app stays macOS-native by choice, that Desktop carries its own `0.x` until parity, and that this repository remains the complete implementation and the reference for what parity means.
- The Architecture section's kit paragraph now mentions that `agent-session-kit` carries two implementation lanes (Swift here, Rust in Desktop) and that `contracts/` keeps them from drifting into reading the same file differently.

Docs only — no code, no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)