### PR TITLE
Take the reset-history bars off their own colour table

### DIFF
--- a/Sources/VibeBarApp/Views/FillTimelineChart.swift
+++ b/Sources/VibeBarApp/Views/FillTimelineChart.swift
@@ -128,14 +128,14 @@ struct FillTimelineChart: View {
             RoundedRectangle(cornerRadius: 3, style: .continuous)
                 .fill(Theme.barTrack.opacity(isHovered ? 0.95 : 0.62))
             RoundedRectangle(cornerRadius: 3, style: .continuous)
-                .fill(Self.accent(for: tool).opacity(isHovered ? 1 : 0.86))
+                .fill(Theme.providerAccent(for: tool).opacity(isHovered ? 1 : 0.86))
                 .frame(maxHeight: .infinity)
                 .scaleEffect(x: 1, y: max(0.04, percent / 100), anchor: .bottom)
         }
         .overlay {
             if !cycle.isCompleted {
                 RoundedRectangle(cornerRadius: 3, style: .continuous)
-                    .stroke(Self.accent(for: tool).opacity(0.9), style: StrokeStyle(lineWidth: 1, dash: [3, 2]))
+                    .stroke(Theme.providerAccent(for: tool).opacity(0.9), style: StrokeStyle(lineWidth: 1, dash: [3, 2]))
             }
         }
     }
@@ -192,16 +192,6 @@ struct FillTimelineChart: View {
 
     private func axisLabel(_ cycle: SubscriptionWindowSample) -> String {
         Self.dayFormatter.string(from: cycleDate(cycle))
-    }
-
-    private static func accent(for tool: ToolType) -> Color {
-        switch tool {
-        case .codex: Color(red: 0.30, green: 0.78, blue: 0.74)
-        case .claude: Color(red: 0.93, green: 0.40, blue: 0.40)
-        case .gemini, .antigravity: Color(red: 0.34, green: 0.62, blue: 0.96)
-        case .grok: Color(red: 0.45, green: 0.45, blue: 0.50)
-        default: Color(red: 0.45, green: 0.55, blue: 0.65)
-        }
     }
 
     private static let timestampFormatter: DateFormatter = {

--- a/Tests/VibeBarCoreTests/DesignTokenContractTests.swift
+++ b/Tests/VibeBarCoreTests/DesignTokenContractTests.swift
@@ -31,6 +31,63 @@ final class DesignTokenContractTests: XCTestCase {
         )
     }
 
+    private func fillTimelineSource() throws -> String {
+        try String(
+            contentsOf: repositoryRoot
+                .appendingPathComponent("Sources/VibeBarApp/Views/FillTimelineChart.swift"),
+            encoding: .utf8
+        )
+    }
+
+    /// The reset-history bars use their own five-colour palette, not
+    /// `Theme.providerAccent`. Both clients draw the same chart, so the palette
+    /// belongs in the contract like the rest — and one case per line makes it
+    /// easy to add a provider here and forget the other client entirely.
+    func testResetHistoryAccentsMatchTheContract() throws {
+        let source = try fillTimelineSource()
+        let contractAccents = try XCTUnwrap(
+            contract()["resetHistoryAccent"] as? [String: String]
+        )
+
+        let block = try XCTUnwrap(slice(
+            source,
+            from: "private static func accent(for tool: ToolType)",
+            to: "private static let timestampFormatter"
+        ))
+        var found: [String: String] = [:]
+        for line in block.split(separator: "\n") {
+            guard let red = capture(line, #"red: ([\d.]+)"#),
+                  let green = capture(line, #"green: ([\d.]+)"#),
+                  let blue = capture(line, #"blue: ([\d.]+)"#)
+            else { continue }
+            let colour = hex(red, green, blue)
+            if line.contains("default:") {
+                found["default"] = colour
+                continue
+            }
+            // One case can name several tools: `case .gemini, .antigravity:`.
+            guard let cases = capture(line, #"case ([^:]+):"#) else { continue }
+            for tool in cases.split(separator: ",") {
+                found[tool.trimmingCharacters(in: CharacterSet(charactersIn: " ."))] = colour
+            }
+        }
+
+        XCTAssertFalse(found.isEmpty, "no reset-history accents were parsed")
+        XCTAssertEqual(
+            Set(found.keys), Set(contractAccents.keys),
+            "the contract and the chart disagree about which tools have an accent"
+        )
+        for (tool, colour) in found {
+            XCTAssertEqual(
+                contractAccents[tool], colour,
+                "reset-history accent for \(tool) drifted from the chart"
+            )
+        }
+        // The fallback is what an unlisted provider gets in both clients, so a
+        // missing one would silently give them different colours.
+        XCTAssertNotNil(found["default"], "the fallback accent must be in the contract")
+    }
+
     /// Every provider accent in `Theme.providerAccent` appears in the contract
     /// with the same colour, and the contract names no provider the theme has
     /// dropped.

--- a/Tests/VibeBarCoreTests/DesignTokenContractTests.swift
+++ b/Tests/VibeBarCoreTests/DesignTokenContractTests.swift
@@ -31,63 +31,6 @@ final class DesignTokenContractTests: XCTestCase {
         )
     }
 
-    private func fillTimelineSource() throws -> String {
-        try String(
-            contentsOf: repositoryRoot
-                .appendingPathComponent("Sources/VibeBarApp/Views/FillTimelineChart.swift"),
-            encoding: .utf8
-        )
-    }
-
-    /// The reset-history bars use their own five-colour palette, not
-    /// `Theme.providerAccent`. Both clients draw the same chart, so the palette
-    /// belongs in the contract like the rest — and one case per line makes it
-    /// easy to add a provider here and forget the other client entirely.
-    func testResetHistoryAccentsMatchTheContract() throws {
-        let source = try fillTimelineSource()
-        let contractAccents = try XCTUnwrap(
-            contract()["resetHistoryAccent"] as? [String: String]
-        )
-
-        let block = try XCTUnwrap(slice(
-            source,
-            from: "private static func accent(for tool: ToolType)",
-            to: "private static let timestampFormatter"
-        ))
-        var found: [String: String] = [:]
-        for line in block.split(separator: "\n") {
-            guard let red = capture(line, #"red: ([\d.]+)"#),
-                  let green = capture(line, #"green: ([\d.]+)"#),
-                  let blue = capture(line, #"blue: ([\d.]+)"#)
-            else { continue }
-            let colour = hex(red, green, blue)
-            if line.contains("default:") {
-                found["default"] = colour
-                continue
-            }
-            // One case can name several tools: `case .gemini, .antigravity:`.
-            guard let cases = capture(line, #"case ([^:]+):"#) else { continue }
-            for tool in cases.split(separator: ",") {
-                found[tool.trimmingCharacters(in: CharacterSet(charactersIn: " ."))] = colour
-            }
-        }
-
-        XCTAssertFalse(found.isEmpty, "no reset-history accents were parsed")
-        XCTAssertEqual(
-            Set(found.keys), Set(contractAccents.keys),
-            "the contract and the chart disagree about which tools have an accent"
-        )
-        for (tool, colour) in found {
-            XCTAssertEqual(
-                contractAccents[tool], colour,
-                "reset-history accent for \(tool) drifted from the chart"
-            )
-        }
-        // The fallback is what an unlisted provider gets in both clients, so a
-        // missing one would silently give them different colours.
-        XCTAssertNotNil(found["default"], "the fallback accent must be in the contract")
-    }
-
     /// Every provider accent in `Theme.providerAccent` appears in the contract
     /// with the same colour, and the contract names no provider the theme has
     /// dropped.

--- a/docs/contracts/design-tokens-v1.json
+++ b/docs/contracts/design-tokens-v1.json
@@ -54,5 +54,13 @@
       "warningAtOrAbove": 70
     }
   },
+  "resetHistoryAccent": {
+    "antigravity": "#579EF5",
+    "claude": "#ED6666",
+    "codex": "#4DC7BD",
+    "default": "#738CA6",
+    "gemini": "#579EF5",
+    "grok": "#737380"
+  },
   "schema": 1
 }

--- a/docs/contracts/design-tokens-v1.json
+++ b/docs/contracts/design-tokens-v1.json
@@ -54,13 +54,5 @@
       "warningAtOrAbove": 70
     }
   },
-  "resetHistoryAccent": {
-    "antigravity": "#579EF5",
-    "claude": "#ED6666",
-    "codex": "#4DC7BD",
-    "default": "#738CA6",
-    "gemini": "#579EF5",
-    "grok": "#737380"
-  },
   "schema": 1
 }


### PR DESCRIPTION
`FillTimelineChart` carried a private five-colour palette for its bars.
It was not an alternative table — it was a stale partial copy of
`Theme.providerAccent`, byte-identical for codex, claude and gemini and
diverging only where it had fallen behind:

- **AntiGravity** was painted Gemini's blue instead of its own violet,
  so two providers looked like one.
- **Grok** lost its light/dark adaptation to a fixed grey.
- Unlisted providers got a different fallback.

`docs/DESIGN.md` says colour comes from one table and never from a call
site, and gives this exact failure as the reason. Deleting the local
palette fixes all three at once.

The first commit on this branch added the palette to
`docs/contracts/design-tokens-v1.json` so Vibe Bar Desktop could draw
the same chart; review caught that this would have enshrined the drift
in a cross-client contract. That entry and its test are removed again —
the desktop chart reads `providerAccent`, which the contract already
carries.

1,703 tests pass.