### PR TITLE
Bump the version to 1.6.0 for the next Main release

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -19,9 +19,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.5.0</string>
+	<string>1.6.0</string>
 	<key>CFBundleVersion</key>
-	<string>58</string>
+	<string>59</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>26.0</string>
 	<key>LSUIElement</key>


### PR DESCRIPTION
Version only — `CFBundleShortVersionString` 1.6.0, `CFBundleVersion` 59.

Everything on `main` since 1.5.0 shipped yesterday:

- **The mini window's ring layout** (#284)
- **Forecast confidence on both clients** (#285)
- **Shared settings two clients can write at once** (#286) — each writer puts back only what it changed, under an advisory lock, and adopts the other's edits instead of overwriting them
- The quota naming axis and the forecast verdict colours written down as contracts (#276, #279, #283), reset-history bars off their own colour table (#275), early-refill clock handling (#278, #281), and the refreshed parity table and light screenshots (#273, #282)

A minor rather than a patch: three of those are things a user can see and reach, not repairs to what 1.5.0 already did.

`swift build`, `swift test` (all suites), `./Scripts/build_app.sh release`, `codesign -d --entitlements -` → empty `<dict/>` with no `app-sandbox`, `codesign --verify --deep --strict` → passes, bundle reports 1.6.0 (59).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
