### PR TITLE
Let an agent read a session, not just find one

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -503,12 +503,52 @@ and it is documented rather than hidden for that reason.
 
 **Tools.** `quota.get`, `quota.refresh`, `usage.summary`, `usage.trend`,
 `usage.requests`, `cost.snapshot`, `cost.history`, `sessions.search`,
-`sessions.list`, `status.get`, `pricing.effective`, `skills.install`, plus the
+`sessions.list`, `sessions.transcript`, `status.get`, `pricing.effective`,
+`skills.install`, plus the
 `vibebar://naming-spec` and `vibebar://tools` resources. The naming-spec
 resource is **generated** from `ProviderHierarchyCatalog`, `ToolType` and
 `HarnessCatalog` — never transcribe § 7.1 into it by hand, because a stale
 spec teaches a model a label that no longer exists. `MCPResourceCatalogTests`
-enforces that every harness, company and provider key appears.
+enforces that every harness, company and provider key appears, and that
+`vibebar://tools` routes every tool in the catalog — a new tool that nobody
+can find is a new tool nobody will call.
+
+**The session tools are the local session manager.** `sessions.search` finds
+another agent's working session by what was said in it, `sessions.list` by
+project or time, and `sessions.transcript` reads one. They share one filter
+vocabulary with `usage.*` — `from`, `to`, `models`, `harnesses` — plus
+`projectDir`, which is a case-insensitive **substring** of the working
+directory because that is what `SessionIndexStore.summaryPage` implements in
+SQL; a host-side prefix re-filter would leave the store's `totalCount`
+describing a wider set than the rows returned. `to` and `models` are the two
+the store cannot answer, so they run host-side over a bounded scan and the
+count is withheld rather than misreported (`hasMore` stays truthful);
+`SessionQueryFilter.isAnsweredEntirelyByTheIndex` is the one place that rule
+lives. `sessions.list` still accepts its original `since` as an alias for
+`from`.
+
+`sessions.transcript` returns **bounded windows**, never a whole log. It goes
+through `SessionIndexingBounds.readTranscriptWindow`, which is a wrapper
+around the same `readTranscript` the Workbench viewer uses — one read path,
+one cancellation story, one scratch sweep. There is no seek: a message index
+cannot become a byte offset without parsing, because not every line of a
+rollout produces a message. So the reader *escalates* — 1 MiB, then a limit
+estimated from the bytes-per-message it just measured, up to
+`agentTranscriptByteCeiling` (32 MiB) — and stops the moment it has the
+requested window. Two consequences worth knowing: `totalMessageCount` is
+absent whenever the read stopped short of the end (usually), and a window
+that lies past the ceiling comes back empty with a `readCeiling` reason and
+**no** cursor, so a model cannot loop on it. A search hit's `matchedSeq` is
+always reachable, because the indexer only ever read the first
+`SessionIndexExcerptPolicy.headParseByteLimit` (8 MiB) of the log — anything
+findable is inside the window. Responses are capped by message count, by a
+UTF-8 budget, and per message; every cap that bit is named in
+`truncationReasons`.
+
+Reads resolve **through the index**: the tool takes `id` or
+`sessionId` + `provider`, never a path, so an agent can only open files Vibe
+Bar already discovered under a provider's own roots. The parse runs on a held
+detached task off both the main actor and the index actor.
 
 **Privacy.** Everything is read-only except two tools. `quota.refresh`
 is gated on `AppSettings.mcpServer.allowRefreshTools` and throttled to

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -550,6 +550,25 @@ Reads resolve **through the index**: the tool takes `id` or
 Bar already discovered under a provider's own roots. The parse runs on a held
 detached task off both the main actor and the index actor.
 
+Three refusals are deliberate, because a tool an agent calls in a loop must
+never answer with silence or a stall. A store outside
+`headTruncatableProviders` — Cursor, AntiGravity, Grok, Grok Bot — cannot be
+bounded at all, so above the ceiling `readTranscriptWindow` throws
+`TranscriptReadRefusal.wholeFileOnly` naming the size instead of parsing the
+whole thing. A window whose cursor could not advance (the read never reached
+it, or the role filter can never match) returns **no** cursor rather than one
+that repeats the same page. And `sessions.search` applies its host-side
+filters after the index's ranking cut, so when a page comes back short because
+of that cut it says so in `notice` — an agent cannot otherwise tell "nothing
+matches" from "the cut ate the matches".
+
+The backfill for a never-built index lives behind one door
+(`MCPController.readingSessions`) shared by all three reads, and that door asks
+the store whether it has ever held a row. It must not infer it from a zero-row
+result: an offset past the end, a filter that matches nothing and an unknown id
+are all ordinary empty answers, and treating them as "unbuilt" turned each one
+into a filesystem-wide sweep.
+
 **Privacy.** Everything is read-only except two tools. `quota.refresh`
 is gated on `AppSettings.mcpServer.allowRefreshTools` and throttled to
 one forced refresh per 20 s. `skills.install` is gated on

--- a/Sources/VibeBarApp/MCPController.swift
+++ b/Sources/VibeBarApp/MCPController.swift
@@ -45,6 +45,9 @@ final class MCPController: ObservableObject, MCPDataSource {
     private var didAttemptSessionBackfill = false
     /// Built on the first `sessions.transcript` call. See `transcriptRegistry`.
     private var registryStorage: SessionProviderRegistry?
+    /// Latched once the index is known to hold rows, so `readingSessions`
+    /// stops asking. See `isSessionIndexUnbuilt`.
+    private var didObservePopulatedIndex = false
 
     /// How long a connected client may say nothing before its socket is
     /// closed.
@@ -335,49 +338,111 @@ final class MCPController: ObservableObject, MCPDataSource {
 
     /// The one door every session read goes through.
     ///
-    /// `read` runs, and if it came back empty on an index that has never been
-    /// built, the one-per-process backfill runs and `read` is retried. It is a
-    /// single entry point on purpose: the backfill used to be remembered at
-    /// each call site, and the host-side `sessions.list` path was added
-    /// without it — so a fresh install with a `to` or `models` filter returned
-    /// zero and never scanned. Two places that must both remember something
-    /// is how that happens.
+    /// `read` runs, and if the index has *never been built* the one-per-process
+    /// backfill runs and `read` is retried. It is a single entry point on
+    /// purpose: the backfill used to be remembered at each call site, and the
+    /// host-side `sessions.list` path was added without it — so a fresh
+    /// install with a `to` or `models` filter returned zero and never scanned.
+    ///
+    /// "Never been built" is asked of the store, not inferred from a zero-row
+    /// result. Inferring it made the door far too eager: an offset past the
+    /// last row, a filter that legitimately matches nothing, an unknown
+    /// transcript id — each of those is an ordinary empty answer, and each
+    /// used to kick off a filesystem-wide sweep of every provider's logs.
+    /// `isEmpty` survives only as a cheap gate on *asking*: rows in hand
+    /// already prove the index is populated, so the count query never runs on
+    /// the common path.
     private func readingSessions<T>(
-        isEmpty: @escaping (T) -> Bool,
+        isEmpty: (T) -> Bool,
         _ read: (SessionIndexService) async throws -> T
     ) async throws -> T {
         let index = try sessionIndexService()
         let first = try await read(index)
-        guard isEmpty(first), await backfillSessionIndexIfNeeded(index) else { return first }
+        guard isEmpty(first) else {
+            didObservePopulatedIndex = true
+            return first
+        }
+        guard await isSessionIndexUnbuilt(), await backfillSessionIndexIfNeeded(index) else {
+            return first
+        }
         return try await read(index)
+    }
+
+    /// Has the session index never held a row?
+    ///
+    /// One `SELECT COUNT(*)` per process at most: a populated index latches
+    /// the flag and is never asked again, and an unpopulated one is answered
+    /// by the backfill's own one-shot guard.
+    private func isSessionIndexUnbuilt() async -> Bool {
+        if didObservePopulatedIndex { return false }
+        guard let store = environment?.sessionIndex.store else { return false }
+        let count = (try? await store.sessionCount()) ?? 0
+        if count > 0 {
+            didObservePopulatedIndex = true
+            return false
+        }
+        return true
     }
 
     func searchSessions(
         query: String,
         filter: SessionQueryFilter,
         limit: Int
-    ) async throws -> [SessionSearchHit] {
+    ) async throws -> MCPSessionSearchOutcome {
         // An explicitly empty list means "nothing" (see
         // `SessionQueryFilter.matchesNothing`), and nothing is answerable
         // without touching the index at all.
-        guard !filter.matchesNothing else { return [] }
-        // The store ranks and caps; `to`, `from` and `models` are ours to
+        guard !filter.matchesNothing else { return MCPSessionSearchOutcome(hits: []) }
+        // The store ranks and caps, and `to`, `from` and `models` are ours to
         // apply afterwards (it has no upper time bound and no model column
-        // filter). Over-fetch so a narrow filter over a broad query still
-        // fills a page, but stay bounded — this is a ranked result set, not a
-        // scan, and asking for the whole index would defeat the ranking.
-        let wanted = filter.isAnsweredEntirelyByTheIndex && filter.from == nil
-            ? limit
-            : min(limit * Self.searchOverFetchFactor, Self.searchOverFetchCap)
-        let hits = try await readingSessions(isEmpty: \.isEmpty) { index in
-            try await Self.rankedHits(index, query: query, filter: filter, limit: wanted)
+        // filter). So the host-side filter runs *after* the ranking cut, and
+        // a query whose top hits are all excluded — searching with an old
+        // `to` bound against a term that matches mostly recent sessions — can
+        // starve a page of matches that exist further down.
+        //
+        // Escalate rather than accept that: ask for more ranked hits until
+        // the page is filled or the store's own ceiling is reached. At most
+        // two passes, and FTS ranking is the fast part of this query.
+        let needsHostFilter = !(filter.isAnsweredEntirelyByTheIndex && filter.from == nil)
+        return try await readingSessions(isEmpty: \.hits.isEmpty) { index in
+            var wanted = needsHostFilter
+                ? min(limit * Self.searchOverFetchFactor, Self.searchOverFetchCap)
+                : limit
+            var matched: [SessionSearchHit] = []
+            var sawEverything = false
+            while true {
+                let hits = try await Self.rankedHits(
+                    index, query: query, filter: filter, limit: wanted
+                )
+                matched = hits.filter { filter.matches($0.summary) }
+                // Fewer hits than asked for means the store had no more to
+                // rank, so nothing is hiding below the cut.
+                sawEverything = hits.count < wanted
+                if matched.count >= limit || sawEverything || wanted >= Self.searchRankingCeiling {
+                    break
+                }
+                wanted = Self.searchRankingCeiling
+            }
+            // Silence is the one wrong answer here: an agent cannot tell
+            // "nothing matches" from "the ranking cut ate the matches".
+            let incomplete = matched.count < limit && !sawEverything
+            return MCPSessionSearchOutcome(
+                hits: Array(matched.prefix(limit)),
+                notice: incomplete
+                    ? "Filters ran after the ranking cut: the top \(wanted) hits for this query "
+                        + "yielded \(matched.count) match(es), and more may exist below the cut. "
+                        + "Narrow 'query', or widen 'from' / 'to' / 'models' / 'projectDir'."
+                    : nil
+            )
         }
-        return Array(hits.filter { filter.matches($0.summary) }.prefix(limit))
     }
 
-    /// Over-fetch multiplier and ceiling for a filtered search.
+    /// Over-fetch multiplier and the ceiling on one ranked pass.
     private static let searchOverFetchFactor = 4
     private static let searchOverFetchCap = 200
+    /// `SessionIndexStore.search` clamps its own limit here, so asking for
+    /// more than this returns the same rows.
+    private static let searchRankingCeiling = 500
     /// How many index rows a host-side-filtered `sessions.list` will walk
     /// before it stops and says so. Eight store pages at 11 000 indexed
     /// sessions — enough to page deep into a filtered view, bounded enough

--- a/Sources/VibeBarApp/MCPController.swift
+++ b/Sources/VibeBarApp/MCPController.swift
@@ -333,12 +333,34 @@ final class MCPController: ObservableObject, MCPDataSource {
 
     // MARK: - MCPDataSource: sessions
 
+    /// The one door every session read goes through.
+    ///
+    /// `read` runs, and if it came back empty on an index that has never been
+    /// built, the one-per-process backfill runs and `read` is retried. It is a
+    /// single entry point on purpose: the backfill used to be remembered at
+    /// each call site, and the host-side `sessions.list` path was added
+    /// without it — so a fresh install with a `to` or `models` filter returned
+    /// zero and never scanned. Two places that must both remember something
+    /// is how that happens.
+    private func readingSessions<T>(
+        isEmpty: @escaping (T) -> Bool,
+        _ read: (SessionIndexService) async throws -> T
+    ) async throws -> T {
+        let index = try sessionIndexService()
+        let first = try await read(index)
+        guard isEmpty(first), await backfillSessionIndexIfNeeded(index) else { return first }
+        return try await read(index)
+    }
+
     func searchSessions(
         query: String,
         filter: SessionQueryFilter,
         limit: Int
     ) async throws -> [SessionSearchHit] {
-        let index = try sessionIndexService()
+        // An explicitly empty list means "nothing" (see
+        // `SessionQueryFilter.matchesNothing`), and nothing is answerable
+        // without touching the index at all.
+        guard !filter.matchesNothing else { return [] }
         // The store ranks and caps; `to`, `from` and `models` are ours to
         // apply afterwards (it has no upper time bound and no model column
         // filter). Over-fetch so a narrow filter over a broad query still
@@ -347,9 +369,8 @@ final class MCPController: ObservableObject, MCPDataSource {
         let wanted = filter.isAnsweredEntirelyByTheIndex && filter.from == nil
             ? limit
             : min(limit * Self.searchOverFetchFactor, Self.searchOverFetchCap)
-        var hits = try await Self.rankedHits(index, query: query, filter: filter, limit: wanted)
-        if hits.isEmpty, await backfillSessionIndexIfNeeded(index) {
-            hits = try await Self.rankedHits(index, query: query, filter: filter, limit: wanted)
+        let hits = try await readingSessions(isEmpty: \.isEmpty) { index in
+            try await Self.rankedHits(index, query: query, filter: filter, limit: wanted)
         }
         return Array(hits.filter { filter.matches($0.summary) }.prefix(limit))
     }
@@ -384,57 +405,64 @@ final class MCPController: ObservableObject, MCPDataSource {
         offset: Int,
         limit: Int
     ) async throws -> MCPSessionListing {
-        let index = try sessionIndexService()
-        // Fast path: the index can answer all of it, so its own count and
-        // offset describe exactly the rows returned.
-        if filter.isAnsweredEntirelyByTheIndex {
-            var page = try await Self.storePage(index, filter: filter, offset: offset, limit: limit)
-            if page.totalCount == 0, await backfillSessionIndexIfNeeded(index) {
-                page = try await Self.storePage(index, filter: filter, offset: offset, limit: limit)
-            }
+        guard !filter.matchesNothing else {
             return MCPSessionListing(
-                summaries: page.summaries,
-                totalCount: page.totalCount,
-                offset: page.offset,
-                limit: page.limit,
-                hasMore: page.offset + page.summaries.count < page.totalCount
+                summaries: [], totalCount: 0, offset: offset, limit: limit, hasMore: false
             )
         }
+        // Both paths go through `readingSessions`, so a fresh install
+        // backfills and retries whichever one the filter selected.
+        return try await readingSessions(isEmpty: \.summaries.isEmpty) { index in
+            // Fast path: the index can answer all of it, so its own count and
+            // offset describe exactly the rows returned.
+            if filter.isAnsweredEntirelyByTheIndex {
+                let page = try await Self.storePage(
+                    index, filter: filter, offset: offset, limit: limit
+                )
+                return MCPSessionListing(
+                    summaries: page.summaries,
+                    totalCount: page.totalCount,
+                    offset: page.offset,
+                    limit: page.limit,
+                    hasMore: page.offset + page.summaries.count < page.totalCount
+                )
+            }
 
-        // Host-side path: walk the index in store pages and filter as we go.
-        // `totalCount` is withheld rather than reported — the store's count
-        // describes the rows before `to` / `models` ran.
-        var kept: [SessionSummary] = []
-        var scanned = 0
-        var storeOffset = 0
-        var exhausted = false
-        // One past the last row this page needs, so the loop knows when to
-        // stop instead of draining the index.
-        let needed = offset + limit + 1
-        while kept.count < needed, scanned < Self.listScanCap {
-            let page = try await Self.storePage(
-                index, filter: filter, offset: storeOffset, limit: Self.listStorePageSize
+            // Host-side path: walk the index in store pages and filter as we
+            // go. `totalCount` is withheld rather than reported — the store's
+            // count describes the rows before `to` / `models` ran.
+            var kept: [SessionSummary] = []
+            var scanned = 0
+            var storeOffset = 0
+            var exhausted = false
+            // One past the last row this page needs, so the loop knows when to
+            // stop instead of draining the index.
+            let needed = offset + limit + 1
+            while kept.count < needed, scanned < Self.listScanCap {
+                let page = try await Self.storePage(
+                    index, filter: filter, offset: storeOffset, limit: Self.listStorePageSize
+                )
+                guard !page.summaries.isEmpty else { exhausted = true; break }
+                scanned += page.summaries.count
+                storeOffset += page.summaries.count
+                kept.append(contentsOf: page.summaries.filter(filter.matches))
+                if storeOffset >= page.totalCount { exhausted = true; break }
+            }
+            let window = Array(kept.dropFirst(offset).prefix(limit))
+            let hasMore = kept.count > offset + window.count || !exhausted
+            return MCPSessionListing(
+                summaries: window,
+                totalCount: exhausted && scanned < Self.listScanCap ? kept.count : nil,
+                offset: offset,
+                limit: limit,
+                hasMore: hasMore,
+                notice: scanned >= Self.listScanCap
+                    ? "Stopped after examining \(scanned) indexed sessions; 'to' and 'models' are "
+                        + "applied after the index query. Narrow 'from', 'projectDir' or 'harnesses' "
+                        + "to see further back."
+                    : nil
             )
-            guard !page.summaries.isEmpty else { exhausted = true; break }
-            scanned += page.summaries.count
-            storeOffset += page.summaries.count
-            kept.append(contentsOf: page.summaries.filter(filter.matches))
-            if storeOffset >= page.totalCount { exhausted = true; break }
         }
-        let window = Array(kept.dropFirst(offset).prefix(limit))
-        let hasMore = kept.count > offset + window.count || !exhausted
-        return MCPSessionListing(
-            summaries: window,
-            totalCount: exhausted && scanned < Self.listScanCap ? kept.count : nil,
-            offset: offset,
-            limit: limit,
-            hasMore: hasMore,
-            notice: scanned >= Self.listScanCap
-                ? "Stopped after examining \(scanned) indexed sessions; 'to' and 'models' are "
-                    + "applied after the index query. Narrow 'from', 'projectDir' or 'harnesses' "
-                    + "to see further back."
-                : nil
-        )
     }
 
     private nonisolated static func storePage(
@@ -470,16 +498,10 @@ final class MCPController: ObservableObject, MCPDataSource {
         locator: SessionLocator,
         window: TranscriptWindowRequest
     ) async throws -> SessionTranscriptResult {
-        let index = try sessionIndexService()
-        var summary = try await index.summary(
-            provider: locator.provider, sessionID: locator.sessionID
-        )
-        if summary == nil, await backfillSessionIndexIfNeeded(index) {
-            summary = try await index.summary(
-                provider: locator.provider, sessionID: locator.sessionID
-            )
+        let found = try await readingSessions(isEmpty: { $0 == nil }) { index in
+            try await index.summary(provider: locator.provider, sessionID: locator.sessionID)
         }
-        guard let summary else {
+        guard let summary = found else {
             throw MCPToolFailure(
                 "No indexed \(locator.provider.displayName) session with id '\(locator.sessionID)'. "
                     + "The index is as fresh as Vibe Bar's last sweep, so a session created moments "

--- a/Sources/VibeBarApp/MCPController.swift
+++ b/Sources/VibeBarApp/MCPController.swift
@@ -43,6 +43,8 @@ final class MCPController: ObservableObject, MCPDataSource {
     /// to open the Workbench, which reads as a bug rather than as an empty
     /// index.
     private var didAttemptSessionBackfill = false
+    /// Built on the first `sessions.transcript` call. See `transcriptRegistry`.
+    private var registryStorage: SessionProviderRegistry?
 
     /// How long a connected client may say nothing before its socket is
     /// closed.
@@ -57,7 +59,7 @@ final class MCPController: ObservableObject, MCPDataSource {
     /// shorter than a day of leaving editors open.
     static let clientIdleTimeout: TimeInterval = 45 * 60
 
-    init(environment: AppEnvironment, socketPath: String = MCPSocketServer.defaultSocketPath) {
+    init(environment: AppEnvironment, socketPath: String = MCPSocketServer.configuredSocketPath) {
         self.environment = environment
         self.socketPath = socketPath
     }
@@ -333,45 +335,207 @@ final class MCPController: ObservableObject, MCPDataSource {
 
     func searchSessions(
         query: String,
-        providers: [SessionProvider]?,
-        harnesses: [Harness]?,
+        filter: SessionQueryFilter,
         limit: Int
     ) async throws -> [SessionSearchHit] {
         let index = try sessionIndexService()
-        var hits = try await index.search(query, providers: providers, harnesses: harnesses, limit: limit)
+        // The store ranks and caps; `to`, `from` and `models` are ours to
+        // apply afterwards (it has no upper time bound and no model column
+        // filter). Over-fetch so a narrow filter over a broad query still
+        // fills a page, but stay bounded — this is a ranked result set, not a
+        // scan, and asking for the whole index would defeat the ranking.
+        let wanted = filter.isAnsweredEntirelyByTheIndex && filter.from == nil
+            ? limit
+            : min(limit * Self.searchOverFetchFactor, Self.searchOverFetchCap)
+        var hits = try await Self.rankedHits(index, query: query, filter: filter, limit: wanted)
         if hits.isEmpty, await backfillSessionIndexIfNeeded(index) {
-            hits = try await index.search(query, providers: providers, harnesses: harnesses, limit: limit)
+            hits = try await Self.rankedHits(index, query: query, filter: filter, limit: wanted)
         }
-        return hits
+        return Array(hits.filter { filter.matches($0.summary) }.prefix(limit))
+    }
+
+    /// Over-fetch multiplier and ceiling for a filtered search.
+    private static let searchOverFetchFactor = 4
+    private static let searchOverFetchCap = 200
+    /// How many index rows a host-side-filtered `sessions.list` will walk
+    /// before it stops and says so. Eight store pages at 11 000 indexed
+    /// sessions — enough to page deep into a filtered view, bounded enough
+    /// that a pathological filter cannot turn one tool call into a full scan.
+    private static let listScanCap = 4_000
+    private static let listStorePageSize = 500
+
+    private nonisolated static func rankedHits(
+        _ index: SessionIndexService,
+        query: String,
+        filter: SessionQueryFilter,
+        limit: Int
+    ) async throws -> [SessionSearchHit] {
+        try await index.search(
+            query,
+            providers: filter.providers,
+            harnesses: filter.harnesses,
+            projectIncludes: filter.projectIncludes,
+            limit: limit
+        )
     }
 
     func listSessions(
-        providers: [SessionProvider]?,
-        harnesses: [Harness]?,
-        since: Date?,
+        filter: SessionQueryFilter,
+        offset: Int,
+        limit: Int
+    ) async throws -> MCPSessionListing {
+        let index = try sessionIndexService()
+        // Fast path: the index can answer all of it, so its own count and
+        // offset describe exactly the rows returned.
+        if filter.isAnsweredEntirelyByTheIndex {
+            var page = try await Self.storePage(index, filter: filter, offset: offset, limit: limit)
+            if page.totalCount == 0, await backfillSessionIndexIfNeeded(index) {
+                page = try await Self.storePage(index, filter: filter, offset: offset, limit: limit)
+            }
+            return MCPSessionListing(
+                summaries: page.summaries,
+                totalCount: page.totalCount,
+                offset: page.offset,
+                limit: page.limit,
+                hasMore: page.offset + page.summaries.count < page.totalCount
+            )
+        }
+
+        // Host-side path: walk the index in store pages and filter as we go.
+        // `totalCount` is withheld rather than reported — the store's count
+        // describes the rows before `to` / `models` ran.
+        var kept: [SessionSummary] = []
+        var scanned = 0
+        var storeOffset = 0
+        var exhausted = false
+        // One past the last row this page needs, so the loop knows when to
+        // stop instead of draining the index.
+        let needed = offset + limit + 1
+        while kept.count < needed, scanned < Self.listScanCap {
+            let page = try await Self.storePage(
+                index, filter: filter, offset: storeOffset, limit: Self.listStorePageSize
+            )
+            guard !page.summaries.isEmpty else { exhausted = true; break }
+            scanned += page.summaries.count
+            storeOffset += page.summaries.count
+            kept.append(contentsOf: page.summaries.filter(filter.matches))
+            if storeOffset >= page.totalCount { exhausted = true; break }
+        }
+        let window = Array(kept.dropFirst(offset).prefix(limit))
+        let hasMore = kept.count > offset + window.count || !exhausted
+        return MCPSessionListing(
+            summaries: window,
+            totalCount: exhausted && scanned < Self.listScanCap ? kept.count : nil,
+            offset: offset,
+            limit: limit,
+            hasMore: hasMore,
+            notice: scanned >= Self.listScanCap
+                ? "Stopped after examining \(scanned) indexed sessions; 'to' and 'models' are "
+                    + "applied after the index query. Narrow 'from', 'projectDir' or 'harnesses' "
+                    + "to see further back."
+                : nil
+        )
+    }
+
+    private nonisolated static func storePage(
+        _ index: SessionIndexService,
+        filter: SessionQueryFilter,
         offset: Int,
         limit: Int
     ) async throws -> SessionSummaryPage {
-        let index = try sessionIndexService()
-        var page = try await index.summaryPage(
-            providers: providers,
-            harnesses: harnesses,
-            since: since,
+        try await index.summaryPage(
+            providers: filter.providers,
+            harnesses: filter.harnesses,
+            since: filter.from,
+            projectIncludes: filter.projectIncludes,
             order: .recentFirst,
             offset: offset,
             limit: limit
         )
-        if page.totalCount == 0, await backfillSessionIndexIfNeeded(index) {
-            page = try await index.summaryPage(
-                providers: providers,
-                harnesses: harnesses,
-                since: since,
-                order: .recentFirst,
-                offset: offset,
-                limit: limit
+    }
+
+    // MARK: - MCPDataSource: transcripts
+
+    /// The raw registry, built once. The *bounded* one lives on
+    /// `SharedSessionIndex` and belongs to the indexer; a transcript read
+    /// wants whole messages, bounded by bytes rather than by excerpt policy.
+    private var transcriptRegistry: SessionProviderRegistry {
+        if let registryStorage { return registryStorage }
+        let registry = SessionProviderRegistry.standard(homeDirectory: RealHomeDirectory.path)
+        registryStorage = registry
+        return registry
+    }
+
+    func sessionTranscript(
+        locator: SessionLocator,
+        window: TranscriptWindowRequest
+    ) async throws -> SessionTranscriptResult {
+        let index = try sessionIndexService()
+        var summary = try await index.summary(
+            provider: locator.provider, sessionID: locator.sessionID
+        )
+        if summary == nil, await backfillSessionIndexIfNeeded(index) {
+            summary = try await index.summary(
+                provider: locator.provider, sessionID: locator.sessionID
             )
         }
-        return page
+        guard let summary else {
+            throw MCPToolFailure(
+                "No indexed \(locator.provider.displayName) session with id '\(locator.sessionID)'. "
+                    + "The index is as fresh as Vibe Bar's last sweep, so a session created moments "
+                    + "ago may not be in it yet. Use sessions.search or sessions.list to get an id."
+            )
+        }
+        guard let adapter = transcriptRegistry.adapter(for: summary.provider) else {
+            throw MCPToolFailure("No reader is registered for \(summary.provider.displayName).")
+        }
+        let scratch = VibeBarLocalStore.sessionIndexScratchDirectoryURL(
+            homeDirectory: RealHomeDirectory.path
+        )
+        // Off the main actor, and off the index actor: the read is the
+        // expensive part and neither of those may wait on it.
+        let read = try await Self.readWindow(
+            adapter: adapter,
+            url: URL(fileURLWithPath: summary.sourcePath),
+            request: window,
+            scratchDirectory: scratch
+        )
+        return SessionTranscriptResult(summary: summary, window: read)
+    }
+
+    /// Same shape as the Workbench's transcript parse: a held detached task
+    /// with its cancellation forwarded, so a client that disconnects mid-read
+    /// actually stops the parse instead of only stopping the wait.
+    private nonisolated static func readWindow(
+        adapter: any SessionProviderAdapter,
+        url: URL,
+        request: TranscriptWindowRequest,
+        scratchDirectory: URL
+    ) async throws -> TranscriptWindow {
+        let handle = Task.detached(priority: .userInitiated) {
+            try SessionIndexingBounds.readTranscriptWindow(
+                adapter: adapter,
+                fileURL: url,
+                request: request,
+                scratchDirectory: scratchDirectory
+            )
+        }
+        return try await withTaskCancellationHandler {
+            do {
+                return try await handle.value
+            } catch is CancellationError {
+                throw MCPToolFailure("The transcript read was cancelled.")
+            } catch {
+                // Never the raw error: a parse failure's description can carry
+                // the path, and this string goes to an agent and into logs.
+                throw MCPToolFailure(
+                    "This session's log could not be read: "
+                        + SafeLog.sanitize(error.localizedDescription)
+                )
+            }
+        } onCancel: {
+            handle.cancel()
+        }
     }
 
     /// The app-wide index, opened on this call if nothing has needed it yet.

--- a/Sources/VibeBarCore/Compat/AgentSessionKitReexport.swift
+++ b/Sources/VibeBarCore/Compat/AgentSessionKitReexport.swift
@@ -63,6 +63,27 @@ extension MCPSocketServer {
         VibeBarLocalStore.baseDirectory.appendingPathComponent("mcp.sock").path
     }
 
+    /// Where *this* process should listen.
+    ///
+    /// `VIBEBAR_MCP_SOCKET` moves it, which is what `AGENTS.md` § 5.1 has
+    /// always said the variable is for — "tests (and a second build) can
+    /// point at a temporary socket". Only the stdio bridge honoured it,
+    /// though, so a second build still bound `~/.vibebar/mcp.sock` and took
+    /// it from the copy the user is actually running. Both halves read it
+    /// now, so a development build and the installed app can serve side by
+    /// side.
+    ///
+    /// The directory of a custom path is not created here: the convenience
+    /// initializer below only ever chmods Vibe Bar's own directory, because
+    /// locking down a path it was merely handed is not its business.
+    public static var configuredSocketPath: String {
+        let override = ProcessInfo.processInfo
+            .environment[MCPStdioBridge.socketPathEnvironmentKey]?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let override, !override.isEmpty else { return defaultSocketPath }
+        return override
+    }
+
     /// Bind Vibe Bar's dispatch to a socket.
     ///
     /// Only the app's own directory is created (and forced to 0700). A custom

--- a/Sources/VibeBarCore/MCP/MCPDTOs.swift
+++ b/Sources/VibeBarCore/MCP/MCPDTOs.swift
@@ -594,24 +594,123 @@ public struct MCPSessionSummaryDTO: Codable, Equatable, Sendable {
 public struct MCPSessionListDTO: Codable, Equatable, Sendable {
     public let generatedAt: Date
     public let sessions: [MCPSessionSummaryDTO]
-    /// Total matching the filter, for `sessions.list`. Search does not count
-    /// past its own limit, so it is absent there.
+    /// Total matching the filter, for `sessions.list`. Absent for search,
+    /// which does not count past its own limit — and absent for a list whose
+    /// `to` or `models` filter the index cannot answer in SQL, because then
+    /// the store's count describes a wider set than the rows returned.
+    /// `hasMore` is the reliable signal in both cases.
     public let totalCount: Int?
     public let offset: Int?
     public let limit: Int
+    /// True when another page exists past this one.
+    public let hasMore: Bool?
+    /// Set when a host-side filter stopped at its scan cap, so the answer is
+    /// "the first N matches" rather than "all of them".
+    public let notice: String?
 
     public init(
         generatedAt: Date,
         sessions: [MCPSessionSummaryDTO],
         totalCount: Int?,
         offset: Int?,
-        limit: Int
+        limit: Int,
+        hasMore: Bool? = nil,
+        notice: String? = nil
     ) {
         self.generatedAt = generatedAt
         self.sessions = sessions
         self.totalCount = totalCount
         self.offset = offset
         self.limit = limit
+        self.hasMore = hasMore
+        self.notice = notice
+    }
+}
+
+// MARK: - sessions.transcript
+
+public struct MCPTranscriptMessageDTO: Codable, Equatable, Sendable {
+    /// Index of this message in the session, and the unit every window
+    /// argument speaks: `around`, `from`, `nextFrom` and a search hit's
+    /// `matchedSeq` are all this number.
+    public let seq: Int
+    /// `user` / `assistant` / `tool` / `system` / `other`.
+    public let role: String
+    public let text: String
+    public let timestamp: Date?
+    /// Present and true only when `text` is a prefix of what the log holds.
+    public let textTruncated: Bool?
+    /// UTF-8 length of the message's full text, whether or not it was cut.
+    public let textBytes: Int
+
+    public init(message: SessionMessage, textTruncated: Bool, textBytes: Int) {
+        self.seq = message.seq
+        self.role = message.role.rawValue
+        self.text = message.text
+        self.timestamp = message.timestamp
+        self.textTruncated = textTruncated ? true : nil
+        self.textBytes = textBytes
+    }
+}
+
+public struct MCPTranscriptDTO: Codable, Equatable, Sendable {
+    public let generatedAt: Date
+    /// Who this transcript belongs to, so a caller that started from a
+    /// `sessionId` does not need a second round trip to label the answer.
+    public let session: MCPSessionSummaryDTO
+    public let messages: [MCPTranscriptMessageDTO]
+    public let firstSeq: Int?
+    public let lastSeq: Int?
+    /// Messages in the whole session. Absent whenever the read stopped
+    /// before the end of the log — which a bounded read usually does, since
+    /// it stops as soon as it has the requested window. The count of a prefix
+    /// is not the count of the log.
+    public let totalMessageCount: Int?
+    public let hasMore: Bool
+    /// Pass back as `from` to continue. Absent when there is nothing more to
+    /// read, and also when the request pointed past the readable window, so
+    /// retrying the same call cannot loop.
+    public let nextFrom: Int?
+    public let truncated: Bool
+    /// Machine-readable: `messageLimit`, `byteBudget`, `messageText`,
+    /// `readCeiling`.
+    public let truncationReasons: [String]
+    /// One sentence to relay when something was cut.
+    public let notice: String?
+    /// Bytes of the log parsed to answer this, and its size on disk.
+    public let bytesRead: Int64
+    public let fileBytes: Int64
+
+    public init(generatedAt: Date, result: SessionTranscriptResult) {
+        let window = result.window
+        self.generatedAt = generatedAt
+        self.session = MCPSessionSummaryDTO(summary: result.summary)
+        self.messages = zip(
+            window.messages,
+            zip(window.textTruncated, window.textBytes)
+        ).map { message, meta in
+            MCPTranscriptMessageDTO(message: message, textTruncated: meta.0, textBytes: meta.1)
+        }
+        self.firstSeq = window.messages.first?.seq
+        self.lastSeq = window.messages.last?.seq
+        self.totalMessageCount = window.totalMessageCount
+        self.hasMore = window.hasMore
+        self.nextFrom = window.nextFrom
+        self.truncated = window.isTruncated
+        self.truncationReasons = window.reasons.map(\.rawValue)
+        self.notice = window.notice { Self.megabytes($0) }
+        self.bytesRead = window.bytesRead
+        self.fileBytes = window.fileBytes
+    }
+
+    /// Deliberately not `ByteCountFormatter`: this string goes into a JSON
+    /// payload a model will quote, and a locale-dependent separator there is
+    /// a reproducibility problem, not a nicety.
+    static func megabytes(_ bytes: Int64) -> String {
+        let mb = Double(bytes) / (1024 * 1024)
+        return mb >= 10
+            ? "\(Int(mb.rounded())) MB"
+            : String(format: "%.1f MB", mb)
     }
 }
 

--- a/Sources/VibeBarCore/MCP/MCPResourceCatalog.swift
+++ b/Sources/VibeBarCore/MCP/MCPResourceCatalog.swift
@@ -159,8 +159,9 @@ public enum MCPResourceCatalog {
         | "how has my spend moved day by day?" | `cost.history` |
         | "show me my usage over time" | `usage.trend` |
         | "what were my last N requests?" | `usage.requests` |
-        | "find my session about X" | `sessions.search` |
-        | "what have I been working on?" | `sessions.list` |
+        | "find my session about X" / "which session was that work in?" | `sessions.search` |
+        | "what have I been working on?" / "what ran in this repo lately?" | `sessions.list` |
+        | "what did that agent actually do?" / "show me the match in context" | `sessions.transcript` |
         | "is Anthropic down?" | `status.get` |
         | "why is this model costing so much?" | `pricing.effective` |
         | "install the Vibe Bar skill" / "add this skill" | `skills.install` |
@@ -186,6 +187,24 @@ public enum MCPResourceCatalog {
         - **Request-level history is about 30 days deep.** Older usage survives as
           daily totals, visible through `usage.summary` and `usage.trend` but not
           through `usage.requests`.
+        - **Read sessions through `sessions.transcript`, not the filesystem.**
+          Every `sessions.*` row carries `sourcePath`, and on a busy Mac that path
+          can be a multi-hundred-megabyte JSONL log. `sessions.transcript` returns
+          bounded windows with a cursor. Treat `sourcePath` as a label — for
+          telling two sessions apart, or for a shell command the *user* runs —
+          not as something to open.
+        - **`sessions.*` share one filter vocabulary with `usage.*`:** `from`,
+          `to`, `models`, `harnesses`. `projectDir` is a case-insensitive
+          substring of the session's working directory. `sessions.list` still
+          accepts `since` as an alias for `from`.
+        - **Search hit → transcript.** A hit's `matchedSeq` is a message index;
+          pass it to `sessions.transcript` as `around` to read that message in
+          context. It always resolves, because a hit can only come from the part
+          of the log the indexer read.
+        - **The index is as fresh as the last sweep.** A session being written
+          right now is searchable up to that sweep, not up to its latest message.
+          Body search also needs Vibe Bar's session body indexing switched on;
+          with it off, titles and project paths still match.
         - **`skills.install` installs; it does not browse.** Name a source —
           `owner/repo`, `owner/repo@branch`, either plus `#<skill>` when the
           repository holds several, a github.com URL, or an absolute local

--- a/Sources/VibeBarCore/MCP/MCPServer.swift
+++ b/Sources/VibeBarCore/MCP/MCPServer.swift
@@ -33,6 +33,38 @@ public enum MCPCostHistoryTimeframe: String, Sendable, CaseIterable {
 /// implementation over `AppEnvironment`. That split is what lets the whole
 /// tool surface be tested against a fixture without a menu bar, a home
 /// directory, or a network.
+/// What `sessions.list` came back with.
+///
+/// A plain page when the index answered the whole filter; otherwise the rows
+/// that survived a host-side pass, with `totalCount` withheld rather than
+/// reported as a number that describes a wider set. `AGENTS.md` § 5.1 and
+/// `SessionQueryFilter.isAnsweredEntirelyByTheIndex` say which is which.
+public struct MCPSessionListing: Sendable {
+    public var summaries: [SessionSummary]
+    public var totalCount: Int?
+    public var offset: Int
+    public var limit: Int
+    public var hasMore: Bool
+    /// Set when a host-side filter stopped at its scan cap.
+    public var notice: String?
+
+    public init(
+        summaries: [SessionSummary],
+        totalCount: Int?,
+        offset: Int,
+        limit: Int,
+        hasMore: Bool,
+        notice: String? = nil
+    ) {
+        self.summaries = summaries
+        self.totalCount = totalCount
+        self.offset = offset
+        self.limit = limit
+        self.hasMore = hasMore
+        self.notice = notice
+    }
+}
+
 public protocol MCPDataSource: AnyObject, Sendable {
     func serverInfo() async -> MCPServerInfo
 
@@ -53,17 +85,21 @@ public protocol MCPDataSource: AnyObject, Sendable {
 
     func searchSessions(
         query: String,
-        providers: [SessionProvider]?,
-        harnesses: [Harness]?,
+        filter: SessionQueryFilter,
         limit: Int
     ) async throws -> [SessionSearchHit]
     func listSessions(
-        providers: [SessionProvider]?,
-        harnesses: [Harness]?,
-        since: Date?,
+        filter: SessionQueryFilter,
         offset: Int,
         limit: Int
-    ) async throws -> SessionSummaryPage
+    ) async throws -> MCPSessionListing
+    /// One bounded window of one session's messages. Implementations resolve
+    /// `locator` through the session index — never through a path the caller
+    /// supplied — and read off the main actor.
+    func sessionTranscript(
+        locator: SessionLocator,
+        window: TranscriptWindowRequest
+    ) async throws -> SessionTranscriptResult
 
     func serviceStatus(tools: [ToolType]?) async throws -> MCPServiceStatusDTO
     func effectivePricing() async throws -> [EffectiveModelPricingRow]
@@ -239,6 +275,7 @@ public final class MCPServer: @unchecked Sendable {
         case "cost.history":      return try await costHistory(arguments)
         case "sessions.search":   return try await sessionsSearch(arguments)
         case "sessions.list":     return try await sessionsList(arguments)
+        case "sessions.transcript": return try await sessionsTranscript(arguments)
         case "status.get":        return try await statusGet(arguments)
         case "pricing.effective": return try await pricingEffective(arguments)
         case "skills.install":    return try await skillsInstall(arguments)
@@ -350,6 +387,25 @@ public final class MCPServer: @unchecked Sendable {
         return MCPCostHistoryDTO(timeframe: timeframe.rawValue, history: history)
     }
 
+    /// The narrowing both session tools share. `since` is `sessions.list`'s
+    /// original spelling and still works; `from` is the one that matches
+    /// `usage.*`, and wins when a caller passes both.
+    private func sessionFilter(_ arguments: MCPArguments) throws -> SessionQueryFilter {
+        let from = try arguments.optionalDate("from") ?? arguments.optionalDate("since")
+        let to = try arguments.optionalDate("to")
+        if let from, let to, to <= from {
+            throw MCPRPCError.invalidParams("'to' must be after 'from'.")
+        }
+        return SessionQueryFilter(
+            providers: try arguments.optionalEnumList("providers", SessionProvider.self),
+            harnesses: try arguments.optionalEnumList("harnesses", Harness.self),
+            projectDir: try arguments.optionalString("projectDir"),
+            from: from,
+            to: to,
+            models: try arguments.optionalStringList("models")
+        )
+    }
+
     private func sessionsSearch(_ arguments: MCPArguments) async throws -> MCPSessionListDTO {
         let query = try arguments.requiredString("query")
         guard !query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
@@ -358,8 +414,7 @@ public final class MCPServer: @unchecked Sendable {
         let limit = try arguments.optionalInt("limit", minimum: 1, maximum: 50) ?? 20
         let hits = try await dataSource.searchSessions(
             query: query,
-            providers: try arguments.optionalEnumList("providers", SessionProvider.self),
-            harnesses: try arguments.optionalEnumList("harnesses", Harness.self),
+            filter: try sessionFilter(arguments),
             limit: limit
         )
         return MCPSessionListDTO(
@@ -369,27 +424,69 @@ public final class MCPServer: @unchecked Sendable {
             },
             totalCount: nil,
             offset: nil,
-            limit: limit
+            limit: limit,
+            hasMore: nil
         )
     }
 
     private func sessionsList(_ arguments: MCPArguments) async throws -> MCPSessionListDTO {
         let offset = try arguments.optionalInt("offset", minimum: 0, maximum: 1_000_000) ?? 0
         let limit = try arguments.optionalInt("limit", minimum: 1, maximum: 100) ?? 50
-        let page = try await dataSource.listSessions(
-            providers: try arguments.optionalEnumList("providers", SessionProvider.self),
-            harnesses: try arguments.optionalEnumList("harnesses", Harness.self),
-            since: try arguments.optionalDate("since"),
+        let listing = try await dataSource.listSessions(
+            filter: try sessionFilter(arguments),
             offset: offset,
             limit: limit
         )
         return MCPSessionListDTO(
             generatedAt: now(),
-            sessions: page.summaries.map { MCPSessionSummaryDTO(summary: $0) },
-            totalCount: page.totalCount,
-            offset: page.offset,
-            limit: page.limit
+            sessions: listing.summaries.map { MCPSessionSummaryDTO(summary: $0) },
+            totalCount: listing.totalCount,
+            offset: listing.offset,
+            limit: listing.limit,
+            hasMore: listing.hasMore,
+            notice: listing.notice
         )
+    }
+
+    private func sessionsTranscript(_ arguments: MCPArguments) async throws -> MCPTranscriptDTO {
+        let locator = try Self.locator(arguments)
+        let around = try arguments.optionalInt("around", minimum: 0, maximum: 10_000_000)
+        let request = TranscriptWindowRequest(
+            around: around,
+            radius: try arguments.optionalInt(
+                "radius", minimum: 0, maximum: TranscriptWindowRequest.maximumMessages
+            ) ?? TranscriptWindowRequest.defaultRadius,
+            from: try arguments.optionalInt("from", minimum: 0, maximum: 10_000_000) ?? 0,
+            limit: try arguments.optionalInt(
+                "limit", minimum: 1, maximum: TranscriptWindowRequest.maximumMessages
+            ) ?? TranscriptWindowRequest.defaultLimit,
+            roles: try arguments.optionalEnumList("roles", SessionRole.self).map { Set($0) }
+        )
+        let result = try await dataSource.sessionTranscript(locator: locator, window: request)
+        return MCPTranscriptDTO(generatedAt: now(), result: result)
+    }
+
+    /// `id`, or `sessionId` + `provider`. Named separately from the tool so
+    /// the "which arguments identify a session" rule is one function.
+    static func locator(_ arguments: MCPArguments) throws -> SessionLocator {
+        if let composite = try arguments.optionalString("id") {
+            guard let locator = SessionLocator.parse(compositeID: composite) else {
+                throw MCPRPCError.invalidParams(
+                    "'id' is not a session id. Pass one exactly as sessions.search or "
+                        + "sessions.list returned it, or use 'sessionId' with 'provider'."
+                )
+            }
+            return locator
+        }
+        guard let sessionID = try arguments.optionalString("sessionId") else {
+            throw MCPRPCError.invalidParams(
+                "Name a session: pass 'id', or 'sessionId' with 'provider'."
+            )
+        }
+        guard let provider = try arguments.optionalEnum("provider", SessionProvider.self) else {
+            throw MCPRPCError.invalidParams("'sessionId' needs 'provider' alongside it.")
+        }
+        return SessionLocator(provider: provider, sessionID: sessionID)
     }
 
     private func statusGet(_ arguments: MCPArguments) async throws -> MCPServiceStatusDTO {

--- a/Sources/VibeBarCore/MCP/MCPServer.swift
+++ b/Sources/VibeBarCore/MCP/MCPServer.swift
@@ -27,12 +27,23 @@ public enum MCPCostHistoryTimeframe: String, Sendable, CaseIterable {
 
 // MARK: - Data source
 
-/// Everything the MCP surface needs from the running app.
+/// What `sessions.search` came back with.
 ///
-/// Core owns the protocol shape and every projection; the App supplies one
-/// implementation over `AppEnvironment`. That split is what lets the whole
-/// tool surface be tested against a fixture without a menu bar, a home
-/// directory, or a network.
+/// The notice exists because the host-side filters (`to`, `from`, `models`)
+/// run *after* the index's ranking cut. When a page comes back short and the
+/// cut is the reason, saying so is the difference between "nothing matches"
+/// and "the matches are below the cut" — an agent cannot tell those apart
+/// from an empty array.
+public struct MCPSessionSearchOutcome: Sendable {
+    public var hits: [SessionSearchHit]
+    public var notice: String?
+
+    public init(hits: [SessionSearchHit], notice: String? = nil) {
+        self.hits = hits
+        self.notice = notice
+    }
+}
+
 /// What `sessions.list` came back with.
 ///
 /// A plain page when the index answered the whole filter; otherwise the rows
@@ -65,6 +76,12 @@ public struct MCPSessionListing: Sendable {
     }
 }
 
+/// Everything the MCP surface needs from the running app.
+///
+/// Core owns the protocol shape and every projection; the App supplies one
+/// implementation over `AppEnvironment`. That split is what lets the whole
+/// tool surface be tested against a fixture without a menu bar, a home
+/// directory, or a network.
 public protocol MCPDataSource: AnyObject, Sendable {
     func serverInfo() async -> MCPServerInfo
 
@@ -87,7 +104,7 @@ public protocol MCPDataSource: AnyObject, Sendable {
         query: String,
         filter: SessionQueryFilter,
         limit: Int
-    ) async throws -> [SessionSearchHit]
+    ) async throws -> MCPSessionSearchOutcome
     func listSessions(
         filter: SessionQueryFilter,
         offset: Int,
@@ -412,20 +429,21 @@ public final class MCPServer: @unchecked Sendable {
             throw MCPRPCError.invalidParams("'query' must not be blank.")
         }
         let limit = try arguments.optionalInt("limit", minimum: 1, maximum: 50) ?? 20
-        let hits = try await dataSource.searchSessions(
+        let outcome = try await dataSource.searchSessions(
             query: query,
             filter: try sessionFilter(arguments),
             limit: limit
         )
         return MCPSessionListDTO(
             generatedAt: now(),
-            sessions: hits.map {
+            sessions: outcome.hits.map {
                 MCPSessionSummaryDTO(summary: $0.summary, snippet: $0.snippet, matchedSeq: $0.matchedSeq)
             },
             totalCount: nil,
             offset: nil,
             limit: limit,
-            hasMore: nil
+            hasMore: nil,
+            notice: outcome.notice
         )
     }
 

--- a/Sources/VibeBarCore/MCP/MCPToolCatalog.swift
+++ b/Sources/VibeBarCore/MCP/MCPToolCatalog.swift
@@ -346,7 +346,8 @@ public enum MCPToolCatalog {
             pass a search hit's 'matchedSeq' straight in, which always works because anything \
             sessions.search can find lies inside the indexed head of the log. 'from' plus 'limit' pages \
             forward; feed the previous response's 'nextFrom' back as 'from'. 'roles' thins a window \
-            (for example just the user's prompts); it does not search past it.
+            (for example just the user's prompts); it does not search past it. Omitting a filter list \
+            means everything; sending an empty one means nothing.
 
             The response is capped by message count and by a byte budget, and a single long message is \
             clipped rather than being allowed to fill the answer. When anything is cut, 'truncated' is \
@@ -366,7 +367,10 @@ public enum MCPToolCatalog {
                 enumValues: sessionProviderValues
             ),
             "around": integer(
-                "Centre the window on this message index — a search hit's 'matchedSeq'. Wins over 'from'.",
+                "Centre the window on this message index — a search hit's 'matchedSeq'. Wins over "
+                    + "'from'. The message you name is always in the result: when a cap bites, the "
+                    + "window shrinks towards it rather than dropping it. Only a 'roles' filter it "
+                    + "does not match can exclude it.",
                 minimum: 0
             ),
             "radius": integer(

--- a/Sources/VibeBarCore/MCP/MCPToolCatalog.swift
+++ b/Sources/VibeBarCore/MCP/MCPToolCatalog.swift
@@ -20,6 +20,7 @@ public enum MCPToolCatalog {
         costHistory,
         sessionsSearch,
         sessionsList,
+        sessionsTranscript,
         statusGet,
         pricingEffective,
         skillsInstall
@@ -125,6 +126,36 @@ public enum MCPToolCatalog {
                 "description": .string(
                     "Raw vendor model ids to keep, exactly as the provider spelled them "
                         + "(for example 'claude-opus-4-7', not 'Opus')."
+                ),
+                "items": .object(["type": .string("string")])
+            ])
+        ]
+    }
+
+    /// Narrowing shared by `sessions.search` and `sessions.list`.
+    ///
+    /// The names are `usage.*`'s (`from` / `to` / `models` / `harnesses`) on
+    /// purpose: one vocabulary for one concept across the whole surface.
+    private static var sessionFilterProperties: [String: MCPJSON] {
+        [
+            "harnesses": harnessFilter,
+            "providers": stringEnumList(
+                sessionProviderValues,
+                description: "On-disk session stores to read. Prefer 'harnesses' unless you specifically want a store."
+            ),
+            "projectDir": string(
+                "Keep sessions whose working directory contains this text (case-insensitive "
+                    + "substring, so a full absolute path behaves as an exact match and a repo "
+                    + "name matches every checkout of it)."
+            ),
+            "from": string("Inclusive ISO-8601 lower bound on last activity."),
+            "to": string("Exclusive ISO-8601 upper bound on last activity."),
+            "models": .object([
+                "type": .string("array"),
+                "description": .string(
+                    "Raw vendor model ids to keep, exactly as the log spelled them "
+                        + "(for example 'claude-opus-4-7', not 'Opus'). A session whose log never "
+                        + "recorded a model matches no model filter."
                 ),
                 "items": .object(["type": .string("string")])
             ])
@@ -259,22 +290,22 @@ public enum MCPToolCatalog {
         name: "sessions.search",
         title: "Full-text search local agent sessions",
         description: """
-            Search titles, projects and message bodies across every local CLI session Vibe Bar has \
-            indexed. Answers 'find my session about X'. Results carry the matching excerpt with <b> \
-            markers around the hit, plus the on-disk path so the transcript can be opened. Body search \
-            needs Vibe Bar's session body indexing enabled; with it off, titles and projects still match. \
-            Rows are labelled with the harness (the usage axis), not the quota SubProvider.
+            Find a local agent session — yours or another agent's — by what was said in it. Searches \
+            titles, project paths and message bodies across every CLI session Vibe Bar has indexed, and \
+            answers 'which session was the socket-server work in'. Each hit carries 'snippet' (the \
+            matching excerpt, <b> markers around the hit) and 'matchedSeq' (the message index) — pass \
+            that seq to sessions.transcript as 'around' to read the match in context. Also carries \
+            'sessionId' to resume with that CLI and 'projectDir' for where the work happened. Body \
+            search needs Vibe Bar's session body indexing enabled; with it off, titles and projects still \
+            match. The index is as fresh as the last sweep, so a session being written right now is \
+            searchable up to that point. Rows are labelled with the harness (the usage axis), not the \
+            quota SubProvider.
             """,
         inputSchema: object(
-            properties: [
+            properties: sessionFilterProperties.merging([
                 "query": string("Text to look for. Substring matching, so partial words and CJK both work."),
-                "harnesses": harnessFilter,
-                "providers": stringEnumList(
-                    sessionProviderValues,
-                    description: "On-disk session stores to search. Prefer 'harnesses' unless you specifically want a store."
-                ),
                 "limit": integer("Maximum hits, 1–50. Default 20.", minimum: 1, maximum: 50)
-            ],
+            ]) { _, new in new },
             required: ["query"]
         )
     )
@@ -283,19 +314,80 @@ public enum MCPToolCatalog {
         name: "sessions.list",
         title: "List local agent sessions",
         description: """
-            Recent local CLI sessions, newest first, with title, project directory, model, message count \
-            and on-disk path. Use sessions.search when you know what the session was about. Rows are \
+            Recent local agent sessions, newest first, with title, project directory, model, message \
+            count and identity. Answers 'what has been worked on in this repo lately' and 'which session \
+            is that other agent in'. Use sessions.search when you know what the session was about, and \
+            sessions.transcript to read one. 'totalCount' is exact unless a 'to' or 'models' filter is \
+            in play — those are applied after the index query, so trust 'hasMore' instead. Rows are \
             labelled with the harness (the usage axis).
             """,
-        inputSchema: object(properties: [
-            "harnesses": harnessFilter,
-            "providers": stringEnumList(
-                sessionProviderValues,
-                description: "On-disk session stores to list. Prefer 'harnesses' unless you specifically want a store."
+        inputSchema: object(properties: sessionFilterProperties.merging([
+            "since": string(
+                "Deprecated alias for 'from', kept so existing callers keep working. Prefer 'from'."
             ),
-            "since": string("Only sessions last active at or after this ISO-8601 instant."),
             "offset": integer("Rows to skip, for paging. Default 0.", minimum: 0),
             "limit": integer("Rows to return, 1–100. Default 50.", minimum: 1, maximum: 100)
+        ]) { _, new in new })
+    )
+
+    public static let sessionsTranscript = MCPTool(
+        name: "sessions.transcript",
+        title: "Read a window of one session's transcript",
+        description: """
+            Read messages out of one local agent session, in bounded windows. This is how to inspect \
+            another agent's working session — prefer it over opening 'sourcePath' yourself, which on a \
+            busy Mac can be a multi-hundred-megabyte JSONL log.
+
+            Name the session with 'id' (the composite id every sessions.* row carries) or with \
+            'sessionId' plus 'provider'. There is no path argument: reads resolve through Vibe Bar's \
+            index, so only sessions it already discovered can be opened.
+
+            Two window shapes. 'around: <seq>' with 'radius' (default 20) reads a match in context — \
+            pass a search hit's 'matchedSeq' straight in, which always works because anything \
+            sessions.search can find lies inside the indexed head of the log. 'from' plus 'limit' pages \
+            forward; feed the previous response's 'nextFrom' back as 'from'. 'roles' thins a window \
+            (for example just the user's prompts); it does not search past it.
+
+            The response is capped by message count and by a byte budget, and a single long message is \
+            clipped rather than being allowed to fill the answer. When anything is cut, 'truncated' is \
+            true, 'truncationReasons' says which cap bit, and 'notice' is a sentence you can relay. \
+            'totalMessageCount' is absent whenever the read stopped before the end of the log, which a \
+            bounded read usually does — a prefix's count is not the log's count. Use 'hasMore' and \
+            'nextFrom' to keep going.
+            """,
+        inputSchema: object(properties: [
+            "id": string(
+                "Composite session id from a sessions.search / sessions.list row "
+                    + "('<provider>:<sessionId>:<path>'). Use this when you have it."
+            ),
+            "sessionId": string("The session's own id. Needs 'provider' alongside it."),
+            "provider": string(
+                "On-disk store the session lives in. Required with 'sessionId'.",
+                enumValues: sessionProviderValues
+            ),
+            "around": integer(
+                "Centre the window on this message index — a search hit's 'matchedSeq'. Wins over 'from'.",
+                minimum: 0
+            ),
+            "radius": integer(
+                "Messages either side of 'around'. Default \(TranscriptWindowRequest.defaultRadius).",
+                minimum: 0,
+                maximum: TranscriptWindowRequest.maximumMessages
+            ),
+            "from": integer(
+                "First message index to return, when 'around' is absent. Default 0.",
+                minimum: 0
+            ),
+            "limit": integer(
+                "Maximum messages, 1–\(TranscriptWindowRequest.maximumMessages). "
+                    + "Default \(TranscriptWindowRequest.defaultLimit).",
+                minimum: 1,
+                maximum: TranscriptWindowRequest.maximumMessages
+            ),
+            "roles": stringEnumList(
+                SessionRole.allCases.map(\.rawValue),
+                description: "Message roles to keep. Omit for all of them."
+            )
         ])
     )
 

--- a/Sources/VibeBarCore/Services/SessionAgentQuery.swift
+++ b/Sources/VibeBarCore/Services/SessionAgentQuery.swift
@@ -61,6 +61,19 @@ public struct SessionQueryFilter: Sendable, Equatable {
         return [projectDir]
     }
 
+    /// True when this filter can never match anything.
+    ///
+    /// The house rule, stated once: **an omitted list means "everything", an
+    /// explicitly empty list means "nothing"**. `quota.get`'s `tools: []`
+    /// already works that way, the skill documents it, and `SessionIndexStore`
+    /// returns an empty page for `providers: []` / `harnesses: []` — but the
+    /// store has no model column filter at all, so `models: []` could only be
+    /// honoured here. It used to be skipped instead, which quietly turned
+    /// "match nothing" into "match everything".
+    public var matchesNothing: Bool {
+        providers?.isEmpty == true || harnesses?.isEmpty == true || models?.isEmpty == true
+    }
+
     /// True when every part of this filter is something the index can answer
     /// in SQL, so a page's `totalCount` and `offset` describe exactly the rows
     /// that come back.
@@ -68,15 +81,19 @@ public struct SessionQueryFilter: Sendable, Equatable {
     /// `to` and `models` are the two that are not: `summaryPage` has a `since`
     /// but no upper bound, and no model column filter. They are applied here
     /// instead, which means the count has to be withheld rather than reported
-    /// as something it no longer describes.
+    /// as something it no longer describes. Any `models` list counts —
+    /// including an empty one, which the store cannot express.
     public var isAnsweredEntirelyByTheIndex: Bool {
-        to == nil && (models.map(\.isEmpty) ?? true)
+        to == nil && models == nil
     }
 
     /// Does this summary survive the parts of the filter the index did not
     /// apply? Safe to call for the store-native parts too — it re-asserts all
     /// of them, so a caller never has to track which half ran where.
     public func matches(_ summary: SessionSummary) -> Bool {
+        // Every list below is `if let`, never `if let … , !isEmpty`: an empty
+        // list has to fall into the membership test and fail it, which is
+        // what makes "nothing" mean nothing.
         if let providers, !providers.contains(summary.provider) { return false }
         if let harnesses, !harnesses.contains(summary.effectiveHarness) { return false }
         if let needle = projectIncludes.first {
@@ -84,7 +101,7 @@ public struct SessionQueryFilter: Sendable, Equatable {
                   directory.range(of: needle, options: .caseInsensitive) != nil
             else { return false }
         }
-        if let models, !models.isEmpty {
+        if let models {
             guard let model = summary.model, !model.isEmpty else { return false }
             guard models.contains(where: { $0.compare(model, options: .caseInsensitive) == .orderedSame })
             else { return false }
@@ -147,10 +164,14 @@ public struct TranscriptWindowRequest: Sendable, Equatable {
     public var from: Int
     /// Maximum messages to return, before the byte budget has its say.
     public var limit: Int
-    /// Roles to keep. `nil` is every role. Applied *after* the window is
+    /// Roles to keep. `nil` is every role, an empty set is none — the same
+    /// house rule as every other list filter. Applied *after* the window is
     /// taken, so a `roles` filter thins a window rather than scanning for
     /// more matches beyond it — otherwise "the 20 messages around seq 400"
     /// would silently become "the next 20 user messages, wherever they are".
+    ///
+    /// It also outranks `around`'s guarantee to include its target: a caller
+    /// asking for user turns only did not ask for an assistant one.
     public var roles: Set<SessionRole>?
 
     public static let defaultRadius = 20

--- a/Sources/VibeBarCore/Services/SessionAgentQuery.swift
+++ b/Sources/VibeBarCore/Services/SessionAgentQuery.swift
@@ -1,0 +1,290 @@
+import Foundation
+
+/// The vocabulary an *agent* uses to find and read someone else's session.
+///
+/// The Workbench's Sessions page has its own filter state, shaped by the
+/// controls on screen. This is the MCP side of the same idea, and it is
+/// deliberately a plain value: `MCPServer` parses arguments into one,
+/// `MCPController` applies it, and `VibeBarCoreTests` can exercise the
+/// semantics without a running app or an index.
+///
+/// The argument names match `usage.*` (`from` / `to` / `models` /
+/// `harnesses`) on purpose. Two vocabularies for one concept is how an agent
+/// ends up passing `since` to a tool that wanted `from` and silently getting
+/// an unfiltered answer.
+public struct SessionQueryFilter: Sendable, Equatable {
+    /// On-disk stores to read. `nil` is every store; an empty list is none.
+    public var providers: [SessionProvider]?
+    /// Usage-axis harnesses to keep. `nil` is every harness; empty is none.
+    public var harnesses: [Harness]?
+    /// **Substring** match against the session's project directory.
+    ///
+    /// Substring rather than prefix because that is what
+    /// `SessionIndexStore.summaryPage` implements in SQL
+    /// (`project_dir LIKE '%needle%'`), which keeps `totalCount` and paging
+    /// exact — a host-side prefix re-filter would make the store's count
+    /// describe a different set than the rows returned. A full absolute path
+    /// therefore behaves as an exact match, and `vibe-bar` matches every
+    /// checkout of it.
+    public var projectDir: String?
+    /// Inclusive lower bound on the session's last activity
+    /// (`lastActiveAt ?? createdAt`).
+    public var from: Date?
+    /// Exclusive upper bound on the same stamp.
+    public var to: Date?
+    /// Raw vendor model ids, compared case-insensitively and exactly — the
+    /// same rule as `usage.*`. A session whose log never recorded a model
+    /// matches no model filter; it is never inferred.
+    public var models: [String]?
+
+    public init(
+        providers: [SessionProvider]? = nil,
+        harnesses: [Harness]? = nil,
+        projectDir: String? = nil,
+        from: Date? = nil,
+        to: Date? = nil,
+        models: [String]? = nil
+    ) {
+        self.providers = providers
+        self.harnesses = harnesses
+        self.projectDir = projectDir
+        self.from = from
+        self.to = to
+        self.models = models
+    }
+
+    /// Project terms in the shape `SessionIndexStore` takes them.
+    public var projectIncludes: [String] {
+        guard let projectDir, !projectDir.trimmingCharacters(in: .whitespaces).isEmpty else {
+            return []
+        }
+        return [projectDir]
+    }
+
+    /// True when every part of this filter is something the index can answer
+    /// in SQL, so a page's `totalCount` and `offset` describe exactly the rows
+    /// that come back.
+    ///
+    /// `to` and `models` are the two that are not: `summaryPage` has a `since`
+    /// but no upper bound, and no model column filter. They are applied here
+    /// instead, which means the count has to be withheld rather than reported
+    /// as something it no longer describes.
+    public var isAnsweredEntirelyByTheIndex: Bool {
+        to == nil && (models.map(\.isEmpty) ?? true)
+    }
+
+    /// Does this summary survive the parts of the filter the index did not
+    /// apply? Safe to call for the store-native parts too — it re-asserts all
+    /// of them, so a caller never has to track which half ran where.
+    public func matches(_ summary: SessionSummary) -> Bool {
+        if let providers, !providers.contains(summary.provider) { return false }
+        if let harnesses, !harnesses.contains(summary.effectiveHarness) { return false }
+        if let needle = projectIncludes.first {
+            guard let directory = summary.projectDir,
+                  directory.range(of: needle, options: .caseInsensitive) != nil
+            else { return false }
+        }
+        if let models, !models.isEmpty {
+            guard let model = summary.model, !model.isEmpty else { return false }
+            guard models.contains(where: { $0.compare(model, options: .caseInsensitive) == .orderedSame })
+            else { return false }
+        }
+        guard from != nil || to != nil else { return true }
+        // A row with no timestamp at all cannot satisfy a time window. Saying
+        // "unknown" is not the same as saying "in range".
+        guard let stamp = summary.lastActiveAt ?? summary.createdAt else { return false }
+        if let from, stamp < from { return false }
+        if let to, stamp >= to { return false }
+        return true
+    }
+}
+
+/// How to name one session across the MCP surface.
+///
+/// Either the composite `id` every `sessions.*` row already carries, or the
+/// `sessionId` + `provider` pair. There is deliberately **no** path argument:
+/// every read resolves through the session index, so an agent can only reach
+/// files Vibe Bar already discovered under a provider's own roots. The path
+/// component of a composite id is informational — the index row is what
+/// decides which file is opened.
+public struct SessionLocator: Sendable, Equatable {
+    public var provider: SessionProvider
+    public var sessionID: String
+
+    public init(provider: SessionProvider, sessionID: String) {
+        self.provider = provider
+        self.sessionID = sessionID
+    }
+
+    /// Parse `provider:sessionID:sourcePath`, the shape of `SessionSummary.id`.
+    ///
+    /// Only the first two components are read. A macOS path may contain `:`,
+    /// so the split is bounded rather than greedy, and the trailing path is
+    /// dropped rather than validated — see the type's note on why.
+    public static func parse(compositeID: String) -> SessionLocator? {
+        let parts = compositeID.split(separator: ":", maxSplits: 2, omittingEmptySubsequences: false)
+        guard parts.count >= 2,
+              let provider = SessionProvider(rawValue: String(parts[0])),
+              !parts[1].isEmpty
+        else { return nil }
+        return SessionLocator(provider: provider, sessionID: String(parts[1]))
+    }
+}
+
+// MARK: - Transcript windows
+
+/// Which slice of a transcript an agent asked for.
+///
+/// Two shapes, and they are not interchangeable. `around` is "show me this
+/// match in context" — the answer to a `sessions.search` hit's `matchedSeq`.
+/// `from` is "keep reading" — the answer to a previous window's cursor.
+public struct TranscriptWindowRequest: Sendable, Equatable {
+    /// Centre the window on this message index. Wins over `from`.
+    public var around: Int?
+    /// Messages either side of `around`.
+    public var radius: Int
+    /// First message index to return, when `around` is absent.
+    public var from: Int
+    /// Maximum messages to return, before the byte budget has its say.
+    public var limit: Int
+    /// Roles to keep. `nil` is every role. Applied *after* the window is
+    /// taken, so a `roles` filter thins a window rather than scanning for
+    /// more matches beyond it — otherwise "the 20 messages around seq 400"
+    /// would silently become "the next 20 user messages, wherever they are".
+    public var roles: Set<SessionRole>?
+
+    public static let defaultRadius = 20
+    public static let defaultLimit = 40
+    /// Hard ceiling on messages per response, whatever was asked for.
+    public static let maximumMessages = 200
+    /// UTF-8 budget for all message text in one response. An agent asking for
+    /// 200 tool-call outputs gets a truncated answer and a cursor, not a
+    /// multi-megabyte payload it then has to page through in its context.
+    public static let maximumTextBytes = 256 * 1024
+    /// Cap on a single message's text, in **characters** — the unit
+    /// `SessionParsing.truncate` works in, and four times the kit's own prose
+    /// excerpt cap. One pasted build log must not be able to spend the whole
+    /// response on itself. The response-wide budget above is in bytes and is
+    /// what actually bounds the payload; this only stops one message from
+    /// being the whole of it.
+    public static let maximumMessageTextCharacters = 8_000
+
+    public init(
+        around: Int? = nil,
+        radius: Int = TranscriptWindowRequest.defaultRadius,
+        from: Int = 0,
+        limit: Int = TranscriptWindowRequest.defaultLimit,
+        roles: Set<SessionRole>? = nil
+    ) {
+        self.around = around
+        self.radius = max(0, radius)
+        self.from = max(0, from)
+        self.limit = min(max(1, limit), TranscriptWindowRequest.maximumMessages)
+        self.roles = roles
+    }
+
+    /// First message index this request needs, before any role filtering.
+    public var lowerBound: Int {
+        guard let around else { return from }
+        return max(0, around - radius)
+    }
+
+    /// Highest message index this request needs. The reader uses it to decide
+    /// how many bytes of the log it has to parse.
+    public var upperBound: Int {
+        guard let around else { return from + limit - 1 }
+        return around + radius
+    }
+}
+
+/// Why a window stops where it does. Reported verbatim so an agent can act on
+/// the reason rather than guess from a short list.
+public enum TranscriptTruncationReason: String, Sendable, Codable, CaseIterable {
+    /// The requested message count was reached.
+    case messageLimit
+    /// The response's UTF-8 budget was reached.
+    case byteBudget
+    /// At least one message's own text was clipped.
+    case messageText
+    /// The read stopped at its byte ceiling before reaching the requested
+    /// window. The rest of the log exists; it is past what a bounded read
+    /// will parse.
+    case readCeiling
+}
+
+/// One slice of a transcript, plus everything needed to ask for the next.
+public struct TranscriptWindow: Sendable, Equatable {
+    public var messages: [SessionMessage]
+    /// Per-message flag, parallel to `messages`: true where `text` is a
+    /// prefix of what the log holds.
+    public var textTruncated: [Bool]
+    /// Original UTF-8 length of each message's text, before any clipping.
+    public var textBytes: [Int]
+    /// Total messages in the log, when the read actually reached the end of
+    /// the file — which a bounded read often does not, because it stops as
+    /// soon as it has the window it was asked for. `nil` otherwise: the count
+    /// of a prefix is not the count of the log, and reporting it as one would
+    /// make an agent believe it had seen everything.
+    public var totalMessageCount: Int?
+    /// Index to pass back as `from` to continue. `nil` when the window
+    /// reached the end of what was read *and* the read reached the end of the
+    /// file.
+    public var nextFrom: Int?
+    public var reasons: [TranscriptTruncationReason]
+    /// Bytes of the log actually parsed, and its size on disk.
+    public var bytesRead: Int64
+    public var fileBytes: Int64
+
+    public var hasMore: Bool { nextFrom != nil }
+    public var isTruncated: Bool { !reasons.isEmpty }
+
+    public init(
+        messages: [SessionMessage],
+        textTruncated: [Bool],
+        textBytes: [Int],
+        totalMessageCount: Int?,
+        nextFrom: Int?,
+        reasons: [TranscriptTruncationReason],
+        bytesRead: Int64,
+        fileBytes: Int64
+    ) {
+        self.messages = messages
+        self.textTruncated = textTruncated
+        self.textBytes = textBytes
+        self.totalMessageCount = totalMessageCount
+        self.nextFrom = nextFrom
+        self.reasons = reasons
+        self.bytesRead = bytesRead
+        self.fileBytes = fileBytes
+    }
+
+    /// One sentence an agent can relay, or `nil` when nothing was cut.
+    public func notice(fileByteFormatter: (Int64) -> String) -> String? {
+        guard isTruncated else { return nil }
+        var parts: [String] = []
+        if reasons.contains(.readCeiling) {
+            parts.append(
+                "the requested messages lie past the first "
+                    + fileByteFormatter(bytesRead)
+                    + " of a " + fileByteFormatter(fileBytes) + " log, which is as far as a bounded read goes"
+            )
+        }
+        if reasons.contains(.messageLimit) { parts.append("the message limit was reached") }
+        if reasons.contains(.byteBudget) { parts.append("the response byte budget was reached") }
+        if reasons.contains(.messageText) { parts.append("some message text was clipped to fit") }
+        let joined = parts.joined(separator: "; ")
+        guard nextFrom != nil else { return "Truncated: " + joined + "." }
+        return "Truncated: " + joined + ". Call again with the reported nextFrom to continue."
+    }
+}
+
+/// One session, read for an agent.
+public struct SessionTranscriptResult: Sendable {
+    public let summary: SessionSummary
+    public let window: TranscriptWindow
+
+    public init(summary: SessionSummary, window: TranscriptWindow) {
+        self.summary = summary
+        self.window = window
+    }
+}

--- a/Sources/VibeBarCore/Services/SessionAgentQuery.swift
+++ b/Sources/VibeBarCore/Services/SessionAgentQuery.swift
@@ -299,6 +299,37 @@ public struct TranscriptWindow: Sendable, Equatable {
     }
 }
 
+/// A bounded read that cannot be performed as asked.
+///
+/// Four providers keep their sessions in stores that are not byte-truncatable
+/// JSONL — Cursor's and AntiGravity's SQLite databases, Grok's sibling-file
+/// transcript, Grok Bot's blob cache. For those, "read the first N bytes" has
+/// no meaning: the only read available is the whole store.
+///
+/// The transcript tool advertises a byte ceiling, and an agent may call it in
+/// a loop. Documenting the exception was not enough — an unbounded parse of a
+/// large store stalls the request and can exhaust the app. So the tool refuses
+/// above the ceiling and says why, which is something the caller can act on.
+public enum TranscriptReadRefusal: Error, LocalizedError, Equatable {
+    case wholeFileOnly(provider: SessionProvider, fileBytes: Int64, ceilingBytes: Int64)
+
+    public var errorDescription: String? {
+        switch self {
+        case let .wholeFileOnly(provider, fileBytes, ceilingBytes):
+            return "\(provider.displayName) stores its sessions in a format that can only be read "
+                + "whole, and this one is \(Self.megabytes(fileBytes)) — past the "
+                + "\(Self.megabytes(ceilingBytes)) a bounded read allows. Reading it would hold the "
+                + "entire store in memory. Use sessions.search to find the moment you need, or open "
+                + "the session in \(provider.displayName) itself."
+        }
+    }
+
+    static func megabytes(_ bytes: Int64) -> String {
+        let mb = Double(bytes) / (1024 * 1024)
+        return mb >= 10 ? "\(Int(mb.rounded())) MB" : String(format: "%.1f MB", mb)
+    }
+}
+
 /// One session, read for an agent.
 public struct SessionTranscriptResult: Sendable {
     public let summary: SessionSummary

--- a/Sources/VibeBarCore/Services/SessionIndexingBounds.swift
+++ b/Sources/VibeBarCore/Services/SessionIndexingBounds.swift
@@ -176,6 +176,19 @@ public enum SessionIndexingBounds {
         scratchDirectory: URL = VibeBarLocalStore.sessionIndexScratchDirectoryURL,
         isCancelled: () -> Bool = { Task.isCancelled }
     ) throws -> TranscriptWindow {
+        // A store that cannot be cut at a byte offset cannot be bounded, and
+        // the ceiling above is a promise this function makes to a caller that
+        // may be an agent in a loop. Refuse rather than quietly parsing the
+        // whole thing: a refusal naming the size is something the agent can
+        // act on, a multi-hundred-megabyte parse is a stall it cannot.
+        let size = SessionParsing.fileSize(fileURL)
+        if !headTruncatableProviders.contains(adapter.provider), size > byteCeiling {
+            throw TranscriptReadRefusal.wholeFileOnly(
+                provider: adapter.provider,
+                fileBytes: size,
+                ceilingBytes: byteCeiling
+            )
+        }
         let needed = request.upperBound
         var limit = min(agentTranscriptInitialByteLimit, byteCeiling)
         var read = try readTranscript(
@@ -307,17 +320,33 @@ public enum SessionIndexingBounds {
             ))
         }
 
-        // Where "keep reading" resumes: after the last message returned.
+        // Where "keep reading" resumes.
         //
-        // The exception is a window that returned nothing because the read
-        // never got that far. Handing back a cursor there would invite an
-        // agent to retry the identical request forever, so it gets `nil` and
-        // the `readCeiling` notice, which is the only useful answer.
+        // A cursor must always be *past* something this call already looked
+        // at, or a client following the documented loop repeats the identical
+        // page forever. Two ways that used to happen:
+        //
+        // - the read never reached the requested window (`readCeiling`), so
+        //   retrying it would parse the same bytes to the same non-answer;
+        // - every message in the window was filtered out by `roles`, which
+        //   left `chosen` empty and resumed at the window's own start.
+        //
+        // The first gets no cursor. The second resumes after the span that
+        // *was* examined, so the loop makes progress — unless the filter can
+        // never match anything at all, in which case there is nothing to make
+        // progress towards.
+        let examinedEnd = messages.isEmpty
+            ? request.lowerBound
+            : min(request.upperBound, messages.count - 1) + 1
         let nextFrom: Int?
         if kept.isEmpty, reasons.contains(.readCeiling) {
             nextFrom = nil
+        } else if request.roles?.isEmpty == true {
+            // An empty role set selects no role, here and everywhere else.
+            // Paging cannot rescue it.
+            nextFrom = nil
         } else {
-            let resume = (chosen.last.map { $0 + 1 }) ?? request.lowerBound
+            let resume = chosen.last.map { $0 + 1 } ?? examinedEnd
             nextFrom = hitCap || resume < messages.count || !reachedEndOfFile ? resume : nil
         }
 

--- a/Sources/VibeBarCore/Services/SessionIndexingBounds.swift
+++ b/Sources/VibeBarCore/Services/SessionIndexingBounds.swift
@@ -131,6 +131,203 @@ public enum SessionIndexingBounds {
         }
     }
 
+    // MARK: - Reading a transcript for an agent
+
+    /// Byte ceiling for one `sessions.transcript` read.
+    ///
+    /// The same number as the viewer's, for the same reason and with the same
+    /// consequence: past this, the answer says so instead of growing. It is
+    /// generous relative to what an agent normally needs, because of a
+    /// property worth stating outright — **`sessions.search` can only return a
+    /// `matchedSeq` that lies inside the indexed head.** The indexer parses at
+    /// most `SessionIndexExcerptPolicy.headParseByteLimit` (8 MiB) of any
+    /// session, so every hit an agent can discover is reachable well inside
+    /// this ceiling. "Read the match in context" therefore always works; only
+    /// "page to the end of a 1 GB log" runs out of room.
+    public static let agentTranscriptByteCeiling: Int64 = 32 * 1024 * 1024
+
+    /// First read size. Most sessions are smaller than this, so the common
+    /// case is one parse of the whole file.
+    static let agentTranscriptInitialByteLimit: Int64 = 1024 * 1024
+
+    /// Read the slice of `fileURL` that `request` asks for.
+    ///
+    /// There is no seek. A message index cannot be turned into a byte offset
+    /// without parsing, because not every line of a rollout produces a
+    /// message — the Codex adapter alone drops most of them. So reaching
+    /// message *N* means parsing from the start until *N* exists, and the
+    /// only bound available is the one this already has: bytes.
+    ///
+    /// What that buys is an *escalating head read* rather than a whole-file
+    /// one. Start at `agentTranscriptInitialByteLimit`; if the parse did not
+    /// reach the requested window and the file has more to give, estimate the
+    /// bytes-per-message from what was just parsed, grow, and retry — up to
+    /// `byteCeiling`. Small sessions cost one parse. A match near the head of
+    /// a huge rollout costs one or two. Only a request that genuinely points
+    /// past the ceiling gets a truncated answer, and it is told why.
+    ///
+    /// This deliberately calls `readTranscript` rather than reimplementing the
+    /// bound: one read path, one cancellation story, one scratch sweep.
+    public static func readTranscriptWindow(
+        adapter: any SessionProviderAdapter,
+        fileURL: URL,
+        request: TranscriptWindowRequest,
+        byteCeiling: Int64 = SessionIndexingBounds.agentTranscriptByteCeiling,
+        scratchDirectory: URL = VibeBarLocalStore.sessionIndexScratchDirectoryURL,
+        isCancelled: () -> Bool = { Task.isCancelled }
+    ) throws -> TranscriptWindow {
+        let needed = request.upperBound
+        var limit = min(agentTranscriptInitialByteLimit, byteCeiling)
+        var read = try readTranscript(
+            adapter: adapter,
+            fileURL: fileURL,
+            headByteLimit: limit,
+            scratchDirectory: scratchDirectory,
+            isCancelled: isCancelled
+        )
+        while read.isHeadTruncated, read.document.messages.count <= needed, limit < byteCeiling {
+            limit = min(byteCeiling, Self.nextByteLimit(after: limit, read: read, needed: needed))
+            read = try readTranscript(
+                adapter: adapter,
+                fileURL: fileURL,
+                headByteLimit: limit,
+                scratchDirectory: scratchDirectory,
+                isCancelled: isCancelled
+            )
+        }
+        return window(
+            for: request,
+            in: read.document.messages,
+            reachedEndOfFile: !read.isHeadTruncated,
+            bytesRead: read.isHeadTruncated ? limit : read.fileByteSize,
+            fileBytes: read.fileByteSize
+        )
+    }
+
+    /// How far to grow the next attempt.
+    ///
+    /// Doubling alone walks up to a deep message in log₂ steps, each one
+    /// re-parsing everything before it. The bytes-per-message the last parse
+    /// just measured is a much better guess, so take whichever is larger and
+    /// give it 50% headroom — messages get longer further into a session.
+    static func nextByteLimit(
+        after limit: Int64,
+        read: BoundedTranscript,
+        needed: Int
+    ) -> Int64 {
+        let doubled = limit * 2
+        let parsed = read.document.messages.count
+        guard parsed > 0 else { return doubled }
+        let perMessage = max(1, limit / Int64(parsed))
+        let estimated = perMessage * Int64(needed + 1) * 3 / 2
+        return max(doubled, estimated)
+    }
+
+    /// Slice, role-filter and budget one window out of the parsed messages.
+    ///
+    /// Split out from the read so the whole windowing contract — bounds,
+    /// caps, cursor, reasons — is testable against a plain array with no
+    /// file, adapter or scratch directory in sight.
+    static func window(
+        for request: TranscriptWindowRequest,
+        in messages: [SessionMessage],
+        reachedEndOfFile: Bool,
+        bytesRead: Int64,
+        fileBytes: Int64
+    ) -> TranscriptWindow {
+        var reasons: [TranscriptTruncationReason] = []
+        let lower = request.lowerBound
+        // The window asked for more than the read could see. Say so rather
+        // than returning an empty slice that reads like "no such messages".
+        if !reachedEndOfFile, messages.count <= request.upperBound {
+            reasons.append(.readCeiling)
+        }
+
+        var kept: [SessionMessage] = []
+        var truncatedFlags: [Bool] = []
+        var originalBytes: [Int] = []
+        var spent = 0
+        var cursor = lower
+        var stoppedEarly = false
+
+        while cursor < messages.count {
+            let message = messages[cursor]
+            if let roles = request.roles, !roles.contains(message.role) {
+                cursor += 1
+                // A role filter thins the window; it does not extend it.
+                if cursor > request.upperBound { break }
+                continue
+            }
+            if kept.count >= request.limit {
+                reasons.append(.messageLimit)
+                stoppedEarly = true
+                break
+            }
+            let full = message.text.utf8.count
+            let clipped = SessionParsing.truncate(
+                message.text,
+                limit: TranscriptWindowRequest.maximumMessageTextCharacters
+            )
+            let cost = clipped.utf8.count
+            // Always allow the first message through: a response of zero
+            // messages plus "the budget was full" is not an answer.
+            if !kept.isEmpty, spent + cost > TranscriptWindowRequest.maximumTextBytes {
+                reasons.append(.byteBudget)
+                stoppedEarly = true
+                break
+            }
+            if clipped != message.text {
+                if !reasons.contains(.messageText) { reasons.append(.messageText) }
+                truncatedFlags.append(true)
+            } else {
+                truncatedFlags.append(false)
+            }
+            originalBytes.append(full)
+            kept.append(SessionMessage(
+                seq: message.seq,
+                role: message.role,
+                text: clipped,
+                timestamp: message.timestamp
+            ))
+            spent += cost
+            cursor += 1
+            if cursor > request.upperBound {
+                stoppedEarly = false
+                break
+            }
+        }
+
+        // Where "keep reading" resumes. A window that ran out of budget
+        // resumes at the message it could not fit; one that simply reached
+        // the end of its own span resumes after that span, and only when
+        // there is something past it.
+        //
+        // The exception is a window that returned nothing because the read
+        // never got that far: handing back a cursor there would invite an
+        // agent to retry the identical request forever. It gets `nil` and the
+        // `readCeiling` notice, which is the only useful answer.
+        let nextFrom: Int?
+        if kept.isEmpty, reasons.contains(.readCeiling) {
+            nextFrom = nil
+        } else if stoppedEarly || cursor < messages.count || !reachedEndOfFile {
+            nextFrom = cursor
+        } else {
+            nextFrom = nil
+        }
+
+        return TranscriptWindow(
+            messages: kept,
+            textTruncated: truncatedFlags,
+            textBytes: originalBytes,
+            // Only a read that saw the whole file knows the whole count.
+            totalMessageCount: reachedEndOfFile ? messages.count : nil,
+            nextFrom: nextFrom,
+            reasons: reasons,
+            bytesRead: bytesRead,
+            fileBytes: fileBytes
+        )
+    }
+
     /// Streams the first `limit` bytes of `fileURL` into a scratch file.
     /// Constant memory; the caller deletes the copy after parsing. Scratch
     /// lives under `~/.vibebar` because that directory is the only place

--- a/Sources/VibeBarCore/Services/SessionIndexingBounds.swift
+++ b/Sources/VibeBarCore/Services/SessionIndexingBounds.swift
@@ -228,6 +228,12 @@ public enum SessionIndexingBounds {
     /// Split out from the read so the whole windowing contract — bounds,
     /// caps, cursor, reasons — is testable against a plain array with no
     /// file, adapter or scratch directory in sight.
+    ///
+    /// The two request shapes are collected in different orders, and that is
+    /// the whole point. `from` reads forward and stops when a cap bites.
+    /// `around` collects **outward from the target**, so a cap shrinks the
+    /// window towards the message the caller asked to see instead of
+    /// truncating the far side of it away.
     static func window(
         for request: TranscriptWindowRequest,
         in messages: [SessionMessage],
@@ -236,83 +242,83 @@ public enum SessionIndexingBounds {
         fileBytes: Int64
     ) -> TranscriptWindow {
         var reasons: [TranscriptTruncationReason] = []
-        let lower = request.lowerBound
         // The window asked for more than the read could see. Say so rather
         // than returning an empty slice that reads like "no such messages".
         if !reachedEndOfFile, messages.count <= request.upperBound {
             reasons.append(.readCeiling)
         }
 
+        // `min` matters: a `from` past the end of what was read would other-
+        // wise build a reversed range, which traps rather than returning the
+        // empty window that situation actually calls for.
+        let order = request.around == nil
+            ? Array(min(request.lowerBound, messages.count)..<messages.count)
+            : Self.centredOrder(request: request, messageCount: messages.count)
+
+        var chosen: [Int] = []
+        var spent = 0
+        var hitCap = false
+
+        for index in order {
+            guard index <= request.upperBound, index < messages.count else { continue }
+            let message = messages[index]
+            // A role filter thins the window; it does not extend it — and it
+            // outranks "always include the target", because a caller asking
+            // for user turns only did not ask for an assistant one.
+            if let roles = request.roles, !roles.contains(message.role) { continue }
+            if chosen.count >= request.limit {
+                reasons.append(.messageLimit)
+                hitCap = true
+                break
+            }
+            // Always let the first message through: a response of zero
+            // messages plus "the budget was full" is not an answer.
+            let cost = Self.clipped(message).utf8.count
+            if !chosen.isEmpty, spent + cost > TranscriptWindowRequest.maximumTextBytes {
+                reasons.append(.byteBudget)
+                hitCap = true
+                break
+            }
+            chosen.append(index)
+            spent += cost
+        }
+
+        // Centred collection visits neighbours alternately, so sort back into
+        // reading order before anyone sees it.
+        chosen.sort()
         var kept: [SessionMessage] = []
         var truncatedFlags: [Bool] = []
         var originalBytes: [Int] = []
-        var spent = 0
-        var cursor = lower
-        var stoppedEarly = false
-
-        while cursor < messages.count {
-            let message = messages[cursor]
-            if let roles = request.roles, !roles.contains(message.role) {
-                cursor += 1
-                // A role filter thins the window; it does not extend it.
-                if cursor > request.upperBound { break }
-                continue
-            }
-            if kept.count >= request.limit {
-                reasons.append(.messageLimit)
-                stoppedEarly = true
-                break
-            }
-            let full = message.text.utf8.count
-            let clipped = SessionParsing.truncate(
-                message.text,
-                limit: TranscriptWindowRequest.maximumMessageTextCharacters
-            )
-            let cost = clipped.utf8.count
-            // Always allow the first message through: a response of zero
-            // messages plus "the budget was full" is not an answer.
-            if !kept.isEmpty, spent + cost > TranscriptWindowRequest.maximumTextBytes {
-                reasons.append(.byteBudget)
-                stoppedEarly = true
-                break
-            }
+        for index in chosen {
+            let message = messages[index]
+            let clipped = Self.clipped(message)
             if clipped != message.text {
                 if !reasons.contains(.messageText) { reasons.append(.messageText) }
                 truncatedFlags.append(true)
             } else {
                 truncatedFlags.append(false)
             }
-            originalBytes.append(full)
+            originalBytes.append(message.text.utf8.count)
             kept.append(SessionMessage(
                 seq: message.seq,
                 role: message.role,
                 text: clipped,
                 timestamp: message.timestamp
             ))
-            spent += cost
-            cursor += 1
-            if cursor > request.upperBound {
-                stoppedEarly = false
-                break
-            }
         }
 
-        // Where "keep reading" resumes. A window that ran out of budget
-        // resumes at the message it could not fit; one that simply reached
-        // the end of its own span resumes after that span, and only when
-        // there is something past it.
+        // Where "keep reading" resumes: after the last message returned.
         //
         // The exception is a window that returned nothing because the read
-        // never got that far: handing back a cursor there would invite an
-        // agent to retry the identical request forever. It gets `nil` and the
-        // `readCeiling` notice, which is the only useful answer.
+        // never got that far. Handing back a cursor there would invite an
+        // agent to retry the identical request forever, so it gets `nil` and
+        // the `readCeiling` notice, which is the only useful answer.
         let nextFrom: Int?
         if kept.isEmpty, reasons.contains(.readCeiling) {
             nextFrom = nil
-        } else if stoppedEarly || cursor < messages.count || !reachedEndOfFile {
-            nextFrom = cursor
         } else {
-            nextFrom = nil
+            let resume = (chosen.last.map { $0 + 1 }) ?? request.lowerBound
+            nextFrom = hitCap || resume < messages.count || !reachedEndOfFile ? resume : nil
         }
 
         return TranscriptWindow(
@@ -325,6 +331,49 @@ public enum SessionIndexingBounds {
             reasons: reasons,
             bytesRead: bytesRead,
             fileBytes: fileBytes
+        )
+    }
+
+    /// Indices to try for an `around` request, nearest the target first.
+    ///
+    /// Target, then one before, one after, two before, two after… Collecting
+    /// in this order is what guarantees the requested message survives every
+    /// cap: it is considered before anything else, so the only thing that can
+    /// exclude it is a `roles` filter it does not match.
+    ///
+    /// Walking outward from a centre also keeps the result contiguous, which
+    /// is why `nextFrom` can stay a single "resume after the last message"
+    /// index rather than a set of holes.
+    ///
+    /// The previous version simply started at `around - radius` and read
+    /// forward, so `around: 500, radius: 100` with the default limit of 40
+    /// returned 400–439 and omitted 500 — the one message the caller named.
+    static func centredOrder(request: TranscriptWindowRequest, messageCount: Int) -> [Int] {
+        guard let around = request.around, messageCount > 0 else { return [] }
+        let lower = request.lowerBound
+        let upper = min(request.upperBound, messageCount - 1)
+        // The target itself has to be inside the readable span. When it is
+        // not, there is no centred window to build: the caller gets the empty
+        // result, and `readCeiling` explains it when the read was the reason.
+        guard lower <= upper, around >= lower, around <= upper else { return [] }
+        var order: [Int] = [around]
+        order.reserveCapacity(upper - lower + 1)
+        var step = 1
+        while true {
+            let before = around - step
+            let after = around + step
+            if before < lower, after > upper { break }
+            if before >= lower { order.append(before) }
+            if after <= upper { order.append(after) }
+            step += 1
+        }
+        return order
+    }
+
+    private static func clipped(_ message: SessionMessage) -> String {
+        SessionParsing.truncate(
+            message.text,
+            limit: TranscriptWindowRequest.maximumMessageTextCharacters
         )
     }
 

--- a/Tests/VibeBarCoreTests/MCPFixtures.swift
+++ b/Tests/VibeBarCoreTests/MCPFixtures.swift
@@ -316,18 +316,26 @@ final class FakeMCPDataSource: MCPDataSource, @unchecked Sendable {
         query: String,
         filter: SessionQueryFilter,
         limit: Int
-    ) async throws -> [SessionSearchHit] {
+    ) async throws -> MCPSessionSearchOutcome {
         lastSessionQuery = query
         lastSessionLimit = limit
         lastSessionFilter = filter
-        return [
-            SessionSearchHit(
-                summary: Self.sessionSummary,
-                snippet: "the <b>socket</b> server",
-                matchedSeq: 4
-            )
-        ]
+        return MCPSessionSearchOutcome(
+            hits: searchHits,
+            notice: searchNotice
+        )
     }
+
+    /// What `searchSessions` hands back. A test that cares about the ranking
+    /// cut empties this and sets `searchNotice`.
+    var searchHits: [SessionSearchHit] = [
+        SessionSearchHit(
+            summary: FakeMCPDataSource.sessionSummary,
+            snippet: "the <b>socket</b> server",
+            matchedSeq: 4
+        )
+    ]
+    var searchNotice: String?
 
     func listSessions(
         filter: SessionQueryFilter,

--- a/Tests/VibeBarCoreTests/MCPFixtures.swift
+++ b/Tests/VibeBarCoreTests/MCPFixtures.swift
@@ -18,6 +18,18 @@ final class FakeMCPDataSource: MCPDataSource, @unchecked Sendable {
     private(set) var lastRequestPageSize: Int?
     private(set) var lastSessionQuery: String?
     private(set) var lastSessionLimit: Int?
+    private(set) var lastSessionFilter: SessionQueryFilter?
+    private(set) var lastTranscriptLocator: SessionLocator?
+    private(set) var lastTranscriptWindow: TranscriptWindowRequest?
+
+    /// What `listSessions` claims about paging.
+    var listTotalCount: Int? = 1
+    var listHasMore = false
+    var listNotice: String?
+    /// Whether the fake transcript read saw the whole file.
+    var transcriptReachedEndOfFile = true
+    /// Non-nil makes `sessionTranscript` fail with this message.
+    var transcriptFailure: String?
 
     /// `refreshQuota` is the one method a test drives from two tasks at once,
     /// so its recording is the one that needs a lock.
@@ -302,12 +314,12 @@ final class FakeMCPDataSource: MCPDataSource, @unchecked Sendable {
 
     func searchSessions(
         query: String,
-        providers: [SessionProvider]?,
-        harnesses: [Harness]?,
+        filter: SessionQueryFilter,
         limit: Int
     ) async throws -> [SessionSearchHit] {
         lastSessionQuery = query
         lastSessionLimit = limit
+        lastSessionFilter = filter
         return [
             SessionSearchHit(
                 summary: Self.sessionSummary,
@@ -318,17 +330,47 @@ final class FakeMCPDataSource: MCPDataSource, @unchecked Sendable {
     }
 
     func listSessions(
-        providers: [SessionProvider]?,
-        harnesses: [Harness]?,
-        since: Date?,
+        filter: SessionQueryFilter,
         offset: Int,
         limit: Int
-    ) async throws -> SessionSummaryPage {
-        SessionSummaryPage(
+    ) async throws -> MCPSessionListing {
+        lastSessionFilter = filter
+        return MCPSessionListing(
             summaries: [Self.sessionSummary],
-            totalCount: 1,
+            totalCount: listTotalCount,
             offset: offset,
-            limit: limit
+            limit: limit,
+            hasMore: listHasMore,
+            notice: listNotice
+        )
+    }
+
+    /// The eight messages `sessions.transcript` reads from, seq 0…7.
+    static let transcriptMessages: [SessionMessage] = (0..<8).map { seq in
+        SessionMessage(
+            seq: seq,
+            role: seq.isMultiple(of: 2) ? .user : .assistant,
+            text: "message \(seq)",
+            timestamp: epoch.addingTimeInterval(TimeInterval(seq * 60))
+        )
+    }
+
+    func sessionTranscript(
+        locator: SessionLocator,
+        window: TranscriptWindowRequest
+    ) async throws -> SessionTranscriptResult {
+        lastTranscriptLocator = locator
+        lastTranscriptWindow = window
+        if let transcriptFailure { throw MCPToolFailure(transcriptFailure) }
+        return SessionTranscriptResult(
+            summary: Self.sessionSummary,
+            window: SessionIndexingBounds.window(
+                for: window,
+                in: Self.transcriptMessages,
+                reachedEndOfFile: transcriptReachedEndOfFile,
+                bytesRead: 4_096,
+                fileBytes: 4_096
+            )
         )
     }
 

--- a/Tests/VibeBarCoreTests/MCPJSONRPCTests.swift
+++ b/Tests/VibeBarCoreTests/MCPJSONRPCTests.swift
@@ -52,8 +52,8 @@ final class MCPJSONRPCTests: XCTestCase {
             names.sorted(),
             [
                 "cost.history", "cost.snapshot", "pricing.effective", "quota.get", "quota.refresh",
-                "sessions.list", "sessions.search", "skills.install", "status.get", "usage.requests",
-                "usage.summary", "usage.trend"
+                "sessions.list", "sessions.search", "sessions.transcript", "skills.install",
+                "status.get", "usage.requests", "usage.summary", "usage.trend"
             ]
         )
         for tool in tools {

--- a/Tests/VibeBarCoreTests/MCPToolCallTests.swift
+++ b/Tests/VibeBarCoreTests/MCPToolCallTests.swift
@@ -409,6 +409,28 @@ final class MCPToolCallTests: XCTestCase {
         XCTAssertEqual(source.lastTranscriptWindow?.roles, [])
     }
 
+    /// Filters run after the index's ranking cut, so a short page can mean
+    /// "nothing matches" or "the matches are below the cut". An agent cannot
+    /// tell those apart from an empty array, so the payload says which.
+    func testSearchSurfacesTheRankingCutRatherThanReturningASilentEmptyPage() async throws {
+        source.searchHits = []
+        source.searchNotice = "Filters ran after the ranking cut: the top 200 hits for this "
+            + "query yielded 0 match(es), and more may exist below the cut."
+        let result = try await call("sessions.search", .object([
+            "query": .string("socket"),
+            "to": .string("2020-01-01T00:00:00Z")
+        ]))
+        XCTAssertEqual(result["sessions"]?.arrayValue?.count, 0)
+        let notice = try XCTUnwrap(result["notice"]?.stringValue)
+        XCTAssertTrue(notice.contains("below the cut"), notice)
+    }
+
+    func testACompleteSearchCarriesNoNotice() async throws {
+        let result = try await call("sessions.search", .object(["query": .string("socket")]))
+        XCTAssertEqual(result["sessions"]?.arrayValue?.count, 1)
+        XCTAssertNil(result["notice"], "a full page must not be labelled incomplete")
+    }
+
     func testAHostSideFilterWithholdsTheCountAndSaysWhy() async throws {
         source.listTotalCount = nil
         source.listHasMore = true

--- a/Tests/VibeBarCoreTests/MCPToolCallTests.swift
+++ b/Tests/VibeBarCoreTests/MCPToolCallTests.swift
@@ -311,6 +311,203 @@ final class MCPToolCallTests: XCTestCase {
         XCTAssertEqual(result["offset"]?.intValue, 0)
         XCTAssertEqual(result["totalCount"]?.intValue, 1)
         XCTAssertEqual(result["sessions"]?.arrayValue?.count, 1)
+        XCTAssertEqual(result["hasMore"]?.boolValue, false)
+    }
+
+    // MARK: - session filters
+
+    /// One vocabulary across the surface: `sessions.*` narrows with the same
+    /// `from` / `to` / `models` / `harnesses` that `usage.*` uses.
+    func testSessionFiltersReachTheDataSourceOnBothTools() async throws {
+        let arguments = MCPJSON.object([
+            "query": .string("socket"),
+            "harnesses": .array([.string("codex")]),
+            "providers": .array([.string("codex")]),
+            "projectDir": .string("vibe-bar"),
+            "from": .string("2026-01-01T00:00:00Z"),
+            "to": .string("2026-02-01T00:00:00Z"),
+            "models": .array([.string("gpt-5-codex")])
+        ])
+        _ = try await call("sessions.search", arguments)
+        var filter = try XCTUnwrap(source.lastSessionFilter)
+        XCTAssertEqual(filter.harnesses, [.codex])
+        XCTAssertEqual(filter.providers, [.codex])
+        XCTAssertEqual(filter.projectDir, "vibe-bar")
+        XCTAssertEqual(filter.from, Date(timeIntervalSince1970: 1_767_225_600))
+        XCTAssertEqual(filter.to, Date(timeIntervalSince1970: 1_769_904_000))
+        XCTAssertEqual(filter.models, ["gpt-5-codex"])
+
+        var listArguments = arguments
+        if case var .object(fields) = listArguments {
+            fields.removeValue(forKey: "query")
+            listArguments = .object(fields)
+        }
+        _ = try await call("sessions.list", listArguments)
+        filter = try XCTUnwrap(source.lastSessionFilter)
+        XCTAssertEqual(filter.projectDir, "vibe-bar")
+        XCTAssertEqual(filter.models, ["gpt-5-codex"])
+    }
+
+    /// `since` was `sessions.list`'s original spelling. It keeps working, and
+    /// `from` wins when a caller sends both.
+    func testSinceStillWorksAsAnAliasForFrom() async throws {
+        _ = try await call("sessions.list", .object(["since": .string("2026-01-01T00:00:00Z")]))
+        XCTAssertEqual(
+            try XCTUnwrap(source.lastSessionFilter).from,
+            Date(timeIntervalSince1970: 1_767_225_600)
+        )
+        _ = try await call("sessions.list", .object([
+            "since": .string("2020-01-01T00:00:00Z"),
+            "from": .string("2026-01-01T00:00:00Z")
+        ]))
+        XCTAssertEqual(
+            try XCTUnwrap(source.lastSessionFilter).from,
+            Date(timeIntervalSince1970: 1_767_225_600)
+        )
+    }
+
+    func testAnInvertedSessionWindowIsRejected() async throws {
+        let response = try MCPTestSupport.decode(
+            await server.handle(line: MCPTestSupport.call(
+                id: 1,
+                tool: "sessions.list",
+                arguments: .object([
+                    "from": .string("2026-02-01T00:00:00Z"),
+                    "to": .string("2026-01-01T00:00:00Z")
+                ])
+            ))
+        )
+        XCTAssertEqual(response["error"]?["code"]?.intValue, -32_602)
+    }
+
+    func testAHostSideFilterWithholdsTheCountAndSaysWhy() async throws {
+        source.listTotalCount = nil
+        source.listHasMore = true
+        source.listNotice = "Stopped after examining 4000 indexed sessions."
+        let result = try await call("sessions.list", .object(["models": .array([.string("gpt-5")])]))
+        XCTAssertNil(result["totalCount"], "the store's count describes a wider set than the rows")
+        XCTAssertEqual(result["hasMore"]?.boolValue, true)
+        XCTAssertNotNil(result["notice"]?.stringValue)
+    }
+
+    // MARK: - sessions.transcript
+
+    func testTranscriptReadsAWindowAroundAMatch() async throws {
+        let result = try await call("sessions.transcript", .object([
+            "id": .string("claude:sess-42:/Users/example/.claude/projects/x/sess-42.jsonl"),
+            "around": .int(4),
+            "radius": .int(1)
+        ]))
+        XCTAssertEqual(source.lastTranscriptLocator?.provider, .claude)
+        XCTAssertEqual(source.lastTranscriptLocator?.sessionID, "sess-42")
+        XCTAssertEqual(source.lastTranscriptWindow?.around, 4)
+        XCTAssertEqual(source.lastTranscriptWindow?.radius, 1)
+
+        let messages = try XCTUnwrap(result["messages"]?.arrayValue)
+        XCTAssertEqual(messages.compactMap { $0["seq"]?.intValue }, [3, 4, 5])
+        XCTAssertEqual(messages.first?["role"]?.stringValue, "assistant")
+        XCTAssertEqual(messages.first?["text"]?.stringValue, "message 3")
+        XCTAssertEqual(messages.first?["textBytes"]?.intValue, 9)
+        XCTAssertNil(messages.first?["textTruncated"], "absent unless the text was actually cut")
+        XCTAssertEqual(result["firstSeq"]?.intValue, 3)
+        XCTAssertEqual(result["lastSeq"]?.intValue, 5)
+        XCTAssertEqual(result["totalMessageCount"]?.intValue, 8)
+        XCTAssertEqual(result["truncated"]?.boolValue, false)
+        // The session it belongs to travels with it, so a caller that started
+        // from a bare sessionId does not need a second round trip to label it.
+        XCTAssertEqual(result["session"]?["harness"]?.stringValue, "claudeCode")
+    }
+
+    func testTranscriptPagesWithACursor() async throws {
+        let first = try await call("sessions.transcript", .object([
+            "sessionId": .string("sess-42"),
+            "provider": .string("claude"),
+            "from": .int(0),
+            "limit": .int(3)
+        ]))
+        XCTAssertEqual(first["hasMore"]?.boolValue, true)
+        let next = try XCTUnwrap(first["nextFrom"]?.intValue)
+        XCTAssertEqual(next, 3)
+
+        let second = try await call("sessions.transcript", .object([
+            "sessionId": .string("sess-42"),
+            "provider": .string("claude"),
+            "from": .int(Int64(next)),
+            "limit": .int(10)
+        ]))
+        XCTAssertEqual(
+            second["messages"]?.arrayValue?.compactMap { $0["seq"]?.intValue },
+            [3, 4, 5, 6, 7]
+        )
+        XCTAssertEqual(second["hasMore"]?.boolValue, false)
+        XCTAssertNil(second["nextFrom"], "the last page must not hand back a cursor")
+    }
+
+    func testTranscriptRolesThinTheWindow() async throws {
+        let result = try await call("sessions.transcript", .object([
+            "sessionId": .string("sess-42"),
+            "provider": .string("claude"),
+            "from": .int(0),
+            "limit": .int(6),
+            "roles": .array([.string("user")])
+        ]))
+        XCTAssertEqual(
+            result["messages"]?.arrayValue?.compactMap { $0["seq"]?.intValue },
+            [0, 2, 4]
+        )
+    }
+
+    func testTranscriptSaysWhenTheReadStoppedShort() async throws {
+        source.transcriptReachedEndOfFile = false
+        let result = try await call("sessions.transcript", .object([
+            "sessionId": .string("sess-42"),
+            "provider": .string("claude"),
+            "around": .int(500)
+        ]))
+        XCTAssertEqual(result["truncated"]?.boolValue, true)
+        XCTAssertEqual(result["truncationReasons"]?.arrayValue?.compactMap { $0.stringValue },
+                       ["readCeiling"])
+        XCTAssertNil(result["totalMessageCount"])
+        XCTAssertNil(result["nextFrom"], "retrying the identical call would loop")
+        XCTAssertTrue(try XCTUnwrap(result["notice"]?.stringValue).contains("bounded read"))
+    }
+
+    func testTranscriptNeedsASessionAndRejectsNonsenseIds() async throws {
+        for arguments in [
+            MCPJSON.object([:]),
+            .object(["sessionId": .string("sess-42")]),
+            .object(["id": .string("not-a-provider:sess-42:/x")])
+        ] {
+            let response = try MCPTestSupport.decode(
+                await server.handle(line: MCPTestSupport.call(
+                    id: 1, tool: "sessions.transcript", arguments: arguments
+                ))
+            )
+            XCTAssertEqual(
+                response["error"]?["code"]?.intValue, -32_602,
+                "\(arguments) should be an argument error"
+            )
+        }
+    }
+
+    /// An unknown session is a tool failure the model can act on, not a
+    /// protocol error — and the message has to explain the index's freshness
+    /// rather than implying the session does not exist.
+    func testAnUnindexedSessionExplainsTheIndexRatherThanFailingBlankly() async throws {
+        source.transcriptFailure = "No indexed Claude Code session with id 'nope'. "
+            + "The index is as fresh as Vibe Bar's last sweep."
+        let response = try MCPTestSupport.decode(
+            await server.handle(line: MCPTestSupport.call(
+                id: 1,
+                tool: "sessions.transcript",
+                arguments: .object(["sessionId": .string("nope"), "provider": .string("claude")])
+            ))
+        )
+        XCTAssertNil(response["error"], "a missing session is a tool result, not a JSON-RPC error")
+        XCTAssertTrue(MCPTestSupport.isError(response))
+        XCTAssertTrue(
+            try XCTUnwrap(MCPTestSupport.errorText(response)).contains("last sweep")
+        )
     }
 
     // MARK: - status and pricing

--- a/Tests/VibeBarCoreTests/MCPToolCallTests.swift
+++ b/Tests/VibeBarCoreTests/MCPToolCallTests.swift
@@ -380,6 +380,35 @@ final class MCPToolCallTests: XCTestCase {
         XCTAssertEqual(response["error"]?["code"]?.intValue, -32_602)
     }
 
+    /// An empty list reaches the data source as an empty list, not as `nil`.
+    /// That is what lets `SessionQueryFilter` read it as "nothing" — the same
+    /// rule `quota.get`'s `tools: []` follows.
+    func testAnEmptySessionFilterListStaysEmptyRatherThanBecomingUnfiltered() async throws {
+        _ = try await call("sessions.list", .object([
+            "models": .array([]),
+            "harnesses": .array([])
+        ]))
+        let filter = try XCTUnwrap(source.lastSessionFilter)
+        XCTAssertEqual(filter.models, [])
+        XCTAssertEqual(filter.harnesses, [])
+        XCTAssertTrue(filter.matchesNothing)
+
+        _ = try await call("sessions.list", .object([:]))
+        let unfiltered = try XCTUnwrap(source.lastSessionFilter)
+        XCTAssertNil(unfiltered.models)
+        XCTAssertNil(unfiltered.harnesses)
+        XCTAssertFalse(unfiltered.matchesNothing)
+    }
+
+    func testAnEmptyRolesListReachesTheTranscriptWindowAsAnEmptySet() async throws {
+        _ = try await call("sessions.transcript", .object([
+            "sessionId": .string("sess-42"),
+            "provider": .string("claude"),
+            "roles": .array([])
+        ]))
+        XCTAssertEqual(source.lastTranscriptWindow?.roles, [])
+    }
+
     func testAHostSideFilterWithholdsTheCountAndSaysWhy() async throws {
         source.listTotalCount = nil
         source.listHasMore = true

--- a/Tests/VibeBarCoreTests/SessionAgentQueryTests.swift
+++ b/Tests/VibeBarCoreTests/SessionAgentQueryTests.swift
@@ -485,6 +485,170 @@ final class SessionAgentQueryTests: XCTestCase {
         XCTAssertLessThan(result.bytesRead, result.fileBytes)
     }
 
+    // MARK: - Stores that can only be read whole
+
+    /// Cursor, AntiGravity, Grok and Grok Bot keep their sessions in formats
+    /// that cannot be cut at a byte offset, so a bounded read of a large one
+    /// is impossible. Documenting that was not enough: `sessions.transcript`
+    /// advertises a ceiling and an agent may call it in a loop, so it refuses
+    /// rather than performing the unbounded parse.
+    func testAnOversizedWholeFileOnlyStoreIsRefusedNotParsed() throws {
+        let fileURL = directory.appendingPathComponent("store.db")
+        try Data(repeating: 0x41, count: 4_096).write(to: fileURL)
+
+        let adapter = WholeFileOnlyAdapter()
+        XCTAssertFalse(
+            SessionIndexingBounds.headTruncatableProviders.contains(adapter.provider),
+            "this test is only meaningful for a store that cannot be head-read"
+        )
+        XCTAssertThrowsError(
+            try SessionIndexingBounds.readTranscriptWindow(
+                adapter: adapter,
+                fileURL: fileURL,
+                request: TranscriptWindowRequest(from: 0, limit: 10),
+                byteCeiling: 1_024,
+                scratchDirectory: scratchURL
+            )
+        ) { error in
+            guard case let TranscriptReadRefusal.wholeFileOnly(provider, fileBytes, ceiling) = error
+            else { return XCTFail("expected a refusal, got \(error)") }
+            XCTAssertEqual(provider, .cursor)
+            XCTAssertEqual(fileBytes, 4_096)
+            XCTAssertEqual(ceiling, 1_024)
+            // The message has to be actionable: it names the size, the limit
+            // and what to do instead.
+            let message = (error as? LocalizedError)?.errorDescription ?? ""
+            XCTAssertTrue(message.contains("read"), message)
+            XCTAssertTrue(message.contains("sessions.search"), message)
+        }
+        XCTAssertEqual(
+            adapter.parses.value, 0,
+            "the refusal must come before any parse, or it saved nothing"
+        )
+    }
+
+    func testAWholeFileOnlyStoreUnderTheCeilingIsStillRead() throws {
+        // Small enough to be safe, so the refusal must not fire: the ceiling
+        // bounds the damage, it does not ban the provider.
+        let fileURL = directory.appendingPathComponent("small.db")
+        try Data(repeating: 0x41, count: 64).write(to: fileURL)
+        let adapter = WholeFileOnlyAdapter()
+        let result = try SessionIndexingBounds.readTranscriptWindow(
+            adapter: adapter,
+            fileURL: fileURL,
+            request: TranscriptWindowRequest(from: 0, limit: 10),
+            byteCeiling: 1_024,
+            scratchDirectory: scratchURL
+        )
+        XCTAssertEqual(adapter.parses.value, 1, "under the ceiling it should still read")
+        XCTAssertEqual(result.messages.map(\.text), ["stored turn"])
+    }
+
+    /// Stands in for Cursor / AntiGravity / Grok / Grok Bot: a provider whose
+    /// store can only be read whole. Deterministic, and it counts parses so a
+    /// test can prove the refusal happened *before* one.
+    private struct WholeFileOnlyAdapter: SessionProviderAdapter {
+        let parses = Counter()
+        var provider: SessionProvider { .cursor }
+
+        func roots(homeDirectory: String) -> [URL] { [] }
+        func discoverSessionFiles(homeDirectory: String) -> [URL] { [] }
+
+        func extractMetadata(fileURL: URL) throws -> SessionSummary {
+            SessionSummary(provider: .cursor, sessionID: "s", sourcePath: fileURL.path)
+        }
+
+        func deletionPlan(for summary: SessionSummary, homeDirectory: String) throws
+            -> SessionDeletionPlan {
+            throw SessionDeleteError.providerIsReadOnly(.cursor)
+        }
+
+        func parseTranscript(fileURL: URL, range: Range<Int>?) throws -> TranscriptDocument {
+            parses.increment()
+            return TranscriptDocument(
+                messages: [SessionMessage(seq: 0, role: .user, text: "stored turn", timestamp: nil)],
+                totalMessageCount: 1,
+                truncated: false
+            )
+        }
+    }
+
+    /// Thread-safe call counter for the stub above.
+    private final class Counter: @unchecked Sendable {
+        private let lock = NSLock()
+        private var count = 0
+
+        @discardableResult
+        func increment() -> Int {
+            lock.lock(); defer { lock.unlock() }
+            count += 1
+            return count
+        }
+
+        var value: Int {
+            lock.lock(); defer { lock.unlock() }
+            return count
+        }
+    }
+
+    // MARK: - A cursor always advances
+
+    /// The loop this prevents: when `roles` excluded every message in the
+    /// window, `chosen` was empty and the cursor was set back to the window's
+    /// own start, so a client following the documented loop fetched the same
+    /// empty page forever.
+    func testARoleFilterThatMatchesNothingStillAdvancesTheCursor() {
+        // seq 0…9 are user/assistant only, so a tool filter matches none.
+        let result = window(
+            TranscriptWindowRequest(from: 0, limit: 10, roles: [.tool]), in: messages(100)
+        )
+        XCTAssertTrue(result.messages.isEmpty)
+        let next = try? XCTUnwrap(result.nextFrom)
+        XCTAssertEqual(next, 10, "the cursor must move past the span that was examined")
+        XCTAssertGreaterThan(next ?? 0, 0)
+
+        // And following it makes progress rather than repeating.
+        let second = window(
+            TranscriptWindowRequest(from: next ?? 0, limit: 10, roles: [.tool]), in: messages(100)
+        )
+        XCTAssertNotEqual(second.nextFrom, result.nextFrom)
+        XCTAssertEqual(second.nextFrom, 20)
+    }
+
+    func testAnAroundWindowWhoseRolesMatchNothingAlsoAdvances() {
+        let result = window(
+            TranscriptWindowRequest(around: 50, radius: 5, roles: [.tool]), in: messages(100)
+        )
+        XCTAssertTrue(result.messages.isEmpty)
+        XCTAssertEqual(result.nextFrom, 56, "past the examined span, not back to its start")
+    }
+
+    /// An empty role set can never match, so paging cannot rescue it: the
+    /// answer is "no cursor", not "try the next page".
+    func testAnEmptyRoleSetOffersNoCursorAtAll() {
+        let result = window(TranscriptWindowRequest(from: 0, limit: 10, roles: []), in: messages(100))
+        XCTAssertTrue(result.messages.isEmpty)
+        XCTAssertNil(result.nextFrom)
+        XCTAssertFalse(result.hasMore)
+    }
+
+    /// A cursor is only ever useful if it is strictly ahead of where the call
+    /// started. Walk the documented loop and prove it terminates.
+    func testFollowingTheCursorAlwaysTerminates() {
+        var from = 0
+        var pages = 0
+        while pages < 50 {
+            let page = window(
+                TranscriptWindowRequest(from: from, limit: 7, roles: [.tool]), in: messages(60)
+            )
+            guard let next = page.nextFrom else { break }
+            XCTAssertGreaterThan(next, from, "page \(pages) did not advance")
+            from = next
+            pages += 1
+        }
+        XCTAssertLessThan(pages, 50, "the loop must end rather than run out the counter")
+    }
+
     // MARK: - One backfill call site
 
     /// The fresh-install bug this guards: `sessions.list` grew a host-side
@@ -524,6 +688,38 @@ final class SessionAgentQueryTests: XCTestCase {
                 "\(path) must read through the shared entry point"
             )
         }
+    }
+
+    /// The regression the single door introduced: it treated *any* empty
+    /// result as an unbuilt index, so an offset past the last row, a filter
+    /// that legitimately matches nothing, or an unknown transcript id each
+    /// kicked off a filesystem-wide sweep on an installation with thousands
+    /// of indexed sessions.
+    ///
+    /// The door stays; what changed is that it asks the store whether it has
+    /// ever held a row instead of inferring it from zero results.
+    func testTheBackfillDoorAsksTheStoreInsteadOfInferringFromAnEmptyPage() throws {
+        let source = try String(
+            contentsOf: repoRoot().appendingPathComponent("Sources/VibeBarApp/MCPController.swift"),
+            encoding: .utf8
+        )
+        XCTAssertTrue(
+            source.contains("func isSessionIndexUnbuilt()"),
+            "the door needs a way to tell an uninitialised index from an empty page"
+        )
+        XCTAssertTrue(
+            source.contains("store.sessionCount()"),
+            "that answer has to come from the store, not from the shape of a result"
+        )
+        // And the backfill is gated on it, not on emptiness alone.
+        guard let door = source.range(of: "private func readingSessions<T>") else {
+            return XCTFail("readingSessions not found")
+        }
+        let body = source[door.lowerBound...].prefix(1_200)
+        XCTAssertTrue(
+            body.contains("isSessionIndexUnbuilt()"),
+            "readingSessions must consult the store before starting a sweep"
+        )
     }
 
     private func repoRoot() throws -> URL {

--- a/Tests/VibeBarCoreTests/SessionAgentQueryTests.swift
+++ b/Tests/VibeBarCoreTests/SessionAgentQueryTests.swift
@@ -68,6 +68,40 @@ final class SessionAgentQueryTests: XCTestCase {
         XCTAssertFalse(SessionQueryFilter(models: ["gpt-5-codex"]).matches(summary(model: nil)))
     }
 
+    /// The house rule, and the regression behind it: an omitted list means
+    /// everything, an explicitly empty one means nothing. `models: []` used
+    /// to be skipped entirely, so it matched every session — the exact
+    /// opposite of what the skill documents and of what `quota.get`'s
+    /// `tools: []` already does.
+    func testAnEmptyListFilterMatchesNothingOnEveryDimension() {
+        XCTAssertFalse(SessionQueryFilter(models: []).matches(summary()))
+        XCTAssertFalse(SessionQueryFilter(providers: []).matches(summary()))
+        XCTAssertFalse(SessionQueryFilter(harnesses: []).matches(summary()))
+        // Omitted still means everything.
+        XCTAssertTrue(SessionQueryFilter().matches(summary()))
+    }
+
+    func testMatchesNothingNamesEveryEmptyListUpFront() {
+        XCTAssertTrue(SessionQueryFilter(models: []).matchesNothing)
+        XCTAssertTrue(SessionQueryFilter(providers: []).matchesNothing)
+        XCTAssertTrue(SessionQueryFilter(harnesses: []).matchesNothing)
+        XCTAssertFalse(SessionQueryFilter().matchesNothing)
+        XCTAssertFalse(SessionQueryFilter(models: ["gpt-5"]).matchesNothing)
+        XCTAssertFalse(
+            SessionQueryFilter(projectDir: "").matchesNothing,
+            "an empty string is not an empty list; it simply narrows nothing"
+        )
+    }
+
+    /// The store has no model column filter at all, so *any* `models` list —
+    /// empty included — has to take the host-side path. Treating `[]` as
+    /// index-answerable is how it slipped through as "match everything".
+    func testAnyModelsListForcesTheHostSidePath() {
+        XCTAssertFalse(SessionQueryFilter(models: []).isAnsweredEntirelyByTheIndex)
+        XCTAssertFalse(SessionQueryFilter(models: ["gpt-5"]).isAnsweredEntirelyByTheIndex)
+        XCTAssertTrue(SessionQueryFilter().isAnsweredEntirelyByTheIndex)
+    }
+
     func testTimeWindowIsInclusiveBelowAndExclusiveAbove() {
         let filter = SessionQueryFilter(from: epoch, to: epoch.addingTimeInterval(60))
         XCTAssertTrue(filter.matches(summary(lastActiveAt: epoch)))
@@ -100,10 +134,11 @@ final class SessionAgentQueryTests: XCTestCase {
         )
         XCTAssertFalse(SessionQueryFilter(to: epoch).isAnsweredEntirelyByTheIndex)
         XCTAssertFalse(SessionQueryFilter(models: ["gpt-5"]).isAnsweredEntirelyByTheIndex)
-        XCTAssertTrue(
-            SessionQueryFilter(models: []).isAnsweredEntirelyByTheIndex,
-            "an empty model list narrows nothing here; the store already returns nothing for it"
-        )
+        // This used to assert the opposite, which is what let `models: []`
+        // reach the store unfiltered and match everything. The store has no
+        // model column filter of any kind, so an empty list is no more
+        // answerable there than a populated one.
+        XCTAssertFalse(SessionQueryFilter(models: []).isAnsweredEntirelyByTheIndex)
     }
 
     // MARK: - Locator
@@ -181,13 +216,17 @@ final class SessionAgentQueryTests: XCTestCase {
         XCTAssertFalse(last.hasMore)
     }
 
+    /// This test used to assert the bug: it expected seqs 10–19 for a window
+    /// centred on 50, i.e. ten messages that do not include the one asked
+    /// for. The cap now shrinks the window towards the target instead.
     func testTheMessageLimitTruncatesAWideAroundWindowAndLeavesACursor() {
         let result = window(
             TranscriptWindowRequest(around: 50, radius: 40, limit: 10), in: messages(200)
         )
         XCTAssertEqual(result.messages.count, 10)
-        XCTAssertEqual(result.messages.first?.seq, 10)
-        XCTAssertEqual(result.nextFrom, 20)
+        XCTAssertEqual(result.messages.map(\.seq), Array(45...54))
+        XCTAssertTrue(result.messages.contains { $0.seq == 50 })
+        XCTAssertEqual(result.nextFrom, 55)
         XCTAssertEqual(result.reasons, [.messageLimit])
         XCTAssertTrue(result.notice { "\($0) B" }?.contains("nextFrom") ?? false)
     }
@@ -241,6 +280,98 @@ final class SessionAgentQueryTests: XCTestCase {
         )
         XCTAssertEqual(result.messages.map(\.seq), [0, 2, 4])
         XCTAssertTrue(result.messages.allSatisfy { $0.role == .user })
+    }
+
+    // MARK: - `around` stays centred on its target
+
+    /// The exact regression: `around: 500, radius: 100` with the default
+    /// limit of 40 used to start at 400, fill up, and return 400–439 —
+    /// omitting message 500, the one the caller named. Widening the radius
+    /// made the answer *worse*, which broke the whole search-hit workflow.
+    func testAWideRadiusStillReturnsTheMessageItWasCentredOn() {
+        let result = window(
+            TranscriptWindowRequest(around: 500, radius: 100, limit: 40), in: messages(1_000)
+        )
+        XCTAssertEqual(result.messages.count, 40)
+        XCTAssertTrue(
+            result.messages.contains { $0.seq == 500 },
+            "the requested message must survive every cap; got \(result.messages.map(\.seq))"
+        )
+        // Shrunk towards the target rather than truncated from the left. The
+        // half-message bias goes to the earlier side on purpose: for a search
+        // hit, what led up to the match is usually the more useful context.
+        XCTAssertEqual(result.messages.map(\.seq), Array(480...519))
+        XCTAssertEqual(result.reasons, [.messageLimit])
+        XCTAssertEqual(result.nextFrom, 520)
+    }
+
+    /// Same guarantee under the other cap: a window of large messages must
+    /// spend its byte budget around the target, not before it.
+    func testTheByteBudgetShrinksAnAroundWindowTowardsItsTarget() {
+        let fat = messages(1_000) { _ in String(repeating: "x", count: 6_000) }
+        let result = window(TranscriptWindowRequest(around: 500, radius: 100, limit: 200), in: fat)
+        XCTAssertTrue(
+            result.messages.contains { $0.seq == 500 },
+            "got \(result.messages.map(\.seq))"
+        )
+        XCTAssertTrue(result.reasons.contains(.byteBudget))
+        let bytes = result.messages.reduce(0) { $0 + $1.text.utf8.count }
+        XCTAssertLessThanOrEqual(bytes, TranscriptWindowRequest.maximumTextBytes)
+        // Centred: roughly as many either side of the target.
+        let before = result.messages.filter { $0.seq < 500 }.count
+        let after = result.messages.filter { $0.seq > 500 }.count
+        XCTAssertLessThanOrEqual(abs(before - after), 1)
+    }
+
+    func testACappedAroundWindowIsStillContiguousSoOneCursorDescribesIt() {
+        let result = window(
+            TranscriptWindowRequest(around: 500, radius: 100, limit: 11), in: messages(1_000)
+        )
+        let seqs = result.messages.map(\.seq)
+        XCTAssertEqual(seqs, Array(495...505))
+        XCTAssertEqual(zip(seqs, seqs.dropFirst()).allSatisfy { $1 == $0 + 1 }, true)
+    }
+
+    /// A `roles` filter is the one thing allowed to drop the target: asking
+    /// for user turns only rules out an assistant one.
+    func testARoleFilterMayStillExcludeTheCentredMessage() {
+        // seq 5 is an assistant turn in this fixture.
+        let result = window(
+            TranscriptWindowRequest(around: 5, radius: 2, roles: [.user]), in: messages(100)
+        )
+        XCTAssertEqual(result.messages.map(\.seq), [4, 6])
+        XCTAssertFalse(result.messages.contains { $0.seq == 5 })
+    }
+
+    func testAnAroundWindowNearTheStartClampsWithoutLosingItsTarget() {
+        let result = window(
+            TranscriptWindowRequest(around: 1, radius: 100, limit: 5), in: messages(1_000)
+        )
+        XCTAssertTrue(result.messages.contains { $0.seq == 1 })
+        XCTAssertEqual(result.messages.map(\.seq), [0, 1, 2, 3, 4])
+    }
+
+    /// `from` past the end of what was read must be an empty window, not a
+    /// reversed range.
+    func testAFromBeyondTheReadMessagesIsEmptyRatherThanATrap() {
+        let result = window(TranscriptWindowRequest(from: 500, limit: 10), in: messages(10))
+        XCTAssertTrue(result.messages.isEmpty)
+        XCTAssertNil(result.nextFrom)
+    }
+
+    func testAnAroundSeqBeyondAFullyReadFileIsEmpty() {
+        let result = window(TranscriptWindowRequest(around: 500, radius: 2), in: messages(10))
+        XCTAssertTrue(result.messages.isEmpty)
+        XCTAssertEqual(result.totalMessageCount, 10, "the file was read whole, so the total is known")
+        XCTAssertNil(result.nextFrom)
+    }
+
+    // MARK: - Empty list filters mean nothing
+
+    /// The house rule, on the window side: `roles: []` selects no role.
+    func testAnEmptyRoleSetSelectsNothing() {
+        let result = window(TranscriptWindowRequest(from: 0, limit: 10, roles: []), in: messages(20))
+        XCTAssertTrue(result.messages.isEmpty)
     }
 
     func testAWindowPastTheReadableRegionSaysSoAndOffersNoCursor() {
@@ -352,6 +483,61 @@ final class SessionAgentQueryTests: XCTestCase {
         XCTAssertNil(result.totalMessageCount)
         XCTAssertLessThanOrEqual(result.bytesRead, 64 * 1024)
         XCTAssertLessThan(result.bytesRead, result.fileBytes)
+    }
+
+    // MARK: - One backfill call site
+
+    /// The fresh-install bug this guards: `sessions.list` grew a host-side
+    /// path that simply forgot to trigger the one-time index backfill, so a
+    /// new install answering a `to` or `models` query returned zero forever.
+    ///
+    /// The fix was to hoist it, and the invariant that keeps it fixed is
+    /// structural rather than behavioural — there is exactly one place that
+    /// can start a backfill, so no future read path can be added without
+    /// going through it. A source contract is the honest way to assert that:
+    /// `MCPController` lives in the app target and cannot be constructed
+    /// here.
+    func testEverySessionReadSharesOneBackfillCallSite() throws {
+        let source = try String(
+            contentsOf: repoRoot().appendingPathComponent("Sources/VibeBarApp/MCPController.swift"),
+            encoding: .utf8
+        )
+        let calls = source.components(separatedBy: "await backfillSessionIndexIfNeeded(").count - 1
+        XCTAssertEqual(
+            calls, 1,
+            "Every session read must go through `readingSessions`. A second call site means some "
+                + "path can be added that forgets to backfill — which is exactly how the "
+                + "host-side sessions.list path shipped returning zero on a fresh install."
+        )
+        XCTAssertTrue(
+            source.contains("private func readingSessions<T>"),
+            "the shared entry point should still be the thing that owns the retry"
+        )
+        // And every read actually goes through it.
+        for path in ["searchSessions", "listSessions", "sessionTranscript"] {
+            guard let range = source.range(of: "func \(path)(") else {
+                return XCTFail("\(path) not found in MCPController")
+            }
+            let body = source[range.lowerBound...].prefix(3_000)
+            XCTAssertTrue(
+                body.contains("readingSessions"),
+                "\(path) must read through the shared entry point"
+            )
+        }
+    }
+
+    private func repoRoot() throws -> URL {
+        var dir = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
+        for _ in 0..<12 {
+            if FileManager.default.fileExists(
+                atPath: dir.appendingPathComponent("Package.swift").path
+            ) { return dir }
+            dir.deleteLastPathComponent()
+        }
+        throw NSError(
+            domain: "SessionAgentQueryTests", code: 1,
+            userInfo: [NSLocalizedDescriptionKey: "Could not locate repo root from \(#filePath)"]
+        )
     }
 
     func testTheGrowthEstimateBeatsPlainDoubling() {

--- a/Tests/VibeBarCoreTests/SessionAgentQueryTests.swift
+++ b/Tests/VibeBarCoreTests/SessionAgentQueryTests.swift
@@ -1,0 +1,377 @@
+import XCTest
+@testable import VibeBarCore
+
+/// The vocabulary `sessions.*` hands an agent: how a filter narrows, how a
+/// session is named, and where a transcript window stops.
+final class SessionAgentQueryTests: XCTestCase {
+    private let epoch = Date(timeIntervalSince1970: 1_767_225_600)
+    private var directory: URL!
+
+    override func setUpWithError() throws {
+        directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("VibeBarSessionAgentQuery-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: directory)
+    }
+
+    private var scratchURL: URL { directory.appendingPathComponent("scratch", isDirectory: true) }
+
+    private func summary(
+        sessionID: String = "s-1",
+        provider: SessionProvider = .codex,
+        projectDir: String? = "/Users/example/Coding/vibe-bar",
+        model: String? = "gpt-5-codex",
+        lastActiveAt: Date? = nil,
+        createdAt: Date? = nil
+    ) -> SessionSummary {
+        SessionSummary(
+            provider: provider,
+            sessionID: sessionID,
+            model: model,
+            title: "Bounded the transcript viewer",
+            projectDir: projectDir,
+            createdAt: createdAt ?? epoch,
+            lastActiveAt: lastActiveAt ?? epoch,
+            sourcePath: "/Users/example/.codex/sessions/\(sessionID).jsonl",
+            sizeBytes: 4_096,
+            messageCount: 12
+        )
+    }
+
+    // MARK: - Filter semantics
+
+    func testProjectDirIsACaseInsensitiveSubstring() {
+        // Substring, not prefix — see `SessionQueryFilter.projectDir` for why
+        // (the store's SQL is what keeps `totalCount` honest).
+        var filter = SessionQueryFilter(projectDir: "vibe-bar")
+        XCTAssertTrue(filter.matches(summary()))
+        filter.projectDir = "VIBE-BAR"
+        XCTAssertTrue(filter.matches(summary()), "matching must not depend on case")
+        filter.projectDir = "/Users/example/Coding/vibe-bar"
+        XCTAssertTrue(filter.matches(summary()), "a full path behaves as an exact match")
+        filter.projectDir = "some-other-repo"
+        XCTAssertFalse(filter.matches(summary()))
+        // A session with no recorded project cannot satisfy a project filter.
+        XCTAssertFalse(
+            SessionQueryFilter(projectDir: "vibe-bar").matches(summary(projectDir: nil))
+        )
+    }
+
+    func testModelsMatchExactlyAndCaseInsensitively() {
+        XCTAssertTrue(SessionQueryFilter(models: ["GPT-5-Codex"]).matches(summary()))
+        // A substring of a model id is not that model.
+        XCTAssertFalse(SessionQueryFilter(models: ["gpt-5"]).matches(summary()))
+        // Never inferred: a log that recorded no model matches no filter.
+        XCTAssertFalse(SessionQueryFilter(models: ["gpt-5-codex"]).matches(summary(model: nil)))
+    }
+
+    func testTimeWindowIsInclusiveBelowAndExclusiveAbove() {
+        let filter = SessionQueryFilter(from: epoch, to: epoch.addingTimeInterval(60))
+        XCTAssertTrue(filter.matches(summary(lastActiveAt: epoch)))
+        XCTAssertTrue(filter.matches(summary(lastActiveAt: epoch.addingTimeInterval(59))))
+        XCTAssertFalse(filter.matches(summary(lastActiveAt: epoch.addingTimeInterval(60))))
+        XCTAssertFalse(filter.matches(summary(lastActiveAt: epoch.addingTimeInterval(-1))))
+    }
+
+    func testATimeWindowRejectsASessionWithNoTimestampAtAll() {
+        // "Unknown" is not "in range".
+        let undated = SessionSummary(
+            provider: .codex, sessionID: "s-2",
+            createdAt: nil, lastActiveAt: nil,
+            sourcePath: "/Users/example/.codex/sessions/s-2.jsonl", sizeBytes: 1, messageCount: 0
+        )
+        XCTAssertFalse(SessionQueryFilter(from: epoch).matches(undated))
+        XCTAssertTrue(SessionQueryFilter().matches(undated), "an unfiltered query keeps it")
+    }
+
+    /// Which half of the filter the index can answer decides whether
+    /// `totalCount` may be reported at all.
+    func testOnlyToAndModelsForceTheHostSidePath() {
+        XCTAssertTrue(SessionQueryFilter().isAnsweredEntirelyByTheIndex)
+        XCTAssertTrue(
+            SessionQueryFilter(
+                providers: [.codex], harnesses: [.codex],
+                projectDir: "vibe-bar", from: epoch
+            ).isAnsweredEntirelyByTheIndex,
+            "providers, harnesses, projectDir and from are all SQL clauses in the store"
+        )
+        XCTAssertFalse(SessionQueryFilter(to: epoch).isAnsweredEntirelyByTheIndex)
+        XCTAssertFalse(SessionQueryFilter(models: ["gpt-5"]).isAnsweredEntirelyByTheIndex)
+        XCTAssertTrue(
+            SessionQueryFilter(models: []).isAnsweredEntirelyByTheIndex,
+            "an empty model list narrows nothing here; the store already returns nothing for it"
+        )
+    }
+
+    // MARK: - Locator
+
+    func testACompositeIDParsesEvenWhenThePathHasColons() {
+        let id = "codex:abc-123:/Users/example/odd:dir/rollout.jsonl"
+        let locator = try? XCTUnwrap(SessionLocator.parse(compositeID: id))
+        XCTAssertEqual(locator?.provider, .codex)
+        XCTAssertEqual(locator?.sessionID, "abc-123")
+    }
+
+    func testARealSummaryIDRoundTripsThroughTheLocator() {
+        let row = summary()
+        let locator = SessionLocator.parse(compositeID: row.id)
+        XCTAssertEqual(locator?.provider, row.provider)
+        XCTAssertEqual(locator?.sessionID, row.sessionID)
+    }
+
+    func testNonsenseIDsAreRejectedRatherThanGuessed() {
+        XCTAssertNil(SessionLocator.parse(compositeID: "not-a-provider:abc:/x"))
+        XCTAssertNil(SessionLocator.parse(compositeID: "codex"))
+        XCTAssertNil(SessionLocator.parse(compositeID: "codex::/x"))
+    }
+
+    // MARK: - Window slicing
+
+    private func messages(_ count: Int, text: @escaping (Int) -> String = { "message \($0)" })
+        -> [SessionMessage] {
+        (0..<count).map {
+            SessionMessage(
+                seq: $0,
+                role: $0.isMultiple(of: 2) ? .user : .assistant,
+                text: text($0),
+                timestamp: nil
+            )
+        }
+    }
+
+    private func window(
+        _ request: TranscriptWindowRequest,
+        in messages: [SessionMessage],
+        reachedEndOfFile: Bool = true
+    ) -> TranscriptWindow {
+        SessionIndexingBounds.window(
+            for: request,
+            in: messages,
+            reachedEndOfFile: reachedEndOfFile,
+            bytesRead: 1_024,
+            fileBytes: 1_024
+        )
+    }
+
+    func testAroundCentresTheWindowOnTheMatch() {
+        let result = window(TranscriptWindowRequest(around: 50, radius: 2), in: messages(100))
+        XCTAssertEqual(result.messages.map(\.seq), [48, 49, 50, 51, 52])
+        XCTAssertEqual(result.totalMessageCount, 100)
+        XCTAssertEqual(result.nextFrom, 53)
+        XCTAssertFalse(result.isTruncated)
+    }
+
+    func testAroundClampsAtTheStartOfTheSession() {
+        let result = window(TranscriptWindowRequest(around: 1, radius: 5), in: messages(100))
+        XCTAssertEqual(result.messages.map(\.seq), [0, 1, 2, 3, 4, 5, 6])
+    }
+
+    func testFromAndLimitPageForwardAndStopAtTheEnd() {
+        let first = window(TranscriptWindowRequest(from: 0, limit: 3), in: messages(7))
+        XCTAssertEqual(first.messages.map(\.seq), [0, 1, 2])
+        XCTAssertEqual(first.nextFrom, 3)
+        XCTAssertTrue(first.hasMore)
+
+        let last = window(TranscriptWindowRequest(from: 6, limit: 3), in: messages(7))
+        XCTAssertEqual(last.messages.map(\.seq), [6])
+        XCTAssertNil(last.nextFrom, "the last page must not hand back a cursor")
+        XCTAssertFalse(last.hasMore)
+    }
+
+    func testTheMessageLimitTruncatesAWideAroundWindowAndLeavesACursor() {
+        let result = window(
+            TranscriptWindowRequest(around: 50, radius: 40, limit: 10), in: messages(200)
+        )
+        XCTAssertEqual(result.messages.count, 10)
+        XCTAssertEqual(result.messages.first?.seq, 10)
+        XCTAssertEqual(result.nextFrom, 20)
+        XCTAssertEqual(result.reasons, [.messageLimit])
+        XCTAssertTrue(result.notice { "\($0) B" }?.contains("nextFrom") ?? false)
+    }
+
+    /// The failure this cap exists for: 200 tool-call outputs must come back
+    /// as a truncated answer plus a cursor, not as a multi-megabyte payload.
+    func testTheByteBudgetStopsAWindowOfHugeMessages() {
+        let fat = messages(200) { _ in String(repeating: "x", count: 6_000) }
+        let result = window(TranscriptWindowRequest(from: 0, limit: 200), in: fat)
+        XCTAssertLessThan(result.messages.count, 200)
+        let bytes = result.messages.reduce(0) { $0 + $1.text.utf8.count }
+        XCTAssertLessThanOrEqual(bytes, TranscriptWindowRequest.maximumTextBytes)
+        XCTAssertTrue(result.reasons.contains(.byteBudget))
+        XCTAssertEqual(result.nextFrom, result.messages.count, "resume at the message that did not fit")
+    }
+
+    func testOneEnormousMessageIsClippedRatherThanFillingTheAnswer() {
+        let huge = String(repeating: "y", count: 50_000)
+        let result = window(
+            TranscriptWindowRequest(from: 0, limit: 3),
+            in: [
+                SessionMessage(seq: 0, role: .tool, text: huge, timestamp: nil),
+                SessionMessage(seq: 1, role: .user, text: "and then?", timestamp: nil)
+            ]
+        )
+        XCTAssertEqual(result.messages.count, 2, "clipping one message must not drop the next")
+        XCTAssertTrue(result.textTruncated[0])
+        XCTAssertFalse(result.textTruncated[1])
+        XCTAssertEqual(result.textBytes[0], 50_000, "the original size is still reported")
+        XCTAssertLessThan(result.messages[0].text.count, huge.count)
+        XCTAssertTrue(result.reasons.contains(.messageText))
+    }
+
+    func testEvenASingleOversizedMessageComesBack() {
+        // A response of zero messages plus "the budget was full" is not an
+        // answer, so the first message always goes through.
+        let giant = String(repeating: "z", count: 400_000)
+        let result = window(
+            TranscriptWindowRequest(from: 0, limit: 5),
+            in: [SessionMessage(seq: 0, role: .tool, text: giant, timestamp: nil)]
+        )
+        XCTAssertEqual(result.messages.count, 1)
+        XCTAssertTrue(result.textTruncated[0])
+    }
+
+    func testRolesThinAWindowRatherThanExtendingIt() {
+        // Only the user turns inside seq 0…5 — not "the next 3 user turns,
+        // wherever they are".
+        let result = window(
+            TranscriptWindowRequest(from: 0, limit: 6, roles: [.user]), in: messages(100)
+        )
+        XCTAssertEqual(result.messages.map(\.seq), [0, 2, 4])
+        XCTAssertTrue(result.messages.allSatisfy { $0.role == .user })
+    }
+
+    func testAWindowPastTheReadableRegionSaysSoAndOffersNoCursor() {
+        // The escalating read stopped at its ceiling before reaching seq 5000.
+        let result = window(
+            TranscriptWindowRequest(around: 5_000, radius: 5),
+            in: messages(1_200),
+            reachedEndOfFile: false
+        )
+        XCTAssertTrue(result.messages.isEmpty)
+        XCTAssertEqual(result.reasons, [.readCeiling])
+        XCTAssertNil(result.nextFrom, "a cursor here would invite an identical retry forever")
+        XCTAssertNil(result.totalMessageCount, "a prefix's count is not the log's count")
+        XCTAssertTrue(result.notice { "\($0) B" }?.contains("bounded read") ?? false)
+    }
+
+    func testABoundedReadWithheldTheTotalButStillPages() {
+        let result = window(
+            TranscriptWindowRequest(from: 0, limit: 5), in: messages(1_200), reachedEndOfFile: false
+        )
+        XCTAssertEqual(result.messages.count, 5)
+        XCTAssertNil(result.totalMessageCount)
+        XCTAssertEqual(result.nextFrom, 5)
+    }
+
+    // MARK: - Escalating read
+
+    private func codexLine(role: String, text: String) -> String {
+        let payload: [String: Any] = [
+            "type": "message",
+            "role": role,
+            "content": [["type": "input_text", "text": text]]
+        ]
+        let object: [String: Any] = ["type": "response_item", "payload": payload]
+        return String(data: try! JSONSerialization.data(withJSONObject: object), encoding: .utf8)!
+    }
+
+    /// A message index cannot be turned into a byte offset without parsing,
+    /// so reaching a deep message means growing the read. The point of the
+    /// estimate is that it does not take log₂(file) attempts to get there.
+    func testTheReadGrowsUntilItReachesTheRequestedMessage() throws {
+        // ~500 messages of ~2 KB each, comfortably past a 1 MiB first read.
+        let body = String(repeating: "context ", count: 250)
+        let lines = (0..<500).map { codexLine(role: $0.isMultiple(of: 2) ? "user" : "assistant",
+                                              text: "\(body) turn \($0)") }
+        let fileURL = directory.appendingPathComponent("rollout-deep.jsonl")
+        try Data((lines.joined(separator: "\n") + "\n").utf8).write(to: fileURL)
+        XCTAssertGreaterThan(
+            SessionParsing.fileSize(fileURL),
+            SessionIndexingBounds.agentTranscriptInitialByteLimit,
+            "the fixture has to be bigger than the first read for this to test anything"
+        )
+
+        let result = try SessionIndexingBounds.readTranscriptWindow(
+            adapter: CodexSessionAdapter(homeDirectory: directory.path),
+            fileURL: fileURL,
+            request: TranscriptWindowRequest(around: 480, radius: 2),
+            scratchDirectory: scratchURL
+        )
+        XCTAssertEqual(result.messages.map(\.seq), [478, 479, 480, 481, 482])
+        XCTAssertTrue(result.messages[2].text.contains("turn 480"))
+        // Nothing was cut: the window is exactly what was asked for.
+        XCTAssertFalse(result.isTruncated)
+        // But the read stopped the moment it had the window rather than
+        // finishing the file, so it does not know how long the session is —
+        // and says nil instead of reporting the prefix's count as the total.
+        XCTAssertNil(result.totalMessageCount)
+        XCTAssertNotNil(result.nextFrom, "there is more to read past this window")
+        XCTAssertLessThan(result.bytesRead, result.fileBytes)
+        XCTAssertTrue(
+            (try? FileManager.default.contentsOfDirectory(atPath: scratchURL.path))?.isEmpty ?? true,
+            "every head copy is scratch and must not outlive its parse"
+        )
+    }
+
+    func testASmallSessionIsReadWholeInOneGo() throws {
+        let lines = (0..<5).map { codexLine(role: "user", text: "turn \($0)") }
+        let fileURL = directory.appendingPathComponent("rollout-small.jsonl")
+        try Data((lines.joined(separator: "\n") + "\n").utf8).write(to: fileURL)
+
+        let result = try SessionIndexingBounds.readTranscriptWindow(
+            adapter: CodexSessionAdapter(homeDirectory: directory.path),
+            fileURL: fileURL,
+            request: TranscriptWindowRequest(from: 0, limit: 40),
+            scratchDirectory: scratchURL
+        )
+        XCTAssertEqual(result.messages.count, 5)
+        XCTAssertEqual(result.totalMessageCount, 5)
+        XCTAssertNil(result.nextFrom)
+        XCTAssertFalse(result.isTruncated)
+    }
+
+    func testTheCeilingBoundsTheReadRatherThanTheRequest() throws {
+        let body = String(repeating: "context ", count: 250)
+        let lines = (0..<500).map { codexLine(role: "user", text: "\(body) turn \($0)") }
+        let fileURL = directory.appendingPathComponent("rollout-ceiling.jsonl")
+        try Data((lines.joined(separator: "\n") + "\n").utf8).write(to: fileURL)
+
+        // A ceiling far below what seq 480 needs: the answer is a refusal
+        // with a reason, not a whole-file parse.
+        let result = try SessionIndexingBounds.readTranscriptWindow(
+            adapter: CodexSessionAdapter(homeDirectory: directory.path),
+            fileURL: fileURL,
+            request: TranscriptWindowRequest(around: 480, radius: 2),
+            byteCeiling: 64 * 1024,
+            scratchDirectory: scratchURL
+        )
+        XCTAssertTrue(result.reasons.contains(.readCeiling))
+        XCTAssertNil(result.totalMessageCount)
+        XCTAssertLessThanOrEqual(result.bytesRead, 64 * 1024)
+        XCTAssertLessThan(result.bytesRead, result.fileBytes)
+    }
+
+    func testTheGrowthEstimateBeatsPlainDoubling() {
+        // 100 messages in 1 MiB, and seq 900 wanted: doubling would offer
+        // 2 MiB, the measured rate says ~10 MiB is what it actually takes.
+        let read = SessionIndexingBounds.BoundedTranscript(
+            document: TranscriptDocument(
+                messages: (0..<100).map {
+                    SessionMessage(seq: $0, role: .user, text: "x", timestamp: nil)
+                },
+                totalMessageCount: 100,
+                truncated: true
+            ),
+            isHeadTruncated: true,
+            fileByteSize: 100 * 1024 * 1024
+        )
+        let next = SessionIndexingBounds.nextByteLimit(
+            after: 1024 * 1024, read: read, needed: 900
+        )
+        XCTAssertGreaterThan(next, 2 * 1024 * 1024, "doubling alone would take too many passes")
+        XCTAssertLessThan(next, 32 * 1024 * 1024)
+    }
+}

--- a/docs/agent-setup/skill/vibe-bar/SKILL.md
+++ b/docs/agent-setup/skill/vibe-bar/SKILL.md
@@ -161,13 +161,16 @@ call. `sessions.transcript` exists so you never have to.
 shapes:
 
 - **`around: <seq>`** with `radius` (default 20) — a match in context. Pass a
-  search hit's `matchedSeq` directly; it always resolves.
+  search hit's `matchedSeq` directly; it always resolves, and the message you
+  named is always in the result. Widen `radius` freely: when the response caps
+  bite, the window shrinks *towards* your message rather than dropping it.
 - **`from` / `limit`** — paging. Feed the response's `nextFrom` back as `from`
   until `hasMore` is false.
 
 `roles` thins a window (`["user"]` for just the prompts). It does *not* search
 past the window, so "the 20 messages around seq 400, user turns only" stays
-inside 380–420.
+inside 380–420 — and it is the one thing that can exclude the message `around`
+named, since asking for user turns only rules out an assistant one.
 
 Responses are capped three ways — message count, a total byte budget, and per
 message — so one 40 KB tool dump cannot swallow the answer. When a cap bites,

--- a/docs/agent-setup/skill/vibe-bar/SKILL.md
+++ b/docs/agent-setup/skill/vibe-bar/SKILL.md
@@ -6,10 +6,14 @@ description: >-
   when the user asks about "my AI quota", "how much Codex / Claude / Gemini /
   Grok / Cursor do I have left", "when does my 5-hour window reset", "am I
   going to run out", "refresh my usage", "what did I spend this month", "who
-  used the most tokens", "why is this costing so much", "is Anthropic down", or
-  "find my session about …". Also installs agent skills through Vibe Bar's
-  Skills manager ("install this skill", "set me up with the Vibe Bar skill").
-  Requires the Vibe Bar app to be running with its MCP server enabled.
+  used the most tokens", "why is this costing so much", or "is Anthropic
+  down". Also the local session manager for agent work on this Mac: find any
+  CLI session by keyword, project or time and read its transcript — "find the
+  session about …", "what was Codex doing in this repo", "what did that other
+  agent already try", "show me that conversation". Also installs agent skills
+  through Vibe Bar's Skills manager ("install this skill", "set me up with the
+  Vibe Bar skill"). Requires the Vibe Bar app to be running with its MCP
+  server enabled.
 ---
 
 # Vibe Bar
@@ -59,8 +63,9 @@ never infer a model that a log recorded as absent.
 | "which model costs me the most?" | `usage.summary` with `groupBy: "model"` |
 | "show my usage over time" | `usage.trend` |
 | "what were my last N requests?" | `usage.requests` |
-| "find my session about X" | `sessions.search` |
-| "what have I been working on?" | `sessions.list` |
+| "find the session about X" / "which session was that in?" | `sessions.search` |
+| "what ran in this repo lately?" / "what have I been working on?" | `sessions.list` |
+| "what did that agent actually do?" / "show me the match in context" | `sessions.transcript` |
 | "is <provider> down?" | `status.get` |
 | "why is this model so expensive?" | `pricing.effective` |
 | "install this skill" / "set me up with the Vibe Bar skill" | `skills.install` |
@@ -94,6 +99,8 @@ would rather read it than trust this copy.
 - **Cursor has no local token counters.** Its sessions are listed locally, but
   its cost comes from the dashboard. A Cursor session with real messages and no
   tokens is expected, not a bug.
+- **Never open `sourcePath` yourself.** Read sessions through
+  `sessions.transcript`. See the section below for why.
 - **Empty filter lists mean "nothing"**, not "everything". Omit a filter to
   mean everything.
 - **`skills.install` is the only tool that writes.** It installs into
@@ -101,6 +108,90 @@ would rather read it than trust this copy.
   nowhere else, and never over a folder a different skill already holds. Pass
   `apps` or the skill is on the machine switched on for nobody. It can be
   turned off in Settings → MCP Server, in which case it says so.
+
+## Sessions: the local session manager
+
+Every coding agent on this Mac leaves a session log behind — Codex rollouts,
+Claude Code projects, Gemini chats, Grok updates, Cursor stores. Vibe Bar
+indexes all of them, which makes these three tools the way one agent finds and
+reads what another agent did. That is the point of them: you are usually not
+answering "find *my* session about X" for a human, you are picking up work
+someone else started.
+
+### Locate
+
+`sessions.search` when you know what was said — it matches titles, project
+paths and message bodies, substring, so partial words and CJK both work.
+`sessions.list` when you know *where* or *when* instead. Both narrow the same
+way, with the same argument names `usage.*` uses:
+
+| Argument | Means |
+| --- | --- |
+| `harnesses` | the CLI or app that produced it (`codex`, `claudeCode`, …) |
+| `providers` | the on-disk store — prefer `harnesses` unless you want a specific store |
+| `projectDir` | case-insensitive **substring** of the working directory |
+| `from` / `to` | ISO-8601 bounds on last activity, `from` inclusive, `to` exclusive |
+| `models` | raw vendor model ids, exact and case-insensitive |
+
+`projectDir` being a substring is deliberate and useful: pass a repo name to
+match every checkout of it, or a full absolute path for an exact one.
+`sessions.list` also still accepts `since` as an alias for `from`.
+
+### What comes back, and what to use it for
+
+| Field | Use it for |
+| --- | --- |
+| `sessionId` | resuming with that CLI — the id its own `--resume` wants |
+| `projectDir` | where the work happened; `cd` there before continuing it |
+| `harness` / `harnessName` | which agent produced it (the usage axis, not a quota name) |
+| `title` / `summary` | naming the session to the user |
+| `lastActiveAt` | how stale the work is |
+| `matchedSeq` (search) | the message index of the hit — feed straight to `sessions.transcript` |
+| `snippet` (search) | the excerpt, `<b>` around the match — render as emphasis or strip, never print raw |
+| `sourcePath` | telling two sessions apart, or a command the *user* runs. **Not** for you to open |
+| `id` | naming the session to `sessions.transcript` |
+
+`sourcePath` is a last resort. On a busy Mac these logs reach hundreds of
+megabytes; reading one yourself burns your context and can stall the tool
+call. `sessions.transcript` exists so you never have to.
+
+### Read
+
+`sessions.transcript` takes `id`, or `sessionId` plus `provider`. Two window
+shapes:
+
+- **`around: <seq>`** with `radius` (default 20) — a match in context. Pass a
+  search hit's `matchedSeq` directly; it always resolves.
+- **`from` / `limit`** — paging. Feed the response's `nextFrom` back as `from`
+  until `hasMore` is false.
+
+`roles` thins a window (`["user"]` for just the prompts). It does *not* search
+past the window, so "the 20 messages around seq 400, user turns only" stays
+inside 380–420.
+
+Responses are capped three ways — message count, a total byte budget, and per
+message — so one 40 KB tool dump cannot swallow the answer. When a cap bites,
+`truncated` is true, `truncationReasons` names which (`messageLimit`,
+`byteBudget`, `messageText`, `readCeiling`), and `notice` is a sentence you can
+relay. Relay it: silently reporting a clipped transcript as the whole one is
+the failure mode here.
+
+### The honest limits
+
+- **The index is as fresh as the last sweep.** A session being written right
+  now is searchable up to that sweep, not up to its newest message. If a
+  colleague's agent just started, wait or ask them.
+- **Body search needs body indexing on.** With it off (Vibe Bar → Settings),
+  titles and project paths still match, but the words inside messages do not —
+  so an empty result means "not indexed", not "never happened".
+- **`totalMessageCount` is usually absent.** The reader stops as soon as it has
+  your window, so it genuinely does not know how long the log is. Use
+  `hasMore` / `nextFrom`, not arithmetic on a total.
+- **A window past the readable region comes back empty** with `readCeiling`
+  and no cursor. Retrying the identical call will not help; that part of the
+  log is past what a bounded read reaches.
+- **Sessions are read-only here.** There is no edit, no delete, no resume.
+  Hand the user a resume command; do not try to drive another agent's session.
 
 ## Worked patterns
 
@@ -115,11 +206,19 @@ percent, reset time, and the forecast verdict if the confidence is not
 `totalTokens`, quote `costUSD` alongside. Answer in harness names ("Claude
 Code", "Codex"), and only mention companies if the user asked at that level.
 
-**"Find that session where I fixed the socket server."**
-`sessions.search` with the user's own words as `query`. Show the title,
-project directory, harness and last-active time, and offer the `sourcePath` so
-they can open the transcript. The `<b>` markers in `snippet` mark the match —
-render them as emphasis or strip them, do not print them raw.
+**"Another agent was working on the socket server here — what did it try?"**
+`sessions.search` with `query: "socket server"` and `projectDir` set to the
+repo you are in. Take the newest hit, then `sessions.transcript` with its `id`
+and `around: <matchedSeq>` to read the match in context. Widen with `radius`,
+or page from `nextFrom`, before concluding anything — one message is rarely
+the whole attempt. Report the harness and `lastActiveAt` so the user knows
+whose work it was and how old.
+
+**"What has Codex been doing in this repo this week?"**
+`sessions.list` with `harnesses: ["codex"]`, `projectDir` set to the repo, and
+`from` seven days back. Summarize by title and last-active time. Open the
+interesting ones with `sessions.transcript` and `roles: ["user"]` — the
+prompts are the outline of what was attempted.
 
 **"Refresh and tell me where I stand."**
 `quota.refresh` (no `force`), wait a couple of seconds, then `quota.get`. If

--- a/docs/agent-setup/skill/vibe-bar/SKILL.md
+++ b/docs/agent-setup/skill/vibe-bar/SKILL.md
@@ -193,6 +193,16 @@ the failure mode here.
 - **A window past the readable region comes back empty** with `readCeiling`
   and no cursor. Retrying the identical call will not help; that part of the
   log is past what a bounded read reaches.
+- **Four stores can only be read whole, so a large one is refused.** Cursor,
+  AntiGravity, Grok Build and Grok Bot keep sessions in formats that cannot be
+  cut at a byte offset. Past the bounded-read ceiling `sessions.transcript`
+  refuses and names the size rather than stalling on a multi-hundred-megabyte
+  parse. Use `sessions.search` to find the moment you need, or send the user to
+  the owning app.
+- **A short `sessions.search` page may carry a `notice`.** Filters run after
+  the index ranks, so a query whose top hits are all excluded can come back
+  short. When that happens the payload says so — read `notice` before telling
+  anyone nothing matched.
 - **Sessions are read-only here.** There is no edit, no delete, no resume.
   Hand the user a resume command; do not try to drive another agent's session.
 


### PR DESCRIPTION
## Summary

The maintainer wants Vibe Bar to be this Mac's session manager for agents. Discovery already worked — `sessions.search` returns `sessionId`, `projectDir`, `sourcePath`, `snippet` and `matchedSeq`, verified over the live socket. What was missing was everything after discovery: an agent could locate a session and was then handed a path to a file that can be 280 MB.

- **`sessions.transcript`** — resolve by `id` (or `sessionId` + `provider`) **through the index**, never by path, so an agent can only open sessions Vibe Bar already discovered. `around: <seq>` + `radius` for the context of a search hit, or `from`/`limit` to page, with an optional `roles` filter. Caps: 200 messages, 256 KiB, 8,000 characters per message — every cap that bites is named in `truncationReasons` with a relayable `notice`.
- **No fake seek.** A message index cannot become a byte offset without parsing (not every line of a rollout produces a message), so it reads an escalating head — 1 MiB, growing by bytes-per-message measured in the parse just done, ceiling 32 MiB — and stops as soon as it holds the window. A 269 MB rollout opens on a 1 MiB read. Because the indexer only parses the first 8 MiB of a session, a search hit is *always* inside reach; paging to the end of a huge log is not, and returns no cursor rather than letting a model retry forever.
- **`totalMessageCount` is absent whenever the read stopped short of EOF** — reporting a prefix's count as the total would tell an agent it had seen everything.
- **Filters on both tools**: `from`/`to`/`models`/`harnesses`/`providers`/`projectDir`, named as `usage.*` already names them. `projectDir` is a case-insensitive substring because that is what `SessionIndexStore` implements in SQL — keeping it there is what keeps `totalCount` and `offset` exact; a host-side prefix filter would leave the count describing a wider set than the rows. `to` and `models` are host-side over a bounded scan, and `totalCount` is withheld unless the scan exhausted.
- **Skill rewritten** for agent-to-agent work: locate/read split, a table saying which field is for what (`sourcePath` explicitly *not* for you to open), the search-hit → `around:` flow, and honest limits. `vibebar://tools` and `AGENTS.md` § 5.1 updated; `MCPResourceCatalogTests` enforces the resource copy.

**Fixed while verifying**: `MCPController` ignored `VIBEBAR_MCP_SOCKET`, which `AGENTS.md` § 5.1 has always documented as how a second build points at a temporary socket. A test instance bound `~/.vibebar/mcp.sock` and took it from the running app.

## Test plan

- [x] `swift build`
- [x] `swift test` — 2038 tests, 0 failures (32 new)
- [x] Driven over a real `--mcp-stdio` socket against the live 8,321-session index, on a temporary socket with the installed app untouched: a search hit at `matchedSeq: 504` fed straight into `around:` returned seqs 502–506 with `truncationReasons: ["messageText"]` and a working `nextFrom`; a 282 MB rollout opened with `bytesRead: 1048576`; `around: 900000` on it returned no cursor and an explaining notice; paging, `roles` thinning, `projectDir`+`from`+`to` with an exact `totalCount`, and the schema's `limit` cap all behave
- [ ] After install: `skills.install` to refresh the skill, then confirm another agent can go search → transcript without touching a path

## Known limit

`sessions.transcript` reads Grok / Cursor / AntiGravity / Grok Bot sessions **whole** — their stores cannot be cut at a byte offset (`headTruncatableProviders` is codex/claude/claudeCowork). The message caps still bound the response; the parse does not. Worth a follow-up if any of those grow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)