### PR TITLE
Add a reset-history comparison across weekly-and-longer quotas

### DIFF
--- a/Sources/VibeBarApp/Views/PageModuleCatalog.swift
+++ b/Sources/VibeBarApp/Views/PageModuleCatalog.swift
@@ -39,6 +39,9 @@ enum PageModuleKind: Hashable {
     case overviewCost(ToolType)
     case overviewUsageMix
     case overviewUpcomingResets
+    /// Every weekly-and-longer quota's reset history side by side — where
+    /// quota is being wasted, across providers.
+    case overviewResetHistoryCompare
     case overviewModelRanking
     case overviewYearHeatmap
     case overviewActivityHeatmap
@@ -46,6 +49,8 @@ enum PageModuleKind: Hashable {
     /// Carries `QuotaGroupModule.id` so the page can find the live group again.
     case quotaGroup(String)
     case serviceStatus
+    /// The same comparison scoped to this page's provider family.
+    case resetHistoryCompare
     case costHeader
     case costHistory
     case modelRanking
@@ -84,6 +89,12 @@ enum PageModuleCatalog {
     private enum FallbackHeight {
         static let quota: Double = 260
         static let quotaHistory: Double = 300
+        /// One row per weekly-and-longer quota plus header, legend and axis.
+        /// The Overview's copy carries every provider's lanes, a provider
+        /// page's carries two to four — stand-ins until the first measurement
+        /// replaces them.
+        static let resetCompareAll: Double = 460
+        static let resetCompareProvider: Double = 220
         static let cost: Double = 320
         static let analytics: Double = 200
         static let usageMix: Double = 300
@@ -169,6 +180,20 @@ enum PageModuleCatalog {
                 accent: .neutral,
                 masonryPhase: .quota,
                 fallbackHeight: FallbackHeight.status
+            )
+        )
+        // The retrospective half of the same question, immediately after the
+        // horizon: Upcoming Resets says when quota comes back, this says how
+        // much of the last one expired unused.
+        result.append(
+            PageModuleDescriptor(
+                id: .custom("overview-reset-history-compare"),
+                kind: .overviewResetHistoryCompare,
+                displayName: "Reset History Compare",
+                defaultColumn: 1,
+                accent: .neutral,
+                masonryPhase: .quota,
+                fallbackHeight: FallbackHeight.resetCompareAll
             )
         )
         let hasCostData = self.hasCostData(environment: environment, settings: settings)
@@ -325,6 +350,21 @@ enum PageModuleCatalog {
                 accent: .neutral,
                 masonryPhase: .quota,
                 fallbackHeight: FallbackHeight.status
+            )
+        )
+        // Right column, above the cost cards: a quota answer, and the reason
+        // the wide column no longer starts far below the narrow one. Appended
+        // before the no-cost-data early return so a provider with no local
+        // sessions still gets it.
+        result.append(
+            PageModuleDescriptor(
+                id: .custom("reset-history-compare:\(tool.rawValue)"),
+                kind: .resetHistoryCompare,
+                displayName: "Reset History Compare",
+                defaultColumn: 1,
+                accent: .provider(tool),
+                masonryPhase: .quota,
+                fallbackHeight: FallbackHeight.resetCompareProvider
             )
         )
 

--- a/Sources/VibeBarApp/Views/PopoverRoot.swift
+++ b/Sources/VibeBarApp/Views/PopoverRoot.swift
@@ -626,6 +626,8 @@ private struct OverviewWaterfall: View {
             OverviewUsageMixCard(density: density)
         case .overviewUpcomingResets:
             UpcomingResetsCard(density: density)
+        case .overviewResetHistoryCompare:
+            ResetHistoryCompareCard(density: density)
         case .overviewModelRanking:
             ModelRankingList(
                 breakdowns: context.models,
@@ -644,8 +646,9 @@ private struct OverviewWaterfall: View {
                 density: density,
                 titleOverride: "When you use everything"
             )
-        case .quotaGroup, .serviceStatus, .costHeader, .costHistory,
-             .modelRanking, .yearHeatmap, .activityHeatmap, .costEmpty:
+        case .quotaGroup, .serviceStatus, .resetHistoryCompare, .costHeader,
+             .costHistory, .modelRanking, .yearHeatmap, .activityHeatmap,
+             .costEmpty:
             // Provider-page families. `PageModuleCatalog` never puts them on
             // the Overview, and a stale identifier is dropped before it gets
             // here, so this is unreachable rather than a fallback.
@@ -1732,6 +1735,15 @@ private struct ProviderPageModule: View {
             }
         case .serviceStatus:
             ServiceStatusCard(tools: [context.pageTool], density: density)
+        case .resetHistoryCompare:
+            // Scoped to the page's family, so the Google AI page keeps
+            // AntiGravity beside Gemini Web and the SpaceXAI page keeps
+            // Cursor beside Grok — the same pairing the refresh button uses.
+            ResetHistoryCompareCard(
+                density: density,
+                tools: PageModuleCatalog.quotaRefreshTools(for: context.pageTool),
+                titleOverride: "Reset History"
+            )
         case .costHeader:
             if let snapshot = context.snapshot {
                 CostHeaderCard(
@@ -1789,7 +1801,8 @@ private struct ProviderPageModule: View {
             }
         case .overviewCostSummary, .overviewStatusSummary, .overviewQuota,
              .overviewQuotaHistoryAll, .overviewCostAll, .overviewCost,
-             .overviewUsageMix, .overviewUpcomingResets, .overviewModelRanking,
+             .overviewUsageMix, .overviewUpcomingResets,
+             .overviewResetHistoryCompare, .overviewModelRanking,
              .overviewYearHeatmap, .overviewActivityHeatmap:
             // Overview families. `PageModuleCatalog` never puts them on a
             // provider page, and a stale identifier is dropped before it gets

--- a/Sources/VibeBarApp/Views/ResetHistoryCompareView.swift
+++ b/Sources/VibeBarApp/Views/ResetHistoryCompareView.swift
@@ -92,31 +92,134 @@ enum ResetHistoryLanes {
                     // SubProviders. A tool outside this page's scope falls
                     // back to the account's rather than leaking onto it.
                     let sampleTool = samples[0].tool
-                    let laneTool = (tools?.contains(sampleTool) ?? true) ? sampleTool : tool
                     out.append(
-                        ResetHistoryLaneInput(
+                        retiredLane(
                             accountId: account.id,
-                            tool: laneTool,
                             bucketId: key.bucketId,
-                            company: laneTool.vendorName,
-                            subProvider: laneTool.quotaSubProviderName(bucketID: key.bucketId),
-                            groupTitle: nil,
-                            bucketTitle: retiredBucketTitle(
-                                tool: laneTool,
-                                bucketId: key.bucketId,
-                                registry: registry
-                            ),
+                            tool: (tools?.contains(sampleTool) ?? true) ? sampleTool : tool,
                             accountLabel: accountLabel,
-                            liveWindowSeconds: nil,
-                            currentUsedPercent: nil,
-                            currentResetAt: nil,
-                            samples: samples
+                            samples: samples,
+                            registry: registry
+                        )
+                    )
+                }
+            }
+        }
+        out.append(
+            contentsOf: signedOutAccountLanes(
+                environment: environment,
+                settings: settings,
+                tools: tools,
+                history: history,
+                recordedByAccount: recordedByAccount,
+                registry: registry
+            )
+        )
+        return out
+    }
+
+    /// Lanes for accounts `AccountStore` no longer lists.
+    ///
+    /// Signing out of a provider, or switching to a different account, removes
+    /// the identity while `QuotaService` goes on hydrating its retained
+    /// samples — and the Workbench's reset calendar goes on reading them
+    /// straight out of `historyByAccountBucket`. Discovering only from the
+    /// detected accounts therefore made the same completed cycles visible on
+    /// one surface and absent from the comparison next to it.
+    ///
+    /// The identity is reconstructed from the samples, which carry the tool;
+    /// the account id is a privacy-preserving hash and never becomes copy, so
+    /// former accounts are labelled positionally instead.
+    @MainActor
+    private static func signedOutAccountLanes(
+        environment: AppEnvironment,
+        settings: AppSettings,
+        tools: [ToolType]?,
+        history: [SubscriptionHistoryKey: [SubscriptionWindowSample]],
+        recordedByAccount: [String: [SubscriptionHistoryKey]],
+        registry: QuotaFieldRegistry
+    ) -> [ResetHistoryLaneInput] {
+        // Detected across every provider, not just the in-scope ones: an
+        // account that is live under a filtered-out tool has not been signed
+        // out of, and must not reappear here as a ghost.
+        let detected = Set(
+            ToolType.dedicatedCardProviders.flatMap { tool in
+                environment.accountStore.accounts(for: tool).map(\.id)
+            }
+        )
+        var keysByTool: [ToolType: [String: [SubscriptionHistoryKey]]] = [:]
+        for (accountId, keys) in recordedByAccount where !detected.contains(accountId) {
+            for key in keys {
+                guard let first = history[key]?.first else { continue }
+                keysByTool[first.tool, default: [:]][accountId, default: []].append(key)
+            }
+        }
+        guard !keysByTool.isEmpty else { return [] }
+
+        var out: [ResetHistoryLaneInput] = []
+        // Canonical provider order again, so these lanes carry the same
+        // company precedence as the live ones.
+        for tool in ToolType.dedicatedCardProviders {
+            if let tools {
+                guard tools.contains(tool) else { continue }
+            } else {
+                guard settings.isCoreProviderVisible(tool) else { continue }
+            }
+            guard let accounts = keysByTool[tool] else { continue }
+            let accountIds = accounts.keys.sorted()
+            for (position, accountId) in accountIds.enumerated() {
+                // Numbered only when a provider has more than one former
+                // identity, so the ordinary case reads plainly.
+                let label = accountIds.count > 1
+                    ? "Signed-out account \(position + 1)"
+                    : "Signed-out account"
+                for key in (accounts[accountId] ?? []).sorted(by: { $0.bucketId < $1.bucketId }) {
+                    guard let samples = history[key], !samples.isEmpty else { continue }
+                    out.append(
+                        retiredLane(
+                            accountId: accountId,
+                            bucketId: key.bucketId,
+                            tool: tool,
+                            accountLabel: label,
+                            samples: samples,
+                            registry: registry
                         )
                     )
                 }
             }
         }
         return out
+    }
+
+    /// One lane no live bucket backs any more — a withdrawn bucket, or one
+    /// belonging to an account that has been signed out of.
+    ///
+    /// `isRetired` rather than merely leaving the live fields nil: the last
+    /// sample of a bucket nothing observes again never closes, and without the
+    /// flag it would render as a dashed current cycle forever.
+    private static func retiredLane(
+        accountId: String,
+        bucketId: String,
+        tool: ToolType,
+        accountLabel: String?,
+        samples: [SubscriptionWindowSample],
+        registry: QuotaFieldRegistry
+    ) -> ResetHistoryLaneInput {
+        ResetHistoryLaneInput(
+            accountId: accountId,
+            tool: tool,
+            bucketId: bucketId,
+            company: tool.vendorName,
+            subProvider: tool.quotaSubProviderName(bucketID: bucketId),
+            groupTitle: nil,
+            bucketTitle: retiredBucketTitle(tool: tool, bucketId: bucketId, registry: registry),
+            accountLabel: accountLabel,
+            liveWindowSeconds: nil,
+            currentUsedPercent: nil,
+            currentResetAt: nil,
+            isRetired: true,
+            samples: samples
+        )
     }
 
     /// What to call a bucket no live quota carries any more.

--- a/Sources/VibeBarApp/Views/ResetHistoryCompareView.swift
+++ b/Sources/VibeBarApp/Views/ResetHistoryCompareView.swift
@@ -1,0 +1,780 @@
+import SwiftUI
+import VibeBarCore
+
+// MARK: - Lane discovery
+
+/// Turns the live quotas plus the recorded cycle history into the pure inputs
+/// `ResetHistoryComparison` aggregates.
+///
+/// Reads only what is already in memory — the cached quotas and the published
+/// history dictionary. No I/O, no fetch, no forecast: this runs inside a
+/// render pass.
+enum ResetHistoryLanes {
+    /// - Parameter tools: restricts the module to one provider family (a
+    ///   provider detail page passes `googleAIPair` / `grokFamily` so the
+    ///   Google AI page keeps showing AntiGravity next to Gemini Web). `nil`
+    ///   means every dedicated provider the user has left visible.
+    @MainActor
+    static func inputs(
+        environment: AppEnvironment,
+        tools: [ToolType]? = nil
+    ) -> [ResetHistoryLaneInput] {
+        let settings = environment.settingsStore.settings
+        var out: [ResetHistoryLaneInput] = []
+        // Canonical provider order, so the `.company` grouping is the app's
+        // own order rather than an alphabetical reshuffle.
+        for tool in ToolType.dedicatedCardProviders {
+            if let tools {
+                guard tools.contains(tool) else { continue }
+            } else {
+                guard settings.isCoreProviderVisible(tool) else { continue }
+            }
+            // Every account, not the first: multi-account providers refill
+            // per account, and each account is its own lane.
+            let accounts = environment.accountStore.accounts(for: tool)
+            for account in accounts {
+                guard let quota = environment.quotaService.cachedQuota(for: account.id) else { continue }
+                let accountLabel = accounts.count > 1 ? account.displayLabel : nil
+                for bucket in quota.buckets {
+                    let key = SubscriptionHistoryKey(accountId: account.id, bucketId: bucket.id)
+                    let subProvider = tool.quotaSubProviderName(bucketID: bucket.id)
+                    let trimmed = bucket.groupTitle?.trimmingCharacters(in: .whitespacesAndNewlines)
+                    // A group titled after its own SubProvider is the primary
+                    // lane (Grok Bot), not a model group.
+                    let group = (trimmed?.isEmpty ?? true)
+                        || trimmed?.caseInsensitiveCompare(subProvider) == .orderedSame
+                        ? nil : trimmed
+                    out.append(
+                        ResetHistoryLaneInput(
+                            accountId: account.id,
+                            tool: tool,
+                            bucketId: bucket.id,
+                            company: tool.vendorName,
+                            subProvider: subProvider,
+                            groupTitle: group,
+                            bucketTitle: bucket.title,
+                            accountLabel: accountLabel,
+                            liveWindowSeconds: bucket.rawWindowSeconds,
+                            currentUsedPercent: bucket.usedPercent,
+                            currentResetAt: bucket.resetAt,
+                            // COW: this is a retain, not a copy, which is what
+                            // makes the cache's equality check cheap.
+                            samples: environment.quotaService.historyByAccountBucket[key] ?? []
+                        )
+                    )
+                }
+            }
+        }
+        return out
+    }
+}
+
+// MARK: - Memo
+
+/// One built comparison, kept until its inputs change.
+///
+/// The aggregation walks every recorded cycle on the Mac, which is not work a
+/// `body` may do per render (`AGENTS.md` § 7). Equality on the inputs is what
+/// makes the memo cheap: `[SubscriptionWindowSample]` short-circuits on
+/// identical storage, so an unchanged history costs one pointer compare per
+/// lane.
+@MainActor
+final class ResetHistoryComparisonCache {
+    private struct Key: Equatable {
+        let inputs: [ResetHistoryLaneInput]
+        let window: ResetHistoryComparison.Window
+        let ordering: ResetHistoryComparison.Ordering
+        let hour: Double
+    }
+
+    private var key: Key?
+    private var value: ResetHistoryComparison?
+
+    func comparison(
+        inputs: [ResetHistoryLaneInput],
+        window: ResetHistoryComparison.Window,
+        ordering: ResetHistoryComparison.Ordering,
+        now: Date = Date()
+    ) -> ResetHistoryComparison {
+        // The visible span is anchored to now, so the clock is an input — but
+        // quantized to the hour. A weeks-wide axis does not move within one,
+        // and this module starts no timer of its own: the next quota refresh
+        // redraws it.
+        let hour = (now.timeIntervalSinceReferenceDate / 3_600).rounded(.down) * 3_600
+        let candidate = Key(inputs: inputs, window: window, ordering: ordering, hour: hour)
+        if let key, key == candidate, let value { return value }
+        let built = ResetHistoryComparison.build(
+            inputs: inputs,
+            window: window,
+            ordering: ordering,
+            now: Date(timeIntervalSinceReferenceDate: hour)
+        )
+        key = candidate
+        value = built
+        return built
+    }
+}
+
+// MARK: - Card
+
+/// Every weekly-and-longer quota's reset history, side by side on one time
+/// axis: where quota is being thrown away, and where it is being spent.
+///
+/// Same bar semantics as `FillTimelineChart`, which shows one lane inside its
+/// own quota card — height is the peak used percent, the muted remainder above
+/// it is what expired unused, a dashed outline is the cycle still running, and
+/// a dot over a bar means the window refilled before it said it would. The two
+/// surfaces are one system; changing a colour or a marker here means changing
+/// it there.
+///
+/// Five-hour lanes are excluded by `ResetHistoryComparison` itself — see the
+/// note there for why, and why the cut is made on the window length rather
+/// than on a bucket name.
+struct ResetHistoryCompareCard: View {
+    let density: Theme.Density
+    /// Provider family this instance is scoped to. `nil` on the Overview and
+    /// in the Workbench, which compare everything.
+    var tools: [ToolType]?
+    var titleOverride: String?
+
+    @EnvironmentObject private var environment: AppEnvironment
+    @EnvironmentObject private var settingsStore: SettingsStore
+    /// Observed: the module's whole content is this service's published
+    /// history plus its cached quotas.
+    @EnvironmentObject private var quotaService: QuotaService
+
+    @State private var window: ResetHistoryComparison.Window = .eightWeeks
+    @State private var groupByCompany = false
+    @State private var cache = ResetHistoryComparisonCache()
+
+    var body: some View {
+        let comparison = cache.comparison(
+            inputs: ResetHistoryLanes.inputs(environment: environment, tools: tools),
+            window: window,
+            ordering: groupByCompany ? .company : .waste
+        )
+        CardShell(density: density, spacing: 8) {
+            header
+            summary(comparison)
+            if comparison.isEmpty {
+                Text("Nothing to compare yet — weekly and longer quotas appear here once a provider reports one.")
+                    .font(.system(size: density.subtitleFontSize))
+                    .foregroundStyle(.tertiary)
+                    .padding(.vertical, 14)
+                    .frame(maxWidth: .infinity)
+            } else {
+                ResetHistoryCompareView(comparison: comparison, density: density)
+            }
+        }
+    }
+
+    private var title: String { titleOverride ?? "Reset History Compare" }
+
+    private var header: some View {
+        HStack(alignment: .firstTextBaseline, spacing: 8) {
+            Text(title)
+                .font(.system(size: density.bucketTitleFontSize, weight: .semibold))
+                .lineLimit(1)
+            Spacer(minLength: 6)
+            groupToggle
+            windowPicker
+        }
+    }
+
+    /// Compact 4w / 8w / 12w / All. The same hand-drawn segment pill the cost
+    /// card's metric switch uses, so the two read as one control family.
+    private var windowPicker: some View {
+        HStack(spacing: 1) {
+            ForEach(ResetHistoryComparison.Window.allCases, id: \.self) { option in
+                Button {
+                    window = option
+                } label: {
+                    Text(option.shortTitle)
+                        .font(.system(size: max(8.5, density.segmentedFontSize - 1.5), weight: .semibold, design: .rounded))
+                        .foregroundStyle(window == option ? Color.primary : Color.secondary)
+                        .lineLimit(1)
+                        .padding(.horizontal, 5)
+                        .frame(minHeight: 17)
+                        .contentShape(Rectangle())
+                        .background {
+                            if window == option {
+                                RoundedRectangle(cornerRadius: 5, style: .continuous)
+                                    .fill(Color.primary.opacity(0.12))
+                            }
+                        }
+                }
+                .buttonStyle(.vibeBar(cornerRadius: 5))
+                .help("Compare the \(option.spokenTitle)")
+                .accessibilityLabel("Compare the \(option.spokenTitle)")
+                // The fill is the only sighted cue for which span is showing;
+                // VoiceOver needs the selection stated outright.
+                .accessibilityAddTraits(window == option ? [.isSelected] : [])
+            }
+        }
+        .padding(2)
+        .background(
+            RoundedRectangle(cornerRadius: 6, style: .continuous)
+                .fill(Color.primary.opacity(0.08))
+        )
+    }
+
+    private var groupToggle: some View {
+        Button {
+            groupByCompany.toggle()
+        } label: {
+            Image(systemName: groupByCompany ? "rectangle.3.group.fill" : "arrow.down.right")
+                .font(.system(size: 9, weight: .semibold))
+                .foregroundStyle(groupByCompany ? Color.primary : Color.secondary)
+                .frame(width: 19, height: 17)
+                .contentShape(Rectangle())
+                .background {
+                    if groupByCompany {
+                        RoundedRectangle(cornerRadius: 5, style: .continuous)
+                            .fill(Color.primary.opacity(0.12))
+                    }
+                }
+        }
+        .buttonStyle(.vibeBar(cornerRadius: 5))
+        .help(
+            groupByCompany
+                ? "Grouped by company — switch back to most wasted first"
+                : "Sorted by most wasted — group by company instead"
+        )
+        .accessibilityLabel("Group quotas by company")
+        .accessibilityAddTraits(groupByCompany ? [.isSelected] : [])
+        .padding(.trailing, 2)
+    }
+
+    /// The header's arithmetic and the one plain sentence under it.
+    private func summary(_ comparison: ResetHistoryComparison) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(comparison.totals.headline)
+                .font(.system(size: density.subtitleFontSize, weight: .semibold, design: .rounded).monospacedDigit())
+                .foregroundStyle(.secondary)
+            Text(comparison.verdict)
+                .font(.system(size: max(9, density.subtitleFontSize - 0.5)))
+                .foregroundStyle(.tertiary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+// MARK: - Geometry
+
+/// Row metrics plus the time→x mapping, resolved once and shared by the
+/// drawing surface and the hit test — so the tooltip can never describe a bar
+/// the cursor is not actually over.
+struct ResetHistoryCompareLayout: Equatable {
+    let rowHeight: CGFloat
+    let labelWidth: CGFloat
+    /// Band above each track holding the early-refill dots.
+    let markerBand: CGFloat = 5
+    /// Gap under each track.
+    let rowGap: CGFloat = 6
+    let labelGap: CGFloat = 8
+    let axisHeight: CGFloat = 13
+    let laneCount: Int
+    let titleFontSize: CGFloat
+    let captionFontSize: CGFloat
+    let rangeStart: Date
+    let rangeEnd: Date
+    let now: Date
+
+    init(density: Theme.Density, comparison: ResetHistoryComparison) {
+        // Two text lines and a bar per row. Deliberately tight: a dozen
+        // weekly-and-longer quotas have to fit on one screen, which is the
+        // whole point of the module.
+        switch density.profile {
+        case .compact:
+            rowHeight = 38
+            labelWidth = 142
+        case .regular:
+            rowHeight = 44
+            labelWidth = 164
+        case .spacious:
+            rowHeight = 52
+            labelWidth = 190
+        }
+        laneCount = comparison.lanes.count
+        titleFontSize = max(9, density.subtitleFontSize - 0.5)
+        captionFontSize = max(8, density.subtitleFontSize - 2)
+        rangeStart = comparison.rangeStart
+        rangeEnd = comparison.rangeEnd
+        now = comparison.now
+    }
+
+    var totalHeight: CGFloat { CGFloat(laneCount) * rowHeight + axisHeight }
+    var rowsHeight: CGFloat { CGFloat(laneCount) * rowHeight }
+    var chartX: CGFloat { labelWidth + labelGap }
+
+    func chartWidth(in size: CGSize) -> CGFloat { max(20, size.width - chartX) }
+    func rowTop(_ index: Int) -> CGFloat { CGFloat(index) * rowHeight }
+    func trackTop(_ index: Int) -> CGFloat { rowTop(index) + markerBand }
+    func trackBottom(_ index: Int) -> CGFloat { rowTop(index) + rowHeight - rowGap }
+
+    /// Bars per lane the row has room for. Three points is already narrower
+    /// than a bar the eye can separate.
+    func drawBudget(in size: CGSize) -> Int { max(4, Int(chartWidth(in: size) / 3)) }
+
+    func x(for date: Date, in size: CGSize) -> CGFloat {
+        let span = max(1, rangeEnd.timeIntervalSince(rangeStart))
+        let fraction = date.timeIntervalSince(rangeStart) / span
+        return chartX + chartWidth(in: size) * CGFloat(fraction)
+    }
+
+    /// One bar's rectangle, clamped to the visible axis. `nil` when the cycle
+    /// falls entirely outside it.
+    func barRect(
+        _ cycle: ResetHistoryComparison.Cycle,
+        laneIndex: Int,
+        in size: CGSize
+    ) -> CGRect? {
+        let left = x(for: cycle.start, in: size)
+        let right = x(for: cycle.end, in: size)
+        let minX = chartX
+        let maxX = chartX + chartWidth(in: size)
+        guard right > minX, left < maxX else { return nil }
+        let clampedLeft = max(minX, left)
+        let clampedRight = min(maxX, right)
+        // One point of air between neighbours, and never thinner than a bar
+        // the eye can find.
+        let width = max(2, clampedRight - clampedLeft - 1)
+        let top = trackTop(laneIndex)
+        return CGRect(x: clampedLeft, y: top, width: width, height: trackBottom(laneIndex) - top)
+    }
+
+    /// Six evenly spaced dates across the visible span.
+    var ticks: [Date] {
+        let span = rangeEnd.timeIntervalSince(rangeStart)
+        guard span > 0 else { return [] }
+        let count = 5
+        return (0...count).map { index in
+            rangeStart.addingTimeInterval(span * Double(index) / Double(count))
+        }
+    }
+}
+
+// MARK: - Small multiples
+
+/// Every lane on one shared time axis.
+///
+/// The bars are a single `Canvas` (`AGENTS.md` § 11: dense status history is
+/// one drawing surface, not hundreds of views) held behind `.equatable()`, so
+/// moving the pointer across fifteen lanes re-renders the hover highlight and
+/// one tooltip — never the several hundred bars underneath them.
+struct ResetHistoryCompareView: View {
+    let comparison: ResetHistoryComparison
+    let density: Theme.Density
+
+    @State private var hover: Hover?
+
+    private struct Hover: Equatable {
+        let laneIndex: Int
+        let cycleID: String
+        let point: CGPoint
+    }
+
+    var body: some View {
+        let layout = ResetHistoryCompareLayout(density: density, comparison: comparison)
+        VStack(alignment: .leading, spacing: 5) {
+            legend
+            GeometryReader { proxy in
+                ZStack(alignment: .topLeading) {
+                    ResetHistoryLanesCanvas(comparison: comparison, layout: layout)
+                        .equatable()
+                    if let hover, let rect = hoveredRect(hover, in: proxy.size, layout: layout) {
+                        RoundedRectangle(cornerRadius: min(2.5, rect.width / 2) + 1, style: .continuous)
+                            .stroke(Color.primary.opacity(0.5), lineWidth: 1)
+                            .frame(width: rect.width + 2, height: rect.height + 2)
+                            .offset(x: rect.minX - 1, y: rect.minY - 1)
+                            .allowsHitTesting(false)
+                    }
+                    if let hover, let cycle = cycle(for: hover) {
+                        tooltip(lane: comparison.lanes[hover.laneIndex], cycle: cycle)
+                            .offset(tooltipOffset(hover, in: proxy.size))
+                            .allowsHitTesting(false)
+                    }
+                }
+                .contentShape(Rectangle())
+                .onContinuousHover { phase in
+                    switch phase {
+                    case let .active(location):
+                        let next = hit(location, in: proxy.size, layout: layout)
+                        if next != hover { hover = next }
+                    case .ended:
+                        hover = nil
+                    }
+                }
+            }
+            .frame(height: layout.totalHeight)
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel(comparison.accessibilitySummary)
+        }
+    }
+
+    // MARK: Legend
+
+    /// One composite swatch rather than three abstractions of it: the reader
+    /// is being told how to read a bar, and the swatch *is* a bar.
+    private var legend: some View {
+        HStack(spacing: 10) {
+            HStack(spacing: 4) {
+                ZStack(alignment: .bottom) {
+                    RoundedRectangle(cornerRadius: 1.5, style: .continuous)
+                        .fill(Color.primary.opacity(0.12))
+                        .frame(width: 6, height: 9)
+                    RoundedRectangle(cornerRadius: 1.5, style: .continuous)
+                        .fill(Color.secondary)
+                        .frame(width: 6, height: 5)
+                }
+                Text("bar height = used, grey remainder = wasted")
+            }
+            HStack(spacing: 4) {
+                RoundedRectangle(cornerRadius: 1.5, style: .continuous)
+                    .stroke(Color.secondary, style: StrokeStyle(lineWidth: 0.8, dash: [2, 1.5]))
+                    .frame(width: 6, height: 9)
+                Text("current")
+            }
+            HStack(spacing: 3) {
+                Circle()
+                    .fill(Color.secondary)
+                    .frame(width: 3, height: 3)
+                Text("refilled early")
+            }
+            Spacer(minLength: 0)
+        }
+        .font(.system(size: max(7.5, density.subtitleFontSize - 3), design: .rounded))
+        .foregroundStyle(.tertiary)
+    }
+
+    // MARK: Hover
+
+    private func hit(
+        _ location: CGPoint,
+        in size: CGSize,
+        layout: ResetHistoryCompareLayout
+    ) -> Hover? {
+        let index = Int(location.y / layout.rowHeight)
+        guard index >= 0, index < comparison.lanes.count else { return nil }
+        let lane = comparison.lanes[index]
+        var candidates = ResetHistoryComparison.downsampled(
+            lane.cycles,
+            limit: layout.drawBudget(in: size)
+        )
+        if let current = lane.currentCycle { candidates.append(current) }
+        // Reverse order matches the draw order: the current cycle is painted
+        // last and is therefore the one on top.
+        for cycle in candidates.reversed() {
+            guard let rect = layout.barRect(cycle, laneIndex: index, in: size) else { continue }
+            if location.x >= rect.minX - 1, location.x <= rect.maxX + 1 {
+                return Hover(laneIndex: index, cycleID: cycle.id, point: location)
+            }
+        }
+        return nil
+    }
+
+    private func cycle(for hover: Hover) -> ResetHistoryComparison.Cycle? {
+        guard hover.laneIndex < comparison.lanes.count else { return nil }
+        let lane = comparison.lanes[hover.laneIndex]
+        if let match = lane.cycles.first(where: { $0.id == hover.cycleID }) { return match }
+        return lane.currentCycle?.id == hover.cycleID ? lane.currentCycle : nil
+    }
+
+    private func hoveredRect(
+        _ hover: Hover,
+        in size: CGSize,
+        layout: ResetHistoryCompareLayout
+    ) -> CGRect? {
+        guard let cycle = cycle(for: hover) else { return nil }
+        return layout.barRect(cycle, laneIndex: hover.laneIndex, in: size)
+    }
+
+    private func tooltip(
+        lane: ResetHistoryComparison.Lane,
+        cycle: ResetHistoryComparison.Cycle
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 3) {
+            HStack(spacing: 5) {
+                Circle()
+                    .fill(Theme.providerAccent(for: lane.tool))
+                    .frame(width: 5, height: 5)
+                Text(lane.label)
+                    .font(.system(size: 9.5, weight: .semibold))
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.7)
+            }
+            Text(dateRange(cycle))
+                .font(.system(size: 9, design: .rounded).monospacedDigit())
+                .foregroundStyle(.secondary)
+            Text(
+                cycle.isCompleted
+                    ? "\(Int(cycle.usedPercent.rounded()))% used · \(Int(cycle.wastedPercent.rounded()))% wasted"
+                    : "Current cycle · \(Int(cycle.usedPercent.rounded()))% used so far · \(Int(cycle.wastedPercent.rounded()))% left"
+            )
+            .font(.system(size: 9, design: .rounded).monospacedDigit())
+            .foregroundStyle(.primary.opacity(0.85))
+            if !cycle.resetDescription.isEmpty {
+                Text(cycle.resetDescription)
+                    .font(.system(size: 8.5, design: .rounded))
+                    .foregroundStyle(.tertiary)
+            }
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 6)
+        .frame(width: Self.tooltipWidth, alignment: .leading)
+        // Opaque, not shadowed or glassy: the flat language's way of saying
+        // "this is on top" (docs/DESIGN.md § 2).
+        .workbenchOverlaySurface(in: RoundedRectangle(cornerRadius: 7, style: .continuous))
+    }
+
+    private static let tooltipWidth: CGFloat = 236
+
+    private func tooltipOffset(_ hover: Hover, in size: CGSize) -> CGSize {
+        let x = min(max(0, hover.point.x - Self.tooltipWidth / 2), max(0, size.width - Self.tooltipWidth))
+        // Above the hovered row when there is room for it, below otherwise.
+        let above = hover.point.y > 76
+        return CGSize(width: x, height: above ? hover.point.y - 74 : hover.point.y + 14)
+    }
+
+    private func dateRange(_ cycle: ResetHistoryComparison.Cycle) -> String {
+        let start = ResetHistoryCompareFormatters.tooltip.string(from: cycle.start)
+        let end = ResetHistoryCompareFormatters.tooltip.string(from: cycle.end)
+        return cycle.isCompleted ? "\(start) → \(end) reset" : "\(start) → \(end) reset due"
+    }
+}
+
+// MARK: - The drawing surface
+
+/// The bars, the labels, the grid and the axis — one `Canvas`, no per-cell
+/// views and no `.help()` per bar.
+///
+/// `Equatable` so hover, which changes several times a second, cannot drag the
+/// whole surface through a redraw with it. The value is the comparison plus
+/// the geometry; nothing else here reads state.
+private struct ResetHistoryLanesCanvas: View, Equatable {
+    let comparison: ResetHistoryComparison
+    let layout: ResetHistoryCompareLayout
+
+    static func == (lhs: ResetHistoryLanesCanvas, rhs: ResetHistoryLanesCanvas) -> Bool {
+        lhs.layout == rhs.layout && lhs.comparison == rhs.comparison
+    }
+
+    var body: some View {
+        Canvas(opaque: false, rendersAsynchronously: false) { context, size in
+            drawGrid(&context, size: size)
+            for (index, lane) in comparison.lanes.enumerated() {
+                drawLabels(&context, lane: lane, index: index)
+                drawLane(&context, lane: lane, index: index, size: size)
+            }
+            drawAxis(&context, size: size)
+        }
+    }
+
+    /// Week gridlines behind every row, plus the *now* hairline — the same
+    /// "the leading hairline is now" idiom the refill-horizon lane uses.
+    private func drawGrid(_ context: inout GraphicsContext, size: CGSize) {
+        for tick in layout.ticks {
+            let tickX = layout.x(for: tick, in: size)
+            context.fill(
+                Path(CGRect(x: tickX, y: 0, width: 0.5, height: layout.rowsHeight)),
+                with: .color(Color.primary.opacity(0.07))
+            )
+        }
+        let nowX = layout.x(for: min(layout.rangeEnd, layout.now), in: size)
+        if nowX >= layout.chartX, nowX <= layout.chartX + layout.chartWidth(in: size) {
+            context.fill(
+                Path(CGRect(x: nowX - 0.5, y: 0, width: 1, height: layout.rowsHeight)),
+                with: .color(Color.primary.opacity(0.28))
+            )
+        }
+    }
+
+    private func drawLabels(
+        _ context: inout GraphicsContext,
+        lane: ResetHistoryComparison.Lane,
+        index: Int
+    ) {
+        let maxWidth = layout.labelWidth - layout.labelGap
+        let top = layout.rowTop(index) + layout.markerBand - 2
+        // Grouped by company, the heading carries the company; sorted by
+        // waste, each row has to name itself in full.
+        let title = comparison.ordering == .company ? lane.labelWithoutCompany : lane.label
+        context.draw(
+            truncated(
+                context,
+                title,
+                font: .system(size: layout.titleFontSize, weight: .semibold),
+                color: Color.primary.opacity(0.88),
+                maxWidth: maxWidth
+            ),
+            at: CGPoint(x: 0, y: top),
+            anchor: .topLeading
+        )
+        context.draw(
+            truncated(
+                context,
+                lane.wasteSummary,
+                font: .system(size: layout.captionFontSize, design: .rounded),
+                color: Color.primary.opacity(0.5),
+                maxWidth: maxWidth
+            ),
+            at: CGPoint(x: 0, y: top + layout.titleFontSize + 4),
+            anchor: .topLeading
+        )
+    }
+
+    private func drawLane(
+        _ context: inout GraphicsContext,
+        lane: ResetHistoryComparison.Lane,
+        index: Int,
+        size: CGSize
+    ) {
+        let baseline = layout.trackBottom(index)
+        let chartWidth = layout.chartWidth(in: size)
+        context.fill(
+            Path(CGRect(x: layout.chartX, y: baseline - 0.5, width: chartWidth, height: 0.5)),
+            with: .color(Color.primary.opacity(0.10))
+        )
+        guard !lane.cycles.isEmpty || lane.currentCycle != nil else {
+            context.draw(
+                truncated(
+                    context,
+                    lane.emptyStateText,
+                    font: .system(size: layout.captionFontSize),
+                    color: Color.primary.opacity(0.35),
+                    maxWidth: chartWidth - 8
+                ),
+                at: CGPoint(x: layout.chartX + 4, y: (layout.trackTop(index) + baseline) / 2),
+                anchor: .leading
+            )
+            return
+        }
+        // Downsample before drawing: a lane can hold more cycles than the row
+        // has pixels, and the wasteful ones are exactly the ones that must
+        // survive the cut.
+        let accent = Theme.providerAccent(for: lane.tool)
+        for cycle in ResetHistoryComparison.downsampled(lane.cycles, limit: layout.drawBudget(in: size)) {
+            drawBar(&context, cycle: cycle, laneIndex: index, accent: accent, size: size)
+        }
+        if let current = lane.currentCycle {
+            drawBar(&context, cycle: current, laneIndex: index, accent: accent, size: size)
+        }
+    }
+
+    private func drawBar(
+        _ context: inout GraphicsContext,
+        cycle: ResetHistoryComparison.Cycle,
+        laneIndex: Int,
+        accent: Color,
+        size: CGSize
+    ) {
+        guard let rect = layout.barRect(cycle, laneIndex: laneIndex, in: size) else { return }
+        let radius = min(2.5, rect.width / 2)
+        // The track is the wasted remainder; the fill is what was spent. The
+        // same two-part bar `FillTimelineChart` draws for a single lane.
+        context.fill(
+            Path(roundedRect: rect, cornerRadius: radius, style: .continuous),
+            with: .color(Theme.barTrack.opacity(0.62))
+        )
+        let fillHeight = cycle.usedPercent > 0 ? max(1, rect.height * cycle.usedPercent / 100) : 0
+        if fillHeight > 0 {
+            let fillRect = CGRect(
+                x: rect.minX,
+                y: rect.maxY - fillHeight,
+                width: rect.width,
+                height: fillHeight
+            )
+            context.fill(
+                Path(roundedRect: fillRect, cornerRadius: min(radius, fillHeight / 2), style: .continuous),
+                with: .color(accent.opacity(0.86))
+            )
+        }
+        if !cycle.isCompleted {
+            context.stroke(
+                Path(roundedRect: rect, cornerRadius: radius, style: .continuous),
+                with: .color(accent.opacity(0.9)),
+                style: StrokeStyle(lineWidth: 1, dash: [3, 2])
+            )
+        }
+        // Above the bar rather than inside it: a cycle that spent everything
+        // fills its track to the top, where a marker would be the same colour
+        // as the fill under it.
+        if cycle.refilledEarly {
+            let dot = CGRect(x: rect.midX - 1.5, y: layout.rowTop(laneIndex) + 1, width: 3, height: 3)
+            context.fill(Path(ellipseIn: dot), with: .color(accent.opacity(0.8)))
+        }
+    }
+
+    private func drawAxis(_ context: inout GraphicsContext, size: CGSize) {
+        let y = layout.rowsHeight + 1
+        let chartWidth = layout.chartWidth(in: size)
+        for tick in layout.ticks {
+            let tickX = layout.x(for: tick, in: size)
+            guard tickX >= layout.chartX - 1, tickX <= layout.chartX + chartWidth else { continue }
+            let text = context.resolve(
+                Text(ResetHistoryCompareFormatters.axis.string(from: tick))
+                    .font(.system(size: max(7, layout.captionFontSize - 1), design: .rounded))
+                    .foregroundStyle(Color.primary.opacity(0.4))
+            )
+            let width = text.measure(in: CGSize(width: 80, height: 20)).width
+            // Keep the first and last labels inside the plot instead of
+            // letting them hang off either end.
+            let clamped = min(
+                max(tickX - width / 2, layout.chartX),
+                layout.chartX + chartWidth - width
+            )
+            context.draw(text, at: CGPoint(x: clamped, y: y), anchor: .topLeading)
+        }
+    }
+
+    /// Single-line text that fits `maxWidth`, with an ellipsis when it does
+    /// not. `Canvas` has no truncation of its own, and a wrapped-then-clipped
+    /// label reads as a bug. Costs one resolve for a label that already fits,
+    /// which is most of them.
+    private func truncated(
+        _ context: GraphicsContext,
+        _ string: String,
+        font: Font,
+        color: Color,
+        maxWidth: CGFloat
+    ) -> GraphicsContext.ResolvedText {
+        let probe = CGSize(width: 10_000, height: 40)
+        func resolve(_ candidate: String) -> GraphicsContext.ResolvedText {
+            context.resolve(Text(candidate).font(font).foregroundStyle(color))
+        }
+        let full = resolve(string)
+        guard maxWidth > 0, full.measure(in: probe).width > maxWidth else { return full }
+        let characters = Array(string)
+        var low = 0
+        var high = characters.count
+        var best = ""
+        while low <= high {
+            let mid = (low + high) / 2
+            let candidate = String(characters.prefix(mid)) + "…"
+            if resolve(candidate).measure(in: probe).width <= maxWidth {
+                best = candidate
+                low = mid + 1
+            } else {
+                high = mid - 1
+            }
+        }
+        return resolve(best.isEmpty ? "…" : best)
+    }
+}
+
+private enum ResetHistoryCompareFormatters {
+    static let axis: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "MMM d"
+        return formatter
+    }()
+
+    static let tooltip: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "MMM d, HH:mm"
+        return formatter
+    }()
+}

--- a/Sources/VibeBarApp/Views/ResetHistoryCompareView.swift
+++ b/Sources/VibeBarApp/Views/ResetHistoryCompareView.swift
@@ -20,6 +20,15 @@ enum ResetHistoryLanes {
         tools: [ToolType]? = nil
     ) -> [ResetHistoryLaneInput] {
         let settings = environment.settingsStore.settings
+        let history = environment.quotaService.historyByAccountBucket
+        let registry = environment.quotaService.fieldRegistry
+        // Every bucket the history remembers, grouped once. Walking the whole
+        // dictionary per account would be O(accounts x lanes) for an answer
+        // that does not change between accounts.
+        var recordedByAccount: [String: [SubscriptionHistoryKey]] = [:]
+        for key in history.keys {
+            recordedByAccount[key.accountId, default: []].append(key)
+        }
         var out: [ResetHistoryLaneInput] = []
         // Canonical provider order, so the `.company` grouping is the app's
         // own order rather than an alphabetical reshuffle.
@@ -33,9 +42,14 @@ enum ResetHistoryLanes {
             // per account, and each account is its own lane.
             let accounts = environment.accountStore.accounts(for: tool)
             for account in accounts {
-                guard let quota = environment.quotaService.cachedQuota(for: account.id) else { continue }
+                // Not `guard let`: an account with no cached quota can still
+                // have recorded cycles, and dropping it here is exactly how a
+                // renamed bucket used to vanish.
+                let quota = environment.quotaService.cachedQuota(for: account.id)
                 let accountLabel = accounts.count > 1 ? account.displayLabel : nil
-                for bucket in quota.buckets {
+                var liveBucketIds: Set<String> = []
+                for bucket in quota?.buckets ?? [] {
+                    liveBucketIds.insert(bucket.id)
                     let key = SubscriptionHistoryKey(accountId: account.id, bucketId: bucket.id)
                     let subProvider = tool.quotaSubProviderName(bucketID: bucket.id)
                     let trimmed = bucket.groupTitle?.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -59,13 +73,74 @@ enum ResetHistoryLanes {
                             currentResetAt: bucket.resetAt,
                             // COW: this is a retain, not a copy, which is what
                             // makes the cache's equality check cheap.
-                            samples: environment.quotaService.historyByAccountBucket[key] ?? []
+                            samples: history[key] ?? []
+                        )
+                    )
+                }
+                // Buckets the provider has stopped returning. Their cycles are
+                // still in the history, and a weekly model limit that was
+                // renamed away is precisely the one whose waste record the
+                // user would otherwise never see again. No current cycle:
+                // there is no live bucket to read one from.
+                for key in (recordedByAccount[account.id] ?? []).sorted(by: { $0.bucketId < $1.bucketId }) {
+                    guard !liveBucketIds.contains(key.bucketId),
+                          let samples = history[key], !samples.isEmpty
+                    else { continue }
+                    // Identity comes from the samples themselves: the account
+                    // pins the tool, but a sample records its own, which is
+                    // what names a bucket whose adapter serves two
+                    // SubProviders. A tool outside this page's scope falls
+                    // back to the account's rather than leaking onto it.
+                    let sampleTool = samples[0].tool
+                    let laneTool = (tools?.contains(sampleTool) ?? true) ? sampleTool : tool
+                    out.append(
+                        ResetHistoryLaneInput(
+                            accountId: account.id,
+                            tool: laneTool,
+                            bucketId: key.bucketId,
+                            company: laneTool.vendorName,
+                            subProvider: laneTool.quotaSubProviderName(bucketID: key.bucketId),
+                            groupTitle: nil,
+                            bucketTitle: retiredBucketTitle(
+                                tool: laneTool,
+                                bucketId: key.bucketId,
+                                registry: registry
+                            ),
+                            accountLabel: accountLabel,
+                            liveWindowSeconds: nil,
+                            currentUsedPercent: nil,
+                            currentResetAt: nil,
+                            samples: samples
                         )
                     )
                 }
             }
         }
         return out
+    }
+
+    /// What to call a bucket no live quota carries any more.
+    ///
+    /// The mini-window catalog already names buckets — the static table for
+    /// the ones this build ships with, `QuotaFieldRegistry` for the ones an
+    /// adapter discovered at runtime, which it keeps precisely so a bucket
+    /// survives the provider dropping it. Its titles are already in the
+    /// "group / window" form the lane label wants ("Fable / Weekly"), so the
+    /// group slot stays empty. Only when neither knows the bucket does this
+    /// fall back to the id, spaced out rather than left as a raw token.
+    static func retiredBucketTitle(
+        tool: ToolType,
+        bucketId: String,
+        registry: QuotaFieldRegistry
+    ) -> String {
+        let fieldId = MenuBarFieldCatalog.fieldId(tool: tool, bucketId: bucketId)
+        if let known = MenuBarFieldCatalog.field(id: fieldId, registry: registry) {
+            return known.title
+        }
+        return bucketId
+            .split(whereSeparator: { $0 == "_" || $0 == "-" })
+            .map { $0.prefix(1).uppercased() + $0.dropFirst() }
+            .joined(separator: " ")
     }
 }
 
@@ -274,12 +349,27 @@ struct ResetHistoryCompareLayout: Equatable {
     let rowGap: CGFloat = 6
     let labelGap: CGFloat = 8
     let axisHeight: CGFloat = 13
-    let laneCount: Int
     let titleFontSize: CGFloat
     let captionFontSize: CGFloat
     let rangeStart: Date
     let rangeEnd: Date
     let now: Date
+    /// Height of a company heading. Zero unless the rows are grouped, so the
+    /// ungrouped layout is byte-for-byte the one it always was.
+    let headingHeight: CGFloat
+    /// What the surface draws, top to bottom.
+    let rows: [Row]
+    /// Y of each row in `rows`.
+    let rowTops: [CGFloat]
+    /// Y of each lane, indexed by its position in `comparison.lanes`. The
+    /// headings push these down, which is the whole reason the geometry is
+    /// resolved once and shared instead of derived from an index twice.
+    let laneTops: [CGFloat]
+
+    enum Row: Equatable {
+        case heading(String)
+        case lane(Int)
+    }
 
     init(density: Theme.Density, comparison: ResetHistoryComparison) {
         // Two text lines and a bar per row. Deliberately tight: a dozen
@@ -296,22 +386,60 @@ struct ResetHistoryCompareLayout: Equatable {
             rowHeight = 52
             labelWidth = 190
         }
-        laneCount = comparison.lanes.count
         titleFontSize = max(9, density.subtitleFontSize - 0.5)
         captionFontSize = max(8, density.subtitleFontSize - 2)
         rangeStart = comparison.rangeStart
         rangeEnd = comparison.rangeEnd
         now = comparison.now
+
+        let grouped = comparison.ordering == .company
+        let heading = grouped ? max(16, titleFontSize + 8) : 0
+        headingHeight = heading
+        var rows: [Row] = []
+        var rowTops: [CGFloat] = []
+        var laneTops: [CGFloat] = []
+        var y: CGFloat = 0
+        var currentCompany: String?
+        for (index, lane) in comparison.lanes.enumerated() {
+            if grouped, lane.company != currentCompany {
+                currentCompany = lane.company
+                rows.append(.heading(lane.company))
+                rowTops.append(y)
+                y += heading
+            }
+            rows.append(.lane(index))
+            rowTops.append(y)
+            laneTops.append(y)
+            y += rowHeight
+        }
+        self.rows = rows
+        self.rowTops = rowTops
+        self.laneTops = laneTops
+        rowsHeight = y
     }
 
-    var totalHeight: CGFloat { CGFloat(laneCount) * rowHeight + axisHeight }
-    var rowsHeight: CGFloat { CGFloat(laneCount) * rowHeight }
+    /// Total height of the rows, headings included.
+    let rowsHeight: CGFloat
+
+    var totalHeight: CGFloat { rowsHeight + axisHeight }
     var chartX: CGFloat { labelWidth + labelGap }
 
     func chartWidth(in size: CGSize) -> CGFloat { max(20, size.width - chartX) }
-    func rowTop(_ index: Int) -> CGFloat { CGFloat(index) * rowHeight }
-    func trackTop(_ index: Int) -> CGFloat { rowTop(index) + markerBand }
-    func trackBottom(_ index: Int) -> CGFloat { rowTop(index) + rowHeight - rowGap }
+    func laneTop(_ index: Int) -> CGFloat {
+        index >= 0 && index < laneTops.count ? laneTops[index] : 0
+    }
+    func trackTop(_ index: Int) -> CGFloat { laneTop(index) + markerBand }
+    func trackBottom(_ index: Int) -> CGFloat { laneTop(index) + rowHeight - rowGap }
+
+    /// The lane under a pointer, or `nil` over a heading, a gap, or the axis.
+    /// Never `y / rowHeight`: with headings in the stack that arithmetic is
+    /// off by one row per company.
+    func laneIndex(atY y: CGFloat) -> Int? {
+        for (index, top) in laneTops.enumerated() where y >= top && y < top + rowHeight {
+            return index
+        }
+        return nil
+    }
 
     /// Bars per lane the row has room for. Three points is already narrower
     /// than a bar the eye can separate.
@@ -455,8 +583,9 @@ struct ResetHistoryCompareView: View {
         in size: CGSize,
         layout: ResetHistoryCompareLayout
     ) -> Hover? {
-        let index = Int(location.y / layout.rowHeight)
-        guard index >= 0, index < comparison.lanes.count else { return nil }
+        guard let index = layout.laneIndex(atY: location.y),
+              index < comparison.lanes.count
+        else { return nil }
         let lane = comparison.lanes[index]
         var candidates = ResetHistoryComparison.downsampled(
             lane.cycles,
@@ -563,9 +692,21 @@ private struct ResetHistoryLanesCanvas: View, Equatable {
     var body: some View {
         Canvas(opaque: false, rendersAsynchronously: false) { context, size in
             drawGrid(&context, size: size)
-            for (index, lane) in comparison.lanes.enumerated() {
-                drawLabels(&context, lane: lane, index: index)
-                drawLane(&context, lane: lane, index: index, size: size)
+            for (row, top) in zip(layout.rows, layout.rowTops) {
+                switch row {
+                case let .heading(company):
+                    drawHeading(
+                        &context,
+                        company: company,
+                        top: top,
+                        isFirst: top == 0,
+                        size: size
+                    )
+                case let .lane(index):
+                    let lane = comparison.lanes[index]
+                    drawLabels(&context, lane: lane, index: index)
+                    drawLane(&context, lane: lane, index: index, size: size)
+                }
             }
             drawAxis(&context, size: size)
         }
@@ -590,13 +731,44 @@ private struct ResetHistoryLanesCanvas: View, Equatable {
         }
     }
 
+    /// One L1 company band: a rule across the full width and the company's
+    /// name over it. Without this the grouped ordering strips the company off
+    /// every row and puts it nowhere — "Gemini Web" and "AntiGravity" sitting
+    /// under no Google AI at all.
+    private func drawHeading(
+        _ context: inout GraphicsContext,
+        company: String,
+        top: CGFloat,
+        isFirst: Bool,
+        size: CGSize
+    ) {
+        if !isFirst {
+            context.fill(
+                Path(CGRect(x: 0, y: top + 1, width: size.width, height: 0.5)),
+                with: .color(Color.primary.opacity(0.12))
+            )
+        }
+        context.draw(
+            truncated(
+                context,
+                company.uppercased(),
+                font: .system(size: max(8, layout.captionFontSize), weight: .bold),
+                color: Color.primary.opacity(0.55),
+                maxWidth: max(20, size.width),
+                tracking: 0.5
+            ),
+            at: CGPoint(x: 0, y: top + layout.headingHeight - 4),
+            anchor: .bottomLeading
+        )
+    }
+
     private func drawLabels(
         _ context: inout GraphicsContext,
         lane: ResetHistoryComparison.Lane,
         index: Int
     ) {
         let maxWidth = layout.labelWidth - layout.labelGap
-        let top = layout.rowTop(index) + layout.markerBand - 2
+        let top = layout.laneTop(index) + layout.markerBand - 2
         // Grouped by company, the heading carries the company; sorted by
         // waste, each row has to name itself in full.
         let title = comparison.ordering == .company ? lane.labelWithoutCompany : lane.label
@@ -701,7 +873,7 @@ private struct ResetHistoryLanesCanvas: View, Equatable {
         // fills its track to the top, where a marker would be the same colour
         // as the fill under it.
         if cycle.refilledEarly {
-            let dot = CGRect(x: rect.midX - 1.5, y: layout.rowTop(laneIndex) + 1, width: 3, height: 3)
+            let dot = CGRect(x: rect.midX - 1.5, y: layout.laneTop(laneIndex) + 1, width: 3, height: 3)
             context.fill(Path(ellipseIn: dot), with: .color(accent.opacity(0.8)))
         }
     }
@@ -737,11 +909,14 @@ private struct ResetHistoryLanesCanvas: View, Equatable {
         _ string: String,
         font: Font,
         color: Color,
-        maxWidth: CGFloat
+        maxWidth: CGFloat,
+        tracking: CGFloat = 0
     ) -> GraphicsContext.ResolvedText {
         let probe = CGSize(width: 10_000, height: 40)
         func resolve(_ candidate: String) -> GraphicsContext.ResolvedText {
-            context.resolve(Text(candidate).font(font).foregroundStyle(color))
+            context.resolve(
+                Text(candidate).font(font).tracking(tracking).foregroundStyle(color)
+            )
         }
         let full = resolve(string)
         guard maxWidth > 0, full.measure(in: probe).width > maxWidth else { return full }

--- a/Sources/VibeBarApp/Views/Workbench/ResetsPage.swift
+++ b/Sources/VibeBarApp/Views/Workbench/ResetsPage.swift
@@ -45,6 +45,10 @@ struct ResetsPage: View {
                         laneHeight: 96
                     )
                 }
+                // Draws its own card, so it is inserted bare rather than
+                // wrapped in `box` — a second surface under a card is the one
+                // thing `docs/DESIGN.md` forbids outright.
+                ResetHistoryCompareCard(density: density)
                 cycleGrid(cycles, now: now)
                 HStack(alignment: .top, spacing: 14) {
                     box {

--- a/Sources/VibeBarCore/Models/ResetHistoryComparison.swift
+++ b/Sources/VibeBarCore/Models/ResetHistoryComparison.swift
@@ -34,6 +34,16 @@ public struct ResetHistoryLaneInput: Equatable, Sendable, Identifiable {
     /// history has no open sample of its own.
     public var currentUsedPercent: Double?
     public var currentResetAt: Date?
+    /// No live bucket backs this lane any more — the provider stopped
+    /// returning it, or the account it belonged to is gone.
+    ///
+    /// It is not the same question as "are the live fields nil", and the
+    /// difference is a bar on screen. A cycle closes only when another
+    /// observation arrives, so a withdrawn bucket keeps its last *open*
+    /// sample forever. Without this flag `build` would read that stale sample
+    /// as the current cycle and draw a dashed "Current" bar for a quota that
+    /// stopped existing months ago.
+    public var isRetired: Bool
     public var samples: [SubscriptionWindowSample]
 
     public var id: String { "\(accountId).\(bucketId)" }
@@ -50,6 +60,7 @@ public struct ResetHistoryLaneInput: Equatable, Sendable, Identifiable {
         liveWindowSeconds: Int? = nil,
         currentUsedPercent: Double? = nil,
         currentResetAt: Date? = nil,
+        isRetired: Bool = false,
         samples: [SubscriptionWindowSample]
     ) {
         self.accountId = accountId
@@ -63,6 +74,7 @@ public struct ResetHistoryLaneInput: Equatable, Sendable, Identifiable {
         self.liveWindowSeconds = liveWindowSeconds
         self.currentUsedPercent = currentUsedPercent
         self.currentResetAt = currentResetAt
+        self.isRetired = isRetired
         self.samples = samples
     }
 }
@@ -352,6 +364,10 @@ public struct ResetHistoryComparison: Equatable, Sendable {
         for (input, windowSeconds) in qualifying {
             var completed: [Cycle] = []
             var open: Cycle?
+            // A retired lane has no present tense. Its last open sample was
+            // never closed because nothing observed it again, and the live
+            // quota that would have closed it is gone.
+            let hasCurrentCycle = !input.isRetired
             for sample in input.samples {
                 let start = cycleStart(sample, windowSeconds: windowSeconds)
                 // A cycle ends when the refill was noticed, which is not always
@@ -371,7 +387,7 @@ public struct ResetHistoryComparison: Equatable, Sendable {
                     guard cycle.end >= rangeStart else { continue }
                     completed.append(cycle)
                     latestEnd = max(latestEnd, cycle.end)
-                } else if open == nil || cycle.end > open!.end {
+                } else if hasCurrentCycle, open == nil || cycle.end > open!.end {
                     open = cycle
                 }
             }
@@ -379,7 +395,8 @@ public struct ResetHistoryComparison: Equatable, Sendable {
 
             // The live quota is the fallback for the in-progress cycle: a lane
             // whose history holds only closed samples still has one running.
-            if open == nil,
+            if hasCurrentCycle,
+               open == nil,
                let used = input.currentUsedPercent,
                let resetAt = input.currentResetAt {
                 open = Cycle(

--- a/Sources/VibeBarCore/Models/ResetHistoryComparison.swift
+++ b/Sources/VibeBarCore/Models/ResetHistoryComparison.swift
@@ -1,0 +1,576 @@
+import Foundation
+
+/// One quota lane handed to the reset-history comparison.
+///
+/// The App layer does the discovery (which accounts, which buckets, what they
+/// are called); everything downstream of that — the weekly-and-up filter, the
+/// waste arithmetic, the ordering, the verdict sentence, the draw budget —
+/// lives here so it can be tested without a view and computed once per data
+/// change instead of once per render.
+///
+/// `Equatable` on purpose: the App caches a built comparison keyed on the
+/// inputs, and `[SubscriptionWindowSample]` comparison short-circuits on
+/// identical storage, so an unchanged history costs one pointer compare per
+/// lane rather than a walk over every sample.
+public struct ResetHistoryLaneInput: Equatable, Sendable, Identifiable {
+    public var accountId: String
+    public var tool: ToolType
+    public var bucketId: String
+    /// L1 company ("Anthropic"). See `AGENTS.md` § 7.1 — this surface is on
+    /// the quota axis, so it speaks company / SubProvider / group / bucket.
+    public var company: String
+    /// L2 SubProvider ("Claude"), from `ToolType.quotaSubProviderName`.
+    public var subProvider: String
+    /// L3 quota / model group ("Fable"), `nil` for a SubProvider's primary lane.
+    public var groupTitle: String?
+    /// The bucket itself ("Weekly").
+    public var bucketTitle: String
+    /// Set only when the provider has more than one account, so a
+    /// single-account setup keeps its short labels.
+    public var accountLabel: String?
+    /// Window length from the live bucket, used when a sample carries none.
+    public var liveWindowSeconds: Int?
+    /// The in-progress cycle as the live quota sees it. Used only when the
+    /// history has no open sample of its own.
+    public var currentUsedPercent: Double?
+    public var currentResetAt: Date?
+    public var samples: [SubscriptionWindowSample]
+
+    public var id: String { "\(accountId).\(bucketId)" }
+
+    public init(
+        accountId: String,
+        tool: ToolType,
+        bucketId: String,
+        company: String,
+        subProvider: String,
+        groupTitle: String? = nil,
+        bucketTitle: String,
+        accountLabel: String? = nil,
+        liveWindowSeconds: Int? = nil,
+        currentUsedPercent: Double? = nil,
+        currentResetAt: Date? = nil,
+        samples: [SubscriptionWindowSample]
+    ) {
+        self.accountId = accountId
+        self.tool = tool
+        self.bucketId = bucketId
+        self.company = company
+        self.subProvider = subProvider
+        self.groupTitle = groupTitle
+        self.bucketTitle = bucketTitle
+        self.accountLabel = accountLabel
+        self.liveWindowSeconds = liveWindowSeconds
+        self.currentUsedPercent = currentUsedPercent
+        self.currentResetAt = currentResetAt
+        self.samples = samples
+    }
+}
+
+/// Every weekly-and-longer quota's reset history, side by side on one time
+/// axis, answering a single question: how much of what was paid for expired
+/// unused?
+///
+/// Five-hour lanes are deliberately excluded. They refill several times a day,
+/// so a bar per cycle would be noise at any width the module can occupy, and
+/// "wasted" is not a meaningful verdict on a window that comes back before
+/// lunch. The cut is made on the *window length* (`minimumWindowSeconds`),
+/// never on a bucket name — bucket ids and titles vary per provider and change
+/// without notice.
+public struct ResetHistoryComparison: Equatable, Sendable {
+    // MARK: - Policy
+
+    /// Weekly and up. A lane whose window is shorter than this never appears.
+    public static let minimumWindowSeconds = 7 * 86_400
+
+    /// How many recent cycles the per-lane "avg wasted" figure covers.
+    public static let averageCycleCount = 4
+
+    /// A cycle that refilled with more than this much unused is the shape the
+    /// verdict sentence is allowed to call out.
+    public static let wastefulCyclePercent: Double = 50
+
+    /// Below this, an average is not worth a sentence of its own.
+    public static let notableAverageWastePercent: Double = 25
+
+    // MARK: - Nested types
+
+    /// Visible span of the shared time axis.
+    public enum Window: String, CaseIterable, Hashable, Sendable, Codable {
+        case fourWeeks
+        case eightWeeks
+        case twelveWeeks
+        case all
+
+        public var weeks: Int? {
+            switch self {
+            case .fourWeeks: 4
+            case .eightWeeks: 8
+            case .twelveWeeks: 12
+            case .all: nil
+            }
+        }
+
+        /// Compact picker label.
+        public var shortTitle: String {
+            switch self {
+            case .fourWeeks: "4w"
+            case .eightWeeks: "8w"
+            case .twelveWeeks: "12w"
+            case .all: "All"
+            }
+        }
+
+        public var spokenTitle: String {
+            switch self {
+            case .fourWeeks: "last 4 weeks"
+            case .eightWeeks: "last 8 weeks"
+            case .twelveWeeks: "last 12 weeks"
+            case .all: "all recorded history"
+            }
+        }
+    }
+
+    /// Row order.
+    public enum Ordering: String, CaseIterable, Hashable, Sendable, Codable {
+        /// Most wasted first — the default, because the module exists to
+        /// answer "where am I throwing quota away".
+        case waste
+        /// Grouped by L1 company, most wasted first inside each company.
+        case company
+    }
+
+    /// One bar: a subscription cycle placed on the shared axis.
+    public struct Cycle: Equatable, Sendable, Identifiable {
+        public let id: String
+        public let start: Date
+        public let end: Date
+        /// Peak used percent — the bar's height.
+        public let usedPercent: Double
+        public let isCompleted: Bool
+        public let resetKind: SubscriptionWindowSample.ResetKind?
+
+        /// The muted remainder above the fill: quota that expired unused.
+        public var wastedPercent: Double { max(0, 100 - usedPercent) }
+
+        /// Did this window refill before it said it would? Same question, and
+        /// the same answer, as `SubscriptionWindowSample.refilledEarly`.
+        public var refilledEarly: Bool {
+            switch resetKind {
+            case .earlyClockRestarted, .earlyClockUnchanged, .earlyUnclear: true
+            case .onSchedule, .unobserved, nil: false
+            }
+        }
+
+        /// What the provider did to the clock, when it did anything unusual.
+        /// Empty for an ordinary on-schedule reset — the two early shapes mean
+        /// opposite things, so the copy says which (see `AGENTS.md` § 11).
+        public var resetDescription: String {
+            switch resetKind {
+            case .earlyClockRestarted: "refilled early, next window restarted"
+            case .earlyClockUnchanged: "refilled early, next reset unchanged"
+            case .earlyUnclear: "refilled early, onto a different schedule"
+            case .onSchedule, .unobserved, nil: ""
+            }
+        }
+
+        public init(
+            id: String,
+            start: Date,
+            end: Date,
+            usedPercent: Double,
+            isCompleted: Bool,
+            resetKind: SubscriptionWindowSample.ResetKind? = nil
+        ) {
+            self.id = id
+            self.start = start
+            self.end = end
+            self.usedPercent = usedPercent.isFinite ? min(100, max(0, usedPercent)) : 0
+            self.isCompleted = isCompleted
+            self.resetKind = resetKind
+        }
+    }
+
+    /// One row: a quota that resets independently of every other row.
+    public struct Lane: Equatable, Sendable, Identifiable {
+        public let id: String
+        public let tool: ToolType
+        public let company: String
+        public let subProvider: String
+        public let groupTitle: String?
+        public let bucketTitle: String
+        public let accountLabel: String?
+        /// The lane's own window length, in seconds. Always at least
+        /// `minimumWindowSeconds`.
+        public let windowSeconds: Int
+        /// Completed cycles inside the visible span, oldest first.
+        public let cycles: [Cycle]
+        /// The cycle running right now, if one is known.
+        public let currentCycle: Cycle?
+        /// Mean unused percent over the most recent `averagedCycleCount`
+        /// completed cycles. `nil` when nothing has completed yet.
+        public let averageWastedPercent: Double?
+        /// How many cycles that average actually covers — the copy says so
+        /// rather than promising "last 4" it does not have.
+        public let averagedCycleCount: Int
+        /// Completed cycles in the span that refilled with more than half
+        /// unused.
+        public let wastefulCycleCount: Int
+
+        /// Full quota-axis name: company · SubProvider · group · bucket.
+        public var label: String {
+            var parts = [company, subProvider]
+            if let groupTitle, !groupTitle.isEmpty { parts.append(groupTitle) }
+            if !bucketTitle.isEmpty, bucketTitle != groupTitle { parts.append(bucketTitle) }
+            if let accountLabel, !accountLabel.isEmpty { parts.append(accountLabel) }
+            return parts.joined(separator: " · ")
+        }
+
+        /// The same name with the company dropped, for the company-grouped
+        /// ordering where the heading already carries it.
+        public var labelWithoutCompany: String {
+            var parts = [subProvider]
+            if let groupTitle, !groupTitle.isEmpty { parts.append(groupTitle) }
+            if !bucketTitle.isEmpty, bucketTitle != groupTitle { parts.append(bucketTitle) }
+            if let accountLabel, !accountLabel.isEmpty { parts.append(accountLabel) }
+            return parts.joined(separator: " · ")
+        }
+
+        /// The line under the label. Says how many cycles it is averaging so a
+        /// one-cycle lane cannot read as a settled habit.
+        public var wasteSummary: String {
+            guard let averageWastedPercent else {
+                return "No completed cycles yet"
+            }
+            let cycleWord = averagedCycleCount == 1 ? "cycle" : "cycles"
+            return "avg wasted \(Self.percentText(averageWastedPercent))% · last \(averagedCycleCount) \(cycleWord)"
+        }
+
+        /// Empty-state copy for a lane the history has never closed a cycle on
+        /// — a brand-new bucket, or one whose provider has not refilled since
+        /// Vibe Bar first saw it.
+        public var emptyStateText: String {
+            "No completed cycles yet — a cycle is recorded when the quota refills"
+        }
+
+        static func percentText(_ value: Double) -> String {
+            String(Int(value.rounded()))
+        }
+    }
+
+    /// The header's one-line arithmetic across every visible lane.
+    public struct Totals: Equatable, Sendable {
+        public let cycleCount: Int
+        /// Share of the refilled capacity that was actually spent.
+        public let usedPercent: Double
+        public var wastedPercent: Double { max(0, 100 - usedPercent) }
+
+        public init(cycleCount: Int, usedPercent: Double) {
+            self.cycleCount = cycleCount
+            self.usedPercent = usedPercent.isFinite ? min(100, max(0, usedPercent)) : 0
+        }
+
+        public var headline: String {
+            guard cycleCount > 0 else { return "No completed cycles in this window" }
+            let cycleWord = cycleCount == 1 ? "cycle" : "cycles"
+            return "\(Lane.percentText(usedPercent))% used · \(Lane.percentText(wastedPercent))% wasted · \(cycleCount) \(cycleWord)"
+        }
+    }
+
+    // MARK: - Value
+
+    public let window: Window
+    public let ordering: Ordering
+    /// The clock the comparison was built against, so the view can draw its
+    /// "now" hairline without reading the wall clock inside a draw pass — a
+    /// value that changed under an otherwise-equal comparison would make the
+    /// drawing surface's `Equatable` short-circuit a lie.
+    public let now: Date
+    public let rangeStart: Date
+    public let rangeEnd: Date
+    public let lanes: [Lane]
+    public let totals: Totals
+    /// One plain sentence generated from the data, never a template with a
+    /// blank in it. Always non-empty.
+    public let verdict: String
+
+    public var isEmpty: Bool { lanes.isEmpty }
+
+    /// Whole-module screen-reader text. The lanes are a drawing surface, so
+    /// this is the only thing VoiceOver gets to read.
+    public var accessibilitySummary: String {
+        guard !lanes.isEmpty else {
+            return "Reset history comparison. \(verdict)"
+        }
+        let laneText = lanes.prefix(8).map { lane -> String in
+            guard let wasted = lane.averageWastedPercent else {
+                return "\(lane.label): no completed cycles"
+            }
+            return "\(lane.label): \(Lane.percentText(wasted))% wasted on average over \(lane.averagedCycleCount) cycles"
+        }.joined(separator: ". ")
+        let more = lanes.count > 8 ? " And \(lanes.count - 8) more quotas." : ""
+        return "Reset history comparison over \(window.spokenTitle). \(totals.headline). \(verdict) \(laneText).\(more)"
+    }
+
+    // MARK: - Building
+
+    /// Build the comparison. Pure: everything it needs is in `inputs`.
+    public static func build(
+        inputs: [ResetHistoryLaneInput],
+        window: Window = .eightWeeks,
+        ordering: Ordering = .waste,
+        now: Date
+    ) -> ResetHistoryComparison {
+        // 1. Weekly and up, decided on the window length rather than a name.
+        let qualifying: [(input: ResetHistoryLaneInput, windowSeconds: Int)] = inputs.compactMap { input in
+            guard let seconds = laneWindowSeconds(input), seconds >= minimumWindowSeconds else {
+                return nil
+            }
+            return (input, seconds)
+        }
+
+        // 2. The visible span. A fixed window counts back from now; `all`
+        //    starts at the oldest cycle anything recorded.
+        var rangeStart: Date
+        if let weeks = window.weeks {
+            rangeStart = now.addingTimeInterval(-Double(weeks) * 7 * 86_400)
+        } else {
+            let earliest = qualifying.compactMap { entry in
+                entry.input.samples
+                    .map { cycleStart($0, windowSeconds: entry.windowSeconds) }
+                    .min()
+            }.min()
+            rangeStart = earliest ?? now.addingTimeInterval(-8 * 7 * 86_400)
+        }
+        if rangeStart >= now {
+            rangeStart = now.addingTimeInterval(-Double(minimumWindowSeconds))
+        }
+
+        // 3. One lane per qualifying quota.
+        var lanes: [Lane] = []
+        var latestEnd = now
+        for (input, windowSeconds) in qualifying {
+            var completed: [Cycle] = []
+            var open: Cycle?
+            for sample in input.samples {
+                let start = cycleStart(sample, windowSeconds: windowSeconds)
+                // A cycle ends when the refill was noticed, which is not always
+                // the boundary it advertised — an early refill genuinely ended
+                // sooner, and drawing it at the advertised end would put the
+                // bar where nothing happened.
+                let end = sample.isCompleted ? (sample.completedAt ?? sample.windowEnd) : sample.windowEnd
+                let cycle = Cycle(
+                    id: "\(input.id).\(end.timeIntervalSinceReferenceDate)",
+                    start: min(start, end),
+                    end: end,
+                    usedPercent: sample.peakUsedPercent,
+                    isCompleted: sample.isCompleted,
+                    resetKind: sample.resetKind
+                )
+                if sample.isCompleted {
+                    guard cycle.end >= rangeStart else { continue }
+                    completed.append(cycle)
+                    latestEnd = max(latestEnd, cycle.end)
+                } else if open == nil || cycle.end > open!.end {
+                    open = cycle
+                }
+            }
+            completed.sort { $0.end < $1.end }
+
+            // The live quota is the fallback for the in-progress cycle: a lane
+            // whose history holds only closed samples still has one running.
+            if open == nil,
+               let used = input.currentUsedPercent,
+               let resetAt = input.currentResetAt {
+                open = Cycle(
+                    id: "\(input.id).current",
+                    start: resetAt.addingTimeInterval(-Double(windowSeconds)),
+                    end: resetAt,
+                    usedPercent: used,
+                    isCompleted: false,
+                    resetKind: nil
+                )
+            }
+            if let open { latestEnd = max(latestEnd, min(open.end, now)) }
+
+            let averaged = Array(completed.suffix(averageCycleCount))
+            let average = averaged.isEmpty
+                ? nil
+                : averaged.reduce(0) { $0 + $1.wastedPercent } / Double(averaged.count)
+
+            lanes.append(
+                Lane(
+                    id: input.id,
+                    tool: input.tool,
+                    company: input.company,
+                    subProvider: input.subProvider,
+                    groupTitle: input.groupTitle,
+                    bucketTitle: input.bucketTitle,
+                    accountLabel: input.accountLabel,
+                    windowSeconds: windowSeconds,
+                    cycles: completed,
+                    currentCycle: open,
+                    averageWastedPercent: average,
+                    averagedCycleCount: averaged.count,
+                    wastefulCycleCount: completed.count { $0.wastedPercent > wastefulCyclePercent }
+                )
+            )
+        }
+
+        // 4. Order.
+        let ordered = sorted(lanes, by: ordering, companyOrder: companyOrder(qualifying.map(\.input)))
+
+        // 5. Header arithmetic and the sentence under it.
+        let allCycles = ordered.flatMap(\.cycles)
+        let totals = Totals(
+            cycleCount: allCycles.count,
+            usedPercent: allCycles.isEmpty
+                ? 0
+                : allCycles.reduce(0) { $0 + $1.usedPercent } / Double(allCycles.count)
+        )
+
+        return ResetHistoryComparison(
+            window: window,
+            ordering: ordering,
+            now: now,
+            rangeStart: rangeStart,
+            rangeEnd: max(latestEnd, rangeStart.addingTimeInterval(Double(minimumWindowSeconds))),
+            lanes: ordered,
+            totals: totals,
+            verdict: verdict(lanes: ordered, totals: totals)
+        )
+    }
+
+    // MARK: - Draw budget
+
+    /// Bars that actually get drawn when a lane has more cycles than the row
+    /// has pixels.
+    ///
+    /// Not uniform striding: this chart's whole point is the wasteful cycles,
+    /// and an even stride is exactly as likely to drop the worst one as any
+    /// other. Endpoints survive first (they anchor the axis), then the largest
+    /// waste, and the result comes back in time order.
+    public static func downsampled(_ cycles: [Cycle], limit: Int) -> [Cycle] {
+        guard limit > 0 else { return [] }
+        guard cycles.count > limit else { return cycles }
+        var keep: Set<Int> = []
+        if limit >= 1 { keep.insert(0) }
+        if limit >= 2 { keep.insert(cycles.count - 1) }
+        let byWaste = cycles.indices.sorted { lhs, rhs in
+            let left = cycles[lhs].wastedPercent
+            let right = cycles[rhs].wastedPercent
+            return left == right ? lhs < rhs : left > right
+        }
+        for index in byWaste where keep.count < limit {
+            keep.insert(index)
+        }
+        return keep.sorted().map { cycles[$0] }
+    }
+
+    // MARK: - Internals
+
+    /// The lane's window length: what the live bucket says, else the length
+    /// the samples agree on most often. Ties go to the longer window, because
+    /// under-reporting a window is what would wrongly demote a weekly lane
+    /// into the excluded five-hour band.
+    static func laneWindowSeconds(_ input: ResetHistoryLaneInput) -> Int? {
+        if let live = input.liveWindowSeconds, live > 0 { return live }
+        var counts: [Int: Int] = [:]
+        for sample in input.samples {
+            guard let seconds = sample.rawWindowSeconds, seconds > 0 else { continue }
+            counts[seconds, default: 0] += 1
+        }
+        guard !counts.isEmpty else { return nil }
+        return counts.max { lhs, rhs in
+            lhs.value == rhs.value ? lhs.key < rhs.key : lhs.value < rhs.value
+        }?.key
+    }
+
+    /// Where a cycle's bar starts. The stored `windowStart` is the measured
+    /// truth and wins whenever it exists — reconstructing it from the nominal
+    /// window is the "fix" § 11 of `AGENTS.md` records as already wrong.
+    private static func cycleStart(_ sample: SubscriptionWindowSample, windowSeconds: Int) -> Date {
+        if let start = sample.windowStart { return start }
+        let end = sample.isCompleted ? (sample.completedAt ?? sample.windowEnd) : sample.windowEnd
+        return end.addingTimeInterval(-Double(sample.rawWindowSeconds ?? windowSeconds))
+    }
+
+    /// Companies in the order the caller discovered them, which is the app's
+    /// canonical provider order — not alphabetical, which would reshuffle the
+    /// page whenever a vendor renames itself.
+    private static func companyOrder(_ inputs: [ResetHistoryLaneInput]) -> [String: Int] {
+        var order: [String: Int] = [:]
+        for input in inputs where order[input.company] == nil {
+            order[input.company] = order.count
+        }
+        return order
+    }
+
+    private static func sorted(
+        _ lanes: [Lane],
+        by ordering: Ordering,
+        companyOrder: [String: Int]
+    ) -> [Lane] {
+        func wasteFirst(_ lhs: Lane, _ rhs: Lane) -> Bool {
+            // A lane with no completed cycle has no verdict to offer, so it
+            // sinks below every lane that does rather than sorting as 0% waste.
+            switch (lhs.averageWastedPercent, rhs.averageWastedPercent) {
+            case let (left?, right?) where left != right:
+                return left > right
+            case (nil, .some):
+                return false
+            case (.some, nil):
+                return true
+            default:
+                return lhs.label < rhs.label
+            }
+        }
+        switch ordering {
+        case .waste:
+            return lanes.sorted(by: wasteFirst)
+        case .company:
+            return lanes.sorted { lhs, rhs in
+                let left = companyOrder[lhs.company] ?? Int.max
+                let right = companyOrder[rhs.company] ?? Int.max
+                if left != right { return left < right }
+                return wasteFirst(lhs, rhs)
+            }
+        }
+    }
+
+    /// The header sentence, in priority order:
+    ///
+    /// 1. Nothing to compare — no weekly-or-longer lane exists at all.
+    /// 2. Lanes exist but nothing has closed a cycle yet.
+    /// 3. Some lane refilled with more than half unused; name it and count it.
+    ///    This is the finding the module was built to surface.
+    /// 4. Nothing that stark, but the leakiest lane still averages a notable
+    ///    amount of waste; quote it.
+    /// 5. Everything is being spent; say so with the number, not a platitude.
+    static func verdict(lanes: [Lane], totals: Totals) -> String {
+        guard !lanes.isEmpty else {
+            return "No weekly or longer quota is being tracked yet."
+        }
+        guard totals.cycleCount > 0 else {
+            return "No completed cycles yet — a cycle is recorded when a quota refills."
+        }
+        let worstByCount = lanes
+            .filter { $0.wastefulCycleCount > 0 }
+            .max { lhs, rhs in
+                lhs.wastefulCycleCount == rhs.wastefulCycleCount
+                    ? (lhs.averageWastedPercent ?? 0) < (rhs.averageWastedPercent ?? 0)
+                    : lhs.wastefulCycleCount < rhs.wastefulCycleCount
+            }
+        if let worst = worstByCount {
+            let count = worst.wastefulCycleCount
+            let times = count == 1 ? "once" : "\(count) times"
+            return "\(worst.label) refilled \(times) with more than half unused."
+        }
+        let leakiest = lanes.max { ($0.averageWastedPercent ?? -1) < ($1.averageWastedPercent ?? -1) }
+        if let leakiest, let wasted = leakiest.averageWastedPercent, wasted >= notableAverageWastePercent {
+            let cycleWord = leakiest.averagedCycleCount == 1 ? "cycle" : "cycles"
+            return "\(leakiest.label) left \(Lane.percentText(wasted))% unused on average across \(leakiest.averagedCycleCount) \(cycleWord)."
+        }
+        return "Nothing is going noticeably to waste — \(Lane.percentText(totals.usedPercent))% of the refilled capacity was spent."
+    }
+}

--- a/Tests/VibeBarCoreTests/ResetHistoryComparisonTests.swift
+++ b/Tests/VibeBarCoreTests/ResetHistoryComparisonTests.swift
@@ -234,6 +234,60 @@ final class ResetHistoryComparisonTests: XCTestCase {
         XCTAssertEqual(result.lanes[0].cycles[0].resetDescription, "")
     }
 
+    // MARK: - History-only lanes
+
+    func testALaneWithNoLiveBucketStillComparesItsRecordedCycles() {
+        // A bucket the provider renamed or withdrew keeps its samples in the
+        // history, and its waste record is exactly the one the user would
+        // otherwise never see again. No live window, no live percent, no
+        // reset time — only what was recorded.
+        let retired = ResetHistoryLaneInput(
+            accountId: "acct",
+            tool: .claude,
+            bucketId: "weekly_opus",
+            company: "Anthropic",
+            subProvider: "Claude",
+            groupTitle: nil,
+            bucketTitle: "Opus · Weekly",
+            liveWindowSeconds: nil,
+            currentUsedPercent: nil,
+            currentResetAt: nil,
+            samples: [
+                sample(bucketId: "weekly_opus", endingDaysAgo: 7, used: 20),
+                sample(bucketId: "weekly_opus", endingDaysAgo: 14, used: 30)
+            ]
+        )
+        let live = lane(samples: [sample(bucketId: "weekly", endingDaysAgo: 7, used: 95)])
+        let result = ResetHistoryComparison.build(inputs: [retired, live], window: .all, now: now)
+
+        XCTAssertEqual(result.lanes.map(\.id), ["acct.weekly_opus", "acct.weekly"])
+        let lane = result.lanes[0]
+        XCTAssertEqual(lane.cycles.count, 2)
+        XCTAssertEqual(lane.windowSeconds, 7 * 86_400)
+        XCTAssertEqual(lane.label, "Anthropic · Claude · Opus · Weekly")
+        // Nothing is running, so there is no dashed bar to draw.
+        XCTAssertNil(lane.currentCycle)
+        XCTAssertEqual(try XCTUnwrap(lane.averageWastedPercent), 75, accuracy: 0.001)
+    }
+
+    func testAHistoryOnlyFiveHourLaneIsStillExcluded() {
+        // Losing the live bucket must not smuggle a sub-daily lane in through
+        // the sample fallback.
+        let retired = ResetHistoryLaneInput(
+            accountId: "acct",
+            tool: .claude,
+            bucketId: "five_hour_legacy",
+            company: "Anthropic",
+            subProvider: "Claude",
+            bucketTitle: "5 Hours",
+            liveWindowSeconds: nil,
+            samples: [
+                sample(bucketId: "five_hour_legacy", endingDaysAgo: 1, used: 20, windowSeconds: 5 * 3_600)
+            ]
+        )
+        XCTAssertTrue(ResetHistoryComparison.build(inputs: [retired], window: .all, now: now).isEmpty)
+    }
+
     // MARK: - Ordering
 
     func testLanesSortByAverageWasteDescendingAndEmptyLanesSinkToTheBottom() {
@@ -280,6 +334,34 @@ final class ResetHistoryComparisonTests: XCTestCase {
             now: now
         )
         XCTAssertEqual(byWaste.lanes.first?.id, "acct.weekly")
+    }
+
+    func testCompanyOrderingKeepsEachCompanyContiguous() {
+        // The drawing surface emits one heading per run of a company, so a
+        // company appearing in two runs would render two headings for it.
+        let openAI = lane(
+            id: "codex_weekly", tool: .codex, company: "OpenAI", subProvider: "ChatGPT Agentic",
+            samples: [sample(bucketId: "codex_weekly", endingDaysAgo: 7, used: 90)]
+        )
+        let anthropicLeaky = lane(
+            id: "weekly_fable", group: "Fable",
+            samples: [sample(bucketId: "weekly_fable", endingDaysAgo: 7, used: 2)]
+        )
+        let anthropicTight = lane(
+            id: "weekly",
+            samples: [sample(bucketId: "weekly", endingDaysAgo: 7, used: 99)]
+        )
+        let result = ResetHistoryComparison.build(
+            inputs: [openAI, anthropicLeaky, anthropicTight],
+            ordering: .company,
+            now: now
+        )
+        var runs: [String] = []
+        for lane in result.lanes where runs.last != lane.company {
+            runs.append(lane.company)
+        }
+        XCTAssertEqual(runs, ["OpenAI", "Anthropic"])
+        XCTAssertEqual(Set(runs).count, runs.count)
     }
 
     // MARK: - Labels

--- a/Tests/VibeBarCoreTests/ResetHistoryComparisonTests.swift
+++ b/Tests/VibeBarCoreTests/ResetHistoryComparisonTests.swift
@@ -1,0 +1,438 @@
+import XCTest
+@testable import VibeBarCore
+
+/// The aggregation behind the Reset History Compare module: which lanes get in,
+/// what "wasted" means, how the rows are ordered, and what the header sentence
+/// is allowed to say.
+final class ResetHistoryComparisonTests: XCTestCase {
+    private let now = Date(timeIntervalSinceReferenceDate: 800_000_000)
+    private let week = 7.0 * 86_400
+
+    // MARK: - Fixtures
+
+    private func sample(
+        bucketId: String,
+        endingDaysAgo: Double,
+        used: Double,
+        windowSeconds: Int = 7 * 86_400,
+        completed: Bool = true,
+        resetKind: SubscriptionWindowSample.ResetKind? = .onSchedule
+    ) -> SubscriptionWindowSample {
+        let end = now.addingTimeInterval(-endingDaysAgo * 86_400)
+        return SubscriptionWindowSample(
+            accountId: "acct",
+            tool: .claude,
+            bucketId: bucketId,
+            windowEnd: end,
+            windowStart: end.addingTimeInterval(-Double(windowSeconds)),
+            rawWindowSeconds: windowSeconds,
+            peakUsedPercent: used,
+            lastUsedPercent: used,
+            firstSeenAt: end.addingTimeInterval(-Double(windowSeconds)),
+            lastSeenAt: end,
+            completedAt: completed ? end : nil,
+            completionReason: completed ? .refillDetected : nil,
+            resetKind: completed ? resetKind : nil
+        )
+    }
+
+    private func lane(
+        id: String = "weekly",
+        tool: ToolType = .claude,
+        company: String = "Anthropic",
+        subProvider: String = "Claude",
+        group: String? = nil,
+        bucketTitle: String = "Weekly",
+        windowSeconds: Int? = 7 * 86_400,
+        currentUsed: Double? = nil,
+        currentResetAt: Date? = nil,
+        samples: [SubscriptionWindowSample]
+    ) -> ResetHistoryLaneInput {
+        ResetHistoryLaneInput(
+            accountId: "acct",
+            tool: tool,
+            bucketId: id,
+            company: company,
+            subProvider: subProvider,
+            groupTitle: group,
+            bucketTitle: bucketTitle,
+            liveWindowSeconds: windowSeconds,
+            currentUsedPercent: currentUsed,
+            currentResetAt: currentResetAt,
+            samples: samples
+        )
+    }
+
+    // MARK: - Window filter
+
+    func testFiveHourLanesAreExcludedAndWeeklyLanesAreKept() {
+        // The cut is on the window length, never on the bucket's name: bucket
+        // ids differ per provider and change without notice.
+        let fiveHour = lane(
+            id: "five_hour",
+            bucketTitle: "5 Hours",
+            windowSeconds: 5 * 3_600,
+            samples: [sample(bucketId: "five_hour", endingDaysAgo: 1, used: 20, windowSeconds: 5 * 3_600)]
+        )
+        let weekly = lane(samples: [sample(bucketId: "weekly", endingDaysAgo: 3, used: 40)])
+        let result = ResetHistoryComparison.build(inputs: [fiveHour, weekly], now: now)
+        XCTAssertEqual(result.lanes.map(\.id), ["acct.weekly"])
+    }
+
+    func testAMonthlyLaneQualifies() {
+        // "Weekly and up" — Cursor's 744-hour pools are the up.
+        let monthly = lane(
+            id: "other_models",
+            bucketTitle: "Other Models",
+            windowSeconds: 744 * 3_600,
+            samples: [sample(bucketId: "other_models", endingDaysAgo: 10, used: 12, windowSeconds: 744 * 3_600)]
+        )
+        let result = ResetHistoryComparison.build(inputs: [monthly], window: .all, now: now)
+        XCTAssertEqual(result.lanes.count, 1)
+        XCTAssertEqual(result.lanes[0].windowSeconds, 744 * 3_600)
+    }
+
+    func testLaneWindowFallsBackToTheSamplesWhenTheLiveBucketHasNone() {
+        // A bucket the live quota no longer carries still has history, and the
+        // samples know how long its window was.
+        let input = lane(
+            windowSeconds: nil,
+            samples: [
+                sample(bucketId: "weekly", endingDaysAgo: 3, used: 40),
+                sample(bucketId: "weekly", endingDaysAgo: 10, used: 50)
+            ]
+        )
+        XCTAssertEqual(ResetHistoryComparison.laneWindowSeconds(input), 7 * 86_400)
+        XCTAssertEqual(ResetHistoryComparison.build(inputs: [input], now: now).lanes.count, 1)
+    }
+
+    func testALaneWithNoWindowEvidenceAtAllIsDropped() {
+        var input = lane(windowSeconds: nil, samples: [])
+        input.samples = []
+        XCTAssertNil(ResetHistoryComparison.laneWindowSeconds(input))
+        XCTAssertTrue(ResetHistoryComparison.build(inputs: [input], now: now).isEmpty)
+    }
+
+    // MARK: - Visible span
+
+    func testTheFixedWindowDropsCyclesOlderThanIt() {
+        let input = lane(samples: [
+            sample(bucketId: "weekly", endingDaysAgo: 3, used: 90),
+            sample(bucketId: "weekly", endingDaysAgo: 40, used: 10)
+        ])
+        let fourWeeks = ResetHistoryComparison.build(inputs: [input], window: .fourWeeks, now: now)
+        XCTAssertEqual(fourWeeks.lanes[0].cycles.count, 1)
+        XCTAssertEqual(fourWeeks.totals.cycleCount, 1)
+
+        let all = ResetHistoryComparison.build(inputs: [input], window: .all, now: now)
+        XCTAssertEqual(all.lanes[0].cycles.count, 2)
+        XCTAssertLessThanOrEqual(all.rangeStart, now.addingTimeInterval(-40 * 86_400))
+    }
+
+    func testCyclesComeBackOldestFirst() {
+        let input = lane(samples: [
+            sample(bucketId: "weekly", endingDaysAgo: 7, used: 10),
+            sample(bucketId: "weekly", endingDaysAgo: 21, used: 20),
+            sample(bucketId: "weekly", endingDaysAgo: 14, used: 30)
+        ])
+        let result = ResetHistoryComparison.build(inputs: [input], now: now)
+        XCTAssertEqual(result.lanes[0].cycles.map(\.usedPercent), [20, 30, 10])
+    }
+
+    // MARK: - Waste maths
+
+    func testAverageWasteCoversTheLastFourCyclesOnly() {
+        // Five cycles: the oldest 0%-used one must not drag the average.
+        let input = lane(samples: [
+            sample(bucketId: "weekly", endingDaysAgo: 35, used: 0),
+            sample(bucketId: "weekly", endingDaysAgo: 28, used: 100),
+            sample(bucketId: "weekly", endingDaysAgo: 21, used: 100),
+            sample(bucketId: "weekly", endingDaysAgo: 14, used: 100),
+            sample(bucketId: "weekly", endingDaysAgo: 7, used: 100)
+        ])
+        let result = ResetHistoryComparison.build(inputs: [input], window: .all, now: now)
+        XCTAssertEqual(result.lanes[0].averagedCycleCount, 4)
+        XCTAssertEqual(try XCTUnwrap(result.lanes[0].averageWastedPercent), 0, accuracy: 0.001)
+    }
+
+    func testWasteIsTheUnusedRemainderAtReset() {
+        let input = lane(samples: [
+            sample(bucketId: "weekly", endingDaysAgo: 7, used: 30),
+            sample(bucketId: "weekly", endingDaysAgo: 14, used: 10)
+        ])
+        let result = ResetHistoryComparison.build(inputs: [input], window: .all, now: now)
+        // (100-30 + 100-10) / 2 = 80
+        XCTAssertEqual(try XCTUnwrap(result.lanes[0].averageWastedPercent), 80, accuracy: 0.001)
+        XCTAssertEqual(result.lanes[0].wasteSummary, "avg wasted 80% · last 2 cycles")
+    }
+
+    func testALaneWithNoCompletedCyclesHasNoAverageAndSaysSo() {
+        let input = lane(currentUsed: 42, currentResetAt: now.addingTimeInterval(3 * 86_400), samples: [])
+        let result = ResetHistoryComparison.build(inputs: [input], now: now)
+        XCTAssertNil(result.lanes[0].averageWastedPercent)
+        XCTAssertEqual(result.lanes[0].wasteSummary, "No completed cycles yet")
+        XCTAssertEqual(
+            result.lanes[0].emptyStateText,
+            "No completed cycles yet — a cycle is recorded when the quota refills"
+        )
+    }
+
+    func testTotalsAreTheShareOfRefilledCapacityThatWasSpent() {
+        let a = lane(id: "weekly", samples: [
+            sample(bucketId: "weekly", endingDaysAgo: 7, used: 100),
+            sample(bucketId: "weekly", endingDaysAgo: 14, used: 60)
+        ])
+        let b = lane(id: "weekly_fable", group: "Fable", samples: [
+            sample(bucketId: "weekly_fable", endingDaysAgo: 7, used: 20),
+            sample(bucketId: "weekly_fable", endingDaysAgo: 14, used: 20)
+        ])
+        let result = ResetHistoryComparison.build(inputs: [a, b], window: .all, now: now)
+        XCTAssertEqual(result.totals.cycleCount, 4)
+        XCTAssertEqual(result.totals.usedPercent, 50, accuracy: 0.001)
+        XCTAssertEqual(result.totals.wastedPercent, 50, accuracy: 0.001)
+        XCTAssertEqual(result.totals.headline, "50% used · 50% wasted · 4 cycles")
+    }
+
+    // MARK: - Current cycle
+
+    func testTheOpenSampleBecomesTheCurrentCycle() {
+        let input = lane(samples: [
+            sample(bucketId: "weekly", endingDaysAgo: 7, used: 80),
+            sample(bucketId: "weekly", endingDaysAgo: -2, used: 25, completed: false)
+        ])
+        let result = ResetHistoryComparison.build(inputs: [input], now: now)
+        let current = try? XCTUnwrap(result.lanes[0].currentCycle)
+        XCTAssertEqual(current?.usedPercent, 25)
+        XCTAssertEqual(current?.isCompleted, false)
+        XCTAssertEqual(result.lanes[0].cycles.count, 1)
+    }
+
+    func testTheLiveQuotaSuppliesTheCurrentCycleWhenTheHistoryHasNoOpenSample() {
+        let resetAt = now.addingTimeInterval(4 * 86_400)
+        let input = lane(
+            currentUsed: 66,
+            currentResetAt: resetAt,
+            samples: [sample(bucketId: "weekly", endingDaysAgo: 3, used: 80)]
+        )
+        let result = ResetHistoryComparison.build(inputs: [input], now: now)
+        let current = try? XCTUnwrap(result.lanes[0].currentCycle)
+        XCTAssertEqual(current?.usedPercent, 66)
+        XCTAssertEqual(current?.end, resetAt)
+        XCTAssertEqual(current?.start, resetAt.addingTimeInterval(-week))
+    }
+
+    // MARK: - Reset kind
+
+    func testEarlyRefillsSurviveOntoTheCycle() {
+        let input = lane(samples: [
+            sample(bucketId: "weekly", endingDaysAgo: 7, used: 40, resetKind: .earlyClockRestarted),
+            sample(bucketId: "weekly", endingDaysAgo: 14, used: 40, resetKind: .onSchedule)
+        ])
+        let result = ResetHistoryComparison.build(inputs: [input], window: .all, now: now)
+        XCTAssertEqual(result.lanes[0].cycles.map(\.refilledEarly), [false, true])
+        XCTAssertEqual(result.lanes[0].cycles[1].resetDescription, "refilled early, next window restarted")
+        XCTAssertEqual(result.lanes[0].cycles[0].resetDescription, "")
+    }
+
+    // MARK: - Ordering
+
+    func testLanesSortByAverageWasteDescendingAndEmptyLanesSinkToTheBottom() {
+        let leaky = lane(id: "weekly_fable", group: "Fable", samples: [
+            sample(bucketId: "weekly_fable", endingDaysAgo: 7, used: 10)
+        ])
+        let tight = lane(id: "weekly", samples: [
+            sample(bucketId: "weekly", endingDaysAgo: 7, used: 95)
+        ])
+        let unknown = lane(id: "gpt_reserve_weekly", group: "Reserve", samples: [])
+        let result = ResetHistoryComparison.build(inputs: [tight, unknown, leaky], now: now)
+        XCTAssertEqual(
+            result.lanes.map(\.id),
+            ["acct.weekly_fable", "acct.weekly", "acct.gpt_reserve_weekly"]
+        )
+    }
+
+    func testCompanyOrderingKeepsDiscoveryOrderAndSortsByWasteInside() {
+        // Discovery order is the app's canonical provider order; alphabetical
+        // would reshuffle the page whenever a vendor renames itself.
+        let openAITight = lane(
+            id: "codex_weekly", tool: .codex, company: "OpenAI", subProvider: "ChatGPT Agentic",
+            samples: [sample(bucketId: "codex_weekly", endingDaysAgo: 7, used: 90)]
+        )
+        let openAILeaky = lane(
+            id: "spark_weekly", tool: .codex, company: "OpenAI", subProvider: "ChatGPT Agentic",
+            group: "Codex Spark",
+            samples: [sample(bucketId: "spark_weekly", endingDaysAgo: 7, used: 5)]
+        )
+        let anthropic = lane(samples: [sample(bucketId: "weekly", endingDaysAgo: 7, used: 1)])
+        let result = ResetHistoryComparison.build(
+            inputs: [openAITight, openAILeaky, anthropic],
+            ordering: .company,
+            now: now
+        )
+        XCTAssertEqual(
+            result.lanes.map(\.id),
+            ["acct.spark_weekly", "acct.codex_weekly", "acct.weekly"]
+        )
+        // …and by pure waste, Anthropic's 1%-used lane would have led.
+        let byWaste = ResetHistoryComparison.build(
+            inputs: [openAITight, openAILeaky, anthropic],
+            ordering: .waste,
+            now: now
+        )
+        XCTAssertEqual(byWaste.lanes.first?.id, "acct.weekly")
+    }
+
+    // MARK: - Labels
+
+    func testLabelsUseTheQuotaNamingAxis() {
+        let input = lane(
+            id: "weekly_fable", company: "Anthropic", subProvider: "Claude",
+            group: "Fable", bucketTitle: "Weekly",
+            samples: [sample(bucketId: "weekly_fable", endingDaysAgo: 7, used: 10)]
+        )
+        let lane = ResetHistoryComparison.build(inputs: [input], now: now).lanes[0]
+        XCTAssertEqual(lane.label, "Anthropic · Claude · Fable · Weekly")
+        XCTAssertEqual(lane.labelWithoutCompany, "Claude · Fable · Weekly")
+    }
+
+    func testABucketTitleEqualToItsGroupIsNotRepeated() {
+        let input = lane(
+            id: "grok_bot_weekly", company: "SpaceXAI", subProvider: "Grok Bot",
+            group: "Weekly", bucketTitle: "Weekly",
+            samples: [sample(bucketId: "grok_bot_weekly", endingDaysAgo: 7, used: 10)]
+        )
+        XCTAssertEqual(
+            ResetHistoryComparison.build(inputs: [input], now: now).lanes[0].label,
+            "SpaceXAI · Grok Bot · Weekly"
+        )
+    }
+
+    // MARK: - Verdict
+
+    func testVerdictNamesTheLaneThatKeepsRefillingMoreThanHalfUnused() {
+        let leaky = lane(id: "weekly", samples: [
+            sample(bucketId: "weekly", endingDaysAgo: 7, used: 10),
+            sample(bucketId: "weekly", endingDaysAgo: 14, used: 20),
+            sample(bucketId: "weekly", endingDaysAgo: 21, used: 30)
+        ])
+        let result = ResetHistoryComparison.build(inputs: [leaky], window: .all, now: now)
+        XCTAssertEqual(
+            result.verdict,
+            "Anthropic · Claude · Weekly refilled 3 times with more than half unused."
+        )
+    }
+
+    func testASingleWastefulCycleIsCalledOutInTheSingular() {
+        let input = lane(samples: [
+            sample(bucketId: "weekly", endingDaysAgo: 7, used: 10),
+            sample(bucketId: "weekly", endingDaysAgo: 14, used: 95)
+        ])
+        let result = ResetHistoryComparison.build(inputs: [input], window: .all, now: now)
+        XCTAssertEqual(
+            result.verdict,
+            "Anthropic · Claude · Weekly refilled once with more than half unused."
+        )
+    }
+
+    func testANotableAverageIsQuotedWhenNoSingleCycleCrossesHalf() {
+        // 60% used every cycle: never more than half unused, but 40% average
+        // waste is still worth a sentence.
+        let input = lane(samples: [
+            sample(bucketId: "weekly", endingDaysAgo: 7, used: 60),
+            sample(bucketId: "weekly", endingDaysAgo: 14, used: 60)
+        ])
+        let result = ResetHistoryComparison.build(inputs: [input], window: .all, now: now)
+        XCTAssertEqual(
+            result.verdict,
+            "Anthropic · Claude · Weekly left 40% unused on average across 2 cycles."
+        )
+    }
+
+    func testAHealthySetOfLanesGetsTheNumberRatherThanAPlatitude() {
+        let input = lane(samples: [
+            sample(bucketId: "weekly", endingDaysAgo: 7, used: 90),
+            sample(bucketId: "weekly", endingDaysAgo: 14, used: 90)
+        ])
+        let result = ResetHistoryComparison.build(inputs: [input], window: .all, now: now)
+        XCTAssertEqual(
+            result.verdict,
+            "Nothing is going noticeably to waste — 90% of the refilled capacity was spent."
+        )
+    }
+
+    func testVerdictWhenThereIsNothingToCompare() {
+        XCTAssertEqual(
+            ResetHistoryComparison.build(inputs: [], now: now).verdict,
+            "No weekly or longer quota is being tracked yet."
+        )
+    }
+
+    func testVerdictWhenLanesExistButNothingHasCompleted() {
+        let input = lane(currentUsed: 10, currentResetAt: now.addingTimeInterval(86_400), samples: [])
+        XCTAssertEqual(
+            ResetHistoryComparison.build(inputs: [input], now: now).verdict,
+            "No completed cycles yet — a cycle is recorded when a quota refills."
+        )
+    }
+
+    // MARK: - Draw budget
+
+    private func cycle(index: Int, used: Double) -> ResetHistoryComparison.Cycle {
+        let start: Date = now.addingTimeInterval(Double(index) * week)
+        let end: Date = start.addingTimeInterval(week)
+        return ResetHistoryComparison.Cycle(
+            id: "c\(index)",
+            start: start,
+            end: end,
+            usedPercent: used,
+            isCompleted: true
+        )
+    }
+
+    func testDownsamplingKeepsEndpointsAndTheWorstCyclesInTimeOrder() {
+        var cycles: [ResetHistoryComparison.Cycle] = []
+        for index in 0..<10 {
+            cycles.append(cycle(index: index, used: index == 5 ? 1 : 90))
+        }
+        let kept = ResetHistoryComparison.downsampled(cycles, limit: 3)
+        XCTAssertEqual(kept.map(\.id), ["c0", "c5", "c9"])
+    }
+
+    func testDownsamplingLeavesAShortLaneAlone() {
+        var cycles: [ResetHistoryComparison.Cycle] = []
+        for index in 0..<3 {
+            cycles.append(cycle(index: index, used: 50))
+        }
+        XCTAssertEqual(ResetHistoryComparison.downsampled(cycles, limit: 10).count, 3)
+        XCTAssertTrue(ResetHistoryComparison.downsampled(cycles, limit: 0).isEmpty)
+    }
+
+    // MARK: - Caching contract
+
+    func testTheBuildClockIsCarriedSoTheViewNeedNotReadItWhileDrawing() {
+        let input = lane(samples: [sample(bucketId: "weekly", endingDaysAgo: 7, used: 40)])
+        let result = ResetHistoryComparison.build(inputs: [input], now: now)
+        XCTAssertEqual(result.now, now)
+        XCTAssertGreaterThanOrEqual(result.rangeEnd, result.now)
+    }
+
+    func testEqualInputsProduceEqualComparisons() {
+        // The App caches on the inputs; if two identical builds compared
+        // unequal the cache would rebuild on every render.
+        let input = lane(samples: [sample(bucketId: "weekly", endingDaysAgo: 7, used: 40)])
+        XCTAssertEqual(
+            ResetHistoryComparison.build(inputs: [input], now: now),
+            ResetHistoryComparison.build(inputs: [input], now: now)
+        )
+    }
+
+    // MARK: - Accessibility
+
+    func testAccessibilitySummaryNamesTheLanesAndTheHeadline() {
+        let input = lane(samples: [sample(bucketId: "weekly", endingDaysAgo: 7, used: 40)])
+        let summary = ResetHistoryComparison.build(inputs: [input], now: now).accessibilitySummary
+        XCTAssertTrue(summary.contains("Anthropic · Claude · Weekly"))
+        XCTAssertTrue(summary.contains("60% wasted on average"))
+        XCTAssertTrue(summary.contains("last 8 weeks"))
+    }
+}

--- a/Tests/VibeBarCoreTests/ResetHistoryComparisonTests.swift
+++ b/Tests/VibeBarCoreTests/ResetHistoryComparisonTests.swift
@@ -252,6 +252,7 @@ final class ResetHistoryComparisonTests: XCTestCase {
             liveWindowSeconds: nil,
             currentUsedPercent: nil,
             currentResetAt: nil,
+            isRetired: true,
             samples: [
                 sample(bucketId: "weekly_opus", endingDaysAgo: 7, used: 20),
                 sample(bucketId: "weekly_opus", endingDaysAgo: 14, used: 30)
@@ -270,6 +271,100 @@ final class ResetHistoryComparisonTests: XCTestCase {
         XCTAssertEqual(try XCTUnwrap(lane.averageWastedPercent), 75, accuracy: 0.001)
     }
 
+    func testARetiredLaneNeverShowsACurrentCycleFromItsStaleOpenSample() {
+        // A cycle closes only when another observation arrives, so a bucket
+        // the provider withdrew — or one whose account was signed out of —
+        // keeps its last open sample forever. Reading that as the present
+        // tense would draw a dashed "Current" bar for a quota that stopped
+        // existing months ago.
+        let retired = ResetHistoryLaneInput(
+            accountId: "acct",
+            tool: .claude,
+            bucketId: "weekly_opus",
+            company: "Anthropic",
+            subProvider: "Claude",
+            bucketTitle: "Opus · Weekly",
+            liveWindowSeconds: nil,
+            isRetired: true,
+            samples: [
+                sample(bucketId: "weekly_opus", endingDaysAgo: 14, used: 30),
+                // Never closed: nothing observed this bucket again.
+                sample(bucketId: "weekly_opus", endingDaysAgo: 7, used: 45, completed: false)
+            ]
+        )
+        let result = ResetHistoryComparison.build(inputs: [retired], window: .all, now: now)
+        XCTAssertEqual(result.lanes.count, 1)
+        XCTAssertNil(result.lanes[0].currentCycle)
+        // The open sample is not a completed cycle either, so it contributes
+        // nothing to the waste arithmetic.
+        XCTAssertEqual(result.lanes[0].cycles.count, 1)
+        XCTAssertEqual(result.totals.cycleCount, 1)
+    }
+
+    func testARetiredLaneIgnoresLiveQuotaFieldsEvenIfTheyAreSupplied() {
+        // Belt and braces: the flag, not the nil-ness of the live fields, is
+        // what decides whether a lane has a present tense.
+        let retired = ResetHistoryLaneInput(
+            accountId: "acct",
+            tool: .claude,
+            bucketId: "weekly",
+            company: "Anthropic",
+            subProvider: "Claude",
+            bucketTitle: "Weekly",
+            liveWindowSeconds: 7 * 86_400,
+            currentUsedPercent: 40,
+            currentResetAt: now.addingTimeInterval(2 * 86_400),
+            isRetired: true,
+            samples: [sample(bucketId: "weekly", endingDaysAgo: 7, used: 30)]
+        )
+        XCTAssertNil(
+            ResetHistoryComparison.build(inputs: [retired], window: .all, now: now).lanes[0].currentCycle
+        )
+    }
+
+    func testALiveLaneStillTakesItsCurrentCycleFromAnOpenSample() {
+        // The guard must not cost a live lane its dashed bar.
+        let live = lane(samples: [
+            sample(bucketId: "weekly", endingDaysAgo: 7, used: 80),
+            sample(bucketId: "weekly", endingDaysAgo: -2, used: 25, completed: false)
+        ])
+        let result = ResetHistoryComparison.build(inputs: [live], window: .all, now: now)
+        XCTAssertEqual(result.lanes[0].currentCycle?.usedPercent, 25)
+    }
+
+    func testASignedOutAccountsLanesCompareAlongsideTheLiveOnes() {
+        // The discovery path that produces these lives in the app target, so
+        // what is pinned here is the contract it relies on: a lane whose
+        // account no longer exists is an ordinary retired lane, sorts by its
+        // own waste, and carries the label that says whose it was.
+        let signedOut = ResetHistoryLaneInput(
+            accountId: "former",
+            tool: .claude,
+            bucketId: "weekly",
+            company: "Anthropic",
+            subProvider: "Claude",
+            bucketTitle: "Weekly",
+            accountLabel: "Signed-out account",
+            liveWindowSeconds: nil,
+            isRetired: true,
+            samples: [
+                sample(bucketId: "weekly", endingDaysAgo: 14, used: 5),
+                sample(bucketId: "weekly", endingDaysAgo: 21, used: 5)
+            ]
+        )
+        let live = lane(samples: [sample(bucketId: "weekly", endingDaysAgo: 7, used: 92)])
+        let result = ResetHistoryComparison.build(inputs: [live, signedOut], window: .all, now: now)
+
+        XCTAssertEqual(result.lanes.map(\.id), ["former.weekly", "acct.weekly"])
+        XCTAssertEqual(result.lanes[0].label, "Anthropic · Claude · Weekly · Signed-out account")
+        XCTAssertEqual(result.lanes[0].cycles.count, 2)
+        XCTAssertNil(result.lanes[0].currentCycle)
+        // Both accounts' cycles count toward the header arithmetic; hiding the
+        // signed-out one is what made the totals disagree with the Workbench
+        // reset calendar, which reads the same history directly.
+        XCTAssertEqual(result.totals.cycleCount, 3)
+    }
+
     func testAHistoryOnlyFiveHourLaneIsStillExcluded() {
         // Losing the live bucket must not smuggle a sub-daily lane in through
         // the sample fallback.
@@ -281,6 +376,7 @@ final class ResetHistoryComparisonTests: XCTestCase {
             subProvider: "Claude",
             bucketTitle: "5 Hours",
             liveWindowSeconds: nil,
+            isRetired: true,
             samples: [
                 sample(bucketId: "five_hour_legacy", endingDaysAgo: 1, used: 20, windowSeconds: 5 * 3_600)
             ]


### PR DESCRIPTION
## Summary

- New `ResetHistoryComparison` (Core, pure, memoised per data change) and `ResetHistoryCompareCard`/`ResetHistoryCompareView` (App): every weekly-and-longer quota lane (`rawWindowSeconds >= 7 d`, never matched by bucket name) drawn one row per lane on a shared time axis (4w / 8w / 12w / All), bar = one cycle positioned by its real `windowStart…completedAt`, height = peak used, muted remainder = wasted; dashed current cycle and early-refill marker reuse `FillTimelineChart`'s vocabulary. Rows sort by average waste (last 4 completed cycles), optional group-by-company. Header: used / wasted totals plus one verdict sentence derived from the data.
- One equatable `Canvas` for all rows; hover state lives outside it so pointer movement only redraws a highlight rect and one tooltip. No per-bar `.help()`, no timer. Accessibility summary provided.
- Registered on the Overview (right after Upcoming Resets), on each provider page scoped to that page's family (Google AI keeps AntiGravity beside Gemini Web, SpaceXAI keeps Cursor beside Grok) at the top of the wide right column, and on the Workbench Resets page above the cycle grid. Layout editor and saved layouts need no change (catalog-driven; unknown modules resolve to their default position).
- Lanes with no completed cycle show "No completed cycles yet — a cycle is recorded when the quota refills" instead of vanishing (Cursor's lanes until #289 lands).

Requested by the maintainer during the 2026-09-03 audit ("compare every quota's reset history on one screen, weekly and up, so I can see whether I am wasting quota; also on the Resets tab; and something to balance the provider page's short right column").

## Test plan

- [x] `swift build`
- [x] `swift test` — 1810 tests, 0 failures (28 new: window filter, waste maths, sort/ties, verdict rules, downsampling keeps endpoints and worst bars, current-cycle synthesis, empty lanes)
- [ ] After install: Overview card after Upcoming Resets; provider page right column starts with it; Resets tab shows it above the cycle grid; hover sweeps without hitching; layout editor lists "Reset History Compare" for both surfaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)