### PR TITLE
Say in the contract which buckets are their own quota group

### DIFF
--- a/Scripts/generate_quota_naming_contract.py
+++ b/Scripts/generate_quota_naming_contract.py
@@ -122,6 +122,19 @@ def group_key_rules() -> dict:
                    slice_between(source, "static func namingGroupKey", "static func groupKey"))
     )
 
+    # Which buckets go through the rules at all. The rest take their tool's
+    # default group, and a second implementation cannot infer the difference:
+    # Codex's plain Weekly is "All", but its Spark buckets are their own group.
+    branch = slice_between(
+        read("Sources/VibeBarApp/Views/MiniQuotaWindowView.swift"),
+        "static func isBranchStyleField",
+        "\n    }",
+    )
+    always = re.findall(r"if field\.tool == \.(\w+) \{\s*\n\s*return true", branch)
+    listed = re.findall(r'"([\w]+)"', branch[branch.index("switch field.bucketId"):])
+    if not always or not listed:
+        raise SystemExit("the branch-style rule did not parse")
+
     suffixes = re.findall(
         r'"(_[a-z_]+)"',
         slice_between(read("Sources/VibeBarCore/Models/QuotaFieldRegistry.swift"),
@@ -132,6 +145,11 @@ def group_key_rules() -> dict:
         "contains": contains,
         "defaultGroup": defaults,
         "stemSuffixes": [s for s in suffixes if s != "_window"],
+        "branchStyle": {
+            "alwaysTools": always,
+            "buckets": listed,
+            "discoveredNeedGroupTitle": True,
+        },
     }
     # Every group key the Swift switch can return must have made it into one of
     # the rule lists. A regex that stops matching is otherwise indistinguishable
@@ -171,6 +189,16 @@ def main() -> None:
             "A bucket no rule names takes the key '<tool>.<stem>', where the stem "
             "is the bucket id with one stemSuffix removed, and shows the bucket's "
             "own groupTitle as its label."
+        ),
+        "groupKeyOrder": (
+            "Cursor first: grok_bot_weekly is ungrouped, its other buckets go "
+            "through the rules. Then branchStyle decides whether a bucket is its "
+            "own L3 group at all — alwaysTools always are, a bucket in "
+            "branchStyle.buckets is, and a bucket discovered at runtime is "
+            "exactly when it carried a groupTitle. Everything else takes its "
+            "tool's defaultGroup, and has none if the tool is not listed there. "
+            "Only a branch-style bucket reaches exact, then contains in order, "
+            "then the fallback."
         ),
     }
     path = ROOT / "docs/contracts/quota-naming-v1.json"

--- a/Tests/VibeBarCoreTests/QuotaNamingContractTests.swift
+++ b/Tests/VibeBarCoreTests/QuotaNamingContractTests.swift
@@ -126,6 +126,34 @@ final class QuotaNamingContractTests: XCTestCase {
                         "the unnamed case has to be written down somewhere")
     }
 
+    /// The rule that decides whether a bucket is an L3 group at all. Without
+    /// it a second implementation cannot tell Codex's plain Weekly (which
+    /// belongs to the "All" group) from its Spark buckets (which are their
+    /// own), and has to guess — the guess I wrote was wrong for every bucket
+    /// discovered at runtime.
+    func testTheContractSaysWhichBucketsAreTheirOwnGroup() throws {
+        let rules = try XCTUnwrap(contract()["groupKey"] as? [String: Any])
+        let branch = try XCTUnwrap(rules["branchStyle"] as? [String: Any])
+
+        let always = try XCTUnwrap(branch["alwaysTools"] as? [String])
+        XCTAssertEqual(
+            always, [ToolType.antigravity.rawValue],
+            "AntiGravity's lanes are split across two groups, so all of its rows are"
+        )
+        let buckets = try XCTUnwrap(branch["buckets"] as? [String])
+        XCTAssertTrue(buckets.contains("weekly_fable"))
+        XCTAssertFalse(
+            buckets.contains("weekly"),
+            "a plain weekly bucket takes its tool's default group, not its own"
+        )
+        XCTAssertEqual(branch["discoveredNeedGroupTitle"] as? Bool, true)
+
+        // Order is load-bearing and cannot be recovered from the tables.
+        let order = try XCTUnwrap(contract()["groupKeyOrder"] as? String)
+        XCTAssertTrue(order.contains("defaultGroup"))
+        XCTAssertTrue(order.contains("in order"), "`contains` rules are ordered")
+    }
+
     private func contract() throws -> [String: Any] {
         let data = try Data(contentsOf: contractURL)
         return try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])

--- a/docs/contracts/quota-naming-v1.json
+++ b/docs/contracts/quota-naming-v1.json
@@ -1,6 +1,22 @@
 {
   "fallback": "A bucket no rule names takes the key '<tool>.<stem>', where the stem is the bucket id with one stemSuffix removed, and shows the bucket's own groupTitle as its label.",
   "groupKey": {
+    "branchStyle": {
+      "alwaysTools": [
+        "antigravity"
+      ],
+      "buckets": [
+        "gpt_5_3_codex_spark_five_hour",
+        "gpt_5_3_codex_spark_weekly",
+        "weekly_sonnet",
+        "weekly_design",
+        "daily_routines",
+        "weekly_opus",
+        "weekly_fable",
+        "weekly_oauth_apps"
+      ],
+      "discoveredNeedGroupTitle": true
+    },
     "contains": [
       {
         "contains": "flash-lite",
@@ -118,6 +134,7 @@
       "_secondary"
     ]
   },
+  "groupKeyOrder": "Cursor first: grok_bot_weekly is ungrouped, its other buckets go through the rules. Then branchStyle decides whether a bucket is its own L3 group at all \u2014 alwaysTools always are, a bucket in branchStyle.buckets is, and a bucket discovered at runtime is exactly when it carried a groupTitle. Everything else takes its tool's defaultGroup, and has none if the tool is not listed there. Only a branch-style bucket reaches exact, then contains in order, then the fallback.",
   "groupLabels": {
     "antigravity.claude-gpt-models": "Claude + GPT",
     "antigravity.gemini-models": "Gemini",


### PR DESCRIPTION
Follow-up to #276, found by writing the client side of it.

The contract carried the group-key tables but not `isBranchStyleField` —
the rule that decides whether a bucket goes through those tables at all.
Everything else takes its tool's `defaultGroup`, so without it a second
implementation cannot tell Codex's plain `weekly` (which belongs to the
"All" group) from `gpt_5_3_codex_spark_weekly` (which is its own group).

I noticed because I had to invent a predicate to fill the gap, and the
one I invented was wrong for every bucket discovered at runtime: native
asks whether it carried a `groupTitle` when it was recorded, which no
amount of staring at the static tables would have told me.

The rule *order* is written down as well. It is load-bearing and not
recoverable from the tables: Cursor is special-cased first, `branchStyle`
decides next, and the `contains` rules are tried in order because
`flash-lite` must be tested before `flash`.

A new test binds the parsed rule to what the app does — AntiGravity is
always branch-style, `weekly_fable` is, a plain `weekly` is not — and the
generator refuses to emit a contract where the rule failed to parse.

No behaviour change. 1,707 tests pass.