### PR TITLE
Compute forecasts once per 5-minute tick instead of per row per render

### DIFF
--- a/Sources/VibeBarApp/PopoverPresentation.swift
+++ b/Sources/VibeBarApp/PopoverPresentation.swift
@@ -1,0 +1,141 @@
+import SwiftUI
+
+/// Whether any Vibe Bar popover is currently on screen.
+///
+/// `StatusItemController` caches one `NSPopover` — and therefore one whole
+/// SwiftUI hosting tree — per menu-bar kind for the life of the process, so a
+/// *closed* popover's views are still alive and still ticking. This object is
+/// the one thing a hidden tree can read to stop doing work. It is deliberately
+/// not a teardown switch: nothing is deallocated, the hosting controller keeps
+/// its state, and the next open is still a cache hit.
+///
+/// It mirrors what `AppEnvironment.setPopoverVisible` already computes; the two
+/// are set from the same places in `StatusItemController` so they cannot drift.
+final class PopoverPresentation: ObservableObject {
+    @Published var isShown: Bool
+
+    init(isShown: Bool = false) {
+        self.isShown = isShown
+    }
+
+    /// What every host that is *not* the popover sees. Mini windows, the
+    /// Workbench, Settings and the onboarding assistant are on screen whenever
+    /// they exist, so their clocks must never be gated — and reading this
+    /// through `@Environment` (which has a default) rather than
+    /// `@EnvironmentObject` (which crashes when nothing injected it) means a
+    /// clock that ends up in one of those trees keeps running instead of
+    /// trapping.
+    static let alwaysVisible = PopoverPresentation(isShown: true)
+}
+
+private struct PopoverPresentationKey: EnvironmentKey {
+    static let defaultValue = PopoverPresentation.alwaysVisible
+}
+
+extension EnvironmentValues {
+    var popoverPresentation: PopoverPresentation {
+        get { self[PopoverPresentationKey.self] }
+        set { self[PopoverPresentationKey.self] = newValue }
+    }
+}
+
+/// A periodic timeline schedule with a *fixed* phase and an on/off switch.
+///
+/// Two things are wrong with `TimelineView(.periodic(from: .now, by: 30))`,
+/// which is what every quota surface used to write:
+///
+/// 1. `.now` is re-evaluated on every body pass, so each surface — and each
+///    re-render of the same surface — gets its own tick phase. Downstream that
+///    means every consumer hands `QuotaService.paceForecast` a slightly
+///    different `now`, and the memo it keeps on that input never hits. A 30 s
+///    idle sample put 7.6% of main-thread time in exactly that recomputation.
+/// 2. It keeps firing inside a popover that is closed but still hosted.
+///
+/// The anchor here is resolved once per process and floored to a five-minute
+/// boundary, so the 30 s and 60 s clocks land on the same grid and every
+/// surface asks for the same instant — one forecast per bucket per tick for
+/// the whole app instead of one per row.
+struct QuotaClockSchedule: TimelineSchedule {
+    /// While false the schedule yields exactly one entry and then ends, so the
+    /// view keeps its last rendered date and starts no timer at all.
+    var isActive: Bool
+    var interval: TimeInterval
+
+    /// Process-wide phase anchor. Floored to a 5-minute boundary so clocks of
+    /// different intervals stay in step with each other and with the
+    /// forecast's own 5-minute quantization.
+    static let anchor: Date = {
+        let seconds = Date().timeIntervalSinceReferenceDate
+        return Date(timeIntervalSinceReferenceDate: (seconds / 300).rounded(.down) * 300)
+    }()
+
+    func entries(from startDate: Date, mode: TimelineScheduleMode) -> AnyIterator<Date> {
+        let step = max(1, interval)
+        let anchor = Self.anchor.timeIntervalSinceReferenceDate
+        let elapsed = startDate.timeIntervalSinceReferenceDate - anchor
+        // First entry is the grid point at or before `startDate`, so the view
+        // renders immediately and every later entry stays on the grid.
+        var tick = anchor + (elapsed / step).rounded(.down) * step
+        let active = isActive
+        var started = false
+        return AnyIterator {
+            if started {
+                guard active else { return nil }
+                tick += step
+            } else {
+                started = true
+            }
+            return Date(timeIntervalSinceReferenceDate: tick)
+        }
+    }
+}
+
+/// One periodic clock for a whole page, card, or window layout. Pass its date
+/// down to the leaves as plain data — a row must never own a timer.
+///
+/// Use this for surfaces that are visible whenever they exist: mini windows,
+/// the Workbench, Settings. Popover-hosted surfaces use `PageClock`.
+struct StableClock<Content: View>: View {
+    var interval: TimeInterval = 30
+    @ViewBuilder var content: (Date) -> Content
+
+    var body: some View {
+        TimelineView(QuotaClockSchedule(isActive: true, interval: interval)) { context in
+            content(context.date)
+        }
+    }
+}
+
+/// `StableClock` for popover-hosted surfaces: same fixed phase, but it stops
+/// ticking while the popover is hidden and re-ticks on the next show.
+///
+/// Outside a popover (mini windows, Workbench, Settings) the environment's
+/// default `PopoverPresentation` reports "shown", so this degrades to a plain
+/// `StableClock` rather than freezing or crashing.
+struct PageClock<Content: View>: View {
+    var interval: TimeInterval = 30
+    @ViewBuilder var content: (Date) -> Content
+
+    @Environment(\.popoverPresentation) private var presentation
+
+    var body: some View {
+        GatedClock(presentation: presentation, interval: interval, content: content)
+    }
+}
+
+/// The observing half of `PageClock`. `@Environment` hands over the object
+/// without subscribing to it; `@ObservedObject` here is what turns an
+/// open/close into a schedule change.
+private struct GatedClock<Content: View>: View {
+    @ObservedObject var presentation: PopoverPresentation
+    var interval: TimeInterval
+    @ViewBuilder var content: (Date) -> Content
+
+    var body: some View {
+        TimelineView(
+            QuotaClockSchedule(isActive: presentation.isShown, interval: interval)
+        ) { context in
+            content(context.date)
+        }
+    }
+}

--- a/Sources/VibeBarApp/StatusItemController.swift
+++ b/Sources/VibeBarApp/StatusItemController.swift
@@ -45,6 +45,10 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
     /// app has to repair. Production always has one.
     private var compactStatusItem: NSStatusItem?
     private var popovers: [MenuBarItemKind: NSPopover] = [:]
+    /// Whether any popover is on screen, published into every popover tree so
+    /// its page-level clocks can stop ticking while it is hidden. The hosting
+    /// controllers stay cached either way — this gates work, not lifetime.
+    private let popoverPresentation = PopoverPresentation()
     private let environment: AppEnvironment
     private let miniWindowController: MiniQuotaWindowController
     private var cancellables: Set<AnyCancellable> = []
@@ -205,6 +209,13 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
                 .environmentObject(environment.costService)
                 .environmentObject(environment.remoteProbeService)
                 .environmentObject(environment.pageLayout)
+                .environmentObject(controller.popoverPresentation)
+                // Also handed over as an environment *value*: `PageClock`
+                // reads it that way so a view that ends up in a non-popover
+                // host (mini window, Workbench, Settings) gets the
+                // always-visible default instead of trapping on a missing
+                // `@EnvironmentObject`.
+                .environment(\.popoverPresentation, controller.popoverPresentation)
         )
         return popover
     }
@@ -310,6 +321,7 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
         // render pass, and anything that would rather not compete with it (the
         // hidden Claude budget WebView) checks this flag.
         environment.setPopoverVisible(true)
+        popoverPresentation.isShown = true
         popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
         popover.contentViewController?.view.window?.makeKey()
     }
@@ -322,9 +334,9 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
                 self.popoverCloseStamps[kind] = Date()
                 break
             }
-            self.environment.setPopoverVisible(
-                self.popovers.values.contains { $0.isShown && $0 !== popover }
-            )
+            let anyOtherShown = self.popovers.values.contains { $0.isShown && $0 !== popover }
+            self.environment.setPopoverVisible(anyOtherShown)
+            self.popoverPresentation.isShown = anyOtherShown
         }
     }
 
@@ -530,6 +542,7 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
         // stays until the process exits.
         popover.behavior = .applicationDefined
         environment.setPopoverVisible(true)
+        popoverPresentation.isShown = true
         popover.show(relativeTo: target.rect, of: target.view, preferredEdge: .minY)
         // Key status would hand keyboard focus to the first button;
         // `vibeBarNoInitialFocus()` on the popover root clears that initial

--- a/Sources/VibeBarApp/Views/ChartBrushNavigator.swift
+++ b/Sources/VibeBarApp/Views/ChartBrushNavigator.swift
@@ -256,8 +256,18 @@ struct ChartBrushNavigator<Mini: View>: View {
 /// One drawable point on a quota line. Segment membership travels with the
 /// point as `seriesKey` so Swift Charts never joins two sides of a reset (or of
 /// a stretch where Vibe Bar was not running) into one stroke.
+///
+/// `id` is the point's slot in the array it was built into, not a printed
+/// `"<series>-<offset>"` key. `ForEach` only needs identity to be unique inside
+/// the collection it walks, and every one of these arrays is walked by exactly
+/// one `ForEach` — so a `String` id bought nothing and cost one heap allocation
+/// *per mark, per rebuild*. On a zoomed-out chart that is a thousand transient
+/// strings built and released on the main thread every time the visible window
+/// moves. `seriesKey` stays a `String` because Swift Charts plots against it,
+/// but it is built once per segment and shared by every point in that segment,
+/// so copying it is a retain rather than an allocation.
 struct QuotaChartLinePoint: Identifiable {
-    let id: String
+    let id: Int
     let seriesKey: String
     let time: Date
     let value: Double
@@ -297,18 +307,23 @@ enum QuotaChartMarks {
             budget: budget
         )
         var result: [QuotaChartLinePoint] = []
+        result.reserveCapacity(allowance.reduce(0, +))
+        // One running counter across every segment: identity has to be unique
+        // inside this array, and nothing outside it ever looks a point up by id.
+        var nextId = 0
         for (slot, entry) in visible.enumerated() {
             let thinned = ChartSeriesThinning.strided(entry.samples, limit: allowance[slot])
             let key = "\(kind)-\(entry.index)"
-            for (offset, sample) in thinned.enumerated() {
+            for sample in thinned {
                 result.append(
                     QuotaChartLinePoint(
-                        id: "\(key)-\(offset)",
+                        id: nextId,
                         seriesKey: key,
                         time: time(sample),
                         value: value(sample)
                     )
                 )
+                nextId += 1
             }
         }
         return result
@@ -331,6 +346,7 @@ enum QuotaChartMarks {
     ) -> [QuotaChartLinePoint] {
         guard segments.count > 1 else { return [] }
         var result: [QuotaChartLinePoint] = []
+        var nextId = 0
         for index in 0..<(segments.count - 1) {
             guard let tail = segments[index].last,
                   let head = segments[index + 1].first
@@ -342,11 +358,12 @@ enum QuotaChartMarks {
             guard end >= range.lowerBound, start <= range.upperBound else { continue }
             let key = "\(kind)-bridge-\(index)"
             result.append(
-                QuotaChartLinePoint(id: "\(key)-0", seriesKey: key, time: start, value: value(tail))
+                QuotaChartLinePoint(id: nextId, seriesKey: key, time: start, value: value(tail))
             )
             result.append(
-                QuotaChartLinePoint(id: "\(key)-1", seriesKey: key, time: end, value: value(head))
+                QuotaChartLinePoint(id: nextId + 1, seriesKey: key, time: end, value: value(head))
             )
+            nextId += 2
         }
         return result
     }

--- a/Sources/VibeBarApp/Views/FillTimelineChart.swift
+++ b/Sources/VibeBarApp/Views/FillTimelineChart.swift
@@ -24,6 +24,19 @@ struct FillTimelineChart: View {
     @EnvironmentObject var quotaService: QuotaService
     @State private var hoveredIndex: Int?
 
+    /// The visible window memoized on the samples it was built from. Hovering
+    /// the strip writes `hoveredIndex`, which re-runs `body`, which used to
+    /// re-sort the bucket's whole retained history on every mouse move. A
+    /// reference box on purpose: filling it during `body` must not dirty view
+    /// state.
+    private final class CycleCache {
+        var key: SubscriptionHistoryKey?
+        var samples: [SubscriptionWindowSample] = []
+        var visible: [SubscriptionWindowSample] = []
+    }
+
+    @State private var cycleCache = CycleCache()
+
     private static let maxCycles = 12
 
     private var barSpacing: CGFloat {
@@ -69,7 +82,16 @@ struct FillTimelineChart: View {
     private func visibleCycles(series: FillTimelineSeries) -> [SubscriptionWindowSample] {
         let key = SubscriptionHistoryKey(accountId: series.accountId, bucketId: series.bucket.id)
         let samples = quotaService.historyByAccountBucket[key] ?? []
-        return Array(samples.sorted { cycleDate($0) < cycleDate($1) }.suffix(Self.maxCycles))
+        // An equality check over the retained samples is far cheaper than the
+        // sort plus the per-element date resolution it drives.
+        if cycleCache.key == key, cycleCache.samples == samples {
+            return cycleCache.visible
+        }
+        let visible = Array(samples.sorted { cycleDate($0) < cycleDate($1) }.suffix(Self.maxCycles))
+        cycleCache.key = key
+        cycleCache.samples = samples
+        cycleCache.visible = visible
+        return visible
     }
 
     @ViewBuilder

--- a/Sources/VibeBarApp/Views/HeaderView.swift
+++ b/Sources/VibeBarApp/Views/HeaderView.swift
@@ -27,8 +27,11 @@ struct HeaderView: View {
                     .lineLimit(1)
                     .truncationMode(.tail)
                     .layoutPriority(2)
-                TimelineView(.periodic(from: .now, by: 30)) { context in
-                    Text(updatedSummary(now: context.date))
+                // `PageClock`, not `TimelineView(.periodic(from: .now, ...))`:
+                // shared 5-minute-floored phase with every other quota
+                // surface, and it stops ticking while the popover is hidden.
+                PageClock(interval: 30) { now in
+                    Text(updatedSummary(now: now))
                         .font(.system(size: subtitleFontSize))
                         .foregroundStyle(.secondary)
                         .lineLimit(1)

--- a/Sources/VibeBarApp/Views/MiniQuotaWindowView.swift
+++ b/Sources/VibeBarApp/Views/MiniQuotaWindowView.swift
@@ -28,8 +28,8 @@ struct MiniQuotaWindowView: View {
     @EnvironmentObject var settingsStore: SettingsStore
     /// Observe the QuotaService directly so the mini window re-renders the
     /// instant a quota refresh lands. Without this the view only redraws on
-    /// a settings change or the inner TimelineView's 30 s tick, which made
-    /// timer- or button-driven refreshes feel laggy compared to the popover.
+    /// a settings change or the panel clock's 30 s tick, which made timer- or
+    /// button-driven refreshes feel laggy compared to the popover.
     @EnvironmentObject var quotaService: QuotaService
 
     private var config: MiniWindowConfig {
@@ -330,23 +330,33 @@ private struct MiniWindowProviderLayout: View {
             contentByTool: contentByTool,
             registry: registry
         )
-        HStack(alignment: .top, spacing: displayMode == .compact ? 8 : 14) {
-            // Positional identity on purpose: an arrangement that interleaves
-            // vendors legally produces two columns named "Google AI", and a
-            // name-keyed ForEach would render the first column's content
-            // twice.
-            ForEach(Array(groups.enumerated()), id: \.offset) { index, group in
-                if index > 0 {
-                    MiniProviderDivider(height: displayMode == .compact ? 94 : 131)
-                        .padding(.top, 2)
-                }
-                switch displayMode {
-                case .compact:
-                    MiniCompactL2GroupColumn(group: group, labels: labels)
-                default:
-                    // Only regular and compact reach this layout; the
-                    // alternative modes render their own views.
-                    MiniCompanyGroupColumn(group: group, labels: labels)
+        // One clock for the whole panel. Every ring / bar cell used to own a
+        // `TimelineView(.periodic(from: .now, by: 30))`, so a mini window with
+        // a dozen selected buckets ran a dozen timers on a dozen phases and
+        // handed `QuotaService.paceForecast` a dozen different `now` values —
+        // its memo could not hit once. The cells take the date as plain data
+        // now, and hoisting the tick also keeps `miniProductGroups` above out
+        // of the per-tick path. Mini windows are visible whenever they exist,
+        // so this is an ungated `StableClock`.
+        StableClock(interval: 30) { tickDate in
+            HStack(alignment: .top, spacing: displayMode == .compact ? 8 : 14) {
+                // Positional identity on purpose: an arrangement that
+                // interleaves vendors legally produces two columns named
+                // "Google AI", and a name-keyed ForEach would render the first
+                // column's content twice.
+                ForEach(Array(groups.enumerated()), id: \.offset) { index, group in
+                    if index > 0 {
+                        MiniProviderDivider(height: displayMode == .compact ? 94 : 131)
+                            .padding(.top, 2)
+                    }
+                    switch displayMode {
+                    case .compact:
+                        MiniCompactL2GroupColumn(group: group, labels: labels, now: tickDate)
+                    default:
+                        // Only regular and compact reach this layout; the
+                        // alternative modes render their own views.
+                        MiniCompanyGroupColumn(group: group, labels: labels, now: tickDate)
+                    }
                 }
             }
         }
@@ -693,6 +703,8 @@ private func miniPrimaryGroupTitle(
 private struct MiniCompanyGroupColumn: View {
     let group: MiniCompanyGroup
     let labels: MiniLabelContext
+    /// Tick from the panel's single clock, passed straight down to the cells.
+    let now: Date
 
     var body: some View {
         VStack(alignment: .center, spacing: 7) {
@@ -713,7 +725,7 @@ private struct MiniCompanyGroupColumn: View {
                         MiniGroupDivider(height: 112)
                             .padding(.top, 4)
                     }
-                    MiniMemberStack(member: member, labels: labels)
+                    MiniMemberStack(member: member, labels: labels, now: now)
                 }
             }
         }
@@ -743,6 +755,7 @@ private struct MiniCompanyGroupColumn: View {
 private struct MiniMemberStack: View {
     let member: MiniL2Member
     let labels: MiniLabelContext
+    let now: Date
 
     var body: some View {
         VStack(alignment: .center, spacing: MiniRingMetrics.subProviderLabelGap) {
@@ -761,11 +774,12 @@ private struct MiniMemberStack: View {
                 if !member.content.primaryCells.isEmpty {
                     MiniPrimaryRingGroup(
                         cells: member.content.primaryCells,
-                        title: primaryGroupTitle
+                        title: primaryGroupTitle,
+                        now: now
                     )
                 }
                 ForEach(branchGroups) { group in
-                    MiniBranchRingGroup(group: group)
+                    MiniBranchRingGroup(group: group, now: now)
                 }
             }
         }
@@ -806,12 +820,13 @@ private struct MiniMemberStack: View {
 private struct MiniPrimaryRingGroup: View {
     let cells: [MiniCell]
     let title: String?
+    let now: Date
 
     var body: some View {
         MiniRingGroupShell(title: title, width: groupWidth) {
             HStack(alignment: .top, spacing: MiniRingMetrics.ringSpacing) {
                 ForEach(cells) { cell in
-                    MiniRingCell(cell: cell)
+                    MiniRingCell(cell: cell, now: now)
                 }
             }
         }
@@ -825,12 +840,13 @@ private struct MiniPrimaryRingGroup: View {
 
 private struct MiniBranchRingGroup: View {
     let group: MiniBranchGroup
+    let now: Date
 
     var body: some View {
         MiniRingGroupShell(title: group.title, width: groupWidth) {
             HStack(alignment: .top, spacing: MiniRingMetrics.ringSpacing) {
                 ForEach(group.cells) { cell in
-                    MiniBranchRingCell(cell: cell)
+                    MiniBranchRingCell(cell: cell, now: now)
                 }
             }
         }
@@ -871,16 +887,16 @@ private struct MiniRingGroupShell<Content: View>: View {
 
 private struct MiniBranchRingCell: View {
     let cell: MiniBranchCell
+    /// Tick from the panel's clock — this cell owns no timer.
+    let now: Date
 
     @EnvironmentObject var settingsStore: SettingsStore
     @EnvironmentObject var environment: AppEnvironment
     @EnvironmentObject var quotaService: QuotaService
 
     var body: some View {
-        TimelineView(.periodic(from: .now, by: 30)) { context in
-            content(now: context.date)
-        }
-        .frame(width: MiniRingMetrics.cellWidth)
+        content(now: now)
+            .frame(width: MiniRingMetrics.cellWidth)
     }
 
     @ViewBuilder
@@ -997,16 +1013,16 @@ private struct MiniGroupDivider: View {
 
 private struct MiniRingCell: View {
     let cell: MiniCell
+    /// Tick from the panel's clock — this cell owns no timer.
+    let now: Date
 
     @EnvironmentObject var settingsStore: SettingsStore
     @EnvironmentObject var environment: AppEnvironment
     @EnvironmentObject var quotaService: QuotaService
 
     var body: some View {
-        TimelineView(.periodic(from: .now, by: 30)) { context in
-            content(now: context.date)
-        }
-        .frame(width: MiniRingMetrics.cellWidth)
+        content(now: now)
+            .frame(width: MiniRingMetrics.cellWidth)
     }
 
     @ViewBuilder
@@ -1159,6 +1175,8 @@ private enum MiniCompactMetrics {
 private struct MiniCompactL2GroupColumn: View {
     let group: MiniCompanyGroup
     let labels: MiniLabelContext
+    /// Tick from the panel's single clock, passed straight down to the cells.
+    let now: Date
 
     var body: some View {
         VStack(alignment: .center, spacing: 5) {
@@ -1179,7 +1197,7 @@ private struct MiniCompactL2GroupColumn: View {
                         MiniGroupDivider(height: 98)
                             .padding(.top, 3)
                     }
-                    MiniCompactMemberStack(member: member, labels: labels)
+                    MiniCompactMemberStack(member: member, labels: labels, now: now)
                 }
             }
         }
@@ -1201,6 +1219,7 @@ private struct MiniCompactL2GroupColumn: View {
 private struct MiniCompactMemberStack: View {
     let member: MiniL2Member
     let labels: MiniLabelContext
+    let now: Date
 
     var body: some View {
         VStack(alignment: .center, spacing: MiniCompactMetrics.subProviderLabelGap) {
@@ -1219,11 +1238,12 @@ private struct MiniCompactMemberStack: View {
                 if !member.content.primaryCells.isEmpty {
                     MiniCompactPrimaryGroup(
                         cells: member.content.primaryCells,
-                        title: primaryGroupTitle
+                        title: primaryGroupTitle,
+                        now: now
                     )
                 }
                 ForEach(branchGroups) { group in
-                    MiniCompactBranchGroup(group: group)
+                    MiniCompactBranchGroup(group: group, now: now)
                 }
             }
         }
@@ -1264,6 +1284,7 @@ private struct MiniCompactMemberStack: View {
 private struct MiniCompactPrimaryGroup: View {
     let cells: [MiniCell]
     let title: String?
+    let now: Date
 
     var body: some View {
         MiniCompactGroupShell(title: title, width: groupWidth) {
@@ -1276,7 +1297,8 @@ private struct MiniCompactPrimaryGroup: View {
                             title: cell.resolvedLabel,
                             bucket: cell.bucket,
                             help: "\(providerTitle(for: cell.tool)) · \(cell.resolvedLabel)"
-                        )
+                        ),
+                        now: now
                     )
                 }
             }
@@ -1291,6 +1313,7 @@ private struct MiniCompactPrimaryGroup: View {
 
 private struct MiniCompactBranchGroup: View {
     let group: MiniBranchGroup
+    let now: Date
 
     var body: some View {
         MiniCompactGroupShell(title: group.title, width: groupWidth) {
@@ -1303,7 +1326,8 @@ private struct MiniCompactBranchGroup: View {
                             title: cell.title,
                             bucket: cell.bucket,
                             help: "\(providerTitle(for: cell.tool)) · \(cell.bucket.groupTitle ?? cell.bucket.shortLabel) · \(cell.bucket.title)"
-                        )
+                        ),
+                        now: now
                     )
                 }
             }
@@ -1353,16 +1377,16 @@ private struct MiniCompactCellData: Identifiable {
 
 private struct MiniCompactBarCell: View {
     let data: MiniCompactCellData
+    /// Tick from the panel's clock — this cell owns no timer.
+    let now: Date
 
     @EnvironmentObject var settingsStore: SettingsStore
     @EnvironmentObject var environment: AppEnvironment
     @EnvironmentObject var quotaService: QuotaService
 
     var body: some View {
-        TimelineView(.periodic(from: .now, by: 30)) { context in
-            content(now: context.date)
-        }
-        .frame(width: MiniCompactMetrics.cellWidth)
+        content(now: now)
+            .frame(width: MiniCompactMetrics.cellWidth)
     }
 
     @ViewBuilder

--- a/Sources/VibeBarApp/Views/MiniWindowAltLayouts.swift
+++ b/Sources/VibeBarApp/Views/MiniWindowAltLayouts.swift
@@ -217,8 +217,11 @@ struct MiniLedgerLayout: View {
     @EnvironmentObject var settingsStore: SettingsStore
 
     var body: some View {
-        TimelineView(.periodic(from: .now, by: 30)) { context in
-            content(now: context.date)
+        // One clock for the layout, on the app-wide phase anchor: a moving
+        // `.now` anchor re-phased the tick on every body pass, so no two
+        // surfaces ever asked `QuotaService.paceForecast` the same question.
+        StableClock(interval: 30) { tickDate in
+            content(now: tickDate)
         }
         .frame(width: MiniLedgerMetrics.width)
     }
@@ -663,8 +666,8 @@ struct MiniFocusLayout: View {
     @State private var pageIndex = 0
 
     var body: some View {
-        TimelineView(.periodic(from: .now, by: 30)) { context in
-            content(now: context.date)
+        StableClock(interval: 30) { tickDate in
+            content(now: tickDate)
         }
         .frame(width: MiniFocusMetrics.size.width, height: MiniFocusMetrics.size.height)
     }
@@ -813,8 +816,8 @@ struct MiniRailLayout: View {
     @EnvironmentObject var settingsStore: SettingsStore
 
     var body: some View {
-        TimelineView(.periodic(from: .now, by: 60)) { context in
-            content(now: context.date)
+        StableClock(interval: 60) { tickDate in
+            content(now: tickDate)
         }
         .frame(width: MiniRailMetrics.size.width, height: MiniRailMetrics.size.height)
     }

--- a/Sources/VibeBarApp/Views/ModelRankingList.swift
+++ b/Sources/VibeBarApp/Views/ModelRankingList.swift
@@ -40,6 +40,9 @@ struct ModelRankingList: View {
 
     var body: some View {
         let models = filteredModels(breakdowns)
+        // `total(models)` used to be called inside the loop, so the reduce
+        // ran once per row for a number that is the same for every row.
+        let totalCost = total(models)
         if !models.isEmpty {
             VStack(alignment: .leading, spacing: density.bucketRowSpacing) {
                 HStack(alignment: .firstTextBaseline) {
@@ -55,9 +58,11 @@ struct ModelRankingList: View {
                     .padding(.leading, 4)
                 }
                 ScrollView(.vertical, showsIndicators: false) {
-                    VStack(alignment: .leading, spacing: 4) {
+                    // Lazy: the list scrolls to as many models as the user has
+                    // ever run, and only a handful are on screen at once.
+                    LazyVStack(alignment: .leading, spacing: 4) {
                         ForEach(Array(models.enumerated()), id: \.element.id) { index, model in
-                            row(rank: index + 1, model: model, total: total(models))
+                            row(rank: index + 1, model: model, total: totalCost)
                         }
                     }
                 }
@@ -126,15 +131,26 @@ struct ModelRankingList: View {
                     .foregroundStyle(.tertiary)
                     .frame(width: 32, alignment: .trailing)
             }
-            // Inline share bar so eye-tracking the column is easy.
-            GeometryReader { proxy in
-                ZStack(alignment: .leading) {
-                    Capsule()
-                        .fill(Color.primary.opacity(0.05))
-                    Capsule()
-                        .fill(rankColor(rank).opacity(0.6))
-                        .frame(width: max(2, proxy.size.width * share / 100))
-                }
+            // Inline share bar so eye-tracking the column is easy. Drawn in a
+            // `Canvas` rather than a `GeometryReader` per row: the bar needs
+            // its own width, and a Canvas gets it at draw time instead of
+            // adding a layout container to every row of the list.
+            Canvas { context, size in
+                let track = CGRect(origin: .zero, size: size)
+                context.fill(
+                    Path(roundedRect: track, cornerRadius: min(track.width, track.height) / 2),
+                    with: .color(Color.primary.opacity(0.05))
+                )
+                let fill = CGRect(
+                    x: 0,
+                    y: 0,
+                    width: max(2, size.width * share / 100),
+                    height: size.height
+                )
+                context.fill(
+                    Path(roundedRect: fill, cornerRadius: min(fill.width, fill.height) / 2),
+                    with: .color(rankColor(rank).opacity(0.6))
+                )
             }
             .frame(height: 4)
         }

--- a/Sources/VibeBarApp/Views/OverviewQuotaHistoryCard.swift
+++ b/Sources/VibeBarApp/Views/OverviewQuotaHistoryCard.swift
@@ -76,6 +76,9 @@ private struct OverviewLaneBuild {
     var curve: OverviewQuotaCurve
     var segments: [[QuotaHistorySample]]
     var flat: [QuotaHistorySample]
+    /// The thinned copy the brush strip draws. Cached with the lane because it
+    /// depends only on the segments, never on the visible window.
+    var mini: [[QuotaHistorySample]]
 }
 
 /// Every recorded quota, from every provider and account, on one time axis.
@@ -90,8 +93,15 @@ private struct OverviewLaneBuild {
 /// A pull-down picks which curves are drawn, and the choice persists — see
 /// `AppSettings.overviewQuotaHistoryHiddenCurveIds`.
 ///
-/// Like `QuotaHistoryChartView`, this view reads no wall clock and no
-/// environment value, so it is safe under any re-proposal from above.
+/// Split in two. This half discovers the lanes, which means reading three
+/// environment objects; `OverviewQuotaChartBody` draws them and is `.equatable()`
+/// over plain values, so a `QuotaService` or `SettingsStore` publish that
+/// changes nothing the chart shows stops at that boundary instead of re-running
+/// the mark pipeline for every curve. The crosshair sits one level lower again,
+/// in `OverviewQuotaHoverOverlay`, so a pointer move invalidates neither.
+///
+/// Like `QuotaHistoryChartView`, neither half reads a wall clock, so both are
+/// safe under any re-proposal from above.
 struct OverviewQuotaHistoryCard: View {
     let density: Theme.Density
 
@@ -109,29 +119,54 @@ struct OverviewQuotaHistoryCard: View {
     /// order a binary search needs. Built with the series so a pointer move
     /// costs a search rather than a scan.
     @State private var flatByCurve: [String: [QuotaHistorySample]] = [:]
+    /// Each curve thinned for the brush strip. This used to be recomputed
+    /// inside the strip's `Path` builder, which put a full re-thin of every
+    /// curve on the main thread once per navigator frame — every frame of a pan
+    /// included. It depends on the segments alone and never on the window, so
+    /// it belongs with the rest of the per-data-change work.
+    @State private var miniByCurve: [String: [[QuotaHistorySample]]] = [:]
     @State private var window: ChartTimeWindow?
     @State private var windowKey: String?
     @State private var initialSpan: TimeInterval = OverviewQuotaHistoryCard.preferredInitialSpan
-    @State private var hoverDate: Date?
-    @State private var panBase: ChartTimeWindow?
-    @State private var magnifyBase: ChartTimeWindow?
+    /// Bumped once per `rebuild()`. It stands in for the three sample
+    /// dictionaries above in `OverviewQuotaChartBody`'s `==`: they are the
+    /// expensive half of that view's input, nothing but `rebuild()` writes them,
+    /// and comparing a counter is both cheaper and exactly as correct as walking
+    /// thirty lanes of samples.
+    @State private var seriesRevision = 0
+    /// Bumped when the picker or a range pill has to drop the crosshair. The
+    /// hover state itself lives in `OverviewQuotaHoverOverlay` so that a pointer
+    /// move cannot invalidate *this* view — which reads three environment
+    /// objects and, before the split, re-ran the whole mark pipeline whenever
+    /// any of them published.
+    @State private var hoverResetToken = 0
 
-    /// Shared across every visible curve, so a provider with nine quotas
-    /// cannot starve the rest of the chart of detail.
-    private static let visibleMarkBudget = 900
-    private static let minimumMarkBudget = 90
     private static let miniMarkLimit = 120
-    /// Past this many rows the tooltip stops being a readout and becomes a
-    /// second chart; the rest are counted instead. Safe to cap only because
-    /// the rows are sorted lowest-remaining first — the quotas that get folded
-    /// into "+N more" are the ones with the most headroom.
-    private static let tooltipRowLimit = 8
 
     var body: some View {
         VStack(alignment: .leading, spacing: density.cardSpacing) {
             header
             if let window, window.domainSpan > 0, !visibleCurves.isEmpty {
-                chartBody(window: window)
+                // Everything below this line is a plain value and the drawing
+                // view is `.equatable()`. That barrier is the point: this card
+                // has to read `AccountStore`, `QuotaService` and `SettingsStore`
+                // to discover its lanes, an environment object invalidates its
+                // readers directly, and a refresh publishes repeatedly — so
+                // without it every unrelated publish re-ran clip → budget →
+                // thin → build for every curve.
+                OverviewQuotaChartBody(
+                    density: density,
+                    curves: visibleCurves,
+                    segmentsByCurve: segmentsByCurve,
+                    flatByCurve: flatByCurve,
+                    miniByCurve: miniByCurve,
+                    revision: seriesRevision,
+                    window: window,
+                    initialSpan: initialSpan,
+                    resetToken: hoverResetToken,
+                    setWindow: { self.window = $0 }
+                )
+                .equatable()
             } else if curves.isEmpty {
                 note("Quota history builds up as refreshes come in.")
             } else {
@@ -169,7 +204,9 @@ struct OverviewQuotaHistoryCard: View {
                 ChartRangePills(
                     window: rangeBinding,
                     fontSize: max(9, density.segmentedFontSize - 2),
-                    onSelect: { hoverDate = nil }
+                    // The crosshair lives in the overlay now, so a pill asks for
+                    // it to be dropped instead of clearing it directly.
+                    onSelect: { hoverResetToken &+= 1 }
                 )
             }
         }
@@ -251,7 +288,7 @@ struct OverviewQuotaHistoryCard: View {
     private func setHidden(_ hidden: Set<String>) {
         guard hidden != settingsStore.settings.overviewQuotaHistoryHiddenCurveIds else { return }
         settingsStore.settings.overviewQuotaHistoryHiddenCurveIds = hidden
-        hoverDate = nil
+        hoverResetToken &+= 1
     }
 
     /// Quick way back to a readable chart from a wall of curves: keep the ones
@@ -270,357 +307,6 @@ struct OverviewQuotaHistoryCard: View {
         guard let segment = segmentsByCurve[curve.id]?.last, segment.count > 1 else { return 0 }
         let values = segment.map(\.remainingPercent)
         return (values.max() ?? 0) - (values.min() ?? 0)
-    }
-
-    // MARK: - Chart
-
-    @ViewBuilder
-    private func chartBody(window: ChartTimeWindow) -> some View {
-        let visible = window.visibleRange
-        let shown = visibleCurves
-        // One budget per curve, split again across the segments that curve is
-        // drawn in — a five-hour quota over months of history is hundreds of
-        // small segments, and thinning each to the curve's budget would have
-        // meant multiplying it by their count.
-        let budget = max(Self.minimumMarkBudget, Self.visibleMarkBudget / max(1, shown.count))
-        let lines = shown.map { curve -> (OverviewQuotaCurve, [QuotaChartLinePoint], [QuotaChartLinePoint]) in
-            let segments = segmentsByCurve[curve.id] ?? []
-            return (
-                curve,
-                QuotaChartMarks.points(
-                    segments,
-                    kind: curve.id,
-                    range: visible,
-                    budget: budget,
-                    time: { $0.time },
-                    value: { $0.remainingPercent }
-                ),
-                QuotaChartMarks.bridges(
-                    segments,
-                    kind: curve.id,
-                    range: visible,
-                    time: { $0.time },
-                    value: { $0.remainingPercent }
-                )
-            )
-        }
-
-        VStack(alignment: .leading, spacing: 6) {
-            legend(shown)
-
-            Chart {
-                // Bridges first so a real observation always draws over the
-                // connector that leads into it.
-                ForEach(lines, id: \.0.id) { curve, _, bridges in
-                    ForEach(bridges) { point in
-                        LineMark(
-                            x: .value("Time", point.time),
-                            y: .value("Left", point.value),
-                            series: .value("Line", point.seriesKey)
-                        )
-                        .foregroundStyle(curve.color.opacity(QuotaChartMarks.bridgeOpacity))
-                        .lineStyle(QuotaChartMarks.bridgeStroke)
-                    }
-                }
-                ForEach(lines, id: \.0.id) { curve, points, _ in
-                    ForEach(points) { point in
-                        LineMark(
-                            x: .value("Time", point.time),
-                            y: .value("Left", point.value),
-                            series: .value("Line", point.seriesKey)
-                        )
-                        .foregroundStyle(curve.color)
-                        .lineStyle(
-                            StrokeStyle(
-                                lineWidth: 1.6,
-                                lineCap: .round,
-                                lineJoin: .round,
-                                dash: curve.dash
-                            )
-                        )
-                    }
-                }
-            }
-            .chartLegend(.hidden)
-            .chartXScale(domain: visible)
-            // Same clip as QuotaHistoryChartView: bridge marks deliberately
-            // carry endpoints outside the visible range, and unclipped they
-            // stroke across whatever sits left of the card.
-            .chartPlotStyle { plotArea in
-                plotArea.clipped()
-            }
-            .chartYScale(domain: 0...100)
-            .chartYAxis {
-                AxisMarks(position: .leading, values: [0, 25, 50, 75, 100]) { value in
-                    AxisGridLine().foregroundStyle(.secondary.opacity(0.15))
-                    AxisValueLabel {
-                        if let raw = value.as(Double.self) {
-                            Text("\(Int(raw))%")
-                                .font(.system(size: 9, design: .rounded).monospacedDigit())
-                        }
-                    }
-                }
-            }
-            .chartXAxis {
-                AxisMarks(values: .automatic(desiredCount: 4)) { _ in
-                    AxisGridLine().foregroundStyle(.secondary.opacity(0.10))
-                    AxisValueLabel()
-                        .font(.system(size: 9))
-                }
-            }
-            .chartOverlay { proxy in
-                interactionOverlay(proxy: proxy, curves: shown)
-            }
-            .frame(height: density.overviewQuotaHistoryChartHeight)
-
-            ChartBrushNavigator(
-                window: rangeBinding,
-                accent: Color.secondary,
-                height: density.chartBrushHeight,
-                accessibilityDescription: "All-providers quota history range navigator"
-            ) { geometry in
-                miniPaths(shown, in: geometry)
-            }
-
-            Text(scopeNote(shown, window: window))
-                .font(.system(size: max(8, density.resetCountdownFontSize - 1)))
-                .foregroundStyle(.tertiary)
-                .lineLimit(1)
-                .minimumScaleFactor(0.85)
-        }
-    }
-
-    private func miniPaths(
-        _ shown: [OverviewQuotaCurve],
-        in geometry: ChartBrushGeometry
-    ) -> some View {
-        ZStack {
-            ForEach(shown) { curve in
-                Path { path in
-                    let strip = ChartMarkBudget.thinned(
-                        segmentsByCurve[curve.id] ?? [],
-                        budget: Self.miniMarkLimit
-                    )
-                    for segment in strip {
-                        guard let first = segment.first else { continue }
-                        path.move(to: miniPoint(first, in: geometry))
-                        for sample in segment.dropFirst() {
-                            path.addLine(to: miniPoint(sample, in: geometry))
-                        }
-                    }
-                }
-                .stroke(
-                    curve.color.opacity(0.6),
-                    style: StrokeStyle(lineWidth: 0.8, lineCap: .round, lineJoin: .round)
-                )
-            }
-        }
-    }
-
-    private func miniPoint(
-        _ sample: QuotaHistorySample,
-        in geometry: ChartBrushGeometry
-    ) -> CGPoint {
-        CGPoint(
-            x: geometry.x(for: sample.time),
-            y: geometry.y(forFraction: sample.remainingPercent / 100)
-        )
-    }
-
-    // MARK: - Legend
-
-    private func legend(_ shown: [OverviewQuotaCurve]) -> some View {
-        LazyVGrid(
-            columns: [GridItem(.adaptive(minimum: 138), spacing: 8)],
-            alignment: .leading,
-            spacing: 3
-        ) {
-            ForEach(shown) { curve in
-                HStack(spacing: 4) {
-                    swatch(curve)
-                    Text(curve.label)
-                        .font(.system(size: max(8, density.subtitleFontSize - 2)))
-                        .foregroundStyle(.secondary)
-                        .lineLimit(1)
-                        .truncationMode(.middle)
-                    Spacer(minLength: 0)
-                }
-            }
-        }
-    }
-
-    private func swatch(_ curve: OverviewQuotaCurve) -> some View {
-        Path { path in
-            path.move(to: CGPoint(x: 0, y: 1))
-            path.addLine(to: CGPoint(x: 13, y: 1))
-        }
-        .stroke(curve.color, style: StrokeStyle(lineWidth: 2, lineCap: .round, dash: curve.dash))
-        .frame(width: 13, height: 2)
-    }
-
-    // MARK: - Hover + gestures
-
-    private func interactionOverlay(
-        proxy: ChartProxy,
-        curves shown: [OverviewQuotaCurve]
-    ) -> some View {
-        GeometryReader { geometry in
-            let plot = proxy.plotFrame.map { geometry[$0] }
-            let plotMinX = plot?.minX ?? 0
-            let plotWidth = plot?.width ?? geometry.size.width
-            ZStack(alignment: .topLeading) {
-                Rectangle()
-                    .fill(Color.clear)
-                    .contentShape(Rectangle())
-                    .onContinuousHover { phase in
-                        switch phase {
-                        case .active(let location):
-                            let value = proxy.value(atX: location.x - plotMinX, as: Date.self)
-                            hoverDate = value.flatMap {
-                                window?.visibleRange.contains($0) == true ? $0 : nil
-                            }
-                        case .ended:
-                            hoverDate = nil
-                        }
-                    }
-                    .gesture(panGesture(plotWidth: plotWidth))
-                    .simultaneousGesture(magnifyGesture(proxy: proxy, plotMinX: plotMinX))
-                    .onTapGesture(count: 2) {
-                        window = window?.jumped(toSpan: initialSpan)
-                        hoverDate = nil
-                    }
-
-                if let hoverDate,
-                   let x = proxy.position(forX: hoverDate),
-                   let plot {
-                    let readings = hoverReadings(at: hoverDate, curves: shown)
-                    Rectangle()
-                        .fill(Color.primary.opacity(0.22))
-                        .frame(width: 1, height: plot.height)
-                        .offset(x: plotMinX + x, y: plot.minY)
-                        .allowsHitTesting(false)
-                    tooltip(at: hoverDate, readings: readings)
-                        .offset(x: tooltipX(plotMinX: plotMinX, x: x, width: geometry.size.width))
-                        .allowsHitTesting(false)
-                }
-            }
-        }
-    }
-
-    private func panGesture(plotWidth: CGFloat) -> some Gesture {
-        DragGesture(minimumDistance: 3)
-            .onChanged { value in
-                guard plotWidth > 0, let current = window else { return }
-                let base = panBase ?? current
-                if panBase == nil { panBase = base }
-                let secondsPerPoint = base.visibleSpan / TimeInterval(plotWidth)
-                window = base.panned(by: -TimeInterval(value.translation.width) * secondsPerPoint)
-            }
-            .onEnded { _ in panBase = nil }
-    }
-
-    private func magnifyGesture(proxy: ChartProxy, plotMinX: CGFloat) -> some Gesture {
-        MagnifyGesture(minimumScaleDelta: 0.01)
-            .onChanged { value in
-                guard let current = window else { return }
-                let base = magnifyBase ?? current
-                if magnifyBase == nil { magnifyBase = base }
-                let anchor = proxy.value(atX: value.startLocation.x - plotMinX, as: Date.self)
-                    ?? base.visibleMidpoint
-                window = base.zoomed(scale: value.magnification, around: anchor)
-            }
-            .onEnded { _ in magnifyBase = nil }
-    }
-
-    private static let tooltipWidth: CGFloat = 214
-
-    private func tooltipX(plotMinX: CGFloat, x: CGFloat, width: CGFloat) -> CGFloat {
-        min(max(plotMinX + x - Self.tooltipWidth / 2, 0), max(0, width - Self.tooltipWidth))
-    }
-
-    private func tooltip(at date: Date, readings: [OverviewHoverReading]) -> some View {
-        VStack(alignment: .leading, spacing: 3) {
-            Text(Self.tooltipFormatter.string(from: date))
-                .font(.system(size: 10, weight: .semibold))
-            if readings.isEmpty {
-                // Same wording as the per-group chart's empty row, and for the
-                // same reason: an absent sample says the app was not watching,
-                // not that the quota was between windows.
-                Text("No data recorded")
-                    .font(.system(size: 9))
-                    .foregroundStyle(.white.opacity(0.7))
-            } else {
-                ForEach(readings.prefix(Self.tooltipRowLimit)) { reading in
-                    HStack(alignment: .firstTextBaseline, spacing: 6) {
-                        Circle()
-                            .fill(reading.color)
-                            .frame(width: 5, height: 5)
-                        Text(reading.label)
-                            .font(.system(size: 9))
-                            .foregroundStyle(.white.opacity(0.78))
-                            .lineLimit(1)
-                            .truncationMode(.middle)
-                        Spacer(minLength: 6)
-                        Text("\(Int(reading.value.rounded()))%")
-                            .font(
-                                .system(size: 9, weight: .semibold, design: .rounded)
-                                    .monospacedDigit()
-                            )
-                    }
-                }
-                if readings.count > Self.tooltipRowLimit {
-                    Text("+\(readings.count - Self.tooltipRowLimit) more")
-                        .font(.system(size: 9))
-                        .foregroundStyle(.white.opacity(0.55))
-                }
-            }
-        }
-        .padding(.horizontal, 8)
-        .padding(.vertical, 6)
-        .background(RoundedRectangle(cornerRadius: 6).fill(Color.black.opacity(0.87)))
-        .foregroundStyle(.white)
-        .frame(width: Self.tooltipWidth, alignment: .leading)
-    }
-
-    /// Nearest observation per curve, **lowest remaining first**.
-    ///
-    /// The order is the whole point of the card: the reader is looking for
-    /// whichever quota is closest to running out, and the tooltip caps its rows
-    /// — so sorting the fullest quotas to the top would have buried exactly the
-    /// curves this card exists to surface behind "+N more". Curves with no
-    /// coverage near the cursor are omitted rather than shown as zero.
-    ///
-    /// Resolved by binary search over each curve's flattened, time-sorted
-    /// samples, because this runs on every pointer move — and with a tolerance
-    /// resolved per curve, because this card exists to overlay quotas whose
-    /// windows (and therefore whose sampling rhythms) differ by orders of
-    /// magnitude.
-    private func hoverReadings(
-        at date: Date,
-        curves shown: [OverviewQuotaCurve]
-    ) -> [OverviewHoverReading] {
-        guard let window else { return [] }
-        var result: [OverviewHoverReading] = []
-        for curve in shown {
-            guard let sample = ChartSampleSearch.nearest(
-                in: flatByCurve[curve.id] ?? [],
-                to: date,
-                tolerance: ChartHoverTolerance.seconds(
-                    windowSeconds: curve.windowSeconds,
-                    visibleSpan: window.visibleSpan
-                ),
-                time: { $0.time }
-            ) else { continue }
-            result.append(
-                OverviewHoverReading(
-                    id: curve.id,
-                    label: curve.label,
-                    color: curve.color,
-                    value: sample.remainingPercent
-                )
-            )
-        }
-        return result.sorted { $0.value < $1.value }
     }
 
     // MARK: - Selection
@@ -737,8 +423,10 @@ struct OverviewQuotaHistoryCard: View {
             laneCache = [:]
             segmentsByCurve = [:]
             flatByCurve = [:]
+            miniByCurve = [:]
             window = nil
             windowKey = nil
+            seriesRevision &+= 1
             return
         }
 
@@ -753,6 +441,7 @@ struct OverviewQuotaHistoryCard: View {
         var built: [OverviewQuotaCurve] = []
         var series: [String: [[QuotaHistorySample]]] = [:]
         var flat: [String: [QuotaHistorySample]] = [:]
+        var mini: [String: [[QuotaHistorySample]]] = [:]
         var rebuiltCache: [String: OverviewLaneBuild] = [:]
         var indexPerTool: [ToolType: Int] = [:]
         for (account, bucket) in lanes {
@@ -774,6 +463,7 @@ struct OverviewQuotaHistoryCard: View {
                 built.append(cached.curve)
                 series[id] = cached.segments
                 flat[id] = cached.flat
+                mini[id] = cached.mini
                 rebuiltCache[id] = cached
                 continue
             }
@@ -796,16 +486,19 @@ struct OverviewQuotaHistoryCard: View {
                 range: domain
             ).actual
             let flattened = actual.flatMap { $0 }
+            let thinned = ChartMarkBudget.thinned(actual, budget: Self.miniMarkLimit)
             built.append(curve)
             series[id] = actual
             flat[id] = flattened
+            mini[id] = thinned
             rebuiltCache[id] = OverviewLaneBuild(
                 signature: signature,
                 variantIndex: index,
                 qualifier: qualifier,
                 curve: curve,
                 segments: actual,
-                flat: flattened
+                flat: flattened,
+                mini: thinned
             )
         }
 
@@ -813,6 +506,10 @@ struct OverviewQuotaHistoryCard: View {
         laneCache = rebuiltCache
         segmentsByCurve = series
         flatByCurve = flat
+        miniByCurve = mini
+        // Everything the drawing view memoizes has just been replaced, so
+        // invalidate it with one integer instead of a deep compare of every lane.
+        seriesRevision &+= 1
 
         let key = built.map(\.id).joined(separator: ",")
         let sameCurves = windowKey == key
@@ -909,14 +606,6 @@ struct OverviewQuotaHistoryCard: View {
         return masked.isEmpty ? String(account.id.suffix(4)) : masked
     }
 
-    private func scopeNote(_ shown: [OverviewQuotaCurve], window: ChartTimeWindow) -> String {
-        let providers = Set(shown.map(\.tool)).count
-        let curveWord = shown.count == 1 ? "curve" : "curves"
-        let providerWord = providers == 1 ? "provider" : "providers"
-        return "\(shown.count) \(curveWord) · \(providers) \(providerWord) · showing "
-            + "\(Self.spanLabel(window.visibleSpan)) of \(Self.spanLabel(window.domainSpan)) recorded"
-    }
-
     // MARK: - Palette
 
     /// One brand hue per provider, stepped in lightness (then in dash pattern)
@@ -961,11 +650,349 @@ struct OverviewQuotaHistoryCard: View {
         )
     }
 
+}
+
+/// The drawn half of the all-providers quota history card.
+///
+/// Split out of `OverviewQuotaHistoryCard` and made `Equatable` on purpose. That
+/// card has to read `AccountStore`, `QuotaService` and `SettingsStore` to
+/// discover which lanes exist, and an `@EnvironmentObject` invalidates the views
+/// that read it *directly* — so every publish from a refresh, and a refresh
+/// publishes repeatedly, re-ran the clip → budget → thin → build pipeline for
+/// every curve on the main thread. Here the inputs are plain values and the diff
+/// is a counter plus the window, so an unrelated publish stops at this boundary.
+///
+/// Like the card it came from, this view reads no wall clock and no environment
+/// value, so it is safe under any re-proposal from above.
+private struct OverviewQuotaChartBody: View, Equatable {
+    let density: Theme.Density
+    let curves: [OverviewQuotaCurve]
+    let segmentsByCurve: [String: [[QuotaHistorySample]]]
+    let flatByCurve: [String: [QuotaHistorySample]]
+    let miniByCurve: [String: [[QuotaHistorySample]]]
+    /// Stands in for the three dictionaries above; see the card's
+    /// `seriesRevision`.
+    let revision: Int
+    let window: ChartTimeWindow
+    let initialSpan: TimeInterval
+    let resetToken: Int
+    /// A plain setter rather than a `Binding`, so `==` never has to pull a
+    /// value back through a binding whose view may no longer be installed.
+    let setWindow: (ChartTimeWindow) -> Void
+
+    /// Curves are compared by id rather than by value on purpose. Everything
+    /// else about a curve — its hue, its dash, its label — is written by
+    /// `rebuild()`, which bumps `revision`, so the ids answer the only question
+    /// left: which curves the picker is currently showing. It also keeps the
+    /// diff off `Color` equality, whose result for an appearance-aware
+    /// `NSColor` is not something this comparison should depend on.
+    static func == (lhs: OverviewQuotaChartBody, rhs: OverviewQuotaChartBody) -> Bool {
+        lhs.revision == rhs.revision
+            && lhs.window == rhs.window
+            && lhs.density == rhs.density
+            && lhs.initialSpan == rhs.initialSpan
+            && lhs.resetToken == rhs.resetToken
+            && lhs.curves.elementsEqual(rhs.curves) { $0.id == $1.id }
+    }
+
+    /// Shared across every visible curve, so a provider with nine quotas
+    /// cannot starve the rest of the chart of detail. It is a *chart* budget:
+    /// each curve draws one thinned line, so the plot stays inside it up to ten
+    /// curves and thins every curve to the floor past that.
+    private static let visibleMarkBudget = 900
+    private static let minimumMarkBudget = 90
+
+    /// One curve's drawable marks. Also carries the stroke, so the `Chart`
+    /// closure never has to look a curve back up while laying marks out.
+    private struct CurveLines: Identifiable {
+        let id: String
+        let color: Color
+        let dash: [CGFloat]
+        let points: [QuotaChartLinePoint]
+        let bridges: [QuotaChartLinePoint]
+    }
+
+    private struct PlanKey: Equatable {
+        let revision: Int
+        let curveIds: [String]
+        let range: ClosedRange<Date>
+    }
+
+    /// Reference box, so a memo hit or update during `body` never dirties view
+    /// state; correctness comes from the key, not from invalidation timing.
+    /// Same pattern (and reasoning) as `UsageTrendChartView`.
+    private final class PlanCache {
+        var key: PlanKey?
+        var lines: [CurveLines]?
+    }
+
+    @State private var planCache = PlanCache()
+
+    private var lines: [CurveLines] {
+        let key = PlanKey(
+            revision: revision,
+            curveIds: curves.map(\.id),
+            range: window.visibleRange
+        )
+        if let cached = planCache.lines, planCache.key == key { return cached }
+        let built = Self.buildLines(
+            curves: curves,
+            segmentsByCurve: segmentsByCurve,
+            range: key.range
+        )
+        planCache.key = key
+        planCache.lines = built
+        return built
+    }
+
+    private static func buildLines(
+        curves: [OverviewQuotaCurve],
+        segmentsByCurve: [String: [[QuotaHistorySample]]],
+        range: ClosedRange<Date>
+    ) -> [CurveLines] {
+        // One budget per curve, split again across the segments that curve is
+        // drawn in — a five-hour quota over months of history is hundreds of
+        // small segments, and thinning each to the curve's budget would have
+        // meant multiplying it by their count.
+        let budget = max(minimumMarkBudget, visibleMarkBudget / max(1, curves.count))
+        return curves.map { curve in
+            let segments = segmentsByCurve[curve.id] ?? []
+            return CurveLines(
+                id: curve.id,
+                color: curve.color,
+                dash: curve.dash,
+                points: QuotaChartMarks.points(
+                    segments,
+                    kind: curve.id,
+                    range: range,
+                    budget: budget,
+                    time: { $0.time },
+                    value: { $0.remainingPercent }
+                ),
+                bridges: QuotaChartMarks.bridges(
+                    segments,
+                    kind: curve.id,
+                    range: range,
+                    time: { $0.time },
+                    value: { $0.remainingPercent }
+                )
+            )
+        }
+    }
+
+    var body: some View {
+        let binding = Binding<ChartTimeWindow>(get: { window }, set: setWindow)
+        // Memoized on (series revision, curves, visible range): a pan or a zoom
+        // is a genuine miss and rebuilds, every other re-proposal reuses what is
+        // already laid out.
+        let lines = self.lines
+
+        VStack(alignment: .leading, spacing: 6) {
+            legend
+
+            Chart {
+                // Bridges first so a real observation always draws over the
+                // connector that leads into it.
+                ForEach(lines) { line in
+                    ForEach(line.bridges) { point in
+                        LineMark(
+                            x: .value("Time", point.time),
+                            y: .value("Left", point.value),
+                            series: .value("Line", point.seriesKey)
+                        )
+                        .foregroundStyle(line.color.opacity(QuotaChartMarks.bridgeOpacity))
+                        .lineStyle(QuotaChartMarks.bridgeStroke)
+                    }
+                }
+                ForEach(lines) { line in
+                    ForEach(line.points) { point in
+                        LineMark(
+                            x: .value("Time", point.time),
+                            y: .value("Left", point.value),
+                            series: .value("Line", point.seriesKey)
+                        )
+                        .foregroundStyle(line.color)
+                        .lineStyle(
+                            StrokeStyle(
+                                lineWidth: 1.6,
+                                lineCap: .round,
+                                lineJoin: .round,
+                                dash: line.dash
+                            )
+                        )
+                    }
+                }
+            }
+            .chartLegend(.hidden)
+            .chartXScale(domain: window.visibleRange)
+            // Same clip as QuotaHistoryChartView: bridge marks deliberately
+            // carry endpoints outside the visible range, and unclipped they
+            // stroke across whatever sits left of the card.
+            .chartPlotStyle { plotArea in
+                plotArea.clipped()
+            }
+            .chartYScale(domain: 0...100)
+            .chartYAxis {
+                AxisMarks(position: .leading, values: [0, 25, 50, 75, 100]) { value in
+                    AxisGridLine().foregroundStyle(.secondary.opacity(0.15))
+                    AxisValueLabel {
+                        if let raw = value.as(Double.self) {
+                            Text("\(Int(raw))%")
+                                .font(.system(size: 9, design: .rounded).monospacedDigit())
+                        }
+                    }
+                }
+            }
+            .chartXAxis {
+                AxisMarks(values: .automatic(desiredCount: 4)) { _ in
+                    AxisGridLine().foregroundStyle(.secondary.opacity(0.10))
+                    AxisValueLabel()
+                        .font(.system(size: 9))
+                }
+            }
+            // A view of its own rather than a closure over this body, so a
+            // pointer move re-renders the crosshair and the tooltip and leaves
+            // the marks above untouched.
+            .chartOverlay { proxy in
+                OverviewQuotaHoverOverlay(
+                    proxy: proxy,
+                    curves: curves,
+                    flatByCurve: flatByCurve,
+                    initialSpan: initialSpan,
+                    resetToken: resetToken,
+                    window: binding
+                )
+            }
+            .frame(height: density.overviewQuotaHistoryChartHeight)
+
+            ChartBrushNavigator(
+                window: binding,
+                accent: Color.secondary,
+                height: density.chartBrushHeight,
+                accessibilityDescription: "All-providers quota history range navigator"
+            ) { geometry in
+                miniPaths(in: geometry)
+            }
+
+            Text(scopeNote)
+                .font(.system(size: max(8, density.resetCountdownFontSize - 1)))
+                .foregroundStyle(.tertiary)
+                .lineLimit(1)
+                .minimumScaleFactor(0.85)
+        }
+    }
+
+    // MARK: - Brush mini
+
+    private func miniPaths(in geometry: ChartBrushGeometry) -> some View {
+        ZStack {
+            ForEach(curves) { curve in
+                Path { path in
+                    // Already thinned when the lanes were built — this only
+                    // projects the samples into the strip's coordinate space.
+                    for segment in miniByCurve[curve.id] ?? [] {
+                        guard let first = segment.first else { continue }
+                        path.move(to: miniPoint(first, in: geometry))
+                        for sample in segment.dropFirst() {
+                            path.addLine(to: miniPoint(sample, in: geometry))
+                        }
+                    }
+                }
+                .stroke(
+                    curve.color.opacity(0.6),
+                    style: StrokeStyle(lineWidth: 0.8, lineCap: .round, lineJoin: .round)
+                )
+            }
+        }
+    }
+
+    private func miniPoint(
+        _ sample: QuotaHistorySample,
+        in geometry: ChartBrushGeometry
+    ) -> CGPoint {
+        CGPoint(
+            x: geometry.x(for: sample.time),
+            y: geometry.y(forFraction: sample.remainingPercent / 100)
+        )
+    }
+
+    // MARK: - Legend
+
+    private var legend: some View {
+        LazyVGrid(
+            columns: [GridItem(.adaptive(minimum: 138), spacing: 8)],
+            alignment: .leading,
+            spacing: 3
+        ) {
+            ForEach(curves) { curve in
+                HStack(spacing: 4) {
+                    swatch(curve)
+                    Text(curve.label)
+                        .font(.system(size: max(8, density.subtitleFontSize - 2)))
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                    Spacer(minLength: 0)
+                }
+            }
+        }
+    }
+
+    private func swatch(_ curve: OverviewQuotaCurve) -> some View {
+        Path { path in
+            path.move(to: CGPoint(x: 0, y: 1))
+            path.addLine(to: CGPoint(x: 13, y: 1))
+        }
+        .stroke(curve.color, style: StrokeStyle(lineWidth: 2, lineCap: .round, dash: curve.dash))
+        .frame(width: 13, height: 2)
+    }
+
+    // MARK: - Footer
+
+    private var scopeNote: String {
+        let providers = Set(curves.map(\.tool)).count
+        let curveWord = curves.count == 1 ? "curve" : "curves"
+        let providerWord = providers == 1 ? "provider" : "providers"
+        return "\(curves.count) \(curveWord) · \(providers) \(providerWord) · showing "
+            + "\(Self.spanLabel(window.visibleSpan)) of \(Self.spanLabel(window.domainSpan)) recorded"
+    }
+
     private static func spanLabel(_ seconds: TimeInterval) -> String {
         if seconds < 90 * 60 { return "\(max(1, Int((seconds / 60).rounded())))m" }
         if seconds < 48 * 3_600 { return "\(Int((seconds / 3_600).rounded()))h" }
         return "\(Int((seconds / 86_400).rounded()))d"
     }
+}
+
+/// Crosshair, tooltip and the all-providers plot's pan / pinch / double-tap
+/// gestures.
+///
+/// A view of its own, with its own `@State`, for the same reason
+/// `QuotaChartHoverOverlay` is: `hoverDate` used to sit on the card, so every
+/// pointer move invalidated the card and re-ran the mark pipeline for every
+/// curve before the crosshair could move a pixel. Here a pointer move
+/// re-renders only this overlay, and the reading itself is one binary search per
+/// curve over an array flattened when the lanes were built.
+private struct OverviewQuotaHoverOverlay: View {
+    let proxy: ChartProxy
+    let curves: [OverviewQuotaCurve]
+    let flatByCurve: [String: [QuotaHistorySample]]
+    let initialSpan: TimeInterval
+    /// Incremented by the card when the picker or a range pill has to drop the
+    /// crosshair.
+    let resetToken: Int
+    @Binding var window: ChartTimeWindow
+
+    @State private var hoverDate: Date?
+    @State private var panBase: ChartTimeWindow?
+    @State private var magnifyBase: ChartTimeWindow?
+
+    private static let tooltipWidth: CGFloat = 214
+    /// Past this many rows the tooltip stops being a readout and becomes a
+    /// second chart; the rest are counted instead. Safe to cap only because
+    /// the rows are sorted lowest-remaining first — the quotas that get folded
+    /// into "+N more" are the ones with the most headroom.
+    private static let tooltipRowLimit = 8
 
     private static let tooltipFormatter: DateFormatter = {
         let formatter = DateFormatter()
@@ -973,4 +1000,162 @@ struct OverviewQuotaHistoryCard: View {
         formatter.dateFormat = "MMM d · HH:mm"
         return formatter
     }()
+
+    var body: some View {
+        GeometryReader { geometry in
+            let plot = proxy.plotFrame.map { geometry[$0] }
+            let plotMinX = plot?.minX ?? 0
+            let plotWidth = plot?.width ?? geometry.size.width
+            ZStack(alignment: .topLeading) {
+                Rectangle()
+                    .fill(Color.clear)
+                    .contentShape(Rectangle())
+                    .onContinuousHover { phase in
+                        switch phase {
+                        case .active(let location):
+                            let value = proxy.value(atX: location.x - plotMinX, as: Date.self)
+                            hoverDate = value.flatMap {
+                                window.visibleRange.contains($0) ? $0 : nil
+                            }
+                        case .ended:
+                            hoverDate = nil
+                        }
+                    }
+                    .gesture(panGesture(plotWidth: plotWidth))
+                    .simultaneousGesture(magnifyGesture(plotMinX: plotMinX))
+                    .onTapGesture(count: 2) {
+                        window = window.jumped(toSpan: initialSpan)
+                        hoverDate = nil
+                    }
+
+                if let hoverDate,
+                   let x = proxy.position(forX: hoverDate),
+                   let plot {
+                    let readings = hoverReadings(at: hoverDate)
+                    Rectangle()
+                        .fill(Color.primary.opacity(0.22))
+                        .frame(width: 1, height: plot.height)
+                        .offset(x: plotMinX + x, y: plot.minY)
+                        .allowsHitTesting(false)
+                    tooltip(at: hoverDate, readings: readings)
+                        .offset(x: tooltipX(plotMinX: plotMinX, x: x, width: geometry.size.width))
+                        .allowsHitTesting(false)
+                }
+            }
+        }
+        .onChange(of: resetToken) { _, _ in hoverDate = nil }
+    }
+
+    // MARK: - Gestures
+
+    private func panGesture(plotWidth: CGFloat) -> some Gesture {
+        DragGesture(minimumDistance: 3)
+            .onChanged { value in
+                guard plotWidth > 0 else { return }
+                let base = panBase ?? window
+                if panBase == nil { panBase = base }
+                let secondsPerPoint = base.visibleSpan / TimeInterval(plotWidth)
+                window = base.panned(by: -TimeInterval(value.translation.width) * secondsPerPoint)
+            }
+            .onEnded { _ in panBase = nil }
+    }
+
+    private func magnifyGesture(plotMinX: CGFloat) -> some Gesture {
+        MagnifyGesture(minimumScaleDelta: 0.01)
+            .onChanged { value in
+                let base = magnifyBase ?? window
+                if magnifyBase == nil { magnifyBase = base }
+                let anchor = proxy.value(atX: value.startLocation.x - plotMinX, as: Date.self)
+                    ?? base.visibleMidpoint
+                window = base.zoomed(scale: value.magnification, around: anchor)
+            }
+            .onEnded { _ in magnifyBase = nil }
+    }
+
+    // MARK: - Tooltip
+
+    private func tooltipX(plotMinX: CGFloat, x: CGFloat, width: CGFloat) -> CGFloat {
+        min(max(plotMinX + x - Self.tooltipWidth / 2, 0), max(0, width - Self.tooltipWidth))
+    }
+
+    private func tooltip(at date: Date, readings: [OverviewHoverReading]) -> some View {
+        VStack(alignment: .leading, spacing: 3) {
+            Text(Self.tooltipFormatter.string(from: date))
+                .font(.system(size: 10, weight: .semibold))
+            if readings.isEmpty {
+                // Same wording as the per-group chart's empty row, and for the
+                // same reason: an absent sample says the app was not watching,
+                // not that the quota was between windows.
+                Text("No data recorded")
+                    .font(.system(size: 9))
+                    .foregroundStyle(.white.opacity(0.7))
+            } else {
+                ForEach(readings.prefix(Self.tooltipRowLimit)) { reading in
+                    HStack(alignment: .firstTextBaseline, spacing: 6) {
+                        Circle()
+                            .fill(reading.color)
+                            .frame(width: 5, height: 5)
+                        Text(reading.label)
+                            .font(.system(size: 9))
+                            .foregroundStyle(.white.opacity(0.78))
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                        Spacer(minLength: 6)
+                        Text("\(Int(reading.value.rounded()))%")
+                            .font(
+                                .system(size: 9, weight: .semibold, design: .rounded)
+                                    .monospacedDigit()
+                            )
+                    }
+                }
+                if readings.count > Self.tooltipRowLimit {
+                    Text("+\(readings.count - Self.tooltipRowLimit) more")
+                        .font(.system(size: 9))
+                        .foregroundStyle(.white.opacity(0.55))
+                }
+            }
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 6)
+        .background(RoundedRectangle(cornerRadius: 6).fill(Color.black.opacity(0.87)))
+        .foregroundStyle(.white)
+        .frame(width: Self.tooltipWidth, alignment: .leading)
+    }
+
+    /// Nearest observation per curve, **lowest remaining first**.
+    ///
+    /// The order is the whole point of the card: the reader is looking for
+    /// whichever quota is closest to running out, and the tooltip caps its rows
+    /// — so sorting the fullest quotas to the top would have buried exactly the
+    /// curves this card exists to surface behind "+N more". Curves with no
+    /// coverage near the cursor are omitted rather than shown as zero.
+    ///
+    /// Resolved by binary search over each curve's flattened, time-sorted
+    /// samples, because this runs on every pointer move — and with a tolerance
+    /// resolved per curve, because this card exists to overlay quotas whose
+    /// windows (and therefore whose sampling rhythms) differ by orders of
+    /// magnitude.
+    private func hoverReadings(at date: Date) -> [OverviewHoverReading] {
+        var result: [OverviewHoverReading] = []
+        for curve in curves {
+            guard let sample = ChartSampleSearch.nearest(
+                in: flatByCurve[curve.id] ?? [],
+                to: date,
+                tolerance: ChartHoverTolerance.seconds(
+                    windowSeconds: curve.windowSeconds,
+                    visibleSpan: window.visibleSpan
+                ),
+                time: { $0.time }
+            ) else { continue }
+            result.append(
+                OverviewHoverReading(
+                    id: curve.id,
+                    label: curve.label,
+                    color: curve.color,
+                    value: sample.remainingPercent
+                )
+            )
+        }
+        return result.sorted { $0.value < $1.value }
+    }
 }

--- a/Sources/VibeBarApp/Views/PopoverRoot.swift
+++ b/Sources/VibeBarApp/Views/PopoverRoot.swift
@@ -550,11 +550,13 @@ private struct OverviewWaterfall: View {
     /// called by both the arranged and the balanced path, so the two can never
     /// render a module differently.
     ///
-    /// No module here reads the wall clock, so the Overview starts no periodic
-    /// timer of its own: a page-level tick would re-measure every card in the
-    /// masonry twice a minute. If a clock-consuming module is ever added, hoist
-    /// one `TimelineView` in `body` and pass its date through this factory —
-    /// never a timer per card.
+    /// The Overview starts no periodic timer of its own: a page-level tick
+    /// would re-measure every card in the masonry twice a minute, and the
+    /// masonry session lock would fight it. The two clock-consuming modules —
+    /// the quota cards and Upcoming Resets — each own exactly one `PageClock`
+    /// at *card* level instead, which is one timer per card rather than one
+    /// per bucket row, and none at all while the popover is closed. Never add
+    /// a timer below a card.
     @ViewBuilder
     private func card(
         for descriptor: PageModuleDescriptor,
@@ -1654,7 +1656,13 @@ private struct ProviderDetailView: View {
         // reads the wall clock; they take the tick as plain data so no card
         // owns a timer of its own. `QuotaHistoryChartView` stays `.equatable()`
         // inside `QuotaGroupCard`, so the chart still ignores the tick.
-        TimelineView(.periodic(from: .now, by: 30)) { timeline in
+        //
+        // `PageClock` rather than `TimelineView(.periodic(from: .now, ...))`:
+        // the anchor has to be stable across body passes (otherwise every
+        // re-render re-phases the tick and the forecast memo never hits), and
+        // the popover keeps this tree alive after it closes, so the clock has
+        // to stop while it is hidden.
+        PageClock(interval: 30) { tickDate in
             PageLayoutColumns(
                 page: page,
                 descriptors: descriptors,
@@ -1674,7 +1682,7 @@ private struct ProviderDetailView: View {
                     context: context,
                     density: density,
                     mode: settingsStore.displayMode,
-                    now: timeline.date
+                    now: tickDate
                 )
             }
         }
@@ -1990,7 +1998,22 @@ struct ProviderQuotaCard: View {
             }
 
             if !visibleBuckets.isEmpty {
-                bucketContent(visibleBuckets, accountId: resolvedAccount?.id)
+                // One clock for the whole card. Every bucket row used to own a
+                // `TimelineView(.periodic(from: .now, by: 30))`, which meant N
+                // timers per card, N different tick phases, and therefore N
+                // distinct `now` values reaching `QuotaService.paceForecast` —
+                // the memo there could never hit. The rows take the date as
+                // plain data now, and the shared anchor in `QuotaClockSchedule`
+                // makes every card on the page ask for the same instant.
+                //
+                // Both inputs are resolved *outside* the clock: `visibleBuckets`
+                // re-reads the cached quota and `resolvedAccount` scans the
+                // account store, and neither answer can change on a tick.
+                let buckets = visibleBuckets
+                let bucketAccountId = resolvedAccount?.id
+                PageClock(interval: 30) { tickDate in
+                    bucketContent(buckets, accountId: bucketAccountId, now: tickDate)
+                }
                 if tool == .codex, let credits = resolvedQuota?.resetCredits, credits.availableCount > 0 {
                     ResetCreditsRow(credits: credits, density: density)
                 }
@@ -2095,7 +2118,11 @@ struct ProviderQuotaCard: View {
         )
     }
 
-    private func bucketContent(_ buckets: [QuotaBucket], accountId: String?) -> some View {
+    private func bucketContent(
+        _ buckets: [QuotaBucket],
+        accountId: String?,
+        now: Date
+    ) -> some View {
         let primary = buckets.filter { $0.groupTitle == nil }
         let extras = buckets.filter { $0.groupTitle != nil }
         return VStack(alignment: .leading, spacing: density.bucketGroupSpacing) {
@@ -2106,7 +2133,8 @@ struct ProviderQuotaCard: View {
                         accountId: accountId,
                         bucket: bucket,
                         mode: settingsStore.displayMode,
-                        density: density
+                        density: density,
+                        now: now
                     )
                 }
             }
@@ -2131,7 +2159,8 @@ struct ProviderQuotaCard: View {
                                 accountId: accountId,
                                 bucket: bucket,
                                 mode: settingsStore.displayMode,
-                                density: density
+                                density: density,
+                                now: now
                             )
                         }
                     }
@@ -2230,18 +2259,17 @@ private struct ProviderBucketRow: View {
     let bucket: QuotaBucket
     let mode: DisplayMode
     let density: Theme.Density
+    /// Tick from the enclosing card's single clock. Plain data — this row
+    /// starts no timer, however many buckets the card ends up rendering. The
+    /// visible cadence is unchanged (30 s, minute-granular countdowns); only
+    /// the owner of the clock moved up one level.
+    let now: Date
 
     @EnvironmentObject var environment: AppEnvironment
     @EnvironmentObject var quotaService: QuotaService
 
     var body: some View {
-        // We only refresh "resets in …" periodically, but we don't repaint
-        // the entire bucket row at that cadence — only the strings that depend
-        // on `now`. The displayed countdown is minute-granular, so 30 seconds
-        // keeps it fresh without making popover open/close fight row updates.
-        TimelineView(.periodic(from: .now, by: 30)) { context in
-            content(now: context.date)
-        }
+        content(now: now)
     }
 
     @ViewBuilder

--- a/Sources/VibeBarApp/Views/QuotaHistoryChartView.swift
+++ b/Sources/VibeBarApp/Views/QuotaHistoryChartView.swift
@@ -121,8 +121,12 @@ enum QuotaBucketGrouping {
 }
 
 /// One drawable point of the forecast's uncertainty band.
+///
+/// `id` is the slot in the array, for the same reason `QuotaChartLinePoint`'s
+/// is: a printed id allocated a string per band mark per rebuild and no caller
+/// ever reads it back.
 private struct QuotaBandPoint: Identifiable {
-    let id: String
+    let id: Int
     let seriesKey: String
     let time: Date
     let low: Double
@@ -158,6 +162,31 @@ private struct QuotaHoverReading {
     let buckets: [QuotaHoverBucketReading]
 
     var isEmpty: Bool { buckets.allSatisfy(\.isEmpty) }
+}
+
+/// One overlaid quota, reduced to exactly what the crosshair needs: flat,
+/// ascending copies of its three lines plus how to name and colour it.
+///
+/// The segments are contiguous runs of an already time-sorted array, so
+/// concatenating them keeps the order a binary search needs. Built once per data
+/// change in `rebuild()` and handed to the hover overlay as a plain value, so a
+/// pointer move costs three binary searches per lane and touches none of the
+/// chart's own state. (This is what `BucketLookup` used to be; it moved out of
+/// the chart view because the hover moved out with it.)
+private struct QuotaHoverLane {
+    let id: String
+    let title: String
+    let color: Color
+    let windowSeconds: Int?
+    let actual: [QuotaHistorySample]
+    let pace: [QuotaHistorySample]
+    let forecast: [QuotaHistoryForecastSample]
+}
+
+/// Shared by the legend and by the hover tooltip, which live in two different
+/// views now and have to print a percentage the same way.
+private func quotaPercentLabel(_ value: Double) -> String {
+    "\(Int(value.rounded()))%"
 }
 
 /// Everything that decides the shape of the chart. Rebuilding is keyed on this
@@ -206,6 +235,12 @@ private struct QuotaSeriesSignature: Equatable {
 /// `@EnvironmentObject` at all — an environment read here would bypass the
 /// diff entirely and re-run the body on every unrelated service publish.
 ///
+/// The crosshair is deliberately *not* part of that diff: it lives in
+/// `QuotaChartHoverOverlay`, a child with its own `@State`, so a pointer move
+/// re-renders the overlay and never this body — the marks below it are memoized
+/// on `seriesRevision` and the visible window and are not rebuilt to move a
+/// crosshair one pixel.
+///
 /// The other half of that contract: **this view must never read the current
 /// time**. There is no `now` parameter and no `Date()` anywhere in it — every
 /// "current" reading in the legend comes from the newest recorded sample, so a
@@ -250,14 +285,24 @@ struct QuotaHistoryChartView: View, Equatable {
 
     @State private var forecastByBucket: [String: [ForecastTimelinePoint]] = [:]
     @State private var seriesByBucket: [String: QuotaHistorySeries] = [:]
-    @State private var lookupByBucket: [String: BucketLookup] = [:]
+    /// Flattened lines per bucket, in the shape the hover overlay searches.
+    @State private var hoverLanes: [QuotaHoverLane] = []
     @State private var miniSegments: [[QuotaHistorySample]] = []
     @State private var window: ChartTimeWindow?
     @State private var windowKey: String?
     @State private var initialSpan: TimeInterval = QuotaHistoryChartView.defaultInitialSpan
-    @State private var hoverDate: Date?
-    @State private var panBase: ChartTimeWindow?
-    @State private var magnifyBase: ChartTimeWindow?
+    /// Bumped once per `rebuild()`. The mark plan is keyed on it instead of on
+    /// the series themselves: the series are dictionaries of arrays of arrays,
+    /// and comparing them per body pass is exactly the walk the cache exists to
+    /// avoid. Nothing but `rebuild()` writes `seriesByBucket`, so a counter is
+    /// as correct as a deep compare and O(1).
+    @State private var seriesRevision = 0
+    /// Bumped when a range pill jumps the window — the one case where something
+    /// outside the hover overlay has to drop its crosshair. The hover state
+    /// itself lives in that overlay so a pointer move cannot invalidate this
+    /// view; see `QuotaChartHoverOverlay`.
+    @State private var hoverResetToken = 0
+    @State private var planCache = PlanCache()
 
     /// Hue per bucket inside one group, reused from the accents the rest of the
     /// app already spends: the healthy-quota green, the forecast blue, the
@@ -272,12 +317,24 @@ struct QuotaHistoryChartView: View, Equatable {
     ]
     private static let paceColor = Color.secondary
 
-    /// Marks per line inside the visible window. Beyond this the strokes stop
-    /// gaining detail and start costing frames on a zoomed-out weekly domain —
-    /// so the budget is shared out across however many buckets overlay, and
-    /// then again across the segments each bucket is drawn in.
-    private static let visibleMarkBudget = 520
-    private static let minimumMarkBudget = 140
+    /// Marks the whole plot may draw inside the visible window, across every
+    /// thinned line in it.
+    ///
+    /// This used to be a per-*line* budget, and it under-counted the chart by
+    /// the number of lines it draws: a single-bucket chart strokes four thinned
+    /// layers (observed, forecast, time-only pace, uncertainty band), so 520 per
+    /// line was really ~2 080 marks — twice the project's ~1 000-mark ceiling
+    /// (`AGENTS.md` § 7) on the *smallest* chart this view can render. The
+    /// budget is now the chart's: it is divided by the layers that will actually
+    /// be stroked, and each layer's share is divided again across the segments
+    /// that layer is drawn in.
+    private static let chartMarkBudget = 900
+    /// Floor per layer, so a group overlaying many quotas thins every line hard
+    /// rather than reducing one of them to a stub. It only starts winning past
+    /// ten drawn layers — five overlaid quotas each with a forecast — which no
+    /// real group reaches; past that the chart is deliberately over budget for
+    /// the same reason `ChartMarkBudget` lets segment floors overshoot.
+    private static let minimumMarkBudget = 90
     private static let miniMarkLimit = 160
     /// Past this many reset lines the plot reads as a picket fence rather than
     /// as a set of boundaries, so a zoomed-out five-hour quota drops them.
@@ -285,9 +342,12 @@ struct QuotaHistoryChartView: View, Equatable {
 
     var body: some View {
         let buckets = bucketsWithHistory
-        let drawable = buckets.first.flatMap { first in
-            window.flatMap { $0.domainSpan > 0 ? (first, $0) : nil }
-        }
+        // The first bucket is the primary one (shortest window first), and the
+        // plan reads it back out of `buckets`; all this needs to decide is
+        // whether there is anything drawable at all.
+        let drawable = buckets.isEmpty
+            ? nil
+            : window.flatMap { $0.domainSpan > 0 ? $0 : nil }
 
         Group {
             if isEmbedded {
@@ -297,7 +357,7 @@ struct QuotaHistoryChartView: View, Equatable {
                 if let drawable {
                     VStack(alignment: .leading, spacing: 5) {
                         embeddedHeader
-                        chartBody(buckets: buckets, primary: drawable.0, window: drawable.1)
+                        chartBody(buckets: buckets, window: drawable)
                     }
                     .padding(.top, 5)
                 }
@@ -305,7 +365,7 @@ struct QuotaHistoryChartView: View, Equatable {
                 VStack(alignment: .leading, spacing: density.cardSpacing) {
                     cardHeader
                     if let drawable {
-                        chartBody(buckets: buckets, primary: drawable.0, window: drawable.1)
+                        chartBody(buckets: buckets, window: drawable)
                     } else {
                         emptyNote
                     }
@@ -378,7 +438,6 @@ struct QuotaHistoryChartView: View, Equatable {
     @ViewBuilder
     private func chartBody(
         buckets: [QuotaBucket],
-        primary: QuotaBucket,
         window: ChartTimeWindow
     ) -> some View {
         let binding = Binding<ChartTimeWindow>(
@@ -386,37 +445,17 @@ struct QuotaHistoryChartView: View, Equatable {
             set: { self.window = $0 }
         )
         let visible = window.visibleRange
-        let isSingle = buckets.count == 1
-        // One budget per bucket, shared out across however many segments that
-        // bucket happens to be drawn in.
-        let budget = max(Self.minimumMarkBudget, Self.visibleMarkBudget / max(1, buckets.count))
-        let lines = bucketLines(buckets: buckets, range: visible, budget: budget)
-        let primarySeries = seriesByBucket[primary.id] ?? .empty
-        // Only a single-bucket chart can afford the wall-clock reference and
-        // the uncertainty band: two of them overlaid is mud, and the pace
-        // reading moves into the hover tooltip instead.
-        let pacePoints = isSingle
-            ? linePoints(primarySeries.pace, kind: "pace", range: visible, budget: budget)
-            : []
-        let paceBridges = isSingle
-            ? bridgePoints(
-                primarySeries.pace,
-                time: { $0.time },
-                value: { $0.remainingPercent },
-                kind: "pace",
-                range: visible
-            )
-            : []
-        let bandPoints = isSingle
-            ? forecastBandPoints(primarySeries.forecast, range: visible, budget: budget)
-            : []
-        let resets = resetMarks(primarySeries: primarySeries, range: visible)
+        // Every mark this plot draws, memoized on (series revision, buckets,
+        // visible range). A pan or a zoom is a genuine miss and rebuilds; every
+        // other re-proposal — a forecast landing, a density change, a range
+        // pill clearing the crosshair — reuses what is already laid out.
+        let plan = markPlan(buckets: buckets, range: visible)
 
         VStack(alignment: .leading, spacing: 6) {
             legend(buckets: buckets)
 
             Chart {
-                ForEach(bandPoints) { point in
+                ForEach(plan.band) { point in
                     AreaMark(
                         x: .value("Time", point.time),
                         yStart: .value("Low", point.low),
@@ -425,12 +464,12 @@ struct QuotaHistoryChartView: View, Equatable {
                     )
                     .foregroundStyle(forecastTint(Self.bucketPalette[0]).opacity(0.08))
                 }
-                ForEach(resets, id: \.self) { reset in
+                ForEach(plan.resets, id: \.self) { reset in
                     RuleMark(x: .value("Reset", reset))
                         .foregroundStyle(Color.primary.opacity(0.16))
                         .lineStyle(StrokeStyle(lineWidth: 1, dash: [3, 3]))
                 }
-                ForEach(paceBridges) { point in
+                ForEach(plan.paceBridges) { point in
                     LineMark(
                         x: .value("Time", point.time),
                         y: .value("Left", point.value),
@@ -439,7 +478,7 @@ struct QuotaHistoryChartView: View, Equatable {
                     .foregroundStyle(Self.paceColor.opacity(QuotaChartMarks.bridgeOpacity))
                     .lineStyle(QuotaChartMarks.bridgeStroke)
                 }
-                ForEach(pacePoints) { point in
+                ForEach(plan.pace) { point in
                     LineMark(
                         x: .value("Time", point.time),
                         y: .value("Left", point.value),
@@ -448,7 +487,7 @@ struct QuotaHistoryChartView: View, Equatable {
                     .foregroundStyle(Self.paceColor.opacity(0.85))
                     .lineStyle(StrokeStyle(lineWidth: 1.6, dash: [5, 4]))
                 }
-                ForEach(lines) { line in
+                ForEach(plan.lines) { line in
                     ForEach(line.forecastBridges) { point in
                         LineMark(
                             x: .value("Time", point.time),
@@ -459,7 +498,7 @@ struct QuotaHistoryChartView: View, Equatable {
                         .lineStyle(QuotaChartMarks.bridgeStroke)
                     }
                 }
-                ForEach(lines) { line in
+                ForEach(plan.lines) { line in
                     ForEach(line.forecast) { point in
                         LineMark(
                             x: .value("Time", point.time),
@@ -470,7 +509,7 @@ struct QuotaHistoryChartView: View, Equatable {
                         .lineStyle(StrokeStyle(lineWidth: 1.8, lineCap: .round, dash: [2, 3.4]))
                     }
                 }
-                ForEach(lines) { line in
+                ForEach(plan.lines) { line in
                     ForEach(line.actualBridges) { point in
                         LineMark(
                             x: .value("Time", point.time),
@@ -481,7 +520,7 @@ struct QuotaHistoryChartView: View, Equatable {
                         .lineStyle(QuotaChartMarks.bridgeStroke)
                     }
                 }
-                ForEach(lines) { line in
+                ForEach(plan.lines) { line in
                     ForEach(line.actual) { point in
                         LineMark(
                             x: .value("Time", point.time),
@@ -522,11 +561,16 @@ struct QuotaHistoryChartView: View, Equatable {
                         .font(.system(size: 9))
                 }
             }
+            // The overlay is a view of its own, not a closure over this body:
+            // it owns the hover state, so a pointer move re-renders the
+            // crosshair and the tooltip and leaves the marks above untouched.
             .chartOverlay { proxy in
-                interactionOverlay(
+                QuotaChartHoverOverlay(
                     proxy: proxy,
-                    buckets: buckets,
-                    primary: primary,
+                    lanes: hoverLanes,
+                    showsBucketTitles: buckets.count > 1,
+                    initialSpan: initialSpan,
+                    resetToken: hoverResetToken,
                     window: binding
                 )
             }
@@ -599,7 +643,7 @@ struct QuotaHistoryChartView: View, Equatable {
     /// shortest-window quota's boundaries are drawn — its sawtooth is the one a
     /// reader is trying to line up, and stacking a second schedule on top of it
     /// just stripes the plot.
-    private func resetMarks(
+    private static func resetMarks(
         primarySeries: QuotaHistorySeries,
         range: ClosedRange<Date>
     ) -> [Date] {
@@ -762,231 +806,6 @@ struct QuotaHistoryChartView: View, Equatable {
         .frame(width: 14, height: 2)
     }
 
-    // MARK: - Hover + gestures
-
-    private func interactionOverlay(
-        proxy: ChartProxy,
-        buckets: [QuotaBucket],
-        primary: QuotaBucket,
-        window: Binding<ChartTimeWindow>
-    ) -> some View {
-        GeometryReader { geometry in
-            let plot = proxy.plotFrame.map { geometry[$0] }
-            let plotMinX = plot?.minX ?? 0
-            let plotWidth = plot?.width ?? geometry.size.width
-            ZStack(alignment: .topLeading) {
-                Rectangle()
-                    .fill(Color.clear)
-                    .contentShape(Rectangle())
-                    .onContinuousHover { phase in
-                        switch phase {
-                        case .active(let location):
-                            // The overlay also covers the leading axis strip;
-                            // a reading from there would park the crosshair
-                            // outside the plot.
-                            let value = proxy.value(atX: location.x - plotMinX, as: Date.self)
-                            hoverDate = value.flatMap {
-                                window.wrappedValue.visibleRange.contains($0) ? $0 : nil
-                            }
-                        case .ended:
-                            hoverDate = nil
-                        }
-                    }
-                    .gesture(panGesture(window: window, plotWidth: plotWidth))
-                    .simultaneousGesture(
-                        magnifyGesture(window: window, proxy: proxy, plotMinX: plotMinX)
-                    )
-                    .onTapGesture(count: 2) {
-                        window.wrappedValue = window.wrappedValue.jumped(toSpan: initialSpan)
-                        hoverDate = nil
-                    }
-
-                if let hoverDate,
-                   let reading = hoverReading(at: hoverDate, buckets: buckets, primary: primary),
-                   let x = proxy.position(forX: reading.time),
-                   let plot {
-                    // The reading anchors to the nearest sample, which the
-                    // pointer slop can put just outside the visible range —
-                    // clamp so the crosshair stays inside the plot instead of
-                    // drawing into the axis gutter.
-                    let clampedX = min(max(x, 0), plot.width)
-                    Rectangle()
-                        .fill(Color.primary.opacity(0.22))
-                        .frame(width: 1, height: plot.height)
-                        .offset(x: plotMinX + clampedX, y: plot.minY)
-                        .allowsHitTesting(false)
-                    tooltip(reading, showsBucketTitles: buckets.count > 1)
-                        .offset(x: tooltipX(plotMinX: plotMinX, x: clampedX, width: geometry.size.width))
-                        .allowsHitTesting(false)
-                }
-            }
-        }
-    }
-
-    private func panGesture(window: Binding<ChartTimeWindow>, plotWidth: CGFloat) -> some Gesture {
-        DragGesture(minimumDistance: 3)
-            .onChanged { value in
-                guard plotWidth > 0 else { return }
-                let base = panBase ?? window.wrappedValue
-                if panBase == nil { panBase = base }
-                let secondsPerPoint = base.visibleSpan / TimeInterval(plotWidth)
-                window.wrappedValue = base.panned(
-                    by: -TimeInterval(value.translation.width) * secondsPerPoint
-                )
-            }
-            .onEnded { _ in panBase = nil }
-    }
-
-    private func magnifyGesture(
-        window: Binding<ChartTimeWindow>,
-        proxy: ChartProxy,
-        plotMinX: CGFloat
-    ) -> some Gesture {
-        MagnifyGesture(minimumScaleDelta: 0.01)
-            .onChanged { value in
-                let base = magnifyBase ?? window.wrappedValue
-                if magnifyBase == nil { magnifyBase = base }
-                let anchor = proxy.value(atX: value.startLocation.x - plotMinX, as: Date.self)
-                    ?? base.visibleMidpoint
-                window.wrappedValue = base.zoomed(scale: value.magnification, around: anchor)
-            }
-            .onEnded { _ in magnifyBase = nil }
-    }
-
-    private func tooltipX(plotMinX: CGFloat, x: CGFloat, width: CGFloat) -> CGFloat {
-        let tooltipWidth = Self.tooltipWidth
-        return min(max(plotMinX + x - tooltipWidth / 2, 0), max(0, width - tooltipWidth))
-    }
-
-    private static let tooltipWidth: CGFloat = 178
-
-    private func tooltip(_ reading: QuotaHoverReading, showsBucketTitles: Bool) -> some View {
-        VStack(alignment: .leading, spacing: 3) {
-            Text(Self.tooltipFormatter.string(from: reading.time))
-                .font(.system(size: 10, weight: .semibold))
-            ForEach(reading.buckets) { bucket in
-                if showsBucketTitles {
-                    HStack(spacing: 4) {
-                        Circle()
-                            .fill(bucket.color)
-                            .frame(width: 5, height: 5)
-                        Text(bucket.title)
-                            .font(.system(size: 9, weight: .semibold))
-                            .foregroundStyle(.white.opacity(0.85))
-                        Spacer(minLength: 0)
-                    }
-                    .padding(.top, 1)
-                }
-                if bucket.isEmpty {
-                    // Deliberately about the *evidence*, not about the quota.
-                    // Nothing here means no sample was taken near this instant
-                    // — the Mac was asleep, the app was quit, a refresh was
-                    // skipped. The window itself was very probably wide open,
-                    // and nothing in a fill lane can tell the two apart, so
-                    // claiming there was no active window was a guess dressed
-                    // up as a reading.
-                    Text("No data recorded")
-                        .font(.system(size: 9))
-                        .foregroundStyle(.white.opacity(0.7))
-                } else {
-                    if let actual = bucket.actual {
-                        tooltipRow("Quota left", percent(actual), color: bucket.color)
-                    }
-                    if let pace = bucket.pace {
-                        tooltipRow("Pace", percent(pace), color: .white.opacity(0.8))
-                    }
-                    if let forecast = bucket.forecast {
-                        tooltipRow("At reset", percent(forecast), color: bucket.color.opacity(0.75))
-                    }
-                }
-            }
-        }
-        .padding(.horizontal, 8)
-        .padding(.vertical, 6)
-        .background(RoundedRectangle(cornerRadius: 6).fill(Color.black.opacity(0.87)))
-        .foregroundStyle(.white)
-        .frame(width: Self.tooltipWidth, alignment: .leading)
-    }
-
-    private func tooltipRow(_ label: String, _ value: String, color: Color) -> some View {
-        HStack(alignment: .firstTextBaseline, spacing: 6) {
-            Text(label)
-                .font(.system(size: 9))
-                .foregroundStyle(.white.opacity(0.75))
-            Spacer(minLength: 6)
-            Text(value)
-                .font(.system(size: 9, weight: .semibold, design: .rounded).monospacedDigit())
-                .foregroundStyle(color)
-        }
-    }
-
-    /// Nearest reading on each line, per bucket, or nothing at all for a bucket
-    /// whose coverage does not reach the cursor — a gap is information, not a
-    /// rounding error, so it is never bridged to the closest sample on either
-    /// side. The time label follows the shortest-window quota, which is the one
-    /// sampled most densely.
-    ///
-    /// The tolerance is resolved **per bucket**, not once for the group. The
-    /// buckets overlaid here are sampled at different rhythms — Claude's 5
-    /// Hours is filed into five-minute slots and its Weekly into hourly ones —
-    /// so a single tolerance taken from the shortest window missed the sparse
-    /// lanes on most cursor positions and reported them as having nothing to
-    /// say while their line ran under the crosshair. See `ChartHoverTolerance`.
-    ///
-    /// Binary search rather than a scan: this runs on every pointer move, and a
-    /// densely sampled lane under unlimited retention is tens of thousands of
-    /// samples per bucket.
-    private func hoverReading(
-        at date: Date,
-        buckets: [QuotaBucket],
-        primary: QuotaBucket
-    ) -> QuotaHoverReading? {
-        guard let window else { return nil }
-        var readings: [QuotaHoverBucketReading] = []
-        var anchor: Date?
-        for (index, bucket) in buckets.enumerated() {
-            let tolerance = ChartHoverTolerance.seconds(
-                windowSeconds: bucket.rawWindowSeconds,
-                visibleSpan: window.visibleSpan
-            )
-            let lookup = lookupByBucket[bucket.id] ?? BucketLookup()
-            let actual = ChartSampleSearch.nearest(
-                in: lookup.actual, to: date, tolerance: tolerance, time: { $0.time }
-            )
-            let pace = ChartSampleSearch.nearest(
-                in: lookup.pace, to: date, tolerance: tolerance, time: { $0.time }
-            )
-            let forecast = ChartSampleSearch.nearest(
-                in: lookup.forecast, to: date, tolerance: tolerance, time: { $0.time }
-            )
-            if bucket.id == primary.id {
-                anchor = actual?.time ?? forecast?.time
-            }
-            readings.append(
-                QuotaHoverBucketReading(
-                    id: bucket.id,
-                    title: bucket.title,
-                    color: color(at: index),
-                    actual: actual?.remainingPercent,
-                    pace: pace?.remainingPercent,
-                    forecast: forecast?.remainingPercent
-                )
-            )
-        }
-        return QuotaHoverReading(time: anchor ?? date, buckets: readings)
-    }
-
-    /// Flattened, ascending copies of one bucket's lines.
-    ///
-    /// The segments are contiguous runs of an already time-sorted array, so
-    /// concatenating them keeps the order a binary search needs. Built once per
-    /// data change rather than walked per pointer move.
-    private struct BucketLookup {
-        var actual: [QuotaHistorySample] = []
-        var pace: [QuotaHistorySample] = []
-        var forecast: [QuotaHistoryForecastSample] = []
-    }
-
     // MARK: - Range pills
 
     /// Preset spans, shared with the Overview chart so both surfaces offer the
@@ -1005,7 +824,9 @@ struct QuotaHistoryChartView: View, Equatable {
                     set: { self.window = $0 }
                 ),
                 fontSize: max(9, density.segmentedFontSize - 2),
-                onSelect: { hoverDate = nil }
+                // The crosshair lives in the overlay now, so a pill asks for it
+                // to be dropped instead of clearing it directly.
+                onSelect: { hoverResetToken &+= 1 }
             )
         }
     }
@@ -1118,10 +939,11 @@ struct QuotaHistoryChartView: View, Equatable {
         let buckets = bucketsWithHistory
         guard let primary = buckets.first, let domain = domainRange(buckets: buckets) else {
             seriesByBucket = [:]
-            lookupByBucket = [:]
+            hoverLanes = []
             miniSegments = []
             window = nil
             windowKey = nil
+            seriesRevision &+= 1
             return
         }
 
@@ -1134,17 +956,29 @@ struct QuotaHistoryChartView: View, Equatable {
             )
         }
         seriesByBucket = built
-        lookupByBucket = built.mapValues {
-            BucketLookup(
-                actual: $0.actual.flatMap { $0 },
-                pace: $0.pace.flatMap { $0 },
-                forecast: $0.forecast.flatMap { $0 }
+        // The hover overlay gets its own flattened copy of every lane, in
+        // bucket order, so the crosshair never has to reach back into this
+        // view's state — and so the palette and the titles are resolved once
+        // per data change rather than once per pointer move.
+        hoverLanes = buckets.enumerated().map { index, bucket in
+            let series = built[bucket.id] ?? .empty
+            return QuotaHoverLane(
+                id: bucket.id,
+                title: bucket.title,
+                color: color(at: index),
+                windowSeconds: bucket.rawWindowSeconds,
+                actual: series.actual.flatMap { $0 },
+                pace: series.pace.flatMap { $0 },
+                forecast: series.forecast.flatMap { $0 }
             )
         }
         miniSegments = ChartMarkBudget.thinned(
             built[primary.id]?.actual ?? [],
             budget: Self.miniMarkLimit
         )
+        // Everything the mark plan reads has just been replaced, so invalidate
+        // it with one integer instead of a deep compare of every lane.
+        seriesRevision &+= 1
 
         let minimumSpan = minimumSpan(for: primary)
         initialSpan = Self.defaultInitialSpan
@@ -1234,91 +1068,149 @@ struct QuotaHistoryChartView: View, Equatable {
 
     // MARK: - Mark shaping
 
-    private func bucketLines(
-        buckets: [QuotaBucket],
-        range: ClosedRange<Date>,
-        budget: Int
-    ) -> [QuotaBucketLines] {
-        buckets.enumerated().map { index, bucket in
-            let series = seriesByBucket[bucket.id] ?? .empty
-            let hue = color(at: index)
+    /// Every mark the `Chart` draws at one visible window.
+    ///
+    /// A struct rather than a run of computed properties because the whole set
+    /// is memoized together: the pipeline behind it (clip → allocate budget →
+    /// thin → build marks) walks every lane of the series, and it used to run
+    /// on every body pass — including the one per mouse sample that a hover
+    /// triggered.
+    private struct QuotaChartPlan {
+        var lines: [QuotaBucketLines] = []
+        var pace: [QuotaChartLinePoint] = []
+        var paceBridges: [QuotaChartLinePoint] = []
+        var band: [QuotaBandPoint] = []
+        var resets: [Date] = []
+    }
+
+    /// What the plan was built from. `revision` stands in for the series
+    /// themselves — see `seriesRevision`.
+    private struct PlanKey: Equatable {
+        let revision: Int
+        let bucketIds: [String]
+        let range: ClosedRange<Date>
+    }
+
+    /// Reference box, so a memo hit or update during `body` never dirties view
+    /// state; correctness comes from the key, not from invalidation timing.
+    /// Same pattern (and the same reasoning) as `UsageTrendChartView`.
+    private final class PlanCache {
+        var key: PlanKey?
+        var plan: QuotaChartPlan?
+    }
+
+    private func markPlan(buckets: [QuotaBucket], range: ClosedRange<Date>) -> QuotaChartPlan {
+        let key = PlanKey(
+            revision: seriesRevision,
+            bucketIds: buckets.map(\.id),
+            range: range
+        )
+        if let cached = planCache.plan, planCache.key == key { return cached }
+        let built = Self.buildPlan(key: key, seriesByBucket: seriesByBucket)
+        planCache.key = key
+        planCache.plan = built
+        return built
+    }
+
+    /// Static because the plan must depend on nothing but its key and the
+    /// series: anything it could read off `self` would be a dependency the
+    /// cache does not know about.
+    private static func buildPlan(
+        key: PlanKey,
+        seriesByBucket: [String: QuotaHistorySeries]
+    ) -> QuotaChartPlan {
+        var plan = QuotaChartPlan()
+        guard let primaryId = key.bucketIds.first else { return plan }
+        let range = key.range
+        let primarySeries = seriesByBucket[primaryId] ?? .empty
+        let isSingle = key.bucketIds.count == 1
+
+        // Count the layers that will actually be stroked *before* spending
+        // anything, then give each an equal share of the chart's budget. A
+        // per-line budget silently multiplied by the number of lines, which is
+        // how a one-bucket chart came to draw ~2 080 marks against a ~1 000-mark
+        // ceiling. Layers with nothing recorded are not counted, so a group with
+        // no forecast yet spends the whole budget on the lines it does draw.
+        var layers = 0
+        for id in key.bucketIds {
+            let series = seriesByBucket[id] ?? .empty
+            if !series.actual.isEmpty { layers += 1 }
+            if !series.forecast.isEmpty { layers += 1 }
+        }
+        if isSingle {
+            if !primarySeries.pace.isEmpty { layers += 1 }
+            // The uncertainty band is drawn from the same forecast segments and
+            // costs its own mark per point, so it is a layer of its own.
+            if !primarySeries.forecast.isEmpty { layers += 1 }
+        }
+        let budget = max(minimumMarkBudget, chartMarkBudget / max(1, layers))
+
+        plan.lines = key.bucketIds.enumerated().map { index, id in
+            let series = seriesByBucket[id] ?? .empty
+            let hue = bucketPalette[index % bucketPalette.count]
             return QuotaBucketLines(
-                id: bucket.id,
+                id: id,
                 color: hue,
-                forecastColor: forecastTint(hue),
-                actual: linePoints(
+                forecastColor: forecastTints[hue] ?? hue,
+                actual: QuotaChartMarks.points(
                     series.actual,
                     kind: "actual-\(index)",
                     range: range,
-                    budget: budget
-                ),
-                actualBridges: bridgePoints(
-                    series.actual,
+                    budget: budget,
                     time: { $0.time },
-                    value: { $0.remainingPercent },
-                    kind: "actual-\(index)",
-                    range: range
+                    value: { $0.remainingPercent }
                 ),
-                forecast: forecastLinePoints(
+                actualBridges: QuotaChartMarks.bridges(
+                    series.actual,
+                    kind: "actual-\(index)",
+                    range: range,
+                    time: { $0.time },
+                    value: { $0.remainingPercent }
+                ),
+                forecast: QuotaChartMarks.points(
                     series.forecast,
                     kind: "forecast-\(index)",
                     range: range,
-                    budget: budget
-                ),
-                forecastBridges: bridgePoints(
-                    series.forecast,
+                    budget: budget,
                     time: { $0.time },
-                    value: { $0.remainingPercent },
+                    value: { $0.remainingPercent }
+                ),
+                forecastBridges: QuotaChartMarks.bridges(
+                    series.forecast,
                     kind: "forecast-\(index)",
-                    range: range
+                    range: range,
+                    time: { $0.time },
+                    value: { $0.remainingPercent }
                 )
             )
         }
+
+        // Only a single-bucket chart can afford the wall-clock reference and
+        // the uncertainty band: two of them overlaid is mud, and the pace
+        // reading moves into the hover tooltip instead.
+        if isSingle {
+            plan.pace = QuotaChartMarks.points(
+                primarySeries.pace,
+                kind: "pace",
+                range: range,
+                budget: budget,
+                time: { $0.time },
+                value: { $0.remainingPercent }
+            )
+            plan.paceBridges = QuotaChartMarks.bridges(
+                primarySeries.pace,
+                kind: "pace",
+                range: range,
+                time: { $0.time },
+                value: { $0.remainingPercent }
+            )
+            plan.band = forecastBandPoints(primarySeries.forecast, range: range, budget: budget)
+        }
+        plan.resets = resetMarks(primarySeries: primarySeries, range: range)
+        return plan
     }
 
-    private func bridgePoints<Element>(
-        _ segments: [[Element]],
-        time: (Element) -> Date,
-        value: (Element) -> Double,
-        kind: String,
-        range: ClosedRange<Date>
-    ) -> [QuotaChartLinePoint] {
-        QuotaChartMarks.bridges(segments, kind: kind, range: range, time: time, value: value)
-    }
-
-    private func linePoints(
-        _ segments: [[QuotaHistorySample]],
-        kind: String,
-        range: ClosedRange<Date>,
-        budget: Int
-    ) -> [QuotaChartLinePoint] {
-        QuotaChartMarks.points(
-            segments,
-            kind: kind,
-            range: range,
-            budget: budget,
-            time: { $0.time },
-            value: { $0.remainingPercent }
-        )
-    }
-
-    private func forecastLinePoints(
-        _ segments: [[QuotaHistoryForecastSample]],
-        kind: String,
-        range: ClosedRange<Date>,
-        budget: Int
-    ) -> [QuotaChartLinePoint] {
-        QuotaChartMarks.points(
-            segments,
-            kind: kind,
-            range: range,
-            budget: budget,
-            time: { $0.time },
-            value: { $0.remainingPercent }
-        )
-    }
-
-    private func forecastBandPoints(
+    private static func forecastBandPoints(
         _ segments: [[QuotaHistoryForecastSample]],
         range: ClosedRange<Date>,
         budget: Int
@@ -1334,19 +1226,21 @@ struct QuotaHistoryChartView: View, Equatable {
             budget: budget
         )
         var result: [QuotaBandPoint] = []
+        var nextId = 0
         for (slot, entry) in visible.enumerated() {
             let thinned = ChartSeriesThinning.strided(entry.samples, limit: allowance[slot])
             let key = "band-\(entry.index)"
-            for (offset, sample) in thinned.enumerated() {
+            for sample in thinned {
                 result.append(
                     QuotaBandPoint(
-                        id: "\(key)-\(offset)",
+                        id: nextId,
                         seriesKey: key,
                         time: sample.time,
                         low: min(sample.lowerRemainingPercent, sample.upperRemainingPercent),
                         high: max(sample.lowerRemainingPercent, sample.upperRemainingPercent)
                     )
                 )
+                nextId += 1
             }
         }
         return result
@@ -1392,7 +1286,7 @@ struct QuotaHistoryChartView: View, Equatable {
     }
 
     private func percent(_ value: Double) -> String {
-        "\(Int(value.rounded()))%"
+        quotaPercentLabel(value)
     }
 
     private func scopeNote(buckets: [QuotaBucket], window: ChartTimeWindow) -> String {
@@ -1409,6 +1303,37 @@ struct QuotaHistoryChartView: View, Equatable {
         if seconds < 48 * 3_600 { return "\(Int((seconds / 3_600).rounded()))h" }
         return "\(Int((seconds / 86_400).rounded()))d"
     }
+}
+
+/// Crosshair, tooltip and the plot's own pan / pinch / double-tap gestures.
+///
+/// A view of its own, with its own `@State`, on purpose. `hoverDate` used to sit
+/// on `QuotaHistoryChartView`, which meant every pointer move invalidated that
+/// whole body and re-ran the clip → budget → thin → build pipeline for every
+/// lane before a single pixel of crosshair moved — a full re-plan per mouse
+/// sample against a one-frame (8.3 ms) hover budget. Layered here under
+/// `.chartOverlay`, a pointer move re-renders this view and nothing else: the
+/// marks above keep the layout they already have.
+///
+/// The gesture bases moved down with it for the same reason. Everything the
+/// overlay needs arrives as plain values — `lanes` is built once per data
+/// change, not per frame — plus the window binding the gestures always had to
+/// write through.
+private struct QuotaChartHoverOverlay: View {
+    let proxy: ChartProxy
+    let lanes: [QuotaHoverLane]
+    let showsBucketTitles: Bool
+    let initialSpan: TimeInterval
+    /// Incremented by the chart when a range pill jumps the window — the one
+    /// case where something outside this view has to drop the crosshair.
+    let resetToken: Int
+    @Binding var window: ChartTimeWindow
+
+    @State private var hoverDate: Date?
+    @State private var panBase: ChartTimeWindow?
+    @State private var magnifyBase: ChartTimeWindow?
+
+    private static let tooltipWidth: CGFloat = 178
 
     private static let tooltipFormatter: DateFormatter = {
         let formatter = DateFormatter()
@@ -1416,4 +1341,216 @@ struct QuotaHistoryChartView: View, Equatable {
         formatter.dateFormat = "MMM d · HH:mm"
         return formatter
     }()
+
+    var body: some View {
+        GeometryReader { geometry in
+            let plot = proxy.plotFrame.map { geometry[$0] }
+            let plotMinX = plot?.minX ?? 0
+            let plotWidth = plot?.width ?? geometry.size.width
+            ZStack(alignment: .topLeading) {
+                Rectangle()
+                    .fill(Color.clear)
+                    .contentShape(Rectangle())
+                    .onContinuousHover { phase in
+                        switch phase {
+                        case .active(let location):
+                            // The overlay also covers the leading axis strip;
+                            // a reading from there would park the crosshair
+                            // outside the plot.
+                            let value = proxy.value(atX: location.x - plotMinX, as: Date.self)
+                            hoverDate = value.flatMap {
+                                window.visibleRange.contains($0) ? $0 : nil
+                            }
+                        case .ended:
+                            hoverDate = nil
+                        }
+                    }
+                    .gesture(panGesture(plotWidth: plotWidth))
+                    .simultaneousGesture(magnifyGesture(plotMinX: plotMinX))
+                    .onTapGesture(count: 2) {
+                        window = window.jumped(toSpan: initialSpan)
+                        hoverDate = nil
+                    }
+
+                if let hoverDate,
+                   let reading = hoverReading(at: hoverDate),
+                   let x = proxy.position(forX: reading.time),
+                   let plot {
+                    // The reading anchors to the nearest sample, which the
+                    // pointer slop can put just outside the visible range —
+                    // clamp so the crosshair stays inside the plot instead of
+                    // drawing into the axis gutter.
+                    let clampedX = min(max(x, 0), plot.width)
+                    Rectangle()
+                        .fill(Color.primary.opacity(0.22))
+                        .frame(width: 1, height: plot.height)
+                        .offset(x: plotMinX + clampedX, y: plot.minY)
+                        .allowsHitTesting(false)
+                    tooltip(reading)
+                        .offset(
+                            x: tooltipX(
+                                plotMinX: plotMinX,
+                                x: clampedX,
+                                width: geometry.size.width
+                            )
+                        )
+                        .allowsHitTesting(false)
+                }
+            }
+        }
+        .onChange(of: resetToken) { _, _ in hoverDate = nil }
+    }
+
+    // MARK: - Gestures
+
+    private func panGesture(plotWidth: CGFloat) -> some Gesture {
+        DragGesture(minimumDistance: 3)
+            .onChanged { value in
+                guard plotWidth > 0 else { return }
+                let base = panBase ?? window
+                if panBase == nil { panBase = base }
+                let secondsPerPoint = base.visibleSpan / TimeInterval(plotWidth)
+                window = base.panned(
+                    by: -TimeInterval(value.translation.width) * secondsPerPoint
+                )
+            }
+            .onEnded { _ in panBase = nil }
+    }
+
+    private func magnifyGesture(plotMinX: CGFloat) -> some Gesture {
+        MagnifyGesture(minimumScaleDelta: 0.01)
+            .onChanged { value in
+                let base = magnifyBase ?? window
+                if magnifyBase == nil { magnifyBase = base }
+                let anchor = proxy.value(atX: value.startLocation.x - plotMinX, as: Date.self)
+                    ?? base.visibleMidpoint
+                window = base.zoomed(scale: value.magnification, around: anchor)
+            }
+            .onEnded { _ in magnifyBase = nil }
+    }
+
+    // MARK: - Reading
+
+    /// Nearest reading on each line, per lane, or nothing at all for a lane
+    /// whose coverage does not reach the cursor — a gap is information, not a
+    /// rounding error, so it is never bridged to the closest sample on either
+    /// side. The time label follows the first lane, which is the shortest-window
+    /// quota and therefore the one sampled most densely.
+    ///
+    /// The tolerance is resolved **per lane**, not once for the group. The
+    /// quotas overlaid here are sampled at different rhythms — Claude's 5 Hours
+    /// is filed into five-minute slots and its Weekly into hourly ones — so a
+    /// single tolerance taken from the shortest window missed the sparse lanes
+    /// on most cursor positions and reported them as having nothing to say
+    /// while their line ran under the crosshair. See `ChartHoverTolerance`.
+    ///
+    /// Binary search rather than a scan: this runs on every pointer move, and a
+    /// densely sampled lane under unlimited retention is tens of thousands of
+    /// samples.
+    private func hoverReading(at date: Date) -> QuotaHoverReading? {
+        guard !lanes.isEmpty else { return nil }
+        var readings: [QuotaHoverBucketReading] = []
+        readings.reserveCapacity(lanes.count)
+        var anchor: Date?
+        for (index, lane) in lanes.enumerated() {
+            let tolerance = ChartHoverTolerance.seconds(
+                windowSeconds: lane.windowSeconds,
+                visibleSpan: window.visibleSpan
+            )
+            let actual = ChartSampleSearch.nearest(
+                in: lane.actual, to: date, tolerance: tolerance, time: { $0.time }
+            )
+            let pace = ChartSampleSearch.nearest(
+                in: lane.pace, to: date, tolerance: tolerance, time: { $0.time }
+            )
+            let forecast = ChartSampleSearch.nearest(
+                in: lane.forecast, to: date, tolerance: tolerance, time: { $0.time }
+            )
+            if index == 0 {
+                anchor = actual?.time ?? forecast?.time
+            }
+            readings.append(
+                QuotaHoverBucketReading(
+                    id: lane.id,
+                    title: lane.title,
+                    color: lane.color,
+                    actual: actual?.remainingPercent,
+                    pace: pace?.remainingPercent,
+                    forecast: forecast?.remainingPercent
+                )
+            )
+        }
+        return QuotaHoverReading(time: anchor ?? date, buckets: readings)
+    }
+
+    // MARK: - Tooltip
+
+    private func tooltipX(plotMinX: CGFloat, x: CGFloat, width: CGFloat) -> CGFloat {
+        let tooltipWidth = Self.tooltipWidth
+        return min(max(plotMinX + x - tooltipWidth / 2, 0), max(0, width - tooltipWidth))
+    }
+
+    private func tooltip(_ reading: QuotaHoverReading) -> some View {
+        VStack(alignment: .leading, spacing: 3) {
+            Text(Self.tooltipFormatter.string(from: reading.time))
+                .font(.system(size: 10, weight: .semibold))
+            ForEach(reading.buckets) { bucket in
+                if showsBucketTitles {
+                    HStack(spacing: 4) {
+                        Circle()
+                            .fill(bucket.color)
+                            .frame(width: 5, height: 5)
+                        Text(bucket.title)
+                            .font(.system(size: 9, weight: .semibold))
+                            .foregroundStyle(.white.opacity(0.85))
+                        Spacer(minLength: 0)
+                    }
+                    .padding(.top, 1)
+                }
+                if bucket.isEmpty {
+                    // Deliberately about the *evidence*, not about the quota.
+                    // Nothing here means no sample was taken near this instant
+                    // — the Mac was asleep, the app was quit, a refresh was
+                    // skipped. The window itself was very probably wide open,
+                    // and nothing in a fill lane can tell the two apart, so
+                    // claiming there was no active window was a guess dressed
+                    // up as a reading.
+                    Text("No data recorded")
+                        .font(.system(size: 9))
+                        .foregroundStyle(.white.opacity(0.7))
+                } else {
+                    if let actual = bucket.actual {
+                        tooltipRow("Quota left", quotaPercentLabel(actual), color: bucket.color)
+                    }
+                    if let pace = bucket.pace {
+                        tooltipRow("Pace", quotaPercentLabel(pace), color: .white.opacity(0.8))
+                    }
+                    if let forecast = bucket.forecast {
+                        tooltipRow(
+                            "At reset",
+                            quotaPercentLabel(forecast),
+                            color: bucket.color.opacity(0.75)
+                        )
+                    }
+                }
+            }
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 6)
+        .background(RoundedRectangle(cornerRadius: 6).fill(Color.black.opacity(0.87)))
+        .foregroundStyle(.white)
+        .frame(width: Self.tooltipWidth, alignment: .leading)
+    }
+
+    private func tooltipRow(_ label: String, _ value: String, color: Color) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: 6) {
+            Text(label)
+                .font(.system(size: 9))
+                .foregroundStyle(.white.opacity(0.75))
+            Spacer(minLength: 6)
+            Text(value)
+                .font(.system(size: 9, weight: .semibold, design: .rounded).monospacedDigit())
+                .foregroundStyle(color)
+        }
+    }
 }

--- a/Sources/VibeBarApp/Views/ServiceStatusCard.swift
+++ b/Sources/VibeBarApp/Views/ServiceStatusCard.swift
@@ -227,14 +227,20 @@ private struct ComponentGroupBlock: View {
     }
 
     var body: some View {
+        // `aggregateStatus` walks every component and `summaryDays` merges
+        // ~90 days per component through a set and a dictionary; the header,
+        // the icon and the strip each used to ask for them again. One
+        // derivation each per pass, reused below.
+        let status = aggregateStatus
+        let days = summaryDays
         VStack(alignment: .leading, spacing: density.statusComponentSpacing) {
             BorderlessRowButton(action: {
                 withAnimation(.easeInOut(duration: 0.18)) { expanded.toggle() }
             }) {
                 HStack(spacing: 6) {
-                    Image(systemName: statusIcon)
+                    Image(systemName: Self.statusIcon(for: status))
                         .font(.system(size: density.resetCountdownFontSize, weight: .semibold))
-                        .foregroundStyle(componentColor(aggregateStatus))
+                        .foregroundStyle(componentColor(status))
                     Text(title)
                         .font(.system(size: density.subtitleFontSize, weight: .semibold))
                         .foregroundStyle(.primary)
@@ -253,8 +259,8 @@ private struct ComponentGroupBlock: View {
                 }
             }
 
-            if !summaryDays.isEmpty {
-                UptimeStrip(days: summaryDays, currentImpact: impact(for: aggregateStatus))
+            if !days.isEmpty {
+                UptimeStrip(days: days, currentImpact: impact(for: status))
                     .frame(height: density.statusStripHeight)
             } else {
                 Capsule()
@@ -311,8 +317,10 @@ private struct ComponentGroupBlock: View {
         }
     }
 
-    private var statusIcon: String {
-        switch aggregateStatus {
+    /// Takes the already-derived status so `body` doesn't recompute the
+    /// aggregate just to pick a glyph.
+    private static func statusIcon(for status: ComponentStatusLevel) -> String {
+        switch status {
         case .operational:         return "checkmark.circle.fill"
         case .underMaintenance:    return "wrench.and.screwdriver.fill"
         case .degradedPerformance: return "exclamationmark.circle.fill"

--- a/Sources/VibeBarApp/Views/UpcomingResets.swift
+++ b/Sources/VibeBarApp/Views/UpcomingResets.swift
@@ -268,10 +268,14 @@ struct UpcomingResetsCard: View {
     @EnvironmentObject private var quotaService: QuotaService
 
     var body: some View {
-        // A leaf timer, one minute: the lane's countdowns drift slowly, and
-        // quota refreshes re-render the card on their own.
-        TimelineView(.periodic(from: .now, by: 60)) { context in
-            content(now: context.date)
+        // One clock for the card, one minute: the lane's countdowns drift
+        // slowly, and quota refreshes re-render the card on their own. It is a
+        // `PageClock` rather than a raw `TimelineView(.periodic(from: .now,
+        // ...))` for two reasons — the phase has to survive a body pass so the
+        // date matches what the quota cards ask for, and the Overview stays
+        // hosted after the popover closes, where this must not keep firing.
+        PageClock(interval: 60) { tickDate in
+            content(now: tickDate)
         }
     }
 

--- a/Sources/VibeBarApp/Views/UsageActivityView.swift
+++ b/Sources/VibeBarApp/Views/UsageActivityView.swift
@@ -107,13 +107,12 @@ struct UsageActivityView: View {
     }
 
     private func contentHeight(for metrics: HeatmapGridMetrics) -> CGFloat {
-        // bar row + spacing + hour axis (8pt) + spacing + 7 cell rows
+        // bar row + spacing + hour axis (8pt) + spacing + the 7-row cell block
         barRowHeight
             + metrics.cellSpacing
             + 8
             + metrics.cellSpacing
-            + 7 * metrics.cellSide
-            + 6 * metrics.cellSpacing
+            + metrics.gridHeight
     }
 
     // MARK: - Bar row
@@ -195,43 +194,26 @@ struct UsageActivityView: View {
     // MARK: - Heatmap grid
 
     private func heatmapGrid(metrics: HeatmapGridMetrics) -> some View {
-        let maxCell = heatmap.cells.flatMap { $0 }.max() ?? 0
-        return VStack(alignment: .leading, spacing: metrics.cellSpacing) {
-            ForEach(0..<7, id: \.self) { weekday in
-                HStack(spacing: metrics.cellSpacing) {
+        // The weekday gutter stays as seven `Text`s; the 168 cells are one
+        // `Canvas`. The row `HStack`s used to put the label and its 24 cells
+        // on the same baseline, so the label column now carries an explicit
+        // cell-height frame to keep the rows lined up identically.
+        HStack(alignment: .top, spacing: metrics.cellSpacing) {
+            VStack(alignment: .trailing, spacing: metrics.cellSpacing) {
+                ForEach(0..<7, id: \.self) { weekday in
                     Text(weekdayLabels[weekday])
                         .font(.system(size: 9, design: .rounded))
                         .foregroundStyle(.secondary)
-                        .frame(width: metrics.labelWidth, alignment: .trailing)
-                    ForEach(0..<24, id: \.self) { hour in
-                        RoundedRectangle(cornerRadius: metrics.cellCornerRadius, style: .continuous)
-                            .fill(cellColor(weekday: weekday, hour: hour, max: maxCell))
-                            .frame(width: metrics.cellSide, height: metrics.cellSide)
-                            .help(cellTooltip(weekday: weekday, hour: hour))
-                    }
-                    Spacer(minLength: 0)
+                        .frame(width: metrics.labelWidth, height: metrics.cellSide, alignment: .trailing)
                 }
             }
+            UsageHeatmapCanvas(
+                cells: heatmap.cells,
+                metrics: metrics,
+                weekdayLabels: weekdayLabels
+            )
+            Spacer(minLength: 0)
         }
-    }
-
-    private func cellColor(weekday: Int, hour: Int, max: Int) -> Color {
-        let value = heatmap.cells[weekday][hour]
-        guard value > 0, max > 0 else { return Color.primary.opacity(0.05) }
-        let normalized = log1p(Double(value)) / log1p(Double(max))
-        return intensityColor(intensity: normalized)
-    }
-
-    private func cellTooltip(weekday: Int, hour: Int) -> String {
-        let value = heatmap.cells[weekday][hour]
-        let day = weekdayLabels[weekday]
-        let hourStr = UsageHeatmap.formatHourLabel(hour)
-        let label: String
-        if value < 1_000 { label = "\(value) tok" }
-        else if value < 1_000_000 { label = String(format: "%.1fk tok", Double(value) / 1_000) }
-        else if value < 1_000_000_000 { label = String(format: "%.2fM tok", Double(value) / 1_000_000) }
-        else { label = String(format: "%.2fB tok", Double(value) / 1_000_000_000) }
-        return "\(day) \(hourStr) · \(label)"
     }
 
     // MARK: - Legend
@@ -251,5 +233,105 @@ struct UsageActivityView: View {
                 .foregroundStyle(.tertiary)
             Spacer()
         }
+    }
+}
+
+/// The 7 × 24 grid drawn as one `Canvas` instead of 168 `RoundedRectangle`
+/// views with a `.help()` each. This card is instantiated three times while
+/// the popover is open, so the view-per-cell shape cost ~500 view nodes and as
+/// many tooltip nodes just to sit idle. Hit-testing the hover point against
+/// the same geometry the canvas draws with reproduces the per-cell tooltip
+/// from a single string, and keeping the hover state in this leaf means a
+/// mouse move redraws the grid, not the whole card.
+private struct UsageHeatmapCanvas: View {
+    let cells: [[Int]]
+    let metrics: HeatmapGridMetrics
+    let weekdayLabels: [String]
+
+    /// The peak cell, derived once when the grid is built rather than by a
+    /// `flatMap { $0 }.max()` that allocated a fresh 168-element array on
+    /// every body pass.
+    private let maxCell: Int
+
+    @State private var hoveredTooltip: String?
+
+    init(cells: [[Int]], metrics: HeatmapGridMetrics, weekdayLabels: [String]) {
+        self.cells = cells
+        self.metrics = metrics
+        self.weekdayLabels = weekdayLabels
+        var peak = 0
+        for row in cells {
+            for value in row where value > peak { peak = value }
+        }
+        self.maxCell = peak
+    }
+
+    var body: some View {
+        Canvas { context, _ in
+            let step = metrics.cellSide + metrics.cellSpacing
+            for weekday in 0..<min(7, cells.count) {
+                let row = cells[weekday]
+                for hour in 0..<min(24, row.count) {
+                    let rect = CGRect(
+                        x: CGFloat(hour) * step,
+                        y: CGFloat(weekday) * step,
+                        width: metrics.cellSide,
+                        height: metrics.cellSide
+                    )
+                    context.fill(
+                        Path(roundedRect: rect, cornerRadius: metrics.cellCornerRadius, style: .continuous),
+                        with: .color(cellColor(value: row[hour]))
+                    )
+                }
+            }
+        }
+        .frame(width: metrics.gridWidth, height: metrics.gridHeight)
+        .contentShape(Rectangle())
+        .onContinuousHover { phase in
+            switch phase {
+            case .active(let location):
+                let text = tooltip(at: location)
+                if text != hoveredTooltip { hoveredTooltip = text }
+            case .ended:
+                if hoveredTooltip != nil { hoveredTooltip = nil }
+            }
+        }
+        .help(hoveredTooltip ?? "")
+        // The individual cell views are gone, so the grid speaks for itself.
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("Token usage by weekday and hour, 7 days by 24 hours")
+    }
+
+    private func cellColor(value: Int) -> Color {
+        guard value > 0, maxCell > 0 else { return Color.primary.opacity(0.05) }
+        let normalized = log1p(Double(value)) / log1p(Double(maxCell))
+        return intensityColor(intensity: normalized)
+    }
+
+    private func tooltip(at point: CGPoint) -> String? {
+        guard let hour = heatmapCellIndex(
+            for: point.x,
+            side: metrics.cellSide,
+            spacing: metrics.cellSpacing,
+            count: 24
+        ), let weekday = heatmapCellIndex(
+            for: point.y,
+            side: metrics.cellSide,
+            spacing: metrics.cellSpacing,
+            count: 7
+        ), weekday < cells.count, hour < cells[weekday].count else { return nil }
+        return cellTooltip(weekday: weekday, hour: hour)
+    }
+
+    private func cellTooltip(weekday: Int, hour: Int) -> String {
+        let value = cells[weekday][hour]
+        let day = weekdayLabels[weekday]
+        let hourStr = UsageHeatmap.formatHourLabel(hour)
+        let label: String
+        if value < 1_000 { label = "\(value) tok" }
+        else if value < 1_000_000 { label = String(format: "%.1fk tok", Double(value) / 1_000) }
+        else if value < 1_000_000_000 { label = String(format: "%.2fM tok", Double(value) / 1_000_000) }
+        else { label = String(format: "%.2fB tok", Double(value) / 1_000_000_000) }
+        return "\(day) \(hourStr) · \(label)"
     }
 }

--- a/Sources/VibeBarApp/Views/UsageHeatmapShared.swift
+++ b/Sources/VibeBarApp/Views/UsageHeatmapShared.swift
@@ -17,6 +17,16 @@ struct HeatmapGridMetrics {
         min(2.5, max(1.5, cellSide * 0.16))
     }
 
+    /// Size of the 7 × 24 cell block — what the per-row `HStack`s used to
+    /// measure to on their own, now the frame of the single grid `Canvas`.
+    var gridWidth: CGFloat {
+        cellSide * 24 + cellSpacing * 23
+    }
+
+    var gridHeight: CGFloat {
+        cellSide * 7 + cellSpacing * 6
+    }
+
     /// Compute the metrics that fit `availableWidth`. A measured width of 0
     /// (first layout pass before GeometryReader has a real width) falls back
     /// to a conservative 520 pt so a nested popover cannot inflate itself
@@ -44,6 +54,22 @@ struct HeatmapGridWidthPreferenceKey: PreferenceKey {
     static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
         value = max(value, nextValue())
     }
+}
+
+/// Which cell a hover point lands on in a uniform `side + spacing` grid.
+///
+/// Both heatmaps draw their cells into a single `Canvas` rather than one view
+/// per cell, so the per-cell `.help()` tooltip is reproduced by hit-testing the
+/// hover location against the same geometry the canvas drew with. Returns `nil`
+/// in the gaps between cells, because the old per-cell tooltip only covered the
+/// filled square.
+func heatmapCellIndex(for offset: CGFloat, side: CGFloat, spacing: CGFloat, count: Int) -> Int? {
+    let step = side + spacing
+    guard step > 0, side > 0, offset >= 0 else { return nil }
+    let index = Int(offset / step)
+    guard index >= 0, index < count else { return nil }
+    guard offset - CGFloat(index) * step <= side else { return nil }
+    return index
 }
 
 /// Continuous faint-blue → warm-orange gradient. `intensity` is clamped to 0…1.

--- a/Sources/VibeBarApp/Views/Workbench/ResetsPage.swift
+++ b/Sources/VibeBarApp/Views/Workbench/ResetsPage.swift
@@ -17,10 +17,14 @@ struct ResetsPage: View {
     @State private var calendarMonthOffset = 0
 
     var body: some View {
-        // One leaf timer for the whole page: countdown text drifts by the
-        // minute; data re-renders arrive with quota refreshes on their own.
-        TimelineView(.periodic(from: .now, by: 60)) { context in
-            content(now: context.date)
+        // One timer for the whole page: countdown text drifts by the minute;
+        // data re-renders arrive with quota refreshes on their own. The clock
+        // shares the app-wide phase anchor, so the instant this page asks the
+        // forecast about is the same one every other surface asks about — a
+        // `.now` anchor re-phased on every body pass and defeated the memo.
+        // Ungated: the Workbench window is visible whenever it exists.
+        StableClock(interval: 60) { tickDate in
+            content(now: tickDate)
         }
     }
 

--- a/Sources/VibeBarApp/Views/Workbench/UsageBreakdownTables.swift
+++ b/Sources/VibeBarApp/Views/Workbench/UsageBreakdownTables.swift
@@ -35,16 +35,41 @@ struct UsageBreakdownTables: View {
     private static let periodPageSize = 120
     @State private var visiblePeriodLimit = UsageBreakdownTables.periodPageSize
 
+    /// The active breakdown's rows, derived once per body pass.
+    ///
+    /// Each case is a sort or a filter over the whole result set, and the
+    /// header count, the empty check, the table and its height each used to
+    /// ask the computed property for it again — up to eight derivations of the
+    /// same array per pass, on a page whose row count runs into the hundreds.
+    private enum BreakdownRows {
+        case periods([UsageTrendPoint])
+        case requests
+        case providers([UsageProviderStat])
+        case projects([UsageProjectStat])
+        case models([UsageModelStat])
+    }
+
+    private var activeRows: BreakdownRows {
+        switch model.activeBreakdown {
+        case .periods:   .periods(populatedPeriods)
+        case .requests:  .requests
+        case .providers: .providers(sortedProviders)
+        case .projects:  .projects(sortedProjects)
+        case .models:    .models(sortedModels)
+        }
+    }
+
     var body: some View {
+        let rows = activeRows
         CardShell(density: density, spacing: 12) {
-            header
-            content
+            header(rows)
+            content(rows)
         }
     }
 
     // MARK: - Header
 
-    private var header: some View {
+    private func header(_ rows: BreakdownRows) -> some View {
         HStack(spacing: 10) {
             HStack(spacing: 2) {
                 ForEach(UsageStatsViewModel.Breakdown.allCases) { value in
@@ -94,7 +119,7 @@ struct UsageBreakdownTables: View {
 
             Spacer(minLength: 8)
 
-            Text(countSummary)
+            Text(countSummary(rows))
                 .font(.system(size: 10, weight: .medium, design: .rounded).monospacedDigit())
                 .foregroundStyle(.tertiary)
                 .lineLimit(1)
@@ -106,11 +131,11 @@ struct UsageBreakdownTables: View {
         }
     }
 
-    private var countSummary: String {
-        switch model.activeBreakdown {
-        case .periods:
-            return "\(populatedPeriods.count) active \(periodUnit)"
-                + (populatedPeriods.count == 1 ? "" : "s")
+    private func countSummary(_ rows: BreakdownRows) -> String {
+        switch rows {
+        case .periods(let points):
+            return "\(points.count) active \(periodUnit)"
+                + (points.count == 1 ? "" : "s")
         case .requests:
             let loaded = model.requestRows.count
             let total = model.requestTotalCount
@@ -129,13 +154,13 @@ struct UsageBreakdownTables: View {
     // MARK: - Tables
 
     @ViewBuilder
-    private var content: some View {
-        switch model.activeBreakdown {
-        case .periods:
-            if populatedPeriods.isEmpty {
+    private func content(_ rows: BreakdownRows) -> some View {
+        switch rows {
+        case .periods(let points):
+            if points.isEmpty {
                 empty("No active periods in this range")
             } else {
-                periodsTable
+                periodsTable(points)
             }
         case .requests:
             if model.requestRows.isEmpty {
@@ -143,23 +168,23 @@ struct UsageBreakdownTables: View {
             } else {
                 requestsTable
             }
-        case .providers:
-            if sortedProviders.isEmpty {
+        case .providers(let stats):
+            if stats.isEmpty {
                 empty("No provider totals in this range")
             } else {
-                providersTable
+                providersTable(stats)
             }
-        case .projects:
-            if sortedProjects.isEmpty {
+        case .projects(let stats):
+            if stats.isEmpty {
                 empty("No project-attributed Codex or Claude usage in this range")
             } else {
-                projectsTable
+                projectsTable(stats)
             }
-        case .models:
-            if sortedModels.isEmpty {
+        case .models(let stats):
+            if stats.isEmpty {
                 empty("No model totals in this range")
             } else {
-                modelsTable
+                modelsTable(stats)
             }
         }
     }
@@ -167,7 +192,7 @@ struct UsageBreakdownTables: View {
     /// The Period, Provider and Model grids borrow the card's available
     /// width. Their trailing values are never hidden behind a scroller at the
     /// ordinary Workbench width; only their descriptive leading column flexes.
-    private var periodsTable: some View {
+    private func periodsTable(_ points: [UsageTrendPoint]) -> some View {
         GeometryReader { proxy in
             let columns = PeriodColumns(
                 title: periodColumnTitle,
@@ -176,7 +201,7 @@ struct UsageBreakdownTables: View {
             VStack(spacing: 0) {
                 tableHeader(columns.all)
                 LazyVStack(spacing: 0) {
-                    ForEach(populatedPeriods.prefix(visiblePeriodLimit), id: \.bucketStart) { point in
+                    ForEach(points.prefix(visiblePeriodLimit), id: \.bucketStart) { point in
                         let label = period(point.bucketStart)
                         PorcelainUsageRow(
                             accessibilityLabel: periodAccessibilityLabel(point, label: label)
@@ -189,11 +214,11 @@ struct UsageBreakdownTables: View {
                             moneyCell(point.costMicros, columns.cost, emphasis: true)
                         }
                     }
-                    if populatedPeriods.count > visiblePeriodLimit {
+                    if points.count > visiblePeriodLimit {
                         Button {
                             visiblePeriodLimit += Self.periodPageSize
                         } label: {
-                            Text("Show \(min(Self.periodPageSize, populatedPeriods.count - visiblePeriodLimit)) more of \(populatedPeriods.count) periods")
+                            Text("Show \(min(Self.periodPageSize, points.count - visiblePeriodLimit)) more of \(points.count) periods")
                                 .font(.system(size: 11, weight: .medium))
                                 .foregroundStyle(.secondary)
                                 .frame(maxWidth: .infinity)
@@ -205,7 +230,7 @@ struct UsageBreakdownTables: View {
                 }
             }
         }
-        .frame(height: tableHeight(for: visiblePeriodRowCount))
+        .frame(height: tableHeight(for: visiblePeriodRowCount(points)))
         // Any new result series — bucket size, range, window, or filter
         // change — starts the viewport over; an expanded limit must not
         // carry into a different series.
@@ -222,10 +247,11 @@ struct UsageBreakdownTables: View {
         return "\(model.trend.bucket)|\(model.trend.points.count)|\(first)|\(last)"
     }
 
-    /// Rows the clamped table actually shows, load-more row included.
-    private var visiblePeriodRowCount: Int {
-        let shown = min(populatedPeriods.count, visiblePeriodLimit)
-        return shown + (populatedPeriods.count > visiblePeriodLimit ? 1 : 0)
+    /// Rows the clamped table actually shows, load-more row included. Takes
+    /// the already-filtered periods so the height doesn't re-derive them.
+    private func visiblePeriodRowCount(_ points: [UsageTrendPoint]) -> Int {
+        let shown = min(points.count, visiblePeriodLimit)
+        return shown + (points.count > visiblePeriodLimit ? 1 : 0)
     }
 
     /// Requests intentionally retain a horizontal scroll surface: a request
@@ -318,7 +344,7 @@ struct UsageBreakdownTables: View {
         return min(tableHeight(for: rows), Self.requestsMaxViewportHeight)
     }
 
-    private var providersTable: some View {
+    private func providersTable(_ stats: [UsageProviderStat]) -> some View {
         GeometryReader { proxy in
             let columns = ProviderColumns(
                 contentWidth: proxy.size.width - UsageTableMetrics.horizontalInset * 2
@@ -326,7 +352,7 @@ struct UsageBreakdownTables: View {
             VStack(spacing: 0) {
                 tableHeader(columns.all)
                 LazyVStack(spacing: 0) {
-                    ForEach(sortedProviders) { stat in
+                    ForEach(stats) { stat in
                         let vendor = stat.tool.vendorName
                         PorcelainUsageRow(
                             accessibilityLabel: providerAccessibilityLabel(stat, vendor: vendor)
@@ -340,10 +366,10 @@ struct UsageBreakdownTables: View {
                 }
             }
         }
-        .frame(height: tableHeight(for: sortedProviders.count))
+        .frame(height: tableHeight(for: stats.count))
     }
 
-    private var modelsTable: some View {
+    private func modelsTable(_ stats: [UsageModelStat]) -> some View {
         GeometryReader { proxy in
             let columns = ModelColumns(
                 contentWidth: proxy.size.width - UsageTableMetrics.horizontalInset * 2
@@ -351,7 +377,7 @@ struct UsageBreakdownTables: View {
             VStack(spacing: 0) {
                 tableHeader(columns.all)
                 LazyVStack(spacing: 0) {
-                    ForEach(sortedModels) { stat in
+                    ForEach(stats) { stat in
                         let name = UsageModelNaming.canonicalDisplayName(stat.model)
                         PorcelainUsageRow(
                             accessibilityLabel: modelAccessibilityLabel(stat, name: name)
@@ -366,10 +392,10 @@ struct UsageBreakdownTables: View {
                 }
             }
         }
-        .frame(height: tableHeight(for: sortedModels.count))
+        .frame(height: tableHeight(for: stats.count))
     }
 
-    private var projectsTable: some View {
+    private func projectsTable(_ stats: [UsageProjectStat]) -> some View {
         GeometryReader { proxy in
             let columns = ProviderColumns(
                 contentWidth: proxy.size.width - UsageTableMetrics.horizontalInset * 2
@@ -377,7 +403,7 @@ struct UsageBreakdownTables: View {
             VStack(spacing: 0) {
                 tableHeader(columns.all)
                 LazyVStack(spacing: 0) {
-                    ForEach(sortedProjects) { stat in
+                    ForEach(stats) { stat in
                         PorcelainUsageRow(
                             accessibilityLabel: "\(stat.name), \(stat.requests) requests, "
                                 + "\(UsageFormatting.formatTokens(stat.totalTokens)), "
@@ -392,7 +418,7 @@ struct UsageBreakdownTables: View {
                 }
             }
         }
-        .frame(height: tableHeight(for: sortedProjects.count))
+        .frame(height: tableHeight(for: stats.count))
     }
 
     // MARK: - Cells

--- a/Sources/VibeBarApp/Views/YearlyContributionHeatmapView.swift
+++ b/Sources/VibeBarApp/Views/YearlyContributionHeatmapView.swift
@@ -23,13 +23,16 @@ struct YearlyContributionHeatmapView: View {
     @State private var measuredGridWidth: CGFloat = 0
     @EnvironmentObject var environment: AppEnvironment
 
-    /// The 365-day walk and the month markers rebuilt only when the history
-    /// (or the day) changes — not on every redraw of the card. A reference
-    /// box on purpose: filling it during `body` must not dirty view state.
+    /// The 365-day walk, the month markers, the quartile thresholds and the
+    /// header total rebuilt only when the history (or the day) changes — not
+    /// on every redraw of the card. A reference box on purpose: filling it
+    /// during `body` must not dirty view state.
     private final class GridCache {
         var historyStamp: GridStamp?
         var columns: [WeekColumn] = []
         var markers: [MonthMarker] = []
+        var thresholds: (p25: Double, p50: Double, p75: Double) = (0, 0, 0)
+        var totalLabel: String?
     }
 
     private struct GridStamp: Equatable {
@@ -42,37 +45,48 @@ struct YearlyContributionHeatmapView: View {
 
     @State private var gridCache = GridCache()
 
-    private func cachedGrid() -> (columns: [WeekColumn], markers: [MonthMarker]) {
+    private typealias CachedGrid = (
+        columns: [WeekColumn],
+        markers: [MonthMarker],
+        thresholds: (p25: Double, p50: Double, p75: Double),
+        totalLabel: String?
+    )
+
+    private func cachedGrid() -> CachedGrid {
         let stamp = GridStamp(
             history: history,
             today: Calendar.current.startOfDay(for: Date()),
             calendarIdentity: "\(Calendar.current.identifier)|\(TimeZone.current.identifier)"
         )
         if gridCache.historyStamp == stamp {
-            return (gridCache.columns, gridCache.markers)
+            return (gridCache.columns, gridCache.markers, gridCache.thresholds, gridCache.totalLabel)
         }
         let columns = makeColumns()
         let markers = monthLabelPositions(columns: columns)
+        let levels = thresholds
+        let total = totalLabel
         gridCache.historyStamp = stamp
         gridCache.columns = columns
         gridCache.markers = markers
-        return (columns, markers)
+        gridCache.thresholds = levels
+        gridCache.totalLabel = total
+        return (columns, markers, levels, total)
     }
 
     var body: some View {
-        // `thresholds` does a sort on the year's non-zero days, and
-        // `cell(...)` is invoked ~365 times — hoisted once per body; the
-        // grid itself is memoized across bodies on the history generation.
-        let (columns, cachedMonthMarkers) = cachedGrid()
+        // Everything derived from the year of history — the week walk, the
+        // month markers, the quartile sort behind `thresholds`, and the
+        // header total — is memoized on the history generation, so a redraw
+        // of the card (hover, resize, refresh tick) costs a stamp compare.
+        let (columns, cachedMonthMarkers, cachedThresholds, cachedTotalLabel) = cachedGrid()
         let metrics = gridMetrics(columnCount: columns.count, measuredWidth: measuredGridWidth)
-        let cachedThresholds = thresholds
 
         VStack(alignment: .leading, spacing: density.cardSpacing) {
             HStack(alignment: .firstTextBaseline) {
                 Text("\(toolName) — Past Year")
                     .font(.system(size: density.bucketTitleFontSize, weight: .semibold))
                 Spacer()
-                if let total = totalLabel {
+                if let total = cachedTotalLabel {
                     Text(total)
                         .font(.system(size: density.subtitleFontSize))
                         .foregroundStyle(.secondary)
@@ -100,7 +114,7 @@ struct YearlyContributionHeatmapView: View {
                     .foregroundStyle(.tertiary)
                 ForEach(0..<5, id: \.self) { step in
                     RoundedRectangle(cornerRadius: 1.5, style: .continuous)
-                        .fill(color(forLevel: step))
+                        .fill(yearlyLevelColor(step))
                         .frame(width: metrics.cellSize, height: metrics.cellSize)
                 }
                 Text("More")
@@ -121,7 +135,8 @@ struct YearlyContributionHeatmapView: View {
     }
 
     private func gridHeight(for metrics: YearlyGridMetrics) -> CGFloat {
-        12 + cellSpacing + 7 * metrics.cellSize + 6 * cellSpacing
+        // Month label row + the VStack spacing under it + the cell block.
+        12 + cellSpacing + metrics.cellsHeight
     }
 
     private func grid(
@@ -167,28 +182,14 @@ struct YearlyContributionHeatmapView: View {
                         .frame(width: metrics.labelWidth, height: metrics.cellSize)
                     }
                 }
-                HStack(alignment: .top, spacing: metrics.cellSpacing) {
-                    ForEach(columns.indices, id: \.self) { columnIndex in
-                        VStack(spacing: metrics.cellSpacing) {
-                            ForEach(0..<7, id: \.self) { weekday in
-                                cell(at: weekday, columnEntry: columns[columnIndex], metrics: metrics, thresholds: thresholds)
-                            }
-                        }
-                    }
-                }
+                YearlyHeatmapCanvas(
+                    columns: columns,
+                    metrics: metrics,
+                    thresholds: thresholds,
+                    accessibilityLabel: "\(toolName) daily spend over the past year, \(columns.count) weeks"
+                )
             }
         }
-    }
-
-    @ViewBuilder
-    private func cell(at weekday: Int, columnEntry: WeekColumn, metrics: YearlyGridMetrics, thresholds: (p25: Double, p50: Double, p75: Double)) -> some View {
-        let entry = columnEntry.days[weekday]
-        let value = entry?.costUSD ?? 0
-        let level = Self.level(for: value, thresholds: thresholds)
-        RoundedRectangle(cornerRadius: metrics.cellCornerRadius, style: .continuous)
-            .fill(color(forLevel: level))
-            .frame(width: metrics.cellSize, height: metrics.cellSize)
-            .help(tooltip(for: entry))
     }
 
     private func gridMetrics(columnCount: Int, measuredWidth: CGFloat) -> YearlyGridMetrics {
@@ -215,19 +216,6 @@ struct YearlyContributionHeatmapView: View {
         )
     }
 
-    // Static on purpose: `tooltip(for:)` runs once per cell — ~365 times per
-    // body pass — and a fresh `DateFormatter` per call is milliseconds of
-    // pure allocation on every redraw of the card.
-    private static let tooltipFormatter: DateFormatter = {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "MMM d, yyyy"
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        // The app runs for weeks; a static formatter must follow a system
-        // time-zone change instead of keeping the one it was born with.
-        formatter.timeZone = .autoupdatingCurrent
-        return formatter
-    }()
-
     private static let monthLabelFormatter: DateFormatter = {
         let formatter = DateFormatter()
         formatter.locale = Locale(identifier: "en_US_POSIX")
@@ -235,21 +223,6 @@ struct YearlyContributionHeatmapView: View {
         formatter.timeZone = .autoupdatingCurrent
         return formatter
     }()
-
-    private func tooltip(for entry: DailyCostPoint?) -> String {
-        guard let entry else { return "" }
-        let cost: String = entry.costUSD < 0.01 ? "$0.00"
-            : entry.costUSD < 100 ? String(format: "$%.2f", entry.costUSD)
-            : String(format: "$%.0f", entry.costUSD)
-        return "\(Self.tooltipFormatter.string(from: entry.date)) · \(cost)"
-    }
-
-    /// Build week columns for the past 365 days, anchored to the most recent
-    /// Sunday so the grid always ends with the current week aligned right.
-    private struct WeekColumn {
-        let weekStart: Date
-        let days: [DailyCostPoint?]   // exactly 7, indexed by weekday
-    }
 
     private func makeColumns() -> [WeekColumn] {
         let calendar = Calendar.current
@@ -335,30 +308,125 @@ struct YearlyContributionHeatmapView: View {
         let idx = max(0, min(sorted.count - 1, Int(Double(sorted.count - 1) * p)))
         return sorted[idx]
     }
+}
 
-    /// Discrete level 0…4. 0 = no usage, 1…4 increase in saturation.
-    /// Picking levels by quartile means the grid always feels populated even
-    /// for users with little history (no faint pale-blue washout).
-    private static func level(for value: Double, thresholds t: (p25: Double, p50: Double, p75: Double)) -> Int {
-        guard value > 0 else { return 0 }
-        if t.p75 == 0 { return 1 }                 // only one active day
-        if value > t.p75 { return 4 }
-        if value > t.p50 { return 3 }
-        if value > t.p25 { return 2 }
-        return 1
+/// One week of the yearly grid: exactly 7 slots, indexed by weekday. At file
+/// scope so the canvas that draws it can read it too.
+private struct WeekColumn {
+    let weekStart: Date
+    let days: [DailyCostPoint?]   // exactly 7, indexed by weekday
+}
+
+/// The ~365 cells drawn as one `Canvas` instead of one `RoundedRectangle` per
+/// cell with a `.help()` each. Three of these cards are alive while the
+/// popover is open, so the view-per-cell shape cost roughly 1 100 view nodes
+/// and as many tooltip nodes just to sit idle. Hit-testing the hover point
+/// against the same geometry the canvas draws with reproduces the per-cell
+/// tooltip from a single string, and keeping the hover state in this leaf
+/// means a mouse move redraws the grid, not the whole card.
+private struct YearlyHeatmapCanvas: View {
+    let columns: [WeekColumn]
+    let metrics: YearlyGridMetrics
+    let thresholds: (p25: Double, p50: Double, p75: Double)
+    let accessibilityLabel: String
+
+    @State private var hoveredTooltip: String?
+
+    var body: some View {
+        Canvas { context, _ in
+            let step = metrics.cellSize + metrics.cellSpacing
+            for (columnIndex, column) in columns.enumerated() {
+                let x = CGFloat(columnIndex) * step
+                for weekday in 0..<7 {
+                    let value = column.days[weekday]?.costUSD ?? 0
+                    let rect = CGRect(
+                        x: x,
+                        y: CGFloat(weekday) * step,
+                        width: metrics.cellSize,
+                        height: metrics.cellSize
+                    )
+                    context.fill(
+                        Path(roundedRect: rect, cornerRadius: metrics.cellCornerRadius, style: .continuous),
+                        with: .color(yearlyLevelColor(yearlyLevel(for: value, thresholds: thresholds)))
+                    )
+                }
+            }
+        }
+        .frame(width: metrics.gridWidth, height: metrics.cellsHeight)
+        .contentShape(Rectangle())
+        .onContinuousHover { phase in
+            switch phase {
+            case .active(let location):
+                let text = tooltip(at: location)
+                if text != hoveredTooltip { hoveredTooltip = text }
+            case .ended:
+                if hoveredTooltip != nil { hoveredTooltip = nil }
+            }
+        }
+        .help(hoveredTooltip ?? "")
+        // The individual cell views are gone, so the grid speaks for itself.
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(accessibilityLabel)
     }
 
-    private func color(forLevel level: Int) -> Color {
-        // GitHub-style palette in cool→warm. Saturation/opacity steps are
-        // chosen so each level is visibly distinct on both light and dark
-        // backgrounds.
-        switch level {
-        case 0: return Color.primary.opacity(0.06)
-        case 1: return Color(red: 0.42, green: 0.60, blue: 0.97).opacity(0.55)
-        case 2: return Color(red: 0.42, green: 0.60, blue: 0.97).opacity(0.85)
-        case 3: return Color(red: 0.97, green: 0.65, blue: 0.30).opacity(0.85)
-        default: return Color(red: 0.97, green: 0.45, blue: 0.18)
-        }
+    private func tooltip(at point: CGPoint) -> String? {
+        guard let column = heatmapCellIndex(
+            for: point.x,
+            side: metrics.cellSize,
+            spacing: metrics.cellSpacing,
+            count: columns.count
+        ), let weekday = heatmapCellIndex(
+            for: point.y,
+            side: metrics.cellSize,
+            spacing: metrics.cellSpacing,
+            count: 7
+        ), let entry = columns[column].days[weekday] else { return nil }
+        return yearlyCellTooltip(for: entry)
+    }
+}
+
+// Static on purpose: the tooltip formatter used to be rebuilt per cell —
+// ~365 times per body pass — and a fresh `DateFormatter` per call is
+// milliseconds of pure allocation on every redraw of the card.
+private let yearlyTooltipFormatter: DateFormatter = {
+    let formatter = DateFormatter()
+    formatter.dateFormat = "MMM d, yyyy"
+    formatter.locale = Locale(identifier: "en_US_POSIX")
+    // The app runs for weeks; a static formatter must follow a system
+    // time-zone change instead of keeping the one it was born with.
+    formatter.timeZone = .autoupdatingCurrent
+    return formatter
+}()
+
+private func yearlyCellTooltip(for entry: DailyCostPoint) -> String {
+    let cost: String = entry.costUSD < 0.01 ? "$0.00"
+        : entry.costUSD < 100 ? String(format: "$%.2f", entry.costUSD)
+        : String(format: "$%.0f", entry.costUSD)
+    return "\(yearlyTooltipFormatter.string(from: entry.date)) · \(cost)"
+}
+
+/// Discrete level 0…4. 0 = no usage, 1…4 increase in saturation.
+/// Picking levels by quartile means the grid always feels populated even
+/// for users with little history (no faint pale-blue washout).
+private func yearlyLevel(for value: Double, thresholds t: (p25: Double, p50: Double, p75: Double)) -> Int {
+    guard value > 0 else { return 0 }
+    if t.p75 == 0 { return 1 }                 // only one active day
+    if value > t.p75 { return 4 }
+    if value > t.p50 { return 3 }
+    if value > t.p25 { return 2 }
+    return 1
+}
+
+private func yearlyLevelColor(_ level: Int) -> Color {
+    // GitHub-style palette in cool→warm. Saturation/opacity steps are
+    // chosen so each level is visibly distinct on both light and dark
+    // backgrounds.
+    switch level {
+    case 0: return Color.primary.opacity(0.06)
+    case 1: return Color(red: 0.42, green: 0.60, blue: 0.97).opacity(0.55)
+    case 2: return Color(red: 0.42, green: 0.60, blue: 0.97).opacity(0.85)
+    case 3: return Color(red: 0.97, green: 0.65, blue: 0.30).opacity(0.85)
+    default: return Color(red: 0.97, green: 0.45, blue: 0.18)
     }
 }
 
@@ -371,6 +439,12 @@ private struct YearlyGridMetrics {
 
     var gridWidth: CGFloat {
         CGFloat(columnCount) * cellSize + CGFloat(max(0, columnCount - 1)) * cellSpacing
+    }
+
+    /// Height of the 7-row cell block — what the per-column `VStack`s used to
+    /// measure to on their own.
+    var cellsHeight: CGFloat {
+        7 * cellSize + 6 * cellSpacing
     }
 
     var cellCornerRadius: CGFloat {

--- a/Sources/VibeBarCore/Services/QuotaPaceForecast.swift
+++ b/Sources/VibeBarCore/Services/QuotaPaceForecast.swift
@@ -152,23 +152,41 @@ public struct QuotaPaceForecast: Sendable, Equatable {
         let windowStart = resetAt.addingTimeInterval(-duration)
         let actual = clamp(bucket.usedPercent, 0, 100)
         let profile = ActivityProfile(heatmap: activityHeatmap, calendar: calendar)
+        let completed = cycles.filter(\.isCompleted)
+        // Build the hour table once, covering everything this pass will ask
+        // about. `weight(from:to:)` grows the table on demand, and the store
+        // hands completed cycles over newest-first, so the previous shape
+        // rebuilt an ever-widening table once per cycle on the way back
+        // through history — quadratic in the number of retained cycles for a
+        // table that only ever needed building once.
+        let span = activitySpan(
+            windowStart: windowStart,
+            evaluationDate: evaluationDate,
+            resetAt: resetAt,
+            cycles: completed
+        )
+        profile.prepare(from: span.start, to: span.end)
         let totalActivity = max(0.001, profile.weight(from: windowStart, to: resetAt))
         let elapsedActivity = clamp(profile.weight(from: windowStart, to: evaluationDate), 0, totalActivity)
         let futureActivity = max(0, totalActivity - elapsedActivity)
         let behavioralProgress = clamp(elapsedActivity / totalActivity, 0, 1)
 
-        let currentPoints = observations
-            .filter {
-                $0.sampledAt >= windowStart.addingTimeInterval(-300)
-                    && $0.sampledAt <= evaluationDate.addingTimeInterval(60)
-            }
-            .sorted { $0.sampledAt < $1.sampledAt }
+        // The observation lane is already in time order everywhere the app
+        // uses it, so the current window is a contiguous slice of it: two
+        // binary searches instead of a `filter { … }.sorted { … }` that copied
+        // every point in the lane.
+        let lane = ObservationLane(observations)
+        let currentLower = lane.lowerBound(windowStart.addingTimeInterval(-300))
+        let currentUpper = lane.upperBound(evaluationDate.addingTimeInterval(60))
+        // A window that has not opened yet (the `1.1 * duration` grace above
+        // admits one) inverts the two bounds; that is an empty slice, exactly
+        // as the old predicate was unsatisfiable there.
+        let currentRanks = currentLower..<max(currentLower, currentUpper)
 
-        let recent = recentSlope(points: currentPoints, profile: profile)
-        let completed = cycles.filter(\.isCompleted)
+        let recent = recentSlope(lane: lane, ranks: currentRanks, profile: profile)
         let historicalAdditions = historicalRemainingUsage(
             cycles: completed,
-            observations: observations,
+            lane: lane,
             currentProgress: behavioralProgress,
             profile: profile
         )
@@ -211,19 +229,22 @@ public struct QuotaPaceForecast: Sendable, Equatable {
         let projected = max(actual, rawProjection)
 
         let observationCoverage: Double = {
-            guard let first = currentPoints.first, let last = currentPoints.last else { return 0 }
-            let span = max(0, last.sampledAt.timeIntervalSince(first.sampledAt))
+            guard let firstRank = currentRanks.first, let lastRank = currentRanks.last else { return 0 }
+            let observedSpan = max(
+                0,
+                lane.sampledAt(atRank: lastRank).timeIntervalSince(lane.sampledAt(atRank: firstRank))
+            )
             let elapsed = max(1, evaluationDate.timeIntervalSince(windowStart))
-            let countScore = min(1, Double(currentPoints.count) / 10)
-            let spanScore = min(1, span / elapsed)
+            let countScore = min(1, Double(currentRanks.count) / 10)
+            let spanScore = min(1, observedSpan / elapsed)
             return countScore * 0.65 + spanScore * 0.35
         }()
         let historyCoverage = min(1, Double(completed.count) / 5)
         let freshness: Double = {
-            guard let last = currentPoints.last else { return 0 }
+            guard let lastRank = currentRanks.last else { return 0 }
             let naturalSlot: TimeInterval = rawWindowSeconds <= 6 * 3_600 ? 5 * 60 : 3_600
             return clamp(
-                1 - evaluationDate.timeIntervalSince(last.sampledAt) / max(60, naturalSlot * 3),
+                1 - evaluationDate.timeIntervalSince(lane.sampledAt(atRank: lastRank)) / max(60, naturalSlot * 3),
                 0,
                 1
             )
@@ -301,7 +322,7 @@ public struct QuotaPaceForecast: Sendable, Equatable {
             targetRemainingPercent: targetRemaining,
             runOutAt: runOutAt,
             completedCycleCount: completed.count,
-            currentObservationCount: currentPoints.count,
+            currentObservationCount: currentRanks.count,
             diagnostics: Diagnostics(
                 recentProjectionUsedPercent: recentProjection,
                 historicalProjectionUsedPercent: historicalProjection,
@@ -325,14 +346,26 @@ public struct QuotaPaceForecast: Sendable, Equatable {
         let sampleCount: Int
     }
 
-    private static func recentSlope(points: [FillTimelinePoint], profile: ActivityProfile) -> RecentSlope {
-        guard points.count >= 2 else { return RecentSlope(rate: nil, spread: 0, sampleCount: 0) }
-        let recentPoints = Array(points.suffix(18))
+    private static func recentSlope(
+        lane: ObservationLane,
+        ranks: Range<Int>,
+        profile: ActivityProfile
+    ) -> RecentSlope {
+        guard ranks.count >= 2 else { return RecentSlope(rate: nil, spread: 0, sampleCount: 0) }
+        // The old shape materialised `Array(points.suffix(18))`; the pairs it
+        // walked are the same, addressed by rank instead of copied out.
+        let start = max(ranks.lowerBound, ranks.upperBound - 18)
         var slopes: [Double] = []
-        for pair in zip(recentPoints, recentPoints.dropFirst()) {
-            let delta = pair.1.usedPercent - pair.0.usedPercent
+        slopes.reserveCapacity(ranks.upperBound - start)
+        for rank in (start + 1)..<ranks.upperBound {
+            let earlier = lane.index(atRank: rank - 1)
+            let later = lane.index(atRank: rank)
+            let delta = lane.points[later].usedPercent - lane.points[earlier].usedPercent
             guard delta >= 0, delta <= 45 else { continue }
-            let activity = profile.weight(from: pair.0.sampledAt, to: pair.1.sampledAt)
+            let activity = profile.weight(
+                from: lane.points[earlier].sampledAt,
+                to: lane.points[later].sampledAt
+            )
             guard activity > 0.002 else { continue }
             slopes.append(delta / activity)
         }
@@ -344,13 +377,31 @@ public struct QuotaPaceForecast: Sendable, Equatable {
         )
     }
 
-    private static func historicalRemainingUsage(
+    /// How much more each completed cycle consumed from the point it was as
+    /// far along as the current one.
+    ///
+    /// This used to re-filter the whole observation lane once per cycle. On
+    /// real data — a Claude five-hour bucket retains ~200 completed cycles and
+    /// ~7 300 observations — that is ~1.5 M `FillTimelinePoint` copies per
+    /// call, and the struct carries three `String`s, so each copy is six ARC
+    /// operations. It ran inside a SwiftUI `body`.
+    ///
+    /// Each cycle's observations are a contiguous slice of the time-ordered
+    /// lane, so the same answer comes from one binary search plus a scan
+    /// bounded by that slice: linear in the lane, not in lane × cycles, and
+    /// nothing is copied out of the array.
+    ///
+    /// Internal rather than private so `QuotaPaceForecastEquivalenceTests` can
+    /// pin it against a verbatim copy of the retired algorithm.
+    static func historicalRemainingUsage(
         cycles: [SubscriptionWindowSample],
-        observations: [FillTimelinePoint],
+        lane: ObservationLane,
         currentProgress: Double,
         profile: ActivityProfile
     ) -> [Double] {
-        cycles.compactMap { cycle in
+        var additions: [Double] = []
+        additions.reserveCapacity(cycles.count)
+        for cycleIndex in cycles.indices {
             // `windowStart` tracks what the provider reported, and measurement
             // says to leave it alone. Several buckets refill far more often
             // than their stated window — two Codex weeklies have a median gap
@@ -359,9 +410,9 @@ public struct QuotaPaceForecast: Sendable, Equatable {
             // interval between observed refills, the stored start is right for
             // 86-100% of cycles on every bucket; reconstructing it from the
             // window length instead drops that to 14% on the worst.
-            let cycleStart = cycle.windowStart ?? cycle.firstSeenAt
-            let cycleEnd = cycle.completedAt ?? cycle.windowEnd
-            guard cycleEnd > cycleStart else { return nil }
+            let cycleStart = cycles[cycleIndex].windowStart ?? cycles[cycleIndex].firstSeenAt
+            let cycleEnd = cycles[cycleIndex].completedAt ?? cycles[cycleIndex].windowEnd
+            guard cycleEnd > cycleStart else { continue }
             let total = max(0.001, profile.weight(from: cycleStart, to: cycleEnd))
             // Bounded by the last observation this cycle actually absorbed,
             // not by its end. The observation that detected the refill belongs
@@ -373,18 +424,126 @@ public struct QuotaPaceForecast: Sendable, Equatable {
             // "the last reading that was mine". Without it a 60% → 5% refill
             // contributed 55 points of consumption to a window that had
             // already finished.
-            let observationEnd = cycle.lastSeenAt
-            let matching = observations
-                .filter { $0.sampledAt >= cycleStart && $0.sampledAt <= observationEnd }
-                .map { point -> (distance: Double, used: Double) in
-                    let progress = clamp(profile.weight(from: cycleStart, to: point.sampledAt) / total, 0, 1)
-                    return (abs(progress - currentProgress), point.usedPercent)
+            let observationEnd = cycles[cycleIndex].lastSeenAt
+            var bestDistance = Double.infinity
+            // `min(by:)` kept the *first* element of a tie in the order the
+            // filter produced, which was the lane's own order. Ties are broken
+            // on the original position for exactly that reason, so a caller
+            // that hands `compute` an unsorted lane still gets the old answer.
+            var bestOriginal = Int.max
+            var bestUsed = 0.0
+            var rank = lane.lowerBound(cycleStart)
+            while rank < lane.count {
+                let original = lane.index(atRank: rank)
+                let sampledAt = lane.points[original].sampledAt
+                if sampledAt > observationEnd { break }
+                let progress = clamp(profile.weight(from: cycleStart, to: sampledAt) / total, 0, 1)
+                let distance = abs(progress - currentProgress)
+                if distance < bestDistance || (distance == bestDistance && original < bestOriginal) {
+                    bestDistance = distance
+                    bestOriginal = original
+                    bestUsed = lane.points[original].usedPercent
                 }
-                .min { $0.distance < $1.distance }
-            if let matching, matching.distance <= 0.22 {
-                return max(0, cycle.peakUsedPercent - matching.used)
+                rank += 1
             }
-            return max(0, cycle.peakUsedPercent * (1 - currentProgress))
+            if bestOriginal != Int.max, bestDistance <= 0.22 {
+                additions.append(max(0, cycles[cycleIndex].peakUsedPercent - bestUsed))
+            } else {
+                additions.append(max(0, cycles[cycleIndex].peakUsedPercent * (1 - currentProgress)))
+            }
+        }
+        return additions
+    }
+
+    /// Widest instant range this pass will ask the activity profile about, so
+    /// the hour table can be built once instead of grown per cycle.
+    private static func activitySpan(
+        windowStart: Date,
+        evaluationDate: Date,
+        resetAt: Date,
+        cycles: [SubscriptionWindowSample]
+    ) -> (start: Date, end: Date) {
+        var start = min(windowStart.addingTimeInterval(-300), evaluationDate)
+        var end = max(resetAt, evaluationDate.addingTimeInterval(60))
+        for index in cycles.indices {
+            let cycleStart = cycles[index].windowStart ?? cycles[index].firstSeenAt
+            let cycleEnd = max(cycles[index].completedAt ?? cycles[index].windowEnd, cycles[index].lastSeenAt)
+            if cycleStart < start { start = cycleStart }
+            if cycleEnd > end { end = cycleEnd }
+        }
+        return (start, end)
+    }
+
+    /// A read-only, time-ordered view over one bucket's observation lane.
+    ///
+    /// `QuotaService` keeps every lane sorted ascending by `sampledAt`
+    /// (`applyInitialObservations` sorts, and `UsageFillTimelineStore` returns
+    /// sorted points), so the common case builds no storage at all: `order` is
+    /// `nil` and a rank *is* an index. Only a caller that hands `compute` an
+    /// out-of-order array pays for one permutation — once, not once per cycle.
+    ///
+    /// Callers address points by *rank* (position in time order) and read
+    /// fields through `points[index]`, which borrows the element rather than
+    /// copying it out of the array.
+    struct ObservationLane {
+        let points: [FillTimelinePoint]
+        /// Indices into `points` in time order, or `nil` when `points` is
+        /// already in that order.
+        private let order: [Int]?
+
+        init(_ points: [FillTimelinePoint]) {
+            self.points = points
+            var ascending = true
+            var index = 1
+            while index < points.count {
+                if points[index].sampledAt < points[index - 1].sampledAt {
+                    ascending = false
+                    break
+                }
+                index += 1
+            }
+            guard !ascending else {
+                self.order = nil
+                return
+            }
+            // Ties broken on the original position, so this is the stable
+            // ordering the old `filter { … }.sorted { … }` produced.
+            self.order = points.indices.sorted { lhs, rhs in
+                let left = points[lhs].sampledAt
+                let right = points[rhs].sampledAt
+                if left == right { return lhs < rhs }
+                return left < right
+            }
+        }
+
+        var count: Int { points.count }
+
+        @inline(__always)
+        func index(atRank rank: Int) -> Int { order?[rank] ?? rank }
+
+        @inline(__always)
+        func sampledAt(atRank rank: Int) -> Date { points[index(atRank: rank)].sampledAt }
+
+        /// First rank whose `sampledAt` is at or after `date`.
+        func lowerBound(_ date: Date) -> Int {
+            var low = 0
+            var high = count
+            while low < high {
+                let middle = low + (high - low) / 2
+                if sampledAt(atRank: middle) < date { low = middle + 1 } else { high = middle }
+            }
+            return low
+        }
+
+        /// First rank whose `sampledAt` is strictly after `date`.
+        func upperBound(_ date: Date) -> Int {
+            var low = 0
+            var high = count
+            while low < high {
+                let middle = low + (high - low) / 2
+                if sampledAt(atRank: middle) <= date { low = middle + 1 } else { high = middle }
+            }
+            return low
         }
     }
 
@@ -464,7 +623,16 @@ public struct QuotaPaceForecast: Sendable, Equatable {
 
         init(heatmap: UsageHeatmap?, calendar: Calendar) {
             self.calendar = calendar
-            let maximum = Double(heatmap?.cells.flatMap { $0 }.max() ?? 0)
+            // Scanned rather than `flatMap { $0 }.max()`: the flatten
+            // allocated a 168-element array on a path the forecast runs per
+            // bucket per data generation.
+            var peak = 0
+            if let heatmap {
+                for row in heatmap.cells {
+                    for value in row where value > peak { peak = value }
+                }
+            }
+            let maximum = Double(peak)
             guard let heatmap, heatmap.totalTokens > 0, maximum > 0 else {
                 self.cellWeights = nil
                 return
@@ -480,6 +648,23 @@ public struct QuotaPaceForecast: Sendable, Equatable {
                 }
             }
             self.cellWeights = weights
+        }
+
+        /// Build the hour table once for a span the caller is about to walk.
+        ///
+        /// The table grows on demand, which is right for a single query and
+        /// wrong for a pass that walks two hundred completed cycles from
+        /// newest to oldest: each older cycle fell outside the table and paid
+        /// for a rebuild of everything already covered. A span wider than one
+        /// table is left to the chunked path in `weight(from:to:)`, which is
+        /// what keeps a corrupt stored date from asking for a
+        /// hundred-million-entry array.
+        func prepare(from start: Date, to end: Date) {
+            guard cellWeights != nil else { return }
+            let lower = start.timeIntervalSince1970
+            let upper = end.timeIntervalSince1970
+            guard upper >= lower, upper - lower <= Self.maximumTableSeconds else { return }
+            _ = table(covering: lower, upper)
         }
 
         func weight(from start: Date, to end: Date) -> Double {

--- a/Sources/VibeBarCore/Services/QuotaService.swift
+++ b/Sources/VibeBarCore/Services/QuotaService.swift
@@ -274,6 +274,43 @@ public final class QuotaService: ObservableObject {
         store(success: quota)
     }
 
+    /// Grid the forecast clock is snapped to.
+    ///
+    /// The forecast answers "how much will be left when this refills" — a
+    /// question whose answer cannot move measurably in five minutes, and whose
+    /// cheapest input (`bucket.usedPercent`) only changes when a refresh
+    /// lands. Countdown labels, run-out ETAs, and the reset strings keep their
+    /// own clocks and are not affected by this.
+    nonisolated public static let paceForecastClockQuantumSeconds: TimeInterval = 300
+
+    /// The forecast clock for `now`, floored to the 5-minute grid.
+    nonisolated public static func quantizedForecastClock(_ now: Date) -> Date {
+        let quantum = paceForecastClockQuantumSeconds
+        return Date(
+            timeIntervalSince1970: (now.timeIntervalSince1970 / quantum).rounded(.down) * quantum
+        )
+    }
+
+    /// Personal pace forecast for one bucket, memoised per data generation.
+    ///
+    /// **`now` is floored to a 5-minute grid** before anything else happens.
+    /// Every render surface used to hand this a clock of its own — a per-row
+    /// `TimelineView(.periodic(from: .now, by: 30))` re-anchors on every body
+    /// pass, `StatusItemController` passed a fresh `Date()` per menu-bar
+    /// render, `MCPController` omitted the parameter entirely — so no two asks
+    /// ever agreed and the memo below never hit. Snapping the clock here fixes
+    /// all of them at once without a call-site change, and the forecast is not
+    /// a value that can move meaningfully inside one grid step. The one
+    /// exception is the reset boundary: if flooring would step back across
+    /// `bucket.resetAt` the exact `now` is used, so "this window is over"
+    /// still happens at the second it happens.
+    ///
+    /// The memo is keyed on the *exact* remaining inputs, so a hit is provably
+    /// the same pure-function call and behaviour cannot drift. It is evicted
+    /// by data generation rather than by age: a refresh replaces the
+    /// observation and cycle arrays wholesale, so entries from the previous
+    /// generation can never match again and are dropped in one go — which also
+    /// stops them retaining thousands of points per bucket.
     public func paceForecast(
         accountId: String,
         bucket: QuotaBucket,
@@ -285,104 +322,112 @@ public final class QuotaService: ObservableObject {
         let key = SubscriptionHistoryKey(accountId: accountId, bucketId: bucket.id)
         let observations = observationsByAccountBucket[key] ?? []
         let cycles = historyByAccountBucket[key] ?? []
-        // Render paths ask for this once per bucket per body pass — every
-        // quota-group row, mini-window cell, and the status item — and the
-        // blend walks every stored observation per completed cycle. Between
-        // data changes the inputs are byte-identical (each `TimelineView`
-        // hands every re-render of a tick the same date), so the memo turns
-        // the repeat asks into a handful of COW identity comparisons. Keyed
-        // on the *exact* inputs, never a quantized clock: a hit is provably
-        // the same pure-function call, so behavior cannot drift.
-        if let memos = paceForecastMemo[key] {
-            for memo in memos where memo.matches(
+        let floored = Self.quantizedForecastClock(now)
+        let clock: Date = {
+            guard let resetAt = bucket.resetAt else { return floored }
+            // Only when the floor would put a finished window back inside its
+            // own reset. Costs one un-memoised compute per reset, per bucket.
+            return (resetAt > floored && resetAt <= now) ? now : floored
+        }()
+        let memoKey = PaceForecastMemoKey(now: clock, allowsPostResetGrace: allowsPostResetGrace)
+
+        if var generation = paceForecastMemo[key] {
+            if generation.matchesData(
                 bucket: bucket,
                 observations: observations,
                 cycles: cycles,
                 heatmap: activityHeatmap,
-                dailyActivity: dailyActivity,
-                now: now,
-                allowsPostResetGrace: allowsPostResetGrace
+                dailyActivity: dailyActivity
             ) {
-                return memo.result
+                if let hit = generation.results[memoKey] { return hit }
+                let result = QuotaPaceForecast.compute(
+                    bucket: bucket,
+                    observations: observations,
+                    cycles: cycles,
+                    activityHeatmap: activityHeatmap,
+                    dailyActivity: dailyActivity,
+                    now: clock,
+                    allowsPostResetGrace: allowsPostResetGrace
+                )
+                generation.record(memoKey, result: result)
+                paceForecastMemo[key] = generation
+                return result
             }
         }
+
         let result = QuotaPaceForecast.compute(
             bucket: bucket,
             observations: observations,
             cycles: cycles,
             activityHeatmap: activityHeatmap,
             dailyActivity: dailyActivity,
-            now: now,
+            now: clock,
             allowsPostResetGrace: allowsPostResetGrace
         )
-        var memos = paceForecastMemo[key] ?? []
-        // A refresh replaces the observation/cycle arrays wholesale, so a
-        // memo from the previous data generation can never match again —
-        // but it would keep retaining those arrays (thousands of points per
-        // bucket) for as long as it sat in the list. Keep only memos of the
-        // current generation; the differently-phased `now` values are what
-        // the multi-entry list is for.
-        memos.removeAll { memo in
-            !memo.matchesData(
-                bucket: bucket,
-                observations: observations,
-                cycles: cycles,
-                heatmap: activityHeatmap,
-                dailyActivity: dailyActivity
-            )
-        }
-        memos.append(PaceForecastMemo(
+        var generation = PaceForecastMemo(
             bucket: bucket,
             observations: observations,
             cycles: cycles,
             heatmap: activityHeatmap,
-            dailyActivity: dailyActivity,
-            now: now,
-            allowsPostResetGrace: allowsPostResetGrace,
-            result: result
-        ))
-        // Several surfaces (popover, mini windows, status item) tick on
-        // their own 30 s phases, so keep a few entries per bucket rather
-        // than one; the arrays inside are references to storage the service
-        // already retains, so the memo itself is a few dozen words.
-        if memos.count > Self.paceForecastMemoLimit {
-            memos.removeFirst(memos.count - Self.paceForecastMemoLimit)
-        }
-        paceForecastMemo[key] = memos
+            dailyActivity: dailyActivity
+        )
+        generation.record(memoKey, result: result)
+        paceForecastMemo[key] = generation
         return result
     }
 
+    private struct PaceForecastMemoKey: Hashable {
+        let now: Date
+        let allowsPostResetGrace: Bool
+    }
+
+    /// One data generation's worth of memoised forecasts for one bucket.
     private struct PaceForecastMemo {
         let bucket: QuotaBucket
         let observations: [FillTimelinePoint]
         let cycles: [SubscriptionWindowSample]
         let heatmap: UsageHeatmap?
         let dailyActivity: [DailyCostPoint]
-        let now: Date
-        let allowsPostResetGrace: Bool
-        let result: QuotaPaceForecast?
+        /// Keyed by clock and grace flag. Held alongside `order` so the
+        /// oldest entry can be evicted without sorting.
+        private(set) var results: [PaceForecastMemoKey: QuotaPaceForecast?] = [:]
+        private var order: [PaceForecastMemoKey] = []
 
-        func matches(
+        init(
             bucket: QuotaBucket,
             observations: [FillTimelinePoint],
             cycles: [SubscriptionWindowSample],
             heatmap: UsageHeatmap?,
-            dailyActivity: [DailyCostPoint],
-            now: Date,
-            allowsPostResetGrace: Bool
-        ) -> Bool {
-            self.now == now
-                && self.allowsPostResetGrace == allowsPostResetGrace
-                && matchesData(
-                    bucket: bucket,
-                    observations: observations,
-                    cycles: cycles,
-                    heatmap: heatmap,
-                    dailyActivity: dailyActivity
-                )
+            dailyActivity: [DailyCostPoint]
+        ) {
+            self.bucket = bucket
+            self.observations = observations
+            self.cycles = cycles
+            self.heatmap = heatmap
+            self.dailyActivity = dailyActivity
         }
 
-        /// The time-independent half of `matches` — one data generation.
+        mutating func record(_ memoKey: PaceForecastMemoKey, result: QuotaPaceForecast?) {
+            if results.updateValue(result, forKey: memoKey) == nil {
+                order.append(memoKey)
+            }
+            while order.count > Self.limit {
+                let evicted = order.removeFirst()
+                results.removeValue(forKey: evicted)
+            }
+        }
+
+        /// Distinct clocks retained per bucket per data generation. Generous
+        /// because the surfaces no longer evict each other: the popover, the
+        /// Workbench, every mini window, the status item, and the MCP server
+        /// all land on the same 5-minute grid, and the two
+        /// `allowsPostResetGrace` variants plus a reset-boundary exact clock
+        /// are the only spread left.
+        static let limit = 16
+
+        /// One data generation: the inputs a refresh replaces wholesale.
+        /// Array `==` short-circuits on buffer identity, so the usual answer
+        /// costs a few pointer comparisons.
         func matchesData(
             bucket: QuotaBucket,
             observations: [FillTimelinePoint],
@@ -398,8 +443,7 @@ public final class QuotaService: ObservableObject {
         }
     }
 
-    private static let paceForecastMemoLimit = 4
-    private var paceForecastMemo: [SubscriptionHistoryKey: [PaceForecastMemo]] = [:]
+    private var paceForecastMemo: [SubscriptionHistoryKey: PaceForecastMemo] = [:]
 
     /// The picker's explicit "forget": drop one discovered field from the
     /// registry and persist. The caller removes its own references
@@ -563,22 +607,41 @@ public final class QuotaService: ObservableObject {
         historyByAccountBucket = grouped
     }
 
+    /// Republish every bucket's cycle history for one account.
+    ///
+    /// One actor hop, for the same reason as `refreshObservations`. The
+    /// previous shape awaited `SubscriptionHistoryStore.samples` once per
+    /// bucket, and each of those calls filters and sorts the whole stored
+    /// sample list — a thirty-bucket account paid for thirty suspensions and
+    /// thirty full scans per refresh. `allSamples()` is the same file read
+    /// once; the grouping and the newest-first order are the store's own
+    /// (`completedAt ?? lastSeenAt`), reproduced here so nothing downstream
+    /// sees a different order than it used to.
     private func refreshSubscriptionHistory(for quota: AccountQuota) async {
-        var updates: [SubscriptionHistoryKey: [SubscriptionWindowSample]] = [:]
-        for bucket in quota.buckets {
-            let samples = await SubscriptionHistoryStore.shared.samples(
-                accountId: quota.accountId,
-                bucketId: bucket.id
-            )
-            let key = SubscriptionHistoryKey(accountId: quota.accountId, bucketId: bucket.id)
-            updates[key] = samples
+        let bucketIds = Set(quota.buckets.map(\.id))
+        guard !bucketIds.isEmpty else { return }
+        let all = await SubscriptionHistoryStore.shared.allSamples()
+        var grouped: [String: [SubscriptionWindowSample]] = [:]
+        for sample in all
+        where sample.accountId == quota.accountId && bucketIds.contains(sample.bucketId) {
+            grouped[sample.bucketId, default: []].append(sample)
+        }
+        for bucketId in grouped.keys {
+            grouped[bucketId]?.sort { Self.sampleSortDate($0) > Self.sampleSortDate($1) }
         }
         // Same one-publish rule as `refreshObservations`.
         var merged = historyByAccountBucket
-        for (key, samples) in updates {
-            merged[key] = samples
+        for bucketId in bucketIds {
+            let key = SubscriptionHistoryKey(accountId: quota.accountId, bucketId: bucketId)
+            merged[key] = grouped[bucketId] ?? []
         }
         historyByAccountBucket = merged
+    }
+
+    /// The store's own sort key for a cycle, mirrored so the batched read
+    /// above orders exactly like `SubscriptionHistoryStore.samples` did.
+    private nonisolated static func sampleSortDate(_ sample: SubscriptionWindowSample) -> Date {
+        sample.completedAt ?? sample.lastSeenAt
     }
 
     private func store(error: QuotaError, for account: AccountIdentity, now: Date = Date()) {

--- a/Tests/VibeBarCoreTests/QuotaPaceForecastEquivalenceTests.swift
+++ b/Tests/VibeBarCoreTests/QuotaPaceForecastEquivalenceTests.swift
@@ -1,0 +1,503 @@
+import XCTest
+@testable import VibeBarCore
+
+/// `QuotaPaceForecast.historicalRemainingUsage` used to re-filter the entire
+/// observation lane once per completed cycle, copying every `FillTimelinePoint`
+/// it looked at. On real data — a Claude five-hour bucket retains ~200
+/// completed cycles against ~7 300 observations — that is ~1.5 M struct copies
+/// per call, and the struct carries three `String`s, so each copy is six ARC
+/// operations. It ran inside a SwiftUI `body`.
+///
+/// It now binary-searches the time-ordered lane once per cycle and scans only
+/// that cycle's slice, addressing points by index instead of copying them.
+/// These tests pin the new walk against `referenceHistoricalRemainingUsage`
+/// below — a verbatim copy of the retired algorithm — so the swap stays a
+/// performance change rather than a behaviour change.
+final class QuotaPaceForecastEquivalenceTests: XCTestCase {
+    // MARK: - The retired algorithm, kept as the equivalence oracle
+
+    private func referenceHistoricalRemainingUsage(
+        cycles: [SubscriptionWindowSample],
+        observations: [FillTimelinePoint],
+        currentProgress: Double,
+        profile: QuotaPaceForecast.ActivityProfile
+    ) -> [Double] {
+        func clamp(_ value: Double, _ lower: Double, _ upper: Double) -> Double {
+            min(max(value, lower), upper)
+        }
+        return cycles.compactMap { cycle in
+            let cycleStart = cycle.windowStart ?? cycle.firstSeenAt
+            let cycleEnd = cycle.completedAt ?? cycle.windowEnd
+            guard cycleEnd > cycleStart else { return nil }
+            let total = max(0.001, profile.weight(from: cycleStart, to: cycleEnd))
+            let observationEnd = cycle.lastSeenAt
+            let matching = observations
+                .filter { $0.sampledAt >= cycleStart && $0.sampledAt <= observationEnd }
+                .map { point -> (distance: Double, used: Double) in
+                    let progress = clamp(profile.weight(from: cycleStart, to: point.sampledAt) / total, 0, 1)
+                    return (abs(progress - currentProgress), point.usedPercent)
+                }
+                .min { $0.distance < $1.distance }
+            if let matching, matching.distance <= 0.22 {
+                return max(0, cycle.peakUsedPercent - matching.used)
+            }
+            return max(0, cycle.peakUsedPercent * (1 - currentProgress))
+        }
+    }
+
+    /// The retired shape of `compute`'s current-window slice, kept so the
+    /// index range that replaced it can be checked against it.
+    private func referenceCurrentPoints(
+        observations: [FillTimelinePoint],
+        windowStart: Date,
+        evaluationDate: Date
+    ) -> [FillTimelinePoint] {
+        observations
+            .filter {
+                $0.sampledAt >= windowStart.addingTimeInterval(-300)
+                    && $0.sampledAt <= evaluationDate.addingTimeInterval(60)
+            }
+            .sorted { $0.sampledAt < $1.sampledAt }
+    }
+
+    // MARK: - Deterministic synthetic data
+
+    /// A seeded generator, so a failure is reproducible and CI never flakes.
+    private struct Random {
+        private var state: UInt64
+
+        init(seed: UInt64) { state = seed &* 6_364_136_223_846_793_005 &+ 1 }
+
+        mutating func next() -> UInt64 {
+            state ^= state << 13
+            state ^= state >> 7
+            state ^= state << 17
+            return state
+        }
+
+        mutating func double(_ lower: Double, _ upper: Double) -> Double {
+            let unit = Double(next() % 1_000_000) / 1_000_000
+            return lower + unit * (upper - lower)
+        }
+
+        mutating func int(_ range: ClosedRange<Int>) -> Int {
+            range.lowerBound + Int(next() % UInt64(range.count))
+        }
+
+        mutating func bool(_ probability: Double) -> Bool { double(0, 1) < probability }
+    }
+
+    private let epoch = Date(timeIntervalSince1970: 1_800_000_000)
+
+    private func point(_ used: Double, at date: Date) -> FillTimelinePoint {
+        FillTimelinePoint(
+            accountId: "account",
+            tool: .claude,
+            bucketId: "five_hour",
+            slotStart: UsageFillTimelineStore.hourSlotStart(for: date),
+            usedPercent: used,
+            sampledAt: date,
+            resetAt: nil,
+            rawWindowSeconds: 5 * 3_600
+        )
+    }
+
+    private func cycle(
+        start: Date?,
+        firstSeenAt: Date,
+        lastSeenAt: Date,
+        windowEnd: Date,
+        completedAt: Date?,
+        peak: Double
+    ) -> SubscriptionWindowSample {
+        SubscriptionWindowSample(
+            accountId: "account",
+            tool: .claude,
+            bucketId: "five_hour",
+            windowEnd: windowEnd,
+            windowStart: start,
+            rawWindowSeconds: 5 * 3_600,
+            peakUsedPercent: peak,
+            lastUsedPercent: peak,
+            observationCount: 4,
+            firstSeenAt: firstSeenAt,
+            lastSeenAt: lastSeenAt,
+            completedAt: completedAt,
+            completionReason: completedAt == nil ? nil : .refillDetected
+        )
+    }
+
+    /// A lane shaped like the real thing: back-to-back five-hour cycles that
+    /// mostly refill on schedule, some early, some with no observations at
+    /// all, and one degenerate cycle whose end precedes its start.
+    private func syntheticLane(
+        seed: UInt64,
+        cycleCount: Int,
+        shuffled: Bool
+    ) -> (cycles: [SubscriptionWindowSample], observations: [FillTimelinePoint]) {
+        var random = Random(seed: seed)
+        var cycles: [SubscriptionWindowSample] = []
+        var observations: [FillTimelinePoint] = []
+        var cursor = epoch.addingTimeInterval(-Double(cycleCount) * 5 * 3_600)
+
+        for index in 0..<cycleCount {
+            // Some cycles refill early — a stated five-hour window that
+            // actually closes after two or three.
+            let span = random.bool(0.3)
+                ? random.double(2 * 3_600, 4 * 3_600)
+                : 5 * 3_600
+            let start = cursor
+            let end = start.addingTimeInterval(span)
+            let emptyCycle = random.bool(0.12)
+            var peak = 0.0
+            var lastSeenAt = start
+            if !emptyCycle {
+                let sampleCount = random.int(3...40)
+                var used = random.double(0, 8)
+                for sample in 0..<sampleCount {
+                    let offset = span * (Double(sample) + random.double(0.05, 0.9)) / Double(sampleCount)
+                    let at = start.addingTimeInterval(offset)
+                    used = min(100, used + random.double(0, 6))
+                    peak = max(peak, used)
+                    lastSeenAt = max(lastSeenAt, at)
+                    observations.append(point(used, at: at))
+                }
+            }
+            // A degenerate cycle in the middle: `compactMap` used to drop it
+            // and the new loop must drop it too, or every later element of
+            // the result array shifts.
+            if index == cycleCount / 2 {
+                cycles.append(cycle(
+                    start: end,
+                    firstSeenAt: end,
+                    lastSeenAt: end,
+                    windowEnd: start,
+                    completedAt: start,
+                    peak: 42
+                ))
+            }
+            cycles.append(cycle(
+                start: random.bool(0.15) ? nil : start,
+                firstSeenAt: start,
+                lastSeenAt: lastSeenAt,
+                windowEnd: start.addingTimeInterval(5 * 3_600),
+                completedAt: end,
+                peak: peak
+            ))
+            cursor = end
+        }
+
+        if shuffled {
+            // Deliberately out of order, including exact-duplicate timestamps,
+            // which is where "first minimum wins" has to keep meaning the same
+            // point as before.
+            if let first = observations.first {
+                observations.append(first)
+            }
+            var shuffledPoints = observations
+            for index in stride(from: shuffledPoints.count - 1, to: 0, by: -1) {
+                let swapWith = random.int(0...index)
+                shuffledPoints.swapAt(index, swapWith)
+            }
+            observations = shuffledPoints
+        }
+
+        return (cycles, observations)
+    }
+
+    private func heatmap() -> UsageHeatmap {
+        var cells = Array(repeating: Array(repeating: 0, count: 24), count: 7)
+        var random = Random(seed: 99)
+        for weekday in 0..<7 {
+            for hour in 0..<24 {
+                cells[weekday][hour] = hour >= 9 && hour <= 20 ? random.int(400...9_000) : random.int(0...200)
+            }
+        }
+        let total = cells.reduce(0) { $0 + $1.reduce(0, +) }
+        return UsageHeatmap(tool: .claude, cells: cells, totalTokens: total)
+    }
+
+    // MARK: - Tests
+
+    /// The reference and the new walk share one *prepared* profile, so the
+    /// hour table underneath them is byte-identical and any difference in the
+    /// result is a difference in the algorithm rather than in floating-point
+    /// association.
+    private func assertEquivalent(
+        cycles: [SubscriptionWindowSample],
+        observations: [FillTimelinePoint],
+        currentProgress: Double,
+        activityHeatmap: UsageHeatmap?,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        let profile = QuotaPaceForecast.ActivityProfile(
+            heatmap: activityHeatmap,
+            calendar: Calendar(identifier: .gregorian)
+        )
+        let earliest = cycles.map { $0.windowStart ?? $0.firstSeenAt }.min() ?? epoch
+        let latest = cycles.map { max($0.completedAt ?? $0.windowEnd, $0.lastSeenAt) }.max() ?? epoch
+        profile.prepare(from: earliest.addingTimeInterval(-86_400), to: latest.addingTimeInterval(86_400))
+
+        let expected = referenceHistoricalRemainingUsage(
+            cycles: cycles,
+            observations: observations,
+            currentProgress: currentProgress,
+            profile: profile
+        )
+        let actual = QuotaPaceForecast.historicalRemainingUsage(
+            cycles: cycles,
+            lane: QuotaPaceForecast.ObservationLane(observations),
+            currentProgress: currentProgress,
+            profile: profile
+        )
+        XCTAssertEqual(actual.count, expected.count, "cycle count differs", file: file, line: line)
+        guard actual.count == expected.count else { return }
+        for index in actual.indices {
+            XCTAssertEqual(
+                actual[index],
+                expected[index],
+                accuracy: 1e-12,
+                "cycle \(index) differs",
+                file: file,
+                line: line
+            )
+        }
+    }
+
+    func testHistoricalRemainingUsageMatchesRetiredAlgorithmOnSortedLanes() {
+        let map = heatmap()
+        for seed in UInt64(1)...6 {
+            let lane = syntheticLane(seed: seed, cycleCount: 24, shuffled: false)
+            for progress in [0.0, 0.05, 0.31, 0.5, 0.78, 1.0] {
+                assertEquivalent(
+                    cycles: lane.cycles,
+                    observations: lane.observations,
+                    currentProgress: progress,
+                    activityHeatmap: map
+                )
+            }
+        }
+    }
+
+    func testHistoricalRemainingUsageMatchesRetiredAlgorithmWithoutAHeatmap() {
+        for seed in UInt64(11)...14 {
+            let lane = syntheticLane(seed: seed, cycleCount: 18, shuffled: false)
+            for progress in [0.0, 0.22, 0.63, 1.0] {
+                assertEquivalent(
+                    cycles: lane.cycles,
+                    observations: lane.observations,
+                    currentProgress: progress,
+                    activityHeatmap: nil
+                )
+            }
+        }
+    }
+
+    /// The retired code filtered the lane in whatever order it arrived, so an
+    /// out-of-order lane picked the first minimum in *input* order. The new
+    /// walk sorts once and breaks distance ties on the original position for
+    /// exactly that reason.
+    func testHistoricalRemainingUsageMatchesRetiredAlgorithmOnOutOfOrderLanes() {
+        let map = heatmap()
+        for seed in UInt64(21)...26 {
+            let lane = syntheticLane(seed: seed, cycleCount: 20, shuffled: true)
+            for progress in [0.0, 0.17, 0.5, 0.91, 1.0] {
+                assertEquivalent(
+                    cycles: lane.cycles,
+                    observations: lane.observations,
+                    currentProgress: progress,
+                    activityHeatmap: map
+                )
+                assertEquivalent(
+                    cycles: lane.cycles,
+                    observations: lane.observations,
+                    currentProgress: progress,
+                    activityHeatmap: nil
+                )
+            }
+        }
+    }
+
+    func testHistoricalRemainingUsageMatchesOnEmptyAndDegenerateInputs() {
+        let lane = syntheticLane(seed: 31, cycleCount: 6, shuffled: false)
+        assertEquivalent(cycles: [], observations: lane.observations, currentProgress: 0.4, activityHeatmap: nil)
+        assertEquivalent(cycles: lane.cycles, observations: [], currentProgress: 0.4, activityHeatmap: nil)
+        assertEquivalent(cycles: [], observations: [], currentProgress: 0.4, activityHeatmap: nil)
+        // Cycles whose observations were all pruned away fall back to
+        // `peak * (1 - progress)`; keep that path covered explicitly.
+        let shift: TimeInterval = -90 * 86_400
+        let orphaned = lane.cycles.map { sample -> SubscriptionWindowSample in
+            cycle(
+                start: sample.windowStart.map { start in start.addingTimeInterval(shift) },
+                firstSeenAt: sample.firstSeenAt.addingTimeInterval(shift),
+                lastSeenAt: sample.lastSeenAt.addingTimeInterval(shift),
+                windowEnd: sample.windowEnd.addingTimeInterval(shift),
+                completedAt: sample.completedAt?.addingTimeInterval(shift),
+                peak: sample.peakUsedPercent
+            )
+        }
+        assertEquivalent(
+            cycles: orphaned,
+            observations: lane.observations,
+            currentProgress: 0.4,
+            activityHeatmap: nil
+        )
+    }
+
+    /// A refill inside the retention window: the point that *detected* the
+    /// refill is stamped a shade before `completedAt` and belongs to the next
+    /// cycle, which is why the scan is bounded by `lastSeenAt`. Both
+    /// implementations must agree about that boundary.
+    func testHistoricalRemainingUsageAgreesAcrossARefillBoundary() {
+        let start = epoch.addingTimeInterval(-5 * 3_600)
+        let lastSeen = start.addingTimeInterval(4 * 3_600)
+        let completed = lastSeen.addingTimeInterval(60)
+        let observations = [
+            point(5, at: start.addingTimeInterval(600)),
+            point(28, at: start.addingTimeInterval(2 * 3_600)),
+            point(60, at: lastSeen),
+            // The refill reading: after `lastSeenAt`, before `completedAt`.
+            point(5, at: lastSeen.addingTimeInterval(30))
+        ]
+        let cycles = [cycle(
+            start: start,
+            firstSeenAt: start,
+            lastSeenAt: lastSeen,
+            windowEnd: start.addingTimeInterval(5 * 3_600),
+            completedAt: completed,
+            peak: 60
+        )]
+        for progress in [0.0, 0.25, 0.5, 0.75, 1.0] {
+            assertEquivalent(
+                cycles: cycles,
+                observations: observations,
+                currentProgress: progress,
+                activityHeatmap: nil
+            )
+        }
+    }
+
+    // MARK: - The rest of the pass
+
+    /// `compute` replaced `observations.filter { … }.sorted { … }` with an
+    /// index range over the same lane. It has to select the same points.
+    func testCurrentWindowSliceMatchesTheRetiredFilter() {
+        for shuffled in [false, true] {
+            let lane = syntheticLane(seed: 41, cycleCount: 12, shuffled: shuffled)
+            let observationLane = QuotaPaceForecast.ObservationLane(lane.observations)
+            let windowStart = epoch.addingTimeInterval(-5 * 3_600)
+            let evaluationDate = epoch.addingTimeInterval(-1_800)
+            let lower = observationLane.lowerBound(windowStart.addingTimeInterval(-300))
+            let upper = observationLane.upperBound(evaluationDate.addingTimeInterval(60))
+            let ranks = lower..<max(lower, upper)
+            let expected = referenceCurrentPoints(
+                observations: lane.observations,
+                windowStart: windowStart,
+                evaluationDate: evaluationDate
+            )
+            XCTAssertEqual(ranks.count, expected.count)
+            guard ranks.count == expected.count else { continue }
+            for (offset, rank) in ranks.enumerated() {
+                XCTAssertEqual(observationLane.sampledAt(atRank: rank), expected[offset].sampledAt)
+            }
+        }
+    }
+
+    /// End-to-end: the lane's storage order must not reach the forecast. A
+    /// shuffled lane and its sorted twin have to produce the same forecast.
+    func testForecastIsIndependentOfObservationStorageOrder() throws {
+        let lane = syntheticLane(seed: 51, cycleCount: 20, shuffled: false)
+        var shuffledPoints = lane.observations
+        var random = Random(seed: 777)
+        for index in stride(from: shuffledPoints.count - 1, to: 0, by: -1) {
+            shuffledPoints.swapAt(index, random.int(0...index))
+        }
+        let bucket = QuotaBucket(
+            id: "five_hour",
+            title: "5-hour",
+            shortLabel: "5h",
+            usedPercent: 46,
+            resetAt: epoch.addingTimeInterval(2 * 3_600),
+            rawWindowSeconds: 5 * 3_600
+        )
+        let sorted = try XCTUnwrap(QuotaPaceForecast.compute(
+            bucket: bucket,
+            observations: lane.observations,
+            cycles: lane.cycles,
+            activityHeatmap: heatmap(),
+            now: epoch,
+            calendar: Calendar(identifier: .gregorian)
+        ))
+        let shuffled = try XCTUnwrap(QuotaPaceForecast.compute(
+            bucket: bucket,
+            observations: shuffledPoints,
+            cycles: lane.cycles,
+            activityHeatmap: heatmap(),
+            now: epoch,
+            calendar: Calendar(identifier: .gregorian)
+        ))
+        XCTAssertEqual(sorted, shuffled)
+    }
+
+    /// Prewarming the hour table is a performance change, so a profile that
+    /// was prepared over a wide span must answer exactly like one that grew on
+    /// demand, to within the association error of the prefix sums it walks.
+    func testPreparingTheHourTableDoesNotChangeWeights() {
+        let map = heatmap()
+        let calendar = Calendar(identifier: .gregorian)
+        let lazyProfile = QuotaPaceForecast.ActivityProfile(heatmap: map, calendar: calendar)
+        let eagerProfile = QuotaPaceForecast.ActivityProfile(heatmap: map, calendar: calendar)
+        eagerProfile.prepare(
+            from: epoch.addingTimeInterval(-60 * 86_400),
+            to: epoch.addingTimeInterval(86_400)
+        )
+        var random = Random(seed: 123)
+        for _ in 0..<200 {
+            let start = epoch.addingTimeInterval(-random.double(0, 55 * 86_400))
+            let end = start.addingTimeInterval(random.double(60, 6 * 86_400))
+            XCTAssertEqual(
+                eagerProfile.weight(from: start, to: end),
+                lazyProfile.weight(from: start, to: end),
+                accuracy: 1e-9
+            )
+        }
+    }
+
+    /// A span wider than one table falls back to the chunked path, which is
+    /// what keeps a corrupt stored date from asking for a giant array.
+    func testPreparingAnAbsurdSpanIsIgnored() {
+        let profile = QuotaPaceForecast.ActivityProfile(
+            heatmap: heatmap(),
+            calendar: Calendar(identifier: .gregorian)
+        )
+        profile.prepare(from: Date(timeIntervalSince1970: 0), to: epoch)
+        // Still answers, via the chunked walk in `weight(from:to:)`.
+        XCTAssertGreaterThan(
+            profile.weight(from: epoch.addingTimeInterval(-3_600), to: epoch),
+            0
+        )
+    }
+
+    // MARK: - The quantized forecast clock
+
+    func testForecastClockFloorsToFiveMinutes() {
+        let quantum = QuotaService.paceForecastClockQuantumSeconds
+        XCTAssertEqual(quantum, 300)
+        let base = Date(timeIntervalSince1970: 1_800_000_000)
+        XCTAssertEqual(QuotaService.quantizedForecastClock(base), base)
+        for offset in [1.0, 59.0, 299.0, 299.999] {
+            XCTAssertEqual(
+                QuotaService.quantizedForecastClock(base.addingTimeInterval(offset)),
+                base
+            )
+        }
+        XCTAssertEqual(
+            QuotaService.quantizedForecastClock(base.addingTimeInterval(300)),
+            base.addingTimeInterval(300)
+        )
+        // Never rounds forward, including before the epoch.
+        let negative = Date(timeIntervalSince1970: -1)
+        XCTAssertLessThanOrEqual(QuotaService.quantizedForecastClock(negative), negative)
+    }
+}


### PR DESCRIPTION
## Summary

Main-thread hitch fix from the 2026-09-03 audit. Measured on the maintainer's Mac before this change: a 30 s idle `sample` had 7.6% of main-thread time under `ProviderBucketRow.body → QuotaService.paceForecast → QuotaPaceForecast.compute`, with a 5 s sample catching a single ~0.5 s burst (AGENTS.md § 7 blocker is ≥ 100 ms).

- **`QuotaPaceForecast.historicalRemainingUsage`** was O(cycles × observations) with a struct copy per visit (claude/five_hour: 204 × 7,327). Rewritten as a per-cycle binary search over the already-sorted lane, indexing instead of copying, plus one hour table per `compute`. 164.8 ms → 5.1 ms per call on the real lane. `QuotaPaceForecastEquivalenceTests` carries the retired algorithm as an oracle and compares element-wise (1e-12) on seeded lanes including out-of-order/duplicate timestamps, early refills, empty and degenerate cycles.
- **`QuotaService.paceForecast`** now floors `now` to a 5-minute grid before memo lookup/compute (reset boundary stays exact), and the memo is keyed by data generation (limit 16 within a generation). `StatusItemController`, `MCPController`, `ResetsPage`, mini windows and `UpcomingResets` hit it with no call-site change.
- **Clocks**: new `PageClock`/`StableClock` (`PopoverPresentation.swift`) with a process-wide 5-minute-floored phase. `ProviderBucketRow` no longer owns a `TimelineView`; one clock per quota card / page / mini-window layout, `now` passed down as data. `PageClock` stops ticking while the popover is hidden (`PopoverPresentation` injected by `StatusItemController`, no teardown) and degrades to always-on outside a popover. `HeaderView`'s last per-body `TimelineView` is converted too.
- **Charts**: hover/crosshair/pan/zoom moved into `.chartOverlay` children so pointer movement does not re-run the clip → budget → thin → build pipeline; `PlanCache` keyed on `(seriesRevision, bucketIds, visibleRange)`; `Int` point ids; per-chart budget of 900 marks (single-bucket chart was ~2,080); `OverviewQuotaChartBody` is `Equatable` so unrelated `QuotaService`/`SettingsStore` publishes stop there.
- **Heatmaps**: yearly contribution and activity grids are one `Canvas` each with one hover tooltip and an accessibility summary (~539 rect views and as many `.help()` nodes removed).
- `ModelRankingList` computes its total once and is lazy; `UsageBreakdownTables`, `ServiceStatusCard`, `FillTimelineChart` no longer re-derive per body pass; `refreshSubscriptionHistory` is one actor hop.

## Test plan

- [x] `swift build`
- [x] `swift test` — 1792 tests, 0 failures (10 new equivalence tests)
- [ ] After install: popover countdowns tick and resume with a fresh value after close → reopen; mini windows keep ticking with the popover closed; chart hover/pan/zoom/brush still work; heatmap tooltips change per cell; idle CPU with popover closed < 0.5% (was ~4%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)