### PR TITLE
Move the re-homed cards out of a stored Overview quota band

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1310,6 +1310,15 @@ Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
   therefore needs an entry in `PageLayoutDefaultsMigration` — matched on the old
   default's exact signature, recorded once in `AppSettings.appliedLayoutMigrations`,
   and never applied to a layout that has been arranged.
+
+  Two shapes of entry, and the choice is not free. A provider page can be
+  matched *whole* — every card in both columns, no segmentation, the default
+  width split — so its migration moves cards only when nothing on the page has
+  been touched. The Overview cannot: its columns are planner-computed from
+  measured card heights, and the layout editor keeps a hand-dragged arrangement
+  in every mode, so no property of a saved Overview proves nobody arranged it.
+  Do not clear an Overview's segmentation to make a new default derive; move the
+  named cards out of the one named band instead, which needs no such proof.
 - **Dense status history is one drawing surface, not hundreds of views.** Use
   `Canvas` (or an equivalent batched renderer) for uptime strips and avoid one
   Swift Charts instance per quota. These detail pages can display many status

--- a/Sources/VibeBarCore/Services/PageLayoutDefaultsMigration.swift
+++ b/Sources/VibeBarCore/Services/PageLayoutDefaultsMigration.swift
@@ -35,17 +35,38 @@ public enum PageLayoutDefaultsMigration {
     /// column to close the wide one.
     public static let providerRightColumnIdentifier = "provider-right-column-v2"
 
-    // No entry for the Overview's split quota phase, deliberately. Its stored
-    // `columns` are a hand-draggable arrangement in *every* mode — the layout
-    // editor keeps them when the page is switched to Auto or Compact and back
-    // — so a phase-homogeneous three-band segmentation does not establish that
-    // the page is untouched, and clearing it would re-sort those columns under
-    // the new four-band default. Nothing needs the rewrite either: a stored
-    // segmentation has never seen the three moved cards, so
-    // `PageLayoutSegments.resolve` places them at
-    // `min(defaultIndex, count - 1)` and the quota band keeps only the
-    // provider cards. They share the cost band instead of getting their own,
-    // which is the right price for not overruling an arrangement.
+    /// 1.6.2: the Overview's quota phase kept only the provider cards, so the
+    /// four cards it used to also hold move out of a stored quota band.
+    public static let overviewQuotaBandIdentifier = "overview-quota-band-v1"
+
+    /// The cards 1.6.2 moved out of the Overview's `.quota` phase — three to a
+    /// history band of their own, Usage Mix to the cost band.
+    ///
+    /// A stored segmentation that *names* one of these keeps it wherever it is,
+    /// because `PageLayoutSegments.resolve` only places modules a saved
+    /// segmentation has never seen. Every release up to 1.6.1 put them in the
+    /// quota band, so anyone whose Overview segmentation was materialized by
+    /// one of those builds — opening the layout editor is enough — has them
+    /// pinned there, which is exactly the crowding this release set out to fix.
+    /// Family prefix of an Overview provider quota card. A literal because
+    /// `PageModuleCatalog` builds these ids from one too — and because a
+    /// migration is a frozen snapshot of a past release either way.
+    static let overviewQuotaFamily = "overview-quota"
+
+    static let movedOutOfOverviewQuotaBand: Set<PageLayoutModuleID> = [
+        PageLayoutModuleID(rawValue: "overview-upcoming-resets"),
+        PageLayoutModuleID(rawValue: "overview-reset-history-compare"),
+        PageLayoutModuleID(rawValue: "overview-usage-mix"),
+        .quotaHistoryAll
+    ]
+
+    // Note on what is deliberately *not* migrated: the whole segmentation.
+    // Clearing it so the new four-band default derives would re-sort the
+    // stored `columns` too, and those are a hand-draggable arrangement in
+    // every mode — the layout editor keeps them when a page is switched to
+    // Auto or Compact and back — so no property of a saved Overview
+    // establishes that nobody arranged it. Moving the named cards out of one
+    // named band is the narrow repair that does not need that proof.
 
     /// Module family the reset-history table is registered under.
     static let resetHistoryFamily = "reset-history-compare"
@@ -63,7 +84,60 @@ public enum PageLayoutDefaultsMigration {
         if applied.insert(providerRightColumnIdentifier).inserted {
             layouts = migratedProviderRightColumn(layouts)
         }
+        if applied.insert(overviewQuotaBandIdentifier).inserted {
+            layouts = migratedOverviewQuotaBand(layouts)
+        }
         return (layouts, applied)
+    }
+
+    /// Move the cards 1.6.2 re-homed out of a stored Overview quota band.
+    ///
+    /// Narrow on purpose. It touches only `segments`, only the band that holds
+    /// the provider quota cards, and only the four identifiers this release
+    /// moved; the destination is the band holding the cost cards, which is
+    /// where `PageLayoutSegments.resolve` sends them as newcomers anyway. A
+    /// card sitting anywhere else, a page with one band, and every other card
+    /// in the quota band are all left exactly as they are.
+    ///
+    /// `columns` need no edit: `PageLayoutSegments.sortedColumns` re-sorts each
+    /// column by segment rank at render time and its sort is stable, so the
+    /// order the user dragged *within* a band survives the move.
+    ///
+    /// The cost of being wrong is bounded and recoverable: someone who put
+    /// Usage Mix beside their quota cards on purpose has it moved once, and
+    /// dragging it back is honoured — `applied` records the migration whether
+    /// or not it found anything, so it never asks twice.
+    public static func migratedOverviewQuotaBand(
+        _ layouts: [PageLayoutPageID: StoredPageLayout]
+    ) -> [PageLayoutPageID: StoredPageLayout] {
+        var result = layouts
+        for (page, layout) in layouts where page.isOverview {
+            var segments = layout.segments
+            guard segments.count > 1,
+                  let quotaBand = segments.firstIndex(where: { band in
+                      band.contains { $0.family == overviewQuotaFamily }
+                  })
+            else { continue }
+            let strays = segments[quotaBand].filter(movedOutOfOverviewQuotaBand.contains)
+            guard !strays.isEmpty else { continue }
+            // The cost band, or the last one when a stored segmentation has no
+            // cost cards to point at — the same fallback `resolve` clamps to.
+            let destination = segments.firstIndex { band in
+                band.contains { $0.family == PageLayoutModuleID.Family.cost }
+                    || band.contains(.costAll)
+            } ?? segments.index(before: segments.endIndex)
+            guard destination != quotaBand else { continue }
+            segments[quotaBand].removeAll(where: strays.contains)
+            segments[destination].append(contentsOf: strays)
+            result[page] = StoredPageLayout(
+                mode: layout.mode,
+                ratio: layout.ratio,
+                columns: layout.columns,
+                segments: segments,
+                hidden: layout.hidden
+            )
+        }
+        return result
     }
 
     /// Move `status` and `reset-history-compare:<tool>` to their new homes on

--- a/Tests/VibeBarCoreTests/PageLayoutDefaultsMigrationTests.swift
+++ b/Tests/VibeBarCoreTests/PageLayoutDefaultsMigrationTests.swift
@@ -276,6 +276,112 @@ final class PageLayoutDefaultsMigrationTests: XCTestCase {
         ]
     }
 
+    // MARK: - The Overview's quota band
+
+    private func storedOverview(
+        quotaBand: [PageLayoutModuleID],
+        costBand: [PageLayoutModuleID]
+    ) -> StoredPageLayout {
+        StoredPageLayout(
+            mode: .compact,
+            ratio: .equal,
+            columns: [summaryIDs, []],
+            segments: [summaryIDs, quotaBand, costBand]
+        )
+    }
+
+    private let providerQuotaIDs = [
+        PageLayoutModuleID(rawValue: "overview-quota:codex"),
+        PageLayoutModuleID(rawValue: "overview-quota:claude")
+    ]
+    private let usageMix = PageLayoutModuleID(rawValue: "overview-usage-mix")
+    private let upcomingResets = PageLayoutModuleID(rawValue: "overview-upcoming-resets")
+    private let comparison = PageLayoutModuleID(rawValue: "overview-reset-history-compare")
+
+    func testTheCardsThisReleaseRehomedLeaveAStoredQuotaBand() {
+        // What 1.6.1 pinned there: the provider cards plus everything the
+        // quota phase used to also hold.
+        let layout = storedOverview(
+            quotaBand: [providerQuotaIDs[0], upcomingResets, providerQuotaIDs[1],
+                        comparison, usageMix, .quotaHistoryAll],
+            costBand: [.costAll, .cost(tool: .codex)]
+        )
+        let moved = PageLayoutDefaultsMigration
+            .migratedOverviewQuotaBand([overview: layout])[overview]
+        XCTAssertEqual(
+            moved?.segments[1], providerQuotaIDs,
+            "the quota band keeps only the provider cards, in the order they were in"
+        )
+        XCTAssertEqual(
+            moved?.segments[2],
+            [.costAll, .cost(tool: .codex), upcomingResets, comparison, usageMix,
+             .quotaHistoryAll],
+            "the re-homed cards join the cost band, keeping their relative order"
+        )
+        XCTAssertEqual(moved?.columns, layout.columns, "columns are not touched")
+        XCTAssertEqual(moved?.mode, layout.mode)
+        XCTAssertEqual(moved?.ratio, layout.ratio)
+    }
+
+    func testAQuotaBandThatIsAlreadyJustProviderCardsIsLeftAlone() {
+        let layout = storedOverview(
+            quotaBand: providerQuotaIDs,
+            costBand: [.costAll, usageMix]
+        )
+        XCTAssertEqual(
+            PageLayoutDefaultsMigration.migratedOverviewQuotaBand([overview: layout])[overview],
+            layout
+        )
+    }
+
+    func testARehomedCardOutsideTheQuotaBandIsLeftWhereItIs() {
+        // Usage Mix sitting in the cost band is where it belongs; one in a
+        // band of its own is somebody's arrangement. Neither is this
+        // migration's business.
+        let layout = StoredPageLayout(
+            mode: .manual,
+            ratio: .equal,
+            columns: [summaryIDs, []],
+            segments: [summaryIDs, providerQuotaIDs, [usageMix], [.costAll]]
+        )
+        XCTAssertEqual(
+            PageLayoutDefaultsMigration.migratedOverviewQuotaBand([overview: layout])[overview],
+            layout
+        )
+    }
+
+    func testASingleBandOverviewIsLeftAlone() {
+        let layout = StoredPageLayout(
+            mode: .compact,
+            ratio: .equal,
+            columns: [summaryIDs, []],
+            segments: [providerQuotaIDs + [usageMix]]
+        )
+        XCTAssertEqual(
+            PageLayoutDefaultsMigration.migratedOverviewQuotaBand([overview: layout])[overview],
+            layout
+        )
+    }
+
+    func testWithoutACostBandTheCardsGoToTheLastBand() {
+        let layout = storedOverview(
+            quotaBand: providerQuotaIDs + [usageMix],
+            costBand: [PageLayoutModuleID(rawValue: "heatmap-year:all")]
+        )
+        let moved = PageLayoutDefaultsMigration
+            .migratedOverviewQuotaBand([overview: layout])[overview]
+        XCTAssertEqual(moved?.segments[1], providerQuotaIDs)
+        XCTAssertEqual(moved?.segments[2].last, usageMix)
+    }
+
+    func testAProviderPageIsNeverTouchedByTheQuotaBandMigration() {
+        let layout = previousDefault()
+        XCTAssertEqual(
+            PageLayoutDefaultsMigration.migratedOverviewQuotaBand([page: layout])[page],
+            layout
+        )
+    }
+
     /// The decision this file records by *not* having an Overview entry.
     ///
     /// A stored segmentation cannot prove the page is untouched — the layout
@@ -287,7 +393,7 @@ final class PageLayoutDefaultsMigrationTests: XCTestCase {
             mode: .compact,
             ratio: .equal,
             columns: [summaryIDs, []],
-            segments: previousOverviewSegments()
+            segments: [summaryIDs, providerQuotaIDs, [.costAll]]
         )
         let result = PageLayoutDefaultsMigration.migrate(
             layouts: [overview: layout],
@@ -295,7 +401,7 @@ final class PageLayoutDefaultsMigrationTests: XCTestCase {
         )
         XCTAssertEqual(
             result.layouts[overview], layout,
-            "the Overview's saved arrangement is the user's, including its bands"
+            "an Overview whose bands hold nothing this release re-homed is the user's"
         )
     }
 
@@ -336,7 +442,10 @@ final class PageLayoutDefaultsMigrationTests: XCTestCase {
         let result = PageLayoutDefaultsMigration.migrate(layouts: [:], applied: [])
         XCTAssertEqual(
             result.applied,
-            [PageLayoutDefaultsMigration.providerRightColumnIdentifier]
+            [
+                PageLayoutDefaultsMigration.providerRightColumnIdentifier,
+                PageLayoutDefaultsMigration.overviewQuotaBandIdentifier
+            ]
         )
         XCTAssertTrue(result.layouts.isEmpty)
     }


### PR DESCRIPTION
## Summary

Follow-up to #298. Splitting the `.quota` phase fixed the *default* Overview segmentation, but not a saved one: `PageLayoutSegments.resolve` places only modules a stored segmentation has never seen, and every build up to 1.6.1 put Upcoming Resets, the reset-history comparison, Usage Mix and the all-providers quota history in the quota band. Opening the layout editor once materializes that, so the crowding this release set out to fix survived the upgrade — verified on the maintainer's own machine after installing 1.6.2: the persisted `segments[1]` came back as the four provider cards **plus** `overview-usage-mix`.

`overview-quota-band-v1` moves exactly those four identifiers out of the band holding the `overview-quota:*` cards and into the band holding the cost cards (the last band when there are none) — the same destination `resolve` clamps newcomers to. It touches nothing else: not `columns` (`sortedColumns` re-sorts them stably at render, so within-band drag order survives), not a re-homed card sitting in any other band, not a single-band page, and not the segmentation as a whole. The earlier attempt to clear the bands was withdrawn in #298 because the Overview has no property that proves nobody arranged it; moving named cards out of one named band needs no such proof, and `AGENTS.md` § 11 now records both shapes of entry and when each is allowed.

## Test plan

- [x] `swift build`
- [x] `swift test` — 1984 tests, 0 failures (6 new: the move preserves order and leaves columns/mode/ratio alone; a clean quota band, a re-homed card in another band, a single-band page and a provider page are all left alone; no cost band falls back to the last band)
- [ ] After install: the layout editor's Overview segment 2 shows only the four provider cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)