### PR TITLE
Bump version to 1.6.2 (build 61)

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -19,9 +19,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.6.1</string>
+	<string>1.6.2</string>
 	<key>CFBundleVersion</key>
-	<string>60</string>
+	<string>61</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>26.0</string>
 	<key>LSUIElement</key>


### PR DESCRIPTION
## Summary

Version bump for the 1.6.2 release: `CFBundleShortVersionString` 1.6.1 → 1.6.2, `CFBundleVersion` 60 → 61. Bundle ID unchanged, entitlements still an empty `<dict/>`, `SUPublicEDKey` / `SUFeedURL` untouched.

1.6.2 ships #296: the reset-history comparison laid out by hierarchy (company heading → SubProvider · bucket rows, full names) with cycle-ordinal columns and bars showing what was left at reset; provider pages default the comparison after the cost cards and Service Status to the end of the right column (AGENTS.md § 11 updated), with a one-time migration that moves only layouts still carrying the exact 1.6.1 default.

## Test plan

- [x] `swift build`
- [x] `swift test`
- [x] `./Scripts/build_app.sh release`
- [x] `codesign -d --entitlements -` is an empty `<dict/>`; `codesign --verify --deep --strict` passes
- [x] Packaged `Info.plist` reads 1.6.2 (61)
- [ ] Tag `v1.6.2` after merge → release workflow → draft asset inspection → publish → install → check Overview / SpaceXAI / Resets layouts

🤖 Generated with [Claude Code](https://claude.com/claude-code)
