### PR TITLE
Bump version to 1.6.1 (build 60)

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -19,9 +19,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.6.0</string>
+	<string>1.6.1</string>
 	<key>CFBundleVersion</key>
-	<string>59</string>
+	<string>60</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>26.0</string>
 	<key>LSUIElement</key>


### PR DESCRIPTION
## Summary

Version bump for the 1.6.1 release: `CFBundleShortVersionString` 1.6.0 → 1.6.1, `CFBundleVersion` 59 → 60. Bundle ID unchanged, entitlements still an empty `<dict/>`, `SUPublicEDKey` / `SUFeedURL` untouched.

1.6.1 ships the 2026-09-03 performance / UX audit fixes:
- #294 cost scan: no more 64 MiB cache rejection thrash, warm cache, autorelease pools, cheap fingerprints, own 15-minute cadence; hidden WebView timeout, cookie re-import cooldown, off-main status persistence, hourly timeline prune
- #291 forecast: linear `historicalRemainingUsage`, 5-minute quantized memo, one clock per page, popover-hidden gating, chart hover overlays + plan cache, Canvas heatmaps
- #293 sessions / Workbench: bounded + cancellable transcript viewer, 8 MiB index head copies, shared session index store, no rescan on tab entry, debounced search, memoised Usage Stats, stop on window close, MCP idle timeout
- #289 Cursor / Grok Bot reset cycles recorded and backfilled; subscription history index
- #292 provider setup UX: adapter diagnostics reach the card (redacted at the log and MCP sinks), console links by region, plan-qualified sidebar names + search, inline credential validation, Keychain cooldown surfaced, Z.ai Auto region
- #290 reset-history comparison module (Overview, provider pages, Resets tab)

## Test plan

- [x] `swift build`
- [x] `swift test` — 1937 tests, 0 failures
- [x] `./Scripts/build_app.sh release`
- [x] `codesign -d --entitlements -` is an empty `<dict/>`; `codesign --verify --deep --strict` passes
- [x] Packaged `Info.plist` reads 1.6.1 (60)
- [ ] Tag `v1.6.1` after merge → release workflow → draft asset inspection → publish → install → re-measure against the audit baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)
