### PR TITLE
Split the comparison's row labels into their two levels

### DIFF
--- a/Sources/VibeBarApp/Views/FillTimelineChart.swift
+++ b/Sources/VibeBarApp/Views/FillTimelineChart.swift
@@ -32,12 +32,45 @@ struct FillTimelineChart: View {
     private final class CycleCache {
         var key: SubscriptionHistoryKey?
         var samples: [SubscriptionWindowSample] = []
+        var limit = 0
         var visible: [SubscriptionWindowSample] = []
     }
 
     @State private var cycleCache = CycleCache()
+    /// Strip width, updated only when it changes. The number of cycles worth
+    /// drawing is a function of it.
+    @State private var stripWidth: CGFloat = 0
 
-    private static let maxCycles = 12
+    /// Most cycles the strip will draw, however wide it gets.
+    ///
+    /// A legibility budget, not a storage one — `SubscriptionHistoryStore`
+    /// keeps every cycle it ever recorded, and the busiest lane on a real Mac
+    /// holds a couple of hundred. Past this many the strip stops being a shape
+    /// you can read and becomes texture.
+    private static let maximumCycles = 60
+
+    /// Bar width the count is derived from. `cycleStrip` never draws narrower
+    /// than the geometry allows, so deriving from a slightly generous figure is
+    /// what keeps a little air between bars at the wide end.
+    private static let preferredBarWidth: CGFloat = 6
+
+    /// Until the strip has been measured. Small enough to look deliberate for
+    /// the one frame before the real width arrives.
+    private static let unmeasuredCycles = 12
+
+    /// As many cycles as fit at `preferredBarWidth`, capped.
+    ///
+    /// Fewer bars beats unreadable ones: the count comes down until each bar
+    /// has room, rather than the bars thinning to hairlines to fit a count.
+    private func maxCycles(forWidth width: CGFloat) -> Int {
+        guard width > 0 else { return Self.unmeasuredCycles }
+        let slot = Self.preferredBarWidth + barSpacing
+        return min(Self.maximumCycles, max(4, Int((width + barSpacing) / slot)))
+    }
+
+    /// Band above the bars holding the early-refill dots. Always reserved, so
+    /// the strip does not change height when a cycle refills early.
+    private var markerBand: CGFloat { 5 }
 
     private var barSpacing: CGFloat {
         switch density.profile {
@@ -56,7 +89,7 @@ struct FillTimelineChart: View {
     }
 
     var body: some View {
-        let cycles = visibleCycles(series: series)
+        let cycles = visibleCycles(series: series, limit: maxCycles(forWidth: stripWidth))
         VStack(alignment: .leading, spacing: 4) {
             HStack(alignment: .firstTextBaseline, spacing: 8) {
                 Text("Reset history")
@@ -67,7 +100,6 @@ struct FillTimelineChart: View {
                     .font(.system(size: max(7.5, density.subtitleFontSize - 4)))
                     .foregroundStyle(.quaternary)
             }
-            earlyRefillMarks(cycles, tool: series.tool)
             cycleStrip(cycles, tool: series.tool, targetPercent: targetPercent)
             Text(caption(cycles))
                 .font(.system(size: max(8, density.subtitleFontSize - 3), design: .rounded).monospacedDigit())
@@ -79,21 +111,34 @@ struct FillTimelineChart: View {
         .padding(.top, 4)
     }
 
-    private func visibleCycles(series: FillTimelineSeries) -> [SubscriptionWindowSample] {
+    private func visibleCycles(
+        series: FillTimelineSeries,
+        limit: Int
+    ) -> [SubscriptionWindowSample] {
         let key = SubscriptionHistoryKey(accountId: series.accountId, bucketId: series.bucket.id)
         let samples = quotaService.historyByAccountBucket[key] ?? []
         // An equality check over the retained samples is far cheaper than the
-        // sort plus the per-element date resolution it drives.
-        if cycleCache.key == key, cycleCache.samples == samples {
+        // sort plus the per-element date resolution it drives. The limit is
+        // part of the key: it moves with the strip's width.
+        if cycleCache.key == key, cycleCache.limit == limit, cycleCache.samples == samples {
             return cycleCache.visible
         }
-        let visible = Array(samples.sorted { cycleDate($0) < cycleDate($1) }.suffix(Self.maxCycles))
+        let visible = Array(samples.sorted { cycleDate($0) < cycleDate($1) }.suffix(limit))
         cycleCache.key = key
         cycleCache.samples = samples
+        cycleCache.limit = limit
         cycleCache.visible = visible
         return visible
     }
 
+    /// The strip: one bar per cycle, the early-refill dots above them and the
+    /// safety target across them — all in one `Canvas`.
+    ///
+    /// One drawing surface because the count is now width-derived and can
+    /// reach sixty (`AGENTS.md` § 11: dense status history is one drawing
+    /// surface, not hundreds of views). The per-bar `ForEach` this replaces
+    /// was two views per cycle plus a second `ForEach` for the dots, and a
+    /// provider page draws one of these strips per bucket.
     @ViewBuilder
     private func cycleStrip(
         _ cycles: [SubscriptionWindowSample],
@@ -110,81 +155,111 @@ struct FillTimelineChart: View {
                 }
                 .frame(height: chartHeight)
         } else {
-            GeometryReader { geo in
-                let count = cycles.count
-                let barWidth = max(5, (geo.size.width - CGFloat(count - 1) * barSpacing) / CGFloat(count))
-                ZStack(alignment: .topLeading) {
-                    HStack(alignment: .bottom, spacing: barSpacing) {
-                        ForEach(Array(cycles.enumerated()), id: \.offset) { index, cycle in
-                            cycleBar(cycle, tool: tool, isHovered: hoveredIndex == index)
-                                .frame(width: barWidth, height: geo.size.height)
-                        }
+            Canvas(opaque: false, rendersAsynchronously: false) { context, size in
+                let accent = Theme.providerAccent(for: tool)
+                let barWidth = Self.barWidth(in: size.width, count: cycles.count, spacing: barSpacing)
+                let top = markerBand
+                let plotHeight = max(1, size.height - top)
+                for (index, cycle) in cycles.enumerated() {
+                    let x = CGFloat(index) * (barWidth + barSpacing)
+                    let isHovered = hoveredIndex == index
+                    let rect = CGRect(x: x, y: top, width: barWidth, height: plotHeight)
+                    let radius = min(3, barWidth / 2)
+                    context.fill(
+                        Path(roundedRect: rect, cornerRadius: radius, style: .continuous),
+                        with: .color(Theme.barTrack.opacity(isHovered ? 0.95 : 0.62))
+                    )
+                    // The 4% floor keeps a spent cycle visible as a sliver
+                    // rather than an empty track, exactly as the bars did when
+                    // they were views and scaled themselves.
+                    let percent = displayedPercent(cycle)
+                    let fillHeight = max(plotHeight * 0.04, plotHeight * percent / 100)
+                    context.fill(
+                        Path(
+                            roundedRect: CGRect(
+                                x: x,
+                                y: rect.maxY - fillHeight,
+                                width: barWidth,
+                                height: fillHeight
+                            ),
+                            cornerRadius: min(radius, fillHeight / 2),
+                            style: .continuous
+                        ),
+                        with: .color(accent.opacity(isHovered ? 1 : 0.86))
+                    )
+                    if !cycle.isCompleted {
+                        context.stroke(
+                            Path(roundedRect: rect, cornerRadius: radius, style: .continuous),
+                            with: .color(accent.opacity(0.9)),
+                            style: StrokeStyle(lineWidth: 1, dash: [3, 2])
+                        )
                     }
-                    if let targetPercent, targetPercent > 3, targetPercent < 97 {
-                        Path { path in
-                            let y = geo.size.height * (1 - targetPercent / 100)
-                            path.move(to: CGPoint(x: 0, y: y))
-                            path.addLine(to: CGPoint(x: geo.size.width, y: y))
-                        }
-                        .stroke(
-                            Color.primary.opacity(0.34),
-                            style: StrokeStyle(lineWidth: 1, dash: [4, 3])
+                    // Above the bar, not inside it: a cycle that spent all of
+                    // its quota fills its track to the top, where a marker
+                    // would be the same colour as the fill under it. Shrinks
+                    // with the bar so it never overlaps its neighbour.
+                    if cycle.refilledEarly {
+                        let diameter = min(3, barWidth)
+                        context.fill(
+                            Path(
+                                ellipseIn: CGRect(
+                                    x: rect.midX - diameter / 2,
+                                    y: max(0, top - diameter) / 2,
+                                    width: diameter,
+                                    height: diameter
+                                )
+                            ),
+                            with: .color(accent.opacity(0.8))
                         )
                     }
                 }
-                .contentShape(Rectangle())
-                .onContinuousHover { phase in
-                    switch phase {
-                    case .active(let location):
-                        hoveredIndex = min(max(0, Int(location.x / (barWidth + barSpacing))), count - 1)
-                    case .ended:
-                        hoveredIndex = nil
-                    }
+                if let targetPercent, targetPercent > 3, targetPercent < 97 {
+                    let y = top + plotHeight * (1 - targetPercent / 100)
+                    var path = Path()
+                    path.move(to: CGPoint(x: 0, y: y))
+                    path.addLine(to: CGPoint(x: size.width, y: y))
+                    context.stroke(
+                        path,
+                        with: .color(Color.primary.opacity(0.34)),
+                        style: StrokeStyle(lineWidth: 1, dash: [4, 3])
+                    )
                 }
             }
-            .frame(height: chartHeight)
-        }
-    }
-
-    private func cycleBar(_ cycle: SubscriptionWindowSample, tool: ToolType, isHovered: Bool) -> some View {
-        let percent = displayedPercent(cycle)
-        return ZStack(alignment: .bottom) {
-            RoundedRectangle(cornerRadius: 3, style: .continuous)
-                .fill(Theme.barTrack.opacity(isHovered ? 0.95 : 0.62))
-            RoundedRectangle(cornerRadius: 3, style: .continuous)
-                .fill(Theme.providerAccent(for: tool).opacity(isHovered ? 1 : 0.86))
-                .frame(maxHeight: .infinity)
-                .scaleEffect(x: 1, y: max(0.04, percent / 100), anchor: .bottom)
-        }
-        .overlay {
-            if !cycle.isCompleted {
-                RoundedRectangle(cornerRadius: 3, style: .continuous)
-                    .stroke(Theme.providerAccent(for: tool).opacity(0.9), style: StrokeStyle(lineWidth: 1, dash: [3, 2]))
+            .frame(height: chartHeight + markerBand)
+            .contentShape(Rectangle())
+            .onGeometryChange(for: CGFloat.self) { proxy in
+                proxy.size.width
+            } action: { width in
+                stripWidth = width
+            }
+            .onContinuousHover { phase in
+                switch phase {
+                case .active(let location):
+                    let barWidth = Self.barWidth(
+                        in: stripWidth,
+                        count: cycles.count,
+                        spacing: barSpacing
+                    )
+                    hoveredIndex = min(
+                        max(0, Int(location.x / (barWidth + barSpacing))),
+                        cycles.count - 1
+                    )
+                case .ended:
+                    hoveredIndex = nil
+                }
             }
         }
     }
 
-    /// Dots over the cycles that refilled before their window was up.
+    /// One bar's width. Shared by the draw and the hit test so the caption can
+    /// never describe a cycle the cursor is not over.
     ///
-    /// Above the bars rather than inside them: a cycle that spent all of its
-    /// quota fills its track to the top, where a marker would be the same
-    /// colour as the fill under it.
-    @ViewBuilder
-    private func earlyRefillMarks(
-        _ cycles: [SubscriptionWindowSample],
-        tool: ToolType
-    ) -> some View {
-        if cycles.contains(where: \.refilledEarly) {
-            HStack(alignment: .center, spacing: barSpacing) {
-                ForEach(Array(cycles.enumerated()), id: \.offset) { _, cycle in
-                    Circle()
-                        .fill(Theme.providerAccent(for: tool).opacity(cycle.refilledEarly ? 0.8 : 0))
-                        .frame(width: 3, height: 3)
-                        .frame(maxWidth: .infinity)
-                }
-            }
-            .frame(height: 4)
-        }
+    /// No lower floor: the count is chosen so the natural width clears
+    /// `preferredBarWidth`, and flooring it instead would push the last bars
+    /// off the end of the strip during the frame after a resize.
+    private static func barWidth(in width: CGFloat, count: Int, spacing: CGFloat) -> CGFloat {
+        guard count > 0 else { return 0 }
+        return max(1, (width - CGFloat(count - 1) * spacing) / CGFloat(count))
     }
 
     @ViewBuilder

--- a/Sources/VibeBarApp/Views/ResetHistoryCompareView.swift
+++ b/Sources/VibeBarApp/Views/ResetHistoryCompareView.swift
@@ -330,8 +330,28 @@ struct ResetHistoryCompareCard: View {
     /// history plus its cached quotas.
     @EnvironmentObject private var quotaService: QuotaService
 
-    @State private var window: ResetHistoryComparison.Window = .eight
+    /// The window the user picked, if they picked one. `nil` means "still on
+    /// the default", which is derived from how much room the card actually got
+    /// rather than hard-coded — a card half the popover wide and one filling
+    /// the Workbench are the same module with very different space.
+    ///
+    /// Session state, as before: an explicit choice sticks until the popover
+    /// closes, and only the *initial* value became width-derived.
+    @State private var chosenWindow: ResetHistoryComparison.Window?
+    /// The card's content width, updated only when it actually changes —
+    /// `onGeometryChange` fires on a new value, not on every layout pass.
+    ///
+    /// Measured rather than derived from `density.popoverWidth`: this card
+    /// sits in an Overview column, a provider page's wide column and a full
+    /// Workbench page, and only one of those is a function of the popover.
+    @State private var cardWidth: CGFloat = 0
     @State private var cache = ResetHistoryComparisonCache()
+
+    private var window: ResetHistoryComparison.Window {
+        chosenWindow ?? ResetHistoryComparison.defaultWindow(
+            chartWidth: Double(max(0, cardWidth - ResetHistoryCompareLayout.chartX(for: density)))
+        )
+    }
 
     /// Persisted, not `@State`: switching the Overview's copy switches the
     /// provider pages' and the Workbench's too, which is what a reader who
@@ -352,6 +372,14 @@ struct ResetHistoryCompareCard: View {
         CardShell(density: density, spacing: 8) {
             header
             summary(comparison)
+                // Inside the shell, so this is the card's *content* width —
+                // the shell's own width would include its padding and make
+                // every plot look wider than it is.
+                .onGeometryChange(for: CGFloat.self) { proxy in
+                    proxy.size.width
+                } action: { width in
+                    cardWidth = width
+                }
             if comparison.isEmpty {
                 Text("Nothing to compare yet — weekly and longer quotas appear here once a provider reports one.")
                     .font(.system(size: density.subtitleFontSize))
@@ -420,7 +448,7 @@ struct ResetHistoryCompareCard: View {
         HStack(spacing: 1) {
             ForEach(ResetHistoryComparison.Window.allCases, id: \.self) { option in
                 Button {
-                    window = option
+                    chosenWindow = option
                 } label: {
                     Text(option.shortTitle(for: axis))
                         .font(.system(size: max(8.5, density.segmentedFontSize - 1.5), weight: .semibold, design: .rounded))
@@ -486,9 +514,11 @@ struct ResetHistoryCompareLayout: Equatable {
     let titleFontSize: CGFloat
     let captionFontSize: CGFloat
     let titleLineHeight: CGFloat
-    /// Label lines every row reserves, so the grid stays even whether or not
-    /// a particular name needs the second one.
-    let titleLineLimit = 2
+    /// Label lines every row reserves. Exactly two, always: the SubProvider
+    /// on the first and the group/bucket on the second. A fixed count is what
+    /// keeps the caption under it on one line across the whole table — the
+    /// wrapped version moved it up or down per row.
+    let labelLineCount = 2
     let now: Date
     /// Which grid the bars sit on. Everything above this line — heading
     /// heights, label block, track height, row rhythm — is identical for both,
@@ -516,16 +546,11 @@ struct ResetHistoryCompareLayout: Equatable {
         // in full — the first version clipped every row at about twenty
         // characters, which is the complaint this layout exists to answer.
         switch density.profile {
-        case .compact:
-            trackHeight = 26
-            labelWidth = 176
-        case .regular:
-            trackHeight = 30
-            labelWidth = 202
-        case .spacious:
-            trackHeight = 36
-            labelWidth = 232
+        case .compact: trackHeight = 26
+        case .regular: trackHeight = 30
+        case .spacious: trackHeight = 36
         }
+        labelWidth = Self.labelWidth(for: density)
         titleFontSize = max(9, density.subtitleFontSize - 0.5)
         captionFontSize = max(8, density.subtitleFontSize - 2)
         titleLineHeight = titleFontSize + 3
@@ -535,7 +560,7 @@ struct ResetHistoryCompareLayout: Equatable {
         // Two label lines plus the caption, or the bar track, whichever is
         // taller. Uniform per density: this is a table, and a table's rows
         // line up.
-        let labelBlock = CGFloat(titleLineLimit) * titleLineHeight + captionFontSize + 4
+        let labelBlock = CGFloat(labelLineCount) * titleLineHeight + captionFontSize + 4
         let rowHeight = max(trackHeight, labelBlock) + markerBand + rowGap
         self.rowHeight = rowHeight
         headingHeight = max(16, titleFontSize + 8)
@@ -563,6 +588,21 @@ struct ResetHistoryCompareLayout: Equatable {
         self.rowTops = rowTops
         self.laneTops = laneTops
         rowsHeight = y
+    }
+
+    /// Width of the label column, resolved from density alone — the card asks
+    /// for it before there is a comparison to build a layout from.
+    static func labelWidth(for density: Theme.Density) -> CGFloat {
+        switch density.profile {
+        case .compact: 176
+        case .regular: 202
+        case .spacious: 232
+        }
+    }
+
+    /// Where the plot starts, for a card that has not been laid out yet.
+    static func chartX(for density: Theme.Density) -> CGFloat {
+        labelWidth(for: density) + CGFloat(10)
     }
 
     var totalHeight: CGFloat { rowsHeight + axisHeight }
@@ -965,11 +1005,19 @@ private struct ResetHistoryLanesCanvas: View, Equatable {
         )
     }
 
-    /// The row's name over its waste summary.
+    /// The row's name as two levels, over its waste summary.
     ///
-    /// The name wraps on its own separators rather than truncating: every row
-    /// reserves two lines, and the caption follows whatever the name actually
-    /// used, so a one-line row has no hole under it.
+    /// Line one is the SubProvider and line two is the quota inside it; they
+    /// are never joined and line one never wraps. The single wrapped string
+    /// this replaces broke wherever the column ran out — "ChatGPT Agentic ·
+    /// Weekly" on one row, "AntiGravity" over "Claude and GPT Models · Weekly"
+    /// on the next — so no two rows agreed on where the level boundary was.
+    /// Line two truncates rather than wrapping, because a third line would
+    /// push the caption out of the row every row it happened on.
+    ///
+    /// Weight and colour carry the hierarchy, not size: both lines are set at
+    /// `titleFontSize` so the reserved block height is exactly two lines
+    /// whatever the labels say.
     private func drawLabels(
         _ context: inout GraphicsContext,
         lane: ResetHistoryComparison.Lane,
@@ -977,24 +1025,40 @@ private struct ResetHistoryLanesCanvas: View, Equatable {
     ) {
         let maxWidth = layout.labelWidth - layout.labelGap
         var y = layout.laneTop(index) + layout.markerBand - 2
-        let lines = wrapped(
-            context,
-            lane.labelWithoutCompany,
-            font: .system(size: layout.titleFontSize, weight: .semibold),
-            color: Color.primary.opacity(0.88),
-            maxWidth: maxWidth,
-            lineLimit: layout.titleLineLimit
+        context.draw(
+            truncated(
+                context,
+                lane.subProvider,
+                font: .system(size: layout.titleFontSize, weight: .semibold),
+                color: Color.primary.opacity(0.88),
+                maxWidth: maxWidth
+            ),
+            at: CGPoint(x: 0, y: y),
+            anchor: .topLeading
         )
-        for line in lines {
-            context.draw(line, at: CGPoint(x: 0, y: y), anchor: .topLeading)
-            y += layout.titleLineHeight
+        y += layout.titleLineHeight
+        // Empty only for a lane whose bucket nothing could name; the line is
+        // still reserved so the caption below stays put.
+        if !lane.bucketLine.isEmpty {
+            context.draw(
+                truncated(
+                    context,
+                    lane.bucketLine,
+                    font: .system(size: layout.titleFontSize),
+                    color: Color.primary.opacity(0.58),
+                    maxWidth: maxWidth
+                ),
+                at: CGPoint(x: 0, y: y),
+                anchor: .topLeading
+            )
         }
+        y += layout.titleLineHeight
         context.draw(
             truncated(
                 context,
                 lane.wasteSummary,
                 font: .system(size: layout.captionFontSize, design: .rounded),
-                color: Color.primary.opacity(0.5),
+                color: Color.primary.opacity(0.45),
                 maxWidth: maxWidth
             ),
             at: CGPoint(x: 0, y: y + 1),
@@ -1206,53 +1270,6 @@ private struct ResetHistoryLanesCanvas: View, Equatable {
                 anchor: .topLeading
             )
         }
-    }
-
-    /// A name broken across at most `lineLimit` lines on its own " · "
-    /// separators, so "AntiGravity · Claude & GPT Models · Weekly" wraps where
-    /// a reader would break it instead of being cut at twenty characters.
-    /// The last line still truncates if even that will not fit.
-    private func wrapped(
-        _ context: GraphicsContext,
-        _ string: String,
-        font: Font,
-        color: Color,
-        maxWidth: CGFloat,
-        lineLimit: Int
-    ) -> [GraphicsContext.ResolvedText] {
-        let probe = CGSize(width: 10_000, height: 40)
-        func resolve(_ candidate: String) -> GraphicsContext.ResolvedText {
-            context.resolve(Text(candidate).font(font).foregroundStyle(color))
-        }
-        let full = resolve(string)
-        guard maxWidth > 0, full.measure(in: probe).width > maxWidth, lineLimit > 1 else {
-            return [truncated(context, string, font: font, color: color, maxWidth: maxWidth)]
-        }
-        let separator = " · "
-        let parts = string.components(separatedBy: separator)
-        guard parts.count > 1 else {
-            return [truncated(context, string, font: font, color: color, maxWidth: maxWidth)]
-        }
-        var lines: [String] = []
-        var current = ""
-        for part in parts {
-            let candidate = current.isEmpty ? part : current + separator + part
-            if current.isEmpty || resolve(candidate).measure(in: probe).width <= maxWidth {
-                current = candidate
-                continue
-            }
-            lines.append(current)
-            current = part
-        }
-        if !current.isEmpty { lines.append(current) }
-        if lines.count > lineLimit {
-            // Everything that did not fit joins the last allowed line, which
-            // then truncates — better a trailing ellipsis than a dropped
-            // bucket name.
-            let tail = lines[(lineLimit - 1)...].joined(separator: separator)
-            lines = Array(lines.prefix(lineLimit - 1)) + [tail]
-        }
-        return lines.map { truncated(context, $0, font: font, color: color, maxWidth: maxWidth) }
     }
 
     /// Single-line text that fits `maxWidth`, with an ellipsis when it does

--- a/Sources/VibeBarCore/Models/ResetHistoryComparison.swift
+++ b/Sources/VibeBarCore/Models/ResetHistoryComparison.swift
@@ -391,7 +391,10 @@ public struct ResetHistoryComparison: Equatable, Sendable {
         /// were computed from.
         public var isTruncated: Bool { windowCycleCount > cycles.count }
 
-        /// Full quota-axis name: company · SubProvider · group · bucket.
+        /// Full quota-axis name on one line: company · SubProvider · group ·
+        /// bucket. The tooltip and the screen-reader summary use this — both
+        /// are prose, with no column to line levels up in. The row itself uses
+        /// `subProvider` over `bucketLine` instead.
         public var label: String {
             var parts = [company, subProvider]
             if let groupTitle, !groupTitle.isEmpty { parts.append(groupTitle) }
@@ -400,11 +403,21 @@ public struct ResetHistoryComparison: Equatable, Sendable {
             return parts.joined(separator: " · ")
         }
 
-        /// The row's own name: SubProvider / group / bucket, with the company
-        /// dropped because the heading above the group already carries it.
-        /// "Gemini Web / Weekly", "AntiGravity / Claude & GPT Models / Weekly".
-        public var labelWithoutCompany: String {
-            var parts = [subProvider]
+        /// Second line of the row label: the quota group and the bucket inside
+        /// the SubProvider, plus the account when the provider has more than
+        /// one of them.
+        ///
+        /// The row label is drawn as two *levels*, not as one string that
+        /// wraps: `subProvider` is line one and this is line two. Joined, they
+        /// read "ChatGPT Agentic · Weekly" and the break landed wherever the
+        /// column happened to run out, so no two rows agreed on where the
+        /// SubProvider ended and the bucket began.
+        ///
+        /// The group and the bucket *are* one level, so they stay joined here —
+        /// "GPT-5.3 Codex Spark · Weekly" is one answer to "which quota", not
+        /// two. A lane whose L3 is only a bucket gets just the bucket.
+        public var bucketLine: String {
+            var parts: [String] = []
             if let groupTitle, !groupTitle.isEmpty { parts.append(groupTitle) }
             if !bucketTitle.isEmpty, bucketTitle != groupTitle { parts.append(bucketTitle) }
             if let accountLabel, !accountLabel.isEmpty { parts.append(accountLabel) }
@@ -681,6 +694,39 @@ public struct ResetHistoryComparison: Equatable, Sendable {
             totals: totals,
             verdict: verdict(lanes: ordered, totals: totals)
         )
+    }
+
+    // MARK: - Default window
+
+    /// A bar narrower than this is a hairline, not a bar. Twelve points of
+    /// bar plus the point-and-a-half of air `barRect` insets on each side.
+    public static let minimumComfortableColumnWidth: Double = 15
+
+    /// The window a card of this width should open on.
+    ///
+    /// The widest of the fixed steps whose columns still draw as bars. A card
+    /// half the popover wide and one filling the Workbench are the same module
+    /// with very different room, and a single hard-coded default left one of
+    /// them either sparse or crammed.
+    ///
+    /// `all` is never chosen for you: it is a deliberate "show me everything",
+    /// and on a lane with years of history it is exactly the choice that needs
+    /// to be made on purpose.
+    ///
+    /// One extra column is assumed for the cycle running now — the common case,
+    /// and guessing it wrong costs a slightly *wider* bar rather than a
+    /// narrower one.
+    public static func defaultWindow(
+        chartWidth: Double,
+        minimumColumnWidth: Double = minimumComfortableColumnWidth
+    ) -> Window {
+        for window in [Window.twelve, .eight, .four] {
+            guard let cycles = window.cycleLimit else { continue }
+            if chartWidth / Double(cycles + 1) >= minimumColumnWidth { return window }
+        }
+        // Fewer bars beats unreadable ones, so the narrowest step is the floor
+        // rather than an even narrower ad-hoc count.
+        return .four
     }
 
     // MARK: - Draw budget

--- a/Tests/VibeBarCoreTests/ResetHistoryComparisonTests.swift
+++ b/Tests/VibeBarCoreTests/ResetHistoryComparisonTests.swift
@@ -364,6 +364,55 @@ final class ResetHistoryComparisonTests: XCTestCase {
         )
     }
 
+    // MARK: - Default window
+
+    func testTheDefaultWindowIsTheWidestThatStillDrawsBars() {
+        // A card half the popover wide and one filling the Workbench are the
+        // same module with very different room; one hard-coded default left
+        // one of them sparse or crammed.
+        let minimum = ResetHistoryComparison.minimumComfortableColumnWidth
+        // Twelve cycles plus the live column need thirteen columns.
+        XCTAssertEqual(
+            ResetHistoryComparison.defaultWindow(chartWidth: 13 * minimum),
+            .twelve
+        )
+        // A hair under, and twelve would be hairlines — so eight it is.
+        XCTAssertEqual(
+            ResetHistoryComparison.defaultWindow(chartWidth: 13 * minimum - 1),
+            .eight
+        )
+        XCTAssertEqual(
+            ResetHistoryComparison.defaultWindow(chartWidth: 9 * minimum),
+            .eight
+        )
+        XCTAssertEqual(
+            ResetHistoryComparison.defaultWindow(chartWidth: 9 * minimum - 1),
+            .four
+        )
+    }
+
+    func testTheNarrowestStepIsTheFloorRatherThanUnreadableBars() {
+        // Fewer bars beats bars nobody can read, so the count stops coming
+        // down at the narrowest step instead of inventing a narrower one.
+        XCTAssertEqual(ResetHistoryComparison.defaultWindow(chartWidth: 10), .four)
+        XCTAssertEqual(ResetHistoryComparison.defaultWindow(chartWidth: 0), .four)
+    }
+
+    func testAllIsNeverChosenForYou() {
+        // On a lane with years of history it is exactly the choice that has to
+        // be made on purpose.
+        for width in stride(from: 0.0, through: 4_000.0, by: 37.0) {
+            XCTAssertNotEqual(ResetHistoryComparison.defaultWindow(chartWidth: width), .all)
+        }
+    }
+
+    func testTheOverviewCardWidthPicksTwelveAndANarrowerHostPicksEight() {
+        // The widths this card actually gets: an Overview column at regular
+        // density leaves ~217pt of plot once the label column is taken off.
+        XCTAssertEqual(ResetHistoryComparison.defaultWindow(chartWidth: 217), .twelve)
+        XCTAssertEqual(ResetHistoryComparison.defaultWindow(chartWidth: 160), .eight)
+    }
+
     // MARK: - Picker labels
 
     func testThePickerLabelsCarryTheUnitOfTheirAxis() {
@@ -818,8 +867,57 @@ final class ResetHistoryComparisonTests: XCTestCase {
             samples: [sample(bucketId: "weekly_fable", endingDaysAgo: 7, used: 10)]
         )
         let lane = ResetHistoryComparison.build(inputs: [input], now: now).lanes[0]
+        // The joined form is for prose — the tooltip and the screen reader —
+        // where there is no column to line levels up in.
         XCTAssertEqual(lane.label, "Anthropic · Claude · Fable · Weekly")
-        XCTAssertEqual(lane.labelWithoutCompany, "Claude · Fable · Weekly")
+    }
+
+    func testTheRowLabelIsTwoLevelsAndNeverJoinsThem() {
+        // The complaint: one wrapped string broke wherever the column ran out,
+        // so "ChatGPT Agentic · Weekly" sat on one line and "AntiGravity" over
+        // "Claude and GPT Models · Weekly" on the next, and no two rows agreed
+        // on where the SubProvider ended.
+        let input = lane(
+            id: "gpt_5_3_codex_spark_weekly", tool: .codex, company: "OpenAI",
+            subProvider: "ChatGPT Agentic", group: "GPT-5.3 Codex Spark",
+            bucketTitle: "Weekly",
+            samples: [sample(bucketId: "gpt_5_3_codex_spark_weekly", endingDaysAgo: 7, used: 10)]
+        )
+        let lane = ResetHistoryComparison.build(inputs: [input], now: now).lanes[0]
+        XCTAssertEqual(lane.subProvider, "ChatGPT Agentic")
+        // The group and the bucket are one level, so they stay joined.
+        XCTAssertEqual(lane.bucketLine, "GPT-5.3 Codex Spark · Weekly")
+        XCTAssertFalse(lane.subProvider.contains("·"))
+    }
+
+    func testALaneWithNoGroupPutsOnlyTheBucketOnTheSecondLine() {
+        let input = lane(
+            id: "weekly", company: "OpenAI", subProvider: "ChatGPT Agentic",
+            bucketTitle: "Weekly",
+            samples: [sample(bucketId: "weekly", endingDaysAgo: 7, used: 10)]
+        )
+        let lane = ResetHistoryComparison.build(inputs: [input], now: now).lanes[0]
+        XCTAssertEqual(lane.subProvider, "ChatGPT Agentic")
+        XCTAssertEqual(lane.bucketLine, "Weekly")
+    }
+
+    func testTheAccountQualifierRidesOnTheSecondLine() {
+        // Line one stays exactly the SubProvider, so two accounts of the same
+        // provider are told apart on line two rather than by widening line one.
+        let input = ResetHistoryLaneInput(
+            accountId: "acct",
+            tool: .gemini,
+            bucketId: "weekly",
+            company: "Google AI",
+            subProvider: "Gemini Web",
+            bucketTitle: "Weekly",
+            accountLabel: "second account",
+            liveWindowSeconds: 7 * 86_400,
+            samples: [sample(bucketId: "weekly", endingDaysAgo: 7, used: 10)]
+        )
+        let lane = ResetHistoryComparison.build(inputs: [input], now: now).lanes[0]
+        XCTAssertEqual(lane.subProvider, "Gemini Web")
+        XCTAssertEqual(lane.bucketLine, "Weekly · second account")
     }
 
     func testABucketTitleEqualToItsGroupIsNotRepeated() {
@@ -828,10 +926,11 @@ final class ResetHistoryComparisonTests: XCTestCase {
             group: "Weekly", bucketTitle: "Weekly",
             samples: [sample(bucketId: "grok_bot_weekly", endingDaysAgo: 7, used: 10)]
         )
-        XCTAssertEqual(
-            ResetHistoryComparison.build(inputs: [input], now: now).lanes[0].label,
-            "SpaceXAI · Grok Bot · Weekly"
-        )
+        let lane = ResetHistoryComparison.build(inputs: [input], now: now).lanes[0]
+        XCTAssertEqual(lane.label, "SpaceXAI · Grok Bot · Weekly")
+        // …and the row says it once, on the second line.
+        XCTAssertEqual(lane.subProvider, "Grok Bot")
+        XCTAssertEqual(lane.bucketLine, "Weekly")
     }
 
     // MARK: - Verdict


### PR DESCRIPTION
## Summary

Three maintainer requests on the reset-history surfaces.

- **Two-level row labels.** A row read `ChatGPT Agentic · Weekly` joined on one line while the next wrapped as `ChatGPT Agentic` / `GPT-5.3 Codex Spark · Weekly`, so the levels never lined up. Line 1 is now exactly the SubProvider, line 2 the bucket within it (`Weekly`, `GPT-5.3 Codex Spark · Weekly`, `Fable · Weekly`, and the account qualifier when there is one); neither wraps, line 2 truncates, and the joined form is kept for the tooltip and accessibility text where there is no column to align. `Lane.bucketLine` is built from `groupTitle`/`bucketTitle`/`accountLabel`, not by re-splitting a string.
- **Width-derived default window.** The card opens on the widest of 12 / 8 / 4 whose columns still clear a readable bar width (`minimumComfortableColumnWidth = 15`), never `All`. Measured: Overview 217 pt plot → 12, compact Overview → 12, provider right column → 12, a 160 pt plot → 8. An explicit pick still wins and sticks; only the initial value is derived, once per width change.
- **Per-bucket strip shows the history it has.** `FillTimelineChart` drew a fixed 12 cycles while the store holds 908 samples (206 completed cycles on the busiest lane, retention unlimited). It now draws as many as fit at a ~6 pt bar, floored at 4 and capped at 60 — 37–42 at real widths. That meant converting the strip to a single `Canvas`: two views per bar was fine at 12 and ~120 views per bucket at 60, which AGENTS.md § 11 forbids for a strip drawn once per bucket. Early-refill dots moved into a reserved band so the strip no longer changes height when a cycle refills early.

Legibility is preserved by lowering the count, not thinning the bars, in both places.

## Test plan

- [x] `swift build`
- [x] `swift test` — 1991 tests, 0 failures (7 new: two-level label with and without a group, account qualifier on line 2, widest-readable window, floor step, `All` never auto-selected, real Overview/narrow widths)
- [ ] After install: Overview rows read as two aligned levels; the card opens on 12 there and 8 in a narrow host; the Subscription Utilization strip shows dozens of cycles with the dashed current bar and early-refill dots still legible

🤖 Generated with [Claude Code](https://claude.com/claude-code)