### PR TITLE
Compose the menu-bar strip out of typed blocks

### DIFF
--- a/Resources/i18n/_schema.json
+++ b/Resources/i18n/_schema.json
@@ -5,7 +5,7 @@
   "description": "One language catalog. A flat map of stable dotted key to entry, so the file diffs by key and a translator never has to reason about nesting. Files beginning with '_' in this directory are metadata, not catalogs. Placeholders are named and brace-delimited ({provider}, {days}); printf specifiers are rejected, because the positional order they encode is exactly what a second language reorders and because the cross-platform client cannot render them. Plurals are ICU (`{count, plural, one {...} other {...}}`) with '#' standing for the number; Simplified Chinese has only the 'other' category and English needs 'one' and 'other'. Only Scripts/build_localizations.py reads these files - it compiles them into .strings, .stringsdict and a typed Swift API, all checked in, so no build depends on this directory or on Python.",
   "type": "object",
   "propertyNames": {
-    "pattern": "^(common|popover|quota|cost|status|usage|workbench|onboarding|settings|error|platform)(\\.[A-Za-z0-9_]+)+$",
+    "pattern": "^(common|menuBar|popover|quota|cost|status|usage|workbench|onboarding|settings|error|platform)(\\.[A-Za-z0-9_]+)+$",
     "description": "Surface scope, then a dotted path. The scope says where the string is read. 'platform.macos.*' is for copy only one client can ever show; everything else must be renderable by a React client too."
   },
   "additionalProperties": {

--- a/Resources/i18n/en.json
+++ b/Resources/i18n/en.json
@@ -914,6 +914,10 @@
     "comment": "What the Two rows template does.",
     "value": "Two stacked rows in one status item."
   },
+  "menuBar.composer.text.empty": {
+    "comment": "Shown under the text field when the selected text block has nothing in it.",
+    "value": "An empty text block draws nothing. Type something for it to appear in the menu bar."
+  },
   "menuBar.composer.text.limit": {
     "comment": "Explains that long text is cut short in the bar. Count is the character ceiling.",
     "value": "Blocks longer than {count} characters are cut short with an ellipsis in the bar.",

--- a/Resources/i18n/en.json
+++ b/Resources/i18n/en.json
@@ -598,6 +598,393 @@
     "comment": "QuotaError: unclassified failure; reason is the underlying message, untranslated",
     "value": "Error: {reason}"
   },
+  "menuBar.composer.action.duplicate": {
+    "comment": "Button copying the selected block.",
+    "value": "Duplicate"
+  },
+  "menuBar.composer.action.remove": {
+    "comment": "Button deleting the selected block.",
+    "value": "Remove"
+  },
+  "menuBar.composer.appIcon.detail": {
+    "comment": "What the app-icon block shows.",
+    "value": "Vibe Bar's own icon — what the Icon Only layout shows."
+  },
+  "menuBar.composer.block.appIcon": {
+    "comment": "A block showing the app's own icon.",
+    "value": "Vibe Bar icon"
+  },
+  "menuBar.composer.block.emptyText": {
+    "comment": "Chip label for a text block with nothing typed in it.",
+    "value": "Empty text"
+  },
+  "menuBar.composer.block.gap": {
+    "comment": "Chip label for a separator block with nothing typed in it.",
+    "value": "Gap"
+  },
+  "menuBar.composer.block.logo": {
+    "comment": "A block showing a provider's brand mark.",
+    "value": "Logo"
+  },
+  "menuBar.composer.block.newRow": {
+    "comment": "A block that ends one row and starts the next.",
+    "value": "New row"
+  },
+  "menuBar.composer.block.quota": {
+    "comment": "A block showing a number read from a quota.",
+    "value": "Quota"
+  },
+  "menuBar.composer.block.separator": {
+    "comment": "A block that draws a divider the user chose.",
+    "value": "Separator"
+  },
+  "menuBar.composer.block.space": {
+    "comment": "A block that draws blank space.",
+    "value": "Space"
+  },
+  "menuBar.composer.block.structure": {
+    "comment": "Palette group holding spacing and row blocks.",
+    "value": "Structure"
+  },
+  "menuBar.composer.block.text": {
+    "comment": "A block showing words the user typed.",
+    "value": "Text"
+  },
+  "menuBar.composer.blocks": {
+    "comment": "Caption over the reorderable list of blocks.",
+    "value": "Blocks — drag to reorder"
+  },
+  "menuBar.composer.blocks.empty": {
+    "comment": "Shown when the strip has no blocks.",
+    "value": "No blocks yet. Add one from the palette below."
+  },
+  "menuBar.composer.colour.automatic": {
+    "comment": "Colour choice: whatever the strip would use on its own.",
+    "value": "Automatic"
+  },
+  "menuBar.composer.colour.brand": {
+    "comment": "Colour choice: a provider's brand colour.",
+    "value": "Brand"
+  },
+  "menuBar.composer.colour.fixed": {
+    "comment": "Colour choice: a colour the user picks. Opens a colour well.",
+    "value": "Custom…"
+  },
+  "menuBar.composer.colour.followsQuota": {
+    "comment": "Colour choice: track another quota's colour.",
+    "value": "Follow a quota"
+  },
+  "menuBar.composer.colour.forecast": {
+    "comment": "Colour choice: the quota's forecast verdict colour.",
+    "value": "Forecast"
+  },
+  "menuBar.composer.colour.primary": {
+    "comment": "Colour choice: the menu bar's ordinary text colour.",
+    "value": "Primary"
+  },
+  "menuBar.composer.colour.secondary": {
+    "comment": "Colour choice: a quieter text colour.",
+    "value": "Secondary"
+  },
+  "menuBar.composer.colour.tertiary": {
+    "comment": "Colour choice: the quietest text colour.",
+    "value": "Tertiary"
+  },
+  "menuBar.composer.field.colour": {
+    "comment": "Picker choosing a block's colour.",
+    "value": "Colour"
+  },
+  "menuBar.composer.field.monospacedDigits": {
+    "comment": "Toggle keeping digits the same width.",
+    "value": "Monospaced digits"
+  },
+  "menuBar.composer.field.monospacedDigitsHelp": {
+    "comment": "Why monospaced digits matter.",
+    "value": "Keeps a changing number from shifting the blocks beside it."
+  },
+  "menuBar.composer.field.offlineOption": {
+    "comment": "A quota in a picker that is not currently being returned. Title is the quota's name.",
+    "value": "{title} (offline)"
+  },
+  "menuBar.composer.field.provider": {
+    "comment": "Picker choosing which provider's logo a block shows.",
+    "value": "Provider"
+  },
+  "menuBar.composer.field.show": {
+    "comment": "Picker choosing when a block is on screen.",
+    "value": "Show"
+  },
+  "menuBar.composer.field.shows": {
+    "comment": "Picker choosing which number a quota block prints.",
+    "value": "Shows"
+  },
+  "menuBar.composer.field.size": {
+    "comment": "Picker choosing a block's type size.",
+    "value": "Size"
+  },
+  "menuBar.composer.field.verdicts": {
+    "comment": "Checkboxes choosing which forecast verdicts show a block.",
+    "value": "Verdicts"
+  },
+  "menuBar.composer.field.weight": {
+    "comment": "Picker choosing a block's type weight.",
+    "value": "Weight"
+  },
+  "menuBar.composer.metric.displayPercent": {
+    "comment": "Quota metric: whichever percentage the app-wide Used/Remaining setting selects.",
+    "value": "Percent (follows setting)"
+  },
+  "menuBar.composer.metric.forecastPercent": {
+    "comment": "Quota metric: the projected figure when the quota refills.",
+    "value": "Forecast at reset"
+  },
+  "menuBar.composer.metric.label": {
+    "comment": "Quota metric: the quota's own name.",
+    "value": "Name"
+  },
+  "menuBar.composer.metric.pace": {
+    "comment": "Quota metric: distance from the linear expectation.",
+    "value": "Pace"
+  },
+  "menuBar.composer.metric.remainingPercent": {
+    "comment": "Quota metric: the remaining percentage.",
+    "value": "Remaining %"
+  },
+  "menuBar.composer.metric.resetAt": {
+    "comment": "Quota metric: the wall-clock time of the refill.",
+    "value": "Resets at"
+  },
+  "menuBar.composer.metric.resetsIn": {
+    "comment": "Quota metric: countdown to the refill.",
+    "value": "Resets in"
+  },
+  "menuBar.composer.metric.runsOutIn": {
+    "comment": "Quota metric: countdown to projected exhaustion.",
+    "value": "Runs out in"
+  },
+  "menuBar.composer.metric.usedPercent": {
+    "comment": "Quota metric: the used percentage.",
+    "value": "Used %"
+  },
+  "menuBar.composer.mode.custom": {
+    "comment": "Segment: the strip the user assembles out of blocks.",
+    "value": "Custom"
+  },
+  "menuBar.composer.mode.customCaption": {
+    "comment": "Caption under the mode picker while Custom is selected; reassures that switching back is not destructive.",
+    "value": "Switching back to Default keeps every block you built — you can return to Custom and find it exactly as you left it."
+  },
+  "menuBar.composer.mode.default": {
+    "comment": "Segment: the field-list strip the app has always drawn.",
+    "value": "Default"
+  },
+  "menuBar.composer.mode.defaultCaption": {
+    "comment": "Caption under the mode picker while Default is selected.",
+    "value": "Default shows the fields you tick below. Custom lets you build the strip out of blocks: logos, words, and any quota."
+  },
+  "menuBar.composer.mode.label": {
+    "comment": "Segmented control choosing how the menu-bar strip is built.",
+    "value": "Strip"
+  },
+  "menuBar.composer.newRow.capped": {
+    "comment": "Tooltip on the New row palette button once both rows are used.",
+    "value": "The menu bar can only draw two rows."
+  },
+  "menuBar.composer.newRow.detail": {
+    "comment": "What a new-row block does, and that it accepts a rule.",
+    "value": "Ends the first row and starts the second. Give it a rule below to split only when that quota says so."
+  },
+  "menuBar.composer.newRow.help": {
+    "comment": "Tooltip on the New row palette button when a second row is still available.",
+    "value": "Split the strip into a second row."
+  },
+  "menuBar.composer.palette": {
+    "comment": "Caption over the list of blocks that can be added.",
+    "value": "Add a block"
+  },
+  "menuBar.composer.preview": {
+    "comment": "Caption over the live preview of the composed strip.",
+    "value": "Preview"
+  },
+  "menuBar.composer.preview.dark": {
+    "comment": "Accessibility label for the dark-background preview.",
+    "value": "Dark menu bar preview"
+  },
+  "menuBar.composer.preview.empty": {
+    "comment": "Accessibility label for a preview with nothing to draw.",
+    "value": "Empty strip"
+  },
+  "menuBar.composer.preview.grounds": {
+    "comment": "Explains why the preview is shown twice.",
+    "value": "Light and dark menu bars, side by side — a fixed colour that reads well on one can vanish on the other."
+  },
+  "menuBar.composer.preview.light": {
+    "comment": "Accessibility label for the light-background preview.",
+    "value": "Light menu bar preview"
+  },
+  "menuBar.composer.preview.twoRowScaling": {
+    "comment": "Explains that a two-row strip is scaled to fit the menu bar's height.",
+    "value": "Two rows share the menu bar's height, so large sizes are scaled down to fit — the preview scales with them."
+  },
+  "menuBar.composer.removeTarget": {
+    "comment": "Drop target that deletes the dragged block.",
+    "value": "Drag here to remove"
+  },
+  "menuBar.composer.rule.always": {
+    "comment": "Visibility rule: the block is always shown.",
+    "value": "Always"
+  },
+  "menuBar.composer.rule.whenForecast": {
+    "comment": "Visibility rule: show only for chosen forecast verdicts.",
+    "value": "When the forecast says"
+  },
+  "menuBar.composer.rule.whenRemainingAtMost": {
+    "comment": "Visibility rule: show once a quota's remaining percentage falls to a threshold.",
+    "value": "When remaining is at most"
+  },
+  "menuBar.composer.rule.whenUsedAtLeast": {
+    "comment": "Visibility rule: show once a quota's used percentage reaches a threshold.",
+    "value": "When used is at least"
+  },
+  "menuBar.composer.selected": {
+    "comment": "Caption over the controls for the selected block.",
+    "value": "Selected block"
+  },
+  "menuBar.composer.size.large": {
+    "comment": "Type size choice.",
+    "value": "Large"
+  },
+  "menuBar.composer.size.regular": {
+    "comment": "Type size choice.",
+    "value": "Regular"
+  },
+  "menuBar.composer.size.small": {
+    "comment": "Type size choice.",
+    "value": "Small"
+  },
+  "menuBar.composer.space.detail": {
+    "comment": "What a space block does.",
+    "value": "A gap one space wide. Size changes how wide."
+  },
+  "menuBar.composer.startOver": {
+    "comment": "Button rebuilding every block from the default strip.",
+    "value": "Start over from the current strip…"
+  },
+  "menuBar.composer.startOver.confirm": {
+    "comment": "Destructive button in the confirmation dialog.",
+    "value": "Start over"
+  },
+  "menuBar.composer.startOver.confirmMessage": {
+    "comment": "Body of the confirmation dialog.",
+    "value": "Every block you arranged is discarded and rebuilt from the default strip."
+  },
+  "menuBar.composer.startOver.confirmTitle": {
+    "comment": "Title of the confirmation dialog.",
+    "value": "Replace your blocks?"
+  },
+  "menuBar.composer.startOver.detail": {
+    "comment": "Warns that starting over cannot be undone.",
+    "value": "Starting over replaces every block with a fresh copy of the default strip. There is no undo."
+  },
+  "menuBar.composer.template": {
+    "comment": "Picker choosing a starting set of spacing and type sizes.",
+    "value": "Template"
+  },
+  "menuBar.composer.template.compact": {
+    "comment": "Template name.",
+    "value": "Compact"
+  },
+  "menuBar.composer.template.compactDetail": {
+    "comment": "What the Compact template does.",
+    "value": "Tight spacing and a slightly smaller face."
+  },
+  "menuBar.composer.template.roomy": {
+    "comment": "Template name.",
+    "value": "Roomy"
+  },
+  "menuBar.composer.template.roomyDetail": {
+    "comment": "What the Roomy template does.",
+    "value": "Today's size, with more air between blocks."
+  },
+  "menuBar.composer.template.twoRows": {
+    "comment": "Template name: two stacked rows.",
+    "value": "Two rows"
+  },
+  "menuBar.composer.template.twoRowsDetail": {
+    "comment": "What the Two rows template does.",
+    "value": "Two stacked rows in one status item."
+  },
+  "menuBar.composer.text.limit": {
+    "comment": "Explains that long text is cut short in the bar. Count is the character ceiling.",
+    "value": "Blocks longer than {count} characters are cut short with an ellipsis in the bar.",
+    "args": {
+      "count": "int"
+    }
+  },
+  "menuBar.composer.text.placeholder": {
+    "comment": "Starting content of a newly added text block, before the user types over it.",
+    "value": "Label"
+  },
+  "menuBar.composer.warning.degraded": {
+    "comment": "Shown on a block whose colour or rule points at a quota that is not being returned.",
+    "value": "This block still draws, but a colour or a rule on it points at a quota that is not being returned right now."
+  },
+  "menuBar.composer.warning.missing": {
+    "comment": "Lists the quotas that are not answering. Fields is a comma-separated list of quota names.",
+    "value": "Not answering right now: {fields}"
+  },
+  "menuBar.composer.warning.silent": {
+    "comment": "Shown on a block whose quota is not being returned.",
+    "value": "This quota is not being returned right now, so this block draws nothing. It stays here and comes back on its own."
+  },
+  "menuBar.composer.weight.medium": {
+    "comment": "Type weight choice.",
+    "value": "Medium"
+  },
+  "menuBar.composer.weight.regular": {
+    "comment": "Type weight choice.",
+    "value": "Regular"
+  },
+  "menuBar.composer.weight.semibold": {
+    "comment": "Type weight choice.",
+    "value": "Semibold"
+  },
+  "menuBar.spoken.forecast": {
+    "comment": "One quota's projection spoken aloud.",
+    "value": "{label} forecast {value} left at reset"
+  },
+  "menuBar.spoken.pace": {
+    "comment": "One quota's pace spoken aloud; value is a signed percentage.",
+    "value": "{label} pace {value}"
+  },
+  "menuBar.spoken.remaining": {
+    "comment": "One quota spoken aloud, remaining rather than used.",
+    "value": "{label} {value} remaining"
+  },
+  "menuBar.spoken.resetAt": {
+    "comment": "One quota's refill time spoken aloud.",
+    "value": "{label} resets at {value}"
+  },
+  "menuBar.spoken.resetsIn": {
+    "comment": "One quota's refill countdown spoken aloud.",
+    "value": "{label} resets in {value}"
+  },
+  "menuBar.spoken.runsOutIn": {
+    "comment": "One quota's exhaustion countdown spoken aloud.",
+    "value": "{label} runs out in {value}"
+  },
+  "menuBar.spoken.title": {
+    "comment": "Accessibility label for the status item when nothing is being shown. Kind names the item.",
+    "value": "{kind} quota"
+  },
+  "menuBar.spoken.titleBody": {
+    "comment": "Accessibility label and tooltip for the status item. Body lists each quota in words.",
+    "value": "{kind} quota: {body}"
+  },
+  "menuBar.spoken.used": {
+    "comment": "One quota spoken aloud. Label is the quota's name, value an already-formatted percentage.",
+    "value": "{label} {value} used"
+  },
   "onboarding.apiKeys.hide": {
     "comment": "Button that folds a provider's credential form away",
     "value": "Hide"

--- a/Resources/i18n/en.json
+++ b/Resources/i18n/en.json
@@ -650,6 +650,10 @@
     "comment": "A block showing words the user typed.",
     "value": "Text"
   },
+  "menuBar.composer.block.unsupported": {
+    "comment": "Chip label for a block written by a newer version of the app that this one cannot draw.",
+    "value": "From a newer version"
+  },
   "menuBar.composer.blocks": {
     "comment": "Caption over the reorderable list of blocks.",
     "value": "Blocks — drag to reorder"
@@ -928,6 +932,10 @@
   "menuBar.composer.text.placeholder": {
     "comment": "Starting content of a newly added text block, before the user types over it.",
     "value": "Label"
+  },
+  "menuBar.composer.unsupported.detail": {
+    "comment": "Explains an unsupported block: it is kept so an upgrade restores it, and only removal applies.",
+    "value": "This block was made by a newer version of Vibe Bar. It is kept exactly as it was and will work again after an update; until then it draws nothing."
   },
   "menuBar.composer.warning.degraded": {
     "comment": "Shown on a block whose colour or rule points at a quota that is not being returned.",

--- a/Resources/i18n/en.json
+++ b/Resources/i18n/en.json
@@ -908,7 +908,7 @@
   },
   "menuBar.composer.template.roomyDetail": {
     "comment": "What the Roomy template does.",
-    "value": "Today's size, with more air between blocks."
+    "value": "The menu bar's usual size."
   },
   "menuBar.composer.template.twoRows": {
     "comment": "Template name: two stacked rows.",

--- a/Resources/i18n/zh-Hans.json
+++ b/Resources/i18n/zh-Hans.json
@@ -645,7 +645,7 @@
     "value": "宽松"
   },
   "menuBar.composer.template.roomyDetail": {
-    "value": "保持当前字号，积木之间留白更多。"
+    "value": "菜单栏的常规字号。"
   },
   "menuBar.composer.template.twoRows": {
     "value": "两行"

--- a/Resources/i18n/zh-Hans.json
+++ b/Resources/i18n/zh-Hans.json
@@ -413,6 +413,294 @@
   "error.unknownDetail": {
     "value": "错误：{reason}"
   },
+  "menuBar.composer.action.duplicate": {
+    "value": "复制"
+  },
+  "menuBar.composer.action.remove": {
+    "value": "移除"
+  },
+  "menuBar.composer.appIcon.detail": {
+    "value": "Vibe Bar 自身图标，即「仅图标」布局所显示的内容。"
+  },
+  "menuBar.composer.block.appIcon": {
+    "value": "Vibe Bar 图标"
+  },
+  "menuBar.composer.block.emptyText": {
+    "value": "空文字"
+  },
+  "menuBar.composer.block.gap": {
+    "value": "间隔"
+  },
+  "menuBar.composer.block.logo": {
+    "value": "图标"
+  },
+  "menuBar.composer.block.newRow": {
+    "value": "换行"
+  },
+  "menuBar.composer.block.quota": {
+    "value": "额度"
+  },
+  "menuBar.composer.block.separator": {
+    "value": "分隔符"
+  },
+  "menuBar.composer.block.space": {
+    "value": "空格"
+  },
+  "menuBar.composer.block.structure": {
+    "value": "结构"
+  },
+  "menuBar.composer.block.text": {
+    "value": "文字"
+  },
+  "menuBar.composer.blocks": {
+    "value": "积木 · 拖动可重新排序"
+  },
+  "menuBar.composer.blocks.empty": {
+    "value": "尚无积木。可从下方面板添加。"
+  },
+  "menuBar.composer.colour.automatic": {
+    "value": "自动"
+  },
+  "menuBar.composer.colour.brand": {
+    "value": "品牌色"
+  },
+  "menuBar.composer.colour.fixed": {
+    "value": "自定义…"
+  },
+  "menuBar.composer.colour.followsQuota": {
+    "value": "跟随某个额度"
+  },
+  "menuBar.composer.colour.forecast": {
+    "value": "预测"
+  },
+  "menuBar.composer.colour.primary": {
+    "value": "主要"
+  },
+  "menuBar.composer.colour.secondary": {
+    "value": "次要"
+  },
+  "menuBar.composer.colour.tertiary": {
+    "value": "第三级"
+  },
+  "menuBar.composer.field.colour": {
+    "value": "颜色"
+  },
+  "menuBar.composer.field.monospacedDigits": {
+    "value": "等宽数字"
+  },
+  "menuBar.composer.field.monospacedDigitsHelp": {
+    "value": "数字变化时不会挤动相邻积木。"
+  },
+  "menuBar.composer.field.offlineOption": {
+    "value": "{title}（未返回数据）"
+  },
+  "menuBar.composer.field.provider": {
+    "value": "厂商"
+  },
+  "menuBar.composer.field.show": {
+    "value": "显示条件"
+  },
+  "menuBar.composer.field.shows": {
+    "value": "显示内容"
+  },
+  "menuBar.composer.field.size": {
+    "value": "字号"
+  },
+  "menuBar.composer.field.verdicts": {
+    "value": "预测结论"
+  },
+  "menuBar.composer.field.weight": {
+    "value": "字重"
+  },
+  "menuBar.composer.metric.displayPercent": {
+    "value": "百分比（跟随设置）"
+  },
+  "menuBar.composer.metric.forecastPercent": {
+    "value": "重置时预测"
+  },
+  "menuBar.composer.metric.label": {
+    "value": "名称"
+  },
+  "menuBar.composer.metric.pace": {
+    "value": "消耗速度"
+  },
+  "menuBar.composer.metric.remainingPercent": {
+    "value": "剩余百分比"
+  },
+  "menuBar.composer.metric.resetAt": {
+    "value": "重置时刻"
+  },
+  "menuBar.composer.metric.resetsIn": {
+    "value": "重置倒计时"
+  },
+  "menuBar.composer.metric.runsOutIn": {
+    "value": "耗尽倒计时"
+  },
+  "menuBar.composer.metric.usedPercent": {
+    "value": "已用百分比"
+  },
+  "menuBar.composer.mode.custom": {
+    "value": "自定义"
+  },
+  "menuBar.composer.mode.customCaption": {
+    "value": "切回默认样式会保留已拼装的全部积木，再次切换到自定义时可原样恢复。"
+  },
+  "menuBar.composer.mode.default": {
+    "value": "默认"
+  },
+  "menuBar.composer.mode.defaultCaption": {
+    "value": "默认样式显示下方勾选的字段。自定义样式可用积木自行拼装：logo、文字与任意额度。"
+  },
+  "menuBar.composer.mode.label": {
+    "value": "样式"
+  },
+  "menuBar.composer.newRow.capped": {
+    "value": "菜单栏最多显示两行。"
+  },
+  "menuBar.composer.newRow.detail": {
+    "value": "结束第一行并开始第二行。可在下方设置条件，仅在该额度满足条件时换行。"
+  },
+  "menuBar.composer.newRow.help": {
+    "value": "将菜单栏内容拆成第二行。"
+  },
+  "menuBar.composer.palette": {
+    "value": "添加积木"
+  },
+  "menuBar.composer.preview": {
+    "value": "预览"
+  },
+  "menuBar.composer.preview.dark": {
+    "value": "深色菜单栏预览"
+  },
+  "menuBar.composer.preview.empty": {
+    "value": "空样式"
+  },
+  "menuBar.composer.preview.grounds": {
+    "value": "并排显示浅色与深色菜单栏：固定颜色在一种底色下清晰，在另一种下可能不可见。"
+  },
+  "menuBar.composer.preview.light": {
+    "value": "浅色菜单栏预览"
+  },
+  "menuBar.composer.preview.twoRowScaling": {
+    "value": "两行共用菜单栏高度，较大字号会等比缩小以适应，预览同步缩放。"
+  },
+  "menuBar.composer.removeTarget": {
+    "value": "拖到此处移除"
+  },
+  "menuBar.composer.rule.always": {
+    "value": "始终显示"
+  },
+  "menuBar.composer.rule.whenForecast": {
+    "value": "当预测结论为"
+  },
+  "menuBar.composer.rule.whenRemainingAtMost": {
+    "value": "剩余不高于"
+  },
+  "menuBar.composer.rule.whenUsedAtLeast": {
+    "value": "已用不低于"
+  },
+  "menuBar.composer.selected": {
+    "value": "已选积木"
+  },
+  "menuBar.composer.size.large": {
+    "value": "大"
+  },
+  "menuBar.composer.size.regular": {
+    "value": "标准"
+  },
+  "menuBar.composer.size.small": {
+    "value": "小"
+  },
+  "menuBar.composer.space.detail": {
+    "value": "宽度为一个空格的间隔。字号决定其宽度。"
+  },
+  "menuBar.composer.startOver": {
+    "value": "从当前样式重新开始…"
+  },
+  "menuBar.composer.startOver.confirm": {
+    "value": "重新开始"
+  },
+  "menuBar.composer.startOver.confirmMessage": {
+    "value": "已排列的全部积木将被丢弃，并按默认样式重新生成。"
+  },
+  "menuBar.composer.startOver.confirmTitle": {
+    "value": "替换已有积木？"
+  },
+  "menuBar.composer.startOver.detail": {
+    "value": "重新开始会用默认样式重新生成全部积木，且无法撤销。"
+  },
+  "menuBar.composer.template": {
+    "value": "模板"
+  },
+  "menuBar.composer.template.compact": {
+    "value": "紧凑"
+  },
+  "menuBar.composer.template.compactDetail": {
+    "value": "间距更紧，字号略小。"
+  },
+  "menuBar.composer.template.roomy": {
+    "value": "宽松"
+  },
+  "menuBar.composer.template.roomyDetail": {
+    "value": "保持当前字号，积木之间留白更多。"
+  },
+  "menuBar.composer.template.twoRows": {
+    "value": "两行"
+  },
+  "menuBar.composer.template.twoRowsDetail": {
+    "value": "在一个状态项中上下显示两行。"
+  },
+  "menuBar.composer.text.limit": {
+    "value": "超过 {count} 个字符的文字积木在菜单栏中会截断并以省略号结尾。"
+  },
+  "menuBar.composer.text.placeholder": {
+    "value": "标签"
+  },
+  "menuBar.composer.warning.degraded": {
+    "value": "此积木仍会显示，但其颜色或显示条件指向的额度当前未返回数据。"
+  },
+  "menuBar.composer.warning.missing": {
+    "value": "当前未返回数据：{fields}"
+  },
+  "menuBar.composer.warning.silent": {
+    "value": "该额度当前未返回数据，此积木暂不显示内容。积木会保留，数据恢复后自动显示。"
+  },
+  "menuBar.composer.weight.medium": {
+    "value": "中等"
+  },
+  "menuBar.composer.weight.regular": {
+    "value": "常规"
+  },
+  "menuBar.composer.weight.semibold": {
+    "value": "半粗"
+  },
+  "menuBar.spoken.forecast": {
+    "value": "{label} 预测重置时剩余 {value}"
+  },
+  "menuBar.spoken.pace": {
+    "value": "{label} 消耗速度 {value}"
+  },
+  "menuBar.spoken.remaining": {
+    "value": "{label} 剩余 {value}"
+  },
+  "menuBar.spoken.resetAt": {
+    "value": "{label} 于 {value} 重置"
+  },
+  "menuBar.spoken.resetsIn": {
+    "value": "{label} 距重置 {value}"
+  },
+  "menuBar.spoken.runsOutIn": {
+    "value": "{label} 距耗尽 {value}"
+  },
+  "menuBar.spoken.title": {
+    "value": "{kind} 额度"
+  },
+  "menuBar.spoken.titleBody": {
+    "value": "{kind} 额度：{body}"
+  },
+  "menuBar.spoken.used": {
+    "value": "{label} 已用 {value}"
+  },
   "onboarding.apiKeys.hide": {
     "value": "收起"
   },

--- a/Resources/i18n/zh-Hans.json
+++ b/Resources/i18n/zh-Hans.json
@@ -650,6 +650,9 @@
   "menuBar.composer.template.twoRowsDetail": {
     "value": "在一个状态项中上下显示两行。"
   },
+  "menuBar.composer.text.empty": {
+    "value": "空的文字积木不显示任何内容。输入文字后才会出现在菜单栏。"
+  },
   "menuBar.composer.text.limit": {
     "value": "超过 {count} 个字符的文字积木在菜单栏中会截断并以省略号结尾。"
   },

--- a/Resources/i18n/zh-Hans.json
+++ b/Resources/i18n/zh-Hans.json
@@ -452,6 +452,9 @@
   "menuBar.composer.block.text": {
     "value": "文字"
   },
+  "menuBar.composer.block.unsupported": {
+    "value": "来自更新版本"
+  },
   "menuBar.composer.blocks": {
     "value": "积木 · 拖动可重新排序"
   },
@@ -658,6 +661,9 @@
   },
   "menuBar.composer.text.placeholder": {
     "value": "标签"
+  },
+  "menuBar.composer.unsupported.detail": {
+    "value": "此积木由更新版本的 Vibe Bar 创建，将原样保留，更新后可恢复显示；在此之前不显示任何内容。"
   },
   "menuBar.composer.warning.degraded": {
     "value": "此积木仍会显示，但其颜色或显示条件指向的额度当前未返回数据。"

--- a/Scripts/build_localizations.py
+++ b/Scripts/build_localizations.py
@@ -68,6 +68,7 @@ LANGUAGES = ["en", "zh-Hans"]
 # permission — and everything outside it must be renderable by both.
 SCOPES = {
     "common": "Common",        # reused everywhere: Refresh, Cancel, units
+    "menuBar": "MenuBar",      # the status item itself and its composer editor
     "popover": "Popover",      # the menu-bar popover shell, tabs, cards
     "quota": "Quota",          # quota bars, buckets, forecast, reset history
     "cost": "Cost",            # cost cards, history, model ranking
@@ -80,7 +81,9 @@ SCOPES = {
     "platform": "Platform",    # macOS-only copy: platform.macos.*
 }
 
-KEY_PATTERN = re.compile(r"^[a-z][a-z0-9]*(?:\.[A-Za-z0-9_]+)+$")
+# The scope segment is camelCase-able so a two-word surface reads as one
+# word (`menuBar.*`), which is how the shared catalog spells it.
+KEY_PATTERN = re.compile(r"^[a-z][A-Za-z0-9]*(?:\.[A-Za-z0-9_]+)+$")
 NAME_PATTERN = re.compile(r"^[a-z][A-Za-z0-9]*$")
 
 # `{name}` — a simple substitution. Braces are only ever placeholders, so

--- a/Scripts/lint_localization.py
+++ b/Scripts/lint_localization.py
@@ -93,10 +93,6 @@ MIGRATED = [
     "Sources/VibeBarApp/Views/Workbench/SkillDiscoverSheet.swift",
     "Sources/VibeBarApp/Views/Workbench/SkillImportSheet.swift",
     "Sources/VibeBarApp/Views/Workbench/SkillBackupsSheet.swift",
-    # Settings, its panes, and the model types whose `label` / `title` /
-    # `detail` properties they render. An enum carrying a presentation string
-    # looks like a model detail and *is* UI: the picker label was localized
-    # while its choices stayed English until a reviewer caught it.
     "Sources/VibeBarApp/Views/SettingsSidebarView.swift",
     "Sources/VibeBarApp/Views/MCPSettingsSection.swift",
     "Sources/VibeBarApp/Views/MiniWindowsSettingsSection.swift",
@@ -133,6 +129,8 @@ MIGRATED = [
     "Sources/VibeBarApp/Views/CodexBarProviderBridgeCard.swift",
     "Sources/VibeBarApp/Views/RemoteMachinesPage.swift",
     "Sources/VibeBarApp/Views/RemoteMachinesPage.swift",
+    "Sources/VibeBarApp/Views/MenuBarComposerEditor.swift",
+    "Sources/VibeBarApp/Views/MenuBarStripView.swift",
 ]
 
 

--- a/Sources/VibeBarApp/AppEnvironment.swift
+++ b/Sources/VibeBarApp/AppEnvironment.swift
@@ -176,10 +176,20 @@ final class AppEnvironment: ObservableObject {
             // The menu bar selects from the same registry: a discovered
             // bucket shown only there must survive a response that
             // temporarily omits it.
+            //
+            // A composed strip is a *second* referrer, and one the default
+            // strip knows nothing about — a block can name a bucket the field
+            // list never selected, through the block itself, a colour that
+            // follows a quota, or a visibility rule. Its references are kept
+            // whether or not custom mode is currently on, because a stored
+            // composition is exactly the arrangement switching back restores.
             for kind in MenuBarItemKind.allCases {
                 let item = settings.menuBarItem(kind)
                 fieldIds.formUnion(item.selectedFieldIds)
                 fieldIds.formUnion(item.customLabels.keys)
+                if let composition = item.composition {
+                    fieldIds.formUnion(composition.referencedFieldIds)
+                }
             }
             return QuotaFieldKeepSet(fieldIds: fieldIds, groupKeys: groupKeys)
         }

--- a/Sources/VibeBarApp/StatusItemController.swift
+++ b/Sources/VibeBarApp/StatusItemController.swift
@@ -17,9 +17,33 @@ private enum MenuBarStatusMetrics {
     static let twoRowLogoGap: CGFloat = 2
 }
 
+/// One cell of the rasterized two-row status image, drawn left to right.
+///
+/// A composed row can put a logo anywhere — between two words, at the end —
+/// so a cell is a run list rather than one optional leading logo. Logos stay
+/// out of the attributed strings on purpose: the two-row canvas is about 10pt
+/// per band and a text attachment inflates its line box to 14pt no matter what
+/// bounds it declares, which pushes the second row out of the bar.
 private struct TwoRowMenuCell {
-    var text: NSAttributedString
-    var logo: NSImage?
+    enum Run {
+        case logo(NSImage)
+        case text(NSAttributedString)
+    }
+
+    var runs: [Run]
+
+    init(runs: [Run]) {
+        self.runs = runs
+    }
+
+    init(text: NSAttributedString, logo: NSImage? = nil) {
+        var runs: [Run] = []
+        if let logo { runs.append(.logo(logo)) }
+        runs.append(.text(text))
+        self.runs = runs
+    }
+
+    var isEmpty: Bool { runs.isEmpty }
 }
 
 private struct TwoRowMenuColumn {
@@ -90,6 +114,8 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
     /// Rendered brand-logo images keyed by tool, point size, and appearance —
     /// see `brandAttachment(for:fontSize:font:)`.
     private var brandAttachmentImages: [String: NSImage?] = [:]
+    /// Bridged provider accents for composed blocks wearing `.brand`.
+    private var brandAccentColors: [ToolType: NSColor] = [:]
 
     init(environment: AppEnvironment) {
         self.environment = environment
@@ -813,6 +839,20 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
             button.image = nil
             button.imagePosition = .noImage
             removeTwoRowStatusContent(from: button)
+            // Custom mode replaces the field walk outright — the composition
+            // owns its own rows, so it also supersedes `layout`. Everything
+            // the field path stores stays untouched underneath it.
+            if let composition = itemSettings.composition, composition.isEnabled {
+                installComposedContent(
+                    composition,
+                    in: button,
+                    item: item,
+                    kind: kind,
+                    itemSettings: itemSettings,
+                    settings: settings
+                )
+                continue
+            }
             // Resolved once and shared by every layout: the field walk, the
             // group merge, the bucket lookups, and the forecast colors all
             // happen here rather than inside each builder.
@@ -915,6 +955,313 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
         "\(Int(percent.rounded()))%"
     }
 
+    // MARK: - Composed strip
+
+    /// A composed strip resolved for one render: the draw plan plus the quota
+    /// snapshots it was planned against, kept together because the colour
+    /// roles the plan emits are resolved against those same snapshots.
+    private struct ComposedStrip {
+        var plan: MenuBarRenderPlan
+        var quotas: [MenuBarQuotaSnapshot]
+    }
+
+    private func installComposedContent(
+        _ composition: MenuBarComposition,
+        in button: NSStatusBarButton,
+        item: NSStatusItem,
+        kind: MenuBarItemKind,
+        itemSettings: MenuBarItemSettings,
+        settings: AppSettings
+    ) {
+        let strip = composedStrip(composition, itemSettings: itemSettings, settings: settings)
+        let rows = strip.plan.rows.filter { !$0.isEmpty }
+        if rows.count >= 2 {
+            let cells = rows.prefix(MenuBarComposition.maximumRows).map {
+                composedCell(row: $0, strip: strip, settings: settings)
+            }
+            installTwoRowImageContent(
+                in: button,
+                item: item,
+                columns: [TwoRowMenuColumn(top: cells[0], bottom: cells[1])]
+            )
+        } else {
+            // Every block the user kept fell away — no quota is answering, or
+            // every rule said no. Show the same "—" the field strip shows
+            // rather than an empty status item nobody can find to click. No
+            // title in front of it: in custom mode the title is a block the
+            // user may have deleted, so reviving it here would be a surprise.
+            button.attributedTitle = rows.isEmpty
+                ? Self.composedPlaceholder(fontSize: NSFont.smallSystemFontSize)
+                : composedAttributedRow(
+                    rows[0],
+                    strip: strip,
+                    settings: settings,
+                    baseFontSize: NSFont.smallSystemFontSize
+                )
+            item.length = NSStatusItem.variableLength
+        }
+        applyStatusDescription(body: strip.plan.spokenDescription, to: button, kind: kind)
+    }
+
+    /// Resolve the quotas the strip names, then plan it.
+    ///
+    /// Runs inside the 120 ms throttle, so it resolves each *distinct* field
+    /// exactly once — `quotaRequirements` is the deduplicated list, and a strip
+    /// that mentions one bucket three times still costs one bucket lookup and
+    /// at most one forecast. The forecast is only computed where a block, a
+    /// colour, or a rule reads one, plus the case the field path already pays
+    /// for: an automatic colour under the forecast basis.
+    private func composedStrip(
+        _ composition: MenuBarComposition,
+        itemSettings: MenuBarItemSettings,
+        settings: AppSettings
+    ) -> ComposedStrip {
+        let registry = environment.quotaService.fieldRegistry
+        let requirements = composition.quotaRequirements
+        let wantsForecastColors = settings.menuBarColorBasis == .forecast
+        let now = Date()
+        var quotas: [MenuBarQuotaSnapshot] = []
+        quotas.reserveCapacity(requirements.count)
+        for requirement in requirements {
+            guard
+                let field = MenuBarFieldCatalog.field(id: requirement.fieldId, registry: registry),
+                let bucket = environment.quota(for: field.tool)?.bucket(id: field.bucketId)
+            else { continue }
+            var forecast: MenuBarQuotaSnapshot.Forecast?
+            if requirement.needsForecast || wantsForecastColors,
+               let computed = paceForecast(for: field.tool, bucket: bucket) {
+                forecast = MenuBarQuotaSnapshot.Forecast(
+                    verdict: computed.verdict,
+                    projectedRemainingPercent: computed.projectedRemainingPercent,
+                    runOutAt: computed.runOutAt
+                )
+            }
+            let pace = requirement.needsPace
+                ? UsagePace.compute(bucket: bucket, now: now, allowsPostResetGrace: true)
+                : nil
+            quotas.append(MenuBarQuotaSnapshot(
+                fieldId: field.id,
+                tool: field.tool,
+                label: label(for: field, bucket: bucket, itemSettings: itemSettings),
+                usedPercent: bucket.usedPercent,
+                displayPercent: bucket.displayPercent(settings.displayMode, tool: field.tool),
+                resetAt: bucket.resetAt,
+                paceDeltaPercent: pace?.deltaPercent,
+                forecast: forecast
+            ))
+        }
+        return ComposedStrip(
+            plan: composition.plan(
+                quotas: quotas,
+                displayMode: settings.displayMode,
+                colorBasis: settings.menuBarColorBasis,
+                now: now
+            ),
+            quotas: quotas
+        )
+    }
+
+    /// One composed row as an attributed string. Used for a single-row strip,
+    /// where a logo can ride along as a text attachment.
+    private func composedAttributedRow(
+        _ row: MenuBarRenderRow,
+        strip: ComposedStrip,
+        settings: AppSettings,
+        baseFontSize: CGFloat
+    ) -> NSAttributedString {
+        let attributed = NSMutableAttributedString()
+        for (index, token) in row.tokens.enumerated() {
+            if index > 0, let gap = composedGap(strip.plan, baseFontSize: baseFontSize) {
+                attributed.append(gap)
+            }
+            let size = composedFontSize(token, baseFontSize: baseFontSize)
+            let font = composedFont(token, size: size)
+            if let tool = token.logo {
+                let tint = composedColor(token.color, strip: strip, settings: settings)
+                if let attachment = brandAttachment(
+                    for: tool,
+                    fontSize: size,
+                    font: font,
+                    tint: tint,
+                    tintKey: Self.tintKey(for: token.color, strip: strip, settings: settings)
+                ) {
+                    attributed.append(attachment)
+                }
+                continue
+            }
+            guard let text = token.text, !text.isEmpty else { continue }
+            attributed.append(NSAttributedString(
+                string: text,
+                attributes: [
+                    .foregroundColor: composedColor(token.color, strip: strip, settings: settings),
+                    .font: font
+                ]
+            ))
+        }
+        return attributed
+    }
+
+    /// One composed row as a rasterizer cell. Logos break the row into runs
+    /// instead of becoming attachments — see `TwoRowMenuCell`.
+    private func composedCell(
+        row: MenuBarRenderRow,
+        strip: ComposedStrip,
+        settings: AppSettings
+    ) -> TwoRowMenuCell {
+        let baseFontSize = MenuBarStatusMetrics.twoRowFontSize
+        var runs: [TwoRowMenuCell.Run] = []
+        var pending = NSMutableAttributedString()
+        func flush() {
+            if pending.length > 0 {
+                runs.append(.text(pending))
+                pending = NSMutableAttributedString()
+            }
+        }
+        for (index, token) in row.tokens.enumerated() {
+            if index > 0, let gap = composedGap(strip.plan, baseFontSize: baseFontSize) {
+                pending.append(gap)
+            }
+            if let tool = token.logo {
+                flush()
+                if let image = brandLogoImage(
+                    for: tool,
+                    side: MenuBarStatusMetrics.twoRowLogoSide,
+                    tint: composedColor(token.color, strip: strip, settings: settings),
+                    tintKey: Self.tintKey(for: token.color, strip: strip, settings: settings)
+                ) {
+                    runs.append(.logo(image))
+                }
+                continue
+            }
+            guard let text = token.text, !text.isEmpty else { continue }
+            pending.append(NSAttributedString(
+                string: text,
+                attributes: [
+                    .foregroundColor: composedColor(token.color, strip: strip, settings: settings),
+                    .font: composedFont(token, size: composedFontSize(token, baseFontSize: baseFontSize))
+                ]
+            ))
+        }
+        flush()
+        return TwoRowMenuCell(runs: runs)
+    }
+
+    /// What a composed strip shows when nothing survived.
+    private static func composedPlaceholder(fontSize: CGFloat) -> NSAttributedString {
+        NSAttributedString(
+            string: "—",
+            attributes: [
+                .foregroundColor: NSColor.tertiaryLabelColor,
+                .font: NSFont.monospacedDigitSystemFont(ofSize: fontSize, weight: .regular)
+            ]
+        )
+    }
+
+    /// The gap between two blocks, drawn as a space glyph at a scaled point
+    /// size — the same idiom the logo-to-label gap has always used, and the
+    /// only one that works in the two-row canvas, where an attachment would
+    /// inflate the line box.
+    private func composedGap(_ plan: MenuBarRenderPlan, baseFontSize: CGFloat) -> NSAttributedString? {
+        let spacing = plan.tokenSpacing
+        guard spacing > 0 else { return nil }
+        return NSAttributedString(
+            string: " ",
+            attributes: [.font: NSFont.systemFont(ofSize: max(1, baseFontSize * spacing))]
+        )
+    }
+
+    private func composedFontSize(_ token: MenuBarRenderedToken, baseFontSize: CGFloat) -> CGFloat {
+        max(4, baseFontSize * token.fontScale)
+    }
+
+    private func composedFont(_ token: MenuBarRenderedToken, size: CGFloat) -> NSFont {
+        let weight: NSFont.Weight
+        switch token.weight {
+        case .regular: weight = .regular
+        case .medium: weight = .medium
+        case .semibold: weight = .semibold
+        }
+        return token.monospacedDigits
+            ? NSFont.monospacedDigitSystemFont(ofSize: size, weight: weight)
+            : NSFont.systemFont(ofSize: size, weight: weight)
+    }
+
+    /// A composed block's colour. `.quota` goes through exactly the resolver
+    /// the field strip uses, so a block left on `.automatic` is the same
+    /// colour it would have been before the composer existed.
+    private func composedColor(
+        _ role: MenuBarTokenColorRole,
+        strip: ComposedStrip,
+        settings: AppSettings
+    ) -> NSColor {
+        switch role {
+        case let .quota(fieldId, basis):
+            guard let quota = strip.quotas.first(where: { $0.fieldId == fieldId }) else {
+                return .labelColor
+            }
+            return Self.nsColor(for: MenuBarPercentColor.resolve(
+                basis: basis,
+                verdict: basis == .forecast ? quota.forecast?.verdict : nil,
+                percent: quota.displayPercent,
+                displayMode: settings.displayMode
+            ))
+        case let .brand(tool):
+            return brandAccentColor(for: tool)
+        case .primary:
+            return .labelColor
+        case .secondary:
+            return .secondaryLabelColor
+        case .tertiary:
+            return .tertiaryLabelColor
+        case let .fixed(hex):
+            guard let parts = MenuBarHexColor.components(hex) else { return .labelColor }
+            return NSColor(srgbRed: parts.r, green: parts.g, blue: parts.b, alpha: parts.a)
+        }
+    }
+
+    /// Stable cache key for a resolved tint. Keyed on the colour's *role*
+    /// rather than the `NSColor`, whose description is not stable for a
+    /// dynamic system colour.
+    private static func tintKey(
+        for role: MenuBarTokenColorRole,
+        strip: ComposedStrip,
+        settings: AppSettings
+    ) -> String {
+        switch role {
+        case let .quota(fieldId, basis):
+            guard let quota = strip.quotas.first(where: { $0.fieldId == fieldId }) else {
+                return "label"
+            }
+            let resolved = MenuBarPercentColor.resolve(
+                basis: basis,
+                verdict: basis == .forecast ? quota.forecast?.verdict : nil,
+                percent: quota.displayPercent,
+                displayMode: settings.displayMode
+            )
+            switch resolved {
+            case .healthy: return "healthy"
+            case .surplus: return "surplus"
+            case .watch: return "watch"
+            case .risk: return "risk"
+            }
+        case let .brand(tool): return "brand.\(tool.rawValue)"
+        case .primary: return "label"
+        case .secondary: return "secondary"
+        case .tertiary: return "tertiary"
+        case let .fixed(hex): return "fixed\(hex)"
+        }
+    }
+
+    /// AppKit twin of the shared provider accent table, cached per tool: the
+    /// composer lets a block wear a provider's brand colour, and the status
+    /// item must not rebuild a bridged colour on every 120 ms render.
+    private func brandAccentColor(for tool: ToolType) -> NSColor {
+        if let cached = brandAccentColors[tool] { return cached }
+        let color = NSColor(Theme.providerAccent(for: tool))
+        brandAccentColors[tool] = color
+        return color
+    }
+
     /// The status item always *speaks* one clause per quota window, even when
     /// the bar draws a merged group as `5%/100%`: "Claude 5 Hours 5% used,
     /// Weekly 100% used". The shorthand is a space-saving glyph, not a
@@ -924,7 +1271,18 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
         to button: NSStatusBarButton,
         kind: MenuBarItemKind
     ) {
-        let body = pieces.map(\.spokenDescription).joined(separator: " · ")
+        applyStatusDescription(
+            body: pieces.map(\.spokenDescription).joined(separator: " · "),
+            to: button,
+            kind: kind
+        )
+    }
+
+    private func applyStatusDescription(
+        body: String,
+        to button: NSStatusBarButton,
+        kind: MenuBarItemKind
+    ) {
         let description = body.isEmpty
             ? "\(kind.label) quota"
             : "\(kind.label) quota: \(body)"
@@ -1199,23 +1557,15 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
     /// painted logos invisible on the opposite menu bar. Small fonts (the
     /// two-row layout) cap the icon at 10pt — a 12pt attachment grew the
     /// line and pushed the second row out of the bar.
-    private func brandAttachment(for tool: ToolType, fontSize: CGFloat, font: NSFont) -> NSAttributedString? {
+    private func brandAttachment(
+        for tool: ToolType,
+        fontSize: CGFloat,
+        font: NSFont,
+        tint: NSColor = .labelColor,
+        tintKey: String = "label"
+    ) -> NSAttributedString? {
         let side: CGFloat = (fontSize + 3).rounded()
-        let appearance = compactStatusItem?.button?.effectiveAppearance ?? NSApp.effectiveAppearance
-        let key = "\(tool.rawValue).\(side).\(appearance.name.rawValue)"
-        let image: NSImage?
-        if let cached = brandAttachmentImages[key] {
-            image = cached
-        } else {
-            image = ProviderBrandIcon.image(
-                for: tool,
-                size: NSSize(width: side, height: side),
-                tint: NSColor.labelColor,
-                appearance: appearance
-            )
-            brandAttachmentImages[key] = image
-        }
-        guard let image else { return nil }
+        guard let image = brandImage(for: tool, side: side, tint: tint, tintKey: tintKey) else { return nil }
         let attachment = NSTextAttachment()
         attachment.image = image
         let yOffset = (font.capHeight - side) / 2
@@ -1225,14 +1575,34 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
 
     /// Raw logo image for the two-row rasterizer's manual drawing — same
     /// cache the attachment path uses.
-    private func brandLogoImage(for tool: ToolType, side: CGFloat) -> NSImage? {
+    private func brandLogoImage(
+        for tool: ToolType,
+        side: CGFloat,
+        tint: NSColor = .labelColor,
+        tintKey: String = "label"
+    ) -> NSImage? {
+        brandImage(for: tool, side: side, tint: tint, tintKey: tintKey)
+    }
+
+    /// Rasterized brand mark, cached by tool, point size, appearance, and the
+    /// tint's *role* — a composed strip can paint a logo in a fixed colour or
+    /// in a quota's live verdict colour, and those must not collide in the
+    /// cache with the plain label-coloured one. `tintKey` is the role name
+    /// rather than the `NSColor`, whose description is not a stable key for a
+    /// dynamic system colour.
+    private func brandImage(
+        for tool: ToolType,
+        side: CGFloat,
+        tint: NSColor,
+        tintKey: String
+    ) -> NSImage? {
         let appearance = compactStatusItem?.button?.effectiveAppearance ?? NSApp.effectiveAppearance
-        let key = "\(tool.rawValue).\(side).\(appearance.name.rawValue)"
+        let key = "\(tool.rawValue).\(side).\(appearance.name.rawValue).\(tintKey)"
         if let cached = brandAttachmentImages[key] { return cached }
         let image = ProviderBrandIcon.image(
             for: tool,
             size: NSSize(width: side, height: side),
-            tint: NSColor.labelColor,
+            tint: tint,
             appearance: appearance
         )
         brandAttachmentImages[key] = image
@@ -1273,25 +1643,43 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
     }
 
     nonisolated private static func cellWidth(_ cell: TwoRowMenuCell) -> CGFloat {
-        let logoWidth = cell.logo == nil
-            ? 0
-            : MenuBarStatusMetrics.twoRowLogoSide + MenuBarStatusMetrics.twoRowLogoGap
-        return logoWidth + cell.text.size().width
+        var width: CGFloat = 0
+        for (index, run) in cell.runs.enumerated() {
+            if index > 0 { width += MenuBarStatusMetrics.twoRowLogoGap }
+            switch run {
+            case .logo: width += MenuBarStatusMetrics.twoRowLogoSide
+            case let .text(text): width += text.size().width
+            }
+        }
+        return width
+    }
+
+    /// Tallest text run in the cell; a logo-only cell falls back to the logo
+    /// box so its row band does not collapse to nothing.
+    nonisolated private static func cellHeight(_ cell: TwoRowMenuCell) -> CGFloat {
+        var height: CGFloat = 0
+        var sawLogo = false
+        for run in cell.runs {
+            switch run {
+            case .logo: sawLogo = true
+            case let .text(text): height = max(height, text.size().height)
+            }
+        }
+        if height == 0, sawLogo { return MenuBarStatusMetrics.twoRowLogoSide }
+        return height
     }
 
     private func twoRowImage(for columns: [TwoRowMenuColumn], appearance: NSAppearance) -> NSImage {
-        let columnSizes = columns.map { column -> (top: NSSize, bottom: NSSize?, width: CGFloat) in
-            let topSize = column.top.text.size()
-            let bottomSize = column.bottom?.text.size()
-            return (
-                top: topSize,
-                bottom: bottomSize,
+        let columnSizes = columns.map { column -> (top: CGFloat, bottom: CGFloat?, width: CGFloat) in
+            (
+                top: Self.cellHeight(column.top),
+                bottom: column.bottom.map(Self.cellHeight),
                 width: ceil(max(Self.cellWidth(column.top), column.bottom.map(Self.cellWidth) ?? 0))
             )
         }
 
-        let topRowHeight = ceil(columnSizes.map(\.top.height).max() ?? 0)
-        let bottomRowHeight = ceil(columnSizes.compactMap { $0.bottom?.height }.max() ?? 0)
+        let topRowHeight = ceil(columnSizes.map(\.top).max() ?? 0)
+        let bottomRowHeight = ceil(columnSizes.compactMap { $0.bottom }.max() ?? 0)
         let hasBottomRow = columns.contains { $0.bottom != nil }
         let contentHeight = hasBottomRow
             ? topRowHeight + bottomRowHeight + MenuBarStatusMetrics.twoRowLineSpacing
@@ -1324,21 +1712,28 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
             func drawCell(_ cell: TwoRowMenuCell, at origin: NSPoint, rowHeight: CGFloat, columnWidth: CGFloat) {
                 let width = Self.cellWidth(cell)
                 var x = origin.x + floor((columnWidth - width) / 2)
-                if let logo = cell.logo {
-                    let side = MenuBarStatusMetrics.twoRowLogoSide
-                    // Centered in the row's own band, clamped to the canvas —
-                    // never handed to the text system, whose attachment line
-                    // box would not fit two rows in this height.
-                    let logoY = max(0, origin.y + floor((rowHeight - side) / 2))
-                    logo.draw(
-                        in: NSRect(x: x, y: logoY, width: side, height: side),
-                        from: .zero,
-                        operation: .sourceOver,
-                        fraction: 1
-                    )
-                    x += side + MenuBarStatusMetrics.twoRowLogoGap
+                for (index, run) in cell.runs.enumerated() {
+                    if index > 0 { x += MenuBarStatusMetrics.twoRowLogoGap }
+                    switch run {
+                    case let .logo(logo):
+                        let side = MenuBarStatusMetrics.twoRowLogoSide
+                        // Centered in the row's own band, clamped to the
+                        // canvas — never handed to the text system, whose
+                        // attachment line box would not fit two rows in this
+                        // height.
+                        let logoY = max(0, origin.y + floor((rowHeight - side) / 2))
+                        logo.draw(
+                            in: NSRect(x: x, y: logoY, width: side, height: side),
+                            from: .zero,
+                            operation: .sourceOver,
+                            fraction: 1
+                        )
+                        x += side
+                    case let .text(text):
+                        text.draw(at: NSPoint(x: x, y: origin.y))
+                        x += text.size().width
+                    }
                 }
-                cell.text.draw(at: NSPoint(x: x, y: origin.y))
             }
 
             var x = MenuBarStatusMetrics.twoRowHorizontalPadding
@@ -1361,8 +1756,8 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
                 } else {
                     drawCell(
                         column.top,
-                        at: NSPoint(x: x, y: floor((imageHeight - sizes.top.height) / 2)),
-                        rowHeight: sizes.top.height,
+                        at: NSPoint(x: x, y: floor((imageHeight - sizes.top) / 2)),
+                        rowHeight: sizes.top,
                         columnWidth: sizes.width
                     )
                 }
@@ -1414,6 +1809,12 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
     /// observations, cached cycle history, and a rebased cost snapshot — and
     /// only the handful of buckets the user put in the menu bar are asked for.
     private func forecastVerdict(for tool: ToolType, bucket: QuotaBucket) -> QuotaPaceForecast.Verdict? {
+        paceForecast(for: tool, bucket: bucket)?.verdict
+    }
+
+    /// The whole forecast, not just its verdict: a composed strip can print
+    /// the projection and the run-out ETA, which the field path never needed.
+    private func paceForecast(for tool: ToolType, bucket: QuotaBucket) -> QuotaPaceForecast? {
         guard let accountId = environment.account(for: tool)?.id else { return nil }
         let snapshot = environment.costService.snapshot(for: tool)
         return environment.quotaService.paceForecast(
@@ -1423,7 +1824,7 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
             dailyActivity: snapshot?.dailyHistory ?? [],
             now: Date(),
             allowsPostResetGrace: true
-        )?.verdict
+        )
     }
 
     /// AppKit twin of `QuotaForecastPalette`. System colors rather than the

--- a/Sources/VibeBarApp/StatusItemController.swift
+++ b/Sources/VibeBarApp/StatusItemController.swift
@@ -4,11 +4,11 @@ import Combine
 import VibeBarCore
 
 private enum MenuBarStatusMetrics {
-    static let twoRowFontSize: CGFloat = 9
+    static let twoRowFontSize = MenuBarStripMetrics.twoRowFontSize
     static let twoRowColumnSpacing: CGFloat = 8
-    static let twoRowLineSpacing: CGFloat = -2
+    static let twoRowLineSpacing = MenuBarStripMetrics.twoRowLineSpacing
     static let twoRowHorizontalPadding: CGFloat = 2
-    static let twoRowVerticalPadding: CGFloat = 1
+    static let twoRowVerticalPadding = MenuBarStripMetrics.twoRowVerticalPadding
     static let minimumTwoRowLength: CGFloat = 24
     static let twoRowContentIdentifier = NSUserInterfaceItemIdentifier("VibeBarTwoRowStatusContent")
     /// Manually drawn beside the text in each ~10pt row band; see
@@ -17,7 +17,7 @@ private enum MenuBarStatusMetrics {
     static let twoRowLogoGap: CGFloat = 2
     /// Ceiling for a composed glyph in a two-row strip: past this it is the
     /// glyph, not the type, that decides the row height.
-    static let twoRowMaximumGlyphSide: CGFloat = 12
+    static let twoRowMaximumGlyphSide = MenuBarStripMetrics.maximumGlyphSide
 }
 
 /// One cell of the rasterized two-row status image, drawn left to right.
@@ -308,25 +308,13 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
             }
             .store(in: &cancellables)
 
-        // Coalesce all render triggers into one throttled pipeline so a burst
-        // of quota, settings, account, and status updates only redraws once.
-        //
-        // Observations, cycle history, and cost snapshots are in the set
-        // because forecast coloring depends on them, and they land *after*
-        // `$lastSuccessByAccount` — a refresh publishes the new quota first and
-        // records the observation in a follow-up task. Without them the color
-        // would always describe the previous refresh. The extra churn is
-        // bounded: observations publish once per account per refresh.
-        let renderTriggers: [AnyPublisher<Void, Never>] = [
-            environment.settingsStore.$settings.map { _ in () }.eraseToAnyPublisher(),
-            environment.quotaService.$lastSuccessByAccount.map { _ in () }.eraseToAnyPublisher(),
-            environment.quotaService.$lastErrorByAccount.map { _ in () }.eraseToAnyPublisher(),
-            environment.quotaService.$observationsByAccountBucket.map { _ in () }.eraseToAnyPublisher(),
-            environment.quotaService.$historyByAccountBucket.map { _ in () }.eraseToAnyPublisher(),
-            environment.costService.$snapshots.map { _ in () }.eraseToAnyPublisher(),
-            environment.accountStore.$accounts.map { _ in () }.eraseToAnyPublisher(),
-            environment.serviceStatus.$snapshotByTool.map { _ in () }.eraseToAnyPublisher()
-        ]
+        // Coalesce every input a composed or field strip reads into one
+        // throttled pipeline, so a burst of quota, settings, account, and
+        // status updates only redraws once. The list itself lives with the
+        // resolver that reads those inputs — see
+        // `MenuBarStripResolver.inputPublishers`, which the Settings preview
+        // subscribes to as well.
+        let renderTriggers = MenuBarStripResolver.inputPublishers(environment: environment)
         Publishers.MergeMany(renderTriggers)
             .throttle(for: .milliseconds(120), scheduler: RunLoop.main, latest: true)
             .sink { [weak self] _ in self?.renderMenuBar() }
@@ -1748,9 +1736,9 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
     }
 
     /// Height the rasterized image actually has for content, after padding.
+    /// Shared with the preview so both fit against the same canvas.
     nonisolated private static func twoRowAvailableHeight() -> CGFloat {
-        max(18, NSStatusBar.system.thickness - 2)
-            - MenuBarStatusMetrics.twoRowVerticalPadding * 2
+        MenuBarStripMetrics.twoRowAvailableHeight()
     }
 
     private func twoRowImage(for columns: [TwoRowMenuColumn], appearance: NSAppearance) -> NSImage {

--- a/Sources/VibeBarApp/StatusItemController.swift
+++ b/Sources/VibeBarApp/StatusItemController.swift
@@ -114,6 +114,10 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
     /// Rendered brand-logo images keyed by tool, point size, and appearance —
     /// see `brandAttachment(for:fontSize:font:)`.
     private var brandAttachmentImages: [String: NSImage?] = [:]
+    /// One-shot, minute-aligned tick that keeps a composed countdown honest.
+    /// Nil whenever no visible item shows a time-based block — see
+    /// `updateCountdownClock`.
+    private var countdownTimer: Timer?
 
     init(environment: AppEnvironment) {
         self.environment = environment
@@ -798,6 +802,8 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
     }
 
     func applicationWillTerminate() {
+        countdownTimer?.invalidate()
+        countdownTimer = nil
         miniWindowController.applicationWillTerminate()
         blockWatchdog?.stop()
     }
@@ -827,6 +833,11 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
     private func renderMenuBar() {
         let settings = environment.settingsStore.settings
         let allHidden = MenuBarItemKind.allCases.allSatisfy { !settings.menuBarItem($0).isVisible }
+        // Set while walking the items, so the clock decision uses the same
+        // effective visibility the drawing does rather than a second copy of
+        // the rule.
+        var needsCountdownClock = false
+        defer { updateCountdownClock(needed: needsCountdownClock) }
         for kind in MenuBarItemKind.allCases {
             guard let item = statusItem(for: kind) else { continue }
             let itemSettings = settings.menuBarItem(kind)
@@ -841,6 +852,7 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
             // owns its own rows, so it also supersedes `layout`. Everything
             // the field path stores stays untouched underneath it.
             if let composition = itemSettings.composition, composition.isEnabled {
+                if item.isVisible, composition.hasTimeBasedBlock { needsCountdownClock = true }
                 installComposedContent(
                     composition,
                     in: button,
@@ -877,6 +889,44 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
                 applyStatusDescription(pieces, to: button, kind: kind)
             }
         }
+    }
+
+    /// Keeps a composed countdown honest between refreshes.
+    ///
+    /// The render pipeline is driven by settings, quota, account, cost and
+    /// status publishers — none of which is a clock. A strip printing
+    /// `resets in 12m` therefore sat unchanged until the next refresh, which
+    /// on a 30-minute interval means the number is wrong for most of its life
+    /// and can outlive its own deadline.
+    ///
+    /// Armed only while a *visible* item draws a time-based block, so a strip
+    /// of percentages costs no wakeups at all (`AGENTS.md` § 7's idle-CPU
+    /// budget). One shot at a time rather than a repeating 60 s timer, and
+    /// phased on the same process-wide anchor the popover's clocks use — a
+    /// menu bar drifting a few seconds from the popover would show two
+    /// different countdowns for one quota.
+    private func updateCountdownClock(needed: Bool) {
+        guard needed else {
+            countdownTimer?.invalidate()
+            countdownTimer = nil
+            return
+        }
+        // Already armed for a future tick. Re-arming here would let a burst of
+        // quota publishes push the countdown out indefinitely.
+        if let existing = countdownTimer, existing.isValid, existing.fireDate > Date() { return }
+        countdownTimer?.invalidate()
+        let timer = Timer(
+            fire: MenuBarCountdownClock.nextTick(after: Date(), anchor: QuotaClockSchedule.anchor),
+            interval: 0,
+            repeats: false
+        ) { [weak self] _ in
+            Task { @MainActor in self?.renderMenuBar() }
+        }
+        // A minute-granularity number does not need sub-second accuracy; let
+        // the system coalesce the wakeup with whatever else it has queued.
+        timer.tolerance = 5
+        RunLoop.main.add(timer, forMode: .common)
+        countdownTimer = timer
     }
 
     /// Everything the three text layouts need for one render.
@@ -974,8 +1024,29 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
         let strip = composedStrip(composition, itemSettings: itemSettings, settings: settings)
         let rows = strip.plan.rows.filter { !$0.isEmpty }
         if rows.count >= 2 {
-            let cells = rows.prefix(MenuBarComposition.maximumRows).map {
-                composedCell(row: $0, strip: strip, settings: settings)
+            let capped = Array(rows.prefix(MenuBarComposition.maximumRows))
+            let base = MenuBarStatusMetrics.twoRowFontSize
+            var cells = capped.map {
+                composedCell(row: $0, strip: strip, settings: settings, baseFontSize: base)
+            }
+            // Two rows of `.large` blocks, or a composition scaled towards
+            // 1.6, are taller than the ~22pt status bar. The canvas used to be
+            // capped while the row heights were not, so the upper row was
+            // cropped or the rows overlapped. Shrink the type to fit instead:
+            // a smaller strip is honest, a cropped one is a bug.
+            let fit = MenuBarStripFit.scale(
+                contentHeight: Double(Self.twoRowContentHeight(cells)),
+                availableHeight: Double(Self.twoRowAvailableHeight())
+            )
+            if fit < 1 {
+                cells = capped.map {
+                    composedCell(
+                        row: $0,
+                        strip: strip,
+                        settings: settings,
+                        baseFontSize: base * CGFloat(fit)
+                    )
+                }
             }
             installTwoRowImageContent(
                 in: button,
@@ -1046,10 +1117,10 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
             }
             let size = composedFontSize(token, baseFontSize: baseFontSize)
             let font = composedFont(token, size: size)
-            if let tool = token.logo {
+            if let glyph = token.glyph {
                 let paint = composedPaint(token.color, strip: strip, settings: settings)
-                if let attachment = brandAttachment(
-                    for: tool,
+                if let attachment = glyphAttachment(
+                    glyph,
                     fontSize: size,
                     font: font,
                     tint: MenuBarStripPalette.nsColor(paint),
@@ -1078,9 +1149,9 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
     private func composedCell(
         row: MenuBarRenderRow,
         strip: ComposedStrip,
-        settings: AppSettings
+        settings: AppSettings,
+        baseFontSize: CGFloat
     ) -> TwoRowMenuCell {
-        let baseFontSize = MenuBarStatusMetrics.twoRowFontSize
         var runs: [TwoRowMenuCell.Run] = []
         var pending = NSMutableAttributedString()
         func flush() {
@@ -1093,11 +1164,11 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
             if index > 0, let gap = composedGap(strip.plan, baseFontSize: baseFontSize) {
                 pending.append(gap)
             }
-            if let tool = token.logo {
+            if let glyph = token.glyph {
                 flush()
                 let paint = composedPaint(token.color, strip: strip, settings: settings)
-                if let image = brandLogoImage(
-                    for: tool,
+                if let image = glyphImage(
+                    glyph,
                     side: MenuBarStatusMetrics.twoRowLogoSide,
                     tint: MenuBarStripPalette.nsColor(paint),
                     tintKey: MenuBarStripPalette.cacheKey(paint)
@@ -1481,11 +1552,70 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
     ) -> NSAttributedString? {
         let side: CGFloat = (fontSize + 3).rounded()
         guard let image = brandImage(for: tool, side: side, tint: tint, tintKey: tintKey) else { return nil }
+        return attachment(image: image, side: side, font: font)
+    }
+
+    /// One glyph run, vertically centered on the font's cap height.
+    private func attachment(image: NSImage, side: CGFloat, font: NSFont) -> NSAttributedString {
         let attachment = NSTextAttachment()
         attachment.image = image
         let yOffset = (font.capHeight - side) / 2
         attachment.bounds = CGRect(x: 0, y: yOffset, width: side, height: side)
         return NSAttributedString(attachment: attachment)
+    }
+
+    /// A composed glyph block as a text attachment: a provider's brand mark,
+    /// or Vibe Bar's own icon for a block seeded from the Icon Only layout.
+    private func glyphAttachment(
+        _ glyph: MenuBarRenderedToken.Glyph,
+        fontSize: CGFloat,
+        font: NSFont,
+        tint: NSColor,
+        tintKey: String
+    ) -> NSAttributedString? {
+        switch glyph {
+        case let .provider(tool):
+            return brandAttachment(
+                for: tool, fontSize: fontSize, font: font, tint: tint, tintKey: tintKey
+            )
+        case .app:
+            let side: CGFloat = (fontSize + 3).rounded()
+            guard let image = appGlyphImage(side: side, tint: tint, tintKey: tintKey) else {
+                return nil
+            }
+            return attachment(image: image, side: side, font: font)
+        }
+    }
+
+    /// The same glyph as a raw image, for the two-row rasterizer.
+    private func glyphImage(
+        _ glyph: MenuBarRenderedToken.Glyph,
+        side: CGFloat,
+        tint: NSColor,
+        tintKey: String
+    ) -> NSImage? {
+        switch glyph {
+        case let .provider(tool):
+            return brandLogoImage(for: tool, side: side, tint: tint, tintKey: tintKey)
+        case .app:
+            return appGlyphImage(side: side, tint: tint, tintKey: tintKey)
+        }
+    }
+
+    /// Vibe Bar's own mark, cached beside the provider marks on the same key
+    /// shape so the two never collide.
+    private func appGlyphImage(side: CGFloat, tint: NSColor, tintKey: String) -> NSImage? {
+        let appearance = compactStatusItem?.button?.effectiveAppearance ?? NSApp.effectiveAppearance
+        let key = "vibebar.\(side).\(appearance.name.rawValue).\(tintKey)"
+        if let cached = brandAttachmentImages[key] { return cached }
+        let image = ProviderBrandIcon.image(
+            for: MenuBarItemKind.compact,
+            size: NSSize(width: side, height: side),
+            tint: tint,
+            appearance: appearance
+        )
+        brandAttachmentImages[key] = image
+        return image
     }
 
     /// Raw logo image for the two-row rasterizer's manual drawing — same
@@ -1582,6 +1712,19 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
         }
         if height == 0, sawLogo { return MenuBarStatusMetrics.twoRowLogoSide }
         return height
+    }
+
+    /// Stacked height of a set of row cells, including the deliberate
+    /// negative line spacing that tucks the two bands together.
+    nonisolated private static func twoRowContentHeight(_ cells: [TwoRowMenuCell]) -> CGFloat {
+        cells.reduce(0) { $0 + cellHeight($1) }
+            + MenuBarStatusMetrics.twoRowLineSpacing * CGFloat(max(0, cells.count - 1))
+    }
+
+    /// Height the rasterized image actually has for content, after padding.
+    nonisolated private static func twoRowAvailableHeight() -> CGFloat {
+        max(18, NSStatusBar.system.thickness - 2)
+            - MenuBarStatusMetrics.twoRowVerticalPadding * 2
     }
 
     private func twoRowImage(for columns: [TwoRowMenuColumn], appearance: NSAppearance) -> NSImage {

--- a/Sources/VibeBarApp/StatusItemController.swift
+++ b/Sources/VibeBarApp/StatusItemController.swift
@@ -132,6 +132,9 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
     /// Nil whenever no visible item shows a time-based block — see
     /// `updateCountdownClock`.
     private var countdownTimer: Timer?
+    /// The cadence `countdownTimer` was armed at, so a strip that changes what
+    /// it needs re-arms instead of keeping the old one.
+    private var countdownInterval: TimeInterval?
 
     init(environment: AppEnvironment) {
         self.environment = environment
@@ -806,6 +809,7 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
     func applicationWillTerminate() {
         countdownTimer?.invalidate()
         countdownTimer = nil
+        countdownInterval = nil
         miniWindowController.applicationWillTerminate()
         blockWatchdog?.stop()
     }
@@ -838,8 +842,8 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
         // Set while walking the items, so the clock decision uses the same
         // effective visibility the drawing does rather than a second copy of
         // the rule.
-        var needsCountdownClock = false
-        defer { updateCountdownClock(needed: needsCountdownClock) }
+        var stripClockInterval: TimeInterval?
+        defer { updateStripClock(interval: stripClockInterval) }
         for kind in MenuBarItemKind.allCases {
             guard let item = statusItem(for: kind) else { continue }
             let itemSettings = settings.menuBarItem(kind)
@@ -854,7 +858,12 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
             // owns its own rows, so it also supersedes `layout`. Everything
             // the field path stores stays untouched underneath it.
             if let composition = itemSettings.composition, composition.isEnabled {
-                if item.isVisible, composition.hasTimeBasedBlock { needsCountdownClock = true }
+                if item.isVisible,
+                   let interval = composition.clockInterval(
+                       colorBasis: settings.menuBarColorBasis
+                   ) {
+                    stripClockInterval = min(stripClockInterval ?? interval, interval)
+                }
                 installComposedContent(
                     composition,
                     in: button,
@@ -893,32 +902,44 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
         }
     }
 
-    /// Keeps a composed countdown honest between refreshes.
+    /// Keeps a composed strip honest between refreshes.
     ///
     /// The render pipeline is driven by settings, quota, account, cost and
     /// status publishers — none of which is a clock. A strip printing
-    /// `resets in 12m` therefore sat unchanged until the next refresh, which
-    /// on a 30-minute interval means the number is wrong for most of its life
-    /// and can outlive its own deadline.
+    /// `resets in 12m` sat unchanged until the next refresh, which on a
+    /// 30-minute interval means the number is wrong for most of its life; a
+    /// forecast percentage, a verdict rule, or a forecast colour goes stale
+    /// the same way, just on the forecast's own five-minute grid.
     ///
-    /// Armed only while a *visible* item draws a time-based block, so a strip
-    /// of percentages costs no wakeups at all (`AGENTS.md` § 7's idle-CPU
-    /// budget). One shot at a time rather than a repeating 60 s timer, and
-    /// phased on the same process-wide anchor the popover's clocks use — a
-    /// menu bar drifting a few seconds from the popover would show two
-    /// different countdowns for one quota.
-    private func updateCountdownClock(needed: Bool) {
-        guard needed else {
+    /// Armed only while a *visible* item needs it, at the interval that item
+    /// asks for, so a strip of plain percentages costs no wakeups at all
+    /// (`AGENTS.md` § 7's idle-CPU budget). One shot at a time rather than a
+    /// repeating timer, and phased on the same process-wide anchor the
+    /// popover's clocks use — a menu bar drifting a few seconds from the
+    /// popover would show two different countdowns for one quota.
+    private func updateStripClock(interval: TimeInterval?) {
+        guard let interval else {
             countdownTimer?.invalidate()
             countdownTimer = nil
+            countdownInterval = nil
             return
         }
-        // Already armed for a future tick. Re-arming here would let a burst of
-        // quota publishes push the countdown out indefinitely.
-        if let existing = countdownTimer, existing.isValid, existing.fireDate > Date() { return }
+        // Already armed for a future tick at this cadence. Re-arming here
+        // would let a burst of quota publishes push the tick out indefinitely.
+        if let existing = countdownTimer,
+           existing.isValid,
+           existing.fireDate > Date(),
+           countdownInterval == interval {
+            return
+        }
         countdownTimer?.invalidate()
+        countdownInterval = interval
         let timer = Timer(
-            fire: MenuBarCountdownClock.nextTick(after: Date(), anchor: QuotaClockSchedule.anchor),
+            fire: MenuBarCountdownClock.nextTick(
+                after: Date(),
+                anchor: QuotaClockSchedule.anchor,
+                interval: interval
+            ),
             interval: 0,
             repeats: false
         ) { [weak self] _ in

--- a/Sources/VibeBarApp/StatusItemController.swift
+++ b/Sources/VibeBarApp/StatusItemController.swift
@@ -114,8 +114,6 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
     /// Rendered brand-logo images keyed by tool, point size, and appearance —
     /// see `brandAttachment(for:fontSize:font:)`.
     private var brandAttachmentImages: [String: NSImage?] = [:]
-    /// Bridged provider accents for composed blocks wearing `.brand`.
-    private var brandAccentColors: [ToolType: NSColor] = [:]
 
     init(environment: AppEnvironment) {
         self.environment = environment
@@ -1005,51 +1003,23 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
 
     /// Resolve the quotas the strip names, then plan it.
     ///
-    /// Runs inside the 120 ms throttle, so it resolves each *distinct* field
-    /// exactly once — `quotaRequirements` is the deduplicated list, and a strip
-    /// that mentions one bucket three times still costs one bucket lookup and
-    /// at most one forecast. The forecast is only computed where a block, a
-    /// colour, or a rule reads one, plus the case the field path already pays
-    /// for: an automatic colour under the forecast basis.
+    /// The resolution itself lives in `MenuBarStripResolver` so the editor's
+    /// live preview is looking at the same numbers under the same rules — the
+    /// preview drifting from the bar it is previewing would be worse than
+    /// having no preview.
     private func composedStrip(
         _ composition: MenuBarComposition,
         itemSettings: MenuBarItemSettings,
         settings: AppSettings
     ) -> ComposedStrip {
-        let registry = environment.quotaService.fieldRegistry
-        let requirements = composition.quotaRequirements
-        let wantsForecastColors = settings.menuBarColorBasis == .forecast
         let now = Date()
-        var quotas: [MenuBarQuotaSnapshot] = []
-        quotas.reserveCapacity(requirements.count)
-        for requirement in requirements {
-            guard
-                let field = MenuBarFieldCatalog.field(id: requirement.fieldId, registry: registry),
-                let bucket = environment.quota(for: field.tool)?.bucket(id: field.bucketId)
-            else { continue }
-            var forecast: MenuBarQuotaSnapshot.Forecast?
-            if requirement.needsForecast || wantsForecastColors,
-               let computed = paceForecast(for: field.tool, bucket: bucket) {
-                forecast = MenuBarQuotaSnapshot.Forecast(
-                    verdict: computed.verdict,
-                    projectedRemainingPercent: computed.projectedRemainingPercent,
-                    runOutAt: computed.runOutAt
-                )
-            }
-            let pace = requirement.needsPace
-                ? UsagePace.compute(bucket: bucket, now: now, allowsPostResetGrace: true)
-                : nil
-            quotas.append(MenuBarQuotaSnapshot(
-                fieldId: field.id,
-                tool: field.tool,
-                label: label(for: field, bucket: bucket, itemSettings: itemSettings),
-                usedPercent: bucket.usedPercent,
-                displayPercent: bucket.displayPercent(settings.displayMode, tool: field.tool),
-                resetAt: bucket.resetAt,
-                paceDeltaPercent: pace?.deltaPercent,
-                forecast: forecast
-            ))
-        }
+        let quotas = MenuBarStripResolver.snapshots(
+            for: composition,
+            itemSettings: itemSettings,
+            settings: settings,
+            environment: environment,
+            now: now
+        )
         return ComposedStrip(
             plan: composition.plan(
                 quotas: quotas,
@@ -1077,13 +1047,13 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
             let size = composedFontSize(token, baseFontSize: baseFontSize)
             let font = composedFont(token, size: size)
             if let tool = token.logo {
-                let tint = composedColor(token.color, strip: strip, settings: settings)
+                let paint = composedPaint(token.color, strip: strip, settings: settings)
                 if let attachment = brandAttachment(
                     for: tool,
                     fontSize: size,
                     font: font,
-                    tint: tint,
-                    tintKey: Self.tintKey(for: token.color, strip: strip, settings: settings)
+                    tint: MenuBarStripPalette.nsColor(paint),
+                    tintKey: MenuBarStripPalette.cacheKey(paint)
                 ) {
                     attributed.append(attachment)
                 }
@@ -1093,7 +1063,9 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
             attributed.append(NSAttributedString(
                 string: text,
                 attributes: [
-                    .foregroundColor: composedColor(token.color, strip: strip, settings: settings),
+                    .foregroundColor: MenuBarStripPalette.nsColor(
+                        composedPaint(token.color, strip: strip, settings: settings)
+                    ),
                     .font: font
                 ]
             ))
@@ -1123,11 +1095,12 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
             }
             if let tool = token.logo {
                 flush()
+                let paint = composedPaint(token.color, strip: strip, settings: settings)
                 if let image = brandLogoImage(
                     for: tool,
                     side: MenuBarStatusMetrics.twoRowLogoSide,
-                    tint: composedColor(token.color, strip: strip, settings: settings),
-                    tintKey: Self.tintKey(for: token.color, strip: strip, settings: settings)
+                    tint: MenuBarStripPalette.nsColor(paint),
+                    tintKey: MenuBarStripPalette.cacheKey(paint)
                 ) {
                     runs.append(.logo(image))
                 }
@@ -1137,7 +1110,9 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
             pending.append(NSAttributedString(
                 string: text,
                 attributes: [
-                    .foregroundColor: composedColor(token.color, strip: strip, settings: settings),
+                    .foregroundColor: MenuBarStripPalette.nsColor(
+                        composedPaint(token.color, strip: strip, settings: settings)
+                    ),
                     .font: composedFont(token, size: composedFontSize(token, baseFontSize: baseFontSize))
                 ]
             ))
@@ -1186,80 +1161,20 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
             : NSFont.systemFont(ofSize: size, weight: weight)
     }
 
-    /// A composed block's colour. `.quota` goes through exactly the resolver
-    /// the field strip uses, so a block left on `.automatic` is the same
-    /// colour it would have been before the composer existed.
-    private func composedColor(
+    /// A composed block's colour and its cache key, both from the one shared
+    /// palette the editor's preview draws with. Keeping the decision in a
+    /// single place is the only thing stopping the preview and the bar from
+    /// disagreeing about what `.automatic` means.
+    private func composedPaint(
         _ role: MenuBarTokenColorRole,
         strip: ComposedStrip,
         settings: AppSettings
-    ) -> NSColor {
-        switch role {
-        case let .quota(fieldId, basis):
-            guard let quota = strip.quotas.first(where: { $0.fieldId == fieldId }) else {
-                return .labelColor
-            }
-            return Self.nsColor(for: MenuBarPercentColor.resolve(
-                basis: basis,
-                verdict: basis == .forecast ? quota.forecast?.verdict : nil,
-                percent: quota.displayPercent,
-                displayMode: settings.displayMode
-            ))
-        case let .brand(tool):
-            return brandAccentColor(for: tool)
-        case .primary:
-            return .labelColor
-        case .secondary:
-            return .secondaryLabelColor
-        case .tertiary:
-            return .tertiaryLabelColor
-        case let .fixed(hex):
-            guard let parts = MenuBarHexColor.components(hex) else { return .labelColor }
-            return NSColor(srgbRed: parts.r, green: parts.g, blue: parts.b, alpha: parts.a)
-        }
-    }
-
-    /// Stable cache key for a resolved tint. Keyed on the colour's *role*
-    /// rather than the `NSColor`, whose description is not stable for a
-    /// dynamic system colour.
-    private static func tintKey(
-        for role: MenuBarTokenColorRole,
-        strip: ComposedStrip,
-        settings: AppSettings
-    ) -> String {
-        switch role {
-        case let .quota(fieldId, basis):
-            guard let quota = strip.quotas.first(where: { $0.fieldId == fieldId }) else {
-                return "label"
-            }
-            let resolved = MenuBarPercentColor.resolve(
-                basis: basis,
-                verdict: basis == .forecast ? quota.forecast?.verdict : nil,
-                percent: quota.displayPercent,
-                displayMode: settings.displayMode
-            )
-            switch resolved {
-            case .healthy: return "healthy"
-            case .surplus: return "surplus"
-            case .watch: return "watch"
-            case .risk: return "risk"
-            }
-        case let .brand(tool): return "brand.\(tool.rawValue)"
-        case .primary: return "label"
-        case .secondary: return "secondary"
-        case .tertiary: return "tertiary"
-        case let .fixed(hex): return "fixed\(hex)"
-        }
-    }
-
-    /// AppKit twin of the shared provider accent table, cached per tool: the
-    /// composer lets a block wear a provider's brand colour, and the status
-    /// item must not rebuild a bridged colour on every 120 ms render.
-    private func brandAccentColor(for tool: ToolType) -> NSColor {
-        if let cached = brandAccentColors[tool] { return cached }
-        let color = NSColor(Theme.providerAccent(for: tool))
-        brandAccentColors[tool] = color
-        return color
+    ) -> MenuBarStripPaint {
+        MenuBarStripPalette.paint(
+            for: role,
+            quotas: strip.quotas,
+            displayMode: settings.displayMode
+        )
     }
 
     /// The status item always *speaks* one clause per quota window, even when
@@ -1815,28 +1730,13 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
     /// The whole forecast, not just its verdict: a composed strip can print
     /// the projection and the run-out ETA, which the field path never needed.
     private func paceForecast(for tool: ToolType, bucket: QuotaBucket) -> QuotaPaceForecast? {
-        guard let accountId = environment.account(for: tool)?.id else { return nil }
-        let snapshot = environment.costService.snapshot(for: tool)
-        return environment.quotaService.paceForecast(
-            accountId: accountId,
-            bucket: bucket,
-            activityHeatmap: snapshot?.heatmap,
-            dailyActivity: snapshot?.dailyHistory ?? [],
-            now: Date(),
-            allowsPostResetGrace: true
-        )
+        MenuBarStripResolver.paceForecast(for: tool, bucket: bucket, environment: environment)
     }
 
-    /// AppKit twin of `QuotaForecastPalette`. System colors rather than the
-    /// popover's literal RGB values: the menu bar has to stay legible against
-    /// light, dark, and tinted wallpapers, and these are the exact colors the
-    /// pre-forecast menu bar used.
+    /// AppKit twin of `QuotaForecastPalette`, via the one palette the composed
+    /// strip and its preview also read — the field path and the composer must
+    /// paint an identical percentage identically.
     private static func nsColor(for color: MenuBarPercentColor) -> NSColor {
-        switch color {
-        case .healthy: return NSColor.systemGreen
-        case .surplus: return NSColor.systemBlue
-        case .watch: return NSColor.systemOrange
-        case .risk: return NSColor.systemRed
-        }
+        MenuBarStripPalette.nsColor(.quota(color))
     }
 }

--- a/Sources/VibeBarApp/StatusItemController.swift
+++ b/Sources/VibeBarApp/StatusItemController.swift
@@ -1484,11 +1484,10 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
         return attributed
     }
 
+    /// One naming seam for both strips — the field list and the composed one
+    /// must not call the same bucket different things.
     private func label(for field: MenuBarFieldOption, bucket: QuotaBucket, itemSettings: MenuBarItemSettings) -> String {
-        let custom = itemSettings.customLabels[field.id]?.trimmingCharacters(in: .whitespacesAndNewlines)
-        if let custom, !custom.isEmpty { return custom }
-        if field.defaultLabel != bucket.shortLabel { return bucket.shortLabel }
-        return field.defaultLabel
+        MenuBarStripResolver.label(for: field, bucket: bucket, itemSettings: itemSettings)
     }
 
     private func menuTextPiece(

--- a/Sources/VibeBarApp/StatusItemController.swift
+++ b/Sources/VibeBarApp/StatusItemController.swift
@@ -297,7 +297,7 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
         button.lineBreakMode = .byClipping
         button.font = NSFont.systemFont(ofSize: NSFont.smallSystemFontSize, weight: .medium)
         button.tag = statusItemTag(for: kind)
-        button.toolTip = "\(kind.label) quota"
+        button.toolTip = L10n.MenuBar.spokenTitle(kind: kind.label)
     }
 
     private func observeChanges() {
@@ -1023,7 +1023,7 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
     }
 
     private func percentText(_ percent: Double) -> String {
-        "\(Int(percent.rounded()))%"
+        L10n.Common.percent(value: Int(percent.rounded()))
     }
 
     // MARK: - Composed strip
@@ -1194,9 +1194,8 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
                 // 8pt mark: a `.large` logo in a composed row should grow with
                 // the words beside it. Capped at the row band so it cannot be
                 // the thing that overflows the canvas.
-                let side = min(
-                    composedFontSize(token, baseFontSize: baseFontSize) + 1,
-                    MenuBarStatusMetrics.twoRowMaximumGlyphSide
+                let side = MenuBarStripMetrics.twoRowGlyphSide(
+                    fontSize: composedFontSize(token, baseFontSize: baseFontSize)
                 )
                 if let image = glyphImage(
                     glyph,
@@ -1303,8 +1302,8 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
         kind: MenuBarItemKind
     ) {
         let description = body.isEmpty
-            ? "\(kind.label) quota"
-            : "\(kind.label) quota: \(body)"
+            ? L10n.MenuBar.spokenTitle(kind: kind.label)
+            : L10n.MenuBar.spokenTitleBody(kind: kind.label, body: body)
         button.setAccessibilityLabel(description)
         if button.toolTip != description { button.toolTip = description }
     }
@@ -1583,7 +1582,7 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
         tint: NSColor = .labelColor,
         tintKey: String = "label"
     ) -> NSAttributedString? {
-        let side: CGFloat = (fontSize + 3).rounded()
+        let side = MenuBarStripMetrics.singleRowGlyphSide(fontSize: fontSize)
         guard let image = brandImage(for: tool, side: side, tint: tint, tintKey: tintKey) else { return nil }
         return attachment(image: image, side: side, font: font)
     }
@@ -1612,7 +1611,7 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
                 for: tool, fontSize: fontSize, font: font, tint: tint, tintKey: tintKey
             )
         case .app:
-            let side: CGFloat = (fontSize + 3).rounded()
+            let side = MenuBarStripMetrics.singleRowGlyphSide(fontSize: fontSize)
             guard let image = appGlyphImage(side: side, tint: tint, tintKey: tintKey) else {
                 return nil
             }
@@ -1700,7 +1699,7 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
         // This layout draws no percentages, so it skips the piece walk (and
         // its per-bucket forecasts) entirely — which also means it must clear
         // any live description a previous layout left on the button.
-        let idleToolTip = "\(kind.label) quota"
+        let idleToolTip = L10n.MenuBar.spokenTitle(kind: kind.label)
         if button.toolTip != idleToolTip { button.toolTip = idleToolTip }
     }
 

--- a/Sources/VibeBarApp/StatusItemController.swift
+++ b/Sources/VibeBarApp/StatusItemController.swift
@@ -1048,7 +1048,10 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
         let rows = strip.plan.rows.filter { !$0.isEmpty }
         if rows.count >= 2 {
             let capped = Array(rows.prefix(MenuBarComposition.maximumRows))
-            let base = MenuBarStatusMetrics.twoRowFontSize
+            let base = MenuBarStripMetrics.baseFontSize(
+                template: composition.template,
+                rowCount: capped.count
+            )
             var cells = capped.map {
                 composedCell(row: $0, strip: strip, settings: settings, baseFontSize: base)
             }
@@ -1082,13 +1085,20 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
             // rather than an empty status item nobody can find to click. No
             // title in front of it: in custom mode the title is a block the
             // user may have deleted, so reviving it here would be a surprise.
+            // Not always the system face: a strip seeded from the Compact
+            // layout has to be drawn at the face that layout draws at, or the
+            // seed is visibly bigger than the strip it reproduced.
+            let base = MenuBarStripMetrics.baseFontSize(
+                template: composition.template,
+                rowCount: max(1, rows.count)
+            )
             button.attributedTitle = rows.isEmpty
-                ? Self.composedPlaceholder(fontSize: NSFont.smallSystemFontSize)
+                ? Self.composedPlaceholder(fontSize: base)
                 : composedAttributedRow(
                     rows[0],
                     strip: strip,
                     settings: settings,
-                    baseFontSize: NSFont.smallSystemFontSize
+                    baseFontSize: base
                 )
             item.length = NSStatusItem.variableLength
         }

--- a/Sources/VibeBarApp/StatusItemController.swift
+++ b/Sources/VibeBarApp/StatusItemController.swift
@@ -15,6 +15,9 @@ private enum MenuBarStatusMetrics {
     /// `twoRowImage` — text attachments cannot be used at this size.
     static let twoRowLogoSide: CGFloat = 8
     static let twoRowLogoGap: CGFloat = 2
+    /// Ceiling for a composed glyph in a two-row strip: past this it is the
+    /// glyph, not the type, that decides the row height.
+    static let twoRowMaximumGlyphSide: CGFloat = 12
 }
 
 /// One cell of the rasterized two-row status image, drawn left to right.
@@ -31,9 +34,19 @@ private struct TwoRowMenuCell {
     }
 
     var runs: [Run]
+    /// Points inserted between adjacent runs.
+    ///
+    /// The built-in two-row layout draws a leading logo and needs a fixed gap
+    /// after it. A composed row does not: it already carries the user's
+    /// configured spacing inside its own text runs, so adding this again
+    /// double-counts it — zero spacing would still show a gap, and non-zero
+    /// spacing would come out wider in the status item than in the preview
+    /// and the single-row bar.
+    var runGap: CGFloat
 
-    init(runs: [Run]) {
+    init(runs: [Run], runGap: CGFloat = 0) {
         self.runs = runs
+        self.runGap = runGap
     }
 
     init(text: NSAttributedString, logo: NSImage? = nil) {
@@ -41,6 +54,7 @@ private struct TwoRowMenuCell {
         if let logo { runs.append(.logo(logo)) }
         runs.append(.text(text))
         self.runs = runs
+        self.runGap = MenuBarStatusMetrics.twoRowLogoGap
     }
 
     var isEmpty: Bool { runs.isEmpty }
@@ -1167,9 +1181,17 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
             if let glyph = token.glyph {
                 flush()
                 let paint = composedPaint(token.color, strip: strip, settings: settings)
+                // Sized from the block, not from the built-in layout's fixed
+                // 8pt mark: a `.large` logo in a composed row should grow with
+                // the words beside it. Capped at the row band so it cannot be
+                // the thing that overflows the canvas.
+                let side = min(
+                    composedFontSize(token, baseFontSize: baseFontSize) + 1,
+                    MenuBarStatusMetrics.twoRowMaximumGlyphSide
+                )
                 if let image = glyphImage(
                     glyph,
-                    side: MenuBarStatusMetrics.twoRowLogoSide,
+                    side: side,
                     tint: MenuBarStripPalette.nsColor(paint),
                     tintKey: MenuBarStripPalette.cacheKey(paint)
                 ) {
@@ -1189,7 +1211,9 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
             ))
         }
         flush()
-        return TwoRowMenuCell(runs: runs)
+        // The configured spacing already lives inside the text runs above, so
+        // the cell adds nothing between them.
+        return TwoRowMenuCell(runs: runs, runGap: 0)
     }
 
     /// What a composed strip shows when nothing survived.
@@ -1688,30 +1712,32 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
     }
 
     nonisolated private static func cellWidth(_ cell: TwoRowMenuCell) -> CGFloat {
-        var width: CGFloat = 0
-        for (index, run) in cell.runs.enumerated() {
-            if index > 0 { width += MenuBarStatusMetrics.twoRowLogoGap }
+        let runWidths = cell.runs.map { run -> Double in
             switch run {
-            case .logo: width += MenuBarStatusMetrics.twoRowLogoSide
-            case let .text(text): width += text.size().width
+            case let .logo(image): return Double(image.size.width)
+            case let .text(text): return Double(text.size().width)
             }
         }
-        return width
+        return CGFloat(MenuBarStripGeometry.cellWidth(
+            runWidths: runWidths,
+            gap: Double(cell.runGap)
+        ))
     }
 
     /// Tallest text run in the cell; a logo-only cell falls back to the logo
     /// box so its row band does not collapse to nothing.
     nonisolated private static func cellHeight(_ cell: TwoRowMenuCell) -> CGFloat {
-        var height: CGFloat = 0
-        var sawLogo = false
+        var textHeight: CGFloat = 0
+        var glyphHeight: CGFloat = 0
         for run in cell.runs {
             switch run {
-            case .logo: sawLogo = true
-            case let .text(text): height = max(height, text.size().height)
+            case let .logo(image): glyphHeight = max(glyphHeight, image.size.height)
+            case let .text(text): textHeight = max(textHeight, text.size().height)
             }
         }
-        if height == 0, sawLogo { return MenuBarStatusMetrics.twoRowLogoSide }
-        return height
+        // A glyph-only row still needs a band, and a composed glyph sized up
+        // by its block must not be measured as the built-in 8pt mark.
+        return max(textHeight, glyphHeight)
     }
 
     /// Stacked height of a set of row cells, including the deliberate
@@ -1771,22 +1797,22 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
                 let width = Self.cellWidth(cell)
                 var x = origin.x + floor((columnWidth - width) / 2)
                 for (index, run) in cell.runs.enumerated() {
-                    if index > 0 { x += MenuBarStatusMetrics.twoRowLogoGap }
+                    if index > 0 { x += cell.runGap }
                     switch run {
                     case let .logo(logo):
-                        let side = MenuBarStatusMetrics.twoRowLogoSide
+                        let size = logo.size
                         // Centered in the row's own band, clamped to the
                         // canvas — never handed to the text system, whose
                         // attachment line box would not fit two rows in this
                         // height.
-                        let logoY = max(0, origin.y + floor((rowHeight - side) / 2))
+                        let logoY = max(0, origin.y + floor((rowHeight - size.height) / 2))
                         logo.draw(
-                            in: NSRect(x: x, y: logoY, width: side, height: side),
+                            in: NSRect(x: x, y: logoY, width: size.width, height: size.height),
                             from: .zero,
                             operation: .sourceOver,
                             fraction: 1
                         )
-                        x += side
+                        x += size.width
                     case let .text(text):
                         text.draw(at: NSPoint(x: x, y: origin.y))
                         x += text.size().width

--- a/Sources/VibeBarApp/StatusItemController.swift
+++ b/Sources/VibeBarApp/StatusItemController.swift
@@ -1012,7 +1012,14 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
                 label: label,
                 percents: percents,
                 tool: run.primary.tool,
-                style: itemSettings.style(for: run.primary.id),
+                // Through the shared rule rather than straight from settings:
+                // the single-line builder has always ignored the per-field
+                // style, and that fact now lives in one place both this and
+                // the seed read.
+                style: MenuBarFieldStripRules.effectiveStyle(
+                    itemSettings.style(for: run.primary.id),
+                    layout: itemSettings.layout
+                ),
                 spokenDescription: run.isMerged
                     ? "\(label) \(windows.joined(separator: ", "))"
                     : "\(label) \(percentText(percents[0].value)) \(modeWord)"

--- a/Sources/VibeBarApp/Views/DebouncedSettingsTextField.swift
+++ b/Sources/VibeBarApp/Views/DebouncedSettingsTextField.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import VibeBarCore
 
 /// A Settings text field that types into its own draft and writes back later.
 ///
@@ -25,18 +26,32 @@ struct DebouncedSettingsTextField: View {
     @Binding var value: String
     /// How long the field waits after the last keystroke before writing.
     let idleDelay: Duration
+    /// A queue this field's pending write joins, so a caller that flushes
+    /// before doing something else picks this field's draft up too.
+    ///
+    /// Without it the field owns its own timer, which nothing outside can
+    /// reach: acting on the block while a draft is in flight — duplicating it,
+    /// say — copies the pre-edit value, and the original then receives the new
+    /// text while the copy keeps the old. Optional, so every existing call
+    /// site keeps the self-contained behaviour it was written against.
+    let pending: PendingEditQueue?
+    let pendingKey: String
 
     @FocusState private var isFocused: Bool
     @State private var draft: String = ""
 
     init(
         prompt: String,
+        pending: PendingEditQueue? = nil,
+        pendingKey: String = "",
         value: Binding<String>,
         idleDelay: Duration = .milliseconds(400)
     ) {
         self.prompt = prompt
         self._value = value
         self.idleDelay = idleDelay
+        self.pending = pending
+        self.pendingKey = pendingKey
     }
 
     var body: some View {
@@ -50,6 +65,14 @@ struct DebouncedSettingsTextField: View {
             // leaves the view tree.
             .task(id: draft) {
                 guard draft != value else { return }
+                // With a queue, the wait is the queue's and the write is
+                // reachable from outside; without one, this timer is the only
+                // thing holding the keystroke back.
+                if let pending {
+                    let text = draft
+                    pending.schedule(pendingKey) { value = text }
+                    return
+                }
                 try? await Task.sleep(for: idleDelay)
                 guard !Task.isCancelled else { return }
                 commit()

--- a/Sources/VibeBarApp/Views/MenuBarComposerEditor.swift
+++ b/Sources/VibeBarApp/Views/MenuBarComposerEditor.swift
@@ -27,7 +27,7 @@ struct MenuBarComposerEditor: View {
     @StateObject private var inputs = MenuBarStripInputObserver()
     /// Holds a debounced control's last change until a moment this view can
     /// observe — see `MenuBarPendingCommit`.
-    @StateObject private var pendingCommit = MenuBarPendingCommit()
+    @StateObject private var pendingCommit = PendingEditQueue()
     @State private var selection: UUID?
     @State private var draggedTokenId: UUID?
     /// The order the strip *would* have if the drag ended here.
@@ -380,7 +380,7 @@ struct MenuBarComposerEditor: View {
             let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
             return trimmed.isEmpty ? L10n.MenuBar.composerBlockEmptyText : MenuBarToken.truncated(trimmed)
         case let .quota(fieldId, metric):
-            let name = optionsById[fieldId]?.defaultLabel ?? fieldId
+            let name = optionsById[fieldId]?.displayDefaultLabel ?? fieldId
             return "\(name) · \(metric.title)"
         case .space:
             return L10n.MenuBar.composerBlockSpace
@@ -428,7 +428,7 @@ struct MenuBarComposerEditor: View {
                 ForEach(paletteQuotaSections) { section in
                     Menu {
                         ForEach(section.options) { option in
-                            Button(option.title) {
+                            Button(option.displayTitle) {
                                 add(MenuBarToken(
                                     kind: .quota(fieldId: option.id, metric: .displayPercent),
                                     style: .percent
@@ -583,7 +583,7 @@ struct MenuBarComposerEditor: View {
             if !availability.isFullyAvailable {
                 warning(L10n.MenuBar.composerWarningMissing(
                     fields: availability.missingFieldIds
-                        .map { optionsById[$0]?.title ?? $0 }
+                        .map { optionsById[$0]?.displayTitle ?? $0 }
                         .joined(separator: ", ")
                 ))
             }
@@ -704,10 +704,13 @@ struct MenuBarComposerEditor: View {
     private func templateBinding() -> Binding<MenuBarComposition.Template> {
         Binding(
             get: { composition.template },
-            // Changing the template re-styles the strip, never its contents:
-            // the blocks the user arranged are theirs. "Start over" is the
-            // control that rebuilds them, and it asks first.
-            set: { template in mutate { $0.template = template } }
+            // A template is spacing and type size — and, for "Two rows", a
+            // shape. `setTemplate` takes the row structure with it, because a
+            // picker whose description promises two stacked rows has to
+            // produce them. It still never invents or discards content: the
+            // blocks the user arranged are theirs, and "Start over" is the
+            // control that rebuilds those, after asking.
+            set: { template in mutate { $0.setTemplate(template) } }
         )
     }
 
@@ -768,7 +771,7 @@ private struct MenuBarTokenInspector: View {
     let token: MenuBarToken
     let options: [MenuBarFieldOption]
     let liveFieldIds: Set<String>
-    let pending: MenuBarPendingCommit
+    let pending: PendingEditQueue
     /// Hands over *what changed*, applied to the stored token at write time.
     let apply: (@escaping (inout MenuBarToken) -> Void) -> Void
 
@@ -1013,7 +1016,9 @@ private struct MenuBarTokenInspector: View {
         let apply = self.apply
         // Only the colour: a queued write that carried a whole token would
         // undo whatever else the user changed while it sat in the queue.
-        pending.schedule { apply { $0.style.color = .hex(hex) } }
+        // Keyed on this block's colour: the threshold control beside it queues
+        // under its own key and neither can drop the other.
+        pending.schedule("color.\(token.id)") { apply { $0.style.color = .hex(hex) } }
     }
 
     // MARK: Rule
@@ -1091,7 +1096,11 @@ private struct MenuBarTokenInspector: View {
         HStack(spacing: 8) {
             Text(L10n.MenuBar.composerBlockQuota).frame(width: 62, alignment: .leading)
             fieldPicker(selected: fieldId) { newId in set(newId, percent) }
-            DebouncedPercentStepper(percent: percent, pending: pending) { set(fieldId, $0) }
+            DebouncedPercentStepper(
+                percent: percent,
+                pending: pending,
+                key: "threshold.\(token.id)"
+            ) { set(fieldId, $0) }
             Spacer(minLength: 0)
         }
     }
@@ -1108,8 +1117,8 @@ private struct MenuBarTokenInspector: View {
             }
             ForEach(options) { option in
                 Text(liveFieldIds.contains(option.id)
-                    ? option.title
-                    : L10n.MenuBar.composerFieldOfflineOption(title: option.title))
+                    ? option.displayTitle
+                    : L10n.MenuBar.composerFieldOfflineOption(title: option.displayTitle))
                     .tag(option.id)
             }
         }
@@ -1209,49 +1218,6 @@ private struct MenuBarTokenInspector: View {
     }
 }
 
-/// One queued settings write, owned by something that outlives the control
-/// that queued it.
-///
-/// Debouncing a control means the last change lives in limbo for a moment, and
-/// whatever owns that moment must survive long enough to spend it. Hanging it
-/// off the control itself and flushing in `onDisappear` looks equivalent and
-/// is not: the inspector is `.id(token.id)`, so selecting another block tears
-/// the control down, and a window being destroyed does not reliably deliver
-/// `onDisappear` at all. The editor outlives both, so the editor holds the
-/// pending write and flushes it at moments it can actually observe — a
-/// selection change, any other edit, its own teardown.
-@MainActor
-final class MenuBarPendingCommit: ObservableObject {
-    private var pending: (() -> Void)?
-    private var task: Task<Void, Never>?
-
-    /// Queue `commit`, replacing anything already queued: while the user is
-    /// still dragging or clicking, only the newest value matters.
-    func schedule(
-        after delay: Duration = .milliseconds(250),
-        _ commit: @escaping () -> Void
-    ) {
-        pending = commit
-        task?.cancel()
-        task = Task { @MainActor [weak self] in
-            try? await Task.sleep(for: delay)
-            guard !Task.isCancelled else { return }
-            self?.flush()
-        }
-    }
-
-    /// Write whatever is queued, now. Safe to call when nothing is, and safe
-    /// to re-enter: the queue is cleared before the work runs, so a flush
-    /// triggered from inside a commit finds nothing to do.
-    func flush() {
-        task?.cancel()
-        task = nil
-        let work = pending
-        pending = nil
-        work?()
-    }
-}
-
 /// A percent stepper that writes settings on an idle window rather than on
 /// every repeat.
 ///
@@ -1261,7 +1227,8 @@ final class MenuBarPendingCommit: ObservableObject {
 /// well: the control tracks its own draft and commits once the user stops.
 private struct DebouncedPercentStepper: View {
     let percent: Double
-    let pending: MenuBarPendingCommit
+    let pending: PendingEditQueue
+    let key: String
     let commit: (Double) -> Void
 
     @State private var draft: Double = 0
@@ -1284,7 +1251,7 @@ private struct DebouncedPercentStepper: View {
         .onChange(of: draft) { _, value in
             guard value != percent else { return }
             let commit = self.commit
-            pending.schedule { commit(value) }
+            pending.schedule(key) { commit(value) }
         }
     }
 }

--- a/Sources/VibeBarApp/Views/MenuBarComposerEditor.swift
+++ b/Sources/VibeBarApp/Views/MenuBarComposerEditor.swift
@@ -89,6 +89,15 @@ struct MenuBarComposerEditor: View {
         var customLabels: [String: String]
     }
 
+    /// Whether the preview's cached snapshot goes stale on the forecast's own
+    /// clock. The `TimelineView` below only re-plans; forecast values live in
+    /// the snapshot, so they need a rebuild, not a redraw.
+    private var needsForecastClock: Bool {
+        displayedComposition.needsForecastClock(
+            colorBasis: settingsStore.settings.menuBarColorBasis
+        )
+    }
+
     private var snapshotKey: SnapshotKey {
         SnapshotKey(
             requirements: composition.quotaRequirements,
@@ -131,6 +140,24 @@ struct MenuBarComposerEditor: View {
         // teardown to be delivered.
         .onChange(of: selection) { _, _ in pendingCommit.flush() }
         .onDisappear { pendingCommit.flush() }
+        // A forecast percentage, a verdict rule, or a forecast colour goes
+        // stale on `QuotaService`'s five-minute grid, and none of the input
+        // publishers fires in between. Rebuild the cached snapshot on that
+        // grid — gated, so a strip with no forecast in it starts nothing, and
+        // paced to the forecast's own quantum rather than anything faster.
+        .task(id: needsForecastClock) {
+            guard needsForecastClock else { return }
+            while !Task.isCancelled {
+                let next = MenuBarCountdownClock.nextTick(
+                    after: Date(),
+                    anchor: QuotaClockSchedule.anchor,
+                    interval: MenuBarCountdownClock.forecastInterval
+                )
+                try? await Task.sleep(for: .seconds(max(0, next.timeIntervalSinceNow)))
+                guard !Task.isCancelled else { return }
+                rebuildSnapshots()
+            }
+        }
     }
 
     // MARK: - Template

--- a/Sources/VibeBarApp/Views/MenuBarComposerEditor.swift
+++ b/Sources/VibeBarApp/Views/MenuBarComposerEditor.swift
@@ -240,6 +240,11 @@ struct MenuBarComposerEditor: View {
                     ForEach(composition.tokens) { token in
                         chip(token, availability: availability)
                             .onDrag {
+                                // A queued colour or threshold has to land
+                                // first: the drop writes this snapshot back
+                                // wholesale, so an edit missing from it would
+                                // be undone by the drag that followed it.
+                                pendingCommit.flush()
                                 dragEnteredTarget()
                                 draggedTokenId = token.id
                                 // Snapshot the committed order; every crossing
@@ -1060,13 +1065,39 @@ private struct MenuBarTokenInspector: View {
         case .always:
             EmptyView()
         case let .whenUsedAtLeast(fieldId, percent):
-            thresholdRow(fieldId: fieldId, percent: percent) { newId, newPercent in
-                update { $0.visibility = .whenUsedAtLeast(fieldId: newId, percent: newPercent) }
-            }
+            thresholdRow(
+                fieldId: fieldId,
+                percent: percent,
+                setField: { newId in
+                    update {
+                        guard case let .whenUsedAtLeast(_, current) = $0.visibility else { return }
+                        $0.visibility = .whenUsedAtLeast(fieldId: newId, percent: current)
+                    }
+                },
+                setPercent: { newPercent in
+                    update {
+                        guard case let .whenUsedAtLeast(id, _) = $0.visibility else { return }
+                        $0.visibility = .whenUsedAtLeast(fieldId: id, percent: newPercent)
+                    }
+                }
+            )
         case let .whenRemainingAtMost(fieldId, percent):
-            thresholdRow(fieldId: fieldId, percent: percent) { newId, newPercent in
-                update { $0.visibility = .whenRemainingAtMost(fieldId: newId, percent: newPercent) }
-            }
+            thresholdRow(
+                fieldId: fieldId,
+                percent: percent,
+                setField: { newId in
+                    update {
+                        guard case let .whenRemainingAtMost(_, current) = $0.visibility else { return }
+                        $0.visibility = .whenRemainingAtMost(fieldId: newId, percent: current)
+                    }
+                },
+                setPercent: { newPercent in
+                    update {
+                        guard case let .whenRemainingAtMost(id, _) = $0.visibility else { return }
+                        $0.visibility = .whenRemainingAtMost(fieldId: id, percent: newPercent)
+                    }
+                }
+            )
         case let .whenForecast(fieldId, verdicts):
             HStack(spacing: 8) {
                 Text(L10n.MenuBar.composerBlockQuota).frame(width: 62, alignment: .leading)
@@ -1110,19 +1141,28 @@ private struct MenuBarTokenInspector: View {
         verdict.label
     }
 
+    /// Two setters, not one taking both values.
+    ///
+    /// A combined setter has to capture the value it is not changing, and the
+    /// captured copy is stale the moment the parent flushes a queued edit —
+    /// so picking another quota within the debounce window wrote the
+    /// pre-flush threshold back over the one that had just landed. Each
+    /// control changes only what it owns, which is the same rule that made
+    /// whole-token replacement go away.
     private func thresholdRow(
         fieldId: String,
         percent: Double,
-        set: @escaping (String, Double) -> Void
+        setField: @escaping (String) -> Void,
+        setPercent: @escaping (Double) -> Void
     ) -> some View {
         HStack(spacing: 8) {
             Text(L10n.MenuBar.composerBlockQuota).frame(width: 62, alignment: .leading)
-            fieldPicker(selected: fieldId) { newId in set(newId, percent) }
+            fieldPicker(selected: fieldId) { setField($0) }
             DebouncedPercentStepper(
                 percent: percent,
                 pending: pending,
                 key: "threshold.\(token.id)"
-            ) { set(fieldId, $0) }
+            ) { setPercent($0) }
             Spacer(minLength: 0)
         }
     }

--- a/Sources/VibeBarApp/Views/MenuBarComposerEditor.swift
+++ b/Sources/VibeBarApp/Views/MenuBarComposerEditor.swift
@@ -671,6 +671,11 @@ struct MenuBarComposerEditor: View {
             try? await Task.sleep(for: .milliseconds(200))
             guard !Task.isCancelled else { return }
             dragComposition = composition
+            // The identity goes with it. `displayedComposition` prefers the
+            // drag snapshot while a token is being dragged, so leaving the id
+            // set kept the editor and the preview showing the old blocks after
+            // Start over while the status item had already changed.
+            draggedTokenId = nil
             dragCancelTask = nil
         }
     }
@@ -854,6 +859,8 @@ private struct MenuBarTokenInspector: View {
                 Text(L10n.MenuBar.composerBlockText).frame(width: 62, alignment: .leading)
                 DebouncedSettingsTextField(
                     prompt: L10n.MenuBar.composerTextPlaceholder,
+                    pending: pending,
+                    pendingKey: "text.\(token.id)",
                     value: Binding(
                         get: { text },
                         set: { value in
@@ -878,6 +885,8 @@ private struct MenuBarTokenInspector: View {
                 Text(L10n.MenuBar.composerBlockSeparator).frame(width: 62, alignment: .leading)
                 DebouncedSettingsTextField(
                     prompt: " · ",
+                    pending: pending,
+                    pendingKey: "separator.\(token.id)",
                     value: Binding(
                         get: { separator },
                         set: { value in update { $0.kind = .separator(value) } }

--- a/Sources/VibeBarApp/Views/MenuBarComposerEditor.swift
+++ b/Sources/VibeBarApp/Views/MenuBarComposerEditor.swift
@@ -1,0 +1,1143 @@
+import SwiftUI
+import UniformTypeIdentifiers
+import VibeBarCore
+
+/// The menu-bar strip composer.
+///
+/// Template, then a live preview on both menu-bar grounds, then the strip as
+/// draggable chips over a remove target, then a palette of blocks to add, then
+/// an inspector for whichever chip is selected.
+///
+/// The view owns no list logic: every insert, move, duplicate and delete is a
+/// `MenuBarComposition` mutation, so what the editor does to a strip is
+/// testable without a gesture. It also owns no quota resolution — the preview
+/// draws `MenuBarStripView` from the same plan the status item draws, and the
+/// snapshots behind it are cached per data change rather than rebuilt while
+/// the user types (`AGENTS.md` § 7).
+struct MenuBarComposerEditor: View {
+    let kind: MenuBarItemKind
+    let density: Theme.Density
+
+    @EnvironmentObject private var environment: AppEnvironment
+    @EnvironmentObject private var settingsStore: SettingsStore
+    @EnvironmentObject private var quotaService: QuotaService
+
+    @State private var selection: UUID?
+    @State private var draggedTokenId: UUID?
+    @State private var isOverRemoveTarget = false
+    @State private var isConfirmingReseed = false
+
+    // Everything expensive is cached and rebuilt on a data change, never on a
+    // keystroke: resolving a quota can compute a personal forecast, and this
+    // editor re-renders on every character typed into a text block.
+    @State private var snapshots: [MenuBarQuotaSnapshot] = []
+    @State private var liveFieldIds: Set<String> = []
+    @State private var optionsById: [String: MenuBarFieldOption] = [:]
+    @State private var paletteQuotaSections: [PaletteQuotaSection] = []
+    @State private var paletteLogoTools: [ToolType] = []
+
+    private struct PaletteQuotaSection: Identifiable {
+        let tool: ToolType
+        let title: String
+        let options: [MenuBarFieldOption]
+        var id: String { "\(tool.rawValue).\(title)" }
+    }
+
+    private var item: MenuBarItemSettings { settingsStore.settings.menuBarItem(kind) }
+    private var composition: MenuBarComposition { item.composition ?? MenuBarComposition() }
+
+    var body: some View {
+        let composition = self.composition
+        let plan = composition.plan(
+            quotas: snapshots,
+            displayMode: settingsStore.settings.displayMode,
+            colorBasis: settingsStore.settings.menuBarColorBasis
+        )
+        let availability = composition.availability(liveFieldIds: liveFieldIds)
+
+        VStack(alignment: .leading, spacing: density.cardSpacing + 4) {
+            templateRow(composition)
+            previewRow(plan: plan)
+            stripRow(composition, availability: availability)
+            paletteRow(composition)
+            inspectorRow(composition, availability: availability)
+            footerRow(availability: availability)
+        }
+        .onAppear {
+            rebuildCatalog()
+            rebuildSnapshots()
+        }
+        .onChange(of: quotaService.fieldRegistry) { _, _ in
+            rebuildCatalog()
+            rebuildSnapshots()
+        }
+        .onReceive(quotaService.$lastSuccessByAccount) { _ in rebuildSnapshots() }
+        // Adding or removing a quota block changes which buckets the preview
+        // needs; editing a word does not. Keying the rebuild on the referenced
+        // set is what keeps a forecast off the typing path.
+        .onChange(of: composition.referencedFieldIds) { _, _ in rebuildSnapshots() }
+    }
+
+    // MARK: - Template
+
+    private func templateRow(_ composition: MenuBarComposition) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Picker("Template", selection: templateBinding()) {
+                ForEach(MenuBarComposition.Template.allCases, id: \.self) { template in
+                    Text(template.title).tag(template)
+                }
+            }
+            .pickerStyle(.segmented)
+            Text(composition.template.detail)
+                .font(.caption2)
+                .foregroundStyle(.tertiary)
+        }
+    }
+
+    // MARK: - Preview
+
+    private func previewRow(plan: MenuBarRenderPlan) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            caption("Preview")
+            MenuBarStripPreview(
+                plan: plan,
+                quotas: snapshots,
+                displayMode: settingsStore.settings.displayMode,
+                highlighted: selection
+            )
+            Text("Light and dark menu bars, side by side — a fixed colour that reads well on one can vanish on the other.")
+                .font(.caption2)
+                .foregroundStyle(.tertiary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    // MARK: - Strip
+
+    private func stripRow(
+        _ composition: MenuBarComposition,
+        availability: MenuBarComposition.Availability
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            caption("Blocks — drag to reorder")
+            if composition.tokens.isEmpty {
+                Text("No blocks yet. Add one from the palette below.")
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+            } else {
+                MenuBarChipFlow(spacing: 5, lineSpacing: 5) {
+                    ForEach(composition.tokens) { token in
+                        chip(token, availability: availability)
+                            .onDrag {
+                                draggedTokenId = token.id
+                                return NSItemProvider(object: token.id.uuidString as NSString)
+                            }
+                            .onDrop(
+                                of: [.text],
+                                delegate: MenuBarChipDropDelegate(
+                                    target: token.id,
+                                    dragged: $draggedTokenId,
+                                    apply: { mutate($0) }
+                                )
+                            )
+                    }
+                    // Trailing landing strip, so a block can be dragged to the
+                    // very end without having to hit the last chip exactly.
+                    Color.clear
+                        .frame(width: 16, height: 22)
+                        .contentShape(Rectangle())
+                        .onDrop(
+                            of: [.text],
+                            delegate: MenuBarChipDropDelegate(
+                                target: nil,
+                                dragged: $draggedTokenId,
+                                apply: { mutate($0) }
+                            )
+                        )
+                }
+            }
+            removeTarget
+        }
+    }
+
+    private var removeTarget: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "trash")
+                .font(.system(size: 10, weight: .semibold))
+            Text("Drag here to remove")
+                .font(.caption)
+        }
+        .foregroundStyle(isOverRemoveTarget ? Color.red : Color.secondary)
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 7)
+        .background(
+            RoundedRectangle(cornerRadius: 6, style: .continuous)
+                .fill(Color.red.opacity(isOverRemoveTarget ? 0.16 : 0.05))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 6, style: .continuous)
+                .strokeBorder(
+                    Color.red.opacity(isOverRemoveTarget ? 0.55 : 0.2),
+                    style: StrokeStyle(lineWidth: 0.5, dash: [3, 3])
+                )
+        )
+        .onDrop(
+            of: [.text],
+            delegate: MenuBarChipRemoveDelegate(
+                dragged: $draggedTokenId,
+                isTargeted: $isOverRemoveTarget,
+                selection: $selection,
+                apply: { mutate($0) }
+            )
+        )
+    }
+
+    private func chip(
+        _ token: MenuBarToken,
+        availability: MenuBarComposition.Availability
+    ) -> some View {
+        let isSelected = selection == token.id
+        let isSilent = availability.silentTokenIds.contains(token.id)
+        let isDegraded = availability.degradedTokenIds.contains(token.id)
+        return Button {
+            selection = isSelected ? nil : token.id
+        } label: {
+            HStack(spacing: 4) {
+                if case let .logo(tool) = token.kind {
+                    ToolBrandIconView(tool: tool, size: 11)
+                } else {
+                    Image(systemName: symbol(for: token.kind))
+                        .font(.system(size: 9, weight: .semibold))
+                        .foregroundStyle(.secondary)
+                }
+                Text(chipTitle(token))
+                    .font(.system(size: 11, weight: .medium))
+                    .lineLimit(1)
+                if isSilent || isDegraded {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .font(.system(size: 8, weight: .semibold))
+                        .foregroundStyle(isSilent ? Color.orange : Color.secondary)
+                }
+            }
+            .padding(.horizontal, 7)
+            .padding(.vertical, 4)
+            .background(
+                RoundedRectangle(cornerRadius: 5, style: .continuous)
+                    .fill(Color.primary.opacity(isSelected ? 0.14 : 0.06))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 5, style: .continuous)
+                    .strokeBorder(
+                        isSelected ? Color.accentColor.opacity(0.8) : Color.primary.opacity(0.10),
+                        lineWidth: 0.5
+                    )
+            )
+            .opacity(isSilent ? 0.55 : 1)
+        }
+        .buttonStyle(.plain)
+        .help(chipHelp(token, isSilent: isSilent, isDegraded: isDegraded))
+    }
+
+    private func symbol(for kind: MenuBarToken.Kind) -> String {
+        switch kind {
+        case .logo: return "app.badge"
+        case .text: return "textformat"
+        case .quota: return "percent"
+        case .space: return "space"
+        case .separator: return "line.diagonal"
+        case .lineBreak: return "return"
+        }
+    }
+
+    private func chipTitle(_ token: MenuBarToken) -> String {
+        switch token.kind {
+        case let .logo(tool):
+            return tool.menuTitle
+        case let .text(text):
+            let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+            return trimmed.isEmpty ? "Empty text" : MenuBarToken.truncated(trimmed)
+        case let .quota(fieldId, metric):
+            let name = optionsById[fieldId]?.defaultLabel ?? fieldId
+            return "\(name) · \(metric.title)"
+        case .space:
+            return "Space"
+        case let .separator(separator):
+            let trimmed = separator.trimmingCharacters(in: .whitespacesAndNewlines)
+            return trimmed.isEmpty ? "Gap" : trimmed
+        case .lineBreak:
+            return "New row"
+        }
+    }
+
+    private func chipHelp(_ token: MenuBarToken, isSilent: Bool, isDegraded: Bool) -> String {
+        if isSilent {
+            return "This quota is not being returned right now, so this block draws nothing. "
+                + "It stays here and comes back on its own."
+        }
+        if isDegraded {
+            return "This block still draws, but a colour or a rule on it points at a quota "
+                + "that is not being returned right now."
+        }
+        return chipTitle(token)
+    }
+
+    // MARK: - Palette
+
+    private func paletteRow(_ composition: MenuBarComposition) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            caption("Add a block")
+            paletteGroup("Logo") {
+                ForEach(paletteLogoTools, id: \.self) { tool in
+                    paletteButton(title: tool.menuTitle, icon: nil, tool: tool) {
+                        add(MenuBarToken(kind: .logo(tool), style: .label))
+                    }
+                }
+            }
+            paletteGroup("Text") {
+                paletteButton(title: "Text", icon: "textformat") {
+                    add(MenuBarToken(kind: .text("Label"), style: .label))
+                }
+            }
+            paletteGroup("Quota") {
+                ForEach(paletteQuotaSections) { section in
+                    Menu {
+                        ForEach(section.options) { option in
+                            Button(option.title) {
+                                add(MenuBarToken(
+                                    kind: .quota(fieldId: option.id, metric: .displayPercent),
+                                    style: .percent
+                                ))
+                            }
+                        }
+                    } label: {
+                        HStack(spacing: 4) {
+                            ToolBrandIconView(tool: section.tool, size: 11)
+                            Text(section.title).font(.system(size: 11, weight: .medium))
+                        }
+                    }
+                    .menuStyle(.borderlessButton)
+                    .fixedSize()
+                }
+            }
+            paletteGroup("Structure") {
+                paletteButton(title: "Space", icon: "space") {
+                    add(MenuBarToken(kind: .space))
+                }
+                paletteButton(title: "Separator", icon: "line.diagonal") {
+                    add(MenuBarToken(kind: .separator(" · "), style: .divider))
+                }
+                paletteButton(title: "New row", icon: "return") {
+                    add(MenuBarToken(kind: .lineBreak))
+                }
+                // Two rows is all the status item can draw; offering a third
+                // break would build a row the bar silently folds away.
+                .disabled(!composition.canAddLineBreak)
+                .help(
+                    composition.canAddLineBreak
+                        ? "Split the strip into a second row."
+                        : "The menu bar can only draw two rows."
+                )
+            }
+        }
+    }
+
+    private func paletteGroup<Content: View>(
+        _ title: String,
+        @ViewBuilder content: () -> Content
+    ) -> some View {
+        HStack(alignment: .top, spacing: 8) {
+            Text(title)
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundStyle(.tertiary)
+                .frame(width: 62, alignment: .leading)
+                .padding(.top, 4)
+            MenuBarChipFlow(spacing: 5, lineSpacing: 5) {
+                content()
+            }
+        }
+    }
+
+    private func paletteButton(
+        title: String,
+        icon: String?,
+        tool: ToolType? = nil,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            HStack(spacing: 4) {
+                if let tool {
+                    ToolBrandIconView(tool: tool, size: 11)
+                } else if let icon {
+                    Image(systemName: icon).font(.system(size: 9, weight: .semibold))
+                }
+                Text(title).font(.system(size: 11, weight: .medium))
+            }
+            .padding(.horizontal, 7)
+            .padding(.vertical, 4)
+            .background(
+                RoundedRectangle(cornerRadius: 5, style: .continuous)
+                    .fill(Color.primary.opacity(0.06))
+            )
+        }
+        .buttonStyle(.plain)
+    }
+
+    // MARK: - Inspector
+
+    @ViewBuilder
+    private func inspectorRow(
+        _ composition: MenuBarComposition,
+        availability: MenuBarComposition.Availability
+    ) -> some View {
+        if let id = selection, let token = composition.token(id) {
+            VStack(alignment: .leading, spacing: 8) {
+                HStack(spacing: 8) {
+                    caption("Selected block")
+                    Spacer(minLength: 8)
+                    Button("Duplicate") { mutate { $0.duplicate(id) } }
+                        .buttonStyle(.vibeBar)
+                    Button("Remove") {
+                        selection = nil
+                        mutate { $0.remove(id) }
+                    }
+                    .buttonStyle(.vibeBar)
+                }
+                if availability.silentTokenIds.contains(id) {
+                    warning("This quota is not being returned right now, so the block draws nothing. Nothing is broken — it reappears when the provider answers again.")
+                } else if availability.degradedTokenIds.contains(id) {
+                    warning("A colour or rule on this block points at a quota that is not being returned right now, so that part falls back.")
+                }
+                MenuBarTokenInspector(
+                    token: token,
+                    options: sortedOptions,
+                    liveFieldIds: liveFieldIds,
+                    apply: { updated in
+                        mutate { composed in
+                            guard let index = composed.index(of: updated.id) else { return }
+                            composed.tokens[index] = updated
+                        }
+                    }
+                )
+                // Selecting a different chip is a different inspector, so its
+                // colour-well draft starts from that block rather than from
+                // whatever the last one was.
+                .id(token.id)
+            }
+            .padding(10)
+            .background(
+                RoundedRectangle(cornerRadius: 6, style: .continuous)
+                    .fill(Color.primary.opacity(0.04))
+            )
+        }
+    }
+
+    private func warning(_ text: String) -> some View {
+        HStack(alignment: .top, spacing: 5) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .font(.system(size: 9, weight: .semibold))
+                .foregroundStyle(.orange)
+            Text(text)
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    // MARK: - Footer
+
+    private func footerRow(availability: MenuBarComposition.Availability) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            if !availability.isFullyAvailable {
+                warning(
+                    "Not answering right now: "
+                        + availability.missingFieldIds
+                            .map { optionsById[$0]?.title ?? $0 }
+                            .joined(separator: ", ")
+                        + "."
+                )
+            }
+            HStack(spacing: 8) {
+                Button("Start over from the current strip…") { isConfirmingReseed = true }
+                    .buttonStyle(.vibeBar)
+                Spacer(minLength: 8)
+            }
+            Text("Starting over replaces every block with a fresh copy of the default strip. There is no undo.")
+                .font(.caption2)
+                .foregroundStyle(.tertiary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .confirmationDialog(
+            "Replace your blocks?",
+            isPresented: $isConfirmingReseed,
+            titleVisibility: .visible
+        ) {
+            Button("Start over", role: .destructive) {
+                selection = nil
+                var updated = item
+                updated.reseedComposedStrip(
+                    template: composition.template,
+                    registry: quotaService.fieldRegistry,
+                    groupCatalogLabel: MiniWindowGroupLabelCatalog.defaultLabel(for:)
+                )
+                settingsStore.settings.setMenuBarItem(updated)
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("Every block you arranged is discarded and rebuilt from the default strip.")
+        }
+    }
+
+    private func caption(_ text: String) -> some View {
+        Text(text)
+            .font(.system(size: 10, weight: .semibold))
+            .foregroundStyle(.tertiary)
+            .textCase(.uppercase)
+            .tracking(0.4)
+    }
+
+    // MARK: - Mutations
+
+    private func mutate(_ change: (inout MenuBarComposition) -> Void) {
+        var updated = item
+        var composed = updated.composition ?? MenuBarComposition(isEnabled: true)
+        change(&composed)
+        updated.composition = composed
+        settingsStore.settings.setMenuBarItem(updated)
+    }
+
+    private func add(_ token: MenuBarToken) {
+        mutate { $0.append(token) }
+        selection = token.id
+    }
+
+    private func templateBinding() -> Binding<MenuBarComposition.Template> {
+        Binding(
+            get: { composition.template },
+            // Changing the template re-styles the strip, never its contents:
+            // the blocks the user arranged are theirs. "Start over" is the
+            // control that rebuilds them, and it asks first.
+            set: { template in mutate { $0.template = template } }
+        )
+    }
+
+    // MARK: - Caches
+
+    private var sortedOptions: [MenuBarFieldOption] {
+        paletteQuotaSections.flatMap(\.options)
+    }
+
+    private func rebuildCatalog() {
+        let merged = MenuBarFieldCatalog.mergedFields(registry: quotaService.fieldRegistry)
+        optionsById = Dictionary(merged.map { ($0.id, $0) }, uniquingKeysWith: { first, _ in first })
+        liveFieldIds = MenuBarStripResolver.liveFieldIds(environment: environment)
+
+        var sections: [PaletteQuotaSection] = []
+        for tool in ToolType.dedicatedCardProviders {
+            let options = merged.filter { $0.tool == tool }
+            guard !options.isEmpty else { continue }
+            // One entry per L2 SubProvider, so Grok Bot is not filed under
+            // Cursor — the quota axis, as `AGENTS.md` § 7.1 requires.
+            var bySubProvider: [(name: String, options: [MenuBarFieldOption])] = []
+            for option in options {
+                let name = tool.quotaSubProviderName(bucketID: option.bucketId)
+                if let index = bySubProvider.firstIndex(where: { $0.name == name }) {
+                    bySubProvider[index].options.append(option)
+                } else {
+                    bySubProvider.append((name, [option]))
+                }
+            }
+            for group in bySubProvider {
+                sections.append(PaletteQuotaSection(
+                    tool: tool,
+                    title: group.name,
+                    options: group.options
+                ))
+            }
+        }
+        paletteQuotaSections = sections
+        paletteLogoTools = ToolType.dedicatedCardProviders
+    }
+
+    private func rebuildSnapshots() {
+        snapshots = MenuBarStripResolver.snapshots(
+            for: composition,
+            itemSettings: item,
+            settings: settingsStore.settings,
+            environment: environment
+        )
+        liveFieldIds = MenuBarStripResolver.liveFieldIds(environment: environment)
+    }
+}
+
+// MARK: - Inspector
+
+/// Controls for one block. Split out so the editor's own body does not
+/// re-evaluate every palette section and every chip when a slider moves.
+private struct MenuBarTokenInspector: View {
+    let token: MenuBarToken
+    let options: [MenuBarFieldOption]
+    let liveFieldIds: Set<String>
+    let apply: (MenuBarToken) -> Void
+
+    @State private var fixedDraft: Color = .accentColor
+
+    private enum ColorChoice: String, CaseIterable, Identifiable {
+        case automatic, forecast, followsQuota, brand, primary, secondary, tertiary, fixed
+        var id: String { rawValue }
+        var title: String {
+            switch self {
+            case .automatic: return "Automatic"
+            case .forecast: return "Forecast"
+            case .followsQuota: return "Follow a quota"
+            case .brand: return "Brand"
+            case .primary: return "Primary"
+            case .secondary: return "Secondary"
+            case .tertiary: return "Tertiary"
+            case .fixed: return "Custom…"
+            }
+        }
+    }
+
+    private enum RuleChoice: String, CaseIterable, Identifiable {
+        case always, whenUsedAtLeast, whenRemainingAtMost, whenForecast
+        var id: String { rawValue }
+        var title: String {
+            switch self {
+            case .always: return "Always"
+            case .whenUsedAtLeast: return "When used is at least"
+            case .whenRemainingAtMost: return "When remaining is at most"
+            case .whenForecast: return "When the forecast says"
+            }
+        }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            contentControls
+            Divider().opacity(0.4)
+            colorControls
+            HStack(spacing: 10) {
+                Picker("Size", selection: sizeBinding) {
+                    ForEach(MenuBarToken.SizeStep.allCases, id: \.self) { Text($0.title).tag($0) }
+                }
+                .frame(width: 150)
+                Picker("Weight", selection: weightBinding) {
+                    ForEach(MenuBarToken.Weight.allCases, id: \.self) { Text($0.title).tag($0) }
+                }
+                .frame(width: 165)
+            }
+            Toggle("Monospaced digits", isOn: monospacedBinding)
+                .help("Keeps a changing number from shifting the blocks beside it.")
+            Divider().opacity(0.4)
+            ruleControls
+        }
+        .font(.system(size: 11.5))
+    }
+
+    // MARK: Content
+
+    @ViewBuilder
+    private var contentControls: some View {
+        switch token.kind {
+        case let .text(text):
+            HStack(spacing: 8) {
+                Text("Text").frame(width: 62, alignment: .leading)
+                DebouncedSettingsTextField(
+                    prompt: "Label",
+                    value: Binding(
+                        get: { text },
+                        set: { value in
+                            // Truncation is a drawing rule, not an input rule:
+                            // the block keeps what was typed and the bar shows
+                            // as much of it as fits.
+                            update { $0.kind = .text(value) }
+                        }
+                    )
+                )
+            }
+            Text("Blocks longer than \(MenuBarToken.maximumTextLength) characters are cut short with an ellipsis in the bar.")
+                .font(.caption2)
+                .foregroundStyle(.tertiary)
+        case let .separator(separator):
+            HStack(spacing: 8) {
+                Text("Separator").frame(width: 62, alignment: .leading)
+                DebouncedSettingsTextField(
+                    prompt: " · ",
+                    value: Binding(
+                        get: { separator },
+                        set: { value in update { $0.kind = .separator(value) } }
+                    )
+                )
+            }
+        case let .quota(fieldId, metric):
+            HStack(spacing: 8) {
+                Text("Quota").frame(width: 62, alignment: .leading)
+                fieldPicker(selected: fieldId) { newId in
+                    update { $0.kind = .quota(fieldId: newId, metric: metric) }
+                }
+            }
+            HStack(spacing: 8) {
+                Text("Shows").frame(width: 62, alignment: .leading)
+                Picker("", selection: Binding(
+                    get: { metric },
+                    set: { value in update { $0.kind = .quota(fieldId: fieldId, metric: value) } }
+                )) {
+                    ForEach(MenuBarQuotaMetric.allCases, id: \.self) { Text($0.title).tag($0) }
+                }
+                .labelsHidden()
+                .frame(width: 220)
+            }
+        case let .logo(tool):
+            HStack(spacing: 8) {
+                Text("Provider").frame(width: 62, alignment: .leading)
+                Picker("", selection: Binding(
+                    get: { tool },
+                    set: { value in update { $0.kind = .logo(value) } }
+                )) {
+                    ForEach(ToolType.dedicatedCardProviders, id: \.self) {
+                        Text($0.menuTitle).tag($0)
+                    }
+                }
+                .labelsHidden()
+                .frame(width: 220)
+            }
+        case .space:
+            // Nothing to configure until the model grows a width; size and
+            // colour below still apply to the gap it draws.
+            Text("A gap one space wide. Size changes how wide.")
+                .font(.caption2)
+                .foregroundStyle(.tertiary)
+        case .lineBreak:
+            Text("Ends the first row and starts the second.")
+                .font(.caption2)
+                .foregroundStyle(.tertiary)
+        }
+    }
+
+    // MARK: Colour
+
+    @ViewBuilder
+    private var colorControls: some View {
+        HStack(spacing: 8) {
+            Text("Colour").frame(width: 62, alignment: .leading)
+            Picker("", selection: colorChoiceBinding) {
+                ForEach(ColorChoice.allCases) { Text($0.title).tag($0) }
+            }
+            .labelsHidden()
+            .frame(width: 165)
+            switch token.style.color {
+            case let .brand(tool):
+                Picker("", selection: Binding(
+                    get: { tool },
+                    set: { value in update { $0.style.color = .brand(value) } }
+                )) {
+                    // The same table `.brand` resolves through, so a swatch
+                    // here cannot promise a colour the bar will not paint.
+                    ForEach(ToolType.dedicatedCardProviders, id: \.self) { candidate in
+                        Label {
+                            Text(candidate.menuTitle)
+                        } icon: {
+                            Circle().fill(Theme.providerAccent(for: candidate))
+                        }
+                        .tag(candidate)
+                    }
+                }
+                .labelsHidden()
+                .frame(width: 150)
+            case .fixed:
+                ColorPicker("", selection: $fixedDraft, supportsOpacity: false)
+                    .labelsHidden()
+                    // Dragging inside a colour well fires continuously; commit
+                    // on an idle window so a drag is one settings write rather
+                    // than a hundred.
+                    .task(id: fixedDraft) {
+                        try? await Task.sleep(for: .milliseconds(250))
+                        guard !Task.isCancelled else { return }
+                        commitFixedColor()
+                    }
+            case let .followsQuota(fieldId, basis):
+                fieldPicker(selected: fieldId) { newId in
+                    update { $0.style.color = .followsQuota(fieldId: newId, basis: basis) }
+                }
+                Picker("", selection: Binding(
+                    get: { basis },
+                    set: { value in
+                        update { $0.style.color = .followsQuota(fieldId: fieldId, basis: value) }
+                    }
+                )) {
+                    ForEach(MenuBarColorBasis.allCases) { Text($0.label).tag($0) }
+                }
+                .labelsHidden()
+                .frame(width: 110)
+            default:
+                EmptyView()
+            }
+            Spacer(minLength: 0)
+        }
+        .onAppear(perform: syncFixedDraft)
+        // Switching the colour role to Custom writes a starting hex; the well
+        // has to follow it, or it would show one colour while the block wears
+        // another.
+        .onChange(of: token.style.color) { _, _ in syncFixedDraft() }
+    }
+
+    private func syncFixedDraft() {
+        guard case let .fixed(hex) = token.style.color,
+              let parts = MenuBarHexColor.components(hex)
+        else { return }
+        fixedDraft = Color(.sRGB, red: parts.r, green: parts.g, blue: parts.b, opacity: parts.a)
+    }
+
+    private func commitFixedColor() {
+        guard case .fixed = token.style.color else { return }
+        let resolved = NSColor(fixedDraft).usingColorSpace(.sRGB) ?? NSColor(fixedDraft)
+        let hex = String(
+            format: "#%02x%02x%02x",
+            Int((resolved.redComponent * 255).rounded()),
+            Int((resolved.greenComponent * 255).rounded()),
+            Int((resolved.blueComponent * 255).rounded())
+        )
+        guard case let .fixed(current) = token.style.color, current != hex else { return }
+        update { $0.style.color = .hex(hex) }
+    }
+
+    // MARK: Rule
+
+    @ViewBuilder
+    private var ruleControls: some View {
+        HStack(spacing: 8) {
+            Text("Show").frame(width: 62, alignment: .leading)
+            Picker("", selection: ruleChoiceBinding) {
+                ForEach(RuleChoice.allCases) { Text($0.title).tag($0) }
+            }
+            .labelsHidden()
+            .frame(width: 210)
+            Spacer(minLength: 0)
+        }
+        switch token.visibility {
+        case .always:
+            EmptyView()
+        case let .whenUsedAtLeast(fieldId, percent):
+            thresholdRow(fieldId: fieldId, percent: percent) { newId, newPercent in
+                update { $0.visibility = .whenUsedAtLeast(fieldId: newId, percent: newPercent) }
+            }
+        case let .whenRemainingAtMost(fieldId, percent):
+            thresholdRow(fieldId: fieldId, percent: percent) { newId, newPercent in
+                update { $0.visibility = .whenRemainingAtMost(fieldId: newId, percent: newPercent) }
+            }
+        case let .whenForecast(fieldId, verdicts):
+            HStack(spacing: 8) {
+                Text("Quota").frame(width: 62, alignment: .leading)
+                fieldPicker(selected: fieldId) { newId in
+                    update { $0.visibility = .whenForecast(fieldId: newId, verdicts: verdicts) }
+                }
+                Spacer(minLength: 0)
+            }
+            HStack(spacing: 6) {
+                Text("Verdicts").frame(width: 62, alignment: .leading)
+                ForEach(Self.selectableVerdicts, id: \.self) { verdict in
+                    Toggle(Self.verdictTitle(verdict), isOn: Binding(
+                        get: { verdicts.contains(verdict) },
+                        set: { on in
+                            var next = verdicts
+                            if on { next.insert(verdict) } else { next.remove(verdict) }
+                            // An empty set would hide the block forever, which
+                            // is not a state the editor should let anyone
+                            // build; it reads as "no rule" instead.
+                            update {
+                                $0.visibility = next.isEmpty
+                                    ? .always
+                                    : .whenForecast(fieldId: fieldId, verdicts: next)
+                            }
+                        }
+                    ))
+                    .toggleStyle(.checkbox)
+                    .font(.caption)
+                }
+                Spacer(minLength: 0)
+            }
+        }
+    }
+
+    private static let selectableVerdicts: [QuotaPaceForecast.Verdict] =
+        [.atRisk, .watch, .enough, .surplus]
+
+    private static func verdictTitle(_ verdict: QuotaPaceForecast.Verdict) -> String {
+        switch verdict {
+        case .atRisk: return "At risk"
+        case .watch: return "Watch"
+        case .enough: return "Enough"
+        case .surplus: return "Surplus"
+        case .learning: return "Learning"
+        }
+    }
+
+    private func thresholdRow(
+        fieldId: String,
+        percent: Double,
+        set: @escaping (String, Double) -> Void
+    ) -> some View {
+        HStack(spacing: 8) {
+            Text("Quota").frame(width: 62, alignment: .leading)
+            fieldPicker(selected: fieldId) { newId in set(newId, percent) }
+            Stepper(
+                value: Binding(
+                    get: { percent },
+                    set: { set(fieldId, $0) }
+                ),
+                in: 0...100,
+                step: 5
+            ) {
+                Text("\(Int(percent.rounded()))%")
+                    .font(.system(size: 11.5).monospacedDigit())
+                    .frame(width: 42, alignment: .trailing)
+            }
+            Spacer(minLength: 0)
+        }
+    }
+
+    private func fieldPicker(
+        selected: String,
+        set: @escaping (String) -> Void
+    ) -> some View {
+        Picker("", selection: Binding(get: { selected }, set: set)) {
+            // A field the strip names but the catalog no longer lists still
+            // needs a row, or selecting it would silently jump elsewhere.
+            if !options.contains(where: { $0.id == selected }) {
+                Text(selected).tag(selected)
+            }
+            ForEach(options) { option in
+                Text(liveFieldIds.contains(option.id) ? option.title : "\(option.title) (offline)")
+                    .tag(option.id)
+            }
+        }
+        .labelsHidden()
+        .frame(width: 210)
+    }
+
+    // MARK: Bindings
+
+    private func update(_ change: (inout MenuBarToken) -> Void) {
+        var updated = token
+        change(&updated)
+        guard updated != token else { return }
+        apply(updated)
+    }
+
+    private var colorChoiceBinding: Binding<ColorChoice> {
+        Binding(
+            get: {
+                switch token.style.color {
+                case .automatic: return .automatic
+                case .forecast: return .forecast
+                case .followsQuota: return .followsQuota
+                case .brand: return .brand
+                case .primary: return .primary
+                case .secondary: return .secondary
+                case .tertiary: return .tertiary
+                case .fixed: return .fixed
+                }
+            },
+            set: { choice in
+                let fallbackField = token.quotaFieldId ?? options.first?.id
+                update { edited in
+                    switch choice {
+                    case .automatic: edited.style.color = .automatic
+                    case .forecast: edited.style.color = .forecast
+                    case .followsQuota:
+                        guard let fallbackField else { return }
+                        edited.style.color = .followsQuota(fieldId: fallbackField, basis: .forecast)
+                    case .brand:
+                        if case let .logo(tool) = edited.kind {
+                            edited.style.color = .brand(tool)
+                        } else {
+                            edited.style.color = .brand(ToolType.dedicatedCardProviders.first ?? .claude)
+                        }
+                    case .primary: edited.style.color = .primary
+                    case .secondary: edited.style.color = .secondary
+                    case .tertiary: edited.style.color = .tertiary
+                    case .fixed: edited.style.color = .hex("#7f7f7f")
+                    }
+                }
+            }
+        )
+    }
+
+    private var ruleChoiceBinding: Binding<RuleChoice> {
+        Binding(
+            get: {
+                switch token.visibility {
+                case .always: return .always
+                case .whenUsedAtLeast: return .whenUsedAtLeast
+                case .whenRemainingAtMost: return .whenRemainingAtMost
+                case .whenForecast: return .whenForecast
+                }
+            },
+            set: { choice in
+                let field = token.visibility.fieldId ?? token.quotaFieldId ?? options.first?.id
+                update { edited in
+                    switch choice {
+                    case .always:
+                        edited.visibility = .always
+                    case .whenUsedAtLeast:
+                        guard let field else { return }
+                        edited.visibility = .whenUsedAtLeast(fieldId: field, percent: 80)
+                    case .whenRemainingAtMost:
+                        guard let field else { return }
+                        edited.visibility = .whenRemainingAtMost(fieldId: field, percent: 20)
+                    case .whenForecast:
+                        guard let field else { return }
+                        edited.visibility = .whenForecast(fieldId: field, verdicts: [.atRisk, .watch])
+                    }
+                }
+            }
+        )
+    }
+
+    private var sizeBinding: Binding<MenuBarToken.SizeStep> {
+        Binding(get: { token.style.size }, set: { value in update { $0.style.size = value } })
+    }
+
+    private var weightBinding: Binding<MenuBarToken.Weight> {
+        Binding(get: { token.style.weight }, set: { value in update { $0.style.weight = value } })
+    }
+
+    private var monospacedBinding: Binding<Bool> {
+        Binding(
+            get: { token.style.monospacedDigits },
+            set: { value in update { $0.style.monospacedDigits = value } }
+        )
+    }
+}
+
+// MARK: - Drag and drop
+
+/// Reorder onto a chip, or onto the trailing landing strip when `target` is
+/// nil. The move itself is `MenuBarComposition.move`, so the delegate decides
+/// only *where*, never *how*.
+private struct MenuBarChipDropDelegate: DropDelegate {
+    let target: UUID?
+    @Binding var dragged: UUID?
+    let apply: ((inout MenuBarComposition) -> Void) -> Void
+
+    func dropEntered(info: DropInfo) {
+        guard let dragged else { return }
+        apply { composed in
+            if let target {
+                composed.move(dragged, before: target)
+            } else {
+                composed.move(dragged, to: composed.tokens.count)
+            }
+        }
+    }
+
+    func performDrop(info: DropInfo) -> Bool {
+        dragged = nil
+        return true
+    }
+
+    func dropUpdated(info: DropInfo) -> DropProposal? {
+        DropProposal(operation: .move)
+    }
+}
+
+private struct MenuBarChipRemoveDelegate: DropDelegate {
+    @Binding var dragged: UUID?
+    @Binding var isTargeted: Bool
+    @Binding var selection: UUID?
+    let apply: ((inout MenuBarComposition) -> Void) -> Void
+
+    func dropEntered(info: DropInfo) { isTargeted = true }
+
+    func dropExited(info: DropInfo) { isTargeted = false }
+
+    func performDrop(info: DropInfo) -> Bool {
+        defer {
+            dragged = nil
+            isTargeted = false
+        }
+        guard let dragged else { return false }
+        if selection == dragged { selection = nil }
+        apply { $0.remove(dragged) }
+        return true
+    }
+
+    func dropUpdated(info: DropInfo) -> DropProposal? {
+        DropProposal(operation: .move)
+    }
+}
+
+// MARK: - Layout
+
+/// Left-to-right wrapping row of chips.
+///
+/// The strip and the palette are both "as many small things as fit, then wrap"
+/// — a `LazyVGrid` would force a column width every chip has to live inside,
+/// which is wrong for labels that range from "Space" to "Claude Weekly · Runs
+/// out in".
+struct MenuBarChipFlow: Layout {
+    var spacing: CGFloat = 6
+    var lineSpacing: CGFloat = 6
+
+    func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout Void) -> CGSize {
+        // An unspecified *or* infinite proposal means "how wide do you want to
+        // be" — answering `.infinity` there makes the whole settings column
+        // grow without bound.
+        let proposed = proposal.width
+        let maxWidth = (proposed?.isFinite ?? false) ? proposed! : .infinity
+        let rows = lines(subviews: subviews, maxWidth: maxWidth)
+        let height = rows.reduce(0) { $0 + $1.height } +
+            lineSpacing * CGFloat(max(0, rows.count - 1))
+        let widest = rows.map(\.width).max() ?? 0
+        return CGSize(width: maxWidth.isFinite ? maxWidth : widest, height: height)
+    }
+
+    func placeSubviews(
+        in bounds: CGRect,
+        proposal: ProposedViewSize,
+        subviews: Subviews,
+        cache: inout Void
+    ) {
+        var y = bounds.minY
+        for row in lines(subviews: subviews, maxWidth: bounds.width) {
+            var x = bounds.minX
+            for index in row.indices {
+                let size = subviews[index].sizeThatFits(.unspecified)
+                subviews[index].place(
+                    at: CGPoint(x: x, y: y + (row.height - size.height) / 2),
+                    proposal: ProposedViewSize(size)
+                )
+                x += size.width + spacing
+            }
+            y += row.height + lineSpacing
+        }
+    }
+
+    private struct Line {
+        var indices: [Int] = []
+        var width: CGFloat = 0
+        var height: CGFloat = 0
+    }
+
+    private func lines(subviews: Subviews, maxWidth: CGFloat) -> [Line] {
+        var rows: [Line] = []
+        var current = Line()
+        for index in subviews.indices {
+            let size = subviews[index].sizeThatFits(.unspecified)
+            let advance = current.indices.isEmpty ? size.width : current.width + spacing + size.width
+            if !current.indices.isEmpty, advance > maxWidth {
+                rows.append(current)
+                current = Line()
+                current.indices = [index]
+                current.width = size.width
+                current.height = size.height
+            } else {
+                current.indices.append(index)
+                current.width = advance
+                current.height = max(current.height, size.height)
+            }
+        }
+        if !current.indices.isEmpty { rows.append(current) }
+        return rows
+    }
+}

--- a/Sources/VibeBarApp/Views/MenuBarComposerEditor.swift
+++ b/Sources/VibeBarApp/Views/MenuBarComposerEditor.swift
@@ -36,6 +36,10 @@ struct MenuBarComposerEditor: View {
     /// path. The reorder is kept here while the drag is live and committed
     /// once, on drop.
     @State private var dragComposition: MenuBarComposition?
+    /// Fires shortly after the pointer leaves every drop target. SwiftUI has
+    /// no "drag cancelled" callback, so a release outside the strip is
+    /// inferred from the pointer leaving and not coming back.
+    @State private var dragCancelTask: Task<Void, Never>?
     @State private var isOverRemoveTarget = false
     @State private var isConfirmingReseed = false
 
@@ -200,6 +204,7 @@ struct MenuBarComposerEditor: View {
                     ForEach(composition.tokens) { token in
                         chip(token, availability: availability)
                             .onDrag {
+                                dragEnteredTarget()
                                 draggedTokenId = token.id
                                 // Snapshot the committed order; every crossing
                                 // reorders this copy, and only the drop writes.
@@ -212,7 +217,9 @@ struct MenuBarComposerEditor: View {
                                     target: token.id,
                                     dragged: $draggedTokenId,
                                     provisional: $dragComposition,
-                                    commit: { commitDrag() }
+                                    commit: { commitDrag() },
+                                    entered: { dragEnteredTarget() },
+                                    exited: { dragLeftTarget() }
                                 )
                             )
                     }
@@ -227,7 +234,9 @@ struct MenuBarComposerEditor: View {
                                 target: nil,
                                 dragged: $draggedTokenId,
                                 provisional: $dragComposition,
-                                commit: { commitDrag() }
+                                commit: { commitDrag() },
+                                entered: { dragEnteredTarget() },
+                                exited: { dragLeftTarget() }
                             )
                         )
                 }
@@ -263,7 +272,9 @@ struct MenuBarComposerEditor: View {
                 dragged: $draggedTokenId,
                 isTargeted: $isOverRemoveTarget,
                 selection: $selection,
-                remove: { removeDragged($0) }
+                remove: { removeDragged($0) },
+                entered: { dragEnteredTarget() },
+                exited: { dragLeftTarget() }
             )
         )
     }
@@ -582,6 +593,8 @@ struct MenuBarComposerEditor: View {
     private func mutate(_ change: (inout MenuBarComposition) -> Void) {
         // A real edit ends any drag state: the provisional order must never
         // outlive the arrangement it was based on.
+        dragCancelTask?.cancel()
+        dragCancelTask = nil
         dragComposition = nil
         draggedTokenId = nil
         var updated = item
@@ -589,6 +602,30 @@ struct MenuBarComposerEditor: View {
         change(&composed)
         updated.composition = composed
         settingsStore.settings.setMenuBarItem(updated)
+    }
+
+    /// The pointer is over a drop target again, so the drag is still live.
+    private func dragEnteredTarget() {
+        dragCancelTask?.cancel()
+        dragCancelTask = nil
+    }
+
+    /// The pointer left a drop target. If it does not come back, the drag was
+    /// released somewhere that accepts nothing and `performDrop` will never
+    /// run — so the provisional order has to go, or the strip keeps showing an
+    /// arrangement no settings write ever matched.
+    ///
+    /// The provisional copy is reset to the committed order rather than
+    /// dropped: the pointer may well come back, and `dropEntered` reorders
+    /// from whatever is here.
+    private func dragLeftTarget() {
+        dragCancelTask?.cancel()
+        dragCancelTask = Task { @MainActor in
+            try? await Task.sleep(for: .milliseconds(200))
+            guard !Task.isCancelled else { return }
+            dragComposition = composition
+            dragCancelTask = nil
+        }
     }
 
     /// The one settings write a completed drag performs.
@@ -689,6 +726,12 @@ private struct MenuBarTokenInspector: View {
 
     @State private var fixedDraft: Color = .accentColor
 
+    /// Whether this block puts anything on screen. A row break does not.
+    private var drawsInk: Bool {
+        if case .lineBreak = token.kind { return false }
+        return true
+    }
+
     private enum ColorChoice: String, CaseIterable, Identifiable {
         case automatic, forecast, followsQuota, brand, primary, secondary, tertiary, fixed
         var id: String { rawValue }
@@ -722,20 +765,25 @@ private struct MenuBarTokenInspector: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
             contentControls
-            Divider().opacity(0.4)
-            colorControls
-            HStack(spacing: 10) {
-                Picker("Size", selection: sizeBinding) {
-                    ForEach(MenuBarToken.SizeStep.allCases, id: \.self) { Text($0.title).tag($0) }
+            // A row break draws no ink, so colour, size and weight would be
+            // controls that quietly do nothing. Its rule still applies — a
+            // conditional break is the whole point of putting one on it.
+            if drawsInk {
+                Divider().opacity(0.4)
+                colorControls
+                HStack(spacing: 10) {
+                    Picker("Size", selection: sizeBinding) {
+                        ForEach(MenuBarToken.SizeStep.allCases, id: \.self) { Text($0.title).tag($0) }
+                    }
+                    .frame(width: 150)
+                    Picker("Weight", selection: weightBinding) {
+                        ForEach(MenuBarToken.Weight.allCases, id: \.self) { Text($0.title).tag($0) }
+                    }
+                    .frame(width: 165)
                 }
-                .frame(width: 150)
-                Picker("Weight", selection: weightBinding) {
-                    ForEach(MenuBarToken.Weight.allCases, id: \.self) { Text($0.title).tag($0) }
-                }
-                .frame(width: 165)
+                Toggle("Monospaced digits", isOn: monospacedBinding)
+                    .help("Keeps a changing number from shifting the blocks beside it.")
             }
-            Toggle("Monospaced digits", isOn: monospacedBinding)
-                .help("Keeps a changing number from shifting the blocks beside it.")
             Divider().opacity(0.4)
             ruleControls
         }
@@ -816,9 +864,10 @@ private struct MenuBarTokenInspector: View {
                 .font(.caption2)
                 .foregroundStyle(.tertiary)
         case .lineBreak:
-            Text("Ends the first row and starts the second.")
+            Text("Ends the first row and starts the second. Give it a rule below to split only when that quota says so.")
                 .font(.caption2)
                 .foregroundStyle(.tertiary)
+                .fixedSize(horizontal: false, vertical: true)
         case .appIcon:
             Text("Vibe Bar's own icon — what the Icon Only layout shows.")
                 .font(.caption2)
@@ -867,6 +916,11 @@ private struct MenuBarTokenInspector: View {
                         guard !Task.isCancelled else { return }
                         commitFixedColor()
                     }
+                    // Same removal, same flush: picking a colour and
+                    // immediately selecting another block must not drop it.
+                    // `commitFixedColor` no-ops unless the block is still a
+                    // custom colour, so switching the role away is safe.
+                    .onDisappear(perform: commitFixedColor)
             case let .followsQuota(fieldId, basis):
                 fieldPicker(selected: fieldId) { newId in
                     update { $0.style.color = .followsQuota(fieldId: newId, basis: basis) }
@@ -1142,6 +1196,13 @@ private struct DebouncedPercentStepper: View {
             guard !Task.isCancelled else { return }
             commit(draft)
         }
+        // The inspector is `.id(token.id)`, so selecting another block removes
+        // this control and cancels the pending commit mid-window. Flush, the
+        // way `DebouncedSettingsTextField` already does, or the last change the
+        // user made is silently lost.
+        .onDisappear {
+            if draft != percent { commit(draft) }
+        }
     }
 }
 
@@ -1156,8 +1217,13 @@ private struct MenuBarChipDropDelegate: DropDelegate {
     /// Reordered in place on every crossing. Local state, not settings.
     @Binding var provisional: MenuBarComposition?
     let commit: () -> Void
+    let entered: () -> Void
+    let exited: () -> Void
+
+    func dropExited(info: DropInfo) { exited() }
 
     func dropEntered(info: DropInfo) {
+        entered()
         guard let dragged, provisional != nil else { return }
         if let target {
             provisional?.move(dragged, before: target)
@@ -1181,10 +1247,18 @@ private struct MenuBarChipRemoveDelegate: DropDelegate {
     @Binding var isTargeted: Bool
     @Binding var selection: UUID?
     let remove: (UUID) -> Void
+    let entered: () -> Void
+    let exited: () -> Void
 
-    func dropEntered(info: DropInfo) { isTargeted = true }
+    func dropEntered(info: DropInfo) {
+        entered()
+        isTargeted = true
+    }
 
-    func dropExited(info: DropInfo) { isTargeted = false }
+    func dropExited(info: DropInfo) {
+        exited()
+        isTargeted = false
+    }
 
     func performDrop(info: DropInfo) -> Bool {
         defer { isTargeted = false }

--- a/Sources/VibeBarApp/Views/MenuBarComposerEditor.swift
+++ b/Sources/VibeBarApp/Views/MenuBarComposerEditor.swift
@@ -411,17 +411,17 @@ struct MenuBarComposerEditor: View {
             caption(L10n.MenuBar.composerPalette)
             paletteGroup(L10n.MenuBar.composerBlockLogo) {
                 paletteButton(title: L10n.MenuBar.composerBlockAppIcon, icon: "menubar.rectangle") {
-                    add(MenuBarToken(kind: .appIcon, style: .label))
+                    add(.newAppIcon())
                 }
                 ForEach(paletteLogoTools, id: \.self) { tool in
                     paletteButton(title: tool.menuTitle, icon: nil, tool: tool) {
-                        add(MenuBarToken(kind: .logo(tool), style: .label))
+                        add(.newLogo(tool))
                     }
                 }
             }
             paletteGroup(L10n.MenuBar.composerBlockText) {
                 paletteButton(title: L10n.MenuBar.composerBlockText, icon: "textformat") {
-                    add(MenuBarToken(kind: .text(L10n.MenuBar.composerTextPlaceholder), style: .label))
+                    add(.newText())
                 }
             }
             paletteGroup(L10n.MenuBar.composerBlockQuota) {
@@ -429,10 +429,7 @@ struct MenuBarComposerEditor: View {
                     Menu {
                         ForEach(section.options) { option in
                             Button(option.displayTitle) {
-                                add(MenuBarToken(
-                                    kind: .quota(fieldId: option.id, metric: .displayPercent),
-                                    style: .percent
-                                ))
+                                add(.newQuota(fieldId: option.id))
                             }
                         }
                     } label: {
@@ -447,13 +444,13 @@ struct MenuBarComposerEditor: View {
             }
             paletteGroup(L10n.MenuBar.composerBlockStructure) {
                 paletteButton(title: L10n.MenuBar.composerBlockSpace, icon: "space") {
-                    add(MenuBarToken(kind: .space))
+                    add(.newSpace())
                 }
                 paletteButton(title: L10n.MenuBar.composerBlockSeparator, icon: "line.diagonal") {
-                    add(MenuBarToken(kind: .separator(" · "), style: .divider))
+                    add(.newSeparator())
                 }
                 paletteButton(title: L10n.MenuBar.composerBlockNewRow, icon: "return") {
-                    add(MenuBarToken(kind: .lineBreak))
+                    add(.newLineBreak())
                 }
                 // Two rows is all the status item can draw; offering a third
                 // break would build a row the bar silently folds away.
@@ -850,7 +847,7 @@ private struct MenuBarTokenInspector: View {
             HStack(spacing: 8) {
                 Text(L10n.MenuBar.composerBlockText).frame(width: 62, alignment: .leading)
                 DebouncedSettingsTextField(
-                    prompt: L10n.MenuBar.composerBlockText,
+                    prompt: L10n.MenuBar.composerTextPlaceholder,
                     value: Binding(
                         get: { text },
                         set: { value in
@@ -862,9 +859,14 @@ private struct MenuBarTokenInspector: View {
                     )
                 )
             }
-            Text(L10n.MenuBar.composerTextLimit(count: MenuBarToken.maximumTextLength))
-                .font(.caption2)
-                .foregroundStyle(.tertiary)
+            Text(
+                text.isEmpty
+                    ? L10n.MenuBar.composerTextEmpty
+                    : L10n.MenuBar.composerTextLimit(count: MenuBarToken.maximumTextLength)
+            )
+            .font(.caption2)
+            .foregroundStyle(.tertiary)
+            .fixedSize(horizontal: false, vertical: true)
         case let .separator(separator):
             HStack(spacing: 8) {
                 Text(L10n.MenuBar.composerBlockSeparator).frame(width: 62, alignment: .leading)

--- a/Sources/VibeBarApp/Views/MenuBarComposerEditor.swift
+++ b/Sources/VibeBarApp/Views/MenuBarComposerEditor.swift
@@ -24,6 +24,15 @@ struct MenuBarComposerEditor: View {
 
     @State private var selection: UUID?
     @State private var draggedTokenId: UUID?
+    /// The order the strip *would* have if the drag ended here.
+    ///
+    /// A drag crosses several chips, and writing each crossing through
+    /// `settingsStore.settings` fanned every intermediate order out to every
+    /// settings subscriber and re-rendered the menu bar mid-gesture — exactly
+    /// the per-tick settings write `AGENTS.md` § 7 forbids on an interaction
+    /// path. The reorder is kept here while the drag is live and committed
+    /// once, on drop.
+    @State private var dragComposition: MenuBarComposition?
     @State private var isOverRemoveTarget = false
     @State private var isConfirmingReseed = false
 
@@ -46,8 +55,41 @@ struct MenuBarComposerEditor: View {
     private var item: MenuBarItemSettings { settingsStore.settings.menuBarItem(kind) }
     private var composition: MenuBarComposition { item.composition ?? MenuBarComposition() }
 
+    /// What the editor draws: the provisional order while a drag is in
+    /// flight, the committed one otherwise. The preview follows it too, so the
+    /// user sees the arrangement they are about to get.
+    private var displayedComposition: MenuBarComposition {
+        guard draggedTokenId != nil, let dragComposition else { return composition }
+        return dragComposition
+    }
+
+    /// Everything the cached snapshots are derived from.
+    ///
+    /// Keyed on the *requirements*, not the referenced field ids: switching a
+    /// block from `.displayPercent` to `.pace` leaves the field set identical
+    /// while changing the work the preview needs, and the stale snapshot would
+    /// drop the block until the next quota publication even though the status
+    /// item renders it at once. The display mode and colour basis are in here
+    /// for the same reason — both change what a snapshot holds, and both are
+    /// editable a few controls above this one.
+    private struct SnapshotKey: Equatable {
+        var requirements: [MenuBarQuotaRequirement]
+        var displayMode: DisplayMode
+        var colorBasis: MenuBarColorBasis
+        var customLabels: [String: String]
+    }
+
+    private var snapshotKey: SnapshotKey {
+        SnapshotKey(
+            requirements: composition.quotaRequirements,
+            displayMode: settingsStore.settings.displayMode,
+            colorBasis: settingsStore.settings.menuBarColorBasis,
+            customLabels: item.customLabels
+        )
+    }
+
     var body: some View {
-        let composition = self.composition
+        let composition = displayedComposition
         let plan = composition.plan(
             quotas: snapshots,
             displayMode: settingsStore.settings.displayMode,
@@ -72,10 +114,16 @@ struct MenuBarComposerEditor: View {
             rebuildSnapshots()
         }
         .onReceive(quotaService.$lastSuccessByAccount) { _ in rebuildSnapshots() }
-        // Adding or removing a quota block changes which buckets the preview
-        // needs; editing a word does not. Keying the rebuild on the referenced
-        // set is what keeps a forecast off the typing path.
-        .onChange(of: composition.referencedFieldIds) { _, _ in rebuildSnapshots() }
+        // The same inputs the status item re-renders on. A refresh publishes
+        // the quota first and records the observation in a follow-up task, so
+        // without these the preview's forecast colour would describe the
+        // previous refresh while the bar beside it showed the current one.
+        .onReceive(quotaService.$observationsByAccountBucket) { _ in rebuildSnapshots() }
+        .onReceive(environment.costService.$snapshots) { _ in rebuildSnapshots() }
+        // Changing what the strip asks of a quota rebuilds; editing a word
+        // does not. That is what keeps a forecast off the typing path while
+        // still letting a metric swap show up immediately.
+        .onChange(of: snapshotKey) { _, _ in rebuildSnapshots() }
     }
 
     // MARK: - Template
@@ -136,6 +184,9 @@ struct MenuBarComposerEditor: View {
                         chip(token, availability: availability)
                             .onDrag {
                                 draggedTokenId = token.id
+                                // Snapshot the committed order; every crossing
+                                // reorders this copy, and only the drop writes.
+                                dragComposition = self.composition
                                 return NSItemProvider(object: token.id.uuidString as NSString)
                             }
                             .onDrop(
@@ -143,7 +194,8 @@ struct MenuBarComposerEditor: View {
                                 delegate: MenuBarChipDropDelegate(
                                     target: token.id,
                                     dragged: $draggedTokenId,
-                                    apply: { mutate($0) }
+                                    provisional: $dragComposition,
+                                    commit: { commitDrag() }
                                 )
                             )
                     }
@@ -157,7 +209,8 @@ struct MenuBarComposerEditor: View {
                             delegate: MenuBarChipDropDelegate(
                                 target: nil,
                                 dragged: $draggedTokenId,
-                                apply: { mutate($0) }
+                                provisional: $dragComposition,
+                                commit: { commitDrag() }
                             )
                         )
                 }
@@ -193,7 +246,7 @@ struct MenuBarComposerEditor: View {
                 dragged: $draggedTokenId,
                 isTargeted: $isOverRemoveTarget,
                 selection: $selection,
-                apply: { mutate($0) }
+                remove: { removeDragged($0) }
             )
         )
     }
@@ -510,11 +563,37 @@ struct MenuBarComposerEditor: View {
     // MARK: - Mutations
 
     private func mutate(_ change: (inout MenuBarComposition) -> Void) {
+        // A real edit ends any drag state: the provisional order must never
+        // outlive the arrangement it was based on.
+        dragComposition = nil
+        draggedTokenId = nil
         var updated = item
         var composed = updated.composition ?? MenuBarComposition(isEnabled: true)
         change(&composed)
         updated.composition = composed
         settingsStore.settings.setMenuBarItem(updated)
+    }
+
+    /// The one settings write a completed drag performs.
+    private func commitDrag() {
+        guard let reordered = dragComposition else {
+            draggedTokenId = nil
+            return
+        }
+        let tokens = reordered.tokens
+        // `mutate` clears the drag state before writing.
+        mutate { $0.tokens = tokens }
+    }
+
+    private func removeDragged(_ id: UUID) {
+        if selection == id { selection = nil }
+        // Start from the provisional order when there is one, so a block that
+        // was dragged across the strip and then onto the bin does not
+        // resurrect the intermediate order it passed through.
+        let base = dragComposition ?? composition
+        var tokens = base.tokens
+        tokens.removeAll { $0.id == id }
+        mutate { $0.tokens = tokens }
     }
 
     private func add(_ token: MenuBarToken) {
@@ -896,18 +975,7 @@ private struct MenuBarTokenInspector: View {
         HStack(spacing: 8) {
             Text("Quota").frame(width: 62, alignment: .leading)
             fieldPicker(selected: fieldId) { newId in set(newId, percent) }
-            Stepper(
-                value: Binding(
-                    get: { percent },
-                    set: { set(fieldId, $0) }
-                ),
-                in: 0...100,
-                step: 5
-            ) {
-                Text("\(Int(percent.rounded()))%")
-                    .font(.system(size: 11.5).monospacedDigit())
-                    .frame(width: 42, alignment: .trailing)
-            }
+            DebouncedPercentStepper(percent: percent) { set(fieldId, $0) }
             Spacer(minLength: 0)
         }
     }
@@ -1026,6 +1094,40 @@ private struct MenuBarTokenInspector: View {
     }
 }
 
+/// A percent stepper that writes settings on an idle window rather than on
+/// every repeat.
+///
+/// A held stepper auto-repeats, and each repeat used to publish `AppSettings`
+/// — a fan-out to every subscriber, plus a menu-bar re-render, ten times a
+/// second. Same discipline as `DebouncedSettingsTextField` and the colour
+/// well: the control tracks its own draft and commits once the user stops.
+private struct DebouncedPercentStepper: View {
+    let percent: Double
+    let commit: (Double) -> Void
+
+    @State private var draft: Double = 0
+
+    var body: some View {
+        Stepper(value: $draft, in: 0...100, step: 5) {
+            Text("\(Int(draft.rounded()))%")
+                .font(.system(size: 11.5).monospacedDigit())
+                .frame(width: 42, alignment: .trailing)
+        }
+        .onAppear { draft = percent }
+        // An external write — selecting another block, a reset — replaces a
+        // draft the user is not in the middle of changing.
+        .onChange(of: percent) { _, updated in
+            if updated != draft { draft = updated }
+        }
+        .task(id: draft) {
+            guard draft != percent else { return }
+            try? await Task.sleep(for: .milliseconds(250))
+            guard !Task.isCancelled else { return }
+            commit(draft)
+        }
+    }
+}
+
 // MARK: - Drag and drop
 
 /// Reorder onto a chip, or onto the trailing landing strip when `target` is
@@ -1034,21 +1136,21 @@ private struct MenuBarTokenInspector: View {
 private struct MenuBarChipDropDelegate: DropDelegate {
     let target: UUID?
     @Binding var dragged: UUID?
-    let apply: ((inout MenuBarComposition) -> Void) -> Void
+    /// Reordered in place on every crossing. Local state, not settings.
+    @Binding var provisional: MenuBarComposition?
+    let commit: () -> Void
 
     func dropEntered(info: DropInfo) {
-        guard let dragged else { return }
-        apply { composed in
-            if let target {
-                composed.move(dragged, before: target)
-            } else {
-                composed.move(dragged, to: composed.tokens.count)
-            }
+        guard let dragged, provisional != nil else { return }
+        if let target {
+            provisional?.move(dragged, before: target)
+        } else {
+            provisional?.move(dragged, to: provisional?.tokens.count ?? 0)
         }
     }
 
     func performDrop(info: DropInfo) -> Bool {
-        dragged = nil
+        commit()
         return true
     }
 
@@ -1061,20 +1163,16 @@ private struct MenuBarChipRemoveDelegate: DropDelegate {
     @Binding var dragged: UUID?
     @Binding var isTargeted: Bool
     @Binding var selection: UUID?
-    let apply: ((inout MenuBarComposition) -> Void) -> Void
+    let remove: (UUID) -> Void
 
     func dropEntered(info: DropInfo) { isTargeted = true }
 
     func dropExited(info: DropInfo) { isTargeted = false }
 
     func performDrop(info: DropInfo) -> Bool {
-        defer {
-            dragged = nil
-            isTargeted = false
-        }
+        defer { isTargeted = false }
         guard let dragged else { return false }
-        if selection == dragged { selection = nil }
-        apply { $0.remove(dragged) }
+        remove(dragged)
         return true
     }
 

--- a/Sources/VibeBarApp/Views/MenuBarComposerEditor.swift
+++ b/Sources/VibeBarApp/Views/MenuBarComposerEditor.swift
@@ -25,6 +25,9 @@ struct MenuBarComposerEditor: View {
     /// Holds the subscription to the one list of things a composed strip
     /// depends on. Without it the preview drifts a generation behind the bar.
     @StateObject private var inputs = MenuBarStripInputObserver()
+    /// Holds a debounced control's last change until a moment this view can
+    /// observe — see `MenuBarPendingCommit`.
+    @StateObject private var pendingCommit = MenuBarPendingCommit()
     @State private var selection: UUID?
     @State private var draggedTokenId: UUID?
     /// The order the strip *would* have if the drag ended here.
@@ -123,6 +126,11 @@ struct MenuBarComposerEditor: View {
         // does not. That is what keeps a forecast off the typing path while
         // still letting a metric swap show up immediately.
         .onChange(of: snapshotKey) { _, _ in rebuildSnapshots() }
+        // Selecting another block retires the inspector that queued the write,
+        // so spend it first. Deterministic, unlike waiting for that view's
+        // teardown to be delivered.
+        .onChange(of: selection) { _, _ in pendingCommit.flush() }
+        .onDisappear { pendingCommit.flush() }
     }
 
     // MARK: - Template
@@ -504,6 +512,7 @@ struct MenuBarComposerEditor: View {
                     token: token,
                     options: sortedOptions,
                     liveFieldIds: liveFieldIds,
+                    pending: pendingCommit,
                     apply: { updated in
                         mutate { composed in
                             guard let index = composed.index(of: updated.id) else { return }
@@ -591,6 +600,10 @@ struct MenuBarComposerEditor: View {
     // MARK: - Mutations
 
     private func mutate(_ change: (inout MenuBarComposition) -> Void) {
+        // Spend a queued write before making another, so the two cannot land
+        // out of order or overwrite each other. Re-entrant-safe: `flush`
+        // clears the queue before running it.
+        pendingCommit.flush()
         // A real edit ends any drag state: the provisional order must never
         // outlive the arrangement it was based on.
         dragCancelTask?.cancel()
@@ -722,6 +735,7 @@ private struct MenuBarTokenInspector: View {
     let token: MenuBarToken
     let options: [MenuBarFieldOption]
     let liveFieldIds: Set<String>
+    let pending: MenuBarPendingCommit
     let apply: (MenuBarToken) -> Void
 
     @State private var fixedDraft: Color = .accentColor
@@ -908,19 +922,12 @@ private struct MenuBarTokenInspector: View {
             case .fixed:
                 ColorPicker("", selection: $fixedDraft, supportsOpacity: false)
                     .labelsHidden()
-                    // Dragging inside a colour well fires continuously; commit
-                    // on an idle window so a drag is one settings write rather
-                    // than a hundred.
-                    .task(id: fixedDraft) {
-                        try? await Task.sleep(for: .milliseconds(250))
-                        guard !Task.isCancelled else { return }
-                        commitFixedColor()
+                    // Dragging inside a colour well fires continuously, so the
+                    // write is queued rather than made per frame — on the
+                    // editor, which is still around when this control is not.
+                    .onChange(of: fixedDraft) { _, value in
+                        scheduleColorCommit(value)
                     }
-                    // Same removal, same flush: picking a colour and
-                    // immediately selecting another block must not drop it.
-                    // `commitFixedColor` no-ops unless the block is still a
-                    // custom colour, so switching the role away is safe.
-                    .onDisappear(perform: commitFixedColor)
             case let .followsQuota(fieldId, basis):
                 fieldPicker(selected: fieldId) { newId in
                     update { $0.style.color = .followsQuota(fieldId: newId, basis: basis) }
@@ -954,17 +961,25 @@ private struct MenuBarTokenInspector: View {
         fixedDraft = Color(.sRGB, red: parts.r, green: parts.g, blue: parts.b, opacity: parts.a)
     }
 
-    private func commitFixedColor() {
-        guard case .fixed = token.style.color else { return }
-        let resolved = NSColor(fixedDraft).usingColorSpace(.sRGB) ?? NSColor(fixedDraft)
+    /// Queue the colour the well is showing.
+    ///
+    /// Everything the write needs is captured as a value here — the finished
+    /// token and the apply closure — so nothing reads this view's `@State`
+    /// after it has gone away.
+    private func scheduleColorCommit(_ color: Color) {
+        guard case let .fixed(current) = token.style.color else { return }
+        let resolved = NSColor(color).usingColorSpace(.sRGB) ?? NSColor(color)
         let hex = String(
             format: "#%02x%02x%02x",
             Int((resolved.redComponent * 255).rounded()),
             Int((resolved.greenComponent * 255).rounded()),
             Int((resolved.blueComponent * 255).rounded())
         )
-        guard case let .fixed(current) = token.style.color, current != hex else { return }
-        update { $0.style.color = .hex(hex) }
+        guard current != hex else { return }
+        var updated = token
+        updated.style.color = .hex(hex)
+        let apply = self.apply
+        pending.schedule { apply(updated) }
     }
 
     // MARK: Rule
@@ -1046,7 +1061,7 @@ private struct MenuBarTokenInspector: View {
         HStack(spacing: 8) {
             Text("Quota").frame(width: 62, alignment: .leading)
             fieldPicker(selected: fieldId) { newId in set(newId, percent) }
-            DebouncedPercentStepper(percent: percent) { set(fieldId, $0) }
+            DebouncedPercentStepper(percent: percent, pending: pending) { set(fieldId, $0) }
             Spacer(minLength: 0)
         }
     }
@@ -1165,6 +1180,49 @@ private struct MenuBarTokenInspector: View {
     }
 }
 
+/// One queued settings write, owned by something that outlives the control
+/// that queued it.
+///
+/// Debouncing a control means the last change lives in limbo for a moment, and
+/// whatever owns that moment must survive long enough to spend it. Hanging it
+/// off the control itself and flushing in `onDisappear` looks equivalent and
+/// is not: the inspector is `.id(token.id)`, so selecting another block tears
+/// the control down, and a window being destroyed does not reliably deliver
+/// `onDisappear` at all. The editor outlives both, so the editor holds the
+/// pending write and flushes it at moments it can actually observe — a
+/// selection change, any other edit, its own teardown.
+@MainActor
+final class MenuBarPendingCommit: ObservableObject {
+    private var pending: (() -> Void)?
+    private var task: Task<Void, Never>?
+
+    /// Queue `commit`, replacing anything already queued: while the user is
+    /// still dragging or clicking, only the newest value matters.
+    func schedule(
+        after delay: Duration = .milliseconds(250),
+        _ commit: @escaping () -> Void
+    ) {
+        pending = commit
+        task?.cancel()
+        task = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: delay)
+            guard !Task.isCancelled else { return }
+            self?.flush()
+        }
+    }
+
+    /// Write whatever is queued, now. Safe to call when nothing is, and safe
+    /// to re-enter: the queue is cleared before the work runs, so a flush
+    /// triggered from inside a commit finds nothing to do.
+    func flush() {
+        task?.cancel()
+        task = nil
+        let work = pending
+        pending = nil
+        work?()
+    }
+}
+
 /// A percent stepper that writes settings on an idle window rather than on
 /// every repeat.
 ///
@@ -1174,6 +1232,7 @@ private struct MenuBarTokenInspector: View {
 /// well: the control tracks its own draft and commits once the user stops.
 private struct DebouncedPercentStepper: View {
     let percent: Double
+    let pending: MenuBarPendingCommit
     let commit: (Double) -> Void
 
     @State private var draft: Double = 0
@@ -1190,18 +1249,13 @@ private struct DebouncedPercentStepper: View {
         .onChange(of: percent) { _, updated in
             if updated != draft { draft = updated }
         }
-        .task(id: draft) {
-            guard draft != percent else { return }
-            try? await Task.sleep(for: .milliseconds(250))
-            guard !Task.isCancelled else { return }
-            commit(draft)
-        }
-        // The inspector is `.id(token.id)`, so selecting another block removes
-        // this control and cancels the pending commit mid-window. Flush, the
-        // way `DebouncedSettingsTextField` already does, or the last change the
-        // user made is silently lost.
-        .onDisappear {
-            if draft != percent { commit(draft) }
+        // Queued on the editor, not here: this control does not outlive a
+        // selection change, and the value must. Values are captured, never
+        // read back out of `@State` after teardown.
+        .onChange(of: draft) { _, value in
+            guard value != percent else { return }
+            let commit = self.commit
+            pending.schedule { commit(value) }
         }
     }
 }

--- a/Sources/VibeBarApp/Views/MenuBarComposerEditor.swift
+++ b/Sources/VibeBarApp/Views/MenuBarComposerEditor.swift
@@ -22,6 +22,9 @@ struct MenuBarComposerEditor: View {
     @EnvironmentObject private var settingsStore: SettingsStore
     @EnvironmentObject private var quotaService: QuotaService
 
+    /// Holds the subscription to the one list of things a composed strip
+    /// depends on. Without it the preview drifts a generation behind the bar.
+    @StateObject private var inputs = MenuBarStripInputObserver()
     @State private var selection: UUID?
     @State private var draggedTokenId: UUID?
     /// The order the strip *would* have if the drag ended here.
@@ -90,36 +93,28 @@ struct MenuBarComposerEditor: View {
 
     var body: some View {
         let composition = displayedComposition
-        let plan = composition.plan(
-            quotas: snapshots,
-            displayMode: settingsStore.settings.displayMode,
-            colorBasis: settingsStore.settings.menuBarColorBasis
-        )
         let availability = composition.availability(liveFieldIds: liveFieldIds)
 
         VStack(alignment: .leading, spacing: density.cardSpacing + 4) {
             templateRow(composition)
-            previewRow(plan: plan)
+            previewRow(composition)
             stripRow(composition, availability: availability)
             paletteRow(composition)
             inspectorRow(composition, availability: availability)
             footerRow(availability: availability)
         }
         .onAppear {
+            inputs.start(environment: environment)
             rebuildCatalog()
             rebuildSnapshots()
         }
-        .onChange(of: quotaService.fieldRegistry) { _, _ in
+        // Exactly what the status item re-renders on — one list, two
+        // consumers. Subscribing to a subset of it is how the preview ended up
+        // a generation behind the bar for forecasts, colours and rules.
+        .onReceive(inputs.$generation) { _ in
             rebuildCatalog()
             rebuildSnapshots()
         }
-        .onReceive(quotaService.$lastSuccessByAccount) { _ in rebuildSnapshots() }
-        // The same inputs the status item re-renders on. A refresh publishes
-        // the quota first and records the observation in a follow-up task, so
-        // without these the preview's forecast colour would describe the
-        // previous refresh while the bar beside it showed the current one.
-        .onReceive(quotaService.$observationsByAccountBucket) { _ in rebuildSnapshots() }
-        .onReceive(environment.costService.$snapshots) { _ in rebuildSnapshots() }
         // Changing what the strip asks of a quota rebuilds; editing a word
         // does not. That is what keeps a forecast off the typing path while
         // still letting a metric swap show up immediately.
@@ -144,24 +139,46 @@ struct MenuBarComposerEditor: View {
 
     // MARK: - Preview
 
-    private func previewRow(plan: MenuBarRenderPlan) -> some View {
+    private func previewRow(_ composition: MenuBarComposition) -> some View {
         VStack(alignment: .leading, spacing: 4) {
             caption("Preview")
-            MenuBarStripPreview(
-                plan: plan,
-                quotas: snapshots,
-                displayMode: settingsStore.settings.displayMode,
-                highlighted: selection
-            )
-            Text("Light and dark menu bars, side by side — a fixed colour that reads well on one can vanish on the other.")
-                .font(.caption2)
-                .foregroundStyle(.tertiary)
-                .fixedSize(horizontal: false, vertical: true)
-            if plan.rows.filter({ !$0.isEmpty }).count >= 2 {
-                Text("Two rows have to share the menu bar's height, so large sizes are scaled down to fit. The preview above shows the size you set, not the scaled one.")
-                    .font(.caption2)
-                    .foregroundStyle(.tertiary)
-                    .fixedSize(horizontal: false, vertical: true)
+            // A countdown block is wrong a minute later with no new data
+            // behind it, and nothing else here invalidates the view. Gated on
+            // the strip actually printing one: `QuotaClockSchedule` yields a
+            // single entry and starts no timer when inactive, so a strip of
+            // percentages still costs nothing. Same phase anchor the popover's
+            // clocks and the status item's tick use, so the preview and the
+            // bar never show two different countdowns for one quota.
+            TimelineView(
+                QuotaClockSchedule(
+                    isActive: composition.hasTimeBasedBlock,
+                    interval: MenuBarCountdownClock.interval
+                )
+            ) { context in
+                let plan = composition.plan(
+                    quotas: snapshots,
+                    displayMode: settingsStore.settings.displayMode,
+                    colorBasis: settingsStore.settings.menuBarColorBasis,
+                    now: context.date
+                )
+                VStack(alignment: .leading, spacing: 4) {
+                    MenuBarStripPreview(
+                        plan: plan,
+                        quotas: snapshots,
+                        displayMode: settingsStore.settings.displayMode,
+                        highlighted: selection
+                    )
+                    Text("Light and dark menu bars, side by side — a fixed colour that reads well on one can vanish on the other.")
+                        .font(.caption2)
+                        .foregroundStyle(.tertiary)
+                        .fixedSize(horizontal: false, vertical: true)
+                    if plan.rows.filter({ !$0.isEmpty }).count >= 2 {
+                        Text("Two rows share the menu bar's height, so large sizes are scaled down to fit — the preview scales with them.")
+                            .font(.caption2)
+                            .foregroundStyle(.tertiary)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                }
             }
         }
     }

--- a/Sources/VibeBarApp/Views/MenuBarComposerEditor.swift
+++ b/Sources/VibeBarApp/Views/MenuBarComposerEditor.swift
@@ -164,7 +164,7 @@ struct MenuBarComposerEditor: View {
 
     private func templateRow(_ composition: MenuBarComposition) -> some View {
         VStack(alignment: .leading, spacing: 4) {
-            Picker("Template", selection: templateBinding()) {
+            Picker(L10n.MenuBar.composerTemplate, selection: templateBinding()) {
                 ForEach(MenuBarComposition.Template.allCases, id: \.self) { template in
                     Text(template.title).tag(template)
                 }
@@ -180,7 +180,7 @@ struct MenuBarComposerEditor: View {
 
     private func previewRow(_ composition: MenuBarComposition) -> some View {
         VStack(alignment: .leading, spacing: 4) {
-            caption("Preview")
+            caption(L10n.MenuBar.composerPreview)
             // A countdown block is wrong a minute later with no new data
             // behind it, and nothing else here invalidates the view. Gated on
             // the strip actually printing one: `QuotaClockSchedule` yields a
@@ -207,12 +207,12 @@ struct MenuBarComposerEditor: View {
                         displayMode: settingsStore.settings.displayMode,
                         highlighted: selection
                     )
-                    Text("Light and dark menu bars, side by side — a fixed colour that reads well on one can vanish on the other.")
+                    Text(L10n.MenuBar.composerPreviewGrounds)
                         .font(.caption2)
                         .foregroundStyle(.tertiary)
                         .fixedSize(horizontal: false, vertical: true)
                     if plan.rows.filter({ !$0.isEmpty }).count >= 2 {
-                        Text("Two rows share the menu bar's height, so large sizes are scaled down to fit — the preview scales with them.")
+                        Text(L10n.MenuBar.composerPreviewTwoRowScaling)
                             .font(.caption2)
                             .foregroundStyle(.tertiary)
                             .fixedSize(horizontal: false, vertical: true)
@@ -229,9 +229,9 @@ struct MenuBarComposerEditor: View {
         availability: MenuBarComposition.Availability
     ) -> some View {
         VStack(alignment: .leading, spacing: 6) {
-            caption("Blocks — drag to reorder")
+            caption(L10n.MenuBar.composerBlocks)
             if composition.tokens.isEmpty {
-                Text("No blocks yet. Add one from the palette below.")
+                Text(L10n.MenuBar.composerBlocksEmpty)
                     .font(.caption)
                     .foregroundStyle(.tertiary)
             } else {
@@ -284,7 +284,7 @@ struct MenuBarComposerEditor: View {
         HStack(spacing: 6) {
             Image(systemName: "trash")
                 .font(.system(size: 10, weight: .semibold))
-            Text("Drag here to remove")
+            Text(L10n.MenuBar.composerRemoveTarget)
                 .font(.caption)
         }
         .foregroundStyle(isOverRemoveTarget ? Color.red : Color.secondary)
@@ -378,30 +378,28 @@ struct MenuBarComposerEditor: View {
             return tool.menuTitle
         case let .text(text):
             let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
-            return trimmed.isEmpty ? "Empty text" : MenuBarToken.truncated(trimmed)
+            return trimmed.isEmpty ? L10n.MenuBar.composerBlockEmptyText : MenuBarToken.truncated(trimmed)
         case let .quota(fieldId, metric):
             let name = optionsById[fieldId]?.defaultLabel ?? fieldId
             return "\(name) · \(metric.title)"
         case .space:
-            return "Space"
+            return L10n.MenuBar.composerBlockSpace
         case let .separator(separator):
             let trimmed = separator.trimmingCharacters(in: .whitespacesAndNewlines)
-            return trimmed.isEmpty ? "Gap" : trimmed
+            return trimmed.isEmpty ? L10n.MenuBar.composerBlockGap : trimmed
         case .lineBreak:
-            return "New row"
+            return L10n.MenuBar.composerBlockNewRow
         case .appIcon:
-            return "Vibe Bar icon"
+            return L10n.MenuBar.composerBlockAppIcon
         }
     }
 
     private func chipHelp(_ token: MenuBarToken, isSilent: Bool, isDegraded: Bool) -> String {
         if isSilent {
-            return "This quota is not being returned right now, so this block draws nothing. "
-                + "It stays here and comes back on its own."
+            return L10n.MenuBar.composerWarningSilent
         }
         if isDegraded {
-            return "This block still draws, but a colour or a rule on it points at a quota "
-                + "that is not being returned right now."
+            return L10n.MenuBar.composerWarningDegraded
         }
         return chipTitle(token)
     }
@@ -410,9 +408,9 @@ struct MenuBarComposerEditor: View {
 
     private func paletteRow(_ composition: MenuBarComposition) -> some View {
         VStack(alignment: .leading, spacing: 6) {
-            caption("Add a block")
-            paletteGroup("Logo") {
-                paletteButton(title: "Vibe Bar", icon: "menubar.rectangle") {
+            caption(L10n.MenuBar.composerPalette)
+            paletteGroup(L10n.MenuBar.composerBlockLogo) {
+                paletteButton(title: L10n.MenuBar.composerBlockAppIcon, icon: "menubar.rectangle") {
                     add(MenuBarToken(kind: .appIcon, style: .label))
                 }
                 ForEach(paletteLogoTools, id: \.self) { tool in
@@ -421,12 +419,12 @@ struct MenuBarComposerEditor: View {
                     }
                 }
             }
-            paletteGroup("Text") {
-                paletteButton(title: "Text", icon: "textformat") {
-                    add(MenuBarToken(kind: .text("Label"), style: .label))
+            paletteGroup(L10n.MenuBar.composerBlockText) {
+                paletteButton(title: L10n.MenuBar.composerBlockText, icon: "textformat") {
+                    add(MenuBarToken(kind: .text(L10n.MenuBar.composerTextPlaceholder), style: .label))
                 }
             }
-            paletteGroup("Quota") {
+            paletteGroup(L10n.MenuBar.composerBlockQuota) {
                 ForEach(paletteQuotaSections) { section in
                     Menu {
                         ForEach(section.options) { option in
@@ -447,14 +445,14 @@ struct MenuBarComposerEditor: View {
                     .fixedSize()
                 }
             }
-            paletteGroup("Structure") {
-                paletteButton(title: "Space", icon: "space") {
+            paletteGroup(L10n.MenuBar.composerBlockStructure) {
+                paletteButton(title: L10n.MenuBar.composerBlockSpace, icon: "space") {
                     add(MenuBarToken(kind: .space))
                 }
-                paletteButton(title: "Separator", icon: "line.diagonal") {
+                paletteButton(title: L10n.MenuBar.composerBlockSeparator, icon: "line.diagonal") {
                     add(MenuBarToken(kind: .separator(" · "), style: .divider))
                 }
-                paletteButton(title: "New row", icon: "return") {
+                paletteButton(title: L10n.MenuBar.composerBlockNewRow, icon: "return") {
                     add(MenuBarToken(kind: .lineBreak))
                 }
                 // Two rows is all the status item can draw; offering a third
@@ -462,8 +460,8 @@ struct MenuBarComposerEditor: View {
                 .disabled(!composition.canAddLineBreak)
                 .help(
                     composition.canAddLineBreak
-                        ? "Split the strip into a second row."
-                        : "The menu bar can only draw two rows."
+                        ? L10n.MenuBar.composerNewRowHelp
+                        : L10n.MenuBar.composerNewRowCapped
                 )
             }
         }
@@ -520,30 +518,36 @@ struct MenuBarComposerEditor: View {
         if let id = selection, let token = composition.token(id) {
             VStack(alignment: .leading, spacing: 8) {
                 HStack(spacing: 8) {
-                    caption("Selected block")
+                    caption(L10n.MenuBar.composerSelected)
                     Spacer(minLength: 8)
-                    Button("Duplicate") { mutate { $0.duplicate(id) } }
+                    Button(L10n.MenuBar.composerActionDuplicate) { mutate { $0.duplicate(id) } }
                         .buttonStyle(.vibeBar)
-                    Button("Remove") {
+                    Button(L10n.MenuBar.composerActionRemove) {
                         selection = nil
                         mutate { $0.remove(id) }
                     }
                     .buttonStyle(.vibeBar)
                 }
                 if availability.silentTokenIds.contains(id) {
-                    warning("This quota is not being returned right now, so the block draws nothing. Nothing is broken — it reappears when the provider answers again.")
+                    warning(L10n.MenuBar.composerWarningSilent)
                 } else if availability.degradedTokenIds.contains(id) {
-                    warning("A colour or rule on this block points at a quota that is not being returned right now, so that part falls back.")
+                    warning(L10n.MenuBar.composerWarningDegraded)
                 }
                 MenuBarTokenInspector(
                     token: token,
                     options: sortedOptions,
                     liveFieldIds: liveFieldIds,
                     pending: pendingCommit,
-                    apply: { updated in
+                    // A control hands over the field it owns, not a copy of
+                    // the whole block. `mutate` flushes a queued write first,
+                    // so the edit lands on the token as it is *after* that
+                    // flush — a whole-token replacement built before it would
+                    // carry pre-flush state and silently undo the colour or
+                    // threshold the user had just set.
+                    apply: { change in
                         mutate { composed in
-                            guard let index = composed.index(of: updated.id) else { return }
-                            composed.tokens[index] = updated
+                            guard let index = composed.index(of: id) else { return }
+                            change(&composed.tokens[index])
                         }
                     }
                 )
@@ -577,30 +581,28 @@ struct MenuBarComposerEditor: View {
     private func footerRow(availability: MenuBarComposition.Availability) -> some View {
         VStack(alignment: .leading, spacing: 6) {
             if !availability.isFullyAvailable {
-                warning(
-                    "Not answering right now: "
-                        + availability.missingFieldIds
-                            .map { optionsById[$0]?.title ?? $0 }
-                            .joined(separator: ", ")
-                        + "."
-                )
+                warning(L10n.MenuBar.composerWarningMissing(
+                    fields: availability.missingFieldIds
+                        .map { optionsById[$0]?.title ?? $0 }
+                        .joined(separator: ", ")
+                ))
             }
             HStack(spacing: 8) {
-                Button("Start over from the current strip…") { isConfirmingReseed = true }
+                Button(L10n.MenuBar.composerStartOver) { isConfirmingReseed = true }
                     .buttonStyle(.vibeBar)
                 Spacer(minLength: 8)
             }
-            Text("Starting over replaces every block with a fresh copy of the default strip. There is no undo.")
+            Text(L10n.MenuBar.composerStartOverDetail)
                 .font(.caption2)
                 .foregroundStyle(.tertiary)
                 .fixedSize(horizontal: false, vertical: true)
         }
         .confirmationDialog(
-            "Replace your blocks?",
+            L10n.MenuBar.composerStartOverConfirmTitle,
             isPresented: $isConfirmingReseed,
             titleVisibility: .visible
         ) {
-            Button("Start over", role: .destructive) {
+            Button(L10n.MenuBar.composerStartOverConfirm, role: .destructive) {
                 selection = nil
                 var updated = item
                 updated.reseedComposedStrip(
@@ -610,9 +612,9 @@ struct MenuBarComposerEditor: View {
                 )
                 settingsStore.settings.setMenuBarItem(updated)
             }
-            Button("Cancel", role: .cancel) {}
+            Button(L10n.Common.cancel, role: .cancel) {}
         } message: {
-            Text("Every block you arranged is discarded and rebuilt from the default strip.")
+            Text(L10n.MenuBar.composerStartOverConfirmMessage)
         }
     }
 
@@ -638,8 +640,12 @@ struct MenuBarComposerEditor: View {
         dragComposition = nil
         draggedTokenId = nil
         var updated = item
-        var composed = updated.composition ?? MenuBarComposition(isEnabled: true)
+        let before = updated.composition
+        var composed = before ?? MenuBarComposition(isEnabled: true)
         change(&composed)
+        // An edit that changes nothing must not publish settings: every write
+        // fans out to every subscriber and re-renders the menu bar.
+        guard composed != before else { return }
         updated.composition = composed
         settingsStore.settings.setMenuBarItem(updated)
     }
@@ -763,7 +769,8 @@ private struct MenuBarTokenInspector: View {
     let options: [MenuBarFieldOption]
     let liveFieldIds: Set<String>
     let pending: MenuBarPendingCommit
-    let apply: (MenuBarToken) -> Void
+    /// Hands over *what changed*, applied to the stored token at write time.
+    let apply: (@escaping (inout MenuBarToken) -> Void) -> Void
 
     @State private var fixedDraft: Color = .accentColor
 
@@ -778,14 +785,14 @@ private struct MenuBarTokenInspector: View {
         var id: String { rawValue }
         var title: String {
             switch self {
-            case .automatic: return "Automatic"
-            case .forecast: return "Forecast"
-            case .followsQuota: return "Follow a quota"
-            case .brand: return "Brand"
-            case .primary: return "Primary"
-            case .secondary: return "Secondary"
-            case .tertiary: return "Tertiary"
-            case .fixed: return "Custom…"
+            case .automatic: return L10n.MenuBar.composerColourAutomatic
+            case .forecast: return L10n.MenuBar.composerColourForecast
+            case .followsQuota: return L10n.MenuBar.composerColourFollowsQuota
+            case .brand: return L10n.MenuBar.composerColourBrand
+            case .primary: return L10n.MenuBar.composerColourPrimary
+            case .secondary: return L10n.MenuBar.composerColourSecondary
+            case .tertiary: return L10n.MenuBar.composerColourTertiary
+            case .fixed: return L10n.MenuBar.composerColourFixed
             }
         }
     }
@@ -795,10 +802,10 @@ private struct MenuBarTokenInspector: View {
         var id: String { rawValue }
         var title: String {
             switch self {
-            case .always: return "Always"
-            case .whenUsedAtLeast: return "When used is at least"
-            case .whenRemainingAtMost: return "When remaining is at most"
-            case .whenForecast: return "When the forecast says"
+            case .always: return L10n.MenuBar.composerRuleAlways
+            case .whenUsedAtLeast: return L10n.MenuBar.composerRuleWhenUsedAtLeast
+            case .whenRemainingAtMost: return L10n.MenuBar.composerRuleWhenRemainingAtMost
+            case .whenForecast: return L10n.MenuBar.composerRuleWhenForecast
             }
         }
     }
@@ -813,17 +820,17 @@ private struct MenuBarTokenInspector: View {
                 Divider().opacity(0.4)
                 colorControls
                 HStack(spacing: 10) {
-                    Picker("Size", selection: sizeBinding) {
+                    Picker(L10n.MenuBar.composerFieldSize, selection: sizeBinding) {
                         ForEach(MenuBarToken.SizeStep.allCases, id: \.self) { Text($0.title).tag($0) }
                     }
                     .frame(width: 150)
-                    Picker("Weight", selection: weightBinding) {
+                    Picker(L10n.MenuBar.composerFieldWeight, selection: weightBinding) {
                         ForEach(MenuBarToken.Weight.allCases, id: \.self) { Text($0.title).tag($0) }
                     }
                     .frame(width: 165)
                 }
-                Toggle("Monospaced digits", isOn: monospacedBinding)
-                    .help("Keeps a changing number from shifting the blocks beside it.")
+                Toggle(L10n.MenuBar.composerFieldMonospacedDigits, isOn: monospacedBinding)
+                    .help(L10n.MenuBar.composerFieldMonospacedDigitsHelp)
             }
             Divider().opacity(0.4)
             ruleControls
@@ -838,9 +845,9 @@ private struct MenuBarTokenInspector: View {
         switch token.kind {
         case let .text(text):
             HStack(spacing: 8) {
-                Text("Text").frame(width: 62, alignment: .leading)
+                Text(L10n.MenuBar.composerBlockText).frame(width: 62, alignment: .leading)
                 DebouncedSettingsTextField(
-                    prompt: "Label",
+                    prompt: L10n.MenuBar.composerBlockText,
                     value: Binding(
                         get: { text },
                         set: { value in
@@ -852,12 +859,12 @@ private struct MenuBarTokenInspector: View {
                     )
                 )
             }
-            Text("Blocks longer than \(MenuBarToken.maximumTextLength) characters are cut short with an ellipsis in the bar.")
+            Text(L10n.MenuBar.composerTextLimit(count: MenuBarToken.maximumTextLength))
                 .font(.caption2)
                 .foregroundStyle(.tertiary)
         case let .separator(separator):
             HStack(spacing: 8) {
-                Text("Separator").frame(width: 62, alignment: .leading)
+                Text(L10n.MenuBar.composerBlockSeparator).frame(width: 62, alignment: .leading)
                 DebouncedSettingsTextField(
                     prompt: " · ",
                     value: Binding(
@@ -868,13 +875,13 @@ private struct MenuBarTokenInspector: View {
             }
         case let .quota(fieldId, metric):
             HStack(spacing: 8) {
-                Text("Quota").frame(width: 62, alignment: .leading)
+                Text(L10n.MenuBar.composerBlockQuota).frame(width: 62, alignment: .leading)
                 fieldPicker(selected: fieldId) { newId in
                     update { $0.kind = .quota(fieldId: newId, metric: metric) }
                 }
             }
             HStack(spacing: 8) {
-                Text("Shows").frame(width: 62, alignment: .leading)
+                Text(L10n.MenuBar.composerFieldShows).frame(width: 62, alignment: .leading)
                 Picker("", selection: Binding(
                     get: { metric },
                     set: { value in update { $0.kind = .quota(fieldId: fieldId, metric: value) } }
@@ -886,7 +893,7 @@ private struct MenuBarTokenInspector: View {
             }
         case let .logo(tool):
             HStack(spacing: 8) {
-                Text("Provider").frame(width: 62, alignment: .leading)
+                Text(L10n.MenuBar.composerFieldProvider).frame(width: 62, alignment: .leading)
                 Picker("", selection: Binding(
                     get: { tool },
                     set: { value in update { $0.kind = .logo(value) } }
@@ -901,16 +908,16 @@ private struct MenuBarTokenInspector: View {
         case .space:
             // Nothing to configure until the model grows a width; size and
             // colour below still apply to the gap it draws.
-            Text("A gap one space wide. Size changes how wide.")
+            Text(L10n.MenuBar.composerSpaceDetail)
                 .font(.caption2)
                 .foregroundStyle(.tertiary)
         case .lineBreak:
-            Text("Ends the first row and starts the second. Give it a rule below to split only when that quota says so.")
+            Text(L10n.MenuBar.composerNewRowDetail)
                 .font(.caption2)
                 .foregroundStyle(.tertiary)
                 .fixedSize(horizontal: false, vertical: true)
         case .appIcon:
-            Text("Vibe Bar's own icon — what the Icon Only layout shows.")
+            Text(L10n.MenuBar.composerAppIconDetail)
                 .font(.caption2)
                 .foregroundStyle(.tertiary)
         }
@@ -921,7 +928,7 @@ private struct MenuBarTokenInspector: View {
     @ViewBuilder
     private var colorControls: some View {
         HStack(spacing: 8) {
-            Text("Colour").frame(width: 62, alignment: .leading)
+            Text(L10n.MenuBar.composerFieldColour).frame(width: 62, alignment: .leading)
             Picker("", selection: colorChoiceBinding) {
                 ForEach(ColorChoice.allCases) { Text($0.title).tag($0) }
             }
@@ -1003,10 +1010,10 @@ private struct MenuBarTokenInspector: View {
             Int((resolved.blueComponent * 255).rounded())
         )
         guard current != hex else { return }
-        var updated = token
-        updated.style.color = .hex(hex)
         let apply = self.apply
-        pending.schedule { apply(updated) }
+        // Only the colour: a queued write that carried a whole token would
+        // undo whatever else the user changed while it sat in the queue.
+        pending.schedule { apply { $0.style.color = .hex(hex) } }
     }
 
     // MARK: Rule
@@ -1014,7 +1021,7 @@ private struct MenuBarTokenInspector: View {
     @ViewBuilder
     private var ruleControls: some View {
         HStack(spacing: 8) {
-            Text("Show").frame(width: 62, alignment: .leading)
+            Text(L10n.MenuBar.composerFieldShow).frame(width: 62, alignment: .leading)
             Picker("", selection: ruleChoiceBinding) {
                 ForEach(RuleChoice.allCases) { Text($0.title).tag($0) }
             }
@@ -1035,14 +1042,14 @@ private struct MenuBarTokenInspector: View {
             }
         case let .whenForecast(fieldId, verdicts):
             HStack(spacing: 8) {
-                Text("Quota").frame(width: 62, alignment: .leading)
+                Text(L10n.MenuBar.composerBlockQuota).frame(width: 62, alignment: .leading)
                 fieldPicker(selected: fieldId) { newId in
                     update { $0.visibility = .whenForecast(fieldId: newId, verdicts: verdicts) }
                 }
                 Spacer(minLength: 0)
             }
             HStack(spacing: 6) {
-                Text("Verdicts").frame(width: 62, alignment: .leading)
+                Text(L10n.MenuBar.composerFieldVerdicts).frame(width: 62, alignment: .leading)
                 ForEach(Self.selectableVerdicts, id: \.self) { verdict in
                     Toggle(Self.verdictTitle(verdict), isOn: Binding(
                         get: { verdicts.contains(verdict) },
@@ -1070,14 +1077,10 @@ private struct MenuBarTokenInspector: View {
     private static let selectableVerdicts: [QuotaPaceForecast.Verdict] =
         [.atRisk, .watch, .enough, .surplus]
 
+    /// The verdict names the forecast surfaces already use, so the composer's
+    /// checkboxes cannot drift from the quota bar's wording.
     private static func verdictTitle(_ verdict: QuotaPaceForecast.Verdict) -> String {
-        switch verdict {
-        case .atRisk: return "At risk"
-        case .watch: return "Watch"
-        case .enough: return "Enough"
-        case .surplus: return "Surplus"
-        case .learning: return "Learning"
-        }
+        verdict.label
     }
 
     private func thresholdRow(
@@ -1086,7 +1089,7 @@ private struct MenuBarTokenInspector: View {
         set: @escaping (String, Double) -> Void
     ) -> some View {
         HStack(spacing: 8) {
-            Text("Quota").frame(width: 62, alignment: .leading)
+            Text(L10n.MenuBar.composerBlockQuota).frame(width: 62, alignment: .leading)
             fieldPicker(selected: fieldId) { newId in set(newId, percent) }
             DebouncedPercentStepper(percent: percent, pending: pending) { set(fieldId, $0) }
             Spacer(minLength: 0)
@@ -1104,7 +1107,9 @@ private struct MenuBarTokenInspector: View {
                 Text(selected).tag(selected)
             }
             ForEach(options) { option in
-                Text(liveFieldIds.contains(option.id) ? option.title : "\(option.title) (offline)")
+                Text(liveFieldIds.contains(option.id)
+                    ? option.title
+                    : L10n.MenuBar.composerFieldOfflineOption(title: option.title))
                     .tag(option.id)
             }
         }
@@ -1114,11 +1119,8 @@ private struct MenuBarTokenInspector: View {
 
     // MARK: Bindings
 
-    private func update(_ change: (inout MenuBarToken) -> Void) {
-        var updated = token
-        change(&updated)
-        guard updated != token else { return }
-        apply(updated)
+    private func update(_ change: @escaping (inout MenuBarToken) -> Void) {
+        apply(change)
     }
 
     private var colorChoiceBinding: Binding<ColorChoice> {
@@ -1266,7 +1268,7 @@ private struct DebouncedPercentStepper: View {
 
     var body: some View {
         Stepper(value: $draft, in: 0...100, step: 5) {
-            Text("\(Int(draft.rounded()))%")
+            Text(L10n.Common.percent(value: Int(draft.rounded())))
                 .font(.system(size: 11.5).monospacedDigit())
                 .frame(width: 42, alignment: .trailing)
         }

--- a/Sources/VibeBarApp/Views/MenuBarComposerEditor.swift
+++ b/Sources/VibeBarApp/Views/MenuBarComposerEditor.swift
@@ -205,6 +205,7 @@ struct MenuBarComposerEditor: View {
                         plan: plan,
                         quotas: snapshots,
                         displayMode: settingsStore.settings.displayMode,
+                        template: composition.template,
                         highlighted: selection
                     )
                     Text(L10n.MenuBar.composerPreviewGrounds)
@@ -369,6 +370,7 @@ struct MenuBarComposerEditor: View {
         case .separator: return "line.diagonal"
         case .lineBreak: return "return"
         case .appIcon: return "menubar.rectangle"
+        case .unsupported: return "questionmark.square.dashed"
         }
     }
 
@@ -391,6 +393,8 @@ struct MenuBarComposerEditor: View {
             return L10n.MenuBar.composerBlockNewRow
         case .appIcon:
             return L10n.MenuBar.composerBlockAppIcon
+        case .unsupported:
+            return L10n.MenuBar.composerBlockUnsupported
         }
     }
 
@@ -776,8 +780,10 @@ private struct MenuBarTokenInspector: View {
 
     /// Whether this block puts anything on screen. A row break does not.
     private var drawsInk: Bool {
-        if case .lineBreak = token.kind { return false }
-        return true
+        switch token.kind {
+        case .lineBreak, .unsupported: return false
+        default: return true
+        }
     }
 
     private enum ColorChoice: String, CaseIterable, Identifiable {
@@ -925,6 +931,11 @@ private struct MenuBarTokenInspector: View {
             Text(L10n.MenuBar.composerAppIconDetail)
                 .font(.caption2)
                 .foregroundStyle(.tertiary)
+        case .unsupported:
+            Text(L10n.MenuBar.composerUnsupportedDetail)
+                .font(.caption2)
+                .foregroundStyle(.tertiary)
+                .fixedSize(horizontal: false, vertical: true)
         }
     }
 

--- a/Sources/VibeBarApp/Views/MenuBarComposerEditor.swift
+++ b/Sources/VibeBarApp/Views/MenuBarComposerEditor.swift
@@ -109,6 +109,12 @@ struct MenuBarComposerEditor: View {
                 .font(.caption2)
                 .foregroundStyle(.tertiary)
                 .fixedSize(horizontal: false, vertical: true)
+            if plan.rows.filter({ !$0.isEmpty }).count >= 2 {
+                Text("Two rows have to share the menu bar's height, so large sizes are scaled down to fit. The preview above shows the size you set, not the scaled one.")
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
         }
     }
 
@@ -246,6 +252,7 @@ struct MenuBarComposerEditor: View {
         case .space: return "space"
         case .separator: return "line.diagonal"
         case .lineBreak: return "return"
+        case .appIcon: return "menubar.rectangle"
         }
     }
 
@@ -266,6 +273,8 @@ struct MenuBarComposerEditor: View {
             return trimmed.isEmpty ? "Gap" : trimmed
         case .lineBreak:
             return "New row"
+        case .appIcon:
+            return "Vibe Bar icon"
         }
     }
 
@@ -287,6 +296,9 @@ struct MenuBarComposerEditor: View {
         VStack(alignment: .leading, spacing: 6) {
             caption("Add a block")
             paletteGroup("Logo") {
+                paletteButton(title: "Vibe Bar", icon: "menubar.rectangle") {
+                    add(MenuBarToken(kind: .appIcon, style: .label))
+                }
                 ForEach(paletteLogoTools, id: \.self) { tool in
                     paletteButton(title: tool.menuTitle, icon: nil, tool: tool) {
                         add(MenuBarToken(kind: .logo(tool), style: .label))
@@ -709,6 +721,10 @@ private struct MenuBarTokenInspector: View {
                 .foregroundStyle(.tertiary)
         case .lineBreak:
             Text("Ends the first row and starts the second.")
+                .font(.caption2)
+                .foregroundStyle(.tertiary)
+        case .appIcon:
+            Text("Vibe Bar's own icon — what the Icon Only layout shows.")
                 .font(.caption2)
                 .foregroundStyle(.tertiary)
         }

--- a/Sources/VibeBarApp/Views/MenuBarFieldsEditor.swift
+++ b/Sources/VibeBarApp/Views/MenuBarFieldsEditor.swift
@@ -140,7 +140,7 @@ struct MenuBarFieldsEditor: View {
             Circle()
                 .fill(Theme.providerAccent(for: option.tool))
                 .frame(width: 6, height: 6)
-            Text(option.title)
+            Text(option.displayTitle)
                 .font(.system(size: 11.5, weight: .medium))
                 .lineLimit(1)
                 .minimumScaleFactor(0.75)
@@ -160,7 +160,7 @@ struct MenuBarFieldsEditor: View {
             .frame(width: 108)
             .help("How this field draws on the menu bar: its label, the provider's logo, or both — each beside the percent.")
             DebouncedSettingsTextField(
-                prompt: option.defaultLabel,
+                prompt: option.displayDefaultLabel,
                 value: labelBinding(option)
             )
             .frame(width: 108)
@@ -265,7 +265,7 @@ struct MenuBarFieldsEditor: View {
                 get: { settingsStore.settings.menuBarItem(kind).selectedFieldIds.contains(option.id) },
                 set: { setSelected(option.id, $0) }
             )) {
-                Text(option.title)
+                Text(option.displayTitle)
                     .font(.system(size: 12, weight: .medium))
                     .lineLimit(2)
             }

--- a/Sources/VibeBarApp/Views/MenuBarStripView.swift
+++ b/Sources/VibeBarApp/Views/MenuBarStripView.swift
@@ -305,8 +305,8 @@ struct MenuBarStripView: View {
             displayMode: displayMode
         )
         Group {
-            if let tool = token.logo {
-                MenuBarStripLogo(tool: tool, side: size + 1, paint: paint)
+            if let glyph = token.glyph {
+                MenuBarStripGlyph(glyph: glyph, side: size + 1, paint: paint)
             } else if let text = token.text {
                 Text(text)
                     .font(font(for: token, size: size))
@@ -335,26 +335,22 @@ struct MenuBarStripView: View {
     }
 }
 
-/// A brand mark inside the preview, tinted to match the block's paint and
-/// rasterized against the preview's own colour scheme rather than the app's —
-/// a light-menu-bar preview has to show the light-menu-bar glyph.
-private struct MenuBarStripLogo: View {
+/// A glyph inside the preview — a provider's brand mark or Vibe Bar's own —
+/// tinted to match the block's paint and rasterized against the preview's own
+/// colour scheme rather than the app's: a light-menu-bar preview has to show
+/// the light-menu-bar glyph.
+private struct MenuBarStripGlyph: View {
     @Environment(\.colorScheme) private var colorScheme
-    let tool: ToolType
+    let glyph: MenuBarRenderedToken.Glyph
     let side: CGFloat
     let paint: MenuBarStripPaint
 
     var body: some View {
         Group {
-            if let image = ProviderBrandIcon.image(
-                for: tool,
-                size: NSSize(width: side, height: side),
-                tint: MenuBarStripPalette.nsColor(paint),
-                appearance: NSAppearance(named: colorScheme == .dark ? .darkAqua : .aqua)
-            ) {
+            if let image {
                 Image(nsImage: image).resizable().scaledToFit()
             } else {
-                Image(systemName: ProviderBrandIcon.fallbackSystemImage(for: tool))
+                Image(systemName: fallbackSymbol)
                     .resizable()
                     .scaledToFit()
                     .foregroundStyle(MenuBarStripPalette.color(paint))
@@ -362,6 +358,27 @@ private struct MenuBarStripLogo: View {
         }
         .frame(width: side, height: side)
         .accessibilityHidden(true)
+    }
+
+    private var image: NSImage? {
+        let size = NSSize(width: side, height: side)
+        let tint = MenuBarStripPalette.nsColor(paint)
+        let appearance = NSAppearance(named: colorScheme == .dark ? .darkAqua : .aqua)
+        switch glyph {
+        case let .provider(tool):
+            return ProviderBrandIcon.image(for: tool, size: size, tint: tint, appearance: appearance)
+        case .app:
+            return ProviderBrandIcon.image(
+                for: MenuBarItemKind.compact, size: size, tint: tint, appearance: appearance
+            )
+        }
+    }
+
+    private var fallbackSymbol: String {
+        switch glyph {
+        case let .provider(tool): return ProviderBrandIcon.fallbackSystemImage(for: tool)
+        case .app: return ProviderBrandIcon.fallbackSystemImage(for: MenuBarItemKind.compact)
+        }
     }
 }
 

--- a/Sources/VibeBarApp/Views/MenuBarStripView.swift
+++ b/Sources/VibeBarApp/Views/MenuBarStripView.swift
@@ -38,8 +38,13 @@ enum MenuBarStripMetrics {
     /// item measures its real attributed strings.
     static let lineHeightRatio: CGFloat = 1.2
 
-    static func baseFontSize(rowCount: Int) -> CGFloat {
-        rowCount >= 2 ? twoRowFontSize : singleRowFontSize
+    /// The face the status item would draw this strip at. The choice lives in
+    /// `MenuBarStripGeometry.face`; this only spells the point sizes.
+    static func baseFontSize(template: MenuBarComposition.Template, rowCount: Int) -> CGFloat {
+        switch MenuBarStripGeometry.face(template: template, rowCount: rowCount) {
+        case .system: return singleRowFontSize
+        case .compact: return twoRowFontSize
+        }
     }
 
     /// Height the rasterized image actually has for content, after padding.
@@ -54,10 +59,11 @@ enum MenuBarStripMetrics {
     /// the size it will actually be drawn.
     static func estimatedFitScale(rows: [MenuBarRenderRow], baseFontSize: CGFloat) -> CGFloat {
         guard rows.count >= 2 else { return 1 }
-        let heights = rows.map { row in
-            baseFontSize * (row.tokens.map(\.fontScale).max() ?? 1) * lineHeightRatio
-        }
-        let content = heights.reduce(0, +) + twoRowLineSpacing * CGFloat(rows.count - 1)
+        let content = CGFloat(MenuBarStripGeometry.twoRowContentHeight(
+            rowFontSizes: rows.map { Double(baseFontSize) * ($0.tokens.map(\.fontScale).max() ?? 1) },
+            lineSpacing: Double(twoRowLineSpacing),
+            lineHeightRatio: Double(lineHeightRatio)
+        ))
         return CGFloat(MenuBarStripFit.scale(
             contentHeight: Double(content),
             availableHeight: Double(twoRowAvailableHeight())
@@ -539,6 +545,8 @@ struct MenuBarStripPreview: View {
     let plan: MenuBarRenderPlan
     let quotas: [MenuBarQuotaSnapshot]
     let displayMode: DisplayMode
+    /// Which face the bar will use — see `MenuBarStripGeometry.face`.
+    let template: MenuBarComposition.Template
     var highlighted: UUID?
 
     var body: some View {
@@ -554,7 +562,7 @@ struct MenuBarStripPreview: View {
         // fit. The preview does all three, or it is previewing a strip the
         // user will never see.
         let rows = plan.rows.filter { !$0.isEmpty }
-        let base = MenuBarStripMetrics.baseFontSize(rowCount: rows.count)
+        let base = MenuBarStripMetrics.baseFontSize(template: template, rowCount: rows.count)
         let fit = MenuBarStripMetrics.estimatedFitScale(rows: rows, baseFontSize: base)
         return MenuBarStripView(
             plan: plan,

--- a/Sources/VibeBarApp/Views/MenuBarStripView.swift
+++ b/Sources/VibeBarApp/Views/MenuBarStripView.swift
@@ -327,6 +327,12 @@ enum MenuBarStripResolver {
 
     /// What a quota is called on this item's strip: the user's rename if there
     /// is one, else the live bucket's own short label.
+    ///
+    /// Resolved here, on every render, rather than captured once: the generic
+    /// window words go through `QuotaGroupLabelLocalizer`, so the name follows
+    /// the app's language the way every other label does. A rename the user
+    /// typed is returned untouched — it is their text, not a contract value a
+    /// translation may improve.
     static func label(
         for field: MenuBarFieldOption,
         bucket: QuotaBucket,
@@ -334,8 +340,10 @@ enum MenuBarStripResolver {
     ) -> String {
         let custom = itemSettings.customLabels[field.id]?.trimmingCharacters(in: .whitespacesAndNewlines)
         if let custom, !custom.isEmpty { return custom }
-        if field.defaultLabel != bucket.shortLabel { return bucket.shortLabel }
-        return field.defaultLabel
+        let contractLabel = field.defaultLabel != bucket.shortLabel
+            ? bucket.shortLabel
+            : field.defaultLabel
+        return QuotaGroupLabelLocalizer.display(contractLabel)
     }
 }
 

--- a/Sources/VibeBarApp/Views/MenuBarStripView.swift
+++ b/Sources/VibeBarApp/Views/MenuBarStripView.swift
@@ -17,7 +17,22 @@ enum MenuBarStripMetrics {
     static let twoRowLineSpacing: CGFloat = -2
     static let twoRowVerticalPadding: CGFloat = 1
     /// Past this it is the glyph, not the type, that sets the row height.
-    static let maximumGlyphSide: CGFloat = 12
+    static let maximumGlyphSide = CGFloat(MenuBarStripGeometry.maximumTwoRowGlyphSide)
+
+    /// The glyph box every drawing path asks for — the arithmetic lives in
+    /// `MenuBarStripGeometry` so it is one decision with tests, not three that
+    /// agree by coincidence.
+    static func glyphSide(fontSize: CGFloat, rowCount: Int) -> CGFloat {
+        CGFloat(MenuBarStripGeometry.glyphSide(fontSize: Double(fontSize), rowCount: rowCount))
+    }
+
+    static func singleRowGlyphSide(fontSize: CGFloat) -> CGFloat {
+        CGFloat(MenuBarStripGeometry.singleRowGlyphSide(fontSize: Double(fontSize)))
+    }
+
+    static func twoRowGlyphSide(fontSize: CGFloat) -> CGFloat {
+        CGFloat(MenuBarStripGeometry.twoRowGlyphSide(fontSize: Double(fontSize)))
+    }
     /// System text occupies roughly this much vertical space per point of
     /// font size. Only used to *estimate* the preview's height; the status
     /// item measures its real attributed strings.
@@ -368,6 +383,12 @@ struct MenuBarStripView: View {
     /// selection is visible in the preview too.
     var highlighted: UUID?
 
+    /// Rows the strip actually draws — the same count the status item uses to
+    /// pick its face and its glyph box.
+    private var drawnRowCount: Int {
+        plan.rows.reduce(0) { $0 + ($1.isEmpty ? 0 : 1) }
+    }
+
     var body: some View {
         let rows = plan.rows.filter { !$0.isEmpty }
         Group {
@@ -384,7 +405,11 @@ struct MenuBarStripView: View {
             }
         }
         .accessibilityElement(children: .ignore)
-        .accessibilityLabel(plan.spokenDescription.isEmpty ? "Empty strip" : plan.spokenDescription)
+        .accessibilityLabel(
+            plan.spokenDescription.isEmpty
+                ? L10n.MenuBar.composerPreviewEmpty
+                : plan.spokenDescription
+        )
     }
 
     private func rowView(_ row: MenuBarRenderRow) -> some View {
@@ -414,7 +439,12 @@ struct MenuBarStripView: View {
             if let glyph = token.glyph {
                 MenuBarStripGlyph(
                     glyph: glyph,
-                    side: min(size + 1, MenuBarStripMetrics.maximumGlyphSide),
+                    // Whatever the bar will use for this many rows, not a
+                    // preview-only cap.
+                    side: MenuBarStripMetrics.glyphSide(
+                        fontSize: size,
+                        rowCount: drawnRowCount
+                    ),
                     paint: paint
                 )
             } else if let text = token.text {
@@ -539,6 +569,8 @@ struct MenuBarStripPreview: View {
                 .stroke(Color.primary.opacity(0.12), lineWidth: 0.5)
         )
         .accessibilityElement(children: .contain)
-        .accessibilityLabel(scheme == .dark ? "Dark menu bar preview" : "Light menu bar preview")
+        .accessibilityLabel(
+            scheme == .dark ? L10n.MenuBar.composerPreviewDark : L10n.MenuBar.composerPreviewLight
+        )
     }
 }

--- a/Sources/VibeBarApp/Views/MenuBarStripView.swift
+++ b/Sources/VibeBarApp/Views/MenuBarStripView.swift
@@ -1,6 +1,54 @@
 import AppKit
+import Combine
 import SwiftUI
 import VibeBarCore
+
+/// The measurements a composed strip is drawn at.
+///
+/// One table, because the status item and the Settings preview draw the same
+/// strip: a preview at a different face, a different glyph cap, or without the
+/// bar's fit-to-height pass is a preview of a different strip.
+enum MenuBarStripMetrics {
+    /// The face a one-row strip is drawn at — the status item's own.
+    static var singleRowFontSize: CGFloat { NSFont.smallSystemFontSize }
+    /// ...and a rasterized two-row strip, which has half the height each.
+    static let twoRowFontSize: CGFloat = 9
+    /// Deliberate negative tuck between the two bands.
+    static let twoRowLineSpacing: CGFloat = -2
+    static let twoRowVerticalPadding: CGFloat = 1
+    /// Past this it is the glyph, not the type, that sets the row height.
+    static let maximumGlyphSide: CGFloat = 12
+    /// System text occupies roughly this much vertical space per point of
+    /// font size. Only used to *estimate* the preview's height; the status
+    /// item measures its real attributed strings.
+    static let lineHeightRatio: CGFloat = 1.2
+
+    static func baseFontSize(rowCount: Int) -> CGFloat {
+        rowCount >= 2 ? twoRowFontSize : singleRowFontSize
+    }
+
+    /// Height the rasterized image actually has for content, after padding.
+    static func twoRowAvailableHeight() -> CGFloat {
+        max(18, NSStatusBar.system.thickness - 2) - twoRowVerticalPadding * 2
+    }
+
+    /// The fit-to-height scale for a plan drawn at `baseFontSize`, estimated
+    /// from the type metrics rather than measured. The status item applies the
+    /// same `MenuBarStripFit` rule to its real measurements — this is the
+    /// preview's approximation of it, so a two-row strip previews at roughly
+    /// the size it will actually be drawn.
+    static func estimatedFitScale(rows: [MenuBarRenderRow], baseFontSize: CGFloat) -> CGFloat {
+        guard rows.count >= 2 else { return 1 }
+        let heights = rows.map { row in
+            baseFontSize * (row.tokens.map(\.fontScale).max() ?? 1) * lineHeightRatio
+        }
+        let content = heights.reduce(0, +) + twoRowLineSpacing * CGFloat(rows.count - 1)
+        return CGFloat(MenuBarStripFit.scale(
+            contentHeight: Double(content),
+            availableHeight: Double(twoRowAvailableHeight())
+        ))
+    }
+}
 
 /// The paint a composed block ends up wearing.
 ///
@@ -154,6 +202,43 @@ enum MenuBarStripPalette {
 /// under the forecast basis.
 @MainActor
 enum MenuBarStripResolver {
+    /// Every publisher a composed strip's inputs arrive on.
+    ///
+    /// One list with two consumers — the status item's render pipeline and the
+    /// Settings preview — because two lists is two chances to forget one, and
+    /// forgetting one is invisible: the preview simply keeps showing the
+    /// previous generation while the bar beside it updates.
+    ///
+    /// Everything `snapshots(...)` and `liveFieldIds(...)` read has to be here:
+    ///
+    /// | What the resolver reads | Publisher |
+    /// | --- | --- |
+    /// | display mode, colour basis, custom labels, the composition itself | `settingsStore.$settings` |
+    /// | the live buckets | `quotaService.$lastSuccessByAccount`, `$lastErrorByAccount` |
+    /// | discovered fields, so a new bucket resolves | `quotaService.$fieldRegistry` |
+    /// | forecast evidence | `quotaService.$observationsByAccountBucket`, `$historyByAccountBucket` |
+    /// | forecast activity weighting | `costService.$snapshots` |
+    /// | the account id a forecast is keyed on | `accountStore.$accounts` |
+    /// | the field path's provider status | `serviceStatus.$snapshotByTool` |
+    ///
+    /// A refresh publishes the quota first and records observations in a
+    /// follow-up task, so the later ones are not redundant — they are the
+    /// difference between a forecast colour describing this refresh and the
+    /// previous one.
+    static func inputPublishers(environment: AppEnvironment) -> [AnyPublisher<Void, Never>] {
+        [
+            environment.settingsStore.$settings.map { _ in () }.eraseToAnyPublisher(),
+            environment.quotaService.$lastSuccessByAccount.map { _ in () }.eraseToAnyPublisher(),
+            environment.quotaService.$lastErrorByAccount.map { _ in () }.eraseToAnyPublisher(),
+            environment.quotaService.$fieldRegistry.map { _ in () }.eraseToAnyPublisher(),
+            environment.quotaService.$observationsByAccountBucket.map { _ in () }.eraseToAnyPublisher(),
+            environment.quotaService.$historyByAccountBucket.map { _ in () }.eraseToAnyPublisher(),
+            environment.costService.$snapshots.map { _ in () }.eraseToAnyPublisher(),
+            environment.accountStore.$accounts.map { _ in () }.eraseToAnyPublisher(),
+            environment.serviceStatus.$snapshotByTool.map { _ in () }.eraseToAnyPublisher()
+        ]
+    }
+
     static func snapshots(
         for composition: MenuBarComposition,
         itemSettings: MenuBarItemSettings,
@@ -180,9 +265,6 @@ enum MenuBarStripResolver {
                     runOutAt: computed.runOutAt
                 )
             }
-            let pace = requirement.needsPace
-                ? UsagePace.compute(bucket: bucket, now: now, allowsPostResetGrace: true)
-                : nil
             out.append(MenuBarQuotaSnapshot(
                 fieldId: field.id,
                 tool: field.tool,
@@ -190,7 +272,7 @@ enum MenuBarStripResolver {
                 usedPercent: bucket.usedPercent,
                 displayPercent: bucket.displayPercent(settings.displayMode, tool: field.tool),
                 resetAt: bucket.resetAt,
-                paceDeltaPercent: pace?.deltaPercent,
+                rawWindowSeconds: bucket.rawWindowSeconds,
                 forecast: forecast
             ))
         }
@@ -242,6 +324,29 @@ enum MenuBarStripResolver {
     }
 }
 
+/// Subscribes once to `MenuBarStripResolver.inputPublishers` and republishes a
+/// counter.
+///
+/// A SwiftUI surface cannot subscribe to a merged publisher directly without
+/// rebuilding it on every body pass, so this holds the subscription for the
+/// life of the view and lets the view depend on exactly the inputs the status
+/// item depends on.
+@MainActor
+final class MenuBarStripInputObserver: ObservableObject {
+    @Published private(set) var generation = 0
+    private var cancellables: Set<AnyCancellable> = []
+
+    func start(environment: AppEnvironment) {
+        guard cancellables.isEmpty else { return }
+        Publishers.MergeMany(MenuBarStripResolver.inputPublishers(environment: environment))
+            // The same 120 ms coalescing the status item uses: one refresh
+            // publishes several of these back to back.
+            .throttle(for: .milliseconds(120), scheduler: RunLoop.main, latest: true)
+            .sink { [weak self] _ in self?.generation &+= 1 }
+            .store(in: &cancellables)
+    }
+}
+
 /// The composed strip, drawn in SwiftUI.
 ///
 /// This is the editor's preview, and it consumes exactly the plan the status
@@ -257,7 +362,8 @@ struct MenuBarStripView: View {
     let plan: MenuBarRenderPlan
     let quotas: [MenuBarQuotaSnapshot]
     let displayMode: DisplayMode
-    var baseFontSize: CGFloat = 12
+    /// The face the status item would draw this plan at.
+    var baseFontSize: CGFloat = MenuBarStripMetrics.singleRowFontSize
     /// Draws the id'd block with a selection ring, so the editor's chip
     /// selection is visible in the preview too.
     var highlighted: UUID?
@@ -306,7 +412,11 @@ struct MenuBarStripView: View {
         )
         Group {
             if let glyph = token.glyph {
-                MenuBarStripGlyph(glyph: glyph, side: size + 1, paint: paint)
+                MenuBarStripGlyph(
+                    glyph: glyph,
+                    side: min(size + 1, MenuBarStripMetrics.maximumGlyphSide),
+                    paint: paint
+                )
             } else if let text = token.text {
                 Text(text)
                     .font(font(for: token, size: size))
@@ -401,10 +511,18 @@ struct MenuBarStripPreview: View {
     }
 
     private func ground(scheme: ColorScheme) -> some View {
-        MenuBarStripView(
+        // The bar draws a one-row strip at the small system face and a
+        // rasterized two-row strip at 9pt, then shrinks two rows that do not
+        // fit. The preview does all three, or it is previewing a strip the
+        // user will never see.
+        let rows = plan.rows.filter { !$0.isEmpty }
+        let base = MenuBarStripMetrics.baseFontSize(rowCount: rows.count)
+        let fit = MenuBarStripMetrics.estimatedFitScale(rows: rows, baseFontSize: base)
+        return MenuBarStripView(
             plan: plan,
             quotas: quotas,
             displayMode: displayMode,
+            baseFontSize: base * fit,
             highlighted: highlighted
         )
         .environment(\.colorScheme, scheme)

--- a/Sources/VibeBarApp/Views/MenuBarStripView.swift
+++ b/Sources/VibeBarApp/Views/MenuBarStripView.swift
@@ -411,7 +411,11 @@ struct MenuBarStripView: View {
                     .font(.system(size: baseFontSize, weight: .regular).monospacedDigit())
                     .foregroundStyle(.tertiary)
             } else {
-                VStack(alignment: .leading, spacing: 0) {
+                // Centred, because `twoRowImage` centres each cell inside the
+                // column's shared width. An odd number of entries leaves the
+                // second row narrower, and a preview that left-aligns it shows
+                // the user something the menu bar will not draw.
+                VStack(alignment: .center, spacing: 0) {
                     ForEach(Array(rows.enumerated()), id: \.offset) { _, row in
                         rowView(row)
                     }

--- a/Sources/VibeBarApp/Views/MenuBarStripView.swift
+++ b/Sources/VibeBarApp/Views/MenuBarStripView.swift
@@ -1,0 +1,409 @@
+import AppKit
+import SwiftUI
+import VibeBarCore
+
+/// The paint a composed block ends up wearing.
+///
+/// One step past `MenuBarTokenColorRole`: the role says *which* colour to
+/// follow, this says which colour that turned out to be. It exists so the
+/// status item and the editor's preview share one decision and only differ in
+/// how they spell the result — an `NSColor` in an attributed string, a
+/// SwiftUI `Color` in a view. Two independent switches would drift the day
+/// somebody adds a role.
+enum MenuBarStripPaint: Equatable {
+    case quota(MenuBarPercentColor)
+    case brand(ToolType)
+    case primary
+    case secondary
+    case tertiary
+    case fixed(red: Double, green: Double, blue: Double, alpha: Double)
+}
+
+enum MenuBarStripPalette {
+    /// Resolve a role against the snapshot it was planned with.
+    ///
+    /// Pure and cheap: the expensive inputs (the forecast verdict) are already
+    /// in the snapshot, so this is safe to call while drawing.
+    static func paint(
+        for role: MenuBarTokenColorRole,
+        quotas: [MenuBarQuotaSnapshot],
+        displayMode: DisplayMode
+    ) -> MenuBarStripPaint {
+        switch role {
+        case let .quota(fieldId, basis):
+            guard let quota = quotas.first(where: { $0.fieldId == fieldId }) else { return .primary }
+            return .quota(MenuBarPercentColor.resolve(
+                basis: basis,
+                verdict: basis == .forecast ? quota.forecast?.verdict : nil,
+                percent: quota.displayPercent,
+                displayMode: displayMode
+            ))
+        case let .brand(tool):
+            return .brand(tool)
+        case .primary:
+            return .primary
+        case .secondary:
+            return .secondary
+        case .tertiary:
+            return .tertiary
+        case let .fixed(hex):
+            guard let parts = MenuBarHexColor.components(hex) else { return .primary }
+            return .fixed(red: parts.r, green: parts.g, blue: parts.b, alpha: parts.a)
+        }
+    }
+
+    /// AppKit spelling, for the status item's attributed strings and its
+    /// rasterized two-row image.
+    @MainActor
+    static func nsColor(_ paint: MenuBarStripPaint) -> NSColor {
+        switch paint {
+        case let .quota(color):
+            // The same system colours the pre-composer menu bar used: they
+            // have to stay legible against light, dark, and tinted wallpapers.
+            switch color {
+            case .healthy: return .systemGreen
+            case .surplus: return .systemBlue
+            case .watch: return .systemOrange
+            case .risk: return .systemRed
+            }
+        case let .brand(tool):
+            return brandAccent(for: tool)
+        case .primary:
+            return .labelColor
+        case .secondary:
+            return .secondaryLabelColor
+        case .tertiary:
+            return .tertiaryLabelColor
+        case let .fixed(red, green, blue, alpha):
+            return NSColor(srgbRed: red, green: green, blue: blue, alpha: alpha)
+        }
+    }
+
+    /// SwiftUI spelling, for the editor's preview. `.primary` and friends stay
+    /// semantic so a preview rendered in the opposite colour scheme shows what
+    /// the other menu bar will actually look like — which is the entire point
+    /// of showing both.
+    static func color(_ paint: MenuBarStripPaint) -> Color {
+        switch paint {
+        case let .quota(color):
+            switch color {
+            case .healthy: return Color(nsColor: .systemGreen)
+            case .surplus: return Color(nsColor: .systemBlue)
+            case .watch: return Color(nsColor: .systemOrange)
+            case .risk: return Color(nsColor: .systemRed)
+            }
+        case let .brand(tool):
+            return Theme.providerAccent(for: tool)
+        case .primary:
+            return .primary
+        case .secondary:
+            return .secondary
+        case .tertiary:
+            return Color.primary.opacity(0.45)
+        case let .fixed(red, green, blue, alpha):
+            return Color(.sRGB, red: red, green: green, blue: blue, opacity: alpha)
+        }
+    }
+
+    /// Stable cache key for a resolved paint, used to key rasterized brand
+    /// marks. Keyed on the paint rather than the `NSColor`, whose description
+    /// is not stable for a dynamic system colour.
+    static func cacheKey(_ paint: MenuBarStripPaint) -> String {
+        switch paint {
+        case let .quota(color):
+            switch color {
+            case .healthy: return "healthy"
+            case .surplus: return "surplus"
+            case .watch: return "watch"
+            case .risk: return "risk"
+            }
+        case let .brand(tool): return "brand.\(tool.rawValue)"
+        case .primary: return "label"
+        case .secondary: return "secondary"
+        case .tertiary: return "tertiary"
+        case let .fixed(red, green, blue, alpha):
+            return "fixed.\(red).\(green).\(blue).\(alpha)"
+        }
+    }
+
+    /// AppKit twin of the shared provider accent table, memoized for the
+    /// process: the status item re-renders on a 120 ms throttle and must not
+    /// bridge a SwiftUI colour every tick.
+    ///
+    /// The table itself is `Theme.providerAccent` — the composer's brand
+    /// swatches, the mini window, and the charts all read that one table, so a
+    /// provider cannot be teal in one place and green in another.
+    @MainActor
+    static func brandAccent(for tool: ToolType) -> NSColor {
+        if let cached = brandAccentCache[tool] { return cached }
+        let color = NSColor(Theme.providerAccent(for: tool))
+        brandAccentCache[tool] = color
+        return color
+    }
+
+    @MainActor private static var brandAccentCache: [ToolType: NSColor] = [:]
+}
+
+/// Builds the live quota snapshots a composed strip is planned against.
+///
+/// Shared by the status item and the editor's preview so both are looking at
+/// the same numbers, and so the rule about *which* quotas get a forecast is
+/// written once. Only the fields the strip actually names are resolved, and a
+/// forecast is computed only where a block, a colour, or a rule reads one —
+/// plus the case the plain field strip already pays for, an automatic colour
+/// under the forecast basis.
+@MainActor
+enum MenuBarStripResolver {
+    static func snapshots(
+        for composition: MenuBarComposition,
+        itemSettings: MenuBarItemSettings,
+        settings: AppSettings,
+        environment: AppEnvironment,
+        now: Date = Date()
+    ) -> [MenuBarQuotaSnapshot] {
+        let registry = environment.quotaService.fieldRegistry
+        let requirements = composition.quotaRequirements
+        let wantsForecastColors = settings.menuBarColorBasis == .forecast
+        var out: [MenuBarQuotaSnapshot] = []
+        out.reserveCapacity(requirements.count)
+        for requirement in requirements {
+            guard
+                let field = MenuBarFieldCatalog.field(id: requirement.fieldId, registry: registry),
+                let bucket = environment.quota(for: field.tool)?.bucket(id: field.bucketId)
+            else { continue }
+            var forecast: MenuBarQuotaSnapshot.Forecast?
+            if requirement.needsForecast || wantsForecastColors,
+               let computed = paceForecast(for: field.tool, bucket: bucket, environment: environment) {
+                forecast = MenuBarQuotaSnapshot.Forecast(
+                    verdict: computed.verdict,
+                    projectedRemainingPercent: computed.projectedRemainingPercent,
+                    runOutAt: computed.runOutAt
+                )
+            }
+            let pace = requirement.needsPace
+                ? UsagePace.compute(bucket: bucket, now: now, allowsPostResetGrace: true)
+                : nil
+            out.append(MenuBarQuotaSnapshot(
+                fieldId: field.id,
+                tool: field.tool,
+                label: label(for: field, bucket: bucket, itemSettings: itemSettings),
+                usedPercent: bucket.usedPercent,
+                displayPercent: bucket.displayPercent(settings.displayMode, tool: field.tool),
+                resetAt: bucket.resetAt,
+                paceDeltaPercent: pace?.deltaPercent,
+                forecast: forecast
+            ))
+        }
+        return out
+    }
+
+    /// Every catalog field whose bucket a provider is currently returning.
+    /// Feeds `MenuBarComposition.availability(liveFieldIds:)`, which is how the
+    /// editor tells "this block is misconfigured" apart from "this provider is
+    /// not answering right now".
+    static func liveFieldIds(environment: AppEnvironment) -> Set<String> {
+        let registry = environment.quotaService.fieldRegistry
+        var live: Set<String> = []
+        for option in MenuBarFieldCatalog.mergedFields(registry: registry)
+        where environment.quota(for: option.tool)?.bucket(id: option.bucketId) != nil {
+            live.insert(option.id)
+        }
+        return live
+    }
+
+    static func paceForecast(
+        for tool: ToolType,
+        bucket: QuotaBucket,
+        environment: AppEnvironment
+    ) -> QuotaPaceForecast? {
+        guard let accountId = environment.account(for: tool)?.id else { return nil }
+        let snapshot = environment.costService.snapshot(for: tool)
+        return environment.quotaService.paceForecast(
+            accountId: accountId,
+            bucket: bucket,
+            activityHeatmap: snapshot?.heatmap,
+            dailyActivity: snapshot?.dailyHistory ?? [],
+            now: Date(),
+            allowsPostResetGrace: true
+        )
+    }
+
+    /// What a quota is called on this item's strip: the user's rename if there
+    /// is one, else the live bucket's own short label.
+    static func label(
+        for field: MenuBarFieldOption,
+        bucket: QuotaBucket,
+        itemSettings: MenuBarItemSettings
+    ) -> String {
+        let custom = itemSettings.customLabels[field.id]?.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let custom, !custom.isEmpty { return custom }
+        if field.defaultLabel != bucket.shortLabel { return bucket.shortLabel }
+        return field.defaultLabel
+    }
+}
+
+/// The composed strip, drawn in SwiftUI.
+///
+/// This is the editor's preview, and it consumes exactly the plan the status
+/// item consumes — same blocks, same order, same colours, same truncation. It
+/// is deliberately not an independent drawing of the same idea: the whole
+/// reason the plan is a value in Core is so the preview cannot tell a
+/// different story from the menu bar.
+///
+/// It does not resolve quotas, compute forecasts, or read settings. Everything
+/// it needs arrives as a value, so re-rendering it while the user types costs
+/// a layout pass and nothing else.
+struct MenuBarStripView: View {
+    let plan: MenuBarRenderPlan
+    let quotas: [MenuBarQuotaSnapshot]
+    let displayMode: DisplayMode
+    var baseFontSize: CGFloat = 12
+    /// Draws the id'd block with a selection ring, so the editor's chip
+    /// selection is visible in the preview too.
+    var highlighted: UUID?
+
+    var body: some View {
+        let rows = plan.rows.filter { !$0.isEmpty }
+        Group {
+            if rows.isEmpty {
+                Text("—")
+                    .font(.system(size: baseFontSize, weight: .regular).monospacedDigit())
+                    .foregroundStyle(.tertiary)
+            } else {
+                VStack(alignment: .leading, spacing: 0) {
+                    ForEach(Array(rows.enumerated()), id: \.offset) { _, row in
+                        rowView(row)
+                    }
+                }
+            }
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(plan.spokenDescription.isEmpty ? "Empty strip" : plan.spokenDescription)
+    }
+
+    private func rowView(_ row: MenuBarRenderRow) -> some View {
+        HStack(spacing: baseFontSize * plan.tokenSpacing * Self.spacingToPoints) {
+            ForEach(row.tokens) { token in
+                tokenView(token)
+            }
+        }
+    }
+
+    /// The plan states gaps as a multiplier on the base font size because the
+    /// status item realizes them as a space glyph, which is the only thing the
+    /// two-row canvas can carry. A stack has real point spacing, so convert
+    /// with the width a system-font space actually occupies — close enough
+    /// that the preview and the bar agree at a glance.
+    private static let spacingToPoints: CGFloat = 0.28
+
+    @ViewBuilder
+    private func tokenView(_ token: MenuBarRenderedToken) -> some View {
+        let size = max(4, baseFontSize * token.fontScale)
+        let paint = MenuBarStripPalette.paint(
+            for: token.color,
+            quotas: quotas,
+            displayMode: displayMode
+        )
+        Group {
+            if let tool = token.logo {
+                MenuBarStripLogo(tool: tool, side: size + 1, paint: paint)
+            } else if let text = token.text {
+                Text(text)
+                    .font(font(for: token, size: size))
+                    .foregroundStyle(MenuBarStripPalette.color(paint))
+                    .fixedSize()
+            }
+        }
+        .padding(.horizontal, highlighted == token.id ? 2 : 0)
+        .background {
+            if highlighted == token.id {
+                RoundedRectangle(cornerRadius: 3, style: .continuous)
+                    .fill(Color.accentColor.opacity(0.28))
+            }
+        }
+    }
+
+    private func font(for token: MenuBarRenderedToken, size: CGFloat) -> Font {
+        let weight: Font.Weight
+        switch token.weight {
+        case .regular: weight = .regular
+        case .medium: weight = .medium
+        case .semibold: weight = .semibold
+        }
+        let base = Font.system(size: size, weight: weight)
+        return token.monospacedDigits ? base.monospacedDigit() : base
+    }
+}
+
+/// A brand mark inside the preview, tinted to match the block's paint and
+/// rasterized against the preview's own colour scheme rather than the app's —
+/// a light-menu-bar preview has to show the light-menu-bar glyph.
+private struct MenuBarStripLogo: View {
+    @Environment(\.colorScheme) private var colorScheme
+    let tool: ToolType
+    let side: CGFloat
+    let paint: MenuBarStripPaint
+
+    var body: some View {
+        Group {
+            if let image = ProviderBrandIcon.image(
+                for: tool,
+                size: NSSize(width: side, height: side),
+                tint: MenuBarStripPalette.nsColor(paint),
+                appearance: NSAppearance(named: colorScheme == .dark ? .darkAqua : .aqua)
+            ) {
+                Image(nsImage: image).resizable().scaledToFit()
+            } else {
+                Image(systemName: ProviderBrandIcon.fallbackSystemImage(for: tool))
+                    .resizable()
+                    .scaledToFit()
+                    .foregroundStyle(MenuBarStripPalette.color(paint))
+            }
+        }
+        .frame(width: side, height: side)
+        .accessibilityHidden(true)
+    }
+}
+
+/// The strip shown twice, on a light and a dark menu-bar ground.
+///
+/// Both, always: a fixed colour is the one thing in the composer that can look
+/// deliberate on one menu bar and be invisible on the other, and the user has
+/// no way to check that without switching their whole system appearance.
+struct MenuBarStripPreview: View {
+    let plan: MenuBarRenderPlan
+    let quotas: [MenuBarQuotaSnapshot]
+    let displayMode: DisplayMode
+    var highlighted: UUID?
+
+    var body: some View {
+        HStack(spacing: 8) {
+            ground(scheme: .light)
+            ground(scheme: .dark)
+        }
+    }
+
+    private func ground(scheme: ColorScheme) -> some View {
+        MenuBarStripView(
+            plan: plan,
+            quotas: quotas,
+            displayMode: displayMode,
+            highlighted: highlighted
+        )
+        .environment(\.colorScheme, scheme)
+        .padding(.horizontal, 8)
+        .frame(maxWidth: .infinity, minHeight: 30, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 6, style: .continuous)
+                // A stand-in for a menu bar, not a card: the point is a light
+                // and a dark ground to read the strip against.
+                .fill(scheme == .dark ? Color.black.opacity(0.82) : Color.white.opacity(0.92))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 6, style: .continuous)
+                .stroke(Color.primary.opacity(0.12), lineWidth: 0.5)
+        )
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel(scheme == .dark ? "Dark menu bar preview" : "Light menu bar preview")
+    }
+}

--- a/Sources/VibeBarApp/Views/SettingsView.swift
+++ b/Sources/VibeBarApp/Views/SettingsView.swift
@@ -795,15 +795,15 @@ struct SettingsView: View {
 
             // The way back to the plain strip is the second control in the
             // section, not something to hunt for inside the composer.
-            Picker("Strip", selection: menuBarStripModeBinding(kind)) {
-                Text("Default").tag(false)
-                Text("Custom").tag(true)
+            Picker(L10n.MenuBar.composerModeLabel, selection: menuBarStripModeBinding(kind)) {
+                Text(L10n.MenuBar.composerModeDefault).tag(false)
+                Text(L10n.MenuBar.composerModeCustom).tag(true)
             }
             .pickerStyle(.segmented)
             Text(
                 isCustom
-                    ? "Switching back to Default keeps every block you built — you can return to Custom and find it exactly as you left it."
-                    : "Default shows the fields you tick below. Custom lets you build the strip out of blocks: logos, words, and any quota."
+                    ? L10n.MenuBar.composerModeCustomCaption
+                    : L10n.MenuBar.composerModeDefaultCaption
             )
             .font(.caption2)
             .foregroundStyle(.tertiary)

--- a/Sources/VibeBarApp/Views/SettingsView.swift
+++ b/Sources/VibeBarApp/Views/SettingsView.swift
@@ -860,7 +860,9 @@ struct SettingsView: View {
                 var item = settingsStore.settings.menuBarItem(kind)
                 item.setComposedStripEnabled(
                     enabled,
-                    template: .roomy,
+                    // Match the layout the user is looking at, so the seed
+                    // starts with their spacing as well as their blocks.
+                    template: .matching(item.layout),
                     registry: quotaService.fieldRegistry,
                     groupCatalogLabel: MiniWindowGroupLabelCatalog.defaultLabel(for:)
                 )

--- a/Sources/VibeBarApp/Views/SettingsView.swift
+++ b/Sources/VibeBarApp/Views/SettingsView.swift
@@ -789,19 +789,42 @@ struct SettingsView: View {
 
     private func menuBarOverviewEditor() -> some View {
         let kind = MenuBarItemKind.compact
+        let isCustom = settingsStore.settings.menuBarItem(kind).usesComposedStrip
         return VStack(alignment: .leading, spacing: 10) {
             Toggle(L10n.Platform.macosMenuBarShowInMenuBar, isOn: menuItemVisibleBinding(kind))
-            Toggle(L10n.Platform.macosMenuBarShowTitleText, isOn: menuItemTitleBinding(kind))
-            Picker(L10n.Platform.macosMenuBarLayout, selection: menuItemLayoutBinding(kind)) {
-                ForEach(MenuBarLayout.allCases) { layout in
-                    Text(layout.label).tag(layout)
-                }
+
+            // The way back to the plain strip is the second control in the
+            // section, not something to hunt for inside the composer.
+            Picker("Strip", selection: menuBarStripModeBinding(kind)) {
+                Text("Default").tag(false)
+                Text("Custom").tag(true)
             }
             .pickerStyle(.segmented)
-            Toggle(L10n.Platform.macosMenuBarMergeGroupWindows, isOn: menuItemMergeGroupWindowsBinding(kind))
-            Text(L10n.Platform.macosMenuBarMergeGroupWindowsDetail)
-                .font(.caption2)
-                .foregroundStyle(.tertiary)
+            Text(
+                isCustom
+                    ? "Switching back to Default keeps every block you built — you can return to Custom and find it exactly as you left it."
+                    : "Default shows the fields you tick below. Custom lets you build the strip out of blocks: logos, words, and any quota."
+            )
+            .font(.caption2)
+            .foregroundStyle(.tertiary)
+            .fixedSize(horizontal: false, vertical: true)
+
+            if isCustom {
+                MenuBarComposerEditor(kind: kind, density: density)
+            } else {
+                Toggle(L10n.Platform.macosMenuBarShowTitleText, isOn: menuItemTitleBinding(kind))
+                Picker(L10n.Platform.macosMenuBarLayout, selection: menuItemLayoutBinding(kind)) {
+                    ForEach(MenuBarLayout.allCases) { layout in
+                        Text(layout.label).tag(layout)
+                    }
+                }
+                .pickerStyle(.segmented)
+                Toggle(L10n.Platform.macosMenuBarMergeGroupWindows, isOn: menuItemMergeGroupWindowsBinding(kind))
+                Text(L10n.Platform.macosMenuBarMergeGroupWindowsDetail)
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+            }
+
             Picker(L10n.Platform.macosMenuBarDisplayDensity, selection: popoverDensityBinding()) {
                 ForEach(PopoverDensity.allCases) { Text($0.label).tag($0) }
             }
@@ -816,7 +839,7 @@ struct SettingsView: View {
             Text(settingsStore.settings.menuBarColorBasis.detail)
                 .font(.caption2)
                 .foregroundStyle(.tertiary)
-            if !MenuBarFieldCatalog.fields(for: kind).isEmpty {
+            if !isCustom, !MenuBarFieldCatalog.fields(for: kind).isEmpty {
                 Text(L10n.Platform.macosMenuBarFields)
                     .font(.caption)
                     .foregroundStyle(.secondary)
@@ -824,6 +847,26 @@ struct SettingsView: View {
                 menuItemFieldList(for: kind)
             }
         }
+    }
+
+    /// Default ↔ Custom. Off never destroys anything: the composed strip is
+    /// kept on the item and only its `isEnabled` flag moves, so the field
+    /// selection and the block arrangement coexist rather than overwriting
+    /// each other. Seeding happens once, the first time Custom is chosen.
+    private func menuBarStripModeBinding(_ kind: MenuBarItemKind) -> Binding<Bool> {
+        Binding(
+            get: { settingsStore.settings.menuBarItem(kind).usesComposedStrip },
+            set: { enabled in
+                var item = settingsStore.settings.menuBarItem(kind)
+                item.setComposedStripEnabled(
+                    enabled,
+                    template: .roomy,
+                    registry: quotaService.fieldRegistry,
+                    groupCatalogLabel: MiniWindowGroupLabelCatalog.defaultLabel(for:)
+                )
+                settingsStore.settings.setMenuBarItem(item)
+            }
+        )
     }
 
     private func launchAtLoginBinding() -> Binding<Bool> {

--- a/Sources/VibeBarCore/Localization/L10n+Generated.swift
+++ b/Sources/VibeBarCore/Localization/L10n+Generated.swift
@@ -889,6 +889,10 @@ extension L10n {
         public static var composerTemplateTwoRowsDetail: String {
             L10n.string("menuBar.composer.template.twoRowsDetail")
         }
+        /// `menuBar.composer.text.empty` — An empty text block draws nothing. Type something for it to appear in the menu bar.
+        public static var composerTextEmpty: String {
+            L10n.string("menuBar.composer.text.empty")
+        }
         /// `menuBar.composer.text.limit` — Blocks longer than {count} characters are cut short with an ellipsis in the bar.
         public static func composerTextLimit(count: Int) -> String {
             L10n.string("menuBar.composer.text.limit", count)
@@ -6341,6 +6345,7 @@ extension L10n {
         "menuBar.composer.template.roomyDetail",
         "menuBar.composer.template.twoRows",
         "menuBar.composer.template.twoRowsDetail",
+        "menuBar.composer.text.empty",
         "menuBar.composer.text.limit",
         "menuBar.composer.text.placeholder",
         "menuBar.composer.warning.degraded",

--- a/Sources/VibeBarCore/Localization/L10n+Generated.swift
+++ b/Sources/VibeBarCore/Localization/L10n+Generated.swift
@@ -572,6 +572,393 @@ extension L10n {
         }
     }
 
+    public enum MenuBar {
+        /// `menuBar.composer.action.duplicate` — Duplicate
+        public static var composerActionDuplicate: String {
+            L10n.string("menuBar.composer.action.duplicate")
+        }
+        /// `menuBar.composer.action.remove` — Remove
+        public static var composerActionRemove: String {
+            L10n.string("menuBar.composer.action.remove")
+        }
+        /// `menuBar.composer.appIcon.detail` — Vibe Bar's own icon — what the Icon Only layout shows.
+        public static var composerAppIconDetail: String {
+            L10n.string("menuBar.composer.appIcon.detail")
+        }
+        /// `menuBar.composer.block.appIcon` — Vibe Bar icon
+        public static var composerBlockAppIcon: String {
+            L10n.string("menuBar.composer.block.appIcon")
+        }
+        /// `menuBar.composer.block.emptyText` — Empty text
+        public static var composerBlockEmptyText: String {
+            L10n.string("menuBar.composer.block.emptyText")
+        }
+        /// `menuBar.composer.block.gap` — Gap
+        public static var composerBlockGap: String {
+            L10n.string("menuBar.composer.block.gap")
+        }
+        /// `menuBar.composer.block.logo` — Logo
+        public static var composerBlockLogo: String {
+            L10n.string("menuBar.composer.block.logo")
+        }
+        /// `menuBar.composer.block.newRow` — New row
+        public static var composerBlockNewRow: String {
+            L10n.string("menuBar.composer.block.newRow")
+        }
+        /// `menuBar.composer.block.quota` — Quota
+        public static var composerBlockQuota: String {
+            L10n.string("menuBar.composer.block.quota")
+        }
+        /// `menuBar.composer.block.separator` — Separator
+        public static var composerBlockSeparator: String {
+            L10n.string("menuBar.composer.block.separator")
+        }
+        /// `menuBar.composer.block.space` — Space
+        public static var composerBlockSpace: String {
+            L10n.string("menuBar.composer.block.space")
+        }
+        /// `menuBar.composer.block.structure` — Structure
+        public static var composerBlockStructure: String {
+            L10n.string("menuBar.composer.block.structure")
+        }
+        /// `menuBar.composer.block.text` — Text
+        public static var composerBlockText: String {
+            L10n.string("menuBar.composer.block.text")
+        }
+        /// `menuBar.composer.blocks` — Blocks — drag to reorder
+        public static var composerBlocks: String {
+            L10n.string("menuBar.composer.blocks")
+        }
+        /// `menuBar.composer.blocks.empty` — No blocks yet. Add one from the palette below.
+        public static var composerBlocksEmpty: String {
+            L10n.string("menuBar.composer.blocks.empty")
+        }
+        /// `menuBar.composer.colour.automatic` — Automatic
+        public static var composerColourAutomatic: String {
+            L10n.string("menuBar.composer.colour.automatic")
+        }
+        /// `menuBar.composer.colour.brand` — Brand
+        public static var composerColourBrand: String {
+            L10n.string("menuBar.composer.colour.brand")
+        }
+        /// `menuBar.composer.colour.fixed` — Custom…
+        public static var composerColourFixed: String {
+            L10n.string("menuBar.composer.colour.fixed")
+        }
+        /// `menuBar.composer.colour.followsQuota` — Follow a quota
+        public static var composerColourFollowsQuota: String {
+            L10n.string("menuBar.composer.colour.followsQuota")
+        }
+        /// `menuBar.composer.colour.forecast` — Forecast
+        public static var composerColourForecast: String {
+            L10n.string("menuBar.composer.colour.forecast")
+        }
+        /// `menuBar.composer.colour.primary` — Primary
+        public static var composerColourPrimary: String {
+            L10n.string("menuBar.composer.colour.primary")
+        }
+        /// `menuBar.composer.colour.secondary` — Secondary
+        public static var composerColourSecondary: String {
+            L10n.string("menuBar.composer.colour.secondary")
+        }
+        /// `menuBar.composer.colour.tertiary` — Tertiary
+        public static var composerColourTertiary: String {
+            L10n.string("menuBar.composer.colour.tertiary")
+        }
+        /// `menuBar.composer.field.colour` — Colour
+        public static var composerFieldColour: String {
+            L10n.string("menuBar.composer.field.colour")
+        }
+        /// `menuBar.composer.field.monospacedDigits` — Monospaced digits
+        public static var composerFieldMonospacedDigits: String {
+            L10n.string("menuBar.composer.field.monospacedDigits")
+        }
+        /// `menuBar.composer.field.monospacedDigitsHelp` — Keeps a changing number from shifting the blocks beside it.
+        public static var composerFieldMonospacedDigitsHelp: String {
+            L10n.string("menuBar.composer.field.monospacedDigitsHelp")
+        }
+        /// `menuBar.composer.field.offlineOption` — {title} (offline)
+        public static func composerFieldOfflineOption(title: String) -> String {
+            L10n.string("menuBar.composer.field.offlineOption", title)
+        }
+        /// `menuBar.composer.field.provider` — Provider
+        public static var composerFieldProvider: String {
+            L10n.string("menuBar.composer.field.provider")
+        }
+        /// `menuBar.composer.field.show` — Show
+        public static var composerFieldShow: String {
+            L10n.string("menuBar.composer.field.show")
+        }
+        /// `menuBar.composer.field.shows` — Shows
+        public static var composerFieldShows: String {
+            L10n.string("menuBar.composer.field.shows")
+        }
+        /// `menuBar.composer.field.size` — Size
+        public static var composerFieldSize: String {
+            L10n.string("menuBar.composer.field.size")
+        }
+        /// `menuBar.composer.field.verdicts` — Verdicts
+        public static var composerFieldVerdicts: String {
+            L10n.string("menuBar.composer.field.verdicts")
+        }
+        /// `menuBar.composer.field.weight` — Weight
+        public static var composerFieldWeight: String {
+            L10n.string("menuBar.composer.field.weight")
+        }
+        /// `menuBar.composer.metric.displayPercent` — Percent (follows setting)
+        public static var composerMetricDisplayPercent: String {
+            L10n.string("menuBar.composer.metric.displayPercent")
+        }
+        /// `menuBar.composer.metric.forecastPercent` — Forecast at reset
+        public static var composerMetricForecastPercent: String {
+            L10n.string("menuBar.composer.metric.forecastPercent")
+        }
+        /// `menuBar.composer.metric.label` — Name
+        public static var composerMetricLabel: String {
+            L10n.string("menuBar.composer.metric.label")
+        }
+        /// `menuBar.composer.metric.pace` — Pace
+        public static var composerMetricPace: String {
+            L10n.string("menuBar.composer.metric.pace")
+        }
+        /// `menuBar.composer.metric.remainingPercent` — Remaining %
+        public static var composerMetricRemainingPercent: String {
+            L10n.string("menuBar.composer.metric.remainingPercent")
+        }
+        /// `menuBar.composer.metric.resetAt` — Resets at
+        public static var composerMetricResetAt: String {
+            L10n.string("menuBar.composer.metric.resetAt")
+        }
+        /// `menuBar.composer.metric.resetsIn` — Resets in
+        public static var composerMetricResetsIn: String {
+            L10n.string("menuBar.composer.metric.resetsIn")
+        }
+        /// `menuBar.composer.metric.runsOutIn` — Runs out in
+        public static var composerMetricRunsOutIn: String {
+            L10n.string("menuBar.composer.metric.runsOutIn")
+        }
+        /// `menuBar.composer.metric.usedPercent` — Used %
+        public static var composerMetricUsedPercent: String {
+            L10n.string("menuBar.composer.metric.usedPercent")
+        }
+        /// `menuBar.composer.mode.custom` — Custom
+        public static var composerModeCustom: String {
+            L10n.string("menuBar.composer.mode.custom")
+        }
+        /// `menuBar.composer.mode.customCaption` — Switching back to Default keeps every block you built — you can return to Custom and find it exactly as you left it.
+        public static var composerModeCustomCaption: String {
+            L10n.string("menuBar.composer.mode.customCaption")
+        }
+        /// `menuBar.composer.mode.default` — Default
+        public static var composerModeDefault: String {
+            L10n.string("menuBar.composer.mode.default")
+        }
+        /// `menuBar.composer.mode.defaultCaption` — Default shows the fields you tick below. Custom lets you build the strip out of blocks: logos, words, and any quota.
+        public static var composerModeDefaultCaption: String {
+            L10n.string("menuBar.composer.mode.defaultCaption")
+        }
+        /// `menuBar.composer.mode.label` — Strip
+        public static var composerModeLabel: String {
+            L10n.string("menuBar.composer.mode.label")
+        }
+        /// `menuBar.composer.newRow.capped` — The menu bar can only draw two rows.
+        public static var composerNewRowCapped: String {
+            L10n.string("menuBar.composer.newRow.capped")
+        }
+        /// `menuBar.composer.newRow.detail` — Ends the first row and starts the second. Give it a rule below to split only when that quota says so.
+        public static var composerNewRowDetail: String {
+            L10n.string("menuBar.composer.newRow.detail")
+        }
+        /// `menuBar.composer.newRow.help` — Split the strip into a second row.
+        public static var composerNewRowHelp: String {
+            L10n.string("menuBar.composer.newRow.help")
+        }
+        /// `menuBar.composer.palette` — Add a block
+        public static var composerPalette: String {
+            L10n.string("menuBar.composer.palette")
+        }
+        /// `menuBar.composer.preview` — Preview
+        public static var composerPreview: String {
+            L10n.string("menuBar.composer.preview")
+        }
+        /// `menuBar.composer.preview.dark` — Dark menu bar preview
+        public static var composerPreviewDark: String {
+            L10n.string("menuBar.composer.preview.dark")
+        }
+        /// `menuBar.composer.preview.empty` — Empty strip
+        public static var composerPreviewEmpty: String {
+            L10n.string("menuBar.composer.preview.empty")
+        }
+        /// `menuBar.composer.preview.grounds` — Light and dark menu bars, side by side — a fixed colour that reads well on one can vanish on the other.
+        public static var composerPreviewGrounds: String {
+            L10n.string("menuBar.composer.preview.grounds")
+        }
+        /// `menuBar.composer.preview.light` — Light menu bar preview
+        public static var composerPreviewLight: String {
+            L10n.string("menuBar.composer.preview.light")
+        }
+        /// `menuBar.composer.preview.twoRowScaling` — Two rows share the menu bar's height, so large sizes are scaled down to fit — the preview scales with them.
+        public static var composerPreviewTwoRowScaling: String {
+            L10n.string("menuBar.composer.preview.twoRowScaling")
+        }
+        /// `menuBar.composer.removeTarget` — Drag here to remove
+        public static var composerRemoveTarget: String {
+            L10n.string("menuBar.composer.removeTarget")
+        }
+        /// `menuBar.composer.rule.always` — Always
+        public static var composerRuleAlways: String {
+            L10n.string("menuBar.composer.rule.always")
+        }
+        /// `menuBar.composer.rule.whenForecast` — When the forecast says
+        public static var composerRuleWhenForecast: String {
+            L10n.string("menuBar.composer.rule.whenForecast")
+        }
+        /// `menuBar.composer.rule.whenRemainingAtMost` — When remaining is at most
+        public static var composerRuleWhenRemainingAtMost: String {
+            L10n.string("menuBar.composer.rule.whenRemainingAtMost")
+        }
+        /// `menuBar.composer.rule.whenUsedAtLeast` — When used is at least
+        public static var composerRuleWhenUsedAtLeast: String {
+            L10n.string("menuBar.composer.rule.whenUsedAtLeast")
+        }
+        /// `menuBar.composer.selected` — Selected block
+        public static var composerSelected: String {
+            L10n.string("menuBar.composer.selected")
+        }
+        /// `menuBar.composer.size.large` — Large
+        public static var composerSizeLarge: String {
+            L10n.string("menuBar.composer.size.large")
+        }
+        /// `menuBar.composer.size.regular` — Regular
+        public static var composerSizeRegular: String {
+            L10n.string("menuBar.composer.size.regular")
+        }
+        /// `menuBar.composer.size.small` — Small
+        public static var composerSizeSmall: String {
+            L10n.string("menuBar.composer.size.small")
+        }
+        /// `menuBar.composer.space.detail` — A gap one space wide. Size changes how wide.
+        public static var composerSpaceDetail: String {
+            L10n.string("menuBar.composer.space.detail")
+        }
+        /// `menuBar.composer.startOver` — Start over from the current strip…
+        public static var composerStartOver: String {
+            L10n.string("menuBar.composer.startOver")
+        }
+        /// `menuBar.composer.startOver.confirm` — Start over
+        public static var composerStartOverConfirm: String {
+            L10n.string("menuBar.composer.startOver.confirm")
+        }
+        /// `menuBar.composer.startOver.confirmMessage` — Every block you arranged is discarded and rebuilt from the default strip.
+        public static var composerStartOverConfirmMessage: String {
+            L10n.string("menuBar.composer.startOver.confirmMessage")
+        }
+        /// `menuBar.composer.startOver.confirmTitle` — Replace your blocks?
+        public static var composerStartOverConfirmTitle: String {
+            L10n.string("menuBar.composer.startOver.confirmTitle")
+        }
+        /// `menuBar.composer.startOver.detail` — Starting over replaces every block with a fresh copy of the default strip. There is no undo.
+        public static var composerStartOverDetail: String {
+            L10n.string("menuBar.composer.startOver.detail")
+        }
+        /// `menuBar.composer.template` — Template
+        public static var composerTemplate: String {
+            L10n.string("menuBar.composer.template")
+        }
+        /// `menuBar.composer.template.compact` — Compact
+        public static var composerTemplateCompact: String {
+            L10n.string("menuBar.composer.template.compact")
+        }
+        /// `menuBar.composer.template.compactDetail` — Tight spacing and a slightly smaller face.
+        public static var composerTemplateCompactDetail: String {
+            L10n.string("menuBar.composer.template.compactDetail")
+        }
+        /// `menuBar.composer.template.roomy` — Roomy
+        public static var composerTemplateRoomy: String {
+            L10n.string("menuBar.composer.template.roomy")
+        }
+        /// `menuBar.composer.template.roomyDetail` — Today's size, with more air between blocks.
+        public static var composerTemplateRoomyDetail: String {
+            L10n.string("menuBar.composer.template.roomyDetail")
+        }
+        /// `menuBar.composer.template.twoRows` — Two rows
+        public static var composerTemplateTwoRows: String {
+            L10n.string("menuBar.composer.template.twoRows")
+        }
+        /// `menuBar.composer.template.twoRowsDetail` — Two stacked rows in one status item.
+        public static var composerTemplateTwoRowsDetail: String {
+            L10n.string("menuBar.composer.template.twoRowsDetail")
+        }
+        /// `menuBar.composer.text.limit` — Blocks longer than {count} characters are cut short with an ellipsis in the bar.
+        public static func composerTextLimit(count: Int) -> String {
+            L10n.string("menuBar.composer.text.limit", count)
+        }
+        /// `menuBar.composer.text.placeholder` — Label
+        public static var composerTextPlaceholder: String {
+            L10n.string("menuBar.composer.text.placeholder")
+        }
+        /// `menuBar.composer.warning.degraded` — This block still draws, but a colour or a rule on it points at a quota that is not being returned right now.
+        public static var composerWarningDegraded: String {
+            L10n.string("menuBar.composer.warning.degraded")
+        }
+        /// `menuBar.composer.warning.missing` — Not answering right now: {fields}
+        public static func composerWarningMissing(fields: String) -> String {
+            L10n.string("menuBar.composer.warning.missing", fields)
+        }
+        /// `menuBar.composer.warning.silent` — This quota is not being returned right now, so this block draws nothing. It stays here and comes back on its own.
+        public static var composerWarningSilent: String {
+            L10n.string("menuBar.composer.warning.silent")
+        }
+        /// `menuBar.composer.weight.medium` — Medium
+        public static var composerWeightMedium: String {
+            L10n.string("menuBar.composer.weight.medium")
+        }
+        /// `menuBar.composer.weight.regular` — Regular
+        public static var composerWeightRegular: String {
+            L10n.string("menuBar.composer.weight.regular")
+        }
+        /// `menuBar.composer.weight.semibold` — Semibold
+        public static var composerWeightSemibold: String {
+            L10n.string("menuBar.composer.weight.semibold")
+        }
+        /// `menuBar.spoken.forecast` — {label} forecast {value} left at reset
+        public static func spokenForecast(label: String, value: String) -> String {
+            L10n.string("menuBar.spoken.forecast", label, value)
+        }
+        /// `menuBar.spoken.pace` — {label} pace {value}
+        public static func spokenPace(label: String, value: String) -> String {
+            L10n.string("menuBar.spoken.pace", label, value)
+        }
+        /// `menuBar.spoken.remaining` — {label} {value} remaining
+        public static func spokenRemaining(label: String, value: String) -> String {
+            L10n.string("menuBar.spoken.remaining", label, value)
+        }
+        /// `menuBar.spoken.resetAt` — {label} resets at {value}
+        public static func spokenResetAt(label: String, value: String) -> String {
+            L10n.string("menuBar.spoken.resetAt", label, value)
+        }
+        /// `menuBar.spoken.resetsIn` — {label} resets in {value}
+        public static func spokenResetsIn(label: String, value: String) -> String {
+            L10n.string("menuBar.spoken.resetsIn", label, value)
+        }
+        /// `menuBar.spoken.runsOutIn` — {label} runs out in {value}
+        public static func spokenRunsOutIn(label: String, value: String) -> String {
+            L10n.string("menuBar.spoken.runsOutIn", label, value)
+        }
+        /// `menuBar.spoken.title` — {kind} quota
+        public static func spokenTitle(kind: String) -> String {
+            L10n.string("menuBar.spoken.title", kind)
+        }
+        /// `menuBar.spoken.titleBody` — {kind} quota: {body}
+        public static func spokenTitleBody(kind: String, body: String) -> String {
+            L10n.string("menuBar.spoken.titleBody", kind, body)
+        }
+        /// `menuBar.spoken.used` — {label} {value} used
+        public static func spokenUsed(label: String, value: String) -> String {
+            L10n.string("menuBar.spoken.used", label, value)
+        }
+    }
+
     public enum Onboarding {
         /// `onboarding.apiKeys.hide` — Hide
         public static var apiKeysHide: String {
@@ -5875,6 +6262,102 @@ extension L10n {
         "error.rateLimited",
         "error.unknown",
         "error.unknownDetail",
+        "menuBar.composer.action.duplicate",
+        "menuBar.composer.action.remove",
+        "menuBar.composer.appIcon.detail",
+        "menuBar.composer.block.appIcon",
+        "menuBar.composer.block.emptyText",
+        "menuBar.composer.block.gap",
+        "menuBar.composer.block.logo",
+        "menuBar.composer.block.newRow",
+        "menuBar.composer.block.quota",
+        "menuBar.composer.block.separator",
+        "menuBar.composer.block.space",
+        "menuBar.composer.block.structure",
+        "menuBar.composer.block.text",
+        "menuBar.composer.blocks",
+        "menuBar.composer.blocks.empty",
+        "menuBar.composer.colour.automatic",
+        "menuBar.composer.colour.brand",
+        "menuBar.composer.colour.fixed",
+        "menuBar.composer.colour.followsQuota",
+        "menuBar.composer.colour.forecast",
+        "menuBar.composer.colour.primary",
+        "menuBar.composer.colour.secondary",
+        "menuBar.composer.colour.tertiary",
+        "menuBar.composer.field.colour",
+        "menuBar.composer.field.monospacedDigits",
+        "menuBar.composer.field.monospacedDigitsHelp",
+        "menuBar.composer.field.offlineOption",
+        "menuBar.composer.field.provider",
+        "menuBar.composer.field.show",
+        "menuBar.composer.field.shows",
+        "menuBar.composer.field.size",
+        "menuBar.composer.field.verdicts",
+        "menuBar.composer.field.weight",
+        "menuBar.composer.metric.displayPercent",
+        "menuBar.composer.metric.forecastPercent",
+        "menuBar.composer.metric.label",
+        "menuBar.composer.metric.pace",
+        "menuBar.composer.metric.remainingPercent",
+        "menuBar.composer.metric.resetAt",
+        "menuBar.composer.metric.resetsIn",
+        "menuBar.composer.metric.runsOutIn",
+        "menuBar.composer.metric.usedPercent",
+        "menuBar.composer.mode.custom",
+        "menuBar.composer.mode.customCaption",
+        "menuBar.composer.mode.default",
+        "menuBar.composer.mode.defaultCaption",
+        "menuBar.composer.mode.label",
+        "menuBar.composer.newRow.capped",
+        "menuBar.composer.newRow.detail",
+        "menuBar.composer.newRow.help",
+        "menuBar.composer.palette",
+        "menuBar.composer.preview",
+        "menuBar.composer.preview.dark",
+        "menuBar.composer.preview.empty",
+        "menuBar.composer.preview.grounds",
+        "menuBar.composer.preview.light",
+        "menuBar.composer.preview.twoRowScaling",
+        "menuBar.composer.removeTarget",
+        "menuBar.composer.rule.always",
+        "menuBar.composer.rule.whenForecast",
+        "menuBar.composer.rule.whenRemainingAtMost",
+        "menuBar.composer.rule.whenUsedAtLeast",
+        "menuBar.composer.selected",
+        "menuBar.composer.size.large",
+        "menuBar.composer.size.regular",
+        "menuBar.composer.size.small",
+        "menuBar.composer.space.detail",
+        "menuBar.composer.startOver",
+        "menuBar.composer.startOver.confirm",
+        "menuBar.composer.startOver.confirmMessage",
+        "menuBar.composer.startOver.confirmTitle",
+        "menuBar.composer.startOver.detail",
+        "menuBar.composer.template",
+        "menuBar.composer.template.compact",
+        "menuBar.composer.template.compactDetail",
+        "menuBar.composer.template.roomy",
+        "menuBar.composer.template.roomyDetail",
+        "menuBar.composer.template.twoRows",
+        "menuBar.composer.template.twoRowsDetail",
+        "menuBar.composer.text.limit",
+        "menuBar.composer.text.placeholder",
+        "menuBar.composer.warning.degraded",
+        "menuBar.composer.warning.missing",
+        "menuBar.composer.warning.silent",
+        "menuBar.composer.weight.medium",
+        "menuBar.composer.weight.regular",
+        "menuBar.composer.weight.semibold",
+        "menuBar.spoken.forecast",
+        "menuBar.spoken.pace",
+        "menuBar.spoken.remaining",
+        "menuBar.spoken.resetAt",
+        "menuBar.spoken.resetsIn",
+        "menuBar.spoken.runsOutIn",
+        "menuBar.spoken.title",
+        "menuBar.spoken.titleBody",
+        "menuBar.spoken.used",
         "onboarding.apiKeys.hide",
         "onboarding.apiKeys.intro",
         "onboarding.apiKeys.setUp",

--- a/Sources/VibeBarCore/Localization/L10n+Generated.swift
+++ b/Sources/VibeBarCore/Localization/L10n+Generated.swift
@@ -625,6 +625,10 @@ extension L10n {
         public static var composerBlockText: String {
             L10n.string("menuBar.composer.block.text")
         }
+        /// `menuBar.composer.block.unsupported` — From a newer version
+        public static var composerBlockUnsupported: String {
+            L10n.string("menuBar.composer.block.unsupported")
+        }
         /// `menuBar.composer.blocks` — Blocks — drag to reorder
         public static var composerBlocks: String {
             L10n.string("menuBar.composer.blocks")
@@ -900,6 +904,10 @@ extension L10n {
         /// `menuBar.composer.text.placeholder` — Label
         public static var composerTextPlaceholder: String {
             L10n.string("menuBar.composer.text.placeholder")
+        }
+        /// `menuBar.composer.unsupported.detail` — This block was made by a newer version of Vibe Bar. It is kept exactly as it was and will work again after an update; until then it draws nothing.
+        public static var composerUnsupportedDetail: String {
+            L10n.string("menuBar.composer.unsupported.detail")
         }
         /// `menuBar.composer.warning.degraded` — This block still draws, but a colour or a rule on it points at a quota that is not being returned right now.
         public static var composerWarningDegraded: String {
@@ -6279,6 +6287,7 @@ extension L10n {
         "menuBar.composer.block.space",
         "menuBar.composer.block.structure",
         "menuBar.composer.block.text",
+        "menuBar.composer.block.unsupported",
         "menuBar.composer.blocks",
         "menuBar.composer.blocks.empty",
         "menuBar.composer.colour.automatic",
@@ -6348,6 +6357,7 @@ extension L10n {
         "menuBar.composer.text.empty",
         "menuBar.composer.text.limit",
         "menuBar.composer.text.placeholder",
+        "menuBar.composer.unsupported.detail",
         "menuBar.composer.warning.degraded",
         "menuBar.composer.warning.missing",
         "menuBar.composer.warning.silent",

--- a/Sources/VibeBarCore/Localization/L10n+Generated.swift
+++ b/Sources/VibeBarCore/Localization/L10n+Generated.swift
@@ -881,7 +881,7 @@ extension L10n {
         public static var composerTemplateRoomy: String {
             L10n.string("menuBar.composer.template.roomy")
         }
-        /// `menuBar.composer.template.roomyDetail` — Today's size, with more air between blocks.
+        /// `menuBar.composer.template.roomyDetail` — The menu bar's usual size.
         public static var composerTemplateRoomyDetail: String {
             L10n.string("menuBar.composer.template.roomyDetail")
         }

--- a/Sources/VibeBarCore/Models/MenuBarComposition.swift
+++ b/Sources/VibeBarCore/Models/MenuBarComposition.swift
@@ -441,13 +441,15 @@ public struct MenuBarComposition: Codable, Equatable, Sendable {
         /// size. Realized as a space glyph, exactly the way the existing
         /// logo-to-label gap already is — a text attachment would inflate the
         /// line box and push the second row out of the bar.
-        public var tokenSpacing: Double {
-            switch self {
-            case .compact: return 0.35
-            case .roomy: return 0.9
-            case .twoColumn: return 0.8
-            }
-        }
+        /// One space, in every template.
+        ///
+        /// The composed renderer puts this between *every* pair of blocks,
+        /// including a label and its number — and one space is exactly what
+        /// each field renderer draws there. Anything else makes a seeded strip
+        /// a different width from the strip it reproduces, which is what a
+        /// larger value did. The templates differ by face and by rows, not by
+        /// how far apart the words sit.
+        public var tokenSpacing: Double { 1.0 }
 
         /// Multiplier on the layout's base font size.
         public var fontScale: Double {
@@ -464,11 +466,23 @@ public struct MenuBarComposition: Codable, Equatable, Sendable {
 
         var seedsSecondRow: Bool { self == .twoColumn }
 
-        /// What this template draws between two entries sharing a row. Used
-        /// when a two-row strip collapses back to one, so the entries that
-        /// were rows again become entries side by side.
-        var inlineSeparator: MenuBarToken.Kind {
-            self == .compact ? .space : .separator(" · ")
+        /// What this template draws between two entries sharing a row, when a
+        /// two-row strip collapses back to one.
+        ///
+        /// The same answer the seed uses, from the same table — a row break
+        /// and an entry boundary are the same boundary seen two ways, so they
+        /// must round-trip.
+        var inlineSeparator: MenuBarToken.Kind? {
+            MenuBarFieldStripRules.separator(for: seededFrom)
+        }
+
+        /// The field layout this template reproduces.
+        var seededFrom: MenuBarLayout {
+            switch self {
+            case .compact: return .compact
+            case .roomy: return .singleLine
+            case .twoColumn: return .twoRows
+            }
         }
 
         /// The template whose proportions match a field-mode layout, so
@@ -481,6 +495,11 @@ public struct MenuBarComposition: Codable, Equatable, Sendable {
             case .singleLine, .iconOnly: return .roomy
             }
         }
+
+        /// Layouts this template can be the match for. `.iconOnly` also maps
+        /// to `.roomy`, since an icon-only seed is a single glyph and has no
+        /// spacing or separator of its own to reproduce.
+        static var allLayouts: [MenuBarLayout] { MenuBarLayout.allCases }
     }
 
     /// The status item is ~22pt tall: two rows is the most the rasterizer can
@@ -537,11 +556,14 @@ public struct MenuBarComposition: Codable, Equatable, Sendable {
                 tokens.insert(MenuBarToken(kind: .lineBreak), at: seam)
             }
         } else {
+            guard let inline = newTemplate.inlineSeparator else {
+                // Nothing is drawn between entries on this template; the
+                // strip's own spacing does the work, so the break just goes.
+                tokens.removeAll { $0.kind == .lineBreak }
+                return
+            }
             for index in tokens.indices where tokens[index].kind == .lineBreak {
-                tokens[index] = MenuBarToken(
-                    kind: newTemplate.inlineSeparator,
-                    style: .divider
-                )
+                tokens[index] = MenuBarToken(kind: inline, style: .divider)
             }
         }
     }
@@ -551,14 +573,15 @@ public struct MenuBarComposition: Codable, Equatable, Sendable {
     /// break replaces the divider instead of joining it. `nil` when there is
     /// not enough on the strip to split.
     private static func rowSeamIndex(in tokens: [MenuBarToken]) -> Int? {
-        let content = tokens.indices.filter { index in
-            switch tokens[index].kind {
-            case .space, .separator, .lineBreak: return false
-            default: return true
-            }
-        }
-        guard content.count >= 2 else { return nil }
-        let start = content[(content.count + 1) / 2]
+        // Between entries, never through one. Counting raw content tokens put
+        // the seam in the middle of the *second* entry of three — an entry is
+        // a name and a number, so six tokens bisected the pair — leaving one
+        // field's label on the first row and its percentage on the second.
+        let starts = entryStartIndices(in: tokens)
+        guard starts.count >= 2 else { return nil }
+        let start = starts[(starts.count + 1) / 2]
+        // The spacing in front of the entry is the boundary the break takes
+        // over, so it goes with the break rather than dangling at a row end.
         if start > 0 {
             switch tokens[start - 1].kind {
             case .space, .separator: return start - 1
@@ -566,6 +589,31 @@ public struct MenuBarComposition: Codable, Equatable, Sendable {
             }
         }
         return start
+    }
+
+    /// Where each entry begins.
+    ///
+    /// An entry is a name and the value it names — optionally behind a logo.
+    /// A new one starts at the first naming block that follows a value, which
+    /// finds the boundaries whether or not the strip has divider blocks
+    /// between them (Compact and Two rows seed none).
+    private static func entryStartIndices(in tokens: [MenuBarToken]) -> [Int] {
+        var starts: [Int] = []
+        var sawValue = true
+        for (index, token) in tokens.enumerated() {
+            switch token.kind {
+            case .space, .separator, .lineBreak:
+                continue
+            case let .quota(_, metric) where metric != .label:
+                sawValue = true
+            case .logo, .appIcon, .text, .quota, .unsupported:
+                if sawValue {
+                    starts.append(index)
+                    sawValue = false
+                }
+            }
+        }
+        return starts
     }
 
     public var effectiveFontScale: Double { fontScale ?? template.fontScale }
@@ -859,20 +907,12 @@ public struct MenuBarComposition: Codable, Equatable, Sendable {
             tokens.append(MenuBarToken(kind: .text(item.kind.title), style: .label))
         }
 
-        // What each renderer actually puts between two entries: Single line
-        // appends a tertiary " · "; Compact appends a plain space; Two rows
-        // packs entries into columns separated by `twoRowColumnSpacing` and
-        // draws no divider at all. Seeding a dot into a Two rows strip put
-        // punctuation on screen that the layout had never drawn, which is the
-        // seed failing at its one job.
-        let separator: MenuBarToken.Kind = item.layout == .singleLine
-            ? .separator(" · ")
-            : .space
+        let separator = MenuBarFieldStripRules.separator(for: item.layout)
 
         for (rowIndex, row) in seedRows(runs, item: item, template: template).enumerated() {
             if rowIndex > 0 { tokens.append(MenuBarToken(kind: .lineBreak)) }
             for (index, run) in row.enumerated() {
-                if index > 0 {
+                if index > 0, let separator {
                     tokens.append(MenuBarToken(kind: separator, style: .divider))
                 }
                 tokens.append(contentsOf: seedRunTokens(
@@ -914,7 +954,13 @@ public struct MenuBarComposition: Codable, Equatable, Sendable {
         groupCatalogLabel: (String) -> String?
     ) -> [MenuBarToken] {
         var tokens: [MenuBarToken] = []
-        let style = item.style(for: run.primary.id)
+        // The style the renderer honours on this layout, not the one stored:
+        // Single line draws words only, so a saved logo style must not put a
+        // logo on a strip that has never shown one.
+        let style = MenuBarFieldStripRules.effectiveStyle(
+            item.style(for: run.primary.id),
+            layout: item.layout
+        )
         if style != .labelAndPercent {
             tokens.append(MenuBarToken(kind: .logo(run.primary.tool), style: .label))
         }
@@ -1982,6 +2028,47 @@ public enum MenuBarStripFit {
 /// built-in gap to a composed row double-counts it, so zero spacing still
 /// shows a gap and non-zero spacing comes out wider in the bar than in the
 /// preview.
+/// The rules the field-based renderer draws by.
+///
+/// Five review rounds found the seed disagreeing with the renderer in five
+/// different dimensions — separator characters, row structure, glyph size,
+/// font face, and now style coercion and spacing. Each was checked against the
+/// dimension that was reported, and none of them stopped the next one, because
+/// the two sides kept their own copy of each rule.
+///
+/// Face and glyph size already live in `MenuBarStripGeometry`, and the layout
+/// to template mapping in `Template.matching`. These are the two that were
+/// still duplicated. A rule that lives here cannot drift; a rule that does not
+/// is a sixth round waiting to happen.
+public enum MenuBarFieldStripRules {
+    /// What the renderer puts *between* two entries, beyond the ordinary gap
+    /// it already leaves between everything.
+    ///
+    /// Only Single line draws a character. Compact butts entries together with
+    /// the same single space it puts between a label and its number, and the
+    /// two-row rasterizer separates columns with spacing and draws nothing at
+    /// all — so for those the answer is nil and the strip's own token spacing
+    /// does the work. Seeding a literal `" · "` and then having the composed
+    /// renderer add its gap on both sides is what made a seeded strip wider
+    /// than the one it copied.
+    public static func separator(for layout: MenuBarLayout) -> MenuBarToken.Kind? {
+        layout == .singleLine ? .separator("·") : nil
+    }
+
+    /// The field style the renderer actually honours.
+    ///
+    /// `singleLineMenuTitle` draws words only and has never consulted the
+    /// per-field style; a saved `.logoAndPercent` is deliberately ignored
+    /// there. The seed applied it anyway and inserted a logo the user had
+    /// never seen on that layout.
+    public static func effectiveStyle(
+        _ style: MenuBarFieldStyle,
+        layout: MenuBarLayout
+    ) -> MenuBarFieldStyle {
+        layout == .singleLine ? .labelAndPercent : style
+    }
+}
+
 public enum MenuBarStripGeometry {
     /// Total width of a cell: its runs, plus one `gap` between each adjacent
     /// pair. A composed row passes `gap: 0`.

--- a/Sources/VibeBarCore/Models/MenuBarComposition.swift
+++ b/Sources/VibeBarCore/Models/MenuBarComposition.swift
@@ -65,17 +65,15 @@ public enum MenuBarQuotaMetric: String, Codable, CaseIterable, Sendable {
         }
     }
 
-    /// Whether this metric needs the linear burn-rate pace for its bucket.
-    var needsPace: Bool { self == .pace }
-
     /// Whether the string this metric renders goes stale on its own, with no
-    /// new data — a countdown ticks down between refreshes, and an absolute
-    /// reset time re-words itself once it crosses a day boundary. A strip
-    /// containing one of these needs a clock; a strip without one must not
-    /// start a timer at all.
+    /// new data — a countdown ticks down between refreshes, an absolute reset
+    /// time re-words itself once it crosses a day boundary, and pace drifts
+    /// because the expectation it is measured against advances with the clock.
+    /// A strip containing one of these needs a clock; a strip without one must
+    /// not start a timer at all.
     public var isTimeBased: Bool {
         switch self {
-        case .resetsIn, .resetAt, .runsOutIn: return true
+        case .resetsIn, .resetAt, .runsOutIn, .pace: return true
         default: return false
         }
     }
@@ -423,30 +421,27 @@ public struct MenuBarComposition: Codable, Equatable, Sendable {
         // of quotas at most — scanning that array beats allocating a hash
         // table every tick.
         var out: [MenuBarQuotaRequirement] = []
-        func requirement(_ fieldId: String, forecast: Bool, pace: Bool) {
+        func requirement(_ fieldId: String, forecast: Bool) {
             if let position = out.firstIndex(where: { $0.fieldId == fieldId }) {
                 out[position].needsForecast = out[position].needsForecast || forecast
-                out[position].needsPace = out[position].needsPace || pace
             } else {
-                out.append(MenuBarQuotaRequirement(
-                    fieldId: fieldId, needsForecast: forecast, needsPace: pace
-                ))
+                out.append(MenuBarQuotaRequirement(fieldId: fieldId, needsForecast: forecast))
             }
         }
         for token in tokens {
             if let fieldId = token.quotaFieldId, let metric = token.metric {
-                requirement(fieldId, forecast: metric.needsForecast, pace: metric.needsPace)
+                requirement(fieldId, forecast: metric.needsForecast)
             }
             // A colour that follows the block's own quota names no field, so
             // it has to be attributed here or nobody ever asks for its verdict.
             if token.style.color.followsOwnQuota, let fieldId = token.quotaFieldId {
-                requirement(fieldId, forecast: token.style.color.needsForecast, pace: false)
+                requirement(fieldId, forecast: token.style.color.needsForecast)
             }
             if let fieldId = token.style.color.fieldId {
-                requirement(fieldId, forecast: token.style.color.needsForecast, pace: false)
+                requirement(fieldId, forecast: token.style.color.needsForecast)
             }
             if let fieldId = token.visibility.fieldId {
-                requirement(fieldId, forecast: token.visibility.needsForecast, pace: false)
+                requirement(fieldId, forecast: token.visibility.needsForecast)
             }
         }
         return out
@@ -795,15 +790,16 @@ private struct LossyMenuBarToken: Codable {
 /// What the renderer must resolve for one quota before it can build the plan.
 public struct MenuBarQuotaRequirement: Equatable, Sendable {
     public var fieldId: String
-    /// Some token, colour, or rule reads the personal forecast.
+    /// Some token, colour, or rule reads the personal forecast — the one
+    /// genuinely expensive input. Pace is not here: it is arithmetic over
+    /// numbers the snapshot already carries, so the planner does it at draw
+    /// time and it advances with the clock instead of freezing at whatever the
+    /// last refresh computed.
     public var needsForecast: Bool
-    /// Some token reads the linear burn-rate pace.
-    public var needsPace: Bool
 
-    public init(fieldId: String, needsForecast: Bool, needsPace: Bool) {
+    public init(fieldId: String, needsForecast: Bool) {
         self.fieldId = fieldId
         self.needsForecast = needsForecast
-        self.needsPace = needsPace
     }
 }
 
@@ -844,8 +840,9 @@ public struct MenuBarQuotaSnapshot: Equatable, Sendable {
     /// Remaining setting.
     public var displayPercent: Double
     public var resetAt: Date?
-    /// `UsagePace.deltaPercent` — actual minus linear expectation.
-    public var paceDeltaPercent: Double?
+    /// The bucket's window length, so pace can be computed at draw time rather
+    /// than frozen into the snapshot.
+    public var rawWindowSeconds: Int?
     public var forecast: Forecast?
 
     public init(
@@ -855,7 +852,7 @@ public struct MenuBarQuotaSnapshot: Equatable, Sendable {
         usedPercent: Double,
         displayPercent: Double,
         resetAt: Date? = nil,
-        paceDeltaPercent: Double? = nil,
+        rawWindowSeconds: Int? = nil,
         forecast: Forecast? = nil
     ) {
         self.fieldId = fieldId
@@ -864,7 +861,7 @@ public struct MenuBarQuotaSnapshot: Equatable, Sendable {
         self.usedPercent = usedPercent
         self.displayPercent = displayPercent
         self.resetAt = resetAt
-        self.paceDeltaPercent = paceDeltaPercent
+        self.rawWindowSeconds = rawWindowSeconds
         self.forecast = forecast
     }
 
@@ -992,6 +989,10 @@ public extension MenuBarComposition {
         now: Date = Date()
     ) -> MenuBarRenderPlan {
         let scale = effectiveFontScale
+        // A seeded strip draws `5 Hours` and then `5 Hours 73% used`. That is
+        // what the bar has always looked like, so the block keeps drawing —
+        // but read aloud it stutters every field name, so it stops speaking.
+        let echoed = Self.labelEchoTokenIds(tokens: tokens, quotas: quotas)
         var rows: [MenuBarRenderRow] = [MenuBarRenderRow()]
         var spokenRows: [[String]] = [[]]
 
@@ -1026,6 +1027,7 @@ public extension MenuBarComposition {
                 quotas: quotas,
                 colorBasis: colorBasis
             )
+            let spoken = echoed.contains(token.id) ? nil : content.spoken
             rows[rows.count - 1].tokens.append(MenuBarRenderedToken(
                 id: token.id,
                 text: content.text,
@@ -1034,9 +1036,9 @@ public extension MenuBarComposition {
                 fontScale: scale * token.style.size.multiplier,
                 weight: token.style.weight,
                 monospacedDigits: token.style.monospacedDigits,
-                spoken: content.spoken
+                spoken: spoken
             ))
-            if let spoken = content.spoken {
+            if let spoken {
                 spokenRows[spokenRows.count - 1].append(spoken)
             }
         }
@@ -1051,6 +1053,43 @@ public extension MenuBarComposition {
             fontScale: scale,
             spokenDescription: spoken
         )
+    }
+
+    /// Text blocks that only repeat the name of the quota block right after
+    /// them, and so contribute nothing to a spoken description.
+    ///
+    /// Purely a speech concern: the strip still draws the label, because that
+    /// is what a seeded strip looks like and what the user arranged. Only
+    /// blocks separated from the quota by nothing but spacing count — a row
+    /// break, a logo, or another word in between means the label is doing its
+    /// own work and is read out.
+    static func labelEchoTokenIds(
+        tokens: [MenuBarToken],
+        quotas: [MenuBarQuotaSnapshot]
+    ) -> Set<UUID> {
+        var echoed: Set<UUID> = []
+        for (index, token) in tokens.enumerated() {
+            guard case let .text(text) = token.kind else { continue }
+            let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty else { continue }
+            var cursor = index + 1
+            scan: while cursor < tokens.count {
+                switch tokens[cursor].kind {
+                case .space, .separator:
+                    cursor += 1
+                case let .quota(fieldId, _):
+                    if let quota = quotas.first(where: { $0.fieldId == fieldId }),
+                       quota.label.trimmingCharacters(in: .whitespacesAndNewlines)
+                           .caseInsensitiveCompare(trimmed) == .orderedSame {
+                        echoed.insert(token.id)
+                    }
+                    break scan
+                default:
+                    break scan
+                }
+            }
+        }
+        return echoed
     }
 
     // MARK: Visibility
@@ -1145,8 +1184,17 @@ public extension MenuBarComposition {
         case .displayPercent:
             return percent(quota.displayPercent)
         case .pace:
-            guard let delta = quota.paceDeltaPercent else { return nil }
-            let rounded = Int(delta.rounded())
+            // Computed here, not in the snapshot: the linear expectation pace
+            // is measured against advances every minute, so a value frozen at
+            // resolve time would drift until the next refresh.
+            guard let pace = UsagePace.compute(
+                usedPercent: quota.usedPercent,
+                resetAt: quota.resetAt,
+                rawWindowSeconds: quota.rawWindowSeconds,
+                now: now,
+                allowsPostResetGrace: true
+            ) else { return nil }
+            let rounded = Int(pace.deltaPercent.rounded())
             if rounded == 0 { return "±0%" }
             return rounded > 0 ? "+\(rounded)%" : "\(rounded)%"
         case .forecastPercent:

--- a/Sources/VibeBarCore/Models/MenuBarComposition.swift
+++ b/Sources/VibeBarCore/Models/MenuBarComposition.swift
@@ -750,14 +750,11 @@ public struct MenuBarComposition: Codable, Equatable, Sendable {
             tokens.append(MenuBarToken(kind: .logo(run.primary.tool), style: .label))
         }
         if style != .logoAndPercent {
-            let label = run.isMerged
-                ? MenuBarFieldCatalog.mergedGroupLabel(
-                    for: run,
-                    customLabels: item.customLabels,
-                    groupCatalogLabel: groupCatalogLabel
-                )
-                : seedLabel(for: run.primary, customLabels: item.customLabels)
-            tokens.append(MenuBarToken(kind: .text(label), style: .label))
+            tokens.append(seedLabelToken(
+                run,
+                item: item,
+                groupCatalogLabel: groupCatalogLabel
+            ))
         }
         for (offset, field) in run.fields.enumerated() {
             if offset > 0 {
@@ -775,18 +772,54 @@ public struct MenuBarComposition: Codable, Equatable, Sendable {
     /// this field to for the menu bar. The live bucket's own short label wins
     /// at render time in the field path; a seed has no bucket in hand, so it
     /// captures the static name and the user can edit the text block after.
-    private static func seedLabel(
-        for field: MenuBarFieldOption,
-        customLabels: [String: String]
-    ) -> String {
-        let custom = customLabels[field.id]?.trimmingCharacters(in: .whitespacesAndNewlines)
-        if let custom, !custom.isEmpty { return custom }
-        // Through the naming seam: "5 Hours" and "Weekly" are generic window
-        // words a Chinese reader has no reason to meet, while "Sonnet" or
-        // "Codex Spark" is a name that comes back untouched. Seeding the raw
-        // contract label would have put English in the middle of a Chinese
-        // strip from the first switch to Custom.
-        return QuotaGroupLabelLocalizer.display(field.defaultLabel)
+    /// The block that names an entry.
+    ///
+    /// Two genuinely different things, kept apart in the *model* rather than
+    /// only in this function:
+    ///
+    /// - A name the user typed is `.text`. It is theirs, it is derived from
+    ///   nothing, and it is stored verbatim and never translated.
+    /// - A name the app derives from the quota is `.quota(_, .label)` — a
+    ///   *reference*, resolved when the strip is drawn. Seeding the resolved
+    ///   words instead would freeze whichever language was selected at that
+    ///   moment into `settings.json`: seed in Chinese, switch to English, and
+    ///   the strip would stay Chinese forever.
+    ///
+    /// A merged group is the third case and is a literal on purpose: its name
+    /// is a naming-axis identifier — a SubProvider, a model-group name — or
+    /// the user's own rename, and `AGENTS.md` § 7.1 says neither is
+    /// translated.
+    ///
+    /// A strip seeded by an earlier build carries the resolved words as
+    /// `.text` and is **left alone**. There is no way to tell a seeded literal
+    /// from one the user typed over — the model says a `.text` block is the
+    /// user's text — so migrating would mean rewriting content on a guess, and
+    /// guessing wrong silently edits something they wrote. "Start over from
+    /// the current strip" is the explicit way to adopt the new shape.
+    private static func seedLabelToken(
+        _ run: MenuBarFieldRun,
+        item: MenuBarItemSettings,
+        groupCatalogLabel: (String) -> String?
+    ) -> MenuBarToken {
+        if run.isMerged {
+            return MenuBarToken(
+                kind: .text(MenuBarFieldCatalog.mergedGroupLabel(
+                    for: run,
+                    customLabels: item.customLabels,
+                    groupCatalogLabel: groupCatalogLabel
+                )),
+                style: .label
+            )
+        }
+        let custom = item.customLabels[run.primary.id]?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        if let custom, !custom.isEmpty {
+            return MenuBarToken(kind: .text(custom), style: .label)
+        }
+        return MenuBarToken(
+            kind: .quota(fieldId: run.primary.id, metric: .label),
+            style: .label
+        )
     }
 
     // MARK: Codable
@@ -1138,22 +1171,37 @@ public extension MenuBarComposition {
     ) -> Set<UUID> {
         var echoed: Set<UUID> = []
         for (index, token) in tokens.enumerated() {
-            guard case let .text(text) = token.kind else { continue }
-            let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard !trimmed.isEmpty else { continue }
+            // A block that names a quota, either way it can be written: words
+            // the user typed, or a reference to the quota's own name.
+            let typed: String?
+            let referenced: String?
+            switch token.kind {
+            case let .text(text):
+                let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+                guard !trimmed.isEmpty else { continue }
+                (typed, referenced) = (trimmed, nil)
+            case let .quota(fieldId, .label):
+                (typed, referenced) = (nil, fieldId)
+            default:
+                continue
+            }
             var cursor = index + 1
             scan: while cursor < tokens.count {
                 switch tokens[cursor].kind {
                 case .space, .separator:
                     cursor += 1
                 case let .quota(fieldId, metric):
-                    if let quota = quotas.first(where: { $0.fieldId == fieldId }),
-                       isVisible(tokens[cursor].visibility, quotas: quotas),
-                       value(of: metric, in: quota, displayMode: displayMode, now: now) != nil,
-                       quota.label.trimmingCharacters(in: .whitespacesAndNewlines)
-                           .caseInsensitiveCompare(trimmed) == .orderedSame {
-                        echoed.insert(token.id)
-                    }
+                    // Two names in a row is not an echo; the second is not
+                    // saying anything the first already said.
+                    guard metric != .label else { break scan }
+                    guard let quota = quotas.first(where: { $0.fieldId == fieldId }),
+                          isVisible(tokens[cursor].visibility, quotas: quotas),
+                          value(of: metric, in: quota, displayMode: displayMode, now: now) != nil
+                    else { break scan }
+                    let echoes = referenced.map { $0 == fieldId }
+                        ?? (quota.label.trimmingCharacters(in: .whitespacesAndNewlines)
+                            .caseInsensitiveCompare(typed ?? "") == .orderedSame)
+                    if echoes { echoed.insert(token.id) }
                     break scan
                 default:
                     break scan

--- a/Sources/VibeBarCore/Models/MenuBarComposition.swift
+++ b/Sources/VibeBarCore/Models/MenuBarComposition.swift
@@ -992,7 +992,12 @@ public extension MenuBarComposition {
         // A seeded strip draws `5 Hours` and then `5 Hours 73% used`. That is
         // what the bar has always looked like, so the block keeps drawing —
         // but read aloud it stutters every field name, so it stops speaking.
-        let echoed = Self.labelEchoTokenIds(tokens: tokens, quotas: quotas)
+        let echoed = Self.labelEchoTokenIds(
+            tokens: tokens,
+            quotas: quotas,
+            displayMode: displayMode,
+            now: now
+        )
         var rows: [MenuBarRenderRow] = [MenuBarRenderRow()]
         var spokenRows: [[String]] = [[]]
 
@@ -1069,9 +1074,17 @@ public extension MenuBarComposition {
     /// blocks separated from the quota by nothing but spacing count — a row
     /// break, a logo, or another word in between means the label is doing its
     /// own work and is read out.
+    ///
+    /// The quota block has to actually *say* something for the label to be
+    /// redundant. A `runsOutIn` block whose forecast predicts no exhaustion,
+    /// or a `forecastPercent` block with no forecast yet, renders nothing —
+    /// and then the label beside it is the only content still on screen, so
+    /// silencing it would leave the strip describing less than it shows.
     static func labelEchoTokenIds(
         tokens: [MenuBarToken],
-        quotas: [MenuBarQuotaSnapshot]
+        quotas: [MenuBarQuotaSnapshot],
+        displayMode: DisplayMode,
+        now: Date
     ) -> Set<UUID> {
         var echoed: Set<UUID> = []
         for (index, token) in tokens.enumerated() {
@@ -1083,8 +1096,10 @@ public extension MenuBarComposition {
                 switch tokens[cursor].kind {
                 case .space, .separator:
                     cursor += 1
-                case let .quota(fieldId, _):
+                case let .quota(fieldId, metric):
                     if let quota = quotas.first(where: { $0.fieldId == fieldId }),
+                       isVisible(tokens[cursor].visibility, quotas: quotas),
+                       value(of: metric, in: quota, displayMode: displayMode, now: now) != nil,
                        quota.label.trimmingCharacters(in: .whitespacesAndNewlines)
                            .caseInsensitiveCompare(trimmed) == .orderedSame {
                         echoed.insert(token.id)

--- a/Sources/VibeBarCore/Models/MenuBarComposition.swift
+++ b/Sources/VibeBarCore/Models/MenuBarComposition.swift
@@ -109,6 +109,13 @@ public struct MenuBarToken: Identifiable, Codable, Hashable, Sendable {
         case appIcon
         /// Ends the current row and starts the next one. Never draws.
         case lineBreak
+        /// A block written by a build that knew something this one does not —
+        /// a kind it has never heard of, or a provider added after it shipped.
+        /// Kept exactly as found and handed back on the next save, because the
+        /// alternative is deleting a block the user made and never telling
+        /// them. Draws nothing and says nothing; the editor labels it and lets
+        /// it be removed.
+        case unsupported(JSONValue)
     }
 
     /// How the block looks. Colour is the interesting axis: any block — a
@@ -130,6 +137,28 @@ public struct MenuBarToken: Identifiable, Codable, Hashable, Sendable {
             self.size = size
             self.weight = weight
             self.monospacedDigits = monospacedDigits
+        }
+
+        private enum CodingKeys: String, CodingKey {
+            case color, size, weight, monospacedDigits
+        }
+
+        /// Every field degrades to its default.
+        ///
+        /// This decoder is hand-written for one reason: the synthesized one
+        /// throws when it meets a `SizeStep` or `Weight` a newer build wrote,
+        /// and `LossyMenuBarToken` turns a throw into a *dropped block* — so
+        /// running a newer build and going back deleted the user's blocks, and
+        /// the next save wrote that deletion to disk. A block that comes back
+        /// a little plainer can be fixed in a second; a block that is gone
+        /// cannot be recovered at all.
+        public init(from decoder: Decoder) throws {
+            let c = try decoder.container(keyedBy: CodingKeys.self)
+            self.color = (try? c.decode(ColorSource.self, forKey: .color)) ?? .automatic
+            self.size = (try? c.decode(SizeStep.self, forKey: .size)) ?? .regular
+            self.weight = (try? c.decode(Weight.self, forKey: .weight)) ?? .medium
+            self.monospacedDigits =
+                (try? c.decode(Bool.self, forKey: .monospacedDigits)) ?? false
         }
 
         /// What today's percentages wear: automatic colour, semibold,
@@ -342,6 +371,22 @@ public struct MenuBarToken: Identifiable, Codable, Hashable, Sendable {
     }
 
     /// The quota this token reads, if it is a quota token.
+    private enum CodingKeys: String, CodingKey {
+        case id, kind, style, visibility
+    }
+
+    /// Same reasoning as `Style`: everything except the block's own identity
+    /// degrades rather than taking the block down. `kind` is the exception —
+    /// a block whose kind this build cannot read is preserved verbatim
+    /// instead, see `Kind.unsupported`.
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        self.id = (try? c.decode(UUID.self, forKey: .id)) ?? UUID()
+        self.kind = try c.decode(Kind.self, forKey: .kind)
+        self.style = (try? c.decode(Style.self, forKey: .style)) ?? Style()
+        self.visibility = (try? c.decode(Visibility.self, forKey: .visibility)) ?? .always
+    }
+
     public var quotaFieldId: String? {
         if case let .quota(fieldId, _) = kind { return fieldId }
         return nil
@@ -407,7 +452,11 @@ public struct MenuBarComposition: Codable, Equatable, Sendable {
         /// Multiplier on the layout's base font size.
         public var fontScale: Double {
             switch self {
-            case .compact: return 0.95
+            // 1.0, not 0.95: Compact's smallness is its *face* — the 9pt one
+            // the built-in compact layout draws at — and scaling that down
+            // again would make the seeded strip smaller than the strip it is
+            // meant to reproduce. See `MenuBarStripGeometry.face`.
+            case .compact: return 1.0
             case .roomy: return 1.0
             case .twoColumn: return 1.0
             }
@@ -960,9 +1009,12 @@ public struct MenuBarComposition: Codable, Equatable, Sendable {
         // rather than taking the whole settings file down with it.
         let stored = try c.decodeIfPresent([LossyMenuBarToken].self, forKey: .tokens) ?? []
         self.tokens = stored.compactMap(\.value)
-        self.fontScale = try c.decodeIfPresent(Double.self, forKey: .fontScale)
+        // `try?`, not `try`: a malformed number here used to throw, and the
+        // item's own decoder catches that into `composition = nil` — losing
+        // every block over one bad scalar.
+        self.fontScale = (try? c.decode(Double.self, forKey: .fontScale))
             .map { $0.clamped(to: Self.fontScaleRange) }
-        self.tokenSpacing = try c.decodeIfPresent(Double.self, forKey: .tokenSpacing)
+        self.tokenSpacing = (try? c.decode(Double.self, forKey: .tokenSpacing))
             .map { $0.clamped(to: Self.tokenSpacingRange) }
     }
 
@@ -1402,6 +1454,10 @@ public extension MenuBarComposition {
             return TokenContent(text: MenuBarToken.truncated(separator), glyph: nil, spoken: nil)
         case .lineBreak:
             return nil
+        case .unsupported:
+            // Nothing to draw: this build does not know what it is. It is on
+            // the strip only so the next save hands it back.
+            return nil
         case let .quota(_, metric):
             // A bucket the provider is not returning right now takes its block
             // off the strip and leaves everything else alone.
@@ -1592,31 +1648,47 @@ extension MenuBarToken.Kind: Codable {
     }
 
     public init(from decoder: Decoder) throws {
+        // Anything unreadable is preserved rather than thrown, which is what
+        // stops `LossyMenuBarToken` from turning it into a deletion. Covers a
+        // discriminator this build lacks *and* a payload it cannot parse — a
+        // `.logo` naming a provider added after this version, most likely.
+        if let known = try? Self.known(from: decoder) {
+            self = known
+            return
+        }
+        self = .unsupported(try JSONValue(from: decoder))
+    }
+
+    private static func known(from decoder: Decoder) throws -> Self {
         let c = try decoder.container(keyedBy: CodingKeys.self)
         switch try c.decode(Discriminator.self, forKey: .type) {
         case .logo:
-            self = .logo(try c.decode(ToolType.self, forKey: .tool))
+            return .logo(try c.decode(ToolType.self, forKey: .tool))
         case .text:
-            self = .text(try c.decode(String.self, forKey: .text))
+            return .text(try c.decode(String.self, forKey: .text))
         case .quota:
-            self = .quota(
+            return .quota(
                 fieldId: try c.decode(String.self, forKey: .fieldId),
                 // An unknown metric from a newer build reads as the plain
                 // percentage rather than dropping the block.
                 metric: (try? c.decode(MenuBarQuotaMetric.self, forKey: .metric)) ?? .displayPercent
             )
         case .space:
-            self = .space
+            return .space
         case .separator:
-            self = .separator(try c.decode(String.self, forKey: .text))
+            return .separator(try c.decode(String.self, forKey: .text))
         case .lineBreak:
-            self = .lineBreak
+            return .lineBreak
         case .appIcon:
-            self = .appIcon
+            return .appIcon
         }
     }
 
     public func encode(to encoder: Encoder) throws {
+        if case let .unsupported(raw) = self {
+            try raw.encode(to: encoder)
+            return
+        }
         var c = encoder.container(keyedBy: CodingKeys.self)
         switch self {
         case let .logo(tool):
@@ -1638,6 +1710,8 @@ extension MenuBarToken.Kind: Codable {
             try c.encode(Discriminator.lineBreak, forKey: .type)
         case .appIcon:
             try c.encode(Discriminator.appIcon, forKey: .type)
+        case .unsupported:
+            break  // handled above, before the keyed container is opened
         }
     }
 }
@@ -1875,21 +1949,25 @@ public enum MenuBarCountdownClock {
 /// cropped or the two rows overlapped. Shrinking the type is the honest
 /// answer: the strip stays legible and nothing is silently cut off.
 public enum MenuBarStripFit {
-    /// Below this the type is too small to read, so the strip accepts being
-    /// tight rather than becoming a smudge.
-    public static let minimumScale: Double = 0.55
+    /// The smallest face the strip is willing to draw at. Nothing enforces it
+    /// in `scale` — it is the *property* the supported ranges are chosen to
+    /// respect, and `MenuBarCompositionTests` asserts that every supported
+    /// combination stays above it. A floor applied inside the arithmetic is
+    /// what let two rows keep overflowing: it made the numbers look reasonable
+    /// while the rows were still cropped.
+    public static let legibleFontSize: Double = 6
 
-    /// Uniform font scale that makes `contentHeight` fit `availableHeight`.
-    /// Returns 1 when it already fits.
-    public static func scale(
-        contentHeight: Double,
-        availableHeight: Double,
-        minimumScale: Double = MenuBarStripFit.minimumScale
-    ) -> Double {
+    /// Uniform font scale that makes `contentHeight` fit `availableHeight`,
+    /// exactly. Returns 1 when it already fits.
+    ///
+    /// No floor. A scale that does not fit is not a fit — the canvas is capped
+    /// afterwards regardless, so returning something too large just moves the
+    /// cropping one step later and hides it.
+    public static func scale(contentHeight: Double, availableHeight: Double) -> Double {
         guard contentHeight > 0, availableHeight > 0, contentHeight > availableHeight else {
             return 1
         }
-        return Swift.max(minimumScale, availableHeight / contentHeight)
+        return availableHeight / contentHeight
     }
 }
 
@@ -1915,6 +1993,54 @@ public enum MenuBarStripGeometry {
     /// Past this a glyph, rather than the type, decides a two-row band's
     /// height.
     public static let maximumTwoRowGlyphSide: Double = 12
+
+    /// The two-row canvas as the status bar usually presents it: a 22pt bar
+    /// less the rasterizer's 2pt inset and 1pt of padding each side. The App
+    /// reads the real thickness at draw time; these exist so the fit property
+    /// can be asserted against the shape users actually get.
+    public static let nominalTwoRowAvailableHeight: Double = 18
+    public static let nominalTwoRowFontSize: Double = 9
+    public static let nominalTwoRowLineSpacing: Double = -2
+    public static let nominalLineHeightRatio: Double = 1.2
+
+    /// Which face a composed strip is drawn at. The point sizes belong to
+    /// AppKit; the *choice* belongs here, so the status item and the preview
+    /// cannot disagree about it.
+    public enum Face: Equatable, Sendable {
+        /// The small system face the single-line status item draws at.
+        case system
+        /// The 9pt face the built-in Compact and two-row layouts draw at.
+        case compact
+    }
+
+    /// One decision, the way glyph size is one decision.
+    ///
+    /// Two rows always go through the rasterizer, which draws at the compact
+    /// face whatever the template says. A single row follows the layout its
+    /// template was seeded from: the Compact template reproduces the built-in
+    /// compact renderer, and that renderer uses the 9pt face — drawing a
+    /// compact seed at the system face instead made it noticeably larger than
+    /// the strip it was meant to reproduce.
+    public static func face(
+        template: MenuBarComposition.Template,
+        rowCount: Int
+    ) -> Face {
+        if rowCount >= 2 { return .compact }
+        return template == .compact ? .compact : .system
+    }
+
+    /// Stacked height of a set of rows, from the type metrics rather than a
+    /// measurement. The status item measures its real attributed strings; the
+    /// preview and the tests estimate with this, so both apply the same rule.
+    public static func twoRowContentHeight(
+        rowFontSizes: [Double],
+        lineSpacing: Double,
+        lineHeightRatio: Double
+    ) -> Double {
+        guard !rowFontSizes.isEmpty else { return 0 }
+        return rowFontSizes.reduce(0) { $0 + $1 * lineHeightRatio }
+            + lineSpacing * Double(rowFontSizes.count - 1)
+    }
 
     /// The glyph box for a block drawn at `fontSize` in a strip of
     /// `rowCount` rows.

--- a/Sources/VibeBarCore/Models/MenuBarComposition.swift
+++ b/Sources/VibeBarCore/Models/MenuBarComposition.swift
@@ -44,15 +44,15 @@ public enum MenuBarQuotaMetric: String, Codable, CaseIterable, Sendable {
     /// Menu label for the stage-2 editor's metric picker.
     public var title: String {
         switch self {
-        case .usedPercent: return "Used %"
-        case .remainingPercent: return "Remaining %"
-        case .displayPercent: return "Percent (follows setting)"
-        case .pace: return "Pace"
-        case .forecastPercent: return "Forecast at reset"
-        case .resetsIn: return "Resets in"
-        case .resetAt: return "Resets at"
-        case .runsOutIn: return "Runs out in"
-        case .label: return "Name"
+        case .usedPercent: return L10n.MenuBar.composerMetricUsedPercent
+        case .remainingPercent: return L10n.MenuBar.composerMetricRemainingPercent
+        case .displayPercent: return L10n.MenuBar.composerMetricDisplayPercent
+        case .pace: return L10n.MenuBar.composerMetricPace
+        case .forecastPercent: return L10n.MenuBar.composerMetricForecastPercent
+        case .resetsIn: return L10n.MenuBar.composerMetricResetsIn
+        case .resetAt: return L10n.MenuBar.composerMetricResetAt
+        case .runsOutIn: return L10n.MenuBar.composerMetricRunsOutIn
+        case .label: return L10n.MenuBar.composerMetricLabel
         }
     }
 
@@ -196,9 +196,9 @@ public struct MenuBarToken: Identifiable, Codable, Hashable, Sendable {
 
         public var title: String {
             switch self {
-            case .small: return "Small"
-            case .regular: return "Regular"
-            case .large: return "Large"
+            case .small: return L10n.MenuBar.composerSizeSmall
+            case .regular: return L10n.MenuBar.composerSizeRegular
+            case .large: return L10n.MenuBar.composerSizeLarge
             }
         }
     }
@@ -210,9 +210,9 @@ public struct MenuBarToken: Identifiable, Codable, Hashable, Sendable {
 
         public var title: String {
             switch self {
-            case .regular: return "Regular"
-            case .medium: return "Medium"
-            case .semibold: return "Semibold"
+            case .regular: return L10n.MenuBar.composerWeightRegular
+            case .medium: return L10n.MenuBar.composerWeightMedium
+            case .semibold: return L10n.MenuBar.composerWeightSemibold
             }
         }
     }
@@ -319,17 +319,17 @@ public struct MenuBarComposition: Codable, Equatable, Sendable {
 
         public var title: String {
             switch self {
-            case .compact: return "Compact"
-            case .roomy: return "Roomy"
-            case .twoColumn: return "Two rows"
+            case .compact: return L10n.MenuBar.composerTemplateCompact
+            case .roomy: return L10n.MenuBar.composerTemplateRoomy
+            case .twoColumn: return L10n.MenuBar.composerTemplateTwoRows
             }
         }
 
         public var detail: String {
             switch self {
-            case .compact: return "Tight spacing and a slightly smaller face."
-            case .roomy: return "Today's size, with more air between blocks."
-            case .twoColumn: return "Two stacked rows in one status item."
+            case .compact: return L10n.MenuBar.composerTemplateCompactDetail
+            case .roomy: return L10n.MenuBar.composerTemplateRoomyDetail
+            case .twoColumn: return L10n.MenuBar.composerTemplateTwoRowsDetail
             }
         }
 
@@ -781,7 +781,12 @@ public struct MenuBarComposition: Codable, Equatable, Sendable {
     ) -> String {
         let custom = customLabels[field.id]?.trimmingCharacters(in: .whitespacesAndNewlines)
         if let custom, !custom.isEmpty { return custom }
-        return field.defaultLabel
+        // Through the naming seam: "5 Hours" and "Weekly" are generic window
+        // words a Chinese reader has no reason to meet, while "Sonnet" or
+        // "Codex Spark" is a name that comes back untouched. Seeding the raw
+        // contract label would have put English in the middle of a Chinese
+        // strip from the first switch to Custom.
+        return QuotaGroupLabelLocalizer.display(field.defaultLabel)
     }
 
     // MARK: Codable
@@ -1281,7 +1286,9 @@ public extension MenuBarComposition {
     }
 
     private static func percent(_ value: Double) -> String {
-        "\(Int(value.rounded()))%"
+        // Through the shared seam rather than a local "%": the sign's place is
+        // a language's decision, and `common.percent` is where that is made.
+        L10n.Common.percent(value: Int(value.rounded()))
     }
 
     private static func spokenClause(
@@ -1290,25 +1297,30 @@ public extension MenuBarComposition {
         quota: MenuBarQuotaSnapshot,
         displayMode: DisplayMode
     ) -> String {
+        // One key per sentence, with the label and the figure as named
+        // placeholders: Chinese does not put the verb where English does, so a
+        // clause assembled by concatenation would come out wrong.
         switch metric {
         case .label:
             return value
         case .usedPercent:
-            return "\(quota.label) \(value) used"
+            return L10n.MenuBar.spokenUsed(label: quota.label, value: value)
         case .remainingPercent:
-            return "\(quota.label) \(value) remaining"
+            return L10n.MenuBar.spokenRemaining(label: quota.label, value: value)
         case .displayPercent:
-            return "\(quota.label) \(value) \(displayMode == .used ? "used" : "remaining")"
+            return displayMode == .used
+                ? L10n.MenuBar.spokenUsed(label: quota.label, value: value)
+                : L10n.MenuBar.spokenRemaining(label: quota.label, value: value)
         case .pace:
-            return "\(quota.label) pace \(value)"
+            return L10n.MenuBar.spokenPace(label: quota.label, value: value)
         case .forecastPercent:
-            return "\(quota.label) forecast \(value) left at reset"
+            return L10n.MenuBar.spokenForecast(label: quota.label, value: value)
         case .resetsIn:
-            return "\(quota.label) resets in \(value)"
+            return L10n.MenuBar.spokenResetsIn(label: quota.label, value: value)
         case .resetAt:
-            return "\(quota.label) resets at \(value)"
+            return L10n.MenuBar.spokenResetAt(label: quota.label, value: value)
         case .runsOutIn:
-            return "\(quota.label) runs out in \(value)"
+            return L10n.MenuBar.spokenRunsOutIn(label: quota.label, value: value)
         }
     }
 
@@ -1723,5 +1735,36 @@ public enum MenuBarStripGeometry {
     public static func cellWidth(runWidths: [Double], gap: Double) -> Double {
         guard !runWidths.isEmpty else { return 0 }
         return runWidths.reduce(0, +) + gap * Double(runWidths.count - 1)
+    }
+
+    /// Past this a glyph, rather than the type, decides a two-row band's
+    /// height.
+    public static let maximumTwoRowGlyphSide: Double = 12
+
+    /// The glyph box for a block drawn at `fontSize` in a strip of
+    /// `rowCount` rows.
+    ///
+    /// One decision for three drawing paths — the status item's single-row
+    /// text attachment, its two-row rasterizer, and the Settings preview —
+    /// which each used to carry their own arithmetic and agreed only by
+    /// coincidence, until they stopped: a `.large` block previewed at the
+    /// 12pt cap while the bar drew it at roughly 16.
+    ///
+    /// The two shapes really are different and both are kept. A one-row strip
+    /// has the whole bar and grows with its type; the two-row rasterizer has
+    /// a fixed band per row, so a glyph that outgrew it would be the thing
+    /// that forced the whole strip to shrink.
+    public static func glyphSide(fontSize: Double, rowCount: Int) -> Double {
+        rowCount >= 2
+            ? twoRowGlyphSide(fontSize: fontSize)
+            : singleRowGlyphSide(fontSize: fontSize)
+    }
+
+    public static func singleRowGlyphSide(fontSize: Double) -> Double {
+        (fontSize + 3).rounded()
+    }
+
+    public static func twoRowGlyphSide(fontSize: Double) -> Double {
+        Swift.min((fontSize + 1).rounded(), maximumTwoRowGlyphSide)
     }
 }

--- a/Sources/VibeBarCore/Models/MenuBarComposition.swift
+++ b/Sources/VibeBarCore/Models/MenuBarComposition.swift
@@ -233,6 +233,23 @@ public struct MenuBarToken: Identifiable, Codable, Hashable, Sendable {
         }
     }
 
+    /// How many characters a `.text` or `.separator` block draws before it is
+    /// cut short. The menu bar is shared with every other status item on the
+    /// machine, and a block with no ceiling can push the clock off screen —
+    /// so the ceiling lives here rather than in whichever editor happens to
+    /// be typing into it.
+    public static let maximumTextLength = 24
+
+    /// The drawn form of a block's literal text: at most
+    /// `maximumTextLength` characters, the last of which becomes an ellipsis
+    /// when anything was dropped. Spoken descriptions keep the full string —
+    /// truncation is a drawing constraint, not a change to what the user
+    /// wrote.
+    public static func truncated(_ text: String) -> String {
+        guard text.count > maximumTextLength else { return text }
+        return text.prefix(maximumTextLength - 1) + "…"
+    }
+
     public var id: UUID
     public var kind: Kind
     public var style: Style
@@ -400,6 +417,140 @@ public struct MenuBarComposition: Codable, Equatable, Sendable {
             }
         }
         return out
+    }
+
+    // MARK: Editing
+    //
+    // List surgery lives here rather than in the editor: the view that drags a
+    // chip should not also be the thing that decides what dropping it means,
+    // and none of this is testable once it is tangled with a gesture.
+
+    public func index(of id: UUID) -> Int? {
+        tokens.firstIndex { $0.id == id }
+    }
+
+    public func token(_ id: UUID) -> MenuBarToken? {
+        tokens.first { $0.id == id }
+    }
+
+    /// Insert at `index`, clamped into range so a drop past either end lands
+    /// at that end instead of trapping.
+    public mutating func insert(_ token: MenuBarToken, at index: Int) {
+        tokens.insert(token, at: Swift.max(0, Swift.min(index, tokens.count)))
+    }
+
+    public mutating func append(_ token: MenuBarToken) {
+        tokens.append(token)
+    }
+
+    @discardableResult
+    public mutating func remove(_ id: UUID) -> Bool {
+        guard let index = index(of: id) else { return false }
+        tokens.remove(at: index)
+        return true
+    }
+
+    /// Copy a block in place, directly after the original. The copy is a new
+    /// block, so it gets a new identity — two blocks that render identically
+    /// are still two blocks the editor can drag apart.
+    /// Returns the copy's id so the editor can select what it just made.
+    @discardableResult
+    public mutating func duplicate(_ id: UUID) -> UUID? {
+        guard let index = index(of: id) else { return nil }
+        var copy = tokens[index]
+        copy.id = UUID()
+        tokens.insert(copy, at: index + 1)
+        return copy.id
+    }
+
+    /// Move `id` so it ends up at `index` in the *resulting* list.
+    ///
+    /// Stated in terms of the result rather than the source array on purpose:
+    /// "insert before element N" changes meaning halfway through a drag once
+    /// the dragged block has been lifted out, which is where reorder
+    /// off-by-ones come from.
+    public mutating func move(_ id: UUID, to index: Int) {
+        guard let from = self.index(of: id) else { return }
+        let token = tokens.remove(at: from)
+        tokens.insert(token, at: Swift.max(0, Swift.min(index, tokens.count)))
+    }
+
+    /// Move `id` to sit immediately before `target`. No-op when they are the
+    /// same block.
+    public mutating func move(_ id: UUID, before target: UUID) {
+        guard id != target, let destination = index(of: target) else { return }
+        let from = index(of: id)
+        // Dragging rightwards past the target lands *on* it once the source
+        // has been lifted out; dragging leftwards lands in front of it.
+        move(id, to: (from.map { $0 < destination } ?? false) ? destination - 1 : destination)
+    }
+
+    public var lineBreakCount: Int {
+        tokens.reduce(0) { $0 + ($1.kind == .lineBreak ? 1 : 0) }
+    }
+
+    /// Whether another row can still be drawn. Past this the editor must stop
+    /// offering a break rather than letting the user build a row that the
+    /// status item silently folds away — see `maximumRows`.
+    public var canAddLineBreak: Bool {
+        lineBreakCount < Self.maximumRows - 1
+    }
+
+    // MARK: Availability
+
+    /// Which blocks are held back by a quota that is not answering right now.
+    ///
+    /// The editor needs this to explain a strip that looks wrong: a block that
+    /// draws nothing looks identical to a block the user mis-configured, and
+    /// only the app knows which quotas the providers are actually returning.
+    public struct Availability: Equatable, Sendable {
+        /// Blocks that draw nothing at all — a quota block whose bucket is
+        /// missing.
+        public var silentTokenIds: Set<UUID>
+        /// Blocks that still draw but lost something: a colour that follows a
+        /// missing quota, or a rule that cannot be evaluated and so no longer
+        /// gates anything.
+        public var degradedTokenIds: Set<UUID>
+        /// Every referenced quota that is not available, in first-reference
+        /// order.
+        public var missingFieldIds: [String]
+
+        public init(
+            silentTokenIds: Set<UUID> = [],
+            degradedTokenIds: Set<UUID> = [],
+            missingFieldIds: [String] = []
+        ) {
+            self.silentTokenIds = silentTokenIds
+            self.degradedTokenIds = degradedTokenIds
+            self.missingFieldIds = missingFieldIds
+        }
+
+        public var isFullyAvailable: Bool { missingFieldIds.isEmpty }
+    }
+
+    public func availability(liveFieldIds: Set<String>) -> Availability {
+        var result = Availability()
+        for token in tokens {
+            if let fieldId = token.quotaFieldId, !liveFieldIds.contains(fieldId) {
+                result.silentTokenIds.insert(token.id)
+                if !result.missingFieldIds.contains(fieldId) {
+                    result.missingFieldIds.append(fieldId)
+                }
+            }
+            for fieldId in [token.style.color.fieldId, token.visibility.fieldId] {
+                guard let fieldId, !liveFieldIds.contains(fieldId) else { continue }
+                // A silent block is already reported; do not also call it
+                // degraded, which would show the user two warnings for one
+                // cause.
+                if !result.silentTokenIds.contains(token.id) {
+                    result.degradedTokenIds.insert(token.id)
+                }
+                if !result.missingFieldIds.contains(fieldId) {
+                    result.missingFieldIds.append(fieldId)
+                }
+            }
+        }
+        return result
     }
 
     // MARK: Seeding
@@ -841,12 +992,18 @@ public extension MenuBarComposition {
         case let .text(text):
             let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
             guard !text.isEmpty else { return nil }
-            return TokenContent(text: text, logo: nil, spoken: trimmed.isEmpty ? nil : trimmed)
+            return TokenContent(
+                text: MenuBarToken.truncated(text),
+                logo: nil,
+                // The full string, not the drawn one: a screen reader should
+                // hear what the user wrote.
+                spoken: trimmed.isEmpty ? nil : trimmed
+            )
         case .space:
             return TokenContent(text: " ", logo: nil, spoken: nil)
         case let .separator(separator):
             guard !separator.isEmpty else { return nil }
-            return TokenContent(text: separator, logo: nil, spoken: nil)
+            return TokenContent(text: MenuBarToken.truncated(separator), logo: nil, spoken: nil)
         case .lineBreak:
             return nil
         case let .quota(_, metric):

--- a/Sources/VibeBarCore/Models/MenuBarComposition.swift
+++ b/Sources/VibeBarCore/Models/MenuBarComposition.swift
@@ -577,7 +577,14 @@ public struct MenuBarComposition: Codable, Equatable, Sendable {
         // the seam in the middle of the *second* entry of three — an entry is
         // a name and a number, so six tokens bisected the pair — leaving one
         // field's label on the first row and its percentage on the second.
-        let starts = entryStartIndices(in: tokens)
+        // A strip the user built out of words and logos has no values, so
+        // nothing closes an entry and the whole thing reads as one. Splitting
+        // between blocks is the honest answer there: choosing Two rows has to
+        // produce two rows, and a control that quietly produces one is the
+        // defect this seam was written to fix.
+        let starts = entryStartIndices(in: tokens).count >= 2
+            ? entryStartIndices(in: tokens)
+            : blockStartIndices(in: tokens)
         guard starts.count >= 2 else { return nil }
         let start = starts[(starts.count + 1) / 2]
         // The spacing in front of the entry is the boundary the break takes
@@ -597,6 +604,16 @@ public struct MenuBarComposition: Codable, Equatable, Sendable {
     /// A new one starts at the first naming block that follows a value, which
     /// finds the boundaries whether or not the strip has divider blocks
     /// between them (Compact and Two rows seed none).
+    /// Every drawn block, used when nothing in the strip closes an entry.
+    private static func blockStartIndices(in tokens: [MenuBarToken]) -> [Int] {
+        tokens.indices.filter { index in
+            switch tokens[index].kind {
+            case .space, .separator, .lineBreak: return false
+            default: return true
+            }
+        }
+    }
+
     private static func entryStartIndices(in tokens: [MenuBarToken]) -> [Int] {
         var starts: [Int] = []
         var sawValue = true

--- a/Sources/VibeBarCore/Models/MenuBarComposition.swift
+++ b/Sources/VibeBarCore/Models/MenuBarComposition.swift
@@ -904,6 +904,17 @@ public struct MenuBarComposition: Codable, Equatable, Sendable {
         var tokens: [MenuBarToken] = []
 
         if item.showTitle {
+            // The one divergence the seed cannot avoid, named rather than
+            // hidden. `twoRowMenuColumns` gives the title a column of its own
+            // with no second cell, which the rasterizer centres across both
+            // rows. A composition is a linear list of blocks with row breaks
+            // and has no way to say "spans both rows"; giving it one would be
+            // a new concept in the model, the codec, the rasterizer, the
+            // preview and the editor, to reproduce the vertical placement of a
+            // two-character label in a surface built for rearranging blocks.
+            // So the title leads the first row. Pinned by
+            // `testATwoRowTitleLeadsTheFirstRow` — if blocks ever gain a row
+            // span, that test is where to revisit this.
             tokens.append(MenuBarToken(kind: .text(item.kind.title), style: .label))
         }
 

--- a/Sources/VibeBarCore/Models/MenuBarComposition.swift
+++ b/Sources/VibeBarCore/Models/MenuBarComposition.swift
@@ -356,6 +356,13 @@ public struct MenuBarComposition: Codable, Equatable, Sendable {
 
         var seedsSecondRow: Bool { self == .twoColumn }
 
+        /// What this template draws between two entries sharing a row. Used
+        /// when a two-row strip collapses back to one, so the entries that
+        /// were rows again become entries side by side.
+        var inlineSeparator: MenuBarToken.Kind {
+            self == .compact ? .space : .separator(" · ")
+        }
+
         /// The template whose proportions match a field-mode layout, so
         /// seeding from that layout starts with matching spacing as well as
         /// matching content.
@@ -397,6 +404,60 @@ public struct MenuBarComposition: Codable, Equatable, Sendable {
         self.tokens = tokens
         self.fontScale = fontScale.map { $0.clamped(to: Self.fontScaleRange) }
         self.tokenSpacing = tokenSpacing.map { $0.clamped(to: Self.tokenSpacingRange) }
+    }
+
+    /// Choose a template, and take the row structure it describes with it.
+    ///
+    /// A template is mostly spacing and type size, but "Two rows" is a claim
+    /// about shape, and `plan` builds rows from `.lineBreak` blocks alone —
+    /// so setting the enum without touching the blocks left the picker
+    /// promising two rows and drawing one. Selecting it splits the strip;
+    /// selecting a single-row template joins it back up.
+    ///
+    /// The split lands where the seed would put it: at the seam between the
+    /// two halves of the entries, taking over the divider that was already
+    /// there rather than adding a second one. Collapsing restores that
+    /// divider, so the two directions round-trip.
+    public mutating func setTemplate(_ newTemplate: Template) {
+        template = newTemplate
+        if newTemplate.seedsSecondRow {
+            guard lineBreakCount == 0, let seam = Self.rowSeamIndex(in: tokens) else { return }
+            switch tokens[seam].kind {
+            case .space, .separator:
+                tokens[seam] = MenuBarToken(kind: .lineBreak)
+            default:
+                tokens.insert(MenuBarToken(kind: .lineBreak), at: seam)
+            }
+        } else {
+            for index in tokens.indices where tokens[index].kind == .lineBreak {
+                tokens[index] = MenuBarToken(
+                    kind: newTemplate.inlineSeparator,
+                    style: .divider
+                )
+            }
+        }
+    }
+
+    /// Where a strip splits into two rows: before the first block of the
+    /// second half, preferring the spacing block just in front of it so the
+    /// break replaces the divider instead of joining it. `nil` when there is
+    /// not enough on the strip to split.
+    private static func rowSeamIndex(in tokens: [MenuBarToken]) -> Int? {
+        let content = tokens.indices.filter { index in
+            switch tokens[index].kind {
+            case .space, .separator, .lineBreak: return false
+            default: return true
+            }
+        }
+        guard content.count >= 2 else { return nil }
+        let start = content[(content.count + 1) / 2]
+        if start > 0 {
+            switch tokens[start - 1].kind {
+            case .space, .separator: return start - 1
+            default: break
+            }
+        }
+        return start
     }
 
     public var effectiveFontScale: Double { fontScale ?? template.fontScale }

--- a/Sources/VibeBarCore/Models/MenuBarComposition.swift
+++ b/Sources/VibeBarCore/Models/MenuBarComposition.swift
@@ -1726,9 +1726,12 @@ extension MenuBarToken.Kind: Codable {
         case .quota:
             return .quota(
                 fieldId: try c.decode(String.self, forKey: .fieldId),
-                // An unknown metric from a newer build reads as the plain
-                // percentage rather than dropping the block.
-                metric: (try? c.decode(MenuBarQuotaMetric.self, forKey: .metric)) ?? .displayPercent
+                // An unknown metric throws, so the block is preserved whole
+                // rather than silently becoming a percentage. Defaulting here
+                // looked like graceful degradation and was destructive: the
+                // next save wrote the substitute back, so a round trip through
+                // an older build permanently changed what the user chose.
+                metric: try c.decode(MenuBarQuotaMetric.self, forKey: .metric)
             )
         case .space:
             return .space

--- a/Sources/VibeBarCore/Models/MenuBarComposition.swift
+++ b/Sources/VibeBarCore/Models/MenuBarComposition.swift
@@ -1002,16 +1002,22 @@ public extension MenuBarComposition {
         }
 
         for token in tokens {
+            // Before the row break, not after it: a row break is a block like
+            // any other, and a conditional one is the point — stay on one row
+            // normally, split to two when a quota goes critical. Checking
+            // visibility afterwards made the strip always split.
+            guard Self.isVisible(token.visibility, quotas: quotas) else { continue }
             if case .lineBreak = token.kind {
                 // Ignored past the second row: a third row cannot be drawn, so
-                // its blocks stay on the second rather than vanishing.
+                // its blocks stay on the second rather than vanishing. A rule
+                // that hides the break simply never opens the row, so honouring
+                // it cannot collide with the cap.
                 if rows.count < Self.maximumRows {
                     rows.append(MenuBarRenderRow())
                     spokenRows.append([])
                 }
                 continue
             }
-            guard Self.isVisible(token.visibility, quotas: quotas) else { continue }
 
             let own = snapshot(token.quotaFieldId)
             guard let content = Self.content(

--- a/Sources/VibeBarCore/Models/MenuBarComposition.swift
+++ b/Sources/VibeBarCore/Models/MenuBarComposition.swift
@@ -1584,3 +1584,23 @@ public enum MenuBarStripFit {
         return Swift.max(minimumScale, availableHeight / contentHeight)
     }
 }
+
+
+/// Geometry shared by the status item's two-row rasterizer and its tests.
+///
+/// A cell is a list of runs — glyphs and text — drawn left to right. The gap
+/// *between* runs belongs to whoever built the cell, and getting that wrong is
+/// invisible until you measure it: the built-in two-row layout draws one
+/// leading logo and needs a fixed gap after it, while a composed row already
+/// carries the user's configured spacing inside its own text runs. Adding the
+/// built-in gap to a composed row double-counts it, so zero spacing still
+/// shows a gap and non-zero spacing comes out wider in the bar than in the
+/// preview.
+public enum MenuBarStripGeometry {
+    /// Total width of a cell: its runs, plus one `gap` between each adjacent
+    /// pair. A composed row passes `gap: 0`.
+    public static func cellWidth(runWidths: [Double], gap: Double) -> Double {
+        guard !runWidths.isEmpty else { return 0 }
+        return runWidths.reduce(0, +) + gap * Double(runWidths.count - 1)
+    }
+}

--- a/Sources/VibeBarCore/Models/MenuBarComposition.swift
+++ b/Sources/VibeBarCore/Models/MenuBarComposition.swift
@@ -565,6 +565,48 @@ public struct MenuBarComposition: Codable, Equatable, Sendable {
         tokens.contains { $0.metric?.isTimeBased == true }
     }
 
+    /// Whether the strip shows anything derived from the personal forecast.
+    ///
+    /// Three different things make a strip forecast-driven and only one of
+    /// them is a metric, which is why classifying on metrics alone left the
+    /// other two stale until the next refresh:
+    ///
+    /// - a `.forecastPercent` or `.runsOutIn` **block**,
+    /// - a `.whenForecast` **visibility rule**, which decides whether a block
+    ///   is on screen at all,
+    /// - a **colour** that follows a forecast — either explicitly, or
+    ///   `.automatic` when the app-wide basis *is* the forecast, which is the
+    ///   colour every seeded percentage wears.
+    ///
+    /// `QuotaService` recomputes forecasts on its own five-minute grid, so a
+    /// strip like this needs a tick of its own; the refresh interval can be
+    /// half an hour.
+    public func needsForecastClock(colorBasis: MenuBarColorBasis) -> Bool {
+        tokens.contains { token in
+            if token.metric?.needsForecast == true { return true }
+            if token.visibility.needsForecast { return true }
+            if token.style.color.needsForecast { return true }
+            return colorBasis == .forecast
+                && token.style.color.followsOwnQuota
+                && token.quotaFieldId != nil
+        }
+    }
+
+    /// How often this strip has to be redrawn from nothing but the clock, or
+    /// nil when it never does.
+    ///
+    /// A minute when anything counts down, otherwise the forecast's own
+    /// quantum. A strip that needs both is served by the faster tick — the
+    /// forecast is memoised on its five-minute grid, so the extra passes hit
+    /// the memo rather than recomputing.
+    public func clockInterval(colorBasis: MenuBarColorBasis) -> TimeInterval? {
+        if hasTimeBasedBlock { return MenuBarCountdownClock.interval }
+        if needsForecastClock(colorBasis: colorBasis) {
+            return MenuBarCountdownClock.forecastInterval
+        }
+        return nil
+    }
+
     public func availability(liveFieldIds: Set<String>) -> Availability {
         var result = Availability()
         for token in tokens {
@@ -648,12 +690,15 @@ public struct MenuBarComposition: Codable, Equatable, Sendable {
             tokens.append(MenuBarToken(kind: .text(item.kind.title), style: .label))
         }
 
-        // The Compact layout butts its entries together with a plain space;
-        // Single line puts a dot between them. Seed whichever the user is
-        // looking at.
-        let separator: MenuBarToken.Kind = item.layout == .compact
-            ? .space
-            : .separator(" · ")
+        // What each renderer actually puts between two entries: Single line
+        // appends a tertiary " · "; Compact appends a plain space; Two rows
+        // packs entries into columns separated by `twoRowColumnSpacing` and
+        // draws no divider at all. Seeding a dot into a Two rows strip put
+        // punctuation on screen that the layout had never drawn, which is the
+        // seed failing at its one job.
+        let separator: MenuBarToken.Kind = item.layout == .singleLine
+            ? .separator(" · ")
+            : .space
 
         for (rowIndex, row) in seedRows(runs, item: item, template: template).enumerated() {
             if rowIndex > 0 { tokens.append(MenuBarToken(kind: .lineBreak)) }
@@ -1612,6 +1657,13 @@ private extension Double {
 public enum MenuBarCountdownClock {
     /// A minute: the finest granularity any menu-bar metric renders.
     public static let interval: TimeInterval = 60
+
+    /// The tick a forecast-driven strip needs. Paced to the forecast's own
+    /// quantization — `QuotaService` floors its clock to five minutes and
+    /// memoises on it, so a faster tick buys nothing but wakeups on the
+    /// menu bar's hot path.
+    public static let forecastInterval: TimeInterval =
+        QuotaService.paceForecastClockQuantumSeconds
 
     /// The next grid point strictly after `date`, on the phase grid anchored
     /// at `anchor`. Strictly after, so a tick that fires a hair early cannot

--- a/Sources/VibeBarCore/Models/MenuBarComposition.swift
+++ b/Sources/VibeBarCore/Models/MenuBarComposition.swift
@@ -67,6 +67,18 @@ public enum MenuBarQuotaMetric: String, Codable, CaseIterable, Sendable {
 
     /// Whether this metric needs the linear burn-rate pace for its bucket.
     var needsPace: Bool { self == .pace }
+
+    /// Whether the string this metric renders goes stale on its own, with no
+    /// new data — a countdown ticks down between refreshes, and an absolute
+    /// reset time re-words itself once it crosses a day boundary. A strip
+    /// containing one of these needs a clock; a strip without one must not
+    /// start a timer at all.
+    public var isTimeBased: Bool {
+        switch self {
+        case .resetsIn, .resetAt, .runsOutIn: return true
+        default: return false
+        }
+    }
 }
 
 // MARK: - Token
@@ -92,6 +104,11 @@ public struct MenuBarToken: Identifiable, Codable, Hashable, Sendable {
         case space
         /// A literal divider the user chose — `" · "`, `"/"`, `"|"`.
         case separator(String)
+        /// Vibe Bar's own glyph — what the Icon Only layout draws, and the
+        /// only mark on the strip that is not a provider's. Without it the
+        /// composer could not seed an Icon Only item with what the user is
+        /// actually looking at.
+        case appIcon
         /// Ends the current row and starts the next one. Never draws.
         case lineBreak
     }
@@ -340,6 +357,17 @@ public struct MenuBarComposition: Codable, Equatable, Sendable {
         }
 
         var seedsSecondRow: Bool { self == .twoColumn }
+
+        /// The template whose proportions match a field-mode layout, so
+        /// seeding from that layout starts with matching spacing as well as
+        /// matching content.
+        public static func matching(_ layout: MenuBarLayout) -> Template {
+            switch layout {
+            case .twoRows: return .twoColumn
+            case .compact: return .compact
+            case .singleLine, .iconOnly: return .roomy
+            }
+        }
     }
 
     /// The status item is ~22pt tall: two rows is the most the rasterizer can
@@ -408,6 +436,11 @@ public struct MenuBarComposition: Codable, Equatable, Sendable {
         for token in tokens {
             if let fieldId = token.quotaFieldId, let metric = token.metric {
                 requirement(fieldId, forecast: metric.needsForecast, pace: metric.needsPace)
+            }
+            // A colour that follows the block's own quota names no field, so
+            // it has to be attributed here or nobody ever asks for its verdict.
+            if token.style.color.followsOwnQuota, let fieldId = token.quotaFieldId {
+                requirement(fieldId, forecast: token.style.color.needsForecast, pace: false)
             }
             if let fieldId = token.style.color.fieldId {
                 requirement(fieldId, forecast: token.style.color.needsForecast, pace: false)
@@ -528,6 +561,15 @@ public struct MenuBarComposition: Codable, Equatable, Sendable {
         public var isFullyAvailable: Bool { missingFieldIds.isEmpty }
     }
 
+    /// Whether any block prints something that goes stale on the clock.
+    ///
+    /// The renderer uses this to decide whether to run a countdown timer at
+    /// all: a strip of percentages redraws when a refresh lands and must not
+    /// cost a wakeup a minute for the rest of the day.
+    public var hasTimeBasedBlock: Bool {
+        tokens.contains { $0.metric?.isTimeBased == true }
+    }
+
     public func availability(liveFieldIds: Set<String>) -> Availability {
         var result = Availability()
         for token in tokens {
@@ -575,6 +617,32 @@ public struct MenuBarComposition: Codable, Equatable, Sendable {
         registry: QuotaFieldRegistry = .empty,
         groupCatalogLabel: (String) -> String? = { _ in nil }
     ) -> MenuBarComposition {
+        MenuBarComposition(
+            isEnabled: false,
+            template: template,
+            tokens: seedTokens(
+                template: template,
+                item: item,
+                registry: registry,
+                groupCatalogLabel: groupCatalogLabel
+            )
+        )
+    }
+
+    private static func seedTokens(
+        template: Template,
+        item: MenuBarItemSettings,
+        registry: QuotaFieldRegistry,
+        groupCatalogLabel: (String) -> String?
+    ) -> [MenuBarToken] {
+        // Icon Only draws one glyph and nothing else — not the selected
+        // fields, which it ignores entirely. Expanding them here would greet
+        // the user with a four-quota strip they have never seen, which is the
+        // opposite of "start from what you already have".
+        if item.layout == .iconOnly {
+            return [MenuBarToken(kind: .appIcon, style: .label)]
+        }
+
         let fields = item.selectedFieldIds.compactMap {
             MenuBarFieldCatalog.field(id: $0, registry: registry)
         }
@@ -585,51 +653,82 @@ public struct MenuBarComposition: Codable, Equatable, Sendable {
             tokens.append(MenuBarToken(kind: .text(item.kind.title), style: .label))
         }
 
-        // Where the second row starts for `.twoColumn`: the midpoint, so a
-        // seeded two-row strip is balanced rather than one long row plus one
-        // orphan.
-        let breakAfter = template.seedsSecondRow && runs.count > 1
-            ? (runs.count + 1) / 2
-            : Int.max
+        // The Compact layout butts its entries together with a plain space;
+        // Single line puts a dot between them. Seed whichever the user is
+        // looking at.
+        let separator: MenuBarToken.Kind = item.layout == .compact
+            ? .space
+            : .separator(" · ")
 
-        for (index, run) in runs.enumerated() {
-            if index > 0 {
-                tokens.append(
-                    index == breakAfter
-                        ? MenuBarToken(kind: .lineBreak)
-                        : MenuBarToken(kind: .separator(" · "), style: .divider)
-                )
-            }
-            let style = item.style(for: run.primary.id)
-            if style != .labelAndPercent {
-                tokens.append(MenuBarToken(kind: .logo(run.primary.tool), style: .label))
-            }
-            if style != .logoAndPercent {
-                let label = run.isMerged
-                    ? MenuBarFieldCatalog.mergedGroupLabel(
-                        for: run,
-                        customLabels: item.customLabels,
-                        groupCatalogLabel: groupCatalogLabel
-                    )
-                    : seedLabel(for: run.primary, customLabels: item.customLabels)
-                tokens.append(MenuBarToken(kind: .text(label), style: .label))
-            }
-            for (offset, field) in run.fields.enumerated() {
-                if offset > 0 {
-                    tokens.append(MenuBarToken(kind: .separator("/"), style: .divider))
+        for (rowIndex, row) in seedRows(runs, item: item, template: template).enumerated() {
+            if rowIndex > 0 { tokens.append(MenuBarToken(kind: .lineBreak)) }
+            for (index, run) in row.enumerated() {
+                if index > 0 {
+                    tokens.append(MenuBarToken(kind: separator, style: .divider))
                 }
-                tokens.append(MenuBarToken(
-                    kind: .quota(fieldId: field.id, metric: .displayPercent),
-                    style: .percent
+                tokens.append(contentsOf: seedRunTokens(
+                    run,
+                    item: item,
+                    groupCatalogLabel: groupCatalogLabel
                 ))
             }
         }
+        return tokens
+    }
 
-        return MenuBarComposition(
-            isEnabled: false,
-            template: template,
-            tokens: tokens
-        )
+    /// How the seed splits runs across rows.
+    ///
+    /// The Two rows layout packs entries into two-cell columns, so its top row
+    /// reads entries 0, 2, 4… and its bottom row 1, 3, 5…. Alternating here
+    /// reproduces the reading order the user already has rather than cutting
+    /// the list in half, which would move every entry.
+    private static func seedRows(
+        _ runs: [MenuBarFieldRun],
+        item: MenuBarItemSettings,
+        template: Template
+    ) -> [[MenuBarFieldRun]] {
+        let splits = item.layout == .twoRows || template.seedsSecondRow
+        guard splits, runs.count > 1 else { return [runs] }
+        var top: [MenuBarFieldRun] = []
+        var bottom: [MenuBarFieldRun] = []
+        for (index, run) in runs.enumerated() {
+            if index.isMultiple(of: 2) { top.append(run) } else { bottom.append(run) }
+        }
+        return [top, bottom]
+    }
+
+    /// One entry: its logo and label where the field style shows them, then a
+    /// percentage per window, slash-joined when the group is merged.
+    private static func seedRunTokens(
+        _ run: MenuBarFieldRun,
+        item: MenuBarItemSettings,
+        groupCatalogLabel: (String) -> String?
+    ) -> [MenuBarToken] {
+        var tokens: [MenuBarToken] = []
+        let style = item.style(for: run.primary.id)
+        if style != .labelAndPercent {
+            tokens.append(MenuBarToken(kind: .logo(run.primary.tool), style: .label))
+        }
+        if style != .logoAndPercent {
+            let label = run.isMerged
+                ? MenuBarFieldCatalog.mergedGroupLabel(
+                    for: run,
+                    customLabels: item.customLabels,
+                    groupCatalogLabel: groupCatalogLabel
+                )
+                : seedLabel(for: run.primary, customLabels: item.customLabels)
+            tokens.append(MenuBarToken(kind: .text(label), style: .label))
+        }
+        for (offset, field) in run.fields.enumerated() {
+            if offset > 0 {
+                tokens.append(MenuBarToken(kind: .separator("/"), style: .divider))
+            }
+            tokens.append(MenuBarToken(
+                kind: .quota(fieldId: field.id, metric: .displayPercent),
+                style: .percent
+            ))
+        }
+        return tokens
     }
 
     /// The catalog's default label, overridden by whatever the user renamed
@@ -791,12 +890,18 @@ public enum MenuBarTokenColorRole: Equatable, Sendable {
 
 /// One block, ready to draw.
 public struct MenuBarRenderedToken: Equatable, Sendable, Identifiable {
+    /// A mark rather than words: a provider's brand, or Vibe Bar's own icon.
+    public enum Glyph: Equatable, Sendable {
+        case provider(ToolType)
+        case app
+    }
+
     /// The source token's id, so stage 2's editor can map a hit test or a
     /// live preview back to the block the user is dragging.
     public var id: UUID
-    /// Nil only for a logo block.
+    /// Nil only for a glyph block.
     public var text: String?
-    public var logo: ToolType?
+    public var glyph: Glyph?
     public var color: MenuBarTokenColorRole
     /// Template scale × size step. The renderer multiplies its base font size
     /// by this.
@@ -810,7 +915,7 @@ public struct MenuBarRenderedToken: Equatable, Sendable, Identifiable {
     public init(
         id: UUID,
         text: String?,
-        logo: ToolType?,
+        glyph: Glyph?,
         color: MenuBarTokenColorRole,
         fontScale: Double,
         weight: MenuBarToken.Weight,
@@ -819,7 +924,7 @@ public struct MenuBarRenderedToken: Equatable, Sendable, Identifiable {
     ) {
         self.id = id
         self.text = text
-        self.logo = logo
+        self.glyph = glyph
         self.color = color
         self.fontScale = fontScale
         self.weight = weight
@@ -924,7 +1029,7 @@ public extension MenuBarComposition {
             rows[rows.count - 1].tokens.append(MenuBarRenderedToken(
                 id: token.id,
                 text: content.text,
-                logo: content.logo,
+                glyph: content.glyph,
                 color: color,
                 fontScale: scale * token.style.size.multiplier,
                 weight: token.style.weight,
@@ -976,7 +1081,7 @@ public extension MenuBarComposition {
 
     private struct TokenContent {
         var text: String?
-        var logo: ToolType?
+        var glyph: MenuBarRenderedToken.Glyph?
         var spoken: String?
     }
 
@@ -988,22 +1093,28 @@ public extension MenuBarComposition {
     ) -> TokenContent? {
         switch token.kind {
         case let .logo(tool):
-            return TokenContent(text: nil, logo: tool, spoken: tool.quotaSubProviderName())
+            return TokenContent(
+                text: nil,
+                glyph: .provider(tool),
+                spoken: tool.quotaSubProviderName()
+            )
+        case .appIcon:
+            return TokenContent(text: nil, glyph: .app, spoken: "Vibe Bar")
         case let .text(text):
             let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
             guard !text.isEmpty else { return nil }
             return TokenContent(
                 text: MenuBarToken.truncated(text),
-                logo: nil,
+                glyph: nil,
                 // The full string, not the drawn one: a screen reader should
                 // hear what the user wrote.
                 spoken: trimmed.isEmpty ? nil : trimmed
             )
         case .space:
-            return TokenContent(text: " ", logo: nil, spoken: nil)
+            return TokenContent(text: " ", glyph: nil, spoken: nil)
         case let .separator(separator):
             guard !separator.isEmpty else { return nil }
-            return TokenContent(text: MenuBarToken.truncated(separator), logo: nil, spoken: nil)
+            return TokenContent(text: MenuBarToken.truncated(separator), glyph: nil, spoken: nil)
         case .lineBreak:
             return nil
         case let .quota(_, metric):
@@ -1013,7 +1124,7 @@ public extension MenuBarComposition {
             else { return nil }
             return TokenContent(
                 text: text,
-                logo: nil,
+                glyph: nil,
                 spoken: spokenClause(metric: metric, value: text, quota: quota, displayMode: displayMode)
             )
         }
@@ -1176,7 +1287,7 @@ extension MenuBarToken.Kind: Codable {
     }
 
     private enum Discriminator: String, Codable {
-        case logo, text, quota, space, separator, lineBreak
+        case logo, text, quota, space, separator, lineBreak, appIcon
     }
 
     public init(from decoder: Decoder) throws {
@@ -1199,6 +1310,8 @@ extension MenuBarToken.Kind: Codable {
             self = .separator(try c.decode(String.self, forKey: .text))
         case .lineBreak:
             self = .lineBreak
+        case .appIcon:
+            self = .appIcon
         }
     }
 
@@ -1222,6 +1335,8 @@ extension MenuBarToken.Kind: Codable {
             try c.encode(separator, forKey: .text)
         case .lineBreak:
             try c.encode(Discriminator.lineBreak, forKey: .type)
+        case .appIcon:
+            try c.encode(Discriminator.appIcon, forKey: .type)
         }
     }
 }
@@ -1314,6 +1429,21 @@ extension MenuBarToken.ColorSource: Codable {
         default: return false
         }
     }
+
+    /// Whether this source colours the block from the block's *own* quota —
+    /// the one field it never names, because naming it would be redundant.
+    ///
+    /// `quotaRequirements` has to special-case these: `.forecast` carries no
+    /// `fieldId`, so without this the requirement walk skipped it entirely and
+    /// a block that explicitly asked for the forecast colour got no verdict to
+    /// resolve against, silently falling back to the percentage thresholds
+    /// whenever the app-wide basis was `.actual`.
+    var followsOwnQuota: Bool {
+        switch self {
+        case .automatic, .forecast: return true
+        default: return false
+        }
+    }
 }
 
 extension MenuBarToken.Visibility: Codable {
@@ -1394,5 +1524,63 @@ extension MenuBarToken.Visibility: Codable {
 private extension Double {
     func clamped(to range: ClosedRange<Double>) -> Double {
         Swift.min(Swift.max(self, range.lowerBound), range.upperBound)
+    }
+}
+
+
+/// The menu bar's countdown clock.
+///
+/// A composed strip can print `resets in 12m`, which is wrong a minute later
+/// with no new data behind it. The render pipeline is driven by settings,
+/// quota, account, cost and status publishers — none of which is a clock — so
+/// with a 30-minute refresh interval that countdown could sit unchanged past
+/// its own deadline.
+///
+/// Ticks are phase-aligned rather than free-running: the app already floors a
+/// process-wide anchor to a five-minute boundary so every surface asks for the
+/// same instant, and a menu-bar countdown that drifts a few seconds away from
+/// the popover's would show two different numbers for one quota.
+public enum MenuBarCountdownClock {
+    /// A minute: the finest granularity any menu-bar metric renders.
+    public static let interval: TimeInterval = 60
+
+    /// The next grid point strictly after `date`, on the phase grid anchored
+    /// at `anchor`. Strictly after, so a tick that fires a hair early cannot
+    /// schedule itself for the instant it just handled and spin.
+    public static func nextTick(
+        after date: Date,
+        anchor: Date,
+        interval: TimeInterval = MenuBarCountdownClock.interval
+    ) -> Date {
+        let step = max(1, interval)
+        let elapsed = date.timeIntervalSinceReferenceDate - anchor.timeIntervalSinceReferenceDate
+        let steps = (elapsed / step).rounded(.down) + 1
+        return Date(timeIntervalSinceReferenceDate: anchor.timeIntervalSinceReferenceDate + steps * step)
+    }
+}
+
+/// Fitting a composed strip into the height it actually has.
+///
+/// The status item is about 22 points tall. Two rows of `.large` blocks at the
+/// composition's top font scale do not fit, and the drawing code used to keep
+/// the full row heights while the canvas was capped — so the upper row was
+/// cropped or the two rows overlapped. Shrinking the type is the honest
+/// answer: the strip stays legible and nothing is silently cut off.
+public enum MenuBarStripFit {
+    /// Below this the type is too small to read, so the strip accepts being
+    /// tight rather than becoming a smudge.
+    public static let minimumScale: Double = 0.55
+
+    /// Uniform font scale that makes `contentHeight` fit `availableHeight`.
+    /// Returns 1 when it already fits.
+    public static func scale(
+        contentHeight: Double,
+        availableHeight: Double,
+        minimumScale: Double = MenuBarStripFit.minimumScale
+    ) -> Double {
+        guard contentHeight > 0, availableHeight > 0, contentHeight > availableHeight else {
+            return 1
+        }
+        return Swift.max(minimumScale, availableHeight / contentHeight)
     }
 }

--- a/Sources/VibeBarCore/Models/MenuBarComposition.swift
+++ b/Sources/VibeBarCore/Models/MenuBarComposition.swift
@@ -1,0 +1,1241 @@
+import Foundation
+
+// MARK: - Metric
+
+/// What one quota token prints. Every case renders a *short* string — the
+/// menu bar is the most width-constrained surface in the app — and every
+/// format below is exact, because two clients and a screen reader all have to
+/// agree on it.
+///
+/// | Metric             | Renders                | Example        | Renders nothing when |
+/// | ------------------ | ---------------------- | -------------- | -------------------- |
+/// | `usedPercent`      | `<n>%`                 | `73%`          | never (quota present) |
+/// | `remainingPercent` | `<n>%`                 | `27%`          | never (quota present) |
+/// | `displayPercent`   | `<n>%`                 | `27%` / `73%`  | never (quota present) |
+/// | `pace`             | `+<n>%` / `-<n>%` / `±0%` | `+12%`      | no window or no reset |
+/// | `forecastPercent`  | `<n>%`                 | `18%`          | no forecast yet       |
+/// | `resetsIn`         | compact countdown      | `3h 16m`       | no reset date         |
+/// | `resetAt`          | local wall time        | `18:30`        | no reset date         |
+/// | `runsOutIn`        | compact countdown      | `2d 4h`        | not projected to run out |
+/// | `label`            | the quota's own name   | `5 Hours`      | never (quota present) |
+///
+/// `usedPercent` / `remainingPercent` are the raw observation. `displayPercent`
+/// is the provider-normalized number every other surface shows (Cursor rounds
+/// any positive sub-1% pool up to 1%) and follows the app's Used/Remaining
+/// setting, so a token set to it tracks whatever the user picked.
+///
+/// `pace` is the signed distance from the linear expectation — `+12%` means
+/// twelve points *ahead* of where a flat burn would be, i.e. burning fast.
+/// `forecastPercent` is the median projected quota **left at reset**, the same
+/// number the Overview says "forecast N% left" about.
+/// The two countdowns use `ResetCountdownFormatter`: `5d`, `2d 4h`, `3h 16m`,
+/// `12m`, `<1m`, `now`.
+public enum MenuBarQuotaMetric: String, Codable, CaseIterable, Sendable {
+    case usedPercent
+    case remainingPercent
+    case displayPercent
+    case pace
+    case forecastPercent
+    case resetsIn
+    case resetAt
+    case runsOutIn
+    case label
+
+    /// Menu label for the stage-2 editor's metric picker.
+    public var title: String {
+        switch self {
+        case .usedPercent: return "Used %"
+        case .remainingPercent: return "Remaining %"
+        case .displayPercent: return "Percent (follows setting)"
+        case .pace: return "Pace"
+        case .forecastPercent: return "Forecast at reset"
+        case .resetsIn: return "Resets in"
+        case .resetAt: return "Resets at"
+        case .runsOutIn: return "Runs out in"
+        case .label: return "Name"
+        }
+    }
+
+    /// Whether this metric needs the (expensive) personal forecast computed
+    /// for its bucket. Drives `MenuBarComposition.quotaRequirements`.
+    var needsForecast: Bool {
+        switch self {
+        case .forecastPercent, .runsOutIn: return true
+        default: return false
+        }
+    }
+
+    /// Whether this metric needs the linear burn-rate pace for its bucket.
+    var needsPace: Bool { self == .pace }
+}
+
+// MARK: - Token
+
+/// One block in a composed menu-bar strip.
+///
+/// The identity is a `UUID` rather than the content so the stage-2 editor can
+/// drag, duplicate, and undo blocks that happen to render identically — two
+/// `.text("·")` separators are two blocks, not one.
+public struct MenuBarToken: Identifiable, Codable, Hashable, Sendable {
+    /// What the block is.
+    public enum Kind: Hashable, Sendable {
+        /// A provider's brand mark, tinted like the surrounding text unless
+        /// the style says otherwise. Any provider, not just the ones the user
+        /// selected as quota fields.
+        case logo(ToolType)
+        /// Literal words the user typed.
+        case text(String)
+        /// One number (or name, or countdown) read off a live quota bucket.
+        /// `fieldId` is a `MenuBarFieldCatalog` id — `"claude.five_hour"`.
+        case quota(fieldId: String, metric: MenuBarQuotaMetric)
+        /// Blank space, one base-font space glyph wide.
+        case space
+        /// A literal divider the user chose — `" · "`, `"/"`, `"|"`.
+        case separator(String)
+        /// Ends the current row and starts the next one. Never draws.
+        case lineBreak
+    }
+
+    /// How the block looks. Colour is the interesting axis: any block — a
+    /// logo, a word, a number — may follow a quota's live colour, which is
+    /// what makes "the label goes red with the number" expressible.
+    public struct Style: Codable, Hashable, Sendable {
+        public var color: ColorSource
+        public var size: SizeStep
+        public var weight: Weight
+        public var monospacedDigits: Bool
+
+        public init(
+            color: ColorSource = .automatic,
+            size: SizeStep = .regular,
+            weight: Weight = .medium,
+            monospacedDigits: Bool = false
+        ) {
+            self.color = color
+            self.size = size
+            self.weight = weight
+            self.monospacedDigits = monospacedDigits
+        }
+
+        /// What today's percentages wear: automatic colour, semibold,
+        /// monospaced digits so a changing number does not jiggle the strip.
+        public static let percent = Style(
+            color: .automatic,
+            size: .regular,
+            weight: .semibold,
+            monospacedDigits: true
+        )
+
+        /// What today's labels wear.
+        public static let label = Style(color: .primary, size: .regular, weight: .medium)
+
+        /// What today's " · " dividers wear.
+        public static let divider = Style(color: .tertiary, size: .regular, weight: .regular)
+    }
+
+    public enum ColorSource: Hashable, Sendable {
+        /// Exactly what the strip does today: the token's own quota coloured
+        /// under `AppSettings.menuBarColorBasis`. A token with no quota of its
+        /// own is `.primary`.
+        case automatic
+        /// The token's own quota's forecast verdict colour, regardless of the
+        /// app-wide basis. `.primary` for a token with no quota.
+        case forecast
+        /// Follow *another* quota's live colour — the way a text label can go
+        /// red in step with the number beside it.
+        case followsQuota(fieldId: String, basis: MenuBarColorBasis)
+        /// The provider's accent from the shared brand table.
+        case brand(ToolType)
+        case primary
+        case secondary
+        case tertiary
+        /// A literal colour. Always store the normalized `#rrggbb` /
+        /// `#rrggbbaa` form — build it with `hex(_:)` rather than writing the
+        /// case directly, so `#FF8000` and `#ff8000` are one value rather than
+        /// two that survive a round trip differently.
+        case fixed(String)
+
+        /// `.fixed` with the string canonicalized, or `.primary` when the
+        /// string is not a colour. The colour well in stage 2's editor and the
+        /// decoder both go through here, so a hand-edited settings file and a
+        /// picked swatch land on the same value.
+        public static func hex(_ raw: String) -> ColorSource {
+            guard let normalized = MenuBarHexColor.normalized(raw) else { return .primary }
+            return .fixed(normalized)
+        }
+    }
+
+    public enum SizeStep: String, Codable, CaseIterable, Sendable {
+        case small
+        case regular
+        case large
+
+        /// Multiplier on the row's base font size.
+        public var multiplier: Double {
+            switch self {
+            case .small: return 0.85
+            case .regular: return 1.0
+            case .large: return 1.2
+            }
+        }
+
+        public var title: String {
+            switch self {
+            case .small: return "Small"
+            case .regular: return "Regular"
+            case .large: return "Large"
+            }
+        }
+    }
+
+    public enum Weight: String, Codable, CaseIterable, Sendable {
+        case regular
+        case medium
+        case semibold
+
+        public var title: String {
+            switch self {
+            case .regular: return "Regular"
+            case .medium: return "Medium"
+            case .semibold: return "Semibold"
+            }
+        }
+    }
+
+    /// When the block is on screen at all.
+    ///
+    /// A rule that cannot be evaluated — it names a quota this build has never
+    /// heard of, the provider stopped returning it, or it asks about a
+    /// forecast that has not converged — resolves to *visible*. Hiding a block
+    /// because its condition is unknowable is indistinguishable from the app
+    /// being broken, and the user would have no way to find the block again.
+    public enum Visibility: Hashable, Sendable {
+        case always
+        case whenUsedAtLeast(fieldId: String, percent: Double)
+        case whenRemainingAtMost(fieldId: String, percent: Double)
+        case whenForecast(fieldId: String, verdicts: Set<QuotaPaceForecast.Verdict>)
+
+        /// The quota this rule watches, if any.
+        public var fieldId: String? {
+            switch self {
+            case .always: return nil
+            case let .whenUsedAtLeast(fieldId, _),
+                 let .whenRemainingAtMost(fieldId, _):
+                return fieldId
+            case let .whenForecast(fieldId, _):
+                return fieldId
+            }
+        }
+
+        var needsForecast: Bool {
+            if case .whenForecast = self { return true }
+            return false
+        }
+    }
+
+    public var id: UUID
+    public var kind: Kind
+    public var style: Style
+    public var visibility: Visibility
+
+    public init(
+        id: UUID = UUID(),
+        kind: Kind,
+        style: Style = Style(),
+        visibility: Visibility = .always
+    ) {
+        self.id = id
+        self.kind = kind
+        self.style = style
+        self.visibility = visibility
+    }
+
+    /// The quota this token reads, if it is a quota token.
+    public var quotaFieldId: String? {
+        if case let .quota(fieldId, _) = kind { return fieldId }
+        return nil
+    }
+
+    public var metric: MenuBarQuotaMetric? {
+        if case let .quota(_, metric) = kind { return metric }
+        return nil
+    }
+}
+
+// MARK: - Composition
+
+/// A composed menu-bar strip: a template, an ordered token list, and two
+/// optional overrides for the template's spacing and scale.
+///
+/// `isEnabled` is deliberately inside the composition rather than being
+/// modelled as "composition == nil": switching back to the plain field-based
+/// strip must not throw away an arrangement the user built, and switching
+/// back must not reseed over it. `MenuBarItemSettings.composition == nil`
+/// therefore means "never opened the composer", not "composer off".
+public struct MenuBarComposition: Codable, Equatable, Sendable {
+    /// Starting points. A template is only a set of defaults — every one of
+    /// them is a plain token list afterwards, and the user can edit it into
+    /// any of the others.
+    public enum Template: String, Codable, CaseIterable, Sendable {
+        /// Tight and small: fits the most quotas in a crowded menu bar.
+        case compact
+        /// Today's proportions, with breathing room between blocks.
+        case roomy
+        /// Two stacked rows, drawn by the same rasterizer the two-row layout
+        /// uses. Seeds with a `.lineBreak` in the middle.
+        case twoColumn
+
+        public var title: String {
+            switch self {
+            case .compact: return "Compact"
+            case .roomy: return "Roomy"
+            case .twoColumn: return "Two rows"
+            }
+        }
+
+        public var detail: String {
+            switch self {
+            case .compact: return "Tight spacing and a slightly smaller face."
+            case .roomy: return "Today's size, with more air between blocks."
+            case .twoColumn: return "Two stacked rows in one status item."
+            }
+        }
+
+        /// Gap between adjacent blocks, as a multiplier on the row's base font
+        /// size. Realized as a space glyph, exactly the way the existing
+        /// logo-to-label gap already is — a text attachment would inflate the
+        /// line box and push the second row out of the bar.
+        public var tokenSpacing: Double {
+            switch self {
+            case .compact: return 0.35
+            case .roomy: return 0.9
+            case .twoColumn: return 0.8
+            }
+        }
+
+        /// Multiplier on the layout's base font size.
+        public var fontScale: Double {
+            switch self {
+            case .compact: return 0.95
+            case .roomy: return 1.0
+            case .twoColumn: return 1.0
+            }
+        }
+
+        var seedsSecondRow: Bool { self == .twoColumn }
+    }
+
+    /// The status item is ~22pt tall: two rows is the most the rasterizer can
+    /// fit legibly, so a third `.lineBreak` is ignored and its blocks continue
+    /// on the second row. Stage 2's editor should stop offering a break past
+    /// this rather than letting the user build a row that cannot appear.
+    public static let maximumRows = 2
+
+    public static let fontScaleRange: ClosedRange<Double> = 0.6...1.6
+    public static let tokenSpacingRange: ClosedRange<Double> = 0...4
+
+    public var isEnabled: Bool
+    public var template: Template
+    public var tokens: [MenuBarToken]
+    /// Overrides `template.fontScale` when set.
+    public var fontScale: Double?
+    /// Overrides `template.tokenSpacing` when set.
+    public var tokenSpacing: Double?
+
+    public init(
+        isEnabled: Bool = false,
+        template: Template = .roomy,
+        tokens: [MenuBarToken] = [],
+        fontScale: Double? = nil,
+        tokenSpacing: Double? = nil
+    ) {
+        self.isEnabled = isEnabled
+        self.template = template
+        self.tokens = tokens
+        self.fontScale = fontScale.map { $0.clamped(to: Self.fontScaleRange) }
+        self.tokenSpacing = tokenSpacing.map { $0.clamped(to: Self.tokenSpacingRange) }
+    }
+
+    public var effectiveFontScale: Double { fontScale ?? template.fontScale }
+    public var effectiveTokenSpacing: Double { tokenSpacing ?? template.tokenSpacing }
+
+    /// Every quota this strip touches — through a token, a colour that follows
+    /// a quota, or a visibility rule — in first-appearance order, deduplicated.
+    ///
+    /// The renderer resolves exactly these once per render. Without it a strip
+    /// that names one bucket in three tokens would look that bucket up (and
+    /// forecast it) three times inside the 120 ms throttle.
+    public var referencedFieldIds: [String] {
+        quotaRequirements.map(\.fieldId)
+    }
+
+    /// Per-quota work the renderer must do, in `referencedFieldIds` order.
+    /// The forecast is the expensive one — only ask for it where a token, a
+    /// colour, or a rule actually reads it.
+    public var quotaRequirements: [MenuBarQuotaRequirement] {
+        // Linear rather than a dictionary on purpose: this runs inside the
+        // menu bar's 120 ms render throttle, and a status item holds a handful
+        // of quotas at most — scanning that array beats allocating a hash
+        // table every tick.
+        var out: [MenuBarQuotaRequirement] = []
+        func requirement(_ fieldId: String, forecast: Bool, pace: Bool) {
+            if let position = out.firstIndex(where: { $0.fieldId == fieldId }) {
+                out[position].needsForecast = out[position].needsForecast || forecast
+                out[position].needsPace = out[position].needsPace || pace
+            } else {
+                out.append(MenuBarQuotaRequirement(
+                    fieldId: fieldId, needsForecast: forecast, needsPace: pace
+                ))
+            }
+        }
+        for token in tokens {
+            if let fieldId = token.quotaFieldId, let metric = token.metric {
+                requirement(fieldId, forecast: metric.needsForecast, pace: metric.needsPace)
+            }
+            if let fieldId = token.style.color.fieldId {
+                requirement(fieldId, forecast: token.style.color.needsForecast, pace: false)
+            }
+            if let fieldId = token.visibility.fieldId {
+                requirement(fieldId, forecast: token.visibility.needsForecast, pace: false)
+            }
+        }
+        return out
+    }
+
+    // MARK: Seeding
+
+    /// A token list that renders what `item` renders today, so turning the
+    /// composer on starts from what the user is already looking at rather than
+    /// from a blank bar.
+    ///
+    /// Walks the same runs the field path walks — merged group windows seed as
+    /// one label with slash-joined percentages — and reproduces each field's
+    /// `MenuBarFieldStyle`: a logo block where the style shows a logo, a text
+    /// block where it shows a label, then one `.displayPercent` block per
+    /// window in `.automatic` colour, which is the colour the strip is using
+    /// for that number right now.
+    /// `groupCatalogLabel` is the mini window's group-label table, which lives
+    /// in the App target. Pass it and a merged group seeds with the same word
+    /// the strip prints today ("Spark"); omit it and the seed falls back to
+    /// the SubProvider name.
+    public static func seeded(
+        template: Template,
+        from item: MenuBarItemSettings,
+        registry: QuotaFieldRegistry = .empty,
+        groupCatalogLabel: (String) -> String? = { _ in nil }
+    ) -> MenuBarComposition {
+        let fields = item.selectedFieldIds.compactMap {
+            MenuBarFieldCatalog.field(id: $0, registry: registry)
+        }
+        let runs = MenuBarFieldCatalog.runs(fields, merging: item.mergesGroupWindows)
+        var tokens: [MenuBarToken] = []
+
+        if item.showTitle {
+            tokens.append(MenuBarToken(kind: .text(item.kind.title), style: .label))
+        }
+
+        // Where the second row starts for `.twoColumn`: the midpoint, so a
+        // seeded two-row strip is balanced rather than one long row plus one
+        // orphan.
+        let breakAfter = template.seedsSecondRow && runs.count > 1
+            ? (runs.count + 1) / 2
+            : Int.max
+
+        for (index, run) in runs.enumerated() {
+            if index > 0 {
+                tokens.append(
+                    index == breakAfter
+                        ? MenuBarToken(kind: .lineBreak)
+                        : MenuBarToken(kind: .separator(" · "), style: .divider)
+                )
+            }
+            let style = item.style(for: run.primary.id)
+            if style != .labelAndPercent {
+                tokens.append(MenuBarToken(kind: .logo(run.primary.tool), style: .label))
+            }
+            if style != .logoAndPercent {
+                let label = run.isMerged
+                    ? MenuBarFieldCatalog.mergedGroupLabel(
+                        for: run,
+                        customLabels: item.customLabels,
+                        groupCatalogLabel: groupCatalogLabel
+                    )
+                    : seedLabel(for: run.primary, customLabels: item.customLabels)
+                tokens.append(MenuBarToken(kind: .text(label), style: .label))
+            }
+            for (offset, field) in run.fields.enumerated() {
+                if offset > 0 {
+                    tokens.append(MenuBarToken(kind: .separator("/"), style: .divider))
+                }
+                tokens.append(MenuBarToken(
+                    kind: .quota(fieldId: field.id, metric: .displayPercent),
+                    style: .percent
+                ))
+            }
+        }
+
+        return MenuBarComposition(
+            isEnabled: false,
+            template: template,
+            tokens: tokens
+        )
+    }
+
+    /// The catalog's default label, overridden by whatever the user renamed
+    /// this field to for the menu bar. The live bucket's own short label wins
+    /// at render time in the field path; a seed has no bucket in hand, so it
+    /// captures the static name and the user can edit the text block after.
+    private static func seedLabel(
+        for field: MenuBarFieldOption,
+        customLabels: [String: String]
+    ) -> String {
+        let custom = customLabels[field.id]?.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let custom, !custom.isEmpty { return custom }
+        return field.defaultLabel
+    }
+
+    // MARK: Codable
+
+    private enum CodingKeys: String, CodingKey {
+        case isEnabled
+        case template
+        case tokens
+        case fontScale
+        case tokenSpacing
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        self.isEnabled = try c.decodeIfPresent(Bool.self, forKey: .isEnabled) ?? false
+        self.template = (try? c.decodeIfPresent(Template.self, forKey: .template)) ?? .roomy
+        // Lossy per token: a block kind a future build introduces is dropped
+        // rather than taking the whole settings file down with it.
+        let stored = try c.decodeIfPresent([LossyMenuBarToken].self, forKey: .tokens) ?? []
+        self.tokens = stored.compactMap(\.value)
+        self.fontScale = try c.decodeIfPresent(Double.self, forKey: .fontScale)
+            .map { $0.clamped(to: Self.fontScaleRange) }
+        self.tokenSpacing = try c.decodeIfPresent(Double.self, forKey: .tokenSpacing)
+            .map { $0.clamped(to: Self.tokenSpacingRange) }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        try c.encode(isEnabled, forKey: .isEnabled)
+        try c.encode(template, forKey: .template)
+        try c.encode(tokens, forKey: .tokens)
+        try c.encodeIfPresent(fontScale, forKey: .fontScale)
+        try c.encodeIfPresent(tokenSpacing, forKey: .tokenSpacing)
+    }
+}
+
+/// Tolerant wrapper so one unreadable block cannot discard a whole strip —
+/// the same treatment `AppSettings` gives an unknown menu-bar item.
+private struct LossyMenuBarToken: Codable {
+    let value: MenuBarToken?
+
+    init(from decoder: Decoder) throws {
+        self.value = try? MenuBarToken(from: decoder)
+    }
+
+    func encode(to encoder: Encoder) throws {
+        try value?.encode(to: encoder)
+    }
+}
+
+/// What the renderer must resolve for one quota before it can build the plan.
+public struct MenuBarQuotaRequirement: Equatable, Sendable {
+    public var fieldId: String
+    /// Some token, colour, or rule reads the personal forecast.
+    public var needsForecast: Bool
+    /// Some token reads the linear burn-rate pace.
+    public var needsPace: Bool
+
+    public init(fieldId: String, needsForecast: Bool, needsPace: Bool) {
+        self.fieldId = fieldId
+        self.needsForecast = needsForecast
+        self.needsPace = needsPace
+    }
+}
+
+// MARK: - Render inputs
+
+/// One live quota, resolved by the App layer and handed to the planner.
+///
+/// Deliberately a value: the planner is pure, so every format and every
+/// visibility decision below is testable without AppKit, a quota service, or
+/// a running app — the same split `ResetHistoryComparison` uses.
+public struct MenuBarQuotaSnapshot: Equatable, Sendable {
+    /// The forecast half, present only where `quotaRequirements` asked for it.
+    public struct Forecast: Equatable, Sendable {
+        public var verdict: QuotaPaceForecast.Verdict
+        /// Median projected quota left when the window refills.
+        public var projectedRemainingPercent: Double
+        public var runOutAt: Date?
+
+        public init(
+            verdict: QuotaPaceForecast.Verdict,
+            projectedRemainingPercent: Double,
+            runOutAt: Date? = nil
+        ) {
+            self.verdict = verdict
+            self.projectedRemainingPercent = projectedRemainingPercent
+            self.runOutAt = runOutAt
+        }
+    }
+
+    public var fieldId: String
+    public var tool: ToolType
+    /// What this quota is called on the strip — the item's custom label if the
+    /// user set one, else the live bucket's short label.
+    public var label: String
+    /// The raw observation, 0…100.
+    public var usedPercent: Double
+    /// Provider-normalized and already resolved against the app's Used /
+    /// Remaining setting.
+    public var displayPercent: Double
+    public var resetAt: Date?
+    /// `UsagePace.deltaPercent` — actual minus linear expectation.
+    public var paceDeltaPercent: Double?
+    public var forecast: Forecast?
+
+    public init(
+        fieldId: String,
+        tool: ToolType,
+        label: String,
+        usedPercent: Double,
+        displayPercent: Double,
+        resetAt: Date? = nil,
+        paceDeltaPercent: Double? = nil,
+        forecast: Forecast? = nil
+    ) {
+        self.fieldId = fieldId
+        self.tool = tool
+        self.label = label
+        self.usedPercent = usedPercent
+        self.displayPercent = displayPercent
+        self.resetAt = resetAt
+        self.paceDeltaPercent = paceDeltaPercent
+        self.forecast = forecast
+    }
+
+    public var remainingPercent: Double { max(0, min(100, 100 - usedPercent)) }
+}
+
+// MARK: - Render plan
+
+/// The colour a block ends up with, still as a role: the App owns the
+/// `NSColor` translation, exactly as `MenuBarPercentColor` already arranges it.
+public enum MenuBarTokenColorRole: Equatable, Sendable {
+    /// Colour this block the way that quota's percentage is coloured, under
+    /// `basis`. The planner only emits this for a quota it was given, so the
+    /// renderer's lookup always succeeds.
+    case quota(fieldId: String, basis: MenuBarColorBasis)
+    case brand(ToolType)
+    case primary
+    case secondary
+    case tertiary
+    /// Normalized `#rrggbb` / `#rrggbbaa`.
+    case fixed(hex: String)
+}
+
+/// One block, ready to draw.
+public struct MenuBarRenderedToken: Equatable, Sendable, Identifiable {
+    /// The source token's id, so stage 2's editor can map a hit test or a
+    /// live preview back to the block the user is dragging.
+    public var id: UUID
+    /// Nil only for a logo block.
+    public var text: String?
+    public var logo: ToolType?
+    public var color: MenuBarTokenColorRole
+    /// Template scale × size step. The renderer multiplies its base font size
+    /// by this.
+    public var fontScale: Double
+    public var weight: MenuBarToken.Weight
+    public var monospacedDigits: Bool
+    /// This block in words, or nil when it contributes nothing to a spoken
+    /// description (spaces and separators).
+    public var spoken: String?
+
+    public init(
+        id: UUID,
+        text: String?,
+        logo: ToolType?,
+        color: MenuBarTokenColorRole,
+        fontScale: Double,
+        weight: MenuBarToken.Weight,
+        monospacedDigits: Bool,
+        spoken: String?
+    ) {
+        self.id = id
+        self.text = text
+        self.logo = logo
+        self.color = color
+        self.fontScale = fontScale
+        self.weight = weight
+        self.monospacedDigits = monospacedDigits
+        self.spoken = spoken
+    }
+}
+
+public struct MenuBarRenderRow: Equatable, Sendable {
+    public var tokens: [MenuBarRenderedToken]
+
+    public init(tokens: [MenuBarRenderedToken] = []) {
+        self.tokens = tokens
+    }
+
+    public var isEmpty: Bool { tokens.isEmpty }
+}
+
+/// Everything the status item needs for one render of a composed strip.
+public struct MenuBarRenderPlan: Equatable, Sendable {
+    public var rows: [MenuBarRenderRow]
+    /// Gap between adjacent blocks, as a multiplier on the base font size.
+    public var tokenSpacing: Double
+    /// Multiplier on the base font size for the whole strip.
+    public var fontScale: Double
+    /// The strip in words, one clause per meaningful block, rows joined with
+    /// " · ". Never the drawn shorthand — this is what a screen reader and the
+    /// tooltip say.
+    public var spokenDescription: String
+
+    public init(
+        rows: [MenuBarRenderRow],
+        tokenSpacing: Double,
+        fontScale: Double,
+        spokenDescription: String
+    ) {
+        self.rows = rows
+        self.tokenSpacing = tokenSpacing
+        self.fontScale = fontScale
+        self.spokenDescription = spokenDescription
+    }
+
+    /// Nothing survived: every block was hidden, or every quota it named is
+    /// unavailable. The renderer draws the same "—" the field path draws.
+    public var isEmpty: Bool { rows.allSatisfy(\.isEmpty) }
+}
+
+// MARK: - Planner
+
+public extension MenuBarComposition {
+    /// Turn this composition plus a quota snapshot into a draw plan.
+    ///
+    /// One forward pass over the tokens. `quotas` is a small array — the
+    /// distinct fields `referencedFieldIds` named — scanned linearly, which
+    /// beats building a dictionary per render for the handful of quotas a
+    /// menu bar can hold.
+    ///
+    /// A quota token whose bucket is missing renders nothing and does not
+    /// disturb the rest of the strip. Rows past `maximumRows` fold back into
+    /// the last row.
+    func plan(
+        quotas: [MenuBarQuotaSnapshot],
+        displayMode: DisplayMode,
+        colorBasis: MenuBarColorBasis,
+        now: Date = Date()
+    ) -> MenuBarRenderPlan {
+        let scale = effectiveFontScale
+        var rows: [MenuBarRenderRow] = [MenuBarRenderRow()]
+        var spokenRows: [[String]] = [[]]
+
+        func snapshot(_ fieldId: String?) -> MenuBarQuotaSnapshot? {
+            guard let fieldId else { return nil }
+            return quotas.first { $0.fieldId == fieldId }
+        }
+
+        for token in tokens {
+            if case .lineBreak = token.kind {
+                // Ignored past the second row: a third row cannot be drawn, so
+                // its blocks stay on the second rather than vanishing.
+                if rows.count < Self.maximumRows {
+                    rows.append(MenuBarRenderRow())
+                    spokenRows.append([])
+                }
+                continue
+            }
+            guard Self.isVisible(token.visibility, quotas: quotas) else { continue }
+
+            let own = snapshot(token.quotaFieldId)
+            guard let content = Self.content(
+                for: token,
+                quota: own,
+                displayMode: displayMode,
+                now: now
+            ) else { continue }
+
+            let color = Self.colorRole(
+                for: token,
+                own: own,
+                quotas: quotas,
+                colorBasis: colorBasis
+            )
+            rows[rows.count - 1].tokens.append(MenuBarRenderedToken(
+                id: token.id,
+                text: content.text,
+                logo: content.logo,
+                color: color,
+                fontScale: scale * token.style.size.multiplier,
+                weight: token.style.weight,
+                monospacedDigits: token.style.monospacedDigits,
+                spoken: content.spoken
+            ))
+            if let spoken = content.spoken {
+                spokenRows[spokenRows.count - 1].append(spoken)
+            }
+        }
+
+        let spoken = spokenRows
+            .map { $0.joined(separator: ", ") }
+            .filter { !$0.isEmpty }
+            .joined(separator: " · ")
+        return MenuBarRenderPlan(
+            rows: rows,
+            tokenSpacing: effectiveTokenSpacing,
+            fontScale: scale,
+            spokenDescription: spoken
+        )
+    }
+
+    // MARK: Visibility
+
+    /// A rule the inputs cannot answer never hides its block. See
+    /// `MenuBarToken.Visibility`.
+    static func isVisible(
+        _ visibility: MenuBarToken.Visibility,
+        quotas: [MenuBarQuotaSnapshot]
+    ) -> Bool {
+        switch visibility {
+        case .always:
+            return true
+        case let .whenUsedAtLeast(fieldId, percent):
+            guard let quota = quotas.first(where: { $0.fieldId == fieldId }) else { return true }
+            return quota.usedPercent >= percent
+        case let .whenRemainingAtMost(fieldId, percent):
+            guard let quota = quotas.first(where: { $0.fieldId == fieldId }) else { return true }
+            return quota.remainingPercent <= percent
+        case let .whenForecast(fieldId, verdicts):
+            guard let quota = quotas.first(where: { $0.fieldId == fieldId }) else { return true }
+            guard let forecast = quota.forecast else { return true }
+            return verdicts.contains(forecast.verdict)
+        }
+    }
+
+    // MARK: Content
+
+    private struct TokenContent {
+        var text: String?
+        var logo: ToolType?
+        var spoken: String?
+    }
+
+    private static func content(
+        for token: MenuBarToken,
+        quota: MenuBarQuotaSnapshot?,
+        displayMode: DisplayMode,
+        now: Date
+    ) -> TokenContent? {
+        switch token.kind {
+        case let .logo(tool):
+            return TokenContent(text: nil, logo: tool, spoken: tool.quotaSubProviderName())
+        case let .text(text):
+            let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !text.isEmpty else { return nil }
+            return TokenContent(text: text, logo: nil, spoken: trimmed.isEmpty ? nil : trimmed)
+        case .space:
+            return TokenContent(text: " ", logo: nil, spoken: nil)
+        case let .separator(separator):
+            guard !separator.isEmpty else { return nil }
+            return TokenContent(text: separator, logo: nil, spoken: nil)
+        case .lineBreak:
+            return nil
+        case let .quota(_, metric):
+            // A bucket the provider is not returning right now takes its block
+            // off the strip and leaves everything else alone.
+            guard let quota, let text = value(of: metric, in: quota, displayMode: displayMode, now: now)
+            else { return nil }
+            return TokenContent(
+                text: text,
+                logo: nil,
+                spoken: spokenClause(metric: metric, value: text, quota: quota, displayMode: displayMode)
+            )
+        }
+    }
+
+    /// The exact string each metric renders. See `MenuBarQuotaMetric`.
+    static func value(
+        of metric: MenuBarQuotaMetric,
+        in quota: MenuBarQuotaSnapshot,
+        displayMode: DisplayMode,
+        now: Date
+    ) -> String? {
+        switch metric {
+        case .usedPercent:
+            return percent(quota.usedPercent)
+        case .remainingPercent:
+            return percent(quota.remainingPercent)
+        case .displayPercent:
+            return percent(quota.displayPercent)
+        case .pace:
+            guard let delta = quota.paceDeltaPercent else { return nil }
+            let rounded = Int(delta.rounded())
+            if rounded == 0 { return "±0%" }
+            return rounded > 0 ? "+\(rounded)%" : "\(rounded)%"
+        case .forecastPercent:
+            guard let forecast = quota.forecast else { return nil }
+            return percent(forecast.projectedRemainingPercent)
+        case .resetsIn:
+            return ResetCountdownFormatter.string(from: quota.resetAt, now: now)
+        case .resetAt:
+            guard let resetAt = quota.resetAt else { return nil }
+            return ResetCountdownFormatter.absoluteTime(for: resetAt, now: now)
+        case .runsOutIn:
+            guard let runOutAt = quota.forecast?.runOutAt else { return nil }
+            return ResetCountdownFormatter.string(from: runOutAt, now: now)
+        case .label:
+            let trimmed = quota.label.trimmingCharacters(in: .whitespacesAndNewlines)
+            return trimmed.isEmpty ? nil : trimmed
+        }
+    }
+
+    private static func percent(_ value: Double) -> String {
+        "\(Int(value.rounded()))%"
+    }
+
+    private static func spokenClause(
+        metric: MenuBarQuotaMetric,
+        value: String,
+        quota: MenuBarQuotaSnapshot,
+        displayMode: DisplayMode
+    ) -> String {
+        switch metric {
+        case .label:
+            return value
+        case .usedPercent:
+            return "\(quota.label) \(value) used"
+        case .remainingPercent:
+            return "\(quota.label) \(value) remaining"
+        case .displayPercent:
+            return "\(quota.label) \(value) \(displayMode == .used ? "used" : "remaining")"
+        case .pace:
+            return "\(quota.label) pace \(value)"
+        case .forecastPercent:
+            return "\(quota.label) forecast \(value) left at reset"
+        case .resetsIn:
+            return "\(quota.label) resets in \(value)"
+        case .resetAt:
+            return "\(quota.label) resets at \(value)"
+        case .runsOutIn:
+            return "\(quota.label) runs out in \(value)"
+        }
+    }
+
+    // MARK: Colour
+
+    private static func colorRole(
+        for token: MenuBarToken,
+        own: MenuBarQuotaSnapshot?,
+        quotas: [MenuBarQuotaSnapshot],
+        colorBasis: MenuBarColorBasis
+    ) -> MenuBarTokenColorRole {
+        switch token.style.color {
+        case .automatic:
+            guard let own else { return .primary }
+            return .quota(fieldId: own.fieldId, basis: colorBasis)
+        case .forecast:
+            guard let own else { return .primary }
+            return .quota(fieldId: own.fieldId, basis: .forecast)
+        case let .followsQuota(fieldId, basis):
+            // Falls back rather than disappearing: a word coloured by a quota
+            // that went away is still a word the user wrote.
+            guard quotas.contains(where: { $0.fieldId == fieldId }) else { return .primary }
+            return .quota(fieldId: fieldId, basis: basis)
+        case let .brand(tool):
+            return .brand(tool)
+        case .primary:
+            return .primary
+        case .secondary:
+            return .secondary
+        case .tertiary:
+            return .tertiary
+        case let .fixed(hex):
+            guard let normalized = MenuBarHexColor.normalized(hex) else { return .primary }
+            return .fixed(hex: normalized)
+        }
+    }
+}
+
+// MARK: - Hex
+
+/// Validation for `ColorSource.fixed`. Kept separate so both the decoder and
+/// the stage-2 colour well can reject the same strings, and so an invalid
+/// value degrades to `.primary` instead of failing the settings file.
+public enum MenuBarHexColor {
+    /// Accepts `#rgb`, `#rrggbb`, `#rrggbbaa`, with or without the `#`, in any
+    /// case. Returns the normalized lowercase `#rrggbb` / `#rrggbbaa` form, or
+    /// nil when the string is not a colour.
+    public static func normalized(_ raw: String) -> String? {
+        var body = raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        if body.hasPrefix("#") { body.removeFirst() }
+        guard body.allSatisfy({ $0.isHexDigit }) else { return nil }
+        switch body.count {
+        case 3:
+            return "#" + body.flatMap { [$0, $0] }
+        case 6, 8:
+            return "#" + body
+        default:
+            return nil
+        }
+    }
+
+    /// Red, green, blue, alpha in 0…1, or nil for a string `normalized`
+    /// rejects. The App turns this into an `NSColor`.
+    public static func components(_ raw: String) -> (r: Double, g: Double, b: Double, a: Double)? {
+        guard let normalized = normalized(raw) else { return nil }
+        let digits = Array(normalized.dropFirst())
+        func byte(_ index: Int) -> Double {
+            let high = digits[index].hexDigitValue ?? 0
+            let low = digits[index + 1].hexDigitValue ?? 0
+            return Double(high * 16 + low) / 255.0
+        }
+        return (
+            byte(0),
+            byte(2),
+            byte(4),
+            digits.count == 8 ? byte(6) : 1.0
+        )
+    }
+}
+
+// MARK: - Codable for the payload enums
+
+extension MenuBarToken.Kind: Codable {
+    private enum CodingKeys: String, CodingKey {
+        case type
+        case tool
+        case text
+        case fieldId
+        case metric
+    }
+
+    private enum Discriminator: String, Codable {
+        case logo, text, quota, space, separator, lineBreak
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        switch try c.decode(Discriminator.self, forKey: .type) {
+        case .logo:
+            self = .logo(try c.decode(ToolType.self, forKey: .tool))
+        case .text:
+            self = .text(try c.decode(String.self, forKey: .text))
+        case .quota:
+            self = .quota(
+                fieldId: try c.decode(String.self, forKey: .fieldId),
+                // An unknown metric from a newer build reads as the plain
+                // percentage rather than dropping the block.
+                metric: (try? c.decode(MenuBarQuotaMetric.self, forKey: .metric)) ?? .displayPercent
+            )
+        case .space:
+            self = .space
+        case .separator:
+            self = .separator(try c.decode(String.self, forKey: .text))
+        case .lineBreak:
+            self = .lineBreak
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case let .logo(tool):
+            try c.encode(Discriminator.logo, forKey: .type)
+            try c.encode(tool, forKey: .tool)
+        case let .text(text):
+            try c.encode(Discriminator.text, forKey: .type)
+            try c.encode(text, forKey: .text)
+        case let .quota(fieldId, metric):
+            try c.encode(Discriminator.quota, forKey: .type)
+            try c.encode(fieldId, forKey: .fieldId)
+            try c.encode(metric, forKey: .metric)
+        case .space:
+            try c.encode(Discriminator.space, forKey: .type)
+        case let .separator(separator):
+            try c.encode(Discriminator.separator, forKey: .type)
+            try c.encode(separator, forKey: .text)
+        case .lineBreak:
+            try c.encode(Discriminator.lineBreak, forKey: .type)
+        }
+    }
+}
+
+extension MenuBarToken.ColorSource: Codable {
+    private enum CodingKeys: String, CodingKey {
+        case type
+        case tool
+        case hex
+        case fieldId
+        case basis
+    }
+
+    private enum Discriminator: String, Codable {
+        case automatic, forecast, followsQuota, brand, primary, secondary, tertiary, fixed
+    }
+
+    /// Any shape this build cannot read becomes `.primary`: a colour is not
+    /// worth losing a strip over.
+    public init(from decoder: Decoder) throws {
+        guard let c = try? decoder.container(keyedBy: CodingKeys.self),
+              let type = try? c.decode(Discriminator.self, forKey: .type)
+        else {
+            self = .primary
+            return
+        }
+        switch type {
+        case .automatic: self = .automatic
+        case .forecast: self = .forecast
+        case .followsQuota:
+            guard let fieldId = try? c.decode(String.self, forKey: .fieldId) else {
+                self = .primary
+                return
+            }
+            let basis = (try? c.decode(MenuBarColorBasis.self, forKey: .basis)) ?? .forecast
+            self = .followsQuota(fieldId: fieldId, basis: basis)
+        case .brand:
+            guard let tool = try? c.decode(ToolType.self, forKey: .tool) else {
+                self = .primary
+                return
+            }
+            self = .brand(tool)
+        case .primary: self = .primary
+        case .secondary: self = .secondary
+        case .tertiary: self = .tertiary
+        case .fixed:
+            guard let raw = try? c.decode(String.self, forKey: .hex) else {
+                self = .primary
+                return
+            }
+            self = .hex(raw)
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case .automatic: try c.encode(Discriminator.automatic, forKey: .type)
+        case .forecast: try c.encode(Discriminator.forecast, forKey: .type)
+        case let .followsQuota(fieldId, basis):
+            try c.encode(Discriminator.followsQuota, forKey: .type)
+            try c.encode(fieldId, forKey: .fieldId)
+            try c.encode(basis, forKey: .basis)
+        case let .brand(tool):
+            try c.encode(Discriminator.brand, forKey: .type)
+            try c.encode(tool, forKey: .tool)
+        case .primary: try c.encode(Discriminator.primary, forKey: .type)
+        case .secondary: try c.encode(Discriminator.secondary, forKey: .type)
+        case .tertiary: try c.encode(Discriminator.tertiary, forKey: .type)
+        case let .fixed(hex):
+            try c.encode(Discriminator.fixed, forKey: .type)
+            try c.encode(MenuBarHexColor.normalized(hex) ?? hex, forKey: .hex)
+        }
+    }
+
+    /// The quota this colour follows, if any.
+    var fieldId: String? {
+        if case let .followsQuota(fieldId, _) = self { return fieldId }
+        return nil
+    }
+
+    /// Whether resolving this colour needs the personal forecast.
+    var needsForecast: Bool {
+        switch self {
+        case .forecast: return true
+        case let .followsQuota(_, basis): return basis == .forecast
+        // `.automatic` follows the app-wide basis, which the renderer already
+        // resolves for every quota it draws; it never adds a forecast the
+        // field path would not have computed anyway.
+        default: return false
+        }
+    }
+}
+
+extension MenuBarToken.Visibility: Codable {
+    private enum CodingKeys: String, CodingKey {
+        case type
+        case fieldId
+        case percent
+        case verdicts
+    }
+
+    private enum Discriminator: String, Codable {
+        case always, whenUsedAtLeast, whenRemainingAtMost, whenForecast
+    }
+
+    /// An unreadable rule becomes `.always`, for the same reason an
+    /// unevaluatable one resolves to visible.
+    public init(from decoder: Decoder) throws {
+        guard let c = try? decoder.container(keyedBy: CodingKeys.self),
+              let type = try? c.decode(Discriminator.self, forKey: .type)
+        else {
+            self = .always
+            return
+        }
+        switch type {
+        case .always:
+            self = .always
+        case .whenUsedAtLeast:
+            guard let fieldId = try? c.decode(String.self, forKey: .fieldId),
+                  let percent = try? c.decode(Double.self, forKey: .percent)
+            else {
+                self = .always
+                return
+            }
+            self = .whenUsedAtLeast(fieldId: fieldId, percent: percent.clamped(to: 0...100))
+        case .whenRemainingAtMost:
+            guard let fieldId = try? c.decode(String.self, forKey: .fieldId),
+                  let percent = try? c.decode(Double.self, forKey: .percent)
+            else {
+                self = .always
+                return
+            }
+            self = .whenRemainingAtMost(fieldId: fieldId, percent: percent.clamped(to: 0...100))
+        case .whenForecast:
+            guard let fieldId = try? c.decode(String.self, forKey: .fieldId),
+                  let raw = try? c.decode([String].self, forKey: .verdicts)
+            else {
+                self = .always
+                return
+            }
+            let verdicts = Set(raw.compactMap(QuotaPaceForecast.Verdict.init(rawValue:)))
+            // A rule that matches nothing would hide the block forever.
+            self = verdicts.isEmpty ? .always : .whenForecast(fieldId: fieldId, verdicts: verdicts)
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case .always:
+            try c.encode(Discriminator.always, forKey: .type)
+        case let .whenUsedAtLeast(fieldId, percent):
+            try c.encode(Discriminator.whenUsedAtLeast, forKey: .type)
+            try c.encode(fieldId, forKey: .fieldId)
+            try c.encode(percent, forKey: .percent)
+        case let .whenRemainingAtMost(fieldId, percent):
+            try c.encode(Discriminator.whenRemainingAtMost, forKey: .type)
+            try c.encode(fieldId, forKey: .fieldId)
+            try c.encode(percent, forKey: .percent)
+        case let .whenForecast(fieldId, verdicts):
+            try c.encode(Discriminator.whenForecast, forKey: .type)
+            try c.encode(fieldId, forKey: .fieldId)
+            // Sorted so an unchanged rule writes an unchanged settings file.
+            try c.encode(verdicts.map(\.rawValue).sorted(), forKey: .verdicts)
+        }
+    }
+}
+
+private extension Double {
+    func clamped(to range: ClosedRange<Double>) -> Double {
+        Swift.min(Swift.max(self, range.lowerBound), range.upperBound)
+    }
+}

--- a/Sources/VibeBarCore/Models/MenuBarComposition.swift
+++ b/Sources/VibeBarCore/Models/MenuBarComposition.swift
@@ -282,6 +282,65 @@ public struct MenuBarToken: Identifiable, Codable, Hashable, Sendable {
         self.visibility = visibility
     }
 
+    // MARK: Palette
+
+    /// The blocks the palette can add, built in one place.
+    ///
+    /// **A stored string is user-authored, full stop.** Copy that exists to be
+    /// *shown* — a placeholder, a caption, a prompt — must never become a
+    /// block's content, because settings outlive the language that was
+    /// selected when the block was made. A text block added while the app was
+    /// in Chinese used to persist the Chinese placeholder and then render it
+    /// after a switch to English, which is the same defect the seeded labels
+    /// had: a derived name is a reference resolved at render, and only text
+    /// the user actually typed is stored.
+    ///
+    /// Building every palette block here is what makes that checkable rather
+    /// than remembered: `MenuBarCompositionTests` constructs all of them under
+    /// each supported language and asserts the stored values are identical.
+    public static func newText() -> MenuBarToken {
+        // Empty on purpose. The editor shows the placeholder; settings hold
+        // nothing until the user types.
+        MenuBarToken(kind: .text(""), style: .label)
+    }
+
+    public static func newAppIcon() -> MenuBarToken {
+        MenuBarToken(kind: .appIcon, style: .label)
+    }
+
+    public static func newLogo(_ tool: ToolType) -> MenuBarToken {
+        MenuBarToken(kind: .logo(tool), style: .label)
+    }
+
+    public static func newQuota(fieldId: String) -> MenuBarToken {
+        MenuBarToken(kind: .quota(fieldId: fieldId, metric: .displayPercent), style: .percent)
+    }
+
+    public static func newSpace() -> MenuBarToken {
+        MenuBarToken(kind: .space)
+    }
+
+    public static func newSeparator() -> MenuBarToken {
+        // Punctuation, not copy: a middle dot reads the same in every
+        // language the app ships.
+        MenuBarToken(kind: .separator(" · "), style: .divider)
+    }
+
+    public static func newLineBreak() -> MenuBarToken {
+        MenuBarToken(kind: .lineBreak)
+    }
+
+    /// One of each, for the test that pins the invariant above.
+    public static func paletteSamples(
+        tool: ToolType = .claude,
+        fieldId: String = "claude.five_hour"
+    ) -> [MenuBarToken] {
+        [
+            newAppIcon(), newLogo(tool), newText(),
+            newQuota(fieldId: fieldId), newSpace(), newSeparator(), newLineBreak()
+        ]
+    }
+
     /// The quota this token reads, if it is a quota token.
     public var quotaFieldId: String? {
         if case let .quota(fieldId, _) = kind { return fieldId }
@@ -1321,6 +1380,13 @@ public extension MenuBarComposition {
             return TokenContent(text: nil, glyph: .app, spoken: "Vibe Bar")
         case let .text(text):
             let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+            // A text block with nothing in it draws nothing — no reserved gap.
+            // The menu bar is the most width-constrained surface in the app,
+            // and spending pixels on a block that has nothing to say reads as
+            // a rendering fault rather than as an empty field. The block is
+            // still there in the editor, which says so.
+            //
+            // Whitespace the user typed is content: they wanted a gap.
             guard !text.isEmpty else { return nil }
             return TokenContent(
                 text: MenuBarToken.truncated(text),

--- a/Sources/VibeBarCore/Models/MenuBarSettings.swift
+++ b/Sources/VibeBarCore/Models/MenuBarSettings.swift
@@ -270,7 +270,12 @@ public struct MenuBarItemSettings: Codable, Equatable, Identifiable, Sendable {
         self.kind = try c.decode(MenuBarItemKind.self, forKey: .kind)
         self.isVisible = try c.decodeIfPresent(Bool.self, forKey: .isVisible) ?? true
         self.showTitle = try c.decodeIfPresent(Bool.self, forKey: .showTitle) ?? true
-        self.layout = try c.decodeIfPresent(MenuBarLayout.self, forKey: .layout)
+        // `try?`: an unknown layout from a newer build used to throw, and
+        // `LossyMenuBarItem` turns that into a dropped item — which discards
+        // the field selection, every rename, every per-field style *and* the
+        // composed strip, replacing the lot with defaults. One unreadable
+        // enum must cost at most that enum.
+        self.layout = (try? c.decode(MenuBarLayout.self, forKey: .layout))
             ?? (kind == .compact ? .iconOnly : .singleLine)
         self.selectedFieldIds = try c.decodeIfPresent([String].self, forKey: .selectedFieldIds) ?? []
         self.customLabels = try c.decodeIfPresent([String: String].self, forKey: .customLabels) ?? [:]

--- a/Sources/VibeBarCore/Models/MenuBarSettings.swift
+++ b/Sources/VibeBarCore/Models/MenuBarSettings.swift
@@ -163,8 +163,20 @@ public struct MenuBarItemSettings: Codable, Equatable, Identifiable, Sendable {
     /// entry — `Claude 5%/100%` instead of `5 Hours 5% · Weekly 100%`.
     /// Opt-in: the un-merged list is what every existing bar already shows.
     public var mergesGroupWindows: Bool
+    /// The composed strip, when the user has ever opened the composer.
+    ///
+    /// `nil` means they never did, and the item renders the field-based strip
+    /// this type has always rendered. A stored composition with
+    /// `isEnabled == false` means they built one and switched back — the
+    /// arrangement is kept so switching on again returns to it instead of
+    /// reseeding over their work. Every field-mode setting above stays intact
+    /// either way; the two modes never write over each other.
+    public var composition: MenuBarComposition?
 
     public var id: MenuBarItemKind { kind }
+
+    /// Whether this item draws the composed strip rather than the field list.
+    public var usesComposedStrip: Bool { composition?.isEnabled == true }
 
     public init(
         kind: MenuBarItemKind,
@@ -174,7 +186,8 @@ public struct MenuBarItemSettings: Codable, Equatable, Identifiable, Sendable {
         selectedFieldIds: [String],
         customLabels: [String: String] = [:],
         fieldStyles: [String: MenuBarFieldStyle] = [:],
-        mergesGroupWindows: Bool = false
+        mergesGroupWindows: Bool = false,
+        composition: MenuBarComposition? = nil
     ) {
         self.kind = kind
         self.isVisible = isVisible
@@ -184,10 +197,60 @@ public struct MenuBarItemSettings: Codable, Equatable, Identifiable, Sendable {
         self.customLabels = customLabels
         self.fieldStyles = fieldStyles
         self.mergesGroupWindows = mergesGroupWindows
+        self.composition = composition
     }
 
     public func style(for fieldId: String) -> MenuBarFieldStyle {
         fieldStyles[fieldId] ?? .labelAndPercent
+    }
+
+    /// Turn the composer on or off without losing anything.
+    ///
+    /// Seeding happens exactly once — the first time custom mode is switched
+    /// on with no stored strip. Afterwards this only flips `isEnabled`, so a
+    /// user who toggles back and forth keeps the arrangement they built, and
+    /// the field-mode selection is never touched at all. Stage 2's editor
+    /// should call `reseed(template:...)` when the user explicitly asks to
+    /// start over.
+    public mutating func setComposedStripEnabled(
+        _ enabled: Bool,
+        template: MenuBarComposition.Template = .roomy,
+        registry: QuotaFieldRegistry = .empty,
+        groupCatalogLabel: (String) -> String? = { _ in nil }
+    ) {
+        if var existing = composition {
+            existing.isEnabled = enabled
+            composition = existing
+            return
+        }
+        guard enabled else { return }
+        var seeded = MenuBarComposition.seeded(
+            template: template,
+            from: self,
+            registry: registry,
+            groupCatalogLabel: groupCatalogLabel
+        )
+        seeded.isEnabled = true
+        composition = seeded
+    }
+
+    /// Replace the stored strip with a fresh seed of `template`, keeping the
+    /// current on/off state. This is the destructive one; it exists so the
+    /// editor's "start over" is explicit rather than a side effect of a toggle.
+    public mutating func reseedComposedStrip(
+        template: MenuBarComposition.Template,
+        registry: QuotaFieldRegistry = .empty,
+        groupCatalogLabel: (String) -> String? = { _ in nil }
+    ) {
+        let wasEnabled = composition?.isEnabled ?? false
+        var seeded = MenuBarComposition.seeded(
+            template: template,
+            from: self,
+            registry: registry,
+            groupCatalogLabel: groupCatalogLabel
+        )
+        seeded.isEnabled = wasEnabled
+        composition = seeded
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -199,6 +262,7 @@ public struct MenuBarItemSettings: Codable, Equatable, Identifiable, Sendable {
         case customLabels
         case fieldStyles
         case mergesGroupWindows
+        case composition
     }
 
     public init(from decoder: Decoder) throws {
@@ -217,6 +281,10 @@ public struct MenuBarItemSettings: Codable, Equatable, Identifiable, Sendable {
         // Absent in every settings file written before group merging existed;
         // off is the layout those bars were arranged against.
         self.mergesGroupWindows = try c.decodeIfPresent(Bool.self, forKey: .mergesGroupWindows) ?? false
+        // Absent for every item that predates the composer, and lossy on
+        // purpose: an unreadable strip falls back to the field-based bar
+        // instead of taking the whole settings file down.
+        self.composition = try? c.decodeIfPresent(MenuBarComposition.self, forKey: .composition)
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -229,6 +297,7 @@ public struct MenuBarItemSettings: Codable, Equatable, Identifiable, Sendable {
         try c.encode(customLabels, forKey: .customLabels)
         try c.encode(fieldStyles, forKey: .fieldStyles)
         try c.encode(mergesGroupWindows, forKey: .mergesGroupWindows)
+        try c.encodeIfPresent(composition, forKey: .composition)
     }
 }
 

--- a/Sources/VibeBarCore/Models/QuotaFieldRegistry.swift
+++ b/Sources/VibeBarCore/Models/QuotaFieldRegistry.swift
@@ -53,6 +53,33 @@ public struct QuotaFieldRegistry: Codable, Equatable, Sendable {
         self.fields = fields
     }
 
+    private enum CodingKeys: String, CodingKey {
+        case fields
+    }
+
+    /// Lossy per entry.
+    ///
+    /// The synthesized decoder threw on the first entry it could not read — a
+    /// `ToolType` a newer build added, most likely — and `QuotaService` loads
+    /// this with `try? … ?? .empty`, so one unreadable row discarded *every*
+    /// remembered field. The next refresh then rewrote the file without them,
+    /// which is a silent, permanent loss of exactly the rows the keep set
+    /// exists to protect: buckets the user selected that the provider is not
+    /// returning right now.
+    ///
+    /// Dropping a single unreadable entry is right, and is the one place in
+    /// this model where it is: the registry is a record of what adapters
+    /// returned, not something the user authored, and an entry for a provider
+    /// this build has no `ToolType` for cannot be fetched or drawn. The next
+    /// build that understands it rediscovers it from a live response.
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let stored = try container.decodeIfPresent(
+            [LossyDiscoveredQuotaField].self, forKey: .fields
+        ) ?? []
+        self.fields = stored.compactMap(\.value)
+    }
+
     public static let empty = QuotaFieldRegistry()
 
     public func field(id: String) -> DiscoveredQuotaField? {
@@ -264,5 +291,15 @@ public extension MenuBarFieldCatalog {
             }
         }
         return stem.isEmpty ? bucketId : stem
+    }
+}
+
+
+/// Tolerant wrapper: one entry this build cannot read must not cost the rest.
+private struct LossyDiscoveredQuotaField: Decodable {
+    let value: DiscoveredQuotaField?
+
+    init(from decoder: Decoder) throws {
+        self.value = try? DiscoveredQuotaField(from: decoder)
     }
 }

--- a/Sources/VibeBarCore/Resources/en.lproj/Localizable.strings
+++ b/Sources/VibeBarCore/Resources/en.lproj/Localizable.strings
@@ -446,6 +446,9 @@
 /* A block showing words the user typed. */
 "menuBar.composer.block.text" = "Text";
 
+/* Chip label for a block written by a newer version of the app that this one cannot draw. */
+"menuBar.composer.block.unsupported" = "From a newer version";
+
 /* Caption over the reorderable list of blocks. */
 "menuBar.composer.blocks" = "Blocks — drag to reorder";
 
@@ -652,6 +655,9 @@
 
 /* Starting content of a newly added text block, before the user types over it. */
 "menuBar.composer.text.placeholder" = "Label";
+
+/* Explains an unsupported block: it is kept so an upgrade restores it, and only removal applies. */
+"menuBar.composer.unsupported.detail" = "This block was made by a newer version of Vibe Bar. It is kept exactly as it was and will work again after an update; until then it draws nothing.";
 
 /* Shown on a block whose colour or rule points at a quota that is not being returned. */
 "menuBar.composer.warning.degraded" = "This block still draws, but a colour or a rule on it points at a quota that is not being returned right now.";

--- a/Sources/VibeBarCore/Resources/en.lproj/Localizable.strings
+++ b/Sources/VibeBarCore/Resources/en.lproj/Localizable.strings
@@ -644,6 +644,9 @@
 /* What the Two rows template does. */
 "menuBar.composer.template.twoRowsDetail" = "Two stacked rows in one status item.";
 
+/* Shown under the text field when the selected text block has nothing in it. */
+"menuBar.composer.text.empty" = "An empty text block draws nothing. Type something for it to appear in the menu bar.";
+
 /* Explains that long text is cut short in the bar. Count is the character ceiling. */
 "menuBar.composer.text.limit" = "Blocks longer than %1$lld characters are cut short with an ellipsis in the bar.";
 

--- a/Sources/VibeBarCore/Resources/en.lproj/Localizable.strings
+++ b/Sources/VibeBarCore/Resources/en.lproj/Localizable.strings
@@ -407,6 +407,294 @@
 /* QuotaError: unclassified failure; reason is the underlying message, untranslated */
 "error.unknownDetail" = "Error: %1$@";
 
+/* Button copying the selected block. */
+"menuBar.composer.action.duplicate" = "Duplicate";
+
+/* Button deleting the selected block. */
+"menuBar.composer.action.remove" = "Remove";
+
+/* What the app-icon block shows. */
+"menuBar.composer.appIcon.detail" = "Vibe Bar's own icon — what the Icon Only layout shows.";
+
+/* A block showing the app's own icon. */
+"menuBar.composer.block.appIcon" = "Vibe Bar icon";
+
+/* Chip label for a text block with nothing typed in it. */
+"menuBar.composer.block.emptyText" = "Empty text";
+
+/* Chip label for a separator block with nothing typed in it. */
+"menuBar.composer.block.gap" = "Gap";
+
+/* A block showing a provider's brand mark. */
+"menuBar.composer.block.logo" = "Logo";
+
+/* A block that ends one row and starts the next. */
+"menuBar.composer.block.newRow" = "New row";
+
+/* A block showing a number read from a quota. */
+"menuBar.composer.block.quota" = "Quota";
+
+/* A block that draws a divider the user chose. */
+"menuBar.composer.block.separator" = "Separator";
+
+/* A block that draws blank space. */
+"menuBar.composer.block.space" = "Space";
+
+/* Palette group holding spacing and row blocks. */
+"menuBar.composer.block.structure" = "Structure";
+
+/* A block showing words the user typed. */
+"menuBar.composer.block.text" = "Text";
+
+/* Caption over the reorderable list of blocks. */
+"menuBar.composer.blocks" = "Blocks — drag to reorder";
+
+/* Shown when the strip has no blocks. */
+"menuBar.composer.blocks.empty" = "No blocks yet. Add one from the palette below.";
+
+/* Colour choice: whatever the strip would use on its own. */
+"menuBar.composer.colour.automatic" = "Automatic";
+
+/* Colour choice: a provider's brand colour. */
+"menuBar.composer.colour.brand" = "Brand";
+
+/* Colour choice: a colour the user picks. Opens a colour well. */
+"menuBar.composer.colour.fixed" = "Custom…";
+
+/* Colour choice: track another quota's colour. */
+"menuBar.composer.colour.followsQuota" = "Follow a quota";
+
+/* Colour choice: the quota's forecast verdict colour. */
+"menuBar.composer.colour.forecast" = "Forecast";
+
+/* Colour choice: the menu bar's ordinary text colour. */
+"menuBar.composer.colour.primary" = "Primary";
+
+/* Colour choice: a quieter text colour. */
+"menuBar.composer.colour.secondary" = "Secondary";
+
+/* Colour choice: the quietest text colour. */
+"menuBar.composer.colour.tertiary" = "Tertiary";
+
+/* Picker choosing a block's colour. */
+"menuBar.composer.field.colour" = "Colour";
+
+/* Toggle keeping digits the same width. */
+"menuBar.composer.field.monospacedDigits" = "Monospaced digits";
+
+/* Why monospaced digits matter. */
+"menuBar.composer.field.monospacedDigitsHelp" = "Keeps a changing number from shifting the blocks beside it.";
+
+/* A quota in a picker that is not currently being returned. Title is the quota's name. */
+"menuBar.composer.field.offlineOption" = "%1$@ (offline)";
+
+/* Picker choosing which provider's logo a block shows. */
+"menuBar.composer.field.provider" = "Provider";
+
+/* Picker choosing when a block is on screen. */
+"menuBar.composer.field.show" = "Show";
+
+/* Picker choosing which number a quota block prints. */
+"menuBar.composer.field.shows" = "Shows";
+
+/* Picker choosing a block's type size. */
+"menuBar.composer.field.size" = "Size";
+
+/* Checkboxes choosing which forecast verdicts show a block. */
+"menuBar.composer.field.verdicts" = "Verdicts";
+
+/* Picker choosing a block's type weight. */
+"menuBar.composer.field.weight" = "Weight";
+
+/* Quota metric: whichever percentage the app-wide Used/Remaining setting selects. */
+"menuBar.composer.metric.displayPercent" = "Percent (follows setting)";
+
+/* Quota metric: the projected figure when the quota refills. */
+"menuBar.composer.metric.forecastPercent" = "Forecast at reset";
+
+/* Quota metric: the quota's own name. */
+"menuBar.composer.metric.label" = "Name";
+
+/* Quota metric: distance from the linear expectation. */
+"menuBar.composer.metric.pace" = "Pace";
+
+/* Quota metric: the remaining percentage. */
+"menuBar.composer.metric.remainingPercent" = "Remaining %";
+
+/* Quota metric: the wall-clock time of the refill. */
+"menuBar.composer.metric.resetAt" = "Resets at";
+
+/* Quota metric: countdown to the refill. */
+"menuBar.composer.metric.resetsIn" = "Resets in";
+
+/* Quota metric: countdown to projected exhaustion. */
+"menuBar.composer.metric.runsOutIn" = "Runs out in";
+
+/* Quota metric: the used percentage. */
+"menuBar.composer.metric.usedPercent" = "Used %";
+
+/* Segment: the strip the user assembles out of blocks. */
+"menuBar.composer.mode.custom" = "Custom";
+
+/* Caption under the mode picker while Custom is selected; reassures that switching back is not destructive. */
+"menuBar.composer.mode.customCaption" = "Switching back to Default keeps every block you built — you can return to Custom and find it exactly as you left it.";
+
+/* Segment: the field-list strip the app has always drawn. */
+"menuBar.composer.mode.default" = "Default";
+
+/* Caption under the mode picker while Default is selected. */
+"menuBar.composer.mode.defaultCaption" = "Default shows the fields you tick below. Custom lets you build the strip out of blocks: logos, words, and any quota.";
+
+/* Segmented control choosing how the menu-bar strip is built. */
+"menuBar.composer.mode.label" = "Strip";
+
+/* Tooltip on the New row palette button once both rows are used. */
+"menuBar.composer.newRow.capped" = "The menu bar can only draw two rows.";
+
+/* What a new-row block does, and that it accepts a rule. */
+"menuBar.composer.newRow.detail" = "Ends the first row and starts the second. Give it a rule below to split only when that quota says so.";
+
+/* Tooltip on the New row palette button when a second row is still available. */
+"menuBar.composer.newRow.help" = "Split the strip into a second row.";
+
+/* Caption over the list of blocks that can be added. */
+"menuBar.composer.palette" = "Add a block";
+
+/* Caption over the live preview of the composed strip. */
+"menuBar.composer.preview" = "Preview";
+
+/* Accessibility label for the dark-background preview. */
+"menuBar.composer.preview.dark" = "Dark menu bar preview";
+
+/* Accessibility label for a preview with nothing to draw. */
+"menuBar.composer.preview.empty" = "Empty strip";
+
+/* Explains why the preview is shown twice. */
+"menuBar.composer.preview.grounds" = "Light and dark menu bars, side by side — a fixed colour that reads well on one can vanish on the other.";
+
+/* Accessibility label for the light-background preview. */
+"menuBar.composer.preview.light" = "Light menu bar preview";
+
+/* Explains that a two-row strip is scaled to fit the menu bar's height. */
+"menuBar.composer.preview.twoRowScaling" = "Two rows share the menu bar's height, so large sizes are scaled down to fit — the preview scales with them.";
+
+/* Drop target that deletes the dragged block. */
+"menuBar.composer.removeTarget" = "Drag here to remove";
+
+/* Visibility rule: the block is always shown. */
+"menuBar.composer.rule.always" = "Always";
+
+/* Visibility rule: show only for chosen forecast verdicts. */
+"menuBar.composer.rule.whenForecast" = "When the forecast says";
+
+/* Visibility rule: show once a quota's remaining percentage falls to a threshold. */
+"menuBar.composer.rule.whenRemainingAtMost" = "When remaining is at most";
+
+/* Visibility rule: show once a quota's used percentage reaches a threshold. */
+"menuBar.composer.rule.whenUsedAtLeast" = "When used is at least";
+
+/* Caption over the controls for the selected block. */
+"menuBar.composer.selected" = "Selected block";
+
+/* Type size choice. */
+"menuBar.composer.size.large" = "Large";
+
+/* Type size choice. */
+"menuBar.composer.size.regular" = "Regular";
+
+/* Type size choice. */
+"menuBar.composer.size.small" = "Small";
+
+/* What a space block does. */
+"menuBar.composer.space.detail" = "A gap one space wide. Size changes how wide.";
+
+/* Button rebuilding every block from the default strip. */
+"menuBar.composer.startOver" = "Start over from the current strip…";
+
+/* Destructive button in the confirmation dialog. */
+"menuBar.composer.startOver.confirm" = "Start over";
+
+/* Body of the confirmation dialog. */
+"menuBar.composer.startOver.confirmMessage" = "Every block you arranged is discarded and rebuilt from the default strip.";
+
+/* Title of the confirmation dialog. */
+"menuBar.composer.startOver.confirmTitle" = "Replace your blocks?";
+
+/* Warns that starting over cannot be undone. */
+"menuBar.composer.startOver.detail" = "Starting over replaces every block with a fresh copy of the default strip. There is no undo.";
+
+/* Picker choosing a starting set of spacing and type sizes. */
+"menuBar.composer.template" = "Template";
+
+/* Template name. */
+"menuBar.composer.template.compact" = "Compact";
+
+/* What the Compact template does. */
+"menuBar.composer.template.compactDetail" = "Tight spacing and a slightly smaller face.";
+
+/* Template name. */
+"menuBar.composer.template.roomy" = "Roomy";
+
+/* What the Roomy template does. */
+"menuBar.composer.template.roomyDetail" = "Today's size, with more air between blocks.";
+
+/* Template name: two stacked rows. */
+"menuBar.composer.template.twoRows" = "Two rows";
+
+/* What the Two rows template does. */
+"menuBar.composer.template.twoRowsDetail" = "Two stacked rows in one status item.";
+
+/* Explains that long text is cut short in the bar. Count is the character ceiling. */
+"menuBar.composer.text.limit" = "Blocks longer than %1$lld characters are cut short with an ellipsis in the bar.";
+
+/* Starting content of a newly added text block, before the user types over it. */
+"menuBar.composer.text.placeholder" = "Label";
+
+/* Shown on a block whose colour or rule points at a quota that is not being returned. */
+"menuBar.composer.warning.degraded" = "This block still draws, but a colour or a rule on it points at a quota that is not being returned right now.";
+
+/* Lists the quotas that are not answering. Fields is a comma-separated list of quota names. */
+"menuBar.composer.warning.missing" = "Not answering right now: %1$@";
+
+/* Shown on a block whose quota is not being returned. */
+"menuBar.composer.warning.silent" = "This quota is not being returned right now, so this block draws nothing. It stays here and comes back on its own.";
+
+/* Type weight choice. */
+"menuBar.composer.weight.medium" = "Medium";
+
+/* Type weight choice. */
+"menuBar.composer.weight.regular" = "Regular";
+
+/* Type weight choice. */
+"menuBar.composer.weight.semibold" = "Semibold";
+
+/* One quota's projection spoken aloud. */
+"menuBar.spoken.forecast" = "%1$@ forecast %2$@ left at reset";
+
+/* One quota's pace spoken aloud; value is a signed percentage. */
+"menuBar.spoken.pace" = "%1$@ pace %2$@";
+
+/* One quota spoken aloud, remaining rather than used. */
+"menuBar.spoken.remaining" = "%1$@ %2$@ remaining";
+
+/* One quota's refill time spoken aloud. */
+"menuBar.spoken.resetAt" = "%1$@ resets at %2$@";
+
+/* One quota's refill countdown spoken aloud. */
+"menuBar.spoken.resetsIn" = "%1$@ resets in %2$@";
+
+/* One quota's exhaustion countdown spoken aloud. */
+"menuBar.spoken.runsOutIn" = "%1$@ runs out in %2$@";
+
+/* Accessibility label for the status item when nothing is being shown. Kind names the item. */
+"menuBar.spoken.title" = "%1$@ quota";
+
+/* Accessibility label and tooltip for the status item. Body lists each quota in words. */
+"menuBar.spoken.titleBody" = "%1$@ quota: %2$@";
+
+/* One quota spoken aloud. Label is the quota's name, value an already-formatted percentage. */
+"menuBar.spoken.used" = "%1$@ %2$@ used";
+
 /* Button that folds a provider's credential form away */
 "onboarding.apiKeys.hide" = "Hide";
 

--- a/Sources/VibeBarCore/Resources/en.lproj/Localizable.strings
+++ b/Sources/VibeBarCore/Resources/en.lproj/Localizable.strings
@@ -639,7 +639,7 @@
 "menuBar.composer.template.roomy" = "Roomy";
 
 /* What the Roomy template does. */
-"menuBar.composer.template.roomyDetail" = "Today's size, with more air between blocks.";
+"menuBar.composer.template.roomyDetail" = "The menu bar's usual size.";
 
 /* Template name: two stacked rows. */
 "menuBar.composer.template.twoRows" = "Two rows";

--- a/Sources/VibeBarCore/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/VibeBarCore/Resources/zh-Hans.lproj/Localizable.strings
@@ -407,6 +407,294 @@
 /* QuotaError: unclassified failure; reason is the underlying message, untranslated */
 "error.unknownDetail" = "错误：%1$@";
 
+/* Button copying the selected block. */
+"menuBar.composer.action.duplicate" = "复制";
+
+/* Button deleting the selected block. */
+"menuBar.composer.action.remove" = "移除";
+
+/* What the app-icon block shows. */
+"menuBar.composer.appIcon.detail" = "Vibe Bar 自身图标，即「仅图标」布局所显示的内容。";
+
+/* A block showing the app's own icon. */
+"menuBar.composer.block.appIcon" = "Vibe Bar 图标";
+
+/* Chip label for a text block with nothing typed in it. */
+"menuBar.composer.block.emptyText" = "空文字";
+
+/* Chip label for a separator block with nothing typed in it. */
+"menuBar.composer.block.gap" = "间隔";
+
+/* A block showing a provider's brand mark. */
+"menuBar.composer.block.logo" = "图标";
+
+/* A block that ends one row and starts the next. */
+"menuBar.composer.block.newRow" = "换行";
+
+/* A block showing a number read from a quota. */
+"menuBar.composer.block.quota" = "额度";
+
+/* A block that draws a divider the user chose. */
+"menuBar.composer.block.separator" = "分隔符";
+
+/* A block that draws blank space. */
+"menuBar.composer.block.space" = "空格";
+
+/* Palette group holding spacing and row blocks. */
+"menuBar.composer.block.structure" = "结构";
+
+/* A block showing words the user typed. */
+"menuBar.composer.block.text" = "文字";
+
+/* Caption over the reorderable list of blocks. */
+"menuBar.composer.blocks" = "积木 · 拖动可重新排序";
+
+/* Shown when the strip has no blocks. */
+"menuBar.composer.blocks.empty" = "尚无积木。可从下方面板添加。";
+
+/* Colour choice: whatever the strip would use on its own. */
+"menuBar.composer.colour.automatic" = "自动";
+
+/* Colour choice: a provider's brand colour. */
+"menuBar.composer.colour.brand" = "品牌色";
+
+/* Colour choice: a colour the user picks. Opens a colour well. */
+"menuBar.composer.colour.fixed" = "自定义…";
+
+/* Colour choice: track another quota's colour. */
+"menuBar.composer.colour.followsQuota" = "跟随某个额度";
+
+/* Colour choice: the quota's forecast verdict colour. */
+"menuBar.composer.colour.forecast" = "预测";
+
+/* Colour choice: the menu bar's ordinary text colour. */
+"menuBar.composer.colour.primary" = "主要";
+
+/* Colour choice: a quieter text colour. */
+"menuBar.composer.colour.secondary" = "次要";
+
+/* Colour choice: the quietest text colour. */
+"menuBar.composer.colour.tertiary" = "第三级";
+
+/* Picker choosing a block's colour. */
+"menuBar.composer.field.colour" = "颜色";
+
+/* Toggle keeping digits the same width. */
+"menuBar.composer.field.monospacedDigits" = "等宽数字";
+
+/* Why monospaced digits matter. */
+"menuBar.composer.field.monospacedDigitsHelp" = "数字变化时不会挤动相邻积木。";
+
+/* A quota in a picker that is not currently being returned. Title is the quota's name. */
+"menuBar.composer.field.offlineOption" = "%1$@（未返回数据）";
+
+/* Picker choosing which provider's logo a block shows. */
+"menuBar.composer.field.provider" = "厂商";
+
+/* Picker choosing when a block is on screen. */
+"menuBar.composer.field.show" = "显示条件";
+
+/* Picker choosing which number a quota block prints. */
+"menuBar.composer.field.shows" = "显示内容";
+
+/* Picker choosing a block's type size. */
+"menuBar.composer.field.size" = "字号";
+
+/* Checkboxes choosing which forecast verdicts show a block. */
+"menuBar.composer.field.verdicts" = "预测结论";
+
+/* Picker choosing a block's type weight. */
+"menuBar.composer.field.weight" = "字重";
+
+/* Quota metric: whichever percentage the app-wide Used/Remaining setting selects. */
+"menuBar.composer.metric.displayPercent" = "百分比（跟随设置）";
+
+/* Quota metric: the projected figure when the quota refills. */
+"menuBar.composer.metric.forecastPercent" = "重置时预测";
+
+/* Quota metric: the quota's own name. */
+"menuBar.composer.metric.label" = "名称";
+
+/* Quota metric: distance from the linear expectation. */
+"menuBar.composer.metric.pace" = "消耗速度";
+
+/* Quota metric: the remaining percentage. */
+"menuBar.composer.metric.remainingPercent" = "剩余百分比";
+
+/* Quota metric: the wall-clock time of the refill. */
+"menuBar.composer.metric.resetAt" = "重置时刻";
+
+/* Quota metric: countdown to the refill. */
+"menuBar.composer.metric.resetsIn" = "重置倒计时";
+
+/* Quota metric: countdown to projected exhaustion. */
+"menuBar.composer.metric.runsOutIn" = "耗尽倒计时";
+
+/* Quota metric: the used percentage. */
+"menuBar.composer.metric.usedPercent" = "已用百分比";
+
+/* Segment: the strip the user assembles out of blocks. */
+"menuBar.composer.mode.custom" = "自定义";
+
+/* Caption under the mode picker while Custom is selected; reassures that switching back is not destructive. */
+"menuBar.composer.mode.customCaption" = "切回默认样式会保留已拼装的全部积木，再次切换到自定义时可原样恢复。";
+
+/* Segment: the field-list strip the app has always drawn. */
+"menuBar.composer.mode.default" = "默认";
+
+/* Caption under the mode picker while Default is selected. */
+"menuBar.composer.mode.defaultCaption" = "默认样式显示下方勾选的字段。自定义样式可用积木自行拼装：logo、文字与任意额度。";
+
+/* Segmented control choosing how the menu-bar strip is built. */
+"menuBar.composer.mode.label" = "样式";
+
+/* Tooltip on the New row palette button once both rows are used. */
+"menuBar.composer.newRow.capped" = "菜单栏最多显示两行。";
+
+/* What a new-row block does, and that it accepts a rule. */
+"menuBar.composer.newRow.detail" = "结束第一行并开始第二行。可在下方设置条件，仅在该额度满足条件时换行。";
+
+/* Tooltip on the New row palette button when a second row is still available. */
+"menuBar.composer.newRow.help" = "将菜单栏内容拆成第二行。";
+
+/* Caption over the list of blocks that can be added. */
+"menuBar.composer.palette" = "添加积木";
+
+/* Caption over the live preview of the composed strip. */
+"menuBar.composer.preview" = "预览";
+
+/* Accessibility label for the dark-background preview. */
+"menuBar.composer.preview.dark" = "深色菜单栏预览";
+
+/* Accessibility label for a preview with nothing to draw. */
+"menuBar.composer.preview.empty" = "空样式";
+
+/* Explains why the preview is shown twice. */
+"menuBar.composer.preview.grounds" = "并排显示浅色与深色菜单栏：固定颜色在一种底色下清晰，在另一种下可能不可见。";
+
+/* Accessibility label for the light-background preview. */
+"menuBar.composer.preview.light" = "浅色菜单栏预览";
+
+/* Explains that a two-row strip is scaled to fit the menu bar's height. */
+"menuBar.composer.preview.twoRowScaling" = "两行共用菜单栏高度，较大字号会等比缩小以适应，预览同步缩放。";
+
+/* Drop target that deletes the dragged block. */
+"menuBar.composer.removeTarget" = "拖到此处移除";
+
+/* Visibility rule: the block is always shown. */
+"menuBar.composer.rule.always" = "始终显示";
+
+/* Visibility rule: show only for chosen forecast verdicts. */
+"menuBar.composer.rule.whenForecast" = "当预测结论为";
+
+/* Visibility rule: show once a quota's remaining percentage falls to a threshold. */
+"menuBar.composer.rule.whenRemainingAtMost" = "剩余不高于";
+
+/* Visibility rule: show once a quota's used percentage reaches a threshold. */
+"menuBar.composer.rule.whenUsedAtLeast" = "已用不低于";
+
+/* Caption over the controls for the selected block. */
+"menuBar.composer.selected" = "已选积木";
+
+/* Type size choice. */
+"menuBar.composer.size.large" = "大";
+
+/* Type size choice. */
+"menuBar.composer.size.regular" = "标准";
+
+/* Type size choice. */
+"menuBar.composer.size.small" = "小";
+
+/* What a space block does. */
+"menuBar.composer.space.detail" = "宽度为一个空格的间隔。字号决定其宽度。";
+
+/* Button rebuilding every block from the default strip. */
+"menuBar.composer.startOver" = "从当前样式重新开始…";
+
+/* Destructive button in the confirmation dialog. */
+"menuBar.composer.startOver.confirm" = "重新开始";
+
+/* Body of the confirmation dialog. */
+"menuBar.composer.startOver.confirmMessage" = "已排列的全部积木将被丢弃，并按默认样式重新生成。";
+
+/* Title of the confirmation dialog. */
+"menuBar.composer.startOver.confirmTitle" = "替换已有积木？";
+
+/* Warns that starting over cannot be undone. */
+"menuBar.composer.startOver.detail" = "重新开始会用默认样式重新生成全部积木，且无法撤销。";
+
+/* Picker choosing a starting set of spacing and type sizes. */
+"menuBar.composer.template" = "模板";
+
+/* Template name. */
+"menuBar.composer.template.compact" = "紧凑";
+
+/* What the Compact template does. */
+"menuBar.composer.template.compactDetail" = "间距更紧，字号略小。";
+
+/* Template name. */
+"menuBar.composer.template.roomy" = "宽松";
+
+/* What the Roomy template does. */
+"menuBar.composer.template.roomyDetail" = "保持当前字号，积木之间留白更多。";
+
+/* Template name: two stacked rows. */
+"menuBar.composer.template.twoRows" = "两行";
+
+/* What the Two rows template does. */
+"menuBar.composer.template.twoRowsDetail" = "在一个状态项中上下显示两行。";
+
+/* Explains that long text is cut short in the bar. Count is the character ceiling. */
+"menuBar.composer.text.limit" = "超过 %1$lld 个字符的文字积木在菜单栏中会截断并以省略号结尾。";
+
+/* Starting content of a newly added text block, before the user types over it. */
+"menuBar.composer.text.placeholder" = "标签";
+
+/* Shown on a block whose colour or rule points at a quota that is not being returned. */
+"menuBar.composer.warning.degraded" = "此积木仍会显示，但其颜色或显示条件指向的额度当前未返回数据。";
+
+/* Lists the quotas that are not answering. Fields is a comma-separated list of quota names. */
+"menuBar.composer.warning.missing" = "当前未返回数据：%1$@";
+
+/* Shown on a block whose quota is not being returned. */
+"menuBar.composer.warning.silent" = "该额度当前未返回数据，此积木暂不显示内容。积木会保留，数据恢复后自动显示。";
+
+/* Type weight choice. */
+"menuBar.composer.weight.medium" = "中等";
+
+/* Type weight choice. */
+"menuBar.composer.weight.regular" = "常规";
+
+/* Type weight choice. */
+"menuBar.composer.weight.semibold" = "半粗";
+
+/* One quota's projection spoken aloud. */
+"menuBar.spoken.forecast" = "%1$@ 预测重置时剩余 %2$@";
+
+/* One quota's pace spoken aloud; value is a signed percentage. */
+"menuBar.spoken.pace" = "%1$@ 消耗速度 %2$@";
+
+/* One quota spoken aloud, remaining rather than used. */
+"menuBar.spoken.remaining" = "%1$@ 剩余 %2$@";
+
+/* One quota's refill time spoken aloud. */
+"menuBar.spoken.resetAt" = "%1$@ 于 %2$@ 重置";
+
+/* One quota's refill countdown spoken aloud. */
+"menuBar.spoken.resetsIn" = "%1$@ 距重置 %2$@";
+
+/* One quota's exhaustion countdown spoken aloud. */
+"menuBar.spoken.runsOutIn" = "%1$@ 距耗尽 %2$@";
+
+/* Accessibility label for the status item when nothing is being shown. Kind names the item. */
+"menuBar.spoken.title" = "%1$@ 额度";
+
+/* Accessibility label and tooltip for the status item. Body lists each quota in words. */
+"menuBar.spoken.titleBody" = "%1$@ 额度：%2$@";
+
+/* One quota spoken aloud. Label is the quota's name, value an already-formatted percentage. */
+"menuBar.spoken.used" = "%1$@ 已用 %2$@";
+
 /* Button that folds a provider's credential form away */
 "onboarding.apiKeys.hide" = "收起";
 

--- a/Sources/VibeBarCore/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/VibeBarCore/Resources/zh-Hans.lproj/Localizable.strings
@@ -644,6 +644,9 @@
 /* What the Two rows template does. */
 "menuBar.composer.template.twoRowsDetail" = "在一个状态项中上下显示两行。";
 
+/* Shown under the text field when the selected text block has nothing in it. */
+"menuBar.composer.text.empty" = "空的文字积木不显示任何内容。输入文字后才会出现在菜单栏。";
+
 /* Explains that long text is cut short in the bar. Count is the character ceiling. */
 "menuBar.composer.text.limit" = "超过 %1$lld 个字符的文字积木在菜单栏中会截断并以省略号结尾。";
 

--- a/Sources/VibeBarCore/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/VibeBarCore/Resources/zh-Hans.lproj/Localizable.strings
@@ -639,7 +639,7 @@
 "menuBar.composer.template.roomy" = "宽松";
 
 /* What the Roomy template does. */
-"menuBar.composer.template.roomyDetail" = "保持当前字号，积木之间留白更多。";
+"menuBar.composer.template.roomyDetail" = "菜单栏的常规字号。";
 
 /* Template name: two stacked rows. */
 "menuBar.composer.template.twoRows" = "两行";

--- a/Sources/VibeBarCore/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/VibeBarCore/Resources/zh-Hans.lproj/Localizable.strings
@@ -446,6 +446,9 @@
 /* A block showing words the user typed. */
 "menuBar.composer.block.text" = "文字";
 
+/* Chip label for a block written by a newer version of the app that this one cannot draw. */
+"menuBar.composer.block.unsupported" = "来自更新版本";
+
 /* Caption over the reorderable list of blocks. */
 "menuBar.composer.blocks" = "积木 · 拖动可重新排序";
 
@@ -652,6 +655,9 @@
 
 /* Starting content of a newly added text block, before the user types over it. */
 "menuBar.composer.text.placeholder" = "标签";
+
+/* Explains an unsupported block: it is kept so an upgrade restores it, and only removal applies. */
+"menuBar.composer.unsupported.detail" = "此积木由更新版本的 Vibe Bar 创建，将原样保留，更新后可恢复显示；在此之前不显示任何内容。";
 
 /* Shown on a block whose colour or rule points at a quota that is not being returned. */
 "menuBar.composer.warning.degraded" = "此积木仍会显示，但其颜色或显示条件指向的额度当前未返回数据。";

--- a/Sources/VibeBarCore/Services/QuotaPaceForecast.swift
+++ b/Sources/VibeBarCore/Services/QuotaPaceForecast.swift
@@ -17,6 +17,20 @@ public struct QuotaPaceForecast: Sendable, Equatable {
         case watch
         case atRisk
         case learning
+
+        /// The verdict in words. On the enum rather than on the forecast so a
+        /// surface that only has a verdict in hand — the menu-bar composer's
+        /// visibility rule, say — reads the same key the quota bar does
+        /// instead of spelling the five words again.
+        public var label: String {
+            switch self {
+            case .enough: L10n.Quota.forecastVerdictEnough
+            case .surplus: L10n.Quota.forecastVerdictSurplus
+            case .watch: L10n.Quota.forecastVerdictWatch
+            case .atRisk: L10n.Quota.forecastVerdictAtRisk
+            case .learning: L10n.Quota.forecastVerdictLearning
+            }
+        }
     }
 
     public enum Confidence: String, Sendable, Equatable {
@@ -74,15 +88,7 @@ public struct QuotaPaceForecast: Sendable, Equatable {
         max(0, projectedRemainingPercent - targetRemainingPercent)
     }
 
-    public var verdictLabel: String {
-        switch verdict {
-        case .enough: L10n.Quota.forecastVerdictEnough
-        case .surplus: L10n.Quota.forecastVerdictSurplus
-        case .watch: L10n.Quota.forecastVerdictWatch
-        case .atRisk: L10n.Quota.forecastVerdictAtRisk
-        case .learning: L10n.Quota.forecastVerdictLearning
-        }
-    }
+    public var verdictLabel: String { verdict.label }
 
     public var confidenceLabel: String {
         switch confidence {

--- a/Sources/VibeBarCore/Services/UsagePace.swift
+++ b/Sources/VibeBarCore/Services/UsagePace.swift
@@ -68,8 +68,28 @@ public struct UsagePace: Sendable, Equatable {
         now: Date = Date(),
         allowsPostResetGrace: Bool = false
     ) -> UsagePace? {
-        guard let resetsAt = bucket.resetAt else { return nil }
-        guard let windowSeconds = bucket.rawWindowSeconds, windowSeconds > 0 else { return nil }
+        compute(
+            usedPercent: bucket.usedPercent,
+            resetAt: bucket.resetAt,
+            rawWindowSeconds: bucket.rawWindowSeconds,
+            now: now,
+            allowsPostResetGrace: allowsPostResetGrace
+        )
+    }
+
+    /// Value-typed twin, for callers that hold a bucket's numbers rather than
+    /// the bucket — the menu-bar strip computes pace at draw time, from a
+    /// snapshot, so the figure advances with the clock instead of being frozen
+    /// at the moment the snapshot was resolved.
+    public static func compute(
+        usedPercent: Double,
+        resetAt: Date?,
+        rawWindowSeconds: Int?,
+        now: Date = Date(),
+        allowsPostResetGrace: Bool = false
+    ) -> UsagePace? {
+        guard let resetsAt = resetAt else { return nil }
+        guard let windowSeconds = rawWindowSeconds, windowSeconds > 0 else { return nil }
         guard let evaluationDate = QuotaWindowEvaluation.date(
             resetAt: resetsAt,
             now: now,
@@ -83,7 +103,7 @@ public struct UsagePace: Sendable, Equatable {
 
         let elapsed = clamp(duration - timeUntilReset, lower: 0, upper: duration)
         let expected = clamp((elapsed / duration) * 100, lower: 0, upper: 100)
-        let actual = clamp(bucket.usedPercent, lower: 0, upper: 100)
+        let actual = clamp(usedPercent, lower: 0, upper: 100)
 
         // Edge case: zero elapsed but non-zero usage means a fresh window with backfilled state — bail out.
         if elapsed == 0, actual > 0 { return nil }

--- a/Sources/VibeBarCore/Utilities/JSONValue.swift
+++ b/Sources/VibeBarCore/Utilities/JSONValue.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+/// Any JSON value, decoded and re-encoded unchanged.
+///
+/// It exists so a persisted structure can carry something this build does not
+/// understand instead of deleting it. A settings file is shared between app
+/// versions: run a newer build, add a block it introduced, go back to an older
+/// one, and the older one has to hand that block back untouched when it saves.
+/// Dropping it looks harmless in the decoder and is permanent on disk.
+///
+/// Numbers round-trip as `Double`, so a JSON integer comes back as an
+/// equivalent number rather than the identical spelling — semantic fidelity,
+/// not byte fidelity, which is what a consumer of the value needs.
+public enum JSONValue: Codable, Hashable, Sendable {
+    case null
+    case bool(Bool)
+    case number(Double)
+    case string(String)
+    case array([JSONValue])
+    case object([String: JSONValue])
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if container.decodeNil() {
+            self = .null
+        } else if let value = try? container.decode(Bool.self) {
+            self = .bool(value)
+        } else if let value = try? container.decode(Double.self) {
+            self = .number(value)
+        } else if let value = try? container.decode(String.self) {
+            self = .string(value)
+        } else if let value = try? container.decode([JSONValue].self) {
+            self = .array(value)
+        } else if let value = try? container.decode([String: JSONValue].self) {
+            self = .object(value)
+        } else {
+            throw DecodingError.dataCorruptedError(
+                in: container,
+                debugDescription: "not a JSON value"
+            )
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .null: try container.encodeNil()
+        case let .bool(value): try container.encode(value)
+        case let .number(value): try container.encode(value)
+        case let .string(value): try container.encode(value)
+        case let .array(value): try container.encode(value)
+        case let .object(value): try container.encode(value)
+        }
+    }
+}

--- a/Sources/VibeBarCore/Utilities/PendingEditQueue.swift
+++ b/Sources/VibeBarCore/Utilities/PendingEditQueue.swift
@@ -65,4 +65,11 @@ public final class PendingEditQueue: ObservableObject {
     /// Keys still waiting, oldest first. The test seam; nothing in the app
     /// reads it.
     public var pendingKeys: [String] { entries.map(\.key) }
+
+    deinit {
+        // Nothing queued survives the queue. A torn-down editor must not leave
+        // a timer running, and a finished test must not leave one for the next
+        // one to trip over.
+        task?.cancel()
+    }
 }

--- a/Sources/VibeBarCore/Utilities/PendingEditQueue.swift
+++ b/Sources/VibeBarCore/Utilities/PendingEditQueue.swift
@@ -1,0 +1,68 @@
+import Foundation
+
+/// Debounced settings writes that cannot displace each other.
+///
+/// A control that writes on every keystroke, drag frame or stepper repeat
+/// fans a settings publication out to every subscriber each time, so each one
+/// holds its last change back for a moment. That moment has to be owned by
+/// something longer-lived than the control — an inspector row is torn down the
+/// instant another block is selected — and it has to be owned *per control*.
+///
+/// The per-control part is the lesson. A single pending slot looks sufficient
+/// until two debounced controls are edited inside one window, at which point
+/// the second `schedule` silently drops the first one's closure and the user's
+/// change is gone. Keying the queue makes that unrepresentable rather than a
+/// rule every future call site has to remember.
+///
+/// Entries are written in the order they were queued. That ordering is not
+/// load-bearing — each queued write touches only the field its own control
+/// owns — but it is deterministic, which matters when reading a diff.
+@MainActor
+public final class PendingEditQueue: ObservableObject {
+    private struct Entry {
+        let key: String
+        let commit: () -> Void
+    }
+
+    private var entries: [Entry] = []
+    private var task: Task<Void, Never>?
+    private let delay: Duration
+
+    public init(delay: Duration = .milliseconds(250)) {
+        self.delay = delay
+    }
+
+    /// Queue `commit` under `key`, replacing only what that same key had
+    /// queued. While the user is still moving one control, only its newest
+    /// value matters; a different control's pending write is untouched.
+    public func schedule(_ key: String, _ commit: @escaping () -> Void) {
+        if let index = entries.firstIndex(where: { $0.key == key }) {
+            entries[index] = Entry(key: key, commit: commit)
+        } else {
+            entries.append(Entry(key: key, commit: commit))
+        }
+        task?.cancel()
+        task = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: delay)
+            guard !Task.isCancelled else { return }
+            self?.flush()
+        }
+    }
+
+    /// Write everything queued, now.
+    ///
+    /// Safe when nothing is queued, and safe to re-enter: the queue is emptied
+    /// before any of it runs, so a flush triggered from inside a commit finds
+    /// nothing left to do rather than recursing.
+    public func flush() {
+        task?.cancel()
+        task = nil
+        let due = entries
+        entries = []
+        for entry in due { entry.commit() }
+    }
+
+    /// Keys still waiting, oldest first. The test seam; nothing in the app
+    /// reads it.
+    public var pendingKeys: [String] { entries.map(\.key) }
+}

--- a/Tests/VibeBarCoreTests/MenuBarCompositionTests.swift
+++ b/Tests/VibeBarCoreTests/MenuBarCompositionTests.swift
@@ -980,6 +980,126 @@ final class MenuBarCompositionTests: XCTestCase {
         )
     }
 
+    // MARK: - Drag commits once (review thread 1)
+
+    func testADragCrossingSeveralChipsLandsWhereOneMoveWould() {
+        // The editor keeps the provisional order in local state and writes it
+        // once on drop. That is only safe if replaying every crossing on a
+        // scratch copy ends where a single move would have — otherwise the one
+        // committed write would not be the arrangement the user watched.
+        let base = composition([
+            MenuBarToken(kind: .text("a")),
+            MenuBarToken(kind: .text("b")),
+            MenuBarToken(kind: .text("c")),
+            MenuBarToken(kind: .text("d"))
+        ])
+        let ids = base.tokens.map(\.id)
+
+        var provisional = base
+        // One drag of "a" that crosses b, then c, then d.
+        provisional.move(ids[0], before: ids[1])
+        provisional.move(ids[0], before: ids[2])
+        provisional.move(ids[0], before: ids[3])
+
+        var single = base
+        single.move(ids[0], to: 2)
+
+        XCTAssertEqual(provisional.tokens.map(\.kind), single.tokens.map(\.kind))
+        XCTAssertEqual(
+            provisional.tokens.map(\.kind),
+            [.text("b"), .text("c"), .text("a"), .text("d")]
+        )
+        // The committed value is the provisional one — one assignment, not one
+        // per crossing.
+        var committed = base
+        committed.tokens = provisional.tokens
+        XCTAssertEqual(committed.tokens.map(\.id), provisional.tokens.map(\.id))
+        // ...and the source of truth was never touched while the drag ran.
+        XCTAssertEqual(base.tokens.map(\.kind), [.text("a"), .text("b"), .text("c"), .text("d")])
+    }
+
+    func testAnAbandonedDragLeavesTheCommittedOrderAlone() {
+        let base = composition([
+            MenuBarToken(kind: .text("a")),
+            MenuBarToken(kind: .text("b")),
+            MenuBarToken(kind: .text("c"))
+        ])
+        var provisional = base
+        // Drag "c" to the front, then walk away without dropping.
+        provisional.move(base.tokens[2].id, before: base.tokens[0].id)
+        XCTAssertEqual(
+            provisional.tokens.map(\.kind),
+            [.text("c"), .text("a"), .text("b")]
+        )
+        XCTAssertNotEqual(provisional.tokens.map(\.kind), base.tokens.map(\.kind))
+        // Dropping the scratch copy is the whole rollback.
+        XCTAssertEqual(base.tokens.map(\.kind), [.text("a"), .text("b"), .text("c")])
+    }
+
+    // MARK: - Requirement-aware preview cache (review thread 2)
+
+    func testSwappingAMetricChangesTheRequirementsThoughTheFieldSetDoesNot() {
+        let percent = composition([
+            MenuBarToken(kind: .quota(fieldId: "claude.weekly", metric: .displayPercent))
+        ])
+        let pace = composition([
+            MenuBarToken(kind: .quota(fieldId: "claude.weekly", metric: .pace))
+        ])
+        // The field set is identical, which is why keying a cache on it missed
+        // the edit and left the preview showing nothing for the block.
+        XCTAssertEqual(percent.referencedFieldIds, pace.referencedFieldIds)
+        XCTAssertNotEqual(percent.quotaRequirements, pace.quotaRequirements)
+        XCTAssertEqual(pace.quotaRequirements[0].needsPace, true)
+        XCTAssertEqual(percent.quotaRequirements[0].needsPace, false)
+
+        // Same for a metric that starts needing a forecast.
+        let runsOut = composition([
+            MenuBarToken(kind: .quota(fieldId: "claude.weekly", metric: .runsOutIn))
+        ])
+        XCTAssertEqual(percent.referencedFieldIds, runsOut.referencedFieldIds)
+        XCTAssertNotEqual(percent.quotaRequirements, runsOut.quotaRequirements)
+    }
+
+    func testAPaceBlockRendersAsSoonAsItsSnapshotCarriesPace() {
+        // What the stale cache produced: a snapshot resolved for a percentage
+        // block has no pace, so the pace block draws nothing.
+        let stale = quota("claude.weekly", label: "Weekly", used: 50, pace: nil)
+        let fresh = quota("claude.weekly", label: "Weekly", used: 50, pace: 12)
+        let tokens = [MenuBarToken(kind: .quota(fieldId: "claude.weekly", metric: .pace))]
+        XCTAssertTrue(plan(tokens, quotas: [stale]).isEmpty)
+        XCTAssertEqual(texts(plan(tokens, quotas: [fresh])), [["+12%"]])
+    }
+
+    // MARK: - Two-row run gap (review thread 3)
+
+    func testComposedRunsAddNoGapWhileTheBuiltInLayoutStillDoes() {
+        let runs = [10.0, 8.0, 12.0]
+        // A composed row carries the user's configured spacing inside its own
+        // text runs, so the cell adds nothing between them: zero spacing has
+        // to mean zero.
+        XCTAssertEqual(
+            MenuBarStripGeometry.cellWidth(runWidths: runs, gap: 0),
+            30,
+            accuracy: 1e-9
+        )
+        // The built-in two-row layout draws a leading logo and still gets its
+        // fixed gap after it.
+        XCTAssertEqual(
+            MenuBarStripGeometry.cellWidth(runWidths: [8, 20], gap: 2),
+            30,
+            accuracy: 1e-9
+        )
+        // Non-zero spacing is applied once per boundary, never doubled.
+        XCTAssertEqual(
+            MenuBarStripGeometry.cellWidth(runWidths: runs, gap: 3),
+            36,
+            accuracy: 1e-9
+        )
+        // Degenerate shapes stay sane.
+        XCTAssertEqual(MenuBarStripGeometry.cellWidth(runWidths: [], gap: 5), 0)
+        XCTAssertEqual(MenuBarStripGeometry.cellWidth(runWidths: [7], gap: 5), 7)
+    }
+
     // MARK: - Persistence
 
     func testCompositionRoundTripsThroughTheSettingsFile() throws {

--- a/Tests/VibeBarCoreTests/MenuBarCompositionTests.swift
+++ b/Tests/VibeBarCoreTests/MenuBarCompositionTests.swift
@@ -977,52 +977,100 @@ final class MenuBarCompositionTests: XCTestCase {
         XCTAssertEqual(MenuBarStripFit.scale(contentHeight: 20, availableHeight: 0), 1)
     }
 
-    func testTwoLargeRowsAtTheTopScaleAreShrunkToFitRatherThanCropped() {
-        // The extreme the editor can actually produce: the composition's top
-        // font scale (1.6) times the `.large` step (1.2) on the 9pt two-row
-        // face, two rows tucked by the -2pt line spacing, in the ~18pt of
-        // canvas the status bar leaves after padding.
-        let composed = MenuBarComposition(
-            isEnabled: true,
-            template: .twoColumn,
-            tokens: [
-                MenuBarToken(kind: .text("top"), style: .init(size: .large)),
-                MenuBarToken(kind: .lineBreak),
-                MenuBarToken(kind: .text("bottom"), style: .init(size: .large))
-            ],
-            fontScale: 1.6
-        )
-        let rendered = composed.plan(
-            quotas: [], displayMode: .used, colorBasis: .actual, now: reference
-        )
-        let tokenScale = rendered.rows[0].tokens[0].fontScale
-        XCTAssertEqual(tokenScale, 1.6 * 1.2, accuracy: 1e-9)
+    func testEverySupportedTwoRowCombinationFitsTheCanvas() {
+        // The property, not a constant. The previous test asserted the content
+        // fit *or* the floor had bitten, which is a tautology — and it passed
+        // while the rows stayed cropped. At the top composition scale with two
+        // Large blocks the content is ~39.5pt for 18pt of canvas, needing
+        // ~0.46; the old 0.55 floor left ~21.7pt for the canvas cap to crop.
+        let available = MenuBarStripGeometry.nominalTwoRowAvailableHeight
+        let base = MenuBarStripGeometry.nominalTwoRowFontSize
+        let scales = [
+            MenuBarComposition.fontScaleRange.lowerBound,
+            1.0,
+            1.3,
+            MenuBarComposition.fontScaleRange.upperBound
+        ]
+        for compositionScale in scales {
+            for first in MenuBarToken.SizeStep.allCases {
+                for second in MenuBarToken.SizeStep.allCases {
+                    let rows = [first, second].map {
+                        base * compositionScale * $0.multiplier
+                    }
+                    let content = MenuBarStripGeometry.twoRowContentHeight(
+                        rowFontSizes: rows,
+                        lineSpacing: MenuBarStripGeometry.nominalTwoRowLineSpacing,
+                        lineHeightRatio: MenuBarStripGeometry.nominalLineHeightRatio
+                    )
+                    let fit = MenuBarStripFit.scale(
+                        contentHeight: content,
+                        availableHeight: available
+                    )
+                    let label = "scale \(compositionScale), \(first)/\(second)"
 
-        // Text is roughly 1.2x its point size tall, which is what makes two
-        // enlarged rows overflow.
-        let rowHeight = 9.0 * tokenScale * 1.2
-        let contentHeight = rowHeight * 2 - 2
-        let available = 18.0
-        XCTAssertGreaterThan(contentHeight, available, "the extreme must actually overflow")
-
-        let fit = MenuBarStripFit.scale(contentHeight: contentHeight, availableHeight: available)
-        XCTAssertLessThan(fit, 1)
-        XCTAssertGreaterThanOrEqual(fit, MenuBarStripFit.minimumScale)
-        // Shrinking by the returned factor brings it inside the canvas — or,
-        // when the floor bites, at least stops it growing.
-        XCTAssertLessThanOrEqual(
-            contentHeight * fit,
-            max(available, contentHeight * MenuBarStripFit.minimumScale) + 1e-9
-        )
+                    // 1. It fits, so nothing is left for the canvas cap to crop.
+                    XCTAssertLessThanOrEqual(
+                        content * fit, available + 1e-9,
+                        "does not fit at \(label)"
+                    )
+                    // 2. Fitting never turns legible type into a smudge —
+                    //    what the floor was reaching for, and got wrong by
+                    //    applying it inside the arithmetic instead of asking
+                    //    about the result. A face that was already tiny
+                    //    because someone hand-edited `fontScale` down is their
+                    //    choice, not something fitting did to them.
+                    for row in rows where row >= MenuBarStripFit.legibleFontSize {
+                        XCTAssertGreaterThanOrEqual(
+                            row * fit, MenuBarStripFit.legibleFontSize,
+                            "fitting made it illegible at \(label)"
+                        )
+                    }
+                }
+            }
+        }
     }
 
-    func testTheShrinkFloorKeepsTypeLegible() {
-        // An absurd overflow is clamped rather than reduced to a smudge.
-        XCTAssertEqual(
-            MenuBarStripFit.scale(contentHeight: 400, availableHeight: 18),
-            MenuBarStripFit.minimumScale,
-            accuracy: 1e-9
+    func testTheWorstSupportedCombinationReallyDoesOverflow() {
+        // Guards the test above from passing because nothing overflows.
+        let base = MenuBarStripGeometry.nominalTwoRowFontSize
+        let worst = base * MenuBarComposition.fontScaleRange.upperBound
+            * MenuBarToken.SizeStep.large.multiplier
+        let content = MenuBarStripGeometry.twoRowContentHeight(
+            rowFontSizes: [worst, worst],
+            lineSpacing: MenuBarStripGeometry.nominalTwoRowLineSpacing,
+            lineHeightRatio: MenuBarStripGeometry.nominalLineHeightRatio
         )
+        XCTAssertGreaterThan(content, MenuBarStripGeometry.nominalTwoRowAvailableHeight)
+    }
+
+    func testEveryConfigurationTheEditorCanProduceIsLegible() {
+        // What the UI can actually reach: the template defaults, which no
+        // control overrides, times the three size steps.
+        for template in MenuBarComposition.Template.allCases {
+            for step in MenuBarToken.SizeStep.allCases {
+                let row = MenuBarStripGeometry.nominalTwoRowFontSize
+                    * template.fontScale * step.multiplier
+                let content = MenuBarStripGeometry.twoRowContentHeight(
+                    rowFontSizes: [row, row],
+                    lineSpacing: MenuBarStripGeometry.nominalTwoRowLineSpacing,
+                    lineHeightRatio: MenuBarStripGeometry.nominalLineHeightRatio
+                )
+                let fit = MenuBarStripFit.scale(
+                    contentHeight: content,
+                    availableHeight: MenuBarStripGeometry.nominalTwoRowAvailableHeight
+                )
+                XCTAssertGreaterThanOrEqual(
+                    row * fit, MenuBarStripFit.legibleFontSize,
+                    "\(template)/\(step)"
+                )
+            }
+        }
+    }
+
+    func testAStripThatFitsIsNotScaledAtAll() {
+        XCTAssertEqual(MenuBarStripFit.scale(contentHeight: 16, availableHeight: 18), 1)
+        XCTAssertEqual(MenuBarStripFit.scale(contentHeight: 18, availableHeight: 18), 1)
+        XCTAssertEqual(MenuBarStripFit.scale(contentHeight: 0, availableHeight: 18), 1)
     }
 
     // MARK: - Drag commits once (review thread 1)
@@ -2014,6 +2062,167 @@ final class MenuBarCompositionTests: XCTestCase {
         XCTAssertTrue(rendered.spokenDescription.isEmpty)
     }
 
+    // MARK: - A downgrade must not delete blocks (review thread 12)
+
+    /// A token as a newer build might have written it.
+    private func tokenJSON(
+        id: String = "11111111-1111-1111-1111-111111111111",
+        kind: String = #"{"type":"text","text":"keep"}"#,
+        size: String = #""regular""#,
+        weight: String = #""medium""#,
+        color: String = #"{"type":"tertiary"}"#,
+        monospacedDigits: Bool = true
+    ) -> String {
+        """
+        {"id":"\(id)","kind":\(kind),
+         "style":{"color":\(color),"size":\(size),"weight":\(weight),
+                  "monospacedDigits":\(monospacedDigits)},
+         "visibility":{"type":"always"}}
+        """
+    }
+
+    private func decodeComposition(tokens: [String]) throws -> MenuBarComposition {
+        let json = #"{"isEnabled":true,"template":"roomy","tokens":["#
+            + tokens.joined(separator: ",") + "]}"
+        return try JSONDecoder().decode(MenuBarComposition.self, from: Data(json.utf8))
+    }
+
+    func testAnUnknownSizeOrWeightKeepsTheBlock() throws {
+        // The named bug: the synthesized `Style` decoder threw on a value a
+        // newer build wrote, `LossyMenuBarToken` turned that into a dropped
+        // block, and the next save wrote the deletion to disk.
+        let composed = try decodeComposition(tokens: [
+            tokenJSON(size: #""colossal""#),
+            tokenJSON(id: "22222222-2222-2222-2222-222222222222", weight: #""ultrablack""#)
+        ])
+        XCTAssertEqual(composed.tokens.count, 2, "neither block may be dropped")
+        XCTAssertEqual(composed.tokens[0].kind, .text("keep"))
+        XCTAssertEqual(composed.tokens[1].kind, .text("keep"))
+        // Only the attribute this build cannot read falls back. Catching the
+        // failure a level up would keep the block but reset its whole style,
+        // silently discarding the colour and weight the user chose.
+        XCTAssertEqual(composed.tokens[0].style.size, .regular, "the unreadable one")
+        XCTAssertEqual(composed.tokens[0].style.weight, .medium, "kept as written")
+        XCTAssertEqual(composed.tokens[0].style.color, .tertiary, "kept as written")
+        XCTAssertTrue(composed.tokens[0].style.monospacedDigits, "kept as written")
+        XCTAssertEqual(composed.tokens[1].style.weight, .medium, "the unreadable one")
+        XCTAssertEqual(composed.tokens[1].style.color, .tertiary, "kept as written")
+        XCTAssertEqual(composed.tokens[1].style.size, .regular)
+    }
+
+    func testAnUnknownBlockKindIsKeptVerbatimRatherThanDeleted() throws {
+        let composed = try decodeComposition(tokens: [
+            tokenJSON(),
+            tokenJSON(
+                id: "33333333-3333-3333-3333-333333333333",
+                kind: #"{"type":"sparkline","fieldId":"claude.weekly","window":"7d"}"#
+            )
+        ])
+        XCTAssertEqual(composed.tokens.count, 2)
+        guard case .unsupported = composed.tokens[1].kind else {
+            return XCTFail("expected the unknown block to be preserved")
+        }
+        // Draws nothing, says nothing...
+        let rendered = composed.plan(
+            quotas: [], displayMode: .used, colorBasis: .actual, now: reference
+        )
+        XCTAssertEqual(texts(rendered), [["keep"]])
+        XCTAssertEqual(rendered.spokenDescription, "keep")
+
+        // ...and goes back out unchanged, so a newer build finds it again.
+        let reencoded = try JSONEncoder().encode(composed)
+        let raw = try JSONSerialization.jsonObject(with: reencoded) as? [String: Any]
+        let rawTokens = raw?["tokens"] as? [[String: Any]]
+        let preserved = (rawTokens?[1]["kind"] as? [String: Any]) ?? [:]
+        XCTAssertEqual(preserved["type"] as? String, "sparkline")
+        XCTAssertEqual(preserved["fieldId"] as? String, "claude.weekly")
+        XCTAssertEqual(preserved["window"] as? String, "7d")
+    }
+
+    func testAProviderThisBuildDoesNotKnowKeepsItsBlock() throws {
+        // The realistic instance: a logo naming a provider added after this
+        // version shipped. `ToolType` gains cases regularly.
+        let composed = try decodeComposition(tokens: [
+            tokenJSON(kind: #"{"type":"logo","tool":"someFutureProvider"}"#)
+        ])
+        XCTAssertEqual(composed.tokens.count, 1)
+        guard case .unsupported = composed.tokens[0].kind else {
+            return XCTFail("expected the block to be preserved")
+        }
+    }
+
+    func testAnUnknownLayoutKeepsTheWholeMenuBarItem() throws {
+        // Worse than the named bug, found by applying the same lens: an
+        // unreadable `layout` threw, `LossyMenuBarItem` dropped the item, and
+        // the field selection, every rename, every per-field style and the
+        // composed strip went with it.
+        let json = """
+        {"kind":"compact","isVisible":true,"showTitle":false,"layout":"notchIsland",
+         "selectedFieldIds":["claude.five_hour"],"customLabels":{"claude.five_hour":"C5"},
+         "fieldStyles":{"claude.five_hour":"logoAndPercent"},"mergesGroupWindows":true}
+        """
+        let item = try JSONDecoder().decode(MenuBarItemSettings.self, from: Data(json.utf8))
+        XCTAssertEqual(item.selectedFieldIds, ["claude.five_hour"])
+        XCTAssertEqual(item.customLabels, ["claude.five_hour": "C5"])
+        XCTAssertEqual(item.style(for: "claude.five_hour"), .logoAndPercent)
+        XCTAssertTrue(item.mergesGroupWindows)
+        XCTAssertEqual(item.layout, .iconOnly, "only the unreadable enum falls back")
+    }
+
+    func testAMalformedScalarKeepsTheStrip() throws {
+        // One bad number used to throw out of the composition decoder, which
+        // the item catches into `composition = nil` — every block gone.
+        let json = #"{"isEnabled":true,"template":"roomy","fontScale":"wide","tokens":["#
+            + tokenJSON() + "]}"
+        let composed = try JSONDecoder().decode(MenuBarComposition.self, from: Data(json.utf8))
+        XCTAssertEqual(composed.tokens.count, 1)
+        XCTAssertNil(composed.fontScale)
+        XCTAssertEqual(composed.effectiveFontScale, MenuBarComposition.Template.roomy.fontScale)
+    }
+
+    func testOneUnreadableRegistryEntryDoesNotDiscardTheRest() throws {
+        // `QuotaService` loads this with `try? … ?? .empty`, so a decoder that
+        // threw on one row silently emptied the whole registry — and the next
+        // refresh rewrote the file without any of it, losing precisely the
+        // rows the keep set exists to protect.
+        let json = """
+        {"fields":[
+          {"tool":"claude","bucketId":"weekly_new","title":"Weekly","groupTitle":"New",
+           "shortLabel":"New","firstSeen":0,"lastSeen":0},
+          {"tool":"someFutureProvider","bucketId":"weekly","title":"Weekly",
+           "shortLabel":"Weekly","firstSeen":0,"lastSeen":0}
+        ]}
+        """
+        let registry = try JSONDecoder().decode(QuotaFieldRegistry.self, from: Data(json.utf8))
+        XCTAssertEqual(registry.fields.count, 1, "only the unreadable row is dropped")
+        XCTAssertEqual(registry.fields.first?.bucketId, "weekly_new")
+    }
+
+    // MARK: - A template draws at its renderer's face (review thread 2)
+
+    func testEachTemplateAsksForTheFaceItsRendererUses() {
+        // Compact's seed is one row, and the built-in compact renderer draws
+        // at the 9pt face — asking for the system face made the seeded strip
+        // noticeably larger than the strip it reproduced.
+        XCTAssertEqual(MenuBarStripGeometry.face(template: .compact, rowCount: 1), .compact)
+        XCTAssertEqual(MenuBarStripGeometry.face(template: .roomy, rowCount: 1), .system)
+        // Two rows always go through the rasterizer, whatever the template.
+        for template in MenuBarComposition.Template.allCases {
+            XCTAssertEqual(
+                MenuBarStripGeometry.face(template: template, rowCount: 2),
+                .compact,
+                "\(template) at two rows"
+            )
+        }
+    }
+
+    func testCompactDoesNotScaleItsFaceDownAgain() {
+        // Its smallness is the face, not a multiplier applied to a larger one.
+        for template in MenuBarComposition.Template.allCases {
+            XCTAssertEqual(template.fontScale, 1.0, "\(template)")
+        }
+    }
+
     // MARK: - Persistence
 
     func testCompositionRoundTripsThroughTheSettingsFile() throws {
@@ -2079,7 +2288,11 @@ final class MenuBarCompositionTests: XCTestCase {
         XCTAssertEqual(restored.composition?.tokens.last?.kind, .text("tail"))
     }
 
-    func testAnUnreadableBlockDropsWithoutTakingTheStripDown() throws {
+    func testAnUnreadableBlockIsKeptRatherThanDroppedFromTheStrip() throws {
+        // This used to assert the block was dropped. Dropping is a silent,
+        // permanent deletion the moment the settings file is saved again, so
+        // an unreadable block is now preserved verbatim instead — see
+        // `MenuBarToken.Kind.unsupported`.
         let json = """
         {"isEnabled":true,"template":"roomy","tokens":[
           {"id":"11111111-1111-1111-1111-111111111111",
@@ -2093,7 +2306,16 @@ final class MenuBarCompositionTests: XCTestCase {
         ]}
         """
         let decoded = try JSONDecoder().decode(MenuBarComposition.self, from: Data(json.utf8))
-        XCTAssertEqual(decoded.tokens.map(\.kind), [.text("keep")])
+        XCTAssertEqual(decoded.tokens.count, 2)
+        XCTAssertEqual(decoded.tokens[0].kind, .text("keep"))
+        guard case .unsupported = decoded.tokens[1].kind else {
+            return XCTFail("the unreadable block should be preserved")
+        }
+        // It contributes nothing to the strip either way.
+        let rendered = decoded.plan(
+            quotas: [], displayMode: .used, colorBasis: .actual, now: reference
+        )
+        XCTAssertEqual(texts(rendered), [["keep"]])
     }
 
     func testUnreadableStyleAndRuleDegradeInsteadOfFailing() throws {

--- a/Tests/VibeBarCoreTests/MenuBarCompositionTests.swift
+++ b/Tests/VibeBarCoreTests/MenuBarCompositionTests.swift
@@ -1792,6 +1792,118 @@ final class MenuBarCompositionTests: XCTestCase {
         XCTAssertNil(registry.field(id: "codex.gpt_reserve_weekly"))
     }
 
+    // MARK: - A template applies the shape it names (review thread 2)
+
+    private func rowCount(_ composed: MenuBarComposition) -> Int {
+        composed.plan(
+            quotas: [
+                quota("claude.five_hour", label: "5 Hours", used: 40, display: 40),
+                quota("claude.weekly", label: "Weekly", used: 60, display: 60)
+            ],
+            displayMode: .used,
+            colorBasis: .actual,
+            now: reference
+        ).rows.filter { !$0.isEmpty }.count
+    }
+
+    func testChoosingTwoRowsActuallyProducesTwoRows() {
+        // The picker's own description says "Two stacked rows in one status
+        // item". Setting the enum alone left the strip single-row, because
+        // rows come from `.lineBreak` blocks and nothing had added one.
+        var composed = MenuBarComposition.seeded(template: .roomy, from: fieldItem())
+        composed.isEnabled = true
+        XCTAssertEqual(rowCount(composed), 1)
+
+        composed.setTemplate(.twoColumn)
+        XCTAssertEqual(composed.template, .twoColumn)
+        XCTAssertEqual(rowCount(composed), 2)
+    }
+
+    func testTheSplitTakesOverTheDividerRatherThanJoiningIt() {
+        // The break lands where the seed would put it, replacing the divider
+        // between the two entries instead of leaving a dangling one.
+        var composed = MenuBarComposition.seeded(template: .roomy, from: fieldItem())
+        composed.setTemplate(.twoColumn)
+        XCTAssertEqual(composed.tokens.map(\.kind), [
+            .quota(fieldId: "claude.five_hour", metric: .label),
+            .quota(fieldId: "claude.five_hour", metric: .displayPercent),
+            .lineBreak,
+            .quota(fieldId: "claude.weekly", metric: .label),
+            .quota(fieldId: "claude.weekly", metric: .displayPercent)
+        ])
+    }
+
+    func testChoosingASingleRowTemplateJoinsTheRowsBackUp() {
+        var composed = MenuBarComposition.seeded(template: .twoColumn, from: layoutItem(.twoRows))
+        composed.isEnabled = true
+        XCTAssertEqual(rowCount(composed), 2)
+
+        composed.setTemplate(.roomy)
+        XCTAssertEqual(composed.lineBreakCount, 0)
+        XCTAssertEqual(rowCount(composed), 1)
+        // The divider the break took over comes back, so the entries are still
+        // separated rather than run together.
+        XCTAssertTrue(composed.tokens.contains { $0.kind == .separator(" · ") })
+    }
+
+    func testTheTwoDirectionsRoundTrip() {
+        let original = MenuBarComposition.seeded(template: .roomy, from: fieldItem())
+        var composed = original
+        composed.setTemplate(.twoColumn)
+        composed.setTemplate(.roomy)
+        XCTAssertEqual(composed.tokens.map(\.kind), original.tokens.map(\.kind))
+    }
+
+    func testCompactRejoinsWithASpaceBecauseThatIsWhatItDraws() {
+        var composed = MenuBarComposition.seeded(template: .twoColumn, from: layoutItem(.twoRows))
+        composed.setTemplate(.compact)
+        XCTAssertTrue(composed.tokens.contains { $0.kind == .space })
+        XCTAssertFalse(composed.tokens.contains { $0.kind == .separator(" · ") })
+    }
+
+    func testChoosingTwoRowsTwiceDoesNotAddASecondBreak() {
+        var composed = MenuBarComposition.seeded(template: .roomy, from: fieldItem())
+        composed.setTemplate(.twoColumn)
+        composed.setTemplate(.twoColumn)
+        XCTAssertEqual(composed.lineBreakCount, 1)
+    }
+
+    func testAStripWithNothingToSplitIsLeftAlone() {
+        var composed = composition([MenuBarToken(kind: .text("only"))])
+        composed.setTemplate(.twoColumn)
+        XCTAssertEqual(composed.lineBreakCount, 0)
+        XCTAssertEqual(composed.tokens.map(\.kind), [.text("only")])
+        XCTAssertEqual(composed.template, .twoColumn)
+    }
+
+    // MARK: - A field is chosen by the words it is drawn with (review thread 3)
+
+    func testAnOptionIsNamedTheWayTheStripDrawsIt() {
+        // The picker used to render the contract spelling while the strip drew
+        // the resolved one, so the user chose "5 Hours" and got "5 小时".
+        let fiveHour = MenuBarFieldCatalog.field(id: "claude.five_hour")!
+        XCTAssertEqual(fiveHour.displayTitle, QuotaGroupLabelLocalizer.display("5 Hours"))
+        XCTAssertEqual(fiveHour.displayDefaultLabel, QuotaGroupLabelLocalizer.display("5 Hours"))
+    }
+
+    func testAComposedTitleIsResolvedPartByPart() {
+        // "All Models · Weekly": both halves are generic window words.
+        let weekly = MenuBarFieldCatalog.field(id: "claude.weekly")!
+        XCTAssertEqual(weekly.title, "All Models · Weekly")
+        XCTAssertEqual(
+            weekly.displayTitle,
+            [QuotaGroupLabelLocalizer.display("All Models"),
+             QuotaGroupLabelLocalizer.display("Weekly")].joined(separator: " · ")
+        )
+    }
+
+    func testAProductNameInATitleIsNeverTranslated() {
+        // "GPT-5.3 Codex Spark · 5 Hours": only the window half may move.
+        let spark = MenuBarFieldCatalog.field(id: "codex.gpt_5_3_codex_spark_five_hour")!
+        XCTAssertTrue(spark.displayTitle.hasPrefix("GPT-5.3 Codex Spark · "))
+        XCTAssertFalse(QuotaGroupLabelLocalizer.isTranslated("GPT-5.3 Codex Spark"))
+    }
+
     // MARK: - Persistence
 
     func testCompositionRoundTripsThroughTheSettingsFile() throws {

--- a/Tests/VibeBarCoreTests/MenuBarCompositionTests.swift
+++ b/Tests/VibeBarCoreTests/MenuBarCompositionTests.swift
@@ -1389,6 +1389,149 @@ final class MenuBarCompositionTests: XCTestCase {
         XCTAssertEqual(rendered.spokenDescription, "Weekly runs out in 5h")
     }
 
+    // MARK: - A forecast-driven strip is on a clock (review thread 1)
+
+    func testAForecastMetricPutsTheStripOnAClock() {
+        for metric in [MenuBarQuotaMetric.forecastPercent, .runsOutIn] {
+            let composed = composition([
+                MenuBarToken(kind: .quota(fieldId: "claude.weekly", metric: metric))
+            ])
+            XCTAssertTrue(
+                composed.needsForecastClock(colorBasis: .actual),
+                "\(metric) reads the forecast"
+            )
+        }
+    }
+
+    func testAForecastVisibilityRulePutsTheStripOnAClock() {
+        // The rule decides whether the block is on screen at all, so a stale
+        // verdict leaves a block wrongly shown or wrongly hidden.
+        let composed = composition([
+            MenuBarToken(
+                kind: .text("!"),
+                visibility: .whenForecast(fieldId: "claude.weekly", verdicts: [.atRisk])
+            )
+        ])
+        XCTAssertTrue(composed.needsForecastClock(colorBasis: .actual))
+    }
+
+    func testAForecastColourPutsTheStripOnAClock() {
+        // Explicit forecast colour...
+        let explicit = composition([
+            MenuBarToken(
+                kind: .quota(fieldId: "claude.weekly", metric: .displayPercent),
+                style: .init(color: .forecast)
+            )
+        ])
+        XCTAssertTrue(explicit.needsForecastClock(colorBasis: .actual))
+
+        // ...and one that follows another quota's forecast.
+        let follows = composition([
+            MenuBarToken(
+                kind: .text("Claude"),
+                style: .init(color: .followsQuota(fieldId: "claude.weekly", basis: .forecast))
+            )
+        ])
+        XCTAssertTrue(follows.needsForecastClock(colorBasis: .actual))
+    }
+
+    func testAnAutomaticColourIsAForecastColourUnderThatBasis() {
+        // What every seeded percentage wears. Under the forecast basis its
+        // colour is the verdict, so the strip is forecast-driven even though
+        // no block names a forecast.
+        let composed = composition([
+            MenuBarToken(
+                kind: .quota(fieldId: "claude.weekly", metric: .displayPercent),
+                style: .percent
+            )
+        ])
+        XCTAssertTrue(composed.needsForecastClock(colorBasis: .forecast))
+        XCTAssertFalse(composed.needsForecastClock(colorBasis: .actual))
+    }
+
+    func testAPlainStripStartsNoClockAtAll() {
+        let composed = composition([
+            MenuBarToken(kind: .logo(.claude)),
+            MenuBarToken(kind: .text("Claude")),
+            MenuBarToken(
+                kind: .quota(fieldId: "claude.weekly", metric: .usedPercent),
+                style: .init(color: .primary)
+            )
+        ])
+        XCTAssertFalse(composed.needsForecastClock(colorBasis: .actual))
+        XCTAssertFalse(composed.hasTimeBasedBlock)
+        XCTAssertNil(composed.clockInterval(colorBasis: .actual))
+    }
+
+    func testTheClockIsPacedToWhateverTheStripActuallyNeeds() {
+        // Forecast only: the forecast's own quantum, because `QuotaService`
+        // floors and memoises on it and a faster tick buys only wakeups.
+        let forecastOnly = composition([
+            MenuBarToken(kind: .quota(fieldId: "claude.weekly", metric: .forecastPercent))
+        ])
+        XCTAssertEqual(
+            forecastOnly.clockInterval(colorBasis: .actual),
+            MenuBarCountdownClock.forecastInterval
+        )
+        XCTAssertEqual(
+            MenuBarCountdownClock.forecastInterval,
+            QuotaService.paceForecastClockQuantumSeconds
+        )
+
+        // Anything counting down needs the minute, and that also covers the
+        // forecast.
+        let countdown = composition([
+            MenuBarToken(kind: .quota(fieldId: "claude.weekly", metric: .resetsIn)),
+            MenuBarToken(kind: .quota(fieldId: "claude.weekly", metric: .forecastPercent))
+        ])
+        XCTAssertEqual(
+            countdown.clockInterval(colorBasis: .actual),
+            MenuBarCountdownClock.interval
+        )
+    }
+
+    // MARK: - Seeds match what each layout draws (review thread 2)
+
+    func testTwoRowsSeedsSpacingNotADivider() {
+        // `twoRowMenuColumns` packs entries into columns separated by
+        // `twoRowColumnSpacing` and draws no divider, so a seeded " · " put
+        // punctuation on screen the layout never had.
+        let seeded = MenuBarComposition.seeded(
+            template: .matching(.twoRows),
+            from: layoutItem(.twoRows)
+        )
+        XCTAssertFalse(
+            seeded.tokens.contains { $0.kind == .separator(" · ") },
+            "Two rows draws no dot between entries"
+        )
+        XCTAssertTrue(seeded.tokens.contains { $0.kind == .space })
+    }
+
+    func testEachLayoutSeedsTheSeparatorItsRendererDraws() {
+        // Single line appends a tertiary " · " between pieces.
+        let single = MenuBarComposition.seeded(
+            template: .matching(.singleLine),
+            from: layoutItem(.singleLine, fields: ["claude.five_hour", "claude.weekly"])
+        )
+        XCTAssertTrue(single.tokens.contains { $0.kind == .separator(" · ") })
+        XCTAssertFalse(single.tokens.contains { $0.kind == .space })
+
+        // Compact appends a plain space.
+        let compact = MenuBarComposition.seeded(
+            template: .matching(.compact),
+            from: layoutItem(.compact, fields: ["claude.five_hour", "claude.weekly"])
+        )
+        XCTAssertTrue(compact.tokens.contains { $0.kind == .space })
+        XCTAssertFalse(compact.tokens.contains { $0.kind == .separator(" · ") })
+
+        // Icon Only draws one glyph and nothing else.
+        let icon = MenuBarComposition.seeded(
+            template: .matching(.iconOnly),
+            from: layoutItem(.iconOnly)
+        )
+        XCTAssertEqual(icon.tokens.map(\.kind), [.appIcon])
+    }
+
     // MARK: - Persistence
 
     func testCompositionRoundTripsThroughTheSettingsFile() throws {

--- a/Tests/VibeBarCoreTests/MenuBarCompositionTests.swift
+++ b/Tests/VibeBarCoreTests/MenuBarCompositionTests.swift
@@ -531,11 +531,13 @@ final class MenuBarCompositionTests: XCTestCase {
 
     func testSeedingReproducesTodaysUnmergedStrip() {
         let seeded = MenuBarComposition.seeded(template: .roomy, from: fieldItem())
+        // The name is a *reference*, not the words: resolved when the strip is
+        // drawn, so it follows the app's language.
         XCTAssertEqual(seeded.tokens.map(\.kind), [
-            .text("5 Hours"),
+            .quota(fieldId: "claude.five_hour", metric: .label),
             .quota(fieldId: "claude.five_hour", metric: .displayPercent),
             .separator(" · "),
-            .text("Weekly"),
+            .quota(fieldId: "claude.weekly", metric: .label),
             .quota(fieldId: "claude.weekly", metric: .displayPercent)
         ])
         // Seeding never switches the mode on by itself.
@@ -956,8 +958,9 @@ final class MenuBarCompositionTests: XCTestCase {
         XCTAssertEqual(decoded.tokens.map(\.kind), [.appIcon])
     }
 
+    /// The field of a percentage block, ignoring the name block beside it.
     private func quotaFieldId(_ kind: MenuBarToken.Kind) -> String? {
-        if case let .quota(fieldId, _) = kind { return fieldId }
+        if case let .quota(fieldId, metric) = kind, metric != .label { return fieldId }
         return nil
     }
 
@@ -1649,6 +1652,144 @@ final class MenuBarCompositionTests: XCTestCase {
             return raw.compactMapValues { $0["value"] as? String }
         }
         return (try load("en.json"), try load("zh-Hans.json"))
+    }
+
+    // MARK: - A seeded name follows the language (review thread 2)
+
+    func testASeededNameIsAReferenceAndATypedOneIsVerbatim() {
+        let item = fieldItem(labels: ["claude.weekly": "C-wk"])
+        let seeded = MenuBarComposition.seeded(template: .roomy, from: item)
+
+        // Nothing derived is stored as words: the only literals in the seed
+        // are the divider and the name the user typed.
+        let literals: [String] = seeded.tokens.compactMap {
+            if case let .text(text) = $0.kind { return text }
+            return nil
+        }
+        XCTAssertEqual(literals, ["C-wk"])
+        XCTAssertTrue(seeded.tokens.contains {
+            $0.kind == .quota(fieldId: "claude.five_hour", metric: .label)
+        })
+    }
+
+    func testTheSeededNameMovesWithTheLanguageAndTheTypedOneDoesNot() {
+        var seeded = MenuBarComposition.seeded(
+            template: .roomy,
+            from: fieldItem(labels: ["claude.weekly": "C-wk"])
+        )
+        seeded.isEnabled = true
+
+        // The resolver hands the planner an already-localized name, so a
+        // language change arrives as a different snapshot label.
+        func drawn(fiveHourLabel: String) -> [String] {
+            texts(seeded.plan(
+                quotas: [
+                    quota("claude.five_hour", label: fiveHourLabel, used: 73, display: 73),
+                    quota("claude.weekly", label: "Weekly", used: 40, display: 40)
+                ],
+                displayMode: .used,
+                colorBasis: .actual,
+                now: reference
+            )).flatMap { $0 }
+        }
+
+        let english = drawn(fiveHourLabel: "5 Hours")
+        let chinese = drawn(fiveHourLabel: "5 小时")
+        XCTAssertTrue(english.contains("5 Hours"))
+        XCTAssertTrue(chinese.contains("5 小时"))
+        XCTAssertFalse(chinese.contains("5 Hours"), "the seeded name followed the language")
+        // ...while the name the user typed is theirs in both.
+        XCTAssertTrue(english.contains("C-wk"))
+        XCTAssertTrue(chinese.contains("C-wk"), "a typed name is never translated")
+    }
+
+    func testASeededNameReferenceIsNotSpokenTwice() {
+        // The round-six rule, in the shape the seed now produces: a name block
+        // that refers to the very quota the next block reports says nothing of
+        // its own.
+        var seeded = MenuBarComposition.seeded(template: .roomy, from: fieldItem())
+        seeded.isEnabled = true
+        let rendered = seeded.plan(
+            quotas: [
+                quota("claude.five_hour", label: "5 Hours", used: 73, display: 73),
+                quota("claude.weekly", label: "Weekly", used: 100, display: 100)
+            ],
+            displayMode: .used,
+            colorBasis: .actual,
+            now: reference
+        )
+        XCTAssertEqual(texts(rendered), [["5 Hours", "73%", " · ", "Weekly", "100%"]])
+        XCTAssertEqual(rendered.spokenDescription, "5 Hours 73% used, Weekly 100% used")
+    }
+
+    func testTwoNameBlocksInARowAreBothSpoken() {
+        // Only a name followed by a *report* of the same quota is an echo.
+        let rendered = plan(
+            [
+                MenuBarToken(kind: .quota(fieldId: "claude.five_hour", metric: .label)),
+                MenuBarToken(kind: .quota(fieldId: "claude.weekly", metric: .label))
+            ],
+            quotas: [
+                quota("claude.five_hour", label: "5 Hours", used: 10, display: 10),
+                quota("claude.weekly", label: "Weekly", used: 20, display: 20)
+            ]
+        )
+        XCTAssertEqual(rendered.spokenDescription, "5 Hours, Weekly")
+    }
+
+    // MARK: - A composed strip claims its fields (review thread 1)
+
+    private func discoveredRegistry() -> QuotaFieldRegistry {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        return QuotaFieldRegistry(fields: [
+            DiscoveredQuotaField(
+                tool: .codex,
+                bucketId: "gpt_reserve_weekly",
+                title: "Weekly",
+                groupTitle: "GPT-reserve",
+                shortLabel: "Weekly",
+                firstSeen: now,
+                lastSeen: now
+            )
+        ])
+    }
+
+    func testAFieldOnlyTheComposedStripNamesSurvivesAPrune() {
+        // The field is in no `selectedFieldIds` and has no custom label — the
+        // composition is its only referrer, and it names it three ways none of
+        // which the default strip knows about.
+        let composed = composition([
+            MenuBarToken(kind: .quota(fieldId: "codex.gpt_reserve_weekly", metric: .displayPercent)),
+            MenuBarToken(
+                kind: .text("!"),
+                style: .init(color: .followsQuota(fieldId: "codex.gpt_reserve_weekly", basis: .actual))
+            ),
+            MenuBarToken(
+                kind: .logo(.codex),
+                visibility: .whenUsedAtLeast(fieldId: "codex.gpt_reserve_weekly", percent: 90)
+            )
+        ])
+        XCTAssertEqual(composed.referencedFieldIds, ["codex.gpt_reserve_weekly"])
+
+        var registry = discoveredRegistry()
+        // The provider's next response omits the bucket.
+        let dropped = registry.prune(
+            tool: .codex,
+            liveBucketIds: [],
+            keeping: QuotaFieldKeepSet(fieldIds: Set(composed.referencedFieldIds))
+        )
+        XCTAssertFalse(dropped)
+        XCTAssertNotNil(
+            registry.field(id: "codex.gpt_reserve_weekly"),
+            "a bucket the composed strip names must keep its display metadata"
+        )
+    }
+
+    func testAFieldNothingNamesIsStillPruned() {
+        var registry = discoveredRegistry()
+        let dropped = registry.prune(tool: .codex, liveBucketIds: [], keeping: QuotaFieldKeepSet())
+        XCTAssertTrue(dropped)
+        XCTAssertNil(registry.field(id: "codex.gpt_reserve_weekly"))
     }
 
     // MARK: - Persistence

--- a/Tests/VibeBarCoreTests/MenuBarCompositionTests.swift
+++ b/Tests/VibeBarCoreTests/MenuBarCompositionTests.swift
@@ -1,0 +1,699 @@
+import XCTest
+@testable import VibeBarCore
+
+/// The composed menu-bar strip: what each block renders, when a block is on
+/// screen, what colour it ends up asking for, and what survives a settings
+/// file round trip.
+final class MenuBarCompositionTests: XCTestCase {
+    private let reference = Date(timeIntervalSince1970: 1_800_000_000)
+
+    private func quota(
+        _ fieldId: String = "claude.five_hour",
+        tool: ToolType = .claude,
+        label: String = "5 Hours",
+        used: Double = 73,
+        display: Double? = nil,
+        resetAt: Date? = nil,
+        pace: Double? = nil,
+        forecast: MenuBarQuotaSnapshot.Forecast? = nil
+    ) -> MenuBarQuotaSnapshot {
+        MenuBarQuotaSnapshot(
+            fieldId: fieldId,
+            tool: tool,
+            label: label,
+            usedPercent: used,
+            displayPercent: display ?? used,
+            resetAt: resetAt,
+            paceDeltaPercent: pace,
+            forecast: forecast
+        )
+    }
+
+    private func composition(
+        _ tokens: [MenuBarToken],
+        template: MenuBarComposition.Template = .roomy
+    ) -> MenuBarComposition {
+        MenuBarComposition(isEnabled: true, template: template, tokens: tokens)
+    }
+
+    private func plan(
+        _ tokens: [MenuBarToken],
+        quotas: [MenuBarQuotaSnapshot],
+        displayMode: DisplayMode = .used,
+        colorBasis: MenuBarColorBasis = .actual,
+        now: Date? = nil
+    ) -> MenuBarRenderPlan {
+        composition(tokens).plan(
+            quotas: quotas,
+            displayMode: displayMode,
+            colorBasis: colorBasis,
+            now: now ?? reference
+        )
+    }
+
+    private func texts(_ plan: MenuBarRenderPlan) -> [[String]] {
+        plan.rows.map { $0.tokens.compactMap(\.text) }
+    }
+
+    // MARK: - Metric formats
+
+    func testPercentMetricsRenderRoundedWholePercentages() {
+        let snapshot = quota(used: 72.6, display: 27.4)
+        XCTAssertEqual(metric(.usedPercent, snapshot), "73%")
+        XCTAssertEqual(metric(.remainingPercent, snapshot), "27%")
+        XCTAssertEqual(metric(.displayPercent, snapshot), "27%")
+    }
+
+    func testRemainingIsDerivedFromTheRawObservationAndClamped() {
+        XCTAssertEqual(metric(.remainingPercent, quota(used: 0)), "100%")
+        XCTAssertEqual(metric(.remainingPercent, quota(used: 100)), "0%")
+    }
+
+    func testPaceRendersASignedDelta() {
+        XCTAssertEqual(metric(.pace, quota(pace: 12.4)), "+12%")
+        XCTAssertEqual(metric(.pace, quota(pace: -8)), "-8%")
+        XCTAssertEqual(metric(.pace, quota(pace: 0.2)), "±0%")
+        // No window, no reset date, or a cycle past its grace: nothing to say.
+        XCTAssertNil(metric(.pace, quota(pace: nil)))
+    }
+
+    func testForecastMetricsReadTheProjection() {
+        let forecast = MenuBarQuotaSnapshot.Forecast(
+            verdict: .watch,
+            projectedRemainingPercent: 18.4,
+            runOutAt: reference.addingTimeInterval(3600 * 52)
+        )
+        XCTAssertEqual(metric(.forecastPercent, quota(forecast: forecast)), "18%")
+        XCTAssertEqual(metric(.runsOutIn, quota(forecast: forecast)), "2d 4h")
+        // A quota with no forecast yet prints neither rather than guessing.
+        XCTAssertNil(metric(.forecastPercent, quota()))
+        XCTAssertNil(metric(.runsOutIn, quota()))
+        // A forecast that does not predict exhaustion has no ETA to print.
+        XCTAssertNil(metric(.runsOutIn, quota(forecast: MenuBarQuotaSnapshot.Forecast(
+            verdict: .enough,
+            projectedRemainingPercent: 40
+        ))))
+    }
+
+    func testResetMetricsUseTheSharedCountdownFormatter() {
+        let resetAt = reference.addingTimeInterval(3600 * 3 + 60 * 16)
+        XCTAssertEqual(metric(.resetsIn, quota(resetAt: resetAt)), "3h 16m")
+        XCTAssertNil(metric(.resetsIn, quota(resetAt: nil)))
+        XCTAssertNil(metric(.resetAt, quota(resetAt: nil)))
+
+        // `resetAt` is the local wall time, so derive the expectation from the
+        // same calendar the formatter uses rather than hard-coding a zone.
+        let parts = Calendar.current.dateComponents([.hour, .minute], from: resetAt)
+        XCTAssertEqual(
+            metric(.resetAt, quota(resetAt: resetAt)),
+            String(format: "%02d:%02d", parts.hour ?? 0, parts.minute ?? 0)
+        )
+    }
+
+    func testLabelMetricPrintsTheQuotasOwnName() {
+        XCTAssertEqual(metric(.label, quota(label: "Weekly")), "Weekly")
+        XCTAssertNil(metric(.label, quota(label: "   ")))
+    }
+
+    private func metric(_ metric: MenuBarQuotaMetric, _ snapshot: MenuBarQuotaSnapshot) -> String? {
+        MenuBarComposition.value(
+            of: metric,
+            in: snapshot,
+            displayMode: .remaining,
+            now: reference
+        )
+    }
+
+    // MARK: - Visibility
+
+    func testAlwaysAndThresholdRules() {
+        let snapshot = quota(used: 80)
+        XCTAssertTrue(MenuBarComposition.isVisible(.always, quotas: [snapshot]))
+        XCTAssertTrue(MenuBarComposition.isVisible(
+            .whenUsedAtLeast(fieldId: snapshot.fieldId, percent: 80), quotas: [snapshot]
+        ))
+        XCTAssertFalse(MenuBarComposition.isVisible(
+            .whenUsedAtLeast(fieldId: snapshot.fieldId, percent: 81), quotas: [snapshot]
+        ))
+        XCTAssertTrue(MenuBarComposition.isVisible(
+            .whenRemainingAtMost(fieldId: snapshot.fieldId, percent: 20), quotas: [snapshot]
+        ))
+        XCTAssertFalse(MenuBarComposition.isVisible(
+            .whenRemainingAtMost(fieldId: snapshot.fieldId, percent: 19), quotas: [snapshot]
+        ))
+    }
+
+    func testARuleThatCannotBeEvaluatedNeverHidesItsBlock() {
+        // The quota was removed from the catalog, or the provider stopped
+        // returning it: hiding the block would leave the user no way to find
+        // it again, and looks exactly like a broken app.
+        XCTAssertTrue(MenuBarComposition.isVisible(
+            .whenUsedAtLeast(fieldId: "gone.bucket", percent: 90), quotas: [quota()]
+        ))
+        XCTAssertTrue(MenuBarComposition.isVisible(
+            .whenRemainingAtMost(fieldId: "gone.bucket", percent: 5), quotas: [quota()]
+        ))
+        XCTAssertTrue(MenuBarComposition.isVisible(
+            .whenForecast(fieldId: "gone.bucket", verdicts: [.atRisk]), quotas: [quota()]
+        ))
+        // Same reasoning while the forecast is still learning: the rule has no
+        // verdict to test, so it does not get to suppress the block.
+        XCTAssertTrue(MenuBarComposition.isVisible(
+            .whenForecast(fieldId: "claude.five_hour", verdicts: [.atRisk]),
+            quotas: [quota(forecast: nil)]
+        ))
+    }
+
+    func testForecastRuleMatchesOnlyItsVerdicts() {
+        let atRisk = quota(forecast: .init(verdict: .atRisk, projectedRemainingPercent: 0))
+        let enough = quota(forecast: .init(verdict: .enough, projectedRemainingPercent: 40))
+        XCTAssertTrue(MenuBarComposition.isVisible(
+            .whenForecast(fieldId: atRisk.fieldId, verdicts: [.atRisk, .watch]), quotas: [atRisk]
+        ))
+        XCTAssertFalse(MenuBarComposition.isVisible(
+            .whenForecast(fieldId: enough.fieldId, verdicts: [.atRisk, .watch]), quotas: [enough]
+        ))
+    }
+
+    func testHiddenBlocksLeaveTheStrip() {
+        let snapshot = quota(used: 10)
+        let rendered = plan(
+            [
+                MenuBarToken(kind: .text("A")),
+                MenuBarToken(
+                    kind: .text("B"),
+                    visibility: .whenUsedAtLeast(fieldId: snapshot.fieldId, percent: 90)
+                ),
+                MenuBarToken(kind: .text("C"))
+            ],
+            quotas: [snapshot]
+        )
+        XCTAssertEqual(texts(rendered), [["A", "C"]])
+    }
+
+    // MARK: - Plan
+
+    func testRowsSplitOnLineBreak() {
+        let rendered = plan(
+            [
+                MenuBarToken(kind: .text("top")),
+                MenuBarToken(kind: .lineBreak),
+                MenuBarToken(kind: .text("bottom"))
+            ],
+            quotas: []
+        )
+        XCTAssertEqual(texts(rendered), [["top"], ["bottom"]])
+    }
+
+    func testAThirdRowFoldsBackIntoTheSecond() {
+        // The status item cannot draw a third band; its blocks stay visible on
+        // the second row rather than disappearing.
+        let rendered = plan(
+            [
+                MenuBarToken(kind: .text("one")),
+                MenuBarToken(kind: .lineBreak),
+                MenuBarToken(kind: .text("two")),
+                MenuBarToken(kind: .lineBreak),
+                MenuBarToken(kind: .text("three"))
+            ],
+            quotas: []
+        )
+        XCTAssertEqual(rendered.rows.count, MenuBarComposition.maximumRows)
+        XCTAssertEqual(texts(rendered), [["one"], ["two", "three"]])
+    }
+
+    func testAnUnavailableQuotaDropsOnlyItsOwnBlock() {
+        let rendered = plan(
+            [
+                MenuBarToken(kind: .text("Claude")),
+                MenuBarToken(kind: .quota(fieldId: "claude.five_hour", metric: .displayPercent)),
+                MenuBarToken(kind: .separator("/"), style: .divider),
+                MenuBarToken(kind: .quota(fieldId: "claude.weekly", metric: .displayPercent))
+            ],
+            quotas: [quota("claude.five_hour", used: 40)]
+        )
+        XCTAssertEqual(texts(rendered), [["Claude", "40%", "/"]])
+        XCTAssertFalse(rendered.isEmpty)
+    }
+
+    func testAStripWhoseQuotasAreAllMissingIsEmpty() {
+        let rendered = plan(
+            [MenuBarToken(kind: .quota(fieldId: "claude.five_hour", metric: .displayPercent))],
+            quotas: []
+        )
+        XCTAssertTrue(rendered.isEmpty)
+    }
+
+    func testTemplateSuppliesSpacingAndScaleUnlessOverridden() {
+        let roomy = MenuBarComposition(template: .roomy)
+        XCTAssertEqual(roomy.effectiveTokenSpacing, MenuBarComposition.Template.roomy.tokenSpacing)
+        XCTAssertEqual(roomy.effectiveFontScale, MenuBarComposition.Template.roomy.fontScale)
+
+        let tuned = MenuBarComposition(template: .roomy, fontScale: 9, tokenSpacing: -3)
+        // Clamped rather than rejected: a bad number should not be able to
+        // render the menu bar unusable.
+        XCTAssertEqual(tuned.effectiveFontScale, MenuBarComposition.fontScaleRange.upperBound)
+        XCTAssertEqual(tuned.effectiveTokenSpacing, MenuBarComposition.tokenSpacingRange.lowerBound)
+    }
+
+    func testSizeStepScalesOnTopOfTheTemplate() {
+        let rendered = MenuBarComposition(
+            isEnabled: true,
+            template: .compact,
+            tokens: [
+                MenuBarToken(kind: .text("s"), style: .init(size: .small)),
+                MenuBarToken(kind: .text("l"), style: .init(size: .large))
+            ]
+        ).plan(quotas: [], displayMode: .used, colorBasis: .actual, now: reference)
+        let scale = MenuBarComposition.Template.compact.fontScale
+        XCTAssertEqual(rendered.rows[0].tokens[0].fontScale, scale * 0.85, accuracy: 1e-9)
+        XCTAssertEqual(rendered.rows[0].tokens[1].fontScale, scale * 1.2, accuracy: 1e-9)
+    }
+
+    // MARK: - Colour
+
+    func testAutomaticFollowsTheAppWideBasisForTheBlocksOwnQuota() {
+        let token = MenuBarToken(
+            kind: .quota(fieldId: "claude.five_hour", metric: .displayPercent),
+            style: .percent
+        )
+        let actual = plan([token], quotas: [quota()], colorBasis: .actual)
+        XCTAssertEqual(
+            actual.rows[0].tokens[0].color,
+            .quota(fieldId: "claude.five_hour", basis: .actual)
+        )
+        let forecast = plan([token], quotas: [quota()], colorBasis: .forecast)
+        XCTAssertEqual(
+            forecast.rows[0].tokens[0].color,
+            .quota(fieldId: "claude.five_hour", basis: .forecast)
+        )
+    }
+
+    func testAutomaticOnABlockWithNoQuotaIsPrimary() {
+        let rendered = plan(
+            [MenuBarToken(kind: .text("hi"), style: .init(color: .automatic))],
+            quotas: [quota()]
+        )
+        XCTAssertEqual(rendered.rows[0].tokens[0].color, .primary)
+    }
+
+    func testAnyBlockCanFollowAnotherQuotasColour() {
+        let rendered = plan(
+            [MenuBarToken(
+                kind: .text("Claude"),
+                style: .init(color: .followsQuota(fieldId: "claude.five_hour", basis: .forecast))
+            )],
+            quotas: [quota()]
+        )
+        XCTAssertEqual(
+            rendered.rows[0].tokens[0].color,
+            .quota(fieldId: "claude.five_hour", basis: .forecast)
+        )
+    }
+
+    func testFollowingAMissingQuotaFallsBackWithoutHidingTheBlock() {
+        let rendered = plan(
+            [MenuBarToken(
+                kind: .text("Claude"),
+                style: .init(color: .followsQuota(fieldId: "gone.bucket", basis: .actual))
+            )],
+            quotas: [quota()]
+        )
+        XCTAssertEqual(texts(rendered), [["Claude"]])
+        XCTAssertEqual(rendered.rows[0].tokens[0].color, .primary)
+    }
+
+    func testForcedForecastColourIgnoresTheAppWideBasis() {
+        let rendered = plan(
+            [MenuBarToken(
+                kind: .quota(fieldId: "claude.five_hour", metric: .usedPercent),
+                style: .init(color: .forecast)
+            )],
+            quotas: [quota()],
+            colorBasis: .actual
+        )
+        XCTAssertEqual(
+            rendered.rows[0].tokens[0].color,
+            .quota(fieldId: "claude.five_hour", basis: .forecast)
+        )
+    }
+
+    func testFixedColoursNormalizeAndBadOnesFallBack() {
+        XCTAssertEqual(MenuBarHexColor.normalized("#F0A"), "#ff00aa")
+        XCTAssertEqual(MenuBarHexColor.normalized("00FF00"), "#00ff00")
+        XCTAssertEqual(MenuBarHexColor.normalized("#11223344"), "#11223344")
+        XCTAssertNil(MenuBarHexColor.normalized("cornflower"))
+        XCTAssertNil(MenuBarHexColor.normalized("#12345"))
+
+        // `hex(_:)` canonicalizes at construction, so a picked swatch and a
+        // hand-typed value are one stored value rather than two.
+        XCTAssertEqual(MenuBarToken.ColorSource.hex("#F0A"), .fixed("#ff00aa"))
+        XCTAssertEqual(MenuBarToken.ColorSource.hex("nope"), .primary)
+
+        let good = plan(
+            [MenuBarToken(kind: .text("x"), style: .init(color: .hex("#F0A")))],
+            quotas: []
+        )
+        XCTAssertEqual(good.rows[0].tokens[0].color, .fixed(hex: "#ff00aa"))
+
+        // Even a raw case that skipped the factory degrades rather than
+        // painting something arbitrary.
+        let bad = plan(
+            [MenuBarToken(kind: .text("x"), style: .init(color: .fixed("nope")))],
+            quotas: []
+        )
+        XCTAssertEqual(bad.rows[0].tokens[0].color, .primary)
+
+        let parts = MenuBarHexColor.components("#ff8000")
+        XCTAssertEqual(parts?.r ?? 0, 1.0, accuracy: 1e-9)
+        XCTAssertEqual(parts?.g ?? 0, 128.0 / 255.0, accuracy: 1e-9)
+        XCTAssertEqual(parts?.b ?? 0, 0.0, accuracy: 1e-9)
+        XCTAssertEqual(parts?.a ?? 0, 1.0, accuracy: 1e-9)
+    }
+
+    // MARK: - Requirements
+
+    func testReferencedFieldsAreDeduplicatedInFirstAppearanceOrder() {
+        let composed = composition([
+            MenuBarToken(kind: .quota(fieldId: "claude.five_hour", metric: .label)),
+            MenuBarToken(kind: .quota(fieldId: "claude.five_hour", metric: .displayPercent)),
+            MenuBarToken(
+                kind: .text("!"),
+                style: .init(color: .followsQuota(fieldId: "codex.weekly", basis: .actual))
+            ),
+            MenuBarToken(
+                kind: .logo(.claude),
+                visibility: .whenUsedAtLeast(fieldId: "gemini.weekly", percent: 50)
+            )
+        ])
+        XCTAssertEqual(
+            composed.referencedFieldIds,
+            ["claude.five_hour", "codex.weekly", "gemini.weekly"]
+        )
+    }
+
+    func testOnlyBlocksThatReadAForecastAskForOne() {
+        let composed = composition([
+            MenuBarToken(kind: .quota(fieldId: "a.x", metric: .displayPercent)),
+            MenuBarToken(kind: .quota(fieldId: "b.x", metric: .runsOutIn)),
+            MenuBarToken(kind: .quota(fieldId: "c.x", metric: .pace)),
+            MenuBarToken(kind: .text("!"), style: .init(color: .forecast))
+        ])
+        let byField = Dictionary(
+            uniqueKeysWithValues: composed.quotaRequirements.map { ($0.fieldId, $0) }
+        )
+        XCTAssertEqual(byField["a.x"]?.needsForecast, false)
+        XCTAssertEqual(byField["a.x"]?.needsPace, false)
+        XCTAssertEqual(byField["b.x"]?.needsForecast, true)
+        XCTAssertEqual(byField["c.x"]?.needsPace, true)
+        XCTAssertEqual(byField["c.x"]?.needsForecast, false)
+    }
+
+    func testRequirementsMergeAcrossBlocksNamingTheSameQuota() {
+        let composed = composition([
+            MenuBarToken(kind: .quota(fieldId: "a.x", metric: .displayPercent)),
+            MenuBarToken(kind: .quota(fieldId: "a.x", metric: .pace)),
+            MenuBarToken(kind: .quota(fieldId: "a.x", metric: .forecastPercent))
+        ])
+        XCTAssertEqual(composed.quotaRequirements.count, 1)
+        XCTAssertEqual(composed.quotaRequirements[0].needsPace, true)
+        XCTAssertEqual(composed.quotaRequirements[0].needsForecast, true)
+    }
+
+    // MARK: - Spoken description
+
+    func testTheStripIsDescribedInWordsNotInTheDrawnShorthand() {
+        let rendered = plan(
+            [
+                MenuBarToken(kind: .logo(.claude)),
+                MenuBarToken(kind: .quota(fieldId: "claude.five_hour", metric: .displayPercent)),
+                MenuBarToken(kind: .separator("/"), style: .divider),
+                MenuBarToken(kind: .quota(fieldId: "claude.weekly", metric: .resetsIn)),
+                MenuBarToken(kind: .lineBreak),
+                MenuBarToken(kind: .quota(fieldId: "claude.weekly", metric: .forecastPercent))
+            ],
+            quotas: [
+                quota("claude.five_hour", used: 5, display: 5),
+                quota(
+                    "claude.weekly",
+                    label: "Weekly",
+                    used: 100,
+                    display: 100,
+                    resetAt: reference.addingTimeInterval(3600 * 3),
+                    forecast: .init(verdict: .atRisk, projectedRemainingPercent: 0)
+                )
+            ]
+        )
+        XCTAssertEqual(
+            rendered.spokenDescription,
+            "Claude, 5 Hours 5% used, Weekly resets in 3h · Weekly forecast 0% left at reset"
+        )
+        // Separators and spaces are drawing, not words.
+        XCTAssertFalse(rendered.spokenDescription.contains("/"))
+    }
+
+    func testDisplayPercentIsSpokenWithTheModeTheUserPicked() {
+        let used = plan(
+            [MenuBarToken(kind: .quota(fieldId: "claude.five_hour", metric: .displayPercent))],
+            quotas: [quota(used: 73, display: 73)],
+            displayMode: .used
+        )
+        XCTAssertEqual(used.spokenDescription, "5 Hours 73% used")
+        let remaining = plan(
+            [MenuBarToken(kind: .quota(fieldId: "claude.five_hour", metric: .displayPercent))],
+            quotas: [quota(used: 73, display: 27)],
+            displayMode: .remaining
+        )
+        XCTAssertEqual(remaining.spokenDescription, "5 Hours 27% remaining")
+    }
+
+    // MARK: - Seeding
+
+    private func fieldItem(
+        merging: Bool = false,
+        showTitle: Bool = false,
+        styles: [String: MenuBarFieldStyle] = [:],
+        labels: [String: String] = [:]
+    ) -> MenuBarItemSettings {
+        MenuBarItemSettings(
+            kind: .compact,
+            isVisible: true,
+            showTitle: showTitle,
+            layout: .singleLine,
+            selectedFieldIds: ["claude.five_hour", "claude.weekly"],
+            customLabels: labels,
+            fieldStyles: styles,
+            mergesGroupWindows: merging
+        )
+    }
+
+    func testSeedingReproducesTodaysUnmergedStrip() {
+        let seeded = MenuBarComposition.seeded(template: .roomy, from: fieldItem())
+        XCTAssertEqual(seeded.tokens.map(\.kind), [
+            .text("5 Hours"),
+            .quota(fieldId: "claude.five_hour", metric: .displayPercent),
+            .separator(" · "),
+            .text("Weekly"),
+            .quota(fieldId: "claude.weekly", metric: .displayPercent)
+        ])
+        // Seeding never switches the mode on by itself.
+        XCTAssertFalse(seeded.isEnabled)
+    }
+
+    func testSeedingFollowsTheGroupMergeAndTheFieldStyles() {
+        let seeded = MenuBarComposition.seeded(
+            template: .roomy,
+            from: fieldItem(merging: true, styles: ["claude.five_hour": .logoLabelAndPercent])
+        )
+        XCTAssertEqual(seeded.tokens.map(\.kind), [
+            .logo(.claude),
+            .text("Claude"),
+            .quota(fieldId: "claude.five_hour", metric: .displayPercent),
+            .separator("/"),
+            .quota(fieldId: "claude.weekly", metric: .displayPercent)
+        ])
+    }
+
+    func testSeedingHonoursCustomLabelsAndTheTitleToggle() {
+        let seeded = MenuBarComposition.seeded(
+            template: .roomy,
+            from: fieldItem(showTitle: true, labels: ["claude.five_hour": "C5"])
+        )
+        XCTAssertEqual(seeded.tokens.first?.kind, .text(MenuBarItemKind.compact.title))
+        XCTAssertTrue(seeded.tokens.contains { $0.kind == .text("C5") })
+    }
+
+    func testTwoColumnTemplateSeedsALineBreak() {
+        let seeded = MenuBarComposition.seeded(template: .twoColumn, from: fieldItem())
+        XCTAssertTrue(seeded.tokens.contains { $0.kind == .lineBreak })
+        let rendered = seeded.plan(
+            quotas: [quota("claude.five_hour"), quota("claude.weekly", label: "Weekly")],
+            displayMode: .used,
+            colorBasis: .actual,
+            now: reference
+        )
+        XCTAssertEqual(rendered.rows.count, 2)
+        XCTAssertFalse(rendered.rows[1].isEmpty)
+    }
+
+    func testSeededPercentagesKeepTodaysColourAndFace() {
+        let seeded = MenuBarComposition.seeded(template: .roomy, from: fieldItem())
+        let percent = seeded.tokens.first { $0.metric == .displayPercent }
+        XCTAssertEqual(percent?.style.color, .automatic)
+        XCTAssertEqual(percent?.style.weight, .semibold)
+        XCTAssertEqual(percent?.style.monospacedDigits, true)
+    }
+
+    // MARK: - Mode switching
+
+    func testTurningCustomModeOnSeedsOnceAndTurningItOffKeepsEverything() {
+        var item = fieldItem(labels: ["claude.five_hour": "C5"])
+        XCTAssertNil(item.composition)
+        XCTAssertFalse(item.usesComposedStrip)
+
+        item.setComposedStripEnabled(true)
+        XCTAssertTrue(item.usesComposedStrip)
+        let seededKinds = item.composition?.tokens.map(\.kind)
+        XCTAssertFalse(seededKinds?.isEmpty ?? true)
+
+        // The user edits their strip.
+        item.composition?.tokens.append(MenuBarToken(kind: .text("!")))
+        let edited = item.composition?.tokens.map(\.kind)
+
+        item.setComposedStripEnabled(false)
+        XCTAssertFalse(item.usesComposedStrip)
+        // Field mode is exactly as it was — the two modes never overwrite
+        // each other.
+        XCTAssertEqual(item.selectedFieldIds, ["claude.five_hour", "claude.weekly"])
+        XCTAssertEqual(item.customLabels, ["claude.five_hour": "C5"])
+        // ...and the composed arrangement survived being switched off.
+        XCTAssertEqual(item.composition?.tokens.map(\.kind), edited)
+
+        item.setComposedStripEnabled(true)
+        XCTAssertTrue(item.usesComposedStrip)
+        XCTAssertEqual(item.composition?.tokens.map(\.kind), edited, "re-enabling must not reseed")
+    }
+
+    func testReseedIsTheOnlyThingThatReplacesAStrip() {
+        var item = fieldItem()
+        item.setComposedStripEnabled(true)
+        item.composition?.tokens = [MenuBarToken(kind: .text("mine"))]
+        item.reseedComposedStrip(template: .twoColumn)
+        XCTAssertNotEqual(item.composition?.tokens.map(\.kind), [.text("mine")])
+        XCTAssertEqual(item.composition?.template, .twoColumn)
+        // Reseeding does not change whether custom mode is on.
+        XCTAssertTrue(item.usesComposedStrip)
+    }
+
+    // MARK: - Persistence
+
+    func testCompositionRoundTripsThroughTheSettingsFile() throws {
+        let tokens = [
+            MenuBarToken(kind: .logo(.codex), style: .init(color: .brand(.codex), size: .large)),
+            MenuBarToken(kind: .text("Codex"), style: .label),
+            MenuBarToken(
+                kind: .quota(fieldId: "codex.weekly", metric: .runsOutIn),
+                style: .init(color: .hex("#FF8000"), size: .small, weight: .regular, monospacedDigits: true),
+                visibility: .whenForecast(fieldId: "codex.weekly", verdicts: [.atRisk, .watch])
+            ),
+            MenuBarToken(kind: .space),
+            MenuBarToken(kind: .separator(" · "), style: .divider),
+            MenuBarToken(kind: .lineBreak),
+            MenuBarToken(
+                kind: .quota(fieldId: "codex.five_hour", metric: .pace),
+                style: .init(color: .followsQuota(fieldId: "codex.five_hour", basis: .forecast)),
+                visibility: .whenRemainingAtMost(fieldId: "codex.five_hour", percent: 25)
+            )
+        ]
+        let composed = MenuBarComposition(
+            isEnabled: true,
+            template: .twoColumn,
+            tokens: tokens,
+            fontScale: 1.1,
+            tokenSpacing: 0.5
+        )
+        let data = try JSONEncoder().encode(composed)
+        let decoded = try JSONDecoder().decode(MenuBarComposition.self, from: data)
+        XCTAssertEqual(decoded, composed)
+    }
+
+    func testItemDefaultsToNoCompositionAndOldFilesStillDecode() throws {
+        let json = """
+        {"kind":"compact","isVisible":true,"showTitle":true,"layout":"singleLine",
+         "selectedFieldIds":["claude.five_hour"],"customLabels":{},"fieldStyles":{}}
+        """
+        let decoded = try JSONDecoder().decode(MenuBarItemSettings.self, from: Data(json.utf8))
+        XCTAssertNil(decoded.composition)
+        XCTAssertFalse(decoded.usesComposedStrip)
+    }
+
+    func testCompositionSurvivesAnAppSettingsRoundTrip() throws {
+        var settings = AppSettings(
+            displayMode: .remaining,
+            refreshIntervalSeconds: 600,
+            launchAtLogin: false,
+            menuBarTextEnabled: true,
+            mockEnabled: false
+        )
+        var item = settings.menuBarItem(.compact)
+        item.setComposedStripEnabled(true, template: .compact)
+        item.composition?.tokens.append(MenuBarToken(kind: .text("tail")))
+        settings.setMenuBarItem(item)
+
+        let decoded = try JSONDecoder().decode(
+            AppSettings.self,
+            from: try JSONEncoder().encode(settings)
+        )
+        let restored = decoded.menuBarItem(.compact)
+        XCTAssertTrue(restored.usesComposedStrip)
+        XCTAssertEqual(restored.composition?.template, .compact)
+        XCTAssertEqual(restored.composition?.tokens.last?.kind, .text("tail"))
+    }
+
+    func testAnUnreadableBlockDropsWithoutTakingTheStripDown() throws {
+        let json = """
+        {"isEnabled":true,"template":"roomy","tokens":[
+          {"id":"11111111-1111-1111-1111-111111111111",
+           "kind":{"type":"text","text":"keep"},
+           "style":{"color":{"type":"primary"},"size":"regular","weight":"medium","monospacedDigits":false},
+           "visibility":{"type":"always"}},
+          {"id":"22222222-2222-2222-2222-222222222222",
+           "kind":{"type":"sparkline","fieldId":"claude.weekly"},
+           "style":{"color":{"type":"primary"},"size":"regular","weight":"medium","monospacedDigits":false},
+           "visibility":{"type":"always"}}
+        ]}
+        """
+        let decoded = try JSONDecoder().decode(MenuBarComposition.self, from: Data(json.utf8))
+        XCTAssertEqual(decoded.tokens.map(\.kind), [.text("keep")])
+    }
+
+    func testUnreadableStyleAndRuleDegradeInsteadOfFailing() throws {
+        let json = """
+        {"isEnabled":true,"template":"kaleidoscope","tokens":[
+          {"id":"33333333-3333-3333-3333-333333333333",
+           "kind":{"type":"text","text":"x"},
+           "style":{"color":{"type":"plaid"},"size":"regular","weight":"medium","monospacedDigits":false},
+           "visibility":{"type":"whenTheMoonIsFull","fieldId":"claude.weekly"}}
+        ]}
+        """
+        let decoded = try JSONDecoder().decode(MenuBarComposition.self, from: Data(json.utf8))
+        // An unknown template is the default one, not a decode failure.
+        XCTAssertEqual(decoded.template, .roomy)
+        XCTAssertEqual(decoded.tokens.count, 1)
+        XCTAssertEqual(decoded.tokens[0].style.color, .primary)
+        XCTAssertEqual(decoded.tokens[0].visibility, .always)
+    }
+
+    func testAnEmptyForecastRuleWouldHideForeverSoItDecodesToAlways() throws {
+        let json = """
+        {"isEnabled":true,"template":"roomy","tokens":[
+          {"id":"44444444-4444-4444-4444-444444444444",
+           "kind":{"type":"text","text":"x"},
+           "style":{"color":{"type":"primary"},"size":"regular","weight":"medium","monospacedDigits":false},
+           "visibility":{"type":"whenForecast","fieldId":"claude.weekly","verdicts":[]}}
+        ]}
+        """
+        let decoded = try JSONDecoder().decode(MenuBarComposition.self, from: Data(json.utf8))
+        XCTAssertEqual(decoded.tokens[0].visibility, .always)
+    }
+}

--- a/Tests/VibeBarCoreTests/MenuBarCompositionTests.swift
+++ b/Tests/VibeBarCoreTests/MenuBarCompositionTests.swift
@@ -1317,6 +1317,78 @@ final class MenuBarCompositionTests: XCTestCase {
         XCTAssertEqual(composed.quotaRequirements.first?.needsForecast, true)
     }
 
+    // MARK: - A label is only silenced when its quota speaks (review thread 1)
+
+    private func labelThenQuota(_ metric: MenuBarQuotaMetric) -> [MenuBarToken] {
+        [
+            MenuBarToken(kind: .text("Weekly")),
+            MenuBarToken(kind: .quota(fieldId: "claude.weekly", metric: metric))
+        ]
+    }
+
+    func testALabelIsStillSpokenWhenItsQuotaBlockHasNothingToSay() {
+        // The forecast exists but does not predict exhaustion, so `runsOutIn`
+        // renders nothing. The label beside it is then the only content on
+        // screen — silencing it would describe less than the strip shows.
+        let noRunOut = quota(
+            "claude.weekly",
+            label: "Weekly",
+            used: 30,
+            forecast: .init(verdict: .enough, projectedRemainingPercent: 60)
+        )
+        XCTAssertEqual(
+            plan(labelThenQuota(.runsOutIn), quotas: [noRunOut]).spokenDescription,
+            "Weekly"
+        )
+
+        // Same one level down: a quota that is answering, but has no forecast
+        // yet for a forecast metric.
+        let noForecast = quota("claude.weekly", label: "Weekly", used: 30)
+        XCTAssertEqual(
+            plan(labelThenQuota(.forecastPercent), quotas: [noForecast]).spokenDescription,
+            "Weekly"
+        )
+
+        // And a countdown with no reset date behind it.
+        XCTAssertEqual(
+            plan(labelThenQuota(.resetsIn), quotas: [noForecast]).spokenDescription,
+            "Weekly"
+        )
+    }
+
+    func testALabelIsStillSpokenWhenItsQuotaBlockIsHiddenByARule() {
+        let calm = quota("claude.weekly", label: "Weekly", used: 10, display: 10)
+        let rendered = plan(
+            [
+                MenuBarToken(kind: .text("Weekly")),
+                MenuBarToken(
+                    kind: .quota(fieldId: "claude.weekly", metric: .displayPercent),
+                    visibility: .whenUsedAtLeast(fieldId: "claude.weekly", percent: 90)
+                )
+            ],
+            quotas: [calm]
+        )
+        XCTAssertEqual(texts(rendered), [["Weekly"]])
+        XCTAssertEqual(rendered.spokenDescription, "Weekly")
+    }
+
+    func testALabelIsStillSilencedWhenItsQuotaDoesSpeak() {
+        // The case the coalescing exists for, unchanged.
+        let live = quota(
+            "claude.weekly",
+            label: "Weekly",
+            used: 30,
+            forecast: .init(
+                verdict: .watch,
+                projectedRemainingPercent: 12,
+                runOutAt: reference.addingTimeInterval(3600 * 5)
+            )
+        )
+        let rendered = plan(labelThenQuota(.runsOutIn), quotas: [live])
+        XCTAssertEqual(texts(rendered), [["Weekly", "5h"]])
+        XCTAssertEqual(rendered.spokenDescription, "Weekly runs out in 5h")
+    }
+
     // MARK: - Persistence
 
     func testCompositionRoundTripsThroughTheSettingsFile() throws {

--- a/Tests/VibeBarCoreTests/MenuBarCompositionTests.swift
+++ b/Tests/VibeBarCoreTests/MenuBarCompositionTests.swift
@@ -950,6 +950,23 @@ final class MenuBarCompositionTests: XCTestCase {
         }
     }
 
+    func testATwoRowTitleLeadsTheFirstRow() {
+        // A named exception, not a gap. The field renderer gives the title a
+        // column of its own that spans both rows; a composition is a linear
+        // list with row breaks and cannot express that. The title leads the
+        // first row instead, which keeps it on screen and first in reading
+        // order. If blocks ever gain a row span, this is the test that says
+        // to revisit the seed.
+        var item = layoutItem(.twoRows, fields: ["claude.five_hour", "claude.weekly"])
+        item.showTitle = true
+        let seeded = MenuBarComposition.seeded(template: .matching(.twoRows), from: item)
+        XCTAssertEqual(seeded.tokens.first?.kind, .text(item.kind.title))
+        let kinds = seeded.tokens.map(\.kind)
+        let breakIndex = kinds.firstIndex(of: .lineBreak)
+        XCTAssertNotNil(breakIndex, "a two-row seed needs a row break")
+        XCTAssertGreaterThan(breakIndex ?? 0, 0, "the title belongs above the break")
+    }
+
     func testASeedNeverAppliesAStyleItsLayoutIgnores() {
         // Single line draws words only. A saved logo style must not put a logo
         // on a strip that has never shown one.

--- a/Tests/VibeBarCoreTests/MenuBarCompositionTests.swift
+++ b/Tests/VibeBarCoreTests/MenuBarCompositionTests.swift
@@ -585,6 +585,144 @@ final class MenuBarCompositionTests: XCTestCase {
         XCTAssertTrue(item.usesComposedStrip)
     }
 
+    // MARK: - Editing
+
+    private func editable() -> MenuBarComposition {
+        composition([
+            MenuBarToken(kind: .text("a")),
+            MenuBarToken(kind: .text("b")),
+            MenuBarToken(kind: .text("c"))
+        ])
+    }
+
+    func testInsertClampsInsteadOfTrapping() {
+        var composed = editable()
+        composed.insert(MenuBarToken(kind: .text("front")), at: -5)
+        composed.insert(MenuBarToken(kind: .text("back")), at: 999)
+        XCTAssertEqual(
+            composed.tokens.map(\.kind),
+            [.text("front"), .text("a"), .text("b"), .text("c"), .text("back")]
+        )
+    }
+
+    func testRemoveReportsWhetherItFoundAnything() {
+        var composed = editable()
+        let id = composed.tokens[1].id
+        XCTAssertTrue(composed.remove(id))
+        XCTAssertEqual(composed.tokens.map(\.kind), [.text("a"), .text("c")])
+        XCTAssertFalse(composed.remove(id))
+    }
+
+    func testDuplicateCopiesInPlaceWithAFreshIdentity() {
+        var composed = editable()
+        let source = composed.tokens[1]
+        let copyId = composed.duplicate(source.id)
+        XCTAssertEqual(composed.tokens.map(\.kind), [.text("a"), .text("b"), .text("b"), .text("c")])
+        XCTAssertNotNil(copyId)
+        XCTAssertNotEqual(copyId, source.id)
+        XCTAssertEqual(composed.tokens[2].id, copyId)
+        // Two blocks that render identically are still two blocks.
+        XCTAssertEqual(Set(composed.tokens.map(\.id)).count, 4)
+        XCTAssertNil(composed.duplicate(UUID()))
+    }
+
+    func testMoveIsStatedInTermsOfTheResultingList() {
+        var composed = editable()
+        let a = composed.tokens[0].id
+        composed.move(a, to: 2)
+        XCTAssertEqual(composed.tokens.map(\.kind), [.text("b"), .text("c"), .text("a")])
+        composed.move(a, to: 0)
+        XCTAssertEqual(composed.tokens.map(\.kind), [.text("a"), .text("b"), .text("c")])
+        // Out of range clamps to the ends rather than trapping.
+        composed.move(a, to: 99)
+        XCTAssertEqual(composed.tokens.last?.kind, .text("a"))
+    }
+
+    func testMoveBeforeWorksInBothDragDirections() {
+        var composed = editable()
+        let a = composed.tokens[0].id
+        let c = composed.tokens[2].id
+        // Rightwards: A lands where C was.
+        composed.move(a, before: c)
+        XCTAssertEqual(composed.tokens.map(\.kind), [.text("b"), .text("a"), .text("c")])
+        // Leftwards: C lands in front of B.
+        let b = composed.tokens[0].id
+        composed.move(c, before: b)
+        XCTAssertEqual(composed.tokens.map(\.kind), [.text("c"), .text("b"), .text("a")])
+        // Dropping a block on itself changes nothing.
+        composed.move(c, before: c)
+        XCTAssertEqual(composed.tokens.map(\.kind), [.text("c"), .text("b"), .text("a")])
+    }
+
+    func testLineBreaksStopBeingOfferedAtTheRowCap() {
+        var composed = composition([MenuBarToken(kind: .text("a"))])
+        XCTAssertTrue(composed.canAddLineBreak)
+        composed.append(MenuBarToken(kind: .lineBreak))
+        XCTAssertEqual(composed.lineBreakCount, 1)
+        // One break is two rows, which is all the status item can draw.
+        XCTAssertFalse(composed.canAddLineBreak)
+    }
+
+    // MARK: - Availability
+
+    func testAvailabilitySeparatesSilentBlocksFromDegradedOnes() {
+        let silent = MenuBarToken(kind: .quota(fieldId: "gone.bucket", metric: .displayPercent))
+        let degradedColor = MenuBarToken(
+            kind: .text("Claude"),
+            style: .init(color: .followsQuota(fieldId: "gone.bucket", basis: .actual))
+        )
+        let degradedRule = MenuBarToken(
+            kind: .logo(.claude),
+            visibility: .whenUsedAtLeast(fieldId: "also.gone", percent: 50)
+        )
+        let fine = MenuBarToken(kind: .quota(fieldId: "claude.five_hour", metric: .label))
+        let composed = composition([silent, degradedColor, degradedRule, fine])
+
+        let availability = composed.availability(liveFieldIds: ["claude.five_hour"])
+        XCTAssertEqual(availability.silentTokenIds, [silent.id])
+        XCTAssertEqual(availability.degradedTokenIds, [degradedColor.id, degradedRule.id])
+        XCTAssertEqual(availability.missingFieldIds, ["gone.bucket", "also.gone"])
+        XCTAssertFalse(availability.isFullyAvailable)
+    }
+
+    func testASilentBlockIsNotAlsoReportedAsDegraded() {
+        // One cause, one warning: a quota block whose own bucket is gone would
+        // otherwise light up twice when its colour follows the same bucket.
+        let token = MenuBarToken(
+            kind: .quota(fieldId: "gone.bucket", metric: .displayPercent),
+            style: .init(color: .followsQuota(fieldId: "gone.bucket", basis: .actual))
+        )
+        let availability = composition([token]).availability(liveFieldIds: [])
+        XCTAssertEqual(availability.silentTokenIds, [token.id])
+        XCTAssertTrue(availability.degradedTokenIds.isEmpty)
+        XCTAssertEqual(availability.missingFieldIds, ["gone.bucket"])
+    }
+
+    func testEverythingLiveIsFullyAvailable() {
+        let composed = composition([
+            MenuBarToken(kind: .quota(fieldId: "claude.five_hour", metric: .displayPercent)),
+            MenuBarToken(kind: .text("x"))
+        ])
+        XCTAssertTrue(composed.availability(liveFieldIds: ["claude.five_hour"]).isFullyAvailable)
+    }
+
+    // MARK: - Truncation
+
+    func testALongTextBlockIsCutShortWithAnEllipsisButStillSpokenInFull() {
+        let long = String(repeating: "x", count: 40)
+        let rendered = plan([MenuBarToken(kind: .text(long))], quotas: [])
+        let drawn = rendered.rows[0].tokens[0].text ?? ""
+        XCTAssertEqual(drawn.count, MenuBarToken.maximumTextLength)
+        XCTAssertTrue(drawn.hasSuffix("…"))
+        XCTAssertEqual(rendered.spokenDescription, long)
+    }
+
+    func testTextAtTheLimitIsLeftAlone() {
+        let exact = String(repeating: "y", count: MenuBarToken.maximumTextLength)
+        let rendered = plan([MenuBarToken(kind: .text(exact))], quotas: [])
+        XCTAssertEqual(rendered.rows[0].tokens[0].text, exact)
+    }
+
     // MARK: - Persistence
 
     func testCompositionRoundTripsThroughTheSettingsFile() throws {

--- a/Tests/VibeBarCoreTests/MenuBarCompositionTests.swift
+++ b/Tests/VibeBarCoreTests/MenuBarCompositionTests.swift
@@ -536,7 +536,7 @@ final class MenuBarCompositionTests: XCTestCase {
         XCTAssertEqual(seeded.tokens.map(\.kind), [
             .quota(fieldId: "claude.five_hour", metric: .label),
             .quota(fieldId: "claude.five_hour", metric: .displayPercent),
-            .separator(" · "),
+            .separator("·"),
             .quota(fieldId: "claude.weekly", metric: .label),
             .quota(fieldId: "claude.weekly", metric: .displayPercent)
         ])
@@ -549,8 +549,10 @@ final class MenuBarCompositionTests: XCTestCase {
             template: .roomy,
             from: fieldItem(merging: true, styles: ["claude.five_hour": .logoLabelAndPercent])
         )
+        // Roomy seeds from Single line, which draws words only and has never
+        // honoured the per-field style — so the saved logo style is dropped
+        // here exactly as the renderer drops it.
         XCTAssertEqual(seeded.tokens.map(\.kind), [
-            .logo(.claude),
             .text("Claude"),
             .quota(fieldId: "claude.five_hour", metric: .displayPercent),
             .separator("/"),
@@ -874,7 +876,11 @@ final class MenuBarCompositionTests: XCTestCase {
 
     // MARK: - Seeding follows the layout (review thread 3)
 
-    private func layoutItem(_ layout: MenuBarLayout, fields: [String]? = nil) -> MenuBarItemSettings {
+    private func layoutItem(
+        _ layout: MenuBarLayout,
+        fields: [String]? = nil,
+        styles: [String: MenuBarFieldStyle] = [:]
+    ) -> MenuBarItemSettings {
         MenuBarItemSettings(
             kind: .compact,
             isVisible: true,
@@ -882,7 +888,8 @@ final class MenuBarCompositionTests: XCTestCase {
             layout: layout,
             selectedFieldIds: fields ?? [
                 "codex.five_hour", "codex.weekly", "claude.five_hour", "claude.weekly"
-            ]
+            ],
+            fieldStyles: styles
         )
     }
 
@@ -918,21 +925,57 @@ final class MenuBarCompositionTests: XCTestCase {
         XCTAssertEqual(bottom, ["codex.weekly", "claude.weekly"])
     }
 
-    func testCompactSeedsSpacesAndSingleLineSeedsDots() {
-        let compact = MenuBarComposition.seeded(
-            template: .matching(.compact),
-            from: layoutItem(.compact, fields: ["claude.five_hour", "claude.weekly"])
-        )
-        XCTAssertTrue(compact.tokens.contains { $0.kind == .space })
-        XCTAssertFalse(compact.tokens.contains { $0.kind == .separator(" · ") })
+    func testEverySeedUsesTheSameSeparatorRuleTheRendererDoes() {
+        // Five review rounds found the seed and the renderer disagreeing about
+        // a different dimension each time, because each kept its own copy of
+        // the rule. Both read `MenuBarFieldStripRules` now, so this asserts
+        // the agreement over every layout instead of listing what each one
+        // happens to draw — a hand-listed expectation is what passed through
+        // all five of those rounds.
+        for layout in MenuBarLayout.allCases {
+            let seeded = MenuBarComposition.seeded(
+                template: .matching(layout),
+                from: layoutItem(layout, fields: ["claude.five_hour", "claude.weekly"])
+            )
+            let separators = seeded.tokens.map(\.kind).filter {
+                if case .separator = $0 { return true }
+                return $0 == .space
+            }
+            let expected = MenuBarFieldStripRules.separator(for: layout)
+            XCTAssertEqual(
+                Set(separators),
+                expected.map { Set([$0]) } ?? [],
+                "\(layout) seeds a separator its renderer does not draw"
+            )
+        }
+    }
 
-        let single = MenuBarComposition.seeded(
-            template: .matching(.singleLine),
-            from: layoutItem(.singleLine, fields: ["claude.five_hour", "claude.weekly"])
-        )
-        XCTAssertTrue(single.tokens.contains { $0.kind == .separator(" · ") })
-        XCTAssertFalse(single.tokens.contains { $0.kind == .space })
-        XCTAssertFalse(single.tokens.contains { $0.kind == .lineBreak })
+    func testASeedNeverAppliesAStyleItsLayoutIgnores() {
+        // Single line draws words only. A saved logo style must not put a logo
+        // on a strip that has never shown one.
+        for layout in MenuBarLayout.allCases {
+            let seeded = MenuBarComposition.seeded(
+                template: .matching(layout),
+                from: layoutItem(
+                    layout,
+                    fields: ["claude.five_hour"],
+                    styles: ["claude.five_hour": .logoLabelAndPercent]
+                )
+            )
+            let hasLogo = seeded.tokens.contains {
+                if case .logo = $0.kind { return true }
+                return false
+            }
+            let styleKeepsLogo = MenuBarFieldStripRules.effectiveStyle(
+                .logoLabelAndPercent, layout: layout
+            ) != .labelAndPercent
+            // Icon Only seeds the app glyph and no field blocks at all.
+            if layout == .iconOnly { continue }
+            XCTAssertEqual(
+                hasLogo, styleKeepsLogo,
+                "\(layout) disagrees with its renderer about the logo style"
+            )
+        }
     }
 
     func testTemplateMatchesTheLayoutItSeedsFrom() {
@@ -1210,7 +1253,7 @@ final class MenuBarCompositionTests: XCTestCase {
         )
         // The strip still *draws* the label blocks — that is what the seeded
         // bar looks like today.
-        XCTAssertEqual(texts(rendered), [["5 Hours", "73%", " · ", "Weekly", "100%"]])
+        XCTAssertEqual(texts(rendered), [["5 Hours", "73%", "·", "Weekly", "100%"]])
         // ...and says each field name exactly once.
         XCTAssertEqual(rendered.spokenDescription, "5 Hours 73% used, Weekly 100% used")
     }
@@ -1543,46 +1586,6 @@ final class MenuBarCompositionTests: XCTestCase {
 
     // MARK: - Seeds match what each layout draws (review thread 2)
 
-    func testTwoRowsSeedsSpacingNotADivider() {
-        // `twoRowMenuColumns` packs entries into columns separated by
-        // `twoRowColumnSpacing` and draws no divider, so a seeded " · " put
-        // punctuation on screen the layout never had.
-        let seeded = MenuBarComposition.seeded(
-            template: .matching(.twoRows),
-            from: layoutItem(.twoRows)
-        )
-        XCTAssertFalse(
-            seeded.tokens.contains { $0.kind == .separator(" · ") },
-            "Two rows draws no dot between entries"
-        )
-        XCTAssertTrue(seeded.tokens.contains { $0.kind == .space })
-    }
-
-    func testEachLayoutSeedsTheSeparatorItsRendererDraws() {
-        // Single line appends a tertiary " · " between pieces.
-        let single = MenuBarComposition.seeded(
-            template: .matching(.singleLine),
-            from: layoutItem(.singleLine, fields: ["claude.five_hour", "claude.weekly"])
-        )
-        XCTAssertTrue(single.tokens.contains { $0.kind == .separator(" · ") })
-        XCTAssertFalse(single.tokens.contains { $0.kind == .space })
-
-        // Compact appends a plain space.
-        let compact = MenuBarComposition.seeded(
-            template: .matching(.compact),
-            from: layoutItem(.compact, fields: ["claude.five_hour", "claude.weekly"])
-        )
-        XCTAssertTrue(compact.tokens.contains { $0.kind == .space })
-        XCTAssertFalse(compact.tokens.contains { $0.kind == .separator(" · ") })
-
-        // Icon Only draws one glyph and nothing else.
-        let icon = MenuBarComposition.seeded(
-            template: .matching(.iconOnly),
-            from: layoutItem(.iconOnly)
-        )
-        XCTAssertEqual(icon.tokens.map(\.kind), [.appIcon])
-    }
-
     // MARK: - A field edit never carries stale neighbours (review thread 2)
 
     func testTwoFieldEditsInOneDebounceWindowBothSurvive() {
@@ -1766,7 +1769,7 @@ final class MenuBarCompositionTests: XCTestCase {
             colorBasis: .actual,
             now: reference
         )
-        XCTAssertEqual(texts(rendered), [["5 Hours", "73%", " · ", "Weekly", "100%"]])
+        XCTAssertEqual(texts(rendered), [["5 Hours", "73%", "·", "Weekly", "100%"]])
         XCTAssertEqual(rendered.spokenDescription, "5 Hours 73% used, Weekly 100% used")
     }
 
@@ -1891,7 +1894,7 @@ final class MenuBarCompositionTests: XCTestCase {
         XCTAssertEqual(rowCount(composed), 1)
         // The divider the break took over comes back, so the entries are still
         // separated rather than run together.
-        XCTAssertTrue(composed.tokens.contains { $0.kind == .separator(" · ") })
+        XCTAssertTrue(composed.tokens.contains { $0.kind == .separator("·") })
     }
 
     func testTheTwoDirectionsRoundTrip() {
@@ -1902,11 +1905,15 @@ final class MenuBarCompositionTests: XCTestCase {
         XCTAssertEqual(composed.tokens.map(\.kind), original.tokens.map(\.kind))
     }
 
-    func testCompactRejoinsWithASpaceBecauseThatIsWhatItDraws() {
+    func testCompactRejoinsWithNothingBecauseThatIsWhatItDraws() {
+        // Compact butts entries together with the ordinary token gap and draws
+        // no character between them, so collapsing two rows into one leaves
+        // the spacing to do the work rather than inserting punctuation.
         var composed = MenuBarComposition.seeded(template: .twoColumn, from: layoutItem(.twoRows))
         composed.setTemplate(.compact)
-        XCTAssertTrue(composed.tokens.contains { $0.kind == .space })
-        XCTAssertFalse(composed.tokens.contains { $0.kind == .separator(" · ") })
+        XCTAssertEqual(composed.lineBreakCount, 0)
+        XCTAssertFalse(composed.tokens.contains { $0.kind == .separator("·") })
+        XCTAssertFalse(composed.tokens.contains { $0.kind == .space })
     }
 
     func testChoosingTwoRowsTwiceDoesNotAddASecondBreak() {

--- a/Tests/VibeBarCoreTests/MenuBarCompositionTests.swift
+++ b/Tests/VibeBarCoreTests/MenuBarCompositionTests.swift
@@ -14,7 +14,7 @@ final class MenuBarCompositionTests: XCTestCase {
         used: Double = 73,
         display: Double? = nil,
         resetAt: Date? = nil,
-        pace: Double? = nil,
+        windowSeconds: Int? = nil,
         forecast: MenuBarQuotaSnapshot.Forecast? = nil
     ) -> MenuBarQuotaSnapshot {
         MenuBarQuotaSnapshot(
@@ -24,8 +24,24 @@ final class MenuBarCompositionTests: XCTestCase {
             usedPercent: used,
             displayPercent: display ?? used,
             resetAt: resetAt,
-            paceDeltaPercent: pace,
+            rawWindowSeconds: windowSeconds,
             forecast: forecast
+        )
+    }
+
+    /// A bucket halfway through its window, so the linear expectation is 50%
+    /// and pace is `used - 50`.
+    private func halfwayQuota(
+        _ fieldId: String = "claude.five_hour",
+        label: String = "5 Hours",
+        used: Double
+    ) -> MenuBarQuotaSnapshot {
+        quota(
+            fieldId,
+            label: label,
+            used: used,
+            resetAt: reference.addingTimeInterval(1800),
+            windowSeconds: 3600
         )
     }
 
@@ -70,11 +86,38 @@ final class MenuBarCompositionTests: XCTestCase {
     }
 
     func testPaceRendersASignedDelta() {
-        XCTAssertEqual(metric(.pace, quota(pace: 12.4)), "+12%")
-        XCTAssertEqual(metric(.pace, quota(pace: -8)), "-8%")
-        XCTAssertEqual(metric(.pace, quota(pace: 0.2)), "±0%")
-        // No window, no reset date, or a cycle past its grace: nothing to say.
-        XCTAssertNil(metric(.pace, quota(pace: nil)))
+        // Halfway through the window, so the linear expectation is 50%.
+        XCTAssertEqual(metric(.pace, halfwayQuota(used: 62)), "+12%")
+        XCTAssertEqual(metric(.pace, halfwayQuota(used: 42)), "-8%")
+        XCTAssertEqual(metric(.pace, halfwayQuota(used: 50)), "±0%")
+        // No window or no reset date: nothing to say.
+        XCTAssertNil(metric(.pace, quota()))
+        XCTAssertNil(metric(.pace, quota(resetAt: reference.addingTimeInterval(60))))
+    }
+
+    func testPaceIsComputedAtDrawTimeSoItAdvancesWithTheClock() {
+        // The same snapshot, read a quarter of an hour later: the expectation
+        // it is measured against has moved, so the figure has to move with it.
+        // Freezing pace into the snapshot is what made it stale between
+        // refreshes — and made the preview and the bar disagree.
+        let snapshot = quota(
+            used: 50,
+            resetAt: reference.addingTimeInterval(1800),
+            windowSeconds: 3600
+        )
+        XCTAssertEqual(
+            MenuBarComposition.value(of: .pace, in: snapshot, displayMode: .used, now: reference),
+            "±0%"
+        )
+        XCTAssertEqual(
+            MenuBarComposition.value(
+                of: .pace,
+                in: snapshot,
+                displayMode: .used,
+                now: reference.addingTimeInterval(900)
+            ),
+            "-25%"
+        )
     }
 
     func testForecastMetricsReadTheProjection() {
@@ -403,9 +446,9 @@ final class MenuBarCompositionTests: XCTestCase {
             uniqueKeysWithValues: composed.quotaRequirements.map { ($0.fieldId, $0) }
         )
         XCTAssertEqual(byField["a.x"]?.needsForecast, false)
-        XCTAssertEqual(byField["a.x"]?.needsPace, false)
         XCTAssertEqual(byField["b.x"]?.needsForecast, true)
-        XCTAssertEqual(byField["c.x"]?.needsPace, true)
+        // Pace is arithmetic over what the snapshot already carries, so it
+        // asks for nothing and stays free.
         XCTAssertEqual(byField["c.x"]?.needsForecast, false)
     }
 
@@ -416,7 +459,6 @@ final class MenuBarCompositionTests: XCTestCase {
             MenuBarToken(kind: .quota(fieldId: "a.x", metric: .forecastPercent))
         ])
         XCTAssertEqual(composed.quotaRequirements.count, 1)
-        XCTAssertEqual(composed.quotaRequirements[0].needsPace, true)
         XCTAssertEqual(composed.quotaRequirements[0].needsForecast, true)
     }
 
@@ -787,7 +829,7 @@ final class MenuBarCompositionTests: XCTestCase {
 
     func testOnlyTimeBasedMetricsAskForAClock() {
         for metric in MenuBarQuotaMetric.allCases {
-            let expected = [.resetsIn, .resetAt, .runsOutIn].contains(metric)
+            let expected = [.resetsIn, .resetAt, .runsOutIn, .pace].contains(metric)
             XCTAssertEqual(metric.isTimeBased, expected, "\(metric)")
             let composed = composition([
                 MenuBarToken(kind: .quota(fieldId: "claude.weekly", metric: metric))
@@ -1042,32 +1084,31 @@ final class MenuBarCompositionTests: XCTestCase {
         let percent = composition([
             MenuBarToken(kind: .quota(fieldId: "claude.weekly", metric: .displayPercent))
         ])
-        let pace = composition([
-            MenuBarToken(kind: .quota(fieldId: "claude.weekly", metric: .pace))
-        ])
-        // The field set is identical, which is why keying a cache on it missed
-        // the edit and left the preview showing nothing for the block.
-        XCTAssertEqual(percent.referencedFieldIds, pace.referencedFieldIds)
-        XCTAssertNotEqual(percent.quotaRequirements, pace.quotaRequirements)
-        XCTAssertEqual(pace.quotaRequirements[0].needsPace, true)
-        XCTAssertEqual(percent.quotaRequirements[0].needsPace, false)
-
-        // Same for a metric that starts needing a forecast.
         let runsOut = composition([
             MenuBarToken(kind: .quota(fieldId: "claude.weekly", metric: .runsOutIn))
         ])
+        // The field set is identical, which is why keying a cache on it missed
+        // the edit and left the preview showing nothing for the block.
         XCTAssertEqual(percent.referencedFieldIds, runsOut.referencedFieldIds)
         XCTAssertNotEqual(percent.quotaRequirements, runsOut.quotaRequirements)
+        XCTAssertEqual(runsOut.quotaRequirements[0].needsForecast, true)
+        XCTAssertEqual(percent.quotaRequirements[0].needsForecast, false)
     }
 
-    func testAPaceBlockRendersAsSoonAsItsSnapshotCarriesPace() {
-        // What the stale cache produced: a snapshot resolved for a percentage
-        // block has no pace, so the pace block draws nothing.
-        let stale = quota("claude.weekly", label: "Weekly", used: 50, pace: nil)
-        let fresh = quota("claude.weekly", label: "Weekly", used: 50, pace: 12)
-        let tokens = [MenuBarToken(kind: .quota(fieldId: "claude.weekly", metric: .pace))]
+    func testAForecastBlockRendersOnlyOnceItsSnapshotCarriesAForecast() {
+        // What a stale cache produces: a snapshot resolved for a percentage
+        // block carries no forecast, so a forecast block draws nothing until
+        // the cache notices the metric changed.
+        let stale = quota("claude.weekly", label: "Weekly", used: 50)
+        let fresh = quota(
+            "claude.weekly",
+            label: "Weekly",
+            used: 50,
+            forecast: .init(verdict: .watch, projectedRemainingPercent: 18)
+        )
+        let tokens = [MenuBarToken(kind: .quota(fieldId: "claude.weekly", metric: .forecastPercent))]
         XCTAssertTrue(plan(tokens, quotas: [stale]).isEmpty)
-        XCTAssertEqual(texts(plan(tokens, quotas: [fresh])), [["+12%"]])
+        XCTAssertEqual(texts(plan(tokens, quotas: [fresh])), [["18%"]])
     }
 
     // MARK: - Two-row run gap (review thread 3)
@@ -1098,6 +1139,99 @@ final class MenuBarCompositionTests: XCTestCase {
         // Degenerate shapes stay sane.
         XCTAssertEqual(MenuBarStripGeometry.cellWidth(runWidths: [], gap: 5), 0)
         XCTAssertEqual(MenuBarStripGeometry.cellWidth(runWidths: [7], gap: 5), 7)
+    }
+
+    // MARK: - Seeded labels are not spoken twice (review thread 3)
+
+    func testASeededStripDrawsItsLabelsButSaysEachFieldOnce() {
+        // End to end: seed the way switching to Custom seeds, then plan it
+        // against live buckets.
+        var seeded = MenuBarComposition.seeded(template: .roomy, from: fieldItem())
+        seeded.isEnabled = true
+        let rendered = seeded.plan(
+            quotas: [
+                quota("claude.five_hour", label: "5 Hours", used: 73, display: 73),
+                quota("claude.weekly", label: "Weekly", used: 100, display: 100)
+            ],
+            displayMode: .used,
+            colorBasis: .actual,
+            now: reference
+        )
+        // The strip still *draws* the label blocks — that is what the seeded
+        // bar looks like today.
+        XCTAssertEqual(texts(rendered), [["5 Hours", "73%", " · ", "Weekly", "100%"]])
+        // ...and says each field name exactly once.
+        XCTAssertEqual(rendered.spokenDescription, "5 Hours 73% used, Weekly 100% used")
+    }
+
+    func testALabelBlockDoingItsOwnWorkIsStillSpoken() {
+        let quotas = [quota("claude.five_hour", label: "5 Hours", used: 40, display: 40)]
+        // A word that is not the quota's name is the user's own and is read.
+        let custom = plan(
+            [
+                MenuBarToken(kind: .text("Claude")),
+                MenuBarToken(kind: .quota(fieldId: "claude.five_hour", metric: .displayPercent))
+            ],
+            quotas: quotas
+        )
+        XCTAssertEqual(custom.spokenDescription, "Claude, 5 Hours 40% used")
+
+        // A row break between them means the label is heading its own row.
+        let split = plan(
+            [
+                MenuBarToken(kind: .text("5 Hours")),
+                MenuBarToken(kind: .lineBreak),
+                MenuBarToken(kind: .quota(fieldId: "claude.five_hour", metric: .displayPercent))
+            ],
+            quotas: quotas
+        )
+        XCTAssertEqual(split.spokenDescription, "5 Hours · 5 Hours 40% used")
+
+        // A label with no quota after it at all is still read.
+        let alone = plan([MenuBarToken(kind: .text("5 Hours"))], quotas: quotas)
+        XCTAssertEqual(alone.spokenDescription, "5 Hours")
+    }
+
+    func testAnEchoedLabelIsSuppressedThroughSpacingOnly() {
+        let quotas = [quota("claude.weekly", label: "Weekly", used: 20, display: 20)]
+        // Spacing between the label and its number does not make it a
+        // different block.
+        let spaced = plan(
+            [
+                MenuBarToken(kind: .text("Weekly")),
+                MenuBarToken(kind: .space),
+                MenuBarToken(kind: .separator(":")),
+                MenuBarToken(kind: .quota(fieldId: "claude.weekly", metric: .displayPercent))
+            ],
+            quotas: quotas
+        )
+        XCTAssertEqual(spaced.spokenDescription, "Weekly 20% used")
+        // Case and surrounding whitespace do not make it a different word.
+        let sloppy = plan(
+            [
+                MenuBarToken(kind: .text(" weekly ")),
+                MenuBarToken(kind: .quota(fieldId: "claude.weekly", metric: .displayPercent))
+            ],
+            quotas: quotas
+        )
+        XCTAssertEqual(sloppy.spokenDescription, "Weekly 20% used")
+        // The rendered token also stops carrying the clause, so every consumer
+        // agrees rather than only the joined description.
+        XCTAssertNil(sloppy.rows[0].tokens[0].spoken)
+        XCTAssertEqual(sloppy.rows[0].tokens[0].text, " weekly ")
+    }
+
+    func testAnEchoedLabelBeforeAnUnavailableQuotaIsStillSpoken() {
+        // The number is gone, so the label is the only thing left describing
+        // the block — suppressing it would leave the strip silent.
+        let rendered = plan(
+            [
+                MenuBarToken(kind: .text("5 Hours")),
+                MenuBarToken(kind: .quota(fieldId: "claude.five_hour", metric: .displayPercent))
+            ],
+            quotas: []
+        )
+        XCTAssertEqual(rendered.spokenDescription, "5 Hours")
     }
 
     // MARK: - Persistence

--- a/Tests/VibeBarCoreTests/MenuBarCompositionTests.swift
+++ b/Tests/VibeBarCoreTests/MenuBarCompositionTests.swift
@@ -1532,6 +1532,125 @@ final class MenuBarCompositionTests: XCTestCase {
         XCTAssertEqual(icon.tokens.map(\.kind), [.appIcon])
     }
 
+    // MARK: - A field edit never carries stale neighbours (review thread 2)
+
+    func testTwoFieldEditsInOneDebounceWindowBothSurvive() {
+        // The exact sequence: pick a colour, then change the threshold before
+        // the colour's queued write has landed. The queued write flushes
+        // first, and the threshold edit must be applied to the token *after*
+        // that flush — a whole-token replacement built beforehand would carry
+        // the old colour and silently undo it.
+        var composed = composition([
+            MenuBarToken(
+                kind: .quota(fieldId: "claude.weekly", metric: .displayPercent),
+                style: .init(color: .primary),
+                visibility: .whenUsedAtLeast(fieldId: "claude.weekly", percent: 80)
+            )
+        ])
+        let id = composed.tokens[0].id
+
+        // The queued colour write, expressed as the field it owns.
+        func edit(_ change: (inout MenuBarToken) -> Void) {
+            guard let index = composed.index(of: id) else { return XCTFail("token went missing") }
+            change(&composed.tokens[index])
+        }
+        edit { $0.style.color = .hex("#ff0000") }
+        // ...then the threshold, from a control that never saw the colour.
+        edit { $0.visibility = .whenUsedAtLeast(fieldId: "claude.weekly", percent: 40) }
+
+        XCTAssertEqual(composed.tokens[0].style.color, .fixed("#ff0000"), "the colour survived")
+        XCTAssertEqual(
+            composed.tokens[0].visibility,
+            .whenUsedAtLeast(fieldId: "claude.weekly", percent: 40),
+            "the threshold survived"
+        )
+    }
+
+    func testAWholeTokenReplacementIsWhatUsedToLoseTheEdit() {
+        // The shape of the old bug, kept as the reason the contract is
+        // field-level: a copy taken before the flush wins over what the flush
+        // wrote, so the colour is gone.
+        var composed = composition([
+            MenuBarToken(
+                kind: .quota(fieldId: "claude.weekly", metric: .displayPercent),
+                style: .init(color: .primary),
+                visibility: .whenUsedAtLeast(fieldId: "claude.weekly", percent: 80)
+            )
+        ])
+        let stale = composed.tokens[0]
+
+        composed.tokens[0].style.color = .hex("#ff0000")
+        var replacement = stale
+        replacement.visibility = .whenUsedAtLeast(fieldId: "claude.weekly", percent: 40)
+        composed.tokens[0] = replacement
+
+        XCTAssertEqual(composed.tokens[0].style.color, .primary, "this is the regression")
+    }
+
+    // MARK: - One glyph-sizing decision (review thread 3)
+
+    func testAOneRowGlyphGrowsWithItsTypeAndATwoRowGlyphIsCapped() {
+        // The single-row strip builds an uncapped attachment, so a Large block
+        // is a large glyph; the preview used to cap it at 12 and show a
+        // different icon from the one the bar drew.
+        XCTAssertEqual(MenuBarStripGeometry.glyphSide(fontSize: 13, rowCount: 1), 16)
+        XCTAssertEqual(MenuBarStripGeometry.singleRowGlyphSide(fontSize: 13), 16)
+        // A `.large` block on the 13pt face: still uncapped, still ~19.
+        XCTAssertEqual(MenuBarStripGeometry.glyphSide(fontSize: 13 * 1.2, rowCount: 1), 19)
+
+        // The two-row band is fixed, so the glyph is capped there.
+        XCTAssertEqual(MenuBarStripGeometry.glyphSide(fontSize: 9, rowCount: 2), 10)
+        XCTAssertEqual(
+            MenuBarStripGeometry.glyphSide(fontSize: 40, rowCount: 2),
+            MenuBarStripGeometry.maximumTwoRowGlyphSide
+        )
+    }
+
+    // MARK: - Localization register
+
+    func testEveryComposerStringIsInBothCatalogs() throws {
+        let (en, zh) = try Self.catalogs()
+        let keys = en.keys.filter { $0.hasPrefix("menuBar.") }
+        XCTAssertFalse(keys.isEmpty)
+        for key in keys {
+            XCTAssertNotNil(zh[key], "\(key) has no Simplified Chinese value")
+            XCTAssertFalse((zh[key] ?? "").isEmpty, "\(key) is empty in Simplified Chinese")
+        }
+    }
+
+    func testTheChineseComposerCopyKeepsTheWrittenRegister() throws {
+        let (_, zh) = try Self.catalogs()
+        // Second person, mood particles, exclamation marks and the banned
+        // colloquial rendering of "surplus" — all of which read as chat rather
+        // than as an interface.
+        let banned = ["你", "您", "吧", "呢", "啦", "！", "用不完"]
+        for (key, value) in zh where key.hasPrefix("menuBar.") {
+            for term in banned {
+                XCTAssertFalse(
+                    value.contains(term),
+                    "\(key) uses \(term), which the written register does not allow: \(value)"
+                )
+            }
+        }
+        // And the term the composer reuses from the forecast surfaces.
+        XCTAssertEqual(zh["quota.forecast.verdict.surplus"], "盈余")
+    }
+
+    /// The two catalogs as flat key → value maps.
+    private static func catalogs() throws -> ([String: String], [String: String]) {
+        let root = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("Resources/i18n")
+        func load(_ name: String) throws -> [String: String] {
+            let data = try Data(contentsOf: root.appendingPathComponent(name))
+            let raw = try JSONSerialization.jsonObject(with: data) as? [String: [String: Any]] ?? [:]
+            return raw.compactMapValues { $0["value"] as? String }
+        }
+        return (try load("en.json"), try load("zh-Hans.json"))
+    }
+
     // MARK: - Persistence
 
     func testCompositionRoundTripsThroughTheSettingsFile() throws {

--- a/Tests/VibeBarCoreTests/MenuBarCompositionTests.swift
+++ b/Tests/VibeBarCoreTests/MenuBarCompositionTests.swift
@@ -950,6 +950,32 @@ final class MenuBarCompositionTests: XCTestCase {
         }
     }
 
+    func testTwoRowsSplitsAStripThatHasNoFieldEntries() {
+        // The composer takes arbitrary blocks, so a strip can be words and
+        // logos with no value to close an entry. Choosing Two rows still has
+        // to produce two rows — a control that quietly produces one is the
+        // defect the seam exists to fix.
+        var composed = composition([
+            MenuBarToken(kind: .logo(.claude)),
+            MenuBarToken(kind: .text("A")),
+            MenuBarToken(kind: .text("B")),
+            MenuBarToken(kind: .appIcon)
+        ])
+        composed.isEnabled = true
+        composed.setTemplate(.twoColumn)
+        XCTAssertEqual(composed.lineBreakCount, 1, "Two rows must add a break")
+        XCTAssertEqual(rowCount(composed), 2)
+    }
+
+    func testASingleBlockStripStaysOnOneRow() {
+        // ...and the fallback must not invent a break where there is nothing
+        // to put on the second row.
+        var composed = composition([MenuBarToken(kind: .text("only"))])
+        composed.isEnabled = true
+        composed.setTemplate(.twoColumn)
+        XCTAssertEqual(composed.lineBreakCount, 0)
+    }
+
     func testATwoRowTitleLeadsTheFirstRow() {
         // A named exception, not a gap. The field renderer gives the title a
         // column of its own that spans both rows; a composition is a linear

--- a/Tests/VibeBarCoreTests/MenuBarCompositionTests.swift
+++ b/Tests/VibeBarCoreTests/MenuBarCompositionTests.swift
@@ -1234,6 +1234,89 @@ final class MenuBarCompositionTests: XCTestCase {
         XCTAssertEqual(rendered.spokenDescription, "5 Hours")
     }
 
+    // MARK: - A row break obeys its own rule (review thread 1)
+
+    private func conditionalBreakTokens(percent: Double) -> [MenuBarToken] {
+        [
+            MenuBarToken(kind: .text("top")),
+            MenuBarToken(
+                kind: .lineBreak,
+                visibility: .whenUsedAtLeast(fieldId: "claude.weekly", percent: percent)
+            ),
+            MenuBarToken(kind: .text("bottom"))
+        ]
+    }
+
+    func testAConditionalRowBreakSplitsOnlyWhenItsRuleIsMet() {
+        // The point of a conditional break: one row normally, two when a quota
+        // goes critical. Evaluating visibility after handling the break made it
+        // split unconditionally.
+        let calm = [quota("claude.weekly", label: "Weekly", used: 40, display: 40)]
+        XCTAssertEqual(
+            texts(plan(conditionalBreakTokens(percent: 90), quotas: calm)),
+            [["top", "bottom"]]
+        )
+
+        let critical = [quota("claude.weekly", label: "Weekly", used: 95, display: 95)]
+        XCTAssertEqual(
+            texts(plan(conditionalBreakTokens(percent: 90), quotas: critical)),
+            [["top"], ["bottom"]]
+        )
+    }
+
+    func testAnUnconditionalRowBreakStillAlwaysSplits() {
+        let rendered = plan(
+            [
+                MenuBarToken(kind: .text("top")),
+                MenuBarToken(kind: .lineBreak),
+                MenuBarToken(kind: .text("bottom"))
+            ],
+            quotas: []
+        )
+        XCTAssertEqual(texts(rendered), [["top"], ["bottom"]])
+    }
+
+    func testARowBreakWhoseRuleCannotBeEvaluatedStillSplits() {
+        // Same contract as every other block: a rule the inputs cannot answer
+        // does not suppress. A strip that silently stopped splitting because a
+        // provider went quiet would look broken.
+        let rendered = plan(conditionalBreakTokens(percent: 90), quotas: [])
+        XCTAssertEqual(texts(rendered), [["top"], ["bottom"]])
+    }
+
+    func testAHiddenRowBreakDoesNotSpendTheRowBudget() {
+        // The cap is on rows actually opened, so a break that never fires must
+        // not use up the one split the status item can draw.
+        let calm = [quota("claude.weekly", label: "Weekly", used: 10, display: 10)]
+        let rendered = plan(
+            [
+                MenuBarToken(kind: .text("a")),
+                MenuBarToken(
+                    kind: .lineBreak,
+                    visibility: .whenUsedAtLeast(fieldId: "claude.weekly", percent: 90)
+                ),
+                MenuBarToken(kind: .text("b")),
+                MenuBarToken(kind: .lineBreak),
+                MenuBarToken(kind: .text("c"))
+            ],
+            quotas: calm
+        )
+        XCTAssertEqual(texts(rendered), [["a", "b"], ["c"]])
+    }
+
+    func testARowBreaksRuleIsPartOfWhatTheStripDependsOn() {
+        // The renderer resolves only the quotas `quotaRequirements` names, so a
+        // rule on a break has to be in there or it could never be evaluated.
+        let composed = composition([
+            MenuBarToken(
+                kind: .lineBreak,
+                visibility: .whenForecast(fieldId: "claude.weekly", verdicts: [.atRisk])
+            )
+        ])
+        XCTAssertEqual(composed.referencedFieldIds, ["claude.weekly"])
+        XCTAssertEqual(composed.quotaRequirements.first?.needsForecast, true)
+    }
+
     // MARK: - Persistence
 
     func testCompositionRoundTripsThroughTheSettingsFile() throws {

--- a/Tests/VibeBarCoreTests/MenuBarCompositionTests.swift
+++ b/Tests/VibeBarCoreTests/MenuBarCompositionTests.swift
@@ -2134,6 +2134,25 @@ final class MenuBarCompositionTests: XCTestCase {
         XCTAssertEqual(composed.tokens[1].style.size, .regular)
     }
 
+    func testAnUnknownQuotaMetricKeepsTheBlockAsWritten() throws {
+        // Substituting a readable metric looked like graceful degradation and
+        // was destructive: the next save wrote the substitute back, so a round
+        // trip through an older build permanently changed what the user chose.
+        let composed = try decodeComposition(tokens: [
+            tokenJSON(
+                kind: #"{"type":"quota","fieldId":"claude.weekly","metric":"vibes"}"#
+            )
+        ])
+        XCTAssertEqual(composed.tokens.count, 1, "the block is kept")
+        guard case .unsupported = composed.tokens[0].kind else {
+            return XCTFail("an unknown metric must be preserved, not substituted")
+        }
+        // And handed back byte-for-byte, which is the whole point.
+        let round = try JSONEncoder().encode(composed)
+        let json = String(decoding: round, as: UTF8.self)
+        XCTAssertTrue(json.contains("vibes"), "the original metric survives a save")
+    }
+
     func testAnUnknownBlockKindIsKeptVerbatimRatherThanDeleted() throws {
         let composed = try decodeComposition(tokens: [
             tokenJSON(),

--- a/Tests/VibeBarCoreTests/MenuBarCompositionTests.swift
+++ b/Tests/VibeBarCoreTests/MenuBarCompositionTests.swift
@@ -1904,6 +1904,116 @@ final class MenuBarCompositionTests: XCTestCase {
         XCTAssertFalse(QuotaGroupLabelLocalizer.isTranslated("GPT-5.3 Codex Spark"))
     }
 
+    // MARK: - Nothing stored depends on the language (review thread 11)
+
+    /// Run `body` with each supported language selected, restoring whatever
+    /// was set before.
+    private func underEachLanguage(_ body: (AppLanguage) -> Void) {
+        let restore = L10n.languageOverride
+        defer { L10n.languageOverride = restore }
+        for language in [AppLanguage.english, .simplifiedChinese] {
+            L10n.languageOverride = language
+            body(language)
+        }
+    }
+
+    func testAddingABlockStoresNothingThatDependsOnTheLanguage() {
+        // A placeholder is prompt copy that happened to be in the field, not
+        // text the user typed. Persisting it froze whichever language was
+        // selected when the block was made — a Chinese placeholder rendered
+        // in an English menu bar forever after.
+        var byLanguage: [AppLanguage: [MenuBarToken.Kind]] = [:]
+        underEachLanguage { language in
+            byLanguage[language] = MenuBarToken.paletteSamples().map(\.kind)
+        }
+        XCTAssertEqual(byLanguage[.english], byLanguage[.simplifiedChinese])
+        // ...and specifically: a fresh text block carries no content at all.
+        XCTAssertEqual(MenuBarToken.newText().kind, .text(""))
+    }
+
+    func testSeedingStoresNothingThatDependsOnTheLanguage() {
+        // The same invariant on the other constructor, so round nine's fix
+        // cannot regress either.
+        var byLanguage: [AppLanguage: [MenuBarToken.Kind]] = [:]
+        underEachLanguage { language in
+            byLanguage[language] = MenuBarComposition
+                .seeded(template: .roomy, from: fieldItem(labels: ["claude.weekly": "C-wk"]))
+                .tokens
+                .map(\.kind)
+        }
+        XCTAssertEqual(byLanguage[.english], byLanguage[.simplifiedChinese])
+    }
+
+    func testEveryStoredStringIsEitherTypedOrAnIdentifier() {
+        // The rule in one assertion: no stored value may equal a catalog
+        // string that differs between the two languages. A value that is the
+        // same in both is either punctuation or a naming-axis identifier, and
+        // those are safe to store.
+        let restore = L10n.languageOverride
+        defer { L10n.languageOverride = restore }
+
+        func storedStrings() -> [String] {
+            var seeded = MenuBarComposition.seeded(template: .roomy, from: fieldItem())
+            seeded.tokens.append(contentsOf: MenuBarToken.paletteSamples())
+            return seeded.tokens.compactMap { token in
+                switch token.kind {
+                case let .text(value): return value
+                case let .separator(value): return value
+                default: return nil
+                }
+            }
+        }
+
+        L10n.languageOverride = .english
+        let english = storedStrings()
+        L10n.languageOverride = .simplifiedChinese
+        let chinese = storedStrings()
+        XCTAssertEqual(english, chinese)
+        for value in english where !value.isEmpty {
+            XCTAssertFalse(
+                Self.isLocalizedCopy(value),
+                "\(value) is copy that exists to be shown; it must not be stored"
+            )
+        }
+    }
+
+    /// Whether a string is one the catalog renders differently per language —
+    /// which makes it copy, not an identifier.
+    private static func isLocalizedCopy(_ value: String) -> Bool {
+        // Reads the catalog files directly, so it neither depends on nor
+        // touches the selected language — this runs inside a test that has
+        // one set, and nudging a global from a helper is how a suite starts
+        // failing depending on what ran before it.
+        guard let (en, zh) = try? catalogs() else { return false }
+        for (key, english) in en where english == value {
+            if let chinese = zh[key], chinese != english { return true }
+        }
+        return false
+    }
+
+    func testAnEmptyTextBlockDrawsNothing() {
+        // The decision this fix turns on: no reserved gap. The block is in the
+        // editor, which says so; the menu bar spends no width on it.
+        let rendered = plan(
+            [
+                MenuBarToken(kind: .text("before")),
+                MenuBarToken.newText(),
+                MenuBarToken(kind: .text("after"))
+            ],
+            quotas: []
+        )
+        XCTAssertEqual(texts(rendered), [["before", "after"]])
+        XCTAssertEqual(rendered.spokenDescription, "before, after")
+    }
+
+    func testWhitespaceTheUserTypedIsStillContent() {
+        // Spaces are a gap they asked for, not an empty block.
+        let rendered = plan([MenuBarToken(kind: .text("   "))], quotas: [])
+        XCTAssertEqual(texts(rendered), [["   "]])
+        // It says nothing, though — there are no words in it.
+        XCTAssertTrue(rendered.spokenDescription.isEmpty)
+    }
+
     // MARK: - Persistence
 
     func testCompositionRoundTripsThroughTheSettingsFile() throws {

--- a/Tests/VibeBarCoreTests/MenuBarCompositionTests.swift
+++ b/Tests/VibeBarCoreTests/MenuBarCompositionTests.swift
@@ -723,6 +723,263 @@ final class MenuBarCompositionTests: XCTestCase {
         XCTAssertEqual(rendered.rows[0].tokens[0].text, exact)
     }
 
+    // MARK: - Own-quota forecast colour (review thread 1)
+
+    func testForecastColourRequestsItsOwnBlocksForecastUnderEitherBasis() {
+        // `.forecast` names no field — it means "this block's own quota" — so
+        // the requirement walk has to attribute it, or the renderer supplies
+        // no verdict and the explicitly chosen forecast colour silently falls
+        // back to the percentage thresholds.
+        let composed = composition([
+            MenuBarToken(
+                kind: .quota(fieldId: "claude.five_hour", metric: .displayPercent),
+                style: .init(color: .forecast)
+            )
+        ])
+        let requirements = composed.quotaRequirements
+        XCTAssertEqual(requirements.count, 1)
+        XCTAssertEqual(requirements[0].fieldId, "claude.five_hour")
+        XCTAssertTrue(
+            requirements[0].needsForecast,
+            "a block asking for the forecast colour must get a forecast computed for it"
+        )
+
+        // And the resolved role is the forecast one whichever basis the app is
+        // set to — the block asked explicitly.
+        for basis in MenuBarColorBasis.allCases {
+            let rendered = composed.plan(
+                quotas: [quota()],
+                displayMode: .used,
+                colorBasis: basis,
+                now: reference
+            )
+            XCTAssertEqual(
+                rendered.rows[0].tokens[0].color,
+                .quota(fieldId: "claude.five_hour", basis: .forecast),
+                "basis \(basis)"
+            )
+        }
+    }
+
+    func testAutomaticColourDoesNotForceAForecastOfItsOwn() {
+        // `.automatic` follows the app-wide basis, which the renderer already
+        // resolves for every quota it draws; it must not add a forecast the
+        // plain field strip would never have computed.
+        let composed = composition([
+            MenuBarToken(
+                kind: .quota(fieldId: "claude.five_hour", metric: .displayPercent),
+                style: .percent
+            )
+        ])
+        XCTAssertEqual(composed.quotaRequirements[0].needsForecast, false)
+    }
+
+    func testForecastColourOnATextBlockAsksForNothing() {
+        // No own quota to follow, so it resolves to `.primary` and needs no
+        // forecast.
+        let composed = composition([
+            MenuBarToken(kind: .text("hi"), style: .init(color: .forecast))
+        ])
+        XCTAssertTrue(composed.quotaRequirements.isEmpty)
+    }
+
+    // MARK: - Countdown clock (review thread 2)
+
+    func testOnlyTimeBasedMetricsAskForAClock() {
+        for metric in MenuBarQuotaMetric.allCases {
+            let expected = [.resetsIn, .resetAt, .runsOutIn].contains(metric)
+            XCTAssertEqual(metric.isTimeBased, expected, "\(metric)")
+            let composed = composition([
+                MenuBarToken(kind: .quota(fieldId: "claude.weekly", metric: metric))
+            ])
+            XCTAssertEqual(composed.hasTimeBasedBlock, expected, "\(metric)")
+        }
+        // A strip of words and logos must not start a timer at all.
+        XCTAssertFalse(composition([
+            MenuBarToken(kind: .text("Claude")),
+            MenuBarToken(kind: .logo(.claude))
+        ]).hasTimeBasedBlock)
+    }
+
+    func testCountdownTicksAreMinuteAlignedAndStrictlyForward() {
+        let anchor = Date(timeIntervalSinceReferenceDate: 1_000_000)
+        // Mid-minute: the next tick is the following boundary.
+        let mid = anchor.addingTimeInterval(23.4)
+        let next = MenuBarCountdownClock.nextTick(after: mid, anchor: anchor)
+        XCTAssertEqual(next.timeIntervalSinceReferenceDate, 1_000_060, accuracy: 1e-9)
+
+        // Exactly on a boundary: strictly after, so a tick that fires a hair
+        // early cannot re-schedule itself for the instant it just handled.
+        let onGrid = anchor.addingTimeInterval(120)
+        XCTAssertEqual(
+            MenuBarCountdownClock.nextTick(after: onGrid, anchor: anchor)
+                .timeIntervalSinceReferenceDate,
+            1_000_180,
+            accuracy: 1e-9
+        )
+
+        // Every tick lands on the shared grid, so the menu bar and the popover
+        // never disagree about what "now" is.
+        var cursor = anchor.addingTimeInterval(7)
+        for _ in 0..<5 {
+            cursor = MenuBarCountdownClock.nextTick(after: cursor, anchor: anchor)
+            let offset = cursor.timeIntervalSince(anchor)
+            XCTAssertEqual(offset.truncatingRemainder(dividingBy: 60), 0, accuracy: 1e-9)
+        }
+    }
+
+    // MARK: - Seeding follows the layout (review thread 3)
+
+    private func layoutItem(_ layout: MenuBarLayout, fields: [String]? = nil) -> MenuBarItemSettings {
+        MenuBarItemSettings(
+            kind: .compact,
+            isVisible: true,
+            showTitle: false,
+            layout: layout,
+            selectedFieldIds: fields ?? [
+                "codex.five_hour", "codex.weekly", "claude.five_hour", "claude.weekly"
+            ]
+        )
+    }
+
+    func testIconOnlySeedsTheGlyphItActuallyShows() {
+        // The default item is `.iconOnly` while still carrying four selected
+        // fields. Expanding those would greet the user with a four-quota strip
+        // they have never seen.
+        let seeded = MenuBarComposition.seeded(
+            template: .matching(.iconOnly),
+            from: layoutItem(.iconOnly)
+        )
+        XCTAssertEqual(seeded.tokens.map(\.kind), [.appIcon])
+    }
+
+    func testTwoRowsSeedsTwoRowsSplitTheWayTheLayoutSplitsThem() {
+        let seeded = MenuBarComposition.seeded(
+            template: .matching(.twoRows),
+            from: layoutItem(.twoRows)
+        )
+        let rendered = seeded.plan(
+            quotas: [], displayMode: .used, colorBasis: .actual, now: reference
+        )
+        XCTAssertEqual(rendered.rows.count, 2)
+        // The two-row layout packs entries into two-cell columns, so its top
+        // row reads entries 0, 2, … and its bottom row 1, 3, ….
+        let kinds = seeded.tokens.map(\.kind)
+        guard let breakIndex = kinds.firstIndex(of: .lineBreak) else {
+            return XCTFail("a two-row seed needs a row break")
+        }
+        let top = kinds[..<breakIndex].compactMap(quotaFieldId)
+        let bottom = kinds[(breakIndex + 1)...].compactMap(quotaFieldId)
+        XCTAssertEqual(top, ["codex.five_hour", "claude.five_hour"])
+        XCTAssertEqual(bottom, ["codex.weekly", "claude.weekly"])
+    }
+
+    func testCompactSeedsSpacesAndSingleLineSeedsDots() {
+        let compact = MenuBarComposition.seeded(
+            template: .matching(.compact),
+            from: layoutItem(.compact, fields: ["claude.five_hour", "claude.weekly"])
+        )
+        XCTAssertTrue(compact.tokens.contains { $0.kind == .space })
+        XCTAssertFalse(compact.tokens.contains { $0.kind == .separator(" · ") })
+
+        let single = MenuBarComposition.seeded(
+            template: .matching(.singleLine),
+            from: layoutItem(.singleLine, fields: ["claude.five_hour", "claude.weekly"])
+        )
+        XCTAssertTrue(single.tokens.contains { $0.kind == .separator(" · ") })
+        XCTAssertFalse(single.tokens.contains { $0.kind == .space })
+        XCTAssertFalse(single.tokens.contains { $0.kind == .lineBreak })
+    }
+
+    func testTemplateMatchesTheLayoutItSeedsFrom() {
+        XCTAssertEqual(MenuBarComposition.Template.matching(.twoRows), .twoColumn)
+        XCTAssertEqual(MenuBarComposition.Template.matching(.compact), .compact)
+        XCTAssertEqual(MenuBarComposition.Template.matching(.singleLine), .roomy)
+        XCTAssertEqual(MenuBarComposition.Template.matching(.iconOnly), .roomy)
+    }
+
+    func testTheAppGlyphRendersAsAGlyphAndIsSpoken() {
+        let rendered = plan([MenuBarToken(kind: .appIcon)], quotas: [])
+        XCTAssertEqual(rendered.rows[0].tokens[0].glyph, .app)
+        XCTAssertNil(rendered.rows[0].tokens[0].text)
+        XCTAssertEqual(rendered.spokenDescription, "Vibe Bar")
+    }
+
+    func testTheAppGlyphRoundTrips() throws {
+        let composed = composition([MenuBarToken(kind: .appIcon)])
+        let decoded = try JSONDecoder().decode(
+            MenuBarComposition.self,
+            from: try JSONEncoder().encode(composed)
+        )
+        XCTAssertEqual(decoded.tokens.map(\.kind), [.appIcon])
+    }
+
+    private func quotaFieldId(_ kind: MenuBarToken.Kind) -> String? {
+        if case let .quota(fieldId, _) = kind { return fieldId }
+        return nil
+    }
+
+    // MARK: - Two-row fit (review thread 4)
+
+    func testAStripThatAlreadyFitsIsNotShrunk() {
+        XCTAssertEqual(
+            MenuBarStripFit.scale(contentHeight: 16, availableHeight: 18),
+            1,
+            accuracy: 1e-9
+        )
+        // Degenerate inputs never produce a zero-size strip.
+        XCTAssertEqual(MenuBarStripFit.scale(contentHeight: 0, availableHeight: 18), 1)
+        XCTAssertEqual(MenuBarStripFit.scale(contentHeight: 20, availableHeight: 0), 1)
+    }
+
+    func testTwoLargeRowsAtTheTopScaleAreShrunkToFitRatherThanCropped() {
+        // The extreme the editor can actually produce: the composition's top
+        // font scale (1.6) times the `.large` step (1.2) on the 9pt two-row
+        // face, two rows tucked by the -2pt line spacing, in the ~18pt of
+        // canvas the status bar leaves after padding.
+        let composed = MenuBarComposition(
+            isEnabled: true,
+            template: .twoColumn,
+            tokens: [
+                MenuBarToken(kind: .text("top"), style: .init(size: .large)),
+                MenuBarToken(kind: .lineBreak),
+                MenuBarToken(kind: .text("bottom"), style: .init(size: .large))
+            ],
+            fontScale: 1.6
+        )
+        let rendered = composed.plan(
+            quotas: [], displayMode: .used, colorBasis: .actual, now: reference
+        )
+        let tokenScale = rendered.rows[0].tokens[0].fontScale
+        XCTAssertEqual(tokenScale, 1.6 * 1.2, accuracy: 1e-9)
+
+        // Text is roughly 1.2x its point size tall, which is what makes two
+        // enlarged rows overflow.
+        let rowHeight = 9.0 * tokenScale * 1.2
+        let contentHeight = rowHeight * 2 - 2
+        let available = 18.0
+        XCTAssertGreaterThan(contentHeight, available, "the extreme must actually overflow")
+
+        let fit = MenuBarStripFit.scale(contentHeight: contentHeight, availableHeight: available)
+        XCTAssertLessThan(fit, 1)
+        XCTAssertGreaterThanOrEqual(fit, MenuBarStripFit.minimumScale)
+        // Shrinking by the returned factor brings it inside the canvas — or,
+        // when the floor bites, at least stops it growing.
+        XCTAssertLessThanOrEqual(
+            contentHeight * fit,
+            max(available, contentHeight * MenuBarStripFit.minimumScale) + 1e-9
+        )
+    }
+
+    func testTheShrinkFloorKeepsTypeLegible() {
+        // An absurd overflow is clamped rather than reduced to a smudge.
+        XCTAssertEqual(
+            MenuBarStripFit.scale(contentHeight: 400, availableHeight: 18),
+            MenuBarStripFit.minimumScale,
+            accuracy: 1e-9
+        )
+    }
+
     // MARK: - Persistence
 
     func testCompositionRoundTripsThroughTheSettingsFile() throws {

--- a/Tests/VibeBarCoreTests/PendingEditQueueTests.swift
+++ b/Tests/VibeBarCoreTests/PendingEditQueueTests.swift
@@ -1,0 +1,89 @@
+import XCTest
+@testable import VibeBarCore
+
+/// The queue that holds a debounced control's last change until a moment the
+/// app can observe.
+@MainActor
+final class PendingEditQueueTests: XCTestCase {
+    func testTwoControlsEditedInOneWindowBothSurvive() {
+        // The regression that came back three review rounds running: a single
+        // pending slot meant the second control to queue silently dropped the
+        // first one's write. Keying the queue is what makes that impossible.
+        let queue = PendingEditQueue()
+        var written: [String] = []
+        queue.schedule("color") { written.append("color") }
+        queue.schedule("threshold") { written.append("threshold") }
+        XCTAssertEqual(queue.pendingKeys, ["color", "threshold"])
+
+        queue.flush()
+        XCTAssertEqual(written, ["color", "threshold"])
+        XCTAssertTrue(queue.pendingKeys.isEmpty)
+    }
+
+    func testEveryOneOfManyControlsSurvivesOneWindow() {
+        // The general shape, so a fourth control added later cannot quietly
+        // reintroduce the bug.
+        let queue = PendingEditQueue()
+        var written: Set<String> = []
+        let keys = (0..<8).map { "control.\($0)" }
+        for key in keys {
+            queue.schedule(key) { written.insert(key) }
+        }
+        XCTAssertEqual(queue.pendingKeys, keys)
+        queue.flush()
+        XCTAssertEqual(written, Set(keys))
+    }
+
+    func testOneControlMovingKeepsOnlyItsNewestValue() {
+        // Within a control, the newest value is the only one that matters —
+        // a colour drag must not write every frame it passed through.
+        let queue = PendingEditQueue()
+        var written: [Int] = []
+        for value in 1...5 {
+            queue.schedule("color") { written.append(value) }
+        }
+        XCTAssertEqual(queue.pendingKeys, ["color"])
+        queue.flush()
+        XCTAssertEqual(written, [5])
+    }
+
+    func testAControlKeepsItsPlaceWhenItQueuesAgain() {
+        let queue = PendingEditQueue()
+        var written: [String] = []
+        queue.schedule("a") { written.append("a-old") }
+        queue.schedule("b") { written.append("b") }
+        queue.schedule("a") { written.append("a-new") }
+        queue.flush()
+        XCTAssertEqual(written, ["a-new", "b"])
+    }
+
+    func testFlushingAnEmptyQueueDoesNothing() {
+        let queue = PendingEditQueue()
+        queue.flush()
+        XCTAssertTrue(queue.pendingKeys.isEmpty)
+    }
+
+    func testAFlushFromInsideACommitDoesNotRecurse() {
+        // Every other edit flushes first, and a queued write is itself an
+        // edit — the queue empties before it runs so the re-entrant call
+        // finds nothing rather than looping.
+        let queue = PendingEditQueue()
+        var runs = 0
+        queue.schedule("self-flushing") {
+            runs += 1
+            queue.flush()
+        }
+        queue.flush()
+        XCTAssertEqual(runs, 1)
+    }
+
+    func testAQueuedWriteLandsOnItsOwnAfterTheIdleWindow() async throws {
+        let queue = PendingEditQueue(delay: .milliseconds(20))
+        var written = false
+        queue.schedule("color") { written = true }
+        XCTAssertFalse(written, "not written while the user may still be moving")
+        try await Task.sleep(for: .milliseconds(200))
+        XCTAssertTrue(written, "written once the control went quiet")
+        XCTAssertTrue(queue.pendingKeys.isEmpty)
+    }
+}

--- a/Tests/VibeBarCoreTests/PendingEditQueueTests.swift
+++ b/Tests/VibeBarCoreTests/PendingEditQueueTests.swift
@@ -78,11 +78,16 @@ final class PendingEditQueueTests: XCTestCase {
     }
 
     func testAQueuedWriteLandsOnItsOwnAfterTheIdleWindow() async throws {
-        let queue = PendingEditQueue(delay: .milliseconds(20))
+        let queue = PendingEditQueue(delay: .milliseconds(5))
         var written = false
         queue.schedule("color") { written = true }
         XCTAssertFalse(written, "not written while the user may still be moving")
-        try await Task.sleep(for: .milliseconds(200))
+        // Polled rather than slept through: a fixed sleep spends wall time on
+        // a shared test timeline whether or not it is needed, and this suite
+        // runs beside timing-sensitive ones.
+        for _ in 0..<100 where !written {
+            try await Task.sleep(for: .milliseconds(5))
+        }
         XCTAssertTrue(written, "written once the control went quiet")
         XCTAssertTrue(queue.pendingKeys.isEmpty)
     }


### PR DESCRIPTION
## Summary

A CodexBar-style composer for the menu-bar item, in two commits: the model and renderer, then the editor. Inert until the user switches the item to Custom — an existing install renders byte-identically.

**The blocks.** An ordered list of typed tokens: a provider logo, free text, one metric of one quota, or structure (space, separator, line break). Nine quota metrics — used / remaining / display percent, pace, forecast percent, resets-in, reset-at, runs-out-in, and the quota's own label — each rendering nothing rather than a placeholder when its input is absent. Every block carries colour, size step, weight, monospaced digits, and a **visibility rule**: always, or only when a quota is above / below a threshold, or only when its forecast reaches a verdict. A rule that cannot be evaluated resolves to *visible*: a block hidden for a reason the user cannot see is indistinguishable from a broken app.

**Colour.** `.automatic` takes the quota's own live colour under the app's colour basis, so a freshly seeded strip looks exactly like the built-in one; `.forecast`, `.followsQuota`, `.brand`, `.primary/.secondary/.tertiary` and `.fixed(hex)` are the rest. The preview and the status item now share one palette — that shared decision replaced `StatusItemController`'s private forecast lookup and accent cache, so the plain strip and a composed one paint an identical percentage identically.

**The editor** (Settings → Menu Bar): template picker → live preview over light and dark grounds → the strip as reorderable chips with a drag-to-remove target → a palette grouped Logo / Text / Quota / Structure, with quota entries grouped by SubProvider so Grok Bot is not filed under Cursor → an inspector for the selected chip. List mutations (insert, move, duplicate, remove) live in Core with tests; `move` is defined in terms of the resulting list.

**The escape hatch is first-class**: a `Default | Custom` picker with the caption "Switching back to Default keeps every block you built — you can return to Custom and find it exactly as you left it." Only the footer's explicit "Start over from the current strip…" reseeds, behind a confirmation.

Also: rows are capped at two and the line-break control disables itself at the cap; a `.text` block draws truncated at 24 characters but keeps and speaks what was typed; brand swatches render through the same table `.brand` resolves through, so a swatch cannot promise a colour the bar will not paint.

## Test plan

- [x] `swift build`
- [x] `swift test` — 2057 tests, 0 failures (51 in `MenuBarCompositionTests`: every metric and its nil cases, visibility including the three unevaluatable paths, row splitting, colour roles under both bases, requirement dedup, seeding, mode-switch non-destruction, full Codable round trip and lossy decode of every unknown enum, list mutations, availability, truncation)
- [x] `./Scripts/build_app.sh release` + `codesign --verify --deep --strict`
- [x] Launches clean in demo mode (no status item registered, no output, stable)
- [ ] **Interactive smoke test outstanding** — drag-reorder a chip, drop one on the remove target, drive the colour well, and resize the settings column to exercise the wrapping chip layout. These four are the only parts not covered by a test or a launch check.

Two bugs found while building: the colour well desynced from the block when the role was switched to Custom (the token id doesn't change, so the draft never resynced), and the chip flow returned `.infinity` for an infinite proposal, which would have let the settings column grow without bound.

🤖 Generated with [Claude Code](https://claude.com/claude-code)