### PR TITLE
Add a first-run setup assistant window

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -672,7 +672,7 @@ gate reads. With it on:
 - `KeychainStore` reports every item missing and swallows writes at its
   three primitives, so no surface can raise the login-keychain prompt.
 - `DemoPresenter` (`Sources/VibeBarApp/Controllers/`) opens one surface
-  (`VIBEBAR_DEMO_SURFACE=popover:<page>|mini:<mode>|workbench:<page>|settings:<section>`)
+  (`VIBEBAR_DEMO_SURFACE=popover:<page>|mini:<mode>|workbench:<page>|settings:<section>|onboarding:<step>`)
   on the sharpest display, behind it a flat full-screen backdrop, pinned to
   `VIBEBAR_DEMO_APPEARANCE=light|dark`, and prints the window frames on
   stdout for the capture script. The popover is anchored to the backdrop

--- a/Scripts/capture_demo_screenshots.sh
+++ b/Scripts/capture_demo_screenshots.sh
@@ -45,6 +45,7 @@ SURFACES=(
   "settings-menubar=settings:menuBar=both"
   "settings-mcp=settings:mcp=both"
   "settings-remote=settings:remote=both"
+  "onboarding=onboarding=both"
 )
 if (( $# > 0 )); then
   SURFACES=()

--- a/Sources/VibeBarApp/AppDelegate.swift
+++ b/Sources/VibeBarApp/AppDelegate.swift
@@ -43,7 +43,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         } catch {
             SafeLog.warn("Reconciling launch at login failed: \(SafeLog.sanitize(error.localizedDescription))")
         }
-        self.statusItem = StatusItemController(environment: env)
+        let statusItem = StatusItemController(environment: env)
+        self.statusItem = statusItem
+        env.presentPopoverHandler = { [weak statusItem] in
+            statusItem?.presentCompactPopover()
+        }
+        presentOnboardingIfNeeded(environment: env)
 
         CookieRefreshScheduler.shared.start()
         observeCookieRefreshes(environment: env)
@@ -58,6 +63,28 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
 
         SafeLog.info("Vibe Bar started")
+    }
+
+    /// First real launch: open the setup assistant. The decision is
+    /// `OnboardingGate`'s; this only gathers its two signals — a quota cache
+    /// on disk, or a Codex / Claude account the store resolved at init — and
+    /// records completion silently for an install that predates the key.
+    private func presentOnboardingIfNeeded(environment env: AppEnvironment) {
+        let settings = env.settingsStore.settings
+        let hasCLIQuotaAccount = !env.accountStore.accounts(for: .codex).isEmpty
+            || !env.accountStore.accounts(for: .claude).isEmpty
+        switch OnboardingGate.decide(
+            hasCompletedOnboarding: settings.hasCompletedOnboarding,
+            hasQuotaCaches: OnboardingGate.hasQuotaCaches(),
+            hasCLIQuotaAccount: hasCLIQuotaAccount
+        ) {
+        case .show:
+            env.showOnboarding()
+        case .markCompleted:
+            env.settingsStore.settings.hasCompletedOnboarding = true
+        case .skip:
+            break
+        }
     }
 
     private func observeCookieRefreshes(environment: AppEnvironment) {

--- a/Sources/VibeBarApp/AppDelegate.swift
+++ b/Sources/VibeBarApp/AppDelegate.swift
@@ -24,6 +24,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         installMainMenuIfNeeded()
 
+        // Taken before the environment exists on purpose: constructing
+        // `SettingsStore` materialises the defaults and writes `settings.json`
+        // back, so from that point on the file always exists and can no
+        // longer tell a fresh install from an upgrade. See `OnboardingGate`.
+        let hadSettingsFile = FileManager.default.fileExists(atPath: VibeBarLocalStore.settingsURL.path)
+
         let env = AppEnvironment()
         self.environment = env
         if let demo = DemoMode.configuration {
@@ -48,7 +54,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         env.presentPopoverHandler = { [weak statusItem] in
             statusItem?.presentCompactPopover()
         }
-        presentOnboardingIfNeeded(environment: env)
+        presentOnboardingIfNeeded(environment: env, hadSettingsFile: hadSettingsFile)
 
         CookieRefreshScheduler.shared.start()
         observeCookieRefreshes(environment: env)
@@ -66,14 +72,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     /// First real launch: open the setup assistant. The decision is
-    /// `OnboardingGate`'s; this only supplies its one signal — a quota cache
-    /// on disk — and records completion silently for an install that
-    /// predates the key. CLI credentials on the Mac are not consulted: they
-    /// say the user runs Codex or Claude, not that they have run Vibe Bar.
-    private func presentOnboardingIfNeeded(environment env: AppEnvironment) {
+    /// `OnboardingGate`'s; this only supplies its signals — a quota cache on
+    /// disk, and whether `settings.json` predated this launch's store — and
+    /// records completion silently for an install that predates the key.
+    /// CLI credentials on the Mac are not consulted: they say the user runs
+    /// Codex or Claude, not that they have run Vibe Bar.
+    private func presentOnboardingIfNeeded(environment env: AppEnvironment, hadSettingsFile: Bool) {
         switch OnboardingGate.decide(
             hasCompletedOnboarding: env.settingsStore.settings.hasCompletedOnboarding,
-            hasQuotaCaches: OnboardingGate.hasQuotaCaches()
+            hasQuotaCaches: OnboardingGate.hasQuotaCaches(),
+            hadSettingsFile: hadSettingsFile
         ) {
         case .show:
             env.showOnboarding()
@@ -106,13 +114,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
 
-    /// Clicking the Dock icon — which only exists while the Workbench holds a
-    /// Dock token — should bring that window back rather than do nothing. The
-    /// Workbench is never created here: a Dock icon without a live Workbench
-    /// means the window is mid-teardown, and resurrecting it would fight the
+    /// Clicking the Dock icon — which only exists while the Workbench or the
+    /// setup assistant holds a Dock token — should bring that window back
+    /// rather than do nothing. The assistant is asked first: on a first
+    /// launch it is the only window, and a minimised one has no other way
+    /// back. Neither window is ever created here: a Dock icon without a live
+    /// window means it is mid-teardown, and resurrecting it would fight the
     /// close the user just asked for.
     func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
-        environment?.frontWorkbenchIfOpen()
+        guard let environment else { return true }
+        if !environment.frontOnboardingIfOpen() {
+            environment.frontWorkbenchIfOpen()
+        }
         return true
     }
 

--- a/Sources/VibeBarApp/AppDelegate.swift
+++ b/Sources/VibeBarApp/AppDelegate.swift
@@ -66,17 +66,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     /// First real launch: open the setup assistant. The decision is
-    /// `OnboardingGate`'s; this only gathers its two signals — a quota cache
-    /// on disk, or a Codex / Claude account the store resolved at init — and
-    /// records completion silently for an install that predates the key.
+    /// `OnboardingGate`'s; this only supplies its one signal — a quota cache
+    /// on disk — and records completion silently for an install that
+    /// predates the key. CLI credentials on the Mac are not consulted: they
+    /// say the user runs Codex or Claude, not that they have run Vibe Bar.
     private func presentOnboardingIfNeeded(environment env: AppEnvironment) {
-        let settings = env.settingsStore.settings
-        let hasCLIQuotaAccount = !env.accountStore.accounts(for: .codex).isEmpty
-            || !env.accountStore.accounts(for: .claude).isEmpty
         switch OnboardingGate.decide(
-            hasCompletedOnboarding: settings.hasCompletedOnboarding,
-            hasQuotaCaches: OnboardingGate.hasQuotaCaches(),
-            hasCLIQuotaAccount: hasCLIQuotaAccount
+            hasCompletedOnboarding: env.settingsStore.settings.hasCompletedOnboarding,
+            hasQuotaCaches: OnboardingGate.hasQuotaCaches()
         ) {
         case .show:
             env.showOnboarding()

--- a/Sources/VibeBarApp/AppEnvironment.swift
+++ b/Sources/VibeBarApp/AppEnvironment.swift
@@ -721,6 +721,14 @@ final class AppEnvironment: ObservableObject {
         workbenchWindowController.frontExistingWindow()
     }
 
+    /// Front an open or minimised setup assistant without creating one; the
+    /// Dock reopen path's first stop, since on a first launch it is the only
+    /// window there is.
+    @discardableResult
+    func frontOnboardingIfOpen() -> Bool {
+        onboardingWindowController.frontExistingWindow()
+    }
+
     func openClaudeWebLogin() {
         claudeWebLoginController.open { [weak self] in
             self?.hasClaudeWebCookies = ClaudeWebCookieStore.hasCookieHeader()

--- a/Sources/VibeBarApp/AppEnvironment.swift
+++ b/Sources/VibeBarApp/AppEnvironment.swift
@@ -50,6 +50,12 @@ final class AppEnvironment: ObservableObject {
     private let claudeWebLoginController = ClaudeWebLoginController()
     private let miscWebLoginRegistry = MiscWebLoginRegistry()
     private let workbenchWindowController = WorkbenchWindowController()
+    private let onboardingWindowController = OnboardingWindowController()
+    /// Opens the compact popover from its status item. Installed by the
+    /// `AppDelegate` once the status item exists, so the setup assistant's
+    /// Finish can land the user on the readout; nil in demo mode, where
+    /// there is no status item to anchor to.
+    var presentPopoverHandler: (() -> Void)?
     private var workbenchServicesStorage: WorkbenchServices?
     private var cancellables: Set<AnyCancellable> = []
     private var routineBudgetInFlightAccountIds: Set<String> = []
@@ -672,6 +678,25 @@ final class AppEnvironment: ObservableObject {
 
     func showSettings(_ destination: SettingsDestination) {
         workbenchWindowController.show(environment: self, page: .settings, settingsDestination: destination)
+    }
+
+    /// Open the first-run setup assistant, on `step` if one is named. Resets
+    /// nothing: from Settings it is a guided tour of controls that also
+    /// live there.
+    func showOnboarding(step: OnboardingStep? = nil) {
+        onboardingWindowController.show(environment: self, step: step)
+    }
+
+    /// Finishing and skipping both record completion; only finishing goes on
+    /// to open the popover, because a user who skipped asked to be left alone.
+    func finishOnboarding(openPopover: Bool) {
+        settingsStore.settings.hasCompletedOnboarding = true
+        onboardingWindowController.close()
+        guard !DemoMode.isEnabled else { return }
+        refreshAll()
+        if openPopover {
+            presentPopoverHandler?()
+        }
     }
 
     /// Built on the first Workbench open and kept for the process lifetime, so

--- a/Sources/VibeBarApp/Controllers/DemoPresenter.swift
+++ b/Sources/VibeBarApp/Controllers/DemoPresenter.swift
@@ -164,6 +164,10 @@ final class DemoPresenter {
         case let .settings(section):
             guard let destination = Self.settingsDestination(for: section) else { return warnUnknown(surface) }
             environment.showSettings(destination)
+        case let .onboarding(step):
+            let resolved = step.isEmpty ? .welcome : OnboardingStep(rawValue: step)
+            guard let resolved else { return warnUnknown(surface) }
+            environment.showOnboarding(step: resolved)
         }
     }
 

--- a/Sources/VibeBarApp/Controllers/DockActivationController.swift
+++ b/Sources/VibeBarApp/Controllers/DockActivationController.swift
@@ -13,6 +13,7 @@ final class DockActivationController {
 
     enum DockToken: String, Hashable {
         case workbench
+        case onboarding
     }
 
     private var tokens: Set<DockToken> = []

--- a/Sources/VibeBarApp/Controllers/OnboardingWindowController.swift
+++ b/Sources/VibeBarApp/Controllers/OnboardingWindowController.swift
@@ -88,6 +88,25 @@ final class OnboardingWindowController: NSObject {
         NSApp.activate(ignoringOtherApps: true)
     }
 
+    /// Bring an open (or minimised) assistant back to the front without
+    /// building one. On a first launch it is the only Dock-visible window,
+    /// so the Dock reopen path asks here before it asks the Workbench.
+    /// Reports whether there was anything to front.
+    @discardableResult
+    func frontExistingWindow() -> Bool {
+        // A minimised window is not "visible" but is still open: it holds
+        // its Dock token, and the Dock click is how it comes back.
+        guard let window, window.isVisible || window.isMiniaturized else { return false }
+        DockActivationController.shared.acquire(.onboarding)
+        if window.isMiniaturized {
+            window.deminiaturize(nil)
+        }
+        window.makeKeyAndOrderFront(nil)
+        InitialFocusPolicy.clearOnReopen(of: window)
+        NSApp.activate(ignoringOtherApps: true)
+        return true
+    }
+
     func close() {
         window?.close()
     }

--- a/Sources/VibeBarApp/Controllers/OnboardingWindowController.swift
+++ b/Sources/VibeBarApp/Controllers/OnboardingWindowController.swift
@@ -1,0 +1,109 @@
+import AppKit
+import SwiftUI
+import VibeBarCore
+
+/// Which step the setup assistant is on. Owned by the window controller so a
+/// second `showOnboarding(step:)` can move an already-open window rather than
+/// build a second one.
+@MainActor
+final class OnboardingNavigation: ObservableObject {
+    @Published var step: OnboardingStep = .welcome
+}
+
+/// Hosts the first-run setup assistant in a standalone window.
+///
+/// The assistant is a place users pass through once, so it is smaller than
+/// the Workbench and remembers nothing about its frame. Like the Workbench it
+/// holds a Dock token while open: an agent-only app has no other way to be
+/// reached from the app switcher, and a first-run window that vanished behind
+/// the browser the user just switched to would be a poor introduction.
+@MainActor
+final class OnboardingWindowController: NSObject {
+    static let contentSize = NSSize(width: 720, height: 560)
+
+    private var window: NSWindow?
+    private weak var environment: AppEnvironment?
+    private let navigation = OnboardingNavigation()
+
+    func show(environment: AppEnvironment, step: OnboardingStep? = nil) {
+        self.environment = environment
+        if let step {
+            navigation.step = step
+        }
+        // Before the window exists, for the same reason the Workbench does it
+        // first: switching activation policy reorders the app's windows.
+        DockActivationController.shared.acquire(.onboarding)
+
+        if let window {
+            if window.isMiniaturized {
+                window.deminiaturize(nil)
+            }
+            window.makeKeyAndOrderFront(nil)
+            InitialFocusPolicy.clearOnReopen(of: window)
+            NSApp.activate(ignoringOtherApps: true)
+            return
+        }
+
+        let hosting = NSHostingController(
+            rootView: OnboardingView(navigation: navigation)
+                .vibeBarNoInitialFocus()
+                .environmentObject(environment)
+                .environmentObject(environment.accountStore)
+                .environmentObject(environment.settingsStore)
+                .environmentObject(environment.quotaService)
+                .environmentObject(environment.serviceStatus)
+                .environmentObject(environment.costService)
+                .environmentObject(environment.remoteProbeService)
+                .environmentObject(environment.pageLayout)
+                .environmentObject(environment.workbenchServices)
+        )
+        let win = NSWindow(
+            contentRect: NSRect(origin: .zero, size: Self.contentSize),
+            styleMask: [.titled, .closable, .miniaturizable, .resizable, .fullSizeContentView],
+            backing: .buffered,
+            defer: false
+        )
+        win.title = "Vibe Bar Setup"
+        win.titlebarAppearsTransparent = true
+        win.titleVisibility = .hidden
+        win.isReleasedWhenClosed = false
+        win.contentViewController = hosting
+        win.setContentSize(Self.contentSize)
+        win.contentMinSize = Self.contentSize
+        if DemoMode.isEnabled, let screen = DemoPresenter.targetScreen {
+            // Centred on the display the capture lands on, like the Workbench.
+            let visible = screen.visibleFrame
+            let size = win.frame.size
+            win.setFrameOrigin(NSPoint(
+                x: visible.midX - size.width / 2,
+                y: visible.midY - size.height / 2
+            ))
+        } else {
+            win.center()
+        }
+        win.delegate = self
+        self.window = win
+
+        win.makeKeyAndOrderFront(nil)
+        NSApp.activate(ignoringOtherApps: true)
+    }
+
+    func close() {
+        window?.close()
+    }
+}
+
+extension OnboardingWindowController: NSWindowDelegate {
+    func windowWillClose(_ notification: Notification) {
+        DockActivationController.shared.release(.onboarding)
+        // The window is cached; the next open should start at the beginning
+        // rather than on whatever step the user closed it from.
+        navigation.step = .welcome
+        // Closing with the red button or ⌘W is a "not now" too. Recording it
+        // keeps the assistant from reappearing on every launch until the user
+        // finds the Skip button; Settings → System brings it back on demand.
+        if let environment, !environment.settingsStore.settings.hasCompletedOnboarding {
+            environment.settingsStore.settings.hasCompletedOnboarding = true
+        }
+    }
+}

--- a/Sources/VibeBarApp/StatusItemController.swift
+++ b/Sources/VibeBarApp/StatusItemController.swift
@@ -280,6 +280,20 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
             popoverCloseStamps.removeValue(forKey: kind)
             return
         }
+        openPopover(popover, kind: kind, anchoredTo: button)
+    }
+
+    /// Open the compact popover as a click on its status item would. The
+    /// setup assistant calls this on Finish, so the first thing a new user
+    /// sees after setup is the readout they installed the app for.
+    func presentCompactPopover() {
+        guard let button = compactStatusItem?.button else { return }
+        let popover = popover(for: .compact)
+        guard !popover.isShown else { return }
+        openPopover(popover, kind: .compact, anchoredTo: button)
+    }
+
+    private func openPopover(_ popover: NSPopover, kind: MenuBarItemKind, anchoredTo button: NSStatusBarButton) {
         // Close any other open popover first to keep behavior consistent.
         for (otherKind, other) in popovers where otherKind != kind && other.isShown {
             other.performClose(nil)

--- a/Sources/VibeBarApp/Views/MiscProviderSettingsSection.swift
+++ b/Sources/VibeBarApp/Views/MiscProviderSettingsSection.swift
@@ -63,7 +63,7 @@ struct MiscProviderSettingsSection: View {
                     }
                 }
             }
-            placeholderRow
+            MiscProviderCredentialRows(instance: instance)
         }
     }
 
@@ -94,8 +94,24 @@ struct MiscProviderSettingsSection: View {
         }
     }
 
+}
+
+/// The credential and configuration controls for one misc-provider instance —
+/// API-key and AK/SK fields, cookie slots, region and variant pickers, web
+/// login rows. Every Keychain write happens in the field views this composes;
+/// nothing here touches a secret itself. Shared by the Misc Providers settings
+/// page and the setup assistant so the two can never offer different ways to
+/// enter the same credential.
+struct MiscProviderCredentialRows: View {
+    let instance: MiscProviderInstance
+
+    @EnvironmentObject var settingsStore: SettingsStore
+
+    private var tool: ToolType { instance.tool }
+    private var instanceID: String { instance.id }
+
     @ViewBuilder
-    private var placeholderRow: some View {
+    var body: some View {
         switch tool {
         case .zai:
             VStack(alignment: .leading, spacing: 4) {
@@ -311,7 +327,6 @@ struct MiscProviderSettingsSection: View {
             EmptyView()
         }
     }
-
 }
 
 /// Alibaba Token Plan commercial edition. This uses a dedicated

--- a/Sources/VibeBarApp/Views/Onboarding/OnboardingStepViews.swift
+++ b/Sources/VibeBarApp/Views/Onboarding/OnboardingStepViews.swift
@@ -72,7 +72,7 @@ struct OnboardingSubscriptionsStep: View {
     @EnvironmentObject private var settingsStore: SettingsStore
 
     var body: some View {
-        Text("Turn on the subscriptions you use. A provider that is off stays out of the Overview, the menu bar and the refresh schedule; turning one off later keeps its credentials and history.")
+        Text("Turn on the subscriptions you use. A provider that is off stays out of the Overview and the menu bar; turning one off later keeps its credentials and history.")
             .font(.caption)
             .foregroundStyle(.secondary)
             .fixedSize(horizontal: false, vertical: true)

--- a/Sources/VibeBarApp/Views/Onboarding/OnboardingStepViews.swift
+++ b/Sources/VibeBarApp/Views/Onboarding/OnboardingStepViews.swift
@@ -1,0 +1,661 @@
+import SwiftUI
+import VibeBarCore
+
+// MARK: - Welcome
+
+struct OnboardingWelcomeStep: View {
+    let density: Theme.Density
+
+    var body: some View {
+        CardShell(density: density) {
+            Text("Vibe Bar sits in your menu bar and shows, at a glance, how much of each AI subscription you have left, what your coding agents are spending, and which sessions and skills live on this Mac. It reads the credentials the Codex, Claude Code, Gemini and Grok CLIs already keep here, adds web quotas from your browser's cookies when you ask it to, and never sends any of it anywhere but the provider it came from.")
+                .font(.system(size: 13))
+                .fixedSize(horizontal: false, vertical: true)
+            Divider()
+            OnboardingFeatureRow(
+                systemImage: "gauge.with.dots.needle.33percent",
+                title: "Subscription quotas",
+                detail: "Codex, Claude Code, Gemini, Grok and a shelf of API-key plans, each with its reset countdown."
+            )
+            OnboardingFeatureRow(
+                systemImage: "dollarsign.circle",
+                title: "Token cost",
+                detail: "Priced locally from the agents' own session logs against a merged model price catalog."
+            )
+            OnboardingFeatureRow(
+                systemImage: "rectangle.stack",
+                title: "Sessions and skills",
+                detail: "Browse, search and tidy agent sessions and shared skills from the Workbench."
+            )
+            OnboardingFeatureRow(
+                systemImage: "point.3.connected.trianglepath.dotted",
+                title: "Local MCP server",
+                detail: "Your agents can ask Vibe Bar for quota and cost over a Unix socket in your home directory."
+            )
+        }
+        Text("This takes about two minutes. Every choice here can be changed later in Settings, and the assistant is one click away under Settings → System.")
+            .font(.caption)
+            .foregroundStyle(.secondary)
+            .fixedSize(horizontal: false, vertical: true)
+    }
+}
+
+private struct OnboardingFeatureRow: View {
+    let systemImage: String
+    let title: String
+    let detail: String
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 10) {
+            Image(systemName: systemImage)
+                .font(.system(size: 13, weight: .medium))
+                .foregroundStyle(WorkbenchPorcelain.accent)
+                .frame(width: 20, alignment: .center)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title)
+                    .font(.system(size: 13, weight: .semibold))
+                Text(detail)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+    }
+}
+
+// MARK: - Subscriptions
+
+struct OnboardingSubscriptionsStep: View {
+    let density: Theme.Density
+
+    @EnvironmentObject private var environment: AppEnvironment
+    @EnvironmentObject private var settingsStore: SettingsStore
+
+    var body: some View {
+        Text("Turn on the subscriptions you use. A provider that is off stays out of the Overview, the menu bar and the refresh schedule; turning one off later keeps its credentials and history.")
+            .font(.caption)
+            .foregroundStyle(.secondary)
+            .fixedSize(horizontal: false, vertical: true)
+        ForEach(ToolType.coreProviderRepresentatives, id: \.self) { tool in
+            OnboardingCoreProviderCard(tool: tool, density: density)
+        }
+    }
+}
+
+/// One core provider: the Overview switch, what credential is already on
+/// this Mac, and the same import / login actions the provider's Settings
+/// page offers.
+private struct OnboardingCoreProviderCard: View {
+    let tool: ToolType
+    let density: Theme.Density
+
+    @EnvironmentObject private var environment: AppEnvironment
+    @EnvironmentObject private var settingsStore: SettingsStore
+
+    var body: some View {
+        CardShell(density: density) {
+            HStack(spacing: 10) {
+                ToolBrandBadge(tool: tool, iconSize: 20, containerSize: 26)
+                VStack(alignment: .leading, spacing: 1) {
+                    Text(tool.vendorName)
+                        .font(.system(size: 13, weight: .semibold))
+                    Text(productLine)
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer(minLength: 12)
+                Toggle("Show in Overview", isOn: visibilityBinding)
+                    .toggleStyle(.switch)
+                    .controlSize(.small)
+                    .font(.caption)
+            }
+            credentialHint
+            actions
+            statusLines
+        }
+    }
+
+    private var productLine: String {
+        switch tool {
+        case .codex: "Codex CLI · ChatGPT web"
+        case .claude: "Claude Code · claude.ai web"
+        case .gemini: "Gemini web · AntiGravity"
+        case .grok: "Grok CLI · grok.com · Cursor"
+        default: tool.subtitle
+        }
+    }
+
+    private var visibilityBinding: Binding<Bool> {
+        Binding(
+            get: { settingsStore.settings.isCoreProviderVisible(tool) },
+            set: { settingsStore.settings.setCoreProviderVisible($0, for: tool) }
+        )
+    }
+
+    @ViewBuilder
+    private var credentialHint: some View {
+        switch tool {
+        case .codex:
+            cliHint(
+                account: environment.account(for: .codex),
+                detected: "Codex CLI login detected — quota will come from it.",
+                web: "ChatGPT web cookies saved — quota will come from them.",
+                missing: "No Codex CLI login found. Run `codex login`, or import ChatGPT cookies from your browser below."
+            )
+        case .claude:
+            cliHint(
+                account: environment.account(for: .claude),
+                detected: "Claude Code login detected — quota will come from it.",
+                web: "claude.ai cookies saved — quota will come from them.",
+                missing: "No Claude Code login found. Run `claude login`, or import claude.ai cookies from your browser below."
+            )
+        case .gemini:
+            hintLabel(
+                "Gemini quota is read from gemini.google.com cookies; there is no CLI login or WebView path. AntiGravity is probed locally when it is running.",
+                systemImage: "info.circle",
+                tint: .secondary
+            )
+        case .grok:
+            if GrokCredentialsStore.hasCredentials() {
+                hintLabel("~/.grok/auth.json detected — quota will come from it.", systemImage: "checkmark.circle", tint: .green)
+            } else {
+                hintLabel(
+                    "No ~/.grok/auth.json yet. Run `grok login`, or import grok.com cookies from your browser below.",
+                    systemImage: "exclamationmark.circle",
+                    tint: .secondary
+                )
+            }
+        default:
+            EmptyView()
+        }
+    }
+
+    @ViewBuilder
+    private func cliHint(account: AccountIdentity?, detected: String, web: String, missing: String) -> some View {
+        switch account?.source {
+        case .cliDetected, .oauthCLI:
+            hintLabel(detected, systemImage: "checkmark.circle", tint: .green)
+        case .webCookie:
+            hintLabel(web, systemImage: "checkmark.circle", tint: .green)
+        case .some:
+            hintLabel(detected, systemImage: "checkmark.circle", tint: .green)
+        case .none:
+            hintLabel(missing, systemImage: "exclamationmark.circle", tint: .secondary)
+        }
+    }
+
+    private func hintLabel(_ text: String, systemImage: String, tint: Color) -> some View {
+        Label(text, systemImage: systemImage)
+            .font(.caption2)
+            .foregroundStyle(tint)
+            .fixedSize(horizontal: false, vertical: true)
+    }
+
+    @ViewBuilder
+    private var actions: some View {
+        HStack {
+            switch tool {
+            case .codex:
+                Button {
+                    environment.importOpenAIBrowserCookies()
+                } label: {
+                    Label("Import from browser", systemImage: "safari")
+                }
+                .disabled(environment.isImportingOpenAIBrowserCookies)
+                Button {
+                    environment.openOpenAIWebLogin()
+                } label: {
+                    Label("Open WebView login", systemImage: "person.crop.circle.badge.key")
+                }
+            case .claude:
+                Button {
+                    environment.importClaudeBrowserCookies()
+                } label: {
+                    Label("Import from browser", systemImage: "safari")
+                }
+                .disabled(environment.isImportingClaudeBrowserCookies)
+                Button {
+                    environment.openClaudeWebLogin()
+                } label: {
+                    Label("Open WebView login", systemImage: "person.crop.circle.badge.key")
+                }
+            case .gemini:
+                Button {
+                    environment.importGeminiBrowserCookies()
+                } label: {
+                    Label("Import Gemini cookies from browser", systemImage: "safari")
+                }
+                .disabled(environment.isImportingGeminiBrowserCookies)
+            case .grok:
+                Button {
+                    environment.importGrokBrowserCookies()
+                } label: {
+                    Label("Import Grok cookies from browser", systemImage: "safari")
+                }
+                .disabled(environment.isImportingGrokBrowserCookies)
+            default:
+                EmptyView()
+            }
+        }
+    }
+
+    /// Whether this provider's web cookies are in the Keychain, and the
+    /// last import's status line, if any.
+    private var cookieState: (saved: Bool, status: String?) {
+        switch tool {
+        case .codex:
+            (environment.hasOpenAIWebCookies, environment.openAIBrowserCookieImportStatus)
+        case .claude:
+            (environment.hasClaudeWebCookies, environment.claudeBrowserCookieImportStatus)
+        case .gemini:
+            (environment.hasGeminiWebCookies, environment.geminiBrowserCookieImportStatus)
+        case .grok:
+            (environment.hasGrokWebCookies, environment.grokBrowserCookieImportStatus)
+        default:
+            (false, nil)
+        }
+    }
+
+    @ViewBuilder
+    private var statusLines: some View {
+        let (saved, status) = cookieState
+        if saved {
+            Text("Cookies saved.")
+                .font(.caption2)
+                .foregroundStyle(.green)
+        }
+        if let status {
+            Text(status)
+                .font(.caption2)
+                .foregroundStyle(status.hasPrefix("Imported") ? .green : .secondary)
+        }
+    }
+}
+
+// MARK: - Browser cookies
+
+struct OnboardingBrowserCookiesStep: View {
+    let density: Theme.Density
+
+    @EnvironmentObject private var environment: AppEnvironment
+
+    private var isImportingAny: Bool {
+        environment.isImportingOpenAIBrowserCookies
+            || environment.isImportingClaudeBrowserCookies
+            || environment.isImportingGeminiBrowserCookies
+            || environment.isImportingGrokBrowserCookies
+    }
+
+    var body: some View {
+        CardShell(density: density) {
+            Text("Web quotas — the ones the provider shows on its own site — come from the session your browser already has. Vibe Bar reads the cookie stores of the browsers on this Mac (Chrome and other Chromium browsers, Safari, Firefox), keeps only the few cookies each provider needs, and stores them in your login Keychain, never in a plaintext file. macOS may ask once for permission to read a browser's cookie key.")
+                .font(.system(size: 13))
+                .fixedSize(horizontal: false, vertical: true)
+            Button {
+                environment.importOpenAIBrowserCookies()
+                environment.importClaudeBrowserCookies()
+                environment.importGeminiBrowserCookies()
+                environment.importGrokBrowserCookies()
+            } label: {
+                Label(isImportingAny ? "Importing…" : "Import from all browsers now", systemImage: "safari")
+            }
+            .disabled(isImportingAny)
+            Divider()
+            providerRow(
+                .codex,
+                importing: environment.isImportingOpenAIBrowserCookies,
+                saved: environment.hasOpenAIWebCookies,
+                status: environment.openAIBrowserCookieImportStatus
+            )
+            providerRow(
+                .claude,
+                importing: environment.isImportingClaudeBrowserCookies,
+                saved: environment.hasClaudeWebCookies,
+                status: environment.claudeBrowserCookieImportStatus
+            )
+            providerRow(
+                .gemini,
+                importing: environment.isImportingGeminiBrowserCookies,
+                saved: environment.hasGeminiWebCookies,
+                status: environment.geminiBrowserCookieImportStatus
+            )
+            providerRow(
+                .grok,
+                importing: environment.isImportingGrokBrowserCookies,
+                saved: environment.hasGrokWebCookies,
+                status: environment.grokBrowserCookieImportStatus
+            )
+        }
+        Text("Sign in to chatgpt.com, claude.ai, gemini.google.com or grok.com in your browser first — an import can only find a session that exists. Providers you have not signed in to simply report nothing.")
+            .font(.caption)
+            .foregroundStyle(.secondary)
+            .fixedSize(horizontal: false, vertical: true)
+    }
+
+    private func providerRow(_ tool: ToolType, importing: Bool, saved: Bool, status: String?) -> some View {
+        HStack(spacing: 10) {
+            ToolBrandBadge(tool: tool, iconSize: 17, containerSize: 24)
+            Text(tool.vendorName)
+                .font(.system(size: 13, weight: .medium))
+            Spacer(minLength: 12)
+            statusText(importing: importing, saved: saved, status: status)
+                .font(.caption2)
+                .multilineTextAlignment(.trailing)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    @ViewBuilder
+    private func statusText(importing: Bool, saved: Bool, status: String?) -> some View {
+        if importing {
+            Text("Importing…")
+                .foregroundStyle(.secondary)
+        } else if let status {
+            Text(status)
+                .foregroundStyle(status.hasPrefix("Imported") ? .green : .secondary)
+        } else if saved {
+            Text("Cookies saved.")
+                .foregroundStyle(.green)
+        } else {
+            Text("Not imported yet")
+                .foregroundStyle(.tertiary)
+        }
+    }
+}
+
+// MARK: - API-key providers
+
+struct OnboardingAPIKeyProvidersStep: View {
+    let density: Theme.Density
+
+    @EnvironmentObject private var settingsStore: SettingsStore
+    /// Rows whose credential controls are unfolded. Kept apart from
+    /// visibility so a page with every provider on (the default) does not
+    /// open twenty credential forms at once.
+    @State private var expanded: Set<String> = []
+
+    var body: some View {
+        Text("These plans are tracked with an API key or a console cookie rather than a CLI login. Tick the ones you have — a ticked provider gets a card on the Misc page — and unfold a row to enter its credential now. Keys and cookies go to your login Keychain.")
+            .font(.caption)
+            .foregroundStyle(.secondary)
+            .fixedSize(horizontal: false, vertical: true)
+        CardShell(density: density, spacing: 0) {
+            let instances = settingsStore.settings.miscProviderInstances
+                .filter { $0.tool.isMiscPageProvider }
+            ForEach(Array(instances.enumerated()), id: \.element.id) { index, instance in
+                if index > 0 {
+                    Divider()
+                        .padding(.vertical, 6)
+                }
+                providerRow(instance)
+            }
+        }
+    }
+
+    private func providerRow(_ instance: MiscProviderInstance) -> some View {
+        let visible = instance.isVisible
+        let unfolded = visible && expanded.contains(instance.id)
+        return VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: 8) {
+                Toggle(isOn: visibilityBinding(instance.id)) {
+                    EmptyView()
+                }
+                .toggleStyle(.checkbox)
+                .labelsHidden()
+                .help("Show \(instance.tool.menuTitle) on the Misc page")
+                ToolBrandBadge(tool: instance.tool, iconSize: 17, containerSize: 24)
+                    .opacity(visible ? 1 : 0.55)
+                Text(instance.displayTitle(fallback: instance.tool.menuTitle))
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundStyle(visible ? Color.primary : Color.secondary)
+                Text(instance.tool.subtitle)
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+                Spacer(minLength: 8)
+                Button {
+                    if unfolded {
+                        expanded.remove(instance.id)
+                    } else {
+                        expanded.insert(instance.id)
+                    }
+                } label: {
+                    Label(unfolded ? "Hide" : "Set up", systemImage: unfolded ? "chevron.up" : "chevron.down")
+                        .font(.caption)
+                }
+                .buttonStyle(WorkbenchPillButtonStyle())
+                .controlSize(.small)
+                .disabled(!visible)
+                // The pill draws no disabled state of its own.
+                .opacity(visible ? 1 : 0.4)
+            }
+            if unfolded {
+                MiscProviderCredentialRows(instance: instance)
+                    .padding(.leading, 32)
+            }
+        }
+    }
+
+    private func visibilityBinding(_ id: String) -> Binding<Bool> {
+        Binding(
+            get: { settingsStore.settings.miscProviderInstance(id: id)?.isVisible ?? false },
+            set: { settingsStore.settings.setMiscProviderInstanceVisible($0, forID: id) }
+        )
+    }
+}
+
+// MARK: - Model pricing
+
+struct OnboardingPricingStep: View {
+    let density: Theme.Density
+
+    @EnvironmentObject private var environment: AppEnvironment
+    @EnvironmentObject private var settingsStore: SettingsStore
+
+    var body: some View {
+        CardShell(density: density) {
+            Text("Token cost is computed on this Mac from your agents' session logs, priced with a catalog merged from several public price lists — higher-priority entries win when a model appears in more than one, your own overrides beat them all, and a bundled table is the offline floor. Catalogs refresh in the background every \(intervalLabel(settingsStore.settings.pricingRefreshIntervalSeconds)); fetching now gives the first cost numbers current prices.")
+                .font(.system(size: 13))
+                .fixedSize(horizontal: false, vertical: true)
+            HStack {
+                Button(action: environment.refreshPricingNow) {
+                    Label(
+                        environment.isRefreshingPricing ? "Fetching…" : "Fetch prices now",
+                        systemImage: "arrow.triangle.2.circlepath"
+                    )
+                }
+                .disabled(environment.isRefreshingPricing)
+                if let date = environment.pricingRefreshStatus.mergedAt {
+                    Text("Merged \(date.formatted(date: .abbreviated, time: .shortened)) · \(environment.pricingRefreshStatus.mergedModelCount) models")
+                        .font(.caption2.monospacedDigit())
+                        .foregroundStyle(.secondary)
+                } else {
+                    Text("Not fetched yet — the bundled table is in use.")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            Divider()
+            ForEach(PricingSourceID.allCases, id: \.self) { source in
+                sourceRow(source)
+            }
+        }
+        Text("Prices are USD per one million tokens. Local overrides live under Settings → Model Pricing.")
+            .font(.caption)
+            .foregroundStyle(.secondary)
+    }
+
+    private func sourceRow(_ source: PricingSourceID) -> some View {
+        let status = environment.pricingRefreshStatus.sources.first { $0.source == source }
+        return HStack(spacing: 10) {
+            Circle()
+                .fill(statusColor(status?.result ?? .never))
+                .frame(width: 7, height: 7)
+            Text(source.label)
+                .font(.system(size: 13))
+            Spacer()
+            Text(sourceDetail(status))
+                .font(.caption2.monospacedDigit())
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private func sourceDetail(_ status: PricingSourceStatus?) -> String {
+        guard let status else { return "Not refreshed" }
+        switch status.result {
+        case .ready: return "\(status.modelCount) models"
+        case .unchanged: return "\(status.modelCount) models · unchanged"
+        case .failed: return "Cached \(status.modelCount) · refresh failed"
+        case .never: return "Not refreshed"
+        }
+    }
+
+    private func statusColor(_ result: PricingSourceRefreshResult) -> Color {
+        switch result {
+        case .ready, .unchanged: .green
+        case .failed: .orange
+        case .never: .secondary
+        }
+    }
+
+    private func intervalLabel(_ seconds: Int) -> String {
+        let hours = seconds / 3600
+        return hours == 1 ? "hour" : "\(hours) hours"
+    }
+}
+
+// MARK: - Launch at login
+
+struct OnboardingLaunchAtLoginStep: View {
+    let density: Theme.Density
+
+    @EnvironmentObject private var settingsStore: SettingsStore
+    // A demo launch registers nothing with the system and must not read the
+    // real login item either: the captured state is the settings file's.
+    @State private var statusText: String = DemoMode.isEnabled ? "Off." : LoginItemController.statusText
+    @State private var errorText: String?
+
+    var body: some View {
+        CardShell(density: density) {
+            Toggle("Launch Vibe Bar at login", isOn: binding)
+                .toggleStyle(.switch)
+            Text(statusText)
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+            if let errorText {
+                Text(errorText)
+                    .font(.caption2)
+                    .foregroundStyle(.orange)
+            }
+            Divider()
+            Text("Vibe Bar is a menu-bar app with no Dock icon. Starting it at login keeps the quota readout and the local MCP server available from the moment you sign in; macOS may ask you to approve the login item in System Settings the first time.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .onAppear(perform: refreshState)
+    }
+
+    private var binding: Binding<Bool> {
+        Binding(
+            get: { settingsStore.settings.launchAtLogin },
+            set: { enabled in
+                if DemoMode.isEnabled {
+                    settingsStore.settings.launchAtLogin = enabled
+                    statusText = enabled ? "Enabled in macOS Login Items." : "Off."
+                    return
+                }
+                do {
+                    try LoginItemController.reconcileDesiredState(enabled)
+                    settingsStore.settings.launchAtLogin = enabled
+                    errorText = nil
+                } catch {
+                    errorText = error.localizedDescription
+                }
+                refreshState()
+            }
+        )
+    }
+
+    private func refreshState() {
+        guard !DemoMode.isEnabled else { return }
+        switch LoginItemController.status {
+        case .enabled, .requiresApproval:
+            settingsStore.settings.launchAtLogin = true
+        case .notRegistered:
+            settingsStore.settings.launchAtLogin = false
+        case .notFound:
+            break
+        @unknown default:
+            break
+        }
+        statusText = LoginItemController.statusText
+    }
+}
+
+// MARK: - Done
+
+struct OnboardingDoneStep: View {
+    let density: Theme.Density
+
+    @EnvironmentObject private var environment: AppEnvironment
+    @EnvironmentObject private var settingsStore: SettingsStore
+
+    var body: some View {
+        CardShell(density: density) {
+            Text("That is everything the menu bar needs. Finish opens the popover with whatever quota is already readable; the rest fills in on the first refresh.")
+                .font(.system(size: 13))
+                .fixedSize(horizontal: false, vertical: true)
+            Divider()
+            summaryRow("Subscriptions", value: visibleCoreProviders)
+            summaryRow("Browser cookies", value: "\(savedCookieCount) of 4 providers saved")
+            summaryRow("API-key providers", value: "\(visibleMiscCount) on the Misc page")
+            summaryRow("Model pricing", value: pricingSummary)
+            summaryRow("Launch at login", value: settingsStore.settings.launchAtLogin ? "On" : "Off")
+        }
+        Text("Every one of these lives in Settings, and the assistant is one click away under Settings → System.")
+            .font(.caption)
+            .foregroundStyle(.secondary)
+            .fixedSize(horizontal: false, vertical: true)
+    }
+
+    private func summaryRow(_ title: String, value: String) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: 12) {
+            Text(title)
+                .font(.system(size: 13))
+            Spacer(minLength: 12)
+            Text(value)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.trailing)
+        }
+    }
+
+    private var visibleCoreProviders: String {
+        let names = ToolType.coreProviderRepresentatives
+            .filter { settingsStore.settings.isCoreProviderVisible($0) }
+            .map(\.vendorName)
+        return names.isEmpty ? "None shown" : names.joined(separator: ", ")
+    }
+
+    private var savedCookieCount: Int {
+        [
+            environment.hasOpenAIWebCookies,
+            environment.hasClaudeWebCookies,
+            environment.hasGeminiWebCookies,
+            environment.hasGrokWebCookies,
+        ].filter { $0 }.count
+    }
+
+    private var visibleMiscCount: Int {
+        settingsStore.settings.miscProviderInstances
+            .filter { $0.tool.isMiscPageProvider && $0.isVisible }
+            .count
+    }
+
+    private var pricingSummary: String {
+        if let date = environment.pricingRefreshStatus.mergedAt {
+            return "Merged \(date.formatted(date: .abbreviated, time: .shortened))"
+        }
+        return "Bundled table until the first fetch"
+    }
+}

--- a/Sources/VibeBarApp/Views/Onboarding/OnboardingView.swift
+++ b/Sources/VibeBarApp/Views/Onboarding/OnboardingView.swift
@@ -1,0 +1,296 @@
+import SwiftUI
+import VibeBarCore
+
+/// The setup assistant's steps, in order. Raw values double as the
+/// `onboarding:<step>` identifiers demo mode accepts.
+enum OnboardingStep: String, CaseIterable, Identifiable {
+    case welcome
+    case subscriptions
+    case browserCookies
+    case apiKeyProviders
+    case pricing
+    case launchAtLogin
+    case done
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .welcome: "Welcome"
+        case .subscriptions: "Subscriptions"
+        case .browserCookies: "Browser cookies"
+        case .apiKeyProviders: "API-key providers"
+        case .pricing: "Model pricing"
+        case .launchAtLogin: "Launch at login"
+        case .done: "All set"
+        }
+    }
+
+    var subtitle: String {
+        switch self {
+        case .welcome: "What Vibe Bar does, in one paragraph."
+        case .subscriptions: "Turn on the plans you pay for."
+        case .browserCookies: "Web quotas come from the session your browser already has."
+        case .apiKeyProviders: "Plans tracked with an API key or a console cookie."
+        case .pricing: "Where the token prices behind the cost numbers come from."
+        case .launchAtLogin: "Keep the readout in your menu bar from the moment you sign in."
+        case .done: "Everything here lives in Settings too."
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .welcome: "hand.wave"
+        case .subscriptions: "creditcard"
+        case .browserCookies: "safari"
+        case .apiKeyProviders: "key"
+        case .pricing: "dollarsign.circle"
+        case .launchAtLogin: "power"
+        case .done: "checkmark.circle"
+        }
+    }
+
+    var previous: OnboardingStep? {
+        let all = Self.allCases
+        guard let index = all.firstIndex(of: self), index > all.startIndex else { return nil }
+        return all[index - 1]
+    }
+
+    var next: OnboardingStep? {
+        let all = Self.allCases
+        guard let index = all.firstIndex(of: self), index + 1 < all.endIndex else { return nil }
+        return all[index + 1]
+    }
+}
+
+/// The first-run setup assistant: a step list on the left, one step's
+/// controls on the right, Back / Skip / Continue underneath.
+///
+/// Every control here is the same control Settings shows — the visibility
+/// switches, the cookie importers, the credential fields, the pricing
+/// refresh, the login item — bound to the same stores. The assistant adds
+/// order and explanation, never a second copy of state.
+struct OnboardingView: View {
+    @ObservedObject var navigation: OnboardingNavigation
+
+    @EnvironmentObject private var environment: AppEnvironment
+    @EnvironmentObject private var settingsStore: SettingsStore
+    @Environment(\.colorScheme) private var colorScheme
+
+    private static let stepListWidth: CGFloat = 212
+    /// Distance from the window's top edge to the first line of either pane.
+    static let titleBarInset: CGFloat = 44
+
+    var body: some View {
+        let density = Theme.density(for: settingsStore.settings.popoverDensity)
+        HStack(spacing: 0) {
+            OnboardingStepList(current: $navigation.step)
+                .frame(width: Self.stepListWidth)
+            Rectangle()
+                .fill(WorkbenchPorcelain.hairline(for: colorScheme))
+                .frame(width: 1)
+            VStack(spacing: 0) {
+                ScrollView(.vertical, showsIndicators: true) {
+                    VStack(alignment: .leading, spacing: density.interSectionSpacing) {
+                        header
+                        stepContent(density: density)
+                    }
+                    .padding(.horizontal, 28)
+                    // Clears the traffic lights in the transparent title
+                    // bar; the step list carries the same inset.
+                    .padding(.top, Self.titleBarInset)
+                    .padding(.bottom, 24)
+                    .frame(maxWidth: .infinity, alignment: .topLeading)
+                }
+                // The step pane is native toggles and fields: their system
+                // focus ring is what tells a keyboard user where they are.
+                .vibeBarSystemControlFocus()
+                Rectangle()
+                    .fill(WorkbenchPorcelain.hairline(for: colorScheme))
+                    .frame(height: 1)
+                footer
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+        .frame(
+            minWidth: OnboardingWindowController.contentSize.width,
+            minHeight: OnboardingWindowController.contentSize.height
+        )
+        // The window's title bar is transparent and full-size; the panes own
+        // the whole height so the hairline between them runs edge to edge,
+        // and each one insets its content past the traffic lights itself.
+        .ignoresSafeArea(.container, edges: .top)
+        .background(WorkbenchPorcelain.windowFill(for: colorScheme))
+        .workbenchPorcelain()
+        .vibeBarControlFocus()
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(navigation.step.title)
+                .font(.system(size: 22, weight: .bold))
+                .tracking(-0.35)
+            Text(navigation.step.subtitle)
+                .font(.system(size: 11.5))
+                .foregroundStyle(.secondary)
+        }
+        .padding(.bottom, 4)
+    }
+
+    @ViewBuilder
+    private func stepContent(density: Theme.Density) -> some View {
+        switch navigation.step {
+        case .welcome:
+            OnboardingWelcomeStep(density: density)
+        case .subscriptions:
+            OnboardingSubscriptionsStep(density: density)
+        case .browserCookies:
+            OnboardingBrowserCookiesStep(density: density)
+        case .apiKeyProviders:
+            OnboardingAPIKeyProvidersStep(density: density)
+        case .pricing:
+            OnboardingPricingStep(density: density)
+        case .launchAtLogin:
+            OnboardingLaunchAtLoginStep(density: density)
+        case .done:
+            OnboardingDoneStep(density: density)
+        }
+    }
+
+    private var footer: some View {
+        HStack(spacing: 10) {
+            Button("Back") {
+                if let previous = navigation.step.previous {
+                    navigation.step = previous
+                }
+            }
+            .buttonStyle(WorkbenchPillButtonStyle())
+            .disabled(navigation.step.previous == nil)
+
+            Spacer(minLength: 12)
+
+            if navigation.step != .done {
+                Button("Skip for now") {
+                    environment.finishOnboarding(openPopover: false)
+                }
+                .buttonStyle(WorkbenchPillButtonStyle())
+            }
+
+            if let next = navigation.step.next {
+                Button("Continue") {
+                    navigation.step = next
+                }
+                .buttonStyle(WorkbenchPillButtonStyle(prominent: true))
+                .keyboardShortcut(.defaultAction)
+            } else {
+                Button("Finish") {
+                    environment.finishOnboarding(openPopover: true)
+                }
+                .buttonStyle(WorkbenchPillButtonStyle(prominent: true))
+                .keyboardShortcut(.defaultAction)
+            }
+        }
+        .padding(.horizontal, 24)
+        .padding(.vertical, 14)
+    }
+}
+
+/// The rail of steps. A step behind the current one shows a check; any step
+/// can be jumped to — the order is a suggestion, not a gate.
+private struct OnboardingStepList: View {
+    @Binding var current: OnboardingStep
+
+    @Environment(\.colorScheme) private var colorScheme
+    @State private var hovered: OnboardingStep?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text("Setup")
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundStyle(.secondary)
+                .padding(.horizontal, 8)
+                .padding(.bottom, 6)
+            ForEach(OnboardingStep.allCases) { step in
+                row(step)
+            }
+            Spacer(minLength: 0)
+            Text(versionLabel)
+                .font(.system(size: 10, weight: .medium))
+                .foregroundStyle(.tertiary)
+                .padding(.horizontal, 8)
+        }
+        .padding(.horizontal, 10)
+        .padding(.top, OnboardingView.titleBarInset)
+        .padding(.bottom, 14)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .background(WorkbenchPorcelain.sidebarFill(for: colorScheme))
+    }
+
+    private func row(_ step: OnboardingStep) -> some View {
+        let selected = current == step
+        let completed = isCompleted(step)
+        return Button {
+            current = step
+        } label: {
+            HStack(spacing: 9) {
+                ZStack {
+                    Circle()
+                        .fill(
+                            selected
+                                ? WorkbenchPorcelain.accent.opacity(0.16)
+                                : (completed ? Color.green.opacity(0.14) : WorkbenchPorcelain.hoverFill(for: colorScheme))
+                        )
+                    Image(systemName: completed && !selected ? "checkmark" : step.systemImage)
+                        .font(.system(size: 10, weight: .semibold))
+                        .foregroundStyle(
+                            selected
+                                ? WorkbenchPorcelain.accent
+                                : (completed ? Color.green : Color.secondary)
+                        )
+                }
+                .frame(width: 22, height: 22)
+                Text(step.title)
+                    .font(.system(size: 13, weight: selected ? .semibold : .medium))
+                    .lineLimit(1)
+                Spacer(minLength: 0)
+            }
+            .foregroundStyle(selected ? Color.primary : Color.primary.opacity(0.78))
+            .padding(.horizontal, 8)
+            .frame(maxWidth: .infinity, minHeight: 32, alignment: .leading)
+            .background(
+                RoundedRectangle(cornerRadius: 9, style: .continuous)
+                    .fill(
+                        selected
+                            ? WorkbenchPorcelain.selectedNavigationFill(for: colorScheme)
+                            : (hovered == step ? WorkbenchPorcelain.hoverFill(for: colorScheme) : Color.clear)
+                    )
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 9, style: .continuous)
+                    .strokeBorder(
+                        selected ? WorkbenchPorcelain.hairline(for: colorScheme) : Color.clear,
+                        lineWidth: Theme.Card.hairlineWidth
+                    )
+            )
+            .contentShape(RoundedRectangle(cornerRadius: 9, style: .continuous))
+        }
+        .buttonStyle(.vibeBar(cornerRadius: 9))
+        .onHover { hovering in
+            hovered = hovering ? step : (hovered == step ? nil : hovered)
+        }
+        .accessibilityAddTraits(selected ? [.isSelected] : [])
+    }
+
+    private func isCompleted(_ step: OnboardingStep) -> Bool {
+        let all = OnboardingStep.allCases
+        guard let index = all.firstIndex(of: step), let currentIndex = all.firstIndex(of: current) else {
+            return false
+        }
+        return index < currentIndex
+    }
+
+    private var versionLabel: String {
+        let version = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
+        return "Vibe Bar · " + (version ?? "Setup")
+    }
+}

--- a/Sources/VibeBarApp/Views/SettingsView.swift
+++ b/Sources/VibeBarApp/Views/SettingsView.swift
@@ -188,6 +188,16 @@ struct SettingsView: View {
                                 .font(.caption2)
                                 .foregroundStyle(.orange)
                         }
+                        Divider()
+                            .padding(.vertical, 2)
+                        Button {
+                            environment.showOnboarding()
+                        } label: {
+                            Label("Show setup assistant", systemImage: "wand.and.stars")
+                        }
+                        Text("Walk through subscriptions, browser cookies, API keys, model pricing and login items again. Nothing is reset.")
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
                     }
                     .id(SettingsSectionID.system.rawValue)
 

--- a/Sources/VibeBarCore/Models/AppSettings.swift
+++ b/Sources/VibeBarCore/Models/AppSettings.swift
@@ -6,6 +6,11 @@ public struct AppSettings: Codable, Equatable, Sendable {
     public var refreshOnPopoverOpen: Bool
     public var popoverOpenRefreshCooldownSeconds: Int
     public var launchAtLogin: Bool
+    /// Set once the first-run setup assistant has been finished or skipped.
+    /// Absent from a settings file written before the assistant existed;
+    /// `OnboardingGate` tells a fresh install apart from an upgrade so an
+    /// existing user is never walked through setup they already did.
+    public var hasCompletedOnboarding: Bool
     public var updateChannel: UpdateChannel
     public var menuBarTextEnabled: Bool
     /// Set by "Don't check again" on the alert that reports macOS blocking our
@@ -177,6 +182,7 @@ public struct AppSettings: Codable, Equatable, Sendable {
         refreshOnPopoverOpen: false,
         popoverOpenRefreshCooldownSeconds: 60,
         launchAtLogin: false,
+        hasCompletedOnboarding: false,
         updateChannel: .main,
         menuBarTextEnabled: true,
         menuBarBlockAlertSuppressed: false,
@@ -284,6 +290,7 @@ public struct AppSettings: Codable, Equatable, Sendable {
         refreshOnPopoverOpen: Bool = false,
         popoverOpenRefreshCooldownSeconds: Int = 60,
         launchAtLogin: Bool,
+        hasCompletedOnboarding: Bool = false,
         updateChannel: UpdateChannel = .main,
         menuBarTextEnabled: Bool,
         menuBarBlockAlertSuppressed: Bool = false,
@@ -323,6 +330,7 @@ public struct AppSettings: Codable, Equatable, Sendable {
         self.refreshOnPopoverOpen = refreshOnPopoverOpen
         self.popoverOpenRefreshCooldownSeconds = max(60, popoverOpenRefreshCooldownSeconds)
         self.launchAtLogin = launchAtLogin
+        self.hasCompletedOnboarding = hasCompletedOnboarding
         self.updateChannel = updateChannel
         self.menuBarTextEnabled = menuBarTextEnabled
         self.menuBarBlockAlertSuppressed = menuBarBlockAlertSuppressed
@@ -395,6 +403,7 @@ public struct AppSettings: Codable, Equatable, Sendable {
         case refreshOnPopoverOpen
         case popoverOpenRefreshCooldownSeconds
         case launchAtLogin
+        case hasCompletedOnboarding
         case updateChannel
         case menuBarTextEnabled
         case menuBarBlockAlertSuppressed
@@ -442,6 +451,11 @@ public struct AppSettings: Codable, Equatable, Sendable {
                 ?? Self.default.popoverOpenRefreshCooldownSeconds
         )
         self.launchAtLogin = try c.decodeIfPresent(Bool.self, forKey: .launchAtLogin) ?? Self.default.launchAtLogin
+        // Missing means "never recorded", not "not done": whether that is a
+        // fresh install or an upgrade is `OnboardingGate`'s call at launch.
+        self.hasCompletedOnboarding =
+            try c.decodeIfPresent(Bool.self, forKey: .hasCompletedOnboarding)
+            ?? Self.default.hasCompletedOnboarding
         self.updateChannel =
             (try? c.decodeIfPresent(UpdateChannel.self, forKey: .updateChannel))
             ?? Self.default.updateChannel
@@ -628,6 +642,7 @@ public struct AppSettings: Codable, Equatable, Sendable {
         try c.encode(refreshOnPopoverOpen, forKey: .refreshOnPopoverOpen)
         try c.encode(popoverOpenRefreshCooldownSeconds, forKey: .popoverOpenRefreshCooldownSeconds)
         try c.encode(launchAtLogin, forKey: .launchAtLogin)
+        try c.encode(hasCompletedOnboarding, forKey: .hasCompletedOnboarding)
         try c.encode(updateChannel, forKey: .updateChannel)
         try c.encode(menuBarTextEnabled, forKey: .menuBarTextEnabled)
         try c.encode(menuBarBlockAlertSuppressed, forKey: .menuBarBlockAlertSuppressed)

--- a/Sources/VibeBarCore/Utilities/DemoMode.swift
+++ b/Sources/VibeBarCore/Utilities/DemoMode.swift
@@ -19,8 +19,9 @@ import Foundation
 ///   process, so the same surface can be captured in both.
 /// - `VIBEBAR_DEMO_SURFACE=<surface>` — open one surface after launch:
 ///   `popover:<page>`, `mini:<regular|compact>`, `workbench:<page>`,
-///   `settings:<section>`, where the identifiers are the app's own raw
-///   values (`overview`, `openAI`, `usageStats`, `layout`, …).
+///   `settings:<section>`, `onboarding:<step>`, where the identifiers are
+///   the app's own raw values (`overview`, `openAI`, `usageStats`, `layout`,
+///   `subscriptions`, …).
 /// - `VIBEBAR_DEMO_BACKDROP=0` — skip the solid backdrop window demo mode
 ///   otherwise puts behind the popover so a translucent surface is captured
 ///   over one flat colour rather than over whatever happens to be on screen.
@@ -40,6 +41,8 @@ public enum DemoMode {
         case miniWindow(mode: String)
         case workbench(page: String)
         case settings(section: String)
+        /// The first-run setup assistant, opened on the named step.
+        case onboarding(step: String)
 
         /// `kind:identifier`. An unknown kind is `nil`; an empty identifier
         /// is allowed and means "the surface's default".
@@ -51,6 +54,7 @@ public enum DemoMode {
                 case "mini": self = .miniWindow(mode: "")
                 case "workbench": self = .workbench(page: "")
                 case "settings": self = .settings(section: "")
+                case "onboarding": self = .onboarding(step: "")
                 default: return nil
                 }
                 return
@@ -62,6 +66,7 @@ public enum DemoMode {
             case "mini": self = .miniWindow(mode: identifier)
             case "workbench": self = .workbench(page: identifier)
             case "settings": self = .settings(section: identifier)
+            case "onboarding": self = .onboarding(step: identifier)
             default: return nil
             }
         }

--- a/Sources/VibeBarCore/Utilities/OnboardingGate.swift
+++ b/Sources/VibeBarCore/Utilities/OnboardingGate.swift
@@ -6,10 +6,15 @@ import Foundation
 /// durable record of having been through it is `AppSettings.hasCompletedOnboarding`,
 /// and that key did not exist before the assistant did — so a missing key
 /// reads as `false` for an upgrade as much as for a fresh install. The gate
-/// therefore asks what the install looks like, not just what the key says:
-/// a quota cache under `~/.vibebar/quotas/` or a resolvable Codex / Claude
-/// account means the app has already been doing its job here, and an
-/// existing user is never walked through setup they already did.
+/// therefore asks what the install looks like, not just what the key says —
+/// and it asks only Vibe Bar's own evidence: a quota cache under
+/// `~/.vibebar/quotas/` means the app has already been doing its job here,
+/// and an existing user is never walked through setup they already did.
+///
+/// A Codex or Claude CLI login on the Mac is deliberately *not* evidence.
+/// People who already run those CLIs are exactly who installs Vibe Bar, so
+/// counting their credentials as "prior use" would hide the assistant from
+/// its primary audience on a clean install.
 public enum OnboardingGate {
     public enum Decision: Equatable, Sendable {
         /// A fresh install: open the assistant.
@@ -21,28 +26,22 @@ public enum OnboardingGate {
         case markCompleted
     }
 
-    /// The whole rule, pure. `hasQuotaCaches` and `hasCLIQuotaAccount` are
-    /// the two signs of an install that is not fresh; either one is enough.
+    /// The whole rule, pure. A quota cache is the one sign of an install
+    /// that is not fresh.
     public static func decide(
         hasCompletedOnboarding: Bool,
-        hasQuotaCaches: Bool,
-        hasCLIQuotaAccount: Bool
+        hasQuotaCaches: Bool
     ) -> Decision {
         if hasCompletedOnboarding { return .skip }
-        if hasQuotaCaches || hasCLIQuotaAccount { return .markCompleted }
+        if hasQuotaCaches { return .markCompleted }
         return .show
     }
 
     /// `decide` reduced to the one question the launch path asks.
-    public static func shouldShow(
-        settings: AppSettings,
-        hasQuotaCaches: Bool,
-        hasCLIQuotaAccount: Bool
-    ) -> Bool {
+    public static func shouldShow(settings: AppSettings, hasQuotaCaches: Bool) -> Bool {
         decide(
             hasCompletedOnboarding: settings.hasCompletedOnboarding,
-            hasQuotaCaches: hasQuotaCaches,
-            hasCLIQuotaAccount: hasCLIQuotaAccount
+            hasQuotaCaches: hasQuotaCaches
         ) == .show
     }
 

--- a/Sources/VibeBarCore/Utilities/OnboardingGate.swift
+++ b/Sources/VibeBarCore/Utilities/OnboardingGate.swift
@@ -7,9 +7,18 @@ import Foundation
 /// and that key did not exist before the assistant did — so a missing key
 /// reads as `false` for an upgrade as much as for a fresh install. The gate
 /// therefore asks what the install looks like, not just what the key says —
-/// and it asks only Vibe Bar's own evidence: a quota cache under
-/// `~/.vibebar/quotas/` means the app has already been doing its job here,
+/// and it asks only Vibe Bar's own evidence. Two things count: a quota cache
+/// under `~/.vibebar/quotas/`, and a `settings.json` that was already on
+/// disk when the app launched. Either means Vibe Bar has run here before,
 /// and an existing user is never walked through setup they already did.
+/// The settings file matters because a user whose providers were all
+/// unconfigured, or whose every refresh failed, has no cache to show for
+/// months of use — but they do have the file every launch writes.
+///
+/// The file check has to be taken *before* `SettingsStore` is constructed:
+/// loading the store materialises every default and writes the file back,
+/// so a check taken afterwards says "exists" on every launch, fresh install
+/// included. `AppDelegate` captures it as the first thing it does.
 ///
 /// A Codex or Claude CLI login on the Mac is deliberately *not* evidence.
 /// People who already run those CLIs are exactly who installs Vibe Bar, so
@@ -26,22 +35,32 @@ public enum OnboardingGate {
         case markCompleted
     }
 
-    /// The whole rule, pure. A quota cache is the one sign of an install
-    /// that is not fresh.
+    /// The whole rule, pure. A quota cache or a pre-existing settings file is
+    /// a sign of an install that is not fresh; either one is enough.
+    ///
+    /// - Parameter hadSettingsFile: whether `settings.json` existed before
+    ///   this launch's `SettingsStore` was created — not after, when it
+    ///   always does.
     public static func decide(
         hasCompletedOnboarding: Bool,
-        hasQuotaCaches: Bool
+        hasQuotaCaches: Bool,
+        hadSettingsFile: Bool
     ) -> Decision {
         if hasCompletedOnboarding { return .skip }
-        if hasQuotaCaches { return .markCompleted }
+        if hasQuotaCaches || hadSettingsFile { return .markCompleted }
         return .show
     }
 
     /// `decide` reduced to the one question the launch path asks.
-    public static func shouldShow(settings: AppSettings, hasQuotaCaches: Bool) -> Bool {
+    public static func shouldShow(
+        settings: AppSettings,
+        hasQuotaCaches: Bool,
+        hadSettingsFile: Bool
+    ) -> Bool {
         decide(
             hasCompletedOnboarding: settings.hasCompletedOnboarding,
-            hasQuotaCaches: hasQuotaCaches
+            hasQuotaCaches: hasQuotaCaches,
+            hadSettingsFile: hadSettingsFile
         ) == .show
     }
 

--- a/Sources/VibeBarCore/Utilities/OnboardingGate.swift
+++ b/Sources/VibeBarCore/Utilities/OnboardingGate.swift
@@ -1,0 +1,61 @@
+import Foundation
+
+/// Decides whether the first-run setup assistant opens at launch.
+///
+/// The assistant is for people who have just installed Vibe Bar. The only
+/// durable record of having been through it is `AppSettings.hasCompletedOnboarding`,
+/// and that key did not exist before the assistant did — so a missing key
+/// reads as `false` for an upgrade as much as for a fresh install. The gate
+/// therefore asks what the install looks like, not just what the key says:
+/// a quota cache under `~/.vibebar/quotas/` or a resolvable Codex / Claude
+/// account means the app has already been doing its job here, and an
+/// existing user is never walked through setup they already did.
+public enum OnboardingGate {
+    public enum Decision: Equatable, Sendable {
+        /// A fresh install: open the assistant.
+        case show
+        /// Setup was finished or skipped on an earlier launch.
+        case skip
+        /// The key is unset on an install that clearly predates it. Record
+        /// completion silently so the question is not asked again.
+        case markCompleted
+    }
+
+    /// The whole rule, pure. `hasQuotaCaches` and `hasCLIQuotaAccount` are
+    /// the two signs of an install that is not fresh; either one is enough.
+    public static func decide(
+        hasCompletedOnboarding: Bool,
+        hasQuotaCaches: Bool,
+        hasCLIQuotaAccount: Bool
+    ) -> Decision {
+        if hasCompletedOnboarding { return .skip }
+        if hasQuotaCaches || hasCLIQuotaAccount { return .markCompleted }
+        return .show
+    }
+
+    /// `decide` reduced to the one question the launch path asks.
+    public static func shouldShow(
+        settings: AppSettings,
+        hasQuotaCaches: Bool,
+        hasCLIQuotaAccount: Bool
+    ) -> Bool {
+        decide(
+            hasCompletedOnboarding: settings.hasCompletedOnboarding,
+            hasQuotaCaches: hasQuotaCaches,
+            hasCLIQuotaAccount: hasCLIQuotaAccount
+        ) == .show
+    }
+
+    /// Whether the quota cache directory holds at least one file. Dotfiles
+    /// are ignored: a `.DS_Store` left by Finder is not a quota snapshot.
+    /// One directory listing, so it is cheap enough for the launch path.
+    public static func hasQuotaCaches(
+        in directory: URL = VibeBarLocalStore.quotaDirectory,
+        fileManager: FileManager = .default
+    ) -> Bool {
+        guard let entries = try? fileManager.contentsOfDirectory(atPath: directory.path) else {
+            return false
+        }
+        return entries.contains { !$0.hasPrefix(".") }
+    }
+}

--- a/Tests/VibeBarCoreTests/AppSettingsTests.swift
+++ b/Tests/VibeBarCoreTests/AppSettingsTests.swift
@@ -201,6 +201,27 @@ final class AppSettingsTests: XCTestCase {
         XCTAssertEqual(settings.displayMode, .used)
     }
 
+    func testHasCompletedOnboardingDefaultsFalseAndRoundTrips() throws {
+        // A file written before the setup assistant existed carries no key;
+        // that decodes to `false` and it is `OnboardingGate`, not the decoder,
+        // that decides whether an upgrade counts as done.
+        let legacy = try JSONDecoder().decode(
+            AppSettings.self,
+            from: Data(#"{"displayMode":"remaining"}"#.utf8)
+        )
+        XCTAssertFalse(legacy.hasCompletedOnboarding)
+        XCTAssertFalse(AppSettings.default.hasCompletedOnboarding)
+
+        var settings = AppSettings.default
+        settings.hasCompletedOnboarding = true
+        let data = try JSONEncoder().encode(settings)
+        let decoded = try JSONDecoder().decode(AppSettings.self, from: data)
+        XCTAssertTrue(decoded.hasCompletedOnboarding)
+
+        let object = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        XCTAssertEqual(object["hasCompletedOnboarding"] as? Bool, true)
+    }
+
     func testSkillsSyncMethodDefaultsToAutoAndRoundTrips() throws {
         // `.auto` links where it can and copies where it cannot, which is the
         // only value that keeps every agent CLI reading one copy of a skill —

--- a/Tests/VibeBarCoreTests/DemoModeTests.swift
+++ b/Tests/VibeBarCoreTests/DemoModeTests.swift
@@ -137,6 +137,8 @@ final class DemoModeTests: XCTestCase {
         XCTAssertEqual(DemoMode.Surface(parsing: "mini:compact"), .miniWindow(mode: "compact"))
         XCTAssertEqual(DemoMode.Surface(parsing: " workbench:skillsManager "), .workbench(page: "skillsManager"))
         XCTAssertEqual(DemoMode.Surface(parsing: "settings:layout"), .settings(section: "layout"))
+        XCTAssertEqual(DemoMode.Surface(parsing: "onboarding"), .onboarding(step: ""))
+        XCTAssertEqual(DemoMode.Surface(parsing: "onboarding:subscriptions"), .onboarding(step: "subscriptions"))
         XCTAssertNil(DemoMode.Surface(parsing: "window:main"))
         XCTAssertNil(DemoMode.Surface(parsing: ""))
     }

--- a/Tests/VibeBarCoreTests/KeyboardFocusPolicyTests.swift
+++ b/Tests/VibeBarCoreTests/KeyboardFocusPolicyTests.swift
@@ -5,7 +5,7 @@ import XCTest
 /// The App target is an executable, so its views cannot be imported here;
 /// these tests read the sources instead. What they pin down:
 ///
-/// 1. Every presentation — the two hosting roots plus every `.sheet` and
+/// 1. Every presentation — the three hosting roots plus every `.sheet` and
 ///    `.popover` — opts into `vibeBarNoInitialFocus()`, so no surface opens
 ///    with a control pre-selected. Adding a presentation without the policy
 ///    breaks the count on purpose.
@@ -26,17 +26,20 @@ final class KeyboardFocusPolicyTests: XCTestCase {
             count += source.numberOfOccurrences(of: ".popover(isPresented")
         }
 
-        // The two AppKit hosting roots that can become key: the menu-bar
-        // popover and the Workbench window. The mini window's hosting root
-        // is deliberately absent — its panel is borderless and
-        // non-activating, so it never receives an initial responder.
+        // The three AppKit hosting roots that can become key: the menu-bar
+        // popover, the Workbench window and the setup assistant. The mini
+        // window's hosting root is deliberately absent — its panel is
+        // borderless and non-activating, so it never receives an initial
+        // responder.
         let popoverHost = try XCTUnwrap(sources["StatusItemController.swift"])
         let workbenchHost = try XCTUnwrap(sources["WorkbenchWindowController.swift"])
+        let onboardingHost = try XCTUnwrap(sources["OnboardingWindowController.swift"])
         let miniWindowHost = try XCTUnwrap(sources["MiniQuotaWindowController.swift"])
         XCTAssertEqual(popoverHost.numberOfOccurrences(of: ".vibeBarNoInitialFocus()"), 1)
         XCTAssertEqual(workbenchHost.numberOfOccurrences(of: ".vibeBarNoInitialFocus()"), 1)
+        XCTAssertEqual(onboardingHost.numberOfOccurrences(of: ".vibeBarNoInitialFocus()"), 1)
         XCTAssertEqual(miniWindowHost.numberOfOccurrences(of: ".vibeBarNoInitialFocus()"), 0)
-        let hostingRootCount = 2
+        let hostingRootCount = 3
 
         let policyCount = sources.values.reduce(0) {
             $0 + $1.numberOfOccurrences(of: ".vibeBarNoInitialFocus()")

--- a/Tests/VibeBarCoreTests/OnboardingGateTests.swift
+++ b/Tests/VibeBarCoreTests/OnboardingGateTests.swift
@@ -4,8 +4,9 @@ import XCTest
 /// The first-run assistant must open for a fresh install and never for an
 /// upgrade — and the only thing separating the two is what the install
 /// looks like, because the completion key did not exist before the
-/// assistant did. Only Vibe Bar's own evidence counts: a Codex or Claude
-/// CLI login on the Mac is what its users have *before* they install it.
+/// assistant did. Only Vibe Bar's own evidence counts — a quota cache, or a
+/// settings file that was already there at launch; a Codex or Claude CLI
+/// login on the Mac is what its users have *before* they install it.
 final class OnboardingGateTests: XCTestCase {
     private var temporaryDirectory: URL!
 
@@ -25,37 +26,50 @@ final class OnboardingGateTests: XCTestCase {
     /// Mac that already has Codex or Claude CLI credentials. The gate takes
     /// no such signal, so there is nothing for those credentials to change.
     func testFreshInstallShows() {
+        // No settings file before the store was built, no quota cache.
         XCTAssertEqual(
-            OnboardingGate.decide(hasCompletedOnboarding: false, hasQuotaCaches: false),
+            OnboardingGate.decide(hasCompletedOnboarding: false, hasQuotaCaches: false, hadSettingsFile: false),
             .show
         )
     }
 
     func testCompletedSkipsWhateverTheInstallLooksLike() {
         for caches in [false, true] {
-            XCTAssertEqual(
-                OnboardingGate.decide(hasCompletedOnboarding: true, hasQuotaCaches: caches),
-                .skip,
-                "caches=\(caches)"
-            )
+            for file in [false, true] {
+                XCTAssertEqual(
+                    OnboardingGate.decide(hasCompletedOnboarding: true, hasQuotaCaches: caches, hadSettingsFile: file),
+                    .skip,
+                    "caches=\(caches) file=\(file)"
+                )
+            }
         }
     }
 
     func testUnsetKeyOnAnExistingInstallMarksCompletedSilently() {
-        // A quota cache is proof the app has run here before, and the only
-        // proof the gate accepts.
+        // A quota cache is proof the app has run here before.
         XCTAssertEqual(
-            OnboardingGate.decide(hasCompletedOnboarding: false, hasQuotaCaches: true),
+            OnboardingGate.decide(hasCompletedOnboarding: false, hasQuotaCaches: true, hadSettingsFile: false),
+            .markCompleted
+        )
+        // So is a settings file that was on disk before this launch wrote
+        // one — the case of a user whose providers never produced a cache.
+        XCTAssertEqual(
+            OnboardingGate.decide(hasCompletedOnboarding: false, hasQuotaCaches: false, hadSettingsFile: true),
+            .markCompleted
+        )
+        XCTAssertEqual(
+            OnboardingGate.decide(hasCompletedOnboarding: false, hasQuotaCaches: true, hadSettingsFile: true),
             .markCompleted
         )
     }
 
     func testShouldShowReadsTheSettingsKey() {
         var settings = AppSettings.default
-        XCTAssertTrue(OnboardingGate.shouldShow(settings: settings, hasQuotaCaches: false))
-        XCTAssertFalse(OnboardingGate.shouldShow(settings: settings, hasQuotaCaches: true))
+        XCTAssertTrue(OnboardingGate.shouldShow(settings: settings, hasQuotaCaches: false, hadSettingsFile: false))
+        XCTAssertFalse(OnboardingGate.shouldShow(settings: settings, hasQuotaCaches: true, hadSettingsFile: false))
+        XCTAssertFalse(OnboardingGate.shouldShow(settings: settings, hasQuotaCaches: false, hadSettingsFile: true))
         settings.hasCompletedOnboarding = true
-        XCTAssertFalse(OnboardingGate.shouldShow(settings: settings, hasQuotaCaches: false))
+        XCTAssertFalse(OnboardingGate.shouldShow(settings: settings, hasQuotaCaches: false, hadSettingsFile: false))
     }
 
     // MARK: - The quota-cache probe

--- a/Tests/VibeBarCoreTests/OnboardingGateTests.swift
+++ b/Tests/VibeBarCoreTests/OnboardingGateTests.swift
@@ -1,0 +1,94 @@
+import XCTest
+@testable import VibeBarCore
+
+/// The first-run assistant must open for a fresh install and never for an
+/// upgrade — and the only thing separating the two is what the install
+/// looks like, because the completion key did not exist before the
+/// assistant did.
+final class OnboardingGateTests: XCTestCase {
+    private var temporaryDirectory: URL!
+
+    override func setUpWithError() throws {
+        temporaryDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("vibebar-onboarding-gate-tests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: temporaryDirectory, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: temporaryDirectory)
+    }
+
+    // MARK: - The rule
+
+    func testFreshInstallShows() {
+        XCTAssertEqual(
+            OnboardingGate.decide(hasCompletedOnboarding: false, hasQuotaCaches: false, hasCLIQuotaAccount: false),
+            .show
+        )
+    }
+
+    func testCompletedSkipsWhateverTheInstallLooksLike() {
+        for caches in [false, true] {
+            for account in [false, true] {
+                XCTAssertEqual(
+                    OnboardingGate.decide(hasCompletedOnboarding: true, hasQuotaCaches: caches, hasCLIQuotaAccount: account),
+                    .skip,
+                    "caches=\(caches) account=\(account)"
+                )
+            }
+        }
+    }
+
+    func testUnsetKeyOnAnExistingInstallMarksCompletedSilently() {
+        // Quota caches alone are proof the app has run here before.
+        XCTAssertEqual(
+            OnboardingGate.decide(hasCompletedOnboarding: false, hasQuotaCaches: true, hasCLIQuotaAccount: false),
+            .markCompleted
+        )
+        // So is a Codex / Claude account the launch path could already resolve.
+        XCTAssertEqual(
+            OnboardingGate.decide(hasCompletedOnboarding: false, hasQuotaCaches: false, hasCLIQuotaAccount: true),
+            .markCompleted
+        )
+        XCTAssertEqual(
+            OnboardingGate.decide(hasCompletedOnboarding: false, hasQuotaCaches: true, hasCLIQuotaAccount: true),
+            .markCompleted
+        )
+    }
+
+    func testShouldShowReadsTheSettingsKey() {
+        var settings = AppSettings.default
+        XCTAssertTrue(OnboardingGate.shouldShow(settings: settings, hasQuotaCaches: false, hasCLIQuotaAccount: false))
+        XCTAssertFalse(OnboardingGate.shouldShow(settings: settings, hasQuotaCaches: true, hasCLIQuotaAccount: false))
+        XCTAssertFalse(OnboardingGate.shouldShow(settings: settings, hasQuotaCaches: false, hasCLIQuotaAccount: true))
+        settings.hasCompletedOnboarding = true
+        XCTAssertFalse(OnboardingGate.shouldShow(settings: settings, hasQuotaCaches: false, hasCLIQuotaAccount: false))
+    }
+
+    // MARK: - The quota-cache probe
+
+    func testMissingQuotaDirectoryHasNoCaches() {
+        let missing = temporaryDirectory.appendingPathComponent("quotas", isDirectory: true)
+        XCTAssertFalse(OnboardingGate.hasQuotaCaches(in: missing))
+    }
+
+    func testEmptyQuotaDirectoryHasNoCaches() throws {
+        let quotas = temporaryDirectory.appendingPathComponent("quotas", isDirectory: true)
+        try FileManager.default.createDirectory(at: quotas, withIntermediateDirectories: true)
+        XCTAssertFalse(OnboardingGate.hasQuotaCaches(in: quotas))
+    }
+
+    func testDotfilesAloneDoNotCountAsCaches() throws {
+        let quotas = temporaryDirectory.appendingPathComponent("quotas", isDirectory: true)
+        try FileManager.default.createDirectory(at: quotas, withIntermediateDirectories: true)
+        try Data().write(to: quotas.appendingPathComponent(".DS_Store"))
+        XCTAssertFalse(OnboardingGate.hasQuotaCaches(in: quotas))
+    }
+
+    func testAnyCacheFileCounts() throws {
+        let quotas = temporaryDirectory.appendingPathComponent("quotas", isDirectory: true)
+        try FileManager.default.createDirectory(at: quotas, withIntermediateDirectories: true)
+        try Data("{}".utf8).write(to: quotas.appendingPathComponent("cli-codex.json"))
+        XCTAssertTrue(OnboardingGate.hasQuotaCaches(in: quotas))
+    }
+}

--- a/Tests/VibeBarCoreTests/OnboardingGateTests.swift
+++ b/Tests/VibeBarCoreTests/OnboardingGateTests.swift
@@ -4,7 +4,8 @@ import XCTest
 /// The first-run assistant must open for a fresh install and never for an
 /// upgrade — and the only thing separating the two is what the install
 /// looks like, because the completion key did not exist before the
-/// assistant did.
+/// assistant did. Only Vibe Bar's own evidence counts: a Codex or Claude
+/// CLI login on the Mac is what its users have *before* they install it.
 final class OnboardingGateTests: XCTestCase {
     private var temporaryDirectory: URL!
 
@@ -20,49 +21,41 @@ final class OnboardingGateTests: XCTestCase {
 
     // MARK: - The rule
 
+    /// A clean install shows the assistant — including, and especially, on a
+    /// Mac that already has Codex or Claude CLI credentials. The gate takes
+    /// no such signal, so there is nothing for those credentials to change.
     func testFreshInstallShows() {
         XCTAssertEqual(
-            OnboardingGate.decide(hasCompletedOnboarding: false, hasQuotaCaches: false, hasCLIQuotaAccount: false),
+            OnboardingGate.decide(hasCompletedOnboarding: false, hasQuotaCaches: false),
             .show
         )
     }
 
     func testCompletedSkipsWhateverTheInstallLooksLike() {
         for caches in [false, true] {
-            for account in [false, true] {
-                XCTAssertEqual(
-                    OnboardingGate.decide(hasCompletedOnboarding: true, hasQuotaCaches: caches, hasCLIQuotaAccount: account),
-                    .skip,
-                    "caches=\(caches) account=\(account)"
-                )
-            }
+            XCTAssertEqual(
+                OnboardingGate.decide(hasCompletedOnboarding: true, hasQuotaCaches: caches),
+                .skip,
+                "caches=\(caches)"
+            )
         }
     }
 
     func testUnsetKeyOnAnExistingInstallMarksCompletedSilently() {
-        // Quota caches alone are proof the app has run here before.
+        // A quota cache is proof the app has run here before, and the only
+        // proof the gate accepts.
         XCTAssertEqual(
-            OnboardingGate.decide(hasCompletedOnboarding: false, hasQuotaCaches: true, hasCLIQuotaAccount: false),
-            .markCompleted
-        )
-        // So is a Codex / Claude account the launch path could already resolve.
-        XCTAssertEqual(
-            OnboardingGate.decide(hasCompletedOnboarding: false, hasQuotaCaches: false, hasCLIQuotaAccount: true),
-            .markCompleted
-        )
-        XCTAssertEqual(
-            OnboardingGate.decide(hasCompletedOnboarding: false, hasQuotaCaches: true, hasCLIQuotaAccount: true),
+            OnboardingGate.decide(hasCompletedOnboarding: false, hasQuotaCaches: true),
             .markCompleted
         )
     }
 
     func testShouldShowReadsTheSettingsKey() {
         var settings = AppSettings.default
-        XCTAssertTrue(OnboardingGate.shouldShow(settings: settings, hasQuotaCaches: false, hasCLIQuotaAccount: false))
-        XCTAssertFalse(OnboardingGate.shouldShow(settings: settings, hasQuotaCaches: true, hasCLIQuotaAccount: false))
-        XCTAssertFalse(OnboardingGate.shouldShow(settings: settings, hasQuotaCaches: false, hasCLIQuotaAccount: true))
+        XCTAssertTrue(OnboardingGate.shouldShow(settings: settings, hasQuotaCaches: false))
+        XCTAssertFalse(OnboardingGate.shouldShow(settings: settings, hasQuotaCaches: true))
         settings.hasCompletedOnboarding = true
-        XCTAssertFalse(OnboardingGate.shouldShow(settings: settings, hasQuotaCaches: false, hasCLIQuotaAccount: false))
+        XCTAssertFalse(OnboardingGate.shouldShow(settings: settings, hasQuotaCaches: false))
     }
 
     // MARK: - The quota-cache probe


### PR DESCRIPTION
## Summary
- New `OnboardingWindowController` + `OnboardingView` (720×560, flat cards, Workbench chrome): Welcome → Subscriptions → Browser cookies → API-key providers → Model pricing → Launch at login → All set, with Back / Skip for now / Continue (Finish on the last step).
- Every step reuses existing machinery: `setCoreProviderVisible` / `isCoreProviderVisible`, the four `import…BrowserCookies()` + `open…WebLogin()` actions with their `is…Importing` / `…ImportStatus` state, `setMiscProviderInstanceVisible`, `ApiKeyField` / `CookieSourceControls` etc. via the new shared `MiscProviderCredentialRows` (lifted out of `MiscProviderSettingsSection`, no new Keychain path), `refreshPricingNow()` + `pricingRefreshStatus`, and `LoginItemController.reconcileDesiredState(_:)`.
- `AppSettings.hasCompletedOnboarding` (default `false`, missing key → `false`, encoded on write). Decision rule lives in Core as `OnboardingGate.decide(hasCompletedOnboarding:hasQuotaCaches:hadSettingsFile:)` and takes only Vibe Bar-owned evidence: completed → skip; not completed but `~/.vibebar/quotas/` already holds a cache **or** `settings.json` existed before this launch's `SettingsStore` was built → mark completed silently (existing users never see it); otherwise show. `AppDelegate` samples the settings-file check before constructing `AppEnvironment`, because loading the store writes the file back. CLI credentials on the Mac are deliberately not a signal — they say the user runs Codex/Claude, not that they have run Vibe Bar (see review threads). `OnboardingGate.hasQuotaCaches(in:)` is a single directory listing that ignores dotfiles. Wired in `AppDelegate.applicationDidFinishLaunching` right after the status item is built, non-demo path only.
- Finish sets the flag, closes the window, calls `refreshAll()` and opens the compact popover through a new `StatusItemController.presentCompactPopover()` (the click path's open logic, extracted). Skip / closing the window record completion without opening the popover.
- Settings → System: "Show setup assistant" (`environment.showOnboarding()`, resets nothing).
- Demo surface: `DemoMode.Surface.onboarding(step:)` parsed from `onboarding` / `onboarding:<step>`, handled in `DemoPresenter`; `onboarding=onboarding=both` added to `SURFACES` in `Scripts/capture_demo_screenshots.sh`; AGENTS.md § 6.5 surface list updated. In demo the login-item step neither registers nor reads `SMAppService`.
- `KeyboardFocusPolicyTests` now counts the assistant as the third hosting root.

## Test plan
- [x] `swift build`
- [x] `swift test` — 1782 tests, 0 failures (new: `OnboardingGateTests` ×8, `testHasCompletedOnboardingDefaultsFalseAndRoundTrips`, onboarding surface parse cases in `DemoModeTests`)
- [x] `./Scripts/build_app.sh release`
- [x] `codesign -d --entitlements - ".build/Vibe Bar.app"` → empty `<dict/>`, no `app-sandbox`; `codesign --verify --deep --strict` clean; no `~/Library/Containers/com.astroqore.VibeBar` created
- [x] Home-API grep (`NSHomeDirectory()` etc.) — no hits outside `RealHomeDirectory`; `glassEffect` / materials / `.shadow(` — no new hits
- [x] Demo-mode captures of all seven steps in both appearances via `./Scripts/demo_home.py` + `./Scripts/capture_demo_screenshots.sh /tmp/onboarding-shots onboarding onboarding:subscriptions … onboarding:done`; inspected each PNG, fixed the title-bar inset, the disabled "Set up" pill and the demo login-item status text, recaptured
- [ ] Not run against the real home (by design); a real first-launch smoke test on a machine without `~/.vibebar/quotas/` and without Codex/Claude credentials is still worth doing before release

🤖 Generated with [Claude Code](https://claude.com/claude-code)

