### PR TITLE
Record what a provider does to the clock when it refills early

### DIFF
--- a/Sources/VibeBarApp/Views/FillTimelineChart.swift
+++ b/Sources/VibeBarApp/Views/FillTimelineChart.swift
@@ -186,7 +186,7 @@ struct FillTimelineChart: View {
         case .earlyClockRestarted: " · refilled early, next window restarted"
         case .earlyClockUnchanged: " · refilled early, next reset unchanged"
         case .earlyUnclear: " · refilled early, onto a different schedule"
-        case .onSchedule, nil: ""
+        case .onSchedule, .unobserved, nil: ""
         }
     }
 

--- a/Sources/VibeBarApp/Views/FillTimelineChart.swift
+++ b/Sources/VibeBarApp/Views/FillTimelineChart.swift
@@ -54,11 +54,13 @@ struct FillTimelineChart: View {
                     .font(.system(size: max(7.5, density.subtitleFontSize - 4)))
                     .foregroundStyle(.quaternary)
             }
+            earlyRefillMarks(cycles, tool: series.tool)
             cycleStrip(cycles, tool: series.tool, targetPercent: targetPercent)
             Text(caption(cycles))
                 .font(.system(size: max(8, density.subtitleFontSize - 3), design: .rounded).monospacedDigit())
                 .foregroundStyle(.secondary)
                 .fixedSize(horizontal: false, vertical: true)
+            earlyRefillNote(cycles)
             axis(cycles)
         }
         .padding(.top, 4)
@@ -140,6 +142,54 @@ struct FillTimelineChart: View {
         }
     }
 
+    /// Dots over the cycles that refilled before their window was up.
+    ///
+    /// Above the bars rather than inside them: a cycle that spent all of its
+    /// quota fills its track to the top, where a marker would be the same
+    /// colour as the fill under it.
+    @ViewBuilder
+    private func earlyRefillMarks(
+        _ cycles: [SubscriptionWindowSample],
+        tool: ToolType
+    ) -> some View {
+        if cycles.contains(where: \.refilledEarly) {
+            HStack(alignment: .center, spacing: barSpacing) {
+                ForEach(Array(cycles.enumerated()), id: \.offset) { _, cycle in
+                    Circle()
+                        .fill(Theme.providerAccent(for: tool).opacity(cycle.refilledEarly ? 0.8 : 0))
+                        .frame(width: 3, height: 3)
+                        .frame(maxWidth: .infinity)
+                }
+            }
+            .frame(height: 4)
+        }
+    }
+
+    @ViewBuilder
+    private func earlyRefillNote(_ cycles: [SubscriptionWindowSample]) -> some View {
+        let early = cycles.filter(\.refilledEarly).count
+        if early > 0 {
+            Text(
+                early == 1
+                    ? "1 cycle refilled before the window was up"
+                    : "\(early) cycles refilled before the window was up"
+            )
+            .font(.system(size: max(7.5, density.subtitleFontSize - 4), design: .rounded))
+            .foregroundStyle(.quaternary)
+        }
+    }
+
+    /// What the provider did to the clock, when it did anything unusual. The
+    /// two early shapes mean opposite things, so the caption says which.
+    private func resetDescription(_ cycle: SubscriptionWindowSample) -> String {
+        switch cycle.resetKind {
+        case .earlyClockRestarted: " · refilled early, next window restarted"
+        case .earlyClockUnchanged: " · refilled early, next reset unchanged"
+        case .earlyUnclear: " · refilled early, onto a different schedule"
+        case .onSchedule, nil: ""
+        }
+    }
+
     private func caption(_ cycles: [SubscriptionWindowSample]) -> String {
         guard !cycles.isEmpty else {
             return "A cycle is recorded when the quota refills"
@@ -157,7 +207,7 @@ struct FillTimelineChart: View {
             } else {
                 gapText = ""
             }
-            return "\(Self.timestampFormatter.string(from: completedAt)) reset · \(used)% used · \(left)% left\(gapText)"
+            return "\(Self.timestampFormatter.string(from: completedAt)) reset · \(used)% used · \(left)% left\(resetDescription(cycle))\(gapText)"
         }
         return "Current cycle · \(used)% used so far · \(left)% left"
     }

--- a/Sources/VibeBarCore/Models/SubscriptionWindowSample.swift
+++ b/Sources/VibeBarCore/Models/SubscriptionWindowSample.swift
@@ -24,6 +24,12 @@ public struct SubscriptionWindowSample: Codable, Hashable, Sendable {
         case earlyClockRestarted
         case earlyClockUnchanged
         case earlyUnclear
+        /// Asked and unanswerable: the observations this cycle would have been
+        /// judged from are gone, pruned or never recorded. Distinct from `nil`,
+        /// which means nobody has looked — without the difference the backfill
+        /// would retry every launch, forever, for a cycle whose evidence no
+        /// longer exists.
+        case unobserved
     }
 
     public var accountId: String
@@ -53,7 +59,7 @@ public struct SubscriptionWindowSample: Codable, Hashable, Sendable {
     public var refilledEarly: Bool {
         switch resetKind {
         case .earlyClockRestarted, .earlyClockUnchanged, .earlyUnclear: true
-        case .onSchedule, nil: false
+        case .onSchedule, .unobserved, nil: false
         }
     }
     public var remainingPercentAtReset: Double {

--- a/Sources/VibeBarCore/Models/SubscriptionWindowSample.swift
+++ b/Sources/VibeBarCore/Models/SubscriptionWindowSample.swift
@@ -10,6 +10,22 @@ public struct SubscriptionWindowSample: Codable, Hashable, Sendable {
         case legacyTimelineMigration
     }
 
+    /// What the provider did to the clock when it refilled, which is a
+    /// different question from how the refill was noticed.
+    ///
+    /// A window that refills before it said it would is an event worth
+    /// showing, and the two early shapes mean opposite things. When the next
+    /// reset moves out to a full window from the refill, a whole window lies
+    /// ahead and the extra capacity is usable. When it does not move, less
+    /// than a window remains to spend the refill in, so it is the easier one
+    /// to waste.
+    public enum ResetKind: String, Codable, Hashable, Sendable {
+        case onSchedule
+        case earlyClockRestarted
+        case earlyClockUnchanged
+        case earlyUnclear
+    }
+
     public var accountId: String
     public var tool: ToolType
     public var bucketId: String
@@ -23,8 +39,23 @@ public struct SubscriptionWindowSample: Codable, Hashable, Sendable {
     public var lastSeenAt: Date
     public var completedAt: Date?
     public var completionReason: CompletionReason?
+    /// Optional so samples written before this existed still decode; a nil on
+    /// a completed cycle means it finished before the app classified them.
+    public var resetKind: ResetKind?
+    /// How long after the previous refill this one arrived. Compared against
+    /// `rawWindowSeconds`, this is what shows a bucket keeping a schedule
+    /// other than the one it advertises.
+    public var intervalSeconds: TimeInterval?
 
     public var isCompleted: Bool { completedAt != nil }
+
+    /// Did this window refill before it said it would?
+    public var refilledEarly: Bool {
+        switch resetKind {
+        case .earlyClockRestarted, .earlyClockUnchanged, .earlyUnclear: true
+        case .onSchedule, nil: false
+        }
+    }
     public var remainingPercentAtReset: Double {
         max(0, 100 - peakUsedPercent)
     }
@@ -42,7 +73,9 @@ public struct SubscriptionWindowSample: Codable, Hashable, Sendable {
         firstSeenAt: Date,
         lastSeenAt: Date,
         completedAt: Date? = nil,
-        completionReason: CompletionReason? = nil
+        completionReason: CompletionReason? = nil,
+        resetKind: ResetKind? = nil,
+        intervalSeconds: TimeInterval? = nil
     ) {
         self.accountId = accountId
         self.tool = tool
@@ -57,6 +90,8 @@ public struct SubscriptionWindowSample: Codable, Hashable, Sendable {
         self.lastSeenAt = lastSeenAt
         self.completedAt = completedAt
         self.completionReason = completionReason
+        self.resetKind = resetKind
+        self.intervalSeconds = intervalSeconds
     }
 
     private static func clamp(_ value: Double) -> Double {

--- a/Sources/VibeBarCore/Services/SubscriptionHistoryStore.swift
+++ b/Sources/VibeBarCore/Services/SubscriptionHistoryStore.swift
@@ -44,7 +44,7 @@ public actor SubscriptionHistoryStore {
     private static let storageSchemaVersion = 2
     private static let saveThrottleInterval: TimeInterval = 30
     private static let maxFileBytes = 16 * 1024 * 1024
-    private static let currentResetSignalRepairVersion = 2
+    private static let currentResetSignalRepairVersion = 1
     /// How early is early, and how close a new reset has to be to count as
     /// restarted or unchanged. A tenth of the window on each side: wide enough
     /// to absorb the minute or two a provider takes to publish a new boundary,
@@ -169,7 +169,10 @@ public actor SubscriptionHistoryStore {
         let needsLegacyImport = !storage.legacyTimelineImported
         let needsResetSignalRepair = (storage.resetSignalRepairVersion ?? 0)
             < Self.currentResetSignalRepairVersion
-        guard needsLegacyImport || needsResetSignalRepair else { return }
+        let needsClassification = storage.samples.contains {
+            $0.isCompleted && $0.resetKind == nil
+        }
+        guard needsLegacyImport || needsResetSignalRepair || needsClassification else { return }
 
         if needsLegacyImport {
             storage.legacyTimelineImported = true
@@ -184,6 +187,13 @@ public actor SubscriptionHistoryStore {
         // Cheap to fill in, and worth doing rather than waiting: the chart
         // shows twelve cycles, which on a weekly bucket is three months of
         // going without.
+        //
+        // Gated on the samples themselves rather than on
+        // `resetSignalRepairVersion`. That number also gates
+        // `repairMissedResetSignals`, so bumping it to reach this pass would
+        // re-run a migration that had already finished — and a pass that knows
+        // from its own data whether there is anything to do needs no version
+        // at all.
         classifyStoredResets(points, in: &storage)
         pruneInPlace(&storage, retentionDays: retentionDays, now: Date())
         save(storage)
@@ -245,7 +255,15 @@ public actor SubscriptionHistoryStore {
         }
         var sortedByKey: [SubscriptionHistoryKey: [FillTimelinePoint]] = [:]
         for (key, raw) in grouped {
-            sortedByKey[key] = raw.sorted { $0.sampledAt < $1.sampledAt }
+            // Only points carrying a reset time, because those are the only
+            // ones `observe` ever looked at: it skips the rest outright. A
+            // nearest-timestamp match over the full series lands on a
+            // neighbour the live path never saw, and on this developer's
+            // timeline that is most of them — 173 cycles went unclassified
+            // for want of a reset time on the row next door.
+            sortedByKey[key] = raw
+                .filter { $0.resetAt != nil }
+                .sorted { $0.sampledAt < $1.sampledAt }
         }
 
         // Previous refill per bucket, for the gap between them.
@@ -269,7 +287,11 @@ public actor SubscriptionHistoryStore {
                   let completedAt = sample.completedAt,
                   let sorted = sortedByKey[key],
                   // The observation that saw the refill, and the one before it.
-                  let refillIndex = sorted.firstIndex(where: { $0.sampledAt >= completedAt }),
+                  let refillIndex = Self.indexOfRefillObservation(
+                      in: sorted,
+                      completedAt: completedAt,
+                      rawWindowSeconds: sample.rawWindowSeconds
+                  ),
                   refillIndex > 0,
                   let newReset = sorted[refillIndex].resetAt,
                   let reportedReset = sorted[refillIndex - 1].resetAt
@@ -544,6 +566,40 @@ public actor SubscriptionHistoryStore {
             return .earlyClockUnchanged
         }
         return .earlyUnclear
+    }
+
+    /// Which observation saw the refill that ended a cycle.
+    ///
+    /// Matched by nearest timestamp rather than by the first at or after
+    /// `completedAt`. The two clocks are not the same one: the timeline point
+    /// is written by `UsageFillTimelineStore.observe` a moment before this
+    /// store is told, and each takes its own `Date()`, so the refill
+    /// observation normally sits *just before* `completedAt`. Reaching forward
+    /// instead picked the following poll, which made the observation before it
+    /// — the refill itself, already carrying the new reset — stand in for the
+    /// reset the old cycle had been reporting.
+    ///
+    /// A match further away than half a window is not the refill; the sample
+    /// stays unclassified rather than being classified from the wrong pair.
+    static func indexOfRefillObservation(
+        in sorted: [FillTimelinePoint],
+        completedAt: Date,
+        rawWindowSeconds: Int?
+    ) -> Int? {
+        guard !sorted.isEmpty else { return nil }
+        var best: (index: Int, distance: TimeInterval)?
+        for (index, point) in sorted.enumerated() {
+            let distance = abs(point.sampledAt.timeIntervalSince(completedAt))
+            if best == nil || distance < best!.distance {
+                best = (index, distance)
+            } else if point.sampledAt > completedAt {
+                // Sorted ascending, so nothing later can be closer.
+                break
+            }
+        }
+        guard let best else { return nil }
+        let window = TimeInterval(rawWindowSeconds ?? 86_400)
+        return best.distance <= window / 2 ? best.index : nil
     }
 
     /// When this bucket last refilled, for the gap between refills.

--- a/Sources/VibeBarCore/Services/SubscriptionHistoryStore.swift
+++ b/Sources/VibeBarCore/Services/SubscriptionHistoryStore.swift
@@ -283,8 +283,8 @@ public actor SubscriptionHistoryStore {
                 storage.samples[index].intervalSeconds =
                     sample.windowEnd.timeIntervalSince(last)
             }
-            guard sample.resetKind == nil,
-                  let completedAt = sample.completedAt,
+            guard sample.resetKind == nil else { continue }
+            guard let completedAt = sample.completedAt,
                   let sorted = sortedByKey[key],
                   // The observation that saw the refill, and the one before it.
                   let refillIndex = Self.indexOfRefillObservation(
@@ -295,7 +295,12 @@ public actor SubscriptionHistoryStore {
                   refillIndex > 0,
                   let newReset = sorted[refillIndex].resetAt,
                   let reportedReset = sorted[refillIndex - 1].resetAt
-            else { continue }
+            else {
+                // Recorded as asked-and-unanswerable, so the pass does not come
+                // back to it on every launch for evidence that is gone.
+                storage.samples[index].resetKind = .unobserved
+                continue
+            }
 
             storage.samples[index].resetKind = Self.classifyReset(
                 reportedResetAt: reportedReset,
@@ -303,7 +308,7 @@ public actor SubscriptionHistoryStore {
                 observedAt: completedAt,
                 rawWindowSeconds: sample.rawWindowSeconds
                     ?? sorted[refillIndex - 1].rawWindowSeconds
-            )
+            ) ?? .unobserved
         }
     }
 
@@ -559,13 +564,16 @@ public actor SubscriptionHistoryStore {
         if reportedResetAt.timeIntervalSince(observedAt) <= tolerance {
             return .onSchedule
         }
-        if abs(newResetAt.timeIntervalSince(observedAt.addingTimeInterval(window))) <= tolerance {
-            return .earlyClockRestarted
-        }
-        if abs(newResetAt.timeIntervalSince(reportedResetAt)) <= tolerance {
-            return .earlyClockUnchanged
-        }
-        return .earlyUnclear
+        // The two bands overlap near the start of a window — an hour into a
+        // week, a boundary that has not moved is 167 hours out, which is also
+        // within tolerance of a full window from here. Testing in order would
+        // always answer "restarted"; the nearer explanation wins instead.
+        let restartedBy = abs(
+            newResetAt.timeIntervalSince(observedAt.addingTimeInterval(window))
+        )
+        let unchangedBy = abs(newResetAt.timeIntervalSince(reportedResetAt))
+        guard min(restartedBy, unchangedBy) <= tolerance else { return .earlyUnclear }
+        return unchangedBy <= restartedBy ? .earlyClockUnchanged : .earlyClockRestarted
     }
 
     /// Which observation saw the refill that ended a cycle.

--- a/Sources/VibeBarCore/Services/SubscriptionHistoryStore.swift
+++ b/Sources/VibeBarCore/Services/SubscriptionHistoryStore.swift
@@ -44,7 +44,13 @@ public actor SubscriptionHistoryStore {
     private static let storageSchemaVersion = 2
     private static let saveThrottleInterval: TimeInterval = 30
     private static let maxFileBytes = 16 * 1024 * 1024
-    private static let currentResetSignalRepairVersion = 1
+    private static let currentResetSignalRepairVersion = 2
+    /// How early is early, and how close a new reset has to be to count as
+    /// restarted or unchanged. A tenth of the window on each side: wide enough
+    /// to absorb the minute or two a provider takes to publish a new boundary,
+    /// narrow enough that a genuinely different schedule does not slip
+    /// through. Shared with the Rust client, which classifies identically.
+    private static let resetToleranceFraction = 0.10
     private static let strongResetAdvanceFraction = 0.10
     private static let weakResetAdvanceFraction = 0.01
     private static let minimumStrongUsageDrop = 0.5
@@ -105,6 +111,21 @@ public actor SubscriptionHistoryStore {
             ) {
                 current.completedAt = now
                 current.completionReason = reason
+                // Classified before `windowEnd` is overwritten below: the reset
+                // this cycle was still carrying is one of the two inputs, and
+                // that is the last moment it exists.
+                current.resetKind = Self.classifyReset(
+                    reportedResetAt: current.windowEnd,
+                    newResetAt: resetAt,
+                    observedAt: now,
+                    rawWindowSeconds: current.rawWindowSeconds
+                )
+                current.intervalSeconds = Self.previousRefill(
+                    in: storage.samples,
+                    accountId: quota.accountId,
+                    bucketId: bucket.id,
+                    before: now
+                ).map { now.timeIntervalSince($0) }
                 // The observed refill time is more useful than a stale reset
                 // forecast when providers reset early or late.
                 current.windowEnd = now
@@ -159,6 +180,11 @@ public actor SubscriptionHistoryStore {
             repairMissedResetSignals(points, in: &storage)
             storage.resetSignalRepairVersion = Self.currentResetSignalRepairVersion
         }
+        // Cycles finished before the app classified refills carry no answer.
+        // Cheap to fill in, and worth doing rather than waiting: the chart
+        // shows twelve cycles, which on a weekly bucket is three months of
+        // going without.
+        classifyStoredResets(points, in: &storage)
         pruneInPlace(&storage, retentionDays: retentionDays, now: Date())
         save(storage)
     }
@@ -205,6 +231,60 @@ public actor SubscriptionHistoryStore {
     /// model. This repairs low-utilization and reset-time-only transitions
     /// missed by older builds without manufacturing cycles from ordinary
     /// reset forecast drift.
+    /// Fill in `resetKind` and `intervalSeconds` for cycles that completed
+    /// before those existed, from the observations that were recorded at the
+    /// time. The inputs are the same two the live path uses: the reset the
+    /// cycle was still carrying just before it refilled, and the reset the
+    /// next observation reported.
+    private func classifyStoredResets(
+        _ points: [FillTimelinePoint],
+        in storage: inout Storage
+    ) {
+        let grouped = Dictionary(grouping: points) {
+            SubscriptionHistoryKey(accountId: $0.accountId, bucketId: $0.bucketId)
+        }
+        var sortedByKey: [SubscriptionHistoryKey: [FillTimelinePoint]] = [:]
+        for (key, raw) in grouped {
+            sortedByKey[key] = raw.sorted { $0.sampledAt < $1.sampledAt }
+        }
+
+        // Previous refill per bucket, for the gap between them.
+        var previousEnd: [SubscriptionHistoryKey: Date] = [:]
+        let order = storage.samples.indices.sorted {
+            storage.samples[$0].windowEnd < storage.samples[$1].windowEnd
+        }
+        for index in order {
+            let sample = storage.samples[index]
+            guard sample.isCompleted else { continue }
+            let key = SubscriptionHistoryKey(
+                accountId: sample.accountId, bucketId: sample.bucketId
+            )
+            defer { previousEnd[key] = sample.windowEnd }
+
+            if storage.samples[index].intervalSeconds == nil, let last = previousEnd[key] {
+                storage.samples[index].intervalSeconds =
+                    sample.windowEnd.timeIntervalSince(last)
+            }
+            guard sample.resetKind == nil,
+                  let completedAt = sample.completedAt,
+                  let sorted = sortedByKey[key],
+                  // The observation that saw the refill, and the one before it.
+                  let refillIndex = sorted.firstIndex(where: { $0.sampledAt >= completedAt }),
+                  refillIndex > 0,
+                  let newReset = sorted[refillIndex].resetAt,
+                  let reportedReset = sorted[refillIndex - 1].resetAt
+            else { continue }
+
+            storage.samples[index].resetKind = Self.classifyReset(
+                reportedResetAt: reportedReset,
+                newResetAt: newReset,
+                observedAt: completedAt,
+                rawWindowSeconds: sample.rawWindowSeconds
+                    ?? sorted[refillIndex - 1].rawWindowSeconds
+            )
+        }
+    }
+
     private func repairMissedResetSignals(
         _ points: [FillTimelinePoint],
         in storage: inout Storage
@@ -434,6 +514,52 @@ public actor SubscriptionHistoryStore {
             return .scheduledReset
         }
         return nil
+    }
+
+    /// Did the window end when it said it would, and if not, what happened to
+    /// the next boundary?
+    ///
+    /// Deliberately not a table of provider habits. Over ~600 real boundaries
+    /// OpenAI's weekly buckets restart the clock in 85% of cycles while
+    /// Anthropic's ran on schedule 128 times out of 128, but that was one
+    /// 50-day window on one machine: "never seen" is not "never happens", and
+    /// a bucket that changes behaviour should be described correctly without a
+    /// code change.
+    static func classifyReset(
+        reportedResetAt: Date,
+        newResetAt: Date,
+        observedAt: Date,
+        rawWindowSeconds: Int?
+    ) -> SubscriptionWindowSample.ResetKind? {
+        guard let rawWindowSeconds, rawWindowSeconds > 0 else { return nil }
+        let window = TimeInterval(rawWindowSeconds)
+        let tolerance = window * resetToleranceFraction
+        if reportedResetAt.timeIntervalSince(observedAt) <= tolerance {
+            return .onSchedule
+        }
+        if abs(newResetAt.timeIntervalSince(observedAt.addingTimeInterval(window))) <= tolerance {
+            return .earlyClockRestarted
+        }
+        if abs(newResetAt.timeIntervalSince(reportedResetAt)) <= tolerance {
+            return .earlyClockUnchanged
+        }
+        return .earlyUnclear
+    }
+
+    /// When this bucket last refilled, for the gap between refills.
+    private static func previousRefill(
+        in samples: [SubscriptionWindowSample],
+        accountId: String,
+        bucketId: String,
+        before: Date
+    ) -> Date? {
+        samples
+            .filter {
+                $0.accountId == accountId && $0.bucketId == bucketId
+                    && $0.isCompleted && $0.windowEnd < before
+            }
+            .map(\.windowEnd)
+            .max()
     }
 
     private static func isMaterialRefill(previous: Double, peak: Double, current: Double) -> Bool {

--- a/Sources/VibeBarCore/Services/SubscriptionHistoryStore.swift
+++ b/Sources/VibeBarCore/Services/SubscriptionHistoryStore.swift
@@ -255,15 +255,7 @@ public actor SubscriptionHistoryStore {
         }
         var sortedByKey: [SubscriptionHistoryKey: [FillTimelinePoint]] = [:]
         for (key, raw) in grouped {
-            // Only points carrying a reset time, because those are the only
-            // ones `observe` ever looked at: it skips the rest outright. A
-            // nearest-timestamp match over the full series lands on a
-            // neighbour the live path never saw, and on this developer's
-            // timeline that is most of them — 173 cycles went unclassified
-            // for want of a reset time on the row next door.
-            sortedByKey[key] = raw
-                .filter { $0.resetAt != nil }
-                .sorted { $0.sampledAt < $1.sampledAt }
+            sortedByKey[key] = raw.sorted { $0.sampledAt < $1.sampledAt }
         }
 
         // Previous refill per bucket, for the gap between them.
@@ -286,15 +278,23 @@ public actor SubscriptionHistoryStore {
             guard sample.resetKind == nil else { continue }
             guard let completedAt = sample.completedAt,
                   let sorted = sortedByKey[key],
-                  // The observation that saw the refill, and the one before it.
+                  // The observation that saw the refill…
                   let refillIndex = Self.indexOfRefillObservation(
                       in: sorted,
                       completedAt: completedAt,
                       rawWindowSeconds: sample.rawWindowSeconds
                   ),
-                  refillIndex > 0,
                   let newReset = sorted[refillIndex].resetAt,
-                  let reportedReset = sorted[refillIndex - 1].resetAt
+                  // …and the last one before it that reported a reset, which
+                  // is not always the row immediately above. Not every point
+                  // carries one, and the migration passes can place a cycle on
+                  // a point that does not, so neither the match nor its
+                  // predecessor can assume it.
+                  let reportedReset = sorted[..<refillIndex]
+                      .reversed()
+                      .lazy
+                      .compactMap(\.resetAt)
+                      .first
             else {
                 // Recorded as asked-and-unanswerable, so the pass does not come
                 // back to it on every launch for evidence that is gone.

--- a/Tests/VibeBarCoreTests/ResetKindRealDataTests.swift
+++ b/Tests/VibeBarCoreTests/ResetKindRealDataTests.swift
@@ -86,6 +86,89 @@ final class ResetKindRealDataTests: XCTestCase {
                 samples.filter { $0.resetKind == nil }.count, 0,
                 "\(key.bucketId) left cycles unclassified"
             )
+
+            // The same history through the other route. Cycles recorded before
+            // classification existed are filled in from the timeline instead of
+            // at the moment they completed, and the two clocks involved are not
+            // the same one — so the two paths agreeing is the thing to check,
+            // not that either one runs.
+            let backfilled = try await classifiedByBackfill(key: key, points: sorted)
+            // Matched by the cycle each describes, not by position: the repair
+            // pass can also recover boundaries the replay missed, and whether
+            // the two paths find the same *set* of cycles is a different
+            // question from whether they classify a shared one the same way.
+            let live = Dictionary(
+                samples.map { ($0.windowEnd, $0.resetKind) },
+                uniquingKeysWith: { first, _ in first }
+            )
+            var compared = 0
+            for cycle in backfilled {
+                guard let expected = live[cycle.windowEnd] else { continue }
+                compared += 1
+                XCTAssertEqual(
+                    cycle.resetKind, expected,
+                    "\(key.bucketId) at \(cycle.windowEnd): backfill says "
+                        + "\(String(describing: cycle.resetKind)), the live path says "
+                        + "\(String(describing: expected))"
+                )
+            }
+            XCTAssertGreaterThan(compared, 0, "\(key.bucketId): nothing was comparable")
         }
+    }
+
+    /// Replay the same observations into a store whose samples carry no
+    /// classification, then let the repair pass fill them in.
+    private func classifiedByBackfill(
+        key: SubscriptionHistoryKey,
+        points: [FillTimelinePoint]
+    ) async throws -> [SubscriptionWindowSample] {
+        let scratch = FileManager.default.temporaryDirectory
+            .appendingPathComponent("vibebar-backfill-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: scratch, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: scratch) }
+        let file = scratch.appendingPathComponent("subscription_history.json")
+        let store = SubscriptionHistoryStore(fileURL: file)
+
+        for point in points {
+            await store.observe(
+                AccountQuota(
+                    accountId: key.accountId,
+                    tool: point.tool,
+                    buckets: [QuotaBucket(
+                        id: key.bucketId,
+                        title: key.bucketId,
+                        shortLabel: key.bucketId,
+                        usedPercent: point.usedPercent,
+                        resetAt: point.resetAt,
+                        rawWindowSeconds: point.rawWindowSeconds
+                    )],
+                    queriedAt: point.sampledAt
+                ),
+                now: point.sampledAt,
+                retentionDays: 3_650
+            )
+        }
+        await store.flushPendingWrites()
+
+        // Strip the classifications and re-open, so the repair pass has to do
+        // the work rather than finding it already done.
+        var document = try JSONSerialization.jsonObject(
+            with: Data(contentsOf: file)
+        ) as! [String: Any]
+        var samples = document["samples"] as! [[String: Any]]
+        for index in samples.indices {
+            samples[index]["resetKind"] = nil
+            samples[index].removeValue(forKey: "resetKind")
+            samples[index].removeValue(forKey: "intervalSeconds")
+        }
+        document["samples"] = samples
+        try JSONSerialization.data(withJSONObject: document).write(to: file)
+
+        let reopened = SubscriptionHistoryStore(fileURL: file)
+        await reopened.importLegacyTimeline(points, retentionDays: 3_650)
+        return await reopened.samples(
+            accountId: key.accountId, bucketId: key.bucketId,
+            now: Date(), includeCurrent: false
+        ).filter(\.isCompleted)
     }
 }

--- a/Tests/VibeBarCoreTests/ResetKindRealDataTests.swift
+++ b/Tests/VibeBarCoreTests/ResetKindRealDataTests.swift
@@ -1,0 +1,91 @@
+import XCTest
+@testable import VibeBarCore
+
+/// Classify the developer's own quota history and report what each provider
+/// does when it refills early.
+///
+/// Ignored by default: it needs a machine that has run the app. It reads a
+/// copy of the timeline and writes to a temporary store, so the real files are
+/// untouched.
+///
+/// The same classification runs in Vibe Bar Desktop over the same observations,
+/// so the two outputs should agree bucket for bucket. They are separate
+/// implementations of one rule, and this is the cheapest place to notice them
+/// drifting apart.
+final class ResetKindRealDataTests: XCTestCase {
+    func testClassifyTheDevelopersOwnHistory() async throws {
+        let home = URL(fileURLWithPath: NSHomeDirectory())
+        let timeline = home.appendingPathComponent(".vibebar/fill_timeline.sqlite3")
+        guard FileManager.default.fileExists(atPath: timeline.path) else {
+            throw XCTSkip("no fill timeline on this machine")
+        }
+        try XCTSkipIf(
+            ProcessInfo.processInfo.environment["VIBEBAR_CLASSIFY_REAL_HISTORY"] == nil,
+            "set VIBEBAR_CLASSIFY_REAL_HISTORY to run"
+        )
+
+        let scratch = FileManager.default.temporaryDirectory
+            .appendingPathComponent("vibebar-reset-kind-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: scratch, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: scratch) }
+        let copy = scratch.appendingPathComponent("fill_timeline.sqlite3")
+        try FileManager.default.copyItem(at: timeline, to: copy)
+
+        let points = await UsageFillTimelineStore(fileURL: copy).allPoints()
+        XCTAssertFalse(points.isEmpty, "the timeline copy read as empty")
+
+        // Replay every observation through the live path, so this exercises
+        // what the app actually does rather than a parallel implementation.
+        let store = SubscriptionHistoryStore(
+            fileURL: scratch.appendingPathComponent("subscription_history.json")
+        )
+        let grouped = Dictionary(grouping: points) {
+            SubscriptionHistoryKey(accountId: $0.accountId, bucketId: $0.bucketId)
+        }
+        for (key, raw) in grouped.sorted(by: { $0.key.bucketId < $1.key.bucketId }) {
+            let sorted = raw.sorted { $0.sampledAt < $1.sampledAt }
+            for point in sorted {
+                await store.observe(
+                    AccountQuota(
+                        accountId: key.accountId,
+                        tool: point.tool,
+                        buckets: [QuotaBucket(
+                            id: key.bucketId,
+                            title: key.bucketId,
+                            shortLabel: key.bucketId,
+                            usedPercent: point.usedPercent,
+                            resetAt: point.resetAt,
+                            rawWindowSeconds: point.rawWindowSeconds
+                        )],
+                        queriedAt: point.sampledAt
+                    ),
+                    now: point.sampledAt,
+                    retentionDays: 3_650
+                )
+            }
+            let samples = await store
+                .samples(accountId: key.accountId, bucketId: key.bucketId,
+                         now: Date(), includeCurrent: false)
+                .filter(\.isCompleted)
+            guard samples.count >= 5 else { continue }
+            func count(_ kind: SubscriptionWindowSample.ResetKind) -> Int {
+                samples.filter { $0.resetKind == kind }.count
+            }
+            // Not every point carries the window; take the first that does.
+            let window = sorted.compactMap(\.rawWindowSeconds).first.map { Double($0) / 3600 } ?? 0
+            print(
+                """
+                \(key.bucketId): window \(Int(window))h, \(samples.count) cycles — \
+                on schedule \(count(.onSchedule)), \
+                early+restarted \(count(.earlyClockRestarted)), \
+                early+unchanged \(count(.earlyClockUnchanged)), \
+                unclear \(count(.earlyUnclear))
+                """
+            )
+            XCTAssertEqual(
+                samples.filter { $0.resetKind == nil }.count, 0,
+                "\(key.bucketId) left cycles unclassified"
+            )
+        }
+    }
+}

--- a/Tests/VibeBarCoreTests/SubscriptionHistoryStoreTests.swift
+++ b/Tests/VibeBarCoreTests/SubscriptionHistoryStoreTests.swift
@@ -133,6 +133,68 @@ final class SubscriptionHistoryStoreTests: XCTestCase {
         XCTAssertEqual(completed.first?.resetKind, .earlyClockUnchanged)
     }
 
+    /// Near the start of a window the two early bands overlap: a boundary
+    /// that has not moved is almost exactly a window away from here. Testing
+    /// the bands in order always answered "restarted", which is the opposite
+    /// of the truth and the more reassuring of the two.
+    func testAnEarlyRefillJustAfterAWindowOpensIsNotMisreadAsRestarted() async throws {
+        let (store, _, cleanup) = try makeTempStore()
+        defer { cleanup() }
+        let week = 604_800
+        let start = Date(timeIntervalSince1970: 1_800_000_000)
+        let reset = start.addingTimeInterval(TimeInterval(week))
+        // One hour in, and the boundary does not move.
+        let early = start.addingTimeInterval(3_600)
+
+        await store.observe(
+            quota(tool: .claude, buckets: [
+                bucket(id: "weekly", usedPercent: 40, resetAt: reset, rawWindowSeconds: week)
+            ], queriedAt: start),
+            now: start
+        )
+        await store.observe(
+            quota(tool: .claude, buckets: [
+                bucket(id: "weekly", usedPercent: 2, resetAt: reset, rawWindowSeconds: week)
+            ], queriedAt: early),
+            now: early
+        )
+
+        let completed = await store.samples(accountId: "acct-test", bucketId: "weekly")
+            .filter(\.isCompleted)
+        XCTAssertEqual(
+            completed.first?.resetKind, .earlyClockUnchanged,
+            "an unmoved boundary an hour into a week was read as a restarted clock"
+        )
+    }
+
+    /// A cycle whose evidence is gone is marked as asked-and-unanswerable,
+    /// not left blank. Blank means nobody has looked, so the backfill would
+    /// come back to it on every launch for observations that no longer exist.
+    func testACycleWithNoSurvivingObservationsIsMarkedUnobserved() async throws {
+        let (store, url, cleanup) = try makeTempStore()
+        defer { cleanup() }
+        let window = 18_000
+        let base = Date(timeIntervalSince1970: 1_800_000_000)
+        let json = """
+        {"schemaVersion":2,"legacyTimelineImported":true,"resetSignalRepairVersion":1,\
+        "samples":[{"accountId":"acct-test","tool":"codex","bucketId":"weekly",\
+        "windowEnd":\(base.timeIntervalSinceReferenceDate),"rawWindowSeconds":\(window),\
+        "peakUsedPercent":40,"lastUsedPercent":40,"observationCount":3,\
+        "firstSeenAt":\(base.timeIntervalSinceReferenceDate),\
+        "lastSeenAt":\(base.timeIntervalSinceReferenceDate),\
+        "completedAt":\(base.timeIntervalSinceReferenceDate),\
+        "completionReason":"scheduledReset"}]}
+        """
+        try Data(json.utf8).write(to: url)
+
+        // The timeline has been pruned; nothing survives to judge this by.
+        await store.importLegacyTimeline([])
+
+        let samples = await store.samples(accountId: "acct-test", bucketId: "weekly")
+        XCTAssertEqual(samples.first?.resetKind, .unobserved)
+        XCTAssertEqual(samples.first?.refilledEarly, false, "unanswerable is not early")
+    }
+
     /// The gap between refills, which is what shows a bucket keeping a
     /// schedule other than the one it advertises.
     func testTheGapBetweenRefillsIsRecorded() async throws {

--- a/Tests/VibeBarCoreTests/SubscriptionHistoryStoreTests.swift
+++ b/Tests/VibeBarCoreTests/SubscriptionHistoryStoreTests.swift
@@ -48,6 +48,190 @@ final class SubscriptionHistoryStoreTests: XCTestCase {
 
     // MARK: - Tests
 
+    /// A window that ran its full length.
+    func testAWindowThatRunsItsLengthIsRecordedAsOnSchedule() async throws {
+        let (store, _, cleanup) = try makeTempStore()
+        defer { cleanup() }
+        let start = Date(timeIntervalSince1970: 1_800_000_000)
+        let reset = start.addingTimeInterval(18_000)
+
+        await store.observe(
+            quota(tool: .claude, buckets: [
+                bucket(id: "five_hour", usedPercent: 40, resetAt: reset, rawWindowSeconds: 18_000)
+            ], queriedAt: start),
+            now: start
+        )
+        // The reset arrives; the next window is a full one from here.
+        await store.observe(
+            quota(tool: .claude, buckets: [
+                bucket(id: "five_hour", usedPercent: 2,
+                       resetAt: reset.addingTimeInterval(18_000), rawWindowSeconds: 18_000)
+            ], queriedAt: reset),
+            now: reset
+        )
+
+        let completed = await store.samples(accountId: "acct-test", bucketId: "five_hour")
+            .filter(\.isCompleted)
+        XCTAssertEqual(completed.count, 1)
+        XCTAssertEqual(completed.first?.resetKind, .onSchedule)
+        XCTAssertEqual(completed.first?.refilledEarly, false)
+    }
+
+    /// Refilled early, and the next reset moved out to a full window from the
+    /// refill — a whole window lies ahead, so the extra capacity is usable.
+    func testAnEarlyRefillThatRestartsTheClockIsRecorded() async throws {
+        let (store, _, cleanup) = try makeTempStore()
+        defer { cleanup() }
+        let start = Date(timeIntervalSince1970: 1_800_000_000)
+        let reset = start.addingTimeInterval(18_000)
+        let early = start.addingTimeInterval(5_000)
+
+        await store.observe(
+            quota(tool: .codex, buckets: [
+                bucket(id: "weekly", usedPercent: 40, resetAt: reset, rawWindowSeconds: 18_000)
+            ], queriedAt: start),
+            now: start
+        )
+        await store.observe(
+            quota(tool: .codex, buckets: [
+                bucket(id: "weekly", usedPercent: 2,
+                       resetAt: early.addingTimeInterval(18_000), rawWindowSeconds: 18_000)
+            ], queriedAt: early),
+            now: early
+        )
+
+        let completed = await store.samples(accountId: "acct-test", bucketId: "weekly")
+            .filter(\.isCompleted)
+        XCTAssertEqual(completed.first?.resetKind, .earlyClockRestarted)
+        XCTAssertEqual(completed.first?.refilledEarly, true)
+    }
+
+    /// The opposite consequence: refilled early and the boundary did not move,
+    /// so less than a window remains to spend the refill in.
+    func testAnEarlyRefillThatLeavesTheClockAloneIsRecorded() async throws {
+        let (store, _, cleanup) = try makeTempStore()
+        defer { cleanup() }
+        let start = Date(timeIntervalSince1970: 1_800_000_000)
+        let reset = start.addingTimeInterval(18_000)
+        let early = start.addingTimeInterval(5_000)
+
+        await store.observe(
+            quota(tool: .claude, buckets: [
+                bucket(id: "five_hour", usedPercent: 40, resetAt: reset, rawWindowSeconds: 18_000)
+            ], queriedAt: start),
+            now: start
+        )
+        await store.observe(
+            quota(tool: .claude, buckets: [
+                bucket(id: "five_hour", usedPercent: 2, resetAt: reset, rawWindowSeconds: 18_000)
+            ], queriedAt: early),
+            now: early
+        )
+
+        let completed = await store.samples(accountId: "acct-test", bucketId: "five_hour")
+            .filter(\.isCompleted)
+        XCTAssertEqual(completed.first?.resetKind, .earlyClockUnchanged)
+    }
+
+    /// The gap between refills, which is what shows a bucket keeping a
+    /// schedule other than the one it advertises.
+    func testTheGapBetweenRefillsIsRecorded() async throws {
+        let (store, _, cleanup) = try makeTempStore()
+        defer { cleanup() }
+        let start = Date(timeIntervalSince1970: 1_800_000_000)
+        let window: TimeInterval = 18_000
+
+        var moment = start
+        for step in 0...3 {
+            let used: Double = step % 2 == 0 ? 40 : 2
+            await store.observe(
+                quota(tool: .claude, buckets: [
+                    bucket(id: "five_hour", usedPercent: used,
+                           resetAt: moment.addingTimeInterval(window),
+                           rawWindowSeconds: Int(window))
+                ], queriedAt: moment),
+                now: moment
+            )
+            moment = moment.addingTimeInterval(window)
+        }
+
+        let completed = await store.samples(accountId: "acct-test", bucketId: "five_hour")
+            .filter(\.isCompleted)
+            .sorted { $0.windowEnd < $1.windowEnd }
+        XCTAssertGreaterThanOrEqual(completed.count, 2)
+        // Nothing to measure the first against.
+        XCTAssertNil(completed.first?.intervalSeconds)
+        let gap = try XCTUnwrap(completed.dropFirst().first?.intervalSeconds)
+        XCTAssertEqual(gap, window, accuracy: 1)
+    }
+
+    /// A file written before this existed still decodes, and its cycles simply
+    /// have no classification rather than a wrong one.
+    func testSamplesWrittenBeforeClassificationStillDecode() async throws {
+        let (store, url, cleanup) = try makeTempStore()
+        defer { cleanup() }
+        let json = """
+        {"schemaVersion":2,"legacyTimelineImported":false,"samples":[{\
+        "accountId":"acct-test","tool":"claude","bucketId":"five_hour",\
+        "windowEnd":800000000,"rawWindowSeconds":18000,"peakUsedPercent":40,\
+        "lastUsedPercent":40,"observationCount":3,"firstSeenAt":799982000,\
+        "lastSeenAt":799999400,"completedAt":800000000,\
+        "completionReason":"scheduledReset"}]}
+        """
+        try Data(json.utf8).write(to: url)
+
+        let samples = await store.samples(accountId: "acct-test", bucketId: "five_hour")
+        XCTAssertEqual(samples.count, 1, "an older file must still load")
+        XCTAssertNil(samples.first?.resetKind)
+        XCTAssertEqual(samples.first?.refilledEarly, false, "unclassified is not early")
+    }
+
+    /// Cycles that finished before the app classified refills get their answer
+    /// from the observations recorded at the time, rather than waiting three
+    /// months for a weekly bucket to fill twelve fresh bars.
+    func testStoredCyclesAreClassifiedFromTheTimeline() async throws {
+        let (store, url, cleanup) = try makeTempStore()
+        defer { cleanup() }
+        let window = 18_000
+        let base = Date(timeIntervalSince1970: 1_800_000_000)
+        let refill = base.addingTimeInterval(5_000)
+
+        // One completed cycle, written the way an older build would have.
+        let json = """
+        {"schemaVersion":2,"legacyTimelineImported":true,"resetSignalRepairVersion":1,\
+        "samples":[{"accountId":"acct-test","tool":"codex","bucketId":"weekly",\
+        "windowEnd":\(refill.timeIntervalSinceReferenceDate),"rawWindowSeconds":\(window),\
+        "peakUsedPercent":40,"lastUsedPercent":40,"observationCount":3,\
+        "firstSeenAt":\(base.timeIntervalSinceReferenceDate),\
+        "lastSeenAt":\(refill.timeIntervalSinceReferenceDate),\
+        "completedAt":\(refill.timeIntervalSinceReferenceDate),\
+        "completionReason":"scheduledReset"}]}
+        """
+        try Data(json.utf8).write(to: url)
+
+        func point(_ used: Double, at date: Date, resetAt: Date) -> FillTimelinePoint {
+            FillTimelinePoint(
+                accountId: "acct-test",
+                tool: .codex,
+                bucketId: "weekly",
+                slotStart: UsageFillTimelineStore.hourSlotStart(for: date),
+                usedPercent: used,
+                sampledAt: date,
+                resetAt: resetAt,
+                rawWindowSeconds: window
+            )
+        }
+        // Refilled 13,000s early, and the next reset moved a full window out.
+        let reported = base.addingTimeInterval(TimeInterval(window))
+        await store.importLegacyTimeline([
+            point(40, at: base, resetAt: reported),
+            point(2, at: refill, resetAt: refill.addingTimeInterval(TimeInterval(window))),
+        ])
+
+        let samples = await store.samples(accountId: "acct-test", bucketId: "weekly")
+        XCTAssertEqual(samples.first?.resetKind, .earlyClockRestarted)
+    }
+
     func testObserveCreatesOneSamplePerEligibleBucket() async throws {
         let (store, _, cleanup) = try makeTempStore()
         defer { cleanup() }

--- a/Tests/VibeBarCoreTests/SubscriptionHistoryStoreTests.swift
+++ b/Tests/VibeBarCoreTests/SubscriptionHistoryStoreTests.swift
@@ -189,22 +189,31 @@ final class SubscriptionHistoryStoreTests: XCTestCase {
     /// Cycles that finished before the app classified refills get their answer
     /// from the observations recorded at the time, rather than waiting three
     /// months for a weekly bucket to fill twelve fresh bars.
+    ///
+    /// Shaped around the case that shows a mismatched lookup: a window that
+    /// ran its *full* length. The timeline point that saw the refill is
+    /// written a moment before this store is told, by a different `Date()`, so
+    /// it lands just before `completedAt`. Reaching forward from there picks
+    /// the following poll and reads the refill's own reset as the one the old
+    /// cycle had been reporting — which makes an on-schedule cycle look like
+    /// an early refill, and puts a mark on a bar that deserves none.
     func testStoredCyclesAreClassifiedFromTheTimeline() async throws {
         let (store, url, cleanup) = try makeTempStore()
         defer { cleanup() }
         let window = 18_000
         let base = Date(timeIntervalSince1970: 1_800_000_000)
-        let refill = base.addingTimeInterval(5_000)
+        let reset = base.addingTimeInterval(TimeInterval(window))
 
-        // One completed cycle, written the way an older build would have.
+        // One completed cycle, written the way an older build would have: it
+        // ran its full length and ended at its stated reset.
         let json = """
         {"schemaVersion":2,"legacyTimelineImported":true,"resetSignalRepairVersion":1,\
         "samples":[{"accountId":"acct-test","tool":"codex","bucketId":"weekly",\
-        "windowEnd":\(refill.timeIntervalSinceReferenceDate),"rawWindowSeconds":\(window),\
+        "windowEnd":\(reset.timeIntervalSinceReferenceDate),"rawWindowSeconds":\(window),\
         "peakUsedPercent":40,"lastUsedPercent":40,"observationCount":3,\
         "firstSeenAt":\(base.timeIntervalSinceReferenceDate),\
-        "lastSeenAt":\(refill.timeIntervalSinceReferenceDate),\
-        "completedAt":\(refill.timeIntervalSinceReferenceDate),\
+        "lastSeenAt":\(reset.timeIntervalSinceReferenceDate),\
+        "completedAt":\(reset.timeIntervalSinceReferenceDate),\
         "completionReason":"scheduledReset"}]}
         """
         try Data(json.utf8).write(to: url)
@@ -221,15 +230,21 @@ final class SubscriptionHistoryStoreTests: XCTestCase {
                 rawWindowSeconds: window
             )
         }
-        // Refilled 13,000s early, and the next reset moved a full window out.
-        let reported = base.addingTimeInterval(TimeInterval(window))
+        let seen = reset.addingTimeInterval(-0.4)
+        let nextReset = seen.addingTimeInterval(TimeInterval(window))
         await store.importLegacyTimeline([
-            point(40, at: base, resetAt: reported),
-            point(2, at: refill, resetAt: refill.addingTimeInterval(TimeInterval(window))),
+            point(40, at: base, resetAt: reset),
+            point(2, at: seen, resetAt: nextReset),
+            // The poll after the refill, which a forward lookup would match.
+            point(6, at: reset.addingTimeInterval(600), resetAt: nextReset),
         ])
 
         let samples = await store.samples(accountId: "acct-test", bucketId: "weekly")
-        XCTAssertEqual(samples.first?.resetKind, .earlyClockRestarted)
+        XCTAssertEqual(
+            samples.first?.resetKind, .onSchedule,
+            "a window that ran its full length was read as an early refill"
+        )
+        XCTAssertEqual(samples.first?.refilledEarly, false)
     }
 
     func testObserveCreatesOneSamplePerEligibleBucket() async throws {

--- a/Tests/VibeBarCoreTests/SubscriptionHistoryStoreTests.swift
+++ b/Tests/VibeBarCoreTests/SubscriptionHistoryStoreTests.swift
@@ -167,6 +167,53 @@ final class SubscriptionHistoryStoreTests: XCTestCase {
         )
     }
 
+    /// The migration passes can place a completed cycle on a timeline point
+    /// that reported no reset time. Dropping such points before matching
+    /// removed the refill observation itself, and the nearest survivor — a
+    /// poll ten minutes later — produced a confident answer for a cycle whose
+    /// evidence does not support one.
+    func testACycleOnAPointWithNoResetTimeIsNotGivenAnInventedAnswer() async throws {
+        let (store, url, cleanup) = try makeTempStore()
+        defer { cleanup() }
+        let window = 18_000
+        let base = Date(timeIntervalSince1970: 1_800_000_000)
+        let reset = base.addingTimeInterval(TimeInterval(window))
+        // The refill was seen on a point that carried no reset time.
+        let refill = reset.addingTimeInterval(-0.4)
+        let json = """
+        {"schemaVersion":2,"legacyTimelineImported":true,"resetSignalRepairVersion":1,\
+        "samples":[{"accountId":"acct-test","tool":"codex","bucketId":"weekly",\
+        "windowEnd":\(refill.timeIntervalSinceReferenceDate),"rawWindowSeconds":\(window),\
+        "peakUsedPercent":40,"lastUsedPercent":40,"observationCount":4,\
+        "firstSeenAt":\(base.timeIntervalSinceReferenceDate),\
+        "lastSeenAt":\(refill.timeIntervalSinceReferenceDate),\
+        "completedAt":\(refill.timeIntervalSinceReferenceDate),\
+        "completionReason":"refillDetected"}]}
+        """
+        try Data(json.utf8).write(to: url)
+
+        func point(_ used: Double, at date: Date, resetAt: Date?) -> FillTimelinePoint {
+            FillTimelinePoint(
+                accountId: "acct-test", tool: .codex, bucketId: "weekly",
+                slotStart: UsageFillTimelineStore.hourSlotStart(for: date),
+                usedPercent: used, sampledAt: date, resetAt: resetAt,
+                rawWindowSeconds: window
+            )
+        }
+        await store.importLegacyTimeline([
+            point(30, at: base, resetAt: reset),
+            point(2, at: refill, resetAt: nil),
+            point(6, at: reset.addingTimeInterval(600),
+                  resetAt: reset.addingTimeInterval(TimeInterval(window))),
+        ])
+
+        let samples = await store.samples(accountId: "acct-test", bucketId: "weekly")
+        XCTAssertEqual(
+            samples.first?.resetKind, .unobserved,
+            "a cycle whose refill reported no reset time was given a confident answer"
+        )
+    }
+
     /// A cycle whose evidence is gone is marked as asked-and-unanswerable,
     /// not left blank. Blank means nobody has looked, so the backfill would
     /// come back to it on every launch for observations that no longer exist.


### PR DESCRIPTION
A window that refills before it said it would is an event worth showing,
and there are **two kinds with opposite consequences**:

- **clock restarted** — the next reset moves out to a full window from
  the refill, so a whole window lies ahead and the extra capacity is
  usable;
- **clock unchanged** — the next boundary stays put, so less than a
  window remains to spend the refill in, which makes it the easier one
  to waste.

Both are decidable from what is already recorded: compare the reset the
new cycle reports against the refill time plus the window, and against
the reset the old cycle was still carrying. That second value only
exists until `windowEnd` is overwritten at completion, so the
classification happens there.

### What the data says

Over ~600 real boundaries in a 50-day window:

| bucket | on schedule | early, clock restarted | early, clock unchanged |
| --- | --- | --- | --- |
| Codex `weekly` | 2 | **13** | 0 |
| Codex Spark `weekly` | 2 | **12** | 0 |
| Codex Spark `five_hour` | 14 | **16** | 0 |
| AntiGravity `claude_gpt_five_hour` | 88 | 21 | 3 |
| Claude `five_hour` / `weekly` / `weekly_fable` | 128 | 0 | 0 |
| Grok `weekly` / Grok Bot `weekly` | 8 | 1 | 1 |

This deliberately does **not** become a table of provider habits. That
was one 50-day window on one machine, limited to when the app was
running — "never seen" is not "never happens", and a bucket that starts
behaving differently should be described correctly without a code
change. Every cycle is classified from its own observations.

### Backfill

Cycles that finished before this existed are classified from the
observations recorded at the time, through the `resetSignalRepairVersion`
mechanism already there. Waiting instead would leave a weekly bucket
without a full chart for three months, and would make this app's chart
disagree with Vibe Bar Desktop's over the same history.

### Chart

Reset history marks those cycles in a row above the bars, says how many,
and names which kind on hover. Above rather than inside because a cycle
that spent all its quota fills its track to the top, where a marker
would be the same colour as the fill under it.

### Verification

An ignored test classifies this machine's own history into a temporary
store (the real files are copied, never written) and prints the
distribution. It agrees with the Rust implementation in
`AstroQore/vibe-bar-desktop#33` **bucket for bucket on all ~600
boundaries** — two independent implementations of one rule over the same
observations.

Schema unchanged: the new fields are optional, an older file still
decodes, and its cycles read as unclassified rather than wrongly
classified. 1,714 tests pass; each new test was checked to fail without
the code it covers.