### PR TITLE
Merge settings on write and adopt another writer's changes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1381,6 +1381,30 @@ but add for parity so the labels look hand-tuned):**
 buckets by `QuotaBucket.groupTitle`, so a new model appears there the
 moment step 1 lands.
 
+### Writing a file two clients share
+
+`settings.json` has two writers (this app and Vibe Bar Desktop, in any
+combination of versions). The full rule is
+`docs/contracts/settings-write-v1.md`; three traps are worth naming here
+because each one passed its first round of tests.
+
+- **A merge measured against the file cannot tell a user's choice from a
+  materialised default.** The load-time write fills in every key the
+  file did not carry, so the first save looks like the user just changed
+  all forty settings, and the next external edit reports most of the
+  document as lost. What this process changed is what changed *here*:
+  diff against its own previous value.
+- **Atomic writes replace the inode**, so a `DispatchSource` on the file
+  descriptor goes quiet after the first replacement — and it is the
+  second write, not the first, that proves a watcher works. A missing
+  file has the mirror problem: the write that creates it happens before
+  there is anything to watch, so a successful re-open after a failed one
+  *is* the change.
+- **Testing the merge function is not testing the merge.** Replacing the
+  store's merged write with a whole-file one left every test of the pure
+  helper green. If a change claims the file survives a save, a test has
+  to drive the thing that saves.
+
 ## 12. Releases
 
 - Follow [RELEASING.md](RELEASING.md) for the complete tag, asset, signing,

--- a/Sources/VibeBarApp/Views/SettingsView.swift
+++ b/Sources/VibeBarApp/Views/SettingsView.swift
@@ -131,6 +131,43 @@ struct SettingsView: View {
         selectedDestination.sectionID
     }
 
+    /// `settings.json` is shared with Vibe Bar Desktop and with a second copy
+    /// of this app, and the last writer wins per setting. When that costs the
+    /// user a choice they made here, say so where they made it — the
+    /// alternative is a control that silently springs back.
+    @ViewBuilder
+    private var externalChangeBanner: some View {
+        if let change = settingsStore.replacedByAnotherWriter {
+            HStack(alignment: .firstTextBaseline, spacing: 8) {
+                Image(systemName: "exclamationmark.arrow.triangle.2.circlepath")
+                    .foregroundStyle(.orange)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Another Vibe Bar replaced your change")
+                        .font(.callout.weight(.medium))
+                    Text(change.summary)
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                Spacer(minLength: 12)
+                Button("Dismiss") { settingsStore.acknowledgeExternalChange() }
+                    .buttonStyle(.vibeBar)
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 10)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(
+                RoundedRectangle(cornerRadius: density.cardCornerRadius, style: .continuous)
+                    .fill(Color.orange.opacity(0.12))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: density.cardCornerRadius, style: .continuous)
+                    .strokeBorder(Color.orange.opacity(0.35), lineWidth: 1)
+            )
+            .transition(.opacity)
+        }
+    }
+
     var body: some View {
         HStack(spacing: 0) {
             SettingsSidebarView(selection: $selection)
@@ -139,6 +176,7 @@ struct SettingsView: View {
 
             ScrollView(.vertical, showsIndicators: true) {
                         VStack(alignment: .leading, spacing: density.interSectionSpacing) {
+                    externalChangeBanner
                     if selectedSection == .system {
                     settingsSection("System") {
                         Toggle("Launch at login", isOn: launchAtLoginBinding())

--- a/Sources/VibeBarCore/Storage/FileChangeWatcher.swift
+++ b/Sources/VibeBarCore/Storage/FileChangeWatcher.swift
@@ -1,0 +1,144 @@
+import Foundation
+
+/// Notices when a file changes underneath this process.
+///
+/// Every store here writes atomically — a temporary file and a rename — which
+/// is what makes this more than one `DispatchSource`. A rename puts a *new*
+/// inode at the path, and a source watching the old file descriptor keeps
+/// watching the old inode, which nothing will ever write to again. So a
+/// delete or rename is not just an event to report, it is the signal to
+/// re-open the path and start again.
+///
+/// Events are coalesced: one atomic replace can produce several, and a caller
+/// re-reading the file wants to do it once, after the dust settles.
+public final class FileChangeWatcher {
+    private let url: URL
+    private let debounce: DispatchTimeInterval
+    private let onChange: @Sendable () -> Void
+    private let queue: DispatchQueue
+    /// How often to look again for a file that is not there yet. Slower than
+    /// the debounce on purpose: a path that never appears should not hold a
+    /// timer at the rate a burst of writes is coalesced at.
+    private static let retryInterval: DispatchTimeInterval = .milliseconds(500)
+    /// Guards `source` and `pending` against `start`/`stop`/`cancel` racing.
+    private let lock = NSLock()
+    private var source: DispatchSourceFileSystemObject?
+    private var pending: DispatchWorkItem?
+    private var stopped = false
+    /// Whether the last attempt to open the path found nothing there.
+    private var awaitingFile = false
+
+    public init(
+        url: URL,
+        debounceMilliseconds: Int = 150,
+        queue: DispatchQueue = DispatchQueue(
+            label: "com.astroqore.VibeBar.file-watch", qos: .utility
+        ),
+        onChange: @escaping @Sendable () -> Void
+    ) {
+        self.url = url
+        self.debounce = .milliseconds(debounceMilliseconds)
+        self.queue = queue
+        self.onChange = onChange
+    }
+
+    deinit { stop() }
+
+    public func start() {
+        lock.lock()
+        stopped = false
+        lock.unlock()
+        arm()
+    }
+
+    public func stop() {
+        lock.lock()
+        stopped = true
+        let source = self.source
+        let pending = self.pending
+        self.source = nil
+        self.pending = nil
+        lock.unlock()
+        pending?.cancel()
+        source?.cancel()
+    }
+
+    /// Open the path and watch whatever is there now.
+    ///
+    /// A missing file is not a failure: settings.json does not exist until the
+    /// first write, and a rename can be observed in the instant between the
+    /// unlink and the link. Retry on the same timer the debounce uses, so a
+    /// file that appears later is picked up without spinning.
+    private func arm() {
+        lock.lock()
+        let stopped = self.stopped
+        lock.unlock()
+        guard !stopped else { return }
+
+        let descriptor = open(url.path, O_EVTONLY)
+        guard descriptor >= 0 else {
+            lock.lock()
+            awaitingFile = true
+            lock.unlock()
+            queue.asyncAfter(deadline: .now() + Self.retryInterval) { [weak self] in
+                self?.arm()
+            }
+            return
+        }
+        // Opening what was missing a moment ago *is* the change: the write
+        // that created the file happened before there was a descriptor to
+        // watch, so no event will ever arrive for it.
+        lock.lock()
+        let appeared = awaitingFile
+        awaitingFile = false
+        lock.unlock()
+        if appeared { schedule() }
+
+        let source = DispatchSource.makeFileSystemObjectSource(
+            fileDescriptor: descriptor,
+            eventMask: [.write, .extend, .delete, .rename, .link, .revoke],
+            queue: queue
+        )
+        source.setEventHandler { [weak self] in
+            guard let self else { return }
+            let events = source.data
+            self.schedule()
+            // The path now points at a different inode (or none), so this
+            // source is watching a file nobody will write to again.
+            if !events.intersection([.delete, .rename, .revoke]).isEmpty {
+                source.cancel()
+                self.queue.asyncAfter(deadline: .now() + self.debounce) { [weak self] in
+                    self?.arm()
+                }
+            }
+        }
+        source.setCancelHandler { close(descriptor) }
+
+        lock.lock()
+        if self.stopped {
+            lock.unlock()
+            source.cancel()
+            return
+        }
+        self.source?.cancel()
+        self.source = source
+        lock.unlock()
+        source.resume()
+    }
+
+    private func schedule() {
+        let work = DispatchWorkItem { [weak self] in
+            guard let self else { return }
+            self.lock.lock()
+            let stopped = self.stopped
+            self.lock.unlock()
+            guard !stopped else { return }
+            self.onChange()
+        }
+        lock.lock()
+        pending?.cancel()
+        pending = work
+        lock.unlock()
+        queue.asyncAfter(deadline: .now() + debounce, execute: work)
+    }
+}

--- a/Sources/VibeBarCore/Storage/SettingsDocument.swift
+++ b/Sources/VibeBarCore/Storage/SettingsDocument.swift
@@ -21,9 +21,14 @@ enum SettingsDocument {
     /// a caller should then fall back to its defaults rather than assume an
     /// empty document, which would look like "every setting was cleared".
     static func read(from url: URL) -> Object? {
-        guard let data = try? Data(contentsOf: url) else { return nil }
+        guard let data = try? Data(contentsOf: url), data.count <= maximumBytes else { return nil }
         return object(from: data)
     }
+
+    /// A settings file is a few tens of kilobytes. Anything approaching this
+    /// is a corrupt or hostile file, not settings, and parsing it into memory
+    /// is work with nothing at the end of it.
+    static let maximumBytes = 8 * 1024 * 1024
 
     static func object(from data: Data) -> Object? {
         (try? JSONSerialization.jsonObject(with: data)) as? Object

--- a/Sources/VibeBarCore/Storage/SettingsDocument.swift
+++ b/Sources/VibeBarCore/Storage/SettingsDocument.swift
@@ -1,0 +1,127 @@
+import Foundation
+
+/// `settings.json` as it exists on disk, rather than as this build understands
+/// it.
+///
+/// Two things make the difference matter. A second client — Vibe Bar Desktop —
+/// reads and will write the same file, and an older build of this app knows
+/// fewer keys than a newer one. In both cases a whole-file rewrite from a
+/// decoded `AppSettings` silently deletes every key the writer did not happen
+/// to know about, and the loss is invisible until someone goes looking for a
+/// setting that has quietly reverted.
+///
+/// So writes go through here: decode for the app, keep the raw object, and put
+/// back only the keys this process actually changed. Everything else on disk
+/// survives untouched, including keys this build has never heard of.
+enum SettingsDocument {
+    /// A JSON object, as `JSONSerialization` gives it.
+    typealias Object = [String: Any]
+
+    /// Read the file as an object. Nil when it is absent or not an object —
+    /// a caller should then fall back to its defaults rather than assume an
+    /// empty document, which would look like "every setting was cleared".
+    static func read(from url: URL) -> Object? {
+        guard let data = try? Data(contentsOf: url) else { return nil }
+        return object(from: data)
+    }
+
+    static func object(from data: Data) -> Object? {
+        (try? JSONSerialization.jsonObject(with: data)) as? Object
+    }
+
+    static func object<T: Encodable>(encoding value: T) -> Object? {
+        guard let data = try? JSONEncoder().encode(value) else { return nil }
+        return object(from: data)
+    }
+
+    /// The bytes to write, in the same shape `VibeBarLocalStore.writeJSON`
+    /// produces, so a merged write is indistinguishable from a plain one.
+    static func data(from object: Object) throws -> Data {
+        try JSONSerialization.data(
+            withJSONObject: object, options: [.prettyPrinted, .sortedKeys]
+        )
+    }
+
+    /// Which top-level keys differ between two objects, in either direction.
+    ///
+    /// `owned` is the vocabulary the comparison is allowed to speak. Without
+    /// it every key this build cannot encode looks like a deletion — an
+    /// encoded `AppSettings` never mentions a key it has never heard of — and
+    /// the merge would delete exactly the keys it exists to protect. Nil means
+    /// "both objects speak the same vocabulary", which is true when comparing
+    /// two states of the file itself.
+    ///
+    /// Key granularity is a deliberate limit: two clients editing *different*
+    /// fields inside the same top-level object still resolve to one of them
+    /// winning that whole object. Settings are edited by hand and rarely, so
+    /// the alternative — a deep merge, which has no obvious right answer for
+    /// arrays — buys precision nobody needs at a cost in surprises.
+    static func changedKeys(
+        from baseline: Object,
+        to current: Object,
+        owned: Set<String>? = nil
+    ) -> Set<String> {
+        var changed = Set<String>()
+        for (key, value) in current where !equal(value, baseline[key]) {
+            changed.insert(key)
+        }
+        // A key that vanished is a removal only if the writer could have
+        // written it in the first place.
+        for key in baseline.keys where current[key] == nil {
+            if owned?.contains(key) ?? true { changed.insert(key) }
+        }
+        return changed
+    }
+
+    /// Apply this process's own edits onto whatever is on disk now.
+    ///
+    /// A three-way merge: `baseline` is what we last saw, `mine` is what we
+    /// want, `theirs` is what the file says now. Only the keys we changed move;
+    /// every other key keeps the value the file already had, whether or not
+    /// this build knows what it means.
+    static func merge(
+        baseline: Object,
+        mine: Object,
+        theirs: Object,
+        owned: Set<String>? = nil
+    ) -> Object {
+        var result = theirs
+        for key in changedKeys(from: baseline, to: mine, owned: owned) {
+            if let value = mine[key] {
+                result[key] = value
+            } else {
+                result.removeValue(forKey: key)
+            }
+        }
+        return result
+    }
+
+    /// The keys both sides changed since the baseline, and disagree about.
+    ///
+    /// These are the only edits a merge can cost someone: everywhere else both
+    /// clients get what they asked for. Surfacing them is the difference
+    /// between "your change was replaced" and a setting that silently reverts.
+    static func conflictingKeys(
+        baseline: Object,
+        mine: Object,
+        theirs: Object,
+        owned: Set<String>? = nil
+    ) -> Set<String> {
+        changedKeys(from: baseline, to: mine, owned: owned)
+            .intersection(changedKeys(from: baseline, to: theirs))
+            .filter { !equal(mine[$0], theirs[$0]) }
+            .reduce(into: Set<String>()) { $0.insert($1) }
+    }
+
+    /// JSON value equality. `NSObject.isEqual` handles the nested dictionaries
+    /// and arrays `JSONSerialization` produces; the nil cases are spelled out
+    /// because a key that is absent and a key that is present are different
+    /// facts, and `NSNull` is a third one.
+    static func equal(_ left: Any?, _ right: Any?) -> Bool {
+        switch (left, right) {
+        case (nil, nil): return true
+        case (nil, _), (_, nil): return false
+        default: return (left as AnyObject).isEqual(right as AnyObject)
+        }
+    }
+}

--- a/Sources/VibeBarCore/Storage/SettingsStore.swift
+++ b/Sources/VibeBarCore/Storage/SettingsStore.swift
@@ -286,26 +286,31 @@ public final class SettingsStore: ObservableObject {
             SafeLog.warn("Saving settings failed: settings did not encode to an object")
             return
         }
-        // Re-read rather than trusting the baseline: something else may have
-        // written since, and its keys have to survive this write.
-        let theirs = SettingsDocument.read(from: fileURL) ?? baseline
-        let changed = SettingsDocument.changedKeys(
-            from: baseline, to: mine, owned: ownedKeys(writing: mine)
-        )
-        editedKeys.formUnion(SettingsDocument.changedKeys(from: lastMine, to: mine))
-        lastMine = mine
-        var merged = theirs
-        for key in changed {
-            if let value = mine[key] { merged[key] = value } else { merged.removeValue(forKey: key) }
-        }
-        do {
-            try VibeBarLocalStore.writeData(
-                SettingsDocument.data(from: merged), to: fileURL,
-                base: fileURL.deletingLastPathComponent()
+        // Re-read and write under one lock: the re-read is what lets the
+        // other writer's keys survive, and without the lock another writer
+        // can land between the two and have its whole merge undone.
+        SharedFileLock.withLock(named: "settings", in: fileURL.deletingLastPathComponent()) {
+            // Re-read rather than trusting the baseline: something else may have
+            // written since, and its keys have to survive this write.
+            let theirs = SettingsDocument.read(from: fileURL) ?? baseline
+            let changed = SettingsDocument.changedKeys(
+                from: baseline, to: mine, owned: ownedKeys(writing: mine)
             )
-            baseline = merged
-        } catch {
-            SafeLog.warn("Saving settings failed: \(SafeLog.sanitize(error.localizedDescription))")
+            editedKeys.formUnion(SettingsDocument.changedKeys(from: lastMine, to: mine))
+            lastMine = mine
+            var merged = theirs
+            for key in changed {
+                if let value = mine[key] { merged[key] = value } else { merged.removeValue(forKey: key) }
+            }
+            do {
+                try VibeBarLocalStore.writeData(
+                    SettingsDocument.data(from: merged), to: fileURL,
+                    base: fileURL.deletingLastPathComponent()
+                )
+                baseline = merged
+            } catch {
+                SafeLog.warn("Saving settings failed: \(SafeLog.sanitize(error.localizedDescription))")
+            }
         }
     }
 

--- a/Sources/VibeBarCore/Storage/SettingsStore.swift
+++ b/Sources/VibeBarCore/Storage/SettingsStore.swift
@@ -85,10 +85,13 @@ public final class SettingsStore: ObservableObject {
         persistSequence += 1
         let sequence = persistSequence
         let snapshot = settings
+        let fold = foldHandler()
         pendingPersist = Task.detached(priority: .utility) {
             try? await Task.sleep(nanoseconds: Self.persistCoalesceNanoseconds)
             guard !Task.isCancelled else { return }
-            Self.writeQueue.async { Self.write(snapshot, sequence: sequence) }
+            Self.writeQueue.async {
+                Self.write(snapshot, sequence: sequence, foldedExternalChange: fold)
+            }
         }
     }
 
@@ -103,7 +106,10 @@ public final class SettingsStore: ObservableObject {
         persistSequence += 1
         let sequence = persistSequence
         let value = snapshot ?? settings
-        Self.writeQueue.sync { Self.write(value, sequence: sequence) }
+        let fold = foldHandler()
+        Self.writeQueue.sync {
+            Self.write(value, sequence: sequence, foldedExternalChange: fold)
+        }
     }
 
     /// What another writer took over, for the user to be told about.
@@ -158,18 +164,22 @@ public final class SettingsStore: ObservableObject {
         let url = settingsURL ?? VibeBarLocalStore.settingsURL
         // The raw object as well as the decoded value: a write puts back only
         // what changed, so it needs to know what was there to begin with.
+        var existing: SettingsDocument.Object?
         Self.writeQueue.sync {
             Self.fileURL = url
             Self.lastWrittenSequence = 0
             Self.editedKeys = []
             Self.lastMine = [:]
-            Self.baseline = SettingsDocument.read(from: url) ?? [:]
+            existing = SettingsDocument.read(from: url)
+            Self.baseline = existing ?? [:]
         }
-        if
-            let decoded = try? VibeBarLocalStore.readJSON(AppSettings.self, from: url)
-        {
+
+        if let decoded = try? VibeBarLocalStore.readJSON(AppSettings.self, from: url) {
             let migrated = Self.migrated(decoded)
             self.settings = migrated
+            // What was loaded is this process's starting position. A migration
+            // that follows is a real change and writes only what it changed.
+            Self.setLastMine(encoding: decoded)
             if migrated != decoded {
                 persist()
             }
@@ -178,21 +188,36 @@ public final class SettingsStore: ObservableObject {
             let decoded = try? JSONDecoder().decode(AppSettings.self, from: data)
         {
             self.settings = Self.migrated(decoded)
-            persist()
+            adoptStartingPosition(writingOver: existing)
         } else {
             self.settings = .default
-            persist()
-        }
-        // The settings this process starts from — whatever migration or the
-        // defaults just filled in — are its position, not its edits. Any
-        // write above ran against an empty `lastMine` and so recorded the
-        // whole document; this is where that accounting is set straight.
-        let loaded = SettingsDocument.object(encoding: settings)
-        Self.writeQueue.sync {
-            Self.lastMine = loaded ?? [:]
-            Self.editedKeys = []
+            adoptStartingPosition(writingOver: existing)
         }
         startWatching(url)
+    }
+
+    /// The fallback branches, which run both when there is no file and when
+    /// there is one this build cannot decode. Those are opposite situations.
+    ///
+    /// No file: write, so the settings exist somewhere. A file that is a valid
+    /// object but does not decode is a *newer* client's — a settings value with
+    /// a case added since this build — and saving defaults over it destroys
+    /// exactly what the merge exists to protect. Hold the defaults in memory so
+    /// there is something to show, take them as the starting position so a
+    /// later write carries only what the user actually changes, and leave the
+    /// file alone.
+    private func adoptStartingPosition(writingOver existing: SettingsDocument.Object?) {
+        Self.setLastMine(encoding: existing == nil ? nil : settings)
+        if existing == nil {
+            persist()
+        }
+    }
+
+    /// `nil` means "nothing written yet", so the first write carries the whole
+    /// document — which is right when there is no file to carry it.
+    private nonisolated static func setLastMine<T: Encodable>(encoding value: T?) {
+        let object = value.flatMap { SettingsDocument.object(encoding: $0) } ?? [:]
+        writeQueue.sync { lastMine = object }
     }
 
     /// The file is shared — with Vibe Bar Desktop, and with a second copy of
@@ -286,9 +311,33 @@ public final class SettingsStore: ObservableObject {
         isAdoptingExternalChange = false
         if hadUnsavedEdits { schedulePersist() }
 
-        replacedByAnotherWriter = adopted.conflicts.isEmpty
-            ? nil
-            : ExternalSettingsChange(replacedKeys: adopted.conflicts, observedAt: Date())
+        report(replaced: adopted.conflicts)
+    }
+
+    /// Install a file this process has just written on top of an external
+    /// change, so what is on screen matches what is on disk.
+    private func install(_ object: SettingsDocument.Object, replaced: [String]) {
+        guard
+            let data = try? SettingsDocument.data(from: object),
+            let decoded = try? JSONDecoder().decode(AppSettings.self, from: data)
+        else { return }
+        isAdoptingExternalChange = true
+        settings = Self.migrated(decoded)
+        isAdoptingExternalChange = false
+        report(replaced: replaced)
+    }
+
+    /// Add to the standing notice rather than replacing it.
+    ///
+    /// A later external write that costs nothing is not news that the first
+    /// one cost nothing, and a second one that costs something does not undo
+    /// the first. Only `acknowledgeExternalChange()` clears this.
+    private func report(replaced keys: [String]) {
+        guard !keys.isEmpty else { return }
+        let combined = Set(replacedByAnotherWriter?.replacedKeys ?? []).union(keys)
+        replacedByAnotherWriter = ExternalSettingsChange(
+            replacedKeys: combined.sorted(), observedAt: Date()
+        )
     }
 
     /// Dismiss the notice, once the user has seen it.
@@ -297,7 +346,16 @@ public final class SettingsStore: ObservableObject {
     }
 
     private func persist() {
-        Self.write(settings, sequence: nil)
+        Self.write(settings, sequence: nil, foldedExternalChange: foldHandler())
+    }
+
+    /// A write can find the file already changed, fold it in, and record the
+    /// result as seen. The watcher then has nothing left to notice, so the
+    /// write says so itself.
+    private func foldHandler() -> @Sendable (SettingsDocument.Object, [String]) -> Void {
+        { [weak self] object, replaced in
+            Task { @MainActor in self?.install(object, replaced: replaced) }
+        }
     }
 
     /// `sequence == nil` (load-time migration writes) always applies.
@@ -306,7 +364,11 @@ public final class SettingsStore: ObservableObject {
     /// rewrite from a decoded `AppSettings` deletes every key the writer did
     /// not know — another client's settings, or a newer build's — and the loss
     /// only shows up later as a setting that quietly reverted.
-    private nonisolated static func write(_ settings: AppSettings, sequence: UInt64?) {
+    private nonisolated static func write(
+        _ settings: AppSettings,
+        sequence: UInt64?,
+        foldedExternalChange: (@Sendable (SettingsDocument.Object, [String]) -> Void)? = nil
+    ) {
         if let sequence {
             guard sequence > lastWrittenSequence else { return }
             lastWrittenSequence = sequence
@@ -322,11 +384,37 @@ public final class SettingsStore: ObservableObject {
             // Re-read rather than trusting the baseline: something else may have
             // written since, and its keys have to survive this write.
             let theirs = SettingsDocument.read(from: fileURL) ?? baseline
+            // Against this process's own previous value, never against the
+            // file. A settings file written by an older version is missing
+            // keys that decoding materialises as defaults here; measured
+            // against the file those defaults look like edits, and the next
+            // save writes them over whatever the other client had put there.
             let changed = SettingsDocument.changedKeys(
-                from: baseline, to: mine, owned: ownedKeys(writing: mine)
+                from: lastMine, to: mine, owned: ownedKeys(writing: mine)
             )
-            editedKeys.formUnion(SettingsDocument.changedKeys(from: lastMine, to: mine))
+            editedKeys.formUnion(changed)
             lastMine = mine
+            // The other writer got there first, and this write is about to put
+            // its own keys on top and record the result as the file we have
+            // seen. Without saying so, the watcher that follows compares the
+            // file against a baseline that already contains their change,
+            // finds nothing, and this process goes on showing stale settings
+            // until the next external write or a restart.
+            let theirChanges = SettingsDocument.changedKeys(from: baseline, to: theirs)
+            let conflicts = theirChanges
+                .intersection(editedKeys.union(changed))
+                .filter { !SettingsDocument.equal(mine[$0], theirs[$0]) }
+                .sorted()
+            // Their value is our position now for anything we are not writing.
+            for key in theirChanges where !changed.contains(key) {
+                if let value = theirs[key] {
+                    lastMine[key] = value
+                } else {
+                    lastMine.removeValue(forKey: key)
+                }
+                editedKeys.remove(key)
+            }
+
             var merged = theirs
             for key in changed {
                 if let value = mine[key] { merged[key] = value } else { merged.removeValue(forKey: key) }
@@ -337,6 +425,9 @@ public final class SettingsStore: ObservableObject {
                     base: fileURL.deletingLastPathComponent()
                 )
                 baseline = merged
+                if !theirChanges.isEmpty {
+                    foldedExternalChange?(merged, conflicts)
+                }
             } catch {
                 SafeLog.warn("Saving settings failed: \(SafeLog.sanitize(error.localizedDescription))")
             }

--- a/Sources/VibeBarCore/Storage/SettingsStore.swift
+++ b/Sources/VibeBarCore/Storage/SettingsStore.swift
@@ -4,8 +4,22 @@ import Combine
 @MainActor
 public final class SettingsStore: ObservableObject {
     @Published public var settings: AppSettings {
-        didSet { schedulePersist() }
+        didSet {
+            guard !isAdoptingExternalChange else { return }
+            schedulePersist()
+        }
     }
+
+    /// Set when a setting this process had changed was replaced by another
+    /// writer's value. Nil at every other time, including for the far more
+    /// common case of an external edit to a setting nobody here touched —
+    /// that one is adopted silently, because nothing was lost.
+    @Published public private(set) var replacedByAnotherWriter: ExternalSettingsChange?
+
+    /// True while the file's values are being copied into `settings`, so the
+    /// adoption does not schedule a write of what was just read.
+    private var isAdoptingExternalChange = false
+    private var watcher: FileChangeWatcher?
 
     private let defaultsKey = "VibeBar.settings.v1"
 
@@ -25,6 +39,46 @@ public final class SettingsStore: ObservableObject {
     )
     /// Only ever touched on `writeQueue`.
     private nonisolated(unsafe) static var lastWrittenSequence: UInt64 = 0
+    /// Where this store reads and writes. A parameter rather than a constant
+    /// so the merge can be exercised against a real file: the whole point of
+    /// this class is what it does to one that changed underneath it.
+    private nonisolated(unsafe) static var fileURL: URL = VibeBarLocalStore.settingsURL
+    /// The file as this process last saw it, which is what a write measures
+    /// its own edits against. Only ever touched on `writeQueue`.
+    private nonisolated(unsafe) static var baseline: SettingsDocument.Object = [:]
+
+    /// The settings this process has actually changed since it launched.
+    ///
+    /// Without it there is no way to tell "someone replaced the value I chose"
+    /// from "someone changed a setting I have never touched" — by the time the
+    /// other writer's file arrives, our own edit is long since saved and looks
+    /// exactly like the value that was always there. Only ever touched on
+    /// `writeQueue`.
+    private nonisolated(unsafe) static var editedKeys: Set<String> = []
+
+    /// This process's own settings as of its last write.
+    ///
+    /// Deliberately not the file: measuring our edits against the file counts
+    /// every default the file did not happen to carry as something the user
+    /// chose, and the first save then claims authorship of the entire
+    /// document. What we changed is what changed *here*. Only ever touched on
+    /// `writeQueue`.
+    private nonisolated(unsafe) static var lastMine: SettingsDocument.Object = [:]
+
+    /// The keys a default document has, which is the part of this build's
+    /// vocabulary that does not depend on the current value.
+    private nonisolated static let defaultKeys: Set<String> =
+        Set(SettingsDocument.object(encoding: AppSettings.default)?.keys ?? [:].keys)
+
+    /// Every top-level key this build could write, so a merge can tell a
+    /// setting the user removed from one it has never heard of.
+    ///
+    /// The union of what is being written and what a default document holds:
+    /// an optional field that is nil right now is absent from the first and
+    /// present in the second, and it is still ours to remove.
+    private nonisolated static func ownedKeys(writing mine: SettingsDocument.Object) -> Set<String> {
+        defaultKeys.union(mine.keys)
+    }
 
     private func schedulePersist() {
         pendingPersist?.cancel()
@@ -52,9 +106,67 @@ public final class SettingsStore: ObservableObject {
         Self.writeQueue.sync { Self.write(value, sequence: sequence) }
     }
 
-    public init(userDefaults: UserDefaults = .standard) {
+    /// What another writer took over, for the user to be told about.
+    public struct ExternalSettingsChange: Equatable, Sendable {
+        /// The settings whose values this process had changed and which now
+        /// hold someone else's value instead.
+        public let replacedKeys: [String]
+        public let observedAt: Date
+
+        public init(replacedKeys: [String], observedAt: Date) {
+            self.replacedKeys = replacedKeys
+            self.observedAt = observedAt
+        }
+
+        /// One sentence naming what was taken over.
+        ///
+        /// Settings are named by their JSON key, which is the only name that
+        /// exists for every one of them — a hand-kept table of prettier
+        /// labels would be wrong for whichever setting was added last.
+        public var summary: String {
+            let names = replacedKeys.map(Self.humanised(_:))
+            guard !names.isEmpty else { return "" }
+            let listed = names.prefix(3).joined(separator: ", ")
+            if names.count > 3 {
+                let rest = names.count - 3
+                return "\(listed) and \(rest) more settings now hold the other copy's value."
+            }
+            let verb = names.count == 1 ? "holds" : "hold"
+            return "\(listed) now \(verb) the other copy's value."
+        }
+
+        /// `refreshIntervalSeconds` reads as "Refresh interval seconds".
+        static func humanised(_ key: String) -> String {
+            var words: [String] = []
+            var current = ""
+            for character in key {
+                if character.isUppercase, !current.isEmpty {
+                    words.append(current)
+                    current = String(character).lowercased()
+                } else {
+                    current.append(character)
+                }
+            }
+            if !current.isEmpty { words.append(current) }
+            guard let first = words.first else { return key }
+            return ([first.prefix(1).uppercased() + first.dropFirst()] + words.dropFirst())
+                .joined(separator: " ")
+        }
+    }
+
+    public init(userDefaults: UserDefaults = .standard, settingsURL: URL? = nil) {
+        let url = settingsURL ?? VibeBarLocalStore.settingsURL
+        // The raw object as well as the decoded value: a write puts back only
+        // what changed, so it needs to know what was there to begin with.
+        Self.writeQueue.sync {
+            Self.fileURL = url
+            Self.lastWrittenSequence = 0
+            Self.editedKeys = []
+            Self.lastMine = [:]
+            Self.baseline = SettingsDocument.read(from: url) ?? [:]
+        }
         if
-            let decoded = try? VibeBarLocalStore.readJSON(AppSettings.self, from: VibeBarLocalStore.settingsURL)
+            let decoded = try? VibeBarLocalStore.readJSON(AppSettings.self, from: url)
         {
             let migrated = Self.migrated(decoded)
             self.settings = migrated
@@ -71,6 +183,88 @@ public final class SettingsStore: ObservableObject {
             self.settings = .default
             persist()
         }
+        // The settings this process starts from — whatever migration or the
+        // defaults just filled in — are its position, not its edits. Any
+        // write above ran against an empty `lastMine` and so recorded the
+        // whole document; this is where that accounting is set straight.
+        let loaded = SettingsDocument.object(encoding: settings)
+        Self.writeQueue.sync {
+            Self.lastMine = loaded ?? [:]
+            Self.editedKeys = []
+        }
+        startWatching(url)
+    }
+
+    /// The file is shared — with Vibe Bar Desktop, and with a second copy of
+    /// this app — so a change to it is news, not an error. Adopt it while it
+    /// is happening rather than at the next launch.
+    private func startWatching(_ url: URL) {
+        let watcher = FileChangeWatcher(url: url) { [weak self] in
+            // Our own saves come back through this watcher too, and they are
+            // the common case by a wide margin. Settle that here, on the
+            // watcher's own queue, rather than waking the main actor to
+            // re-encode the settings and find nothing has changed.
+            guard Self.fileDiffersFromBaseline() else { return }
+            Task { @MainActor [weak self] in self?.adoptExternalChange() }
+        }
+        watcher.start()
+        self.watcher = watcher
+    }
+
+    private nonisolated static func fileDiffersFromBaseline() -> Bool {
+        writeQueue.sync {
+            guard let theirs = SettingsDocument.read(from: fileURL) else { return false }
+            return !SettingsDocument.equal(theirs, baseline)
+        }
+    }
+
+    /// Take on whatever another writer changed, and report only what it cost.
+    ///
+    /// The file wins where both sides moved the same setting: it is the shared
+    /// state, and the alternative — quietly keeping a value the file no longer
+    /// holds — is the stale-UI bug this watching exists to end. The user is
+    /// told, which is the part that makes the file winning acceptable.
+    private func adoptExternalChange() {
+        guard let mine = SettingsDocument.object(encoding: settings) else { return }
+        var adopted: (object: SettingsDocument.Object, conflicts: [String])?
+
+        Self.writeQueue.sync {
+            guard let theirs = SettingsDocument.read(from: Self.fileURL) else { return }
+            // Our own write, coming back to us.
+            guard !SettingsDocument.equal(theirs, Self.baseline) else { return }
+            // What they changed, among the settings we chose a value for —
+            // whether that choice is still sitting unsaved in memory or was
+            // written out and has since been taken over.
+            let unsaved = SettingsDocument.changedKeys(from: Self.lastMine, to: mine)
+            let ours = Self.editedKeys.union(unsaved)
+            let conflicts = SettingsDocument.changedKeys(from: Self.baseline, to: theirs)
+                .intersection(ours)
+                .filter { !SettingsDocument.equal(mine[$0], theirs[$0]) }
+            // Their changes land on top of ours; anything we changed and they
+            // did not is still unwritten here and survives to the next save.
+            let object = SettingsDocument.merge(baseline: Self.baseline, mine: theirs, theirs: mine)
+            Self.baseline = theirs
+            adopted = (object, conflicts.sorted())
+        }
+
+        guard
+            let adopted,
+            let data = try? SettingsDocument.data(from: adopted.object),
+            let decoded = try? JSONDecoder().decode(AppSettings.self, from: data)
+        else { return }
+
+        isAdoptingExternalChange = true
+        settings = Self.migrated(decoded)
+        isAdoptingExternalChange = false
+
+        replacedByAnotherWriter = adopted.conflicts.isEmpty
+            ? nil
+            : ExternalSettingsChange(replacedKeys: adopted.conflicts, observedAt: Date())
+    }
+
+    /// Dismiss the notice, once the user has seen it.
+    public func acknowledgeExternalChange() {
+        replacedByAnotherWriter = nil
     }
 
     private func persist() {
@@ -78,13 +272,38 @@ public final class SettingsStore: ObservableObject {
     }
 
     /// `sequence == nil` (load-time migration writes) always applies.
+    ///
+    /// Writes what this process changed, not everything it holds. A whole-file
+    /// rewrite from a decoded `AppSettings` deletes every key the writer did
+    /// not know — another client's settings, or a newer build's — and the loss
+    /// only shows up later as a setting that quietly reverted.
     private nonisolated static func write(_ settings: AppSettings, sequence: UInt64?) {
         if let sequence {
             guard sequence > lastWrittenSequence else { return }
             lastWrittenSequence = sequence
         }
+        guard let mine = SettingsDocument.object(encoding: settings) else {
+            SafeLog.warn("Saving settings failed: settings did not encode to an object")
+            return
+        }
+        // Re-read rather than trusting the baseline: something else may have
+        // written since, and its keys have to survive this write.
+        let theirs = SettingsDocument.read(from: fileURL) ?? baseline
+        let changed = SettingsDocument.changedKeys(
+            from: baseline, to: mine, owned: ownedKeys(writing: mine)
+        )
+        editedKeys.formUnion(SettingsDocument.changedKeys(from: lastMine, to: mine))
+        lastMine = mine
+        var merged = theirs
+        for key in changed {
+            if let value = mine[key] { merged[key] = value } else { merged.removeValue(forKey: key) }
+        }
         do {
-            try VibeBarLocalStore.writeJSON(settings, to: VibeBarLocalStore.settingsURL)
+            try VibeBarLocalStore.writeData(
+                SettingsDocument.data(from: merged), to: fileURL,
+                base: fileURL.deletingLastPathComponent()
+            )
+            baseline = merged
         } catch {
             SafeLog.warn("Saving settings failed: \(SafeLog.sanitize(error.localizedDescription))")
         }

--- a/Sources/VibeBarCore/Storage/SettingsStore.swift
+++ b/Sources/VibeBarCore/Storage/SettingsStore.swift
@@ -226,36 +226,65 @@ public final class SettingsStore: ObservableObject {
     /// told, which is the part that makes the file winning acceptable.
     private func adoptExternalChange() {
         guard let mine = SettingsDocument.object(encoding: settings) else { return }
-        var adopted: (object: SettingsDocument.Object, conflicts: [String])?
+        var adopted: (settings: AppSettings, conflicts: [String])?
 
+        // One block: the decode decides whether any of this is adopted at all,
+        // and a write landing between deciding and recording would leave the
+        // baseline describing a file this store never actually took on.
         Self.writeQueue.sync {
             guard let theirs = SettingsDocument.read(from: Self.fileURL) else { return }
             // Our own write, coming back to us.
             guard !SettingsDocument.equal(theirs, Self.baseline) else { return }
+            let theirChanges = SettingsDocument.changedKeys(from: Self.baseline, to: theirs)
             // What they changed, among the settings we chose a value for —
             // whether that choice is still sitting unsaved in memory or was
             // written out and has since been taken over.
             let unsaved = SettingsDocument.changedKeys(from: Self.lastMine, to: mine)
-            let ours = Self.editedKeys.union(unsaved)
-            let conflicts = SettingsDocument.changedKeys(from: Self.baseline, to: theirs)
-                .intersection(ours)
+            let conflicts = theirChanges
+                .intersection(Self.editedKeys.union(unsaved))
                 .filter { !SettingsDocument.equal(mine[$0], theirs[$0]) }
             // Their changes land on top of ours; anything we changed and they
             // did not is still unwritten here and survives to the next save.
             let object = SettingsDocument.merge(baseline: Self.baseline, mine: theirs, theirs: mine)
+
+            // A file this build cannot read is one it must not claim to have
+            // seen. Advancing the baseline here would let the next save diff
+            // our old values against it and write them over a newer writer's
+            // — losing exactly what the merge exists to keep.
+            guard
+                let data = try? SettingsDocument.data(from: object),
+                let decoded = try? JSONDecoder().decode(AppSettings.self, from: data)
+            else { return }
+
             Self.baseline = theirs
-            adopted = (object, conflicts.sorted())
+            // Their value is our position now, not our edit: leaving `lastMine`
+            // behind would make the next save claim their key as ours and
+            // report it as lost the next time they touched it.
+            for key in theirChanges {
+                if let value = theirs[key] {
+                    Self.lastMine[key] = value
+                } else {
+                    Self.lastMine.removeValue(forKey: key)
+                }
+            }
+            Self.editedKeys.subtract(theirChanges)
+            adopted = (Self.migrated(decoded), conflicts.sorted())
         }
 
-        guard
-            let adopted,
-            let data = try? SettingsDocument.data(from: adopted.object),
-            let decoded = try? JSONDecoder().decode(AppSettings.self, from: data)
-        else { return }
+        guard let adopted else { return }
+
+        // A coalesced save may be in flight, holding a snapshot taken before
+        // any of this. Left alone it would write those values back and undo
+        // the change just adopted, so it is replaced rather than cancelled:
+        // the snapshot is stale, the edits in it are not.
+        let hadUnsavedEdits = pendingPersist != nil
+        pendingPersist?.cancel()
+        pendingPersist = nil
 
         isAdoptingExternalChange = true
-        settings = Self.migrated(decoded)
+        settings = adopted.settings
         isAdoptingExternalChange = false
+        if hadUnsavedEdits { schedulePersist() }
 
         replacedByAnotherWriter = adopted.conflicts.isEmpty
             ? nil

--- a/Sources/VibeBarCore/Storage/SettingsStore.swift
+++ b/Sources/VibeBarCore/Storage/SettingsStore.swift
@@ -392,8 +392,6 @@ public final class SettingsStore: ObservableObject {
             let changed = SettingsDocument.changedKeys(
                 from: lastMine, to: mine, owned: ownedKeys(writing: mine)
             )
-            editedKeys.formUnion(changed)
-            lastMine = mine
             // The other writer got there first, and this write is about to put
             // its own keys on top and record the result as the file we have
             // seen. Without saying so, the watcher that follows compares the
@@ -401,30 +399,51 @@ public final class SettingsStore: ObservableObject {
             // finds nothing, and this process goes on showing stale settings
             // until the next external write or a restart.
             let theirChanges = SettingsDocument.changedKeys(from: baseline, to: theirs)
+            // Not the keys this write is applying: ours is the value that
+            // reaches the file, so nothing of ours was replaced there. Saying
+            // otherwise puts "another Vibe Bar replaced your change" in front
+            // of someone whose change is the one that won.
             let conflicts = theirChanges
-                .intersection(editedKeys.union(changed))
+                .subtracting(changed)
+                .intersection(editedKeys)
                 .filter { !SettingsDocument.equal(mine[$0], theirs[$0]) }
                 .sorted()
-            // Their value is our position now for anything we are not writing.
-            for key in theirChanges where !changed.contains(key) {
-                if let value = theirs[key] {
-                    lastMine[key] = value
-                } else {
-                    lastMine.removeValue(forKey: key)
-                }
-                editedKeys.remove(key)
-            }
 
             var merged = theirs
             for key in changed {
                 if let value = mine[key] { merged[key] = value } else { merged.removeValue(forKey: key) }
             }
+
+            // Whether this build can read back what it is about to write. It
+            // writes either way — the file is correct, and their value is in
+            // it — but a merged object it cannot decode is one whose values it
+            // has *not* taken on, and recording otherwise would let the next
+            // save treat its own fallback as an edit and overwrite them.
+            let readable = (try? SettingsDocument.data(from: merged))
+                .flatMap { try? JSONDecoder().decode(AppSettings.self, from: $0) } != nil
+
             do {
                 try VibeBarLocalStore.writeData(
                     SettingsDocument.data(from: merged), to: fileURL,
                     base: fileURL.deletingLastPathComponent()
                 )
+                // Only now: a write that failed has changed nothing, and a
+                // process that recorded these as written would leave them out
+                // of the next merge and off the disk until it restarted.
                 baseline = merged
+                editedKeys.formUnion(changed)
+                lastMine = mine
+                guard readable else { return }
+                // Their value is our position now for anything we are not
+                // writing ourselves.
+                for key in theirChanges where !changed.contains(key) {
+                    if let value = theirs[key] {
+                        lastMine[key] = value
+                    } else {
+                        lastMine.removeValue(forKey: key)
+                    }
+                    editedKeys.remove(key)
+                }
                 if !theirChanges.isEmpty {
                     foldedExternalChange?(merged, conflicts)
                 }

--- a/Sources/VibeBarCore/Storage/SharedFileLock.swift
+++ b/Sources/VibeBarCore/Storage/SharedFileLock.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+/// An advisory lock over one shared file, held across a read-modify-write.
+///
+/// `settings.json` has two writers in separate processes. Each one re-reads
+/// the file before writing so the other's keys survive, but re-read and
+/// rename are two steps: two writers can interleave between them and the
+/// second one's merge is then based on a file that no longer exists. The
+/// window is small and the loss is silent, which is the combination worth
+/// spending a lock on.
+///
+/// `flock(2)` rather than a lock file with a pid in it: the kernel releases it
+/// when the descriptor closes, including when the process dies, so there is no
+/// stale lock to break and no liveness check to get wrong. It is advisory —
+/// it binds the clients that ask for it, which is both of them.
+public enum SharedFileLock {
+    /// Run `body` while holding the lock named by `name` under `directory`.
+    ///
+    /// Failing to take the lock is not failing to write: a read-only or
+    /// unusual filesystem should degrade to the unlocked behaviour that came
+    /// before, not to losing the user's settings. The narrow race is worth
+    /// closing; it is not worth a new way to fail.
+    @discardableResult
+    public static func withLock<T>(
+        named name: String, in directory: URL, _ body: () throws -> T
+    ) rethrows -> T {
+        guard let descriptor = acquire(named: name, in: directory) else { return try body() }
+        defer {
+            flock(descriptor, LOCK_UN)
+            close(descriptor)
+        }
+        return try body()
+    }
+
+    private static func acquire(named name: String, in directory: URL) -> Int32? {
+        let runDirectory = directory.appendingPathComponent("run", isDirectory: true)
+        try? FileManager.default.createDirectory(
+            at: runDirectory, withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700]
+        )
+        let path = runDirectory.appendingPathComponent("\(name).lock").path
+        let descriptor = open(path, O_CREAT | O_RDWR, 0o600)
+        guard descriptor >= 0 else { return nil }
+        // Blocking: the other holder has a file read, a merge and a rename to
+        // do, and waiting for that is the entire point.
+        guard flock(descriptor, LOCK_EX) == 0 else {
+            close(descriptor)
+            return nil
+        }
+        return descriptor
+    }
+}

--- a/Tests/VibeBarCoreTests/FileChangeWatcherTests.swift
+++ b/Tests/VibeBarCoreTests/FileChangeWatcherTests.swift
@@ -93,23 +93,45 @@ final class FileChangeWatcherTests: XCTestCase {
         wait(for: [quiet], timeout: 0.5)
     }
 
-    /// A burst of writes is one reload, not one per event.
+    /// A burst of writes is far fewer reloads than writes.
+    ///
+    /// Written in place rather than atomically, which is the only way this
+    /// measures the debounce: an atomic write replaces the inode, the source
+    /// cancels and re-arms, and that gap swallows a burst all by itself. The
+    /// first version of this test used atomic writes and passed with the
+    /// debounce removed entirely.
+    ///
+    /// And not *one* reload: the debounce promises at most one report per
+    /// window, not that a burst finishes inside one. An exact count asserts
+    /// how fast the machine is, which is how the first version passed here
+    /// and failed on a slower CI runner.
     func testCoalescesABurstOfWrites() throws {
         try writeAtomically("{}")
         let counter = OSAllocatedUnfairLockCounter()
-        let watcher = FileChangeWatcher(url: file, debounceMilliseconds: 120) {
+        let watcher = FileChangeWatcher(url: file, debounceMilliseconds: 300) {
             _ = counter.increment()
         }
         watcher.start()
         defer { watcher.stop() }
 
         Thread.sleep(forTimeInterval: 0.1)
-        for index in 0..<5 {
-            try writeAtomically(#"{"a":\#(index)}"#)
+        let handle = try FileHandle(forWritingTo: file)
+        defer { try? handle.close() }
+        let writes = 8
+        for index in 0..<writes {
+            try handle.seek(toOffset: 0)
+            try handle.write(contentsOf: Data("{\"a\":\(index)}".utf8))
+            try handle.synchronize()
             Thread.sleep(forTimeInterval: 0.01)
         }
-        Thread.sleep(forTimeInterval: 0.6)
-        XCTAssertEqual(counter.value, 1, "expected one coalesced report for one burst")
+        Thread.sleep(forTimeInterval: 1.0)
+
+        let reports = counter.value
+        XCTAssertGreaterThan(reports, 0, "a burst of writes was not reported at all")
+        XCTAssertLessThan(
+            reports, writes,
+            "every write produced its own report, so nothing is being coalesced"
+        )
     }
 }
 

--- a/Tests/VibeBarCoreTests/FileChangeWatcherTests.swift
+++ b/Tests/VibeBarCoreTests/FileChangeWatcherTests.swift
@@ -1,0 +1,134 @@
+import XCTest
+@testable import VibeBarCore
+
+/// Everything here writes atomically, so the case that matters is the one a
+/// naive descriptor watch gets wrong: after a rename the path holds a new
+/// inode, and a watcher still holding the old one goes quiet forever.
+final class FileChangeWatcherTests: XCTestCase {
+    private var directory: URL!
+    private var file: URL!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        directory = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("watch-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        file = directory.appendingPathComponent("settings.json")
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: directory)
+        try super.tearDownWithError()
+    }
+
+    /// `Data.write(options: .atomic)` — the way every store here writes.
+    private func writeAtomically(_ text: String) throws {
+        try Data(text.utf8).write(to: file, options: [.atomic])
+    }
+
+    private func watcher(_ onChange: @escaping @Sendable () -> Void) -> FileChangeWatcher {
+        FileChangeWatcher(url: file, debounceMilliseconds: 20, onChange: onChange)
+    }
+
+    func testReportsAnAtomicReplace() throws {
+        try writeAtomically("{}")
+        let changed = expectation(description: "change reported")
+        let watcher = watcher { changed.fulfill() }
+        watcher.start()
+        defer { watcher.stop() }
+
+        // Let the source arm before the write it is meant to see.
+        Thread.sleep(forTimeInterval: 0.1)
+        try writeAtomically(#"{"a":1}"#)
+
+        wait(for: [changed], timeout: 3)
+    }
+
+    /// The one a descriptor watch fails: a second atomic write, after the
+    /// first has already replaced the inode the watcher opened.
+    func testKeepsReportingAfterTheInodeIsReplaced() throws {
+        try writeAtomically("{}")
+        let second = expectation(description: "second change reported")
+        second.assertForOverFulfill = false
+        let seen = OSAllocatedUnfairLockCounter()
+        let watcher = watcher {
+            if seen.increment() >= 2 { second.fulfill() }
+        }
+        watcher.start()
+        defer { watcher.stop() }
+
+        Thread.sleep(forTimeInterval: 0.1)
+        try writeAtomically(#"{"a":1}"#)
+        Thread.sleep(forTimeInterval: 0.2)
+        try writeAtomically(#"{"a":2}"#)
+
+        wait(for: [second], timeout: 3)
+    }
+
+    /// settings.json does not exist until something writes it, and a watcher
+    /// started first still has to report that first write.
+    func testReportsAFileThatDoesNotExistYet() throws {
+        let created = expectation(description: "creation reported")
+        created.assertForOverFulfill = false
+        let watcher = watcher { created.fulfill() }
+        watcher.start()
+        defer { watcher.stop() }
+
+        Thread.sleep(forTimeInterval: 0.1)
+        try writeAtomically(#"{"a":1}"#)
+
+        wait(for: [created], timeout: 3)
+    }
+
+    func testSaysNothingAfterBeingStopped() throws {
+        try writeAtomically("{}")
+        let quiet = expectation(description: "no change reported")
+        quiet.isInverted = true
+        let watcher = watcher { quiet.fulfill() }
+        watcher.start()
+        Thread.sleep(forTimeInterval: 0.1)
+        watcher.stop()
+
+        try writeAtomically(#"{"a":1}"#)
+        wait(for: [quiet], timeout: 0.5)
+    }
+
+    /// A burst of writes is one reload, not one per event.
+    func testCoalescesABurstOfWrites() throws {
+        try writeAtomically("{}")
+        let counter = OSAllocatedUnfairLockCounter()
+        let watcher = FileChangeWatcher(url: file, debounceMilliseconds: 120) {
+            _ = counter.increment()
+        }
+        watcher.start()
+        defer { watcher.stop() }
+
+        Thread.sleep(forTimeInterval: 0.1)
+        for index in 0..<5 {
+            try writeAtomically(#"{"a":\#(index)}"#)
+            Thread.sleep(forTimeInterval: 0.01)
+        }
+        Thread.sleep(forTimeInterval: 0.6)
+        XCTAssertEqual(counter.value, 1, "expected one coalesced report for one burst")
+    }
+}
+
+/// A counter the watcher's queue and the test can both touch.
+final class OSAllocatedUnfairLockCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var count = 0
+
+    @discardableResult
+    func increment() -> Int {
+        lock.lock()
+        defer { lock.unlock() }
+        count += 1
+        return count
+    }
+
+    var value: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return count
+    }
+}

--- a/Tests/VibeBarCoreTests/SettingsDocumentTests.swift
+++ b/Tests/VibeBarCoreTests/SettingsDocumentTests.swift
@@ -155,6 +155,19 @@ final class SettingsDocumentTests: XCTestCase {
     /// A file that is not an object at all reads as nothing, so a caller falls
     /// back to its defaults rather than treating a corrupt file as "every
     /// setting was cleared" and writing that back.
+    /// A file far larger than settings could be is not settings.
+    func testAFileTooLargeToBeSettingsReadsAsNothing() throws {
+        let url = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("huge-\(UUID().uuidString).json")
+        defer { try? FileManager.default.removeItem(at: url) }
+        var data = Data(#"{"a":""#.utf8)
+        data.append(Data(repeating: UInt8(ascii: "x"), count: SettingsDocument.maximumBytes))
+        data.append(Data(#""}"#.utf8))
+        try data.write(to: url)
+
+        XCTAssertNil(SettingsDocument.read(from: url))
+    }
+
     func testAFileThatIsNotAnObjectReadsAsNothing() {
         XCTAssertNil(SettingsDocument.object(from: Data("[1,2,3]".utf8)))
         XCTAssertNil(SettingsDocument.object(from: Data("not json".utf8)))

--- a/Tests/VibeBarCoreTests/SettingsDocumentTests.swift
+++ b/Tests/VibeBarCoreTests/SettingsDocumentTests.swift
@@ -1,0 +1,162 @@
+import XCTest
+@testable import VibeBarCore
+
+/// Settings are one file with two writers — this app and Vibe Bar Desktop —
+/// and, across versions, two vocabularies. Both make a whole-file rewrite
+/// lossy, so these cover what a write is allowed to touch.
+final class SettingsDocumentTests: XCTestCase {
+    private func object(_ json: String) -> SettingsDocument.Object {
+        SettingsDocument.object(from: Data(json.utf8)) ?? [:]
+    }
+
+    // MARK: - What a write may change
+
+    /// The case that motivates all of this: a key this build has never heard
+    /// of, written by another client or a newer version, must survive a write
+    /// from a build that cannot decode it.
+    func testAKeyThisBuildDoesNotKnowSurvivesAWrite() {
+        let baseline = object(#"{"displayMode":"remaining","futureSetting":{"a":1}}"#)
+        // What an encoded `AppSettings` looks like in a build that has never
+        // heard of `futureSetting`: the key is simply not mentioned.
+        let mine = object(#"{"displayMode":"used"}"#)
+        let merged = SettingsDocument.merge(
+            baseline: baseline, mine: mine, theirs: baseline, owned: ["displayMode"]
+        )
+
+        XCTAssertEqual(merged["displayMode"] as? String, "used")
+        XCTAssertNotNil(merged["futureSetting"], "a key we cannot decode was deleted")
+    }
+
+    /// The same absence, from a build that *does* know the key: then it is a
+    /// removal and has to reach the file.
+    func testAKeyThisBuildKnowsIsRemovedWhenItGoesMissing() {
+        let baseline = object(#"{"displayMode":"remaining","futureSetting":{"a":1}}"#)
+        let mine = object(#"{"displayMode":"used"}"#)
+        let merged = SettingsDocument.merge(
+            baseline: baseline, mine: mine, theirs: baseline,
+            owned: ["displayMode", "futureSetting"]
+        )
+
+        XCTAssertNil(merged["futureSetting"])
+    }
+
+    /// The other client's edit, made while this process was running, is still
+    /// there afterwards.
+    func testAnotherClientsEditSurvivesThisOnesWrite() {
+        let baseline = object(#"{"displayMode":"remaining","refreshIntervalSeconds":600}"#)
+        let mine = object(#"{"displayMode":"used","refreshIntervalSeconds":600}"#)
+        let theirs = object(#"{"displayMode":"remaining","refreshIntervalSeconds":120}"#)
+
+        let merged = SettingsDocument.merge(baseline: baseline, mine: mine, theirs: theirs)
+
+        XCTAssertEqual(merged["displayMode"] as? String, "used", "our own edit was dropped")
+        XCTAssertEqual(
+            merged["refreshIntervalSeconds"] as? Int, 120,
+            "the other client's edit was overwritten by a value we never touched"
+        )
+    }
+
+    /// A write that changed nothing changes nothing, however far the file has
+    /// moved on. Coalesced writes fire on a timer, and one arriving after
+    /// another client wrote must not undo it.
+    func testAWriteThatChangedNothingLeavesTheFileAlone() {
+        let baseline = object(#"{"displayMode":"remaining"}"#)
+        let theirs = object(#"{"displayMode":"used","newKey":true}"#)
+
+        let merged = SettingsDocument.merge(baseline: baseline, mine: baseline, theirs: theirs)
+
+        XCTAssertEqual(merged as NSDictionary, theirs as NSDictionary)
+    }
+
+    /// Removing a setting is an edit like any other, and has to reach the file
+    /// rather than being read as "unchanged".
+    func testRemovingAKeyRemovesIt() {
+        let baseline = object(#"{"displayMode":"remaining","customLabels":{"a":"b"}}"#)
+        let mine = object(#"{"displayMode":"remaining"}"#)
+
+        let merged = SettingsDocument.merge(
+            baseline: baseline, mine: mine, theirs: baseline,
+            owned: ["displayMode", "customLabels"]
+        )
+
+        XCTAssertNil(merged["customLabels"])
+    }
+
+    func testNestedValuesCompareByContentNotIdentity() {
+        let baseline = object(#"{"miniWindow":{"fields":["a","b"],"size":{"w":1}}}"#)
+        let same = object(#"{"miniWindow":{"size":{"w":1},"fields":["a","b"]}}"#)
+        XCTAssertTrue(SettingsDocument.changedKeys(from: baseline, to: same).isEmpty)
+
+        let different = object(#"{"miniWindow":{"fields":["a"],"size":{"w":1}}}"#)
+        XCTAssertEqual(
+            SettingsDocument.changedKeys(from: baseline, to: different), ["miniWindow"]
+        )
+    }
+
+    /// An absent key, a present key and an explicit null are three different
+    /// statements about a setting.
+    func testAbsentAndNullAreNotTheSame() {
+        XCTAssertFalse(SettingsDocument.equal(nil, NSNull()))
+        XCTAssertTrue(SettingsDocument.equal(NSNull(), NSNull()))
+        XCTAssertTrue(SettingsDocument.equal(nil, nil))
+    }
+
+    // MARK: - What the user should be told
+
+    /// Only where both sides changed the same key does anyone lose an edit.
+    func testOnlyTheSameKeyChangedTwiceIsAConflict() {
+        let baseline = object(#"{"displayMode":"remaining","refreshIntervalSeconds":600}"#)
+        let mine = object(#"{"displayMode":"used","refreshIntervalSeconds":600}"#)
+        let theirs = object(#"{"displayMode":"remaining","refreshIntervalSeconds":120}"#)
+
+        XCTAssertTrue(
+            SettingsDocument.conflictingKeys(baseline: baseline, mine: mine, theirs: theirs).isEmpty,
+            "editing different settings is not a conflict"
+        )
+    }
+
+    func testTheSameKeyChangedToTheSameValueIsNotAConflict() {
+        let baseline = object(#"{"displayMode":"remaining"}"#)
+        let agreed = object(#"{"displayMode":"used"}"#)
+        XCTAssertTrue(
+            SettingsDocument.conflictingKeys(baseline: baseline, mine: agreed, theirs: agreed)
+                .isEmpty,
+            "both clients asking for the same thing is agreement, not a conflict"
+        )
+    }
+
+    func testTheSameKeyChangedTwoWaysIsAConflict() {
+        let baseline = object(#"{"displayMode":"remaining"}"#)
+        let mine = object(#"{"displayMode":"used"}"#)
+        let theirs = object(#"{"displayMode":"forecast"}"#)
+
+        XCTAssertEqual(
+            SettingsDocument.conflictingKeys(baseline: baseline, mine: mine, theirs: theirs),
+            ["displayMode"]
+        )
+    }
+
+    // MARK: - Round trip
+
+    /// The bytes a merged write produces are the shape the rest of the app
+    /// already writes, so nothing downstream can tell the two apart.
+    func testMergedBytesKeepTheFormatTheRestOfTheAppUses() throws {
+        let merged = object(#"{"b":2,"a":1}"#)
+        let data = try SettingsDocument.data(from: merged)
+        let text = String(decoding: data, as: UTF8.self)
+        XCTAssertTrue(text.contains("\n"), "expected pretty-printed output")
+        XCTAssertLessThan(
+            try XCTUnwrap(text.range(of: "\"a\"")).lowerBound,
+            try XCTUnwrap(text.range(of: "\"b\"")).lowerBound,
+            "expected sorted keys"
+        )
+    }
+
+    /// A file that is not an object at all reads as nothing, so a caller falls
+    /// back to its defaults rather than treating a corrupt file as "every
+    /// setting was cleared" and writing that back.
+    func testAFileThatIsNotAnObjectReadsAsNothing() {
+        XCTAssertNil(SettingsDocument.object(from: Data("[1,2,3]".utf8)))
+        XCTAssertNil(SettingsDocument.object(from: Data("not json".utf8)))
+    }
+}

--- a/Tests/VibeBarCoreTests/SettingsMergeContractTests.swift
+++ b/Tests/VibeBarCoreTests/SettingsMergeContractTests.swift
@@ -1,0 +1,72 @@
+import XCTest
+@testable import VibeBarCore
+
+/// The merge cases both clients must resolve the same way.
+///
+/// Hand-written tests on each side drift: each ends up covering what its
+/// author thought of, and a disagreement shows up as a setting that reverts on
+/// one client only. These run from one file, vendored by Vibe Bar Desktop and
+/// executed there too.
+final class SettingsMergeContractTests: XCTestCase {
+    private struct Case {
+        let name: String
+        let baseline: SettingsDocument.Object
+        let mine: SettingsDocument.Object
+        let theirs: SettingsDocument.Object
+        let owned: Set<String>?
+        let merged: SettingsDocument.Object
+        let conflicts: [String]
+    }
+
+    private func loadCases() throws -> [Case] {
+        let url = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()   // VibeBarCoreTests
+            .deletingLastPathComponent()   // Tests
+            .deletingLastPathComponent()   // repository root
+            .appendingPathComponent("docs/contracts/settings-merge-v1.json")
+        let object = try XCTUnwrap(
+            SettingsDocument.object(from: try Data(contentsOf: url)),
+            "the contract file is missing or is not an object"
+        )
+        let raw = try XCTUnwrap(object["cases"] as? [[String: Any]])
+        return try raw.map { entry in
+            Case(
+                name: try XCTUnwrap(entry["name"] as? String),
+                baseline: try XCTUnwrap(entry["baseline"] as? SettingsDocument.Object),
+                mine: try XCTUnwrap(entry["mine"] as? SettingsDocument.Object),
+                theirs: try XCTUnwrap(entry["theirs"] as? SettingsDocument.Object),
+                owned: (entry["owned"] as? [String]).map(Set.init),
+                merged: try XCTUnwrap(entry["merged"] as? SettingsDocument.Object),
+                conflicts: try XCTUnwrap(entry["conflicts"] as? [String])
+            )
+        }
+    }
+
+    func testEveryCaseMergesAsTheContractSays() throws {
+        let cases = try loadCases()
+        XCTAssertGreaterThan(cases.count, 10, "the contract file looks truncated")
+        for testCase in cases {
+            let merged = SettingsDocument.merge(
+                baseline: testCase.baseline, mine: testCase.mine,
+                theirs: testCase.theirs, owned: testCase.owned
+            )
+            XCTAssertTrue(
+                SettingsDocument.equal(merged, testCase.merged),
+                "\(testCase.name): merged to \(merged), contract says \(testCase.merged)"
+            )
+        }
+    }
+
+    func testEveryCaseReportsTheConflictsTheContractSays() throws {
+        for testCase in try loadCases() {
+            let conflicts = SettingsDocument.conflictingKeys(
+                baseline: testCase.baseline, mine: testCase.mine,
+                theirs: testCase.theirs, owned: testCase.owned
+            )
+            XCTAssertEqual(
+                conflicts.sorted(), testCase.conflicts.sorted(),
+                "\(testCase.name): conflicts"
+            )
+        }
+    }
+}

--- a/Tests/VibeBarCoreTests/SettingsStoreMergeTests.swift
+++ b/Tests/VibeBarCoreTests/SettingsStoreMergeTests.swift
@@ -111,6 +111,65 @@ final class SettingsStoreMergeTests: XCTestCase {
         )
     }
 
+    /// A value this build cannot decode, folded in by a save rather than by
+    /// the watcher. The merge keeps it on disk, but nothing here took it on —
+    /// the merged object does not decode — so recording it as this process's
+    /// own value lets the next save write the fallback over it.
+    func testAnUndecodableValueASaveFoldedInSurvivesTheNextSave() throws {
+        try writeFile(#"{"displayMode":"remaining","refreshIntervalSeconds":600}"#)
+        let store = try makeStore()
+
+        try writeFile(#"{"displayMode":"aModeFromAFutureBuild","refreshIntervalSeconds":600}"#)
+        store.settings.refreshIntervalSeconds = 900
+        store.flush()
+        XCTAssertEqual(try fileObject()["displayMode"] as? String, "aModeFromAFutureBuild")
+
+        store.settings.refreshIntervalSeconds = 1200
+        store.flush()
+        XCTAssertEqual(
+            try fileObject()["displayMode"] as? String, "aModeFromAFutureBuild",
+            "a later save overwrote a value this build cannot decode"
+        )
+        XCTAssertEqual(try fileObject()["refreshIntervalSeconds"] as? Int, 1200)
+    }
+
+    /// A write that failed has changed nothing. A process that recorded those
+    /// settings as written leaves them out of the next merge, and they stay
+    /// off the disk until it restarts.
+    ///
+    /// The failure is a directory where the file should be, rather than a
+    /// read-only parent: `ensureDirectory` resets the parent to 0700 on every
+    /// write, so taking its permissions away does not stop anything.
+    func testASettingSurvivesAWriteThatFailed() throws {
+        let original = #"{"displayMode":"remaining","refreshIntervalSeconds":600}"#
+        try writeFile(original)
+        let store = try makeStore()
+        let manager = FileManager.default
+
+        store.settings.refreshIntervalSeconds = 900
+        try manager.removeItem(at: settingsURL)
+        try manager.createDirectory(at: settingsURL, withIntermediateDirectories: false)
+        store.flush()
+
+        try manager.removeItem(at: settingsURL)
+        try writeFile(original)
+        XCTAssertEqual(
+            try fileObject()["refreshIntervalSeconds"] as? Int, 600,
+            "the write was expected to fail; this test proves nothing if it did not"
+        )
+
+        // A later, unrelated edit. The setting that could not be written is
+        // still this process's, and belongs in the same save.
+        store.settings.displayMode = .used
+        store.flush()
+
+        XCTAssertEqual(try fileObject()["displayMode"] as? String, "used")
+        XCTAssertEqual(
+            try fileObject()["refreshIntervalSeconds"] as? Int, 900,
+            "a setting was dropped because a failed write had recorded it as saved"
+        )
+    }
+
     /// The file is still something the store itself can read back: a merged
     /// write has to stay a decodable `AppSettings`, not just a valid object.
     func testTheMergedFileStillLoadsAsSettings() throws {
@@ -312,6 +371,32 @@ final class SettingsStoreAdoptionTests: XCTestCase {
         XCTAssertNil(
             store.replacedByAnotherWriter,
             "reported a loss for a setting this process never chose a value for"
+        )
+    }
+
+    /// When this process is the one writing the contested setting, its value
+    /// is the one that reaches the file. Telling the user their change was
+    /// replaced puts the notice in front of the person whose change won.
+    func testNoNoticeWhenOurOwnWriteIsTheValueThatWins() throws {
+        try writeFile(#"{"displayMode":"remaining","refreshIntervalSeconds":600}"#)
+        let store = try makeStore()
+
+        store.settings.refreshIntervalSeconds = 900
+        store.flush()
+
+        // Theirs, then ours again before the watcher runs.
+        try writeFile(#"{"displayMode":"remaining","refreshIntervalSeconds":120}"#)
+        store.settings.refreshIntervalSeconds = 1800
+        store.flush()
+
+        let settled = expectation(description: "settled")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { settled.fulfill() }
+        wait(for: [settled], timeout: 3)
+
+        XCTAssertEqual(try fileObject()["refreshIntervalSeconds"] as? Int, 1800)
+        XCTAssertNil(
+            store.replacedByAnotherWriter,
+            "reported a loss for the setting this process had just won"
         )
     }
 

--- a/Tests/VibeBarCoreTests/SettingsStoreMergeTests.swift
+++ b/Tests/VibeBarCoreTests/SettingsStoreMergeTests.swift
@@ -95,6 +95,22 @@ final class SettingsStoreMergeTests: XCTestCase {
         XCTAssertEqual(try fileObject()["refreshIntervalSeconds"] as? Int, 900)
     }
 
+    /// A newer client's file, opened by an older build: the typed decode
+    /// fails, and the fallback is defaults. Saving those over the file is the
+    /// downgrade version of the loss this whole change exists to prevent, and
+    /// it happens before the user has touched anything.
+    func testDefaultsAreNotSavedOverAFileThisBuildCannotDecode() throws {
+        let original = #"{"displayMode":"aModeFromAFutureBuild","refreshIntervalSeconds":120}"#
+        try writeFile(original)
+
+        _ = try makeStore()
+
+        XCTAssertEqual(
+            try String(contentsOf: settingsURL, encoding: .utf8), original,
+            "launching wrote defaults over a file written by a newer client"
+        )
+    }
+
     /// The file is still something the store itself can read back: a merged
     /// write has to stay a decodable `AppSettings`, not just a valid object.
     func testTheMergedFileStillLoadsAsSettings() throws {
@@ -139,6 +155,10 @@ final class SettingsStoreAdoptionTests: XCTestCase {
 
     private func writeFile(_ json: String) throws {
         try Data(json.utf8).write(to: settingsURL, options: [.atomic])
+    }
+
+    private func fileObject() throws -> SettingsDocument.Object {
+        try XCTUnwrap(SettingsDocument.read(from: settingsURL), "settings.json is missing")
     }
 
     /// Waits for the watcher's debounce plus the hop back to the main actor.
@@ -293,6 +313,95 @@ final class SettingsStoreAdoptionTests: XCTestCase {
             store.replacedByAnotherWriter,
             "reported a loss for a setting this process never chose a value for"
         )
+    }
+
+    /// A save can beat the watcher to an external change. The save re-reads,
+    /// keeps their keys, and records the result as the file it has seen — at
+    /// which point the watcher has nothing left to notice, and this process
+    /// shows settings the file has not held for some time.
+    func testASaveThatFoldsInAnExternalChangeStillAdoptsIt() throws {
+        try writeFile(#"{"displayMode":"remaining","refreshIntervalSeconds":600}"#)
+        let store = try makeStore()
+
+        // Their write, then ours before the watcher's debounce elapses.
+        try writeFile(#"{"displayMode":"remaining","refreshIntervalSeconds":120}"#)
+        store.settings.displayMode = .used
+        store.flush()
+
+        waitForAdoption(store) { $0.settings.refreshIntervalSeconds == 120 }
+        XCTAssertEqual(store.settings.displayMode, .used, "our own edit was lost")
+        XCTAssertEqual(try fileObject()["refreshIntervalSeconds"] as? Int, 120)
+    }
+
+    /// The notice is about something the user lost. A later external change
+    /// that costs nothing is not news that the first one cost nothing.
+    func testANoticeStandsUntilItIsAcknowledged() throws {
+        try writeFile(#"{"displayMode":"remaining","refreshIntervalSeconds":600}"#)
+        let store = try makeStore()
+
+        store.settings.refreshIntervalSeconds = 900
+        store.flush()
+        try writeFile(#"{"displayMode":"remaining","refreshIntervalSeconds":120}"#)
+        waitForAdoption(store) { $0.replacedByAnotherWriter != nil }
+
+        // An unrelated external change, costing nothing.
+        try writeFile(#"{"displayMode":"used","refreshIntervalSeconds":120}"#)
+        waitForAdoption(store) { $0.settings.displayMode == .used }
+
+        XCTAssertEqual(
+            store.replacedByAnotherWriter?.replacedKeys, ["refreshIntervalSeconds"],
+            "the notice was cleared by a later change that cost nothing"
+        )
+        store.acknowledgeExternalChange()
+        XCTAssertNil(store.replacedByAnotherWriter)
+    }
+
+    /// Two losses are two things to tell the user about, not one replacing
+    /// the other.
+    func testASecondLossIsAddedToTheNotice() throws {
+        try writeFile(#"{"displayMode":"remaining","refreshIntervalSeconds":600}"#)
+        let store = try makeStore()
+
+        store.settings.refreshIntervalSeconds = 900
+        store.flush()
+        try writeFile(#"{"displayMode":"remaining","refreshIntervalSeconds":120}"#)
+        waitForAdoption(store) { $0.replacedByAnotherWriter != nil }
+
+        store.settings.displayMode = .used
+        store.flush()
+        try writeFile(#"{"displayMode":"remaining","refreshIntervalSeconds":120}"#)
+        waitForAdoption(store) { ($0.replacedByAnotherWriter?.replacedKeys.count ?? 0) > 1 }
+
+        XCTAssertEqual(
+            store.replacedByAnotherWriter?.replacedKeys,
+            ["displayMode", "refreshIntervalSeconds"]
+        )
+    }
+
+    /// A settings file from an older version is missing keys this build knows.
+    /// Decoding materialises defaults for them, and measuring a save against
+    /// the file makes every one of those look like something this process
+    /// chose — so a save writes them over whatever the other client has just
+    /// put there.
+    ///
+    /// Before the watcher runs, deliberately: once their value has been
+    /// adopted it is in memory too, and the save agrees with it by accident.
+    func testADefaultThisBuildFilledInIsNotTreatedAsOurChoice() throws {
+        try writeFile(#"{"displayMode":"remaining"}"#)
+        let store = try makeStore()
+        let theirValue = !store.settings.refreshOnPopoverOpen
+
+        // The other client sets a key our file never carried, and this store
+        // saves something unrelated before hearing about it.
+        try writeFile(#"{"displayMode":"remaining","refreshOnPopoverOpen":\#(theirValue)}"#)
+        store.settings.refreshIntervalSeconds = 300
+        store.flush()
+
+        XCTAssertEqual(
+            try fileObject()["refreshOnPopoverOpen"] as? Bool, theirValue,
+            "a default this build filled in was written over the other client's value"
+        )
+        XCTAssertEqual(try fileObject()["refreshIntervalSeconds"] as? Int, 300)
     }
 
     /// Adopting the file must not schedule a save of what was just read: that

--- a/Tests/VibeBarCoreTests/SettingsStoreMergeTests.swift
+++ b/Tests/VibeBarCoreTests/SettingsStoreMergeTests.swift
@@ -209,6 +209,92 @@ final class SettingsStoreAdoptionTests: XCTestCase {
         XCTAssertEqual(store.settings.refreshIntervalSeconds, 900)
     }
 
+    /// A save is coalesced over 250ms, so an external change can land while
+    /// one is still in flight holding a snapshot taken before it. Left alone
+    /// that snapshot writes the pre-adoption values back and undoes the other
+    /// writer's edit — the merge having done its job and then been overwritten
+    /// by a save that never knew.
+    func testAnInFlightSaveDoesNotUndoAChangeThatLandedDuringIt() throws {
+        try writeFile(#"{"displayMode":"remaining","refreshIntervalSeconds":600}"#)
+        let store = try makeStore()
+
+        // Our edit: coalesced, not yet written.
+        store.settings.displayMode = .used
+        // Theirs, arriving inside that window.
+        try writeFile(#"{"displayMode":"remaining","refreshIntervalSeconds":120}"#)
+
+        waitForAdoption(store) { $0.settings.refreshIntervalSeconds == 120 }
+        // Long enough for the coalesced save — original or replacement — to run.
+        let settled = expectation(description: "settled")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.8) { settled.fulfill() }
+        wait(for: [settled], timeout: 3)
+
+        let onDisk = try XCTUnwrap(SettingsDocument.read(from: settingsURL))
+        XCTAssertEqual(
+            onDisk["refreshIntervalSeconds"] as? Int, 120,
+            "a save from before the external change wrote the old value back"
+        )
+        XCTAssertEqual(
+            onDisk["displayMode"] as? String, "used",
+            "our own unsaved edit was dropped along with the stale snapshot"
+        )
+    }
+
+    /// A newer writer can put a value in the file that this build cannot
+    /// decode — a settings enum with a case added since. Treating that as
+    /// "seen" would let the next save diff our old values against it and
+    /// overwrite the newer writer's, which is the whole failure this change
+    /// exists to prevent.
+    func testAFileThisBuildCannotDecodeIsNotTakenAsSeen() throws {
+        try writeFile(#"{"displayMode":"remaining","refreshIntervalSeconds":600}"#)
+        let store = try makeStore()
+
+        try writeFile(#"{"displayMode":"aModeFromAFutureBuild","refreshIntervalSeconds":120}"#)
+
+        // Nothing to wait for — the point is that nothing happens.
+        let settled = expectation(description: "settled")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) { settled.fulfill() }
+        wait(for: [settled], timeout: 3)
+        XCTAssertEqual(store.settings.displayMode, .remaining, "an undecodable value was adopted")
+
+        // The save that follows must leave the value it could not read alone.
+        store.settings.refreshIntervalSeconds = 300
+        store.flush()
+
+        let onDisk = try XCTUnwrap(SettingsDocument.read(from: settingsURL))
+        XCTAssertEqual(
+            onDisk["displayMode"] as? String, "aModeFromAFutureBuild",
+            "a value this build cannot decode was overwritten by a save"
+        )
+        XCTAssertEqual(onDisk["refreshIntervalSeconds"] as? Int, 300)
+    }
+
+    /// A setting adopted from the other writer is that writer's, not ours. If
+    /// the next save were to claim it, the time after that they changed it we
+    /// would tell the user their own choice had been replaced — about a value
+    /// they never picked.
+    func testASettingAdoptedFromAnotherWriterIsNotClaimedAsOurs() throws {
+        try writeFile(#"{"displayMode":"remaining","refreshIntervalSeconds":600}"#)
+        let store = try makeStore()
+
+        try writeFile(#"{"displayMode":"used","refreshIntervalSeconds":600}"#)
+        waitForAdoption(store) { $0.settings.displayMode == .used }
+        XCTAssertNil(store.replacedByAnotherWriter)
+
+        // A save of something else, which must not adopt authorship of theirs.
+        store.settings.refreshIntervalSeconds = 300
+        store.flush()
+
+        // They change their own setting again.
+        try writeFile(#"{"displayMode":"remaining","refreshIntervalSeconds":300}"#)
+        waitForAdoption(store) { $0.settings.displayMode == .remaining }
+
+        XCTAssertNil(
+            store.replacedByAnotherWriter,
+            "reported a loss for a setting this process never chose a value for"
+        )
+    }
+
     /// Adopting the file must not schedule a save of what was just read: that
     /// would be this store answering every external edit with a write.
     func testAdoptingDoesNotWriteBack() throws {

--- a/Tests/VibeBarCoreTests/SettingsStoreMergeTests.swift
+++ b/Tests/VibeBarCoreTests/SettingsStoreMergeTests.swift
@@ -1,0 +1,268 @@
+import XCTest
+@testable import VibeBarCore
+
+/// `SettingsDocumentTests` covers the merge itself. These cover the store's
+/// *use* of it, against a real file — the claim being made is about what
+/// `settings.json` looks like after a save, and a merge nothing calls would
+/// pass every test in that other file.
+@MainActor
+final class SettingsStoreMergeTests: XCTestCase {
+    private var home: URL!
+    private var settingsURL: URL!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        home = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("settings-store-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: home, withIntermediateDirectories: true)
+        settingsURL = home.appendingPathComponent("settings.json")
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: home)
+        try super.tearDownWithError()
+    }
+
+    /// A `UserDefaults` the store cannot fall back onto, so a test that meant
+    /// to read the file never silently reads this machine's real settings.
+    private func scratchDefaults() throws -> UserDefaults {
+        try XCTUnwrap(UserDefaults(suiteName: "SettingsStoreMergeTests.\(UUID().uuidString)"))
+    }
+
+    private func writeFile(_ json: String) throws {
+        try Data(json.utf8).write(to: settingsURL)
+    }
+
+    private func fileObject() throws -> SettingsDocument.Object {
+        try XCTUnwrap(SettingsDocument.read(from: settingsURL), "settings.json is missing or is not an object")
+    }
+
+    private func makeStore() throws -> SettingsStore {
+        SettingsStore(userDefaults: try scratchDefaults(), settingsURL: settingsURL)
+    }
+
+    /// The case the whole change exists for: a key written by another client
+    /// or a newer build, which `AppSettings` drops on decode, is still in the
+    /// file after this build saves.
+    func testAKeyThisBuildCannotDecodeSurvivesASave() throws {
+        try writeFile(#"{"displayMode":"remaining","refreshIntervalSeconds":600,"futureSetting":{"a":1}}"#)
+
+        let store = try makeStore()
+        store.settings.refreshIntervalSeconds = 900
+        store.flush()
+
+        let saved = try fileObject()
+        XCTAssertEqual(saved["refreshIntervalSeconds"] as? Int, 900, "our own edit did not reach the file")
+        XCTAssertNotNil(
+            saved["futureSetting"],
+            "a key this build cannot decode was deleted by a save — settings.json is rewritten wholesale"
+        )
+    }
+
+    /// An edit made by the other client *while this store was running* is not
+    /// undone by the next save here. This is the one a whole-file rewrite
+    /// fails even when both builds know every key.
+    func testAnotherClientsEditIsNotUndoneByASaveHere() throws {
+        try writeFile(#"{"displayMode":"remaining","refreshIntervalSeconds":600}"#)
+        let store = try makeStore()
+
+        // The other client changes a setting this store is not touching. The
+        // store's in-memory copy still says 600.
+        try writeFile(#"{"displayMode":"remaining","refreshIntervalSeconds":120}"#)
+
+        store.settings.displayMode = .used
+        store.flush()
+
+        let saved = try fileObject()
+        XCTAssertEqual(saved["displayMode"] as? String, "used", "our own edit did not reach the file")
+        XCTAssertEqual(
+            saved["refreshIntervalSeconds"] as? Int, 120,
+            "a setting this store never touched was written back from a stale in-memory copy"
+        )
+    }
+
+    /// And the mirror image: a value this store *did* change wins over the
+    /// file, so the merge cannot be passing the test above by simply never
+    /// writing anything.
+    func testThisStoresOwnEditWinsOverTheFile() throws {
+        try writeFile(#"{"displayMode":"remaining","refreshIntervalSeconds":600}"#)
+        let store = try makeStore()
+
+        store.settings.refreshIntervalSeconds = 900
+        try writeFile(#"{"displayMode":"remaining","refreshIntervalSeconds":120}"#)
+        store.flush()
+
+        XCTAssertEqual(try fileObject()["refreshIntervalSeconds"] as? Int, 900)
+    }
+
+    /// The file is still something the store itself can read back: a merged
+    /// write has to stay a decodable `AppSettings`, not just a valid object.
+    func testTheMergedFileStillLoadsAsSettings() throws {
+        try writeFile(#"{"displayMode":"remaining","refreshIntervalSeconds":600,"futureSetting":{"a":1}}"#)
+        let store = try makeStore()
+        store.settings.refreshIntervalSeconds = 900
+        store.flush()
+
+        let reloaded = SettingsStore(userDefaults: try scratchDefaults(), settingsURL: settingsURL)
+        XCTAssertEqual(reloaded.settings.refreshIntervalSeconds, 900)
+    }
+}
+
+/// The other half: what this store does when the file changes under it.
+/// Without watching, another client's edit is invisible until the next launch
+/// — the settings on screen are simply wrong, and saving them writes that
+/// wrongness back for every key this store later touches.
+@MainActor
+final class SettingsStoreAdoptionTests: XCTestCase {
+    private var home: URL!
+    private var settingsURL: URL!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        home = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("settings-adopt-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: home, withIntermediateDirectories: true)
+        settingsURL = home.appendingPathComponent("settings.json")
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: home)
+        try super.tearDownWithError()
+    }
+
+    private func makeStore() throws -> SettingsStore {
+        SettingsStore(
+            userDefaults: try XCTUnwrap(UserDefaults(suiteName: "adopt.\(UUID().uuidString)")),
+            settingsURL: settingsURL
+        )
+    }
+
+    private func writeFile(_ json: String) throws {
+        try Data(json.utf8).write(to: settingsURL, options: [.atomic])
+    }
+
+    /// Waits for the watcher's debounce plus the hop back to the main actor.
+    private func waitForAdoption(
+        _ store: SettingsStore, until condition: @escaping @MainActor (SettingsStore) -> Bool
+    ) {
+        let met = expectation(description: "settings caught up with the file")
+        met.assertForOverFulfill = false
+        let deadline = Date().addingTimeInterval(3)
+        func poll() {
+            if condition(store) { met.fulfill(); return }
+            guard Date() < deadline else { return }
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) { MainActor.assumeIsolated(poll) }
+        }
+        poll()
+        wait(for: [met], timeout: 4)
+    }
+
+    func testTakesOnAChangeMadeByAnotherWriter() throws {
+        try writeFile(#"{"displayMode":"remaining","refreshIntervalSeconds":600}"#)
+        let store = try makeStore()
+        XCTAssertEqual(store.settings.refreshIntervalSeconds, 600)
+
+        try writeFile(#"{"displayMode":"remaining","refreshIntervalSeconds":120}"#)
+
+        waitForAdoption(store) { $0.settings.refreshIntervalSeconds == 120 }
+        XCTAssertNil(
+            store.replacedByAnotherWriter,
+            "a setting this store never chose a value for was reported as a loss"
+        )
+    }
+
+    /// The case that motivates the notice, and the one a naive "did my
+    /// in-memory copy differ" check misses entirely: our edit was saved, so it
+    /// matches the baseline, and only the record of having made it survives.
+    func testReportsAnEditOfOursBeingReplaced() throws {
+        try writeFile(#"{"displayMode":"remaining","refreshIntervalSeconds":600}"#)
+        let store = try makeStore()
+
+        store.settings.refreshIntervalSeconds = 900
+        store.flush()
+
+        // Another client, which loaded before that save, writes its own value.
+        try writeFile(#"{"displayMode":"remaining","refreshIntervalSeconds":120}"#)
+
+        waitForAdoption(store) { $0.replacedByAnotherWriter != nil }
+        XCTAssertEqual(store.replacedByAnotherWriter?.replacedKeys, ["refreshIntervalSeconds"])
+        XCTAssertEqual(store.settings.refreshIntervalSeconds, 120, "the file is the shared truth")
+
+        store.acknowledgeExternalChange()
+        XCTAssertNil(store.replacedByAnotherWriter)
+    }
+
+    /// Our own save comes back through the same watcher, and is not news.
+    func testOurOwnSaveIsNotReportedAsSomeoneElsesChange() throws {
+        try writeFile(#"{"displayMode":"remaining","refreshIntervalSeconds":600}"#)
+        let store = try makeStore()
+
+        store.settings.refreshIntervalSeconds = 900
+        store.flush()
+
+        let quiet = expectation(description: "nothing reported")
+        quiet.isInverted = true
+        let cancellable = store.$replacedByAnotherWriter.dropFirst()
+            .sink { if $0 != nil { quiet.fulfill() } }
+        wait(for: [quiet], timeout: 1)
+        cancellable.cancel()
+        XCTAssertEqual(store.settings.refreshIntervalSeconds, 900)
+    }
+
+    /// Adopting the file must not schedule a save of what was just read: that
+    /// would be this store answering every external edit with a write.
+    func testAdoptingDoesNotWriteBack() throws {
+        try writeFile(#"{"displayMode":"remaining","refreshIntervalSeconds":600}"#)
+        let store = try makeStore()
+
+        try writeFile(#"{"displayMode":"remaining","refreshIntervalSeconds":120,"futureSetting":1}"#)
+        waitForAdoption(store) { $0.settings.refreshIntervalSeconds == 120 }
+
+        // Long enough for a coalesced write to have fired had one been queued.
+        let settled = expectation(description: "settled")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { settled.fulfill() }
+        wait(for: [settled], timeout: 2)
+
+        let onDisk = try XCTUnwrap(SettingsDocument.read(from: settingsURL))
+        XCTAssertNotNil(onDisk["futureSetting"], "adopting rewrote the file and dropped a key")
+    }
+}
+
+/// The sentence the user actually reads.
+final class ExternalSettingsChangeSummaryTests: XCTestCase {
+    private func summary(_ keys: [String]) -> String {
+        SettingsStore.ExternalSettingsChange(replacedKeys: keys, observedAt: Date()).summary
+    }
+
+    func testNamesOneSettingInTheSingular() {
+        XCTAssertEqual(
+            summary(["refreshIntervalSeconds"]),
+            "Refresh interval seconds now holds the other copy's value."
+        )
+    }
+
+    func testNamesASmallHandfulInFull() {
+        XCTAssertEqual(
+            summary(["displayMode", "launchAtLogin"]),
+            "Display mode, Launch at login now hold the other copy's value."
+        )
+    }
+
+    /// A writer that replaced most of the file should not produce a paragraph.
+    func testCountsTheRestOnceThereAreTooManyToRead() {
+        let summary = summary(["a", "b", "c", "d", "e"])
+        XCTAssertTrue(summary.hasPrefix("A, B, C and 2 more settings"), summary)
+    }
+
+    /// The notice is only published with keys in it, but the sentence should
+    /// not be a fragment if that ever changes.
+    func testSaysNothingWhenNothingWasReplaced() {
+        XCTAssertEqual(summary([]), "")
+    }
+
+    func testKeepsAnAcronymReadable() {
+        XCTAssertEqual(
+            SettingsStore.ExternalSettingsChange.humanised("mcpServer"), "Mcp server"
+        )
+    }
+}

--- a/Tests/VibeBarCoreTests/SettingsValueEqualityContractTests.swift
+++ b/Tests/VibeBarCoreTests/SettingsValueEqualityContractTests.swift
@@ -1,0 +1,50 @@
+import XCTest
+@testable import VibeBarCore
+
+/// When two JSON values mean the same setting.
+///
+/// Both clients decide this, and a disagreement is not academic: whichever
+/// side thinks a value changed writes a file the other did not expect, and
+/// tells its user their setting was replaced when nothing happened to it.
+final class SettingsValueEqualityContractTests: XCTestCase {
+    private func contract() throws -> SettingsDocument.Object {
+        let url = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent().deletingLastPathComponent().deletingLastPathComponent()
+            .appendingPathComponent("docs/contracts/settings-value-equality-v1.json")
+        // Parsed the same way settings are, so the cases exercise the same
+        // number representation the real path produces.
+        return try XCTUnwrap(SettingsDocument.object(from: try Data(contentsOf: url)))
+    }
+
+    /// A divergence is only worth recording while it is still true. If this
+    /// client's answer changes, the record is stale and the note explaining
+    /// why it was left alone no longer applies.
+    func testTheRecordedDivergencesAreStillWhatThisClientDoes() throws {
+        let divergences = try XCTUnwrap(contract()["knownDivergences"] as? [[String: Any]])
+        for entry in divergences {
+            let name = try XCTUnwrap(entry["case"] as? String)
+            XCTAssertEqual(
+                SettingsDocument.equal(entry["left"], entry["right"]),
+                try XCTUnwrap(entry["native"] as? Bool),
+                "\(name): this client no longer behaves as the contract records"
+            )
+        }
+    }
+
+    func testEveryCaseAgreesWithTheContract() throws {
+        let cases = try XCTUnwrap(contract()["cases"] as? [[String: Any]])
+        XCTAssertGreaterThan(cases.count, 10, "the contract file looks truncated")
+
+        for entry in cases {
+            let name = try XCTUnwrap(entry["name"] as? String)
+            let expected = try XCTUnwrap(entry["equal"] as? Bool)
+            // `nil` in the file is `NSNull` here, which is the point of two of
+            // the cases; a missing key would be a different fact entirely.
+            XCTAssertTrue(entry.keys.contains("left") && entry.keys.contains("right"), name)
+            XCTAssertEqual(
+                SettingsDocument.equal(entry["left"], entry["right"]), expected,
+                "\(name): left=\(entry["left"] ?? "nil") right=\(entry["right"] ?? "nil")"
+            )
+        }
+    }
+}

--- a/Tests/VibeBarCoreTests/SharedFileLockTests.swift
+++ b/Tests/VibeBarCoreTests/SharedFileLockTests.swift
@@ -1,0 +1,120 @@
+import XCTest
+@testable import VibeBarCore
+
+/// The lock exists to close one window: two writers that both re-read a file,
+/// both merge onto what they read, and both rename — the second one's merge
+/// having been based on a file that no longer exists.
+final class SharedFileLockTests: XCTestCase {
+    private var directory: URL!
+    private var counter: URL!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        directory = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("lock-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        counter = directory.appendingPathComponent("counter")
+        try "0".write(to: counter, atomically: true, encoding: .utf8)
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: directory)
+        try super.tearDownWithError()
+    }
+
+    /// A read-modify-write with a gap in the middle, which is what a merge is.
+    private func incrementUnderLock() {
+        SharedFileLock.withLock(named: "counter", in: directory) {
+            let value = Int(
+                (try? String(contentsOf: counter, encoding: .utf8)) ?? "0"
+            ) ?? 0
+            // Wide enough that an unlocked version loses updates reliably.
+            Thread.sleep(forTimeInterval: 0.002)
+            try? "\(value + 1)".write(to: counter, atomically: true, encoding: .utf8)
+        }
+    }
+
+    func testSerialisesConcurrentReadModifyWrites() throws {
+        let rounds = 40
+        DispatchQueue.concurrentPerform(iterations: rounds) { _ in incrementUnderLock() }
+
+        let final = Int(try String(contentsOf: counter, encoding: .utf8))
+        XCTAssertEqual(final, rounds, "an update was lost, so the lock is not excluding anything")
+    }
+
+    /// The control: the same work without the lock does lose updates, so the
+    /// test above is measuring the lock and not the timing.
+    func testTheSameWorkWithoutTheLockLosesUpdates() throws {
+        let rounds = 40
+        DispatchQueue.concurrentPerform(iterations: rounds) { _ in
+            let value = Int((try? String(contentsOf: counter, encoding: .utf8)) ?? "0") ?? 0
+            Thread.sleep(forTimeInterval: 0.002)
+            try? "\(value + 1)".write(to: counter, atomically: true, encoding: .utf8)
+        }
+        let final = Int(try String(contentsOf: counter, encoding: .utf8))
+        XCTAssertLessThan(final ?? .max, rounds)
+    }
+
+    /// A lock that cannot be taken must not stop the write: settings that
+    /// cannot be saved is a worse outcome than a race that is already the
+    /// behaviour everything shipped with until now.
+    func testRunsTheBodyEvenWhenTheLockCannotBeTaken() {
+        let unwritable = URL(fileURLWithPath: "/dev/null/nowhere", isDirectory: true)
+        var ran = false
+        SharedFileLock.withLock(named: "settings", in: unwritable) { ran = true }
+        XCTAssertTrue(ran)
+    }
+
+    func testGivesBackWhatTheBodyReturns() {
+        XCTAssertEqual(SharedFileLock.withLock(named: "value", in: directory) { 7 }, 7)
+    }
+
+    /// The claim that matters is cross-process and cross-language: the other
+    /// writer is Vibe Bar Desktop, a separate Rust process. `flock(2)` is the
+    /// same primitive from any language, and this checks that rather than
+    /// assuming it — a foreign process must fail to take the lock while this
+    /// one holds it, and succeed once it does not.
+    func testAForeignProcessIsExcludedWhileWeHoldTheLock() throws {
+        let lockPath = directory.appendingPathComponent("run/settings.lock").path
+        func foreignAttempt() throws -> String {
+            let process = Process()
+            process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+            process.arguments = [
+                "python3", "-c",
+                """
+                import fcntl, os, sys
+                fd = os.open(sys.argv[1], os.O_CREAT | os.O_RDWR, 0o600)
+                try:
+                    fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                    print("took")
+                except OSError:
+                    print("blocked")
+                """,
+                lockPath
+            ]
+            let pipe = Pipe()
+            process.standardOutput = pipe
+            try process.run()
+            let data = pipe.fileHandleForReading.readDataToEndOfFile()
+            process.waitUntilExit()
+            return String(decoding: data, as: UTF8.self).trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+
+        var whileHeld = ""
+        SharedFileLock.withLock(named: "settings", in: directory) {
+            whileHeld = (try? foreignAttempt()) ?? "error"
+        }
+        XCTAssertEqual(whileHeld, "blocked", "another process took the lock while we held it")
+        XCTAssertEqual(try foreignAttempt(), "took", "the lock was not released")
+    }
+
+    /// The lock lives under `run/`, not next to the data.
+    func testKeepsItsLockFileOutOfTheWay() {
+        SharedFileLock.withLock(named: "settings", in: directory) {}
+        XCTAssertTrue(
+            FileManager.default.fileExists(
+                atPath: directory.appendingPathComponent("run/settings.lock").path
+            )
+        )
+    }
+}

--- a/docs/contracts/README.md
+++ b/docs/contracts/README.md
@@ -15,6 +15,7 @@ is not finished until it has been carried across.
 | `design-tokens-v1.json` | Provider accents, quota-bar colours and thresholds, card recipe | `DesignTokenContractTests` |
 | `quota-naming-v1.json` | The quota axis: L1 company, L2 SubProvider, L3 group, and the rules that assign them | `QuotaNamingContractTests` |
 | `forecast-v1.json` | The quota pace forecast, as evaluated vectors | `ForecastContractTests` |
+| `settings-write-v1.md` | How either client may write `settings.json` without losing the other's data | `SettingsDocumentTests`, `SettingsStoreMergeTests` |
 
 ## `design-tokens-v1.json`
 

--- a/docs/contracts/README.md
+++ b/docs/contracts/README.md
@@ -16,6 +16,8 @@ is not finished until it has been carried across.
 | `quota-naming-v1.json` | The quota axis: L1 company, L2 SubProvider, L3 group, and the rules that assign them | `QuotaNamingContractTests` |
 | `forecast-v1.json` | The quota pace forecast, as evaluated vectors | `ForecastContractTests` |
 | `settings-write-v1.md` | How either client may write `settings.json` without losing the other's data | `SettingsDocumentTests`, `SettingsStoreMergeTests` |
+| `settings-value-equality-v1.json` | When two JSON values mean the same setting, and the one place the clients disagree | `SettingsValueEqualityContractTests` |
+| `settings-merge-v1.json` | The three-way patch, which only this client performs | `SettingsMergeContractTests` |
 
 ## `design-tokens-v1.json`
 
@@ -54,3 +56,23 @@ Regenerate the cycle-carrying cases with:
 ```sh
 VIBEBAR_EMIT_FORECAST_VECTORS=/tmp/cycles.json swift test --filter ForecastVectorGenerator
 ```
+
+## `settings-write-v1.md`, `settings-value-equality-v1.json`, `settings-merge-v1.json`
+
+The write rule is prose because what has to match is a procedure, not a
+table. Underneath it, the two files split by who implements what.
+
+Value equality is the shared part: both clients decide whether a value
+changed, and a disagreement is not academic — whichever side thinks it
+did writes a file the other did not expect, and tells its user a setting
+was replaced when nothing happened to it. Numbers are why it is not
+structural equality, and the file records the one case where the two
+clients genuinely differ rather than papering over it. Each side asserts
+that its own recorded behaviour is still true, so the note explaining why
+it was left alone cannot go stale unnoticed.
+
+The merge vectors are this client's alone. Vibe Bar Desktop holds no
+in-memory settings model — every surface reads the file when it needs it
+— so its writes are a locked read, the changed keys set on top, and a
+write. There is no second state to reconcile there, and a merge it never
+calls would be worse than none.

--- a/docs/contracts/settings-merge-v1.json
+++ b/docs/contracts/settings-merge-v1.json
@@ -1,0 +1,304 @@
+{
+  "version": 1,
+  "note": "Merge cases for the three-way patch. Only this client implements one: Vibe Bar Desktop holds no in-memory settings model, so its writes are a locked read, the changed keys set on top, and a write. Value equality is the part both implement and both verify \u2014 settings-value-equality-v1.json.",
+  "cases": [
+    {
+      "name": "a key this build cannot encode survives a write",
+      "baseline": {
+        "displayMode": "remaining",
+        "futureSetting": {
+          "a": 1
+        }
+      },
+      "mine": {
+        "displayMode": "used"
+      },
+      "theirs": {
+        "displayMode": "remaining",
+        "futureSetting": {
+          "a": 1
+        }
+      },
+      "owned": [
+        "displayMode"
+      ],
+      "merged": {
+        "displayMode": "used",
+        "futureSetting": {
+          "a": 1
+        }
+      },
+      "conflicts": []
+    },
+    {
+      "name": "a key this build knows is removed when it goes missing",
+      "baseline": {
+        "displayMode": "remaining",
+        "customLabels": {
+          "a": "b"
+        }
+      },
+      "mine": {
+        "displayMode": "remaining"
+      },
+      "theirs": {
+        "displayMode": "remaining",
+        "customLabels": {
+          "a": "b"
+        }
+      },
+      "owned": [
+        "displayMode",
+        "customLabels"
+      ],
+      "merged": {
+        "displayMode": "remaining"
+      },
+      "conflicts": []
+    },
+    {
+      "name": "the other client's edit survives this one's write",
+      "baseline": {
+        "displayMode": "remaining",
+        "refreshIntervalSeconds": 600
+      },
+      "mine": {
+        "displayMode": "used",
+        "refreshIntervalSeconds": 600
+      },
+      "theirs": {
+        "displayMode": "remaining",
+        "refreshIntervalSeconds": 120
+      },
+      "owned": null,
+      "merged": {
+        "displayMode": "used",
+        "refreshIntervalSeconds": 120
+      },
+      "conflicts": []
+    },
+    {
+      "name": "a write that changed nothing leaves the file alone",
+      "baseline": {
+        "displayMode": "remaining"
+      },
+      "mine": {
+        "displayMode": "remaining"
+      },
+      "theirs": {
+        "displayMode": "used",
+        "newKey": true
+      },
+      "owned": null,
+      "merged": {
+        "displayMode": "used",
+        "newKey": true
+      },
+      "conflicts": []
+    },
+    {
+      "name": "the same key changed two ways is a conflict, and the file wins nothing",
+      "baseline": {
+        "displayMode": "remaining"
+      },
+      "mine": {
+        "displayMode": "used"
+      },
+      "theirs": {
+        "displayMode": "forecast"
+      },
+      "owned": null,
+      "merged": {
+        "displayMode": "used"
+      },
+      "conflicts": [
+        "displayMode"
+      ]
+    },
+    {
+      "name": "the same key changed to the same value is agreement",
+      "baseline": {
+        "displayMode": "remaining"
+      },
+      "mine": {
+        "displayMode": "used"
+      },
+      "theirs": {
+        "displayMode": "used"
+      },
+      "owned": null,
+      "merged": {
+        "displayMode": "used"
+      },
+      "conflicts": []
+    },
+    {
+      "name": "nested values compare by content, not by order",
+      "baseline": {
+        "miniWindow": {
+          "fields": [
+            "a",
+            "b"
+          ],
+          "size": {
+            "w": 1
+          }
+        }
+      },
+      "mine": {
+        "miniWindow": {
+          "size": {
+            "w": 1
+          },
+          "fields": [
+            "a",
+            "b"
+          ]
+        }
+      },
+      "theirs": {
+        "miniWindow": {
+          "fields": [
+            "a"
+          ],
+          "size": {
+            "w": 1
+          }
+        }
+      },
+      "owned": null,
+      "merged": {
+        "miniWindow": {
+          "fields": [
+            "a"
+          ],
+          "size": {
+            "w": 1
+          }
+        }
+      },
+      "conflicts": []
+    },
+    {
+      "name": "an explicit null is a value, not an absence",
+      "baseline": {
+        "a": null
+      },
+      "mine": {
+        "a": 1
+      },
+      "theirs": {
+        "a": null
+      },
+      "owned": null,
+      "merged": {
+        "a": 1
+      },
+      "conflicts": []
+    },
+    {
+      "name": "a key added by this process reaches the file",
+      "baseline": {
+        "displayMode": "remaining"
+      },
+      "mine": {
+        "displayMode": "remaining",
+        "providerPlanLabels": {
+          "codex": "Pro"
+        }
+      },
+      "theirs": {
+        "displayMode": "remaining",
+        "theirNewKey": 2
+      },
+      "owned": null,
+      "merged": {
+        "displayMode": "remaining",
+        "providerPlanLabels": {
+          "codex": "Pro"
+        },
+        "theirNewKey": 2
+      },
+      "conflicts": []
+    },
+    {
+      "name": "both sides removing the same key is not a conflict",
+      "baseline": {
+        "displayMode": "remaining",
+        "gone": 1
+      },
+      "mine": {
+        "displayMode": "remaining"
+      },
+      "theirs": {
+        "displayMode": "remaining"
+      },
+      "owned": [
+        "displayMode",
+        "gone"
+      ],
+      "merged": {
+        "displayMode": "remaining"
+      },
+      "conflicts": []
+    },
+    {
+      "name": "our removal against their change is a conflict",
+      "baseline": {
+        "displayMode": "remaining",
+        "contested": 1
+      },
+      "mine": {
+        "displayMode": "remaining"
+      },
+      "theirs": {
+        "displayMode": "remaining",
+        "contested": 2
+      },
+      "owned": [
+        "displayMode",
+        "contested"
+      ],
+      "merged": {
+        "displayMode": "remaining"
+      },
+      "conflicts": [
+        "contested"
+      ]
+    },
+    {
+      "name": "a number that differs only in spelling is not a change",
+      "baseline": {
+        "a": 1
+      },
+      "mine": {
+        "a": 1.0
+      },
+      "theirs": {
+        "a": 1
+      },
+      "owned": null,
+      "merged": {
+        "a": 1
+      },
+      "conflicts": []
+    },
+    {
+      "name": "integers past the precision of a double are still told apart",
+      "baseline": {
+        "a": 9007199254740993
+      },
+      "mine": {
+        "a": 9007199254740992
+      },
+      "theirs": {
+        "a": 9007199254740993
+      },
+      "owned": null,
+      "merged": {
+        "a": 9007199254740992
+      },
+      "conflicts": []
+    }
+  ]
+}

--- a/docs/contracts/settings-value-equality-v1.json
+++ b/docs/contracts/settings-value-equality-v1.json
@@ -1,0 +1,137 @@
+{
+  "version": 1,
+  "note": "When two JSON values mean the same setting. Both clients implement this and both run these cases. Numbers are the reason it is not plain structural equality: the native client parses with JSONSerialization, which compares NSNumbers numerically and re-emits them in its own spelling, so no client can keep a number's exact text. Measured against Foundation, not assumed.",
+  "cases": [
+    {
+      "name": "an integer and the same value written as a decimal",
+      "left": 1,
+      "right": 1.0,
+      "equal": true
+    },
+    {
+      "name": "different integers",
+      "left": 1,
+      "right": 2,
+      "equal": false
+    },
+    {
+      "name": "integers past the precision of a double are still told apart",
+      "left": 9007199254740993,
+      "right": 9007199254740992,
+      "equal": false
+    },
+    {
+      "name": "a value that underflows a double is the value it underflows to",
+      "left": 0.0,
+      "right": 0,
+      "equal": true
+    },
+    {
+      "name": "trailing zeroes do not make a different number",
+      "left": 2.5,
+      "right": 2.5,
+      "equal": true
+    },
+    {
+      "name": "a number and its string spelling are different values",
+      "left": 1,
+      "right": "1",
+      "equal": false
+    },
+    {
+      "name": "null is not zero",
+      "left": null,
+      "right": 0,
+      "equal": false
+    },
+    {
+      "name": "null equals null",
+      "left": null,
+      "right": null,
+      "equal": true
+    },
+    {
+      "name": "objects compare by content, whatever order they were written in",
+      "left": {
+        "a": 1,
+        "b": [
+          1,
+          2
+        ]
+      },
+      "right": {
+        "b": [
+          1,
+          2
+        ],
+        "a": 1
+      },
+      "equal": true
+    },
+    {
+      "name": "an object with an extra key is a different object",
+      "left": {
+        "a": 1
+      },
+      "right": {
+        "a": 1,
+        "b": 2
+      },
+      "equal": false
+    },
+    {
+      "name": "arrays keep their order",
+      "left": [
+        1,
+        2
+      ],
+      "right": [
+        2,
+        1
+      ],
+      "equal": false
+    },
+    {
+      "name": "numbers nested in an array follow the same rule",
+      "left": [
+        1,
+        2.0
+      ],
+      "right": [
+        1.0,
+        2
+      ],
+      "equal": true
+    },
+    {
+      "name": "numbers nested in an object follow the same rule",
+      "left": {
+        "a": {
+          "b": 3.0
+        }
+      },
+      "right": {
+        "a": {
+          "b": 3
+        }
+      },
+      "equal": true
+    },
+    {
+      "name": "an empty object is not an empty array",
+      "left": {},
+      "right": [],
+      "equal": false
+    }
+  ],
+  "knownDivergences": [
+    {
+      "case": "a boolean against the number it is represented by",
+      "left": false,
+      "right": 0,
+      "native": true,
+      "desktop": false,
+      "why": "Foundation parses JSON `false` into an NSNumber, and NSNumber compares booleans against integers numerically, so the native client reads `false` and `0` as the same value. serde_json keeps them as distinct types. Both clients *store* them correctly \u2014 measured: a round trip through either writer leaves `false` as `false` and `0` as `0` \u2014 and both encode settings from typed models, so neither ever writes one where the other would write the other. Recorded rather than reconciled: making Rust agree would carry a Foundation representation quirk into a client that does not share it, to settle a case that cannot arise. Desktop's stricter reading is the safe direction \u2014 it writes when unsure rather than skipping a write it should have made."
+    }
+  ]
+}

--- a/docs/contracts/settings-write-v1.md
+++ b/docs/contracts/settings-write-v1.md
@@ -121,6 +121,18 @@ Three more, each of which turns the merge against itself if missed:
   that already contains their change and finds nothing. The write has to
   report what it folded in, or this client shows settings the file
   stopped holding some time ago.
+- **A key this write is applying is not a key this write lost.** Ours is
+  the value that reaches the file, so reporting it puts "another client
+  replaced your change" in front of the person whose change won. Only
+  the keys the other writer changed and this one is *not* writing count.
+- **Record a write only after it succeeds.** A write that failed changed
+  nothing; a process that has already recorded those settings as written
+  leaves them out of the next merge, and they stay off the disk until it
+  restarts.
+- **A merged object this build cannot decode is one it has not taken
+  on.** Write it — the file is correct, and the other writer's value is
+  in it — but do not record its values as this process's own, or the
+  next save treats its own fallback as an edit and overwrites them.
 - **A notice stands until the user dismisses it.** A later external
   change that costs nothing is not news that the first one cost nothing,
   and a second loss is a second thing to say rather than a replacement

--- a/docs/contracts/settings-write-v1.md
+++ b/docs/contracts/settings-write-v1.md
@@ -31,9 +31,24 @@ A writer keeps three things, not one:
 
 A write is then:
 
-1. `changed` = the top-level keys where `mine` differs from `baseline`,
-   including keys present in `baseline` and absent from `mine` — but a
-   key is only *absent* if this build could have written it (below).
+1. `changed` = the top-level keys where `mine` differs from **the value
+   this process last wrote**, including keys it wrote and no longer has
+   — but a key is only *absent* if this build could have written it
+   (below).
+
+   Not against `baseline`. A settings file from an older version is
+   missing keys this build knows, and decoding materialises defaults for
+   them; measured against the file every one of those looks like a
+   choice this process made, and the next save writes them over whatever
+   the other client had put there. What this process changed is what
+   changed *here*.
+
+   The same reasoning covers the file this build cannot decode at all: it
+   holds defaults in memory so there is something to show, takes them as
+   its starting position, and does not save them. Writing defaults over a
+   newer client's file is the downgrade version of the loss this whole
+   rule exists to prevent, and it would happen before the user had
+   touched anything.
 2. Start from `theirs`. Apply `changed`, setting or removing each key.
 3. Write that, atomically.
 4. `baseline` = what was written.
@@ -100,6 +115,16 @@ Three more, each of which turns the merge against itself if missed:
   adoption.** Left to run it writes those values back and undoes what
   was just adopted. Replace it rather than cancel it: the snapshot is
   stale, the unsaved edits in it are not.
+- **A write can beat the watcher to an external change.** It re-reads,
+  keeps the other writer's keys, and records the result as the file it
+  has seen — after which the watcher compares the file with a baseline
+  that already contains their change and finds nothing. The write has to
+  report what it folded in, or this client shows settings the file
+  stopped holding some time ago.
+- **A notice stands until the user dismisses it.** A later external
+  change that costs nothing is not news that the first one cost nothing,
+  and a second loss is a second thing to say rather than a replacement
+  for the first.
 
 ## Telling the user
 

--- a/docs/contracts/settings-write-v1.md
+++ b/docs/contracts/settings-write-v1.md
@@ -145,6 +145,33 @@ worth a new way to lose settings.
 Reads do not take it. A write is a rename, so a reader either sees the
 whole old file or the whole new one.
 
+## Size
+
+8 MiB, refused rather than truncated. A settings file is a few tens of
+kilobytes; anything near the cap is a corrupt or hostile file, and a
+reader that refuses it falls back to its defaults rather than parsing it.
+
+## What this supersedes
+
+Vibe Bar Desktop's `docs/contracts/settings-document-v1.md` records an
+earlier design for the same problem, kept as a design record after its
+implementation was removed. Two of its decisions are deliberately not
+carried over, and one is:
+
+- **No `schemaVersion` / `revision` envelope.** That design had both
+  clients adopt one together; neither did, and the file in the field has
+  neither key. A writer that added them alone would be adding keys the
+  reference implementation never emits, to a file whose whole point is
+  that unknown keys are somebody else's.
+- **A contested key goes to the last writer, not the first.** That
+  design left a key alone when the file had moved and reported a
+  conflict, so a user's most recent click could silently fail to take
+  effect. Here the write applies it, a later external change replaces
+  it, and either way the person who is told is the one whose choice was
+  replaced.
+- **The 8 MiB cap and the writer whitelist are kept**, both from that
+  design.
+
 ## Why there is no revision counter
 
 An earlier sketch of this had every writer carry a revision, so a client

--- a/docs/contracts/settings-write-v1.md
+++ b/docs/contracts/settings-write-v1.md
@@ -83,6 +83,24 @@ Where both sides changed the same setting, the file wins — it is the
 shared state, and keeping a value the file no longer holds is the stale
 reading this watching exists to end.
 
+Three more, each of which turns the merge against itself if missed:
+
+- **Do not advance `baseline` until the merged object decodes.** A newer
+  writer can put a value in the file this build cannot read — an enum
+  case added since. Recording it as seen lets the next save diff our old
+  values against it and write them over the newer writer's, which is
+  precisely the loss the merge exists to prevent. A file that cannot be
+  read has not been seen.
+- **A setting adopted from the other writer is theirs, not ours.** Move
+  it in the record of this process's own previous values, and drop it
+  from the set of settings this process changed. Otherwise the next save
+  claims it, and the next time they touch it the user is told their own
+  choice was replaced — about a value they never picked.
+- **A coalesced save in flight holds a snapshot from before the
+  adoption.** Left to run it writes those values back and undoes what
+  was just adopted. Replace it rather than cancel it: the snapshot is
+  stale, the unsaved edits in it are not.
+
 ## Telling the user
 
 The one cost of the file winning is that a choice the user made here can

--- a/docs/contracts/settings-write-v1.md
+++ b/docs/contracts/settings-write-v1.md
@@ -98,9 +98,40 @@ of the whole document and the next external edit reports most of it as
 lost. An external change to a setting nobody here touched is adopted
 silently — nothing was lost, and a notice would be noise.
 
-## Not covered
+## The lock
 
-No lock. Two writers can still interleave read-merge-write and lose the
-later one's edit; the window is the few milliseconds between re-reading
-and renaming, and settings are written by hand. An advisory lock under
-`~/.vibebar/run/` is the fix if that ever stops being true.
+Re-reading and renaming are two steps, so two writers can interleave
+between them and the second one's merge is based on a file that no
+longer exists. Both steps go under one lock.
+
+```
+~/.vibebar/run/settings.lock      mode 0600, in a run/ directory of 0700
+```
+
+`flock(2)`, `LOCK_EX`, blocking, held from the re-read to the rename and
+released by closing the descriptor. Not a lock file holding a pid: the
+kernel drops a `flock` when the descriptor closes, process death
+included, so there is no stale lock to break and no liveness check to
+get wrong. It is advisory, which binds the clients that ask for it —
+both of them.
+
+Rust takes the same lock through `flock(2)` on the same path; the
+primitive is the same from either language, and the interop is worth a
+test rather than an assumption.
+
+**Failing to take the lock is not failing to write.** A read-only or
+unusual filesystem falls back to the unlocked behaviour, which is what
+both clients did until now. The narrow race is worth closing; it is not
+worth a new way to lose settings.
+
+Reads do not take it. A write is a rename, so a reader either sees the
+whole old file or the whole new one.
+
+## Why there is no revision counter
+
+An earlier sketch of this had every writer carry a revision, so a client
+could tell that the file had moved under it. With the lock, a write
+cannot be based on a stale read; with the baseline, a client already
+knows *which* settings changed, which is strictly more than a counter
+would tell it, and is what the user is shown. A revision would be a
+number both clients maintain and neither consults.

--- a/docs/contracts/settings-write-v1.md
+++ b/docs/contracts/settings-write-v1.md
@@ -1,0 +1,106 @@
+# Writing `settings.json` — v1
+
+`~/.vibebar/settings.json` has two writers: this app and Vibe Bar
+Desktop, in any combination of versions. This is the rule both must
+follow. Unlike the other contracts here there is no generated fixture —
+what has to match is a procedure, not a table — so it is written out.
+
+## The failure it prevents
+
+Both clients used to hold settings as a decoded struct and save by
+rewriting the whole file from it. That deletes every key the writer did
+not know about:
+
+- a setting the *other client* has and this one does not;
+- a setting a *newer version* added, when an older version saves;
+- a setting the other client changed a moment ago, overwritten from a
+  copy read at launch.
+
+Nothing reports it. The user sees a setting revert some time later, with
+no way to connect it to the save that did it.
+
+## The rule
+
+A writer keeps three things, not one:
+
+| | |
+| --- | --- |
+| `baseline` | the file's raw JSON object as this process last saw it — at load, and after each of its own writes |
+| `mine` | the settings this process holds, encoded to a JSON object |
+| `theirs` | the file's raw JSON object, **re-read immediately before writing** |
+
+A write is then:
+
+1. `changed` = the top-level keys where `mine` differs from `baseline`,
+   including keys present in `baseline` and absent from `mine` — but a
+   key is only *absent* if this build could have written it (below).
+2. Start from `theirs`. Apply `changed`, setting or removing each key.
+3. Write that, atomically.
+4. `baseline` = what was written.
+
+Everything not in `changed` keeps the value the file already had,
+whatever it means to this build.
+
+### Vocabulary
+
+Step 1's exception matters more than it looks. An encoded settings
+object never mentions a key the build has never heard of, so *every*
+unknown key looks like a deletion, and the merge would delete exactly
+what it exists to protect. A vanished key is a removal only when it is
+one this build could have written: the union of the keys in a
+default-valued settings object and the keys in `mine`. Anything else is
+someone else's, and is preserved.
+
+### Granularity
+
+Top-level keys. Two clients editing different fields *inside* one
+top-level object — say two entries of `miniWindow` — still resolve to
+one of them winning that object. Settings are edited by hand and rarely;
+a deep merge has no defensible answer for arrays, and buys precision
+nobody has needed against surprises everyone would meet.
+
+### Format
+
+Pretty-printed, keys sorted, written to a temporary file and renamed.
+A merged write must be byte-indistinguishable from a plain one.
+
+## Reading the file back
+
+A writer must also notice the *other* writer, or its `baseline` is
+frozen at launch and its own settings are stale for as long as it runs.
+Watch the file; on change, re-read and take on what changed.
+
+Two details, both of which were got wrong first:
+
+- **Atomic writes replace the inode.** A watch on the file descriptor
+  keeps watching a file nobody will write to again. Treat delete and
+  rename as the signal to re-open the path, not merely as events.
+- **A file that does not exist yet still has a first write.** Opening a
+  path that was missing a moment ago *is* the change; no event will
+  arrive for the write that created it.
+
+Where both sides changed the same setting, the file wins — it is the
+shared state, and keeping a value the file no longer holds is the stale
+reading this watching exists to end.
+
+## Telling the user
+
+The one cost of the file winning is that a choice the user made here can
+be replaced. Report exactly that case, and no other:
+
+> the settings **this process changed since it launched**, which the
+> other writer has since changed to a different value.
+
+Measured against this process's own previous value, not against the
+file. Measuring against the file counts every default the file did not
+happen to carry as a user's choice, so the first save claims authorship
+of the whole document and the next external edit reports most of it as
+lost. An external change to a setting nobody here touched is adopted
+silently — nothing was lost, and a notice would be noise.
+
+## Not covered
+
+No lock. Two writers can still interleave read-merge-write and lose the
+later one's edit; the window is the few milliseconds between re-reading
+and renaming, and settings are written by hand. An advisory lock under
+`~/.vibebar/run/` is the fix if that ever stops being true.


### PR DESCRIPTION
`settings.json` has two writers — this app and Vibe Bar Desktop — and,
across versions, two vocabularies. Both saved by rewriting the whole file
from a decoded `AppSettings`, so a save deleted every key the writer did
not know about.

## Measured, on the two real binaries

Same scenario both times: seed `settings.json` with a key no build knows,
launch the app, have another client atomically change `refreshIntervalSeconds`
and add a key of its own, quit the app, read the file.

| | `main` | this branch |
| --- | --- | --- |
| keys in the file | 38 | 40 |
| `refreshIntervalSeconds` | **600** — the other client's 120 written back over | 120 |
| the other client's key | **deleted** | kept |
| a future build's key | **deleted** | kept |

## What changed

- `SettingsDocument` — a three-way merge at top-level-key granularity:
  baseline (what we last saw), mine, theirs (re-read immediately before
  writing). Only keys this process changed move.
- `SettingsStore` writes through it, and watches the file so another
  writer's change is adopted while it happens rather than at the next
  launch. Where both sides changed the same setting the file wins and the
  user is told — a banner in Settings, dismissible.
- `FileChangeWatcher` — a watch that survives atomic writes.
- `docs/contracts/settings-write-v1.md` — the rule, since Desktop has to
  follow the same one.

## Three things that passed their first tests and were still wrong

- **Testing the merge function is not testing the merge.** Replacing the
  store's merged write with a whole-file one left all 12 tests of the pure
  helper green. `SettingsStoreMergeTests` drives the store; two of its four
  cases fail under that tamper.
- **Measuring our edits against the file** counts every default the
  load-time write materialises as a user's choice — the first save claimed
  authorship of 37 settings, so the next external edit reported nearly the
  whole document as lost. Caught by an assertion on the exact key list.
  They are measured against this process's own previous value now.
- **A watcher on a file descriptor goes quiet after the first atomic
  replace**, and a missing file's creation arrives before there is anything
  to watch. The second was caught by a test, having been missed in review.

## Verification

`swift build`, `swift test` (1,751 tests, 3 skipped, 0 failures),
`./Scripts/build_app.sh release`, `codesign -d --entitlements -` → empty
`[Dict]`. Plus the before/after above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
