### PR TITLE
Bump build number to 57 for the next Dev release

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.4.1</string>
 	<key>CFBundleVersion</key>
-	<string>56</string>
+	<string>57</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>26.0</string>
 	<key>LSUIElement</key>


### PR DESCRIPTION
## Summary

Dev release for the five commits since `v1.4.1-dev.56`:

- **agent-session-kit 0.7.0** (#270) — the kit split into peer Swift and Rust implementation lanes under `implementations/`, plus a `contracts/` directory holding the facts both must honour. The first entry is the session index schema this app's `SessionIndexStore` creates, which until now existed only inside that writer while the Rust reader asserted a matching `user_version` by hand. Every product name, import, and pin form here is unchanged.
- **README: one product, two clients** (#269) — [Vibe Bar Desktop](https://github.com/AstroQore/vibe-bar-desktop) is public now and shares this app's data root, so both READMEs say so, in both languages. The claim is deliberately narrow: they share one data root, and Desktop writes only its own `client/desktop/` namespace. Concurrent writers to the shared root are named as separate work rather than implied to already work, because this app reads `settings.json` once at launch and rewrites it whole.

`CFBundleShortVersionString` stays `1.4.1`; build number 56 → 57, which is what Sparkle compares.

## Test plan

Per AGENTS.md § 4:

- `swift build`: clean.
- `swift test`: 1698 tests, 1 skipped, 0 failures.
- `./Scripts/build_app.sh release`: bundle produced and ad-hoc signed.
- `codesign -d --entitlements -`: empty `[Dict]`, no `app-sandbox` key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)