### PR TITLE
Bump build number to 62 for the 1.6.2 Dev release

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.6.2</string>
 	<key>CFBundleVersion</key>
-	<string>61</string>
+	<string>62</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>26.0</string>
 	<key>LSUIElement</key>


### PR DESCRIPTION
## Summary

Build number for the Dev release of 1.6.2: `CFBundleVersion` 61 → 62 (`CFBundleShortVersionString` stays 1.6.2). Bundle ID unchanged, entitlements still an empty `<dict/>`, `SUPublicEDKey` / `SUFeedURL` untouched.

1.6.2 collects #296 and #298: the reset-history comparison grouped by company with full labels, switchable between cycle-ordinal columns and a real time axis (`AppSettings.resetHistoryCompareAxis`), bars showing what was left at reset; provider pages default the comparison after the cost cards and Service Status to the end of the right column (AGENTS.md § 11 updated) with a one-time migration for untouched layouts; the Overview's quota segment holds only the four provider cards, with Upcoming Resets, Quota History and the comparison in a history band of their own.

To be tagged `v1.6.2-dev.62` (Dev channel).

## Test plan

- [x] `swift build`
- [x] `swift test` — 1978 tests, 0 failures
- [x] `./Scripts/build_app.sh release`
- [x] `codesign -d --entitlements -` is an empty `<dict/>`; `codesign --verify --deep --strict` passes
- [x] Packaged `Info.plist` reads 1.6.2 (62)
- [ ] Tag → release workflow → draft asset inspection (appcast entry carries `<sparkle:channel>dev`) → publish as prerelease → install

🤖 Generated with [Claude Code](https://claude.com/claude-code)
