### PR TITLE
Record reset cycles for Cursor and index the subscription history

### DIFF
--- a/Sources/VibeBarCore/Adapters/CursorSessionResolver.swift
+++ b/Sources/VibeBarCore/Adapters/CursorSessionResolver.swift
@@ -14,6 +14,13 @@ struct CursorSessionResolutionPlan: Sendable {
 /// out, and preserve the existing `misc-cursor` Keychain account during the
 /// move from the Misc page into the SpaceXAI provider family.
 enum CursorSessionResolver {
+    /// Still built by `AccountStore.miscAccountId` even though Cursor is no
+    /// longer a Misc-page provider. The value (`misc-cursor`) is the account
+    /// id already written into `accounts.json`, the Keychain items, the fill
+    /// timeline, the forecast timeline, and the subscription history — the
+    /// helper is a naming accident, not a claim about the tier. Renaming it
+    /// would orphan every one of those caches, so it stays as-is; the tier
+    /// question is answered by `ToolType.supportsDedicatedCard`, not here.
     static let stableAccountID = AccountStore.miscAccountId(for: .cursor)
 
     static func plan(

--- a/Sources/VibeBarCore/Models/ProviderPlanDisplay.swift
+++ b/Sources/VibeBarCore/Models/ProviderPlanDisplay.swift
@@ -11,7 +11,16 @@ public enum ProviderPlanDisplay {
             return prefixed(codexDisplayName(rawPlan), brand: "Google AI")
         case .grok:
             return grokDisplayName(rawPlan)
-        case .alibaba, .alibabaTokenPlan, .copilot, .zai, .minimax, .kimi, .cursor, .mimo, .iflytek, .tencentHunyuan, .tencentTokenPlan, .volcengine, .volcengineAgentPlan, .baiduQianfan, .openCodeGo, .kilo, .kiro, .ollama, .openRouter, .warp:
+        case .cursor:
+            // Cursor left the Misc bucket when it became a dedicated card in
+            // the SpaceXAI family, so it gets its own case rather than
+            // riding on the misc fall-through. `CursorQuotaAdapter`
+            // already normalizes `membershipType` (`ultra` -> `Ultra`,
+            // `free_trial` -> `Free Trial`), so the generic formatter is
+            // still the right one and the rendered names do not change.
+            // No brand prefix: the card is already titled "Cursor".
+            return codexDisplayName(rawPlan)
+        case .alibaba, .alibabaTokenPlan, .copilot, .zai, .minimax, .kimi, .mimo, .iflytek, .tencentHunyuan, .tencentTokenPlan, .volcengine, .volcengineAgentPlan, .baiduQianfan, .openCodeGo, .kilo, .kiro, .ollama, .openRouter, .warp:
             // Misc providers feed `plan` straight through. Each adapter
             // is responsible for normalizing the raw API response
             // (e.g. `Pro Coding` → `Pro`) before it reaches this map.

--- a/Sources/VibeBarCore/Models/ToolType.swift
+++ b/Sources/VibeBarCore/Models/ToolType.swift
@@ -116,17 +116,18 @@ public enum ToolType: String, Codable, CaseIterable, Hashable, Sendable {
         allCases.filter { $0.isMisc }
     }
 
-    public static var dedicatedCardProviders: [ToolType] {
+    /// Stored, not computed: SwiftUI `body` reads these on every render, and
+    /// a `var` re-ran `allCases.filter` each time. The membership predicates
+    /// are compile-time switches over a fixed enum, so the answer cannot
+    /// change at runtime.
+    public static let dedicatedCardProviders: [ToolType] =
         allCases.filter { $0.supportsDedicatedCard }
-    }
 
-    public static var partialPrimaryProviders: [ToolType] {
+    public static let partialPrimaryProviders: [ToolType] =
         allCases.filter { $0.isPartialPrimary }
-    }
 
-    public static var costAwareProviders: [ToolType] {
+    public static let costAwareProviders: [ToolType] =
         allCases.filter { $0.supportsTokenCost }
-    }
 
     /// Provider keys exposed by the Workbench usage ledger. Cursor dashboard
     /// events are a source inside the SpaceXAI provider total, matching the
@@ -134,7 +135,7 @@ public enum ToolType: String, Codable, CaseIterable, Hashable, Sendable {
     /// total — which is exactly the set that can be priced per token, so this
     /// is `costAwareProviders`. It stays a separate name because the two
     /// answer different questions and could diverge again.
-    public static var usageStatsProviders: [ToolType] { costAwareProviders }
+    public static let usageStatsProviders: [ToolType] = costAwareProviders
 
     public static var statusPageProviders: [ToolType] {
         allCases.filter { $0.supportsStatusPage }
@@ -178,9 +179,8 @@ public enum ToolType: String, Codable, CaseIterable, Hashable, Sendable {
         }
     }
 
-    public static var miscPageProviders: [ToolType] {
+    public static let miscPageProviders: [ToolType] =
         allCases.filter { $0.isMiscPageProvider }
-    }
 
     /// The two Google AI providers that render side-by-side in the
     /// Overview popover's "Google AI" page.

--- a/Sources/VibeBarCore/Services/SubscriptionHistoryStore.swift
+++ b/Sources/VibeBarCore/Services/SubscriptionHistoryStore.swift
@@ -338,7 +338,13 @@ public actor SubscriptionHistoryStore {
                             bucketId: first.bucketId,
                             windowEnd: point.sampledAt,
                             windowStart: segmentStart,
-                            rawWindowSeconds: nil,
+                            // The window the provider reported while this
+                            // cycle was live. Cursor's weekly bucket has
+                            // reported 13-, 156- and 168-hour windows, and
+                            // ResetsPage sorts a cycle into the sub-daily lane
+                            // or the month calendar by this value; `nil` here
+                            // would file a recovered 13-hour cycle as a day.
+                            rawWindowSeconds: previous.rawWindowSeconds ?? point.rawWindowSeconds,
                             peakUsedPercent: peak,
                             lastUsedPercent: clamp(previous.usedPercent),
                             observationCount: 1,

--- a/Sources/VibeBarCore/Services/SubscriptionHistoryStore.swift
+++ b/Sources/VibeBarCore/Services/SubscriptionHistoryStore.swift
@@ -18,17 +18,25 @@ public actor SubscriptionHistoryStore {
         /// because they required a five-point usage drop. Optional keeps
         /// schema-v2 files backward compatible.
         var resetSignalRepairVersion: Int?
+        /// One-time backfill for lanes that only became eligible once
+        /// `supportedTools` grew. Separate from the two flags above because
+        /// those record work that has already run to completion; this one
+        /// records which *providers* have been reached into the retained fill
+        /// timeline for. Optional keeps older files decodable.
+        var promotedProviderBackfillVersion: Int?
         var samples: [SubscriptionWindowSample]
 
         init(
             schemaVersion: Int = SubscriptionHistoryStore.storageSchemaVersion,
             legacyTimelineImported: Bool = false,
             resetSignalRepairVersion: Int? = nil,
+            promotedProviderBackfillVersion: Int? = nil,
             samples: [SubscriptionWindowSample] = []
         ) {
             self.schemaVersion = schemaVersion
             self.legacyTimelineImported = legacyTimelineImported
             self.resetSignalRepairVersion = resetSignalRepairVersion
+            self.promotedProviderBackfillVersion = promotedProviderBackfillVersion
             self.samples = samples
         }
     }
@@ -37,6 +45,15 @@ public actor SubscriptionHistoryStore {
 
     private let fileURL: URL
     private var cachedStorage: Storage?
+    /// Positions in `cachedStorage.samples`, keyed by account + bucket.
+    ///
+    /// Retention is commonly unlimited, so the array only ever grows — a
+    /// couple of months of five core providers is already ~900 samples — and
+    /// both hot paths used to walk all of it: `observe` once per bucket
+    /// (~30 buckets per refresh) and `samples` once per bucket on every
+    /// popover render. `nil` means "not built yet"; anything that reshuffles
+    /// the array clears it and the next reader rebuilds one.
+    private var cachedIndex: [SubscriptionHistoryKey: [Int]]?
     private var lastSavedAt: Date?
     private var pendingFlushTask: Task<Void, Never>?
     private var pendingStorage: Storage?
@@ -45,6 +62,18 @@ public actor SubscriptionHistoryStore {
     private static let saveThrottleInterval: TimeInterval = 30
     private static let maxFileBytes = 16 * 1024 * 1024
     private static let currentResetSignalRepairVersion = 1
+    /// Bump when a provider joins `supportedTools` after users already have
+    /// history on disk, and list its tools under the new version below.
+    private static let currentPromotedProviderBackfillVersion = 1
+    /// Which lanes each backfill version has to recover from the retained
+    /// fill timeline. Version 1 is Cursor: it was promoted out of the Misc
+    /// page into the SpaceXAI family, but `supportedTools` was a hand-written
+    /// literal that did not follow, so every Cursor cycle since the promotion
+    /// was discarded here while `UsageFillTimelineStore` — whose own list did
+    /// include Cursor — kept recording the observations behind it.
+    private static let promotedProviderBackfillTools: [Int: Set<ToolType>] = [
+        1: [.cursor]
+    ]
     /// How early is early, and how close a new reset has to be to count as
     /// restarted or unchanged. A tenth of the window on each side: wide enough
     /// to absorb the minute or two a provider takes to publish a new boundary,
@@ -55,9 +84,16 @@ public actor SubscriptionHistoryStore {
     private static let weakResetAdvanceFraction = 0.01
     private static let minimumStrongUsageDrop = 0.5
     private static let minimumWeakUsageDrop = 0.25
-    private static let supportedTools: Set<ToolType> = [
-        .codex, .claude, .gemini, .antigravity, .grok
-    ]
+    /// Every provider that gets a dedicated card, derived rather than listed.
+    ///
+    /// The literal this replaced is what hid Cursor's reset history: Cursor
+    /// became a dedicated-card member of the SpaceXAI family and nobody
+    /// remembered this set, so its cards said "Waiting for the first quota
+    /// observation" while the fill timeline quietly banked hundreds of
+    /// observations of the same buckets. Deriving it means the next promotion
+    /// cannot repeat that. `UsageFillTimelineStore` and
+    /// `UsageForecastTimelineStore` cover exactly the same providers.
+    private static let supportedTools = Set(ToolType.dedicatedCardProviders)
 
     public init(fileURL: URL = SubscriptionHistoryStore.defaultFileURL()) {
         self.fileURL = fileURL
@@ -77,20 +113,20 @@ public actor SubscriptionHistoryStore {
     ) {
         guard Self.supportedTools.contains(quota.tool) else { return }
 
-        var storage = load()
+        var (storage, index) = loadIndexed()
         var dirty = false
         for bucket in quota.buckets {
             guard let resetAt = bucket.resetAt, bucket.usedPercent.isFinite else { continue }
             let used = clamp(bucket.usedPercent)
-            let currentIndex = storage.samples.indices
-                .filter {
-                    storage.samples[$0].accountId == quota.accountId
-                        && storage.samples[$0].bucketId == bucket.id
-                        && !storage.samples[$0].isCompleted
-                }
+            let key = SubscriptionHistoryKey(accountId: quota.accountId, bucketId: bucket.id)
+            // This bucket's own samples, not the whole file.
+            let positions = index[key] ?? []
+            let currentIndex = positions
+                .filter { !storage.samples[$0].isCompleted }
                 .max { storage.samples[$0].lastSeenAt < storage.samples[$1].lastSeenAt }
 
             guard let currentIndex else {
+                index[key, default: []].append(storage.samples.count)
                 storage.samples.append(makeCurrentSample(
                     quota: quota,
                     bucket: bucket,
@@ -120,16 +156,19 @@ public actor SubscriptionHistoryStore {
                     observedAt: now,
                     rawWindowSeconds: current.rawWindowSeconds
                 )
+                // Read before `current` is written back, so the cycle that is
+                // closing right now is still open in the array and excludes
+                // itself — as it did when this scanned every sample.
                 current.intervalSeconds = Self.previousRefill(
                     in: storage.samples,
-                    accountId: quota.accountId,
-                    bucketId: bucket.id,
+                    positions: positions,
                     before: now
                 ).map { now.timeIntervalSince($0) }
                 // The observed refill time is more useful than a stale reset
                 // forecast when providers reset early or late.
                 current.windowEnd = now
                 storage.samples[currentIndex] = current
+                index[key, default: []].append(storage.samples.count)
                 storage.samples.append(makeCurrentSample(
                     quota: quota,
                     bucket: bucket,
@@ -153,8 +192,10 @@ public actor SubscriptionHistoryStore {
         }
 
         guard dirty else { return }
-        pruneInPlace(&storage, retentionDays: retentionDays, now: now)
-        save(storage)
+        // Pruning renumbers everything left; anything else kept the index in
+        // step above and can hand it straight back.
+        let pruned = pruneInPlace(&storage, retentionDays: retentionDays, now: now)
+        save(storage, index: pruned ? nil : index)
     }
 
     /// One-time best-effort migration from the old hourly fill timeline.
@@ -169,10 +210,17 @@ public actor SubscriptionHistoryStore {
         let needsLegacyImport = !storage.legacyTimelineImported
         let needsResetSignalRepair = (storage.resetSignalRepairVersion ?? 0)
             < Self.currentResetSignalRepairVersion
+        let backfillTools = Self.promotedProviderBackfillTools(
+            after: storage.promotedProviderBackfillVersion ?? 0
+        )
+        let needsPromotedBackfill = (storage.promotedProviderBackfillVersion ?? 0)
+            < Self.currentPromotedProviderBackfillVersion
         let needsClassification = storage.samples.contains {
             $0.isCompleted && $0.resetKind == nil
         }
-        guard needsLegacyImport || needsResetSignalRepair || needsClassification else { return }
+        guard needsLegacyImport || needsResetSignalRepair
+                || needsPromotedBackfill || needsClassification
+        else { return }
 
         if needsLegacyImport {
             storage.legacyTimelineImported = true
@@ -182,6 +230,40 @@ public actor SubscriptionHistoryStore {
         if needsResetSignalRepair {
             repairMissedResetSignals(points, in: &storage)
             storage.resetSignalRepairVersion = Self.currentResetSignalRepairVersion
+        }
+
+        if needsPromotedBackfill {
+            // Existing installs already carry `legacyTimelineImported: true`
+            // and a current `resetSignalRepairVersion`, so the two passes
+            // above will never run again — and neither of them ever saw a
+            // Cursor point, because the whitelist they filter on excluded it.
+            // Replay them for the newly eligible lanes only, in the same
+            // order a fresh install runs them, so the refill pass lays down
+            // the obvious cycles and the reset-signal pass fills in the
+            // low-utilization ones without duplicating them.
+            //
+            // Skipped where the full pass has just run in this very call:
+            // `supportedTools` now includes the promoted lanes, so a fresh
+            // install has already covered them and a second, narrower pass
+            // would append the same cycles twice.
+            //
+            // Narrowed to the promoted lanes' own points first: the timeline
+            // is tens of thousands of rows across every provider, and grouping
+            // all of them to then throw away everything but Cursor made a
+            // launch-time pass out of a few hundred rows' work.
+            if !backfillTools.isEmpty {
+                let owned = points.filter { backfillTools.contains($0.tool) }
+                if !needsLegacyImport {
+                    importMaterialRefills(
+                        owned, into: &storage,
+                        limitedTo: backfillTools, skippingExisting: true
+                    )
+                }
+                if !needsResetSignalRepair {
+                    repairMissedResetSignals(owned, in: &storage, limitedTo: backfillTools)
+                }
+            }
+            storage.promotedProviderBackfillVersion = Self.currentPromotedProviderBackfillVersion
         }
         // Cycles finished before the app classified refills carry no answer.
         // Cheap to fill in, and worth doing rather than waiting: the chart
@@ -199,34 +281,73 @@ public actor SubscriptionHistoryStore {
         save(storage)
     }
 
-    private func importMaterialRefills(_ points: [FillTimelinePoint], into storage: inout Storage) {
+    /// Lanes still owed a backfill, for a file stamped with `storedVersion`.
+    ///
+    /// The union of every version above the stored one, so a user who skips
+    /// a release is not skipped along with it.
+    private static func promotedProviderBackfillTools(
+        after storedVersion: Int
+    ) -> Set<ToolType> {
+        guard storedVersion < currentPromotedProviderBackfillVersion else { return [] }
+        var tools: Set<ToolType> = []
+        for version in (storedVersion + 1)...currentPromotedProviderBackfillVersion {
+            tools.formUnion(promotedProviderBackfillTools[version] ?? [])
+        }
+        // A lane that has since been demoted out of `supportedTools` would
+        // import cycles nothing will ever display or extend.
+        return tools.intersection(supportedTools)
+    }
+
+    /// `skippingExisting` is for the backfill, which runs against a store
+    /// that already holds history rather than an empty one. Two clients share
+    /// this file (AGENTS.md § 11) and the older one drops a version key it
+    /// does not know, so the flag alone cannot be the only thing standing
+    /// between a re-run and a doubled chart — a cycle already recorded near
+    /// this refill is left alone on its own evidence.
+    private func importMaterialRefills(
+        _ points: [FillTimelinePoint],
+        into storage: inout Storage,
+        limitedTo tools: Set<ToolType>? = nil,
+        skippingExisting: Bool = false
+    ) {
+        let eligible = tools ?? Self.supportedTools
         let grouped = Dictionary(grouping: points) {
             SubscriptionHistoryKey(accountId: $0.accountId, bucketId: $0.bucketId)
         }
         for (_, rawPoints) in grouped {
             let sorted = rawPoints.sorted { $0.sampledAt < $1.sampledAt }
-            guard let first = sorted.first, Self.supportedTools.contains(first.tool) else { continue }
+            guard let first = sorted.first, eligible.contains(first.tool) else { continue }
             var peak = clamp(first.usedPercent)
             var previous = first
             var segmentStart = first.sampledAt
             for point in sorted.dropFirst() {
                 let currentUsed = clamp(point.usedPercent)
                 if Self.isMaterialRefill(previous: previous.usedPercent, peak: peak, current: currentUsed) {
-                    storage.samples.append(SubscriptionWindowSample(
+                    // The boundary is a boundary either way; only the record
+                    // of it is skipped when one is already there.
+                    if !skippingExisting || !hasNearbyCompletedSample(
                         accountId: first.accountId,
-                        tool: first.tool,
                         bucketId: first.bucketId,
-                        windowEnd: point.sampledAt,
-                        windowStart: segmentStart,
-                        rawWindowSeconds: nil,
-                        peakUsedPercent: peak,
-                        lastUsedPercent: clamp(previous.usedPercent),
-                        observationCount: 1,
-                        firstSeenAt: segmentStart,
-                        lastSeenAt: previous.sampledAt,
                         completedAt: point.sampledAt,
-                        completionReason: .legacyTimelineMigration
-                    ))
+                        windowSeconds: point.rawWindowSeconds ?? previous.rawWindowSeconds,
+                        in: storage.samples
+                    ) {
+                        storage.samples.append(SubscriptionWindowSample(
+                            accountId: first.accountId,
+                            tool: first.tool,
+                            bucketId: first.bucketId,
+                            windowEnd: point.sampledAt,
+                            windowStart: segmentStart,
+                            rawWindowSeconds: nil,
+                            peakUsedPercent: peak,
+                            lastUsedPercent: clamp(previous.usedPercent),
+                            observationCount: 1,
+                            firstSeenAt: segmentStart,
+                            lastSeenAt: previous.sampledAt,
+                            completedAt: point.sampledAt,
+                            completionReason: .legacyTimelineMigration
+                        ))
+                    }
                     segmentStart = point.sampledAt
                     peak = currentUsed
                 } else {
@@ -314,8 +435,10 @@ public actor SubscriptionHistoryStore {
 
     private func repairMissedResetSignals(
         _ points: [FillTimelinePoint],
-        in storage: inout Storage
+        in storage: inout Storage,
+        limitedTo tools: Set<ToolType>? = nil
     ) {
+        let eligible = tools ?? Self.supportedTools
         let grouped = Dictionary(grouping: points) {
             SubscriptionHistoryKey(accountId: $0.accountId, bucketId: $0.bucketId)
         }
@@ -323,7 +446,7 @@ public actor SubscriptionHistoryStore {
             let sorted = rawPoints.sorted { $0.sampledAt < $1.sampledAt }
             guard let first = sorted.first,
                   sorted.count > 1,
-                  Self.supportedTools.contains(first.tool)
+                  eligible.contains(first.tool)
             else { continue }
 
             var previous = first
@@ -460,10 +583,15 @@ public actor SubscriptionHistoryStore {
         includeCurrent: Bool = true,
         limit: Int? = nil
     ) -> [SubscriptionWindowSample] {
-        var matching = load().samples.filter {
-            $0.accountId == accountId
-                && $0.bucketId == bucketId
-                && (includeCurrent || $0.isCompleted)
+        let (storage, index) = loadIndexed()
+        let key = SubscriptionHistoryKey(accountId: accountId, bucketId: bucketId)
+        guard let positions = index[key] else { return [] }
+        // Positions are ascending, so `sort` is handed the same sequence the
+        // whole-array filter used to produce and returns the same order.
+        var matching = positions.compactMap { position -> SubscriptionWindowSample? in
+            let sample = storage.samples[position]
+            guard includeCurrent || sample.isCompleted else { return nil }
+            return sample
         }
         matching.sort { sampleSortDate($0) > sampleSortDate($1) }
         if let limit, matching.count > limit {
@@ -482,6 +610,7 @@ public actor SubscriptionHistoryStore {
 
     public func eraseAll() {
         cachedStorage = Storage()
+        cachedIndex = [:]
         pendingStorage = nil
         pendingFlushTask?.cancel()
         pendingFlushTask = nil
@@ -611,17 +740,17 @@ public actor SubscriptionHistoryStore {
     }
 
     /// When this bucket last refilled, for the gap between refills.
+    ///
+    /// `positions` are the caller's index entries for one account + bucket,
+    /// so the account and bucket have already been matched.
     private static func previousRefill(
         in samples: [SubscriptionWindowSample],
-        accountId: String,
-        bucketId: String,
+        positions: [Int],
         before: Date
     ) -> Date? {
-        samples
-            .filter {
-                $0.accountId == accountId && $0.bucketId == bucketId
-                    && $0.isCompleted && $0.windowEnd < before
-            }
+        positions.lazy
+            .map { samples[$0] }
+            .filter { $0.isCompleted && $0.windowEnd < before }
             .map(\.windowEnd)
             .max()
     }
@@ -681,6 +810,7 @@ public actor SubscriptionHistoryStore {
            size > Self.maxFileBytes {
             let empty = Storage()
             cachedStorage = empty
+            cachedIndex = [:]
             return empty
         }
         guard let data = try? Data(contentsOf: fileURL),
@@ -690,14 +820,43 @@ public actor SubscriptionHistoryStore {
         else {
             let empty = Storage()
             cachedStorage = empty
+            cachedIndex = [:]
             return empty
         }
         cachedStorage = storage
+        cachedIndex = nil
         return storage
     }
 
-    private func save(_ storage: Storage) {
+    /// The cached storage together with the sample positions of each
+    /// account + bucket, building the index on first use.
+    private func loadIndexed() -> (Storage, [SubscriptionHistoryKey: [Int]]) {
+        let storage = load()
+        if let cachedIndex { return (storage, cachedIndex) }
+        let built = Self.buildIndex(storage.samples)
+        cachedIndex = built
+        return (storage, built)
+    }
+
+    private static func buildIndex(
+        _ samples: [SubscriptionWindowSample]
+    ) -> [SubscriptionHistoryKey: [Int]] {
+        var index: [SubscriptionHistoryKey: [Int]] = [:]
+        for position in samples.indices {
+            let sample = samples[position]
+            let key = SubscriptionHistoryKey(
+                accountId: sample.accountId, bucketId: sample.bucketId
+            )
+            index[key, default: []].append(position)
+        }
+        return index
+    }
+
+    /// `index` is the caller's, kept in step with `storage`; passing `nil`
+    /// (the default) drops the cached one and the next reader rebuilds it.
+    private func save(_ storage: Storage, index: [SubscriptionHistoryKey: [Int]]? = nil) {
         cachedStorage = storage
+        cachedIndex = index
         let now = Date()
         if let last = lastSavedAt, now.timeIntervalSince(last) < Self.saveThrottleInterval {
             pendingStorage = storage
@@ -728,12 +887,17 @@ public actor SubscriptionHistoryStore {
         }
     }
 
-    private func pruneInPlace(_ storage: inout Storage, retentionDays: Int, now: Date) {
-        guard !CostDataSettings.isUnlimitedRetention(retentionDays) else { return }
+    /// Returns true when samples were dropped, which invalidates every
+    /// position an index is holding.
+    @discardableResult
+    private func pruneInPlace(_ storage: inout Storage, retentionDays: Int, now: Date) -> Bool {
+        guard !CostDataSettings.isUnlimitedRetention(retentionDays) else { return false }
         let cutoff = now.addingTimeInterval(-TimeInterval(retentionDays) * 86_400)
+        let before = storage.samples.count
         storage.samples.removeAll {
             let relevantDate = $0.completedAt ?? $0.lastSeenAt
             return relevantDate < cutoff
         }
+        return storage.samples.count != before
     }
 }

--- a/Tests/VibeBarCoreTests/SubscriptionHistoryStoreTests.swift
+++ b/Tests/VibeBarCoreTests/SubscriptionHistoryStoreTests.swift
@@ -865,4 +865,343 @@ final class SubscriptionHistoryStoreTests: XCTestCase {
         XCTAssertEqual(samples[0].peakUsedPercent, 75, accuracy: 0.001)
         XCTAssertEqual(samples[0].completionReason, .legacyTimelineMigration)
     }
+
+    // MARK: - Cursor, promoted out of the Misc page
+
+    /// Cursor spent its first weeks as a dedicated card whose reset history
+    /// said "Waiting for the first quota observation" forever, because the
+    /// store's tool whitelist was a literal that the promotion did not touch.
+    func testACursorWeeklyBucketThatRefillsIsRecorded() async throws {
+        let (store, _, cleanup) = try makeTempStore()
+        defer { cleanup() }
+        let start = Date(timeIntervalSince1970: 1_800_000_000)
+        let week: TimeInterval = 604_800
+
+        await store.observe(
+            quota(tool: .cursor, buckets: [
+                bucket(id: "grok_bot_weekly", usedPercent: 62,
+                       resetAt: start.addingTimeInterval(week),
+                       rawWindowSeconds: Int(week), groupTitle: "Grok Bot")
+            ], queriedAt: start),
+            now: start,
+            retentionDays: 3_650
+        )
+        let refill = start.addingTimeInterval(week)
+        await store.observe(
+            quota(tool: .cursor, buckets: [
+                bucket(id: "grok_bot_weekly", usedPercent: 3,
+                       resetAt: refill.addingTimeInterval(week),
+                       rawWindowSeconds: Int(week), groupTitle: "Grok Bot")
+            ], queriedAt: refill),
+            now: refill,
+            retentionDays: 3_650
+        )
+
+        let samples = await store.samples(accountId: "acct-test", bucketId: "grok_bot_weekly")
+        XCTAssertEqual(samples.count, 2, "the cycle that refilled plus the one that replaced it")
+        let completed = try XCTUnwrap(samples.first(where: \.isCompleted))
+        XCTAssertEqual(completed.tool, .cursor)
+        XCTAssertEqual(completed.completionReason, .refillDetected)
+        XCTAssertEqual(completed.peakUsedPercent, 62, accuracy: 0.001)
+        XCTAssertEqual(completed.resetKind, .onSchedule)
+    }
+
+    /// Cursor reports a different window length for the same weekly bucket
+    /// from one period to the next (13 h, 156 h and 168 h have all been
+    /// observed). AGENTS.md § 11: a cycle shorter than its stated window is
+    /// usually real, so each cycle keeps the window it was told, and the
+    /// refill is recorded where it was seen rather than where a nominal
+    /// window would have put it.
+    func testACursorCycleKeepsTheShortWindowItWasReported() async throws {
+        let (store, _, cleanup) = try makeTempStore()
+        defer { cleanup() }
+        let start = Date(timeIntervalSince1970: 1_800_000_000)
+        let thirteenHours: TimeInterval = 46_800
+        let week: TimeInterval = 604_800
+
+        await store.observe(
+            quota(tool: .cursor, buckets: [
+                bucket(id: "grok_bot_weekly", usedPercent: 80,
+                       resetAt: start.addingTimeInterval(thirteenHours),
+                       rawWindowSeconds: Int(thirteenHours), groupTitle: "Grok Bot")
+            ], queriedAt: start),
+            now: start,
+            retentionDays: 3_650
+        )
+        let refill = start.addingTimeInterval(thirteenHours)
+        await store.observe(
+            quota(tool: .cursor, buckets: [
+                bucket(id: "grok_bot_weekly", usedPercent: 1,
+                       resetAt: refill.addingTimeInterval(week),
+                       rawWindowSeconds: Int(week), groupTitle: "Grok Bot")
+            ], queriedAt: refill),
+            now: refill,
+            retentionDays: 3_650
+        )
+
+        let samples = await store.samples(accountId: "acct-test", bucketId: "grok_bot_weekly")
+        let completed = try XCTUnwrap(samples.first(where: \.isCompleted))
+        XCTAssertEqual(
+            completed.rawWindowSeconds, Int(thirteenHours),
+            "the window this cycle reported, not the one the next cycle reported"
+        )
+        XCTAssertEqual(completed.windowEnd, refill, "the refill was moved off where it was seen")
+        let current = try XCTUnwrap(samples.first(where: { !$0.isCompleted }))
+        XCTAssertEqual(current.rawWindowSeconds, Int(week))
+    }
+
+    /// The one-time backfill for a lane that joined `supportedTools` after
+    /// users already had history: it reaches into the retained fill timeline
+    /// for Cursor only, and it runs once.
+    func testTheCursorBackfillImportsFromTheFillTimelineExactlyOnce() async throws {
+        let (store, url, cleanup) = try makeTempStore()
+        defer { cleanup() }
+        let base = Date(timeIntervalSince1970: 1_800_000_000)
+        let week = 604_800
+        // An install from before Cursor was eligible: both older migrations
+        // have already run, so neither of them will run again.
+        let json = """
+        {"schemaVersion":2,"legacyTimelineImported":true,"resetSignalRepairVersion":1,\
+        "samples":[{"accountId":"acct-test","tool":"codex","bucketId":"weekly",\
+        "windowEnd":\(base.timeIntervalSinceReferenceDate),"rawWindowSeconds":\(week),\
+        "peakUsedPercent":40,"lastUsedPercent":40,"observationCount":3,\
+        "firstSeenAt":\(base.timeIntervalSinceReferenceDate),\
+        "lastSeenAt":\(base.timeIntervalSinceReferenceDate),\
+        "completedAt":\(base.timeIntervalSinceReferenceDate),\
+        "completionReason":"refillDetected","resetKind":"onSchedule"}]}
+        """
+        try Data(json.utf8).write(to: url)
+
+        let points = Self.cursorAndCodexRefillPoints(base: base, week: week)
+
+        await store.importLegacyTimeline(points, retentionDays: 3_650)
+        var cursor = await store.samples(accountId: "acct-test", bucketId: "grok_bot_weekly")
+        XCTAssertEqual(cursor.count, 1, "the Cursor refill in the fill timeline was not recovered")
+        let recovered = try XCTUnwrap(cursor.first)
+        XCTAssertEqual(recovered.tool, .cursor)
+        XCTAssertEqual(recovered.completionReason, .legacyTimelineMigration)
+        XCTAssertEqual(recovered.peakUsedPercent, 55, accuracy: 0.001)
+        XCTAssertEqual(recovered.resetKind, .onSchedule)
+
+        await store.importLegacyTimeline(points, retentionDays: 3_650)
+        cursor = await store.samples(accountId: "acct-test", bucketId: "grok_bot_weekly")
+        XCTAssertEqual(cursor.count, 1, "the backfill ran a second time")
+
+        let codex = await store.samples(accountId: "acct-test", bucketId: "weekly")
+        XCTAssertEqual(
+            codex.count, 1,
+            "a lane the earlier migrations already covered was imported all over again"
+        )
+    }
+
+    /// The version is persisted, not just remembered in memory.
+    func testTheCursorBackfillVersionSurvivesAReopen() async throws {
+        let (store, url, cleanup) = try makeTempStore()
+        defer { cleanup() }
+        let base = Date(timeIntervalSince1970: 1_800_000_000)
+        let week = 604_800
+        let json = """
+        {"schemaVersion":2,"legacyTimelineImported":true,"resetSignalRepairVersion":1,"samples":[]}
+        """
+        try Data(json.utf8).write(to: url)
+        let points = Self.cursorAndCodexRefillPoints(base: base, week: week)
+        await store.importLegacyTimeline(points, retentionDays: 3_650)
+        await store.flushPendingWrites()
+
+        let reopened = SubscriptionHistoryStore(fileURL: url)
+        await reopened.importLegacyTimeline(points, retentionDays: 3_650)
+        let cursor = await reopened.samples(accountId: "acct-test", bucketId: "grok_bot_weekly")
+        XCTAssertEqual(cursor.count, 1, "a relaunch replayed the backfill")
+    }
+
+    /// Two clients share this file and the older one re-encodes it without
+    /// the version key it has never heard of, so the flag cannot be the only
+    /// thing standing between a re-run and a doubled chart.
+    func testTheCursorBackfillDoesNotDuplicateWhenItsVersionIsStripped() async throws {
+        let (store, url, cleanup) = try makeTempStore()
+        defer { cleanup() }
+        let base = Date(timeIntervalSince1970: 1_800_000_000)
+        let json = """
+        {"schemaVersion":2,"legacyTimelineImported":true,"resetSignalRepairVersion":1,"samples":[]}
+        """
+        try Data(json.utf8).write(to: url)
+        let points = Self.cursorAndCodexRefillPoints(base: base, week: 604_800)
+        await store.importLegacyTimeline(points, retentionDays: 3_650)
+        await store.flushPendingWrites()
+
+        // What the other client leaves behind.
+        var stored = try XCTUnwrap(
+            try JSONSerialization.jsonObject(with: Data(contentsOf: url)) as? [String: Any]
+        )
+        XCTAssertNotNil(
+            stored["promotedProviderBackfillVersion"],
+            "the backfill did not stamp its version"
+        )
+        stored.removeValue(forKey: "promotedProviderBackfillVersion")
+        try JSONSerialization.data(withJSONObject: stored).write(to: url)
+
+        let reopened = SubscriptionHistoryStore(fileURL: url)
+        await reopened.importLegacyTimeline(points, retentionDays: 3_650)
+        let cursor = await reopened.samples(accountId: "acct-test", bucketId: "grok_bot_weekly")
+        XCTAssertEqual(cursor.count, 1, "the same refill was recorded twice")
+    }
+
+    /// A fresh install runs the full legacy import, which already covers
+    /// Cursor — the narrower backfill must not append the same cycles again.
+    func testTheCursorBackfillDoesNotDoubleImportOnAFreshInstall() async throws {
+        let (store, _, cleanup) = try makeTempStore()
+        defer { cleanup() }
+        let base = Date(timeIntervalSince1970: 1_800_000_000)
+        let points = Self.cursorAndCodexRefillPoints(base: base, week: 604_800)
+
+        await store.importLegacyTimeline(points, retentionDays: 3_650)
+
+        let cursor = await store.samples(accountId: "acct-test", bucketId: "grok_bot_weekly")
+        XCTAssertEqual(cursor.count, 1)
+        let codex = await store.samples(accountId: "acct-test", bucketId: "weekly")
+        XCTAssertEqual(codex.count, 1)
+    }
+
+    /// Nothing recorded yet means nothing to recover.
+    func testTheCursorBackfillIsANoOpWithNoFillPoints() async throws {
+        let (store, _, cleanup) = try makeTempStore()
+        defer { cleanup() }
+        await store.importLegacyTimeline([], retentionDays: 3_650)
+        let samples = await store.allSamples()
+        XCTAssertTrue(samples.isEmpty)
+    }
+
+    /// Deriving the whitelist from `supportsDedicatedCard` must not quietly
+    /// let the Misc page in.
+    func testAMiscPageProviderIsStillNotRecorded() async throws {
+        let (store, _, cleanup) = try makeTempStore()
+        defer { cleanup() }
+        let start = Date(timeIntervalSince1970: 1_800_000_000)
+        await store.observe(
+            quota(tool: .kimi, buckets: [
+                bucket(id: "monthly", usedPercent: 20,
+                       resetAt: start.addingTimeInterval(86_400), rawWindowSeconds: 86_400)
+            ], queriedAt: start),
+            now: start,
+            retentionDays: 3_650
+        )
+        let samples = await store.allSamples()
+        XCTAssertTrue(samples.isEmpty, "a Misc-page provider was recorded as a subscription cycle")
+    }
+
+    // MARK: - Per-bucket index
+
+    /// `samples` answers from a per-bucket index rather than by scanning the
+    /// whole file. It must return exactly the lane asked for, in exactly the
+    /// order the whole-file filter produced.
+    func testSamplesReturnTheSameLaneAndOrderAsAWholeFileScan() async throws {
+        let (store, _, cleanup) = try makeTempStore()
+        defer { cleanup() }
+        let start = Date(timeIntervalSince1970: 1_800_000_000)
+        let window: TimeInterval = 18_000
+        let lanes: [(String, ToolType)] = [("acct-cursor", .cursor), ("acct-claude", .claude)]
+
+        for step in 0...5 {
+            let moment = start.addingTimeInterval(TimeInterval(step) * window)
+            let used: Double = step % 2 == 0 ? 70 : 2
+            for (account, tool) in lanes {
+                await store.observe(
+                    quota(accountId: account, tool: tool, buckets: [
+                        bucket(id: "alpha", usedPercent: used,
+                               resetAt: moment.addingTimeInterval(window),
+                               rawWindowSeconds: Int(window)),
+                        bucket(id: "beta", usedPercent: used / 2,
+                               resetAt: moment.addingTimeInterval(window),
+                               rawWindowSeconds: Int(window))
+                    ], queriedAt: moment),
+                    now: moment,
+                    retentionDays: 3_650
+                )
+            }
+        }
+
+        let all = await store.allSamples()
+        XCTAssertGreaterThan(all.count, 8, "the fixture stopped exercising several cycles")
+        for (account, _) in lanes {
+            for bucketId in ["alpha", "beta"] {
+                // The whole-file filter this replaced, sorted the same way:
+                // both start from the array in storage order, so an identical
+                // sort input has to produce an identical order.
+                var expected = all.filter { $0.accountId == account && $0.bucketId == bucketId }
+                expected.sort { ($0.completedAt ?? $0.lastSeenAt) > ($1.completedAt ?? $1.lastSeenAt) }
+                let got = await store.samples(accountId: account, bucketId: bucketId)
+                XCTAssertEqual(got, expected, "\(account)/\(bucketId)")
+                XCTAssertFalse(got.isEmpty)
+            }
+        }
+
+        let completedOnly = await store.samples(
+            accountId: "acct-cursor", bucketId: "alpha", includeCurrent: false
+        )
+        XCTAssertTrue(completedOnly.allSatisfy(\.isCompleted))
+        let limited = await store.samples(accountId: "acct-cursor", bucketId: "alpha", limit: 2)
+        XCTAssertEqual(limited.count, 2)
+        let full = await store.samples(accountId: "acct-cursor", bucketId: "alpha")
+        XCTAssertEqual(limited, Array(full.prefix(2)), "the limit dropped the wrong end")
+
+        let missing = await store.samples(accountId: "acct-cursor", bucketId: "nonexistent")
+        XCTAssertTrue(missing.isEmpty)
+    }
+
+    /// Pruning renumbers every surviving sample, so the index has to be
+    /// rebuilt rather than reused.
+    func testSamplesStayCorrectAfterAPruneRenumbersTheStore() async throws {
+        let (store, _, cleanup) = try makeTempStore()
+        defer { cleanup() }
+        let start = Date(timeIntervalSince1970: 1_800_000_000)
+        let window: TimeInterval = 18_000
+
+        for step in 0...5 {
+            let moment = start.addingTimeInterval(TimeInterval(step) * window)
+            await store.observe(
+                quota(accountId: "acct-cursor", tool: .cursor, buckets: [
+                    bucket(id: "grok_bot_weekly", usedPercent: step % 2 == 0 ? 70 : 2,
+                           resetAt: moment.addingTimeInterval(window),
+                           rawWindowSeconds: Int(window))
+                ], queriedAt: moment),
+                now: moment,
+                retentionDays: 3_650
+            )
+        }
+
+        let last = start.addingTimeInterval(5 * window)
+        await store.prune(retentionDays: 1, now: last.addingTimeInterval(86_400))
+        let survivors = await store.samples(accountId: "acct-cursor", bucketId: "grok_bot_weekly")
+        let all = await store.allSamples()
+        XCTAssertEqual(survivors.count, all.count)
+        XCTAssertTrue(survivors.allSatisfy { $0.bucketId == "grok_bot_weekly" })
+    }
+
+    // MARK: - Shared fixtures
+
+    /// One Cursor refill and one Codex refill in the retained fill timeline.
+    /// The Codex pair is there to prove the backfill leaves lanes the earlier
+    /// migrations already covered alone.
+    private static func cursorAndCodexRefillPoints(base: Date, week: Int) -> [FillTimelinePoint] {
+        let span = TimeInterval(week)
+        func point(
+            _ tool: ToolType, _ bucketId: String, _ used: Double, at date: Date, resetAt: Date
+        ) -> FillTimelinePoint {
+            FillTimelinePoint(
+                accountId: "acct-test", tool: tool, bucketId: bucketId,
+                slotStart: date, usedPercent: used, sampledAt: date,
+                resetAt: resetAt, rawWindowSeconds: week
+            )
+        }
+        return [
+            point(.cursor, "grok_bot_weekly", 55, at: base, resetAt: base.addingTimeInterval(span)),
+            point(.cursor, "grok_bot_weekly", 2, at: base.addingTimeInterval(span),
+                  resetAt: base.addingTimeInterval(2 * span)),
+            point(.cursor, "grok_bot_weekly", 5, at: base.addingTimeInterval(span + 3_600),
+                  resetAt: base.addingTimeInterval(2 * span)),
+            point(.codex, "weekly", 70, at: base, resetAt: base.addingTimeInterval(span)),
+            point(.codex, "weekly", 1, at: base.addingTimeInterval(span),
+                  resetAt: base.addingTimeInterval(2 * span))
+        ]
+    }
 }

--- a/Tests/VibeBarCoreTests/SubscriptionHistoryStoreTests.swift
+++ b/Tests/VibeBarCoreTests/SubscriptionHistoryStoreTests.swift
@@ -982,6 +982,10 @@ final class SubscriptionHistoryStoreTests: XCTestCase {
         XCTAssertEqual(recovered.completionReason, .legacyTimelineMigration)
         XCTAssertEqual(recovered.peakUsedPercent, 55, accuracy: 0.001)
         XCTAssertEqual(recovered.resetKind, .onSchedule)
+        XCTAssertEqual(
+            recovered.rawWindowSeconds, week,
+            "a recovered cycle must keep the window the provider reported while it was live"
+        )
 
         await store.importLegacyTimeline(points, retentionDays: 3_650)
         cursor = await store.samples(accountId: "acct-test", bucketId: "grok_bot_weekly")


### PR DESCRIPTION
## Summary

- `SubscriptionHistoryStore.supportedTools` was a hand-written list (`codex, claude, gemini, antigravity, grok`) that never learned Cursor had been promoted into the SpaceXAI family, so the Grok Bot card showed "Waiting for the first quota observation" while the fill timeline held hundreds of observations of the same bucket (362 `cursor/grok_bot_weekly` points, 0 cursor samples in `subscription_history.json` on the maintainer's Mac). The set is now derived from `ToolType.dedicatedCardProviders`.
- A versioned one-time backfill (`promotedProviderBackfillVersion`) replays the material-refill and reset-signal passes for the newly eligible lanes only, from the retained fill timeline. It is idempotent, skips lanes a fresh install already covered, and de-duplicates against cycles already on disk because the shared `subscription_history.json` can be re-encoded by an older client that drops the version key.
- Per-lane position index in the store so `observe()` and `samples()` no longer scan every sample on each refresh and render (retention is unlimited by default, so the array only grows).
- `ToolType.dedicatedCardProviders` / `partialPrimaryProviders` / `costAwareProviders` / `usageStatsProviders` / `miscPageProviders` are now `static let` instead of re-filtering `allCases` from SwiftUI `body`.
- `ProviderPlanDisplay` gives `.cursor` its own case instead of the misc fall-through (rendered names unchanged); `CursorSessionResolver.stableAccountID` keeps the `misc-cursor` id with a comment explaining why renaming would orphan existing caches.

Part of the 2026-09-03 performance / UX audit (report: private artifact).

## Test plan

- [x] `swift build`
- [x] `swift test` — 1792 tests, 0 failures (10 new tests: cursor cycle recording, short reported window kept, backfill exactly once / survives reopen / version stripped / fresh install / no points, misc provider still excluded, `samples` order parity, index after prune)
- [x] Backfill ran against the maintainer's real store during the test run: 6 Cursor cycles recovered (5 × `grok_bot_weekly`, 1 × `models`), no duplicates across repeated runs
- [ ] After install: Grok Bot card under SpaceXAI shows Reset history bars instead of "Waiting for the first quota observation"

🤖 Generated with [Claude Code](https://claude.com/claude-code)