### PR TITLE
Write the quota naming axis down as a contract

### DIFF
--- a/Scripts/generate_quota_naming_contract.py
+++ b/Scripts/generate_quota_naming_contract.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""Regenerate docs/contracts/quota-naming-v1.json from the Swift sources.
+
+The quota axis names — L1 company, L2 SubProvider, L3 group — decide how every
+surface in both clients arranges providers, and AGENTS.md § 7.1 makes getting
+them identical a behavioural rule rather than a nicety. They live in three
+different Swift files here, so this reads all three rather than restating them.
+
+Run after changing ToolType.hierarchy, MiniWindowGroupLabelCatalog, or the
+window suffixes in QuotaFieldRegistry. A test fails if the file drifts.
+"""
+import json
+import pathlib
+import re
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+
+def read(relative: str) -> str:
+    return (ROOT / relative).read_text()
+
+
+def slice_between(text: str, start: str, end: str) -> str:
+    begin = text.index(start)
+    return text[begin : text.index(end, begin)]
+
+
+def hierarchy() -> dict:
+    """L1 company and L2 SubProvider for every tool.
+
+    Two hops: ToolType.hierarchy maps a case to a named catalog entry, and the
+    catalog holds the strings. `ToolType: String` takes its raw value from the
+    case name, so the case name is also the wire key both clients use.
+    """
+    catalog_source = read("Sources/VibeBarCore/Models/ProviderHierarchy.swift")
+    catalog = {
+        name: {"company": vendor, "subProvider": product}
+        for name, vendor, product, _tool in re.findall(
+            r'static let (\w+)\s*=\s*ProviderHierarchy\(vendor: "([^"]*)",\s*'
+            r'product: "([^"]*)",\s*tool: "([^"]*)"\)',
+            catalog_source,
+        )
+    }
+    if not catalog:
+        raise SystemExit("ProviderHierarchyCatalog entries not found")
+
+    table = slice_between(
+        read("Sources/VibeBarCore/Models/ToolType.swift"),
+        "public var hierarchy: ProviderHierarchy",
+        "\n    }",
+    )
+    out = {}
+    for case, entry in re.findall(
+        r"case \.(\w+):\s*return ProviderHierarchyCatalog\.(\w+)", table
+    ):
+        if entry not in catalog:
+            raise SystemExit(f"{case} points at unknown catalog entry {entry}")
+        out[case] = catalog[entry]
+    if not out:
+        raise SystemExit("ToolType.hierarchy cases not found")
+    return out
+
+
+def group_labels() -> dict:
+    """The short label each L3 group shows, e.g. codex.spark -> "Spark"."""
+    source = read("Sources/VibeBarApp/Views/MiniWindowGroupLabelCatalog.swift")
+    catalog = slice_between(source, "static let all:", "static func defaultLabel")
+    return {
+        key: label
+        for key, _title, label in re.findall(
+            r'\.init\(id: "([^"]+)", title: "([^"]*)", defaultLabel: "([^"]*)"\)', catalog
+        )
+    }
+
+
+def group_key_rules() -> dict:
+    """How a bucket id becomes an L3 group key, in the order native applies."""
+    source = read("Sources/VibeBarApp/Views/MiniWindowGroupLabelCatalog.swift")
+    body = slice_between(source, "static func groupKey(", "static func subProviderKey")
+
+    exact = []
+    # A case can list several buckets: `case "a", "b": return "key"`. Matching
+    # only the single-bucket form silently dropped codex.spark, which is the
+    # kind of omission a generator must fail on rather than quietly ship.
+    for buckets, tool, key in re.findall(
+        r'case ((?:"[^"]+"(?:, )?)+)(?: where tool == \.(\w+))?: return "([^"]+)"', body
+    ):
+        for bucket in re.findall(r'"([^"]+)"', buckets):
+            entry = {"bucket": bucket, "key": key}
+            if tool:
+                entry["tool"] = tool
+            exact.append(entry)
+
+    contains = []
+    current_tool = None
+    for line in body.splitlines():
+        tool_match = re.search(r"if tool == \.(\w+) \{", line)
+        if tool_match:
+            current_tool = tool_match.group(1)
+            continue
+        needle_match = re.search(r'if id\.contains\("([^"]+)"\) \{ return "([^"]+)" \}', line)
+        if needle_match and current_tool:
+            contains.append({
+                "tool": current_tool,
+                "contains": needle_match.group(1),
+                "key": needle_match.group(2),
+            })
+            continue
+        list_match = re.search(
+            r'if \[([^\]]+)\]\.contains\(id\) \{', line)
+        if list_match and current_tool:
+            buckets = re.findall(r'"([^"]+)"', list_match.group(1))
+            contains.append({"tool": current_tool, "anyOf": buckets, "key": None})
+    # The multi-bucket `anyOf` branches return on the following line.
+    keys = re.findall(r'\]\.contains\(id\)\s*\{\s*return\s*"([^"]+)"', body, re.S)
+    pending = [rule for rule in contains if rule["key"] is None]
+    for rule, key in zip(pending, keys):
+        rule["key"] = key
+
+    defaults = dict(
+        re.findall(r'case \.(\w+): return "([^"]+)"',
+                   slice_between(source, "static func namingGroupKey", "static func groupKey"))
+    )
+
+    suffixes = re.findall(
+        r'"(_[a-z_]+)"',
+        slice_between(read("Sources/VibeBarCore/Models/QuotaFieldRegistry.swift"),
+                      "static func bucketGroupStem", "return stem.isEmpty"),
+    )
+    rules = {
+        "exact": exact,
+        "contains": contains,
+        "defaultGroup": defaults,
+        "stemSuffixes": [s for s in suffixes if s != "_window"],
+    }
+    # Every group key the Swift switch can return must have made it into one of
+    # the rule lists. A regex that stops matching is otherwise indistinguishable
+    # from a rule that was deleted.
+    returned = set(re.findall(r'return "([\w.+-]+)"', body))
+    captured = {rule["key"] for rule in exact} | {rule["key"] for rule in contains}
+    missing = returned - captured
+    if missing:
+        raise SystemExit(f"groupKey rules not captured: {sorted(missing)}")
+    if any(rule["key"] is None for rule in contains):
+        raise SystemExit("a multi-bucket rule did not find its key")
+    return rules
+
+
+def main() -> None:
+    tools = hierarchy()
+    document = {
+        "schema": "quota-naming-v1",
+        "note": (
+            "The quota axis: L1 company, L2 SubProvider, L3 group. Generated by "
+            "Scripts/generate_quota_naming_contract.py from ToolType.swift, "
+            "MiniWindowGroupLabelCatalog.swift and QuotaFieldRegistry.swift. "
+            "Usage-axis names (harnesses) are a different axis and never mix "
+            "with these in one list."
+        ),
+        "hierarchy": tools,
+        "subProviderOverrides": [
+            {"tool": "cursor", "bucket": "grok_bot_weekly", "subProvider": "Grok Bot"}
+        ],
+        "ungrouped": [
+            {"tool": "cursor", "bucket": "grok_bot_weekly",
+             "why": "sits directly under its SubProvider, with no L3 group"}
+        ],
+        "groupLabels": group_labels(),
+        "groupKey": group_key_rules(),
+        "fallback": (
+            "A bucket no rule names takes the key '<tool>.<stem>', where the stem "
+            "is the bucket id with one stemSuffix removed, and shows the bucket's "
+            "own groupTitle as its label."
+        ),
+    }
+    path = ROOT / "docs/contracts/quota-naming-v1.json"
+    path.write_text(json.dumps(document, indent=2, sort_keys=True) + "\n")
+    print(f"{path.name}: {len(tools)} tools, {len(document['groupLabels'])} group labels, "
+          f"{len(document['groupKey']['exact'])} exact + {len(document['groupKey']['contains'])} pattern rules")
+
+
+if __name__ == "__main__":
+    main()

--- a/Tests/VibeBarCoreTests/QuotaNamingContractTests.swift
+++ b/Tests/VibeBarCoreTests/QuotaNamingContractTests.swift
@@ -1,0 +1,142 @@
+import XCTest
+@testable import VibeBarCore
+
+/// The quota axis — L1 company, L2 SubProvider, L3 group — is shared with Vibe
+/// Bar Desktop through `docs/contracts/quota-naming-v1.json`. Both clients
+/// arrange every provider list by it, and `AGENTS.md` § 7.1 makes agreeing on
+/// these names a behavioural rule rather than a nicety: a bucket filed under
+/// "Spark" here and "GPT-5.3 Codex Spark" there is two things to the reader.
+///
+/// The contract is generated from three Swift files. Rather than reimplement
+/// that parsing in Swift and get a second thing to keep in step, this runs the
+/// generator and compares — so the check is exact and total by construction,
+/// including any rule added after this test was written.
+final class QuotaNamingContractTests: XCTestCase {
+    /// `Tests/VibeBarCoreTests/<this file>` → three levels up.
+    private var repositoryRoot: URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+    }
+
+    private var contractURL: URL {
+        repositoryRoot.appendingPathComponent("docs/contracts/quota-naming-v1.json")
+    }
+
+    func testContractIsWhatTheGeneratorProduces() throws {
+        let committed = try Data(contentsOf: contractURL)
+        guard let python = try locatePython() else {
+            throw XCTSkip("no python3 on PATH; the generator cannot be re-run here")
+        }
+
+        // Regenerate into a scratch copy of the repository's contract path so a
+        // failing test never leaves the working tree modified.
+        let backup = committed
+        defer { try? backup.write(to: contractURL) }
+
+        let process = Process()
+        process.executableURL = python
+        process.arguments = [
+            repositoryRoot
+                .appendingPathComponent("Scripts/generate_quota_naming_contract.py")
+                .path
+        ]
+        let errors = Pipe()
+        process.standardError = errors
+        process.standardOutput = Pipe()
+        try process.run()
+        let errorText = String(
+            data: errors.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8
+        ) ?? ""
+        process.waitUntilExit()
+        XCTAssertEqual(
+            process.terminationStatus, 0,
+            "the generator refused to run: \(errorText)"
+        )
+
+        let regenerated = try Data(contentsOf: contractURL)
+        XCTAssertEqual(
+            regenerated, committed,
+            """
+            quota-naming-v1.json is stale. The naming tables in ToolType.swift, \
+            MiniWindowGroupLabelCatalog.swift or QuotaFieldRegistry.swift changed \
+            without the contract being regenerated, which leaves Vibe Bar Desktop \
+            grouping providers the way this app used to. Run \
+            Scripts/generate_quota_naming_contract.py.
+            """
+        )
+    }
+
+    /// The parts a second implementation cannot infer, asserted directly. If
+    /// the generator were ever pointed at the wrong file it would still agree
+    /// with itself; these do not.
+    func testTheContractDescribesTheHierarchyThisAppUses() throws {
+        let document = try contract()
+        let hierarchy = try XCTUnwrap(document["hierarchy"] as? [String: [String: String]])
+
+        XCTAssertEqual(hierarchy.count, ToolType.allCases.count,
+                       "every tool needs a place on the quota axis")
+        for tool in ToolType.allCases {
+            let entry = try XCTUnwrap(hierarchy[tool.rawValue], "no hierarchy for \(tool.rawValue)")
+            XCTAssertEqual(entry["company"], tool.hierarchy.vendor)
+            XCTAssertEqual(entry["subProvider"], tool.hierarchy.product)
+        }
+
+        // Cursor reports Grok Bot's usage, so that one bucket belongs to a
+        // different SubProvider than the account it arrives on. It is the only
+        // case, and the one a naive tool-level mapping gets wrong.
+        let overrides = try XCTUnwrap(document["subProviderOverrides"] as? [[String: String]])
+        let grokBot = try XCTUnwrap(overrides.first { $0["bucket"] == "grok_bot_weekly" })
+        XCTAssertEqual(grokBot["tool"], ToolType.cursor.rawValue)
+        XCTAssertEqual(
+            grokBot["subProvider"],
+            ToolType.cursor.quotaSubProviderName(bucketID: "grok_bot_weekly")
+        )
+        XCTAssertNotEqual(grokBot["subProvider"], ToolType.cursor.hierarchy.product,
+                          "an override that matches the default is not an override")
+    }
+
+    /// Every group key a rule can produce is either labelled here or documented
+    /// as taking the bucket's own `groupTitle`. Without this a rule could point
+    /// at a key nothing names, and the second client would draw a blank column
+    /// header where this one draws a word.
+    func testEveryRuleKeyIsEitherLabelledOrExplicitlyUnlabelled() throws {
+        let document = try contract()
+        let labels = try XCTUnwrap(document["groupLabels"] as? [String: String])
+        let rules = try XCTUnwrap(document["groupKey"] as? [String: Any])
+        let exact = try XCTUnwrap(rules["exact"] as? [[String: Any]])
+        let contains = try XCTUnwrap(rules["contains"] as? [[String: Any]])
+
+        let keys = Set(
+            exact.compactMap { $0["key"] as? String }
+                + contains.compactMap { $0["key"] as? String }
+        )
+        XCTAssertFalse(keys.isEmpty)
+        for key in keys where labels[key] == nil {
+            // Unlabelled is allowed, but only for keys this app also leaves to
+            // the runtime catalog. Those all describe model families a provider
+            // may or may not expose.
+            XCTAssertTrue(
+                key.hasPrefix("antigravity."),
+                "\(key) has no label and is not one of the runtime-named groups"
+            )
+        }
+        XCTAssertNotNil(document["fallback"] as? String,
+                        "the unnamed case has to be written down somewhere")
+    }
+
+    private func contract() throws -> [String: Any] {
+        let data = try Data(contentsOf: contractURL)
+        return try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+    }
+
+    private func locatePython() throws -> URL? {
+        for candidate in ["/usr/bin/python3", "/opt/homebrew/bin/python3", "/usr/local/bin/python3"] {
+            if FileManager.default.isExecutableFile(atPath: candidate) {
+                return URL(fileURLWithPath: candidate)
+            }
+        }
+        return nil
+    }
+}

--- a/docs/contracts/quota-naming-v1.json
+++ b/docs/contracts/quota-naming-v1.json
@@ -1,0 +1,259 @@
+{
+  "fallback": "A bucket no rule names takes the key '<tool>.<stem>', where the stem is the bucket id with one stemSuffix removed, and shows the bucket's own groupTitle as its label.",
+  "groupKey": {
+    "contains": [
+      {
+        "contains": "flash-lite",
+        "key": "gemini.flash-lite",
+        "tool": "gemini"
+      },
+      {
+        "contains": "flash",
+        "key": "gemini.flash",
+        "tool": "gemini"
+      },
+      {
+        "contains": "pro",
+        "key": "gemini.pro",
+        "tool": "gemini"
+      },
+      {
+        "anyOf": [
+          "gemini_five_hour",
+          "gemini_weekly"
+        ],
+        "key": "antigravity.gemini-models",
+        "tool": "antigravity"
+      },
+      {
+        "anyOf": [
+          "claude_gpt_five_hour",
+          "claude_gpt_weekly"
+        ],
+        "key": "antigravity.claude-gpt-models",
+        "tool": "antigravity"
+      },
+      {
+        "contains": "gpt-oss",
+        "key": "antigravity.gpt-oss",
+        "tool": "antigravity"
+      },
+      {
+        "contains": "claude",
+        "key": "antigravity.claude",
+        "tool": "antigravity"
+      },
+      {
+        "contains": "flash-lite",
+        "key": "antigravity.gemini-flash-lite",
+        "tool": "antigravity"
+      },
+      {
+        "contains": "flash",
+        "key": "antigravity.gemini-flash",
+        "tool": "antigravity"
+      },
+      {
+        "contains": "pro",
+        "key": "antigravity.gemini-pro",
+        "tool": "antigravity"
+      }
+    ],
+    "defaultGroup": {
+      "claude": "claude.all-models",
+      "codex": "codex.all-models",
+      "gemini": "gemini.all-models",
+      "grok": "grok.all-models"
+    },
+    "exact": [
+      {
+        "bucket": "gpt_5_3_codex_spark_five_hour",
+        "key": "codex.spark"
+      },
+      {
+        "bucket": "gpt_5_3_codex_spark_weekly",
+        "key": "codex.spark"
+      },
+      {
+        "bucket": "weekly_sonnet",
+        "key": "claude.sonnet"
+      },
+      {
+        "bucket": "weekly_design",
+        "key": "claude.design"
+      },
+      {
+        "bucket": "daily_routines",
+        "key": "claude.routine"
+      },
+      {
+        "bucket": "weekly_opus",
+        "key": "claude.opus"
+      },
+      {
+        "bucket": "weekly_fable",
+        "key": "claude.fable"
+      },
+      {
+        "bucket": "weekly_oauth_apps",
+        "key": "claude.oauth"
+      },
+      {
+        "bucket": "models",
+        "key": "cursor.models",
+        "tool": "cursor"
+      },
+      {
+        "bucket": "other_models",
+        "key": "cursor.other-models",
+        "tool": "cursor"
+      }
+    ],
+    "stemSuffixes": [
+      "_five_hour",
+      "_weekly",
+      "_monthly",
+      "_daily",
+      "_primary",
+      "_secondary"
+    ]
+  },
+  "groupLabels": {
+    "antigravity.claude-gpt-models": "Claude + GPT",
+    "antigravity.gemini-models": "Gemini",
+    "claude.all-models": "All",
+    "claude.design": "Design",
+    "claude.fable": "Fable",
+    "claude.oauth": "OAuth",
+    "claude.opus": "Opus",
+    "claude.routine": "Routine",
+    "claude.sonnet": "Sonnet",
+    "codex.all-models": "All",
+    "codex.spark": "Spark",
+    "cursor.models": "Cursor",
+    "cursor.other-models": "Other",
+    "gemini.all-models": "All",
+    "gemini.flash": "Flash",
+    "gemini.flash-lite": "Flash Lite",
+    "gemini.pro": "Pro",
+    "grok.all-models": "All"
+  },
+  "hierarchy": {
+    "alibaba": {
+      "company": "Alibaba",
+      "subProvider": "Bailian"
+    },
+    "alibabaTokenPlan": {
+      "company": "Alibaba",
+      "subProvider": "Bailian"
+    },
+    "antigravity": {
+      "company": "Google AI",
+      "subProvider": "AntiGravity"
+    },
+    "baiduQianfan": {
+      "company": "Baidu",
+      "subProvider": "Qianfan"
+    },
+    "claude": {
+      "company": "Anthropic",
+      "subProvider": "Claude"
+    },
+    "codex": {
+      "company": "OpenAI",
+      "subProvider": "ChatGPT Agentic"
+    },
+    "copilot": {
+      "company": "GitHub",
+      "subProvider": "Copilot"
+    },
+    "cursor": {
+      "company": "SpaceXAI",
+      "subProvider": "Cursor"
+    },
+    "gemini": {
+      "company": "Google AI",
+      "subProvider": "Gemini Web"
+    },
+    "grok": {
+      "company": "SpaceXAI",
+      "subProvider": "Grok"
+    },
+    "iflytek": {
+      "company": "iFlytek",
+      "subProvider": "Spark"
+    },
+    "kilo": {
+      "company": "Kilo",
+      "subProvider": "Kilo"
+    },
+    "kimi": {
+      "company": "Moonshot",
+      "subProvider": "Kimi"
+    },
+    "kiro": {
+      "company": "Kiro",
+      "subProvider": "Kiro"
+    },
+    "mimo": {
+      "company": "Xiaomi",
+      "subProvider": "MiMo"
+    },
+    "minimax": {
+      "company": "MiniMax",
+      "subProvider": "MiniMax"
+    },
+    "ollama": {
+      "company": "Ollama",
+      "subProvider": "Ollama"
+    },
+    "openCodeGo": {
+      "company": "OpenCode",
+      "subProvider": "OpenCode Go"
+    },
+    "openRouter": {
+      "company": "OpenRouter",
+      "subProvider": "OpenRouter"
+    },
+    "tencentHunyuan": {
+      "company": "Tencent",
+      "subProvider": "Hunyuan"
+    },
+    "tencentTokenPlan": {
+      "company": "Tencent",
+      "subProvider": "Hunyuan"
+    },
+    "volcengine": {
+      "company": "ByteDance",
+      "subProvider": "Doubao"
+    },
+    "volcengineAgentPlan": {
+      "company": "ByteDance",
+      "subProvider": "Doubao"
+    },
+    "warp": {
+      "company": "Warp",
+      "subProvider": "Warp"
+    },
+    "zai": {
+      "company": "Zhipu",
+      "subProvider": "GLM"
+    }
+  },
+  "note": "The quota axis: L1 company, L2 SubProvider, L3 group. Generated by Scripts/generate_quota_naming_contract.py from ToolType.swift, MiniWindowGroupLabelCatalog.swift and QuotaFieldRegistry.swift. Usage-axis names (harnesses) are a different axis and never mix with these in one list.",
+  "schema": "quota-naming-v1",
+  "subProviderOverrides": [
+    {
+      "bucket": "grok_bot_weekly",
+      "subProvider": "Grok Bot",
+      "tool": "cursor"
+    }
+  ],
+  "ungrouped": [
+    {
+      "bucket": "grok_bot_weekly",
+      "tool": "cursor",
+      "why": "sits directly under its SubProvider, with no L3 group"
+    }
+  ]
+}


### PR DESCRIPTION
L1 company, L2 SubProvider, L3 group decide how both clients arrange
every provider list, and `AGENTS.md` § 7.1 makes agreeing on them a
behavioural rule rather than a nicety.

They currently live in three Swift files — `ProviderHierarchy.swift`,
`MiniWindowGroupLabelCatalog.swift` and `QuotaFieldRegistry.swift` — so
Vibe Bar Desktop maintains its own copy of the tool-level half and has
no access at all to the group-level half. A bucket this app files under
**Spark** would appear there as **GPT-5.3 Codex Spark**, and one it
files under **Claude + GPT** as **Claude + GPT Models**.

`docs/contracts/quota-naming-v1.json` is generated from all three files
by `Scripts/generate_quota_naming_contract.py`. The main test re-runs
the generator and diffs the result, so it covers rules added after the
test was written, not just the ones present today. Two further tests
bind what a self-consistent generator would still get wrong: the
hierarchy against `ToolType` itself, and the one bucket
(`cursor/grok_bot_weekly`) whose SubProvider differs from its account's.

Writing the generator surfaced a rule it had silently dropped —
`codex.spark`, whose Swift case lists two bucket ids — so it now refuses
to emit a contract missing any key the switch can return.

No behaviour change. 1,706 tests pass; each of the three tests was
checked to fail when the thing it guards is altered.
