### PR TITLE
Bump agent-session-kit to 0.7.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -163,7 +163,7 @@ there, not in the package.
 
 **Where it comes from.** `Package.swift` pins the package to an exact
 tag on GitHub (`.package(url: "https://github.com/AstroQore/agent-session-kit.git",
-exact: "0.6.3")`), so a plain clone builds and a release build resolves the
+exact: "0.7.0")`), so a plain clone builds and a release build resolves the
 same package the developer built against — `Package.resolved` is
 gitignored here, and the exact pin is what stands in for it.
 

--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
         // from a clean checkout with no Package.resolved (it is gitignored),
         // so the pin is the only thing that makes two builds of the same
         // Vibe Bar commit contain the same package. Bump it deliberately.
-        .package(url: "https://github.com/AstroQore/agent-session-kit.git", exact: "0.6.3"),
+        .package(url: "https://github.com/AstroQore/agent-session-kit.git", exact: "0.7.0"),
         // SweetCookieKit encapsulates Chromium cookie + localStorage parsing,
         // "Chrome Safe Storage" Keychain decryption, and Safari
         // binarycookies / Firefox SQLite reads used by misc providers.


### PR DESCRIPTION
## Summary

[`0.7.0`](https://github.com/AstroQore/agent-session-kit/releases/tag/0.7.0) restructures the kit into peer Swift and Rust implementation lanes — `Sources/` and `Tests/` moved under `implementations/swift/`, the Rust crates under `implementations/rust/`.

Both manifests stay at the repository root and reach in with explicit paths, so **every product name, import, and pin form here is unchanged**. The bump is mechanical; the restructure was verified against this package before the kit PR merged.

It also adds `contracts/`, where facts both lanes must honour live with a test on each side. The first is [`session-index-v5.sql`](https://github.com/AstroQore/agent-session-kit/blob/main/contracts/storage/session-index-v5.sql) — the schema `SessionIndexStore` creates, which until now existed only inside that writer while the Rust reader asserted a matching `user_version` by hand. A schema change on one side alone now fails the kit's CI.

## Test plan
- `swift build`: clean.
- `swift test`: 1698 tests, 1 skipped, 0 failures.

## Note

The kit release also carries the two 0.6.x fixes this app already had: `SO_NOSIGPIPE` on MCP socket descriptors and AntiGravity turn dating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)