### PR TITLE
Bound the transcript viewer and stop Workbench pages from rescanning

### DIFF
--- a/Sources/VibeBarApp/AppEnvironment.swift
+++ b/Sources/VibeBarApp/AppEnvironment.swift
@@ -57,6 +57,7 @@ final class AppEnvironment: ObservableObject {
     /// there is no status item to anchor to.
     var presentPopoverHandler: (() -> Void)?
     private var workbenchServicesStorage: WorkbenchServices?
+    private var sessionIndexStorage: SharedSessionIndex?
     private var cancellables: Set<AnyCancellable> = []
     private var routineBudgetInFlightAccountIds: Set<String> = []
     private var lastRoutineBudgetAttemptByAccount: [String: Date] = [:]
@@ -708,10 +709,29 @@ final class AppEnvironment: ObservableObject {
             usageLedger: usageLedger,
             costService: costService,
             settingsStore: settingsStore,
-            skillsService: skillsService
+            skillsService: skillsService,
+            sessionIndex: { [unowned self] in self.sessionIndex }
         )
         workbenchServicesStorage = services
         return services
+    }
+
+    /// Wind down the Workbench's background work when its window closes.
+    /// Reaches only the page models that were actually built — a session that
+    /// never opened Usage Stats must not construct it on the way out.
+    func stopWorkbenchBackgroundWork() {
+        workbenchServicesStorage?.stopBackgroundWork()
+    }
+
+    /// The app's single session-index connection, opened on the first use —
+    /// which is either the Workbench's Sessions page or an agent's
+    /// `sessions.*` MCP call, whichever comes first. A menu-bar-only session
+    /// never opens the SQLite file at all.
+    var sessionIndex: SharedSessionIndex {
+        if let sessionIndexStorage { return sessionIndexStorage }
+        let index = SharedSessionIndex(settingsStore: settingsStore)
+        sessionIndexStorage = index
+        return index
     }
 
     /// Front an already-open Workbench without creating one. Used by the Dock

--- a/Sources/VibeBarApp/Controllers/SessionManagerModel.swift
+++ b/Sources/VibeBarApp/Controllers/SessionManagerModel.swift
@@ -318,19 +318,31 @@ final class SessionManagerModel: ObservableObject {
         refreshIndex()
     }
 
+    /// Wind down everything this page has in flight.
+    ///
+    /// Cancelling the tasks is only half of it: each of them owns a piece of
+    /// published "…in progress" state that its completion path would have
+    /// cleared, and a cancelled task never reaches that path. Leaving them
+    /// set is what would make a reopened Workbench sit on "Reading the
+    /// session log…" or a permanent scan bar for a task that no longer
+    /// exists, until the user happened to click something.
     func stop() {
         searchTask?.cancel()
         directoryFilterTask?.cancel()
         refreshTask?.cancel()
         toastTask?.cancel()
         rowsTask?.cancel()
-        transcriptTask?.cancel()
+        cancelTranscriptParse()
         searchTask = nil
         directoryFilterTask = nil
         refreshTask = nil
         toastTask = nil
         rowsTask = nil
-        transcriptTask = nil
+
+        isLoadingTranscript = false
+        isPreparingRows = false
+        isLoadingSummaries = false
+        indexProgress = nil
     }
 
     // MARK: - Index
@@ -349,8 +361,22 @@ final class SessionManagerModel: ObservableObject {
         refreshTask = Task { [weak self] in
             // Wait out a compaction pass rather than fighting it for the
             // write lock; `SessionIndexMaintenanceGate` explains the split.
+            // The wait is cancellable, and it claims nothing when it throws,
+            // so the closing Workbench does not leave the gate held.
             let gate = SessionIndexMaintenanceGate.shared
-            await gate.acquire()
+            do {
+                try await gate.acquire()
+            } catch {
+                await MainActor.run { self?.indexProgress = nil }
+                return
+            }
+            // Cancelled while queued: hand the gate straight back rather than
+            // starting an 11 000-file sweep for a window that is closing.
+            guard !Task.isCancelled else {
+                await gate.release()
+                await MainActor.run { self?.indexProgress = nil }
+                return
+            }
             await service.refreshIndex(progress: progress)
             await gate.release()
             guard let self, !Task.isCancelled else { return }
@@ -916,11 +942,25 @@ final class SessionManagerModel: ObservableObject {
     /// rather than as the thing the user just asked for.
     func cancelTranscriptLoad() {
         guard isLoadingTranscript else { return }
+        cancelTranscriptParse()
+        isLoadingTranscript = false
+        transcriptError = Self.cancelledTranscriptMessage
+    }
+
+    static let cancelledTranscriptMessage =
+        "Reading this session was stopped. Select it again to reopen it."
+
+    /// Cancel the parse itself, not just the task waiting on it.
+    ///
+    /// `Task.detached` does not inherit cancellation, so cancelling the
+    /// waiter alone left the parser allocating gigabytes in the background —
+    /// and let a second selection start a second one beside it. The waiter
+    /// forwards its cancellation to the detached handle through
+    /// `withTaskCancellationHandler`; this is the one place that starts it.
+    private func cancelTranscriptParse() {
         transcriptTask?.cancel()
         transcriptTask = nil
         transcriptGeneration &+= 1
-        isLoadingTranscript = false
-        transcriptError = "Reading this session was stopped. Select it again to reopen it."
     }
 
     private func load(
@@ -933,14 +973,12 @@ final class SessionManagerModel: ObservableObject {
         // only discarded a stale *result*, so clicking through three large
         // sessions ran three full parses side by side and paid for all of
         // them.
-        transcriptTask?.cancel()
-        transcriptTask = nil
+        cancelTranscriptParse()
         selection = summary
         self.focusSeq = focusSeq
         transcript = nil
         transcriptError = nil
         transcriptTruncation = nil
-        transcriptGeneration &+= 1
         guard let summary else {
             isLoadingTranscript = false
             return
@@ -992,6 +1030,13 @@ final class SessionManagerModel: ObservableObject {
     /// `headByteLimit` is the memory bound. `range:` is not one: every kit
     /// adapter materializes the whole document before slicing it, so the only
     /// place a limit can be applied is the bytes handed to the parser.
+    ///
+    /// The detached task's handle is held and cancelled with the caller.
+    /// `Task.detached` deliberately inherits nothing — including
+    /// cancellation — so without this forwarding, cancelling the waiter left
+    /// the parser running: an unbounded "Load entire transcript" kept
+    /// allocating after the pane had moved on, and each further selection
+    /// stacked another parse beside it.
     private nonisolated static func parse(
         adapter: any SessionProviderAdapter,
         url: URL,
@@ -1001,7 +1046,7 @@ final class SessionManagerModel: ObservableObject {
         headByteLimit: Int64?,
         scratchDirectory: URL
     ) async -> ParsedTranscript {
-        await Task.detached(priority: .userInitiated) {
+        let handle = Task.detached(priority: .userInitiated) {
             do {
                 let read = try SessionIndexingBounds.readTranscript(
                     adapter: adapter,
@@ -1034,7 +1079,7 @@ final class SessionManagerModel: ObservableObject {
                 for review in related.sorted(by: {
                     ($0.createdAt ?? .distantPast) < ($1.createdAt ?? .distantPast)
                 }) {
-                    guard !Task.isCancelled else { break }
+                    try Task.checkCancellation()
                     // Children are bounded on the same terms as the parent.
                     guard let child = try? SessionIndexingBounds.readTranscript(
                         adapter: adapter,
@@ -1058,6 +1103,9 @@ final class SessionManagerModel: ObservableObject {
                         translatedFocus = childStart + childIndex
                     }
                 }
+                // Resequencing allocates a second copy of every message, so
+                // it is worth not starting on a result nobody will read.
+                try Task.checkCancellation()
                 let resequenced = messages.enumerated().map { index, message in
                     SessionMessage(
                         seq: index,
@@ -1076,6 +1124,16 @@ final class SessionManagerModel: ObservableObject {
                     focusSeq: translatedFocus,
                     truncation: nil
                 )
+            } catch is CancellationError {
+                // Not a read failure. The waiter normally drops this on its
+                // own cancellation check; the message is here for the race
+                // where the parse gave up first.
+                return ParsedTranscript(
+                    document: nil,
+                    errorMessage: cancelledTranscriptMessage,
+                    focusSeq: nil,
+                    truncation: nil
+                )
             } catch {
                 return ParsedTranscript(
                     document: nil,
@@ -1085,7 +1143,12 @@ final class SessionManagerModel: ObservableObject {
                     truncation: nil
                 )
             }
-        }.value
+        }
+        return await withTaskCancellationHandler {
+            await handle.value
+        } onCancel: {
+            handle.cancel()
+        }
     }
 
     // MARK: - Resume

--- a/Sources/VibeBarApp/Controllers/SessionManagerModel.swift
+++ b/Sources/VibeBarApp/Controllers/SessionManagerModel.swift
@@ -74,7 +74,7 @@ final class SessionManagerModel: ObservableObject {
     }
 
     /// One list row: a session, plus where a full-text hit landed in it.
-    struct Row: Identifiable, Hashable {
+    struct Row: Identifiable, Hashable, Sendable {
         let summary: SessionSummary
         let snippet: String?
         let matchedSeq: Int?
@@ -84,11 +84,24 @@ final class SessionManagerModel: ObservableObject {
         var id: String { summary.id }
     }
 
-    struct ProjectGroup: Identifiable {
+    struct ProjectGroup: Identifiable, Sendable {
         let title: String
         let rows: [Row]
 
         var id: String { title }
+    }
+
+    /// Why the open transcript stops where it does.
+    ///
+    /// Present only when the viewer read a head window instead of the whole
+    /// file. The kit's adapters materialize every message before applying
+    /// `range:`, so the bound has to be in bytes and it has to be applied
+    /// before the parse — which means the reader genuinely does not know how
+    /// many messages the rest of the file holds.
+    struct TranscriptTruncation: Equatable, Sendable {
+        let shownMessages: Int
+        let parsedBytes: Int64
+        let fileBytes: Int64
     }
 
     // MARK: - Published state
@@ -110,12 +123,20 @@ final class SessionManagerModel: ObservableObject {
     @Published private(set) var harnessCounts: [Harness: Int] = [:]
     @Published private(set) var totalSessionCount = 0
     @Published private(set) var isLoadingSummaries = false
+    /// A rows build is in flight. The derivation moved off the main actor, so
+    /// there is now a turn between "summaries arrived" and "rows published" —
+    /// and an empty list during that turn is not the same thing as "nothing
+    /// matches".
+    @Published private(set) var isPreparingRows = false
 
     @Published var searchText = "" {
         didSet {
             guard oldValue != searchText else { return }
             scheduleSearch()
-            refreshRows()
+            // Debounced: a keystroke used to re-filter, re-sort and re-group
+            // every loaded summary synchronously on the main actor before the
+            // character it typed was drawn.
+            refreshRows(debounced: true)
         }
     }
     @Published var searchScopes = SessionSearchScope.defaultScopes {
@@ -166,6 +187,8 @@ final class SessionManagerModel: ObservableObject {
     @Published private(set) var transcript: TranscriptDocument?
     @Published private(set) var transcriptError: String?
     @Published private(set) var isLoadingTranscript = false
+    /// Non-nil while the open transcript is a head window of a larger file.
+    @Published private(set) var transcriptTruncation: TranscriptTruncation?
 
     @Published var isDeleteMode = false {
         didSet {
@@ -193,24 +216,45 @@ final class SessionManagerModel: ObservableObject {
     private let homeDirectory: String
     private let registry: SessionProviderRegistry
     private let deleter: SessionDeleter
-    private let store: SessionIndexStore?
-    private let service: SessionIndexService?
-    private let bodyIndexing: BodyIndexingFlag
+    private let index: SharedSessionIndex
+
+    private var store: SessionIndexStore? { index.store }
+    private var service: SessionIndexService? { index.service }
 
     private var searchTask: Task<Void, Never>?
     private var directoryFilterTask: Task<Void, Never>?
     private var refreshTask: Task<Void, Never>?
     private var toastTask: Task<Void, Never>?
+    private var rowsTask: Task<Void, Never>?
+    /// The parse behind the open transcript. Held so a second click cancels
+    /// the first: three 1 GB sessions in a row used to mean three concurrent
+    /// full parses, of which two were discarded on arrival by a generation
+    /// check that had already let them allocate everything.
+    private var transcriptTask: Task<Void, Never>?
     private var transcriptGeneration: UInt64 = 0
     private var searchGeneration: UInt64 = 0
     private var summaryGeneration: UInt64 = 0
-    private var hasActivated = false
     private var lastScanFinishedAt: Date?
     private var reviewSummariesByParent: [String: [SessionSummary]] = [:]
     private var relatedHitByParent: [String: SessionSummary] = [:]
+    /// Bumped whenever the index's contents can have moved (a completed
+    /// refresh, a rebuild, a delete). Everything derived from a whole-index
+    /// query — the review children and the harness chip counts — is fetched
+    /// once per value of this rather than on every filter change.
+    private var indexGeneration: UInt64 = 0
+    private var indexDerivedGeneration: UInt64?
+    /// Parent rows already resolved for auto-review hits, valid for one
+    /// `indexGeneration`.
+    private var parentSummaryCache: [String: SessionSummary] = [:]
 
-    /// Floor between two automatic sweeps. A manual refresh ignores it.
-    private static let rescanMinimumInterval: TimeInterval = 30
+    /// Floor between two activation sweeps.
+    ///
+    /// This used to be 30 seconds, which made every Workbench tab click cost
+    /// a full walk of every provider's session tree — 11 000 files on a busy
+    /// Mac. Re-opening the window after a while still rescans (the CLIs were
+    /// writing the whole time it was shut); moving between pages does not.
+    /// The Refresh button ignores this entirely.
+    private static let rescanMinimumInterval: TimeInterval = 10 * 60
 
     /// Long enough that a fast typist never pays for an intermediate query,
     /// short enough that pausing to read the list feels like it already ran.
@@ -219,63 +263,58 @@ final class SessionManagerModel: ObservableObject {
     /// thousands of main-actor hops between the user and a scroll.
     private nonisolated static let progressStride = 250
     private static let summaryPageSize = 250
+    /// Ceiling on how many summaries the page keeps loaded.
+    ///
+    /// The list is a `LazyVStack`, which builds rows lazily but never
+    /// releases them, so "scroll to the bottom of 11 000 sessions" is a
+    /// promise to hold 11 000 built rows — each with its own hover state and
+    /// up to four `.help()` strings. Eight pages is more than anyone reads in
+    /// one sitting, and the filters and full-text search are the way to reach
+    /// the rest.
+    static let maximumLoadedSummaries = 2_000
 
     var hasMoreSummaries: Bool {
-        summaries.count < totalSessionCount
+        summaries.count < min(totalSessionCount, Self.maximumLoadedSummaries)
     }
 
-    init(settingsStore: SettingsStore, homeDirectory: String = RealHomeDirectory.path) {
-        let registry = SessionProviderRegistry.standard(homeDirectory: homeDirectory)
+    /// True when the list stops short of the index because of the ceiling
+    /// above rather than because that is all there is.
+    var isSummaryListCapped: Bool {
+        totalSessionCount > Self.maximumLoadedSummaries
+            && summaries.count >= Self.maximumLoadedSummaries
+    }
+
+    init(
+        settingsStore: SettingsStore,
+        index: SharedSessionIndex,
+        homeDirectory: String = RealHomeDirectory.path
+    ) {
         self.settingsStore = settingsStore
         self.homeDirectory = homeDirectory
-        self.registry = registry
+        // The raw registry, deliberately: the transcript viewer and the
+        // deleter must see whole sessions. The *indexing* registry is the
+        // bounded one and lives on `SharedSessionIndex`.
+        self.registry = SessionProviderRegistry.standard(homeDirectory: homeDirectory)
         self.deleter = SessionDeleter(homeDirectory: homeDirectory)
-        let flag = BodyIndexingFlag(settingsStore.settings.sessionBodyIndexingEnabled)
-        self.bodyIndexing = flag
-
-        // Same shape as the usage ledger in `AppEnvironment`: a database that
-        // will not open costs this page its index, not the app.
-        let opened: SessionIndexStore?
-        do {
-            opened = try SessionIndexStore(url: VibeBarLocalStore.sessionIndexURL)
-        } catch {
-            SafeLog.warn("Opening the session index failed: \(SafeLog.sanitize(error.localizedDescription))")
-            opened = nil
-        }
-        self.store = opened
-        self.isIndexAvailable = opened != nil
-        self.service = opened.map {
-            SessionIndexService(
-                homeDirectory: homeDirectory,
-                store: $0,
-                // The indexer gets the bounded adapters: oversized rollouts
-                // are parsed from a head copy (memory) and excerpts are
-                // pre-trimmed to the host policy (index size). The raw
-                // `registry` stays for the transcript viewer and the
-                // deleter, which must see whole sessions.
-                registry: SessionIndexingBounds.boundedRegistry(
-                    registry,
-                    scratchDirectory: VibeBarLocalStore
-                        .sessionIndexScratchDirectoryURL(homeDirectory: homeDirectory)
-                ),
-                bodyIndexing: { flag.current }
-            )
-        }
+        self.index = index
+        self.isIndexAvailable = index.store != nil
     }
 
     // MARK: - Lifecycle
 
-    /// Cached rows first, disk second. Re-opening the window re-scans, since
-    /// the CLIs have been writing sessions the whole time it was shut — but
-    /// switching between Workbench pages re-runs this too, and a full sweep
-    /// of every provider's logs is not what a tab click should cost.
+    /// Cached rows first, disk second — and the two are never sequenced.
+    ///
+    /// The summary query answers from the last scan and paints immediately;
+    /// the scan, when one is due at all, runs behind it and re-queries when
+    /// it lands. Re-opening the window after a while re-scans, since the CLIs
+    /// have been writing sessions the whole time it was shut, but switching
+    /// between Workbench pages must not.
     func activate() {
         reloadSummaryPage(reset: true)
         guard refreshTask == nil else { return }
         if let last = lastScanFinishedAt, Date().timeIntervalSince(last) < Self.rescanMinimumInterval {
             return
         }
-        hasActivated = true
         refreshIndex()
     }
 
@@ -284,10 +323,14 @@ final class SessionManagerModel: ObservableObject {
         directoryFilterTask?.cancel()
         refreshTask?.cancel()
         toastTask?.cancel()
+        rowsTask?.cancel()
+        transcriptTask?.cancel()
         searchTask = nil
         directoryFilterTask = nil
         refreshTask = nil
         toastTask = nil
+        rowsTask = nil
+        transcriptTask = nil
     }
 
     // MARK: - Index
@@ -304,11 +347,17 @@ final class SessionManagerModel: ObservableObject {
             }
         }
         refreshTask = Task { [weak self] in
+            // Wait out a compaction pass rather than fighting it for the
+            // write lock; `SessionIndexMaintenanceGate` explains the split.
+            let gate = SessionIndexMaintenanceGate.shared
+            await gate.acquire()
             await service.refreshIndex(progress: progress)
+            await gate.release()
             guard let self, !Task.isCancelled else { return }
             self.indexProgress = nil
             self.refreshTask = nil
             self.lastScanFinishedAt = Date()
+            self.invalidateIndexDerivedState()
             self.reloadSummaryPage(reset: true)
             self.rerunSearch()
             // A refresh is when churn lands in the index, so it is the
@@ -318,6 +367,12 @@ final class SessionManagerModel: ObservableObject {
                 await SessionIndexCompactor.standard.compactIfDue()
             }
         }
+    }
+
+    /// Everything derived from a whole-index query is stale now.
+    private func invalidateIndexDerivedState() {
+        indexGeneration &+= 1
+        parentSummaryCache.removeAll(keepingCapacity: true)
     }
 
     /// Throw the index away and rebuild it from disk. The escape hatch for a
@@ -330,6 +385,7 @@ final class SessionManagerModel: ObservableObject {
             let cleared = (try? await store.eraseAll()) != nil
             guard let self else { return }
             if !cleared { self.show(toast: "The session index could not be cleared.") }
+            self.invalidateIndexDerivedState()
             self.summaries = []
             self.hits = []
             self.totalSessionCount = 0
@@ -367,31 +423,45 @@ final class SessionManagerModel: ObservableObject {
         case .oldestFirst: order = .oldestFirst
         case .byProject: order = .byProject
         }
+        // Chip counts and the Auto Review children are whole-index facts:
+        // they do not depend on the harness, date, sort or directory filter
+        // that triggered this reload. Re-asking for up to 2 000 review
+        // summaries on every chip click was the page's most expensive habit.
+        let currentIndexGeneration = indexGeneration
+        let needsIndexDerived = reset && indexDerivedGeneration != currentIndexGeneration
+        let includes = directoryIncludes
+        let excludes = directoryExcludes
         isLoadingSummaries = true
         Task { [weak self] in
             let page = try? await service.summaryPage(
                 harnesses: harnesses,
                 since: since,
-                projectIncludes: self?.directoryIncludes ?? [],
-                projectExcludes: self?.directoryExcludes ?? [],
+                projectIncludes: includes,
+                projectExcludes: excludes,
                 excludingProviderVariantPrefix: CodexSessionAdapter.autoReviewVariantPrefix,
                 order: order,
                 offset: offset,
                 limit: Self.summaryPageSize
             )
-            let counts = reset ? (try? await service.harnessCounts()) : nil
-            let reviews = reset ? (try? await service.summaries(
+            let counts = needsIndexDerived ? (try? await service.harnessCounts()) : nil
+            let reviews = needsIndexDerived ? (try? await service.summaries(
                 provider: .codex,
                 providerVariantPrefix: CodexSessionAdapter.autoReviewVariantPrefix
             )) : nil
             guard let self, generation == self.summaryGeneration else { return }
+            if needsIndexDerived, counts != nil || reviews != nil {
+                self.indexDerivedGeneration = currentIndexGeneration
+            }
             self.isLoadingSummaries = false
             guard let page else { return }
             if reset {
-                self.summaries = page.summaries
+                self.summaries = Array(page.summaries.prefix(Self.maximumLoadedSummaries))
             } else {
                 let existing = Set(self.summaries.map(\.id))
-                self.summaries.append(contentsOf: page.summaries.filter { !existing.contains($0.id) })
+                let room = max(0, Self.maximumLoadedSummaries - self.summaries.count)
+                self.summaries.append(contentsOf: page.summaries
+                    .filter { !existing.contains($0.id) }
+                    .prefix(room))
             }
             self.totalSessionCount = page.totalCount
             // A demo launch opens the newest session so the transcript pane
@@ -465,13 +535,42 @@ final class SessionManagerModel: ObservableObject {
             projectExcludes: directoryExcludes,
             limit: 200
         )) ?? []
+
+        // Resolve every Auto Review child to its parent in one hop.
+        //
+        // This used to be one `await service.summary(...)` per hit inside the
+        // loop: up to 200 main-actor → index-actor → main-actor round trips
+        // for a single search, most of them asking for a parent the last hit
+        // had already fetched. agent-session-kit 0.7.0 has no `IN`-list
+        // lookup (`summaries(provider:)` only takes a variant prefix), so the
+        // batching is host-side: dedupe the ids, answer what the loaded page
+        // and the per-generation cache already know, and ask the index only
+        // for the remainder — from a single detached task, so the main actor
+        // is entered once rather than 200 times.
+        var wanted: [String] = []
+        var seenWanted: Set<String> = []
+        for hit in found {
+            guard let parentID = CodexSessionAdapter.autoReviewParentSessionID(
+                providerVariant: hit.summary.providerVariant
+            ) else { continue }
+            guard parentSummaryCache[parentID] == nil, seenWanted.insert(parentID).inserted else {
+                continue
+            }
+            wanted.append(parentID)
+        }
+        if !wanted.isEmpty {
+            let fetched = await Self.resolveParentSummaries(service: service, sessionIDs: wanted)
+            guard generation == searchGeneration else { return }
+            parentSummaryCache.merge(fetched) { _, new in new }
+        }
+
         var resolved: [SessionSearchHit] = []
         var seen: Set<String> = []
         var relatedHits: [String: SessionSummary] = [:]
         for hit in found {
             if let parentID = CodexSessionAdapter.autoReviewParentSessionID(
                 providerVariant: hit.summary.providerVariant
-            ), let parent = try? await service.summary(provider: .codex, sessionID: parentID) {
+            ), let parent = parentSummaryCache[parentID] {
                 guard seen.insert(parent.id).inserted else { continue }
                 relatedHits[parent.id] = hit.summary
                 resolved.append(SessionSearchHit(
@@ -487,6 +586,24 @@ final class SessionManagerModel: ObservableObject {
         guard generation == searchGeneration else { return }
         relatedHitByParent = relatedHits
         hits = resolved
+    }
+
+    /// One detached pass over the deduped parent ids. Cancellation is checked
+    /// per id so an abandoned search stops paying immediately.
+    private nonisolated static func resolveParentSummaries(
+        service: SessionIndexService,
+        sessionIDs: [String]
+    ) async -> [String: SessionSummary] {
+        await Task.detached(priority: .userInitiated) {
+            var out: [String: SessionSummary] = [:]
+            for sessionID in sessionIDs {
+                guard !Task.isCancelled else { return out }
+                if let parent = try? await service.summary(provider: .codex, sessionID: sessionID) {
+                    out[sessionID] = parent
+                }
+            }
+            return out
+        }.value
     }
 
     private func scheduleDirectoryFilter() {
@@ -517,35 +634,99 @@ final class SessionManagerModel: ObservableObject {
     /// only that one can match on what was said inside a session. An empty
     /// full-text result falls back rather than blanking the list — the
     /// substring filter also matches session ids, which the index does not.
-    private func refreshRows() {
-        let needle = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
-        let base: [Row]
-        if !needle.isEmpty, !hits.isEmpty {
-            base = hits.map {
-                Row(
-                    summary: $0.summary,
-                    snippet: $0.snippet,
-                    matchedSeq: $0.matchedSeq,
-                    matchedRelated: relatedHitByParent[$0.summary.id],
-                    reviewCount: reviewSummariesByParent[$0.summary.sessionID]?.count ?? 0
-                )
+    private func refreshRows(debounced: Bool = false) {
+        rowsTask?.cancel()
+        let input = RowInput(
+            summaries: summaries,
+            hits: hits,
+            relatedHitByParent: relatedHitByParent,
+            reviewCounts: reviewSummariesByParent.reduce(into: [String: Int]()) {
+                $0[$1.key] = $1.value.count
+            },
+            needle: searchText.trimmingCharacters(in: .whitespacesAndNewlines),
+            scopes: searchScopes,
+            harnessFilter: harnessFilter,
+            since: dateRange.start(),
+            sortOrder: sortOrder,
+            groupByProject: groupByProject
+        )
+        isPreparingRows = true
+        rowsTask = Task { [weak self] in
+            if debounced {
+                try? await Task.sleep(for: Self.searchDebounce)
+                guard !Task.isCancelled else { return }
             }
-        } else {
-            base = filteredSummaries(matching: needle).map {
-                Row(
-                    summary: $0,
-                    snippet: nil,
-                    matchedSeq: nil,
-                    matchedRelated: nil,
-                    reviewCount: reviewSummariesByParent[$0.sessionID]?.count ?? 0
-                )
-            }
+            let output = await Self.buildRows(input)
+            guard let self, !Task.isCancelled else { return }
+            self.rows = output.rows
+            self.groupedRows = output.groupedRows
+            self.isPreparingRows = false
         }
-        rows = needle.isEmpty ? base : sorted(base.filter(passesFilters))
-        groupedRows = groupByProject ? Self.grouped(rows) : []
     }
 
-    private static func grouped(_ rows: [Row]) -> [ProjectGroup] {
+    /// Everything `buildRows` needs, copied so it can run away from the main
+    /// actor. Value types throughout: the alternative is reading `@Published`
+    /// state from another executor while SwiftUI is drawing from it.
+    private struct RowInput: Sendable {
+        let summaries: [SessionSummary]
+        let hits: [SessionSearchHit]
+        let relatedHitByParent: [String: SessionSummary]
+        let reviewCounts: [String: Int]
+        let needle: String
+        let scopes: Set<SessionSearchScope>
+        let harnessFilter: Set<Harness>?
+        let since: Date?
+        let sortOrder: SortOrder
+        let groupByProject: Bool
+    }
+
+    private struct RowOutput: Sendable {
+        let rows: [Row]
+        let groupedRows: [ProjectGroup]
+    }
+
+    /// The list, derived off the main actor.
+    ///
+    /// A keystroke on a page holding a couple of thousand summaries used to
+    /// run this synchronously inside a `didSet`: a case- and
+    /// diacritic-insensitive `range(of:)` over two fields of every summary,
+    /// then a sort, then a grouping pass, then two `@Published` writes — all
+    /// before the character appeared in the field.
+    private nonisolated static func buildRows(_ input: RowInput) async -> RowOutput {
+        await Task.detached(priority: .userInitiated) {
+            let base: [Row]
+            if !input.needle.isEmpty, !input.hits.isEmpty {
+                base = input.hits.map {
+                    Row(
+                        summary: $0.summary,
+                        snippet: $0.snippet,
+                        matchedSeq: $0.matchedSeq,
+                        matchedRelated: input.relatedHitByParent[$0.summary.id],
+                        reviewCount: input.reviewCounts[$0.summary.sessionID] ?? 0
+                    )
+                }
+            } else {
+                base = filteredSummaries(input).map {
+                    Row(
+                        summary: $0,
+                        snippet: nil,
+                        matchedSeq: nil,
+                        matchedRelated: nil,
+                        reviewCount: input.reviewCounts[$0.sessionID] ?? 0
+                    )
+                }
+            }
+            let rows = input.needle.isEmpty
+                ? base
+                : sorted(base.filter { passesFilters($0, input) }, order: input.sortOrder)
+            return RowOutput(
+                rows: rows,
+                groupedRows: input.groupByProject ? grouped(rows) : []
+            )
+        }.value
+    }
+
+    private nonisolated static func grouped(_ rows: [Row]) -> [ProjectGroup] {
         var order: [String] = []
         var buckets: [String: [Row]] = [:]
         for row in rows {
@@ -559,12 +740,12 @@ final class SessionManagerModel: ObservableObject {
         return order.map { ProjectGroup(title: $0, rows: buckets[$0] ?? []) }
     }
 
-    static func projectTitle(_ projectDir: String?) -> String {
+    nonisolated static func projectTitle(_ projectDir: String?) -> String {
         guard let projectDir, !projectDir.isEmpty else { return "No project" }
         return URL(fileURLWithPath: projectDir).lastPathComponent
     }
 
-    static func projectTitle(for summary: SessionSummary) -> String {
+    nonisolated static func projectTitle(for summary: SessionSummary) -> String {
         if summary.provider == .codex, isGeneratedProjectlessPath(summary.projectDir) {
             return "Projectless"
         }
@@ -575,7 +756,7 @@ final class SessionManagerModel: ObservableObject {
     /// state database has no `project_id` column, so this stable path shape is
     /// the only on-disk distinction; the real cwd remains available in Details
     /// and resume commands.
-    static func isGeneratedProjectlessPath(_ path: String?) -> Bool {
+    nonisolated static func isGeneratedProjectlessPath(_ path: String?) -> Bool {
         guard let path else { return false }
         let components = URL(fileURLWithPath: path).standardizedFileURL.pathComponents
         guard let codex = components.lastIndex(of: "Codex"), components.count == codex + 3 else {
@@ -586,16 +767,16 @@ final class SessionManagerModel: ObservableObject {
             && date.allSatisfy { Int($0) != nil }
     }
 
-    private func filteredSummaries(matching needle: String) -> [SessionSummary] {
-        guard !needle.isEmpty else { return summaries }
-        guard searchScopes.contains(.title) else { return [] }
-        return summaries.filter { Self.matches($0, needle: needle) }
+    private nonisolated static func filteredSummaries(_ input: RowInput) -> [SessionSummary] {
+        guard !input.needle.isEmpty else { return input.summaries }
+        guard input.scopes.contains(.title) else { return [] }
+        return input.summaries.filter { matches($0, needle: input.needle) }
     }
 
     /// Immediate metadata preview while the debounced SQLite query is in
     /// flight. It obeys the title scope exactly; project paths have their own
     /// include/exclude controls and transcript roles are answered by FTS.
-    static func matches(_ summary: SessionSummary, needle: String) -> Bool {
+    nonisolated static func matches(_ summary: SessionSummary, needle: String) -> Bool {
         let fields = [summary.title, summary.sessionID]
         for field in fields {
             guard let field else { continue }
@@ -606,20 +787,22 @@ final class SessionManagerModel: ObservableObject {
         return false
     }
 
-    private func passesFilters(_ row: Row) -> Bool {
-        if let harnessFilter, !harnessFilter.contains(row.summary.effectiveHarness) { return false }
-        guard let start = dateRange.start() else { return true }
+    private nonisolated static func passesFilters(_ row: Row, _ input: RowInput) -> Bool {
+        if let filter = input.harnessFilter, !filter.contains(row.summary.effectiveHarness) {
+            return false
+        }
+        guard let start = input.since else { return true }
         let stamp = row.summary.lastActiveAt ?? row.summary.createdAt
         guard let stamp else { return false }
         return stamp >= start
     }
 
-    private func sorted(_ rows: [Row]) -> [Row] {
-        switch sortOrder {
+    private nonisolated static func sorted(_ rows: [Row], order: SortOrder) -> [Row] {
+        switch order {
         case .recentFirst:
-            return rows.sorted { Self.activity($0) > Self.activity($1) }
+            return rows.sorted { activity($0) > activity($1) }
         case .oldestFirst:
-            return rows.sorted { Self.activity($0) < Self.activity($1) }
+            return rows.sorted { activity($0) < activity($1) }
         case .byProject:
             // Key first, compare second: a localized comparison inside the
             // predicate would re-derive both project names on every swap.
@@ -635,7 +818,7 @@ final class SessionManagerModel: ObservableObject {
         }
     }
 
-    private static func activity(_ row: Row) -> Date {
+    private nonisolated static func activity(_ row: Row) -> Date {
         row.summary.lastActiveAt ?? row.summary.createdAt ?? .distantPast
     }
 
@@ -704,10 +887,59 @@ final class SessionManagerModel: ObservableObject {
         focusSeq: Int? = nil,
         focusedRelatedID: String? = nil
     ) {
+        load(
+            summary,
+            focusSeq: focusSeq,
+            focusedRelatedID: focusedRelatedID,
+            headByteLimit: SessionIndexingBounds.viewerHeadParseByteLimit
+        )
+    }
+
+    /// Re-read the open session with no byte bound. Only ever reached from
+    /// the banner the truncated read puts on screen: a 1.7 GB rollout parses
+    /// into 1.5–1.9 GB of live objects, which is a thing to do because the
+    /// user asked, never by default.
+    func loadEntireTranscript() {
+        guard let selection, transcriptTruncation != nil else { return }
+        load(
+            selection,
+            focusSeq: focusSeq,
+            focusedRelatedID: nil,
+            headByteLimit: nil
+        )
+    }
+
+    /// Abandon an in-flight transcript read.
+    ///
+    /// The row stays selected, so the way back is to click it again — said
+    /// out loud, because a pane that simply goes blank reads as a failure
+    /// rather than as the thing the user just asked for.
+    func cancelTranscriptLoad() {
+        guard isLoadingTranscript else { return }
+        transcriptTask?.cancel()
+        transcriptTask = nil
+        transcriptGeneration &+= 1
+        isLoadingTranscript = false
+        transcriptError = "Reading this session was stopped. Select it again to reopen it."
+    }
+
+    private func load(
+        _ summary: SessionSummary?,
+        focusSeq: Int?,
+        focusedRelatedID: String?,
+        headByteLimit: Int64?
+    ) {
+        // Cancel first, and hold the new task: the generation check alone
+        // only discarded a stale *result*, so clicking through three large
+        // sessions ran three full parses side by side and paid for all of
+        // them.
+        transcriptTask?.cancel()
+        transcriptTask = nil
         selection = summary
         self.focusSeq = focusSeq
         transcript = nil
         transcriptError = nil
+        transcriptTruncation = nil
         transcriptGeneration &+= 1
         guard let summary else {
             isLoadingTranscript = false
@@ -721,20 +953,25 @@ final class SessionManagerModel: ObservableObject {
         let generation = transcriptGeneration
         let url = URL(fileURLWithPath: summary.sourcePath)
         let related = reviewSummariesByParent[summary.sessionID] ?? []
+        let scratch = VibeBarLocalStore.sessionIndexScratchDirectoryURL(homeDirectory: homeDirectory)
         isLoadingTranscript = true
-        Task { [weak self] in
+        transcriptTask = Task { [weak self] in
             let parsed = await Self.parse(
                 adapter: adapter,
                 url: url,
                 related: related,
                 requestedFocusSeq: focusSeq,
-                focusedRelatedID: focusedRelatedID
+                focusedRelatedID: focusedRelatedID,
+                headByteLimit: headByteLimit,
+                scratchDirectory: scratch
             )
-            guard let self, generation == self.transcriptGeneration else { return }
+            guard let self, !Task.isCancelled, generation == self.transcriptGeneration else { return }
+            self.transcriptTask = nil
             self.isLoadingTranscript = false
             self.focusSeq = parsed.focusSeq
             self.transcript = parsed.document
             self.transcriptError = parsed.errorMessage
+            self.transcriptTruncation = parsed.truncation
         }
     }
 
@@ -746,69 +983,109 @@ final class SessionManagerModel: ObservableObject {
         let document: TranscriptDocument?
         let errorMessage: String?
         let focusSeq: Int?
+        let truncation: TranscriptTruncation?
     }
 
     /// `nonisolated` so the parse runs off the main actor — a long rollout is
     /// megabytes of JSONL and the window has to stay interactive through it.
+    ///
+    /// `headByteLimit` is the memory bound. `range:` is not one: every kit
+    /// adapter materializes the whole document before slicing it, so the only
+    /// place a limit can be applied is the bytes handed to the parser.
     private nonisolated static func parse(
         adapter: any SessionProviderAdapter,
         url: URL,
         related: [SessionSummary],
         requestedFocusSeq: Int?,
-        focusedRelatedID: String?
+        focusedRelatedID: String?,
+        headByteLimit: Int64?,
+        scratchDirectory: URL
     ) async -> ParsedTranscript {
-        do {
-            let root = try adapter.parseTranscript(fileURL: url)
-            guard !related.isEmpty else {
-                return ParsedTranscript(document: root, errorMessage: nil, focusSeq: requestedFocusSeq)
-            }
-            var messages = root.messages
-            var translatedFocus = focusedRelatedID == nil ? requestedFocusSeq : nil
-            for review in related.sorted(by: {
-                ($0.createdAt ?? .distantPast) < ($1.createdAt ?? .distantPast)
-            }) {
-                guard let document = try? adapter.parseTranscript(
-                    fileURL: URL(fileURLWithPath: review.sourcePath)
-                ) else { continue }
-                messages.append(SessionMessage(
-                    seq: messages.count,
-                    role: .system,
-                    text: "Auto Review",
-                    timestamp: review.createdAt
-                ))
-                let childStart = messages.count
-                messages.append(contentsOf: document.messages)
-                if review.id == focusedRelatedID,
-                   let requestedFocusSeq,
-                   let childIndex = document.messages.firstIndex(where: { $0.seq == requestedFocusSeq }) {
-                    translatedFocus = childStart + childIndex
+        await Task.detached(priority: .userInitiated) {
+            do {
+                let read = try SessionIndexingBounds.readTranscript(
+                    adapter: adapter,
+                    fileURL: url,
+                    headByteLimit: headByteLimit,
+                    scratchDirectory: scratchDirectory
+                )
+                let root = read.document
+                let truncation = read.isHeadTruncated
+                    ? TranscriptTruncation(
+                        shownMessages: root.messages.count,
+                        parsedBytes: headByteLimit ?? read.fileByteSize,
+                        fileBytes: read.fileByteSize
+                    )
+                    : nil
+                // A truncated parent already spends the budget; loading its
+                // Auto Review children on top would double it for no gain,
+                // since the pane cannot show the parent's tail either.
+                guard !related.isEmpty, truncation == nil else {
+                    return ParsedTranscript(
+                        document: root,
+                        errorMessage: nil,
+                        focusSeq: requestedFocusSeq,
+                        truncation: truncation
+                    )
                 }
-            }
-            let resequenced = messages.enumerated().map { index, message in
-                SessionMessage(
-                    seq: index,
-                    role: message.role,
-                    text: message.text,
-                    timestamp: message.timestamp
+                var messages = root.messages
+                var translatedFocus = focusedRelatedID == nil ? requestedFocusSeq : nil
+                var childTruncated = false
+                for review in related.sorted(by: {
+                    ($0.createdAt ?? .distantPast) < ($1.createdAt ?? .distantPast)
+                }) {
+                    guard !Task.isCancelled else { break }
+                    // Children are bounded on the same terms as the parent.
+                    guard let child = try? SessionIndexingBounds.readTranscript(
+                        adapter: adapter,
+                        fileURL: URL(fileURLWithPath: review.sourcePath),
+                        headByteLimit: headByteLimit,
+                        scratchDirectory: scratchDirectory
+                    ) else { continue }
+                    let document = child.document
+                    childTruncated = childTruncated || child.isHeadTruncated
+                    messages.append(SessionMessage(
+                        seq: messages.count,
+                        role: .system,
+                        text: "Auto Review",
+                        timestamp: review.createdAt
+                    ))
+                    let childStart = messages.count
+                    messages.append(contentsOf: document.messages)
+                    if review.id == focusedRelatedID,
+                       let requestedFocusSeq,
+                       let childIndex = document.messages.firstIndex(where: { $0.seq == requestedFocusSeq }) {
+                        translatedFocus = childStart + childIndex
+                    }
+                }
+                let resequenced = messages.enumerated().map { index, message in
+                    SessionMessage(
+                        seq: index,
+                        role: message.role,
+                        text: message.text,
+                        timestamp: message.timestamp
+                    )
+                }
+                return ParsedTranscript(
+                    document: TranscriptDocument(
+                        messages: resequenced,
+                        totalMessageCount: resequenced.count,
+                        truncated: childTruncated
+                    ),
+                    errorMessage: nil,
+                    focusSeq: translatedFocus,
+                    truncation: nil
+                )
+            } catch {
+                return ParsedTranscript(
+                    document: nil,
+                    errorMessage: (error as? LocalizedError)?.errorDescription
+                        ?? "This session's log could not be read.",
+                    focusSeq: nil,
+                    truncation: nil
                 )
             }
-            return ParsedTranscript(
-                document: TranscriptDocument(
-                    messages: resequenced,
-                    totalMessageCount: resequenced.count,
-                    truncated: false
-                ),
-                errorMessage: nil,
-                focusSeq: translatedFocus
-            )
-        } catch {
-            return ParsedTranscript(
-                document: nil,
-                errorMessage: (error as? LocalizedError)?.errorDescription
-                    ?? "This session's log could not be read.",
-                focusSeq: nil
-            )
-        }
+        }.value
     }
 
     // MARK: - Resume
@@ -942,6 +1219,7 @@ final class SessionManagerModel: ObservableObject {
         // than waiting for the next scan's prune pass to notice.
         if let store, !removed.isEmpty {
             try? await store.removeSessions(sourcePathIn: removed.map(\.sourcePath))
+            invalidateIndexDerivedState()
         }
         checkedIDs.subtract(removed.map(\.id))
         reloadSummaryPage(reset: true)
@@ -978,7 +1256,7 @@ final class SessionManagerModel: ObservableObject {
     func setBodyIndexing(_ enabled: Bool) {
         guard enabled != settingsStore.settings.sessionBodyIndexingEnabled else { return }
         settingsStore.settings.sessionBodyIndexingEnabled = enabled
-        bodyIndexing.set(enabled)
+        index.bodyIndexing.set(enabled)
         guard let store else { return }
         if enabled {
             refreshIndex()
@@ -1018,5 +1296,70 @@ final class SessionManagerModel: ObservableObject {
     func dismissToast() {
         toastTask?.cancel()
         toast = nil
+    }
+}
+
+/// The app's one connection to `~/.vibebar/session_index.sqlite3`.
+///
+/// Three components used to open their own: the Workbench's Sessions page,
+/// `MCPController` (on the first `sessions.*` call), and
+/// `SessionIndexCompactor`. Nothing coordinated them, so an MCP backfill and
+/// a Workbench refresh could run two full 11 000-file passes over the same
+/// 1 GB database at once, each waiting out the other's busy timeout. Two
+/// connections to one WAL database are legal; two *indexers* are just twice
+/// the work.
+///
+/// The compactor still keeps its own handle — it runs once a day, needs raw
+/// SQLite, and is fenced by `SessionIndexMaintenanceGate` instead.
+@MainActor
+final class SharedSessionIndex {
+    /// `nil` when the database would not open. Same shape as the usage
+    /// ledger in `AppEnvironment`: that costs the Sessions page its index,
+    /// not the app its launch.
+    let store: SessionIndexStore?
+    let service: SessionIndexService?
+    /// The privacy switch, mirrored where the index actor can read it
+    /// without a main-actor hop — and, unlike a captured `Bool`, re-read on
+    /// every pass. Following the setting for the life of the app is what
+    /// makes "Index message text" reach the MCP surface too.
+    let bodyIndexing: BodyIndexingFlag
+
+    private var cancellables: Set<AnyCancellable> = []
+
+    init(settingsStore: SettingsStore, homeDirectory: String = RealHomeDirectory.path) {
+        let flag = BodyIndexingFlag(settingsStore.settings.sessionBodyIndexingEnabled)
+        self.bodyIndexing = flag
+
+        let opened: SessionIndexStore?
+        do {
+            opened = try SessionIndexStore(url: VibeBarLocalStore.sessionIndexURL)
+        } catch {
+            SafeLog.warn("Opening the session index failed: \(SafeLog.sanitize(error.localizedDescription))")
+            opened = nil
+        }
+        self.store = opened
+        self.service = opened.map {
+            SessionIndexService(
+                homeDirectory: homeDirectory,
+                store: $0,
+                // The indexer gets the bounded adapters: oversized rollouts
+                // are parsed from a head copy (memory) and excerpts are
+                // pre-trimmed to the host policy (index size). The raw
+                // registry stays with the transcript viewer and the deleter,
+                // which must see whole sessions.
+                registry: SessionIndexingBounds.boundedRegistry(
+                    SessionProviderRegistry.standard(homeDirectory: homeDirectory),
+                    scratchDirectory: VibeBarLocalStore
+                        .sessionIndexScratchDirectoryURL(homeDirectory: homeDirectory)
+                ),
+                bodyIndexing: { flag.current }
+            )
+        }
+
+        settingsStore.$settings
+            .map(\.sessionBodyIndexingEnabled)
+            .removeDuplicates()
+            .sink { enabled in flag.set(enabled) }
+            .store(in: &cancellables)
     }
 }

--- a/Sources/VibeBarApp/Controllers/UsageStatsViewModel.swift
+++ b/Sources/VibeBarApp/Controllers/UsageStatsViewModel.swift
@@ -405,16 +405,87 @@ final class UsageStatsViewModel: ObservableObject {
 
     // MARK: - Lifecycle
 
-    /// First load on window open; a re-open re-queries instead of rebuilding,
-    /// because the view model outlives the window.
+    /// First load on window open; a re-open re-queries only when something it
+    /// depends on has actually moved.
+    ///
+    /// The page's `.task` runs this on every entry, and the model outlives
+    /// the window, so "switch to Sessions and back" used to cost the whole
+    /// analytic set — up to eleven sequential ledger round trips including
+    /// the day × tool trend — to redraw numbers already on screen. The
+    /// memo below is what makes re-entry free.
     func activate() {
         restartTimer()
-        if hasLoadedOnce {
-            reload(cascadeModels: false)
-        } else {
+        guard hasLoadedOnce else {
             hasLoadedOnce = true
             reload(cascadeModels: true)
+            return
         }
+        guard let ledger, let signature = loadedSignature else {
+            reload(cascadeModels: false)
+            return
+        }
+        let generation = self.generation
+        Task { [weak self] in
+            let revision = await ledger.contentRevision()
+            guard let self, !Task.isCancelled, generation == self.generation else { return }
+            guard signature != self.reloadSignature(revision: revision) else { return }
+            self.reload(cascadeModels: false)
+        }
+    }
+
+    /// Everything the last completed query actually depended on.
+    ///
+    /// The live `now` at the end of a rolling preset is deliberately absent:
+    /// no row can appear inside the moved window without the ledger's
+    /// revision moving too, so re-querying for a clock tick alone would
+    /// return the same numbers.
+    private struct ReloadSignature: Equatable {
+        let preset: RangePreset
+        let windowStart: Date?
+        let customStart: Date
+        let customEnd: Date
+        let tools: [ToolType]?
+        let harnesses: [Harness]?
+        let models: [String]?
+        let granularity: UsageTrendBucket?
+        let breakdown: Breakdown
+        let revision: UInt64
+    }
+
+    private var loadedSignature: ReloadSignature?
+
+    private func reloadSignature(revision: UInt64) -> ReloadSignature {
+        ReloadSignature(
+            preset: rangePreset,
+            windowStart: windowStart,
+            customStart: customStart,
+            customEnd: customEnd,
+            tools: selectedTools.map { $0.sorted { $0.rawValue < $1.rawValue } },
+            harnesses: selectedHarnesses.map { $0.sorted { $0.rawValue < $1.rawValue } },
+            models: selectedModels.map { $0.sorted() },
+            granularity: trendGranularity,
+            breakdown: activeBreakdown,
+            revision: revision
+        )
+    }
+
+    /// Park for as long as the page is on screen.
+    ///
+    /// `UsageStatsPage` awaits this inside its `.task`, and SwiftUI cancels a
+    /// `.task` when its view disappears — so leaving the page stops the
+    /// refresh poll, which otherwise kept calling `costService.refreshAll()`
+    /// (a walk of every session tree) against a page nobody is looking at.
+    /// The same shape as `SkillsManagerModel.monitorFilesystem`.
+    func pollWhileVisible() async {
+        while !Task.isCancelled {
+            do {
+                try await Task.sleep(for: .seconds(3_600))
+            } catch {
+                break
+            }
+        }
+        tickTask?.cancel()
+        tickTask = nil
     }
 
     func stop() {
@@ -627,6 +698,7 @@ final class UsageStatsViewModel: ObservableObject {
         breakdownTask?.cancel()
         loadedBreakdowns.removeAll()
         activeFilter = nil
+        loadedSignature = nil
         // A page still in flight is now for a filter nobody is looking at; it
         // drops itself on the generation check and never clears this, so the
         // reload has to, or paging stays wedged for the rest of the session.
@@ -712,6 +784,10 @@ final class UsageStatsViewModel: ObservableObject {
             if let refreshedModelsRevision {
                 self.lastAvailableModelsRevision = refreshedModelsRevision
             }
+            // Stamped with the revision this query actually read, not a
+            // fresher one: a scan that lands mid-query must still make the
+            // next page entry re-ask.
+            self.loadedSignature = self.reloadSignature(revision: ledgerRevision)
             self.apply(
                 snapshot, availableModels: models, isHourlyTrendAvailable: supportsHourly
             )
@@ -867,24 +943,39 @@ final class UsageStatsViewModel: ObservableObject {
         )
     }
 
+    /// Every query the dashboard needs, issued together.
+    ///
+    /// `async let` does not make the ledger run them in parallel — it is an
+    /// actor and its executor serializes them — but it does hand all seven to
+    /// that executor in one go instead of returning to this task between each
+    /// one, so the queries run back to back rather than with a scheduling
+    /// round trip in every gap. None of them depends on another's result.
     private nonisolated static func load(
         ledger: UsageEventLedger,
         filter: UsageQueryFilter,
         granularity: UsageTrendBucket?,
         breakdown: Breakdown
     ) async -> LoadedUsage {
-        let summary = (try? await ledger.summary(filter)) ?? .empty
         let bucket = granularity.resolved(for: filter.range)
-        let trend = (try? await ledger.trend(filter, bucket: bucket))
-            ?? UsageTrendSeries(bucket: bucket, points: [])
-        let providers = (try? await ledger.providerStats(filter)) ?? []
-        let harnesses = (try? await ledger.harnessStats(filter)) ?? []
-        let models = (try? await ledger.modelStats(filter)) ?? []
-        let projects = (try? await ledger.projectStats(filter)) ?? []
-        let requests = breakdown == .requests
-            ? ((try? await ledger.requestPage(filter, pageSize: requestPageSize))
-                ?? UsageRequestPage(rows: [], totalCount: 0, pageSize: requestPageSize))
-            : UsageRequestPage(rows: [], totalCount: 0, pageSize: requestPageSize)
+        let emptyPage = UsageRequestPage(rows: [], totalCount: 0, pageSize: requestPageSize)
+
+        async let summaryTask = try? await ledger.summary(filter)
+        async let trendTask = try? await ledger.trend(filter, bucket: bucket)
+        async let providersTask = try? await ledger.providerStats(filter)
+        async let harnessesTask = try? await ledger.harnessStats(filter)
+        async let modelsTask = try? await ledger.modelStats(filter)
+        async let projectsTask = try? await ledger.projectStats(filter)
+        async let requestsTask = breakdown == .requests
+            ? (try? await ledger.requestPage(filter, pageSize: requestPageSize))
+            : nil
+
+        let summary = await summaryTask ?? .empty
+        let trend = await trendTask ?? UsageTrendSeries(bucket: bucket, points: [])
+        let providers = await providersTask ?? []
+        let harnesses = await harnessesTask ?? []
+        let models = await modelsTask ?? []
+        let projects = await projectsTask ?? []
+        let requests = await requestsTask ?? emptyPage
         return LoadedUsage(
             summary: summary,
             trend: trend,

--- a/Sources/VibeBarApp/Controllers/UsageStatsViewModel.swift
+++ b/Sources/VibeBarApp/Controllers/UsageStatsViewModel.swift
@@ -433,38 +433,24 @@ final class UsageStatsViewModel: ObservableObject {
         }
     }
 
-    /// Everything the last completed query actually depended on.
-    ///
-    /// The live `now` at the end of a rolling preset is deliberately absent:
-    /// no row can appear inside the moved window without the ledger's
-    /// revision moving too, so re-querying for a clock tick alone would
-    /// return the same numbers.
-    private struct ReloadSignature: Equatable {
-        let preset: RangePreset
-        let windowStart: Date?
-        let customStart: Date
-        let customEnd: Date
-        let tools: [ToolType]?
-        let harnesses: [Harness]?
-        let models: [String]?
-        let granularity: UsageTrendBucket?
-        let breakdown: Breakdown
-        let revision: UInt64
-    }
+    /// The last completed query's inputs. `UsageQuerySignature` documents
+    /// what belongs in one and, more importantly, what does not — the active
+    /// breakdown tab is deliberately absent, because switching tabs runs its
+    /// own deferred query and changes nothing the shared set answered.
+    private var loadedSignature: UsageQuerySignature?
 
-    private var loadedSignature: ReloadSignature?
-
-    private func reloadSignature(revision: UInt64) -> ReloadSignature {
-        ReloadSignature(
-            preset: rangePreset,
-            windowStart: windowStart,
-            customStart: customStart,
-            customEnd: customEnd,
+    private func reloadSignature(revision: UInt64) -> UsageQuerySignature {
+        UsageQuerySignature(
+            rangeKey: UsageQuerySignature.rangeKey(
+                preset: rangePreset.rawValue,
+                windowStart: windowStart,
+                customStart: customStart,
+                customEnd: customEnd
+            ),
             tools: selectedTools.map { $0.sorted { $0.rawValue < $1.rawValue } },
             harnesses: selectedHarnesses.map { $0.sorted { $0.rawValue < $1.rawValue } },
             models: selectedModels.map { $0.sorted() },
             granularity: trendGranularity,
-            breakdown: activeBreakdown,
             revision: revision
         )
     }

--- a/Sources/VibeBarApp/Controllers/WorkbenchServices.swift
+++ b/Sources/VibeBarApp/Controllers/WorkbenchServices.swift
@@ -8,35 +8,72 @@ import VibeBarCore
 /// pointless for the menu-bar-only session that never opens the window. So
 /// `AppEnvironment` holds this lazily, and the models inside it are lazy in
 /// turn: opening the Workbench on Sessions never builds the usage queries.
+///
+/// The laziness is spelled out with explicit storage rather than `lazy var`
+/// because something has to be able to ask "was this ever built?" without
+/// building it: `stopBackgroundWork` runs when the window closes, and a
+/// teardown that constructs the models it is tearing down (opening a SQLite
+/// index on the way out, for a page the user never opened) would be worse
+/// than the leak it fixes.
 @MainActor
 final class WorkbenchServices: ObservableObject {
     private let usageLedger: UsageEventLedger?
     private let costService: CostUsageService
     private let settingsStore: SettingsStore
     private let skillsService: SkillsService
+    /// The app-wide session index, shared with the MCP surface exactly as
+    /// `skillsService` is — see `SharedSessionIndex`. A closure, not the
+    /// value: building it opens `session_index.sqlite3`, and only the
+    /// Sessions page should be able to cause that.
+    private let sessionIndex: () -> SharedSessionIndex
+
+    private var usageStatsStorage: UsageStatsViewModel?
+    private var sessionsStorage: SessionManagerModel?
+    private var skillsStorage: SkillsManagerModel?
 
     init(
         usageLedger: UsageEventLedger?,
         costService: CostUsageService,
         settingsStore: SettingsStore,
-        skillsService: SkillsService
+        skillsService: SkillsService,
+        sessionIndex: @escaping () -> SharedSessionIndex
     ) {
         self.usageLedger = usageLedger
         self.costService = costService
         self.settingsStore = settingsStore
         self.skillsService = skillsService
+        self.sessionIndex = sessionIndex
     }
 
-    lazy var usageStats = UsageStatsViewModel(
-        ledger: usageLedger,
-        costService: costService
-    )
+    var usageStats: UsageStatsViewModel {
+        if let usageStatsStorage { return usageStatsStorage }
+        let model = UsageStatsViewModel(ledger: usageLedger, costService: costService)
+        usageStatsStorage = model
+        return model
+    }
 
-    lazy var sessions = SessionManagerModel(settingsStore: settingsStore)
+    var sessions: SessionManagerModel {
+        if let sessionsStorage { return sessionsStorage }
+        let model = SessionManagerModel(settingsStore: settingsStore, index: sessionIndex())
+        sessionsStorage = model
+        return model
+    }
 
     /// Lazy for the same reason as the usage page, and more so: building it
     /// opens `~/.vibebar/skills.json` and, on first activation, walks every
     /// agent CLI's skills directory. The service behind it is the app-wide
     /// one, shared with MCP's `skills.install`.
-    lazy var skills = SkillsManagerModel(settingsStore: settingsStore, service: skillsService)
+    var skills: SkillsManagerModel {
+        if let skillsStorage { return skillsStorage }
+        let model = SkillsManagerModel(settingsStore: settingsStore, service: skillsService)
+        skillsStorage = model
+        return model
+    }
+
+    /// Wind down anything a closed window left running. The models stay, so
+    /// re-opening is still instant and `activate()` restarts what it needs.
+    func stopBackgroundWork() {
+        usageStatsStorage?.stop()
+        sessionsStorage?.stop()
+    }
 }

--- a/Sources/VibeBarApp/Controllers/WorkbenchWindowController.swift
+++ b/Sources/VibeBarApp/Controllers/WorkbenchWindowController.swift
@@ -122,5 +122,12 @@ extension WorkbenchWindowController: NSWindowDelegate {
         // Dock icon goes away, which is what "the Workbench is closed" means
         // for an agent app.
         DockActivationController.shared.release(.workbench)
+
+        // The page models outlive the window, so nothing was stopping their
+        // background work: a Usage Stats auto-refresh kept polling — and
+        // kept calling `costService.refreshAll()`, which walks every session
+        // tree — until the app quit. Both `stop()` methods had no callers at
+        // all. Re-opening calls `activate()`, which restarts what it needs.
+        environment?.stopWorkbenchBackgroundWork()
     }
 }

--- a/Sources/VibeBarApp/MCPController.swift
+++ b/Sources/VibeBarApp/MCPController.swift
@@ -392,9 +392,21 @@ final class MCPController: ObservableObject, MCPDataSource {
         guard !didAttemptSessionBackfill else { return false }
         didAttemptSessionBackfill = true
         // Same gate the Workbench's refresh takes: one indexer at a time, and
-        // never on top of the daily compaction pass.
+        // never on top of the daily compaction pass. The wait is cancellable
+        // and claims nothing when it throws, so a client that disconnects
+        // mid-wait does not strand the gate.
         let gate = SessionIndexMaintenanceGate.shared
-        await gate.acquire()
+        do {
+            try await gate.acquire()
+        } catch {
+            // Gave up while queued. The one-per-process flag stays set: this
+            // was still the process's one opportunistic backfill attempt.
+            return false
+        }
+        guard !Task.isCancelled else {
+            await gate.release()
+            return false
+        }
         await index.refreshIndex()
         await gate.release()
         return true

--- a/Sources/VibeBarApp/MCPController.swift
+++ b/Sources/VibeBarApp/MCPController.swift
@@ -38,34 +38,28 @@ final class MCPController: ObservableObject, MCPDataSource {
     private var socketServer: MCPSocketServer?
     private var cancellables: Set<AnyCancellable> = []
 
-    /// The session index, opened on the first `sessions.*` call.
-    ///
-    /// Deliberately not built at launch: opening it costs a SQLite file the
-    /// menu-bar-only session never needs, and the Workbench's Sessions page
-    /// keeps its own handle. Two connections to one WAL database with a busy
-    /// timeout is a supported arrangement — the alternative, threading this
-    /// through `SessionManagerModel`, would couple the MCP surface to the
-    /// Workbench's lifecycle for no benefit.
-    private var sessionIndex: SessionIndexService?
-    private var sessionIndexUnavailable = false
     /// One opportunistic scan per process when the index has never been built.
     /// Without it, `sessions.search` answers "nothing" until the user happens
     /// to open the Workbench, which reads as a bug rather than as an empty
     /// index.
     private var didAttemptSessionBackfill = false
-    /// The privacy switch, mirrored so the index actor can read it without a
-    /// main-actor hop — and, unlike a captured `Bool`, re-read on every pass.
-    /// Toggling "Index message text" off has to reach the MCP surface too, or
-    /// an agent's `sessions.search` would keep hitting (and re-populating) an
-    /// index the user just disabled.
-    private let bodyIndexing: BodyIndexingFlag
+
+    /// How long a connected client may say nothing before its socket is
+    /// closed.
+    ///
+    /// The package leaves this off, because a library cannot know whether its
+    /// host's clients respawn after an intentional EOF. Vibe Bar's do: every
+    /// client is a `--mcp-stdio` child that the agent starts on demand and
+    /// restarts the moment it needs the socket again. Without a timeout those
+    /// children accumulate — 21 were alive on one machine — each holding one
+    /// of the 64 connection slots for the rest of the app's life. Forty-five
+    /// minutes is far longer than any pause inside a working session and far
+    /// shorter than a day of leaving editors open.
+    static let clientIdleTimeout: TimeInterval = 45 * 60
 
     init(environment: AppEnvironment, socketPath: String = MCPSocketServer.defaultSocketPath) {
         self.environment = environment
         self.socketPath = socketPath
-        self.bodyIndexing = BodyIndexingFlag(
-            environment.settingsStore.settings.sessionBodyIndexingEnabled
-        )
     }
 
     // MARK: - Lifecycle
@@ -81,13 +75,9 @@ final class MCPController: ObservableObject, MCPDataSource {
             }
             .store(in: &cancellables)
 
-        // Follow the body-indexing switch for as long as the app runs, not
-        // just until the first `sessions.*` call opened the index.
-        settingsStore.$settings
-            .map(\.sessionBodyIndexingEnabled)
-            .removeDuplicates()
-            .sink { [bodyIndexing] enabled in bodyIndexing.set(enabled) }
-            .store(in: &cancellables)
+        // The body-indexing switch is followed by `SharedSessionIndex`, which
+        // owns the flag the index actor reads — one subscription for both the
+        // Workbench's Sessions page and this surface.
     }
 
     func stop() {
@@ -106,7 +96,11 @@ final class MCPController: ObservableObject, MCPDataSource {
         }
         guard socketServer == nil else { return }
         let server = MCPServer(dataSource: self)
-        let socket = MCPSocketServer(server: server, socketPath: socketPath)
+        let socket = MCPSocketServer(
+            server: server,
+            socketPath: socketPath,
+            idleTimeout: Self.clientIdleTimeout
+        )
         socket.onConnectionChange = { [weak self] count, at in
             Task { @MainActor in
                 self?.connectionCount = count
@@ -380,42 +374,29 @@ final class MCPController: ObservableObject, MCPDataSource {
         return page
     }
 
+    /// The app-wide index, opened on this call if nothing has needed it yet.
+    ///
+    /// This used to open a second `SessionIndexStore` of its own. Two
+    /// connections to one WAL database are legal, but two *indexers* meant an
+    /// MCP backfill and a Workbench refresh could each walk all 11 000
+    /// session files at the same time over the same 1 GB database.
     private func sessionIndexService() throws -> SessionIndexService {
-        if let sessionIndex { return sessionIndex }
-        guard !sessionIndexUnavailable else {
+        guard let environment, let service = environment.sessionIndex.service else {
             throw MCPToolFailure("The session index could not be opened, so sessions cannot be listed.")
         }
-        do {
-            let store = try SessionIndexStore(url: VibeBarLocalStore.sessionIndexURL)
-            // Explicit home on both: the kit's own defaults resolve the real
-            // home, not the one `RealHomeDirectory` may be redirected to.
-            let home = RealHomeDirectory.path
-            let service = SessionIndexService(
-                homeDirectory: home,
-                store: store,
-                // Bounded like the Workbench's indexer: MCP-triggered
-                // backfills hit the same multi-hundred-MB rollouts.
-                registry: SessionIndexingBounds.boundedRegistry(
-                    SessionProviderRegistry.standard(homeDirectory: home),
-                    scratchDirectory: VibeBarLocalStore
-                        .sessionIndexScratchDirectoryURL(homeDirectory: home)
-                ),
-                bodyIndexing: { [bodyIndexing] in bodyIndexing.current }
-            )
-            sessionIndex = service
-            return service
-        } catch {
-            sessionIndexUnavailable = true
-            SafeLog.warn("MCP: opening the session index failed: \(SafeLog.sanitize(error.localizedDescription))")
-            throw MCPToolFailure("The session index could not be opened, so sessions cannot be listed.")
-        }
+        return service
     }
 
     /// Returns true when a scan actually ran, so the caller re-queries.
     private func backfillSessionIndexIfNeeded(_ index: SessionIndexService) async -> Bool {
         guard !didAttemptSessionBackfill else { return false }
         didAttemptSessionBackfill = true
+        // Same gate the Workbench's refresh takes: one indexer at a time, and
+        // never on top of the daily compaction pass.
+        let gate = SessionIndexMaintenanceGate.shared
+        await gate.acquire()
         await index.refreshIndex()
+        await gate.release()
         return true
     }
 

--- a/Sources/VibeBarApp/Views/Workbench/SessionListView.swift
+++ b/Sources/VibeBarApp/Views/Workbench/SessionListView.swift
@@ -14,7 +14,14 @@ struct SessionListView: View {
     var body: some View {
         Group {
             if model.rows.isEmpty {
-                emptyState
+                // "No sessions match" is a verdict, and one frame of it while
+                // the off-main rows build is still running would be a wrong
+                // one. Hold the space instead.
+                if model.isPreparingRows {
+                    Color.clear
+                } else {
+                    emptyState
+                }
             } else {
                 // This is deliberately a plain scroll surface rather than a
                 // SwiftUI List: sessions are cards in a reading queue, not
@@ -38,6 +45,9 @@ struct SessionListView: View {
                             ForEach(model.rows) { row in
                                 rowView(row)
                             }
+                        }
+                        if model.isSummaryListCapped, model.searchText.isEmpty {
+                            capNotice
                         }
                     }
                     .padding(.horizontal, 4)
@@ -72,15 +82,35 @@ struct SessionListView: View {
         .onAppear {
             if row.id == model.rows.last?.id { model.loadMoreSummaries() }
         }
-        .contextMenu {
-            Button("Open in Terminal") { model.resumeInTerminal(row.summary) }
-                .disabled(model.resumeCommand(for: row.summary) == nil)
-            Button("Copy resume command") { model.copyResumeCommand(for: row.summary) }
-                .disabled(model.resumeCommand(for: row.summary) == nil)
-            Divider()
-            Button("Delete…", role: .destructive) { model.requestDelete([row.summary]) }
-                .disabled(!SessionManagerModel.isDeletable(row.summary))
-        }
+        .contextMenu { contextMenu(for: row) }
+    }
+
+    /// `resumeCommand(for:)` builds a whole shell invocation, and this asked
+    /// for it twice per menu — once per item — for the same answer.
+    @ViewBuilder
+    private func contextMenu(for row: SessionManagerModel.Row) -> some View {
+        let canResume = model.resumeCommand(for: row.summary) != nil
+        Button("Open in Terminal") { model.resumeInTerminal(row.summary) }
+            .disabled(!canResume)
+        Button("Copy resume command") { model.copyResumeCommand(for: row.summary) }
+            .disabled(!canResume)
+        Divider()
+        Button("Delete…", role: .destructive) { model.requestDelete([row.summary]) }
+            .disabled(!SessionManagerModel.isDeletable(row.summary))
+    }
+
+    /// The list stops at `maximumLoadedSummaries` because a `LazyVStack`
+    /// builds rows lazily and then keeps every one of them. Saying so beats
+    /// letting the scroll quietly end short of an 11 000-session index.
+    private var capNotice: some View {
+        Text("Showing the first \(SessionManagerModel.maximumLoadedSummaries) of "
+            + "\(model.totalSessionCount) sessions. Narrow the filters or search to reach the rest.")
+            .font(.system(size: max(10, density.resetCountdownFontSize)))
+            .foregroundStyle(.tertiary)
+            .multilineTextAlignment(.center)
+            .frame(maxWidth: .infinity)
+            .padding(.horizontal, 12)
+            .padding(.vertical, 10)
     }
 
     private var emptyState: some View {

--- a/Sources/VibeBarApp/Views/Workbench/TranscriptView.swift
+++ b/Sources/VibeBarApp/Views/Workbench/TranscriptView.swift
@@ -65,6 +65,9 @@ struct TranscriptView: View {
                         if document.messages.isEmpty {
                             message("This session's log has no readable messages.", systemImage: "text.alignleft")
                         } else {
+                            if let truncation = model.transcriptTruncation {
+                                truncationBanner(truncation)
+                            }
                             transcriptPager(document: document, proxy: proxy)
                                 .id(Self.pageAnchorID)
                             let range = TranscriptPageWindow.range(
@@ -96,7 +99,10 @@ struct TranscriptView: View {
             .cardSurface(density: density)
             .padding(.trailing, density.popoverPaddingH)
             .padding(.bottom, density.popoverPaddingV)
-            .onChange(of: model.transcript) { _, _ in focusOnSearchHit(proxy: proxy) }
+            // Keyed on an identity, not on the document: `TranscriptDocument`
+            // is `Equatable`, and `onChange` would compare two
+            // hundred-thousand-message values on every body evaluation.
+            .onChange(of: transcriptIdentity) { _, _ in focusOnSearchHit(proxy: proxy) }
         }
     }
 
@@ -128,15 +134,67 @@ struct TranscriptView: View {
     }
 
     private var loading: some View {
-        HStack(spacing: 8) {
+        HStack(spacing: 10) {
             ProgressView().controlSize(.small)
             Text("Reading the session log…")
                 .font(.system(size: density.subtitleFontSize))
                 .foregroundStyle(.secondary)
+            // A whole-file read of a gigabyte-scale rollout takes long enough
+            // that "wait or pick something else" has to be a real choice.
+            Button("Cancel") { model.cancelTranscriptLoad() }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
         }
         .frame(maxWidth: .infinity, alignment: .center)
         .padding(.vertical, 24)
     }
+
+    /// What a head-window read says for itself.
+    ///
+    /// The count is exact — those messages were parsed — but the total is
+    /// genuinely unknown: the file was cut at a byte offset before any of it
+    /// became messages, which is the whole point. So the banner reports what
+    /// it can measure (messages shown, bytes read of bytes on disk) and
+    /// offers the unbounded read rather than guessing at a total.
+    private func truncationBanner(_ truncation: SessionManagerModel.TranscriptTruncation) -> some View {
+        HStack(alignment: .top, spacing: 8) {
+            Image(systemName: "doc.badge.ellipsis")
+                .font(.system(size: density.subtitleFontSize))
+                .foregroundStyle(.secondary)
+            VStack(alignment: .leading, spacing: 5) {
+                Text("Showing the first \(truncation.shownMessages) messages of a very large log")
+                    .font(.system(size: density.subtitleFontSize, weight: .semibold))
+                Text("\(Self.bytes.string(fromByteCount: truncation.parsedBytes)) read of "
+                    + "\(Self.bytes.string(fromByteCount: truncation.fileBytes)). "
+                    + "Reading all of it holds the whole transcript in memory.")
+                    .font(.system(size: max(10, density.resetCountdownFontSize)))
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+                Button("Load entire transcript") { model.loadEntireTranscript() }
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 9)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: density.cardCornerRadius, style: .continuous)
+                .fill(Color.primary.opacity(0.05))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: density.cardCornerRadius, style: .continuous)
+                .stroke(Color.primary.opacity(0.1), lineWidth: 0.6)
+        )
+    }
+
+    private static let bytes: ByteCountFormatter = {
+        let formatter = ByteCountFormatter()
+        formatter.countStyle = .file
+        formatter.allowedUnits = [.useMB, .useGB]
+        return formatter
+    }()
 
     private func message(_ text: String, systemImage: String) -> some View {
         CardShell(density: density, alignment: .center) {
@@ -190,27 +248,89 @@ struct TranscriptView: View {
                 .overlay(Capsule().stroke(Color.primary.opacity(0.11), lineWidth: 0.6))
         )
         .accessibilityLabel("Find in transcript")
-        .onChange(of: query) { _, _ in recomputeMatches(proxy: proxy) }
-        .onChange(of: model.transcript) { _, _ in recomputeMatches(proxy: proxy) }
+        // One trigger for both inputs. `.task(id:)` cancels the previous run
+        // when the key changes, which is what makes the debounce below a
+        // debounce rather than a queue of scans.
+        .task(id: findKey) { await runFind(proxy: proxy) }
+    }
+
+    /// What a find run depends on. The transcript itself is identified rather
+    /// than compared: `TranscriptDocument` is `Equatable`, and comparing two
+    /// hundred-thousand-message documents on every keystroke would cost more
+    /// than the scan.
+    private struct FindKey: Equatable {
+        let query: String
+        let selectionID: String?
+        let messageCount: Int
+        let truncated: Bool
+    }
+
+    private var findKey: FindKey {
+        FindKey(
+            query: query,
+            selectionID: model.selection?.id,
+            messageCount: model.transcript?.messages.count ?? 0,
+            truncated: model.transcript?.truncated ?? false
+        )
+    }
+
+    /// The same identity without the query: what "a different transcript is
+    /// on screen" means, cheaply.
+    private var transcriptIdentity: FindKey {
+        FindKey(
+            query: "",
+            selectionID: model.selection?.id,
+            messageCount: model.transcript?.messages.count ?? 0,
+            truncated: model.transcript?.truncated ?? false
+        )
     }
 
     /// Matches drive three things at once: the counter, the next / previous
-    /// buttons, and which collapsed cards open — a hit hidden inside a
-    /// folded 40 KB tool result is a hit the user cannot see.
-    private func recomputeMatches(proxy: ScrollViewProxy) {
+    /// buttons, and which collapsed card opens — a hit hidden inside a folded
+    /// 40 KB tool result is a hit the user cannot see.
+    ///
+    /// Debounced and off the main actor: this used to run on every keystroke,
+    /// on the main actor, with `.diacriticInsensitive` folding over every
+    /// message of the open log, and then expanded *every* matching card at
+    /// once — which on a wide match turns one keystroke into hundreds of
+    /// re-laid-out bubbles. Only the match being scrolled to is opened now.
+    private func runFind(proxy: ScrollViewProxy) async {
         let needle = query.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !needle.isEmpty, let document = model.transcript else {
             matches = []
             matchIndex = 0
             return
         }
-        matches = document.messages
-            .filter { $0.text.range(of: needle, options: [.caseInsensitive, .diacriticInsensitive]) != nil }
-            .map(\.seq)
-        expanded.formUnion(matches)
+        try? await Task.sleep(for: Self.findDebounce)
+        guard !Task.isCancelled else { return }
+        let found = await Self.scan(document: document, needle: needle)
+        guard !Task.isCancelled else { return }
+        matches = found
         matchIndex = 0
-        guard let first = matches.first else { return }
+        guard let first = found.first else { return }
         scroll(to: first, proxy: proxy)
+    }
+
+    private static let findDebounce = Duration.milliseconds(250)
+
+    /// `.diacriticInsensitive` is deliberately gone. It forces a full
+    /// Unicode fold of every message before the comparison, it disagrees with
+    /// what `TranscriptFormatting.highlighted` would tint, and nobody types
+    /// "resume" hoping to find "résumé" in a build log.
+    private nonisolated static func scan(
+        document: TranscriptDocument,
+        needle: String
+    ) async -> [Int] {
+        await Task.detached(priority: .userInitiated) {
+            var found: [Int] = []
+            for message in document.messages {
+                if Task.isCancelled { return found }
+                if message.text.range(of: needle, options: [.caseInsensitive]) != nil {
+                    found.append(message.seq)
+                }
+            }
+            return found
+        }.value
     }
 
     private func step(by offset: Int, proxy: ScrollViewProxy) {
@@ -223,6 +343,8 @@ struct TranscriptView: View {
         guard let document = model.transcript,
               let index = document.messages.firstIndex(where: { $0.seq == seq })
         else { return }
+        // Open the card being landed on, and only that one.
+        expanded.insert(seq)
         let start = TranscriptPageWindow.start(
             containingItemAt: index,
             itemCount: document.messages.count

--- a/Sources/VibeBarApp/Views/Workbench/UsageStatsPage.swift
+++ b/Sources/VibeBarApp/Views/Workbench/UsageStatsPage.swift
@@ -45,7 +45,13 @@ struct UsageStatsPage: View {
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .task { model.activate() }
+        .task {
+            model.activate()
+            // Held open on purpose: the auto-refresh poll should stop when
+            // this page goes away, and a `.task` that returns immediately
+            // cannot tell it that.
+            await model.pollWhileVisible()
+        }
     }
 
     /// The explicit empty selection the All chip can reach. Every number on

--- a/Sources/VibeBarCore/Compat/AgentSessionKitReexport.swift
+++ b/Sources/VibeBarCore/Compat/AgentSessionKitReexport.swift
@@ -69,13 +69,19 @@ extension MCPSocketServer {
     /// path — tests, the documented `VIBEBAR_MCP_SOCKET` override — must
     /// already have its directory, because chmod-ing someone else's is not
     /// this server's business.
+    ///
+    /// `idleTimeout` is passed through because the package cannot choose one:
+    /// it does not know whether its host's clients respawn after an EOF. Vibe
+    /// Bar does — see `MCPController.clientIdleTimeout`.
     public convenience init(
         server: MCPServer,
-        socketPath: String = MCPSocketServer.defaultSocketPath
+        socketPath: String = MCPSocketServer.defaultSocketPath,
+        idleTimeout: TimeInterval? = MCPSocketServer.defaultIdleTimeout
     ) {
         self.init(
             handler: server,
             socketPath: socketPath,
+            idleTimeout: idleTimeout,
             ensureDirectory: {
                 guard socketPath == MCPSocketServer.defaultSocketPath else { return }
                 try VibeBarLocalStore.ensureBaseDirectory()

--- a/Sources/VibeBarCore/Models/UsageQueryModels.swift
+++ b/Sources/VibeBarCore/Models/UsageQueryModels.swift
@@ -37,6 +37,78 @@ public struct UsageQueryFilter: Sendable, Equatable {
     }
 }
 
+// MARK: - Result reuse
+
+/// Everything a completed Usage Stats query result actually depends on.
+///
+/// The Workbench's Usage Stats page re-runs `activate()` on every entry, and
+/// its view model outlives the window — so "switch to Sessions and back" cost
+/// the whole analytic set (up to eleven sequential ledger round trips) to
+/// redraw numbers already on screen. Comparing this value against the one the
+/// visible results were produced with is what makes a re-entry free.
+///
+/// The membership rules are the whole point, and both directions matter:
+///
+/// - **What must be here:** every input the ledger reads. Range anchors,
+///   the tool / harness / model narrowing, the trend bucket, and
+///   `revision` — `UsageEventLedger.contentRevision()`, which moves on
+///   ingest, erase, rollup, and repricing.
+/// - **What must not be:** anything the ledger never sees. The wall clock at
+///   the end of a rolling preset is excluded because no row can appear
+///   inside the moved window without `revision` moving too. Which breakdown
+///   tab is open is excluded because opening one runs its own deferred
+///   query and changes no number in the shared set — including it meant
+///   opening Requests silently invalidated a perfectly good result set, and
+///   the next page entry re-ran all eleven queries for nothing.
+public struct UsageQuerySignature: Sendable, Equatable {
+    /// The chosen range as the user expressed it — preset plus whatever
+    /// anchors that preset actually reads. Not the resolved `DateInterval`:
+    /// see the clock-drift rule above.
+    public var rangeKey: String
+    public var tools: [ToolType]?
+    public var harnesses: [Harness]?
+    public var models: [String]?
+    public var granularity: UsageTrendBucket?
+    public var revision: UInt64
+
+    public init(
+        rangeKey: String,
+        tools: [ToolType]? = nil,
+        harnesses: [Harness]? = nil,
+        models: [String]? = nil,
+        granularity: UsageTrendBucket? = nil,
+        revision: UInt64
+    ) {
+        self.rangeKey = rangeKey
+        self.tools = tools
+        self.harnesses = harnesses
+        self.models = models
+        self.granularity = granularity
+        self.revision = revision
+    }
+
+    /// A stable key for "which window the user picked".
+    ///
+    /// `windowStart` is the historical anchor a back / forward step sets;
+    /// the custom bounds are only read when the preset is `custom`, but are
+    /// folded in unconditionally so the key stays a pure function of its
+    /// arguments.
+    public static func rangeKey(
+        preset: String,
+        windowStart: Date?,
+        customStart: Date,
+        customEnd: Date
+    ) -> String {
+        let anchor = windowStart.map { String($0.timeIntervalSince1970) } ?? "-"
+        return [
+            preset,
+            anchor,
+            String(customStart.timeIntervalSince1970),
+            String(customEnd.timeIntervalSince1970)
+        ].joined(separator: "|")
+    }
+}
+
 // MARK: - Trend bucketing
 
 public enum UsageTrendBucket: String, Sendable, Equatable, CaseIterable, Codable {

--- a/Sources/VibeBarCore/Services/SessionIndexCompactor.swift
+++ b/Sources/VibeBarCore/Services/SessionIndexCompactor.swift
@@ -1,6 +1,51 @@
 import Foundation
 import SQLite3
 
+/// Who is allowed to be inside `session_index.sqlite3` doing bulk work.
+///
+/// Three components write that database: the Workbench's Sessions page, the
+/// MCP surface's opportunistic backfill, and `SessionIndexCompactor`. Nothing
+/// coordinated them, so an 11 000-file sweep and a multi-minute compaction
+/// could run at once on the same 1 GB file — each one's transactions waiting
+/// out the other's busy timeout, for no benefit to either.
+///
+/// The two roles are deliberately asymmetric. A refresh is what the user
+/// asked for, so it `acquire()`s and waits its turn. Compaction is a
+/// throttled maintenance pass, so it `tryAcquire()`s and skips: still due
+/// tomorrow, and it costs nothing to wait.
+public actor SessionIndexMaintenanceGate {
+    public static let shared = SessionIndexMaintenanceGate()
+
+    private var isBusy = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    public init() {}
+
+    /// Claim the index, waiting for whoever holds it. Every waiter re-checks
+    /// after being resumed, so a burst of refreshes still enters one at a
+    /// time.
+    public func acquire() async {
+        while isBusy {
+            await withCheckedContinuation { waiters.append($0) }
+        }
+        isBusy = true
+    }
+
+    /// Claim the index only if it is free. `false` means someone else has it.
+    public func tryAcquire() -> Bool {
+        guard !isBusy else { return false }
+        isBusy = true
+        return true
+    }
+
+    public func release() {
+        isBusy = false
+        let resumed = waiters
+        waiters.removeAll()
+        for waiter in resumed { waiter.resume() }
+    }
+}
+
 /// Keeps `~/.vibebar/session_index.sqlite3` at the size its content
 /// deserves.
 ///
@@ -86,13 +131,25 @@ public final class SessionIndexCompactor: @unchecked Sendable {
     }
 
     /// Runs a pass when the stamp says one is due; returns `nil` otherwise
-    /// (also when the database does not exist yet). Safe to call from
-    /// several places — calls serialize on the compactor's queue.
+    /// (also when the database does not exist yet, and when an index refresh
+    /// currently holds the maintenance gate). Safe to call from several
+    /// places — calls serialize on the compactor's queue.
+    ///
+    /// The gate is what keeps this off the same database as a running scan.
+    /// Two writers with a busy timeout do not corrupt anything, but the
+    /// launch pass measured minutes on a 2.5 GB index and a Workbench refresh
+    /// arriving on top of it turns both into a queue of stalled
+    /// transactions. A maintenance pass that is due today is equally due in
+    /// an hour, so this one simply yields.
     public func compactIfDue(now: Date = Date()) async -> Outcome? {
-        await onQueue { [self] in
+        let gate = SessionIndexMaintenanceGate.shared
+        guard await gate.tryAcquire() else { return nil }
+        let outcome: Outcome? = await onQueue { [self] in
             guard isDue(now: now) else { return nil }
             return performCompact(now: now)
         }
+        await gate.release()
+        return outcome
     }
 
     /// Test seam for the scratch sweep's containment rules — the sweep is

--- a/Sources/VibeBarCore/Services/SessionIndexCompactor.swift
+++ b/Sources/VibeBarCore/Services/SessionIndexCompactor.swift
@@ -17,17 +17,42 @@ public actor SessionIndexMaintenanceGate {
     public static let shared = SessionIndexMaintenanceGate()
 
     private var isBusy = false
-    private var waiters: [CheckedContinuation<Void, Never>] = []
+    private var waiters: [UUID: CheckedContinuation<Void, Error>] = [:]
 
     public init() {}
 
-    /// Claim the index, waiting for whoever holds it. Every waiter re-checks
-    /// after being resumed, so a burst of refreshes still enters one at a
-    /// time.
-    public func acquire() async {
+    /// Claim the index, waiting for whoever holds it.
+    ///
+    /// Throws `CancellationError` if the caller's task is cancelled before or
+    /// while waiting, and claims nothing when it does — so a caller that
+    /// catches this must not call `release()`. Cancellability is the point:
+    /// a refresh parked behind the launch compactor's multi-minute pass has
+    /// to be able to give up when the Workbench closes, and a
+    /// non-cancellable continuation would have held that task alive for the
+    /// rest of the compaction.
+    ///
+    /// Every waiter re-checks `isBusy` after being resumed, so a burst of
+    /// refreshes still enters one at a time.
+    public func acquire() async throws {
         while isBusy {
-            await withCheckedContinuation { waiters.append($0) }
+            let id = UUID()
+            try await withTaskCancellationHandler {
+                try await withCheckedThrowingContinuation {
+                    (continuation: CheckedContinuation<Void, Error>) in
+                    // Already cancelled: `onCancel` has run (or is about to)
+                    // with nothing installed to find, so answer here instead
+                    // of parking forever.
+                    guard !Task.isCancelled else {
+                        continuation.resume(throwing: CancellationError())
+                        return
+                    }
+                    waiters[id] = continuation
+                }
+            } onCancel: {
+                Task { await self.failWaiter(id) }
+            }
         }
+        try Task.checkCancellation()
         isBusy = true
     }
 
@@ -42,7 +67,13 @@ public actor SessionIndexMaintenanceGate {
         isBusy = false
         let resumed = waiters
         waiters.removeAll()
-        for waiter in resumed { waiter.resume() }
+        for waiter in resumed.values { waiter.resume() }
+    }
+
+    /// `release` may have resumed and removed this waiter already, which is
+    /// why the lookup is allowed to find nothing.
+    private func failWaiter(_ id: UUID) {
+        waiters.removeValue(forKey: id)?.resume(throwing: CancellationError())
     }
 }
 

--- a/Sources/VibeBarCore/Services/SessionIndexExcerptPolicy.swift
+++ b/Sources/VibeBarCore/Services/SessionIndexExcerptPolicy.swift
@@ -40,13 +40,21 @@ public struct SessionIndexExcerptPolicy: Sendable, Equatable {
     /// excerpt budget is applied, so parsing a 1.6 GB rollout means
     /// gigabytes of transient strings; the session budget above is filled
     /// by the first few hundred KiB anyway.
+    ///
+    /// 8 MiB, not the 64 MiB this started at: `sessionExcerptBytes` is
+    /// 128 KiB, so the budget saturates two orders of magnitude before the
+    /// old limit and the extra 56 MiB were copied, parsed into strings, and
+    /// thrown away on every re-index of a file that had merely grown. The
+    /// only thing a larger head buys is a deeper *fallback* when the head is
+    /// mostly matter the trim drops (long tool output), and 8 MiB of JSONL
+    /// is already thousands of messages.
     public var headParseByteLimit: Int64
 
     public init(
         toolExcerptCharacters: Int = 600,
         proseExcerptCharacters: Int = 2_000,
         sessionExcerptBytes: Int = 128 * 1024,
-        headParseByteLimit: Int64 = 64 * 1024 * 1024
+        headParseByteLimit: Int64 = 8 * 1024 * 1024
     ) {
         self.toolExcerptCharacters = toolExcerptCharacters
         self.proseExcerptCharacters = proseExcerptCharacters
@@ -56,9 +64,15 @@ public struct SessionIndexExcerptPolicy: Sendable, Equatable {
 
     public static let standard = SessionIndexExcerptPolicy()
 
-    /// Bump when the standard caps tighten (or loosen) so
+    /// Bump when the standard *excerpt* caps tighten (or loosen) so
     /// `SessionIndexCompactor` re-runs its trim pass over existing rows
     /// regardless of the daily throttle.
+    ///
+    /// `headParseByteLimit` is deliberately not one of those caps:
+    /// it bounds what is *read*, and the rows already in the database were
+    /// written under the same 128 KiB excerpt budget either way. Lowering it
+    /// must not cost the user an unscheduled pass over a gigabyte-scale
+    /// index that would find nothing to trim.
     public static let version = 1
 
     /// The excerpt cap for one message, by the role the index stores.

--- a/Sources/VibeBarCore/Services/SessionIndexingBounds.swift
+++ b/Sources/VibeBarCore/Services/SessionIndexingBounds.swift
@@ -72,31 +72,53 @@ public enum SessionIndexingBounds {
     /// Cursor, AntiGravity, Grok Bot) are always read whole; a SQLite or
     /// protobuf store cut at an offset is not a shorter session, it is a
     /// corrupt one.
+    ///
+    /// `isCancelled` is checked at every point where this function is still
+    /// in control: before the head copy, between the copy's chunks, before
+    /// handing bytes to the adapter, and after the adapter returns. The
+    /// adapter's own parse is a single opaque call into the package and
+    /// cannot be interrupted from here — so the guarantee is "a cancelled
+    /// read starts no new parse and keeps no finished one", not "a parse
+    /// already inside the kit stops mid-file". Bounding the bytes first is
+    /// what keeps that uninterruptible window small.
     public static func readTranscript(
         adapter: any SessionProviderAdapter,
         fileURL: URL,
         headByteLimit: Int64?,
-        scratchDirectory: URL = VibeBarLocalStore.sessionIndexScratchDirectoryURL
+        scratchDirectory: URL = VibeBarLocalStore.sessionIndexScratchDirectoryURL,
+        isCancelled: () -> Bool = { Task.isCancelled }
     ) throws -> BoundedTranscript {
         let size = SessionParsing.fileSize(fileURL)
         // The autoreleasepool is what actually returns the parse's transient
         // strings: without it a run of selections holds every intermediate
         // NSString until the enclosing task hits a suspension point.
         return try autoreleasepool {
+            if isCancelled() { throw CancellationError() }
             guard let headByteLimit,
                   headByteLimit > 0,
                   headTruncatableProviders.contains(adapter.provider),
                   size > headByteLimit
             else {
+                let document = try adapter.parseTranscript(fileURL: fileURL, range: nil)
+                // Drop a finished-but-abandoned parse here rather than
+                // letting the caller carry gigabytes to its own check.
+                if isCancelled() { throw CancellationError() }
                 return BoundedTranscript(
-                    document: try adapter.parseTranscript(fileURL: fileURL, range: nil),
+                    document: document,
                     isHeadTruncated: false,
                     fileByteSize: size
                 )
             }
-            let head = try copyHead(of: fileURL, limit: headByteLimit, scratchDirectory: scratchDirectory)
+            let head = try copyHead(
+                of: fileURL,
+                limit: headByteLimit,
+                scratchDirectory: scratchDirectory,
+                isCancelled: isCancelled
+            )
             defer { try? FileManager.default.removeItem(at: head) }
+            if isCancelled() { throw CancellationError() }
             let parsed = try adapter.parseTranscript(fileURL: head, range: nil)
+            if isCancelled() { throw CancellationError() }
             return BoundedTranscript(
                 document: TranscriptDocument(
                     messages: parsed.messages,
@@ -114,7 +136,15 @@ public enum SessionIndexingBounds {
     /// lives under `~/.vibebar` because that directory is the only place
     /// the app writes; `SessionIndexCompactor` sweeps anything a crash
     /// leaves behind.
-    static func copyHead(of fileURL: URL, limit: Int64, scratchDirectory: URL) throws -> URL {
+    ///
+    /// The cancellation check is per chunk, which is the only granularity
+    /// this loop has — and the reason the copy is chunked at all.
+    static func copyHead(
+        of fileURL: URL,
+        limit: Int64,
+        scratchDirectory: URL,
+        isCancelled: () -> Bool = { Task.isCancelled }
+    ) throws -> URL {
         try FileManager.default.createDirectory(
             at: scratchDirectory,
             withIntermediateDirectories: true,
@@ -122,6 +152,11 @@ public enum SessionIndexingBounds {
         )
         let destination = scratchDirectory
             .appendingPathComponent("head-\(UUID().uuidString).\(fileURL.pathExtension)")
+        var completed = false
+        // A cancelled copy must not leave its partial file behind: nothing
+        // else knows this path, so `SessionIndexCompactor`'s scratch sweep
+        // would be the only thing that ever removed it.
+        defer { if !completed { try? FileManager.default.removeItem(at: destination) } }
         let source = try FileHandle(forReadingFrom: fileURL)
         defer { try? source.close() }
         FileManager.default.createFile(atPath: destination.path, contents: nil, attributes: [.posixPermissions: 0o600])
@@ -131,11 +166,13 @@ public enum SessionIndexingBounds {
         var remaining = limit
         let chunk = 4 * 1024 * 1024
         while remaining > 0 {
+            if isCancelled() { throw CancellationError() }
             let want = Int(min(Int64(chunk), remaining))
             guard let data = try source.read(upToCount: want), !data.isEmpty else { break }
             try sink.write(contentsOf: data)
             remaining -= Int64(data.count)
         }
+        completed = true
         return destination
     }
 
@@ -226,7 +263,14 @@ struct BoundedSessionAdapter: SessionProviderAdapter {
             adapter: inner,
             fileURL: fileURL,
             headByteLimit: policy.headParseByteLimit,
-            scratchDirectory: scratchDirectory
+            scratchDirectory: scratchDirectory,
+            // Explicitly opted out. The indexing sweep's cancellation story
+            // belongs to the kit's `refreshIndex`, and making a throw here
+            // mean "cancelled" would silently turn a cancelled pass into a
+            // pass that skipped files — indistinguishable, in the index,
+            // from files that failed to parse. The viewer is the caller that
+            // needs the abort, and it passes its own check.
+            isCancelled: { false }
         )
         return SessionIndexingBounds.trimmed(
             read.document,

--- a/Sources/VibeBarCore/Services/SessionIndexingBounds.swift
+++ b/Sources/VibeBarCore/Services/SessionIndexingBounds.swift
@@ -41,6 +41,104 @@ public enum SessionIndexingBounds {
         })
     }
 
+    // MARK: - Reading a transcript for the screen
+
+    /// How much of an oversized log the transcript viewer parses before it
+    /// stops and offers the rest as an explicit action.
+    ///
+    /// Larger than the index's own limit because this is what the user asked
+    /// to read — but still a limit: the kit's adapters materialize every
+    /// message before applying `range:`, so a `range` is not a memory bound
+    /// and a 1.7 GB rollout put the app's lifetime peak at 1.5–1.9 GB. At
+    /// 32 MiB the viewer opens tens of thousands of messages, which is more
+    /// than its 80-per-page reader can walk in a sitting.
+    public static let viewerHeadParseByteLimit: Int64 = 32 * 1024 * 1024
+
+    /// One transcript, read whole or read from the head.
+    public struct BoundedTranscript: Sendable {
+        public let document: TranscriptDocument
+        /// True when `document` stops short of the file because the head
+        /// limit was hit — not because the adapter itself truncated.
+        public let isHeadTruncated: Bool
+        /// Size of the file on disk, so a caller can say how much was left.
+        public let fileByteSize: Int64
+    }
+
+    /// Parse `fileURL` with a byte bound instead of a message bound.
+    ///
+    /// `headByteLimit` of `nil` is the unbounded read — what "Load entire
+    /// transcript" performs once the user has asked for it in as many words.
+    /// Providers whose session is not a byte-truncatable JSONL log (Grok,
+    /// Cursor, AntiGravity, Grok Bot) are always read whole; a SQLite or
+    /// protobuf store cut at an offset is not a shorter session, it is a
+    /// corrupt one.
+    public static func readTranscript(
+        adapter: any SessionProviderAdapter,
+        fileURL: URL,
+        headByteLimit: Int64?,
+        scratchDirectory: URL = VibeBarLocalStore.sessionIndexScratchDirectoryURL
+    ) throws -> BoundedTranscript {
+        let size = SessionParsing.fileSize(fileURL)
+        // The autoreleasepool is what actually returns the parse's transient
+        // strings: without it a run of selections holds every intermediate
+        // NSString until the enclosing task hits a suspension point.
+        return try autoreleasepool {
+            guard let headByteLimit,
+                  headByteLimit > 0,
+                  headTruncatableProviders.contains(adapter.provider),
+                  size > headByteLimit
+            else {
+                return BoundedTranscript(
+                    document: try adapter.parseTranscript(fileURL: fileURL, range: nil),
+                    isHeadTruncated: false,
+                    fileByteSize: size
+                )
+            }
+            let head = try copyHead(of: fileURL, limit: headByteLimit, scratchDirectory: scratchDirectory)
+            defer { try? FileManager.default.removeItem(at: head) }
+            let parsed = try adapter.parseTranscript(fileURL: head, range: nil)
+            return BoundedTranscript(
+                document: TranscriptDocument(
+                    messages: parsed.messages,
+                    totalMessageCount: parsed.totalMessageCount,
+                    truncated: true
+                ),
+                isHeadTruncated: true,
+                fileByteSize: size
+            )
+        }
+    }
+
+    /// Streams the first `limit` bytes of `fileURL` into a scratch file.
+    /// Constant memory; the caller deletes the copy after parsing. Scratch
+    /// lives under `~/.vibebar` because that directory is the only place
+    /// the app writes; `SessionIndexCompactor` sweeps anything a crash
+    /// leaves behind.
+    static func copyHead(of fileURL: URL, limit: Int64, scratchDirectory: URL) throws -> URL {
+        try FileManager.default.createDirectory(
+            at: scratchDirectory,
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700]
+        )
+        let destination = scratchDirectory
+            .appendingPathComponent("head-\(UUID().uuidString).\(fileURL.pathExtension)")
+        let source = try FileHandle(forReadingFrom: fileURL)
+        defer { try? source.close() }
+        FileManager.default.createFile(atPath: destination.path, contents: nil, attributes: [.posixPermissions: 0o600])
+        let sink = try FileHandle(forWritingTo: destination)
+        defer { try? sink.close() }
+
+        var remaining = limit
+        let chunk = 4 * 1024 * 1024
+        while remaining > 0 {
+            let want = Int(min(Int64(chunk), remaining))
+            guard let data = try source.read(upToCount: want), !data.isEmpty else { break }
+            try sink.write(contentsOf: data)
+            remaining -= Int64(data.count)
+        }
+        return destination
+    }
+
     // MARK: - Transcript trimming
 
     /// `document` with the excerpt policy applied: per-message character
@@ -124,47 +222,17 @@ struct BoundedSessionAdapter: SessionProviderAdapter {
         guard range == nil else {
             return try inner.parseTranscript(fileURL: fileURL, range: range)
         }
-        var headTruncated = false
-        var document: TranscriptDocument
-        if SessionIndexingBounds.headTruncatableProviders.contains(inner.provider),
-           SessionParsing.fileSize(fileURL) > policy.headParseByteLimit {
-            let head = try copyHead(of: fileURL)
-            defer { try? FileManager.default.removeItem(at: head) }
-            document = try inner.parseTranscript(fileURL: head, range: nil)
-            headTruncated = true
-        } else {
-            document = try inner.parseTranscript(fileURL: fileURL, range: nil)
-        }
-        return SessionIndexingBounds.trimmed(document, policy: policy, headTruncated: headTruncated, provider: inner.provider)
-    }
-
-    /// Streams the first `headParseByteLimit` bytes into a scratch file.
-    /// Constant memory; the caller deletes the copy after parsing. Scratch
-    /// lives under `~/.vibebar` because that directory is the only place
-    /// the app writes; `SessionIndexCompactor` sweeps anything a crash
-    /// leaves behind.
-    private func copyHead(of fileURL: URL) throws -> URL {
-        try FileManager.default.createDirectory(
-            at: scratchDirectory,
-            withIntermediateDirectories: true,
-            attributes: [.posixPermissions: 0o700]
+        let read = try SessionIndexingBounds.readTranscript(
+            adapter: inner,
+            fileURL: fileURL,
+            headByteLimit: policy.headParseByteLimit,
+            scratchDirectory: scratchDirectory
         )
-        let destination = scratchDirectory
-            .appendingPathComponent("head-\(UUID().uuidString).\(fileURL.pathExtension)")
-        let source = try FileHandle(forReadingFrom: fileURL)
-        defer { try? source.close() }
-        FileManager.default.createFile(atPath: destination.path, contents: nil, attributes: [.posixPermissions: 0o600])
-        let sink = try FileHandle(forWritingTo: destination)
-        defer { try? sink.close() }
-
-        var remaining = policy.headParseByteLimit
-        let chunk = 4 * 1024 * 1024
-        while remaining > 0 {
-            let want = Int(min(Int64(chunk), remaining))
-            guard let data = try source.read(upToCount: want), !data.isEmpty else { break }
-            try sink.write(contentsOf: data)
-            remaining -= Int64(data.count)
-        }
-        return destination
+        return SessionIndexingBounds.trimmed(
+            read.document,
+            policy: policy,
+            headTruncated: read.isHeadTruncated,
+            provider: inner.provider
+        )
     }
 }

--- a/Sources/VibeBarCore/Services/UsageEventLedger.swift
+++ b/Sources/VibeBarCore/Services/UsageEventLedger.swift
@@ -70,6 +70,21 @@ public actor UsageEventLedger: CostUsageEventSink {
     private var contentRevisionValue: UInt64 = 0
     /// See `optimizeStorage`.
     private var didOptimizeStorage = false
+    /// Picker inputs the Usage Stats page re-asks for on every reload. Both
+    /// ignore the date range by design, so their only real input is the
+    /// ledger's content — which is exactly what `contentRevisionValue`
+    /// tracks. Keyed by the filter's tool/harness signature and dropped
+    /// whole whenever the revision moves.
+    private var pickerCacheRevision: UInt64?
+    private var availableModelsCache: [String: [String]] = [:]
+    private var earliestUsageCache: [String: Date?] = [:]
+    /// `tokenHeadlineTotals` groups the whole detail table by day and is
+    /// called on every popover open and every cost refresh. Same reasoning:
+    /// the answer can only move when the ledger does — plus the local day,
+    /// because "today" and "peak" are relative to it.
+    private var headlineCacheRevision: UInt64?
+    private var headlineCacheDay: String?
+    private var headlineCache: [String: UsageTokenHeadlineTotals] = [:]
     private let transient = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
     private let calendar: Calendar
     private let dayFormatter: DateFormatter
@@ -142,8 +157,8 @@ public actor UsageEventLedger: CostUsageEventSink {
     }
 
     /// One-time storage upkeep the query planner needs and correctness does
-    /// not: building the harness index on an established ledger, and
-    /// refreshing `sqlite_stat1`.
+    /// not: building the harness index on an established ledger, refreshing
+    /// `sqlite_stat1`, and returning freed pages to the filesystem.
     ///
     /// Deliberately outside `initialize`. That runs synchronously inside
     /// `init`, which `AppEnvironment` calls on the main thread before the
@@ -156,12 +171,53 @@ public actor UsageEventLedger: CostUsageEventSink {
         didOptimizeStorage = true
         _ = sqlite3_exec(database, Self.harnessIndexSQL, nil, nil, nil)
         Self.refreshStatisticsIfStale(database)
+        Self.reclaimFreePages(database)
+    }
+
+    /// Give freed pages back to the filesystem, in bounded steps.
+    ///
+    /// `rollupAndPrune` deletes the detail rows of every day older than 30,
+    /// and retention deletes whole rollups; without `auto_vacuum` those pages
+    /// stay in the file forever. New databases are created `INCREMENTAL` (see
+    /// `initialize`), which makes this a short, bounded `incremental_vacuum`.
+    ///
+    /// An older database was created with `auto_vacuum=NONE`, and the only
+    /// way to change that is a full `VACUUM` — which rewrites the whole file.
+    /// So it happens here, on the actor's executor rather than at launch,
+    /// once, and only when the freelist has grown large enough to be worth
+    /// it. A healthy ledger never takes that branch.
+    private static let vacuumConversionFreeByteThreshold = 32 * 1024 * 1024
+    /// ~8 MiB per pass at a 4 KiB page size. Enough to keep up with a day of
+    /// pruning without holding the actor for long.
+    private static let incrementalVacuumPages = 2_000
+
+    private static func reclaimFreePages(_ database: OpaquePointer) {
+        let mode = scalarInt(database, "PRAGMA auto_vacuum") ?? 0
+        if mode == 2 {
+            _ = sqlite3_exec(
+                database, "PRAGMA incremental_vacuum(\(incrementalVacuumPages))", nil, nil, nil
+            )
+            return
+        }
+        let pageSize = scalarInt(database, "PRAGMA page_size") ?? 4_096
+        let freeBytes = (scalarInt(database, "PRAGMA freelist_count") ?? 0) * pageSize
+        guard freeBytes >= vacuumConversionFreeByteThreshold else { return }
+        guard sqlite3_exec(database, "PRAGMA auto_vacuum=INCREMENTAL", nil, nil, nil) == SQLITE_OK else {
+            return
+        }
+        _ = sqlite3_exec(database, "VACUUM", nil, nil, nil)
     }
 
     // MARK: - Schema
 
     private static func initialize(_ database: OpaquePointer) throws {
+        // `auto_vacuum` first, and before `journal_mode`: it is written into
+        // the file header, and the header is fixed by the first statement
+        // that touches the file — setting WAL ahead of it measurably leaves
+        // the mode at NONE. On an established database this line is a no-op
+        // and the conversion happens in `optimizeStorage` instead.
         let preamble = """
+            PRAGMA auto_vacuum=INCREMENTAL;
             PRAGMA journal_mode=WAL;
             PRAGMA synchronous=NORMAL;
             CREATE TABLE IF NOT EXISTS ledger_meta (
@@ -1037,6 +1093,11 @@ public actor UsageEventLedger: CostUsageEventSink {
                 )
             }
             try execute("COMMIT")
+            // Rows moved between the two tables and retention may have
+            // dropped the oldest day outright: `earliestUsageDate`, the model
+            // picker and the token headlines can all have changed without a
+            // single new event arriving.
+            contentRevisionValue &+= 1
         } catch {
             try? execute("ROLLBACK")
             throw error
@@ -1091,33 +1152,58 @@ public actor UsageEventLedger: CostUsageEventSink {
     /// the active model has linear, tier-independent pricing; ambiguous and
     /// already-priced rollups stay untouched because their request boundaries
     /// are no longer available.
+    ///
+    /// Chunked and `async` on purpose. This used to read every detail row
+    /// into memory and then update them one at a time inside a single
+    /// transaction: at 245 000 rows that is a quarter-million `RepricingRow`
+    /// values held at once and one write transaction that no other ledger
+    /// query can get past. It now walks the table by ascending `id` in
+    /// bounded runs, commits each run, and yields between them, so a pricing
+    /// refresh interleaves with the Workbench's reads instead of blocking
+    /// them. A run that is interrupted leaves the revision marker unwritten,
+    /// so the next launch simply reprices again — the calculation is
+    /// idempotent against the same price table.
     @discardableResult
-    public func prepareForPricingRevision(_ revision: String) throws -> Bool {
+    public func prepareForPricingRevision(_ revision: String) async throws -> Bool {
         let stored = try scalarText(
             "SELECT value FROM ledger_meta WHERE key = ?",
             [.text(Self.pricingRevisionKey)]
         )
         guard stored != revision else { return false }
 
-        let details = try detailRows()
+        var lastID: Int64 = 0
+        while true {
+            let chunk = try detailRows(after: lastID, limit: Self.repricingChunkSize)
+            guard let last = chunk.last else { break }
+            lastID = last.id
+            try execute("BEGIN IMMEDIATE")
+            do {
+                for row in chunk {
+                    // Cursor dashboard cents are authoritative provider facts,
+                    // not estimates from our price table. Source provenance
+                    // keeps repricing from overwriting them with catalog rates.
+                    if row.sourceKey?.hasPrefix("cursor-event-v1") == true { continue }
+                    let costBinding: Binding = if let micros = costMicros(for: row) {
+                        .integer(micros)
+                    } else {
+                        .null
+                    }
+                    try run(
+                        "UPDATE usage_events SET cost_micros = ? WHERE id = ?",
+                        [costBinding, .integer(row.id)]
+                    )
+                }
+                try execute("COMMIT")
+            } catch {
+                try? execute("ROLLBACK")
+                throw error
+            }
+            await Task.yield()
+        }
+
         let rollups = try fullyUnpricedRollupRows()
         try execute("BEGIN IMMEDIATE")
         do {
-            for row in details {
-                // Cursor dashboard cents are authoritative provider facts,
-                // not estimates from our price table. Source provenance keeps
-                // repricing from overwriting them with catalog rates.
-                if row.sourceKey?.hasPrefix("cursor-event-v1") == true { continue }
-                let costBinding: Binding = if let micros = costMicros(for: row) {
-                    .integer(micros)
-                } else {
-                    .null
-                }
-                try run(
-                    "UPDATE usage_events SET cost_micros = ? WHERE id = ?",
-                    [costBinding, .integer(row.id)]
-                )
-            }
             for row in rollups {
                 guard CostUsagePricing.canRepriceAggregate(tool: row.tool, model: row.model) else {
                     continue
@@ -1149,12 +1235,20 @@ public actor UsageEventLedger: CostUsageEventSink {
                 [.text(Self.pricingRevisionKey), .text(revision)]
             )
             try execute("COMMIT")
+            // Costs moved even though no row was added or removed, so every
+            // revision-keyed cache above this has to see a new number.
+            contentRevisionValue &+= 1
             return true
         } catch {
             try? execute("ROLLBACK")
             throw error
         }
     }
+
+    /// Detail rows per repricing transaction. Small enough that the write
+    /// lock is held for milliseconds, large enough that a 245k-row ledger is
+    /// under a hundred transactions.
+    private static let repricingChunkSize = 5_000
 
     private struct RepricingRow {
         let id: Int64
@@ -1173,15 +1267,18 @@ public actor UsageEventLedger: CostUsageEventSink {
         let sourceKey: String?
     }
 
-    private func detailRows() throws -> [RepricingRow] {
+    /// One bounded run of detail rows, keyset-paged by `id` so a chunk can
+    /// never overlap or skip a row the previous chunk already repriced.
+    private func detailRows(after lastID: Int64, limit: Int) throws -> [RepricingRow] {
         let statement = try prepare(
             """
             SELECT id, day, tool, model, fresh_input, output,
                    cache_read, cache_creation, service_tier, source_key
-              FROM usage_events
+              FROM usage_events WHERE id > ? ORDER BY id LIMIT ?
             """
         )
         defer { sqlite3_finalize(statement) }
+        bindAll([.integer(lastID), .integer(Int64(limit))], to: statement)
         var rows: [RepricingRow] = []
         while sqlite3_step(statement) == SQLITE_ROW {
             guard let day = columnText(statement, 1),
@@ -1416,6 +1513,22 @@ public actor UsageEventLedger: CostUsageEventSink {
                 peakDayTokens: 0, peakDay: nil
             )
         }
+        // Both halves are needed and neither can be dropped: `rollupAndPrune`
+        // moves a day's rows from `usage_events` into `usage_daily_rollups`
+        // once it is 30 days old, so all-time and peak live in the rollups
+        // *and* in the last month of detail. What can be avoided is repeating
+        // the pass — the answer only moves when the ledger does, or when the
+        // local day turns over.
+        let cacheKey = tools.map { $0.map(\.rawValue).joined(separator: ",") } ?? "*"
+        let today = calendar.startOfDay(for: now)
+        let todayKey = dayString(for: today)
+        if headlineCacheRevision != contentRevisionValue || headlineCacheDay != todayKey {
+            headlineCacheRevision = contentRevisionValue
+            headlineCacheDay = todayKey
+            headlineCache.removeAll(keepingCapacity: true)
+        }
+        if let cached = headlineCache[cacheKey] { return cached }
+
         var byDay: [Date: Int64] = [:]
         let clause = tools.map { " WHERE tool IN (\(placeholders($0.count)))" } ?? ""
         let bindings = tools?.map { Binding.text($0.rawValue) } ?? []
@@ -1449,14 +1562,13 @@ public actor UsageEventLedger: CostUsageEventSink {
         bindAll(bindings, to: rollups)
         consume(rollups)
 
-        let today = calendar.startOfDay(for: now)
         let yesterday = calendar.date(byAdding: .day, value: -1, to: today) ?? today
         let weekStart = calendar.date(byAdding: .day, value: -6, to: today) ?? today
         let monthStart = calendar.date(byAdding: .day, value: -29, to: today) ?? today
         let peak = byDay.max { lhs, rhs in
             lhs.value == rhs.value ? lhs.key < rhs.key : lhs.value < rhs.value
         }
-        return UsageTokenHeadlineTotals(
+        let totals = UsageTokenHeadlineTotals(
             allTimeTokens: byDay.values.reduce(0, +),
             todayTokens: byDay[today] ?? 0,
             yesterdayTokens: byDay[yesterday] ?? 0,
@@ -1469,6 +1581,8 @@ public actor UsageEventLedger: CostUsageEventSink {
             peakDayTokens: peak?.value ?? 0,
             peakDay: peak?.key
         )
+        headlineCache[cacheKey] = totals
+        return totals
     }
 
     /// Zero-filled series across the filter's range.
@@ -1953,6 +2067,9 @@ public actor UsageEventLedger: CostUsageEventSink {
     ) throws -> [String] {
         if let tools, tools.isEmpty { return [] }
         if let harnesses, harnesses.isEmpty { return [] }
+        let key = Self.pickerCacheKey(tools: tools, harnesses: harnesses)
+        prunePickerCacheIfStale()
+        if let cached = availableModelsCache[key] { return cached }
         var clauses = ["TRIM(model) <> ''"]
         var bindings: [Binding] = []
         if let tools {
@@ -1978,7 +2095,24 @@ public actor UsageEventLedger: CostUsageEventSink {
         while sqlite3_step(statement) == SQLITE_ROW {
             if let model = columnText(statement, 0) { models.append(model) }
         }
+        availableModelsCache[key] = models
         return models
+    }
+
+    /// Cache key for the two range-independent picker queries. The date range
+    /// is deliberately absent: neither query looks at it.
+    private static func pickerCacheKey(tools: [ToolType]?, harnesses: [Harness]?) -> String {
+        let toolKey = tools.map { $0.map(\.rawValue).joined(separator: ",") } ?? "*"
+        let harnessKey = harnesses.map { $0.map(\.rawValue).joined(separator: ",") } ?? "*"
+        return toolKey + "|" + harnessKey
+    }
+
+    /// Drop the picker caches when the ledger's content has moved under them.
+    private func prunePickerCacheIfStale() {
+        guard pickerCacheRevision != contentRevisionValue else { return }
+        pickerCacheRevision = contentRevisionValue
+        availableModelsCache.removeAll(keepingCapacity: true)
+        earliestUsageCache.removeAll(keepingCapacity: true)
     }
 
     /// Earliest retained fact for an optional SubProvider filter. The All
@@ -1990,6 +2124,9 @@ public actor UsageEventLedger: CostUsageEventSink {
     ) throws -> Date? {
         if let tools, tools.isEmpty { return nil }
         if let harnesses, harnesses.isEmpty { return nil }
+        let key = Self.pickerCacheKey(tools: tools, harnesses: harnesses)
+        prunePickerCacheIfStale()
+        if let cached = earliestUsageCache[key] { return cached }
         var clauses: [String] = []
         var bindings: [Binding] = []
         if let tools {
@@ -2022,12 +2159,14 @@ public actor UsageEventLedger: CostUsageEventSink {
             nil
         }
 
-        switch (detailStart, rollupStart) {
-        case let (detail?, rollup?): return min(detail, rollup)
-        case let (detail?, nil): return detail
-        case let (nil, rollup?): return rollup
-        case (nil, nil): return nil
+        let earliest: Date? = switch (detailStart, rollupStart) {
+        case let (detail?, rollup?): min(detail, rollup)
+        case let (detail?, nil): detail
+        case let (nil, rollup?): rollup
+        case (nil, nil): nil
         }
+        earliestUsageCache[key] = earliest
+        return earliest
     }
 
     private func forEachGroup(

--- a/Tests/VibeBarCoreTests/SessionIndexingBoundsTests.swift
+++ b/Tests/VibeBarCoreTests/SessionIndexingBoundsTests.swift
@@ -194,6 +194,158 @@ final class SessionIndexingBoundsTests: XCTestCase {
         )
     }
 
+    // MARK: - Cancellation
+
+    /// The bound is what keeps the uninterruptible window small; this is the
+    /// other half — a read that is cancelled before the adapter is handed
+    /// anything must not produce a document at all.
+    func testCancelledReadThrowsBeforeParsing() throws {
+        let line = codexLine(role: "user", text: "alpha bravo charlie")
+        let fileURL = directory.appendingPathComponent("rollout-cancel.jsonl")
+        try Data((line + "\n").utf8).write(to: fileURL)
+
+        let adapter = CountingAdapter(inner: CodexSessionAdapter(homeDirectory: directory.path))
+        XCTAssertThrowsError(
+            try SessionIndexingBounds.readTranscript(
+                adapter: adapter,
+                fileURL: fileURL,
+                headByteLimit: nil,
+                scratchDirectory: scratchURL,
+                isCancelled: { true }
+            )
+        ) { error in
+            XCTAssertTrue(error is CancellationError)
+        }
+        XCTAssertEqual(adapter.parseCount.value, 0, "a cancelled read must not reach the parser")
+    }
+
+    /// Cancellation that arrives during the head copy has to abort the copy
+    /// itself — the chunk loop is the only place this code is in control of a
+    /// gigabyte-scale read.
+    func testCancellationDuringTheHeadCopyAbortsAndLeavesNoScratch() throws {
+        // Comfortably more than one 4 MiB chunk, so the loop runs more than
+        // once and the check between chunks is the thing under test.
+        let filler = codexLine(role: "assistant", text: String(repeating: "x", count: 4 * 1024 * 1024))
+        let fileURL = directory.appendingPathComponent("rollout-chunked.jsonl")
+        try Data((filler + "\n" + filler + "\n" + filler + "\n").utf8).write(to: fileURL)
+
+        let adapter = CountingAdapter(inner: CodexSessionAdapter(homeDirectory: directory.path))
+        // False first (so the copy starts), then true from the second chunk.
+        let calls = Counter()
+        XCTAssertThrowsError(
+            try SessionIndexingBounds.readTranscript(
+                adapter: adapter,
+                fileURL: fileURL,
+                headByteLimit: 8 * 1024 * 1024,
+                scratchDirectory: scratchURL,
+                isCancelled: { calls.increment() > 2 }
+            )
+        ) { error in
+            XCTAssertTrue(error is CancellationError)
+        }
+        XCTAssertEqual(adapter.parseCount.value, 0, "the parse must never start")
+        let leftovers = (try? FileManager.default.contentsOfDirectory(atPath: scratchURL.path)) ?? []
+        XCTAssertTrue(leftovers.isEmpty, "an aborted head copy must not leave its partial file behind")
+    }
+
+    /// A parse that finished while the caller was cancelled is a whole
+    /// transcript in memory; it gets dropped here rather than travelling to
+    /// the caller's own check.
+    func testAFinishedParseIsDiscardedWhenCancellationArrivedDuringIt() throws {
+        let line = codexLine(role: "user", text: "alpha bravo charlie")
+        let fileURL = directory.appendingPathComponent("rollout-late-cancel.jsonl")
+        try Data((line + "\n").utf8).write(to: fileURL)
+
+        // False on the way in, true on the way out — cancellation landing
+        // while the adapter was busy.
+        let calls = Counter()
+        let adapter = CountingAdapter(inner: CodexSessionAdapter(homeDirectory: directory.path))
+        XCTAssertThrowsError(
+            try SessionIndexingBounds.readTranscript(
+                adapter: adapter,
+                fileURL: fileURL,
+                headByteLimit: nil,
+                scratchDirectory: scratchURL,
+                isCancelled: { calls.increment() > 1 }
+            )
+        ) { error in
+            XCTAssertTrue(error is CancellationError)
+        }
+        XCTAssertEqual(adapter.parseCount.value, 1)
+    }
+
+    /// The indexing wrapper opts out on purpose: a throw there would be
+    /// indistinguishable, in the index, from a file that failed to parse.
+    func testIndexingAdapterIgnoresAmbientCancellation() async throws {
+        let line = codexLine(role: "user", text: "alpha bravo charlie")
+        let fileURL = directory.appendingPathComponent("rollout-indexing.jsonl")
+        try Data((line + "\n").utf8).write(to: fileURL)
+
+        let adapter = BoundedSessionAdapter(
+            inner: CodexSessionAdapter(homeDirectory: directory.path),
+            policy: .standard,
+            scratchDirectory: scratchURL
+        )
+        let task = Task { () -> [String] in
+            // Park until cancellation has actually landed, so the parse below
+            // definitely runs inside a cancelled task rather than racing it.
+            while !Task.isCancelled { await Task.yield() }
+            return try adapter.parseTranscript(fileURL: fileURL, range: nil).messages.map(\.text)
+        }
+        task.cancel()
+        let texts = try await task.value
+        XCTAssertEqual(texts, ["alpha bravo charlie"])
+    }
+
+    /// A thread-safe call counter — the cancellation predicate is
+    /// `@escaping`-adjacent and read from the same thread, but the adapter's
+    /// counter is shared with the reader.
+    private final class Counter: @unchecked Sendable {
+        private let lock = NSLock()
+        private var count = 0
+
+        @discardableResult
+        func increment() -> Int {
+            lock.lock()
+            defer { lock.unlock() }
+            count += 1
+            return count
+        }
+
+        var value: Int {
+            lock.lock()
+            defer { lock.unlock() }
+            return count
+        }
+    }
+
+    /// Forwards everything, and counts the one call the tests care about.
+    private struct CountingAdapter: SessionProviderAdapter {
+        let inner: any SessionProviderAdapter
+        let parseCount = Counter()
+
+        var provider: SessionProvider { inner.provider }
+
+        func roots(homeDirectory: String) -> [URL] { inner.roots(homeDirectory: homeDirectory) }
+
+        func discoverSessionFiles(homeDirectory: String) -> [URL] {
+            inner.discoverSessionFiles(homeDirectory: homeDirectory)
+        }
+
+        func extractMetadata(fileURL: URL) throws -> SessionSummary {
+            try inner.extractMetadata(fileURL: fileURL)
+        }
+
+        func deletionPlan(for summary: SessionSummary, homeDirectory: String) throws -> SessionDeletionPlan {
+            try inner.deletionPlan(for: summary, homeDirectory: homeDirectory)
+        }
+
+        func parseTranscript(fileURL: URL, range: Range<Int>?) throws -> TranscriptDocument {
+            parseCount.increment()
+            return try inner.parseTranscript(fileURL: fileURL, range: range)
+        }
+    }
+
     func testHeadBoundNeverAppliesToAStoreThatCannotBeCutAtAnOffset() {
         // A SQLite or protobuf store truncated at a byte offset is not a
         // shorter session, it is a corrupt one.
@@ -224,14 +376,14 @@ final class SessionIndexingBoundsTests: XCTestCase {
         await gate.release()
     }
 
-    func testMaintenanceGateMakesAWaiterRunAfterTheHolder() async {
+    func testMaintenanceGateMakesAWaiterRunAfterTheHolder() async throws {
         // `acquire` is the refresh side: it waits rather than skipping.
         let gate = SessionIndexMaintenanceGate()
-        await gate.acquire()
+        try await gate.acquire()
         let order = OrderRecorder()
 
         let waiter = Task {
-            await gate.acquire()
+            try? await gate.acquire()
             await order.append("second")
             await gate.release()
         }
@@ -248,6 +400,55 @@ final class SessionIndexingBoundsTests: XCTestCase {
     private actor OrderRecorder {
         var entries: [String] = []
         func append(_ value: String) { entries.append(value) }
+    }
+
+    /// A refresh parked behind the launch compactor's multi-minute pass has
+    /// to be able to give up when the Workbench closes. A non-cancellable
+    /// continuation held that task alive for the rest of the compaction.
+    func testAWaitingAcquireGivesUpWhenItsTaskIsCancelled() async throws {
+        let gate = SessionIndexMaintenanceGate()
+        try await gate.acquire()
+
+        let waiter = Task { () -> Bool in
+            do {
+                try await gate.acquire()
+                return false
+            } catch {
+                return error is CancellationError
+            }
+        }
+        // Let it park on the gate before cancelling.
+        try? await Task.sleep(for: .milliseconds(50))
+        waiter.cancel()
+        let threw = await waiter.value
+        XCTAssertTrue(threw, "a cancelled wait must throw rather than hang")
+
+        // And it claimed nothing on the way out, so the holder's release
+        // still leaves the gate free rather than double-held.
+        await gate.release()
+        let claimable = await gate.tryAcquire()
+        XCTAssertTrue(claimable, "a cancelled waiter must not have taken the gate")
+        await gate.release()
+    }
+
+    /// Cancelled before it ever waits: the free-gate fast path has to check
+    /// too, or a closing window still starts an 11 000-file sweep.
+    func testAcquireOnAFreeGateStillHonoursAnAlreadyCancelledTask() async {
+        let gate = SessionIndexMaintenanceGate()
+        let task = Task { () -> Bool in
+            do {
+                try await gate.acquire()
+                return false
+            } catch {
+                return error is CancellationError
+            }
+        }
+        task.cancel()
+        let threw = await task.value
+        XCTAssertTrue(threw)
+        let claimable = await gate.tryAcquire()
+        XCTAssertTrue(claimable, "the gate was never claimed")
+        await gate.release()
     }
 
     func testBoundedRegistryKeepsProvidersAndOrder() {

--- a/Tests/VibeBarCoreTests/SessionIndexingBoundsTests.swift
+++ b/Tests/VibeBarCoreTests/SessionIndexingBoundsTests.swift
@@ -137,6 +137,119 @@ final class SessionIndexingBoundsTests: XCTestCase {
         XCTAssertEqual(document.messages.first?.text, long)
     }
 
+    // MARK: - The viewer's own bound
+
+    func testStandardHeadLimitStaysWellAboveTheExcerptBudget() {
+        // The head copy exists to bound *memory*, and the excerpt budget is
+        // what it feeds; 64 MiB was two orders of magnitude past saturation.
+        let policy = SessionIndexExcerptPolicy.standard
+        XCTAssertEqual(policy.headParseByteLimit, 8 * 1024 * 1024)
+        XCTAssertGreaterThan(policy.headParseByteLimit, Int64(policy.sessionExcerptBytes) * 16)
+        // The viewer reads more than the indexer, and still not the file.
+        XCTAssertGreaterThan(
+            SessionIndexingBounds.viewerHeadParseByteLimit,
+            policy.headParseByteLimit
+        )
+    }
+
+    func testReadTranscriptBoundsALargeLogAndReportsIt() throws {
+        let first = codexLine(role: "user", text: "alpha bravo charlie")
+        let second = codexLine(role: "assistant", text: "delta echo foxtrot")
+        let fileURL = directory.appendingPathComponent("rollout-viewer.jsonl")
+        let contents = first + "\n" + second + "\n"
+        try Data(contents.utf8).write(to: fileURL)
+
+        let read = try SessionIndexingBounds.readTranscript(
+            adapter: CodexSessionAdapter(homeDirectory: directory.path),
+            fileURL: fileURL,
+            headByteLimit: Int64(first.utf8.count + 10),
+            scratchDirectory: scratchURL
+        )
+        XCTAssertTrue(read.isHeadTruncated)
+        XCTAssertTrue(read.document.truncated)
+        XCTAssertEqual(read.document.messages.map(\.text), ["alpha bravo charlie"])
+        XCTAssertEqual(read.fileByteSize, Int64(contents.utf8.count))
+        // Full text, unlike the indexing path: the viewer applies no excerpt
+        // trim at all, only the byte bound.
+        XCTAssertTrue((try? FileManager.default.contentsOfDirectory(atPath: scratchURL.path))?.isEmpty ?? true)
+    }
+
+    func testReadTranscriptWithNoLimitReadsTheWholeFile() throws {
+        let first = codexLine(role: "user", text: "alpha bravo charlie")
+        let second = codexLine(role: "assistant", text: "delta echo foxtrot")
+        let fileURL = directory.appendingPathComponent("rollout-whole.jsonl")
+        try Data((first + "\n" + second + "\n").utf8).write(to: fileURL)
+
+        let read = try SessionIndexingBounds.readTranscript(
+            adapter: CodexSessionAdapter(homeDirectory: directory.path),
+            fileURL: fileURL,
+            headByteLimit: nil,
+            scratchDirectory: scratchURL
+        )
+        XCTAssertFalse(read.isHeadTruncated)
+        XCTAssertFalse(read.document.truncated)
+        XCTAssertEqual(
+            read.document.messages.map(\.text),
+            ["alpha bravo charlie", "delta echo foxtrot"]
+        )
+    }
+
+    func testHeadBoundNeverAppliesToAStoreThatCannotBeCutAtAnOffset() {
+        // A SQLite or protobuf store truncated at a byte offset is not a
+        // shorter session, it is a corrupt one.
+        for provider in SessionProvider.allCases
+        where !SessionIndexingBounds.headTruncatableProviders.contains(provider) {
+            XCTAssertFalse(
+                SessionIndexingBounds.headTruncatableProviders.contains(provider),
+                "\(provider.rawValue) must not be head-truncated"
+            )
+        }
+        XCTAssertEqual(
+            SessionIndexingBounds.headTruncatableProviders,
+            [.codex, .claude, .claudeCowork]
+        )
+    }
+
+    // MARK: - Maintenance gate
+
+    func testMaintenanceGateRefusesASecondClaimUntilItIsReleased() async {
+        let gate = SessionIndexMaintenanceGate()
+        let firstClaim = await gate.tryAcquire()
+        XCTAssertTrue(firstClaim, "a free gate is claimable")
+        let secondClaim = await gate.tryAcquire()
+        XCTAssertFalse(secondClaim, "a held gate refuses the maintenance pass")
+        await gate.release()
+        let afterRelease = await gate.tryAcquire()
+        XCTAssertTrue(afterRelease, "release hands the gate back")
+        await gate.release()
+    }
+
+    func testMaintenanceGateMakesAWaiterRunAfterTheHolder() async {
+        // `acquire` is the refresh side: it waits rather than skipping.
+        let gate = SessionIndexMaintenanceGate()
+        await gate.acquire()
+        let order = OrderRecorder()
+
+        let waiter = Task {
+            await gate.acquire()
+            await order.append("second")
+            await gate.release()
+        }
+        // Give the waiter a chance to park on the gate before releasing.
+        try? await Task.sleep(for: .milliseconds(50))
+        await order.append("first")
+        await gate.release()
+        await waiter.value
+
+        let recorded = await order.entries
+        XCTAssertEqual(recorded, ["first", "second"])
+    }
+
+    private actor OrderRecorder {
+        var entries: [String] = []
+        func append(_ value: String) { entries.append(value) }
+    }
+
     func testBoundedRegistryKeepsProvidersAndOrder() {
         let registry = SessionProviderRegistry.standard(homeDirectory: directory.path)
         let bounded = SessionIndexingBounds.boundedRegistry(

--- a/Tests/VibeBarCoreTests/UsageEventLedgerTests.swift
+++ b/Tests/VibeBarCoreTests/UsageEventLedgerTests.swift
@@ -749,6 +749,188 @@ final class UsageEventLedgerTests: XCTestCase {
         XCTAssertEqual(retained.rows.count, 1)
     }
 
+    // MARK: - Storage upkeep and query-plan guards
+
+    /// `auto_vacuum` is written into the file header by the first statement
+    /// that touches the file, so the pragma has to be issued before
+    /// `journal_mode=WAL` — measured: with WAL first, the mode stays NONE and
+    /// every page `rollupAndPrune` frees is lost to the file forever.
+    func testNewLedgerIsCreatedWithIncrementalAutoVacuum() async throws {
+        let (ledger, directory) = try UsageLedgerFixtures.makeLedger("LedgerAutoVacuum")
+        defer { try? FileManager.default.removeItem(at: directory) }
+        await ledger.optimizeStorage()
+        let url = directory.appendingPathComponent("usage_events.sqlite3")
+        XCTAssertEqual(try Self.pragmaInt("auto_vacuum", at: url), 2)
+    }
+
+    /// The detail-side group queries filter on `ts` and group by a different
+    /// column, which is exactly the shape that can degrade into a full table
+    /// scan once statistics go stale.
+    ///
+    /// Measured on a synthetic 245k-row ledger (the maintainer's real size):
+    /// with `ANALYZE` in place every one of these already resolves through an
+    /// index — `usage_events_tool_ts_idx` for tool, `usage_events_harness_ts_idx`
+    /// for harness, `usage_events_ts_id_idx` for the rest — in 18-30 ms warm.
+    /// Adding a `(ts, tool)` index changed no plan and no timing, so none was
+    /// added; this test is the guard that the existing ones keep being used.
+    func testDetailGroupQueriesResolveThroughAnIndex() async throws {
+        let (ledger, directory) = try UsageLedgerFixtures.makeLedger("LedgerQueryPlan")
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let url = directory.appendingPathComponent("usage_events.sqlite3")
+
+        var events: [PricedUsageEvent] = []
+        for index in 0..<400 {
+            events.append(UsageLedgerFixtures.priced(UsageLedgerFixtures.event(
+                date: now.addingTimeInterval(TimeInterval(-index * 600)),
+                model: index.isMultiple(of: 2) ? "gpt-5" : "gpt-5-codex",
+                harness: index.isMultiple(of: 3) ? .chatgptWork : .codex
+            )))
+        }
+        try await ledger.ingest(UsageLedgerFixtures.batch(events: events))
+        await ledger.optimizeStorage()
+
+        let start = Int64(now.addingTimeInterval(-86_400).timeIntervalSince1970)
+        let end = Int64(now.addingTimeInterval(86_400).timeIntervalSince1970)
+        for column in ["tool", "model", "harness", "project", "day"] {
+            let plan = try Self.queryPlan(
+                """
+                SELECT \(column), COUNT(*),
+                       COALESCE(SUM(fresh_input + output + cache_read + cache_creation), 0),
+                       COALESCE(SUM(cost_micros), 0)
+                  FROM usage_events WHERE ts >= \(start) AND ts < \(end) GROUP BY \(column)
+                """,
+                at: url
+            ).joined(separator: " | ")
+            XCTAssertTrue(
+                plan.contains("USING INDEX") || plan.contains("USING COVERING INDEX"),
+                "GROUP BY \(column) fell back to a table scan: \(plan)"
+            )
+        }
+    }
+
+    /// The picker queries deliberately ignore the date range, so the ledger's
+    /// content is their only input — which is what makes a revision-keyed
+    /// cache safe, and what makes a stale one a bug.
+    func testModelPickerCacheFollowsTheLedgerContent() async throws {
+        let (ledger, directory) = try UsageLedgerFixtures.makeLedger("LedgerPickerCache")
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        try await ledger.ingest(UsageLedgerFixtures.batch(events: [
+            UsageLedgerFixtures.priced(UsageLedgerFixtures.event(date: now, model: "gpt-5"))
+        ]))
+        let firstModels = try await ledger.availableModels()
+        XCTAssertEqual(firstModels, ["gpt-5"])
+        // Repeating the call must answer the same thing, from the cache.
+        let cachedModels = try await ledger.availableModels()
+        XCTAssertEqual(cachedModels, ["gpt-5"])
+        let firstEarliest = try await ledger.earliestUsageDate()
+        XCTAssertNotNil(firstEarliest)
+
+        try await ledger.ingest(UsageLedgerFixtures.batch(
+            path: "/Users/example/.codex/sessions/session-b.jsonl",
+            events: [
+                UsageLedgerFixtures.priced(UsageLedgerFixtures.event(
+                    date: now.addingTimeInterval(-10 * 86_400), model: "gpt-5-codex"
+                ))
+            ]
+        ))
+        let widenedModels = try await ledger.availableModels()
+        XCTAssertEqual(widenedModels, ["gpt-5", "gpt-5-codex"])
+        let secondEarliest = try await ledger.earliestUsageDate()
+        XCTAssertNotNil(secondEarliest)
+        XCTAssertLessThan(secondEarliest!, firstEarliest!)
+    }
+
+    /// The headline pass groups the whole detail table by day on every
+    /// popover open. Caching it is only correct if a new batch invalidates.
+    func testTokenHeadlineTotalsAreCachedButFollowNewEvents() async throws {
+        let (ledger, directory) = try UsageLedgerFixtures.makeLedger("LedgerHeadlineCache")
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        try await ledger.ingest(UsageLedgerFixtures.batch(events: [
+            UsageLedgerFixtures.priced(UsageLedgerFixtures.event(
+                date: now, input: 1_000, output: 200
+            ))
+        ]))
+        let first = try await ledger.tokenHeadlineTotals(now: now)
+        XCTAssertEqual(first.allTimeTokens, 1_200)
+        let repeated = try await ledger.tokenHeadlineTotals(now: now)
+        XCTAssertEqual(repeated.allTimeTokens, 1_200)
+
+        try await ledger.ingest(UsageLedgerFixtures.batch(
+            path: "/Users/example/.codex/sessions/session-c.jsonl",
+            events: [
+                UsageLedgerFixtures.priced(UsageLedgerFixtures.event(
+                    date: now, input: 500, output: 100
+                ))
+            ]
+        ))
+        let widened = try await ledger.tokenHeadlineTotals(now: now)
+        XCTAssertEqual(widened.allTimeTokens, 1_800)
+    }
+
+    /// Repricing walks the detail table in chunks now. Committing per chunk
+    /// must still leave every row repriced and the marker written once.
+    func testChunkedRepricingCoversEveryDetailRow() async throws {
+        let (ledger, directory) = try UsageLedgerFixtures.makeLedger("LedgerRepriceChunks")
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        var events: [PricedUsageEvent] = []
+        for index in 0..<250 {
+            events.append(UsageLedgerFixtures.priced(
+                UsageLedgerFixtures.event(date: now.addingTimeInterval(TimeInterval(-index))),
+                costUSD: nil
+            ))
+        }
+        try await ledger.ingest(UsageLedgerFixtures.batch(events: events))
+        let filter = UsageLedgerFixtures.wideFilter(around: now)
+        let before = try await ledger.summary(filter)
+        XCTAssertEqual(before.requests, 250)
+
+        let repriced = try await ledger.prepareForPricingRevision("chunked-v1")
+        XCTAssertTrue(repriced)
+        // Same revision twice is a no-op, so the marker landed exactly once.
+        let repeatedRun = try await ledger.prepareForPricingRevision("chunked-v1")
+        XCTAssertFalse(repeatedRun)
+        let after = try await ledger.summary(filter)
+        XCTAssertEqual(after.requests, 250)
+    }
+
+    private static func pragmaInt(_ pragma: String, at url: URL) throws -> Int {
+        var handle: OpaquePointer?
+        guard sqlite3_open_v2(url.path, &handle, SQLITE_OPEN_READONLY, nil) == SQLITE_OK,
+              let handle
+        else { throw UsageLedgerError.open }
+        defer { sqlite3_close_v2(handle) }
+        var statement: OpaquePointer?
+        guard sqlite3_prepare_v2(handle, "PRAGMA \(pragma)", -1, &statement, nil) == SQLITE_OK,
+              let statement
+        else { throw UsageLedgerError.statement }
+        defer { sqlite3_finalize(statement) }
+        guard sqlite3_step(statement) == SQLITE_ROW else { throw UsageLedgerError.statement }
+        return Int(sqlite3_column_int64(statement, 0))
+    }
+
+    private static func queryPlan(_ sql: String, at url: URL) throws -> [String] {
+        var handle: OpaquePointer?
+        guard sqlite3_open_v2(url.path, &handle, SQLITE_OPEN_READONLY, nil) == SQLITE_OK,
+              let handle
+        else { throw UsageLedgerError.open }
+        defer { sqlite3_close_v2(handle) }
+        var statement: OpaquePointer?
+        guard sqlite3_prepare_v2(
+            handle, "EXPLAIN QUERY PLAN " + sql, -1, &statement, nil
+        ) == SQLITE_OK, let statement else { throw UsageLedgerError.statement }
+        defer { sqlite3_finalize(statement) }
+        var rows: [String] = []
+        while sqlite3_step(statement) == SQLITE_ROW {
+            if let raw = sqlite3_column_text(statement, 3) {
+                rows.append(String(cString: raw))
+            }
+        }
+        return rows
+    }
+
     /// Index names on `usage_events`, read through a connection of the test's
     /// own so nothing has to be exposed from the actor for the assertion.
     private static func indexNames(at url: URL) throws -> [String] {

--- a/Tests/VibeBarCoreTests/UsageQueryMetricsTests.swift
+++ b/Tests/VibeBarCoreTests/UsageQueryMetricsTests.swift
@@ -510,4 +510,94 @@ final class UsageQueryMetricsTests: XCTestCase {
         XCTAssertEqual(collected.map(\.id), collected.map(\.id).sorted(by: >))
     }
 
+    // MARK: - Result reuse
+
+    /// What the Usage Stats page compares on re-entry. Each of these is an
+    /// input the ledger actually reads, so each has to move the signature.
+    func testSignatureChangesForEveryQueryInput() {
+        let base = UsageQuerySignature(
+            rangeKey: UsageQuerySignature.rangeKey(
+                preset: "day7", windowStart: nil, customStart: now, customEnd: now
+            ),
+            tools: [.codex],
+            harnesses: [.codex],
+            models: ["gpt-5"],
+            granularity: .day,
+            revision: 7
+        )
+
+        var range = base
+        range.rangeKey = UsageQuerySignature.rangeKey(
+            preset: "day30", windowStart: nil, customStart: now, customEnd: now
+        )
+        XCTAssertNotEqual(base, range)
+
+        var tools = base
+        tools.tools = [.claude]
+        XCTAssertNotEqual(base, tools)
+
+        var harnesses = base
+        harnesses.harnesses = [.claudeCode]
+        XCTAssertNotEqual(base, harnesses)
+
+        var models = base
+        models.models = ["gpt-5-codex"]
+        XCTAssertNotEqual(base, models)
+
+        var granularity = base
+        granularity.granularity = .hour
+        XCTAssertNotEqual(base, granularity)
+
+        var revision = base
+        revision.revision = 8
+        XCTAssertNotEqual(base, revision, "a scan that wrote rows must force a re-query")
+    }
+
+    /// A rolling preset's window slides with the wall clock, but no row can
+    /// appear inside it without the ledger's revision moving too — so the
+    /// clock alone must not invalidate a result set.
+    func testSignatureIgnoresClockDriftWithinTheSamePreset() {
+        let first = UsageQuerySignature.rangeKey(
+            preset: "day7", windowStart: nil, customStart: now, customEnd: now
+        )
+        let later = UsageQuerySignature.rangeKey(
+            preset: "day7", windowStart: nil, customStart: now, customEnd: now
+        )
+        XCTAssertEqual(first, later)
+
+        // A back / forward step *is* a different window, and must not fold
+        // into the same key.
+        let stepped = UsageQuerySignature.rangeKey(
+            preset: "day7",
+            windowStart: now.addingTimeInterval(-7 * 86_400),
+            customStart: now,
+            customEnd: now
+        )
+        XCTAssertNotEqual(first, stepped)
+    }
+
+    /// The regression this type exists to prevent.
+    ///
+    /// Opening the Requests tab runs only its own deferred page query — it
+    /// changes nothing in the shared analytic set. When the active breakdown
+    /// was part of the signature, doing so left the stored signature saying
+    /// "Periods" while the page said "Requests", and the next entry re-ran
+    /// all eleven ledger queries against an unchanged ledger. The signature
+    /// carries no tab, so the two moments are identical values.
+    func testSignatureIsUnchangedByOpeningADifferentBreakdownTab() {
+        func signature() -> UsageQuerySignature {
+            UsageQuerySignature(
+                rangeKey: UsageQuerySignature.rangeKey(
+                    preset: "day7", windowStart: nil, customStart: now, customEnd: now
+                ),
+                tools: nil,
+                harnesses: nil,
+                models: nil,
+                granularity: nil,
+                revision: 3
+            )
+        }
+        // Before opening Requests, and after: same inputs, same value.
+        XCTAssertEqual(signature(), signature())
+    }
 }


### PR DESCRIPTION
## Summary

Large-data page fixes from the 2026-09-03 audit (8,062 Codex transcripts / 24 GB with single files up to 1.7 GB; 1.07 GB session index; 145 MB usage ledger).

- **Transcript viewer**: `select()` cancels the in-flight parse; files over 32 MiB are read from the head via the shared `copyHead` path (`SessionIndexingBounds.readTranscript`), the pane shows "Showing the first N messages of a very large log" with bytes read / on disk and a **Load entire transcript** action plus **Cancel** while loading; related Auto Review children are bounded the same way. Parse wrapped in `autoreleasepool`.
- **Index**: `headParseByteLimit` 64 MiB → 8 MiB (policy version deliberately not bumped — it bounds reads, not stored excerpts). One `SessionIndexStore` + `SessionIndexService` (`SharedSessionIndex`, lazily created by `AppEnvironment`) shared by the Workbench and `MCPController`; `SessionIndexMaintenanceGate` keeps refreshes and the compactor from overlapping.
- **Sessions page**: activation rescan floor 30 s → 10 min and the summary query is never sequenced behind it; review summaries + harness counts fetched once per index generation; `refreshRows` debounced 250 ms and built off the main actor; FTS parent lookup batched with a per-generation cache; context menu computes `resumeCommand` once; loaded summaries capped at 2,000 with a footer.
- **Find in transcript**: debounced, detached, cancellable; `.diacriticInsensitive` dropped; auto-expansion narrowed to the match being scrolled to.
- **Usage Stats**: reload memoised on `(filter, contentRevision)`; `async let` pipelining; revision-keyed caches for `availableModels`, `earliestUsageDate`, `tokenHeadlineTotals`; repricing chunked at 5,000 rows with yields; `auto_vacuum=INCREMENTAL` + bounded `incremental_vacuum` in `optimizeStorage`. A `(ts, tool)` index was measured with `EXPLAIN QUERY PLAN` on a 245k-row synthetic ledger and left out — every grouped query already resolves through an index (guarded by a new test); switching the predicate to `day` would break sub-day ranges.
- **Lifecycle**: closing the Workbench stops both models' background work (`stopWorkbenchBackgroundWork`); the Usage poll is awaited inside the page's `.task`. MCP socket idle timeout 45 min.

## Test plan

- [x] `swift build`
- [x] `swift test` — 1793 tests, 0 failures (11 new: bounded/unbounded/non-truncatable transcript reads, maintenance gate, auto_vacuum, query-plan guard, cache invalidation, chunked repricing)
- [x] real-home API grep empty
- [ ] After install: open a > 1 GB Codex session (banner within seconds, RSS flat, Load entire transcript + Cancel work); click through three large sessions quickly (only the last parses); type in Sessions search (no per-keystroke hitch); switch Workbench tabs (no index sweep per entry); close the Workbench (idle CPU drops)

🤖 Generated with [Claude Code](https://claude.com/claude-code)