### PR TITLE
Release 1.5.0

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -19,9 +19,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.4.1</string>
+	<string>1.5.0</string>
 	<key>CFBundleVersion</key>
-	<string>57</string>
+	<string>58</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>26.0</string>
 	<key>LSUIElement</key>


### PR DESCRIPTION
## Summary

First Main-channel release since `v1.4.1` (build 49). Twenty-two non-bump commits have landed across previews dev.50–dev.57.

**Why minor, not patch** — several are new capability, not fixes:

- Each menu bar field can now choose label, logo, or both beside its percent, and the editor gained style scopes and the unified tree.
- The mini window's three separate editors merged into one arrangement tree, and every layout was aligned to the quota hierarchy.
- Both reset surfaces were rebuilt: hover cards, group cards, and a real calendar.
- Menu bar logos are tinted for the bar's own appearance, with two-row logos hand-drawn because attachments cannot fit that canvas.

**The two fixes worth naming:**

- A vanished MCP peer can no longer take the app down through `SIGPIPE` — both the process-wide ignore here and the `SO_NOSIGPIPE` descriptors in agent-session-kit 0.6.3.
- The session index is bounded and its accumulated **2.5 GB** compacted.

Also adopts agent-session-kit 0.7.0 (peer Swift/Rust lanes plus `contracts/`) and documents the second client in both READMEs.

`CFBundleShortVersionString` 1.4.1 → **1.5.0**; build 57 → **58**, ahead of every preview so Sparkle never sees a downgrade.

## Test plan

Per AGENTS.md § 4:

- `swift build`: clean.
- `swift test`: 1698 tests, 1 skipped, 0 failures.
- `./Scripts/build_app.sh release`: bundle produced and ad-hoc signed; `CFBundleShortVersionString` in the bundle reads `1.5.0`.
- `codesign -d --entitlements -`: empty `[Dict]`, no `app-sandbox` key.
- `codesign --verify --deep --strict`: passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)