### PR TITLE
Let the reset-history comparison switch between cycle and time axes

### DIFF
--- a/Sources/VibeBarApp/Views/ColumnMasonryLayout.swift
+++ b/Sources/VibeBarApp/Views/ColumnMasonryLayout.swift
@@ -3,7 +3,10 @@ import VibeBarCore
 
 enum OverviewMasonryPhase: Int {
     case summary
+    /// The provider quota cards only — see `OverviewMasonryPlanner.Phase`.
     case quota
+    /// Upcoming resets, quota history, the reset-history comparison.
+    case history
     case cost
     case auxiliary
 
@@ -11,6 +14,7 @@ enum OverviewMasonryPhase: Int {
         switch self {
         case .summary: .summary
         case .quota: .quota
+        case .history: .history
         case .cost: .cost
         case .auxiliary: .auxiliary
         }

--- a/Sources/VibeBarApp/Views/PageModuleCatalog.swift
+++ b/Sources/VibeBarApp/Views/PageModuleCatalog.swift
@@ -170,7 +170,13 @@ enum PageModuleCatalog {
                 fallbackHeight: FallbackHeight.summary
             )
         )
-        // Refill horizon — a quota answer, so it sits with the quota band.
+        // The history band, in reading order: when quota comes back, how it has
+        // been trending, and how much of the last cycles expired unused.
+        //
+        // These are quota *answers*, but they are not the quota cards. Carrying
+        // `.quota` put all three in the band a reader scans for "how much is
+        // left", which grew that band to seven cards; `.history` is that band's
+        // own segment, immediately below it.
         result.append(
             PageModuleDescriptor(
                 id: .custom("overview-upcoming-resets"),
@@ -178,13 +184,24 @@ enum PageModuleCatalog {
                 displayName: "Upcoming Resets",
                 defaultColumn: 1,
                 accent: .neutral,
-                masonryPhase: .quota,
+                masonryPhase: .history,
                 fallbackHeight: FallbackHeight.status
             )
         )
-        // The retrospective half of the same question, immediately after the
-        // horizon: Upcoming Resets says when quota comes back, this says how
-        // much of the last one expired unused.
+        result.append(
+            PageModuleDescriptor(
+                id: .quotaHistoryAll,
+                kind: .overviewQuotaHistoryAll,
+                displayName: "All Providers Quota History",
+                defaultColumn: 0,
+                accent: .neutral,
+                masonryPhase: .history,
+                fallbackHeight: FallbackHeight.quotaHistory
+            )
+        )
+        // The retrospective half of the horizon's question: Upcoming Resets
+        // says when quota comes back, this says how much of the last one
+        // expired unused.
         result.append(
             PageModuleDescriptor(
                 id: .custom("overview-reset-history-compare"),
@@ -192,15 +209,15 @@ enum PageModuleCatalog {
                 displayName: "Reset History Compare",
                 defaultColumn: 1,
                 accent: .neutral,
-                masonryPhase: .quota,
+                masonryPhase: .history,
                 fallbackHeight: FallbackHeight.resetCompareAll
             )
         )
         let hasCostData = self.hasCostData(environment: environment, settings: settings)
         if hasCostData {
-            // The composition explorer is a headline usage answer, so it
-            // starts the first post-summary band instead of disappearing
-            // below every provider's long cost history.
+            // The composition explorer opens the cost band rather than the
+            // quota one: it measures what was spent, which is the question the
+            // cards under it answer per provider.
             result.append(
                 PageModuleDescriptor(
                     id: .custom("overview-usage-mix"),
@@ -208,7 +225,7 @@ enum PageModuleCatalog {
                     displayName: "Usage Mix",
                     defaultColumn: 1,
                     accent: .cost,
-                    masonryPhase: .quota,
+                    masonryPhase: .cost,
                     fallbackHeight: FallbackHeight.usageMix
                 )
             )
@@ -226,17 +243,6 @@ enum PageModuleCatalog {
                 )
             )
         }
-        result.append(
-            PageModuleDescriptor(
-                id: .quotaHistoryAll,
-                kind: .overviewQuotaHistoryAll,
-                displayName: "All Providers Quota History",
-                defaultColumn: 0,
-                accent: .neutral,
-                masonryPhase: .quota,
-                fallbackHeight: FallbackHeight.quotaHistory
-            )
-        )
         if hasCostData {
             result.append(
                 PageModuleDescriptor(

--- a/Sources/VibeBarApp/Views/ResetHistoryCompareView.swift
+++ b/Sources/VibeBarApp/Views/ResetHistoryCompareView.swift
@@ -260,6 +260,7 @@ enum ResetHistoryLanes {
 final class ResetHistoryComparisonCache {
     private struct Key: Equatable {
         let inputs: [ResetHistoryLaneInput]
+        let axis: ResetHistoryAxis
         let window: ResetHistoryComparison.Window
         let hour: Double
     }
@@ -269,6 +270,7 @@ final class ResetHistoryComparisonCache {
 
     func comparison(
         inputs: [ResetHistoryLaneInput],
+        axis: ResetHistoryAxis,
         window: ResetHistoryComparison.Window,
         now: Date = Date()
     ) -> ResetHistoryComparison {
@@ -276,10 +278,11 @@ final class ResetHistoryComparisonCache {
         // build, so it is quantized to the hour. This module starts no timer
         // of its own: the next quota refresh redraws it.
         let hour = (now.timeIntervalSinceReferenceDate / 3_600).rounded(.down) * 3_600
-        let candidate = Key(inputs: inputs, window: window, hour: hour)
+        let candidate = Key(inputs: inputs, axis: axis, window: window, hour: hour)
         if let key, key == candidate, let value { return value }
         let built = ResetHistoryComparison.build(
             inputs: inputs,
+            axis: axis,
             window: window,
             now: Date(timeIntervalSinceReferenceDate: hour)
         )
@@ -296,12 +299,15 @@ final class ResetHistoryComparisonCache {
 ///
 /// Two decisions carry the design.
 ///
-/// **Columns are cycle ordinals, not dates.** Quotas refill on their own
-/// schedules, so a shared calendar axis put every row's bars in different
-/// places and made two rows impossible to read against each other. Here the
-/// newest completed cycle of every quota sits in the same column, the one
-/// before it in the column to its left; a row with less history is
-/// right-aligned into the grid and starts further right.
+/// **Two axes, and the reader picks.** On `Cycles` the columns are ordinals:
+/// the newest completed cycle of every quota sits in the same column, the one
+/// before it in the column to its left, and a row with less history is
+/// right-aligned into the grid. Quotas refill on unrelated schedules, so that
+/// is the only layout in which two rows can be read against each other. On
+/// `Time` each cycle sits where it actually happened, which is the only layout
+/// that shows two quotas running dry in the same week — or a lane that stopped
+/// refilling in March. The choice persists in `AppSettings`, one setting for
+/// every surface that draws the module.
 ///
 /// **The bar is what was left, not what was spent.** The question is "am I
 /// wasting quota", so a tall bar is a cycle that expired mostly unused and an
@@ -327,9 +333,20 @@ struct ResetHistoryCompareCard: View {
     @State private var window: ResetHistoryComparison.Window = .eight
     @State private var cache = ResetHistoryComparisonCache()
 
+    /// Persisted, not `@State`: switching the Overview's copy switches the
+    /// provider pages' and the Workbench's too, which is what a reader who
+    /// changed their mind about the layout means.
+    private var axis: ResetHistoryAxis { settingsStore.settings.resetHistoryCompareAxis }
+
+    private func setAxis(_ next: ResetHistoryAxis) {
+        guard settingsStore.settings.resetHistoryCompareAxis != next else { return }
+        settingsStore.settings.resetHistoryCompareAxis = next
+    }
+
     var body: some View {
         let comparison = cache.comparison(
             inputs: ResetHistoryLanes.inputs(environment: environment, tools: tools),
+            axis: axis,
             window: window
         )
         CardShell(density: density, spacing: 8) {
@@ -355,23 +372,57 @@ struct ResetHistoryCompareCard: View {
                 .font(.system(size: density.bucketTitleFontSize, weight: .semibold))
                 .lineLimit(1)
             Spacer(minLength: 6)
-            Text("cycles")
-                .font(.system(size: max(8, density.subtitleFontSize - 2.5)))
-                .foregroundStyle(.quaternary)
+            axisPicker
             windowPicker
         }
     }
 
-    /// How many cycles back the table reaches. The same hand-drawn segment
-    /// pill the cost card's metric switch uses, so the two read as one control
-    /// family.
+    /// Cycles or Time. Words rather than glyphs: the difference between an
+    /// ordinal grid and a calendar is not something an icon carries, and this
+    /// control changes what the whole chart measures.
+    private var axisPicker: some View {
+        HStack(spacing: 1) {
+            ForEach(ResetHistoryAxis.allCases, id: \.self) { option in
+                Button {
+                    setAxis(option)
+                } label: {
+                    Text(option.title)
+                        .font(.system(size: max(8.5, density.segmentedFontSize - 1.5), weight: .semibold))
+                        .foregroundStyle(axis == option ? Color.primary : Color.secondary)
+                        .lineLimit(1)
+                        .padding(.horizontal, 6)
+                        .frame(minHeight: 17)
+                        .contentShape(Rectangle())
+                        .background {
+                            if axis == option {
+                                RoundedRectangle(cornerRadius: 5, style: .continuous)
+                                    .fill(Color.primary.opacity(0.12))
+                            }
+                        }
+                }
+                .buttonStyle(.vibeBar(cornerRadius: 5))
+                .help(option.help)
+                .accessibilityLabel(option.help)
+                .accessibilityAddTraits(axis == option ? [.isSelected] : [])
+            }
+        }
+        .padding(2)
+        .background(
+            RoundedRectangle(cornerRadius: 6, style: .continuous)
+                .fill(Color.primary.opacity(0.08))
+        )
+    }
+
+    /// How far back the comparison reaches, in whichever unit the axis counts.
+    /// The same hand-drawn segment pill the cost card's metric switch uses, so
+    /// the two read as one control family.
     private var windowPicker: some View {
         HStack(spacing: 1) {
             ForEach(ResetHistoryComparison.Window.allCases, id: \.self) { option in
                 Button {
                     window = option
                 } label: {
-                    Text(option.shortTitle)
+                    Text(option.shortTitle(for: axis))
                         .font(.system(size: max(8.5, density.segmentedFontSize - 1.5), weight: .semibold, design: .rounded))
                         .foregroundStyle(window == option ? Color.primary : Color.secondary)
                         .lineLimit(1)
@@ -386,8 +437,8 @@ struct ResetHistoryCompareCard: View {
                         }
                 }
                 .buttonStyle(.vibeBar(cornerRadius: 5))
-                .help("Compare the \(option.spokenTitle)")
-                .accessibilityLabel("Compare the \(option.spokenTitle)")
+                .help("Compare the \(option.spokenTitle(for: axis))")
+                .accessibilityLabel("Compare the \(option.spokenTitle(for: axis))")
                 // The fill is the only sighted cue for which span is showing;
                 // VoiceOver needs the selection stated outright.
                 .accessibilityAddTraits(window == option ? [.isSelected] : [])
@@ -439,7 +490,10 @@ struct ResetHistoryCompareLayout: Equatable {
     /// a particular name needs the second one.
     let titleLineLimit = 2
     let now: Date
-    let columns: ResetHistoryComparison.ColumnPlan
+    /// Which grid the bars sit on. Everything above this line — heading
+    /// heights, label block, track height, row rhythm — is identical for both,
+    /// so flipping the axis moves bars without reflowing a single label.
+    let grid: ResetHistoryComparison.Grid
     /// Height of a company heading.
     let headingHeight: CGFloat
     /// What the surface draws, top to bottom.
@@ -476,7 +530,7 @@ struct ResetHistoryCompareLayout: Equatable {
         captionFontSize = max(8, density.subtitleFontSize - 2)
         titleLineHeight = titleFontSize + 3
         now = comparison.now
-        columns = comparison.columns
+        grid = comparison.grid
 
         // Two label lines plus the caption, or the bar track, whichever is
         // taller. Uniform per density: this is a table, and a table's rows
@@ -529,10 +583,61 @@ struct ResetHistoryCompareLayout: Equatable {
         return nil
     }
 
+    /// The cycle axis's column plan; an empty one on the time axis.
+    var columns: ResetHistoryComparison.ColumnPlan {
+        guard case let .cycles(plan) = grid else {
+            return ResetHistoryComparison.ColumnPlan(completedColumnCount: 0, hasCurrentColumn: false)
+        }
+        return plan
+    }
+
+    var span: ResetHistoryComparison.TimeSpan? {
+        guard case let .time(span) = grid else { return nil }
+        return span
+    }
+
     func columnWidth(in size: CGSize) -> CGFloat {
         guard columns.totalColumnCount > 0 else { return 0 }
         return chartWidth(in: size) / CGFloat(columns.totalColumnCount)
     }
+
+    // MARK: Time axis
+
+    func x(for date: Date, in size: CGSize) -> CGFloat {
+        guard let span else { return chartX }
+        return chartX + chartWidth(in: size) * CGFloat(span.fraction(of: date))
+    }
+
+    /// A cycle's rectangle on the time axis, clamped to the plot. `nil` when
+    /// the cycle falls entirely outside the visible span.
+    func timeBarRect(
+        _ cycle: ResetHistoryComparison.Cycle,
+        laneIndex: Int,
+        in size: CGSize
+    ) -> CGRect? {
+        guard span != nil else { return nil }
+        let left = x(for: cycle.start, in: size)
+        let right = x(for: cycle.end, in: size)
+        let minX = chartX
+        let maxX = chartX + chartWidth(in: size)
+        guard right > minX, left < maxX else { return nil }
+        let clampedLeft = max(minX, left)
+        let clampedRight = min(maxX, right)
+        // One point of air between neighbours, and never thinner than a bar
+        // the eye can find.
+        return CGRect(
+            x: clampedLeft,
+            y: trackTop(laneIndex),
+            width: max(2, clampedRight - clampedLeft - 1),
+            height: trackHeight
+        )
+    }
+
+    /// Bars a lane may draw on the time axis before they stop being separable.
+    /// Three points is already narrower than the eye can split.
+    func timeDrawBudget(in size: CGSize) -> Int { max(4, Int(chartWidth(in: size) / 3)) }
+
+    // MARK: Cycle axis
 
     /// One bar's rectangle. Identical x for the same column on every row —
     /// that identity is the alignment the table is built on.
@@ -570,7 +675,9 @@ struct ResetHistoryCompareView: View {
     private struct Hover: Equatable {
         let laneIndex: Int
         let cycleID: String
-        let column: Int
+        /// Cycle axis only; `nil` on the time axis, where the bar's rectangle
+        /// comes from the cycle's own dates instead of a column index.
+        let column: Int?
         let point: CGPoint
     }
 
@@ -582,12 +689,7 @@ struct ResetHistoryCompareView: View {
                 ZStack(alignment: .topLeading) {
                     ResetHistoryLanesCanvas(comparison: comparison, layout: layout)
                         .equatable()
-                    if let hover,
-                       let rect = layout.barRect(
-                           column: hover.column,
-                           laneIndex: hover.laneIndex,
-                           in: proxy.size
-                       ) {
+                    if let hover, let rect = hoveredRect(hover, in: proxy.size, layout: layout) {
                         RoundedRectangle(cornerRadius: 3.5, style: .continuous)
                             .stroke(Color.primary.opacity(0.5), lineWidth: 1)
                             .frame(width: rect.width + 2, height: rect.height + 2)
@@ -633,6 +735,9 @@ struct ResetHistoryCompareView: View {
                 }
                 Text("bar height = remaining at reset")
             }
+            // What the x position means, which is the one thing the axis
+            // toggle changes about how to read the chart.
+            Text(comparison.axis == .cycle ? "one column per cycle" : "placed by date")
             HStack(spacing: 4) {
                 RoundedRectangle(cornerRadius: 1.5, style: .continuous)
                     .stroke(Color.secondary, style: StrokeStyle(lineWidth: 0.8, dash: [2, 1.5]))
@@ -658,30 +763,60 @@ struct ResetHistoryCompareView: View {
         in size: CGSize,
         layout: ResetHistoryCompareLayout
     ) -> Hover? {
-        // `>= chartX` matters: a pointer over the label column would otherwise
-        // truncate to column 0 and light up a bar it is nowhere near.
+        // `>= chartX` matters on both axes: a pointer over the label column
+        // would otherwise resolve to the leftmost bar it is nowhere near.
         guard let index = layout.laneIndex(atY: location.y),
               index < comparison.lanes.count,
-              location.x >= layout.chartX,
-              layout.columnWidth(in: size) > 0
+              location.x >= layout.chartX
         else { return nil }
-        let column = Int((location.x - layout.chartX) / layout.columnWidth(in: size))
-        guard column >= 0, column < comparison.columns.totalColumnCount else { return nil }
         let lane = comparison.lanes[index]
-        if column == comparison.columns.currentColumn, let current = lane.currentCycle {
-            return Hover(laneIndex: index, cycleID: current.id, column: column, point: location)
+        switch comparison.grid {
+        case let .cycles(plan):
+            guard layout.columnWidth(in: size) > 0 else { return nil }
+            let column = Int((location.x - layout.chartX) / layout.columnWidth(in: size))
+            guard column >= 0, column < plan.totalColumnCount else { return nil }
+            if column == plan.currentColumn, let current = lane.currentCycle {
+                return Hover(laneIndex: index, cycleID: current.id, column: column, point: location)
+            }
+            let offset = column - plan.column(ofCycleAt: 0, inLaneWithCycleCount: lane.cycles.count)
+            guard offset >= 0, offset < lane.cycles.count else { return nil }
+            return Hover(
+                laneIndex: index,
+                cycleID: lane.cycles[offset].id,
+                column: column,
+                point: location
+            )
+        case .time:
+            // The same thinned set the canvas drew, so the tooltip can never
+            // describe a bar that is not on screen.
+            var candidates = ResetHistoryComparison.downsampled(
+                lane.cycles,
+                limit: layout.timeDrawBudget(in: size)
+            )
+            if let current = lane.currentCycle { candidates.append(current) }
+            // Reverse order matches the draw order: the current cycle is
+            // painted last and is therefore the one on top.
+            for cycle in candidates.reversed() {
+                guard let rect = layout.timeBarRect(cycle, laneIndex: index, in: size) else { continue }
+                if location.x >= rect.minX - 1, location.x <= rect.maxX + 1 {
+                    return Hover(laneIndex: index, cycleID: cycle.id, column: nil, point: location)
+                }
+            }
+            return nil
         }
-        let offset = column - comparison.columns.column(
-            ofCycleAt: 0,
-            inLaneWithCycleCount: lane.cycles.count
-        )
-        guard offset >= 0, offset < lane.cycles.count else { return nil }
-        return Hover(
-            laneIndex: index,
-            cycleID: lane.cycles[offset].id,
-            column: column,
-            point: location
-        )
+    }
+
+    /// The hovered bar's rectangle, resolved the way its axis resolves bars.
+    private func hoveredRect(
+        _ hover: Hover,
+        in size: CGSize,
+        layout: ResetHistoryCompareLayout
+    ) -> CGRect? {
+        if let column = hover.column {
+            return layout.barRect(column: column, laneIndex: hover.laneIndex, in: size)
+        }
+        guard let cycle = cycle(for: hover) else { return nil }
+        return layout.timeBarRect(cycle, laneIndex: hover.laneIndex, in: size)
     }
 
     private func cycle(for hover: Hover) -> ResetHistoryComparison.Cycle? {
@@ -782,12 +917,17 @@ private struct ResetHistoryLanesCanvas: View, Equatable {
     }
 
     /// Column separators behind every row, and the live column marked off from
-    /// the completed ones.
+    /// the completed ones — or, on the time axis, the date rules and a *now*
+    /// hairline.
     private func drawGrid(_ context: inout GraphicsContext, size: CGSize) {
+        guard case let .cycles(plan) = comparison.grid else {
+            drawTimeGrid(&context, size: size)
+            return
+        }
         let width = layout.columnWidth(in: size)
         guard width > 0 else { return }
-        for column in 1..<max(1, comparison.columns.totalColumnCount) {
-            let isCurrentBoundary = column == comparison.columns.currentColumn
+        for column in 1..<max(1, plan.totalColumnCount) {
+            let isCurrentBoundary = column == plan.currentColumn
             context.fill(
                 Path(CGRect(x: layout.chartX + CGFloat(column) * width, y: 0, width: 0.5, height: layout.rowsHeight)),
                 with: .color(Color.primary.opacity(isCurrentBoundary ? 0.22 : 0.06))
@@ -889,27 +1029,69 @@ private struct ResetHistoryLanesCanvas: View, Equatable {
             return
         }
         let accent = Theme.providerAccent(for: lane.tool)
-        for (offset, cycle) in lane.cycles.enumerated() {
-            let column = comparison.columns.column(
-                ofCycleAt: offset,
-                inLaneWithCycleCount: lane.cycles.count
-            )
-            drawBar(&context, cycle: cycle, column: column, laneIndex: index, accent: accent, size: size)
+        switch comparison.grid {
+        case let .cycles(plan):
+            for (offset, cycle) in lane.cycles.enumerated() {
+                let column = plan.column(ofCycleAt: offset, inLaneWithCycleCount: lane.cycles.count)
+                guard let rect = layout.barRect(column: column, laneIndex: index, in: size) else { continue }
+                drawBar(&context, cycle: cycle, in: rect, laneIndex: index, accent: accent)
+            }
+            if let current = lane.currentCycle, let column = plan.currentColumn,
+               let rect = layout.barRect(column: column, laneIndex: index, in: size) {
+                drawBar(&context, cycle: current, in: rect, laneIndex: index, accent: accent)
+            }
+        case .time:
+            // Thinned before drawing: the time axis has no column ceiling, so
+            // a year of weeklies on a short row is a bar every two pixels.
+            // Endpoints and the wasteful cycles are what survive the cut.
+            for cycle in ResetHistoryComparison.downsampled(
+                lane.cycles,
+                limit: layout.timeDrawBudget(in: size)
+            ) {
+                guard let rect = layout.timeBarRect(cycle, laneIndex: index, in: size) else { continue }
+                drawBar(&context, cycle: cycle, in: rect, laneIndex: index, accent: accent)
+            }
+            if let current = lane.currentCycle,
+               let rect = layout.timeBarRect(current, laneIndex: index, in: size) {
+                drawBar(&context, cycle: current, in: rect, laneIndex: index, accent: accent)
+            }
         }
-        if let current = lane.currentCycle, let column = comparison.columns.currentColumn {
-            drawBar(&context, cycle: current, column: column, laneIndex: index, accent: accent, size: size)
+    }
+
+    /// Date rules across the plot and the *now* hairline — the same idiom the
+    /// refill-horizon lane uses.
+    private func drawTimeGrid(_ context: inout GraphicsContext, size: CGSize) {
+        guard let span = layout.span else { return }
+        for tick in Self.timeTicks(span) {
+            context.fill(
+                Path(CGRect(x: layout.x(for: tick, in: size), y: 0, width: 0.5, height: layout.rowsHeight)),
+                with: .color(Color.primary.opacity(0.07))
+            )
+        }
+        let nowX = layout.x(for: min(span.end, layout.now), in: size)
+        if nowX >= layout.chartX, nowX <= layout.chartX + layout.chartWidth(in: size) {
+            context.fill(
+                Path(CGRect(x: nowX - 0.5, y: 0, width: 1, height: layout.rowsHeight)),
+                with: .color(Color.primary.opacity(0.28))
+            )
+        }
+    }
+
+    /// Six evenly spaced dates across the visible span.
+    static func timeTicks(_ span: ResetHistoryComparison.TimeSpan) -> [Date] {
+        let count = 5
+        return (0...count).map { index in
+            span.start.addingTimeInterval(span.duration * Double(index) / Double(count))
         }
     }
 
     private func drawBar(
         _ context: inout GraphicsContext,
         cycle: ResetHistoryComparison.Cycle,
-        column: Int,
+        in rect: CGRect,
         laneIndex: Int,
-        accent: Color,
-        size: CGSize
+        accent: Color
     ) {
-        guard let rect = layout.barRect(column: column, laneIndex: laneIndex, in: size) else { return }
         let radius = min(2.5, rect.width / 2)
         // The track is the whole quota; the fill is the part of it that was
         // still there when the window refilled. A cycle spent to the last
@@ -950,37 +1132,27 @@ private struct ResetHistoryLanesCanvas: View, Equatable {
         }
     }
 
-    /// How many cycles back each column is, and `now` for the live one.
-    /// Deliberately not dates: the columns are ordinals, and each cycle's own
-    /// dates are in its tooltip.
+    /// The axis caption row: how many cycles back each column is on the cycle
+    /// axis (dates live in the tooltips there, because the columns are
+    /// ordinals), and real dates on the time axis.
     private func drawAxis(_ context: inout GraphicsContext, size: CGSize) {
         let y = layout.rowsHeight + 1
+        drawTruncationNote(&context, y: y)
+        guard case let .cycles(plan) = comparison.grid else {
+            drawTimeAxis(&context, size: size, y: y)
+            return
+        }
         let width = layout.columnWidth(in: size)
         guard width > 0 else { return }
-        // The label column is free on the axis row, which is where the caveat
-        // belongs: the grid is capped, the numbers above it are not.
-        if let note = comparison.truncationNote {
-            context.draw(
-                truncated(
-                    context,
-                    note,
-                    font: .system(size: max(7, layout.captionFontSize - 1), design: .rounded),
-                    color: Color.primary.opacity(0.4),
-                    maxWidth: layout.labelWidth - layout.labelGap
-                ),
-                at: CGPoint(x: 0, y: y),
-                anchor: .topLeading
-            )
-        }
-        let total = comparison.columns.totalColumnCount
+        let total = plan.totalColumnCount
         // Label the ends and the live column, plus interior ordinals only
         // while they still have room to be read.
         let stride = max(1, Int((28 / max(width, 1)).rounded(.up)))
         for column in 0..<total {
-            let isCurrent = column == comparison.columns.currentColumn
-            let isEdge = column == 0 || column == comparison.columns.completedColumnCount - 1
+            let isCurrent = column == plan.currentColumn
+            let isEdge = column == 0 || column == plan.completedColumnCount - 1
             guard isCurrent || isEdge || column % stride == 0,
-                  let label = comparison.columns.axisLabel(forColumn: column)
+                  let label = plan.axisLabel(forColumn: column)
             else { continue }
             let text = context.resolve(
                 Text(label)
@@ -994,6 +1166,45 @@ private struct ResetHistoryLanesCanvas: View, Equatable {
                 layout.chartX + layout.chartWidth(in: size) - measured
             )
             context.draw(text, at: CGPoint(x: clamped, y: y), anchor: .topLeading)
+        }
+    }
+
+    /// Dates under the time axis, kept inside the plot at both ends.
+    private func drawTimeAxis(_ context: inout GraphicsContext, size: CGSize, y: CGFloat) {
+        guard let span = layout.span else { return }
+        let chartWidth = layout.chartWidth(in: size)
+        for tick in Self.timeTicks(span) {
+            let tickX = layout.x(for: tick, in: size)
+            guard tickX >= layout.chartX - 1, tickX <= layout.chartX + chartWidth else { continue }
+            let text = context.resolve(
+                Text(ResetHistoryCompareFormatters.axis.string(from: tick))
+                    .font(.system(size: max(7, layout.captionFontSize - 1), design: .rounded))
+                    .foregroundStyle(Color.primary.opacity(0.4))
+            )
+            let measured = text.measure(in: CGSize(width: 80, height: 20)).width
+            let clamped = min(
+                max(tickX - measured / 2, layout.chartX),
+                layout.chartX + chartWidth - measured
+            )
+            context.draw(text, at: CGPoint(x: clamped, y: y), anchor: .topLeading)
+        }
+    }
+
+    /// The label column is free on the axis row, which is where the caveat
+    /// belongs: the grid is capped, the numbers above it are not.
+    private func drawTruncationNote(_ context: inout GraphicsContext, y: CGFloat) {
+        if let note = comparison.truncationNote {
+            context.draw(
+                truncated(
+                    context,
+                    note,
+                    font: .system(size: max(7, layout.captionFontSize - 1), design: .rounded),
+                    color: Color.primary.opacity(0.4),
+                    maxWidth: layout.labelWidth - layout.labelGap
+                ),
+                at: CGPoint(x: 0, y: y),
+                anchor: .topLeading
+            )
         }
     }
 
@@ -1083,6 +1294,13 @@ private struct ResetHistoryLanesCanvas: View, Equatable {
 }
 
 private enum ResetHistoryCompareFormatters {
+    static let axis: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "MMM d"
+        return formatter
+    }()
+
     static let tooltip: DateFormatter = {
         let formatter = DateFormatter()
         formatter.locale = Locale(identifier: "en_US_POSIX")

--- a/Sources/VibeBarCore/Models/AppSettings.swift
+++ b/Sources/VibeBarCore/Models/AppSettings.swift
@@ -132,6 +132,19 @@ public struct AppSettings: Codable, Equatable, Sendable {
     /// documented app state instead of leaking into `UserDefaults`.
     public var costChartMetric: String
 
+    /// Which axis the reset-history comparison lays its bars out on —
+    /// ordinal cycle columns, or a real calendar.
+    ///
+    /// A user-facing control, so it round-trips here rather than living in
+    /// `@State` per surface: the Overview, the provider pages and the
+    /// Workbench's Resets page all draw the same module, and a reader who
+    /// switches one of them means all of them. Written only when the
+    /// segmented control is used — never on a refresh tick.
+    ///
+    /// `.cycle` by default, which is what a settings file written before this
+    /// existed decodes to and what the module shipped with.
+    public var resetHistoryCompareAxis: ResetHistoryAxis
+
     /// Per-page card arrangement chosen in Settings → Layout, keyed by
     /// `PageLayoutPageID` raw value (`"overview"`, `"detail:claude"`, …).
     ///
@@ -330,6 +343,7 @@ public struct AppSettings: Codable, Equatable, Sendable {
         overviewQuotaHistoryHiddenCurveIds: Set<String> = [],
         costChartMetric: String = "cost",
         pageLayouts: [PageLayoutPageID: StoredPageLayout] = [:],
+        resetHistoryCompareAxis: ResetHistoryAxis = .cycle,
         appliedLayoutMigrations: Set<String> = [],
         pageLayoutPresets: [PageLayoutPageID: [StoredPageLayoutPreset]] = [:],
         miscCookieAutoImportEnabled: Bool = false,
@@ -381,6 +395,7 @@ public struct AppSettings: Codable, Equatable, Sendable {
         self.overviewQuotaHistoryHiddenCurveIds = overviewQuotaHistoryHiddenCurveIds
         self.costChartMetric = costChartMetric
         self.pageLayouts = pageLayouts
+        self.resetHistoryCompareAxis = resetHistoryCompareAxis
         self.appliedLayoutMigrations = appliedLayoutMigrations
         self.pageLayoutPresets = Self.normalizedPageLayoutPresets(pageLayoutPresets)
         self.miscCookieAutoImportEnabled = miscCookieAutoImportEnabled
@@ -446,6 +461,7 @@ public struct AppSettings: Codable, Equatable, Sendable {
         case overviewQuotaHistoryHiddenCurveIds
         case costChartMetric
         case pageLayouts
+        case resetHistoryCompareAxis
         case appliedLayoutMigrations
         case pageLayoutPresets
         case miscCookieAutoImportEnabled
@@ -607,6 +623,14 @@ public struct AppSettings: Codable, Equatable, Sendable {
         // the user their card arrangement, not every other setting in the file.
         self.pageLayouts =
             (try? c.decodeIfPresent([PageLayoutPageID: StoredPageLayout].self, forKey: .pageLayouts)) ?? [:]
+        // Absent means a file written before the axis toggle existed, which
+        // must decode to the layout that shipped — an upgrade cannot silently
+        // re-lay-out a module the user was reading yesterday.
+        // `try?` for the same reason `pageLayouts` uses it: an axis a newer
+        // build wrote, or a hand-edited file, should cost the reader their
+        // choice of layout — not every other setting in the file.
+        self.resetHistoryCompareAxis =
+            (try? c.decodeIfPresent(ResetHistoryAxis.self, forKey: .resetHistoryCompareAxis)) ?? .cycle
         // Absent means "no layout migration has run on this Mac", which is
         // what a file written before they existed should decode to: the
         // migrations are then applied once, on this launch.
@@ -702,6 +726,7 @@ public struct AppSettings: Codable, Equatable, Sendable {
         try c.encode(overviewQuotaHistoryHiddenCurveIds, forKey: .overviewQuotaHistoryHiddenCurveIds)
         try c.encode(costChartMetric, forKey: .costChartMetric)
         try c.encode(pageLayouts, forKey: .pageLayouts)
+        try c.encode(resetHistoryCompareAxis, forKey: .resetHistoryCompareAxis)
         try c.encode(appliedLayoutMigrations, forKey: .appliedLayoutMigrations)
         try c.encode(pageLayoutPresets, forKey: .pageLayoutPresets)
         try c.encode(miscCookieAutoImportEnabled, forKey: .miscCookieAutoImportEnabled)

--- a/Sources/VibeBarCore/Models/ResetHistoryComparison.swift
+++ b/Sources/VibeBarCore/Models/ResetHistoryComparison.swift
@@ -79,6 +79,39 @@ public struct ResetHistoryLaneInput: Equatable, Sendable, Identifiable {
     }
 }
 
+/// Which axis the reset-history comparison lays its bars out on.
+///
+/// Two honest answers to "compare these quotas", and the module ships both
+/// because they answer different questions. `cycle` puts every quota's newest
+/// refill in the same column, so two rows can be read against each other even
+/// though they refill on unrelated schedules — the comparison the module was
+/// built for. `time` puts each cycle where it actually happened, which is the
+/// only way to see that two quotas ran dry in the same week, or that a lane
+/// stopped refilling in March.
+///
+/// Persisted in `AppSettings.resetHistoryCompareAxis`, one choice shared by
+/// every surface that draws the module.
+public enum ResetHistoryAxis: String, CaseIterable, Hashable, Sendable, Codable {
+    case cycle
+    case time
+
+    /// Segmented-control label. Plain words: the difference between the two is
+    /// not something an icon can carry.
+    public var title: String {
+        switch self {
+        case .cycle: "Cycles"
+        case .time: "Time"
+        }
+    }
+
+    public var help: String {
+        switch self {
+        case .cycle: "One column per cycle, newest aligned across every quota"
+        case .time: "Each cycle where it actually happened, on a shared calendar"
+        }
+    }
+}
+
 /// Every weekly-and-longer quota's reset history, side by side as one table,
 /// answering a single question: how much of what was paid for expired unused?
 ///
@@ -114,17 +147,22 @@ public struct ResetHistoryComparison: Equatable, Sendable {
 
     // MARK: - Nested types
 
-    /// How many cycles back the table reaches. Counted in cycles rather than
-    /// weeks, because the columns are ordinals: "last 8" means the same eight
-    /// columns for every row, however far apart one row's refills happen to
-    /// fall.
+    /// How far back the comparison reaches.
+    ///
+    /// The four steps are shared by both axes, but the unit is the axis's own:
+    /// on `cycle` they count cycles, because the columns are ordinals and
+    /// "last 8" has to mean the same eight columns for every row however far
+    /// apart its refills fall; on `time` they count weeks, because there the
+    /// x position *is* the calendar.
     public enum Window: String, CaseIterable, Hashable, Sendable, Codable {
         case four
         case eight
         case twelve
         case all
 
-        /// `nil` for `all`, which is then bounded by `ColumnPlan.maximumColumns`.
+        /// Cycle axis: how many of the newest cycles the window keeps. `nil`
+        /// for `all`, whose *drawing* is then bounded by
+        /// `ColumnPlan.maximumColumns`.
         public var cycleLimit: Int? {
             switch self {
             case .four: 4
@@ -134,24 +172,71 @@ public struct ResetHistoryComparison: Equatable, Sendable {
             }
         }
 
-        /// Compact picker label.
-        public var shortTitle: String {
+        /// Time axis: how many weeks back the span starts. `nil` for `all`,
+        /// which starts at the oldest recorded cycle.
+        public var weeks: Int? {
             switch self {
-            case .four: "4"
-            case .eight: "8"
-            case .twelve: "12"
-            case .all: "All"
+            case .four: 4
+            case .eight: 8
+            case .twelve: 12
+            case .all: nil
             }
         }
 
-        public var spokenTitle: String {
-            switch self {
-            case .four: "last 4 cycles"
-            case .eight: "last 8 cycles"
-            case .twelve: "last 12 cycles"
-            case .all: "every recorded cycle"
+        /// Compact picker label. Carries the unit on the time axis, because
+        /// "8" next to a calendar would read as eight of the wrong thing.
+        public func shortTitle(for axis: ResetHistoryAxis) -> String {
+            switch (self, axis) {
+            case (.four, .cycle): "4"
+            case (.eight, .cycle): "8"
+            case (.twelve, .cycle): "12"
+            case (.four, .time): "4w"
+            case (.eight, .time): "8w"
+            case (.twelve, .time): "12w"
+            case (.all, _): "All"
             }
         }
+
+        public func spokenTitle(for axis: ResetHistoryAxis) -> String {
+            switch (self, axis) {
+            case (.four, .cycle): "last 4 cycles"
+            case (.eight, .cycle): "last 8 cycles"
+            case (.twelve, .cycle): "last 12 cycles"
+            case (.all, .cycle): "every recorded cycle"
+            case (.four, .time): "last 4 weeks"
+            case (.eight, .time): "last 8 weeks"
+            case (.twelve, .time): "last 12 weeks"
+            case (.all, .time): "all recorded history"
+            }
+        }
+    }
+
+    /// The stretch of calendar the time axis maps onto the plot.
+    public struct TimeSpan: Equatable, Sendable {
+        public let start: Date
+        public let end: Date
+
+        public init(start: Date, end: Date) {
+            self.start = start
+            // A span has to have width, or every bar lands on the same pixel.
+            self.end = max(end, start.addingTimeInterval(1))
+        }
+
+        public var duration: TimeInterval { end.timeIntervalSince(start) }
+
+        /// Where a date sits across the span, 0…1 at the ends. Deliberately
+        /// unclamped: a cycle that begins before the span still has to be
+        /// drawn from off the left edge and clipped, not stacked at zero.
+        public func fraction(of date: Date) -> Double {
+            date.timeIntervalSince(start) / duration
+        }
+    }
+
+    /// The grid the bars are placed on, which is what the two axes actually
+    /// differ in — everything else about a comparison is shared.
+    public enum Grid: Equatable, Sendable {
+        case cycles(ColumnPlan)
+        case time(TimeSpan)
     }
 
     /// The shared column grid every row is drawn against.
@@ -369,14 +454,15 @@ public struct ResetHistoryComparison: Equatable, Sendable {
 
     // MARK: - Value
 
+    public let axis: ResetHistoryAxis
     public let window: Window
     /// The clock the comparison was built against, so the view never reads the
     /// wall clock inside a draw pass — a value that changed under an
     /// otherwise-equal comparison would make the drawing surface's `Equatable`
     /// short-circuit a lie.
     public let now: Date
-    /// The shared column grid every row is drawn against.
-    public let columns: ColumnPlan
+    /// Where the bars go: ordinal columns, or a stretch of calendar.
+    public let grid: Grid
     /// Rows in hierarchy order: L1 company, then L2 SubProvider, then the L3
     /// groups and buckets in the order the popover lists them.
     public let lanes: [Lane]
@@ -387,15 +473,36 @@ public struct ResetHistoryComparison: Equatable, Sendable {
 
     public var isEmpty: Bool { lanes.isEmpty }
 
+    /// The cycle axis's column grid. An empty plan on the time axis, which
+    /// has no columns — callers switch on `grid`, and this is the convenience
+    /// for the ones that only ever ask about one of them.
+    public var columns: ColumnPlan {
+        guard case let .cycles(plan) = grid else {
+            return ColumnPlan(completedColumnCount: 0, hasCurrentColumn: false)
+        }
+        return plan
+    }
+
+    /// The time axis's span, or `nil` on the cycle axis.
+    public var span: TimeSpan? {
+        guard case let .time(span) = grid else { return nil }
+        return span
+    }
+
     /// What to say when the grid shows fewer cycles than the numbers describe.
     ///
     /// `All` on a three-year retention can reach past the column ceiling. The
     /// statistics still cover everything — only the drawing is capped — and
     /// this is the sentence that keeps the two honest with each other.
     public var truncationNote: String? {
-        guard lanes.contains(where: \.isTruncated) else { return nil }
+        // Only the cycle axis has a ceiling to overflow: the time axis draws
+        // every retained cycle and thins by pixel at draw time, which loses no
+        // cycle from the arithmetic and needs no caveat on it.
+        guard case let .cycles(plan) = grid,
+              lanes.contains(where: \.isTruncated)
+        else { return nil }
         let deepest = lanes.map(\.windowCycleCount).max() ?? 0
-        return "showing the newest \(columns.completedColumnCount) of \(deepest) cycles"
+        return "showing the newest \(plan.completedColumnCount) of \(deepest) cycles"
     }
 
     /// Whole-module screen-reader text. The lanes are a drawing surface, so
@@ -414,7 +521,7 @@ public struct ResetHistoryComparison: Equatable, Sendable {
         // The note comes before the numbers on purpose: it is the caveat on
         // them, not a footnote to the lane list.
         let truncation = truncationNote.map { " Grid \($0); the figures cover every one." } ?? ""
-        return "Reset history comparison, \(window.spokenTitle), bar height is the quota remaining at reset.\(truncation) \(totals.headline). \(verdict) \(laneText).\(more)"
+        return "Reset history comparison, \(window.spokenTitle(for: axis)), bar height is the quota remaining at reset.\(truncation) \(totals.headline). \(verdict) \(laneText).\(more)"
     }
 
     // MARK: - Building
@@ -422,6 +529,7 @@ public struct ResetHistoryComparison: Equatable, Sendable {
     /// Build the comparison. Pure: everything it needs is in `inputs`.
     public static func build(
         inputs: [ResetHistoryLaneInput],
+        axis: ResetHistoryAxis = .cycle,
         window: Window = .eight,
         now: Date
     ) -> ResetHistoryComparison {
@@ -433,16 +541,26 @@ public struct ResetHistoryComparison: Equatable, Sendable {
             return (input, seconds)
         }
 
-        // 2. One lane per qualifying quota.
+        // 2. The window, in whichever unit this axis counts. The cycle axis
+        //    keeps the newest N cycles per lane; the time axis keeps whatever
+        //    fell inside a stretch of calendar, which is a different set and
+        //    a different size per lane.
         //
-        //    Two limits, deliberately different. `retained` is what the window
-        //    means — the newest N cycles, or every recorded one for `all` — and
-        //    every statistic is computed from it. `drawable` is what the grid
-        //    has columns for. Capping the statistics at the drawing budget
-        //    would make "All" quietly mean "the newest 52" in the headline, the
-        //    verdict and the wasteful-cycle counts.
-        let statisticsLimit = window.cycleLimit ?? Int.max
-        let drawLimit = min(statisticsLimit, ColumnPlan.maximumColumns)
+        //    On the cycle axis, two limits, deliberately different. `retained`
+        //    is what the window means and every statistic is computed from it;
+        //    `drawable` is what the grid has columns for. Capping the
+        //    statistics at the drawing budget would make "All" quietly mean
+        //    "the newest 52" in the headline, the verdict and the
+        //    wasteful-cycle counts. The time axis needs no such cap — it thins
+        //    by pixel at draw time, which drops no cycle from the arithmetic.
+        let statisticsLimit = axis == .cycle ? (window.cycleLimit ?? Int.max) : Int.max
+        let drawLimit = axis == .cycle
+            ? min(statisticsLimit, ColumnPlan.maximumColumns)
+            : Int.max
+        let spanStart = axis == .time
+            ? timeSpanStart(window: window, qualifying: qualifying, now: now)
+            : nil
+        var latestEnd = now
         var lanes: [Lane] = []
         var totalCycleCount = 0
         var totalUsedSum: Double = 0
@@ -474,10 +592,17 @@ public struct ResetHistoryComparison: Equatable, Sendable {
                 }
             }
             completed.sort { $0.end < $1.end }
+            if let spanStart {
+                // The time axis's window is a date, not a count: a lane that
+                // refilled twice in twelve weeks contributes two bars, and a
+                // lane that refilled thirty times contributes thirty.
+                completed.removeAll { $0.end < spanStart }
+            }
             let retained = Array(completed.suffix(statisticsLimit))
             let drawable = Array(retained.suffix(drawLimit))
             totalCycleCount += retained.count
             totalUsedSum += retained.reduce(0) { $0 + $1.usedPercent }
+            if let last = retained.last { latestEnd = max(latestEnd, last.end) }
 
             // The live quota is the fallback for the in-progress cycle: a lane
             // whose history holds only closed samples still has one running.
@@ -522,10 +647,23 @@ public struct ResetHistoryComparison: Equatable, Sendable {
 
         // 3. Hierarchy order, then the grid every row shares.
         let ordered = hierarchical(lanes, ranks: hierarchyRanks(qualifying.map(\.input)))
-        let columns = ColumnPlan(
-            completedColumnCount: ordered.map(\.cycles.count).max() ?? 0,
-            hasCurrentColumn: ordered.contains { $0.currentCycle != nil }
-        )
+        let grid: Grid
+        if let spanStart {
+            // The live cycle's bar runs to its scheduled reset, which is in
+            // the future — the span has to reach it or the dashed bar is
+            // clipped off the right edge on every lane.
+            for lane in ordered {
+                if let current = lane.currentCycle { latestEnd = max(latestEnd, current.end) }
+            }
+            grid = .time(TimeSpan(start: spanStart, end: latestEnd))
+        } else {
+            grid = .cycles(
+                ColumnPlan(
+                    completedColumnCount: ordered.map(\.cycles.count).max() ?? 0,
+                    hasCurrentColumn: ordered.contains { $0.currentCycle != nil }
+                )
+            )
+        }
 
         // 4. Header arithmetic and the sentence under it, over every cycle the
         //    window covers — not only the ones that fit on the grid.
@@ -535,16 +673,70 @@ public struct ResetHistoryComparison: Equatable, Sendable {
         )
 
         return ResetHistoryComparison(
+            axis: axis,
             window: window,
             now: now,
-            columns: columns,
+            grid: grid,
             lanes: ordered,
             totals: totals,
             verdict: verdict(lanes: ordered, totals: totals)
         )
     }
 
+    // MARK: - Draw budget
+
+    /// Bars a lane actually draws on the **time** axis, when it has more
+    /// cycles than the row has pixels.
+    ///
+    /// The cycle axis needs none of this — one column is one cycle, and the
+    /// ceiling is the plan. The time axis has no such bound: a year of Codex
+    /// weeklies on a 200-point row is a bar every two pixels, so something has
+    /// to go, and *which* something matters. Not a uniform stride, which is
+    /// exactly as likely to drop the worst cycle as any other: the endpoints
+    /// survive first because they anchor the span, then the largest waste,
+    /// because a chart about wasted quota that drops the wasteful cycles is
+    /// worse than no chart. The result comes back in time order.
+    public static func downsampled(_ cycles: [Cycle], limit: Int) -> [Cycle] {
+        guard limit > 0 else { return [] }
+        guard cycles.count > limit else { return cycles }
+        var keep: Set<Int> = []
+        if limit >= 1 { keep.insert(0) }
+        if limit >= 2 { keep.insert(cycles.count - 1) }
+        let byWaste = cycles.indices.sorted { lhs, rhs in
+            let left = cycles[lhs].wastedPercent
+            let right = cycles[rhs].wastedPercent
+            return left == right ? lhs < rhs : left > right
+        }
+        for index in byWaste where keep.count < limit {
+            keep.insert(index)
+        }
+        return keep.sorted().map { cycles[$0] }
+    }
+
     // MARK: - Internals
+
+    /// Where the time axis starts: a fixed number of weeks back, or the oldest
+    /// recorded cycle for `all`.
+    private static func timeSpanStart(
+        window: Window,
+        qualifying: [(input: ResetHistoryLaneInput, windowSeconds: Int)],
+        now: Date
+    ) -> Date {
+        if let weeks = window.weeks {
+            return now.addingTimeInterval(-Double(weeks) * 7 * 86_400)
+        }
+        let earliest = qualifying.compactMap { entry in
+            entry.input.samples
+                .map { cycleStart($0, windowSeconds: entry.windowSeconds) }
+                .min()
+        }.min()
+        // Nothing recorded yet still needs a span with width to it.
+        guard let earliest, earliest < now else {
+            return now.addingTimeInterval(-8 * 7 * 86_400)
+        }
+        return earliest
+    }
+
 
     /// The lane's window length: what the live bucket says, else the length
     /// the samples agree on most often. Ties go to the longer window, because

--- a/Sources/VibeBarCore/Services/OverviewMasonryPlanner.swift
+++ b/Sources/VibeBarCore/Services/OverviewMasonryPlanner.swift
@@ -16,13 +16,20 @@ import Foundation
 /// which is the Overview's default segmentation and therefore the behaviour this
 /// planner has always had.
 public enum OverviewMasonryPlanner {
-    public enum Phase: Int, Sendable, Comparable {
+    public enum Phase: Int, Sendable, Comparable, CaseIterable {
         /// The Overview's header band: cards pinned to one shared height that
         /// read as a single row. Placed across the columns in declaration
         /// order rather than balanced, because a band whose cards are all the
         /// same height has nothing to balance.
         case summary
+        /// The provider quota cards, and nothing else. Kept narrow on purpose:
+        /// this is the band a reader scans for "how much is left", and the
+        /// cards that merely *relate* to quota — the refill horizon, the reset
+        /// history — crowded it out of being scannable.
         case quota
+        /// Retrospective and forward-looking quota answers: upcoming resets,
+        /// the all-providers quota history, the reset-history comparison.
+        case history
         case cost
         case auxiliary
 
@@ -110,6 +117,7 @@ public enum OverviewMasonryPlanner {
     ) {
         let summaries = group.filter { $0.phase == .summary }
         let quotas = group.filter { $0.phase == .quota }
+        let history = group.filter { $0.phase == .history }
         let costs = group.filter { $0.phase == .cost }
         let auxiliary = group.filter { $0.phase == .auxiliary }
 
@@ -141,6 +149,14 @@ public enum OverviewMasonryPlanner {
                 let column = shortestColumn(heights)
                 append(item, to: column, spacing: spacing, heights: &heights, positions: &positions)
             }
+        }
+
+        // The history band has no fixed count to enumerate over and no pairing
+        // invariant to preserve, so it takes the same deterministic
+        // shortest-column placement the auxiliary band does.
+        for item in history {
+            let column = shortestColumn(heights)
+            append(item, to: column, spacing: spacing, heights: &heights, positions: &positions)
         }
 
         // There are only five Cost cards, so exhaustive assignment is both
@@ -176,7 +192,7 @@ public enum OverviewMasonryPlanner {
         var heights = Array(repeating: 0.0, count: columnCount)
 
         for group in grouped(items, by: groups) {
-            for phase in [Phase.summary, .quota, .cost, .auxiliary] {
+            for phase in Phase.allCases {
                 for item in group where item.phase == phase {
                     let preferred = fixedColumns[item.id] ?? shortestColumn(heights)
                     let column = min(max(0, preferred), columnCount - 1)
@@ -201,7 +217,7 @@ public enum OverviewMasonryPlanner {
     /// phase, in phase order.
     private static func grouped(_ items: [Item], by groups: [[String]]) -> [[Item]] {
         guard !groups.isEmpty else {
-            return [Phase.summary, .quota, .cost, .auxiliary]
+            return Phase.allCases
                 .map { phase in items.filter { $0.phase == phase } }
                 .filter { !$0.isEmpty }
         }

--- a/Sources/VibeBarCore/Services/PageLayoutDefaultsMigration.swift
+++ b/Sources/VibeBarCore/Services/PageLayoutDefaultsMigration.swift
@@ -35,9 +35,17 @@ public enum PageLayoutDefaultsMigration {
     /// column to close the wide one.
     public static let providerRightColumnIdentifier = "provider-right-column-v2"
 
-    /// 1.6.2: the Overview's quota phase was split, so the default
-    /// segmentation gained a history band between quota and cost.
-    public static let overviewHistorySegmentIdentifier = "overview-history-segment-v1"
+    // No entry for the Overview's split quota phase, deliberately. Its stored
+    // `columns` are a hand-draggable arrangement in *every* mode — the layout
+    // editor keeps them when the page is switched to Auto or Compact and back
+    // — so a phase-homogeneous three-band segmentation does not establish that
+    // the page is untouched, and clearing it would re-sort those columns under
+    // the new four-band default. Nothing needs the rewrite either: a stored
+    // segmentation has never seen the three moved cards, so
+    // `PageLayoutSegments.resolve` places them at
+    // `min(defaultIndex, count - 1)` and the quota band keeps only the
+    // provider cards. They share the cost band instead of getting their own,
+    // which is the right price for not overruling an arrangement.
 
     /// Module family the reset-history table is registered under.
     static let resetHistoryFamily = "reset-history-compare"
@@ -54,9 +62,6 @@ public enum PageLayoutDefaultsMigration {
         var applied = applied
         if applied.insert(providerRightColumnIdentifier).inserted {
             layouts = migratedProviderRightColumn(layouts)
-        }
-        if applied.insert(overviewHistorySegmentIdentifier).inserted {
-            layouts = migratedOverviewHistorySegment(layouts)
         }
         return (layouts, applied)
     }
@@ -102,99 +107,6 @@ public enum PageLayoutDefaultsMigration {
             )
         }
         return result
-    }
-
-    /// Let a saved Overview whose segmentation is still the old default derive
-    /// the new one.
-    ///
-    /// Unlike a provider page, this migration touches `segments` and never
-    /// `columns`. It cannot check the columns: the Overview's default
-    /// arrangement is computed by `OverviewMasonryPlanner` from *measured card
-    /// heights*, so "the previous default columns" is a different list on every
-    /// Mac and there is no signature to match.
-    ///
-    /// The segmentation, though, is exact. Three bands whose members are all
-    /// old-`.summary`, all old-`.quota`, and all old-`.cost`/`.auxiliary`
-    /// respectively is the old default and nothing else — a hand-grouped page
-    /// puts something somewhere those rules do not. Clearing it means "no
-    /// chosen segmentation", which is what makes the new four-band default
-    /// derive.
-    ///
-    /// Most users need nothing here. A page with no stored segments already
-    /// picks up the new default, and a page *with* them gets the three moved
-    /// cards re-placed by `PageLayoutSegments.resolve`, which sends a module
-    /// the stored segments have never seen to the band its new phase points at.
-    /// This exists for the one case neither covers: a segmentation materialized
-    /// straight from the old defaults, which would otherwise pin the reset and
-    /// history cards inside the quota band forever.
-    public static func migratedOverviewHistorySegment(
-        _ layouts: [PageLayoutPageID: StoredPageLayout]
-    ) -> [PageLayoutPageID: StoredPageLayout] {
-        var result = layouts
-        for (page, layout) in layouts where page.isOverview {
-            guard matchesPreviousOverviewSegmentation(layout) else { continue }
-            result[page] = StoredPageLayout(
-                mode: layout.mode,
-                ratio: layout.ratio,
-                columns: layout.columns,
-                segments: [],
-                hidden: layout.hidden
-            )
-        }
-        return result
-    }
-
-    /// The phase an Overview module carried before the quota band was split.
-    ///
-    /// A frozen snapshot of a past release's `PageModuleCatalog`, which is what
-    /// a migration is. `nil` for anything this table does not recognize, and an
-    /// unrecognized id is enough to refuse the whole page: a card we cannot
-    /// classify may be exactly the one the user placed by hand.
-    enum PreviousOverviewPhase {
-        case summary
-        case quota
-        case costOrAuxiliary
-    }
-
-    static func previousOverviewPhase(_ moduleID: PageLayoutModuleID) -> PreviousOverviewPhase? {
-        let raw = moduleID.rawValue
-        if raw.hasPrefix("overview-summary-") { return .summary }
-        if raw.hasPrefix("overview-quota:") { return .quota }
-        switch raw {
-        case "overview-upcoming-resets",
-             "overview-reset-history-compare",
-             "overview-usage-mix",
-             PageLayoutModuleID.Family.quotaHistoryAll:
-            return .quota
-        case PageLayoutModuleID.Family.costAll:
-            return .costOrAuxiliary
-        default:
-            break
-        }
-        switch moduleID.family {
-        case PageLayoutModuleID.Family.cost,
-             PageLayoutModuleID.Family.modelBreakdown,
-             "heatmap-year",
-             "heatmap-activity":
-            return .costOrAuxiliary
-        default:
-            return nil
-        }
-    }
-
-    /// Are these stored segments exactly the segmentation the old phase
-    /// grouping produced — summary, then quota, then cost with its analytics?
-    static func matchesPreviousOverviewSegmentation(_ layout: StoredPageLayout) -> Bool {
-        // Nothing stored is already handled: the default derives on its own.
-        guard layout.segments.count == 3 else { return false }
-        let expected: [PreviousOverviewPhase] = [.summary, .quota, .costOrAuxiliary]
-        for (band, phase) in zip(layout.segments, expected) {
-            guard !band.isEmpty else { return false }
-            for moduleID in band {
-                guard previousOverviewPhase(moduleID) == phase else { return false }
-            }
-        }
-        return true
     }
 
     /// Is this saved layout, in full, the arrangement 1.6.1 shipped for a

--- a/Sources/VibeBarCore/Services/PageLayoutDefaultsMigration.swift
+++ b/Sources/VibeBarCore/Services/PageLayoutDefaultsMigration.swift
@@ -35,6 +35,10 @@ public enum PageLayoutDefaultsMigration {
     /// column to close the wide one.
     public static let providerRightColumnIdentifier = "provider-right-column-v2"
 
+    /// 1.6.2: the Overview's quota phase was split, so the default
+    /// segmentation gained a history band between quota and cost.
+    public static let overviewHistorySegmentIdentifier = "overview-history-segment-v1"
+
     /// Module family the reset-history table is registered under.
     static let resetHistoryFamily = "reset-history-compare"
 
@@ -50,6 +54,9 @@ public enum PageLayoutDefaultsMigration {
         var applied = applied
         if applied.insert(providerRightColumnIdentifier).inserted {
             layouts = migratedProviderRightColumn(layouts)
+        }
+        if applied.insert(overviewHistorySegmentIdentifier).inserted {
+            layouts = migratedOverviewHistorySegment(layouts)
         }
         return (layouts, applied)
     }
@@ -95,6 +102,99 @@ public enum PageLayoutDefaultsMigration {
             )
         }
         return result
+    }
+
+    /// Let a saved Overview whose segmentation is still the old default derive
+    /// the new one.
+    ///
+    /// Unlike a provider page, this migration touches `segments` and never
+    /// `columns`. It cannot check the columns: the Overview's default
+    /// arrangement is computed by `OverviewMasonryPlanner` from *measured card
+    /// heights*, so "the previous default columns" is a different list on every
+    /// Mac and there is no signature to match.
+    ///
+    /// The segmentation, though, is exact. Three bands whose members are all
+    /// old-`.summary`, all old-`.quota`, and all old-`.cost`/`.auxiliary`
+    /// respectively is the old default and nothing else — a hand-grouped page
+    /// puts something somewhere those rules do not. Clearing it means "no
+    /// chosen segmentation", which is what makes the new four-band default
+    /// derive.
+    ///
+    /// Most users need nothing here. A page with no stored segments already
+    /// picks up the new default, and a page *with* them gets the three moved
+    /// cards re-placed by `PageLayoutSegments.resolve`, which sends a module
+    /// the stored segments have never seen to the band its new phase points at.
+    /// This exists for the one case neither covers: a segmentation materialized
+    /// straight from the old defaults, which would otherwise pin the reset and
+    /// history cards inside the quota band forever.
+    public static func migratedOverviewHistorySegment(
+        _ layouts: [PageLayoutPageID: StoredPageLayout]
+    ) -> [PageLayoutPageID: StoredPageLayout] {
+        var result = layouts
+        for (page, layout) in layouts where page.isOverview {
+            guard matchesPreviousOverviewSegmentation(layout) else { continue }
+            result[page] = StoredPageLayout(
+                mode: layout.mode,
+                ratio: layout.ratio,
+                columns: layout.columns,
+                segments: [],
+                hidden: layout.hidden
+            )
+        }
+        return result
+    }
+
+    /// The phase an Overview module carried before the quota band was split.
+    ///
+    /// A frozen snapshot of a past release's `PageModuleCatalog`, which is what
+    /// a migration is. `nil` for anything this table does not recognize, and an
+    /// unrecognized id is enough to refuse the whole page: a card we cannot
+    /// classify may be exactly the one the user placed by hand.
+    enum PreviousOverviewPhase {
+        case summary
+        case quota
+        case costOrAuxiliary
+    }
+
+    static func previousOverviewPhase(_ moduleID: PageLayoutModuleID) -> PreviousOverviewPhase? {
+        let raw = moduleID.rawValue
+        if raw.hasPrefix("overview-summary-") { return .summary }
+        if raw.hasPrefix("overview-quota:") { return .quota }
+        switch raw {
+        case "overview-upcoming-resets",
+             "overview-reset-history-compare",
+             "overview-usage-mix",
+             PageLayoutModuleID.Family.quotaHistoryAll:
+            return .quota
+        case PageLayoutModuleID.Family.costAll:
+            return .costOrAuxiliary
+        default:
+            break
+        }
+        switch moduleID.family {
+        case PageLayoutModuleID.Family.cost,
+             PageLayoutModuleID.Family.modelBreakdown,
+             "heatmap-year",
+             "heatmap-activity":
+            return .costOrAuxiliary
+        default:
+            return nil
+        }
+    }
+
+    /// Are these stored segments exactly the segmentation the old phase
+    /// grouping produced — summary, then quota, then cost with its analytics?
+    static func matchesPreviousOverviewSegmentation(_ layout: StoredPageLayout) -> Bool {
+        // Nothing stored is already handled: the default derives on its own.
+        guard layout.segments.count == 3 else { return false }
+        let expected: [PreviousOverviewPhase] = [.summary, .quota, .costOrAuxiliary]
+        for (band, phase) in zip(layout.segments, expected) {
+            guard !band.isEmpty else { return false }
+            for moduleID in band {
+                guard previousOverviewPhase(moduleID) == phase else { return false }
+            }
+        }
+        return true
     }
 
     /// Is this saved layout, in full, the arrangement 1.6.1 shipped for a

--- a/Sources/VibeBarCore/Services/PageLayoutSegments.swift
+++ b/Sources/VibeBarCore/Services/PageLayoutSegments.swift
@@ -43,15 +43,24 @@ public enum PageLayoutSegments {
     }
 
     /// Phases that share a segment in the Overview's default segmentation: the
-    /// pinned summary header, then the quota cards packed among themselves,
-    /// then cost together with the analytics derived from it.
+    /// pinned summary header, the provider quota cards packed among themselves,
+    /// the quota history and reset answers, then cost together with the
+    /// analytics derived from it.
     ///
     /// This is the answer to the complaint segments exist for — a user who
     /// picks Compact on the Overview gets a minimal-height quota block without
-    /// having to arrange anything.
+    /// having to arrange anything. The quota band grew to seven cards when the
+    /// refill horizon, the reset comparison, the usage mix and the
+    /// all-providers history all carried `.quota`, which is precisely the block
+    /// that has to stay scannable; `.history` is their band instead.
+    ///
+    /// Cost and its analytics stay one band. They read as a single block, and
+    /// splitting them would put an ordering constraint between a cost card and
+    /// the heatmap derived from it that nobody asked for.
     static let overviewPhaseGroups: [[OverviewMasonryPlanner.Phase]] = [
         [.summary],
         [.quota],
+        [.history],
         [.cost, .auxiliary]
     ]
 

--- a/Tests/VibeBarCoreTests/PageLayoutDefaultsMigrationTests.swift
+++ b/Tests/VibeBarCoreTests/PageLayoutDefaultsMigrationTests.swift
@@ -246,7 +246,7 @@ final class PageLayoutDefaultsMigrationTests: XCTestCase {
         )
     }
 
-    // MARK: - Overview history segment
+    // MARK: - The Overview is left to resolve itself
 
     private let overview = PageLayoutPageID.overview
     private let summaryIDs = [
@@ -276,120 +276,27 @@ final class PageLayoutDefaultsMigrationTests: XCTestCase {
         ]
     }
 
-    func testAnOverviewStillSegmentedTheOldWayIsLetGoOfItsSegmentation() {
-        // Clearing means "no chosen segmentation", which is what makes the new
-        // four-band default derive. The columns are not touched: the Overview's
-        // default arrangement is planner-computed from measured heights, so
-        // there is no cross-Mac signature to match there.
-        let columns = [[PageLayoutModuleID.quotaHistoryAll], [PageLayoutModuleID.costAll]]
+    /// The decision this file records by *not* having an Overview entry.
+    ///
+    /// A stored segmentation cannot prove the page is untouched — the layout
+    /// editor keeps hand-dragged `columns` in every mode — so nothing here
+    /// rewrites one, and `PageLayoutSegments.resolve` is what places the moved
+    /// cards. `PageLayoutTests` covers where they land.
+    func testAStoredOverviewSegmentationIsNeverRewritten() {
         let layout = StoredPageLayout(
             mode: .compact,
             ratio: .equal,
-            columns: columns,
-            segments: previousOverviewSegments(),
-            hidden: [.costAll]
+            columns: [summaryIDs, []],
+            segments: previousOverviewSegments()
         )
-        let after = try? XCTUnwrap(
-            PageLayoutDefaultsMigration.migratedOverviewHistorySegment([overview: layout])[overview]
-        )
-        XCTAssertEqual(after?.segments, [])
-        XCTAssertEqual(after?.columns, columns)
-        XCTAssertEqual(after?.mode, .compact)
-        XCTAssertEqual(after?.ratio, .equal)
-        XCTAssertEqual(after?.hidden, [.costAll])
-    }
-
-    func testAnOverviewWithNoStoredSegmentationIsLeftAlone() {
-        // It already derives the new default; there is nothing to repair.
-        let layout = StoredPageLayout(mode: .compact, ratio: .equal, columns: [[.costAll], []])
-        XCTAssertEqual(
-            PageLayoutDefaultsMigration.migratedOverviewHistorySegment([overview: layout])[overview],
-            layout
-        )
-    }
-
-    func testAHandGroupedOverviewKeepsItsSegmentation() {
-        // The real shape this has to refuse: a segmentation somebody packed by
-        // hand, where the all-providers history sits in the cost band rather
-        // than the quota one. `PageLayoutSegments.resolve` will re-place the
-        // three moved cards by their new phase anyway, so refusing costs the
-        // user nothing.
-        var segments = previousOverviewSegments()
-        segments[1].removeAll {
-            [
-                PageLayoutModuleID(rawValue: "overview-upcoming-resets"),
-                PageLayoutModuleID(rawValue: "overview-reset-history-compare"),
-                PageLayoutModuleID(rawValue: "overview-usage-mix"),
-                .quotaHistoryAll
-            ].contains($0)
-        }
-        segments[2].append(.quotaHistoryAll)
-        let arranged = StoredPageLayout(
-            mode: .compact,
-            ratio: .equal,
-            columns: [[.quotaHistoryAll], [.costAll]],
-            segments: segments
+        let result = PageLayoutDefaultsMigration.migrate(
+            layouts: [overview: layout],
+            applied: []
         )
         XCTAssertEqual(
-            PageLayoutDefaultsMigration.migratedOverviewHistorySegment([overview: arranged])[overview],
-            arranged
+            result.layouts[overview], layout,
+            "the Overview's saved arrangement is the user's, including its bands"
         )
-    }
-
-    func testAnOverviewSegmentedIntoSomethingOtherThanThreeBandsIsLeftAlone() {
-        let arranged = StoredPageLayout(
-            mode: .manual,
-            ratio: .equal,
-            columns: [[.costAll], []],
-            segments: [summaryIDs, [.quotaHistoryAll]]
-        )
-        XCTAssertEqual(
-            PageLayoutDefaultsMigration.migratedOverviewHistorySegment([overview: arranged])[overview],
-            arranged
-        )
-    }
-
-    func testAnUnrecognizedModuleIsEnoughToLeaveTheOverviewAlone() {
-        // A card this table cannot classify may be exactly the one the user
-        // placed by hand.
-        var segments = previousOverviewSegments()
-        segments[1].append(PageLayoutModuleID(rawValue: "overview-something-new"))
-        let arranged = StoredPageLayout(
-            mode: .compact, ratio: .equal, columns: [[.costAll], []], segments: segments
-        )
-        XCTAssertEqual(
-            PageLayoutDefaultsMigration.migratedOverviewHistorySegment([overview: arranged])[overview],
-            arranged
-        )
-    }
-
-    func testAProviderPageIsNeverTouchedByTheOverviewMigration() {
-        let layout = previousDefault()
-        XCTAssertEqual(
-            PageLayoutDefaultsMigration.migratedOverviewHistorySegment([page: layout])[page],
-            layout
-        )
-    }
-
-    func testThePreviousPhaseTableClassifiesEveryOverviewCardItShipped() {
-        typealias Phase = PageLayoutDefaultsMigration.PreviousOverviewPhase
-        func phase(_ raw: String) -> Phase? {
-            PageLayoutDefaultsMigration.previousOverviewPhase(PageLayoutModuleID(rawValue: raw))
-        }
-        XCTAssertEqual(phase("overview-summary-cost"), .summary)
-        XCTAssertEqual(phase("overview-quota:grok"), .quota)
-        // The four that used to ride in the quota band with the provider cards.
-        XCTAssertEqual(phase("overview-upcoming-resets"), .quota)
-        XCTAssertEqual(phase("overview-reset-history-compare"), .quota)
-        XCTAssertEqual(phase("overview-usage-mix"), .quota)
-        XCTAssertEqual(phase("quota-history-all"), .quota)
-        XCTAssertEqual(phase("cost-all"), .costOrAuxiliary)
-        XCTAssertEqual(phase("cost:codex"), .costOrAuxiliary)
-        XCTAssertEqual(phase("model-breakdown:all"), .costOrAuxiliary)
-        XCTAssertEqual(phase("heatmap-year:all"), .costOrAuxiliary)
-        XCTAssertEqual(phase("heatmap-activity:all"), .costOrAuxiliary)
-        XCTAssertNil(phase("status"))
-        XCTAssertNil(phase("overview-something-new"))
     }
 
     // MARK: - Once, and only once
@@ -401,9 +308,6 @@ final class PageLayoutDefaultsMigrationTests: XCTestCase {
         )
         XCTAssertTrue(
             first.applied.contains(PageLayoutDefaultsMigration.providerRightColumnIdentifier)
-        )
-        XCTAssertTrue(
-            first.applied.contains(PageLayoutDefaultsMigration.overviewHistorySegmentIdentifier)
         )
         XCTAssertEqual(first.layouts[page]?.columns[0].count, 1)
 
@@ -432,10 +336,7 @@ final class PageLayoutDefaultsMigrationTests: XCTestCase {
         let result = PageLayoutDefaultsMigration.migrate(layouts: [:], applied: [])
         XCTAssertEqual(
             result.applied,
-            [
-                PageLayoutDefaultsMigration.providerRightColumnIdentifier,
-                PageLayoutDefaultsMigration.overviewHistorySegmentIdentifier
-            ]
+            [PageLayoutDefaultsMigration.providerRightColumnIdentifier]
         )
         XCTAssertTrue(result.layouts.isEmpty)
     }

--- a/Tests/VibeBarCoreTests/PageLayoutDefaultsMigrationTests.swift
+++ b/Tests/VibeBarCoreTests/PageLayoutDefaultsMigrationTests.swift
@@ -300,6 +300,33 @@ final class PageLayoutDefaultsMigrationTests: XCTestCase {
         XCTAssertEqual(decoded.appliedLayoutMigrations, settings.appliedLayoutMigrations)
     }
 
+    func testTheResetHistoryAxisRoundTripsThroughSettings() throws {
+        // A user-facing control, so it round-trips through `AppSettings` like
+        // every other one (`AGENTS.md` § 11).
+        var settings = AppSettings.default
+        settings.resetHistoryCompareAxis = .time
+        let data = try JSONEncoder().encode(settings)
+        let decoded = try JSONDecoder().decode(AppSettings.self, from: data)
+        XCTAssertEqual(decoded.resetHistoryCompareAxis, .time)
+    }
+
+    func testSettingsWrittenBeforeTheAxisToggleDecodeToCycles() throws {
+        // An upgrade must not silently re-lay-out a module the user was
+        // reading yesterday.
+        let decoded = try JSONDecoder().decode(AppSettings.self, from: Data("{}".utf8))
+        XCTAssertEqual(decoded.resetHistoryCompareAxis, .cycle)
+        XCTAssertEqual(AppSettings.default.resetHistoryCompareAxis, .cycle)
+    }
+
+    func testAnUnknownAxisInTheSettingsFileFallsBackToCycles() throws {
+        // A value written by a newer build must cost the axis, not the file.
+        let decoded = try JSONDecoder().decode(
+            AppSettings.self,
+            from: Data(#"{"resetHistoryCompareAxis":"spiral"}"#.utf8)
+        )
+        XCTAssertEqual(decoded.resetHistoryCompareAxis, .cycle)
+    }
+
     func testSettingsWrittenBeforeMigrationsExistedDecodeToNoneApplied() throws {
         // Which is what makes the first launch on this build run them.
         let decoded = try JSONDecoder().decode(AppSettings.self, from: Data("{}".utf8))

--- a/Tests/VibeBarCoreTests/PageLayoutDefaultsMigrationTests.swift
+++ b/Tests/VibeBarCoreTests/PageLayoutDefaultsMigrationTests.swift
@@ -246,6 +246,152 @@ final class PageLayoutDefaultsMigrationTests: XCTestCase {
         )
     }
 
+    // MARK: - Overview history segment
+
+    private let overview = PageLayoutPageID.overview
+    private let summaryIDs = [
+        PageLayoutModuleID(rawValue: "overview-summary-cost"),
+        PageLayoutModuleID(rawValue: "overview-summary-status")
+    ]
+
+    /// The three bands the old phase grouping produced.
+    private func previousOverviewSegments() -> [[PageLayoutModuleID]] {
+        [
+            summaryIDs,
+            [
+                PageLayoutModuleID(rawValue: "overview-quota:codex"),
+                PageLayoutModuleID(rawValue: "overview-quota:claude"),
+                PageLayoutModuleID(rawValue: "overview-upcoming-resets"),
+                PageLayoutModuleID(rawValue: "overview-reset-history-compare"),
+                PageLayoutModuleID(rawValue: "overview-usage-mix"),
+                .quotaHistoryAll
+            ],
+            [
+                .costAll,
+                .cost(tool: .codex),
+                .modelBreakdown(tool: .codex),
+                PageLayoutModuleID(rawValue: "heatmap-year:all"),
+                PageLayoutModuleID(rawValue: "heatmap-activity:all")
+            ]
+        ]
+    }
+
+    func testAnOverviewStillSegmentedTheOldWayIsLetGoOfItsSegmentation() {
+        // Clearing means "no chosen segmentation", which is what makes the new
+        // four-band default derive. The columns are not touched: the Overview's
+        // default arrangement is planner-computed from measured heights, so
+        // there is no cross-Mac signature to match there.
+        let columns = [[PageLayoutModuleID.quotaHistoryAll], [PageLayoutModuleID.costAll]]
+        let layout = StoredPageLayout(
+            mode: .compact,
+            ratio: .equal,
+            columns: columns,
+            segments: previousOverviewSegments(),
+            hidden: [.costAll]
+        )
+        let after = try? XCTUnwrap(
+            PageLayoutDefaultsMigration.migratedOverviewHistorySegment([overview: layout])[overview]
+        )
+        XCTAssertEqual(after?.segments, [])
+        XCTAssertEqual(after?.columns, columns)
+        XCTAssertEqual(after?.mode, .compact)
+        XCTAssertEqual(after?.ratio, .equal)
+        XCTAssertEqual(after?.hidden, [.costAll])
+    }
+
+    func testAnOverviewWithNoStoredSegmentationIsLeftAlone() {
+        // It already derives the new default; there is nothing to repair.
+        let layout = StoredPageLayout(mode: .compact, ratio: .equal, columns: [[.costAll], []])
+        XCTAssertEqual(
+            PageLayoutDefaultsMigration.migratedOverviewHistorySegment([overview: layout])[overview],
+            layout
+        )
+    }
+
+    func testAHandGroupedOverviewKeepsItsSegmentation() {
+        // The real shape this has to refuse: a segmentation somebody packed by
+        // hand, where the all-providers history sits in the cost band rather
+        // than the quota one. `PageLayoutSegments.resolve` will re-place the
+        // three moved cards by their new phase anyway, so refusing costs the
+        // user nothing.
+        var segments = previousOverviewSegments()
+        segments[1].removeAll {
+            [
+                PageLayoutModuleID(rawValue: "overview-upcoming-resets"),
+                PageLayoutModuleID(rawValue: "overview-reset-history-compare"),
+                PageLayoutModuleID(rawValue: "overview-usage-mix"),
+                .quotaHistoryAll
+            ].contains($0)
+        }
+        segments[2].append(.quotaHistoryAll)
+        let arranged = StoredPageLayout(
+            mode: .compact,
+            ratio: .equal,
+            columns: [[.quotaHistoryAll], [.costAll]],
+            segments: segments
+        )
+        XCTAssertEqual(
+            PageLayoutDefaultsMigration.migratedOverviewHistorySegment([overview: arranged])[overview],
+            arranged
+        )
+    }
+
+    func testAnOverviewSegmentedIntoSomethingOtherThanThreeBandsIsLeftAlone() {
+        let arranged = StoredPageLayout(
+            mode: .manual,
+            ratio: .equal,
+            columns: [[.costAll], []],
+            segments: [summaryIDs, [.quotaHistoryAll]]
+        )
+        XCTAssertEqual(
+            PageLayoutDefaultsMigration.migratedOverviewHistorySegment([overview: arranged])[overview],
+            arranged
+        )
+    }
+
+    func testAnUnrecognizedModuleIsEnoughToLeaveTheOverviewAlone() {
+        // A card this table cannot classify may be exactly the one the user
+        // placed by hand.
+        var segments = previousOverviewSegments()
+        segments[1].append(PageLayoutModuleID(rawValue: "overview-something-new"))
+        let arranged = StoredPageLayout(
+            mode: .compact, ratio: .equal, columns: [[.costAll], []], segments: segments
+        )
+        XCTAssertEqual(
+            PageLayoutDefaultsMigration.migratedOverviewHistorySegment([overview: arranged])[overview],
+            arranged
+        )
+    }
+
+    func testAProviderPageIsNeverTouchedByTheOverviewMigration() {
+        let layout = previousDefault()
+        XCTAssertEqual(
+            PageLayoutDefaultsMigration.migratedOverviewHistorySegment([page: layout])[page],
+            layout
+        )
+    }
+
+    func testThePreviousPhaseTableClassifiesEveryOverviewCardItShipped() {
+        typealias Phase = PageLayoutDefaultsMigration.PreviousOverviewPhase
+        func phase(_ raw: String) -> Phase? {
+            PageLayoutDefaultsMigration.previousOverviewPhase(PageLayoutModuleID(rawValue: raw))
+        }
+        XCTAssertEqual(phase("overview-summary-cost"), .summary)
+        XCTAssertEqual(phase("overview-quota:grok"), .quota)
+        // The four that used to ride in the quota band with the provider cards.
+        XCTAssertEqual(phase("overview-upcoming-resets"), .quota)
+        XCTAssertEqual(phase("overview-reset-history-compare"), .quota)
+        XCTAssertEqual(phase("overview-usage-mix"), .quota)
+        XCTAssertEqual(phase("quota-history-all"), .quota)
+        XCTAssertEqual(phase("cost-all"), .costOrAuxiliary)
+        XCTAssertEqual(phase("cost:codex"), .costOrAuxiliary)
+        XCTAssertEqual(phase("model-breakdown:all"), .costOrAuxiliary)
+        XCTAssertEqual(phase("heatmap-year:all"), .costOrAuxiliary)
+        XCTAssertEqual(phase("heatmap-activity:all"), .costOrAuxiliary)
+        XCTAssertNil(phase("status"))
+        XCTAssertNil(phase("overview-something-new"))
+    }
+
     // MARK: - Once, and only once
 
     func testMigrateRecordsItsIdentifierAndDoesNothingOnASecondPass() {
@@ -255,6 +401,9 @@ final class PageLayoutDefaultsMigrationTests: XCTestCase {
         )
         XCTAssertTrue(
             first.applied.contains(PageLayoutDefaultsMigration.providerRightColumnIdentifier)
+        )
+        XCTAssertTrue(
+            first.applied.contains(PageLayoutDefaultsMigration.overviewHistorySegmentIdentifier)
         )
         XCTAssertEqual(first.layouts[page]?.columns[0].count, 1)
 
@@ -283,7 +432,10 @@ final class PageLayoutDefaultsMigrationTests: XCTestCase {
         let result = PageLayoutDefaultsMigration.migrate(layouts: [:], applied: [])
         XCTAssertEqual(
             result.applied,
-            [PageLayoutDefaultsMigration.providerRightColumnIdentifier]
+            [
+                PageLayoutDefaultsMigration.providerRightColumnIdentifier,
+                PageLayoutDefaultsMigration.overviewHistorySegmentIdentifier
+            ]
         )
         XCTAssertTrue(result.layouts.isEmpty)
     }

--- a/Tests/VibeBarCoreTests/PageLayoutTests.swift
+++ b/Tests/VibeBarCoreTests/PageLayoutTests.swift
@@ -1210,7 +1210,7 @@ final class PageLayoutTests: XCTestCase {
             .init(id: PageLayoutModuleID("overview-quota:claude"), phase: .quota),
             .init(id: PageLayoutModuleID("overview-quota:gemini"), phase: .quota),
             .init(id: PageLayoutModuleID("overview-quota:grok"), phase: .quota),
-            .init(id: .quotaHistoryAll, phase: .quota),
+            .init(id: .quotaHistoryAll, phase: .history),
             .init(id: .costAll, phase: .cost),
             .init(id: .cost(tool: .codex), phase: .cost),
             .init(id: PageLayoutModuleID("model-breakdown:all"), phase: .auxiliary),
@@ -1218,27 +1218,30 @@ final class PageLayoutTests: XCTestCase {
         ]
     }
 
-    func testOverviewDefaultsToSummaryThenQuotaThenEverythingElse() {
+    func testOverviewDefaultsToSummaryQuotaHistoryThenCostWithItsAnalytics() {
         let segments = PageLayoutSegments.defaultSegments(
             modules: overviewModules(),
             page: .overview
         )
 
-        XCTAssertEqual(segments.count, 3)
+        XCTAssertEqual(segments.count, 4)
         XCTAssertEqual(segments[0], [Self.summaryCost, Self.summaryStatus])
+        // The complaint this grouping answers: the quota band is the band a
+        // reader scans for "how much is left", so it holds the provider cards
+        // and nothing else.
         XCTAssertEqual(
             segments[1],
             [
                 PageLayoutModuleID("overview-quota:codex"),
                 PageLayoutModuleID("overview-quota:claude"),
                 PageLayoutModuleID("overview-quota:gemini"),
-                PageLayoutModuleID("overview-quota:grok"),
-                .quotaHistoryAll
+                PageLayoutModuleID("overview-quota:grok")
             ]
         )
-        // Cost and the analytics derived from it read as one block.
+        XCTAssertEqual(segments[2], [.quotaHistoryAll])
+        // Cost and the analytics derived from it still read as one block.
         XCTAssertEqual(
-            segments[2],
+            segments[3],
             [
                 .costAll,
                 .cost(tool: .codex),
@@ -1246,6 +1249,88 @@ final class PageLayoutTests: XCTestCase {
                 PageLayoutModuleID("heatmap-year:all")
             ]
         )
+    }
+
+    func testACompactOverviewKeepsTheMovedCardsOutOfItsStoredQuotaBand() {
+        // The shape a real Compact Overview stores: three bands materialized
+        // when it was packed, whose second band is already just the provider
+        // cards — and whose third holds the all-providers history, so the
+        // migration refuses it. What fixed the complaint for this layout is not
+        // the migration but the phase change: the three cards the stored bands
+        // have never seen are newcomers, and `resolve` sends a newcomer to the
+        // band its *current* phase points at, clamped into range.
+        let stored: [[PageLayoutModuleID]] = [
+            [Self.summaryCost, Self.summaryStatus],
+            [
+                PageLayoutModuleID("overview-quota:codex"),
+                PageLayoutModuleID("overview-quota:gemini"),
+                PageLayoutModuleID("overview-quota:claude"),
+                PageLayoutModuleID("overview-quota:grok")
+            ],
+            [.costAll, .cost(tool: .codex), .quotaHistoryAll]
+        ]
+        let modules: [PageLayoutSegments.Module] = [
+            .init(id: Self.summaryCost, phase: .summary),
+            .init(id: Self.summaryStatus, phase: .summary),
+            .init(id: PageLayoutModuleID("overview-upcoming-resets"), phase: .history),
+            .init(id: .quotaHistoryAll, phase: .history),
+            .init(id: PageLayoutModuleID("overview-reset-history-compare"), phase: .history),
+            .init(id: PageLayoutModuleID("overview-usage-mix"), phase: .cost),
+            .init(id: PageLayoutModuleID("overview-quota:codex"), phase: .quota),
+            .init(id: PageLayoutModuleID("overview-quota:gemini"), phase: .quota),
+            .init(id: PageLayoutModuleID("overview-quota:claude"), phase: .quota),
+            .init(id: PageLayoutModuleID("overview-quota:grok"), phase: .quota),
+            .init(id: .costAll, phase: .cost),
+            .init(id: .cost(tool: .codex), phase: .cost)
+        ]
+        let resolved = PageLayoutSegments.resolve(
+            stored: stored,
+            available: modules.map(\.id),
+            defaultSegments: PageLayoutSegments.defaultSegments(modules: modules, page: .overview)
+        )
+
+        XCTAssertEqual(resolved.count, 3)
+        // The band the maintainer looks at holds the four provider cards, and
+        // nothing that merely relates to quota.
+        XCTAssertEqual(
+            resolved[1],
+            [
+                PageLayoutModuleID("overview-quota:codex"),
+                PageLayoutModuleID("overview-quota:gemini"),
+                PageLayoutModuleID("overview-quota:claude"),
+                PageLayoutModuleID("overview-quota:grok")
+            ]
+        )
+        // The three newcomers land below it — history at its own index, the
+        // usage mix clamped down from the cost index this layout has no band for.
+        XCTAssertEqual(
+            Set(resolved[2]),
+            Set([
+                .costAll,
+                .cost(tool: .codex),
+                .quotaHistoryAll,
+                PageLayoutModuleID("overview-upcoming-resets"),
+                PageLayoutModuleID("overview-reset-history-compare"),
+                PageLayoutModuleID("overview-usage-mix")
+            ])
+        )
+    }
+
+    func testTheOverviewQuotaSegmentHoldsOnlyProviderQuotaCards() {
+        // Stated as an invariant rather than a list, so a card added to the
+        // Overview later cannot quietly rejoin the band.
+        let segments = PageLayoutSegments.defaultSegments(
+            modules: overviewModules(),
+            page: .overview
+        )
+        XCTAssertGreaterThan(segments.count, 1)
+        XCTAssertFalse(segments[1].isEmpty)
+        for moduleID in segments[1] {
+            XCTAssertTrue(
+                moduleID.rawValue.hasPrefix("overview-quota:"),
+                "\(moduleID.rawValue) does not belong in the quota segment"
+            )
+        }
     }
 
     func testAProviderPageDefaultsToASingleSegment() {
@@ -1535,22 +1620,22 @@ final class PageLayoutTests: XCTestCase {
             spacing: 12
         )
 
-        XCTAssertEqual(packed.count, 3)
+        XCTAssertEqual(packed.count, 4)
         XCTAssertEqual(Set(packed[0].flatMap { $0 }), [Self.summaryCost, Self.summaryStatus])
+        // Nothing from below leaks into the quota segment, which is exactly what
+        // the unsegmented packer was free to do.
         XCTAssertEqual(
             Set(packed[1].flatMap { $0 }),
             Set([
                 PageLayoutModuleID("overview-quota:codex"),
                 PageLayoutModuleID("overview-quota:claude"),
                 PageLayoutModuleID("overview-quota:gemini"),
-                PageLayoutModuleID("overview-quota:grok"),
-                .quotaHistoryAll
+                PageLayoutModuleID("overview-quota:grok")
             ])
         )
-        // Nothing from below leaks into the quota segment, which is exactly what
-        // the unsegmented packer was free to do.
+        XCTAssertEqual(Set(packed[2].flatMap { $0 }), [.quotaHistoryAll])
         XCTAssertEqual(
-            Set(packed[2].flatMap { $0 }),
+            Set(packed[3].flatMap { $0 }),
             Set([
                 .costAll,
                 .cost(tool: .codex),

--- a/Tests/VibeBarCoreTests/ResetHistoryComparisonTests.swift
+++ b/Tests/VibeBarCoreTests/ResetHistoryComparisonTests.swift
@@ -226,6 +226,161 @@ final class ResetHistoryComparisonTests: XCTestCase {
         XCTAssertNil(result.truncationNote)
     }
 
+    // MARK: - Time axis
+
+    func testTheTimeAxisPlacesEachCycleWhereItActuallyHappened() {
+        // The point of the second axis: bars sit on the calendar, so a lane
+        // that refilled in March is drawn in March rather than in "column 3".
+        let input = lane(samples: [
+            sample(bucketId: "weekly", endingDaysAgo: 21, used: 10),
+            sample(bucketId: "weekly", endingDaysAgo: 7, used: 40)
+        ])
+        let result = ResetHistoryComparison.build(inputs: [input], axis: .time, window: .all, now: now)
+        let span = try? XCTUnwrap(result.span)
+        XCTAssertNotNil(span)
+        // No columns on this axis.
+        XCTAssertEqual(result.columns.totalColumnCount, 0)
+
+        let cycles = result.lanes[0].cycles
+        XCTAssertEqual(cycles.count, 2)
+        // Each bar's own dates decide where it goes, and they are the sample's
+        // real window, not an ordinal.
+        XCTAssertEqual(cycles[0].end, now.addingTimeInterval(-21 * 86_400))
+        XCTAssertEqual(cycles[1].end, now.addingTimeInterval(-7 * 86_400))
+        // …and they map to increasing positions across the span.
+        if let span {
+            XCTAssertLessThan(span.fraction(of: cycles[0].end), span.fraction(of: cycles[1].end))
+            XCTAssertGreaterThanOrEqual(span.end, now)
+        }
+    }
+
+    func testTheTimeAxisWindowIsCountedInWeeks() {
+        // Same four steps as the cycle axis, different unit: here "4" is four
+        // weeks of calendar, so an older cycle falls outside it however few
+        // cycles the lane has.
+        let input = lane(samples: [
+            sample(bucketId: "weekly", endingDaysAgo: 3, used: 90),
+            sample(bucketId: "weekly", endingDaysAgo: 40, used: 10)
+        ])
+        let fourWeeks = ResetHistoryComparison.build(inputs: [input], axis: .time, window: .four, now: now)
+        XCTAssertEqual(fourWeeks.lanes[0].cycles.count, 1)
+        XCTAssertEqual(fourWeeks.totals.cycleCount, 1)
+        XCTAssertEqual(fourWeeks.span?.start, now.addingTimeInterval(-4 * 7 * 86_400))
+
+        let all = ResetHistoryComparison.build(inputs: [input], axis: .time, window: .all, now: now)
+        XCTAssertEqual(all.lanes[0].cycles.count, 2)
+        // `all` reaches back to the oldest recorded cycle's start.
+        XCTAssertLessThanOrEqual(
+            try XCTUnwrap(all.span?.start),
+            now.addingTimeInterval(-40 * 86_400)
+        )
+    }
+
+    func testTheSpanReachesTheScheduledResetSoTheDashedBarIsNotClipped() {
+        let resetAt = now.addingTimeInterval(5 * 86_400)
+        let input = lane(
+            currentUsed: 30,
+            currentResetAt: resetAt,
+            samples: [sample(bucketId: "weekly", endingDaysAgo: 2, used: 40)]
+        )
+        let result = ResetHistoryComparison.build(inputs: [input], axis: .time, window: .eight, now: now)
+        XCTAssertGreaterThanOrEqual(try XCTUnwrap(result.span?.end), resetAt)
+    }
+
+    func testTheTimeAxisNeverReportsTruncation() {
+        // It thins by pixel at draw time, which drops no cycle from the
+        // arithmetic, so there is nothing to caveat.
+        var samples: [SubscriptionWindowSample] = []
+        for index in 0..<(ResetHistoryComparison.ColumnPlan.maximumColumns + 20) {
+            samples.append(sample(bucketId: "weekly", endingDaysAgo: Double(7 * (index + 1)), used: 50))
+        }
+        let result = ResetHistoryComparison.build(
+            inputs: [lane(samples: samples)], axis: .time, window: .all, now: now
+        )
+        XCTAssertNil(result.truncationNote)
+        XCTAssertFalse(result.lanes[0].isTruncated)
+        XCTAssertEqual(result.lanes[0].cycles.count, ResetHistoryComparison.ColumnPlan.maximumColumns + 20)
+    }
+
+    func testBothAxesAgreeOnTheStatisticsForTheSameCycles() {
+        // The axis decides where a bar goes, never what the numbers say. With
+        // a window both axes resolve to the same set, every figure matches.
+        let input = lane(samples: [
+            sample(bucketId: "weekly", endingDaysAgo: 7, used: 20),
+            sample(bucketId: "weekly", endingDaysAgo: 14, used: 60)
+        ])
+        let cycles = ResetHistoryComparison.build(inputs: [input], axis: .cycle, window: .all, now: now)
+        let time = ResetHistoryComparison.build(inputs: [input], axis: .time, window: .all, now: now)
+
+        XCTAssertEqual(cycles.totals.cycleCount, time.totals.cycleCount)
+        XCTAssertEqual(cycles.totals.usedPercent, time.totals.usedPercent, accuracy: 0.001)
+        XCTAssertEqual(cycles.verdict, time.verdict)
+        XCTAssertEqual(cycles.lanes[0].averageWastedPercent, time.lanes[0].averageWastedPercent)
+        XCTAssertEqual(cycles.lanes[0].wastefulCycleCount, time.lanes[0].wastefulCycleCount)
+        XCTAssertEqual(cycles.lanes.map(\.id), time.lanes.map(\.id))
+    }
+
+    func testTheAxisIsCarriedOnTheComparison() {
+        let input = lane(samples: [sample(bucketId: "weekly", endingDaysAgo: 7, used: 40)])
+        XCTAssertEqual(ResetHistoryComparison.build(inputs: [input], now: now).axis, .cycle)
+        XCTAssertEqual(
+            ResetHistoryComparison.build(inputs: [input], axis: .time, now: now).axis,
+            .time
+        )
+    }
+
+    // MARK: - Time-axis draw budget
+
+    func testDownsamplingKeepsTheEndpointsAndTheWorstBars() {
+        // The time axis has no column ceiling, so something has to go when a
+        // lane has more cycles than the row has pixels — and a chart about
+        // wasted quota must not be the thing that drops the wasteful cycles.
+        var cycles: [ResetHistoryComparison.Cycle] = []
+        for index in 0..<10 {
+            cycles.append(cycle(index: index, used: index == 5 ? 1 : 90))
+        }
+        let kept = ResetHistoryComparison.downsampled(cycles, limit: 3)
+        XCTAssertEqual(kept.map(\.id), ["c0", "c5", "c9"])
+    }
+
+    func testDownsamplingLeavesALaneThatAlreadyFitsAlone() {
+        var cycles: [ResetHistoryComparison.Cycle] = []
+        for index in 0..<3 {
+            cycles.append(cycle(index: index, used: 50))
+        }
+        XCTAssertEqual(ResetHistoryComparison.downsampled(cycles, limit: 10).count, 3)
+        XCTAssertTrue(ResetHistoryComparison.downsampled(cycles, limit: 0).isEmpty)
+    }
+
+    private func cycle(index: Int, used: Double) -> ResetHistoryComparison.Cycle {
+        let start: Date = now.addingTimeInterval(Double(index) * week)
+        let end: Date = start.addingTimeInterval(week)
+        return ResetHistoryComparison.Cycle(
+            id: "c\(index)",
+            start: start,
+            end: end,
+            usedPercent: used,
+            isCompleted: true
+        )
+    }
+
+    // MARK: - Picker labels
+
+    func testThePickerLabelsCarryTheUnitOfTheirAxis() {
+        XCTAssertEqual(ResetHistoryComparison.Window.eight.shortTitle(for: .cycle), "8")
+        XCTAssertEqual(ResetHistoryComparison.Window.eight.shortTitle(for: .time), "8w")
+        XCTAssertEqual(ResetHistoryComparison.Window.all.shortTitle(for: .cycle), "All")
+        XCTAssertEqual(ResetHistoryComparison.Window.all.shortTitle(for: .time), "All")
+        XCTAssertEqual(
+            ResetHistoryComparison.Window.eight.spokenTitle(for: .cycle),
+            "last 8 cycles"
+        )
+        XCTAssertEqual(
+            ResetHistoryComparison.Window.eight.spokenTitle(for: .time),
+            "last 8 weeks"
+        )
+    }
+
     // MARK: - Ordinal alignment
 
     func testRowsWithFewerCyclesRightAlignToTheNewestColumn() {


### PR DESCRIPTION
## Summary

Two maintainer requests on the comparison module.

**Cycle / Time axis toggle.** `ResetHistoryAxis` (`cycle` / `time`) in Core; `ResetHistoryComparison.build(inputs:axis:window:now:)` produces either the ordinal `ColumnPlan` (default) or a `TimeSpan` grid — cycles placed by real `windowStart … completedAt`, window in weeks (4w / 8w / 12w / All), span reaching the live cycle's scheduled reset, per-lane pixel downsampling that keeps endpoints and the worst bars; no statistics cap on either axis. The card gains a "Cycles | Time" control; the choice is `AppSettings.resetHistoryCompareAxis` (default `.cycle`, absent or unknown value decodes to `.cycle` via `try?` so a bad value never breaks the settings file), written only on toggle, shared by the Overview, provider pages and the Resets page. Heading/label/track geometry is identical across axes (no label reflow); one `Canvas`, per-axis hit test for the single tooltip.

**Overview quota segment = provider cards only.** The `.quota` masonry phase had grown to hold Upcoming Resets, the comparison, Usage Mix and the all-providers quota history beside the four provider cards (the layout editor showed 7 cards in segment 2). New `.history` phase (Upcoming Resets, Quota History all, Reset History Compare) between quota and cost; Usage Mix moves to `.cost`; default Overview bands are summary → provider quotas → history → cost with its analytics (cost + auxiliary stay one band, as before). `OverviewMasonryPlanner` now iterates `Phase.allCases` (the hard-coded lists would have dropped the new phase). A saved Overview segmentation that still equals the old three-band default is cleared once (`overview-history-segment-v1` in `appliedLayoutMigrations`) so the new default derives; hand-packed segmentations are left alone — new modules already resolve into the history band via `min(defaultIndex, count-1)`.

## Test plan

- [x] `swift build`
- [x] `swift test` — 1984 tests, 0 failures (time-axis placement / weeks window / span / downsampling / shared statistics; settings round-trip, absent key, unknown value; Overview segment invariant "segment 2 holds only `overview-quota:*`", compact stored-shape resolution, migration move + refusals)
- [ ] After install: Cycles/Time toggle on the Overview is followed by the provider page and Resets tab; layout editor's Overview segment 2 shows only the four provider cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)