### PR TITLE
Bump build number to 64 for the 1.6.2 Dev release

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.6.2</string>
 	<key>CFBundleVersion</key>
-	<string>63</string>
+	<string>64</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>26.0</string>
 	<key>LSUIElement</key>


### PR DESCRIPTION
## Summary

`CFBundleVersion` 63 → 64 (`CFBundleShortVersionString` stays 1.6.2). Bundle ID unchanged, entitlements still an empty `<dict/>`, `SUPublicEDKey` / `SUFeedURL` untouched.

Adds on top of dev.63:
- #302 the comparison's row labels split into their two levels (SubProvider on line 1, the bucket within it on line 2, neither wrapping), the card's window defaults by width (12 / 8 / 4, never All), and the per-bucket strip draws as many cycles as fit instead of a fixed twelve.
- #303 an opt-in that combines a group's quota windows into one menu-bar entry — `5%/100%`, each percentage in its own colour, one label and one badge per entry, with the accessibility text still naming each window.

To be tagged `v1.6.2-dev.64` (Dev channel).

## Test plan

- [x] `swift build`
- [x] `swift test` — 2006 tests, 0 failures
- [x] `./Scripts/build_app.sh release`
- [x] `codesign -d --entitlements -` is an empty `<dict/>`; `codesign --verify --deep --strict` passes
- [x] Packaged `Info.plist` reads 1.6.2 (64)
- [ ] Tag → workflow → draft asset inspection (`<sparkle:channel>dev`) → publish as prerelease → install

🤖 Generated with [Claude Code](https://claude.com/claude-code)