### PR TITLE
Explain each misc provider's credential and surface adapter diagnostics

### DIFF
--- a/Sources/VibeBarApp/Views/MiscProviderLandingView.swift
+++ b/Sources/VibeBarApp/Views/MiscProviderLandingView.swift
@@ -14,6 +14,7 @@ struct MiscProviderLandingView: View {
 
     @State private var isImporting = false
     @State private var outcomes: [MiscCookieResolver.BatchImportOutcome] = []
+    @State private var cooldowns: [BrowserCookieAccessGate.Cooldown] = []
 
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
@@ -63,6 +64,8 @@ struct MiscProviderLandingView: View {
                         }
                     }
                 }
+
+                cooldownControls
             }
 
             Divider()
@@ -75,7 +78,45 @@ struct MiscProviderLandingView: View {
                 .font(.caption2)
                 .foregroundStyle(.tertiary)
         }
+        .onAppear { cooldowns = BrowserCookieAccessGate.activeCooldowns() }
     }
+
+    /// Declining a Chromium "Safe Storage" prompt parks that browser for
+    /// six hours, and every import in the meantime honestly finds nothing —
+    /// which used to be reported as "no signed-in session found". Show the
+    /// suppression and the way out of it.
+    @ViewBuilder
+    private var cooldownControls: some View {
+        if !cooldowns.isEmpty {
+            Divider()
+                .padding(.vertical, 2)
+            ForEach(cooldowns, id: \.browserName) { cooldown in
+                HStack(alignment: .firstTextBaseline, spacing: 6) {
+                    Image(systemName: "lock.slash")
+                        .font(.caption2)
+                        .foregroundStyle(.orange)
+                        .frame(width: 12)
+                    Text("macOS Keychain access for \(cooldown.browserName) was declined. Vibe Bar will not ask again until \(Self.timeFormatter.string(from: cooldown.until)).")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                    Spacer(minLength: 6)
+                }
+            }
+            Button("Reset browser-cookie cooldown") {
+                BrowserCookieAccessGate.reset()
+                cooldowns = []
+            }
+            .controlSize(.small)
+        }
+    }
+
+    private static let timeFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateStyle = .none
+        f.timeStyle = .short
+        return f
+    }()
 
     private var autoImportBinding: Binding<Bool> {
         Binding(
@@ -113,6 +154,7 @@ struct MiscProviderLandingView: View {
             DispatchQueue.main.async {
                 isImporting = false
                 outcomes = results
+                cooldowns = BrowserCookieAccessGate.activeCooldowns()
                 // One refresh for the whole batch rather than one per
                 // provider — the quota service fans out on its own.
                 environment.refreshAll()
@@ -143,18 +185,19 @@ private struct OutcomeRow: View {
 
     private var symbol: String {
         switch outcome {
-        case .imported:        return "checkmark.circle"
-        case .noSessionFound:  return "minus.circle"
-        case .cookiesDisabled: return "slash.circle"
-        case .saveFailed:      return "exclamationmark.triangle"
+        case .imported:         return "checkmark.circle"
+        case .noSessionFound:   return "minus.circle"
+        case .keychainCooldown: return "lock.slash"
+        case .cookiesDisabled:  return "slash.circle"
+        case .saveFailed:       return "exclamationmark.triangle"
         }
     }
 
     private var tint: Color {
         switch outcome {
-        case .imported:                        return .green
+        case .imported:                         return .green
         case .noSessionFound, .cookiesDisabled: return .secondary
-        case .saveFailed:                      return .orange
+        case .keychainCooldown, .saveFailed:    return .orange
         }
     }
 
@@ -164,10 +207,22 @@ private struct OutcomeRow: View {
             return "Imported from \(sourceLabel)"
         case .noSessionFound:
             return "No signed-in session found"
+        case let .keychainCooldown(browser, until):
+            return "\(browser) Keychain access declined until \(Self.timeFormatter.string(from: until))"
         case .cookiesDisabled:
-            return "Cookies disabled for this provider"
+            // Reachable only through a hand-edited settings.json: the
+            // source-mode fields have no UI and every instance is created
+            // with `automaticSourceSelection`.
+            return "Cookie sources turned off in settings.json"
         case .saveFailed:
             return "Could not save to Keychain"
         }
     }
+
+    private static let timeFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateStyle = .none
+        f.timeStyle = .short
+        return f
+    }()
 }

--- a/Sources/VibeBarApp/Views/MiscProviderSettingsSection.swift
+++ b/Sources/VibeBarApp/Views/MiscProviderSettingsSection.swift
@@ -129,7 +129,7 @@ struct MiscProviderCredentialRows: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
             credentialControls
-            MiscProviderSetupNote(tool: tool)
+            MiscProviderSetupNote(tool: tool, instanceID: instanceID)
         }
     }
 
@@ -363,6 +363,11 @@ struct MiscProviderCredentialRows: View {
 /// to one field.
 struct MiscProviderSetupNote: View {
     let tool: ToolType
+    /// Read live from the store rather than from a snapshot, so switching
+    /// the Region picker re-points the console link in the same frame.
+    let instanceID: String
+
+    @EnvironmentObject var settingsStore: SettingsStore
 
     var body: some View {
         if let note = tool.miscSetupNote {
@@ -371,62 +376,31 @@ struct MiscProviderSetupNote: View {
                     .font(.caption)
                     .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)
-                Link(destination: tool.miscConsoleURL) {
-                    Text("\(tool.miscConsoleLinkTitle) →")
-                        .font(.caption)
+                // Two links when a region-aware provider is on "Auto":
+                // either console could be the one holding the credential.
+                ForEach(consoleLinks) { link in
+                    Link(destination: link.url) {
+                        Text("\(link.title) →")
+                            .font(.caption)
+                    }
+                    .buttonStyle(.plain)
+                    .foregroundStyle(Color.accentColor)
+                    .help(link.url.absoluteString)
                 }
-                .buttonStyle(.plain)
-                .foregroundStyle(Color.accentColor)
-                .help(tool.miscConsoleURL.absoluteString)
             }
             .padding(.top, 2)
         }
     }
+
+    private var consoleLinks: [MiscProviderConsole.Link] {
+        MiscProviderConsole.links(
+            for: tool,
+            settings: settingsStore.settings.miscProviderSettings(forInstanceID: instanceID)
+        )
+    }
 }
 
 extension ToolType {
-    /// Where the user goes to obtain or check this provider's credential.
-    ///
-    /// `statusPageURL` already points at the console for every misc
-    /// provider (including Agent Plan's `advancedActiveKey=agentPlan` deep
-    /// link); Copilot is the exception, whose entry there is GitHub's
-    /// status page rather than anything you can get a token from. Kept as
-    /// a local accessor so `ToolType.swift` stays untouched.
-    var miscConsoleURL: URL {
-        switch self {
-        case .copilot:
-            return URL(string: "https://github.com/settings/copilot")!
-        default:
-            return statusPageURL
-        }
-    }
-
-    /// Link label. Names the destination rather than saying "console" for
-    /// providers whose page is a product site or a settings screen.
-    var miscConsoleLinkTitle: String {
-        switch self {
-        case .alibaba, .alibabaTokenPlan:         return "Open Bailian console"
-        case .copilot:                            return "Open GitHub Copilot settings"
-        case .zai:                                return "Open z.ai"
-        case .minimax:                            return "Open platform.minimax.io"
-        case .kimi:                               return "Open kimi.com"
-        case .mimo:                               return "Open platform.xiaomimimo.com"
-        case .iflytek:                            return "Open maas.xfyun.cn"
-        case .tencentHunyuan, .tencentTokenPlan:  return "Open Tencent Cloud console"
-        case .volcengine:                         return "Open Ark console"
-        case .volcengineAgentPlan:                return "Open Agent Plan console"
-        case .baiduQianfan:                       return "Open Qianfan console"
-        case .openCodeGo:                         return "Open opencode.ai"
-        case .kilo:                               return "Open app.kilo.ai"
-        case .kiro:                               return "Open kiro.dev"
-        case .ollama:                             return "Open ollama.com"
-        case .openRouter:                         return "Open openrouter.ai"
-        case .warp:                               return "Open app.warp.dev"
-        case .codex, .claude, .gemini, .antigravity, .grok, .cursor:
-            return "Open status page"
-        }
-    }
-
     /// nil for the providers that have no misc-card credential row.
     var miscSetupNote: String? {
         switch self {

--- a/Sources/VibeBarApp/Views/MiscProviderSettingsSection.swift
+++ b/Sources/VibeBarApp/Views/MiscProviderSettingsSection.swift
@@ -16,6 +16,8 @@ struct MiscProviderSettingsSection: View {
     @EnvironmentObject var environment: AppEnvironment
     @EnvironmentObject var settingsStore: SettingsStore
 
+    @State private var isConfirmingRemoval = false
+
     private var tool: ToolType { instance.tool }
     private var instanceID: String { instance.id }
 
@@ -59,11 +61,25 @@ struct MiscProviderSettingsSection: View {
                         help: "Remove this \(tool.menuTitle) copy",
                         size: 10
                     ) {
-                        removeClone()
+                        isConfirmingRemoval = true
                     }
                 }
             }
             MiscProviderCredentialRows(instance: instance)
+        }
+        // Removing a copy also deletes its Keychain entries — the API key
+        // or AK/SK and every stored cookie slot — and none of that comes
+        // back. A one-click trash icon next to a Clone button is too easy
+        // to hit for something irreversible.
+        .confirmationDialog(
+            "Remove this \(tool.menuTitle) copy?",
+            isPresented: $isConfirmingRemoval,
+            titleVisibility: .visible
+        ) {
+            Button("Remove Copy", role: .destructive, action: removeClone)
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("Its saved credentials are deleted from your Keychain — the API key or AK/SK and every imported cookie slot. This cannot be undone.")
         }
     }
 
@@ -110,12 +126,24 @@ struct MiscProviderCredentialRows: View {
     private var tool: ToolType { instance.tool }
     private var instanceID: String { instance.id }
 
-    @ViewBuilder
     var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            credentialControls
+            MiscProviderSetupNote(tool: tool)
+        }
+    }
+
+    @ViewBuilder
+    private var credentialControls: some View {
         switch tool {
         case .zai:
             VStack(alignment: .leading, spacing: 4) {
-                ApiKeyField(tool: .zai, instanceID: instanceID, prompt: "Paste Z.ai API key (zai-...)", helpText: "Find it under z.ai → API Keys. Stored in macOS Keychain.")
+                ApiKeyField(
+                    tool: .zai,
+                    instanceID: instanceID,
+                    prompt: "Paste Z.ai API key (zai-...)",
+                    helpText: "Find it under API Keys on z.ai (Global) or open.bigmodel.cn (China mainland). Stored in macOS Keychain."
+                )
                 ZaiRegionPicker(instanceID: instanceID)
             }
         case .copilot:
@@ -186,12 +214,6 @@ struct MiscProviderCredentialRows: View {
                 instanceID: instanceID,
                 manualPrompt: "Paste www.kimi.com Cookie header (kimi-auth=eyJ...)"
             )
-        case .cursor:
-            CookieSourceControls(
-                tool: .cursor,
-                instanceID: instanceID,
-                manualPrompt: "Paste cursor.com Cookie header (WorkosCursorSessionToken=...)"
-            )
         case .mimo:
             VStack(alignment: .leading, spacing: 4) {
                 CookieSourceControls(
@@ -248,7 +270,7 @@ struct MiscProviderCredentialRows: View {
                 MiscWebLoginRow(
                     tool: .volcengine,
                     instanceID: instanceID,
-                    helpText: "Volcengine console session cookies expire after a few hours. When the card flips to \"Needs re-login\", click here to refresh."
+                    helpText: "Coding Plan reads a Volcengine console session — there is no API key for it. Sign in here, or paste the header above; either way it must carry csrfToken, which the Ark console sets on its first request. Console cookies expire after a few hours."
                 )
             }
         case .volcengineAgentPlan:
@@ -256,7 +278,7 @@ struct MiscProviderCredentialRows: View {
                 AkSkField(
                     tool: .volcengineAgentPlan,
                     instanceID: instanceID,
-                    helpText: "Agent Plan reads usage via Volcengine's official signed API — paste an AK/SK. Create an Access Key in the Volcengine console under Access Control / 访问控制 → API Access Key (a sub-user key with Ark read access works)."
+                    helpText: "Agent Plan reads usage through Volcengine's signed OpenAPI, so it needs an Access Key pair from Console → Access Control (访问控制) → API Access Key — not the sk-… Ark inference key, and not a console login. A sub-user key with Ark read access is enough."
                 )
             }
         case .baiduQianfan:
@@ -284,13 +306,16 @@ struct MiscProviderCredentialRows: View {
                     instanceID: instanceID,
                     prompt: "Workspace ID or URL (optional, wrk_... or /workspace/wrk_.../go)"
                 )
+                Text("Only needed when the account owns more than one workspace — otherwise Vibe Bar uses the first one it finds.")
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
             }
         case .kilo:
             ApiKeyField(
                 tool: .kilo,
                 instanceID: instanceID,
                 prompt: "Paste Kilo API key (optional)",
-                helpText: "Optional. Vibe Bar also reads ~/.local/share/kilo/auth.json after `kilo login`. Env fallback: KILO_API_KEY."
+                helpText: "From app.kilo.ai → API Keys, and optional: Vibe Bar also reads the auth file `kilo login` writes under ~/.local/share/kilo/. Env fallback: KILO_API_KEY."
             )
         case .kiro:
             KiroStatusRow(instanceID: instanceID)
@@ -306,12 +331,10 @@ struct MiscProviderCredentialRows: View {
                     tool: .openRouter,
                     instanceID: instanceID,
                     prompt: "Paste OpenRouter API key (sk-or-v1-...)",
-                    helpText: "Stored in macOS Keychain. Env fallback: OPENROUTER_API_KEY."
+                    helpText: "From openrouter.ai → Keys; credit-read access is enough. Stored in macOS Keychain. Env fallback: OPENROUTER_API_KEY."
                 )
                 EnterpriseHostField(tool: .openRouter, instanceID: instanceID, prompt: "OpenRouter API URL (optional, defaults to https://openrouter.ai/api/v1)")
             }
-        case .antigravity:
-            AntigravityStatusRow(instanceID: instanceID)
         case .warp:
             ApiKeyField(
                 tool: .warp,
@@ -319,12 +342,134 @@ struct MiscProviderCredentialRows: View {
                 prompt: "Paste Warp API key (wk-...)",
                 helpText: "Open Warp → Settings → AI → API Keys to mint one. Stored in macOS Keychain. Env fallback: WARP_API_KEY, then WARP_TOKEN."
             )
-        case .grok:
-            // Partial-primary providers don't ship a misc-card UI;
-            // their settings live in the dedicated SettingsView panel.
+        case .codex, .claude, .gemini, .antigravity, .grok, .cursor:
+            // Partial-primary and primary providers don't ship a misc-card
+            // UI: `AppSettings` only builds instances for
+            // `isMiscPageProvider` tools, and their credentials live in the
+            // dedicated SettingsView panel. These cases exist purely to
+            // keep the switch exhaustive.
             EmptyView()
-        case .codex, .claude:
-            EmptyView()
+        }
+    }
+}
+
+/// One line per provider saying where its credential comes from, what
+/// Vibe Bar actually reads, and whether an API key exists for usage at
+/// all — plus a click-through to the page that issues it.
+///
+/// This lives beside the credential controls rather than inside them
+/// because several providers have two entry points (a key *and* a cookie
+/// jar) and the "which one do I need?" answer belongs to the provider, not
+/// to one field.
+struct MiscProviderSetupNote: View {
+    let tool: ToolType
+
+    var body: some View {
+        if let note = tool.miscSetupNote {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(note)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+                Link(destination: tool.miscConsoleURL) {
+                    Text("\(tool.miscConsoleLinkTitle) →")
+                        .font(.caption)
+                }
+                .buttonStyle(.plain)
+                .foregroundStyle(Color.accentColor)
+                .help(tool.miscConsoleURL.absoluteString)
+            }
+            .padding(.top, 2)
+        }
+    }
+}
+
+extension ToolType {
+    /// Where the user goes to obtain or check this provider's credential.
+    ///
+    /// `statusPageURL` already points at the console for every misc
+    /// provider (including Agent Plan's `advancedActiveKey=agentPlan` deep
+    /// link); Copilot is the exception, whose entry there is GitHub's
+    /// status page rather than anything you can get a token from. Kept as
+    /// a local accessor so `ToolType.swift` stays untouched.
+    var miscConsoleURL: URL {
+        switch self {
+        case .copilot:
+            return URL(string: "https://github.com/settings/copilot")!
+        default:
+            return statusPageURL
+        }
+    }
+
+    /// Link label. Names the destination rather than saying "console" for
+    /// providers whose page is a product site or a settings screen.
+    var miscConsoleLinkTitle: String {
+        switch self {
+        case .alibaba, .alibabaTokenPlan:         return "Open Bailian console"
+        case .copilot:                            return "Open GitHub Copilot settings"
+        case .zai:                                return "Open z.ai"
+        case .minimax:                            return "Open platform.minimax.io"
+        case .kimi:                               return "Open kimi.com"
+        case .mimo:                               return "Open platform.xiaomimimo.com"
+        case .iflytek:                            return "Open maas.xfyun.cn"
+        case .tencentHunyuan, .tencentTokenPlan:  return "Open Tencent Cloud console"
+        case .volcengine:                         return "Open Ark console"
+        case .volcengineAgentPlan:                return "Open Agent Plan console"
+        case .baiduQianfan:                       return "Open Qianfan console"
+        case .openCodeGo:                         return "Open opencode.ai"
+        case .kilo:                               return "Open app.kilo.ai"
+        case .kiro:                               return "Open kiro.dev"
+        case .ollama:                             return "Open ollama.com"
+        case .openRouter:                         return "Open openrouter.ai"
+        case .warp:                               return "Open app.warp.dev"
+        case .codex, .claude, .gemini, .antigravity, .grok, .cursor:
+            return "Open status page"
+        }
+    }
+
+    /// nil for the providers that have no misc-card credential row.
+    var miscSetupNote: String? {
+        switch self {
+        case .alibaba:
+            return "The console session is read from bailian.console.aliyun.com (or modelstudio.console.alibabacloud.com internationally); Region has to match the account that owns the plan. A DashScope key is optional and is tried first when present."
+        case .alibabaTokenPlan:
+            return "Same Aliyun login as the Coding Plan card, a different subscription. Token Plan usage is only exposed to the console session — there is no DashScope key for it."
+        case .copilot:
+            return "Sign-in runs GitHub's device flow and Vibe Bar keeps only the OAuth token it returns; no cookies are read. Set the Enterprise host if the seat lives on GitHub Enterprise Server."
+        case .zai:
+            return "Mint the key under API Keys on z.ai (Global) or on open.bigmodel.cn (China mainland), then set Region to match — a key issued on one host returns nothing on the other. \"Auto\" tries both."
+        case .minimax:
+            return "The Token Plan key is under Billing → Token Plan (platform.minimax.io, or minimaxi.com in China mainland). A general MiniMax platform key authenticates but reports no Token Plan quota."
+        case .kimi:
+            return "Sign in at www.kimi.com in your browser, then import: Vibe Bar keeps the kimi-auth and kimi-refresh values (Chrome stores them in localStorage, which the importer also reads). Kimi publishes no API key for Coding Plan usage."
+        case .mimo:
+            return "Sign in at platform.xiaomimimo.com; Vibe Bar keeps userId, api-platform_slh, api-platform_ph and api-platform_serviceToken. There is no API key for Token Plan usage."
+        case .iflytek:
+            return "Sign in at maas.xfyun.cn with the account that owns the Coding Plan. The usage API checks HttpOnly tickets, so the whole maas.xfyun.cn / passport.xfyun.cn jar is kept rather than a few named cookies. No API key exposes this usage."
+        case .tencentHunyuan:
+            return "Sign in at console.cloud.tencent.com. The usage call needs the console's skey and uin cookies, and skey expires within hours — expect to refresh the session more often than other providers. No API key exposes Coding Plan usage."
+        case .tencentTokenPlan:
+            return "Same Tencent Cloud login as the Coding Plan card, a different subscription. It needs the same skey and uin console cookies, and there is no API key for Token Plan usage."
+        case .volcengine:
+            return "Coding Plan is read from a Volcengine console session (Sign in via Web, or paste the console.volcengine.com Cookie header) and the header must include csrfToken, which only appears once the Ark console has been opened in that browser. There is no API key for it. The Agent Plan is a separate subscription with a separate credential — set it up on the Volcengine Agent Plan card."
+        case .volcengineAgentPlan:
+            return "Agent Plan is read through Volcengine's signed OpenAPI, so it needs an Access Key pair (Console → Access Control (访问控制) → API Access Key) — not the sk-… Ark inference key, and not a console login. The Coding Plan is a separate subscription read from console cookies — set it up on the Volcengine Coding Plan card."
+        case .baiduQianfan:
+            return "Sign in at console.bce.baidu.com with the Baidu Cloud account that owns the Coding Plan; Vibe Bar keeps the BCE console jar. There is no API key for this usage endpoint."
+        case .openCodeGo:
+            return "Sign in at opencode.ai in your browser, then import: Vibe Bar keeps the __Host-auth (or auth) cookie. There is no API key for Go usage."
+        case .kilo:
+            return "The key comes from app.kilo.ai → API Keys and is optional — `kilo login` writes an auth file Vibe Bar reads instead."
+        case .kiro:
+            return "Kiro has neither a key to paste nor a cookie to import: Vibe Bar shells out to the locally installed kiro-cli. Install it from kiro.dev, run `kiro-cli login` in Terminal, then Probe."
+        case .ollama:
+            return "Ollama Cloud usage is only exposed to a signed-in web session — there is no API key for it. Sign in at ollama.com, then import; Vibe Bar keeps the session (or next-auth.session-token) cookie."
+        case .openRouter:
+            return "The key comes from openrouter.ai → Keys and only needs to read credits. Set the API URL when you route OpenRouter through a proxy."
+        case .warp:
+            return "The key is minted inside Warp itself: Warp → Settings → AI → API Keys."
+        case .codex, .claude, .gemini, .antigravity, .grok, .cursor:
+            return nil
         }
     }
 }
@@ -420,6 +565,7 @@ struct ApiKeyField: View {
     @State private var draft: String = ""
     @State private var hasStored: Bool = false
     @State private var saveError: String?
+    @State private var saveWarning: String?
 
     var body: some View {
         VStack(alignment: .leading, spacing: 4) {
@@ -448,6 +594,13 @@ struct ApiKeyField: View {
                 Text(saveError)
                     .font(.caption2)
                     .foregroundStyle(.orange)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            if let saveWarning {
+                Text(saveWarning)
+                    .font(.caption2)
+                    .foregroundStyle(.orange)
+                    .fixedSize(horizontal: false, vertical: true)
             }
         }
         .onAppear { hasStored = MiscCredentialStore.hasValue(tool: tool, kind: .apiKey, instanceID: instanceID) }
@@ -456,9 +609,19 @@ struct ApiKeyField: View {
     private func save() {
         let trimmed = draft.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return }
+        // Shape-check before writing: a key that is silently the wrong kind
+        // used to be stored, shown as saved, and only fail later on a
+        // different screen.
+        let verdict = MiscCredentialFieldRules.check(tool: tool, kind: .apiKey, value: trimmed)
+        guard verdict.allowsSave else {
+            saveWarning = nil
+            saveError = verdict.message
+            return
+        }
         let ok = MiscCredentialStore.writeString(trimmed, tool: tool, kind: .apiKey, instanceID: instanceID)
         if ok {
             saveError = nil
+            saveWarning = verdict.message
             hasStored = true
             draft = ""
             triggerRefresh()
@@ -470,6 +633,8 @@ struct ApiKeyField: View {
     private func clear() {
         MiscCredentialStore.delete(tool: tool, kind: .apiKey, instanceID: instanceID)
         hasStored = false
+        saveError = nil
+        saveWarning = nil
         triggerRefresh()
     }
 
@@ -494,6 +659,7 @@ struct AkSkField: View {
     @State private var skDraft: String = ""
     @State private var hasStored: Bool = false
     @State private var saveError: String?
+    @State private var saveWarning: String?
 
     var body: some View {
         VStack(alignment: .leading, spacing: 4) {
@@ -524,6 +690,13 @@ struct AkSkField: View {
                 Text(saveError)
                     .font(.caption2)
                     .foregroundStyle(.orange)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            if let saveWarning {
+                Text(saveWarning)
+                    .font(.caption2)
+                    .foregroundStyle(.orange)
+                    .fixedSize(horizontal: false, vertical: true)
             }
         }
         .onAppear {
@@ -536,10 +709,20 @@ struct AkSkField: View {
         let ak = akDraft.trimmingCharacters(in: .whitespacesAndNewlines)
         let sk = skDraft.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !ak.isEmpty, !sk.isEmpty else { return }
+        // Pasting the `sk-…` Ark inference key here is the single most
+        // common Agent Plan setup mistake, and it used to look like a
+        // success until the card came back with an auth error.
+        let verdict = MiscCredentialFieldRules.check(tool: tool, kind: .accessKeyID, value: ak)
+        guard verdict.allowsSave else {
+            saveWarning = nil
+            saveError = verdict.message
+            return
+        }
         let savedAK = MiscCredentialStore.writeString(ak, tool: tool, kind: .accessKeyID, instanceID: instanceID)
         let savedSK = MiscCredentialStore.writeString(sk, tool: tool, kind: .secretAccessKey, instanceID: instanceID)
         if savedAK && savedSK {
             saveError = nil
+            saveWarning = verdict.message
             hasStored = true
             akDraft = ""
             skDraft = ""
@@ -553,6 +736,8 @@ struct AkSkField: View {
         MiscCredentialStore.delete(tool: tool, kind: .accessKeyID, instanceID: instanceID)
         MiscCredentialStore.delete(tool: tool, kind: .secretAccessKey, instanceID: instanceID)
         hasStored = false
+        saveError = nil
+        saveWarning = nil
         triggerRefresh()
     }
 
@@ -687,37 +872,6 @@ struct CopilotDeviceLoginRow: View {
     }
 }
 
-/// AntiGravity has no remote credential — it talks to a locally
-/// running language server. The settings row is a tiny status
-/// indicator + manual refresh; the real action happens on the misc
-/// card itself.
-struct AntigravityStatusRow: View {
-    let instanceID: String
-
-    @EnvironmentObject var environment: AppEnvironment
-    @EnvironmentObject var quotaService: QuotaService
-
-    var body: some View {
-        HStack(spacing: 6) {
-            Image(systemName: "info.circle")
-                .foregroundStyle(.secondary)
-                .font(.caption)
-            Text("Reads the locally running language_server_macos process. Open AntiGravity, then refresh.")
-                .font(.caption)
-                .foregroundStyle(.tertiary)
-            Spacer(minLength: 4)
-            Button("Probe", action: probe)
-                .buttonStyle(.bordered)
-                .controlSize(.small)
-        }
-    }
-
-    private func probe() {
-        guard let account = environment.accountStore.account(forMiscProviderInstanceID: instanceID) else { return }
-        Task { _ = await quotaService.refresh(account) }
-    }
-}
-
 /// Kiro is local-CLI only. The row mirrors AntiGravity's probe style
 /// but points users at the login command that creates the usable
 /// session.
@@ -767,6 +921,27 @@ struct CookieSourceControls: View {
     @State private var slots: [MiscCookieSlot] = []
     @State private var manualDraft: String = ""
     @State private var importStatus: String?
+    /// Set when the last import found nothing because macOS Keychain
+    /// access for a browser had been declined. Carries its own row with a
+    /// "Retry now" button, because the fix is a gate reset rather than
+    /// anything the user can do in the browser.
+    @State private var keychainCooldown: KeychainCooldownNotice?
+
+    struct KeychainCooldownNotice: Equatable {
+        let browser: String
+        let until: Date
+
+        var message: String {
+            "macOS Keychain access for \(browser) was declined. Vibe Bar will not ask again until \(Self.formatter.string(from: until))."
+        }
+
+        private static let formatter: DateFormatter = {
+            let f = DateFormatter()
+            f.dateStyle = .none
+            f.timeStyle = .short
+            return f
+        }()
+    }
 
     /// Which cookies to look for. Comes from `MiscCookieSpecCatalog`
     /// rather than the caller so this row and the all-providers batch
@@ -800,13 +975,14 @@ struct CookieSourceControls: View {
                     }
                 }
             }
-            HStack(spacing: 6) {
+            HStack(alignment: .top, spacing: 6) {
                 Button("Import from browser", action: importNow)
                     .buttonStyle(.bordered)
                     .controlSize(.small)
-                Text("Adds or refreshes the first signed-in browser profile found. Existing profiles stay stacked.")
+                Text("Adds or refreshes the first signed-in browser profile found; profiles already imported stay stacked, and this provider's quota is the average across every slot listed above. macOS may ask for your login-keychain password once per Chromium-family browser.")
                     .font(.caption)
                     .foregroundStyle(.tertiary)
+                    .fixedSize(horizontal: false, vertical: true)
             }
             HStack(spacing: 6) {
                 SecureField(manualPrompt, text: $manualDraft)
@@ -814,10 +990,25 @@ struct CookieSourceControls: View {
                 Button("Add", action: saveManual)
                     .disabled(manualDraft.isEmpty)
             }
+            if let keychainCooldown {
+                HStack(alignment: .firstTextBaseline, spacing: 6) {
+                    Image(systemName: "lock.slash")
+                        .font(.caption)
+                        .foregroundStyle(.orange)
+                    Text(keychainCooldown.message)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                    Button("Retry now", action: resetCooldownAndRetry)
+                        .buttonStyle(.bordered)
+                        .controlSize(.small)
+                }
+            }
             if let importStatus {
                 Text(importStatus)
                     .font(.caption)
                     .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
             }
         }
         .onAppear(perform: reloadSlots)
@@ -849,19 +1040,45 @@ struct CookieSourceControls: View {
     private func importNow() {
         guard let snapshotSpec = spec else { return }
         importStatus = "Importing…"
+        keychainCooldown = nil
         let snapshotInstanceID = instanceID
         DispatchQueue.global(qos: .userInitiated).async {
-            let result = MiscCookieResolver.appendBrowserImport(for: snapshotSpec, instanceID: snapshotInstanceID)
+            let result = MiscCookieResolver.appendBrowserImportOutcome(
+                for: snapshotSpec,
+                instanceID: snapshotInstanceID
+            )
             DispatchQueue.main.async {
-                if let result {
-                    importStatus = "Imported from \(result.sourceLabel)."
-                    reloadSlots()
-                    triggerRefresh()
-                } else {
-                    importStatus = "No cookies found. Sign in at the provider in your browser, then retry."
-                }
+                apply(result)
             }
         }
+    }
+
+    private func apply(_ result: MiscCookieResolver.BatchImportOutcome.Result) {
+        switch result {
+        case .imported(let sourceLabel):
+            keychainCooldown = nil
+            importStatus = "Imported from \(sourceLabel)."
+            reloadSlots()
+            triggerRefresh()
+        case .noSessionFound:
+            keychainCooldown = nil
+            importStatus = "No cookies found. Sign in at the provider in your browser, then retry."
+        case let .keychainCooldown(browser, until):
+            importStatus = nil
+            keychainCooldown = KeychainCooldownNotice(browser: browser, until: until)
+        case .cookiesDisabled:
+            keychainCooldown = nil
+            importStatus = "Cookie sources are turned off for this provider in settings.json."
+        case .saveFailed:
+            keychainCooldown = nil
+            importStatus = "Found a session, but could not save it to Keychain."
+        }
+    }
+
+    private func resetCooldownAndRetry() {
+        BrowserCookieAccessGate.reset()
+        keychainCooldown = nil
+        importNow()
     }
 
     private func saveManual() {
@@ -869,6 +1086,13 @@ struct CookieSourceControls: View {
         guard !trimmed.isEmpty else { return }
         guard let normalised = normalizedManualCookie(from: trimmed), !normalised.isEmpty else {
             importStatus = missingCookieMessage
+            return
+        }
+        // Providers that ship the whole jar can't lean on `requiredNames`
+        // to reject a useless paste, so check the one cookie their adapter
+        // actually reads out of the header before storing it.
+        if let rejection = MiscManualCookieRules.rejectionMessage(for: tool, header: normalised) {
+            importStatus = rejection
             return
         }
         let slot = MiscCookieSlot(
@@ -927,9 +1151,13 @@ struct CookieSourceControls: View {
 
     private var missingCookieMessage: String {
         guard let spec, !spec.requiredNames.isEmpty else {
-            return "No usable cookie found in pasted text."
+            let names = MiscManualCookieRules.requiredCookieNames(for: tool)
+            if !names.isEmpty {
+                return "No \(names.joined(separator: " or ")) cookie found in the pasted text — copy the whole Cookie header from the provider's console tab."
+            }
+            return "No usable cookie found in the pasted text — copy the whole Cookie header from the provider's console tab."
         }
-        return "No \(spec.requiredNames.sorted().joined(separator: ", ")) cookie found in pasted text."
+        return "No \(spec.requiredNames.sorted().joined(separator: ", ")) cookie found in the pasted text."
     }
 
     private func triggerRefresh() {
@@ -953,6 +1181,20 @@ private struct CookieSlotRow: View {
             Text(slot.sourceLabel)
                 .font(.caption)
                 .foregroundStyle(.primary)
+            // Where this slot's header came from. That is the slot state
+            // Settings actually has: per-slot quota outcomes are merged by
+            // `MiscQuotaAggregator` before they reach any store, so a
+            // per-slot health badge would have to be invented here.
+            Text(originLabel)
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+                .padding(.horizontal, 5)
+                .padding(.vertical, 1)
+                .background(
+                    Capsule(style: .continuous)
+                        .fill(Color.primary.opacity(0.07))
+                )
+                .help(originHelp)
             Spacer(minLength: 4)
             Text(Self.dateFormatter.string(from: slot.importedAt))
                 .font(.caption2)
@@ -976,6 +1218,25 @@ private struct CookieSlotRow: View {
         case .manual:         return "doc.on.clipboard"
         case .browserImport:  return "safari"
         case .autoRefresh:    return "arrow.clockwise.circle"
+        }
+    }
+
+    private var originLabel: String {
+        switch slot.origin {
+        case .manual:         return "Pasted"
+        case .browserImport:  return "Browser"
+        case .autoRefresh:    return "Auto-refreshed"
+        }
+    }
+
+    private var originHelp: String {
+        switch slot.origin {
+        case .manual:
+            return "Pasted by hand. Auto re-import never overwrites this slot."
+        case .browserImport:
+            return "Imported from this browser profile. \"Import from browser\" refreshes it in place."
+        case .autoRefresh:
+            return "Re-read from the browser automatically after the stored header stopped working."
         }
     }
 
@@ -1068,19 +1329,23 @@ struct TencentTokenPlanVariantPicker: View {
     }
 }
 
-/// Z.ai has separate international and mainland China quota hosts.
+/// Z.ai has separate international and mainland China quota hosts, and a
+/// key issued on one returns 401 on the other — indistinguishable from a
+/// bad key. "Auto" lets the adapter try the second host before giving up.
 struct ZaiRegionPicker: View {
     let instanceID: String
 
     @EnvironmentObject var settingsStore: SettingsStore
 
     enum Choice: String, CaseIterable, Identifiable {
+        case auto = ""
         case global
         case bigmodelCN = "bigmodel-cn"
 
         var id: String { rawValue }
         var label: String {
             switch self {
+            case .auto:       return "Auto (try both)"
             case .global:     return "Global (api.z.ai)"
             case .bigmodelCN: return "China mainland (open.bigmodel.cn)"
             }
@@ -1099,12 +1364,12 @@ struct ZaiRegionPicker: View {
     private var choiceBinding: Binding<Choice> {
         Binding(
             get: {
-                let raw = settingsStore.settings.miscProviderSettings(forInstanceID: instanceID).region ?? Choice.global.rawValue
-                return Choice(rawValue: raw) ?? .global
+                let raw = settingsStore.settings.miscProviderSettings(forInstanceID: instanceID).region ?? ""
+                return Choice(rawValue: raw) ?? .auto
             },
             set: { newValue in
                 var current = settingsStore.settings.miscProviderSettings(forInstanceID: instanceID)
-                current.region = newValue.rawValue
+                current.region = newValue == .auto ? nil : newValue.rawValue
                 settingsStore.settings.setMiscProviderInstanceSettings(current, forID: instanceID)
             }
         )

--- a/Sources/VibeBarApp/Views/MiscProvidersPage.swift
+++ b/Sources/VibeBarApp/Views/MiscProvidersPage.swift
@@ -66,7 +66,8 @@ private struct MiscProviderCard: View {
                 quota: environment.quota(for: instance),
                 liveError: quotaService.lastErrorByAccount[accountID],
                 lastUpdated: quotaService.lastUpdatedByAccount[accountID],
-                isCompact: false
+                isCompact: false,
+                instanceID: instance.id
             )
         }
     }
@@ -290,7 +291,8 @@ private struct MiscProviderInstanceStatusRow: View {
                 quota: environment.quota(for: instance),
                 liveError: quotaService.lastErrorByAccount[accountID],
                 lastUpdated: quotaService.lastUpdatedByAccount[accountID],
-                isCompact: true
+                isCompact: true,
+                instanceID: instance.id
             )
         }
         .padding(.leading, 6)
@@ -318,6 +320,10 @@ private struct MiscQuotaBody: View {
     let liveError: QuotaError?
     let lastUpdated: Date?
     let isCompact: Bool
+    /// The instance whose Settings row the buttons should open. Nil on the
+    /// grouped card, whose body is an average over several copies and so
+    /// belongs to no single row.
+    var instanceID: String?
 
     @EnvironmentObject var environment: AppEnvironment
     @EnvironmentObject var settingsStore: SettingsStore
@@ -422,13 +428,23 @@ private struct MiscQuotaBody: View {
         }
     }
 
+    /// Open Settings on this provider's own row rather than dumping the
+    /// user on whatever page Settings happened to show last.
+    private func openSettings() {
+        if let instanceID {
+            environment.showSettings(.miscProvider(instanceID))
+        } else {
+            environment.showSettingsWindow()
+        }
+    }
+
     private var setupState: some View {
         VStack(alignment: .leading, spacing: 8) {
             Text("Not configured.")
                 .font(.system(size: density.subtitleFontSize))
                 .foregroundStyle(.secondary)
             Button {
-                environment.showSettingsWindow()
+                openSettings()
             } label: {
                 HStack(spacing: 4) {
                     Image(systemName: "gearshape")
@@ -453,7 +469,7 @@ private struct MiscQuotaBody: View {
                     .fixedSize(horizontal: false, vertical: true)
             }
             Button {
-                environment.showSettingsWindow()
+                openSettings()
             } label: {
                 HStack(spacing: 4) {
                     Image(systemName: "gearshape")

--- a/Sources/VibeBarApp/Views/Onboarding/OnboardingStepViews.swift
+++ b/Sources/VibeBarApp/Views/Onboarding/OnboardingStepViews.swift
@@ -330,6 +330,10 @@ struct OnboardingBrowserCookiesStep: View {
             .font(.caption)
             .foregroundStyle(.secondary)
             .fixedSize(horizontal: false, vertical: true)
+        Text("This button covers the four plans above. The console-cookie plans on the next step have their own one-click batch import later, under Settings → Browser Cookies.")
+            .font(.caption)
+            .foregroundStyle(.secondary)
+            .fixedSize(horizontal: false, vertical: true)
     }
 
     private func providerRow(_ tool: ToolType, importing: Bool, saved: Bool, status: String?) -> some View {
@@ -405,6 +409,9 @@ struct OnboardingAPIKeyProvidersStep: View {
                 .help("Show \(instance.tool.menuTitle) on the Misc page")
                 ToolBrandBadge(tool: instance.tool, iconSize: 17, containerSize: 24)
                     .opacity(visible ? 1 : 0.55)
+                // `menuTitle` alone renders both Volcengine plans as
+                // "Volcengine"; the subtitle beside it is what separates
+                // Coding Plan from Agent Plan.
                 Text(instance.displayTitle(fallback: instance.tool.menuTitle))
                     .font(.system(size: 13, weight: .semibold))
                     .foregroundStyle(visible ? Color.primary : Color.secondary)

--- a/Sources/VibeBarApp/Views/Onboarding/OnboardingView.swift
+++ b/Sources/VibeBarApp/Views/Onboarding/OnboardingView.swift
@@ -19,7 +19,7 @@ enum OnboardingStep: String, CaseIterable, Identifiable {
         case .welcome: "Welcome"
         case .subscriptions: "Subscriptions"
         case .browserCookies: "Browser cookies"
-        case .apiKeyProviders: "API-key providers"
+        case .apiKeyProviders: "Other plans"
         case .pricing: "Model pricing"
         case .launchAtLogin: "Launch at login"
         case .done: "All set"

--- a/Sources/VibeBarApp/Views/SettingsSidebarView.swift
+++ b/Sources/VibeBarApp/Views/SettingsSidebarView.swift
@@ -154,11 +154,62 @@ struct SettingsSidebarView: View {
     }
 
     private var filteredMiscProviders: [MiscProviderInstance] {
-        settingsStore.settings.miscProviderInstances.filter { instance in
-            let title = instance.displayTitle(fallback: instance.tool.menuTitle)
-            return searchText.isEmpty
-                || title.localizedCaseInsensitiveContains(searchText)
-                || instance.tool.vendorName.localizedCaseInsensitiveContains(searchText)
+        guard !searchText.isEmpty else { return settingsStore.settings.miscProviderInstances }
+        return settingsStore.settings.miscProviderInstances.filter { instance in
+            Self.searchTerms(for: instance).contains {
+                $0.localizedCaseInsensitiveContains(searchText)
+            }
+        }
+    }
+
+    /// Everything a user might type to find one misc row.
+    ///
+    /// `menuTitle` collapses the plan pairs — both Volcengine rows are
+    /// "Volcengine", both Bailian rows "Bailian" — so searching for the
+    /// thing that actually distinguishes them ("Agent Plan", "Token Plan")
+    /// used to match nothing. `displayName` and `subtitle` carry the plan;
+    /// the vendor aliases cover the brands whose console name differs from
+    /// the one Vibe Bar shows.
+    private static func searchTerms(for instance: MiscProviderInstance) -> [String] {
+        let tool = instance.tool
+        var terms = [
+            instance.displayTitle(fallback: tool.displayName),
+            tool.displayName,
+            tool.menuTitle,
+            tool.subtitle,
+            tool.productName,
+            tool.vendorName,
+            tool.statusProviderName
+        ]
+        terms.append(contentsOf: vendorAliases(for: tool))
+        return terms
+    }
+
+    /// Names users know a provider by that no `ToolType` field carries.
+    private static func vendorAliases(for tool: ToolType) -> [String] {
+        switch tool {
+        case .alibaba, .alibabaTokenPlan:
+            return ["DashScope", "Aliyun", "Model Studio", "阿里云", "百炼"]
+        case .volcengine, .volcengineAgentPlan:
+            return ["Doubao", "Ark", "ByteDance", "火山引擎", "豆包"]
+        case .tencentHunyuan, .tencentTokenPlan:
+            return ["TokenHub", "腾讯云", "混元"]
+        case .zai:
+            return ["Zhipu", "BigModel", "GLM", "智谱"]
+        case .baiduQianfan:
+            return ["Baidu", "BCE", "百度", "千帆"]
+        case .iflytek:
+            return ["Spark", "MaaS", "讯飞", "星火"]
+        case .mimo:
+            return ["Xiaomi", "小米"]
+        case .kimi:
+            return ["Moonshot", "月之暗面"]
+        case .copilot:
+            return ["GitHub"]
+        case .openCodeGo:
+            return ["OpenCode"]
+        default:
+            return []
         }
     }
 
@@ -220,7 +271,11 @@ struct SettingsSidebarView: View {
         let enabled = instance.isVisible
         return sidebarRow(
             destination: .miscProvider(instance.id),
-            title: instance.displayTitle(fallback: instance.tool.menuTitle),
+            // `menuTitle` is the L2 SubProvider, which is identical for the
+            // Coding Plan / Token Plan / Agent Plan pairs — two sidebar rows
+            // reading "Volcengine" with no way to tell which is which.
+            // `displayName` keeps the plan.
+            title: instance.displayTitle(fallback: instance.tool.displayName),
             icon: AnyView(ToolBrandIconView(tool: instance.tool, size: 17).frame(width: 20, height: 20)),
             enabled: enabled,
             showsStatusDot: true,

--- a/Sources/VibeBarCore/Adapters/GeminiQuotaAdapter.swift
+++ b/Sources/VibeBarCore/Adapters/GeminiQuotaAdapter.swift
@@ -135,7 +135,8 @@ public struct GeminiQuotaAdapter: QuotaAdapter {
             // response from the private RPC itself indicates a likely rotated
             // route/argument that WebKit can learn.
             return message.contains("Gemini Web batchexecute HTTP")
-        case .noCredential, .needsLogin, .rateLimited, .notImplemented, .unknown:
+        case .noCredential, .needsLogin, .credentialRejected,
+             .rateLimited, .notImplemented, .unknown:
             return false
         }
     }

--- a/Sources/VibeBarCore/Adapters/KiroQuotaAdapter.swift
+++ b/Sources/VibeBarCore/Adapters/KiroQuotaAdapter.swift
@@ -50,9 +50,12 @@ public struct KiroQuotaAdapter: QuotaAdapter {
         } catch KiroResponseParser.KiroError.notLoggedIn {
             throw QuotaError.needsLogin
         } catch KiroResponseParser.KiroError.cliFailed {
-            throw QuotaError.noCredential
+            // "Not configured" is what `.noCredential` renders, and it is
+            // wrong twice over here: the user *did* configure the card, and
+            // the actual problem is a CLI that ran but did not answer.
+            throw QuotaError.parseFailure(Self.cliFailedMessage)
         } catch KiroCLIRunner.Error.cliNotFound {
-            throw QuotaError.noCredential
+            throw QuotaError.parseFailure(Self.cliNotFoundMessage)
         } catch KiroCLIRunner.Error.timeout {
             throw QuotaError.network("Kiro CLI timed out.")
         } catch let error as KiroCLIRunner.Error {
@@ -64,12 +67,12 @@ public struct KiroQuotaAdapter: QuotaAdapter {
             case .notLoggedIn:
                 throw QuotaError.needsLogin
             case .cliFailed:
-                throw QuotaError.noCredential
+                throw QuotaError.parseFailure(Self.cliFailedMessage)
             }
         } catch let error as ProcessRunner.Error {
             switch error {
             case .binaryNotFound:
-                throw QuotaError.noCredential
+                throw QuotaError.parseFailure(Self.cliNotFoundMessage)
             case .timedOut:
                 throw QuotaError.network("Kiro CLI timed out.")
             case .launchFailed(let message):
@@ -81,6 +84,12 @@ public struct KiroQuotaAdapter: QuotaAdapter {
             throw QuotaError.parseFailure("Kiro usage output was not recognized.")
         }
     }
+
+    static let cliNotFoundMessage =
+        "kiro-cli is not installed. Install it from kiro.dev, then run `kiro-cli login`."
+
+    static let cliFailedMessage =
+        "kiro-cli ran but returned no usage. Run `kiro-cli login` in Terminal, then probe again."
 }
 
 enum KiroResponseParser {

--- a/Sources/VibeBarCore/Adapters/VolcengineAgentPlanQuotaAdapter.swift
+++ b/Sources/VibeBarCore/Adapters/VolcengineAgentPlanQuotaAdapter.swift
@@ -175,7 +175,10 @@ public struct VolcengineAgentPlanQuotaAdapter: QuotaAdapter {
         }
         guard http.statusCode == 200 else {
             if http.statusCode == 401 || http.statusCode == 403 {
-                throw QuotaError.needsLogin
+                // This card has no login of its own — it is signed with an
+                // Access Key pair — so "Needs re-login" pointed at a
+                // control that does not exist. Name the field instead.
+                throw QuotaError.credentialRejected(VolcengineAgentPlanQuotaAdapter.rejectedKeyMessage)
             }
             if http.statusCode == 429 {
                 throw QuotaError.rateLimited
@@ -190,6 +193,18 @@ public struct VolcengineAgentPlanQuotaAdapter: QuotaAdapter {
     // OpenAPI gateway — NOT the Ark inference host
     // `ark.cn-beijing.volces.com`, which rejects these management actions
     // with HTTP 401. Service `ark`, region `cn-beijing`.
+    /// Shown whenever Volcengine refuses the signature. Both the HTTP
+    /// status path and the `ResponseMetadata.Error` path use it so the card
+    /// says the same thing however the rejection arrives.
+    static let rejectedKeyMessage =
+        "Key rejected — check that the Access Key is current and has Ark read access. Agent Plan needs an Access Key pair from Access Control (访问控制) → API Access Key, not the sk-… Ark inference key."
+
+    /// Shown when the signed call succeeds but the account carries no
+    /// Agent Plan windows — the normal outcome of setting this card up on
+    /// a Coding Plan account.
+    static let noAgentPlanMessage =
+        "This Volcengine account has no Agent Plan subscription. If you bought the Coding Plan, set up the Volcengine Coding Plan card instead."
+
     private static let openAPIHost = "open.volcengineapi.com"
     private static let region = "cn-beijing"
     private static let service = "ark"
@@ -223,7 +238,9 @@ enum VolcengineAgentPlanResponseParser {
             let code = err.code?.lowercased() ?? ""
             let message = err.message?.trimmedNonEmpty ?? "code \(err.code ?? "?")"
             if isAuthCode(code) || message.lowercased().contains("login") {
-                throw QuotaError.needsLogin
+                throw QuotaError.credentialRejected(
+                    VolcengineAgentPlanQuotaAdapter.rejectedKeyMessage
+                )
             }
             if code.contains("requestlimit") || code.contains("ratelimit") {
                 throw QuotaError.rateLimited
@@ -232,7 +249,9 @@ enum VolcengineAgentPlanResponseParser {
         }
 
         guard let result = envelope.result else {
-            throw QuotaError.parseFailure("Volcengine Agent Plan response had no Result block.")
+            throw QuotaError.parseFailure(
+                VolcengineAgentPlanQuotaAdapter.noAgentPlanMessage
+            )
         }
 
         // The console shows 5-hour / weekly / monthly; `AFPDaily` is
@@ -249,7 +268,9 @@ enum VolcengineAgentPlanResponseParser {
             buckets.append(bucket)
         }
         guard !buckets.isEmpty else {
-            throw QuotaError.parseFailure("Volcengine Agent Plan response had no usable AFP windows.")
+            throw QuotaError.parseFailure(
+                VolcengineAgentPlanQuotaAdapter.noAgentPlanMessage
+            )
         }
 
         return UsageSnapshot(buckets: buckets, planName: planName(from: result.planType))

--- a/Sources/VibeBarCore/Adapters/VolcengineQuotaAdapter.swift
+++ b/Sources/VibeBarCore/Adapters/VolcengineQuotaAdapter.swift
@@ -98,8 +98,14 @@ public struct VolcengineQuotaAdapter: QuotaAdapter {
             // No `csrfToken` means the user signed in to volcengine.com
             // at the public-website level but never opened the console
             // — the cookie is set by the first console request after
-            // login.
-            throw QuotaError.needsLogin
+            // login. "Needs re-login" sent people back to a sign-in they
+            // had already done; say what actually creates the cookie.
+            // `.credentialRejected` is still a credential state, so the
+            // silent re-import and cached-quota grace period behave
+            // exactly as they did under `.needsLogin`.
+            throw QuotaError.credentialRejected(
+                "The imported Volcengine cookies have no csrfToken. Open the Ark console once in your browser (console.volcengine.com/ark), then re-import."
+            )
         }
 
         let usageData = try await callBFF(
@@ -215,11 +221,16 @@ enum VolcengineResponseParser {
             throw QuotaError.network("Volcengine: \(message)")
         }
 
+        // An account without a Coding Plan gets a well-formed 200 with an
+        // empty Result / QuotaUsage — the single most common way this card
+        // "fails", and almost always because the user bought the Agent
+        // Plan instead. Name the other card rather than blaming the
+        // response format.
         guard let result = envelope.result else {
-            throw QuotaError.parseFailure("Volcengine usage response had no Result block.")
+            throw QuotaError.parseFailure(Self.noCodingPlanMessage)
         }
         guard let usage = result.quotaUsage, !usage.isEmpty else {
-            throw QuotaError.parseFailure("Volcengine usage response had no QuotaUsage entries.")
+            throw QuotaError.parseFailure(Self.noCodingPlanMessage)
         }
 
         var buckets: [QuotaBucket] = []
@@ -228,10 +239,17 @@ enum VolcengineResponseParser {
             buckets.append(bucket)
         }
         guard !buckets.isEmpty else {
-            throw QuotaError.parseFailure("Volcengine usage response had no recognizable Levels.")
+            throw QuotaError.parseFailure(
+                "Volcengine returned Coding Plan windows Vibe Bar does not recognize (expected session, weekly, monthly)."
+            )
         }
         return UsageSnapshot(buckets: buckets)
     }
+
+    /// Shared by both empty-result paths — the message a user with only an
+    /// Agent Plan subscription sees on the Coding Plan card.
+    static let noCodingPlanMessage =
+        "This Volcengine account has no Coding Plan subscription. If you bought the Agent Plan, set up the Volcengine Agent Plan card instead."
 
     static func parsePlanName(data: Data) throws -> String? {
         guard !data.isEmpty else { return nil }

--- a/Sources/VibeBarCore/Adapters/WarpQuotaAdapter.swift
+++ b/Sources/VibeBarCore/Adapters/WarpQuotaAdapter.swift
@@ -201,7 +201,12 @@ public enum WarpResponseParser {
                 joined.lowercased().contains("unauthorized") {
                 throw QuotaError.needsLogin
             }
-            throw QuotaError.parseFailure(joined.isEmpty ? "Warp GraphQL error." : joined)
+            // Straight from the provider's response, so it is redacted at
+            // construction rather than only at the log / MCP sinks: a
+            // GraphQL error is free to name the account it refused.
+            throw QuotaError.parseFailure(
+                joined.isEmpty ? "Warp GraphQL error." : ProviderDiagnosticRedactor.redact(joined)
+            )
         }
 
         guard let dataObj = json["data"] as? [String: Any],

--- a/Sources/VibeBarCore/Adapters/ZaiQuotaAdapter.swift
+++ b/Sources/VibeBarCore/Adapters/ZaiQuotaAdapter.swift
@@ -48,17 +48,8 @@ public struct ZaiQuotaAdapter: QuotaAdapter {
             throw QuotaError.noCredential
         }
 
-        let snapshot: ZaiResponseParser.Snapshot
-        do {
-            snapshot = try await fetchSnapshot(url: settings.quotaURL, apiKey: apiKey)
-        } catch let error as QuotaError where Self.isWrongHostSignal(error) && settings.fallbackQuotaURL != nil {
-            // "Auto (try both)": a Global key on the mainland console (or
-            // the reverse) answers 401/403 or an empty body, which is
-            // indistinguishable from a bad key until we have tried the
-            // other host. Only Auto reaches here — an explicitly chosen
-            // region is honoured exactly as picked.
-            guard let fallback = settings.fallbackQuotaURL else { throw error }
-            snapshot = try await fetchSnapshot(url: fallback, apiKey: apiKey)
+        let snapshot = try await Self.resolveSnapshot(settings: settings) { url in
+            try await self.fetchSnapshot(url: url, apiKey: apiKey)
         }
         return AccountQuota(
             accountId: account.id,
@@ -103,6 +94,46 @@ public struct ZaiQuotaAdapter: QuotaAdapter {
         }
 
         return try ZaiResponseParser.parse(data: data, now: now())
+    }
+
+    /// The "Auto (try both)" retry, factored out of `fetch` so the decision
+    /// can be exercised without a network or a Keychain.
+    ///
+    /// Two things look identical from the wrong host, and only one of them
+    /// throws:
+    ///
+    /// - the host rejects the key outright (401/403, or an empty body), and
+    /// - the host answers a perfectly good HTTP 200 whose envelope carries
+    ///   no limits at all, because the key belongs to the other region.
+    ///
+    /// The second case used to end the fetch with zero buckets and no
+    /// error, which the card renders as "Not configured" — the fallback
+    /// host was never tried. Both now retry.
+    ///
+    /// If the other host also comes back empty we keep the *first* answer:
+    /// it was a successful 200, so it is the more authoritative "this
+    /// account has no quota" of the two. A throw from the retry is likewise
+    /// swallowed in favour of the first host's empty result, and only
+    /// surfaces when the first host threw as well.
+    static func resolveSnapshot(
+        settings: ZaiSettings,
+        fetch: (URL) async throws -> ZaiResponseParser.Snapshot
+    ) async throws -> ZaiResponseParser.Snapshot {
+        let first: ZaiResponseParser.Snapshot
+        do {
+            first = try await fetch(settings.quotaURL)
+        } catch let error as QuotaError where isWrongHostSignal(error) {
+            guard let fallback = settings.fallbackQuotaURL else { throw error }
+            return try await fetch(fallback)
+        }
+
+        guard first.buckets.isEmpty, let fallback = settings.fallbackQuotaURL else {
+            return first
+        }
+        guard let retried = try? await fetch(fallback), !retried.buckets.isEmpty else {
+            return first
+        }
+        return retried
     }
 
     /// Failures that could equally mean "right key, wrong host". Anything

--- a/Sources/VibeBarCore/Adapters/ZaiQuotaAdapter.swift
+++ b/Sources/VibeBarCore/Adapters/ZaiQuotaAdapter.swift
@@ -48,7 +48,30 @@ public struct ZaiQuotaAdapter: QuotaAdapter {
             throw QuotaError.noCredential
         }
 
-        let url = settings.quotaURL
+        let snapshot: ZaiResponseParser.Snapshot
+        do {
+            snapshot = try await fetchSnapshot(url: settings.quotaURL, apiKey: apiKey)
+        } catch let error as QuotaError where Self.isWrongHostSignal(error) && settings.fallbackQuotaURL != nil {
+            // "Auto (try both)": a Global key on the mainland console (or
+            // the reverse) answers 401/403 or an empty body, which is
+            // indistinguishable from a bad key until we have tried the
+            // other host. Only Auto reaches here — an explicitly chosen
+            // region is honoured exactly as picked.
+            guard let fallback = settings.fallbackQuotaURL else { throw error }
+            snapshot = try await fetchSnapshot(url: fallback, apiKey: apiKey)
+        }
+        return AccountQuota(
+            accountId: account.id,
+            tool: .zai,
+            buckets: snapshot.buckets,
+            plan: snapshot.planName,
+            email: account.email,
+            queriedAt: now(),
+            error: nil
+        )
+    }
+
+    private func fetchSnapshot(url: URL, apiKey: String) async throws -> ZaiResponseParser.Snapshot {
         var request = URLRequest(url: url)
         request.httpMethod = "GET"
         request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
@@ -66,7 +89,9 @@ public struct ZaiQuotaAdapter: QuotaAdapter {
         }
         guard http.statusCode == 200 else {
             if http.statusCode == 401 || http.statusCode == 403 {
-                throw QuotaError.needsLogin
+                // Z.ai is an API-key card with no login of its own, so
+                // "Needs re-login" pointed at a control that isn't there.
+                throw QuotaError.credentialRejected(Self.rejectedKeyMessage)
             }
             if http.statusCode == 429 {
                 throw QuotaError.rateLimited
@@ -77,23 +102,40 @@ public struct ZaiQuotaAdapter: QuotaAdapter {
             throw QuotaError.parseFailure("Z.ai returned an empty body — confirm the region (Global vs BigModel CN) and the API key.")
         }
 
-        let snapshot = try ZaiResponseParser.parse(data: data, now: now())
-        return AccountQuota(
-            accountId: account.id,
-            tool: .zai,
-            buckets: snapshot.buckets,
-            plan: snapshot.planName,
-            email: account.email,
-            queriedAt: now(),
-            error: nil
-        )
+        return try ZaiResponseParser.parse(data: data, now: now())
     }
+
+    /// Failures that could equally mean "right key, wrong host". Anything
+    /// else (network down, rate limit, a parseable error body) is reported
+    /// as-is rather than retried against the other region.
+    static func isWrongHostSignal(_ error: QuotaError) -> Bool {
+        switch error {
+        case .credentialRejected, .needsLogin:
+            return true
+        case .parseFailure(let message):
+            return message.contains("empty body")
+        case .noCredential, .network, .rateLimited, .notImplemented, .unknown:
+            return false
+        }
+    }
+
+    static let rejectedKeyMessage =
+        "Z.ai rejected the API key. Check the key and the Region picker — z.ai keys work on api.z.ai, open.bigmodel.cn keys on the China mainland host."
 }
 
 // MARK: - Region / endpoint resolution
 
 struct ZaiSettings {
     let quotaURL: URL
+    /// The other region's endpoint, set only when the user left Region on
+    /// "Auto (try both)". An explicit region, an enterprise host, or either
+    /// env override pins exactly one URL and leaves this nil.
+    var fallbackQuotaURL: URL?
+
+    init(quotaURL: URL, fallbackQuotaURL: URL? = nil) {
+        self.quotaURL = quotaURL
+        self.fallbackQuotaURL = fallbackQuotaURL
+    }
 
     static func resolve(
         environment: [String: String],
@@ -128,7 +170,12 @@ struct ZaiSettings {
             return ZaiSettings(quotaURL: region.quotaURL)
         }
 
-        return ZaiSettings(quotaURL: ZaiRegion.global.quotaURL)
+        // No region stored (fresh card, or "Auto" picked explicitly):
+        // start Global and keep the mainland host as the retry.
+        return ZaiSettings(
+            quotaURL: ZaiRegion.global.quotaURL,
+            fallbackQuotaURL: ZaiRegion.bigmodelCN.quotaURL
+        )
     }
 
     static func quotaURL(fromHost host: String) -> URL? {

--- a/Sources/VibeBarCore/BrowserCookies/BrowserCookieAccessGate.swift
+++ b/Sources/VibeBarCore/BrowserCookies/BrowserCookieAccessGate.swift
@@ -85,6 +85,52 @@ public enum BrowserCookieAccessGate {
         SafeLog.info("Browser cookie access denied for \(browser.displayName); cooldown until \(blockedUntil)")
     }
 
+    /// One browser currently inside its denial cooldown.
+    public struct Cooldown: Equatable, Sendable {
+        /// Human-readable browser name, e.g. "Google Chrome".
+        public let browserName: String
+        public let until: Date
+
+        public init(browserName: String, until: Date) {
+            self.browserName = browserName
+            self.until = until
+        }
+    }
+
+    /// When `browser` may be asked for cookies again, or `nil` if it is
+    /// not in a cooldown right now.
+    public static func blockedUntil(_ browser: Browser, now: Date = Date()) -> Date? {
+        lock.withLock { state in
+            loadIfNeeded(&state)
+            guard let blockedUntil = state.deniedUntilByBrowser[browser.rawValue],
+                  blockedUntil > now else { return nil }
+            return blockedUntil
+        }
+    }
+
+    /// Every browser currently suppressed, soonest expiry first.
+    ///
+    /// The import UI needs this because a cooldown looks exactly like "no
+    /// session found" from the outside: the gate short-circuits before
+    /// touching Keychain, so the importer honestly finds nothing and used
+    /// to tell the user to go sign in again — advice that could not
+    /// possibly help.
+    public static func activeCooldowns(now: Date = Date()) -> [Cooldown] {
+        let raw: [String: Date] = lock.withLock { state in
+            loadIfNeeded(&state)
+            return state.deniedUntilByBrowser
+        }
+        return raw
+            .filter { $0.value > now }
+            .map { key, value in
+                Cooldown(
+                    browserName: Browser(rawValue: key)?.displayName ?? key,
+                    until: value
+                )
+            }
+            .sorted { $0.until < $1.until }
+    }
+
     /// Wipe persisted denials. Exposed for the Settings panel "Reset
     /// browser-cookie cooldown" button as well as the test suite.
     public static func reset() {

--- a/Sources/VibeBarCore/BrowserCookies/BrowserCookieAccessGate.swift
+++ b/Sources/VibeBarCore/BrowserCookies/BrowserCookieAccessGate.swift
@@ -68,14 +68,20 @@ public enum BrowserCookieAccessGate {
 
     /// Record an explicit denial coming back from SweetCookieKit's
     /// own error path. Re-uses the same cooldown window.
-    public static func recordIfNeeded(_ error: Error, now: Date = Date()) {
-        guard let err = error as? BrowserCookieError else { return }
-        guard case .accessDenied = err else { return }
-        recordDenied(for: err.browser, now: now)
+    ///
+    /// Returns the cooldown it installed, so a caller that is classifying
+    /// one import attempt can tell "this browser refused us just now" from
+    /// "some browser is in a cooldown from an unrelated earlier import".
+    @discardableResult
+    public static func recordIfNeeded(_ error: Error, now: Date = Date()) -> Cooldown? {
+        guard let err = error as? BrowserCookieError else { return nil }
+        guard case .accessDenied = err else { return nil }
+        return recordDenied(for: err.browser, now: now)
     }
 
-    public static func recordDenied(for browser: Browser, now: Date = Date()) {
-        guard browser.usesKeychainForCookieDecryption else { return }
+    @discardableResult
+    public static func recordDenied(for browser: Browser, now: Date = Date()) -> Cooldown? {
+        guard browser.usesKeychainForCookieDecryption else { return nil }
         let blockedUntil = now.addingTimeInterval(cooldownInterval)
         lock.withLock { state in
             loadIfNeeded(&state)
@@ -83,6 +89,7 @@ public enum BrowserCookieAccessGate {
             persist(state)
         }
         SafeLog.info("Browser cookie access denied for \(browser.displayName); cooldown until \(blockedUntil)")
+        return Cooldown(browserName: browser.displayName, until: blockedUntil)
     }
 
     /// One browser currently inside its denial cooldown.

--- a/Sources/VibeBarCore/BrowserCookies/MiscCookieResolver.swift
+++ b/Sources/VibeBarCore/BrowserCookies/MiscCookieResolver.swift
@@ -211,11 +211,7 @@ public enum MiscCookieResolver {
     public static func appendBrowserImport(for spec: Spec, instanceID: String) -> Resolution? {
         let settings = currentSettings(for: spec.tool, instanceID: instanceID)
         guard SlotFilter(settings: settings) != .none else { return nil }
-        guard let imported = importFromBrowsers(
-            spec: spec,
-            settings: settings,
-            allowKeychainPrompt: true
-        ) else {
+        guard let imported = attemptBrowserImport(spec: spec, settings: settings).session else {
             return nil
         }
         let slot = MiscCookieSlot(
@@ -247,13 +243,8 @@ public enum MiscCookieResolver {
     ) -> BatchImportOutcome.Result {
         let settings = currentSettings(for: spec.tool, instanceID: instanceID)
         guard SlotFilter(settings: settings) != .none else { return .cookiesDisabled }
-        guard let imported = importFromBrowsers(
-            spec: spec,
-            settings: settings,
-            allowKeychainPrompt: true
-        ) else {
-            return emptyImportReason(now: now)
-        }
+        let attempt = attemptBrowserImport(spec: spec, settings: settings, now: now)
+        guard let imported = attempt.session else { return attempt.emptyOutcome }
         let slot = MiscCookieSlot(
             cookieHeader: imported.header,
             sourceLabel: imported.sourceLabel,
@@ -266,16 +257,6 @@ public enum MiscCookieResolver {
             instanceID: instanceID
         ) != nil else { return .saveFailed }
         return .imported(sourceLabel: imported.sourceLabel)
-    }
-
-    /// Why an import that touched no browser came back empty. A cooldown
-    /// recorded *during* this attempt (the user just clicked "Don't Allow")
-    /// counts the same as one that was already running.
-    private static func emptyImportReason(now: Date) -> BatchImportOutcome.Result {
-        guard let cooldown = BrowserCookieAccessGate.activeCooldowns(now: now).first else {
-            return .noSessionFound
-        }
-        return .keychainCooldown(browser: cooldown.browserName, until: cooldown.until)
     }
 
     /// Legacy alias for callers that haven't migrated to
@@ -371,16 +352,19 @@ public enum MiscCookieResolver {
                     result: .cookiesDisabled
                 )
             }
-            guard let imported = importFromBrowsers(
+            let attempt = attemptBrowserImport(
                 spec: target.spec,
                 settings: settings,
-                allowKeychainPrompt: true,
                 context: context
-            ) else {
+            )
+            guard let imported = attempt.session else {
                 return BatchImportOutcome(
                     tool: target.tool,
                     instanceID: target.instanceID,
-                    result: emptyImportReason(now: Date())
+                    // Per target, not per batch: one provider blocked by a
+                    // Chromium cooldown says nothing about the next one,
+                    // which may not read cookie jars at all.
+                    result: attempt.emptyOutcome
                 )
             }
             let slot = MiscCookieSlot(
@@ -561,19 +545,57 @@ public enum MiscCookieResolver {
         let sourceLabel: String
     }
 
-    private static func importFromBrowsers(
+    /// What one user-initiated import actually did.
+    ///
+    /// `blockedByCooldown` is scoped to *this* attempt: the browsers this
+    /// walk was refused by or skipped over, never the process-wide denial
+    /// map. That distinction is the whole point — a Kimi import reads
+    /// Chromium localStorage and never touches the Keychain gate, so an
+    /// unrelated Chrome cooldown must not turn its empty result into
+    /// "Chrome Keychain access was declined".
+    struct AttemptedImport {
+        let session: BrowserImportResult?
+        let blockedByCooldown: [BrowserCookieAccessGate.Cooldown]
+
+        /// How to report an attempt that stored nothing.
+        var emptyOutcome: BatchImportOutcome.Result {
+            guard let blocked = blockedByCooldown.min(by: { $0.until < $1.until }) else {
+                return .noSessionFound
+            }
+            return .keychainCooldown(browser: blocked.browserName, until: blocked.until)
+        }
+    }
+
+    /// Mutable scratch for one walk. A plain class because the walk is
+    /// synchronous and single-threaded; it never escapes the call.
+    final class BrowserImportAttempt {
+        private(set) var blocked: [BrowserCookieAccessGate.Cooldown] = []
+
+        func record(_ cooldown: BrowserCookieAccessGate.Cooldown) {
+            guard !blocked.contains(where: { $0.browserName == cooldown.browserName }) else { return }
+            blocked.append(cooldown)
+        }
+    }
+
+    /// Run one user-initiated import and report both the session it found
+    /// and what got in the way, without touching the slot store.
+    static func attemptBrowserImport(
         spec: Spec,
         settings: MiscProviderSettings,
-        allowKeychainPrompt: Bool = false,
-        context: BrowserImportContext = BrowserImportContext()
-    ) -> BrowserImportResult? {
-        browserSessions(
+        context: BrowserImportContext = BrowserImportContext(),
+        now: Date = Date()
+    ) -> AttemptedImport {
+        let attempt = BrowserImportAttempt()
+        let session = browserSessions(
             spec: spec,
             settings: settings,
-            allowKeychainPrompt: allowKeychainPrompt,
+            allowKeychainPrompt: true,
             context: context,
-            maxSessions: 1
+            maxSessions: 1,
+            attempt: attempt,
+            now: now
         ).first
+        return AttemptedImport(session: session, blockedByCooldown: attempt.blocked)
     }
 
     /// Walk the candidate browsers and return every usable session for
@@ -589,7 +611,9 @@ public enum MiscCookieResolver {
         settings: MiscProviderSettings,
         allowKeychainPrompt: Bool,
         context: BrowserImportContext,
-        maxSessions: Int?
+        maxSessions: Int?,
+        attempt: BrowserImportAttempt = BrowserImportAttempt(),
+        now: Date = Date()
     ) -> [BrowserImportResult] {
         let preferred: [Browser]
         if let kind = settings.preferredBrowser {
@@ -605,7 +629,9 @@ public enum MiscCookieResolver {
                 preferred: preferred,
                 allowKeychainPrompt: allowKeychainPrompt,
                 context: context,
-                maxSessions: maxSessions
+                maxSessions: maxSessions,
+                attempt: attempt,
+                now: now
             )
         case let .chromiumLocalStorage(credential):
             return chromiumLocalStorageBrowserSessions(
@@ -653,15 +679,65 @@ public enum MiscCookieResolver {
         }
     }
 
+    /// Split a preference list into the browsers a *prompting* import may
+    /// read right now and the ones the denial cooldown is holding back.
+    ///
+    /// "The user clicked Import" is permission to show a Keychain prompt;
+    /// it is not permission to show the same prompt again for a browser
+    /// whose prompt the user just declined — which is what the card means
+    /// when it says Vibe Bar will not ask again until a stated time. The
+    /// only way past a live cooldown is the explicit "Retry now" / "Reset
+    /// browser-cookie cooldown" control, which clears the gate first.
+    ///
+    /// Filtering happens on the preference list rather than after
+    /// `cookieImportCandidates`, so its one-Chromium-browser-per-click cap
+    /// lands on the first browser we can actually read. A cooled-down
+    /// browser is only reported as blocking *this* attempt when it is
+    /// installed with usable cookie data — otherwise we would not have
+    /// read it either way.
+    static func cooldownPartition(
+        _ preferred: [Browser],
+        detection: BrowserDetection,
+        now: Date = Date()
+    ) -> (eligible: [Browser], blocked: [BrowserCookieAccessGate.Cooldown]) {
+        var blocked: [BrowserCookieAccessGate.Cooldown] = []
+        let eligible = preferred.filter { browser in
+            guard let until = BrowserCookieAccessGate.blockedUntil(browser, now: now) else {
+                return true
+            }
+            if detection.isCookieSourceAvailable(browser) {
+                blocked.append(
+                    BrowserCookieAccessGate.Cooldown(browserName: browser.displayName, until: until)
+                )
+            }
+            return false
+        }
+        return (eligible, blocked)
+    }
+
     private static func cookieBrowserSessions(
         spec: Spec,
         preferred: [Browser],
         allowKeychainPrompt: Bool,
         context: BrowserImportContext,
-        maxSessions: Int?
+        maxSessions: Int?,
+        attempt: BrowserImportAttempt = BrowserImportAttempt(),
+        now: Date = Date()
     ) -> [BrowserImportResult] {
         let warm = allowKeychainPrompt ? [] : warmKeychainBrowserIDs
-        let candidates = preferred.cookieImportCandidates(
+        // A silent read already consults the gate inside
+        // `cookieImportCandidates`; a prompting one used to bypass it
+        // entirely, so the prompt could reappear the moment the user
+        // clicked Import again.
+        let searchOrder: [Browser]
+        if allowKeychainPrompt {
+            let partition = cooldownPartition(preferred, detection: context.detection, now: now)
+            partition.blocked.forEach(attempt.record)
+            searchOrder = partition.eligible
+        } else {
+            searchOrder = preferred
+        }
+        let candidates = searchOrder.cookieImportCandidates(
             using: context.detection,
             allowKeychainPrompt: allowKeychainPrompt,
             warmKeychainBrowsers: warm
@@ -682,7 +758,11 @@ public enum MiscCookieResolver {
                     logger: nil
                 )
             } catch {
-                BrowserCookieAccessGate.recordIfNeeded(error)
+                // A refusal that lands *now* belongs to this attempt just
+                // as much as one carried over from an earlier click.
+                if let cooldown = BrowserCookieAccessGate.recordIfNeeded(error, now: now) {
+                    attempt.record(cooldown)
+                }
                 // A warm browser that suddenly refuses means the cached
                 // Safe Storage key is gone (keychain relocked, browser
                 // rotated it). Forget the warmth so we stop bypassing

--- a/Sources/VibeBarCore/BrowserCookies/MiscCookieResolver.swift
+++ b/Sources/VibeBarCore/BrowserCookies/MiscCookieResolver.swift
@@ -236,6 +236,48 @@ public enum MiscCookieResolver {
         )
     }
 
+    /// `appendBrowserImport` with the reason attached when it fails.
+    ///
+    /// The Settings row uses this so a declined Keychain prompt reads as a
+    /// cooldown with a Retry-now button rather than as "no cookies found".
+    public static func appendBrowserImportOutcome(
+        for spec: Spec,
+        instanceID: String,
+        now: Date = Date()
+    ) -> BatchImportOutcome.Result {
+        let settings = currentSettings(for: spec.tool, instanceID: instanceID)
+        guard SlotFilter(settings: settings) != .none else { return .cookiesDisabled }
+        guard let imported = importFromBrowsers(
+            spec: spec,
+            settings: settings,
+            allowKeychainPrompt: true
+        ) else {
+            return emptyImportReason(now: now)
+        }
+        let slot = MiscCookieSlot(
+            cookieHeader: imported.header,
+            sourceLabel: imported.sourceLabel,
+            importedAt: Date(),
+            origin: .browserImport
+        )
+        guard MiscCookieSlotStore.upsertBrowserImport(
+            slot,
+            for: spec.tool,
+            instanceID: instanceID
+        ) != nil else { return .saveFailed }
+        return .imported(sourceLabel: imported.sourceLabel)
+    }
+
+    /// Why an import that touched no browser came back empty. A cooldown
+    /// recorded *during* this attempt (the user just clicked "Don't Allow")
+    /// counts the same as one that was already running.
+    private static func emptyImportReason(now: Date) -> BatchImportOutcome.Result {
+        guard let cooldown = BrowserCookieAccessGate.activeCooldowns(now: now).first else {
+            return .noSessionFound
+        }
+        return .keychainCooldown(browser: cooldown.browserName, until: cooldown.until)
+    }
+
     /// Legacy alias for callers that haven't migrated to
     /// `appendBrowserImport`. Slot semantics are identical.
     public static func forceBrowserImport(for spec: Spec) -> Resolution? {
@@ -269,6 +311,13 @@ public enum MiscCookieResolver {
             /// The browsers we were allowed to read had no usable
             /// session for this provider's domains.
             case noSessionFound
+            /// Every Chromium-family browser we would have read is inside
+            /// `BrowserCookieAccessGate`'s denial cooldown, so nothing was
+            /// read. Indistinguishable from `.noSessionFound` at the call
+            /// site — which is exactly why it needs its own case: telling
+            /// the user to sign in again cannot fix a declined Keychain
+            /// prompt.
+            case keychainCooldown(browser: String, until: Date)
             /// The provider's source mode bans cookies entirely, so we
             /// never looked.
             case cookiesDisabled
@@ -331,7 +380,7 @@ public enum MiscCookieResolver {
                 return BatchImportOutcome(
                     tool: target.tool,
                     instanceID: target.instanceID,
-                    result: .noSessionFound
+                    result: emptyImportReason(now: Date())
                 )
             }
             let slot = MiscCookieSlot(

--- a/Sources/VibeBarCore/MCP/MCPDTOs.swift
+++ b/Sources/VibeBarCore/MCP/MCPDTOs.swift
@@ -212,7 +212,7 @@ extension MCPQuotaAccountDTO {
             lastUpdated: lastUpdated,
             lastAttempted: lastAttempted,
             inFlight: inFlight,
-            error: error?.userFacingMessage
+            error: error?.agentFacingMessage
         )
     }
 }

--- a/Sources/VibeBarCore/Models/MiscProviderConsoleLinks.swift
+++ b/Sources/VibeBarCore/Models/MiscProviderConsoleLinks.swift
@@ -1,0 +1,144 @@
+import Foundation
+
+/// Where a misc provider's credential is issued, given how that instance
+/// is configured.
+///
+/// `ToolType.statusPageURL` holds one fixed URL per tool, which is wrong
+/// for the providers that ship two consoles behind one card: a Z.ai
+/// instance set to China mainland was still sent to www.z.ai, and a
+/// MiniMax China instance to platform.minimax.io, so the "Open console"
+/// link landed on a site that does not hold the key the card is asking
+/// for. This picks by the instance's Region setting instead, and offers
+/// both when the region is on "Auto" — either console could be the one
+/// that issued the key.
+///
+/// Lives in Core rather than beside the SwiftUI row so the choice is
+/// testable without a view.
+public enum MiscProviderConsole {
+    public struct Link: Equatable, Sendable, Identifiable {
+        /// Button copy, naming the destination rather than saying
+        /// "console" for the providers whose page is a product site or a
+        /// settings screen.
+        public let title: String
+        public let url: URL
+
+        public var id: String { url.absoluteString }
+
+        public init(title: String, url: URL) {
+            self.title = title
+            self.url = url
+        }
+    }
+
+    /// One link for most providers, two when a region-aware provider is
+    /// left on "Auto". Never empty for a misc-page provider.
+    public static func links(for tool: ToolType, settings: MiscProviderSettings) -> [Link] {
+        switch tool {
+        case .zai:
+            return zaiLinks(region: settings.region)
+        case .minimax:
+            return minimaxLinks(region: settings.region)
+        case .alibaba:
+            return alibabaLinks(region: settings.region, tokenPlan: false)
+        case .alibabaTokenPlan:
+            return alibabaLinks(region: settings.region, tokenPlan: true)
+        default:
+            return [Link(title: defaultTitle(for: tool), url: defaultURL(for: tool))]
+        }
+    }
+
+    // MARK: - Region-aware providers
+
+    /// Keys minted on z.ai do not work on open.bigmodel.cn and vice
+    /// versa, which is the whole reason the Region picker exists.
+    private static func zaiLinks(region: String?) -> [Link] {
+        let global = Link(title: "Open z.ai API keys", url: URL(string: "https://z.ai/manage-apikey/apikey-list")!)
+        let mainland = Link(title: "Open open.bigmodel.cn", url: URL(string: "https://open.bigmodel.cn/usercenter/apikeys")!)
+        switch normalized(region) {
+        case "global":       return [global]
+        case "bigmodel-cn":  return [mainland]
+        default:             return [global, mainland]   // Auto
+        }
+    }
+
+    private static func minimaxLinks(region: String?) -> [Link] {
+        let global = Link(title: "Open platform.minimax.io", url: URL(string: "https://platform.minimax.io/")!)
+        let mainland = Link(title: "Open platform.minimaxi.com", url: URL(string: "https://platform.minimaxi.com/")!)
+        // Matches `MiniMaxRegion.resolve`: only the explicit mainland
+        // spellings pin the China host; everything else starts Global.
+        switch normalized(region) {
+        case "cn", "china", "china-mainland", "cn-beijing":
+            return [mainland]
+        default:
+            return [global]
+        }
+    }
+
+    /// Bailian's two consoles are a different Aliyun account surface each,
+    /// so an instance pinned to a region must not offer the other one.
+    private static func alibabaLinks(region: String?, tokenPlan: Bool) -> [Link] {
+        let international = Link(
+            title: "Open Model Studio console",
+            url: tokenPlan
+                ? URL(string: "https://modelstudio.console.alibabacloud.com/ap-southeast-1?tab=plan#/efm/subscription/token-plan")!
+                : URL(string: "https://modelstudio.console.alibabacloud.com/ap-southeast-1/?tab=coding-plan#/efm/detail")!
+        )
+        let mainland = Link(
+            title: "Open Bailian console",
+            url: tokenPlan
+                ? URL(string: "https://bailian.console.aliyun.com/cn-beijing?tab=plan#/efm/subscription/token-plan")!
+                : URL(string: "https://bailian.console.aliyun.com/cn-beijing/?tab=model#/efm/coding_plan")!
+        )
+        // Same spellings `AlibabaRegion.resolve` accepts.
+        switch normalized(region) {
+        case "ap-southeast-1", "intl", "international":
+            return [international]
+        case "cn-beijing", "cn", "china":
+            return [mainland]
+        default:
+            return [mainland, international]   // Auto
+        }
+    }
+
+    private static func normalized(_ region: String?) -> String {
+        region?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() ?? ""
+    }
+
+    // MARK: - Everything else
+
+    /// `statusPageURL` is already the console for every misc provider
+    /// except Copilot, whose entry there is GitHub's *status* page rather
+    /// than anywhere a token can be obtained.
+    static func defaultURL(for tool: ToolType) -> URL {
+        switch tool {
+        case .copilot:
+            return URL(string: "https://github.com/settings/copilot")!
+        default:
+            return tool.statusPageURL
+        }
+    }
+
+    static func defaultTitle(for tool: ToolType) -> String {
+        switch tool {
+        case .alibaba, .alibabaTokenPlan:         return "Open Bailian console"
+        case .copilot:                            return "Open GitHub Copilot settings"
+        case .zai:                                return "Open z.ai"
+        case .minimax:                            return "Open platform.minimax.io"
+        case .kimi:                               return "Open kimi.com"
+        case .mimo:                               return "Open platform.xiaomimimo.com"
+        case .iflytek:                            return "Open maas.xfyun.cn"
+        case .tencentHunyuan, .tencentTokenPlan:  return "Open Tencent Cloud console"
+        case .volcengine:                         return "Open Ark console"
+        case .volcengineAgentPlan:                return "Open Agent Plan console"
+        case .baiduQianfan:                       return "Open Qianfan console"
+        case .openCodeGo:                         return "Open opencode.ai"
+        case .kilo:                               return "Open app.kilo.ai"
+        case .kiro:                               return "Open kiro.dev"
+        case .ollama:                             return "Open ollama.com"
+        case .openRouter:                         return "Open openrouter.ai"
+        case .warp:                               return "Open app.warp.dev"
+        case .codex, .claude, .gemini, .antigravity, .grok, .cursor:
+            return "Open status page"
+        }
+    }
+}

--- a/Sources/VibeBarCore/Models/MiscProviderCredentialRules.swift
+++ b/Sources/VibeBarCore/Models/MiscProviderCredentialRules.swift
@@ -1,0 +1,165 @@
+import Foundation
+
+/// Shape checks for the credentials a user types into a misc-provider row.
+///
+/// These exist because the Settings fields used to accept any non-empty
+/// string and immediately show a green "saved" state — so pasting an Ark
+/// inference key into Volcengine's Agent Plan Access Key field looked like
+/// success, and the mistake only surfaced later as an opaque quota error on
+/// a different screen.
+///
+/// The rules are deliberately two-tier:
+///
+/// - `.rejected` is reserved for a value we can positively identify as a
+///   *different* credential the same vendor issues. Those are the mistakes
+///   worth blocking, and the message can name both credentials.
+/// - `.warning` covers "this does not look like the documented prefix".
+///   Vendors rotate key formats without telling anyone, so an unrecognised
+///   shape must never stop a user who knows better — the value is saved and
+///   the row explains what Vibe Bar expected.
+///
+/// Everything here is pure string inspection on a value the user just
+/// typed. Nothing is logged, stored, or echoed back into a message.
+public enum MiscCredentialFieldRules {
+    public enum Verdict: Equatable, Sendable {
+        case accepted
+        /// Saved, with a caveat shown under the field.
+        case warning(String)
+        /// Not saved. The message says which credential this looks like
+        /// and which one the field wants.
+        case rejected(String)
+
+        public var allowsSave: Bool {
+            if case .rejected = self { return false }
+            return true
+        }
+
+        public var message: String? {
+            switch self {
+            case .accepted:            return nil
+            case .warning(let text):   return text
+            case .rejected(let text):  return text
+            }
+        }
+    }
+
+    /// Check one field's value. `value` is expected to be pre-trimmed.
+    public static func check(
+        tool: ToolType,
+        kind: MiscCredentialStore.Kind,
+        value: String
+    ) -> Verdict {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return .accepted }
+
+        switch (tool, kind) {
+        case (.volcengineAgentPlan, .accessKeyID):
+            if trimmed.lowercased().hasPrefix("sk-") {
+                return .rejected(
+                    "That looks like an Ark inference key (sk-…). Agent Plan needs an Access Key ID, which starts with AKLT — create one in the Volcengine console under Access Control (访问控制) → API Access Key."
+                )
+            }
+            if !trimmed.hasPrefix("AKLT") {
+                return .warning(
+                    "Volcengine Access Key IDs normally start with AKLT. Saved anyway — if the card reports a rejected key, copy the Access Key ID from Access Control (访问控制) → API Access Key."
+                )
+            }
+            return .accepted
+
+        case (.warp, .apiKey):
+            if !trimmed.hasPrefix("wk-") {
+                return .warning(
+                    "Warp API keys normally start with wk-. Saved anyway — mint one in Warp → Settings → AI → API Keys if the card reports a rejected key."
+                )
+            }
+            return .accepted
+
+        case (.openRouter, .apiKey):
+            if !trimmed.hasPrefix("sk-or-") {
+                return .warning(
+                    "OpenRouter keys normally start with sk-or-v1-. Saved anyway — create one at openrouter.ai → Keys if the card reports a rejected key."
+                )
+            }
+            return .accepted
+
+        case (.minimax, .apiKey):
+            if !trimmed.hasPrefix("sk-cp-") {
+                return .warning(
+                    "The Token Plan key from Billing → Token Plan starts with sk-cp-. Saved anyway — a general MiniMax platform key can authenticate but report no Token Plan quota."
+                )
+            }
+            return .accepted
+
+        case (.zai, .apiKey):
+            // z.ai issues `zai-…`; open.bigmodel.cn issues `<id>.<secret>`.
+            // Accept either shape, warn on anything else.
+            if !trimmed.hasPrefix("zai-") && !trimmed.contains(".") {
+                return .warning(
+                    "Z.ai keys from z.ai → API Keys start with zai-; open.bigmodel.cn keys look like id.secret. Saved anyway — check the Region picker if the card reports a rejected key."
+                )
+            }
+            return .accepted
+
+        default:
+            return .accepted
+        }
+    }
+}
+
+/// Which cookie a hand-pasted header has to carry before the provider's
+/// adapter can do anything with it.
+///
+/// Providers whose `MiscCookieResolver.Spec.requiredNames` is empty ship
+/// the whole jar, so the paste field could not reject anything and a header
+/// missing the one cookie that matters was stored, marked "saved", and only
+/// failed at the next refresh. These are the sentinels each adapter
+/// actually reads out of the header.
+///
+/// Only providers with a *hard* sentinel are listed. Alibaba, Baidu
+/// Qianfan, and iFlytek stitch identity out of HttpOnly tickets we cannot
+/// enumerate and have no single load-bearing cookie name, so their pastes
+/// stay unvalidated rather than risk rejecting a working header.
+public enum MiscManualCookieRules {
+    /// Cookie names that must all be present, in the order a message
+    /// should list them. Empty means "no sentinel is known".
+    public static func requiredCookieNames(for tool: ToolType) -> [String] {
+        switch tool {
+        case .volcengine:
+            return ["csrfToken"]
+        case .tencentHunyuan, .tencentTokenPlan:
+            return ["skey", "uin"]
+        default:
+            return []
+        }
+    }
+
+    /// `nil` when the header is usable; otherwise the message to show
+    /// instead of saving it.
+    public static func rejectionMessage(for tool: ToolType, header: String) -> String? {
+        let names = Set(CookieHeaderNormalizer.pairs(from: header)
+            .filter { !$0.value.isEmpty }
+            .map(\.name))
+
+        let missing = requiredCookieNames(for: tool).filter { !names.contains($0) }
+        if !missing.isEmpty {
+            return message(tool: tool, missing: missing)
+        }
+
+        if tool == .ollama, !OllamaQuotaAdapter.hasRecognizedSessionCookie(header) {
+            return "No Ollama session cookie found in the pasted text. Copy the ollama.com Cookie header while signed in — it must include session (or next-auth.session-token)."
+        }
+        return nil
+    }
+
+    private static func message(tool: ToolType, missing: [String]) -> String {
+        let list = missing.joined(separator: " and ")
+        switch tool {
+        case .volcengine:
+            return "No \(list) cookie found in the pasted text. csrfToken is only set after you open the Ark console (console.volcengine.com/ark) once — open it, then copy the Cookie header again."
+        case .tencentHunyuan, .tencentTokenPlan:
+            return "No \(list) cookie found in the pasted text. Both are set by the Tencent Cloud console — open console.cloud.tencent.com once, then copy the Cookie header again."
+        default:
+            return "No \(list) cookie found in the pasted text."
+        }
+    }
+}

--- a/Sources/VibeBarCore/Models/QuotaError.swift
+++ b/Sources/VibeBarCore/Models/QuotaError.swift
@@ -3,6 +3,16 @@ import Foundation
 public enum QuotaError: Error, Equatable, Hashable, Sendable {
     case noCredential
     case needsLogin
+    /// The key we hold was rejected by the provider (typically HTTP
+    /// 401/403 on an API-key, PAT, or AK/SK path).
+    ///
+    /// Distinct from `.needsLogin`, which means "the browser session
+    /// expired — sign in again": on a key provider there is no session to
+    /// refresh, only a credential to replace, and telling the user to
+    /// re-login sends them to the wrong control entirely. The associated
+    /// message names the field and the fix; it is provider copy, never a
+    /// credential value.
+    case credentialRejected(String)
     case network(String)
     case rateLimited
     case parseFailure(String)
@@ -13,17 +23,28 @@ public enum QuotaError: Error, Equatable, Hashable, Sendable {
         switch self {
         case .noCredential:    return "No account found"
         case .needsLogin:      return "Needs re-login"
+        case .credentialRejected(let m):
+            return m.isEmpty ? "Credential rejected" : m
         case .network(let m):  return "Network error\(m.isEmpty ? "" : ": \(m)")"
         case .rateLimited:     return "Rate limited, try later"
-        case .parseFailure:    return "Response format changed"
+        // The adapter's own diagnosis is the whole point of the payload:
+        // "no Coding Plan subscription on this account" is actionable in a
+        // way "Response format changed" never was. Only a genuinely empty
+        // message falls back to the generic line.
+        case .parseFailure(let m):
+            return m.isEmpty ? "Response format changed" : m
         case .notImplemented:  return "Not yet supported"
         case .unknown(let m):  return "Error\(m.isEmpty ? "" : ": \(m)")"
         }
     }
 
+    /// True when the failure is about *which credential we hold* rather
+    /// than about the response. Drives the cached-quota grace period in
+    /// `QuotaService` and the silent cookie re-import in
+    /// `MiscCookieAutoImporter`.
     public var isCredentialState: Bool {
         switch self {
-        case .noCredential, .needsLogin:
+        case .noCredential, .needsLogin, .credentialRejected:
             return true
         case .network, .rateLimited, .parseFailure, .notImplemented, .unknown:
             return false

--- a/Sources/VibeBarCore/Models/QuotaError.swift
+++ b/Sources/VibeBarCore/Models/QuotaError.swift
@@ -38,6 +38,35 @@ public enum QuotaError: Error, Equatable, Hashable, Sendable {
         }
     }
 
+    /// The same text, safe to hand to `os_log`.
+    ///
+    /// `userFacingMessage` can carry a payload an adapter lifted verbatim
+    /// out of a provider response, and `os_log` lines written at
+    /// `.public` are readable outside this process and end up in
+    /// sysdiagnose bundles.
+    ///
+    /// Both redactors run, because neither is sufficient alone:
+    /// `SafeLog.sanitize` masks 20+ character token runs but an address
+    /// splits at the `@` into two shorter ones, so `EmailMasker` has to go
+    /// first. The pair is deliberately aggressive here — it also eats
+    /// dotted hostnames, which a log line can afford to lose.
+    public var logSafeMessage: String {
+        SafeLog.sanitize(ProviderDiagnosticRedactor.maskEmails(in: userFacingMessage))
+    }
+
+    /// The projection for the MCP surface, where the reader is an agent
+    /// rather than the person whose machine this is.
+    ///
+    /// Same concern as `logSafeMessage`, different trade-off: an agent
+    /// acting on "no Coding Plan subscription — set up the Agent Plan
+    /// card" needs the actionable half of the message intact, so this
+    /// masks addresses and opaque identifiers without flattening ordinary
+    /// hostnames, and caps the length so a provider stack trace cannot
+    /// flood the agent's context.
+    public var agentFacingMessage: String {
+        ProviderDiagnosticRedactor.redact(userFacingMessage)
+    }
+
     /// True when the failure is about *which credential we hold* rather
     /// than about the response. Drives the cached-quota grace period in
     /// `QuotaService` and the silent cookie re-import in

--- a/Sources/VibeBarCore/Services/QuotaService.swift
+++ b/Sources/VibeBarCore/Services/QuotaService.swift
@@ -219,7 +219,7 @@ public final class QuotaService: ObservableObject {
             store(success: quota)
             return quota
         case let .completed(.failure(qe)):
-            SafeLog.net("\(account.tool.rawValue) refresh failed: \(qe.userFacingMessage)")
+            SafeLog.net("\(account.tool.rawValue) refresh failed: \(qe.logSafeMessage)")
             store(error: qe, for: account)
             return cachedOrEmpty(for: account, error: qe)
         case .timedOut:

--- a/Sources/VibeBarCore/Utilities/ProviderDiagnosticRedactor.swift
+++ b/Sources/VibeBarCore/Utilities/ProviderDiagnosticRedactor.swift
@@ -1,0 +1,84 @@
+import Foundation
+
+/// Redacts a diagnostic string that may have come from a provider's own
+/// response before it leaves this machine.
+///
+/// `QuotaError`'s payloads are a mix of two things: copy Vibe Bar wrote
+/// ("This account has no Coding Plan subscription…") and text lifted
+/// verbatim out of a provider response — `WarpResponseParser` builds a
+/// `.parseFailure` straight from GraphQL `errors[].message`, and half a
+/// dozen adapters interpolate a BFF's `Message` field into `.network`.
+/// Nothing stops such a message from carrying the account's email, a
+/// session id, or a token fragment, and the error text reaches two sinks
+/// that leave the app: a public `os_log` line and the MCP projection an
+/// agent reads.
+///
+/// This is deliberately gentler than `SafeLog.sanitize`, which masks any
+/// run of 20+ `[A-Za-z0-9_-.]` characters and therefore eats ordinary
+/// hostnames — `console.volcengine.com` becomes `***`, which is exactly
+/// the actionable half of the message an agent needs. Here the dot is not
+/// part of the token class, so dotted hostnames survive intact while an
+/// opaque 20+ character blob (a JWT segment, an API key, an account id)
+/// still gets masked, and addresses go through `EmailMasker` first.
+public enum ProviderDiagnosticRedactor {
+    public static let defaultMaxLength = 300
+
+    /// Mask addresses and opaque identifiers, collapse whitespace, and cap
+    /// the length so one provider's stack trace cannot flood a log line or
+    /// an agent's context window.
+    public static func redact(_ raw: String, maxLength: Int = defaultMaxLength) -> String {
+        var text = raw.replacingOccurrences(of: "\n", with: " ")
+        text = maskEmails(in: text)
+        text = maskOpaqueRuns(in: text)
+        text = text
+            .replacingOccurrences(of: "  ", with: " ")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return truncate(text, maxLength: maxLength)
+    }
+
+    /// Run every address in `text` through `EmailMasker`.
+    ///
+    /// Exposed because `SafeLog.sanitize` on its own does not catch one:
+    /// the `@` splits an address into two runs that are each well under
+    /// its 20-character threshold, so `user@example.com` sails through
+    /// untouched. Anything logging a provider diagnostic wants both.
+    public static func maskEmails(in text: String) -> String {
+        guard let regex = emailRegex else { return text }
+        let full = NSRange(text.startIndex..., in: text)
+        var result = text
+        // Replace back-to-front so earlier ranges stay valid.
+        for match in regex.matches(in: text, options: [], range: full).reversed() {
+            guard let range = Range(match.range, in: text) else { continue }
+            let masked = EmailMasker.mask(String(text[range]))
+            result.replaceSubrange(
+                Range(match.range, in: result) ?? range,
+                with: masked
+            )
+        }
+        return result
+    }
+
+    private static func maskOpaqueRuns(in text: String) -> String {
+        guard let regex = opaqueRunRegex else { return text }
+        let range = NSRange(text.startIndex..., in: text)
+        return regex.stringByReplacingMatches(
+            in: text, options: [], range: range, withTemplate: "***"
+        )
+    }
+
+    private static func truncate(_ text: String, maxLength: Int) -> String {
+        guard maxLength > 0, text.count > maxLength else { return text }
+        return String(text.prefix(maxLength)) + "…"
+    }
+
+    private static let emailRegex = try? NSRegularExpression(
+        pattern: "[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}"
+    )
+
+    /// No dot in the character class — that is what keeps
+    /// `console.volcengine.com` readable while a JWT segment or an API key
+    /// is still masked.
+    private static let opaqueRunRegex = try? NSRegularExpression(
+        pattern: "[A-Za-z0-9_\\-]{20,}"
+    )
+}

--- a/Tests/VibeBarCoreTests/BrowserCookieGateTests.swift
+++ b/Tests/VibeBarCoreTests/BrowserCookieGateTests.swift
@@ -68,6 +68,42 @@ final class BrowserCookieGateTests: XCTestCase {
         // doesn't crash and clears the persisted UserDefaults.
         XCTAssertNil(UserDefaults.standard.dictionary(forKey: "vibebarBrowserCookieAccessDeniedUntil"))
     }
+
+    /// The import UI needs to tell a declined Keychain prompt apart from
+    /// "no session found" — from the importer's side both look like an
+    /// empty result.
+    func testActiveCooldownsReportBrowserAndExpiry() {
+        let now = Date(timeIntervalSince1970: 1_715_000_000)
+        BrowserCookieAccessGate.recordDenied(for: .chrome, now: now)
+
+        let blockedUntil = BrowserCookieAccessGate.blockedUntil(.chrome, now: now)
+        XCTAssertEqual(blockedUntil, now.addingTimeInterval(60 * 60 * 6))
+
+        let cooldowns = BrowserCookieAccessGate.activeCooldowns(now: now)
+        XCTAssertEqual(cooldowns.count, 1)
+        XCTAssertEqual(cooldowns.first?.browserName, Browser.chrome.displayName)
+        XCTAssertEqual(cooldowns.first?.until, now.addingTimeInterval(60 * 60 * 6))
+    }
+
+    func testCooldownsSortByExpiryAndDropExpiredEntries() {
+        let now = Date(timeIntervalSince1970: 1_715_000_000)
+        BrowserCookieAccessGate.recordDenied(for: .brave, now: now.addingTimeInterval(60))
+        BrowserCookieAccessGate.recordDenied(for: .chrome, now: now)
+
+        let names = BrowserCookieAccessGate.activeCooldowns(now: now).map(\.browserName)
+        XCTAssertEqual(names, [Browser.chrome.displayName, Browser.brave.displayName])
+
+        let afterEverything = now.addingTimeInterval(60 * 60 * 7)
+        XCTAssertTrue(BrowserCookieAccessGate.activeCooldowns(now: afterEverything).isEmpty)
+        XCTAssertNil(BrowserCookieAccessGate.blockedUntil(.chrome, now: afterEverything))
+    }
+
+    func testResetClearsTheReportedCooldowns() {
+        BrowserCookieAccessGate.recordDenied(for: .chrome)
+        XCTAssertFalse(BrowserCookieAccessGate.activeCooldowns().isEmpty)
+        BrowserCookieAccessGate.reset()
+        XCTAssertTrue(BrowserCookieAccessGate.activeCooldowns().isEmpty)
+    }
 }
 
 final class BrowserKindMappingTests: XCTestCase {

--- a/Tests/VibeBarCoreTests/MiscCookieImportCooldownTests.swift
+++ b/Tests/VibeBarCoreTests/MiscCookieImportCooldownTests.swift
@@ -1,0 +1,214 @@
+import XCTest
+@testable import VibeBarCore
+import SweetCookieKit
+
+/// A declined Chromium "Safe Storage" prompt parks that browser for six
+/// hours, and the Settings row now says so. Two things have to hold for
+/// that message to be true:
+///
+/// 1. An ordinary "Import from browser" click honours the cooldown instead
+///    of prompting straight through it — only the explicit "Retry now" /
+///    "Reset browser-cookie cooldown" control clears the gate.
+/// 2. The cooldown is only blamed for an import that would actually have
+///    read that browser. A provider whose credential lives in Chromium
+///    localStorage never touches the Keychain gate at all.
+final class MiscCookieImportCooldownTests: XCTestCase {
+    private var emptyHome: URL!
+
+    /// Reports every path as present with a single `Default` profile, so
+    /// `BrowserDetection` finds usable Chromium data without a browser
+    /// actually being installed on the test machine.
+    private func fakeDetection() -> BrowserDetection {
+        BrowserDetection(
+            homeDirectory: "/Users/example",
+            fileExists: { _ in true },
+            directoryContents: { _ in ["Default"] }
+        )
+    }
+
+    /// The opposite: nothing on disk, so no browser counts as a source
+    /// this import could have read.
+    private func absentDetection() -> BrowserDetection {
+        BrowserDetection(
+            homeDirectory: "/Users/example",
+            fileExists: { _ in false },
+            directoryContents: { _ in nil }
+        )
+    }
+
+    /// A home with no Chromium profiles under it, so the localStorage
+    /// importer finds no roots and nothing is ever written.
+    private func context(detection: BrowserDetection) -> MiscCookieResolver.BrowserImportContext {
+        MiscCookieResolver.BrowserImportContext(
+            detection: detection,
+            homeDirectory: emptyHome
+        )
+    }
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        BrowserCookieAccessGate.reset()
+        MiscCookieResolver.resetKeychainWarmthForTesting()
+        KeychainAccessGate.isDisabled = false
+        emptyHome = FileManager.default.temporaryDirectory
+            .appendingPathComponent("vibebar-cooldown-tests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: emptyHome, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        BrowserCookieAccessGate.reset()
+        MiscCookieResolver.resetKeychainWarmthForTesting()
+        KeychainAccessGate.isDisabled = false
+        if let emptyHome { try? FileManager.default.removeItem(at: emptyHome) }
+        try super.tearDownWithError()
+    }
+
+    // MARK: - The cooldown is honoured, not bypassed
+
+    func testAPromptingImportSkipsABrowserInsideItsCooldown() {
+        let now = Date(timeIntervalSince1970: 1_715_000_000)
+        BrowserCookieAccessGate.recordDenied(for: .chrome, now: now)
+
+        let partition = MiscCookieResolver.cooldownPartition(
+            [.chrome, .brave],
+            detection: fakeDetection(),
+            now: now
+        )
+        XCTAssertEqual(partition.eligible, [.brave])
+        XCTAssertEqual(partition.blocked.map(\.browserName), [Browser.chrome.displayName])
+        XCTAssertEqual(partition.blocked.first?.until, now.addingTimeInterval(60 * 60 * 6))
+    }
+
+    /// The cap on Chromium browsers per click has to land on a browser we
+    /// can actually read, so the filter runs on the preference list rather
+    /// than on what `cookieImportCandidates` returns.
+    func testTheOneChromiumPerClickCapSkipsPastACooledDownBrowser() {
+        let now = Date(timeIntervalSince1970: 1_715_000_000)
+        BrowserCookieAccessGate.recordDenied(for: .chrome, now: now)
+
+        let partition = MiscCookieResolver.cooldownPartition(
+            [.chrome, .brave, .edge],
+            detection: fakeDetection(),
+            now: now
+        )
+        let candidates = partition.eligible.cookieImportCandidates(
+            using: fakeDetection(),
+            allowKeychainPrompt: true
+        )
+        XCTAssertEqual(candidates, [.brave])
+    }
+
+    func testResettingTheGateLetsTheNextImportPromptAgain() {
+        BrowserCookieAccessGate.recordDenied(for: .chrome)
+        XCTAssertTrue(
+            MiscCookieResolver.cooldownPartition([.chrome], detection: fakeDetection()).eligible.isEmpty
+        )
+
+        // What "Retry now" and "Reset browser-cookie cooldown" do first.
+        BrowserCookieAccessGate.reset()
+        XCTAssertEqual(
+            MiscCookieResolver.cooldownPartition([.chrome], detection: fakeDetection()).eligible,
+            [.chrome]
+        )
+    }
+
+    func testExpiredCooldownsDoNotBlockAnImport() {
+        let now = Date(timeIntervalSince1970: 1_715_000_000)
+        BrowserCookieAccessGate.recordDenied(for: .chrome, now: now)
+        let partition = MiscCookieResolver.cooldownPartition(
+            [.chrome],
+            detection: fakeDetection(),
+            now: now.addingTimeInterval(60 * 60 * 6 + 1)
+        )
+        XCTAssertEqual(partition.eligible, [.chrome])
+        XCTAssertTrue(partition.blocked.isEmpty)
+    }
+
+    func testAnUninstalledBrowserIsNotReportedAsBlockingThisImport() {
+        let now = Date(timeIntervalSince1970: 1_715_000_000)
+        BrowserCookieAccessGate.recordDenied(for: .chrome, now: now)
+        let partition = MiscCookieResolver.cooldownPartition(
+            [.chrome],
+            detection: absentDetection(),
+            now: now
+        )
+        XCTAssertTrue(partition.eligible.isEmpty)
+        XCTAssertTrue(partition.blocked.isEmpty, "Nothing to read means nothing to blame.")
+    }
+
+    /// End to end through the import walk: every Chromium channel the user
+    /// prefers is suppressed, so the row says "declined" rather than
+    /// sending them back to the browser to sign in again.
+    func testAFullySuppressedImportReportsTheCooldownOutcome() {
+        let now = Date(timeIntervalSince1970: 1_715_000_000)
+        for browser in BrowserKind.chrome.sweetCookieKitBrowsers {
+            BrowserCookieAccessGate.recordDenied(for: browser, now: now)
+        }
+
+        let attempt = MiscCookieResolver.attemptBrowserImport(
+            spec: Self.syntheticCookieSpec,
+            settings: MiscProviderSettings(preferredBrowser: .chrome),
+            context: context(detection: fakeDetection()),
+            now: now
+        )
+
+        XCTAssertNil(attempt.session)
+        guard case let .keychainCooldown(browser, until) = attempt.emptyOutcome else {
+            return XCTFail("Expected keychainCooldown, got \(attempt.emptyOutcome)")
+        }
+        XCTAssertTrue(BrowserKind.chrome.sweetCookieKitBrowsers.map(\.displayName).contains(browser))
+        XCTAssertEqual(until, now.addingTimeInterval(60 * 60 * 6))
+    }
+
+    // MARK: - Cooldowns are per attempt, not process-wide
+
+    /// Kimi's credential lives in Chromium localStorage, which the
+    /// Keychain gate never gates. An unrelated Chrome cooldown from some
+    /// earlier cookie-jar import must not make a failed Kimi import claim
+    /// that Chrome Keychain access was declined.
+    func testLocalStorageImportIsNotBlamedOnAnUnrelatedChromeCooldown() {
+        BrowserCookieAccessGate.recordDenied(for: .chrome)
+
+        let attempt = MiscCookieResolver.attemptBrowserImport(
+            spec: KimiQuotaAdapter.cookieSpec,
+            settings: .default,
+            context: context(detection: fakeDetection())
+        )
+
+        XCTAssertNil(attempt.session)
+        XCTAssertTrue(attempt.blockedByCooldown.isEmpty)
+        XCTAssertEqual(attempt.emptyOutcome, .noSessionFound)
+    }
+
+    /// The same rule for a cookie-jar provider whose preferred browser is
+    /// not the one in the cooldown: Safari needs no Keychain key at all.
+    func testACooldownOnADifferentBrowserIsNotBlamedEither() {
+        let now = Date(timeIntervalSince1970: 1_715_000_000)
+        BrowserCookieAccessGate.recordDenied(for: .chrome, now: now)
+
+        let partition = MiscCookieResolver.cooldownPartition(
+            BrowserKind.safari.sweetCookieKitBrowsers,
+            detection: fakeDetection(),
+            now: now
+        )
+        XCTAssertEqual(partition.eligible, [.safari])
+        XCTAssertTrue(partition.blocked.isEmpty)
+    }
+
+    func testAnAttemptWithNothingBlockedFallsBackToNoSessionFound() {
+        let attempt = MiscCookieResolver.attemptBrowserImport(
+            spec: KimiQuotaAdapter.cookieSpec,
+            settings: .default,
+            context: context(detection: absentDetection())
+        )
+        XCTAssertEqual(attempt.emptyOutcome, .noSessionFound)
+    }
+
+    /// Domains that cannot resolve to any real cookie store, so a walk that
+    /// reaches SweetCookieKit finds nothing on any machine.
+    private static let syntheticCookieSpec = MiscCookieResolver.Spec(
+        tool: .volcengine,
+        domains: ["cookies.invalid"],
+        requiredNames: []
+    )
+}

--- a/Tests/VibeBarCoreTests/MiscProviderConsoleLinkTests.swift
+++ b/Tests/VibeBarCoreTests/MiscProviderConsoleLinkTests.swift
@@ -1,0 +1,106 @@
+import XCTest
+@testable import VibeBarCore
+
+/// The "Open console" link has to land where the credential actually
+/// lives. `ToolType.statusPageURL` holds one fixed URL per tool, so a Z.ai
+/// instance set to China mainland was still sent to the Global site, and a
+/// MiniMax China instance to platform.minimax.io — in both cases a console
+/// that cannot issue the key the card is asking for.
+final class MiscProviderConsoleLinkTests: XCTestCase {
+    private func settings(region: String?) -> MiscProviderSettings {
+        MiscProviderSettings(region: region)
+    }
+
+    private func hosts(_ tool: ToolType, region: String?) -> [String] {
+        MiscProviderConsole.links(for: tool, settings: settings(region: region))
+            .compactMap(\.url.host)
+    }
+
+    // MARK: - Z.ai
+
+    func testZaiFollowsTheRegionPicker() {
+        XCTAssertEqual(hosts(.zai, region: "global"), ["z.ai"])
+        XCTAssertEqual(hosts(.zai, region: "bigmodel-cn"), ["open.bigmodel.cn"])
+    }
+
+    /// On Auto either console could hold the key, so offer both rather
+    /// than silently guessing Global.
+    func testZaiOnAutoOffersBothConsoles() {
+        XCTAssertEqual(hosts(.zai, region: nil), ["z.ai", "open.bigmodel.cn"])
+        XCTAssertEqual(hosts(.zai, region: ""), ["z.ai", "open.bigmodel.cn"])
+    }
+
+    // MARK: - MiniMax
+
+    func testMiniMaxChinaInstanceGetsTheMainlandConsole() {
+        XCTAssertEqual(hosts(.minimax, region: "cn"), ["platform.minimaxi.com"])
+        XCTAssertEqual(hosts(.minimax, region: "cn-beijing"), ["platform.minimaxi.com"])
+    }
+
+    /// The picker has no Auto entry and defaults to Global, matching
+    /// `MiniMaxRegion.resolve`.
+    func testMiniMaxDefaultsToTheGlobalConsole() {
+        XCTAssertEqual(hosts(.minimax, region: nil), ["platform.minimax.io"])
+        XCTAssertEqual(hosts(.minimax, region: "global"), ["platform.minimax.io"])
+    }
+
+    // MARK: - Alibaba Bailian
+
+    func testAlibabaFollowsTheRegionPicker() {
+        XCTAssertEqual(hosts(.alibaba, region: "cn-beijing"), ["bailian.console.aliyun.com"])
+        XCTAssertEqual(
+            hosts(.alibaba, region: "ap-southeast-1"),
+            ["modelstudio.console.alibabacloud.com"]
+        )
+    }
+
+    func testAlibabaOnAutoOffersBothConsoles() {
+        XCTAssertEqual(
+            hosts(.alibaba, region: nil),
+            ["bailian.console.aliyun.com", "modelstudio.console.alibabacloud.com"]
+        )
+    }
+
+    func testAlibabaTokenPlanLinksLandOnTheTokenPlanTab() {
+        let links = MiscProviderConsole.links(
+            for: .alibabaTokenPlan,
+            settings: settings(region: "cn-beijing")
+        )
+        XCTAssertEqual(links.count, 1)
+        XCTAssertTrue(links[0].url.absoluteString.contains("token-plan"))
+    }
+
+    // MARK: - Everything else
+
+    /// Tencent's Token Plan card stores its *variant* in `region`, so it
+    /// must never be treated as a region.
+    func testTencentTokenPlanVariantIsNotMistakenForARegion() {
+        let generic = MiscProviderConsole.links(for: .tencentTokenPlan, settings: settings(region: nil))
+        let hy3 = MiscProviderConsole.links(for: .tencentTokenPlan, settings: settings(region: "hy3"))
+        XCTAssertEqual(generic, hy3)
+        XCTAssertEqual(generic.count, 1)
+    }
+
+    func testCopilotPointsAtSettingsRatherThanTheStatusPage() {
+        let links = MiscProviderConsole.links(for: .copilot, settings: .default)
+        XCTAssertEqual(links.map(\.url.host), ["github.com"])
+        XCTAssertNotEqual(links[0].url, ToolType.copilot.statusPageURL)
+    }
+
+    func testEveryMiscProviderOffersAtLeastOneLink() {
+        for tool in ToolType.allCases where tool.isMiscPageProvider {
+            let links = MiscProviderConsole.links(for: tool, settings: .default)
+            XCTAssertFalse(links.isEmpty, "\(tool.rawValue) has no console link")
+            for link in links {
+                XCTAssertEqual(link.url.scheme, "https", "\(tool.rawValue) link is not https")
+                XCTAssertTrue(link.title.hasPrefix("Open "), "\(tool.rawValue): \(link.title)")
+            }
+        }
+    }
+
+    func testAgentPlanKeepsItsDeepLink() {
+        let links = MiscProviderConsole.links(for: .volcengineAgentPlan, settings: .default)
+        XCTAssertEqual(links.count, 1)
+        XCTAssertTrue(links[0].url.absoluteString.contains("agentPlan"))
+    }
+}

--- a/Tests/VibeBarCoreTests/MiscProviderSetupUXTests.swift
+++ b/Tests/VibeBarCoreTests/MiscProviderSetupUXTests.swift
@@ -114,6 +114,115 @@ final class MiscProviderSetupUXTests: XCTestCase {
         XCTAssertNil(settings.fallbackQuotaURL)
     }
 
+    /// The gap the Auto retry originally missed: the first host answers a
+    /// perfectly good HTTP 200 whose envelope carries no limits, so nothing
+    /// throws, the fetch "succeeds" with zero buckets, and the card renders
+    /// "Not configured" without the other host ever being tried.
+    func testAutoRetriesTheOtherHostWhenTheFirstReturnsNoBuckets() async throws {
+        let settings = ZaiSettings(
+            quotaURL: ZaiRegion.global.quotaURL,
+            fallbackQuotaURL: ZaiRegion.bigmodelCN.quotaURL
+        )
+        let tried = Tried()
+
+        let snapshot = try await ZaiQuotaAdapter.resolveSnapshot(settings: settings) { url in
+            await tried.record(url)
+            return url == ZaiRegion.bigmodelCN.quotaURL
+                ? ZaiResponseParser.Snapshot(buckets: [Self.bucket], planName: "GLM Coding Plan")
+                : ZaiResponseParser.Snapshot(buckets: [], planName: nil)
+        }
+
+        XCTAssertEqual(snapshot.buckets.map(\.id), ["zai.tokens"])
+        let visited = await tried.urls
+        XCTAssertEqual(visited, [ZaiRegion.global.quotaURL, ZaiRegion.bigmodelCN.quotaURL])
+    }
+
+    func testAHostThatAnswersWithBucketsIsAcceptedWithoutASecondCall() async throws {
+        let settings = ZaiSettings(
+            quotaURL: ZaiRegion.global.quotaURL,
+            fallbackQuotaURL: ZaiRegion.bigmodelCN.quotaURL
+        )
+        let tried = Tried()
+
+        _ = try await ZaiQuotaAdapter.resolveSnapshot(settings: settings) { url in
+            await tried.record(url)
+            return ZaiResponseParser.Snapshot(buckets: [Self.bucket], planName: nil)
+        }
+
+        let visited = await tried.urls
+        XCTAssertEqual(visited, [ZaiRegion.global.quotaURL])
+    }
+
+    /// A pinned region has no fallback, so an empty answer is the answer.
+    func testAPinnedRegionNeverTriesTheOtherHost() async throws {
+        let settings = ZaiSettings(quotaURL: ZaiRegion.bigmodelCN.quotaURL)
+        let tried = Tried()
+
+        let snapshot = try await ZaiQuotaAdapter.resolveSnapshot(settings: settings) { url in
+            await tried.record(url)
+            return ZaiResponseParser.Snapshot(buckets: [], planName: nil)
+        }
+
+        XCTAssertTrue(snapshot.buckets.isEmpty)
+        let visited = await tried.urls
+        XCTAssertEqual(visited, [ZaiRegion.bigmodelCN.quotaURL])
+    }
+
+    /// Both hosts empty means the account really has no quota — keep the
+    /// first host's answer rather than reporting the retry's.
+    func testTwoEmptyHostsKeepTheFirstAnswer() async throws {
+        let settings = ZaiSettings(
+            quotaURL: ZaiRegion.global.quotaURL,
+            fallbackQuotaURL: ZaiRegion.bigmodelCN.quotaURL
+        )
+        let snapshot = try await ZaiQuotaAdapter.resolveSnapshot(settings: settings) { _ in
+            ZaiResponseParser.Snapshot(buckets: [], planName: "empty")
+        }
+        XCTAssertTrue(snapshot.buckets.isEmpty)
+        XCTAssertEqual(snapshot.planName, "empty")
+    }
+
+    /// A retry that throws must not replace a successful-but-empty first
+    /// answer with the second host's error.
+    func testAThrowingRetryDoesNotMaskTheFirstHostsAnswer() async throws {
+        let settings = ZaiSettings(
+            quotaURL: ZaiRegion.global.quotaURL,
+            fallbackQuotaURL: ZaiRegion.bigmodelCN.quotaURL
+        )
+        let snapshot = try await ZaiQuotaAdapter.resolveSnapshot(settings: settings) { url in
+            if url == ZaiRegion.bigmodelCN.quotaURL { throw QuotaError.rateLimited }
+            return ZaiResponseParser.Snapshot(buckets: [], planName: "first")
+        }
+        XCTAssertEqual(snapshot.planName, "first")
+    }
+
+    func testAThrownWrongHostSignalStillRetries() async throws {
+        let settings = ZaiSettings(
+            quotaURL: ZaiRegion.global.quotaURL,
+            fallbackQuotaURL: ZaiRegion.bigmodelCN.quotaURL
+        )
+        let snapshot = try await ZaiQuotaAdapter.resolveSnapshot(settings: settings) { url in
+            if url == ZaiRegion.global.quotaURL {
+                throw QuotaError.credentialRejected(ZaiQuotaAdapter.rejectedKeyMessage)
+            }
+            return ZaiResponseParser.Snapshot(buckets: [Self.bucket], planName: nil)
+        }
+        XCTAssertEqual(snapshot.buckets.map(\.id), ["zai.tokens"])
+    }
+
+    private static let bucket = QuotaBucket(
+        id: "zai.tokens",
+        title: "Tokens",
+        shortLabel: "Tok",
+        usedPercent: 12
+    )
+
+    /// Records the hosts a retry policy actually reached.
+    private actor Tried {
+        private(set) var urls: [URL] = []
+        func record(_ url: URL) { urls.append(url) }
+    }
+
     func testOnlyAmbiguousFailuresTriggerTheOtherHost() {
         XCTAssertTrue(ZaiQuotaAdapter.isWrongHostSignal(.credentialRejected("x")))
         XCTAssertTrue(ZaiQuotaAdapter.isWrongHostSignal(.needsLogin))

--- a/Tests/VibeBarCoreTests/MiscProviderSetupUXTests.swift
+++ b/Tests/VibeBarCoreTests/MiscProviderSetupUXTests.swift
@@ -1,0 +1,295 @@
+import XCTest
+@testable import VibeBarCore
+
+/// Covers the provider-setup diagnostics: the adapter messages that reach
+/// the card, the shape checks on the credential fields, and the sentinel
+/// check on a hand-pasted cookie header.
+final class MiscProviderSetupUXTests: XCTestCase {
+
+    // MARK: - QuotaError plumbing
+
+    func testParseFailureSurfacesTheAdapterMessage() {
+        let error = QuotaError.parseFailure("This account has no Coding Plan subscription.")
+        XCTAssertEqual(error.userFacingMessage, "This account has no Coding Plan subscription.")
+    }
+
+    func testEmptyParseFailureFallsBackToTheGenericLine() {
+        XCTAssertEqual(QuotaError.parseFailure("").userFacingMessage, "Response format changed")
+    }
+
+    func testCredentialRejectedIsACredentialStateAndKeepsItsMessage() {
+        let error = QuotaError.credentialRejected("Key rejected — check the Access Key.")
+        XCTAssertEqual(error.userFacingMessage, "Key rejected — check the Access Key.")
+        XCTAssertTrue(error.isCredentialState)
+        XCTAssertEqual(QuotaError.credentialRejected("").userFacingMessage, "Credential rejected")
+    }
+
+    func testExistingCredentialStateSemanticsAreUnchanged() {
+        XCTAssertTrue(QuotaError.noCredential.isCredentialState)
+        XCTAssertTrue(QuotaError.needsLogin.isCredentialState)
+        XCTAssertFalse(QuotaError.parseFailure("x").isCredentialState)
+        XCTAssertFalse(QuotaError.network("x").isCredentialState)
+        XCTAssertFalse(QuotaError.rateLimited.isCredentialState)
+        XCTAssertFalse(QuotaError.notImplemented.isCredentialState)
+        XCTAssertFalse(QuotaError.unknown("x").isCredentialState)
+    }
+
+    // MARK: - Volcengine cross-references
+
+    func testVolcengineEmptyUsagePointsAtTheAgentPlanCard() {
+        let json = #"{"ResponseMetadata": {"RequestId": "r"}, "Result": {"QuotaUsage": []}}"#
+        XCTAssertThrowsError(try VolcengineResponseParser.parseUsage(data: Data(json.utf8))) { error in
+            guard let quotaError = error as? QuotaError,
+                  case .parseFailure(let message) = quotaError else {
+                return XCTFail("Expected parseFailure, got \(error)")
+            }
+            XCTAssertTrue(message.contains("no Coding Plan subscription"))
+            XCTAssertTrue(message.contains("Volcengine Agent Plan card"))
+            XCTAssertEqual(quotaError.userFacingMessage, message)
+        }
+    }
+
+    func testVolcengineMissingResultAlsoPointsAtTheAgentPlanCard() {
+        let json = #"{"ResponseMetadata": {"RequestId": "r"}}"#
+        XCTAssertThrowsError(try VolcengineResponseParser.parseUsage(data: Data(json.utf8))) { error in
+            guard let quotaError = error as? QuotaError,
+                  case .parseFailure(let message) = quotaError else {
+                return XCTFail("Expected parseFailure, got \(error)")
+            }
+            XCTAssertEqual(message, VolcengineResponseParser.noCodingPlanMessage)
+        }
+    }
+
+    func testTheTwoVolcengineCardsPointAtEachOther() {
+        XCTAssertTrue(
+            VolcengineResponseParser.noCodingPlanMessage.contains("Volcengine Agent Plan card")
+        )
+        XCTAssertTrue(
+            VolcengineAgentPlanQuotaAdapter.noAgentPlanMessage.contains("Volcengine Coding Plan card")
+        )
+    }
+
+    func testAgentPlanRejectionNamesTheAccessKeyNotALogin() {
+        let message = VolcengineAgentPlanQuotaAdapter.rejectedKeyMessage
+        XCTAssertTrue(message.contains("Access Key"))
+        XCTAssertFalse(message.lowercased().contains("re-login"))
+    }
+
+    // MARK: - Kiro
+
+    func testKiroMissingCLIExplainsHowToInstallIt() {
+        XCTAssertTrue(KiroQuotaAdapter.cliNotFoundMessage.contains("kiro-cli"))
+        XCTAssertTrue(KiroQuotaAdapter.cliNotFoundMessage.contains("kiro.dev"))
+        XCTAssertEqual(
+            QuotaError.parseFailure(KiroQuotaAdapter.cliNotFoundMessage).userFacingMessage,
+            KiroQuotaAdapter.cliNotFoundMessage
+        )
+        // Both used to render as "No account found", which is what the
+        // `.noCredential` mapping produced for a card the user had set up.
+        XCTAssertNotEqual(
+            QuotaError.parseFailure(KiroQuotaAdapter.cliFailedMessage).userFacingMessage,
+            QuotaError.noCredential.userFacingMessage
+        )
+    }
+
+    // MARK: - Z.ai region fallback
+
+    func testZaiWithNoStoredRegionKeepsTheOtherHostAsAFallback() {
+        let settings = ZaiSettings.resolve(environment: [:])
+        XCTAssertEqual(settings.quotaURL, ZaiRegion.global.quotaURL)
+        XCTAssertEqual(settings.fallbackQuotaURL, ZaiRegion.bigmodelCN.quotaURL)
+    }
+
+    func testZaiWithAnExplicitRegionHasNoFallback() {
+        let settings = ZaiSettings.resolve(
+            environment: [:],
+            providerSettings: MiscProviderSettings(region: "bigmodel-cn")
+        )
+        XCTAssertEqual(settings.quotaURL, ZaiRegion.bigmodelCN.quotaURL)
+        XCTAssertNil(settings.fallbackQuotaURL)
+    }
+
+    func testZaiEnvOverrideHasNoFallback() {
+        let settings = ZaiSettings.resolve(environment: ["Z_AI_API_HOST": "https://zai.example.com"])
+        XCTAssertNil(settings.fallbackQuotaURL)
+    }
+
+    func testOnlyAmbiguousFailuresTriggerTheOtherHost() {
+        XCTAssertTrue(ZaiQuotaAdapter.isWrongHostSignal(.credentialRejected("x")))
+        XCTAssertTrue(ZaiQuotaAdapter.isWrongHostSignal(.needsLogin))
+        XCTAssertTrue(ZaiQuotaAdapter.isWrongHostSignal(.parseFailure("Z.ai returned an empty body — …")))
+        XCTAssertFalse(ZaiQuotaAdapter.isWrongHostSignal(.rateLimited))
+        XCTAssertFalse(ZaiQuotaAdapter.isWrongHostSignal(.network("offline")))
+        XCTAssertFalse(ZaiQuotaAdapter.isWrongHostSignal(.parseFailure("Z.ai response missing data envelope.")))
+    }
+
+    // MARK: - Credential field shape checks
+
+    func testArkInferenceKeyIsRejectedByTheAgentPlanAccessKeyField() {
+        let verdict = MiscCredentialFieldRules.check(
+            tool: .volcengineAgentPlan,
+            kind: .accessKeyID,
+            value: "sk-0123456789abcdef"
+        )
+        XCTAssertFalse(verdict.allowsSave)
+        let message = verdict.message ?? ""
+        XCTAssertTrue(message.contains("Ark inference key"))
+        XCTAssertTrue(message.contains("AKLT"))
+    }
+
+    func testWellFormedAccessKeyIDIsAccepted() {
+        let verdict = MiscCredentialFieldRules.check(
+            tool: .volcengineAgentPlan,
+            kind: .accessKeyID,
+            value: "AKLTexampleexampleexample"
+        )
+        XCTAssertEqual(verdict, .accepted)
+    }
+
+    func testUnrecognizedAccessKeyShapeWarnsButStillSaves() {
+        let verdict = MiscCredentialFieldRules.check(
+            tool: .volcengineAgentPlan,
+            kind: .accessKeyID,
+            value: "AKAPexampleexample"
+        )
+        XCTAssertTrue(verdict.allowsSave)
+        XCTAssertNotNil(verdict.message)
+    }
+
+    func testSecretAccessKeyHasNoShapeRule() {
+        XCTAssertEqual(
+            MiscCredentialFieldRules.check(
+                tool: .volcengineAgentPlan,
+                kind: .secretAccessKey,
+                value: "whatever-base64=="
+            ),
+            .accepted
+        )
+    }
+
+    func testApiKeyPrefixWarnings() {
+        XCTAssertEqual(
+            MiscCredentialFieldRules.check(tool: .warp, kind: .apiKey, value: "wk-abc"),
+            .accepted
+        )
+        XCTAssertTrue(
+            MiscCredentialFieldRules.check(tool: .warp, kind: .apiKey, value: "abc").allowsSave
+        )
+        XCTAssertNotNil(
+            MiscCredentialFieldRules.check(tool: .warp, kind: .apiKey, value: "abc").message
+        )
+
+        XCTAssertEqual(
+            MiscCredentialFieldRules.check(tool: .openRouter, kind: .apiKey, value: "sk-or-v1-abc"),
+            .accepted
+        )
+        XCTAssertNotNil(
+            MiscCredentialFieldRules.check(tool: .openRouter, kind: .apiKey, value: "sk-abc").message
+        )
+
+        XCTAssertEqual(
+            MiscCredentialFieldRules.check(tool: .minimax, kind: .apiKey, value: "sk-cp-abc"),
+            .accepted
+        )
+        XCTAssertNotNil(
+            MiscCredentialFieldRules.check(tool: .minimax, kind: .apiKey, value: "eyJhbGciOi").message
+        )
+
+        // Z.ai issues `zai-…`; open.bigmodel.cn issues `<id>.<secret>`.
+        XCTAssertEqual(
+            MiscCredentialFieldRules.check(tool: .zai, kind: .apiKey, value: "zai-abc"),
+            .accepted
+        )
+        XCTAssertEqual(
+            MiscCredentialFieldRules.check(tool: .zai, kind: .apiKey, value: "abc123.def456"),
+            .accepted
+        )
+        XCTAssertNotNil(
+            MiscCredentialFieldRules.check(tool: .zai, kind: .apiKey, value: "abc123").message
+        )
+    }
+
+    func testProvidersWithoutARuleAreNeverBlocked() {
+        for tool in [ToolType.kilo, .kimi, .iflytek, .baiduQianfan, .copilot] {
+            XCTAssertEqual(
+                MiscCredentialFieldRules.check(tool: tool, kind: .apiKey, value: "anything"),
+                .accepted,
+                "\(tool.rawValue) should have no shape rule"
+            )
+        }
+    }
+
+    func testEmptyValueIsNeverRejected() {
+        XCTAssertEqual(
+            MiscCredentialFieldRules.check(tool: .volcengineAgentPlan, kind: .accessKeyID, value: "   "),
+            .accepted
+        )
+    }
+
+    // MARK: - Manual cookie sentinels
+
+    func testVolcengineCookieWithoutCsrfTokenIsRejected() {
+        let message = MiscManualCookieRules.rejectionMessage(
+            for: .volcengine,
+            header: "AccountID=1; cna=abc"
+        )
+        XCTAssertNotNil(message)
+        XCTAssertTrue(message?.contains("csrfToken") ?? false)
+        XCTAssertTrue(message?.contains("Ark console") ?? false)
+    }
+
+    func testVolcengineCookieWithCsrfTokenIsAccepted() {
+        XCTAssertNil(
+            MiscManualCookieRules.rejectionMessage(
+                for: .volcengine,
+                header: "csrfToken=abc; AccountID=1"
+            )
+        )
+    }
+
+    func testTencentNeedsBothSkeyAndUin() {
+        XCTAssertNotNil(
+            MiscManualCookieRules.rejectionMessage(for: .tencentHunyuan, header: "skey=abc")
+        )
+        XCTAssertNotNil(
+            MiscManualCookieRules.rejectionMessage(for: .tencentTokenPlan, header: "uin=o123")
+        )
+        XCTAssertNil(
+            MiscManualCookieRules.rejectionMessage(
+                for: .tencentTokenPlan,
+                header: "skey=abc; uin=o123"
+            )
+        )
+    }
+
+    func testEmptyCookieValueDoesNotCountAsPresent() {
+        XCTAssertNotNil(
+            MiscManualCookieRules.rejectionMessage(for: .volcengine, header: "csrfToken=; cna=abc")
+        )
+    }
+
+    func testOllamaNeedsARecognizedSessionCookie() {
+        XCTAssertNotNil(
+            MiscManualCookieRules.rejectionMessage(for: .ollama, header: "ph_phc_x=1")
+        )
+        XCTAssertNil(
+            MiscManualCookieRules.rejectionMessage(for: .ollama, header: "session=abc")
+        )
+        XCTAssertNil(
+            MiscManualCookieRules.rejectionMessage(
+                for: .ollama,
+                header: "next-auth.session-token=abc"
+            )
+        )
+    }
+
+    /// Alibaba, Baidu and iFlytek stitch identity from HttpOnly tickets
+    /// with no single load-bearing name, so a paste there must not be
+    /// second-guessed.
+    func testProvidersWithoutASentinelAcceptAnyHeader() {
+        for tool in [ToolType.alibaba, .alibabaTokenPlan, .baiduQianfan, .iflytek] {
+            XCTAssertTrue(MiscManualCookieRules.requiredCookieNames(for: tool).isEmpty)
+            XCTAssertNil(MiscManualCookieRules.rejectionMessage(for: tool, header: "anything=1"))
+        }
+    }
+}

--- a/Tests/VibeBarCoreTests/QuotaErrorRedactionTests.swift
+++ b/Tests/VibeBarCoreTests/QuotaErrorRedactionTests.swift
@@ -1,0 +1,134 @@
+import XCTest
+@testable import VibeBarCore
+
+/// `QuotaError` payloads are a mix of copy Vibe Bar wrote and text lifted
+/// verbatim out of a provider response — `WarpResponseParser` builds a
+/// `.parseFailure` straight from GraphQL `errors[].message`. Since the
+/// payload started reaching the card, it also started reaching two sinks
+/// that leave this machine: a public `os_log` line and the MCP projection
+/// an agent reads. Both have to be redacted, and the agent-facing one has
+/// to stay useful while it is.
+final class QuotaErrorRedactionTests: XCTestCase {
+    /// Synthetic throughout: a documented example address and a JWT-shaped
+    /// string that is not a credential for anything.
+    private let leakyDiagnostic =
+        "Warp GraphQL: user quota-user@example.com rejected, session eyJhbGciOiJIUzI1NiJ9xxxxx"
+
+    // MARK: - Log projection
+
+    func testLogProjectionMasksAnEmailAndATokenFromAProviderPayload() {
+        let logged = QuotaError.parseFailure(leakyDiagnostic).logSafeMessage
+        XCTAssertFalse(logged.contains("quota-user@example.com"))
+        XCTAssertFalse(logged.contains("eyJhbGciOiJIUzI1NiJ9xxxxx"))
+        XCTAssertTrue(logged.contains("***"))
+    }
+
+    func testLogProjectionCoversEveryPayloadCarryingCase() {
+        for error: QuotaError in [
+            .parseFailure(leakyDiagnostic),
+            .network(leakyDiagnostic),
+            .unknown(leakyDiagnostic),
+            .credentialRejected(leakyDiagnostic)
+        ] {
+            XCTAssertFalse(
+                error.logSafeMessage.contains("eyJhbGciOiJIUzI1NiJ9xxxxx"),
+                "\(error) leaked a token into the log projection"
+            )
+        }
+    }
+
+    func testCuratedMessagesWithoutSecretsSurviveTheLogProjection() {
+        let error = QuotaError.parseFailure(VolcengineResponseParser.noCodingPlanMessage)
+        XCTAssertTrue(error.logSafeMessage.contains("no Coding Plan subscription"))
+        XCTAssertTrue(error.logSafeMessage.contains("Volcengine Agent Plan card"))
+    }
+
+    // MARK: - Agent projection
+
+    func testAgentProjectionMasksAnEmailAndAToken() {
+        let projected = QuotaError.parseFailure(leakyDiagnostic).agentFacingMessage
+        XCTAssertFalse(projected.contains("quota-user@example.com"))
+        XCTAssertFalse(projected.contains("eyJhbGciOiJIUzI1NiJ9xxxxx"))
+    }
+
+    /// The agent still has to be able to act on the message, so the
+    /// redactor that feeds it must not flatten ordinary hostnames the way
+    /// the log redactor does.
+    func testAgentProjectionKeepsTheActionableHalfOfACuratedMessage() {
+        let error = QuotaError.credentialRejected(
+            "The imported Volcengine cookies have no csrfToken. Open the Ark console once in your browser (console.volcengine.com/ark), then re-import."
+        )
+        XCTAssertTrue(error.agentFacingMessage.contains("console.volcengine.com"))
+        XCTAssertTrue(error.agentFacingMessage.contains("csrfToken"))
+    }
+
+    func testAgentProjectionCapsARunawayProviderPayload() {
+        let flood = String(repeating: "stack frame. ", count: 200)
+        let projected = QuotaError.network(flood).agentFacingMessage
+        XCTAssertLessThanOrEqual(
+            projected.count,
+            ProviderDiagnosticRedactor.defaultMaxLength + 1
+        )
+        XCTAssertTrue(projected.hasSuffix("…"))
+    }
+
+    // MARK: - The MCP DTO uses the agent projection
+
+    func testMCPAccountProjectionDoesNotShipTheRawProviderPayload() {
+        let quota = AccountQuota(
+            accountId: "misc-warp",
+            tool: .warp,
+            buckets: [],
+            plan: nil,
+            email: "quota-user@example.com",
+            queriedAt: Date(timeIntervalSince1970: 1_786_968_000)
+        )
+        let dto = MCPQuotaAccountDTO(
+            quota: quota,
+            lastUpdated: nil,
+            lastAttempted: nil,
+            inFlight: false,
+            error: .parseFailure(leakyDiagnostic)
+        )
+
+        let error = dto.error ?? ""
+        XCTAssertFalse(error.isEmpty)
+        XCTAssertFalse(error.contains("quota-user@example.com"))
+        XCTAssertFalse(error.contains("eyJhbGciOiJIUzI1NiJ9xxxxx"))
+        // The account's own email was already masked; the one inside the
+        // diagnostic must not sneak past on a different route.
+        XCTAssertFalse((dto.email ?? "").contains("quota-user@example.com"))
+    }
+
+    // MARK: - Redaction at construction, for the named example
+
+    func testWarpRedactsGraphQLErrorsBeforeTheyBecomeAQuotaError() {
+        let body = """
+        {"errors": [{"message": "denied for quota-user@example.com token eyJhbGciOiJIUzI1NiJ9xxxxx"}]}
+        """
+        XCTAssertThrowsError(try WarpResponseParser.parse(data: Data(body.utf8), now: Date())) { error in
+            guard let quotaError = error as? QuotaError,
+                  case .parseFailure(let message) = quotaError else {
+                return XCTFail("Expected parseFailure, got \(error)")
+            }
+            XCTAssertFalse(message.contains("quota-user@example.com"))
+            XCTAssertFalse(message.contains("eyJhbGciOiJIUzI1NiJ9xxxxx"))
+        }
+    }
+
+    // MARK: - Redactor behaviour
+
+    func testRedactorMasksAddressesAndOpaqueRunsButKeepsWords() {
+        let redacted = ProviderDiagnosticRedactor.redact(
+            "quota-user@example.com asked api.z.ai for a plan and got AKLTaaaaaaaaaaaaaaaaaaaaaa"
+        )
+        XCTAssertFalse(redacted.contains("quota-user@example.com"))
+        XCTAssertFalse(redacted.contains("AKLTaaaaaaaaaaaaaaaaaaaaaa"))
+        XCTAssertTrue(redacted.contains("api.z.ai"))
+        XCTAssertTrue(redacted.contains("asked"))
+    }
+
+    func testRedactorCollapsesNewlines() {
+        XCTAssertFalse(ProviderDiagnosticRedactor.redact("first\nsecond").contains("\n"))
+    }
+}

--- a/Tests/VibeBarCoreTests/VolcengineAgentPlanParserTests.swift
+++ b/Tests/VibeBarCoreTests/VolcengineAgentPlanParserTests.swift
@@ -80,15 +80,39 @@ final class VolcengineAgentPlanParserTests: XCTestCase {
         XCTAssertEqual(snap.buckets[0].usedPercent, 0, accuracy: 0.0001)
     }
 
-    func testInvalidStateMapsToNeedsLogin() {
+    /// This card is signed with an Access Key pair and has no login of its
+    /// own, so an auth-shaped failure has to name the key, not a re-login
+    /// the user cannot perform here.
+    func testInvalidStateMapsToCredentialRejected() {
         let json = """
         {"ResponseMetadata": {"Error": {"Code": "InvalidState", "Message": "登录态已更新"}}}
         """
         XCTAssertThrowsError(try VolcengineAgentPlanResponseParser.parseUsage(data: Data(json.utf8))) { error in
-            guard let qe = error as? QuotaError, case .needsLogin = qe else {
-                XCTFail("Expected needsLogin, got \(error)")
+            guard let qe = error as? QuotaError, case .credentialRejected(let message) = qe else {
+                XCTFail("Expected credentialRejected, got \(error)")
                 return
             }
+            XCTAssertTrue(qe.isCredentialState)
+            XCTAssertTrue(message.contains("Access Key"))
+            XCTAssertEqual(qe.userFacingMessage, message)
+        }
+    }
+
+    /// A 200 with no Agent Plan windows is what a Coding-Plan-only account
+    /// gets, so the message has to point at the other card instead of
+    /// blaming the response shape.
+    func testMissingWindowsPointsAtTheCodingPlanCard() {
+        let json = """
+        {"Result": {"PlanType": "small"}}
+        """
+        XCTAssertThrowsError(try VolcengineAgentPlanResponseParser.parseUsage(data: Data(json.utf8))) { error in
+            guard let qe = error as? QuotaError, case .parseFailure(let message) = qe else {
+                XCTFail("Expected parseFailure, got \(error)")
+                return
+            }
+            XCTAssertTrue(message.contains("no Agent Plan subscription"))
+            XCTAssertTrue(message.contains("Volcengine Coding Plan card"))
+            XCTAssertEqual(qe.userFacingMessage, message)
         }
     }
 


### PR DESCRIPTION
## Summary

Provider-setup UX fixes from the 2026-09-03 audit (the maintainer's example: "with Volcengine I don't know that Coding Plan and Agent Plan are fetched differently, or which key to use").

- **Errors reach the card.** `QuotaError.parseFailure` now renders its payload (was always "Response format changed"). New `credentialRejected(String)` keeps `isCredentialState == true` (cached-quota grace + cookie auto-reimport unchanged) but says what is wrong on API-key / AK/SK paths instead of "Needs re-login". Volcengine Coding Plan and Agent Plan each point at the other card when the account has the other plan; missing `csrfToken` says "open the Ark console once, then re-import"; Kiro reports that `kiro-cli` is not installed; Z.ai's empty-body diagnosis is no longer lost.
- **Setup notes + console links** on every misc credential row (`ToolType.statusPageURL` already held the URLs; the Agent Plan deep link is used). Kimi, iFlytek, Ollama, OpenCode Go, Kilo, Kiro, OpenRouter get real help text; each note says whether a usage API key exists at all.
- **Sidebar**: plan-qualified names ("Volcengine Coding Plan" / "Volcengine Agent Plan", same for Bailian and Tencent) and search over plan/brand aliases (Agent Plan, Token Plan, Doubao, DashScope, BigModel, …).
- **Inline validation** (`MiscProviderCredentialRules`): an `sk-…` Ark key in the Agent Plan Access Key field is rejected with the fix; missing `AKLT` / `wk-` / `sk-or-` / `sk-cp-` / `zai-` prefixes warn but save; hand-pasted cookie headers must carry the adapter's sentinel (Volcengine `csrfToken`, Tencent `skey`+`uin`, Ollama session).
- **Keychain cooldown surfaced**: a declined Keychain prompt shows "…will not ask again until <time>" with Retry now; the documented "Reset browser-cookie cooldown" button now exists on the Misc landing page.
- Z.ai gets "Auto (try both)" with a host fallback; "Set up in Settings" opens the provider's own row; removing a provider copy confirms the Keychain deletion; per-slot provenance badge and averaged-quota wording; onboarding step renamed "Other plans" and the batch import is mentioned in the browser-cookies step; dead `.cursor`/`.antigravity` credential rows removed.

## Test plan

- [x] `swift build`
- [x] `swift test` — 1812 tests, 0 failures (26 new in `MiscProviderSetupUXTests`, +3 `BrowserCookieGateTests`, Volcengine Agent Plan parser tests updated)
- [x] `grep '/Users/[a-z]'` over Sources/Tests empty
- [ ] After install: Settings sidebar shows two distinct Volcengine rows and finds "Agent Plan"; pasting `sk-…` into Access Key ID is rejected; cookie header without `csrfToken` is rejected; Keychain decline shows the cooldown row with Retry; Z.ai region menu has Auto; "Set up in Settings" lands on the provider

🤖 Generated with [Claude Code](https://claude.com/claude-code)