### PR TITLE
Bump build number to 63 for the 1.6.2 Dev release

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.6.2</string>
 	<key>CFBundleVersion</key>
-	<string>62</string>
+	<string>63</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>26.0</string>
 	<key>LSUIElement</key>


### PR DESCRIPTION
## Summary

`CFBundleVersion` 62 → 63 (`CFBundleShortVersionString` stays 1.6.2). Bundle ID unchanged, entitlements still an empty `<dict/>`, `SUPublicEDKey` / `SUFeedURL` untouched.

Adds #300 on top of dev.62: the one-time migration that moves Upcoming Resets, the reset-history comparison, Usage Mix and the all-providers quota history out of a *stored* Overview quota band, which is what still crowded segment 2 for anyone upgrading from 1.6.1 (confirmed on the maintainer's machine after installing dev.62).

To be tagged `v1.6.2-dev.63` (Dev channel).

## Test plan

- [x] `swift build`
- [x] `swift test` — 1984 tests, 0 failures
- [x] `./Scripts/build_app.sh release`
- [x] `codesign -d --entitlements -` is an empty `<dict/>`; `codesign --verify --deep --strict` passes
- [x] Packaged `Info.plist` reads 1.6.2 (63)
- [ ] Tag → workflow → draft asset inspection (`<sparkle:channel>dev`) → publish as prerelease → install → read back that the Overview quota band holds only the provider cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)